### PR TITLE
add wget in docker production image

### DIFF
--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -148,7 +148,7 @@ cat >> /paddle/build/Dockerfile <<EOF
 ADD *.deb /
 # run paddle version to install python packages first
 RUN apt-get update &&\
-    apt-get install -y python-pip && pip install -U pip && \
+    apt-get install -y wget python-pip && pip install -U pip && \
     dpkg -i /*.deb ; apt-get install -f -y && \
     apt-get clean -y && \
     rm -f /*.deb && \


### PR DESCRIPTION
Add `wget` in production image to support models, such as : 
- `wget` in sequence_tagging_for_ner:  [download.sh](https://github.com/PaddlePaddle/models/blob/63fc48b0b1cde6e82bb9daf9494a1510b4c97ecc/sequence_tagging_for_ner/data/download.sh#L4)
- `wget` in deep_speech2: [run.sh](https://github.com/PaddlePaddle/models/blob/38a1d265347ddc67f3276ecab8435d594b34b6a5/deep_speech_2/lm/run.sh#L8), and [librispeech.py](https://github.com/PaddlePaddle/models/blob/8981919daf5c5b21f513840200fdcfbadac1495f/deep_speech_2/datasets/librispeech/librispeech.py#L69)