### PR TITLE
Layer run

### DIFF
--- a/python/paddle/v2/__init__.py
+++ b/python/paddle/v2/__init__.py
@@ -22,7 +22,7 @@ import py_paddle.swig_paddle as api
 
 __all__ = [
     'optimizer', 'layer', 'activation', 'parameters', 'init', 'trainer',
-    'event', 'data_type.py'
+    'event', 'data_type'
 ]
 
 

--- a/python/paddle/v2/layer.py
+++ b/python/paddle/v2/layer.py
@@ -67,7 +67,7 @@ paddle.v2.parameters.create, no longer exposed to users.
 """
 
 import paddle.trainer_config_helpers as conf_helps
-from . import data_type as v2_data
+import data_type as data_type
 from paddle.trainer_config_helpers.config_parser_utils import \
     parse_network_config as __parse__
 from paddle.trainer_config_helpers.default_decorators import wrap_name_default
@@ -166,7 +166,7 @@ So we also need to implement some special LayerV2.
 
 class DataLayerV2(Layer):
     def __init__(self, name, type, **kwargs):
-        assert isinstance(type, v2_data.InputType)
+        assert isinstance(type, data_type.InputType)
 
         self.type = type
         self.__method_name__ = 'data_layer'
@@ -198,8 +198,8 @@ cross_entropy_cost = __convert_to_v2__(
     parent_names=['input', 'label'])
 
 if __name__ == '__main__':
-    pixel = data(name='pixel', type=v2_data.dense_vector(784))
-    label = data(name='label', type=v2_data.integer_value(10))
+    pixel = data(name='pixel', type=data_type.dense_vector(784))
+    label = data(name='label', type=data_type.integer_value(10))
     hidden = fc(input=pixel, size=100, act=conf_helps.SigmoidActivation())
     inference = fc(input=hidden, size=10, act=conf_helps.SoftmaxActivation())
     maxid = max_id(input=inference)

--- a/python/paddle/v2/layer.py
+++ b/python/paddle/v2/layer.py
@@ -66,12 +66,14 @@ Also, the creation of a protobuf message is hidden in the invocation of
 paddle.v2.parameters.create, no longer exposed to users.
 """
 
+import collections
+
 import paddle.trainer_config_helpers as conf_helps
-import data_type as data_type
 from paddle.trainer_config_helpers.config_parser_utils import \
     parse_network_config as __parse__
 from paddle.trainer_config_helpers.default_decorators import wrap_name_default
-import collections
+
+import data_type
 
 __all__ = [
     'parse_network', 'data', 'fc', 'max_id', 'classification_cost',


### PR DESCRIPTION
包含相对路径import 的Python脚本不能直接运行，只能作为module被引用。原因正如手册中描述的，所谓相对路径其实就是相对于当前module的路径，但如果直接执行脚本，这个module的name就是“__main__”, 而不是module原来的name， 这样相对路径也就不是原来的相对路径了，导入就会失败，出现错误“ValueError: Attempted relative import in non-package”

上一个pr修改layer.py的时候用了
```python
from . import data_type
```
这样造成 python layer.py会失败