### PR TITLE
Refine the loggging in fluid-contrib-utils

### DIFF
--- a/python/paddle/fluid/contrib/utils/hdfs_utils.py
+++ b/python/paddle/fluid/contrib/utils/hdfs_utils.py
@@ -27,9 +27,12 @@ import logging
 
 __all__ = ["HDFSClient", "multi_download", "multi_upload"]
 
-logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s')
+_formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(message)s')
+_handler = logging.StreamHandler(stream=sys.stderr)
+_handler.setFormatter(_formatter)
 _logger = logging.getLogger("hdfs_utils")
 _logger.setLevel(logging.INFO)
+_logger.addHandler(_handler)
 
 
 class HDFSClient(object):

--- a/python/paddle/fluid/contrib/utils/lookup_table_utils.py
+++ b/python/paddle/fluid/contrib/utils/lookup_table_utils.py
@@ -27,9 +27,12 @@ __all__ = [
     "convert_dist_to_sparse_program"
 ]
 
-logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s')
+_formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(message)s')
+_handler = logging.StreamHandler(stream=sys.stderr)
+_handler.setFormatter(_formatter)
 _logger = logging.getLogger("lookup_table_utils")
 _logger.setLevel(logging.INFO)
+_logger.addHandler(_handler)
 
 model_filename = "__model__"
 lookup_table_dir = "__lookup_table__"


### PR DESCRIPTION
Refine the loggging in fluid-contrib-utils.
As the comments saying, the usage of `logging.basicConfig` will make effect on the user's code logging setting, maybe we should remove it.

```python
def basicConfig(**kwargs):
    """
    Do basic configuration for the logging system.

    This function does nothing if the root logger already has handlers
    configured. It is a convenience method intended for use by simple scripts
    to do one-shot configuration of the logging package.

    The default behaviour is to create a StreamHandler which writes to
    sys.stderr, set a formatter using the BASIC_FORMAT format string, and
    add the handler to the root logger.

    A number of optional keyword arguments may be specified, which can alter
    the default behaviour.

    filename  Specifies that a FileHandler be created, using the specified
              filename, rather than a StreamHandler.
    filemode  Specifies the mode to open the file, if filename is specified
              (if filemode is unspecified, it defaults to 'a').
    format    Use the specified format string for the handler.
    datefmt   Use the specified date/time format.
    level     Set the root logger level to the specified level.
    stream    Use the specified stream to initialize the StreamHandler. Note
              that this argument is incompatible with 'filename' - if both
              are present, 'stream' is ignored.

    Note that you could specify a stream created using open(filename, mode)
    rather than passing the filename and mode in. However, it should be
    remembered that StreamHandler does not close its stream (since it may be
    using sys.stdout or sys.stderr), whereas FileHandler closes its stream
    when the handler is closed.
    """
    # Add thread safety in case someone mistakenly calls
    # basicConfig() from multiple threads
    _acquireLock()
    try:
        if len(root.handlers) == 0:
            filename = kwargs.get("filename")
            if filename:
                mode = kwargs.get("filemode", 'a')
                hdlr = FileHandler(filename, mode)
            else:
                stream = kwargs.get("stream")
                hdlr = StreamHandler(stream)
            fs = kwargs.get("format", BASIC_FORMAT)
            dfs = kwargs.get("datefmt", None)
            fmt = Formatter(fs, dfs)
            hdlr.setFormatter(fmt)
            root.addHandler(hdlr)
            level = kwargs.get("level")
            if level is not None:
                root.setLevel(level)
    finally:
        _releaseLock()
```