### PR TITLE
bug fix in order to print sequence contents (ids) correctly

### DIFF
--- a/paddle/parameter/Argument.cpp
+++ b/paddle/parameter/Argument.cpp
@@ -632,7 +632,7 @@ void Argument::printValueString(std::ostream& stream,
                                 const std::string& prefix) const {
   std::unordered_map<std::string, std::string> out;
   getValueString(&out);
-  for (auto field : {"value", "id", "sequence pos", "sub-sequence pos"}) {
+  for (auto field : {"value", "ids", "sequence pos", "sub-sequence pos"}) {
     auto it = out.find(field);
     if (it != out.end()) {
       stream << prefix << field << ":\n" << it->second;


### PR DESCRIPTION
There is a bug in Argument::printValueString function for sequences. 
This bug leads to the effect that for sequences, only sequence-pos/sub-sequence-pos can be printed (e.g., when using print_layer), but the contents of the sequences (ids) is not printed correctly.

