### PR TITLE
Revert "Fix for accuracy problem for inplace operators when MKL-DNN mode is enabled"

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -754,7 +754,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx));
 
-  if (run_by_executor_ && !transfered_inplace_vars.empty()) {
+  if (!transfered_inplace_vars.empty()) {
     // there is inplace variable has been transfered.
     TransferInplaceVarsBack(scope, transfered_inplace_vars, *transfer_scope);
   }
@@ -776,7 +776,6 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
     }
   }
 }
-
 void OperatorWithKernel::TransferInplaceVarsBack(
     const Scope& scope, const std::vector<std::string>& inplace_vars,
     const Scope& transfer_scope) const {


### PR DESCRIPTION
Reverts PaddlePaddle/Paddle#14693
The reason is that object_detection fails on http://ce.paddlepaddle.org:8080/viewLog.html?buildId=5532&buildTypeId=PaddleCe_CEBuild&tab=buildChangesDiv