### PR TITLE
Fixed some ssd bugs.

### DIFF
--- a/paddle/gserver/layers/DetectionOutputLayer.cpp
+++ b/paddle/gserver/layers/DetectionOutputLayer.cpp
@@ -139,6 +139,7 @@ void DetectionOutputLayer::forward(PassType passType) {
                                        allDecodedBBoxes,
                                        &allIndices);
 
+  numKept = numKept > 0 ? numKept : 1;
   resetOutput(numKept, 7);
   MatrixPtr outV = getOutputValue();
   getDetectionOutput(confBuffer_->getData(),

--- a/paddle/gserver/layers/DetectionOutputLayer.cpp
+++ b/paddle/gserver/layers/DetectionOutputLayer.cpp
@@ -139,8 +139,13 @@ void DetectionOutputLayer::forward(PassType passType) {
                                        allDecodedBBoxes,
                                        &allIndices);
 
-  numKept = numKept > 0 ? numKept : 1;
-  resetOutput(numKept, 7);
+  if (numKept > 0) {
+    resetOutput(numKept, 7);
+  } else {
+    MatrixPtr outV = getOutputValue();
+    outV = NULL;
+    return;
+  }
   MatrixPtr outV = getOutputValue();
   getDetectionOutput(confBuffer_->getData(),
                      numKept,

--- a/paddle/gserver/layers/DetectionUtil.cpp
+++ b/paddle/gserver/layers/DetectionUtil.cpp
@@ -536,7 +536,6 @@ void getDetectionOutput(const real* confData,
   MatrixPtr outBuffer;
   Matrix::resizeOrCreate(outBuffer, numKept, 7, false, false);
   real* bufferData = outBuffer->getData();
-  for (size_t i = 0; i < 7; i++) bufferData[i] = -1;
   size_t count = 0;
   for (size_t n = 0; n < batchSize; ++n) {
     for (map<size_t, vector<size_t>>::const_iterator it = allIndices[n].begin();

--- a/paddle/gserver/layers/DetectionUtil.cpp
+++ b/paddle/gserver/layers/DetectionUtil.cpp
@@ -469,7 +469,7 @@ size_t getDetectionIndices(
     const size_t numClasses,
     const size_t backgroundId,
     const size_t batchSize,
-    const size_t confThreshold,
+    const real confThreshold,
     const size_t nmsTopK,
     const real nmsThreshold,
     const size_t keepTopK,
@@ -536,6 +536,8 @@ void getDetectionOutput(const real* confData,
   MatrixPtr outBuffer;
   Matrix::resizeOrCreate(outBuffer, numKept, 7, false, false);
   real* bufferData = outBuffer->getData();
+  for (size_t i = 0; i < 7; i++)
+     bufferData[i] = -1;
   size_t count = 0;
   for (size_t n = 0; n < batchSize; ++n) {
     for (map<size_t, vector<size_t>>::const_iterator it = allIndices[n].begin();

--- a/paddle/gserver/layers/DetectionUtil.cpp
+++ b/paddle/gserver/layers/DetectionUtil.cpp
@@ -537,7 +537,7 @@ void getDetectionOutput(const real* confData,
   Matrix::resizeOrCreate(outBuffer, numKept, 7, false, false);
   real* bufferData = outBuffer->getData();
   for (size_t i = 0; i < 7; i++)
-     bufferData[i] = -1;
+    bufferData[i] = -1;
   size_t count = 0;
   for (size_t n = 0; n < batchSize; ++n) {
     for (map<size_t, vector<size_t>>::const_iterator it = allIndices[n].begin();

--- a/paddle/gserver/layers/DetectionUtil.cpp
+++ b/paddle/gserver/layers/DetectionUtil.cpp
@@ -536,8 +536,7 @@ void getDetectionOutput(const real* confData,
   MatrixPtr outBuffer;
   Matrix::resizeOrCreate(outBuffer, numKept, 7, false, false);
   real* bufferData = outBuffer->getData();
-  for (size_t i = 0; i < 7; i++)
-    bufferData[i] = -1;
+  for (size_t i = 0; i < 7; i++) bufferData[i] = -1;
   size_t count = 0;
   for (size_t n = 0; n < batchSize; ++n) {
     for (map<size_t, vector<size_t>>::const_iterator it = allIndices[n].begin();

--- a/paddle/gserver/layers/DetectionUtil.h
+++ b/paddle/gserver/layers/DetectionUtil.h
@@ -275,7 +275,7 @@ size_t getDetectionIndices(
     const size_t numClasses,
     const size_t backgroundId,
     const size_t batchSize,
-    const size_t confThreshold,
+    const real confThreshold,
     const size_t nmsTopK,
     const real nmsThreshold,
     const size_t keepTopK,

--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -1223,7 +1223,8 @@ def detection_output_layer(input_loc,
                            name=None):
     """
     Apply the NMS to the output of network and compute the predict bounding
-    box location.
+    box location. The output of this layer could be None if there is no valid
+    bounding box.
 
     :param name: The Layer Name.
     :type name: basestring


### PR DESCRIPTION
ssd confidence threshold 需要是浮点数，在confidence threshold过大的时候，detection output层会没有输出, output resize时候会报错。我觉得应该判断这种情况并返回一个全-1的output。