### PR TITLE
Support: int64_t type of input data

### DIFF
--- a/paddle/fluid/operators/sum_mkldnn_op.cc
+++ b/paddle/fluid/operators/sum_mkldnn_op.cc
@@ -236,5 +236,8 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
 }  // namespace operators
 }  // namespace paddle
 
-REGISTER_OP_KERNEL(sum, MKLDNN, ::paddle::platform::CPUPlace,
-                   paddle::operators::SumMKLDNNOpKernel<float>);
+REGISTER_OP_KERNEL(
+    sum, MKLDNN, ::paddle::platform::CPUPlace,
+    paddle::operators::SumMKLDNNOpKernel<float>,
+    paddle::operators::SumKernel<paddle::platform::CPUDeviceContext, int>,
+    paddle::operators::SumKernel<paddle::platform::CPUDeviceContext, int64_t>);


### PR DESCRIPTION
This version of the sum operator supports other types of the input data - fall back to the cpu'