### PR TITLE
fix ids reverse order in fillGenOutputs

### DIFF
--- a/paddle/gserver/gradientmachines/RecurrentGradientMachine.cpp
+++ b/paddle/gserver/gradientmachines/RecurrentGradientMachine.cpp
@@ -1344,7 +1344,7 @@ void RecurrentGradientMachine::fillGenOutputs() {
       CHECK(!finalPaths_[i].empty());
       Path& path = finalPaths_[i][0];
       generator_.ids.insert(
-          generator_.ids.begin(), path.ids.begin(), path.ids.end());
+          generator_.ids.end(), path.ids.begin(), path.ids.end());
       starts[i + 1] = starts[i] + path.ids.size();
     }
   }


### PR DESCRIPTION
When numResults == 1, path.ids are wrongly inserted into the beginning of generator_.ids. This is fine if the batchSize == 1, but will have an reverse batch if batchSize > 1. The .begin() should be changed to .end(). The original code '.begin()' must be a typo.