### PR TITLE
DNN classification demo

### DIFF
--- a/demo/kaldi_dnn/combine-ark-label.py
+++ b/demo/kaldi_dnn/combine-ark-label.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+#from paddle.trainer_config_helpers import *
+import sys
+import struct
+
+def combine_feats_pdf(feats, pdf, feats_pdf):
+    utt_pdf = dict()
+    with open(pdf) as f:
+        for line in f:
+            parts = line.split()
+            pdf_buf = struct.pack('<%di' % (len(parts) - 1), *[int (s) for s in parts[1:]])
+            utt_pdf[parts[0]] = pdf_buf
+    const_tag = struct.pack('6c', *[chr(i) for i in (0x00, 0x42, 0x46, 0x4d, 0x20, 0x04)])
+    with open(feats) as fin, open(feats_pdf, 'w') as fout:
+        key = ''
+        while True:
+            key = ''
+            while True:
+                buf = fin.read(1)
+                if buf == '' or buf == ' ':
+                    break
+                key = key + buf
+            if buf == '':
+                break
+            key += ' '
+            fout.write(key)
+            buf = fin.read(15)
+            assert buf[:6] == const_tag and buf[10] == chr(0x04)
+            fout.write(buf)
+            num_frame = struct.unpack('<i', buf[6:10])[0]
+            dim = struct.unpack('<i', buf[11:15])[0]
+            buf = fin.read(4 * dim * num_frame) # 4 is size of float
+            fout.write(buf)
+            fout.write(utt_pdf[key[:-1]])
+
+def main():
+    if len(sys.argv) != 4:
+        print >> sys.stderr, 'Usage: %s feats.ark pdf.txt feats_pdf.ark' % sys.argv[0]
+        sys.exit(-1)
+    combine_feats_pdf(sys.argv[1], sys.argv[2], sys.argv[3])
+
+if __name__ == '__main__':
+    main()

--- a/demo/kaldi_dnn/dataprovider_ark.py
+++ b/demo/kaldi_dnn/dataprovider_ark.py
@@ -24,7 +24,7 @@ def initializer(settings, num_senone, **kwargs):
 # `setting` is the same object used by initializer()
 # `file_name` is the name of a file listed train_list or test_list file given
 # to define_py_data_sources2(). See trainer_config.lr.py.
-@provider(init_hook=initializer, cache=CacheType.NO_CACHE, pool_size=16384, min_pool_size=16384)
+@provider(init_hook=initializer, cache=CacheType.CACHE_PASS_IN_MEM, pool_size=16384, min_pool_size=16384)
 def process(settings, file_name):
     # Open the input data file.
     const_tag = struct.pack('6c', *[chr(i) for i in (0x00, 0x42, 0x46, 0x4d, 0x20, 0x04)])

--- a/demo/kaldi_dnn/dataprovider_ark.py
+++ b/demo/kaldi_dnn/dataprovider_ark.py
@@ -1,0 +1,52 @@
+from paddle.trainer.PyDataProvider2 import *
+
+# id of the word not in dictionary
+UNK_IDX = 0
+
+# initializer is called by the framework during initialization.
+# It allows the user to describe the data types and setup the
+# necessary data structure for later use.
+# `settings` is an object. initializer need to properly fill settings.input_types.
+# initializer can also store other data structures needed to be used at process().
+# In this example, dictionary is stored in settings.
+# `dictionay` and `kwargs` are arguments passed from trainer_config.lr.py
+def initializer(settings, utt_pdf, num_senone, **kwargs):
+    # Put the word dictionary into settings
+    settings.utt_pdf = utt_pdf
+
+    # setting.input_types specifies what the data types the data provider
+    # generates.
+    settings.input_types = [
+        dense_float_vector(484), # FIXME: read the input dim from somewhere
+        integer_value(num_senone)]
+
+# Delaring a data provider. It has an initializer 'data_initialzer'.
+# It will cache the generated data of the first pass in memory, so that
+# during later pass, no on-the-fly data generation will be needed.
+# `setting` is the same object used by initializer()
+# `file_name` is the name of a file listed train_list or test_list file given
+# to define_py_data_sources2(). See trainer_config.lr.py.
+@provider(init_hook=initializer, cache=None)
+def process(settings, file_name):
+    # Open the input data file.
+    utt_pdf = settings.utt_pdf
+    with open(file_name, 'r') as fin:
+        while not f.eof():
+            key = ''
+            while True:
+                buf = fin.read(1)
+                if buf == ' ':
+                    break
+                key = key + buf
+            pdf = utt_pdf[key] # FIXME: catch the KeyError
+            buf = fin.read(15)
+            assert buf[:6] == const_tag and buf[10] == chr(0x04)
+            num_frame = struct.unpack('<i', buf[6:10])[0]
+            dim = struct.unpack('<i', buf[11:15])[0]
+            buf = fin.read(4 * dim * num_frame) # 4 is size of float
+            buf = buf[:dim] * 4 + buf + buf[-dim:] * 4 # Pad 4 frames to head and tail
+            for row in range(num_frame):
+                feat = struct.unpack('<%df' % (dim*11), buf[row*dim*4 : (row+11)*dim*4]) # 4 is size of float
+                yield feat, pdf[row]
+
+

