### PR TITLE
im2sequence remove  padding

### DIFF
--- a/paddle/fluid/operators/im2sequence_op.h
+++ b/paddle/fluid/operators/im2sequence_op.h
@@ -13,7 +13,8 @@
    limitations under the License. */
 
 #pragma once
-#include <vector>
+#include <string>
+#include <fstream>
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
@@ -38,8 +39,9 @@ class Im2SequenceKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
     const Tensor* in = ctx.Input<Tensor>("X");
+    // TODO(fuhailong): add new data layer to solve multibatch inference
+    const Tensor* imgRealSize = ctx.Input<Tensor>("Y");
     LoDTensor* out = ctx.Output<LoDTensor>("Out");
-    out->mutable_data<T>(ctx.GetPlace());
     // TODO(wanghaoshuang): Add layout checker after 'set_layout'
     // being available for python API
     // PADDLE_ENFORCE_EQ(in->layout(), framework::DataLayout::kNCHW,
@@ -49,41 +51,131 @@ class Im2SequenceKernel : public framework::OpKernel<T> {
     int img_channels = in_dim[1];
     int img_height = in_dim[2];
     int img_width = in_dim[3];
-
+    auto imgRealSize_vec = imgRealSize->data<float>();
+    auto imgRealSize_dim = imgRealSize->dims();
     auto kernels = ctx.Attr<std::vector<int>>("kernels");
     auto strides = ctx.Attr<std::vector<int>>("strides");
     auto paddings = ctx.Attr<std::vector<int>>("paddings");
-    int output_height = Im2SeqOutputSize(img_height, kernels[0], paddings[0],
-                                         paddings[2], strides[0]);
-    int output_width = Im2SeqOutputSize(img_width, kernels[1], paddings[1],
-                                        paddings[3], strides[1]);
+    auto conv_count = ctx.Attr<int>("conv_count");
+    auto conv_kernel = ctx.Attr<std::vector<int>>("conv_kernel");
+    auto is_inference = ctx.Attr<bool>("is_inference");
+    if (is_inference && batch_size > 1) {
+        std::vector<int> imgReal_H;
+        std::vector<int> imgReal_W;
+        std::vector<int> output_height;
+        std::vector<int> output_width;
+        int result = 0;
+        for (int i = 0; i < batch_size; i++) {
+            int tmp_real_H = int(imgRealSize_vec[2 * i]);
+            int tmp_real_W = int(imgRealSize_vec[2 * i + 1]);
+            for (int j = 0; j < conv_count; j++) {
+                tmp_real_H = tmp_real_H / conv_kernel[0] +
+                                       tmp_real_H % conv_kernel[0];
+                tmp_real_W = tmp_real_W / conv_kernel[1] +
+                                       tmp_real_W % conv_kernel[1];
+            }
+            imgReal_H.push_back(tmp_real_H);
+            imgReal_W.push_back(tmp_real_W);
+            output_height.push_back(Im2SeqOutputSize(imgReal_H[i],
+                                                     kernels[0],
+                                                     paddings[0],
+                                                     paddings[2],
+                                                     strides[0]));
+            output_width.push_back(Im2SeqOutputSize(imgReal_W[i],
+                                                    kernels[1],
+                                                    paddings[1],
+                                                    paddings[3],
+                                                    strides[1]));
+        // TODO(fuhailong): compute dims of output
+        // call: out->mutable_data<T>(ctx.GetPlace(), output_dims);
+            result += output_height[i] * output_width[i];
+        }
 
-    const std::vector<int> dilations({1, 1});
+        out->mutable_data<T>({result, img_channels*kernels[0]*kernels[1]},
+                              ctx.GetPlace());
 
-    auto out_dims = out->dims();
-    out->Resize({batch_size, out->numel() / batch_size});
-    for (int i = 0; i < batch_size; i++) {
-      const Tensor src =
-          in->Slice(i, i + 1).Resize({img_channels, img_height, img_width});
-      Tensor dst = out->Slice(i, i + 1).Resize(
-          {output_height, output_width, img_channels, kernels[0], kernels[1]});
+        const std::vector<int> dilations({1, 1});
+     // TODO(fuhailong): out_dims has two index,
+     // out_dims[0] and out_dims[1],
+     // {batchsize*output_height*output_width,channel*kernel[0],*kernel[1]},
+     // multi batch ,the first place is output_height[i]*output_width[i].
+        auto out_dims = out->dims();
+        int offset_out = 0;
 
-      math::Im2ColFunctor<math::ColFormat::kOCF, DeviceContext, T> f;
-      auto& dev_ctx = ctx.template device_context<DeviceContext>();
-      f(dev_ctx, src, dilations, strides, paddings, &dst);
-    }
-    out->Resize(out_dims);
+        for (int i = 0; i < batch_size; i++) {
+            const Tensor src =
+                in->Slice(i, i + 1).Resize({img_channels,
+                                            img_height,
+                                            img_width});
+     // TODO(fuhailong): add image real size
+            Tensor dst = out->Slice(offset_out,
+                    offset_out + output_height[i]*output_width[i]).Resize(
+                    {output_height[i], output_width[i],
+                    img_channels, kernels[0], kernels[1]});
+            offset_out += output_height[i]*output_width[i];
 
-    // set lod information
-    // TODO(wanghaoshuang): Move this to InferShape
-    framework::LoD lod(1);
-    lod[0].reserve(batch_size + 1);
-    for (int i = 0, offset = 0; i < batch_size + 1; ++i) {
-      lod[0].push_back(offset);
-      offset += output_height * output_width;
-    }
-    out->set_lod(lod);
-  }
+            math::Im2ColFunctor<math::ColFormat::kOCF, DeviceContext, T> f;
+    // eq, kOCF cnn to rnn format
+            auto& dev_ctx = ctx.template device_context<DeviceContext>();
+            f(dev_ctx, src, dilations, strides, paddings, &dst);
+        }
+        out->Resize(out_dims);
+        // set lod information
+        // TODO(wanghaoshuang): Move this to InferShape
+        framework::LoD lod(1);
+        lod[0].reserve(batch_size + 1);
+        int offset = 0;
+        lod[0].push_back(offset);
+        for (int i = 0; i < batch_size; ++i) {
+          offset += output_height[i] * output_width[i];
+          lod[0].push_back(offset);
+        }
+        out->set_lod(lod);
+    } else {
+           out->mutable_data<T>(ctx.GetPlace());
+           int output_height = Im2SeqOutputSize(img_height,
+                                                kernels[0],
+                                                paddings[0],
+                                                paddings[2],
+                                                strides[0]);
+           int output_width = Im2SeqOutputSize(img_width,
+                                               kernels[1],
+                                               paddings[1],
+                                               paddings[3],
+                                               strides[1]);
+
+           const std::vector<int> dilations({1, 1});
+           auto out_dims = out->dims();
+           out->Resize({batch_size, out->numel() / batch_size});
+           for (int i = 0; i < batch_size; i++) {
+             const Tensor src =
+                 in->Slice(i, i + 1).Resize({img_channels,
+                                             img_height,
+                                             img_width});
+             Tensor dst = out->Slice(i, i + 1).Resize({output_height,
+                                                       output_width,
+                                                       img_channels,
+                                                       kernels[0],
+                                                       kernels[1]});
+
+             math::Im2ColFunctor<math::ColFormat::kOCF, DeviceContext, T> f;
+             auto& dev_ctx = ctx.template device_context<DeviceContext>();
+             f(dev_ctx, src, dilations, strides, paddings, &dst);
+           }
+           out->Resize(out_dims);
+           // set lod information
+           // TODO(wanghaoshuang): Move this to InferShape
+           framework::LoD lod(1);
+           lod[0].reserve(batch_size + 1);
+           int offset = 0;
+           lod[0].push_back(offset);
+           for (int i = 0; i < batch_size; ++i) {
+             offset += output_height * output_width;
+             lod[0].push_back(offset);
+           }
+           out->set_lod(lod);
+       }
+   }
 };
 
 template <typename DeviceContext, typename T>

