### PR TITLE
Rename Python function DataBase into create_data_config_proto

### DIFF
--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -895,7 +895,7 @@ class MaxOut(Cfg):
 
 
 def create_data_config_proto(async_load_data=False,
-                             onstant_slots=None,
+                             constant_slots=None,
                              data_ratio=1,
                              is_main_data=True,
                              usage_ratio=None):

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -894,6 +894,30 @@ class MaxOut(Cfg):
         self.add_keys(locals())
 
 
+def create_data_config_proto(async_load_data=False,
+             constant_slots=None,
+             data_ratio=1,
+             is_main_data=True,
+             usage_ratio=None):
+    # default: all sub dataproviders are treat as "main data".
+    # see proto/DataConfig.proto for is_main_data
+    data_config = DataConfig()
+
+    data_config.async_load_data = async_load_data
+
+    if constant_slots:
+        data_config.constant_slots.extend(constant_slots)
+    data_config.data_ratio = data_ratio
+    data_config.is_main_data = is_main_data
+
+    usage_ratio = default(usage_ratio, settings_deprecated["usage_ratio"])
+    config_assert(usage_ratio >= 0 and usage_ratio <= 1,
+                  "The range of usage_ratio is [0, 1]")
+    data_config.usage_ratio = usage_ratio
+
+    return data_config
+
+
 @config_func
 def SimpleData(files=None,
                feat_dim=None,

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -895,10 +895,10 @@ class MaxOut(Cfg):
 
 
 def create_data_config_proto(async_load_data=False,
-             constant_slots=None,
-             data_ratio=1,
-             is_main_data=True,
-             usage_ratio=None):
+                             onstant_slots=None,
+                             data_ratio=1,
+                             is_main_data=True,
+                             usage_ratio=None):
     # default: all sub dataproviders are treat as "main data".
     # see proto/DataConfig.proto for is_main_data
     data_config = DataConfig()

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -894,30 +894,6 @@ class MaxOut(Cfg):
         self.add_keys(locals())
 
 
