### PR TITLE
Fix save load inference model and remove pickle 

### DIFF
--- a/paddle/inference/inference.cc
+++ b/paddle/inference/inference.cc
@@ -19,10 +19,6 @@ limitations under the License. */
 #include "paddle/framework/init.h"
 #include "paddle/framework/scope.h"
 
-#ifdef PADDLE_USE_PTOOLS
-#include "chooseser.h"
-#endif
-
 namespace paddle {
 
 void InferenceEngine::LoadInferenceModel(const std::string& dirname) {

--- a/paddle/inference/inference.cc
+++ b/paddle/inference/inference.cc
@@ -26,7 +26,7 @@ limitations under the License. */
 namespace paddle {
 
 void InferenceEngine::LoadInferenceModel(const std::string& dirname) {
-  std::string model_filename = dirname + "/__model__.dat";
+  std::string model_filename = dirname + "/__model__";
   LOG(INFO) << "loading model from " << model_filename;
   std::ifstream inputfs(model_filename, std::ios::in | std::ios::binary);
   std::string program_desc_str;
@@ -52,39 +52,15 @@ void InferenceEngine::LoadInferenceModel(const std::string& dirname) {
   }
 }
 
-void InferenceEngine::LoadInferenceModel(
-    const std::string& dirname,
-    const std::vector<std::string>& feed_var_names,
-    const std::vector<std::string>& fetch_var_names) {
-  std::string model_filename = dirname + "/__model__.dat";
-  LOG(INFO) << "loading model from " << model_filename;
-  std::ifstream inputfs(model_filename, std::ios::in | std::ios::binary);
-  std::string program_desc_str;
-  inputfs.seekg(0, std::ios::end);
-  program_desc_str.resize(inputfs.tellg());
-  inputfs.seekg(0, std::ios::beg);
-  LOG(INFO) << "program_desc_str's size: " << program_desc_str.size();
-  inputfs.read(&program_desc_str[0], program_desc_str.size());
-  inputfs.close();
-
-  program_ = new framework::ProgramDesc(program_desc_str);
-  GenerateLoadProgram(dirname);
-
-  if (feed_var_names.empty() || fetch_var_names.empty()) {
-    LOG(FATAL) << "Please specify the feed_var_names and fetch_var_names.";
-  }
-  feed_var_names_ = feed_var_names;
-  fetch_var_names_ = fetch_var_names;
-  PrependFeedOp();
-  AppendFetchOp();
-}
-
 bool InferenceEngine::IsParameter(const framework::VarDesc* var) {
-  if (var->Persistable() && var->Name() != "feed" && var->Name() != "fetch") {
+  if (var->Persistable()) {
     // There are many unreachable variables in the program
     for (size_t i = 0; i < program_->Size(); ++i) {
       const framework::BlockDesc& block = program_->Block(i);
       for (auto* op : block.AllOps()) {
+        if (op->Type() == "feed") {
+          continue;
+        }
         for (auto input_argument_name : op->InputArgumentNames()) {
           if (input_argument_name == var->Name()) {
             return true;

--- a/paddle/inference/inference.h
+++ b/paddle/inference/inference.h
@@ -29,9 +29,6 @@ public:
   }
 
   void LoadInferenceModel(const std::string& dirname);
-  void LoadInferenceModel(const std::string& dirname,
-                          const std::vector<std::string>& feed_var_names,
-                          const std::vector<std::string>& fetch_var_names);
   void Execute(const std::vector<framework::LoDTensor>& feeds,
                std::vector<framework::LoDTensor>& fetchs);
 

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -131,7 +131,7 @@ class Executor(object):
                 feed_target_name = op.desc.output('Out')[0]
                 assert feed_target_name in feed_targets
                 cur_feed = feed_targets[feed_target_name]
-                if not instance(cur_feed, core.LoDTensor):
+                if not isinstance(cur_feed, core.LoDTensor):
                     cur_feed = self.aslodtensor(cur_feed)
                 idx = op.desc.attr('col')
                 core.set_feed_variable(scope, cur_feed, feed_holder_name, idx)
@@ -198,7 +198,8 @@ class Executor(object):
                 type=core.VarDesc.VarType.FETCH_LIST,
                 persistable=True)
 
-        if not has_feed_operators(scope, global_block, feed, feed_var_name):
+        if not self.has_feed_operators(scope, global_block, feed,
+                                       feed_var_name):
             for i, name in enumerate(feed):
                 out = global_block.var(name)
                 global_block.prepend_op(
@@ -211,7 +212,8 @@ class Executor(object):
                     cur_feed = self.aslodtensor(cur_feed)
                 core.set_feed_variable(scope, cur_feed, feed_var.name, i)
 
-        if not has_fetch_operators(global_block, fetch_list, fetch_var_name):
+        if not self.has_fetch_operators(global_block, fetch_list,
+                                        fetch_var_name):
             for i, var in enumerate(fetch_list):
                 global_block.append_op(
                     type='fetch',

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -206,7 +206,7 @@ class Executor(object):
                     outputs={'Out': [out]},
                     attrs={'col': i})
 
-        for op in block.ops:
+        for op in global_block.ops:
             if op.desc.type() == 'feed':
                 feed_target_name = op.desc.output('Out')[0]
                 cur_feed = feed[feed_target_name]

--- a/python/paddle/v2/fluid/executor.py
+++ b/python/paddle/v2/fluid/executor.py
@@ -146,7 +146,7 @@ class Executor(object):
 
         program = program.clone()
         global_block = program.global_block()
-        print global_block.vars
+
         if feed_var_name in global_block.vars:
             feed_var = global_block.var(feed_var_name)
         else:
@@ -163,43 +163,44 @@ class Executor(object):
                 type=core.VarDesc.VarType.FETCH_LIST,
                 persistable=True)
 
-        print global_block.ops
         feed_count = 0
         fetch_count = 0
         for op in global_block.ops:
             if op.desc.type() == 'feed':
-                feed_cout += 1
+                feed_count += 1
                 assert op.desc.input('X')[0] == feed_var_name
                 name = op.desc.output('Out')[0]
                 if name not in feed:
                     raise Exception("feed does not have {} variable".format(
                         name))
                 cur_feed = feed[name]
+                if not isinstance(cur_feed, core.LoDTensor):
+                    cur_feed = self.aslodtensor(cur_feed)
                 idx = op.desc.attr('col')
                 core.set_feed_variable(scope, cur_feed, feed_var.name, idx)
             elif op.desc.type() == 'fetch':
                 fetch_count += 1
                 assert op.desc.output('Out')[0] == fetch_var_name
                 name = op.desc.input('X')[0]
-                if global_block.var(name) not in fetch_list:
+                if name not in [var.desc.name() for var in fetch_list]:
                     raise Exception(
                         "fetch_list does not have {} variable".format(name))
                 idx = op.desc.attr('col')
-                assert name == fetch_list[idx].name()
+                assert name == fetch_list[idx].desc.name()
 
         if feed_count > 0 and feed_count != len(feed):
             raise Exception(
-                "Feed operators info in program desc does not match feed input")
+                "Feed operators in program desc does not match 'feed'")
 
         if fetch_count > 0 and fetch_count != len(fetch_list):
             raise Exception(
-                "Fetch operators info in program desc does not match fetch_list")
+                "Fetch operators in program desc does not match 'fetch_list'")
 
         if feed_count == 0:
             for i, name in enumerate(feed):
                 out = global_block.var(name)
                 global_block.prepend_op(
-                    'feed',
+                    type='feed',
                     inputs={'X': [feed_var]},
                     outputs={'Out': [out]},
                     attrs={'col': i})

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -12,7 +12,6 @@
 #See the License for the specific language governing permissions and
 #limitations under the License.
 import os
-import cPickle as pickle
 
 from paddle.v2.fluid.framework import Program, Parameter, default_main_program, Variable
 from . import core

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -302,7 +302,7 @@ def get_feed_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'feed':
-            feed_targets.insert(0, op.outputs['Out'][0])
+            feed_targets.insert(0, op.desc.output('Out')[0])
     return feed_targets
 
 
@@ -311,7 +311,7 @@ def get_fetch_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'fetch':
-            fetch_targets.append(op.inputs['X'][0])
+            fetch_targets.append(op.desc.input('X')[0])
     return fetch_targets
 
 

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -192,10 +192,14 @@ def get_inference_program(target_vars, main_program=None):
     return inference_program
 
 
-def prepend_feed_ops(inference_program, feeded_var_names):
+def prepend_feed_ops(inference_program,
+                     feeded_var_names,
+                     feed_holder_name='feed'):
     global_block = inference_program.global_block()
     feed_var = global_block.create_var(
-        name='feed', type=core.VarDesc.VarType.FEED_MINIBATCH, persistable=True)
+        name=feed_holder_name,
+        type=core.VarDesc.VarType.FEED_MINIBATCH,
+        persistable=True)
 
     for i, name in enumerate(feeded_var_names):
         out = global_block.var(name)
@@ -206,10 +210,14 @@ def prepend_feed_ops(inference_program, feeded_var_names):
             attrs={'col': i})
 
 
-def append_fetch_ops(inference_program, fetch_var_names):
+def append_fetch_ops(inference_program,
+                     fetch_var_names,
+                     fetch_holder_name='fetch'):
     global_block = inference_program.global_block()
     fetch_var = global_block.create_var(
-        name='fetch', type=core.VarDesc.VarType.FETCH_LIST, persistable=True)
+        name=fetch_holder_name,
+        type=core.VarDesc.VarType.FETCH_LIST,
+        persistable=True)
 
     for i, name in enumerate(fetch_var_names):
         global_block.append_op(
@@ -261,21 +269,12 @@ def save_inference_model(dirname,
     inference_program = pruned_program.inference_optimize()
     fetch_var_names = [v.name for v in target_vars]
 
-    model_file_name = dirname + "/__model__"
-    with open(model_file_name, "w") as f:
-        pickle.dump({
-            "program_desc_str": inference_program.desc.serialize_to_string(),
-            "feed_var_names": feeded_var_names,
-            "fetch_var_names": fetch_var_names
-        }, f, -1)
-
     prepend_feed_ops(inference_program, feeded_var_names)
     append_fetch_ops(inference_program, fetch_var_names)
 
-    # Save only programDesc of inference_program in binary format
-    # in another file: __model__.dat
-    with open(model_file_name + ".dat", "wb") as fp:
-        fp.write(inference_program.desc.serialize_to_string())
+    model_file_name = dirname + "/__model__"
+    with open(model_file_name, "wb") as f:
+        f.write(inference_program.desc.serialize_to_string())
 
     save_params(executor, dirname, main_program)
 
@@ -298,6 +297,24 @@ def load_persistables_if_exist(executor, dirname, main_program=None):
         predicate=_is_presistable_and_exist_)
 
 
+def get_feed_targets(program):
+    feed_targets = []
+    global_block = program.global_block()
+    for op in global_block.ops:
+        if op.desc.type() == 'feed':
+            feed_targets.insert(0, op.outputs['Out'][0])
+    return feed_targets
+
+
+def get_fetch_targets(program):
+    fetch_targets = []
+    global_block = program.global_block()
+    for op in global_block.ops:
+        if op.desc.type() == 'fetch':
+            fetch_targets.append(op.inputs['X'][0])
+    return fetch_targets
+
+
 def load_inference_model(dirname, executor):
     """
     Load inference model from a directory
@@ -314,12 +331,15 @@ def load_inference_model(dirname, executor):
         raise ValueError("There is no directory named '%s'", dirname)
 
     model_file_name = dirname + "/__model__"
-    model = pickle.load(open(model_file_name, "r"))
-    program_desc_str = model["program_desc_str"]
-    feed_var_names = model["feed_var_names"]
-    fetch_var_names = model["fetch_var_names"]
+    with open(model_file_name, "rb") as f:
+        program_desc_str = f.read()
+
     program = Program.parse_from_string(program_desc_str)
     load_persistables_if_exist(executor, dirname, program)
+
+    feed_var_names = get_feed_targets(program)
+    fetch_var_names = get_fetch_targets(program)
+
     fetch_vars = [program.global_block().var(name) for name in fetch_var_names]
 
     return [program, feed_var_names, fetch_vars]

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -302,6 +302,8 @@ def get_feed_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'feed':
+            print op.outputs
+            print op.desc.output('Out')
             feed_targets.insert(0, str(op.desc.output('Out')[0]))
     return feed_targets
 
@@ -311,6 +313,8 @@ def get_fetch_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'fetch':
+            print op.inputs
+            print op.desc.input('X')
             fetch_targets.append(str(op.desc.input('X')[0]))
     return fetch_targets
 

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -302,7 +302,7 @@ def get_feed_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'feed':
-            feed_targets.insert(0, op.desc.output('Out')[0])
+            feed_targets.insert(0, str(op.desc.output('Out')[0]))
     return feed_targets
 
 
@@ -311,7 +311,7 @@ def get_fetch_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'fetch':
-            fetch_targets.append(op.desc.input('X')[0])
+            fetch_targets.append(str(op.desc.input('X')[0]))
     return fetch_targets
 
 

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -302,9 +302,7 @@ def get_feed_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'feed':
-            print op.outputs
-            print op.desc.output('Out')
-            feed_targets.insert(0, str(op.desc.output('Out')[0]))
+            feed_targets.insert(0, op.desc.output('Out')[0])
     return feed_targets
 
 
@@ -313,9 +311,7 @@ def get_fetch_targets(program):
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'fetch':
-            print op.inputs
-            print op.desc.input('X')
-            fetch_targets.append(str(op.desc.input('X')[0]))
+            fetch_targets.append(op.desc.input('X')[0])
     return fetch_targets
 
 
@@ -343,7 +339,6 @@ def load_inference_model(dirname, executor):
 
     feed_var_names = get_feed_targets(program)
     fetch_var_names = get_fetch_targets(program)
-
     fetch_vars = [program.global_block().var(name) for name in fetch_var_names]
 
     return [program, feed_var_names, fetch_vars]

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -192,7 +192,7 @@ def get_inference_program(target_vars, main_program=None):
 
 
 def prepend_feed_ops(inference_program,
-                     feeded_var_names,
+                     feed_target_names,
                      feed_holder_name='feed'):
     global_block = inference_program.global_block()
     feed_var = global_block.create_var(
@@ -200,7 +200,7 @@ def prepend_feed_ops(inference_program,
         type=core.VarDesc.VarType.FEED_MINIBATCH,
         persistable=True)
 
-    for i, name in enumerate(feeded_var_names):
+    for i, name in enumerate(feed_target_names):
         out = global_block.var(name)
         global_block.prepend_op(
             type='feed',
@@ -210,7 +210,7 @@ def prepend_feed_ops(inference_program,
 
 
 def append_fetch_ops(inference_program,
-                     fetch_var_names,
+                     fetch_target_names,
                      fetch_holder_name='fetch'):
     global_block = inference_program.global_block()
     fetch_var = global_block.create_var(
@@ -218,7 +218,7 @@ def append_fetch_ops(inference_program,
         type=core.VarDesc.VarType.FETCH_LIST,
         persistable=True)
 
-    for i, name in enumerate(fetch_var_names):
+    for i, name in enumerate(fetch_target_names):
         global_block.append_op(
             type='fetch',
             inputs={'X': [name]},
@@ -296,22 +296,22 @@ def load_persistables_if_exist(executor, dirname, main_program=None):
         predicate=_is_presistable_and_exist_)
 
 
-def get_feed_targets(program):
-    feed_targets = []
+def get_feed_targets_names(program):
+    feed_targets_names = []
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'feed':
-            feed_targets.insert(0, op.desc.output('Out')[0])
-    return feed_targets
+            feed_targets_names.insert(0, op.desc.output('Out')[0])
+    return feed_targets_names
 
 
-def get_fetch_targets(program):
-    fetch_targets = []
+def get_fetch_targets_names(program):
+    fetch_targets_names = []
     global_block = program.global_block()
     for op in global_block.ops:
         if op.desc.type() == 'fetch':
-            fetch_targets.append(op.desc.input('X')[0])
-    return fetch_targets
+            fetch_targets_names.append(op.desc.input('X')[0])
+    return fetch_targets_names
 
 
 def load_inference_model(dirname, executor):

--- a/python/paddle/v2/fluid/io.py
+++ b/python/paddle/v2/fluid/io.py
@@ -321,10 +321,10 @@ def load_inference_model(dirname, executor):
     :param dirname: directory path
     :param executor: executor that load inference model
 
-    :return: [program, feed_var_names, fetch_var_names]
+    :return: [program, feed_target_names, fetch_targets]
              program: program especially for inference.
-             feeded_var_names: Names of variables that need to feed data
-             fetch_vars: Variables from which we can get inference results.
+             feed_target_names: Names of variables that need to feed data
+             fetch_targets: Variables from which we can get inference results.
     """
     if not os.path.isdir(dirname):
         raise ValueError("There is no directory named '%s'", dirname)
@@ -336,11 +336,13 @@ def load_inference_model(dirname, executor):
     program = Program.parse_from_string(program_desc_str)
     load_persistables_if_exist(executor, dirname, program)
 
-    feed_var_names = get_feed_targets(program)
-    fetch_var_names = get_fetch_targets(program)
-    fetch_vars = [program.global_block().var(name) for name in fetch_var_names]
+    feed_target_names = get_feed_targets_names(program)
+    fetch_target_names = get_fetch_targets_names(program)
+    fetch_targets = [
+        program.global_block().var(name) for name in fetch_target_names
+    ]
 
-    return [program, feed_var_names, fetch_vars]
+    return [program, feed_target_names, fetch_targets]
 
 
 def get_parameter_value(para, executor):

--- a/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
+++ b/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
@@ -82,9 +82,9 @@ for pass_id in range(PASS_NUM):
                                fetch_list=[avg_cost] + test_accuracy.metrics)
 
         test_pass_acc = test_accuracy.eval(exe)
-        print("pass_id=" + str(pass_id) + " train_cost=" + str(out) +
-              " train_acc=" + str(acc) + " train_pass_acc=" + str(pass_acc) +
-              " test_acc=" + str(test_pass_acc))
+        print("pass_id=" + str(pass_id) + " train_cost=" + str(
+            out) + " train_acc=" + str(acc) + " train_pass_acc=" + str(pass_acc)
+              + " test_acc=" + str(test_pass_acc))
 
         if test_pass_acc > 0.7:
             fluid.io.save_inference_model(
@@ -99,7 +99,7 @@ for pass_id in range(PASS_NUM):
             results = exe.run(infer_prog,
                               feed={feed_var_names[0]: tensor_x},
                               fetch_list=fetch_vars)
-            print results[0]
+            print(results[0])
 
             exit(0)
 

--- a/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
+++ b/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
@@ -66,7 +66,7 @@ exe = fluid.Executor(place)
 feeder = fluid.DataFeeder(feed_list=[image, label], place=place)
 exe.run(fluid.default_startup_program())
 
-PASS_NUM = 100
+PASS_NUM = 1
 for pass_id in range(PASS_NUM):
     accuracy.reset(exe)
     for data in train_reader():
@@ -90,17 +90,21 @@ for pass_id in range(PASS_NUM):
             fluid.io.save_inference_model(
                 "./recognize_digits_mlp.inference.model/", ["x"], [predict],
                 exe)
+            break
 
-            [infer_prog, feed_var_names,
-             fetch_vars] = fluid.io.load_inference_model(
-                 "./recognize_digits_mlp.inference.model/", exe)
+# Use load_inference_model to obtain the inference program desc,
+# the feed_target_names (the names of variables that will be feeded 
+# data using feed operators), and the fetch_targets (variables that 
+# we want to obtain data from using fetch operators).
+[infer_prog, feed_target_names, fetch_targets] = fluid.io.load_inference_model(
+    "./recognize_digits_mlp.inference.model/", exe)
 
-            tensor_x = np.random.rand(1, 784).astype("float32")
-            results = exe.run(infer_prog,
-                              feed={feed_var_names[0]: tensor_x},
-                              fetch_list=fetch_vars)
-            print(results[0])
+tensor_x = np.random.rand(1, 784).astype("float32")
+# Construct feed as a dictionary of {feed_target_name: feed_target_data}
+# and results will contain a list of data corresponding to fetch_targets.
+results = exe.run(infer_prog,
+                  feed={feed_target_names[0]: tensor_x},
+                  fetch_list=fetch_targets)
+print(results[0])
 
-            exit(0)
-
-exit(1)
+exit(0)

--- a/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
+++ b/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
@@ -66,7 +66,7 @@ exe = fluid.Executor(place)
 feeder = fluid.DataFeeder(feed_list=[image, label], place=place)
 exe.run(fluid.default_startup_program())
 
-PASS_NUM = 1
+PASS_NUM = 100
 for pass_id in range(PASS_NUM):
     accuracy.reset(exe)
     for data in train_reader():

--- a/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
+++ b/python/paddle/v2/fluid/tests/book/test_recognize_digits_mlp.py
@@ -82,14 +82,25 @@ for pass_id in range(PASS_NUM):
                                fetch_list=[avg_cost] + test_accuracy.metrics)
 
         test_pass_acc = test_accuracy.eval(exe)
-        print("pass_id=" + str(pass_id) + " train_cost=" + str(
-            out) + " train_acc=" + str(acc) + " train_pass_acc=" + str(pass_acc)
-              + " test_acc=" + str(test_pass_acc))
+        print("pass_id=" + str(pass_id) + " train_cost=" + str(out) +
+              " train_acc=" + str(acc) + " train_pass_acc=" + str(pass_acc) +
+              " test_acc=" + str(test_pass_acc))
 
         if test_pass_acc > 0.7:
             fluid.io.save_inference_model(
                 "./recognize_digits_mlp.inference.model/", ["x"], [predict],
                 exe)
+
+            [infer_prog, feed_var_names,
+             fetch_vars] = fluid.io.load_inference_model(
+                 "./recognize_digits_mlp.inference.model/", exe)
+
+            tensor_x = np.random.rand(1, 784).astype("float32")
+            results = exe.run(infer_prog,
+                              feed={feed_var_names[0]: tensor_x},
+                              fetch_list=fetch_vars)
+            print results[0]
+
             exit(0)
 
 exit(1)


### PR DESCRIPTION
Fix #7221 

This pr addresses comments by @Xreki on #7636.

It fixes the following issues:
1. Remove unused LoadInferenceModel() function
2. Use a better way to detect if a variable is a feed var.
3. Allow user to pass different feed/fetch var names other than the default `feed` and `fetch`
4. Remove dependency on pickle when saving / loading inference model
5. Because of the change in save/load_inference_model function, the executor.run() method in executor.py is also modified to also handle the situation where the loaded inference model has already been prepended/appended feed/fetch operator (it will throw error when the info contained in the already attached feed/fetch ops do not match the `feed` and `fetch_list` input arguments)

TODO: In the future PR, we will also create a new executor.run() function in the C++ executor class to mimic how executor.py handle ProgramDesc in this PR.
