### PR TITLE
Add extern "C" to paddle_error_string

### DIFF
--- a/paddle/capi/error.cpp
+++ b/paddle/capi/error.cpp
@@ -14,7 +14,7 @@ limitations under the License. */
 
 #include "error.h"
 
-const char* paddle_error_string(paddle_error err) {
+extern "C" const char* paddle_error_string(paddle_error err) {
   switch (err) {
     case kPD_NULLPTR:
       return "nullptr error";

--- a/paddle/capi/error.h
+++ b/paddle/capi/error.h
@@ -29,9 +29,17 @@ typedef enum {
   kPD_UNDEFINED_ERROR = -1,
 } paddle_error;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Error string for Paddle API.
  */
 PD_API const char* paddle_error_string(paddle_error err);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Fix #6619 
capi中的paddle_error_string没有extern "C"声明，导致C中无法使用该函数