### PR TITLE
[Important] MKLDNN version of the code must have all space of memory

### DIFF
--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -57,12 +57,18 @@ inline size_t CpuTotalPhysicalMemory() {
 }
 
 size_t CpuMaxAllocSize() {
+// The MKLDNN version of the code must have all space of memory to use.
+// This solution gives ability to obtain the better performance.
+#ifdef PADDLE_WITH_MKLDNN
+  return FLAGS_fraction_of_cpu_memory_to_use * CpuTotalPhysicalMemory();
+#else
   // For distributed systems, it requires configuring and limiting
   // the fraction of memory to use.
   return std::min(
       static_cast<size_t>(FLAGS_fraction_of_cpu_memory_to_use *
                           CpuTotalPhysicalMemory()),
       static_cast<size_t>(FLAGS_initial_cpu_memory_in_mb * 1 << 20));
+#endif
 }
 
 size_t CpuMinChunkSize() {


### PR DESCRIPTION
Problem with the MKLDNN performance after this change : [commit](https://github.com/PaddlePaddle/Paddle/commit/9300212701505e0cf35b5570f3881950525ec73c)

Description and solution 
The mkldnn performance of the newest Paddle is a worse than the code before the changes: nearly **50%**, The mkldnn version of code need to have all space of the memory to work correctly. During the tests with htop the loss of power of the threads is significant and we can not keep the fluency between the threads. 


The code shows the solution to this problem. Summary: this is the fall back to the previous version of the code + MKLDNN flag.