### PR TITLE
reduce time of test_TrainerOnePass

### DIFF
--- a/paddle/trainer/tests/simple_sparse_neural_network.py
+++ b/paddle/trainer/tests/simple_sparse_neural_network.py
@@ -1,6 +1,6 @@
 from paddle.trainer_config_helpers import *
 
-settings(batch_size=128, learning_method=AdaGradOptimizer(), learning_rate=1e-4)
+settings(batch_size=17, learning_method=AdaGradOptimizer(), learning_rate=1e-4)
 
 file_list = 'trainer/tests/fake_file_list.list'
 
@@ -12,7 +12,7 @@ define_py_data_sources2(
 
 embedding = embedding_layer(
     input=data_layer(
-        name="word_ids", size=65536),
+        name="word_ids", size=8191),
     size=128,
     param_attr=ParamAttr(sparse_update=True))
 prediction = fc_layer(input=embedding, size=10, act=SoftmaxActivation())

--- a/paddle/trainer/tests/simple_sparse_neural_network_dp.py
+++ b/paddle/trainer/tests/simple_sparse_neural_network_dp.py
@@ -7,15 +7,15 @@ def init_hook(settings, is_train, **kwargs):
 
 
 @provider(
-    input_types={'word_ids': integer_value(65536),
+    input_types={'word_ids': integer_value(8191),
                  'label': integer_value(10)},
     min_pool_size=0,
     init_hook=init_hook)
 def process(settings, filename):
     if settings.is_train:
-        data_size = 2**20
-    else:
         data_size = 2**10
+    else:
+        data_size = 2**5
 
     for _ in xrange(data_size):
-        yield random.randint(0, 65535), random.randint(0, 9)
+        yield random.randint(0, 8190), random.randint(0, 9)

--- a/paddle/trainer/tests/test_TrainerOnePass.cpp
+++ b/paddle/trainer/tests/test_TrainerOnePass.cpp
@@ -100,25 +100,25 @@ TEST(average_window, gpu) {
 }
 
 TEST(average_window, gpu2) {
-  FLAGS_num_passes = 100;
+  FLAGS_num_passes = 20;
   trainerOnePassTest(configFile1, true, false, 2, 0.01);
   FLAGS_num_passes = 1;
 }
 
 TEST(average_window, gpu4) {
-  FLAGS_num_passes = 100;
+  FLAGS_num_passes = 20;
   trainerOnePassTest(configFile1, true, false, 4, 0.01);
   FLAGS_num_passes = 1;
 }
 
 TEST(average_window_cpu, gpu2) {
-  FLAGS_num_passes = 100;
+  FLAGS_num_passes = 20;
   trainerOnePassTest(configFile1, true, false, 2, 0.01, true);
   FLAGS_num_passes = 1;
 }
 
 TEST(average_window_cpu, gpu4) {
-  FLAGS_num_passes = 100;
+  FLAGS_num_passes = 20;
   trainerOnePassTest(configFile1, true, false, 4, 0.01, true);
   FLAGS_num_passes = 1;
 }


### PR DESCRIPTION
partly fix #3259 
`test_TrainerOnePass`的单测分成两种：
1. TEST(checkRemoteUpdater, XXX)：共有10个，每个消耗4s（在本地测）。调用`checkRemoteParameterUpdaterTest`函数，主要消耗在启动pserver的部分，对这一部分没有进行修改。下面是其中的一个具体时间。
```
64: [ RUN      ] checkRemoteUpdater.gpu2TrainerOldUpdater
64: I0807 12:06:49.846887  2287 test_TrainerOnePass.cpp:235]  useGpu=1 trainerCount=2 configFile=trainer/tests/sample_trainer_config.conf
64: I0807 12:06:49.846958  7112 LightNetwork.cpp:269] tcp server start 
64: [INFO 2017-08-07 12:06:49,858 networks.py:1491] The input order is [input, label]
64: [INFO 2017-08-07 12:06:49,858 networks.py:1497] The output order is [__cost_0__]
64: I0807 12:06:49.862642  2287 Trainer.cpp:165] trainer mode: Normal
64: I0807 12:06:49.862903  2287 MultiGradientMachine.cpp:99] numLogicalDevices=1 numThreads=2 numDevices=4
64: I0807 12:06:49.865258  2287 DataProvider.cpp:388] load data file trainer/tests/sample_data.txt
64: I0807 12:06:49.865303  2287 DataProvider.cpp:391] read done, num of instance=10 data size=30
64: I0807 12:06:49.865449  2287 DataProvider.cpp:388] load data file trainer/tests/sample_data.txt
64: I0807 12:06:49.865481  2287 DataProvider.cpp:391] read done, num of instance=10 data size=30
64: I0807 12:06:49.865561  2287 GradientMachine.cpp:85] Initing parameters..
64: I0807 12:06:49.867841  2287 GradientMachine.cpp:92] Init parameters done.
64: I0807 12:06:49.871497  2287 ParameterClient2.cpp:114] pserver 0 127.0.0.1:38110
64: I0807 12:06:49.871615  7121 LightNetwork.cpp:322] worker started, peer = 127.0.0.1
64: I0807 12:06:51.872315  7121 ParameterServer2.cpp:256] pserver: setParameter
64: I0807 12:06:51.872351  7121 ParameterServer2.cpp:302] pserver: new cpuvector: size=16384
64: I0807 12:06:51.872582  8344 ParameterClient2.cpp:114] pserver 0 127.0.0.1:38110
64: I0807 12:06:51.872742  8345 LightNetwork.cpp:322] worker started, peer = 127.0.0.1
64: I0807 12:06:53.879446  2287 test_TrainerOnePass.cpp:214] ___fc_layer_0__.w0  diff=0              
64: I0807 12:06:53.879509  2287 test_TrainerOnePass.cpp:214] ___fc_layer_1__.w0  diff=0              
64: I0807 12:06:53.879547  2287 test_TrainerOnePass.cpp:214] ___fc_layer_2__.w0  diff=0              
64: I0807 12:06:53.879582  2287 test_TrainerOnePass.cpp:214] sharew              diff=0              
64: I0807 12:06:53.879611  2287 test_TrainerOnePass.cpp:214] ___fc_layer_4__.w0  diff=0              
64: I0807 12:06:53.879647  2287 test_TrainerOnePass.cpp:214] ___fc_layer_5__.w0  diff=0              
64: I0807 12:06:53.879675  2287 test_TrainerOnePass.cpp:214] ___fc_layer_6__.w0  diff=0              
64: I0807 12:06:53.879709  2287 test_TrainerOnePass.cpp:214] ___fc_layer_7__.w0  diff=0              
64: I0807 12:06:53.879737  2287 test_TrainerOnePass.cpp:214] ___fc_layer_7__.wbiasdiff=0              
64: I0807 12:06:53.879771  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w0     diff=0              
64: I0807 12:06:53.879806  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w1     diff=0              
64: I0807 12:06:53.879842  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w2     diff=0              
64: I0807 12:06:53.879873  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w4     diff=0              
64: I0807 12:06:53.879906  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w5     diff=0              
64: I0807 12:06:53.879935  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w6     diff=0              
64: I0807 12:06:53.879969  2287 test_TrainerOnePass.cpp:214] ___mixed_0__.w7     diff=0              
64: I0807 12:06:53.880100  8344 SocketChannel.cpp:42] destory connection in socket channel, peer = 127.0.0.1
64: I0807 12:06:53.880110  8345 LightNetwork.cpp:339] worker begin to finish, peer = 127.0.0.1
64: I0807 12:06:53.880129  7121 ParameterServer2.cpp:564] pserver: getParameter
64: I0807 12:06:53.880147  8345 SocketChannel.cpp:42] destory connection in socket channel, peer = 127.0.0.1
64: I0807 12:06:53.880996  7121 LightNetwork.cpp:339] worker begin to finish, peer = 127.0.0.1
64: I0807 12:06:53.880998  2287 SocketChannel.cpp:42] destory connection in socket channel, peer = 127.0.0.1
64: I0807 12:06:53.881031  7121 SocketChannel.cpp:42] destory connection in socket channel, peer = 127.0.0.1
64: I0807 12:06:53.881778  7112 LightNetwork.cpp:215] pserver accept thread finish, addr= port=38110
64: I0807 12:06:53.881824  2287 SocketChannel.cpp:42] destory connection in socket channel, peer = 127.0.0.1
64: [       OK ] checkRemoteUpdater.gpu2TrainerOldUpdater (4035 ms)
``` 
2. 其余调用`trainerOnePassTest`，通过设置稍小一点的data_size, num_pass, 时间从几十s下降到几s。