### PR TITLE
fix typo test=develop

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -142,7 +142,7 @@ if os.name == 'nt':
 
 if '${WITH_FLUID_ONLY}'== 'OFF':
     package_data['paddle.v2.master']=['libpaddle_master' + ext_name]
-    package_data['py_paddle']=['*.py','_swig_paddle' +  + ext_name]
+    package_data['py_paddle']=['*.py','_swig_paddle' + ext_name]
 
 package_dir={
     '': '${PADDLE_BINARY_DIR}/python',


### PR DESCRIPTION
test=develop
http://ci.paddlepaddle.org/viewLog.html?buildId=28842&tab=buildLog&buildTypeId=Manylinux1_Cuda90cudnn7avxMkl&logTab=tail￼
![image](https://user-images.githubusercontent.com/6836917/48594781-09ddee00-e98d-11e8-8cbd-bab6292c4afe.png)
