### PR TITLE
[MKL-DNN ]Added transpose/transpose2 Op

### DIFF
--- a/paddle/fluid/operators/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/transpose_mkldnn_op.cc
@@ -1,0 +1,122 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+
+#include "paddle/fluid/framework/data_layout_transform.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/memory/malloc.h"
+#include "paddle/fluid/platform/mkldnn_reuse.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+using framework::DataLayout;
+
+template <typename T>
+class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
+ public:
+  void Compute(const paddle::framework::ExecutionContext& ctx) const override {
+    PADDLE_ENFORCE(paddle::platform::is_cpu_place(ctx.GetPlace()),
+                   "It must use CPUPlace.");
+    const bool is_test = ctx.Attr<bool>("is_test");
+    PADDLE_ENFORCE(
+        is_test == true,
+        "ConvTransposeMKLDNN works only for inference!. Set is_test = True");
+    auto& dev_ctx =
+        ctx.template device_context<paddle::platform::MKLDNNDeviceContext>();
+    const auto& mkldnn_engine = dev_ctx.GetEngine();
+    std::vector<int> axis = ctx.Attr<std::vector<int>>("axis");
+    int ndims = axis.size();
+    auto* input = ctx.Input<Tensor>("X");
+    auto* output = ctx.Output<Tensor>("Out");
+    const T* input_data = input->data<T>();
+
+    // TODO: Any layout support
+    // TODO: make it working for other inputs. Eg. analyze entry data itp
+    std::vector<int> nchw_tz = paddle::framework::vectorize2int(input->dims());
+
+    if (ndims == 1) {
+      output->ShareDataWith(*input);
+      return;
+    }
+
+    std::vector<int> nchw_axis(ndims, 0);
+    for (int i = 0; i < nchw_axis.size(); ++i) {
+      nchw_axis[i] = i;
+    }
+
+    this->TransposeKernel(ctx.GetPlace(), Axis2MemoryDesc(nchw_tz, axis),
+                          Axis2MemoryDesc(nchw_tz, nchw_axis), output,
+                          input_data, nchw_tz, mkldnn_engine);
+  }
+
+ protected:
+  mkldnn_memory_desc_t Axis2MemoryDesc(std::vector<int>& nchw_tz,
+                                       std::vector<int>& axis) const {
+    mkldnn_memory_desc_t mem_fmt;
+
+    mem_fmt.primitive_kind = mkldnn_memory;
+    mem_fmt.ndims = axis.size();
+    for (unsigned int i = 0; i < nchw_tz.size(); ++i) {
+      mem_fmt.dims[i] = nchw_tz[i];  // logical dimensions (nchw format,
+                                     // regardless physical layout)
+    }
+    mem_fmt.data_type = mkldnn_f32;
+    mem_fmt.format = mkldnn_blocked;
+
+    unsigned int total_stride = 1;
+    for (int i = nchw_tz.size() - 1; i >= 0; --i) {
+      mem_fmt.layout_desc.blocking.padding_dims[i] =
+          nchw_tz[i];  // logical dimensions (nchw format, regardless physical
+                       // layout)
+      mem_fmt.layout_desc.blocking.block_dims[i] = 1;
+      mem_fmt.layout_desc.blocking.offset_padding_to_data[i] = 0;  // no offset
+      mem_fmt.layout_desc.blocking.strides[0][axis[i]] = total_stride;
+      mem_fmt.layout_desc.blocking.strides[1][axis[i]] = 1;
+      total_stride *= nchw_tz[axis[i]];
+    }
+    mem_fmt.layout_desc.blocking.offset_padding = 0;  // no initial offset
+    return mem_fmt;
+  }
+
+  void TransposeKernel(platform::Place place, mkldnn_memory_desc_t md_o,
+                       mkldnn_memory_desc_t md_i,
+                       // mkldnn::memory::format fmt_i,
+                       Tensor* output, const T* data_i,
+                       std::vector<int>& nchw_dims,
+                       const mkldnn::engine& eng) const {
+    // Make Memory primitive descriptors
+    auto mpd_o = mkldnn::memory::primitive_desc(md_o, eng);
+    auto mpd_i = mkldnn::memory::primitive_desc(md_i, eng);
+
+    auto data_o = output->mutable_data<T>(
+        place, paddle::memory::Allocator::kDefault, mpd_o.get_size());
+
+    auto src = mkldnn::memory(mpd_i, const_cast<T*>(data_i));
+    auto dst = mkldnn::memory(mpd_o, data_o);
+
+    auto r = mkldnn::reorder(src, dst);
+    mkldnn::stream(mkldnn::stream::kind::eager).submit({r}).wait();
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OP_KERNEL(transpose2, MKLDNN, ::paddle::platform::CPUPlace,
+                   ops::TransposeMKLDNNOpKernel<float>);
+REGISTER_OP_KERNEL(transpose, MKLDNN, ::paddle::platform::CPUPlace,
+                   ops::TransposeMKLDNNOpKernel<float>);

--- a/paddle/fluid/operators/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/transpose_mkldnn_op.cc
@@ -48,7 +48,7 @@ class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     }
 
     std::vector<int> nchw_axis(ndims, 0);
