### PR TITLE
Fix bug in computing output size of IdentityOffsetProjection

### DIFF
--- a/python/paddle/trainer/config_parser.py
+++ b/python/paddle/trainer/config_parser.py
@@ -559,6 +559,9 @@ class IdentityOffsetProjection(Projection):
                                                        **xargs)
         self.proj_conf.offset = offset
 
+    def calc_output_size(self, input_layer_config):
+        return 0  # depends on the outside MixedLayer
+
     def calc_parameter_size(self, input_size, output_size):
         return 0
 


### PR DESCRIPTION
The output size of IdentityOffsetProjection depends on the size of the outer MixedLayer. And the same instance of IdentityOffsetProjection may serve as input for multiple MixedLayer with different sizes. Therefore, the output size of IdentityOffsetProjection should be set as 0.

原理是IdentityOffsetProjection的size要由外层的mixed layer决定，而且同一个IdentityOffsetProjection可能会用在不同的mixed layer里，所以size是没法预先算出的，因而要设成0.