### PR TITLE
Fix DataTransFunc

### DIFF
--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -38,7 +38,8 @@ void TransDataDevice(const Tensor& in, const platform::Place& dst_place,
   auto* dev_ctx = GetDeviceContext(in.place(), dst_place);
 
   TensorCopy(in, dst_place, *dev_ctx, out);
-  if (platform::is_gpu_place(in.place()) && platform::is_cpu_place(dst_place)) {
+
+  if (in.place().which() != dst_place.which()) {
     dev_ctx->Wait();
   }
 }


### PR DESCRIPTION
TransDataDevice is used to transform data from GPU to CPU and the enforced checkings have been done in GetDeviceContext, so the `dev_ctx->Wait()` is necessary. But `dev_ctx->Wait()` will make the program slow, especially when the number of elements is little, for example, the elements of learning rate are one and it's CPU side. 
One solution is to use a CUDA kernel to complete the copy operation when the transforming is from CPU to GPU and the number of elements is little. But the embarrassment is that this solution this solution makes training slower.
