### PR TITLE
fix test error in fluid_benchmark.py

### DIFF
--- a/benchmark/fluid/fluid_benchmark.py
+++ b/benchmark/fluid/fluid_benchmark.py
@@ -85,8 +85,8 @@ def parse_args():
         help='If set, use nvprof for CUDA.')
     parser.add_argument(
         '--no_test',
-        action='store_false',
-        help='If set, test the testset during training.')
+        action='store_true',
+        help='If set, do not test the testset during training.')
     parser.add_argument(
         '--memory_optimize',
         action='store_true',
@@ -229,9 +229,9 @@ def train(avg_loss, infer_prog, optimizer, train_reader, test_reader, batch_acc,
             print("Pass: %d, Iter: %d, Loss: %f\n" %
                   (pass_id, iters, np.mean(train_losses)))
         print_train_time(start_time, time.time(), num_samples)
-        print("Pass: %d, Loss: %f" % (pass_id, np.mean(train_losses)))
+        print("Pass: %d, Loss: %f" % (pass_id, np.mean(train_losses))),
         # evaluation
-        if not args.no_test and batch_acc != None:
+        if not args.no_test and batch_acc:
             pass_test_acc = test(exe, infer_prog, test_reader, feeder,
                                  batch_acc)
             print(", Test Accuracy: %f" % pass_test_acc)
@@ -310,7 +310,7 @@ def train_parallel(avg_loss, infer_prog, optimizer, train_reader, test_reader,
                 print("Pass %d, batch %d, loss %s" %
                       (pass_id, batch_id, np.array(loss)))
         print_train_time(start_time, time.time(), num_samples)
-        if not args.no_test and batch_acc != None:
+        if not args.no_test and batch_acc:
             test_acc = test(startup_exe, infer_prog, test_reader, feeder,
                             batch_acc)
             print("Pass: %d, Test Accuracy: %f\n" % (pass_id, test_acc))


### PR DESCRIPTION
fix #11163 
- The reason is that `batch_acc != None` is None, so use `batch_acc` directly.
- fix typo of `no_test` meaning, and its action. The original meaning and action are both reversed. After fixing, the default `run.sh` will test the testset during the training.
- Add `,` at the end of line 232, thus, line 232 and line 237 will be printed in the same line. 