### PR TITLE
Remove the CUDA stream synchronization between each operator.

### DIFF
--- a/paddle/framework/operator.cc
+++ b/paddle/framework/operator.cc
@@ -426,9 +426,6 @@ void OperatorWithKernel::Run(const Scope& scope,
   }
 
   kernel_iter->second->Compute(ctx);
-
-  // throws errors if have.
-  dev_ctx.Finish();
 }
 OpKernelType OperatorWithKernel::GetKernelType(
     const ExecutionContext& ctx) const {


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/6283

At first, we add this CUDA stream synchronization in the operator developing period to detect the CUDA error of each CUDA kernel. When the framework is stable, this synchronization should be removed to speed up training.