### PR TITLE
Dockerfile: add --allow-downgrades option when install libnccl.

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -433,7 +433,7 @@ EOF
 EOF
 
     if [[ ${WITH_GPU} == "ON"  ]]; then
-        NCCL_DEPS="apt-get install -y libnccl2=2.1.2-1+cuda${CUDA_MAJOR} libnccl-dev=2.1.2-1+cuda${CUDA_MAJOR} &&"
+        NCCL_DEPS="apt-get install -y --allow-downgrades libnccl2=2.1.2-1+cuda${CUDA_MAJOR} libnccl-dev=2.1.2-1+cuda${CUDA_MAJOR} &&"
     else
         NCCL_DEPS=""
     fi


### PR DESCRIPTION
Base image, nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04, preinstalled higher version of libnccl, which will cause "apt-get install -y libnccl2=2.1.2-1+cuda9.0 libnccl-dev=2.1.2-1+cuda9.0" error. Add "--allow-downgrades" to fix this.