### PR TITLE
Enhance batch_norm_op: support 2d and 5d data and unbiased variance estimation

### DIFF
--- a/paddle/operators/batch_norm_op.cc
+++ b/paddle/operators/batch_norm_op.cc
@@ -37,37 +37,55 @@ class BatchNormOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext *ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"), "");
-    PADDLE_ENFORCE(ctx->HasInput("Scale"), "");
-    PADDLE_ENFORCE(ctx->HasInput("Bias"), "");
-    PADDLE_ENFORCE(ctx->HasInput("Mean"), "");
-    PADDLE_ENFORCE(ctx->HasInput("Variance"), "");
-    PADDLE_ENFORCE(ctx->HasOutput("Y"), "");
-    PADDLE_ENFORCE(ctx->HasOutput("MeanOut"), "");
-    PADDLE_ENFORCE(ctx->HasOutput("VarianceOut"), "");
-    PADDLE_ENFORCE(ctx->HasOutput("SavedMean"), "");
-    PADDLE_ENFORCE(ctx->HasOutput("SavedVariance"), "");
+    PADDLE_ENFORCE(ctx->HasInput("X"),
+                   "Input(X) of BatchNormOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput("Scale"),
+                   "Input(Scale) of BatchNormOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput("Bias"),
+                   "Input(Bias) of BatchNormOp should not be null");
+    PADDLE_ENFORCE(ctx->HasInput("Mean"),
+                   "Input(Mean) of BatchNormOp should not be null");
+    PADDLE_ENFORCE(ctx->HasInput("Variance"),
+                   "Input(Variance) of BatchNormOp should not be null");
+    PADDLE_ENFORCE(ctx->HasOutput("Y"),
+                   "Output(Y) of BatchNormOp should not be null");
+    auto is_test = ctx->Attrs().Get<bool>("is_test");
+    PADDLE_ENFORCE_NE(ctx->HasOutput("MeanOut"), is_test,
+                      "Output(MeanOut) should be set only in trainning(i.e. "
+                      "is_test=false) mode");
+    PADDLE_ENFORCE_NE(
+        ctx->HasOutput("VarianceOut"), is_test,
+        "Output(VarianceOut) should be set only in trainning(i.e. "
+        "is_test=false) mode");
+    PADDLE_ENFORCE_NE(ctx->HasOutput("SavedMean"), is_test,
+                      "Output(SavedMean) should be set only in trainning(i.e. "
+                      "is_test=false) mode");
+    PADDLE_ENFORCE_NE(
+        ctx->HasOutput("SavedVariance"), is_test,
+        "Output(SavedVariance) should be set only in trainning(i.e. "
+        "is_test=false) mode");
 
     const float epsilon = ctx->Attrs().Get<float>("epsilon");
     PADDLE_ENFORCE_GE(epsilon, 0.0, "epsilon should be larger than 0");
     PADDLE_ENFORCE_LE(epsilon, 0.001, "epsilon should not be too large");
 
-    // make sure Mean/MeanOut and Variance/VarianceOut share memory in Python
-    PADDLE_ENFORCE_EQ(ctx->Inputs("Mean")[0], ctx->Outputs("MeanOut")[0],
-                      "Mean and MeanOut should share the same memory");
-    PADDLE_ENFORCE_EQ(ctx->Inputs("Variance")[0],
-                      ctx->Outputs("VarianceOut")[0],
-                      "Variance and VarianceOut should share the same memory");
+    if (!is_test) {
+      // make sure Mean/MeanOut and Variance/VarianceOut share memory in Python
+      PADDLE_ENFORCE_EQ(ctx->Inputs("Mean")[0], ctx->Outputs("MeanOut")[0],
+                        "Mean and MeanOut should share the same memory");
+      PADDLE_ENFORCE_EQ(
+          ctx->Inputs("Variance")[0], ctx->Outputs("VarianceOut")[0],
+          "Variance and VarianceOut should share the same memory");
+    }
 
     const auto x_dims = ctx->GetInputDim("X");
     const TensorFormat tensor_format =
         StringToTensorFormat(ctx->Attrs().Get<std::string>("tensor_format"));
-    const int C =
-        (tensor_format == TensorFormat::NCHW ? x_dims[1]
-                                             : x_dims[x_dims.size() - 1]);
-
-    PADDLE_ENFORCE(x_dims.size() >= 3 && x_dims.size() <= 5,
-                   "Input X must have 3 to 5 dimensions.");
+    const int C = (tensor_format == TensorFormat::NCHW ||
+                           tensor_format == TensorFormat::NCDHW
+                       ? x_dims[1]
+                       : x_dims[x_dims.size() - 1]);
+    ValidTensorRank(x_dims.size(), tensor_format);
 
     PADDLE_ENFORCE_EQ(ctx->GetInputDim("Scale").size(), 1UL);
     PADDLE_ENFORCE_EQ(ctx->GetInputDim("Scale")[0], C);
