### PR TITLE
Speed/sequence op1

### DIFF
--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -169,7 +169,7 @@ class SequencePoolGradFunctor<platform::CPUDeviceContext, T> {
                                    static_cast<int>(lod[i + 1]));
       auto out_g_t = out_grad.Slice(i, i + 1);
       int64_t h = static_cast<int64_t>(lod[i + 1] - lod[i]);
-      int64_t w = in->numel() / in_grad->dims()[0];
+      int64_t w = in_grad->numel() / in_grad->dims()[0];
       auto in_g_e = EigenMatrix<T>::From(in_g_t, {h, w});
       auto out_g_e = EigenMatrix<T>::From(out_g_t, {1, w});
       auto out_g_e_v = EigenVector<T>::Flatten(out_g_t);

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -19,8 +19,17 @@ namespace paddle {
 namespace operators {
 namespace math {
 
+using Tensor = framework::Tensor;
+using LoDTensor = framework::LoDTensor;
+template <typename T, int MajorType = Eigen::RowMajor,
+          typename IndexType = Eigen::DenseIndex>
+using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
+template <typename T, int MajorType = Eigen::RowMajor,
+          typename IndexType = Eigen::DenseIndex>
+using EigenMatrix = framework::EigenMatrix<T, MajorType, IndexType>;
+
 template <typename T>
-class MaxSeqPoolFunctor<platform::CPUDeviceContext, T> {
+class MaxSeqPoolFunctor {
  public:
   void operator()(const platform::CPUDeviceContext& context,
                   const framework::LoDTensor& input, framework::Tensor* output,
@@ -60,7 +69,7 @@ class MaxSeqPoolFunctor<platform::CPUDeviceContext, T> {
 };
 
 template <typename T>
-class MaxSeqPoolGradFunctor<platform::CPUDeviceContext, T> {
+class MaxSeqPoolGradFunctor {
  public:
   void operator()(const platform::CPUDeviceContext& context,
                   const framework::Tensor& out_grad,
@@ -93,10 +102,101 @@ class MaxSeqPoolGradFunctor<platform::CPUDeviceContext, T> {
   }
 };
 
-template class MaxSeqPoolFunctor<platform::CPUDeviceContext, float>;
-template class MaxSeqPoolFunctor<platform::CPUDeviceContext, double>;
-template class MaxSeqPoolGradFunctor<platform::CPUDeviceContext, float>;
-template class MaxSeqPoolGradFunctor<platform::CPUDeviceContext, double>;
+template <typename T>
+class SequencePoolFunctor<platform::CPUDeviceContext, T> {
+ public:
+  /* max pool has index output */
+  void operator()(const platform::CPUDeviceContext& context,
+                  const std::string pooltype, const framework::LoDTensor& input,
+                  framework::Tensor* output,
+                  framework::Tensor* index = nullptr) {
+    if (pooltype == "MAX") {
+      math::MaxSeqPoolFunctor<T> max_pool;
+      max_pool(context, input, output, index);
+      return;
+    }
+    auto lod = input.lod()[0];
+    auto& place = *context.eigen_device();
+    for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
+      Tensor in_t =
+          input.Slice(static_cast<int>(lod[i]), static_cast<int>(lod[i + 1]));
+      Tensor out_t = output->Slice(i, i + 1);
+      int64_t h = static_cast<int64_t>(lod[i + 1] - lod[i]);
+      int64_t w = input.numel() / input.dims()[0];
+      auto in_e = EigenMatrix<T>::From(in_t, framework::make_ddim({h, w}));
+      auto out_e = EigenVector<T>::Flatten(out_t);
+      if (pooltype == "AVERAGE") {
+        out_e.device(place) = in_e.mean(Eigen::array<int, 1>({{0}}));
+      } else if (pooltype == "SUM") {
+        out_e.device(place) = in_e.sum(Eigen::array<int, 1>({{0}}));
+      } else if (pooltype == "SQRT") {
+        out_e.device(place) = in_e.sum(Eigen::array<int, 1>({{0}})) /
+                              std::sqrt(static_cast<T>(h));
+      } else if (pooltype == "LAST") {
+        out_e.device(place) = in_e.chip(h - 1, 0);
+      } else if (pooltype == "FIRST") {
+        out_e.device(place) = in_e.chip(0, 0);
+      } else {
+        PADDLE_THROW("unsupported pooling pooltype");
+      }
+    }
+  }
+};
+
+template <typename T>
+class SequencePoolGradFunctor<platform::CPUDeviceContext, T> {
+ public:
+  void operator()(const platform::CPUDeviceContext& context,
+                  const std::string pooltype, const framework::Tensor& out_grad,
+                  framework::LoDTensor* in_grad,
+                  /* max pool has index */
+                  const framework::Tensor* index = nullptr) {
+    if (pooltype == "MAX") {
+      math::MaxSeqPoolGradFunctor<T> max_pool_grad;
+      max_pool_grad(context, out_grad, *index, in_grad);
+      return;
+    }
+    auto lod = in_grad->lod()[0];
+    auto& place = *context.eigen_device();
+    for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
+      auto in_g_t = in_grad->Slice(static_cast<int>(lod[i]),
+                                   static_cast<int>(lod[i + 1]));
+      auto out_g_t = out_grad.Slice(i, i + 1);
+      int64_t h = static_cast<int64_t>(lod[i + 1] - lod[i]);
+      int64_t w = in_grad->numel() / in_grad->dims()[0];
+      auto in_g_e = EigenMatrix<T>::From(in_g_t, {h, w});
+      auto out_g_e = EigenMatrix<T>::From(out_g_t, {1, w});
+      auto out_g_e_v = EigenVector<T>::Flatten(out_g_t);
+      Eigen::DSizes<int, 2> bcast(h, 1);
+
+      if (pooltype == "AVERAGE") {
+        in_g_e.device(place) = (out_g_e / static_cast<T>(h)).broadcast(bcast);
+      } else if (pooltype == "SUM") {
+        in_g_e.device(place) = (out_g_e).broadcast(bcast);
+      } else if (pooltype == "SQRT") {
+        in_g_e.device(place) =
+            (out_g_e / std::sqrt(static_cast<T>(h))).broadcast(bcast);
+      } else if (pooltype == "LAST") {
+        in_g_e.chip(h - 1, 0).device(place) = out_g_e_v;
+      } else if (pooltype == "FIRST") {
+        in_g_e.chip(0, 0).device(place) = out_g_e_v;
+      } else {
+        PADDLE_THROW("unsupported pooling pooltype");
+      }
+    }
+  }
+};
+
+// explicit functor specialization
+template class MaxSeqPoolFunctor<float>;
+template class MaxSeqPoolFunctor<double>;
+template class MaxSeqPoolGradFunctor<float>;
+template class MaxSeqPoolGradFunctor<double>;
+// sequence pooling
+template class SequencePoolFunctor<platform::CPUDeviceContext, float>;
+template class SequencePoolFunctor<platform::CPUDeviceContext, double>;
+template class SequencePoolGradFunctor<platform::CPUDeviceContext, float>;
+template class SequencePoolGradFunctor<platform::CPUDeviceContext, double>;
 
 }  // namespace math
 }  // namespace operators

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -156,6 +156,12 @@ class SequencePoolGradFunctor<platform::CPUDeviceContext, T> {
       max_pool_grad(context, out_grad, *index, in_grad);
       return;
     }
+
+    if (pooltype == "LAST" || pooltype == "FIRST") {
+      // set X@Grad be zero at first when pooltype is LAST/FIRST
+      math::SetConstant<platform::CPUDeviceContext, T> functor;
+      functor(context, in_grad, 0)
+    }
     auto lod = in_grad->lod()[0];
     auto& place = *context.eigen_device();
     for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
@@ -163,7 +169,7 @@ class SequencePoolGradFunctor<platform::CPUDeviceContext, T> {
                                    static_cast<int>(lod[i + 1]));
       auto out_g_t = out_grad.Slice(i, i + 1);
       int64_t h = static_cast<int64_t>(lod[i + 1] - lod[i]);
-      int64_t w = in_grad->numel() / in_grad->dims()[0];
+      int64_t w = in->numel() / in_grad->dims()[0];
       auto in_g_e = EigenMatrix<T>::From(in_g_t, {h, w});
       auto out_g_e = EigenMatrix<T>::From(out_g_t, {1, w});
       auto out_g_e_v = EigenVector<T>::Flatten(out_g_t);

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -160,7 +160,7 @@ class SequencePoolGradFunctor<platform::CPUDeviceContext, T> {
     if (pooltype == "LAST" || pooltype == "FIRST") {
       // set X@Grad be zero at first when pooltype is LAST/FIRST
       math::SetConstant<platform::CPUDeviceContext, T> functor;
-      functor(context, in_grad, 0)
+      functor(context, in_grad, 0);
     }
     auto lod = in_grad->lod()[0];
     auto& place = *context.eigen_device();

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -187,12 +187,6 @@ class SequencePoolGradFunctor<platform::CPUDeviceContext, T> {
   }
 };
 
-// explicit functor specialization
-template class MaxSeqPoolFunctor<float>;
-template class MaxSeqPoolFunctor<double>;
-template class MaxSeqPoolGradFunctor<float>;
-template class MaxSeqPoolGradFunctor<double>;
-// sequence pooling
 template class SequencePoolFunctor<platform::CPUDeviceContext, float>;
 template class SequencePoolFunctor<platform::CPUDeviceContext, double>;
 template class SequencePoolGradFunctor<platform::CPUDeviceContext, float>;

--- a/paddle/fluid/operators/math/sequence_pooling.cu
+++ b/paddle/fluid/operators/math/sequence_pooling.cu
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/operators/math/sequence_pooling.h"
+
 #include "paddle/fluid/platform/cuda_helper.h"
 
 namespace paddle {
@@ -21,115 +22,6 @@ namespace operators {
 namespace math {
 
 #define FLT_MAX __FLT_MAX__
-
-template <typename T>
-__global__ void KeMaxSequencePool(const T* input, const size_t* starts,
-                                  T* output, int* index, int64_t num_seq,
-                                  int64_t dim) {
-  int dim_idx = threadIdx.x;
-  int seq_id = blockIdx.x;
-  if (seq_id >= num_seq) return;
-  size_t start = starts[seq_id];
-  size_t end = starts[seq_id + 1];
-
-  for (int64_t i = dim_idx; i < dim; i += blockDim.x) {
-    T max_val = static_cast<T>(-FLT_MAX);
-    int max_id = -1;
-    for (size_t step_id = start; step_id < end; step_id++) {
-      if (max_val < input[step_id * dim + i]) {
-        max_val = input[step_id * dim + i];
-        max_id = step_id;
-      }
-    }
-    output[seq_id * dim + i] = max_val;
-    index[seq_id * dim + i] = max_id;
-  }
-}
-
-template <typename T>
-class MaxSeqPoolFunctor<platform::CUDADeviceContext, T> {
- public:
-  void operator()(const platform::CUDADeviceContext& context,
-                  const framework::LoDTensor& input, framework::Tensor* output,
-                  framework::Tensor* index) {
-    auto in_dims = input.dims();
-    auto out_dims = output->dims();
-    auto idx_dims = index->dims();
-    PADDLE_ENFORCE_GT(in_dims.size(), static_cast<int64_t>(1));
-    PADDLE_ENFORCE_GT(out_dims.size(), 1);
-    for (int64_t i = 1; i < in_dims.size(); ++i) {
-      PADDLE_ENFORCE_EQ(in_dims[i], out_dims[i]);
-    }
-    PADDLE_ENFORCE_EQ(idx_dims, out_dims);
-
-    auto starts = input.lod()[0];
-    const T* in_data = input.data<T>();
-    T* out_data = output->data<T>();
-    int* max_index = index->data<int>();
-
-    int64_t num_seq = out_dims[0];
-    int64_t dim = output->numel() / num_seq;
-
-    dim3 threads(256, 1);
-    dim3 grid(num_seq, 1);
-    auto stream = context.stream();
-    KeMaxSequencePool<T><<<grid, threads, 0, stream>>>(
-        in_data, starts.CUDAData(context.GetPlace()), out_data, max_index,
-        num_seq, dim);
-  }
-};
-
-template <typename T>
-__global__ void KeMaxSequencePoolGrad(const T* out_grad, const int* max_index,
-                                      T* in_grad, int64_t num_seq,
-                                      int64_t dim) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  int col_idx = idx % dim;
-  if (idx < num_seq * dim) {
-    int step_id = max_index[idx];
-    in_grad[step_id * dim + col_idx] = out_grad[idx];
-  }
-}
-
-template <typename T>
-class MaxSeqPoolGradFunctor<platform::CUDADeviceContext, T> {
- public:
-  void operator()(const platform::CUDADeviceContext& context,
-                  const framework::Tensor& out_grad,
-                  const framework::Tensor& index,
-                  framework::LoDTensor* in_grad) {
-    auto og_dims = out_grad.dims();
-    auto idx_dims = index.dims();
-    auto ig_dims = in_grad->dims();
-    PADDLE_ENFORCE_GT(og_dims.size(), static_cast<int64_t>(1));
-    PADDLE_ENFORCE_GT(ig_dims.size(), static_cast<int64_t>(1));
-    for (int64_t i = 1; i < og_dims.size(); ++i) {
-      PADDLE_ENFORCE_EQ(og_dims[i], ig_dims[i]);
-    }
-    PADDLE_ENFORCE_EQ(idx_dims, og_dims);
-
-    const T* og_data = out_grad.data<T>();
-    const int* max_index = index.data<int>();
-    T* ig_data = in_grad->data<T>();
-
-    SetConstant<platform::CUDADeviceContext, T> set_zero;
-    set_zero(context, in_grad, static_cast<T>(0.0));
-    int64_t num_seq = og_dims[0];
-    int64_t dim = out_grad.numel() / num_seq;
-
-    unsigned int blocks = (num_seq * dim + 128 - 1) / 128;
-    dim3 threads(128, 1);
-    dim3 grid(blocks, 1);
-    auto stream = context.stream();
-    KeMaxSequencePoolGrad<T><<<grid, threads, 0, stream>>>(
-        og_data, max_index, ig_data, num_seq, dim);
-  }
-};
-
-template class MaxSeqPoolFunctor<platform::CUDADeviceContext, float>;
-template class MaxSeqPoolFunctor<platform::CUDADeviceContext, double>;
-template class MaxSeqPoolGradFunctor<platform::CUDADeviceContext, float>;
-template class MaxSeqPoolGradFunctor<platform::CUDADeviceContext, double>;
 
 template <typename T>
 struct MaxPoolFunctor {
@@ -156,7 +48,6 @@ struct AvgPoolFunctor {
   HOSTDEVICE void operator()(const T* input, const size_t start,
                              const size_t end, const size_t item_dim, T* output,
                              int* index) {
-    int offset = end - start > blockDim.x ? blockDim.x : end - start;
     for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
       T val = static_cast<T>(0);
       for (int i = start; i < end; ++i) {
@@ -169,17 +60,69 @@ struct AvgPoolFunctor {
 };
 
 template <typename T>
-HOSTDEVICE void sum_pool(const T* input, const size_t start, const size_t end,
-                         const size_t item_dim, T* output, int* index) {
-  int offset = end - start > blockDim.x ? blockDim.x : end - start;
-  for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
-    T val = static_cast<T>(0);
-    for (int i = start; i < end; ++i) {
-      val += input[item_dim * i + tid];
+struct SumPoolFunctor {
+  HOSTDEVICE void operator()(const T* input, const size_t start,
+                             const size_t end, const size_t item_dim, T* output,
+                             int* index) {
+    for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
+      T val = static_cast<T>(0);
+      for (int i = start; i < end; ++i) {
+        val += input[item_dim * i + tid];
+      }
+      output[tid] = val;
     }
-    output[tid] = val;
   }
-}
+};
+
+template <typename T>
+struct SqrtPoolFunctor {
+  HOSTDEVICE void operator()(const T* input, const size_t start,
+                             const size_t end, const size_t item_dim, T* output,
+                             int* index) {
+    for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
+      T val = static_cast<T>(0);
+      for (int i = start; i < end; ++i) {
+        val += input[item_dim * i + tid];
+      }
+      // end, start is lod, so end - start != 0
+      output[tid] = val / sqrt(end - start);
+    }
+  }
+};
+
+template <typename T>
+struct LastPoolFunctor {
+  HOSTDEVICE void operator()(const T* input, const size_t start,
+                             const size_t end, const size_t item_dim, T* output,
+                             int* index) {
+    for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
+      for (int i = start; i < end; ++i) {
+        if (i == end - 1) {
+          output[tid] = input[item_dim * i + tid];
+        } else {
+          output[tid] = static_cast<T>(0);
+        }
+      }
+    }
+  }
+};
+
+template <typename T>
+struct FirstPoolFunctor {
+  HOSTDEVICE void operator()(const T* input, const size_t start,
+                             const size_t end, const size_t item_dim, T* output,
+                             int* index) {
+    for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
+      for (int i = start; i < end; ++i) {
+        if (i == start) {
+          output[tid] = input[item_dim * i + tid];
+        } else {
+          output[tid] = static_cast<T>(0);
+        }
+      }
+    }
+  }
+};
 
 template <typename T, typename Range_OP>
 __global__ void sequence_pool_kernel(Range_OP op, const T* input,
@@ -219,6 +162,83 @@ class SequencePoolFunctor<platform::CUDADeviceContext, T> {
     }
   }
 };
+
+template <typename T>
+struct MaxPoolGradFunctor {
+  HOSTDEVICE void operator()(const T* out_grad, const size_t start,
+                             const size_t end, const size_t item_dim,
+                             T* in_grad, int* index) {
+    for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
+      for (int i = start; i < end; ++i) {
+        if (i == *index) {
+          in_grad[item_dim * i + tid] = out_grad[tid];
+        } else {
+          in_grad[item_dim * i + tid] = static_cast<T>(0);
+        }
+      }
+    }
+  }
+};
+
+template <typename T>
+struct AvgPoolGradFunctor {
+  HOSTDEVICE void operator()(const T* out_grad, const size_t start,
+                             const size_t end, const size_t item_dim,
+                             T* in_grad, int* index) {
+    for (int tid = threadIdx.x; tid < item_dim; tid += blockDim.x) {
+      for (int i = start; i < end; ++i) {
+        in_grad[item_dim * i + tid] = out_grad[tid] / (end - start);
+      }
+    }
+  }
+};
+
+template <typename T, typename Range_OP>
+__global__ void sequence_pool_grad_kernel(Range_OP op, const T* out_grad,
+                                          const size_t* lod,
+                                          const size_t lod_size,
+                                          const size_t item_dim, T* in_grad,
+                                          int* index) {
+  int bid = blockIdx.x;
+  if (bid >= lod_size) return;
+  size_t start = lod[bid];
+  size_t end = lod[bid + 1];
+  op(&out_grad[bid * item_dim], start, end, item_dim, in_grad, index);
+}
+
+template <typename T>
+class SequencePoolGradFunctor<platform::CUDADeviceContext, T> {
+ public:
+  void operator()(const platform::CUDADeviceContext& context,
+                  const std::string pooltype, const framework::Tensor& out_grad,
+                  framework::LoDTensor* in_grad,
+                  /* max pool has index */
+                  const framework::Tensor* index = nullptr) {
+    auto lod = in_grad->lod()[0];
+    int item_dim = in_grad->numel() / out_grad.dims()[0];
+    dim3 threads(1024, 1);
+    dim3 block(lod.size(), 1);
+    if (pooltype == "MAX") {
+      sequence_pool_grad_kernel<
+          T, MaxPoolGradFunctor<T>><<<block, threads, 0, context.stream()>>>(
+          MaxPoolGradFunctor<T>(), out_grad.data<T>(),
+          lod.CUDAData(context.GetPlace()), lod.size(), item_dim,
+          in_grad->mutable_data<T>(context.GetPlace()), index->data<T>());
+    } else if (pooltype == "AVG") {
+      sequence_pool_grad_kernel<
+          T, AvgPoolGradFunctor<T>><<<block, threads, 0, context.stream()>>>(
+          AvgPoolGradFunctor<T>(), out_grad.data<T>(),
+          lod.CUDAData(context.GetPlace()), lod.size(), item_dim,
+          in_grad->mutable_data<T>(context.GetPlace()));
+    }
+  }
+};
+
+// sequence pooling
+template class SequencePoolFunctor<platform::CUDADeviceContext, float>;
+template class SequencePoolFunctor<platform::CUDADeviceContext, double>;
+template class SequencePoolGradFunctor<platform::CUDADeviceContext, float>;
+template class SequencePoolGradFunctor<platform::CUDADeviceContext, double>;
 
 }  // namespace math
 }  // namespace operators

--- a/paddle/fluid/operators/math/sequence_pooling.cu
+++ b/paddle/fluid/operators/math/sequence_pooling.cu
@@ -11,6 +11,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
+#include <stdio.h>
 
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/operators/math/sequence_pooling.h"

--- a/paddle/fluid/operators/math/sequence_pooling.h
+++ b/paddle/fluid/operators/math/sequence_pooling.h
@@ -31,13 +31,32 @@ class MaxSeqPoolFunctor {
                   framework::Tensor* index);
 };
 
-template <typename DeviceContext, class T>
+template <typename DeviceContext, typename T>
 class MaxSeqPoolGradFunctor {
  public:
   void operator()(const DeviceContext& context,
                   const framework::Tensor& out_grad,
                   const framework::Tensor& index,
                   framework::LoDTensor* in_grad);
+};
+
+template <typename DeviceContext, typename T>
+class SequencePoolFunctor {
+ public:
+  /* max pool has index output */
+  void operator()(const DeviceContext& context, const std::string pooltype,
+                  const framework::LoDTensor& input, framework::Tensor* output,
+                  framework::Tensor* index = nullptr);
+};
+
+template <typename DeviceContext, typename T>
+class SequencePoolGradFunctor {
+ public:
+  void operator()(const DeviceContext& context, const std::string pooltype,
+                  const framework::Tensor& out_grad,
+                  framework::LoDTensor* in_grad,
+                  /* max pool has index */
+                  const framework::Tensor* index = nullptr)
 };
 
 }  // namespace math

--- a/paddle/fluid/operators/math/sequence_pooling.h
+++ b/paddle/fluid/operators/math/sequence_pooling.h
@@ -21,25 +21,6 @@ namespace paddle {
 namespace operators {
 namespace math {
 
-#define FLT_MAX __FLT_MAX__
-
-template <typename DeviceContext, typename T>
-class MaxSeqPoolFunctor {
- public:
-  void operator()(const DeviceContext& context,
-                  const framework::LoDTensor& input, framework::Tensor* output,
-                  framework::Tensor* index);
-};
-
-template <typename DeviceContext, typename T>
-class MaxSeqPoolGradFunctor {
- public:
-  void operator()(const DeviceContext& context,
-                  const framework::Tensor& out_grad,
-                  const framework::Tensor& index,
-                  framework::LoDTensor* in_grad);
-};
-
 template <typename DeviceContext, typename T>
 class SequencePoolFunctor {
  public:
@@ -56,7 +37,7 @@ class SequencePoolGradFunctor {
                   const framework::Tensor& out_grad,
                   framework::LoDTensor* in_grad,
                   /* max pool has index */
-                  const framework::Tensor* index = nullptr)
+                  const framework::Tensor* index = nullptr);
 };
 
 }  // namespace math

--- a/paddle/fluid/operators/sequence_pool_op.h
+++ b/paddle/fluid/operators/sequence_pool_op.h
@@ -23,12 +23,6 @@ namespace operators {
 
 using Tensor = framework::Tensor;
 using LoDTensor = framework::LoDTensor;
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = framework::EigenMatrix<T, MajorType, IndexType>;
 
 template <typename DeviceContext, typename T>
 class SequencePoolKernel : public framework::OpKernel<T> {
@@ -36,12 +30,11 @@ class SequencePoolKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& context) const override {
     auto* in = context.Input<LoDTensor>("X");
     auto* out = context.Output<Tensor>("Out");
+    auto* index = context.Output<Tensor>("MaxIndex");
     std::string pooltype = context.Attr<std::string>("pooltype");
 
     auto dims = in->dims();
     auto lod = in->lod();
-    int64_t w = in->numel() / dims[0];
-
     // InferShape by lod
     PADDLE_ENFORCE_EQ(lod.size(), 1UL, "Only support one level sequence now.");
     PADDLE_ENFORCE_GE(
@@ -50,45 +43,14 @@ class SequencePoolKernel : public framework::OpKernel<T> {
         "The first dimension of Input(X) must be large than batch size.");
     dims[0] = lod[0].size() - 1;
     out->Resize({dims});
-
-    auto lod_level_0 = lod[0];
-
     out->mutable_data<T>(context.GetPlace());
-    auto& dev_ctx = context.template device_context<DeviceContext>();
     if (pooltype == "MAX") {
-      math::MaxSeqPoolFunctor<DeviceContext, T> max_pool;
-      auto* index = context.Output<Tensor>("MaxIndex");
       index->Resize({dims});
       index->mutable_data<int>(context.GetPlace());
-      max_pool(dev_ctx, *in, out, index);
-      return;
     }
-
-    auto& place =
-        *context.template device_context<DeviceContext>().eigen_device();
-    for (int i = 0; i < static_cast<int>(lod_level_0.size()) - 1; ++i) {
-      Tensor in_t = in->Slice(static_cast<int>(lod_level_0[i]),
-                              static_cast<int>(lod_level_0[i + 1]));
-      Tensor out_t = out->Slice(i, i + 1);
-      int64_t h = static_cast<int64_t>(lod_level_0[i + 1] - lod_level_0[i]);
-      auto in_e = EigenMatrix<T>::From(in_t, framework::make_ddim({h, w}));
-      auto out_e = EigenVector<T>::Flatten(out_t);
-
-      if (pooltype == "AVERAGE") {
-        out_e.device(place) = in_e.mean(Eigen::array<int, 1>({{0}}));
-      } else if (pooltype == "SUM") {
-        out_e.device(place) = in_e.sum(Eigen::array<int, 1>({{0}}));
-      } else if (pooltype == "SQRT") {
-        out_e.device(place) = in_e.sum(Eigen::array<int, 1>({{0}})) /
-                              std::sqrt(static_cast<T>(h));
-      } else if (pooltype == "LAST") {
-        out_e.device(place) = in_e.chip(h - 1, 0);
-      } else if (pooltype == "FIRST") {
-        out_e.device(place) = in_e.chip(0, 0);
-      } else {
-        PADDLE_THROW("unsupported pooling pooltype");
-      }
-    }
+    math::SequencePoolFunctor<DeviceContext, T> pool;
+    pool(context.template device_context<DeviceContext>(), pooltype, *in, out,
+         index);
   }
 };
 
@@ -96,58 +58,14 @@ template <typename DeviceContext, typename T>
 class SequencePoolGradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
-    auto* in = context.Input<LoDTensor>("X");
     auto* out_g = context.Input<Tensor>(framework::GradVarName("Out"));
     auto* in_g = context.Output<LoDTensor>(framework::GradVarName("X"));
+    auto* index = context.Input<Tensor>(framework::GradVarName("MaxIndex"));
     std::string pooltype = context.Attr<std::string>("pooltype");
-
-    auto dims = in->dims();
-    auto lod = in->lod()[0];
-    int64_t w = in->numel() / dims[0];
-
     in_g->mutable_data<T>(context.GetPlace());
-    auto& dev_ctx = context.template device_context<DeviceContext>();
-
-    if (pooltype == "MAX") {
-      math::MaxSeqPoolGradFunctor<DeviceContext, T> max_pool_grad;
-      auto* index = context.Input<Tensor>("MaxIndex");
-      max_pool_grad(dev_ctx, *out_g, *index, in_g);
-      return;
-    }
-
-    if (pooltype == "LAST" || pooltype == "FIRST") {
-      // set X@Grad be zero at first when pooltype is LAST/FIRST
-      math::SetConstant<DeviceContext, T> functor;
-      functor(dev_ctx, in_g, 0);
-    }
-    auto& place =
-        *context.template device_context<DeviceContext>().eigen_device();
-
-    for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {
-      auto in_g_t =
-          in_g->Slice(static_cast<int>(lod[i]), static_cast<int>(lod[i + 1]));
-      auto out_g_t = out_g->Slice(i, i + 1);
-      int64_t h = static_cast<int64_t>(lod[i + 1] - lod[i]);
-      auto in_g_e = EigenMatrix<T>::From(in_g_t, {h, w});
-      auto out_g_e = EigenMatrix<T>::From(out_g_t, {1, w});
-      auto out_g_e_v = EigenVector<T>::Flatten(out_g_t);
-      Eigen::DSizes<int, 2> bcast(h, 1);
-
-      if (pooltype == "AVERAGE") {
-        in_g_e.device(place) = (out_g_e / static_cast<T>(h)).broadcast(bcast);
-      } else if (pooltype == "SUM") {
-        in_g_e.device(place) = (out_g_e).broadcast(bcast);
-      } else if (pooltype == "SQRT") {
-        in_g_e.device(place) =
-            (out_g_e / std::sqrt(static_cast<T>(h))).broadcast(bcast);
-      } else if (pooltype == "LAST") {
-        in_g_e.chip(h - 1, 0).device(place) = out_g_e_v;
-      } else if (pooltype == "FIRST") {
-        in_g_e.chip(0, 0).device(place) = out_g_e_v;
-      } else {
-        PADDLE_THROW("unsupported pooling pooltype");
-      }
-    }
+    math::SequencePoolGradFunctor<DeviceContext, T> pool;
+    pool(context.template device_context<DeviceContext>(), pooltype, *out_g,
+         in_g, index);
   }
 };
 

--- a/paddle/fluid/operators/sequence_pool_op.h
+++ b/paddle/fluid/operators/sequence_pool_op.h
@@ -30,8 +30,11 @@ class SequencePoolKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& context) const override {
     auto* in = context.Input<LoDTensor>("X");
     auto* out = context.Output<Tensor>("Out");
-    auto* index = context.Output<Tensor>("MaxIndex");
     std::string pooltype = context.Attr<std::string>("pooltype");
+    Tensor* index = nullptr;
+    if (pooltype == "MAX") {
+      index = context.Output<Tensor>("MaxIndex");
+    }
 
     auto dims = in->dims();
     auto lod = in->lod();
@@ -60,8 +63,11 @@ class SequencePoolGradKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& context) const override {
     auto* out_g = context.Input<Tensor>(framework::GradVarName("Out"));
     auto* in_g = context.Output<LoDTensor>(framework::GradVarName("X"));
-    auto* index = context.Input<Tensor>(framework::GradVarName("MaxIndex"));
     std::string pooltype = context.Attr<std::string>("pooltype");
+    Tensor* index = nullptr;
+    if (pooltype == "MAX") {
+      index = context.Input<Tensor>("MaxIndex");
+    }
     in_g->mutable_data<T>(context.GetPlace());
     math::SequencePoolGradFunctor<DeviceContext, T> pool;
     pool(context.template device_context<DeviceContext>(), pooltype, *out_g,

--- a/paddle/fluid/operators/sequence_pool_op.h
+++ b/paddle/fluid/operators/sequence_pool_op.h
@@ -64,7 +64,7 @@ class SequencePoolGradKernel : public framework::OpKernel<T> {
     auto* out_g = context.Input<Tensor>(framework::GradVarName("Out"));
     auto* in_g = context.Output<LoDTensor>(framework::GradVarName("X"));
     std::string pooltype = context.Attr<std::string>("pooltype");
-    Tensor* index = nullptr;
+    const Tensor* index = nullptr;
     if (pooltype == "MAX") {
       index = context.Input<Tensor>("MaxIndex");
     }

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -18,30 +18,22 @@ from op_test import OpTest
 
 
 class TestSeqAvgPool(OpTest):
-    # def set_data(self):
-    #     self.op_type = 'sequence_pool'
-    #     # one level, batch size is 4
-    #     x = np.random.uniform(0.1, 1, [11, 23]).astype('float32')
-    #     lod = [[0, 4, 5, 8, 11]]
-    #     self.inputs = {'X': (x, lod)}
-
-    #     out = np.zeros((4, 23)).astype('float32')
-    #     self.outputs = {'Out': out}
-    #     return x, lod, out
     def set_data(self):
-        self.op_type = "sequence_pool"
-        x = np.array([0.1, 0.2, 0.3, 0.4]).astype("float32")
-        lod = [[0, 1, 4]]
+        self.op_type = 'sequence_pool'
+        # one level, batch size is 4
+        x = np.random.uniform(0.1, 1, [11, 23]).astype('float32')
+        lod = [[0, 4, 5, 8, 11]]
         self.inputs = {'X': (x, lod)}
-        out = np.array([0.1, 0.3]).astype("float32")
+
+        out = np.zeros((4, 23)).astype('float32')
         self.outputs = {'Out': out}
         return x, lod, out
 
     def compute(self, x, lod, out):
         self.attrs = {'pooltype': "AVERAGE"}
-        # for i in range(2):
-        #     sub_x = x[lod[0][i]:lod[0][i + 1], :]
-        #     out[i] = sub_x.mean(axis=0)
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = sub_x.mean(axis=0)
 
     def setUp(self):
         x, lod, out = self.set_data()
@@ -50,134 +42,145 @@ class TestSeqAvgPool(OpTest):
     def test_check_output(self):
         self.check_output()
 
-    # def test_check_grad(self):
-    #     # Remove MaxIndex after check_grad is refined.
-    #     self.outputs['MaxIndex'] = \
-    #         np.zeros(self.outputs['Out'].shape).astype('int32')
-    #     self.check_grad(["X"], "Out")
+    def test_check_grad(self):
+        # Remove MaxIndex after check_grad is refined.
+        self.outputs['MaxIndex'] = \
+            np.zeros(self.outputs['Out'].shape).astype('int32')
+        self.check_grad(["X"], "Out")
 
-    # class TestSeqAvgPool2D(TestSeqAvgPool):
-    #     def set_data(self):
-    #         self.op_type = 'sequence_pool'
-    #         # one level, batch size is 4
-    #         x = np.random.uniform(0.1, 1, [13, 3, 17]).astype('float32')
-    #         lod = [[0, 4, 5, 8, 13]]
-    #         self.inputs = {'X': (x, lod)}
 
-    #         out = np.zeros((4, 3, 17)).astype('float32')
-    #         self.outputs = {'Out': out}
-    #         return x, lod, out
+class TestSeqAvgPool2D(TestSeqAvgPool):
+    def set_data(self):
+        self.op_type = 'sequence_pool'
+        # one level, batch size is 4
+        x = np.random.uniform(0.1, 1, [13, 3, 17]).astype('float32')
+        lod = [[0, 4, 5, 8, 13]]
+        self.inputs = {'X': (x, lod)}
 
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "AVERAGE"}
-    #         for i in range(4):
-    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-    #             out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
+        out = np.zeros((4, 3, 17)).astype('float32')
+        self.outputs = {'Out': out}
+        return x, lod, out
 
-    # class TestSeqSumPool(TestSeqAvgPool):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "SUM"}
-    #         for i in range(4):
-    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-    #             out[i] = sub_x.sum(axis=0)
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "AVERAGE"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
 
-    # class TestSeqSumPool2D(TestSeqAvgPool2D):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "SUM"}
-    #         for i in range(4):
-    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-    #             out[i] = np.reshape(sub_x.sum(axis=0), (3, 17))
 
-    # class TestSeqSqrtPool(TestSeqAvgPool):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "SQRT"}
-    #         for i in range(4):
-    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-    #             len = lod[0][i + 1] - lod[0][i]
-    #             out[i] = sub_x.sum(axis=0) / np.sqrt(len)
+class TestSeqSumPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SUM"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = sub_x.sum(axis=0)
 
-    # class TestSeqSqrtPool2D(TestSeqAvgPool2D):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "SQRT"}
-    #         for i in range(4):
-    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-    #             len = lod[0][i + 1] - lod[0][i]
-    #             out[i] = np.reshape(sub_x.sum(axis=0) / np.sqrt(len), (3, 17))
 
-    #     def test_check_grad(self):
-    #         # Remove MaxIndex after check_grad is refined.
-    #         self.outputs['MaxIndex'] = \
-    #             np.zeros(self.outputs['Out'].shape).astype('int32')
-    #         self.check_grad(["X"], "Out", max_relative_error=0.06)
+class TestSeqSumPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SUM"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x.sum(axis=0), (3, 17))
 
-    # class TestSeqMaxPool(TestSeqAvgPool):
-    #     def set_data(self):
-    #         self.op_type = 'sequence_pool'
-    #         x = np.random.uniform(0.1, 1, [13, 23]).astype('float32')
-    #         lod = [[0, 4, 5, 8, 13]]
-    #         for i in range(4):
-    #             l = lod[0][i + 1] - lod[0][i]
-    #             x[lod[0][i] + np.random.randint(l), :] += 2.0
 
-    #         self.inputs = {'X': (x, lod)}
+class TestSeqSqrtPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SQRT"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            len = lod[0][i + 1] - lod[0][i]
+            out[i] = sub_x.sum(axis=0) / np.sqrt(len)
 
-    #         out = np.zeros((4, 23)).astype('float32')
-    #         self.outputs = {'Out': out}
-    #         return x, lod, out
 
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "MAX"}
-    #         for i in range(4):
-    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-    #             out[i] = np.amax(sub_x, axis=0)
+class TestSeqSqrtPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SQRT"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            len = lod[0][i + 1] - lod[0][i]
+            out[i] = np.reshape(sub_x.sum(axis=0) / np.sqrt(len), (3, 17))
 
-    # class TestSeqMaxPool2D(TestSeqAvgPool2D):
-    #     def set_data(self):
-    #         self.op_type = 'sequence_pool'
-    #         x = np.random.uniform(0.1, 1, [13, 3, 11]).astype('float32')
-    #         lod = [[0, 4, 5, 8, 13]]
-    #         self.inputs = {'X': (x, lod)}
-    #         for i in range(4):
-    #             l = lod[0][i + 1] - lod[0][i]
-    #             x[lod[0][i] + np.random.randint(l), :] += 1.0
+    def test_check_grad(self):
+        # Remove MaxIndex after check_grad is refined.
+        self.outputs['MaxIndex'] = \
+            np.zeros(self.outputs['Out'].shape).astype('int32')
+        self.check_grad(["X"], "Out", max_relative_error=0.06)
 
-    #         out = np.zeros((4, 3, 11)).astype('float32')
-    #         self.outputs = {'Out': out}
-    #         return x, lod, out
 
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "MAX"}
-    #         for i in range(4):
-    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 11))
-    #             out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
+class TestSeqMaxPool(TestSeqAvgPool):
+    def set_data(self):
+        self.op_type = 'sequence_pool'
+        x = np.random.uniform(0.1, 1, [13, 23]).astype('float32')
+        lod = [[0, 4, 5, 8, 13]]
+        for i in range(4):
+            l = lod[0][i + 1] - lod[0][i]
+            x[lod[0][i] + np.random.randint(l), :] += 2.0
 
