### PR TITLE
Enable INT8 Calibration Unit Test for MobileNet-V1

### DIFF
--- a/python/paddle/fluid/contrib/tests/test_calibration.py
+++ b/python/paddle/fluid/contrib/tests/test_calibration.py
@@ -23,6 +23,7 @@ import argparse
 import functools
 import contextlib
 import paddle.fluid.profiler as profiler
+from paddle.dataset.common import download
 from PIL import Image, ImageEnhance
 import math
 sys.path.append('..')
@@ -116,26 +117,40 @@ def val(data_dir=DATA_DIR):
     return _reader_creator(file_list, 'val', shuffle=False, data_dir=data_dir)
 
 
-class TestCalibration(unittest.TestCase):
+class TestCalibrationForResnet50(unittest.TestCase):
     def setUp(self):
-        # TODO(guomingz): Put the download process in the cmake.
-        # Download and unzip test data set
-        imagenet_dl_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/calibration_test_data.tar.gz'
-        zip_file_name = imagenet_dl_url.split('/')[-1]
-        cmd = 'rm -rf data {}  && mkdir data && wget {} && tar xvf {} -C data'.format(
-            zip_file_name, imagenet_dl_url, zip_file_name)
-        os.system(cmd)
-        # resnet50 fp32 data
-        resnet50_fp32_model_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/resnet50_int8_model.tar.gz'
-        resnet50_zip_name = resnet50_fp32_model_url.split('/')[-1]
-        resnet50_unzip_folder_name = 'resnet50_fp32'
-        cmd = 'rm -rf {} {} && mkdir {} && wget {} && tar xvf {} -C {}'.format(
-            resnet50_unzip_folder_name, resnet50_zip_name,
-            resnet50_unzip_folder_name, resnet50_fp32_model_url,
-            resnet50_zip_name, resnet50_unzip_folder_name)
+        self.int8_download = 'int8/download'
+        self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' + self.int8_download)
+        
+        data_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/calibration_test_data.tar.gz'
+        data_md5 = '1b6c1c434172cca1bf9ba1e4d7a3157d'
+        download(data_url, self.int8_download, data_md5)
+        data_cache_folder = os.path.join(self.cache_folder, "data")
+        if not os.path.exists(data_cache_folder):
+            file_name = data_url.split('/')[-1]
+            zip_path = os.path.join(self.cache_folder, file_name)
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(data_cache_folder, zip_path)
+            os.system(cmd)
+
+        # reader/decorator.py requires the relative path to the data folder
+	cmd = 'rm -rf {0} && ln -s {1} {0}'.format("data", data_cache_folder)
         os.system(cmd)
 
         self.iterations = 50
+
+
+    def download_data(self):
+        # resnet50 fp32 data
+        data_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/resnet50_int8_model.tar.gz'
+        data_md5 = '4a5194524823d9b76da6e738e1367881'
+        download(data_url, self.int8_download, data_md5)
+        self.model_cache_folder = os.path.join(self.cache_folder, "resnet50_fp32")
+        if not os.path.exists(self.model_cache_folder):
+            file_name = data_url.split('/')[-1]
+            zip_path = os.path.join(self.cache_folder, file_name)
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(self.model_cache_folder, zip_path)
+            os.system(cmd)
+
 
     def run_program(self, model_path, generate_int8=False, algo='direct'):
         image_shape = [3, 224, 224]
@@ -204,14 +219,39 @@ class TestCalibration(unittest.TestCase):
             calibrator.save_int8_model()
 
             print(
-                "Calibration is done and the corresponding files were generated at {}".
+                "Calibration is done and the corresponding files are generated at {}".
                 format(os.path.abspath("calibration_out")))
         else:
             return np.sum(test_info) / cnt
 
-    def test_calibration_for_resnet50(self):
-        fp32_acc1 = self.run_program("resnet50_fp32/model")
-        self.run_program("resnet50_fp32/model", True)
+
+    def test_calibration(self):
+        self.download_data()
+        fp32_acc1 = self.run_program(self.model_cache_folder + "/model")
+        self.run_program(self.model_cache_folder + "/model", True)
+        int8_acc1 = self.run_program("calibration_out")
+        delta_value = np.abs(fp32_acc1 - int8_acc1)
+        self.assertLess(delta_value, 0.01)
+
+
+class TestCalibrationForMobilenetv1(TestCalibrationForResnet50):
+    def download_data(self):
+        # mobilenetv1 fp32 data
+        data_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
+        data_md5 = '13892b0716d26443a8cdea15b3c6438b'
+        download(data_url, self.int8_download, data_md5)
+        self.model_cache_folder = os.path.join(self.cache_folder, "mobilenetv1_fp32")
+        if not os.path.exists(self.model_cache_folder):
+            file_name = data_url.split('/')[-1]
+            zip_path = os.path.join(self.cache_folder, file_name)
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(self.model_cache_folder, zip_path)
+            os.system(cmd)
+
+
+    def test_calibration(self):
+        self.download_data()
+        fp32_acc1 = self.run_program(self.model_cache_folder + "/model")
+        self.run_program(self.model_cache_folder + "/model", True, algo='KL')
         int8_acc1 = self.run_program("calibration_out")
         delta_value = np.abs(fp32_acc1 - int8_acc1)
         self.assertLess(delta_value, 0.01)

