### PR TITLE
install ccache in Dockerfile to speed up compile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && \
     automake locales clang-format swig doxygen cmake  \
     liblapack-dev liblapacke-dev \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
-    net-tools libtool && \
+    net-tools libtool ccache && \
     apt-get clean -y
 
 # Install Go and glide


### PR DESCRIPTION
Install `ccache` in Dockerfile to speed up compile in image `paddle:latest-dev`.
After install, the `make` log is 
```
-- Ccache is founded, use ccache to speed up compile.
```
And we can use `export CCACHE_DIR=XXX` to specify the cache directory.