### PR TITLE
[WIP] Elementwise Operator Functor

### DIFF
--- a/paddle/framework/operator.cc
+++ b/paddle/framework/operator.cc
@@ -22,14 +22,14 @@ namespace framework {
 template <>
 Eigen::DefaultDevice* KernelContext::GetEigenDevice<
     platform::CPUPlace, Eigen::DefaultDevice>() const {
-  return device_context_.get_eigen_device<Eigen::DefaultDevice>();
+  return device_context_.get_eigen_device<platform::CPUPlace>();
 }
 
 #ifndef PADDLE_ONLY_CPU
 template <>
 Eigen::GpuDevice*
 KernelContext::GetEigenDevice<platform::GPUPlace, Eigen::GpuDevice>() const {
-  return device_context_.get_eigen_device<Eigen::GpuDevice>();
+  return device_context_.get_eigen_device<platform::CPUPlace>();
 }
 #endif
 

--- a/paddle/framework/operator.cc
+++ b/paddle/framework/operator.cc
@@ -29,7 +29,7 @@ Eigen::DefaultDevice* KernelContext::GetEigenDevice<
 template <>
 Eigen::GpuDevice*
 KernelContext::GetEigenDevice<platform::GPUPlace, Eigen::GpuDevice>() const {
-  return device_context_.get_eigen_device<platform::CPUPlace>();
+  return device_context_.get_eigen_device<platform::GPUPlace>();
 }
 #endif
 

--- a/paddle/framework/operator.h
+++ b/paddle/framework/operator.h
@@ -31,21 +31,6 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-template <typename T>
-struct EigenDeviceConverter;
-
-template <>
-struct EigenDeviceConverter<platform::CPUPlace> {
-  using EigenDeviceType = Eigen::DefaultDevice;
-};
-
-#ifndef PADDLE_ONLY_CPU
-template <>
-struct EigenDeviceConverter<platform::GPUPlace> {
-  using EigenDeviceType = Eigen::GpuDevice;
-};
-#endif
-
 class OperatorBase;
 using OperatorPtr = std::shared_ptr<OperatorBase>;
 /**
@@ -147,8 +132,8 @@ class KernelContext {
   }
 
   template <typename PlaceType,
-            typename DeviceType =
-                typename EigenDeviceConverter<PlaceType>::EigenDeviceType>
+            typename DeviceType = typename platform::EigenDeviceConverter<
+                PlaceType>::EigenDeviceType>
   DeviceType* GetEigenDevice() const;
 
   platform::Place GetPlace() const { return device_context_.GetPlace(); }

--- a/paddle/operators/functors/elementwise_binary_functor.h
+++ b/paddle/operators/functors/elementwise_binary_functor.h
@@ -13,8 +13,8 @@ struct add {
                   framework::Tensor* output) {
     framework::EigenVector<T>::Flatten(*output).device(
         *(device_context.get_eigen_device<Place>())) =
-        framework::EigenVector<T>::Flatten(input0) +
-        framework::EigenVector<T>::Flatten(input1);
+        framework::EigenVector<T>::Flatten(input1) +
+        framework::EigenVector<T>::Flatten(input2);
   }
 };
 
@@ -26,8 +26,8 @@ struct sub {
                   framework::Tensor* output) {
     framework::EigenVector<T>::Flatten(*output).device(
         *(device_context.get_eigen_device<Place>())) =
-        framework::EigenVector<T>::Flatten(input0) -
-        framework::EigenVector<T>::Flatten(input1);
+        framework::EigenVector<T>::Flatten(input1) -
+        framework::EigenVector<T>::Flatten(input2);
   }
 };
 

--- a/paddle/operators/functors/elementwise_binary_functor.h
+++ b/paddle/operators/functors/elementwise_binary_functor.h
@@ -1,0 +1,36 @@
+#include "paddle/framework/eigen.h"
+#include "paddle/framework/tensor.h"
+
+namespace paddle {
+namespace operators {
+namespace functors {
+
+template <typename Place, typename T>
+struct add {
+  void operator()(const platform::DeviceContext& deice_context,
+                  const framework::Tensor& input1,
+                  const framework::Tensor& input2,
+                  framework::Tensor* output) {
+    framework::EigenVector<T>::Flatten(*output).device(
+        *(device_context.get_eigen_device<Place>())) =
+        framework::EigenVector<T>::Flatten(input0) +
+        framework::EigenVector<T>::Flatten(input1);
+  }
+};
+
+template <typename Place, typename T>
+struct sub {
+  void operator()(const platform::DeviceContext& deice_context,
+                  const framework::Tensor& input1,
+                  const framework::Tensor& input2,
+                  framework::Tensor* output) {
+    framework::EigenVector<T>::Flatten(*output).device(
+        *(device_context.get_eigen_device<Place>())) =
+        framework::EigenVector<T>::Flatten(input0) -
+        framework::EigenVector<T>::Flatten(input1);
+  }
+};
+
+}  // namespace functors
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/operators/functors/elementwise_unary_functor.h
+++ b/paddle/operators/functors/elementwise_unary_functor.h
@@ -1,0 +1,19 @@
+#include "paddle/framework/eigen.h"
+#include "paddle/framework/tensor.h"
+
+namespace paddle {
+namespace operators {
+namespace functors {
+
+template <typename Place, typename T>
+void sigmoid(const platform::DeviceContext& deice_context,
+             const framework::Tensor& input,
+             framework::Tensor* output) {
+  framework::EigenVector<T>::Flatten(*output).device(
+      *(device_context.get_eigen_device<Place>())) =
+      1.0 / (1.0 + (-1.0 * framework::EigenVector<T>::Flatten(input)).exp());
+}
+
+}  // namespace functors
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/operators/functors/elementwise_unary_functor.h
+++ b/paddle/operators/functors/elementwise_unary_functor.h
@@ -6,13 +6,15 @@ namespace operators {
 namespace functors {
 
 template <typename Place, typename T>
-void sigmoid(const platform::DeviceContext& deice_context,
-             const framework::Tensor& input,
-             framework::Tensor* output) {
-  framework::EigenVector<T>::Flatten(*output).device(
-      *(device_context.get_eigen_device<Place>())) =
-      1.0 / (1.0 + (-1.0 * framework::EigenVector<T>::Flatten(input)).exp());
-}
+struct sigmoid {
+  void operator()(const platform::DeviceContext& deice_context,
+                  const framework::Tensor& input,
+                  framework::Tensor* output) {
+    framework::EigenVector<T>::Flatten(*output).device(
+        *(device_context.get_eigen_device<Place>())) =
+        1.0 / (1.0 + (-1.0 * framework::EigenVector<T>::Flatten(input)).exp());
+  }
+};
 
 }  // namespace functors
 }  // namespace operators

--- a/paddle/platform/device_context.cc
+++ b/paddle/platform/device_context.cc
@@ -15,17 +15,17 @@ namespace paddle {
 namespace platform {
 
 template <>
-Eigen::DefaultDevice* DeviceContext::get_eigen_device<Eigen::DefaultDevice>()
-    const {
+Eigen::DefaultDevice* DeviceContext::get_eigen_device<
+    platform::CPUPlace, Eigen::DefaultDevice>() const {
   return reinterpret_cast<const CPUDeviceContext*>(this)->eigen_device();
 }
 
 #ifndef PADDLE_ONLY_CPU
 template <>
-Eigen::GpuDevice* DeviceContext::get_eigen_device<Eigen::GpuDevice>() const {
+Eigen::GpuDevice*
+DeviceContext::get_eigen_device<platform::GPUPlace, Eigen::GpuDevice>() const {
   return reinterpret_cast<const CUDADeviceContext*>(this)->eigen_device();
 }
 #endif
-
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/platform/device_context.h
+++ b/paddle/platform/device_context.h
@@ -28,12 +28,29 @@ limitations under the License. */
 namespace paddle {
 namespace platform {
 
+template <typename T>
+struct EigenDeviceConverter;
+
+template <>
+struct EigenDeviceConverter<platform::CPUPlace> {
+  using EigenDeviceType = Eigen::DefaultDevice;
+};
+
+#ifndef PADDLE_ONLY_CPU
+template <>
+struct EigenDeviceConverter<platform::GPUPlace> {
+  using EigenDeviceType = Eigen::GpuDevice;
+};
+#endif
+
 class DeviceContext {
  public:
   virtual ~DeviceContext() {}
   virtual Place GetPlace() const = 0;
 
-  template <typename DeviceType>
+  template <typename PlaceType,
+            typename DeviceType =
+                typename EigenDeviceConverter<PlaceType>::EigenDeviceType>
   DeviceType* get_eigen_device() const;
 };
 

--- a/paddle/platform/device_context_test.cc
+++ b/paddle/platform/device_context_test.cc
@@ -15,14 +15,13 @@ limitations under the License. */
 #include "paddle/platform/device_context.h"
 #include "gtest/gtest.h"
 
-using DEVICE_GPU = Eigen::GpuDevice;
 TEST(Device, Init) {
   int count = paddle::platform::GetDeviceCount();
   for (int i = 0; i < count; i++) {
     paddle::platform::DeviceContext* device_context =
         new paddle::platform::CUDADeviceContext(i);
     Eigen::GpuDevice* gpu_device =
-        device_context->template get_eigen_device<DEVICE_GPU>();
+        device_context->template get_eigen_device<paddle::platform::GPUPlace>();
     ASSERT_NE(nullptr, gpu_device);
     delete device_context;
   }


### PR DESCRIPTION
Since element-wise operators are almost the same, except the computation functions. 
We can implement computing functors including unary/binary/broadcast/reduce functors first, and then use predefined macros to generate element-wise operators. 