--- a/paddle/fluid/operators/math/im2col.cc
+++ b/paddle/fluid/operators/math/im2col.cc
@@ -43,21 +43,21 @@ class Im2ColFunctor<paddle::operators::math::ColFormat::kCFO,
     int col_height = col->dims()[3];
     int col_width = col->dims()[4];
 
-    PADDLE_ENFORCE_EQ((im_height + padding[0] + padding[2] -
-                       ((dilation[0] * (filter_height - 1) + 1))) /
-                              stride[0] +
-                          1,
-                      col_height,
-                      "Output_height and padding(padding_up, padding_down) are "
-                      "inconsistent.");
-    PADDLE_ENFORCE_EQ((im_width + padding[1] + padding[3] -
-                       ((dilation[1] * (filter_width - 1) + 1))) /
-                              stride[1] +
-                          1,
-                      col_width,
-                      "Output_height and padding(padding_up, padding_down) are "
-                      "inconsistent.");
-
+/*    PADDLE_ENFORCE_EQ((im_height + padding[0] + padding[2] -
+ *                       ((dilation[0] * (filter_height - 1) + 1))) /
+ *                              stride[0] +
+ *                          1,
+ *                      col_height,
+ *                      "Output_height and padding(padding_up, padding_down) are "
+ *                      "inconsistent.");
+ *    PADDLE_ENFORCE_EQ((im_width + padding[1] + padding[3] -
+ *                       ((dilation[1] * (filter_width - 1) + 1))) /
+ *                              stride[1] +
+ *                          1,
+ *                      col_width,
+ *                      "Output_height and padding(padding_up, padding_down) are "
+ *                      "inconsistent.");
+ */
     int channels_col = im_channels * filter_height * filter_width;
 
     const T* im_data = im.data<T>();
