### PR TITLE
Standardize Python import in paddle.v2

### DIFF
--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -1,9 +1,9 @@
 import numpy
 import py_paddle.swig_paddle as api
 import collections
-import topology
-import minibatch
-from data_feeder import DataFeeder
+import paddle.v2.topology as topology
+import paddle.v2.minibatch as minibatch
+import paddle.v2.data_feeder as data_feeder
 
 __all__ = ['infer']
 
@@ -22,7 +22,7 @@ class Inference(object):
         self.__data_types__ = topo.data_type()
 
     def iter_infer(self, input, feeding=None):
-        feeder = DataFeeder(self.__data_types__, feeding)
+        feeder = data_feeder.DataFeeder(self.__data_types__, feeding)
         batch_size = len(input)
 
         def __reader_impl__():

--- a/python/paddle/v2/layer.py
+++ b/python/paddle/v2/layer.py
@@ -33,7 +33,7 @@ The primary usage shows below.
 
 import collections
 import inspect
-from config_base import Layer, __convert_to_v2__
+from paddle.v2.config_base import Layer, __convert_to_v2__
 import paddle.trainer_config_helpers as conf_helps
 from paddle.trainer_config_helpers.config_parser_utils import \
     parse_network_config as __parse__
@@ -46,9 +46,9 @@ from paddle.trainer.config_parser import \
     RecurrentLayerGroupWithoutOutLinksBegin, RecurrentLayerGroupSetOutLink, \
     RecurrentLayerGroupEnd, model_type
 
-import activation
+import paddle.v2.activation as activation
 import re
-import data_type
+import paddle.v2.data_type as data_type
 
 __all__ = ['parse_network', 'data']
 

--- a/python/paddle/v2/layer.py
+++ b/python/paddle/v2/layer.py
@@ -33,7 +33,7 @@ The primary usage shows below.
 
 import collections
 import inspect
-from paddle.v2.config_base import Layer, __convert_to_v2__
+import paddle.v2.config_base as config_base
 import paddle.trainer_config_helpers as conf_helps
 from paddle.trainer_config_helpers.config_parser_utils import \
     parse_network_config as __parse__
@@ -86,7 +86,7 @@ So we also need to implement some special LayerV2.
 """
 
 
-class DataLayerV2(Layer):
+class DataLayerV2(config_base.Layer):
     METHOD_NAME = 'data_layer'
 
     def __init__(self, name, type, **kwargs):
@@ -119,7 +119,7 @@ class DataLayerV2(Layer):
         return doc
 
 
-class WithExtraParent(Layer):
+class WithExtraParent(config_base.Layer):
     def extra_parent(self):
         return self.__extra_parent__
 
@@ -223,7 +223,7 @@ class MemoryV2(WithExtraParent):
         return True
 
 
-class LayerOutputV2(Layer):
+class LayerOutputV2(config_base.Layer):
     """
     LayerOutputV2 is used to store the result of LayerOutput in v1 api.
     It will not store it's parents because layer_output has been parsed already.
@@ -250,7 +250,7 @@ class StaticInputV2(object):
         # assert input.size is not None or size is not None
 
 
