### PR TITLE
support multi-field for inference

### DIFF
--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -41,17 +41,20 @@ class Inference(object):
             yield [each_result[field] for each_result in result]
 
     def infer(self, field='value', **kwargs):
-        retv = None
-        for result in self.iter_infer_field(field=field, **kwargs):
-            if retv is None:
-                retv = [[]] * len(result)
-            for i, item in enumerate(result):
-                retv[i].append(item)
-        retv = [numpy.concatenate(out) for out in retv]
-        if len(retv) == 1:
-            return retv[0]
-        else:
-            return retv
+        if not isinstance(field, list) and not isinstance(field, tuple):
+            field = [field]
+
+        retv_list = []
+        for each_field in field:
+            retv = None
+            for result in self.iter_infer_field(field=each_field, **kwargs):
+                if retv is None:
+                    retv = [[]] * len(result)
+                for i, item in enumerate(result):
+                    retv[i].append(item)
+            retv = [numpy.concatenate(out) for out in retv]
+            retv_list.append(retv[0] if len(retv) == 1 else retv)
+        return retv_list[0] if len(retv_list) == 1 else retv_list
 
 
 def infer(output_layer, parameters, input, feeding=None, field='value'):

--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -38,23 +38,26 @@ class Inference(object):
 
     def iter_infer_field(self, field, **kwargs):
         for result in self.iter_infer(**kwargs):
-            yield [each_result[field] for each_result in result]
+            yield [
+                each_result[each_field]
+                for each_result in result for each_field in field
+            ]
 
     def infer(self, field='value', **kwargs):
         if not isinstance(field, list) and not isinstance(field, tuple):
             field = [field]
 
-        retv_list = []
-        for each_field in field:
-            retv = None
-            for result in self.iter_infer_field(field=each_field, **kwargs):
-                if retv is None:
-                    retv = [[]] * len(result)
-                for i, item in enumerate(result):
-                    retv[i].append(item)
-            retv = [numpy.concatenate(out) for out in retv]
-            retv_list.append(retv[0] if len(retv) == 1 else retv)
-        return retv_list[0] if len(retv_list) == 1 else retv_list
+        retv = None
+        for result in self.iter_infer_field(field=field, **kwargs):
+            if retv is None:
+                retv = [[]] * len(result)
+            for i, item in enumerate(result):
+                retv[i].append(item)
+        retv = [numpy.concatenate(out) for out in retv]
+        if len(retv) == 1:
+            return retv[0]
+        else:
+            return retv
 
 
 def infer(output_layer, parameters, input, feeding=None, field='value'):

--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -37,16 +37,15 @@ class Inference(object):
         self.__gradient_machine__.finish()
 
     def iter_infer_field(self, field, **kwargs):
-        for result in self.iter_infer(**kwargs):
-            yield [
-                each_result[each_field]
-                for each_result in result for each_field in field
-            ]
-
-    def infer(self, field='value', **kwargs):
         if not isinstance(field, list) and not isinstance(field, tuple):
             field = [field]
 
+        for result in self.iter_infer(**kwargs):
+            for each_result in result:
+                item = [each_result[each_field] for each_field in field]
+                yield item
+
+    def infer(self, field='value', **kwargs):
         retv = None
         for result in self.iter_infer_field(field=field, **kwargs):
             if retv is None:


### PR DESCRIPTION
支持infer接口中field参数可以多个，即接受list输入。如在机器翻译生成的时候：
```
gen_result=paddle.infer(
    output_layer=beam_gen,
    parameters=parameters,
    input=gen_data, 
    field=['id', 'value'])
```
需要获得概率value和最大预测的词id，需要两个输出。原来只能返回一个field。