### PR TITLE
Design: set set_program_desc to simplify layer input arguments

### DIFF
--- a/doc/design/set_default_program.md
+++ b/doc/design/set_default_program.md
@@ -1,4 +1,4 @@
-# Design: Simply Layer program inputs
+# Design: Add Model module to maintain global programDesc
 
 ## Motivation
 

--- a/doc/design/set_default_program.md
+++ b/doc/design/set_default_program.md
@@ -26,9 +26,6 @@ class set_program_desc:
         DEFAULT_INIT_PROGRAM = None
 
 def fc_layer():
-    program = DEFAULT_PROGRAM
-    init_program = DEFAULT_INIT_PROGRAM
-
     DEFAULT_PROGRAM.name += " fc_layer added"
     DEFAULT_INIT_PROGRAM.name += " fc_layer added"
 

--- a/doc/design/set_default_program.md
+++ b/doc/design/set_default_program.md
@@ -1,15 +1,24 @@
+# Design: Simply Layer program inputs
+
+## Motivation
+
+In the experience of writting simple python models, we found python API always need to specify a `program` and
+a `init_program`. This is very redundant.
+
+## Solution
 ```python
 DEFAULT_PROGRAM = None
 DEFAULT_INIT_PROGRAM = None
 
-class Program:
+class Program(object):
     def __init__(self, name):
         self.name = name
 
-class set_program_desc:
-    def __init__(self, p, ip):
-        self.p = p
-        self.ip = ip
+class Model(object):
+    def __init__(self, name):
+        self.name = name
+        self.p = Program("program")
+        self.ip = Program("init_program")
 
     def __enter__(self):
         global DEFAULT_PROGRAM
@@ -30,16 +39,16 @@ def fc_layer():
     DEFAULT_INIT_PROGRAM.name += " fc_layer added"
 
 def main():
-    p = Program("program")
-    ip = Program("init_program")
-    print(p.name)
-    print(ip.name)
+    m = Model("M")
 
-    with set_program_desc(p, ip):
+    print(m.p.name)
+    print(m.ip.name)
+
+    with m:
         fc_layer()
 
-    print(p.name)
-    print(ip.name)
+    print(m.p.name)
+    print(m.ip.name)
 
 if __name__ == "__main__":
     main()

--- a/doc/design/set_default_program.md
+++ b/doc/design/set_default_program.md
@@ -1,0 +1,56 @@
+```python
+DEFAULT_PROGRAM = None
+DEFAULT_INIT_PROGRAM = None
+
+class Program:
+    def __init__(self, name):
+        self.name = name
+
+class set_program_desc:
+    def __init__(self, p, ip):
+        self.p = p
+        self.ip = ip
+
+    def __enter__(self):
+        global DEFAULT_PROGRAM
+        global DEFAULT_INIT_PROGRAM
+        assert(DEFAULT_PROGRAM is None)
+        assert(DEFAULT_INIT_PROGRAM is None)
+        DEFAULT_PROGRAM = self.p
+        DEFAULT_INIT_PROGRAM = self.ip
+
+    def __exit__(self, type, value, traceback):
+        global DEFAULT_PROGRAM
+        global DEFAULT_INIT_PROGRAM
+        DEFAULT_PROGRAM = None
+        DEFAULT_INIT_PROGRAM = None
+
+def fc_layer():
+    program = DEFAULT_PROGRAM
+    init_program = DEFAULT_INIT_PROGRAM
+
+    DEFAULT_PROGRAM.name += " fc_layer added"
+    DEFAULT_INIT_PROGRAM.name += " fc_layer added"
+
+def main():
+    p = Program("program")
+    ip = Program("init_program")
+    print(p.name)
+    print(ip.name)
+
+    with set_program_desc(p, ip):
+        fc_layer()
+
+    print(p.name)
+    print(ip.name)
+
+if __name__ == "__main__":
+    main()
+```
+It prints
+```
+program
+init_program
+program fc_layer added
+init_program fc_layer added
+```

--- a/doc/design/set_default_program.md
+++ b/doc/design/set_default_program.md
@@ -2,10 +2,13 @@
 
 ## Motivation
 
-In the experience of writting simple python models, we found python API always need to specify a `program` and
+In the experience of writting simple python models, we found python layer API always need to specify a `program` and
 a `init_program`. This is very redundant.
 
 ## Solution
+
+We add a `Model` module which has `__enter__` and `__exit__` to manage global settings of `programDesc`.
+
 ```python
 DEFAULT_PROGRAM = None
 DEFAULT_INIT_PROGRAM = None


### PR DESCRIPTION
Simplifying layer input through setting a global `ProgramDesc` and using `Model` module to manage global `ProgramDesc`.