### PR TITLE
user need to set feed order for Trainer.train and Trainer.test

### DIFF
--- a/python/paddle/fluid/trainer.py
+++ b/python/paddle/fluid/trainer.py
@@ -172,9 +172,9 @@ class Trainer(object):
     def train(self,
               num_epochs,
               event_handler,
-              reader=None,
-              parallel=False,
-              feed_order=None):
+              reader,
+              feed_order,
+              parallel=False):
         """
         Train the model.
 
@@ -202,7 +202,7 @@ class Trainer(object):
 
         self._train_by_executor(num_epochs, event_handler, reader, feed_order)
 
-    def test(self, reader, feed_order=None):
+    def test(self, reader, feed_order):
         """
         Test the model on given test data
 
@@ -276,12 +276,7 @@ def build_feed_var_list(program, feed_order):
     if not isinstance(program, framework.Program):
         raise TypeError("The 'program' should be an object of Program")
 
-    if feed_order is None:
-        feed_var_list = [
-            var for var in program.global_block().vars.itervalues()
-            if var.is_data
-        ]
-    elif isinstance(feed_order, list):
+    if isinstance(feed_order, list):
         feed_var_list = [
             program.global_block().var(var_name) for var_name in feed_order
         ]


### PR DESCRIPTION
Two reasons:
1. I found that the order of
https://github.com/PaddlePaddle/Paddle/blob/6c32052653fb62b9d694a479fc83e30e1161c916/python/paddle/fluid/trainer.py#L281

is unstable, it will turn out in different order on different machine.

2. the order may change if user change it's train program,  for example
https://github.com/PaddlePaddle/Paddle/blob/6c32052653fb62b9d694a479fc83e30e1161c916/python/paddle/fluid/tests/book/high-level-api/fit_a_line/test_fit_a_line.py#L41-L48

if user write the code as:
```python
def linear():
    y_predict = inference_program()
    y = fluid.layers.data(name='y', shape=[1], dtype='float32')
   
    loss = fluid.layers.square_error_cost(input=y_predict, label=y)
    avg_loss = fluid.layers.mean(loss)

    return avg_loss
```
the order of data layer will change.