### PR TITLE
Use memcpy to rewrite the sequence pooling LAST and FIRST mode

### DIFF
--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -109,40 +109,38 @@ class LastFirstSeqPoolFunctor {
   void operator()(const platform::CPUDeviceContext& context,
                   const framework::LoDTensor& input, framework::Tensor* output,
                   const std::string pooltype) {
-  //Create pointers to input and output data 
-  auto* in_data = input.data<T>();
-  auto* out_data = output->data<T>();
+    // Create pointers to input and output data
+    auto* in_data = input.data<T>();
+    auto* out_data = output->data<T>();
 
-  //Calculate the size of each item in sequence
-  int64_t item_size = input.numel() / input.dims()[0];
-  auto lod = input.lod()[0];
-  int seq_num = static_cast<int>(lod.size()) - 1;
-  if (pooltype == "LAST"){
-      for (int i=0;  i < seq_num; ++i ){
-            //Calculate the length of each sequence
-            int64_t seq_len =  static_cast<int64_t>(lod[i + 1] - lod[i]);
-            //Point to the begin of next sequence
-            in_data += seq_len* item_size;
-            //Copy the last item to output
-            std::memcpy(out_data,(in_data-item_size),item_size*sizeof(T));
-            out_data += item_size;
-       }
-  }
-  else if(pooltype == "FIRST"){
-      for (int i=0;  i < seq_num; ++i ){
-            //Calculate the length of each sequence 
-            int64_t seq_len =  static_cast<int64_t>(lod[i + 1] - lod[i]);
-            //Copy the first item of sequence to output
-            std::memcpy(out_data,in_data,item_size*sizeof(T));
-            //Point to the next sequence
-            in_data += seq_len * item_size;
-            out_data += item_size;
-       }
-     }
-   else {
-        PADDLE_THROW("it's not LAST or FIRST pool type");
+    // Calculate the size of each item in sequence
+    int64_t item_size = input.numel() / input.dims()[0];
+    auto lod = input.lod()[0];
+    int seq_num = static_cast<int>(lod.size()) - 1;
+    if (pooltype == "LAST") {
+      for (int i = 0; i < seq_num; ++i) {
+        // Calculate the length of each sequence
+        int64_t seq_len = static_cast<int64_t>(lod[i + 1] - lod[i]);
+        // Point to the begin of next sequence
+        in_data += seq_len * item_size;
+        // Copy the last item of sequence to output
+        std::memcpy(out_data, (in_data - item_size), item_size * sizeof(T));
+        out_data += item_size;
       }
-   }
+    } else if (pooltype == "FIRST") {
+      for (int i = 0; i < seq_num; ++i) {
+        // Calculate the length of each sequence
+        int64_t seq_len = static_cast<int64_t>(lod[i + 1] - lod[i]);
+        // Copy the first item of sequence to output
+        std::memcpy(out_data, in_data, item_size * sizeof(T));
+        // Point to the next sequence
+        in_data += seq_len * item_size;
+        out_data += item_size;
+      }
+    } else {
+      PADDLE_THROW("it's not LAST or FIRST pool type");
+    }
+  }
 };
 
 template <typename T>

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -113,34 +113,35 @@ class LastFirstSeqPoolFunctor {
   auto* in_data = input.data<T>();
   auto* out_data = output->data<T>();
 
-  //Calculate length of each word
-  int64_t word_len = input.numel() / input.dims()[0];
+  //Calculate the size of each item in sequence
+  int64_t item_size = input.numel() / input.dims()[0];
   auto lod = input.lod()[0];
+  int seq_num = static_cast<int>(lod.size()) - 1;
   if (pooltype == "LAST"){
-      for (int i=0;  i < static_cast<int>(lod.size()) - 1; ++i ){
+      for (int i=0;  i < seq_num; ++i ){
             //Calculate the length of each sequence
             int64_t seq_len =  static_cast<int64_t>(lod[i + 1] - lod[i]);
             //Point to the begin of next sequence
-            in_data += seq_len* word_len;
-            //Copy the last words to output
-            std::memcpy(out_data,(in_data-word_len),word_len*sizeof(T));
-            out_data += word_len;
-            
+            in_data += seq_len* item_size;
+            //Copy the last item to output
+            std::memcpy(out_data,(in_data-item_size),item_size*sizeof(T));
+            out_data += item_size;
        }
   }
   else if(pooltype == "FIRST"){
-      for (int i=0;  i < static_cast<int>(lod.size()) - 1; ++i ){
+      for (int i=0;  i < seq_num; ++i ){
             //Calculate the length of each sequence 
             int64_t seq_len =  static_cast<int64_t>(lod[i + 1] - lod[i]);
-            //Copy the first words of sequence to output
-            std::memcpy(out_data,in_data,word_len*sizeof(T));
+            //Copy the first item of sequence to output
+            std::memcpy(out_data,in_data,item_size*sizeof(T));
             //Point to the next sequence
-            in_data += seq_len * word_len;
-            out_data += word_len;
-
+            in_data += seq_len * item_size;
+            out_data += item_size;
        }
-
      }
+   else {
+        PADDLE_THROW("it's not LAST or FIRST pool type");
+      }
    }
 };
 

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -109,24 +109,32 @@ class LastFirstSeqPoolFunctor {
   void operator()(const platform::CPUDeviceContext& context,
                   const framework::LoDTensor& input, framework::Tensor* output,
                   const std::string pooltype) {
+  //Create pointers to input and output data 
   auto* in_data = input.data<T>();
   auto* out_data = output->data<T>();
+
+  //Calculate length of each word
   int64_t word_len = input.numel() / input.dims()[0];
   auto lod = input.lod()[0];
-  auto dims = input.dims();
   if (pooltype == "LAST"){
       for (int i=0;  i < static_cast<int>(lod.size()) - 1; ++i ){
+            //Calculate the length of each sequence
             int64_t seq_len =  static_cast<int64_t>(lod[i + 1] - lod[i]);
+            //Point to the begin of next sequence
             in_data += seq_len* word_len;
-            std::memcpy(out_data,(in_data-word_len),word_len*sizeof(int));
+            //Copy the last words to output
+            std::memcpy(out_data,(in_data-word_len),word_len*sizeof(T));
             out_data += word_len;
             
        }
   }
   else if(pooltype == "FIRST"){
       for (int i=0;  i < static_cast<int>(lod.size()) - 1; ++i ){
+            //Calculate the length of each sequence 
             int64_t seq_len =  static_cast<int64_t>(lod[i + 1] - lod[i]);
-            std::memcpy(out_data,in_data,word_len*sizeof(int));
+            //Copy the first words of sequence to output
+            std::memcpy(out_data,in_data,word_len*sizeof(T));
+            //Point to the next sequence
             in_data += seq_len * word_len;
             out_data += word_len;
 

--- a/paddle/fluid/operators/math/sequence_pooling.cc
+++ b/paddle/fluid/operators/math/sequence_pooling.cc
@@ -107,7 +107,8 @@ template <typename T>
 class LastSeqPoolFunctor {
  public:
   void operator()(const platform::CPUDeviceContext& context,
-                  const framework::LoDTensor& input, framework::Tensor* output) {
+                  const framework::LoDTensor& input,
+                  framework::Tensor* output) {
     // Create pointers to input and output data
     auto* in_data = input.data<T>();
     auto* out_data = output->data<T>();
@@ -124,7 +125,7 @@ class LastSeqPoolFunctor {
       // Copy the last item of sequence to output
       std::memcpy(out_data, (in_data - item_size), item_size * sizeof(T));
       out_data += item_size;
-     }
+    }
   }
 };
 
@@ -132,7 +133,8 @@ template <typename T>
 class FirstSeqPoolFunctor {
  public:
   void operator()(const platform::CPUDeviceContext& context,
-                  const framework::LoDTensor& input, framework::Tensor* output) {
+                  const framework::LoDTensor& input,
+                  framework::Tensor* output) {
     // Create pointers to input and output data
     auto* in_data = input.data<T>();
     auto* out_data = output->data<T>();
@@ -149,7 +151,7 @@ class FirstSeqPoolFunctor {
       // Point to the next sequence
       in_data += seq_len * item_size;
       out_data += item_size;
-      }
+    }
   }
 };
 
@@ -176,8 +178,6 @@ class SequencePoolFunctor<platform::CPUDeviceContext, T> {
       first_pool(context, input, output);
       return;
     }
-
-
     auto lod = input.lod()[0];
     auto& place = *context.eigen_device();
     for (int i = 0; i < static_cast<int>(lod.size()) - 1; ++i) {


### PR DESCRIPTION
Before EIGEN is used for all sequence pooling implementation (MAX/AVE/FIRST/LAST/...). We use memcpy  directly for FIRST/LAST which is a little bit more efficient.
I ran a benchmark of text classification to show the performance difference with or without modifications.
- command line: `./paddle/fluid/inference/analysis/test_text_classification --infer_model=third_party/inference_demo/text_classification/text-classification-Senta/ --infer_data=third_party/inference_demo/text_classification/data.txt --profiler=1 --repeat=2`
- Platform: Intel(R) Xeon(R) CPU E5-2699 v3 @ 2.30GHz
<img src="https://user-images.githubusercontent.com/33643817/45345719-b8eef980-b5d9-11e8-9894-28e385b49b14.png" width="600px"  />

For sequence pooling op , we got about 13% performance gain.