### PR TITLE
Please refer to https://github.com/PaddlePaddle/Paddle/issues/5363

### DIFF
--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -168,6 +168,7 @@ EOF
     ${DOCKERFILE_GPU_ENV}
     ADD go/cmd/pserver/pserver /usr/bin/
     ADD go/cmd/master/master /usr/bin/
+    ADD paddle/pybind/print_operators_doc /usr/bin/
     # default command shows the paddle version and exit
     CMD ["paddle", "version"]
 EOF


### PR DESCRIPTION
This changed was accidently reverted in a previous pull request.  This pull request adds back in the print_operators_doc to the docker image.

Discussed with Helin and Yi. Currently we have a binary "print_operators_doc" that is built that generates a JSON document. This JSON represents the API documentation of paddle, and will be used by PaddlePaddle.org to generate API documentation.

This issue is to request "print_operators_doc" to be added to the production paddlepaddle/paddle:latest image.