### PR TITLE
enable mkldnn benchmark with googlenet

### DIFF
--- a/benchmark/paddle/image/googlenet.py
+++ b/benchmark/paddle/image/googlenet.py
@@ -5,6 +5,7 @@ height = 224
 width = 224
 num_class = 1000
 batch_size = get_config_arg('batch_size', int, 128)
+use_gpu = get_config_arg('use_gpu', bool, True)
 
 args = {'height': height, 'width': width, 'color': True, 'num_class': num_class}
 define_py_data_sources2(
@@ -15,6 +16,8 @@ settings(
     learning_rate=0.01 / batch_size,
     learning_method=MomentumOptimizer(0.9),
     regularization=L2Regularization(0.0005 * batch_size))
+
+conv_projection = conv_projection if use_gpu else img_conv_layer
 
 def inception2(name, input, channels, \
     filter1,
@@ -138,7 +141,7 @@ def inception(name, input, channels, \
     cat = concat_layer(
         name=name,
         input=[cov1, cov3, cov5, covprj],
-        bias_attr=True,
+        bias_attr=True if use_gpu else False,
         act=ReluActivation())
     return cat
 

--- a/benchmark/paddle/image/run_mkldnn.sh
+++ b/benchmark/paddle/image/run_mkldnn.sh
@@ -40,6 +40,7 @@ fi
 for use_mkldnn in True False; do
   for batchsize in 64 128 256; do
     train vgg 19 $batchsize $use_mkldnn
-    train resnet 50  $batchsize $use_mkldnn
+    train resnet 50 $batchsize $use_mkldnn
+    train googlenet v1 $batchsize $use_mkldnn
   done
 done


### PR DESCRIPTION
fix #5729 

GoogLeNet的脚本可以直接使用gpu的benchmark那个。

但是用CPU跑的时候会遇到些问题，所以需要稍微改下。

1. 把只有GPU能跑的API换为了CPU可以支持的API。

2. CPU的`concat_layer`不支持bias为True，所以改为False。同时，参考的[README.md](https://github.com/PaddlePaddle/Paddle/blob/develop/benchmark/README.md#benchmark-model)中GoogLeNet的concat layer也是不带bias的。

改完之后MKLDNN也同样可以跑了。