@@ -75,10 +93,12 @@ class BatchNormOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_EQ(ctx->GetInputDim("Bias")[0], C);
 
     ctx->SetOutputDim("Y", x_dims);
-    ctx->SetOutputDim("MeanOut", {C});
-    ctx->SetOutputDim("VarianceOut", {C});
-    ctx->SetOutputDim("SavedMean", {C});
-    ctx->SetOutputDim("SavedVariance", {C});
+    if (!is_test) {
+      ctx->SetOutputDim("MeanOut", {C});
+      ctx->SetOutputDim("VarianceOut", {C});
+      ctx->SetOutputDim("SavedMean", {C});
+      ctx->SetOutputDim("SavedVariance", {C});
+    }
   }
 };
 
@@ -87,10 +107,23 @@ class BatchNormOpMaker : public framework::OpProtoAndCheckerMaker {
   BatchNormOpMaker(framework::OpProto *proto,
                    framework::OpAttrChecker *op_checker)
       : OpProtoAndCheckerMaker(proto, op_checker) {
-    AddAttr<bool>("is_test", "").SetDefault(false);
-    AddAttr<float>("momentum", "").SetDefault(0.9);
-    AddAttr<float>("epsilon", "").SetDefault(1e-5);
-    AddAttr<std::string>("tensor_format", "").SetDefault("NCHW");
+    AddAttr<bool>("is_test", "(bool, default false) Mode of operator.")
+        .SetDefault(false);
+    AddAttr<bool>("unbiased_estimate",
+                  "(bool, default true) Whether use Bessel's correction when "
+                  "estimating batch variance.")
+        .SetDefault(true);
+    AddAttr<float>("momentum",
+                   "(float, default 0.9) Momentum for the moving average.")
+        .SetDefault(0.9);
+    AddAttr<float>("epsilon",
+                   "(float, default 1e-5) A small float number added to "
+                   "variance to prevent numerical error.")
+        .SetDefault(static_cast<float>(1e-5));
+    AddAttr<std::string>("tensor_format",
+                         "(string, default NCHW) Layout of input tensor, one "
+                         "of {NC, NHWC, NCHW, NDHWC, HCDHW}")
+        .SetDefault("NCHW");
     AddInput("X", "The input tensor");
     AddInput("Scale",
              "Scale is a 1-dimensional tensor of size C "
@@ -126,9 +159,14 @@ Batch Norm has been implemented as discussed in the paper:
 https://arxiv.org/pdf/1502.03167.pdf
 Can be used as a normalizer function for conv2d and fully_connected operations.
 The required data format for this layer is one of the following:
-1. NHWC `[batch, in_height, in_width, in_channels]`
-2. NCHW `[batch, in_channels, in_height, in_width]`
-
+For 2D tensor:
+- NC `[batch, in_channels]`
+For 4D tensor:
+- NHWC `[batch, in_height, in_width, in_channels]`
+- NCHW `[batch, in_channels, in_height, in_width]`
+For 5D tensor:
+- NCDHW `[batch, in_channels, in_depth, in_height, in_width]`
+- NDHWC `[batch, in_depth, in_height, in_width, in_channels]`
 )DOC");
   }
 };
@@ -137,137 +175,32 @@ template <typename T>
 class BatchNormKernel<platform::CPUPlace, T> : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
-    const float epsilon = ctx.Attr<float>("epsilon");
-    const float momentum = ctx.Attr<float>("momentum");
     const bool is_test = ctx.Attr<bool>("is_test");
-    const std::string tensor_format_str =
-        ctx.Attr<std::string>("tensor_format");
-    const TensorFormat tensor_format = StringToTensorFormat(tensor_format_str);
-
-    const auto *x = ctx.Input<Tensor>("X");
-    const auto &x_dims = x->dims();
-    PADDLE_ENFORCE(x_dims.size() >= 3 && x_dims.size() <= 5,
-                   "The Input dim size should be between 3 and 5");
-    const int N = x_dims[0];
-    const int C =
-        (tensor_format == TensorFormat::NCHW ? x_dims[1]
-                                             : x_dims[x_dims.size() - 1]);
-    const int sample_size = x->numel() / N / C;
-
     auto *y = ctx.Output<Tensor>("Y");
-    auto *mean_out = ctx.Output<Tensor>("MeanOut");
-    auto *variance_out = ctx.Output<Tensor>("VarianceOut");
-    auto *saved_mean = ctx.Output<Tensor>("SavedMean");
-    auto *saved_variance = ctx.Output<Tensor>("SavedVariance");
-
     // alloc memory
     y->mutable_data<T>(ctx.GetPlace());
-    mean_out->mutable_data<T>(ctx.GetPlace());
-    variance_out->mutable_data<T>(ctx.GetPlace());
-    saved_mean->mutable_data<T>(ctx.GetPlace());
-    saved_variance->mutable_data<T>(ctx.GetPlace());
 
