### PR TITLE
fix client discover pserver context cancelled

### DIFF
--- a/go/pserver/client/etcd_client.go
+++ b/go/pserver/client/etcd_client.go
@@ -80,10 +80,10 @@ func (p *EtcdClient) List() []Server {
 	for {
 		for i := 0; i < psDesired; i++ {
 			ctx, cancel := context.WithTimeout(context.Background(), p.timeout)
-			cancel()
 			psKey := pserver.PsPath + strconv.Itoa(i)
 			log.Debugf("checking %s", psKey)
 			resp, err := p.client.Get(ctx, psKey)
+			cancel()
 			if err != nil {
 				log.Infof("Get psKey= %s error, %v", psKey, err)
 				time.Sleep(p.timeout)


### PR DESCRIPTION
It's already fixed by Wuyi's PR, but his PR may take some time to
merge, but I want to get this change in ASAP.

Fixes: https://github.com/PaddlePaddle/Paddle/issues/2969