### PR TITLE
Submit Paddle Job with v2 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ third_party/
 *~
 bazel-*
 third_party/
+
+*pyc

--- a/demo/word2vec/cloud/api_train_v2.py
+++ b/demo/word2vec/cloud/api_train_v2.py
@@ -33,7 +33,9 @@ def dist_train(trainer,
         #submit distributed training job
         job_manager = JobManager(paddle_job)
         if not job_manager.submit():
-            print "paddle job sumit failed."
+            print "submit paddle job failed."
+        else:
+            print "submit paddle job successed."
     else:
         trainer.train(
             reader=reader,

--- a/demo/word2vec/cloud/api_train_v2.py
+++ b/demo/word2vec/cloud/api_train_v2.py
@@ -1,0 +1,148 @@
+import gzip
+import math
+
+import paddle.v2 as paddle
+
+from job.job_manager import JobManager, PaddleJob
+import os
+embsize = 32
+hiddensize = 256
+N = 5
+
+
+def wordemb(inlayer):
+    wordemb = paddle.layer.embedding(
+        input=inlayer,
+        size=embsize,
+        param_attr=paddle.attr.Param(
+            name="_proj",
+            initial_std=0.001,
+            learning_rate=1,
+            l2_rate=0,
+            sparse_update=True))
+    return wordemb
+
+
+def dist_train(trainer,
+               reader,
+               num_passes=1,
+               event_handler=None,
+               feeding=None,
+               paddle_job=None):
+    if os.getenv("PADDLE_NOTEBOOK", "NO") == "YES":
+        #submit distributed training job
+        job_manager = JobManager(paddle_job)
+        if not job_manager.submit():
+            print "paddle job sumit failed."
+    else:
+        trainer.train(
+            reader=reader,
+            num_passes=num_passes,
+            event_handler=event_handler,
+            feeding=feeding)
+
+
+def fetch_trainer_id():
+    return int(os.getenv("TRAINER_ID", 0))
+
+
+def fetch_pserver_ips():
+    return os.getenv("PSERVER_IPS", "")
+
+
+def main():
+    # for local training
+    cluster_train = True
+
+    if not cluster_train:
+        paddle.init(use_gpu=False, trainer_count=1)
+    else:
+        paddle.init(
+            use_gpu=False,
+            trainer_count=1,
+            port=7164,
+            ports_num=1,
+            ports_num_for_sparse=1,
+            num_gradient_servers=1,
+            trainer_id=fetch_trainer_id(),
+            pservers=fetch_pserver_ips())
+    word_dict = paddle.dataset.imikolov.build_dict()
+    dict_size = len(word_dict)
+    firstword = paddle.layer.data(
+        name="firstw", type=paddle.data_type.integer_value(dict_size))
+    secondword = paddle.layer.data(
+        name="secondw", type=paddle.data_type.integer_value(dict_size))
+    thirdword = paddle.layer.data(
+        name="thirdw", type=paddle.data_type.integer_value(dict_size))
+    fourthword = paddle.layer.data(
+        name="fourthw", type=paddle.data_type.integer_value(dict_size))
+    nextword = paddle.layer.data(
+        name="fifthw", type=paddle.data_type.integer_value(dict_size))
+
+    Efirst = wordemb(firstword)
+    Esecond = wordemb(secondword)
+    Ethird = wordemb(thirdword)
+    Efourth = wordemb(fourthword)
+
+    contextemb = paddle.layer.concat(input=[Efirst, Esecond, Ethird, Efourth])
+    hidden1 = paddle.layer.fc(input=contextemb,
+                              size=hiddensize,
+                              act=paddle.activation.Sigmoid(),
+                              layer_attr=paddle.attr.Extra(drop_rate=0.5),
+                              bias_attr=paddle.attr.Param(learning_rate=2),
+                              param_attr=paddle.attr.Param(
+                                  initial_std=1. / math.sqrt(embsize * 8),
+                                  learning_rate=1))
+    predictword = paddle.layer.fc(input=hidden1,
+                                  size=dict_size,
+                                  bias_attr=paddle.attr.Param(learning_rate=2),
+                                  act=paddle.activation.Softmax())
+
+    def event_handler(event):
+        if isinstance(event, paddle.event.EndIteration):
+            if event.batch_id % 100 == 0:
+                with gzip.open("batch-" + str(event.batch_id) + ".tar.gz",
+                               'w') as f:
+                    trainer.save_parameter_to_tar(f)
+                result = trainer.test(
+                    paddle.batch(
+                        paddle.dataset.imikolov.test(word_dict, N), 32))
+                print "Pass %d, Batch %d, Cost %f, %s, Testing metrics %s" % (
+                    event.pass_id, event.batch_id, event.cost, event.metrics,
+                    result.metrics)
+
+    cost = paddle.layer.classification_cost(input=predictword, label=nextword)
+
+    parameters = paddle.parameters.create(cost)
+    adagrad = paddle.optimizer.AdaGrad(
+        learning_rate=3e-3,
+        regularization=paddle.optimizer.L2Regularization(8e-4))
+    trainer = paddle.trainer.SGD(cost,
+                                 parameters,
+                                 adagrad,
+                                 is_local=not cluster_train)
+    dist_train(
+        trainer=trainer,
+        reader=paddle.batch(paddle.dataset.imikolov.train(word_dict, N), 32),
+        num_passes=30,
+        event_handler=event_handler,
+        paddle_job=PaddleJob(
+            trainers=3,
+            pservers=3,
+            base_image="yancey1989/paddle-cloud",
+            glusterfs_volume="gfs_vol",
+            input="/yanxu05",
+            output="/yanxu05",
+            job_name="paddle-cloud",
+            namespace="yanxu",
+            use_gpu=False,
+            port=7164,
+            ports_num=1,
+            ports_num_for_sparse=1,
+            num_gradient_servers=1,
+            trainer_package_path="/yanxu05/word2vec",
+            entry_point="python api_train_v2.py"))
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/word2vec/cloud/base-image/Dockerfile
+++ b/demo/word2vec/cloud/base-image/Dockerfile
@@ -1,0 +1,5 @@
+FROM yancey1989/paddle:0.10.0rc4
+RUN pip install kubernetes
+ADD ./paddle_k8s /usr/bin
+ADD ./k8s_tools.py /root/
+CMD ["paddle_k8s"]

--- a/demo/word2vec/cloud/base-image/k8s_tools.py
+++ b/demo/word2vec/cloud/base-image/k8s_tools.py
@@ -1,0 +1,64 @@
+#!/bin/env python
+import os
+import sys
+import time
+import socket
+from kubernetes import client, config
+PADDLE_JOB_NAME = os.getenv("PADDLE_JOB_NAME")
+NAMESPACE = os.getenv("NAMESPACE")
+PORT = os.getenv("PSERVER_PORT")
+if os.getenv("KUBERNETES_SERVICE_HOST", None):
+    config.load_incluster_config()
+else:
+    config.load_kube_config()
+v1 = client.CoreV1Api()
+
+
+def fetch_pods_info(label_selector):
+    api_response = v1.list_namespaced_pod(
+        namespace=NAMESPACE, pretty=True, label_selector=label_selector)
+    pod_list = []
+    for item in api_response.items:
+        pod_list.append((item.status.phase, item.status.pod_ip))
+    return pod_list
+
+
+def wait_pods_running(label_selector, num):
+    print "label selector: %s, num: %s" % (label_selector, num)
+    while True:
+        pod_list = fetch_pods_info(label_selector)
+        running_pod_list = filter(lambda x: x[0] == "Running", pod_list)
+        print "running pod list: ", running_pod_list
+        if len(running_pod_list) == int(num):
+            return [item[1] for item in running_pod_list]
+        print "sleep for 10 seconds..."
+        time.sleep(10)
+
+
+def fetch_pserver_ips():
+    label_selector = "paddle-job=%s-pserver" % PADDLE_JOB_NAME
+    pod_list = fetch_pods_info(label_selector)
+    pserver_ips = [item[1] for item in pod_list]
+    return ",".join(pserver_ips)
+
+
+def fetch_trainer_id():
+    label_selector = "paddle-job=%s-trainer" % PADDLE_JOB_NAME
+    pod_list = fetch_pods_info(label_selector)
+    trainer_ips = [item[1] for item in pod_list]
+    trainer_ips.sort()
+    local_ip = socket.gethostbyname(socket.gethostname())
+    for i in xrange(len(trainer_ips)):
+        if trainer_ips[i] == local_ip:
+            return i
+    return None
+
+
+if __name__ == "__main__":
+    command = sys.argv[1]
+    if command == "fetch_pserver_ips":
+        print fetch_pserver_ips()
+    elif command == "fetch_trainer_id":
+        print fetch_trainer_id()
+    elif command == "wait_pods_running":
+        wait_pods_running(sys.argv[2], sys.argv[3])

--- a/demo/word2vec/cloud/base-image/paddle_k8s
+++ b/demo/word2vec/cloud/base-image/paddle_k8s
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+start_pserver() {
+    paddle pserver \
+      --port=$PORT \
+      --ports_num=$PORTS_NUM \
+      --ports_num_for_sparse=$PORTS_NUM_FOR_SPARSE \
+      --nics=$NICES \
+      --comment=paddle_process_k8s \
+      --num_gradient_servers=$NUM_GRADIENT_SERVERS
+}
+
+start_trainer() {
+    python /root/k8s_tools.py wait_pods_running paddle-job=${PADDLE_JOB_NAME}-pserver ${PSERVERS}
+    python /root/k8s_tools.py wait_pods_running paddle-job=${PADDLE_JOB_NAME}-trainer ${TRAINERS}
+    export PSERVER_IPS=$(python /root/k8s_tools.py fetch_pserver_ips)
+    export TRAINER_ID=$(python /root/k8s_tools.py fetch_trainer_id)
+
+    rm -rf /root/trainer
+    cp -rf $TRAINER_PACKAGE_PATH /root/trainer
+    cd /root/trainer
+    export PYTHONPATH=/root/trainer:$PYTHONPATH
+    ${ENTRY_POINT}
+}
+
+usage() {
+    echo "usage: paddle_k8s [<args>]:"
+    echo "  start_trainer     Start a trainer process"
+    echo "  start_pserver     Start a pserver process"
+}
+
+case "$1" in
+    start_pserver)
+        start_pserver
+        ;;
+    start_trainer)
+        start_trainer
+        ;;
+    --help)
+        usage
+        ;;
+    *)
+        usage
+        ;;
+esac

