### PR TITLE
polish high frequency enforce error message

### DIFF
--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -263,7 +263,7 @@ inline void throw_on_error(T e) {
  *    PADDLE_ENFORCE_EQ(a, b);
  *
  *    will raise an expression described as follows:
- *    "Data check failed. Expected input a == b, but received a(1) != b(2)."
+ *    "Enforce failed. Expected input a == b, but received a(1) != b(2)."
  *      with detailed stack information.
  *
  *    extra messages is also supported, for example:
@@ -293,7 +293,7 @@ inline void throw_on_error(T e) {
 #define __PADDLE_BINARY_COMPARE(__VAL0, __VAL1, __CMP, __INV_CMP, ...)  \
   do {                                                                  \
     if (UNLIKELY(!((__VAL0)__CMP(__VAL1)))) {                           \
-      PADDLE_THROW("Data check failed. Expected %s " #__CMP             \
+      PADDLE_THROW("Enforce failed. Expected %s " #__CMP                \
                    " %s, but received %s:%s " #__INV_CMP " %s:%s.\n%s", \
                    #__VAL0, #__VAL1, #__VAL0,                           \
                    paddle::string::to_string(__VAL0), #__VAL1,          \

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -263,7 +263,8 @@ inline void throw_on_error(T e) {
  *    PADDLE_ENFORCE_EQ(a, b);
  *
  *    will raise an expression described as follows:
- *    "enforce a == b failed, 1 != 2" with detailed stack information.
+ *    "Data check failed. Expected input a == b, but received a(1) != b(2)."
+ *      with detailed stack information.
  *
  *    extra messages is also supported, for example:
  *    PADDLE_ENFORCE(a, b, "some simple enforce failed between %d numbers", 2)
@@ -292,9 +293,10 @@ inline void throw_on_error(T e) {
 #define __PADDLE_BINARY_COMPARE(__VAL0, __VAL1, __CMP, __INV_CMP, ...)  \
   do {                                                                  \
     if (UNLIKELY(!((__VAL0)__CMP(__VAL1)))) {                           \
-      PADDLE_THROW("enforce %s " #__CMP " %s failed, %s " #__INV_CMP    \
-                   " %s\n%s",                                           \
-                   #__VAL0, #__VAL1, paddle::string::to_string(__VAL0), \
+      PADDLE_THROW("Data check failed. Expected %s " #__CMP             \
+                   " %s, but received %s:%s " #__INV_CMP " %s:%s.\n%s", \
+                   #__VAL0, #__VAL1, #__VAL0,                           \
+                   paddle::string::to_string(__VAL0), #__VAL1,          \
                    paddle::string::to_string(__VAL1),                   \
                    paddle::string::Sprintf("" __VA_ARGS__));            \
     }                                                                   \

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -56,7 +56,7 @@ TEST(ENFORCE_EQ, NO_EXTRA_MSG_FAIL) {
     caught_exception = true;
     HasPrefix(
         StringPiece(error.what()),
-        "Data check failed. Expected a == 1 + 3, but received a:2 != 1 + 3:4.");
+        "Enforce failed. Expected a == 1 + 3, but received a:2 != 1 + 3:4.");
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -69,7 +69,7 @@ TEST(ENFORCE_EQ, EXTRA_MSG_FAIL) {
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
     HasPrefix(StringPiece(error.what()),
-              "Data check failed. Expected a == 1 + 3, but received a:2 != 1 + "
+              "Enforce failed. Expected a == 1 + 3, but received a:2 != 1 + "
               "3:4.\ntheir size not match");
   }
   EXPECT_TRUE(caught_exception);
@@ -89,7 +89,7 @@ TEST(ENFORCE_NE, FAIL) {
     caught_exception = true;
     EXPECT_TRUE(HasPrefix(
         StringPiece(error.what()),
-        "Data check failed. Expected 1.0 != 1UL, but received 1.0:1 == 1UL:1."))
+        "Enforce failed. Expected 1.0 != 1UL, but received 1.0:1 == 1UL:1."))
         << error.what() << " does not have expected prefix";
   }
   EXPECT_TRUE(caught_exception);
@@ -104,7 +104,7 @@ TEST(ENFORCE_GT, FAIL) {
     caught_exception = true;
     EXPECT_TRUE(HasPrefix(
         StringPiece(error.what()),
-        "Data check failed. Expected 1 > 2UL, but received 1:1 <= 2UL:2."));
+        "Enforce failed. Expected 1 > 2UL, but received 1:1 <= 2UL:2."));
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -123,7 +123,7 @@ TEST(ENFORCE_GE, FAIL) {
     caught_exception = true;
     EXPECT_TRUE(HasPrefix(
         StringPiece(error.what()),
-        "Data check failed. Expected 1 >= 2UL, but received 1:1 < 2UL:2."));
+        "Enforce failed. Expected 1 >= 2UL, but received 1:1 < 2UL:2."));
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -143,7 +143,7 @@ TEST(ENFORCE_LE, FAIL) {
     caught_exception = true;
     EXPECT_TRUE(HasPrefix(
         StringPiece(error.what()),
-        "Data check failed. Expected 1 > 2UL, but received 1:1 <= 2UL:2."));
+        "Enforce failed. Expected 1 > 2UL, but received 1:1 <= 2UL:2."));
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -160,7 +160,7 @@ TEST(ENFORCE_LT, FAIL) {
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
     EXPECT_TRUE(HasPrefix(StringPiece(error.what()),
-                          "Data check failed. Expected 1UL < 0.12, but "
+                          "Enforce failed. Expected 1UL < 0.12, but "
                           "received 1UL:1 >= 0.12:0.12."));
   }
   EXPECT_TRUE(caught_exception);

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -54,7 +54,9 @@ TEST(ENFORCE_EQ, NO_EXTRA_MSG_FAIL) {
     PADDLE_ENFORCE_EQ(a, 1 + 3);
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
-    HasPrefix(StringPiece(error.what()), "enforce a == 1 + 3 failed, 2 != 4");
+    HasPrefix(
+        StringPiece(error.what()),
+        "Data check failed. Expected a == 1 + 3, but received a:2 != 1 + 3:4.");
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -67,7 +69,8 @@ TEST(ENFORCE_EQ, EXTRA_MSG_FAIL) {
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
     HasPrefix(StringPiece(error.what()),
-              "enforce a == 1 + 3 failed, 2 != 4\ntheir size not match");
+              "Data check failed. Expected a == 1 + 3, but received a:2 != 1 + "
+              "3:4.\ntheir size not match");
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -84,8 +87,9 @@ TEST(ENFORCE_NE, FAIL) {
     PADDLE_ENFORCE_NE(1.0, 1UL);
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
-    EXPECT_TRUE(HasPrefix(StringPiece(error.what()),
-                          "enforce 1.0 != 1UL failed, 1 == 1"))
+    EXPECT_TRUE(HasPrefix(
+        StringPiece(error.what()),
+        "Data check failed. Expected 1.0 != 1UL, but received 1.0:1 == 1UL:1."))
         << error.what() << " does not have expected prefix";
   }
   EXPECT_TRUE(caught_exception);
@@ -98,8 +102,9 @@ TEST(ENFORCE_GT, FAIL) {
     PADDLE_ENFORCE_GT(1, 2UL);
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
-    EXPECT_TRUE(
-        HasPrefix(StringPiece(error.what()), "enforce 1 > 2UL failed, 1 <= 2"));
+    EXPECT_TRUE(HasPrefix(
+        StringPiece(error.what()),
+        "Data check failed. Expected 1 > 2UL, but received 1:1 <= 2UL:2."));
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -116,8 +121,9 @@ TEST(ENFORCE_GE, FAIL) {
     PADDLE_ENFORCE_GE(1, 2UL);
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
-    EXPECT_TRUE(
-        HasPrefix(StringPiece(error.what()), "enforce 1 >= 2UL failed, 1 < 2"));
+    EXPECT_TRUE(HasPrefix(
+        StringPiece(error.what()),
+        "Data check failed. Expected 1 >= 2UL, but received 1:1 < 2UL:2."));
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -135,8 +141,9 @@ TEST(ENFORCE_LE, FAIL) {
     PADDLE_ENFORCE_GT(1, 2UL);
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
-    EXPECT_TRUE(
-        HasPrefix(StringPiece(error.what()), "enforce 1 > 2UL failed, 1 <= 2"));
+    EXPECT_TRUE(HasPrefix(
+        StringPiece(error.what()),
+        "Data check failed. Expected 1 > 2UL, but received 1:1 <= 2UL:2."));
   }
   EXPECT_TRUE(caught_exception);
 }
@@ -153,7 +160,8 @@ TEST(ENFORCE_LT, FAIL) {
   } catch (paddle::platform::EnforceNotMet error) {
     caught_exception = true;
     EXPECT_TRUE(HasPrefix(StringPiece(error.what()),
-                          "enforce 1UL < 0.12 failed, 1 >= 0.12"));
+                          "Data check failed. Expected 1UL < 0.12, but "
+                          "received 1UL:1 >= 0.12:0.12."));
   }
   EXPECT_TRUE(caught_exception);
 }

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -100,25 +100,25 @@ size_t GpuMinChunkSize() {
 
 size_t GpuMaxChunkSize() {
   size_t total = 0;
-  size_t available = 0;
+  size_t available_memory = 0;
 
-  GpuMemoryUsage(&available, &total);
-  VLOG(10) << "GPU Usage " << available / 1024 / 1024 << "M/"
+  GpuMemoryUsage(&available_memory, &total);
+  VLOG(10) << "GPU Usage " << available_memory / 1024 / 1024 << "M/"
            << total / 1024 / 1024 << "M";
   size_t reserving = static_cast<size_t>(0.05 * total);
   // If available less than minimum chunk size, no usable memory exists.
-  available =
-      std::min(std::max(available, GpuMinChunkSize()) - GpuMinChunkSize(),
-               total - reserving);
+  available_memory = std::min(
+      std::max(available_memory, GpuMinChunkSize()) - GpuMinChunkSize(),
+      total - reserving);
 
   // Reserving the rest memory for page tables, etc.
 
-  size_t allocating = static_cast<size_t>(FLAGS_fraction_of_gpu_memory_to_use *
-                                          (total - reserving));
+  size_t allocating_memory = static_cast<size_t>(
+      FLAGS_fraction_of_gpu_memory_to_use * (total - reserving));
 
-  PADDLE_ENFORCE_LE(allocating, available);
+  PADDLE_ENFORCE_LE(allocating_memory, available_memory);
 
-  return allocating;
+  return allocating_memory;
 }
 
 void GpuMemcpyAsync(void *dst, const void *src, size_t count,

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -100,25 +100,26 @@ size_t GpuMinChunkSize() {
 
 size_t GpuMaxChunkSize() {
   size_t total = 0;
-  size_t available_memory = 0;
+  size_t available = 0;
 
-  GpuMemoryUsage(&available_memory, &total);
-  VLOG(10) << "GPU Usage " << available_memory / 1024 / 1024 << "M/"
+  GpuMemoryUsage(&available, &total);
+  VLOG(10) << "GPU Usage " << available / 1024 / 1024 << "M/"
            << total / 1024 / 1024 << "M";
   size_t reserving = static_cast<size_t>(0.05 * total);
   // If available less than minimum chunk size, no usable memory exists.
-  available_memory = std::min(
-      std::max(available_memory, GpuMinChunkSize()) - GpuMinChunkSize(),
-      total - reserving);
+  available =
+      std::min(std::max(available, GpuMinChunkSize()) - GpuMinChunkSize(),
+               total - reserving);
 
   // Reserving the rest memory for page tables, etc.
 
-  size_t allocating_memory = static_cast<size_t>(
-      FLAGS_fraction_of_gpu_memory_to_use * (total - reserving));
+  size_t allocating = static_cast<size_t>(FLAGS_fraction_of_gpu_memory_to_use *
+                                          (total - reserving));
 
-  PADDLE_ENFORCE_LE(allocating_memory, available_memory);
+  PADDLE_ENFORCE_LE(allocating, available,
+                    "Insufficient GPU memory to allocation.");
 
-  return allocating_memory;
+  return allocating;
 }
 
 void GpuMemcpyAsync(void *dst, const void *src, size_t count,


### PR DESCRIPTION
To resolve problems:

1. enforce compare message isn't easy to understand
```
paddle.fluid.core.EnforceNotMet: enforce x_dims[i + axis] == y_dims[i] failed, 1 != 13
```
after changing:
```
EnforceNotMet: Data check failed. Expected x_dims[i + axis] == y_dims[i], but received x_dims[i + axis]:1 != y_dims[i]:13.
```

2. alloc gpu memory error message isn't easy to understand
```
paddle.fluid.core.EnforceNotMet: enforce allocating <= available failed, 1822361026 > 409206528
```
after changing:
```
EnforceNotMet: Data check failed. Expected allocating_memory <= available_memory, but received allocating_memory:20998685852 > available_memory:1645149952.
```
