### PR TITLE
MKLDNN elementwis_add with default broadcast operations

### DIFF
--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -147,13 +147,9 @@ void TransDataLayoutFromMKLDNN(const OpKernelType& kernel_type_for_var,
                  "Input tensor type is not supported: ", in.type().name());
   memory::data_type out_type = in_type;
 
-  memory::format in_format =
-      in_tz.size() == 1 ? memory::format::x
-                        : in_tz.size() == 2 ? memory::format::nc : in.format();
-  memory::format out_format =
-      in_tz.size() == 1 ? memory::format::x : out_tz.size() == 2
-                                                  ? memory::format::nc
-                                                  : ToMKLDNNFormat(out_layout);
+  auto in_format = MKLDNNFormatForSize(in_tz.size(), in.format());
+  auto out_format =
+      MKLDNNFormatForSize(in_tz.size(), ToMKLDNNFormat(out_layout));
 
   void* in_data = GetDataFromTensor(in, in_type);
 

--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -148,9 +148,12 @@ void TransDataLayoutFromMKLDNN(const OpKernelType& kernel_type_for_var,
   memory::data_type out_type = in_type;
 
   memory::format in_format =
-      in_tz.size() == 2 ? memory::format::nc : in.format();
+      in_tz.size() == 1 ? memory::format::x
+                        : in_tz.size() == 2 ? memory::format::nc : in.format();
   memory::format out_format =
-      out_tz.size() == 2 ? memory::format::nc : ToMKLDNNFormat(out_layout);
+      in_tz.size() == 1 ? memory::format::x : out_tz.size() == 2
+                                                  ? memory::format::nc
+                                                  : ToMKLDNNFormat(out_layout);
 
   void* in_data = GetDataFromTensor(in, in_type);
 

--- a/paddle/fluid/framework/data_layout_transform.h
+++ b/paddle/fluid/framework/data_layout_transform.h
@@ -61,6 +61,13 @@ inline MKLDNNDataType ToMKLDNNDataType(const std::type_index type) {
   if (iter != dict.end()) return iter->second;
   return MKLDNNDataType::data_undef;
 }
+
+inline MKLDNNFormat MKLDNNFormatForSize(size_t dims_size,
+                                        MKLDNNFormat default_format) {
+  return (dims_size == 1
+              ? mkldnn::memory::format::x
+              : dims_size == 2 ? mkldnn::memory::format::nc : default_format);
+}
 #endif
 
 void TransDataLayoutFromMKLDNN(const OpKernelType& kernel_type_for_var,

--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -48,11 +48,8 @@ void DataTransform(const OpKernelType& expected_kernel_type,
         // Case1 - transform from Non-MKLDNN OPKernel to MKLDNN OPKernel
         // Just set layout/format. No real transform occur
 
-        mkldnn::memory::format out_format =
-            in.dims().size() == 1
-                ? mkldnn::memory::format::x
-                : in.dims().size() == 2 ? mkldnn::memory::format::nc
-                                        : ToMKLDNNFormat(lin);
+        auto out_format =
+            MKLDNNFormatForSize(in.dims().size(), ToMKLDNNFormat(lin));
 
         out.ShareDataWith(input_tensor);
         out.set_layout(DataLayout::kMKLDNN);

--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -47,9 +47,16 @@ void DataTransform(const OpKernelType& expected_kernel_type,
 #ifdef PADDLE_WITH_MKLDNN
         // Case1 - transform from Non-MKLDNN OPKernel to MKLDNN OPKernel
         // Just set layout/format. No real transform occur
+
+        mkldnn::memory::format out_format =
+            in.dims().size() == 1
+                ? mkldnn::memory::format::x
+                : in.dims().size() == 2 ? mkldnn::memory::format::nc
+                                        : ToMKLDNNFormat(lin);
+
         out.ShareDataWith(input_tensor);
         out.set_layout(DataLayout::kMKLDNN);
-        out.set_format(ToMKLDNNFormat(lin));
+        out.set_format(out_format);
 #endif
       } else {
         // Case2 - transfrom from MKLDNN OPKernel to Non-MKLDNN OPKernel

--- a/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
@@ -1,0 +1,186 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/elementwise_add_op.h"
+#include "paddle/fluid/operators/elementwise_op_function.h"
+#include "paddle/fluid/memory/memcpy.h"
+
+namespace paddle {
+namespace operators {
+
+using framework::DataLayout;
+using framework::Tensor;
+using mkldnn::memory;
+using mkldnn::reorder;
+using mkldnn::primitive;
+using mkldnn::stream;
+using mkldnn::sum;
+
+template <typename T>
+inline void *cast_const_to_void(const T *t) {
+  return static_cast<void *>(const_cast<T *>(t));
+}
+
+template <typename T>
+class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto& dev_ctx =
+        ctx.template device_context<paddle::platform::MKLDNNDeviceContext>();
+    const auto& mkldnn_engine = dev_ctx.GetEngine();
+
+    auto* x = ctx.Input<Tensor>("X");
+    auto* y = ctx.Input<Tensor>("Y");
+    auto* z = ctx.Output<Tensor>("Out");
+    const T* x_data = x->data<T>();
+    const T* y_data = y->data<T>();
+    T* z_data = z->mutable_data<T>(ctx.GetPlace());
+
+    int axis = ctx.Attr<int>("axis");
+
+    auto x_dims = x->dims();
+    auto y_dims = y->dims();
+    auto z_dims = z->dims();
+
+    if (x_dims.size() != y_dims.size()) {
+      auto func = [](T a, T b) -> T { return a + b; };
+
+      TransformFunctor<decltype(func), T, paddle::platform::CPUDeviceContext, T> functor(
+        x, y, z, ctx.template device_context<paddle::platform::CPUDeviceContext>(), func);
+
+      axis = (axis == -1 ? x_dims.size() - y_dims.size() : axis);
+      PADDLE_ENFORCE(axis >= 0 && axis < x_dims.size(),
+                     "Axis should be in range [0, x_dims)");
+
+      trim_trailing_singular_dims(&y_dims);
+      axis = (y_dims.size() == 0) ? x_dims.size() : axis;
+
+      int pre, n, post;
+      get_mid_dims(x_dims, y_dims, axis, &pre, &n, &post);
+
+      if (post == 1) {
+        functor.RunRowWise(n, pre);
+      } else {
+        functor.RunMidWise(n, pre, post);
+      }
+      z->set_layout(DataLayout::kMKLDNN);
+      z->set_format(x->format());
+    } else {
+      PADDLE_ENFORCE(x->layout() == DataLayout::kMKLDNN &&
+                     x->format() != memory::format::format_undef,
+                     "Wrong layout/format set for X tensor");
+      PADDLE_ENFORCE(y->layout() == DataLayout::kMKLDNN &&
+                     y->format() != memory::format::format_undef,
+                     "Wrong layout/format set for X tensor");
+
+      std::vector<int> src_x_tz = framework::vectorize2int(x_dims);
+      std::vector<int> src_y_tz = framework::vectorize2int(y_dims);
+      std::vector<int> dst_tz = framework::vectorize2int(z_dims);
+
+      std::vector<memory::primitive_desc> srcs_pd;
+      std::vector<memory> srcs;
+      std::vector<float> scales = {1.0f, 1.0f};
+
+      auto src_x_pd = memory::primitive_desc(
+            { {src_x_tz}, memory::data_type::f32, x->format()},
+            mkldnn_engine);
+      auto src_y_pd = memory::primitive_desc(
+            { {src_y_tz}, memory::data_type::f32, y->format()},
+            mkldnn_engine);
+      auto src_x_memory = memory(src_x_pd, cast_const_to_void(x_data));
+      auto src_y_memory = memory(src_y_pd, cast_const_to_void(y_data));
+
+      srcs_pd.push_back(src_x_pd);
+      srcs_pd.push_back(src_y_pd);
+      srcs.push_back(src_x_memory);
+      srcs.push_back(src_y_memory);
+
+      auto dst_md = memory::desc(
+             {dst_tz}, memory::data_type::f32, memory::format::any);
+
+      // create primitive descriptor for sum
+      auto sum_pd = sum::primitive_desc(dst_md, scales, srcs_pd);
+
+      // create mkldnn memory for dst
+      memory dst_memory = memory(sum_pd.dst_primitive_desc(), z_data);
+
+      std::vector<primitive::at> inputs;
+      inputs.push_back(srcs[0]);
+      inputs.push_back(srcs[1]);
+
+      // create sum primitive
+      auto sum_prim = sum(sum_pd, inputs, dst_memory);
+
+      std::vector<primitive> pipeline;
+      pipeline.push_back(sum_prim);
+      stream(stream::kind::eager).submit(pipeline).wait();
+
+      z->set_layout(DataLayout::kMKLDNN);
+      z->set_format((memory::format)
+                    dst_memory.get_primitive_desc().desc().data.format);
+    }
+  }
+};
+
+template <typename T>
+class EltwiseAddMKLDNNGradKernel : public framework::OpKernel<T> {
+ public:
+    void Compute(const framework::ExecutionContext& ctx) const override {
+        using Tensor = framework::Tensor;
+
+        auto* x = ctx.Input<Tensor>("X");
+        auto* y = ctx.Input<Tensor>("Y");
+        auto* out = ctx.Input<Tensor>("Out");
+        auto* dout = ctx.Input<Tensor>(framework::GradVarName("Out"));
+        auto* dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+        auto* dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
+        int axis = ctx.Attr<int>("axis");
+     if (platform::is_cpu_place(ctx.GetPlace()) && (x->dims() == y->dims())) {
+          auto blas = math::GetBlas<paddle::platform::CPUDeviceContext, T>(ctx);
+
+          if (dx) {
+              blas.VCOPY(dout->numel(), dout->data<T>(),
+                         dx->mutable_data<T>(ctx.GetPlace()));
+          }
+
+          if (dy) {
+              blas.VCOPY(dout->numel(), dout->data<T>(),
+                         dy->mutable_data<T>(ctx.GetPlace()));
+          }
+      } else {
+          ElemwiseGradCompute<paddle::platform::CPUDeviceContext, T, IdentityGrad<T>,
+                  IdentityGrad<T>>(
+                  ctx, *x, *y, *out, *dout, axis, dx, dy, IdentityGrad<T>(),
+                  IdentityGrad<T>());
+      }
+
+      dx->set_layout(DataLayout::kMKLDNN);
+      dx->set_format(dout->format());
+      dy->set_layout(DataLayout::kMKLDNN);
+      dy->set_format(dout->format());
+    }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OP_KERNEL(elementwise_add, MKLDNN,
+                   ::paddle::platform::CPUPlace,
+                   ops::EltwiseAddMKLDNNKernel<float>)
+
+REGISTER_OP_KERNEL(elementwise_add_grad, MKLDNN,
+                   ::paddle::platform::CPUPlace,
+                   ops::EltwiseAddMKLDNNGradKernel<float>)

--- a/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
@@ -150,7 +150,7 @@ class EltwiseAddMKLDNNGradKernel : public framework::OpKernel<T> {
     auto* dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
     int axis = ctx.Attr<int>("axis");
 
-    auto set_mkldnn_format = [](Tensor* in, Tensor* out) {
+    auto set_mkldnn_format = [](Tensor* in, const Tensor* out) {
       in->set_layout(DataLayout::kMKLDNN);
       in->set_format(out->format());
     };

--- a/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
@@ -150,20 +150,23 @@ class EltwiseAddMKLDNNGradKernel : public framework::OpKernel<T> {
     auto* dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
     int axis = ctx.Attr<int>("axis");
 
+    auto set_mkldnn_format = [dout](Tensor* d) {
+      d->set_layout(DataLayout::kMKLDNN);
+      d->set_format(dout->format());
+    };
+
     if (x->dims() == y->dims()) {
       auto blas = math::GetBlas<paddle::platform::CPUDeviceContext, T>(ctx);
       if (dx) {
         blas.VCOPY(dout->numel(), dout->data<T>(),
                    dx->mutable_data<T>(ctx.GetPlace()));
-        dx->set_layout(DataLayout::kMKLDNN);
-        dx->set_format(dout->format());
+        set_mkldnn_format(dx);
       }
 
       if (dy) {
         blas.VCOPY(dout->numel(), dout->data<T>(),
                    dy->mutable_data<T>(ctx.GetPlace()));
-        dy->set_layout(DataLayout::kMKLDNN);
-        dy->set_format(dout->format());
+        set_mkldnn_format(dy);
       }
     } else {
       // Execute default kernel when broadcast is needed
@@ -172,13 +175,11 @@ class EltwiseAddMKLDNNGradKernel : public framework::OpKernel<T> {
           ctx, *x, *y, *out, *dout, axis, dx, dy, IdentityGrad<T>(),
           IdentityGrad<T>());
       if (dx) {
-        dx->set_layout(DataLayout::kMKLDNN);
-        dx->set_format(dout->format());
+        set_mkldnn_format(dx);
       }
 
       if (dy) {
-        dy->set_layout(DataLayout::kMKLDNN);
-        dy->set_format(dout->format());
+        set_mkldnn_format(dy);
       }
     }
   }

--- a/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise_add_mkldnn_op.cc
@@ -150,23 +150,16 @@ class EltwiseAddMKLDNNGradKernel : public framework::OpKernel<T> {
     auto* dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
     int axis = ctx.Attr<int>("axis");
 
-    auto set_mkldnn_format = [dout](Tensor* d) {
-      d->set_layout(DataLayout::kMKLDNN);
-      d->set_format(dout->format());
-    };
-
     if (x->dims() == y->dims()) {
       auto blas = math::GetBlas<paddle::platform::CPUDeviceContext, T>(ctx);
       if (dx) {
         blas.VCOPY(dout->numel(), dout->data<T>(),
                    dx->mutable_data<T>(ctx.GetPlace()));
-        set_mkldnn_format(dx);
       }
 
       if (dy) {
         blas.VCOPY(dout->numel(), dout->data<T>(),
                    dy->mutable_data<T>(ctx.GetPlace()));
-        set_mkldnn_format(dy);
       }
     } else {
       // Execute default kernel when broadcast is needed
@@ -174,13 +167,6 @@ class EltwiseAddMKLDNNGradKernel : public framework::OpKernel<T> {
                           IdentityGrad<T>, IdentityGrad<T>>(
           ctx, *x, *y, *out, *dout, axis, dx, dy, IdentityGrad<T>(),
           IdentityGrad<T>());
-      if (dx) {
-        set_mkldnn_format(dx);
-      }
-
-      if (dy) {
-        set_mkldnn_format(dy);
-      }
     }
   }
 };

--- a/paddle/fluid/operators/elementwise_op.h
+++ b/paddle/fluid/operators/elementwise_op.h
@@ -88,6 +88,9 @@ class ElementwiseOpMaker : public framework::OpProtoAndCheckerMaker {
                  "for broadcasting Y onto X.")
         .SetDefault(-1)
         .EqualGreaterThan(-1);
+    AddAttr<bool>("use_mkldnn",
+                  "(bool, default false). Used by MKLDNN.")
+        .SetDefault(false);
     AddComment(string::Sprintf(R"DOC(
 Limited Elementwise %s Operator
 

--- a/paddle/fluid/operators/elementwise_op.h
+++ b/paddle/fluid/operators/elementwise_op.h
@@ -14,13 +14,12 @@ limitations under the License. */
 
 #pragma once
 #include <string>
+#include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/operator.h"
-#include "paddle/fluid/framework/data_layout.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
 #endif
-
 
 namespace paddle {
 namespace operators {
@@ -47,9 +46,9 @@ class ElementwiseOp : public framework::OperatorWithKernel {
   }
 
   framework::OpKernelType GetExpectedKernelType(
-      const framework::ExecutionContext &ctx) const override {
+      const framework::ExecutionContext& ctx) const override {
     auto input_data_type =
-      framework::ToDataType(ctx.Input<Tensor>("X")->type());
+        framework::ToDataType(ctx.Input<Tensor>("X")->type());
 
 #ifdef PADDLE_WITH_MKLDNN
     if (platform::CanMKLDNNBeUsed(ctx)) {
@@ -88,8 +87,7 @@ class ElementwiseOpMaker : public framework::OpProtoAndCheckerMaker {
                  "for broadcasting Y onto X.")
         .SetDefault(-1)
         .EqualGreaterThan(-1);
-    AddAttr<bool>("use_mkldnn",
-                  "(bool, default false). Used by MKLDNN.")
+    AddAttr<bool>("use_mkldnn", "(bool, default false). Used by MKLDNN.")
         .SetDefault(false);
     AddComment(string::Sprintf(R"DOC(
 Limited Elementwise %s Operator
@@ -166,9 +164,9 @@ class ElementwiseOpGrad : public framework::OperatorWithKernel {
   }
 
   framework::OpKernelType GetExpectedKernelType(
-      const framework::ExecutionContext &ctx) const override {
+      const framework::ExecutionContext& ctx) const override {
     auto input_data_type =
-      framework::ToDataType(ctx.Input<Tensor>("X")->type());
+        framework::ToDataType(ctx.Input<Tensor>("X")->type());
 
 #ifdef PADDLE_WITH_MKLDNN
     if (platform::CanMKLDNNBeUsed(ctx)) {

--- a/paddle/fluid/operators/elementwise_op.h
+++ b/paddle/fluid/operators/elementwise_op.h
@@ -55,12 +55,9 @@ class ElementwiseOp : public framework::OperatorWithKernel {
       return framework::OpKernelType(input_data_type, ctx.GetPlace(),
                                      framework::DataLayout::kMKLDNN,
                                      framework::LibraryType::kMKLDNN);
-    } else {
-      return framework::OpKernelType(input_data_type, ctx.GetPlace());
     }
-#else
-    return framework::OpKernelType(input_data_type, ctx.GetPlace());
 #endif
+    return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
 
@@ -173,12 +170,9 @@ class ElementwiseOpGrad : public framework::OperatorWithKernel {
       return framework::OpKernelType(input_data_type, ctx.GetPlace(),
                                      framework::DataLayout::kMKLDNN,
                                      framework::LibraryType::kMKLDNN);
-    } else {
-      return framework::OpKernelType(input_data_type, ctx.GetPlace());
     }
-#else
-    return framework::OpKernelType(input_data_type, ctx.GetPlace());
 #endif
+    return framework::OpKernelType(input_data_type, ctx.GetPlace());
   }
 };
 }  // namespace operators

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_mkldnn_op.py
@@ -16,6 +16,10 @@ import numpy as np
 import paddle.fluid.core as core
 from op_test import OpTest
 from test_elementwise_add_op import TestElementwiseAddOp
+'''
+Some tests differ from the tests defined in test_elementwise_add_op.py
+because MKLDNN does not support tensors of number of dimensions 3.
+'''
 
 
 class TestMKLDNNElementwiseAddOp(TestElementwiseAddOp):
@@ -28,102 +32,63 @@ class TestMKLDNNElementwiseAddOp(TestElementwiseAddOp):
         self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_scalar(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(1).astype(self.dtype)
-        self.out = self.x + self.y
+class TestMKLDNNElementwiseAddOp_scalar(TestElementwiseAddOp_scalar):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_scalar2(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(1, 1).astype(self.dtype)
-        self.out = self.x + self.y
+class TestMKLDNNElementwiseAddOp_scalar2(TestElementwiseAddOp_scalar2):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_Vector(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.random((32, )).astype(self.dtype)
-        self.y = np.random.random((32, )).astype(self.dtype)
-        self.out = np.add(self.x, self.y)
+class TestMKLDNNElementwiseAddOp_Vector(TestElementwiseAddOp_Vector):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TesMKLDNNtElementwiseAddOp_broadcast_0(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(2).astype(self.dtype)
-        self.out = self.x + self.y.reshape(2, 1, 1, 1)
-
-    def init_axis(self):
-        self.axis = 0
+class TesMKLDNNtElementwiseAddOp_broadcast_0(TestElementwiseAddOp_broadcast_0):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_broadcast_1(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(3).astype(self.dtype)
-        self.out = self.x + self.y.reshape(1, 3, 1, 1)
-
-    def init_axis(self):
-        self.axis = 1
+class TestMKLDNNElementwiseAddOp_broadcast_1(TestElementwiseAddOp_broadcast_1):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_broadcast_2(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(5).astype(self.dtype)
-        self.out = self.x + self.y.reshape(1, 1, 1, 5)
+class TestMKLDNNElementwiseAddOp_broadcast_2(TestElementwiseAddOp_broadcast_2):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_broadcast_3(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(3, 4).astype(self.dtype)
-        self.out = self.x + self.y.reshape(1, 3, 4, 1)
-
-    def init_axis(self):
-        self.axis = 1
+class TestMKLDNNElementwiseAddOp_broadcast_3(TestElementwiseAddOp_broadcast_3):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_broadcast_4(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
-        self.y = np.random.rand(2, 1).astype(self.dtype)
-        self.out = self.x + self.y.reshape(2, 1, 1, 1)
-
-    def init_axis(self):
-        self.axis = 0
+class TestMKLDNNElementwiseAddOp_broadcast_4(
+        TestMKLDNNElementwiseAddOp_broadcast_4):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_rowwise_add_0(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 2, 3, 4).astype(self.dtype)
-        self.y = np.random.rand(3, 4).astype(self.dtype)
-        self.out = self.x + self.y.reshape(1, 1, 3, 4)
-
-    def init_axis(self):
-        self.axis = 2
+class TestMKLDNNElementwiseAddOp_rowwise_add_0(
+        TestElementwiseAddOp_rowwise_add_0):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_rowwise_add_1(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 1).astype(self.dtype)
-        self.y = np.random.rand(1).astype(self.dtype)
-        self.out = self.x + self.y.reshape(1, 1)
-
-    def init_axis(self):
-        self.axis = 1
+class TestMKLDNNElementwiseAddOp_rowwise_add_1(
+        TestElementwiseAddOp_rowwise_add_1):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_channelwise_add(TestMKLDNNElementwiseAddOp):
-    def init_input_output(self):
-        self.x = np.random.rand(2, 3, 20, 20).astype(self.dtype)
-        self.y = np.random.rand(2, 1, 1, 1).astype(self.dtype)
-        self.out = self.x + self.y
-
-    def init_axis(self):
-        self.axis = -1
+class TestMKLDNNElementwiseAddOp_channelwise_add(
+        TestMKLDNNElementwiseAddOp_channelwise_add):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_mkldnn_op.py
@@ -15,10 +15,11 @@ import unittest
 import numpy as np
 import paddle.fluid.core as core
 from op_test import OpTest
-from test_elementwise_add_op import TestElementwiseAddOp
+from test_elementwise_add_op import *
 '''
 Some tests differ from the tests defined in test_elementwise_add_op.py
 because MKLDNN does not support tensors of number of dimensions 3.
+Such dimensions cause exceptions in MKLDNN reorder primitive.
 '''
 
 
@@ -33,11 +34,21 @@ class TestMKLDNNElementwiseAddOp(TestElementwiseAddOp):
 
 
 class TestMKLDNNElementwiseAddOp_scalar(TestElementwiseAddOp_scalar):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(1).astype(self.dtype)
+        self.out = self.x + self.y
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 
 
 class TestMKLDNNElementwiseAddOp_scalar2(TestElementwiseAddOp_scalar2):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(1, 1).astype(self.dtype)
+        self.out = self.x + self.y
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 
@@ -48,16 +59,31 @@ class TestMKLDNNElementwiseAddOp_Vector(TestElementwiseAddOp_Vector):
 
 
 class TesMKLDNNtElementwiseAddOp_broadcast_0(TestElementwiseAddOp_broadcast_0):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(2).astype(self.dtype)
+        self.out = self.x + self.y.reshape(2, 1, 1, 1)
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 
 
 class TestMKLDNNElementwiseAddOp_broadcast_1(TestElementwiseAddOp_broadcast_1):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(3).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 3, 1, 1)
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 
 
 class TestMKLDNNElementwiseAddOp_broadcast_2(TestElementwiseAddOp_broadcast_2):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 2, 3, 4).astype(self.dtype)
+        self.y = np.random.rand(4).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 1, 1, 4)
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 
@@ -67,14 +93,18 @@ class TestMKLDNNElementwiseAddOp_broadcast_3(TestElementwiseAddOp_broadcast_3):
         self.use_mkldnn = True
 
 
-class TestMKLDNNElementwiseAddOp_broadcast_4(
-        TestMKLDNNElementwiseAddOp_broadcast_4):
+class TestMKLDNNElementwiseAddOp_broadcast_4(TestElementwiseAddOp_broadcast_4):
     def init_kernel_type(self):
         self.use_mkldnn = True
 
 
 class TestMKLDNNElementwiseAddOp_rowwise_add_0(
         TestElementwiseAddOp_rowwise_add_0):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(3, 4).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 3, 4, 1)
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 
@@ -86,7 +116,12 @@ class TestMKLDNNElementwiseAddOp_rowwise_add_1(
 
 
 class TestMKLDNNElementwiseAddOp_channelwise_add(
-        TestMKLDNNElementwiseAddOp_channelwise_add):
+        TestElementwiseAddOp_channelwise_add):
+    def init_input_output(self):
+        self.x = np.random.rand(3, 5, 20, 20).astype(self.dtype)
+        self.y = np.random.rand(3, 1, 1, 1).astype(self.dtype)
+        self.out = self.x + self.y
+
     def init_kernel_type(self):
         self.use_mkldnn = True
 

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_mkldnn_op.py
@@ -1,0 +1,130 @@
+#  Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+import numpy as np
+import paddle.fluid.core as core
+from op_test import OpTest
+from test_elementwise_add_op import TestElementwiseAddOp
+
+
+class TestMKLDNNElementwiseAddOp(TestElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.uniform(0.1, 1, [2, 3, 4, 5]).astype(self.dtype)
+        self.y = np.random.uniform(0.1, 1, [2, 3, 4, 5]).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
+
+class TestMKLDNNElementwiseAddOp_scalar(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(1).astype(self.dtype)
+        self.out = self.x + self.y
+
+
+class TestMKLDNNElementwiseAddOp_scalar2(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(1, 1).astype(self.dtype)
+        self.out = self.x + self.y
+
+
+class TestMKLDNNElementwiseAddOp_Vector(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.random((32, )).astype(self.dtype)
+        self.y = np.random.random((32, )).astype(self.dtype)
+        self.out = np.add(self.x, self.y)
+
+
+class TesMKLDNNtElementwiseAddOp_broadcast_0(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(2).astype(self.dtype)
+        self.out = self.x + self.y.reshape(2, 1, 1, 1)
+
+    def init_axis(self):
+        self.axis = 0
+
+
+class TestMKLDNNElementwiseAddOp_broadcast_1(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(3).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 3, 1, 1)
+
+    def init_axis(self):
+        self.axis = 1
+
+
+class TestMKLDNNElementwiseAddOp_broadcast_2(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(5).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 1, 1, 5)
+
+
+class TestMKLDNNElementwiseAddOp_broadcast_3(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(3, 4).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 3, 4, 1)
+
+    def init_axis(self):
+        self.axis = 1
+
+
+class TestMKLDNNElementwiseAddOp_broadcast_4(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 4, 5).astype(self.dtype)
+        self.y = np.random.rand(2, 1).astype(self.dtype)
+        self.out = self.x + self.y.reshape(2, 1, 1, 1)
+
+    def init_axis(self):
+        self.axis = 0
+
+
+class TestMKLDNNElementwiseAddOp_rowwise_add_0(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 2, 3, 4).astype(self.dtype)
+        self.y = np.random.rand(3, 4).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 1, 3, 4)
+
+    def init_axis(self):
+        self.axis = 2
+
+
+class TestMKLDNNElementwiseAddOp_rowwise_add_1(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 1).astype(self.dtype)
+        self.y = np.random.rand(1).astype(self.dtype)
+        self.out = self.x + self.y.reshape(1, 1)
+
+    def init_axis(self):
+        self.axis = 1
+
+
+class TestMKLDNNElementwiseAddOp_channelwise_add(TestMKLDNNElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(2, 3, 20, 20).astype(self.dtype)
+        self.y = np.random.rand(2, 1, 1, 1).astype(self.dtype)
+        self.out = self.x + self.y
+
+    def init_axis(self):
+        self.axis = -1
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -18,19 +18,23 @@ from op_test import OpTest
 
 
 class TestElementwiseAddOp(OpTest):
+    def init_kernel_type(self):
+        self.use_mkldnn = False
+
     def setUp(self):
         self.op_type = "elementwise_add"
         self.dtype = np.float32
         self.axis = -1
         self.init_dtype()
         self.init_input_output()
+        self.init_kernel_type()
         self.init_axis()
 
         self.inputs = {
             'X': OpTest.np_dtype_to_fluid_dtype(self.x),
             'Y': OpTest.np_dtype_to_fluid_dtype(self.y)
         }
-        self.attrs = {'axis': self.axis}
+        self.attrs = {'axis': self.axis, 'use_mkldnn': self.use_mkldnn}
         self.outputs = {'Out': self.out}
 
     def test_check_output(self):


### PR DESCRIPTION
This PR implements `elementwise_add` operator based on MKLDNN sum primitive with a fallback to default functors when tensors' dimensions are of different sizes.