### PR TITLE
Make browserable C++ source code into HTMLs

### DIFF
--- a/doc/getstarted/build_and_install/docker_install.rst
+++ b/doc/getstarted/build_and_install/docker_install.rst
@@ -19,8 +19,8 @@ automatically runs the following commands:
 
 .. code-block:: base
 
-   docker build -t paddle:cpu-noavx -f paddle/scripts/docker/Dockerfile .
-   docker build -t paddle:gpu-noavx -f paddle/scripts/docker/Dockerfile.gpu .
+   docker build -t paddle:cpu -f paddle/scripts/docker/Dockerfile .
+   docker build -t paddle:gpu -f paddle/scripts/docker/Dockerfile.gpu .
 
 
 To run the CPU-only image as an interactive container:
@@ -81,3 +81,25 @@ source code:
    cd Paddle
    docker build --build-arg WITH_AVX=OFF -t paddle:cpu-noavx -f paddle/scripts/docker/Dockerfile .
    docker build --build-arg WITH_AVX=OFF -t paddle:gpu-noavx -f paddle/scripts/docker/Dockerfile.gpu .
+
+
+Documentation
+-------------
+
+Paddle Docker images include an HTML version of C++ source code
+generated using `woboq code browser
+<https://github.com/woboq/woboq_codebrowser>`_.  This makes it easy
+for users to browse and understand the C++ source code.
+
+As long as we give the Paddle Docker container a name, we can run an
+additional nginx Docker container to serve the volume from the Paddle
+container:
+
+.. code-block:: bash
+
+   docker run -d --name paddle-cpu-doc paddle:cpu
+   docker run -d --volumes-from paddle-cpu-doc -p 8088:80 nginx
+
+
+Then we can direct our Web browser to the HTML version of source code
+at http://localhost:8088/paddle/

--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update \
     sed grep graphviz libjpeg-dev zlib1g-dev doxygen \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
     && apt-get clean -y
-RUN pip install BeautifulSoup docopt PyYAML pillow \
-    'sphinx>=1.4.0' sphinx_rtd_theme breathe recommonmark
+RUN pip install -U BeautifulSoup docopt PyYAML pillow \
+    sphinx sphinx_rtd_theme breathe recommonmark
 
 ARG WITH_AVX
 ENV WITH_AVX=${WITH_AVX:-ON}

--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -1,13 +1,14 @@
 FROM ubuntu:14.04
 MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
 
-RUN apt-get update && \
-    apt-get install -y cmake libprotobuf-dev protobuf-compiler git \
+RUN apt-get update \
+    && apt-get install -y cmake libprotobuf-dev protobuf-compiler git \
     libgoogle-glog-dev libgflags-dev libatlas-dev libatlas3-base g++ m4 python-pip \
     python-protobuf python-numpy python-dev swig openssh-server \
     wget unzip python-matplotlib tar xz-utils bzip2 gzip coreutils \
-    sed grep graphviz libjpeg-dev zlib1g-dev doxygen && \
-    apt-get clean -y
+    sed grep graphviz libjpeg-dev zlib1g-dev doxygen \
+    clang-3.8 llvm-3.8 libclang-3.8-dev \
+    && apt-get clean -y
 RUN pip install BeautifulSoup docopt PyYAML pillow \
     'sphinx>=1.4.0' sphinx_rtd_theme breathe recommonmark
 
@@ -18,6 +19,7 @@ ENV WITH_GPU=OFF
 RUN mkdir /paddle
 COPY . /paddle/
 RUN /paddle/paddle/scripts/docker/build.sh
