### PR TITLE
FIX: propagation dependencies and rebuild out of date libs

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -103,6 +103,7 @@ function(merge_static_libs TARGET_NAME)
   foreach(lib ${libs})
     list(APPEND libs_deps ${${lib}_LIB_DEPENDS})
   endforeach()
+  list(REMOVE_DUPLICATES libs_deps)
 
   # To produce a library we need at least one source file.
   # It is created by add_custom_command below and will helps 

--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -99,15 +99,37 @@ function(merge_static_libs TARGET_NAME)
   set(libs ${ARGN})
   list(REMOVE_DUPLICATES libs)
 
-  # First get the file names of the libraries to be merged
+  # Get all propagation dependencies from the merged libraries
   foreach(lib ${libs})
+    list(APPEND libs_deps ${${lib}_LIB_DEPENDS})
+  endforeach()
+
+  # To produce a library we need at least one source file.
+  # It is created by add_custom_command below and will helps 
+  # also help to track dependencies.
+  set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_dummy.c)
+
+  # Make the generated dummy source file depended on all static input
+  # libs. If input lib changes,the source file is touched
+  # which causes the desired effect (relink).
+  add_custom_command(OUTPUT ${dummyfile}
+    COMMAND ${CMAKE_COMMAND} -E touch ${dummyfile}
+    DEPENDS ${libs})
+
+  # Generate dummy staic lib
+  file(WRITE ${dummyfile} "const char * dummy = \"${dummyfile}\";")
+  add_library(${TARGET_NAME} STATIC ${dummyfile})
+  target_link_libraries(${TARGET_NAME} ${libs_deps})
+
+  foreach(lib ${libs})
+    # Get the file names of the libraries to be merged
     set(libfiles ${libfiles} $<TARGET_FILE:${lib}>)
   endforeach()
 
+  # Get the file name of the generated library
+  set(outlibfile "$<TARGET_FILE:${TARGET_NAME}>")
+
   if(APPLE) # Use OSX's libtool to merge archives
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_dummy.c)
-    file(WRITE ${dummyfile} "const char * dummy = \"${dummyfile}\";")
-    add_library(${TARGET_NAME} STATIC ${dummyfile})
 		add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
       COMMAND rm "${CMAKE_CURRENT_BINARY_DIR}/lib${TARGET_NAME}.a"
       COMMAND /usr/bin/libtool -static -o "${CMAKE_CURRENT_BINARY_DIR}/lib${TARGET_NAME}.a" ${libfiles})
@@ -117,7 +139,8 @@ function(merge_static_libs TARGET_NAME)
       set(objdir ${lib}.objdir)
 
       add_custom_command(OUTPUT ${objdir}
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${objdir})
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${objdir}
+        DEPENDS ${lib})
 
       add_custom_command(OUTPUT ${objlistfile}
         COMMAND ${CMAKE_AR} -x "$<TARGET_FILE:${lib}>"
@@ -125,23 +148,9 @@ function(merge_static_libs TARGET_NAME)
         DEPENDS ${lib} ${objdir}
         WORKING_DIRECTORY ${objdir})
 
-      # Empty dummy source file that goes into merged library
-      set(mergebase ${lib}.mergebase.c)
-      add_custom_command(OUTPUT ${mergebase}
-        COMMAND ${CMAKE_COMMAND} -E touch ${mergebase}
-        DEPENDS ${objlistfile})
-
-      list(APPEND mergebases "${mergebase}")
-    endforeach()
-
-    # We need a target for the output merged library
-    add_library(${TARGET_NAME} STATIC ${mergebases})
-    set(outlibfile "$<TARGET_FILE:${TARGET_NAME}>")
-
-    foreach(lib ${libs})
       add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
-      COMMAND ${CMAKE_AR} ru ${outlibfile} @"../${lib}.objlist"
-      WORKING_DIRECTORY ${lib}.objdir)
+        COMMAND ${CMAKE_AR} ru ${outlibfile} *.o 
+        WORKING_DIRECTORY ${objdir})
     endforeach()
 
     add_custom_command(TARGET ${TARGET_NAME} POST_BUILD


### PR DESCRIPTION
Pain points:

When I implemented buddy allocator, finally I want to merge all small pieces libraries to `paddle_memory` for testing memory recycling effects. 

```bazel
if(${WITH_GPU})
  nv_library(system_allocator SRCS system_allocator.cc DEPS gflags cpu_info gpu_info)
else(${WITH_GPU})
  cc_library(system_allocator SRCS system_allocator.cc DEPS gflags cpu_info)
endif(${WITH_GPU})

cc_test(system_allocator_test SRCS system_allocator_test.cc DEPS system_allocator)

cc_library(meta_data SRCS meta_data.cc)

cc_library(meta_cache SRCS meta_cache.cc)

cc_library(memory_block SRCS memory_block.cc)

cc_library(buddy_allocator SRCS buddy_allocator.cc DEPS glog)

cc_library(memory SRCS memory.cc)

cc_library(paddle_memory
    DEPS
    memory meta_data
    meta_cache memory_block
    buddy_allocator system_allocator)

cc_test(memory_test SRCS memory_test.cc DEPS place paddle_memory)
```

I found the original generic implementation doesn't allow propagation dependencies and also cannot track out of date records.

The new features for merging static libraries.

1. propagation dependencies
2. rebuild the out of date static library



![image](https://user-images.githubusercontent.com/3071933/27895860-8f3d7516-6248-11e7-89a7-9fca36e9362a.png)
