### PR TITLE
Refine/jit/vmulcode

### DIFF
--- a/paddle/fluid/operators/math/jit_code.h
+++ b/paddle/fluid/operators/math/jit_code.h
@@ -43,17 +43,15 @@ class VMulJitCode : public JitCode {
   reg64_t param1{abi_param1};
   reg64_t param2{abi_param2};
   reg64_t param3{abi_param3};
+  reg64_t tmp = rax;
 
   xmm_t xmm_src1 = xmm_t(0);
-  ymm_t ymm_src1 = ymm_t(0);
-  zmm_t zmm_src1 = zmm_t(0);
   xmm_t xmm_src2 = xmm_t(1);
-  ymm_t ymm_src2 = ymm_t(1);
-  zmm_t zmm_src2 = zmm_t(1);
-
   xmm_t xmm_dst = xmm_t(2);
+
+  ymm_t ymm_src1 = ymm_t(0);
+  ymm_t ymm_src2 = ymm_t(1);
   ymm_t ymm_dst = ymm_t(2);
-  zmm_t zmm_dst = zmm_t(2);
 };
 
 }  // namespace gen

--- a/paddle/fluid/operators/math/jit_code.h
+++ b/paddle/fluid/operators/math/jit_code.h
@@ -43,7 +43,6 @@ class VMulJitCode : public JitCode {
   reg64_t param1{abi_param1};
   reg64_t param2{abi_param2};
   reg64_t param3{abi_param3};
-  reg64_t tmp = rax;
 
   xmm_t xmm_src1 = xmm_t(0);
   xmm_t xmm_src2 = xmm_t(1);

--- a/paddle/fluid/operators/math/jit_kernel_blas.cc
+++ b/paddle/fluid/operators/math/jit_kernel_blas.cc
@@ -65,8 +65,9 @@ class VMulKernelImpl : public VMulKernel<T> {
 
   explicit VMulKernelImpl(int d) : VMulKernel<T>() {
     if (useJIT(d)) {
-      constexpr size_t sz = 256 * 1024;  // TODO(TJ): should be related with d
-      jitcode_.reset(new gen::VMulJitCode(d, sz));
+      // roughly estimate the size of code
+      size_t sz = 96 + d / AVX_FLOAT_BLOCK * 4 * 8;
+      jitcode_.reset(new gen::VMulJitCode(d, sz > 4096 ? sz : 4096));
       this->Compute =
           jitcode_->getCode<void (*)(const T*, const T*, T*, int)>();
       return;

--- a/paddle/fluid/operators/math/jit_kernel_test.cc
+++ b/paddle/fluid/operators/math/jit_kernel_test.cc
@@ -578,7 +578,7 @@ void vmul_mkl(const int n, const float* x, const float* y, float* z) {
 
 TEST(JitKernel, vmul) {
   namespace jit = paddle::operators::math::jitkernel;
-  for (int d : {7, 8, 15, 16, 30, 256, 512, 1000, 1024}) {
+  for (int d : {7, 8, 15, 16, 20, 30, 256, 512, 1000, 1024}) {
     std::vector<float> x(d), y(d);
     std::vector<float> zref(d), ztgt(d);
     RandomVec<float>(d, x.data());

--- a/paddle/fluid/operators/math/jit_kernel_test.cc
+++ b/paddle/fluid/operators/math/jit_kernel_test.cc
@@ -800,7 +800,7 @@ TEST(JitKernel, pool) {
   EXPECT_TRUE(std::dynamic_pointer_cast<const jit::Kernel>(pvmul_f) !=
               std::dynamic_pointer_cast<const jit::Kernel>(pvmul_d));
 
-  const auto& pvmul_from_key = jit::KernelPool::Instance().Get("vmulfany");
+  const auto& pvmul_from_key = jit::KernelPool::Instance().Get("vmulfjit4");
   EXPECT_EQ(pvmul_f, pvmul_from_key);
   const auto& pvmul_from_key2 = jit::KernelPool::Instance().Get("vmulfjit");
   EXPECT_TRUE(pvmul_from_key2 == nullptr);


### PR DESCRIPTION
所有尺寸均远优于ref和mkl。2倍至20倍的提升。

Vec size | JIT / REF     | JIT/ MKL
:------- | :------------ | :------------
7        | 3.46          | 20.18
8        | 2.4           | 18.4
15       | 3.8813559322  | 16.6271186441
16       | 2.78846153846 | 19.6153846154
20       | 3.76785714286 | 17.4821428571
30       | 3.75          | 14.5555555556
256      | 2.31198347107 | 13.882231405
512      | 1.79558541267 | 2.44145873321
1000     | 1.80441176471 | 1.48578431373
1024     | 1.8948824343  | 1.53849700323
```
I1105 08:37:17.704880 58820 jit_kernel_test.cc:623] Vec size 7: refer takes: 0.00865 us, mkl takes: 0.05045 us, tgt takes: 0.0025
I1105 08:37:17.706121 58820 jit_kernel_test.cc:613] Vec size 8 intr takes: 0.0025
I1105 08:37:17.706202 58820 jit_kernel_test.cc:623] Vec size 8: refer takes: 0.006 us, mkl takes: 0.046 us, tgt takes: 0.0025
I1105 08:37:17.707568 58820 jit_kernel_test.cc:623] Vec size 15: refer takes: 0.01145 us, mkl takes: 0.04905 us, tgt takes: 0.00295
I1105 08:37:17.708878 58820 jit_kernel_test.cc:623] Vec size 16: refer takes: 0.00725 us, mkl takes: 0.051 us, tgt takes: 0.0026
I1105 08:37:17.710230 58820 jit_kernel_test.cc:623] Vec size 20: refer takes: 0.01055 us, mkl takes: 0.04895 us, tgt takes: 0.0028
I1105 08:37:17.711726 58820 jit_kernel_test.cc:623] Vec size 30: refer takes: 0.0135 us, mkl takes: 0.0524 us, tgt takes: 0.0036
I1105 08:37:17.720172 58820 jit_kernel_test.cc:623] Vec size 256: refer takes: 0.05595 us, mkl takes: 0.33595 us, tgt takes: 0.0242
I1105 08:37:17.725836 58820 jit_kernel_test.cc:623] Vec size 512: refer takes: 0.09355 us, mkl takes: 0.1272 us, tgt takes: 0.0521
I1105 08:37:17.734786 58820 jit_kernel_test.cc:623] Vec size 1000: refer takes: 0.18405 us, mkl takes: 0.15155 us, tgt takes: 0.102
I1105 08:37:17.744607 58820 jit_kernel_test.cc:623] Vec size 1024: refer takes: 0.2055 us, mkl takes: 0.16685 us, tgt takes: 0.10845
```


same as #14236