### PR TITLE
"fast hack"

### DIFF
--- a/paddle/fluid/operators/dropout_op.cu
+++ b/paddle/fluid/operators/dropout_op.cu
@@ -33,6 +33,7 @@ __global__ void RandomGenerator(const size_t n, const int seed,
 
   int idx = blockDim.x * blockIdx.x + threadIdx.x;
   for (; idx < n; idx += blockDim.x * gridDim.x) {
+    rng.discard(idx);
     if (dist(rng) < dropout_prob) {
       mask_data[idx] = static_cast<T>(0);
     } else {


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/9144 and https://github.com/PaddlePaddle/Paddle/issues/8654
The numpy test can not align with stl and cuda, the cpp and cuda test will be added later.