### PR TITLE
[Profiling]  Update elementwise op

### DIFF
--- a/paddle/operators/elementwise_add_op.h
+++ b/paddle/operators/elementwise_add_op.h
@@ -19,11 +19,48 @@
 namespace paddle {
 namespace operators {
 
+template <typename T>
+struct AddFunctor {
+  HOSTDEVICE T operator()(T a, T b) const { return a + b; }
+};
+
 template <typename Place, typename T>
 class ElementwiseAddKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    ElementwiseCompute<EigenAddFunctor, Place, T>(ctx);
+    using Tensor = framework::Tensor;
+
+    auto* x = ctx.Input<Tensor>("X");
+    auto* y = ctx.Input<Tensor>("Y");
+    auto* z = ctx.Output<Tensor>("Out");
+    z->mutable_data<T>(ctx.GetPlace());
+    TransformFunctor<AddFunctor<T>, T, Place> functor(x, y, z, ctx,
+                                                      AddFunctor<T>());
+
+    auto x_dims = x->dims();
+    auto y_dims = y->dims();
+    PADDLE_ENFORCE_GE(x_dims.size(), y_dims.size(),
+                      "Rank of first input must >= rank of second input.");
+
+    if (x_dims == y_dims) {
+      functor.Run();
+      return;
+    }
+
+    int axis = ctx.Attr<int>("axis");
+    axis = (axis == -1 ? x_dims.size() - y_dims.size() : axis);
+    PADDLE_ENFORCE(axis >= 0 && axis < x_dims.size(),
+                   "Axis should be in range [0, x_dims)");
+
+    int pre, n, post;
+    get_mid_dims(x_dims, y_dims, axis, pre, n, post);
+    if (post == 1) {
+      functor.RunRowWise(n, pre);
+      return;
+    } else {
+      functor.RunMidWise(n, pre, post);
+      return;
+    }
   }
 };
 

