### PR TITLE
EltwiseMul: Changes from previous PR

### DIFF
--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -14,6 +14,7 @@ limitations under the License. */
 #pragma once
 
 #include <mkldnn.h>
+#include <algorithm>
 #include <string>
 #include <vector>
 #include "paddle/fluid/framework/operator.h"
@@ -289,6 +290,22 @@ inline mkldnn::memory::format data_format_to_memory_format(
       return mkldnn::memory::format::nchw;
     default:
       return mkldnn::memory::format::any;
+  }
+}
+
+inline mkldnn::memory::format StringToMKLDNNFormat(std::string* format) {
+  std::transform(format->begin(), format->end(), format->begin(), ::tolower);
+
+  if (!format->compare("nchw")) {
+    return mkldnn::memory::format::nchw;
+  } else if (!format->compare("nchw16c")) {
+    return mkldnn::memory::format::nChw16c;
+  } else if (!format->compare("nchw8c")) {
+    return mkldnn::memory::format::nChw8c;
+  } else if (!format->compare("nhwc")) {
+    return mkldnn::memory::format::nhwc;
+  } else {
+    return mkldnn::memory::format::any;
   }
 }
 


### PR DESCRIPTION
This PR introduces some of the requested changes from the @tpatejko's review from the previous PR https://github.com/PaddlePaddle/Paddle/pull/14351.

Introduced:
https://github.com/PaddlePaddle/Paddle/pull/14351#pullrequestreview-176253297
Not introduced:
https://github.com/PaddlePaddle/Paddle/pull/14351#pullrequestreview-176254380
Because this scenario will never occur.
https://github.com/PaddlePaddle/Paddle/pull/14351#pullrequestreview-176255008
Because usings are not inherited, and using typedef instead causes the necessity to use full type specifier (which considering all the namespace qualifiers get quite big and clutters the code badly).