### PR TITLE
Fix float16 demo location issue

### DIFF
--- a/paddle/contrib/float16/README.md
+++ b/paddle/contrib/float16/README.md
@@ -89,7 +89,7 @@ cd Paddle
 # to `FROM nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04` and similarly for other configurations
 nvidia-docker build -t paddle:float16 .
 # After running this, different results will be written to different log files in Paddle/contrib/float16/
-nvidia-docker run -it -v $PWD:/paddle paddle:float16 /paddle/contrib/float16/run_float16_demo.sh
+nvidia-docker run -it -v $PWD:/paddle paddle:float16 /paddle/paddle/contrib/float16/run_float16_demo.sh
 ```
 
 #### Accuracy

--- a/paddle/contrib/float16/run_float16_demo.sh
+++ b/paddle/contrib/float16/run_float16_demo.sh
@@ -3,7 +3,7 @@
 BUILD_PATH=/paddle/fp16_build
 WHEEL_PATH=$BUILD_PATH/python/dist
 INFER_PATH=$BUILD_PATH/paddle/fluid/inference/tests/book
-DEMO_PATH=/paddle/contrib/float16
+DEMO_PATH=/paddle/paddle/contrib/float16
 
 # Use the single most powerful CUDA GPU on your machine
 export CUDA_VISIBLE_DEVICES=0
@@ -50,7 +50,6 @@ do
          --repeat=1 \
 
   $INFER_PATH/test_inference_image_classification_vgg \
-      --data_set=imagenet \
       --dirname=$DEMO_PATH/image_classification_imagenet_vgg.inference.model \
       --fp16_dirname=$DEMO_PATH/float16_image_classification_imagenet_vgg.inference.model \
       --repeat=$REPEAT \
@@ -68,7 +67,6 @@ do
          --repeat=1 \
 
   $INFER_PATH/test_inference_image_classification_resnet \
-      --data_set=imagenet \
       --dirname=$DEMO_PATH/image_classification_imagenet_resnet.inference.model \
       --fp16_dirname=$DEMO_PATH/float16_image_classification_imagenet_resnet.inference.model \
       --repeat=$REPEAT \
@@ -86,7 +84,6 @@ do
          --repeat=1 \
 
   $INFER_PATH/test_inference_image_classification_vgg \
-      --data_set=cifar10 \
       --dirname=$DEMO_PATH/image_classification_cifar10_vgg.inference.model \
       --fp16_dirname=$DEMO_PATH/float16_image_classification_cifar10_vgg.inference.model \
       --repeat=$REPEAT \
@@ -104,7 +101,6 @@ do
          --repeat=1 \
 
   $INFER_PATH/test_inference_image_classification_vgg \
-      --data_set=cifar10 \
       --dirname=$DEMO_PATH/image_classification_cifar10_resnet.inference.model \
       --fp16_dirname=$DEMO_PATH/float16_image_classification_cifar10_resnet.inference.model \
       --repeat=$REPEAT \


### PR DESCRIPTION
Since the `contrib/float16` folder is moved into `Paddle/paddle`, we need to modify the bash script to run the demo correctly.