### PR TITLE
Add 4 docs to fluid/dev

### DIFF
--- a/doc/fluid/dev/contribute_to_paddle_cn.md
+++ b/doc/fluid/dev/contribute_to_paddle_cn.md
@@ -1,0 +1,1 @@
+../../v2/dev/contribute_to_paddle_cn.md

--- a/doc/fluid/dev/contribute_to_paddle_en.md
+++ b/doc/fluid/dev/contribute_to_paddle_en.md
@@ -1,0 +1,1 @@
+../../v2/dev/contribute_to_paddle_en.md

--- a/doc/fluid/dev/index_cn.rst
+++ b/doc/fluid/dev/index_cn.rst
@@ -4,6 +4,8 @@
 .. toctree::
   :maxdepth: 1
 
+  contribute_to_paddle_cn.md
+  write_docs_cn.md
   api_doc_std_cn.md
   new_op_cn.md
   new_op_kernel.md

--- a/doc/fluid/dev/index_en.rst
+++ b/doc/fluid/dev/index_en.rst
@@ -4,6 +4,8 @@ Development
 .. toctree::
   :maxdepth: 1
 
+  contribute_to_paddle_en.md
+  write_docs_en.md
   api_doc_std_en.md
   new_op_en.md
   new_op_kernel.md

--- a/doc/fluid/dev/write_docs_cn.rst
+++ b/doc/fluid/dev/write_docs_cn.rst
@@ -1,0 +1,1 @@
+../../v2/dev/write_docs_cn.rst

--- a/doc/fluid/dev/write_docs_en.rst
+++ b/doc/fluid/dev/write_docs_en.rst
@@ -1,0 +1,1 @@
+../../v2/dev/write_docs_en.rst


### PR DESCRIPTION
Add 4 documents to fluid/dev by adding soft links from v2/dev:
- [contribute_to_paddle_cn.md](https://github.com/PaddlePaddle/Paddle/blob/develop/doc/v2/dev/contribute_to_paddle_cn.md)
- [contribute_to_paddle_en.md](https://github.com/PaddlePaddle/Paddle/blob/develop/doc/v2/dev/contribute_to_paddle_en.md)
- [write_docs_cn.rst](https://github.com/PaddlePaddle/Paddle/blob/develop/doc/v2/dev/write_docs_cn.rst)
- [write_docs_en.rst](https://github.com/PaddlePaddle/Paddle/blob/develop/doc/v2/dev/write_docs_en.rst)