### PR TITLE
Add excluded_chunk_types to ChunkEvaluator

### DIFF
--- a/paddle/gserver/evaluators/ChunkEvaluator.cpp
+++ b/paddle/gserver/evaluators/ChunkEvaluator.cpp
@@ -162,9 +162,9 @@ public:
     getSegments(label, length, labelSegments_);
     size_t i = 0, j = 0;
     while (i < outputSegments_.size() && j < labelSegments_.size()) {
-      if (outputSegments_[i] == labelSegments_[j]) {
-        if (excludedChunkTypes_.count(outputSegments_[i].type) != 1)
-          ++numCorrect_;
+      if (outputSegments_[i] == labelSegments_[j] &&
+          excludedChunkTypes_.count(outputSegments_[i].type) != 1) {
+        ++numCorrect_;
       }
       if (outputSegments_[i].end < labelSegments_[j].end) {
         ++i;

--- a/proto/ModelConfig.proto
+++ b/proto/ModelConfig.proto
@@ -433,8 +433,12 @@ message EvaluatorConfig {
   repeated string input_layers = 3;
 
   // Used by ChunkEvaluator
-  optional string chunk_scheme = 4; // one of "IOB", "IOE", "IOBES"
-  optional int32 num_chunk_types = 5; // number of chunk types other than "other"
+  // one of "IOB", "IOE", "IOBES"
+  optional string chunk_scheme = 4;
+  // number of chunk types other than "other"
+  optional int32 num_chunk_types = 5;
+  // chunk of these types are not counted
+  repeated int32 excluded_chunk_types = 12;
 
   // Used by PrecisionRecallEvaluator and ClassificationErrorEvaluator
   // For multi binary labels: true if output > classification_threshold
@@ -453,6 +457,8 @@ message EvaluatorConfig {
 
   // whether to delimit the sequence in the seq_text_printer
   optional bool delimited = 11 [default = true];
+
+  // NOTE: 12 has been occupied by excluded_chunk_types
 }
 
 message LinkConfig {

--- a/proto/ModelConfig.proto
+++ b/proto/ModelConfig.proto
@@ -437,8 +437,6 @@ message EvaluatorConfig {
   optional string chunk_scheme = 4;
   // number of chunk types other than "other"
   optional int32 num_chunk_types = 5;
-  // chunk of these types are not counted
-  repeated int32 excluded_chunk_types = 12;
 
   // Used by PrecisionRecallEvaluator and ClassificationErrorEvaluator
   // For multi binary labels: true if output > classification_threshold
@@ -458,7 +456,9 @@ message EvaluatorConfig {
   // whether to delimit the sequence in the seq_text_printer
   optional bool delimited = 11 [default = true];
 
-  // NOTE: 12 has been occupied by excluded_chunk_types
+  // Used by ChunkEvaluator
+  // chunk of these types are not counted
+  repeated int32 excluded_chunk_types = 12;
 }
 
 message LinkConfig {

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -1240,7 +1240,8 @@ def Evaluator(
         dict_file=None,
         result_file=None,
         num_results=None,
-        delimited=None, ):
+        delimited=None,
+        excluded_chunk_types=None, ):
     evaluator = g_config.model_config.evaluators.add()
     evaluator.type = type
     evaluator.name = MakeLayerNameInSubmodel(name)
@@ -1268,6 +1269,9 @@ def Evaluator(
         evaluator.num_results = num_results
     if delimited is not None:
         evaluator.delimited = delimited
+
+    if excluded_chunk_types:
+        evaluator.excluded_chunk_types.extend(excluded_chunk_types)
 
 
 class LayerBase(object):

--- a/python/paddle/trainer_config_helpers/evaluators.py
+++ b/python/paddle/trainer_config_helpers/evaluators.py
@@ -57,19 +57,21 @@ def evaluator(*attrs):
     return impl
 
 
-def evaluator_base(input,
-                   type,
-                   label=None,
-                   weight=None,
-                   name=None,
-                   chunk_scheme=None,
-                   num_chunk_types=None,
-                   classification_threshold=None,
-                   positive_label=None,
-                   dict_file=None,
-                   result_file=None,
-                   num_results=None,
-                   delimited=None):
+def evaluator_base(
+        input,
+        type,
+        label=None,
+        weight=None,
+        name=None,
+        chunk_scheme=None,
+        num_chunk_types=None,
+        classification_threshold=None,
+        positive_label=None,
+        dict_file=None,
+        result_file=None,
+        num_results=None,
+        delimited=None,
+        excluded_chunk_types=None, ):
     """
     Evaluator will evaluate the network status while training/testing.
 
@@ -127,7 +129,8 @@ def evaluator_base(input,
         positive_label=positive_label,
         dict_file=dict_file,
         result_file=result_file,
-        delimited=delimited)
+        delimited=delimited,
+        excluded_chunk_types=excluded_chunk_types, )
 
 
 @evaluator(EvaluatorAttribute.FOR_CLASSIFICATION)
@@ -330,7 +333,8 @@ def chunk_evaluator(
         label,
         chunk_scheme,
         num_chunk_types,
-        name=None, ):
+        name=None,
+        excluded_chunk_types=None, ):
     """
     Chunk evaluator is used to evaluate segment labelling accuracy for a
     sequence. It calculates the chunk detection F1 score.
@@ -376,6 +380,8 @@ def chunk_evaluator(
     :param num_chunk_types: number of chunk types other than "other"
     :param name: The Evaluator name, it is optional.
     :type name: basename|None
+    :param excluded_chunk_types: chunks of these types are not considered
+    :type excluded_chunk_types: list of integer|[]
     """
     evaluator_base(
         name=name,
@@ -383,7 +389,8 @@ def chunk_evaluator(
         input=input,
         label=label,
         chunk_scheme=chunk_scheme,
-        num_chunk_types=num_chunk_types)
+        num_chunk_types=num_chunk_types,
+        excluded_chunk_types=excluded_chunk_types, )
 
 
 @evaluator(EvaluatorAttribute.FOR_UTILS)

--- a/python/paddle/trainer_config_helpers/evaluators.py
+++ b/python/paddle/trainer_config_helpers/evaluators.py
@@ -381,7 +381,7 @@ def chunk_evaluator(
     :param name: The Evaluator name, it is optional.
     :type name: basename|None
     :param excluded_chunk_types: chunks of these types are not considered
-    :type excluded_chunk_types: list of integer|[]
+    :type excluded_chunk_types: list of integer|None
     """
     evaluator_base(
         name=name,


### PR DESCRIPTION
The chunks of types in excluded_chunk_types will not be counted in
ChunkEvaluator. This is useful for tasks such as SRL, in which chunks of
type V (verb) will not be taken into account in evaluation.