### PR TITLE
To make CUDA_LAUNCH_KERNEL_HELPER support large size.

### DIFF
--- a/paddle/fluid/platform/cuda_device_function.h
+++ b/paddle/fluid/platform/cuda_device_function.h
@@ -53,10 +53,12 @@ inline static int RoundToPowerOfTwo(int dim) {
     __VA_ARGS__;                           \
   } break
 
-#define CUDA_LAUNCH_KERNEL_HELPER(...)         \
-  CUDA_LAUNCH_KERNEL_BASE(256, ##__VA_ARGS__); \
-  CUDA_LAUNCH_KERNEL_BASE(128, ##__VA_ARGS__); \
-  CUDA_LAUNCH_KERNEL_BASE(64, ##__VA_ARGS__);  \
+#define CUDA_LAUNCH_KERNEL_HELPER(...)          \
+  CUDA_LAUNCH_KERNEL_BASE(1024, ##__VA_ARGS__); \
+  CUDA_LAUNCH_KERNEL_BASE(512, ##__VA_ARGS__);  \
+  CUDA_LAUNCH_KERNEL_BASE(256, ##__VA_ARGS__);  \
+  CUDA_LAUNCH_KERNEL_BASE(128, ##__VA_ARGS__);  \
+  CUDA_LAUNCH_KERNEL_BASE(64, ##__VA_ARGS__);   \
   CUDA_LAUNCH_KERNEL_BASE(32, ##__VA_ARGS__);
 
 template <typename T>


### PR DESCRIPTION
To make CUDA_LAUNCH_KERNEL_HELPER support large size. Otherwise, [beam_search_op](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/operators/math/beam_search.cu#L361) with `beam_size * num_seqs * 32 > 256` might failed.