-    for (int i = 0; i < nchw_axis.size(); ++i) {
+    for (size_t i = 0; i < nchw_axis.size(); ++i) {
       nchw_axis[i] = i;
     }
 

--- a/paddle/fluid/operators/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/transpose_mkldnn_op.cc
@@ -105,7 +105,7 @@ class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto data_o = output->mutable_data<T>(
         place, paddle::memory::Allocator::kDefault, mpd_o.get_size());
 
-    auto src = mkldnn::memory(mpd_i, const_cast<T*>(data_i));
+    auto src = mkldnn::memory(mpd_i, (T*)(data_i));
     auto dst = mkldnn::memory(mpd_o, data_o);
 
     auto r = mkldnn::reorder(src, dst);

--- a/paddle/fluid/operators/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/transpose_mkldnn_op.cc
@@ -56,9 +56,9 @@ class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     std::string data_format = ctx.Attr<std::string>("data_format");
 
     auto src_md =
-        data_format.compare("AnyLayout") == 0
+        input->format() != mkldnn::memory::format::nchw
             ? platform::MKLDNNMemDesc(nchw_tz, platform::MKLDNNGetDataType<T>(),
-                                      mkldnn::memory::format::any)
+                                      input->format())
             : Axis2MemoryDesc(nchw_tz, nchw_axis);
 
     this->TransposeKernel(ctx.GetPlace(), Axis2MemoryDesc(nchw_tz, axis),

--- a/paddle/fluid/operators/transpose_op.cc
+++ b/paddle/fluid/operators/transpose_op.cc
@@ -16,6 +16,10 @@ limitations under the License. */
 #include <string>
 #include <vector>
 
+#ifdef PADDLE_WITH_MKLDNN
+#include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
 namespace paddle {
 namespace operators {
 
@@ -53,11 +57,33 @@ class TransposeOp : public framework::OperatorWithKernel {
     }
     ctx->SetOutputDim("Out", out_dims);
   }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext &ctx) const override {
+    framework::LibraryType library_{framework::LibraryType::kPlain};
+    std::string data_format = ctx.Attr<std::string>("data_format");
+    framework::DataLayout layout_ = framework::StringToDataLayout(data_format);
+#ifdef PADDLE_WITH_MKLDNN
+    if (library_ == framework::LibraryType::kPlain &&
+        platform::CanMKLDNNBeUsed(ctx)) {
+      library_ = framework::LibraryType::kMKLDNN;
+      layout_ = framework::DataLayout::kMKLDNN;
+    }
+#endif
+    return framework::OpKernelType(
+        framework::ToDataType(ctx.Input<Tensor>("X")->type()), ctx.GetPlace(),
+        layout_, library_);
+  }
 };
 
 class TransposeOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
+    AddAttr<bool>("is_test",
+                  "(bool, default false) Set to true for inference only, false "
+                  "for training. Some layers may run faster when this is true.")
+        .SetDefault(false);
     AddInput(
         "X",
         "(Tensor) The input tensor, tensors with rank up to 6 are supported.");
@@ -67,6 +93,16 @@ class TransposeOpMaker : public framework::OpProtoAndCheckerMaker {
         "(vector<int>) A list of values, and the size of the list should be "
         "the same with the input tensor rank. This operator permutes the input "
         "tensor's axes according to the values given.");
