### PR TITLE
Fix for accuracy problem for inplace operators when MKL-DNN mode is enabled

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -749,7 +749,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx));
 
-  if (!transfered_inplace_vars.empty()) {
+  if (run_by_executor_ && !transfered_inplace_vars.empty()) {
     // there is inplace variable has been transfered.
     TransferInplaceVarsBack(scope, transfered_inplace_vars, *transfer_scope);
   }
@@ -771,6 +771,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
     }
   }
 }
+
 void OperatorWithKernel::TransferInplaceVarsBack(
     const Scope& scope, const std::vector<std::string>& inplace_vars,
     const Scope& transfer_scope) const {


### PR DESCRIPTION
This fix eliminates accuracy problem for inplace operators (e.g. ReLu) when MKL-DNN mode is enabled

test=develop