### PR TITLE
Fix document search in sphinx

### DIFF
--- a/doc_theme/templates/layout.html
+++ b/doc_theme/templates/layout.html
@@ -168,7 +168,8 @@
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            HAS_SOURCE:  {{ has_source|lower }},
+            SOURCELINK_SUFFIX: ".txt",
         };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
* It because we using a old version of theme, but sphinx is up to date.
Manually add field in layout.html.

* Fix #1904