### PR TITLE
Fix bug in protobuf.

### DIFF
--- a/paddle/setup.py.in
+++ b/paddle/setup.py.in
@@ -23,7 +23,7 @@ setup(name="py_paddle",
       install_requires = [
         'nltk>=3.2.2',
         'numpy>=1.8.0',      # The numpy is required.
-        'protobuf>=${PROTOBUF_VERSION}'    # The paddle protobuf version
+        'protobuf==${PROTOBUF_VERSION}'    # The paddle protobuf version
       ],
       url='http://www.paddlepaddle.org/',
       license='Apache 2.0',

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -16,7 +16,7 @@ setup(name='paddle',
       packages=packages,
       install_requires=[
           "numpy",
-          "protobuf==3.1.0",
+          "protobuf==${PROTOBUF_VERSION}",
           "matplotlib",
       ],
       package_dir={


### PR DESCRIPTION
Currently, Paddle only support Python use the sample version of
Protobuf that CPP do.

Fix #1875