### PR TITLE
doc_cn mathjax_path 使用国内镜像以加快访问速度

### DIFF
--- a/doc/templates/conf.py.cn.in
+++ b/doc/templates/conf.py.cn.in
@@ -55,6 +55,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.graphviz'
 ]
+mathjax_path="https://cdn.bootcss.com/mathjax/2.7.0/MathJax.js"
 table_styling_embed_css = True
 
 autodoc_member_order = 'bysource'


### PR DESCRIPTION
solve #1733

默认js路径初次加载需要10秒左右
![image](https://cloud.githubusercontent.com/assets/11692045/24648260/aaa0b7a0-1955-11e7-9a1f-df76f39a7258.png)

国内镜像需要 100毫秒左右，这个速度可以接受。
![image](https://cloud.githubusercontent.com/assets/11692045/24648276/b769f64a-1955-11e7-87df-5b3fabb1ddd0.png)
