### PR TITLE
Refine depends of op_registry

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -19,8 +19,8 @@ cc_test(op_desc_test SRCS op_desc_test.cc DEPS op_desc protobuf)
 cc_library(operator SRCS operator.cc DEPS op_desc device_context tensor)
 cc_test(operator_test SRCS operator_test.cc DEPS operator op_registry)
 
-cc_library(op_registry SRCS op_registry.cc DEPS op_proto op_desc)
-cc_test(op_registry_test SRCS op_registry_test.cc DEPS op_registry operator)
+cc_library(op_registry SRCS op_registry.cc DEPS op_proto operator)
+cc_test(op_registry_test SRCS op_registry_test.cc DEPS op_registry)
 
 py_proto_compile(framework_py_proto SRCS attr_type.proto op_proto.proto op_desc.proto)
 # Generate an empty __init__.py to make framework_py_proto as a valid python module.

--- a/paddle/operators/CMakeLists.txt
+++ b/paddle/operators/CMakeLists.txt
@@ -4,7 +4,7 @@ function(op_library TARGET)
     # for ops.
     set(cc_srcs)
     set(cu_srcs)
-    set(op_common_deps operator op_registry)
+    set(op_common_deps op_registry)
     set(options "")
     set(oneValueArgs "")
     set(multiValueArgs SRCS DEPS)


### PR DESCRIPTION
Because op_registry includes `operator.h`, it depends on `operator`.
So add the dependency in `cc_library`, and simplify other depends in
`CMakeLists.txt`.