### PR TITLE
Deepcopy ParamAttr while creating parameter.

### DIFF
--- a/python/paddle/v2/fluid/layer_helper.py
+++ b/python/paddle/v2/fluid/layer_helper.py
@@ -109,6 +109,7 @@ class LayerHelper(object):
                          is_bias=False,
                          default_initializer=None):
         # Deepcopy the attr so that parameters can be shared in program
+        attr = copy.deepcopy(attr)
         assert isinstance(attr, ParamAttr)
         suffix = 'b' if is_bias else 'w'
 


### PR DESCRIPTION
Deepcopy the attr so that parameters can be shared in program.