### PR TITLE
[Fix bug]Pow returns NaN results for negative input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,12 @@ option(WITH_INFERENCE    "Compile fluid inference library"              ON)
 option(WITH_INFERENCE_API_TEST   "Test fluid inference high-level api interface"  OFF)
 option(WITH_SYSTEM_BLAS   "Use system blas library"           OFF)
 option(PY_VERSION       "Compile PaddlePaddle with python3 support"     ${PY_VERSION})
-option(WITH_FAST_MATH   "Make use of fast math library, might affect the precision to some extent"                 OFF)
+
+# FIXME(chengduo): XX_FAST_MATH may induce the result of some functor is wrong, for example 'powf'.
+# For more information, please refer to: https://github.com/torch/DEPRECEATED-torch7-distro/issues/132
+option(WITH_FAST_MATH   "Make use of fast math library of CUDA which might affect the precision to some extent"                      OFF)
+option(WITH_EIGEN_FAST_MATH   "Make use of fast math library of Eigen which might affect the precision to some extent"   ON)
+
 
 # PY_VERSION
 if(NOT PY_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ option(WITH_INFERENCE    "Compile fluid inference library"              ON)
 option(WITH_INFERENCE_API_TEST   "Test fluid inference high-level api interface"  OFF)
 option(WITH_SYSTEM_BLAS   "Use system blas library"           OFF)
 option(PY_VERSION       "Compile PaddlePaddle with python3 support"     ${PY_VERSION})
-option(WITH_FAST_MATH   "Make use of fast math library, might affect the precision to some extent" ON)
+option(WITH_FAST_MATH   "Make use of fast math library, might affect the precision to some extent"                 OFF)
 
 # PY_VERSION
 if(NOT PY_VERSION)

--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -175,10 +175,14 @@ list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
 list(APPEND CUDA_NVCC_FLAGS "-Xcompiler -fPIC")
 endif(NOT WIN32)
 
+
 if(WITH_FAST_MATH)
   # Make use of fast math library. https://docs.nvidia.com/cuda/cuda-compiler-driver-nvcc/index.html
+  # FIXME(chengduo): 'use_fast_math' may induce the result of some function is wrong, for example 'powf'.
+  # For more information, please refer to: https://github.com/torch/DEPRECEATED-torch7-distro/issues/132
   list(APPEND CUDA_NVCC_FLAGS "--use_fast_math")
-endif()
+endif() 
+
 # in cuda9, suppress cuda warning on eigen 
 list(APPEND CUDA_NVCC_FLAGS "-w")
 # Set :expt-relaxed-constexpr to suppress Eigen warnings

--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -3,7 +3,7 @@ INCLUDE(ExternalProject)
 SET(EIGEN_SOURCE_DIR ${THIRD_PARTY_PATH}/eigen3)
 SET(EIGEN_INCLUDE_DIR ${EIGEN_SOURCE_DIR}/src/extern_eigen3)
 INCLUDE_DIRECTORIES(${EIGEN_INCLUDE_DIR})
-if(NOT WITH_FAST_MATH)
+if(NOT WITH_EIGEN_FAST_MATH)
   # EIGEN_FAST_MATH: https://eigen.tuxfamily.org/dox/TopicPreprocessorDirectives.html
   # enables some optimizations which might affect the accuracy of the result. 
   # This currently enables the SSE vectorization of sin() and cos(), 

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -373,21 +373,6 @@ $out = \min(\max(0, x), 6)$
   }
 };
 
-class PowOpMaker : public framework::OpProtoAndCheckerMaker {
- public:
-  void Make() override {
-    AddInput("X", "Input of Pow operator");
-    AddOutput("Out", "Output of Pow operator");
-    AddAttr<float>("factor", "The exponential factor of Pow").SetDefault(1.0f);
-    AddComment(R"DOC(
-Pow Activation Operator.
-
-$out = x^{factor}$
-
-)DOC");
-  }
-};
-
 class STanhOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
@@ -525,7 +510,6 @@ namespace ops = paddle::operators;
   __macro(Log, log);                 \
   __macro(Square, square);           \
   __macro(BRelu, brelu);             \
