### PR TITLE
add permission AWSKeyManagementServicePowerUser for aws kms key creation

### DIFF
--- a/doc/howto/usage/k8s/k8s_aws_en.md
+++ b/doc/howto/usage/k8s/k8s_aws_en.md
@@ -31,6 +31,7 @@ the user group:
 - IAMUserSSHKeys
 - IAMFullAccess
 - NetworkAdministrator
+- AWSKeyManagementServicePowerUser
 
 
 By the time we write this tutorial, we noticed that Chinese AWS users


### PR DESCRIPTION
Without the permission command `aws kms --region=us-west-1 create-key --description="kube-aws assets"` will fail with:
An error occurred (AccessDeniedException) when calling the CreateKey operation: