### PR TITLE
Moving python gradient_clipping_threshold to protobuf and C++

### DIFF
--- a/paddle/trainer/TrainerConfigHelper.cpp
+++ b/paddle/trainer/TrainerConfigHelper.cpp
@@ -36,6 +36,22 @@ namespace paddle {
 
 struct TrainerConfigHelperPrivate {
   TrainerConfig conf;
+
+  /**
+   * @brief Update trainer default values to each Parameter.
+   */
+  void updateDefaultValues() {
+    // set default gradient clipping.
+    if (conf.default_values().has_gradient_clipping_threshold()) {
+      auto defaultGradientClipping =
+          conf.default_values().gradient_clipping_threshold();
+      for (auto &param : *conf.mutable_model_config()->mutable_parameters()) {
+        if (!param.has_gradient_clipping_threshold()) {
+          param.set_gradient_clipping_threshold(defaultGradientClipping);
+        }
+      }
+    }
+  }
 };
 
 TrainerConfigHelper::TrainerConfigHelper(const std::string &configFilePath)
@@ -55,11 +71,7 @@ TrainerConfigHelper::TrainerConfigHelper(const std::string &configFilePath)
                      kConfigParserFuncName,
                      {configFilePath, configArgs.str()});
   CHECK(m->conf.ParseFromString(configProtoStr));
-}
-
-TrainerConfigHelper::TrainerConfigHelper(const TrainerConfig &config)
-    : m(new TrainerConfigHelperPrivate()) {
-  m->conf = config;
+  m->updateDefaultValues();
 }
 
 TrainerConfigHelper::~TrainerConfigHelper() {

--- a/paddle/trainer/TrainerConfigHelper.cpp
+++ b/paddle/trainer/TrainerConfigHelper.cpp
@@ -41,6 +41,9 @@ struct TrainerConfigHelperPrivate {
    * @brief Update trainer default values to each Parameter.
    */
   void updateDefaultValues() {
+    if (!conf.has_default_values()) {  // if not has default values at all
+      return;
+    }
     // set default gradient clipping.
     if (conf.default_values().has_gradient_clipping_threshold()) {
       auto defaultGradientClipping =

--- a/paddle/trainer/TrainerConfigHelper.cpp
+++ b/paddle/trainer/TrainerConfigHelper.cpp
@@ -74,11 +74,13 @@ TrainerConfigHelper::TrainerConfigHelper(const std::string &configFilePath)
   m->updateDefaultValues();
 }
 
-TrainerConfigHelper::~TrainerConfigHelper() {
-  if (m) {
-    delete m;
-  }
+TrainerConfigHelper::TrainerConfigHelper(const TrainerConfig &config)
+    : m(new TrainerConfigHelperPrivate()) {
+  m->conf = config;
+  m->updateDefaultValues();
 }
+
+TrainerConfigHelper::~TrainerConfigHelper() { delete m; }
 
 const TrainerConfig &TrainerConfigHelper::getConfig() const { return m->conf; }
 

--- a/paddle/trainer/TrainerConfigHelper.h
+++ b/paddle/trainer/TrainerConfigHelper.h
@@ -45,7 +45,6 @@ public:
    * @param configFilePath Config file path.
    */
   explicit TrainerConfigHelper(const std::string& configFilePath);
-  explicit TrainerConfigHelper(const TrainerConfig& config);
 
   /**
    * Dtor

--- a/paddle/trainer/TrainerConfigHelper.h
+++ b/paddle/trainer/TrainerConfigHelper.h
@@ -45,6 +45,7 @@ public:
    * @param configFilePath Config file path.
    */
   explicit TrainerConfigHelper(const std::string& configFilePath);
+  explicit TrainerConfigHelper(const TrainerConfig& config);
 
   /**
    * Dtor

--- a/proto/ParameterConfig.proto
+++ b/proto/ParameterConfig.proto
@@ -62,7 +62,7 @@ message ParameterConfig {
   // sparse remote update or not
   optional bool sparse_remote_update = 16 [default = false];
   // gradient clipping threshold, no clipping by default
-  optional double gradient_clipping_threshold = 17 [default = 0.0];
+  optional double gradient_clipping_threshold = 17 ;
   // static parameters are fixed when training
   optional bool is_static = 18 [default = false];
   // para_id should NOT be set by config_parser. It is for

--- a/proto/TrainerConfig.proto
+++ b/proto/TrainerConfig.proto
@@ -133,6 +133,11 @@ message OptimizationConfig {
   optional double gradient_clipping_threshold = 38 [default = 0.0];
 };
 
+
+message TrainerDefaultValues {
+  optional double gradient_clipping_threshold = 1 [default = 0.0];
+}
+
 message TrainerConfig {
   optional ModelConfig model_config = 1;
   optional DataConfig data_config = 2;
@@ -153,4 +158,6 @@ message TrainerConfig {
 
   // file path to the trainer config file
   optional string config_file = 9;
+
+  required TrainerDefaultValues default_values = 10;
 }

--- a/proto/TrainerConfig.proto
+++ b/proto/TrainerConfig.proto
@@ -159,5 +159,5 @@ message TrainerConfig {
   // file path to the trainer config file
   optional string config_file = 9;
 
-  required TrainerDefaultValues default_values = 10;
+  optional TrainerDefaultValues default_values = 10;
 }

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -114,12 +114,12 @@ g_layer_type_map = {}
 def init_config_environment(
         g_default_momentum=None,
         g_default_decay_rate=None,
+        g_default_gradient_clipping_threshold=None,
         g_default_initial_mean=0.,
         g_default_initial_std=0.01,
         g_default_num_batches_regularization=None,
         g_default_initial_strategy=0,
         g_default_initial_smart=False,
-        g_default_gradient_clipping_threshold=None,
         g_default_device=None,
         g_default_update_hooks=None,
         g_default_compact_func=None,
@@ -3214,8 +3214,6 @@ def Parameter(name,
             g_config.opt_config.use_sparse_remote_updater = True
     if sparse_update is not None:
         para.sparse_update = sparse_update
-    gradient_clipping_threshold = default(gradient_clipping_threshold,
-                                          g_default_gradient_clipping_threshold)
     if gradient_clipping_threshold is not None:
         para.gradient_clipping_threshold = gradient_clipping_threshold
     para.initial_strategy = default(initial_strategy,
@@ -3516,6 +3514,10 @@ def update_g_config():
     for name in g_config.model_config.output_layer_names:
         assert name in g_layer_map, \
             'input name "%s" does not correspond to a layer name' % name
+
+    if g_default_gradient_clipping_threshold is not None:
+        g_config.default_values.gradient_clipping_threshold = g_default_gradient_clipping_threshold
+
     return g_config
 
 

--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -3515,6 +3515,7 @@ def update_g_config():
         assert name in g_layer_map, \
             'input name "%s" does not correspond to a layer name' % name
 
+    # Set g_default_gradient_clipping_threshold to TrainerConfig.default_values
     if g_default_gradient_clipping_threshold is not None:
         g_config.default_values.gradient_clipping_threshold = g_default_gradient_clipping_threshold
 


### PR DESCRIPTION
Moving python gradient_clipping_threshold to protobuf and C++, make Paddle handle gradient_clipping_threshold correctly.