### PR TITLE
Fix docker build command error under some env.

### DIFF
--- a/doc/getstarted/build_and_install/docker_install.rst
+++ b/doc/getstarted/build_and_install/docker_install.rst
@@ -102,7 +102,7 @@ Then you can build an image with Dockerfile and launch a container:
 ..  code-block:: bash
 
     # cd into Dockerfile directory
-    docker build . -t paddle_ssh
+    docker build -t paddle_ssh .
     # run container, and map host machine port 8022 to container port 22
     docker run -d -p 8022:22 --name paddle_ssh_machine paddle_ssh
 

--- a/doc_cn/build_and_install/install/docker_install.rst
+++ b/doc_cn/build_and_install/install/docker_install.rst
@@ -118,7 +118,7 @@ cuda相关的Driver和设备映射进container中，脚本类似于
 ..  code-block:: bash
 
     # cd到含有Dockerfile的路径中
-    $ docker build . -t paddle_ssh
+    $ docker build -t paddle_ssh .
     # 运行这个container，将宿主机的8022端口映射到container的22端口上
     $ docker run -d -p 8022:22  --name paddle_ssh_machine paddle_ssh
 

--- a/paddle/scripts/tools/build_docs/build_docs.sh
+++ b/paddle/scripts/tools/build_docs/build_docs.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-docker build . -t paddle_build_doc
+docker build -t paddle_build_doc .
 docker run --rm -v $PWD/../../../../:/paddle -v $PWD:/output paddle_build_doc


### PR DESCRIPTION
adjust the order of arguments of "docker build" command, to make it executable for all env.
Also, fix the same bugs in doc too, both in en and cn. 
See [issue #661](https://github.com/PaddlePaddle/Paddle/issues/661)