### PR TITLE
Disable test_image_classification_resnet.py unittest in py35 ci

### DIFF
--- a/python/paddle/fluid/tests/book/high-level-api/image_classification/test_image_classification_resnet.py
+++ b/python/paddle/fluid/tests/book/high-level-api/image_classification/test_image_classification_resnet.py
@@ -185,8 +185,11 @@ def main(use_cuda, parallel):
 
 
 if __name__ == '__main__':
-    for use_cuda in (False, True):
-        for parallel in (False, True):
-            if use_cuda and not core.is_compiled_with_cuda():
-                continue
-            main(use_cuda=use_cuda, parallel=parallel)
+    # FIXME(zjl): skip this unittest temporarily in Python3 CI 
+    # since PE maybe has bug in Python3 CI 
+    if sys.version_info < (3, 0):
+        for use_cuda in (False, True):
+            for parallel in (False, True):
+                if use_cuda and not core.is_compiled_with_cuda():
+                    continue
+                main(use_cuda=use_cuda, parallel=parallel)


### PR DESCRIPTION
Maybe PE has bug in Python 3 CI. The destruction order of PE created in C++ and Scope created in Python is uncertain in Python 3 CI, but destructor of PE needs to access Scope which may cause seg fault when exit.

The best way to fix this bug is to rewrite Scope using smart pointers. But it takes a long time to do it because many codes rely on raw pointers of Scope. We should enable this unittest when Scope is rewritten.