### PR TITLE
Executor need reasonable default value

### DIFF
--- a/paddle/pybind/pybind.cc
+++ b/paddle/pybind/pybind.cc
@@ -78,6 +78,14 @@ bool IsCompileGPU() {
 #endif
 }
 
+int GetCUDADeviceCount() {
+#ifndef PADDLE_WITH_CUDA
+  return 0;
+#else
+  return paddle::platform::GetCUDADeviceCount();
+#endif
+}
+
 PYBIND11_PLUGIN(core) {
   py::module m("core", "C++ core of PaddlePaddle");
 
@@ -497,6 +505,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("init_gflags", InitGflags);
 
   m.def("is_compile_gpu", IsCompileGPU);
+  m.def("get_cuda_device_count", GetCUDADeviceCount());
   m.def("set_feed_variable", framework::SetFeedVariable);
   m.def("get_fetch_variable", framework::GetFetchVariable);
 

--- a/paddle/pybind/pybind.cc
+++ b/paddle/pybind/pybind.cc
@@ -78,14 +78,6 @@ bool IsCompileGPU() {
 #endif
 }
 
-int GetCUDADeviceCount() {
-#ifndef PADDLE_WITH_CUDA
-  return 0;
-#else
-  return paddle::platform::GetCUDADeviceCount();
-#endif
-}
-
 PYBIND11_PLUGIN(core) {
   py::module m("core", "C++ core of PaddlePaddle");
 
@@ -505,7 +497,6 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("init_gflags", InitGflags);
 
   m.def("is_compile_gpu", IsCompileGPU);
-  m.def("get_cuda_device_count", GetCUDADeviceCount());
   m.def("set_feed_variable", framework::SetFeedVariable);
   m.def("get_fetch_variable", framework::GetFetchVariable);
 

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -5,7 +5,13 @@ g_scope = core.Scope()
 
 
 class Executor(object):
-    def __init__(self, places):
+    def __init__(self, places=None):
+        if places is None:
+            if core.is_compile_gpu():
+                places = [core.GPUPlace()]
+            else:
+                places = [core.CPUPlace()]
+
         if not isinstance(places, list) and not isinstance(places, tuple):
             places = [places]
 

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -8,7 +8,11 @@ class Executor(object):
     def __init__(self, places=None):
         if places is None:
             if core.is_compile_gpu():
-                places = [core.GPUPlace()]
+                if core.get_cude_device_count() > 0:
+                    places = [core.GPUPlace()]
+                else:
+                    # TODO(tonyyang-svail): print warning here
+                    places = [core.CPUPlace()]
             else:
                 places = [core.CPUPlace()]
 

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -8,7 +8,7 @@ class Executor(object):
     def __init__(self, places=None):
         if places is None:
             if core.is_compile_gpu():
-                if core.get_cude_device_count() > 0:
+                if core.get_cuda_device_count() > 0:
                     places = [core.GPUPlace()]
                 else:
                     # TODO(tonyyang-svail): print warning here


### PR DESCRIPTION
fix #5648 

When using `exe = Executor(place=None)`, the logic is the following:

|                 | compiled without GPU | compiled with GPU     |
|-----------------|----------------------|-----------------------|
| run without GPU | CPU                  | warning, then use CPU |
| run with GPU    | CPU                  | GPU                   |