### PR TITLE
Fix compiling warnings

### DIFF
--- a/paddle/operators/math/sequence_padding_test.cc
+++ b/paddle/operators/math/sequence_padding_test.cc
@@ -31,7 +31,7 @@ void TestSequencePadding(const paddle::framework::LoD& lod,
 
   cpu_seq.set_lod(lod);
   cpu_seq.mutable_data<T>(seq_dims, paddle::platform::CPUPlace());
-  for (size_t i = 0; i < cpu_seq.numel(); ++i) {
+  for (int64_t i = 0; i < cpu_seq.numel(); ++i) {
     cpu_seq.data<T>()[i] = static_cast<T>(i);
   }
 
@@ -69,7 +69,7 @@ void TestSequencePadding(const paddle::framework::LoD& lod,
 
   EXPECT_EQ(cpu_seq.numel(), cpu_seq_back.numel());
   EXPECT_EQ(cpu_seq.dims(), cpu_seq_back.dims());
-  for (size_t i = 0; i < cpu_seq.numel(); ++i) {
+  for (int64_t i = 0; i < cpu_seq.numel(); ++i) {
     EXPECT_EQ(cpu_seq.data<T>()[i], cpu_seq_back.data<T>()[i]);
   }
 


### PR DESCRIPTION
```
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc: In instantiation of ‘void TestSequencePadding(const LoD&, size_t) [with DeviceContext = paddle::platform::CPUDeviceContext; Place = paddle::platform::CPUPlace; T = float; paddle::framework::LoD = std::vector<thrust::host_vector<long unsigned int, thrust::system::cuda::experimental::pinned_allocator<long unsigned int> > >; size_t = long unsigned int]’:
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc:84:66:   required from here
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc:34:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (size_t i = 0; i < cpu_seq.numel(); ++i) {
                        ^
[ 87%] Generating paddle_fluid.dir/linear_chain_crf_op.objdir
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc:72:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (size_t i = 0; i < cpu_seq.numel(); ++i) {
                        ^
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc: In instantiation of ‘void TestSequencePadding(const LoD&, size_t) [with DeviceContext = paddle::platform::CUDADeviceContext; Place = paddle::platform::CUDAPlace; T = float; paddle::framework::LoD = std::vector<thrust::host_vector<long unsigned int, thrust::system::cuda::experimental::pinned_allocator<long unsigned int> > >; size_t = long unsigned int]’:
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc:97:67:   required from here
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc:34:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (size_t i = 0; i < cpu_seq.numel(); ++i) {
                        ^
/paddle/Paddle/paddle/operators/math/sequence_padding_test.cc:72:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (size_t i = 0; i < cpu_seq.numel(); ++i) {
                        ^
```