### PR TITLE
add flag to prevent unnessary memory free

### DIFF
--- a/paddle/fluid/memory/detail/buddy_allocator.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator.cc
@@ -15,6 +15,10 @@ limitations under the License. */
 #include "paddle/fluid/memory/detail/buddy_allocator.h"
 #include "glog/logging.h"
 
+DEFINE_bool(free_idle_memory, false,
+            "If it is true, Paddle will try to free idle memory trunks during "
+            "running time.");
+
 namespace paddle {
 namespace memory {
 namespace detail {
@@ -152,13 +156,14 @@ void BuddyAllocator::Free(void* p) {
   pool_.insert(
       IndexSizeAddress(block->index(cache_), block->total_size(cache_), block));
 
-  // Clean up if existing too much free memory
+  if (FLAGS_free_idle_memory) {
+    // Clean up if existing too much free memory
+    // Prefer freeing fallback allocation first
+    CleanIdleFallBackAlloc();
 
-  // Prefer freeing fallback allocation first
-  CleanIdleFallBackAlloc();
-
-  // Free normal allocation
-  CleanIdleNormalAlloc();
+    // Free normal allocation
+    CleanIdleNormalAlloc();
+  }
 }
 
 size_t BuddyAllocator::Used() { return total_used_; }

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -62,33 +62,33 @@ from paddle.fluid.layers.math_op_patch import monkey_patch_variable
 Tensor = LoDTensor
 
 __all__ = framework.__all__ + executor.__all__ + concurrency.__all__ + \
-          trainer.__all__ + inferencer.__all__ + transpiler.__all__ + \
-          parallel_executor.__all__ + lod_tensor.__all__ + [
-              'io',
-              'initializer',
-              'layers',
-              'contrib',
-              'transpiler',
-              'nets',
-              'optimizer',
-              'learning_rate_decay',
-              'backward',
-              'regularizer',
-              'LoDTensor',
-              'LoDTensorArray',
-              'CPUPlace',
-              'CUDAPlace',
-              'CUDAPinnedPlace',
-              'Tensor',
-              'ParamAttr',
-              'WeightNormParamAttr',
-              'DataFeeder',
-              'clip',
-              'profiler',
-              'unique_name',
-              'recordio_writer',
-              'Scope',
-          ]
+    trainer.__all__ + inferencer.__all__ + transpiler.__all__ + \
+    parallel_executor.__all__ + lod_tensor.__all__ + [
+        'io',
+        'initializer',
+        'layers',
+        'contrib',
+        'transpiler',
+        'nets',
+        'optimizer',
+        'learning_rate_decay',
+        'backward',
+        'regularizer',
+        'LoDTensor',
+        'LoDTensorArray',
+        'CPUPlace',
+        'CUDAPlace',
+        'CUDAPinnedPlace',
+        'Tensor',
+        'ParamAttr',
+        'WeightNormParamAttr',
+        'DataFeeder',
+        'clip',
+        'profiler',
+        'unique_name',
+        'recordio_writer',
+        'Scope',
+    ]
 
 
 def __bootstrap__():
@@ -123,7 +123,7 @@ def __bootstrap__():
     read_env_flags = [
         'use_pinned_memory', 'check_nan_inf', 'benchmark', 'warpctc_dir',
         'eager_delete_scope', 'use_mkldnn', 'initial_cpu_memory_in_mb',
-        'init_allocated_mem'
+        'init_allocated_mem', 'free_idle_memory'
     ]
     if core.is_compiled_with_dist():
         read_env_flags.append('rpc_deadline')


### PR DESCRIPTION
Currently, Fluid has a strategy to free idle memory trunks to reduce memory usage. However, we have found that the strategy is too radical, which results in frequent GPU memory free and re-allocation when we set `FLAG_fraction_of_gpu_memory_to_use` to a not-so-large value(e.g., 0.12 on P40, ResNet50). These unnecessary free and re-allocation can slow down the training speed badly.

In fact, the memory required by Fluid throughout the whole training is almost constant. So the strategy of free idle trunks does not benefit us a lot, but brings the risk of excessive memory free.

The performance log when the excessive memory free triggered (`FLAG_fraction_of_gpu_memory_to_use=0.12`):
```
pass_id=0, batch_id=1, cost=[array([4.4489174], dtype=float32)], img/sec=125.810858
pass_id=0, batch_id=2, cost=[array([4.750519], dtype=float32)], img/sec=94.733411
pass_id=0, batch_id=3, cost=[array([4.7533627], dtype=float32)], img/sec=128.104272
pass_id=0, batch_id=4, cost=[array([7.1040096], dtype=float32)], img/sec=122.321587
pass_id=0, batch_id=5, cost=[array([5.2217026], dtype=float32)], img/sec=125.047903
pass_id=0, batch_id=6, cost=[array([7.110008], dtype=float32)], img/sec=125.092831
pass_id=0, batch_id=7, cost=[array([6.131187], dtype=float32)], img/sec=100.830599
pass_id=0, batch_id=8, cost=[array([8.36142], dtype=float32)], img/sec=126.130967
```

A normal performance log (`FLAG_fraction_of_gpu_memory_to_use=0.9`):
```
pass_id=0, batch_id=1, cost=[array([4.15617], dtype=float32)], img/sec=137.425163
pass_id=0, batch_id=2, cost=[array([4.9357696], dtype=float32)], img/sec=136.662553
pass_id=0, batch_id=3, cost=[array([4.856681], dtype=float32)], img/sec=137.061130
pass_id=0, batch_id=4, cost=[array([8.749122], dtype=float32)], img/sec=136.502785
pass_id=0, batch_id=5, cost=[array([6.53635], dtype=float32)], img/sec=137.167095
pass_id=0, batch_id=6, cost=[array([8.228344], dtype=float32)], img/sec=136.524306
pass_id=0, batch_id=7, cost=[array([6.6035423], dtype=float32)], img/sec=137.329617
pass_id=0, batch_id=8, cost=[array([9.625316], dtype=float32)], img/sec=136.956656
```

To fix this issue, we add a new Flag: `FLAG_free_idle_memory`. When it is set to `false`(which is also its default value), Fluid will not try to free idle memory trunks.


Fix results (ResNet50, P40, `FLAG_fraction_of_gpu_memory_to_use=0.12`):
img/sec :

|               | 1 GPU |  4 GPU  |  8 GPU |
|--------|--------|---------|---------| 
|before  | 116.6   |   457.9    |  835.1     |
|after     | 137.8   |   484.8   |  886.3    |