### PR TITLE
Add temp variable pool in Scope

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -913,7 +913,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   // not Scope. Imperative mode only pass inputs and get outputs.
   kernel_iter->second(ExecutionContext(*this, exec_scope, *dev_ctx, ctx));
 
-  if (!transfered_inplace_vars.empty()) {
+  if (transfer_scope != nullptr && !transfered_inplace_vars.empty()) {
     // there is inplace variable has been transfered.
     TransferInplaceVarsBack(scope, transfered_inplace_vars, *transfer_scope);
   }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1005,16 +1005,14 @@ Scope* OperatorWithKernel::PrepareData(
         new_scope = TryCreateTransferScope(kernel_type_for_var,
                                            expected_kernel_key, &scope);
       }
-      if (!new_scope) {
-        new_scope = &scope.NewScope();
-      }
 
-      auto* trans_var = new_scope->Var(var_name);
-      input_vars[i] = trans_var;
+      std::unique_ptr<Variable> trans_var(new Variable());
+      input_vars[i] = trans_var.get();
 
       Tensor out;
       TransformData(expected_kernel_key, kernel_type_for_var, *tensor_in, &out);
-      SetTensorToVariable(*var, out, trans_var);
+      SetTensorToVariable(*var, out, trans_var.get());
+      scope.AddTempVar(std::move(trans_var));
     }
   }
 

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -174,6 +174,10 @@ class ExecutionContext {
 
   const Scope& scope() const { return scope_; }
 
+  void AddTempVar(std::unique_ptr<Variable>&& var) const {
+    scope_.AddTempVar(std::move(var));
+  }
+
   template <typename T>
   inline const T& Attr(const std::string& name) const {
     return op_.Attr<T>(name);

--- a/paddle/fluid/framework/scope_test.cc
+++ b/paddle/fluid/framework/scope_test.cc
@@ -62,10 +62,12 @@ TEST(Scope, GetAllNames) {
   EXPECT_EQ(&s, s.FindScope(v));
 
   std::vector<std::string> ans = s.LocalVarNames();
-  std::string str;
-  for (auto& var : ans) {
-    str += var;
+  bool found = false;
+  for (auto& str : ans) {
+    if (str == "a") {
+      EXPECT_FALSE(found);
+      found = true;
+    }
   }
-
-  EXPECT_STREQ("a", str.c_str());
+  EXPECT_TRUE(found);
 }

--- a/paddle/fluid/framework/temp_variable_pool.h
+++ b/paddle/fluid/framework/temp_variable_pool.h
@@ -1,0 +1,55 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include <deque>
+#include <mutex>  // NOLINT
+#include "paddle/fluid/framework/variable.h"
+
+namespace paddle {
+namespace framework {
+
+/*
+ * temporary variables stored inside scope
+ */
+constexpr const char kTempVariablePool[] = "@TEMP_VAR_POOL@";
+
+class TempVariablePool {
+ public:
+  TempVariablePool() = default;
+
+  void Push(std::unique_ptr<Variable> &&var) {
+// Not quite sure whether to add this macro guard
+#ifndef PADDLE_ON_INFERENCE
+    std::lock_guard<std::mutex> guard(mtx_);
+#endif
+    vars_.emplace_back(std::move(var));
+  }
+
+  void Clear() {
+#ifndef PADDLE_ON_INFERENCE
+    std::lock_guard<std::mutex> guard(mtx_);
+#endif
+    vars_.clear();
+  }
+
+ private:
+  std::deque<std::unique_ptr<Variable>> vars_;
+#ifndef PADDLE_ON_INFERENCE
+  std::mutex mtx_;
+#endif
+};
+
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/variable.h
+++ b/paddle/fluid/framework/variable.h
@@ -83,17 +83,6 @@ class Variable {
 
   std::unique_ptr<Placeholder>
       holder_;  // pointers to a PlaceholderImpl object indeed.
-
-  // name_ is only meaningful with a Scope and accessible by it.
-  //
-  // NOTE: Please don't expose name_ by adding methods like
-  // Variable::Name or Scope::VarName!  A variable could have a human
-  // readable name or an auto-generated scope-unique name.  In the
-  // former case, the caller knows the name and doesn't need to access
-  // the name; in the latter case, the variable should be identified
-  // by its address but not the unreadable name.
-  friend class Scope;
-  const std::string* name_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -131,9 +131,9 @@ class LoDTensorToArrayOp : public framework::OperatorBase {
       }
     }
 
-    auto &outputs = *const_cast<framework::Scope &>(scope)
-                         .Var()
-                         ->GetMutable<std::map<size_t, framework::Tensor>>();
+    std::unique_ptr<framework::Variable> var(new framework::Variable());
+    auto &outputs = *(var->GetMutable<std::map<size_t, framework::Tensor>>());
+    scope.AddTempVar(std::move(var));
 
     for (size_t i = 0; i < max_seq_len; ++i) {
       auto &ranges = copy_ranges[i];

--- a/paddle/fluid/operators/optimizers/adam_op.h
+++ b/paddle/fluid/operators/optimizers/adam_op.h
@@ -327,12 +327,12 @@ class AdamOpKernel : public framework::OpKernel<T> {
         // merge duplicated rows if any.
         // The rows of grad_merge have been sorted inside MergeAdd functor
         scatter::MergeAdd<DeviceContext, T> merge_func;
-        auto* grad_merge_var = const_cast<framework::Scope&>(ctx.scope())
-                                   .Var()
-                                   ->GetMutable<framework::SelectedRows>();
+        std::unique_ptr<framework::Variable> var(new framework::Variable());
+        auto* grad_merge_var = var->GetMutable<framework::SelectedRows>();
         merge_func(ctx.template device_context<DeviceContext>(), grad,
                    grad_merge_var);
         grad_merge_ptr = grad_merge_var;
+        ctx.AddTempVar(std::move(var));
       }
 
       auto& grad_merge = *grad_merge_ptr;

--- a/paddle/fluid/operators/optimizers/momentum_op.h
+++ b/paddle/fluid/operators/optimizers/momentum_op.h
@@ -349,12 +349,12 @@ class MomentumOpKernel : public framework::OpKernel<T> {
         VLOG(3) << "Grad SelectedRows contains no data!";
         return;
       }
-      auto* merged_grad = const_cast<framework::Scope&>(ctx.scope())
-                              .Var()
-                              ->GetMutable<framework::SelectedRows>();
+      std::unique_ptr<framework::Variable> var(new framework::Variable());
+      auto* merged_grad = var->GetMutable<framework::SelectedRows>();
       math::scatter::MergeAdd<DeviceContext, T> merge_func;
       merge_func(ctx.template device_context<DeviceContext>(), *grad,
                  merged_grad);
+      ctx.AddTempVar(std::move(var));
 
       const int64_t* rows = nullptr;
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/fluid/operators/optimizers/rmsprop_op.h
+++ b/paddle/fluid/operators/optimizers/rmsprop_op.h
@@ -216,12 +216,11 @@ class RmspropOpKernel : public framework::OpKernel<T> {
       }
     } else if (grad_var->IsType<framework::SelectedRows>()) {
       auto &grad = grad_var->Get<framework::SelectedRows>();
-      auto *merged_grad = const_cast<framework::Scope &>(ctx.scope())
-                              .Var()
-                              ->GetMutable<framework::SelectedRows>();
-
+      std::unique_ptr<framework::Variable> var(new framework::Variable());
+      auto *merged_grad = var->GetMutable<framework::SelectedRows>();
       math::scatter::MergeAdd<DeviceContext, T> merge_func;
       merge_func(dev_ctx, grad, merged_grad);
+      ctx.AddTempVar(std::move(var));
 
       platform::ForRange<DeviceContext> for_range(dev_ctx, limit);
       const int64_t *rows;

--- a/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
@@ -103,7 +103,8 @@ class TestClipByNormOpWithSelectedRows(OpTest):
                 np.array(out_tensor), output, atol=1e-5, equal_nan=False))
 
     def test_clip_by_norm_with_selected_ros(self):
-        places = [core.CPUPlace()]
+        #places = [core.CPUPlace()]
+        places = []
         if core.is_compiled_with_cuda():
             places.append(core.CUDAPlace(0))
 

--- a/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
@@ -103,8 +103,7 @@ class TestClipByNormOpWithSelectedRows(OpTest):
                 np.array(out_tensor), output, atol=1e-5, equal_nan=False))
 
     def test_clip_by_norm_with_selected_ros(self):
-        #places = [core.CPUPlace()]
-        places = []
+        places = [core.CPUPlace()]
         if core.is_compiled_with_cuda():
             places.append(core.CUDAPlace(0))
 


### PR DESCRIPTION
This PR is mainly designed to remove `scope.newScope()` in `OperatorWithKernel::RunImpl()`.