### PR TITLE
fix the build issue on manylinux1

### DIFF
--- a/paddle/legacy/cuda/src/hl_cuda_device.cc
+++ b/paddle/legacy/cuda/src/hl_cuda_device.cc
@@ -137,9 +137,9 @@ inline pid_t gettid() {
 #define __NR_gettid 224
 #endif
   pid_t tid = syscall(__NR_gettid);
-#else // _WIN32
+#else   // _WIN32
   pid_t tid = _getpid();
-#endif // _WIN32
+#endif  // _WIN32
 #endif
   CHECK_NE((int)tid, -1);
   return tid;

--- a/paddle/legacy/cuda/src/hl_cuda_device.cc
+++ b/paddle/legacy/cuda/src/hl_cuda_device.cc
@@ -137,10 +137,10 @@ inline pid_t gettid() {
 #define __NR_gettid 224
 #endif
   pid_t tid = syscall(__NR_gettid);
-#endif
-#else   // _WIN32
+#else // _WIN32
   pid_t tid = _getpid();
-#endif  // _WIN32
+#endif // _WIN32
+#endif
   CHECK_NE((int)tid, -1);
   return tid;
 }


### PR DESCRIPTION
Fix the build issue which introduced by https://github.com/PaddlePaddle/Paddle/pull/14545, it can block the manylinux1's nightly builts.
![image](https://user-images.githubusercontent.com/6836917/49123325-2239fb00-f2f3-11e8-8631-f0fc0e16bcb7.png)
http://ci.paddlepaddle.org/viewLog.html?buildId=31488&buildTypeId=Manylinux1_Cuda90cudnn7avxMkl&tab=buildLog