### PR TITLE
Strange usage for decompress gzip file.

### DIFF
--- a/demo/mnist/data/get_mnist_data.sh
+++ b/demo/mnist/data/get_mnist_data.sh
@@ -12,7 +12,7 @@ for fname in train-images-idx3-ubyte train-labels-idx1-ubyte t10k-images-idx3-ub
 do
     if [ ! -e $fname ]; then
         wget --no-check-certificate http://yann.lecun.com/exdb/mnist/${fname}.gz
-        gunzip ${fname}.gz
+        gzip -d ${fname}.gz
     fi
 done
 


### PR DESCRIPTION
* Change `gunzip` to `gzip -d`, because `gunzip` cannot be found in
  many linux distro.