### PR TITLE
"get inputs outputs name from execution context"

### DIFF
--- a/paddle/framework/operator.h
+++ b/paddle/framework/operator.h
@@ -290,6 +290,15 @@ class ExecutionContext {
     return device_context_;
   }
 
+  //! Get a input which has multiple variables.
+  const std::vector<std::string>& Inputs(const std::string& name) const {
+    return op_.Inputs(name);
+  }
+  //! Get an output which has multiple variables.
+  const std::vector<std::string>& Outputs(const std::string& name) const {
+    return op_.Outputs(name);
+  }
+
 #ifdef PADDLE_WITH_CUDA
   const platform::CUDADeviceContext& cuda_device_context() const {
     PADDLE_ENFORCE(platform::is_gpu_place(device_context_.GetPlace()));


### PR DESCRIPTION
Add an interface to the execution context, to get inputs outputs name. PR of #4838 depends on it.