### PR TITLE
bugfix/add_inference_lib_to_release

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -39,7 +39,7 @@ function(copy TARGET)
         message(FATAL_ERROR "${TARGET} source numbers are not equal to destination numbers")
     endif()
     math(EXPR len "${copy_lib_SRCS_len} - 1")
-    
+
     add_custom_target(${TARGET} DEPENDS ${copy_lib_DEPS})
     foreach(index RANGE ${len})
         list(GET copy_lib_SRCS ${index} src)
@@ -154,6 +154,15 @@ copy(inference_lib DEPS paddle_fluid_shared paddle_fluid
   SRCS ${src_dir}/${module}/*.h ${PADDLE_BINARY_DIR}/paddle/fluid/inference/libpaddle_fluid.*
   DSTS ${dst_dir}/${module} ${dst_dir}/${module}
 )
+
+if(WITH_CONTRIB)
+   set(contrib_dst_dir "${FLUID_INSTALL_DIR}/contrib/inference")
+   copy(contrib_inference_lib DEPS paddle_inference_api
+        SRCS ${PADDLE_SOURCE_DIR}/paddle/contrib/inference/paddle_inference_api.h
+        ${PADDLE_BINARY_DIR}/paddle/contrib/inference/libpaddle_inference_api.*
+        DSTS ${contrib_dst_dir} ${contrib_dst_dir}
+   )
+endif()
 
 set(module "platform")
 copy(platform_lib DEPS profiler_py_proto


### PR DESCRIPTION
Add `contrib/inference/`
  - `paddle_inference_api.h`
  - `libpaddle_inference_api.a` 

into dist.

The current output is 

```
total 128M
-rwxr-xr-x 1 root root 2.5K Jun 14 01:36 engine.h
-rwxr-xr-x 1 root root 1.8K Jun 14 01:36 io.h
-rw-r--r-- 1 root root  86M Jun 14 01:36 libpaddle_fluid.a
-rwxr-xr-x 1 root root  43M Jun 14 01:36 libpaddle_fluid.so
-rw-r--r-- 1 root root 217K Jun 14 01:36 libpaddle_inference_api.a
-rwxr-xr-x 1 root root 3.7K Jun 14 01:36 paddle_inference_api.h
```