-    # class TestSeqLastPool(TestSeqAvgPool):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "LAST"}
-    #         for i in range(4):
-    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-    #             out[i] = sub_x[-1, :]
+        self.inputs = {'X': (x, lod)}
 
-    # class TestSeqLastPool2D(TestSeqAvgPool2D):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "LAST"}
-    #         for i in range(4):
-    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-    #             out[i] = np.reshape(sub_x[-1, :], (3, 17))
+        out = np.zeros((4, 23)).astype('float32')
+        self.outputs = {'Out': out}
+        return x, lod, out
 
-    # class TestSeqFirstPool(TestSeqAvgPool):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "FIRST"}
-    #         for i in range(4):
-    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-    #             out[i] = sub_x[0, :]
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "MAX"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = np.amax(sub_x, axis=0)
 
-    # class TestSeqFirstPool2D(TestSeqAvgPool2D):
-    #     def compute(self, x, lod, out):
-    #         self.attrs = {'pooltype': "FIRST"}
-    #         for i in range(4):
-    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-    #             out[i] = np.reshape(sub_x[0, :], (3, 17))
+
+class TestSeqMaxPool2D(TestSeqAvgPool2D):
+    def set_data(self):
+        self.op_type = 'sequence_pool'
+        x = np.random.uniform(0.1, 1, [13, 3, 11]).astype('float32')
+        lod = [[0, 4, 5, 8, 13]]
+        self.inputs = {'X': (x, lod)}
+        for i in range(4):
+            l = lod[0][i + 1] - lod[0][i]
+            x[lod[0][i] + np.random.randint(l), :] += 1.0
+
+        out = np.zeros((4, 3, 11)).astype('float32')
+        self.outputs = {'Out': out}
+        return x, lod, out
+
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "MAX"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 11))
+            out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
+
+
+class TestSeqLastPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "LAST"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = sub_x[-1, :]
+
+
+class TestSeqLastPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "LAST"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x[-1, :], (3, 17))
+
+
+class TestSeqFirstPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "FIRST"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = sub_x[0, :]
+
+
+class TestSeqFirstPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "FIRST"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x[0, :], (3, 17))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -18,22 +18,30 @@ from op_test import OpTest
 
 
 class TestSeqAvgPool(OpTest):
