### PR TITLE
Add float16 support to dropout operator

### DIFF
--- a/paddle/fluid/operators/dropout_op.cc
+++ b/paddle/fluid/operators/dropout_op.cc
@@ -35,7 +35,6 @@ class DropoutOp : public framework::OperatorWithKernel {
   }
 };
 
-template <typename AttrType>
 class DropoutOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   DropoutOpMaker(OpProto* proto, OpAttrChecker* op_checker)
@@ -73,7 +72,6 @@ are set equal to their corresponding inputs.
   }
 };
 
-template <typename AttrType>
 class DropoutOpGrad : public framework::OperatorWithKernel {
  public:
   using framework::OperatorWithKernel::OperatorWithKernel;
@@ -103,11 +101,10 @@ class DropoutOpGrad : public framework::OperatorWithKernel {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-REGISTER_OP(dropout, ops::DropoutOp, ops::DropoutOpMaker<float>, dropout_grad,
-            ops::DropoutOpGrad<float>);
+REGISTER_OP(dropout, ops::DropoutOp, ops::DropoutOpMaker, dropout_grad,
+            ops::DropoutOpGrad);
 REGISTER_OP_CPU_KERNEL(
-    dropout,
-    ops::CPUDropoutKernel<paddle::platform::CPUDeviceContext, float, float>);
+    dropout, ops::CPUDropoutKernel<paddle::platform::CPUDeviceContext, float>);
 REGISTER_OP_CPU_KERNEL(
     dropout_grad,
     ops::DropoutGradKernel<paddle::platform::CPUDeviceContext, float>);

--- a/paddle/fluid/operators/dropout_op.h
+++ b/paddle/fluid/operators/dropout_op.h
@@ -25,7 +25,7 @@ template <typename T, int MajorType = Eigen::RowMajor,
           typename IndexType = Eigen::DenseIndex>
 using EigenMatrix = framework::EigenMatrix<T, MajorType, IndexType>;
 
-template <typename DeviceContext, typename T, typename AttrType>
+template <typename DeviceContext, typename T>
 class CPUDropoutKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {

--- a/paddle/fluid/platform/float16.h
+++ b/paddle/fluid/platform/float16.h
@@ -490,6 +490,7 @@ HOSTDEVICE inline float16 operator+(const float16& a, const float16& b) {
   return float16(__hadd(half(a), half(b)));
 #else
   return float16(float(a) + float(b));
+#endif
 }
 
 HOSTDEVICE inline float16 operator-(const float16& a, const float16& b) {
@@ -497,6 +498,7 @@ HOSTDEVICE inline float16 operator-(const float16& a, const float16& b) {
   return float16(__hsub(half(a), half(b)));
 #else
   return float16(float(a) - float(b));
+#endif
 }
 
 HOSTDEVICE inline float16 operator*(const float16& a, const float16& b) {
@@ -504,6 +506,7 @@ HOSTDEVICE inline float16 operator*(const float16& a, const float16& b) {
   return float16(__hmul(half(a), half(b)));
 #else
   return float16(float(a) * float(b));
+#endif
 }
 
 HOSTDEVICE inline float16 operator/(const float16& a, const float16& b) {
@@ -514,6 +517,7 @@ HOSTDEVICE inline float16 operator/(const float16& a, const float16& b) {
   return float16(num / denom);
 #else
   return float16(float(a) / float(b));
+#endif
 }
 
 HOSTDEVICE inline float16 operator-(const float16& a) {
@@ -523,6 +527,7 @@ HOSTDEVICE inline float16 operator-(const float16& a) {
   float16 res;
   res.x = a.x ^ 0x8000;
   return res;
+#endif
 }
 
 HOSTDEVICE inline float16& operator+=(float16& a, const float16& b) {
@@ -550,6 +555,7 @@ HOSTDEVICE inline bool operator==(const float16& a, const float16& b) {
   return __heq(half(a), half(b));
 #else
   return float(a) == float(b);
+#endif
 }
 
 HOSTDEVICE inline bool operator!=(const float16& a, const float16& b) {
@@ -557,6 +563,7 @@ HOSTDEVICE inline bool operator!=(const float16& a, const float16& b) {
   return __hne(half(a), half(b));
 #else
   return float(a) != float(b);
+#endif
 }
 
 HOSTDEVICE inline bool operator<(const float16& a, const float16& b) {
@@ -564,6 +571,7 @@ HOSTDEVICE inline bool operator<(const float16& a, const float16& b) {
   return __hlt(half(a), half(b));
 #else
   return float(a) < float(b);
+#endif
 }
 
 HOSTDEVICE inline bool operator<=(const float16& a, const float16& b) {
@@ -571,6 +579,7 @@ HOSTDEVICE inline bool operator<=(const float16& a, const float16& b) {
   return __hle(half(a), half(b));
 #else
   return float(a) <= float(b);
+#endif
 }
 
 HOSTDEVICE inline bool operator>(const float16& a, const float16& b) {
@@ -578,6 +587,7 @@ HOSTDEVICE inline bool operator>(const float16& a, const float16& b) {
   return __hgt(half(a), half(b));
 #else
   return float(a) > float(b);
+#endif
 }
 
 HOSTDEVICE inline bool operator>=(const float16& a, const float16& b) {
@@ -585,6 +595,7 @@ HOSTDEVICE inline bool operator>=(const float16& a, const float16& b) {
   return __hge(half(a), half(b));
 #else
   return float(a) >= float(b);
+#endif
 }
 
 // Arithmetic operators for float16 on ARMv8.2-A CPU

--- a/paddle/fluid/platform/float16.h
+++ b/paddle/fluid/platform/float16.h
@@ -484,72 +484,107 @@ DEVICE inline bool operator>=(const half& a, const half& b) {
 #endif  // PADDLE_CUDA_FP16
 
 // Arithmetic operators for float16 on GPU
-#if defined(PADDLE_CUDA_FP16) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
-DEVICE inline float16 operator+(const float16& a, const float16& b) {
+#if defined(PADDLE_CUDA_FP16)
+HOSTDEVICE inline float16 operator+(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return float16(__hadd(half(a), half(b)));
+#else
+  return float16(float(a) + float(b));
 }
 
-DEVICE inline float16 operator-(const float16& a, const float16& b) {
+HOSTDEVICE inline float16 operator-(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return float16(__hsub(half(a), half(b)));
+#else
+  return float16(float(a) - float(b));
 }
 
-DEVICE inline float16 operator*(const float16& a, const float16& b) {
+HOSTDEVICE inline float16 operator*(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return float16(__hmul(half(a), half(b)));
+#else
+  return float16(float(a) * float(b));
 }
 
-DEVICE inline float16 operator/(const float16& a, const float16& b) {
-  // TODO(kexinzhao): check the cuda version that starts to support __hdiv
+HOSTDEVICE inline float16 operator/(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 300
+  // TODO(kexinzhao): check which cuda version starts to support __hdiv
   float num = __half2float(half(a));
   float denom = __half2float(half(b));
   return float16(num / denom);
+#else
+  return float16(float(a) / float(b));
 }
 
-DEVICE inline float16 operator-(const float16& a) {
+HOSTDEVICE inline float16 operator-(const float16& a) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return float16(__hneg(half(a)));
+#else
+  float16 res;
+  res.x = a.x ^ 0x8000;
+  return res;
 }
 
-DEVICE inline float16& operator+=(float16& a, const float16& b) {
+HOSTDEVICE inline float16& operator+=(float16& a, const float16& b) {
   a = a + b;
   return a;
 }
 
-DEVICE inline float16& operator-=(float16& a, const float16& b) {
+HOSTDEVICE inline float16& operator-=(float16& a, const float16& b) {
   a = a - b;
   return a;
 }
 
-DEVICE inline float16& operator*=(float16& a, const float16& b) {
+HOSTDEVICE inline float16& operator*=(float16& a, const float16& b) {
   a = a * b;
   return a;
 }
 
-DEVICE inline float16& operator/=(float16& a, const float16& b) {
+HOSTDEVICE inline float16& operator/=(float16& a, const float16& b) {
   a = a / b;
   return a;
 }
 
-DEVICE inline bool operator==(const float16& a, const float16& b) {
+HOSTDEVICE inline bool operator==(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return __heq(half(a), half(b));
+#else
+  return float(a) == float(b);
 }
 
-DEVICE inline bool operator!=(const float16& a, const float16& b) {
+HOSTDEVICE inline bool operator!=(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return __hne(half(a), half(b));
+#else
+  return float(a) != float(b);
 }
 
-DEVICE inline bool operator<(const float16& a, const float16& b) {
+HOSTDEVICE inline bool operator<(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return __hlt(half(a), half(b));
+#else
+  return float(a) < float(b);
 }
 
-DEVICE inline bool operator<=(const float16& a, const float16& b) {
+HOSTDEVICE inline bool operator<=(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return __hle(half(a), half(b));
+#else
+  return float(a) <= float(b);
 }
 
-DEVICE inline bool operator>(const float16& a, const float16& b) {
+HOSTDEVICE inline bool operator>(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return __hgt(half(a), half(b));
+#else
+  return float(a) > float(b);
 }
 
-DEVICE inline bool operator>=(const float16& a, const float16& b) {
+HOSTDEVICE inline bool operator>=(const float16& a, const float16& b) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 530
   return __hge(half(a), half(b));
+#else
+  return float(a) >= float(b);
 }
 
 // Arithmetic operators for float16 on ARMv8.2-A CPU
@@ -737,71 +772,71 @@ HOST inline bool operator>=(const float16& a, const float16& b) {
   return (res & 0xffff) != 0;
 }
 
-// Arithmetic operators for float16, software emulated on other CPU/GPU
+// Arithmetic operators for float16, software emulated on other CPU
 #else
-HOSTDEVICE inline float16 operator+(const float16& a, const float16& b) {
+HOST inline float16 operator+(const float16& a, const float16& b) {
   return float16(float(a) + float(b));
 }
 
-HOSTDEVICE inline float16 operator-(const float16& a, const float16& b) {
+HOST inline float16 operator-(const float16& a, const float16& b) {
   return float16(float(a) - float(b));
 }
 
-HOSTDEVICE inline float16 operator*(const float16& a, const float16& b) {
+HOST inline float16 operator*(const float16& a, const float16& b) {
   return float16(float(a) * float(b));
 }
 
-HOSTDEVICE inline float16 operator/(const float16& a, const float16& b) {
+HOST inline float16 operator/(const float16& a, const float16& b) {
   return float16(float(a) / float(b));
 }
 
-HOSTDEVICE inline float16 operator-(const float16& a) {
+HOST inline float16 operator-(const float16& a) {
   float16 res;
   res.x = a.x ^ 0x8000;
   return res;
 }
 
-HOSTDEVICE inline float16& operator+=(float16& a, const float16& b) {
+HOST inline float16& operator+=(float16& a, const float16& b) {
   a = float16(float(a) + float(b));
   return a;
 }
 
-HOSTDEVICE inline float16& operator-=(float16& a, const float16& b) {
+HOST inline float16& operator-=(float16& a, const float16& b) {
   a = float16(float(a) - float(b));
   return a;
 }
 
-HOSTDEVICE inline float16& operator*=(float16& a, const float16& b) {
+HOST inline float16& operator*=(float16& a, const float16& b) {
   a = float16(float(a) * float(b));
   return a;
 }
 
-HOSTDEVICE inline float16& operator/=(float16& a, const float16& b) {
+HOST inline float16& operator/=(float16& a, const float16& b) {
   a = float16(float(a) / float(b));
   return a;
 }
 
-HOSTDEVICE inline bool operator==(const float16& a, const float16& b) {
+HOST inline bool operator==(const float16& a, const float16& b) {
   return float(a) == float(b);
 }
 
-HOSTDEVICE inline bool operator!=(const float16& a, const float16& b) {
+HOST inline bool operator!=(const float16& a, const float16& b) {
   return float(a) != float(b);
 }
 
-HOSTDEVICE inline bool operator<(const float16& a, const float16& b) {
+HOST inline bool operator<(const float16& a, const float16& b) {
   return float(a) < float(b);
 }
 
-HOSTDEVICE inline bool operator<=(const float16& a, const float16& b) {
+HOST inline bool operator<=(const float16& a, const float16& b) {
   return float(a) <= float(b);
 }
 
-HOSTDEVICE inline bool operator>(const float16& a, const float16& b) {
+HOST inline bool operator>(const float16& a, const float16& b) {
   return float(a) > float(b);
 }
 
-HOSTDEVICE inline bool operator>=(const float16& a, const float16& b) {
+HOST inline bool operator>=(const float16& a, const float16& b) {
   return float(a) >= float(b);
 }
 #endif

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -14,6 +14,7 @@
 
 import unittest
 import numpy as np
+import paddle.fluid.core as core
 from op_test import OpTest
 
 

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -86,10 +86,13 @@ class TestDropoutOp5(OpTest):
 class TestFP16DropoutOp1(OpTest):
     def setUp(self):
         x = np.random.random((32, 64)).astype("float16")
+        prob = 0.35
+        out = x * (1.0 - prob)
+
         self.op_type = "dropout"
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
-        self.attrs = {'dropout_prob': 0.35, 'fix_seed': True, 'is_test': True}
-        self.outputs = {'Out': x * (1.0 - self.attrs['dropout_prob'])}
+        self.attrs = {'dropout_prob': prob, 'fix_seed': True, 'is_test': True}
+        self.outputs = {'Out': out}
 
     def test_check_output(self):
         if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
@@ -99,10 +102,13 @@ class TestFP16DropoutOp1(OpTest):
 class TestFP16DropoutOp2(OpTest):
     def setUp(self):
         x = np.random.random((32, 64, 3)).astype("float16")
+        prob = 0.75
+        out = x * (1.0 - prob)
+
         self.op_type = "dropout"
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
-        self.attrs = {'dropout_prob': 0.75, 'is_test': True}
-        self.outputs = {'Out': x * (1.0 - self.attrs['dropout_prob'])}
+        self.attrs = {'dropout_prob': prob, 'is_test': True}
+        self.outputs = {'Out': out}
 
     def test_check_output(self):
         if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -82,5 +82,31 @@ class TestDropoutOp5(OpTest):
         self.check_output()
 
 
+class TestFP16DropoutOp1(OpTest):
+    def setUp(self):
+        x = np.random.random((32, 64)).astype("float16")
+        self.op_type = "dropout"
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.attrs = {'dropout_prob': 0.35, 'fix_seed': True, 'is_test': True}
+        self.outputs = {'Out': x * (1.0 - self.attrs['dropout_prob'])}
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
+            self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+
+
+class TestFP16DropoutOp2(OpTest):
+    def setUp(self):
+        x = np.random.random((32, 64, 3)).astype("float16")
+        self.op_type = "dropout"
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.attrs = {'dropout_prob': 0.75, 'is_test': True}
+        self.outputs = {'Out': x * (1.0 - self.attrs['dropout_prob'])}
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
+            self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -83,36 +83,36 @@ class TestDropoutOp5(OpTest):
         self.check_output()
 
 
-class TestFP16DropoutOp1(OpTest):
+class TestFP16DropoutOp(OpTest):
     def setUp(self):
-        x = np.random.random((32, 64)).astype("float16")
-        prob = 0.35
-        out = x * (1.0 - prob)
-
         self.op_type = "dropout"
+        self.init_test_case()
+
+        x = np.random.random(self.input_size).astype("float16")
+        out = x * (1.0 - self.prob)
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
-        self.attrs = {'dropout_prob': prob, 'fix_seed': True, 'is_test': True}
+        self.attrs = {
+            'dropout_prob': self.prob,
+            'fix_seed': self.fix_seed,
+            'is_test': True
+        }
         self.outputs = {'Out': out}
+
+    def init_test_case(self):
+        self.input_size = [32, 64]
+        self.prob = 0.35
+        self.fix_seed = True
 
     def test_check_output(self):
         if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
             self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
 
 
-class TestFP16DropoutOp2(OpTest):
-    def setUp(self):
-        x = np.random.random((32, 64, 3)).astype("float16")
-        prob = 0.75
-        out = x * (1.0 - prob)
-
-        self.op_type = "dropout"
-        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
-        self.attrs = {'dropout_prob': prob, 'is_test': True}
-        self.outputs = {'Out': out}
-
-    def test_check_output(self):
-        if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
-            self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+class TestFP16DropoutOp2(TestFP16DropoutOp):
+    def init_test_case(self):
+        self.input_size = [32, 64, 3]
+        self.prob = 0.75
+        self.fix_seed = False
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
fix #9222 

Added device function for multiplying two float16 numbers on GPU device, which is needed in the following code:
``` cpp
Y.device(place) = X * static_cast<T>(1.0f - dropout_prob);
```
