### PR TITLE
add python API for one_hot OP

### DIFF
--- a/python/paddle/v2/fluid/layers/nn.py
+++ b/python/paddle/v2/fluid/layers/nn.py
@@ -3214,6 +3214,7 @@ def smooth_l1(x, y, inside_weight=None, outside_weight=None, sigma=None):
         attrs={'sigma': sigma})
     return loss
 
+
 def one_hot(input, depth):
     """
     One Hot Operator. This operator creates the one-hot representations for input

--- a/python/paddle/v2/fluid/layers/nn.py
+++ b/python/paddle/v2/fluid/layers/nn.py
@@ -3250,4 +3250,3 @@ def one_hot(input, depth):
         attrs={'depth': depth},
         outputs={'Out': one_hot_out})
     return one_hot_out
-

--- a/python/paddle/v2/fluid/layers/nn.py
+++ b/python/paddle/v2/fluid/layers/nn.py
@@ -68,6 +68,7 @@ __all__ = [
     'layer_norm',
     'softmax_with_cross_entropy',
     'smooth_l1',
+    'one_hot',
 ]
 
 
@@ -3212,3 +3213,40 @@ def smooth_l1(x, y, inside_weight=None, outside_weight=None, sigma=None):
                  'Out': loss},
         attrs={'sigma': sigma})
     return loss
+
+def one_hot(input, depth):
+    """
+    One Hot Operator. This operator creates the one-hot representations for input
+    index values. The following example will help to explain the function of this
+    operator.
+
+    Args:
+        input(Tensor/LodTensor):  A Tensor/LodTensor of indices, last dimension must be 1.
+        depth(scalar): an interger defining the depth of the one hot dimension.
+
+    Returns:
+         The one-hot tensor or LodTensor, same as input.
+
+    Examples:
+        X is a LoDTensor:
+          X.lod = [[0, 1, 4]]
+          X.shape = [4, 1]
+          X.data = [[1], [1], [3], [0]]
+        set depth = 4
+        Out is a LoDTensor:
+          Out.lod = [[0, 1, 4]]
+          Out.shape = [4, 4]
+          Out.data = [[0., 1., 0., 0.],
+                      [0., 1., 0., 0.],
+                      [0., 0., 0., 1.],
+                      [1., 0., 0., 0.]]
+    """
+    helper = LayerHelper("one_hot", **locals())
+    one_hot_out = helper.create_tmp_variable(dtype='float32')
+    helper.append_op(
+        type="one_hot",
+        inputs={'X': input},
+        attrs={'depth': depth},
+        outputs={'Out': one_hot_out})
+    return one_hot_out
+


### PR DESCRIPTION
Hi, I'm zhoubo01 in NLP of BaiDu, Thanks to @pkuyym great job with issue [Need add one_hot operator](https://github.com/PaddlePaddle/Paddle/issues/7740) #7740 and PR [add one_hot op](https://github.com/PaddlePaddle/Paddle/pull/7819) #7819 
But when I was building my model I could't find any API about it for python：）so I add python API for it.
