### PR TITLE
fix parameters.append_gradient_machine

### DIFF
--- a/python/paddle/v2/parameters.py
+++ b/python/paddle/v2/parameters.py
@@ -224,7 +224,8 @@ class Parameters(object):
                 except ValueError:
                     # If no such parameter in gradient machine, then don't copy
                     pass
-            self.__gradient_machines__.append(gradient_machine)
+
+        self.__gradient_machines__.append(gradient_machine)
 
 
 def __get_parameter_in_gradient_machine__(gradient_machine, name):


### PR DESCRIPTION
append_gradient_machine should append __gradient_machines__ in all conditions.

Could possibly address "目前CPU和GPU训练classification_error_evaluator降的都不太正常" in https://github.com/PaddlePaddle/Paddle/pull/1469