### PR TITLE
Enable MKL-DNN INT8 inference

### DIFF
--- a/paddle/fluid/operators/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/conv_mkldnn_op.cc
@@ -12,6 +12,7 @@
    See the License for the specific language governing permissions and
    limitations under the License. */
 
+#include <unordered_map>
 #include "paddle/fluid/framework/data_layout_transform.h"
 #include "paddle/fluid/memory/malloc.h"
 #include "paddle/fluid/operators/conv_op.h"
@@ -68,13 +69,42 @@ inline mkldnn::memory::format GetWeightsFormat(mkldnn::memory::format format,
   }
 }
 
-template <typename T>
+template <typename T, typename K>
 class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
  public:
+  struct ConvInfo {
+    const paddle::framework::Tensor* input;
+    const paddle::framework::Tensor* bias;
+    const paddle::framework::Tensor* output;
+    const paddle::framework::Tensor* weight;
+    std::vector<int>* strides;
+    std::vector<int>* paddings;
+    std::vector<int>* dilations;
+    std::vector<int>* src_tz;
+    std::vector<int>* weights_tz;
+    std::vector<int>* dst_tz;
+    int g;
+  };
+  struct MkldnnInfo {
+    bool fuse_relu;
+    bool fuse_residual_conn;
+    bool force_fp32_output;
+    bool is_test;
+    bool is_conv3d;
+    const mkldnn::engine* mkldnn_engine;
+    std::vector<primitive>* pipeline;
+    const std::string* key_conv_pd;
+    std::string* key;
+    std::shared_ptr<platform::ConvMKLDNNHandler> handler;
+    std::shared_ptr<mkldnn::memory> src_memory_p;
+    std::shared_ptr<mkldnn::memory> user_src_memory_p;
+    std::shared_ptr<mkldnn::memory> dst_memory_p;
+    std::shared_ptr<mkldnn::convolution_forward> conv_p;
+    std::shared_ptr<mkldnn::convolution_forward::primitive_desc> conv_pd;
+  };
   void Compute(const paddle::framework::ExecutionContext& ctx) const override {
     PADDLE_ENFORCE(paddle::platform::is_cpu_place(ctx.GetPlace()),
                    "It must use CPUPlace.");
-
     const bool is_test = ctx.Attr<bool>("is_test");
 
     auto& dev_ctx =
@@ -107,9 +137,16 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     std::vector<int> strides = ctx.Attr<std::vector<int>>("strides");
     std::vector<int> paddings = ctx.Attr<std::vector<int>>("paddings");
     std::vector<int> dilations = ctx.Attr<std::vector<int>>("dilations");
+    int groups = ctx.Attr<int>("groups");
+
     bool fuse_relu = ctx.Attr<bool>("fuse_relu");
     bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
-    int groups = ctx.Attr<int>("groups");
+
+    bool force_fp32_output = ctx.Attr<bool>("force_fp32_output");
+    if (fuse_residual_conn) {
+      PADDLE_ENFORCE(force_fp32_output != true,
+                     "residual fusion does not support force output with fp32");
+    }
 
     bool is_conv3d = strides.size() == 3U;
     // TODO(tpatejko): add support for dilation
@@ -121,7 +158,6 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         "dilation in convolution is not implemented yet");
 
     const T* input_data = input->data<T>();
-    const T* filter_data = filter->data<T>();
 
     std::vector<int> src_tz = paddle::framework::vectorize2int(input->dims());
     std::vector<int> weights_tz =
@@ -131,21 +167,198 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     std::vector<int> dst_tz = paddle::framework::vectorize2int(output->dims());
 
     // Get unique name for storing MKLDNN primitives
-    const std::string key = platform::ConvMKLDNNHandler::GetHash(
-        src_tz, weights_tz, strides, paddings, dilations, groups,
-        ctx.op().Output("Output"));
+    const int MaxKeyLength = 256;
+    std::string key;
+    key.reserve(MaxKeyLength);
+    platform::ConvMKLDNNHandler::AppendKey(key, src_tz, weights_tz, strides,
+                                           paddings, dilations, groups,
+                                           ctx.op().Output("Output"));
+
     const std::string key_conv_pd = key + "@conv_pd";
 
-    std::vector<primitive> pipeline;
+    bool is_INT8 = false;
+    mkldnn::memory::data_type src_dt =
+        paddle::framework::ToMKLDNNDataType(input->type());
+    if (src_dt == mkldnn::memory::data_type::u8 ||
+        src_dt == mkldnn::memory::data_type::s8) {
+      is_INT8 = true;
+    }
 
