### PR TITLE
remove inferencer and Inference from __All__, since infer is sufficen…

### DIFF
--- a/python/paddle/v2/__init__.py
+++ b/python/paddle/v2/__init__.py
@@ -25,14 +25,14 @@ from . import dataset
 from . import reader
 import attr
 import pooling
-import inferencer
+import inference
 import networks
 import py_paddle.swig_paddle as api
 
 __all__ = [
     'optimizer', 'layer', 'activation', 'parameters', 'init', 'trainer',
     'event', 'data_type', 'attr', 'pooling', 'data_feeder', 'dataset', 'reader',
-    'topology', 'networks', 'inferencer', 'infer'
+    'topology', 'networks', 'infer'
 ]
 
 
@@ -44,4 +44,4 @@ def init(**kwargs):
     api.initPaddle(*args)
 
 
-infer = inferencer.infer
+infer = inference.infer

--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -5,7 +5,7 @@ from data_feeder import DataFeeder
 import itertools
 import numpy
 
-__all__ = ['Inference', 'infer']
+__all__ = ['infer']
 
 
 class Inference(object):


### PR DESCRIPTION
…t, they are implementation detail.

rename inferencer.py to inference.py

Fixes https://github.com/PaddlePaddle/Paddle/issues/1514