### PR TITLE
Add lod_tensor.py for ease of creating lod tensor in book examples

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -48,7 +48,7 @@ from transpiler import DistributeTranspiler, SimpleDistributeTranspiler, \
     InferenceTranspiler, memory_optimize, release_memory
 from concurrency import (Go, make_channel, channel_send, channel_recv,
                          channel_close, Select)
-from lod_tensor import create_lod_tensor
+from lod_tensor import create_lod_tensor, create_random_int_lodtensor
 import clip
 import profiler
 import unique_name

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -48,6 +48,7 @@ from transpiler import DistributeTranspiler, SimpleDistributeTranspiler, \
     InferenceTranspiler, memory_optimize, release_memory
 from concurrency import (Go, make_channel, channel_send, channel_recv,
                          channel_close, Select)
+from lod_tensor import create_lod_tensor
 import clip
 import profiler
 import unique_name
@@ -59,7 +60,7 @@ Tensor = LoDTensor
 
 __all__ = framework.__all__ + executor.__all__ + concurrency.__all__ + \
           trainer.__all__ + inferencer.__all__ + transpiler.__all__ + \
-          parallel_executor.__all__ + [
+          parallel_executor.__all__ + lod_tensor.__all__ + [
               'io',
               'initializer',
               'layers',

--- a/python/paddle/fluid/lod_tensor.py
+++ b/python/paddle/fluid/lod_tensor.py
@@ -44,10 +44,10 @@ def _validate_lod(lod, tensor_height=-1):
         if val != len(lod[idx + 1]):
             return False
 
-    # Last level's sum should be equal to the tensor height
     if tensor_height == -1:
         return True
     else:
+        # Last level's sum should be equal to the tensor height
         return lod_sum[-1] == tensor_height
 
 
@@ -78,11 +78,11 @@ def create_lod_tensor(data, lod, place):
         	             but you pass type %s instead" % (type(data)))
 
 
-def create_random_int_lodtensor(lod, shape, low, high, place):
-    assert _validate_lod(lod), "the provided lod info is invalid"
+def create_random_int_lodtensor(lod, shape, place, low, high):
     assert isinstance(shape, list), "shape should be a list"
     converted_lod = _convert_lod(lod)
-    shape.insert(0, converted_lod[-1][-1])
-    # The range of integer data elements is [low, high]    
-    data = np.random.random_integers(low, high, shape).astype("int64")
+    # append the total number of basic elements to the front of its shape
+    new_shape = [converted_lod[-1][-1]] + shape
+    # the range of integer data elements is [low, high]    
+    data = np.random.random_integers(low, high, new_shape).astype("int64")
     return create_lod_tensor(data, lod, place)

--- a/python/paddle/fluid/lod_tensor.py
+++ b/python/paddle/fluid/lod_tensor.py
@@ -1,0 +1,78 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import core
+import numpy
+
+__all__ = ['create_lod_tensor']
+
+
+def _validate_lod(lod, tensor_height):
+    assert isinstance(lod, list), "lod should be a list"
+    # Empty lod is fine
+    if len(lod) == 0:
+        return True
+
+    lod_sum = []
+    for level in lod:
+        assert isinstance(level, list), "each item in lod should be a list"
+        # Each level of lod should have at least one length info
+        if len(level) < 1:
+            return False
+        level_sum = 0
+        for lod_len in level:
+            # Each length in a level should be > 0
+            if lod_len <= 0:
+                return False
+            level_sum += lod_len
+        lod_sum.append(level_sum)
+
+    for idx, val in enumerate(lod_sum[:-1]):
+        # Each level's sum should be equal to 
+        # the number of items in the next level
+        if val != len(lod[idx + 1]):
+            return False
+
+    # Last level's sum should be equal to the tensor height
+    if lod_sum[-1] != tensor_height:
+        return False
+    else:
+        return True
+
+
+def _convert_lod(lod):
+    new_lod = []
+    for level in lod:
+        cur_len = 0
+        new_level = [cur_len]
+        for lod_len in level:
+            cur_len += lod_len
+            new_level.append(cur_len)
+        new_lod.append(new_level)
+    return new_lod
+
+
+def create_lod_tensor(data, lod, place):
+    if isinstance(data, core.LoDTensor):
+        return create_lod_tensor(numpy.array(data), lod, place)
+    elif isinstance(data, numpy.ndarray):
+        assert _validate_lod(lod,
+                             data.shape[0]), "the provided lod info is invalid"
+        tensor = core.LoDTensor()
+        tensor.set(data, place)
+        tensor.set_lod(_convert_lod(lod))
+        return tensor
+    else:
+        raise Exception("data should be either a LoDTensor or a Numpy array, \
+        	             but you pass type %s instead" % (type(data)))

--- a/python/paddle/fluid/tests/book/test_word2vec.py
+++ b/python/paddle/fluid/tests/book/test_word2vec.py
@@ -21,15 +21,6 @@ import math
 import sys
 
 
-def create_random_lodtensor(lod, place, low, high):
-    # The range of data elements is [low, high]
-    data = np.random.random_integers(low, high, [lod[-1], 1]).astype("int64")
-    res = fluid.LoDTensor()
-    res.set(data, place)
-    res.set_lod([lod])
-    return res
-
-
 def train(use_cuda, is_sparse, is_parallel, save_dirname, is_local=True):
     PASS_NUM = 100
     EMBED_SIZE = 32
@@ -175,16 +166,19 @@ def infer(use_cuda, save_dirname=None):
         word_dict = paddle.dataset.imikolov.build_dict()
         dict_size = len(word_dict)
 
-        # Setup inputs, by creating 4 words, the lod of which should be [0, 1]
-        lod = [0, 1]
-        first_word = create_random_lodtensor(
-            lod, place, low=0, high=dict_size - 1)
-        second_word = create_random_lodtensor(
-            lod, place, low=0, high=dict_size - 1)
-        third_word = create_random_lodtensor(
-            lod, place, low=0, high=dict_size - 1)
-        fourth_word = create_random_lodtensor(
-            lod, place, low=0, high=dict_size - 1)
+        # Setup inputs, by creating 4 words, the shape of the word should be [1].
+        # The lod of word should be [[1]] meaning there is only one lod_level and 
+        # there is one sequence of one word on this level
+        lod = [[1]]
+        shape = [1]
+        first_word = fluid.create_random_int_lodtensor(
+            lod, shape, place, low=0, high=dict_size - 1)
+        second_word = fluid.create_random_int_lodtensor(
+            lod, shape, place, low=0, high=dict_size - 1)
+        third_word = fluid.create_random_int_lodtensor(
+            lod, shape, place, low=0, high=dict_size - 1)
+        fourth_word = fluid.create_random_int_lodtensor(
+            lod, shape, place, low=0, high=dict_size - 1)
 
         assert feed_target_names[0] == 'firstw'
         assert feed_target_names[1] == 'secondw'

--- a/python/paddle/fluid/tests/book/test_word2vec.py
+++ b/python/paddle/fluid/tests/book/test_word2vec.py
@@ -166,19 +166,22 @@ def infer(use_cuda, save_dirname=None):
         word_dict = paddle.dataset.imikolov.build_dict()
         dict_size = len(word_dict)
 
-        # Setup inputs, by creating 4 words, the shape of the word should be [1].
-        # The lod of word should be [[1]] meaning there is only one lod_level and 
-        # there is one sequence of one word on this level
+        # Setup inputs by creating 4 LoDTensors representing 4 words. Here each word 
+        # is simply an index to look up for the corresponding word vector and hence 
+        # the shape of word (base_shape) should be [1]. The length-based level of 
+        # detail (lod) info of each LoDtensor should be [[1]] meaning there is only 
+        # one lod_level and there is only one sequence of one word on this level.
+        # Note that lod info should be a list of lists.
         lod = [[1]]
-        shape = [1]
+        base_shape = [1]
         first_word = fluid.create_random_int_lodtensor(
-            lod, shape, place, low=0, high=dict_size - 1)
+            lod, base_shape, place, low=0, high=dict_size - 1)
         second_word = fluid.create_random_int_lodtensor(
-            lod, shape, place, low=0, high=dict_size - 1)
+            lod, base_shape, place, low=0, high=dict_size - 1)
         third_word = fluid.create_random_int_lodtensor(
-            lod, shape, place, low=0, high=dict_size - 1)
+            lod, base_shape, place, low=0, high=dict_size - 1)
         fourth_word = fluid.create_random_int_lodtensor(
-            lod, shape, place, low=0, high=dict_size - 1)
+            lod, base_shape, place, low=0, high=dict_size - 1)
 
         assert feed_target_names[0] == 'firstw'
         assert feed_target_names[1] == 'secondw'

