### PR TITLE
fix compiler error on `tensor_py.h`

### DIFF
--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
+#include <Python.h>
 #include <string>
 #include <tuple>
 #include <vector>


### PR DESCRIPTION
fix #9722 