+    Tensor *mean_out = nullptr, *variance_out = nullptr, *saved_mean = nullptr,
+           *saved_variance = nullptr;
     if (!is_test) {
-      // saved_xx is use just in this batch of data
-      EigenVectorArrayMap<T> saved_mean_e(
-          saved_mean->mutable_data<T>(ctx.GetPlace()), C);
-      EigenVectorArrayMap<T> saved_variance_e(
-          saved_variance->mutable_data<T>(ctx.GetPlace()), C);
-      saved_mean_e.setZero();
-      saved_variance_e.setZero();
+      mean_out = ctx.Output<Tensor>("MeanOut");
+      variance_out = ctx.Output<Tensor>("VarianceOut");
+      saved_mean = ctx.Output<Tensor>("SavedMean");
+      saved_variance = ctx.Output<Tensor>("SavedVariance");
 
-      switch (tensor_format) {
-        case TensorFormat::NCHW: {
-          ConstEigenArrayMap<T> x_arr(x->data<T>(), sample_size, N * C);
-          for (int nc = 0; nc < N * C; ++nc) {
-            saved_mean_e(nc % C) += x_arr.col(nc).sum();
-          }
-          saved_mean_e /= N * sample_size;
-          for (int nc = 0; nc < N * C; ++nc) {
-            saved_variance_e(nc % C) +=
-                (x_arr.col(nc) - saved_mean_e(nc % C)).matrix().squaredNorm();
-          }
-          saved_variance_e /= N * sample_size;
-          break;
-        }
-        case TensorFormat::NHWC: {
-          ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N * sample_size);
-          for (int i = 0; i < N * sample_size; ++i) {
-            saved_mean_e += x_arr.col(i);
-          }
-          saved_mean_e /= N * sample_size;
-          for (int i = 0; i < N * sample_size; ++i) {
-            saved_variance_e +=
-                (x_arr.col(i) - saved_mean_e) * (x_arr.col(i) - saved_mean_e);
-          }
-          saved_variance_e /= N * sample_size;
-          break;
-        }
-        default:
-          PADDLE_THROW("Unknown storage order: %s", tensor_format_str);
-      }
-
-      EigenVectorArrayMap<T> running_mean_arr(
-          mean_out->mutable_data<T>(ctx.GetPlace()), C);
-      EigenVectorArrayMap<T> running_var_arr(
-          variance_out->mutable_data<T>(ctx.GetPlace()), C);
-      running_mean_arr =
-          running_mean_arr * momentum + saved_mean_e * (1. - momentum);
-      running_var_arr =
-          running_var_arr * momentum + saved_variance_e * (1. - momentum);
+      mean_out->mutable_data<T>(ctx.GetPlace());
+      variance_out->mutable_data<T>(ctx.GetPlace());
+      saved_mean->mutable_data<T>(ctx.GetPlace());
+      saved_variance->mutable_data<T>(ctx.GetPlace());
     }
 
-    // use SavedMean and SavedVariance to do normalize
-    Eigen::Array<T, Eigen::Dynamic, 1> inv_std(C);
-    if (is_test) {
-      ConstEigenVectorArrayMap<T> var_arr(
-          ctx.Input<Tensor>("Variance")->data<T>(), C);
-      inv_std = (var_arr + epsilon).sqrt().inverse();
-    } else {
-      EigenVectorArrayMap<T> saved_inv_std(
-          ctx.Output<Tensor>("SavedVariance")->data<T>(), C);
-      // inverse SavedVariance first, gradient will use it too.
-      saved_inv_std = (saved_inv_std + epsilon).inverse().sqrt();
-      inv_std = saved_inv_std;
-    }
-    ConstEigenVectorArrayMap<T> mean_arr(
-        is_test ? ctx.Input<Tensor>("Mean")->data<T>()
-                : ctx.Output<Tensor>("SavedMean")->data<T>(),
-        C);
-
-    //   ((x - est_mean) * (inv_var) * scale + bias
-    //   formula transform ====>
-    //   (x * inv_var * scale) + (bias - est_mean * inv_var * scale)
-    const auto *scale = ctx.Input<Tensor>("Scale");
-    const auto *bias = ctx.Input<Tensor>("Bias");
-    ConstEigenVectorArrayMap<T> scale_arr(scale->data<T>(), C);
-    ConstEigenVectorArrayMap<T> bias_arr(bias->data<T>(), C);
-    Eigen::Array<T, Eigen::Dynamic, 1> new_scale = inv_std * scale_arr;
-    Eigen::Array<T, Eigen::Dynamic, 1> new_bias =
-        bias_arr - mean_arr * inv_std * scale_arr;
-
-    switch (tensor_format) {
-      case TensorFormat::NCHW: {
-        EigenArrayMap<T> y_arr(y->mutable_data<T>(ctx.GetPlace()), sample_size,
-                               N * C);
-        ConstEigenArrayMap<T> x_arr(x->data<T>(), sample_size, N * C);
-        for (int nc = 0; nc < N * C; ++nc) {
-          y_arr.col(nc) = x_arr.col(nc) * new_scale(nc % C) + new_bias(nc % C);
-        }
-        break;
-      }
-      case TensorFormat::NHWC: {
-        EigenArrayMap<T>(y->mutable_data<T>(ctx.GetPlace()), C,
-                         N * sample_size) =
-            (ConstEigenArrayMap<T>(x->data<T>(), C, N * sample_size).colwise() *
-             new_scale)
-                .colwise() +
-            new_bias;
-        break;
-      }
-      default:
-        PADDLE_THROW("Unknown storage order: %d", tensor_format);
-    }
+    BatchNormalizeForward<T>(
+        ctx.GetPlace(), *ctx.Input<Tensor>("X"), *ctx.Input<Tensor>("Scale"),
+        *ctx.Input<Tensor>("Bias"), *ctx.Input<Tensor>("Mean"),
+        *ctx.Input<Tensor>("Variance"), ctx.Attr<float>("epsilon"),
+        ctx.Attr<float>("momentum"), ctx.Attr<std::string>("tensor_format"),
+        ctx.Attr<bool>("unbiased_estimate"), is_test, y, mean_out, variance_out,
+        saved_mean, saved_variance);
   }
 };
 
