### PR TITLE
Variable's Get should never failed, return nullptr if type mismatch.

### DIFF
--- a/paddle/framework/variable.h
+++ b/paddle/framework/variable.h
@@ -23,12 +23,19 @@ namespace framework {
 
 class Variable {
  public:
+  /**
+   * @brief Get variable holding element.
+   * @tparam T element type
+   * @return nullptr if the variable holds nothing or holder's type and type T
+   * are mismatch, otherwise, return the element pointer.
+   */
   template <typename T>
-  const T& Get() const {
-    PADDLE_ASSERT(holder_ != nullptr);
-    PADDLE_ASSERT(std::type_index(typeid(T)) ==
-                  std::type_index(holder_->Type()));
-    return *static_cast<const T*>(holder_->Ptr());
+  const T* Get() const {
+    if (holder_ == nullptr ||
+        std::type_index(typeid(T)) != std::type_index(holder_->Type())) {
+      return nullptr;
+    }
+    return static_cast<const T*>(holder_->Ptr());
   }
 
   template <typename T>

--- a/paddle/framework/variable_test.cc
+++ b/paddle/framework/variable_test.cc
@@ -29,12 +29,22 @@ TEST(Variable, GetMutable) {
   Tensor* t = v->GetMutable<Tensor>();
   t->content_ = 1234;
 
-  const Tensor& tt = v->Get<Tensor>();
+  const Tensor& tt = *v->Get<Tensor>();
   EXPECT_EQ(1234, tt.content_);
 
   std::string* s = v->GetMutable<std::string>();
   *s = "hello";
 
-  const std::string& ss = v->Get<std::string>();
+  const std::string& ss = *v->Get<std::string>();
   EXPECT_EQ("hello", ss);
+}
+
+TEST(Variable, GetMismatchType) {
+  using paddle::framework::Variable;
+  Variable var;
+  *var.GetMutable<int>() = 100;
+  ASSERT_EQ(nullptr, var.Get<float>());
+
+  Variable var_empty;
+  ASSERT_EQ(nullptr, var_empty.Get<int>());
 }


### PR DESCRIPTION
The `Variable::Get` should never fail because Paddle is a user library, we cannot core dump user program. `Variable::Get` should return `nullptr` when it holds nothing or the type mismatch.

Also, `Variable::Get` will let `Operator` handle different types. For example:

```cpp
void FullyConnectionOp(Variable input) {
  auto floatInput = input.Get<Tensor<float>>();
  if (floatInput == nullptr) {
    auto float16Input = input.Get<Tensor<float16>>();
    ...
  }
  ...
}
```