### PR TITLE
Fix the way Paddle reference ccache program

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,9 +1,9 @@
 # Use ccache if found ccache program
 
-find_program(CCACHE_FOUND ccache)
+find_program(CCACHE_PATH ccache)
 
-if(CCACHE_FOUND)
+if(CCACHE_PATH)
     message(STATUS "Ccache is founded, use ccache to speed up compile.")
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-endif(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PATH})
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PATH})
+endif(CCACHE_PATH)


### PR DESCRIPTION
It is a bug in CMake files. If we found ccache by CMAKE, we should use ${CCACHE_PATH} to reference it, not just use `ccache` to reference it. 

It will make compile error, when `ccache` is not in PATH variable but founded by `cmake`.