### PR TITLE
Build default use cmake release

### DIFF
--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -48,6 +48,7 @@ if [[ ${BUILD_AND_INSTALL:-OFF} == 'ON' ]]; then
       rm -rf * && rm -rf ../third_party
     fi
     cmake .. \
+	  -DCMAKE_BUILD_TYPE=Release \
 	  -DWITH_DOC=${WITH_DOC:-OFF} \
 	  -DWITH_GPU=${WITH_GPU:-OFF} \
 	  -DWITH_AVX=${WITH_AVX:-OFF} \


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/1667

Add `-DCMAKE_BUILD_TYPE=Release` when build docker image, this will significantly reduce the size of the binaries.