### PR TITLE
Optimize the rowwise add function.

### DIFF
--- a/paddle/operators/math/math_function.cc
+++ b/paddle/operators/math/math_function.cc
@@ -312,23 +312,12 @@ struct RowwiseAdd<platform::CPUDeviceContext, T> {
     PADDLE_ENFORCE_EQ(vector.numel(), size);
     PADDLE_ENFORCE_EQ(output->dims(), in_dims);
 
-    // auto in = framework::EigenMatrix<T>::From(input);
-    // auto vec = framework::EigenVector<T>::Flatten(vector);
-    // auto out = framework::EigenMatrix<T>::From(*output);
-    // for (int64_t i = 0; i < in_dims[0]; ++i) {
-    //   out.chip(i, 0) = in.chip(i, 0) + vec;
-    // }
+    auto in = framework::EigenMatrix<T>::From(input);
+    auto vec = framework::EigenVector<T>::Flatten(vector);
+    auto out = framework::EigenMatrix<T>::From(*output);
 
-    auto* in = input.data<T>();
-    auto* vec = vector.data<T>();
-    auto* out = output->data<T>();
-
-    int64_t h = in_dims[0];
-    int64_t w = in_dims[1];
-    for (int64_t i = 0; i < h; ++i) {
-      for (int64_t j = 0; j < w; ++j) {
-        out[i * w + j] = in[i * w + j] + vec[j];
-      }
+    for (int64_t i = 0; i < in_dims[0]; ++i) {
+      out.chip(i, 0) = in.chip(i, 0) + vec;
     }
   }
 };

--- a/paddle/operators/math/math_function_impl.h
+++ b/paddle/operators/math/math_function_impl.h
@@ -46,25 +46,6 @@ void Transpose<DeviceContext, T, Rank>::operator()(
 }
 
 template <typename DeviceContext, typename T>
-void RowwiseAdd<DeviceContext, T>::operator()(const DeviceContext& context,
-                                              const framework::Tensor& input,
-                                              const framework::Tensor& vector,
-                                              framework::Tensor* output) {
-  auto in_dims = input.dims();
-  auto size = input.numel() / in_dims[0];
-  PADDLE_ENFORCE_EQ(vector.numel(), size);
-  PADDLE_ENFORCE_EQ(output->dims(), in_dims);
-
-  auto in = framework::EigenMatrix<T>::From(input);
-  auto vec = framework::EigenMatrix<T>::From(vector);
-  auto out = framework::EigenMatrix<T>::From(*output);
-  Eigen::array<int, 2> shape({{1, static_cast<int>(size)}});
-  Eigen::array<int, 2> bcast({{static_cast<int>(in_dims[0]), 1}});
-  out.device(*context.eigen_device()) =
-      in + vec.reshape(shape).broadcast(bcast);
-}
-
-template <typename DeviceContext, typename T>
 void ColwiseSum<DeviceContext, T>::operator()(const DeviceContext& context,
                                               const framework::Tensor& input,
                                               framework::Tensor* out) {


### PR DESCRIPTION
Fix #6842 

Mainly for the broadcast in Eigen. The time changes after optimization are as follows:

- Experiments Env:
  - config: 3 stacked LSTM network, the hidden size is 64
  - 2 epoc

- Total time of 2 epoc:
  - CPU:  345.54137s -> 304.96511s .
  - GPU:  89.72162s vs 89.22058s.  This optimization does not change the execution time on GPU.