### PR TITLE
Add the automatic update of submodules in cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ find_package(Git REQUIRED)
 # version.cmake will get the current PADDLE_VERSION
 include(version)
 add_definitions(-DPADDLE_VERSION=${PADDLE_VERSION})
+include(submodules)
 
 if(NOT WITH_GPU)
     add_definitions(-DPADDLE_ONLY_CPU)

--- a/cmake/submodules.cmake
+++ b/cmake/submodules.cmake
@@ -1,0 +1,28 @@
+# Automatically init submodules
+if(EXISTS ${PROJECT_SOURCE_DIR}/.gitmodules)
+  # warp-ctc
+  function(FindWarpCTC)
+    set(WARPCTC_ROOT $ENV{WARPCTC_ROOT} CACHE PATH "Folder contains warp-ctc")
+    find_path(WARPCTC_INCLUDE_DIR ctc.h PATHS
+      ${WARPCTC_ROOT}/include ${PROJECT_SOURCE_DIR}/warp-ctc/include)
+  endfunction(FindWarpCTC)
+
+  FindWarpCTC()
+  if(NOT WARPCTC_INCLUDE_DIR)
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} submodule update --init -- warp-ctc
+      WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_OUTPUT
+      RESULT_VARIABLE GIT_RESULT)
+    message(STATUS ${GIT_OUTPUT})
+    FindWarpCTC()
+  endif()
+
+  if(NOT WARPCTC_INCLUDE_DIR)
+    message(FATAL_ERROR "warp-ctc must be set."
+        "Try set WARPCTC_ROOT or run command git submodule --init -- warp-ctc.")
+  else()
+    message(STATUS "Found warp-ctc (include: ${WARPCTC_INCLUDE_DIR})")
+  endif()
+  include_directories(${WARPCTC_INCLUDE_DIR})
+endif()

--- a/paddle/cuda/include/hl_warpctc_wrap.h
+++ b/paddle/cuda/include/hl_warpctc_wrap.h
@@ -16,7 +16,7 @@ limitations under the License. */
 #define HL_WARPCTC_WRAP_H_
 
 #include "hl_base.h"
-#include "warp-ctc/include/ctc.h"
+#include "ctc.h"
 
 typedef ctcStatus_t hl_warpctc_status_t;
 typedef ctcOptions hl_warpctc_options_t;

--- a/paddle/cuda/include/hl_warpctc_wrap.h
+++ b/paddle/cuda/include/hl_warpctc_wrap.h
@@ -15,8 +15,8 @@ limitations under the License. */
 #ifndef HL_WARPCTC_WRAP_H_
 #define HL_WARPCTC_WRAP_H_
 
-#include "hl_base.h"
 #include "ctc.h"
+#include "hl_base.h"
 
 typedef ctcStatus_t hl_warpctc_status_t;
 typedef ctcOptions hl_warpctc_options_t;


### PR DESCRIPTION
增加了submodules.cmake，其中可以：
1. cmake时通过`-DWARPCTC_ROOT=...`设置warpctc头文件ctc.h的路径
2. 在`WARPCTC_ROOT/include`和`${PROJECT_SOURCE_DIR}/warp-ctc/include`目录下都没有找到头文件'ctc.h'时，执行命令`git submodule update --init -- warp-ctc`，自动下载submodule。

目前这个功能只能自动下载warp-ctc，看看这个功能是否需要吧。