### PR TITLE
install libgtk2.0-dev in latest images

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -447,7 +447,7 @@ EOF
     # run paddle version to install python packages first
     RUN apt-get update &&\
         ${NCCL_DEPS}\
-        apt-get install -y wget python-pip python-opencv dmidecode python-tk && easy_install -U pip && \
+        apt-get install -y wget python-pip python-opencv libgtk2.0-dev dmidecode python-tk && easy_install -U pip && \
         pip install /*.whl; apt-get install -f -y && \
         apt-get clean -y && \
         rm -f /*.whl && \


### PR DESCRIPTION
After #11204, when run `import cv2` in latest images:
```
root@f6bc27d7d69a:/# python
Python 2.7.12 (default, Dec  4 2017, 14:50:18)
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import cv2
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/cv2/__init__.py", line 3, in <module>
    from .cv2 import *
ImportError: libgthread-2.0.so.0: cannot open shared object file: No such file or directory
>>>
```
For missing `libgthread-2.0.so.0`, https://stackoverflow.com/questions/44205960/what-is-the-cause-of-this-strange-error-message-in-googles-cloud-datalab-when-i suggests to install `libgtk2.0-dev`, and our benchmark/fluid/Dockerfile also install `libgtk2.0-dev`.
https://github.com/PaddlePaddle/Paddle/blob/4aaeeba73875ce96b62e206765037fd8d56258fe/benchmark/fluid/Dockerfile#L2

