### PR TITLE
MKLDNN sum fix: remove in_place condition in loop with memory primitives

### DIFF
--- a/paddle/fluid/operators/sum_mkldnn_op.cc
+++ b/paddle/fluid/operators/sum_mkldnn_op.cc
@@ -88,7 +88,7 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         input_format = memory::format::nc;
       }
 
-      for (int i = in_place ? 1 : 0; i < N; i++) {
+      for (int i = 0; i < N; i++) {
         PADDLE_ENFORCE(in_vars[i]->IsType<LoDTensor>(),
                        "all inputs must be all LoDTensors");
         auto& input = in_vars[i]->Get<LoDTensor>();


### PR DESCRIPTION
This PR fixes a problem in RNN-CTC where edit distance was calculated incorrectly.

In PaddlePaddle, edit distance is calculated by accumulating partial distance values to total distance. The already accumulated value of total distance was skipped and overwritten when `in_place` value was set to `true`.

Buggy situation happened because MKLDNN `sum` primitive does not support any in-place computation. In MKLDNN `sum`, content of the output is ignored and it is always initialized with the content of the first element on the list of sources. When `in_place` attribute was true, value of partially calculated total distance was ignored and it was overwritten.