### PR TITLE
Profiler of FLUID operators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(ON_TRAVIS        "Exclude special unit test on Travis CI"        OFF)
 option(WITH_C_API       "Compile PaddlePaddle with C-API(Prediction)"   OFF)
 # TODO: Only compile PaddlePaddle fluid version by WITH_FLUID option. 
 option(WITH_FLUID       "Compile PaddlePaddle fluid only(TODO)"         ON)
+option(WITH_FLUID_PROFILER "Compile PaddlePaddle with operators execution measuring)" OFF)
 option(WITH_GOLANG      "Compile PaddlePaddle with GOLANG"              OFF)
 option(GLIDE_INSTALL    "Download and install go dependencies "         ON)
 option(USE_NNPACK       "Compile PaddlePaddle with NNPACK library"      OFF)
@@ -124,6 +125,11 @@ else()
     message(STATUS "Do not have AVX2 intrinsics and disabled MKL-DNN")
     set(WITH_MKLDNN OFF)
 endif()
+
+if (WITH_FLUID_PROFILER)
+add_definitions(-DFLUID_PROFILER)
+endif()
+
 
 ########################################################################################
 

--- a/paddle/fluid/framework/executor.h
+++ b/paddle/fluid/framework/executor.h
@@ -20,16 +20,39 @@ limitations under the License. */
 #include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/platform/device_context.h"
 
+#include <map>
+#include <string>
+
 namespace paddle {
 namespace framework {
+
+#ifdef FLUID_PROFILER
+class Perf {
+  struct entity {
+    std::string op_type;
+    uint64_t num_ops;
+    float avg_perf;
+    uint64_t total_time;
+  };
+
+ public:
+  Perf();
+  ~Perf();
+  void addEntry(const std::string &name, uint64_t diff);
+
+ private:
+  uint64_t m_tsc;
+  std::map<std::string, struct entity> m_my_map;
+};
+#endif
 
 class Executor {
  public:
   // TODO(dzhwinter) : Do not rely on this function, it will be removed
-  explicit Executor(const platform::DeviceContext& device)
+  explicit Executor(const platform::DeviceContext &device)
       : Executor(device.GetPlace()) {}
 
-  explicit Executor(const platform::Place& place);
+  explicit Executor(const platform::Place &place);
 
   /* @Brief
    * Runtime evaluation of the given ProgramDesc under certain Scope
@@ -38,14 +61,15 @@ class Executor {
    *  ProgramDesc
    *  Scope
    */
-  void Run(const ProgramDesc&, Scope*, int, bool create_local_scope = true,
+
+  void Run(const ProgramDesc &, Scope *, int, bool create_local_scope = true,
            bool create_vars = true);
 
-  void Run(const ProgramDesc& program, Scope* scope,
-           std::map<std::string, const LoDTensor*>& feed_targets,
-           std::map<std::string, LoDTensor*>& fetch_targets,
-           const std::string& feed_holder_name = "feed",
-           const std::string& fetch_holder_name = "fetch");
+  void Run(const ProgramDesc &program, Scope *scope,
+           std::map<std::string, const LoDTensor *> &feed_targets,
+           std::map<std::string, LoDTensor *> &fetch_targets,
+           const std::string &feed_holder_name = "feed",
+           const std::string &fetch_holder_name = "fetch");
 
  private:
   const platform::Place place_;


### PR DESCRIPTION
Hi,

During work on Fluid optimization for CPU, I created helpful code that counts how much
time given type of fluid operator takes within analyzed workload. I decided to share this as it can be useful for other developers, and also wanted to get your opinion if it is useful, or perhaps should be improved.

### It produce info in a format:

Operator[**type of operator**]:
totalExec: **total time operator of specific type took**
Ratio[totalExec/total_time]: **percentage of total time, operator of specific type took**%
aveExec[ms]: **Average time of specific type of operator took**
Num Execs: **Number of times operator of specific type was called**

### Notes/TODO:
- Counters are accumulated during execution and presented after paddle finish work
- To enable profiler: **-DWITH_FLUID_PROFILER=ON**  # OFF is default
- Works on linux only (I do not know how to read TSC clock Value to convert cycles to ms on MacOS)
- Produce results only if paddle is terminated with signal eg. interruppted training will not show stats.
- No unit tests yet

### example:
Operator[mul_grad]: totalExec: 12973 ms Ratio[totalExec/total_time]: 25.787 % aveExec[ms]: 2.30258 Num Execs: 5628


### Part of output when running RNN Search model
(https://github.com/dzhwinter/benchmark/blob/master/fluid/machine_translation.py):

........
pass_id=0, batch_id=6, train_loss: 10.306499
pass_id=0, batch_id=7, train_loss: 10.305863
pass_id=0, batch_id=8, train_loss: 10.304803
pass_id=0, batch_id=9, train_loss: 10.304098
Operator[mul_grad]: totalExec: 12604 ms Ratio[totalExec/total_time]: 30.1659 % aveExec[ms]: 2.29946 Num Execs: 5474
Operator[adam]: totalExec: 7769 ms Ratio[totalExec/total_time]: 18.594 % aveExec[ms]: 29.9425 Num Execs: 260
Operator[softmax]: totalExec: 5439 ms Ratio[totalExec/total_time]: 13.0175 % aveExec[ms]: 10.9859 Num Execs: 494
Operator[mul]: totalExec: 5313 ms Ratio[totalExec/total_time]: 12.7159 % aveExec[ms]: 0.962658 Num Execs: 5474
Operator[elementwise_mul_grad]: totalExec: 4912 ms Ratio[totalExec/total_time]: 11.7562 % aveExec[ms]: 2.48743 Num Execs: 1976
Operator[softmax_grad]: totalExec: 1799 ms Ratio[totalExec/total_time]: 4.30565 % aveExec[ms]: 3.64903 Num Execs: 494
......
Total average execution time: 41782.3ms


I'm looking forward to your feedback. Whether it is useful? Or perhaps it should be moved (implementation) to some other location in code. Based on feedback I can introduce suggested changes.