### PR TITLE
Update open files op

### DIFF
--- a/paddle/fluid/operators/reader/open_files_op.cc
+++ b/paddle/fluid/operators/reader/open_files_op.cc
@@ -27,7 +27,7 @@ class MultiFileReader : public framework::ReaderBase {
                   const std::vector<framework::DDim>& dims, size_t thread_num,
                   size_t buffer_size)
       : buffer_size_(buffer_size) {
-    readers_.resize(file_names.size());
+    readers_.reserve(file_names.size());
     for (const std::string& f_name : file_names) {
       readers_.emplace_back(CreateReaderByFileName(f_name, dims));
     }

--- a/paddle/fluid/operators/reader/open_files_op.cc
+++ b/paddle/fluid/operators/reader/open_files_op.cc
@@ -63,9 +63,6 @@ void MultiFileReader::ReadNext(std::vector<framework::LoDTensor>* out) {
 
 void MultiFileReader::ReInit() {
   EndScheduler();
-  for (auto& reader : readers_) {
-    reader->ReInit();
-  }
   StartNewScheduler();
 }
 
@@ -141,6 +138,7 @@ void MultiFileReader::PrefetchThreadFunc(size_t reader_idx, size_t thread_idx) {
     std::vector<framework::LoDTensor> ins;
     reader->ReadNext(&ins);
     if (ins.empty()) {
+      reader->ReInit();
       break;
     }
     try {


### PR DESCRIPTION
Reduce the time cost of `MultiFileReader::ReInit()` from 1530ms to 17ms