### PR TITLE
remove superfluous 0 from lod

### DIFF
--- a/paddle/fluid/operators/ctc_align_op.cu
+++ b/paddle/fluid/operators/ctc_align_op.cu
@@ -76,6 +76,9 @@ class CTCAlignOpCUDAKernel : public framework::OpKernel<T> {
     // set output lod
     std::vector<size_t> host_out_lod0(dev_out_lod0.begin(), dev_out_lod0.end());
     framework::LoD out_lod;
+    if (host_out_lod0.back() == 0) {
+      host_out_lod0.resize(1);
+    }
     out_lod.push_back(host_out_lod0);
     output->set_lod(out_lod);
 


### PR DESCRIPTION
In some cases, all output sequences were empty, therefore, the LOD should be  [[0]] rather than [[0, 0]].

[https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/nn.py#L2665](url)