### PR TITLE
reduce threads number to avoid analyzer_rnn1_tester hang in CI

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_rnn1_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_rnn1_tester.cc
@@ -283,7 +283,7 @@ TEST(Analyzer_rnn1, multi_thread) {
   std::vector<std::vector<PaddleTensor>> input_slots_all;
   SetInput(&input_slots_all);
   TestPrediction(reinterpret_cast<const PaddlePredictor::Config *>(&cfg),
-                 input_slots_all, &outputs, 4 /* multi_thread */);
+                 input_slots_all, &outputs, 2 /* multi_thread */);
 }
 
 // Validate that the AnalysisPredictor + ZeroCopyTensor really works by testing


### PR DESCRIPTION
`analyzer_rnn1_tester` hang in three nightly stress CI recently.
```
[21:12:37]	[Step 1/1] I0108 21:12:36.844130 60234 analysis_predictor.cc:355] == optimize end ==
[21:12:37]	[Step 1/1] I0108 21:12:36.845070 60246 tester_helper.h:260] Running thread 0, warm up run...
[21:12:37]	[Step 1/1] I0108 21:12:36.845139 60247 tester_helper.h:260] Running thread 1, warm up run...
[21:12:37]	[Step 1/1] I0108 21:12:36.845293 60248 tester_helper.h:260] Running thread 2, warm up run...
[21:12:37]	[Step 1/1] I0108 21:12:36.845476 60249 tester_helper.h:260] Running thread 3, warm up run...
[21:12:37]	[Step 1/1] I0108 21:12:36.846681 60246 helper.h:239] ====== batch_size: 1, repeat: 1, threads: 4, thread id: 0, latency: 1.58103ms, fps: 632.499 ======
[21:12:37]	[Step 1/1] I0108 21:12:36.846688 60247 helper.h:239] ====== batch_size: 1, repeat: 1, threads: 4, thread id: 1, latency: 1.51622ms, fps: 659.533 ======
[21:12:37]	[Step 1/1] I0108 21:12:36.846711 60246 tester_helper.h:271] Thread 0 run 1 times...
[21:12:37]	[Step 1/1] I0108 21:12:36.846717 60247 tester_helper.h:271] Thread 1 run 1 times...
[21:12:37]	[Step 1/1] 
```
http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiNight&buildId=47056&_focus=22660
http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiNight&buildId=45770&_focus=22567
http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiNight&buildId=42874&_focus=22269

The reason maybe similar to https://github.com/PaddlePaddle/Paddle/issues/15032#issuecomment-451889962.
Thus, this PR reduce threads number to avoid `analyzer_rnn1_teste`r hang in CI at first.