### PR TITLE
Fix sign unsigned comparison warning

### DIFF
--- a/paddle/fluid/operators/lookup_sparse_table_op.cc
+++ b/paddle/fluid/operators/lookup_sparse_table_op.cc
@@ -62,7 +62,7 @@ class LookupSparseTableOp : public framework::OperatorBase {
     auto w_t = w_var->GetMutable<framework::SelectedRows>();
     std::vector<int64_t> keys;
     keys.resize(ids_t.numel());
-    for (size_t i = 0; i < ids_t.numel(); ++i) {
+    for (int64_t i = 0; i < ids_t.numel(); ++i) {
       keys[i] = ids_t.data<int64_t>()[i];
     }
 


### PR DESCRIPTION
```
/paddle/Paddle/paddle/fluid/operators/lookup_sparse_table_op.cc:65:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   for (size_t i = 0; i < ids_t.numel(); ++i) {
```