### PR TITLE
Change the type of conv2d in Python API.

### DIFF
--- a/python/paddle/v2/fluid/layers.py
+++ b/python/paddle/v2/fluid/layers.py
@@ -764,7 +764,7 @@ def conv2d(input,
     pre_bias = helper.create_tmp_variable(dtype)
 
     helper.append_op(
-        type='conv2d',
+        type='conv2d_cudnn',
         inputs={
             'Input': input,
             'Filter': filter,


### PR DESCRIPTION
Before the cuDNN is exposed to Python API, change the type of conv2d temporarily.
