### PR TITLE
Bazel protobuf and gtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ build/
 .pydevproject
 Makefile
 .test_env/
+
+*~
+bazel-*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@
     sha: v0.13.2
     hooks:
     - id: yapf
-      files: (.*\.(py|bzl)|BUILD|.*\.BUILD)$  # Bazel BUILD files follow Python syntax.
+      files: (.*\.(py|bzl)|BUILD|.*\.BUILD|WORKSPACE)$  # Bazel BUILD files follow Python syntax.
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: 7539d8bd1a00a3c1bfd34cdb606d3a6372e83469
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@
 -   repo: https://github.com/reyoung/mirrors-yapf.git
     sha: v0.13.2
     hooks:
-    -   id: yapf
+    - id: yapf
+      files: (.*\.(py|bzl)|BUILD|.*\.BUILD)$  # Bazel BUILD files follow Python syntax.
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     sha: 7539d8bd1a00a3c1bfd34cdb606d3a6372e83469
     hooks:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,22 @@
+# External dependency to grpc-enabled Google-styleprotobuf bulding
+# rules.  This method comes from
+# https://github.com/pubref/rules_protobuf#usage.
 git_repository(
     name = "org_pubref_rules_protobuf",
     remote = "https://github.com/pubref/rules_protobuf",
     tag = "v0.7.1",
 )
+
+# External dependency to gtest 1.7.0.  This method comes from
+# https://www.bazel.io/versions/master/docs/tutorial/cpp.html.
+new_http_archive(
+    name = "gtest",
+    url = "https://github.com/google/googletest/archive/release-1.7.0.zip",
+    sha256 = "b58cb7547a28b2c718d1e38aee18a3659c9e3ff52440297e965f5edffe34b6d0",
+    build_file = "third_party/gtest.BUILD",
+    strip_prefix = "googletest-release-1.7.0",
+)
+
 
 load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
 cpp_proto_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,10 +1,9 @@