--- a/demo/kaldi_dnn/dataprovider_ark.py
+++ b/demo/kaldi_dnn/dataprovider_ark.py
@@ -11,10 +11,7 @@ UNK_IDX = 0
 # initializer can also store other data structures needed to be used at process().
 # In this example, dictionary is stored in settings.
 # `dictionay` and `kwargs` are arguments passed from trainer_config.lr.py
-def initializer(settings, utt_pdf, num_senone, **kwargs):
-    # Put the word dictionary into settings
-    settings.utt_pdf = utt_pdf
-
+def initializer(settings, num_senone, **kwargs):
     # setting.input_types specifies what the data types the data provider
     # generates.
     settings.input_types = [
@@ -27,30 +24,27 @@ def initializer(settings, utt_pdf, num_senone, **kwargs):
 # `setting` is the same object used by initializer()
 # `file_name` is the name of a file listed train_list or test_list file given
 # to define_py_data_sources2(). See trainer_config.lr.py.
-@provider(init_hook=initializer)
+@provider(init_hook=initializer, cache=CacheType.NO_CACHE, pool_size=16384, min_pool_size=16384)
 def process(settings, file_name):
     # Open the input data file.
-    utt_pdf = settings.utt_pdf
     const_tag = struct.pack('6c', *[chr(i) for i in (0x00, 0x42, 0x46, 0x4d, 0x20, 0x04)])
     with open(file_name, 'r') as fin:
         while True:
             key = ''
             while True:
                 buf = fin.read(1)
-                if buf =='':
-                    break
-                if buf == ' ':
+                if buf == '' or buf == ' ':
                     break
                 key = key + buf
             if buf == '':
                 break
-            pdf = utt_pdf[key] # FIXME: catch the KeyError
             buf = fin.read(15)
             assert buf[:6] == const_tag and buf[10] == chr(0x04)
             num_frame = struct.unpack('<i', buf[6:10])[0]
             dim = struct.unpack('<i', buf[11:15])[0]
             buf = fin.read(4 * dim * num_frame) # 4 is size of float
             buf = buf[:(dim*4)] * 5 + buf + buf[-(dim*4):] * 5 # Pad 4 frames to head and tail
+            pdf = struct.unpack('<%di' % num_frame, fin.read(4 * num_frame)) # 4 is size of int
             for row in range(num_frame):
                 feat = struct.unpack('<%df' % (dim*11), buf[row*dim*4 : (row+11)*dim*4]) # 4 is size of float
                 yield feat, pdf[row]

--- a/demo/kaldi_dnn/dataprovider_ark.py
+++ b/demo/kaldi_dnn/dataprovider_ark.py
@@ -1,4 +1,5 @@
 from paddle.trainer.PyDataProvider2 import *
+import struct
 
 # id of the word not in dictionary
 UNK_IDX = 0
@@ -17,7 +18,7 @@ def initializer(settings, utt_pdf, num_senone, **kwargs):
     # setting.input_types specifies what the data types the data provider
     # generates.
     settings.input_types = [
-        dense_float_vector(484), # FIXME: read the input dim from somewhere
+        dense_vector(484), # FIXME: read the input dim from somewhere
         integer_value(num_senone)]
 
 # Delaring a data provider. It has an initializer 'data_initialzer'.
@@ -26,25 +27,30 @@ def initializer(settings, utt_pdf, num_senone, **kwargs):
 # `setting` is the same object used by initializer()
 # `file_name` is the name of a file listed train_list or test_list file given
 # to define_py_data_sources2(). See trainer_config.lr.py.
-@provider(init_hook=initializer, cache=None)
+@provider(init_hook=initializer)
 def process(settings, file_name):
     # Open the input data file.
     utt_pdf = settings.utt_pdf
+    const_tag = struct.pack('6c', *[chr(i) for i in (0x00, 0x42, 0x46, 0x4d, 0x20, 0x04)])
     with open(file_name, 'r') as fin:
-        while not f.eof():
+        while True:
             key = ''
             while True:
                 buf = fin.read(1)
+                if buf =='':
+                    break
                 if buf == ' ':
                     break
                 key = key + buf
+            if buf == '':
+                break
             pdf = utt_pdf[key] # FIXME: catch the KeyError
             buf = fin.read(15)
             assert buf[:6] == const_tag and buf[10] == chr(0x04)
             num_frame = struct.unpack('<i', buf[6:10])[0]
             dim = struct.unpack('<i', buf[11:15])[0]
             buf = fin.read(4 * dim * num_frame) # 4 is size of float
-            buf = buf[:dim] * 4 + buf + buf[-dim:] * 4 # Pad 4 frames to head and tail
+            buf = buf[:(dim*4)] * 5 + buf + buf[-(dim*4):] * 5 # Pad 4 frames to head and tail
             for row in range(num_frame):
                 feat = struct.unpack('<%df' % (dim*11), buf[row*dim*4 : (row+11)*dim*4]) # 4 is size of float
                 yield feat, pdf[row]

--- a/demo/kaldi_dnn/gpu-start-docker.sh
+++ b/demo/kaldi_dnn/gpu-start-docker.sh
@@ -1,10 +1,26 @@
 #!/usr/bin/env bash
 set -e
 work_dir=$(dirname $(dirname $(realpath $0)))
+data_dir=data
 
-sudo docker run -it --rm \
+# md5 info
+# e6ecbe86fff843acb1ae254789cd8c6d data/1k_utt_feats_pdf.ark
+# ec62e2287702ed03456ed18e1a1c3d64 data/9k_utt_feats_pdf.ark
+cd $data_dir
+for item in 1k_utt_feats_pdf.ark 9k_utt_feats_pdf.ark.tar.001 \
+    9k_utt_feats_pdf.ark.tar.002 9k_utt_feats_pdf.ark.tar.003;do
+  if [ ! -f $item ];then
+    wget -P . http://dl.bintray.com/pineking/atlas/$item
+  fi
+done
+cat 9k_utt_feats_pdf.ark.tar.* | tar -x
+cd -
+
+# Use 9000 utterances to train, 1000 utterances to evaluation
+echo "$data_dir/9k_utt_feats_pdf.ark" > $data_dir/train.list
+echo "$data_dir/1k_utt_feats_pdf.ark" > $data_dir/test.list
+
+nvidia-docker run -it --rm \
   --privileged \
   -v $work_dir:/paddle/demo \
-  -v /home/core/paddle/data:/paddle/data \
-  -v /var/lib/nvidia:/usr/local/nvidia/lib64 \
-  harbor.ail.unisound.com/liuqs_public/paddle:gpu-latest /bin/bash
+  docker.io/paddledev/paddle:gpu-latest /bin/bash

--- a/demo/kaldi_dnn/gpu-start-docker.sh
+++ b/demo/kaldi_dnn/gpu-start-docker.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+sudo docker run -it --rm \
+  --privileged \
+  -v /home/core/lipeng/unisound-ail/paddle/demo:/paddle/demo \
+  -v /home/core/paddle/data:/paddle/data \
+  -v /var/lib/nvidia:/usr/local/nvidia/lib64 \
+  harbor.ail.unisound.com/liuqs_public/paddle:gpu-latest /bin/bash

--- a/demo/kaldi_dnn/gpu-start-docker.sh
+++ b/demo/kaldi_dnn/gpu-start-docker.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -e
+work_dir=$(dirname $(dirname $(realpath $0)))
 
 sudo docker run -it --rm \
   --privileged \
-  -v /home/core/lipeng/unisound-ail/paddle/demo:/paddle/demo \
+  -v $work_dir:/paddle/demo \
   -v /home/core/paddle/data:/paddle/data \
   -v /var/lib/nvidia:/usr/local/nvidia/lib64 \
   harbor.ail.unisound.com/liuqs_public/paddle:gpu-latest /bin/bash

--- a/demo/kaldi_dnn/gpu-train-in-docker.sh
+++ b/demo/kaldi_dnn/gpu-train-in-docker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+cfg=/paddle/demo/kaldi_dnn/trainer_config.dnn.py
+
+paddle train \
+  --config=$cfg \
+  --save_dir=/paddle/demo/kaldi_dnn/output \
+  --trainer_count=1 \
+  --log_period=2000 \
+  --num_passes=15 \
+  --use_gpu=true \
+  --show_parameter_stats_period=10000 \
+  --test_all_data_in_one_period=1 \
+  2>&1 | tee 'train.log'
+

--- a/demo/kaldi_dnn/start-docker.sh
+++ b/demo/kaldi_dnn/start-docker.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -e
+work_dir=$(dirname $(dirname $(realpath $0)))
 
 sudo docker run -it --rm \
-  -v /work/local/lipeng/github/unisound-ail/paddle/demo:/paddle/demo \
+  -v $work_dir:/paddle/demo \
   -v /work/local/paddle/data:/paddle/data \
   paddledev/paddle:cpu-latest /bin/bash

--- a/demo/kaldi_dnn/start-docker.sh
+++ b/demo/kaldi_dnn/start-docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -e
+
+sudo docker run -it --rm \
+  -v /work/local/lipeng/github/unisound-ail/paddle/demo:/paddle/demo \
+  -v /work/local/paddle/data:/paddle/data \
+  paddledev/paddle:cpu-latest /bin/bash

--- a/demo/kaldi_dnn/train-in-docker.sh
+++ b/demo/kaldi_dnn/train-in-docker.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+
+cfg=/paddle/demo/kaldi_dnn/trainer_config.dnn.py
+
+paddle train \
+  --config=$cfg \
+  --save_dir=/paddle/demo/kaldi_dnn/output \
+  --trainer_count=24 \
+  --log_period=20 \
+  --num_passes=15 \
+  --use_gpu=false \
+  --show_parameter_stats_period=100 \
+  --test_all_data_in_one_period=1 \
+  2>&1 | tee 'train.log'
+

--- a/demo/kaldi_dnn/train.sh
+++ b/demo/kaldi_dnn/train.sh
@@ -8,7 +8,7 @@ sudo docker run -d \
   -v /work/local/paddle/data:/paddle/data \
   paddledev/paddle:cpu-latest paddle train \
   --config=$cfg \
-  --save_dir=/demo/kaldi_dnn/output \
+  --save_dir=/paddle/demo/kaldi_dnn/output \
   --trainer_count=4 \
   --log_period=20 \
   --num_passes=15 \

--- a/demo/kaldi_dnn/train.sh
+++ b/demo/kaldi_dnn/train.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+cfg=/paddle/demo/kaldi_dnn/trainer_config.dnn.py
+
+sudo docker run -d \
+  -v /work/local/lipeng/github/unisound-ail/paddle/demo:/paddle/demo \
+  -v /work/local/paddle/data:/paddle/data \
+  paddledev/paddle:cpu-latest paddle train \
+  --config=$cfg \
+  --save_dir=/demo/kaldi_dnn/output \
+  --trainer_count=4 \
+  --log_period=20 \
+  --num_passes=15 \
+  --use_gpu=false \
+  --show_parameter_stats_period=100 \
+  --test_all_data_in_one_period=1 \
+  2>&1 | tee 'train.log'
+

--- a/demo/kaldi_dnn/trainer_config.dnn.py
+++ b/demo/kaldi_dnn/trainer_config.dnn.py
@@ -4,23 +4,15 @@ from paddle.trainer_config_helpers import *
 
 trn = '/paddle/data/train.list'
 tst = '/paddle/data/test.list'
-label = '/paddle/data/1k_utt.pdf'
 process = 'process'
-
-utt_pdf = dict()
-with open(label) as f:
-    for line in f:
-        parts = line.split()
-        utt_pdf[parts[0]] = [int(s) for s in parts[1:]]
-
 
 define_py_data_sources2(train_list=trn,
                         test_list=tst,
                         module="dataprovider_ark",
                         obj=process,
-                        args={"utt_pdf" : utt_pdf, "num_senone" : 3513})
+                        args={"num_senone" : 3513})
 
