### PR TITLE
imdb return reader rather than reader().

### DIFF
--- a/python/paddle/v2/dataset/imdb.py
+++ b/python/paddle/v2/dataset/imdb.py
@@ -116,7 +116,7 @@ def reader_creator(pos_pattern, neg_pattern, word_idx, buffer_size):
             yield [word_idx.get(w, UNK) for w in doc], i % 2
             doc = qs[i % 2].get()
 
-    return reader()
+    return reader
 
 
 def train(word_idx):


### PR DESCRIPTION
Paddle/model这个目录下载下来之后， 在text_classification执行run.sh会报错。
```
Traceback (most recent call last):
  File "train.py", line 179, in <module>
    main(args)
  File "train.py", line 170, in main
    model_save_dir=args.model_save_dir)
  File "train.py", line 151, in train
    num_passes=num_passes)
  File "/home/work/playground/ppap/python27-gcc482/lib/python2.7/site-packages/paddle/v2/trainer.py", line 154, in train
    for batch_id, data_batch in enumerate(reader()):
  File "/home/work/playground/ppap/python27-gcc482/lib/python2.7/site-packages/paddle/v2/minibatch.py", line 33, in batch_reader
    for instance in r:
  File "/home/work/playground/ppap/python27-gcc482/lib/python2.7/site-packages/paddle/v2/reader/decorator.py", line 67, in data_reader
    for e in reader():
  File "train.py", line 50, in <lambda>
    lambda: paddle.dataset.imdb.train(word_dict)(), buf_size=1000),
TypeError: 'generator' object is not callable
```
原因是因为Paddle/python/paddle/v2/dataset/imdb.py中，返回的是reader(), 而不是reader. 
 models-develop/text_classification/train.py调用的语句是
```
    ┆   train_reader = paddle.batch(
    ┆   ┆   paddle.reader.shuffle(
    ┆   ┆   ┆   lambda: paddle.dataset.imdb.train(word_dict)(), buf_size=1000),
    ┆   ┆   batch_size=100)
```