### PR TITLE
Avoid multiple definitions of lstm_compute_ctht when linking libpaddle_fluid.so

### DIFF
--- a/paddle/fluid/operators/math/cpu_lstm_compute.cc
+++ b/paddle/fluid/operators/math/cpu_lstm_compute.cc
@@ -13,6 +13,31 @@ limitations under the License. */
 
 namespace paddle {
 namespace operators {
-namespace math {}  // namespace math
+namespace math {
+#ifdef __AVX__
+template <>
+void lstm_compute_ctht<float>(float* gates, const float* ct_1, float* ct,
+                              float* ht) {
+  namespace act = detail::forward::avx;
+  // gates: W_ch, W_ih, W_fh, W_oh
+  __m256 c, i, f, o;
+  c = _mm256_loadu_ps(gates);
+  i = _mm256_loadu_ps(gates + 8);
+  f = _mm256_loadu_ps(gates + 16);
+  o = _mm256_loadu_ps(gates + 24);
+
+  /* C_t = C_t-1 * fgated + cand_gated * igated*/
+  c = _mm256_mul_ps(act::Tanh(c), act::Sigmoid(i));
+  i = _mm256_loadu_ps(ct_1);
+  f = _mm256_mul_ps(i, act::Sigmoid(f));
+  f = _mm256_add_ps(c, f);
+  _mm256_storeu_ps(ct, f);
+
+  /* H_t = act_cell(C_t) * ogated */
+  o = _mm256_mul_ps(act::Tanh(f), act::Sigmoid(o));
+  _mm256_storeu_ps(ht, o);
+}
+#endif
+}  // namespace math
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/math/cpu_lstm_compute.h
+++ b/paddle/fluid/operators/math/cpu_lstm_compute.h
@@ -48,32 +48,15 @@ namespace forward {
 namespace avx {
 __m256 Sigmoid(const __m256 a);
 __m256 Tanh(const __m256 a);
+
 }  // namespace avx
 }  // namespace forward
 }  // namespace detail
 
 template <>
 void lstm_compute_ctht<float>(float* gates, const float* ct_1, float* ct,
-                              float* ht) {
-  namespace act = detail::forward::avx;
-  // gates: W_ch, W_ih, W_fh, W_oh
-  __m256 c, i, f, o;
-  c = _mm256_loadu_ps(gates);
-  i = _mm256_loadu_ps(gates + 8);
-  f = _mm256_loadu_ps(gates + 16);
-  o = _mm256_loadu_ps(gates + 24);
+                              float* ht);
 
-  /* C_t = C_t-1 * fgated + cand_gated * igated*/
-  c = _mm256_mul_ps(act::Tanh(c), act::Sigmoid(i));
-  i = _mm256_loadu_ps(ct_1);
-  f = _mm256_mul_ps(i, act::Sigmoid(f));
-  f = _mm256_add_ps(c, f);
-  _mm256_storeu_ps(ct, f);
-
-  /* H_t = act_cell(C_t) * ogated */
-  o = _mm256_mul_ps(act::Tanh(f), act::Sigmoid(o));
-  _mm256_storeu_ps(ht, o);
-}
 #endif
 
 }  // namespace math


### PR DESCRIPTION
paddle/fluid/operators/math/cpu_lstm_compute.h contains an instatiation of lstm_compute_ctht:
`
template<>
void lstm_compute_ctht<float>(float* gates, const float* ct_1, float* ct, float* ht)
{}
`
When this header file are included in more than one C++ source, compiler will detect that there are multiple definitions.

This commit moves the instatiated lstm_compute_ctht to cpu_lstm_compute.cc, to avoid the multiple definition error.