### PR TITLE
fix bug in inference.py

### DIFF
--- a/python/paddle/v2/inference.py
+++ b/python/paddle/v2/inference.py
@@ -49,7 +49,7 @@ class Inference(object):
         retv = None
         for result in self.iter_infer_field(field=field, **kwargs):
             if retv is None:
-                retv = [[]] * len(result)
+                retv = [[] for i in xrange(len(result))]
             for i, item in enumerate(result):
                 retv[i].append(item)
         retv = [numpy.concatenate(out) for out in retv]


### PR DESCRIPTION
`retv = [[]] * len(result)`使用python的[]作为引用传递，会导致：
<img width="684" alt="14646bddb0decd7f159f932c35dd42c0" src="https://cloud.githubusercontent.com/assets/6836917/25081532/83016e42-237d-11e7-9136-9a8ccd9299ff.PNG">
即其中实际上只有一个值。因此对其进行修改。