### PR TITLE
[In Progress] Fix bug: enable sparse weigth setting in trainer_config_helper APIs

### DIFF
--- a/python/paddle/trainer_config_helpers/attrs.py
+++ b/python/paddle/trainer_config_helpers/attrs.py
@@ -19,34 +19,34 @@ __all__ = [
 
 
 def convert_and_compare(x, Type):
-    """                                                                                                                                                                                                
-    Convert x to be the same type as Type and then convert back to                                                                                                                                      
-    check whether there is a loss of information                                                                                                                                                        
-    :param x: object to be checked                                                                                                                                                                      
-    :param Type: target type to check x over                                                                                                                                                           
-    
+    """
+    Convert x to be the same type as Type and then convert back to
+    check whether there is a loss of information
+    :param x: object to be checked
+    :param Type: target type to check x over
+
     """
     return type(x)(Type(x)) == x
 
 
 def is_compatible_with(x, Type):
-    """                                                                                                                                                                                                
-    Check if x has a type compatible with Type                                                                                                                                                         
-    :param x: object to be checked                                                                                                                                                                     
-    :param Type: target type to check x over                                                                                                                                                           
-    
+    """
+    Check if x has a type compatible with Type
+    :param x: object to be checked
+    :param Type: target type to check x over
+
     """
     if type(x) == Type:
         return True
     try:
         if float == Type or int == Type:
-            # avoid those types that can be converted to float/int but not very                                                                                                                            
-            # meaningful and  could potentially lead to error                                                                                                                                              
-            # i.e., str and bool typed value should not be used for initializing float/int variable                                                                                                        
+            # avoid those types that can be converted to float/int but not very
+            # meaningful and  could potentially lead to error
+            # i.e., str and bool typed value should not be used for initializing float/int variable
             if not isinstance(x, str) and not isinstance(x, bool):
                 return convert_and_compare(x, Type)
         elif bool == Type:
-            # should not use string type to initialize bool variable                                                                                                                                   
+            # should not use string type to initialize bool variable
             if not isinstance(x, str):
                 return convert_and_compare(x, Type)
         else:
@@ -91,6 +91,9 @@ class ParameterAttribute(object):
     :param sparse_update: Enable sparse update for this parameter. It will
                           enable both local and remote sparse update.
     :type sparse_update: bool
+    :param sparse_weight: enable weight sparse. The parameter value will be
+                          stored as sparse format.
+    :type sparse_weight: bool
     """
 
     def __init__(self,
@@ -104,7 +107,8 @@ class ParameterAttribute(object):
                  l2_rate=None,
                  learning_rate=None,
                  momentum=None,
-                 sparse_update=False):
+                 sparse_update=False,
+                 sparse_weight=False):
         # initialize strategy.
         if is_static:
             self.attr = {'is_static': True}
@@ -151,6 +155,10 @@ class ParameterAttribute(object):
         if sparse_update:
             self.attr['sparse_update'] = True
             self.attr['sparse_remote_update'] = True
+
+        if sparse_weight:
+            self.attr['format'] = 'csr'
+            self.attr['nnz'] = 4
 
     def set_default_parameter_name(self, name):
         """


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/948 

为什么开这个pr： 
* 主要目标是通过这个pr和issue梳理清楚sparse相关问题，并记录文档方便其他开发者和用户追踪
* 同时， 尝试fix 一些sparse weight的BUG（区别于sparse update的稀疏策略）： 


BUG相关： 
* 新接口暂时不支持设置sparse weight训练。 

完善新接口对sparse支持，需要进一步分析的问题： 

   * 确定nnz 默认值如何设置比价合理，依据是什么？
   
```
+Layer(
+    name = "layer1_5",
+    type = "fc",
+    size = 3,
+    active_type = "tanh",
+    inputs = Input("input",
+              learning_rate=0.01,
+              momentum=0.9,
+              decay_rate=0.05,
+              initial_mean=0.0,
+              initial_std=0.01,
+              format = "csc",
+              nnz = 4)
+)

``` 
从icode 老版本git 历史： commit af92dcde6afc4454354089e47870c7ef38dfeda3 看，上述nnz=4的配置得来？ 

  * 是否可以默认使用csr稀疏格式。 从理论上parameter weight的稀疏存储是一种内部格式，跟数据源无任何关系，因此不建议将老接口中的format参数，导出到用户。 （csr和csc格式在计算上应该没有什么性能差异？ @reyoung  可以comment这个观点）

  * 老接口中，只有FCLayer和SelectiveFCLayer支持sparse weight的配置，其他layer均不支持。 因此， 是否需要将这个参数作为general的parameter attribute存在？ 是否要将它实现到layer的特殊属性？ （新接口设计初衷之一，也是为了简化用户理解的接口，所以我们应该尽量遵循这个准则来设计接口）


除了fix 接口问题之外，还有一些疑问：  

* 理论上， parameter weight 设置成sparse的特性后， 一般并不能进一步优化训练阶段的forward和backward计算耗时。 因为一般data是sparse的配置后，forward应该已经是sparse计算了的了（backward是否尚需确认？）， 另外再加上sparse update和sparse remote update使能后，再单独设置parameter weight的sparse 应该没有什么性能提升？ 



* 如果parameter weight 设置成sparse的特性，是为了生成稀疏的模型用户预测，那么实际上应该可以通过仅仅在save model阶段进行稀疏存储即可，无需在训练计算阶段进行这种稀疏化处理？ 


因此它存在的价值是什么？  