### PR TITLE
Add init interface for customize devices.

### DIFF
--- a/paddle/fluid/framework/init.cc
+++ b/paddle/fluid/framework/init.cc
@@ -30,7 +30,7 @@ std::once_flag p2p_init_flag;
 
 void InitGflags(std::vector<std::string> argv) {
   std::call_once(gflags_init_flag, [&]() {
-    argv.push_back("dummy");
+    argv.insert(argv.begin(), "dummy");
     int argc = argv.size();
     char **arr = new char *[argv.size()];
     std::string line;

--- a/paddle/fluid/framework/init.cc
+++ b/paddle/fluid/framework/init.cc
@@ -69,9 +69,9 @@ void InitP2P(std::vector<int> devices) {
 }
 
 void InitDevices(bool init_p2p) {
-/*Init all available devices by default */
-#ifdef PADDLE_WITH_CUDA
+  /*Init all available devices by default */
   std::vector<int> devices;
+#ifdef PADDLE_WITH_CUDA
   try {
     int count = platform::GetCUDADeviceCount();
     for (int i = 0; i < count; ++i) {

--- a/paddle/fluid/framework/init.cc
+++ b/paddle/fluid/framework/init.cc
@@ -108,15 +108,14 @@ void InitP2P(std::vector<int> devices) {
 }
 
 void InitDevices(bool init_p2p) {
-  /*Init all available devices by default */
-
-  std::vector<platform::Place> places;
-  places.emplace_back(platform::CPUPlace());
-  int count = 0;
-
+/*Init all available devices by default */
 #ifdef PADDLE_WITH_CUDA
+  std::vector<int> devices;
   try {
-    count = platform::GetCUDADeviceCount();
+    int count = platform::GetCUDADeviceCount();
+    for (int i = 0; i < count; ++i) {
+      devices.push_back(i);
+    }
   } catch (const std::exception &exp) {
     LOG(WARNING) << "Compiled with WITH_GPU, but no GPU found in runtime.";
   }
@@ -124,14 +123,7 @@ void InitDevices(bool init_p2p) {
   LOG(WARNING)
       << "'CUDA' is not supported, Please re-compile with WITH_GPU option";
 #endif
-
-  for (int i = 0; i < count; ++i) {
-    places.emplace_back(platform::CUDAPlace(i));
-  }
-  if (init_p2p) {
-    InitP2P(count);
-  }
-  platform::DeviceContextPool::Init(places);
+  InitDevices(init_p2p, devices);
 }
 
 void InitDevices(bool init_p2p, const std::vector<int> devices) {

--- a/paddle/fluid/framework/init.cc
+++ b/paddle/fluid/framework/init.cc
@@ -20,7 +20,6 @@ limitations under the License. */
 #include "paddle/fluid/framework/init.h"
 #include "paddle/fluid/framework/operator.h"
 #include "paddle/fluid/platform/device_context.h"
-#include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/place.h"
 #include "paddle/fluid/string/piece.h"
 
@@ -35,10 +34,8 @@ std::once_flag p2p_init_flag;
 
 using paddle::platform::DeviceContextPool;
 
-void Init(int argc, char **argv) {
-  std::call_once(gflags_init_flag,
-                 [&]() { google::ParseCommandLineFlags(&argc, &argv, true); });
-
+void Init(std::vector<std::string> &argv) {
+  InitGflags(argv);
   // init devices
   std::vector<int> devices;
   std::string token;
@@ -51,6 +48,7 @@ void Init(int argc, char **argv) {
 
 void InitGflags(std::vector<std::string> &argv) {
   std::call_once(gflags_init_flag, [&]() {
+    argv.push_back("dummy");
     int argc = argv.size();
     char **arr = new char *[argv.size()];
     std::string line;
@@ -151,7 +149,7 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
 #endif
 
   for (size_t i = 0; i < devices.size(); ++i) {
-    if (devices[i] >= count) {
+    if (devices[i] >= count || devices[i] < 0) {
       LOG(WARNING) << "Invalid devices id.";
       continue;
     }

--- a/paddle/fluid/framework/init.h
+++ b/paddle/fluid/framework/init.h
@@ -20,7 +20,7 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-void Init(int argc, char **argv);
+void Init(std::vector<std::string> &argv);
 
 void InitGflags(std::vector<std::string> &argv);
 

--- a/paddle/fluid/framework/init.h
+++ b/paddle/fluid/framework/init.h
@@ -20,11 +20,15 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
+void Init(int argc, char **argv);
+
 void InitGflags(std::vector<std::string> &argv);
 
 void InitGLOG(const std::string &prog_name);
 
 void InitDevices(bool init_p2p);
+
+void InitDevices(bool init_p2p, const std::vector<int> devices);
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/init.h
+++ b/paddle/fluid/framework/init.h
@@ -22,8 +22,6 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-void Init(std::vector<std::string> argv);
-
 void InitGflags(std::vector<std::string> argv);
 
 void InitGLOG(const std::string &prog_name);

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -28,6 +28,8 @@ namespace inference {
 // linking the inference shared library.
 void Init(bool init_p2p) { framework::InitDevices(init_p2p); }
 
+void Init(int argc, char** argv) { framework::Init(argc, argv); }
+
 void ReadBinaryFile(const std::string& filename, std::string* contents) {
   std::ifstream fin(filename, std::ios::in | std::ios::binary);
   PADDLE_ENFORCE(static_cast<bool>(fin), "Cannot open file %s", filename);

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -24,11 +24,7 @@ limitations under the License. */
 namespace paddle {
 namespace inference {
 
-// Temporarily add this function for exposing framework::InitDevices() when
-// linking the inference shared library.
-void Init(bool init_p2p) { framework::InitDevices(init_p2p); }
-
-void Init(int argc, char** argv) { framework::Init(argc, argv); }
+void Init(std::vector<std::string> &argv) { framework::Init(argv); }
 
 void ReadBinaryFile(const std::string& filename, std::string* contents) {
   std::ifstream fin(filename, std::ios::in | std::ios::binary);

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -22,8 +22,8 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/pybind/pybind.h"
 
-DEFINE_string(devices, "", "The devices to be used.");
-DEFINE_bool(init_p2p, true, "Whether to init p2p.");
+DEFINE_string(devices, "", "The devices to be used which is joined by comma.");
+DEFINE_bool(init_p2p, false, "Whether to init p2p.");
 
 namespace paddle {
 namespace inference {

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -24,7 +24,7 @@ limitations under the License. */
 namespace paddle {
 namespace inference {
 
-void Init(std::vector<std::string> &argv) { framework::Init(argv); }
+void Init(const std::vector<std::string> argv) { framework::Init(argv); }
 
 void ReadBinaryFile(const std::string& filename, std::string* contents) {
   std::ifstream fin(filename, std::ios::in | std::ios::binary);

--- a/paddle/fluid/inference/io.cc
+++ b/paddle/fluid/inference/io.cc
@@ -16,15 +16,29 @@ limitations under the License. */
 
 #include <algorithm>
 #include <fstream>
+#include <vector>
 #include "paddle/fluid/framework/block_desc.h"
 #include "paddle/fluid/framework/feed_fetch_type.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/pybind/pybind.h"
 
+DEFINE_string(devices, "", "The devices to be used.");
+DEFINE_bool(init_p2p, true, "Whether to init p2p.");
+
 namespace paddle {
 namespace inference {
 
-void Init(const std::vector<std::string> argv) { framework::Init(argv); }
+void Init(const std::vector<std::string> argv) {
+  framework::InitGflags(argv);
+  // init devices
+  std::vector<int> devices;
+  std::string token;
+  std::istringstream tokenStream(FLAGS_devices);
+  while (std::getline(tokenStream, token, ',')) {
+    devices.push_back(std::stoi(token));
+  }
+  framework::InitDevices(FLAGS_init_p2p, devices);
+}
 
 void ReadBinaryFile(const std::string& filename, std::string* contents) {
   std::ifstream fin(filename, std::ios::in | std::ios::binary);

--- a/paddle/fluid/inference/io.h
+++ b/paddle/fluid/inference/io.h
@@ -27,6 +27,8 @@ namespace inference {
 
 void Init(bool init_p2p);
 
+void Init(int argc, char** argv);
+
 void LoadPersistables(framework::Executor* executor, framework::Scope* scope,
                       const framework::ProgramDesc& main_program,
                       const std::string& dirname,

--- a/paddle/fluid/inference/io.h
+++ b/paddle/fluid/inference/io.h
@@ -25,9 +25,7 @@ limitations under the License. */
 namespace paddle {
 namespace inference {
 
-void Init(bool init_p2p);
-
-void Init(int argc, char** argv);
+void Init(std::vector<std::string> &argv);
 
 void LoadPersistables(framework::Executor* executor, framework::Scope* scope,
                       const framework::ProgramDesc& main_program,

--- a/paddle/fluid/inference/io.h
+++ b/paddle/fluid/inference/io.h
@@ -25,7 +25,7 @@ limitations under the License. */
 namespace paddle {
 namespace inference {
 
-void Init(std::vector<std::string> &argv);
+void Init(const std::vector<std::string> argv);
 
 void LoadPersistables(framework::Executor* executor, framework::Scope* scope,
                       const framework::ProgramDesc& main_program,


### PR DESCRIPTION
在当前单测实现逻辑中，`RUN_ALL_TESTS()`前需要[初始化所有device](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/testing/paddle_gtest_main.cc#L44)，这与"初始化部分devices"的单测有所冲突，所以这个pr没有对`void InitDevices(bool init_p2p, const std::vector<int> devices)`进行单测。

在线下，通过注释掉[这句](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/testing/paddle_gtest_main.cc#L44)，通过了以下单测：
```
 TEST(InitDevices, single_CUDA) {
    using paddle::framework::Init;
    using paddle::platform::DeviceContextPool;
 
  #ifdef PADDLE_WITH_CUDA
    int count = paddle::platform::GetCUDADeviceCount();
    std::vector<char*> argvs;
    argvs.push_back(strdup("--devices=0,1"));
    int argc = static_cast<int>(argvs.size());
    char** argv = argvs.data();
    Init(&argc, &argv);
    DeviceContextPool& pool = DeviceContextPool::Instance();
    ASSERT_EQ(pool.size(), 3U);
  #endif
  }
```