### PR TITLE
Fix protobuf.cmake to handle empty PROTOBUF_VERSION correctly

### DIFF
--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -1,11 +1,11 @@
 # Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
-# 
+#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,7 @@ FIND_PACKAGE(Protobuf ${PROTOBUF_VERSION})
 IF(PROTOBUF_FOUND)
     EXEC_PROGRAM(${PROTOBUF_PROTOC_EXECUTABLE} ARGS --version OUTPUT_VARIABLE PROTOBUF_VERSION)
     STRING(REGEX MATCH "[0-9]+.[0-9]+" PROTOBUF_VERSION "${PROTOBUF_VERSION}")
-    IF (${PROTOBUF_VERSION} VERSION_LESS "3.1.0")
+    IF ("${PROTOBUF_VERSION}" VERSION_LESS "3.1.0")
         SET(PROTOBUF_FOUND OFF)
     ENDIF()
 ENDIF(PROTOBUF_FOUND)


### PR DESCRIPTION
Sometime FIND_PACKAGE(ProtoBuf) get an empty PROTOBUF_VERSION. In this case, ${PROTOBUF_VERSION} needs to be quoted.