### PR TITLE
Modify word2vec example using new LoDTensor API 

### DIFF
--- a/python/paddle/fluid/tests/book/test_word2vec.py
+++ b/python/paddle/fluid/tests/book/test_word2vec.py
@@ -174,6 +174,7 @@ def infer(use_cuda, save_dirname=None):
         # Note that lod info should be a list of lists.
         lod = [[1]]
         base_shape = [1]
+        # The range of random integers is [low, high]
         first_word = fluid.create_random_int_lodtensor(
             lod, base_shape, place, low=0, high=dict_size - 1)
         second_word = fluid.create_random_int_lodtensor(


### PR DESCRIPTION
Please check #10735 for why we are doing this.

To solve the issue above, we have merged a PR #10817 and now there is utility functions [here](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/lod_tensor.py) to create LoDTensor.

So this means that we can simplify the book example code using the new API.
This PR tries to simplify the new word2vec book example.