### PR TITLE
Add traceback info

### DIFF
--- a/paddle/fluid/framework/details/op_handle_base.h
+++ b/paddle/fluid/framework/details/op_handle_base.h
@@ -87,6 +87,14 @@ class OpHandleBase {
 
   ir::Node *Node() { return node_; }
 
+  const std::string GetUserTraceback() const {
+    if (node_->Op()) {
+      return node_->Op()->GetUserTraceback();
+    } else {
+      return "";
+    }
+  }
+
  protected:
   void RunAndRecordEvent(const std::function<void()> &callback);
 
@@ -99,6 +107,8 @@ class OpHandleBase {
   std::vector<VarHandleBase *> inputs_;
   std::vector<VarHandleBase *> outputs_;
   std::map<platform::Place, platform::DeviceContext *> dev_ctxes_;
+
+  std::string user_traceback_;
 
 #ifdef PADDLE_WITH_CUDA
   std::unordered_map<int, cudaEvent_t> events_;

--- a/paddle/fluid/framework/details/threaded_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/threaded_ssa_graph_executor.cc
@@ -237,7 +237,8 @@ void ThreadedSSAGraphExecutor::RunOp(
       std::lock_guard<std::mutex> l(exception_mu_);
       std::string exc_string =
           string::Sprintf("%s\n%s", op->GetUserTraceback(), ex.err_str_);
-      exception_.reset(new platform::EnforceNotMet(ex, exc_string.c_str(), 0));
+      exception_.reset(new platform::EnforceNotMet(std::make_exception_ptr(ex),
+                                                   exc_string.c_str(), 0));
     } catch (...) {
       LOG(FATAL) << "Unknown exception catched";
     }

--- a/paddle/fluid/framework/details/threaded_ssa_graph_executor.cc
+++ b/paddle/fluid/framework/details/threaded_ssa_graph_executor.cc
@@ -235,7 +235,9 @@ void ThreadedSSAGraphExecutor::RunOp(
       }
     } catch (platform::EnforceNotMet ex) {
       std::lock_guard<std::mutex> l(exception_mu_);
-      exception_.reset(new platform::EnforceNotMet(ex));
+      std::string exc_string =
+          string::Sprintf("%s\n%s", op->GetUserTraceback(), ex.err_str_);
+      exception_.reset(new platform::EnforceNotMet(ex, exc_string.c_str(), 0));
     } catch (...) {
       LOG(FATAL) << "Unknown exception catched";
     }

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -135,6 +135,9 @@ class OpDesc {
 
   void SetBlock(BlockDesc *block) { this->block_ = block; }
 
+  void SetUserTraceback(const std::string &tb) { user_traceback_ = tb; }
+  const std::string GetUserTraceback() const { return user_traceback_; }
+
  private:
   template <typename MapType>
   static std::vector<typename MapType::key_type> MapKeys(const MapType &map) {
@@ -153,6 +156,9 @@ class OpDesc {
   // output arg name => output variable names
   VariableNameMap outputs_;
   AttributeMap attrs_;
+
+  // traceback info stores only at runtime
+  std::string user_traceback_;
 
   // need_update_ indicate there some local changes not be synchronized. If
   // local changes should be synchronized, need_update_ should be set to true.

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -308,7 +308,8 @@ void BindOpDesc(pybind11::module *m) {
       .def("set_is_target", &pd::OpDesc::SetIsTarget)
       .def("serialize_to_string", SerializeMessage<pd::OpDesc>)
       .def("block", &pd::OpDesc::Block,
-           pybind11::return_value_policy::reference);
+           pybind11::return_value_policy::reference)
+      .def("set_user_traceback", &pd::OpDesc::SetUserTraceback);
 }
 
 }  // namespace pybind

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -472,7 +472,8 @@ class Operator(object):
                  type=None,
                  inputs=None,
                  outputs=None,
-                 attrs=None):
+                 attrs=None,
+                 traceback=None):
 
         self.block = block
         self.desc = desc
@@ -574,6 +575,8 @@ class Operator(object):
         if self.has_kernel(type):
             self.desc.infer_var_type(self.block.desc)
             self.desc.infer_shape(self.block.desc)
+        if traceback:
+            self.desc.set_user_traceback(traceback)
 
     def has_kernel(self, op_type):
         return op_type not in self.OP_WITHOUT_KERNEL_SET

--- a/python/paddle/fluid/layer_helper.py
+++ b/python/paddle/fluid/layer_helper.py
@@ -14,6 +14,7 @@
 
 import copy
 import itertools
+import traceback
 
 from framework import Variable, Parameter, default_main_program, default_startup_program, dtype_is_floating
 import unique_name
@@ -29,6 +30,8 @@ class LayerHelper(object):
         name = self.kwargs.get('name', None)
         if name is None:
             self.kwargs['name'] = unique_name.generate(self.layer_type)
+        # traceback debug info for all layer API
+        kwargs['traceback'] = traceback.format_stack()
 
     @property
     def name(self):


### PR DESCRIPTION
When `op->Run` throws an exception, can also print out the traceback information of user python program.