### PR TITLE
Update version via branch name

### DIFF
--- a/cmake/version.cmake
+++ b/cmake/version.cmake
@@ -4,25 +4,42 @@ set(tmp_version "HEAD")
 set(TAG_VERSION_REGEX "[0-9]+\\.[0-9]+\\.[0-9]+(\\.(a|b|rc)\\.[0-9]+)?")
 set(COMMIT_VERSION_REGEX "[0-9a-f]+[0-9a-f]+[0-9a-f]+[0-9a-f]+[0-9a-f]+")
 while ("${PADDLE_VERSION}" STREQUAL "")
+  # Check current branch name
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --always ${tmp_version}
+    COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref ${tmp_version}
     WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
-    OUTPUT_VARIABLE GIT_TAG_NAME
-    RESULT_VARIABLE GIT_RESULT
+    OUTPUT_VARIABLE GIT_BRANCH_NAME
+    RESULT_VARIABLE GIT_BRANCH_RESULT
     ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if (NOT ${GIT_RESULT})
-    # Check the tag is a correct version
-    if (${GIT_TAG_NAME} MATCHES "${COMMIT_VERSION_REGEX}")
-      # if no tag was found, set PADDLE_VERSION to latest
-      set(PADDLE_VERSION "latest")
-    elseif (${GIT_TAG_NAME} MATCHES "v${TAG_VERSION_REGEX}")
-      string(REPLACE "v" "" PADDLE_VERSION ${GIT_TAG_NAME})
-    else()  # otherwise, get the previous git tag name.
-      set(tmp_version "${GIT_TAG_NAME}~1")
+  if (NOT ${GIT_BRANCH_RESULT})
+    execute_process(
+      COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --always ${tmp_version}
+      WORKING_DIRECTORY ${PADDLE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_TAG_NAME
+      RESULT_VARIABLE GIT_RESULT
+      ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (NOT ${GIT_RESULT})
+      # Check if current branch is release branch
+      if (${GIT_BRANCH_NAME} MATCHES "release/${TAG_VERSION_REGEX}")
+        # Check the tag is a correct version
+        if (${GIT_TAG_NAME} MATCHES "${COMMIT_VERSION_REGEX}")
+          # if no tag was found, set PADDLE_VERSION to latest
+          set(PADDLE_VERSION "latest")
+        elseif (${GIT_TAG_NAME} MATCHES "v${TAG_VERSION_REGEX}")
+          string(REPLACE "v" "" PADDLE_VERSION ${GIT_TAG_NAME})
+        else()  # otherwise, get the previous git tag name.
+          set(tmp_version "${GIT_TAG_NAME}~1")
+        endif()
+      else() # otherwise, we always set PADDLE_VERSION to latest
+        set(PADDLE_VERSION "latest")
+      endif()
+    else()
+      set(PADDLE_VERSION "0.0.0")
+      message(WARNING "Cannot add paddle version from git tag")
     endif()
   else()
     set(PADDLE_VERSION "0.0.0")
-    message(WARNING "Cannot add paddle version from git tag")
+    message(WARNING "Cannot add paddle version for wrong git branch result")
   endif()
 endwhile()
 

--- a/python/paddle/fluid/tests/unittests/test_version.py
+++ b/python/paddle/fluid/tests/unittests/test_version.py
@@ -46,5 +46,3 @@ class VersionTest(unittest.TestCase):
             self.assertTrue(re.match(self._rc_regex, fluid_version.rc))
             self.assertTrue(
                 re.match(self._version_regex, fluid_version.full_version))
-
-

--- a/python/paddle/fluid/tests/unittests/test_version.py
+++ b/python/paddle/fluid/tests/unittests/test_version.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import re
+
+import paddle.version as fluid_version
+
+class VersionTest(unittest.TestCase):
+    def setUp(self):
+        self._major_regex = "[0-9]+"
+        self._minor_regex = "[0-9]+"
+        self._patch_regex = "[0-9]+(\\.(a|b|rc)\\.[0-9]+)?"
+        self._rc_regex = "[0-9]+"
+        self._version_regex = "[0-9]+\\.[0-9]+\\.[0-9]+(\\.(a|b|rc)\\.[0-9]+)?"
+        self._commit_regex = "[0-9a-f]{5,49}"
+
+    def test_check_output(self):
+        # check commit format
+        self.assertTrue(re.match(self._commit_regex, fluid_version.commit))
+        self.assertTrue(isinstance(fluid_version.istaged, bool))
+
+        # check version format
+        if fluid_version.istaged:
+            self.assertEqual(fluid_version.major, 0)
+            self.assertEqual(fluid_version.minor, 0)
+            self.assertEqual(fluid_version.patch, "0")
+            self.assertEqual(fluid_version.rc, 0)
+            self.assertEqual(fluid_version.full_version, "0.0.0")
+        else:
+            self.assertTrue(re.match(self._major_regex, fluid_version.major))
+            self.assertTrue(re.match(self._minor_regex, fluid_version.minor))
+            self.assertTrue(re.match(self._patch_regex, fluid_version.patch))
+            self.assertTrue(re.match(self._rc_regex, fluid_version.rc))
+            self.assertTrue(re.match(self._version_regex, fluid_version.full_version))
+
+

--- a/python/paddle/fluid/tests/unittests/test_version.py
+++ b/python/paddle/fluid/tests/unittests/test_version.py
@@ -17,6 +17,7 @@ import re
 
 import paddle.version as fluid_version
 
+
 class VersionTest(unittest.TestCase):
     def setUp(self):
         self._major_regex = "[0-9]+"
@@ -43,6 +44,7 @@ class VersionTest(unittest.TestCase):
             self.assertTrue(re.match(self._minor_regex, fluid_version.minor))
             self.assertTrue(re.match(self._patch_regex, fluid_version.patch))
             self.assertTrue(re.match(self._rc_regex, fluid_version.rc))
-            self.assertTrue(re.match(self._version_regex, fluid_version.full_version))
+            self.assertTrue(
+                re.match(self._version_regex, fluid_version.full_version))
 
 


### PR DESCRIPTION
Now, we only get Paddle version when current branch name matches ```release/0.12.0``` pattern.

So we will get ```latest``` in ```develop``` branch and we add a version test for it.

