### PR TITLE
Implement framework::Variable

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -2,3 +2,5 @@ cc_library(ddim SRCS ddim.cc)
 cc_test(ddim_test SRCS ddim_test.cc DEPS ddim)
 
 nv_test(dim_test SRCS dim_test.cu DEPS ddim)
+
+cc_test(variable_test SRCS variable_test.cc)

--- a/paddle/framework/ddim_test.cc
+++ b/paddle/framework/ddim_test.cc
@@ -1,5 +1,3 @@
-//#include <stdexcept>
-//#include <unittest/unittest.h>
 #include <sstream>
 #include <vector>
 

--- a/paddle/framework/variable.h
+++ b/paddle/framework/variable.h
@@ -1,0 +1,88 @@
+/*
+  Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+#pragma once
+
+#include <typeinfo>
+
+namespace paddle {
+namespace framework {
+
+class Variable {
+ public:
+  template <typename T>
+  const T& Get() const {
+    return *static_cast<const T*>(holder_->Ptr());
+  }
+
+  template <typename T>
+  T* GetMutable() {
+    if (holder_ != nullptr && typeid(T) == holder_->Type()) {
+      return static_cast<T*>(holder_->Ptr());
+    } else {
+      return Reset<T>(new T(), DefaultDeleter<T>());
+    }
+  }
+
+  ~Variable() {
+    if (holder_ != nullptr) delete holder_;
+  }
+
+ private:
+  // DefaultDeleter is functor which uses C++'s delete(T*).
+  template <typename T>
+  struct DefaultDeleter {
+    void operator()(T* ptr) { delete ptr; }
+  };
+
+  struct Placeholder {
+    virtual ~Placeholder() {}
+    virtual const std::type_info& Type() const = 0;
+    virtual void* Ptr() const = 0;
+  };
+
+  // Placeholder hides type T, so it doesn't appear as a template
+  // parameter of Variable.
+  template <typename T>
+  struct PlaceholderImpl : public Placeholder {
+    typedef std::function<void(T*)> Deleter;
+
+    PlaceholderImpl(T* ptr) : ptr_(ptr), type_(typeid(T)) {}
+    PlaceholderImpl(T* ptr, Deleter d)
+        : ptr_(ptr), type_(typeid(T)), deleter_(d) {}
+
+    virtual ~PlaceholderImpl() {
+      deleter_(ptr_);
+      ptr_ = nullptr;
+    }
+    virtual const std::type_info& Type() const { return type_; }
+    virtual void* Ptr() const { return ptr_; }
+
+    T* ptr_ = nullptr;
+    const std::type_info& type_;
+    std::function<void(T*)> deleter_ = DefaultDeleter<T>();
+  };
+
+  template <typename T>
+  T* Reset(T* allocated, typename PlaceholderImpl<T>::Deleter deleter) {
+    if (holder_ != nullptr) {
+      delete holder_;
+    }
+    holder_ = new PlaceholderImpl<T>(allocated, deleter);
+    return allocated;
+  }
+
+  Placeholder* holder_;  // pointers to a PlaceholderImpl object indeed.
+};
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/framework/variable.h
+++ b/paddle/framework/variable.h
@@ -16,6 +16,8 @@
 #include <typeindex>
 #include <typeinfo>
 
+#include "paddle/platform/assert.h"
+
 namespace paddle {
 namespace framework {
 
@@ -23,6 +25,9 @@ class Variable {
  public:
   template <typename T>
   const T& Get() const {
+    PADDLE_ASSERT(holder_ != nullptr);
+    PADDLE_ASSERT(std::type_index(typeid(T)) ==
+                  std::type_index(holder_->Type()));
     return *static_cast<const T*>(holder_->Ptr());
   }
 

--- a/paddle/framework/variable.md
+++ b/paddle/framework/variable.md
@@ -1,0 +1,52 @@
+# Design Doc: Variable
+
+
+Variable is also known as *blob* in MxNet and Caffe2.  It is the input and output type of operators, where a neural network is a graph of operators.
+
+## Requirements: Lazy Memory Allocation
+
+For the flexibility of a DL system, a variable should be able to contain any typed value -- a tensor in most cases, but could also be some integer IDs or a scope of other variables in the case of RNN.
+
+To use the minimum amount of memory, we'd like that a variable to allocate memory when it has to, or, lazy memory allocation.  Let's take the following example:
+
+```cpp
+Variable vr, v1, v2;
+
+Tensor* t1 = new Tensor();
+Tensor* t2 = new Tensor();
+
+Randomize(
+  /* malloc */ v1.GetMutable<Tensor>().mutable_data<float16>(DDim(100,200)),
+  /* size */ t1.Size());
+  
+Randomize(
+  /* malloc */ v2.GetMutable<Tensor>().mutable_data<float16>(DDim(200,300)),
+  /* size */ t2.Size());
+  
+Mult(
+  /*result*/ vr.GetMutable<Tensor>().mutable_data<v1.Type()>(SizeOfMult(v1, v2)),
+  /*input1*/ v1.Get<Tensor>().data(),
+  /*input2*/ v2.Get<Tensor>().data());
+```
+     
+We see that a variable holds nothing until `Variable::GetMutable<Tensor>()` allocates a tensor and puts it in the variable.  Similarly, a tensor gets its memory until `Tensor::mutable_data()`.
+
+This syntax for lazy memory allocation when we call `Randomize` and `Mult`, those functions that mutate the variable, so it saves us some line of C++ code.
+
+
+## Implementation: Type Hiding
+
+To make memory allocation lazy, we cannot assume that we know the type held by a variable at definition time.  In other words, `class Variable` cannot be a template `template <T> class Variable`.
+
+Because we don't know the type `T`, we cannot save a `T*` as `Variable's` data member.  Instead, we save an interface object `Placeholder`, who can return the pointer to the saved object via `Placeholder::Ptr()` as `void*`.
+
+But anyway, Variable needs to know `T` so could it `delete<T>(ptr)` and so could `Variable::Get` checks the expected type and the saved object's type.
+
+We save `T` in `PlaceholderImpl`, the implementation of `Placeholder`.  Please be aware that `PlaceholderImpl` is a class template and `T` is passed in as a template parameter.
+
+Because `PlaceholderImpl` knows `T`, it can save and return `typeid(T)` for the type comparison in `Variable::Get` and `Variable::GetMutable`.
+
+
+## Conclusion
+
+The technique type hiding utilizes C++ class templates, interface and derivation, and C++ RTTI (typeid).  This combination saves us from definition something like `caffe2::TypeMata`, which takes hundreds of lines of C++ code.

