### PR TITLE
expose gather/expand/pad ops to python

### DIFF
--- a/paddle/fluid/operators/scatter_op.cc
+++ b/paddle/fluid/operators/scatter_op.cc
@@ -25,8 +25,8 @@ class ScatterOp : public framework::OperatorWithKernel {
   void InferShape(framework::InferShapeContext* ctx) const override {
     PADDLE_ENFORCE(ctx->HasInput("X"),
                    "Input(X) of ScatterOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasInput("Ids"),
-                   "Input(Ids) of ScatterOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput("Index"),
+                   "Input(Index) of ScatterOp should not be null.");
     PADDLE_ENFORCE(ctx->HasInput("Updates"),
                    "Input(Updates) of ScatterOp should not be null.");
     PADDLE_ENFORCE(ctx->HasOutput("Out"),
@@ -34,13 +34,13 @@ class ScatterOp : public framework::OperatorWithKernel {
 
     auto updates_dims = ctx->GetInputDim("Updates");
     auto ref_dims = ctx->GetInputDim("X");
-    PADDLE_ENFORCE_EQ(ctx->GetInputDim("Ids").size(), 1,
-                      "Update Ids should be 1-D.");
+    PADDLE_ENFORCE_EQ(ctx->GetInputDim("Index").size(), 1,
+                      "Update Index should be 1-D.");
     PADDLE_ENFORCE_EQ(ref_dims.size(), updates_dims.size(),
-                      "Xerence and Updates should have the same shape size");
+                      "Reference and Updates should have the same shape size");
     PADDLE_ENFORCE_EQ(ctx->GetInputDim("Updates")[0],
-                      ctx->GetInputDim("Ids")[0],
-                      "Updates and Ids should have same batch-size.");
+                      ctx->GetInputDim("Index")[0],
+                      "Updates and Index should have same batch-size.");
     framework::DDim data_dim(updates_dims);
     for (int i = 1; i < data_dim.size(); ++i) {
       PADDLE_ENFORCE_EQ(data_dim[i], updates_dims[i]);
@@ -81,7 +81,7 @@ class ScatterOpMaker : public framework::OpProtoAndCheckerMaker {
   ScatterOpMaker(OpProto* proto, OpAttrChecker* op_checker)
       : OpProtoAndCheckerMaker(proto, op_checker) {
     AddInput("X", "The source input of scatter op");
-    AddInput("Ids", "The index input of scatter op where X will be updated");
+    AddInput("Index", "The index input of scatter op where X will be updated");
     AddInput("Updates", "The updated value of updates op");
     AddOutput("Out", "The output of add op");
     AddComment(R"DOC(
@@ -91,7 +91,7 @@ This operator obtains output by updating the input on selected indices on the fi
 
 $$
 Out = X \\
-Out[Ids] = X[Ids] + Updates
+Out[Index] = Updates
 $$
 
 )DOC");

--- a/paddle/fluid/operators/scatter_op.cu
+++ b/paddle/fluid/operators/scatter_op.cu
@@ -26,13 +26,13 @@ class ScatterOpCUDAKernel : public framework::OpKernel<T> {
     PADDLE_ENFORCE(platform::is_gpu_place(ctx.GetPlace()),
                    "This kernel only runs on GPU device.");
     auto *X = ctx.Input<Tensor>("X");
-    auto *Ids = ctx.Input<Tensor>("Ids");
+    auto *Index = ctx.Input<Tensor>("Index");
     auto *Updates = ctx.Input<Tensor>("Updates");
     auto *Out = ctx.Output<Tensor>("Out");
 
     Out->ShareDataWith(*X);
 
-    GPUScatterAssign<T>(ctx.device_context(), *Updates, *Ids, Out);
+    GPUScatterAssign<T>(ctx.device_context(), *Updates, *Index, Out);
   }
 };
 
@@ -44,14 +44,14 @@ class ScatterGradOpCUDAKernel : public framework::OpKernel<T> {
                    "This kernel only runs on GPU device.");
     auto *dX = ctx.Output<Tensor>(framework::GradVarName("X"));
     auto *dUpdates = ctx.Output<Tensor>(framework::GradVarName("Updates"));
-    auto *Ids = ctx.Input<Tensor>("Ids");
+    auto *Index = ctx.Input<Tensor>("Index");
     auto *dOut = ctx.Input<Tensor>(framework::GradVarName("Out"));
 
     // In place gradient: dX = dO
     dX->ShareDataWith(*dOut);
     dUpdates->mutable_data<T>(ctx.GetPlace());
-    // Gradient by Gather: dUpdates = dO[Ids]
-    GPUGather<T>(ctx.device_context(), *dOut, *Ids, dUpdates);
+    // Gradient by Gather: dUpdates = dO[Index]
+    GPUGather<T>(ctx.device_context(), *dOut, *Index, dUpdates);
   }
 };
 

--- a/python/paddle/fluid/layers/layer_function_generator.py
+++ b/python/paddle/fluid/layers/layer_function_generator.py
@@ -147,6 +147,14 @@ def generate_layer_fn(op_type):
                     raise ValueError("input of {0} must be variable".format(
                         op_type))
 
+                if dtype is None:
+                    dtype = each.dtype
+                elif dtype != each.dtype:
+                    if op_type not in ["gather", "scatter"]:
+                        raise ValueError(
+                            "operator {0} must input same dtype. {1} vs {2}".
+                            format(op_type, dtype, each.dtype))
+
         return dtype
 
     def func(*args, **kwargs):

--- a/python/paddle/fluid/layers/layer_function_generator.py
+++ b/python/paddle/fluid/layers/layer_function_generator.py
@@ -147,13 +147,6 @@ def generate_layer_fn(op_type):
                     raise ValueError("input of {0} must be variable".format(
                         op_type))
 
-                if dtype is None:
-                    dtype = each.dtype
-                elif dtype != each.dtype:
-                    raise ValueError(
-                        "operator {0} must input same dtype. {1} vs {2}".format(
-                            op_type, dtype, each.dtype))
-
         return dtype
 
     def func(*args, **kwargs):

--- a/python/paddle/fluid/layers/layer_function_generator.py
+++ b/python/paddle/fluid/layers/layer_function_generator.py
@@ -149,11 +149,6 @@ def generate_layer_fn(op_type):
 
                 if dtype is None:
                     dtype = each.dtype
-                elif dtype != each.dtype:
-                    if op_type not in ["gather", "scatter"]:
-                        raise ValueError(
-                            "operator {0} must input same dtype. {1} vs {2}".
-                            format(op_type, dtype, each.dtype))
 
         return dtype
 

--- a/python/paddle/fluid/layers/ops.py
+++ b/python/paddle/fluid/layers/ops.py
@@ -71,7 +71,10 @@ __all__ = [
     'gaussian_random_batch_size_like',
     'cumsum',
     'scatter',
+    'gather',
     'sum',
+    'expand',
+    'pad'
 ] + __activations__
 
 for _OP in set(__all__):

--- a/python/paddle/fluid/tests/unittests/test_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scatter_op.py
@@ -25,7 +25,7 @@ class TestScatterOp(OpTest):
         updates_np = np.random.random((2, 3)).astype("float32")
         output_np = np.copy(ref_np)
         output_np[index_np] = updates_np
-        self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
+        self.inputs = {'X': ref_np, 'Index': index_np, 'Updates': updates_np}
         self.outputs = {'Out': output_np}
 
     def test_check_output(self):


### PR DESCRIPTION
1. Exposed gather/expand/pad ops to python
2. Made variable name consistent between `scatter` and `gather`. I chose to use `index` instead of `ids` because lots of other files used `index` like scatter.h and gather.h. 
3. Removed the check of type consistency in `layer_function_generator.py` so that `gather` and `scatter` ops can be called directly since the type of Input `Index` is integer and `X` can be float. 
4. Corrected the documentation/comment in `scatter` op. It should be an update/replace operation instead of an add operation. 