### PR TITLE
Use a threadpool for each device

### DIFF
--- a/paddle/fluid/framework/details/multi_devices_graph_builder.cc
+++ b/paddle/fluid/framework/details/multi_devices_graph_builder.cc
@@ -76,6 +76,7 @@ std::unique_ptr<SSAGraph> MultiDevSSAGraphBuilder::Build(
       auto *op_handle = result.ops_.back().get();
       op_handle->dev_ctxes_[p] = const_cast<platform::DeviceContext *>(
           platform::DeviceContextPool::Instance().Get(p));
+      op_handle->dev_id_ = i;
 
       auto var_names = op->InputArgumentNames();
 

--- a/paddle/fluid/framework/details/op_handle_base.h
+++ b/paddle/fluid/framework/details/op_handle_base.h
@@ -32,6 +32,7 @@ class OpHandleBase {
   std::unordered_map<platform::Place, platform::DeviceContext *,
                      platform::PlaceHash>
       dev_ctxes_;
+  size_t dev_id_ = 0;
 
 #ifdef PADDLE_WITH_CUDA
   std::unordered_map<int, cudaEvent_t> events_;

--- a/paddle/fluid/framework/details/threaded_ssa_graph_executor.h
+++ b/paddle/fluid/framework/details/threaded_ssa_graph_executor.h
@@ -67,7 +67,7 @@ class BlockingQueue {
 
 class ThreadedSSAGraphExecutor : public SSAGraphExecutor {
  public:
-  ThreadedSSAGraphExecutor(size_t num_threads, bool use_event,
+  ThreadedSSAGraphExecutor(size_t per_place_threads, bool use_event,
                            const std::vector<Scope *> &local_scopes,
                            const std::vector<platform::Place> &places,
                            std::unique_ptr<SSAGraph> &&graph);
@@ -83,7 +83,7 @@ class ThreadedSSAGraphExecutor : public SSAGraphExecutor {
              details::OpHandleBase *op);
 
  private:
-  std::unique_ptr<::ThreadPool> pool_;
+  std::vector<std::unique_ptr<::ThreadPool>> pools_;
   std::vector<Scope *> local_scopes_;
   std::vector<platform::Place> places_;
   platform::DeviceContextPool fetch_ctxs_;

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -43,7 +43,7 @@ class ParallelExecutorPrivate {
 };
 
 ParallelExecutor::ParallelExecutor(
-    size_t num_threads, bool use_event,
+    size_t per_place_threads, bool use_event,
     const std::vector<platform::Place> &places,
     const std::unordered_set<std::string> &params,
     const ProgramDesc &startup_program, const ProgramDesc &main_program,
@@ -82,7 +82,7 @@ ParallelExecutor::ParallelExecutor(
   auto graph = builder.Build(main_program);
 
   member_->executor_.reset(new details::ThreadedSSAGraphExecutor(
-      num_threads, use_event, member_->local_scopes_, places,
+      per_place_threads, use_event, member_->local_scopes_, places,
       std::move(graph)));
 
   // Step 3. Create vars in each scope;

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -32,7 +32,7 @@ class ParallelExecutor {
   DISABLE_COPY_AND_ASSIGN(ParallelExecutor);
 
  public:
-  explicit ParallelExecutor(size_t num_threads, bool use_event,
+  explicit ParallelExecutor(size_t per_place_threads, bool use_event,
                             const std::vector<platform::Place>& places,
                             const std::unordered_set<std::string>& params,
                             const ProgramDesc& startup_program,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -499,13 +499,13 @@ All parameter, weight, gradient are variables in Paddle.
 
   py::class_<ParallelExecutor>(m, "ParallelExecutor")
       .def("__init__",
-           [](ParallelExecutor &self, size_t num_threads, bool use_event,
+           [](ParallelExecutor &self, size_t per_place_threads, bool use_event,
               const std::vector<platform::Place> &places,
               const std::unordered_set<std::string> &params,
               const ProgramDesc &startup_program,
               const ProgramDesc &main_program, const std::string &loss_var_name,
               Scope *scope) {
-             new (&self) ParallelExecutor(num_threads, use_event, places,
+             new (&self) ParallelExecutor(per_place_threads, use_event, places,
                                           params, startup_program, main_program,
                                           loss_var_name, scope);
            })


### PR DESCRIPTION
Currently, I find ParallelExecutor could hang
on for some models. When use a threadpool for
each device, and set num_threads=1, problem is
solved. (However, we should still fix it)