### PR TITLE
fix protobuf memory leak

### DIFF
--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -217,21 +217,9 @@ BlockDesc::BlockDesc(const BlockDesc &other, proto::BlockDesc *desc,
   }
 }
 
-void BlockDesc::ClearPBOps() {
-  auto ops = this->desc_->mutable_ops();
-  while (!ops->empty()) {
-    // we do not own the OpDesc, so release the ownership.
-    ops->ReleaseLast();
-  }
-}
+void BlockDesc::ClearPBOps() {}
 
-void BlockDesc::ClearPBVars() {
-  auto vars = this->desc_->mutable_vars();
-  while (!vars->empty()) {
-    // we do not own the VarDesc, so release the ownership.
-    vars->ReleaseLast();
-  }
-}
+void BlockDesc::ClearPBVars() {}
 
 void BlockDesc::SetForwardBlockID(int32_t forward_block_id) {
   PADDLE_ENFORCE(!desc_->has_forward_block_idx(),

--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -219,7 +219,7 @@ BlockDesc::BlockDesc(const BlockDesc &other, proto::BlockDesc *desc,
 
 void BlockDesc::ClearPBOps() { this->desc_->mutable_ops()->Clear(); }
 
-void BlockDesc::ClearPBVars() { this->desc_->mutable_vars(); }
+void BlockDesc::ClearPBVars() { this->desc_->mutable_vars()->Clear(); }
 
 void BlockDesc::SetForwardBlockID(int32_t forward_block_id) {
   PADDLE_ENFORCE(!desc_->has_forward_block_idx(),

--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -169,17 +169,13 @@ void BlockDesc::Flush() {
   }
 
   if (need_update_) {
-    auto &op_field = *this->desc_->mutable_ops();
-    this->ClearPBOps();
-    op_field.Reserve(static_cast<int>(ops_.size()));
+    this->desc_->mutable_ops()->Clear();
     for (auto &op_desc : ops_) {
-      op_field.AddAllocated(op_desc->Proto());
+      this->desc_->mutable_ops()->Add()->CopyFrom(*op_desc->Proto());
     }
-    auto &var_field = *this->desc_->mutable_vars();
-    this->ClearPBVars();
-    var_field.Reserve(static_cast<int>(vars_.size()));
+    this->desc_->mutable_vars()->Clear();
     for (auto &var_desc : vars_) {
-      var_field.AddAllocated(var_desc.second->Proto());
+      this->desc_->mutable_vars()->Add()->CopyFrom(*var_desc.second->Proto());
     }
     need_update_ = false;
   }
@@ -216,10 +212,6 @@ BlockDesc::BlockDesc(const BlockDesc &other, proto::BlockDesc *desc,
     vars_[it.first].reset(var);
   }
 }
-
-void BlockDesc::ClearPBOps() { this->desc_->mutable_ops()->Clear(); }
-
-void BlockDesc::ClearPBVars() { this->desc_->mutable_vars()->Clear(); }
 
 void BlockDesc::SetForwardBlockID(int32_t forward_block_id) {
   PADDLE_ENFORCE(!desc_->has_forward_block_idx(),

--- a/paddle/fluid/framework/block_desc.cc
+++ b/paddle/fluid/framework/block_desc.cc
@@ -217,9 +217,9 @@ BlockDesc::BlockDesc(const BlockDesc &other, proto::BlockDesc *desc,
   }
 }
 
-void BlockDesc::ClearPBOps() {}
+void BlockDesc::ClearPBOps() { this->desc_->mutable_ops()->Clear(); }
 
-void BlockDesc::ClearPBVars() {}
+void BlockDesc::ClearPBVars() { this->desc_->mutable_vars(); }
 
 void BlockDesc::SetForwardBlockID(int32_t forward_block_id) {
   PADDLE_ENFORCE(!desc_->has_forward_block_idx(),

--- a/paddle/fluid/framework/block_desc.h
+++ b/paddle/fluid/framework/block_desc.h
@@ -41,11 +41,6 @@ class BlockDesc {
 
   BlockDesc(const BlockDesc &other, proto::BlockDesc *desc, ProgramDesc *prog);
 
-  ~BlockDesc() {
-    this->ClearPBVars();
-    this->ClearPBOps();
-  }
-
   int32_t ID() const { return desc_->idx(); }
 
   int32_t Parent() const { return desc_->parent_idx(); }
@@ -112,10 +107,6 @@ class BlockDesc {
   proto::BlockDesc *Proto();
 
   ProgramDesc *Program() const { return this->prog_; }
-
- private:
-  void ClearPBOps();
-  void ClearPBVars();
 
  private:
   ProgramDesc *prog_;       // not_own


### PR DESCRIPTION
fix: https://github.com/PaddlePaddle/Paddle/issues/11100

according to https://developers.google.com/protocol-buffers/docs/reference/arenas

## ReleaseLast
SubMessageType* ReleaseLast(): Returns a heap-allocated message equivalent to the last message in the repeated field, removing it from the repeated field. **If the repeated field itself has a NULL arena pointer (and thus, all of its pointed-to messages are heap-allocated), then this method simply returns a pointer to the original object. Otherwise, if the repeated field has a non-NULL arena pointer, this method makes a copy that is heap-allocated and returns that copy**. In both cases, the caller receives ownership of a heap-allocated object and is responsible for deleting the object.

## analyse
If the message is allocated in arena memory pool, this function will make a copy on heap and return the pointer, but no one will delete the pointer in our code.
