### PR TITLE
Benchmark of tensor serialization performance.

### DIFF
--- a/paddle/framework/CMakeLists.txt
+++ b/paddle/framework/CMakeLists.txt
@@ -1,10 +1,12 @@
 # ddim lib
+proto_library(framework_proto SRCS framework.proto)
+
 cc_library(ddim SRCS ddim.cc DEPS eigen3)
 cc_test(ddim_test SRCS ddim_test.cc DEPS ddim)
 nv_test(dim_test SRCS dim_test.cu DEPS ddim)
 
-cc_library(tensor SRCS tensor.cc DEPS ddim place paddle_memory device_context)
-cc_test(tensor_test SRCS tensor_test.cc DEPS tensor)
+cc_library(tensor SRCS tensor.cc DEPS ddim place paddle_memory device_context framework_proto)
+cc_test(mytensor_test SRCS tensor_test.cc DEPS tensor glog)
 cc_test(eigen_test SRCS eigen_test.cc DEPS tensor)
 
 cc_library(lod_tensor SRCS lod_tensor.cc DEPS ddim place tensor)
@@ -16,7 +18,6 @@ cc_test(variable_test SRCS variable_test.cc)
 cc_library(scope SRCS scope.cc)
 cc_test(scope_test SRCS scope_test.cc DEPS scope)
 
-proto_library(framework_proto SRCS framework.proto)
 
 cc_library(attribute SRCS attribute.cc DEPS framework_proto)
 cc_library(proto_desc SRCS var_desc.cc op_desc.cc block_desc.cc program_desc.cc DEPS attribute)

--- a/paddle/framework/framework.proto
+++ b/paddle/framework/framework.proto
@@ -120,8 +120,8 @@ message ProgramDesc { repeated BlockDesc blocks = 1; }
 message TTensor {
   optional DataType type = 1;
   optional int64 size = 2;
-  repeated float content = 3 [ packed = true ];
-  // repeated float content = 3;
+  // repeated float content = 3 [ packed = true ];
+  repeated float content = 3;
 }
 
 message TensorMeta {

--- a/paddle/framework/framework.proto
+++ b/paddle/framework/framework.proto
@@ -121,6 +121,7 @@ message TTensor {
   optional DataType type = 1;
   optional int64 size = 2;
   repeated float content = 3 [ packed = true ];
+  // repeated float content = 3;
 }
 
 message TensorMeta {

--- a/paddle/framework/framework.proto
+++ b/paddle/framework/framework.proto
@@ -116,3 +116,14 @@ message BlockDesc {
 }
 
 message ProgramDesc { repeated BlockDesc blocks = 1; }
+
+message TTensor {
+  optional DataType type = 1;
+  optional int64 size = 2;
+  repeated float content = 3 [ packed = true ];
+}
+
+message TensorMeta {
+  optional DataType type = 1;
+  optional int64 size = 2;
+}

--- a/paddle/framework/tensor.h
+++ b/paddle/framework/tensor.h
@@ -111,6 +111,18 @@ class Tensor {
 
   std::type_index type() const { return holder_->type(); }
 
+  std::string SerializeToString1() const;
+
+  void DeserializeFromString1(const std::string& s);
+
+  std::string SerializeToString2() const;
+
+  void DeserializeFromString2(const std::string& s);
+
+  std::string SerializeToString3() const;
+
+  void DeserializeFromString3(const std::string& s);
+
  private:
   template <typename T>
   inline void check_memory_size() const;

--- a/paddle/framework/tensor_test.cc
+++ b/paddle/framework/tensor_test.cc
@@ -342,13 +342,9 @@ TEST(Tensor, TestSpeed) {
   using namespace paddle::platform;
   Tensor src;
   Tensor dst;
-  // const long long size = 10000;
-  // float* src_ptr = src.mutable_data<float>({size, size}, CPUPlace());
-  // memset(src_ptr, 1, sizeof(float)*size*size);
-  // src_ptr[0] = 0;
 
   std::vector<int> arr = {1, 10, 100, 1000};
-  const int STOP = 10;
+  const int STOP = 1000;
   std::vector<std::vector<double>> metric(3);
 
   for (int j = 0; j < STOP; ++j) {

--- a/paddle/framework/tensor_test.cc
+++ b/paddle/framework/tensor_test.cc
@@ -275,3 +275,30 @@ TEST(Tensor, ReshapeToMatrix) {
   ASSERT_EQ(res.dims()[0], 2 * 3);
   ASSERT_EQ(res.dims()[1], 4 * 9);
 }
+
+TEST(Tensor, SerializeDeserialize) {
+  using namespace paddle::framework;
+  using namespace paddle::platform;
+  Tensor src;
+  int* src_ptr = src.mutable_data<int>({2, 3}, CPUPlace());
+  for (int i = 0; i < 2 * 3; ++i) {
+    src_ptr[i] = i;
+  }
+  std::string s1 = src.SerializeToString1();
+  std::string s2 = src.SerializeToString2();
+  std::string s3 = src.SerializeToString3();
+  Tensor dst;
+  dst.DeserializeFromString1(s1);
+  std::string d1 = dst.SerializeToString1();
+  EXPECT_STREQ(s1.c_str(), d1.c_str());
+}
+
+TEST(Tensor, TestSpeed) {
+  using namespace paddle::framework;
+  using namespace paddle::platform;
+  Tensor src;
+  int* src_ptr = src.mutable_data<int>({2, 3, 4, 9}, CPUPlace());
+  for (int i = 0; i < 2 * 3 * 4 * 9; ++i) {
+    src_ptr[i] = i;
+  }
+}


### PR DESCRIPTION
This PR is testing the speed of protobuf/pure C format/mixed options. In detail, [](https://github.com/PaddlePaddle/Paddle/pull/4602)

>Option 1: Use Protobuf to serialize tensor.
Protobuf is very bad for the large chunk of data.
Option 2: Write custom tensor serialization.
 The user needs to write the encoding and decoding code.
Option 3: Only use Protobuf to serialize tensor metadata, serialize the tensor memory block directly, and pack them together.This option depends on protobuf, but offers forward and backward compatibility.

 This PR will not merge into the code base, just for reviewing the code's correctness.