### PR TITLE
fix mac compile

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detecter.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detecter.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <array>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
```
/Users/qiaolongfei/project/paddle/paddle/fluid/framework/ir/graph_pattern_detecter.cc:100:40: error: implicit instantiation of undefined template 'std::__1::array<std::__1::vector<paddle::framework::ir::HitGroup, std::__1::allocator<paddle::framework::ir::HitGroup> >, 2>'
  std::array<std::vector<HitGroup>, 2> bi_records;
                                       ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__tuple:222:64: note: template is declared here
template <class _Tp, size_t _Size> struct _LIBCPP_TEMPLATE_VIS array;
```