### PR TITLE
Use ProgramDesc rather than ProgramDescBind for executor.Run

### DIFF
--- a/paddle/framework/executor.h
+++ b/paddle/framework/executor.h
@@ -35,7 +35,7 @@ class Executor {
    *  ProgramDesc
    *  Scope
    */
-  void Run(const ProgramDescBind&, Scope*, int, bool create_local_scope = true);
+  void Run(const ProgramDesc&, Scope*, int, bool create_local_scope = true);
 
  private:
   std::vector<const platform::DeviceContext*> device_contexts_;

--- a/paddle/operators/conditional_block_op.cc
+++ b/paddle/operators/conditional_block_op.cc
@@ -67,7 +67,7 @@ class ConditionalBlockOp : public ConditionalOp {
 
       auto *block = Attr<framework::BlockDescBind *>("block");
       framework::Executor exec(dev_ctx);
-      exec.Run(*block->Program(), &cur_scope, block->ID(), false);
+      exec.Run(*(block->Program()->Proto()), &cur_scope, block->ID(), false);
     }
   }
 };
@@ -119,7 +119,7 @@ class ConditionalBlockGradOp : public ConditionalOp {
 
       auto *block = Attr<framework::BlockDescBind *>("block");
       framework::Executor exec(dev_ctx);
-      exec.Run(*block->Program(), &cur_scope, block->ID(), false);
+      exec.Run(*(block->Program()->Proto()), &cur_scope, block->ID(), false);
 
       AssignLocalGradientToGlobal(dev_ctx, cur_scope, Inputs("Params"),
                                   Outputs(framework::GradVarName("Params")));

--- a/paddle/operators/recurrent_op.cc
+++ b/paddle/operators/recurrent_op.cc
@@ -267,7 +267,7 @@ class RecurrentOp : public RecurrentBase {
       }
 
       // Every inputs are linked now, execute!
-      executor.Run(*program, &cur_scope, block->ID(),
+      executor.Run(*(program->Proto()), &cur_scope, block->ID(),
                    false /*create_local_scope*/);
 
       // Copy inside::output -> outside::output
@@ -373,7 +373,7 @@ class RecurrentGradOp : public RecurrentBase {
 
       VLOG(5) << "Recurrent memory linking finished ";
       // Run step block with cur_scope
-      executor.Run(*program, &cur_scope, block->ID(),
+      executor.Run(*(program->Proto()), &cur_scope, block->ID(),
                    false /*create_local_scope*/);
 
       VLOG(5) << "executor.Run finished ";

--- a/paddle/operators/recv_op.cc
+++ b/paddle/operators/recv_op.cc
@@ -78,7 +78,7 @@ class RecvOp : public framework::OperatorBase {
     framework::ProgramDescBind program(program_desc);
     framework::Executor executor(dev_ctx);
     // Run sub graph to get optimized tensor
-    executor.Run(program, &recv_scope, 0, /*global_block*/
+    executor.Run(*(program->Proto()), &recv_scope, 0,
                  false /*create_local_scope*/);
 
     auto *out_var = recv_scope.FindVar("Out");

--- a/paddle/operators/while_op.cc
+++ b/paddle/operators/while_op.cc
@@ -56,7 +56,7 @@ class WhileOp : public framework::OperatorBase {
       auto &current_scope = scope.NewScope();
       step_scopes->push_back(&current_scope);
 
-      executor.Run(*program, &current_scope, block->ID(),
+      executor.Run(*(program->Proto()), &current_scope, block->ID(),
                    false /*create_local_scope*/);
     }
   }
@@ -155,7 +155,7 @@ class WhileGradOp : public framework::OperatorBase {
         }
       }
 
-      executor.Run(*program, *cur_scope_iter, block->ID(), false);
+      executor.Run(*(program->Proto()), *cur_scope_iter, block->ID(), false);
 
       auto &pg_names = Outputs(kParamGrads);
       auto &p_names = Inputs(kParameters);

--- a/python/paddle/v2/fluid/evaluator.py
+++ b/python/paddle/v2/fluid/evaluator.py
@@ -3,6 +3,7 @@ import numpy as np
 import layers
 from framework import Program, unique_name, Variable
 from layer_helper import LayerHelper
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 __all__ = ['Accuracy']
 
@@ -59,7 +60,9 @@ class Evaluator(object):
                 out=g_var,
                 main_program=reset_program)
 
-        executor.run(reset_program)
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            reset_program.desc.serialize_to_string())
+        executor.run(pdesc)
 
     def eval(self, executor, eval_program=None):
         """
@@ -131,4 +134,6 @@ class Accuracy(Evaluator):
         total = layers.cast(total, dtype='float32', **kwargs)
         correct = layers.cast(correct, dtype='float32', **kwargs)
         out = layers.elementwise_div(x=correct, y=total, **kwargs)
-        return np.array(executor.run(eval_program, fetch_list=[out])[0])
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            eval_program.desc.serialize_to_string())
+        return np.array(executor.run(pdesc, fetch_list=[out])[0])

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -1,6 +1,7 @@
 import numpy as np
 from . import core
 from framework import Program, default_main_program
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 __all__ = ['Executor', 'g_scope']
 
@@ -141,7 +142,9 @@ class Executor(object):
                 outputs={'Out': [fetch_var]},
                 attrs={'col': i})
 
-        self.executor.run(program.desc, scope, 0, True)
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            program.desc.serialize_to_string())
+        self.executor.run(pdesc, scope, 0, True)
         outs = [
             core.get_fetch_variable(scope, fetch_var_name, i)
             for i in xrange(len(fetch_list))

--- a/python/paddle/v2/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/v2/fluid/tests/book/test_fit_a_line.py
@@ -1,6 +1,7 @@
 import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 x = fluid.layers.data(name='x', shape=[13], dtype='float32')
 
@@ -25,14 +26,17 @@ place = fluid.CPUPlace()
 feeder = fluid.DataFeeder(place=place, feed_list=[x, y])
 exe = fluid.Executor(place)
 
-exe.run(fluid.default_startup_program())
+exe.run(
+    framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                         .desc.serialize_to_string()))
 
 PASS_NUM = 100
 for pass_id in range(PASS_NUM):
     fluid.io.save_persistables(exe, "./fit_a_line.model/")
     fluid.io.load_persistables(exe, "./fit_a_line.model/")
     for data in train_reader():
-        avg_loss_value, = exe.run(fluid.default_main_program(),
+        avg_loss_value, = exe.run(framework_pb2.ProgramDesc.FromString(
+            fluid.default_main_program().desc.serialize_to_string()),
                                   feed=feeder.feed(data),
                                   fetch_list=[avg_cost])
 

--- a/python/paddle/v2/fluid/tests/book/test_image_classification_train.py
+++ b/python/paddle/v2/fluid/tests/book/test_image_classification_train.py
@@ -4,6 +4,7 @@ import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
 import sys
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 def resnet_cifar10(input, depth=32):
@@ -114,12 +115,15 @@ train_reader = paddle.batch(
 place = fluid.CPUPlace()
 exe = fluid.Executor(place)
 feeder = fluid.DataFeeder(place=place, feed_list=[images, label])
-exe.run(fluid.default_startup_program())
+exe.run(
+    framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                         .desc.serialize_to_string()))
 
 for pass_id in range(PASS_NUM):
     accuracy.reset(exe)
     for data in train_reader():
-        loss, acc = exe.run(fluid.default_main_program(),
+        loss, acc = exe.run(framework_pb2.ProgramDesc.FromString(
+            fluid.default_main_program().desc.serialize_to_string()),
                             feed=feeder.feed(data),
                             fetch_list=[avg_cost] + accuracy.metrics)
         pass_acc = accuracy.eval(exe)

--- a/python/paddle/v2/fluid/tests/book/test_label_semantic_roles.py
+++ b/python/paddle/v2/fluid/tests/book/test_label_semantic_roles.py
@@ -4,6 +4,7 @@ import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.dataset.conll05 as conll05
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 word_dict, verb_dict, label_dict = conll05.get_dict()
 word_dict_len = len(word_dict)
@@ -168,7 +169,9 @@ def main():
         place=place)
     exe = fluid.Executor(place)
 
-    exe.run(fluid.default_startup_program())
+    exe.run(
+        framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                             .desc.serialize_to_string()))
 
     embedding_param = fluid.g_scope.find_var(embedding_name).get_tensor()
     embedding_param.set(
@@ -177,7 +180,8 @@ def main():
     batch_id = 0
     for pass_id in xrange(PASS_NUM):
         for data in train_data():
-            outs = exe.run(fluid.default_main_program(),
+            outs = exe.run(framework_pb2.ProgramDesc.FromString(
+                fluid.default_main_program().desc.serialize_to_string()),
                            feed=feeder.feed(data),
                            fetch_list=[avg_cost, precision, recall, f1_score])
             avg_cost_val = np.array(outs[0])

--- a/python/paddle/v2/fluid/tests/book/test_machine_translation.py
+++ b/python/paddle/v2/fluid/tests/book/test_machine_translation.py
@@ -5,6 +5,7 @@ import paddle.v2.fluid.core as core
 import paddle.v2.fluid.framework as framework
 import paddle.v2.fluid.layers as layers
 from paddle.v2.fluid.executor import Executor
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 dict_size = 30000
 source_dict_dim = target_dict_dim = dict_size
@@ -92,7 +93,9 @@ def main():
     place = core.CPUPlace()
     exe = Executor(place)
 
-    exe.run(framework.default_startup_program())
+    exe.run(
+        framework_pb2.ProgramDesc.FromString(framework.default_startup_program()
+                                             .desc.serialize_to_string()))
 
     batch_id = 0
     for pass_id in xrange(2):
@@ -100,7 +103,8 @@ def main():
             word_data = to_lodtensor(map(lambda x: x[0], data), place)
             trg_word = to_lodtensor(map(lambda x: x[1], data), place)
             trg_word_next = to_lodtensor(map(lambda x: x[2], data), place)
-            outs = exe.run(framework.default_main_program(),
+            outs = exe.run(framework_pb2.ProgramDesc.FromString(
+                framework.default_main_program().desc.serialize_to_string()),
                            feed={
                                'src_word_id': word_data,
                                'target_language_word': trg_word,

--- a/python/paddle/v2/fluid/tests/book/test_recognize_digits_conv.py
+++ b/python/paddle/v2/fluid/tests/book/test_recognize_digits_conv.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 images = fluid.layers.data(name='pixel', shape=[1, 28, 28], dtype='float32')
 label = fluid.layers.data(name='label', shape=[1], dtype='int64')
@@ -38,12 +39,15 @@ train_reader = paddle.batch(
 place = fluid.CPUPlace()
 exe = fluid.Executor(place)
 feeder = fluid.DataFeeder(feed_list=[images, label], place=place)
-exe.run(fluid.default_startup_program())
+exe.run(
+    framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                         .desc.serialize_to_string()))
 
 for pass_id in range(PASS_NUM):
     accuracy.reset(exe)
     for data in train_reader():
-        loss, acc = exe.run(fluid.default_main_program(),
+        loss, acc = exe.run(framework_pb2.ProgramDesc.FromString(
+            fluid.default_main_program().desc.serialize_to_string()),
                             feed=feeder.feed(data),
                             fetch_list=[avg_cost] + accuracy.metrics)
         pass_acc = accuracy.eval(exe)

--- a/python/paddle/v2/fluid/tests/book/test_recommender_system.py
+++ b/python/paddle/v2/fluid/tests/book/test_recommender_system.py
@@ -6,6 +6,7 @@ import paddle.v2.fluid.layers as layers
 import paddle.v2.fluid.nets as nets
 from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.optimizer import SGDOptimizer
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 IS_SPARSE = True
 USE_GPU = False
@@ -146,7 +147,9 @@ def main():
         place = core.CPUPlace()
 
     exe = Executor(place)
-    exe.run(framework.default_startup_program())
+    exe.run(
+        framework_pb2.ProgramDesc.FromString(framework.default_startup_program()
+                                             .desc.serialize_to_string()))
 
     train_reader = paddle.batch(
         paddle.reader.shuffle(
@@ -195,7 +198,8 @@ def main():
     PASS_NUM = 100
     for pass_id in range(PASS_NUM):
         for data in train_reader():
-            outs = exe.run(framework.default_main_program(),
+            outs = exe.run(framework_pb2.ProgramDesc.FromString(
+                framework.default_main_program().desc.serialize_to_string()),
                            feed=func_feed(feeding, data),
                            fetch_list=[cost])
             out = np.array(outs[0])

--- a/python/paddle/v2/fluid/tests/book/test_understand_sentiment_conv.py
+++ b/python/paddle/v2/fluid/tests/book/test_understand_sentiment_conv.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 def convolution_net(data, label, input_dim, class_dim=2, emb_dim=32,
@@ -67,12 +68,15 @@ def main():
     exe = fluid.Executor(place)
     feeder = fluid.DataFeeder(feed_list=[data, label], place=place)
 
-    exe.run(fluid.default_startup_program())
+    exe.run(
+        framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                             .desc.serialize_to_string()))
 
     for pass_id in xrange(PASS_NUM):
         accuracy.reset(exe)
         for data in train_data():
-            cost_val, acc_val = exe.run(fluid.default_main_program(),
+            cost_val, acc_val = exe.run(framework_pb2.ProgramDesc.FromString(
+                fluid.default_main_program().desc.serialize_to_string()),
                                         feed=feeder.feed(data),
                                         fetch_list=[cost, acc_out])
             pass_acc = accuracy.eval(exe)

--- a/python/paddle/v2/fluid/tests/book/test_understand_sentiment_dynamic_lstm.py
+++ b/python/paddle/v2/fluid/tests/book/test_understand_sentiment_dynamic_lstm.py
@@ -1,6 +1,7 @@
 import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 def stacked_lstm_net(data,
@@ -79,12 +80,15 @@ def main():
     exe = fluid.Executor(place)
     feeder = fluid.DataFeeder(feed_list=[data, label], place=place)
 
-    exe.run(fluid.default_startup_program())
+    exe.run(
+        framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                             .desc.serialize_to_string()))
 
     for pass_id in xrange(PASS_NUM):
         accuracy.reset(exe)
         for data in train_data():
-            cost_val, acc_val = exe.run(fluid.default_main_program(),
+            cost_val, acc_val = exe.run(framework_pb2.ProgramDesc.FromString(
+                fluid.default_main_program().desc.serialize_to_string()),
                                         feed=feeder.feed(data),
                                         fetch_list=[cost, acc_out])
             pass_acc = accuracy.eval(exe)

--- a/python/paddle/v2/fluid/tests/book/test_understand_sentiment_lstm.py
+++ b/python/paddle/v2/fluid/tests/book/test_understand_sentiment_lstm.py
@@ -1,6 +1,7 @@
 import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 def lstm_net(dict_dim, class_dim=2, emb_dim=32, seq_len=80, batch_size=50):
@@ -90,14 +91,17 @@ def main():
     place = fluid.CPUPlace()
     exe = fluid.Executor(place)
 
-    exe.run(fluid.default_startup_program())
+    exe.run(
+        framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                             .desc.serialize_to_string()))
 
     for pass_id in xrange(PASS_NUM):
         for data in train_data():
             chopped_data = chop_data(data)
             tensor_words, tensor_label = prepare_feed_data(chopped_data, place)
 
-            outs = exe.run(fluid.default_main_program(),
+            outs = exe.run(framework_pb2.ProgramDesc.FromString(
+                fluid.default_main_program().desc.serialize_to_string()),
                            feed={"words": tensor_words,
                                  "label": tensor_label},
                            fetch_list=[cost, acc])

--- a/python/paddle/v2/fluid/tests/book/test_word2vec.py
+++ b/python/paddle/v2/fluid/tests/book/test_word2vec.py
@@ -1,6 +1,7 @@
 import numpy as np
 import paddle.v2 as paddle
 import paddle.v2.fluid as fluid
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 PASS_NUM = 100
 EMBED_SIZE = 32
@@ -61,11 +62,14 @@ feeder = fluid.DataFeeder(
     feed_list=[first_word, second_word, third_word, forth_word, next_word],
     place=place)
 
-exe.run(fluid.default_startup_program())
+exe.run(
+    framework_pb2.ProgramDesc.FromString(fluid.default_startup_program()
+                                         .desc.serialize_to_string()))
 
 for pass_id in range(PASS_NUM):
     for data in train_reader():
-        avg_cost_np = exe.run(fluid.default_main_program(),
+        avg_cost_np = exe.run(framework_pb2.ProgramDesc.FromString(
+            fluid.default_main_program().desc.serialize_to_string()),
                               feed=feeder.feed(data),
                               fetch_list=[avg_cost])
         if avg_cost_np[0] < 5.0:

--- a/python/paddle/v2/fluid/tests/op_test.py
+++ b/python/paddle/v2/fluid/tests/op_test.py
@@ -8,6 +8,7 @@ from paddle.v2.fluid.backward import append_backward_ops
 from paddle.v2.fluid.op import Operator
 from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.framework import Program, OpProtoHolder
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 def randomize_probability(batch_size, class_num, dtype='float32'):
@@ -261,7 +262,8 @@ class OpTest(unittest.TestCase):
         feed_map = self.feed_var(inputs, place)
 
         exe = Executor(place)
-        outs = exe.run(program,
+        outs = exe.run(framework_pb2.ProgramDesc.FromString(
+            program.desc.serialize_to_string()),
                        feed=feed_map,
                        fetch_list=fetch_list,
                        return_numpy=False)
@@ -503,6 +505,9 @@ class OpTest(unittest.TestCase):
 
         fetch_list = [g for p, g in param_grad_list]
         executor = Executor(place)
-        return map(
-            np.array,
-            executor.run(prog, feed_dict, fetch_list, return_numpy=False))
+        return map(np.array,
+                   executor.run(framework_pb2.ProgramDesc.FromString(
+                       prog.desc.serialize_to_string()),
+                                feed_dict,
+                                fetch_list,
+                                return_numpy=False))

--- a/python/paddle/v2/fluid/tests/test_array_read_write_op.py
+++ b/python/paddle/v2/fluid/tests/test_array_read_write_op.py
@@ -5,6 +5,7 @@ from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.backward import append_backward_ops
 from paddle.v2.fluid.framework import default_main_program
 import numpy
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestArrayReadWrite(unittest.TestCase):

--- a/python/paddle/v2/fluid/tests/test_conditional_block.py
+++ b/python/paddle/v2/fluid/tests/test_conditional_block.py
@@ -5,6 +5,7 @@ from paddle.v2.fluid.framework import default_startup_program, default_main_prog
 from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.backward import append_backward_ops
 import numpy
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class ConditionalBlock(unittest.TestCase):
@@ -19,7 +20,9 @@ class ConditionalBlock(unittest.TestCase):
 
         cpu = core.CPUPlace()
         exe = Executor(cpu)
-        exe.run(default_startup_program())
+        pdesc = framework_pb2.ProgramDesc.FromString(default_startup_program(
+        ).desc.serialize_to_string())
+        exe.run(pdesc)
 
         x = numpy.random.random(size=(10, 1)).astype('float32')
 

--- a/python/paddle/v2/fluid/tests/test_executor_and_mul.py
+++ b/python/paddle/v2/fluid/tests/test_executor_and_mul.py
@@ -5,6 +5,7 @@ import paddle.v2.fluid.core as core
 
 from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.layers import mul, data
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestExecutor(unittest.TestCase):

--- a/python/paddle/v2/fluid/tests/test_lod_array_length_op.py
+++ b/python/paddle/v2/fluid/tests/test_lod_array_length_op.py
@@ -3,6 +3,7 @@ import paddle.v2.fluid.layers as layers
 from paddle.v2.fluid.executor import Executor
 import paddle.v2.fluid.core as core
 import numpy
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestLoDArrayLength(unittest.TestCase):

--- a/python/paddle/v2/fluid/tests/test_lod_rank_table.py
+++ b/python/paddle/v2/fluid/tests/test_lod_rank_table.py
@@ -3,6 +3,7 @@ from paddle.v2.fluid.executor import Executor
 import paddle.v2.fluid.core as core
 import numpy
 import unittest
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestLoDRankTable(unittest.TestCase):

--- a/python/paddle/v2/fluid/tests/test_lod_tensor_array_ops.py
+++ b/python/paddle/v2/fluid/tests/test_lod_tensor_array_ops.py
@@ -5,6 +5,7 @@ import paddle.v2.fluid.layers as layers
 from paddle.v2.fluid.framework import Program
 from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.backward import append_backward_ops
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestCPULoDTensorArrayOps(unittest.TestCase):
@@ -130,7 +131,10 @@ class TestCPULoDTensorArrayOps(unittest.TestCase):
         result.persistable = True
         exe = Executor(place)
         scope = core.Scope()
-        exe.run(program, feed={'x': tensor}, scope=scope)
+        exe.run(framework_pb2.ProgramDesc.FromString(
+            program.desc.serialize_to_string()),
+                feed={'x': tensor},
+                scope=scope)
         var = scope.find_var(array.name)
         array = var.get_lod_tensor_array()
         if expect_array is not None and expect_lod is not None:
@@ -183,7 +187,8 @@ class TestCPULoDTensorArrayOpGrad(unittest.TestCase):
         exe = Executor(place)
         g_out = [
             numpy.array(item).sum()
-            for item in exe.run(program,
+            for item in exe.run(framework_pb2.ProgramDesc.FromString(
+                program.desc.serialize_to_string()),
                                 feed={'x': tensor},
                                 fetch_list=[g_vars],
                                 return_numpy=False)

--- a/python/paddle/v2/fluid/tests/test_mnist_if_else_op.py
+++ b/python/paddle/v2/fluid/tests/test_mnist_if_else_op.py
@@ -6,6 +6,7 @@ import paddle.v2.fluid.core as core
 import paddle.v2 as paddle
 import unittest
 import numpy as np
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestMNISTIfElseOp(unittest.TestCase):
@@ -57,7 +58,9 @@ class TestMNISTIfElseOp(unittest.TestCase):
         place = core.CPUPlace()
         exe = Executor(place)
 
-        exe.run(kwargs['startup_program'])
+        pdesc = framework_pb2.ProgramDesc.FromString(kwargs[
+            'startup_program'].desc.serialize_to_string())
+        exe.run(pdesc)
         PASS_NUM = 100
         for pass_id in range(PASS_NUM):
             for data in train_reader():
@@ -65,7 +68,9 @@ class TestMNISTIfElseOp(unittest.TestCase):
                 y_data = np.array(map(lambda x: x[1], data)).astype("int64")
                 y_data = np.expand_dims(y_data, axis=1)
 
-                outs = exe.run(kwargs['main_program'],
+                pdesc = framework_pb2.ProgramDesc.FromString(kwargs[
+                    'main_program'].desc.serialize_to_string())
+                outs = exe.run(pdesc,
                                feed={'x': x_data,
                                      'y': y_data},
                                fetch_list=[avg_loss])
@@ -116,7 +121,9 @@ class TestMNISTIfElseOp(unittest.TestCase):
         place = core.CPUPlace()
         exe = Executor(place)
 
-        exe.run(kwargs['startup_program'])
+        pdesc = framework_pb2.ProgramDesc.FromString(kwargs[
+            'startup_program'].desc.serialize_to_string())
+        exe.run(pdesc)
         PASS_NUM = 100
         for pass_id in range(PASS_NUM):
             for data in train_reader():
@@ -124,7 +131,9 @@ class TestMNISTIfElseOp(unittest.TestCase):
                 y_data = np.array(map(lambda x: x[1], data)).astype("int64")
                 y_data = y_data.reshape((y_data.shape[0], 1))
 
-                outs = exe.run(kwargs['main_program'],
+                pdesc = framework_pb2.ProgramDesc.FromString(kwargs[
+                    'main_program'].desc.serialize_to_string())
+                outs = exe.run(pdesc,
                                feed={'x': x_data,
                                      'y': y_data},
                                fetch_list=[avg_loss])

--- a/python/paddle/v2/fluid/tests/test_parameter.py
+++ b/python/paddle/v2/fluid/tests/test_parameter.py
@@ -5,6 +5,7 @@ from paddle.v2.fluid.executor import Executor
 import paddle.v2.fluid.io as io
 from paddle.v2.fluid.initializer import ConstantInitializer
 import numpy as np
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 main_program = default_main_program()
 
@@ -25,7 +26,9 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(core.DataType.FP32, param.dtype)
         self.assertEqual(0, param.block.idx)
         exe = Executor(core.CPUPlace())
-        p = exe.run(main_program, fetch_list=[param])[0]
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            main_program.desc.serialize_to_string())
+        p = exe.run(pdesc, fetch_list=[param])[0]
         self.assertTrue(np.allclose(p, np.ones(shape) * val))
         p = io.get_parameter_value_by_name('fc.w', exe, main_program)
         self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))

--- a/python/paddle/v2/fluid/tests/test_profiler.py
+++ b/python/paddle/v2/fluid/tests/test_profiler.py
@@ -3,6 +3,7 @@ import numpy as np
 import paddle.v2.fluid as fluid
 import paddle.v2.fluid.profiler as profiler
 import paddle.v2.fluid.layers as layers
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestProfiler(unittest.TestCase):
@@ -16,12 +17,16 @@ class TestProfiler(unittest.TestCase):
 
         place = fluid.GPUPlace(0)
         exe = fluid.Executor(place)
-        exe.run(fluid.default_startup_program())
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            fluid.default_startup_program().desc.serialize_to_string())
+        exe.run(pdesc)
 
         with profiler.cuda_profiler("cuda_profiler.txt", 'csv') as nvprof:
             for i in range(epoc):
                 input = np.random.random(dshape).astype('float32')
-                exe.run(fluid.default_main_program(), feed={'data': input})
+                pdesc = framework_pb2.ProgramDesc.FromString(
+                    fluid.default_main_program().desc.serialize_to_string())
+                exe.run(pdesc, feed={'data': input})
 
 
 if __name__ == '__main__':

--- a/python/paddle/v2/fluid/tests/test_recurrent_op.py
+++ b/python/paddle/v2/fluid/tests/test_recurrent_op.py
@@ -6,6 +6,7 @@ from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.backward import append_backward_ops
 import numpy as np
 import paddle.v2.fluid.core as core
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class PyRNNBase(object):
@@ -152,9 +153,9 @@ class RecurrentOpTest1(unittest.TestCase):
             for x in self.data_field
         }
         exe = Executor(self.place)
-        out = exe.run(self.main_program,
-                      feed=self.feed_map,
-                      fetch_list=[self.output])
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            self.main_program.desc.serialize_to_string())
+        out = exe.run(pdesc, feed=self.feed_map, fetch_list=[self.output])
 
         return out[0]
 
@@ -169,7 +170,9 @@ class RecurrentOpTest1(unittest.TestCase):
         ]
 
         exe = Executor(self.place)
-        return exe.run(self.main_program,
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            self.main_program.desc.serialize_to_string())
+        return exe.run(pdesc,
                        feed=self.feed_map,
                        fetch_list=fetch_list,
                        return_numpy=False)

--- a/python/paddle/v2/fluid/tests/test_rnn_memory_helper_op.py
+++ b/python/paddle/v2/fluid/tests/test_rnn_memory_helper_op.py
@@ -5,6 +5,7 @@ from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.backward import append_backward_ops
 import numpy as np
 import paddle.v2.fluid.core as core
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class RNNMemoryHelperOpTest(unittest.TestCase):
@@ -27,9 +28,9 @@ class RNNMemoryHelperOpTest(unittest.TestCase):
         self.feed_map = {'X': x_np}
         self.fetch_list = [self.Out]
         exe = Executor(self.place)
-        out = exe.run(self.program,
-                      feed=self.feed_map,
-                      fetch_list=self.fetch_list)
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            self.program.desc.serialize_to_string())
+        out = exe.run(pdesc, feed=self.feed_map, fetch_list=self.fetch_list)
         self.assertTrue(np.allclose(out[0], x_np, rtol=1e-5))
 
 
@@ -66,9 +67,9 @@ class RNNMemoryHelperGradOpTest(unittest.TestCase):
         self.fetch_list = [self.output_vars['X@GRAD']]
 
         exe = Executor(self.place)
-        out = exe.run(self.program,
-                      feed=self.feed_map,
-                      fetch_list=self.fetch_list)
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            self.program.desc.serialize_to_string())
+        out = exe.run(pdesc, feed=self.feed_map, fetch_list=self.fetch_list)
         np.isclose(out[0], self.feed_map['Out@GRAD'], rtol=1e-5)
 
 
@@ -109,9 +110,9 @@ class RNNMemoryHelperGradOpWithoutInputTest(unittest.TestCase):
         self.fetch_list = [self.output_vars['X@GRAD']]
 
         exe = Executor(self.place)
-        out = exe.run(self.program,
-                      feed=self.feed_map,
-                      fetch_list=self.fetch_list)
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            self.program.desc.serialize_to_string())
+        out = exe.run(pdesc, feed=self.feed_map, fetch_list=self.fetch_list)
         self.assertTrue(
             np.allclose(
                 out[0], np.zeros(shape=(2, 3)).astype("float32"), rtol=1e-5))

--- a/python/paddle/v2/fluid/tests/test_shrink_rnn_memory.py
+++ b/python/paddle/v2/fluid/tests/test_shrink_rnn_memory.py
@@ -5,6 +5,7 @@ import paddle.v2.fluid.layers as layers
 from paddle.v2.fluid.backward import append_backward_ops
 from paddle.v2.fluid.framework import default_main_program
 import numpy
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 main_program = default_main_program()
 

--- a/python/paddle/v2/fluid/tests/test_split_and_merge_lod_tensor_op.py
+++ b/python/paddle/v2/fluid/tests/test_split_and_merge_lod_tensor_op.py
@@ -5,6 +5,7 @@ import paddle.v2.fluid.layers as layers
 from paddle.v2.fluid.framework import Program
 from paddle.v2.fluid.executor import Executor
 from paddle.v2.fluid.backward import append_backward_ops
+import paddle.v2.fluid.proto.framework_pb2 as framework_pb2
 
 
 class TestCPULoDTensorArrayOps(unittest.TestCase):
@@ -98,7 +99,9 @@ class TestCPULoDTensorArrayOps(unittest.TestCase):
 
         exe = Executor(place)
         scope = core.Scope()
-        exe.run(program,
+        pdesc = framework_pb2.ProgramDesc.FromString(
+            program.desc.serialize_to_string())
+        exe.run(pdesc,
                 feed={'x': tensor,
                       'y': mask},
                 scope=scope,
@@ -169,7 +172,8 @@ class TestCPUSplitMergeLoDTensorGrad(unittest.TestCase):
         g_out = [
             item.sum()
             for item in map(np.array,
-                            exe.run(program,
+                            exe.run(framework_pb2.ProgramDesc.FromString(
+                                program.desc.serialize_to_string()),
                                     feed={'x': tensor,
                                           'y': mask},
                                     fetch_list=[g_vars],


### PR DESCRIPTION
Fixes: https://github.com/PaddlePaddle/Paddle/issues/6490

ProgramDescBind is the builder for ProgramDesc, we need to pass the
real entity (ProgramDesc) between module boundaries.

This is because ProgramDescBind is an implementation detail for the module that builds ProgramDesc. For the communication between "the module that builds ProgramDesc" and "executor", we need to use ProgramDesc. In this way, when the implementation detail (ProgramDescBind) changes, the executor code does not need to change.