### PR TITLE
Add the `FLAGS_enable_callstack` to enable the callstack attribute's …

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -642,7 +642,7 @@ class Operator(object):
         if type is None:
             raise ValueError(
                 "`type` to initilized an Operator can not be None.")
-        else:
+        if os.getenv("FLAGS_enable_callstack"):
             callstack_var_name = op_maker.kOpCreationCallstackAttrName()
             op_attrs[callstack_var_name] = list(
                 reversed(traceback.format_stack()))[1:]

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -642,6 +642,7 @@ class Operator(object):
         if type is None:
             raise ValueError(
                 "`type` to initilized an Operator can not be None.")
+
         if os.getenv("FLAGS_enable_callstack"):
             callstack_var_name = op_maker.kOpCreationCallstackAttrName()
             op_attrs[callstack_var_name] = list(


### PR DESCRIPTION
During the  personal debugging of the PaddlePaddle, i found the new-added `callstack` attribute generate a lot of the call stack info as i don't need it.

So i checked the git log and i found there's a option to disable it but removed in the latest commit.

I made this PR to add the `FLAGS_enable_callstack` option to enable  or disable the callstack attribute output.

If you wannan to get the callstack information, you may need to call os.environ['FLAGS_enable_callstack']='True' firstly.