-    def set_data(self):
-        self.op_type = 'sequence_pool'
-        # one level, batch size is 4
-        x = np.random.uniform(0.1, 1, [11, 23]).astype('float32')
-        lod = [[0, 4, 5, 8, 11]]
-        self.inputs = {'X': (x, lod)}
+    # def set_data(self):
+    #     self.op_type = 'sequence_pool'
+    #     # one level, batch size is 4
+    #     x = np.random.uniform(0.1, 1, [11, 23]).astype('float32')
+    #     lod = [[0, 4, 5, 8, 11]]
+    #     self.inputs = {'X': (x, lod)}
 
-        out = np.zeros((4, 23)).astype('float32')
+    #     out = np.zeros((4, 23)).astype('float32')
+    #     self.outputs = {'Out': out}
+    #     return x, lod, out
+    def set_data(self):
+        self.op_type = "sequence_pool"
+        x = np.array([0.1, 0.2, 0.3, 0.4]).astype("float32")
+        lod = [[0, 1, 4]]
+        self.inputs = {'X': (x, lod)}
+        out = np.array([0.1, 0.3]).astype("float32")
         self.outputs = {'Out': out}
         return x, lod, out
 
     def compute(self, x, lod, out):
         self.attrs = {'pooltype': "AVERAGE"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = sub_x.mean(axis=0)
+        # for i in range(2):
+        #     sub_x = x[lod[0][i]:lod[0][i + 1], :]
+        #     out[i] = sub_x.mean(axis=0)
 
     def setUp(self):
         x, lod, out = self.set_data()
@@ -42,145 +50,134 @@ class TestSeqAvgPool(OpTest):
     def test_check_output(self):
         self.check_output()
 
-    def test_check_grad(self):
-        # Remove MaxIndex after check_grad is refined.
-        self.outputs['MaxIndex'] = \
-            np.zeros(self.outputs['Out'].shape).astype('int32')
-        self.check_grad(["X"], "Out")
+    # def test_check_grad(self):
+    #     # Remove MaxIndex after check_grad is refined.
+    #     self.outputs['MaxIndex'] = \
+    #         np.zeros(self.outputs['Out'].shape).astype('int32')
+    #     self.check_grad(["X"], "Out")
 
+    # class TestSeqAvgPool2D(TestSeqAvgPool):
+    #     def set_data(self):
+    #         self.op_type = 'sequence_pool'
+    #         # one level, batch size is 4
+    #         x = np.random.uniform(0.1, 1, [13, 3, 17]).astype('float32')
+    #         lod = [[0, 4, 5, 8, 13]]
+    #         self.inputs = {'X': (x, lod)}
 
-class TestSeqAvgPool2D(TestSeqAvgPool):
-    def set_data(self):
-        self.op_type = 'sequence_pool'
-        # one level, batch size is 4
-        x = np.random.uniform(0.1, 1, [13, 3, 17]).astype('float32')
-        lod = [[0, 4, 5, 8, 13]]
-        self.inputs = {'X': (x, lod)}
+    #         out = np.zeros((4, 3, 17)).astype('float32')
+    #         self.outputs = {'Out': out}
+    #         return x, lod, out
 
-        out = np.zeros((4, 3, 17)).astype('float32')
-        self.outputs = {'Out': out}
-        return x, lod, out
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "AVERAGE"}
+    #         for i in range(4):
+    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+    #             out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
 
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "AVERAGE"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
+    # class TestSeqSumPool(TestSeqAvgPool):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "SUM"}
+    #         for i in range(4):
+    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+    #             out[i] = sub_x.sum(axis=0)
 
