### PR TITLE
speedup the download of inference_demo

### DIFF
--- a/paddle/fluid/inference/api/demo_ci/run.sh
+++ b/paddle/fluid/inference/api/demo_ci/run.sh
@@ -14,7 +14,7 @@ else
 fi
 
 PREFIX=inference-vis-demos%2F
-URL_ROOT=http://paddlemodels.bj.bcebos.com/${PREFIX}
+URL_ROOT=http://paddlemodels.cdn.bcebos.com/${PREFIX}
 
 # download vis_demo data
 function download() {


### PR DESCRIPTION
fix the download slow error
```
[10:00:09]++ ./vis_demo --modeldir=../data/se_resnext50/model --data=../data/se_resnext50/data.txt --refer=../data/se_resnext50/result.txt --use_gpu=true
[10:00:13]WARNING: Logging before InitGoogleLogging() is written to STDERR
[10:00:13]W0904 10:00:13.479611 75531 init.cc:121] AVX512F is available, Please re-compile on local machine
[10:00:13]terminate called after throwing an instance of 'paddle::platform::EnforceNotMet'
[10:00:13]  what():  Cannot open file ../data/se_resnext50/model/__model__ at [/paddle/paddle/fluid/inference/io.cc:49]
[10:00:13]PaddlePaddle Call Stacks: 
```
http://ci.paddlepaddle.org/viewLog.html?buildId=13335&buildTypeId=Paddle_PrCi&tab=buildLog&_focus=22652