### PR TITLE
Remove the feenableexcept in initPaddle.

### DIFF
--- a/paddle/capi/Main.cpp
+++ b/paddle/capi/Main.cpp
@@ -25,7 +25,6 @@ limitations under the License. */
 static void initPaddle(int argc, char** argv) {
   paddle::initMain(argc, argv);
   paddle::initPython(argc, argv);
-  feenableexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW);
 }
 
 extern "C" {


### PR DESCRIPTION
Fix #2024 
We should not decide whether to catch floating point exceptions in initPaddle.
And, for an application, if the result is wrong, it can be discarded, but first, the program can not crash.