### PR TITLE
[WIP] Enhance assign_value_op to support bool type

### DIFF
--- a/paddle/fluid/operators/assign_value_op.cc
+++ b/paddle/fluid/operators/assign_value_op.cc
@@ -52,10 +52,13 @@ class AssignValueOpMaker : public framework::OpProtoAndCheckerMaker {
                               "Shape of values.");
     AddAttr<int>("dtype", "data type of values")
         .InEnum({framework::proto::VarType::INT32,
-                 framework::proto::VarType::FP32});
+                 framework::proto::VarType::FP32,
+                 framework::proto::VarType::BOOL});
     AddAttr<std::vector<float>>("fp32_values", "store the float values")
         .SetDefault({});
     AddAttr<std::vector<int>>("int32_values", "store the int values")
+        .SetDefault({});
+    AddAttr<std::vector<bool>>("bool_values", "store the bool values")
         .SetDefault({});
     AddComment(R"DOC(
 AssignValue operator
@@ -72,4 +75,5 @@ namespace ops = paddle::operators;
 
 REGISTER_OPERATOR(assign_value, ops::AssignValueOp, ops::AssignValueOpMaker);
 REGISTER_OP_CPU_KERNEL(assign_value, ops::AssignValueKernel<int>,
-                       ops::AssignValueKernel<float>);
+                       ops::AssignValueKernel<float>,
+                       ops::AssignValueKernel<bool>);

--- a/paddle/fluid/operators/assign_value_op.cu.cc
+++ b/paddle/fluid/operators/assign_value_op.cu.cc
@@ -16,4 +16,5 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(assign_value, ops::AssignValueKernel<int>,
-                        ops::AssignValueKernel<float>);
+                        ops::AssignValueKernel<float>,
+                        ops::AssignValueKernel<bool>);

--- a/paddle/fluid/operators/assign_value_op.h
+++ b/paddle/fluid/operators/assign_value_op.h
@@ -37,6 +37,9 @@ class AssignValueKernel : public framework::OpKernel<T> {
       case framework::proto::VarType::FP32:
         value_name = "fp32_values";
         break;
+      case framework::proto::VarType::BOOL:
+        value_name = "bool_values";
+        break;
       default:
         PADDLE_THROW("Unsupported dtype for assign_value_op: %d", dtype);
         break;


### PR DESCRIPTION
Sometimes we may need assign a bool array to a variable to flexibly control loop, or switch case, etc. Current assign_value_op supports only int and float. So we want to add bool type support to it.