### PR TITLE
Fix dynamic_gru h_0 bug

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -747,7 +747,7 @@ def dynamic_gru(input,
         attr=helper.bias_attr, shape=[1, 3 * size], dtype=dtype, is_bias=True)
     batch_size = input.shape[0]
     inputs = {'Input': input, 'Weight': weight, 'Bias': bias}
-    if h_0 != None:
+    if h_0:
         assert h_0.shape == (
             batch_size, size
         ), 'The shape of h0 should be(batch_size, %d)' % size


### PR DESCRIPTION
Fix #13746 . 
The bug is caused by the monkey patch methods of variable. Comparing a variable with None using `!=` would create a compare_op in program, which causes a conversation from None to tensor.

```
λ yq01-gpu-255-137-12-00 /Paddle/tests CUDA_VISIBLE_DEVICES=0  python
Python 2.7.12 (default, Dec  4 2017, 14:50:18) 
[GCC 5.4.0 20160609] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import paddle.fluid as fluid
>>> x = fluid.layers.data(name='x', shape=[-1, 32], dtype='float32')
>>> if x != None:
...     print(x)
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/layers/math_op_patch.py", line 118, in __impl__
    self.block, value=other_var, dtype=lhs_dtype)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/layers/math_op_patch.py", line 49, in create_scalar
    return create_tensor(block, value, dtype, shape=[1])
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/layers/math_op_patch.py", line 34, in create_tensor
    value = float(value)
TypeError: float() argument must be a string or a number
>>> 
>>> if x:
...     print(x)
... 
name: "x"
type {
  type: LOD_TENSOR
  lod_tensor {
    tensor {
      data_type: FP32
      dims: -1
      dims: 32
    }
    lod_level: 0
  }
}
persistable: false
```