### PR TITLE
Minimize header file inclusion in StringPiece

### DIFF
--- a/paddle/strings/stringpiece.cc
+++ b/paddle/strings/stringpiece.cc
@@ -16,11 +16,11 @@
 
 #include "paddle/strings/stringpiece.h"
 
-// #include <stddef.h>
 #include <string.h>
 
 #include <algorithm>
 #include <iosfwd>
+#include <stdexcept>
 
 namespace paddle {
 
@@ -38,6 +38,12 @@ StringPiece::StringPiece(const char* s) : data_(s) {
 
 StringPiece::StringPiece(const std::string& s)
     : data_(s.data()), size_(s.size()) {}
+
+char StringPiece::operator[](size_t n) const {
+  if (n >= len())
+    throw std::invalid_argument("index out of StringPiece length");
+  return data_[n];
+}
 
 int Compare(StringPiece a, StringPiece b) {
   const size_t min_len = (a.len() < b.len()) ? a.len() : b.len();

--- a/paddle/strings/stringpiece.h
+++ b/paddle/strings/stringpiece.h
@@ -16,9 +16,6 @@
 
 #pragma once
 
-#include <assert.h>
-
-#include <stdexcept>
 #include <string>
 
 namespace paddle {
@@ -46,10 +43,7 @@ public:
   const char* data() const { return data_; }
   size_t len() const { return size_; }
 
-  char operator[](size_t n) const {
-    assert(n < len());
-    return data_[n];
-  }
+  char operator[](size_t n) const;
 
   // StringPiece doesn't own the string, so both iterator and const
   // iterator are const char* indeed.


### PR DESCRIPTION
Move as many header files to .cc files from .h files. Also minimize the total number of header files needed.