@@ -276,24 +209,35 @@ class BatchNormGradOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext *ctx) const override {
-    // check input
-    PADDLE_ENFORCE(ctx->HasInput("X"));
-    PADDLE_ENFORCE(ctx->HasInput("Scale"), "");
-    PADDLE_ENFORCE(ctx->HasInput(framework::GradVarName("Y")), "");
-    PADDLE_ENFORCE(ctx->HasInput("SavedMean"), "");
-    PADDLE_ENFORCE(ctx->HasInput("SavedVariance"), "");
-
+    PADDLE_ENFORCE(ctx->HasInput("X"),
+                   "Input(X) of BatchNormGradOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput("Scale"),
+                   "Input(Scale) of BatchNormGradOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput(framework::GradVarName("Y")),
+                   "Input(Y@Grad) of BatchNormGradOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput("SavedMean"),
+                   "Input(SavedMean) of BatchNormGradOp should not be null");
+    PADDLE_ENFORCE(
+        ctx->HasInput("SavedVariance"),
+        "Input(SavedVariance) of BatchNormGradOp should not be null");
+    PADDLE_ENFORCE(!ctx->Attrs().Get<bool>("is_test"),
+                   "Attribute(is_test) of BatchNormGradOp should be false, "
+                   "i.e. gradient computation is not allowed in test mode.");
     // check output
-    PADDLE_ENFORCE(ctx->HasOutput(framework::GradVarName("X")), "");
-    PADDLE_ENFORCE(ctx->HasOutput(framework::GradVarName("Scale")), "");
-    PADDLE_ENFORCE(ctx->HasOutput(framework::GradVarName("Bias")), "");
+    PADDLE_ENFORCE(ctx->HasOutput(framework::GradVarName("X")),
+                   "Output(X@Grad) of BatchNormGradOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasOutput(framework::GradVarName("Scale")),
+                   "Output(Scale@Grad) of BatchNormGradOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasOutput(framework::GradVarName("Bias")),
+                   "Output(Bias@Grad) of BatchNormGradOp should not be null.");
 
     const auto x_dims = ctx->GetInputDim("X");
     const TensorFormat tensor_format =
         StringToTensorFormat(ctx->Attrs().Get<std::string>("tensor_format"));
-    const int C =
-        (tensor_format == TensorFormat::NCHW ? x_dims[1]
-                                             : x_dims[x_dims.size() - 1]);
+    const int C = (tensor_format == TensorFormat::NCHW ||
+                           tensor_format == TensorFormat::NCDHW
+                       ? x_dims[1]
+                       : x_dims[x_dims.size() - 1]);
 
     ctx->SetOutputDim(framework::GradVarName("X"), x_dims);
     ctx->SetOutputDim(framework::GradVarName("Scale"), {C});
@@ -326,106 +270,19 @@ class BatchNormGradKernel<platform::CPUPlace, T>
     : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
-    const auto *x = ctx.Input<Tensor>("X");
-    const auto *d_y = ctx.Input<Tensor>(framework::GradVarName("Y"));
-    const auto *scale = ctx.Input<Tensor>("Scale");
-    const auto *saved_mean = ctx.Input<Tensor>("SavedMean");
-    // SavedVariance have been reverted in forward operator
-    const auto *saved_inv_variance = ctx.Input<Tensor>("SavedVariance");
-    const std::string tensor_format_str =
-        ctx.Attr<std::string>("tensor_format");
-    const TensorFormat tensor_format = StringToTensorFormat(tensor_format_str);
-
-    // Get the size for each dimension.
-    // NCHW [batch_size, in_channels, in_height, in_width]
-    const auto &x_dims = x->dims();
-    PADDLE_ENFORCE(x_dims.size() >= 3 && x_dims.size() <= 5,
-                   "The Input dim size should be between 3 and 5");
-    const int N = x_dims[0];
-    const int C =
-        (tensor_format == TensorFormat::NCHW ? x_dims[1]
-                                             : x_dims[x_dims.size() - 1]);
-    const int sample_size = x->numel() / N / C;
-
-    ConstEigenVectorArrayMap<T> scale_arr(scale->data<T>(), C);
-    ConstEigenVectorArrayMap<T> mean_arr(saved_mean->data<T>(), C);
-    ConstEigenVectorArrayMap<T> inv_var_arr(saved_inv_variance->data<T>(), C);
-
     // init output
     auto *d_x = ctx.Output<Tensor>(framework::GradVarName("X"));
     auto *d_scale = ctx.Output<Tensor>(framework::GradVarName("Scale"));
     auto *d_bias = ctx.Output<Tensor>(framework::GradVarName("Bias"));
-
     d_x->mutable_data<T>(ctx.GetPlace());
     d_scale->mutable_data<T>(ctx.GetPlace());
     d_bias->mutable_data<T>(ctx.GetPlace());
 
-    // d_bias = np.sum(d_y, axis=0)
-    // d_scale = np.sum((X - mean) / inv_std * dy, axis=0)
-    // d_x = (1. / N) * scale * inv_var * (N * d_y - np.sum(d_y, axis=0)
-    //   - (X - mean) * inv_var * inv_var * np.sum(d_y * (X - mean), axis=0))
-
-    EigenVectorArrayMap<T> d_bias_arr(d_bias->mutable_data<T>(ctx.GetPlace()),
-                                      C);
-    EigenVectorArrayMap<T> d_scale_arr(d_scale->mutable_data<T>(ctx.GetPlace()),
-                                       C);
-
-    d_bias_arr.setZero();
-    d_scale_arr.setZero();
-
-    const auto scale_inv_var_nhw = scale_arr * inv_var_arr / (N * sample_size);
-
-    switch (tensor_format) {
-      case TensorFormat::NCHW: {
-        ConstEigenArrayMap<T> x_arr(x->data<T>(), sample_size, N * C);
-        ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), sample_size, N * C);
-        EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()),
-                                 sample_size, N * C);
-        d_x_arr.setZero();
-
-        for (int nc = 0; nc < N * C; ++nc) {
-          int c = nc % C;
-          d_bias_arr(c) += d_y_arr.col(nc).sum();
-          d_scale_arr(c) +=
-              ((x_arr.col(nc) - mean_arr(c)) * inv_var_arr(c) * d_y_arr.col(nc))
-                  .sum();
-        }
-        for (int nc = 0; nc < N * C; ++nc) {
-          int c = nc % C;
-          d_x_arr.col(nc) +=
-              scale_inv_var_nhw(c) *
-              (d_y_arr.col(nc) * N * sample_size - d_bias_arr(c) -
-               (x_arr.col(nc) - mean_arr[c]) * d_scale_arr(c) * inv_var_arr(c));
-        }
-        break;
-      }
-      case TensorFormat::NHWC: {
-        ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N * sample_size);
-        ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), C, N * sample_size);
-        EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()), C,
-                                 N * sample_size);
-        d_x_arr.setZero();
-
-        const auto d_y_row_sum = d_y_arr.rowwise().sum();
-        const auto x_minus_mean = x_arr.colwise() - mean_arr;
-        const auto d_y_mul_x_minus_mean_row_sum =
-            (d_y_arr * x_minus_mean).rowwise().sum();
-        const auto inv_var_sqr = inv_var_arr * inv_var_arr;
-        for (int nhw = 0; nhw < N * sample_size; ++nhw) {
-          d_bias_arr += d_y_arr.col(nhw);
-          d_scale_arr +=
-              (x_arr.col(nhw) - mean_arr) * inv_var_arr * d_y_arr.col(nhw);
-          d_x_arr.col(nhw) +=
-              scale_inv_var_nhw *
-              (d_y_arr.col(nhw) * N * sample_size - d_y_row_sum -
-               x_minus_mean.col(nhw) * inv_var_sqr *
-                   d_y_mul_x_minus_mean_row_sum);
-        }
-        break;
-      }
-      default:
-        PADDLE_THROW("Unknown storage order: %s", tensor_format_str);
-    }
+    BatchNormalizeBackward<T>(
+        ctx.GetPlace(), *ctx.Input<Tensor>(framework::GradVarName("Y")),
+        *ctx.Input<Tensor>("X"), *ctx.Input<Tensor>("Scale"),
+        *ctx.Input<Tensor>("SavedMean"), *ctx.Input<Tensor>("SavedVariance"),
+        ctx.Attr<std::string>("tensor_format"), d_x, d_scale, d_bias);
   }
 };
 