-batch_size = 128
+batch_size = 256
 settings(
     batch_size=batch_size,
     learning_rate=2e-3,

--- a/demo/kaldi_dnn/trainer_config.dnn.py
+++ b/demo/kaldi_dnn/trainer_config.dnn.py
@@ -43,6 +43,5 @@ output = fc_layer(input=hidden2, size=3513, act=SoftmaxActivation())
 label = data_layer(name="label", size=3513)
 
 # Define cross-entropy classification loss and error.
-classification_cost(input=output, label=label)
 cls = classification_cost(input=output, label=label)
 outputs(cls)

--- a/demo/kaldi_dnn/trainer_config.dnn.py
+++ b/demo/kaldi_dnn/trainer_config.dnn.py
@@ -2,8 +2,8 @@
 
 from paddle.trainer_config_helpers import *
 
-trn = '/paddle/data/train.list'
-tst = '/paddle/data/test.list'
+trn = 'data/train.list'
+tst = 'data/test.list'
 process = 'process'
 
 define_py_data_sources2(train_list=trn,

--- a/demo/kaldi_dnn/trainer_config.dnn.py
+++ b/demo/kaldi_dnn/trainer_config.dnn.py
@@ -1,0 +1,48 @@
+# edit-mode: -*- python -*-
+
+from paddle.trainer_config_helpers import *
+
+trn = '/paddle/data/train.list'
+tst = '/paddle/data/test.list'
+label = '/paddle/data/100k_utt.pdf'
+process = 'process'
+
+utt_pdf = dict()
+with open(label) as f:
+    for line in f:
+        parts = line.split()
+        utt_pdf[parts[0]] = [int(s) for s in parts[1:]]
+
+
+define_py_data_sources2(train_list=trn,
+                        test_list=tst,
+                        module="dataprovider_kaldi",
+                        obj=process,
+                        args={"utt_pdf" : utt_pdf, "num_seonoe" : 3513})
+
+batch_size = 128
+settings(
+    batch_size=batch_size,
+    learning_rate=2e-3,
+    learning_method=AdamOptimizer(),
+    regularization=L2Regularization(8e-4),
+    gradient_clipping_threshold=25
+)
+
+# Define the data for text features. The size of the data layer is the number
+# of words in the dictionary.
+data = data_layer(name="spliced_mfcc", size=484)
+hidden1 = fc_layer(input=data, size=1024, act=SigmoidActivation())
+hidden2 = fc_layer(input=hidden1, size=1024, act=SigmoidActivation())
+output = fc_layer(input=hidden2, size=3513, act=SoftmaxActivation())
+
+# For training, we need label and cost
+
+# define the category id for each example.
+# The size of the data layer is the number of labels.
+label = data_layer(name="label", size=3513)
+
+# Define cross-entropy classification loss and error.
+classification_cost(input=output, label=label)
+cls = classification_cost(input=output, label=label)
+outputs(cls)

--- a/demo/kaldi_dnn/trainer_config.dnn.py
+++ b/demo/kaldi_dnn/trainer_config.dnn.py
@@ -16,7 +16,7 @@ with open(label) as f:
 
 define_py_data_sources2(train_list=trn,
                         test_list=tst,
-                        module="dataprovider_kaldi",
+                        module="dataprovider_ark",
                         obj=process,
                         args={"utt_pdf" : utt_pdf, "num_seonoe" : 3513})
 

--- a/demo/kaldi_dnn/trainer_config.dnn.py
+++ b/demo/kaldi_dnn/trainer_config.dnn.py
@@ -4,7 +4,7 @@ from paddle.trainer_config_helpers import *
 
 trn = '/paddle/data/train.list'
 tst = '/paddle/data/test.list'
-label = '/paddle/data/100k_utt.pdf'
+label = '/paddle/data/1k_utt.pdf'
 process = 'process'
 
 utt_pdf = dict()
@@ -18,7 +18,7 @@ define_py_data_sources2(train_list=trn,
                         test_list=tst,
                         module="dataprovider_ark",
                         obj=process,
-                        args={"utt_pdf" : utt_pdf, "num_seonoe" : 3513})
+                        args={"utt_pdf" : utt_pdf, "num_senone" : 3513})
 
 batch_size = 128
 settings(

--- a/demo/kaldi_dnn/trim-ark.py
+++ b/demo/kaldi_dnn/trim-ark.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+#from paddle.trainer_config_helpers import *
+import sys
+import struct
+
+def trim_ark(file_in, file_out, num_utt):
+    const_tag = struct.pack('6c', *[chr(i) for i in (0x00, 0x42, 0x46, 0x4d, 0x20, 0x04)])
+    with open(file_in) as fin:
+        fout = open(file_out, 'w')
+        key = ''
+        if num_utt > 0:
+            while num_utt > 0:
+                num_utt -= 1
+                key = ''
+                while True:
+                    buf = fin.read(1)
+                    if buf == ' ':
+                        break
+                    key = key + buf
+                print key
+                key += ' '
+                fout.write(key)
+                buf = fin.read(15)
+                assert buf[:6] == const_tag and buf[10] == chr(0x04)
+                fout.write(buf)
+                num_frame = struct.unpack('<i', buf[6:10])[0]
+                dim = struct.unpack('<i', buf[11:15])[0]
+                buf = fin.read(4 * dim * num_frame) # 4 is size of float
+                fout.write(buf)
+        else:
+            while num_utt < 0:
+                num_utt += 1
+                key = ''
+                while True:
+                    buf = fin.read(1)
+                    if buf == ' ':
+                        break
+                    key = key + buf
+                key += ' '
+                buf = fin.read(15)
+                assert buf[:6] == const_tag and buf[10] == chr(0x04)
+                num_frame = struct.unpack('<i', buf[6:10])[0]
+                dim = struct.unpack('<i', buf[11:15])[0]
+                buf = fin.read(4 * dim * num_frame) # 4 is size of float
+            while True:
+                key = ''
+                while True:
+                    buf = fin.read(1)
+                    if buf == '':
+                        return
+                    if buf == ' ':
+                        break
+                    key = key + buf
+                print key
+                key += ' '
+                fout.write(key)
+                buf = fin.read(15)
+                assert buf[:6] == const_tag and buf[10] == chr(0x04)
+                fout.write(buf)
+                num_frame = struct.unpack('<i', buf[6:10])[0]
+                dim = struct.unpack('<i', buf[11:15])[0]
+                buf = fin.read(4 * dim * num_frame) # 4 is size of float
+                fout.write(buf)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print >> sys.stderr, 'Usage: %s input.ark output.ark num_utt' % sys.argv[0]
+        sys.exit(-1)
+    trim_ark(sys.argv[1], sys.argv[2], int(sys.argv[3]))
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
语音识别任务相关，搭建了一个简单的 DNN 分类任务 demo

运行流程：
- 进入目录 paddle/demo/kaldi_dnn
- 运行脚本 gpu-start-docker.sh，下载预处理数据，配置 paddle docker container
- 运行脚本 gpu-train-in-docker.sh，进行 DNN 训练和测试，单 GPU 大约需要 20 分钟

待解决问题：
- 1000句训练集，同样的1000句测试时，dataprovider_ark.py 中 provider 参数 cache=CacheType.CACHE_PASS_IN_MEM 时，训练集和测试集错误率约为 4%，当 cache=CacheType.NO_CACHE 时，训练集错误率为 9.6%，测试集错误率为 47.0%，而且最后一次迭代跑完时，会卡住。
- 9000句训练集和 1000句测试集的分类错误率差距很大，训练集错误率为 55.2%，测试集错误率为 85.7%
- 多 GPU 速度没有变快，trainer_count 设置为 2，4，8 时，速度与单 GPU 相比，2（变快 10%），4（相当），8（变慢 75%）