### PR TITLE
enhance the forward of concat op

### DIFF
--- a/paddle/fluid/operators/math/concat.cc
+++ b/paddle/fluid/operators/math/concat.cc
@@ -48,16 +48,16 @@ class ConcatFunctor<platform::CPUDeviceContext, T> {
     auto cpu_place = boost::get<platform::CPUPlace>(context.GetPlace());
 
     // computation
-    for (int k = 0; k < out_rows; ++k) {
-      T* dst_ptr = output->data<T>() + k * out_cols;
-      int col_idx = 0;
-      for (int j = 0; j < num; ++j) {
-        int col_len = input_cols[j];
-        const T* src_prt = input[j].data<T>() + k * col_len;
-        memory::Copy(cpu_place, dst_ptr + col_idx, cpu_place, src_prt,
-                     sizeof(T) * col_len);
-        col_idx += col_len;
+    auto output_data = output->data<T>();
+    int col_idx = 0;
+    for (int j = 0; j < num; ++j) {
+      int col_len = input_cols[j];
+      auto input_data = input[j].data<T>();
+      for (int k = 0; k < out_rows; ++k) {
+        memory::Copy(cpu_place, output_data + k * out_cols + col_idx, cpu_place,
+                     input_data + k * col_len, sizeof(T) * col_len);
       }
+      col_idx += col_len;
     }
   }
 };


### PR DESCRIPTION
There are two iterations:
```
for (int k = 0; k < out_rows; ++k)
  for (int j = 0; j < num; ++j)
```
`out_rows > num`. For example, in ditu rnn demo, when batch_size=1, out_rows=35, num=3, and if batch size becomes larger, the out_rows is much larger than num as well.

Thus, simple adjust the order of this iterations
```
for (int j = 0; j < num; ++j)
  for (int k = 0; k < out_rows; ++k)
```
After the adjust, in ditu rnn demo
- when batchsize=100, the elapsed time of this single op decrease from 1.9ms -> 0.6ms.
- But when batchsize=1, the elapsed time of this op remains the same as before.