### PR TITLE
refine sync_with_cpp for insert_op

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -913,6 +913,15 @@ class Block(object):
                     ops_in_cpp_index += 1
                     ops_in_python_index += 1
 
+        # sync ops inserted from c++ end
+        if len(self.ops) != len(ops_in_cpp) and start_index == 0 and len(
+                self.ops) == end_index:
+            self.ops.clear()
+            for index in range(len(ops_in_cpp)):
+                op_desc = ops_in_cpp[index]
+                op = Operator(self, op_desc)
+                self.ops.append(op)
+
         assert len(self.ops) == len(ops_in_cpp)
         for index in range(len(self.ops)):
             assert self.ops[index].desc == ops_in_cpp[index]

--- a/python/paddle/fluid/tests/unittests/test_protobuf_descs.py
+++ b/python/paddle/fluid/tests/unittests/test_protobuf_descs.py
@@ -175,13 +175,20 @@ class TestBlockDesc(unittest.TestCase):
         self.assertEqual(var2_re, var2)
 
     def test_add_op(self):
-        program_desc = core.ProgramDesc()
+        program = Program()
+        program_desc = program.desc
         self.assertIsNotNone(program_desc)
         block = program_desc.block(0)
         self.assertIsNotNone(block)
-        op1 = block.append_op()
         op2 = block.append_op()
         op0 = block.prepend_op()
+        op1 = block.insert_op(1)
+        op0.set_type("test")
+        op1.set_type("test")
+        op2.set_type("test")
+
+        program.sync_with_cpp()
+
         all_ops = []
         for idx in xrange(0, block.op_size()):
             all_ops.append(block.op(idx))


### PR DESCRIPTION
related #9629.
When use `insert_op` method for stage 1, there is error in `sync_with_cpp`.  The reason is that `sync_with_cpp` only consider `remove_op`, `append_op`, `prepend_op`, `remove_var` now, but don't consider `insert_op`. 

Thus, this PR consider `insert_op` in `sync_with_cpp`, and add a unit test to check the `sync_with_cpp` after calling `append_op`, `prepend_op` and `insert_op`.