### PR TITLE
add optional in op proto

### DIFF
--- a/paddle/framework/framework.proto
+++ b/paddle/framework/framework.proto
@@ -68,6 +68,7 @@ message OpProto {
 
     optional bool duplicable = 3 [ default = false ];
     optional bool intermediate = 4 [ default = false ];
+    optional bool dispensable = 5 [ default = false ];
   }
 
   // AttrProto describes the C++ type Attribute.

--- a/paddle/framework/op_proto_maker.h
+++ b/paddle/framework/op_proto_maker.h
@@ -44,6 +44,11 @@ class OpProtoAndCheckerMaker {
       var_->set_intermediate(true);
       return *this;
     }
+
+    VariableBuilder& AsDispensable() {
+      var_->set_dispensable(true);
+      return *this;
+    }
   };
 
   VariableBuilder AddInput(const std::string& name, const std::string& comment);


### PR DESCRIPTION
Add a `dispensable` field to indicate whether an input of an operator is optional or not.

SideNote, maybe `optional` is a better name, but it happens to be the keyword in protobuf.