### PR TITLE
add warm up in TestMultiThreadPrediction

### DIFF
--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -222,19 +222,36 @@ void TestMultiThreadPrediction(
       // The inputs of each thread are all the same.
       std::vector<PaddleTensor> outputs_tid;
       auto &predictor = predictors[tid];
-      LOG(INFO) << "running thread " << tid;
-      Timer timer;
-      timer.tic();
-      for (int i = 0; i < num_times; i++) {
-        for (const auto &input : inputs) {
-          ASSERT_TRUE(predictor->Run(input, &outputs_tid));
+
+      // warmup run
+      LOG(INFO) << "Running thread " << tid << ", warm up run...";
+      {
+        Timer warmup_timer;
+        warmup_timer.tic();
+        predictor->Run(inputs[0], outputs, batch_size);
+        PrintTime(batch_size, 1, num_threads, tid, warmup_timer.toc(), 1);
+#if !defined(_WIN32)
+        if (FLAGS_profile) {
+          paddle::platform::ResetProfiler();
         }
+#endif
       }
 
-      auto time = timer.toc();
-      total_time += time;
-      PrintTime(batch_size, num_times, num_threads, tid, time / num_times,
-                inputs.size());
+      LOG(INFO) << "Thread " << tid << " run " << num_times << " times...";
+      {
+        Timer timer;
+        timer.tic();
+        for (int i = 0; i < num_times; i++) {
+          for (const auto &input : inputs) {
+            ASSERT_TRUE(predictor->Run(input, &outputs_tid));
+          }
+        }
+
+        auto time = timer.toc();
+        total_time += time;
+        PrintTime(batch_size, num_times, num_threads, tid, time / num_times,
+                  inputs.size());
+      }
     });
   }
   for (int i = 0; i < num_threads; ++i) {


### PR DESCRIPTION
Results like:
```
I1120 16:56:35.527462 27299 analysis_predictor.cc:317] == optimize end ==
I1120 16:56:35.530706 27309 tester_helper.h:227] Running thread 0, warm up run...
I1120 16:56:35.530735 27310 tester_helper.h:227] Running thread 1, warm up run...
I1120 16:56:38.344813 27310 helper.h:232] ====== batch_size: 1, repeat: 1, threads: 2, thread id: 1, latency: 2813.92ms, fps: 0.355377 ======
I1120 16:56:38.344910 27310 tester_helper.h:240] Thread 1 run 10 times...
I1120 16:56:38.532701 27309 helper.h:232] ====== batch_size: 1, repeat: 1, threads: 2, thread id: 0, latency: 3001.64ms, fps: 0.333151 ======
I1120 16:56:38.532790 27309 tester_helper.h:240] Thread 0 run 10 times...
I1120 16:56:47.991148 27309 helper.h:232] ====== batch_size: 1, repeat: 10, threads: 2, thread id: 0, latency: 945.82ms, fps: 1.05728 ======
I1120 16:56:48.697176 27310 helper.h:232] ====== batch_size: 1, repeat: 10, threads: 2, thread id: 1, latency: 1035.21ms, fps: 0.965986 ======
```