### PR TITLE
Get rid of pickle for fluid inference

### DIFF
--- a/paddle/framework/framework.proto
+++ b/paddle/framework/framework.proto
@@ -143,4 +143,8 @@ message BlockDesc {
 // Please refer to
 // https://github.com/PaddlePaddle/Paddle/blob/develop/doc/design/program.md
 // for more details.
-message ProgramDesc { repeated BlockDesc blocks = 1; }
+message ProgramDesc {
+  repeated BlockDesc blocks = 1;
+  repeated string feed_var_names = 2;
+  repeated string fetch_var_names = 3;
+}

--- a/paddle/framework/program_desc.cc
+++ b/paddle/framework/program_desc.cc
@@ -42,9 +42,6 @@ ProgramDesc::ProgramDesc() {
 
 ProgramDesc::ProgramDesc(const ProgramDesc &o) {
   desc_ = o.desc_;
-  //  feed_var_names_ = o.feed_var_names_;
-  //  fetch_var_names_ = o.fetch_var_names_;
-
   for (int i = 0; i < desc_.blocks_size(); ++i) {
     auto *block = desc_.mutable_blocks(i);
     blocks_.emplace_back(new BlockDesc(*o.blocks_[i], block, this));
@@ -53,14 +50,6 @@ ProgramDesc::ProgramDesc(const ProgramDesc &o) {
 
 ProgramDesc::ProgramDesc(const proto::ProgramDesc &desc) {
   desc_ = desc;
-  /*
-    for (int i = 0; i < desc_.feed_var_names_size(); i++) {
-      feed_var_names_.push_back(desc_.feed_var_names(i));
-    }
-    for (int i = 0; i < desc_.fetch_var_names_size(); i++) {
-      fetch_var_names_.push_back(desc_.fetch_var_names(i));
-    }
-  */
   for (auto &block_desc : *desc_.mutable_blocks()) {
     blocks_.emplace_back(new BlockDesc(this, &block_desc));
   }
@@ -69,14 +58,7 @@ ProgramDesc::ProgramDesc(const proto::ProgramDesc &desc) {
 ProgramDesc::ProgramDesc(const std::string &binary_str) {
   PADDLE_ENFORCE(desc_.ParseFromString(binary_str),
                  "Fail to parse program_desc from binary string.");
-  /*
-    for (int i = 0; i < desc_.feed_var_names_size(); i++) {
-      feed_var_names_.push_back(desc_.feed_var_names(i));
-    }
-    for (int i = 0; i < desc_.fetch_var_names_size(); i++) {
-      fetch_var_names_.push_back(desc_.fetch_var_names(i));
-    }
-  */
+
   for (auto &block_desc : *desc_.mutable_blocks()) {
     blocks_.emplace_back(new BlockDesc(this, &block_desc));
   }
@@ -85,33 +67,16 @@ ProgramDesc::ProgramDesc(const std::string &binary_str) {
 void ProgramDesc::GetFeedVarNames(std::vector<std::string> &var_names) {
   var_names.clear();
   for (int i = 0; i < desc_.feed_var_names_size(); i++) {
-    feed_var_names_.push_back(desc_.feed_var_names(i));
+    var_names.push_back(desc_.feed_var_names(i));
   }
 }
 
 void ProgramDesc::GetFetchVarNames(std::vector<std::string> &var_names) {
   var_names.clear();
   for (int i = 0; i < desc_.fetch_var_names_size(); i++) {
-    fetch_var_names_.push_back(desc_.fetch_var_names(i));
+    var_names.push_back(desc_.fetch_var_names(i));
   }
 }
 
-/*
-void ProgramDesc::ClearFeedVarNames() {
-  desc_.clear_feed_var_names();
-}
-
-void ProgramDesc::ClearFetchVarNames() {
-  desc_.clear_fetch_var_names();
-}
-
-void AppendFeedVarName(const std::string &var_name) {
-  desc_.add_feed_var_names(var_name);
-}
-
-void AppendFetchVarName(const std::string &var_name) {
-  desc_.add_fetch_var_names(var_name);
-}
-*/
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/program_desc.cc
+++ b/paddle/framework/program_desc.cc
@@ -81,6 +81,21 @@ ProgramDesc::ProgramDesc(const std::string &binary_str) {
     blocks_.emplace_back(new BlockDesc(this, &block_desc));
   }
 }
+
+void ProgramDesc::GetFeedVarNames(std::vector<std::string> &var_names) {
+  var_names.clear();
+  for (int i = 0; i < desc_.feed_var_names_size(); i++) {
+    feed_var_names_.push_back(desc_.feed_var_names(i));
+  }
+}
+
+void ProgramDesc::GetFetchVarNames(std::vector<std::string> &var_names) {
+  var_names.clear();
+  for (int i = 0; i < desc_.fetch_var_names_size(); i++) {
+    fetch_var_names_.push_back(desc_.fetch_var_names(i));
+  }
+}
+
 /*
 void ProgramDesc::ClearFeedVarNames() {
   desc_.clear_feed_var_names();

--- a/paddle/framework/program_desc.cc
+++ b/paddle/framework/program_desc.cc
@@ -42,6 +42,8 @@ ProgramDesc::ProgramDesc() {
 
 ProgramDesc::ProgramDesc(const ProgramDesc &o) {
   desc_ = o.desc_;
+  //  feed_var_names_ = o.feed_var_names_;
+  //  fetch_var_names_ = o.fetch_var_names_;
 
   for (int i = 0; i < desc_.blocks_size(); ++i) {
     auto *block = desc_.mutable_blocks(i);
@@ -51,6 +53,14 @@ ProgramDesc::ProgramDesc(const ProgramDesc &o) {
 
 ProgramDesc::ProgramDesc(const proto::ProgramDesc &desc) {
   desc_ = desc;
+  /*
+    for (int i = 0; i < desc_.feed_var_names_size(); i++) {
+      feed_var_names_.push_back(desc_.feed_var_names(i));
+    }
+    for (int i = 0; i < desc_.fetch_var_names_size(); i++) {
+      fetch_var_names_.push_back(desc_.fetch_var_names(i));
+    }
+  */
   for (auto &block_desc : *desc_.mutable_blocks()) {
     blocks_.emplace_back(new BlockDesc(this, &block_desc));
   }
@@ -59,10 +69,34 @@ ProgramDesc::ProgramDesc(const proto::ProgramDesc &desc) {
 ProgramDesc::ProgramDesc(const std::string &binary_str) {
   PADDLE_ENFORCE(desc_.ParseFromString(binary_str),
                  "Fail to parse program_desc from binary string.");
+  /*
+    for (int i = 0; i < desc_.feed_var_names_size(); i++) {
+      feed_var_names_.push_back(desc_.feed_var_names(i));
+    }
+    for (int i = 0; i < desc_.fetch_var_names_size(); i++) {
+      fetch_var_names_.push_back(desc_.fetch_var_names(i));
+    }
+  */
   for (auto &block_desc : *desc_.mutable_blocks()) {
     blocks_.emplace_back(new BlockDesc(this, &block_desc));
   }
 }
+/*
+void ProgramDesc::ClearFeedVarNames() {
+  desc_.clear_feed_var_names();
+}
 
+void ProgramDesc::ClearFetchVarNames() {
+  desc_.clear_fetch_var_names();
+}
+
+void AppendFeedVarName(const std::string &var_name) {
+  desc_.add_feed_var_names(var_name);
+}
+
+void AppendFetchVarName(const std::string &var_name) {
+  desc_.add_fetch_var_names(var_name);
+}
+*/
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/program_desc.h
+++ b/paddle/framework/program_desc.h
@@ -49,24 +49,10 @@ class ProgramDesc {
 
   void GetFetchVarNames(std::vector<std::string> &var_names);
 
-  /*
-    void ClearFeedVarNames();
-
-    void ClearFetchVarNames();
-
-    void AppendFeedVarName(const std::string &var_name);
-
-    void AppendFetchVarName(const std::string &var_name);
-  */
-
  private:
   proto::ProgramDesc desc_;
 
   std::vector<std::unique_ptr<BlockDesc>> blocks_;
-
-  //  std::vector<std::string> feed_var_names_;
-
-  //  std::vector<std::string> fetch_var_names_;
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/program_desc.h
+++ b/paddle/framework/program_desc.h
@@ -45,10 +45,24 @@ class ProgramDesc {
 
   proto::ProgramDesc *Proto();
 
+  /*
+    void ClearFeedVarNames();
+
+    void ClearFetchVarNames();
+
+    void AppendFeedVarName(const std::string &var_name);
+
+    void AppendFetchVarName(const std::string &var_name);
+  */
+
  private:
   proto::ProgramDesc desc_;
 
   std::vector<std::unique_ptr<BlockDesc>> blocks_;
+
+  //  std::vector<std::string> feed_var_names_;
+
+  //  std::vector<std::string> fetch_var_names_;
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/framework/program_desc.h
+++ b/paddle/framework/program_desc.h
@@ -45,6 +45,10 @@ class ProgramDesc {
 
   proto::ProgramDesc *Proto();
 
+  void GetFeedVarNames(std::vector<std::string> &var_names);
+
+  void GetFetchVarNames(std::vector<std::string> &var_names);
+
   /*
     void ClearFeedVarNames();
 

--- a/paddle/inference/CMakeLists.txt
+++ b/paddle/inference/CMakeLists.txt
@@ -8,27 +8,6 @@ cc_library(paddle_fluid_api
 # Merge all modules into a simgle static library
 cc_library(paddle_fluid DEPS paddle_fluid_api ${FLUID_CORE_MODULES})
 
-# ptools
-# just for testing, we may need to change the storing format for inference_model
-# and move the dependent of pickle.
-# download from http://www.picklingtools.com/
-# build in the C++ sub-directory, using command
-#     make -f Makefile.Linux libptools.so
-set(PTOOLS_LIB)
-set(PTOOLS_ROOT $ENV{PTOOLS_ROOT} CACHE PATH "Folder contains PicklingTools")
-find_path(PTOOLS_INC_DIR chooseser.h PATHS ${PTOOLS_ROOT}/C++)
-find_library(PTOOLS_SHARED_LIB NAMES ptools PATHS ${PTOOLS_ROOT}/C++)
-if(PTOOLS_INC_DIR AND PTOOLS_SHARED_LIB)
-  add_definitions(-DPADDLE_USE_PTOOLS)
-  set(PTOOLS_LIB ptools)
-  message(STATUS "Found PicklingTools: ${PTOOLS_SHARED_LIB}")
-  add_library(${PTOOLS_LIB} SHARED IMPORTED GLOBAL)
-  set_property(TARGET ${PTOOLS_LIB} PROPERTY IMPORTED_LOCATION ${PTOOLS_SHARED_LIB})
-  include_directories(${PTOOLS_ROOT}/C++)
-  include_directories(${PTOOLS_ROOT}/C++/opencontainers_1_8_5/include)
-  add_definitions(-DOC_NEW_STYLE_INCLUDES) # used in ptools
-endif()
-
 add_executable(example example.cc)
 if(APPLE)
   set(OPTIONAL_LINK_FLAGS)

--- a/paddle/inference/example.cc
+++ b/paddle/inference/example.cc
@@ -23,6 +23,7 @@ DEFINE_string(fetch_var_names, "", "Names of fetching variables");
 
 int main(int argc, char** argv) {
   google::ParseCommandLineFlags(&argc, &argv, true);
+  /*
   if (FLAGS_dirname.empty() || FLAGS_feed_var_names.empty() ||
       FLAGS_fetch_var_names.empty()) {
     // Example:
@@ -34,17 +35,23 @@ int main(int argc, char** argv) {
               << std::endl;
     exit(1);
   }
+  */
+  if (FLAGS_dirname.empty()) {
+    std::cout << "Usage: ./example --dirname=path/to/your/model" << std::endl;
+  }
 
   std::cout << "FLAGS_dirname: " << FLAGS_dirname << std::endl;
-  std::cout << "FLAGS_feed_var_names: " << FLAGS_feed_var_names << std::endl;
-  std::cout << "FLAGS_fetch_var_names: " << FLAGS_fetch_var_names << std::endl;
+  //  std::cout << "FLAGS_feed_var_names: " << FLAGS_feed_var_names <<
+  //  std::endl;
+  //  std::cout << "FLAGS_fetch_var_names: " << FLAGS_fetch_var_names <<
+  //  std::endl;
 
   std::string dirname = FLAGS_dirname;
-  std::vector<std::string> feed_var_names = {FLAGS_feed_var_names};
-  std::vector<std::string> fetch_var_names = {FLAGS_fetch_var_names};
+  //  std::vector<std::string> feed_var_names = {FLAGS_feed_var_names};
+  //  std::vector<std::string> fetch_var_names = {FLAGS_fetch_var_names};
 
   paddle::InferenceEngine* engine = new paddle::InferenceEngine();
-  engine->LoadInferenceModel(dirname, feed_var_names, fetch_var_names);
+  engine->LoadInferenceModel(dirname);
 
   paddle::framework::LoDTensor input;
   srand(time(0));

--- a/paddle/inference/example.cc
+++ b/paddle/inference/example.cc
@@ -18,37 +18,20 @@ limitations under the License. */
 #include "paddle/inference/inference.h"
 
 DEFINE_string(dirname, "", "Directory of the inference model.");
-DEFINE_string(feed_var_names, "", "Names of feeding variables");
-DEFINE_string(fetch_var_names, "", "Names of fetching variables");
 
 int main(int argc, char** argv) {
   google::ParseCommandLineFlags(&argc, &argv, true);
-  /*
-  if (FLAGS_dirname.empty() || FLAGS_feed_var_names.empty() ||
-      FLAGS_fetch_var_names.empty()) {
+
+  if (FLAGS_dirname.empty()) {
     // Example:
     //   ./example --dirname=recognize_digits_mlp.inference.model
-    //             --feed_var_names="x"
-    //             --fetch_var_names="fc_2.tmp_2"
-    std::cout << "Usage: ./example --dirname=path/to/your/model "
-                 "--feed_var_names=x --fetch_var_names=y"
-              << std::endl;
-    exit(1);
-  }
-  */
-  if (FLAGS_dirname.empty()) {
     std::cout << "Usage: ./example --dirname=path/to/your/model" << std::endl;
+    exit(1);
   }
 
   std::cout << "FLAGS_dirname: " << FLAGS_dirname << std::endl;
-  //  std::cout << "FLAGS_feed_var_names: " << FLAGS_feed_var_names <<
-  //  std::endl;
-  //  std::cout << "FLAGS_fetch_var_names: " << FLAGS_fetch_var_names <<
-  //  std::endl;
 
   std::string dirname = FLAGS_dirname;
-  //  std::vector<std::string> feed_var_names = {FLAGS_feed_var_names};
-  //  std::vector<std::string> fetch_var_names = {FLAGS_fetch_var_names};
 
   paddle::InferenceEngine* engine = new paddle::InferenceEngine();
   engine->LoadInferenceModel(dirname);

--- a/paddle/inference/inference.cc
+++ b/paddle/inference/inference.cc
@@ -25,10 +25,7 @@ limitations under the License. */
 
 namespace paddle {
 
-void InferenceEngine::LoadInferenceModel(
-    const std::string& dirname,
-    const std::vector<std::string>& feed_var_names,
-    const std::vector<std::string>& fetch_var_names) {
+void InferenceEngine::LoadInferenceModel(const std::string& dirname) {
 #ifdef PADDLE_USE_PTOOLS
   std::string model_filename = dirname + "/__model__";
   LOG(INFO) << "Using PicklingTools, loading model from " << model_filename;
@@ -49,14 +46,21 @@ void InferenceEngine::LoadInferenceModel(
   inputfs.read(&program_desc_str[0], program_desc_str.size());
   inputfs.close();
 #endif
+  LOG(INFO) << "feed size: " << feed_var_names_.size();
+  LOG(INFO) << "fetch size: " << fetch_var_names_.size();
   program_ = new framework::ProgramDesc(program_desc_str);
+  program_->GetFeedVarNames(feed_var_names_);
+  program_->GetFetchVarNames(fetch_var_names_);
+
+  LOG(INFO) << "feed size: " << feed_var_names_.size();
+  LOG(INFO) << "fetch size: " << fetch_var_names_.size();
+
   GenerateLoadProgram(dirname);
 
-  if (feed_var_names.empty() || fetch_var_names.empty()) {
-    LOG(FATAL) << "Please specify the feed_var_names and fetch_var_names.";
+  if (feed_var_names_.empty() || fetch_var_names_.empty()) {
+    LOG(FATAL) << "Please specify the feed_var_names and fetch_var_names when "
+                  "saving inference models.";
   }
-  feed_var_names_ = feed_var_names;
-  fetch_var_names_ = fetch_var_names;
   PrependFeedOp();
   AppendFetchOp();
 }

--- a/paddle/inference/inference.cc
+++ b/paddle/inference/inference.cc
@@ -26,15 +26,6 @@ limitations under the License. */
 namespace paddle {
 
 void InferenceEngine::LoadInferenceModel(const std::string& dirname) {
-#ifdef PADDLE_USE_PTOOLS
-  std::string model_filename = dirname + "/__model__";
-  LOG(INFO) << "Using PicklingTools, loading model from " << model_filename;
-  Val v;
-  LoadValFromFile(model_filename.c_str(), v, SERIALIZE_P0);
-  std::string program_desc_str = v["program_desc_str"];
-  LOG(INFO) << "program_desc_str's size: " << program_desc_str.size();
-// PicklingTools cannot parse the vector of strings correctly.
-#else
   std::string model_filename = dirname + "/__model__.dat";
   LOG(INFO) << "loading model from " << model_filename;
   std::ifstream inputfs(model_filename, std::ios::in | std::ios::binary);
@@ -45,15 +36,10 @@ void InferenceEngine::LoadInferenceModel(const std::string& dirname) {
   LOG(INFO) << "program_desc_str's size: " << program_desc_str.size();
   inputfs.read(&program_desc_str[0], program_desc_str.size());
   inputfs.close();
-#endif
-  LOG(INFO) << "feed size: " << feed_var_names_.size();
-  LOG(INFO) << "fetch size: " << fetch_var_names_.size();
+
   program_ = new framework::ProgramDesc(program_desc_str);
   program_->GetFeedVarNames(feed_var_names_);
   program_->GetFetchVarNames(fetch_var_names_);
-
-  LOG(INFO) << "feed size: " << feed_var_names_.size();
-  LOG(INFO) << "fetch size: " << fetch_var_names_.size();
 
   GenerateLoadProgram(dirname);
 

--- a/paddle/inference/inference.cc
+++ b/paddle/inference/inference.cc
@@ -26,7 +26,7 @@ limitations under the License. */
 namespace paddle {
 
 void InferenceEngine::LoadInferenceModel(const std::string& dirname) {
-  std::string model_filename = dirname + "/__model__.dat";
+  std::string model_filename = dirname + "/__model__";
   LOG(INFO) << "loading model from " << model_filename;
   std::ifstream inputfs(model_filename, std::ios::in | std::ios::binary);
   std::string program_desc_str;

--- a/paddle/inference/inference.h
+++ b/paddle/inference/inference.h
@@ -28,9 +28,7 @@ public:
     delete load_program_;
   }
 
-  void LoadInferenceModel(const std::string& dirname,
-                          const std::vector<std::string>& feed_var_names,
-                          const std::vector<std::string>& fetch_var_names);
+  void LoadInferenceModel(const std::string& dirname);
   void Execute(const std::vector<framework::LoDTensor>& feeds,
                std::vector<framework::LoDTensor>& fetchs);
 

--- a/paddle/pybind/protobuf.cc
+++ b/paddle/pybind/protobuf.cc
@@ -166,7 +166,24 @@ void BindProgramDesc(py::module &m) {
              for (auto var_name : var_names) {
                desc->add_fetch_var_names(var_name);
              }
-           });
+           })
+      .def("get_feed_var_names",
+           [](ProgramDesc &program_desc) {
+             proto::ProgramDesc *desc = program_desc.Proto();
+             std::vector<std::string> retv;
+             for (int i = 0; i < desc->feed_var_names_size(); ++i) {
+               retv.push_back(desc->feed_var_names(i));
+             }
+             return retv;
+           })
+      .def("get_fetch_var_names", [](ProgramDesc &program_desc) {
+        proto::ProgramDesc *desc = program_desc.Proto();
+        std::vector<std::string> retv;
+        for (int i = 0; i < desc->fetch_var_names_size(); ++i) {
+          retv.push_back(desc->fetch_var_names(i));
+        }
+        return retv;
+      });
 }
 
 void BindBlockDesc(py::module &m) {

--- a/paddle/pybind/protobuf.cc
+++ b/paddle/pybind/protobuf.cc
@@ -148,6 +148,24 @@ void BindProgramDesc(py::module &m) {
              PADDLE_ENFORCE(desc->ParseFromString(data),
                             "Fail to parse ProgramDesc from string. This could "
                             "be a bug of Paddle.");
+           })
+      .def("assign_feed_var_names",
+           [](ProgramDesc &program_desc,
+              const std::vector<std::string> &var_names) {
+             proto::ProgramDesc *desc = program_desc.Proto();
+             desc->clear_feed_var_names();
+             for (auto var_name : var_names) {
+               desc->add_feed_var_names(var_name);
+             }
+           })
+      .def("assign_fetch_var_names",
+           [](ProgramDesc &program_desc,
+              const std::vector<std::string> &var_names) {
+             proto::ProgramDesc *desc = program_desc.Proto();
+             desc->clear_fetch_var_names();
+             for (auto var_name : var_names) {
+               desc->add_fetch_var_names(var_name);
+             }
            });
 }
 

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -204,20 +204,20 @@ def save_inference_model(dirname,
     inference_program = pruned_program.inference_optimize()
     fetch_var_names = [v.name for v in target_vars]
 
-    model_file_name = dirname + "/__model__"
-    with open(model_file_name, "w") as f:
-        pickle.dump({
-            "program_desc_str": inference_program.desc.serialize_to_string(),
-            "feed_var_names": feeded_var_names,
-            "fetch_var_names": fetch_var_names
-        }, f, -1)
+    #model_file_name = dirname + "/__model__"
+    #with open(model_file_name, "w") as f:
+    #    pickle.dump({
+    #        "program_desc_str": inference_program.desc.serialize_to_string(),
+    #        "feed_var_names": feeded_var_names,
+    #        "fetch_var_names": fetch_var_names
+    #    }, f, -1)
 
-    # Save only programDesc of inference_program in binary format
-    # in another file: __model__.dat
+    # Save the ProgramDesc of inference_program in binary format
     inference_program.desc.assign_feed_var_names(feeded_var_names)
     inference_program.desc.assign_fetch_var_names(fetch_var_names)
-    with open(model_file_name + ".dat", "wb") as fp:
-        fp.write(inference_program.desc.serialize_to_string())
+    model_file_name = dirname + "/__model__"
+    with open(model_file_name, "wb") as f:
+        f.write(inference_program.desc.serialize_to_string())
 
     save_params(executor, dirname, main_program)
 
@@ -256,11 +256,18 @@ def load_inference_model(dirname, executor):
         raise ValueError("There is no directory named '%s'", dirname)
 
     model_file_name = dirname + "/__model__"
-    model = pickle.load(open(model_file_name, "r"))
-    program_desc_str = model["program_desc_str"]
-    feed_var_names = model["feed_var_names"]
-    fetch_var_names = model["fetch_var_names"]
+    with open(model_file_name, "rb") as f:
+        program_desc_str = f.read()
+
     program = Program.parse_from_string(program_desc_str)
+    feed_var_names = program.desc.get_feed_var_names()
+    fetch_var_names = program.desc.get_fetch_var_names()
+
+    #model = pickle.load(open(model_file_name, "r"))
+    #program_desc_str = model["program_desc_str"]
+    #feed_var_names = model["feed_var_names"]
+    #fetch_var_names = model["fetch_var_names"]
+    #program = Program.parse_from_string(program_desc_str)
     load_persistables_if_exist(executor, dirname, program)
     fetch_vars = [program.global_block().var(name) for name in fetch_var_names]
 

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -214,6 +214,8 @@ def save_inference_model(dirname,
 
     # Save only programDesc of inference_program in binary format
     # in another file: __model__.dat
+    inference_program.desc.assign_feed_var_names(feeded_var_names)
+    inference_program.desc.assign_fetch_var_names(fetch_var_names)
     with open(model_file_name + ".dat", "wb") as fp:
         fp.write(inference_program.desc.serialize_to_string())
 

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -204,17 +204,9 @@ def save_inference_model(dirname,
     inference_program = pruned_program.inference_optimize()
     fetch_var_names = [v.name for v in target_vars]
 
-    #model_file_name = dirname + "/__model__"
-    #with open(model_file_name, "w") as f:
-    #    pickle.dump({
-    #        "program_desc_str": inference_program.desc.serialize_to_string(),
-    #        "feed_var_names": feeded_var_names,
-    #        "fetch_var_names": fetch_var_names
-    #    }, f, -1)
-
-    # Save the ProgramDesc of inference_program in binary format
     inference_program.desc.assign_feed_var_names(feeded_var_names)
     inference_program.desc.assign_fetch_var_names(fetch_var_names)
+
     model_file_name = dirname + "/__model__"
     with open(model_file_name, "wb") as f:
         f.write(inference_program.desc.serialize_to_string())
@@ -263,11 +255,6 @@ def load_inference_model(dirname, executor):
     feed_var_names = program.desc.get_feed_var_names()
     fetch_var_names = program.desc.get_fetch_var_names()
 
-    #model = pickle.load(open(model_file_name, "r"))
-    #program_desc_str = model["program_desc_str"]
-    #feed_var_names = model["feed_var_names"]
-    #fetch_var_names = model["fetch_var_names"]
-    #program = Program.parse_from_string(program_desc_str)
     load_persistables_if_exist(executor, dirname, program)
     fetch_vars = [program.global_block().var(name) for name in fetch_var_names]
 


### PR DESCRIPTION
fixes #7221 

Put fetch_var_names and feed_var_names as repeated string fields in the ProgramDesc

To test this PR：

1. build paddle based on this pr
2. Use pip install -U /home/liuyiqun01/PaddlePaddle/Paddle/build_paddle/dist/opt/paddle/share/wheels/paddlepaddle_gpu-0.11.0-cp27-cp27mu-linux_x86_64.whl to install the latest Paddle and run python test_recognize_digits_mlp.py to train the model, then you will get the inference model in sub-directory recognize_digits_mlp.inference.model

After these steps, you can run the example using:
```
$ GLOG_v=3 ./paddle/inference/example --dirname=/home/liuyiqun01/PaddlePaddle/Paddle/python/paddle/v2/fluid/tests/book/recognize_digits_mlp.inference.model 
```

The output is similar to #7097 
  