+    bool need_s8_to_u8 = false;
+    if (fuse_residual_conn && is_INT8 && fuse_relu) {
+      need_s8_to_u8 = true;
+    }
+
+    std::shared_ptr<mkldnn::convolution_forward> conv_p = nullptr;
+    std::shared_ptr<mkldnn::memory> src_memory_p = nullptr;
+    std::shared_ptr<mkldnn::memory> user_src_memory_p = nullptr;
+    std::shared_ptr<mkldnn::memory> dst_memory_p = nullptr;
+    std::vector<primitive> pipeline;
+    std::shared_ptr<mkldnn::convolution_forward::primitive_desc> conv_pd =
+        nullptr;
+    std::shared_ptr<platform::ConvMKLDNNHandler> handler = nullptr;
+
+    auto prim_key = key + "@conv_p";
+    auto dst_key = key + "@dst_mem_p";
+    auto src_key = key + "@src_mem_p";
+    auto user_src_key = key + "@user_src_mem_p";
+    auto src_reorder_key = key + "@src_mem_preorder_p";
+    conv_p = std::static_pointer_cast<mkldnn::convolution_forward>(
+        dev_ctx.GetBlob(prim_key));
+    if (conv_p == nullptr || !is_test) {
+      struct ConvInfo convinfo;
+      struct MkldnnInfo mkldnninfo;
+      convinfo.strides = &strides;
+      convinfo.paddings = &paddings;
+      convinfo.dilations = &dilations;
+      convinfo.src_tz = &src_tz;
+      convinfo.weights_tz = &weights_tz;
+      convinfo.dst_tz = &dst_tz;
+      convinfo.g = g;
+      mkldnninfo.fuse_relu = fuse_relu;
+      mkldnninfo.fuse_residual_conn = fuse_residual_conn;
+      mkldnninfo.force_fp32_output = force_fp32_output;
+      mkldnninfo.is_test = is_test;
+      mkldnninfo.is_conv3d = is_conv3d;
+      mkldnninfo.mkldnn_engine = &mkldnn_engine;
+      mkldnninfo.handler = handler;
+      mkldnninfo.pipeline = &pipeline;
+      mkldnninfo.key_conv_pd = &key_conv_pd;
+      mkldnninfo.key = &key;
+      mkldnninfo.src_memory_p = src_memory_p;
+      mkldnninfo.user_src_memory_p = user_src_memory_p;
+      mkldnninfo.dst_memory_p = dst_memory_p;
+      mkldnninfo.conv_p = conv_p;
+      mkldnninfo.conv_pd = conv_pd;
+      if (is_INT8) {
+        CreateINT8Primitive(ctx, &dev_ctx, input, filter, bias, output,
+                            &convinfo, &mkldnninfo);
+      } else {
+        CreateFP32Primitive(ctx, &dev_ctx, input, filter, bias, output,
+                            &convinfo, &mkldnninfo);
+      }
+      dst_memory_p = mkldnninfo.dst_memory_p;
+    } else {
+      auto src_memory_reorder_p = std::static_pointer_cast<mkldnn::memory>(
+          dev_ctx.GetBlob(src_reorder_key));
+      src_memory_p =
+          std::static_pointer_cast<mkldnn::memory>(dev_ctx.GetBlob(src_key));
+      if (src_memory_reorder_p) {
+        user_src_memory_p = std::static_pointer_cast<mkldnn::memory>(
+            dev_ctx.GetBlob(user_src_key));
+        user_src_memory_p->set_data_handle(to_void_cast<T>(input_data));
+      } else if (src_memory_p) {
+        src_memory_p->set_data_handle(to_void_cast<T>(input_data));
+      }
+
+      dst_memory_p =
+          std::static_pointer_cast<mkldnn::memory>(dev_ctx.GetBlob(dst_key));
+      conv_pd =
+          std::static_pointer_cast<mkldnn::convolution_forward::primitive_desc>(
+              dev_ctx.GetBlob(key_conv_pd));
+      if (conv_pd) {
+        handler.reset(new platform::ConvMKLDNNHandler(conv_pd, dev_ctx,
+                                                      mkldnn_engine, key));
+      }
+      if (!is_INT8) {
+        if (fuse_residual_conn) {
+          auto residual_param = ctx.Input<Tensor>("ResidualData");
+          auto residual_param_data = residual_param->data<T>();
+          if (residual_param->format() != handler->GetDstFormat()) {
+            auto output_data = output->mutable_data<T>(
+                ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+                handler->GetDstMemorySize());
+            auto residual_data_tz =
+                paddle::framework::vectorize2int(residual_param->dims());
+            auto residual_data_type =
+                paddle::framework::ToMKLDNNDataType(residual_param->type());
+
+            auto user_residual_md = platform::MKLDNNMemDesc(
+                residual_data_tz, residual_data_type, residual_param->format());
+            auto user_residual_memory_p = handler->AcquireResidualDataMemory(
+                user_residual_md, to_void_cast<T>(residual_param_data));
+            dst_memory_p = handler->AcquireDstMemoryFromResidualDataMemory(
+                user_residual_memory_p, to_void_cast<T>(output_data), pipeline);
+          } else {
+            output->ShareDataWith(*residual_param);
+            auto output_data = output->mutable_data<T>(ctx.GetPlace());
+            dst_memory_p->set_data_handle(to_void_cast<T>(output_data));
+          }
+        } else {
+          auto output_data = output->mutable_data<T>(
+              ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+              handler->GetDstMemorySize());
+          dst_memory_p->set_data_handle(to_void_cast<T>(output_data));
+        }
+      } else if (is_INT8) {
+        if (fuse_residual_conn) {
+          auto residual_param = ctx.Input<Tensor>("ResidualData");
+          auto residual_dt =
+              paddle::framework::ToMKLDNNDataType(residual_param->type());
+          output->ShareDataWith(*residual_param);
+          if (residual_dt == mkldnn::memory::data_type::u8) {
+            uint8_t* output_data =
+                output->mutable_data<uint8_t>(ctx.GetPlace());
+            dst_memory_p->set_data_handle(to_void_cast<uint8_t>(output_data));
+          } else {
+            int8_t* output_data = output->mutable_data<int8_t>(ctx.GetPlace());
+            dst_memory_p->set_data_handle(to_void_cast<int8_t>(output_data));
+          }
+        } else if (!force_fp32_output) {
+          if (fuse_relu) {
+            uint8_t* output_data = output->mutable_data<uint8_t>(
+                ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+                handler->GetDstMemorySize());
+            dst_memory_p->set_data_handle(to_void_cast<uint8_t>(output_data));
+          } else {
+            int8_t* output_data = output->mutable_data<int8_t>(
+                ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+                handler->GetDstMemorySize());
+            dst_memory_p->set_data_handle(to_void_cast<int8_t>(output_data));
+          }
+        } else {
+          float* output_data = output->mutable_data<float>(
+              ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+              handler->GetDstMemorySize());
+          dst_memory_p->set_data_handle(to_void_cast<float>(output_data));
+        }
+      }
+
+      if (src_memory_reorder_p) {
+        pipeline.push_back(*src_memory_reorder_p);
+      }
+      pipeline.push_back(*conv_p);
+    }
+
+    // push primitive to stream and wait until it's executed
+    stream(stream::kind::eager).submit(pipeline).wait();
+
+    if (need_s8_to_u8) {
+      output->mutable_data<uint8_t>(ctx.GetPlace());
+    }
+
+    output->set_layout(DataLayout::kMKLDNN);
+    output->set_format(GetMKLDNNFormat(*dst_memory_p));
+  };
+
+ private:
+  void CreateFP32Primitive(const paddle::framework::ExecutionContext& ctx,
+                           const paddle::platform::MKLDNNDeviceContext* dev_ctx,
+                           const paddle::framework::Tensor* input,
+                           const paddle::framework::Tensor* filter,
+                           const paddle::framework::Tensor* bias,
+                           paddle::framework::Tensor* output,
+                           ConvInfo* convinfo, MkldnnInfo* mkldnninfo) const {
+    const T* input_data = input->data<T>();
+    const K* filter_data = filter->data<K>();
     auto src_format = input->format();
     mkldnn::memory::format weights_format =
-        GetWeightsFormat(filter->format(), g, is_conv3d);
-
+        GetWeightsFormat(filter->format(), convinfo->g, mkldnninfo->is_conv3d);
     auto user_src_md = platform::MKLDNNMemDesc(
-        {src_tz}, platform::MKLDNNGetDataType<T>(), src_format);
+        {*convinfo->src_tz}, platform::MKLDNNGetDataType<T>(), src_format);
     auto user_weights_md = platform::MKLDNNMemDesc(
-        {weights_tz}, platform::MKLDNNGetDataType<T>(), weights_format);
+        {*convinfo->weights_tz}, platform::MKLDNNGetDataType<T>(),
+        weights_format);
 
     /* create memory descriptor for convolution without specified format
      * ('any') which lets a primitive (convolution in this case) choose
@@ -155,57 +368,66 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto chosen_memory_format =
         platform::data_format_to_memory_format(data_format);
 
-    if (is_conv3d) {
-      chosen_memory_format =
-          platform::MKLDNNFormatForSize(src_tz.size(), chosen_memory_format);
+    if (mkldnninfo->is_conv3d) {
+      chosen_memory_format = platform::MKLDNNFormatForSize(
+          convinfo->src_tz->size(), chosen_memory_format);
     }
-    weights_format = GetWeightsFormat(chosen_memory_format, g, is_conv3d);
+    weights_format = GetWeightsFormat(chosen_memory_format, convinfo->g,
+                                      mkldnninfo->is_conv3d);
 
-    auto src_md = platform::MKLDNNMemDesc(
-        src_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
-    auto weights_md = platform::MKLDNNMemDesc(
-        weights_tz, platform::MKLDNNGetDataType<T>(), weights_format);
+    auto src_md = platform::MKLDNNMemDesc(*convinfo->src_tz,
+                                          platform::MKLDNNGetDataType<T>(),
+                                          chosen_memory_format);
+    auto weights_md = platform::MKLDNNMemDesc(*convinfo->weights_tz,
+                                              platform::MKLDNNGetDataType<T>(),
+                                              weights_format);
     std::vector<int> bias_tz;  // TODO(mgallus): avoid empty vector creation.
                                // Currently used whenever bias is != nullptr.
-    auto dst_md = platform::MKLDNNMemDesc(
-        dst_tz, platform::MKLDNNGetDataType<T>(), chosen_memory_format);
+
+    auto dst_md = platform::MKLDNNMemDesc(*(convinfo->dst_tz),
+                                          platform::MKLDNNGetDataType<T>(),
+                                          chosen_memory_format);
 
     // create a conv primitive descriptor and save it for usage in backward
-    std::shared_ptr<mkldnn::convolution_forward::primitive_desc> conv_pd;
-    auto fwd_prop_kind = is_test ? mkldnn::prop_kind::forward_inference
-                                 : mkldnn::prop_kind::forward_training;
+    auto fwd_prop_kind = mkldnninfo->is_test
+                             ? mkldnn::prop_kind::forward_inference
+                             : mkldnn::prop_kind::forward_training;
     if (bias) {
       bias_tz = paddle::framework::vectorize2int(bias->dims());
       auto bias_md = platform::MKLDNNMemDesc(
           bias_tz, platform::MKLDNNGetDataType<T>(), memory::format::x);
-      conv_pd = ConvFwdPrimitiveDesc(
-          src_md, weights_md, bias_md, dst_md, strides, paddings, mkldnn_engine,
-          fuse_relu, fuse_residual_conn, fwd_prop_kind);
+      mkldnninfo->conv_pd = ConvFwdPrimitiveDesc(
+          src_md, weights_md, bias_md, dst_md, *convinfo->strides,
+          *convinfo->paddings, *mkldnninfo->mkldnn_engine,
+          mkldnninfo->fuse_relu, mkldnninfo->fuse_residual_conn, fwd_prop_kind);
     } else {
-      conv_pd = ConvFwdPrimitiveDesc(src_md, weights_md, dst_md, strides,
-                                     paddings, mkldnn_engine, fuse_relu,
-                                     fuse_residual_conn, fwd_prop_kind);
+      mkldnninfo->conv_pd = ConvFwdPrimitiveDesc(
+          src_md, weights_md, dst_md, *convinfo->strides, *convinfo->paddings,
+          *mkldnninfo->mkldnn_engine, mkldnninfo->fuse_relu,
+          mkldnninfo->fuse_residual_conn, fwd_prop_kind);
     }
     // Save conv_pd/src_memory/weights_memory for backward pass
-    if (!is_test) dev_ctx.SetBlob(key_conv_pd, conv_pd);
+    dev_ctx->SetBlob(*mkldnninfo->key_conv_pd, mkldnninfo->conv_pd);
 
-    platform::ConvMKLDNNHandler handler(conv_pd, dev_ctx, mkldnn_engine, key);
+    mkldnninfo->handler.reset(new platform::ConvMKLDNNHandler(
+        mkldnninfo->conv_pd, *dev_ctx, *mkldnninfo->mkldnn_engine,
+        *mkldnninfo->key));
 
     // create mkldnn memory from input tensors (data/weights)
-    auto user_src_memory_p =
-        handler.AcquireSrcMemory(user_src_md, to_void_cast<T>(input_data));
-    auto user_weights_memory_p = handler.AcquireWeightsMemory(
-        user_weights_md, to_void_cast<T>(filter_data));
+    mkldnninfo->user_src_memory_p = mkldnninfo->handler->AcquireSrcMemory(
+        user_src_md, to_void_cast<T>(input_data));
+    auto user_weights_memory_p = mkldnninfo->handler->AcquireWeightsMemory(
+        user_weights_md, to_void_cast<K>(filter_data));
 
     // create reorder primitive if the input format is not the preferred one
-    auto src_memory_p =
-        handler.AcquireSrcMemoryFromPrimitive(user_src_memory_p, pipeline);
-    auto weights_memory_p = handler.AcquireWeightsMemoryFromPrimitive(
-        user_weights_memory_p, pipeline, is_test);
+    mkldnninfo->src_memory_p =
+        mkldnninfo->handler->AcquireSrcMemoryFromPrimitive(
+            mkldnninfo->user_src_memory_p, *mkldnninfo->pipeline);
+    auto weights_memory_p =
+        mkldnninfo->handler->AcquireWeightsMemoryFromPrimitive(
+            user_weights_memory_p, *mkldnninfo->pipeline, mkldnninfo->is_test);
 
-    std::shared_ptr<mkldnn::memory> dst_memory_p;
-
-    if (fuse_residual_conn) {
+    if (mkldnninfo->fuse_residual_conn) {
       auto residual_param = ctx.Input<Tensor>("ResidualData");
       auto residual_param_data = residual_param->data<T>();
 
@@ -216,10 +438,10 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
                         "Output and elementwise parameter need to have the "
                         "same dimension sizes");
 
-      if (residual_param->format() != handler.GetDstFormat()) {
+      if (residual_param->format() != mkldnninfo->handler->GetDstFormat()) {
         auto output_data = output->mutable_data<T>(
             ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
-            handler.GetDstMemorySize());
+            mkldnninfo->handler->GetDstMemorySize());
         auto residual_data_tz =
             paddle::framework::vectorize2int(residual_param->dims());
         auto residual_data_type =
@@ -227,54 +449,262 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
 
         auto user_residual_md = platform::MKLDNNMemDesc(
             residual_data_tz, residual_data_type, residual_param->format());
-        auto user_residual_memory_p = handler.AcquireResidualDataMemory(
-            user_residual_md, to_void_cast<T>(residual_param_data));
-
-        dst_memory_p = handler.AcquireDstMemoryFromResidualDataMemory(
-            user_residual_memory_p, to_void_cast<T>(output_data), pipeline);
+        auto user_residual_memory_p =
+            mkldnninfo->handler->AcquireResidualDataMemory(
+                user_residual_md, to_void_cast<T>(residual_param_data));
+        mkldnninfo->dst_memory_p =
+            mkldnninfo->handler->AcquireDstMemoryFromResidualDataMemory(
+                user_residual_memory_p, to_void_cast<T>(output_data),
+                *mkldnninfo->pipeline);
       } else {
         output->ShareDataWith(*residual_param);
         auto output_data = output->mutable_data<T>(ctx.GetPlace());
-        dst_memory_p =
-            handler.AcquireDstMemoryFromPrimitive(to_void_cast<T>(output_data));
+        mkldnninfo->dst_memory_p =
+            mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+                to_void_cast<T>(output_data));
       }
     } else {
       auto output_data = output->mutable_data<T>(
-          ctx.GetPlace(), paddle::memory::Allocator::kDefault,
-          handler.GetDstMemorySize());
-      dst_memory_p =
-          handler.AcquireDstMemoryFromPrimitive(to_void_cast<T>(output_data));
+          ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+          mkldnninfo->handler->GetDstMemorySize());
+      mkldnninfo->dst_memory_p =
+          mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+              to_void_cast<T>(output_data));
     }
 
     // create convolution op primitive
-    std::shared_ptr<mkldnn::convolution_forward> conv_p;
     if (bias) {
       const T* bias_data = bias->data<T>();
       auto user_bias_md = platform::MKLDNNMemDesc(
           {bias_tz}, platform::MKLDNNGetDataType<T>(), memory::format::x);
-      auto user_bias_memory_p =
-          handler.AcquireBiasMemory(user_bias_md, to_void_cast<T>(bias_data));
+      auto user_bias_memory_p = mkldnninfo->handler->AcquireBiasMemory(
+          user_bias_md, to_void_cast<T>(bias_data));
 
-      auto bias_memory_p =
-          handler.AcquireBiasMemoryFromPrimitive(user_bias_memory_p, pipeline);
-      conv_p = handler.AcquireConvolution(src_memory_p, weights_memory_p,
-                                          bias_memory_p, dst_memory_p);
+      auto bias_memory_p = mkldnninfo->handler->AcquireBiasMemoryFromPrimitive(
+          user_bias_memory_p, *mkldnninfo->pipeline, mkldnninfo->is_test);
+      mkldnninfo->conv_p = mkldnninfo->handler->AcquireConvolution(
+          mkldnninfo->src_memory_p, weights_memory_p, bias_memory_p,
+          mkldnninfo->dst_memory_p);
     } else {
-      conv_p = handler.AcquireConvolution(src_memory_p, weights_memory_p,
-                                          dst_memory_p);
+      mkldnninfo->conv_p = mkldnninfo->handler->AcquireConvolution(
+          mkldnninfo->src_memory_p, weights_memory_p, mkldnninfo->dst_memory_p);
+    }
+    // push primitive to stream and wait until it's executed
+    mkldnninfo->pipeline->push_back(*mkldnninfo->conv_p);
+  }
+
+  void CreateINT8Primitive(const paddle::framework::ExecutionContext& ctx,
+                           const paddle::platform::MKLDNNDeviceContext* dev_ctx,
+                           const paddle::framework::Tensor* input,
+                           const paddle::framework::Tensor* filter,
+                           const paddle::framework::Tensor* bias,
+                           paddle::framework::Tensor* output,
+                           ConvInfo* convinfo, MkldnnInfo* mkldnninfo) const {
+    const T* input_data = input->data<T>();
+    const K* filter_data = filter->data<K>();
+    bool is_INT8 = true;
+    auto scale_in_data = ctx.Attr<float>("Scale_in");
+    auto scale_in_eltwise_data = ctx.Attr<float>("Scale_in_eltwise");
+    auto scale_weights_data = ctx.Attr<std::vector<float>>("Scale_weights");
+    auto scale_out_data =
+        mkldnninfo->force_fp32_output ? 1.0f : ctx.Attr<float>("Scale_out");
+
+    bool is_multi_channel = scale_weights_data.size() > 1 ? true : false;
+
+    std::vector<float> output_shift_scale;
+    float sum_scale = 1.0f;
+    int count =
+        is_multi_channel
+            ? (convinfo->g > 1
+                   ? (*convinfo->weights_tz)[1] * (*convinfo->weights_tz)[0]
+                   : (*convinfo->weights_tz)[0])
+            : 1;
+    output_shift_scale.resize(count);
+#pragma omp parallel for if (count > 1)
+    for (int i = 0; i < count; i++) {
+      if (scale_weights_data[i] == 0.0)
+        output_shift_scale[i] = scale_out_data;  // weights data will contain 0
+                                                 // in some models, then weights
+                                                 // scale couldn't be calculated
+      else
+        output_shift_scale[i] =
+            scale_out_data / (scale_in_data * scale_weights_data[i]);
+    }
+    if (mkldnninfo->fuse_residual_conn) {
+      sum_scale = scale_out_data / scale_in_eltwise_data;
+    }
+
+    auto user_src_md = platform::MKLDNNMemDesc(
+        {*convinfo->src_tz}, paddle::framework::ToMKLDNNDataType(input->type()),
+        input->format());
+    auto user_weights_md = platform::MKLDNNMemDesc(
+        {*convinfo->weights_tz}, platform::MKLDNNGetDataType<K>(),
+        ((convinfo->g) == 1) ? mkldnn::memory::format::oihw
+                             : mkldnn::memory::format::goihw);
+
+    /* create memory descriptor for convolution without specified format
+     * ('any') which lets a primitive (convolution in this case) choose
+     * the memory format preferred for best performance
+    */
+    std::string data_format = ctx.Attr<std::string>("data_format");
+    auto chosen_memory_format =
+        platform::data_format_to_memory_format(data_format);
+
+    auto bias_tz = paddle::framework::vectorize2int(bias->dims());
+
+    auto src_md = platform::MKLDNNMemDesc(
+        *convinfo->src_tz, memory::data_type::u8, chosen_memory_format);
+    auto weights_md = platform::MKLDNNMemDesc(
+        *convinfo->weights_tz, memory::data_type::s8, chosen_memory_format);
+
+    auto dst_dt = mkldnninfo->fuse_relu
+                      ? paddle::framework::ToMKLDNNDataType(
+                            framework::DataTypeTrait<int8_t>::DataType)
+                      : paddle::framework::ToMKLDNNDataType(
+                            framework::DataTypeTrait<uint8_t>::DataType);
+
+    if (mkldnninfo->force_fp32_output) {
+      dst_dt = paddle::framework::ToMKLDNNDataType(
+          framework::DataTypeTrait<float>::DataType);
+    }
+
+    if (mkldnninfo->fuse_residual_conn) {
+      auto residual = ctx.Input<Tensor>("ResidualData");
+      auto residual_dt = paddle::framework::ToMKLDNNDataType(residual->type());
+      if (dst_dt != residual_dt) dst_dt = residual_dt;
+    }
+    auto dst_md = platform::MKLDNNMemDesc(*convinfo->dst_tz, dst_dt,
+                                          chosen_memory_format);
+
+    // create a conv primitive descriptor and save it for usage in backward
+    if (bias) {
+      auto bias_md = platform::MKLDNNMemDesc(bias_tz, memory::data_type::s32,
+                                             memory::format::x);
+      mkldnninfo->conv_pd = ConvFwdPrimitiveDesc(
+          src_md, weights_md, bias_md, dst_md, *convinfo->strides,
+          *convinfo->paddings, *mkldnninfo->mkldnn_engine,
+          mkldnninfo->fuse_relu, mkldnninfo->fuse_residual_conn,
+          output_shift_scale, sum_scale, mkldnninfo->is_test);
+    } else {
+      mkldnninfo->conv_pd = ConvFwdPrimitiveDesc(
+          src_md, weights_md, dst_md, *convinfo->strides, *convinfo->paddings,
+          *mkldnninfo->mkldnn_engine, mkldnninfo->fuse_relu,
+          mkldnninfo->fuse_residual_conn, output_shift_scale, sum_scale,
+          mkldnninfo->is_test);
+    }
+    // Save conv_pd/src_memory/weights_memory for backward pass
+    dev_ctx->SetBlob(*mkldnninfo->key_conv_pd, mkldnninfo->conv_pd);
+
+    mkldnninfo->handler.reset(new platform::ConvMKLDNNHandler(
+        mkldnninfo->conv_pd, *dev_ctx, *mkldnninfo->mkldnn_engine,
+        *mkldnninfo->key));
+
+    // create mkldnn memory from input tensors (data/weights)
+    mkldnninfo->user_src_memory_p = mkldnninfo->handler->AcquireSrcMemory(
+        user_src_md, to_void_cast<T>(input_data));
+    auto user_weights_memory_p = mkldnninfo->handler->AcquireWeightsMemory(
+        user_weights_md, to_void_cast<K>(filter_data));
+
+    // create reorder primitive if the input format is not the preferred one
+    mkldnninfo->src_memory_p =
+        mkldnninfo->handler->AcquireSrcMemoryFromPrimitive(
+            mkldnninfo->user_src_memory_p, *mkldnninfo->pipeline);
+
+    std::shared_ptr<mkldnn::memory> weights_memory_p;
+    int mask_reorder = is_multi_channel
+                           ? ((convinfo->g != 1) ? (1 << 1) + (1 << 0) : 1 << 0)
+                           : 0;
+    weights_memory_p = mkldnninfo->handler->AcquireWeightsMemoryFromPrimitive(
+        user_weights_memory_p, *mkldnninfo->pipeline, mkldnninfo->is_test,
+        is_INT8, scale_weights_data, mask_reorder);
+
+    if (mkldnninfo->fuse_residual_conn) {
+      auto residual_param = ctx.Input<Tensor>("ResidualData");
+      PADDLE_ENFORCE_EQ(output->dims(), residual_param->dims(),
+                        "Output and elementwise parameter need to have the "
+                        "same dimension sizes");
+      auto residual_dt =
+          paddle::framework::ToMKLDNNDataType(residual_param->type());
+      PADDLE_ENFORCE_EQ(
+          residual_param->format(), mkldnninfo->handler->GetDstFormat(),
+          "Conv input dimension and filter dimension should be the same.");
+      output->ShareDataWith(*residual_param);
+      if (residual_dt == mkldnn::memory::data_type::u8) {
+        uint8_t* output_data = output->mutable_data<uint8_t>(ctx.GetPlace());
+        mkldnninfo->dst_memory_p =
+            mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+                to_void_cast<uint8_t>(output_data));
+      } else {
+        int8_t* output_data = output->mutable_data<int8_t>(ctx.GetPlace());
+        mkldnninfo->dst_memory_p =
+            mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+                to_void_cast<int8_t>(output_data));
+      }
+    } else if (!mkldnninfo->force_fp32_output) {
+      if (mkldnninfo->fuse_relu) {
+        uint8_t* output_data = output->mutable_data<uint8_t>(
+            ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+            mkldnninfo->handler->GetDstMemorySize());
+        mkldnninfo->dst_memory_p =
+            mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+                to_void_cast<uint8_t>(output_data));
+      } else {
+        int8_t* output_data = output->mutable_data<int8_t>(
+            ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+            mkldnninfo->handler->GetDstMemorySize());
+        mkldnninfo->dst_memory_p =
+            mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+                to_void_cast<int8_t>(output_data));
+      }
+    } else {
+      float* output_data = output->mutable_data<float>(
+          ctx.GetPlace(), ::paddle::memory::Allocator::kDefault,
+          mkldnninfo->handler->GetDstMemorySize());
+      mkldnninfo->dst_memory_p =
+          mkldnninfo->handler->AcquireDstMemoryFromPrimitive(
+              to_void_cast<float>(output_data));
+    }
+
+    // create convolution op primitive
+    std::vector<float> scale_bias_data;
+    auto scale_bias_key = *mkldnninfo->key + "@scale_bias";
+    if (bias) {
+      const float* bias_data = bias->data<float>();
+      auto user_bias_md = platform::MKLDNNMemDesc(
+          {bias_tz}, platform::MKLDNNGetDataType<float>(), memory::format::x);
+      auto user_bias_memory_p = mkldnninfo->handler->AcquireBiasMemory(
+          user_bias_md, to_void_cast<float>(bias_data));
+      std::shared_ptr<mkldnn::memory> bias_memory_p;
+      int mask_reorder = is_multi_channel ? 1 << 0 : 1;
+      int count =
+          is_multi_channel
+              ? (convinfo->g > 1
+                     ? (*convinfo->weights_tz)[1] * (*convinfo->weights_tz)[0]
+                     : (*convinfo->weights_tz)[0])
+              : 1;
+      scale_bias_data.resize(count);
+#pragma omp parallel for if (count > 1)
+      for (int i = 0; i < count; i++) {
+        scale_bias_data[i] = scale_in_data * scale_weights_data[i];
+      }
+      bias_memory_p = mkldnninfo->handler->AcquireBiasMemoryFromPrimitive(
+          user_bias_memory_p, *mkldnninfo->pipeline, mkldnninfo->is_test,
+          is_INT8, scale_bias_data, mask_reorder);
+      mkldnninfo->conv_p = mkldnninfo->handler->AcquireConvolution(
+          mkldnninfo->src_memory_p, weights_memory_p, bias_memory_p,
+          mkldnninfo->dst_memory_p);
+    } else {
+      mkldnninfo->conv_p = mkldnninfo->handler->AcquireConvolution(
+          mkldnninfo->src_memory_p, weights_memory_p, mkldnninfo->dst_memory_p);
     }
 
     // push primitive to stream and wait until it's executed
