### PR TITLE
fix py2 matplotlib deps

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ requests==2.9.2
 numpy>=1.12,<=1.14 #TODO:change to ">=1.12" when numpy fix bug in 1.15 and higher version
 protobuf==3.1
 recordio>=0.1.0
-matplotlib
+matplotlib==2.2.3 # TODO: let python3 paddlepaddle package use latest matplotlib
 rarfile
 scipy>=0.19.0
 Pillow


### PR DESCRIPTION
seems latest matplotlib support py3 only:

```
Collecting matplotlib (from paddlepaddle-gpu==0.15.0.post97)
  Using cached https://pypi.tuna.tsinghua.edu.cn/packages/ec/06/def4fb2620cbe671ba0cb6462cbd8653fbffa4acd87d6d572659e7c71c13/matplotlib-3.0.0.tar.gz
    Complete output from command python setup.py egg_info:

    Matplotlib 3.0+ does not support Python 2.x, 3.0, 3.1, 3.2, 3.3, or 3.4.
    Beginning with Matplotlib 3.0, Python 3.5 and above is required.

    This may be due to an out of date pip.

    Make sure you have pip >= 9.0.1.
```