### PR TITLE
Remove sshd service from Docker Image

### DIFF
--- a/doc/getstarted/build_and_install/docker_install_cn.rst
+++ b/doc/getstarted/build_and_install/docker_install_cn.rst
@@ -10,7 +10,7 @@ PaddlePaddle目前唯一官方支持的运行的方式是Docker容器。因为Do
 开发人员可以在Docker中开发PaddlePaddle。这样开发人员可以以一致的方式在不同的平台上工作 - Linux，Mac OS X和Windows。
 
 1. 将开发环境构建为Docker镜像
-   
+
    .. code-block:: bash
 
       git clone --recursive https://github.com/PaddlePaddle/Paddle
@@ -28,29 +28,27 @@ PaddlePaddle目前唯一官方支持的运行的方式是Docker容器。因为Do
 2. 运行开发环境
 
    当我们编译好了 :code:`paddle:dev`， 我们可以在docker容器里做开发，源代码可以通过挂载本地文件来被载入Docker的开发环境里面：
-   
-   .. code-block:: bash
 
-      docker run -d -p 2202:22 -v $PWD:/paddle paddle:dev
+   .. code-block:: bash
+      docker run -d -v $PWD:/paddle --name mypaddle-dev paddle:dev
 
    以上代码会启动一个带有PaddlePaddle开发环境的docker容器，源代码会被挂载到 :code:`/paddle` 。
 
-   请注意， :code:`paddle:dev` 的默认入口是 :code:`sshd` 。以上的 :code:`docker run` 命令其实会启动一个在2202端口监听的SSHD服务器。这样，我们就能SSH进入我们的开发容器了：
-   
-   .. code-block:: bash
+   通过 :code:`docker exec`命令，可以进入到容器内部进行开发
 
-      ssh root@localhost -p 2202
+   .. code-block:: bash
+      docker exec -it mypaddle-dev /bin/bash
 
 3. 在Docker开发环境中编译与安装PaddlPaddle代码
 
    当在容器里面的时候，可以用脚本 :code:`paddle/scripts/docker/build.sh` 来编译、安装与测试PaddlePaddle：
-   
+
    .. code-block:: bash
-		      
+
       /paddle/paddle/scripts/docker/build.sh
 
    以上指令会在 :code:`/paddle/build` 中编译PaddlePaddle。通过以下指令可以运行单元测试：
-   
+
    .. code-block:: bash
 
       cd /paddle/build
@@ -62,15 +60,15 @@ PaddlePaddle目前唯一官方支持的运行的方式是Docker容器。因为Do
 
    PaddlePaddle书籍是为用户和开发者制作的一个交互式的Jupyter Nodebook。
    如果您想要更深入了解deep learning，PaddlePaddle书籍一定是您最好的选择。
-   
+
    当您进入容器内之后，只用运行以下命令：
 
    .. code-block:: bash
-		   
+
       jupyter notebook
 
    然后在浏览器中输入以下网址：
-      
+
    .. code-block:: text
 
       http://localhost:8888/
@@ -91,22 +89,17 @@ PaddlePaddle目前唯一官方支持的运行的方式是Docker容器。因为Do
 
 .. code-block:: bash
 
-    docker run -it --rm paddledev/paddle:0.10.0rc1-cpu /bin/bash
+    docker run -it --rm --name paddle-cpu paddledev/paddle:0.10.0rc1-cpu /bin/bash
 
 或者，可以以后台进程方式运行容器：
 
 .. code-block:: bash
 
-    docker run -d -p 2202:22 paddledev/paddle:0.10.0rc1-cpu
+    docker run -d --rm --name paddle-cpu paddledev/paddle:0.10.0rc1-cpu
 
-然后用密码 :code:`root` SSH进入容器：
-
+然后通过 :code:`docker exec`进入容器:
 .. code-block:: bash
-
-    ssh -p 2202 root@localhost
-
-SSH方式的一个优点是我们可以从多个终端进入容器。比如，一个终端运行vi，另一个终端运行Python。另一个好处是我们可以把PaddlePaddle容器运行在远程服务器上，并在笔记本上通过SSH与其连接。
-
+    docker exec -it paddle-cpu /bin/bash
 
 以上方法在GPU镜像里也能用－只是请不要忘记按装CUDA驱动，以及告诉Docker：
 

--- a/doc/getstarted/build_and_install/docker_install_en.rst
+++ b/doc/getstarted/build_and_install/docker_install_en.rst
@@ -42,27 +42,21 @@ Windows -- in a consistent way.
 
    .. code-block:: bash
 
-      docker run -d -p 2202:22 -p 8888:8888 -v $PWD:/paddle paddle:dev
+      docker run -d -p 8888:8888 -v $PWD:/paddle --rm --name mypaddle-dev paddle:dev
 
    This runs a container of the development environment Docker image
    with the local source tree mounted to :code:`/paddle` of the
    container.
 
-   Note that the default entry-point of :code:`paddle:dev` is
-   :code:`sshd`, and above :code:`docker run` commands actually starts
-   an SSHD server listening on port 2202.  This allows us to log into
-   this container with:
-
+   We can get into this container with:
    .. code-block:: bash
