### PR TITLE
add example of clone(for_test)

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1387,7 +1387,11 @@ class Program(object):
         * Set for_test to True when we want to clone the program for testing.
 
         Notes: This API DOES NOT prune any operator. Use
-        :code:`clone(for_test=True)` before backward and optimization please.
+        :code:`clone(for_test=True)` before backward and optimization please. e.g.
+
+            >>> test_program = fluid.default_main_program().clone(for_test=True)
+            >>> optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
+            >>> optimizer.minimize()
 
         Args:
             for_test(bool): True if change the :code:`is_test` attribute of


### PR DESCRIPTION
when I test the inference benchmark of https://github.com/chengduoZH/benchmark/blob/add_resnet_50_v2/fluid/ResNet_50/train_resnet.py#L182
The correct script is: 
```
test_program = fluid.default_main_program().clone(for_test=True)
optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
optimizer.minimize(avg_cost)
```
But if I write as 
```
optimizer = fluid.optimizer.Momentum(learning_rate=0.01, momentum=0.9)
optimizer.minimize(avg_cost)
test_program = fluid.default_main_program().clone(for_test=True)
```
The inference elasped time  is the same as the training time.

The reason is that `clone(for_test=True) must be used before backward and optimization please`. After `optimizer.minimize(avg_cost)`, the backward information will be added in program_desc.