### PR TITLE
Able to print gradients in event_handler

### DIFF
--- a/python/paddle/v2/trainer.py
+++ b/python/paddle/v2/trainer.py
@@ -161,14 +161,14 @@ class SGD(object):
                     self.__parameter_updater__.update(each_param)
                 cost_sum = out_args.sum()
                 cost = cost_sum / len(data_batch)
-                self.__parameter_updater__.finishBatch(cost)
-                batch_evaluator.finish()
                 event_handler(
                     v2_event.EndIteration(
                         pass_id=pass_id,
                         batch_id=batch_id,
                         cost=cost,
                         evaluator=batch_evaluator))
+                self.__parameter_updater__.finishBatch(cost)
+                batch_evaluator.finish()
 
             self.__parameter_updater__.finishPass()
             pass_evaluator.finish()


### PR DESCRIPTION
Able to print gradients in event handle using v2 API to train.

Related: https://github.com/PaddlePaddle/Paddle/issues/3040
Fixes: https://github.com/PaddlePaddle/Paddle/issues/3211

```python
def event_handler(event):
        if isinstance(event, paddle.event.EndIteration):
            if event.batch_id % 10 == 0:
                for p in parameters:
                    print "parameters:", parameters.get(p)
                    grad = parameters.get_grad(p)
                    print "gradients:", grad
                    print "gradients max abs:" max(grad.min(), grad.max(), key=abs)
            if event.batch_id % 100 == 0:
                print "Pass %d, Batch %d, Cost %f" % (
                    event.pass_id, event.batch_id, event.cost)
```