### PR TITLE
add timeline to train_parallel

### DIFF
--- a/benchmark/fluid/fluid_benchmark.py
+++ b/benchmark/fluid/fluid_benchmark.py
@@ -156,15 +156,23 @@ def train(avg_loss, infer_prog, optimizer, train_reader, test_reader, batch_acc,
                 start_time = time.time()
                 num_samples = 0
 
+            if args.profile and pass_id == 0 and batch_id == 5:
+                profiler.start_profiler("All")
+            elif args.profile and pass_id == 0 and batch_id == 10:
+                profiler.stop_profiler("total", "/tmp/profile")
+
             if args.use_reader_op:
                 try:
-                    loss = exe.run(train_prog, fetch_list=[avg_loss])
+                    loss = exe.run(train_prog,
+                                   fetch_list=[avg_loss],
+                                   use_program_cache=True)
                 except fluid.core.EnforceNotMet as ex:
                     break
             else:
                 loss = exe.run(train_prog,
                                feed=feeder.feed(data),
-                               fetch_list=[avg_loss])
+                               fetch_list=[avg_loss],
+                               use_program_cache=True)
             iters += 1
             batch_id += 1
             # FIXME(wuyi): For use_reader_op, if the current


### PR DESCRIPTION
```
#!/bin/bash

CUDA_VISIBLE_DEVICES=0 python ../Paddle/benchmark/fluid/fluid_benchmark.py --model resnet --device GPU --iterations=10000 --gpus 1 --profile

PYTHONPATH=/paddle/build/python python ../Paddle/tools/timeline.py --profile_path=/tmp/profile_0 --timeline_path=../timeline_pe
```