### PR TITLE
Fix compilation for gcc5.4

### DIFF
--- a/paddle/fluid/operators/math/concat.cc
+++ b/paddle/fluid/operators/math/concat.cc
@@ -44,7 +44,7 @@ class ConcatFunctor<platform::CPUDeviceContext, T> {
       out_cols += t_cols;
       input_cols[i] = t_cols;
     }
-    auto& cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());
+    auto cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());
 
     // computation
     for (int k = 0; k < out_rows; ++k) {
@@ -87,7 +87,7 @@ class ConcatGradFunctor<platform::CPUDeviceContext, T> {
       input_cols += t_cols;
       output_cols[i] = t_cols;
     }
-    auto& cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());
+    auto cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());
 
     // computation
     for (int k = 0; k < input_rows; ++k) {


### PR DESCRIPTION
The error is:

paddle/fluid/operators/math/concat.cc:47:72: error: invalid initialization of non-const reference of type 'paddle::platform::CPUPlace&' from an rvalue of type 'paddle::platform::CPUPlace'
   auto& cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());

Should not use reference for cpu_place.