### PR TITLE
fix a bug that causes reversed levels when LoD level is larger than one

### DIFF
--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -63,7 +63,7 @@ class DataToLoDTensorConverter(object):
         t = core.LoDTensor()
         t.set(arr, self.place)
         if self.lod_level > 0:
-            t.set_lod(self.lod)
+            t.set_lod(self.lod[::-1])
         return t
 
 


### PR DESCRIPTION
This commit fixes a bug in DataToLoDTensorConverter related to levels when lod level is larger than one.
According to the design convention, smaller level number should correspond to coarser scales (e.g. paragraph) while larger level number corresponds to finer-scales (e.g., sentences), e.g., LoD = [[0, 1, 3], [0, 2, 3, 5]]
However, the current version of DataToLoDTensorConverter produce an LoD in the reversed order, e.g., e.g., LoD = [[0, 2, 3, 5], [0, 1, 3]]