### PR TITLE
Polish Accuracy Op

### DIFF
--- a/paddle/framework/operator.cc
+++ b/paddle/framework/operator.cc
@@ -390,7 +390,8 @@ void OperatorWithKernel::Run(const Scope& scope,
   auto& all_op_kernels = AllOpKernels();
   auto kernels_iter = all_op_kernels.find(type_);
   if (kernels_iter == all_op_kernels.end()) {
-    PADDLE_THROW("op[%s] has no kernel", type_);
+    PADDLE_THROW(
+        "There are no kernels which are registered in the %s operator.", type_);
   }
 
   // check if op[type] have kernel for kernel_key
@@ -399,7 +400,7 @@ void OperatorWithKernel::Run(const Scope& scope,
   auto kernel_iter = kernels.find(kernel_key);
 
   if (kernel_iter == kernels.end()) {
-    PADDLE_THROW("op[%s] has no kernel with kernel_key[%s]", type_, kernel_key);
+    PADDLE_THROW("The operator %s does not support %s", type_, kernel_key);
   }
 
   kernel_iter->second->Compute(ctx);

--- a/paddle/operators/accuracy_op.cc
+++ b/paddle/operators/accuracy_op.cc
@@ -70,7 +70,5 @@ information, or not. But the output only shares the LoD with input `Inference`.
 namespace ops = paddle::operators;
 REGISTER_OP_WITHOUT_GRADIENT(accuracy, ops::AccuracyOp, ops::AccuracyOpMaker);
 REGISTER_OP_CPU_KERNEL(
-    accuracy, ops::AccuracyKernel<paddle::platform::CPUPlace, float>,
-    ops::AccuracyKernel<paddle::platform::CPUPlace, int>,
-    ops::AccuracyKernel<paddle::platform::CPUPlace, double>,
+    accuracy, ops::AccuracyKernel<paddle::platform::CPUPlace, int>,
     ops::AccuracyKernel<paddle::platform::CPUPlace, int64_t>);

--- a/paddle/operators/accuracy_op.cu
+++ b/paddle/operators/accuracy_op.cu
@@ -81,7 +81,5 @@ class AccuracyOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace operators
 }  // namespace paddle
 
-REGISTER_OP_GPU_KERNEL(accuracy, paddle::operators::AccuracyOpCUDAKernel<float>,
-                       paddle::operators::AccuracyOpCUDAKernel<double>,
-                       paddle::operators::AccuracyOpCUDAKernel<int>,
+REGISTER_OP_GPU_KERNEL(accuracy, paddle::operators::AccuracyOpCUDAKernel<int>,
                        paddle::operators::AccuracyOpCUDAKernel<int64_t>);


### PR DESCRIPTION
* Accuracy does not support float/double, only support integers
* Polish error message when an operator does not support some device.