+    # class TestSeqSumPool2D(TestSeqAvgPool2D):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "SUM"}
+    #         for i in range(4):
+    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+    #             out[i] = np.reshape(sub_x.sum(axis=0), (3, 17))
 
-class TestSeqSumPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SUM"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = sub_x.sum(axis=0)
+    # class TestSeqSqrtPool(TestSeqAvgPool):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "SQRT"}
+    #         for i in range(4):
+    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+    #             len = lod[0][i + 1] - lod[0][i]
+    #             out[i] = sub_x.sum(axis=0) / np.sqrt(len)
 
+    # class TestSeqSqrtPool2D(TestSeqAvgPool2D):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "SQRT"}
+    #         for i in range(4):
+    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+    #             len = lod[0][i + 1] - lod[0][i]
+    #             out[i] = np.reshape(sub_x.sum(axis=0) / np.sqrt(len), (3, 17))
 
-class TestSeqSumPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SUM"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x.sum(axis=0), (3, 17))
+    #     def test_check_grad(self):
+    #         # Remove MaxIndex after check_grad is refined.
+    #         self.outputs['MaxIndex'] = \
+    #             np.zeros(self.outputs['Out'].shape).astype('int32')
+    #         self.check_grad(["X"], "Out", max_relative_error=0.06)
 