+VOLUME ["/usr/share/nginx/html/data", "/usr/share/nginx/html/paddle"]
 
 RUN echo 'export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH}' >> /etc/profile
 RUN pip install /usr/local/opt/paddle/share/wheels/*.whl

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -1,13 +1,14 @@
 FROM nvidia/cuda:7.5-cudnn5-devel-ubuntu14.04
 MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
 
-RUN apt-get update && \
-    apt-get install -y cmake libprotobuf-dev protobuf-compiler git \
+RUN apt-get update \
+    && apt-get install -y cmake libprotobuf-dev protobuf-compiler git \
     libgoogle-glog-dev libgflags-dev libatlas-dev libatlas3-base g++ m4 python-pip \
     python-protobuf python-numpy python-dev swig openssh-server \
     wget unzip python-matplotlib tar xz-utils bzip2 gzip coreutils \
-    sed grep graphviz libjpeg-dev zlib1g-dev doxygen && \
-    apt-get clean -y
+    sed grep graphviz libjpeg-dev zlib1g-dev doxygen \
+    clang-3.8 llvm-3.8 libclang-3.8-dev \
+    && apt-get clean -y
 RUN pip install BeautifulSoup docopt PyYAML pillow \
     'sphinx>=1.4.0' sphinx_rtd_theme breathe recommonmark
 
@@ -18,6 +19,7 @@ ENV WITH_GPU=ON
 RUN mkdir /paddle
 COPY . /paddle/
 RUN /paddle/paddle/scripts/docker/build.sh
+VOLUME ["/usr/share/nginx/html/data", "/usr/share/nginx/html/paddle"]
 
 RUN echo 'export LD_LIBRARY_PATH=/usr/lib64:${LD_LIBRARY_PATH}' >> /etc/profile
 RUN pip install /usr/local/opt/paddle/share/wheels/*.whl

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -9,8 +9,8 @@ RUN apt-get update \
     sed grep graphviz libjpeg-dev zlib1g-dev doxygen \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
     && apt-get clean -y
-RUN pip install BeautifulSoup docopt PyYAML pillow \
-    'sphinx>=1.4.0' sphinx_rtd_theme breathe recommonmark
+RUN pip install -U BeautifulSoup docopt PyYAML pillow \
+    sphinx sphinx_rtd_theme breathe recommonmark
 
 ARG WITH_AVX
 ENV WITH_AVX=${WITH_AVX:-ON}

--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -20,8 +20,28 @@ cmake .. \
       -DWITH_AVX=${WITH_AVX} \
       -DWITH_SWIG_PY=ON \
       -DCUDNN_ROOT=/usr/ \
-      -DWITH_STYLE_CHECK=OFF
+      -DWITH_STYLE_CHECK=OFF \
+      -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 make -j `nproc`
 make install
+
+# Install woboq_codebrowser.
+git clone https://github.com/woboq/woboq_codebrowser /woboq
+cd /woboq
+cmake -DLLVM_CONFIG_EXECUTABLE=/usr/bin/llvm-config-3.8 \
+      -DCMAKE_BUILD_TYPE=Release \
+      .
+make
+
+export WOBOQ_OUT=/usr/share/nginx/html/paddle
+export BUILD_DIR=/paddle/build
+mkdir -p $WOBOQ_OUT
+cp -rv /woboq/data $WOBOQ_OUT/../data
+/woboq/generator/codebrowser_generator \
+    -b /paddle/build \
+    -a \
+    -o $WOBOQ_OUT \
+    -p paddle:/paddle
+/woboq/indexgenerator/codebrowser_indexgenerator $WOBOQ_OUT
 
 trap : 0


### PR DESCRIPTION
This PR has been updated to fix https://github.com/PaddlePaddle/Paddle/issues/732.

The intention of this PR is to add an additional type of *documentation*.  When I am learning Paddle, I do need this document. Also, a new user asked the same question in https://github.com/PaddlePaddle/Paddle/issues/715.  I feel that before Paddle API is fully stable, this document would be useful for many users.

What I did is to edit our Dockerfile so that

1. make cmake records all build commands into a JSON file, and
1. install woboq code browser which follows the JSON file to convert all .cc/.h files into .html for convenient code browsing.

This idea was from my earlier work at https://github.com/wangkuiyi/paddle-code-browse.

If this PR is merged, we can run a Nginx container to serve browsable .html files as the following:

```
# load documents in a container paddle-cpu-doc
docker run -d --name paddle-cpu-doc paddle:cpu 

# run nginx to serve documents in paddle-cpu-doc
docker run -d --volumes-from paddle-cpu-doc -p 8088:80 nginx 
```