### PR TITLE
Implementing Softplus operator

### DIFF
--- a/paddle/operators/activation_op.cc
+++ b/paddle/operators/activation_op.cc
@@ -188,6 +188,17 @@ class SquareOpMaker : public framework::OpProtoAndCheckerMaker {
   }
 };
 
+class SoftplusOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  SoftplusOpMaker(framework::OpProto *proto,
+                  framework::OpAttrChecker *op_checker)
+      : OpProtoAndCheckerMaker(proto, op_checker) {
+    AddInput("X", "Input of Softplus operator");
+    AddOutput("Y", "Output of Softplus operator");
+    AddComment("Softplus activation operator, softplus(x) = log(1 + exp(x))");
+  }
+};
+
 class SoftsignOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   SoftsignOpMaker(framework::OpProto *proto,
@@ -331,6 +342,9 @@ REGISTER_OP(log, ops::ActivationOp, ops::LogOpMaker, log_grad,
             ops::ActivationOpGrad);
 
 REGISTER_OP(square, ops::ActivationOp, ops::SquareOpMaker, square_grad,
+            ops::ActivationOpGrad);
+
+REGISTER_OP(softplus, ops::ActivationOp, ops::SoftplusOpMaker, softplus_grad,
             ops::ActivationOpGrad);
 
 REGISTER_OP(softsign, ops::ActivationOp, ops::SoftsignOpMaker, softsign_grad,

--- a/paddle/operators/activation_op.h
+++ b/paddle/operators/activation_op.h
@@ -388,7 +388,7 @@ struct SoftplusFunctor : public BaseActivationFunctor<T> {
     auto temp = x.cWiseMax(static_cast<T>(0));  // temp = max(x, 0)
     y.device(d) = temp + (((-temp).exp() + (x - temp).exp()).log());
   }
-}
+};
 
 // d(softplus(x))/dx = exp(x) / (1 + exp(x))
 // For numerical stability:
@@ -401,7 +401,7 @@ struct SoftplusGradFunctor : public BaseActivationFunctor<T> {
     auto temp = x.cWiseMax(static_cast<T>(0));  // temp = max(x, 0)
     dx.device(d) = dy * ((x - temp).exp() / ((-temp).exp() + (x - temp).exp()));
   }
-}
+};
 
 // softsign(x) = x / (1 + |x|)
 template <typename T>

--- a/paddle/operators/activation_op.h
+++ b/paddle/operators/activation_op.h
@@ -562,22 +562,25 @@ struct STanhGradFunctor : public BaseActivationFunctor<T> {
 }  // namespace operators
 }  // namespace paddle
 
-#define FOR_EACH_KERNEL_FUNCTOR(__macro)                         \
-  __macro(sigmoid, SigmoidFunctor, SigmoidGradFunctor);          \
-  __macro(exp, ExpFunctor, ExpGradFunctor);                      \
-  __macro(relu, ReluFunctor, ReluGradFunctor);                   \
-  __macro(tanh, TanhFunctor, TanhGradFunctor);                   \
-  __macro(sqrt, SqrtFunctor, SqrtGradFunctor);                   \
-  __macro(abs, AbsFunctor, AbsGradFunctor);                      \
-  __macro(reciprocal, ReciprocalFunctor, ReciprocalGradFunctor); \
-  __macro(log, LogFunctor, LogGradFunctor);                      \
-  __macro(square, SquareFunctor, SquareGradFunctor);             \
-  __macro(brelu, BReluFunctor, BReluGradFunctor);                \
-  __macro(soft_relu, SoftReluFunctor, SoftReluGradFunctor);      \
-  __macro(pow, PowFunctor, PowGradFunctor);                      \
-  __macro(stanh, STanhFunctor, STanhGradFunctor);                \
-  __macro(softplus, SoftplusFunctor, SoftplusGradFunctor);       \
-  __macro(softsign, SoftsignFunctor, SoftsignGradFunctor);       \
-  __macro(relu6, Relu6Functor, Relu6GradFunctor);                \
-  __macro(leaky_relu, LeakyReluFunctor, LeakyReluGradFunctor);   \
-  __macro(tanh_shrink, TanhShrinkFunctor, TanhShrinkGradFunctor)
+#define FOR_EACH_KERNEL_FUNCTOR(__macro)                          \
+  __macro(sigmoid, SigmoidFunctor, SigmoidGradFunctor);           \
+  __macro(logsigmoid, LogSigmoidFunctor, LogSigmoidGradFunctor);  \
+  __macro(exp, ExpFunctor, ExpGradFunctor);                       \
+  __macro(relu, ReluFunctor, ReluGradFunctor);                    \
+  __macro(tanh, TanhFunctor, TanhGradFunctor);                    \
+  __macro(softshrink, SoftShrinkFunctor, SoftShrinkGradFunctor);  \
+  __macro(sqrt, SqrtFunctor, SqrtGradFunctor);                    \
+  __macro(abs, AbsFunctor, AbsGradFunctor);                       \
+  __macro(reciprocal, ReciprocalFunctor, ReciprocalGradFunctor);  \
+  __macro(log, LogFunctor, LogGradFunctor);                       \
+  __macro(square, SquareFunctor, SquareGradFunctor);              \
+  __macro(brelu, BReluFunctor, BReluGradFunctor);                 \
+  __macro(soft_relu, SoftReluFunctor, SoftReluGradFunctor);       \
+  __macro(pow, PowFunctor, PowGradFunctor);                       \
+  __macro(stanh, STanhFunctor, STanhGradFunctor);                 \
+  __macro(softplus, SoftplusFunctor, SoftplusGradFunctor);        \
+  __macro(softsign, SoftsignFunctor, SoftsignGradFunctor);        \
+  __macro(relu6, Relu6Functor, Relu6GradFunctor);                 \
+  __macro(leaky_relu, LeakyReluFunctor, LeakyReluGradFunctor);    \
+  __macro(tanh_shrink, TanhShrinkFunctor, TanhShrinkGradFunctor); \
+  __macro(elu, ELUFunctor, ELUGradFunctor)

