### PR TITLE
One possible solution to add flexibility for mkldnn placement pass

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn_placement_pass.cc
@@ -18,12 +18,20 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+
 std::unique_ptr<ir::Graph> MKLDNNPlacementPass::ApplyImpl(
     std::unique_ptr<ir::Graph> graph) const {
   VLOG(3) << "Aplies MKL-DNN placement strategy.";
+  const std::vector<std::string> op_list = Get<std::vector<std::string>>("mkldnn_op_list");
   for (const Node* n : graph->Nodes()) {
     if (n->IsOp() && n->Op()->HasAttr("use_mkldnn")) {
-      n->Op()->SetAttr("use_mkldnn", true);
+      if (op_list.empty()){
+          n->Op()->SetAttr("use_mkldnn", true);
+      }else{
+          if(std::find(op_list.begin(), op_list.end(), n->Name()) != op_list.end()){
+               n->Op()->SetAttr("use_mkldnn", true);
+          }
+      }
     }
   }
   return graph;
@@ -34,4 +42,5 @@ std::unique_ptr<ir::Graph> MKLDNNPlacementPass::ApplyImpl(
 }  // namespace paddle
 
 REGISTER_PASS(mkldnn_placement_pass,
-              paddle::framework::ir::MKLDNNPlacementPass);
+              paddle::framework::ir::MKLDNNPlacementPass)
+     .RequirePassAttr("mkldnn_op_list");

--- a/paddle/fluid/inference/analysis/argument.h
+++ b/paddle/fluid/inference/analysis/argument.h
@@ -114,6 +114,7 @@ struct Argument {
   // The ir passes to perform in analysis phase.
   DECL_ARGUMENT_FIELD(ir_analysis_passes, IrAnalysisPasses,
                       std::vector<std::string>);
+  DECL_ARGUMENT_FIELD(mkldnn_op, MKLDNNOp, std::vector<std::string>); //Choose to enable mkldnn op
 
   DECL_ARGUMENT_FIELD(use_gpu, UseGPU, bool);
   DECL_ARGUMENT_FIELD(gpu_device_id, GPUDeviceId, int);

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -63,6 +63,9 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set("graph_viz_path", new std::string(std::move(dot_file_path)));
       pass_num++;
     }
+    if (pass_name == "mkldnn_placement_pass"){
+       pass->Set("mkldnn_op_list", new std::vector<std::string>(argument->mkldnn_op()));
+    }
 
     if (pass_name == "tensorrt_subgraph_pass") {
       PADDLE_ENFORCE(argument->tensorrt_node_teller_valid());

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -49,6 +49,10 @@ contrib::AnalysisConfig::AnalysisConfig(const contrib::AnalysisConfig &other) {
   cpu_math_library_num_threads_ = other.cpu_math_library_num_threads_;
   // fields from this.
   enable_ir_optim = other.enable_ir_optim;
+  // For mkldnn
+  use_mkldnn_ = other.use_mkldnn_;
+  mkldnn_op_ = other.mkldnn_op_;
+
   use_feed_fetch_ops = other.use_feed_fetch_ops;
   use_tensorrt_ = other.use_tensorrt_;
   tensorrt_max_batchsize_ = other.tensorrt_max_batchsize_;
@@ -76,6 +80,10 @@ contrib::AnalysisConfig::AnalysisConfig(contrib::AnalysisConfig &&other) {
   cpu_math_library_num_threads_ = other.cpu_math_library_num_threads_;
   // fields from this.
   enable_ir_optim = other.enable_ir_optim;
+  //For mkldnn 
+  use_mkldnn_= other.use_mkldnn_;
+  mkldnn_op_ = other.mkldnn_op_;
+
   use_feed_fetch_ops = other.use_feed_fetch_ops;
   use_tensorrt_ = other.use_tensorrt_;
   tensorrt_max_batchsize_ = other.tensorrt_max_batchsize_;

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -324,6 +324,8 @@ void AnalysisPredictor::OptimizeInferenceProgram() {
     argument_.SetUseTensorRT(true);
     argument_.SetTensorRtWorkspaceSize(config_.tensorrt_workspace_size_);
     argument_.SetTensorRtMaxBatchSize(config_.tensorrt_max_batchsize_);
+  }else if (config_.use_mkldnn()) {
+    argument_.SetMKLDNNOp(config_.mkldnn_op_);
   }
 
   auto passes = config_.pass_builder()->AllPasses();

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -324,9 +324,10 @@ void AnalysisPredictor::OptimizeInferenceProgram() {
     argument_.SetUseTensorRT(true);
     argument_.SetTensorRtWorkspaceSize(config_.tensorrt_workspace_size_);
     argument_.SetTensorRtMaxBatchSize(config_.tensorrt_max_batchsize_);
-  }else if (config_.use_mkldnn()) {
+  }else if(config_.use_mkldnn_){   
     argument_.SetMKLDNNOp(config_.mkldnn_op_);
   }
+  
 
   auto passes = config_.pass_builder()->AllPasses();
   if (!config_.enable_ir_optim) passes.clear();

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -55,12 +55,14 @@ struct AnalysisConfig : public NativeConfig {
   // NOTE this is just for internal development, please not use it.
   // NOT stable yet.
   bool use_mkldnn() const { return use_mkldnn_; }
+  void SetMKLDNNOp(std::vector<std::string> op_list){ mkldnn_op_ = op_list;}
 
   friend class ::paddle::AnalysisPredictor;
 
  protected:
   bool use_tensorrt_{false};
   bool use_mkldnn_{false};
+  std::vector<std::string> mkldnn_op_;
   int tensorrt_workspace_size_;
   int tensorrt_max_batchsize_;
   std::unique_ptr<PassStrategy> pass_builder_;

--- a/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
@@ -171,6 +171,9 @@ void SetConfig(contrib::AnalysisConfig *cfg) {
   cfg->device = 0;
   cfg->specify_input_name = true;
   cfg->enable_ir_optim = true;
+  cfg->EnableMKLDNN();
+  std::vector<std::string> op_list ={"conv3d"};
+  cfg->SetMKLDNNOp(op_list);
 }
 
 void SetInput(std::vector<std::vector<PaddleTensor>> *inputs) {

--- a/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
@@ -171,9 +171,6 @@ void SetConfig(contrib::AnalysisConfig *cfg) {
   cfg->device = 0;
   cfg->specify_input_name = true;
   cfg->enable_ir_optim = true;
-  cfg->EnableMKLDNN();
-  std::vector<std::string> op_list ={"conv3d"};
-  cfg->SetMKLDNNOp(op_list);
 }
 
 void SetInput(std::vector<std::vector<PaddleTensor>> *inputs) {


### PR DESCRIPTION
#14612 This PR proposed one solution to selectively turn on "use_mkldnn" attribute in mkldnn_placement_pass. 
After investigation, we found that we can add attribute to each pass. So we decided to pass a string vector named op_list which contains all the op names we want to enable by this attribute of pass. 
You can add the following code to test this functionality in line 177.  
``` C++
 if (use_mkldnn) {    
      cfg.EnableMKLDNN();  
      std::vector<std::string> op_list ={"conv3d"};  
      cfg.SetMKLDNNOp(op_list);  
 }
```
https://github.com/PaddlePaddle/Paddle/blob/e90afec47b0498e03950369323e4f85335c406f5/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc#L177

This test will enable just conv3d  mkldnn kernel in DAM model. Meanwhile, you can test it with resnet50 to make sure that this works well with resnet50 too.