### PR TITLE
Fix var_handle CMake dependence

### DIFF
--- a/paddle/fluid/framework/details/CMakeLists.txt
+++ b/paddle/fluid/framework/details/CMakeLists.txt
@@ -1,4 +1,4 @@
-cc_library(var_handle SRCS var_handle.cc DEPS place)
+cc_library(var_handle SRCS var_handle.cc DEPS place framework_proto)
 cc_library(op_handle_base SRCS op_handle_base.cc DEPS var_handle device_context lod_tensor)
 cc_library(scale_loss_grad_op_handle SRCS scale_loss_grad_op_handle.cc DEPS op_handle_base scope lod_tensor ddim memory)
 cc_library(fetch_op_handle SRCS fetch_op_handle.cc DEPS op_handle_base scope lod_tensor ddim memory)


### PR DESCRIPTION
```
[12:02:36]	In file included from /paddle/paddle/fluid/framework/op_desc.h:20:0,
[12:02:36]	                 from /paddle/paddle/fluid/framework/ir/node.h:19,
[12:02:36]	                 from /paddle/paddle/fluid/framework/details/var_handle.h:23,
[12:02:36]	                 from /paddle/paddle/fluid/framework/details/var_handle.cc:15:
[12:02:36]	/paddle/paddle/fluid/framework/attribute.h:23:49: fatal error: paddle/fluid/framework/framework.pb.h: No such file or directory
[12:02:36]	 #include "paddle/fluid/framework/framework.pb.h"
[12:02:36]	                                                 ^
[12:02:36]	compilation terminated.
```
https://paddleci.ngrok.io/viewLog.html?buildId=2312&buildTypeId=Manylinux1_Cuda80cudnn5avxOpenblas&tab=buildLog&_focus=1557