### PR TITLE
Fix DataTransFunc

### DIFF
--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -36,9 +36,11 @@ void TransDataDevice(const Tensor& in, const platform::Place& dst_place,
   VLOG(3) << "DeviceTransform in, src_place " << in.place()
           << " dst_place: " << dst_place;
   auto* dev_ctx = GetDeviceContext(in.place(), dst_place);
-  dev_ctx->Wait();
+
   TensorCopy(in, dst_place, *dev_ctx, out);
-  dev_ctx->Wait();
+  if (platform::is_gpu_place(in.place()) && platform::is_cpu_place(dst_place)) {
+    dev_ctx->Wait();
+  }
 }
 
 }  // namespace framework


### PR DESCRIPTION
There are two cases for `TransDataDevice`, CPU->GPU and GPU->CPU.
If the `in` is in CPU and `out ` is in GPU, `dev_ctx->Wait()` is unnecessary here because all the operations(CUDA kernel and cudaMemcpyAsync) are in the same stream and the next operation which is to access `out` is in the same stream too.
If the `in` is in GPU and `out ` is in GPU, it doesn't need `dev_ctx->Wait()` obviously.
If the `in` is in CPU and `out ` is in CPU, it doesn't need `dev_ctx->Wait()` either.

Only if the `in` is in GPU and `out ` is in CPU, `dev_ctx->Wait()` is necessary, because `out ` may be accessed in the next operation.