### PR TITLE
fix parallelexe condition lr decay deps

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -100,7 +100,7 @@ else()
 endif()
 
 
-cc_library(parallel_executor SRCS parallel_executor.cc DEPS threaded_ssa_graph_executor scope_buffered_ssa_graph_executor graph graph_viz_pass multi_devices_graph_builder ssa_graph_printer ssa_graph_checker)
+cc_library(parallel_executor SRCS parallel_executor.cc DEPS threaded_ssa_graph_executor scope_buffered_ssa_graph_executor graph graph_viz_pass multi_devices_graph_builder ssa_graph_printer ssa_graph_checker shrink_assign_depvar_pass)
 
 cc_library(prune SRCS prune.cc DEPS framework_proto)
 cc_test(prune_test SRCS prune_test.cc DEPS op_info prune recurrent_op device_context)

--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -3,6 +3,7 @@ cc_library(graph SRCS graph.cc DEPS node)
 cc_library(graph_helper SRCS graph_helper.cc DEPS graph)
 cc_library(pass SRCS pass.cc DEPS graph node graph_helper)
 cc_library(graph_viz_pass SRCS graph_viz_pass.cc DEPS graph pass graph_helper)
+cc_library(shrink_assign_depvar_pass SRCS shrink_assign_depvar_pass.cc DEPS graph pass graph_helper)
 
 cc_test(pass_test SRCS pass_test.cc DEPS graph pass graph_helper)
 cc_test(graph_test SRCS graph_test.cc DEPS graph graph_helper op_registry)

--- a/paddle/fluid/framework/ir/graph.h
+++ b/paddle/fluid/framework/ir/graph.h
@@ -102,6 +102,12 @@ class Graph {
     return ret;
   }
 
+  void RemoveNode(ir::Node *node) {
+    PADDLE_ENFORCE(node_set_.find(node) != node_set_.end());
+    node_set_.erase(node);
+    nodes_.erase(node);
+  }
+
  private:
   // This method takes ownership of `node`.
   ir::Node *AddNode(ir::Node *node) {
@@ -109,12 +115,6 @@ class Graph {
     nodes_[node].reset(node);
     node_set_.insert(node);
     return node;
-  }
-
-  void RemoveNode(ir::Node *node) {
-    PADDLE_ENFORCE(node_set_.find(node) != node_set_.end());
-    node_set_.erase(node);
-    nodes_.erase(node);
   }
 
   // NOTE: program_ shouldn't be exposed to user.

--- a/paddle/fluid/framework/ir/shrink_assign_depvar_pass.cc
+++ b/paddle/fluid/framework/ir/shrink_assign_depvar_pass.cc
@@ -1,0 +1,103 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <stdio.h>
+#include <algorithm>
+
+#include "paddle/fluid/framework/ir/graph.h"
+#include "paddle/fluid/framework/ir/shrink_assign_depvar_pass.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+std::vector<ir::Node*> GetUpstreamOps(const ir::Node* op) {
+  std::vector<ir::Node*> upstreams;
+  for (ir::Node* var : op->inputs) {
+    for (ir::Node* upstream : var->inputs) {
+      PADDLE_ENFORCE(upstream->NodeType() == ir::Node::Type::kOperation);
+      upstreams.push_back(upstream);
+    }
+  }
+  return upstreams;
+}
+
+std::unique_ptr<ir::Graph> ShrinkAssignDepvarPass::ApplyImpl(
+    std::unique_ptr<ir::Graph> graph) const {
+  std::vector<ir::Node*> to_remove;
+
+  for (ir::Node* n : graph->Nodes()) {
+    if (n->NodeType() == ir::Node::Type::kVariable) continue;
+
+    for (ir::Node* in_var : n->inputs) {
+      for (ir::Node* upstream_op : in_var->inputs) {
+        PADDLE_ENFORCE(upstream_op->NodeType() == ir::Node::Type::kOperation);
+        if (upstream_op->Name() == "assign") {
+          printf("find path: %s -> %s -> %s\n", upstream_op->Name().c_str(),
+                 in_var->Name().c_str(), n->Name().c_str());
+          // connected by dep_var, cases like:
+          // condition_op -> learning_rate
+          //              \-> assign -> final_learning_rate ->
+          //                        \-> dep_var -> contition_op
+          // then, use dep_var to connect ops around assign
+          if (IsControlDepVar(*in_var)) {
+            to_remove.push_back(upstream_op);
+            // remove assign -> dep_var connect
+            auto it = std::find(in_var->inputs.begin(), in_var->inputs.end(),
+                                upstream_op);
+            if (it != in_var->inputs.end()) {
+              in_var->inputs.erase(it);
+            }
+            // add grand -> dep_var connect
+            auto before_assign_ops = GetUpstreamOps(upstream_op);
+            for (ir::Node* grand : before_assign_ops) {
+              grand->outputs.push_back(in_var);
+              in_var->inputs.push_back(grand);
+            }
+            // assign then can remove all inputs
+            upstream_op->inputs.clear();
+          } else {
+            // connected by in/out, case like:
+            // condition_op -> learning_rate -> assign -> final_learning_rate ->
+            // sgd
+            // can remove assign and final_learning_rate
+            // TODO(typhoonzero): Can remove assign for performance
+            //                    but need to change the operators input var
+            //                    names.
+          }
+        }
+      }
+    }
+  }
+
+  for (ir::Node* n : to_remove) {
+    n->outputs.clear();
+  }
+
+  for (ir::Node* n : to_remove) {
+    for (ir::Node* out : n->outputs) {
+      graph->RemoveNode(out);
+    }
+    graph->RemoveNode(n);
+  }
+
+  return graph;
+}
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
+
+REGISTER_PASS(shrink_assign_depvar_pass,
+              paddle::framework::ir::ShrinkAssignDepvarPass);

