### PR TITLE
Fix concat compile warning

### DIFF
--- a/paddle/fluid/operators/math/concat.cc
+++ b/paddle/fluid/operators/math/concat.cc
@@ -93,10 +93,10 @@ class ConcatGradFunctor<platform::CPUDeviceContext, T> {
     auto cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());
 
     // computation
-    for (size_t k = 0; k < input_rows; ++k) {
+    for (int k = 0; k < input_rows; ++k) {
       const T* src_ptr = input.data<T>() + k * input_cols;
       int col_idx = 0;
-      for (int j = 0; j < num; ++j) {
+      for (size_t j = 0; j < num; ++j) {
         int col_len = output_cols[j];
         auto* out_tensor = outputs->at(j);
         if (out_tensor != nullptr) {


### PR DESCRIPTION
Fix concat compile warning
```
../paddle/fluid/operators/math/concat.cc: In instantiation of ‘void paddle::operators::math::ConcatGradFunctor<paddle::platform::CPUDeviceContext, T>::operator()(const paddle::platform::CPUDeviceContext&, const paddle::framework::Tensor&, const std::vector<const paddle::framework::Tensor*>&, int, std::vector<paddle::framework::Tensor*>*) [with T = int]’:
../paddle/fluid/operators/math/concat.cc:118:16:   required from here
../paddle/fluid/operators/math/concat.cc:96:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (size_t k = 0; k < input_rows; ++k) {
                          ^
../paddle/fluid/operators/math/concat.cc:99:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (int j = 0; j < num; ++j) {
                         ^
../paddle/fluid/operators/math/concat.cc: In instantiation of ‘void paddle::operators::math::ConcatGradFunctor<paddle::platform::CPUDeviceContext, T>::operator()(const paddle::platform::CPUDeviceContext&, const paddle::framework::Tensor&, const std::vector<const paddle::framework::Tensor*>&, int, std::vector<paddle::framework::Tensor*>*) [with T = long int]’:
../paddle/fluid/operators/math/concat.cc:119:16:   required from here
../paddle/fluid/operators/math/concat.cc:96:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (size_t k = 0; k < input_rows; ++k) {
                          ^
../paddle/fluid/operators/math/concat.cc:99:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (int j = 0; j < num; ++j) {
                         ^
../paddle/fluid/operators/math/concat.cc: In instantiation of ‘void paddle::operators::math::ConcatGradFunctor<paddle::platform::CPUDeviceContext, T>::operator()(const paddle::platform::CPUDeviceContext&, const paddle::framework::Tensor&, const std::vector<const paddle::framework::Tensor*>&, int, std::vector<paddle::framework::Tensor*>*) [with T = float]’:
../paddle/fluid/operators/math/concat.cc:120:16:   required from here
../paddle/fluid/operators/math/concat.cc:96:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (size_t k = 0; k < input_rows; ++k) {
                          ^
../paddle/fluid/operators/math/concat.cc:99:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (int j = 0; j < num; ++j) {
                         ^
../paddle/fluid/operators/math/concat.cc: In instantiation of ‘void paddle::operators::math::ConcatGradFunctor<paddle::platform::CPUDeviceContext, T>::operator()(const paddle::platform::CPUDeviceContext&, const paddle::framework::Tensor&, const std::vector<const paddle::framework::Tensor*>&, int, std::vector<paddle::framework::Tensor*>*) [with T = double]’:
../paddle/fluid/operators/math/concat.cc:121:16:   required from here
../paddle/fluid/operators/math/concat.cc:96:26: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (size_t k = 0; k < input_rows; ++k) {
                          ^
../paddle/fluid/operators/math/concat.cc:99:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       for (int j = 0; j < num; ++j) {
```