### PR TITLE
Fix performance drop when with MKL-DNN

### DIFF
--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -35,20 +35,8 @@ limitations under the License. */
 DEFINE_double(fraction_of_cpu_memory_to_use, 1,
               "Default use 100% of CPU memory for PaddlePaddle,"
               "reserve the rest for page tables, etc");
-#if !defined(_WIN32)
-DEFINE_uint64(initial_cpu_memory_in_mb,
-#ifdef PADDLE_WITH_MKLDNN
-              /* Aligned with mozga-intel, MKLDNN need at least 5000 MB
-               * to obtain the best performance*/
-              5000ul,
-#else
-              500ul,
-#endif
-              "Initial CPU memory for PaddlePaddle, in MD unit.");
-#else
 DEFINE_uint64(initial_cpu_memory_in_mb, 500ul,
               "Initial CPU memory for PaddlePaddle, in MD unit.");
-#endif  // !defined(_WIN32)
 
 DEFINE_double(
     fraction_of_cuda_pinned_memory_to_use, 0.5,


### PR DESCRIPTION
Recent performance results show that the initial CPU memory of 500MB is enough for inference and training with MKL-DNN.

fix #15282 

test=develop