### PR TITLE
Refine buffer channel

### DIFF
--- a/paddle/framework/channel.h
+++ b/paddle/framework/channel.h
@@ -23,8 +23,8 @@ namespace framework {
 template <typename T>
 class Channel {
  public:
-  virtual void Send(T*) = 0;
-  virtual void Receive(T*) = 0;
+  virtual bool Send(T*) = 0;
+  virtual bool Receive(T*) = 0;
   virtual size_t Cap() = 0;
   virtual void Close() = 0;
   virtual ~Channel() {}

--- a/paddle/framework/details/unbuffered_channel.h
+++ b/paddle/framework/details/unbuffered_channel.h
@@ -29,8 +29,8 @@ class UnBuffered : public paddle::framework::Channel<T> {
   friend void paddle::framework::CloseChannel<T>(Channel<T>*);
 
  public:
-  virtual void Send(T*);
-  virtual void Receive(T*);
+  virtual bool Send(T*);
+  virtual bool Receive(T*);
   virtual size_t Cap() { return 0; }
   virtual void Close();
   virtual ~UnBuffered();
@@ -57,7 +57,7 @@ class UnBuffered : public paddle::framework::Channel<T> {
 // This function implements the concept of how data should
 // be sent from a writer to a reader.
 template <typename T>
-void UnBuffered<T>::Send(T* data) {
+bool UnBuffered<T>::Send(T* data) {
   // Prevent other writers from entering
   std::unique_lock<std::recursive_mutex> writer_lock(mu_write_);
   writer_found_ = true;
@@ -66,22 +66,22 @@ void UnBuffered<T>::Send(T* data) {
   cv_writer_.wait(cv_lock,
                   [this]() { return reader_found_ == true || closed_; });
   cv_reader_.notify_one();
-  if (!closed_) {
-    std::unique_lock<std::mutex> channel_lock(mu_ch_);
-    item = data;
-    channel_lock.unlock();
-    cv_channel_.notify_one();
-    channel_lock.lock();
-    cv_channel_.wait(channel_lock,
-                     [this]() { return item == nullptr || closed_; });
-  }
+  if (closed_) return false;
+  std::unique_lock<std::mutex> channel_lock(mu_ch_);
+  item = data;
+  channel_lock.unlock();
+  cv_channel_.notify_one();
+  channel_lock.lock();
+  cv_channel_.wait(channel_lock,
+                   [this]() { return item == nullptr || closed_; });
   writer_found_ = false;
+  return true;
 }
 
 // This function implements the concept of how
 // data that was sent by a writer is read from a reader.
 template <typename T>
-void UnBuffered<T>::Receive(T* data) {
+bool UnBuffered<T>::Receive(T* data) {
   // Prevent other readers from entering
   std::unique_lock<std::recursive_mutex> read_lock{mu_read_};
   reader_found_ = true;
@@ -90,18 +90,18 @@ void UnBuffered<T>::Receive(T* data) {
   cv_reader_.wait(cv_lock,
                   [this]() { return writer_found_ == true || closed_; });
   cv_writer_.notify_one();
-  if (!closed_) {
-    std::unique_lock<std::mutex> lock_ch{mu_ch_};
-    // Reader should wait for the writer to first write its data
-    cv_channel_.wait(lock_ch, [this]() { return item != nullptr || closed_; });
-    if (!closed_) {
-      *data = std::move(*item);
-      item = nullptr;
-      lock_ch.unlock();
-    }
-    cv_channel_.notify_one();
-  }
+  if (closed_) return false;
+
+  std::unique_lock<std::mutex> lock_ch{mu_ch_};
+  // Reader should wait for the writer to first write its data
+  cv_channel_.wait(lock_ch, [this]() { return item != nullptr || closed_; });
+  if (closed_) return false;
+  *data = std::move(*item);
+  item = nullptr;
+  lock_ch.unlock();
+  cv_channel_.notify_one();
   reader_found_ = false;
+  return true;
 }
 
 // This function implements the sequence of events


### PR DESCRIPTION
- [x] Send sends only one element, we should wake up only one receiver thread by calling notify_one, instead of notify_all.
- [x] There are two possibilities for the return of `Receive` or `Send`:
    - the `Channel` was closed.
    - the `Receive` or `Send` of this `Channel` was called.
we should separate the two possibilities.