### PR TITLE
fix compile error

### DIFF
--- a/paddle/gserver/layers/ROIPoolLayer.cpp
+++ b/paddle/gserver/layers/ROIPoolLayer.cpp
@@ -114,10 +114,10 @@ void ROIPoolLayer::forward(PassType passType) {
           size_t wstart = static_cast<size_t>(std::floor(pw * binSizeW));
           size_t hend = static_cast<size_t>(std::ceil((ph + 1) * binSizeH));
           size_t wend = static_cast<size_t>(std::ceil((pw + 1) * binSizeW));
-          hstart = std::min(std::max(hstart + roiStartH, 0UL), height_);
-          wstart = std::min(std::max(wstart + roiStartW, 0UL), width_);
-          hend = std::min(std::max(hend + roiStartH, 0UL), height_);
-          wend = std::min(std::max(wend + roiStartW, 0UL), width_);
+          hstart = std::min(hstart + roiStartH, height_);
+          wstart = std::min(wstart + roiStartW, width_);
+          hend = std::min(hend + roiStartH, height_);
+          wend = std::min(wend + roiStartW, width_);
 
           bool isEmpty = (hend <= hstart) || (wend <= wstart);
           size_t poolIndex = ph * pooledWidth_ + pw;


### PR DESCRIPTION
```
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:117:29: error: taking the max of a value and unsigned zero is always equal to the other value [-Werror,-Wmax-unsigned-zero]
          hstart = std::min(std::max(hstart + roiStartH, 0UL), height_);
                            ^~~~~~~~                     ~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:117:29: note: remove call to max function and unsigned zero argument
          hstart = std::min(std::max(hstart + roiStartH, 0UL), height_);
                            ^~~~~~~~                   ~~~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:118:29: error: taking the max of a value and unsigned zero is always equal to the other value [-Werror,-Wmax-unsigned-zero]
          wstart = std::min(std::max(wstart + roiStartW, 0UL), width_);
                            ^~~~~~~~                     ~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:118:29: note: remove call to max function and unsigned zero argument
          wstart = std::min(std::max(wstart + roiStartW, 0UL), width_);
                            ^~~~~~~~                   ~~~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:119:27: error: taking the max of a value and unsigned zero is always equal to the other value [-Werror,-Wmax-unsigned-zero]
          hend = std::min(std::max(hend + roiStartH, 0UL), height_);
                          ^~~~~~~~                   ~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:119:27: note: remove call to max function and unsigned zero argument
          hend = std::min(std::max(hend + roiStartH, 0UL), height_);
                          ^~~~~~~~                 ~~~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:120:27: error: taking the max of a value and unsigned zero is always equal to the other value [-Werror,-Wmax-unsigned-zero]
          wend = std::min(std::max(wend + roiStartW, 0UL), width_);
                          ^~~~~~~~                   ~~~
/Users/baidu/Documents/git_workspace/Paddle/paddle/gserver/layers/ROIPoolLayer.cpp:120:27: note: remove call to max function and unsigned zero argument
          wend = std::min(std::max(wend + roiStartW, 0UL), width_);
```

This pr will fix such errors on Mac clang.