--- a/python/paddle/fluid/tests/test_lod_tensor.py
+++ b/python/paddle/fluid/tests/test_lod_tensor.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import unittest
-import numpy
 import paddle.fluid as fluid
-import paddle.fluid.core as core
 from paddle.fluid.lod_tensor import create_lod_tensor, create_random_int_lodtensor, _validate_lod, _convert_lod
+import numpy
+import unittest
 
 
 class TestLoDTensor(unittest.TestCase):
@@ -55,7 +54,7 @@ class TestLoDTensor(unittest.TestCase):
 
     def test_create_lod_tensor(self):
         # Only numpy array or a fluid LoDTensor is valid input to
-        # create_lod_tensor function, a list of lists is not.
+        # create_lod_tensor function, currently a list of lists is not.
         data = [[1, 2], [3, 4]]
         self.assertRaises(Exception, create_lod_tensor, data, [],
                           fluid.CPUPlace())
@@ -73,14 +72,14 @@ class TestLoDTensor(unittest.TestCase):
         self.assertEqual(new_tensor.lod(), [[0, 2, 4, 5], [0, 1, 3, 5, 8, 10]])
 
     def test_create_random_int_lodtensor(self):
-        # The shape of a word, commonly used in speech and NLP problem
+        # The shape of a word, commonly used in speech and NLP problem, is [1]
         shape = [1]
         lod = [[2, 3, 5]]
         dict_size = 10000
         low = 0
         high = dict_size - 1
