### PR TITLE
support plaintext model

### DIFF
--- a/paddle/fluid/framework/framework.proto
+++ b/paddle/fluid/framework/framework.proto
@@ -13,7 +13,6 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 syntax = "proto2";
-option optimize_for = LITE_RUNTIME;
 package paddle.framework.proto;
 
 // Any incompatible changes to ProgramDesc and its dependencies should


### PR DESCRIPTION
The `LITE` option in `framework.proto` is set for mobile.

Currently, the mobile is independent of the server framework, so remove this option for human readable message.