### PR TITLE
add python version evaluate function

### DIFF
--- a/demo/recommendation/evaluate.py
+++ b/demo/recommendation/evaluate.py
@@ -28,10 +28,10 @@ def get_best_pass(filename):
 
 
 filename = sys.argv[1]
-LOG = get_best_pass(filename)
-predict_error = math.sqrt(float(LOG[0])) / 2
+log = get_best_pass(filename)
+predict_error = math.sqrt(float(log[0])) / 2
 print 'Best pass is %s, error is %s, which means predict get error as %f' % (
-    LOG[1], LOG[0], predict_error)
+    log[1], log[0], predict_error)
 
-evaluate_pass = "output/pass-%s" % LOG[1]
+evaluate_pass = "output/pass-%s" % log[1]
 print "evaluating from pass %s" % evaluate_pass

--- a/demo/recommendation/evaluate.py
+++ b/demo/recommendation/evaluate.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python
+# Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import sys
+import re
+import math
+
+
+def get_best_pass(filename):
+    with open(filename, 'r') as f:
+        text = f.read()
+        pattern = re.compile('Test.*? cost=([0-9]+\.[0-9]+).*?pass-([0-9]+)',
+                             re.S)
+        results = re.findall(pattern, text)
+        sorted_results = sorted(results, key=lambda result: float(result[0]))
+        return sorted_results[0]
+
+
+filename = sys.argv[1]
+LOG = get_best_pass(filename)
+predict_error = math.sqrt(float(LOG[0])) / 2
+print 'Best pass is %s, error is %s, which means predict get error as %f' % (
+    LOG[1], LOG[0], predict_error)
+
+evaluate_pass = "output/pass-%s" % LOG[1]
+print "evaluating from pass %s" % evaluate_pass

--- a/demo/recommendation/evaluate.py
+++ b/demo/recommendation/evaluate.py
@@ -17,8 +17,8 @@ import re
 import math
 
 
-def get_best_pass(filename):
-    with open(filename, 'r') as f:
+def get_best_pass(log_filename):
+    with open(log_filename, 'r') as f:
         text = f.read()
         pattern = re.compile('Test.*? cost=([0-9]+\.[0-9]+).*?pass-([0-9]+)',
                              re.S)
@@ -27,8 +27,8 @@ def get_best_pass(filename):
         return sorted_results[0]
 
 
-filename = sys.argv[1]
-log = get_best_pass(filename)
+log_filename = sys.argv[1]
+log = get_best_pass(log_filename)
 predict_error = math.sqrt(float(log[0])) / 2
 print 'Best pass is %s, error is %s, which means predict get error as %f' % (
     log[1], log[0], predict_error)


### PR DESCRIPTION
fix #1035 
As evaluate.sh don't work in Mac, I add a python version evaluate function.  The output is the same as evaluete.sh
```bash
➜  src git:(develop) ✗ ./evaluate.py mlp_train.log
Best pass is 00085, error is 0.164746, which means predict get error as 0.202945
The classification accuracy is 97.44%
evaluating from pass output/pass-00085
```