### PR TITLE
fix compiler error: ‘unique_ptr’ is not a member of ‘std’

### DIFF
--- a/paddle/framework/type_defs.h
+++ b/paddle/framework/type_defs.h
@@ -15,6 +15,7 @@
 #pragma once
 #include <functional>
 #include <map>
+#include <memory>
 #include "paddle/platform/variant.h"
 
 namespace paddle {


### PR DESCRIPTION
fix #4657 