### PR TITLE
allow inference test to generate timeline

### DIFF
--- a/paddle/fluid/inference/tests/test_helper.h
+++ b/paddle/fluid/inference/tests/test_helper.h
@@ -105,7 +105,7 @@ void TestInference(const std::string& dirname,
     state = paddle::platform::ProfilerState::kCPU;
   } else {
 #ifdef PADDLE_WITH_CUDA
-    state = paddle::platform::ProfilerState::kCUDA;
+    state = paddle::platform::ProfilerState::kAll;
     // The default device_id of paddle::platform::CUDAPlace is 0.
     // Users can get the device_id using:
     //   int device_id = place.GetDeviceId();
@@ -143,7 +143,7 @@ void TestInference(const std::string& dirname,
   }
   // Disable the profiler and print the timing information
   paddle::platform::DisableProfiler(paddle::platform::EventSortingKey::kDefault,
-                                    "load_program_profiler.txt");
+                                    "load_program_profiler");
   paddle::platform::ResetProfiler();
 
   // 3. Get the feed_target_names and fetch_target_names
@@ -208,7 +208,7 @@ void TestInference(const std::string& dirname,
     // Disable the profiler and print the timing information
     paddle::platform::DisableProfiler(
         paddle::platform::EventSortingKey::kDefault,
-        "run_inference_profiler.txt");
+        "run_inference_profiler");
     paddle::platform::ResetProfiler();
   }
 


### PR DESCRIPTION
generate timeline file
PYTHONPATH=/paddle/dev/my/build2/python/ python /paddle/dev/my/Paddle2/tools/timeline.py --profile_path=train=run_inference_profiler --timeline_path=/tmp/timeline_infer
visualize it
open url chrome://tracing