### PR TITLE
add profiler to fluid inference

### DIFF
--- a/paddle/fluid/inference/api/CMakeLists.txt
+++ b/paddle/fluid/inference/api/CMakeLists.txt
@@ -49,6 +49,8 @@ cc_test(test_paddle_inference_api
         SRCS api_tester.cc
         DEPS paddle_inference_api)
 
+cc_binary(text_classification SRCS text_classification_tester.cc DEPS "${inference_deps}")
+
 inference_api_test(test_api_impl SRC api_impl_tester.cc
                     ARGS test_word2vec test_image_classification)
 

--- a/paddle/fluid/inference/api/CMakeLists.txt
+++ b/paddle/fluid/inference/api/CMakeLists.txt
@@ -49,8 +49,6 @@ cc_test(test_paddle_inference_api
         SRCS api_tester.cc
         DEPS paddle_inference_api)
 
-cc_binary(text_classification SRCS text_classification_tester.cc DEPS "${inference_deps}")
-
 inference_api_test(test_api_impl SRC api_impl_tester.cc
                     ARGS test_word2vec test_image_classification)
 

--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -22,6 +22,9 @@ limitations under the License. */
 #include <vector>
 
 #include "paddle/fluid/inference/api/api_impl.h"
+#include "paddle/fluid/platform/profiler.h"
+
+DEFINE_bool(profile, false, "Turn on profiler for fluid");
 
 namespace paddle {
 namespace {
@@ -57,6 +60,15 @@ std::string num2str(T a) {
 bool NativePaddlePredictor::Init(
     std::shared_ptr<framework::Scope> parent_scope) {
   VLOG(3) << "Predictor::init()";
+
+  if (FLAGS_profile) {
+    LOG(WARNING) << "Profiler is actived, might affect the performance";
+    LOG(INFO) << "You can turn off by set gflags '-profile false'";
+
+    auto tracking_device = config_.use_gpu ? platform::ProfilerState::kAll
+                                           : platform::ProfilerState::kCPU;
+    platform::EnableProfiler(tracking_device);
+  }
 
   if (config_.use_gpu) {
     place_ = paddle::platform::CUDAPlace(config_.device);
@@ -102,6 +114,10 @@ bool NativePaddlePredictor::Init(
 }
 
 NativePaddlePredictor::~NativePaddlePredictor() {
+  if (FLAGS_profile) {
+    platform::DisableProfiler(platform::EventSortingKey::kTotal,
+                              "./profile.log");
+  }
   if (sub_scope_) {
     scope_->DeleteScope(sub_scope_);
   }


### PR DESCRIPTION
```
./predictor -profile 1
```

will get the profiler:

```
Sorted by total time in descending order in the same thread
Event                       Calls       Total       Min.        Max.        Ave.        Ratio.      
thread0::lstm               200000      7382.84     0.034626    12.2217     0.0369142   0.511531    
thread0::mul                400000      3603.45     0.00255     22.1276     0.00900862  0.24967     
thread0::elementwise_add    400000      1476.78     0.001714    0.652473    0.00369196  0.102321    
thread0::sequence_pool      200000      585.192     0.001931    24.068      0.00292596  0.0405459   
thread0::lookup_table       100000      315.312     0.002843    0.026402    0.00315312  0.0218468   
thread0::concat             100000      309.127     0.002795    0.028634    0.00309127  0.0214183   
thread0::softmax            100000      255.162     0.002277    0.023012    0.00255162  0.0176792   
thread0::load               13          184.042     0.006254    183.568     14.1571     0.0127516   
thread0::tanh               100000      160.167     0.001384    0.027351    0.00160167  0.0110974   
thread0::feed               100000      98.4852     0.000713    3.06237     0.000984852 0.00682368  
thread0::fetch              100000      62.282      0.000456    0.026465    0.00062282  0.0043153
```