### PR TITLE
Remove do_average_in_cpu, max_average_window, average_window from optimizers.py

### DIFF
--- a/python/paddle/trainer_config_helpers/optimizers.py
+++ b/python/paddle/trainer_config_helpers/optimizers.py
@@ -361,9 +361,6 @@ def settings(batch_size,
              learning_rate_decay_b=0.,
              learning_rate_schedule='poly',
              learning_rate_args='',
-             average_window=0,
-             do_average_in_cpu=False,
-             max_average_window=None,
              learning_method=None,
              regularization=None,
              is_async=False,
@@ -412,7 +409,6 @@ def settings(batch_size,
     args = [
         'batch_size', 'learning_rate', 'learning_rate_decay_a',
         'learning_rate_decay_b', 'learning_rate_schedule', 'learning_rate_args',
-        'average_window', 'do_average_in_cpu', 'max_average_window'
     ]
     kwargs = dict()
     kwargs['algorithm'] = algorithm

--- a/python/paddle/trainer_config_helpers/optimizers.py
+++ b/python/paddle/trainer_config_helpers/optimizers.py
@@ -408,7 +408,7 @@ def settings(batch_size,
 
     args = [
         'batch_size', 'learning_rate', 'learning_rate_decay_a',
-        'learning_rate_decay_b', 'learning_rate_schedule', 'learning_rate_args',
+        'learning_rate_decay_b', 'learning_rate_schedule', 'learning_rate_args'
     ]
     kwargs = dict()
     kwargs['algorithm'] = algorithm


### PR DESCRIPTION
These three parameters have already been moved to model_average. Leaving them here will cause duplicate keys in kwargs.