### PR TITLE
Modify inference example to run without picklingtools (Step 1)

### DIFF
--- a/paddle/inference/inference.cc
+++ b/paddle/inference/inference.cc
@@ -38,23 +38,16 @@ void InferenceEngine::LoadInferenceModel(
   LOG(INFO) << "program_desc_str's size: " << program_desc_str.size();
 // PicklingTools cannot parse the vector of strings correctly.
 #else
-  // program_desc_str
-  // the inference.model is stored by following python codes:
-  //  inference_program = fluid.io.get_inference_program(predict)
-  //  model_filename = "recognize_digits_mlp.inference.model/inference.model"
-  //  with open(model_filename, "w") as f:
-  //      program_str = inference_program.desc.serialize_to_string()
-  //          f.write(struct.pack('q', len(program_str)))
-  //          f.write(program_str)
-  std::string model_filename = dirname + "/inference.model";
+  std::string model_filename = dirname + "/__model__.dat";
   LOG(INFO) << "loading model from " << model_filename;
-  std::ifstream fs(model_filename, std::ios_base::binary);
-  int64_t size = 0;
-  fs.read(reinterpret_cast<char*>(&size), sizeof(int64_t));
-  LOG(INFO) << "program_desc_str's size: " << size;
+  std::ifstream inputfs(model_filename, std::ios::in | std::ios::binary);
   std::string program_desc_str;
-  program_desc_str.resize(size);
-  fs.read(&program_desc_str[0], size);
+  inputfs.seekg(0, std::ios::end);
+  program_desc_str.resize(inputfs.tellg());
+  inputfs.seekg(0, std::ios::beg);
+  LOG(INFO) << "program_desc_str's size: " << program_desc_str.size();
+  inputfs.read(&program_desc_str[0], program_desc_str.size());
+  inputfs.close();
 #endif
   program_ = new framework::ProgramDesc(program_desc_str);
   GenerateLoadProgram(dirname);

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -212,6 +212,11 @@ def save_inference_model(dirname,
             "fetch_var_names": fetch_var_names
         }, f, -1)
 
+    # Save only programDesc of inference_program in binary format
+    # in another file: __model__.dat
+    with open(model_file_name + ".dat", "wb") as fp:
+        fp.write(inference_program.desc.serialize_to_string())
+
     save_params(executor, dirname, main_program)
 
 


### PR DESCRIPTION
This is basically a first step towards removing pickle altogether.

In order to run @Xreki's example from PR #7097 , we need "picklingtools" which doesn't seem to be well maintained. So this PR enables us to not use picklingtools and still run the inference example on our machines.

The 2 main things are:
- We are now saving the ProgramDesc of the inference_program to a binary file (in addition to the 3 things stored by Pickling).
- The else block IFDEF code in #7097  (https://github.com/PaddlePaddle/Paddle/pull/7097/files#diff-8b842e8c9f4dd56d96360645246a94c7R40) is modified to read the binary file.

As mentioned earlier, our bigger goal is to remove pickle altogether, and @kexinzhao is working on clubbing the 3 things: programDesc of inference, feed vars, and fetch vars into a unified protobuf. (Issue #7221). So this is more like a step 1, just to avoid "picklingtools".


  