### PR TITLE
saving reordered weights in fwd convolution

### DIFF
--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -173,6 +173,11 @@ class ExecutionContext {
     return ipt == kEmptyVarName ? nullptr : scope_.FindVar(ipt);
   }
 
+  Variable* MutableInputVar(const std::string& name) const {
+    auto ipt = op_.Input(name);
+    return ipt == kEmptyVarName ? nullptr : scope_.FindVar(ipt);
+  }
+
   Variable* OutputVar(const std::string& name) const {
     auto opt = op_.Output(name);
     return opt == kEmptyVarName ? nullptr : scope_.FindVar(opt);
@@ -207,6 +212,12 @@ class ExecutionContext {
   const T* Input(const std::string& name) const {
     auto* var = InputVar(name);
     return var == nullptr ? nullptr : &var->Get<T>();
+  }
+
+  template <typename T>
+  T* MutableInput(const std::string& name) const {
+    auto* var = MutableInputVar(name);
+    return var == nullptr ? nullptr : var->GetMutable<T>();
   }
 
   template <typename T>
@@ -278,6 +289,9 @@ class ExecutionContext {
 
 template <>
 const Tensor* ExecutionContext::Input<Tensor>(const std::string& name) const;
+
+template <>
+Tensor* ExecutionContext::MutableInput<Tensor>(const std::string& name) const;
 
 template <>
 const std::vector<const Tensor*> ExecutionContext::MultiInput<Tensor>(

--- a/paddle/fluid/operators/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/conv_mkldnn_op.cc
@@ -327,8 +327,8 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     // Save reorderd weights. Currently only for inference as it lowers
     // performance for training.
     if (are_weights_reordered && is_test) {
-      std::memcpy(to_void_cast(filter_data), weights_memory_p->get_data_handle(),
-                  filter->memory_size());
+      std::memcpy(to_void_cast(filter_data),
+                  weights_memory_p->get_data_handle(), filter->memory_size());
       filter->set_format(GetMKLDNNFormat(*weights_memory_p));
     }
   }

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -156,6 +156,7 @@ void Conv2DOpMaker::Make() {
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
+  AddAttr<bool>("is_test", "").SetDefault(false);
   AddAttr<std::string>(
       "data_format",
       "(string, default NCHW) Only used in "

--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -251,5 +251,14 @@ inline mkldnn::memory::format MKLDNNFormatForSize(
   return data_format;
 }
 
+static bool InplaceConvWeights(const std::string& name,
+                               const framework::OperatorWithKernel& op) {
+#ifdef PADDLE_WITH_MKLDNN
+  return name.find("conv2d") == 0 && name.find("GRAD") == std::string::npos &&
+         op.Attr<bool>("is_test");
+#endif
+  return false;
+}
+
 }  // namespace platform
 }  // namespace paddle


### PR DESCRIPTION
Currently reorders of convolution weights are not saved for next iterations.
In this commit I'm saving reordered weights for inference.

For training, saving these weights would lower the performance. The reason is that not all layers use MKLDNN layouts (like momentum in training) and this change would introduce more reorders.

To change tensor format within operator, I've added methods for mutable access to tensor from ExecutionContext. Moreover, I had to add additional case for inplace tensor transformation. Without it weights would be transformed from NCHW format to MKLDNN one only locally and change of format would not be propagated to next OP calls.