### PR TITLE
Add Channel as a VarType

### DIFF
--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -112,6 +112,7 @@ message VarType {
     LOD_TENSOR_ARRAY = 13;
     PLACE_LIST = 14;
     READER = 15;
+    CHANNEL = 16;
   }
 
   required Type type = 1;

--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -137,6 +137,12 @@ message VarType {
 
   message ReaderDesc { repeated LoDTensorDesc lod_tensor = 1; }
   optional ReaderDesc reader = 5;
+
+  message ChannelDesc {
+    required Type data_type = 1;
+    required int64 capacity = 2;
+  }
+  optional ChannelDesc channel = 6;
 }
 
 message VarDesc {


### PR DESCRIPTION
@abhinavarora  and I have been pair programming to work on exposing Channel in Python and add it as a `VarType` that PaddlePaddle supports.