### PR TITLE
remove reader.batched and use batch_size as argument for train/test/i…

### DIFF
--- a/demo/mnist/api_train_v2.py
+++ b/demo/mnist/api_train_v2.py
@@ -27,8 +27,7 @@ def main():
     def event_handler(event):
         if isinstance(event, paddle.event.EndIteration):
             if event.batch_id % 1000 == 0:
-                result = trainer.test(reader=paddle.reader.batched(
-                    paddle.dataset.mnist.test(), batch_size=256))
+                result = trainer.test(paddle.dataset.mnist.test(), 256)
 
                 print "Pass %d, Batch %d, Cost %f, %s, Testing metrics %s" % (
                     event.pass_id, event.batch_id, event.cost, event.metrics,
@@ -38,10 +37,9 @@ def main():
             pass
 
     trainer.train(
-        reader=paddle.reader.batched(
-            paddle.reader.shuffle(
-                paddle.dataset.mnist.train(), buf_size=8192),
-            batch_size=32),
+        reader=paddle.reader.shuffle(
+            paddle.dataset.mnist.train(), buf_size=8192),
+        batch_size=32,
         event_handler=event_handler)
 
     # output is a softmax layer. It returns probabilities.
@@ -49,12 +47,10 @@ def main():
     probs = paddle.infer(
         output=inference,
         parameters=parameters,
-        reader=paddle.reader.batched(
-            paddle.reader.firstn(
-                paddle.reader.map_readers(lambda item: (item[0], ),
-                                          paddle.dataset.mnist.test()),
-                n=100),
-            batch_size=32))
+        reader=paddle.reader.firstn(
+            paddle.dataset.mnist.test(), n=100),
+        reader_dict={'pixel': 0},
+        batch_size=32)
     print probs.shape
 
 

--- a/python/paddle/v2/common.py
+++ b/python/paddle/v2/common.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def make_batch(reader, batch_size):
+    def batched_reader():
+        r = reader()
+        batch = []
+        for instance in r:
+            batch.append(instance)
+            if len(batch) == batch_size:
+                yield batch
+                batch = []
+        if batch:
+            yield batch
+
+    return batched_reader

--- a/python/paddle/v2/inferencer.py
+++ b/python/paddle/v2/inferencer.py
@@ -5,6 +5,8 @@ from data_feeder import DataFeeder
 import itertools
 import numpy
 
+from . import common
+
 __all__ = ['Inference', 'infer']
 
 
@@ -54,6 +56,12 @@ class Inference(object):
         return reader_dict
 
 
-def infer(output, parameters, reader, reader_dict=None, field='value'):
+def infer(output,
+          parameters,
+          reader,
+          batch_size,
+          reader_dict=None,
+          field='value'):
+    reader = common.make_batch(reader, batch_size)
     inferer = Inference(output=output, parameters=parameters)
     return inferer.infer(field=field, reader=reader, reader_dict=reader_dict)

--- a/python/paddle/v2/reader/decorator.py
+++ b/python/paddle/v2/reader/decorator.py
@@ -14,7 +14,7 @@
 
 __all__ = [
     'map_readers', 'buffered', 'compose', 'chain', 'shuffle',
-    'ComposeNotAligned', 'batched', 'firstn'
+    'ComposeNotAligned', 'firstn'
 ]
 
 import itertools
@@ -191,28 +191,6 @@ def buffered(reader, size):
             e = q.get()
 
     return data_reader
-
-
-def batched(reader, batch_size):
-    """
-    Create a batched reader.
-    :param reader: the data reader to read from.
-    :param batch_size: batch_size
-    :return: the batched reader.
-    """
-
-    def batched_reader():
-        r = reader()
-        batch = []
-        for instance in r:
-            batch.append(instance)
-            if len(batch) == batch_size:
-                yield batch
-                batch = []
-        if batch:
-            yield batch
-
-    return batched_reader
 
 
 def firstn(reader, n):

--- a/python/paddle/v2/trainer.py
+++ b/python/paddle/v2/trainer.py
@@ -7,6 +7,7 @@ from topology import Topology
 from . import event as v2_event
 from . import optimizer as v2_optimizer
 from . import parameters as v2_parameters
+from . import common
 
 __all__ = ['ITrainer', 'SGD']
 
@@ -30,7 +31,6 @@ class ITrainer(object):
     def train(self, reader, topology, parameters, event_handler=None):
         """
         train method.
-
         :param reader:
         :param topology:
         :param parameters:
@@ -70,7 +70,12 @@ class SGD(ITrainer):
         self.__gradient_machine__ = gm
         self.__gradient_machine__.randParameters()
 
-    def train(self, reader, num_passes=1, event_handler=None, reader_dict=None):
+    def train(self,
+              reader,
+              batch_size,
+              num_passes=1,
+              event_handler=None,
+              reader_dict=None):
         """
         Training method. Will train num_passes of input data.
 
@@ -91,6 +96,7 @@ class SGD(ITrainer):
 
         __check_train_args__(**locals())
 
+        reader = common.make_batch(reader, batch_size)
         updater = self.__optimizer__.create_local_updater()
         updater.init(self.__gradient_machine__)
 
@@ -146,10 +152,11 @@ class SGD(ITrainer):
             reader_dict[tp[0]] = i
         return reader_dict
 
-    def test(self, reader, reader_dict=None):
+    def test(self, reader, batch_size, reader_dict=None):
         if reader_dict is None:
             reader_dict = self.default_reader_dict()
 
+        reader = common.make_batch(reader, batch_size)
         feeder = DataFeeder(self.__data_types__, reader_dict)
         evaluator = self.__gradient_machine__.makeEvaluator()
         out_args = api.Arguments.createArguments(0)


### PR DESCRIPTION
…nfer

our reader definition is func that yield a single item,
it should not be a batch item.
reader.batched creates a func that yield a batch items,
which does not belong to decorator and should not be exposed.