### PR TITLE
Removal the building of C-API

### DIFF
--- a/paddle/CMakeLists.txt
+++ b/paddle/CMakeLists.txt
@@ -13,9 +13,14 @@ if(NOT WITH_FLUID_ONLY)
     add_subdirectory(trainer)
     add_subdirectory(scripts)
 
-    if(WITH_C_API)
-      add_subdirectory(capi)
-    endif()
+# Disable the build of C-API, which is the inference library of old PaddlePaddle.
+# I want to disable it because the capi/CMakeLists.txt depends on SWIG, which 
+# is no longer useful with Fluid and would bother the development of Tape.
+# Once this removal is confirmed alright by the fact that no one askes the C-API
+# in a while, we would be confident to clear the code.
+#    if(WITH_C_API)
+#      add_subdirectory(capi)
+#    endif()
 
     if(WITH_SWIG_PY)
       add_subdirectory(api)


### PR DESCRIPTION
For the purpose of this change, please refer to https://github.com/PaddlePaddle/Paddle/pull/11550/files#diff-e8a3b4cd5fff7d282b01918ab749d61aR16

The CMakeLists.txt file for C-API includes a call to CMake function `SWIG_ADD_MODULE`, which is deprecated and would cause CMake warnings like:

```
CMake Deprecation Warning at /usr/local/Cellar/cmake/3.10.0/share/cmake/Modules/UseSWIG.cmake:231 (message):
  SWIG_ADD_MODULE is deprecated.  Use SWIG_ADD_LIBRARY instead.
```