### PR TITLE
fix bug in default GPU memory allocating policy

### DIFF
--- a/paddle/platform/gpu_info.cc
+++ b/paddle/platform/gpu_info.cc
@@ -18,8 +18,8 @@ limitations under the License. */
 
 #include "paddle/platform/enforce.h"
 
-DEFINE_double(fraction_of_gpu_memory_to_use, 0.95,
-              "Default use 95% of GPU memory for PaddlePaddle,"
+DEFINE_double(fraction_of_gpu_memory_to_use, 0.92,
+              "Default use 92% of GPU memory for PaddlePaddle,"
               "reserve the rest for page tables, etc");
 
 namespace paddle {


### PR DESCRIPTION
fix #6265 
Since we have to reserve 0.05 GPU memory, the default GPU memory allocating should be a little less than 0.95.  This PR set it to 0.92.