-def create_data_config_proto(async_load_data=False,
-             constant_slots=None,
-             data_ratio=1,
-             is_main_data=True,
-             usage_ratio=None):
-    # default: all sub dataproviders are treat as "main data".
-    # see proto/DataConfig.proto for is_main_data
-    data_config = DataConfig()
-
-    data_config.async_load_data = async_load_data
-
-    if constant_slots:
-        data_config.constant_slots.extend(constant_slots)
-    data_config.data_ratio = data_ratio
-    data_config.is_main_data = is_main_data
-
-    usage_ratio = default(usage_ratio, settings_deprecated["usage_ratio"])
-    config_assert(usage_ratio >= 0 and usage_ratio <= 1,
-                  "The range of usage_ratio is [0, 1]")
-    data_config.usage_ratio = usage_ratio
-
-    return data_config
-
-
 @config_func
 def SimpleData(files=None,
                feat_dim=None,

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -894,7 +894,7 @@ class MaxOut(Cfg):
         self.add_keys(locals())
 
 
-def DataBase(async_load_data=False,
+def create_data_config_proto(async_load_data=False,
              constant_slots=None,
              data_ratio=1,
              is_main_data=True,
@@ -924,7 +924,7 @@ def SimpleData(files=None,
                context_len=None,
                buffer_capacity=None,
                **xargs):
-    data_config = DataBase(**xargs)
+    data_config = create_data_config_proto(**xargs)
     data_config.type = 'simple'
     data_config.files = files
     data_config.feat_dim = feat_dim
@@ -946,7 +946,7 @@ def PyData(files=None,
            constant_slots=None,
            load_thread_num=None,
            **xargs):
-    data_config = DataBase(**xargs)
+    data_config = create_data_config_proto(**xargs)
     data_config.type = 'py'
     if load_data_module in g_py_module_name_list:
 
@@ -997,7 +997,7 @@ def ProtoData(files=None,
               constant_slots=None,
               load_thread_num=None,
               **xargs):
-    data_config = DataBase(**xargs)
+    data_config = create_data_config_proto(**xargs)
     if type is None:
         data_config.type = 'proto'
     else:
@@ -1036,7 +1036,7 @@ def Data(type,
          buffer_capacity=None,
          **xargs):
 
-    data_config = DataBase(**xargs)
+    data_config = create_data_config_proto(**xargs)
     data_config.type = type
     data_config.files = files
     data_config.feat_dim = feat_dim
@@ -1927,8 +1927,8 @@ class BatchNormLayer(LayerBase):
         image_conf = self.config.inputs[0].image_conf
         parse_image(self.inputs[0].image, input_layer.name, image_conf)
 
-        # Only pass the width and height of input to batch_norm layer 
-        # when either of it is non-zero. 
+        # Only pass the width and height of input to batch_norm layer
+        # when either of it is non-zero.
         if input_layer.width != 0 or input_layer.height != 0:
             self.set_cnn_layer(name, image_conf.img_size_y, image_conf.img_size,
                                image_conf.channels, False)

--- a/python/paddle/trainer_config_helpers/data_sources.py
+++ b/python/paddle/trainer_config_helpers/data_sources.py
@@ -58,8 +58,8 @@ def define_py_data_source(file_list,
     :param obj: python object name. May be a function name if using
                 PyDataProviderWrapper.
     :type obj: basestring
-    :param args: The best practice is using dict to pass arguments into 
-                 DataProvider, and use :code:`@init_hook_wrapper` to 
+    :param args: The best practice is using dict to pass arguments into
+                 DataProvider, and use :code:`@init_hook_wrapper` to
                  receive arguments.
     :type args: string or picklable object
     :param async: Load Data asynchronously or not.
@@ -98,7 +98,7 @@ def define_py_data_sources(train_list,
     The annotation is almost the same as define_py_data_sources2, except that
     it can specific train_async and data_cls.
 
-    :param data_cls: 
+    :param data_cls:
     :param train_list: Train list name.
     :type train_list: basestring
     :param test_list: Test list name.
@@ -111,8 +111,8 @@ def define_py_data_sources(train_list,
                 a tuple or list to this argument.
     :type obj: basestring or tuple or list
     :param args: The best practice is using dict() to pass arguments into
-                 DataProvider, and use :code:`@init_hook_wrapper` to receive 
-                 arguments. If train and test is different, then pass a tuple 
+                 DataProvider, and use :code:`@init_hook_wrapper` to receive
+                 arguments. If train and test is different, then pass a tuple
                  or list to this argument.
     :type args: string or picklable object or list or tuple.
     :param train_async: Is training data load asynchronously or not.
@@ -163,12 +163,12 @@ def define_py_data_sources2(train_list, test_list, module, obj, args=None):
 
     ..  code-block:: python
 
-        define_py_data_sources2(train_list="train.list", 
-                                test_list="test.list", 
+        define_py_data_sources2(train_list="train.list",
+                                test_list="test.list",
                                 module="data_provider"
                                 # if train/test use different configurations,
                                 # obj=["process_train", "process_test"]
-                                obj="process", 
+                                obj="process",
                                 args={"dictionary": dict_name})
 
     The related data provider can refer to :ref:`api_pydataprovider2_sequential_model` .
@@ -185,8 +185,8 @@ def define_py_data_sources2(train_list, test_list, module, obj, args=None):
                 a tuple or list to this argument.
     :type obj: basestring or tuple or list
     :param args: The best practice is using dict() to pass arguments into
-                 DataProvider, and use :code:`@init_hook_wrapper` to receive 
-                 arguments. If train and test is different, then pass a tuple 
+                 DataProvider, and use :code:`@init_hook_wrapper` to receive
+                 arguments. If train and test is different, then pass a tuple
                  or list to this argument.
     :type args: string or picklable object or list or tuple.
     :return: None
@@ -195,7 +195,7 @@ def define_py_data_sources2(train_list, test_list, module, obj, args=None):
 
     def py_data2(files, load_data_module, load_data_object, load_data_args,
                  **kwargs):
-        data = DataBase()
+        data = create_data_config_proto()
         data.type = 'py2'
         data.files = files
         data.load_data_module = load_data_module

--- a/python/paddle/trainer_config_helpers/data_sources.py
+++ b/python/paddle/trainer_config_helpers/data_sources.py
@@ -14,6 +14,7 @@
 """
 Data Sources are helpers to define paddle training data or testing data.
 """
+import paddle.proto.DataConfig_pb2
 from paddle.trainer.config_parser import *
 from .utils import deprecated
 
@@ -195,7 +196,7 @@ def define_py_data_sources2(train_list, test_list, module, obj, args=None):
 
     def py_data2(files, load_data_module, load_data_object, load_data_args,
                  **kwargs):
-        data = create_data_config_proto()
+        data = paddle.proto.DataConfig_pb2.DataConfig()
         data.type = 'py2'
         data.files = files
         data.load_data_module = load_data_module

--- a/python/paddle/trainer_config_helpers/data_sources.py
+++ b/python/paddle/trainer_config_helpers/data_sources.py
@@ -14,7 +14,6 @@
 """
 Data Sources are helpers to define paddle training data or testing data.
 """
-import paddle.proto.DataConfig_pb2
 from paddle.trainer.config_parser import *
 from .utils import deprecated
 
@@ -196,7 +195,7 @@ def define_py_data_sources2(train_list, test_list, module, obj, args=None):
 
     def py_data2(files, load_data_module, load_data_object, load_data_args,
                  **kwargs):
-        data = paddle.proto.DataConfig_pb2.DataConfig()
+        data = create_data_config_proto()
         data.type = 'py2'
         data.files = files
         data.load_data_module = load_data_module


### PR DESCRIPTION
Two reasons inspired me to rename it:

1. DataBase is a function, and according to PEP8 style guide, functions should be named as  *function_names*, and
1. DataBase as a function is not a verb phrase.

To make sure that I did a complete change, I searched for the appearances of `DataBase` and tried to rename them all:

```bash
# for i in $(du -a | grep '\.py$' | cut -f 2); do if [[ $i != *"build/"* ]]; then if grep DataBase $i; then echo ==== $i ====; fi; fi; done
def DataBase(async_load_data=False,
    data_config = DataBase(**xargs)
    data_config = DataBase(**xargs)
    data_config = DataBase(**xargs)
    data_config = DataBase(**xargs)
==== ./python/paddle/trainer/config_parser.py ====
        data = DataBase()
==== ./python/paddle/trainer_config_helpers/data_sources.py ====
```