-  __macro(Pow, pow);                 \
   __macro(STanh, stanh);             \
   __macro(Softplus, softplus);       \
   __macro(Softsign, softsign);       \

--- a/paddle/fluid/operators/activation_op.h
+++ b/paddle/fluid/operators/activation_op.h
@@ -717,33 +717,6 @@ struct ELUGradFunctor : public BaseActivationFunctor<T> {
   }
 };
 
-// FIXME(qijun) https://github.com/PaddlePaddle/Paddle/issues/5198
-template <typename T>
-struct PowFunctor : public BaseActivationFunctor<T> {
-  float factor;
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
-    return {{"factor", &factor}};
-  }
-  template <typename Device, typename X, typename Out>
-  void operator()(Device d, X x, Out out) const {
-    out.device(d) = x.pow(static_cast<T>(factor));
-  }
-};
-
-template <typename T>
-struct PowGradFunctor : public BaseActivationFunctor<T> {
-  float factor;
-  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
-    return {{"factor", &factor}};
-  }
-  template <typename Device, typename X, typename Out, typename dOut,
-            typename dX>
-  void operator()(Device d, X x, Out out, dOut dout, dX dx) const {
-    dx.device(d) = dout * static_cast<T>(factor) *
-                   x.pow(static_cast<T>(factor - static_cast<T>(1)));
-  }
-};
-
 template <typename T>
 struct STanhFunctor : public BaseActivationFunctor<T> {
   float scale_a;
@@ -892,7 +865,6 @@ struct SwishGradFunctor : public BaseActivationFunctor<T> {
   __macro(square, SquareFunctor, SquareGradFunctor);                 \
   __macro(brelu, BReluFunctor, BReluGradFunctor);                    \
   __macro(soft_relu, SoftReluFunctor, SoftReluGradFunctor);          \
-  __macro(pow, PowFunctor, PowGradFunctor);                          \
   __macro(stanh, STanhFunctor, STanhGradFunctor);                    \
   __macro(softplus, SoftplusFunctor, SoftplusGradFunctor);           \
   __macro(softsign, SoftsignFunctor, SoftsignGradFunctor);           \

--- a/paddle/fluid/operators/pow_op.cc
+++ b/paddle/fluid/operators/pow_op.cc
@@ -1,0 +1,150 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/pow_op.h"
+#include <string>
+#include "paddle/fluid/operators/detail/safe_ref.h"
+
+namespace paddle {
+namespace operators {
+
+class PowOp : public framework::OperatorWithKernel {
+ public:
+  PowOp(const std::string &type, const framework::VariableNameMap &inputs,
+        const framework::VariableNameMap &outputs,
+        const framework::AttributeMap &attrs)
+      : OperatorWithKernel(type, inputs, outputs, attrs) {}
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    PADDLE_ENFORCE(ctx->HasInput("X"), "Input(X) of PowOp should not be null.");
+    PADDLE_ENFORCE(ctx->HasOutput("Out"),
+                   "Output(Out) of PowOp should not be null.");
+    ctx->ShareDim("X", /*->*/ "Out");
+    ctx->ShareLoD("X", /*->*/ "Out");
+  }
+};
+
+class PowOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor) Input tensor of Pow operator.");
+    AddOutput("Out", "(Tensor) Output tensor of Pow operator.");
+    AddAttr<float>("factor", "The exponential factor of Pow").SetDefault(1.0f);
+    AddComment(R"DOC(
+**Pow operator**
+
+$out = x^{factor}$
+
+)DOC");
+  }
+};
+
+class PowOpVarTypeInference : public framework::VarTypeInference {
+ public:
+  void operator()(const framework::OpDesc &op_desc,
+                  framework::BlockDesc *block) const override {
+    auto &in_var_name = op_desc.Input("X").front();
+    auto out_var_name = op_desc.Output("Out").front();
+
+    auto &in_var = detail::Ref(block->FindVarRecursive(in_var_name));
+    auto *out_var = block->FindVarRecursive(out_var_name);
+
+    if (in_var_name != out_var_name) {
+      out_var->SetType(in_var.GetType());
+      out_var->SetDataType(in_var.GetDataType());
+    }
+  }
+};
+
+class PowOpGrad : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    ctx->ShareDim("X", framework::GradVarName("X"));
+    ctx->ShareLoD("X", framework::GradVarName("X"));
+  }
+};
+
+class PowGradMaker : public framework::SingleGradOpDescMaker {
+ public:
+  using framework::SingleGradOpDescMaker::SingleGradOpDescMaker;
+
+  std::unique_ptr<framework::OpDesc> Apply() const override {
+    auto *grad_op = new framework::OpDesc();
+    grad_op->SetType("pow_grad");
+    grad_op->SetInput("X", Input("X"));
+    grad_op->SetInput(framework::GradVarName("Out"), OutputGrad("Out"));
+    grad_op->SetAttrMap(Attrs());
+    grad_op->SetOutput(framework::GradVarName("X"), InputGrad("X"));
+
+    return std::unique_ptr<framework::OpDesc>(grad_op);
+  }
+};
+
+template <typename T>
+struct PowFunctor<platform::CPUDeviceContext, T> {
+  void operator()(const platform::CPUDeviceContext &context,
+                  const framework::Tensor &x, float factor,
+                  framework::Tensor *out) const {
+    const T *src_ptr = x.data<T>();
+    T *dst_ptr = out->data<T>();
+    int64_t numel = x.numel();
+    PADDLE_ENFORCE_EQ(numel, out->numel());
+
+    for (int64_t i = 0; i < numel; ++i) {
+      dst_ptr[i] = std::pow(src_ptr[i], factor);
+    }
+  }
+};
+
+template <typename T>
+struct PowGradFunctor<platform::CPUDeviceContext, T> {
+  void operator()(const platform::CPUDeviceContext &context,
+                  const framework::Tensor &x, const framework::Tensor &d_out,
+                  float factor, framework::Tensor *d_x) const {
+    const T *x_ptr = x.data<T>();
+    const T *d_out_ptr = d_out.data<T>();
+    T *d_x_ptr = d_x->data<T>();
+    int64_t numel = x.numel();
+    PADDLE_ENFORCE_EQ(numel, d_out.numel());
+    PADDLE_ENFORCE_EQ(numel, d_x->numel());
+
+    for (int64_t i = 0; i < numel; ++i) {
+      d_x_ptr[i] = d_out_ptr[i] * factor * std::pow(x_ptr[i], factor - 1);
+    }
+  }
+};
+
+template struct PowFunctor<platform::CPUDeviceContext, float>;
+template struct PowFunctor<platform::CPUDeviceContext, double>;
+
+template struct PowGradFunctor<platform::CPUDeviceContext, float>;
+template struct PowGradFunctor<platform::CPUDeviceContext, double>;
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OPERATOR(pow, ops::PowOp, ops::PowOpMaker, ops::PowGradMaker,
+                  ops::PowOpVarTypeInference);
+REGISTER_OPERATOR(pow_grad, ops::PowOpGrad);
+
+REGISTER_OP_CPU_KERNEL(pow, ops::PowKernel<plat::CPUDeviceContext, float>,
+                       ops::PowKernel<plat::CPUDeviceContext, double>);
+REGISTER_OP_CPU_KERNEL(pow_grad,
+                       ops::PowGradKernel<plat::CPUDeviceContext, float>,
+                       ops::PowGradKernel<plat::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/pow_op.cu
+++ b/paddle/fluid/operators/pow_op.cu
@@ -28,7 +28,7 @@ static __device__ __forceinline__ float real_pow(float x, float factor) {
   return powf(x, factor);
 }
 static __device__ __forceinline__ double real_pow(double x, float factor) {
-  return powf(x, factor);
+  return pow(x, factor);
 }
 
 template <typename T>

--- a/paddle/fluid/operators/pow_op.cu
+++ b/paddle/fluid/operators/pow_op.cu
@@ -1,0 +1,114 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <algorithm>
+#include "paddle/fluid/operators/pow_op.h"
+#include "paddle/fluid/platform/float16.h"
+#include "paddle/fluid/platform/for_range.h"
+
+namespace paddle {
+namespace operators {
+
+static __device__ __forceinline__ platform::float16 real_pow(
+    platform::float16 x, float factor) {
+  return platform::float16(::powf(static_cast<float>(x), factor));
+}
+static __device__ __forceinline__ float real_pow(float x, float factor) {
+  return powf(x, factor);
+}
+static __device__ __forceinline__ double real_pow(double x, float factor) {
+  return powf(x, factor);
+}
+
+template <typename T>
+__global__ void PowCudaKernel(const T* x, float factor, int64_t numel, T* out) {
+  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < numel;
+       index += blockDim.x * gridDim.x) {
+    out[index] = real_pow(x[index], factor);
+  }
+}
+
+template <typename T>
+__global__ void PowGradCudaKernel(const T* x, const T* d_out, float factor,
+                                  int64_t numel, T* d_x) {
+  for (int index = blockIdx.x * blockDim.x + threadIdx.x; index < numel;
+       index += blockDim.x * gridDim.x) {
+    d_x[index] = d_out[index] * factor * real_pow(x[index], factor - 1);
+  }
+}
+
+template <typename T>
+struct PowFunctor<platform::CUDADeviceContext, T> {
+  void operator()(const platform::CUDADeviceContext& context,
+                  const framework::Tensor& x, float factor,
+                  framework::Tensor* out) const {
+    const T* src_ptr = x.data<T>();
+    T* dst_ptr = out->data<T>();
+    int64_t numel = x.numel();
+    PADDLE_ENFORCE_EQ(numel, out->numel());
+
+    const int kThreadsPerBlock = 1024;
+    int max_threads = context.GetMaxPhysicalThreadCount();
+    int max_blocks = std::max(max_threads / kThreadsPerBlock, 1);
+    int grid = std::min(static_cast<int>(numel), max_blocks);
+    int threads = kThreadsPerBlock;
+
+    PowCudaKernel<<<grid, threads, 0, context.stream()>>>(src_ptr, factor,
+                                                          numel, dst_ptr);
+  }
+};
+
+template <typename T>
+struct PowGradFunctor<platform::CUDADeviceContext, T> {
+  void operator()(const platform::CUDADeviceContext& context,
+                  const framework::Tensor& x, const framework::Tensor& d_out,
+                  float factor, framework::Tensor* d_x) const {
+    const T* x_ptr = x.data<T>();
+    const T* d_out_ptr = d_out.data<T>();
+    T* d_x_ptr = d_x->data<T>();
+    int64_t numel = x.numel();
+    PADDLE_ENFORCE_EQ(numel, d_out.numel());
+    PADDLE_ENFORCE_EQ(numel, d_x->numel());
+
+    const int kThreadsPerBlock = 1024;
+    int max_threads = context.GetMaxPhysicalThreadCount();
+    int max_blocks = std::max(max_threads / kThreadsPerBlock, 1);
+    int grid = std::min(static_cast<int>(numel), max_blocks);
+    int threads = kThreadsPerBlock;
+
+    PowGradCudaKernel<<<grid, threads, 0, context.stream()>>>(
+        x_ptr, d_out_ptr, factor, numel, d_x_ptr);
+  }
+};
+
+template struct PowFunctor<platform::CUDADeviceContext, platform::float16>;
+template struct PowFunctor<platform::CUDADeviceContext, float>;
+template struct PowFunctor<platform::CUDADeviceContext, double>;
+
+template struct PowGradFunctor<platform::CUDADeviceContext, float>;
+template struct PowGradFunctor<platform::CUDADeviceContext, double>;
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_CUDA_KERNEL(pow, ops::PowKernel<plat::CUDADeviceContext, float>,
+                        ops::PowKernel<plat::CUDADeviceContext, double>,
+                        ops::PowKernel<plat::CUDADeviceContext, plat::float16>);
+
+REGISTER_OP_CUDA_KERNEL(pow_grad,
+                        ops::PowGradKernel<plat::CUDADeviceContext, float>,
+                        ops::PowGradKernel<plat::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/pow_op.h
+++ b/paddle/fluid/operators/pow_op.h
@@ -1,0 +1,81 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/detail/safe_ref.h"
+#include "paddle/fluid/platform/for_range.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+struct PowFunctor {
+  void operator()(const DeviceContext &context, const framework::Tensor &x,
+                  float factor, framework::Tensor *out) const;
+};
+
+template <typename DeviceContext, typename T>
+struct PowGradFunctor {
+  void operator()(const DeviceContext &context, const framework::Tensor &x,
+                  const framework::Tensor &d_out, float factor,
+                  framework::Tensor *d_x) const;
+};
+
+template <typename DeviceContext, typename T>
+class PowKernel : public framework::OpKernel<T> {
+ public:
+  virtual void Compute(const framework::ExecutionContext &context) const {
+    auto &x = detail::Ref(context.Input<framework::Tensor>("X"),
+                          "Cannot get input tensor X, variable name = %s",
+                          context.op().Input("X"));
+    auto &out = detail::Ref(context.Output<framework::Tensor>("Out"),
+                            "Cannot get output tensor Out, variable name = %s",
+                            context.op().Output("Out"));
+
+    float factor = context.Attr<float>("factor");
+    out.mutable_data<T>(context.GetPlace());
+
+    auto &dev_ctx = context.template device_context<DeviceContext>();
+
+    PowFunctor<DeviceContext, T> pow_functor;
+    pow_functor(dev_ctx, x, factor, &out);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class PowGradKernel : public framework::OpKernel<T> {
+ public:
+  virtual void Compute(const framework::ExecutionContext &context) const {
+    auto &x = detail::Ref(context.Input<framework::Tensor>("X"),
+                          "Cannot get input tensor X, variable name = %s",
+                          context.op().Input("X"));
+    auto &d_out = detail::Ref(
+        context.Input<framework::Tensor>(framework::GradVarName("Out")),
+        "Cannot get output tensor Out, variable name = %s",
+        context.op().Input(framework::GradVarName("Out")));
+
+    auto *d_x = context.Output<framework::Tensor>(framework::GradVarName("X"));
+    d_x->mutable_data<T>(context.GetPlace());
+    float factor = context.Attr<float>("factor");
+    auto &dev_ctx = context.template device_context<DeviceContext>();
+
+    PowGradFunctor<DeviceContext, T> pow_grad_functor;
+    pow_grad_functor(dev_ctx, x, d_out, factor, d_x);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -825,7 +825,7 @@ class TestPow(OpTest):
         self.dtype = np.float32
         self.init_dtype()
 
-        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
+        x = np.random.uniform(-2, 2, [11, 17]).astype(self.dtype)
         out = np.power(x, 3)
 
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext.py
@@ -237,6 +237,7 @@ class TestResnet(TestParallelExecutorBase):
                                   use_cuda=True,
                                   use_reduce=False,
                                   iter=20,
+                                  delta1=1e-6,
                                   delta2=1e-6):
         if use_cuda and not core.is_compiled_with_cuda():
             return
@@ -268,12 +269,13 @@ class TestResnet(TestParallelExecutorBase):
             optimizer=optimizer)
 
         self.assertAlmostEquals(
-            np.mean(parallel_first_loss), single_first_loss[0], delta=1e-6)
+            np.mean(parallel_first_loss), single_first_loss[0], delta=delta1)
         self.assertAlmostEquals(
             np.mean(parallel_last_loss), single_last_loss[0], delta=delta2)
 
     def test_seresnext_with_learning_rate_decay(self):
-        self._check_resnet_convergence(model=SE_ResNeXt50Small, use_cuda=True)
+        self._check_resnet_convergence(
+            model=SE_ResNeXt50Small, use_cuda=True, delta1=1e-5)
         self._check_resnet_convergence(
             model=SE_ResNeXt50Small, use_cuda=False, iter=2, delta2=1e-3)
 


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/5198

The reason for this behavior is the use of the fast math option to NVCC (--use_fast_math). This results in 'pow' being replaced by the intrinsic '__powf', but the implementation of `__powf(x,y)` is  `exp2f(y * __log2f(x))` when add `use_fast_math`. So, if the x is negative, the output will be Nan.

If we use Eigen, the implementation of `x.pow(k)` will use the fast math even we didn't add `use_fast_math` for NVCC. 

For more information, please refer to: https://github.com/torch/DEPRECEATED-torch7-distro/issues/132