### PR TITLE
tensor type deduce

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -16,7 +16,9 @@ proto_library(op_desc SRCS op_desc.proto DEPS attr_type)
 cc_test(op_proto_test SRCS op_proto_test.cc DEPS op_proto protobuf)
 cc_test(op_desc_test SRCS op_desc_test.cc DEPS op_desc protobuf)
 
-cc_library(operator SRCS operator.cc DEPS op_desc device_context tensor)
+cc_library(type_deducer SRCS type_deducer.cc DEPS tensor)
+
+cc_library(operator SRCS operator.cc DEPS op_desc device_context tensor type_deducer)
 cc_test(operator_test SRCS operator_test.cc DEPS operator op_registry)
 
 cc_library(grad_op_builder SRCS grad_op_builder.cc DEPS op_proto operator)

--- a/paddle/framework/detail/tensor-inl.h
+++ b/paddle/framework/detail/tensor-inl.h
@@ -138,5 +138,33 @@ inline void Tensor::Resize(const DDim& dims) { dims_ = dims; }
 
 inline const DDim& Tensor::dims() const { return dims_; }
 
+template <typename T>
+LODTensor LODTensor::Slice(uint32_t level, uint32_t elem_begin,
+                           uint32_t elem_end) const {
+  PADDLE_ENFORCE(level < Levels(), "level [%d] out of range [%d]", level,
+                 Levels());
+  PADDLE_ENFORCE(elem_begin < Elements(level),
+                 "element begin [%d] out of range [%d]", elem_begin,
+                 Elements(level));
+  PADDLE_ENFORCE(elem_end < Elements(level),
+                 "element end [%d] out of range [%d]", elem_begin,
+                 Elements(level));
+  // slice the lod.
+  auto new_lod = std::make_shared<lod_t>();
+  auto start = lod_start_pos_->at(level)[elem_begin];
+  auto end = lod_start_pos_->at(level)[elem_end];
+  for (const auto& l : *lod_start_pos_) {
+    auto it_begin = std::find(l.begin(), l.end(), start);
+    auto it_end = std::find(it_begin, l.end(), end);
+    new_lod->emplace_back(it_begin, it_end);
+  }
+  auto new_tensor = tensor_->Slice<T>(start, end);
+
+  LODTensor res;
+  res.set_tensor(new_tensor);
+  res.set_lod(new_lod);
+  return res;
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/operator.h
+++ b/paddle/framework/operator.h
@@ -8,6 +8,7 @@ You may obtain a copy of the License at
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
+
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
@@ -24,6 +25,7 @@ limitations under the License. */
 #include "paddle/framework/op_proto.pb.h"
 #include "paddle/framework/scope.h"
 #include "paddle/framework/tensor.h"
+#include "paddle/framework/type_deducer.h"
 #include "paddle/platform/device_context.h"
 #include "paddle/platform/place.h"
 #include "paddle/utils/Error.h"

--- a/paddle/framework/tensor.cc
+++ b/paddle/framework/tensor.cc
@@ -15,5 +15,16 @@
 #include "paddle/framework/tensor.h"
 
 namespace paddle {
-namespace framework {}
+namespace framework {
+
+LODTensor LODTensor::Slice(uint32_t level) const {
+  LODTensor res;
+  auto new_lod = std::make_shared<lod_t>(lod_start_pos_->begin() + level,
+                                         lod_start_pos_->end());
+  res.set_tensor(tensor_);
+  res.set_lod(new_lod);
+  return res;
+}
+
+}  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/tensor_test.cc
+++ b/paddle/framework/tensor_test.cc
@@ -260,3 +260,42 @@ TEST(Tensor, CopyFrom) {
   }
 #endif
 }
+
+namespace paddle {
+namespace framework {
+
+class LODTensorTester : public ::testing::Test {
+ public:
+  virtual void SetUp() override {
+    lod_tensor = decltype(lod_tensor)(new LODTensor);
+    // tensor's batch_size: 30
+    // 3 levels
+    // 0 10 20
+    // 0 5 10 15 20
+    // 0 2 5 7 10 12 15 20
+    auto lod = std::make_shared<LODTensor::lod_t>();
+    lod->emplace_back(LODTensor::level_t{0, 10, 20});
+    lod->emplace_back(LODTensor::level_t{0, 5, 10, 15, 20});
+    lod->emplace_back(LODTensor::level_t{0, 2, 5, 7, 10, 12, 15, 17, 20});
+
+    auto tensor = std::make_shared<Tensor>();
+    DDim dims = make_ddim({20 /*batch size*/, 128 /*dim*/});
+    tensor->Resize(dims);
+
+    lod_tensor->set_tensor(tensor);
+    lod_tensor->set_lod(lod);
+  }
+
+ protected:
+  std::unique_ptr<LODTensor> lod_tensor;
+};
+
+TEST_F(LODTensorTester, Levels) { ASSERT_EQ(lod_tensor->Levels(), 3UL); }
+
+TEST_F(LODTensorTester, Elements) {
+  ASSERT_EQ(lod_tensor->Elements(0), 3UL);
+  ASSERT_EQ(lod_tensor->Elements(1), 5UL);
+  ASSERT_EQ(lod_tensor->Elements(2), 9UL);
+}
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/framework/type_deducer.cc
+++ b/paddle/framework/type_deducer.cc
@@ -1,0 +1,44 @@
+/*
+  Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+  http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include "paddle/framework/type_deducer.h"
+
+namespace paddle {
+namespace framework {
+
+template <>
+Tensor* TypeDeducer::operator()<Tensor>(const std::string& name) const {
+  const auto& tensor_type = typeid(Tensor);
+  auto it = rules.find(tensor_type);
+  PADDLE_ENFORCE(it != rules.end(), "no type deduce rules for target type [%s]",
+                 typeid(Tensor).name());
+  for (auto& rule : it->second) {
+    rule->Init(this);
+    if (rule->Match()) {
+      return (*rule)(name, tensor_type)->GetMutable<Tensor>();
+    }
+  }
+  return nullptr;
+}
+
+TypeDeducer::TypeDeducer() {
+  auto tensor2tensor =
+      std::unique_ptr<TypeDeduceRule>(new Tensor2TensorDeduceRule);
+  auto lottensor2tensor =
+      std::unique_ptr<LOT2TensorDeduceRule>(new LOT2TensorDeduceRule);
+  AddRule(typeid(Tensor), std::move(tensor2tensor));
+  AddRule(typeid(Tensor), std::move(lottensor2tensor));
+}
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/framework/type_deducer.h
+++ b/paddle/framework/type_deducer.h
@@ -1,0 +1,180 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <typeindex>
+#include <vector>
+
+#include "paddle/framework/attr_checker.h"
+#include "paddle/framework/scope.h"
+#include "paddle/framework/tensor.h"
+#include "paddle/framework/variable.h"
+
+namespace paddle {
+namespace framework {
+
+/*
+ * Operator will get different types of tensors, most operators just treat some
+ * complex tensor types as basic tensor, but the meta-info of complex tensor may
+ * need to be stored.
+ *
+ * For example, a LOTTensor stores a basic tensor and a LOT info, when it is
+ * transfered to a FC operator as a input, the FC operator just visit the basic
+ * tensor, but the LOT info should be copied to its outputs, in case of some
+ * operator consuming its outputs need the LOT info. FC knows nothing about LOT,
+ * so the framework should copy the LOT info transparently.
+ *
+ * Whether the operator's outputs should be a complex tensor, for example, a
+ * FC's outputs are basic tensors, but they will be LOTTensor or SparseTensor if
+ * FC's inputs are one of these types.
+ *
+ * In a word, we need a API(called TypeDeducer here) to automatically deduce
+ * tensor types for operators, get its context (inputs' types, operator's
+ * attributes) and the target tensor type it wants.
+ */
+class TypeDeduceRule;
+class TypeDeducer {
+ public:
+  void Init(std::vector<const Variable*>* op_inputs, AttributeMap* op_attrs) {
+    this->op_inputs = op_inputs;
+    this->op_attrs = op_attrs;
+  }
+
+  void AddRule(const std::type_info& type,
+               std::unique_ptr<TypeDeduceRule>&& rule) {
+    auto it = rules.find(type);
+    if (it == rules.end()) {
+      rules[type] = std::vector<std::unique_ptr<TypeDeduceRule>>();
+    }
+    rules[type].emplace_back(std::move(rule));
+  }
+
+  static TypeDeducer& Global() {
+    static auto x = std::unique_ptr<TypeDeducer>(new TypeDeducer());
+    return *x;
+  }
+
+  /*
+   * variable's name is passed so that we can get its additional attributes
+   * defined in op_attrs to help deduce its tensor type.
+   */
+  template <typename Target>
+  Target* operator()(const std::string& var_name) const;
+
+  // store all the context.
+  std::vector<const Variable*>* op_inputs;
+  AttributeMap* op_attrs;
+  Scope* scope;
+  std::map<std::type_index /*target type*/,
+           std::vector<std::unique_ptr<TypeDeduceRule>>>
+      rules;
+
+ private:
+  explicit TypeDeducer();
+};
+
+/*
+ * Base class of type deduce rules.
+ */
+class TypeDeduceRule {
+ public:
+  void Init(const TypeDeducer* deducer) {
+    this->op_inputs = deducer->op_inputs;
+    this->op_attrs = deducer->op_attrs;
+    this->scope = deducer->scope;
+  }
+
+  /*
+   * @param[in] var_name: variable's name
+   * @param[in] target_type: the tensor type caller wants
+   */
+  virtual Variable* operator()(const std::string& var_name,
+                               const std::type_info& target_type) const = 0;
+  /*
+   * Whether this rule matches.
+   */
+  virtual bool Match() const = 0;
+
+  virtual ~TypeDeduceRule() {}
+
+ protected:
+  std::vector<const Variable*>* op_inputs;
+  AttributeMap* op_attrs;
+  Scope* scope;
+};
+
+/*
+ * Default deduce rule, if all the inputs are Tensor, then the output's tensors
+ * are Tensor.
+ */
+class Tensor2TensorDeduceRule final : public TypeDeduceRule {
+ public:
+  virtual Variable* operator()(
+      const std::string& var_name,
+      const std::type_info& target_type) const override {
+    PADDLE_ENFORCE(target_type.hash_code() == typeid(Tensor).hash_code(),
+                   "wrong rule on target type %s", target_type.name());
+    auto target = scope->CreateVariable(var_name);
+    target->GetMutable<Tensor>();
+    return target;
+  }
+
+  virtual bool Match() const override {
+    for (const auto var : *op_inputs) {
+      if (!var->IsType<Tensor>()) {
+        return false;
+      }
+    }
+    return true;
+  }
+};
+
+/*
+ * Default deduce rule for LOTTensor(used in RNNOp), if one of the inputs is
+ * LODTensor, all the outputs will be LODTensor.
+ */
+class LOT2TensorDeduceRule final : public TypeDeduceRule {
+ public:
+  virtual Variable* operator()(
+      const std::string& var_name,
+      const std::type_info& target_type) const override {
+    PADDLE_ENFORCE(target_type.hash_code() == typeid(Tensor).hash_code(),
+                   "wrong rule on target type %s", target_type.name());
+    auto target = scope->CreateVariable(var_name);
+    auto lodtensor = target->GetMutable<LODTensor>();
+    lodtensor->ShareConstLODFrom(*first_lot_tensor_);
+    return target;
+  }
+
+  virtual bool Match() const override {
+    for (auto var : *op_inputs) {
+      if (var->IsType<LODTensor>()) {
+        first_lot_tensor_ = const_cast<LODTensor*>(&var->Get<LODTensor>());
+        return true;
+      }
+    }
+
+    first_lot_tensor_ = nullptr;
+    return false;
+  }
+
+ private:
+  mutable LODTensor* first_lot_tensor_;
+};
+
+}  // namespace framework
+}  // namespace paddle


### PR DESCRIPTION
We will have more tensor types like:

- Tensor
- LODTensor
- SparseTensor
- SparseLOTTensor (maybe in the future)

Some operator(FC e.g.) just process Tensor, when an `LODTensor` passed in as an input, FC assumes that the outputs are all `Tensor`s, but the framework should copy LOD info from inputs to outputs transparently, and make outputs LODTensors so that the LOD info will not be dropped. 

So, a type deducer is needed, it will get an operator's input tensor types and attributes, and deduce the outputs' tensor types.

We treat the type deducer a container of various deduce rules, and the type-deducer will only be used in `OperatorBase.InferShape` when the operators first visit the outputs.
The new tensor-types will be free to add, with new deduce rules to help deduce the tensor types, for example:

- LODTensor -> Tensor
- SparseTensor -> Tensor

 A real whole deduce example:

- `RNN->FC`, FC will get more than one `LODTensor`s, and FC assumes the outputs are `Tensors`
   - when FC needs output, it calls `auto output1 = TypeDeducer<Tensor>(input_vars, op_attrs, var_name)`
    - and get a `Tensor*`, but `TypeDeducer` will make this output a `LODTensor` in fact, and return the `LODTensor.get_tensor()`

This implementation is just a demo of the idea, and far from the actual usage.

Ignore the implementation of `LODTensor`, it is not finished and has another [PR](https://github.com/PaddlePaddle/Paddle/pull/3109).