### PR TITLE
fix error in the example for lod_rank_table

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -665,7 +665,8 @@ class While(object):
 
 def lod_rank_table(x, level=0):
     """LoD Rank Table Operator. Given an input variable **x** and a level number
-    of LoD, this layer creates a LodRankTable object. A LoDRankTable object
+    of LoD, this layer creates a LodRankTable object. A larger level number
+    corresponds to coarser-level of details. A LoDRankTable object
     contains a list of bi-element tuples. Each tuple consists of an index and
     a length, both of which are int type. Refering to specified level of LoD,
     the index is the sequence index number and the length representes the
@@ -684,14 +685,14 @@ def lod_rank_table(x, level=0):
                     lod_rank_table_obj = lod_rank_table(x, level=0)
 
                 Get:
-                    lod_rank_table_obj.items() = [(0, 2), (1, 1)]
+                    lod_rank_table_obj.items() = [(0, 5), (1, 1), (2, 1)]
 
             2. set level to 1:
                 Create lod rank table:
                     lod_rank_table_obj = lod_rank_table(x, level=1)
 
                 Get:
-                    lod_rank_table_obj.items() = [(0, 5), (1, 1), (2, 1)]
+                    lod_rank_table_obj.items() = [(0, 2), (1, 1)]
 
     Args:
         x (Variable): Input variable, a LoDTensor based which to create the lod


### PR DESCRIPTION
The example for lod_rank_table function is wrong and mis-leading for understanding the function as well as the meaning of 'level' in LoD.