### PR TITLE
add shared warpctc lib in whl

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -31,7 +31,9 @@ paddle_bins = ['${PADDLE_BINARY_DIR}/paddle/scripts/paddle_usage',
                '${PADDLE_BINARY_DIR}/paddle/pserver/paddle_pserver_main']
 
 paddle_rt_lib_dir = 'local/lib'
-paddle_rt_libs = [] if '${MKL_SHARED_LIBS}'== '' else '${MKL_SHARED_LIBS}'.split(';')
+paddle_rt_libs = ['${WARPCTC_LIBRARIES}']
+if '${MKL_SHARED_LIBS}'!= '':
+  paddle_rt_libs += '${MKL_SHARED_LIBS}'.split(';')
 
 setup(name='paddlepaddle',
       version='${PADDLE_VERSION}',


### PR DESCRIPTION
Inspired by #3461 , add shared warpctc lib in whl. 
- Thus, after `pip install *.whl`, we can run warpctc layer exactly. 
- Before this PR, we should `export LD_LIBRARY_PATH=$PADDLE_INSTALL_DIR/Paddle/third_party/install/warpctc/lib:$LD_LIBRARY_PATH` to run warpctc layer.