### PR TITLE
fix api fetch

### DIFF
--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -275,7 +275,7 @@ bool NativePaddlePredictor::GetFetch(
     if (buffer.empty() || buffer.length() < sizeof(float) * data.size()) {
       buffer.Resize(sizeof(float) * data.size());
     }
-    std::memcpy(buffer.data(), data.data(), buffer.length());
+    std::memcpy(buffer.data(), data.data(), sizeof(float) * data.size());
     // copy LoD
     for (const auto &level : fetchs[i].lod()) {
       outputs->at(i).lod.emplace_back(level);


### PR DESCRIPTION
本来是要cherry pick 08cfe27c638a4d4e119273bbc95ed48f971d84d3 的，但是发现develop上的code已经超出太多，`float`已经被换为`T`了，没法pick了，所以直接改了。