### PR TITLE
OpTest enhancement: unify forward backward logics; bug fix; support in-place operator test

### DIFF
--- a/python/paddle/v2/fluid/tests/op_test.py
+++ b/python/paddle/v2/fluid/tests/op_test.py
@@ -562,8 +562,7 @@ class OpTest(unittest.TestCase):
             debug_idx = 0
             for cur_loss in mean_inputs:
                 debug_idx += 1
-                cur_avg_loss = block.create_var(
-                    dtype=cur_loss.data_type, shape=[1])
+                cur_avg_loss = block.create_var(dtype=cur_loss.dtype, shape=[1])
                 op = block.append_op(
                     inputs={"X": [cur_loss]},
                     outputs={"Out": [cur_avg_loss]},
@@ -572,13 +571,13 @@ class OpTest(unittest.TestCase):
                 op.desc.infer_shape(block.desc)
                 avg_sum.append(cur_avg_loss)
 
-            loss_sum = block.create_var(dtype=avg_sum[0].data_type, shape=[1])
+            loss_sum = block.create_var(dtype=avg_sum[0].dtype, shape=[1])
             op_sum = block.append_op(
                 inputs={"X": avg_sum}, outputs={"Out": loss_sum}, type='sum')
             op_sum.desc.infer_var_type(block.desc)
             op_sum.desc.infer_shape(block.desc)
 
-            loss = block.create_var(dtype=loss_sum.data_type, shape=[1])
+            loss = block.create_var(dtype=loss_sum.dtype, shape=[1])
             op_loss = block.append_op(
                 inputs={"X": loss_sum},
                 outputs={"Out": loss},

--- a/python/paddle/v2/fluid/tests/op_test.py
+++ b/python/paddle/v2/fluid/tests/op_test.py
@@ -19,180 +19,6 @@ def randomize_probability(batch_size, class_num, dtype='float32'):
     return prob
 
 
-def create_op(scope, op_type, inputs, outputs, attrs):
-    kwargs = dict()
-
-    def __create_var__(name, var_name):
-        scope.var(var_name).get_tensor()
-        kwargs[name].append(var_name)
-
-    for in_name, in_dup in Operator.get_op_inputs(op_type):
-        if in_name in inputs:
-            kwargs[in_name] = []
-            if in_dup:
-                sub_in = inputs[in_name]
-                for sub_in_name, _ in sub_in:
-                    __create_var__(in_name, sub_in_name)
-            else:
-                __create_var__(in_name, in_name)
-
-    for out_name, out_dup in Operator.get_op_outputs(op_type):
-        if out_name in outputs:
-            kwargs[out_name] = []
-            if out_dup:
-                sub_out = outputs[out_name]
-                for sub_out_name, _ in sub_out:
-                    __create_var__(out_name, sub_out_name)
-            else:
-                __create_var__(out_name, out_name)
-
-    for attr_name in Operator.get_op_attr_names(op_type):
-        if attr_name in attrs:
-            kwargs[attr_name] = attrs[attr_name]
-
-    return Operator(op_type, **kwargs)
-
-
-def set_input(scope, op, inputs, place):
-    def __set_input__(var_name, var):
-        if isinstance(var, tuple) or isinstance(var, np.ndarray):
-            tensor = scope.find_var(var_name).get_tensor()
-            if isinstance(var, tuple):
-                tensor.set_lod(var[1])
-                var = var[0]
-            tensor.set_dims(var.shape)
-            tensor.set(var, place)
-        elif isinstance(var, float):
-            scope.find_var(var_name).set_float(var)
-        elif isinstance(var, int):
-            scope.find_var(var_name).set_int(var)
-
-    for in_name, in_dup in Operator.get_op_inputs(op.type()):
-        if in_name in inputs:
-            if in_dup:
-                sub_in = inputs[in_name]
-                for sub_in_name, sub_in_val in sub_in:
-                    __set_input__(sub_in_name, sub_in_val)
-            else:
-                __set_input__(in_name, inputs[in_name])
-
-
-def get_numeric_gradient(scope,
-                         op,
-                         inputs,
-                         input_to_check,
-                         output_names,
-                         delta=0.005,
-                         in_place=False):
-    # FIXME: change this method by compile time concepts
-    set_input(scope, op, inputs, core.CPUPlace())
-
-    def product(dim):
-        return reduce(lambda a, b: a * b, dim, 1)
-
-    ctx = core.DeviceContext.create(core.CPUPlace())
-
-    def get_output():
-        sum = []
-        for output_name in output_names:
-            op.run(scope, ctx)
-            sum.append(
-                np.array(scope.find_var(output_name).get_tensor()).mean())
-        return np.array(sum).mean()
-
-    tensor_to_check = scope.find_var(input_to_check).get_tensor()
-    tensor_size = product(tensor_to_check.get_dims())
-    tensor_to_check_dtype = tensor_to_check.dtype()
-    if tensor_to_check_dtype == core.DataType.FP32:
-        tensor_to_check_dtype = np.float32
-    elif tensor_to_check_dtype == core.DataType.FP64:
-        tensor_to_check_dtype = np.float64
-    else:
-        raise ValueError("Not supported data type " + str(
-            tensor_to_check_dtype))
-
-    gradient_flat = np.zeros(shape=(tensor_size, ), dtype=tensor_to_check_dtype)
-
-    def __get_elem__(tensor, i):
-        if tensor_to_check_dtype == np.float32:
-            return tensor.get_float_element(i)
-        else:
-            return tensor.get_double_element(i)
-
-    def __set_elem__(tensor, i, e):
-        if tensor_to_check_dtype == np.float32:
-            tensor.set_float_element(i, e)
-        else:
-            tensor.set_double_element(i, e)
-
-    # we only compute gradient of one element each time.
-    # we use a for loop to compute the gradient of every element.
-    for i in xrange(tensor_size):
-        if in_place:
-            set_input(scope, op, inputs, core.CPUPlace())
-
-        # get one input element throw it's index i.
-        origin = __get_elem__(tensor_to_check, i)
-        # add delta to it, run op and then get the sum of the result tensor.
-        x_pos = origin + delta
-        __set_elem__(tensor_to_check, i, x_pos)
-        y_pos = get_output()
-
-        if in_place:
-            set_input(scope, op, inputs, core.CPUPlace())
-
-        x_neg = origin - delta
-        __set_elem__(tensor_to_check, i, x_neg)
-        y_neg = get_output()
-
-        __set_elem__(tensor_to_check, i, origin)
-        gradient_flat[i] = (y_pos - y_neg) / delta / 2
-
-    return gradient_flat.reshape(tensor_to_check.get_dims())
-
-
-def append_input_output(block, op_proto, np_list, is_input):
-    '''Insert VarDesc and generate Python variable instance'''
-    proto_list = op_proto.inputs if is_input else op_proto.outputs
-
-    def create_var(block, name, np_list, var_proto):
-        if name not in np_list:
-            assert var_proto.intermediate, "{} not found".format(name)
-            shape = None
-            lod_level = None
-        else:
-            np_value = np_list[name]
-            if isinstance(np_value, tuple):
-                shape = list(np_value[0].shape)
-                lod_level = len(np_value[1])
-            else:
-                shape = list(np_value.shape)
-                lod_level = 0
-        return block.create_var(
-            dtype="float32", shape=shape, lod_level=lod_level, name=name)
-
-    var_dict = {}
-    for var_proto in proto_list:
-        var_name = str(var_proto.name)
-        if is_input:
-            if (var_name not in np_list) and var_proto.dispensable:
-                continue
-            assert (var_name in np_list) or (var_proto.dispensable), \
-                "Missing {} as input".format(var_name)
-        if var_proto.duplicable:
-            assert isinstance(np_list[var_name], list), \
-                "Duplicable {} should be set as list".format(var_name)
-            var_list = []
-            for (name, np_value) in np_list[var_name]:
-                var_list.append(
-                    create_var(block, name, {name: np_value}, var_proto))
-            var_dict[var_name] = var_list
-        else:
-            var_dict[var_name] = create_var(block, var_name, np_list, var_proto)
-
-    return var_dict
-
-
 class OpTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -209,76 +35,253 @@ class OpTest(unittest.TestCase):
         np.random.set_state(cls._np_rand_state)
         random.setstate(cls._py_rand_state)
 
-    def feed_var(self, input_vars, place):
+    def _init_program(self):
+        """Initialize test environment
+
+        Initialize `Program` and  global `Block`.
+        """
+        self.op_proto = OpProtoHolder.instance().get_op_proto(self.op_type)
+        self.program = Program()
+        self.block = self.program.global_block()
+        # If operator performs in place computation on a variable, in_place_map maps both input and output to the same variable .
+        self.cached_var = {}
+        if not hasattr(self, "in_place_map"):
+            self.in_place_map = {}
+        # Initialize attributes
+        if not hasattr(self, "inputs"):
+            self.inputs = {}
+        if not hasattr(self, "outputs"):
+            self.outputs = {}
+        if not hasattr(self, "attrs"):
+            self.attrs = {}
+
+    def _init_var_desc(self, name, feed_value=None, dtype="float32"):
+        """Initialize description for one varible in current block.
+
+        Create a variable description in current block if it dosen't exist.
+
+        :param name: variable name. 
+        :type name: basestring.
+        :param feed_value: tensor value and shape that used to initialize the variable. 
+        :type feed_value: 1) numpy `array`, in which case lod_level is 0; 2) 2d tuple, where the first element is numpy `array` and the second element is a `list` specifying the lod_level.
+        :param dtype: data type of tensor. 
+        :type dtype: basestring or one of numpy data types.
+        :return: variable in current block.
+        :rtype: Variable.
+        """
+        block = self.block
+        if block.has_var(name):
+            return block.var(name)
+
+        shape = None
+        lod_level = None
+        if feed_value is not None:
+            if isinstance(feed_value, tuple):
+                shape = list(feed_value[0].shape)
+                lod_level = len(feed_value[1])
+            else:
+                shape = list(feed_value.shape)
+                lod_level = 0
+        return block.create_var(
+            dtype=dtype, shape=shape, lod_level=lod_level, name=name)
+
+    def _init_var_descs(self, var_protos, feed_values, is_input):
+        """Initialize descriptions for varibles in current block.
+
+        Create variable description for input variables or output variables of an operator.
+
+        :param var_protos: input or output variable protobuf message. 
+        :type name: list of VarProto.
+        :param feed_values: a dictionary that maps variable name to its initial values .
+        :type feed_values: dict.
+        :param is_input: True if var_protos contains input variables .
+        :type is_input: Boolean. 
+        :return: a dictionary that maps variable names to the variable description object. 
+        :rtype: dict.
+        """
+        var_dict = {}
+
+        def value_data_type(value):
+            if value is None:
+                return np.float32
+            if isinstance(value, tuple):
+                value = value[0]
+            return value.dtype
+
+        for var_proto in var_protos:
+            var_name = str(
+                var_proto.
+                name)  # name is a unicode object. but this shouldn't matter.
+            if var_name not in feed_values:
+                if var_proto.dispensable and is_input:
+                    continue
+                assert var_proto.dispensable or var_proto.intermediate, "Missing {}".format(
+                    var_name)
+
+            # if it is inplace computation, use the same variable
+            if var_name in self.in_place_map:
+                linked_var = self.in_place_map[var_name]
+                if linked_var in self.cached_var:
+                    var_dict[var_name] = self.cached_var[linked_var]
+                    continue
+                var_name = linked_var
+
+            if var_proto.duplicable:
+                assert isinstance(feed_values[var_name], list), \
+                    "Duplicable {} should be set as list".format(var_name)
+                var_dict[var_name] = [
+                    self._init_var_desc(
+                        name, feed_value=value, dtype=value_data_type(value))
+                    for name, value in feed_values[var_name]
+                ]
+            else:
+                value = feed_values.get(var_name, None)
+                var_dict[var_name] = self._init_var_desc(
+                    var_name, feed_value=value, dtype=value_data_type(value))
+        self.cached_var.update(var_dict)
+        return var_dict
+
+    @staticmethod
+    def _feed_vars(var_descs, var_values, place):
+        """Feed values to tensors in variable
+
+        :param var_descs: a list of variable descriptions 
+        :type name: list.
+        :param var_values: a dictionary that maps variable name to its initial values.
+        :type var_values: dict.
+        :param place: Gpu or Cpu place .
+        :type is_input: Place. 
+        :return: a dictionary that maps variable names to its corresponding tensor. 
+        :rtype: dict.
+        """
         feed_map = {}
-        for var_name in input_vars:
-            if isinstance(input_vars[var_name], list):
-                for name, np_value in self.inputs[var_name]:
+        assert all([key in var_values for key in var_descs.keys()
+                    ]), "Not all variable are fed with values"
+        for var_name, var_desc in var_descs.iteritems():
+            fed_value = var_values[var_name]
+            if isinstance(var_desc, list):
+                for name, value in fed_value:
                     tensor = core.LoDTensor()
-                    if isinstance(np_value, tuple):
-                        tensor.set(np_value[0], place)
-                        tensor.set_lod(np_value[1])
+                    if isinstance(value, tuple):
+                        tensor.set(value[0], place)
+                        tensor.set_lod(value[1])
                     else:
-                        tensor.set(np_value, place)
+                        tensor.set(value, place)
                     feed_map[name] = tensor
             else:
                 tensor = core.LoDTensor()
-                if isinstance(self.inputs[var_name], tuple):
-                    tensor.set(self.inputs[var_name][0], place)
-                    tensor.set_lod(self.inputs[var_name][1])
+                if isinstance(fed_value, tuple):
+                    tensor.set(fed_value[0], place)
+                    tensor.set_lod(fed_value[1])
                 else:
-                    tensor.set(self.inputs[var_name], place)
+                    tensor.set(fed_value, place)
                 feed_map[var_name] = tensor
 
         return feed_map
 
-    def check_output_with_place(self, place, atol):
-        op_proto = OpProtoHolder.instance().get_op_proto(self.op_type)
+    def _compile_op(self, place):
+        """create an operator in current block.
 
-        program = Program()
-        block = program.global_block()
-
-        inputs = append_input_output(block, op_proto, self.inputs, True)
-        outputs = append_input_output(block, op_proto, self.outputs, False)
+        :param place: Gpu or Cpu place. 
+        :type name: Place.
+        :return: 3d tuple (operator, input variable descriptions, output variable descriptions) 
+        :rtype: tuple.
+        """
+        # compile time prepare
+        block = self.block
+        input_var_descs = self._init_var_descs(
+            self.op_proto.inputs, feed_values=self.inputs, is_input=True)
+        output_var_descs = self._init_var_descs(
+            self.op_proto.outputs, feed_values=self.outputs, is_input=False)
         op = block.append_op(
             type=self.op_type,
-            inputs=inputs,
-            outputs=outputs,
+            inputs=input_var_descs,
+            outputs=output_var_descs,
             attrs=self.attrs if hasattr(self, "attrs") else dict())
         # infer variable type and infer shape in compile-time
         op.desc.infer_var_type(block.desc)
         op.desc.infer_shape(block.desc)
 
+        return op, input_var_descs, output_var_descs
+
+    @staticmethod
+    def _get_fetch_list(var_descs, place, filter=None):
+        """Get a list of variable descriptions that needs to be fetched from the result.
+
+        :param var_descs: variable descriptions. 
+        :type var_descs: list.
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :param filter: If provided, only variable names in filter is added into fetch list. 
+        :type filter: list.
+        :return: a list of variable descriptions needs to be fetched. 
+        :rtype: list.
+        """
         fetch_list = []
-        for var_name, var in outputs.iteritems():
-            if var_name in self.outputs:
-                if isinstance(var, list):
-                    for v in var:
-                        fetch_list.append(v)
-                else:
-                    fetch_list.append(var)
+        # flat var_descs values
+        for var_name, var_desc in var_descs.iteritems():
+            sub_vars = []
+            if isinstance(var_desc, list):
+                sub_filters = [sub_var.name for sub_var in var_desc]
+            if isinstance(var_desc, list):
+                if filter is not None:
+                    if var_name not in filter:
+                        var_desc = [
+                            sub_var for sub_var in var_desc
+                            if sub_var.name in filter
+                        ]
+                fetch_list.extend(var_desc)
+            else:
+                if filter is not None and var_name not in filter:
+                    continue
+                fetch_list.append(var_desc)
 
-        feed_map = self.feed_var(inputs, place)
+        return fetch_list
 
+    def _execute(self, feed_map, fetch_list, place):
+        """Run the operator with given inputs and outputs.
+
+        :param feed_map: input tensors.
+        :type feed_map: dict.
+        :param fetch_list: output variables.
+        :type fetch_list: list.
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :return: output values.
+        :rtype: list.
+        """
         exe = Executor(place)
-        outs = exe.run(program,
+        return exe.run(self.program,
                        feed=feed_map,
                        fetch_list=fetch_list,
                        return_numpy=False)
 
+    def _compare_results(self, place, outs, fetch_list, atol):
+        """Check differences between outputs
+
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :param outs: output values.
+        :type outs: list.
+        :param fetch_list: output variables.
+        :type fetch_list: list.
+        :param atol: minimum difference allowed.
+        :type atol: float.
+        """
+
+        def find_actual(target_name, fetch_list):
+            if target_name in self.in_place_map:
+                target_name = self.in_place_map[target_name]
+            found = [
+                i for i, var in enumerate(fetch_list) if var.name == target_name
+            ]
+            self.assertTrue(
+                len(found) == 1, "Found {} {}".format(len(found), target_name))
+            return found[0]
+
         for out_name, out_dup in Operator.get_op_outputs(self.op_type):
             if out_name not in self.outputs:
                 continue
-
-            def find_actual(target_name, fetch_list):
-                found = [
-                    i for i, var in enumerate(fetch_list)
-                    if var.name == target_name
-                ]
-                self.assertTrue(
-                    len(found) == 1, "Found {} {}".format(
-                        len(found), target_name))
-                return found[0]
 
             if out_dup:
                 sub_out = self.outputs[out_name]
@@ -315,7 +318,28 @@ class OpTest(unittest.TestCase):
                                          "Output (" + out_name +
                                          ") has different lod at " + str(place))
 
+    def check_output_with_place(self, place, atol):
+        """Check output on the specific place(CPU or GPU)
+
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :param atol: minimum difference allowed.
+        :type atol: float.
+        """
+        self._init_program()
+        op, input_var_descs, output_var_descs = self._compile_op(place)
+        feed_map = self._feed_vars(input_var_descs, self.inputs, place)
+        fetch_list = self._get_fetch_list(
+            output_var_descs, place, filter=self.outputs.keys())
+        outs = self._execute(feed_map, fetch_list, place)
+        self._compare_results(place, outs, fetch_list, atol)
+
     def check_output(self, atol=1e-5):
+        """Check operator forward process
+
+        :param atol: minimum difference allowed.
+        :type atol: float.
+        """
         places = [core.CPUPlace()]
         if core.is_compile_gpu() and core.op_support_gpu(self.op_type):
             places.append(core.GPUPlace(0))
@@ -324,7 +348,19 @@ class OpTest(unittest.TestCase):
 
     def __assert_is_close(self, numeric_grads, analytic_grads, names,
                           max_relative_error, msg_prefix):
+        """Check differences between numerical gradient and analytical gradient
 
+        :param numeric_grads: nemerical gradient.
+        :type numeric_grads: numpy `array`.
+        :param analytic_grads: analytical gradient.
+        :type analytic_grads: numpy `array`.
+        :param names: variable name.
+        :type names: basestring.
+        :param max_relative_error: minimum difference allowed.
+        :type max_relative_error: float.
+        :param msg_prefix: error message prefix.
+        :type msg_prefix: basestring.
+        """
         for a, b, name in itertools.izip(numeric_grads, analytic_grads, names):
             abs_a = np.abs(a)
             abs_a[abs_a < 1e-3] = 1
@@ -341,46 +377,150 @@ class OpTest(unittest.TestCase):
 
             self.assertLessEqual(max_diff, max_relative_error, err_msg())
 
+    def _numeric_gradient(self,
+                          input_var_descs,
+                          output_var_descs,
+                          input_to_check,
+                          output_names,
+                          place,
+                          delta=0.005,
+                          in_place=False):
+        """Compute numerical gradient for one input variable
+
+        :param input_var_descs: input variable descriptions. 
+        :type input_var_descs: list.
+        :param output_var_descs: input variable descriptions. 
+        :type output_var_descs: list.
+        :param input_to_check: the input variable to compute gradient. 
+        :type input_to_check: basestring.
+        :param output_names: the output variable names. 
+        :type output_names: list.
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :param delta: the small value added to original value. 
+        :type delta: float.
+        :param in_place: wheter the operator performs in-place computation.
+        :type in_place: boolean.
+        :return: numerical gradients.
+        :rtype: numpy `array`
+        """
+        ctx = core.DeviceContext.create(core.CPUPlace())
+
+        def _init_input():
+            feed_map = self._feed_vars(input_var_descs, self.inputs, place)
+            tensor_to_check = feed_map.get(input_to_check, None)
+            assert tensor_to_check is not None, "Can't find input name {}".format(
+                input_to_check)
+            return feed_map, tensor_to_check
+
+        feed_map, tensor_to_check = _init_input()
+        tensor_to_check_dtype = {
+            core.DataType.FP32: np.float32,
+            core.DataType.FP64: np.float64
+        }.get(tensor_to_check.dtype(), None)
+        if tensor_to_check_dtype is None:
+            raise ValueError("Not supported data type " + str(
+                tensor_to_check_dtype))
+        tensor_size = np.prod(tensor_to_check.get_dims())
+        gradient_flat = np.zeros(
+            shape=(tensor_size, ), dtype=tensor_to_check_dtype)
+        # print "Joe:_num_grad:output_names", output_names
+        fetch_list = self._get_fetch_list(
+            output_var_descs, place, filter=output_names)
+        # output_var_descs, place, filter=output_names)
+        exe = Executor(place)
+
+        def __get_elem__(tensor, i):
+            if tensor_to_check_dtype == np.float32:
+                return tensor.get_float_element(i)
+            else:
+                return tensor.get_double_element(i)
+
+        def __set_elem__(tensor, i, e):
+            if tensor_to_check_dtype == np.float32:
+                tensor.set_float_element(i, e)
+            else:
+                tensor.set_double_element(i, e)
+
+        def run_once():
+            outs = exe.run(self.program,
+                           feed=feed_map,
+                           fetch_list=fetch_list,
+                           return_numpy=False)
+            return np.nanmean(
+                np.array([np.array(out) for out in outs]).mean(axis=0))
+
+        for i in xrange(tensor_size):
+            if in_place:
+                feed_map, tensor_to_check = _init_input()
+            # positive
+            origin = __get_elem__(tensor_to_check, i)
+            __set_elem__(tensor_to_check, i, origin + delta)
+            y_pos = run_once()
+
+            if in_place:
+                feed_map, tensor_to_check = _init_input()
+            # negative     
+            __set_elem__(tensor_to_check, i, origin - delta)
+            y_neg = run_once()
+            # restore            
+            __set_elem__(tensor_to_check, i, origin)
+            gradient_flat[i] = (y_pos - y_neg) / delta / 2.
+
+        return gradient_flat.reshape(tensor_to_check.get_dims())
+
     def check_grad(self,
                    inputs_to_check,
                    output_names,
-                   no_grad_set=None,
+                   no_grad_set=set(),
                    numeric_grad_delta=0.005,
                    in_place=False,
                    max_relative_error=0.005,
                    user_defined_grads=None):
-        self.scope = core.Scope()
-        op_inputs = self.inputs if hasattr(self, "inputs") else dict()
-        op_outputs = self.outputs if hasattr(self, "outputs") else dict()
-        op_attrs = self.attrs if hasattr(self, "attrs") else dict()
-        self.op = create_op(self.scope, self.op_type, op_inputs, op_outputs,
-                            op_attrs)
+        """Check the backward computation of operator 
 
-        if no_grad_set is None:
-            no_grad_set = set()
+        :param inputs_to_check: the input variables to compute gradient. 
+        :type inputs_to_check: list.
+        :param output_names: the output variable names. 
+        :type output_names: list.
+        :param no_grad_set: the set of variables that doesn't need to compute gradient
+        :type no_grad_set: set
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :param numeric_grad_delta: the small value added to original value 
+        :type numeric_grad_delta: delta: float.
+        :param in_place: wheter the operator performs in-place computation
+        :type in_place: boolean.
+        :param max_relative_error: minimum difference allowed.
+        :type max_relative_error: float.
+        :param user_defined_grads: if provided, use these user defined gradients as reference.
+        :type user_defined_grads: list.
+        """
+        self._init_program()
+        place = core.CPUPlace()
+        op, input_var_descs, output_var_descs = self._compile_op(place)
 
-        if not type(output_names) is list:
+        if not isinstance(output_names, list):
             output_names = [output_names]
-
         numeric_grads = user_defined_grads or [
-            get_numeric_gradient(
-                self.scope,
-                self.op,
-                self.inputs,
+            self._numeric_gradient(
+                input_var_descs,
+                output_var_descs,
                 input_to_check,
                 output_names,
+                place,
                 delta=numeric_grad_delta,
                 in_place=in_place) for input_to_check in inputs_to_check
         ]
-        cpu_place = core.CPUPlace()
-        cpu_analytic_grads = self._get_gradient(inputs_to_check, cpu_place,
+
+        cpu_analytic_grads = self._get_gradient(inputs_to_check, place,
                                                 output_names, no_grad_set)
 
         self.__assert_is_close(numeric_grads, cpu_analytic_grads,
                                inputs_to_check, max_relative_error,
-                               "Gradient Check On %s" % str(cpu_place))
+                               "Gradient Check On %s" % str(place))
 
-        if core.is_compile_gpu() and self.op.support_gpu():
+        if core.is_compile_gpu() and core.op_support_gpu(self.op_type):
             gpu_place = core.GPUPlace(0)
             gpu_analytic_grads = self._get_gradient(inputs_to_check, gpu_place,
                                                     output_names, no_grad_set)
@@ -389,77 +529,26 @@ class OpTest(unittest.TestCase):
                                    inputs_to_check, max_relative_error,
                                    "Gradient Check On %s" % str(gpu_place))
 
-    @staticmethod
-    def _create_var_descs_(block, var_dict):
-        # FIXME: Try unify with `append_input_output`
-        for param_name in var_dict:
-            var = var_dict[param_name]
-            if not isinstance(var, list) and not isinstance(var, tuple):
-                var = [(param_name, var, None)]
-            if not isinstance(var[0], list) and not isinstance(var[0], tuple):
-                var = [(param_name, var[0], var[1])]
-
-            for i, item in enumerate(var):
-                if not isinstance(item[0], basestring):
-                    item = [[param_name] + list(item)]
-                if len(item) == 2:
-                    if isinstance(item[1], tuple):
-                        var[i] = [item[0], item[1][0], item[1][1]]
-                    else:
-                        # only set var name and value, set lod to None
-                        var[i] = list(item) + [None]
-            var_descs = [(block.create_var(
-                name=name, shape=each.shape, dtype=each.dtype), each, lod)
-                         for name, each, lod in var]
-
-            yield param_name, var_descs
-
-    @staticmethod
-    def _merge_list(iterable):
-        return reduce(lambda a, b: list(a) + list(b), iterable, [])
-
-    @staticmethod
-    def _numpy_to_lod_tensor(np_value, lod, place):
-        tensor = core.LoDTensor()
-        tensor.set(np_value, place)
-        if lod is not None:
-            tensor.set_lod(lod)
-        return tensor
-
     def _get_gradient(self, input_to_check, place, output_names, no_grad_set):
-        prog = Program()
-        block = prog.global_block()
-        inputs_with_np = {
-            key: value
-            for (key, value) in OpTest._create_var_descs_(
-                block, getattr(self, 'inputs', {}))
-        }
-        outputs_with_np = {
-            key: val
-            for (key, val) in OpTest._create_var_descs_(
-                block, getattr(self, 'outputs', {}))
-        }
-        inputs = {
-            k: [item[0] for item in inputs_with_np[k]]
-            for k in inputs_with_np
-        }
-        outputs = {
-            k: [item[0] for item in outputs_with_np[k]]
-            for k in outputs_with_np
-        }
+        """Compute analytical gradient for one input variable
 
-        op = block.append_op(
-            type=self.op_type,
-            inputs=inputs,
-            outputs=outputs,
-            attrs=getattr(self, 'attrs', {}))
+        :param input_to_check: the input variable to compute gradient. 
+        :type input_to_check: basestring.
+        :param place: Gpu or Cpu place. 
+        :type place: Place.
+        :param output_names: the output variable names. 
+        :type output_names: list.
+        :param no_grad_set: the set of variables that doesn't need to compute gradient
+        :type no_grad_set: set
+        :return: numerical gradients.
+        :rtype: numpy `array`
+        """
+        self._init_program()
+        forward_op, input_var_descs, output_var_descs = self._compile_op(place)
+        feed_map = self._feed_vars(input_var_descs, self.inputs, place)
 
-        # infer variable type and infer shape in compile-time
-        op.desc.infer_var_type(block.desc)
-        op.desc.infer_shape(block.desc)
-
+        block = self.block
         mean_inputs = map(block.var, output_names)
-
         if len(mean_inputs) == 1:
             loss = block.create_var(dtype=mean_inputs[0].dtype, shape=[1])
             op = block.append_op(
@@ -468,8 +557,11 @@ class OpTest(unittest.TestCase):
             op.desc.infer_shape(block.desc)
         else:
             avg_sum = []
+            debug_idx = 0
             for cur_loss in mean_inputs:
-                cur_avg_loss = block.create_var(dtype=cur_loss.dtype, shape=[1])
+                debug_idx += 1
+                cur_avg_loss = block.create_var(
+                    dtype=cur_loss.data_type, shape=[1])
                 op = block.append_op(
                     inputs={"X": [cur_loss]},
                     outputs={"Out": [cur_avg_loss]},
@@ -478,13 +570,13 @@ class OpTest(unittest.TestCase):
                 op.desc.infer_shape(block.desc)
                 avg_sum.append(cur_avg_loss)
 
-            loss_sum = block.create_var(dtype=avg_sum[0].dtype, shape=[1])
+            loss_sum = block.create_var(dtype=avg_sum[0].data_type, shape=[1])
             op_sum = block.append_op(
                 inputs={"X": avg_sum}, outputs={"Out": loss_sum}, type='sum')
             op_sum.desc.infer_var_type(block.desc)
             op_sum.desc.infer_shape(block.desc)
 
-            loss = block.create_var(dtype=loss_sum.dtype, shape=[1])
+            loss = block.create_var(dtype=loss_sum.data_type, shape=[1])
             op_loss = block.append_op(
                 inputs={"X": loss_sum},
                 outputs={"Out": loss},
@@ -495,14 +587,7 @@ class OpTest(unittest.TestCase):
 
         param_grad_list = append_backward_ops(
             loss=loss, parameter_list=input_to_check, no_grad_set=no_grad_set)
+        fetch_list = [g for _, g in param_grad_list]
 
-        feed_dict = {
-            item[0].name: OpTest._numpy_to_lod_tensor(item[1], item[2], place)
-            for p_name in inputs_with_np for item in inputs_with_np[p_name]
-        }
-
-        fetch_list = [g for p, g in param_grad_list]
-        executor = Executor(place)
-        return map(
-            np.array,
-            executor.run(prog, feed_dict, fetch_list, return_numpy=False))
+        result = self._execute(feed_map, fetch_list, place)
+        return map(np.array, result)

--- a/python/paddle/v2/fluid/tests/op_test.py
+++ b/python/paddle/v2/fluid/tests/op_test.py
@@ -43,7 +43,8 @@ class OpTest(unittest.TestCase):
         self.op_proto = OpProtoHolder.instance().get_op_proto(self.op_type)
         self.program = Program()
         self.block = self.program.global_block()
-        # If operator performs in place computation on a variable, in_place_map maps both input and output to the same variable .
+        # If operator performs in place computation on a variable, in_place_map 
+        # maps both input and output to the same variable .
         self.cached_var = {}
         if not hasattr(self, "in_place_map"):
             self.in_place_map = {}
@@ -63,7 +64,9 @@ class OpTest(unittest.TestCase):
         :param name: variable name. 
         :type name: basestring.
         :param feed_value: tensor value and shape that used to initialize the variable. 
-        :type feed_value: 1) numpy `array`, in which case lod_level is 0; 2) 2d tuple, where the first element is numpy `array` and the second element is a `list` specifying the lod_level.
+        :type feed_value: 1) numpy `array`, in which case lod_level is 0; 
+                          2) 2d tuple, where the first element is numpy `array` and 
+                          the second element is a `list` specifying the lod_level.
         :param dtype: data type of tensor. 
         :type dtype: basestring or one of numpy data types.
         :return: variable in current block.
@@ -184,7 +187,8 @@ class OpTest(unittest.TestCase):
 
         :param place: Gpu or Cpu place. 
         :type name: Place.
-        :return: 3d tuple (operator, input variable descriptions, output variable descriptions) 
+        :return: 3d tuple (operator, input variable descriptions, 
+                 output variable descriptions) 
         :rtype: tuple.
         """
         # compile time prepare
@@ -424,10 +428,8 @@ class OpTest(unittest.TestCase):
         tensor_size = np.prod(tensor_to_check.get_dims())
         gradient_flat = np.zeros(
             shape=(tensor_size, ), dtype=tensor_to_check_dtype)
-        # print "Joe:_num_grad:output_names", output_names
         fetch_list = self._get_fetch_list(
             output_var_descs, place, filter=output_names)
-        # output_var_descs, place, filter=output_names)
         exe = Executor(place)
 
         def __get_elem__(tensor, i):

--- a/python/paddle/v2/fluid/tests/test_batch_norm_op.py
+++ b/python/paddle/v2/fluid/tests/test_batch_norm_op.py
@@ -1,353 +1,134 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.v2.fluid.core as core
-from paddle.v2.fluid.op import Operator
 
 
-def grad_var_name(var_name):
-    return var_name + "@GRAD"
+class TestBatchNormOpNCHW(OpTest):
+    def setUp(self):
+        self.op_type = "batch_norm"
+        N, C, H, W = [np.random.randint(2, 10) for i in range(4)]
+        scale_shape = (C)
+        x_np = np.random.uniform(
+            size=(N, C, H, W), low=-1., high=1.).astype(np.float32)
+        scale_np = np.random.uniform(
+            size=scale_shape, low=-1., high=1.).astype(np.float32)
+        bias_np = np.random.uniform(
+            size=scale_shape, low=-1., high=1.).astype(np.float32)
 
-
-def get_backward_op(scope, op, no_grad_set):
-    backward_op = core.Operator.backward(op, no_grad_set)
-    for input in backward_op.input_vars():
-        var = scope.var(input)
-        var.get_tensor()
-    for output in backward_op.output_vars():
-        var = scope.var(output)
-        var.get_tensor()
-    return backward_op
-
-
-def _reference_training(x, scale, offset, epsilon, data_format):
-    x_shape = x.shape
-    if len(x_shape) == 2:
-        if data_format == "NCHW":
-            x = np.reshape(x, (x.shape[0], x.shape[1], 1, 1))
-        else:
-            x = np.reshape(x, (x.shape[0], 1, 1, x.shape[1]))
-
-    if data_format == "NCHW":
-        n, c, h, w = x.shape
-        x_square = x * x
-        x_square_sum = np.sum(x_square, (0, 2, 3))
-        x_sum = np.sum(x, axis=(0, 2, 3))
-        element_count = np.size(x) / int(np.shape(x)[1])
-        mean = x_sum / element_count
-        var = x_square_sum / element_count - mean * mean
-        mean_tile = np.reshape(mean, (1, c, 1, 1))
-        mean_tile = np.tile(mean_tile, (n, 1, h, w))
-        var_tile = np.reshape(var, (1, c, 1, 1))
-        var_tile = np.tile(var_tile, (n, 1, h, w))
-        normalized = (x - mean_tile) / np.sqrt(var_tile + epsilon)
-        scale_tile = np.reshape(scale, (1, c, 1, 1))
-        scale_tile = np.tile(scale_tile, (n, 1, h, w))
-        offset_tile = np.reshape(offset, (1, c, 1, 1))
-        offset_tile = np.reshape(offset_tile, (1, c, 1, 1))
-        y = normalized * scale_tile + offset_tile
-        if len(x_shape) == 2:
-            y = np.reshape(y, (y.shape[0], y.shape[1]))
-        return y, mean, var
-    elif data_format == "NHWC":
-        x_square = x * x
-        x_square_sum = np.sum(x_square, (0, 1, 2))
-        x_sum = np.sum(x, axis=(0, 1, 2))
-        element_count = np.size(x) / int(np.shape(x)[-1])
-        mean = x_sum / element_count
-        var = x_square_sum / element_count - mean * mean
-        normalized = (x - mean) / np.sqrt(var + epsilon)
-        y = normalized * scale + offset
-        if len(x_shape) == 2:
-            y = np.reshape(y, x_shape)
-        return y, mean, var
-    else:
-        raise ValueError("Unknown data order.")
-
-
-def _reference_grad(x, grad_y, scale, mean, var, epsilon, data_format):
-    # Use the following formulas to calculate gradients:
-    # grad_scale =
-    #   sum(grad_y * (x - mean)) * rsqrt(var + epsilon)
-    #
-    # grad_offset = sum(output_y)
-    #
-    # grad_x =
-    #   1/N * scale * rsqrt(var + epsilon) * (N * grad_y - sum(grad_y) -
-    #   (x - mean) * sum(grad_y * (x - mean)) / (var + epsilon))
-
-    # transfer from (N, C, H, W) to (N, H, W, C) to simplify computation
-    x_shape = x.shape
-
-    if len(x_shape) == 2:
-        if data_format == "NCHW":
-            x = np.reshape(x, (x.shape[0], x.shape[1], 1, 1))
-            grad_y = np.reshape(grad_y,
-                                (grad_y.shape[0], grad_y.shape[1], 1, 1))
-        else:
-            x = np.reshape(x, (x.shape[0], 1, 1, x.shape[1]))
-            grad_y = np.reshape(grad_y,
-                                (grad_y.shape[0], 1, 1, grad_y.shape[1]))
-
-    if data_format == "NCHW":
-        x = np.transpose(x, (0, 2, 3, 1))
-        grad_y = np.transpose(grad_y, (0, 2, 3, 1))
-
-        # raise ValueError("data_format must be NHWC, got %s." % data_format)
-    grad_x = scale * (grad_y - np.mean(
-        grad_y, axis=(0, 1, 2)) - (x - mean) * np.mean(
-            grad_y * (x - mean), axis=(0, 1, 2)) /
-                      (var + epsilon)) / np.sqrt(var + epsilon)
-    grad_scale = np.sum(grad_y * (x - mean) / np.sqrt(var + epsilon),
-                        axis=(0, 1, 2))
-    grad_offset = np.sum(grad_y, axis=(0, 1, 2))
-
-    # transfer back to N, C, H, W
-    if data_format == "NCHW":
-        grad_x = np.transpose(grad_x, (0, 3, 1, 2))
-        x = np.transpose(x, (0, 3, 1, 2))
-        grad_y = np.transpose(grad_y, (0, 3, 1, 2))
-
-    if len(x_shape) == 2:
-        grad_x = np.reshape(grad_x, x_shape)
-    return grad_x, grad_scale, grad_offset
-
-
-def create_or_get_tensor(scope, var_name, var, place):
-    tensor = scope.var(var_name).get_tensor()
-    if var is not None:
-        assert isinstance(var, np.ndarray)
-        tensor.set_lod([[]])
-        tensor.set_dims(var.shape)
-        tensor.set(var, place)
-    return tensor
-
-
-def set_output_grad(scope, outputs, place, feed_dict=None):
-    def __set_tensor__(name, data=None):
-        out_tensor = scope.find_var(name).get_tensor()
-        grad_tensor = scope.var(grad_var_name(name)).get_tensor()
-        out_dtype = out_tensor.dtype()
-        if data is None:
-            if out_dtype == core.DataType.FP64:
-                data = np.ones(out_tensor.shape(), dtype=np.float64)
-            elif out_dtype == core.DataType.FP32:
-                data = np.ones(out_tensor.shape(), dtype=np.float32)
-            else:
-                raise ValueError("Not supported data type " + str(out_dtype))
-        grad_tensor.set(data, place)
-
-    for output in outputs:
-        data = None
-        if output in feed_dict:
-            data = feed_dict[output]
-        __set_tensor__(output, data)
-
-
-class TestBatchNormOp(OpTest):
-    def __assert_close(self, tensor, np_array, msg, atol=1e-4):
-        self.assertTrue(np.allclose(np.array(tensor), np_array, atol=atol), msg)
-
-    def test_python(self):
-        data_format = "NHWC"
-        epsilon = 0.00001
+        mean_np = np.zeros(scale_shape).astype(np.float32)
+        variance_np = np.ones(scale_shape).astype(np.float32)
+        epsilon = 1e-5
         momentum = 0.9
 
-        # N, H, W, C: 2, 3, 4, 2
-        n, h, w, c = 2, 3, 4, 5
-        x_shape = [n, h, w, c]
-        scale_shape = [c]
+        #forward
+        batch_mean = np.mean(x_np, axis=(0, 2, 3))
+        batch_var = np.var(x_np, axis=(0, 2, 3), ddof=0)
+        batch_std = (batch_var + epsilon)**-0.5
+        x_centered = (x_np - np.reshape(
+            batch_mean, newshape=(1, C, 1, 1))) * np.reshape(
+                batch_std, newshape=(1, C, 1, 1))
+        y = x_centered * np.reshape(
+            scale_np, newshape=(1, C, 1, 1)) + np.reshape(
+                bias_np, newshape=(1, C, 1, 1))
+        running_mean = mean_np * momentum + batch_mean * (1. - momentum)
+        running_var = variance_np * momentum + batch_var * (1. - momentum)
 
-        x_val = np.random.random_sample(x_shape).astype(np.float32)
-        scale_val = np.random.random_sample(scale_shape).astype(np.float32)
-        bias_val = np.random.random_sample(scale_shape).astype(np.float32)
+        self.attrs = {
+            "is_test": False,
+            "epsilon": epsilon,
+            "momentum": momentum,
+            "tensor_format": "NCHW"
+        }
+        self.inputs = {
+            "X": x_np,
+            "Scale": scale_np,
+            "Bias": bias_np,
+            "Mean": mean_np,
+            "Variance": variance_np
+        }
+        self.outputs = {
+            "Y": y,
+            'MeanOut': running_mean,
+            "VarianceOut": running_var,
+            "SavedMean": batch_mean,
+            "SavedVariance": batch_std
+        }
+        self.in_place_map = {
+            "MeanOut": "Mean",
+            "Mean": "Mean",
+            "VarianceOut": "Variance",
+            "Variance": "Variance"
+        }
 
-        mean = np.zeros(scale_shape).astype(np.float32)
-        variance = np.ones(scale_shape).astype(np.float32)
+    def test_check_output(self):
+        self.check_output()
 
-        # run forward
-        y_out, saved_mean, var_ref = _reference_training(
-            x_val, scale_val, bias_val, epsilon, "NHWC")
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Y')
 
-        #
-        mean_out = saved_mean * (1. - momentum) + momentum * mean
-        variance_out = var_ref * (1. - momentum) + momentum * variance
-        saved_variance = 1. / np.sqrt(var_ref + epsilon)
 
-        # running N, C, H, W case
-        # should produce the same results
-        x_shape2 = [n, c, h, w]
-        x_val2 = np.transpose(x_val, (0, 3, 1, 2))
-        y_out2, saved_mean2, var_ref2 = _reference_training(
-            x_val2, scale_val, bias_val, epsilon, "NCHW")
+class TestBatchNormOpNHWC(OpTest):
+    def setUp(self):
+        self.op_type = "batch_norm"
+        N, H, W, C = [np.random.randint(2, 10) for i in range(4)]
+        scale_shape = (C)
+        x_np = np.random.uniform(
+            size=(N, H, W, C), low=-1., high=1.).astype(np.float32)
+        scale_np = np.random.uniform(
+            size=scale_shape, low=-1., high=1.).astype(np.float32)
+        bias_np = np.random.uniform(
+            size=scale_shape, low=-1., high=1.).astype(np.float32)
 
-        self.__assert_close(saved_mean, saved_mean2, "batch mean")
-        self.__assert_close(var_ref, var_ref2, "batch variance")
+        mean_np = np.zeros(scale_shape).astype(np.float32)
+        variance_np = np.ones(scale_shape).astype(np.float32)
+        epsilon = 1e-5
+        momentum = 0.9
 
-        # transfer (N, C, H, W) back to (N, H, W, C)
-        y_out2_trans = np.transpose(y_out2, (0, 2, 3, 1))
-        self.__assert_close(y_out, y_out2_trans, "batch variance")
-        print 'python: NHWC, NCHW, forward checking passed'
+        #forward
+        batch_mean = np.mean(x_np, axis=(0, 1, 2))
+        batch_var = np.var(x_np, axis=(0, 1, 2), ddof=0)
+        batch_std = (batch_var + epsilon)**-0.5
+        x_centered = (x_np - np.reshape(
+            batch_mean, newshape=(1, 1, 1, C))) * np.reshape(
+                batch_std, newshape=(1, 1, 1, C))
+        y = x_centered * np.reshape(
+            scale_np, newshape=(1, 1, 1, C)) + np.reshape(
+                bias_np, newshape=(1, 1, 1, C))
+        running_mean = mean_np * momentum + batch_mean * (1. - momentum)
+        running_var = variance_np * momentum + batch_var * (1. - momentum)
 
-        # test backward now
-        # NHWC
-        self.y_grad = np.random.random_sample(x_shape).astype(np.float32)
-        y_grad = self.y_grad
-        # y_grad = np.ones(x_shape).astype(np.float32)
-        x_grad_ref, scale_grad_ref, bias_grad_ref = _reference_grad(
-            x_val, y_grad, scale_val, saved_mean, var_ref, epsilon, "NHWC")
+        self.attrs = {
+            "is_test": False,
+            "epsilon": epsilon,
+            "momentum": momentum,
+            "tensor_format": "NHWC"
+        }
+        self.inputs = {
+            "X": x_np,
+            "Scale": scale_np,
+            "Bias": bias_np,
+            "Mean": mean_np,
+            "Variance": variance_np
+        }
+        self.outputs = {
+            "Y": y,
+            'MeanOut': running_mean,
+            "VarianceOut": running_var,
+            "SavedMean": batch_mean,
+            "SavedVariance": batch_std
+        }
+        self.in_place_map = {
+            "MeanOut": "Mean",
+            "Mean": "Mean",
+            "VarianceOut": "Variance",
+            "Variance": "Variance"
+        }
 
-        # NCHW
-        y_grad2 = np.transpose(y_grad, (0, 3, 1, 2))
-        # y_grad2 = np.ones(x_shape2).astype(np.float32)
-        x_grad_ref2, scale_grad_ref2, bias_grad_ref2 = _reference_grad(
-            x_val2, y_grad2, scale_val, saved_mean2, var_ref2, epsilon, "NCHW")
+    def test_check_output(self):
+        self.check_output()
 
-        self.__assert_close(scale_grad_ref, scale_grad_ref2, "scale gradient")
-        self.__assert_close(bias_grad_ref, bias_grad_ref2, "bias gradient")
-
-        x_grad_transpose = np.transpose(x_grad_ref2, (0, 2, 3, 1))
-        self.__assert_close(x_grad_ref, x_grad_transpose, "x gradient")
-        print 'python: NHWC, NCHW, backward checking passed'
-
-    def test_forward_backward(self):
-        def test_with_place(place, tensor_format, shape):
-            # attr
-            epsilon = 0.00001
-            momentum = 0.9
-
-            if len(shape) == 2:
-                x_shape = shape
-                c = shape[1]
-            else:
-                # n, h, w, c = 2, 3, 4, 2
-                n, h, w, c = shape[0], shape[1], shape[2], shape[3]
-                if data_format == "NHWC":
-                    x_shape = [n, h, w, c]
-                elif data_format == "NCHW":
-                    x_shape = [n, c, h, w]
-                else:
-                    raise ValueError("Unknown data type.")
-            scale_shape = [c]
-
-            x_val = np.random.random_sample(x_shape).astype(np.float32)
-            scale_val = np.random.random_sample(scale_shape).astype(np.float32)
-            bias_val = np.random.random_sample(scale_shape).astype(np.float32)
-
-            mean = np.zeros(scale_shape).astype(np.float32)
-            variance = np.ones(scale_shape).astype(np.float32)
-
-            # run forward
-            y_out, saved_mean, var_ref = _reference_training(
-                x_val, scale_val, bias_val, epsilon, data_format)
-
-            # update moving mean and variance
-            mean_out = saved_mean * (1. - momentum) + momentum * mean
-            variance_out = var_ref * (1. - momentum) + momentum * variance
-            saved_variance = 1. / np.sqrt(var_ref + epsilon)
-
-            #  for gradient test
-            # y_grad = np.ones(x_shape).astype(np.float32)
-            y_grad = np.zeros(x_shape).astype(np.float32)
-            if len(y_grad.shape) == 2:
-                y_grad[0, 0] = 1.
-            else:
-                y_grad[0, 0, 0, 0] = 1.
-            # y_grad = np.random.random_sample(x_shape).astype(np.float32)
-            x_grad_ref, scale_grad_ref, bias_grad_ref = _reference_grad(
-                x_val, y_grad, scale_val, saved_mean, var_ref, epsilon,
-                data_format)
-
-            scope = core.Scope()
-
-            # create input
-            x_tensor = create_or_get_tensor(scope, "x_val", x_val, place)
-            scale_tensor = create_or_get_tensor(scope, "scale_val", scale_val,
-                                                place)
-            bias_tensor = create_or_get_tensor(scope, "bias_val", bias_val,
-                                               place)
-            mean_tensor = create_or_get_tensor(scope, "mean", mean, place)
-            variance_tensor = create_or_get_tensor(scope, "variance", variance,
-                                                   place)
-
-            # create output
-            y_tensor = create_or_get_tensor(scope, "y_out", None, place)
-            saved_mean_tensor = create_or_get_tensor(scope, "saved_mean", None,
-                                                     place)
-            saved_variance_tensor = create_or_get_tensor(
-                scope, "saved_variance", None, place)
-            mean_out_tensor = mean_tensor
-            variance_out_tensor = variance_tensor
-
-            batch_norm_op = Operator(
-                "batch_norm",
-                # inputs
-                X="x_val",
-                Scale="scale_val",
-                Bias="bias_val",
-                Mean="mean",
-                Variance="variance",
-                # outputs
-                Y="y_out",
-                MeanOut="mean",
-                VarianceOut="variance",
-                SavedMean="saved_mean",
-                SavedVariance="saved_variance",
-                # attrs
-                is_test=False,
-                tensor_format=tensor_format,
-                momentum=momentum,
-                epsilon=epsilon)
-
-            ctx = core.DeviceContext.create(place)
-            batch_norm_op.run(scope, ctx)
-
-            # check forward result
-            self.__assert_close(y_tensor, y_out, "y_out")
-            self.__assert_close(saved_mean_tensor, saved_mean, "saved_mean")
-            self.__assert_close(saved_variance_tensor, saved_variance,
-                                "saved_variance")
-            self.__assert_close(mean_out_tensor, mean_out, "mean_out")
-            if isinstance(place, core.GPUPlace):
-                atol = 5e-2
-            else:
-                atol = 1e-4
-            self.__assert_close(variance_out_tensor, variance_out,
-                                "variance_out", atol)
-            print "op test forward passed: ", str(place), tensor_format
-
-            # run backward
-            batch_norm_op_grad = get_backward_op(scope, batch_norm_op, set())
-            set_output_grad(
-                scope,
-                ["y_out", "mean", "variance", "saved_mean", "saved_variance"],
-                place,
-                feed_dict={"y_out": y_grad})
-            batch_norm_op_grad.run(scope, ctx)
-
-            x_grad_tensor = create_or_get_tensor(scope,
-                                                 grad_var_name("x_val"), None,
-                                                 place)
-            scale_grad_tensor = create_or_get_tensor(scope,
-                                                     grad_var_name("scale_val"),
-                                                     None, place)
-            bias_grad_tensor = create_or_get_tensor(scope,
-                                                    grad_var_name("bias_val"),
-                                                    None, place)
-
-            # check gradient output
-            self.__assert_close(x_grad_tensor, x_grad_ref, "x_grad")
-            self.__assert_close(scale_grad_tensor, scale_grad_ref, "scale_grad")
-            self.__assert_close(bias_grad_tensor, bias_grad_ref, "bias_grad")
-            print "op test backward passed: ", str(place), tensor_format
-
-        places = [core.CPUPlace()]
-        if core.is_compile_gpu() and core.op_support_gpu("batch_norm"):
-            places.append(core.GPUPlace(0))
-        for place in places:
-            for data_format in ["NCHW", "NHWC"]:
-                test_with_place(place, data_format, [2, 3, 4, 5])
-                test_with_place(place, data_format, [2, 3])
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Y')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
resolve #5842 

1. As described in issue #5842, I was trying to add a small feature to OpTest class to support convenient unit test for in-place computation operators, which is supported by the `in_place_map` attribute added in base class `OpTest`.

2. After reading the original implementation, I find several places that can be improved and start to rewrite some of the methods, which mainly to improve the following aspects:

### Unify forward/backward code
In the old implementation, forward test and backward test are implemented in completely different logics, probably due to historical reasons. They use different ways to create operators, to create variable descriptions, feed variables, and execute the program. Check the "#FIXME" comment in the old code.

In this PR, both forward and backward use similar process to do computation:
```python
#1. initialize program, global block
self._init_program()

#2. compile the operator, return input and output descriptions
op, input_var_descs, output_var_descs = self._compile_op(place)

#3. prepare input and output of the operator
feed_map = self._feed_vars(input_var_descs, self.inputs, place)
fetch_list = self._get_fetch_list(output_var_descs, place, filter=self.outputs.keys())

#4. execute
outs = self._execute(feed_map, fetch_list, place)
```

### Scope and Block
The old code uses both `block` and `scope` to manage variables. I find it quite confusing, so I completely remove `scope` related code and replace it with `block` methods. 

I'm actually a little fuzzy about the `scope` and `block` concept in PaddlePaddle, even after reading all the design docs in current repo, so **Please** help to make sure this is ok. I ran all the unit tests, it seems alright.

### New batch_norm_op unit test
Due to lack of in-place computation support, the original batch_norm_op unit test rewrites most of the logic in the `OpTest` base class. Now a simpler version is possible after the enhancement.

