### PR TITLE
Profiler support merge data of all thread

### DIFF
--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -294,11 +294,11 @@ void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
 
   std::cout << "Place: " << place << std::endl;
   std::cout << "Time unit: ms" << std::endl;
-  std::cout << "Sorted by " << sorted_domain
-            << " in descending order in the same thread\n\n";
   if (merge_thread) {
     std::cout << "merge all thread" << std::endl;
   }
+  std::cout << "Sorted by " << sorted_domain
+            << " in descending order in the same thread\n\n";
   // Output events table
   std::cout.setf(std::ios::left);
   std::cout << std::setw(name_width) << "Event" << std::setw(data_width)

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -276,7 +276,7 @@ struct EventItem {
 // Print results
 void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
                    const std::string& sorted_domain, const size_t name_width,
-                   const size_t data_width, double total) {
+                   const size_t data_width, double total, bool merge_thread) {
   // Output header information
   std::cout << "\n------------------------->"
             << "     Profiling Report     "
@@ -296,6 +296,9 @@ void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
   std::cout << "Time unit: ms" << std::endl;
   std::cout << "Sorted by " << sorted_domain
             << " in descending order in the same thread\n\n";
+  if (merge_thread) {
+    std::cout << "merge all thread" << std::endl;
+  }
   // Output events table
   std::cout.setf(std::ios::left);
   std::cout << std::setw(name_width) << "Event" << std::setw(data_width)
@@ -461,7 +464,8 @@ void ParseEvents(const std::vector<std::vector<Event>>& events,
   }
 
   // Print report
-  PrintProfiler(events_table, sorted_domain, max_name_width + 4, 12, total);
+  PrintProfiler(events_table, sorted_domain, max_name_width + 4, 12, total,
+                merge_thread);
 }
 
 void DisableProfiler(EventSortingKey sorted_key,

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -276,7 +276,7 @@ struct EventItem {
 // Print results
 void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
                    const std::string& sorted_domain, const size_t name_width,
-                   const size_t data_width, double total, bool merge_thread) {
+                   const size_t data_width, bool merge_thread) {
   // Output header information
   std::cout << "\n------------------------->"
             << "     Profiling Report     "
@@ -315,8 +315,7 @@ void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
                 << std::setw(data_width) << event_item.min_time
                 << std::setw(data_width) << event_item.max_time
                 << std::setw(data_width) << event_item.ave_time
-                << std::setw(data_width) << event_item.total_time / total
-                << std::endl;
+                << std::setw(data_width) << event_item.ratio << std::endl;
     }
   }
   std::cout << std::endl;
@@ -383,8 +382,8 @@ void ParseEvents(const std::vector<std::vector<Event>>& events,
 
   std::vector<std::vector<EventItem>> events_table;
   size_t max_name_width = 0;
-  double total = 0.;  // the total time
   for (size_t i = 0; i < (*analyze_events).size(); i++) {
+    double total = 0.;  // the total time in one thread
     std::list<Event> pushed_events;
     std::vector<EventItem> event_items;
     std::unordered_map<std::string, int> event_idx;
@@ -447,6 +446,7 @@ void ParseEvents(const std::vector<std::vector<Event>>& events,
     // average time
     for (auto& item : event_items) {
       item.ave_time = item.total_time / item.calls;
+      item.ratio = item.total_time / total;
     }
     // sort
     if (sorted_by != EventSortingKey::kDefault) {
@@ -464,7 +464,7 @@ void ParseEvents(const std::vector<std::vector<Event>>& events,
   }
 
   // Print report
-  PrintProfiler(events_table, sorted_domain, max_name_width + 4, 12, total,
+  PrintProfiler(events_table, sorted_domain, max_name_width + 4, 12,
                 merge_thread);
 }
 

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -293,8 +293,7 @@ void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
   }
 
   if (merge_thread) {
-    std::cout << "Note! This Report merge all thread into one" << place
-              << std::endl;
+    std::cout << "Note! This Report merge all thread into one." << std::endl;
   }
   std::cout << "Place: " << place << std::endl;
   std::cout << "Time unit: ms" << std::endl;

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -292,11 +292,12 @@ void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
     PADDLE_THROW("Invalid profiler state", g_state);
   }
 
+  if (merge_thread) {
+    std::cout << "Note! This Report merge all thread into one" << place
+              << std::endl;
+  }
   std::cout << "Place: " << place << std::endl;
   std::cout << "Time unit: ms" << std::endl;
-  if (merge_thread) {
-    std::cout << "merge all thread" << std::endl;
-  }
   std::cout << "Sorted by " << sorted_domain
             << " in descending order in the same thread\n\n";
   // Output events table

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -293,7 +293,8 @@ void PrintProfiler(const std::vector<std::vector<EventItem>>& events_table,
   }
 
   if (merge_thread) {
-    std::cout << "Note! This Report merge all thread into one." << std::endl;
+    std::cout << "Note! This Report merge all thread info into one."
+              << std::endl;
   }
   std::cout << "Place: " << place << std::endl;
   std::cout << "Time unit: ms" << std::endl;

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -364,11 +364,11 @@ void ParseEvents(const std::vector<std::vector<Event>>& events,
   }
 
   const std::vector<std::vector<Event>>* analyze_events;
+  std::vector<std::vector<Event>> merged_events_list;
   if (merge_thread) {
-    std::vector<std::vector<Event>> merged_events_list;
     std::vector<Event> merged_events;
     for (int i = 0; i < events.size(); ++i) {
-      for (int j = 0; j < events[i].size(); ++i) {
+      for (int j = 0; j < events[i].size(); ++j) {
         merged_events.push_back(events[i][j]);
       }
     }


### PR DESCRIPTION
之前的profiler report在多线程的场景下，会统计每个线程内部同一个op运行时间占所有线程运行中时间的百分比，当线程数比较多的时候，无法清楚的看出特定op占所op运行时间的比例，这个pr主要改动了两点：

1. 增加了一个统计报告，当多线程的时候，把所有线程中的op合并到一起，计算每个op的时间占比
2. 把特定op在每个线程中占用的时间和所有线程总时间的占比，改成在当前线程中的运行时间占比。

### 所有线程merge之后的时间占比
![image](https://user-images.githubusercontent.com/3048612/46745715-32186400-cce0-11e8-9a18-1d176c1a5d53.png)

### 每个线程内部单个op运行时间占比

![image](https://user-images.githubusercontent.com/3048612/46745947-9f2bf980-cce0-11e8-84c6-d12920c8e102.png)