+    AddAttr<bool>("use_mkldnn",
+                  "(bool, default false) Only used in mkldnn kernel")
+        .SetDefault(false);
+    AddAttr<std::string>(
+        "data_format",
+        "(string, default NCHW) Only used in "
+        "An optional string from: \"NHWC\", \"NCHW\". "
+        "Defaults to \"NHWC\". Specify the data format of the output data, "
+        "the input will be transformed automatically. ")
+        .SetDefault("AnyLayout");
     AddComment(R"DOC(
 Transpose Operator.
 
@@ -144,8 +180,19 @@ class Transpose2Op : public TransposeOp {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    return framework::OpKernelType(ctx.Input<framework::LoDTensor>("X")->type(),
-                                   ctx.device_context());
+    framework::LibraryType library_{framework::LibraryType::kPlain};
+    std::string data_format = ctx.Attr<std::string>("data_format");
+    framework::DataLayout layout_ = framework::StringToDataLayout(data_format);
+#ifdef PADDLE_WITH_MKLDNN
+    if (library_ == framework::LibraryType::kPlain &&
+        platform::CanMKLDNNBeUsed(ctx)) {
+      library_ = framework::LibraryType::kMKLDNN;
+      layout_ = framework::DataLayout::kMKLDNN;
+    }
+#endif
+    return framework::OpKernelType(
+        framework::ToDataType(ctx.Input<Tensor>("X")->type()), ctx.GetPlace(),
+        layout_, library_);
   }
 };
 

--- a/paddle/fluid/operators/transpose_op.cc
+++ b/paddle/fluid/operators/transpose_op.cc
@@ -71,9 +71,8 @@ class TransposeOp : public framework::OperatorWithKernel {
       layout_ = framework::DataLayout::kMKLDNN;
     }
 #endif
-    return framework::OpKernelType(
-        framework::ToDataType(ctx.Input<Tensor>("X")->type()), ctx.GetPlace(),
-        layout_, library_);
+    return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
+                                   ctx.GetPlace(), layout_, library_);
   }
 };
 
@@ -190,9 +189,8 @@ class Transpose2Op : public TransposeOp {
       layout_ = framework::DataLayout::kMKLDNN;
     }
 #endif
-    return framework::OpKernelType(
-        framework::ToDataType(ctx.Input<Tensor>("X")->type()), ctx.GetPlace(),
-        layout_, library_);
+    return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
+                                   ctx.GetPlace(), layout_, library_);
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/test_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_mkldnn_op.py
@@ -24,6 +24,7 @@ class TestTransposeMKLDNN(TestTransposeOp):
         self.op_type = "transpose2"
         self.use_mkldnn = True
         self.is_test = True
+        self.data_format = "NCHW"
         return
 
     def test_check_grad(self):

--- a/python/paddle/fluid/tests/unittests/test_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_mkldnn_op.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,66 +15,58 @@
 from __future__ import print_function
 
 import unittest
-import numpy as np
-from op_test import OpTest
+
+from test_transpose_op import TestTransposeOp
 
 
-class TestTransposeOp(OpTest):
-    def setUp(self):
-        self.init_op_type()
-        self.initTestCase()
-        self.inputs = {'X': np.random.random(self.shape).astype("float32")}
-        self.attrs = {
-            'axis': list(self.axis),
-            'use_mkldnn': self.use_mkldnn,
-            'is_test': self.is_test
-        }
-        self.outputs = {
-            'XShape': np.random.random(self.shape).astype("float32"),
-            'Out': self.inputs['X'].transpose(self.axis)
-        }
-
+class TestTransposeMKLDNN(TestTransposeOp):
     def init_op_type(self):
         self.op_type = "transpose2"
-        self.use_mkldnn = False
-        self.is_test = False
-
-    def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
+        self.use_mkldnn = True
+        self.is_test = True
+        return
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out')
+        return
 
