### PR TITLE
"fix client send empty gradients bug"

### DIFF
--- a/go/pserver/client.go
+++ b/go/pserver/client.go
@@ -1,6 +1,7 @@
 package pserver
 
 import (
+	"errors"
 	"hash/fnv"
 	"sort"
 	"time"
@@ -124,8 +125,7 @@ func (c *Client) FinishInitParams() error {
 // parameters.
 func (c *Client) SendGrads(grads []Gradient) error {
 	if len(grads) == 0 {
-		log.Info("Send Empty Gradient")
-		return nil
+		return errors.New("no gradient received")
 	}
 	errCh := make(chan error, len(grads))
 	for _, g := range grads {

--- a/go/pserver/client.go
+++ b/go/pserver/client.go
@@ -123,6 +123,10 @@ func (c *Client) FinishInitParams() error {
 // SendGrads sends gradients to parameter servers for updating
 // parameters.
 func (c *Client) SendGrads(grads []Gradient) error {
+	if len(grads) == 0 {
+		log.Info("Send Empty Gradient")
+		return nil
+	}
 	errCh := make(chan error, len(grads))
 	for _, g := range grads {
 		go func(g Gradient) {


### PR DESCRIPTION
In some miss use situation, SendGrads will get empty slice here, then `errCh` will block forever. 

```Go
// SendGrads sends gradients to parameter servers for updating
// parameters.
func (c *Client) SendGrads(grads []Gradient) error {
  if len(grads) == 0 {
    log.Info("Send Empty Gradient")
    return nil
  }
  errCh := make(chan error, len(grads))
  for _, g := range grads {
    go func(g Gradient) {
      err := c.pservers[c.partition(g.Name)].Call("Service.SendGrad", g, nil)
      errCh <- err
    }(g)
  }

  recv := 0
  for err := range errCh {
    if err != nil {
      return err
    }

```
