### PR TITLE
Demangle exception call stack for PADDLE_ENFORCE

### DIFF
--- a/paddle/platform/enforce.h
+++ b/paddle/platform/enforce.h
@@ -79,9 +79,11 @@ struct EnforceNotMet : public std::exception {
       for (int i = 0; i < size; ++i) {
         if (dladdr(call_stack[i], &info)) {
           auto demangled = demangle(info.dli_sname);
-          sout << string::Sprintf(
-              "%-3d %*0p %s + %zd\n", i, 2 + sizeof(void*) * 2, call_stack[i],
-              demangled, (char*)call_stack[i] - (char*)info.dli_saddr);
+          auto addr_offset = static_cast<char*>(call_stack[i]) -
+                             static_cast<char*>(info.dli_saddr);
+          sout << string::Sprintf("%-3d %*0p %s + %zd\n", i,
+                                  2 + sizeof(void*) * 2, call_stack[i],
+                                  demangled, addr_offset);
         } else {
           sout << string::Sprintf("%-3d %*0p %s\n", i, 2 + sizeof(void*) * 2,
                                   call_stack[i]);

--- a/paddle/platform/enforce.h
+++ b/paddle/platform/enforce.h
@@ -14,13 +14,19 @@ limitations under the License. */
 
 #pragma once
 
-#include <execinfo.h>
+#include <dlfcn.h>     // for dladdr
+#include <execinfo.h>  // for backtrace
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
 #include <string>
+
 #include "paddle/string/printf.h"
 #include "paddle/string/to_string.h"
+
+#ifdef __GNUC__
+#include <cxxabi.h>  // for __cxa_demangle
+#endif
 
 #ifndef PADDLE_ONLY_CPU
 
@@ -39,6 +45,19 @@ limitations under the License. */
 namespace paddle {
 namespace platform {
 
+namespace {
+#ifdef __GNUC__
+inline std::string demangle(std::string name) {
+  int status = -4;  // some arbitrary value to eliminate the compiler warning
+  std::unique_ptr<char, void (*)(void*)> res{
+      abi::__cxa_demangle(name.c_str(), NULL, NULL, &status), std::free};
+  return (status == 0) ? res.get() : name;
+}
+#else
+inline std::string demangle(std::string name) { return name; }
+#endif
+}
+
 struct EnforceNotMet : public std::exception {
   std::exception_ptr exp_;
   std::string err_str_;
@@ -48,15 +67,27 @@ struct EnforceNotMet : public std::exception {
       std::rethrow_exception(exp_);
     } catch (const std::exception& exp) {
       std::ostringstream sout;
+
       sout << string::Sprintf("%s at [%s:%d]", exp.what(), f, l) << std::endl;
-      sout << "Call Stacks: " << std::endl;
+      sout << "PaddlePaddle Call Stacks: " << std::endl;
+
       void* call_stack[TRACE_STACK_LIMIT];
-      int sz = backtrace(call_stack, TRACE_STACK_LIMIT);
-      auto line = backtrace_symbols(call_stack, sz);
-      for (int i = 0; i < sz; ++i) {
-        sout << line[i] << std::endl;
+      auto size = backtrace(call_stack, TRACE_STACK_LIMIT);
+      auto symbols = backtrace_symbols(call_stack, size);
+
+      Dl_info info;
+      for (int i = 0; i < size; ++i) {
+        if (dladdr(call_stack[i], &info)) {
+          auto demangled = demangle(info.dli_sname);
+          sout << string::Sprintf(
+              "%-3d %*0p %s + %zd\n", i, 2 + sizeof(void*) * 2, call_stack[i],
+              demangled, (char*)call_stack[i] - (char*)info.dli_saddr);
+        } else {
+          sout << string::Sprintf("%-3d %*0p %s\n", i, 2 + sizeof(void*) * 2,
+                                  call_stack[i]);
+        }
       }
-      free(line);
+      free(symbols);
       err_str_ = sout.str();
     }
   }
@@ -170,7 +201,7 @@ inline void throw_on_error(T e) {
  *    PADDLE_ENFORCE_EQ(a, b);
  *
  *    will raise an expression described as follows:
- *    "enforce a == b failed, 1 != 2" with detailed stack infomation.
+ *    "enforce a == b failed, 1 != 2" with detailed stack information.
  *
  *    extra messages is also supported, for example:
  *    PADDLE_ENFORCE(a, b, "some simple enforce failed between %d numbers", 2)

--- a/paddle/platform/enforce.h
+++ b/paddle/platform/enforce.h
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <dlfcn.h>     // for dladdr
 #include <execinfo.h>  // for backtrace
 #include <iomanip>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
fix #3462 

After this PR, if we meet some exceptions like this:

```c++
TEST(ENFORCE_USER_DEFINED_CLASS, EQ) {
  Dims a{{1, 3, 3, 4}}, b{{1, 2, 3, 4}};
  PADDLE_ENFORCE_EQ(a, b);
}
```

Call Stack:
```c++
: [ RUN      ] ENFORCE_USER_DEFINED_CLASS.EQ
68: unknown file: Failure
68: C++ exception with description "enforce a == b failed, [1, 3, 3, 4] != [1, 2, 3, 4]
68:  at [/Users/liaogang/baidu/Paddle/paddle/platform/enforce_test.cc:210]
68: PaddlePaddle Call Stacks:
68: 0          0x1051a58e0p paddle::platform::EnforceNotMet::EnforceNotMet(std::exception_ptr, char const*, int) + 768
68: 1          0x1051a4f79p ENFORCE_USER_DEFINED_CLASS_EQ_Test::TestBody() + 377
68: 2          0x1051b957bp void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) + 75
68: 3          0x1051b94cep testing::Test::Run() + 254
68: 4          0x1051ba4e2p testing::TestInfo::Run() + 306
68: 5          0x1051bad73p testing::TestCase::Run() + 275
68: 6          0x1051c2e59p testing::internal::UnitTestImpl::RunAllTests() + 1241
68: 7          0x1051c27c0p bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) + 80
68: 8          0x1051c271ep testing::UnitTest::Run() + 174
68: 9          0x1051d40d1p main + 49
68: 10      0x7fffa9e0c235p start + 1
68: 11                 0x1p " thrown in the test body.
68: [  FAILED  ] ENFORCE_USER_DEFINED_CLASS.EQ (0 ms)
```