### PR TITLE
build paddle_python before build paddle_docs

### DIFF
--- a/paddle/scripts/travis/build_doc.sh
+++ b/paddle/scripts/travis/build_doc.sh
@@ -8,6 +8,7 @@ cd $TRAVIS_BUILD_DIR/build
 # Compile Documentation only.
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON
 make -j `nproc` gen_proto_py
+make -j `nproc` paddle_python
 make -j `nproc` paddle_docs paddle_docs_cn
 
 # check websites for broken links


### PR DESCRIPTION
Fix #6224 