### PR TITLE
reduce doc build time in travis ci

### DIFF
--- a/doc/templates/conf.py.cn.in
+++ b/doc/templates/conf.py.cn.in
@@ -82,7 +82,7 @@ language = 'zh_CN'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '**/*_en*', '*_en*']
+exclude_patterns = ['_build', '**/*_en*', '*_en*', 'api/*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/doc/templates/conf.py.en.in
+++ b/doc/templates/conf.py.en.in
@@ -82,7 +82,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '**/*_cn*', '*_cn*']
+exclude_patterns = ['_build', '**/*_cn*', '*_cn*', 'api/*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -116,7 +116,7 @@ EOF
             -DWITH_SWIG_PY=ON \
             -DWITH_STYLE_CHECK=OFF
         make -j `nproc` gen_proto_py
-        make -j `nproc` paddle_python
+        make -j `nproc` copy_paddle_pybind
         make -j `nproc` paddle_docs paddle_docs_cn paddle_api_docs
         popd
     fi

--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -115,7 +115,7 @@ EOF
             -DWITH_AVX=${WITH_AVX:-ON} \
             -DWITH_SWIG_PY=ON \
             -DWITH_STYLE_CHECK=OFF
-        make -j `nproc` gen_proto_py
+        make -j `nproc` gen_proto_py framework_py_proto
         make -j `nproc` copy_paddle_pybind
         make -j `nproc` paddle_docs paddle_docs_cn paddle_api_docs
         popd

--- a/paddle/scripts/travis/build_doc.sh
+++ b/paddle/scripts/travis/build_doc.sh
@@ -8,7 +8,7 @@ cd $TRAVIS_BUILD_DIR/build
 # Compile Documentation only.
 cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON
 make -j `nproc` gen_proto_py
-make -j `nproc` paddle_python
+make -j `nproc` copy_paddle_pybind
 make -j `nproc` paddle_docs paddle_docs_cn paddle_api_docs
 
 # check websites for broken links

--- a/paddle/scripts/travis/build_doc.sh
+++ b/paddle/scripts/travis/build_doc.sh
@@ -6,8 +6,8 @@ mkdir -p $TRAVIS_BUILD_DIR/build
 cd $TRAVIS_BUILD_DIR/build
 
 # Compile Documentation only.
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON
-make -j `nproc` gen_proto_py
+cmake .. -DCMAKE_BUILD_TYPE=Release -DWITH_GPU=OFF -DWITH_MKL=OFF -DWITH_DOC=ON -DWITH_STYLE_CHECK=OFF
+make -j `nproc` gen_proto_py framework_py_proto
 make -j `nproc` copy_paddle_pybind
 make -j `nproc` paddle_docs paddle_docs_cn paddle_api_docs
 


### PR DESCRIPTION
The build_doc time in travis ci is more than 30min, like
![image](https://user-images.githubusercontent.com/6836917/36069203-f3e54aaa-0f1f-11e8-8393-45215db63701.png)
Now, the travis ci time is reduced to 22min:
![image](https://user-images.githubusercontent.com/6836917/36070089-f10d8ab8-0f2e-11e8-8564-fe11e678eb6c.png)

This PR reduce the build time in three ways:
- Since only paddle fluid api doc depends on `core.so`, we can only build paddle fluid codes. We change `make paddle_python` to `make framework_py_proto copy_paddle_pybind` for this reason.
- Now, there is another command `make paddle_api_docs` to build all api doc. Thus, `make paddle_docs paddle_docs_cn` can build docs excluding api. We change the conf.py.cn/en.in for this reason.
- set `WITH_STYLE_CHECK=OFF` to skip the style checking.
