### PR TITLE
fix a bug of AgentLayer

### DIFF
--- a/paddle/gserver/layers/AgentLayer.cpp
+++ b/paddle/gserver/layers/AgentLayer.cpp
@@ -42,7 +42,8 @@ void AgentLayer::forward(PassType passType) {
   // get Arguments from real layers
   if (numSamples_ > 0 && numSamples_ < realHeight) {
     if (realOutput.ids) {
-      output_.ids->subVecFrom(*realOutput.ids, 0, numSamples_);
+      output_.ids =
+          IVector::create(realOutput.ids->getData(), numSamples_, useGpu_);
     } else {
       output_.subArgFrom(
           realOutput, /* offset */ 0, numSamples_, getSize(), useGpu_);


### PR DESCRIPTION
1.  在RecurrentLayerGroup中使用 Scheduled Sampling 训练，每个时间步需要有一个 memory ，对应了AgentLayer，用来记录模型预测出来的下一个词。这个 memory 引用 MaxId Layer 的输出，MaxId Layer 的输出放在 Argument.ids 中。

2. 原来调用 subVecFrom 这个函数会出core：
     - 不论是训练还是生成，AgentLayer 都不需要考虑重组batch；
     - AgentLayer 不存储数据，只是一个指针指向一个 real layer，从这个 real layer 的输出中截取连续的一段内存。当RecurrentLayerGroup forward batch size 改变时，AgentLayer 没有其它Layer中的resetOutput这个操作，output_ .ids->subVecFrom 会出 core。

3. 训练和生成均测试过。