### PR TITLE
hot fix the Native clone

### DIFF
--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -161,10 +161,21 @@ bool NativePaddlePredictor::Run(const std::vector<PaddleTensor> &inputs,
 }
 
 std::unique_ptr<PaddlePredictor> NativePaddlePredictor::Clone() {
-  VLOG(3) << "Predictor::clone";
-  // Hot fix the bug that result diff in multi-thread.
+	std::unique_ptr<PaddlePredictor> cls(new NativePaddlePredictor(config_));
+	// Hot fix the bug that result diff in multi-thread.
   // TODO(Superjomn) re-implement a real clone here.
-  return CreatePaddlePredictor(config_);
+	if (!dynamic_cast<NativePaddlePredictor *>(cls.get())->Init(nullptr)) {
+		LOG(ERROR) << "fail to call Init";	
+		return nullptr;	
+  }
+
+#ifdef __clang__	
+  // fix clang compile error	
+  return cls;	
+#else	
+  // fix manylinux compile error.	
+  return std::move(cls);	
+#endif
 }
 
 bool NativePaddlePredictor::SetFeed(const std::vector<PaddleTensor> &inputs,

--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -161,20 +161,20 @@ bool NativePaddlePredictor::Run(const std::vector<PaddleTensor> &inputs,
 }
 
 std::unique_ptr<PaddlePredictor> NativePaddlePredictor::Clone() {
-	std::unique_ptr<PaddlePredictor> cls(new NativePaddlePredictor(config_));
-	// Hot fix the bug that result diff in multi-thread.
+  std::unique_ptr<PaddlePredictor> cls(new NativePaddlePredictor(config_));
+  // Hot fix the bug that result diff in multi-thread.
   // TODO(Superjomn) re-implement a real clone here.
-	if (!dynamic_cast<NativePaddlePredictor *>(cls.get())->Init(nullptr)) {
-		LOG(ERROR) << "fail to call Init";	
-		return nullptr;	
+  if (!dynamic_cast<NativePaddlePredictor *>(cls.get())->Init(nullptr)) {
+    LOG(ERROR) << "fail to call Init";
+    return nullptr;
   }
 
-#ifdef __clang__	
-  // fix clang compile error	
-  return cls;	
-#else	
-  // fix manylinux compile error.	
-  return std::move(cls);	
+#ifdef __clang__
+  // fix clang compile error
+  return cls;
+#else
+  // fix manylinux compile error.
+  return std::move(cls);
 #endif
 }
 

--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -162,19 +162,9 @@ bool NativePaddlePredictor::Run(const std::vector<PaddleTensor> &inputs,
 
 std::unique_ptr<PaddlePredictor> NativePaddlePredictor::Clone() {
   VLOG(3) << "Predictor::clone";
-  std::unique_ptr<PaddlePredictor> cls(new NativePaddlePredictor(config_));
-
-  if (!dynamic_cast<NativePaddlePredictor *>(cls.get())->Init(scope_)) {
-    LOG(ERROR) << "fail to call Init";
-    return nullptr;
-  }
-#ifdef __clang__
-  // fix clang compile error
-  return cls;
-#else
-  // fix manylinux compile error.
-  return std::move(cls);
-#endif
+  // Hot fix the bug that result diff in multi-thread.
+  // TODO(Superjomn) re-implement a real clone here.
+  return CreatePaddlePredictor(config_);
 }
 
 bool NativePaddlePredictor::SetFeed(const std::vector<PaddleTensor> &inputs,


### PR DESCRIPTION
The Clone API is broken in the `NativePredictor` .
Replace the Clone with `Create` instead.

PROS: quick fix
CONS: more memory consumption

fixes: https://github.com/PaddlePaddle/Paddle/issues/15274