### PR TITLE
fix fuse_broadcast_op not exported in BuildStrategy

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -932,9 +932,7 @@ All parameter, weight, gradient are variables in Paddle.
           R"DOC(The type is BOOL. If set True, some locks in GPU ops would be released and ParallelExecutor would run faster. Default False.)DOC")
       .def_property(
           "fuse_broadcast_op",
-          [](const BuildStrategy &self) {
-            return self.fuse_broadcast_op_;
-          },
+          [](const BuildStrategy &self) { return self.fuse_broadcast_op_; },
           [](BuildStrategy &self, bool b) {
             PADDLE_ENFORCE(!self.IsFinalized(), "BuildStrategy is finlaized.");
             self.fuse_broadcast_op_ = b;

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -931,6 +931,16 @@ All parameter, weight, gradient are variables in Paddle.
           },
           R"DOC(The type is BOOL. If set True, some locks in GPU ops would be released and ParallelExecutor would run faster. Default False.)DOC")
       .def_property(
+          "fuse_broadcast_op",
+          [](const BuildStrategy &self) {
+            return self.fuse_broadcast_op_;
+          },
+          [](BuildStrategy &self, bool b) {
+            PADDLE_ENFORCE(!self.IsFinalized(), "BuildStrategy is finlaized.");
+            self.fuse_broadcast_op_ = b;
+          },
+          R"DOC(The type is BOOL. If set, would fuse multiple broadcast operators into one fused_broadcast operator.)DOC")
+      .def_property(
           "num_trainers",
           [](const BuildStrategy &self) { return self.num_trainers_; },
           [](BuildStrategy &self, int num_trainers) {


### PR DESCRIPTION
in https://github.com/PaddlePaddle/Paddle/blob/develop/benchmark/fluid/fluid_benchmark.py#L182

```
  build_strategy.fuse_broadcast_op = args.fuse_broadcast_op
```

however `fuse_broadcast_op` of `BuildStrategy` is not exported by pybind, hence may result in crash when run fluid_benchmark.py

need to fix this by exporting fuse_broadcast_op in pybind.cc