### PR TITLE
better profiler and benchmark

### DIFF
--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -272,8 +272,6 @@ if(NOT WITH_MKLDNN)
     list(REMOVE_ITEM GENERAL_OPS fc_op)
 endif(NOT WITH_MKLDNN)
 
-list(REMOVE_ITEM GENERAL_OPS reduce_op)
-
 foreach(src ${GENERAL_OPS})
     op_library(${src})
 endforeach()

--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -272,6 +272,8 @@ if(NOT WITH_MKLDNN)
     list(REMOVE_ITEM GENERAL_OPS fc_op)
 endif(NOT WITH_MKLDNN)
 
+list(REMOVE_ITEM GENERAL_OPS reduce_op)
+
 foreach(src ${GENERAL_OPS})
     op_library(${src})
 endforeach()

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -235,7 +235,7 @@ void EnableProfiler(ProfilerState state) {
     return;
   }
   g_state = state;
-  { should_send_profile_state = true; }
+  should_send_profile_state = true;
   GetDeviceTracer()->Enable();
 #ifdef PADDLE_WITH_CUDA
   if (g_state == ProfilerState::kCUDA) {
@@ -460,7 +460,7 @@ void DisableProfiler(EventSortingKey sorted_key,
     tracer->GenProfile(profile_path);
   }
   g_state = ProfilerState::kDisabled;
-  { should_send_profile_state = true; }
+  should_send_profile_state = true;
 }
 
 bool IsProfileEnabled() { return g_state != ProfilerState::kDisabled; }

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -492,6 +492,7 @@ All parameter, weight, gradient are variables in Paddle.
 
   m.def("enable_profiler", platform::EnableProfiler);
   m.def("disable_profiler", platform::DisableProfiler);
+  m.def("is_profiler_enabled", platform::IsProfileEnabled);
   m.def("reset_profiler", platform::ResetProfiler);
 
   // -- python binds for parallel executor.

--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -76,6 +76,15 @@ def reset_profiler():
 
 
 def start_profiler(state):
+    """Enable the profiler.
+
+    Args:
+        state (string) : The profiling state, which should be 'CPU', 'GPU'
+            or 'All'. 'CPU' means only profile CPU. 'GPU' means profiling
+            GPU as well. 'All' also generates timeline.
+    """
+    if core.is_profiler_enabled():
+        return
     if state not in ['CPU', 'GPU', "All"]:
         raise ValueError("The state must be 'CPU' or 'GPU' or 'All'.")
     if state == "GPU":
@@ -88,6 +97,23 @@ def start_profiler(state):
 
 
 def stop_profiler(sorted_key=None, profile_path='/tmp/profile'):
+    """Stop the profiler.
+
+    Args:
+        sorted_key (string) : If None, the profiling results will be printed
+            in the order of first end time of events. Otherwise, the profiling
+            results will be sorted by the this flag. This flag should be one
+            of 'calls', 'total', 'max', 'min' or 'ave'.
+            The `calls` means sorting by the number of calls.
+            The `total` means sorting by the total execution time.
+            The `max` means sorting by the maximum execution time.
+            The `min` means sorting by the minimum execution time.
+            The `ave` means sorting by the average execution time.
+        profile_path (string) : If state == 'All', it will write a profile
+            proto output file.
+    """
+    if not core.is_profiler_enabled():
+        return
     sorted_key = 'default' if sorted_key is None else sorted_key
     if sorted_key not in ['default', 'calls', 'total', 'max', 'min', 'ave']:
         raise ValueError("The sorted_key must be None or in 'calls', 'total', "


### PR DESCRIPTION
1. fix fluid_benchmark train_parallel() wrong trainer_id (always 0 trainer_id in train_parallel()).
2. fix profiler int value overflow
3. more flexible profiler python API

![image](https://user-images.githubusercontent.com/2887803/40704635-4083bf2c-641b-11e8-8b6d-bd9fa3601906.png)

try it with

```
#!/bin/bash

PADDLE_TRAINING_ROLE=PSERVER PADDLE_PSERVER_PORT=7164 PADDLE_PSERVER_IPS=127.0.0.1 PADDLE_TRAINERS=2 PADDLE_CURRENT_IP=127.0.0.1 PADDLE_TRAINER_ID=0 python ../Paddle/benchmark/fluid/fluid_benchmark.py --model resnet --device GPU --update_method pserver --iterations=10000 &

sleep 15

CUDA_VISIBLE_DEVICES=0,1 PADDLE_TRAINING_ROLE=TRAINER PADDLE_PSERVER_PORT=7164 PADDLE_PSERVER_IPS=127.0.0.1 PADDLE_TRAINERS=2 PADDLE_CURRENT_IP=127.0.0.1 PADDLE_TRAINER_ID=0 python ../Paddle/benchmark/fluid/fluid_benchmark.py --model resnet --device GPU --update_method pserver --iterations=10000 --gpus 2 --profile &

CUDA_VISIBLE_DEVICES=4,5 PADDLE_TRAINING_ROLE=TRAINER PADDLE_PSERVER_PORT=7164 PADDLE_PSERVER_IPS=127.0.0.1 PADDLE_TRAINERS=2 PADDLE_CURRENT_IP=127.0.0.1 PADDLE_TRAINER_ID=1 python ../Paddle/benchmark/fluid/fluid_benchmark.py --model resnet --device GPU --update_method pserver --iterations=10000 --gpus 2 --profile &
```