### PR TITLE
"fix cuda9 error"

### DIFF
--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -39,7 +39,6 @@ ExternalProject_Add(
     extern_warpctc
     ${EXTERNAL_PROJECT_LOG_ARGS}
     GIT_REPOSITORY  "https://github.com/dzhwinter/warp-ctc.git"
-    GIT_TAG         cc12b667a89d8d4c9b163c523f0709eba5f0364f
     PREFIX          ${WARPCTC_SOURCES_DIR}
     UPDATE_COMMAND  ""
     CMAKE_ARGS      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -39,7 +39,7 @@ ExternalProject_Add(
     extern_warpctc
     ${EXTERNAL_PROJECT_LOG_ARGS}
     GIT_REPOSITORY  "https://github.com/dzhwinter/warp-ctc.git"
-    GIT_TAG         b63a0644654a3e0ed624c85a1767bc8193aead09
+    GIT_TAG         cc12b667a89d8d4c9b163c523f0709eba5f0364f
     PREFIX          ${WARPCTC_SOURCES_DIR}
     UPDATE_COMMAND  ""
     CMAKE_ARGS      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -38,7 +38,7 @@ ENDIF()
 ExternalProject_Add(
     extern_warpctc
     ${EXTERNAL_PROJECT_LOG_ARGS}
-    GIT_REPOSITORY  "https://github.com/gangliao/warp-ctc.git"
+    GIT_REPOSITORY  "https://github.com/dzhwinter/warp-ctc.git"
     GIT_TAG         b63a0644654a3e0ed624c85a1767bc8193aead09
     PREFIX          ${WARPCTC_SOURCES_DIR}
     UPDATE_COMMAND  ""


### PR DESCRIPTION
Currently, default warpctc will fail on cuda9. It has been fixed in my repo, and the original repo and gangliao's repo is not maintained anymore. We need to upgrade it to cuda9.0 because it is dependent by OCR model, speech model. 
This PR do the upgrade trick.