### PR TITLE
Fix mkDirRecursively

### DIFF
--- a/paddle/utils/Util.cpp
+++ b/paddle/utils/Util.cpp
@@ -289,6 +289,7 @@ void mkDir(const char* filename) {
 void mkDirRecursively(const char* dir) {
   struct stat sb;
 
+  if (*dir == 0) return;  // empty string
   if (!stat(dir, &sb)) return;
 
   mkDirRecursively(path::dirname(dir).c_str());


### PR DESCRIPTION
In previous version mkDirRecursively("output") will cause infinite recursion because path::dirname("output") return an empty string.
