### PR TITLE
Change class to struct in GemmFunctor to avoid errors on special compilers

### DIFF
--- a/paddle/function/GemmFunctor.cpp
+++ b/paddle/function/GemmFunctor.cpp
@@ -84,7 +84,7 @@ struct BlasGemm<DEVICE_TYPE_GPU, T> {
   }
 };
 
-template class BlasGemm<DEVICE_TYPE_CPU, real>;
-template class BlasGemm<DEVICE_TYPE_GPU, real>;
+template struct BlasGemm<DEVICE_TYPE_CPU, real>;
+template struct BlasGemm<DEVICE_TYPE_GPU, real>;
 
 }  // namespace paddle


### PR DESCRIPTION
Since compiling error `class template 'BlasGemm' was previously declared as a struct template` was encountered when compiled by native compilers `c++` and `cc`, will it be better to change `template class BlasGemm<DEVICE_TYPE_CPU, real>` to `template struct BlasGemm<DEVICE_TYPE_CPU, real>`.