### PR TITLE
Feature/add attribute proto

### DIFF
--- a/paddle/gserver/tests/test_PyDataProvider2.cpp
+++ b/paddle/gserver/tests/test_PyDataProvider2.cpp
@@ -348,10 +348,7 @@ TEST(PyDataProvider2, multiThread) {
 
 TEST(PyDataProvider2, minPoolSizeWithCache) {
   paddle::DataConfig config;
-  config.set_type("py2");
-  config.set_files(FLAGS_train_list.c_str());
-  config.set_load_data_module("test_PyDataProvider2");
-  config.set_load_data_object("test_min_pool_size_with_cache");
+  setFunction(&config, "test_min_pool_size_with_cache");
   config.set_async_load_data(true);
 
   std::unique_ptr<paddle::DataProvider> provider(

--- a/paddle/utils/ProtoAttrs.cpp
+++ b/paddle/utils/ProtoAttrs.cpp
@@ -1,0 +1,19 @@
+/* Copyright (c) 2016 PaddlePaddle Authors, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "ProtoAttrs.h"
+
+namespace paddle {
+std::string internal::gReaderErrorStub;
+}  // namespace paddle

--- a/paddle/utils/ProtoAttrs.h
+++ b/paddle/utils/ProtoAttrs.h
@@ -1,0 +1,148 @@
+#pragma once
+/* Copyright (c) 2016 PaddlePaddle Authors, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <algorithm>
+#include "Attribute.pb.h"
+#include "Logging.h"
+#include "TypeDefs.h"
+
+namespace paddle {
+
+namespace internal {
+extern std::string gReaderErrorStub;
+}
+
+template <typename Container = google::protobuf::RepeatedPtrField<Attribute>>
+class AttributeReader {
+public:
+  explicit inline AttributeReader(const Container& attrs) : attrs_(attrs) {}
+
+  inline typename Container::const_iterator get(const std::string& name) const {
+    return std::find_if(
+        attrs_.begin(), attrs_.end(), [&name](const Attribute& attr) {
+          return attr.name() == name;
+        });
+  }
+
+  inline bool contain(const std::string& name) const {
+    return this->get(name) != attrs_.end();
+  }
+
+  inline const Attribute& attr(const std::string& name,
+                               bool* ok = nullptr) const {
+    auto it = this->get(name);
+    CHECK(it != attrs_.end() || ok != nullptr) << "cannot find " << name
+                                               << " in attributes";
+    if (ok != nullptr) {
+      *ok = it != attrs_.end();
+    }
+    return *it;
+  }
+
+  inline Attribute::AttributeType getType(const std::string& name,
+                                          bool* ok = nullptr) const {
+    auto& tmp = attr(name, ok);
+    if (ok != nullptr && !(*ok)) {  // cannot found.
+      return Attribute_AttributeType_REAL;
+    } else {
+      return tmp.type();
+    }
+  }
+
+  inline const std::string& getStr(const std::string& name,
+                                   bool* ok = nullptr) const {
+    auto& attr = this->attr(name, ok);
+    if (ok != nullptr && !(*ok)) {
+      return internal::gReaderErrorStub;
+    }
+    CHECK_EQ(attr.type(), Attribute_AttributeType_STRING);
+    return attr.s_val();
+  }
+
+  inline real getReal(const std::string& name, bool* ok = nullptr) const {
+    auto& attr = this->attr(name, ok);
+    if (ok != nullptr && !(*ok)) {
+      return .0;
+    }
+    CHECK_EQ(attr.type(), Attribute_AttributeType_REAL);
+    return attr.r_val();
+  }
+
+  inline bool getBool(const std::string& name, bool* ok = nullptr) const {
+    auto& attr = this->attr(name);
+    if (ok != nullptr && !(*ok)) {
+      return false;
+    }
+    CHECK_EQ(attr.type(), Attribute_AttributeType_BOOL);
+    return attr.b_val();
+  }
+
+  inline int32_t getInt32(const std::string& name, bool* ok = nullptr) const {
+    auto& attr = this->attr(name);
+    if (ok != nullptr && !(*ok)) {
+      return 0;
+    }
+    CHECK_EQ(attr.type(), Attribute_AttributeType_INT32);
+    return attr.i_val();
+  }
+
+private:
+  const Container& attrs_;
+};
+
+template <typename Container = google::protobuf::RepeatedPtrField<Attribute>>
+class AttributeWriter {
+public:
+  explicit inline AttributeWriter(Container* attrs) : attrs_(attrs) {}
+
+  inline bool contain(const std::string& name) const {
+    return AttributeReader<Container>(*attrs_).contain(name);
+  }
+
+  inline Attribute* add(const std::string& name) {
+    CHECK(!contain(name)) << name << " has been set";
+    Attribute* attr = attrs_->Add();
+    attr->set_name(name);
+    return attr;
+  }
+
+  inline void addStr(const std::string& name, const std::string& value) {
+    Attribute* attr = this->add(name);
+    attr->set_type(Attribute_AttributeType_STRING);
+    attr->set_s_val(value);
+  }
+
+  inline void addInt32(const std::string& name, int32_t value) {
+    Attribute* attr = this->add(name);
+    attr->set_type(Attribute_AttributeType_INT32);
+    attr->set_i_val(value);
+  }
+
+  inline void addReal(const std::string& name, real value) {
+    Attribute* attr = this->add(name);
+    attr->set_type(Attribute_AttributeType_REAL);
+    attr->set_r_val(value);
+  }
+
+  inline void addBool(const std::string& name, bool value) {
+    Attribute* attr = add(name);
+    attr->set_type(Attribute_AttributeType_BOOL);
+    attr->set_b_val(value);
+  }
+
+private:
+  Container* attrs_;
+};
+}  // namespace paddle

--- a/proto/Attribute.proto.m4
+++ b/proto/Attribute.proto.m4
@@ -1,0 +1,33 @@
+/* Copyright (c) 2016 PaddlePaddle Authors, Inc. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+ifdef(`proto3', `syntax = "proto2";')
+package paddle;
+
+
+message Attribute {
+  required string name = 1; 
+  enum AttributeType {
+  	REAL = 0;
+  	BOOL = 1;
+  	INT32 = 2;
+  	STRING = 3;
+  }
+
+  required AttributeType type = 2;
+
+  optional real r_val = 3;
+  optional bool b_val = 4;
+  optional int32 i_val = 5;
+  optional string s_val = 6;
+}

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -4,7 +4,8 @@ set(proto_filenames
     ModelConfig.proto
     ParameterConfig.proto
     ParameterService.proto
-    TrainerConfig.proto)
+    TrainerConfig.proto
+    Attribute.proto)
 
 set(real_proto_files)
 

--- a/proto/DataConfig.proto.m4
+++ b/proto/DataConfig.proto.m4
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 ifdef(`proto3', `syntax = "proto2";')
+import "Attribute.proto";
 
 package paddle;
 
@@ -81,5 +82,8 @@ sinclude(`DataConfigInter.proto.m4')
 
   // the usage ratio of instances. Setting to 1.0 means the use of all instances.
   optional real usage_ratio = 27 [default = 1.0];
+
+  // Data Provider attributes.
+  repeated Attribute attributes = 100;
 };
 

--- a/proto/ModelConfig.proto.m4
+++ b/proto/ModelConfig.proto.m4
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 ifdef(`proto3', `syntax = "proto2";')
 
+import "Attribute.proto";
 import "ParameterConfig.proto";
 
 package paddle;

--- a/python/paddle/trainer_config_helpers/data_sources.py
+++ b/python/paddle/trainer_config_helpers/data_sources.py
@@ -15,7 +15,7 @@
 Data Sources are helpers to define paddle training data or testing data.
 """
 from paddle.trainer.config_parser import *
-from .utils import deprecated
+from paddle.proto.Attribute_pb2 import Attribute
 
 try:
     import cPickle as pickle
@@ -85,9 +85,22 @@ def define_py_data_source(file_list,
             data = DataBase()
             data.type = 'py2'
             data.files = files
-            data.load_data_module = load_data_module
-            data.load_data_object = load_data_object
-            data.load_data_args = load_data_args
+            module = data.attributes.add()
+            module.name = "pydp2.load_module"
+            module.type = Attribute.STRING
+            module.s_val = load_data_module
+
+            object = data.attributes.add()
+            object.name = "pydp2.load_obj"
+            object.type = Attribute.STRING
+            object.s_val = load_data_object
+
+            if load_data_args is not None:
+                args = data.attributes.add()
+                args.name = "pydp2.load_args"
+                args.type = Attribute.STRING
+                args.s_val = load_data_args
+
             data.async_load_data = True
             return data
 

--- a/python/paddle/trainer_config_helpers/tests/configs/protostr/test_split_datasource.protostr
+++ b/python/paddle/trainer_config_helpers/tests/configs/protostr/test_split_datasource.protostr
@@ -21,12 +21,19 @@ data_config {
   files: "train.list"
   async_load_data: true
   for_test: false
-  load_data_module: "a"
-  load_data_object: "c"
-  load_data_args: ""
   data_ratio: 1
   is_main_data: true
   usage_ratio: 1.0
+  attributes {
+    name: "pydp2.load_module"
+    type: STRING
+    s_val: "a"
+  }
+  attributes {
+    name: "pydp2.load_obj"
+    type: STRING
+    s_val: "c"
+  }
 }
 opt_config {
   batch_size: 1000
@@ -60,12 +67,19 @@ test_data_config {
   files: "test.list"
   async_load_data: true
   for_test: true
-  load_data_module: "b"
-  load_data_object: "d"
-  load_data_args: ""
   data_ratio: 1
   is_main_data: true
   usage_ratio: 1.0
+  attributes {
+    name: "pydp2.load_module"
+    type: STRING
+    s_val: "b"
+  }
+  attributes {
+    name: "pydp2.load_obj"
+    type: STRING
+    s_val: "d"
+  }
 }
 save_dir: "./output/model"
 start_pass: 0


### PR DESCRIPTION
添加protobuf Attribute。

## 基本用法

### 简化Protobuf
我们之后写的Layer和DataProvider的参数，都可以用这个Attribute来统一。这样，我们新写Layer就不用改Protobuf了。

### Protobuf3兼容性
如果我们所有的Attribute都是用这种机制写的，那么(未来)升级Protobuf3的时候，就会非常简单。只需要写一个新的AttributeWriter和AttributeReader就好了。

## 进阶用法

我们可以在每个Layer的cpp里面，定义一些Attribute，比如这个Layer输入的类型是什么，支持的参数类型有什么。然后序列化到protobuf中。

config_parser部分的python文件，直接读取这个序列化的proto，动态(运行时)生成layer function。这样我们添加新Layer，就只需要改Cpp了。

## 这个patch

### 做了什么
这个Patch只添加了Attribute这个类，并且用PyDataProvider2做了实验，证明这个机制可以跑通。

### 可能有的问题

* 这样的Attribute不支持Default Value。不过protobuf3里面也不支持default value。
* 这样读取Attribute的时候，会有一次O(n)的线性查找
   * 升级到protobuf3，可以改成map
   * 即使在protobuf2，这种attribute的读取工作并不常见，应该不会是性能瓶颈。

