### PR TITLE
Include Eigen not framework/eigen in float16

### DIFF
--- a/paddle/fluid/platform/float16.h
+++ b/paddle/fluid/platform/float16.h
@@ -67,8 +67,8 @@ struct float16;
 }  // namespace platform
 }  // namespace paddle
 
-#include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/platform/hostdevice.h"
+#include "unsupported/Eigen/CXX11/Tensor"
 
 namespace paddle {
 namespace platform {


### PR DESCRIPTION
If `float16.h` include `framework/eigen.h`, it includes `tensor.h`, `ddim.h` indirectly, which causes circular reference. (`tensor` -> `float16` -> `tensor`)