### PR TITLE
Run startup in parallel executor

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -24,7 +24,7 @@ paddle.fluid.DistributeTranspiler.transpile ArgSpec(args=['self', 'trainer_id', 
 paddle.fluid.memory_optimize ArgSpec(args=['input_program', 'skip_opt_set', 'print_log', 'level', 'skip_grads'], varargs=None, keywords=None, defaults=(None, False, 0, False))
 paddle.fluid.release_memory ArgSpec(args=['input_program', 'skip_opt_set'], varargs=None, keywords=None, defaults=(None,))
 paddle.fluid.DistributeTranspilerConfig.__init__ 
-paddle.fluid.ParallelExecutor.__init__ ArgSpec(args=['self', 'use_cuda', 'loss_name', 'main_program', 'share_vars_from', 'exec_strategy', 'build_strategy', 'num_trainers', 'trainer_id', 'scope'], varargs=None, keywords=None, defaults=(None, None, None, None, None, 1, 0, None))
+paddle.fluid.ParallelExecutor.__init__ ArgSpec(args=['self', 'use_cuda', 'loss_name', 'main_program', 'startup_program', 'share_vars_from', 'exec_strategy', 'build_strategy', 'num_trainers', 'trainer_id', 'scope'], varargs=None, keywords=None, defaults=(None, None, None, None, None, None, 1, 0, None))
 paddle.fluid.ParallelExecutor.run ArgSpec(args=['self', 'fetch_list', 'feed', 'feed_dict', 'return_numpy'], varargs=None, keywords=None, defaults=(None, None, True))
 paddle.fluid.ExecutionStrategy.__init__ __init__(self: paddle.fluid.core.ExecutionStrategy) -> None
 paddle.fluid.BuildStrategy.GradientScaleStrategy.__init__ __init__(self: paddle.fluid.core.GradientScaleStrategy, arg0: int) -> None

--- a/paddle/fluid/framework/details/build_strategy.cc
+++ b/paddle/fluid/framework/details/build_strategy.cc
@@ -86,7 +86,8 @@ std::shared_ptr<ir::PassBuilder> BuildStrategy::CreatePassesFromStrategy()
 }
 
 std::unique_ptr<ir::Graph> BuildStrategy::Apply(
-    const ProgramDesc &main_program, const std::vector<platform::Place> &places,
+    const ProgramDesc &main_program, const ProgramDesc &startup_program,
+    const std::vector<platform::Place> &places,
     const std::string &loss_var_name,
     const std::unordered_set<std::string> &param_names,
     const std::vector<Scope *> &local_scopes,
@@ -100,7 +101,8 @@ std::unique_ptr<ir::Graph> BuildStrategy::Apply(
     CreatePassesFromStrategy();
   }
 
-  std::unique_ptr<ir::Graph> graph(new ir::Graph(main_program));
+  std::unique_ptr<ir::Graph> graph(
+      new ir::Graph(main_program, startup_program));
 
   for (std::shared_ptr<ir::Pass> &pass : pass_builder_->AllPasses()) {
     if (pass->Type() == "multi_devices_pass") {

--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -85,7 +85,7 @@ struct BuildStrategy {
   // Apply the passes built by the pass_builder_. The passes will be
   // applied to the Program and output an ir::Graph.
   std::unique_ptr<ir::Graph> Apply(
-      const ProgramDesc &main_program,
+      const ProgramDesc &main_program, const ProgramDesc &startup_program,
       const std::vector<platform::Place> &places,
       const std::string &loss_var_name,
       const std::unordered_set<std::string> &param_names,

--- a/paddle/fluid/framework/ir/graph.cc
+++ b/paddle/fluid/framework/ir/graph.cc
@@ -82,7 +82,10 @@ void CheckProgram(const ProgramDesc &program) {
 }
 }  // namespace
 
-Graph::Graph(const ProgramDesc &program) : program_(program) {
+Graph::Graph(const ProgramDesc &program) : Graph(program, ProgramDesc()) {}
+
+Graph::Graph(const ProgramDesc &program, const ProgramDesc &startup_program)
+    : program_(program), startup_program_(startup_program) {
   CheckProgram(program_);
   // Make the nodes id start from 0.
   Node::ResetId();

--- a/paddle/fluid/framework/ir/graph.h
+++ b/paddle/fluid/framework/ir/graph.h
@@ -62,7 +62,10 @@ namespace ir {
  */
 class Graph {
  public:
+  // Default init with an empty startup program.
   explicit Graph(const ProgramDesc &program);
+  explicit Graph(const ProgramDesc &program,
+                 const ProgramDesc &startup_program);
 
   virtual ~Graph() {
     for (auto &attr : attrs_) {
@@ -71,6 +74,8 @@ class Graph {
     attrs_.clear();
     attr_dels_.clear();
   }
+
+  ProgramDesc GetStartupProgram() const { return startup_program_; }
 
   bool Has(const std::string &attr_name) const {
     return attrs_.find(attr_name) != attrs_.end();
@@ -186,6 +191,7 @@ class Graph {
 
   // NOTE: program_ shouldn't be exposed to user.
   const ProgramDesc program_;
+  ProgramDesc startup_program_;
   std::map<std::string, boost::any> attrs_;
   std::map<std::string, std::function<void(void)>> attr_dels_;
   std::map<ir::Node *, std::unique_ptr<ir::Node>> nodes_;

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -49,6 +49,7 @@ class ParallelExecutor {
                             const std::unordered_set<std::string> &params,
                             const std::unordered_set<std::string> &bcast_vars,
                             const ProgramDesc &main_program,
+                            const ProgramDesc &startup_program,
                             const std::string &loss_var_name, Scope *scope,
                             const std::vector<Scope *> &local_scopes,
                             const ExecutionStrategy &exec_strategy,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -863,9 +863,9 @@ All parameter, weight, gradient are variables in Paddle.
   pe.def(py::init<const std::vector<platform::Place> &,
                   const std::unordered_set<std::string> &,
                   const std::unordered_set<std::string> &, const ProgramDesc &,
-                  const std::string &, Scope *, std::vector<Scope *> &,
-                  const ExecutionStrategy &, const BuildStrategy &, size_t,
-                  size_t>())
+                  const ProgramDesc &, const std::string &, Scope *,
+                  std::vector<Scope *> &, const ExecutionStrategy &,
+                  const BuildStrategy &, size_t, size_t>())
       // NOTE: even we return a vec<Scope*>* to Python use reference policy.
       // We still cannot get local_scope from this vector, since the element
       // of vec<Scope*> will be freed by Python GC. We can only return Scope*

--- a/python/paddle/fluid/parallel_executor.py
+++ b/python/paddle/fluid/parallel_executor.py
@@ -86,6 +86,7 @@ class ParallelExecutor(object):
                  use_cuda,
                  loss_name=None,
                  main_program=None,
+                 startup_program=None,
                  share_vars_from=None,
                  exec_strategy=None,
                  build_strategy=None,
@@ -136,6 +137,8 @@ class ParallelExecutor(object):
 
         main = main_program
         main = main if main else framework.default_main_program()
+        startup = startup_program
+        startup = startup if startup else framework.default_startup_program()
         if scope == None:
             scope = executor.global_scope()
 
@@ -160,7 +163,8 @@ class ParallelExecutor(object):
                 for p in main.global_block().iter_parameters()
                 if not p.stop_gradient
             ]),
-            set(cpt.to_text(var) for var in self.persistable_vars), main.desc,
+            set(cpt.to_text(var)
+                for var in self.persistable_vars), main.desc, startup.desc,
             cpt.to_text(loss_name)
             if loss_name else six.u(''), scope, local_scopes, exec_strategy,
             build_strategy, num_trainers, trainer_id)

--- a/python/paddle/fluid/parallel_executor.py
+++ b/python/paddle/fluid/parallel_executor.py
@@ -141,7 +141,7 @@ class ParallelExecutor(object):
         startup = startup if startup else framework.default_startup_program()
         if scope == None:
             scope = executor.global_scope()
-        if self.is_startup_ran(scope, main):
+        if self._is_startup_ran(scope, main):
             # if startup is already ran by user, set parallel exe to run an
             # empty program, this is used for v1.x API compatibility, should
             # remove this when API is settled.
@@ -175,7 +175,7 @@ class ParallelExecutor(object):
             build_strategy, num_trainers, trainer_id)
         self.scope = scope
 
-    def is_startup_ran(self, scope, main):
+    def _is_startup_ran(self, scope, main):
         for var in main.global_block().iter_parameters():
             if scope.find_var(var.name) is None:
                 return False

--- a/python/paddle/fluid/parallel_executor.py
+++ b/python/paddle/fluid/parallel_executor.py
@@ -141,6 +141,11 @@ class ParallelExecutor(object):
         startup = startup if startup else framework.default_startup_program()
         if scope == None:
             scope = executor.global_scope()
+        if self.is_startup_ran(scope, main):
+            # if startup is already ran by user, set parallel exe to run an
+            # empty program, this is used for v1.x API compatibility, should
+            # remove this when API is settled.
+            startup = framework.Program()
 
         if share_vars_from and not isinstance(share_vars_from,
                                               ParallelExecutor):
@@ -169,6 +174,12 @@ class ParallelExecutor(object):
             if loss_name else six.u(''), scope, local_scopes, exec_strategy,
             build_strategy, num_trainers, trainer_id)
         self.scope = scope
+
+    def is_startup_ran(self, scope, main):
+        for var in main.global_block().iter_parameters():
+            if scope.find_var(var.name) is None:
+                return False
+        return True
 
     def run(self, fetch_list, feed=None, feed_dict=None, return_numpy=True):
         """


### PR DESCRIPTION
### Reason of this change:

1. IR passes need to modify startup program if the pass add/rename/delete variables, and the variable needs an initializer.
1. Passes are executed by ParallelExecutor, and we want to run statup after `passes.Apply`, so we need to run startup in ParallelExecutor constructor.
1. To keep API compatibility, we can allow user to call `executor.run(startup)` before ParallelExecutor constructor
1. User may need to load a model before running, need to be compatible of loading models

### Cases
Consider below cases, this change should work on all of them:

```python
# Normal cases
exe.run(startup)
pe = fluid.ParallelExecutor()
pe.run()
```

```python
# single node load model and fine tune
exe.run(startup)
fluid.load_vars()  # or fluid.load_persistables etc.
pe = fluid.ParallelExecutor()
pe.run()
```

```python
# single node load model and fine tune
exe.run(startup)
fluid.load_vars()  # or fluid.load_persistables etc.
pe = fluid.ParallelExecutor()
pe.run()
```

```python
# single node simplified
pe = fluid.ParallelExecutor() # run startup inside here
pe.run()
```

```python
# single node load model
fluid.load_vars()
pe = fluid.ParallelExecutor() # run startup inside here
pe.run()
```


```python
# distributed mode
main, startup = fluid.DistributedTranspiler().transpile(...)
exe.run(startup)
fluid.load_vars()
pe = fluid.ParallelExecutor() # run startup inside here
pe.run()
```