### PR TITLE
priorbox layer for Single Shot Multibox Detection Network

### DIFF
--- a/paddle/gserver/layers/PriorBox.cpp
+++ b/paddle/gserver/layers/PriorBox.cpp
@@ -1,0 +1,137 @@
+/* Copyright (c) 2016 Baidu, Inc. All Rights Reserve.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "Layer.h"
+#include "paddle/math/Matrix.h"
+#include "paddle/math/BaseMatrix.h"
+
+namespace paddle {
+
+class PriorBoxLayer : public Layer {
+public:
+  explicit PriorBoxLayer(const LayerConfig& config) : Layer(config) {}
+  bool init(const LayerMap& layerMap, const ParameterMap& parameterMap);
+  void forward(PassType passType);
+  void backward(const UpdateCallback& callback) {}
+  int numPriors_;
+  std::vector<int> minSize_;
+  std::vector<int> maxSize_;
+  std::vector<float> aspectRatio_;
+  std::vector<float> variance_;
+  MatrixPtr buffer_;
+};
+
+bool PriorBoxLayer::init(const LayerMap& layerMap,
+                       const ParameterMap& parameterMap) {
+  Layer::init(layerMap, parameterMap);
+  std::copy(config_.inputs(0).priorbox_conf().min_size().begin(),
+            config_.inputs(0).priorbox_conf().min_size().end(),
+            std::back_inserter(minSize_));
+  std::copy(config_.inputs(0).priorbox_conf().max_size().begin(),
+            config_.inputs(0).priorbox_conf().max_size().end(),
+            std::back_inserter(maxSize_));
+  std::copy(config_.inputs(0).priorbox_conf().aspect_ratio().begin(),
+            config_.inputs(0).priorbox_conf().aspect_ratio().end(),
+            std::back_inserter(aspectRatio_));
+  std::copy(config_.inputs(0).priorbox_conf().variance().begin(),
+            config_.inputs(0).priorbox_conf().variance().end(),
+            std::back_inserter(variance_));
+  // flip
+  int input_ratio_length = aspectRatio_.size();
+  for (int index = 0; index < input_ratio_length; index++)
+      aspectRatio_.push_back(1 / aspectRatio_[index]);
+  aspectRatio_.push_back(1.);
+  numPriors_ = aspectRatio_.size();
+  if (maxSize_.size() > 0)
+      numPriors_++;
+  buffer_ = Matrix::create(1, 1, false, false);
+  return true;
+}
+
+void PriorBoxLayer::forward(PassType passType) {
+  Layer::forward(passType);
+  auto input = getInput(0);
+  int layer_width = input.getFrameWidth();
+  int layer_height = input.getFrameHeight();
+
+  MatrixPtr inV1 = getInputValue(1);
+  int image_width = inV1->getElement(0, 0);
+  int image_height = inV1->getElement(0, 1);
+  float step_w = static_cast<float>(image_width) / layer_width;
+  float step_h = static_cast<float>(image_height) / layer_height;
+  int dim = layer_height * layer_width * numPriors_ * 4;
+  reserveOutput(1, dim * 2);
+  // use a cpu buffer to compute
+  Matrix::resizeOrCreate(buffer_, 1, dim * 2, false, false);
+  auto* tmp_ptr = buffer_->getData();
+
+  int idx = 0;
+  for (int h = 0; h < layer_height; ++h) {
+    for (int w = 0; w < layer_width; ++w) {
+      float center_x = (w + 0.5)  * step_w;
+      float center_y = (h + 0.5) * step_h;
+      int min_size = 0;
+      for (size_t s = 0; s < minSize_.size(); s++) {
+        // first prior.
+        min_size = minSize_[s];
+        int box_width = min_size;
+        int box_height = min_size;
+        // xmin, ymin, xmax, ymax.
+        tmp_ptr[idx++] = (center_x - box_width / 2.) / image_width;
+        tmp_ptr[idx++] = (center_y - box_height / 2.) / image_height;
+        tmp_ptr[idx++] = (center_x + box_width / 2.) / image_width;
+        tmp_ptr[idx++] = (center_y + box_height / 2.) / image_height;
+
+        if (maxSize_.size() > 0) {
+          CHECK_EQ(minSize_.size(), maxSize_.size());
+          // second prior.
+          for (size_t s = 0; s < maxSize_.size(); s++) {
+            int max_size = maxSize_[s];
+            box_width = box_height = sqrt(min_size * max_size);
+            tmp_ptr[idx++] = (center_x - box_width / 2.) / image_width;
+            tmp_ptr[idx++] = (center_y - box_height / 2.) / image_height;
+            tmp_ptr[idx++] = (center_x + box_width / 2.) / image_width;
+            tmp_ptr[idx++] = (center_y + box_height / 2.) / image_height;
+          }
+        }
+      }
+      // rest of priors.
+      for (size_t r = 0; r < aspectRatio_.size(); r++) {
+        float ar = aspectRatio_[r];
+        if (fabs(ar - 1.) < 1e-6)
+          continue;
+        float box_width = min_size * sqrt(ar);
+        float box_height = min_size / sqrt(ar);
+        tmp_ptr[idx++] = (center_x - box_width / 2.) / image_width;
+        tmp_ptr[idx++] = (center_y - box_height / 2.) / image_height;
+        tmp_ptr[idx++] = (center_x + box_width / 2.) / image_width;
+        tmp_ptr[idx++] = (center_y + box_height / 2.) / image_height;
+      }
+    }
+  }
+  // clip the prior's coordidate such that it is within [0, 1]
+  for (int d = 0; d < dim; ++d)
+    tmp_ptr[d] = std::min(std::max(tmp_ptr[d], (float)0.), (float)1.);
+  // set the variance.
+  for (int h = 0; h < layer_height; h++)
+    for (int w = 0; w < layer_width; w++)
+      for (int i = 0; i < numPriors_; i++)
+        for (int j = 0; j < 4; j++)
+          tmp_ptr[idx++] = variance_[j];
+  MatrixPtr outV = getOutputValue();
+  outV->copyFrom(buffer_->data_, dim * 2);
+}
+REGISTER_LAYER(priorbox, PriorBoxLayer);
+
+}  // namespace paddle

--- a/paddle/gserver/layers/PriorBox.cpp
+++ b/paddle/gserver/layers/PriorBox.cpp
@@ -36,8 +36,8 @@ public:
   int numPriors_;
   std::vector<int> minSize_;
   std::vector<int> maxSize_;
-  std::vector<float> aspectRatio_;
-  std::vector<float> variance_;
+  std::vector<real> aspectRatio_;
+  std::vector<real> variance_;
   MatrixPtr buffer_;
 };
 
@@ -77,8 +77,8 @@ void PriorBoxLayer::forward(PassType passType) {
   int imageWidth = image.getFrameWidth();
   int imageHeight = image.getFrameHeight();
 
-  float stepW = static_cast<float>(imageWidth) / layerWidth;
-  float stepH = static_cast<float>(imageHeight) / layerHeight;
+  real stepW = static_cast<real>(imageWidth) / layerWidth;
+  real stepH = static_cast<real>(imageHeight) / layerHeight;
   int dim = layerHeight * layerWidth * numPriors_ * 4;
   reserveOutput(1, dim * 2);
   // use a cpu buffer to compute
@@ -88,8 +88,8 @@ void PriorBoxLayer::forward(PassType passType) {
   int idx = 0;
   for (int h = 0; h < layerHeight; ++h) {
     for (int w = 0; w < layerWidth; ++w) {
-      float centerX = (w + 0.5) * stepW;
-      float centerY = (h + 0.5) * stepH;
+      real centerX = (w + 0.5) * stepW;
+      real centerY = (h + 0.5) * stepH;
       int minSize = 0;
       for (size_t s = 0; s < minSize_.size(); s++) {
         // first prior.
@@ -121,10 +121,10 @@ void PriorBoxLayer::forward(PassType passType) {
       }
       // rest of priors.
       for (size_t r = 0; r < aspectRatio_.size(); r++) {
-        float ar = aspectRatio_[r];
+        real ar = aspectRatio_[r];
         if (fabs(ar - 1.) < 1e-6) continue;
-        float boxWidth = minSize * sqrt(ar);
-        float boxHeight = minSize / sqrt(ar);
+        real boxWidth = minSize * sqrt(ar);
+        real boxHeight = minSize / sqrt(ar);
         tmpPtr[idx++] = (centerX - boxWidth / 2.) / imageWidth;
         tmpPtr[idx++] = (centerY - boxHeight / 2.) / imageHeight;
         tmpPtr[idx++] = (centerX + boxWidth / 2.) / imageWidth;
@@ -137,7 +137,7 @@ void PriorBoxLayer::forward(PassType passType) {
   // clip the prior's coordidate such that it is within [0, 1]
   for (int d = 0; d < dim * 2; ++d)
     if ((d % 8) < 4)
-      tmpPtr[d] = std::min(std::max(tmpPtr[d], (float)0.), (float)1.);
+      tmpPtr[d] = std::min(std::max(tmpPtr[d], (real)0.), (real)1.);
   MatrixPtr outV = getOutputValue();
   outV->copyFrom(buffer_->data_, dim * 2);
 }

--- a/paddle/gserver/layers/PriorBox.cpp
+++ b/paddle/gserver/layers/PriorBox.cpp
@@ -18,10 +18,10 @@ limitations under the License. */
 
 namespace paddle {
 /**
- * @brief A layer for generate prior box locations and variances.
+ * @brief A layer for generating priorbox locations and variances.
  * - Input: Two and only two input layer are accepted. The input layer must be
  *        be a data output layer and a convolution output layer.
- * - Output: The prior box locations and variances of the input data.
+ * - Output: The priorbox locations and variances of the input data.
  * Reference:
  *    Wei Liu, Dragomir Anguelov, Dumitru Erhan, Christian Szegedy, Scott Reed,
  *    Cheng-Yang Fu, Alexander C. Berg. SSD: Single Shot MultiBox Detector
@@ -31,8 +31,11 @@ class PriorBoxLayer : public Layer {
 public:
   explicit PriorBoxLayer(const LayerConfig& config) : Layer(config) {}
   bool init(const LayerMap& layerMap, const ParameterMap& parameterMap);
+
   void forward(PassType passType);
   void backward(const UpdateCallback& callback) {}
+
+protected:
   int numPriors_;
   std::vector<int> minSize_;
   std::vector<int> maxSize_;

--- a/paddle/gserver/layers/PriorBox.cpp
+++ b/paddle/gserver/layers/PriorBox.cpp
@@ -76,6 +76,7 @@ void PriorBoxLayer::forward(PassType passType) {
   auto image = getInput(1);
   int imageWidth = image.getFrameWidth();
   int imageHeight = image.getFrameHeight();
+
   float stepW = static_cast<float>(imageWidth) / layerWidth;
   float stepH = static_cast<float>(imageHeight) / layerHeight;
   int dim = layerHeight * layerWidth * numPriors_ * 4;

--- a/paddle/gserver/tests/CMakeLists.txt
+++ b/paddle/gserver/tests/CMakeLists.txt
@@ -34,6 +34,14 @@ add_unittest_without_exec(test_ConvTrans
 
 add_test(NAME test_ConvTrans
     COMMAND test_ConvTrans)
+################# test_PriorBox #######################
+add_unittest_without_exec(test_PriorBox
+    test_PriorBox.cpp
+    LayerGradUtil.cpp
+    TestUtil.cpp)
+
+add_test(NAME test_PriorBox
+    COMMAND test_PriorBox)
 ################# test_ConvUnify #######################
 add_unittest_without_exec(test_ConvUnify
     test_ConvUnify.cpp

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -12,8 +12,14 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include <gtest/gtest.h>
 #include <string>
 #include <vector>
+#include "ModelConfig.pb.h"
+#include "paddle/gserver/layers/DataLayer.h"
+#include "paddle/math/MathUtils.h"
+#include "paddle/trainer/Trainer.h"
+#include "paddle/utils/GlobalConstants.h"
 
 #include "LayerGradUtil.h"
 #include "TestUtil.h"

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -30,8 +30,8 @@ void doOnePriorBoxTest(size_t feature_map_width,
                        size_t image_height,
                        vector<int> min_size,
                        vector<int> max_size,
-                       vector<float> aspect_ratio,
-                       vector<float> variance,
+                       vector<real> aspect_ratio,
+                       vector<real> variance,
                        bool use_gpu,
                        MatrixPtr& result) {
   // Setting up the priorbox layer
@@ -71,8 +71,8 @@ void doOnePriorBoxTest(size_t feature_map_width,
 TEST(Layer, priorBoxLayerFwd) {
   vector<int> minSize;
   vector<int> maxSize;
-  vector<float> aspectRatio;
-  vector<float> variance;
+  vector<real> aspectRatio;
+  vector<real> variance;
   bool useGpu = false;
 
   minSize.push_back(276);
@@ -84,22 +84,22 @@ TEST(Layer, priorBoxLayerFwd) {
 
   // CPU case 1.
   MatrixPtr result;
-  float resultData[] = {0.04,
-                        0.04,
-                        0.96,
-                        0.96,
-                        0.1,
-                        0.1,
-                        0.2,
-                        0.2,
-                        0,
-                        0,
-                        1,
-                        1,
-                        0.1,
-                        0.1,
-                        0.2,
-                        0.2};
+  real resultData[] = {0.04,
+                       0.04,
+                       0.96,
+                       0.96,
+                       0.1,
+                       0.1,
+                       0.2,
+                       0.2,
+                       0,
+                       0,
+                       1,
+                       1,
+                       0.1,
+                       0.1,
+                       0.2,
+                       0.2};
   result = Matrix::create(1, 2 * 8, false, useGpu);
   result->setData(resultData);
   doOnePriorBoxTest(/* feature_map_width */ 1,
@@ -116,10 +116,10 @@ TEST(Layer, priorBoxLayerFwd) {
   variance[1] = 0.2;
   variance[3] = 0.1;
   maxSize.pop_back();
-  float resultData2[] = {0,     0,     0.595, 0.595, 0.1, 0.2, 0.2, 0.1,
-                         0.405, 0,     1,     0.595, 0.1, 0.2, 0.2, 0.1,
-                         0,     0.405, 0.595, 1,     0.1, 0.2, 0.2, 0.1,
-                         0.405, 0.405, 1,     1,     0.1, 0.2, 0.2, 0.1};
+  real resultData2[] = {0,     0,     0.595, 0.595, 0.1, 0.2, 0.2, 0.1,
+                        0.405, 0,     1,     0.595, 0.1, 0.2, 0.2, 0.1,
+                        0,     0.405, 0.595, 1,     0.1, 0.2, 0.2, 0.1,
+                        0.405, 0.405, 1,     1,     0.1, 0.2, 0.2, 0.1};
   Matrix::resizeOrCreate(result, 1, 4 * 8, false, useGpu);
   result->setData(resultData2);
   doOnePriorBoxTest(/* feature_map_width */ 2,
@@ -134,10 +134,10 @@ TEST(Layer, priorBoxLayerFwd) {
                     result);
   // CPU case 3.
   aspectRatio.push_back(2);
-  float resultData3[] = {0.04,     0.04, 0.96, 0.96,       0.1,        0.2,
-                         0.2,      0.1,  0,    0.17473088, 1,          0.825269,
-                         0.1,      0.2,  0.2,  0.1,        0.17473088, 0,
-                         0.825269, 1,    0.1,  0.2,        0.2,        0.1};
+  real resultData3[] = {0.04,     0.04, 0.96, 0.96,       0.1,        0.2,
+                        0.2,      0.1,  0,    0.17473088, 1,          0.825269,
+                        0.1,      0.2,  0.2,  0.1,        0.17473088, 0,
+                        0.825269, 1,    0.1,  0.2,        0.2,        0.1};
   Matrix::resizeOrCreate(result, 1, 3 * 8, false, useGpu);
   result->setData(resultData3);
   doOnePriorBoxTest(/* feature_map_width */ 1,

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -24,14 +24,15 @@ using namespace std;     // NOLINT
 
 // Do one forward pass of priorBox layer and check to see if its output
 // matches the given result
-void doOnePriorBoxTest(size_t featureMapWidth,
-                       size_t featureMapHeight,
-                       size_t imageWidth,
-                       size_t imageHeight,
-                       vector<int> minSize,
-                       vector<int> maxSize,
-                       vector<float> aspectRatio,
+void doOnePriorBoxTest(size_t feature_map_width,
+                       size_t feature_map_height,
+                       size_t image_width,
+                       size_t image_height,
+                       vector<int> min_size,
+                       vector<int> max_size,
+                       vector<float> aspect_ratio,
                        vector<float> variance,
+                       bool use_gpu,
                        MatrixPtr& result) {
   // Setting up the priorbox layer
   TestConfig configt;
@@ -42,28 +43,27 @@ void doOnePriorBoxTest(size_t featureMapWidth,
   configt.inputDefs.push_back({INPUT_DATA, "image", 1, 0});
   configt.layerConfig.add_inputs();
   PriorBoxConfig* pb = input->mutable_priorbox_conf();
-  for (size_t i = 0; i < minSize.size(); i++) pb->add_min_size(minSize[i]);
-  for (size_t i = 0; i < maxSize.size(); i++) pb->add_max_size(maxSize[i]);
-  for (size_t i = 0; i < aspectRatio.size(); i++)
-    pb->add_aspect_ratio(aspectRatio[i]);
+  for (size_t i = 0; i < min_size.size(); i++) pb->add_min_size(min_size[i]);
+  for (size_t i = 0; i < max_size.size(); i++) pb->add_max_size(max_size[i]);
   for (size_t i = 0; i < variance.size(); i++) pb->add_variance(variance[i]);
+  for (size_t i = 0; i < aspect_ratio.size(); i++)
+    pb->add_aspect_ratio(aspect_ratio[i]);
 
   // data layer initialize
   std::vector<DataLayerPtr> dataLayers;
   LayerMap layerMap;
   vector<Argument> datas;
   initDataLayer(
-      configt, &dataLayers, &datas, &layerMap, "priorbox", 1, false, false);
-  dataLayers[0]->getOutput().setFrameHeight(featureMapHeight);
-  dataLayers[0]->getOutput().setFrameWidth(featureMapWidth);
-  dataLayers[1]->getOutput().setFrameHeight(imageHeight);
-  dataLayers[1]->getOutput().setFrameWidth(imageWidth);
+      configt, &dataLayers, &datas, &layerMap, "priorbox", 1, false, use_gpu);
+  dataLayers[0]->getOutput().setFrameHeight(feature_map_height);
+  dataLayers[0]->getOutput().setFrameWidth(feature_map_width);
+  dataLayers[1]->getOutput().setFrameHeight(image_height);
+  dataLayers[1]->getOutput().setFrameWidth(image_width);
 
   // test layer initialize
   std::vector<ParameterPtr> parameters;
   LayerPtr priorboxLayer;
   initTestLayer(configt, &layerMap, &parameters, &priorboxLayer);
-
   priorboxLayer->forward(PASS_GC);
   checkMatrixEqual(priorboxLayer->getOutputValue(), result);
 }
@@ -73,6 +73,7 @@ TEST(Layer, priorBoxLayerFwd) {
   vector<int> maxSize;
   vector<float> aspectRatio;
   vector<float> variance;
+  bool useGpu = false;
 
   minSize.push_back(276);
   maxSize.push_back(330);
@@ -81,9 +82,8 @@ TEST(Layer, priorBoxLayerFwd) {
   variance.push_back(0.2);
   variance.push_back(0.2);
 
+  // CPU case 1.
   MatrixPtr result;
-  result = Matrix::create(1, 2 * 8, false, false);
-
   float resultData[] = {0.04,
                         0.04,
                         0.96,
@@ -100,52 +100,109 @@ TEST(Layer, priorBoxLayerFwd) {
                         0.1,
                         0.2,
                         0.2};
+  result = Matrix::create(1, 2 * 8, false, useGpu);
   result->setData(resultData);
-  doOnePriorBoxTest(/* featureMapWidth */ 1,
-                    /* featureMapHeight */ 1,
-                    /* imageWidth */ 300,
-                    /* imageHeight */ 300,
+  doOnePriorBoxTest(/* feature_map_width */ 1,
+                    /* feature_map_height */ 1,
+                    /* image_width */ 300,
+                    /* image_height */ 300,
                     minSize,
                     maxSize,
                     aspectRatio,
                     variance,
+                    useGpu,
                     result);
-
+  // CPU case 2.
   variance[1] = 0.2;
   variance[3] = 0.1;
   maxSize.pop_back();
-  Matrix::resizeOrCreate(result, 1, 4 * 8, false, false);
   float resultData2[] = {0,     0,     0.595, 0.595, 0.1, 0.2, 0.2, 0.1,
                          0.405, 0,     1,     0.595, 0.1, 0.2, 0.2, 0.1,
                          0,     0.405, 0.595, 1,     0.1, 0.2, 0.2, 0.1,
                          0.405, 0.405, 1,     1,     0.1, 0.2, 0.2, 0.1};
+  Matrix::resizeOrCreate(result, 1, 4 * 8, false, useGpu);
   result->setData(resultData2);
-  doOnePriorBoxTest(/* featureMapWidth */ 2,
-                    /* featureMapHeight */ 2,
-                    /* imageWidth */ 400,
-                    /* imageHeight */ 400,
+  doOnePriorBoxTest(/* feature_map_width */ 2,
+                    /* feature_map_height */ 2,
+                    /* image_width */ 400,
+                    /* image_height */ 400,
                     minSize,
                     maxSize,
                     aspectRatio,
                     variance,
+                    useGpu,
                     result);
-
+  // CPU case 3.
   aspectRatio.push_back(2);
-  Matrix::resizeOrCreate(result, 1, 3 * 8, false, false);
   float resultData3[] = {0.04,     0.04, 0.96, 0.96,       0.1,        0.2,
                          0.2,      0.1,  0,    0.17473088, 1,          0.825269,
                          0.1,      0.2,  0.2,  0.1,        0.17473088, 0,
                          0.825269, 1,    0.1,  0.2,        0.2,        0.1};
+  Matrix::resizeOrCreate(result, 1, 3 * 8, false, useGpu);
   result->setData(resultData3);
-  doOnePriorBoxTest(/* featureMapWidth */ 1,
-                    /* featureMapHeight */ 1,
-                    /* imageWidth */ 300,
-                    /* imageHeight */ 300,
+  doOnePriorBoxTest(/* feature_map_width */ 1,
+                    /* feature_map_height */ 1,
+                    /* image_width */ 300,
+                    /* image_height */ 300,
                     minSize,
                     maxSize,
                     aspectRatio,
                     variance,
+                    useGpu,
                     result);
+
+#ifndef PADDLE_ONLY_CPU
+  // reset the input parameters
+  variance[1] = 0.1;
+  variance[3] = 0.2;
+  maxSize.push_back(330);
+  aspectRatio.pop_back();
+  MatrixPtr resultGpu;
+  useGpu = true;
+  // GPU case 1.
+  resultGpu = Matrix::create(1, 2 * 8, false, useGpu);
+  resultGpu->copyFrom(resultData, 2 * 8);
+  doOnePriorBoxTest(/* feature_map_width */ 1,
+                    /* feature_map_height */ 1,
+                    /* image_width */ 300,
+                    /* image_height */ 300,
+                    minSize,
+                    maxSize,
+                    aspectRatio,
+                    variance,
+                    useGpu,
+                    resultGpu);
+  // GPU case 2.
+  variance[1] = 0.2;
+  variance[3] = 0.1;
+  maxSize.pop_back();
+  Matrix::resizeOrCreate(resultGpu, 1, 4 * 8, false, useGpu);
+  resultGpu->copyFrom(resultData2, 4 * 8);
+  doOnePriorBoxTest(/* feature_map_width */ 2,
+                    /* feature_map_height */ 2,
+                    /* image_width */ 400,
+                    /* image_height */ 400,
+                    minSize,
+                    maxSize,
+                    aspectRatio,
+                    variance,
+                    useGpu,
+                    resultGpu);
+  // GPU case 3.
+  aspectRatio.push_back(2);
+  Matrix::resizeOrCreate(resultGpu, 1, 3 * 8, false, useGpu);
+  resultGpu->copyFrom(resultData3, 3 * 8);
+  doOnePriorBoxTest(/* feature_map_width */ 1,
+                    /* feature_map_height */ 1,
+                    /* image_width */ 300,
+                    /* image_height */ 300,
+                    minSize,
+                    maxSize,
+                    aspectRatio,
+                    variance,
+                    useGpu,
+                    resultGpu);
+#endif
 }
 
 int main(int argc, char** argv) {

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -15,8 +15,10 @@ limitations under the License. */
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
+#include "./paddle/utils/CommandLineParser.h"
 #include "ModelConfig.pb.h"
 #include "paddle/gserver/layers/DataLayer.h"
+#include "paddle/gserver/layers/ExpandConvTransLayer.h"
 #include "paddle/math/MathUtils.h"
 #include "paddle/trainer/Trainer.h"
 #include "paddle/utils/GlobalConstants.h"
@@ -29,7 +31,9 @@ using namespace std;     // NOLINT
 
 P_DECLARE_bool(use_gpu);
 P_DECLARE_int32(gpu_id);
+P_DECLARE_double(checkgrad_eps);
 P_DECLARE_bool(thread_local_rand_use_global_seed);
+P_DECLARE_bool(prev_batch_state);
 
 // Do one forward pass of priorBox layer and check to see if its output
 // matches the given result

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -53,7 +53,7 @@ void doOnePriorBoxTest(size_t featureMapWidth,
   LayerMap layerMap;
   vector<Argument> datas;
   initDataLayer(
-      configt, &dataLayers, &datas, &layerMap, "priorbox", 1, false, true);
+      configt, &dataLayers, &datas, &layerMap, "priorbox", 1, false, false);
   dataLayers[0]->getOutput().setFrameHeight(featureMapHeight);
   dataLayers[0]->getOutput().setFrameWidth(featureMapWidth);
   dataLayers[1]->getOutput().setFrameHeight(imageHeight);

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -1,0 +1,160 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <string>
+#include <vector>
+
+#include "LayerGradUtil.h"
+#include "TestUtil.h"
+
+using namespace paddle;  // NOLINT
+using namespace std;     // NOLINT
+
+P_DECLARE_bool(use_gpu);
+P_DECLARE_int32(gpu_id);
+P_DECLARE_bool(thread_local_rand_use_global_seed);
+
+// Do one forward pass of priorBox layer and check to see if its output
+// matches the given result
+void doOnePriorBoxTest(size_t featureMapWidth,
+                       size_t featureMapHeight,
+                       size_t imageWidth,
+                       size_t imageHeight,
+                       vector<int> minSize,
+                       vector<int> maxSize,
+                       vector<float> aspectRatio,
+                       vector<float> variance,
+                       MatrixPtr& result) {
+  // Setting up the priorbox layer
+  TestConfig configt;
+  configt.layerConfig.set_type("priorbox");
+
+  configt.inputDefs.push_back({INPUT_DATA, "featureMap", 1, 0});
+  LayerInputConfig* input = configt.layerConfig.add_inputs();
+  configt.inputDefs.push_back({INPUT_DATA, "image", 1, 0});
+  configt.layerConfig.add_inputs();
+  PriorBoxConfig* pb = input->mutable_priorbox_conf();
+  for (size_t i = 0; i < minSize.size(); i++) pb->add_min_size(minSize[i]);
+  for (size_t i = 0; i < maxSize.size(); i++) pb->add_max_size(maxSize[i]);
+  for (size_t i = 0; i < aspectRatio.size(); i++)
+    pb->add_aspect_ratio(aspectRatio[i]);
+  for (size_t i = 0; i < variance.size(); i++) pb->add_variance(variance[i]);
+
+  // data layer initialize
+  std::vector<DataLayerPtr> dataLayers;
+  LayerMap layerMap;
+  vector<Argument> datas;
+  initDataLayer(
+      configt, &dataLayers, &datas, &layerMap, "priorbox", 1, false, true);
+  dataLayers[0]->getOutput().setFrameHeight(featureMapHeight);
+  dataLayers[0]->getOutput().setFrameWidth(featureMapWidth);
+  dataLayers[1]->getOutput().setFrameHeight(imageHeight);
+  dataLayers[1]->getOutput().setFrameWidth(imageWidth);
+
+  // test layer initialize
+  std::vector<ParameterPtr> parameters;
+  LayerPtr priorboxLayer;
+  initTestLayer(configt, &layerMap, &parameters, &priorboxLayer);
+
+  priorboxLayer->forward(PASS_GC);
+  checkMatrixEqual(priorboxLayer->getOutputValue(), result);
+}
+
+TEST(Layer, priorBoxLayerFwd) {
+  vector<int> minSize;
+  vector<int> maxSize;
+  vector<float> aspectRatio;
+  vector<float> variance;
+
+  minSize.push_back(276);
+  maxSize.push_back(330);
+  variance.push_back(0.1);
+  variance.push_back(0.1);
+  variance.push_back(0.2);
+  variance.push_back(0.2);
+
+  MatrixPtr result;
+  result = Matrix::create(1, 2 * 8, false, false);
+
+  float resultData[] = {0.04,
+                        0.04,
+                        0.96,
+                        0.96,
+                        0.1,
+                        0.1,
+                        0.2,
+                        0.2,
+                        0,
+                        0,
+                        1,
+                        1,
+                        0.1,
+                        0.1,
+                        0.2,
+                        0.2};
+  result->setData(resultData);
+  doOnePriorBoxTest(/* featureMapWidth */ 1,
+                    /* featureMapHeight */ 1,
+                    /* imageWidth */ 300,
+                    /* imageHeight */ 300,
+                    minSize,
+                    maxSize,
+                    aspectRatio,
+                    variance,
+                    result);
+
+  variance[1] = 0.2;
+  variance[3] = 0.1;
+  maxSize.pop_back();
+  Matrix::resizeOrCreate(result, 1, 4 * 8, false, false);
+  float resultData2[] = {0,     0,     0.595, 0.595, 0.1, 0.2, 0.2, 0.1,
+                         0.405, 0,     1,     0.595, 0.1, 0.2, 0.2, 0.1,
+                         0,     0.405, 0.595, 1,     0.1, 0.2, 0.2, 0.1,
+                         0.405, 0.405, 1,     1,     0.1, 0.2, 0.2, 0.1};
+  result->setData(resultData2);
+  doOnePriorBoxTest(/* featureMapWidth */ 2,
+                    /* featureMapHeight */ 2,
+                    /* imageWidth */ 400,
+                    /* imageHeight */ 400,
+                    minSize,
+                    maxSize,
+                    aspectRatio,
+                    variance,
+                    result);
+
+  aspectRatio.push_back(2);
+  Matrix::resizeOrCreate(result, 1, 3 * 8, false, false);
+  float resultData3[] = {0.04,     0.04, 0.96, 0.96,       0.1,        0.2,
+                         0.2,      0.1,  0,    0.17473088, 1,          0.825269,
+                         0.1,      0.2,  0.2,  0.1,        0.17473088, 0,
+                         0.825269, 1,    0.1,  0.2,        0.2,        0.1};
+  result->setData(resultData3);
+  doOnePriorBoxTest(/* featureMapWidth */ 1,
+                    /* featureMapHeight */ 1,
+                    /* imageWidth */ 300,
+                    /* imageHeight */ 300,
+                    minSize,
+                    maxSize,
+                    aspectRatio,
+                    variance,
+                    result);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  initMain(argc, argv);
+  FLAGS_thread_local_rand_use_global_seed = true;
+  srand(1);
+  return RUN_ALL_TESTS();
+}

--- a/paddle/gserver/tests/test_PriorBox.cpp
+++ b/paddle/gserver/tests/test_PriorBox.cpp
@@ -15,25 +15,12 @@ limitations under the License. */
 #include <gtest/gtest.h>
 #include <string>
 #include <vector>
-#include "./paddle/utils/CommandLineParser.h"
-#include "ModelConfig.pb.h"
-#include "paddle/gserver/layers/DataLayer.h"
-#include "paddle/gserver/layers/ExpandConvTransLayer.h"
-#include "paddle/math/MathUtils.h"
-#include "paddle/trainer/Trainer.h"
-#include "paddle/utils/GlobalConstants.h"
 
 #include "LayerGradUtil.h"
 #include "TestUtil.h"
 
 using namespace paddle;  // NOLINT
 using namespace std;     // NOLINT
-
-P_DECLARE_bool(use_gpu);
-P_DECLARE_int32(gpu_id);
-P_DECLARE_double(checkgrad_eps);
-P_DECLARE_bool(thread_local_rand_use_global_seed);
-P_DECLARE_bool(prev_batch_state);
 
 // Do one forward pass of priorBox layer and check to see if its output
 // matches the given result
@@ -164,7 +151,5 @@ TEST(Layer, priorBoxLayerFwd) {
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   initMain(argc, argv);
-  FLAGS_thread_local_rand_use_global_seed = true;
-  srand(1);
   return RUN_ALL_TESTS();
 }

--- a/proto/ModelConfig.proto
+++ b/proto/ModelConfig.proto
@@ -248,6 +248,15 @@ message ImageConfig {
   required uint32 img_size_y = 9;
 }
 
+message PriorBoxConfig {
+  repeated uint32 min_size = 1;
+  repeated uint32 max_size = 2;
+  repeated float aspect_ratio = 3;
+  repeated float variance = 4;
+  optional bool flip = 5 [default = true];
+  optional bool clip = 6 [default = true];
+}
+
 message LayerInputConfig {
   required string input_layer_name = 1;
   optional string input_parameter_name = 2;
@@ -263,6 +272,7 @@ message LayerInputConfig {
   optional BilinearInterpConfig bilinear_interp_conf = 10;
   optional MaxOutConfig maxout_conf = 11;
   optional SppConfig spp_conf = 12;
+  optional PriorBoxConfig priorbox_conf = 13;
 }
 
 message LayerConfig {

--- a/proto/ModelConfig.proto
+++ b/proto/ModelConfig.proto
@@ -253,8 +253,6 @@ message PriorBoxConfig {
   repeated uint32 max_size = 2;
   repeated float aspect_ratio = 3;
   repeated float variance = 4;
-  optional bool flip = 5 [default = true];
-  optional bool clip = 6 [default = true];
 }
 
 message LayerInputConfig {

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1577,6 +1577,19 @@ class PrintLayer(LayerBase):
     def __init__(self, name, inputs):
         super(PrintLayer, self).__init__(name, 'print', 0, inputs)
 
+@config_layer('priorbox')
+class PriorBoxLayer(LayerBase):
+    def __init__(self, name, inputs, size, min_size, max_size, aspect_ratio, variance):
+        super(PriorBoxLayer, self).__init__(name, 'priorbox', 0, inputs)
+        config_assert(len(inputs) == 2, 'PriorBoxLayer must have 2 input')
+        self.config.inputs[0].priorbox_conf.min_size.extend(min_size)
+        self.config.inputs[0].priorbox_conf.max_size.extend(max_size)
+        self.config.inputs[0].priorbox_conf.aspect_ratio.extend(aspect_ratio)
+        self.config.inputs[0].priorbox_conf.variance.extend(variance)
+        self.config.size = size
+        input_layer0 = self.get_input_layer(0)
+        input_layer1 = self.get_input_layer(1)
+
 
 @config_layer('data')
 class DataLayer(LayerBase):

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1583,7 +1583,7 @@ class PriorBoxLayer(LayerBase):
     def __init__(self, name, inputs, size, min_size, max_size, aspect_ratio,
                  variance):
         super(PriorBoxLayer, self).__init__(name, 'priorbox', 0, inputs)
-        config_assert(len(inputs) == 2, 'PriorBoxLayer must have 2 input')
+        config_assert(len(inputs) == 2, 'PriorBoxLayer must have 2 inputs')
         input_layer = self.get_input_layer(1)
         config_assert(
             input_layer.type == 'data',
@@ -1591,6 +1591,7 @@ class PriorBoxLayer(LayerBase):
             'a data layer')
         config_assert(input_layer.width > 0, 'The data layer must set width')
         config_assert(input_layer.height > 0, 'The data layer must set height')
+        config_assert(len(variance) == 4, 'The variance must have 4 inputs')
         self.config.inputs[0].priorbox_conf.min_size.extend(min_size)
         self.config.inputs[0].priorbox_conf.max_size.extend(max_size)
         self.config.inputs[0].priorbox_conf.aspect_ratio.extend(aspect_ratio)

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1589,8 +1589,6 @@ class PriorBoxLayer(LayerBase):
         self.config.inputs[0].priorbox_conf.aspect_ratio.extend(aspect_ratio)
         self.config.inputs[0].priorbox_conf.variance.extend(variance)
         self.config.size = size
-        input_layer0 = self.get_input_layer(0)
-        input_layer1 = self.get_input_layer(1)
 
 
 @config_layer('data')

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1584,6 +1584,13 @@ class PriorBoxLayer(LayerBase):
                  variance):
         super(PriorBoxLayer, self).__init__(name, 'priorbox', 0, inputs)
         config_assert(len(inputs) == 2, 'PriorBoxLayer must have 2 input')
+        input_layer = self.get_input_layer(1)
+        config_assert(
+            input_layer.type == 'data',
+            'Expecting the second input layer of an priorbox layer to be '
+            'a data layer')
+        config_assert(input_layer.width > 0, 'The data layer must set width')
+        config_assert(input_layer.height > 0, 'The data layer must set height')
         self.config.inputs[0].priorbox_conf.min_size.extend(min_size)
         self.config.inputs[0].priorbox_conf.max_size.extend(max_size)
         self.config.inputs[0].priorbox_conf.aspect_ratio.extend(aspect_ratio)

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1577,9 +1577,11 @@ class PrintLayer(LayerBase):
     def __init__(self, name, inputs):
         super(PrintLayer, self).__init__(name, 'print', 0, inputs)
 
+
 @config_layer('priorbox')
 class PriorBoxLayer(LayerBase):
-    def __init__(self, name, inputs, size, min_size, max_size, aspect_ratio, variance):
+    def __init__(self, name, inputs, size, min_size, max_size, aspect_ratio,
+                 variance):
         super(PriorBoxLayer, self).__init__(name, 'priorbox', 0, inputs)
         config_assert(len(inputs) == 2, 'PriorBoxLayer must have 2 input')
         self.config.inputs[0].priorbox_conf.min_size.extend(min_size)

--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -106,6 +106,7 @@ __all__ = [
     'maxout_layer',
     'out_prod_layer',
     'print_layer',
+    'priorbox_layer',
     'spp_layer',
 ]
 
@@ -171,6 +172,7 @@ class LayerType(object):
     SPP_LAYER = "spp"
 
     PRINT_LAYER = "print"
+    PRIORBOX_LAYER = "priorbox"
 
     CTC_LAYER = "ctc"
     WARP_CTC_LAYER = "warp_ctc"
@@ -933,6 +935,40 @@ def print_layer(input, name=None):
         inputs=[l.name for l in input], )
     # this layer don't return anything, can not be input of other layer.
 
+@wrap_name_default("priorbox")
+def priorbox_layer(input, img_shape, aspect_ratio, variance, min_size, max_size=[], name=None):
+    """
+    Compute the priorbox and set the variance. This layer is necessary for ssd.
+
+    :param name: The Layer Name.
+    :type name: basestring
+    :param input: The input layer.
+    :type input: LayerOutput
+    :param img_shape: The width and height of the network input image.
+    :type img_shape: LayerOutput
+    :param aspect_ratio: The aspect ratio.
+    :type aspect_ratio: list
+    :param variance: The bounding box variance.
+    :type min_size: The min size of the priorbox width/height.
+    :param min_size: list
+    :type max_size: The max size of the priorbox width/height. Could be NULL.
+    :param max_size: list
+    :return: LayerOutput
+    """
+    # plus one for ratio 1.
+    num_filters = (len(aspect_ratio) * 2 + 1 + len(max_size)) * 4
+    size=(input.size / input.num_filters) * num_filters * 2
+    Layer(
+        name=name,
+        type=LayerType.PRIORBOX_LAYER,
+        inputs=[input.name, img_shape.name],
+        size=size,
+        min_size=min_size,
+        max_size=max_size,
+        aspect_ratio=aspect_ratio,
+        variance=variance)
+    return LayerOutput(
+        name, LayerType.PRIORBOX_LAYER, parents=[input, img_shape], num_filters=num_filters, size=size)
 
 @wrap_name_default("seq_pooling")
 @wrap_bias_attr_default(has_bias=False)

--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -935,8 +935,15 @@ def print_layer(input, name=None):
         inputs=[l.name for l in input], )
     # this layer don't return anything, can not be input of other layer.
 
+
 @wrap_name_default("priorbox")
-def priorbox_layer(input, img_shape, aspect_ratio, variance, min_size, max_size=[], name=None):
+def priorbox_layer(input,
+                   img_shape,
+                   aspect_ratio,
+                   variance,
+                   min_size,
+                   max_size=[],
+                   name=None):
     """
     Compute the priorbox and set the variance. This layer is necessary for ssd.
 
@@ -957,7 +964,7 @@ def priorbox_layer(input, img_shape, aspect_ratio, variance, min_size, max_size=
     """
     # plus one for ratio 1.
     num_filters = (len(aspect_ratio) * 2 + 1 + len(max_size)) * 4
-    size=(input.size / input.num_filters) * num_filters * 2
+    size = (input.size / input.num_filters) * num_filters * 2
     Layer(
         name=name,
         type=LayerType.PRIORBOX_LAYER,
@@ -968,7 +975,12 @@ def priorbox_layer(input, img_shape, aspect_ratio, variance, min_size, max_size=
         aspect_ratio=aspect_ratio,
         variance=variance)
     return LayerOutput(
-        name, LayerType.PRIORBOX_LAYER, parents=[input, img_shape], num_filters=num_filters, size=size)
+        name,
+        LayerType.PRIORBOX_LAYER,
+        parents=[input, img_shape],
+        num_filters=num_filters,
+        size=size)
+
 
 @wrap_name_default("seq_pooling")
 @wrap_bias_attr_default(has_bias=False)

--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -938,7 +938,7 @@ def print_layer(input, name=None):
 
 @wrap_name_default("priorbox")
 def priorbox_layer(input,
-                   img_shape,
+                   image,
                    aspect_ratio,
                    variance,
                    min_size,
@@ -951,8 +951,8 @@ def priorbox_layer(input,
     :type name: basestring
     :param input: The input layer.
     :type input: LayerOutput
-    :param img_shape: The width and height of the network input image.
-    :type img_shape: LayerOutput
+    :param image: The network input image.
+    :type image: LayerOutput
     :param aspect_ratio: The aspect ratio.
     :type aspect_ratio: list
     :param variance: The bounding box variance.
@@ -968,7 +968,7 @@ def priorbox_layer(input,
     Layer(
         name=name,
         type=LayerType.PRIORBOX_LAYER,
-        inputs=[input.name, img_shape.name],
+        inputs=[input.name, image.name],
         size=size,
         min_size=min_size,
         max_size=max_size,
@@ -977,7 +977,7 @@ def priorbox_layer(input,
     return LayerOutput(
         name,
         LayerType.PRIORBOX_LAYER,
-        parents=[input, img_shape],
+        parents=[input, image],
         num_filters=num_filters,
         size=size)
 


### PR DESCRIPTION
The priorbox layer for Single Shot Multibox Detection Network. This layer doesn't need the backward propagation and the layer's result is independent of the value of the input image but the shape.  The layer's result has been verified by the Caffe's implementation. 