### PR TITLE
Add .dockerignore as an alias of .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+.gitignore


### PR DESCRIPTION
Without `.dockerignore`, `docker build` would send `/build` directory created by `cmake` as part of build context to Docker daemon.  This makes the context as huge as 3GB and it takes a long while to sending.

```
$ docker build -t paddle:me -f paddle/scripts/docker/Dockerfile.cpu .
Sending build context to Docker daemon  2.95 GB
```

By setting `.dockerignore` with the same content as `.gitignore`,  it is dozens of MB:

```
$ docker build -t paddle:me -f paddle/scripts/docker/Dockerfile.cpu .
Sending build context to Docker daemon 35.47 MB
```