### PR TITLE
Disable conv3d mkldnn in dam

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
@@ -191,6 +191,7 @@ void profile(bool use_mkldnn = false) {
 
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
+    // Enable all the mkldnn supported ops except conv3d in dam
     std::unordered_set<std::string> op_list = {"softmax", "elementwise_add",
                                                "relu"};
     cfg.SetMKLDNNOp(op_list);
@@ -236,6 +237,7 @@ void compare(bool use_mkldnn = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
+    // Enable all the mkldnn supported ops except conv3d in dam
     std::unordered_set<std::string> op_list = {"softmax", "elementwise_add",
                                                "relu"};
     cfg.SetMKLDNNOp(op_list);

--- a/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_dam_tester.cc
@@ -191,7 +191,8 @@ void profile(bool use_mkldnn = false) {
 
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    std::unordered_set<std::string> op_list = {"conv3d"};
+    std::unordered_set<std::string> op_list = {"softmax", "elementwise_add",
+                                               "relu"};
     cfg.SetMKLDNNOp(op_list);
   }
 
@@ -235,7 +236,8 @@ void compare(bool use_mkldnn = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    std::unordered_set<std::string> op_list = {"conv3d"};
+    std::unordered_set<std::string> op_list = {"softmax", "elementwise_add",
+                                               "relu"};
     cfg.SetMKLDNNOp(op_list);
   }
 


### PR DESCRIPTION
#15032 reported that recently, DAM model CI test frequently hang with the test compare_mkldnn. This PR is for disabling the conv3d mkldnn kernel when test compare_mkldnn and profile_mkldnn. This test is also aim to help PR 15032 narrow down the cause.

Platform: | Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
-- | -- 
Core: | 24 |   |   |  
Turbo boost: | Enable 
Env Config: | OMP_NUM_THREADS=1 
Command line: | ./paddle/fluid/inference/tests/api/test_analyzer_small_dam --infer_model=third_party/inference_demo/small_dam/model/ --infer_data=third_party/inference_demo/small_dam/data.txt --gtest_filter=Analyzer_dam.profile_mkldnn --paddle_num_threads=1 --repeat=10 --batch_size=300 --max_turn_num=1 --test_all_data
repeat: | 10 
commit id: | 3f815e079fa6eaa9ce4d00a4de65eac922c6e873


Average latency of each sample | MKLML | MKLDNN conv3d | MKLDNN disable conv3d
-- | -- | -- | --
BS=300 (ms) | 7.75 | 6.94 | 8.15

**MKLML**: Run with `--gtest_filter=Analyzer_dam.profile`
**MKLDNN conv3d** : Run with original small dam with  `--gtest_filter=Analyzer_dam.profile_mkldnn` , it will  only enable conv3d mkldnn kernel
**MKLDNN disable conv3d**:  Run with  modified small dam with  `--gtest_filter=Analyzer_dam.profile_mkldnn`， it will enable all mkldnn supported op except the conv3d.