-    pipeline.push_back(*conv_p);
-    stream(stream::kind::eager).submit(pipeline).wait();
-
-    output->set_layout(DataLayout::kMKLDNN);
-    output->set_format(GetMKLDNNFormat(*dst_memory_p));
+    mkldnninfo->pipeline->push_back(*mkldnninfo->conv_p);
   }
 
- private:
-  mkldnn::primitive_attr CreatePostOps(bool fuse_relu,
-                                       bool fuse_residual_conn) const {
+  mkldnn::primitive_attr CreatePostOps(
+      bool fuse_relu, bool fuse_residual_conn,
+      const std::vector<float> output_shift_scale, float sum_scale) const {
     mkldnn::primitive_attr conv_attr;
     mkldnn::post_ops post_operations;
     // Fusion with Elementwise layer relies on adding a sum post-operation with
@@ -282,6 +712,31 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     // true, the output tensor contains the data coming from residual
     // connection. The result of this post_op is:
     // Output = scale * Output + Conv_Out.
+    int mask = output_shift_scale.size() > 1 ? 1 << 1 : 0;
+    conv_attr.set_output_scales(mask, output_shift_scale);
+    if (fuse_residual_conn) {
+      post_operations.append_sum(sum_scale);
+    }
+    if (fuse_relu) {
+      constexpr float scale = 1.0f;
+      constexpr float negative_slope = 0.0f;
+      constexpr float placeholder = 1.0f;  // beta
+      post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_relu,
+                                     negative_slope, placeholder);
+    }
+    conv_attr.set_post_ops(post_operations);
+    return conv_attr;
+  }
+
+  mkldnn::primitive_attr CreatePostOps(bool fuse_relu,
+                                       bool fuse_residual_conn) const {
+    mkldnn::primitive_attr conv_attr;
+    mkldnn::post_ops post_operations;
+    // Fusion with Elementwise layer relies on adding a sum post-operation with
+    // the scale parameter. It is assumed that when fuse_residual_conn is true,
+    // the
+    // Output tensor contains the data coming from residual connection. The
+    // result of this post_op is: Output = scale * Output + Conv_Out.
     if (fuse_residual_conn) {
       post_operations.append_sum(1.0f);
     }
@@ -304,6 +759,34 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
                        const std::vector<int>& paddings,
                        const mkldnn::engine& engine, const bool fuse_relu,
                        const bool fuse_residual_conn,
+                       const std::vector<float> output_shift_scale,
+                       const float sum_scale, bool is_test) const {
+    memory::dims stride_dims = {strides[0], strides[1]};
+    memory::dims padding_dims = {paddings[0], paddings[1]};
+
+    auto propagation = is_test ? mkldnn::prop_kind::forward_scoring
+                               : mkldnn::prop_kind::forward_training;
+
+    auto conv_desc = mkldnn::convolution_forward::desc(
+        propagation, mkldnn::convolution_direct, src, weights, dst, stride_dims,
+        padding_dims, padding_dims, mkldnn::padding_kind::zero);
+
+    mkldnn::primitive_attr conv_attr = CreatePostOps(
+        fuse_relu, fuse_residual_conn, output_shift_scale, sum_scale);
+
+    auto p_conv_pd = new mkldnn::convolution_forward::primitive_desc(
+        conv_desc, conv_attr, engine);
+
+    return std::unique_ptr<mkldnn::convolution_forward::primitive_desc>(
+        p_conv_pd);
+  }
+
+  std::unique_ptr<mkldnn::convolution_forward::primitive_desc>
+  ConvFwdPrimitiveDesc(const memory::desc& src, const memory::desc& weights,
+                       const memory::desc& dst, const std::vector<int>& strides,
+                       const std::vector<int>& paddings,
+                       const mkldnn::engine& engine, const bool fuse_relu,
+                       const bool fuse_residual_conn,
                        mkldnn::prop_kind fwd_prop_kind) const {
     memory::dims stride_dims = strides;
     memory::dims padding_dims = paddings;
@@ -314,6 +797,35 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
 
     mkldnn::primitive_attr conv_attr =
         CreatePostOps(fuse_relu, fuse_residual_conn);
+
+    auto p_conv_pd = new mkldnn::convolution_forward::primitive_desc(
+        conv_desc, conv_attr, engine);
+
+    return std::unique_ptr<mkldnn::convolution_forward::primitive_desc>(
+        p_conv_pd);
+  }
+
+  std::unique_ptr<mkldnn::convolution_forward::primitive_desc>
+  ConvFwdPrimitiveDesc(const memory::desc& src, const memory::desc& weights,
+                       const memory::desc& bias, const memory::desc& dst,
+                       const std::vector<int>& strides,
+                       const std::vector<int>& paddings,
+                       const mkldnn::engine& engine, const bool fuse_relu,
+                       const bool fuse_residual_conn,
+                       const std::vector<float> output_shift_scale,
+                       const float sum_scale, bool is_test) const {
+    memory::dims stride_dims = {strides[0], strides[1]};
+    memory::dims padding_dims = {paddings[0], paddings[1]};
+
+    auto propagation = is_test ? mkldnn::prop_kind::forward_scoring
+                               : mkldnn::prop_kind::forward_training;
+
+    auto conv_desc = mkldnn::convolution_forward::desc(
+        propagation, mkldnn::convolution_direct, src, weights, bias, dst,
+        stride_dims, padding_dims, padding_dims, mkldnn::padding_kind::zero);
+
+    mkldnn::primitive_attr conv_attr = CreatePostOps(
+        fuse_relu, fuse_residual_conn, output_shift_scale, sum_scale);
 
     auto p_conv_pd = new mkldnn::convolution_forward::primitive_desc(
         conv_desc, conv_attr, engine);
@@ -412,9 +924,12 @@ class ConvMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     // Get an unique name from "argument" name of "Output" variable
     // as well as attributes of primitive to be created
     // This name will be used as key when saving info into device context
-    const std::string key = platform::ConvMKLDNNHandler::GetHash(
-        src_tz, weights_tz, strides, paddings, dilations, groups,
-        ctx.op().Input("Output"));
+    const int MaxKeyLength = 256;
+    std::string key;
+    key.reserve(MaxKeyLength);
+    platform::ConvMKLDNNHandler::AppendKey(key, src_tz, weights_tz, strides,
+                                           paddings, dilations, groups,
+                                           ctx.op().Input("Output"));
 
     const std::string key_conv_pd = key + "@conv_pd";
     std::vector<primitive> pipeline;
@@ -486,7 +1001,6 @@ class ConvMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
         user_weights_md, to_void_cast<T>(filter_data));
     auto user_diff_dst_memory_p = handler.AcquireDiffDstMemory(
         user_diff_dst_md, to_void_cast<T>(output_grad_data));
