### PR TITLE
fix compiler error in paddle:latest-dev image

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 file(GLOB UTILS_PY_FILES . ./paddle/utils/*.py)
-file(GLOB_RECURSE FLUID_PY_FILES ./paddle/fluid/ *.py)
+file(GLOB_RECURSE FLUID_PY_FILES ./paddle/fluid/*.py)
 set(PY_FILES paddle/__init__.py
   ${UTILS_PY_FILES}
   ${FLUID_PY_FILES})
@@ -7,7 +7,7 @@ set(PY_FILES paddle/__init__.py
 if(NOT WITH_FLUID_ONLY)
   file(GLOB TRAINER_PY_FILES . ./paddle/trainer/*.py)
   file(GLOB HELPERS_PY_FILES . ./paddle/trainer_config_helpers/*.py)
-  file(GLOB_RECURSE V2_PY_FILES ./paddle/v2/ *.py)
+  file(GLOB_RECURSE V2_PY_FILES ./paddle/v2/*.py)
   set(PY_FILES ${PY_FILES}
     ${TRAINER_PY_FILES}
     ${HELPERS_PY_FILES}
@@ -55,7 +55,7 @@ add_custom_target(copy_paddle_pybind ALL DEPENDS ${PADDLE_BINARY_DIR}/python/pad
 
 add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
     COMMAND touch stub.cc
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python/paddle
+    COMMAND cp -r ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python
     COMMAND cp -r ${PADDLE_SOURCE_DIR}/paddle/py_paddle ${PADDLE_BINARY_DIR}/python/
     COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel
     COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp


### PR DESCRIPTION
fix #9906 
The reason is that original `file(GLOB_RECURSE FLUID_PY_FILES ./paddle/fluid/ *.py)` will add `paddle/v2` files.

After fix #9906, there is compile error:
```
Error copying directory from "/Paddle/python/paddle" to 
"/Paddle/docker_build/python/paddle".
python/CMakeFiles/paddle_python.dir/build.make:352: recipe for target 
'python/build/.timestamp' failed
make[2]: *** [python/build/.timestamp] Error 1
CMakeFiles/Makefile2:30120: recipe for target 'python/CMakeFiles/paddle_python.dir/all' 
failed
make[1]: *** [python/CMakeFiles/paddle_python.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
```
Thus, change `COMMAND ${CMAKE_COMMAND} -E copy_directory` to `COMMAND cp -r`