### PR TITLE
Add test case to return zero on a closed channel

### DIFF
--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -62,7 +62,7 @@ TEST(Channel, SufficientBufferSizeDoesntBlock) {
 
 // This test tests that CloseChannel returns a value of zero
 // immediately to all receivers that are trying to receive from the channel.
-TEST(Channel, ReceiverGetsZeroOnClosedChannel) {
+TEST(Channel, ReceiverGetsZeroOnClosedBufferedChannel) {
   const size_t buffer_size = 10;
   auto ch = MakeChannel<size_t>(buffer_size);
 
@@ -70,19 +70,24 @@ TEST(Channel, ReceiverGetsZeroOnClosedChannel) {
     EXPECT_EQ(ch->Send(&i), true);  // sending should not block
   }
 
+  for (size_t i = 1; i <= 5; ++i) {
+    int out;
+    EXPECT_EQ(ch->Receive(&out), true);
+    EXPECT_EQ(out, i);
+  }
   CloseChannel(ch);
 
   // Now try receiving for more number of times than buffer size
   // after channel is closed
-  int out;
-  for (size_t i = 1; i <= 12; ++i) {
+
+  for (size_t i = 6; i <= 12; ++i) {
+    int out;
     ch->Receive(&out);
     if (i <= buffer_size)
       EXPECT_EQ(out, i);  // same value as was written by senders
     else
       EXPECT_EQ(out, 0U); // 0 after all elements are emptied from a closed channel
   }
-
   delete ch;
 }
 
@@ -145,6 +150,7 @@ TEST(Channel, BufferedChannelCloseUnblocksReceiversTest) {
           int data;
           // All reads should return false
           EXPECT_EQ(ch->Receive(&data), false);
+          EXPECT_EQ(data, 0);
           *p = true;
         },
         &thread_ended[i]);
@@ -240,6 +246,7 @@ TEST(Channel, UnbufferedChannelCloseUnblocksReceiversTest) {
         [&](bool *p) {
           int data;
           EXPECT_EQ(ch->Receive(&data), false);
+          EXPECT_EQ(data, 0);
           *p = true;
         },
         &thread_ended[i]);

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -69,7 +69,7 @@ TEST(Channel, ReceiverGetsZeroOnClosedChannel) {
     // Try to write more than buffer size.
     size_t out;
     for (size_t i = 0; i < 12; ++i) {
-      ch->Receive(&out)
+      ch->Receive(&out);
       if (i < buffer_size)
         EXPECT_EQ(out, i);  // should block after 10 iterations
       else

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -70,7 +70,7 @@ TEST(Channel, ReceiverGetsZeroOnClosedBufferedChannel) {
     EXPECT_EQ(ch->Send(&i), true);  // sending should not block
   }
 
-  for (size_t i = 1; i <= 5; ++i) {
+  for (size_t i = 1; i < buffer_size/2; ++i) {
     int out;
     EXPECT_EQ(ch->Receive(&out), true);
     EXPECT_EQ(out, i);
@@ -80,7 +80,7 @@ TEST(Channel, ReceiverGetsZeroOnClosedBufferedChannel) {
   // Now try receiving for more number of times than buffer size
   // after channel is closed
 
-  for (size_t i = 6; i <= 12; ++i) {
+  for (size_t i = buffer_size/2; i <= 12; ++i) {
     int out;
     ch->Receive(&out);
     if (i <= buffer_size)

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -60,7 +60,9 @@ TEST(Channel, SufficientBufferSizeDoesntBlock) {
   delete ch;
 }
 
-TEST(Channel, SufficientBufferSizeDoesntBlock) {
+// This test tests that CloseChannel returns a value of zero
+// immediately to all receivers that are trying to receive from the channel.
+TEST(Channel, ReceiverGetsZeroOnClosedChannel) {
   const size_t buffer_size = 10;
   auto ch = MakeChannel<size_t>(buffer_size);
   std::thread t([&]() {

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -60,6 +60,30 @@ TEST(Channel, SufficientBufferSizeDoesntBlock) {
   delete ch;
 }
 
+TEST(Channel, SufficientBufferSizeDoesntBlock) {
+  const size_t buffer_size = 10;
+  auto ch = MakeChannel<size_t>(buffer_size);
+  std::thread t([&]() {
+    // Try to write more than buffer size.
+    size_t out;
+    for (size_t i = 0; i < 12; ++i) {
+      ch->Receive(&out)
+      if (i < buffer_size)
+        EXPECT_EQ(out, i);  // should block after 10 iterations
+      else
+        EXPECT_EQ(out, 0U); // after close Channel is called, expected value is 0
+    }
+  });
+
+  for (size_t i = 0; i < buffer_size; ++i) {
+    EXPECT_EQ(ch->Send(&i), true);  // sending should not block
+  }
+
+  CloseChannel(ch);
+  t.join();
+  delete ch;
+}
+
 TEST(Channel, ConcurrentSendNonConcurrentReceiveWithSufficientBufferSize) {
   const size_t buffer_size = 10;
   auto ch = MakeChannel<size_t>(buffer_size);


### PR DESCRIPTION
This test case covers the expected behavior of receiving in a closed channel as explained in the Axioms here : https://github.com/PaddlePaddle/Paddle/blob/2500f30ef210e8e55cccb5cc18ab525941e970f2/doc/design/csp.md 