### PR TITLE
Refine openblas find package.

### DIFF
--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -29,7 +29,14 @@ IF(NOT ${CBLAS_FOUND})
 
     IF(CMAKE_COMPILER_IS_GNUCC)
         ENABLE_LANGUAGE(Fortran)
-        find_library(GFORTRAN_LIBRARY NAMES gfortran)
+        string(REGEX MATCHALL "[0-9]+" Fortran_VERSION ${CMAKE_Fortran_COMPILER_VERSION})
+        list(GET Fortran_VERSION 0 Fortran_MAJOR)
+        list(GET Fortran_VERSION 1 Fortran_MINOR)
+        find_library(GFORTRAN_LIBRARY NAMES gfortran PATHS 
+                     /lib
+                     /usr/lib
+                     /usr/lib/gcc/x86_64-linux-gnu/${Fortran_MAJOR}.${Fortran_MINOR}/
+                     /usr/lib/gcc/x86_64-linux-gnu/${Fortran_MAJOR}/)
         if (NOT GFORTRAN_LIBRARY)
             message(FATAL_ERROR "Cannot found gfortran library which it is used by openblas")
         endif()

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -29,6 +29,10 @@ IF(NOT ${CBLAS_FOUND})
 
     IF(CMAKE_COMPILER_IS_GNUCC)
         ENABLE_LANGUAGE(Fortran)
+        if (NOT CMAKE_Fortran_COMPILER_VERSION)
+          # cmake version is too old, we cannot get fortran version, using CXX version instead.
+          set(CMAKE_Fortran_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+        endif()
         string(REGEX MATCHALL "[0-9]+" Fortran_VERSION ${CMAKE_Fortran_COMPILER_VERSION})
         list(GET Fortran_VERSION 0 Fortran_MAJOR)
         list(GET Fortran_VERSION 1 Fortran_MINOR)

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -29,7 +29,12 @@ IF(NOT ${CBLAS_FOUND})
 
     IF(CMAKE_COMPILER_IS_GNUCC)
         ENABLE_LANGUAGE(Fortran)
-        LIST(APPEND CBLAS_LIBRARIES gfortran pthread)
+        find_library(GFORTRAN_LIBRARY NAMES gfortran)
+        if (NOT GFORTRAN_LIBRARY)
+            message(FATAL_ERROR "Cannot found gfortran library which it is used by openblas")
+        endif()
+        find_package(Threads REQUIRED)
+        LIST(APPEND CBLAS_LIBRARIES ${GFORTRAN_LIBRARY} ${CMAKE_THREAD_LIBS_INIT})
     ENDIF(CMAKE_COMPILER_IS_GNUCC)
 
     IF(NOT CMAKE_Fortran_COMPILER)

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -30,8 +30,9 @@ IF(NOT ${CBLAS_FOUND})
     IF(CMAKE_COMPILER_IS_GNUCC)
         ENABLE_LANGUAGE(Fortran)
         if (NOT CMAKE_Fortran_COMPILER_VERSION)
-          # cmake version is too old, we cannot get fortran version, using CXX version instead.
-          set(CMAKE_Fortran_COMPILER_VERSION ${CMAKE_CXX_COMPILER_VERSION})
+          # cmake < 3.4 cannot get CMAKE_Fortran_COMPILER_VERSION directly.
+          execute_process(COMMAND ${CMAKE_Fortran_COMPILER} -dumpversion
+                    OUTPUT_VARIABLE CMAKE_Fortran_COMPILER_VERSION)
         endif()
         string(REGEX MATCHALL "[0-9]+" Fortran_VERSION ${CMAKE_Fortran_COMPILER_VERSION})
         list(GET Fortran_VERSION 0 Fortran_MAJOR)


### PR DESCRIPTION
If the versions of g++ and gfortran are different, directly use '-lgfortran' will cause link error.
Correctly searching gfortran is tested in `ubuntu 14.04` and `ubuntu 16.04`