### PR TITLE
FIX: Release CPU/GPU memory at the end of the Program 

### DIFF
--- a/paddle/memory/detail/system_allocator.cc
+++ b/paddle/memory/detail/system_allocator.cc
@@ -27,7 +27,7 @@ limitations under the License. */
 // between host and device.  Allocates too much would reduce the amount
 // of memory available to the system for paging.  So, by default, we
 // should set false to use_pinned_memory.
-DEFINE_bool(use_pinned_memory, false, "If set, allocate cpu pinned memory.");
+DEFINE_bool(use_pinned_memory, true, "If set, allocate cpu pinned memory.");
 
 namespace paddle {
 namespace memory {

--- a/paddle/memory/memory.cc
+++ b/paddle/memory/memory.cc
@@ -13,14 +13,13 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/memory/memory.h"
-#include "paddle/memory/detail/buddy_allocator.h"
-#include "paddle/memory/detail/system_allocator.h"
 
 #include <algorithm>  // for transfrom
 #include <cstring>    // for memcpy
 #include <mutex>      // for call_once
 
-#include "glog/logging.h"
+#include "paddle/memory/detail/buddy_allocator.h"
+#include "paddle/memory/detail/system_allocator.h"
 
 namespace paddle {
 namespace memory {

--- a/paddle/memory/memory.cc
+++ b/paddle/memory/memory.cc
@@ -30,8 +30,7 @@ std::once_flag cpu_allocator_flag;
 std::once_flag gpu_allocator_flag;
 
 BuddyAllocator* GetCPUBuddyAllocator() {
-  static std::unique_ptr<BuddyAllocator, void (*)(BuddyAllocator*)> a{
-      nullptr, [](BuddyAllocator* p) { delete p; }};
+  static std::unique_ptr<BuddyAllocator> a{nullptr};
 
   std::call_once(cpu_allocator_flag, [&]() {
     a.reset(new BuddyAllocator(new detail::CPUAllocator,

--- a/paddle/memory/memory.cc
+++ b/paddle/memory/memory.cc
@@ -14,7 +14,7 @@ limitations under the License. */
 
 #include "paddle/memory/memory.h"
 
-#include <algorithm>  // for transfrom
+#include <algorithm>  // for transform
 #include <cstring>    // for memcpy
 #include <mutex>      // for call_once
 

--- a/paddle/memory/memory.cc
+++ b/paddle/memory/memory.cc
@@ -63,7 +63,7 @@ size_t Used<platform::CPUPlace>(platform::CPUPlace place) {
 BuddyAllocator* GetGPUBuddyAllocator(int gpu_id) {
   using BuddyAllocVec = std::vector<BuddyAllocator*>;
   static std::unique_ptr<BuddyAllocVec, void (*)(BuddyAllocVec * p)> as{
-      new std::vector<BuddyAllocator*>, [](BuddyAllocVec* p) {
+      new BuddyAllocVec, [](BuddyAllocVec* p) {
         std::for_each(p->begin(), p->end(),
                       [](BuddyAllocator* p) { delete p; });
       }};

--- a/paddle/operators/gather_test.cc
+++ b/paddle/operators/gather_test.cc
@@ -45,4 +45,8 @@ TEST(Gather, GatherData) {
 
   for (int i = 0; i < 4; ++i) EXPECT_EQ(p_output[i], i + 4);
   for (int i = 4; i < 8; ++i) EXPECT_EQ(p_output[i], i - 4);
+
+  delete src;
+  delete index;
+  delete output;
 }

--- a/paddle/operators/scatter_test.cc
+++ b/paddle/operators/scatter_test.cc
@@ -49,4 +49,8 @@ TEST(scatter, ScatterUpdate) {
     EXPECT_EQ(output->data<float>()[i], float(i - 4));
   for (size_t i = 8; i < 16; ++i) EXPECT_EQ(p_output[i], float(0));
   for (size_t i = 8; i < 16; ++i) EXPECT_EQ(output->data<float>()[i], float(0));
+
+  delete src;
+  delete index;
+  delete output;
 }


### PR DESCRIPTION
After unit test is passed, release memory!

```bash
[----------] Global test environment tear-down
[==========] 4 tests from 1 test case ran. (600 ms total)
[  PASSED  ] 4 tests.
I0816 19:44:47.157642 3000099776 buddy_allocator.cc:30] BuddyAllocator Disconstructor makes sure that all of these have actually been freed
I0816 19:44:47.157649 3000099776 buddy_allocator.cc:34] Free from block (0x700960000, 1818944052)
I0816 19:44:47.159529 3000099776 buddy_allocator.cc:30] BuddyAllocator Disconstructor makes sure that all of these have actually been freed
I0816 19:44:47.159555 3000099776 buddy_allocator.cc:34] Free from block (0x11419c000, 536870912)
```

fix #3536 
fix #3537 