### PR TITLE
Fixing some bugs related to hierarchical-RNN (lod_level > 1)

### DIFF
--- a/paddle/fluid/framework/lod_rank_table.cc
+++ b/paddle/fluid/framework/lod_rank_table.cc
@@ -22,10 +22,16 @@ void LoDRankTable::Reset(const LoD& lod, size_t level) {
   PADDLE_ENFORCE(level < lod.size(),
                  "Cannot rank lod since the level %d is less than lod size %d",
                  level, lod.size());
-  coarse_lod_.reserve(level);
-  for (size_t i = 0; i < level; ++i) {
+  coarse_lod_.reserve(level + 1);
+  fine_lod_.reserve(lod.size() - level - 1);
+
+  for (size_t i = 0; i <= level; ++i) {
     coarse_lod_.push_back(lod[i]);
   }
+  for (size_t i = level + 1; i < lod.size(); ++i) {
+    fine_lod_.push_back(lod[i]);
+  }
+
   auto& vec = lod[level];
   for (size_t i = 0; i < vec.size() - 1; ++i) {
     TableItem item;

--- a/paddle/fluid/framework/lod_rank_table.h
+++ b/paddle/fluid/framework/lod_rank_table.h
@@ -46,10 +46,13 @@ class LoDRankTable {
 
   const LoD& coarse_lod() const { return this->coarse_lod_; }
 
-  size_t level() const { return coarse_lod_.size(); }
+  const LoD& fine_lod() const { return this->fine_lod_; }
+
+  size_t level() const { return coarse_lod_.size() - 1; }
 
  private:
   LoD coarse_lod_;
+  LoD fine_lod_;  //  LoD = coarse_lod_ union fine_lod_
   std::vector<TableItem> items_;
 };
 

--- a/paddle/fluid/framework/lod_tensor.cc
+++ b/paddle/fluid/framework/lod_tensor.cc
@@ -206,7 +206,6 @@ using LoDAndOffset = std::pair<LoD, std::pair<size_t, size_t>>;
 LoDAndOffset GetSubLoDAndAbsoluteOffset(const LoD &lod, size_t start_idx,
                                         size_t end_idx, size_t start_level) {
   LoD sub_lod;
-
   for (size_t level_idx = start_level; level_idx < lod.size(); ++level_idx) {
     PADDLE_ENFORCE_LE(start_idx, end_idx);
     PADDLE_ENFORCE_LT(end_idx, lod[level_idx].size());
@@ -218,7 +217,6 @@ LoDAndOffset GetSubLoDAndAbsoluteOffset(const LoD &lod, size_t start_idx,
     start_idx = lod[level_idx][start_idx];
     end_idx = lod[level_idx][end_idx];
   }
-
   return LoDAndOffset{sub_lod, {start_idx, end_idx}};
 }
 

--- a/paddle/fluid/framework/lod_tensor.h
+++ b/paddle/fluid/framework/lod_tensor.h
@@ -193,7 +193,9 @@ LoDTensor LodExpand(const LoDTensor& source, const LoD& lod, size_t level,
 }
 
 // Get the absolute offset of a lod[start_level][start_idx:end_idx] and
-// relative length of details for every levels(i.e., [start_level: ]).
+// relative length of details for levels between begin_level and end_level
+// (i.e., [start_level:end_level]) or every levels if end_level = 0
+// (i.e., [start_level: ]).
 //
 // For example,
 //   lod = [[0, 3, 4, 8], [0, 9, 10, 11, 13, 17, 19, 22, 24]]
@@ -205,7 +207,8 @@ LoDTensor LodExpand(const LoDTensor& source, const LoD& lod, size_t level,
 //  LoD = [[1, 4], [2, 4, 2, 3, 2]]
 //  pair<size_t, size_t> = {11, 24}
 std::pair<LoD, std::pair<size_t, size_t>> GetSubLoDAndAbsoluteOffset(
-    const LoD& lod, size_t start_idx, size_t end_idx, size_t start_level);
+    const LoD& lod, size_t start_idx, size_t end_idx,
+    size_t start_level);
 
 void AppendLoD(LoD* lod, const LoD& lod_length);
 

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -62,8 +62,10 @@ class LoDTensorToArrayOp : public framework::OperatorBase {
           break;
         }
         size_t start_idx = x.lod()[rank_level][item.index] + t;
+        // when rank_level_curr is 0, GetSubLoD .. is not used effectively
+        auto rank_level_curr = rank_level >= 1 ? rank_level - 1 : 1;
         auto lod_and_offset = framework::GetSubLoDAndAbsoluteOffset(
-            x.lod(), start_idx, start_idx + 1, rank_level + 1);
+              x.lod(), start_idx, start_idx + 1, rank_level_curr);
         auto &lod_length = lod_and_offset.first;
         framework::AppendLoD(&lod, lod_length);
         size_t start_offset = lod_and_offset.second.first;

--- a/paddle/fluid/operators/print_op.cc
+++ b/paddle/fluid/operators/print_op.cc
@@ -283,4 +283,6 @@ namespace ops = paddle::operators;
 REGISTER_OPERATOR(print, ops::TensorPrintOp, ops::PrintOpProtoAndCheckMaker,
                   ops::PrintOpProtoAndCheckGradOpMaker, ops::InferShapeForward,
                   ops::InferVarType);
-REGISTER_OPERATOR(print_grad, ops::TensorPrintOp, ops::InferShapeBackward);
+// currently no need to register print_grad, which will cause printing problem
+// when embedded in a while_op block
+// REGISTER_OPERATOR(print_grad, ops::TensorPrintOp, ops::InferShapeBackward);

--- a/paddle/fluid/operators/while_op.cc
+++ b/paddle/fluid/operators/while_op.cc
@@ -269,8 +269,8 @@ class WhileGradOpDescMaker : public framework::SingleGradOpDescMaker {
         // The input is located in I/O or other op's outputs or the variable is
         // located in grad_block's parents
         if (block_ins.find(input_name) != block_ins.end() ||
-            (fwd_block->FindVarRecursive(input_name) != nullptr ||
-             parent_block->FindVarRecursive(input_name) != nullptr)) {
+            fwd_block->FindVarRecursive(input_name) != nullptr ||
+             parent_block->FindVarRecursive(input_name) != nullptr) {
           continue;
         }
         output_grads.insert(input_name);

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -56,16 +56,16 @@ class DataToLoDTensorConverter(object):
             self.data.append(data)
         else:
             cur_lod_len = len(data)
-            lod[0].append(lod[0][-1] + cur_lod_len)
+            lod[-1].append(lod[-1][-1] + cur_lod_len)
             for each_data in data:
-                self._feed_impl_(each_data, lod[1:], lod_level - 1)
+                self._feed_impl_(each_data, lod[:-1], lod_level - 1)
 
     def done(self):
         arr = numpy.array(self.data, dtype=self.dtype).reshape(self.shape)
         t = core.LoDTensor()
         t.set(arr, self.place)
         if self.lod_level > 0:
-            t.set_lod(self.lod)
+            t.set_lod(self.lod[::-1])
         return t
 
 

--- a/python/paddle/fluid/tests/unittests/test_hrnn.py
+++ b/python/paddle/fluid/tests/unittests/test_hrnn.py
@@ -1,0 +1,165 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import paddle
+import unittest
+import numpy
+from paddle.fluid import debugger
+
+class TestNestedRNN(unittest.TestCase):
+    def setUp(self):
+        self.dict_dim = 20
+        self.word_dim = 1
+        self.hidden_dim = 1
+        self.label_dim = 3
+        #self.data = [
+        #    [[[1, 3, 2], [4, 5, 2]], 0],
+        #    [[[0, 0], [0, 2], [2, 5], [0, 1, 2]], 1],
+        #]
+        self.data = [
+            [[[1, 2], [4]], 0],
+            [[[11], [15]], 1],
+        ]
+
+    def rnn_data(self):
+        for d in self.data:
+            seq = []
+            for subseq in d[0]:
+                seq += subseq
+            yield seq, d[1]
+
+    def hrnn_data(self):
+        for d in self.data:
+            yield d
+
+    def rnn(self):
+        data = fluid.layers.data(
+                        name='word', shape=[1], dtype='int64', lod_level=1)
+        emb = fluid.layers.embedding(
+            input=data, size=[self.dict_dim, self.word_dim])
+
+        rnn = fluid.layers.DynamicRNN()
+
+        with rnn.block():
+            y = rnn.step_input(emb)
+            fluid.layers.Print(y, message="y")
+            mem = rnn.memory(shape=[self.hidden_dim])
+            out = fluid.layers.fc(input=[y, mem],
+                                  size=self.hidden_dim,
+                                  act='tanh')
+            rnn.update_memory(mem, out)
+            rnn.output(out)
+
+        rep = fluid.layers.sequence_last_step(input=rnn())
+        prob = fluid.layers.fc(input=rep, size=self.label_dim, act='softmax')
+
+        label = fluid.layers.data(name='label', shape=[1], dtype='int64')
+
+        loss = fluid.layers.cross_entropy(prob, label)
+        loss = fluid.layers.mean(loss)
+        sgd = fluid.optimizer.Adam(1e-3)
+        sgd.minimize(loss=loss)
+        return [data, label], [loss]
+
+    def hrnn(self):
+        data = fluid.layers.data(
+                        name='word', shape=[1], dtype='int64', lod_level=2)
+        fluid.layers.Print(data, message="raw_data")
+
+        label = fluid.layers.data(name='label', shape=[1], dtype='int64')
+
+        emb = fluid.layers.embedding(
+            input=data, size=[self.dict_dim, self.word_dim])
+
+        rnn = fluid.layers.DynamicRNN()
+        rnn_inner = fluid.layers.DynamicRNN()
+
+        fluid.layers.Print(emb, print_phase='forward', message='emb')
+        with rnn.block():
+            y = rnn.step_input(emb)
+            mem = rnn.memory(shape=[self.hidden_dim], prefix='outer_')
+            fluid.layers.Print(y, print_phase='forward', message='y')
+            inner_flag = False # change this to True to insert the inner-RNN
+            if inner_flag:
+                # rnn_inner = fluid.layers.DynamicRNN()
+                with rnn_inner.block():
+                    y_inner = rnn_inner.step_input(y)
+                    mem_inner = rnn_inner.memory(init=mem, shape=[self.hidden_dim], prefix='inner_')
+                    out_inner = fluid.layers.fc(input=[y_inner, mem_inner],
+                                  size=self.hidden_dim,
+                                  act='tanh')
+                    rnn_inner.update_memory(mem_inner, out_inner)
+                    rnn_inner.output(out_inner)
+                y_inner_out = rnn_inner()
+            else:
+                y_inner_out = y
+
+            fluid.layers.Print(y_inner_out, print_phase='forward', message='y_inner_out')
+            y = fluid.layers.sequence_last_step(input=y_inner_out)
+            # will have linking error if not feeding mem into fc
+            out = fluid.layers.fc(input=[y, mem],
+                                  size=self.hidden_dim,
+                                  act='tanh')
+            rnn.update_memory(mem, out)
+            rnn.output(out)
+        out = rnn()
+        rep = fluid.layers.sequence_last_step(input=out)
+        prob = fluid.layers.fc(input=rep, size=self.label_dim, act='softmax')
+        loss = fluid.layers.cross_entropy(prob, label)
+        loss = fluid.layers.mean(loss)
+        fluid.layers.Print(loss, print_phase='forward', message='loss')
+        sgd = fluid.optimizer.Adam(1e-3)
+        sgd.minimize(loss=loss)
+        return [data, label], [loss]
+
+    def test_hrnn(self):
+        main_program = fluid.Program()
+        startup_program = fluid.Program()
+
+        with fluid.program_guard(main_program, startup_program):
+            inputs, outputs = self.hrnn()
+        # print(main_program)
+
+        cpu = fluid.CPUPlace()
+        exe = fluid.Executor(cpu)
+        exe.run(startup_program)
+
+        feeder = fluid.DataFeeder(feed_list=inputs, place=cpu)
+        dataset = paddle.batch(self.hrnn_data, batch_size=2)
+        for data in dataset():
+            # GRAD, tmp
+            loss_np = exe.run(main_program,
+                              feed=feeder.feed(data),
+                              fetch_list=outputs)[0]
+
+    def test_rnn(self):
+        main_program = fluid.Program()
+        startup_program = fluid.Program()
+
+        with fluid.program_guard(main_program, startup_program):
+            inputs, outputs = self.rnn()
+
+        cpu = fluid.CPUPlace()
+        exe = fluid.Executor(cpu)
+        exe.run(startup_program)
+        feeder = fluid.DataFeeder(feed_list=inputs, place=cpu)
+        dataset = paddle.batch(self.rnn_data, batch_size=2)
+        for data in dataset():
+            loss_np = exe.run(main_program,
+                              feed=feeder.feed(data),
+                              fetch_list=outputs)[0]
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
    Fixing some bugs related to hierarchical-RNN
    1) fix a bug in data feeder which returns an LoDTensor with a
       reversed lod structure when lod_level > 1
    2) fix a bug in setting lod with the corresponding lod_level
       during array to lod_tensor conversion (in array_to_lod_tensor_op.cc
       and lod_rank_table.cc)
    3) some fix in lod_tensor_to_array_op.cc related to getting the correct
       lod_and_offset at different lod_levels
    4) some other minor fixes:
        * enable Print to be used within an RNN block
        * add prefix for memory related variables in DynamicRNN