### PR TITLE
Fix rdma links bug

### DIFF
--- a/paddle/api/CMakeLists.txt
+++ b/paddle/api/CMakeLists.txt
@@ -76,8 +76,6 @@ SWIG_LINK_LIBRARIES(swig_paddle
     ${CMAKE_DL_LIBS}
     ${EXTERNAL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${RDMA_LD_FLAGS}
-    ${RDMA_LIBS}
     ${START_END}
 )
 


### PR DESCRIPTION
查看了下，之前swig是不会连接rdma的。

Fix #1705 