### PR TITLE
rename EigenTensor to math::Tensor

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(math)
+
 # ddim lib
 cc_library(ddim SRCS ddim.cc DEPS eigen3)
 cc_test(ddim_test SRCS ddim_test.cc DEPS ddim)
@@ -5,7 +7,7 @@ nv_test(dim_test SRCS dim_test.cu DEPS ddim)
 
 cc_library(tensor SRCS tensor.cc DEPS ddim place paddle_memory)
 cc_test(tensor_test SRCS tensor_test.cc DEPS tensor)
-cc_test(eigen_test SRCS eigen_test.cc DEPS tensor)
+
 
 cc_test(variable_test SRCS variable_test.cc)
 cc_test(scope_test SRCS scope_test.cc)

--- a/paddle/framework/math/CMakeLists.txt
+++ b/paddle/framework/math/CMakeLists.txt
@@ -1,0 +1,1 @@
+cc_test(eigen_test SRCS eigen_test.cc DEPS tensor)

--- a/paddle/framework/math/eigen.h
+++ b/paddle/framework/math/eigen.h
@@ -19,6 +19,7 @@ limitations under the License. */
 
 namespace paddle {
 namespace framework {
+namespace math {
 
 // EigenDim converts paddle::platform::DDim into Eigen::DSizes.
 template <int D>
@@ -38,7 +39,7 @@ struct EigenDim {
 // Interpret paddle::platform::Tensor as EigenTensor and EigenConstTensor.
 template <typename T, size_t D, int MajorType = Eigen::RowMajor,
           typename IndexType = Eigen::DenseIndex>
-struct EigenTensor {
+struct Tensor {
   // TODO(qijun) Now, default type in unaligned, and we will make a benchmark on
   // the speed of aligned and unaligned version in future.
   using Type = Eigen::TensorMap<Eigen::Tensor<T, D, MajorType, IndexType>>;
@@ -46,39 +47,43 @@ struct EigenTensor {
   using ConstType =
       Eigen::TensorMap<Eigen::Tensor<const T, D, MajorType, IndexType>>;
 
-  static Type From(Tensor& tensor, DDim dims) {
+  static Type From(framework::Tensor& tensor, DDim dims) {
     return Type(tensor.data<T>(), EigenDim<D>::From(dims));
   }
 
-  static Type From(Tensor& tensor) { return From(tensor, tensor.dims_); }
+  static Type From(framework::Tensor& tensor) {
+    return From(tensor, tensor.dims_);
+  }
 
-  static ConstType From(const Tensor& tensor, DDim dims) {
+  static ConstType From(const framework::Tensor& tensor, DDim dims) {
     return ConstType(tensor.data<T>(), EigenDim<D>::From(dims));
   }
 
-  static ConstType From(const Tensor& tensor) {
+  static ConstType From(const framework::Tensor& tensor) {
     return From(tensor, tensor.dims_);
   }
 };
 
 template <typename T, int MajorType = Eigen::RowMajor,
           typename IndexType = Eigen::DenseIndex>
-struct EigenVector : public EigenTensor<T, 1, MajorType, IndexType> {
+struct Vector : public Tensor<T, 1, MajorType, IndexType> {
   // Flatten is to reshape a Tensor into a one dimension EigenVector
-  static typename EigenTensor<T, 1>::Type Flatten(Tensor& tensor) {
-    return EigenTensor<T, 1>::From(
+  static typename Tensor<T, 1>::Type Flatten(framework::Tensor& tensor) {
+    return Tensor<T, 1>::From(
         tensor, make_ddim({static_cast<int>(product(tensor.dims_))}));
   }
 
-  static typename EigenTensor<T, 1>::ConstType Flatten(const Tensor& tensor) {
-    return EigenTensor<T, 1>::From(
+  static typename Tensor<T, 1>::ConstType Flatten(
+      const framework::Tensor& tensor) {
+    return Tensor<T, 1>::From(
         tensor, make_ddim({static_cast<int>(product(tensor.dims_))}));
   }
 };
 
 template <typename T, int MajorType = Eigen::RowMajor,
           typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = EigenTensor<T, 2, MajorType, IndexType>;
+using Matrix = Tensor<T, 2, MajorType, IndexType>;
 
+}  // namespace math
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/math/eigen_test.cc
+++ b/paddle/framework/math/eigen_test.cc
@@ -11,11 +11,12 @@
   limitations under the License.
 */
 
-#include "paddle/framework/eigen.h"
+#include "paddle/framework/math/eigen.h"
 #include <gtest/gtest.h>
 
 namespace paddle {
 namespace framework {
+namespace math {
 
 TEST(EigenDim, From) {
   EigenDim<3>::Type ed = EigenDim<3>::From(make_ddim({1, 2, 3}));
@@ -25,13 +26,13 @@ TEST(EigenDim, From) {
 }
 
 TEST(Eigen, Tensor) {
-  Tensor t;
+  framework::Tensor t;
   float* p = t.mutable_data<float>(make_ddim({1, 2, 3}), platform::CPUPlace());
   for (int i = 0; i < 1 * 2 * 3; i++) {
     p[i] = static_cast<float>(i);
   }
 
-  EigenTensor<float, 3>::Type et = EigenTensor<float, 3>::From(t);
+  Tensor<float, 3>::Type et = Tensor<float, 3>::From(t);
 
   ASSERT_EQ(1, et.dimension(0));
   ASSERT_EQ(2, et.dimension(1));
@@ -47,13 +48,13 @@ TEST(Eigen, Tensor) {
 }
 
 TEST(Eigen, VectorFrom) {
-  Tensor t;
+  framework::Tensor t;
   float* p = t.mutable_data<float>(make_ddim({6}), platform::CPUPlace());
   for (int i = 0; i < 6; i++) {
     p[i] = static_cast<float>(i);
   }
 
-  EigenVector<float>::Type ev = EigenVector<float>::From(t);
+  Vector<float>::Type ev = Vector<float>::From(t);
 
   ASSERT_EQ(6, ev.dimension(0));
 
@@ -63,13 +64,13 @@ TEST(Eigen, VectorFrom) {
 }
 
 TEST(Eigen, VectorFlatten) {
-  Tensor t;
+  framework::Tensor t;
   float* p = t.mutable_data<float>(make_ddim({1, 2, 3}), platform::CPUPlace());
   for (int i = 0; i < 1 * 2 * 3; i++) {
     p[i] = static_cast<float>(i);
   }
 
-  EigenVector<float>::Type ev = EigenVector<float>::Flatten(t);
+  Vector<float>::Type ev = Vector<float>::Flatten(t);
 
   ASSERT_EQ(1 * 2 * 3, ev.dimension(0));
 
@@ -79,13 +80,13 @@ TEST(Eigen, VectorFlatten) {
 }
 
 TEST(Eigen, Matrix) {
-  Tensor t;
+  framework::Tensor t;
   float* p = t.mutable_data<float>(make_ddim({2, 3}), platform::CPUPlace());
   for (int i = 0; i < 2 * 3; i++) {
     p[i] = static_cast<float>(i);
   }
 
-  EigenMatrix<float>::Type em = EigenMatrix<float>::From(t);
+  Matrix<float>::Type em = Matrix<float>::From(t);
 
   ASSERT_EQ(2, em.dimension(0));
   ASSERT_EQ(3, em.dimension(1));
@@ -97,5 +98,6 @@ TEST(Eigen, Matrix) {
   }
 }
 
+}  // namespace math
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/tensor.h
+++ b/paddle/framework/tensor.h
@@ -32,16 +32,23 @@ struct CastToPyBufferImpl;
 }  // namespace details
 }  // namespace pybind
 namespace framework {
+namespace math {  // forward declare
+template <typename T, size_t D, int MajorType, typename IndexType>
+struct Tensor;
+
+template <typename T, int MajorType, typename IndexType>
+struct Vector;
+}  // namespace math
 
 class Tensor {
   template <bool less, size_t i, typename... args>
   friend struct paddle::pybind::details::CastToPyBufferImpl;
 
   template <typename T, size_t D, int MajorType, typename IndexType>
-  friend struct EigenTensor;
+  friend struct paddle::framework::math::Tensor;
 
   template <typename T, int MajorType, typename IndexType>
-  friend struct EigenVector;
+  friend struct paddle::framework::math::Vector;
 
  public:
   Tensor() : offset_(0) {}

--- a/paddle/operators/add_op.h
+++ b/paddle/operators/add_op.h
@@ -14,7 +14,7 @@ limitations under the License. */
 
 #pragma once
 #include "glog/logging.h"
-#include "paddle/framework/eigen.h"
+#include "paddle/framework/math/eigen.h"
 #include "paddle/framework/operator.h"
 
 namespace paddle {
@@ -30,10 +30,10 @@ public:
 
     output->mutable_data<T>(context.GetPlace());
 
-    framework::EigenVector<T>::Flatten(*output).device(
+    framework::math::Vector<T>::Flatten(*output).device(
         *(context.GetEigenDevice<Place>())) =
-        framework::EigenVector<T>::Flatten(input0) +
-        framework::EigenVector<T>::Flatten(input1);
+        framework::math::Vector<T>::Flatten(input0) +
+        framework::math::Vector<T>::Flatten(input1);
   }
 };
 

--- a/paddle/operators/sgd_op.h
+++ b/paddle/operators/sgd_op.h
@@ -14,7 +14,7 @@ limitations under the License. */
 
 #pragma once
 #include "glog/logging.h"
-#include "paddle/framework/eigen.h"
+#include "paddle/framework/math/eigen.h"
 #include "paddle/framework/operator.h"
 
 namespace paddle {
@@ -31,10 +31,10 @@ public:
 
     param_out->mutable_data<T>(ctx.GetPlace());
 
-    framework::EigenVector<T>::Flatten(*param_out)
+    framework::math::Vector<T>::Flatten(*param_out)
         .device(*(ctx.GetEigenDevice<Place>())) =
-        framework::EigenVector<T>::Flatten(param) -
-        lr * framework::EigenVector<T>::Flatten(grad);
+        framework::math::Vector<T>::Flatten(param) -
+        lr * framework::math::Vector<T>::Flatten(grad);
   }
 };
 


### PR DESCRIPTION
Since [EigenVector](https://en.wikipedia.org/wiki/Eigenvalues_and_eigenvectors) is actually a mathematical concepts.  It's better to find a more appropriate name. Here, just make a new namespace paddle::framework::math to hold Eigen related types.