### PR TITLE
Disable the finding of PythonLibs when WITH_PYTHON is set to OFF.

### DIFF
--- a/cmake/external/python.cmake
+++ b/cmake/external/python.cmake
@@ -16,11 +16,13 @@ INCLUDE(ExternalProject)
 INCLUDE(python_module)
 
 FIND_PACKAGE(PythonInterp 2.7)
-FIND_PACKAGE(PythonLibs 2.7)
+IF(WITH_PYTHON)
+    FIND_PACKAGE(PythonLibs 2.7)
+ENDIF(WITH_PYTHON)
 
 SET(py_env "")
 SET(USE_VIRTUALENV_FOR_TEST 1)
-IF(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
+IF(PYTHONINTERP_FOUND)
     find_python_module(pip REQUIRED)
     find_python_module(numpy REQUIRED)
     find_python_module(wheel REQUIRED)
@@ -30,7 +32,7 @@ IF(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
         MESSAGE(FATAL_ERROR "Found Python Protobuf ${PY_GOOGLE.PROTOBUF_VERSION} < 3.0.0, "
         "please use pip to upgrade protobuf. pip install -U protobuf")
     ENDIF()
-ELSE(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
+ELSE(PYTHONINTERP_FOUND)
     MESSAGE(FATAL_ERROR "Please install python 2.7 before building PaddlePaddle.")
     ##################################### PYTHON ########################################
     SET(PYTHON_SOURCES_DIR ${THIRD_PARTY_PATH}/python)
@@ -217,7 +219,7 @@ ELSE(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
 
     LIST(APPEND external_project_dependencies python setuptools six cython wheel python-protobuf numpy)
 
-ENDIF(PYTHONLIBS_FOUND AND PYTHONINTERP_FOUND)
+ENDIF(PYTHONINTERP_FOUND)
 
 IF(WITH_PYTHON)
     INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIR})


### PR DESCRIPTION
在`WITH_PYTHON=OFF`时，cmake最后将`PYTHON_LIBRARIES`置为空
```
IF(WITH_PYTHON)
     INCLUDE_DIRECTORIES(${PYTHON_INCLUDE_DIR})
     INCLUDE_DIRECTORIES(${PYTHON_NUMPY_INCLUDE_DIR})
ELSE()
     SET(PYTHON_LIBRARIES "")
ENDIF()
```
在一些有python二进制但没有libpython.so的环境cmake会出现error。
`WITH_PYTHON=OFF`时，实际没有必要寻找PythonLibs，这个PR主要修改是在`FIND_PACKAGE(PythonLibs 2.7)`前增加`IF(WITH_PYTHON)`的判断
```
IF(WITH_PYTHON)
     FIND_PACKAGE(PythonLibs 2.7)
ENDIF(WITH_PYTHON)
```