### PR TITLE
Use real test data for fit_a_line model to get valid result

### DIFF
--- a/python/paddle/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/fluid/tests/book/test_fit_a_line.py
@@ -110,14 +110,23 @@ def infer(use_cuda, save_dirname=None):
         # The input's dimension should be 2-D and the second dim is 13
         # The input data should be >= 0
         batch_size = 10
-        tensor_x = numpy.random.uniform(0, 10,
-                                        [batch_size, 13]).astype("float32")
+
+        test_reader = paddle.batch(
+            paddle.dataset.uci_housing.test(), batch_size=batch_size)
+
+        test_data = test_reader().next()
+        test_feat = numpy.array(
+            [data[0] for data in test_data]).astype("float32")
+        test_label = numpy.array(
+            [data[1] for data in test_data]).astype("float32")
+
         assert feed_target_names[0] == 'x'
         results = exe.run(inference_program,
-                          feed={feed_target_names[0]: tensor_x},
+                          feed={feed_target_names[0]: numpy.array(test_feat)},
                           fetch_list=fetch_targets)
         print("infer shape: ", results[0].shape)
         print("infer results: ", results[0])
+        print("ground truth: ", test_label)
 
 
 def main(use_cuda, is_local=True):


### PR DESCRIPTION
Resolve #11856

```
('infer shape: ', (10, 1))
('infer results: ', array([[13.366845],
       [13.256419],
       [13.525405],
       [14.875826],
       [13.950964],
       [14.409012],
       [14.067776],
       [13.956516],
       [12.273897],
       [13.826031]], dtype=float32))
('ground truth: ', array([[ 8.5],
       [ 5. ],
       [11.9],
       [27.9],
       [17.2],
       [27.5],
       [15. ],
       [17.2],
       [17.9],
       [16.3]], dtype=float32))
```