### PR TITLE
fix flowers dataset, should use module as a reference

### DIFF
--- a/python/paddle/dataset/flowers.py
+++ b/python/paddle/dataset/flowers.py
@@ -50,7 +50,7 @@ __all__ = ['train', 'test', 'valid']
 DATA_URL = 'http://paddlemodels.cdn.bcebos.com/flowers/102flowers.tgz'
 LABEL_URL = 'http://paddlemodels.cdn.bcebos.com/flowers/imagelabels.mat'
 SETID_URL = 'http://paddlemodels.cdn.bcebos.com/flowers/setid.mat'
-DATA_MD5 = '52808999861908f626f3c1f4e79d11fa'
+DATA_MD5 = '33bfc11892f1e405ca193ae9a9f2a118'
 LABEL_MD5 = 'e0620be6f572b9609742df49c70aed4d'
 SETID_MD5 = 'a5357ecc9cb78c4bef273ce3793fc85c'
 # In official 'readme', tstid is the flag of test data


### PR DESCRIPTION
Should use reference class in `paddle.dataset`, will refine later
