### PR TITLE
refactor RunImpl

### DIFF
--- a/paddle/fluid/framework/ngraph_operator.cc
+++ b/paddle/fluid/framework/ngraph_operator.cc
@@ -278,19 +278,7 @@ std::shared_ptr<ngraph::runtime::Backend> NgraphEngine::backend_ =
     ngraph::runtime::Backend::create("CPU");
 
 void NgraphEngine::GetNgInputShape(std::shared_ptr<OperatorBase> op) {
-  RuntimeContext ctx;
-  for (auto& var_name_item : op->Inputs()) {
-    std::vector<Variable*> input_vars = ctx.inputs[var_name_item.first];
-    for (auto& var_name : var_name_item.second) {
-      input_vars.push_back(scope_.FindVar(var_name));
-    }
-  }
-  for (auto& var_name_item : op->Outputs()) {
-    std::vector<Variable*> output_vars = ctx.outputs[var_name_item.first];
-    for (auto& var_name : var_name_item.second) {
-      output_vars.push_back(scope_.FindVar(var_name));
-    }
-  }
+  RuntimeContext ctx(op->Inputs(), op->Outputs(), scope_);
   op->RuntimeInferShape(scope_, place_, ctx);
   for (auto& var_name_item : op->Inputs()) {
     for (auto& var_name : var_name_item.second) {

--- a/paddle/fluid/framework/ngraph_operator.cc
+++ b/paddle/fluid/framework/ngraph_operator.cc
@@ -278,7 +278,20 @@ std::shared_ptr<ngraph::runtime::Backend> NgraphEngine::backend_ =
     ngraph::runtime::Backend::create("CPU");
 
 void NgraphEngine::GetNgInputShape(std::shared_ptr<OperatorBase> op) {
-  op->RuntimeInferShape(scope_, place_);
+  RuntimeContext ctx;
+  for (auto& var_name_item : op->Inputs()) {
+    std::vector<Variable*> input_vars = ctx.inputs[var_name_item.first];
+    for (auto& var_name : var_name_item.second) {
+      input_vars.push_back(scope_.FindVar(var_name));
+    }
+  }
+  for (auto& var_name_item : op->Outputs()) {
+    std::vector<Variable*> output_vars = ctx.outputs[var_name_item.first];
+    for (auto& var_name : var_name_item.second) {
+      output_vars.push_back(scope_.FindVar(var_name));
+    }
+  }
+  op->RuntimeInferShape(scope_, place_, ctx);
   for (auto& var_name_item : op->Inputs()) {
     for (auto& var_name : var_name_item.second) {
       auto* var = scope_.FindVar(var_name);

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -919,7 +919,7 @@ Scope* OperatorWithKernel::PrepareData(
       }
 
       auto* trans_var = new_scope->Var(var_name);
-      input_vars[i] = var;
+      input_vars[i] = trans_var;
 
       Tensor out;
       TransformData(expected_kernel_key, kernel_type_for_var, *tensor_in, &out);

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -812,6 +812,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   RuntimeInferShapeContext infer_shape_ctx(*this, exec_scope, ctx);
   this->InferShape(&infer_shape_ctx);
+  // TODO(panyx0718): ExecutionContext should only depend on RuntimeContext
+  // not Scope. Imperative mode only pass inputs and get outputs.
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx, ctx));
 
   if (!transfered_inplace_vars.empty()) {
@@ -917,13 +919,6 @@ Scope* OperatorWithKernel::PrepareData(
       Tensor out;
       TransformData(expected_kernel_key, kernel_type_for_var, *tensor_in, &out);
       SetTensorToVariable(*var, out, trans_var);
-    }
-  }
-  for (auto& var_name_item : Outputs()) {
-    std::vector<Variable*>& output_vars = ctx->outputs[var_name_item.first];
-    for (size_t i = 0; i < var_name_item.second.size(); ++i) {
-      auto& var_name = var_name_item.second[i];
-      output_vars[i] = scope.FindVar(var_name);
     }
   }
 

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -703,8 +703,6 @@ void OperatorWithKernel::RuntimeInferShape(const Scope& scope,
 
 void OperatorWithKernel::RunImpl(const Scope& scope,
                                  const platform::Place& place) const {
-  RuntimeInferShapeContext infer_shape_ctx(*this, scope);
-  this->InferShape(&infer_shape_ctx);
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(place);
 
@@ -758,6 +756,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
     dev_ctx = pool.Get(expected_kernel_key.place_);
   }
 
+  RuntimeInferShapeContext infer_shape_ctx(*this, exec_scope);
+  this->InferShape(&infer_shape_ctx);
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx));
 
   if (!transfered_inplace_vars.empty()) {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -143,14 +143,12 @@ RuntimeContext::RuntimeContext(const VariableNameMap& innames,
   for (auto& var_name_item : innames) {
     std::vector<Variable*>& input_vars = inputs[var_name_item.first];
     for (auto& var_name : var_name_item.second) {
-      LOG(ERROR) << "first in " << var_name_item.first << ":" << var_name;
       input_vars.push_back(scope.FindVar(var_name));
     }
   }
   for (auto& var_name_item : outnames) {
     std::vector<Variable*>& output_vars = outputs[var_name_item.first];
     for (auto& var_name : var_name_item.second) {
-      LOG(ERROR) << "first out " << var_name_item.first << ":" << var_name;
       output_vars.push_back(scope.FindVar(var_name));
     }
   }
@@ -441,22 +439,13 @@ const Variable* ExecutionContext::InputVar(const std::string& name) const {
   return it->second.empty() ? nullptr : it->second[0];
 }
 
+const Variable* ExecutionContext::LegacyInputVar(
+    const std::string& name) const {
+  auto ipt = op_.Input(name);
+  return ipt == kEmptyVarName ? nullptr : scope_.FindVar(ipt);
+}
+
 Variable* ExecutionContext::OutputVar(const std::string& name) const {
-  auto opt = op_.Output(name);
-  return opt == kEmptyVarName ? nullptr : scope_.FindVar(opt);
-}
-
-const Variable* ExecutionContext::FastInputVar(const std::string& name) const {
-  auto it = ctx_.inputs.find(name);
-  if (it == ctx_.inputs.end()) return nullptr;
-
-  PADDLE_ENFORCE_LE(it->second.size(), 1UL,
-                    "Operator %s's input %s should contain only one variable.",
-                    op_.Type(), name);
-  return it->second.empty() ? nullptr : it->second[0];
-}
-
-Variable* ExecutionContext::FastOutputVar(const std::string& name) const {
   auto it = ctx_.outputs.find(name);
   if (it == ctx_.outputs.end()) return nullptr;
 
@@ -466,15 +455,20 @@ Variable* ExecutionContext::FastOutputVar(const std::string& name) const {
   return it->second.empty() ? nullptr : it->second[0];
 }
 
+Variable* ExecutionContext::LegacyOutputVar(const std::string& name) const {
+  auto opt = op_.Output(name);
+  return opt == kEmptyVarName ? nullptr : scope_.FindVar(opt);
+}
+
 template <>
 const Tensor* ExecutionContext::Input<Tensor>(const std::string& name) const {
   return Input<LoDTensor>(name);
 }
 
 template <>
-const Tensor* ExecutionContext::FastInput<Tensor>(
+const Tensor* ExecutionContext::LegacyInput<Tensor>(
     const std::string& name) const {
-  return FastInput<LoDTensor>(name);
+  return LegacyInput<LoDTensor>(name);
 }
 
 template <>
@@ -502,8 +496,8 @@ Tensor* ExecutionContext::Output<Tensor>(const std::string& name) const {
 }
 
 template <>
-Tensor* ExecutionContext::FastOutput<Tensor>(const std::string& name) const {
-  return FastOutput<LoDTensor>(name);
+Tensor* ExecutionContext::LegacyOutput<Tensor>(const std::string& name) const {
+  return LegacyOutput<LoDTensor>(name);
 }
 
 template <>
@@ -870,7 +864,6 @@ Scope* OperatorWithKernel::PrepareData(
       auto& var_name = var_name_item.second[i];
       auto* var = scope.FindVar(var_name);
       input_vars[i] = var;
-      LOG(ERROR) << "second in " << var_name_item.first << ":" << var_name;
 
       // Only tensor can be tranfer to another device.
       if (var == nullptr || !VarIsTensor(*var)) {
@@ -931,7 +924,6 @@ Scope* OperatorWithKernel::PrepareData(
     for (size_t i = 0; i < var_name_item.second.size(); ++i) {
       auto& var_name = var_name_item.second[i];
       output_vars[i] = scope.FindVar(var_name);
-      LOG(ERROR) << "second out " << var_name_item.first << ":" << var_name;
     }
   }
 

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -233,20 +233,20 @@ class ExecutionContext {
   }
 
   template <typename T>
-  const T* FastInput(const std::string& name) const {
-    auto* var = FastInputVar(name);
+  const T* LegacyInput(const std::string& name) const {
+    auto* var = LegacyInputVar(name);
     return var == nullptr ? nullptr : &var->Get<T>();
   }
 
   template <typename T>
-  T* FastOutput(const std::string& name) const {
-    auto var = FastOutputVar(name);
+  T* LegacyOutput(const std::string& name) const {
+    auto var = LegacyOutputVar(name);
     return var == nullptr ? nullptr : var->GetMutable<T>();
   }
 
-  const Variable* FastInputVar(const std::string& name) const;
+  const Variable* LegacyInputVar(const std::string& name) const;
 
-  Variable* FastOutputVar(const std::string& name) const;
+  Variable* LegacyOutputVar(const std::string& name) const;
 
   template <typename T>
   const std::vector<const T*> MultiInput(const std::string& name) const {
@@ -314,7 +314,7 @@ template <>
 const Tensor* ExecutionContext::Input<Tensor>(const std::string& name) const;
 
 template <>
-const Tensor* ExecutionContext::FastInput<Tensor>(
+const Tensor* ExecutionContext::LegacyInput<Tensor>(
     const std::string& name) const;
 
 template <>
@@ -325,7 +325,7 @@ template <>
 Tensor* ExecutionContext::Output<Tensor>(const std::string& name) const;
 
 template <>
-Tensor* ExecutionContext::FastOutput<Tensor>(const std::string& name) const;
+Tensor* ExecutionContext::LegacyOutput<Tensor>(const std::string& name) const;
 
 template <>
 std::vector<Tensor*> ExecutionContext::MultiOutput<Tensor>(

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -72,7 +72,8 @@ class ExecutionContext;
 
 class RuntimeContext {
  public:
-  RuntimeContext() {}
+  RuntimeContext(const VariableNameMap& innames,
+                 const VariableNameMap& outnames, const Scope& scope);
 
   VariableValueMap inputs;
   VariableValueMap outputs;
@@ -165,8 +166,9 @@ class OperatorBase {
 class ExecutionContext {
  public:
   ExecutionContext(const OperatorBase& op, const Scope& scope,
-                   const platform::DeviceContext& device_context)
-      : op_(op), scope_(scope), device_context_(device_context) {}
+                   const platform::DeviceContext& device_context,
+                   const RuntimeContext& ctx)
+      : op_(op), scope_(scope), device_context_(device_context), ctx_(ctx) {}
 
   const OperatorBase& op() const { return op_; }
 
@@ -295,6 +297,7 @@ class ExecutionContext {
   const OperatorBase& op_;
   const Scope& scope_;
   const platform::DeviceContext& device_context_;
+  const RuntimeContext& ctx_;
 };
 
 template <>

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -191,15 +191,9 @@ class ExecutionContext {
     return op_.Outputs(name).size();
   }
 
-  const Variable* InputVar(const std::string& name) const {
-    auto ipt = op_.Input(name);
-    return ipt == kEmptyVarName ? nullptr : scope_.FindVar(ipt);
-  }
+  const Variable* InputVar(const std::string& name) const;
 
-  Variable* OutputVar(const std::string& name) const {
-    auto opt = op_.Output(name);
-    return opt == kEmptyVarName ? nullptr : scope_.FindVar(opt);
-  }
+  Variable* OutputVar(const std::string& name) const;
 
   const std::vector<const Variable*> MultiInputVar(
       const std::string& name) const {
@@ -237,6 +231,22 @@ class ExecutionContext {
     auto var = OutputVar(name);
     return var == nullptr ? nullptr : var->GetMutable<T>();
   }
+
+  template <typename T>
+  const T* FastInput(const std::string& name) const {
+    auto* var = FastInputVar(name);
+    return var == nullptr ? nullptr : &var->Get<T>();
+  }
+
+  template <typename T>
+  T* FastOutput(const std::string& name) const {
+    auto var = FastOutputVar(name);
+    return var == nullptr ? nullptr : var->GetMutable<T>();
+  }
+
+  const Variable* FastInputVar(const std::string& name) const;
+
+  Variable* FastOutputVar(const std::string& name) const;
 
   template <typename T>
   const std::vector<const T*> MultiInput(const std::string& name) const {
@@ -304,11 +314,18 @@ template <>
 const Tensor* ExecutionContext::Input<Tensor>(const std::string& name) const;
 
 template <>
+const Tensor* ExecutionContext::FastInput<Tensor>(
+    const std::string& name) const;
+
+template <>
 const std::vector<const Tensor*> ExecutionContext::MultiInput<Tensor>(
     const std::string& name) const;
 
 template <>
 Tensor* ExecutionContext::Output<Tensor>(const std::string& name) const;
+
+template <>
+Tensor* ExecutionContext::FastOutput<Tensor>(const std::string& name) const;
 
 template <>
 std::vector<Tensor*> ExecutionContext::MultiOutput<Tensor>(

--- a/paddle/fluid/framework/type_defs.h
+++ b/paddle/fluid/framework/type_defs.h
@@ -28,8 +28,11 @@ class OperatorBase;
 class OpDesc;
 class InferShapeContext;
 class BlockDesc;
+class Variable;
 
 using VariableNameMap = std::map<std::string, std::vector<std::string>>;
+// TODO(panyx0718): Replace vector with something like gtl::Vector.
+using VariableValueMap = std::map<std::string, std::vector<Variable*>>;
 
 // The order should be as same as framework.proto
 using Attribute =

--- a/paddle/fluid/operators/beam_search_decode_op.cc
+++ b/paddle/fluid/operators/beam_search_decode_op.cc
@@ -122,7 +122,8 @@ class BeamSearchDecodeOp : public framework::OperatorBase {
     platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
     auto& dev_ctx = *pool.Get(dev_place);
 
-    framework::ExecutionContext ctx(*this, scope, dev_ctx);
+    framework::RuntimeContext run_ctx(Inputs(), Outputs(), scope);
+    framework::ExecutionContext ctx(*this, scope, dev_ctx, run_ctx);
 
     const LoDTensorArray* ids = ctx.Input<LoDTensorArray>("Ids");
     const LoDTensorArray* scores = ctx.Input<LoDTensorArray>("Scores");

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -56,7 +56,7 @@ class PReluOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
+    return framework::OpKernelType(ctx.FastInput<Tensor>("X")->type(),
                                    ctx.device_context());
   }
 };

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -56,7 +56,7 @@ class PReluOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    return framework::OpKernelType(ctx.FastInput<Tensor>("X")->type(),
+    return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
                                    ctx.device_context());
   }
 };


### PR DESCRIPTION
There are a few reasons to make this change

1. RuntimeContext should be prepared before Run and scope lookup should be avoided in InferXXX and Compute
2. Imperative Mode should call Kernel directly and it should pass in Variable and get Variable without Scope.


test=develop