### PR TITLE
check duplicate of ProtoAndCheckerMaker

### DIFF
--- a/paddle/framework/op_registry.h
+++ b/paddle/framework/op_registry.h
@@ -172,7 +172,7 @@ Add a mark to which output is temporary is helpful for future optimization.
 
   void CheckNoDuplicatedInOutAttrs() {
     std::unordered_set<std::string> names;
-    auto checker = [&](std::string name) {
+    auto checker = [&](const std::string& name) {
       PADDLE_ENFORCE(!names.count(name), "[%s] is duplicated", name);
       names.insert(name);
     };

--- a/paddle/framework/op_registry.h
+++ b/paddle/framework/op_registry.h
@@ -67,8 +67,7 @@ class OpProtoAndCheckerMaker {
 
   void Validate() {
     validated_ = true;
-    CheckNoDuplicatedAttrs();
-    CheckNoDuplicatedInOut();
+    CheckNoDuplicatedInOutAttrs();
   }
 
  protected:
@@ -171,20 +170,13 @@ Add a mark to which output is temporary is helpful for future optimization.
     }
   }
 
-  void CheckNoDuplicatedAttrs() {
+  void CheckNoDuplicatedInOutAttrs() {
     std::unordered_set<std::string> names;
     size_t cnt = 0;
     for (auto& attr : proto_->attrs()) {
       names.insert(attr.name());
       ++cnt;
     }
-    PADDLE_ENFORCE(names.size() == cnt,
-                   "Cannot register two attribute with same name!");
-  }
-
-  void CheckNoDuplicatedInOut() {
-    std::unordered_set<std::string> names;
-    size_t cnt = 0;
     for (auto& input : proto_->inputs()) {
       names.insert(input.name());
       ++cnt;
@@ -193,8 +185,9 @@ Add a mark to which output is temporary is helpful for future optimization.
       names.insert(output.name());
       ++cnt;
     }
-    PADDLE_ENFORCE(names.size() == cnt,
-                   "Cannot register two Input or Output with same name!");
+    PADDLE_ENFORCE(
+        names.size() == cnt,
+        "Cannot register two input/output/attribute with same name!");
   }
 
   OpProto* proto_;

--- a/paddle/framework/op_registry.h
+++ b/paddle/framework/op_registry.h
@@ -172,22 +172,19 @@ Add a mark to which output is temporary is helpful for future optimization.
 
   void CheckNoDuplicatedInOutAttrs() {
     std::unordered_set<std::string> names;
-    size_t cnt = 0;
+    auto checker = [&](std::string name) {
+      PADDLE_ENFORCE(!names.count(name), "[%s] is duplicated", name);
+      names.insert(name);
+    };
     for (auto& attr : proto_->attrs()) {
-      names.insert(attr.name());
-      ++cnt;
+      checker(attr.name());
     }
     for (auto& input : proto_->inputs()) {
-      names.insert(input.name());
-      ++cnt;
+      checker(input.name());
     }
     for (auto& output : proto_->outputs()) {
-      names.insert(output.name());
-      ++cnt;
+      checker(output.name());
     }
-    PADDLE_ENFORCE(
-        names.size() == cnt,
-        "Cannot register two input/output/attribute with same name!");
   }
 
   OpProto* proto_;

--- a/paddle/framework/op_registry_test.cc
+++ b/paddle/framework/op_registry_test.cc
@@ -1,6 +1,8 @@
 #include "paddle/framework/op_registry.h"
 #include <gtest/gtest.h>
 
+namespace pd = paddle::framework;
+
 namespace paddle {
 namespace framework {
 class CosineOp : public OperatorBase {
@@ -28,8 +30,6 @@ class MyTestOp : public OperatorBase {
   void InferShape(const ScopePtr& scope) const override {}
   void Run(const ScopePtr& scope,
            const platform::DeviceContext& dev_ctx) const override {}
-
- public:
 };
 
 class MyTestOpProtoAndCheckerMaker : public OpProtoAndCheckerMaker {
@@ -181,4 +181,36 @@ TEST(OpRegistry, CustomChecker) {
   op->Run(scope, dev_ctx);
   int test_attr = op->GetAttr<int>("test_attr");
   ASSERT_EQ(test_attr, 4);
+}
+
+class TestAttrProtoMaker : public pd::OpProtoAndCheckerMaker {
+ public:
+  TestAttrProtoMaker(pd::OpProto* proto, pd::OpAttrChecker* op_checker)
+      : OpProtoAndCheckerMaker(proto, op_checker) {
+    AddAttr<float>("scale", "scale of test op");
+    AddAttr<float>("scale", "scale of test op");
+  }
+};
+
+TEST(ProtoMaker, DuplicatedAttr) {
+  pd::OpProto op_proto;
+  pd::OpAttrChecker op_checker;
+  auto proto_maker = TestAttrProtoMaker(&op_proto, &op_checker);
+  ASSERT_THROW(proto_maker.Validate(), paddle::framework::EnforceNotMet);
+}
+
+class TestInOutProtoMaker : public pd::OpProtoAndCheckerMaker {
+ public:
+  TestInOutProtoMaker(pd::OpProto* proto, pd::OpAttrChecker* op_checker)
+      : OpProtoAndCheckerMaker(proto, op_checker) {
+    AddInput("input", "input of test op");
+    AddInput("input", "input of test op");
+  }
+};
+
+TEST(ProtoMaker, DuplicatedInOut) {
+  pd::OpProto op_proto;
+  pd::OpAttrChecker op_checker;
+  auto proto_maker = TestInOutProtoMaker(&op_proto, &op_checker);
+  ASSERT_THROW(proto_maker.Validate(), paddle::framework::EnforceNotMet);
 }


### PR DESCRIPTION
ProtoAndCheckerMaker should not have the same name in attributes or inputs/outputs.