### PR TITLE
fix build error with clang

### DIFF
--- a/paddle/gserver/gradientmachines/GradientMachine.h
+++ b/paddle/gserver/gradientmachines/GradientMachine.h
@@ -134,9 +134,7 @@ public:
     backward(callback);
   }
 
-  virtual Argument getLayerOutput(const std::string& layerName) {
-    return *((Argument*)nullptr);
-  }
+  virtual Argument getLayerOutput(const std::string& layerName) = 0;
 
   // see comment in Layer.h for the function with the same name
   virtual void resetState() {}


### PR DESCRIPTION
Previous codes build with clang will cause error: "binding dereferenced null pointer to reference has undefined behavior". It's better to change the virtual method to pure virtual method.