### PR TITLE
add flag. test=develop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ message(STATUS "C compiler: ${CMAKE_C_COMPILER}, version: "
         "${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}")
 if(WIN32)
     set(CMAKE_STATIC_LIBRARY_PREFIX lib)
+    set(CMAKE_SUPPRESS_REGENERATION ON)
     add_definitions("/DGOOGLE_GLOG_DLL_DECL=")
     set(CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS_DEBUG} /bigobj /MTd")
     set(CMAKE_C_FLAGS_RELEASE  "${CMAKE_C_FLAGS_RELEASE} /bigobj /MT")


### PR DESCRIPTION
windows always failed with timestamp error 
```txt
[12:41:21] :	 [Step 2/5] cl : 命令行 warning D9025: 正在重写“/W1”(用“/w”) [D:\home\BuildAgent\work\a9b0372f0aea0a80\build\paddle\fluid\inference\tests\book\test_inference_word2vec.vcxproj]
[12:41:21] :	 [Step 2/5] cl : 命令行 warning D9002: 忽略未知选项“-fopenmp” [D:\home\BuildAgent\work\a9b0372f0aea0a80\build\paddle\fluid\inference\tests\book\test_inference_word2vec.vcxproj]
[12:41:22] :	 [Step 2/5] CUSTOMBUILD : CMake error : Cannot restore timestamp D:/home/BuildAgent/work/a9b0372f0aea0a80/build/paddle/fluid/inference/tests/book/CMakeFiles/generate.stamp [D:\home\BuildAgent\work\a9b0372f0aea0a80\build\paddle\fluid\inference\tests\book\test_inference_label_semantic_roles.vcxproj]
[12:41:22] :	 [Step 2/5] CUSTOMBUILD : CMake error : Cannot restore timestamp D:/home/BuildAgent/work/a9b0372f0aea0a80/build/paddle/fluid/inference/tests/book/CMakeFiles/generate.stamp [D:\home\BuildAgent\work\a9b0372f0aea0a80\build\paddle\fluid\inference\tests\book\test_inference_recognize_digits_mlp.vcxproj]
```
use a temporary fix with flag.
https://cmake.org/cmake/help/git-stage/variable/CMAKE_SUPPRESS_REGENERATION.html