-class MixedLayerV2(Layer):
+class MixedLayerV2(config_base.Layer):
     """
     This class is use to support `with` grammar. If not, the following code
     could convert mixed_layer simply.
@@ -347,7 +347,7 @@ class RecurrentLayerInput(WithExtraParent):
         return self
 
 
-class RecurrentLayerOutput(Layer):
+class RecurrentLayerOutput(config_base.Layer):
     def __init__(self, recurrent_name, index, parent_layers):
         assert len(parent_layers) == 1
         self.__parents__ = parent_layers.values()[0]
@@ -364,7 +364,7 @@ class RecurrentLayerOutput(Layer):
         RecurrentLayerGroupEnd(name=self.__recurrent_name__)
 
 
-LayerV2 = Layer
+LayerV2 = config_base.Layer
 data = DataLayerV2
 data.__name__ = 'data'
 AggregateLevel = conf_helps.layers.AggregateLevel
@@ -405,7 +405,8 @@ def __layer_name_mapping_parent_names__(inname):
 def __convert_layer__(_new_name_, _old_name_, _parent_names_):
     global __all__
     __all__.append(_new_name_)
-    globals()[new_name] = __convert_to_v2__(_old_name_, _parent_names_)
+    globals()[new_name] = config_base.__convert_to_v2__(_old_name_,
+                                                        _parent_names_)
     globals()[new_name].__name__ = new_name
 
 
@@ -482,7 +483,7 @@ __all__ += __operator_names__
 
 # convert projection
 for prj in __projection_names__:
-    globals()[prj] = __convert_to_v2__(
+    globals()[prj] = config_base.__convert_to_v2__(
         prj, parent_names=['input'], is_default_name=False)
     globals()[prj].__name__ = prj
 
@@ -493,6 +494,6 @@ operator_list = [
     ['conv_operator', ['img', 'filter']]
 ]
 for op in operator_list:
-    globals()[op[0]] = __convert_to_v2__(
+    globals()[op[0]] = config_base.__convert_to_v2__(
         op[0], parent_names=op[1], is_default_name=False)
     globals()[op[0]].__name__ = op[0]

--- a/python/paddle/v2/networks.py
+++ b/python/paddle/v2/networks.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import paddle.trainer_config_helpers.networks as conf_nw
 import inspect
-from config_base import __convert_to_v2__
+import paddle.trainer_config_helpers.networks as conf_nw
+import paddle.v2.config_base as config_base
 
 __all__ = []
 
@@ -33,7 +33,7 @@ def __initialize__():
         else:
             parents = filter(lambda x: x.startswith('input'), argspec.args)
         assert len(parents) != 0, each_subnetwork
-        v2_subnet = __convert_to_v2__(
+        v2_subnet = config_base.__convert_to_v2__(
             each_subnetwork,
             parent_names=parents,
             is_default_name='name' in argspec.args)

--- a/python/paddle/v2/parameters.py
+++ b/python/paddle/v2/parameters.py
@@ -4,7 +4,7 @@ from paddle.proto.ParameterConfig_pb2 import ParameterConfig
 import struct
 import tarfile
 import cStringIO
-from topology import Topology
+import paddle.v2.topology as topology
 
 __all__ = ['Parameters', 'create']
 
@@ -16,7 +16,7 @@ def create(layers):
     :param layers:
     :return:
     """
-    topology = Topology(layers)
+    topology = topology.Topology(layers)
     pool = Parameters()
     for param in topology.proto().parameters:
         pool.__append_config__(param)

--- a/python/paddle/v2/topology.py
+++ b/python/paddle/v2/topology.py
@@ -12,12 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
-
 from paddle.proto.ModelConfig_pb2 import ModelConfig
-
-import layer as v2_layer
-from layer import WithExtraParent
+import collections
+import paddle.v2.layer as layer
 
 __all__ = ['Topology']
 
@@ -42,7 +39,7 @@ def __bfs_travel__(callback, *layers):
         if __break__:
             return
         __layers__ = each_layer.__parent_layers__.values()
-        if isinstance(each_layer, WithExtraParent):
+        if isinstance(each_layer, layer.WithExtraParent):
             __layers__ = __layers__ + each_layer.extra_parent()
         __bfs_travel__(callback, *__layers__)
 
@@ -60,7 +57,7 @@ class Topology(object):
         for layer in layers:
             __check_layer_type__(layer)
         self.layers = layers
-        self.__model_config__ = v2_layer.parse_network(*layers)
+        self.__model_config__ = layer.parse_network(*layers)
         assert isinstance(self.__model_config__, ModelConfig)
 
     def proto(self):
@@ -93,7 +90,7 @@ class Topology(object):
         data_layers = dict()
 
         def __impl__(l):
-            if isinstance(l, v2_layer.DataLayerV2):
+            if isinstance(l, layer.DataLayerV2):
                 data_layers[l.name] = l
 
         __bfs_travel__(__impl__, *self.layers)
@@ -110,5 +107,5 @@ class Topology(object):
 
 
 def __check_layer_type__(layer):
-    if not isinstance(layer, v2_layer.LayerV2):
+    if not isinstance(layer, layer.LayerV2):
         raise ValueError('layer should have type paddle.layer.Layer')


### PR DESCRIPTION
Fixes https://github.com/PaddlePaddle/Paddle/issues/1730

So I can use the Bash script in above issue to visualize module dependencies in a package.

The dependencies of paddle.v2 is as follows:

![a](https://cloud.githubusercontent.com/assets/1548775/24531794/10ead02e-15ee-11e7-80fd-30a077fe4db2.png)