--- a/paddle/operators/elementwise_add_op.h
+++ b/paddle/operators/elementwise_add_op.h
@@ -34,8 +34,8 @@ class ElementwiseAddKernel : public framework::OpKernel<T> {
     auto* y = ctx.Input<Tensor>("Y");
     auto* z = ctx.Output<Tensor>("Out");
     z->mutable_data<T>(ctx.GetPlace());
-    TransformFunctor<AddFunctor<T>, T, Place> functor(x, y, z, ctx,
-                                                      AddFunctor<T>());
+    TransformFunctor<AddFunctor<T>, T, Place> functor(
+        x, y, z, ctx.device_context(), AddFunctor<T>());
 
     auto x_dims = x->dims();
     auto y_dims = y->dims();

--- a/paddle/operators/elementwise_op_function.h
+++ b/paddle/operators/elementwise_op_function.h
@@ -60,12 +60,13 @@ inline void get_mid_dims(const framework::DDim& x_dims,
 }
 
 template <typename T, typename Place>
-struct RowwiseTransformIterator;
+class RowwiseTransformIterator;
 template <typename T, typename Place>
-struct MidWiseTransformIterator;
+class MidWiseTransformIterator;
 
 template <typename T>
-struct RowwiseTransformIterator<T, platform::CPUPlace> {
+class RowwiseTransformIterator<T, platform::CPUPlace> {
+ public:
   RowwiseTransformIterator(const T* ptr, int n) : ptr_(ptr), i_(0), n_(n) {}
 
   RowwiseTransformIterator<T, platform::CPUPlace>& operator++() {
@@ -86,13 +87,15 @@ struct RowwiseTransformIterator<T, platform::CPUPlace> {
 
   const T& operator*() { return ptr_[i_]; }
 
+ private:
   const T* ptr_;
   int i_;
   int64_t n_;
 };
 
 template <typename T>
-struct MidWiseTransformIterator<T, platform::CPUPlace> {
+class MidWiseTransformIterator<T, platform::CPUPlace> {
+ public:
   MidWiseTransformIterator(const T* ptr, int n, int post)
       : ptr_(ptr), i_(0), j_(0), n_(n), post_(post) {}
 
@@ -113,6 +116,7 @@ struct MidWiseTransformIterator<T, platform::CPUPlace> {
 
   const T& operator*() { return ptr_[i_]; }
 
+ private:
   const T* ptr_;
   int i_;
   int64_t j_;
@@ -122,7 +126,7 @@ struct MidWiseTransformIterator<T, platform::CPUPlace> {
 
 #ifdef __NVCC__
 template <typename T>
-struct RowwiseTransformIterator<T, platform::GPUPlace>
+class RowwiseTransformIterator<T, platform::GPUPlace>
     : public thrust::iterator_adaptor<
           RowwiseTransformIterator<T, platform::GPUPlace>, const T*> {
  public:
@@ -142,7 +146,7 @@ struct RowwiseTransformIterator<T, platform::GPUPlace>
 };
 
 template <typename T>
-struct MidWiseTransformIterator<T, platform::GPUPlace>
+class MidWiseTransformIterator<T, platform::GPUPlace>
     : public thrust::iterator_adaptor<
           MidWiseTransformIterator<T, platform::GPUPlace>, const T*> {
  public:
@@ -164,7 +168,8 @@ struct MidWiseTransformIterator<T, platform::GPUPlace>
 #endif
 
 template <typename Functor, typename T, typename Place>
-struct TransformFunctor {
+class TransformFunctor {
+ public:
   TransformFunctor(const framework::Tensor* x, const framework::Tensor* y,
                    framework::Tensor* z, const platform::DeviceContext& ctx,
                    Functor func)
@@ -192,6 +197,7 @@ struct TransformFunctor {
           z_, func_);
   }
 
+ private:
   const T* x_;
   const T* y_;
   T* z_;

--- a/paddle/operators/elementwise_op_function.h
+++ b/paddle/operators/elementwise_op_function.h
@@ -70,9 +70,7 @@ struct RowwiseTransformIterator<T, platform::CPUPlace> {
 
   RowwiseTransformIterator<T, platform::CPUPlace>& operator++() {
     ++i_;
-    if (i_ == n_) {
-      i_ = 0;
-    }
+    i_ %= n_;
     return *this;
   }
 
@@ -90,7 +88,7 @@ struct RowwiseTransformIterator<T, platform::CPUPlace> {
 
   const T* ptr_;
   int i_;
-  int n_;
+  int64_t n_;
 };
 
 template <typename T>
@@ -99,14 +97,7 @@ struct MidWiseTransformIterator<T, platform::CPUPlace> {
       : ptr_(ptr), i_(0), j_(0), n_(n), post_(post) {}
 
   MidWiseTransformIterator<T, platform::CPUPlace>& operator++() {
-    ++j_;
-    if (j_ == post_) {
-      j_ = 0;
-      ++i_;
-      if (i_ == n_) {
-        i_ = 0;
-      }
-    }
+    i_ = ++j_ / post_ % n_;
     return *this;
   }
 
@@ -124,8 +115,8 @@ struct MidWiseTransformIterator<T, platform::CPUPlace> {
 
   const T* ptr_;
   int i_;
-  int j_;
-  int n_;
+  int64_t j_;
+  int64_t n_;
   int post_;
 };
 


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/6166

"We found the performance of `Eigen::Tensor::broadcast` is not good if the `Tensor` is not just a scalar, because the `Eigen::Tensor::broadcast` try to implement a very general `broadcast` method. However, the most of `broadcast` operators in the neural network is `rowwise` or `colwise`. The implementation of `rowwise` or `colwise` is much simpler and faster than a general implementation.
The `Eigen::Tensor::broadcast` is mainly implmeneted by this [function](https://github.com/RLovelett/eigen/blob/master/unsupported/Eigen/CXX11/src/Tensor/TensorBroadcasting.h#L172 )." —— @reyoung 