--- a/demo/word2vec/cloud/job/__init__.py
+++ b/demo/word2vec/cloud/job/__init__.py
@@ -1,0 +1,4 @@
+import job_manager
+import paddle_job
+
+__all__ = ["job_manager", "paddle_job"]

--- a/demo/word2vec/cloud/job/job_manager.py
+++ b/demo/word2vec/cloud/job/job_manager.py
@@ -22,7 +22,7 @@ class JobManager(object):
         try:
             ret = client.AppsV1beta1Api().create_namespaced_stateful_set(
                 namespace=NAMESPACE,
-                body=paddle_job.new_pserver_job(),
+                body=self.paddle_job.new_pserver_job(),
                 pretty=True)
         except ApiException, e:
             print "Exception when submit pserver job: %s " % e
@@ -32,7 +32,7 @@ class JobManager(object):
         try:
             ret = client.BatchV1Api().create_namespaced_job(
                 namespace=NAMESPACE,
-                body=paddle_job.new_trainer_job(),
+                body=self.paddle_job.new_trainer_job(),
                 pretty=True)
         except ApiException, e:
             print "Exception when submit trainer job: %s" % e

--- a/demo/word2vec/cloud/job/job_manager.py
+++ b/demo/word2vec/cloud/job/job_manager.py
@@ -1,0 +1,61 @@
+import os
+from paddle_job import PaddleJob
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+__all__ = ["JobManager"]
+
+if os.getenv("KUBERNETES_SERVICE_HOST", None):
+    config.load_incluster_config()
+else:
+    config.load_kube_config()
+
+NAMESPACE = os.getenv("NAMESPACE", "yanxu")
+
+
+class JobManager(object):
+    def __init__(self, paddle_job):
+        self.paddle_job = paddle_job
+
+    def submit(self):
+        #submit parameter server statefulset
+        try:
+            ret = client.AppsV1beta1Api().create_namespaced_stateful_set(
+                namespace=NAMESPACE,
+                body=paddle_job.new_pserver_job(),
+                pretty=True)
+        except ApiException, e:
+            print "Exception when submit pserver job: %s " % e
+            return False
+
+        #submit trainer job
+        try:
+            ret = client.BatchV1Api().create_namespaced_job(
+                namespace=NAMESPACE,
+                body=paddle_job.new_trainer_job(),
+                pretty=True)
+        except ApiException, e:
+            print "Exception when submit trainer job: %s" % e
+            return False
+        return True
+
+
+if __name__ == "__main__":
+    paddle_job = PaddleJob(
+        trainers=3,
+        pservers=3,
+        base_image="yancey1989/paddle-cloud",
+        glusterfs_volume="gfs_vol",
+        input="/yanxu05",
+        output="/yanxu05",
+        job_name="paddle-cloud",
+        namespace="yanxu",
+        use_gpu=False,
+        port=7164,
+        ports_num=1,
+        ports_num_for_sparse=1,
+        num_gradient_servers=1,
+        trainer_package_path="/yanxu05/word2vec",
+        entry_point="python api_train_v2.py")
+    jm = JobManager(paddle_job)
+    jm.submit()