-# External dependency to grpc-enabled Google-styleprotobuf bulding
-# rules.  This method comes from
-# https://github.com/pubref/rules_protobuf#usage.
-git_repository(
-    name = "org_pubref_rules_protobuf",
-    remote = "https://github.com/pubref/rules_protobuf",
-    tag = "v0.7.1",
+# External dependency to Google protobuf.
+http_archive(
+    name = "protobuf",
+    url = "http://github.com/google/protobuf/archive/v3.1.0.tar.gz",
+    sha256 = "0a0ae63cbffc274efb573bdde9a253e3f32e458c41261df51c5dbc5ad541e8f7",
+    strip_prefix = "protobuf-3.1.0",
 )
 
 # External dependency to gtest 1.7.0.  This method comes from
@@ -16,7 +15,3 @@ new_http_archive(
     build_file = "third_party/gtest.BUILD",
     strip_prefix = "googletest-release-1.7.0",
 )
-
-
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
-cpp_proto_repositories()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,8 @@
+git_repository(
+    name = "org_pubref_rules_protobuf",
+    remote = "https://github.com/pubref/rules_protobuf",
+    tag = "v0.7.1",
+)
+
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_repositories")
+cpp_proto_repositories()

--- a/doc/getstarted/build_and_install/docker_install_en.rst
+++ b/doc/getstarted/build_and_install/docker_install_en.rst
@@ -119,7 +119,7 @@ The general development workflow with Docker and Bazel is as follows:
 
    .. code-block:: bash
 
-   git clone --recursive https://github.com/paddlepaddle/paddle
+      git clone --recursive https://github.com/paddlepaddle/paddle
 
 
 1. Build a development Docker image `paddle:dev` from the source code.
@@ -129,8 +129,8 @@ The general development workflow with Docker and Bazel is as follows:
 
    .. code-block:: bash
 
-   cd paddle
-   docker build -t paddle:dev -f paddle/scripts/docker/Dockerfile .
+      cd paddle
+      docker build -t paddle:dev -f paddle/scripts/docker/Dockerfile .
 
 
 1. Run the image as a container and mounting local source code
@@ -139,34 +139,34 @@ The general development workflow with Docker and Bazel is as follows:
 
    .. code-block:: bash
 
-   docker run \
-    -d # run the container in background mode \
-    --name paddle # we can run a nginx container to serve documents \
-    -p 2022:22    # so we can SSH into this container \
-    -v $PWD:/paddle # mount the source code \
-    -v $HOME/.cache/bazel:/root/.cache/bazel # mount Bazel cache \
-    paddle:dev
+      docker run \
+       -d # run the container in background mode \
+       --name paddle # we can run a nginx container to serve documents \
+       -p 2022:22    # so we can SSH into this container \
+       -v $PWD:/paddle # mount the source code \
+       -v $HOME/.cache/bazel:/root/.cache/bazel # mount Bazel cache \
+       paddle:dev
 
 1. SSH into the container:
 
    .. code-block:: bash
 
-   ssh root@localhost -p 2022
+      ssh root@localhost -p 2022
 
 1. We can edit the source code in the container or on this host.  Then
    we can build using cmake
 
    .. code-block:: bash
 
-   cd /paddle # where paddle source code has been mounted into the container
-   mkdir -p build
-   cd build
-   cmake ..
-   make -j `nproc`
+      cd /paddle # where paddle source code has been mounted into the container
+      mkdir -p build
+      cd build
+      cmake ..
+      make -j `nproc`
 
    or Bazel in the container:
 
    .. code-block:: bash
 
-   cd /paddle
-   bazel build ...
+      cd /paddle
+      bazel build ...

--- a/doc/getstarted/build_and_install/docker_install_en.rst
+++ b/doc/getstarted/build_and_install/docker_install_en.rst
@@ -122,7 +122,7 @@ The general development workflow with Docker and Bazel is as follows:
       git clone --recursive https://github.com/paddlepaddle/paddle
 
 
-1. Build a development Docker image `paddle:dev` from the source code.
+2. Build a development Docker image `paddle:dev` from the source code.
    This image contains all the development tools and dependencies of
    PaddlePaddle.
 
@@ -133,7 +133,7 @@ The general development workflow with Docker and Bazel is as follows:
       docker build -t paddle:dev -f paddle/scripts/docker/Dockerfile .
 
 
-1. Run the image as a container and mounting local source code
+3. Run the image as a container and mounting local source code
    directory into the container.  This allows us to change the code on
    the host and build it within the container.
 
@@ -147,13 +147,13 @@ The general development workflow with Docker and Bazel is as follows:
        -v $HOME/.cache/bazel:/root/.cache/bazel # mount Bazel cache \
        paddle:dev
 
-1. SSH into the container:
+4. SSH into the container:
 
    .. code-block:: bash
 
       ssh root@localhost -p 2022
 
-1. We can edit the source code in the container or on this host.  Then
+5. We can edit the source code in the container or on this host.  Then
    we can build using cmake
 
    .. code-block:: bash

--- a/doc/getstarted/build_and_install/docker_install_en.rst
+++ b/doc/getstarted/build_and_install/docker_install_en.rst
@@ -104,3 +104,69 @@ container:
 
 Then we can direct our Web browser to the HTML version of source code
 at http://localhost:8088/paddle/
+
+
+Development Using Docker
+------------------------
+
+Develpers can work on PaddlePaddle using Docker.  This allows
+developers to work on different platforms -- Linux, Mac OS X, and
+Windows -- in a consistent way.
+
+The general development workflow with Docker and Bazel is as follows:
+
+1. Get the source code of Paddle:
+
+   .. code-block:: bash
+
+   git clone --recursive https://github.com/paddlepaddle/paddle
+
+
+1. Build a development Docker image `paddle:dev` from the source code.
+   This image contains all the development tools and dependencies of
+   PaddlePaddle.
+
+
+   .. code-block:: bash
+
+   cd paddle
+   docker build -t paddle:dev -f paddle/scripts/docker/Dockerfile .
+
+
+1. Run the image as a container and mounting local source code
+   directory into the container.  This allows us to change the code on
+   the host and build it within the container.
+
+   .. code-block:: bash
+
+   docker run \
+    -d # run the container in background mode \
+    --name paddle # we can run a nginx container to serve documents \
+    -p 2022:22    # so we can SSH into this container \
+    -v $PWD:/paddle # mount the source code \
+    -v $HOME/.cache/bazel:/root/.cache/bazel # mount Bazel cache \
+    paddle:dev
+
+1. SSH into the container:
+
+   .. code-block:: bash
+
+   ssh root@localhost -p 2022
+
+1. We can edit the source code in the container or on this host.  Then
+   we can build using cmake
+
+   .. code-block:: bash
+
+   cd /paddle # where paddle source code has been mounted into the container
+   mkdir -p build
+   cd build
+   cmake ..
+   make -j `nproc`
+
+   or Bazel in the container:
+
+   .. code-block:: bash
+
+   cd /paddle
+   bazel build ...

--- a/doc/getstarted/build_and_install/docker_install_en.rst
+++ b/doc/getstarted/build_and_install/docker_install_en.rst
@@ -161,12 +161,13 @@ The general development workflow with Docker and Bazel is as follows:
       cd /paddle # where paddle source code has been mounted into the container
       mkdir -p build
       cd build
-      cmake ..
+      cmake -DWITH_TESTING=ON ..
       make -j `nproc`
+      CTEST_OUTPUT_ON_FAILURE=1 ctest
 
    or Bazel in the container:
 
    .. code-block:: bash
 
       cd /paddle
-      bazel build ...
+      bazel test ...

--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
     sed grep graphviz libjpeg-dev zlib1g-dev doxygen \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
     && apt-get clean -y
-RUN cd /usr/src/gtest && cmake . && make && sudo cp *.a /usr/lib
+RUN cd /usr/src/gtest && cmake . && make && cp *.a /usr/lib
 RUN pip install -U BeautifulSoup docopt PyYAML pillow \
     sphinx sphinx_rtd_theme breathe recommonmark
 

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -11,7 +11,7 @@ RUN apt-get update \
     sed grep graphviz libjpeg-dev zlib1g-dev doxygen \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
     && apt-get clean -y
-RUN cd /usr/src/gtest && cmake . && make && sudo cp *.a /usr/lib
+RUN cd /usr/src/gtest && cmake . && make && cp *.a /usr/lib
 RUN pip install -U BeautifulSoup docopt PyYAML pillow \
     sphinx sphinx_rtd_theme breathe recommonmark
 

--- a/third_party/gtest.BUILD
+++ b/third_party/gtest.BUILD
@@ -1,0 +1,14 @@
+cc_library(
+    name = "main",
+    srcs = glob(
+        ["src/*.cc"],
+        exclude = ["src/gtest-all.cc"]
+    ),
+    hdrs = glob([
+        "include/**/*.h",
+        "src/*.h"
+    ]),
+    copts = ["-Iexternal/gtest/include"],
+    linkopts = ["-pthread"],
+    visibility = ["//visibility:public"],
+)

--- a/third_party/protobuf_test/BUILD
+++ b/third_party/protobuf_test/BUILD
@@ -7,6 +7,7 @@ cpp_proto_library(
     protos = [
         "example.proto"
     ],
+    with_grpc = True,
 )
 
 cc_library(
@@ -14,4 +15,14 @@ cc_library(
     srcs = ["example_lib.cc"],
     hdrs = ["example_lib.h"],
     deps = [":example_proto"],
+)
+
+cc_test(
+    name = "example_lib_test",
+    srcs = ["example_lib_test.cc"],
+    copts = ["-Iexternal/gtest/include"],
+    deps =[
+        "@gtest//:main",
+        ":example_lib",
+    ],
 )

--- a/third_party/protobuf_test/BUILD
+++ b/third_party/protobuf_test/BUILD
@@ -1,0 +1,17 @@
+licenses(["notice"])  # Apache 2.0
+
+load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
+
+cpp_proto_library(
+    name = "example_proto",
+    protos = [
+        "example.proto"
+    ],
+)
+
+cc_library(
+    name = "example_lib",
+    srcs = ["example_lib.cc"],
+    hdrs = ["example_lib.h"],
+    deps = [":example_proto"],
+)

--- a/third_party/protobuf_test/BUILD
+++ b/third_party/protobuf_test/BUILD
@@ -1,13 +1,12 @@
 licenses(["notice"])  # Apache 2.0
 
-load("@org_pubref_rules_protobuf//cpp:rules.bzl", "cpp_proto_library")
+load("@protobuf//:protobuf.bzl", "cc_proto_library")
 
-cpp_proto_library(
+cc_proto_library(
     name = "example_proto",
-    protos = [
-        "example.proto"
-    ],
-    with_grpc = True,
+    srcs = ["example.proto"],
+    protoc = "@protobuf//:protoc",
+    default_runtime = "@protobuf//:protobuf",
 )
 
 cc_library(

--- a/third_party/protobuf_test/README.md
+++ b/third_party/protobuf_test/README.md
@@ -1,0 +1,1 @@
+This package tests that Bazel can build protobuf related rules.

--- a/third_party/protobuf_test/example.proto
+++ b/third_party/protobuf_test/example.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package protos;
+
+message Greeting {
+  string name = 1;
+}

--- a/third_party/protobuf_test/example.proto
+++ b/third_party/protobuf_test/example.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package protos;
+package third_party.protobuf_test;
 
 message Greeting {
   string name = 1;

--- a/third_party/protobuf_test/example_lib.cc
+++ b/third_party/protobuf_test/example_lib.cc
@@ -1,0 +1,6 @@
+#include "third_party/protobuf_test/example_lib.h"
+#include <string>
+
+std::string get_greet(const ::protos::Greeting& who) {
+  return "Hello " + who.name();
+}

--- a/third_party/protobuf_test/example_lib.cc
+++ b/third_party/protobuf_test/example_lib.cc
@@ -1,6 +1,11 @@
 #include "third_party/protobuf_test/example_lib.h"
-#include <string>
 
-std::string get_greet(const ::protos::Greeting& who) {
+namespace third_party {
+namespace protobuf_test {
+
+std::string get_greet(const Greeting& who) {
   return "Hello " + who.name();
 }
+
+}  // namespace protobuf_test
+}  // namespace thrid_party

--- a/third_party/protobuf_test/example_lib.h
+++ b/third_party/protobuf_test/example_lib.h
@@ -4,4 +4,10 @@
 
 #include <string>
 
-std::string get_greet(const ::protos::Greeting &who);
+namespace third_party {
+namespace protobuf_test {
+
+std::string get_greet(const Greeting &who);
+
+}  // namespace protobuf_test
+}  // namespace third_party

--- a/third_party/protobuf_test/example_lib.h
+++ b/third_party/protobuf_test/example_lib.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "third_party/protobuf_test/example.pb.h"
+
+#include <string>
+
+std::string get_greet(const ::protos::Greeting &who);

--- a/third_party/protobuf_test/example_lib_test.cc
+++ b/third_party/protobuf_test/example_lib_test.cc
@@ -1,0 +1,15 @@
+#include "third_party/protobuf_test/example_lib.h"
+
+#include "gtest/gtest.h"
+
+namespace third_party {
+namespace protobuf_test {
+
+TEST(ProtobufTest, GetGreet) {
+  Greeting g;
+  g.set_name("Paddle");
+  EXPECT_EQ("Hello Paddle", get_greet(g));
+}
+
+}  // namespace protobuf_test
+}  // namespace third_party


### PR DESCRIPTION
Fixes https://github.com/PaddlePaddle/Paddle/issues/816

In this PR, 

1. I initialize Bazel WORKSPACE file to declare an external dependency to https://github.com/pubref/rules_protobuf, which implements the Google-style protobuf building rules. 

   For more information please refer to this example repo: https://github.com/wangkuiyi/learn-bazel.

1. I also add a simple package in `/third_party/protobuf_test` to demonstrate using protobuf and gtest.

1. I updated the `docker_install_en.rst` documents to show how we can develop using Docker and Bazel.

----

Dear reviewers:

Please feel free to use Docker and Bazel to check this PR as described [in my update to Docker document in this PR](https://github.com/PaddlePaddle/Paddle/pull/818/files#diff-ceff150fa8464c5d2d9cc836209c65b5).