### PR TITLE
Feature/model

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -38,9 +38,10 @@ cc_test(backward_test SRCS backward_test.cc DEPS backward)
 cc_library(paddle_pybind SHARED
     SRCS pybind.cc
     DEPS pybind python backward
-	fc_op
-	sgd_op
-	add_op
-	mean_op
-	cross_entropy_op
-	recurrent_op)
+    fc_op
+    sgd_op
+    add_op
+    mean_op
+    cross_entropy_op
+    recurrent_op
+    uniform_random_op)

--- a/paddle/framework/pybind.cc
+++ b/paddle/framework/pybind.cc
@@ -41,6 +41,7 @@ USE_OP(sigmoid);
 USE_OP(softmax);
 USE_OP(rowwise_add);
 USE_OP_WITHOUT_KERNEL(recurrent_op);
+USE_OP(uniform_random);
 namespace paddle {
 namespace framework {
 template <typename ClassType>

--- a/paddle/operators/CMakeLists.txt
+++ b/paddle/operators/CMakeLists.txt
@@ -66,3 +66,5 @@ op_library(fc_op
 op_library(recurrent_op SRCS recurrent_op.cc rnn/recurrent_op_utils.cc
     DEPS op_desc tensor op_registry operator net_op)
 cc_test(recurrent_op_test SRCS recurrent_op_test.cc DEPS recurrent_op gtest mul_op add_op)
+op_library(uniform_random_op
+        SRCS uniform_random_op.cc uniform_random_op.cu)

--- a/paddle/operators/uniform_random_op.cc
+++ b/paddle/operators/uniform_random_op.cc
@@ -1,0 +1,53 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include "paddle/operators/uniform_random_op.h"
+
+namespace paddle {
+namespace operators {
+class RandomOp : public OperatorWithKernel {
+ protected:
+  void InferShape(const InferShapeContext &ctx) const override {
+    PADDLE_ENFORCE(GetAttr<float>("min") < GetAttr<float>("max"),
+                   "uniform_random's min must less then max");
+    auto tensor = ctx.Output<Tensor>(0);
+    auto dims = GetAttr<std::vector<int>>("dims");
+    tensor->Resize(framework::make_ddim(dims));
+  }
+};
+
+class RandomOpMaker : public OpProtoAndCheckerMaker {
+ public:
+  RandomOpMaker(OpProto *proto, OpAttrChecker *op_checker)
+      : OpProtoAndCheckerMaker(proto, op_checker) {
+    AddOutput("Out", "The output tensor of uniform random op");
+    AddComment(R"DOC(Uniform random operator.
+
+Used to initialize tensor with uniform random generator.
+)DOC");
+    AddAttr<std::vector<int>>("dims", "the dimension of random tensor");
+    AddAttr<float>("min", "Minimum value of uniform random").SetDefault(-1.0f);
+    AddAttr<float>("max", "Maximun value of uniform random").SetDefault(1.0f);
+    AddAttr<int>("seed",
+                 "Random seed of uniform random. "
+                 "0 means generate a seed by system")
+        .SetDefault(0);
+  }
+};
+}  // namespace operators
+}  // namespace paddle
+
+REGISTER_OP(uniform_random, ops::RandomOp, ops::RandomOpMaker);
+REGISTER_OP_CPU_KERNEL(uniform_random,
+                       ops::UniformRandomKernel<ops::CPUPlace, float>);

--- a/paddle/operators/uniform_random_op.cu
+++ b/paddle/operators/uniform_random_op.cu
@@ -1,0 +1,18 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include "paddle/operators/uniform_random_op.h"
+
+REGISTER_OP_GPU_KERNEL(uniform_random,
+                       ops::UniformRandomKernel<ops::GPUPlace, float>);

--- a/paddle/operators/uniform_random_op.h
+++ b/paddle/operators/uniform_random_op.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+#include "paddle/operators/type_alias.h"
+namespace paddle {
+namespace operators {
+
+template <typename Place, typename T>
+class UniformRandomKernel : public OpKernel {
+ public:
+  void Compute(const ExecutionContext &context) const override {
+    auto tensor = context.Output<Tensor>(0);
+    tensor->mutable_data<T>(context.GetPlace());
+
+    auto eigenTensor = EigenVector<T>::Flatten(*tensor);
+    auto dev = context.GetEigenDevice<Place>();
+    auto min = context.op_.GetAttr<float>("min");
+    auto max = context.op_.GetAttr<float>("max");
+    auto seed = static_cast<uint64_t>(context.op_.GetAttr<int>("seed"));
+    auto diff = max - min;
+    Eigen::internal::UniformRandomGenerator<T> gen(seed);
+    eigenTensor.device(dev) = eigenTensor.random(gen) * diff + min;
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/v2/framework/model.py
+++ b/python/paddle/v2/framework/model.py
@@ -1,0 +1,239 @@
+import paddle.v2.framework.core as core
+from paddle.v2.framework.op import Operator
+import numpy
+
+
+class ParameterAttribute(object):
+    def __init__(self, name=None, initial_min=-1.0, initial_max=1.0):
+        self.name = name
+        self.initial_min = initial_min
+        self.initial_max = initial_max
+
+
+class Model(object):
+    def __init__(self, place=core.CPUPlace()):
+        self.scope = core.Scope()
+        # init network is the network with initialize operators, they are random
+        # operators or zero operators.
+        self.init_network = core.Net.create()
+
+        # forward network is the full network of all defined forward operators.
+        # We can run a subnet from it, by `get_subnet` method.
+        self.forward_network = core.Net.create()
+
+        # A counter to give a readable variable name in one model
+        self.name_counter = 0
+
+        # A place that this model run on.
+        self.place = place
+
+        # The device context of that place.
+        self.dev_ctx = core.DeviceContext.create(place)
+
+    def data_layer(self, name, dims):
+        """
+        Add a data layer for this model.
+        
+        :param name: the data layer name, i.e., the output variable name. 
+        :param dims: the dimension without batch size.
+        :return: Output variable name.
+        :rtype: str
+        """
+        if isinstance(dims, int):
+            dims = [dims]
+
+        if not isinstance(dims, list) or isinstance(dims, tuple):
+            raise ValueError("dims should be an int, list or tuple.")
+
+        self.assert_not_create_var(name)
+
+        var = self.scope.new_var(name)
+        tensor = var.get_tensor()
+        tensor.set_dims([1] + dims)  # 1 is batch size holder.
+
+        return name
+
+    def fc_layer(self,
+                 input,
+                 size,
+                 act="sigmoid",
+                 param=None,
+                 bias=True,
+                 name=None):
+        """
+        Add a fc layer to model
+        
+        :param input: input variable name.
+        :type input: str
+        :param size: fully connected layer size.
+        :param act: activation name
+        :param param: parameter attribute, used for initialize parameters.
+        :param bias: bias attribute. False will not have a bias.
+        :param name: the name of fc layer. If not set, model will generate a 
+        readable name
+        :return: output variable name.
+        """
+        if name is None:
+            name = 'fc_%d' % self.name_counter
+            self.name_counter += 1
+        if not isinstance(name, str):
+            raise ValueError("name should be string")
+
+        self.assert_not_create_var(name)
+        input_dims = self.scope.find_var(input).get_tensor().get_dims()
+
+        param_name = self.add_param_to_init_network(
+            default_name=name + ".w", param=param, dims=[input_dims[1], size])
+
+        pre_activation = name + ".mul.out"
+        self.scope.new_var(pre_activation)
+        mul_op = Operator("mul", X=input, Y=param_name, Out=pre_activation)
+        self.forward_network.add_op(mul_op)
+
+        if bias:
+            bias_name = self.add_param_to_init_network(
+                default_name=name + ".b", param=bias, dims=[size])
+            bias_out = name + ".rowwise_add.out"
+            self.scope.new_var(bias_out)
+            rowwise_add_op = Operator(
+                "rowwise_add", X=pre_activation, b=bias_name, Out=bias_out)
+            self.forward_network.add_op(rowwise_add_op)
+            pre_activation = bias_out
+
+        out = Operator(act, X=pre_activation, Y=name)
+        self.forward_network.add_op(out)
+        self.scope.new_var(name)
+        # TODO(yuyang): InferShape only these operator.
+        self.forward_network.infer_shape(self.scope)
+        return name
+
+    def init_params(self):
+        """
+        Initialize all parameters inside this model
+        """
+        self.init_network.infer_shape(self.scope)
+        self.init_network.run(self.scope, self.dev_ctx)
+
+    def forward(self, data, output=None):
+        """
+        Forward a (sub) network
+        :param data: the data layer's data. Should be a dict, 
+        key is variable name, value is a numpy array.
+        :param output: The output variable name. If not set, full forward 
+        network will be run. If set, only operators could generate that output
+         will be run, i.e., only a sub network will be run.
+        :return: Nothing, use scope to get variable.
+        """
+        for k in data:
+            arr = data[k]
+            if not isinstance(arr, numpy.ndarray):
+                raise TypeError(
+                    "data should be a dict, value should be ndarray")
+
+            var = self.scope.find_var(k)
+            tensor = var.get_tensor()
+            tensor.set_dims(arr.shape)
+            tensor.alloc_float(self.place)
+            tensor.set(arr, self.place)
+
+        net = self.get_subnet(self.forward_network, output)
+        net.infer_shape(self.scope)
+        net.run(self.scope, self.dev_ctx)
+
+    def get_subnet(self, full_net, output):
+        """
+        Get a sub network from a full_network which is necessary to generate 
+        output variable
+        """
+        if output is None:
+            return full_net
+        else:
+            if not isinstance(output, str):
+                raise TypeError("output of get_subnet should be str")
+
+            all_operators = full_net.ops()
+            need_var_set = set()
+            need_var_set.add(output)
+
+            ret_ops = []
+
+            for i in xrange(len(all_operators)):
+                op = all_operators[-i]
+                outs = op.outputs()
+                if Model.any_in_set(outs, need_var_set):
+                    for out in outs:
+                        need_var_set.add(out)
+                    for ipt in op.inputs():
+                        need_var_set.add(ipt)
+
+                    ret_ops.append(op)
+
+            if len(ret_ops) == 0:
+                raise TypeError("Cannot calculate variable %s in this network",
+                                output)
+
+            net = core.Net.create()
+            for i in xrange(len(ret_ops)):
+                net.add_op(ret_ops[-i])
+            return net
+
+    @staticmethod
+    def any_in_set(names, name_set):
+        """
+        Returns true if any element in set.
+        """
+        for name in names:
+            if name in name_set:
+                return True
+        return False
+
+    def add_param_to_init_network(self, default_name, param, dims):
+        """
+        Add parameter to initialize network
+        """
+        if not isinstance(param, ParameterAttribute):
+            param = ParameterAttribute()
+
+        if param.name is not None:
+            name = param.name
+        else:
+            name = default_name
+        var = self.scope.new_var(name)
+        tensor = var.get_tensor()
+        tensor.set_dims(dims)
+        init_op = Operator(
+            "uniform_random",
+            Out=name,
+            dims=dims,
+            min=param.initial_min,
+            max=param.initial_max)
+        self.init_network.add_op(init_op)
+        return name
+
+    def assert_not_create_var(self, name):
+        """
+        Assert a variable has not been created.
+        """
+        var = self.scope.find_var(name)
+        if var is not None:
+            raise ValueError("Variable %s has been created in this model", name)
+
+
+g_model = Model()
+
+
+# The function below can be automatically generated in runtime.
+def data_layer(*args, **kwargs):
+    return g_model.data_layer(*args, **kwargs)
+
+
+def fc_layer(*args, **kwargs):
+    return g_model.fc_layer(*args, **kwargs)
+
+
+def init_params():
+    g_model.init_params()
+
+
+def forward(*args, **kwargs):
+    g_model.forward(*args, **kwargs)

--- a/python/paddle/v2/framework/tests/CMakeLists.txt
+++ b/python/paddle/v2/framework/tests/CMakeLists.txt
@@ -14,4 +14,5 @@ add_python_test(test_framework
     test_softmax_op.py
     test_rowwise_add_op.py
     test_network.py
-    gradient_checker.py)
+    gradient_checker.py
+    test_uniform_random_op.py)

--- a/python/paddle/v2/framework/tests/test_model.py
+++ b/python/paddle/v2/framework/tests/test_model.py
@@ -1,0 +1,16 @@
+from paddle.v2.framework.model import *
+import unittest
+
+
+class TestModel(unittest.TestCase):
+    def test_simple_fc(self):
+        img = data_layer(name="img", dims=784)
+        hidden1 = fc_layer(input=img, size=200, act="sigmoid")
+        hidden2 = fc_layer(input=hidden1, size=200, act="sigmoid")
+        fc_layer(input=hidden2, size=10, act='softmax')
+        init_params()
+        forward({"img": numpy.random.random((100, 784)).astype('float32')})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/v2/framework/tests/test_uniform_random_op.py
+++ b/python/paddle/v2/framework/tests/test_uniform_random_op.py
@@ -1,0 +1,35 @@
+import unittest
+from paddle.v2.framework.op import Operator
+import paddle.v2.framework.core as core
+import numpy
+
+
+class UniformRandomTest(unittest.TestCase):
+    def test_uniform_random_cpu(self):
+        self.uniform_random_test(place=core.CPUPlace())
+
+    def test_uniform_random_gpu(self):
+        if core.is_compile_gpu():
+            self.uniform_random_test(place=core.GPUPlace(0))
+
+    def uniform_random_test(self, place):
+        scope = core.Scope()
+        scope.new_var("X").get_tensor()
+
+        op = Operator(
+            "uniform_random",
+            Out="X",
+            dims=[1000, 784],
+            min=-5.0,
+            max=10.0,
+            seed=10)
+
+        op.infer_shape(scope)
+        ctx = core.DeviceContext.create(place)
+        op.run(scope, ctx)
+        tensor = numpy.array(scope.find_var("X").get_tensor())
+        self.assertAlmostEqual(tensor.mean(), 2.5, delta=0.1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Trying to give a possible implementation to fix #3129. Try to remove the gap between `operator` and `paddle.v2` API.

1. 我们可能需要很多个网络来完成高层API的设计。他们包括:
   * 前向的网络
   * 参数初始化网路
   * 参数保存/载入网络
   * 反向网络

2. 我们的API，`xxx_layer`可以返回一个Variable的名字。如果我们需要返回Variable，则需要有一个方法可以获取到这个Variable的名字。
3. 配置每层的时候，立即创建Op和InferShape，报错可以尽早完成。
4. forward运行的时候，如果指定了输出，可以从一个完整网络提取出产生这个输出的子网络。进而运行那个子网络。(避免了反向处理复杂依赖)
