### PR TITLE
fix submit_local's paddle pip name issue

### DIFF
--- a/paddle/scripts/submit_local.sh.in
+++ b/paddle/scripts/submit_local.sh.in
@@ -153,9 +153,15 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-INSTALLED_VERSION=`pip freeze 2>/dev/null | grep '^paddle' | sed 's/.*==//g'`
+if [ "@WITH_GPU@" == "ON" ]; then
+    PADDLE_NAME="paddlepaddle-gpu"
+else 
+    PADDLE_NAME="paddlepaddle"
+fi
 
-if [ -z ${INSTALLED_VERSION} ]; then
+INSTALLED_VERSION=`pip freeze 2>/dev/null | grep "^${PADDLE_NAME}==" | sed 's/.*==//g'`
+
+if [ -z "${INSTALLED_VERSION}" ]; then
    INSTALLED_VERSION="0.0.0"  # not installed
 fi
 cat <<EOF | python -


### PR DESCRIPTION
fix: #9391 
fix #7476

the issue is about syntax issue when run the default command "paddle version" from production docker image.
``` bash
[root@k8s-node1 ~]# docker run --rm -it putcn/paddle:pro
/usr/local/bin/paddle: line 158: [: 0.10.0: binary operator expected
  File "<stdin>", line 3
    if LooseVersion("0.10.0
                          ^
SyntaxError: EOL while scanning string literal
```

the fix is to adding a pair of missing quote, and corrected the logic grabbing the current paddle version