### PR TITLE
Fix --job=test

### DIFF
--- a/paddle/gserver/dataproviders/DataProvider.h
+++ b/paddle/gserver/dataproviders/DataProvider.h
@@ -271,7 +271,9 @@ public:
   void finishAsyncLoad() {
     stopping_ = true;
     taskReadySem_.post();
-    asyncLoader_->join();
+    if (asyncLoader_) {
+      asyncLoader_->join();
+    }
   }
 
   void setPending(bool pending) { pending_ = pending; }

--- a/paddle/trainer/Trainer.cpp
+++ b/paddle/trainer/Trainer.cpp
@@ -205,7 +205,7 @@ void Trainer::init(const std::shared_ptr<TrainerConfigHelper>& config,
       (!IGradientMachineMode::dataMustInCpu(mode_, FLAGS_trainer_count));
 
   dataProvider_ = dataProvider;
-  if (!dataProvider_ && config_->hasDataConfig()) {
+  if (!dataProvider_ && config_->hasDataConfig() && !testing_) {
     dataProvider_.reset(DataProvider::create(*config_, *config_, gpuData));
   }
   if (!testDataProvider_) {


### PR DESCRIPTION
When the define_py_data_sources2 has both train_list and test_list,
for job=test, the trainer will create both dataProvider_ and testDataProvider_.
But dataProvider_ is not used. This causes SIGSEGV at finishAsync() because asyncLoader_ is not created.

Change-Id: If579f715f80a70ebc795094792c3436bfa0f5746