### PR TITLE
Fix l1 regularization bug

### DIFF
--- a/python/paddle/fluid/regularizer.py
+++ b/python/paddle/fluid/regularizer.py
@@ -237,6 +237,7 @@ class L1DecayRegularizer(WeightDecayRegularizer):
                         'Ids': idx},
                 outputs={'Out': decay},
                 attrs={'is_sparse': True})
+            param = decay
 
         # Append sign op
         block.append_op(


### PR DESCRIPTION
For sparse parameter regularization, we should extract the corresponding parameters from the origin parameters, and add regularization on the extracted parameter but not the origin parameter.