### PR TITLE
Move Init function into `paddle::framework`

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -12,3 +12,5 @@ cc_test(op_proto_test SRCS op_proto_test.cc DEPS op_proto protobuf)
 
 proto_library(op_desc SRCS op_desc.proto DEPS attr_type)
 cc_test(op_desc_test SRCS op_desc_test.cc DEPS op_desc protobuf)
+cc_library(init_function SRCS init_function.cc)
+cc_test(init_function_test SRCS init_function_test.cc DEPS init_function)

--- a/paddle/framework/init_function.cc
+++ b/paddle/framework/init_function.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <paddle/framework/enforce.h>
+#include <paddle/framework/init_function.h>
+#include <algorithm>
+#include <map>
+#include <vector>
+namespace paddle {
+namespace framework {
+
+using PriorityFuncPair = std::pair<int, InitFunctionType>;
+static bool g_initialized = false;
+static std::vector<PriorityFuncPair>* g_priority_func_pairs = nullptr;
+void RegisterInitFunction(InitFunctionType func, int priority) {
+  if (g_priority_func_pairs == nullptr) {
+    g_priority_func_pairs = new std::vector<PriorityFuncPair>();
+  }
+  PADDLE_ENFORCE(!g_initialized,
+                 "RegisterInitFunction() should only called before initMain()");
+  g_priority_func_pairs->push_back({priority, func});
+}
+
+void RunInitFunctions() {
+  if (g_initialized) return;
+  PADDLE_ENFORCE(
+      g_priority_func_pairs != nullptr,
+      "RegisterInitFunction should be invoked before RunInitFunctions");
+  std::sort(g_priority_func_pairs->begin(), g_priority_func_pairs->end(),
+            [](const PriorityFuncPair& a, const PriorityFuncPair& b) {
+              return a.first > b.first;
+            });
+  for (auto& func : *g_priority_func_pairs) {
+    func.second();
+  }
+  delete g_priority_func_pairs;
+  g_initialized = true;
+}
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/framework/init_function.h
+++ b/paddle/framework/init_function.h
@@ -1,0 +1,31 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <functional>
+
+namespace paddle {
+namespace framework {
+
+using InitFunctionType = std::function<void()>;
+extern void RegisterInitFunction(InitFunctionType func, int priority);
+extern void RunInitFunctions();
+
+class InitFunction {
+ public:
+  explicit InitFunction(InitFunctionType func, int priority = 0) {
+    RegisterInitFunction(func, priority);
+  }
+};
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/framework/init_function_test.cc
+++ b/paddle/framework/init_function_test.cc
@@ -1,0 +1,32 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <gtest/gtest.h>
+#include <paddle/framework/init_function.h>
+
+static bool InitializeFlag = false;
+
+static paddle::framework::InitFunction __init_func1__([] {
+  InitializeFlag = true;
+});
+
+static int InitFlag = 0;
+
+static paddle::framework::InitFunction __init_func2__([] { InitFlag = 1; });
+
+static paddle::framework::InitFunction __init_func3__([] { InitFlag = 10; },
+                                                      -1);
+
+TEST(InitFunction, init_func) {
+  paddle::framework::RunInitFunctions();
+  ASSERT_TRUE(InitializeFlag);
+  ASSERT_EQ(10, InitFlag);
+}

--- a/paddle/utils/CMakeLists.txt
+++ b/paddle/utils/CMakeLists.txt
@@ -17,7 +17,8 @@ add_library(paddle_utils STATIC
 add_style_check_target(paddle_utils ${UTIL_HEADERS})
 add_style_check_target(paddle_utils ${UTIL_SOURCES}
     ${UTIL_ARCH_SOURCES})
-add_dependencies(paddle_utils paddle_proto ${external_project_dependencies})
+add_dependencies(paddle_utils init_function paddle_proto ${external_project_dependencies})
+target_link_libraries(paddle_utils init_function)
 if(WITH_TESTING)
     add_subdirectory(tests)
 endif()

--- a/paddle/utils/Util.h
+++ b/paddle/utils/Util.h
@@ -26,6 +26,7 @@ limitations under the License. */
 #include <unordered_map>
 #include <vector>
 
+#include <paddle/framework/init_function.h>
 #include "Common.h"
 #include "Logging.h"
 #include "TrainerConfig.pb.h"
@@ -138,7 +139,7 @@ typename Container::value_type pop_get_front(Container& c) {
  * call runInitFunctions if they don't need the commandline flags
  * designed for PADDLE main procedure.
  */
-void runInitFunctions();
+inline void runInitFunctions() { paddle::framework::RunInitFunctions(); }
 
 /**
  * Initialize logging and parse commandline
@@ -165,18 +166,7 @@ void rmDir(const char* folderName);
 void loadFileList(const std::string& fileListFileName,
                   std::vector<std::string>& fileList);
 
-/**
- * Register a function, the function will be called in initMain(). Functions
- * with higher priority will be called first. The execution order of functions
- * with same priority is not defined.
- */
-void registerInitFunction(std::function<void()> func, int priority = 0);
-class InitFunction {
-public:
-  explicit InitFunction(std::function<void()> func, int priority = 0) {
-    registerInitFunction(func, priority);
-  }
-};
+using paddle::framework::InitFunction;
 
 /**
  * Class SetDevice provides a mechanism for set device enviroment.


### PR DESCRIPTION
* Make interfaces in Util.h not changed, but call `paddle::framework`.
* The InitFunction will be used when implement Op registry.