### PR TITLE
fix analyzer_test runs error in native_config

### DIFF
--- a/paddle/fluid/inference/tests/api/config_printer.h
+++ b/paddle/fluid/inference/tests/api/config_printer.h
@@ -62,7 +62,7 @@ std::ostream &operator<<(std::ostream &os,
                          const contrib::AnalysisConfig &config) {
   os << GenSpaces(num_spaces) << "contrib::AnalysisConfig {\n";
   num_spaces++;
-  os << *reinterpret_cast<const NativeConfig *>(&config);
+  os << config.ToNativeConfig();
   if (!config.model_from_memory()) {
     os << GenSpaces(num_spaces) << "prog_file: " << config.prog_file() << "\n";
     os << GenSpaces(num_spaces) << "param_file: " << config.params_file()

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -54,11 +54,13 @@ namespace paddle {
 namespace inference {
 
 void PrintConfig(const PaddlePredictor::Config *config, bool use_analysis) {
+  const auto *analysis_config =
+      reinterpret_cast<const contrib::AnalysisConfig *>(config);
   if (use_analysis) {
-    LOG(INFO) << *reinterpret_cast<const contrib::AnalysisConfig *>(config);
+    LOG(INFO) << *analysis_config;
     return;
   }
-  LOG(INFO) << *reinterpret_cast<const NativeConfig *>(config);
+  LOG(INFO) << analysis_config->ToNativeConfig();
 }
 
 void CompareResult(const std::vector<PaddleTensor> &outputs,
@@ -96,12 +98,13 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
 
 std::unique_ptr<PaddlePredictor> CreateTestPredictor(
     const PaddlePredictor::Config *config, bool use_analysis = true) {
+  const auto *analysis_config =
+      reinterpret_cast<const contrib::AnalysisConfig *>(config);
   if (use_analysis) {
-    return CreatePaddlePredictor<contrib::AnalysisConfig>(
-        *(reinterpret_cast<const contrib::AnalysisConfig *>(config)));
+    return CreatePaddlePredictor<contrib::AnalysisConfig>(*analysis_config);
   }
-  return CreatePaddlePredictor<NativeConfig>(
-      *(reinterpret_cast<const NativeConfig *>(config)));
+  auto native_config = analysis_config->ToNativeConfig();
+  return CreatePaddlePredictor<NativeConfig>(native_config);
 }
 
 size_t GetSize(const PaddleTensor &out) { return VecReduceToInt(out.shape); }
@@ -328,10 +331,7 @@ void CompareNativeAndAnalysis(
     const std::vector<std::vector<PaddleTensor>> &inputs) {
   PrintConfig(config, true);
   std::vector<PaddleTensor> native_outputs, analysis_outputs;
-  const auto *analysis_config =
-      reinterpret_cast<const contrib::AnalysisConfig *>(config);
-  auto native_config = analysis_config->ToNativeConfig();
-  TestOneThreadPrediction(&native_config, inputs, &native_outputs, false);
+  TestOneThreadPrediction(config, inputs, &native_outputs, false);
   TestOneThreadPrediction(config, inputs, &analysis_outputs, true);
   CompareResult(analysis_outputs, native_outputs);
 }

--- a/paddle/fluid/inference/tests/api/trt_models_tester.cc
+++ b/paddle/fluid/inference/tests/api/trt_models_tester.cc
@@ -99,24 +99,12 @@ void compare(std::string model_dir, bool use_tensorrt) {
     SetFakeImageInput(&inputs_all, model_dir, false, "__model__", "");
   }
 
-  std::vector<PaddleTensor> native_outputs;
-  NativeConfig native_config;
-  SetConfig<NativeConfig>(&native_config, model_dir, true, false,
-                          FLAGS_batch_size);
-  TestOneThreadPrediction(
-      reinterpret_cast<PaddlePredictor::Config*>(&native_config), inputs_all,
-      &native_outputs, false);
-
-  std::vector<PaddleTensor> analysis_outputs;
   contrib::AnalysisConfig analysis_config;
-  analysis_config.EnableUseGpu(50, 0);
   SetConfig<contrib::AnalysisConfig>(&analysis_config, model_dir, true,
                                      use_tensorrt, FLAGS_batch_size);
-  TestOneThreadPrediction(
-      reinterpret_cast<PaddlePredictor::Config*>(&analysis_config), inputs_all,
-      &analysis_outputs, true);
-
-  CompareResult(native_outputs, analysis_outputs);
+  CompareNativeAndAnalysis(
+      reinterpret_cast<const PaddlePredictor::Config*>(&analysis_config),
+      inputs_all);
 }
 
 TEST(TensorRT_mobilenet, compare) {


### PR DESCRIPTION
command:
```
./paddle/fluid/inference/tests/api/test_analyzer_rnn2 \
--infer_model=third_party/inference_demo/rnn2/model/ \
--infer_data=third_party/inference_demo/rnn2/data.txt \
--gtest_filter=Analyzer_rnn2.profile \
--use_analysis=0
```
error log:
```
[ RUN      ] Analyzer_rnn2.profile
WARNING: Logging before InitGoogleLogging() is written to STDERR
I0108 19:21:21.837157 21298 analyzer_rnn2_tester.cc:118] number of samples: 1
I0108 19:21:21.839112 21298 tester_helper.h:61] NativeConfig {
  PaddlePredictor::Config {
    model_dir:
  }
  use_gpu: 56
  device: 0
  fraction_of_gpu_memory: 6.26097e-37
  specify_input_name: 0
  cpu_num_threads: 32556
}
ERROR: unknown command line flag 'fraction_of_gpu_memory_to_use'
```
- In PrintConfig, `use_gpu`, `fraction_of_gpu_memory`, and `cpu_num_threads` are wrong.
- Native mode throws error `ERROR: unknown command line flag 'fraction_of_gpu_memory_to_use'`

After this PR:
```
I0108 19:15:03.677664   894 tester_helper.h:63] NativeConfig {
  PaddlePredictor::Config {
    model_dir:
  }
  use_gpu: 0
  device: 0
  fraction_of_gpu_memory: 0
  specify_input_name: 1
  cpu_num_threads: 1
}
I0108 19:15:03.681556   894 tester_helper.h:203] Warm up run...
I0108 19:15:03.695171   894 helper.h:239] ====== batch_size: 1, repeat: 1, threads: 1, thread id: 0, latency: 13.4969ms, fps: 74.0909 ======
I0108 19:15:03.695241   894 tester_helper.h:214] Run 1 times...
I0108 19:15:03.696722   894 helper.h:239] ====== batch_size: 1, repeat: 1, threads: 1, thread id: 0, latency: 1.45379ms, fps: 687.856 ======
[       OK ] Analyzer_rnn2.profile (591 ms)
[----------] 1 test from Analyzer_rnn2 (591 ms total)
```
- The PrintConfig is right.
- Native mode runs normally.