### PR TITLE
fix compile

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -117,7 +117,7 @@ cc_library(op_info SRCS op_info.cc DEPS attribute framework_proto)
 cc_library(shape_inference SRCS shape_inference.cc DEPS ddim attribute device_context)
 
 if (NOT WIN32)
-cc_library(transfer_scope_cache SRCS transfer_scope_cache.cc DEPS scope framework_proto)
+cc_library(transfer_scope_cache SRCS transfer_scope_cache.cc DEPS scope framework_proto device_context)
 cc_library(operator SRCS operator.cc DEPS op_info device_context tensor scope glog
     shape_inference data_transform lod_tensor profiler transfer_scope_cache)
 else()


### PR DESCRIPTION
```
[07:00:09][Step 3/3] In file included from /workspace/paddle/fluid/framework/tensor.h:26:0,
[07:00:09][Step 3/3]                  from /workspace/paddle/fluid/framework/eigen.h:17,
[07:00:09][Step 3/3]                  from /workspace/paddle/fluid/platform/float16.h:76,
[07:00:09][Step 3/3]                  from /workspace/paddle/fluid/framework/data_type.h:20,
[07:00:09][Step 3/3]                  from /workspace/paddle/fluid/framework/op_kernel_type.h:19,
[07:00:09][Step 3/3]                  from /workspace/paddle/fluid/framework/transfer_scope_cache.h:20,
[07:00:09][Step 3/3]                  from /workspace/paddle/fluid/framework/transfer_scope_cache.cc:15:
[07:00:09][Step 3/3] /workspace/paddle/fluid/platform/device_context.h:28:22: fatal error: mkldnn.hpp: No such file or directory
[07:00:09][Step 3/3]  #include "mkldnn.hpp"
[07:00:09][Step 3/3]                       ^
[07:00:09][Step 3/3] compilation terminated.
```
http://ce.paddlepaddle.org:8080/viewLog.html?buildId=4876&buildTypeId=PaddleModesl_BuildModels&tab=buildLog&_focus=2998
