### PR TITLE
Build: add make before make install to catch up CMakeLists change.

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -181,6 +181,7 @@ function build() {
     ============================================
 EOF
     make clean
+    make -j `nproc`
     make install -j `nproc`
 }
 


### PR DESCRIPTION
This PR (https://github.com/PaddlePaddle/Paddle/pull/11309) changed the  CMakeLists.txt. Without make before make install, this change cannot be catch up by cmake and will cause the build error. For example:

[100%] Linking CXX executable test_dot
/usr/bin/ld: cannot find -lsend_vars_op
[100%] Linking CXX executable test_node
collect2: error: ld returned 1 exit status
paddle/fluid/inference/analysis/CMakeFiles/test_dot.dir/build.make:406: recipe for target 'paddle/fluid/inference/analysis/test_dot' failed
make[2]: *** [paddle/fluid/inference/analysis/test_dot] Error 1
CMakeFiles/Makefile2:35598: recipe for target 'paddle/fluid/inference/analysis/CMakeFiles/test_dot.dir/all' failed
make[1]: *** [paddle/fluid/inference/analysis/CMakeFiles/test_dot.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
/usr/bin/ld: cannot find -lsend_vars_op
collect2: error: ld returned 1 exit status
paddle/fluid/inference/analysis/CMakeFiles/test_node.dir/build.make:406: recipe for target 'paddle/fluid/inference/analysis/test_node' failed
make[2]: *** [paddle/fluid/inference/analysis/test_node] Error 1
CMakeFiles/Makefile2:36276: recipe for target 'paddle/fluid/inference/analysis/CMakeFiles/test_node.dir/all' failed
make[1]: *** [paddle/fluid/inference/analysis/CMakeFiles/test_node.dir/all] Error 2

Users may fix this build error by just deleting the whole build directory to rebuild everything, but I think adding a make before make install is a more efficient way.