### PR TITLE
[WIP] Using LoDTensor instead of Tensor in every operator.

### DIFF
--- a/paddle/framework/lod_tensor.h
+++ b/paddle/framework/lod_tensor.h
@@ -53,16 +53,22 @@ bool operator==(const LoD& a, const LoD& b);
  */
 class LoDTensor {
  public:
-  LoDTensor() {}
-  LoDTensor(const LoD& lod, Tensor* t) : lod_(lod), tensor_(t) {}
+  LoDTensor() : tensor_(new Tensor()) {}
+
+  LoDTensor(const LoD& lod) : lod_(lod), tensor_(new Tensor()) {}
+
+  ~LoDTensor() { delete tensor_; }
 
   void set_lod(const LoD& lod) { lod_ = lod; }
 
-  void set_tensor(Tensor* tensor) { tensor_ = tensor; }
-
-  Tensor& tensor() { return *tensor_; }
+  Tensor& tensor() {
+    PADDLE_ENFORCE(tensor_, "The tensor_ must be null.");
+    return *tensor_;
+  }
 
   LoD lod() { return lod_; }
+
+  void CopyLoDFrom(const LoDTensor& src) { set_lod(src.lod()); }
 
   /*
    * Get a element from LoD.

--- a/paddle/framework/variable.h
+++ b/paddle/framework/variable.h
@@ -29,6 +29,21 @@ class Variable {
     return *static_cast<const T*>(holder_->Ptr());
   }
 
+  // Specialized template for Tensor,
+  // so that the Tensor can be got from LoDTensor.
+  // How to get Tensor from LoDTensor also can be put in InferShapeContext.
+  template <>
+  const Tensor& Get<Tensor>() const {
+    if (IsType<LoDTensor>()) {
+      auto lod_t = static_cast<const LoDTensor*>(holder_->Ptr());
+      return *lod_t->tensor();
+    } else {
+      PADDLE_ENFORCE(IsType<Tensor>(),
+                     "Variable must be type LoDTensor or Tensor");
+      return *static_cast<const Tensor*>(holder_->Ptr());
+    }
+  }
+
   template <typename T>
   T* GetMutable() {
     if (!IsType<T>()) {

--- a/paddle/operators/mul_op.cc
+++ b/paddle/operators/mul_op.cc
@@ -45,7 +45,13 @@ class MulOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_EQ(
         x_mat_dims[1], y_mat_dims[0],
         "First matrix's width must be equal with second matrix's height.");
-    ctx.Output<Tensor>("Out")->Resize({x_mat_dims[0], y_mat_dims[1]});
+    // Each operator's InferShape must call Output<LoDTensor> to create
+    // LoDTensor in variable.
+    ctx.Output<LoDTensor>("Out")->tensor()->Resize(
+        {x_mat_dims[0], y_mat_dims[1]});
+    // Only the forward operator needs to pass the lod.
+    // pass the lod of Input(X) to output.
+    ctx.CopyLoD(/*in = */ "X", /* out = */ "Out");
   }
 };
 


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/4047
Fix https://github.com/PaddlePaddle/Paddle/issues/3717

解决的问题：

- LoDTensor管理成员变量`Tensor* tensor_`的构造和释放
  - 详细描述： https://github.com/PaddlePaddle/Paddle/issues/4047#issue-257042405
- 如何在不感知LoD的operators用LoDTensor替换Tensor
  - 详细描述： https://github.com/PaddlePaddle/Paddle/issues/4047#issuecomment-328853066
- 如何传递LoD
  -  详细描述：https://github.com/PaddlePaddle/Paddle/issues/4047#issuecomment-328853467


@wangkuiyi @reyoung @Superjom @QiJune @hedaoyuan 

- 这里只写了示例程序，还没有全局替换。
- 和大家讨论下，这种方式是否可以。
- 如果可行，再全局替换。