### PR TITLE
Adding corresponding hl_fini() for each hl_init() used

### DIFF
--- a/paddle/legacy/gserver/gradientmachines/MultiGradientMachine.cpp
+++ b/paddle/legacy/gserver/gradientmachines/MultiGradientMachine.cpp
@@ -532,6 +532,7 @@ void TrainerThread::computeThread() {
         break;
     }
   }
+  hl_fini();
 }
 
 void TrainerThread::prefetch() {
@@ -651,6 +652,7 @@ void TrainerThread::copyGradToBufferThread() {
     }
     partnerThread->notifyGradientCollect(pid);
   }
+  hl_fini();
 }
 
 void TrainerThread::gradCollectThread() {
@@ -693,6 +695,7 @@ void TrainerThread::gradCollectThread() {
       notifyCopyGradToBuffer(pid);
     }
   }
+  hl_fini();
 }
 
 void TrainerThread::doCallback(int pid) {
@@ -741,6 +744,7 @@ void TrainerThread::valueDispatchThread() {
 
     thread->notifyValueReady(pid);
   }
+  hl_fini();
 }
 
 void TrainerThread::notifyValueReady(int paramId) {

--- a/paddle/legacy/gserver/gradientmachines/ParallelNeuralNetwork.cpp
+++ b/paddle/legacy/gserver/gradientmachines/ParallelNeuralNetwork.cpp
@@ -197,6 +197,7 @@ void ParallelThread::computeThread() {
       job_work.layer_->markAllInputGrad();
     }
   }
+  hl_fini();
 }
 
 void ParallelThread::start() {


### PR DESCRIPTION
The leak rootcause is a programming error. According my understanding, for each hl_init() method call that allocate memory (GPU and CPU) there should be corresponding hl_fini() method call.

5 places have been identified where this rule is broken. 4 in MultiGradientMachine and one in ParallelNeuralNetwork.

We use DeepSpeech working over PaddlePPaddle V2 in our project. The leak was consistently reproducible during inference (2 training threads on 2 CUDA devices). For leak detection nvidia-smi tool was used. No leaks are identified after the fix. We run 12 hours test session - ~180 000 audio files were inferred - no GPU memory growth detected.  