### PR TITLE
Fix error with cuDNN version less than 7.1.

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -155,7 +155,7 @@ def __bootstrap__():
             'fraction_of_gpu_memory_to_use', 'cudnn_deterministic',
             'enable_cublas_tensor_op_math', 'conv_workspace_size_limit',
             'cudnn_exhaustive_search', 'memory_optimize_debug', 'selected_gpus',
-            'cudnn_exhaustive_search_times', 'sync_nccl_allreduce'
+            'sync_nccl_allreduce'
         ]
 
     core.init_gflags([sys.argv[0]] +


### PR DESCRIPTION
Since conv_fusion_op is not exposed into Python, remote the env flag in __init__.py

Error:
<img width="957" alt="default" src="https://user-images.githubusercontent.com/7845005/50827251-ed50a780-1378-11e9-8b1b-6040c6a994d7.png">
