### PR TITLE
refine fluid deploy on teamcity

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -172,6 +172,7 @@ add_custom_target(inference_lib_dist DEPENDS ${inference_lib_dist_dep})
 # paddle fluid version
 execute_process(
   COMMAND ${GIT_EXECUTABLE} log --pretty=format:%H -1
+  WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
   OUTPUT_VARIABLE PADDLE_GIT_COMMIT)
 set(version_file ${FLUID_INSTALL_DIR}/version.txt)
 file(WRITE ${version_file}

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -496,7 +496,9 @@ function gen_fluid_inference_lib() {
     ========================================
 EOF
         make -j `nproc` inference_lib_dist
-        tar -cf ${PADDLE_ROOT}/build/fluid.tgz ${PADDLE_ROOT}/build/fluid_install_dir
+        cd ${PADDLE_ROOT}/build
+        mv fluid_install_dir fluid
+        tar -cf fluid.tgz fluid
       fi
 }
 


### PR DESCRIPTION
解决两个问题：
- TeamCity上的version.txt打不出git commit id。原因是本地环境下build目录在source目录里，而TeamCity上的build目录不在source目录里，所以使用git命令打不出commit id。因此需要加上`WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}`
- TeamCity目前下载的包有多余路径为`paddle->build->fluid_install_dir`:
```
paddle/
└── build
    └── fluid_install_dir
        ├── CMakeCache.txt
        ├── paddle
        ├── third_party
        └── version.txt
```
更改后为：
```
fluid/
├── CMakeCache.txt
├── paddle
├── third_party
└── version.txt
```