### PR TITLE
Enable P2P memory copy

### DIFF
--- a/paddle/fluid/framework/init.cc
+++ b/paddle/fluid/framework/init.cc
@@ -44,6 +44,7 @@ void InitGflags(std::vector<std::string> &argv) {
 }
 
 void InitP2P(int count) {
+#ifdef PADDLE_WITH_CUDA
   std::call_once(p2p_init_flag, [&]() {
     for (int i = 0; i < count; ++i) {
       for (int j = 0; j < count; ++j) {
@@ -60,6 +61,7 @@ void InitP2P(int count) {
       }
     }
   });
+#endif
 }
 
 void InitDevices() {


### PR DESCRIPTION
On k40 with 4 devices, time reduces from ~4.0 to ~3.8+, should be
more obvious on better hardware