### PR TITLE
Enable delay op feature

### DIFF
--- a/paddle/fluid/framework/details/threaded_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/threaded_ssa_graph_executor.cc
@@ -128,7 +128,7 @@ FeedFetchList ThreadedSSAGraphExecutor::Run(
     //
     // NOTE: DelayedOps have a lower priority. It will be scheduled after all
     // ready_ops have been performed.
-    if (ready_ops.empty() && allow_op_delay_) {
+    if (ready_ops.empty() && allow_op_delay_ && running_ops_ == 0) {
       run_all_ops(delayed_ops);
     } else {
       run_all_ops(ready_ops);


### PR DESCRIPTION
Currently, the delay_ops feature is invalid. 
`if (ready_ops.empty() && allow_op_delay_)` does not ensure the delayed op should be executed right now when we use thread pool to execute all the ready ops.

<img width="782" alt="wx20180422-171812 2x" src="https://user-images.githubusercontent.com/30176695/39093366-37a8388e-4651-11e8-906a-85b00ab2831e.png">