### PR TITLE
Fix send op data race

### DIFF
--- a/paddle/operators/detail/grpc_client.cc
+++ b/paddle/operators/detail/grpc_client.cc
@@ -102,7 +102,7 @@ bool RPCClient::Wait() {
     return true;
   }
 
-  std::vector<bool> a(req_count_);
+  bool a[req_count_];
   std::vector<std::future<void>> waits(req_count_);
 
   for (int i = 0; i < req_count_; i++) {


### PR DESCRIPTION
`std::vector<bool>` (`std::vector<int>` is fine) is not safe for concurrent write, even to different indices.
More discussion:
https://stackoverflow.com/questions/48452611/is-stdfuturewait-a-memory-barrier-i-can-not-explain-this-data-race

Fixes: https://github.com/PaddlePaddle/Paddle/issues/7878