### PR TITLE
Make parallel tests bind to different GPU.

### DIFF
--- a/paddle/scripts/docker/test.sh
+++ b/paddle/scripts/docker/test.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+
+# the number of process to run tests
+NUM_PROC=6
+
+# calculate and set the memory usage for each process
+MEM_USAGE=$(printf "%.2f" `echo "scale=5; 1.0 / $NUM_PROC" | bc`)
+export FLAGS_fraction_of_gpu_memory_to_use=$MEM_USAGE
+
+# get the CUDA device count
+CUDA_DEVICE_COUNT=$(nvidia-smi -L | wc -l)
+
+for (( i = 0; i < $NUM_PROC; i++ )); do
+    cuda_list=()
+    for (( j = 0; j < $CUDA_DEVICE_COUNT; j++ )); do
+        s=$[i+j]
+        n=$[s%CUDA_DEVICE_COUNT]
+        if [ $j -eq 0 ]; then
+            cuda_list=("$n")
+        else
+            cuda_list="$cuda_list,$n"
+        fi
+    done
+    echo $cuda_list
+    # CUDA_VISIBLE_DEVICES http://acceleware.com/blog/cudavisibledevices-masking-gpus
+    # ctest -I https://cmake.org/cmake/help/v3.0/manual/ctest.1.html?highlight=ctest
+    env CUDA_VISIBLE_DEVICES=$cuda_list ctest -I $i,,$NUM_PROC --output-on-failure &
+done
+wait


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/7992

- Use [CUDA_VISIBLE_DEVICES](http://acceleware.com/blog/cudavisibledevices-masking-gpus) to  change the visible  GPU order for each processor before `ctest` command.

- Use `ctest -I` to run tests in parallel,  please to refer https://cmake.org/cmake/help/v3.0/manual/ctest.1.html?highlight=ctest to learn more about `-I` option

> -I [Start,End,Stride,test#,test#|Test file], --tests-information
Run a specific number of tests by number.

> This option causes ctest to run tests starting at number Start, ending at number End, and incrementing by Stride. Any additional numbers after Stride are considered individual test numbers. Start, End,or stride can be empty. Optionally a file can be given that contains the same syntax as the command line.


But some output log is disorderly:

```
      Start 165: test_split_and_merge_lod_tensor_op
52/75 Test #206: test_is_empty_op ..................   Passed    9.42 sec
      Start 210: test_tensor
53/75 Test #211: 42/76 Test #165: test_crop_op ................................test_split_and_merge_lod_tensor_op .......   Passed     Passed   10.32 sec
  8.57 sec
      Start 215: test_cond_op
      Start 169: test_lookup_table_op
54/75 Test #215: test_cond_op ................................   Passed    3.12 sec
```