### PR TITLE
Refine beam_search_op to output an extra parent_idx tensor

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -106,7 +106,7 @@ paddle.fluid.layers.transpose ArgSpec(args=['x', 'perm', 'name'], varargs=None, 
 paddle.fluid.layers.im2sequence ArgSpec(args=['input', 'filter_size', 'stride', 'padding', 'input_image_size', 'out_stride', 'name'], varargs=None, keywords=None, defaults=(1, 1, 0, None, 1, None))
 paddle.fluid.layers.nce ArgSpec(args=['input', 'label', 'num_total_classes', 'sample_weight', 'param_attr', 'bias_attr', 'num_neg_samples', 'name', 'sampler', 'custom_dist', 'seed', 'is_sparse'], varargs=None, keywords=None, defaults=(None, None, None, None, None, 'uniform', None, 0, False))
 paddle.fluid.layers.hsigmoid ArgSpec(args=['input', 'label', 'num_classes', 'param_attr', 'bias_attr', 'name', 'path_table', 'path_code', 'is_custom', 'is_sparse'], varargs=None, keywords=None, defaults=(None, None, None, None, None, False, False))
-paddle.fluid.layers.beam_search ArgSpec(args=['pre_ids', 'pre_scores', 'ids', 'scores', 'beam_size', 'end_id', 'level', 'name'], varargs=None, keywords=None, defaults=(0, None))
+paddle.fluid.layers.beam_search ArgSpec(args=['pre_ids', 'pre_scores', 'ids', 'scores', 'beam_size', 'end_id', 'level', 'name', 'return_parent_idx'], varargs=None, keywords=None, defaults=(0, None, False))
 paddle.fluid.layers.row_conv ArgSpec(args=['input', 'future_context_size', 'param_attr', 'act'], varargs=None, keywords=None, defaults=(None, None))
 paddle.fluid.layers.multiplex ArgSpec(args=['inputs', 'index'], varargs=None, keywords=None, defaults=None)
 paddle.fluid.layers.layer_norm ArgSpec(args=['input', 'scale', 'shift', 'begin_norm_axis', 'epsilon', 'param_attr', 'bias_attr', 'act', 'name'], varargs=None, keywords=None, defaults=(True, True, 1, 1e-05, None, None, None, None))

--- a/paddle/fluid/operators/beam_search_op.h
+++ b/paddle/fluid/operators/beam_search_op.h
@@ -134,7 +134,8 @@ class BeamSearch {
   void operator()(const framework::LoDTensor& pre_ids,
                   const framework::LoDTensor& pre_scores,
                   framework::LoDTensor* selected_ids,
-                  framework::LoDTensor* selected_scores);
+                  framework::LoDTensor* selected_scores,
+                  framework::LoDTensor* parent_idx);
   /*
    * The basic items help to sort.
    */
@@ -215,9 +216,11 @@ class BeamSearchOpKernel : public framework::OpKernel<T> {
     auto selected_ids = context.Output<framework::LoDTensor>("selected_ids");
     auto selected_scores =
         context.Output<framework::LoDTensor>("selected_scores");
+    auto parent_idx = context.Output<framework::LoDTensor>("parent_idx");
     PADDLE_ENFORCE_NOT_NULL(selected_ids);
     PADDLE_ENFORCE_NOT_NULL(selected_scores);
-    alg(*pre_ids, *pre_scores, selected_ids, selected_scores);
+    PADDLE_ENFORCE_NOT_NULL(parent_idx);
+    alg(*pre_ids, *pre_scores, selected_ids, selected_scores, parent_idx);
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/gather_op.h
+++ b/paddle/fluid/operators/gather_op.h
@@ -35,7 +35,7 @@ class GatherOpKernel : public framework::OpKernel<T> {
     auto *output = ctx.Output<Tensor>("Out");
 
     output->mutable_data<T>(ctx.GetPlace());
-
+    if (x->numel() == 0) return;
     CPUGather<T>(ctx.device_context(), *x, *index, output);
   }
 };
@@ -56,7 +56,7 @@ class GatherGradientOpKernel : public framework::OpKernel<T> {
     auto &place = *ctx.template device_context<platform::CPUDeviceContext>()
                        .eigen_device();
     dxt.device(place) = dxt.constant(static_cast<T>(0));
-
+    if (dO->numel() == 0) return;
     ScatterAssign<T>(ctx.device_context(), *dO, *Index, dX);
   }
 };

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -3455,7 +3455,8 @@ def beam_search(pre_ids,
                 beam_size,
                 end_id,
                 level=0,
-                name=None):
+                name=None,
+                return_parent_idx=False):
     """
     Beam search is a classical algorithm for selecting candidate words in a
     machine translation task.
@@ -3506,10 +3507,16 @@ def beam_search(pre_ids,
             in lod.
         name(str|None): A name for this layer(optional). If set None, the layer
                         will be named automatically.
+        return_parent_idx(bool): Whether to return an extra Tensor variable 
+                        preserving the selected_ids' parent indice in pre_ids
+                        in output, which can be used to gather cell states at
+                        the next time step.
 
     Returns:
-        Variable: The LodTensor pair containing the selected ids and the \
-            corresponding scores.
+        Variable: The LodTensor tuple containing the selected ids and the \
+            corresponding scores. If :attr:`return_parent_idx` is :attr:`True`, \
+            an extra Tensor variable preserving the selected_ids' parent indice \
+            is included.
 
     Examples:
         .. code-block:: python
@@ -3538,6 +3545,11 @@ def beam_search(pre_ids,
     selected_scores = helper.create_variable_for_type_inference(
         dtype=score_type)
     selected_ids = helper.create_variable_for_type_inference(dtype=id_type)
+    # parent_idx is a tensor used to gather cell states at the next time
+    # step. Though lod in selected_ids can also be used to gather by
+    # sequence_expand, it is not efficient.
+    # gather_op's index input only supports int32 dtype currently
+    parent_idx = helper.create_variable_for_type_inference(dtype="int32")
 
     helper.append_op(
         type='beam_search',
@@ -3550,6 +3562,7 @@ def beam_search(pre_ids,
         outputs={
             'selected_ids': selected_ids,
             'selected_scores': selected_scores,
+            'parent_idx': parent_idx
         },
         attrs={
             # TODO(ChunweiYan) to assure other value support
@@ -3557,8 +3570,10 @@ def beam_search(pre_ids,
             'beam_size': beam_size,
             'end_id': end_id,
         })
-
-    return selected_ids, selected_scores
+    if return_parent_idx:
+        return selected_ids, selected_scores, parent_idx
+    else:
+        return selected_ids, selected_scores
 
 
 def beam_search_decode(ids, scores, beam_size, end_id, name=None):


### PR DESCRIPTION
Refine beam_search_op to output an extra parent_idx tensor.  parent_idx is a tensor used to gather cell states at the next time step. Though lod in selected_ids can also be used to gather by sequence_expand, it is not efficient since sequence_expand has to copy lod from cpu to gpu and the computation is more complicated compared to gather. Use parent_idx(assign to gpu) and replace sequence_expand_op with gather_op speed up Transformer inference significantly. Here list parts of profiling results of Transformer inference when replacing sequence_expand with gather.

```text
Event                                      Calls       Total       Min.        Max.        Ave.        Ratio.
--
while                                    1           4523.83     4523.83     4523.83     4523.83     0.50234
sequence_expand                          1775        2181.03     0.030016    5.57475     1.22875     0.242188
matmul                                   1787        698.191     0.032384    3.60365     0.390706    0.0775293
mul                                        3456        613.506     0.034464    5.77315     0.177519    0.0681255
assign                                   1787        246.091     0.018368    3.23789     0.137712    0.0273266
concat                                   852         117.242     0.048992    6.85875     0.137608    0.0130189
elementwise_add                          2729        101.151     0.011616    21.081      0.0370652   0.0112321
beam_search                              71          74.2201     0.599296    6.65718     1.04535     0.00824162
transpose2                               2592        70.8863     0.012096    2.52013     0.0273481   0.00787142
dropout                                  2652        70.1645     0.011168    4.49117     0.0264572   0.00779127
softmax                                  929         69.453      0.014336    3.38106     0.074761    0.00771226
top_k                                    71          69.1206     0.10224     3.11629     0.973529    0.00767535
layer_norm                               1362        50.0504     0.017824    2.06554     0.0367477   0.00555774
reshape2                                 2735        22.3022     0.003328    5.13386     0.00815438  0.00247651
read                                     2           21.1472     10.5665     10.5807     10.5736     0.00234825
relu                                     432         15.5508     0.011328    0.48336     0.0359973   0.00172681
read_from_array                          142         11.2653     0.051904    0.173312    0.0793332   0.00125093
beam_search_decode                       1           11.0426     11.0426     11.0426     11.0426     0.0012262
````

```text
Event                                      Calls       Total       Min.        Max.        Ave.        Ratio.
--
while                                    1           2837.42     2837.42     2837.42     2837.42     0.512778
matmul                                   1787        703.405     0.037152    3.63952     0.393624    0.127119
mul                                        3456        639.879     0.032576    6.84054     0.18515     0.115639
gather                                   1775        352.45      0.003392    7.06938     0.198564    0.0636948
assign                                   1858        251.248     0.00352     4.82582     0.135225    0.0454055
concat                                   852         135.271     0.044928    19.8283     0.158769    0.0244462
elementwise_add                          2729        83.3219     0.011616    3.98928     0.030532    0.0150579
dropout                                  2652        77.4242     0.010848    7.27709     0.0291946   0.0139921
transpose2                               2592        76.0943     0.012192    2.89446     0.0293574   0.0137517
beam_search                              71          73.5428     0.631392    10.2284     1.03581     0.0132906
top_k                                    71          69          0.09632     3.12163     0.971831    0.0124697
softmax                                  929         68.5287     0.014176    3.40208     0.0737661   0.0123845
layer_norm                               1362        52.1339     0.01824     2.51587     0.0382774   0.00942162
reshape2                                 2735        32.8726     0.003328    4.49635     0.0120192   0.00594073
relu                                     432         15.867      0.012256    0.471616    0.0367293   0.00286749
read                                     2           13.7459     6.86704     6.87885     6.87294     0.00248415
beam_search_decode                       1           12.0194     12.0194     12.0194     12.0194     0.00217214


````


Also, make gather_op support gather form size 0 tensor.