### PR TITLE
Ensure name is not set in bias_attr in gru_step_naive_layer

### DIFF
--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -3680,9 +3680,10 @@ def gru_step_naive_layer(input,
         size = input.size / 3
 
     if bias_attr and bias_attr.attr.get("parameter_name", None) is not None:
-        raise ValueError("You should not specify the name of bias parameters. "
-                         "Otherwise, the three bias will share the same "
-                         "parameter matrix.")
+        raise ValueError("You should not specify the field `name` in bias_attr."
+                         " Otherwise, the three biases, which correponding to "
+                         " the two gates and the mixed layer for computing Wx+b"
+                         ", will share the same parameter matrix unexpectedly.")
 
     def __gate__(gate_name, offset):
         with mixed_layer(

--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -3679,6 +3679,11 @@ def gru_step_naive_layer(input,
     if size is None:
         size = input.size / 3
 
+    if bias_attr and bias_attr.attr.get("parameter_name", None) is not None:
+        raise ValueError("You should not specify the name of bias parameters. "
+                         "Otherwise, the three bias will share the same "
+                         "parameter matrix.")
+
     def __gate__(gate_name, offset):
         with mixed_layer(
                 name=name + "_" + gate_name,


### PR DESCRIPTION
Ensure `name` is not set in `bias_attr` in `gru_step_naive_layer`. Otherwise, the three biases will share the same parameter unexpectedly.
Fixes #4829 