### PR TITLE
Simplify CrossMapNormalOpTest and BlockExpandOpTest.

### DIFF
--- a/paddle/function/BlockExpandOpTest.cpp
+++ b/paddle/function/BlockExpandOpTest.cpp
@@ -18,10 +18,10 @@ limitations under the License. */
 namespace paddle {
 
 TEST(BlockExpandForward, real) {
-  for (size_t batchSize : {5, 32}) {
-    for (size_t channels : {1, 5, 32}) {
-      for (size_t inputHeight : {5, 33, 100}) {
-        for (size_t inputWidth : {5, 32, 96}) {
+  for (size_t batchSize : {5}) {
+    for (size_t channels : {1, 5}) {
+      for (size_t inputHeight : {5, 33}) {
+        for (size_t inputWidth : {5, 32}) {
           for (size_t block : {1, 3, 5}) {
             for (size_t stride : {1, 2}) {
               for (size_t padding : {0, 1}) {
@@ -61,10 +61,10 @@ TEST(BlockExpandForward, real) {
 }
 
 TEST(BlockExpandBackward, real) {
-  for (size_t batchSize : {5, 32}) {
-    for (size_t channels : {1, 5, 32}) {
-      for (size_t inputHeight : {5, 33, 100}) {
-        for (size_t inputWidth : {5, 32, 96}) {
+  for (size_t batchSize : {5}) {
+    for (size_t channels : {1, 5}) {
+      for (size_t inputHeight : {5, 33}) {
+        for (size_t inputWidth : {5, 32}) {
           for (size_t block : {1, 3, 5}) {
             for (size_t stride : {1, 2}) {
               for (size_t padding : {0, 1}) {

--- a/paddle/function/CrossMapNormalOpTest.cpp
+++ b/paddle/function/CrossMapNormalOpTest.cpp
@@ -18,11 +18,11 @@ limitations under the License. */
 namespace paddle {
 
 TEST(CrossMapNormal, real) {
-  for (size_t numSamples : {5, 32}) {
-    for (size_t channels : {1, 5, 32}) {
-      for (size_t imgSizeH : {5, 33, 100}) {
-        for (size_t imgSizeW : {5, 32, 96}) {
-          for (size_t size : {1, 2, 3, 5, 7}) {
+  for (size_t numSamples : {5}) {
+    for (size_t channels : {1, 5}) {
+      for (size_t imgSizeH : {5, 33}) {
+        for (size_t imgSizeW : {5, 32}) {
+          for (size_t size : {1, 3}) {
             VLOG(3) << " numSamples=" << numSamples << " channels=" << channels
                     << " imgSizeH=" << imgSizeH << " imgSizeW=" << imgSizeW
                     << " size=" << size;
@@ -48,11 +48,11 @@ TEST(CrossMapNormal, real) {
 }
 
 TEST(CrossMapNormalGrad, real) {
-  for (size_t numSamples : {5, 32}) {
-    for (size_t channels : {1, 5, 32}) {
-      for (size_t imgSizeH : {5, 33, 100}) {
-        for (size_t imgSizeW : {5, 32, 96}) {
-          for (size_t size : {1, 2, 3, 5, 7}) {
+  for (size_t numSamples : {5}) {
+    for (size_t channels : {1, 5}) {
+      for (size_t imgSizeH : {5, 33}) {
+        for (size_t imgSizeW : {5, 32}) {
+          for (size_t size : {1, 3}) {
             VLOG(3) << " numSamples=" << numSamples << " channels=" << channels
                     << " imgSizeH=" << imgSizeH << " imgSizeW=" << imgSizeW
                     << " size=" << size;


### PR DESCRIPTION
Fix #3258
Test time on my machine from
```
 3/80 Test  #3: CrossMapNormalOpTest ................   Passed   52.93 sec
13/73 Test #13: BlockExpandOpTest ...................   Passed  230.37 sec 
 ```
to
```
 3/73 Test  #3: CrossMapNormalOpTest ................   Passed    5.47 sec
13/73 Test #13: BlockExpandOpTest ...................   Passed    6.89 sec
```