### PR TITLE
Change float to real in NormLayer.h

### DIFF
--- a/paddle/gserver/layers/NormLayer.h
+++ b/paddle/gserver/layers/NormLayer.h
@@ -50,7 +50,7 @@ public:
 class ResponseNormLayer : public NormLayer {
 protected:
   size_t channels_, size_, outputX_, imgSize_, outputY_, imgSizeY_;
-  float scale_, pow_;
+  real scale_, pow_;
   MatrixPtr denoms_;
 
 public:


### PR DESCRIPTION
float in ResponseNormLayer causes compile error when WITH_DOUBLE=true. As forward() and backward() in ResponseNormLayer is not implemented, I think the change is safe.