### PR TITLE
Remove ALIGN32_BEG, ALIGN32_END macros

### DIFF
--- a/paddle/fluid/operators/jit/gen/act.cc
+++ b/paddle/fluid/operators/jit/gen/act.cc
@@ -21,27 +21,27 @@ namespace operators {
 namespace jit {
 namespace gen {
 
-const float ALIGN32_BEG exp_float_consts[] ALIGN32_END = {
-    REPEAT_8TIMES(1.f),
-    REPEAT_8TIMES(2.f),
-    REPEAT_8TIMES(0.5f),
-    REPEAT_8TIMES(EXP_HIG),
-    REPEAT_8TIMES(EXP_LOW),
-    REPEAT_8TIMES(CEPHES_LOG2EF),
-    REPEAT_8TIMES(CEPHES_EXP_C1),
-    REPEAT_8TIMES(CEPHES_EXP_C2),
-    REPEAT_8TIMES(CEPHES_EXP_P0),
-    REPEAT_8TIMES(CEPHES_EXP_P1),
-    REPEAT_8TIMES(CEPHES_EXP_P2),
-    REPEAT_8TIMES(CEPHES_EXP_P3),
-    REPEAT_8TIMES(CEPHES_EXP_P4),
-    REPEAT_8TIMES(CEPHES_EXP_P5),
-    REPEAT_8TIMES(EXP_MAX_INPUT),
-    REPEAT_8TIMES(SIGMOID_THRESHOLD_MAX),
-    REPEAT_8TIMES(SIGMOID_THRESHOLD_MIN)};
+alignas(32) const
+    float exp_float_consts[] = {REPEAT_8TIMES(1.f),
+                                REPEAT_8TIMES(2.f),
+                                REPEAT_8TIMES(0.5f),
+                                REPEAT_8TIMES(EXP_HIG),
+                                REPEAT_8TIMES(EXP_LOW),
+                                REPEAT_8TIMES(CEPHES_LOG2EF),
+                                REPEAT_8TIMES(CEPHES_EXP_C1),
+                                REPEAT_8TIMES(CEPHES_EXP_C2),
+                                REPEAT_8TIMES(CEPHES_EXP_P0),
+                                REPEAT_8TIMES(CEPHES_EXP_P1),
+                                REPEAT_8TIMES(CEPHES_EXP_P2),
+                                REPEAT_8TIMES(CEPHES_EXP_P3),
+                                REPEAT_8TIMES(CEPHES_EXP_P4),
+                                REPEAT_8TIMES(CEPHES_EXP_P5),
+                                REPEAT_8TIMES(EXP_MAX_INPUT),
+                                REPEAT_8TIMES(SIGMOID_THRESHOLD_MAX),
+                                REPEAT_8TIMES(SIGMOID_THRESHOLD_MIN)};
 
-const int ALIGN32_BEG exp_int_0x7f[] ALIGN32_END = {REPEAT_8TIMES(0x7f)};
-int ALIGN32_BEG g_tmp_mem[16] ALIGN32_END = {0};
+alignas(32) const int exp_int_0x7f[] = {REPEAT_8TIMES(0x7f)};
+alignas(32) int g_tmp_mem[16] = {0};
 
 void VActJitCode::genCode() {
   int offset = 0;

--- a/paddle/fluid/operators/jit/gen/seqpool.h
+++ b/paddle/fluid/operators/jit/gen/seqpool.h
@@ -193,7 +193,7 @@ class SeqPoolJitCode : public JitCode {
   }
 
  private:
-  float ALIGN32_BEG fp_h_[1] ALIGN32_END;
+  alignas(32) float fp_h_[1];
   int w_;
   SeqPoolType type_;
   reg64_t param_src{abi_param1};

--- a/paddle/fluid/operators/math/detail/avx_mathfun.h
+++ b/paddle/fluid/operators/math/detail/avx_mathfun.h
@@ -49,9 +49,8 @@ typedef __m256 v8sf;   // vector of 8 float (avx)
 typedef __m256i v8si;  // vector of 8 int   (avx)
 typedef __m128i v4si;  // vector of 8 int   (avx)
 
-#define _PI32AVX_CONST(Name, Val)                                          \
-  static const ALIGN32_BEG int _pi32avx_##Name[4] ALIGN32_END = {Val, Val, \
-                                                                 Val, Val}
+#define _PI32AVX_CONST(Name, Val) \
+  alignas(32) static const int _pi32avx_##Name[4] = {Val, Val, Val, Val}
 
 _PI32AVX_CONST(1, 1);
 _PI32AVX_CONST(inv1, ~1);
@@ -59,15 +58,15 @@ _PI32AVX_CONST(2, 2);
 _PI32AVX_CONST(4, 4);
 
 /* declare some AVX constants -- why can't I figure a better way to do that? */
-#define _PS256_CONST(Name, Val)                                   \
-  static const ALIGN32_BEG float _ps256_##Name[8] ALIGN32_END = { \
-      Val, Val, Val, Val, Val, Val, Val, Val}
-#define _PI32_CONST256(Name, Val)                                  \
-  static const ALIGN32_BEG int _pi32_256_##Name[8] ALIGN32_END = { \
-      Val, Val, Val, Val, Val, Val, Val, Val}
-#define _PS256_CONST_TYPE(Name, Type, Val)                       \
-  static const ALIGN32_BEG Type _ps256_##Name[8] ALIGN32_END = { \
-      Val, Val, Val, Val, Val, Val, Val, Val}
+#define _PS256_CONST(Name, Val)                                          \
+  alignas(32) static const float _ps256_##Name[8] = {Val, Val, Val, Val, \
+                                                     Val, Val, Val, Val}
+#define _PI32_CONST256(Name, Val)                                         \
+  alignas(32) static const int _pi32_256_##Name[8] = {Val, Val, Val, Val, \
+                                                      Val, Val, Val, Val}
+#define _PS256_CONST_TYPE(Name, Type, Val)                              \
+  alignas(32) static const Type _ps256_##Name[8] = {Val, Val, Val, Val, \
+                                                    Val, Val, Val, Val}
 
 _PS256_CONST(1, 1.0f);
 _PS256_CONST(0p5, 0.5f);
