### PR TITLE
Fix cpplint error in mkldnn_activation

### DIFF
--- a/paddle/fluid/operators/mkldnn_activation_op.h
+++ b/paddle/fluid/operators/mkldnn_activation_op.h
@@ -60,7 +60,7 @@ class MKLDNNActivationGradKernel
   }
 };
 
-namespace {
+namespace {  // NOLINT
 framework::OpKernelType GetKernelType(
     const framework::ExecutionContext& ctx,
     const framework::OperatorWithKernel& oper) {


### PR DESCRIPTION
The anonymous namespace is exempt from checking.