### PR TITLE
Refine lrn cpu forward

### DIFF
--- a/paddle/fluid/operators/lrn_op.cc
+++ b/paddle/fluid/operators/lrn_op.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/lrn_op.h"
 #include <string>
+#include "paddle/fluid/operators/math/blas.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
 #endif
@@ -29,34 +30,43 @@ struct LRNFunctor<platform::CPUDeviceContext, T> {
                   const framework::Tensor& input, framework::Tensor* out,
                   framework::Tensor* mid, int N, int C, int H, int W, int n,
                   T k, T alpha, T beta) {
-    auto x_v = framework::EigenVector<T>::Flatten(input);
-
-    const int start = -(n - 1) / 2;
-    const int end = start + n;
-
-    auto e_mid = framework::EigenTensor<T, 4>::From(*mid);
-    e_mid = e_mid.constant(k);
-
-    auto e_x = framework::EigenTensor<T, 4>::From(input);
-    for (int m = 0; m < N; m++) {
-      for (int i = 0; i < C; i++) {
-        for (int c = start; c < end; c++) {
-          int ch = i + c;
-          if (ch >= 0 && ch < C) {
-            auto s = e_mid.slice(Eigen::array<int, 4>({{m, i, 0, 0}}),
-                                 Eigen::array<int, 4>({{1, 1, H, W}}));
-
-            auto r = e_x.slice(Eigen::array<int, 4>({{m, ch, 0, 0}}),
-                               Eigen::array<int, 4>({{1, 1, H, W}}));
-
-            s += alpha * r.square();
-          }
-        }
+    const T* idata = input.data<T>();
+    auto place = ctx.GetPlace();
+    auto blas = math::GetBlas<platform::CPUDeviceContext, T>(ctx);
+    T* odata = out->mutable_data<T>(place);
+    T* mdata = mid->mutable_data<T>(place);
+    Tensor squared;
+    T* sdata = squared.mutable_data<T>({1, C + n - 1, H, W}, place);
+    std::memset(sdata, 0, sizeof(T) * squared.numel());
+    for (int i = 0; i < mid->numel(); ++i) {
+      mdata[i] = k;
+    }
+    int img_size = H * W;
+    int fea_size = C * img_size;
+    int pre_pad = (n - 1) / 2;
+    // compute batches one by one
+    for (int i = 0; i < N; ++i) {
+      blas.VSQR(fea_size, idata + i * fea_size, sdata + pre_pad * img_size);
+      // init the first channel of mid
+      for (int c = 0; c < n; ++c) {
+        blas.AXPY(img_size, alpha, sdata + c * img_size, mdata + i * fea_size);
+      }
+      for (int c = 1; c < C; ++c) {
+        // copy previous scale
+        int mid_offset = i * fea_size + c * img_size;
+        std::memcpy(mdata + mid_offset, mdata + mid_offset - img_size,
+                    img_size * sizeof(T));
+        // add last
+        blas.AXPY(img_size, alpha, sdata + (c + n - 1) * img_size,
+                  mdata + mid_offset);
+        // sub rest
+        blas.AXPY(img_size, -alpha, sdata + (c - 1) * img_size,
+                  mdata + mid_offset);
       }
     }
-
-    auto out_e = framework::EigenVector<T>::Flatten(*out);
-    out_e = x_v * e_mid.reshape(Eigen::DSizes<int, 1>(e_mid.size())).pow(-beta);
+    // compute the final output
+    blas.VPOW(mid->numel(), mdata, -beta, odata);
+    blas.VMUL(mid->numel(), odata, idata, odata);
   }
 };
 template struct LRNFunctor<platform::CPUDeviceContext, float>;
@@ -155,6 +165,9 @@ class LRNOp : public framework::OperatorWithKernel {
 
     auto x_dim = ctx->GetInputDim("X");
     PADDLE_ENFORCE_EQ(x_dim.size(), 4, "Input(X)'rank of LRNOp should be 4.");
+
+    int n = ctx->Attrs().Get<int>("n");
+    PADDLE_ENFORCE(n > 0 && n % 2 == 1, "n should be positive odd value");
 
     ctx->SetOutputDim("Out", x_dim);
     ctx->ShareLoD("X", /*->*/ "Out");

--- a/paddle/fluid/operators/lrn_op.h
+++ b/paddle/fluid/operators/lrn_op.h
@@ -60,7 +60,6 @@ class LRNKernel : public framework::OpKernel<T> {
     T beta = ctx.Attr<float>("beta");
     T k = ctx.Attr<float>("k");
 
-    PADDLE_ENFORCE(n > 0, "n should >= 0");
     PADDLE_ENFORCE(alpha >= 0.0, "alpha should >= 0.0");
     PADDLE_ENFORCE(beta >= 0.0, "beta should >= 0.0");
     PADDLE_ENFORCE(k >= 0.0, "k should >= 0.0");

--- a/paddle/fluid/operators/math/blas.h
+++ b/paddle/fluid/operators/math/blas.h
@@ -153,6 +153,12 @@ class Blas {
   void VEXP(int n, const T* x, T* y) const;
 
   template <typename T>
+  void VSQR(int n, const T* x, T* y) const;
+
+  template <typename T>
+  void VPOW(int n, const T* x, T alpha, T* y) const;
+
+  template <typename T>
   void GEMV(bool trans_a, int M, int N, T alpha, const T* A, const T* B, T beta,
             T* C) const;
 
@@ -236,6 +242,16 @@ class BlasT : private Blas<DeviceContext> {
   template <typename... ARGS>
   void VEXP(ARGS... args) const {
     Base()->template VEXP<T>(args...);
+  }
+
+  template <typename... ARGS>
+  void VSQR(ARGS... args) const {
+    Base()->template VSQR<T>(args...);
+  }
+
+  template <typename... ARGS>
+  void VPOW(ARGS... args) const {
+    Base()->template VPOW<T>(args...);
   }
 
   template <typename... ARGS>

--- a/paddle/fluid/operators/math/blas_impl.h
+++ b/paddle/fluid/operators/math/blas_impl.h
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #pragma once
+#include <cmath>
 #include <limits>
 #include <vector>
 #include "paddle/fluid/operators/math/math_function.h"
@@ -102,6 +103,16 @@ struct CBlas<float> {
   static void VEXP(ARGS... args) {
     platform::dynload::vsExp(args...);
   }
+
+  template <typename... ARGS>
+  static void VSQR(ARGS... args) {
+    platform::dynload::vsSqr(args...);
+  }
+
+  template <typename... ARGS>
+  static void VPOW(ARGS... args) {
+    platform::dynload::vsPowx(args...);
+  }
 };
 
 template <>
@@ -182,6 +193,16 @@ struct CBlas<double> {
   static void VEXP(ARGS... args) {
     platform::dynload::vdExp(args...);
   }
+
+  template <typename... ARGS>
+  static void VSQR(ARGS... args) {
+    platform::dynload::vdSqr(args...);
+  }
+
+  template <typename... ARGS>
+  static void VPOW(ARGS... args) {
+    platform::dynload::vdPowx(args...);
+  }
 };
 
 #else
@@ -241,6 +262,8 @@ struct CBlas<platform::float16> {
   }
   static void VMUL(...) { PADDLE_THROW("float16 VMUL not supported on CPU"); }
   static void VEXP(...) { PADDLE_THROW("float16 VEXP not supported on CPU"); }
+  static void VSQR(...) { PADDLE_THROW("float16 VSQR not supported on CPU"); }
+  static void VPOW(...) { PADDLE_THROW("float16 VPOW not supported on CPU"); }
   static void DOT(...) { PADDLE_THROW("float16 DOT not supported on CPU"); };
   static void SCAL(...) { PADDLE_THROW("float16 SCAL not supported on CPU"); };
 #ifdef PADDLE_WITH_MKLML
@@ -394,6 +417,31 @@ void Blas<platform::CPUDeviceContext>::VEXP(int n, const T *x, T *y) const {
   // try to find if openblas support vexp
   for (int i = 0; i < n; ++i) {
     y[i] = std::exp(x[i]);
+  }
+#endif
+}
+
+template <>
+template <typename T>
+void Blas<platform::CPUDeviceContext>::VSQR(int n, const T *x, T *y) const {
+#ifdef PADDLE_WITH_MKLML
+  CBlas<T>::VSQR(n, x, y);
+#else
+  for (int i = 0; i < n; ++i) {
+    y[i] = std::sqrt(x[i]);
+  }
+#endif
+}
+
+template <>
+template <typename T>
+void Blas<platform::CPUDeviceContext>::VPOW(int n, const T *x, T a,
+                                            T *y) const {
+#ifdef PADDLE_WITH_MKLML
+  CBlas<T>::VPOW(n, x, a, y);
+#else
+  for (int i = 0; i < n; ++i) {
+    y[i] = std::pow(x[i], a);
   }
 #endif
 }

--- a/paddle/fluid/platform/dynload/mklml.h
+++ b/paddle/fluid/platform/dynload/mklml.h
@@ -76,6 +76,10 @@ extern void* mklml_dso_handle;
   __macro(vdMul);                   \
   __macro(vsExp);                   \
   __macro(vdExp);                   \
+  __macro(vsSqr);                   \
+  __macro(vdSqr);                   \
+  __macro(vsPowx);                  \
+  __macro(vdPowx);                  \
   __macro(MKL_Set_Num_Threads)
 
 MKLML_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_MKLML_WRAP);


### PR DESCRIPTION
机器   | LRN 提升(After/Before) | GoogleNet提升 (After/Before)
:--- | :------------------- | :-------------------------
V3   | 10.1倍                | 1.813 倍
V4   | 9.7 倍                | 1.780 倍
6148 | 9.6 倍                | 1.842 倍

## 6148

LRN op 前向速度是原来 9.6倍， GoogleNet预测整体提升84%。

-----
优化前：173ms
```
I1113 08:26:31.793946 98667 analysis_predictor.cc:257] == optimize end ==
I1113 08:26:49.181648 98667 helper.h:162] ====== batch_size: 1, repeat: 100, threads: 1, thread id: 0, latency: 173.863ms, fps: 5.75166 ======

------------------------->     Profiling Report     <-------------------------

Place: CPU
Time unit: ms
Sorted by total time in descending order in the same thread

Event                       Calls       Total       Min.        Max.        Ave.        Ratio.
thread0::lrn                200         8900.68     23.453      66.1328     44.5034     0.51258
thread0::conv2d             5700        6436.89     0.07805     52.0661     1.12928     0.370693
thread0::pool2d             1400        1317.07     0.072455    2.08418     0.940767    0.0758487
thread0::elementwise_add    5700        444.942     0.009673    1.05752     0.0780601   0.0256237
thread0::concat             900         130.624     0.02287     0.436969    0.145138    0.00752251
thread0::relu               5700        110.933     0.003437    0.318598    0.0194619   0.0063885
thread0::load_combine       2           17.3249     7.96162     9.36328     8.66245     0.000997721
thread0::fc                 100         4.96089     0.044133    0.189449    0.0496089   0.000285692
thread0::fetch              100         0.661495    0.005259    0.017347    0.00661495  3.80947e-05
thread0::feed               100         0.393301    0.00319     0.008024    0.00393301  2.26497e-05
```
-------
优化后：93.9ms
```
I1113 08:20:31.602970 95697 analysis_predictor.cc:257] == optimize end ==
I1113 08:20:40.994953 95697 helper.h:162] ====== batch_size: 1, repeat: 100, threads: 1, thread id: 0, latency: 93.9061ms, fps: 10.6489 ======

------------------------->     Profiling Report     <-------------------------

Place: CPU
Time unit: ms
Sorted by total time in descending order in the same thread

Event                       Calls       Total       Min.        Max.        Ave.        Ratio.
thread0::conv2d             5700        6418.21     0.076998    54.9928     1.126       0.685076
thread0::pool2d             1400        1315.54     0.071871    2.63455     0.93967     0.14042
thread0::lrn                200         922.137     2.15055     7.64337     4.61069     0.0984284
thread0::elementwise_add    5700        447.857     0.010434    1.09269     0.0785715   0.047804
thread0::concat             900         128.708     0.022344    0.455157    0.143009    0.0137382
thread0::relu               5700        112.951     0.003743    0.317033    0.019816    0.0120563
thread0::load_combine       2           17.4285     8.0317      9.39684     8.71427     0.00186031
thread0::fc                 100         4.7099      0.041282    0.161938    0.047099    0.000502732
thread0::fetch              100         0.64508     0.004953    0.020382    0.0064508   6.88555e-05
thread0::feed               100         0.425996    0.003376    0.009419    0.00425996  4.54706e-05
```

## v3

 181.7 => 100.2 ms 提升81.3%， LRN 提升10.1倍

----
 优化前：181.7ms
```
	 I1113 13:30:20.603967 16574 analysis_predictor.cc:257] == optimize end ==
	I1113 13:30:38.776087 16574 helper.h:162] ====== batch_size: 1, repeat: 100, threads: 1, thread id: 0, latency: 181.709ms, fps: 5.50332 ======
	
	------------------------->     Profiling Report     <-------------------------
	
	Place: CPU
	Time unit: ms
	Sorted by total time in descending order in the same thread
	
	Event                       Calls       Total       Min.        Max.        Ave.        Ratio.
	thread0::lrn                200         8862.97     23.2144     69.7213     44.3149     0.488231
	thread0::conv2d             5700        6554.14     0.075886    24.6968     1.14985     0.361045
	thread0::pool2d             1400        1506.95     0.06609     2.83318     1.07639     0.0830126
	thread0::elementwise_add    5700        1009.25     0.012874    5.36977     0.177061    0.0555962
	thread0::concat             900         104.287     0.022518    1.6519      0.115874    0.0057448
	thread0::relu               5700        97.0754     0.003649    0.279706    0.0170308   0.00534755
	thread0::load_combine       2           13.6027     6.79753     6.80517     6.80135     0.000749326
	thread0::fc                 100         3.99863     0.034518    0.151054    0.0399863   0.000220271
	thread0::fetch              100         0.486273    0.003835    0.020171    0.00486273  2.67871e-05
	thread0::feed               100         0.471438    0.003724    0.017244    0.00471438  2.59699e-05
```

----
	
优化后：100.2 ms
```
	I1113 13:25:58.130270  9241 analysis_predictor.cc:257] == optimize end ==
	I1113 13:26:08.156157  9241 helper.h:162] ====== batch_size: 1, repeat: 100, threads: 1, thread id: 0, latency: 100.246ms, fps: 9.97542 ======
	
	------------------------->     Profiling Report     <-------------------------
	
	Place: CPU
	Time unit: ms
	Sorted by total time in descending order in the same thread
	
	Event                       Calls       Total       Min.        Max.        Ave.        Ratio.
	thread0::conv2d             5700        6409.75     0.075735    17.4146     1.12452     0.640434
	thread0::pool2d             1400        1523.35     0.06594     2.42346     1.0881      0.152206
	thread0::elementwise_add    5700        986.613     0.012623    2.76721     0.17309     0.098578
	thread0::lrn                200         878.263     2.18592     7.30542     4.39132     0.0877522
	thread0::concat             900         97.2331     0.021818    0.603451    0.108037    0.0097151
	thread0::relu               5700        96.9726     0.003735    0.681551    0.0170127   0.00968907
	thread0::load_combine       2           11.9123     5.94347     5.96885     5.95616     0.00119023
	thread0::fc                 100         3.56846     0.031722    0.125973    0.0356846   0.000356545
	thread0::fetch              100         0.420697    0.003514    0.011648    0.00420697  4.20342e-05
	thread0::feed               100         0.366212    0.003042    0.011597    0.00366212  3.65903e-05
```

## v4

204.75 => 115.06 ms 提升 78%， LRN 提升 9.65倍

----

优化前 204.75ms
```
	 I1113 16:42:20.236214  9557 analysis_predictor.cc:257] == optimize end ==
	I1113 16:42:40.713142  9557 helper.h:161] ====== batch_size: 1, repeat: 100, threads: 1, thread id: 0, latency: 204.753ms, fps: 4.88394 ======
	
	------------------------->     Profiling Report     <-------------------------
	
	Place: CPU
	Time unit: ms
	Sorted by total time in descending order in the same thread
	
	Event                       Calls       Total       Min.        Max.        Ave.        Ratio.
	thread0::lrn                200         9824.79     25.3905     76.9484     49.1239     0.480106
	thread0::conv2d             5700        7647.55     0.091993    25.8668     1.34168     0.373711
	thread0::pool2d             1400        1554.15     0.074384    3.02377     1.11011     0.0759462
	thread0::elementwise_add    5700        1157.38     0.015376    2.80089     0.203049    0.0565573
	thread0::relu               5700        120.071     0.004415    0.687635    0.021065    0.00586747
	thread0::concat             900         117.077     0.03373     0.397271    0.130085    0.00572117
	thread0::load_combine       2           36.0182     12.1854     23.8329     18.0091     0.00176009
	thread0::fc                 100         5.51879     0.048238    0.13641     0.0551879   0.000269686
	thread0::fetch              100         0.69827     0.00559     0.014974    0.0069827   3.41222e-05
	thread0::feed               100         0.557636    0.004542    0.016138    0.00557636  2.72499e-05
```

----

优化后 115.06ms
```
	I1113 22:20:58.472754  5334 analysis_predictor.cc:257] == optimize end ==
	I1113 22:21:09.980288  5334 helper.h:162] ====== batch_size: 1, repeat: 100, threads: 1, thread id: 0, latency: 115.06ms, fps: 8.69112 ======
	
	------------------------->     Profiling Report     <-------------------------
	
	Place: CPU
	Time unit: ms
	Sorted by total time in descending order in the same thread
	
	Event                       Calls       Total       Min.        Max.        Ave.        Ratio.
	thread0::conv2d             5700        7486.38     0.087759    25.6001     1.3134      0.65127
	thread0::pool2d             1400        1545.46     0.074949    2.34097     1.1039      0.134446
	thread0::elementwise_add    5700        1171.58     0.017402    2.73098     0.205541    0.101921
	thread0::lrn                200         1017.9      2.42032     8.45936     5.08951     0.0885512
	thread0::relu               5700        116.024     0.004487    0.372304    0.020355    0.0100934
	thread0::concat             900         113.995     0.028074    0.378654    0.126661    0.00991685
	thread0::load_combine       2           36.784      12.5215     24.2625     18.392      0.00319999
	thread0::fc                 100         5.62597     0.049512    0.228108    0.0562597   0.000489425
	thread0::fetch              100         0.745657    0.005222    0.036076    0.00745657  6.48676e-05
	thread0::feed               100         0.552636    0.004427    0.015942    0.00552636  4.8076e-05
```