-    def initTestCase(self):
-        self.shape = (3, 4)
-        self.axis = (1, 0)
+    def test_check_grad_no_input(self):
+        return
+
+    def test_check_grad_no_filter(self):
+        return
 
 
-class TestCase0(TestTransposeOp):
+class TestCase0MKLDNN(TestTransposeMKLDNN):
     def initTestCase(self):
         self.shape = (3, )
         self.axis = (0, )
 
 
-class TestCase1(TestTransposeOp):
+class TestCase1a(TestTransposeMKLDNN):
     def initTestCase(self):
         self.shape = (3, 4, 5)
         self.axis = (0, 2, 1)
 
 
-class TestCase2(TestTransposeOp):
+class TestCase1b(TestTransposeMKLDNN):
+    def initTestCase(self):
+        self.shape = (3, 4, 5)
+        self.axis = (2, 1, 0)
+
+
+class TestCase2(TestTransposeMKLDNN):
     def initTestCase(self):
         self.shape = (2, 3, 4, 5)
         self.axis = (0, 2, 3, 1)
 
 
-class TestCase3(TestTransposeOp):
+class TestCase3(TestTransposeMKLDNN):
     def initTestCase(self):
         self.shape = (2, 3, 4, 5, 6)
         self.axis = (4, 2, 3, 1, 0)
 
 
-class TestCase4(TestTransposeOp):
+class TestCase4(TestTransposeMKLDNN):
     def initTestCase(self):
         self.shape = (2, 3, 4, 5, 6, 1)
         self.axis = (4, 2, 3, 1, 0, 5)

--- a/python/paddle/fluid/tests/unittests/test_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_mkldnn_op.py
@@ -24,7 +24,6 @@ class TestTransposeMKLDNN(TestTransposeOp):
         self.op_type = "transpose2"
         self.use_mkldnn = True
         self.is_test = True
-        self.data_format = "NCHW"
         return
 
     def test_check_grad(self):

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -28,7 +28,6 @@ class TestTransposeOp(OpTest):
             'axis': list(self.axis),
             'use_mkldnn': self.use_mkldnn,
             'is_test': self.is_test,
-            'data_format': self.data_format
         }
         self.outputs = {
             'XShape': np.random.random(self.shape).astype("float32"),
@@ -39,7 +38,6 @@ class TestTransposeOp(OpTest):
         self.op_type = "transpose2"
         self.use_mkldnn = False
         self.is_test = False
-        self.data_format = "AnyLayout"
 
     def test_check_output(self):
         self.check_output(no_check_set=['XShape'])

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -27,7 +27,8 @@ class TestTransposeOp(OpTest):
         self.attrs = {
             'axis': list(self.axis),
             'use_mkldnn': self.use_mkldnn,
-            'is_test': self.is_test
+            'is_test': self.is_test,
+            'data_format': self.data_format
         }
         self.outputs = {
             'XShape': np.random.random(self.shape).astype("float32"),
@@ -38,6 +39,7 @@ class TestTransposeOp(OpTest):
         self.op_type = "transpose2"
         self.use_mkldnn = False
         self.is_test = False
+        self.data_format = "AnyLayout"
 
     def test_check_output(self):
         self.check_output(no_check_set=['XShape'])


### PR DESCRIPTION
Changes proposed here are introducing Transpose/Transpose2 op executed with MKL-DNN reorder primitive. This is **first** out of  three PR's related to transpose Op.

**Performance:**
_Model:_ Transformer (https://github.com/PaddlePaddle/models/tree/develop/fluid/PaddleNLP/neural_machine_translation/transformer)
_Platform:_  Intel(R) Xeon(R) Platinum 8180 CPU @ 2.50GHz
_Threads:_ 1
_Results[overall model speedup]:_ ~2 times(BS:1) , ~6 times(BS:50)

**Notes:**
- Forward Op only was implemented (works if is_test == True))
- No any layout support yet (will come in third installment)
- No reusing of reorder primitives (will come in second installment)
- Other models may benefit from this optimization, but for full performance on convolutional models (eg. mostly mkl-dnn based) any format support has to be added (will happen in third installment of this series)

@luotao1: 
1.This PR does not deliver corressponding Grad Op , so there is added is_test and assertion if this op is used during traning. Is this proper way of handling situation where we implement only Froward Op  ?
2. Could you also check if you see improvment on your target use case of Transformer? 