### PR TITLE
add readme of /doc

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2,6 +2,7 @@
 
 Thanks for reading PaddlePaddle documentation. 
 
-Since **September 17th, 2018**, the **0.15.0 and develop** documentation source has been moved to [Fluiddoc Repo](https://github.com/PaddlePaddle/Paddle).
+Since **September 17th, 2018**, the **0.15.0 and develop** documentation source has been moved to [Fluiddoc Repo](https://github.com/PaddlePaddle/Paddle) and updated in Fluiddoc.
+
 
 Please turn to Fluiddoc Repo for the latest documentation.

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,6 @@
 
 Thanks for reading PaddlePaddle documentation. 
 
-Since **September 17th, 2018**, the **0.15.0 and develop** documentation source has been moved to [Fluiddoc Repo](https://github.com/PaddlePaddle/Paddle) and updated in Fluiddoc.
-
+Since **September 17th, 2018**, the **0.15.0 and develop** documentation source has been moved to [Fluiddoc Repo](https://github.com/PaddlePaddle/Paddle) and updated in Fluiddoc Repo.
 
 Please turn to Fluiddoc Repo for the latest documentation.

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,7 @@
+# For Readers and Developers
+
+Thanks for reading PaddlePaddle documentation. 
+
+Since **September 17th, 2018**, the **0.15.0 and develop** documentation source has been moved to [Fluiddoc Repo](https://github.com/PaddlePaddle/Paddle).
+
+Please turn to Fluiddoc Repo for the latest documentation.


### PR DESCRIPTION
in order to announce readers and developers that the documentation source of PaddlePaddle.org has been moved to Fluiddoc repo