### PR TITLE
fix weights memory format for grouped convolutions

### DIFF
--- a/paddle/fluid/operators/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/conv_mkldnn_op.cc
@@ -61,10 +61,12 @@ inline void GetWeightsTz(std::vector<int>& weights_tz, int groups,  // NOLINT
 
 inline mkldnn::memory::format GetWeightsFormat(mkldnn::memory::format format,
                                                int groups, bool is_conv3d) {
-  if (is_conv3d) {
-    return (groups == 1) ? format : mkldnn::memory::format::goidhw;
+  if (format == mkldnn::memory::format::any || groups == 1) {
+    return format;
+  } else if (is_conv3d) {
+    return mkldnn::memory::format::goidhw;
   } else {
-    return (groups == 1) ? format : mkldnn::memory::format::goihw;
+    return mkldnn::memory::format::goihw;
   }
 }
 


### PR DESCRIPTION
In the case of grouped convolution with MKL-DNN unnecessary reorders `nchw16c->nchw` and back occur. This was fixed previously with https://github.com/PaddlePaddle/Paddle/pull/14333 but came up again after some recent refactoring.

test=develop