### PR TITLE
use isclose instead of assert_almost_equal

### DIFF
--- a/python/paddle/v2/framework/tests/op_test_util.py
+++ b/python/paddle/v2/framework/tests/op_test_util.py
@@ -61,10 +61,7 @@ class OpTestMeta(type):
                 for out_name in func.all_output_args:
                     actual = numpy.array(scope.find_var(out_name).get_tensor())
                     expect = getattr(self, out_name)
-                    # TODO(qijun) The default decimal is 7, but numpy.dot and eigen.mul
-                    # has some diff, and could not pass unittest. So I set decimal 3 here.
-                    # And I will check this in future.
-                    numpy.testing.assert_almost_equal(actual, expect, decimal=3)
+                    numpy.isclose(actual, expect)
 
         obj.test_all = test_all
         return obj


### PR DESCRIPTION
numpy.isclose:
```
absolute(a - b) <= (atol + rtol * absolute(b))
```

numpy.testing.assert_almost_equal:
```
abs(desired-actual) < 1.5 * 10**(-decimal)
```

isclose is more appropriate for comparing two floats.