### PR TITLE
compress the fluid.tgz

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -534,7 +534,7 @@ EOF
         make -j `nproc` inference_lib_dist
         cd ${PADDLE_ROOT}/build
         cp -r fluid_install_dir fluid
-        tar -cf fluid.tgz fluid
+        tar -czf fluid.tgz fluid
       fi
 }
 


### PR DESCRIPTION
Current `fluid.tgz` downloaded from teamcity is too large, which makes download very slow:
- CPU version: about 335+ MB.
- GPU version: about 730+ MB.

Using `tar -czf` instead of `tar -cf`, then:
- CPU verison: about 77 MB.
- GPU version: about 190 MB.