### PR TITLE
Fix bugs in the resize_short and simple_transform funciton

### DIFF
--- a/python/paddle/v2/image.py
+++ b/python/paddle/v2/image.py
@@ -182,7 +182,7 @@ def resize_short(im, size):
         h_new = size * h / w
     else:
         w_new = size * w / h
-    im = cv2.resize(im, (h_new, w_new), interpolation=cv2.INTER_CUBIC)
+    im = cv2.resize(im, (w_new, h_new), interpolation=cv2.INTER_CUBIC)
     return im
 
 
@@ -324,7 +324,6 @@ def simple_transform(im,
         if np.random.randint(2) == 0:
             im = left_right_flip(im, is_color)
     else:
-        im = center_crop(im, crop_size, is_color)
         im = center_crop(im, crop_size, is_color=is_color)
     if len(im.shape) == 3:
         im = to_chw(im)


### PR DESCRIPTION
The resize_short function used the cv2.resize function in a wrong way.
The simple_transform function repeated the code uncorrectly.