### PR TITLE
Fix pow op

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -271,7 +271,7 @@ class GradientClipByGlobalNorm(BaseGradientClipAttr):
                     "All parameters' 'clip_norm' of a same group should be the same"
                 )
 
-        square = grad * grad
+        square = layers.pow(grad, 2)
         local_norm_var = layers.reduce_sum(input=square)
         context[self.group_name].append(local_norm_var)
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7054,13 +7054,16 @@ def pow(x, factor=1.0, name=None):
             x = fluid.layers.data(name="x", shape=[3,10,32,32], dtype="float32")
             y = fluid.layers.pow(x, factor=2.0)
     """
+    assert factor == int(
+        factor
+    ) and factor > 1, "Currently the factor must be an integer, and it's value must be greater than 1."
     helper = LayerHelper('pow', **locals())
     out = helper.create_variable_for_type_inference(dtype=x.dtype)
     helper.append_op(
         type='pow',
         inputs={'X': x},
         outputs={'Out': out},
-        attrs={'factor': factor})
+        attrs={'factor': float(factor)})
     return out
 
 

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -460,7 +460,7 @@ class TestPow(TestActivation):
         self.op_type = "pow"
         self.init_dtype()
 
-        x = np.random.uniform(1, 2, [11, 17]).astype(self.dtype)
+        x = np.random.uniform(-2, 2, [11, 17]).astype(self.dtype)
         out = np.power(x, 3)
 
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}


### PR DESCRIPTION
Temporarily fix pow_op bug. The original implementation of pow_op will get NaN when the use_fast_math is open and the x is negative. 
But some model need use `pow_2`, to ensure the result is right, this PR adds constrains for the factor of pow_op, i.e. the factor must be a positive integer. 

The finally solution is disable `use_fast_math`.