### PR TITLE
Add HIP support to fluid/platform and fluid/operators/nccl.

### DIFF
--- a/paddle/fluid/operators/nccl/CMakeLists.txt
+++ b/paddle/fluid/operators/nccl/CMakeLists.txt
@@ -1,3 +1,5 @@
 if(WITH_GPU)
   nv_library(nccl_common SRCS nccl_gpu_common.cc DEPS device_context operator )
+elseif(WITH_AMD_GPU)
+  hip_library(nccl_common SRCS nccl_gpu_common.cc DEPS device_context operator )
 endif()

--- a/paddle/fluid/operators/nccl/CMakeLists.txt
+++ b/paddle/fluid/operators/nccl/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(WITH_GPU)
   nv_library(nccl_common SRCS nccl_gpu_common.cc DEPS device_context operator )
 elseif(WITH_AMD_GPU)
-  hip_library(nccl_common SRCS nccl_gpu_common.cc DEPS device_context operator )
+  hip_library(nccl_common SRCS rccl_gpu_common.cc DEPS device_context operator )
 endif()

--- a/paddle/fluid/operators/nccl/rccl_gpu_common.cc
+++ b/paddle/fluid/operators/nccl/rccl_gpu_common.cc
@@ -19,7 +19,7 @@ namespace paddle {
 namespace platform {
 namespace {
 // TODO(panyx0718): Where to destroy them.
-std::unique_ptr<std::vector<ncclComm_t>> global_comms;
+std::unique_ptr<std::vector<rcclComm_t>> global_comms;
 std::unique_ptr<std::unordered_map<int, int>> comm_id_map;
 bool inited = false;
 size_t last_num_gpus = -1;
@@ -42,21 +42,22 @@ void Communicator::InitAll(const std::vector<int>& gpus) {
   if (global_comms) {
     for (size_t i = 0; i < global_comms->size(); ++i) {
       // FIXME(dzh) : PADDLE_ENFORCE return void
-      dynload::ncclCommDestroy((*global_comms)[i]);
+      dynload::rcclCommDestroy((*global_comms)[i]);
     }
   }
-  global_comms.reset(new std::vector<ncclComm_t>());
+  global_comms.reset(new std::vector<rcclComm_t>());
   comm_id_map.reset(new std::unordered_map<int, int>());
   global_comms->resize(gpus.size());
   for (size_t i = 0; i < gpus.size(); ++i) {
     (*comm_id_map)[gpus[i]] = i;
   }
-  PADDLE_ENFORCE(
-      dynload::ncclCommInitAll(global_comms->data(), gpus.size(), gpus.data()));
+  PADDLE_ENFORCE(dynload::rcclCommInitAll(global_comms->data(),
+                                          static_cast<int> gpus.size(),
+                                          static_cast<int*> gpus.data()));
   inited = true;
 }
 
-const std::vector<ncclComm_t>& Communicator::comms() const {
+const std::vector<rcclComm_t>& Communicator::comms() const {
   std::lock_guard<std::mutex> guard(comm_mu);
   return *global_comms;
 }

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -13,6 +13,8 @@ add_custom_command(TARGET profiler_py_proto POST_BUILD
 
 if(WITH_GPU)
   cc_library(enforce SRCS enforce.cc DEPS)
+elseif(WITH_AMD_GPU)
+  cc_library(enforce SRCS enforce.cc DEPS)
 else()
   cc_library(enforce SRCS enforce.cc)
 endif()
@@ -22,6 +24,7 @@ cc_library(cpu_info SRCS cpu_info.cc DEPS gflags glog enforce)
 cc_test(cpu_info_test SRCS cpu_info_test.cc DEPS cpu_info)
 
 nv_library(gpu_info SRCS gpu_info.cc DEPS gflags glog enforce)
+hip_library(gpu_info SRCS gpu_info_hip.cc DEPS gflags glog enforce)
 
 cc_library(place SRCS place.cc DEPS enforce boost)
 cc_test(place_test SRCS place_test.cc DEPS place glog gflags)
@@ -30,6 +33,8 @@ add_subdirectory(dynload)
 
 IF(WITH_GPU)
     set(GPU_CTX_DEPS dynload_cuda dynamic_loader)
+ELSEIF(WITH_AMD_GPU)
+    set(GPU_CTX_DEPS dynload_hip dynamic_loader)
 ELSE()
     set(GPU_CTX_DEPS)
 ENDIF()
@@ -45,13 +50,19 @@ ENDIF()
 cc_library(device_context SRCS device_context.cc DEPS malloc
     place eigen3 ${GPU_CTX_DEPS} ${MKLDNN_CTX_DEPS})
 nv_test(device_context_test SRCS device_context_test.cu DEPS device_context gpu_info)
+hip_test(device_context_test SRCS device_context_test.cu DEPS device_context gpu_info)
 
 nv_test(cudnn_helper_test SRCS cudnn_helper_test.cc DEPS dynload_cuda)
+hip_test(miopen_helper_test SRCS miopen_helper_test.cc DEPS dynload_hip)
 nv_test(transform_test SRCS transform_test.cu DEPS memory place device_context)
+hip_test(transform_test SRCS transform_test.cu DEPS memory place device_context)
 
 cc_library(device_tracer SRCS device_tracer.cc DEPS boost profiler_proto ${GPU_CTX_DEPS})
 cc_library(profiler SRCS profiler.cc DEPS device_context device_tracer)
 cc_test(profiler_test SRCS profiler_test.cc DEPS profiler)
 
-nv_test(float16_gpu_test SRCS float16_test.cu)
-cc_test(float16_test SRCS float16_test.cc)
+# These tests depends on framework support, will be enabled later.
+if(NOT WITH_AMD_GPU)
+  nv_test(float16_gpu_test SRCS float16_test.cu)
+  cc_test(float16_test SRCS float16_test.cc)
+endif()

--- a/paddle/fluid/platform/assert.h
+++ b/paddle/fluid/platform/assert.h
@@ -36,6 +36,24 @@ limitations under the License. */
       asm("trap;");                                                     \
     }                                                                   \
   } while (0)
+#elif defined(__HIP_DEVICE_COMPILE__) && !defined(NDEBUG)
+#include <stdio.h>
+#define PADDLE_ASSERT(e)                                           \
+  do {                                                             \
+    if (!(e)) {                                                    \
+      printf("%s:%d Assertion `%s` failed.\n", __FILE__, __LINE__, \
+             TOSTRING(e));                                         \
+    }                                                              \
+  } while (0)
+
+#define PADDLE_ASSERT_MSG(e, m)                                         \
+  do {                                                                  \
+    if (!(e)) {                                                         \
+      printf("%s:%d Assertion `%s` failed (%s).\n", __FILE__, __LINE__, \
+             TOSTRING(e), m);                                           \
+    }                                                                   \
+  } while (0)
+
 #else
 #include <assert.h>
 #define PADDLE_ASSERT(e) assert(e)

--- a/paddle/fluid/platform/cuda_helper.h
+++ b/paddle/fluid/platform/cuda_helper.h
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
+#ifdef PADDLE_WITH_HIP
+#include <hip/hip_runtime.h>
+#else
 #include <cuda.h>
+#endif
 
 namespace paddle {
 namespace platform {

--- a/paddle/fluid/platform/cuda_profiler.h
+++ b/paddle/fluid/platform/cuda_profiler.h
@@ -13,7 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
+#ifdef PADDLE_WITH_HIP
+#include "hip/hip_runtime_api.h"
+#else
 #include <cuda_profiler_api.h>
+#endif
 
 #include <string>
 
@@ -21,6 +25,17 @@ limitations under the License. */
 
 namespace paddle {
 namespace platform {
+
+#ifdef PADDLE_WITH_HIP
+void CudaProfilerInit(std::string output_file, std::string output_mode,
+                      std::string config_file) {
+}
+
+void CudaProfilerStart() { PADDLE_ENFORCE(hipProfilerStart()); }
+
+void CudaProfilerStop() { PADDLE_ENFORCE(hipProfilerStop()); }
+
+#else
 
 void CudaProfilerInit(std::string output_file, std::string output_mode,
                       std::string config_file) {
@@ -34,5 +49,6 @@ void CudaProfilerStart() { PADDLE_ENFORCE(cudaProfilerStart()); }
 
 void CudaProfilerStop() { PADDLE_ENFORCE(cudaProfilerStop()); }
 
+#endif
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/cuda_profiler.h
+++ b/paddle/fluid/platform/cuda_profiler.h
@@ -28,8 +28,7 @@ namespace platform {
 
 #ifdef PADDLE_WITH_HIP
 void CudaProfilerInit(std::string output_file, std::string output_mode,
-                      std::string config_file) {
-}
+                      std::string config_file) {}
 
 void CudaProfilerStart() { PADDLE_ENFORCE(hipProfilerStart()); }
 

--- a/paddle/fluid/platform/details/cuda_transform_iterator_cast.h
+++ b/paddle/fluid/platform/details/cuda_transform_iterator_cast.h
@@ -14,7 +14,7 @@ limitations under the License. */
 
 #pragma once
 
-#ifndef __NVCC__
+#if !(defined(__NVCC__) || defined(__HIPCC__))
 #error device_ptr_cast must be include by .cu file
 #endif
 

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -50,7 +50,7 @@ DeviceContextPool::DeviceContextPool(
           p, PtrType(new CPUDeviceContext(boost::get<CPUPlace>(p))));
 #endif
     } else if (platform::is_gpu_place(p)) {
-#ifdef PADDLE_WITH_CUDA
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP))
       device_contexts_.emplace(
           p, PtrType(new CUDADeviceContext(boost::get<CUDAPlace>(p))));
 #else
@@ -59,7 +59,7 @@ DeviceContextPool::DeviceContextPool(
           "option");
 #endif
     } else if (platform::is_cuda_pinned_place(p)) {
-#ifdef PADDLE_WITH_CUDA
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP))
       device_contexts_.emplace(
           p,
           PtrType(new CUDAPinnedDeviceContext(boost::get<CUDAPinnedPlace>(p))));
@@ -199,6 +199,136 @@ cublasHandle_t CUDADeviceContext::cublas_handle() const {
 cudnnHandle_t CUDADeviceContext::cudnn_handle() const { return cudnn_handle_; }
 
 cudaStream_t CUDADeviceContext::stream() const { return stream_; }
+
+CUDAPinnedDeviceContext::CUDAPinnedDeviceContext() {
+  eigen_device_.reset(new Eigen::DefaultDevice());
+}
+
+CUDAPinnedDeviceContext::CUDAPinnedDeviceContext(CUDAPinnedPlace place)
+    : place_(place) {
+  eigen_device_.reset(new Eigen::DefaultDevice());
+}
+
+Eigen::DefaultDevice* CUDAPinnedDeviceContext::eigen_device() const {
+  return eigen_device_.get();
+}
+
+Place CUDAPinnedDeviceContext::GetPlace() const { return place_; }
+#endif
+
+#ifdef PADDLE_WITH_HIP
+
+class EigenHipStreamDevice : public Eigen::StreamInterface {
+ public:
+  EigenHipStreamDevice() : scratch_(nullptr), semaphore_(nullptr) {
+    Eigen::initializeDeviceProp();
+  }
+  ~EigenHipStreamDevice() override {}
+
+  void Reinitialize(const hipStream_t* cuda_stream, CUDAPlace place) {
+    stream_ = cuda_stream;
+    place_ = place;
+    device_prop_ = &Eigen::m_deviceProperties[place.device];
+  }
+
+  const hipStream_t& stream() const override { return *stream_; }
+
+  const hipDeviceProp_t& deviceProperties() const override {
+    return *device_prop_;
+  }
+
+  void* allocate(size_t num_bytes) const override {
+    return paddle::memory::Alloc(place_, num_bytes);
+  }
+
+  void deallocate(void* buffer) const override {
+    paddle::memory::Free(place_, buffer);
+  }
+
+  void* scratchpad() const override {
+    if (scratch_ == NULL) {
+      scratch_ = allocate(Eigen::kHipScratchSize + sizeof(unsigned int));
+    }
+    return scratch_;
+  }
+
+  unsigned int* semaphore() const override {
+    if (semaphore_ == NULL) {
+      char* scratch =
+          static_cast<char*>(scratchpad()) + Eigen::kHipScratchSize;
+      semaphore_ = reinterpret_cast<unsigned int*>(scratch);
+      PADDLE_ENFORCE(
+          hipMemsetAsync(semaphore_, 0, sizeof(unsigned int), *stream_));
+    }
+    return semaphore_;
+  }
+
+ private:
+  CUDAPlace place_;
+  const hipStream_t* stream_;         // not owned;
+  const hipDeviceProp_t* device_prop_;  // not owned;
+  mutable void* scratch_;
+  mutable unsigned int* semaphore_;
+};
+
+CUDADeviceContext::CUDADeviceContext(CUDAPlace place) : place_(place) {
+  SetDeviceId(place_.device);
+  compute_capability = GetCUDAComputeCapability(place_.device);
+  multi_process = GetCUDAMultiProcessors(place_.device);
+  max_threads_per_mp = GetCUDAMaxThreadsPerMultiProcessor(place_.device);
+  PADDLE_ENFORCE(hipStreamCreate(&stream_));
+  eigen_stream_.reset(new EigenHipStreamDevice());
+  eigen_stream_->Reinitialize(&stream_, place);
+  eigen_device_.reset(new Eigen::GpuDevice(eigen_stream_.get()));
+  PADDLE_ENFORCE(dynload::hipblasCreate(&hipblas_handle_));
+  PADDLE_ENFORCE(dynload::hipblasSetStream(hipblas_handle_, stream_));
+  if (dynload::HasMIOpen()) {
+    PADDLE_ENFORCE(dynload::miopenCreate(&miopen_handle_));
+    PADDLE_ENFORCE(dynload::miopenSetStream(miopen_handle_, stream_));
+  } else {
+    miopen_handle_ = nullptr;
+  }
+}
+
+CUDADeviceContext::~CUDADeviceContext() {
+  SetDeviceId(place_.device);
+  Wait();
+  PADDLE_ENFORCE(dynload::hipblasDestroy(hipblas_handle_));
+  if (miopen_handle_ != nullptr) {
+    PADDLE_ENFORCE(dynload::miopenDestroy(miopen_handle_));
+  }
+  eigen_stream_.reset();
+  eigen_device_.reset();
+  PADDLE_ENFORCE(hipStreamDestroy(stream_));
+}
+
+Place CUDADeviceContext::GetPlace() const { return place_; }
+
+void CUDADeviceContext::Wait() const {
+  std::lock_guard<std::recursive_mutex> guard(mutex_);
+  PADDLE_ENFORCE(hipStreamSynchronize(stream_));
+  PADDLE_ENFORCE(hipGetLastError());
+}
+
+int CUDADeviceContext::GetComputeCapability() const {
+  return compute_capability;
+}
+
+int CUDADeviceContext::GetMaxPhysicalThreadCount() const {
+  return multi_process * max_threads_per_mp;
+}
+
+Eigen::GpuDevice* CUDADeviceContext::eigen_device() const {
+  return eigen_device_.get();
+}
+
+hipblasHandle_t CUDADeviceContext::hipblas_handle() const {
+  return hipblas_handle_;
+}
+
+miopenHandle_t CUDADeviceContext::miopen_handle() const { return miopen_handle_; }
+
+hipStream_t CUDADeviceContext::stream() const { return stream_; }
 
 CUDAPinnedDeviceContext::CUDAPinnedDeviceContext() {
   eigen_device_.reset(new Eigen::DefaultDevice());

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -254,8 +254,7 @@ class EigenHipStreamDevice : public Eigen::StreamInterface {
 
   unsigned int* semaphore() const override {
     if (semaphore_ == NULL) {
-      char* scratch =
-          static_cast<char*>(scratchpad()) + Eigen::kHipScratchSize;
+      char* scratch = static_cast<char*>(scratchpad()) + Eigen::kHipScratchSize;
       semaphore_ = reinterpret_cast<unsigned int*>(scratch);
       PADDLE_ENFORCE(
           hipMemsetAsync(semaphore_, 0, sizeof(unsigned int), *stream_));
@@ -265,7 +264,7 @@ class EigenHipStreamDevice : public Eigen::StreamInterface {
 
  private:
   CUDAPlace place_;
-  const hipStream_t* stream_;         // not owned;
+  const hipStream_t* stream_;           // not owned;
   const hipDeviceProp_t* device_prop_;  // not owned;
   mutable void* scratch_;
   mutable unsigned int* semaphore_;
@@ -326,7 +325,9 @@ hipblasHandle_t CUDADeviceContext::hipblas_handle() const {
   return hipblas_handle_;
 }
 
-miopenHandle_t CUDADeviceContext::miopen_handle() const { return miopen_handle_; }
+miopenHandle_t CUDADeviceContext::miopen_handle() const {
+  return miopen_handle_;
+}
 
 hipStream_t CUDADeviceContext::stream() const { return stream_; }
 

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -22,6 +22,13 @@ limitations under the License. */
 #define EIGEN_USE_GPU
 #endif
 
+#ifdef PADDLE_WITH_HIP
+#include "paddle/fluid/platform/dynload/hipblas.h"
+#include "paddle/fluid/platform/dynload/miopen.h"
+#include "paddle/fluid/platform/gpu_info.h"
+#define EIGEN_USE_GPU
+#endif
+
 #ifdef PADDLE_WITH_MKLDNN
 #include <mkldnn.hpp>
 #endif
@@ -115,7 +122,87 @@ class CUDADeviceContext : public DeviceContext {
   cudaStream_t stream_;
   cudnnHandle_t cudnn_handle_;
   cublasHandle_t cublas_handle_;
+  int compute_capability;
+  int multi_process;
+  int max_threads_per_mp;
+};
 
+template <>
+struct DefaultDeviceContextType<platform::CUDAPlace> {
+  using TYPE = CUDADeviceContext;
+};
+
+// Currently, CUDAPinnedDeviceContext is only used to data copying.
+class CUDAPinnedDeviceContext : public DeviceContext {
+ public:
+  CUDAPinnedDeviceContext();
+  explicit CUDAPinnedDeviceContext(CUDAPinnedPlace place);
+
+  Place GetPlace() const override;
+
+  Eigen::DefaultDevice* eigen_device() const;
+
+ private:
+  CUDAPinnedPlace place_;
+  std::unique_ptr<Eigen::DefaultDevice> eigen_device_;
+};
+
+template <>
+struct DefaultDeviceContextType<platform::CUDAPinnedPlace> {
+  using TYPE = CUDAPinnedDeviceContext;
+};
+#endif
+
+#ifdef PADDLE_WITH_HIP
+
+class EigenHipStreamDevice;
+
+class CUDADeviceContext : public DeviceContext {
+ public:
+  explicit CUDADeviceContext(CUDAPlace place);
+  virtual ~CUDADeviceContext();
+
+  /*! \brief  Wait for all operations completion in the stream. */
+  void Wait() const override;
+
+  /*! \brief  Return place in the device context. */
+  Place GetPlace() const override;
+
+  /*! \brief  Return compute capability in the device context. */
+  int GetComputeCapability() const;
+
+  /*! \brief  Return the max physical thread count in the device context */
+  int GetMaxPhysicalThreadCount() const;
+
+  /*! \brief  Return eigen device in the device context. */
+  Eigen::GpuDevice* eigen_device() const;
+
+  /*! \brief  Return hipblas handle in the device context. */
+  hipblasHandle_t hipblas_handle() const;
+
+  /*! \brief  Return miopen handle in the device context. */
+  miopenHandle_t miopen_handle() const;
+
+  /*! \brief  Return cuda stream in the device context. */
+  hipStream_t stream() const;
+
+  template <typename Callback>
+  void RecordEvent(hipEvent_t ev, Callback callback) {
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    callback();
+    PADDLE_ENFORCE(hipEventRecord(ev, stream_));
+  }
+
+ private:
+  CUDAPlace place_;
+
+  std::unique_ptr<Eigen::GpuDevice> eigen_device_;
+  std::unique_ptr<EigenHipStreamDevice> eigen_stream_;
+
+  mutable std::recursive_mutex mutex_;
+  hipStream_t stream_;
+  miopenHandle_t miopen_handle_;
+  hipblasHandle_t hipblas_handle_;
   int compute_capability;
   int multi_process;
   int max_threads_per_mp;

--- a/paddle/fluid/platform/dynload/CMakeLists.txt
+++ b/paddle/fluid/platform/dynload/CMakeLists.txt
@@ -11,4 +11,8 @@ if (CUPTI_FOUND)
     list(APPEND CUDA_SRCS cupti.cc)
 endif(CUPTI_FOUND)
 nv_library(dynload_cuda SRCS ${CUDA_SRCS} DEPS dynamic_loader)
+
+list(APPEND HIP_SRCS hipblas.cc miopen.cc hiprand.cc rccl.cc)
+hip_library(dynload_hip SRCS ${HIP_SRCS} DEPS dynamic_loader)
+
 cc_library(dynload_warpctc SRCS warpctc.cc DEPS dynamic_loader warpctc)

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -49,6 +49,17 @@ DEFINE_string(
     tensorrt_dir, "",
     "Specify path for loading tensorrt library, such as libnvinfer.so.");
 
+DEFINE_string(rocm_dir, "",
+              "Specify path for loading rocm library, such as libhipblas, "
+              "libhiprand, miopen. If default, "
+              "dlopen will search rocm from LD_LIBRARY_PATH");
+
+DEFINE_string(rccl_dir, "",
+              "Specify path for loading nccl library, such as libcublas, "
+              "libcurand. For instance, /opt/rocm/lib. If default, "
+              "dlopen will search rocm from LD_LIBRARY_PATH");
+
+
 namespace paddle {
 namespace platform {
 namespace dynload {
@@ -204,6 +215,22 @@ void* GetTensorRtDsoHandle() {
 #else
   return GetDsoHandleFromSearchPath(FLAGS_tensorrt_dir, "libnvinfer.so");
 #endif
+}
+
+void* GetMIOpenDsoHandle(){
+  return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libMIOpen.so", false);
+}
+
+void* GetHipblasDsoHandle(){
+  return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libhipblas.so");
+}
+
+void* GetHiprandDsoHandle() {
+  return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libhiprand.so");
+}
+
+void* GetRCCLDsoHandle() {
+  return GetDsoHandleFromSearchPath(FLAGS_rccl_dir, "librccl.so");
 }
 
 }  // namespace dynload

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -59,7 +59,6 @@ DEFINE_string(rccl_dir, "",
               "libcurand. For instance, /opt/rocm/lib. If default, "
               "dlopen will search rocm from LD_LIBRARY_PATH");
 
-
 namespace paddle {
 namespace platform {
 namespace dynload {
@@ -217,11 +216,11 @@ void* GetTensorRtDsoHandle() {
 #endif
 }
 
-void* GetMIOpenDsoHandle(){
+void* GetMIOpenDsoHandle() {
   return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libMIOpen.so", false);
 }
 
-void* GetHipblasDsoHandle(){
+void* GetHipblasDsoHandle() {
   return GetDsoHandleFromSearchPath(FLAGS_rocm_dir, "libhipblas.so");
 }
 

--- a/paddle/fluid/platform/dynload/hipblas.cc
+++ b/paddle/fluid/platform/dynload/hipblas.cc
@@ -12,24 +12,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#pragma once
+#include "paddle/fluid/platform/dynload/hipblas.h"
 
 namespace paddle {
 namespace platform {
 namespace dynload {
+std::once_flag hipblas_dso_flag;
+void *hipblas_dso_handle = nullptr;
 
-void* GetCublasDsoHandle();
-void* GetCUDNNDsoHandle();
-void* GetCUPTIDsoHandle();
-void* GetCurandDsoHandle();
-void* GetWarpCTCDsoHandle();
-void* GetLapackDsoHandle();
-void* GetNCCLDsoHandle();
-void* GetTensorRtDsoHandle();
-void* GetHipblasDsoHandle();
-void* GetMIOpenDsoHandle();
-void* GetHiprandDsoHandle();
-void* GetRCCLDsoHandle();
+#define DEFINE_WRAP(__name) DynLoad__##__name __name
+
+HIPBLAS_BLAS_ROUTINE_EACH(DEFINE_WRAP);
 
 }  // namespace dynload
 }  // namespace platform

--- a/paddle/fluid/platform/dynload/hipblas.h
+++ b/paddle/fluid/platform/dynload/hipblas.h
@@ -1,0 +1,91 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#pragma once
+
+#include <hipblas.h>
+#include <dlfcn.h>
+#include <mutex>  // NOLINT
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+
+extern std::once_flag hipblas_dso_flag;
+extern void *hipblas_dso_handle;
+
+/**
+ * The following macro definition can generate structs
+ * (for each function) to dynamic load cublas routine
+ * via operator overloading.
+ *
+ * note: default dynamic linked libs
+ */
+#ifdef PADDLE_USE_DSO
+#define DECLARE_DYNAMIC_LOAD_HIPBLAS_WRAP(__name)                              \
+  struct DynLoad__##__name {                                                   \
+    template <typename... Args>                                                \
+    inline hipblasStatus_t operator()(Args... args) {                          \
+      typedef hipblasStatus_t (*hipblasFunc)(Args...);                         \
+      std::call_once(hipblas_dso_flag, []() {                                  \
+	hipblas_dso_handle = paddle::platform::dynload::GetHipblasDsoHandle(); \
+      });                                                                      \
+      void *p_##__name = dlsym(hipblas_dso_handle, #__name);                   \
+      return reinterpret_cast<hipblasFunc>(p_##__name)(args...);               \
+    }                                                                          \
+  };                                                                           \
+  extern DynLoad__##__name __name
+#else
+#define DECLARE_DYNAMIC_LOAD_HIPBLAS_WRAP(__name)     \
+  struct DynLoad__##__name {                          \
+    template <typename... Args>                       \
+    inline hipblasStatus_t operator()(Args... args) { \
+      return __name(args...);                         \
+    }                                                 \
+  };                                                  \
+  extern DynLoad__##__name __name
+#endif
+
+#define HIPBLAS_BLAS_ROUTINE_EACH(__macro) \
+  __macro(hipblasSaxpy);                   \
+  __macro(hipblasDaxpy);                   \
+  __macro(hipblasSgemv);                   \
+  __macro(hipblasDgemv);                   \
+  __macro(hipblasSgemm);                   \
+  __macro(hipblasDgemm);                   \
+  __macro(hipblasSgeam);                   \
+  __macro(hipblasDgeam);                   \
+  __macro(hipblasCreate);                  \
+  __macro(hipblasDestroy);                 \
+  __macro(hipblasSetStream);               \
+  __macro(hipblasSetPointerMode);          \
+  __macro(hipblasGetPointerMode);          \
+  __macro(hipblasSgemmBatched);            \
+  __macro(hipblasDgemmBatched);            \
+  __macro(hipblasCgemmBatched);            \
+  __macro(hipblasZgemmBatched);            \
+  __macro(hipblasSgemmStridedBatched);     \
+  __macro(hipblasDgemmStridedBatched);     \
+  __macro(hipblasCgemmStridedBatched);     \
+  __macro(hipblasZgemmStridedBatched);     \
+  __macro(hipblasDgetrfBatched);           \
+  __macro(hipblasDgetriBatched)
+
+HIPBLAS_BLAS_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_HIPBLAS_WRAP);
+
+#undef DECLARE_DYNAMIC_LOAD_HIPBLAS_WRAP
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/hipblas.h
+++ b/paddle/fluid/platform/dynload/hipblas.h
@@ -14,8 +14,8 @@
 
 #pragma once
 
-#include <hipblas.h>
 #include <dlfcn.h>
+#include <hipblas.h>
 #include <mutex>  // NOLINT
 #include "paddle/fluid/platform/dynload/dynamic_loader.h"
 
@@ -40,7 +40,7 @@ extern void *hipblas_dso_handle;
     inline hipblasStatus_t operator()(Args... args) {                          \
       typedef hipblasStatus_t (*hipblasFunc)(Args...);                         \
       std::call_once(hipblas_dso_flag, []() {                                  \
-	hipblas_dso_handle = paddle::platform::dynload::GetHipblasDsoHandle(); \
+        hipblas_dso_handle = paddle::platform::dynload::GetHipblasDsoHandle(); \
       });                                                                      \
       void *p_##__name = dlsym(hipblas_dso_handle, #__name);                   \
       return reinterpret_cast<hipblasFunc>(p_##__name)(args...);               \

--- a/paddle/fluid/platform/dynload/hiprand.cc
+++ b/paddle/fluid/platform/dynload/hiprand.cc
@@ -12,24 +12,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#pragma once
+#include "paddle/fluid/platform/dynload/hiprand.h"
 
 namespace paddle {
 namespace platform {
 namespace dynload {
 
-void* GetCublasDsoHandle();
-void* GetCUDNNDsoHandle();
-void* GetCUPTIDsoHandle();
-void* GetCurandDsoHandle();
-void* GetWarpCTCDsoHandle();
-void* GetLapackDsoHandle();
-void* GetNCCLDsoHandle();
-void* GetTensorRtDsoHandle();
-void* GetHipblasDsoHandle();
-void* GetMIOpenDsoHandle();
-void* GetHiprandDsoHandle();
-void* GetRCCLDsoHandle();
+std::once_flag hiprand_dso_flag;
+void *hiprand_dso_handle;
+
+#define DEFINE_WRAP(__name) DynLoad__##__name __name
+
+HIPRAND_RAND_ROUTINE_EACH(DEFINE_WRAP);
 
 }  // namespace dynload
 }  // namespace platform

--- a/paddle/fluid/platform/dynload/hiprand.h
+++ b/paddle/fluid/platform/dynload/hiprand.h
@@ -1,0 +1,66 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#pragma once
+
+#include <hiprand.h>
+#include <dlfcn.h>
+
+#include <mutex>  // NOLINT
+
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+extern std::once_flag hiprand_dso_flag;
+extern void *hiprand_dso_handle;
+#ifdef PADDLE_USE_DSO
+#define DECLARE_DYNAMIC_LOAD_HIPRAND_WRAP(__name)                              \
+  struct DynLoad__##__name {                                                   \
+    template <typename... Args>                                                \
+    hiprandStatus_t operator()(Args... args) {                                 \
+      typedef hiprandStatus_t (*hiprandFunc)(Args...);                         \
+      std::call_once(hiprand_dso_flag, []() {                                  \
+        hiprand_dso_handle = paddle::platform::dynload::GetHiprandDsoHandle(); \
+      });                                                                      \
+      void *p_##__name = dlsym(hiprand_dso_handle, #__name);                   \
+      return reinterpret_cast<hiprandFunc>(p_##__name)(args...);               \
+    }                                                                          \
+  };                                                                           \
+  extern DynLoad__##__name __name
+#else
+#define DECLARE_DYNAMIC_LOAD_HIPRAND_WRAP(__name) \
+  struct DynLoad__##__name {                      \
+    template <typename... Args>                   \
+    hiprandStatus_t operator()(Args... args) {    \
+      return __name(args...);                     \
+    }                                             \
+  };                                              \
+  extern DynLoad__##__name __name
+#endif
+
+#define HIPRAND_RAND_ROUTINE_EACH(__macro)      \
+  __macro(hiprandCreateGenerator);              \
+  __macro(hiprandSetStream);                    \
+  __macro(hiprandSetPseudoRandomGeneratorSeed); \
+  __macro(hiprandGenerateUniform);              \
+  __macro(hiprandGenerateUniformDouble);        \
+  __macro(hiprandGenerateNormal);               \
+  __macro(hiprandDestroyGenerator);
+
+HIPRAND_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_HIPRAND_WRAP);
+
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/hiprand.h
+++ b/paddle/fluid/platform/dynload/hiprand.h
@@ -13,8 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
-#include <hiprand.h>
 #include <dlfcn.h>
+#include <hiprand.h>
 
 #include <mutex>  // NOLINT
 

--- a/paddle/fluid/platform/dynload/miopen.h
+++ b/paddle/fluid/platform/dynload/miopen.h
@@ -1,0 +1,132 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <miopen/miopen.h>
+#include <dlfcn.h>
+#include <mutex>  // NOLINT
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+
+extern std::once_flag miopen_dso_flag;
+extern void* miopen_dso_handle;
+extern bool HasMIOpen();
+
+inline const char* miopenGetErrorString(miopenStatus_t status) {
+  switch (status) {
+    case miopenStatusSuccess:
+      return "MIOPEN_STATUS_SUCCESS";
+    case miopenStatusNotInitialized:
+      return "MIOPEN_STATUS_NOT_INITIALIZED";
+    case miopenStatusInvalidValue:
+      return "MIOPEN_STATUS_INVALID_VALUE";
+    case miopenStatusBadParm:
+      return "MIOPEN_STATUS_BAD_PARAM";
+    case miopenStatusAllocFailed:
+      return "MIOPEN_STATUS_ALLOC_FAILED";
+    case miopenStatusInternalError:
+      return "MIOPEN_STATUS_INTERNAL_ERROR";
+    case miopenStatusNotImplemented:
+      return "MIOPEN_STATUS_NOT_IMPLEMENTED";
+    case miopenStatusUnknownError:
+    default:
+      return "MIOPEN_STATUS_UNKNOWN_ERROR";
+  }
+}
+
+#ifdef PADDLE_USE_DSO
+
+extern void EnforceMIOpenLoaded(const char* fn_name);
+#define DECLARE_DYNAMIC_LOAD_MIOPEN_WRAP(__name)                             \
+  struct DynLoad__##__name {                                                 \
+    template <typename... Args>                                              \
+    auto operator()(Args... args) -> decltype(__name(args...)) {             \
+      using miopen_func = decltype(__name(args...)) (*)(Args...);            \
+      std::call_once(miopen_dso_flag, []() {                                 \
+	miopen_dso_handle = paddle::platform::dynload::GetMIOpenDsoHandle(); \
+      });                                                                    \
+      EnforceMIOpenLoaded(#__name);                                          \
+      void* p_##__name = dlsym(miopen_dso_handle, #__name);                  \
+      return reinterpret_cast<miopen_func>(p_##__name)(args...);             \
+    }                                                                        \
+  };                                                                         \
+  extern struct DynLoad__##__name __name
+
+#else
+
+#define DECLARE_DYNAMIC_LOAD_MIOPEN_WRAP(__name)                 \
+  struct DynLoad__##__name {                                     \
+    template <typename... Args>                                  \
+    auto operator()(Args... args) -> decltype(__name(args...)) { \
+      return __name(args...);                                    \
+    }                                                            \
+  };                                                             \
+  extern DynLoad__##__name __name
+
+#endif
+
+/**
+ * include all needed miopen functions in HPPL
+ **/
+#define MIOPEN_DNN_ROUTINE_EACH(__macro)                     \
+  __macro(miopenSet4dTensorDescriptor);                      \
+  __macro(miopenGet4dTensorDescriptor);                      \
+  __macro(miopenFindConvolutionForwardAlgorithm);            \
+  __macro(miopenGetConvolutionDescriptor);                   \
+  __macro(miopenCreateTensorDescriptor);                     \
+  __macro(miopenDestroyTensorDescriptor);                    \
+  __macro(miopenSet2dPoolingDescriptor);                     \
+  __macro(miopenGet2dPoolingDescriptor);                     \
+  __macro(miopenCreateConvolutionDescriptor);                \
+  __macro(miopenCreatePoolingDescriptor);                    \
+  __macro(miopenDestroyPoolingDescriptor);                   \
+  __macro(miopenInitConvolutionDescriptor);                  \
+  __macro(miopenDestroyConvolutionDescriptor);               \
+  __macro(miopenDeriveBNTensorDescriptor);                   \
+  __macro(miopenCreate);                                     \
+  __macro(miopenDestroy);                                    \
+  __macro(miopenSetStream);                                  \
+  __macro(miopenActivationForward);                          \
+  __macro(miopenConvolutionForward);                         \
+  __macro(miopenConvolutionBackwardBias);                    \
+  __macro(miopenConvolutionForwardGetWorkSpaceSize);         \
+  __macro(miopenPoolingGetWorkSpaceSize);                    \
+  __macro(miopenPoolingForward);                             \
+  __macro(miopenPoolingBackward);                            \
+  __macro(miopenSoftmaxBackward);                            \
+  __macro(miopenSoftmaxForward);                             \
+  __macro(miopenAddTensor);                                  \
+  __macro(miopenConvolutionBackwardData);                    \
+  __macro(miopenConvolutionBackwardWeights);                 \
+  __macro(miopenConvolutionBackwardWeightsGetWorkspaceSize); \
+  __macro(miopenFindConvolutionBackwardDataAlgorithm);       \
+  __macro(miopenFindConvolutionBackwardWeightsAlgorithm);    \
+  __macro(miopenConvolutionBackwardWeightsGetWorkSpaceSize); \
+  __macro(miopenConvolutionBackwardDataGetWorkSpaceSize);    \
+  __macro(miopenBatchNormalizationForwardTraining);          \
+  __macro(miopenBatchNormalizationForwardInference);         \
+  __macro(miopenBatchNormalizationBackward);                 \
+  __macro(miopenCreateActivationDescriptor);                 \
+  __macro(miopenSetActivationDescriptor);                    \
+  __macro(miopenGetActivationDescriptor);                    \
+  __macro(miopenDestroyActivationDescriptor);
+MIOPEN_DNN_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_MIOPEN_WRAP)
+
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/miopen.h
+++ b/paddle/fluid/platform/dynload/miopen.h
@@ -14,8 +14,8 @@ limitations under the License. */
 
 #pragma once
 
-#include <miopen/miopen.h>
 #include <dlfcn.h>
+#include <miopen/miopen.h>
 #include <mutex>  // NOLINT
 #include "paddle/fluid/platform/dynload/dynamic_loader.h"
 
@@ -58,7 +58,7 @@ extern void EnforceMIOpenLoaded(const char* fn_name);
     auto operator()(Args... args) -> decltype(__name(args...)) {             \
       using miopen_func = decltype(__name(args...)) (*)(Args...);            \
       std::call_once(miopen_dso_flag, []() {                                 \
-	miopen_dso_handle = paddle::platform::dynload::GetMIOpenDsoHandle(); \
+        miopen_dso_handle = paddle::platform::dynload::GetMIOpenDsoHandle(); \
       });                                                                    \
       EnforceMIOpenLoaded(#__name);                                          \
       void* p_##__name = dlsym(miopen_dso_handle, #__name);                  \

--- a/paddle/fluid/platform/dynload/rccl.cc
+++ b/paddle/fluid/platform/dynload/rccl.cc
@@ -12,42 +12,19 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#pragma once
-
-#include <algorithm>
-#include <condition_variable>
-#include <memory>
-#include <mutex>
-#include <string>
-#include <unordered_map>
-#include <vector>
-
-#include "paddle/fluid/platform/device_context.h"
-#ifdef PADDLE_WITH_HIP
 #include "paddle/fluid/platform/dynload/rccl.h"
-#else
-#include "paddle/fluid/platform/dynload/nccl.h"
-#endif
-#include "paddle/fluid/platform/enforce.h"
-#include "paddle/fluid/platform/macros.h"
 
 namespace paddle {
 namespace platform {
-constexpr int kInvalidGPUId = -1;
+namespace dynload {
 
-struct Communicator {
-  Communicator() {}
+std::once_flag rccl_dso_flag;
+void *rccl_dso_handle;
 
-  int GetCommId(int device_id) const;
+#define DEFINE_WRAP(__name) DynLoad__##__name __name
 
-  void InitAll(const std::vector<int>& gpus);
+RCCL_RAND_ROUTINE_EACH(DEFINE_WRAP);
 
-#ifdef PADDLE_WITH_HIP
-  const std::vector<rcclComm_t>& comms() const;
-#else
-  const std::vector<ncclComm_t>& comms() const;
-#endif
-};
-
+}  // namespace dynload
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/dynload/rccl.h
+++ b/paddle/fluid/platform/dynload/rccl.h
@@ -1,0 +1,75 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <dlfcn.h>
+#include <rccl.h>
+
+#include <mutex>  // NOLINT
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+
+extern std::once_flag rccl_dso_flag;
+extern void* rccl_dso_handle;
+
+#ifdef PADDLE_USE_DSO
+extern void LoadRCCLDSO();
+
+#define DECLARE_DYNAMIC_LOAD_RCCL_WRAP(__name)                           \
+  struct DynLoad__##__name {                                             \
+    template <typename... Args>                                          \
+    auto operator()(Args... args) -> decltype(__name(args...)) {         \
+      using rccl_func = decltype(__name(args...)) (*)(Args...);          \
+      std::call_once(rccl_dso_flag, []() {                               \
+        rccl_dso_handle = paddle::platform::dynload::GetRCCLDsoHandle(); \
+      });                                                                \
+      void* p_##__name = dlsym(rccl_dso_handle, #__name);                \
+      return reinterpret_cast<rccl_func>(p_##__name)(args...);           \
+    }                                                                    \
+  };                                                                     \
+  extern DynLoad__##__name __name
+#else
+#define DECLARE_DYNAMIC_LOAD_RCCL_WRAP(__name) \
+  struct DynLoad__##__name {                   \
+    template <typename... Args>                \
+    rcclResult_t operator()(Args... args) {    \
+      return __name(args...);                  \
+    }                                          \
+  };                                           \
+  extern DynLoad__##__name __name
+#endif
+
+#define RCCL_RAND_ROUTINE_EACH(__macro) \
+  __macro(rcclCommInitAll);             \
+  __macro(rcclGetUniqueId);             \
+  __macro(rcclCommInitRank);            \
+  __macro(rcclCommDestroy);             \
+  __macro(rcclCommCount);               \
+  __macro(rcclCommCuDevice);            \
+  __macro(rcclCommUserRank);            \
+  __macro(rcclAllReduce);               \
+  __macro(rcclBcast);                   \
+  __macro(rcclAllGather);               \
+  __macro(rcclReduce);                  \
+  __macro(rcclGetErrorString);
+
+RCCL_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_RCCL_WRAP)
+
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -47,6 +47,23 @@ limitations under the License. */
 #include "paddle/fluid/platform/dynload/nccl.h"
 #endif
 
+#ifdef PADDLE_WITH_HIP
+
+#include "paddle/fluid/platform/dynload/hipblas.h"
+#include "paddle/fluid/platform/dynload/miopen.h"
+#include "paddle/fluid/platform/dynload/hiprand.h"
+#include "paddle/fluid/platform/dynload/rccl.h"
+
+#include <hip/hip_runtime_api.h>
+#include <hipblas.h>
+#include <miopen/miopen.h>
+#include <hiprand.h>
+#include <rccl.h>
+#include <thrust/system/cuda/error.h>
+#include <thrust/system_error.h>
+
+#endif
+
 namespace paddle {
 namespace platform {
 
@@ -186,6 +203,74 @@ inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
 }
 
 #endif  // PADDLE_WITH_CUDA
+
+
+#ifdef PADDLE_WITH_HIP
+
+template <typename... Args>
+inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
+    hipError_t e, const Args&... args) {
+  if (UNLIKELY(e)) {
+    throw thrust::system_error(e, thrust::cuda_category(),
+                               string::Sprintf(args...));
+  }
+}
+
+template <typename... Args>
+inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
+    hiprandStatus_t stat, const Args&... args) {
+  if (stat != HIPRAND_STATUS_SUCCESS) {
+    throw thrust::system_error(hipErrorLaunchFailure, thrust::cuda_category(),
+                               string::Sprintf(args...));
+  }
+}
+
+template <typename... Args>
+inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
+    miopenStatus_t stat, const Args&... args) {
+  if (stat == miopenStatusSuccess) {
+    return;
+  } else {
+    throw std::runtime_error(platform::dynload::miopenGetErrorString(stat) +
+                             string::Sprintf(args...));
+  }
+}
+
+template <typename... Args>
+inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
+    hipblasStatus_t stat, const Args&... args) {
+  std::string err;
+  if (stat == HIPBLAS_STATUS_SUCCESS) {
+    return;
+  } else if (stat == HIPBLAS_STATUS_NOT_INITIALIZED) {
+    err = "CUBLAS: not initialized, ";
+  } else if (stat == HIPBLAS_STATUS_ALLOC_FAILED) {
+    err = "CUBLAS: alloc failed, ";
+  } else if (stat == HIPBLAS_STATUS_INVALID_VALUE) {
+    err = "CUBLAS: invalid value, ";
+  } else if (stat == HIPBLAS_STATUS_MAPPING_ERROR) {
+    err = "CUBLAS: mapping error, ";
+  } else if (stat == HIPBLAS_STATUS_EXECUTION_FAILED) {
+    err = "CUBLAS: execution failed, ";
+  } else if (stat == HIPBLAS_STATUS_INTERNAL_ERROR) {
+    err = "CUBLAS: internal error, ";
+  } else if (stat == HIPBLAS_STATUS_NOT_SUPPORTED) {
+    err = "CUBLAS: not supported, ";
+  }
+  throw std::runtime_error(err + string::Sprintf(args...));
+}
+
+template <typename... Args>
+inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
+    rcclResult_t stat, const Args&... args) {
+  if (stat == rcclSuccess) {
+    return;
+  } else {
+    throw std::runtime_error(string::Sprintf(args...));
+  }
+}
+
+#endif  // PADDLE_WITH_HIP
 
 template <typename T>
 inline void throw_on_error(T e) {

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -50,14 +50,14 @@ limitations under the License. */
 #ifdef PADDLE_WITH_HIP
 
 #include "paddle/fluid/platform/dynload/hipblas.h"
-#include "paddle/fluid/platform/dynload/miopen.h"
 #include "paddle/fluid/platform/dynload/hiprand.h"
+#include "paddle/fluid/platform/dynload/miopen.h"
 #include "paddle/fluid/platform/dynload/rccl.h"
 
 #include <hip/hip_runtime_api.h>
 #include <hipblas.h>
-#include <miopen/miopen.h>
 #include <hiprand.h>
+#include <miopen/miopen.h>
 #include <rccl.h>
 #include <thrust/system/cuda/error.h>
 #include <thrust/system_error.h>
@@ -203,7 +203,6 @@ inline typename std::enable_if<sizeof...(Args) != 0, void>::type throw_on_error(
 }
 
 #endif  // PADDLE_WITH_CUDA
-
 
 #ifdef PADDLE_WITH_HIP
 

--- a/paddle/fluid/platform/float16.h
+++ b/paddle/fluid/platform/float16.h
@@ -21,6 +21,10 @@ limitations under the License. */
 #include <cuda.h>
 #endif  // PADDLE_WITH_CUDA
 
+#ifdef PADDLE_WITH_HIP
+#include <hip/hip_runtime.h>
+#endif  // PADDLE_WITH_HIP
+
 #ifdef __GNUC__
 #define PADDLE_GNUC_VER (__GNUC__ * 10 + __GNUC_MINOR__)
 #else

--- a/paddle/fluid/platform/gpu_info.h
+++ b/paddle/fluid/platform/gpu_info.h
@@ -15,8 +15,13 @@ limitations under the License. */
 #pragma once
 
 #ifdef PADDLE_WITH_CUDA
-
 #include <cuda_runtime.h>
+#endif  // PADDLE_WITH_CUDA
+
+#ifdef PADDLE_WITH_HIP
+#include <hip/hip_runtime.h>
+#endif // PADDLE_WITH_HIP
+
 #include <stddef.h>
 #include <string>
 
@@ -53,6 +58,7 @@ size_t GpuMinChunkSize();
 //! Get the maximum chunk size for GPU buddy allocator.
 size_t GpuMaxChunkSize();
 
+#ifdef PADDLE_WITH_CUDA
 //! Copy memory from address src to dst asynchronously.
 void GpuMemcpyAsync(void *dst, const void *src, size_t count,
                     enum cudaMemcpyKind kind, cudaStream_t stream);
@@ -63,8 +69,20 @@ void GpuMemcpyPeer(void *dst, int dst_device, const void *src, int src_device,
 
 //! Set memory dst with value count size asynchronously
 void GpuMemsetAsync(void *dst, int value, size_t count, cudaStream_t stream);
+#endif  // PADDLE_WITH_CUDA
+
+#ifdef PADDLE_WITH_HIP
+//! Copy memory from address src to dst asynchronously.
+void GpuMemcpyAsync(void *dst, const void *src, size_t count,
+		    enum hipMemcpyKind kind, hipStream_t stream);
+
+//! Copy memory from one device to another device.
+void GpuMemcpyPeer(void *dst, int dst_device, const void *src, int src_device,
+		   size_t count, hipStream_t stream);
+
+//! Set memory dst with value count size asynchronously
+void GpuMemsetAsync(void *dst, int value, size_t count, hipStream_t stream);
+#endif  // PADDLE_WITH_HIP
 
 }  // namespace platform
 }  // namespace paddle
-
-#endif

--- a/paddle/fluid/platform/gpu_info.h
+++ b/paddle/fluid/platform/gpu_info.h
@@ -20,7 +20,7 @@ limitations under the License. */
 
 #ifdef PADDLE_WITH_HIP
 #include <hip/hip_runtime.h>
-#endif // PADDLE_WITH_HIP
+#endif  // PADDLE_WITH_HIP
 
 #include <stddef.h>
 #include <string>
@@ -74,11 +74,11 @@ void GpuMemsetAsync(void *dst, int value, size_t count, cudaStream_t stream);
 #ifdef PADDLE_WITH_HIP
 //! Copy memory from address src to dst asynchronously.
 void GpuMemcpyAsync(void *dst, const void *src, size_t count,
-		    enum hipMemcpyKind kind, hipStream_t stream);
+                    enum hipMemcpyKind kind, hipStream_t stream);
 
 //! Copy memory from one device to another device.
 void GpuMemcpyPeer(void *dst, int dst_device, const void *src, int src_device,
-		   size_t count, hipStream_t stream);
+                   size_t count, hipStream_t stream);
 
 //! Set memory dst with value count size asynchronously
 void GpuMemsetAsync(void *dst, int value, size_t count, hipStream_t stream);

--- a/paddle/fluid/platform/gpu_info_hip.cc
+++ b/paddle/fluid/platform/gpu_info_hip.cc
@@ -1,0 +1,141 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/platform/gpu_info.h"
+
+#include "gflags/gflags.h"
+
+#include "paddle/fluid/platform/enforce.h"
+
+DEFINE_double(fraction_of_gpu_memory_to_use, 0.92,
+              "Default use 92% of GPU memory for PaddlePaddle,"
+              "reserve the rest for page tables, etc");
+
+namespace paddle {
+namespace platform {
+
+int GetCUDADeviceCount() {
+  int count;
+  PADDLE_ENFORCE(
+      hipGetDeviceCount(&count),
+      "hipGetDeviceCount failed in paddle::platform::GetCUDADeviceCount");
+  return count;
+}
+
+int GetCUDAComputeCapability(int id) {
+  PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
+  hipDeviceProp_t device_prop;
+  PADDLE_ENFORCE(hipGetDeviceProperties(&device_prop, id),
+                 "hipGetDeviceProperties failed in "
+                 "paddle::platform::GetCUDAComputeCapability");
+  return device_prop.major * 10 + device_prop.minor;
+}
+
+int GetCUDAMultiProcessors(int id) {
+  PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
+  int count;
+  PADDLE_ENFORCE(
+      hipDeviceGetAttribute(&count, hipDeviceAttributeMultiprocessorCount, id),
+      "hipDeviceGetAttribute failed in "
+      "paddle::platform::GetCUDAMultiProcessors");
+  return count;
+}
+
+int GetCUDAMaxThreadsPerMultiProcessor(int id) {
+  PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
+  int count;
+  PADDLE_ENFORCE(hipDeviceGetAttribute(
+                     &count, hipDeviceAttributeMaxThreadsPerMultiProcessor, id),
+                 "hipDeviceGetAttribute failed in "
+                 "paddle::platform::GetCUDAMaxThreadsPerMultiProcessor");
+  return count;
+}
+
+int GetCurrentDeviceId() {
+  int device_id;
+  PADDLE_ENFORCE(
+      hipGetDevice(&device_id),
+      "hipGetDevice failed in paddle::platform::GetCurrentDeviceId");
+  return device_id;
+}
+
+void SetDeviceId(int id) {
+  // TODO(qijun): find a better way to cache the cuda device count
+  PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
+  PADDLE_ENFORCE(hipSetDevice(id),
+                 "hipSetDevice failed in paddle::platform::SetDeviceId");
+}
+
+void GpuMemoryUsage(size_t *available, size_t *total) {
+  PADDLE_ENFORCE(hipMemGetInfo(available, total),
+                 "hipMemGetInfo failed in paddle::platform::GetMemoryUsage");
+}
+
+size_t GpuMaxAllocSize() {
+  size_t total = 0;
+  size_t available = 0;
+
+  GpuMemoryUsage(&available, &total);
+
+  // Reserve the rest for page tables, etc.
+  return static_cast<size_t>(total * FLAGS_fraction_of_gpu_memory_to_use);
+}
+
+size_t GpuMinChunkSize() {
+  // Allow to allocate the minimum chunk size is 256 bytes.
+  return 1 << 8;
+}
+
+size_t GpuMaxChunkSize() {
+  size_t total = 0;
+  size_t available = 0;
+
+  GpuMemoryUsage(&available, &total);
+  VLOG(10) << "GPU Usage " << available / 1024 / 1024 << "M/"
+           << total / 1024 / 1024 << "M";
+  size_t reserving = static_cast<size_t>(0.05 * total);
+  // If available less than minimum chunk size, no usable memory exists.
+  available =
+      std::min(std::max(available, GpuMinChunkSize()) - GpuMinChunkSize(),
+               total - reserving);
+
+  // Reserving the rest memory for page tables, etc.
+
+  size_t allocating = static_cast<size_t>(FLAGS_fraction_of_gpu_memory_to_use *
+                                          (total - reserving));
+
+  PADDLE_ENFORCE_LE(allocating, available);
+
+  return allocating;
+}
+
+void GpuMemcpyAsync(void *dst, const void *src, size_t count,
+                    enum hipMemcpyKind kind, hipStream_t stream) {
+  PADDLE_ENFORCE(hipMemcpyAsync(dst, src, count, kind, stream),
+                 "hipMemcpyAsync failed in paddle::platform::GpuMemcpyAsync");
+}
+
+void GpuMemcpyPeer(void *dst, int dst_device, const void *src, int src_device,
+                   size_t count, hipStream_t stream) {
+  PADDLE_ENFORCE(
+      hipMemcpyPeerAsync(dst, dst_device, src, src_device, count, stream),
+      "hipMemcpyPeerAsync failed in paddle::platform::GpuMemcpyPeer");
+}
+
+void GpuMemsetAsync(void *dst, int value, size_t count, hipStream_t stream) {
+  PADDLE_ENFORCE(hipMemsetAsync(dst, value, count, stream),
+                 "hipMemsetAsync failed in paddle::platform::GpuMemsetAsync");
+}
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/gpu_info_hip.cc
+++ b/paddle/fluid/platform/gpu_info_hip.cc
@@ -64,9 +64,8 @@ int GetCUDAMaxThreadsPerMultiProcessor(int id) {
 
 int GetCurrentDeviceId() {
   int device_id;
-  PADDLE_ENFORCE(
-      hipGetDevice(&device_id),
-      "hipGetDevice failed in paddle::platform::GetCurrentDeviceId");
+  PADDLE_ENFORCE(hipGetDevice(&device_id),
+                 "hipGetDevice failed in paddle::platform::GetCurrentDeviceId");
   return device_id;
 }
 

--- a/paddle/fluid/platform/hostdevice.h
+++ b/paddle/fluid/platform/hostdevice.h
@@ -13,7 +13,7 @@
 // limitations under the License.
 #pragma once
 
-#ifdef __CUDACC__
+#if (defined(__CUDACC__) || defined(__HIPCC__))
 #define HOSTDEVICE __host__ __device__
 #define DEVICE __device__
 #define HOST __host__

--- a/paddle/fluid/platform/miopen_helper.h
+++ b/paddle/fluid/platform/miopen_helper.h
@@ -1,0 +1,252 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+B
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <vector>
+
+#include "miopen/miopen.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/platform/dynload/miopen.h"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/float16.h"
+#include "paddle/fluid/platform/macros.h"
+
+namespace paddle {
+namespace platform {
+
+#define MIOPEN_ENFORCE(condition)                                  \
+  do {                                                            \
+    miopenStatus_t status = condition;                             \
+    if (status != miopenStatusSuccess) {                         \
+      PADDLE_THROW("miopen call failed");                          \
+    }                                                             \
+  } while (false)
+
+enum class DataLayout {  // Not use
+  kNHWC,
+  kNCHW,
+  kNCDHW,
+  kNCHW_VECT_C,
+};
+
+enum class PoolingMode {
+
+  kMaximum,
+  kAverage,
+};
+
+template <typename T>
+class MIOpenDataType;
+
+template <>
+class MIOpenDataType<float16> {
+ public:
+  static const miopenDataType_t type = miopenHalf;
+  // The scaling param type is float for HALF and FLOAT tensors
+  using ScalingParamType = const float;
+  using BatchNormParamType = float;
+  static ScalingParamType* kOne() {
+    static ScalingParamType v = 1.0;
+    return &v;
+  }
+  static ScalingParamType* kZero() {
+    static ScalingParamType v = 0.0;
+    return &v;
+  }
+};
+
+template <>
+class MIOpenDataType<float> {
+ public:
+  static const miopenDataType_t type = miopenFloat;
+  using ScalingParamType = const float;
+  using BatchNormParamType = float;
+  static ScalingParamType* kOne() {
+    static ScalingParamType v = 1.0;
+    return &v;
+  }
+  static ScalingParamType* kZero() {
+    static ScalingParamType v = 0.0;
+    return &v;
+  }
+};
+
+class ScopedTensorDescriptor {
+ public:
+
+  ScopedTensorDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenCreateTensorDescriptor(&desc_));
+  }
+  ~ScopedTensorDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenDestroyTensorDescriptor(desc_));
+  }
+
+ inline miopenTensorDescriptor_t descriptor(const miopenDataType_t type,
+                                           const std::vector<int>& dims,
+                                           const int groups = 1) {
+   // the format is not used now, will add later
+   std::vector<int> strides(dims.size());
+   strides[dims.size() - 1] = 1;
+   for (int i = dims.size() - 2; i >= 0; i--) {
+     strides[i] = dims[i + 1] * strides[i + 1];
+   }
+   // Update tensor descriptor dims setting if groups > 1
+   // NOTE: Assume using NCHW or NCDHW order
+   std::vector<int> dims_with_group(dims.begin(), dims.end());  // copy
+   if (groups > 1) {
+     dims_with_group[1] = dims_with_group[1] / groups;
+   }
+   if (dims_with_group.size()!=4){
+   	PADDLE_THROW("miopen only supports 4D tensors, dim=%d not allowed",dims_with_group.size());
+   }
+   PADDLE_ENFORCE(dynload::miopenSet4dTensorDescriptor(
+       desc_, type, dims_with_group[0], dims_with_group[1], dims_with_group[2], dims_with_group[3]));
+   return desc_;
+ }
+
+  template <typename T>
+  inline miopenTensorDescriptor_t descriptor(const DataLayout& order,
+                                            const std::vector<int>& dims,
+                                            const int groups = 1) {
+    return descriptor(MIOpenDataType<T>::type, dims,
+                      groups);
+  }
+
+ private:
+  miopenTensorDescriptor_t desc_;
+  DISABLE_COPY_AND_ASSIGN(ScopedTensorDescriptor);
+};
+
+class ScopedFilterDescriptor {
+ public:
+  ScopedFilterDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenCreateTensorDescriptor(&desc_));
+  }
+  ~ScopedFilterDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenDestroyTensorDescriptor(desc_));
+  }
+  inline miopenTensorDescriptor_t descriptor(const miopenDataType_t type,
+                                            const std::vector<int>& kernel,
+                                            const int groups = 1) {
+    // filter layout: MCHW(MCDHW), where M is the number of
+    // output image channels, C is the number of input image channels,
+    // D is the depth of the filter, H is the height of the filter, and W is the
+    // width of the filter.
+    std::vector<int> kernel_with_group(kernel.begin(), kernel.end());
+    if (groups > 1) {
+      kernel_with_group[0] /= groups;
+      // NOTE: input filter(C) of the filter is already asserted to be C/groups.
+    }
+    if (kernel_with_group.size()!=4){
+        PADDLE_THROW("miopen only supports 4D filters, dim=%d not allowed",kernel_with_group.size());
+    }
+    PADDLE_ENFORCE(dynload::miopenSet4dTensorDescriptor(
+        desc_, type, kernel_with_group[0], kernel_with_group[1], kernel_with_group[2], kernel_with_group[3]));
+    return desc_;
+  }
+
+  template <typename T>
+  inline miopenTensorDescriptor_t descriptor(const DataLayout& order,
+                                            const std::vector<int>& kernel,
+                                            const int groups = 1) {
+    return descriptor(MIOpenDataType<T>::type,
+                      kernel, groups);
+  }
+ private:
+  miopenTensorDescriptor_t desc_;
+  DISABLE_COPY_AND_ASSIGN(ScopedFilterDescriptor);
+};
+
+class ScopedConvolutionDescriptor {
+ public:
+  ScopedConvolutionDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenCreateConvolutionDescriptor(&desc_));
+  }
+  ~ScopedConvolutionDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenDestroyConvolutionDescriptor(desc_));
+  }
+
+  inline miopenConvolutionDescriptor_t descriptor(
+      miopenDataType_t type, const std::vector<int>& pads,
+      const std::vector<int>& strides, const std::vector<int>& dilations) {
+    PADDLE_ENFORCE_EQ(pads.size(), strides.size());
+    PADDLE_ENFORCE_EQ(pads.size(), dilations.size());
+    if (pads.size()!=2){
+        PADDLE_THROW("miopen only supports 2D Convolution, dim=%d not allowed",pads.size());
+    }
+
+    PADDLE_ENFORCE(dynload::miopenInitConvolutionDescriptor(
+        desc_, miopenConvolution, pads[0], pads[1], strides[0], strides[1],
+	dilations[0], dilations[1]));
+    return desc_;
+  }
+
+  template <typename T>
+  inline miopenConvolutionDescriptor_t descriptor(
+      const std::vector<int>& pads, const std::vector<int>& strides,
+      const std::vector<int>& dilations) {
+    return descriptor(MIOpenDataType<T>::type, pads, strides, dilations);
+  }
+
+ private:
+  miopenConvolutionDescriptor_t desc_;
+  DISABLE_COPY_AND_ASSIGN(ScopedConvolutionDescriptor);
+};
+
+class ScopedPoolingDescriptor {
+ public:
+  ScopedPoolingDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenCreatePoolingDescriptor(&desc_));
+  }
+  ~ScopedPoolingDescriptor() {
+    PADDLE_ENFORCE(dynload::miopenDestroyPoolingDescriptor(desc_));
+  }
+  inline miopenPoolingDescriptor_t descriptor(const PoolingMode& mode,
+                                             const std::vector<int>& kernel,
+                                             const std::vector<int>& pads,
+                                             const std::vector<int>& strides) {
+    PADDLE_ENFORCE_EQ(kernel.size(), pads.size());
+    PADDLE_ENFORCE_EQ(kernel.size(), strides.size());
+    if (kernel.size()!=2){
+        PADDLE_THROW("miopen only supports 2D Pooling, dim=%d not allowed",kernel.size());
+    }
+
+    PADDLE_ENFORCE(dynload::miopenSet2dPoolingDescriptor(
+        desc_, (mode == PoolingMode::kMaximum
+                    ? miopenPoolingMax
+                    : miopenPoolingAverage),
+        kernel[0], kernel[1], pads[0], pads[1], strides[0], strides[1]));
+    return desc_;
+  }
+ private:
+  miopenPoolingDescriptor_t desc_;
+  DISABLE_COPY_AND_ASSIGN(ScopedPoolingDescriptor);
+};
+
+inline bool CanMIOpenBeUsed(const framework::ExecutionContext& ctx) {
+  bool use_cudnn = ctx.Attr<bool>("use_cudnn");
+  use_cudnn &= paddle::platform::is_gpu_place(ctx.GetPlace());
+#ifdef PADDLE_WITH_HIP
+  if (use_cudnn) {
+    auto& dev_ctx = ctx.device_context<platform::CUDADeviceContext>();
+    use_cudnn &= dev_ctx.miopen_handle() != nullptr;
+  }
+#endif
+  return use_cudnn;
+}
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/miopen_helper_test.cc
+++ b/paddle/fluid/platform/miopen_helper_test.cc
@@ -1,0 +1,116 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/platform/miopen_helper.h"
+#include <gtest/gtest.h>
+
+TEST(CudnnHelper, ScopedTensorDescriptor) {
+  using paddle::platform::ScopedTensorDescriptor;
+  using paddle::platform::DataLayout;
+
+  ScopedTensorDescriptor tensor_desc;
+  std::vector<int> shape = {2, 4, 6, 6};
+  auto desc = tensor_desc.descriptor<float>(DataLayout::kNCHW, shape);
+
+  miopenDataType_t type;
+  std::vector<int> dims(4);
+  std::vector<int> strides(4);
+  paddle::platform::dynload::miopenGet4dTensorDescriptor(
+      desc, &type, &dims[0], &dims[1], &dims[2], &dims[3],
+      &strides[0], &strides[1], &strides[2], &strides[3]);
+
+  for (size_t i = 0; i < dims.size(); ++i) {
+    EXPECT_EQ(dims[i], shape[i]);
+  }
+  EXPECT_EQ(strides[3], 1);
+  EXPECT_EQ(strides[2], 6);
+  EXPECT_EQ(strides[1], 36);
+  EXPECT_EQ(strides[0], 144);
+}
+TEST(CudnnHelper, ScopedFilterDescriptor) {
+  using paddle::platform::ScopedFilterDescriptor;
+  using paddle::platform::DataLayout;
+
+  ScopedFilterDescriptor filter_desc;
+  std::vector<int> shape = {2, 3, 3};
+
+  miopenDataType_t type;
+  std::vector<int> kernel(3);
+
+  ScopedFilterDescriptor filter_desc_4d;
+  std::vector<int> shape_4d = {2, 3, 3, 3};
+  auto desc_4d = filter_desc.descriptor<float>(DataLayout::kNCDHW, shape_4d);
+
+  std::vector<int> kernel_4d(4);
+  std::vector<int> strides(4);
+  paddle::platform::dynload::miopenGet4dTensorDescriptor(
+      desc_4d, &type, &kernel_4d[0], &kernel_4d[1], &kernel_4d[2], &kernel_4d[3],
+      &strides[0], &strides[1], &strides[2], &strides[3]);
+
+  for (size_t i = 0; i < shape_4d.size(); ++i) {
+    EXPECT_EQ(kernel_4d[i], shape_4d[i]);
+  }
+}
+
+TEST(CudnnHelper, ScopedConvolutionDescriptor) {
+  using paddle::platform::ScopedConvolutionDescriptor;
+
+  ScopedConvolutionDescriptor conv_desc;
+  std::vector<int> src_pads = {2, 2};
+  std::vector<int> src_strides = {1, 1};
+  std::vector<int> src_dilations = {1, 1};
+  auto desc = conv_desc.descriptor<float>(src_pads, src_strides, src_dilations);
+
+  miopenConvolutionMode_t mode;
+  std::vector<int> pads(2);
+  std::vector<int> strides(2);
+  std::vector<int> dilations(2);
+  paddle::platform::dynload::miopenGetConvolutionDescriptor(
+      desc, &mode, &pads[0], &pads[1], &strides[0], &strides[1],
+      &dilations[0], &dilations[1]);
+
+  for (size_t i = 0; i < src_pads.size(); ++i) {
+    EXPECT_EQ(pads[i], src_pads[i]);
+    EXPECT_EQ(strides[i], src_strides[i]);
+    EXPECT_EQ(dilations[i], src_dilations[i]);
+  }
+  EXPECT_EQ(mode, miopenConvolution);
+}
+
+TEST(CudnnHelper, ScopedPoolingDescriptor) {
+  using paddle::platform::ScopedPoolingDescriptor;
+  using paddle::platform::PoolingMode;
+
+  ScopedPoolingDescriptor pool_desc;
+  std::vector<int> src_kernel = {2, 2};
+  std::vector<int> src_pads = {1, 1};
+  std::vector<int> src_strides = {2, 2};
+  auto desc = pool_desc.descriptor(PoolingMode::kMaximum, src_kernel, src_pads,
+                                   src_strides);
+
+  miopenPoolingMode_t mode;
+  std::vector<int> kernel(2);
+  std::vector<int> pads(2);
+  std::vector<int> strides(2);
+  paddle::platform::dynload::miopenGet2dPoolingDescriptor(
+      desc, &mode, &kernel[0], &kernel[1], &pads[0], &pads[1],
+      &strides[0], &strides[1]);
+
+  for (size_t i = 0; i < src_pads.size(); ++i) {
+    EXPECT_EQ(kernel[i], src_kernel[i]);
+    EXPECT_EQ(pads[i], src_pads[i]);
+    EXPECT_EQ(strides[i], src_strides[i]);
+  }
+  EXPECT_EQ(mode, miopenPoolingMax);
+}

--- a/paddle/fluid/platform/miopen_helper_test.cc
+++ b/paddle/fluid/platform/miopen_helper_test.cc
@@ -27,8 +27,8 @@ TEST(CudnnHelper, ScopedTensorDescriptor) {
   std::vector<int> dims(4);
   std::vector<int> strides(4);
   paddle::platform::dynload::miopenGet4dTensorDescriptor(
-      desc, &type, &dims[0], &dims[1], &dims[2], &dims[3],
-      &strides[0], &strides[1], &strides[2], &strides[3]);
+      desc, &type, &dims[0], &dims[1], &dims[2], &dims[3], &strides[0],
+      &strides[1], &strides[2], &strides[3]);
 
   for (size_t i = 0; i < dims.size(); ++i) {
     EXPECT_EQ(dims[i], shape[i]);
@@ -55,8 +55,8 @@ TEST(CudnnHelper, ScopedFilterDescriptor) {
   std::vector<int> kernel_4d(4);
   std::vector<int> strides(4);
   paddle::platform::dynload::miopenGet4dTensorDescriptor(
-      desc_4d, &type, &kernel_4d[0], &kernel_4d[1], &kernel_4d[2], &kernel_4d[3],
-      &strides[0], &strides[1], &strides[2], &strides[3]);
+      desc_4d, &type, &kernel_4d[0], &kernel_4d[1], &kernel_4d[2],
+      &kernel_4d[3], &strides[0], &strides[1], &strides[2], &strides[3]);
 
   for (size_t i = 0; i < shape_4d.size(); ++i) {
     EXPECT_EQ(kernel_4d[i], shape_4d[i]);
@@ -77,8 +77,8 @@ TEST(CudnnHelper, ScopedConvolutionDescriptor) {
   std::vector<int> strides(2);
   std::vector<int> dilations(2);
   paddle::platform::dynload::miopenGetConvolutionDescriptor(
-      desc, &mode, &pads[0], &pads[1], &strides[0], &strides[1],
-      &dilations[0], &dilations[1]);
+      desc, &mode, &pads[0], &pads[1], &strides[0], &strides[1], &dilations[0],
+      &dilations[1]);
 
   for (size_t i = 0; i < src_pads.size(); ++i) {
     EXPECT_EQ(pads[i], src_pads[i]);
@@ -104,8 +104,8 @@ TEST(CudnnHelper, ScopedPoolingDescriptor) {
   std::vector<int> pads(2);
   std::vector<int> strides(2);
   paddle::platform::dynload::miopenGet2dPoolingDescriptor(
-      desc, &mode, &kernel[0], &kernel[1], &pads[0], &pads[1],
-      &strides[0], &strides[1]);
+      desc, &mode, &kernel[0], &kernel[1], &pads[0], &pads[1], &strides[0],
+      &strides[1]);
 
   for (size_t i = 0; i < src_pads.size(); ++i) {
     EXPECT_EQ(kernel[i], src_kernel[i]);

--- a/paddle/fluid/platform/place.h
+++ b/paddle/fluid/platform/place.h
@@ -114,7 +114,7 @@ struct PlaceVisitorWrapper
   }
 
   typename Visitor::result_type operator()(const CUDAPlace &cuda) const {
-#ifdef PADDLE_WITH_CUDA
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP))
     return visitor_(cuda);
 #else
     PADDLE_THROW("Paddle is not compiled with CUDA. Cannot visit cuda device");
@@ -124,7 +124,7 @@ struct PlaceVisitorWrapper
 
   typename Visitor::result_type operator()(
       const CUDAPinnedPlace &cuda_pinned) const {
-#ifdef PADDLE_WITH_CUDA
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP))
     return visitor_(cuda_pinned);
 #else
     PADDLE_THROW("Paddle is not compiled with CUDA. Cannot visit cuda_pinned");

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -23,6 +23,9 @@ limitations under the License. */
 #ifdef PADDLE_WITH_CUDA
 #include <cuda.h>
 #endif  // PADDLE_WITH_CUDA
+#ifdef PADDLE_WITH_HIP
+#include <hip/hip_runtime.h>
+#endif  // PADDLE_WITH_HIP
 #include "glog/logging.h"
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/platform/device_tracer.h"
@@ -109,6 +112,16 @@ Event::Event(EventType type, std::string name, uint32_t thread_id,
     PADDLE_ENFORCE(cudaEventRecord(event_, stream));
   }
 #endif
+#ifdef PADDLE_WITH_HIP
+  has_cuda_ = dev_ctx ? platform::is_gpu_place(dev_ctx->GetPlace()) : false;
+  if (has_cuda_) {
+    auto* cuda_dev_ctx = static_cast<const CUDADeviceContext*>(dev_ctx);
+    PADDLE_ENFORCE(hipGetDevice(&device_));
+    PADDLE_ENFORCE(hipEventCreate(&event_));
+    auto stream = cuda_dev_ctx->stream();
+    PADDLE_ENFORCE(hipEventRecord(event_, stream));
+  }
+#endif
   cpu_ns_ = GetTimeInNsec();
 }
 
@@ -127,12 +140,20 @@ double Event::CudaElapsedMs(const Event& e) const {
   float ms;
   PADDLE_ENFORCE(cudaEventElapsedTime(&ms, event_, e.event()));
   return ms;
+#elif defined(PADDLE_WITH_HIP)
+  PADDLE_ENFORCE(e.has_cuda() && has_cuda());
+  PADDLE_ENFORCE(e.device() == device());
+  PADDLE_ENFORCE(hipEventSynchronize(event_));
+  PADDLE_ENFORCE(hipEventSynchronize(e.event()));
+  float ms;
+  PADDLE_ENFORCE(hipEventElapsedTime(&ms, event_, e.event()));
+  return ms;
 #else
   PADDLE_THROW("CUDA is not enabled");
 #endif
 }
 
-#ifdef PADDLE_WITH_CUDA
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP))
 static void ForEachDevice(std::function<void(int)> func) {
   auto original_device = GetCurrentDeviceId();
   int count = GetCUDADeviceCount();
@@ -226,7 +247,7 @@ void EnableProfiler(ProfilerState state) {
   if (g_state == ProfilerState::kAll) {
     GetDeviceTracer()->Enable();
   }
-#ifdef PADDLE_WITH_CUDA
+#if (defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP))
   if (g_state == ProfilerState::kCUDA) {
     // Generate some dummy events first to reduce the startup overhead.
     for (int i = 0; i < 5; i++) {

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -42,6 +42,11 @@ class Event {
   int device() const { return device_; }
 #endif
 
+#ifdef PADDLE_WITH_HIP
+  hipEvent_t event() const { return event_; }
+  int device() const { return device_; }
+#endif
+
   double CpuElapsedMs(const Event& e) const;
   double CudaElapsedMs(const Event& e) const;
 
@@ -53,6 +58,10 @@ class Event {
   bool has_cuda_;
 #ifdef PADDLE_WITH_CUDA
   cudaEvent_t event_ = nullptr;
+  int device_ = -1;
+#endif
+#ifdef PADDLE_WITH_HIP
+  hipEvent_t event_ = nullptr;
   int device_ = -1;
 #endif
 };

--- a/paddle/fluid/platform/rccl_helper.h
+++ b/paddle/fluid/platform/rccl_helper.h
@@ -1,0 +1,137 @@
+//   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <thread>
+#include <typeindex>
+#include "paddle/fluid/platform/dynload/rccl.h"
+#include "paddle/fluid/platform/enforce.h"
+
+namespace paddle {
+namespace platform {
+
+inline rcclDataType_t ToNCCLDataType(std::type_index type) {
+  if (type == typeid(float)) {  // NOLINT
+    return rcclFloat;
+  } else if (type == typeid(double)) {  // NOLINT
+    return rcclDouble;
+  } else if (type == typeid(int)) {  // NOLINT
+    return rcclInt;
+  } else {
+    PADDLE_THROW("Not supported");
+  }
+}
+
+class NCCLGroupGuard {
+ public:
+  inline NCCLGroupGuard() {
+    mutex().lock();
+    //PADDLE_ENFORCE(dynload::rcclGroupStart());
+  }
+
+  inline ~NCCLGroupGuard() {
+    //PADDLE_ENFORCE(dynload::rcclGroupEnd());
+    mutex().unlock();
+  }
+
+ private:
+  static std::mutex &mutex() {
+    static std::mutex mtx;
+    return mtx;
+  }
+};
+
+struct NCCLContext {
+  std::unique_ptr<CUDADeviceContext> ctx_;
+  rcclComm_t comm_;
+
+  explicit NCCLContext(int dev_id)
+      : ctx_(new CUDADeviceContext(CUDAPlace(dev_id))) {}
+
+  hipStream_t stream() const { return ctx_->stream(); }
+
+  int device_id() const {
+    return boost::get<platform::CUDAPlace>(ctx_->GetPlace()).device;
+  }
+
+  static void InitNCCLContext(std::unordered_map<int, NCCLContext> &contexts,
+                              const std::vector<platform::Place> &places) {
+    std::vector<rcclComm_t> comms;
+    std::vector<int> devs;
+    comms.resize(contexts.size());
+    devs.reserve(contexts.size());
+
+    for (auto &p : places) {
+      devs.push_back(boost::get<platform::CUDAPlace>(p).device);
+    }
+
+    PADDLE_ENFORCE(platform::dynload::rcclCommInitAll(
+        &comms[0], static_cast<int>(contexts.size()), &devs[0]));
+
+    int i = 0;
+    for (auto &dev_id : devs) {
+      contexts.at(dev_id).comm_ = comms[i++];
+    }
+  }
+};
+
+struct NCCLContextMap {
+  std::unordered_map<int, NCCLContext> contexts_;
+  std::vector<int> order_;
+
+  NCCLContextMap(const std::vector<platform::Place> &places) {
+    order_.reserve(places.size());
+    for (auto &p : places) {
+      int dev_id = boost::get<CUDAPlace>(p).device;
+      order_.emplace_back(dev_id);
+      contexts_.emplace(dev_id, NCCLContext(dev_id));
+    }
+    PADDLE_ENFORCE_EQ(
+        order_.size(), contexts_.size(),
+        "RCCL Context Map does not support contain two or more same device");
+
+    std::vector<rcclComm_t> comms;
+    comms.resize(order_.size());
+
+    PADDLE_ENFORCE(platform::dynload::rcclCommInitAll(
+        &comms[0], static_cast<int>(order_.size()), &order_[0]));
+
+    int i = 0;
+    for (auto &dev_id : order_) {
+      contexts_.at(dev_id).comm_ = comms[i++];
+    }
+  }
+
+  CUDADeviceContext *DevCtx(int dev_id) const { return at(dev_id).ctx_.get(); }
+
+  CUDADeviceContext *DevCtx(platform::Place p) const {
+    return DevCtx(boost::get<CUDAPlace>(p).device);
+  }
+
+  const NCCLContext &at(platform::Place p) const {
+    return this->at(boost::get<CUDAPlace>(p).device);
+  }
+
+  const NCCLContext &at(int dev_id) const { return contexts_.at(dev_id); }
+
+  void WaitAll() {
+    for (auto &p : contexts_) {
+      p.second.ctx_->Wait();
+    }
+  }
+};
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/rccl_helper.h
+++ b/paddle/fluid/platform/rccl_helper.h
@@ -38,11 +38,11 @@ class NCCLGroupGuard {
  public:
   inline NCCLGroupGuard() {
     mutex().lock();
-    //PADDLE_ENFORCE(dynload::rcclGroupStart());
+    // PADDLE_ENFORCE(dynload::rcclGroupStart());
   }
 
   inline ~NCCLGroupGuard() {
-    //PADDLE_ENFORCE(dynload::rcclGroupEnd());
+    // PADDLE_ENFORCE(dynload::rcclGroupEnd());
     mutex().unlock();
   }
 

--- a/paddle/fluid/platform/transform.h
+++ b/paddle/fluid/platform/transform.h
@@ -22,6 +22,14 @@ limitations under the License. */
 #include "paddle/fluid/platform/hostdevice.h"
 #include "paddle/fluid/platform/place.h"
 
+#ifdef __HIPCC__
+#include <algorithm>
+#include <type_traits>
+#include <thrust/system/cuda/detail/par.h>
+#include <thrust/execution_policy.h>
+#include <thrust/transform.h>
+#include "paddle/fluid/platform/details/cuda_transform_iterator_cast.h"
+#endif
 #ifdef __NVCC__
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
@@ -76,7 +84,7 @@ struct Transform<platform::CPUDeviceContext> {
   }
 };
 
-#ifdef __NVCC__
+#if (defined(__HIPCC__) || defined(__NVCC))
 template <>
 struct Transform<platform::CUDADeviceContext> {
   template <typename InputIter, typename OutputIter, typename UnaryOperation>

--- a/paddle/fluid/platform/transform.h
+++ b/paddle/fluid/platform/transform.h
@@ -23,11 +23,11 @@ limitations under the License. */
 #include "paddle/fluid/platform/place.h"
 
 #ifdef __HIPCC__
+#include <thrust/execution_policy.h>
+#include <thrust/system/cuda/detail/par.h>
+#include <thrust/transform.h>
 #include <algorithm>
 #include <type_traits>
-#include <thrust/system/cuda/detail/par.h>
-#include <thrust/execution_policy.h>
-#include <thrust/transform.h>
 #include "paddle/fluid/platform/details/cuda_transform_iterator_cast.h"
 #endif
 #ifdef __NVCC__

--- a/paddle/fluid/platform/transform.h
+++ b/paddle/fluid/platform/transform.h
@@ -84,7 +84,7 @@ struct Transform<platform::CPUDeviceContext> {
   }
 };
 
-#if (defined(__HIPCC__) || defined(__NVCC))
+#if (defined(__HIPCC__) || defined(__NVCC__))
 template <>
 struct Transform<platform::CUDADeviceContext> {
   template <typename InputIter, typename OutputIter, typename UnaryOperation>


### PR DESCRIPTION
Add HIP support to fluid/platform and fluid/operators/nccl.
Support of MIOpen, hipBLAS, hipRAND and rccl is added to fluid/platform/dynload.
fluid/operators/nccl refers NCCL header files so HIP support is added as well.