### PR TITLE
fix compile error on latest Mac OS 10.14

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -157,7 +157,7 @@ if (APPLE)
         # On Mac OS X build fat binaries with x86_64 architectures by default.
         set (CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Build architectures for OSX" FORCE)
     endif()
-    # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang
+    # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang 10.0.0
     set (COMMON_FLAGS -Wno-deprecated-register)
 endif(APPLE)
 

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -157,7 +157,7 @@ if (APPLE)
         # On Mac OS X build fat binaries with x86_64 architectures by default.
         set (CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Build architectures for OSX" FORCE)
     endif()
-    # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang 10.0.0
+    # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang 10.0
     set (COMMON_FLAGS -Wno-deprecated-register)
 endif(APPLE)
 

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -157,6 +157,8 @@ if (APPLE)
         # On Mac OS X build fat binaries with x86_64 architectures by default.
         set (CMAKE_OSX_ARCHITECTURES "x86_64" CACHE STRING "Build architectures for OSX" FORCE)
     endif()
+    # On Mac OS X register class specifier is deprecated and will cause warning error on latest clang
+    set (COMMON_FLAGS -Wno-deprecated-register)
 endif(APPLE)
 
 if(LINUX)


### PR DESCRIPTION
On Mac OS X register class specifier is deprecated and will cause warning error on latest clang