### PR TITLE
Add demo for image classification models evaluation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ include(external/gtest)     # download, build, install gtest
 include(external/protobuf)  # download, build, install protobuf
 include(external/python)    # download, build, install python
 include(external/openblas)  # download, build, install openblas
+include(external/opencv)    # download, build, install opencv
 include(external/mkldnn)    # download, build, install mkldnn
 include(external/ngraph)    # download, build, install nGraph
 include(external/swig)      # download, build, install swig

--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -80,7 +80,7 @@ link_directories("${PADDLE_LIB}/third_party/install/gflags/lib")
 link_directories("${PADDLE_LIB}/third_party/install/xxhash/lib")
 link_directories("${PADDLE_LIB}/paddle/lib")
 
-add_executable(${DEMO_NAME} ${DEMO_NAME}.cc)
+add_executable(${DEMO_NAME} ${DEMO_NAME}.cc ${DEMO_ADD_SRC})
 
 if(WITH_MKL)
   include_directories("${PADDLE_LIB}/third_party/install/mklml/include")
@@ -98,10 +98,10 @@ endif()
 # Note: libpaddle_inference_api.so/a must put before libpaddle_fluid.so/a
 if(WITH_STATIC_LIB)
   set(DEPS
-      ${PADDLE_LIB}/paddle/lib/libpaddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
+      ${PADDLE_LIB}/paddle/fluid/inference/libpaddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
 else()
   set(DEPS
-      ${PADDLE_LIB}/paddle/lib/libpaddle_fluid${CMAKE_SHARED_LIBRARY_SUFFIX})
+      ${PADDLE_LIB}/paddle/fluid/inference/libpaddle_fluid${CMAKE_SHARED_LIBRARY_SUFFIX})
 endif()
 
 if (NOT WIN32)
@@ -131,6 +131,10 @@ if(WITH_GPU)
   set(DEPS ${DEPS} ${CUDA_LIB}/cublas${CMAKE_STATIC_LIBRARY_SUFFIX} )
   set(DEPS ${DEPS} ${CUDA_LIB}/cudnn${CMAKE_STATIC_LIBRARY_SUFFIX} )
   endif()
+endif()
+
+if (${DEMO_NAME} STREQUAL "infer_image_classification")
+  set(DEPS ${DEPS} opencv_core opencv_highgui opencv_imgproc)
 endif()
 
 target_link_libraries(${DEMO_NAME} ${DEPS})

--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -71,6 +71,7 @@ if (NOT WIN32)
 link_directories("${PADDLE_LIB}/third_party/install/snappy/lib")
 link_directories("${PADDLE_LIB}/third_party/install/snappystream/lib")
 link_directories("${PADDLE_LIB}/third_party/install/zlib/lib")
+link_directories("${PADDLE_LIB}/third_party/install/opencv/lib")
 endif(NOT WIN32)
 
 link_directories("${PADDLE_LIB}/third_party/install/protobuf/lib")

--- a/paddle/fluid/inference/api/demo_ci/README.md
+++ b/paddle/fluid/inference/api/demo_ci/README.md
@@ -14,13 +14,24 @@ There are several demos:
     ```
     <space splitted floats as data>\t<space splitted ints as shape>
     ```
+- infer_image_classification:
+  - The C++ code is in `infer_image_classification.cc`.
+  - It accepts e.g. ResNet50, SE-ResNeXt50 and MobileNet-v1 models.
+  - Requires `ImageNet` directory with the ImageNet dataset
 
 To build and execute the demos, simply run 
 ```
-./run.sh $PADDLE_ROOT $TURN_ON_MKL $TEST_GPU_CPU
+./run.sh $PADDLE_ROOT $TURN_ON_MKL $TEST_GPU_CPU $DATA_DIR
 ```
 - It will build and execute the demos in both static and shared library.
-- `$PADDLE_ROOT`: paddle library path
-- `$TURN_ON_MKL`: use MKL or Openblas
+- `$PADDLE_ROOT`:  paddle library path
+- `$TURN_ON_MKL`:  use MKL or Openblas
 - `$TEST_GPU_CPU`: test both GPU/CPU mode or only CPU mode
+- `$DATA_DIR`:     a directory to store models and datasets in
 - NOTE: for simple_on_word2vec, must run `ctest -R test_word2vec -R` to obtain word2vec model at first.
+
+To build only a single demo, run
+```
+./build.sh <demo_name> $PADDLE_ROOT $TURN_ON_MKL $TEST_GPU_CPU $WITH_STATIC_LIB
+```
+where `$WITH_STATIC_LIB` determines the linkage (static/dynamic) to PaddlePaddle fluid library.

