### PR TITLE
Adding panic logic and test case

### DIFF
--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -16,7 +16,6 @@ limitations under the License. */
 
 #include <chrono>
 #include <thread>
-#include <stdexcept>
 
 #include "gtest/gtest.h"
 

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -64,9 +64,9 @@ TEST(Channel, SendOnClosedChannelPanics){
   const size_t buffer_size = 10;
   auto ch = MakeChannel<size_t>(buffer_size);
   size_t i = 5;
-  EXPECT_EQ(ch->Send(&i), true); // should not block or panic
+  EXPECT_EQ(ch->Send(&i), true);  // should not block or panic
   CloseChannel(ch);
-  EXPECT_EQ(ch->Send(&i), false); // should panic
+  EXPECT_EQ(ch->Send(&i), false);  // should panic
   delete ch;
 }
 

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -65,7 +65,6 @@ TEST(Channel, SendOnClosedChannelPanics){
   const size_t buffer_size = 10;
   auto ch = MakeChannel<size_t>(buffer_size);
   size_t i = 5;
-  size_t error_found = 1U;
   EXPECT_EQ(ch->Send(&i), true); // should not block or panic
   CloseChannel(ch);
   EXPECT_EQ(ch->Send(&i), false); // should panic

--- a/paddle/framework/channel_test.cc
+++ b/paddle/framework/channel_test.cc
@@ -66,23 +66,9 @@ TEST(Channel, SendOnClosedChannelPanics){
   auto ch = MakeChannel<size_t>(buffer_size);
   size_t i = 5;
   size_t error_found = 1U;
-  try {
-    EXPECT_EQ(ch->Send(&i), true); // should not block
-  } catch (std::runtime_error &error) {
-    error_found = 2U;
-  } catch(std::exception &error) {
-    error_found = 3U;
-  }
-  EXPECT_EQ(error_found, 1U); // should not have panicked
+  EXPECT_EQ(ch->Send(&i), true); // should not block or panic
   CloseChannel(ch);
-  try {
-    ch->Send(&i); // should throw an exception
-  } catch (std::runtime_error &error) {
-    error_found = 2U;
-  } catch(std::exception &error) {
-    error_found = 3U;
-  }
-  EXPECT_EQ(error_found, 2U); // should panic with runtime_error exception
+  EXPECT_EQ(ch->Send(&i), false); // should panic
   delete ch;
 }
 

--- a/paddle/framework/details/buffered_channel.h
+++ b/paddle/framework/details/buffered_channel.h
@@ -16,6 +16,7 @@ limitations under the License. */
 #include <condition_variable>
 #include <deque>
 #include <mutex>
+#include <stdexcept>
 
 #include "paddle/framework/channel.h"
 #include "paddle/platform/enforce.h"
@@ -42,7 +43,7 @@ class Buffered : public paddle::framework::Channel<T> {
   std::condition_variable empty_cond_var_;
   std::condition_variable full_cond_var_;
   std::deque<T> channel_;
-  bool closed_;
+  std::atomic<bool> closed_{false};
 
   Buffered(size_t cap) : cap_(cap), closed_(false) {
     PADDLE_ENFORCE_GT(cap, 0);
@@ -53,10 +54,13 @@ class Buffered : public paddle::framework::Channel<T> {
 
 template <typename T>
 bool Buffered<T>::Send(T* item) {
+  bool ret = false;
+  if (closed_) {
+    throw std::runtime_error("Channel is closed!");
+  }
   std::unique_lock<std::mutex> lock(mu_);
   full_cond_var_.wait(lock,
                       [this]() { return channel_.size() < cap_ || closed_; });
-  bool ret = false;
   if (!closed_) {
     channel_.push_back(std::move(*item));
     lock.unlock();

--- a/paddle/framework/details/buffered_channel.h
+++ b/paddle/framework/details/buffered_channel.h
@@ -86,6 +86,9 @@ bool Buffered<T>::Receive(T* item) {
 
 template <typename T>
 void Buffered<T>::Close() {
+  if (closed_) {
+    return;
+  }
   std::unique_lock<std::mutex> lock(mu_);
   closed_ = true;
   NotifyAllParticipants(&lock);

--- a/paddle/framework/details/buffered_channel.h
+++ b/paddle/framework/details/buffered_channel.h
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
+#include <atomic>
 #include <condition_variable>
 #include <deque>
 #include <mutex>

--- a/paddle/framework/details/buffered_channel.h
+++ b/paddle/framework/details/buffered_channel.h
@@ -56,7 +56,7 @@ template <typename T>
 bool Buffered<T>::Send(T* item) {
   bool ret = false;
   if (closed_) {
-    throw std::runtime_error("Channel is closed!");
+    return ret;
   }
   std::unique_lock<std::mutex> lock(mu_);
   full_cond_var_.wait(lock,

--- a/paddle/framework/details/buffered_channel.h
+++ b/paddle/framework/details/buffered_channel.h
@@ -17,7 +17,6 @@ limitations under the License. */
 #include <condition_variable>
 #include <deque>
 #include <mutex>
-#include <stdexcept>
 
 #include "paddle/framework/channel.h"
 #include "paddle/platform/enforce.h"

--- a/paddle/framework/details/unbuffered_channel.h
+++ b/paddle/framework/details/unbuffered_channel.h
@@ -117,6 +117,9 @@ bool UnBuffered<T>::Receive(T* data) {
 // that take place once the channel is closed.
 template <typename T>
 void UnBuffered<T>::Close() {
+  if (closed_) {
+    return;
+  }
   std::unique_lock<std::mutex> lock(mu_ch_);
   item = nullptr;
   closed_ = true;

--- a/paddle/framework/details/unbuffered_channel.h
+++ b/paddle/framework/details/unbuffered_channel.h
@@ -16,7 +16,6 @@ limitations under the License. */
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <stdexcept>
 
 #include "paddle/framework/channel.h"
 

--- a/paddle/framework/details/unbuffered_channel.h
+++ b/paddle/framework/details/unbuffered_channel.h
@@ -16,6 +16,7 @@ limitations under the License. */
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <stdexcept>
 
 #include "paddle/framework/channel.h"
 
@@ -58,6 +59,9 @@ class UnBuffered : public paddle::framework::Channel<T> {
 // be sent from a writer to a reader.
 template <typename T>
 bool UnBuffered<T>::Send(T* data) {
+  if (closed_) {
+    throw std::runtime_error("Channel is closed!");
+  }
   // Prevent other writers from entering
   std::unique_lock<std::recursive_mutex> writer_lock(mu_write_);
   writer_found_ = true;

--- a/paddle/framework/details/unbuffered_channel.h
+++ b/paddle/framework/details/unbuffered_channel.h
@@ -59,8 +59,9 @@ class UnBuffered : public paddle::framework::Channel<T> {
 // be sent from a writer to a reader.
 template <typename T>
 bool UnBuffered<T>::Send(T* data) {
+  bool ret = false;
   if (closed_) {
-    throw std::runtime_error("Channel is closed!");
+    return ret;
   }
   // Prevent other writers from entering
   std::unique_lock<std::recursive_mutex> writer_lock(mu_write_);
@@ -70,7 +71,6 @@ bool UnBuffered<T>::Send(T* data) {
   cv_writer_.wait(cv_lock,
                   [this]() { return reader_found_ == true || closed_; });
   cv_reader_.notify_one();
-  bool ret = false;
   if (!closed_) {
     std::unique_lock<std::mutex> channel_lock(mu_ch_);
     item = data;


### PR DESCRIPTION
Adding a panic case if we are trying to send on a closed channel.
As of now, this PR throws a `runtime_error` if we try to send on a closed channel.
Issue: https://github.com/PaddlePaddle/Paddle/issues/8172