+    # class TestSeqMaxPool(TestSeqAvgPool):
+    #     def set_data(self):
+    #         self.op_type = 'sequence_pool'
+    #         x = np.random.uniform(0.1, 1, [13, 23]).astype('float32')
+    #         lod = [[0, 4, 5, 8, 13]]
+    #         for i in range(4):
+    #             l = lod[0][i + 1] - lod[0][i]
+    #             x[lod[0][i] + np.random.randint(l), :] += 2.0
 
-class TestSeqSqrtPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SQRT"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            len = lod[0][i + 1] - lod[0][i]
-            out[i] = sub_x.sum(axis=0) / np.sqrt(len)
+    #         self.inputs = {'X': (x, lod)}
 
+    #         out = np.zeros((4, 23)).astype('float32')
+    #         self.outputs = {'Out': out}
+    #         return x, lod, out
 
-class TestSeqSqrtPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SQRT"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            len = lod[0][i + 1] - lod[0][i]
-            out[i] = np.reshape(sub_x.sum(axis=0) / np.sqrt(len), (3, 17))
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "MAX"}
+    #         for i in range(4):
+    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+    #             out[i] = np.amax(sub_x, axis=0)
 
-    def test_check_grad(self):
-        # Remove MaxIndex after check_grad is refined.
-        self.outputs['MaxIndex'] = \
-            np.zeros(self.outputs['Out'].shape).astype('int32')
-        self.check_grad(["X"], "Out", max_relative_error=0.06)
+    # class TestSeqMaxPool2D(TestSeqAvgPool2D):
+    #     def set_data(self):
+    #         self.op_type = 'sequence_pool'
+    #         x = np.random.uniform(0.1, 1, [13, 3, 11]).astype('float32')
+    #         lod = [[0, 4, 5, 8, 13]]
+    #         self.inputs = {'X': (x, lod)}
+    #         for i in range(4):
+    #             l = lod[0][i + 1] - lod[0][i]
+    #             x[lod[0][i] + np.random.randint(l), :] += 1.0
 
