### PR TITLE
add print_operators_doc in travis ci

### DIFF
--- a/paddle/scripts/travis/build_doc.sh
+++ b/paddle/scripts/travis/build_doc.sh
@@ -10,6 +10,8 @@ cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON
 make -j `nproc` gen_proto_py
 make -j `nproc` paddle_python
 make -j `nproc` paddle_docs paddle_docs_cn
+make -j `nproc` print_operators_doc
+paddle/pybind/print_operators_doc > doc/en/html/operators.json
 
 # check websites for broken links
 # It will be failed now!


### PR DESCRIPTION
fix #6395 
I put operator.json in doc/en/html, thus, you may modify the following command to use it: 
```
 operator_doc_json_string = client.containers.run(docker_image_name, 'print_operators_doc 2>/dev/null')
```
https://github.com/PaddlePaddle/PaddlePaddle.org/blob/develop/portal/portal/management/commands/update_operator_docs.py#L64 