### PR TITLE
Replace  SoftmaxCUDNNFunctor with SoftmaxFunctor in softmax_with_cross_entropy_op

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -272,8 +272,8 @@ class SoftmaxWithCrossEntropyCUDAKernel : public framework::OpKernel<T> {
           logits_data, labels_data, softmax_data, loss_data, batch_size,
           feature_size, context.cuda_device_context().stream());
     } else {
-      math::SoftmaxCUDNNFunctor<T>()(context.cuda_device_context(), logits,
-                                     softmax);
+      math::SoftmaxFunctor<platform::CUDADeviceContext, T>()(
+          context.cuda_device_context(), logits, softmax);
       math::CrossEntropyFunctor<platform::CUDADeviceContext, T>()(
           context.cuda_device_context(), loss, softmax, labels, false,
           ignore_index);


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/14006

cudnnSoftmaxAlgorithm_t has a parameter that specifies how to do compute the softmax:
- CUDNN_SOFTMAX_ACCURATE for this class (scales everything by max(z_i) to avoid overflow.
- CUDNN_SOFTMAX_FAST (less numerically stable)
- CUDNN_SOFTMAX_LOG (computes the natural log of the softmax function)

All of the optional is not appropriate for Softmax during computation, because it lacks a [clip operation](https://github.com/PaddlePaddle/Paddle/blob/42aa1d409ddcc675fb9ef352f2f7c151918a7116/paddle/fluid/operators/math/softmax_impl.h#L57).

But the speed becomes slow.
```
thread0:: softmax_with_cross_entropy[with SoftmaxFunctor]           6           2.29888     0.380928    0.386048    0.383147    0.00348047  
thread0:: softmax_with_cross_entropy[with SoftmaxCUDNNFunctor]          6           0.914432    0.149504    0.154624    0.152405    0.00139633  
```