-
     // create backward conv primitive for weights
     if (filter_grad) {
       auto src_memory_p = handler.AcquireSrcMemoryFromWeightsPrimitive(
@@ -549,7 +1063,19 @@ namespace ops = paddle::operators;
 REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv2d, MKLDNN,
                                     ::paddle::platform::CPUPlace, FP32,
                                     ops::kConvMKLDNNFP32,
-                                    ops::ConvMKLDNNOpKernel<float>);
+                                    ops::ConvMKLDNNOpKernel<float, float>);
+// ops::ConvMKLDNNOpKernel<uint8_t>,
+// ops::ConvMKLDNNOpKernel<int8_t>);
+
+REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv2d, MKLDNN,
+                                    ::paddle::platform::CPUPlace, U8,
+                                    ops::kConvMKLDNNFP32,
+                                    ops::ConvMKLDNNOpKernel<uint8_t, float>);
+
+REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv2d, MKLDNN,
+                                    ::paddle::platform::CPUPlace, S8,
+                                    ops::kConvMKLDNNFP32,
+                                    ops::ConvMKLDNNOpKernel<int8_t, float>);
 
 REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv2d_grad, MKLDNN,
                                     ::paddle::platform::CPUPlace, FP32,
@@ -559,7 +1085,7 @@ REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv2d_grad, MKLDNN,
 REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv3d, MKLDNN,
                                     ::paddle::platform::CPUPlace, FP32,
                                     ops::kConvMKLDNNFP32,
