### PR TITLE
fix parameter shape in v2

### DIFF
--- a/python/paddle/v2/parameters.py
+++ b/python/paddle/v2/parameters.py
@@ -159,7 +159,8 @@ class Parameters(object):
         if not self.has_key(key):
             raise ValueError("No such parameter %s" % key)
         conf = self.__param_conf__[key]
-        return tuple(map(int, conf.dims))
+        dims = conf.dims if conf.dims else (1, conf.size)
+        return tuple(map(int, dims))
 
     def __setitem__(self, key, value):
         """


### PR DESCRIPTION
relate book [#265](https://github.com/PaddlePaddle/book/issues/265)

一些Layer在config_parse.py里没有设置parameter的dims，比如conv层，直接获取conf.dims会导致为空。

fix方案1： 在config_parse.py里对这些Layer加上dims。
fix方案2：用(1, conf.size)代替dims。

考虑到重构，采用方案2。
