### PR TITLE
Proposing Python syntax for send and recv in design doc

### DIFF
--- a/doc/design/csp.md
+++ b/doc/design/csp.md
@@ -112,13 +112,20 @@ In Fluid, we should be able to perform the above operations on the channel objec
 Send and Receive can be performed as following on a buffered channel:
 
 ```python
+import threading
+
+def send_to_channel(channel, num_time=1):
+  for i in xrange(num_time):
+    channel.send(i)
+
 # Create a buffered channel of capacity 10
 buffer_size = 10;
 ch = fluid.make_channel(dtype=INT, buffer_size)
 
 # Now write three elements to the channel
-for i in xrange(3):
-  ch.send(i)
+thread = threading.Thread(target=send_to_channel, args=(ch, 3, ))
+thread.daemon = True
+thread.start()
 
 # Read all the data from the channel
 for i in xrange(3):
@@ -131,11 +138,19 @@ ch.close()
 The send and receive operations will be similar for unbuffered channel as well, except for the fact that there is no buffer in an unbuffered channel, so the operations are completely synchronized. For example:
 
 ```python
+import threading
+
+def send_to_channel(channel, data):
+  channel.send(data)
+
 # Create an unbuffered channel
 ch = fluid.make_channel(dtype=INT)
 
 # Writes and Reads are synchronous otherwise the calls will block.
-ch.send(10)
+thread = threading.Thread(target=send_to_channel, args=(ch, 10, ))
+thread.daemon = True
+thread.start()
+
 y = ch.recv()
 
 # Done receiving , now close the channel

--- a/doc/design/csp.md
+++ b/doc/design/csp.md
@@ -94,32 +94,33 @@ ch1  := make(chan int)
 ch2  := make(chan int, 100)
 ```
 
-To write (or perform a `Send` operation) the value of a variable `x` to channel `ch1` above, we perform the following:
+To write (or perform a `Send` operation) the value of a variable `x`, to channel `ch1` above, we perform the following:
 
 ```go
 ch1 <- x
 fmt.Println("Written to the channel")
 ```
-Now to read (or perform a `Recv` operation) the value stored in `ch2` into a variable `y` we perform the following:
+Now to read (or perform a `Recv` operation) the value stored in `ch2` into a variable `y`, we perform the following:
 
 ```go
 y <- ch2
-fmt.Println("Received on channel")
+fmt.Println("Received from channel")
 ```
 
-In Fluid, we should be able to perform the above operations on the channels as well. As of now, we support two different kinds of channels : [Buffered Channel](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/framework/details/buffered_channel.h) and [UnBuffered Channel](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/framework/details/unbuffered_channel.h)
+In Fluid, we should be able to perform the above operations on the channel objects as well. As of now, we support two different kinds of channels : [Buffered Channel](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/framework/details/buffered_channel.h) and [UnBuffered Channel](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/framework/details/unbuffered_channel.h)
 
-Send and Receive can be performed as the following on a buffered channel:
+Send and Receive can be performed as following on a buffered channel:
 
 ```python
 # Create a buffered channel of capacity 10
 buffer_size = 10;
-ch = fluid.make_channel(dtype=INT, 100)
+ch = fluid.make_channel(dtype=INT, buffer_size)
 
 # Now write three elements to the channel
 for i in xrange(3):
   ch.send(i)
 
+# Read all the data from the channel
 for i in xrange(3):
   y = ch.recv()
 
@@ -127,7 +128,7 @@ for i in xrange(3):
 ch.close()
 ```
 
-The send and receive operations will be similar for unbuffered channel as well, except for the fact that there is no buffer in the channel, so the operations are completely synchronized. For example:
+The send and receive operations will be similar for unbuffered channel as well, except for the fact that there is no buffer in an unbuffered channel, so the operations are completely synchronized. For example:
 
 ```python
 # Create an unbuffered channel

--- a/doc/design/csp.md
+++ b/doc/design/csp.md
@@ -89,8 +89,6 @@ The point here is that we need a consistent way to compose types, like in C++ we
 
 In Go, we first create a channel as explained in the section above and then perform read and write operations on top of the channels.
 
-In Go, the `select` statement lets a goroutine wait on multiple communication operations. A `select` blocks untill one of its cases can run, then it executes that case. It chooses one at random if multiple are ready.
-
 ```go
 ch1  := make(chan int)       
 ch2  := make(chan int, 100)


### PR DESCRIPTION
In addition to the PR: #7908 that covers the syntax for `Select`, this PR covers proposed Python syntax for `Send/Recv` operations.