### PR TITLE
Support running test with reader

### DIFF
--- a/python/paddle/fluid/layers/io.py
+++ b/python/paddle/fluid/layers/io.py
@@ -753,7 +753,9 @@ def get_test_program(filelist, test_program=None, startup_program=None):
             if op_out_var.type == core.VarDesc.VarType.READER:
                 newname = op_out_var.name + "_test"
                 program.global_block().rename_var(op_out_var.name, newname)
+        if op.type == "create_multi_pass_reader":
+            op.set_attr("pass_num", 1)
 
-        program.sync_with_cpp()
+    program.sync_with_cpp()
 
     return program


### PR DESCRIPTION
Support run test with reader op, sample:

```python
# network forward define above
inference_program = fluid.default_main_program().clone(for_test=True)
inference_program = fluid.layers.get_test_program(test_file_list, inference_program)
# run test with "inference_program"
```