### PR TITLE
modified  rpn_target_assign api

### DIFF
--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -162,7 +162,7 @@ def rpn_target_assign(loc,
         })
 
     # 4. Reshape and gather the target entry
-    scores = nn.reshape(x=scores, shape=(-1, 1))
+    scores = nn.reshape(x=scores, shape=(-1, 2))
     loc = nn.reshape(x=loc, shape=(-1, 4))
     target_label = nn.reshape(x=target_label, shape=(-1, 1))
     target_bbox = nn.reshape(x=target_bbox, shape=(-1, 4))


### PR DESCRIPTION
The dimension of input 'scores' is [N,M,2] which M is the number of anchors. And the dimension of output 'predicted_scores' is [K,2] which K is the total number of labelled anchors and each of them contains 2-D classification scores. So scores should be reshaped to [K,2].