+    #         out = np.zeros((4, 3, 11)).astype('float32')
+    #         self.outputs = {'Out': out}
+    #         return x, lod, out
 
-class TestSeqMaxPool(TestSeqAvgPool):
-    def set_data(self):
-        self.op_type = 'sequence_pool'
-        x = np.random.uniform(0.1, 1, [13, 23]).astype('float32')
-        lod = [[0, 4, 5, 8, 13]]
-        for i in range(4):
-            l = lod[0][i + 1] - lod[0][i]
-            x[lod[0][i] + np.random.randint(l), :] += 2.0
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "MAX"}
+    #         for i in range(4):
+    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 11))
+    #             out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
 
-        self.inputs = {'X': (x, lod)}
+    # class TestSeqLastPool(TestSeqAvgPool):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "LAST"}
+    #         for i in range(4):
+    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+    #             out[i] = sub_x[-1, :]
 
-        out = np.zeros((4, 23)).astype('float32')
-        self.outputs = {'Out': out}
-        return x, lod, out
+    # class TestSeqLastPool2D(TestSeqAvgPool2D):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "LAST"}
+    #         for i in range(4):
+    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+    #             out[i] = np.reshape(sub_x[-1, :], (3, 17))
 
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "MAX"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = np.amax(sub_x, axis=0)
+    # class TestSeqFirstPool(TestSeqAvgPool):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "FIRST"}
+    #         for i in range(4):
+    #             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+    #             out[i] = sub_x[0, :]
 