-                                    ops::ConvMKLDNNOpKernel<float>);
+                                    ops::ConvMKLDNNOpKernel<float, float>);
 
 REGISTER_OP_KERNEL_WITH_CUSTOM_TYPE(conv3d_grad, MKLDNN,
                                     ::paddle::platform::CPUPlace, FP32,

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -98,9 +98,6 @@ framework::OpKernelType ConvOp::GetExpectedKernelType(
 #endif
 
   auto input_data_type = ctx.Input<Tensor>("Input")->type();
-  auto filter_data_type = ctx.Input<Tensor>("Filter")->type();
-  PADDLE_ENFORCE_EQ(input_data_type, filter_data_type,
-                    "input and filter data type should be consistent");
 
   if (input_data_type == framework::proto::VarType::FP16) {
     PADDLE_ENFORCE_EQ(library, framework::LibraryType::kCUDNN,
@@ -178,6 +175,26 @@ void Conv2DOpMaker::Make() {
                 "(bool, default false) Only used in mkldnn kernel. Used "
                 "whenever convolution output is as an input to residual "
                 "connection.")
+      .SetDefault(false);
+  AddAttr<float>("Scale_in",
+                 "Scale_in to be used for int8 input data."
+                 "Only used with INT8.")
+      .SetDefault(1.0f);
+  AddAttr<float>("Scale_out",
+                 "Scale_out to be used for int8 output data."
+                 "Only used with MKL-DNN.")
+      .SetDefault(1.0f);
+  AddAttr<float>("Scale_in_eltwise",
+                 "Scale_in_eltwise to be used for int8 eltwise input data."
+                 "Only used with MKL-DNN.")
+      .SetDefault(1.0f);
+  AddAttr<std::vector<float>>("Scale_weights",
+                              "Scale_weights to be used for int8 weights data."
+                              "Only used with MKL-DNN.")
+      .SetDefault({1.0f});
+  AddAttr<bool>("force_fp32_output",
+                "(bool, default false) Force INT8 kernel output FP32, only "
+                "used in mkldnn kernel")
       .SetDefault(false);
   AddAttr<std::string>(
       "data_format",
@@ -303,6 +320,9 @@ void Conv3DOpMaker::Make() {
       "Defaults to \"NHWC\". Specify the data format of the output data, "
       "the input will be transformed automatically. ")
       .SetDefault("AnyLayout");
+  AddAttr<bool>("force_fp32_output",
+                "(bool, default false) Only used in mkldnn INT8 kernel")
+      .SetDefault(false);
   // TODO(dzhwinter): need to registered layout transform function
   AddAttr<int>("workspace_size_MB",
                "Only used in cudnn kernel. workspace size for cudnn, in MB, "

--- a/paddle/fluid/operators/dequantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/dequantize_mkldnn_op.cc
@@ -1,0 +1,88 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "mkldnn.hpp"
+#include "paddle/fluid/framework/data_layout_transform.h"
+#include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/operators/dequantize_op.h"
+#include "paddle/fluid/platform/mkldnn_helper.h"
+
+namespace paddle {
+namespace operators {
+
+using mkldnn::memory;
+using mkldnn::primitive;
+using mkldnn::reorder;
+using platform::to_void_cast;
+using Tensor = framework::Tensor;
+using framework::DataLayout;
+using mkldnn::stream;
+using platform::GetMKLDNNFormat;
+
+template <typename T>
+class DeQuantOpKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* input = ctx.Input<Tensor>("Input");
+    auto scale_data = ctx.Attr<float>("Scale");
+    auto* output = ctx.Output<Tensor>("Output");
+    auto& dev_ctx =
+        ctx.template device_context<platform::MKLDNNDeviceContext>();
+    const auto& engine = dev_ctx.GetEngine();
+
+    const T* input_data = input->data<T>();
+    float* output_data = output->mutable_data<float>(ctx.GetPlace());
+    std::vector<float> reorder_scale = {1.0f / scale_data};
+
+    std::vector<primitive> pipeline;
+    std::vector<int> src_tz = paddle::framework::vectorize2int(input->dims());
+    std::vector<int> dst_tz = paddle::framework::vectorize2int(output->dims());
+    mkldnn::memory::data_type src_dt =
+        paddle::framework::ToMKLDNNDataType(input->type());
+    mkldnn::memory::format src_fmt = input->format();
+
+    mkldnn::primitive_attr attri;
+    int mask = 0;
+    attri.set_output_scales(mask, reorder_scale);
+
+    auto src_md = platform::MKLDNNMemDesc({src_tz}, src_dt, src_fmt);
+    auto src_pd = mkldnn::memory::primitive_desc(src_md, engine);
+    auto src_memory =
+        std::make_shared<mkldnn::memory>(src_pd, to_void_cast<T>(input_data));
+    std::shared_ptr<primitive::at> src_memory_p =
+        std::shared_ptr<primitive::at>(new primitive::at(*src_memory));
+
+    auto dst_md = platform::MKLDNNMemDesc({dst_tz}, memory::data_type::f32,
+                                          memory::format::nchw);
+    auto dst_pd = mkldnn::memory::primitive_desc(dst_md, engine);
+    auto dst_memory = mkldnn::memory(dst_pd, to_void_cast<float>(output_data));
+
+    auto reorder_pd = std::shared_ptr<reorder::primitive_desc>(
+        new reorder::primitive_desc(src_pd, dst_pd, attri));
+    auto reorder_p = std::shared_ptr<reorder>(
+        new reorder(*reorder_pd, *src_memory_p, dst_memory));
+    pipeline.push_back(*reorder_p);
+    stream(stream::kind::eager).submit(pipeline).wait();
+
+    output->set_format(GetMKLDNNFormat(dst_memory));
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OP_KERNEL(dequantize, MKLDNN, ::paddle::platform::CPUPlace,
+                   ops::DeQuantOpKernel<uint8_t>, ops::DeQuantOpKernel<int8_t>);

--- a/paddle/fluid/operators/dequantize_op.cc
+++ b/paddle/fluid/operators/dequantize_op.cc
@@ -1,0 +1,45 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/dequantize_op.h"
+#ifdef PADDLE_WITH_MKLDNN
+#include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
+namespace paddle {
+namespace operators {
+
+framework::OpKernelType DeQuantOp::GetExpectedKernelType(
+    const framework::ExecutionContext& ctx) const {
+  framework::LibraryType library_ = framework::LibraryType::kMKLDNN;
+  framework::DataLayout layout_ = framework::DataLayout::kMKLDNN;
+
+  return framework::OpKernelType(ctx.Input<Tensor>("Input")->type(),
+                                 ctx.GetPlace(), layout_, library_);
+}
+
+void DeQuantOpMaker::Make() {
+  AddInput("Input", "input data");
+  AddOutput("Output", "output data");
+  AddAttr<float>("Scale", "scale data").SetDefault({1.0f});
+  AddComment(R"DOC(This op will quantize data from INT8 to FP32)DOC");
+}
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(dequantize, ops::DeQuantOp, ops::DeQuantOpMaker,
+                  paddle::framework::DefaultGradOpDescMaker<true>);

--- a/paddle/fluid/operators/dequantize_op.h
+++ b/paddle/fluid/operators/dequantize_op.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+using framework::OpKernelType;
+using framework::Tensor;
+
+class DeQuantOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    ctx->SetOutputDim("Output", ctx->GetInputDim("Input"));
+    ctx->ShareLoD("Input", /*->*/ "Output");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override;
+};
+
+class DeQuantOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override;
+};
+
+class DeQuantGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {}
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/quantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/quantize_mkldnn_op.cc
@@ -1,0 +1,100 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "mkldnn.hpp"
+#include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/operators/quantize_op.h"
+#include "paddle/fluid/platform/mkldnn_helper.h"
+
+namespace paddle {
+namespace operators {
+
+using mkldnn::memory;
+using mkldnn::primitive;
+using mkldnn::reorder;
+using platform::to_void_cast;
+using Tensor = framework::Tensor;
+using framework::DataLayout;
+using mkldnn::stream;
+using platform::GetMKLDNNFormat;
+
+template <typename T>
+class QuantOpKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* input = ctx.Input<Tensor>("Input");
+    auto scale_data = ctx.Attr<float>("Scale");
+    auto* output = ctx.Output<Tensor>("Output");
+    auto& dev_ctx =
+        ctx.template device_context<platform::MKLDNNDeviceContext>();
+    const auto& engine = dev_ctx.GetEngine();
+
+    std::vector<primitive> pipeline;
+    std::vector<int> src_tz = paddle::framework::vectorize2int(input->dims());
+    std::vector<int> dst_tz = paddle::framework::vectorize2int(output->dims());
+
+    const T* input_data = input->data<T>();
+
+    mkldnn::primitive_attr attri;
+    int mask = 0;
+    attri.set_output_scales(mask, {scale_data});
+
+    auto src_md = platform::MKLDNNMemDesc({src_tz}, memory::data_type::f32,
+                                          input->format());
+    auto src_pd = mkldnn::memory::primitive_desc(src_md, engine);
+    auto src_memory =
+        std::make_shared<mkldnn::memory>(src_pd, to_void_cast<T>(input_data));
+    std::shared_ptr<primitive::at> src_memory_p =
+        std::shared_ptr<primitive::at>(new primitive::at(*src_memory));
+
+    bool is_negative = ctx.Attr<bool>("is_negative_input");
+    mkldnn::memory::primitive_desc dst_pd;
+    std::shared_ptr<mkldnn::memory> dst_memory;
+    if (is_negative) {
+      int8_t* output_data = output->mutable_data<int8_t>(ctx.GetPlace());
+      auto dst_md = platform::MKLDNNMemDesc({dst_tz}, memory::data_type::s8,
+                                            memory::format::nhwc);
+      dst_pd = mkldnn::memory::primitive_desc(dst_md, engine);
+      dst_memory.reset(
+          new mkldnn::memory(dst_pd, to_void_cast<int8_t>(output_data)));
+    } else {
+      uint8_t* output_data = output->mutable_data<uint8_t>(ctx.GetPlace());
+      auto dst_md = platform::MKLDNNMemDesc({dst_tz}, memory::data_type::u8,
+                                            memory::format::nhwc);
+      dst_pd = mkldnn::memory::primitive_desc(dst_md, engine);
+      dst_memory.reset(
+          new mkldnn::memory(dst_pd, to_void_cast<uint8_t>(output_data)));
+    }
+
+    auto reorder_pd = std::shared_ptr<reorder::primitive_desc>(
+        new reorder::primitive_desc(src_pd, dst_pd, attri));
+    auto reorder_p = std::shared_ptr<reorder>(
+        new reorder(*reorder_pd, *src_memory_p, *dst_memory));
+
+    pipeline.push_back(*reorder_p);
+    stream(stream::kind::eager).submit(pipeline).wait();
+
+    output->set_layout(DataLayout::kMKLDNN);
+    output->set_format(GetMKLDNNFormat(*dst_memory));
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+namespace ops = paddle::operators;
+
+// TODO(Xiaoli) Support FP32->S8 quantization.
+
+REGISTER_OP_KERNEL(quantize, MKLDNN, ::paddle::platform::CPUPlace,
+                   ops::QuantOpKernel<float>);

--- a/paddle/fluid/operators/quantize_op.cc
+++ b/paddle/fluid/operators/quantize_op.cc
@@ -1,0 +1,47 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *     Unless required by applicable law or agreed to in writing, software
+ *     distributed under the License is distributed on an "AS IS" BASIS,
+ *     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *     See the License for the specific language governing permissions and
+ *     limitations under the License. */
+
+#include "paddle/fluid/operators/quantize_op.h"
+#ifdef PADDLE_WITH_MKLDNN
+#include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
+namespace paddle {
+namespace operators {
+
+framework::OpKernelType QuantOp::GetExpectedKernelType(
+    const framework::ExecutionContext& ctx) const {
+  framework::LibraryType library_ = framework::LibraryType::kMKLDNN;
+  framework::DataLayout layout_ = framework::DataLayout::kMKLDNN;
+
+  return framework::OpKernelType(ctx.Input<Tensor>("Input")->type(),
+                                 ctx.GetPlace(), layout_, library_);
+}
+
+void QuantOpMaker::Make() {
+  AddInput("Input", "input data");
+  AddOutput("Output", "output data");
+  AddAttr<bool>("is_negative_input",
+                "(bool, default false) Only used in mkldnn INT8 kernel")
+      .SetDefault(false);
+  AddAttr<float>("Scale", "scale data").SetDefault({1.0f});
+  AddComment(R"DOC(This op will quantize data from FP32 to INT8)DOC");
+}
+
+}  // namespace operators
+}  // namespace paddle
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(quantize, ops::QuantOp, ops::QuantOpMaker,
+                  paddle::framework::DefaultGradOpDescMaker<true>);

--- a/paddle/fluid/operators/quantize_op.h
+++ b/paddle/fluid/operators/quantize_op.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+using framework::OpKernelType;
+using framework::Tensor;
+
+class QuantOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    ctx->SetOutputDim("Output", ctx->GetInputDim("Input"));
+    ctx->ShareLoD("Input", /*->*/ "Output");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override;
+};
+
+class QuantOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override;
+};
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -144,7 +144,8 @@ class MKLDNNHandler {
       const std::shared_ptr<mkldnn::memory> user_memory_p,
       const std::string& suffix,
       std::vector<mkldnn::primitive>& pipeline,  // NOLINT
-      bool is_persistent = false) {
+      bool is_persistent = false, bool is_INT8 = false,
+      std::vector<float> scale_data = {1.0f}, int mask = 0) {
     // create reorder primitive if the input format is not the preferred one
     auto local_key = key_ + suffix;
     auto key_reorder_p = key_ + suffix + "reorder_p";
@@ -158,8 +159,20 @@ class MKLDNNHandler {
       std::shared_ptr<mkldnn::primitive> reorder_p;
       if (mpd != user_mpd) {
         target_memory_p = std::make_shared<mkldnn::memory>(mpd);
-        auto reorder_p =
-            std::make_shared<mkldnn::reorder>(*user_memory_p, *target_memory_p);
+        std::shared_ptr<mkldnn::reorder> reorder_p;
+        if (is_INT8) {
+          mkldnn::primitive_attr
+              attri;  // attribute for int8 weights and bias data reorder.
+          attri.set_output_scales(mask, scale_data);
+
+          auto reorder_pd = std::shared_ptr<mkldnn::reorder::primitive_desc>(
+              new mkldnn::reorder::primitive_desc(user_mpd, mpd, attri));
+          reorder_p = std::shared_ptr<mkldnn::reorder>(new mkldnn::reorder(
+              *reorder_pd, *user_memory_p, *target_memory_p));
+        } else {
+          reorder_p = std::make_shared<mkldnn::reorder>(*user_memory_p,
+                                                        *target_memory_p);
+        }
         dev_ctx_.SetBlob(key_reorder_p, reorder_p);
         pipeline.push_back(*reorder_p);
       }
@@ -179,6 +192,42 @@ class MKLDNNHandler {
   static std::string GetHash(mkldnn::memory::dims& operand_dims,  // NOLINT
                              const std::string& suffix) {
     return dims2str(operand_dims) + suffix;
+  }
+
+  static void AppendKey(std::string& key,                    // NOLINT
+                        mkldnn::memory::dims& input_dims,    // NOLINT
+                        mkldnn::memory::dims& weights_dims,  // NOLINT
+                        std::vector<int>& strides,           // NOLINT
+                        std::vector<int>& paddings,          // NOLINT
+                        std::vector<int>& dilations,         // NOLINT
+                        int groups, const std::string& suffix) {
+    AppendKeyDims(key, input_dims);
+    AppendKeyDims(key, weights_dims);
+    AppendKeyVec(key, strides);
+    AppendKeyVec(key, paddings);
+    AppendKeyVec(key, dilations);
+    AppendKey(key, std::to_string(groups));
+    AppendKey(key, suffix);
+  }
+
+ protected:
+  static void AppendKeyDims(std::string& key,  // NOLINT
+                            const mkldnn::memory::dims& dims) {
+    for (unsigned int i = 0; i < dims.size(); i++) {
+      AppendKey(key, std::to_string(dims[i]));
+    }
+  }
+
+  static void AppendKeyVec(std::string& key,  // NOLINT
+                           const std::vector<int>& dims) {
+    for (unsigned int i = 0; i < dims.size(); i++) {
+      AppendKey(key, std::to_string(dims[i]));
+    }
+  }
+
+  static void AppendKey(std::string& key,  // NOLINT
+                        const std::string& s) {
+    key.append(s);
   }
 
  protected:
@@ -322,21 +371,26 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
   std::shared_ptr<mkldnn::memory> AcquireWeightsMemoryFromPrimitive(
       const std::shared_ptr<mkldnn::memory> user_weights_memory_p,
       std::vector<mkldnn::primitive>& pipeline,  // NOLINT
-      bool is_persistent = false) {
+      bool is_persistent = false, bool is_INT8 = false,
+      std::vector<float> scale_data = {1.0f}, int mask = 0) {
     auto user_weights_pd = user_weights_memory_p->get_primitive_desc();
     auto weights_pd = conv_pd_->weights_primitive_desc();
-    return this->AcquireMemory(weights_pd, user_weights_pd,
-                               user_weights_memory_p, "@weights_mem_p",
-                               pipeline, is_persistent);
+    return this->AcquireMemory(
+        weights_pd, user_weights_pd, user_weights_memory_p, "@weights_mem_p",
+        pipeline, is_persistent, is_INT8, scale_data, mask);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireBiasMemoryFromPrimitive(
       const std::shared_ptr<mkldnn::memory> user_bias_memory_p,
-      std::vector<mkldnn::primitive>& pipeline) {  // NOLINT
+      std::vector<mkldnn::primitive>& pipeline,  // NOLINT
+      bool is_persistent = false, bool is_INT8 = false,
+      std::vector<float> scale_data = {1.0f},
+      int mask = 0) {  // NOLINT
     auto user_bias_pd = user_bias_memory_p->get_primitive_desc();
     auto bias_pd = conv_pd_->bias_primitive_desc();
     return this->AcquireMemory(bias_pd, user_bias_pd, user_bias_memory_p,
-                               "@bias_mem_p", pipeline);
+                               "@bias_mem_p", pipeline, is_persistent, is_INT8,
+                               scale_data, mask);
   }
 
   std::shared_ptr<forward_t> AcquireConvolution(

--- a/python/paddle/fluid/tests/unittests/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dequantize_mkldnn_op.py
@@ -1,0 +1,73 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+from op_test import OpTest
+
+
+class TestDeQuantizeOp(OpTest):
+    def setUp(self):
+        self.op_type = 'dequantize'
+        self.scale = 2.0
+        self.input_size = [1, 1, 5, 5]  #Naive nChw16c
+        self.data_type = 'int8'
+        self.set_scale()
+        self.set_data_type()
+
+        if self.data_type == 'int8':
+            input = (np.random.randint(0, 100, self.input_size) - 50
+                     ).astype(self.data_type)
+            output = (input * (1 / self.scale)).astype('float')
+        else:
+            input = (np.random.randint(0, 100,
+                                       self.input_size)).astype(self.data_type)
+            output = (input * (1 / self.scale)).astype('float')
+
+        self.inputs = {'Input': OpTest.np_dtype_to_fluid_dtype(input)}
+
+        self.outputs = {'Output': output}
+
+        self.attrs = {'Scale': self.scale, }
+
+    def test_check_output(self):
+        self.check_output()
+
+    def set_scale(self):
+        pass
+
+    def set_data_type(OpTest):
+        pass
+
+
+class TestDeQuantizeOp1(TestDeQuantizeOp):
+    def set_scale(self):
+        self.scale = 1.5
+
+    def set_data_type(self):
+        self.data_type = 'int8'
+
+
+class TestDeQuantizeOp2(TestDeQuantizeOp):
+    def set_scale(self):
+        self.scale = 0.8
+
+    def set_data_type(self):
+        self.data_type = 'uint8'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_quantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_quantize_mkldnn_op.py
@@ -1,0 +1,76 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+from op_test import OpTest
+
+
+class TestQuantizeOp(OpTest):
+    def setUp(self):
+        self.op_type = 'quantize'
+        self.scale = 2.0
+        self.input_size = [1, 1, 5, 5]  #Naive nChw16c
+        self.is_negative = False
+        self.set_scale()
+        self.set_is_negative()
+
+        if self.is_negative:
+            input = (100 * np.random.random_sample(self.input_size) - 50
+                     ).astype('float32')
+            output = np.round(input * self.scale).astype('int8')
+        else:
+            input = (100 *
+                     np.random.random_sample(self.input_size)).astype('float32')
+            output = np.round(input * self.scale).astype('uint8')
+
+        self.inputs = {'Input': OpTest.np_dtype_to_fluid_dtype(input)}
+
+        self.outputs = {'Output': output}
+
+        self.attrs = {
+            'Scale': self.scale,
+            'is_negative_input': self.is_negative
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+    def set_scale(self):
+        pass
+
+    def set_is_negative(self):
+        pass
+
+
+class TestQuantizeOp1(TestQuantizeOp):
+    def set_scale(self):
+        self.scale = 1.5
+
+    def set_is_negative(self):
+        self.is_nagative = True
+
+
+class TestQuantizeOp2(TestQuantizeOp):
+    def set_scale(self):
+        self.scale = 0.1
+
+    def set_is_negative(self):
+        self.is_nagative = False
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
We enabled mkldnn INT8 inference with performance:

Paddle version | Topology | Performance measured on SKX8180 1S (HT On, Turbo On) (Throughput imgs/sec; Latency: ms;   1x1: batch size 1 x thread 1 |  
-- | -- | -- | --
 
FP32 Throughput | INT8 Throughput | FP32 Latency (1x1) | INT8 Latency (1x1) | FP32 Latency (1x4) | INT8 Latency (1x4) | FP32 Latency (1x28) | INT8 Latency (1x28) |  
Our master: 77ca0bce10f1c85de0cc04330958e2bf9db72fee | ResNet-50 (FB) | 338 | 537 | 54.0 | 32.5 | 16.3 | 10.0 | 7.2 | 4.1 |  
MobileNet-V1 | 1206 | 1958 | 8.8 | 6.5 | 3.1 | 2.6 | 2.1 | 1.8 |  
Baidu develop: b82a44ea8500edcdddbd3459ce89f9a44c1e2b41 | ResNet-50 (FB) | 335 |   | 54.7 |   | 17.8 |   | 9.0 |   |  
MobileNet-V1 | 1193 |   | 9.6 |   | 3.7 |   | 2.9 |   |  
  |   |   |   |   |   |   |   |   |   |  
Paddle version | Topology | Performance measured on SKX6148 1S (HT On, Turbo On) (Throughput imgs/sec; Latency: ms;   1x1: batch size 1 x thread 1 |  
 
FP32 Throughput | INT8 Throughput | FP32 Latency (1x1) | INT8 Latency (1x1) | FP32 Latency (1x4) | INT8 Latency (1x4) | FP32 Latency (1x20) | INT8 Latency (1x20) |  
Our master: 77ca0bce10f1c85de0cc04330958e2bf9db72fee | ResNet-50 (FB) | 240 | 384 | 54.3 | 32.8 | 17.1 | 10.5 | 8.0 | 5.4 |  
MobileNet-V1 | 1032 | 1598 | 9.0 | 6.7 | 3.3 | 2.7 | 2.3 | 1.9 |  
Baidu develop: b82a44ea8500edcdddbd3459ce89f9a44c1e2b41 | ResNet-50 (FB) | 239 |   | 55.7 |   | 18.6 |   | 10.2 |   |  
MobileNet-V1 | 1015 |   | 9.8 |   | 4.0 |   | 3.2 |   |  

