### PR TITLE
deepSwap

### DIFF
--- a/paddle/math/BaseMatrix.cu
+++ b/paddle/math/BaseMatrix.cu
@@ -1240,6 +1240,12 @@ void BaseMatrixT<T>::assignAtOffset(BaseMatrixT& b, int64_t columnOffset) {
   }
 }
 
+DEFINE_MATRIX_BINARY_OP(DeepSwap, T tmp = a; a = b; b = tmp);
+template<class T>
+void BaseMatrixT<T>::deepSwap(BaseMatrixT& b) {
+    applyBinary(binary::DeepSwap<T>(), b);
+}
+
 template<>
 void BaseMatrixT<real>::rowDotMul(size_t destCol,
                                   BaseMatrixT& b,

--- a/paddle/math/BaseMatrix.h
+++ b/paddle/math/BaseMatrix.h
@@ -458,6 +458,10 @@ public:
   /**
    * @code
    * swap(this, b)
+   * example: swap two Matrices
+   * MatrixPtr cpuA = std::make_shared<CpuMatrix>(height, width);
+   * MatrixPtr cpuB = std::make_shared<CpuMatrix>(height, width);
+   * cpuA->deepSwap(*cpuB);
    * @endcode
    */
   void deepSwap(BaseMatrixT& b);

--- a/paddle/math/BaseMatrix.h
+++ b/paddle/math/BaseMatrix.h
@@ -457,6 +457,13 @@ public:
 
   /**
    * @code
+   * swap(this, b)
+   * @endcode
+   */
+  void deepSwap(BaseMatrixT& b);
+
+  /**
+   * @code
    * this = this + p
    * @endcode
    */

--- a/paddle/math/tests/test_matrixCompare.cpp
+++ b/paddle/math/tests/test_matrixCompare.cpp
@@ -448,6 +448,24 @@ void testMatrixZeroAtOffset(int height, int width) {
   MatrixCheckEqual(*cpuA, *cpuTest);
 }
 
+void testMatrixDeepSwap(int height, int width) {
+  MatrixPtr cpuA = std::make_shared<CpuMatrix>(height, width);
+  MatrixPtr cpuB = std::make_shared<CpuMatrix>(height, width);
+  MatrixPtr cpuCopyA = std::make_shared<CpuMatrix>(height, width);
+  MatrixPtr cpuCopyB = std::make_shared<CpuMatrix>(height, width);
+
+  cpuA->randomizeUniform();
+  cpuB->randomizeUniform();
+  cpuCopyA->copyFrom(*cpuA);
+  cpuCopyB->copyFrom(*cpuB);
+
+  // swap matrix cpuA and cpuB
+  cpuA->deepSwap(*cpuB);
+
+  MatrixCheckEqual(*cpuA, *cpuCopyB);
+  MatrixCheckEqual(*cpuB, *cpuCopyA);
+}
+
 void testMatrixBinaryAdd(int height, int width) {
   MatrixPtr cpuA = std::make_shared<CpuMatrix>(height, width);
   MatrixPtr cpuB = std::make_shared<CpuMatrix>(height, width);
@@ -479,6 +497,7 @@ void testMatrixAssign(int height, int width) {
   outputCheck->copyFrom(*gpuA);
   MatrixCheckEqual(*cpuA, *outputCheck);
 }
+
 
 void testMatrixAdd(int height, int width) {
   MatrixPtr cpuA = std::make_shared<CpuMatrix>(height, width);
@@ -798,6 +817,7 @@ TEST(Matrix, unary) {
       testMatrixBinaryAdd(height, width);
       testMatrixTanh(height, width);
       testMatrixTanhDerivative(height, width);
+      testMatrixDeepSwap(height, width);
 
       // applyTernary
       testMatrixTernarySub(height, width);


### PR DESCRIPTION
With this PR, we can write  code to directly deeply swap the content of both Vector and Matrix like the following without changing the data_ pointers.

```
para->getBuf(PARAMETER_SNAPSHOT_VALUE)->deepSwap(*para->getBuf(PARAMETER_VALUE))
```
and,
```
MatrixPtr cpuA = std::make_shared<CpuMatrix>(height, width);
MatrixPtr cpuB = std::make_shared<CpuMatrix>(height, width);
cpuA->deepSwap(*cpuB);
```