### PR TITLE
Fix bug in SetAttrDescVisitor

### DIFF
--- a/paddle/framework/op_desc.cc
+++ b/paddle/framework/op_desc.cc
@@ -261,6 +261,7 @@ struct SetAttrDescVisitor : public boost::static_visitor<void> {
   void operator()(float v) const { attr_->set_f(v); }
   void operator()(const std::string &v) const { attr_->set_s(v); }
 
+  // Please refer to https://github.com/PaddlePaddle/Paddle/issues/7162
   template <class T,
             class = typename std::enable_if<std::is_same<bool, T>::value>::type>
   void operator()(T b) const {

--- a/paddle/framework/op_desc.cc
+++ b/paddle/framework/op_desc.cc
@@ -260,7 +260,12 @@ struct SetAttrDescVisitor : public boost::static_visitor<void> {
   void operator()(int v) const { attr_->set_i(v); }
   void operator()(float v) const { attr_->set_f(v); }
   void operator()(const std::string &v) const { attr_->set_s(v); }
-  void operator()(bool b) const { attr_->set_b(b); }
+
+  template <class T,
+            class = typename std::enable_if<std::is_same<bool, T>::value>::type>
+  void operator()(T b) const {
+    attr_->set_b(b);
+  }
 
   void operator()(const std::vector<int> &v) const {
     VectorToRepeated(v, attr_->mutable_ints());
@@ -274,9 +279,7 @@ struct SetAttrDescVisitor : public boost::static_visitor<void> {
   void operator()(const std::vector<bool> &v) const {
     VectorToRepeated(v, attr_->mutable_bools());
   }
-  void operator()(proto::BlockDesc *desc) const {
-    attr_->set_block_idx(desc->idx());
-  }
+  void operator()(BlockDesc *desc) const { attr_->set_block_idx(desc->ID()); }
   void operator()(boost::blank) const { PADDLE_THROW("Unexpected branch"); }
 };
 


### PR DESCRIPTION
fix #7162 

Following is the protobuf of while operator:

Before fix:
```
  type: "while"
  attrs {
  name: "sub_block"
  type: BLOCK
  b: true
}
```


After fix:
```
  type: "while"
  attrs {
  name: "sub_block"
  type: BLOCK
  block_idx: 1
}
```