--- a/paddle/framework/variable_test.cc
+++ b/paddle/framework/variable_test.cc
@@ -1,0 +1,40 @@
+/*
+  Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <memory>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "paddle/framework/variable.h"
+
+TEST(Variable, GetMutable) {
+  using paddle::framework::Variable;
+
+  struct Tensor {
+    int content_;
+  };
+
+  std::unique_ptr<Variable> v(new Variable());
+
+  Tensor* t = v->GetMutable<Tensor>();
+  t->content_ = 1234;
+
+  const Tensor& tt = v->Get<Tensor>();
+  EXPECT_EQ(1234, tt.content_);
+
+  std::string* s = v->GetMutable<std::string>();
+  *s = "hello";
+
+  const std::string& ss = v->Get<std::string>();
+  EXPECT_EQ("hello", ss);
+}


### PR DESCRIPTION
I am using a C++ technique called type-information hiding in this implementation.

Compared with [this design](https://github.com/PaddlePaddle/Paddle/pull/2586), my implementation doesn't use `boost::any` and thus doesn't rely on boost.  Actually, this design relies nothing other than `#include <typeinfo>`.

Compare with [Caffe2's implementation](https://github.com/caffe2/caffe2/blob/master/caffe2/core/blob.h), mine doesn't use self-defined type inference mechanism like `caffe2::TypeMeta`, which is defined in caffe2/core/typeid.{h,cc,test_cc}, and saved about 500 lines C++ code:

```bash
$ wc -l ~/work/caffe2/caffe2/core/typeid*
      56 /Users/yiwang/work/caffe2/caffe2/core/typeid.cc
     300 /Users/yiwang/work/caffe2/caffe2/core/typeid.h
     136 /Users/yiwang/work/caffe2/caffe2/core/typeid_test.cc
```