### PR TITLE
v2 api print network graph only one times by default

### DIFF
--- a/python/paddle/trainer_config_helpers/networks.py
+++ b/python/paddle/trainer_config_helpers/networks.py
@@ -1397,13 +1397,15 @@ def inputs(layers, *args):
     Inputs(*[l.name for l in layers])
 
 
-def outputs(layers, *args):
+def outputs(layers, debug=True, *args):
     """
     Declare the outputs of network. If user have not defined the inputs of
     network, this method will calculate the input order by dfs travel.
 
     :param layers: Output layers.
     :type layers: list|tuple|LayerOutput
+    :param debug: The debug switch for printing input/output order.
+    :type debug: bool
     :return:
     """
 
@@ -1469,13 +1471,16 @@ def outputs(layers, *args):
         if each_output.name not in final_outputs:
             final_outputs.append(each_output.name)
 
-    logger.info("".join(["The input order is [", ", ".join(final_inputs), "]"]))
+    if debug:
+        logger.info("".join(
+            ["The input order is [", ", ".join(final_inputs), "]"]))
 
     if len(final_outputs) == 0:
         final_outputs = map(lambda x: x.name, layers)
 
-    logger.info("".join(
-        ["The output order is [", ", ".join(final_outputs), "]"]))
+    if debug:
+        logger.info("".join(
+            ["The output order is [", ", ".join(final_outputs), "]"]))
 
     Inputs(*final_inputs)
     Outputs(*final_outputs)

--- a/python/paddle/v2/layer.py
+++ b/python/paddle/v2/layer.py
@@ -56,7 +56,7 @@ from config_base import Layer, __convert_to_v2__
 __all__ = ['parse_network', 'data']
 
 
-def parse_network(output_layers, extra_layers=None):
+def parse_network(output_layers, extra_layers=None, debug=True):
     """
     Parse all layers in the neural network graph and
     then generate a ModelConfig object.
@@ -71,6 +71,8 @@ def parse_network(output_layers, extra_layers=None):
     :param extra_layers: Some layers in the neural network graph are not in the
                          path of output_layers.
     :type extra_layers: Layer
+    :param debug: The debug switch for printing neural network graph.
+    :type debug: bool
     :return: A ModelConfig object instance.
     :rtype: ModelConfig
     """
@@ -91,7 +93,7 @@ def parse_network(output_layers, extra_layers=None):
             extra_output = [
                 each.to_proto(context=context) for each in extra_layers
             ]
-        conf_helps.outputs(real_output)
+        conf_helps.outputs(real_output, debug=debug)
 
     return __parse__(__real_func__)
 

--- a/python/paddle/v2/parameters.py
+++ b/python/paddle/v2/parameters.py
@@ -16,7 +16,7 @@ def create(layers):
     :param layers:
     :return:
     """
-    topology = Topology(layers)
+    topology = Topology(layers, debug=False)  # do not print topology
     pool = Parameters()
     for param in topology.proto().parameters:
         pool.__append_config__(param)

--- a/python/paddle/v2/topology.py
+++ b/python/paddle/v2/topology.py
@@ -51,7 +51,7 @@ class Topology(object):
     and network configs.
     """
 
-    def __init__(self, layers, extra_layers=None):
+    def __init__(self, layers, extra_layers=None, debug=True):
         def __check__(layers):
             if not isinstance(layers, collections.Sequence):
                 __check_layer_type__(layers)
@@ -66,7 +66,7 @@ class Topology(object):
             extra_layers = __check__(extra_layers)
 
         self.__model_config__ = v2_layer.parse_network(
-            layers, extra_layers=extra_layers)
+            layers, extra_layers=extra_layers, debug=debug)
 
         if extra_layers is not None:
             self.layers.extend(extra_layers)


### PR DESCRIPTION
Fix #1708 
将parameters.create解析网络配置时的打印开关，默认情况下设为False。
即只有在trainer.train解析网络配置时，会打印网络结构。

使用book中的例子验证过，只打印出一次配置。