--- a/demo/word2vec/cloud/job/paddle_job.py
+++ b/demo/word2vec/cloud/job/paddle_job.py
@@ -1,0 +1,172 @@
+import kubernetes
+from kubernetes import client, config
+import os
+
+__all__ = ["PaddleJob"]
+
+## kubernetes default configuration
+DEFAULT_GLUSTERFS_ENDPOINT = "glusterfs-cluster"
+GLUSTERFS_MOUNT_PATH = "/mnt/glusterfs"
+
+
+class PaddleJob(object):
+    """
+        PaddleJob
+    """
+
+    def __init__(self,
+                 trainers,
+                 pservers,
+                 base_image,
+                 glusterfs_volume,
+                 input,
+                 output,
+                 job_name,
+                 trainer_package_path,
+                 entry_point,
+                 namespace="default",
+                 use_gpu=False,
+                 num_gradient_servers=1,
+                 port=7164,
+                 ports_num=1,
+                 ports_num_for_sparse=1,
+                 env={}):
+        self.trainers = trainers
+        self.pservers = pservers
+        self.base_iamge = base_image
+        self.glusterfs_volume = glusterfs_volume
+        self.input = input
+        self.output = output
+        self.job_name = job_name
+        self.namespace = namespace
+        self.ports_num = ports_num
+        self.ports_num_for_sparse = ports_num_for_sparse
+        self.port = port
+        self.user_env = env
+        self.use_gpu = use_gpu
+        self.trainer_package_path = trainer_package_path
+        self.entry_point = entry_point
+        self.num_gradient_servers = num_gradient_servers
+
+    def get_pserver_job_name(self):
+        return "%s-pserver" % self.job_name
+
+    def get_trainer_job_name(self):
+        return "%s-trainer" % self.job_name
+
+    def get_env(self):
+        envs = []
+        for k, v in self.user_env.items():
+            env = client.V1EnvVar()
+            env.name = k
+            env.value = v
+            envs.append(env)
+        envs.append(
+            client.V1EnvVar(
+                name="PADDLE_JOB_NAME", value=self.job_name))
+        envs.append(client.V1EnvVar(name="INPUT", value=self.input))
+        envs.append(client.V1EnvVar(name="PORT", value=str(self.port)))
+        envs.append(client.V1EnvVar(name="TRAINERS", value=str(self.trainers)))
+        envs.append(client.V1EnvVar(name="PSERVERS", value=str(self.pservers)))
+        envs.append(
+            client.V1EnvVar(
+                name="PORTS_NUM", value=str(self.ports_num)))
+        envs.append(
+            client.V1EnvVar(
+                name="PORTS_NUM_FOR_SPARSE",
+                value=str(self.ports_num_for_sparse)))
+        envs.append(
+            client.V1EnvVar(
+                name="NUM_GRADIENT_SERVERS",
+                value=str(self.num_gradient_servers)))
+        envs.append(client.V1EnvVar(name="OUTPUT", value=self.output))
+        envs.append(client.V1EnvVar(name="ENTRY_POINT", value=self.entry_point))
+        envs.append(
+            client.V1EnvVar(
+                name="TRAINER_PACKAGE_PATH",
+                value=os.path.join(GLUSTERFS_MOUNT_PATH,
+                                   self.trainer_package_path.lstrip("/"))))
+        envs.append(
+            client.V1EnvVar(
+                name="NAMESPACE",
+                value_from=client.V1EnvVarSource(
+                    field_ref=client.V1ObjectFieldSelector(
+                        field_path="metadata.namespace"))))
+        return envs
+
+    def get_pserver_container_ports(self):
+        ports = []
+        port = self.port
+        for i in xrange(self.ports_num + self.ports_num_for_sparse):
+            ports.append(
+                client.V1ContainerPort(
+                    container_port=port, name="jobport-%d" % i))
+            port += 1
+        return ports
+
+    def get_pserver_labels(self):
+        return {"paddle-job": self.get_pserver_job_name()}
+
+    def get_pserver_entrypoint(self):
+        return ["paddle_k8s", "start_pserver"]
+
+    def get_trainer_entrypoint(sefl):
+        return ["paddle_k8s", "start_trainer"]
+
+    def get_trainer_labels(self):
+        return {"paddle-job": self.get_trainer_job_name()}
+
+    def get_runtime_docker_image_name(self):
+        #TODO: use runtime docker image
+        return self.base_iamge
+        #return "%s-%s:latest" % (self.namespace, self.job_name)
+
+    def new_pserver_job(self):
+        return client.V1beta1StatefulSet(
+            metadata=client.V1ObjectMeta(name=self.get_pserver_job_name()),
+            spec=client.V1beta1StatefulSetSpec(
+                service_name=self.get_pserver_job_name(),
+                replicas=self.pservers,
+                template=client.V1PodTemplateSpec(
+                    metadata=client.V1ObjectMeta(
+                        labels=self.get_pserver_labels()),
+                    spec=client.V1PodSpec(containers=[
+                        client.V1Container(
+                            name=self.get_pserver_job_name(),
+                            image=self.get_runtime_docker_image_name(),
+                            ports=self.get_pserver_container_ports(),
+                            env=self.get_env(),
+                            command=self.get_pserver_entrypoint())
+                    ]))))
+
+    def new_trainer_job(self):
+        return client.V1Job(
+            metadata=client.V1ObjectMeta(name=self.get_trainer_job_name()),
+            spec=client.V1JobSpec(
+                parallelism=self.trainers,
+                completions=self.trainers,
+                template=client.V1PodTemplateSpec(
+                    metadata=client.V1ObjectMeta(
+                        labels=self.get_trainer_labels()),
+                    spec=client.V1PodSpec(
+                        volumes=[
+                            client.V1Volume(
+                                name="glusterfsvol",
+                                glusterfs=client.V1GlusterfsVolumeSource(
+                                    endpoints=DEFAULT_GLUSTERFS_ENDPOINT,
+                                    path=self.glusterfs_volume))
+                        ],
+                        containers=[
+                            client.V1Container(
+                                name="trainer",
+                                image=self.get_runtime_docker_image_name(),
+                                image_pull_policy="Always",
+                                command=self.get_trainer_entrypoint(),
+                                env=self.get_env(),
+                                volume_mounts=[
+                                    client.V1VolumeMount(
+                                        mount_path=GLUSTERFS_MOUNT_PATH,
+                                        name="glusterfsvol")
+                                ])
+                        ],
+                        restart_policy="Never"))))


### PR DESCRIPTION
测试方法：
1. 拷贝目录`demo/word2vec/cloud`->`/yanxu05/word2vec/`
```
/yanxu05/word2vec/
    |-api_train_v2.py
    `-job
        |-paddle_job.py
        ...
```
1. 本地模拟Notebook中的提交过程:
```bash
docker run -it -v $PWD:/paddle -v ~/.kube/config:/root/.kube/config yancey1989/paddle-cloud /bin/bash`
cd /paddle
PADDLE_NOTEBOOK=YES python api_train_v2.py
```

另外：`base-image`目录中的脚本为保证跑通流程临时写的`服务发现`,`获取trainerid`等功能，后续会移植到trainer中。

TODO:
- 支持提交GPU任务
- 使用tls认证替换现在`service_account`认证方式