### PR TITLE
Async double buffered py reader

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -218,7 +218,7 @@ paddle.fluid.layers.shuffle ArgSpec(args=['reader', 'buffer_size'], varargs=None
 paddle.fluid.layers.batch ArgSpec(args=['reader', 'batch_size'], varargs=None, keywords=None, defaults=None)
 paddle.fluid.layers.double_buffer ArgSpec(args=['reader', 'place', 'name'], varargs=None, keywords=None, defaults=(None, None))
 paddle.fluid.layers.random_data_generator ArgSpec(args=['low', 'high', 'shapes', 'lod_levels', 'for_parallel'], varargs=None, keywords=None, defaults=(True,))
-paddle.fluid.layers.py_reader ArgSpec(args=['capacity', 'shapes', 'dtypes', 'lod_levels', 'name', 'use_double_buffer'], varargs=None, keywords=None, defaults=(None, None, True))
+paddle.fluid.layers.py_reader ArgSpec(args=['capacity', 'shapes', 'dtypes', 'lod_levels', 'name', 'use_double_buffer', 'use_cuda_pinned_place'], varargs=None, keywords=None, defaults=(None, None, True, None))
 paddle.fluid.layers.create_py_reader_by_data ArgSpec(args=['capacity', 'feed_list', 'name', 'use_double_buffer'], varargs=None, keywords=None, defaults=(None, True))
 paddle.fluid.layers.Preprocessor.__init__ ArgSpec(args=['self', 'reader', 'name'], varargs=None, keywords=None, defaults=(None,))
 paddle.fluid.layers.Preprocessor.block ArgSpec(args=[], varargs='args', keywords='kwds', defaults=None)

--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -218,7 +218,7 @@ paddle.fluid.layers.shuffle ArgSpec(args=['reader', 'buffer_size'], varargs=None
 paddle.fluid.layers.batch ArgSpec(args=['reader', 'batch_size'], varargs=None, keywords=None, defaults=None)
 paddle.fluid.layers.double_buffer ArgSpec(args=['reader', 'place', 'name'], varargs=None, keywords=None, defaults=(None, None))
 paddle.fluid.layers.random_data_generator ArgSpec(args=['low', 'high', 'shapes', 'lod_levels', 'for_parallel'], varargs=None, keywords=None, defaults=(True,))
-paddle.fluid.layers.py_reader ArgSpec(args=['capacity', 'shapes', 'dtypes', 'lod_levels', 'name', 'use_double_buffer', 'use_cuda_pinned_place'], varargs=None, keywords=None, defaults=(None, None, True, None))
+paddle.fluid.layers.py_reader ArgSpec(args=['capacity', 'shapes', 'dtypes', 'lod_levels', 'name', 'use_double_buffer'], varargs=None, keywords=None, defaults=(None, None, True))
 paddle.fluid.layers.create_py_reader_by_data ArgSpec(args=['capacity', 'feed_list', 'name', 'use_double_buffer'], varargs=None, keywords=None, defaults=(None, True))
 paddle.fluid.layers.Preprocessor.__init__ ArgSpec(args=['self', 'reader', 'name'], varargs=None, keywords=None, defaults=(None,))
 paddle.fluid.layers.Preprocessor.block ArgSpec(args=[], varargs='args', keywords='kwds', defaults=None)

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -85,6 +85,10 @@ void BufferedReader::ReadAsync(size_t i) {
           memory::Copy(boost::get<platform::CUDAPlace>(place_), gpu_ptr,
                        boost::get<platform::CUDAPinnedPlace>(cpu_place),
                        cpu_ptr, size, stream);
+        else if ((platform::is_gpu_place(cpu_place)))
+          memory::Copy(boost::get<platform::CUDAPlace>(place_), gpu_ptr,
+                       boost::get<platform::CUDAPlace>(cpu_place), cpu_ptr,
+                       size, stream);
         else
           // if cpu place is not pinned, async copy is slower than sync copy,
           // so we use sync copy instead.

--- a/paddle/fluid/operators/reader/buffered_reader.h
+++ b/paddle/fluid/operators/reader/buffered_reader.h
@@ -19,6 +19,9 @@
 #include <vector>
 #include "ThreadPool.h"
 #include "paddle/fluid/framework/reader.h"
+#ifdef PADDLE_WITH_CUDA
+#include "paddle/fluid/platform/gpu_info.h"
+#endif
 
 namespace paddle {
 namespace operators {
@@ -59,6 +62,9 @@ class BufferedReader : public framework::DecoratedReader {
   std::vector<TensorVec> cpu_buffer_;
   std::vector<TensorVec> gpu_buffer_;
   size_t prev_pos_{-1UL};
+#ifdef PADDLE_WITH_CUDA
+  cudaStream_t stream;
+#endif
 };
 
 }  // namespace reader

--- a/python/paddle/fluid/layers/io.py
+++ b/python/paddle/fluid/layers/io.py
@@ -483,9 +483,8 @@ def _py_reader(capacity,
                lod_levels=None,
                name=None,
                use_double_buffer=True,
-               use_cuda_pinned_place=False,
                feed_list=None):
-
+    use_cuda_pinned_place = use_double_buffer and core.is_compiled_with_cuda()
     if feed_list is not None:
         if not isinstance(feed_list, list):
             raise TypeError("feed_list should be a list of Variable"
@@ -639,8 +638,7 @@ def py_reader(capacity,
               dtypes,
               lod_levels=None,
               name=None,
-              use_double_buffer=True,
-              use_cuda_pinned_place=None):
+              use_double_buffer=True):
     """
     Create a Python reader for data feeding in Python
 
@@ -664,9 +662,6 @@ def py_reader(capacity,
        name(basestring): The prefix Python queue name and Reader name. None will
             be generated automatically.
        use_double_buffer(bool): Whether use double buffer or not.
-       use_cuda_pinned_place(bool): Whether use cuda pinned place or not,
-            this option only works with double buffer and cuda enabled.
-            None will be enabled when double buffer and cuda are enabled.
 
     Returns:
        Variable: A Reader from which we can get feeding data.
@@ -762,22 +757,13 @@ def py_reader(capacity,
         >>>     except fluid.core.EOFException:
         >>>         test_reader.reset()
     """
-    if use_double_buffer and core.is_compiled_with_cuda():
-        if use_cuda_pinned_place == None:
-            use_cuda_pinned_place = True
-    else:
-        if use_cuda_pinned_place:
-            raise RuntimeError(
-                "use_cuda_pinned_place can only be used with double buffer and cuda enabled."
-            )
     return _py_reader(
         capacity=capacity,
         shapes=shapes,
         dtypes=dtypes,
         lod_levels=lod_levels,
         name=name,
-        use_double_buffer=use_double_buffer,
-        use_cuda_pinned_place=use_cuda_pinned_place)
+        use_double_buffer=use_double_buffer)
 
 
 def create_py_reader_by_data(capacity,


### PR DESCRIPTION
This PR changes sync copy to async copy in double buffered py reader. It allowed the memcpy process can overlap with kernels. This PR improves single GPU performance about 1%, and 8 GPUs performance about 1~3%

before(memcpy can not overlap with kernels)
![image](https://user-images.githubusercontent.com/4838354/51072878-6d417f00-16a3-11e9-8389-ad40fbe60793.png)

after (memcpy now overlapped with kernels)
![image](https://user-images.githubusercontent.com/4838354/51072880-88ac8a00-16a3-11e9-9be4-ff097770947e.png)
