### PR TITLE
fix nightly build and build script error

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -105,7 +105,7 @@ function cmake_gen() {
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         -DWITH_FLUID_ONLY=${WITH_FLUID_ONLY:-OFF}
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-        -DWITH_CONTRIB=ON
+        -DWITH_CONTRIB=${WITH_CONTRIB:-ON}
     ========================================
 EOF
     # Disable UNITTEST_USE_VIRTUALENV in docker because
@@ -132,7 +132,7 @@ EOF
         -DCMAKE_MODULE_PATH=/opt/rocm/hip/cmake \
         -DWITH_FLUID_ONLY=${WITH_FLUID_ONLY:-OFF} \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-        -DWITH_CONTRIB=ON
+        -DWITH_CONTRIB=${WITH_CONTRIB:-ON}
 }
 
 function abort(){


### PR DESCRIPTION
Fix nightly build fail:

```
[12:44:40]W:	 [Step 4/5] CMake Error at cmake/generic.cmake:199 (add_dependencies):
[12:44:40]W:	 [Step 4/5]   The dependency target "paddle_fluid_api" of target
[12:44:40]W:	 [Step 4/5]   "paddle_inference_api_impl" does not exist.

```