### PR TITLE
rename grpc to rpc

### DIFF
--- a/paddle/fluid/operators/distributed/grpc_client.h
+++ b/paddle/fluid/operators/distributed/grpc_client.h
@@ -212,7 +212,7 @@ class GRPCClient : public RPCClient {
                              int64_t time_out = FLAGS_rpc_deadline) override;
 
   void AsyncCheckpointNotify(const std::string& ep, const std::string& dir,
-                             int64_t time_out = FLAGS_grpc_deadline) override;
+                             int64_t time_out = FLAGS_rpc_deadline) override;
 
   void Wait() override;
 

--- a/paddle/fluid/operators/distributed/rpc_client.h
+++ b/paddle/fluid/operators/distributed/rpc_client.h
@@ -56,9 +56,9 @@ class RPCClient {
   virtual void AsyncSendFetchBarrier(const std::string& ep,
                                      int64_t time_out = FLAGS_rpc_deadline) = 0;
 
-  virtual void AsyncCheckpointNotify(
-      const std::string& ep, const std::string& dir,
-      int64_t time_out = FLAGS_grpc_deadline) = 0;
+  virtual void AsyncCheckpointNotify(const std::string& ep,
+                                     const std::string& dir,
+                                     int64_t time_out = FLAGS_rpc_deadline) = 0;
 
   // SendComplete tells all the server that current trainer have no more data
   // to train, so that the pserver can reduce it's barrier count, and continue


### PR DESCRIPTION
Bug fix:
rename ```FLAGS_grpc_deadline``` to ```FLAGS_rpc_deadline```.