### PR TITLE
refine tensorrt cmake and dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,11 @@ ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
 RUN curl -s -q https://glide.sh/get | sh
 
 # Install TensorRT
-# The unnecessary files has been removed to make the library small. It only contains include and lib now.
+# following TensorRT.tar.gz is not the default official one, we do two miny changes:
+# 1. Remove the unnecessary files to make the library small. TensorRT.tar.gz only contains include and lib now,
+#    and its size is only one-third of the official one.
+# 2. Manually add ~IPluginFactory() in IPluginFactory class of NvInfer.h, otherwise, it couldn't work in paddle.
+#    See https://github.com/PaddlePaddle/Paddle/issues/10129 for details.
 RUN wget -qO- http://paddlepaddledeps.bj.bcebos.com/TensorRT-4.0.0.3.Ubuntu-16.04.4.x86_64-gnu.cuda-8.0.cudnn7.0.tar.gz | \
     tar -xz -C /usr/local && \
     cp -rf /usr/local/TensorRT/include /usr && \

--- a/cmake/tensorrt.cmake
+++ b/cmake/tensorrt.cmake
@@ -30,4 +30,6 @@ if(TENSORRT_FOUND)
 
     message(STATUS "Current TensorRT header is ${TENSORRT_INCLUDE_DIR}/NvInfer.h. "
         "Current TensorRT version is v${TENSORRT_MAJOR_VERSION}. ")
+    include_directories(${TENSORRT_INCLUDE_DIR})
+    list(APPEND EXTERNAL_LIBS ${TENSORRT_LIBRARY})
 endif()

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -21,7 +21,8 @@ endif()
 
 if(WITH_TESTING)
   add_subdirectory(tests/book)
-  if (TENSORRT_FOUND)
-    add_subdirectory(tensorrt)
-  endif()
+endif()
+
+if (TENSORRT_FOUND)
+  add_subdirectory(tensorrt)
 endif()


### PR DESCRIPTION
- fix #10129 
- add missing `include_directories` and `EXTERNAL_LIBS` when using `-DTENSORRT_ROOT`