-        tensor = create_random_int_lodtensor(lod, shape, low, high,
-                                             fluid.CPUPlace())
+        tensor = create_random_int_lodtensor(lod, shape,
+                                             fluid.CPUPlace(), low, high)
         self.assertEqual(tensor.lod(), [[0, 2, 5, 10]])
         self.assertEqual(tensor.shape(), [10, 1])
 

--- a/python/paddle/fluid/tests/test_lod_tensor.py
+++ b/python/paddle/fluid/tests/test_lod_tensor.py
@@ -1,0 +1,30 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid.lod_tensor import create_lod_tensor, _validate_lod, _convert_lod
+
+
+class TestLoDTensor(unittest.TestCase):
+    def test_validate_lod_1(self):
+        lod = (1, 2, 1)
+        self.assertRaises(AssertionError, _validate_lod, lod, -1)
+        lod = [[1, 2], (2, 3)]
+        self.assertRaises(AssertionError, _validate_lod, lod, -1)
+
+
+if __name__ == ` __main__ `:
+    unittest.main()

--- a/python/paddle/fluid/tests/test_lod_tensor.py
+++ b/python/paddle/fluid/tests/test_lod_tensor.py
@@ -16,24 +16,73 @@ import unittest
 import numpy
 import paddle.fluid as fluid
 import paddle.fluid.core as core
-from paddle.fluid.lod_tensor import create_lod_tensor, _validate_lod, _convert_lod
+from paddle.fluid.lod_tensor import create_lod_tensor, create_random_int_lodtensor, _validate_lod, _convert_lod
 
 
 class TestLoDTensor(unittest.TestCase):
-    def test_validate_lod_1(self):
+    def test_validate_lod(self):
         lod = (1, 2, 1)
         self.assertRaises(AssertionError, _validate_lod, lod, -1)
-        lod = [[1, 2], [2, 3]]
+        lod = [[1, 2], (2, 3)]
+        self.assertRaises(AssertionError, _validate_lod, lod, -1)
+        lod = [1, 2, 3]
         self.assertRaises(AssertionError, _validate_lod, lod, -1)
 
