### PR TITLE
paddle.init() default use env

### DIFF
--- a/python/paddle/v2/__init__.py
+++ b/python/paddle/v2/__init__.py
@@ -43,14 +43,15 @@ __all__ = [
 
 def init(**kwargs):
     args = []
+    args_dict = {}
     # NOTE: append arguments if they are in ENV
     for ek, ev in os.environ.iteritems():
-        if ek.startswith("PADDLE_"):
-            args.append('--%s=%s' % (ek.replace("PADDLE_", "").lower(),
-                                     str(ev)))
+        if ek.startswith("PADDLE_INIT_"):
+            args_dict[ek.replace("PADDLE_INIT_", "").lower()] = str(ev)
 
+    args_dict.update(kwargs)
     # NOTE: overwrite arguments from ENV if it is in kwargs
-    for key in kwargs.keys():
+    for key in args_dict.keys():
         args.append('--%s=%s' % (key, str(kwargs[key])))
 
     api.initPaddle(*args)

--- a/python/paddle/v2/__init__.py
+++ b/python/paddle/v2/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 import optimizer
 import layer
 import activation
@@ -42,6 +43,12 @@ __all__ = [
 
 def init(**kwargs):
     args = []
+    # NOTE: append arguments if they are in ENV
+    for ek, ev in os.environ.iteritems():
+        if ek.startswith("PADDLE_"):
+            args.append('--%s=%s' % (ek.replace("PADDLE_", "").lower(), str(ev)))
+
+    # NOTE: overwrite arguments from ENV if it is in kwargs
     for key in kwargs.keys():
         args.append('--%s=%s' % (key, str(kwargs[key])))
 

--- a/python/paddle/v2/__init__.py
+++ b/python/paddle/v2/__init__.py
@@ -46,7 +46,8 @@ def init(**kwargs):
     # NOTE: append arguments if they are in ENV
     for ek, ev in os.environ.iteritems():
         if ek.startswith("PADDLE_"):
-            args.append('--%s=%s' % (ek.replace("PADDLE_", "").lower(), str(ev)))
+            args.append('--%s=%s' % (ek.replace("PADDLE_", "").lower(),
+                                     str(ev)))
 
     # NOTE: overwrite arguments from ENV if it is in kwargs
     for key in kwargs.keys():


### PR DESCRIPTION
`paddle.init()` will use "PADDLE_*" environment variables to do the init. This will let cluster training jobs read arguments from environment variables which is provided by the cluster nodes.