### PR TITLE
fix MultiGradientMachine train and infer

### DIFF
--- a/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
@@ -166,12 +166,16 @@ MultiGradientMachine::MultiGradientMachine(const ModelConfig& config,
 
   outArgStream_ = HPPL_STREAM_1;
 
+  start();
+}
+
+void MultiGradientMachine::start() {
   for (auto& thread : threads_) {
     thread->start();
   }
 }
 
-MultiGradientMachine::~MultiGradientMachine() {
+void MultiGradientMachine::finish() {
   for (auto& thread : threads_) {
     thread->stop();
   }
@@ -445,7 +449,7 @@ TrainerThread::TrainerThread(const ModelConfig& config,
 
   gradStream_ = HPPL_STREAM_2;
   valueStream_ = HPPL_STREAM_3;
-  stopping_ = false;
+  stopping_ = true;
   updateCounter_ = 0;
   parameterUpdated_ = false;
 }
@@ -453,6 +457,10 @@ TrainerThread::TrainerThread(const ModelConfig& config,
 TrainerThread::~TrainerThread() { stop(); }
 
 void TrainerThread::start() {
+  if (!stopping_) return;
+
+  stopping_ = false;
+
   gradientMachine_->start();
 
   computeThread_.reset(new std::thread([this]() { computeThread(); }));

--- a/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.cpp
@@ -171,6 +171,12 @@ MultiGradientMachine::MultiGradientMachine(const ModelConfig& config,
   }
 }
 
+MultiGradientMachine::~MultiGradientMachine() {
+  for (auto& thread : threads_) {
+    thread->stop();
+  }
+}
+
 std::vector<const std::vector<ParameterPtr>*>
 MultiGradientMachine::getSlaveParameters() {
   std::vector<const std::vector<ParameterPtr>*> vec;
@@ -323,12 +329,6 @@ void MultiGradientMachine::updateThreadParameters() {
 void MultiGradientMachine::onPassEnd() {
   for (auto& thread : threads_) {
     thread->onPassEnd();
-  }
-}
-
-void MultiGradientMachine::finish() {
-  for (auto& thread : threads_) {
-    thread->stop();
   }
 }
 

--- a/paddle/gserver/gradientmachines/MultiGradientMachine.h
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.h
@@ -176,7 +176,9 @@ public:
 
   explicit MultiGradientMachine(const ModelConfig& config, bool useGpu);
 
-  virtual ~MultiGradientMachine();
+  virtual void start();
+
+  virtual void finish();
 
   virtual void prefetch(const std::vector<Argument>& inArgs);
 

--- a/paddle/gserver/gradientmachines/MultiGradientMachine.h
+++ b/paddle/gserver/gradientmachines/MultiGradientMachine.h
@@ -176,6 +176,8 @@ public:
 
   explicit MultiGradientMachine(const ModelConfig& config, bool useGpu);
 
+  virtual ~MultiGradientMachine();
+
   virtual void prefetch(const std::vector<Argument>& inArgs);
 
   virtual void forward(const std::vector<Argument>& inArgs,
@@ -192,8 +194,6 @@ public:
   virtual Argument getLayerOutput(const std::string& layerName);
 
   virtual void onPassEnd();
-
-  virtual void finish();
 
   virtual Evaluator* makeEvaluator() const;
 


### PR DESCRIPTION
fix: https://github.com/PaddlePaddle/Paddle/issues/2534  https://github.com/PaddlePaddle/Paddle/issues/2565

### Problem:
when training or infering with python v2 api, if trainer_count > 1 and call trainer.train or inferer.infer multiple times, the process will hang.

### Reason:
when trainer_count > 1, paddle will use MultiGradientMachine and will start multiple worker threads to do the forward/backward work(thread number is trainer_count)

In v2 python API, trainer or inferer will call [gradinet_machine.finish()](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/v2/trainer.py#L176) after train/infer, this will stop the worker threads, when you call trianer.train or inferrer.infer the second time, there are no worker thread to handle the task, so it hangs there.

### Fix:
Do not close worker threads when gradientMachine.finish() is called, close them in the destructor of gradientMachine.