### PR TITLE
Remove unnecessary tensor copy in load op

### DIFF
--- a/paddle/fluid/operators/load_op.cc
+++ b/paddle/fluid/operators/load_op.cc
@@ -46,19 +46,6 @@ class LoadOp : public framework::OperatorBase {
     auto *tensor = out_var->GetMutable<framework::LoDTensor>();
 
     DeserializeFromStream(fin, tensor, *dev_ctx);
-
-    if (platform::is_gpu_place(place)) {
-      // copy CPU to GPU
-      framework::LoDTensor cpu_tensor;
-      cpu_tensor.ShareDataWith(*tensor);
-      cpu_tensor.set_lod(tensor->lod());
-
-      // reset tensor
-      out_var->Clear();
-      tensor = out_var->GetMutable<framework::LoDTensor>();
-      tensor->set_lod(cpu_tensor.lod());
-      TensorCopy(cpu_tensor, place, *dev_ctx, tensor);
-    }
   }
 };
 


### PR DESCRIPTION
`DeserializeFromStream` function calls `TensorFromStream`, where it has the following code:
https://github.com/PaddlePaddle/Paddle/blob/ccc594e4c41c5687b9cfb8a6e4922a3ffe13d982/paddle/fluid/framework/tensor_util.cc#L319-L336

This means that `TensorFromStream` will first load tensor from disk to CPU place, if the load op is run on GPU place, it will copy the tensor to GPU via `framework::TensorCopy(cpu_tensor, dst_place, dev_ctx, tensor); `

So in the load op, we don't need to do the copy from CPU to GPU again.