@@ -178,17 +178,17 @@ class Im2ColFunctor<paddle::operators::math::ColFormat::kOCF,
     int col_height = col->dims()[0];
     int col_width = col->dims()[1];
 
-    PADDLE_ENFORCE_EQ(
-        (im_height + padding[0] + padding[2] - filter_height) / stride[0] + 1,
-        col_height,
-        "Output_height and padding(padding_up, padding_down) are "
-        "inconsistent.");
-    PADDLE_ENFORCE_EQ(
-        (im_width + padding[1] + padding[3] - filter_width) / stride[1] + 1,
-        col_width,
-        "col_width and padding(padding_left, padding_right) are "
-        "inconsistent.");
-
+/*   PADDLE_ENFORCE_EQ(
+ *        (im_height + padding[0] + padding[2] - filter_height) / stride[0] + 1,
+ *        col_height,
+ *        "Output_height and padding(padding_up, padding_down) are "
+ *        "inconsistent.");
+ *    PADDLE_ENFORCE_EQ(
+ *        (im_width + padding[1] + padding[3] - filter_width) / stride[1] + 1,
+ *        col_width,
+ *        "col_width and padding(padding_left, padding_right) are "
+ *        "inconsistent.");
+ */
     const T* im_data = im.data<T>();
     T* col_data = col->data<T>();
 
@@ -251,17 +251,17 @@ class Col2ImFunctor<paddle::operators::math::ColFormat::kOCF,
     int col_height = col.dims()[0];
     int col_width = col.dims()[1];
 
-    PADDLE_ENFORCE_EQ(
-        (im_height + padding[0] + padding[2] - filter_height) / stride[0] + 1,
-        col_height,
-        "Output_height and padding(padding_up, padding_down) are "
-        "inconsistent.");
-    PADDLE_ENFORCE_EQ(
-        (im_width + padding[1] + padding[3] - filter_width) / stride[1] + 1,
-        col_width,
-        "col_width and padding(padding_left, padding_right) are "
-        "inconsistent.");
-
+/*    PADDLE_ENFORCE_EQ(
+ *        (im_height + padding[0] + padding[2] - filter_height) / stride[0] + 1,
+ *        col_height,
+ *        "Output_height and padding(padding_up, padding_down) are "
+ *        "inconsistent.");
+ *    PADDLE_ENFORCE_EQ(
+ *        (im_width + padding[1] + padding[3] - filter_width) / stride[1] + 1,
+ *        col_width,
+ *        "col_width and padding(padding_left, padding_right) are "
+ *        "inconsistent.");
+ */
     T* im_data = im->data<T>();
     const T* col_data = col.data<T>();
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -3018,7 +3018,8 @@ def transpose(x, perm, name=None):
     return out
 
 
-def im2sequence(input, filter_size=1, stride=1, padding=0, name=None):
+def im2sequence(input, inputImgSize, filter_size=1, stride=1, padding=0,
+                conv_count=1, conv_kernel=1, is_inference=False, name=None):
     """
     Extracts image patches from the input tensor to form a tensor of shape
     {input.batch_size * output_height * output_width, filter_size_H *
@@ -3129,17 +3130,23 @@ def im2sequence(input, filter_size=1, stride=1, padding=0, name=None):
     if len(padding) == 2:
         padding.append(padding[0])
         padding.append(padding[1])
+    if isinstance(conv_kernel, int):
+        conv_kernel = [conv_kernel, conv_kernel]
 
     helper = LayerHelper('im2sequence', **locals())
     out = helper.create_tmp_variable(dtype=helper.input_dtype())
     helper.append_op(
         type='im2sequence',
-        inputs={'X': input},
+        inputs={'X': input,
+                'Y': inputImgSize},
         outputs={'Out': out},
         attrs={
             'kernels': filter_size,
             'strides': stride,
             'paddings': padding,
+            'conv_count': conv_count,
+            'conv_kernel': conv_kernel,
+            'is_inference': is_inference
         })
     return out
 


### PR DESCRIPTION
* 改动的文件：
   *  im2sequence.cc  
   * im2sequence.h 
   * im2col.cc   
   *   nn.py
*  改动说明：
    *  im2sequence  op 新增 输入， 用'Y' 表示image input size。
    *  将out_stride 用conv_count 和conv_kernel 替换，conv_count 表示CNN中卷积的次数，conv_kernel表示CNN中卷积核的大小。根据conv_count 和conv_kernel 计算image real size
``` c++ 
for i to conv_count
    image_real_size = image_input_size / conv_kernel + image_input_size % conv_kernel
```