### PR TITLE
Fix build error in MacOS

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -109,7 +109,8 @@ set(COMMON_FLAGS
     -Wno-unused-function
     -Wno-error=literal-suffix
     -Wno-error=sign-compare
-    -Wno-error=unused-local-typedefs)
+    -Wno-error=unused-local-typedefs
+    -Wno-error=deprecated-declarations)
 
 set(GPU_COMMON_FLAGS
     -fPIC


### PR DESCRIPTION
* Because protobuf 3.1.0 uses a deprecated API.
* Partially fix issue #1936.