### PR TITLE
Fix to Fluid Inference API for MKL-DNN Paddle builds

### DIFF
--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -34,28 +34,6 @@ namespace framework {
 class LoDTensor;
 
 class Tensor {
-#ifdef PADDLE_WITH_MKLDNN
-
- public:
-  inline mkldnn::memory::format format() const { return format_; }
-
-  inline void set_format(const mkldnn::memory::format format) {
-    format_ = format;
-  }
-
- protected:
-  /**
-   * @brief the detail format of memory block which have layout as kMKLDNN
-   *
-   * @note MKLDNN lib support various memory format like nchw, nhwc, nChw8C,
-   *       nChw16c, etc. For a MKLDNN memory block, layout will be set as
-   *       DataLayout::kMKLDNN meanwhile detail memory format will be kept in
-   *       this field.
-   */
-
-  mkldnn::memory::format format_ = mkldnn::memory::format::format_undef;
-#endif
-
  public:
   template <typename T, size_t D, int MajorType, typename IndexType>
   friend struct EigenTensor;
@@ -230,6 +208,27 @@ class Tensor {
    *          PlaceHolder::ptr_ and where the tensor data really begins.
    */
   size_t offset_;
+#ifdef PADDLE_WITH_MKLDNN
+
+ public:
+  inline mkldnn::memory::format format() const { return format_; }
+
+  inline void set_format(const mkldnn::memory::format format) {
+    format_ = format;
+  }
+
+ protected:
+  /**
+   * @brief the detail format of memory block which have layout as kMKLDNN
+   *
+   * @note MKLDNN lib support various memory format like nchw, nhwc, nChw8C,
+   *       nChw16c, etc. For a MKLDNN memory block, layout will be set as
+   *       DataLayout::kMKLDNN meanwhile detail memory format will be kept in
+   *       this field.
+   */
+
+  mkldnn::memory::format format_ = mkldnn::memory::format::format_undef;
+#endif
 };
 
 }  // namespace framework


### PR DESCRIPTION
This is fix to situation when we want to use FLUID inference API with PaddlePaddle build with MKL-DNN support. Currently there is a crash.  The reason for crash (according to my poor understanding of this part) is that we Have Variable::holder_ which is casted into Tensor. It seems intension is to cast
into Tensor->holder_ . Example of copying, followed by function that return Variable::holder_:

https://github.com/PaddlePaddle/Paddle/blob/a11381b173f4b75e9e0982395a41b2c6fbb366c6/paddle/fluid/framework/variable_test.cc#L30


https://github.com/PaddlePaddle/Paddle/blob/a11381b173f4b75e9e0982395a41b2c6fbb366c6/paddle/fluid/framework/variable.h#L39-L45



Casting into Tensor may work as long as Address of Tensor->holder_  and Tensor do match. For MKLDNN build they do not as there is additional (under ifdef) attribute:
 **mkldnn::memory::format format_ = mkldnn::memory::format::format_undef;**
This additional attribute makes assumption Tensor == Tensor->holder_  **false** (Layout of Tensor class is different) so Tensor->holder_ is holding broken data after assignment like this: 
**Tensor* t = v->GetMutable<Tensor>();**


Some more information is here:
https://github.com/luotao1/fluid_inference_example/issues/1
