### PR TITLE
do not enable MKL-DNN twice

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -77,10 +77,6 @@ bool AnalysisPredictor::Init(
     inference_program_ = program;
   }
 
-  if (config_._use_mkldnn) {
-    executor_->EnableMKLDNN(*inference_program_);
-  }
-
   executor_->Prepare(scope_.get(), *inference_program_, 0,
                      config_.use_feed_fetch_ops);
 


### PR DESCRIPTION
After the MKL-DNN placement pass there is no need to enable MKL-DNN
in operators via executor.

I forgot to include this change in the PR https://github.com/PaddlePaddle/Paddle/pull/13958.

test=develop