### PR TITLE
Fix lost of LoD while splitting tensor in parallel executor.

### DIFF
--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -181,10 +181,10 @@ void ParallelExecutor::SplitTensorToPlaces(
         member_->places_.size(), lod_tensors.size());
     for (size_t j = 0; j < member_->places_.size(); ++j) {
       // TODO(panxy0718): Do I need to delete this var?
-      member_->local_scopes_[j]
-          ->Var(it.first)
-          ->GetMutable<LoDTensor>()
-          ->ShareDataWith(lod_tensors[j]);
+      auto t =
+          member_->local_scopes_[j]->Var(it.first)->GetMutable<LoDTensor>();
+      t->ShareDataWith(lod_tensors[j]);
+      t->set_lod(lod_tensors[j].lod());
     }
   }
 }


### PR DESCRIPTION
`ShareDataWith` can't share the LoD of target Tensor. An explicit setting is necessary to avoid none LoD or wrong LoD.