-
-      ssh root@localhost -p 2202
+      docker exec -it mypaddle-dev /bin/bash
 
    Usually, I run above commands on my Mac.  I can also run them on a
-   GPU server :code:`xxx.yyy.zzz.www` and ssh from my Mac to it:
+   GPU server :code:`xxx.yyy.zzz.www` and run `docker exec` to get into the container.
 
    .. code-block:: bash
-
-      my-mac$ ssh root@xxx.yyy.zzz.www -p 2202
+      my-mac$ docker exec -it mypaddle-dev /bin/bash
 
 3. Build and Install Using the Development Environment
 
@@ -88,18 +82,18 @@ Windows -- in a consistent way.
    you to create and share documents that contain live code, equations,
    visualizations and explanatory text in a single browser.
 
-   PaddlePaddle Book is an interactive Jupyter Notebook for users and developers. 
+   PaddlePaddle Book is an interactive Jupyter Notebook for users and developers.
    We already exposed port 8888 for this book. If you want to
    dig deeper into deep learning, PaddlePaddle Book definitely is your best choice.
 
    Once you are inside the container, simply issue the command:
 
    .. code-block:: bash
-		   
+
       jupyter notebook
 
    Then, you would back and paste the address into the local browser:
-      
+
    .. code-block:: text
 
       http://localhost:8888/
@@ -130,19 +124,12 @@ or, we can run it as a daemon container
 
 .. code-block:: bash
 
-    docker run -d -p 2202:22 paddledev/paddle:0.10.0rc1-cpu
+    docker run -d --rm --name paddl-cpu paddledev/paddle:0.10.0rc1-cpu
 
-and SSH to this container using password :code:`root`:
+and get into this container using :code:`docker exec`:
 
 .. code-block:: bash
-
-    ssh -p 2202 root@localhost
-
-An advantage of using SSH is that we can connect to PaddlePaddle from
-more than one terminals.  For example, one terminal running vi and
-another one running Python interpreter.  Another advantage is that we
-can run the PaddlePaddle container on a remote server and SSH to it
-from a laptop.
+    docker exec -it paddle-cpu /bin/bash
 
 
 Above methods work with the GPU image too -- just please don't forget

--- a/paddle/scripts/docker/Dockerfile
+++ b/paddle/scripts/docker/Dockerfile
@@ -18,14 +18,14 @@ ENV WITH_GPU=OFF
 ENV WITH_AVX=${WITH_AVX:-ON}
 ENV WITH_DOC=${WITH_DOC:-OFF}
 ENV WITH_STYLE_CHECK=${WITH_STYLE_CHECK:-OFF}
-ENV DOCKER_BUILD=TRUE
 
 ENV HOME /root
 
 # Add bash enhancements
 COPY ./paddle/scripts/docker/root/ /root/
 
-RUN apt-get update && \
+RUN sudo sed 's@http:\/\/archive.ubuntu.com\/ubuntu\/@mirror:\/\/mirrors.ubuntu.com\/mirrors.txt@' -i /etc/apt/sources.list && \
+    apt-get update && \
     apt-get install -y git python-pip python-dev openssh-server bison && \
     apt-get install -y wget unzip tar xz-utils bzip2 gzip coreutils && \
     apt-get install -y curl sed grep graphviz libjpeg-dev zlib1g-dev && \
@@ -54,14 +54,8 @@ COPY . /paddle/
 RUN cd /paddle/ && git submodule update --init --recursive
 RUN /paddle/paddle/scripts/docker/build.sh
 
-VOLUME ["/usr/share/nginx/html/data", "/usr/share/nginx/html/paddle"]
 
-# Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
-RUN mkdir /var/run/sshd
-RUN echo 'root:root' | chpasswd
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
-EXPOSE 22
+VOLUME ["/usr/share/nginx/html/data", "/usr/share/nginx/html/paddle"]
 
 # Jupyter Notebook: Paddle book
 EXPOSE 8888

--- a/paddle/scripts/docker/Dockerfile.gpu
+++ b/paddle/scripts/docker/Dockerfile.gpu
@@ -56,13 +56,6 @@ RUN /paddle/paddle/scripts/docker/build.sh
 
 VOLUME ["/usr/share/nginx/html/data", "/usr/share/nginx/html/paddle"]
 
-# Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
-RUN mkdir /var/run/sshd
-RUN echo 'root:root' | chpasswd
-RUN sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
-RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
-EXPOSE 22
-
 # Jupyter Notebook: Paddle book
 EXPOSE 8888
 

--- a/paddle/scripts/docker/entrypoint
+++ b/paddle/scripts/docker/entrypoint
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-/usr/sbin/sshd -D &
 jupyter notebook --ip=0.0.0.0 /paddle/book/


### PR DESCRIPTION
It seems that we do not need a **sshd service** in container.
We can use  command `docker exec` with local mode  and `kubectl exec` with kubernetes instead of `ssh root@xxx.yyy.zzz -p 2202` to get into PaddlePaddle container.