### PR TITLE
fix: add batch size check in loading data process

### DIFF
--- a/python/paddle/batch.py
+++ b/python/paddle/batch.py
@@ -40,4 +40,9 @@ def batch(reader, batch_size, drop_last=False):
         if drop_last == False and len(b) != 0:
             yield b
 
+    # Batch size check
+    if batch_size <= 0:
+        raise ValueError("batch_size should be a positive integeral value, "
+                         "but got batch_size={}".format(batch_size))
+
     return batch_reader

--- a/python/paddle/batch.py
+++ b/python/paddle/batch.py
@@ -41,6 +41,7 @@ def batch(reader, batch_size, drop_last=False):
             yield b
 
     # Batch size check
+    batch_size = int(batch_size)
     if batch_size <= 0:
         raise ValueError("batch_size should be a positive integeral value, "
                          "but got batch_size={}".format(batch_size))


### PR DESCRIPTION
I think we should add batch size check when processing data, I try to change the `batch_size` to -1 in paddle book demo 01 and 02, the model can not be generated normally, and then this error will lead to crash. Such as

in 01.fit_a_line:
```
paddle.fluid.core.EnforceNotMet: Cannot open file fit_a_line.inference.model/fc_0.w_0 for load op at [/paddle/paddle/fluid/operators/load_op.cc:42]
```
in 02.recognize_digits
```
paddle.fluid.core.EnforceNotMet: holder_ should not be null
Tensor not initialized yet when Tensor::type() is called. at [/paddle/paddle/fluid/framework/tensor.h:139]
```

Fix https://github.com/PaddlePaddle/Paddle/issues/12447