### PR TITLE
Fix MultiGradientMachine error

### DIFF
--- a/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
@@ -359,9 +359,7 @@ void MultiGradientMachine::getOutArgs(std::vector<Argument>* outArgs,
     thread->waitOutArgsReady();
   }
 
-  // outArgs_.size() only need to be calculated once.
-  static int size = threads_[threads_.size() - 1]->getOutArgs().size();
-  outArgs_.resize(size);
+  outArgs_.resize(threads_[threads_.size() - 1]->getOutArgs().size());
 
   REGISTER_TIMER("copyOutArgs");
   for (size_t i = 0; i < outArgs_.size(); ++i) {

--- a/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
@@ -358,6 +358,7 @@ void MultiGradientMachine::getOutArgs(std::vector<Argument>* outArgs,
     REGISTER_TIMER("waitOutArgs");
     thread->waitOutArgsReady();
   }
+
   // outArgs_.size() only need to be calculated once.
   static int size = threads_[threads_.size() - 1]->getOutArgs().size();
   outArgs_.resize(size);
@@ -574,9 +575,9 @@ void TrainerThread::forward() {
     REGISTER_TIMER("thread_forward");
     if (batchSize_ > 0) {
       gradientMachine_->forward(
-        inArgs_, &outArgs_, multiMachine_->getPassType());
+          inArgs_, &outArgs_, multiMachine_->getPassType());
     } else {
-       outArgs_.clear();
+      outArgs_.clear();
     }
   }
   outArgsReadySem_.post();

--- a/paddle/gserver/gradientmachines/MultiGradientMachine.h
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.h
@@ -470,7 +470,6 @@ protected:
 
   /// indicate whether inArgs is copied before forward()
   bool inArgsCopied_;
-
   int batchSize_;
 };
 

--- a/paddle/gserver/gradientmachines/MultiGradientMachine.h
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.h
@@ -387,6 +387,9 @@ public:
   /// copy the output gradient from the main GradientMachine.
   void copyOutputGrad();
 
+  /// Whether the thread has input data.
+  bool hasInputData() { return batchSize_ != 0; }
+
 protected:
   void mergeCpuGradients();
 
@@ -407,7 +410,7 @@ protected:
   void copyGradToBufferThread();
   void gradCollectThread();
 
-  void copyInArgs();
+  int copyInArgs();
   void forward();
   void backward();
   void backwardCallback(Parameter* para);
@@ -467,6 +470,8 @@ protected:
 
   /// indicate whether inArgs is copied before forward()
   bool inArgsCopied_;
+
+  int batchSize_;
 };
 
 }  // namespace paddle


### PR DESCRIPTION
Fix Issue #1539 中描述的Bug。
MultiGradientMachine在trainer_count > batch_size时会有计算错误这里表现在两个方面。
1. 在第一个batch计算时出现trainer_count > batch_size，程序会崩溃；一般是在某个Layer的resetOutput时有一个分配一个size=0的内存导致的。
2. 在最后一个batch计算时出现trainer_count > batch_size，程序不会崩溃；但是对于计算逻辑有隐含的bug，主要原因是，对于没有数据的thread，在TrainerThread::copyInArgs里面碰到if (copySize == 0)直接返回了，但在TrainerThread::forward里面使用的inArgs_实际是上一个batch的数据。

-----------------------------
以上，两种错误，用understand_sentiment例子有验证，方法是从训练数据中裁剪出10个样本，设置batch_size=3，trainer_count=4可以看到第一种错误；设置batch_size=4, trainer_count=4可以看到第二种错误。则个PR主要是Fix该错误，后续再补上MultiGradientMachine的这部分测试代码。