### PR TITLE
fix default number of threads when inference with or without MKLDNN

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -25,9 +25,11 @@
 #include "paddle/fluid/inference/api/paddle_inference_api.h"
 #include "paddle/fluid/inference/api/paddle_inference_pass.h"
 #include "paddle/fluid/inference/utils/singleton.h"
+#include "paddle/fluid/platform/cpu_helper.h"
 #include "paddle/fluid/platform/profiler.h"
 
 DECLARE_bool(profile);
+DECLARE_int32(paddle_num_threads);
 
 namespace paddle {
 
@@ -46,6 +48,9 @@ bool AnalysisPredictor::Init(
     platform::EnableProfiler(tracking_device);
   }
 #endif
+
+  // no matter with or without MKLDNN
+  paddle::platform::SetNumThreads(FLAGS_paddle_num_threads);
 
   if (config_.use_gpu) {
     place_ = paddle::platform::CUDAPlace(config_.device);

--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -23,9 +23,11 @@ limitations under the License. */
 #include "paddle/fluid/framework/feed_fetch_method.h"
 #include "paddle/fluid/inference/api/api_impl.h"
 #include "paddle/fluid/inference/api/helper.h"
+#include "paddle/fluid/platform/cpu_helper.h"
 #include "paddle/fluid/platform/profiler.h"
 
 DEFINE_bool(profile, false, "Turn on profiler for fluid");
+DECLARE_int32(paddle_num_threads);
 
 namespace paddle {
 namespace {
@@ -71,6 +73,9 @@ bool NativePaddlePredictor::Init(
     platform::EnableProfiler(tracking_device);
   }
 #endif
+
+  // no matter with or without MKLDNN
+  paddle::platform::SetNumThreads(FLAGS_paddle_num_threads);
 
   if (config_.use_gpu) {
     place_ = paddle::platform::CUDAPlace(config_.device);


### PR DESCRIPTION
fix #13845 

本地验证通过，

多线程速度：
```
./paddle/fluid/inference/tests/api/test_analyzer_rnn1 --paddle_num_threads=1 --infer_model=third_party/inference_demo/rnn1/model --repeat=1000 --batch_size=100  --profile=false --gtest_filter=Analyzer_rnn1.profile --num_threads=10 --infer_data=third_party/inference_demo/rnn1/data.txt
...
I1012 07:10:30.976943 22600 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 8, latency: 2.43088ms ======
I1012 07:10:30.981338 22593 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 1, latency: 2.43573ms ======
I1012 07:10:30.981773 22598 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 6, latency: 2.43593ms ======
I1012 07:10:30.992934 22595 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 3, latency: 2.4473ms ======
I1012 07:10:31.000399 22601 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 9, latency: 2.45435ms ======
I1012 07:10:31.002044 22597 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 5, latency: 2.45622ms ======
I1012 07:10:31.016726 22594 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 2, latency: 2.47109ms ======
I1012 07:10:31.020231 22592 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 0, latency: 2.47462ms ======
I1012 07:10:31.022318 22599 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 7, latency: 2.47637ms ======
I1012 07:10:31.072247 22596 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 10, thread id: 4, latency: 2.52651ms ======
```

单线程：
```
./paddle/fluid/inference/tests/api/test_analyzer_rnn1 --paddle_num_threads=1 --infer_model=third_party/inference_demo/rnn1/model --repeat=1000 --batch_size=100  --profile=false --gtest_filter=Analyzer_rnn1.profile --num_threads=1 --infer_data=third_party/inference_demo/rnn1/data.txt
...
I1012 07:12:49.368126 22616 helper.h:161] ====== batch_size: 100, repeat: 1000, threads: 1, thread id: 0, latency: 2.44174ms ======
```