### PR TITLE
optimize data flow analysis time

### DIFF
--- a/python/paddle/v2/fluid/memory_optimization_transpiler.py
+++ b/python/paddle/v2/fluid/memory_optimization_transpiler.py
@@ -92,14 +92,13 @@ class ControlFlowGraph(object):
         live_in = defaultdict(set)
         live_out = defaultdict(set)
         while True:
-            for i in range(self.op_size):
+            for i in range(self.op_size, 0, -1):
                 live_in[i] = set(self._live_in[i])
                 live_out[i] = set(self._live_out[i])
-                self._live_in[i] = self._uses[i] | (
-                    self._live_out[i] - self._defs[i])
                 for s in self._successors[i]:
                     self._live_out[i] |= self._live_in[s]
-
+                self._live_in[i] = self._uses[i] | (
+                    self._live_out[i] - self._defs[i])
             if self._reach_fixed_point(live_in, live_out):
                 break
 


### PR DESCRIPTION
The worst-case run time of dataflow analysis is O(N4). It's quite time consuming. A reversed order analysis usually reduce the iteration time of solving dataflow equation.

I have made a test in resnet demo, after using reverse order, the time of memory_optimize interface reduce from **58.1104869843** to **1.05051589012**, which saving 98.2% analysis time. 

At the same time, the optimized ProgramDesc still keeps same.