### PR TITLE
Fix Production Docker Image's mirror settings.

### DIFF
--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -75,9 +75,8 @@ fi
 
 paddle version
 
-# generate production docker image Dockerfile
-if [ ${USE_MIRROR} ]; then
-  MIRROR_UPDATE="sed 's@http:\/\/archive.ubuntu.com\/ubuntu\/@mirror:\/\/mirrors.ubuntu.com\/mirrors.txt@' -i /etc/apt/sources.list && \\"
+if [[ -n ${APT_MIRROR} ]]; then
+  MIRROR_UPDATE="sed -i '${APT_MIRROR}' /etc/apt/sources.list && \\"
 else
   MIRROR_UPDATE="\\"
 fi


### PR DESCRIPTION
修改Production Image的Mirror环境变量为 `APT_MIRROR`。用户可以直接修改sed参数。

原因是，目前用的`Python-slim` image是一个Debian Image。。。而GPU的 image是一个ubuntu image。他们的源并不一样。