--- a/paddle/operators/activation_op.h
+++ b/paddle/operators/activation_op.h
@@ -385,7 +385,7 @@ template <typename T>
 struct SoftplusFunctor : public BaseActivationFunctor<T> {
   template <typename Device, typename X, typename Y>
   void operator()(Device d, X x, Y y) {
-    auto temp = x.cWiseMax(static_cast<T>(0));  // temp = max(x, 0)
+    auto temp = x.cwiseMax(static_cast<T>(0));  // temp = max(x, 0)
     y.device(d) = temp + (((-temp).exp() + (x - temp).exp()).log());
   }
 };
@@ -398,7 +398,7 @@ template <typename T>
 struct SoftplusGradFunctor : public BaseActivationFunctor<T> {
   template <typename Device, typename X, typename Y, typename dY, typename dX>
   void operator()(Device d, X x, Y y, dY dy, dX dx) {
-    auto temp = x.cWiseMax(static_cast<T>(0));  // temp = max(x, 0)
+    auto temp = x.cwiseMax(static_cast<T>(0));  // temp = max(x, 0)
     dx.device(d) = dy * ((x - temp).exp() / ((-temp).exp() + (x - temp).exp()));
   }
 };

--- a/python/paddle/v2/framework/tests/test_activation_op.py
+++ b/python/paddle/v2/framework/tests/test_activation_op.py
@@ -311,6 +311,21 @@ class TestSTanh(OpTest):
         self.check_grad(['X'], 'Y', max_relative_error=0.007)
 
 
+class TestSoftplug(OpTest):
+    def setUp(self):
+        self.op_type = "softplus"
+        self.inputs = {
+            'X': np.random.uniform(-1, 1, [11, 17]).astype("float32")
+        }
+        self.outputs = {'Y': np.log(1 + np.exp(self.inputs['X']))}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Y', max_relative_error=0.007)
+
+
 class TestSoftsign(OpTest):
     def setUp(self):
         self.op_type = "softsign"

--- a/python/paddle/v2/framework/tests/test_activation_op.py
+++ b/python/paddle/v2/framework/tests/test_activation_op.py
@@ -311,7 +311,7 @@ class TestSTanh(OpTest):
         self.check_grad(['X'], 'Y', max_relative_error=0.007)
 
 
-class TestSoftplug(OpTest):
+class TestSoftplus(OpTest):
     def setUp(self):
         self.op_type = "softplus"
         self.inputs = {


### PR DESCRIPTION
Fixes #4442 

Original formula:   y = log (1 + exp(x))

Following similar trick as in #4663 for numerical stability (reference below):
https://hips.seas.harvard.edu/blog/2013/01/09/computing-log-sum-exp/