-
-class TestSeqMaxPool2D(TestSeqAvgPool2D):
-    def set_data(self):
-        self.op_type = 'sequence_pool'
-        x = np.random.uniform(0.1, 1, [13, 3, 11]).astype('float32')
-        lod = [[0, 4, 5, 8, 13]]
-        self.inputs = {'X': (x, lod)}
-        for i in range(4):
-            l = lod[0][i + 1] - lod[0][i]
-            x[lod[0][i] + np.random.randint(l), :] += 1.0
-
-        out = np.zeros((4, 3, 11)).astype('float32')
-        self.outputs = {'Out': out}
-        return x, lod, out
-
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "MAX"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 11))
-            out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
-
-
-class TestSeqLastPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "LAST"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = sub_x[-1, :]
-
-
-class TestSeqLastPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "LAST"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x[-1, :], (3, 17))
-
-
-class TestSeqFirstPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "FIRST"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = sub_x[0, :]
-
-
-class TestSeqFirstPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "FIRST"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x[0, :], (3, 17))
+    # class TestSeqFirstPool2D(TestSeqAvgPool2D):
+    #     def compute(self, x, lod, out):
+    #         self.attrs = {'pooltype': "FIRST"}
+    #         for i in range(4):
+    #             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+    #             out[i] = np.reshape(sub_x[0, :], (3, 17))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -29,18 +29,6 @@ class TestSeqAvgPool(OpTest):
         self.outputs = {'Out': out}
         return x, lod, out
 
-    # def set_data(self):
-    #     self.op_type = "sequence_pool"
-    #     x = np.array([0.1, 0.2, 0.3, 0.4, 0.5]).astype("float32")
-    #     lod = [[0, 1, 4, 5]]
-    #     self.inputs = {'X': (x, lod)}
-    #     out = np.array([0.1, 0.2, 0.5]).astype("float32")
-    #     self.outputs = {'Out': out}
-    #     return x, lod, out
-
-    # def compute(self, x, lod, out):
-    #     self.attrs = {'pooltype': "FIRST"}
-
     def compute(self, x, lod, out):
         self.attrs = {'pooltype': "AVERAGE"}
         for i in range(4):

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -61,85 +61,12 @@ class TestSeqAvgPool(OpTest):
         self.check_grad(["X"], "Out")
 
 
-# class TestSeqFirstPool(TestSeqAvgPool):
-#     def compute(self, x, lod, out):
-#         self.attrs = {'pooltype': "FIRST"}
-#         for i in range(4):
-#             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-#             out[i] = sub_x[0, :]
-
-
-# class TestSeqAvgPool2D(TestSeqAvgPool):
-class TestSeqAvgPool2D(OpTest):
-    def set_data(self):
-        self.op_type = 'sequence_pool'
-        # one level, batch size is 4
-        x = np.random.uniform(0.1, 1, [13, 3, 17]).astype('float32')
-        lod = [[0, 4, 5, 8, 13]]
-        self.inputs = {'X': (x, lod)}
-
-        out = np.zeros((4, 3, 17)).astype('float32')
-        self.outputs = {'Out': out}
-        return x, lod, out
-
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "AVERAGE"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
-
-    def setUp(self):
-        x, lod, out = self.set_data()
-        self.compute(x, lod, out)
-
-    def test_check_output(self):
-        self.check_output()
-
-    def test_check_grad(self):
-        # Remove MaxIndex after check_grad is refined.
-        self.outputs['MaxIndex'] = \
-            np.zeros(self.outputs['Out'].shape).astype('int32')
-        self.check_grad(["X"], "Out")
-
-
 class TestSeqSumPool(TestSeqAvgPool):
     def compute(self, x, lod, out):
         self.attrs = {'pooltype': "SUM"}
         for i in range(4):
             sub_x = x[lod[0][i]:lod[0][i + 1], :]
             out[i] = sub_x.sum(axis=0)
-
-
-class TestSeqSumPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SUM"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x.sum(axis=0), (3, 17))
-
-
-class TestSeqSqrtPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SQRT"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            len = lod[0][i + 1] - lod[0][i]
-            out[i] = sub_x.sum(axis=0) / np.sqrt(len)
-
-
-class TestSeqSqrtPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "SQRT"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            len = lod[0][i + 1] - lod[0][i]
-            out[i] = np.reshape(sub_x.sum(axis=0) / np.sqrt(len), (3, 17))
-
-    def test_check_grad(self):
-        # Remove MaxIndex after check_grad is refined.
-        self.outputs['MaxIndex'] = \
-            np.zeros(self.outputs['Out'].shape).astype('int32')
-        self.check_grad(["X"], "Out", max_relative_error=0.06)
 
 
 class TestSeqMaxPool(TestSeqAvgPool):
@@ -164,6 +91,73 @@ class TestSeqMaxPool(TestSeqAvgPool):
             out[i] = np.amax(sub_x, axis=0)
 
 
