### PR TITLE
Correct copy path for DockerHub compatibility

### DIFF
--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -22,7 +22,7 @@ ENV WITH_STYLE_CHECK=${WITH_STYLE_CHECK:-OFF}
 ENV HOME /root
 
 # Add bash enhancements
-COPY ./paddle/scripts/docker/root/ /root/
+COPY paddle/paddle/scripts/docker/root/ /root/
 
 RUN apt-get update && \
     apt-get install -y git python-pip python-dev openssh-server bison && \

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -22,7 +22,7 @@ ENV WITH_STYLE_CHECK=${WITH_STYLE_CHECK:-OFF}
 ENV HOME /root
 
 # Add bash enhancements
-COPY ./paddle/scripts/docker/root/ /root/
+COPY paddle/paddle/scripts/docker/root/ /root/
 
 RUN apt-get update && \
     apt-get install -y git python-pip python-dev openssh-server bison && \


### PR DESCRIPTION
Dockerhub.com complains

```
Step 18 : COPY ./paddle/scripts/docker/root/ /root/
lstat paddle/scripts/docker/root/: no such file or directory
```

@helinwang found an issue with Dockerhub: https://github.com/docker/hub-feedback/issues/841 . It seems that Dockerhub.com doesn't `cd` into the git-cloned directory before running `docker build ...`.