### PR TITLE
cmake add ability to skip cleaning test virtual env

### DIFF
--- a/paddle/scripts/run_python_tests.sh
+++ b/paddle/scripts/run_python_tests.sh
@@ -22,12 +22,15 @@ USE_VIRTUALENV_FOR_TEST=$1; shift
 PYTHON=$1; shift
 
 if [ $USE_VIRTUALENV_FOR_TEST -ne 0 ]; then
-   rm -rf .test_env
-   virtualenv .test_env
-   unset PYTHONHOME
-   unset PYTHONPATH
-   source .test_env/bin/activate
-   PYTHON=python
+    if [ "$PADDLE_TEST_SKIP_CLEAN_VIRTUAL_ENV" != "ON" ]
+    then
+	   rm -rf .test_env
+    fi
+    virtualenv .test_env
+    unset PYTHONHOME
+    unset PYTHONPATH
+    source .test_env/bin/activate
+    PYTHON=python
 fi
 
 $PYTHON -m pip install $SCRIPTPATH/../dist/*.whl
@@ -51,5 +54,8 @@ done
 
 if [ $USE_VIRTUALENV_FOR_TEST -ne 0 ]; then
     deactivate
-    rm -rf .test_env
+    if [ "$PADDLE_TEST_SKIP_CLEAN_VIRTUAL_ENV" != "ON" ]
+    then
+	rm -rf .test_env
+    fi
 fi


### PR DESCRIPTION
Our python tests reinstalls dependency every time for each python test, this is because we are using virtual env for every test. We can disable it for TeamCity.

```
[00:23:27] :	 [Step 1/1] 102/106 Test  #68: test_TrainerOnePass .................   Passed   65.80 sec
[00:24:02] :	 [Step 1/1] 103/106 Test #105: test_ploter .........................   Passed   64.38 sec
[00:24:05] :	 [Step 1/1] 104/106 Test #104: reader_tests ........................   Passed   68.79 sec
[00:24:05] :	 [Step 1/1] 105/106 Test #103: test_v2_api .........................   Passed   76.73 sec
[00:24:21] :	 [Step 1/1] 106/106 Test #106: test_framework ......................   Passed   67.06 sec
```