### PR TITLE
add tensor interfaces

### DIFF
--- a/paddle/framework/tensor.h
+++ b/paddle/framework/tensor.h
@@ -57,7 +57,7 @@ class Tensor {
 
   void ShareDataFrom(const Tensor& src) {
     PADDLE_ENFORCE(src.holder_ != nullptr,
-                   "Tenosr 'src' has not been initialized.");
+                   "Can not share data from an uninitialized tensor.");
     holder_ = src.holder_;
     dims_ = src.dims_;
     offset_ = src.offset_;

--- a/paddle/framework/tensor.h
+++ b/paddle/framework/tensor.h
@@ -29,7 +29,7 @@ class Tensor {
  public:
   Tensor() : offset_(0) {}
 
-  Tensor(const DDim& dims) : dims_(dims), offset_(0) {}
+  explicit Tensor(const DDim& dims) : dims_(dims), offset_(0) {}
 
   template <typename T>
   const T* data() const {
@@ -63,7 +63,7 @@ class Tensor {
     offset_ = src.offset_;
   }
 
-  Tensor Slice(const int& begin_idx, const int& end_idx) {
+  Tensor Slice(const int& begin_idx, const int& end_idx) const {
     PADDLE_ENFORCE(holder_ != nullptr,
                    "The sliced tenosr has not been initialized.");
     PADDLE_ENFORCE(begin_idx >= 0 && end_idx <= dims_[0],


### PR DESCRIPTION
1. Add member variable `DDim dims_` and a getter function `dims()`. `dims_` is supposed to hold tensor's shape and it is required by `Op::InferShape`.
2. Remove an overloaded version of `mutable_data` which use default `Place`. Now users must provide an explicit `Place` as parameter when calling `mutable_data`. See #2742.
3. A PlaceHolder may be shared by more than one tensor, and some of them may be the others' slices. So we add a new member variable 'offset_' for Tensor, which is used to show the byte offset between `PlaceHolder::ptr_` and where tensor's data really begins.
4. Add functions `ShareDataFrom` and `Slice` for Tensor.

TODO: Tensor needs a 'CopyFrom' function

And there is another question. After `Op::InferShape`, we are going to get a series of tensors which have only dims_ but no data(`holder_ == nullptr`). So it seems reasonable to add a new interface for these tensors' memory allocation:

```cpp
T* mutable_data(Place place) {
    return mutable_data(dims_, place);
}
```

 If not, we have to write:

```cpp
float* p = my_tensor.mutable_data<float>(my_tesnor.dims(), CPUPlace());
```