### PR TITLE
fix mac compile error

### DIFF
--- a/paddle/fluid/operators/parallel_do_op.cc
+++ b/paddle/fluid/operators/parallel_do_op.cc
@@ -163,12 +163,11 @@ class ParallelDoOp : public framework::OperatorBase {
       auto &place = places[place_idx];
       auto *cur_scope = sub_scopes[place_idx];
 
-      workers.emplace_back(
-          framework::Async([program, cur_scope, place, block, place_idx] {
-            framework::Executor executor(place);
-            executor.Run(*program, cur_scope, block->ID(),
-                         false /*create_local_scope*/);
-          }));
+      workers.emplace_back(framework::Async([program, cur_scope, place, block] {
+        framework::Executor executor(place);
+        executor.Run(*program, cur_scope, block->ID(),
+                     false /*create_local_scope*/);
+      }));
     }
     for (auto &worker : workers) {
       worker.wait();
@@ -239,12 +238,11 @@ class ParallelDoGradOp : public framework::OperatorBase {
       auto *cur_scope = sub_scopes[i];
 
       // execute
-      workers.emplace_back(
-          framework::Async([program, cur_scope, place, block, i] {
-            framework::Executor executor(place);
-            executor.Run(*program, cur_scope, block->ID(),
-                         false /*create_local_scope*/);
-          }));
+      workers.emplace_back(framework::Async([program, cur_scope, place, block] {
+        framework::Executor executor(place);
+        executor.Run(*program, cur_scope, block->ID(),
+                     false /*create_local_scope*/);
+      }));
     }
     for (auto &worker : workers) {
       worker.wait();


### PR DESCRIPTION
Fix compile error:
```
/Users/baidu/Documents/git_workspace/Paddle/paddle/fluid/operators/parallel_do_op.cc:167:63: error: lambda capture 'place_idx' is not used [-Werror,-Wunused-lambda-capture]
          framework::Async([program, cur_scope, place, block, place_idx] {
                                                              ^
/Users/baidu/Documents/git_workspace/Paddle/paddle/fluid/operators/parallel_do_op.cc:243:63: error: lambda capture 'i' is not used [-Werror,-Wunused-lambda-capture]
          framework::Async([program, cur_scope, place, block, i] {
                                                              ^
2 errors generated.
make[2]: *** [paddle/fluid/operators/CMakeFiles/parallel_do_op.dir/parallel_do_op.cc.o] Error 1
make[1]: *** [paddle/fluid/operators/CMakeFiles/parallel_do_op.dir/all] Error 2
make: *** [all] Error 2
```