### PR TITLE
Using previous image for travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+group: deprecated-2017Q2
 language: cpp
 cache:
   directories:


### PR DESCRIPTION
Because travis-ci has been updated Ubuntu Trusty image, it causes
Paddle CI building error. Just using old image now for hot-fix, I
will add another issue to fix Paddle building in new TravisCI image.

Related link https://blog.travis-ci.com/2017-06-21-trusty-updates-2017-Q2-launch