### PR TITLE
Softmax for inference MKL further changes

### DIFF
--- a/paddle/fluid/operators/math/blas.h
+++ b/paddle/fluid/operators/math/blas.h
@@ -169,6 +169,9 @@ class Blas {
   void SCAL(int n, const T a, T* x) const;
 
   template <typename T>
+  T ASUM(int n, T* x, int inc) const;
+
+  template <typename T>
   void BatchedGEMM(CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int M, int N,
                    int K, T alpha, const T* A, const T* B, T beta, T* C,
                    int batchCount, int64_t strideA, int64_t strideB) const;
@@ -267,6 +270,11 @@ class BlasT : private Blas<DeviceContext> {
   template <typename... ARGS>
   void SCAL(ARGS... args) const {
     Base()->template SCAL<T>(args...);
+  }
+
+  template <typename... ARGS>
+  T ASUM(ARGS... args) const {
+    return Base()->template ASUM<T>(args...);
   }
 
   template <typename... ARGS>

--- a/paddle/fluid/operators/math/blas_impl.h
+++ b/paddle/fluid/operators/math/blas_impl.h
@@ -493,7 +493,7 @@ template <typename T>
 T Blas<platform::CPUDeviceContext>::ASUM(int n, T *x, int inc) const {
   auto sum = static_cast<T>(0.0);
 #ifdef PADDLE_WITH_MKLML
-  sum = Blas<T>::ASUM(n, x, inc);
+  sum = CBlas<T>::ASUM(n, x, inc);
 #else
   //TODO(jczaja): check if openblas does provide cblas_sasum/cblas_dasum
   for (int c = 0; c < n; ++c) {

--- a/paddle/fluid/operators/math/blas_impl.h
+++ b/paddle/fluid/operators/math/blas_impl.h
@@ -487,7 +487,6 @@ void Blas<platform::CPUDeviceContext>::SCAL(int n, const T a, T *x) const {
 #endif
 }
 
-
 template <>
 template <typename T>
 T Blas<platform::CPUDeviceContext>::ASUM(int n, T *x, int inc) const {
@@ -495,14 +494,13 @@ T Blas<platform::CPUDeviceContext>::ASUM(int n, T *x, int inc) const {
 #ifdef PADDLE_WITH_MKLML
   sum = CBlas<T>::ASUM(n, x, inc);
 #else
-  //TODO(jczaja): check if openblas does provide cblas_sasum/cblas_dasum
+  // TODO(jczaja): check if openblas does provide cblas_sasum/cblas_dasum
   for (int c = 0; c < n; ++c) {
     sum += x[c];
   }
 #endif
   return sum;
 }
-
 
 template <>
 template <typename T>

--- a/paddle/fluid/operators/math/blas_impl.h
+++ b/paddle/fluid/operators/math/blas_impl.h
@@ -85,6 +85,11 @@ struct CBlas<float> {
   }
 
   template <typename... ARGS>
+  static float ASUM(ARGS... args) {
+    return platform::dynload::cblas_sasum(args...);
+  }
+
+  template <typename... ARGS>
   static void GEMM_BATCH(ARGS... args) {
     platform::dynload::cblas_sgemm_batch(args...);
   }
@@ -172,6 +177,11 @@ struct CBlas<double> {
   template <typename... ARGS>
   static void SCAL(ARGS... args) {
     platform::dynload::cblas_dscal(args...);
+  }
+
+  template <typename... ARGS>
+  static double ASUM(ARGS... args) {
+    return platform::dynload::cblas_dasum(args...);
   }
 
   template <typename... ARGS>
@@ -268,6 +278,7 @@ struct CBlas<platform::float16> {
   static void VPOW(...) { PADDLE_THROW("float16 VPOW not supported on CPU"); }
   static void DOT(...) { PADDLE_THROW("float16 DOT not supported on CPU"); };
   static void SCAL(...) { PADDLE_THROW("float16 SCAL not supported on CPU"); };
+  static void ASUM(...) { PADDLE_THROW("float16 ASUM not supported on CPU"); };
 #ifdef PADDLE_WITH_MKLML
   static void GEMM_BATCH(...) {
     PADDLE_THROW("float16 GEMM_BATCH not supported on CPU");
@@ -475,6 +486,23 @@ void Blas<platform::CPUDeviceContext>::SCAL(int n, const T a, T *x) const {
   }
 #endif
 }
+
+
+template <>
+template <typename T>
+T Blas<platform::CPUDeviceContext>::ASUM(int n, T *x, int inc) const {
+  auto sum = static_cast<T>(0.0);
+#ifdef PADDLE_WITH_MKLML
+  sum = Blas<T>::ASUM(n, x, inc);
+#else
+  //TODO(jczaja): check if openblas does provide cblas_sasum/cblas_dasum
+  for (int c = 0; c < n; ++c) {
+    sum += x[c];
+  }
+#endif
+  return sum;
+}
+
 
 template <>
 template <typename T>

--- a/paddle/fluid/operators/math/softmax_impl.h
+++ b/paddle/fluid/operators/math/softmax_impl.h
@@ -100,11 +100,8 @@ class SoftmaxFunctor<DeviceContext, float, true, enable_if_CPU<DeviceContext>> {
 
     blas.VEXP(num_classes * batch_size, out_data, out_data);
     for (int n = 0; n < batch_size; ++n) {
-      entities[n] = out_data[n * num_classes];
-      for (int c = 1; c < num_classes; ++c) {
-        entities[n] += out_data[n * num_classes + c];
-      }
-      blas.SCAL(num_classes, 1.0f / entities[n], &out_data[n * num_classes]);
+      auto sum = blas.ASUM(num_classes, &out_data[n * num_classes], 1);
+      blas.SCAL(num_classes, 1.0f / sum, &out_data[n * num_classes]);
     }
   }
 };

--- a/paddle/fluid/operators/softmax_op.h
+++ b/paddle/fluid/operators/softmax_op.h
@@ -36,9 +36,7 @@ class SoftmaxKernel : public framework::OpKernel<T> {
     Tensor Out_2d = framework::ReshapeToMatrix(*Out, rank - 1);
 
 #ifdef PADDLE_ON_INFERENCE
-    math::SoftmaxFunctor<
-        DeviceContext, T,
-        std::is_same<DeviceContext, platform::CPUDeviceContext>::value>()(
+    math::SoftmaxFunctor<DeviceContext, T, true>()(
         context.template device_context<DeviceContext>(), &X_2d, &Out_2d);
 #else
     math::SoftmaxFunctor<DeviceContext, T, false>()(

--- a/paddle/fluid/platform/dynload/mklml.h
+++ b/paddle/fluid/platform/dynload/mklml.h
@@ -68,6 +68,8 @@ extern void* mklml_dso_handle;
   __macro(cblas_dgemm_batch);       \
   __macro(cblas_sdot);              \
   __macro(cblas_ddot);              \
+  __macro(cblas_sasum);             \
+  __macro(cblas_dasum);             \
   __macro(cblas_sscal);             \
   __macro(cblas_dscal);             \
   __macro(vsAdd);                   \


### PR DESCRIPTION
Changes here are implementing suggestions from #14437 . 

In terms of performance, replacing single threaded suming replaced with cblas_sasum reduce by **~3-4%** execution time of softmax op in DAM model for single threaded scenario.