### PR TITLE
fix reduce_op_handle_test

### DIFF
--- a/paddle/fluid/framework/details/reduce_op_handle_test.cc
+++ b/paddle/fluid/framework/details/reduce_op_handle_test.cc
@@ -109,7 +109,7 @@ struct TestReduceOpHandle {
     // add input
     for (size_t j = 0; j < gpu_list_.size(); ++j) {
       if (!use_gpu_) {
-        op_handle_->dev_ctxes_[gpu_list_[j]] = ctxs_[j].get();
+        op_handle_->SetDeviceContext(gpu_list_[j], ctxs_[j].get());
       }
       auto *in_var_handle = new VarHandle(1, j, "input", gpu_list_[j]);
       in_var_handle->generated_op_ = nullptr;


### PR DESCRIPTION
build error:
```
[100%] Building CXX object paddle/fluid/framework/details/CMakeFiles/reduce_op_handle_test.dir/reduce_op_handle_test.cc.o
/Users/qiaolongfei/project/paddle/paddle/fluid/framework/details/reduce_op_handle_test.cc:112:21: error: 'dev_ctxes_' is a protected member of 'paddle::framework::details::OpHandleBase'
        op_handle_->dev_ctxes_[gpu_list_[j]] = ctxs_[j].get();
                    ^
/Users/qiaolongfei/project/paddle/paddle/fluid/framework/details/op_handle_base.h:75:7: note: declared protected here
      dev_ctxes_;
      ^
1 error generated.
make[3]: *** [paddle/fluid/framework/details/CMakeFiles/reduce_op_handle_test.dir/reduce_op_handle_test.cc.o] Error 1
make[2]: *** [paddle/fluid/framework/details/CMakeFiles/reduce_op_handle_test.dir/all] Error 2
make[1]: *** [paddle/fluid/framework/details/CMakeFiles/reduce_op_handle_test.dir/rule] Error 2
```