### PR TITLE
Fix std::abs usage in memory_optimize_pass.cc

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -18,6 +18,7 @@
 #include <limits>
 #include <map>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 #include "paddle/fluid/framework/ir/graph_helper.h"
@@ -168,7 +169,11 @@ bool FindSuitableTensorToReuse(
     if (!cluster->count(candidate)) continue;
 
     size_t space = space_table.at(candidate);
-    size_t space_diff = std::abs<size_t>(space - space_required);
+    PADDLE_ENFORCE(
+        space <= std::numeric_limits<std::make_signed<size_t>::type>::max(),
+        "space overload");
+    size_t space_diff =
+        std::abs((std::make_signed<size_t>::type)space - space_required);
     if (space_diff < best_fit.second) {
       best_fit.first = candidate;
       best_fit.second = space_diff;


### PR DESCRIPTION
size_t is an unsigned integer, with a conversion rank
 larger than int, therefore in the following expression
 the int value was promoted to size_t, making it a
 subtraction of unsigned values. The result of such
 a subtraction is also an unsigned value.

```
size_t space;
int space_required;
abs(space - space_required);
```

In the realm of integers, it only makes sense to use std::abs
with signed values, there is no overloaded version of std::abs
in <cstdlib> with an unsigned argument (the absolute value of an
unsigned integer is itself). The compiler has found the std::abs
template in <complex>, which resulted in the size_t value
being converted to a complex number, on which std::abs<size_t>
did operate...

See:
https://en.cppreference.com/w/cpp/language/implicit_conversion
https://en.cppreference.com/w/cpp/numeric/math/abs
https://en.cppreference.com/w/cpp/numeric/complex/abs