### PR TITLE
speedup the im2col in CPU inference

### DIFF
--- a/paddle/fluid/operators/math/im2col.cc
+++ b/paddle/fluid/operators/math/im2col.cc
@@ -66,17 +66,17 @@ class Im2ColFunctor<paddle::operators::math::ColFormat::kCFO,
       int w_offset = c % filter_width;
       int h_offset = (c / filter_width) % filter_height;
       int c_im = c / (filter_width * filter_height);
+      int im_row_start = h_offset * dilation[0] - padding[0];
+      int im_col_start = w_offset * dilation[1] - padding[1];
       for (int h = 0; h < col_height; ++h) {
-        int im_row_idx = h * stride[0] - padding[0] + h_offset * dilation[0];
+        int im_row_idx = im_row_start + h * stride[0];
         for (int w = 0; w < col_width; ++w) {
-          int im_col_idx = w * stride[1] - padding[1] + w_offset * dilation[1];
+          int im_col_idx = im_col_start + w * stride[1];
           int col_idx = (c * col_height + h) * col_width + w;
           int im_idx = (im_row_idx + c_im * im_height) * im_width + im_col_idx;
-
-          col_data[col_idx] = (im_row_idx < 0 || im_row_idx >= im_height ||
-                               im_col_idx < 0 || im_col_idx >= im_width)
-                                  ? static_cast<T>(0)
-                                  : im_data[im_idx];
+          bool flag = im_row_idx < 0 || im_row_idx >= im_height ||
+                      im_col_idx < 0 || im_col_idx >= im_width;
+          col_data[col_idx] = flag ? static_cast<T>(0) : im_data[im_idx];
         }
       }
     }


### PR DESCRIPTION
speed up the im2col function：
- decreasing the calculation: for example, `int im_col_idx = w * stride[1] - padding[1] + w_offset * dilation[1];` needs `channels_col* col_height* col_width * (2 mul + 1sum + 1 minus)`, now, it needs `channels_col* col_height* col_width * 1sum + channels_col * (1sum + 2minus)`
- use `flag = im_row_idx < 0 || im_row_idx >= im_height || im_col_idx < 0 || im_col_idx >= im_width;` to increase the hit of `if`.

#10685 OCR CRNN_CTC model: 
- the conv2d time: 4.83ms(before) -> 4.41ms(after), speedup: +8.7%
- whole inference time: 58.6ms(before) -> 53.2ms(after), speedup: 9.2%