### PR TITLE
[WIP]Experiment/runtime memory optimize

### DIFF
--- a/paddle/fluid/memory/detail/buddy_allocator2.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator2.cc
@@ -1,0 +1,21 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/detail/buddy_allocator2.h"
+
+namespace paddle {
+namespace memory {
+namespace detail {}  // namespace detail
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/detail/buddy_allocator2.h
+++ b/paddle/fluid/memory/detail/buddy_allocator2.h
@@ -1,0 +1,100 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "paddle/fluid/memory/memory_block2.h"
+#include "paddle/fluid/memory/place.h"
+
+namespace paddle {
+namespace memory {
+namespace detail {
+
+template <typename Place>
+class BuddyAllocator {
+ public:
+  BuddyAllocator(Place, uint64_t min_block_size, uint64_t max_block_size);
+  void* Alloc(uint64_t unaligned_size);
+  void Free(void* ptr);
+  uint64_t Used() const;
+
+ private:
+  uint64_t AlignSize(uint64_t unaligned_size, uint64_t alignment) const;
+  MemoryBlock* FindBuddy(MemoryBlock* p, uint64_t size);
+
+ private:
+  Place place_;
+  const uint64_t kMinBlockSize;
+  const uint64_t kMaxBlockSize;
+  // MemoryBlock* root_;
+  std::unique_ptr<MemoryBlock> root_;
+  uint64_t total_size_;
+  uint64_t total_used_;
+  uint64_t current_block_size_;
+  std::mutex mutex_;
+  DISABLE_COPY_AND_ASSIGN(BuddyAllocator);
+};
+
+template <typename Place>
+BuddyAllocator::BuddyAllocator(Place, uint64_t min_block_size,
+                               uint64_t max_block_size)
+    : place_(place),
+      kMinBlockSize(min_block_size),
+      kMaxBlockSize(max_block_size),
+      root_(nullptr),
+      total_size_(0UL),
+      total_used_(0UL) {}
+
+template <typename Place>
+void* BuddyAllocator::Alloc(uint64_t unaligned_size) {
+  if (unaligned_size == 0) return nullptr;
+  auto size = AlignSize(unaligned_size + sizeof(BuddyAllocator), kMinBlockSize);
+
+  std::unique_lock<std::mutex> lock(mutex_);
+  auto* buddy = FindBuddy(root_);
+
+  if (root_ == nullptr) {
+    void* p = Alloc(size);
+    PADDLE_ENFORCE(p != nullptr, "Failed allocate memory from system.")
+  }
+}
+
+template <typename Place>
+uint64_t BuddyAllocator::AlignSize(uint64_t unaligned_size,
+                                   uint64_t alignment) const {
+  return unaligned_size % alignment == 0
+             ? unaligned_size
+             : (unaligned_size / alignment + 1) * alignment;
+}
+
+template <typename Place>
+MemoryBlock* FindBuddy(MemoryBlock* p, uint64_t size) {
+  MemoryBlock* ret = nullptr;
+  if (p->Size() == kMinBlockSize && size < p->Size()) {
+    ret = p;
+  }
+  if (ret == nullptr) {
+    ret = FindBuddy(p->LeftBuddy(), size);
+  }
+  if (ret == nullptr) {
+    ret = FindBuddy(p->RightBuddy(), size);
+  }
+  return ret;
+}
+
+}  // namespace detail
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/detail/memory_block2.cc
+++ b/paddle/fluid/memory/detail/memory_block2.cc
@@ -1,0 +1,106 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/detail/memory_block2.h"
+#include <functional>
+
+namespace paddle {
+namespace memory {
+namespace detail {
+namespace {
+
+template <class T>
+inline void hash_combine(std::uint64_t* seed, const T& v) {
+  std::hash<T> hasher;
+  (*seed) ^= hasher(v) + 0x9e3779b9 + ((*seed) << 6) + ((*seed) >> 2);
+}
+
+inline uint64_t hash(const MemoryBlock& block, uint64_t initial_seed) {
+  uint64_t seed = initial_seed;
+
+  hash_combine(&seed, static_cast<uint64_t>(block.state_));
+  hash_combine(&seed, block.raw_ptr_);
+  hash_combine(&seed, block.size_);
+  hash_combine(&seed, block.left_buddy_);
+  hash_combine(&seed, block.right_buddy_);
+
+  return seed;
+}
+
+}  // namespace
+
+MemoryBlock::MemoryBlock()
+    : state_(State::INVALID_BLOCK),
+      raw_ptr_(nullptr),
+      size_(0UL),
+      left_buddy_(nullptr),
+      right_buddy_(nullptr) {
+  UpdateGuards();
+}
+
+MemoryBlock::MemoryBlock(void* block, uint64_t size)
+    : state_(State::FREE_BLOCK),
+      raw_ptr_(block),
+      size_(size),
+      left_buddy_(nullptr),
+      right_buddy_(nullptr) {
+  UpdateGuards();
+}
+
+MemoryBlock::~MemoryBlock() {
+  // ensure the left, right buddy is released before.
+  PADDLE_ENFORCE(left_buddy_ == nullptr, "left_buddy error");
+  PADDLE_ENFORCE(right_buddy_ == nullptr, "right_buddy error");
+  PADDLE_ENFORCE(CheckGuards() == true, "memory block error");
+  Reset();
+}
+
+void MemoryBlock::Reset() {
+  state_ = State::INVALID_BLOCK;
+  raw_ptr_ = nullptr;
+  size_ = 0;
+  guard_begin_ = guard_end_ = 0;
+}
+
+void MemoryBlock::SplitToBuddy() {
+  left_buddy_.reset(new MemoryBlock(raw_ptr_, size / 2));
+  right_buddy_.reset(new MemoryBlock(raw_ptr_ + (size / 2), size / 2));
+  Reset();
+}
+
+void MemoryBlock::MergeFromBuddy() {
+  bool valid =
+      (left_buddy_ != nullptr) && (left_buddy_->State() == State::FREE_BLOCK);
+  valid &=
+      (right_buddy_ != nullptr) && (right_buddy_->State() == State::FREE_BLOCK);
+  PADDLE_ENFORCE(valid == true, "Failed to merge from buddy.");
+  state_ = State::FREE_BLOCK;
+  raw_ptr_ = left_buddy_;
+  size_ = left_buddy_->Size() * 2;
+  left_buddy_.reset();
+  right_buddy_.reset();
+}
+
+void MemoryBlock::UpdateGuards() {
+  guard_begin_ = hash(*this, 1);
+  guard_end_ = hash(*this, 2);
+}
+
+bool MemoryBlock::CheckGuards() const {
+  return guard_begin_ == hash(*this, 1) && guard_end_ == hash(*this, 2);
+}
+
+}  // namespace detail
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/detail/memory_block2.h
+++ b/paddle/fluid/memory/detail/memory_block2.h
@@ -1,0 +1,65 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/fluid/platform/enforce.h"
+
+namespace paddle {
+namespace memory {
+namespace detail {
+
+class MemoryBlock {
+ public:
+  enum State {
+    FREE_BLOCK,     // idle memory block
+    USED_BLOCK,     // in used memory block
+    INVALID_BLOCK,  // not own memory or memory can not be used.
+  };
+  MemoryBlock();
+  MemoryBlock(void* block, uint64_t size);
+  ~MemoryBlock();
+
+  void SplitToBuddy();
+  void MergeFromBuddy();
+
+  State GetState() const { return state_; }
+  void SetState(State state) { state_ = state; }
+  MemoryBlock* LeftBuddy() const { return left_buddy_; }
+  MemoryBlock* RightBuddy() const { return right_buddy_; }
+  uint64_t Size() const { return size_; }
+
+ private:
+  void UpdateGuards();
+  bool CheckGuards() const;
+  void Reset();
+
+ private:
+  // guard begin/end is magic number,
+  // check the memory when alloc/release
+  uint64_t guard_begin_;
+  State state_;
+  void* raw_ptr_;  // do not own
+  // std::unique_ptr<void> raw_ptr_;
+  uint64_t size_;
+  std::unique_ptr<MemoryBlock> left_buddy_;
+  std::unique_ptr<MemoryBlock> right_buddy_;
+  uint64_t guard_end_;
+  DISABLE_COPY_AND_ASSIGN(MemoryBlock);
+};
+
+}  // namespace detail
+}  // namespace memory
+}  // namespace paddle


### PR DESCRIPTION
 This is an experiment branch which I am doing some experiment on the variable reuse is based on reference counting and dependency analysis. 

Now we go two branches of memory optimize, one of them is runtime memory optimize. The MXNet does go this way, and do excellent job on memory consumption reducing.
https://mxnet.incubator.apache.org/architecture/note_engine.html
https://mxnet.incubator.apache.org/architecture/note_memory.html
However, we have two questions.
- The GPU is an asynchronize device, is it possible to release the memory in time.
- How is the fancy memory reuse technique fit in Fluid.


