### PR TITLE
Remove incorrect statement in compare_op.h

### DIFF
--- a/paddle/fluid/operators/compare_op.h
+++ b/paddle/fluid/operators/compare_op.h
@@ -67,7 +67,6 @@ class CompareOpKernel
     auto* x = context.Input<Tensor>("X");
     auto* y = context.Input<Tensor>("Y");
     auto* z = context.Output<Tensor>("Out");
-    z->mutable_data<T>(context.GetPlace());
     int axis = context.Attr<int>("axis");
     ElementwiseComputeEx<Functor, DeviceContext, T, bool>(context, x, y, axis,
                                                           Functor(), z);


### PR DESCRIPTION
The type of tensor z should be bool. And there's no need to call mutable_data because ElementwiseComputeEx will do it.