### PR TITLE
loosen the restriction of output_size in conv2d_transpose

### DIFF
--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -29,6 +29,7 @@ void ConvTransposeOp::InferShape(framework::InferShapeContext* ctx) const {
 
   auto in_dims = ctx->GetInputDim("Input");
   auto filter_dims = ctx->GetInputDim("Filter");
+  std::vector<int> output_size = ctx->Attrs().Get<std::vector<int>>("output_size");
   std::vector<int> strides = ctx->Attrs().Get<std::vector<int>>("strides");
   std::vector<int> paddings = ctx->Attrs().Get<std::vector<int>>("paddings");
   std::vector<int> dilations = ctx->Attrs().Get<std::vector<int>>("dilations");
@@ -42,6 +43,10 @@ void ConvTransposeOp::InferShape(framework::InferShapeContext* ctx) const {
   PADDLE_ENFORCE(in_dims.size() - strides.size() == 2U,
                  "ConvTransposeOp input dimension and strides dimension should "
                  "be consistent.");
+  if (output_size.size())
+      PADDLE_ENFORCE_EQ(output_size.size(), strides.size(),
+                        "ConvTransposeOp output_size dimension and strides "
+                        "dimension should be the same.");
   PADDLE_ENFORCE_EQ(paddings.size(), strides.size(),
                     "ConvTransposeOp paddings dimension and strides "
                     "dimension should be the same.");
@@ -55,8 +60,17 @@ void ConvTransposeOp::InferShape(framework::InferShapeContext* ctx) const {
   std::vector<int64_t> output_shape({in_dims[0], filter_dims[1] * groups});
   for (size_t i = 0; i < strides.size(); ++i) {
     auto filter_extent = dilations[i] * (filter_dims[i + 2] - 1) + 1;
-    output_shape.push_back((in_dims[i + 2] - 1) * strides[i] - 2 * paddings[i] +
-                           filter_extent);
+    auto infer_shape = (in_dims[i + 2] - 1) * strides[i] - 2 * paddings[i] +
+        filter_extent;
+    if (output_size.size()) {
+    PADDLE_ENFORCE((output_size[i] >= infer_shape &&
+                    output_size[i] < infer_shape + strides[i]),
+                    "ConvTransposeOp output_size should be "
+                    "in appropriate range.");
+      output_shape.push_back(output_size[i]);
+    } else {
+      output_shape.push_back(infer_shape);
+    }
   }
   ctx->SetOutputDim("Output", framework::make_ddim(output_shape));
 }
@@ -103,6 +117,10 @@ void Conv2DTransposeOpMaker::Make() {
   AddOutput("Output",
             "(Tensor) The output tensor of convolution transpose operator. "
             "The format of output tensor is also NCHW.");
+  AddAttr<std::vector<int>>("output_size",
+                            "(vector<int> default: []), the "
+                            "size of the output tensor")
+      .SetDefault({});
   AddAttr<int>("groups",
                "(int default:1), the groups number of the convolution "
                "transpose operator. ")
@@ -247,7 +265,7 @@ Parameters(strides, paddings) are three elements. These three elements represent
 depth, height and width, respectively.
 The input(X) size and output(Out) size may be different.
 
-Example:   
+Example:
   Input:
        Input shape: $(N, C_{in}, D_{in}, H_{in}, W_{in})$
        Filter shape: $(C_{in}, C_{out}, D_f, H_f, W_f)$

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -212,6 +212,9 @@ void Conv3DTransposeOpMaker::Make() {
             "the number of channels, D is the depth of the feature, H is the "
             "height of the feature, and W is the width of the feature.");
 
+  AddAttr<std::vector<int>>("output_size",
+                            "(vector<int> default: []), the "
+                            "size of the output tensor");
   AddAttr<std::vector<int>>(
       "dilations",
       "(vector<int> default:{1, 1, 1}), the "

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -211,10 +211,10 @@ void Conv3DTransposeOpMaker::Make() {
             "Where N is batch size, C is "
             "the number of channels, D is the depth of the feature, H is the "
             "height of the feature, and W is the width of the feature.");
-
   AddAttr<std::vector<int>>("output_size",
                             "(vector<int> default: []), the "
-                            "size of the output tensor");
+                            "size of the output tensor")
+      .SetDefault({});
   AddAttr<std::vector<int>>(
       "dilations",
       "(vector<int> default:{1, 1, 1}), the "

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -29,7 +29,8 @@ void ConvTransposeOp::InferShape(framework::InferShapeContext* ctx) const {
 
   auto in_dims = ctx->GetInputDim("Input");
   auto filter_dims = ctx->GetInputDim("Filter");
-  std::vector<int> output_size = ctx->Attrs().Get<std::vector<int>>("output_size");
+  std::vector<int> output_size =
+      ctx->Attrs().Get<std::vector<int>>("output_size");
   std::vector<int> strides = ctx->Attrs().Get<std::vector<int>>("strides");
   std::vector<int> paddings = ctx->Attrs().Get<std::vector<int>>("paddings");
   std::vector<int> dilations = ctx->Attrs().Get<std::vector<int>>("dilations");
@@ -44,9 +45,9 @@ void ConvTransposeOp::InferShape(framework::InferShapeContext* ctx) const {
                  "ConvTransposeOp input dimension and strides dimension should "
                  "be consistent.");
   if (output_size.size())
-      PADDLE_ENFORCE_EQ(output_size.size(), strides.size(),
-                        "ConvTransposeOp output_size dimension and strides "
-                        "dimension should be the same.");
+    PADDLE_ENFORCE_EQ(output_size.size(), strides.size(),
+                      "ConvTransposeOp output_size dimension and strides "
+                      "dimension should be the same.");
   PADDLE_ENFORCE_EQ(paddings.size(), strides.size(),
                     "ConvTransposeOp paddings dimension and strides "
                     "dimension should be the same.");
@@ -60,13 +61,13 @@ void ConvTransposeOp::InferShape(framework::InferShapeContext* ctx) const {
   std::vector<int64_t> output_shape({in_dims[0], filter_dims[1] * groups});
   for (size_t i = 0; i < strides.size(); ++i) {
     auto filter_extent = dilations[i] * (filter_dims[i + 2] - 1) + 1;
-    auto infer_shape = (in_dims[i + 2] - 1) * strides[i] - 2 * paddings[i] +
-        filter_extent;
+    auto infer_shape =
+        (in_dims[i + 2] - 1) * strides[i] - 2 * paddings[i] + filter_extent;
     if (output_size.size()) {
-    PADDLE_ENFORCE((output_size[i] >= infer_shape &&
-                    output_size[i] < infer_shape + strides[i]),
-                    "ConvTransposeOp output_size should be "
-                    "in appropriate range.");
+      PADDLE_ENFORCE((output_size[i] >= infer_shape &&
+                      output_size[i] < infer_shape + strides[i]),
+                     "ConvTransposeOp output_size should be "
+                     "in appropriate range.");
       output_shape.push_back(output_size[i]);
     } else {
       output_shape.push_back(infer_shape);

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2312,7 +2312,10 @@ def conv2d_transpose(input,
         num_filters(int): The number of the filter. It is as same as the output
             image channel.
         output_size(int|tuple|None): The output image size. If output size is a
-            tuple, it must contain two integers, (image_H, image_W).
+            tuple, it must contain two integers, (image_H, image_W). None if use
+            filter_size, padding, and stride to calculate output_size.
+            if output_size and filter_size are specified at the same time, They
+            should follow the formula above.
         filter_size(int|tuple|None): The filter size. If filter_size is a tuple,
             it must contain two integers, (filter_size_H, filter_size_W).
             Otherwise, the filter will be a square. None if use output size to

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -33,6 +33,10 @@ def conv2dtranspose_forward_naive(input_, filter_, attrs):
     d_bolck_w = dilations[1] * (f_w - 1) + 1
     out_h = (in_h - 1) * stride[0] + d_bolck_h
     out_w = (in_w - 1) * stride[1] + d_bolck_w
+    if attrs.has_key('output_size'):
+        output_size = attrs['output_size']
+        out_h = output_size[0] + 2 * pad[0]
+        out_w = output_size[1] + 2 * pad[1]
 
     out = np.zeros((in_n, out_c, out_h, out_w))
 
@@ -63,6 +67,7 @@ class TestConv2dTransposeOp(OpTest):
     def setUp(self):
         # init as conv transpose
         self.use_cudnn = False
+        self.output_size = None
         self.init_op_type()
         self.init_test_case()
 
@@ -78,6 +83,8 @@ class TestConv2dTransposeOp(OpTest):
             'use_cudnn': self.use_cudnn,
             'data_format': 'AnyLayout'  # TODO(dzhwinter) : should be fix latter
         }
+        if self.output_size is not None:
+            self.attrs['output_size'] = self.output_size
 
         output = conv2dtranspose_forward_naive(input_, filter_,
                                                self.attrs).astype('float32')
@@ -190,6 +197,17 @@ class TestWithDilation(TestConv2dTransposeOp):
         self.filter_size = [f_c, 6, 3, 3]
 
 
+class TestWithEvenUpsample(TestConv2dTransposeOp):
+    def init_test_case(self):
+        self.pad = [2, 2]
+        self.stride = [2, 2]
+        self.groups = 1
+        self.dilations = [1, 1]
+        self.output_size = [14, 14]
+        self.input_size = [2, 3, 7, 7]  # NCHW
+        f_c = self.input_size[1]
+        self.filter_size = [f_c, 6, 5, 5]
+
 # ------------ test_cudnn ------------
 @unittest.skipIf(not core.is_compiled_with_cuda(),
                  "core is not compiled with CUDA")
@@ -262,6 +280,14 @@ class TestDepthwiseConvTranspose(TestConv2dTransposeOp):
         self.filter_size = [self.input_size[1], f_c, 4, 4]
         self.op_type = "depthwise_conv2d_transpose"
 
+
+# ------------ test_cudnn ------------
+@unittest.skipIf(not core.is_compiled_with_cuda(),
+                 "core is not compiled with CUDA")
+class TestCUDNNWithEvenUpsample(TestWithEvenUpsample):
+    def init_op_type(self):
+        self.use_cudnn = True
+        self.op_type = "conv2d_transpose"
 
 # Please Don't remove the following code.
 # Currently, CI use cudnn V5.0 which not support dilation conv.

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -208,6 +208,7 @@ class TestWithEvenUpsample(TestConv2dTransposeOp):
         f_c = self.input_size[1]
         self.filter_size = [f_c, 6, 5, 5]
 
+
 # ------------ test_cudnn ------------
 @unittest.skipIf(not core.is_compiled_with_cuda(),
                  "core is not compiled with CUDA")
@@ -288,6 +289,7 @@ class TestCUDNNWithEvenUpsample(TestWithEvenUpsample):
     def init_op_type(self):
         self.use_cudnn = True
         self.op_type = "conv2d_transpose"
+
 
 # Please Don't remove the following code.
 # Currently, CI use cudnn V5.0 which not support dilation conv.

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -33,7 +33,7 @@ def conv2dtranspose_forward_naive(input_, filter_, attrs):
     d_bolck_w = dilations[1] * (f_w - 1) + 1
     out_h = (in_h - 1) * stride[0] + d_bolck_h
     out_w = (in_w - 1) * stride[1] + d_bolck_w
-    if attrs.has_key('output_size'):
+    if 'output_size' in attrs:
         output_size = attrs['output_size']
         out_h = output_size[0] + 2 * pad[0]
         out_w = output_size[1] + 2 * pad[1]


### PR DESCRIPTION
output_size of conv2d_transpose has a restriction and causes that it is impossible to upsample a 7x7 input tensor to a 14x14 output tensor with a 5x5 kernel. this PR will loosen the restriction.

A example:
```python

import paddle
import paddle.fluid as fluid
import numpy as np



xx = np.array(range(7*7)).astype(np.float32).reshape((1,7,7,1))+1
ww = np.zeros((5,5,25,1)).astype(np.float32)
for i in range(5):
    for j in range(5):
        ww[i,j,i*5+j,0] = 1

exe = fluid.Executor(fluid.CPUPlace())

startup_program = fluid.Program()
program = fluid.Program()
nw = ww.transpose((3,2,0,1))
with fluid.program_guard(program, startup_program):
    blk = program.global_block()
    startup_program.global_block().create_parameter(
        dtype='float32', shape=nw.shape, name='w')
        #, with_initializer=True, initializer=fluid.initializer.Constant(1))
    var = blk.create_parameter(dtype='float32', shape=nw.shape, name='w')
    op = blk.append_op(
        type='assign_value',
        outputs={'Out': [var]},
        attrs={
            'dtype': var.dtype,
            'shape': list(var.shape),
            'fp32_values': map(lambda x:float(x), ww.flatten())
    })
    shape = [1,7,7]
    img = fluid.layers.data(name='img', shape=shape, dtype='float32')

    y = blk.create_var(name = 'y', dtype='float32')
    blk.append_op(
        type='conv2d_transpose',
        inputs={'Input': [img],
                'Filter': [var]},
        outputs={'Output': y},
        attrs={
            'output_size': [14,14],
            'strides': [2,2],
            'paddings': [2,2],
            'dilations': [1,1],
            'groups': 1,
            'use_cudnn': False
        })

exe.run(startup_program)
result = exe.run(program, feed={'img':xx.transpose(0,3,1,2)}, fetch_list={y, var})

print result[1][0,0]
print result[1][0,24]
```

results:
```
[[ 9.  0. 10.  0. 11.  0. 12.  0. 13.  0. 14.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [16.  0. 17.  0. 18.  0. 19.  0. 20.  0. 21.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [23.  0. 24.  0. 25.  0. 26.  0. 27.  0. 28.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [30.  0. 31.  0. 32.  0. 33.  0. 34.  0. 35.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [37.  0. 38.  0. 39.  0. 40.  0. 41.  0. 42.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [44.  0. 45.  0. 46.  0. 47.  0. 48.  0. 49.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]]

[[ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0.  1.  0.  2.  0.  3.  0.  4.  0.  5.  0.  6.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0.  8.  0.  9.  0. 10.  0. 11.  0. 12.  0. 13.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0. 15.  0. 16.  0. 17.  0. 18.  0. 19.  0. 20.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0. 22.  0. 23.  0. 24.  0. 25.  0. 26.  0. 27.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0. 29.  0. 30.  0. 31.  0. 32.  0. 33.  0. 34.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]
 [ 0.  0. 36.  0. 37.  0. 38.  0. 39.  0. 40.  0. 41.  0.]
 [ 0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.  0.]]
```