@@ -106,20 +105,20 @@ typedef union imm_xmm_union {
   v4si xmm[2];
 } imm_xmm_union;
 
-#define COPY_IMM_TO_XMM(imm_, xmm0_, xmm1_)  \
-  {                                          \
-    imm_xmm_union ALIGN32_BEG u ALIGN32_END; \
-    u.imm = imm_;                            \
-    xmm0_ = u.xmm[0];                        \
-    xmm1_ = u.xmm[1];                        \
+#define COPY_IMM_TO_XMM(imm_, xmm0_, xmm1_) \
+  {                                         \
+    alignas(32) imm_xmm_union u;            \
+    u.imm = imm_;                           \
+    xmm0_ = u.xmm[0];                       \
+    xmm1_ = u.xmm[1];                       \
   }
 
-#define COPY_XMM_TO_IMM(xmm0_, xmm1_, imm_)  \
-  {                                          \
-    imm_xmm_union ALIGN32_BEG u ALIGN32_END; \
-    u.xmm[0] = xmm0_;                        \
-    u.xmm[1] = xmm1_;                        \
-    imm_ = u.imm;                            \
+#define COPY_XMM_TO_IMM(xmm0_, xmm1_, imm_) \
+  {                                         \
+    alignas(32) imm_xmm_union u;            \
+    u.xmm[0] = xmm0_;                       \
+    u.xmm[1] = xmm1_;                       \
+    imm_ = u.imm;                           \
   }
 
 #define AVX2_BITOP_USING_SSE2(fn)                        \

--- a/paddle/fluid/platform/cpu_info.h
+++ b/paddle/fluid/platform/cpu_info.h
@@ -28,14 +28,6 @@ limitations under the License. */
 #endif
 #endif  // WIN32
 
-#if defined(_WIN32)
-#define ALIGN32_BEG __declspec(align(32))
-#define ALIGN32_END
-#else
-#define ALIGN32_BEG
-#define ALIGN32_END __attribute__((aligned(32)))
-#endif  // _WIN32
-
 namespace paddle {
 namespace platform {
 

--- a/paddle/fluid/platform/float16.h
+++ b/paddle/fluid/platform/float16.h
@@ -56,12 +56,6 @@ limitations under the License. */
 #include <immintrin.h>
 #endif  // PADDLE_ARM
 
-#if !defined(_WIN32)
-#define PADDLE_ALIGN(x) __attribute__((aligned(x)))
-#else
-#define PADDLE_ALIGN(x) __declspec(align(x))
-#endif
-
 namespace paddle {
 namespace platform {
 
@@ -77,11 +71,7 @@ struct float16;
 namespace paddle {
 namespace platform {
 
-// Use PADDLE_ALIGNED(2) to ensure that each float16 will be allocated
-// and aligned at least on a 2-byte boundary, which leads to efficient
-// memory access of float16 struct and also makes float16 compatible
-// with CUDA half, ARM float16_t, and Eigen::half data types.
-struct PADDLE_ALIGN(2) float16 {
+struct float16 {
  public:
   uint16_t x;
 


### PR DESCRIPTION
The `alignas` keyword is part of ISO C++11
I'm not sure how old VC++ versions support it though.