### PR TITLE
fix debug compile issue of analysis pass

### DIFF
--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -1,6 +1,6 @@
 cc_library(ir_graph_build_pass SRCS ir_graph_build_pass.cc DEPS analysis_pass argument ir_pass_manager)
 cc_library(ir_analysis_pass SRCS ir_analysis_pass.cc DEPS analysis_pass argument ir_pass_manager)
-cc_library(memory_optim_pass SRCS memory_optimize_pass.cc DEPS analysis_pass)
+cc_library(memory_optim_pass SRCS memory_optimize_pass.cc DEPS analysis_pass zero_copy_tensor)
 cc_library(ir_params_sync_among_devices_pass SRCS ir_params_sync_among_devices_pass.cc DEPS analysis_pass argument ir_pass_manager)
 cc_library(ir_graph_to_program_pass SRCS ir_graph_to_program_pass.cc DEPS analysis_pass graph_to_program_pass)
 


### PR DESCRIPTION
fix http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=Paddle_CiDebug&buildId=51985

```
../analysis/passes/libmemory_optim_pass.a(memory_optimize_pass.cc.o): In function `paddle::inference::DescribeZeroCopyTensor(paddle::ZeroCopyTensor const&)':
/home/tangjian/paddle-tj-docker/paddle/fluid/inference/api/helper.h:228: undefined reference to `paddle::ZeroCopyTensor::shape() const'
/home/tangjian/paddle-tj-docker/paddle/fluid/inference/api/helper.h:230: undefined reference to `paddle::ZeroCopyTensor::lod() const'
/home/tangjian/paddle-tj-docker/paddle/fluid/inference/api/helper.h:236: undefined reference to `float* paddle::ZeroCopyTensor::data<float>(paddle::PaddlePlace*, int*) const'
collect2: error: ld returned 1 exit status
paddle/fluid/inference/utils/CMakeFiles/visualizer.dir/build.make:489: recipe for target 'paddle/fluid/inference/utils/visualizer' failed
make[2]: *** [paddle/fluid/inference/utils/visualizer] Error 1
CMakeFiles/Makefile2:58522: recipe for target 'paddle/fluid/inference/utils/CMakeFiles/visualizer.dir/all' failed
make[1]: *** [paddle/fluid/inference/utils/CMakeFiles/visualizer.dir/all] Error 2
Makefile:160: recipe for target 'all' failed
make: *** [all] Error 2
/home/tangjian/paddle-tj-docker
root@yq01-gpu-255-129-13-00 /h/t/paddle-tj-docker#
```