### PR TITLE
Expose more interfaces for Arguments in swig.

### DIFF
--- a/paddle/api/Arguments.cpp
+++ b/paddle/api/Arguments.cpp
@@ -151,4 +151,24 @@ int64_t Arguments::getBatchSize(size_t idx) const throw(RangeError) {
   return a.getBatchSize();
 }
 
+void Arguments::setSlotFrameHeight(size_t idx, size_t h) throw(RangeError) {
+  auto& a = m->getArg(idx);
+  a.setFrameHeight(h);
+}
+
+void Arguments::setSlotFrameWidth(size_t idx, size_t w) throw(RangeError) {
+  auto& a = m->getArg(idx);
+  a.setFrameWidth(w);
+}
+
+size_t Arguments::getSlotFrameHeight(size_t idx) const throw(RangeError) {
+  auto& a = m->getArg(idx);
+  return a.getFrameHeight();
+}
+
+size_t Arguments::getSlotFrameWidth(size_t idx) const throw(RangeError) {
+  auto& a = m->getArg(idx);
+  return a.getFrameWidth();
+}
+
 void* Arguments::getInternalArgumentsPtr() const { return &m->outputs; }

--- a/paddle/api/PaddleAPI.h
+++ b/paddle/api/PaddleAPI.h
@@ -454,6 +454,25 @@ public:
                                         IVector* vec) throw(RangeError);
   void setSlotSequenceDim(size_t idx, IVector* vec) throw(RangeError);
 
+  /**
+   * Set the frame height of the idx-th Argument.
+   *
+   * @param ids The index of which Argument.
+   * @param h The height value.
+   */
+  void setSlotFrameHeight(size_t idx, size_t h) throw(RangeError);
+
+  /**
+   * Set the frame height of the idx-th Argument.
+   *
+   * @param ids The index of which Argument.
+   * @param h The height value.
+   */
+  void setSlotFrameWidth(size_t idx, size_t w) throw(RangeError);
+
+  size_t getSlotFrameHeight(size_t idx = 0) const throw(RangeError);
+  size_t getSlotFrameWidth(size_t idx = 0) const throw(RangeError);
+
   float sum() const;
 
 private:

--- a/paddle/api/test/testArguments.py
+++ b/paddle/api/test/testArguments.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from py_paddle import swig_paddle
+import numpy as np
 import unittest
 
 
@@ -35,6 +36,17 @@ class TestArguments(unittest.TestCase):
         assert isinstance(iv, swig_paddle.IVector)
         np_arr = iv.toNumpyArrayInplace()
         self.assertEqual(np_arr.shape, (6, ))
+
+    def test_arguments_shape(self):
+        h, w = 4, 6
+        v = np.random.rand(2, h * w)
+        m = swig_paddle.Matrix.createDense(v.flatten(), 2, h * w)
+        args = swig_paddle.Arguments.createArguments(1)
+        args.setSlotValue(0, m)
+        args.setSlotFrameHeight(0, h)
+        args.setSlotFrameWidth(0, w)
+        self.assertEqual(args.getSlotFrameHeight(), h)
+        self.assertEqual(args.getSlotFrameWidth(), w)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Some applications, such as OCR, image segmentation, detection, speech, need to support variable -length input feature. Expose these interfaces for Arguments in swig firstly. Then support this feature in Python API.

Related to https://github.com/PaddlePaddle/Paddle/issues/2198