### PR TITLE
Refine CSP doc

### DIFF
--- a/doc/design/csp.md
+++ b/doc/design/csp.md
@@ -144,8 +144,9 @@ ch = fluid.make_channel(dtype=INT, buffer_size)
 # Now write three elements to the channel
 with fluid.while(steps=buffer_size):
   fluid.send(ch, step)
-  fluid.close_channel(ch)
-  
+
+fluid.close_channel(ch)
+
 with fluid.while(steps=buffer_size):
   fluid.print(fluid.recv(ch))
 ```


### PR DESCRIPTION
```
with fluid.while(steps=buffer_size):
  fluid.send(ch, step)
  fluid.close_channel(ch)
```
==>
```
with fluid.while(steps=buffer_size):
  fluid.send(ch, step)

fluid.close_channel(ch)
```
Because once the channel is closed, Send will not put data into the channel but return false.