--- a/paddle/fluid/inference/api/demo_ci/build.sh
+++ b/paddle/fluid/inference/api/demo_ci/build.sh
@@ -1,0 +1,86 @@
+set -x
+DEMO_NAME=$1
+PADDLE_ROOT=$2
+TURN_ON_MKL=$3 # use MKL or Openblas
+TEST_GPU_CPU=$4 # test both GPU/CPU mode or only CPU mode
+WITH_STATIC_LIB=$5
+TENSORRT_INCLUDE_DIR=$6 # TensorRT header file dir, defalut to /usr/local/TensorRT/include
+TENSORRT_LIB_DIR=$7 # TensorRT lib file dir, default to /usr/local/TensorRT/lib
+inference_install_dir=${PADDLE_ROOT}/build/fluid_install_dir
+
+if [ $TURN_ON_MKL == ON ]; then
+  # You can export yourself if move the install path
+  MKL_LIB=${inference_install_dir}/third_party/install/mklml/lib
+  export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${MKL_LIB}
+fi
+if [ $TEST_GPU_CPU == ON ]; then
+  use_gpu_list='true false'
+else
+  use_gpu_list='false'
+fi
+
+USE_TENSORRT=OFF
+if [ -d "$TENSORRT_INCLUDE_DIR" -a -d "$TENSORRT_LIB_DIR" ]; then
+  USE_TENSORRT=ON
+fi
+
+start_dir=${PWD}
+
+if [ ${PWD##*/} == build ]; then
+  rm -rf *
+else
+  mkdir -p build
+  cd build
+  rm -rf *
+fi
+
+echo "pwd: $(pwd)"
+# assume we are in a build directory
+if [ $DEMO_NAME == simple_on_word2vec ]; then
+  # -----simple_on_word2vec-----
+  cmake .. -DPADDLE_LIB=${inference_install_dir} \
+    -DWITH_MKL=$TURN_ON_MKL \
+    -DDEMO_NAME=simple_on_word2vec \
+    -DWITH_GPU=$TEST_GPU_CPU \
+    -DDEMO_ADD_SRC="" \
+    -DWITH_STATIC_LIB=$WITH_STATIC_LIB
+  make -j
+elif [ $DEMO_NAME == vis_demo ]; then
+  # ---------vis_demo---------
+  cmake .. -DPADDLE_LIB=${inference_install_dir} \
+    -DWITH_MKL=$TURN_ON_MKL \
+    -DDEMO_NAME=vis_demo \
+    -DWITH_GPU=$TEST_GPU_CPU \
+    -DDEMO_ADD_SRC="" \
+    -DWITH_STATIC_LIB=$WITH_STATIC_LIB
+  make -j
+elif [ $DEMO_NAME == trt_mobilenet_demo ]; then
+  # --------tensorrt mobilenet------
+  if [ $USE_TENSORRT == ON -a $TEST_GPU_CPU == ON ]; then
+    cmake .. -DPADDLE_LIB=${inference_install_dir} \
+      -DWITH_MKL=$TURN_ON_MKL \
+      -DDEMO_NAME=trt_mobilenet_demo \
+      -DWITH_GPU=$TEST_GPU_CPU \
+      -DWITH_STATIC_LIB=$WITH_STATIC_LIB \
+      -DUSE_TENSORRT=$USE_TENSORRT \
+      -DTENSORRT_INCLUDE_DIR=$TENSORRT_INCLUDE_DIR \
+      -DTENSORRT_LIB_DIR=$TENSORRT_LIB_DIR
+    make -j
+  fi
+elif [ $DEMO_NAME == infer_image_classification ]; then
+  # -------- infer_image_classification (iic) ------
+  cmake .. -DPADDLE_LIB=${inference_install_dir} \
+    -DWITH_MKL=$TURN_ON_MKL \
+    -DDEMO_NAME=infer_image_classification \
+    -DDEMO_ADD_SRC="utils/image_reader.cc;utils/stats.cc" \
+    -DWITH_GPU=$TEST_GPU_CPU \
+    -DWITH_STATIC_LIB=$WITH_STATIC_LIB
+  make -j
+else
+  echo "Unknown demo name ($DEMO_NAME)."
+  exit 1
+fi
+
+cd ${start_dir}
+
+set +x

--- a/paddle/fluid/inference/api/demo_ci/infer_image_classification.cc
+++ b/paddle/fluid/inference/api/demo_ci/infer_image_classification.cc
@@ -1,0 +1,335 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//#include "paddle/fluid/inference/analysis/analyzer.h"
+#include <gflags/gflags.h>
+#include <random>
+#include "paddle/fluid/framework/ir/pass.h"
+#include "paddle/fluid/inference/paddle_inference_api.h"
+#include "paddle/fluid/platform/profiler.h"
+#include "utils/image_reader.h"
+#include "utils/stats.h"
+
+DEFINE_string(infer_model, "", "Directory of the inference model.");
+DEFINE_string(model_file, "__model__", "The name of a file with model.");
+DEFINE_string(params_file, "",
+              "The name of a single file with model parameters. By default "
+              "parameters are stored in separate files.");
+DEFINE_string(data_list, "", "Path to a file with a list of image files.");
+DEFINE_string(data_dir, "", "Path to a directory with image files.");
+DEFINE_int32(batch_size, 1, "Batch size.");
+DEFINE_int32(iterations, 1, "How many times to repeat run.");
+DEFINE_int32(skip_batch_num, 0, "How many minibatches to skip in statistics.");
+DEFINE_bool(use_fake_data, false, "Use fake data (1,2,...).");
+DEFINE_bool(with_mkldnn, false, "Use MKL-DNN.");
+DEFINE_bool(skip_passes, false, "Skip running passes.");
+DEFINE_bool(enable_graphviz, false,
+            "Enable graphviz to get .dot files with data flow graphs.");
+DEFINE_bool(debug_display_images, false, "Show images in windows for debug.");
+DEFINE_bool(with_labels, true, "The infer model do handle data labels.");
+DEFINE_bool(profile, false, "Turn on profiler for fluid");
+DEFINE_int32(num_threads, 1, "Number of threads for each paddle instance.");
+// dimensions of imagenet images are assumed as default:
+DEFINE_int32(resize_size, 256,
+             "Images are resized to make smaller side have length resize_size "
+             "while keeping aspect ratio.");
+DEFINE_int32(crop_size, 224,
+             "Resized images are cropped to crop_size x crop_size.");
+DEFINE_int32(channels, 3, "Width of the image.");
+
+namespace {
+class Timer {
+ public:
+  std::chrono::high_resolution_clock::time_point start;
+  std::chrono::high_resolution_clock::time_point startu;
+
+  void tic() { start = std::chrono::high_resolution_clock::now(); }
+  double toc() {
+    startu = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> time_span =
+        std::chrono::duration_cast<std::chrono::duration<double>>(startu -
+                                                                  start);
+    double used_time_ms = static_cast<double>(time_span.count()) * 1000.0;
+    return used_time_ms;
+  }
+};
+}  // namespace
+
+namespace paddle {
+
+void PrintInfo() {
+  std::cout << std::endl
+            << "--- Used Parameters: -----------------" << std::endl
+            << "Inference model: " << FLAGS_infer_model << std::endl
+            << "Model file: " << FLAGS_model_file << std::endl
+            << "Params file: " << FLAGS_params_file << std::endl
+            << "File with list of images: " << FLAGS_data_list << std::endl
+            << "Directory with images: " << FLAGS_data_dir << std::endl
+            << "Batch size: " << FLAGS_batch_size << std::endl
+            << "Number of threads: " << FLAGS_num_threads << std::endl
+            << "Iterations: " << FLAGS_iterations << std::endl
+            << "Number of batches to skip: " << FLAGS_skip_batch_num
+            << std::endl
+            << "Use fake data: " << FLAGS_use_fake_data << std::endl
+            << "Use MKL-DNN: " << FLAGS_with_mkldnn << std::endl
+            << "Skip passes: " << FLAGS_skip_passes << std::endl
+            << "Debug display image: " << FLAGS_debug_display_images
+            << std::endl
+            << "Profile: " << FLAGS_profile << std::endl
+            << "With labels: " << FLAGS_with_labels << std::endl
+            << "Channels: " << FLAGS_channels << std::endl
+            << "Resize size: " << FLAGS_resize_size << std::endl
+            << "Crop size: " << FLAGS_crop_size << std::endl
+            << "Enable graphviz: " << FLAGS_enable_graphviz << std::endl
+            << "--------------------------------------" << std::endl;
+}
+
+// Count elements of a tensor from its shape vector
+size_t Count(const std::vector<int>& shapevec) {
+  auto sum = shapevec.size() > 0 ? 1 : 0;
+  for (unsigned int i = 0; i < shapevec.size(); ++i) {
+    sum *= shapevec[i];
+  }
+  return sum;
+}
+
+paddle::PaddleTensor DefineInputData() {
+  std::vector<int> shape;
+  shape.push_back(FLAGS_batch_size);
+  shape.push_back(FLAGS_channels);
+  shape.push_back(FLAGS_crop_size);
+  shape.push_back(FLAGS_crop_size);
+  paddle::PaddleTensor data;
+  data.name = "xx";
+  data.shape = shape;
+  data.data.Resize(Count(shape) * sizeof(float));
+  data.dtype = PaddleDType::FLOAT32;
+  return data;
+}
+
+paddle::PaddleTensor DefineInputLabels() {
+  paddle::PaddleTensor labels;
+  labels.name = "yy";
+  labels.shape = std::vector<int>({FLAGS_batch_size, 1});
+  labels.data.Resize(FLAGS_batch_size * sizeof(int64_t));
+  labels.dtype = paddle::PaddleDType::INT64;
+  return labels;
+}
+
+template <typename T>
+void fill_data(T* data, unsigned int count) {
+  for (unsigned int i = 0; i < count; ++i) {
+    *(data + i) = i;
+  }
+}
+
+template <>
+void fill_data<float>(float* data, unsigned int count) {
+  static unsigned int seed = std::random_device()();
+  static std::minstd_rand engine(seed);
+  float mean = 0;
+  float std = 1;
+  std::normal_distribution<float> dist(mean, std);
+  for (unsigned int i = 0; i < count; ++i) {
+    data[i] = dist(engine);
+  }
+}
+
+void CreateFakeData(PaddleTensor& input_data, PaddleTensor& input_labels) {
+  fill_data<float>(static_cast<float*>(input_data.data.data()),
+                   Count(input_data.shape));
+  int labels_size = FLAGS_batch_size;
+  if (FLAGS_with_labels) {
+    // create fake labels
+    fill_data<int64_t>(static_cast<int64_t*>(input_labels.data.data()),
+                       labels_size);
+  }
+}
+
+void InitializeReader(std::unique_ptr<ImageReader>& reader,
+                      bool convert_to_rgb) {
+  reader.reset(new ImageReader(FLAGS_data_list, FLAGS_data_dir,
+                               FLAGS_resize_size, FLAGS_crop_size,
+                               FLAGS_channels, convert_to_rgb));
+  if (!reader->SetSeparator('\t')) reader->SetSeparator(' ');
+}
+
+bool ReadNextBatch(PaddleTensor& input_data, PaddleTensor& input_labels,
+                   std::unique_ptr<ImageReader>& reader) {
+  return reader->NextBatch(static_cast<float*>(input_data.data.data()),
+                           FLAGS_with_labels
+                               ? static_cast<int64_t*>(input_labels.data.data())
+                               : nullptr,
+                           FLAGS_batch_size, FLAGS_debug_display_images);
+}
+
+void PrepareConfig(contrib::AnalysisConfig& config) {
+  config.prog_file = FLAGS_infer_model + "/" + FLAGS_model_file;
+  if (!FLAGS_params_file.empty()) {
+    config.param_file = FLAGS_infer_model + "/" + FLAGS_params_file;
+  } else {
+    config.model_dir = FLAGS_infer_model;
+  }
+  config.use_gpu = false;
+  config.device = 0;
+  config.enable_ir_optim = !FLAGS_skip_passes;
+  config.specify_input_name = false;
+  config.SetCpuMathLibraryNumThreads(FLAGS_num_threads);
+  if (FLAGS_with_mkldnn) config.EnableMKLDNN();
+
+  // remove all passes so that we can add them in correct order
+  for (int i = config.pass_builder()->AllPasses().size() - 1; i >= 0; i--)
+    config.pass_builder()->DeletePass(i);
+
+  // add passes
+  config.pass_builder()->AppendPass("infer_clean_graph_pass");
+  if (FLAGS_with_mkldnn) {
+    // add passes to execute with MKL-DNN
+    config.pass_builder()->AppendPass("mkldnn_placement_pass");
+    config.pass_builder()->AppendPass("depthwise_conv_mkldnn_pass");
+    config.pass_builder()->AppendPass("conv_bn_fuse_pass");
+    config.pass_builder()->AppendPass("conv_eltwiseadd_bn_fuse_pass");
+    config.pass_builder()->AppendPass("conv_bias_mkldnn_fuse_pass");
+    config.pass_builder()->AppendPass("conv_elementwise_add_mkldnn_fuse_pass");
+    config.pass_builder()->AppendPass("conv_relu_mkldnn_fuse_pass");
+    config.pass_builder()->AppendPass("fc_fuse_pass");
+    config.pass_builder()->AppendPass("is_test_pass");
+  } else {
+    // add passes to execute keeping the order - without MKL-DNN
+    config.pass_builder()->AppendPass("conv_bn_fuse_pass");
+    config.pass_builder()->AppendPass("fc_fuse_pass");
+  }
+
+  if (FLAGS_enable_graphviz) config.pass_builder()->TurnOnDebug();
+}
+
+void Main() {
+  PrintInfo();
+
+  if (FLAGS_batch_size <= 0)
+    throw std::invalid_argument(
+        "The batch_size option is less than or equal to 0.");
+  if (FLAGS_iterations <= 0)
+    throw std::invalid_argument(
+        "The iterations option is less than or equal to 0.");
+  if (FLAGS_skip_batch_num < 0)
+    throw std::invalid_argument("The skip_batch_num option is less than 0.");
+  struct stat sb;
+  if (stat(FLAGS_infer_model.c_str(), &sb) != 0 || !S_ISDIR(sb.st_mode)) {
+    throw std::invalid_argument(
+        "The inference model directory does not exist.");
+  }
+  if (FLAGS_with_labels && FLAGS_use_fake_data)
+    throw std::invalid_argument("Cannot use fake data for accuracy measuring.");
+
+  paddle::PaddleTensor input_data = DefineInputData();
+  paddle::PaddleTensor input_labels = DefineInputLabels();
+
+  // reader instance for real data
+  std::unique_ptr<ImageReader> reader;
+  bool convert_to_rgb = true;
+
+  // read the first batch
+  if (FLAGS_use_fake_data) {
+    CreateFakeData(input_data, input_labels);
+  } else {
+    InitializeReader(reader, convert_to_rgb);
+    if (!ReadNextBatch(input_data, input_labels, reader)) {
+      throw std::invalid_argument(
+          "Batch size cannot be bigger than dataset size.");
+    }
+  }
+
+  // configure predictor
+  contrib::AnalysisConfig config;
+  PrepareConfig(config);
+
+  auto predictor = CreatePaddlePredictor<contrib::AnalysisConfig,
+                                         PaddleEngineKind::kAnalysis>(config);
+
+  if (FLAGS_profile) {
+    auto pf_state = paddle::platform::ProfilerState::kCPU;
+    paddle::platform::EnableProfiler(pf_state);
+  }
+
+  // define output
+  std::vector<PaddleTensor> output_slots;
+
+  // run prediction
+  Timer timer;
+  Timer timer_total;
+  Stats stats(FLAGS_batch_size, FLAGS_skip_batch_num);
+  for (int i = 0; i < FLAGS_iterations + FLAGS_skip_batch_num; i++) {
+    // start gathering performance data after `skip_batch_num` iterations
+    if (i == FLAGS_skip_batch_num) {
+      timer_total.tic();
+      if (FLAGS_profile) {
+        paddle::platform::ResetProfiler();
+      }
+    }
+
+    // read next batch of data
+    if (i > 0 && !FLAGS_use_fake_data) {
+      if (!ReadNextBatch(input_data, input_labels, reader)) {
+        std::cout << "No more full batches. Stopping." << std::endl;
+        break;
+      }
+    }
+
+    // display images from batch if requested
+    if (FLAGS_debug_display_images)
+      ImageReader::drawImages(static_cast<float*>(input_data.data.data()),
+                              convert_to_rgb, FLAGS_batch_size, FLAGS_channels,
+                              FLAGS_crop_size, FLAGS_crop_size);
+
+    // define input
+    std::vector<PaddleTensor> input;
+    if (FLAGS_with_labels)
+      input = {input_data, input_labels};
+    else
+      input = {input_data};
+
+    // run inference
+    timer.tic();
+    if (!predictor->Run(input, &output_slots))
+      throw std::runtime_error("Prediction failed.");
+    double batch_time = timer.toc() / 1000;
+
+    // gather statistics from the iteration
+    stats.Gather(output_slots, batch_time, i);
+  }
+
+  if (FLAGS_profile) {
+    paddle::platform::DisableProfiler(paddle::platform::EventSortingKey::kTotal,
+                                      "/tmp/profiler");
+  }
+
+  // postprocess statistics from all iterations
+  double total_samples = FLAGS_iterations * FLAGS_batch_size;
+  double total_time = timer_total.toc() / 1000;
+  stats.Postprocess(total_time, total_samples);
+}
+
+}  // namespace paddle
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  try {
+    paddle::Main();
+  } catch (const std::exception& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return 0;
+}

--- a/paddle/fluid/inference/api/demo_ci/run.sh
+++ b/paddle/fluid/inference/api/demo_ci/run.sh
@@ -5,7 +5,7 @@ TEST_GPU_CPU=$3 # test both GPU/CPU mode or only CPU mode
 DATA_DIR=$4 # dataset
 TENSORRT_INCLUDE_DIR=$5 # TensorRT header file dir, defalut to /usr/local/TensorRT/include
 TENSORRT_LIB_DIR=$6 # TensorRT lib file dir, default to /usr/local/TensorRT/lib
-inference_install_dir=${PADDLE_ROOT}/build/fluid_inference_install_dir
+inference_install_dir=${PADDLE_ROOT}/build/fluid_install_dir
 
 cd `dirname $0`
 current_dir=`pwd`
@@ -41,81 +41,89 @@ function download() {
   fi
   cd ..
 }
+
 mkdir -p $DATA_DIR
 cd $DATA_DIR
+
 vis_demo_list='se_resnext50 ocr mobilenet'
 for vis_demo_name in $vis_demo_list; do
   download $vis_demo_name
 done
 
+ic_model_list='ResNet50 SE-ResNeXt50 MobileNet-v1'
+
+build_demo() {
+  echo "WITH_STATIC_LIB: $WITH_STATIC_LIB"
+  . ${current_dir}/build.sh $1 $PADDLE_ROOT $TURN_ON_MKL $TEST_GPU_CPU $WITH_STATIC_LIB $TENSORRT_INCLUDE_DIR $TENSORRT_LIB_DIR
+}
+
 # compile and test the demo
 cd $current_dir
-mkdir -p build
-cd build
 
 for WITH_STATIC_LIB in ON OFF; do
 # TODO(Superjomn) reopen this
 # something wrong with the TensorArray reset.
 :<<D
   # -----simple_on_word2vec-----
-  rm -rf *
-  cmake .. -DPADDLE_LIB=${inference_install_dir} \
-    -DWITH_MKL=$TURN_ON_MKL \
-    -DDEMO_NAME=simple_on_word2vec \
-    -DWITH_GPU=$TEST_GPU_CPU \
-    -DWITH_STATIC_LIB=$WITH_STATIC_LIB
-  make -j
+  build_demo simple_on_word2vec
   word2vec_model=$DATA_DIR'/word2vec/word2vec.inference.model'
   if [ -d $word2vec_model ]; then
     for use_gpu in $use_gpu_list; do
-      ./simple_on_word2vec \
-        --dirname=$word2vec_model \
-        --use_gpu=$use_gpu
+      ./build/simple_on_word2vec \
+	--dirname=$word2vec_model \
+	--use_gpu=$use_gpu
       if [ $? -ne 0 ]; then
-        echo "simple_on_word2vec demo runs fail."
-        exit 1
+	echo "simple_on_word2vec demo runs fail."
+	exit 1
       fi
     done
   fi
 D
+
   # ---------vis_demo---------
-  rm -rf *
-  cmake .. -DPADDLE_LIB=${inference_install_dir} \
-    -DWITH_MKL=$TURN_ON_MKL \
-    -DDEMO_NAME=vis_demo \
-    -DWITH_GPU=$TEST_GPU_CPU \
-    -DWITH_STATIC_LIB=$WITH_STATIC_LIB
-  make -j
+  build_demo vis_demo
   for use_gpu in $use_gpu_list; do
     for vis_demo_name in $vis_demo_list; do
-      ./vis_demo \
-        --modeldir=$DATA_DIR/$vis_demo_name/model \
-        --data=$DATA_DIR/$vis_demo_name/data.txt \
-        --refer=$DATA_DIR/$vis_demo_name/result.txt \
-        --use_gpu=$use_gpu
+      ./build/vis_demo \
+	--modeldir=$DATA_DIR/$vis_demo_name/model \
+	--data=$DATA_DIR/$vis_demo_name/data.txt \
+	--refer=$DATA_DIR/$vis_demo_name/result.txt \
+	--use_gpu=$use_gpu
       if [ $? -ne 0 ]; then
-        echo "vis demo $vis_demo_name runs fail."
-        exit 1
+	echo "vis demo $vis_demo_name runs fail."
+	exit 1
       fi
     done
   done
 
   # --------tensorrt mobilenet------
   if [ $USE_TENSORRT == ON -a $TEST_GPU_CPU == ON ]; then
-    rm -rf *
-    cmake .. -DPADDLE_LIB=${inference_install_dir} \
-      -DWITH_MKL=$TURN_ON_MKL \
-      -DDEMO_NAME=trt_mobilenet_demo \
-      -DWITH_GPU=$TEST_GPU_CPU \
-      -DWITH_STATIC_LIB=$WITH_STATIC_LIB \
-      -DUSE_TENSORRT=$USE_TENSORRT \
-      -DTENSORRT_INCLUDE_DIR=$TENSORRT_INCLUDE_DIR \
-      -DTENSORRT_LIB_DIR=$TENSORRT_LIB_DIR
-    make -j
-    ./trt_mobilenet_demo \
+    build_demo trt_mobilenet_demo
+    ./build/trt_mobilenet_demo \
       --modeldir=$DATA_DIR/mobilenet/model \
       --data=$DATA_DIR/mobilenet/data.txt \
       --refer=$DATA_DIR/mobilenet/result.txt 
   fi
+
+  #--------- infer_image_classification ---------
+  build_demo infer_image_classification
+  for ic_model in $ic_model_list; do
+    MODEL_DIR=${DATA_DIR}"/"${ic_model}
+    IMAGENET_DIR=$DATA_DIR"/ImageNet/"
+    if [ -d $MODEL_DIR -a -d $IMAGENET_DIR ]; then
+      ./build/infer_image_classification \
+        --infer_model=$MODEL_DIR \
+        --data_list=$IMAGENET_DIR"/val_list.txt" \
+        --data_dir=$IMAGENET_DIR \
+        --batch_size=50 \
+        --num_threads=14 \
+        --skip_batch_num=0 \
+        --iterations=10  \
+        --profile \
+        --with_mkldnn=1 \
+        --with_labels=1
+    fi
+  done
+    
 done
 set +x

--- a/paddle/fluid/inference/api/demo_ci/simple_on_word2vec.cc
+++ b/paddle/fluid/inference/api/demo_ci/simple_on_word2vec.cc
@@ -23,7 +23,7 @@ limitations under the License. */
 #include <memory>
 #include <thread>  //NOLINT
 
-#include "utils.h"  // NOLINT
+#include "utils/utils.h"  // NOLINT
 
 DEFINE_string(dirname, "", "Directory of the inference model.");
 DEFINE_bool(use_gpu, false, "Whether use gpu.");

--- a/paddle/fluid/inference/api/demo_ci/trt_mobilenet_demo.cc
+++ b/paddle/fluid/inference/api/demo_ci/trt_mobilenet_demo.cc
@@ -18,7 +18,7 @@ limitations under the License. */
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>  // use glog instead of CHECK to avoid importing other paddle header files.
-#include "utils.h"  // NOLINT
+#include "utils/utils.h"  // NOLINT
 
 DECLARE_double(fraction_of_gpu_memory_to_use);
 DEFINE_string(modeldir, "", "Directory of the inference model.");

--- a/paddle/fluid/inference/api/demo_ci/utils/image_reader.cc
+++ b/paddle/fluid/inference/api/demo_ci/utils/image_reader.cc
@@ -1,0 +1,206 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "image_reader.h"
+#include <sys/stat.h>
+#include <fstream>
+#include <opencv2/opencv.hpp>
+#include <string>
+// #include "paddle/fluid/inference/api/helper.h"
+
+namespace paddle {
+
+namespace {
+
+cv::Mat center_crop_image(cv::Mat img, int width, int height) {
+  auto w_start = (img.cols - width) / 2;
+  auto h_start = (img.rows - height) / 2;
+
+  cv::Rect roi(w_start, h_start, width, height);
+  return img(roi);
+}
+
+cv::Mat resize_short(cv::Mat img, int target_size) {
+  auto percent = static_cast<float>(target_size) / std::min(img.cols, img.rows);
+  auto resized_width = static_cast<int>(round(img.cols * percent));
+  auto resized_height = static_cast<int>(round(img.rows * percent));
+  cv::Mat resized_img;
+  cv::resize(img, resized_img, cv::Size(resized_width, resized_height), 0, 0,
+             cv::INTER_LANCZOS4);
+  return resized_img;
+}
+
+static void split(const std::string& str, char sep,
+                  std::vector<std::string>* pieces) {
+  pieces->clear();
+  if (str.empty()) {
+    return;
+  }
+  size_t pos = 0;
+  size_t next = str.find(sep, pos);
+  while (next != std::string::npos) {
+    pieces->push_back(str.substr(pos, next - pos));
+    pos = next + 1;
+    next = str.find(sep, pos);
+  }
+  if (!str.substr(pos).empty()) {
+    pieces->push_back(str.substr(pos));
+  }
+}
+
+}  // namespace
+
+void ImageReader::drawImages(float* input, bool is_rgb, int batch_size,
+                             int channels, int width, int height) {
+  for (int b = 0; b < batch_size; b++) {
+    std::vector<cv::Mat> fimage_channels;
+    for (int c = 0; c < channels; c++) {
+      fimage_channels.emplace_back(
+          cv::Size(width, height), CV_32FC1,
+          input + width * height * c + width * height * channels * b);
+    }
+    cv::Mat mat;
+    if (is_rgb) {
+      std::swap(fimage_channels[0], fimage_channels[2]);
+    }
+    cv::merge(fimage_channels, mat);
+    cv::imshow(std::to_string(b) + " output image", mat);
+  }
+  std::cout << "Press any key in image window or close it to continue"
+            << std::endl;
+  cv::waitKey(0);
+}
+
+ImageReader::ImageReader(const std::string& data_list_path,
+                         const std::string& data_dir_path, int resize_size,
+                         int crop_size, int channels, bool convert_to_rgb)
+    : data_list_path(data_list_path),
+      data_dir_path(data_dir_path),
+      file(data_list_path),
+      resize_size(resize_size),
+      crop_size(crop_size),
+      channels(channels),
+      convert_to_rgb(convert_to_rgb) {
+  if (!file.is_open()) {
+    throw std::invalid_argument("Cannot open data list file " + data_list_path);
+  }
+
+  if (data_dir_path.empty()) {
+    throw std::invalid_argument("Data directory must be set to use imagenet.");
+  }
+
+  struct stat sb;
+  if (stat(data_dir_path.c_str(), &sb) != 0 || !S_ISDIR(sb.st_mode)) {
+    throw std::invalid_argument("Data directory does not exist.");
+  }
+
+  if (channels != 3) {
+    throw std::invalid_argument("Only 3 channel image loading supported");
+  }
+
+  if (resize_size < crop_size) {
+    std::stringstream ss;
+    ss << "resize_size (" << resize_size
+       << ") must be greater or equal (>=) crop_size (" << crop_size << ") ."
+       << std::endl;
+    throw std::invalid_argument(ss.str());
+  }
+}
+
+// return true if separator works or false otherwise
+bool ImageReader::SetSeparator(char separator) {
+  sep = separator;
+
+  std::string line;
+  auto position = file.tellg();
+  std::getline(file, line);
+  file.clear();
+  file.seekg(position);
+
+  // test out
+  std::vector<std::string> pieces;
+  split(line, separator, &pieces);
+
+  return (pieces.size() == 2);
+}
+
+bool ImageReader::NextBatch(float* input, int64_t* label, int batch_size,
+                            bool debug_display_images) {
+  std::string line;
+
+  for (int i = 0; i < batch_size; i++) {
+    if (!std::getline(file, line)) return false;
+
+    std::vector<std::string> pieces;
+    split(line, sep, &pieces);
+    if (pieces.size() != 2) {
+      std::stringstream ss;
+      ss << "invalid number of separators '" << sep << "' found in line " << i
+         << ":'" << line << "' of file " << data_list_path;
+      throw std::runtime_error(ss.str());
+    }
+
+    auto filename = data_dir_path + pieces.at(0);
+    if (label != nullptr) label[i] = std::stoi(pieces.at(1));
+
+    cv::Mat image = cv::imread(filename, cv::IMREAD_COLOR);
+
+    if (image.data == nullptr) {
+      std::string error_msg = "Couldn't open file " + filename;
+      throw std::runtime_error(error_msg);
+    }
+
+    if (convert_to_rgb) {
+      cv::cvtColor(image, image, CV_BGR2RGB);
+    }
+
+    if (debug_display_images)
+      cv::imshow(std::to_string(i) + " input image", image);
+
+    cv::Mat image_resized = resize_short(image, resize_size);
+    cv::Mat image_cropped =
+        center_crop_image(image_resized, crop_size, crop_size);
+
+    cv::Mat fimage;
+    image_cropped.convertTo(fimage, CV_32FC3);
+
+    fimage /= 255.f;
+
+    cv::Scalar mean(0.406f, 0.456f, 0.485f);
+    cv::Scalar std(0.225f, 0.224f, 0.229f);
+
+    if (convert_to_rgb) {
+      std::swap(mean[0], mean[2]);
+      std::swap(std[0], std[2]);
+    }
+
+    std::vector<cv::Mat> fimage_channels;
+    cv::split(fimage, fimage_channels);
+
+    for (int c = 0; c < channels; c++) {
+      fimage_channels[c] -= mean[c];
+      fimage_channels[c] /= std[c];
+      for (int row = 0; row < fimage.rows; ++row) {
+        const float* fimage_begin = fimage_channels[c].ptr<const float>(row);
+        const float* fimage_end = fimage_begin + fimage.cols;
+        std::copy(fimage_begin, fimage_end,
+                  input + row * fimage.cols + c * fimage.cols * fimage.rows +
+                      i * 3 * fimage.cols * fimage.rows);
+      }
+    }
+  }
+  return true;
+}
+
+}  // namespace paddle

--- a/paddle/fluid/inference/api/demo_ci/utils/image_reader.h
+++ b/paddle/fluid/inference/api/demo_ci/utils/image_reader.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace paddle {
+
+// Image data reader for imagenet for ResNet50, SE-ResNeXt50, MobileNet
+struct ImageReader {
+  static void drawImages(float* input, bool is_rgb, int batch_size,
+                         int channels, int width, int height);
+
+  explicit ImageReader(const std::string& data_list_path,
+                       const std::string& data_dir_path, int width, int height,
+                       int channels, bool convert_to_rgb);
+
+  // return true if separator works or false otherwise
+  bool SetSeparator(char separator);
+
+  bool NextBatch(float* input, int64_t* label, int batch_size,
+                 bool debug_display_images);
+
+ private:
+  std::string data_list_path;
+  std::string data_dir_path;
+  std::ifstream file;
+  int resize_size;
+  int crop_size;
+  int channels;
+  bool convert_to_rgb;
+  char sep{'\t'};
+};
+
+}  // namespace paddle

--- a/paddle/fluid/inference/api/demo_ci/utils/stats.cc
+++ b/paddle/fluid/inference/api/demo_ci/utils/stats.cc
@@ -1,0 +1,145 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stats.h"
+#include <iostream>
+#include <sstream>
+#include "paddle/fluid/framework/ir/pass.h"
+
+namespace paddle {
+
+namespace {
+
+template <typename T>
+void SkipFirstNData(std::vector<T>& v, int n) {
+  std::vector<T>(v.begin() + n, v.end()).swap(v);
+}
+
+template <typename T>
+T FindAverage(const std::vector<T>& v) {
+  if (v.size() == 0)
+    throw std::invalid_argument("FindAverage: vector is empty.");
+  return std::accumulate(v.begin(), v.end(), 0.0) / v.size();
+}
+
+template <typename T>
+T FindPercentile(std::vector<T> v, int p) {
+  if (v.size() == 0)
+    throw std::invalid_argument("FindPercentile: vector is empty.");
+  std::sort(v.begin(), v.end());
+  if (p == 100) return v.back();
+  int i = v.size() * p / 100;
+  return v[i];
+}
+
+template <typename T>
+T FindStandardDev(std::vector<T> v) {
+  if (v.size() == 0)
+    throw std::invalid_argument("FindStandardDev: vector is empty.");
+  T mean = FindAverage(v);
+  T var = 0;
+  for (size_t i = 0; i < v.size(); ++i) {
+    var += (v[i] - mean) * (v[i] - mean);
+  }
+  var /= v.size();
+  T std = sqrt(var);
+  return std;
+}
+
+}  // namespace
+
+// gather statistics from the output
+void Stats::Gather(const std::vector<PaddleTensor>& output_slots,
+                   double batch_time,
+                   int iter) {
+  latencies.push_back(batch_time);
+  double fps = batch_size / batch_time;
+  fpses.push_back(fps);
+
+  std::stringstream ss;
+  ss << "Iteration: " << iter + 1;
+  if (iter < skip_batch_num) ss << " (warm-up)";
+  // use standard float formatting
+  ss << std::fixed << std::setw(11) << std::setprecision(6);
+
+  // first output: avg_cost
+  if (output_slots.size() == 0)
+    throw std::invalid_argument("Gather: output_slots vector is empty.");
+  if (output_slots.size() >= 2UL) {  // acc_top1
+    // second output: acc_top1
+    if (output_slots[1].lod.size() > 0)
+      throw std::invalid_argument(
+          "Gather: top1 accuracy output has nonempty LoD.");
+    if (output_slots[1].dtype != paddle::PaddleDType::FLOAT32)
+      throw std::invalid_argument(
+          "Gather: top1 accuracy output is of a wrong type.");
+    float* acc1 = static_cast<float*>(output_slots[1].data.data());
+    infer_accs1.push_back(*acc1);
+    ss << ", accuracy: " << *acc1;
+  }
+  if (output_slots.size() >= 3UL) {  // acc_top5
+    // third output: acc_top5
+    if (output_slots[2].lod.size() > 0)
+      throw std::invalid_argument(
+          "Gather: top5 accuracy output has nonempty LoD.");
+    if (output_slots[2].dtype != paddle::PaddleDType::FLOAT32)
+      throw std::invalid_argument(
+          "Gather: top5 accuracy output is of a wrong type.");
+    float* acc5 = static_cast<float*>(output_slots[2].data.data());
+    infer_accs5.push_back(*acc5);
+  }
+  ss << ", latency: " << batch_time << " s, fps: " << fps;
+  std::cout << ss.str() << std::endl;
+}
+
+// postprocess statistics from the whole test
+void Stats::Postprocess(double total_time_sec, int total_samples) {
+  SkipFirstNData(latencies, skip_batch_num);
+  double lat_avg = FindAverage(latencies);
+  double lat_pc99 = FindPercentile(latencies, 99);
+  double lat_std = FindStandardDev(latencies);
+
+  SkipFirstNData(fpses, skip_batch_num);
+  double fps_avg = FindAverage(fpses);
+  double fps_pc01 = FindPercentile(fpses, 1);
+  double fps_std = FindStandardDev(fpses);
+
+  float examples_per_sec = total_samples / total_time_sec;
+  std::stringstream ss;
+  // use standard float formatting
+  ss << std::fixed << std::setw(11) << std::setprecision(6);
+  ss << "\n";
+  ss << "Avg fps: " << fps_avg << ", std fps: " << fps_std
+     << ", fps for 99pc latency: " << fps_pc01 << std::endl;
+  ss << "Avg latency: " << lat_avg << ", std latency: " << lat_std
+     << ", 99pc latency: " << lat_pc99 << std::endl;
+  ss << "Total examples: " << total_samples
+     << ", total time: " << total_time_sec
+     << ", total examples/sec: " << examples_per_sec << std::endl;
+
+  if (infer_accs1.size() > 0) {
+    SkipFirstNData(infer_accs1, skip_batch_num);
+    float acc1_avg = FindAverage(infer_accs1);
+    ss << "Avg top1 accuracy: " << acc1_avg << std::endl;
+  }
+
+  if (infer_accs5.size() > 0) {
+    SkipFirstNData(infer_accs5, skip_batch_num);
+    float acc5_avg = FindAverage(infer_accs5);
+    ss << "Avg top5 accuracy: " << acc5_avg << std::endl;
+  }
+  std::cout << ss.str() << std::endl;
+}
+
+}  // namespace paddle

--- a/paddle/fluid/inference/api/demo_ci/utils/stats.h
+++ b/paddle/fluid/inference/api/demo_ci/utils/stats.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <gflags/gflags.h>
+#include <vector>
+#include "paddle/fluid/inference/paddle_inference_api.h"
+
+namespace paddle {
+
+struct Stats {
+  explicit Stats(int32_t batch_size, int32_t skip_batch_num)
+      : batch_size(batch_size), skip_batch_num(skip_batch_num){};
+
+  void Gather(const std::vector<PaddleTensor>& output_slots,
+              double batch_time,
+              int iter);
+  void Postprocess(double total_time_sec, int total_samples);
+
+  std::vector<double> latencies;
+  std::vector<float> infer_accs1;
+  std::vector<float> infer_accs5;
+  std::vector<double> fpses;
+  int32_t batch_size;
+  int32_t skip_batch_num;
+};
+
+}  // namespace paddle

--- a/paddle/fluid/inference/api/demo_ci/utils/utils.h
+++ b/paddle/fluid/inference/api/demo_ci/utils/utils.h
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
-#include "paddle/include/paddle_inference_api.h"
+#include "paddle/fluid/inference/paddle_inference_api.h"
 
 namespace paddle {
 namespace demo {

--- a/paddle/fluid/inference/api/demo_ci/vis_demo.cc
+++ b/paddle/fluid/inference/api/demo_ci/vis_demo.cc
@@ -18,7 +18,7 @@ limitations under the License. */
 
 #include <gflags/gflags.h>
 #include <glog/logging.h>
-#include "utils.h"  // NOLINT
+#include "utils/utils.h"  // NOLINT
 
 #ifdef PADDLE_WITH_CUDA
 DECLARE_double(fraction_of_gpu_memory_to_use);


### PR DESCRIPTION
This patch adds a demo C-API application for image classification models evaluation.

The `infer_image_classification` application works fine with ResNet50, SE-ResNeXt50 and MobileNet-v1 models containing accuracy and topk layers so accuracy values could be calculated. It is also assumed the ImageNet dataset is available. 