### PR TITLE
Revert ReLu Python API.

### DIFF
--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -126,7 +126,7 @@ $out = e^x$
 __attribute__((unused)) constexpr char ReluDoc[] = R"DOC(
 Relu Activation Operator.
 
-$out = \max(x, 0)$
+$out = \\max(x, 0)$
 
 )DOC";
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -91,7 +91,6 @@ __all__ = [
     'gather',
     'random_crop',
     'mean_iou',
-    'relu',
     'log',
 ]
 
@@ -4923,35 +4922,6 @@ def log(x):
     dtype = helper.input_dtype()
     out = helper.create_tmp_variable(dtype)
     helper.append_op(type="log", inputs={"X": input}, outputs={"Out": out})
-    return out
-
-
-def relu(x):
-    """
-    Relu takes one input data (Tensor) and produces one output data (Tensor)
-    where the rectified linear function, y = max(0, x), is applied to
-    the tensor elementwise.
-
-    .. math::
-
-        Out = \\max(0, x)
-
-    Args:
-        x (Variable): The input tensor. 
-
-    Returns:
-        Variable: The output tensor with the same shape as input.
-
-    Examples:
-
-        .. code-block:: python
-
-            output = fluid.layers.relu(x)
-    """
-    helper = LayerHelper('relu', **locals())
-    dtype = helper.input_dtype()
-    out = helper.create_tmp_variable(dtype)
-    helper.append_op(type="relu", inputs={"X": input}, outputs={"Out": out})
     return out
 
 

--- a/python/paddle/fluid/layers/ops.py
+++ b/python/paddle/fluid/layers/ops.py
@@ -31,6 +31,7 @@ __activations__ = [
     'square',
     'softplus',
     'softsign',
+    'relu',
     'brelu',
     'leaky_relu',
     'soft_relu',


### PR DESCRIPTION
ReLu can be in-place operation. But the new API in nn.py is not this way.

Fix https://github.com/PaddlePaddle/Paddle/issues/11542