### PR TITLE
Add LoD's slice and append function

### DIFF
--- a/paddle/framework/lod_tensor.cc
+++ b/paddle/framework/lod_tensor.cc
@@ -140,9 +140,9 @@ void GetFineGrainedLoDLength(const LoD& lod, size_t start_idx, size_t end_idx,
                              std::vector<std::vector<size_t>>* lod_length,
                              size_t* start_offset) {
   lod_length->clear();
-  PADDLE_ENFORCE(start_idx >= 0 && start_idx < lod.size() - 1,
+  PADDLE_ENFORCE(start_idx < lod.size() - 1,
                  "start_idx should be >= 0 and < lod.size() - 1.");
-  PADDLE_ENFORCE(end_idx >= 0 && end_idx < lod.size(),
+  PADDLE_ENFORCE(end_idx < lod.size(),
                  "end_idx should be >= 0 and < lod.size().");
   PADDLE_ENFORCE_LE(start_idx, end_idx,
                     "start_idx should be less than end_idx.");
@@ -158,7 +158,7 @@ void GetFineGrainedLoDLength(const LoD& lod, size_t start_idx, size_t end_idx,
   *start_offset = start_idx;
 }
 
-void AppendLoD(LoD* lod, std::vector<std::vector<size_t>>& lod_length) {
+void AppendLoD(LoD* lod, const std::vector<std::vector<size_t>>& lod_length) {
   PADDLE_ENFORCE_EQ(
       lod->size(), lod_length.size(),
       "The lod_length should has the same size with the appended lod.");

--- a/paddle/framework/lod_tensor.cc
+++ b/paddle/framework/lod_tensor.cc
@@ -163,7 +163,7 @@ void AppendLoD(LoD* lod, const std::vector<std::vector<size_t>>& lod_length) {
       lod->size(), lod_length.size(),
       "The lod_length should has the same size with the appended lod.");
   for (size_t i = 0; i < lod->size(); ++i) {
-    std::vector<size_t>& level = (*lod)[i];
+    auto& level = (*lod)[i];
     if (level.empty()) {
       level.push_back(0);
     }

--- a/paddle/framework/lod_tensor.h
+++ b/paddle/framework/lod_tensor.h
@@ -185,7 +185,7 @@ void GetFineGrainedLoDLength(const LoD& lod, size_t start_idx, size_t end_idx,
                              std::vector<std::vector<size_t>>* lod_length,
                              size_t* start_offset);
 
-void AppendLoD(LoD* lod, std::vector<std::vector<size_t>>& lod_length);
+void AppendLoD(LoD* lod, const std::vector<std::vector<size_t>>& lod_length);
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/lod_tensor.h
+++ b/paddle/framework/lod_tensor.h
@@ -181,5 +181,11 @@ LoDTensor LodExpand(const LoDTensor& source, const LoD& lod, size_t level,
   return tensor;
 }
 
+void GetFineGrainedLoDLength(const LoD& lod, size_t start_idx, size_t end_idx,
+                             std::vector<std::vector<size_t>>* lod_length,
+                             size_t* start_offset);
+
+void AppendLoD(LoD* lod, std::vector<std::vector<size_t>>& lod_length);
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/lod_tensor_test.cc
+++ b/paddle/framework/lod_tensor_test.cc
@@ -146,9 +146,10 @@ TEST(LodExpand, test) {
 
 TEST(LoD, GetFineGrainedLoDLength) {
   LoD lod;
-  lod.push_back({0, 2, 4, 5});
-  lod.push_back({0, 1, 6, 8, 10, 11});
-  lod.push_back({0, 2, 5, 7, 10, 12, 15, 17, 20, 24, 26, 29});
+  lod.push_back(std::vector<size_t>{0, 2, 4, 5});
+  lod.push_back(std::vector<size_t>{0, 1, 6, 8, 10, 11});
+  lod.push_back(
+      std::vector<size_t>{0, 2, 5, 7, 10, 12, 15, 17, 20, 24, 26, 29});
 
   std::vector<std::vector<size_t>> lod_length;
   size_t start_offset;
@@ -156,30 +157,31 @@ TEST(LoD, GetFineGrainedLoDLength) {
                                              &start_offset);
 
   std::vector<std::vector<size_t>> expected;
-  expected.push_back({2});
-  expected.push_back({2, 2});
-  expected.push_back({2, 3, 4, 2});
+  expected.push_back(std::vector<size_t>{2});
+  expected.push_back(std::vector<size_t>{2, 2});
+  expected.push_back(std::vector<size_t>{2, 3, 4, 2});
   EXPECT_EQ(lod_length, expected);
   EXPECT_EQ(start_offset, 15UL);
 }
 
 TEST(LoD, AppendLoD) {
   std::vector<std::vector<size_t>> lod_lens;
-  lod_lens.push_back({2});
-  lod_lens.push_back({2, 2});
-  lod_lens.push_back({2, 3, 4, 2});
+  lod_lens.push_back(std::vector<size_t>{2});
+  lod_lens.push_back(std::vector<size_t>{2, 2});
+  lod_lens.push_back(std::vector<size_t>{2, 3, 4, 2});
 
   LoD origin;
-  origin.push_back({0, 2});
-  origin.push_back({0, 1, 6});
-  origin.push_back({0, 2, 5, 7, 10, 12, 15});
+  origin.push_back(std::vector<size_t>{0, 2});
+  origin.push_back(std::vector<size_t>{0, 1, 6});
+  origin.push_back(std::vector<size_t>{0, 2, 5, 7, 10, 12, 15});
 
   paddle::framework::AppendLoD(&origin, lod_lens);
 
   LoD expected;
-  expected.push_back({0, 2, 4});
-  expected.push_back({0, 1, 6, 8, 10});
-  expected.push_back({0, 2, 5, 7, 10, 12, 15, 17, 20, 24, 26});
+  expected.push_back(std::vector<size_t>{0, 2, 4});
+  expected.push_back(std::vector<size_t>{0, 1, 6, 8, 10});
+  expected.push_back(
+      std::vector<size_t>{0, 2, 5, 7, 10, 12, 15, 17, 20, 24, 26});
 
   EXPECT_EQ(origin, expected);
 }

--- a/paddle/framework/lod_tensor_test.cc
+++ b/paddle/framework/lod_tensor_test.cc
@@ -144,5 +144,45 @@ TEST(LodExpand, test) {
   }
 }
 
+TEST(LoD, GetFineGrainedLoDLength) {
+  LoD lod;
+  lod.push_back({0, 2, 4, 5});
+  lod.push_back({0, 1, 6, 8, 10, 11});
+  lod.push_back({0, 2, 5, 7, 10, 12, 15, 17, 20, 24, 26, 29});
+
+  std::vector<std::vector<size_t>> lod_length;
+  size_t start_offset;
+  paddle::framework::GetFineGrainedLoDLength(lod, 1, 2, &lod_length,
+                                             &start_offset);
+
+  std::vector<std::vector<size_t>> expected;
+  expected.push_back({2});
+  expected.push_back({2, 2});
+  expected.push_back({2, 3, 4, 2});
+  EXPECT_EQ(lod_length, expected);
+  EXPECT_EQ(start_offset, 15UL);
+}
+
+TEST(LoD, AppendLoD) {
+  std::vector<std::vector<size_t>> lod_lens;
+  lod_lens.push_back({2});
+  lod_lens.push_back({2, 2});
+  lod_lens.push_back({2, 3, 4, 2});
+
+  LoD origin;
+  origin.push_back({0, 2});
+  origin.push_back({0, 1, 6});
+  origin.push_back({0, 2, 5, 7, 10, 12, 15});
+
+  paddle::framework::AppendLoD(&origin, lod_lens);
+
+  LoD expected;
+  expected.push_back({0, 2, 4});
+  expected.push_back({0, 1, 6, 8, 10});
+  expected.push_back({0, 2, 5, 7, 10, 12, 15, 17, 20, 24, 26});
+
+  EXPECT_EQ(origin, expected);
+}
+
 }  // namespace framework
 }  // namespace paddle


### PR DESCRIPTION
In dynamic RNN, we need to assemble and disassemble LoDTensor. Meanwhile， the `LoD` info should also be assembled or disassembled, so a slice and an append function are needed by it.