### PR TITLE
add submodule instructions in build_and_install doc

### DIFF
--- a/doc/getstarted/build_and_install/build_from_source_en.md
+++ b/doc/getstarted/build_and_install/build_from_source_en.md
@@ -14,10 +14,7 @@ cd paddle
 git submodule update --init --recursive
 ```
 
-If you already have a local PaddlePaddle repo and have not initialized the submodule, your local submodule folder will be empty. You can simply run the following command in your PaddlePaddle home directory to initialze your submodule folder.
-```
-git submodule update --init --recursive
-```
+If you already have a local PaddlePaddle repo and have not initialized the submodule, your local submodule folder will be empty. You can simply run the last line of the above codes in your PaddlePaddle home directory to initialze your submodule folder.
 
 If you have already initialized your submodule and you would like to sync with the upstream submodule repo, you can run the following command
 ```

--- a/doc/getstarted/build_and_install/build_from_source_en.md
+++ b/doc/getstarted/build_and_install/build_from_source_en.md
@@ -14,6 +14,16 @@ cd paddle
 git submodule update --init --recursive
 ```
 
+If you already have a local PaddlePaddle repo and have not initialized the submodule, you can simply run the following command in your PaddlePaddle home directory.
+```
+git submodule update --init --recursive
+```
+
+To sync with the upstream submodule repo, you can run the following command
+```
+git submodule update --remote
+```
+
 ## <span id="requirements">Requirements</span>
 
 To compile the source code, your computer must be equipped with the following dependencies.

--- a/doc/getstarted/build_and_install/build_from_source_en.md
+++ b/doc/getstarted/build_and_install/build_from_source_en.md
@@ -14,7 +14,7 @@ cd paddle
 git submodule update --init --recursive
 ```
 
-If you already have a local PaddlePaddle repo and have not initialized the submodule, your local submodule folder will be empty. You can simply run the last line of the above codes in your PaddlePaddle home directory to initialze your submodule folder.
+If you already have a local PaddlePaddle repo and have not initialized the submodule, your local submodule folder will be empty. You can simply run the last line of the above codes in your PaddlePaddle home directory to initialize your submodule folder.
 
 If you have already initialized your submodule and you would like to sync with the upstream submodule repo, you can run the following command
 ```

--- a/doc/getstarted/build_and_install/build_from_source_en.md
+++ b/doc/getstarted/build_and_install/build_from_source_en.md
@@ -14,12 +14,12 @@ cd paddle
 git submodule update --init --recursive
 ```
 
-If you already have a local PaddlePaddle repo and have not initialized the submodule, you can simply run the following command in your PaddlePaddle home directory.
+If you already have a local PaddlePaddle repo and have not initialized the submodule, your local submodule folder will be empty. You can simply run the following command in your PaddlePaddle home directory to initialze your submodule folder.
 ```
 git submodule update --init --recursive
 ```
 
-To sync with the upstream submodule repo, you can run the following command
+If you have already initialized your submodule and you would like to sync with the upstream submodule repo, you can run the following command
 ```
 git submodule update --remote
 ```


### PR DESCRIPTION
I have added submodule git instructions for initializing and updating the submodule.