### PR TITLE
remove unnecessary unit test outputs

### DIFF
--- a/paddle/majel/place_test.cc
+++ b/paddle/majel/place_test.cc
@@ -1,7 +1,6 @@
 #include "paddle/majel/place.h"
 #include <sstream>
 #include "gtest/gtest.h"
-#include "paddle/utils/Logging.h"
 
 TEST(Place, Equality) {
   majel::CpuPlace cpu;

--- a/paddle/majel/place_test.cc
+++ b/paddle/majel/place_test.cc
@@ -38,5 +38,4 @@ TEST(Place, Print) {
     ss << majel::CpuPlace();
     EXPECT_EQ("CpuPlace", ss.str());
   }
-  LOG(INFO) << "\n[----------] Done \n";
 }


### PR DESCRIPTION
Fixes https://github.com/PaddlePaddle/Paddle/issues/2331

I know the "unnecessary outputs" were actually an example of cmake/generic.cmake. Acutally, thanks for this example!