### PR TITLE
Reproduce BeamSearch Bug

### DIFF
--- a/paddle/fluid/memory/malloc.cc
+++ b/paddle/fluid/memory/malloc.cc
@@ -14,9 +14,9 @@ limitations under the License. */
 
 #include <vector>
 
-#include "paddle/fluid/memory/malloc.h"
-
+#include <stdlib.h>
 #include "glog/logging.h"
+#include "paddle/fluid/memory/malloc.h"
 
 #include "paddle/fluid/memory/detail/buddy_allocator.h"
 #include "paddle/fluid/memory/detail/system_allocator.h"
@@ -71,19 +71,18 @@ struct NaiveAllocator {
 
 template <>
 void* Alloc<platform::CPUPlace>(platform::CPUPlace place, size_t size) {
-  VLOG(10) << "Allocate " << size << " bytes on " << platform::Place(place);
-  void* p = GetCPUBuddyAllocator()->Alloc(size);
-  if (FLAGS_init_allocated_mem) {
-    memset(p, 0xEF, size);
-  }
-  VLOG(10) << "  pointer=" << p;
-  return p;
+  //  VLOG(10) << "Allocate " << size << " bytes on " << platform::Place(place);
+  //  void* p = GetCPUBuddyAllocator()->Alloc(size);
+  //  if (FLAGS_init_allocated_mem) {
+  //    memset(p, 0xEF, size);
+  //  }
+  //  VLOG(10) << "  pointer=" << p;
+  return malloc(size);
 }
 
 template <>
 void Free<platform::CPUPlace>(platform::CPUPlace place, void* p) {
-  VLOG(10) << "Free pointer=" << p << " on " << platform::Place(place);
-  GetCPUBuddyAllocator()->Free(p);
+  free(p);
 }
 
 template <>


### PR DESCRIPTION
 beam_search_op_test中似乎有一个内存的写越界。将allocator退化成简单的malloc和free就能复现。

<img width="1037" alt="default" src="https://user-images.githubusercontent.com/728699/46254023-7ecb9600-c4bb-11e8-8c53-058b6341b829.png">

因为某些写越界导致程序退出析构的时候出错。

调用栈(-O3)
<img width="1230" alt="default" src="https://user-images.githubusercontent.com/728699/46254042-c18d6e00-c4bb-11e8-9069-2bfa34001126.png">

调用栈(-O0 -g)
<img width="1254" alt="default" src="https://user-images.githubusercontent.com/728699/46254060-ee418580-c4bb-11e8-9395-65eb36e4df52.png">

