### PR TITLE
fix a bug of subtracting in layer_math

### DIFF
--- a/python/paddle/trainer_config_helpers/layer_math.py
+++ b/python/paddle/trainer_config_helpers/layer_math.py
@@ -75,7 +75,7 @@ LayerOutput.__add__ = add
 
 def sub(layeroutput, other):
     if is_compatible_with(other, float):
-        return slope_intercept_layer(input=layeroutput, intercept=other)
+        return slope_intercept_layer(input=layeroutput, intercept=-other)
     if not isinstance(other, LayerOutput):
         logger.fatal("LayerOutput can only be subtracted with"
                      " another Layeroutput or a number")


### PR DESCRIPTION
I don't know if this file is no longer used or not. But there seems a bug in sub(). For an equation 'x - other' and if 'other' is a floating number, then the slope_intercept_layer should have an intercept of '-other' instead of 'other'.