### PR TITLE
fix text_classification download error

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -53,5 +53,5 @@ set(TEXT_CLASSIFICATION_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/text_classifi
 download_model_and_data(${TEXT_CLASSIFICATION_INSTALL_DIR} "text-classification-Senta.tar.gz" "text_classification_data.txt.tar.gz")
 inference_analysis_test(test_analyzer_text_classification SRCS analyzer_text_classification_tester.cc
     EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
-    ARGS --infer_model=${TEXT_CLASSIFICATION_INSTALL_DIR}/text-classification-Senta
+    ARGS --infer_model=${TEXT_CLASSIFICATION_INSTALL_DIR}/model
          --infer_data=${TEXT_CLASSIFICATION_INSTALL_DIR}/data.txt)


### PR DESCRIPTION
fix ci error:
http://ci.paddlepaddle.org/viewLog.html?buildId=17953&buildTypeId=Paddle_PrCi&tab=buildLog&_focus=25211
```
[07:27:58][Step 1/1] The following tests FAILED:
[07:27:58][Step 1/1] 	126 - test_analyzer_text_classification (Failed)
```