### PR TITLE
Fix IR CMake dependence.

### DIFF
--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -1,5 +1,5 @@
-cc_library(graph SRCS graph.cc DEPS node)
 cc_library(node SRCS node.cc DEPS proto_desc)
+cc_library(graph SRCS graph.cc DEPS node)
 cc_library(pass SRCS pass.cc DEPS graph node)
 
 cc_test(graph_test SRCS graph_test.cc DEPS graph proto_desc op_registry)


### PR DESCRIPTION
Now compling error is:

```
[05:40:09] :	 [Step 1/1] [  5%] Building CXX object paddle/fluid/memory/detail/CMakeFiles/memory_block.dir/memory_block.cc.o
[05:40:09] :	 [Step 1/1] Scanning dependencies of target header
[05:40:09] :	 [Step 1/1] [  5%] Building CXX object paddle/fluid/string/CMakeFiles/stringpiece.dir/piece.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/memory/detail/CMakeFiles/memory_block.dir/memory_block_desc.cc.o
[05:40:09] :	 [Step 1/1] Scanning dependencies of target activation_functions
[05:40:09] :	 [Step 1/1] Scanning dependencies of target node
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/recordio/CMakeFiles/header.dir/header.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/operators/math/detail/CMakeFiles/activation_functions.dir/avx_functions.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/memory/detail/CMakeFiles/memory_block.dir/meta_cache.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/framework/ir/CMakeFiles/node.dir/node.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Linking CXX static library libmemory_block.a
[05:40:09] :	 [Step 1/1] Scanning dependencies of target graph
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/framework/ir/CMakeFiles/graph.dir/graph.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Linking CXX static library libstringpiece.a
[05:40:09]W:	 [Step 1/1] In file included from /paddle/paddle/fluid/framework/op_desc.h:20:0,
[05:40:09]W:	 [Step 1/1]                  from /paddle/paddle/fluid/framework/ir/node.h:19,
[05:40:09]W:	 [Step 1/1]                  from /paddle/paddle/fluid/framework/ir/node.cc:15:
[05:40:09]W:	 [Step 1/1] /paddle/paddle/fluid/framework/attribute.h:23:49: fatal error: paddle/fluid/framework/framework.pb.h: No such file or directory
[05:40:09]W:	 [Step 1/1] compilation terminated.
[05:40:09]W:	 [Step 1/1] make[2]: *** [paddle/fluid/framework/ir/CMakeFiles/node.dir/node.cc.o] Error 1
[05:40:09]W:	 [Step 1/1] make[1]: *** [paddle/fluid/framework/ir/CMakeFiles/node.dir/all] Error 2
[05:40:09]W:	 [Step 1/1] make[1]: *** Waiting for unfinished jobs....
[05:40:09] :	 [Step 1/1] paddle/fluid/framework/ir/CMakeFiles/node.dir/build.make:62: recipe for target 'paddle/fluid/framework/ir/CMakeFiles/node.dir/node.cc.o' failed
[05:40:09] :	 [Step 1/1] CMakeFiles/Makefile2:9239: recipe for target 'paddle/fluid/framework/ir/CMakeFiles/node.dir/all' failed
[05:40:09] :	 [Step 1/1] [  6%] Building CXX object paddle/fluid/framework/ir/CMakeFiles/graph.dir/node.cc.o
[05:40:09] :	 [Step 1/1] [  6%] Built target stringpiece
[05:40:09]W:	 [Step 1/1] In file included from /paddle/paddle/fluid/framework/op_desc.h:20:0,
[05:40:09]W:	 [Step 1/1]                  from /paddle/paddle/fluid/framework/ir/node.h:19,
[05:40:09]W:	 [Step 1/1]                  from /paddle/paddle/fluid/framework/ir/graph.h:22,
[05:40:09]W:	 [Step 1/1]                  from /paddle/paddle/fluid/framework/ir/graph.cc:15:
[05:40:09]W:	 [Step 1/1] /paddle/paddle/fluid/framework/attribute.h:23:49: fatal error: paddle/fluid/framework/framework.pb.h: No such file or directory
```