### PR TITLE
Top K algorithm: parallel version

### DIFF
--- a/paddle/fluid/operators/top_k_op.h
+++ b/paddle/fluid/operators/top_k_op.h
@@ -55,6 +55,9 @@ class TopkKernel : public framework::OpKernel<T> {
     // NOTE: eigen shape doesn't affect paddle tensor.
     eg_input.reshape(flat2dims);
 
+#ifdef PADDLE_WITH_MKLDNN
+#pragma omp parallel for
+#endif
     for (size_t i = 0; i < row; i++) {
       std::vector<std::pair<T, size_t>> vec;
       for (size_t j = 0; j < col; j++) {

--- a/paddle/fluid/operators/top_k_op.h
+++ b/paddle/fluid/operators/top_k_op.h
@@ -55,7 +55,7 @@ class TopkKernel : public framework::OpKernel<T> {
     // NOTE: eigen shape doesn't affect paddle tensor.
     eg_input.reshape(flat2dims);
 
-#ifdef PADDLE_WITH_MKLDNN
+#ifdef PADDLE_WITH_MKLML
 #pragma omp parallel for
 #endif
     for (size_t i = 0; i < row; i++) {


### PR DESCRIPTION
The implementation of the Top-k algorithm of PaddlePaddle with omp.

- The top-k algorithm without omp
Result: top_k   58          **3813.27**     33.239      69.4531     65.746
- The top-k algorithm with omp
Result: top_k   58          **92.8446**     0.889532    5.54269     1.60077