### PR TITLE
remove duplicated ShareLoD in gru_op and sequence_conv_op

### DIFF
--- a/paddle/fluid/operators/gru_op.h
+++ b/paddle/fluid/operators/gru_op.h
@@ -56,8 +56,6 @@ class GRUKernel : public framework::OpKernel<T> {
     auto* hidden = context.Output<LoDTensor>("Hidden");
     hidden->mutable_data<T>(context.GetPlace());
 
-    context.ShareLoD("Input", "Hidden");
-
     auto hidden_dims = hidden->dims();
 
     bool is_reverse = context.Attr<bool>("is_reverse");

--- a/paddle/fluid/operators/sequence_conv_op.h
+++ b/paddle/fluid/operators/sequence_conv_op.h
@@ -33,7 +33,6 @@ class SequenceConvKernel : public framework::OpKernel<T> {
     auto filter = *context.Input<Tensor>("Filter");
 
     out->mutable_data<T>(context.GetPlace());
-    context.ShareLoD("X", "Out");
 
     int context_start = context.Attr<int>("contextStart");
     int context_length = context.Attr<int>("contextLength");

--- a/python/paddle/fluid/tests/book/test_image_classification.py
+++ b/python/paddle/fluid/tests/book/test_image_classification.py
@@ -244,7 +244,7 @@ def infer(use_cuda, save_dirname=None):
         assert len(results[0]) == len(transpiler_results[0])
         for i in range(len(results[0])):
             np.testing.assert_almost_equal(
-                results[0][i], transpiler_results[0][i], decimal=6)
+                results[0][i], transpiler_results[0][i], decimal=5)
 
         print("infer results: ", results[0])
 


### PR DESCRIPTION
`ShareLoD` has already been performed in infershape

https://github.com/PaddlePaddle/Paddle/blob/504e60a881fd7e72d744e256d90eaec4f52e5c7b/paddle/fluid/operators/gru_op.cc#L68

https://github.com/PaddlePaddle/Paddle/blob/504e60a881fd7e72d744e256d90eaec4f52e5c7b/paddle/fluid/operators/sequence_conv_op.cc#L73