### PR TITLE
add field "prob" in paddle.infer

### DIFF
--- a/paddle/py_paddle/util.py
+++ b/paddle/py_paddle/util.py
@@ -83,13 +83,17 @@ def __arguments_to_numpy__(i, arg):
     assert isinstance(arg, swig_paddle.Arguments)
     value = arg.getSlotValue(i)
     ids = arg.getSlotIds(i)
+    prob = arg.getSlotIn(i)
     if value is not None:
         assert isinstance(value, swig_paddle.Matrix)
         value = value.copyToNumpyMat()
     if ids is not None:
         assert isinstance(ids, swig_paddle.IVector)
         ids = ids.copyToNumpyArray()
-    return {"value": value, "id": ids}
+    if prob is not None:
+        assert isinstance(prob, swig_paddle.Matrix)
+        prob = prob.copyToNumpyMat()
+    return {"value": value, "id": ids, "prob": prob}
 
 
 def __monkeypatch_gradient_machine__():

--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -81,9 +81,11 @@ def infer(output_layer, parameters, input, feeding=None, field='value'):
     :type input: collections.Iterable
     :param feeding: Reader dictionary. Default could generate from input
                         value.
-    :param field: The prediction field. It should in [`value`, `ids`]. `value`
-                  means return the prediction probabilities, `ids` means return
-                  the prediction labels. Default is `value`
+    :param field: The prediction field. It should in [`value`, `id`, `prob`]. 
+                  `value` and `prob` mean return the prediction probabilities, 
+                  `id` means return the prediction labels. Default is `value`.
+                  Note that `prob` only used when output_layer is beam_search 
+                  or max_id.
     :type field: str
     :return: a numpy array
     :rtype: numpy.ndarray


### PR DESCRIPTION
1. 增加paddle.infer接口中field的取值范围，在原来的"value", "id"上，另增加一个“prob”，用于beam_search和max_id的概率预测，即取出MaxIdLayer中的output_.in。
2. 对应修改inference.py中的注释。

另外，“prob”和“value”之后可以都统一为“value”，需要修改RecurrentGradientMachine和AgentLayer的相关代码，因此会在以后的PR中完成。
