### PR TITLE
"fix compile error"

### DIFF
--- a/paddle/fluid/operators/beam_search_op.h
+++ b/paddle/fluid/operators/beam_search_op.h
@@ -14,10 +14,6 @@ limitations under the License. */
 
 #pragma once
 
-#ifdef PADDLE_WITH_TESTING
-#include "gtest/gtest.h"
-#endif
-
 #include <string>
 #include <vector>
 #include "paddle/fluid/framework/lod_tensor.h"

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -49,7 +49,7 @@ nv_test(device_context_test SRCS device_context_test.cu DEPS device_context gpu_
 nv_test(cudnn_helper_test SRCS cudnn_helper_test.cc DEPS dynload_cuda)
 nv_test(transform_test SRCS transform_test.cu DEPS memory place device_context)
 
-cc_library(device_tracer SRCS device_tracer.cc DEPS boost profiler_proto ${GPU_CTX_DEPS})
+cc_library(device_tracer SRCS device_tracer.cc DEPS boost profiler_proto framework_proto ${GPU_CTX_DEPS})
 cc_library(profiler SRCS profiler.cc DEPS device_context device_tracer)
 cc_test(profiler_test SRCS profiler_test.cc DEPS profiler)
 


### PR DESCRIPTION
develop branch will be failed in a customed cmake options.
reproduce cmake shell command.
```shell
cmake .. -DWITH_GPU=ON -DWITH_GOLANG=OFF -DCMAKE_BUILD_TYPE=Release -DWITH_TESTING=ON -DWITH_FLUID_ONLY=ON && make -j `nproc` paddle_python
```