### PR TITLE
Avoid relink executables when cmake files are changed

### DIFF
--- a/cmake/make_resource.py
+++ b/cmake/make_resource.py
@@ -1,0 +1,11 @@
+import os
+import re
+import sys
+
+res = sys.argv[1]
+out = sys.argv[2]
+var = re.sub(r'[ .-]', '_', os.path.basename(res))
+
+open(out, "w").write("const unsigned char " + var + "[] = {" + ",".join([
+    "0x%02x" % ord(c) for c in open(res).read()
+]) + ",0};\n" + "const unsigned " + var + "_size = sizeof(" + var + ");\n")

--- a/cmake/util.cmake
+++ b/cmake/util.cmake
@@ -138,17 +138,9 @@ macro(add_simple_unittest TARGET_NAME)
 endmacro()
 
 # Creates C resources file from files in given resource file
-function(create_resources res_file output)
-    # Create empty output file
-    file(WRITE ${output} "")
-    # Get short filename
-    string(REGEX MATCH "([^/]+)$" filename ${res_file})
-    # Replace filename spaces & extension separator for C compatibility
-    string(REGEX REPLACE "\\.| |-" "_" filename ${filename})
-    # Read hex data from file
-    file(READ ${res_file} filedata HEX)
-    # Convert hex data for C compatibility
-    string(REGEX REPLACE "([0-9a-f][0-9a-f])" "0x\\1," filedata ${filedata})
-    # Append data to output file
-    file(APPEND ${output} "const unsigned char ${filename}[] = {${filedata}0};\nconst unsigned ${filename}_size = sizeof(${filename});\n")
+function(create_resources res_file output_file)
+  add_custom_command(
+    OUTPUT ${output_file}
+    COMMAND python ARGS ${PROJ_ROOT}/cmake/make_resource.py ${res_file} ${output_file}
+    DEPENDS ${res_file} ${PROJ_ROOT}/cmake/make_resource.py)
 endfunction()

--- a/paddle/scripts/submit_local.sh.in
+++ b/paddle/scripts/submit_local.sh.in
@@ -50,7 +50,7 @@ if [ -z "${PADDLE_NO_STAT+x}" ]; then
         -c ${PADDLE_CONF_HOME}/paddle.cookie \
         http://api.paddlepaddle.org/version 2>/dev/null`
     if [ $? -eq 0 ] && [ "$(ver2num @PADDLE_VERSION@)" -lt  $(ver2num $SERVER_VER) ]; then
-      echo "Paddle release a new version ${SERVER_VER}, you can get the install package in http://www.paddlepaddle.org" 
+      echo "Paddle release a new version ${SERVER_VER}, you can get the install package in http://www.paddlepaddle.org"
     fi
 fi
 
@@ -95,7 +95,7 @@ if [ $? -eq 1 ]; then  # Older version installed, or not installed at all
     echo "First time run paddle, need to install some python dependencies."
     # setuptools normalizes package version, so we need to use normalized
     # package version for paddle python package
-    PYTHON_PADDLE_VERSION=$(python -c 'import packaging
+    PYTHON_PADDLE_VERSION=$(python -c 'import packaging.version
 import setuptools
 print str(packaging.version.Version("@PADDLE_VERSION@"))
 ' 2>/dev/null)

--- a/paddle/utils/CMakeLists.txt
+++ b/paddle/utils/CMakeLists.txt
@@ -1,8 +1,9 @@
 # The utilities for paddle
 file(GLOB UTIL_HEADERS . *.h)
 file(GLOB UTIL_SOURCES . *.cpp)
-create_resources(enable_virtualenv.py enable_virtualenv.c)
-set(UTIL_RES enable_virtualenv.c)
+create_resources(${CMAKE_CURRENT_SOURCE_DIR}/enable_virtualenv.py
+  ${CMAKE_CURRENT_SOURCE_DIR}/enable_virtualenv.c)
+set(UTIL_RES ${CMAKE_CURRENT_SOURCE_DIR}/enable_virtualenv.c)
 
 if(APPLE)
     file(GLOB UTIL_ARCH_SOURCES . arch/osx/*.cpp)


### PR DESCRIPTION
In the original util.cmake. enable_virtualenv.c is always regenerated when cmake files are changed, which leads to the relinking of all the targets depends on paddle_utils.