+class TestSeqSqrtPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SQRT"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            len = lod[0][i + 1] - lod[0][i]
+            out[i] = sub_x.sum(axis=0) / np.sqrt(len)
+
+
+class TestSeqLastPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "LAST"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = sub_x[-1, :]
+
+
+class TestSeqFirstPool(TestSeqAvgPool):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "FIRST"}
+        for i in range(4):
+            sub_x = x[lod[0][i]:lod[0][i + 1], :]
+            out[i] = sub_x[0, :]
+
+
+class TestSeqAvgPool2D(TestSeqAvgPool):
+    def set_data(self):
+        self.op_type = 'sequence_pool'
+        # one level, batch size is 4
+        x = np.random.uniform(0.1, 1, [13, 3, 17]).astype('float32')
+        lod = [[0, 4, 5, 8, 13]]
+        self.inputs = {'X': (x, lod)}
+
+        out = np.zeros((4, 3, 17)).astype('float32')
+        self.outputs = {'Out': out}
+        return x, lod, out
+
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "AVERAGE"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
+
+
+class TestSeqSumPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SUM"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x.sum(axis=0), (3, 17))
+
+
+class TestSeqSqrtPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "SQRT"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            len = lod[0][i + 1] - lod[0][i]
+            out[i] = np.reshape(sub_x.sum(axis=0) / np.sqrt(len), (3, 17))
+
+    def test_check_grad(self):
+        # Remove MaxIndex after check_grad is refined.
+        self.outputs['MaxIndex'] = \
+            np.zeros(self.outputs['Out'].shape).astype('int32')
+        self.check_grad(["X"], "Out", max_relative_error=0.06)
+
+
 class TestSeqMaxPool2D(TestSeqAvgPool2D):
     def set_data(self):
         self.op_type = 'sequence_pool'
@@ -185,26 +179,21 @@ class TestSeqMaxPool2D(TestSeqAvgPool2D):
             out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
 
 
-# class TestSeqLastPool(TestSeqAvgPool):
-#     def compute(self, x, lod, out):
-#         self.attrs = {'pooltype': "LAST"}
-#         for i in range(4):
-#             sub_x = x[lod[0][i]:lod[0][i + 1], :]
-#             out[i] = sub_x[-1, :]
+class TestSeqLastPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "LAST"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x[-1, :], (3, 17))
 
-# class TestSeqLastPool2D(TestSeqAvgPool2D):
-#     def compute(self, x, lod, out):
-#         self.attrs = {'pooltype': "LAST"}
-#         for i in range(4):
-#             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-#             out[i] = np.reshape(sub_x[-1, :], (3, 17))
 
-# class TestSeqFirstPool2D(TestSeqAvgPool2D):
-#     def compute(self, x, lod, out):
-#         self.attrs = {'pooltype': "FIRST"}
-#         for i in range(4):
-#             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-#             out[i] = np.reshape(sub_x[0, :], (3, 17))
+class TestSeqFirstPool2D(TestSeqAvgPool2D):
+    def compute(self, x, lod, out):
+        self.attrs = {'pooltype': "FIRST"}
+        for i in range(4):
+            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+            out[i] = np.reshape(sub_x[0, :], (3, 17))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -29,6 +29,18 @@ class TestSeqAvgPool(OpTest):
         self.outputs = {'Out': out}
         return x, lod, out
 
+    # def set_data(self):
+    #     self.op_type = "sequence_pool"
+    #     x = np.array([0.1, 0.2, 0.3, 0.4, 0.5]).astype("float32")
+    #     lod = [[0, 1, 4, 5]]
+    #     self.inputs = {'X': (x, lod)}
+    #     out = np.array([0.1, 0.2, 0.5]).astype("float32")
+    #     self.outputs = {'Out': out}
+    #     return x, lod, out
+
+    # def compute(self, x, lod, out):
+    #     self.attrs = {'pooltype': "FIRST"}
+
     def compute(self, x, lod, out):
         self.attrs = {'pooltype': "AVERAGE"}
         for i in range(4):
@@ -49,7 +61,16 @@ class TestSeqAvgPool(OpTest):
         self.check_grad(["X"], "Out")
 
 
-class TestSeqAvgPool2D(TestSeqAvgPool):
+# class TestSeqFirstPool(TestSeqAvgPool):
+#     def compute(self, x, lod, out):
+#         self.attrs = {'pooltype': "FIRST"}
+#         for i in range(4):
+#             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+#             out[i] = sub_x[0, :]
+
+
+# class TestSeqAvgPool2D(TestSeqAvgPool):
+class TestSeqAvgPool2D(OpTest):
     def set_data(self):
         self.op_type = 'sequence_pool'
         # one level, batch size is 4
@@ -66,6 +87,19 @@ class TestSeqAvgPool2D(TestSeqAvgPool):
         for i in range(4):
             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
             out[i] = np.reshape(sub_x.mean(axis=0), (3, 17))
+
+    def setUp(self):
+        x, lod, out = self.set_data()
+        self.compute(x, lod, out)
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        # Remove MaxIndex after check_grad is refined.
+        self.outputs['MaxIndex'] = \
+            np.zeros(self.outputs['Out'].shape).astype('int32')
+        self.check_grad(["X"], "Out")
 
 
 class TestSeqSumPool(TestSeqAvgPool):
@@ -151,37 +185,26 @@ class TestSeqMaxPool2D(TestSeqAvgPool2D):
             out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
 
 
-class TestSeqLastPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "LAST"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = sub_x[-1, :]
+# class TestSeqLastPool(TestSeqAvgPool):
+#     def compute(self, x, lod, out):
+#         self.attrs = {'pooltype': "LAST"}
+#         for i in range(4):
+#             sub_x = x[lod[0][i]:lod[0][i + 1], :]
+#             out[i] = sub_x[-1, :]
 
+# class TestSeqLastPool2D(TestSeqAvgPool2D):
+#     def compute(self, x, lod, out):
+#         self.attrs = {'pooltype': "LAST"}
+#         for i in range(4):
+#             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+#             out[i] = np.reshape(sub_x[-1, :], (3, 17))
 
-class TestSeqLastPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "LAST"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x[-1, :], (3, 17))
-
-
-class TestSeqFirstPool(TestSeqAvgPool):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "FIRST"}
-        for i in range(4):
-            sub_x = x[lod[0][i]:lod[0][i + 1], :]
-            out[i] = sub_x[0, :]
-
-
-class TestSeqFirstPool2D(TestSeqAvgPool2D):
-    def compute(self, x, lod, out):
-        self.attrs = {'pooltype': "FIRST"}
-        for i in range(4):
-            sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
-            out[i] = np.reshape(sub_x[0, :], (3, 17))
-
+# class TestSeqFirstPool2D(TestSeqAvgPool2D):
+#     def compute(self, x, lod, out):
+#         self.attrs = {'pooltype': "FIRST"}
+#         for i in range(4):
+#             sub_x = np.reshape(x[lod[0][i]:lod[0][i + 1], :], (-1, 3 * 17))
+#             out[i] = np.reshape(sub_x[0, :], (3, 17))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/9099
every minibatch sequence_pool and sequence_pool_grad operator have a **~8x time acceleration**.
for example, 
the sequence_pool op enhanced from 0.815583 -> 0.119373
the sequence_pool_grad enhanced from 0.579614 -> 0.0830757 

before optimize
```
Event                                     Calls       Total       Min.        Max.        Ave.
thread0::sum                              72772       6579.74     0.013088    3.43046     0.0904158
thread0::mul_grad                         25928       4135.29     0.049952    4.4888      0.159491
thread0::sequence_softmax_grad            2344        3067.88     0.05872     95.0493     1.30882
thread0::sequence_softmax                 2344        2617.72     0.04976     17.122      1.11677
thread0::mul                              25928       2260.75     0.038624    8.36944     0.0871933
thread0::sequence_pool                    2380        1941.09     0.045984    89.9217     0.815583
thread0::sequence_expand_grad             2344        1730.34     0.05296     8.10054     0.738201
thread0::sequence_pool_grad               2380        1379.48     0.03824     137.793     0.579614
```
after optimize
```
thread0::sigmoid_grad                     7035        304.461     0.024032    89.5161     0.0432781
thread0::sequence_pool                    2381        284.226     0.053984    56.5243     0.119373
thread0::sigmoid                          7035        214.732     0.02448     3.57146     0.0305233
thread0::tanh                             7071        214.441     0.023712    1.59734     0.0303269
thread0::tanh_grad                        7071        206.762     0.023328    0.1432      0.0292408
thread0::sequence_pool_grad               2381        197.803     0.057408    0.934464    0.0830757
thread0::adam                             936         187.986     0.024384    1.28653     0.20084
```