### PR TITLE
Support native build on NVIDIA DRIVE PX2 (arm64 + GPU).

### DIFF
--- a/cmake/cudnn.cmake
+++ b/cmake/cudnn.cmake
@@ -11,11 +11,23 @@ find_path(CUDNN_INCLUDE_DIR cudnn.h
 
 get_filename_component(__libpath_hist ${CUDA_CUDART_LIBRARY} PATH)
 
+if(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR})
+    execute_process(
+        COMMAND uname -m COMMAND tr -d '\n'
+        OUTPUT_VARIABLE HOST_ARCH
+        RESULT_VARIABLE UNAME_RESULT)
+    if(${UNAME_RESULT})
+        set(HOST_ARCH "x86_64")
+    endif(${UNAME_RESULT})
+else(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR})
+    set(HOST_ARCH ${CMAKE_HOST_SYSTEM_PROCESSOR})
+endif(NOT ${CMAKE_HOST_SYSTEM_PROCESSOR})
+
 list(APPEND CUDNN_CHECK_LIBRARY_DIRS
     ${CUDNN_ROOT}
     ${CUDNN_ROOT}/lib64
     ${CUDNN_ROOT}/lib
-    ${CUDNN_ROOT}/lib/x86_64-linux-gnu
+    ${CUDNN_ROOT}/lib/${HOST_ARCH}-linux-gnu
     $ENV{CUDNN_ROOT}
     $ENV{CUDNN_ROOT}/lib64
     $ENV{CUDNN_ROOT}/lib

--- a/paddle/utils/CpuId.cpp
+++ b/paddle/utils/CpuId.cpp
@@ -21,7 +21,7 @@ limitations under the License. */
 
 #else
 
-#if !defined(__arm__)
+#if !defined(__arm__) && !defined(__aarch64__)
 #include <cpuid.h>
 /// for GCC/Clang
 #define CPUID(info, x) __cpuid_count(x, 0, info[0], info[1], info[2], info[3])
@@ -32,7 +32,7 @@ limitations under the License. */
 namespace paddle {
 
 SIMDFlags::SIMDFlags() {
-#if defined(__arm__)
+#if defined(__arm__) || defined(__aarch64__)
   simd_flags_ = SIMD_NEON;
 #else
   unsigned int cpuInfo[4];

--- a/paddle/utils/tests/test_SIMDFlags.cpp
+++ b/paddle/utils/tests/test_SIMDFlags.cpp
@@ -19,7 +19,7 @@ using namespace paddle;  // NOLINT
 
 TEST(SIMDFlags, gccTest) {
 #if (defined(__GNUC__) || defined(__GNUG__)) && !(defined(__clang__)) && \
-    !defined(__arm__)
+    !defined(__arm__) && !defined(__aarch64__)
   // clang-format off
   CHECK(!__builtin_cpu_supports("sse")    != HAS_SSE);
   CHECK(!__builtin_cpu_supports("sse2")   != HAS_SSE2);


### PR DESCRIPTION
Support native build on NVIDIA DRIVE PX2 (arm64 + GPU).

The native build on NVIDIA DRIVE PX2 is very simple. You can login through ssh and use following command to build cpu-only version:
```bash
cmake -DCMAKE_INSTALL_PREFIX=$DEST_ROOT \
      -DCMAKE_BUILD_TYPE=Release \
      -DWITH_GPU=OFF \
      -DWITH_PYTHON=ON \
      -DWITH_SWIG_PY=ON \
      ..  
```
The gpu version cannot be built before #2299 merged. Command to build the gpu version is also listed as follows:
```bash
cmake -DCMAKE_INSTALL_PREFIX=$DEST_ROOT \
      -DCMAKE_BUILD_TYPE=Release \
      -DWITH_GPU=ON \
      -DCUDNN_ROOT=${CUDNN_ROOT} \
      -DWITH_PYTHON=ON \
      -DWITH_SWIG_PY=ON \
      ..  
```

On NVIDIA DRIVE PX2, cuda is installed in `/usr/local/cuda-8.0`, cudnn is installed in `/usr`.

You are free to set `CMAKE_BUILD_TYPE` to other values (`Debug`, `Release`, `RelWithDebInfo`, `MinSizeRel`), as you need.