### PR TITLE
Fix memory leak after MKL-DNN reorders

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -188,6 +188,11 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
   // Fix TensorArray reuse not cleaned bug.
   tensor_array_batch_cleaner_.CollectTensorArrays(scope_.get());
   tensor_array_batch_cleaner_.ResetTensorArray();
+
+  // We should delete all kid scopes after run executor because
+  // MKL-DNN operators create local scope for reorders
+  if (scope) scope->DropKids();
+
   return true;
 }
 


### PR DESCRIPTION
Quick fix for removing memory leaks after MKL-DNN reorders