### PR TITLE
Fix Documentation and API links on paddlepaddle.org

### DIFF
--- a/doc/templates/conf.py.cn.in
+++ b/doc/templates/conf.py.cn.in
@@ -22,6 +22,11 @@ import paddle.v2
 MarkdownParser = parser.CommonMarkParser
 AutoStructify = transform.AutoStructify
 
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+templates_path = ["@PADDLE_SOURCE_DIR@/doc/templates"]
+
 # -- General configuration ------------------------------------------------
 
 # General information about the project.

--- a/doc/templates/conf.py.en.in
+++ b/doc/templates/conf.py.en.in
@@ -23,6 +23,11 @@ import paddle.v2
 MarkdownParser = parser.CommonMarkParser
 AutoStructify = transform.AutoStructify
 
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+templates_path = ["@PADDLE_SOURCE_DIR@/doc/templates"]
+
 # -- General configuration ------------------------------------------------
 
 # General information about the project.

--- a/doc/templates/layout.html
+++ b/doc/templates/layout.html
@@ -2,6 +2,13 @@
 {# Import the theme's layout. #}
 {% extends "!layout.html" %}
 
+{# SIDE NAV, TOGGLES ON MOBILE #}		
+{% block menu %}
+<nav class="doc-menu-vertical" role="navigation">
+{% set toctree = toctree(maxdepth=-1, collapse=False,titles_only=True, includehidden=True) %}
+{{ toctree }}
+</nav>
+{% endblock %}
 
 {%- block extrahead %} 
 <script>


### PR DESCRIPTION
PaddlePaddle.org requires the nav tree to be generated in order to parse the site map.  Since we removed theme in https://github.com/PaddlePaddle/Paddle/pull/8752, this also removed the site navigation menu.  This changelist adds back the site navigation menu.