--- a/paddle/fluid/framework/ir/shrink_assign_depvar_pass.h
+++ b/paddle/fluid/framework/ir/shrink_assign_depvar_pass.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <fstream>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paddle/fluid/framework/ir/graph.h"
+#include "paddle/fluid/framework/ir/pass.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+class ShrinkAssignDepvarPass : public Pass {
+ protected:
+  std::unique_ptr<ir::Graph> ApplyImpl(
+      std::unique_ptr<ir::Graph> graph) const override;
+};
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -56,6 +56,11 @@ std::unique_ptr<ir::Graph> ApplyParallelExecutorPass(
     graph = viz_pass->Apply(std::move(graph));
   }
 
+  // Apply shrink assign depvar pass
+  auto shrink_assign_depvar_pass =
+      ir::PassRegistry::Instance().Get("shrink_assign_depvar_pass");
+  graph = shrink_assign_depvar_pass->Apply(std::move(graph));
+
   // Convert graph to run on multi-devices.
   auto multi_device_pass =
       ir::PassRegistry::Instance().Get("multi_device_pass");
@@ -357,3 +362,4 @@ USE_PASS(graph_viz_pass);
 USE_PASS(multi_device_pass);
 USE_PASS(multi_device_check_pass);
 USE_PASS(multi_device_print_pass);
+USE_PASS(shrink_assign_depvar_pass);

--- a/python/paddle/fluid/tests/unittests/test_dist_transpiler.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_transpiler.py
@@ -268,10 +268,10 @@ class TestLRDecayConditional(TranspilerTest):
         lr_decay_ops = [op.type for op in pserver.blocks[1].ops]
         self.assertEqual(lr_decay_ops, [
             "increment", "cast", "fill_constant", "fill_constant", "less_than",
-            "logical_not", "conditional_block", "fill_constant",
+            "logical_not", "conditional_block", "assign", "fill_constant",
             "fill_constant", "less_than", "logical_not", "logical_and",
-            "logical_and", "conditional_block", "fill_constant",
-            "conditional_block"
+            "logical_and", "conditional_block", "assign", "fill_constant",
+            "conditional_block", "assign"
         ])
         # test the condition blocks
         for b in sub_blocks:
@@ -342,14 +342,14 @@ class TestL2DecayWithPiecewise(TranspilerTest):
         self.assertEqual(len(pserver.blocks), 9)
         self.assertEqual([op.type for op in pserver.blocks[1].ops], [
             "increment", "cast", "fill_constant", "fill_constant", "less_than",
-            "logical_not", "conditional_block", "fill_constant",
+            "logical_not", "conditional_block", "assign", "fill_constant",
             "fill_constant", "less_than", "logical_not", "logical_and",
-            "logical_and", "conditional_block", "fill_constant",
+            "logical_and", "conditional_block", "assign", "fill_constant",
             "fill_constant", "less_than", "logical_not", "logical_and",
-            "logical_and", "conditional_block", "fill_constant",
+            "logical_and", "conditional_block", "assign", "fill_constant",
             "fill_constant", "less_than", "logical_not", "logical_and",
-            "logical_and", "conditional_block", "fill_constant",
-            "conditional_block"
+            "logical_and", "conditional_block", "assign", "fill_constant",
+            "conditional_block", "assign"
         ])
         self.assertEqual(
             [op.type for op in pserver.blocks[7].ops],


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13348433/43776318-0902fd86-9a82-11e8-8d0e-83d969e050e2.png)

As shown in the graph output by parallel executor if we use `piecewise_decay` there's a chance that some conditions may be run after `sgd_op` since there is no dependence between them. After this change, the graph will be like: 

![image](https://user-images.githubusercontent.com/13348433/43776455-7e02ea1a-9a82-11e8-9939-365bce5bdd50.png)

This will harm the performance, will do the enhance ( remove assign ops when building graph).