### PR TITLE
fixed a bug for demo/gan caused by batchNormLayer

### DIFF
--- a/demo/gan/gan_conf_image.py
+++ b/demo/gan/gan_conf_image.py
@@ -87,9 +87,9 @@ def conv_bn(input,
     print(imgSize, output_x, stride, filter_size, padding)
 
     if trans:
-        nameApx = "_conv"
-    else:
         nameApx = "_convt"
+    else:
+        nameApx = "_conv"
 
     if bn:
         conv = img_conv_layer(

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1871,8 +1871,14 @@ class BatchNormLayer(LayerBase):
         input_layer = self.get_input_layer(0)
         image_conf = self.config.inputs[0].image_conf
         parse_image(self.inputs[0].image, input_layer.name, image_conf)
-        self.set_cnn_layer(name, image_conf.img_size_y, image_conf.img_size,
-                           image_conf.channels, False)
+
+        # Only pass the width and height of input to batch_norm layer 
+        # when either of it is non-zero. 
+        if input_layer.width != 0 or input_layer.height != 0:
+            self.set_cnn_layer(name, image_conf.img_size_y, image_conf.img_size,
+                               image_conf.channels, True)
+        else:
+            self.set_layer_size(input_layer.size)
 
         psize = self.calc_parameter_size(image_conf)
         dims = [1, psize]

--- a/python/paddle/trainer_config_helpers/tests/configs/protostr/img_trans_layers.protostr
+++ b/python/paddle/trainer_config_helpers/tests/configs/protostr/img_trans_layers.protostr
@@ -58,8 +58,6 @@ layers {
   }
   bias_parameter_name: "___batch_norm_0__.wbias"
   moving_average_fraction: 0.9
-  height: 256
-  width: 256
 }
 layers {
   name: "__crmnorm_0__"


### PR DESCRIPTION
In response to issue #870 I have modified the BatchNormLayer in config_parser.py so that it will not set LayerConfig.width and LayerConfig.height if the input.width and input.height are both zero.