### PR TITLE
Support variable data shape of non-sequence data in data_feeder.

### DIFF
--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -71,7 +71,7 @@ class DataToLoDTensorConverter(object):
 
     def done(self):
         arr = numpy.array(self.data, dtype=self.dtype)
-        if self.shape:
+        if self.shape and len(arr.shape) != len(self.shape):
             arr = arr.reshape(self.shape)
         t = core.LoDTensor()
         t.set(arr, self.place)


### PR DESCRIPTION
`data_feeder` is used in PyReader. `data_feeder` is not support variable-length input data, it will fail in in following line:

```python
if self.shape:  #  self.shape is from fluid.layers.data
    arr = arr.reshape(self.shape)   # arr.shape is data shape each batch
``` 