### PR TITLE
"fix tensorrt dso"

### DIFF
--- a/cmake/tensorrt.cmake
+++ b/cmake/tensorrt.cmake
@@ -16,7 +16,9 @@ find_library(TENSORRT_LIBRARY NAMES libnvinfer.so libnvinfer.a
     DOC "Path to TensorRT library.")
 
 if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY)
+  if(WITH_DSO)
     set(TENSORRT_FOUND ON)
+  endif(WITH DSO)
 else()
     set(TENSORRT_FOUND OFF)
 endif()


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/13406
tensorrt is not built-in support by the nvidia-docker, need to download by manual. which means without dso, it should not be inclueded.