### PR TITLE
Add print_operators_doc to Paddle Docker Image

### DIFF
--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -162,6 +162,7 @@ ${DOCKERFILE_CUDNN_DSO}
 ${DOCKERFILE_GPU_ENV}
 ADD go/cmd/pserver/pserver /usr/bin/
 ADD go/cmd/master/master /usr/bin/
+ADD paddle/pybind/print_operators_doc /usr/bin/
 # default command shows the paddle version and exit
 CMD ["paddle", "version"]
 EOF


### PR DESCRIPTION
Please refer to https://github.com/PaddlePaddle/Paddle/issues/5363.

After discussion with Helin and Yi, this change adds "print_operators_doc" executable to the Paddle docker nightly image.  This docker image will be pulled by PaddlePaddle.org nightly job and will generate the operator documentation to be put on PaddlePaddle.org website.