### PR TITLE
Remove build_android task from travis temporarily

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
     - $HOME/.ccache
     - $HOME/.cache/pip
     - $TRAVIS_BUILD_DIR/build/third_party
-    - $TRAVIS_BUILD_DIR/build_android/third_party
 sudo: required
 dist: trusty
 os:
@@ -12,7 +11,6 @@ os:
 env:
   - JOB=build_doc
   - JOB=check_style
-  - JOB=build_android
 addons:
   apt:
     packages:


### PR DESCRIPTION
fixes https://github.com/PaddlePaddle/Paddle/issues/3951

Remove `build_android` task from travis temporarily to avoid failure on travis because of the cache of third_party. The detail of compiling error is listed as following:
```bash
[100%] Built target gtest_main
Install the project...
-- Install configuration: ""
-- Installing: /usr/local/lib/libgmock.a
CMake Error at googlemock/cmake_install.cmake:36 (file):
  file INSTALL cannot copy file
  "/home/travis/build/PaddlePaddle/Paddle/build_android/third_party/gtest/src/extern_gtest-build/googlemock/libgmock.a"
  to "/usr/local/lib/libgmock.a".
Call Stack (most recent call first):
  cmake_install.cmake:37 (include)
make[3]: *** [install] Error 1
make[2]: *** [third_party/gtest/src/extern_gtest-stamp/extern_gtest-install] Error 2
make[1]: *** [CMakeFiles/extern_gtest.dir/all] Error 2
make: *** [all] Error 2
The command "timeout 2580 paddle/scripts/travis/${JOB}.sh # 43min timeout
RESULT=$?; if [ $RESULT -eq 0 ] || [ $RESULT -eq 142 ]; then true; else false; fi;
" exited with 1.
cache.2
store build cache
```