### PR TITLE
Fix conv2d bias

### DIFF
--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -244,6 +244,8 @@ def get_parameter_value(para, executor):
     :param para: the given parameter
     :return: the LoDTensor for the parameter
     """
+    assert is_parameter(para)
+
     get_program = Program()
     block = get_program.global_block()
     new_var = _clone_var_in_block_(block, para)
@@ -263,5 +265,4 @@ def get_parameter_value_by_name(name, executor, program=None):
     if program is None:
         program = g_main_program
     var = program.global_block().var(name)
-    assert is_parameter(var)
     return get_parameter_value(var, executor)

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -35,7 +35,7 @@ def save_vars(executor, dirname, main_program=None, vars=None, predicate=None):
 
     :param executor: executor that save variable
     :param dirname: directory path
-    :param main_program: program. If vars is None, then filter all variables in this 
+    :param main_program: program. If vars is None, then filter all variables in this
     program which fit `predicate`. Default g_program.
     :param predicate: The Predicate describes a callable that returns a variable
     as a bool. If it returns true, the variables will be saved.
@@ -96,11 +96,11 @@ def load_vars(executor, dirname, main_program=None, vars=None, predicate=None):
 
     :param executor: executor that save variable
     :param dirname: directory path
-    :param main_program: program. If vars is None, then filter all variables in this 
+    :param main_program: program. If vars is None, then filter all variables in this
     program which fit `predicate`. Default g_program.
     :param predicate: The Predicate describes a callable that returns a variable
     as a bool. If it returns true, the variables will be loaded.
-    :param vars: variables need to be loaded. If specify vars, program & 
+    :param vars: variables need to be loaded. If specify vars, program &
     predicate will be ignored
     :return: None
     """
@@ -157,15 +157,15 @@ def save_inference_model(dirname,
                          executor,
                          main_program=None):
     """
-    Build a model especially for inference, 
+    Build a model especially for inference,
     and save it to directory by the executor.
 
     :param dirname: directory path
     :param feeded_var_names: Names of variables that need to be feeded data during inference
     :param target_vars: Variables from which we can get inference results.
     :param executor: executor that save inference model
-    :param main_program: original program, which will be pruned to build the inference model. 
-    Default g_program.
+    :param main_program: original program, which will be pruned to build the inference model.
+    Default g_main_program.
 
     :return: None
     """
@@ -234,3 +234,34 @@ def load_inference_model(dirname, executor):
     fetch_vars = [program.global_block().var(name) for name in fetch_var_names]
 
     return [program, feed_var_names, fetch_vars]
+
+
+def get_parameter_value(para, executor):
+    """
+    Get the LoDTensor for the parameter
+
+    :param executor: executor for retrieving the value
+    :param para: the given parameter
+    :return: the LoDTensor for the parameter
+    """
+    get_program = Program()
+    block = get_program.global_block()
+    new_var = _clone_var_in_block_(block, para)
+    return executor.run(get_program, feed={}, fetch_list=[new_var])[0]
+
+
+def get_parameter_value_by_name(name, executor, program=None):
+    """
+    Get the LoDTensor for paramter with the given name
+
+    :param executor: executor for retrieving the value
+    :param name: the name of the parameter
+    :param program: the program where the variable is found
+    Default g_main_program.
+    :return: the LoDTensor for the variable
+    """
+    if program is None:
+        program = g_main_program
+    var = program.global_block().var(name)
+    assert is_parameter(var)
+    return get_parameter_value(var, executor)

--- a/python/paddle/v2/fluid/layer_helper.py
+++ b/python/paddle/v2/fluid/layer_helper.py
@@ -158,7 +158,7 @@ class LayerHelper(object):
         or equal than 2.
         :param dim_start:
         :param dim_end: the shape of the bias will be
-        input_var.shape(dim_start:dim_end). The bias is broadcast to other
+        input_var.shape[dim_start:dim_end]. The bias is broadcasted to other
         dimensions and added to input_var to get the output
         """
         size = list(input_var.shape[dim_start:dim_end])

--- a/python/paddle/v2/fluid/layers.py
+++ b/python/paddle/v2/fluid/layers.py
@@ -676,7 +676,6 @@ def conv2d(input,
     filter_shape = [num_filters, num_filter_channels] + filter_size
 
     std = (2.0 / (filter_size[0]**2 * num_channels))**0.5
-    print 'name=', name, 'std=', std
     filter = helper.create_parameter(
         attr=helper.param_attr,
         shape=filter_shape,

--- a/python/paddle/v2/fluid/layers.py
+++ b/python/paddle/v2/fluid/layers.py
@@ -250,7 +250,7 @@ def _convert_(name):
 def _generate_doc_string_(op_proto):
     """
     Generate docstring by OpProto
-    
+
     Args:
         op_proto (framework_pb2.OpProto): a protobuf message typed OpProto
 
@@ -676,6 +676,7 @@ def conv2d(input,
     filter_shape = [num_filters, num_filter_channels] + filter_size
 
     std = (2.0 / (filter_size[0]**2 * num_channels))**0.5
+    print 'name=', name, 'std=', std
     filter = helper.create_parameter(
         attr=helper.param_attr,
         shape=filter_shape,
@@ -694,7 +695,7 @@ def conv2d(input,
                'paddings': padding,
                'groups': groups})
 
-    pre_act = helper.append_bias_op(pre_bias, 1)
+    pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
 
     return helper.append_activation(pre_act)
 

--- a/python/paddle/v2/fluid/tests/test_parameter.py
+++ b/python/paddle/v2/fluid/tests/test_parameter.py
@@ -1,26 +1,32 @@
 import unittest
 from paddle.v2.fluid.framework import g_main_program
 import paddle.v2.fluid.core as core
+from paddle.v2.fluid.executor import Executor
+import paddle.v2.fluid.io as io
+from paddle.v2.fluid.initializer import ConstantInitializer
+import numpy as np
 
 
 class TestParameter(unittest.TestCase):
     def test_param(self):
-        b = g_main_program.create_block()
+        shape = [784, 100]
+        val = 1.0625
+        b = g_main_program.global_block()
         param = b.create_parameter(
             name='fc.w',
-            shape=[784, 100],
+            shape=shape,
             dtype='float32',
-            initialize_attr={
-                'type': 'uniform_random',
-                'seed': 13,
-                'min': -5.0,
-                'max': 5.0
-            })
+            initializer=ConstantInitializer(val))
         self.assertIsNotNone(param)
         self.assertEqual('fc.w', param.name)
         self.assertEqual((784, 100), param.shape)
         self.assertEqual(core.DataType.FP32, param.data_type)
         self.assertEqual(0, param.block.idx)
+        exe = Executor(core.CPUPlace())
+        p = exe.run(g_main_program, fetch_list=[param])[0]
+        self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))
+        p = io.get_parameter_value_by_name('fc.w', exe, g_main_program)
+        self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. The size of the bias parameter should be the number of filters. Changed LayerHelper.append_bias_op to allow this kind of bias.
2. Also change the default initialization of bias to be constant zero
3. Added a helper to get the value of a parameter.
4. Updated test_parameter