--- a/paddle/operators/batch_norm_op.h
+++ b/paddle/operators/batch_norm_op.h
@@ -15,24 +15,10 @@ limitations under the License. */
 #pragma once
 #include "paddle/framework/eigen.h"
 #include "paddle/framework/op_registry.h"
+#include "paddle/operators/normalization.h"
 
 namespace paddle {
 namespace operators {
-
-enum TensorFormat {
-  NHWC = 0,
-  NCHW = 1,
-};
-
-inline TensorFormat StringToTensorFormat(const std::string& str) {
-  if (str == "NHWC" || str == "nhwc") {
-    return TensorFormat::NHWC;
-  } else if (str == "NCHW" || str == "nchw") {
-    return TensorFormat::NCHW;
-  } else {
-    PADDLE_THROW("Unknown storage order string: %s", str);
-  }
-}
 
 template <typename Place, typename T>
 class BatchNormKernel : public framework::OpKernel<T> {

--- a/paddle/operators/normalization.h
+++ b/paddle/operators/normalization.h
@@ -1,0 +1,296 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserve.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include "paddle/framework/eigen.h"
+#include "paddle/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+using LoDTensor = framework::LoDTensor;
+enum TensorFormat { NC = 0, NHWC, NCHW, NDHWC, NCDHW };
+
+inline TensorFormat StringToTensorFormat(const std::string& str) {
+  std::string format;
+  std::transform(str.begin(), str.end(), std::back_inserter(format),
+                 [](unsigned char c) -> unsigned char { return ::toupper(c); });
+  if (format == "NC") {
+    return TensorFormat::NC;
+  } else if (format == "NHWC") {
+    return TensorFormat::NHWC;
+  } else if (format == "NCHW") {
+    return TensorFormat::NCHW;
+  } else if (format == "NDHWC") {
+    return TensorFormat::NDHWC;
+  } else if (format == "NCDHW") {
+    return TensorFormat::NCDHW;
+  } else {
+    PADDLE_THROW("Unknown storage order string: %s", str);
+  }
+}
+
+inline void ValidTensorRank(const int rank, const TensorFormat& tensor_format) {
+  switch (tensor_format) {
+    case TensorFormat::NC:
+      PADDLE_ENFORCE(rank == 2,
+                     "Input tensor rank should be 2 when format is NC.");
+      break;
+    case TensorFormat::NHWC:
+    case TensorFormat::NCHW:
+      PADDLE_ENFORCE(
+          rank == 4,
+          "Input tensor rank should be 4 when format is NHWC or NCHW.");
+      break;
+    case TensorFormat::NDHWC:
+    case TensorFormat::NCDHW:
+      PADDLE_ENFORCE(
+          rank == 5,
+          "Input tensor rank should be 5 when format is NDHWC or NCDHW.");
+      break;
+    default:
+      PADDLE_THROW("Unknown storage order: %d", tensor_format);
+  }
+}
+
+template <typename T>
+using EigenArrayMap =
+    Eigen::Map<Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using ConstEigenArrayMap =
+    Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, Eigen::Dynamic>>;
+template <typename T>
+using EigenVectorArrayMap = Eigen::Map<Eigen::Array<T, Eigen::Dynamic, 1>>;
+template <typename T>
+using ConstEigenVectorArrayMap =
+    Eigen::Map<const Eigen::Array<T, Eigen::Dynamic, 1>>;
+
+template <typename T>
+void BatchEstimate(const platform::Place place, const Tensor& x,
+                   const TensorFormat& tensor_format, const int N, const int C,
+                   const int sample_size, bool unbiased_variance,
+                   EigenVectorArrayMap<T>& saved_mean_e,
+                   EigenVectorArrayMap<T>& saved_variance_e) {
+  switch (tensor_format) {
+    case TensorFormat::NCHW:
+    case TensorFormat::NCDHW: {
+      ConstEigenArrayMap<T> x_arr(x.data<T>(), sample_size, N * C);
+      for (int nc = 0; nc < N * C; ++nc) {
+        saved_mean_e(nc % C) += x_arr.col(nc).sum();
+      }
+      saved_mean_e /= N * sample_size;
+      for (int nc = 0; nc < N * C; ++nc) {
+        saved_variance_e(nc % C) +=
+            (x_arr.col(nc) - saved_mean_e(nc % C)).matrix().squaredNorm();
+      }
+      saved_variance_e /= N * sample_size;
+      break;
+    }
+    case TensorFormat::NC:
+    case TensorFormat::NHWC:
+    case TensorFormat::NDHWC: {
+      ConstEigenArrayMap<T> x_arr(x.data<T>(), C, N * sample_size);
+      for (int i = 0; i < N * sample_size; ++i) {
+        saved_mean_e += x_arr.col(i);
+      }
+      saved_mean_e /= N * sample_size;
+      for (int i = 0; i < N * sample_size; ++i) {
+        saved_variance_e +=
+            (x_arr.col(i) - saved_mean_e) * (x_arr.col(i) - saved_mean_e);
+      }
+      saved_variance_e /= N * sample_size;
+      break;
+    }
+    default:
+      PADDLE_THROW("BatchEstimate not implemeted for storage order: %d",
+                   tensor_format);
+  }
+  if (unbiased_variance && (N * sample_size) > 1) {
+    saved_variance_e *= (N * sample_size) / (N * sample_size - 1);
+  }
+}
+
+template <typename T>
+void BatchNormalizeForward(
+    const platform::Place place, const Tensor& x, const Tensor& scale,
+    const Tensor& bias, const Tensor& mean_input, const Tensor& variance_input,
+    const T epsilon, const T momentum, const std::string& tensor_format_str,
+    bool unbiased_variance, bool is_test, Tensor* y, Tensor* mean_out,
+    Tensor* variance_out, Tensor* saved_mean, Tensor* saved_variance) {
+  const auto& x_dims = x.dims();
+  auto tensor_format = StringToTensorFormat(tensor_format_str);
+  ValidTensorRank(x_dims.size(), tensor_format);
+
+  const int N = x_dims[0];
+  const int C = (tensor_format == TensorFormat::NCHW ||
+                         tensor_format == TensorFormat::NCDHW
+                     ? x_dims[1]
+                     : x_dims[x_dims.size() - 1]);
+  const int sample_size = x.numel() / N / C;
+
+  if (!is_test) {
+    EigenVectorArrayMap<T> saved_mean_e(saved_mean->mutable_data<T>(place), C);
+    EigenVectorArrayMap<T> saved_variance_e(
+        saved_variance->mutable_data<T>(place), C);
+    saved_mean_e.setZero();
+    saved_variance_e.setZero();
+    // saved_xx are estimated using current batch
+    BatchEstimate<T>(place, x, tensor_format, N, C, sample_size,
+                     unbiased_variance, saved_mean_e, saved_variance_e);
+    EigenVectorArrayMap<T> running_mean_arr(mean_out->mutable_data<T>(place),
+                                            C);
+    EigenVectorArrayMap<T> running_var_arr(variance_out->mutable_data<T>(place),
+                                           C);
+    running_mean_arr =
+        running_mean_arr * momentum + saved_mean_e * (1. - momentum);
+    running_var_arr =
+        running_var_arr * momentum + saved_variance_e * (1. - momentum);
+  }
+
+  // use SavedMean and SavedVariance to do normalize
+  Eigen::Array<T, Eigen::Dynamic, 1> inv_std(C);
+  if (is_test) {
+    ConstEigenVectorArrayMap<T> var_arr(variance_input.data<T>(), C);
+    inv_std = (var_arr + epsilon).sqrt().inverse();
+  } else {
+    EigenVectorArrayMap<T> saved_inv_std(saved_variance->data<T>(), C);
+    // inverse SavedVariance first, gradient will use it too.
+    saved_inv_std = (saved_inv_std + epsilon).inverse().sqrt();
+    inv_std = saved_inv_std;
+  }
+  ConstEigenVectorArrayMap<T> mean_arr(
+      is_test ? mean_input.data<T>() : saved_mean->data<T>(), C);
+
+  //   ((x - est_mean) * (inv_var) * scale + bias
+  //   formula transform ====>
+  //   (x * inv_var * scale) + (bias - est_mean * inv_var * scale)
+  ConstEigenVectorArrayMap<T> scale_arr(scale.data<T>(), C);
+  ConstEigenVectorArrayMap<T> bias_arr(bias.data<T>(), C);
+  Eigen::Array<T, Eigen::Dynamic, 1> new_scale = inv_std * scale_arr;
+  Eigen::Array<T, Eigen::Dynamic, 1> new_bias =
+      bias_arr - mean_arr * inv_std * scale_arr;
+
+  switch (tensor_format) {
+    case TensorFormat::NCHW:
+    case TensorFormat::NCDHW: {
+      EigenArrayMap<T> y_arr(y->mutable_data<T>(place), sample_size, N * C);
+      ConstEigenArrayMap<T> x_arr(x.data<T>(), sample_size, N * C);
+      for (int nc = 0; nc < N * C; ++nc) {
+        y_arr.col(nc) = x_arr.col(nc) * new_scale(nc % C) + new_bias(nc % C);
+      }
+      break;
+    }
+    case TensorFormat::NC:
+    case TensorFormat::NHWC:
+    case TensorFormat::NDHWC: {
+      EigenArrayMap<T>(y->mutable_data<T>(place), C, N * sample_size) =
+          (ConstEigenArrayMap<T>(x.data<T>(), C, N * sample_size).colwise() *
+           new_scale)
+              .colwise() +
+          new_bias;
+      break;
+    }
+    default:
+      PADDLE_THROW("Unknown storage order: %s", tensor_format_str);
+  }
+}
+
+template <typename T>
+void BatchNormalizeBackward(const platform::Place place, const Tensor& d_y,
+                            const Tensor& x, const Tensor& scale,
+                            const Tensor& saved_mean,
+                            const Tensor& saved_inv_variance,
+                            const std::string& tensor_format_str, Tensor* d_x,
+                            Tensor* d_scale, Tensor* d_bias) {
+  const auto& x_dims = x.dims();
+  auto tensor_format = StringToTensorFormat(tensor_format_str);
+  ValidTensorRank(x_dims.size(), tensor_format);
+  const int N = x_dims[0];
+  const int C = (tensor_format == TensorFormat::NCHW ||
+                         tensor_format == TensorFormat::NCDHW
+                     ? x_dims[1]
+                     : x_dims[x_dims.size() - 1]);
+  const int sample_size = x.numel() / N / C;
+
+  ConstEigenVectorArrayMap<T> scale_arr(scale.data<T>(), C);
+  ConstEigenVectorArrayMap<T> mean_arr(saved_mean.data<T>(), C);
+  ConstEigenVectorArrayMap<T> inv_var_arr(saved_inv_variance.data<T>(), C);
+
+  // d_bias = np.sum(d_y, axis=0)
+  // d_scale = np.sum((X - mean) / inv_std * dy, axis=0)
+  // d_x = (1. / N) * scale * inv_var * (N * d_y - np.sum(d_y, axis=0)
+  //   - (X - mean) * inv_var * inv_var * np.sum(d_y * (X - mean), axis=0))
+  EigenVectorArrayMap<T> d_bias_arr(d_bias->mutable_data<T>(place), C);
+  EigenVectorArrayMap<T> d_scale_arr(d_scale->mutable_data<T>(place), C);
+  d_bias_arr.setZero();
+  d_scale_arr.setZero();
+
+  const auto scale_inv_var_nhw = scale_arr * inv_var_arr / (N * sample_size);
+
+  switch (tensor_format) {
+    case TensorFormat::NCHW:
+    case TensorFormat::NCDHW: {
+      ConstEigenArrayMap<T> x_arr(x.data<T>(), sample_size, N * C);
+      ConstEigenArrayMap<T> d_y_arr(d_y.data<T>(), sample_size, N * C);
+      EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(place), sample_size, N * C);
+      d_x_arr.setZero();
+
+      for (int nc = 0; nc < N * C; ++nc) {
+        int c = nc % C;
+        d_bias_arr(c) += d_y_arr.col(nc).sum();
+        d_scale_arr(c) +=
+            ((x_arr.col(nc) - mean_arr(c)) * inv_var_arr(c) * d_y_arr.col(nc))
+                .sum();
+      }
+      for (int nc = 0; nc < N * C; ++nc) {
+        int c = nc % C;
+        d_x_arr.col(nc) +=
+            scale_inv_var_nhw(c) *
+            (d_y_arr.col(nc) * N * sample_size - d_bias_arr(c) -
+             (x_arr.col(nc) - mean_arr[c]) * d_scale_arr(c) * inv_var_arr(c));
+      }
+      break;
+    }
+    case TensorFormat::NC:
+    case TensorFormat::NHWC:
+    case TensorFormat::NDHWC: {
+      ConstEigenArrayMap<T> x_arr(x.data<T>(), C, N * sample_size);
+      ConstEigenArrayMap<T> d_y_arr(d_y.data<T>(), C, N * sample_size);
+      EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(place), C, N * sample_size);
+      d_x_arr.setZero();
+
+      const auto d_y_row_sum = d_y_arr.rowwise().sum();
+      const auto x_minus_mean = x_arr.colwise() - mean_arr;
+      const auto d_y_mul_x_minus_mean_row_sum =
+          (d_y_arr * x_minus_mean).rowwise().sum();
+      const auto inv_var_sqr = inv_var_arr * inv_var_arr;
+      for (int nhw = 0; nhw < N * sample_size; ++nhw) {
+        d_bias_arr += d_y_arr.col(nhw);
+        d_scale_arr +=
+            (x_arr.col(nhw) - mean_arr) * inv_var_arr * d_y_arr.col(nhw);
+        d_x_arr.col(nhw) += scale_inv_var_nhw *
+                            (d_y_arr.col(nhw) * N * sample_size - d_y_row_sum -
+                             x_minus_mean.col(nhw) * inv_var_sqr *
+                                 d_y_mul_x_minus_mean_row_sum);
+      }
+      break;
+    }
+    default:
+      PADDLE_THROW("Unknown storage order: %s", tensor_format_str);
+  }
+}
+
+}  // namespace operators
+}  // namespace paddle


### PR DESCRIPTION
Solve #5811 

As part of the job of another PR #5686 , I separate the code that related to batch_norm_op enhancement as a standalone PR for better code review.

This PR does several modifications to the original batch_norm_op implementation.

- [x] Extract normalization logic to a common header file, check issue #5685 for disscussion.

- [x] Fix assertion logic. Some outputs should appear only in training mode.

- [x] Support unbiased variance estimation, i.e. the bessel's correction.

- [x] Support 2D tensor (tensor_format="NC") and 5D tensor (tensor_format="NCDHW" or "NDHWC") in CPU

- [ ] Support 2D tensor (tensor_format="NC") and 5D tensor (tensor_format="NCDHW" or "NDHWC") in GPU.

- [ ] Operator unit test. See issue #5842 .

2D tensor is not supported by cudnn batch norm implementation, so changes need to be made to the GPU code.