### PR TITLE
fix docker build

### DIFF
--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get install -y automake clang-3.8 llvm-3.8 libclang-3.8-dev && \
     apt-get clean -y
 
-RUN pip install --upgrade pip && \ 
-    pip install 'protobuf==3.1.0.post1' && \
+RUN pip install --upgrade pip
+RUN pip install 'protobuf==3.1.0.post1' && \
     pip install -U wheel pillow BeautifulSoup && \
     pip install -U docopt PyYAML sphinx && \
     pip install -U sphinx_rtd_theme recommonmark jupyter

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -13,8 +13,8 @@ RUN apt-get update && \
     apt-get install -y automake clang-3.8 llvm-3.8 libclang-3.8-dev && \
     apt-get clean -y
 
-RUN pip install --upgrade pip && \ 
-    pip install 'protobuf==3.1.0.post1' && \
+RUN pip install --upgrade pip
+RUN pip install 'protobuf==3.1.0.post1' && \
     pip install -U wheel pillow BeautifulSoup && \
     pip install -U docopt PyYAML sphinx && \
     pip install -U sphinx_rtd_theme recommonmark jupyter


### PR DESCRIPTION
I am getting following error without this commit when doing `docker build -t paddle -f paddle/scripts/docker/Dockerfile .`

>   File "<string>", line 1, in <module>
>   File "/usr/local/lib/python2.7/dist-packages/setuptools/__init__.py", line 12, in <module>
>     import setuptools.version
>   File "/usr/local/lib/python2.7/dist-packages/setuptools/version.py", line 1, in <module>
>     import pkg_resources
>   File "/usr/local/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 70, in <module>
>     import packaging.version
> ImportError: No module named packaging.version

No idea why this change fix the problem, but it does fix.