### PR TITLE
Simplify backward when inserting a sum operator to accumulate all duplicated variables

### DIFF
--- a/paddle/framework/backward.cc
+++ b/paddle/framework/backward.cc
@@ -172,30 +172,14 @@ static std::unique_ptr<OperatorBase> BackwardRecursive(
                               std::to_string(i));
         net->ops_[op_offset]->Rename(name, dup_outputs.back());
       }
-      // collect all the offset to append `add` op for each alias
-      //
-      // one variable is shared between multiple operators.
-      // insert add operator one by one, then add it to output
-      for (size_t output_idx = 0; output_idx < dup_outputs.size() - 1;
-           ++output_idx) {
-        auto insert_add_x = dup_outputs[output_idx];
-        auto insert_add_y = dup_outputs[output_idx + 1];
-        auto insert_add_out = name + "@SHARED@" + std::to_string(output_idx);
-        // first add op inserted
-        if (output_idx == dup_outputs.size() - 2) {
-          insert_add_out = name;
-        }
-        if (output_idx != 0) {
-          insert_add_y = name + "@SHARED@" + std::to_string(output_idx - 1);
-        }
-        insert_position.push_back(
-            {dup_op.back(),
-             OpRegistry::CreateOp("sum", {{"X", {insert_add_x, insert_add_y}}},
-                                  {{"Out", {insert_add_out}}}, {})});
-      }
+      // collect all the offset for each alias,
+      // insert a sum operator to add all aliases to output
+      insert_position.push_back(
+          {dup_op.back(), OpRegistry::CreateOp("sum", {{"X", dup_outputs}},
+                                               {{"Out", {name}}}, {})});
     }
 
-    // make sure the inserted `add` ops follow the BFS order.
+    // make sure the inserted `sum` ops follow the BFS order.
     insert_position.sort(
         [](const Pos& l, const Pos& r) { return l.first > r.first; });
 


### PR DESCRIPTION
Since `sum_op` is used instead of `add_op`, and it supports to accumulate a vector of variables at one time, we do not need to insert multiple `sum_op` to add those inputs one by one. Just add all inputs in one `sum_op`.

I make a simple test based on `interp_op`. See diff of `interp_op`:
```diff
$ git diff interp_op.cc
diff --git a/paddle/operators/interp_op.cc b/paddle/operators/interp_op.cc
index d02b01c..08302b7 100644
--- a/paddle/operators/interp_op.cc
+++ b/paddle/operators/interp_op.cc
@@ -54,6 +54,10 @@ class InterpOp : public NetOp {
     // Out = MulOut + Y = (X - Y) * W + Y = X * W + Y * (1 - W)
     AppendOp(framework::OpRegistry::CreateOp("elementwise_add",
                                              {{"X", {mul_out}}, {"Y", {y}}},
+                                             {{"Out", {Output("SubOut")}}}, {}));
+
+    AppendOp(framework::OpRegistry::CreateOp("elementwise_add",
+                                             {{"X", {sub_out}}, {"Y", {y}}},
                                              {{"Out", {Output("Out")}}}, {}));
 
     CompleteAddOp(false);
```

The `DebugString` of `interp_op`:
```
147: Op(interp), inputs:{W[W], X[X], Y[Y]}, outputs:{MulOut[MulOut], Out[Out], SubOut[SubOut]}.
147: Op(elementwise_sub), inputs:{X[X], Y[Y]}, outputs:{Out[SubOut]}.
147: Op(elementwise_mul), inputs:{X[SubOut], Y[W]}, outputs:{Out[MulOut]}.
147: Op(elementwise_add), inputs:{X[MulOut], Y[Y]}, outputs:{Out[SubOut]}.
147: Op(elementwise_add), inputs:{X[SubOut], Y[Y]}, outputs:{Out[Out]}.
```

The `DebugString` of `interp_grad_op` in previous implementation:
```
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_add_grad), inputs:{Out[Out], Out@GRAD[Out@GRAD], X[SubOut], Y[Y]}, outputs:{X@GRAD[SubOut@GRAD], Y@GRAD[Y@GRAD]}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_add_grad), inputs:{Out[SubOut], Out@GRAD[SubOut@GRAD], X[MulOut], Y[Y]}, outputs:{X@GRAD[MulOut@GRAD], Y@GRAD[Y@GRAD]}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_mul_grad), inputs:{Out[MulOut], Out@GRAD[MulOut@GRAD], X[SubOut], Y[W]}, outputs:{X@GRAD[SubOut@GRAD], Y@GRAD[W@GRAD]}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_sub_grad), inputs:{Out[SubOut], Out@GRAD[SubOut@GRAD], X[X], Y[Y]}, outputs:{X@GRAD[X@GRAD], Y@GRAD[Y@GRAD]}.
147: Op(sum), inputs:{X[Y@GRAD@RENAME@0@0, Y@GRAD@RENAME@0@1]}, outputs:{Out[Y@GRAD@SHARED@0]}.
147: Op(sum), inputs:{X[Y@GRAD@RENAME@0@1, Y@GRAD@SHARED@0]}, outputs:{Out[Y@GRAD]}.
147: Op(sum), inputs:{X[SubOut@GRAD@RENAME@0@0, SubOut@GRAD@RENAME@0@1]}, outputs:{Out[SubOut@GRAD]}.
```

The `DebugString` of `interp_grad_op` in this PR:
```
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_add_grad), inputs:{Out[Out], Out@GRAD[Out@GRAD], X[SubOut], Y[Y]}, outputs:{X@GRAD[SubOut@GRAD], Y@GRAD[Y@GRAD]}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_add_grad), inputs:{Out[SubOut], Out@GRAD[SubOut@GRAD], X[MulOut], Y[Y]}, outputs:{X@GRAD[MulOut@GRAD], Y@GRAD[Y@GRAD]}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_mul_grad), inputs:{Out[MulOut], Out@GRAD[MulOut@GRAD], X[SubOut], Y[W]}, outputs:{X@GRAD[SubOut@GRAD], Y@GRAD[W@GRAD]}.
147: Op(plain_net), inputs:{}, outputs:{}.
147: Op(elementwise_sub_grad), inputs:{Out[SubOut], Out@GRAD[SubOut@GRAD], X[X], Y[Y]}, outputs:{X@GRAD[X@GRAD], Y@GRAD[Y@GRAD]}.
147: Op(sum), inputs:{X[Y@GRAD@RENAME@0@0, Y@GRAD@RENAME@0@1, Y@GRAD@RENAME@0@2]}, outputs:{Out[Y@GRAD]}.
147: Op(sum), inputs:{X[SubOut@GRAD@RENAME@0@0, SubOut@GRAD@RENAME@0@1]}, outputs:{Out[SubOut@GRAD]}.
```