### PR TITLE
fix build error on mac

### DIFF
--- a/paddle/fluid/operators/detail/grpc_server.h
+++ b/paddle/fluid/operators/detail/grpc_server.h
@@ -71,8 +71,8 @@ class AsyncGRPCServer final : public RPCServer {
   std::unique_ptr<::grpc::Server> server_;
 
   // condition of the sub program
-  std::mutex barrier_mutex_;
-  mutable int barrier_cond_step_;
+  // std::mutex barrier_mutex_;
+  // mutable int barrier_cond_step_;
   std::condition_variable barrier_condition_;
 
   std::mutex mutex_ready_;

--- a/paddle/fluid/operators/detail/grpc_server.h
+++ b/paddle/fluid/operators/detail/grpc_server.h
@@ -71,8 +71,6 @@ class AsyncGRPCServer final : public RPCServer {
   std::unique_ptr<::grpc::Server> server_;
 
   // condition of the sub program
-  // std::mutex barrier_mutex_;
-  // mutable int barrier_cond_step_;
   std::condition_variable barrier_condition_;
 
   std::mutex mutex_ready_;

--- a/paddle/fluid/operators/listen_and_serv_op.cc
+++ b/paddle/fluid/operators/listen_and_serv_op.cc
@@ -222,8 +222,8 @@ static void FillRequestCtx(detail::RequestHandler *h, framework::Scope *scope,
   h->SetDevCtx(dev_ctx);
   h->SetExecutor(executor);
   h->SetProgram(program);
-  h->SetPrefetchPreparedCtx(std::move(
-      std::unique_ptr<framework::ExecutorPrepareContext>(prefetch_ctx)));
+  h->SetPrefetchPreparedCtx(
+      std::unique_ptr<framework::ExecutorPrepareContext>(prefetch_ctx));
   h->SetRPCServer(rpc_server);
 }
 


### PR DESCRIPTION
```In file included from /Users/qiaolongfei/project/paddle/paddle/fluid/operators/detail/grpc_server.cc:18:
/Users/qiaolongfei/project/paddle/paddle/fluid/operators/detail/grpc_server.h:75:15: error: private field 'barrier_cond_step_' is not used [-Werror,-Wunused-private-field]
  mutable int barrier_cond_step_;
```

```
/Users/qiaolongfei/project/paddle/paddle/fluid/operators/listen_and_serv_op.cc:225:29: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
  h->SetPrefetchPreparedCtx(std::move(
                            ^
/Users/qiaolongfei/project/paddle/paddle/fluid/operators/listen_and_serv_op.cc:225:29: note: remove std::move call here
  h->SetPrefetchPreparedCtx(std::move(
                            ^~~~~~~~~~
```