### PR TITLE
"add net drawer for visualizing the graph"

### DIFF
--- a/python/paddle/v2/framework/net_drawer.py
+++ b/python/paddle/v2/framework/net_drawer.py
@@ -1,0 +1,112 @@
+import argparse
+import json
+import logging
+from collections import defaultdict
+
+import paddle.v2.framework.core as core
+import paddle.v2.framework.proto.framework_pb2 as framework_pb2
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+try:
+    from graphviz import Digraph
+except ImportError:
+    logger.info(
+        'Cannot import graphviz, which is required for drawing a network. This '
+        'can usually be installed in python with "pip install graphviz". Also, '
+        'pydot requires graphviz to convert dot files to pdf: in ubuntu, this '
+        'can usually be installed with "sudo apt-get install graphviz".')
+    print('net_drawer will not run correctly. Please install the correct '
+          'dependencies.')
+    exit(0)
+
+OP_STYLE = {
+    'shape': 'oval',
+    'color': '#0F9D58',
+    'style': 'filled',
+    'fontcolor': '#FFFFFF'
+}
+
+VAR_STYLE = {}
+
+GRAPH_STYLE = {"rankdir": "TB", }
+
+INIT_GRAPH = {"style": "filled", "color": "lightgrey"}
+
+GRAPH_ID = 0
+
+
+def unique_id():
+    def generator():
+        GRAPH_ID += 1
+        return GRAPH_ID
+
+    return generator
+
+
+# use kwargs share common attrs
+def draw_node(op):
+    node = OP_STYLE
+    node["name"] = op.type
+    node["label"] = op.type
+    return node
+
+
+def draw_edge(var_parent, op, var, arg):
+    edge = VAR_STYLE
+    edge["label"] = "%s(%s)" % (var.parameter, arg)
+    edge["head_name"] = op.type
+    edge["tail_name"] = var_parent[arg]
+    return edge
+
+
+def parse_graph(program, graph, var_dict, **kwargs):
+
+    # fill the known variables
+    for block in program.blocks:
+        for var in block.vars:
+            if not var_dict.has_key(var):
+                var_dict[var] = "Feed"
+
+    proto = framework_pb2.ProgramDesc.FromString(
+        program.desc.serialize_to_string())
+    for block in proto.blocks:
+        for op in block.ops:
+            graph.node(**draw_node(op))
+            for o in op.outputs:
+                for arg in o.arguments:
+                    var_dict[arg] = op.type
+            for e in op.inputs:
+                for arg in e.arguments:
+                    if var_dict.has_key(arg):
+                        graph.edge(**draw_edge(var_dict, op, e, arg))
+
+
+def draw_graph(init_program, program, **kwargs):
+    if kwargs.has_key("graph_attr"):
+        GRAPH_STYLE.update(kwargs[graph_attr])
+    if kwargs.has_key("node_attr"):
+        OP_STYLE.update(kwargs[node_attr])
+    if kwargs.has_key("edge_attr"):
+        VAR_STYLE.update(kwargs[edge_attr])
+
+    graph_id = unique_id()
+    filename = kwargs.get("filename")
+    if filename == None:
+        filename = str(graph_id) + ".gv"
+    g = Digraph(
+        name=str(graph_id),
+        filename=filename,
+        graph_attr=GRAPH_STYLE,
+        node_attr=OP_STYLE,
+        edge_attr=VAR_STYLE,
+        **kwargs)
+
+    var_dict = {}
+    parse_graph(init_program, g, var_dict)
+    parse_graph(program, g, var_dict)
+
+    if filename != None:
+        g.save()
+    return g

--- a/python/paddle/v2/framework/net_drawer.py
+++ b/python/paddle/v2/framework/net_drawer.py
@@ -32,8 +32,6 @@ VAR_STYLE = {}
 
 GRAPH_STYLE = {"rankdir": "TB", }
 
-INIT_GRAPH = {"style": "filled", "color": "lightgrey"}
-
 GRAPH_ID = 0
 
 
@@ -45,7 +43,6 @@ def unique_id():
     return generator
 
 
-# use kwargs share common attrs
 def draw_node(op):
     node = OP_STYLE
     node["name"] = op.type

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,3 +7,4 @@ rarfile
 scipy>=0.19.0
 Pillow
 nltk>=3.2.2
+graphviz


### PR DESCRIPTION
add a visualizer for drawing the ProgramDesc.
It's very simple for debugging your python program.
usage:
```python 
import paddle.v2.framework.net_drawer as drawer
print drawer.draw_graph(init_program, program)
```
then you will get the 
```dot
digraph <function generator at 0x7f50ba8bfe60> {
	graph [rankdir=TB]
	node [color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	fill_constant [label=fill_constant color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	uniform_random [label=uniform_random color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	mul [label=mul color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	Feed -> mul [label="X(x)"]
	uniform_random -> mul [label="Y(fc_0.w_0)"]
	elementwise_add [label=elementwise_add color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	mul -> elementwise_add [label="X(fc_0.tmp_0)"]
	fill_constant -> elementwise_add [label="Y(fc_0.b_0)"]
	elementwise_sub [label=elementwise_sub color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	elementwise_add -> elementwise_sub [label="X(fc_0.tmp_1)"]
	Feed -> elementwise_sub [label="Y(y)"]
	square [label=square color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	elementwise_sub -> square [label="X(square_error_cost_0.tmp_0)"]
	mean [label=mean color="#0F9D58" fontcolor="#FFFFFF" shape=oval style=filled]
	square -> mean [label="X(square_error_cost_0.tmp_1)"]
}
```

which can be shown in a web browser.
![image](https://gist.githubusercontent.com/dzhwinter/ff9d90fab7934079c3ea40e476b64d96/raw/e2bb087e76837b2c7139c0fcc8c002cc75586e02/MacHi%25202017-11-01%252016-15-35.png)