### PR TITLE
Add more customizable ARGs with default values to Dockerfiles.

### DIFF
--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -8,12 +8,19 @@ RUN apt-get update && \
     wget unzip python-matplotlib tar xz-utils bzip2 gzip coreutils \
     sed grep graphviz libjpeg-dev zlib1g-dev doxygen && \
     apt-get clean -y
-RUN pip install BeautifulSoup docopt PyYAML pillow \
-    'sphinx>=1.4.0' sphinx_rtd_theme breathe recommonmark
+RUN pip install -U BeautifulSoup docopt PyYAML pillow \
+    sphinx sphinx_rtd_theme breathe recommonmark
 
 ARG WITH_AVX
-ENV WITH_AVX=${WITH_AVX:-ON}
+ARG WITH_DOC
+ARG WITH_SWIG_PY
+ARG WITH_STYLE_CHECK
+
 ENV WITH_GPU=OFF
+ENV WITH_AVX=${WITH_AVX:-ON}
+ENV WITH_DOC=${WITH_DOC:-ON}
+ENV WITH_SWIG_PY=${WITH_SWIG_PY:-ON}
+ENV WITH_STYLE_CHECK=${WITH_STYLE_CHECK:-OFF}
 
 RUN mkdir /paddle
 COPY . /paddle/

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -8,12 +8,19 @@ RUN apt-get update && \
     wget unzip python-matplotlib tar xz-utils bzip2 gzip coreutils \
     sed grep graphviz libjpeg-dev zlib1g-dev doxygen && \
     apt-get clean -y
-RUN pip install BeautifulSoup docopt PyYAML pillow \
-    'sphinx>=1.4.0' sphinx_rtd_theme breathe recommonmark
+RUN pip install -U BeautifulSoup docopt PyYAML pillow \
+    sphinx sphinx_rtd_theme breathe recommonmark
 
 ARG WITH_AVX
-ENV WITH_AVX=${WITH_AVX:-ON}
+ARG WITH_DOC
+ARG WITH_SWIG_PY
+ARG WITH_STYLE_CHECK
+
 ENV WITH_GPU=ON
+ENV WITH_AVX=${WITH_AVX:-ON}
+ENV WITH_DOC=${WITH_DOC:-ON}
+ENV WITH_SWIG_PY=${WITH_SWIG_PY:-ON}
+ENV WITH_STYLE_CHECK=${WITH_STYLE_CHECK:-OFF}
 
 RUN mkdir /paddle
 COPY . /paddle/


### PR DESCRIPTION
I noticed that we need this so we can re-use Docker images for development easily.  In particular, suppose that I cloned Paddle into `~/work/paddle` on my MacBook Pro, and is going to change/develop Paddle's C++ source code, I would

1. Build a Docker image `paddle:dev`:

   ```
   cd ~/work/paddle
   docker build -t paddle:dev -f paddle/scripts/docker/Dockerfile .
   ```

   This copies `~/work/paddle` into the image as `/paddle`.

1. Run the Docker image in a container with `~/work/paddle` on the host mounted into `/paddle`:

   ```
   docker run -d -p 2022:22 -v /Users/yi/work/paddle:/paddle paddle:dev
   ```

   This mounts `~/work/paddle` (aka `/Users/yi/work/paddle`) to `/paddle` in the container. This actually overlays the directory over the previously copied version.

1. Edit files in `~/work/paddle/` on the host, and build the edited source files from within the container:

   ```
   ssh root@localhost -p 2022
   $ cd /paddle
   $ WITH_GPU=OFF WITH_DOC=OFF WITH_STYLE_CHECK=ON WITH_SWIG_PY=ON paddle/scripts/docker/build.sh
   $ make -j4
   ```

   The `cmake` command creates `/paddle/build` directory in the container and makes `make` saves intermediate files in there. This `/paddle/build` is actually created on the host as `~/work/paddle/build`, and intermediate files will be saved on the host and will be re-used the next time we change code and re-build.