### PR TITLE
remove libwarpctc.so in core.so and libpaddle_fluid.so

### DIFF
--- a/paddle/platform/dynload/CMakeLists.txt
+++ b/paddle/platform/dynload/CMakeLists.txt
@@ -1,4 +1,6 @@
 cc_library(dynamic_loader SRCS dynamic_loader.cc DEPS glog gflags enforce)
 nv_library(dynload_cuda SRCS cublas.cc cudnn.cc curand.cc nccl.cc
         DEPS dynamic_loader nccl)
-cc_library(dynload_warpctc SRCS warpctc.cc DEPS dynamic_loader warpctc)
+add_library(dynload_warpctc STATIC warpctc.cc)
+add_dependencies(dynload_warpctc dynamic_loader warpctc)
+target_link_libraries(dynload_warpctc dynamic_loader)


### PR DESCRIPTION
fix #7761 
related #7762, since the TeamCity's unit test of #7762 hangs, this PR test another method to remove libwarpctc.so.