### PR TITLE
Use async instead of defered for threadpool threads.

### DIFF
--- a/paddle/fluid/framework/threadpool.h
+++ b/paddle/fluid/framework/threadpool.h
@@ -54,7 +54,7 @@ class ThreadPool {
   template <typename Callback>
   std::future<void> Run(Callback fn) {
     auto f = this->RunAndGetException(fn);
-    return std::async(std::launch::deferred, ExceptionHandler(std::move(f)));
+    return std::async(std::launch::async, ExceptionHandler(std::move(f)));
   }
 
   template <typename Callback>


### PR DESCRIPTION
I don't have much background. Feel free to let me know "deferred" is the expected
behavior.

Reason for the change:
defered means you need to call get/wait first, then
the thread starts to run.
async means the thread starts ASAP, wait/get are only
used to get the result.

The code comment says:
To wait for the completion of the task, call std::future::wait()

Hence, user would expect wait() is not a method to start the thread.
It seems more reasonable to start running when the thread is available
instead of waiting for a wait/get call.