### PR TITLE
skip mkldnn related pass when use_mkldnn=false to speedup analysis

### DIFF
--- a/paddle/fluid/inference/analysis/analyzer.cc
+++ b/paddle/fluid/inference/analysis/analyzer.cc
@@ -113,7 +113,9 @@ void Analyzer::Run(Argument* argument) {
   passes.push_back("infer_clean_graph_pass");
   passes.push_back("graph_viz_pass");  // add graphviz for debug.
   for (auto& pass : ir_passes_) {
-    if (!disabled_ir_passes_.count(pass)) {
+    // skip mkldnn pass when use_mkldnn_ = false;
+    bool skip_pass = (!use_mkldnn_) && pass.find("mkldnn") != std::string::npos;
+    if (!disabled_ir_passes_.count(pass) && !skip_pass) {
       passes.push_back(pass);
       passes.push_back("graph_viz_pass");  // add graphviz for debug.
     }


### PR DESCRIPTION
when `cfg._use_mkldnn=False`, analysis mode still runs mkldnn related pass.
This PR skip mkldnn related pass when `_use_mkldnn=false` to speedup analysis time.
Results like:
- when `use_mkldnn=0`, there runs no mkldnn passes.
```
104: [ RUN      ] Analyzer_resnet50.profile
104: WARNING: Logging before InitGoogleLogging() is written to STDERR
104: I1109 15:40:59.306018 25193 tester_helper.h:198] use_analysis: 1, use_mkldnn: 0
104: I1109 15:40:59.353713 25193 analysis_predictor.cc:210] optimize begin
104: W1109 15:40:59.356534 25193 fluid_to_ir_pass.h:41] argument's origin_program_desc is already set, might duplicate called
104: I1109 15:40:59.368574 25193 fluid_to_ir_pass.h:61] Loading parameters
104: I1109 15:40:59.373728 25193 fluid_to_ir_pass.cc:46] load single model file from /home/luotao/Paddle/cpu_build/third_party/inference_demo/resnet50/model/model
104: * Running Analysis pass [fluid-to-ir-pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [infer_clean_graph_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [attention_lstm_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [seqconv_eltadd_relu_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [fc_lstm_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [mul_lstm_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [fc_gru_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [mul_gru_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [seq_concat_fc_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [fc_fuse_pass]
104: ---  detect 1 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_bn_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_eltwiseadd_bn_fuse_pass]
104: ---  detect 53 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: * Running Analysis pass [DFG to fluid]
104: W1109 15:41:05.830150 25193 data_flow_graph_to_fluid_pass.cc:70] parameter changes in the scope takes effect
104: * Running Analysis pass [dfg-to-fluid-debuger-pass]
```
- when `use_mkldnn=0`, there runs mkldnn passes.
```
104: [ RUN      ] Analyzer_resnet50.profile_mkldnn
104: I1109 15:41:07.069298 25193 tester_helper.h:198] use_analysis: 1, use_mkldnn: 1
104: I1109 15:41:07.120457 25193 analysis_predictor.cc:210] optimize begin
104: W1109 15:41:07.121816 25193 fluid_to_ir_pass.h:41] argument's origin_program_desc is already set, might duplicate called
104: I1109 15:41:07.128253 25193 fluid_to_ir_pass.h:61] Loading parameters
104: I1109 15:41:07.131672 25193 fluid_to_ir_pass.cc:46] load single model file from /home/luotao/Paddle/cpu_build/third_party/inference_demo/resnet50/model/model
104: * Running Analysis pass [fluid-to-ir-pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [mkldnn_placement_pass]
104: --- Running IR pass [infer_clean_graph_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [attention_lstm_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [seqconv_eltadd_relu_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [fc_lstm_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [mul_lstm_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [fc_gru_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [mul_gru_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [seq_concat_fc_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [fc_fuse_pass]
104: ---  detect 1 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_bn_fuse_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_eltwiseadd_bn_fuse_pass]
104: ---  detect 53 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [depthwise_conv_mkldnn_pass]
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_bias_mkldnn_fuse_pass]
104: ---  detect 53 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_relu_mkldnn_fuse_pass]
104: ---  detect 33 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: --- Running IR pass [conv_elementwise_add_mkldnn_fuse_pass]
104: ---  detect 16 subgraphs
104: --- Running IR pass [graph_viz_pass]
104: * Running Analysis pass [DFG to fluid]
104: W1109 15:41:14.835189 25193 data_flow_graph_to_fluid_pass.cc:70] parameter changes in the scope takes effect
104: * Running Analysis pass [dfg-to-fluid-debuger-pass]
```