### PR TITLE
Solve accuracy problem for inplace operators when MKL-DNN mode is enabled

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -760,6 +760,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx));
 
+  // Transfer variables for inplace operators is not allowed when MKL-DNN
+  // mode is enabled.
   if (expected_kernel_key.library_type_ != LibraryType::kMKLDNN &&
       run_by_executor_ && !transfered_inplace_vars.empty()) {
     // there is inplace variable has been transfered.

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -760,7 +760,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx));
 
-  if (!transfered_inplace_vars.empty()) {
+  if (expected_kernel_key.library_type_ != LibraryType::kMKLDNN &&
+      run_by_executor_ && !transfered_inplace_vars.empty()) {
     // there is inplace variable has been transfered.
     TransferInplaceVarsBack(scope, transfered_inplace_vars, *transfer_scope);
   }
@@ -782,6 +783,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
     }
   }
 }
+
 void OperatorWithKernel::TransferInplaceVarsBack(
     const Scope& scope, const std::vector<std::string>& inplace_vars,
     const Scope& transfer_scope) const {


### PR DESCRIPTION
This PR is important to improve SE-ResNeXt accuracy when MKL-DNN mode is enabled.

test=develop