### PR TITLE
add check for patchelf in CMakelists.txt

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -91,3 +91,9 @@ endif()
 install(DIRECTORY ${PADDLE_PYTHON_PACKAGE_DIR}
     DESTINATION opt/paddle/share/wheels
 )
+
+find_program(PATCHELF_EXECUTABLE patchelf)
+if(NOT PATCHELF_EXECUTABLE)
+  message(FATAL_ERROR "patchelf not found, please install it.\n"
+          "For Ubuntu, the command is: apt-get install -y patchelf.")
+endif()


### PR DESCRIPTION
If the machine doesn't install `patchelf`, this PR will report the error in `cmake` step likes:
```
CMake Error at python/CMakeLists.txt:97 (message):
  patchelf not found, please install it.

  For Ubuntu, the command is: apt-get install -y patchelf.


-- Configuring incomplete, errors occurred!
```