### PR TITLE
Revert "CI: rerun failed tests. (#10536)"

### DIFF
--- a/paddle/fluid/inference/tensorrt/test_engine.cc
+++ b/paddle/fluid/inference/tensorrt/test_engine.cc
@@ -98,7 +98,7 @@ TEST_F(TensorRTEngineTest, add_layer_multi_dim) {
 
   float x_v[2] = {1.0, 2.0};
   engine_->SetInputFromCPU("x", reinterpret_cast<void*>(&x_v),
-                           2 * sizeof(float));
+  2 * sizeof(float));
   engine_->Execute(1);
 
   LOG(INFO) << "to get output";

--- a/paddle/scripts/docker/build.sh
+++ b/paddle/scripts/docker/build.sh
@@ -100,14 +100,7 @@ function run_test() {
     Running unit tests ...
     ========================================
 EOF
-        set +e
         ctest --output-on-failure
-        if [ $? != 0 ]; then
-            set -e
-            ctest --output-on-failure --rerun-failed
-            set +e
-        fi
-        set -e
         # make install should also be test when unittest
         make install -j `nproc`
         pip install /usr/local/opt/paddle/share/wheels/*.whl

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -299,14 +299,7 @@ function run_test() {
     Running unit tests ...
     ========================================
 EOF
-        set +e
         ctest --output-on-failure
-        if [ $? != 0 ]; then
-            set -e
-            ctest --output-on-failure --rerun-failed
-            set +e
-        fi
-        set -e
         # make install should also be test when unittest
         make install -j `nproc`
         pip install /usr/local/opt/paddle/share/wheels/*.whl
@@ -474,7 +467,6 @@ EOF
 }
 
 function main() {
-    set -e
     local CMD=$1
     init
     case $CMD in

--- a/paddle/scripts/paddle_docker_build.sh
+++ b/paddle/scripts/paddle_docker_build.sh
@@ -59,7 +59,7 @@ EOL
     if [ ! -d "${HOME}/.ccache" ]; then
         mkdir ${HOME}/.ccache
     fi
-    set -ex
+    set -x
     ${DOCKER_CMD} run -it \
         --name $CONTAINER_ID \
         ${DOCKER_ENV} \


### PR DESCRIPTION
This reverts commit 0446220e0143afd9a6fafe600c645d9fd010333f.

Reason:

Rerun failed test hides flaky test.
Flaky test can be bugs, for example, race condition.
Test shouldn't be flaky, if a test is flaky, it should be fixed.