### PR TITLE
Fix v2_API equation for img_pool and maxout format.

### DIFF
--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -2722,15 +2722,15 @@ def img_pool_layer(input,
 
     ..  math::
 
-        w = 1 + int(ceil(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
-        h = 1 + int(ceil(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y))
+        w = 1 + \frac{ceil(input\_width + 2 * padding - pool\_size)}{stride} \\\\
+        h = 1 + \frac{ceil(input\_height + 2 * padding\_y - pool\_size\_y)}{stride\_y}
 
     - ceil_mode=False:
 
     ..  math::
 
-        w = 1 + int(floor(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
-        h = 1 + int(floor(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y))
+        w = 1 + \frac{floor(input\_width + 2 * padding - pool\_size)}{stride} \\\\
+        h = 1 + \frac{floor(input\_height + 2 * padding\_y - pool\_size\_y)}{stride\_y}
 
     The example usage is:
 
@@ -2863,17 +2863,17 @@ def img_pool3d_layer(input,
 
     ..  math::
 
-        w = 1 + int(ceil(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
-        h = 1 + int(ceil(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y)) \\\\
-        d = 1 + int(ceil(input\_depth + 2 * padding\_z - pool\_size\_z) / float(stride\_z))
+        w = 1 + \frac{ceil(input\_width + 2 * padding - pool\_size)}{stride} \\\\
+        h = 1 + \frac{ceil(input\_height + 2 * padding\_y - pool\_size\_y)}{stride\_y} \\\\
+        d = 1 + \frac{ceil(input\_depth + 2 * padding\_z - pool\_size\_z)}{stride\_z}
 
     - ceil_mode=False:
 
     ..  math::
 
-        w = 1 + int(floor(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
-        h = 1 + int(floor(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y)) \\\\
-        d = 1 + int(floor(input\_depth + 2 * padding\_z - pool\_size\_z) / float(stride\_z)) \\\\
+        w = 1 + \frac{floor(input\_width + 2 * padding - pool\_size)}{stride} \\\\
+        h = 1 + \frac{floor(input\_height + 2 * padding\_y - pool\_size\_y)}{stride\_y} \\\\
+        d = 1 + \frac{floor(input\_depth + 2 * padding\_z - pool\_size\_z)}{stride\_z} \\\\
 
     The example usage is:
 
@@ -5428,13 +5428,15 @@ def maxout_layer(input, groups, num_channels=None, name=None, layer_attr=None):
         `Multi-digit Number Recognition from Street View Imagery using Deep Convolutional Neural Networks
         https://arxiv.org/pdf/1312.6082v4.pdf`_
 
+
     .. math::
-       y_{si+j} = \max_k x_{gsi + sk + j}    \\\\
-       g = groups                            \\\\
-       s = input.size / num\_channels         \\\\
-       0 \le i < num\_channels / groups       \\\\
-       0 \le j < s                           \\\\
-       0 \le k < groups                      \\\\
+       out = \max_k (in[n, k, o_c , s])   \\\\
+       out_{i * s + j} = \max_k in_{  k * o_{c} * s + i * s + j}  \\\\
+       s = \frac{input.size}{ num\_channels}       \\\\
+       o_{c} =\frac{num\_channels}{groups}         \\\\
+       0 \le i < o_{c}                             \\\\
+       0 \le j < s                                 \\\\
+       0 \le k < groups                            \\\\
 
     The simple usage is:
 

--- a/python/paddle/trainer_config_helpers/layers.py
+++ b/python/paddle/trainer_config_helpers/layers.py
@@ -2722,14 +2722,14 @@ def img_pool_layer(input,
 
     ..  math::
 
-        w = 1 + int(ceil(input\_width + 2 * padding - pool\_size) / float(stride))
+        w = 1 + int(ceil(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
         h = 1 + int(ceil(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y))
 
     - ceil_mode=False:
 
     ..  math::
 
-        w = 1 + int(floor(input\_width + 2 * padding - pool\_size) / float(stride))
+        w = 1 + int(floor(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
         h = 1 + int(floor(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y))
 
     The example usage is:
@@ -2863,17 +2863,17 @@ def img_pool3d_layer(input,
 
     ..  math::
 
-        w = 1 + int(ceil(input\_width + 2 * padding - pool\_size) / float(stride))
-        h = 1 + int(ceil(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y))
+        w = 1 + int(ceil(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
+        h = 1 + int(ceil(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y)) \\\\
         d = 1 + int(ceil(input\_depth + 2 * padding\_z - pool\_size\_z) / float(stride\_z))
 
     - ceil_mode=False:
 
     ..  math::
 
-        w = 1 + int(floor(input\_width + 2 * padding - pool\_size) / float(stride))
-        h = 1 + int(floor(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y))
-        d = 1 + int(floor(input\_depth + 2 * padding\_z - pool\_size\_z) / float(stride\_z))
+        w = 1 + int(floor(input\_width + 2 * padding - pool\_size) / float(stride)) \\\\
+        h = 1 + int(floor(input\_height + 2 * padding\_y - pool\_size\_y) / float(stride\_y)) \\\\
+        d = 1 + int(floor(input\_depth + 2 * padding\_z - pool\_size\_z) / float(stride\_z)) \\\\
 
     The example usage is:
 
@@ -5429,12 +5429,12 @@ def maxout_layer(input, groups, num_channels=None, name=None, layer_attr=None):
         https://arxiv.org/pdf/1312.6082v4.pdf`_
 
     .. math::
-       y_{si+j} = \max_k x_{gsi + sk + j}
-       g = groups
-       s = input.size / num_channels
-       0 \le i < num_channels / groups
-       0 \le j < s
-       0 \le k < groups
+       y_{si+j} = \max_k x_{gsi + sk + j}    \\\\
+       g = groups                            \\\\
+       s = input.size / num\_channels         \\\\
+       0 \le i < num\_channels / groups       \\\\
+       0 \le j < s                           \\\\
+       0 \le k < groups                      \\\\
 
     The simple usage is:
 


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/6393
Currently, the format of equation for img_pool and maxout is very messy.
[paddle.v2.layer.img_pool](http://www.paddlepaddle.org/docs/develop/documentation/en/api/v2/config/layer.html#permalink-4-image-pooling-layer)
[paddle.v2.layer.maxout](http://www.paddlepaddle.org/docs/develop/documentation/en/api/v2/config/layer.html#maxout)