### PR TITLE
Simplelize framework/CMakeLists.txt

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -18,4 +18,4 @@ add_custom_target(framework_py_proto_init ALL COMMAND ${CMAKE_COMMAND} -E touch 
 add_dependencies(framework_py_proto framework_py_proto_init)
 
 proto_library(net_proto SRCS net_proto.proto DEPS op_proto)
-cc_library(net SRCS net.cc DEPS net_proto attr_type op_proto)
+cc_library(net SRCS net.cc DEPS net_proto)


### PR DESCRIPTION
* generic.cmake can propogate dependencies through libraries. It is no
  need to specific all dependencies.