### PR TITLE
Blas optimized elementwise_add forward and backward passes

### DIFF
--- a/paddle/fluid/operators/elementwise_add_op.cc
+++ b/paddle/fluid/operators/elementwise_add_op.cc
@@ -25,6 +25,6 @@ REGISTER_OP_CPU_KERNEL(
 REGISTER_OP_CPU_KERNEL(
     elementwise_add_grad,
     ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, float>,
-    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, double>);
-// ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int>,
-// ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
+    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int>,
+    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/elementwise_add_op.cc
+++ b/paddle/fluid/operators/elementwise_add_op.cc
@@ -18,10 +18,10 @@ namespace ops = paddle::operators;
 REGISTER_ELEMWISE_OP(elementwise_add, "Add", "Out = X + Y");
 REGISTER_OP_CPU_KERNEL(
     elementwise_add,
-    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, float>,
-    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, double>,
-    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int>,
-    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int64_t>);
+    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, float>);
+//    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, double>);
+//    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int>,
+//    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int64_t>);
 REGISTER_OP_CPU_KERNEL(
     elementwise_add_grad,
     ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, float>,

--- a/paddle/fluid/operators/elementwise_add_op.cc
+++ b/paddle/fluid/operators/elementwise_add_op.cc
@@ -18,10 +18,10 @@ namespace ops = paddle::operators;
 REGISTER_ELEMWISE_OP(elementwise_add, "Add", "Out = X + Y");
 REGISTER_OP_CPU_KERNEL(
     elementwise_add,
-    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, float>);
-//    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, double>);
-//    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int>,
-//    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int64_t>);
+    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int>,
+    ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext, int64_t>);
 REGISTER_OP_CPU_KERNEL(
     elementwise_add_grad,
     ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, float>,

--- a/paddle/fluid/operators/elementwise_add_op.cc
+++ b/paddle/fluid/operators/elementwise_add_op.cc
@@ -26,5 +26,5 @@ REGISTER_OP_CPU_KERNEL(
     elementwise_add_grad,
     ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, float>,
     ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, double>);
-//    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int>,
-//    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
+// ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int>,
+// ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/elementwise_add_op.cc
+++ b/paddle/fluid/operators/elementwise_add_op.cc
@@ -25,6 +25,6 @@ REGISTER_OP_CPU_KERNEL(
 REGISTER_OP_CPU_KERNEL(
     elementwise_add_grad,
     ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, float>,
-    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, double>,
-    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int>,
-    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
+    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, double>);
+//    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int>,
+//    ops::ElementwiseAddGradKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/elementwise_add_op.h
+++ b/paddle/fluid/operators/elementwise_add_op.h
@@ -102,13 +102,15 @@ class ElementwiseAddGradKernel : public framework::OpKernel<T> {
     if (platform::is_cpu_place(ctx.GetPlace()) && (x->dims() == y->dims())) {
       auto blas = math::GetBlas<DeviceContext, T>(ctx);
 
-      if (dx)
-        dx->mutable_data<T>(ctx.GetPlace());
-      if (dy)
-        dy->mutable_data<T>(ctx.GetPlace());
+      if (dx) {
+        blas.VCOPY(dout->numel(), dout->data<T>(),
+                   dx->mutable_data<T>(ctx.GetPlace()));
+      }
 
-      blas.VCOPY(dout->numel(), dout->data<T>(), dx->data<T>());
-      blas.VCOPY(dout->numel(), dout->data<T>(), dy->data<T>());
+      if (dy) {
+        blas.VCOPY(dout->numel(), dout->data<T>(),
+                   dy->mutable_data<T>(ctx.GetPlace()));
+      }
     } else {
       ElemwiseGradCompute<DeviceContext, T, IdentityGrad<T>, IdentityGrad<T>>(
           ctx, *x, *y, *out, *dout, axis, dx, dy, IdentityGrad<T>(),

--- a/paddle/fluid/operators/elementwise_add_op.h
+++ b/paddle/fluid/operators/elementwise_add_op.h
@@ -102,7 +102,7 @@ class ElementwiseAddGradKernel : public framework::OpKernel<T> {
     if (platform::is_cpu_place(ctx.GetPlace()) && (x->dims() == y->dims())) {
       auto blas = math::GetBlas<DeviceContext, T>(ctx);
 
-      if (dx) 
+      if (dx)
         dx->mutable_data<T>(ctx.GetPlace());
       if (dy)
         dy->mutable_data<T>(ctx.GetPlace());

--- a/paddle/fluid/operators/elementwise_add_op.h
+++ b/paddle/fluid/operators/elementwise_add_op.h
@@ -85,7 +85,7 @@ struct IdentityGrad {
   HOSTDEVICE T operator()(T x, T y, T out, T dout) const { return dout; }
 };
 
-template<typename DeviceContext, typename T>
+template <typename DeviceContext, typename T>
 void default_elementwise_add_grad(const framework::ExecutionContext& ctx,
                                   const framework::Tensor* x,
                                   const framework::Tensor* y,
@@ -100,16 +100,15 @@ void default_elementwise_add_grad(const framework::ExecutionContext& ctx,
       IdentityGrad<T>());
 }
 
-template<typename DeviceContext, typename T>
+template <typename DeviceContext, typename T>
 typename std::enable_if<
     std::is_floating_point<T>::value &&
     std::is_same<DeviceContext, platform::CPUDeviceContext>::value>::type
 elementwise_add_grad(const framework::ExecutionContext& ctx,
-                     const framework::Tensor* x,
-                     const framework::Tensor* y,
+                     const framework::Tensor* x, const framework::Tensor* y,
                      const framework::Tensor* out,
-                     const framework::Tensor* dout,
-                     framework::Tensor* dx, framework::Tensor* dy) {
+                     const framework::Tensor* dout, framework::Tensor* dx,
+                     framework::Tensor* dy) {
   auto blas = math::GetBlas<DeviceContext, T>(ctx);
 
   if (dx) {
@@ -123,16 +122,15 @@ elementwise_add_grad(const framework::ExecutionContext& ctx,
   }
 }
 
-template<typename DeviceContext, typename T>
+template <typename DeviceContext, typename T>
 typename std::enable_if<
     !std::is_floating_point<T>::value ||
     !std::is_same<DeviceContext, platform::CPUDeviceContext>::value>::type
 elementwise_add_grad(const framework::ExecutionContext& ctx,
-                     const framework::Tensor* x,
-                     const framework::Tensor* y,
+                     const framework::Tensor* x, const framework::Tensor* y,
                      const framework::Tensor* out,
-                     const framework::Tensor* dout,
-                     framework::Tensor* dx, framework::Tensor* dy) {
+                     const framework::Tensor* dout, framework::Tensor* dx,
+                     framework::Tensor* dy) {
   default_elementwise_add_grad<DeviceContext, T>(ctx, x, y, out, dout, dx, dy);
 }
 
@@ -152,8 +150,8 @@ class ElementwiseAddGradKernel : public framework::OpKernel<T> {
     if (platform::is_cpu_place(ctx.GetPlace()) && (x->dims() == y->dims())) {
       elementwise_add_grad<DeviceContext, T>(ctx, x, y, out, dout, dx, dy);
     } else {
-      default_elementwise_add_grad<DeviceContext, T>(
-            ctx, x, y, out, dout, dx, dy);
+      default_elementwise_add_grad<DeviceContext, T>(ctx, x, y, out, dout, dx,
+                                                     dy);
     }
   }
 };

--- a/paddle/fluid/operators/math/blas.h
+++ b/paddle/fluid/operators/math/blas.h
@@ -126,6 +126,12 @@ class Blas {
   void AXPY(int n, T alpha, const T* x, T* y) const;
 
   template <typename T>
+  void VADD(int n, const T* x, const T* y, T* z) const;
+
+  template <typename T>
+  void VCOPY(int n, const T* x, T* y) const;
+
+  template <typename T>
   void GEMV(bool trans_a, int M, int N, T alpha, const T* A, const T* B, T beta,
             T* C) const;
 
@@ -161,6 +167,16 @@ class BlasT : private Blas<DeviceContext> {
   template <typename... ARGS>
   void AXPY(ARGS... args) const {
     Base()->template AXPY<T>(args...);
+  }
+
+  template <typename... ARGS>
+  void VADD(ARGS... args) const {
+    Base()->template VADD<T>(args...);
+  }
+
+  template <typename... ARGS>
+  void VCOPY(ARGS... args) const {
+    Base()->template VCOPY<T>(args...);
   }
 
   template <typename... ARGS>


### PR DESCRIPTION
This PR implements optimization of elementwse_add forward and backward passes.
It includes for forward pass:
* MKL VML-based optimization with `v?Add` then MKL/MKLDNN are used
* Blas-based optimization with `VCopy` and `SAXPY` operations when MKL is disabled

For backward pass:
* Blas level 1 `VCopy` is used for copying `dx` and `dy` vectors.

When integral or float16 types, or GPU device are used, the implementation falls back to the default (generic) `elementwise_add` operation.