### PR TITLE
Add CopyFrom interface for base DeviceContext in Tensor.

### DIFF
--- a/paddle/framework/detail/tensor-inl.h
+++ b/paddle/framework/detail/tensor-inl.h
@@ -96,7 +96,7 @@ inline void Tensor::CopyFrom(const Tensor& src,
     return;
   }
 #endif
-  PADDLE_ENFORCE(false, "Thte device context type is not supported.");
+  PADDLE_ENFORCE(false, "The device context type is not supported.");
 }
 
 template <typename T>

--- a/paddle/framework/detail/tensor-inl.h
+++ b/paddle/framework/detail/tensor-inl.h
@@ -83,6 +83,24 @@ inline void Tensor::ShareDataWith(const Tensor& src) {
 
 template <typename T>
 inline void Tensor::CopyFrom(const Tensor& src,
+                             const platform::DeviceContext& ctx) {
+  const auto cpu_ctx = dynamic_cast<const platform::CPUDeviceContext*>(&ctx);
+  if (cpu_ctx) {
+    CopyFrom<T>(src, *cpu_ctx);
+    return;
+  }
+#ifndef PADDLE_ONLY_CPU
+  const auto gpu_ctx = dynamic_cast<const platform::CUDADeviceContext*>(&ctx);
+  if (gpu_ctx) {
+    CopyFrom<T>(src, *gpu_ctx);
+    return;
+  }
+#endif
+  PADDLE_ENFORCE(false, "Thte device context type is not supported.");
+}
+
+template <typename T>
+inline void Tensor::CopyFrom(const Tensor& src,
                              const platform::CPUDeviceContext& ctx) {
   src.check_memory_size<T>();
   Resize(src.dims());

--- a/paddle/framework/tensor.h
+++ b/paddle/framework/tensor.h
@@ -94,6 +94,9 @@ class Tensor {
    * @note    CopyFrom supports CPU <-> GPU, GPU <-> GPU.
    */
   template <typename T>
+  inline void CopyFrom(const Tensor& src, const platform::DeviceContext& ctx);
+
+  template <typename T>
   inline void CopyFrom(const Tensor& src,
                        const platform::CPUDeviceContext& ctx);
 


### PR DESCRIPTION
The base DeviceContext is used in operator and operator kernel.  But, the CopyFrom in Tensor is as follows:

```C++
template <typename T>
inline void CopyFrom(const Tensor& src, const platform::CPUDeviceContext& ctx);	
 
template <typename T>
inline void CopyFrom(const Tensor& src, const platform::CUDADeviceContext& ctx);			 
```

It's not inconvenient to use in the operator. So add a CopyFrom for base DeviceContext:

```C++
template <typename T>
inline void CopyFrom(const Tensor& src, const platform::DeviceContext& ctx);	
```

