### PR TITLE
Tensor should use PADDLE_ONLY_CPU macro

### DIFF
--- a/paddle/framework/tensor.h
+++ b/paddle/framework/tensor.h
@@ -55,14 +55,14 @@ class Tensor {
         holder_.reset(new PlaceholderImpl<T, platform::CPUPlace>(
             boost::get<platform::CPUPlace>(place), product(dims_) * sizeof(T)));
       } else if (platform::is_gpu_place(place)) {
-#ifdef __CUDACC__
+#ifdef PADDLE_ONLY_CPU
+        PADDLE_THROW("'GPUPlace' is not supported in CPU only device.");
+#else
         holder_.reset(new PlaceholderImpl<T, platform::GPUPlace>(
             boost::get<platform::GPUPlace>(place), product(dims_) * sizeof(T)));
-#else
-        PADDLE_ENFORCE(true, "'GPUPlace' is not supported in CPU only device.");
 #endif
       } else {
-        PADDLE_ENFORCE(true, "Unknown 'place'.");
+        PADDLE_THROW("Unknown 'place'.");
       }
       offset_ = 0;
     }


### PR DESCRIPTION
* Not use __CUDACC__ macro, because malloc in GPU memory do not have to
  used in .cu file.
* Also, `PADDLE_ENFORCE` logic is wrong.