--- a/python/paddle/fluid/contrib/tests/test_calibration.py
+++ b/python/paddle/fluid/contrib/tests/test_calibration.py
@@ -120,37 +120,39 @@ def val(data_dir=DATA_DIR):
 class TestCalibrationForResnet50(unittest.TestCase):
     def setUp(self):
         self.int8_download = 'int8/download'
-        self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' + self.int8_download)
-        
+        self.cache_folder = os.path.expanduser('~/.cache/paddle/dataset/' +
+                                               self.int8_download)
+
         data_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/calibration_test_data.tar.gz'
         data_md5 = '1b6c1c434172cca1bf9ba1e4d7a3157d'
         download(data_url, self.int8_download, data_md5)
         data_cache_folder = os.path.join(self.cache_folder, "data")
-        if not os.path.exists(data_cache_folder):
-            file_name = data_url.split('/')[-1]
-            zip_path = os.path.join(self.cache_folder, file_name)
-            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(data_cache_folder, zip_path)
-            os.system(cmd)
+        file_name = data_url.split('/')[-1]
+        zip_path = os.path.join(self.cache_folder, file_name)
+        self.cache_unzipping(data_cache_folder, zip_path)
 
         # reader/decorator.py requires the relative path to the data folder
-	cmd = 'rm -rf {0} && ln -s {1} {0}'.format("data", data_cache_folder)
+        cmd = 'rm -rf {0} && ln -s {1} {0}'.format("data", data_cache_folder)
         os.system(cmd)
 
         self.iterations = 50
 
+    def cache_unzipping(self, target_folder, zip_path):
+        if not os.path.exists(target_folder):
+            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(target_folder,
+                                                          zip_path)
+            os.system(cmd)
 
     def download_data(self):
         # resnet50 fp32 data
         data_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/resnet50_int8_model.tar.gz'
         data_md5 = '4a5194524823d9b76da6e738e1367881'
         download(data_url, self.int8_download, data_md5)
-        self.model_cache_folder = os.path.join(self.cache_folder, "resnet50_fp32")
-        if not os.path.exists(self.model_cache_folder):
-            file_name = data_url.split('/')[-1]
-            zip_path = os.path.join(self.cache_folder, file_name)
-            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(self.model_cache_folder, zip_path)
-            os.system(cmd)
-
+        self.model_cache_folder = os.path.join(self.cache_folder,
+                                               "resnet50_fp32")
+        file_name = data_url.split('/')[-1]
+        zip_path = os.path.join(self.cache_folder, file_name)
+        self.cache_unzipping(self.model_cache_folder, zip_path)
 
     def run_program(self, model_path, generate_int8=False, algo='direct'):
         image_shape = [3, 224, 224]
@@ -224,7 +226,6 @@ class TestCalibrationForResnet50(unittest.TestCase):
         else:
             return np.sum(test_info) / cnt
 
-
     def test_calibration(self):
         self.download_data()
         fp32_acc1 = self.run_program(self.model_cache_folder + "/model")
@@ -240,13 +241,11 @@ class TestCalibrationForMobilenetv1(TestCalibrationForResnet50):
         data_url = 'http://paddle-inference-dist.cdn.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         data_md5 = '13892b0716d26443a8cdea15b3c6438b'
         download(data_url, self.int8_download, data_md5)
-        self.model_cache_folder = os.path.join(self.cache_folder, "mobilenetv1_fp32")
-        if not os.path.exists(self.model_cache_folder):
-            file_name = data_url.split('/')[-1]
-            zip_path = os.path.join(self.cache_folder, file_name)
-            cmd = 'mkdir {0} && tar xf {1} -C {0}'.format(self.model_cache_folder, zip_path)
-            os.system(cmd)
-
+        self.model_cache_folder = os.path.join(self.cache_folder,
+                                               "mobilenetv1_fp32")
+        file_name = data_url.split('/')[-1]
+        zip_path = os.path.join(self.cache_folder, file_name)
+        self.cache_unzipping(self.model_cache_folder, zip_path)
 
     def test_calibration(self):
         self.download_data()


### PR DESCRIPTION
This PR is to enable INT8 calibration unit test for MobileNet-V1. Besides new test, we made below changes:
* Cache downloading by using PaddlePaddle download utility
* Cache unzipping by checking whether the target folder exists
* Unit test change: extract download_data function from setup; define two test classes to ease test result analysis
* Fix typo

Please note that:
* Test elapsed time is reduced by 3X+ after cache downloading and unzipping at local machine
* reader/decorator.py requires the relative path to the data folder (use softlink to bypass in unit test)

test=develop

