### PR TITLE
fix tensorrt compiler bug

### DIFF
--- a/paddle/contrib/inference/CMakeLists.txt
+++ b/paddle/contrib/inference/CMakeLists.txt
@@ -18,7 +18,10 @@ if(APPLE)
 endif(APPLE)
 
 
-set(inference_deps paddle_inference_api paddle_fluid_api paddle_inference_tensorrt_subgraph_engine)
+set(inference_deps paddle_inference_api paddle_fluid_api)
+if(WITH_GPU AND TENSORRT_FOUND)
+    set(inference_deps ${inference_deps} paddle_inference_tensorrt_subgraph_engine)
+endif()
 
 function(inference_api_test TARGET_NAME)
     if (WITH_TESTING)


### PR DESCRIPTION
There is compiler bug when tensorrt doens't found in system.
```
CMake Error at cmake/generic.cmake:247 (add_dependencies):
  The dependency target "paddle_inference_tensorrt_subgraph_engine" of target
  "test_paddle_inference_api_impl" does not exist.
Call Stack (most recent call first):
  paddle/contrib/inference/CMakeLists.txt:31 (cc_test)
  paddle/contrib/inference/CMakeLists.txt:50 (inference_api_test)


CMake Error at cmake/generic.cmake:247 (add_dependencies):
  The dependency target "paddle_inference_tensorrt_subgraph_engine" of target
  "simple_on_word2vec" does not exist.
Call Stack (most recent call first):
  paddle/contrib/inference/CMakeLists.txt:31 (cc_test)
  paddle/contrib/inference/demo/CMakeLists.txt:16 (inference_api_test)


-- Generating done
-- Build files have been written to: /home/luotao02/Paddle/build
```