### PR TITLE
fix a bug in imdb data reader

### DIFF
--- a/python/paddle/v2/dataset/imdb.py
+++ b/python/paddle/v2/dataset/imdb.py
@@ -116,7 +116,7 @@ def reader_creator(pos_pattern, neg_pattern, word_idx, buffer_size):
             yield [word_idx.get(w, UNK) for w in doc], i % 2
             doc = qs[i % 2].get()
 
-    return reader()
+    return reader
 
 
 def train(word_idx):


### PR DESCRIPTION
In function `reader_creator()` of `imdb.py`, a redundant `()` is added to the return value, which leads to that imbd's data reader acts differently from all the other readers.