-    def test_convert_lod_1(self):
+        lod = []
+        self.assertTrue(_validate_lod(lod, -1))
+        lod = [[], [1], [3]]
+        self.assertFalse(_validate_lod(lod, -1))
+        lod = [[0], [-1], [3]]
+        self.assertFalse(_validate_lod(lod, -1))
+
+        # Each level's sum should be equal to the number of items in the next level
+        # Moreover, last level's sum should be equal to the tensor height
+        lod = [[2, 3], [1, 3, 1, 2, 1]]
+        self.assertTrue(_validate_lod(lod, tensor_height=8))
+        lod = [[1, 3], [2, 1, 3]]
+        self.assertFalse(_validate_lod(lod, tensor_height=6))
+        lod = [[1, 3], [2, 1, 3, 4]]
+        self.assertFalse(_validate_lod(lod, tensor_height=5))
+
+    def test_convert_lod(self):
         lod = [[1, 2, 3]]
         converted_lod = [[0, 1, 3, 6]]
         self.assertEqual(_convert_lod(lod), converted_lod)
 
-    def test_create_lod_tensor_1(self):
-        tensor = numpy.random.random([10, 1])
-        create_lod_tensor(tensor, [[2, 2], [3, 3, 4]], fluid.CPUPlace())
+        lod = [[2, 3], [1, 3, 1, 2, 1]]
+        converted_lod = [[0, 2, 5], [0, 1, 4, 5, 7, 8]]
+        self.assertEqual(_convert_lod(lod), converted_lod)
+
+    def test_create_lod_tensor(self):
+        # Only numpy array or a fluid LoDTensor is valid input to
+        # create_lod_tensor function, a list of lists is not.
+        data = [[1, 2], [3, 4]]
+        self.assertRaises(Exception, create_lod_tensor, data, [],
+                          fluid.CPUPlace())
+
+        # Create LoDTensor from numpy array
+        data = numpy.random.random([10, 1])
+        lod = [[2, 1], [3, 3, 4]]
+        tensor = create_lod_tensor(data, lod, fluid.CPUPlace())
+        self.assertEqual(tensor.lod(), [[0, 2, 3], [0, 3, 6, 10]])
+
+        # Create LoDTensor from another LoDTensor, they are differnt instances
+        new_lod = [[2, 2, 1], [1, 2, 2, 3, 2]]
+        new_tensor = create_lod_tensor(tensor, new_lod, fluid.CPUPlace())
+        self.assertEqual(tensor.lod(), [[0, 2, 3], [0, 3, 6, 10]])
+        self.assertEqual(new_tensor.lod(), [[0, 2, 4, 5], [0, 1, 3, 5, 8, 10]])
+
+    def test_create_random_int_lodtensor(self):
+        # The shape of a word, commonly used in speech and NLP problem
+        shape = [1]
+        lod = [[2, 3, 5]]
+        dict_size = 10000
+        low = 0
+        high = dict_size - 1
+        tensor = create_random_int_lodtensor(lod, shape, low, high,
+                                             fluid.CPUPlace())
+        self.assertEqual(tensor.lod(), [[0, 2, 5, 10]])
+        self.assertEqual(tensor.shape(), [10, 1])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/test_lod_tensor.py
+++ b/python/paddle/fluid/tests/test_lod_tensor.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+import numpy
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.lod_tensor import create_lod_tensor, _validate_lod, _convert_lod
@@ -22,9 +23,18 @@ class TestLoDTensor(unittest.TestCase):
     def test_validate_lod_1(self):
         lod = (1, 2, 1)
         self.assertRaises(AssertionError, _validate_lod, lod, -1)
-        lod = [[1, 2], (2, 3)]
+        lod = [[1, 2], [2, 3]]
         self.assertRaises(AssertionError, _validate_lod, lod, -1)
 
+    def test_convert_lod_1(self):
+        lod = [[1, 2, 3]]
+        converted_lod = [[0, 1, 3, 6]]
+        self.assertEqual(_convert_lod(lod), converted_lod)
 
-if __name__ == ` __main__ `:
+    def test_create_lod_tensor_1(self):
+        tensor = numpy.random.random([10, 1])
+        create_lod_tensor(tensor, [[2, 2], [3, 3, 4]], fluid.CPUPlace())
+
+
+if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
fix #10735 

This PR did the following things:

1. Add lod_tensor.py utility module providing functions for ease of creating LoDTensor in book examples.
2. Add test code for lod_tensor.py
3. As an example, modify test_word2vec.py to show how to use the lod_tensor.py module in book examples. 