### PR TITLE
update sphinx cmake

### DIFF
--- a/cmake/FindSphinx.cmake
+++ b/cmake/FindSphinx.cmake
@@ -72,7 +72,7 @@ function( Sphinx_add_target target_name builder conf cache source destination )
     ${source}
     ${destination}
     COMMENT "Generating sphinx documentation: ${builder}"
-    COMMAND cd ${destination} && ln -s ./index_*.html index.html
+    COMMAND cd ${destination} && ln -sf ./index_*.html index.html
     )
 
   set_property(


### PR DESCRIPTION
首次编译文档不出错，第二次编译时会出现：
```
ln: creating symbolic link `index.html': File exists
make[3]: *** [doc/CMakeFiles/paddle_docs] Error 1
make[2]: *** [doc/CMakeFiles/paddle_docs.dir/all] Error 2
make[1]: *** [doc/CMakeFiles/paddle_docs.dir/rule] Error 2
```
因此将`ln -s`命令改成强制执行`ln -sf`