### PR TITLE
fea/pile allocator

### DIFF
--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -41,6 +41,7 @@ cc_library(aligned_allocator SRCS aligned_allocator.cc DEPS allocator)
 cc_library(auto_increment_allocator SRCS auto_increment_allocator.cc DEPS allocator)
 cc_library(zero_size_allocator SRCS zero_size_allocator.cc DEPS allocator)
 cc_library(conditional_allocator SRCS conditional_allocator.cc DEPS allocator)
+cc_library(pile_allocator SRCS pile_allocator.cc)
 cc_library(allocator_strategy SRCS allocator_strategy.cc DEPS gflags)
 cc_library(allocator_facade SRCS allocator_facade.cc DEPS
         ${AllocatorFacadeDeps}
@@ -62,3 +63,5 @@ nv_test(allocation_and_eigen_test SRCS allocation_and_eigen_test.cu DEPS allocat
 cc_test(retry_allocator_test SRCS retry_allocator_test.cc DEPS retry_allocator best_fit_allocator locked_allocator cpu_allocator)
 
 cc_test(allocator_facade_test SRCS allocator_facade_test.cc DEPS allocator_facade)
+
+cc_test(pile_allocator_test SRCS pile_allocator_test.cc DEPS pile_allocator)

--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -41,7 +41,7 @@ cc_library(aligned_allocator SRCS aligned_allocator.cc DEPS allocator)
 cc_library(auto_increment_allocator SRCS auto_increment_allocator.cc DEPS allocator)
 cc_library(zero_size_allocator SRCS zero_size_allocator.cc DEPS allocator)
 cc_library(conditional_allocator SRCS conditional_allocator.cc DEPS allocator)
-cc_library(pile_allocator SRCS pile_allocator.cc)
+cc_library(pile_allocator SRCS pile_allocator.cc DEPS system_allocator)
 cc_library(allocator_strategy SRCS allocator_strategy.cc DEPS gflags)
 cc_library(allocator_facade SRCS allocator_facade.cc DEPS
         ${AllocatorFacadeDeps}

--- a/paddle/fluid/memory/allocation/allocator_strategy.cc
+++ b/paddle/fluid/memory/allocation/allocator_strategy.cc
@@ -25,9 +25,12 @@ namespace memory {
 namespace allocation {
 
 static AllocatorStrategy GetStrategyFromFlag() {
-  return FLAGS_allocator_strategy == "legacy"
-             ? AllocatorStrategy::kLegacy
-             : AllocatorStrategy::kNaiveBestFit;
+  if (FLAGS_allocator_strategy == "legacy") {
+    return AllocatorStrategy::kLegacy;
+  } else if (FLAGS_allocator_strategy == "pile") {
+    return AllocatorStrategy::kPile;
+  }
+  return AllocatorStrategy::kNaiveBestFit;
 }
 
 AllocatorStrategy GetAllocatorStrategy() {

--- a/paddle/fluid/memory/allocation/allocator_strategy.h
+++ b/paddle/fluid/memory/allocation/allocator_strategy.h
@@ -18,7 +18,7 @@ namespace paddle {
 namespace memory {
 namespace allocation {
 
-enum class AllocatorStrategy { kLegacy, kNaiveBestFit };
+enum class AllocatorStrategy { kLegacy, kNaiveBestFit, kPile };
 
 extern AllocatorStrategy GetAllocatorStrategy();
 

--- a/paddle/fluid/memory/allocation/buffered_allocator.cc
+++ b/paddle/fluid/memory/allocation/buffered_allocator.cc
@@ -56,7 +56,7 @@ void BufferedAllocator::Free(Allocation *allocation) {
 }
 Allocation *BufferedAllocator::AllocateImpl(size_t size, Allocator::Attr attr) {
   {
-    platform::LockGuardPtr<std::mutex> guard(mtx_);
+    platform::LockGuardPtr<std::mutex> gurd(mtx_);
     auto it = allocations_.lower_bound(size);
     if (it != allocations_.end() && it->first < size * 2) {
       AllocationPtr result(std::move(it->second));

--- a/paddle/fluid/memory/allocation/buffered_allocator.cc
+++ b/paddle/fluid/memory/allocation/buffered_allocator.cc
@@ -56,7 +56,7 @@ void BufferedAllocator::Free(Allocation *allocation) {
 }
 Allocation *BufferedAllocator::AllocateImpl(size_t size, Allocator::Attr attr) {
   {
-    platform::LockGuardPtr<std::mutex> gurd(mtx_);
+    platform::LockGuardPtr<std::mutex> guard(mtx_);
     auto it = allocations_.lower_bound(size);
     if (it != allocations_.end() && it->first < size * 2) {
       AllocationPtr result(std::move(it->second));

--- a/paddle/fluid/memory/allocation/legacy_allocator.cc
+++ b/paddle/fluid/memory/allocation/legacy_allocator.cc
@@ -67,25 +67,6 @@ BuddyAllocator *GetCPUBuddyAllocator() {
   return a;
 }
 
-// We compared the NaiveAllocator with BuddyAllocator in CPU memory allocation,
-// seems they are almost the same overhead.
-struct NaiveAllocator {
-  void *Alloc(size_t size) { return malloc(size); }
-
-  void Free(void *p) {
-    PADDLE_ENFORCE(p);
-    free(p);
-  }
-
-  static NaiveAllocator *Instance() {
-    static NaiveAllocator x;
-    return &x;
-  }
-
- private:
-  std::mutex lock_;
-};
-
 template <>
 void *Alloc<platform::CPUPlace>(const platform::CPUPlace &place, size_t size) {
   VLOG(10) << "Allocate " << size << " bytes on " << platform::Place(place);

--- a/paddle/fluid/memory/allocation/pile_allocator.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator.cc
@@ -14,8 +14,90 @@
 
 #include "paddle/fluid/memory/allocation/pile_allocator.h"
 
+DEFINE_int32(pile_allocator_init_memory_size_in_mb, 200,
+             "Initial memory pool size for PileAllocator");
+DEFINE_int32(pile_allocator_realloc_memory_size_in_mb, 100,
+             "Initial memory pool size for PileAllocator");
+
 namespace paddle {
 namespace memory {
-namespace allocation {}  // namespace allocation
+namespace allocation {
+
+void BuddySystem::Free(void* p) {
+  auto* ptr = static_cast<byte_t*>(p);
+  // Ignore null.
+  if (!ptr) return;
+
+  size_t request = ptr2request_[ptr];
+  size_t bucket = BucketForRequest(request);
+  int pool_idx = PoolIdxForPtr(ptr);
+  // System allocated.
+  if (pool_idx < 0) {
+    delete[] ptr;
+    return;
+  }
+
+  size_t node = NodeForPtr(ptr, bucket, pool_idx);
+
+  while (node != 0) {
+    FlipParentIsSplit(node, pool_idx);
+    VLOG(3) << "parent is split " << IsParentSplit(node, pool_idx) << " node "
+            << (node - 1) / 2 << " bucket_size " << BucketSize(bucket - 1);
+    // The bucket is used, no need to merge.
+    if (IsParentSplit(node, pool_idx)) break;
+
+    // Here, the bucket is not used, remove the bucket from free list.
+    size_t brother = GetBrotherNode(node);
+    auto* list_node = PtrForNode(brother, bucket, pool_idx);
+    PopBucket(bucket, list_node);
+    // Jump to parent
+    node = (node - 1) / 2;
+    bucket--;
+  }
+  PushBucket(bucket, PtrForNode(node, bucket, pool_idx));
+}
+
+void* BuddySystem::MallocImpl(size_t request, size_t pool_idx) {
+  if (request > max_mem_size_) {
+    LOG(ERROR) << "OOM";
+    return nullptr;
+  }
+  PADDLE_ENFORCE(!buffer_->empty());
+
+  // We should reserve the memory for Header of request.
+  size_t origin_bucket = BucketForRequest(request);
+  size_t bucket = origin_bucket;
+
+  while (bucket + 1 != 0) {
+    // If no free list in current bucket, go to bigger bucket and try.
+    // time complexity: O(logN)
+    byte_t* ptr = reinterpret_cast<byte_t*>(PopBucket(bucket));
+
+    if (!ptr) {
+      --bucket;
+      continue;
+    }
+
+    size_t pool_idx = PoolIdxForPtr(ptr);
+    size_t index = NodeForPtr(ptr, bucket, pool_idx);
+    if (index != 0) FlipParentIsSplit(index, pool_idx);
+
+    while (bucket < origin_bucket) {
+      size_t size = BucketSize(bucket);
+      SplitBucket(bucket, ptr, size / 2, pool_idx);
+      size_t index = NodeForPtr(ptr, bucket, pool_idx);
+
+      VLOG(3) << "split bucket " << bucket << " node " << index << " fliped "
+              << is_splits_->at(pool_idx).Tell(index);
+      bucket++;
+    }
+
+    ptr2request_[ptr] = request;
+    return ptr;
+  }
+  return nullptr;
+}
+
+}  // namespace allocation
 }  // namespace memory
 }  // namespace paddle

--- a/paddle/fluid/memory/allocation/pile_allocator.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator.cc
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "paddle/fluid/memory/allocation/pile_allocator.h"
 
 namespace paddle {

--- a/paddle/fluid/memory/allocation/pile_allocator.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator.cc
@@ -1,0 +1,7 @@
+#include "paddle/fluid/memory/allocation/pile_allocator.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/pile_allocator.h
+++ b/paddle/fluid/memory/allocation/pile_allocator.h
@@ -1,0 +1,381 @@
+#include <gtest/gtest_prod.h>
+#include <list>
+#include <stack>
+#include <unordered_map>
+#include "paddle/fluid/memory/allocation/allocator.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class PileAllocation : public Allocation {};
+
+struct BitSet {
+  using byte_t = unsigned char;
+
+  BitSet() = default;
+  BitSet(size_t num_bits) { Resize(num_bits); }
+
+  void Resize(size_t num_bits) {
+    buffer_.resize(std::ceil(num_bits / 8.), 0);
+    size_ = num_bits;
+  }
+
+  void Set(size_t idx) {
+    auto& byte = buffer_[idx / 8];
+    int offset = idx - 8 * (idx / 8);
+    byte ^= 1 << offset;
+  }
+
+  void UnSet(size_t idx) {
+    auto& byte = buffer_[idx / 8];
+    int offset = idx - 8 * (idx / 8);
+
+    byte &= ~(1 << offset);
+  }
+
+  void Flip(size_t idx) {
+    auto& byte = buffer_[idx / 8];
+    int offset = idx - 8 * (idx / 8);
+    byte ^= 1 << offset;
+  }
+
+  bool Tell(size_t idx) {
+    auto& byte = buffer_[idx / 8];
+    int offset = idx - 8 * (idx / 8);
+    return byte & 1 << idx;
+  }
+
+  size_t num_bytes() const { return buffer_.size(); }
+
+  size_t size() const { return size_; }
+
+ private:
+  std::vector<byte_t> buffer_;
+  size_t size_{0};
+};
+
+struct ListNode {
+  ListNode* pre;
+  ListNode* next;
+
+  ListNode() { Init(); }
+
+  void Init() {
+    pre = this;
+    next = this;
+  }
+
+  void Append(ListNode* other) {
+    auto* the_next = this->next;
+    other->pre = this;
+    this->next = other;
+    other->next = the_next;
+    the_next->pre = other;
+  }
+
+  void Remove() {
+    auto* preone = pre;
+    preone->next = this->next;
+    this->next->pre = preone;
+  }
+};
+
+size_t ListGetSizeSlow(ListNode* head) {
+  if (!head) return 0;
+  auto* p = head;
+
+  size_t res = 0;
+  while (p) {
+    p = p->next;
+    ++res;
+    if (p == head) break;
+  }
+  return res;
+}
+
+/**
+ * Memory model:
+ * The underlying memory is an buffer allocated by system, the buckets is some
+ * descriptions wraps it.
+ *
+ * There are several data structure on it:
+ * - ListNode: the double-link list node, which help to maintain the free list
+ * for buckets.
+ * - Bucket: a free list
+ * - Request: an size_t value which indicate the memory used.
+ *
+ * For each free bucket, the memory is
+ *   | ListNode |  ... rest memory of this bucket |
+ * For each used bucket, the memory is
+ *   | Request | ... rest memory of this bucket |
+ */
+struct BuddyManager {
+  using byte_t = unsigned char;
+  // An integer is needed to store the size of request. We use a 8-byte header
+  // to store this integer to keep memory aligned by 8.
+  const uint32_t kHeaderSize{sizeof(size_t)};
+
+  BuddyManager(size_t min_mem_log_size, size_t max_mem_log_size)
+      : min_mem_log_size_(min_mem_log_size),
+        max_mem_log_size_(max_mem_log_size),
+        min_mem_size_(1 << min_mem_log_size),
+        max_mem_size_(1 << max_mem_log_size),
+        num_buckets_(max_mem_log_size - min_mem_log_size + 1) {
+    Init();
+  }
+
+  void* Malloc(size_t request) {
+    if (request + kHeaderSize > max_mem_size_) {
+      LOG(ERROR) << "OOM";
+      return nullptr;
+    }
+    PADDLE_ENFORCE_NOT_NULL(buffer_);
+
+    // We should reserve the memory for Header of request.
+    size_t origin_bucket = BucketForRequest(request + kHeaderSize);
+    size_t bucket = origin_bucket;
+
+    while (bucket + 1 != 0) {
+      // If no free list in current bucket, go to bigger bucket and try.
+      // time complexity: O(logN)
+      byte_t* ptr = reinterpret_cast<byte_t*>(PopBucket(bucket));
+
+      if (!ptr) {
+        --bucket;
+        continue;
+      }
+
+      while (bucket < origin_bucket) {
+        size_t size = BucketSize(bucket);
+        SplitBucket(bucket, ptr, size / 2);
+        size_t index = NodeForPtr(ptr, bucket);
+
+        LOG(INFO) << "split bucket " << bucket << " node " << index
+                  << " fliped " << is_splits_.Tell(index);
+        bucket++;
+      }
+
+      *reinterpret_cast<size_t*>(ptr) = request;
+      return ptr + kHeaderSize;
+    }
+    return nullptr;
+  }
+
+  void Free(void* p) {
+    byte_t* ptr = static_cast<byte_t*>(p);
+    // Ignore null.
+    if (!ptr) return;
+
+    ptr = ptr - kHeaderSize;
+    size_t request = *reinterpret_cast<size_t*>(ptr);
+    size_t bucket = BucketForRequest(request + kHeaderSize);
+    size_t node = NodeForPtr(ptr, bucket);
+
+    while (node != 0) {
+      FlipParentIsSplit(node);
+      LOG(INFO) << "parent is split " << IsParentSplit(node) << " node "
+                << (node - 1) / 2 << " bucket_size " << BucketSize(bucket - 1);
+      // The bucket is used, no need to merge.
+      if (IsParentSplit(node)) break;
+
+      // Here, the bucket is not used, remove the bucket from free list.
+      size_t brother = GetBrotherNode(node);
+      auto* listnode = PtrForNode(brother, bucket);
+      reinterpret_cast<ListNode*>(listnode)->Remove();
+      if (buckets_[bucket] == reinterpret_cast<ListNode*>(listnode))
+        buckets_[bucket] = nullptr;
+      // Jump to parent
+      node = (node - 1) / 2;
+      bucket--;
+    }
+    PushBucket(bucket, reinterpret_cast<ListNode*>(PtrForNode(node, bucket)));
+  }
+
+  ~BuddyManager() { delete[] buffer_; }
+
+ protected:
+  /** The tree is always rooted at the largest bucket, and grow if needed. It
+   * will grow leefs until hit the bucket limit.
+   */
+  void Init() {
+    buckets_.resize(num_buckets_, nullptr);
+    labels_.resize(1 << num_buckets_, 0);
+
+    InitIsSplits();
+    AllocFirstBucket();
+  }
+
+  /**
+   * Allocate the largest bucket, and add it to the free list.
+   */
+  void AllocFirstBucket() {
+    PADDLE_ENFORCE_GE(max_mem_size_, sizeof(ListNode));
+    buffer_ = SystemAllocate(max_mem_size_);
+    PushBucket(0, reinterpret_cast<ListNode*>(buffer_));
+  }
+
+  void InitIsSplits() { is_splits_.Resize(1 << num_buckets_); }
+
+  /** Get the minest bucket that satisfy the request.
+   */
+  size_t BucketForRequest(size_t request) {
+    size_t bucket_idx = num_buckets_ - 1;
+    auto size = min_mem_size_;
+    while (size < request) {
+      bucket_idx--;
+      size *= 2;
+    }
+    return bucket_idx;
+  }
+
+  size_t BucketSize(size_t bucket) {
+    return (1 << (min_mem_log_size_ + num_buckets_ - bucket - 1));
+  }
+
+  void FlipParentIsSplit(size_t index) {
+    if (index == 0) return;
+    index = (index - 1) / 2;
+    is_splits_.Flip(index);
+  }
+
+  bool IsParentSplit(size_t index) {
+    index = (index - 1) / 2;
+    return is_splits_.Tell(index);
+  }
+
+  ListNode* PopBucket(size_t bucket) {
+    auto* head = buckets_[bucket];
+    if (!head) return nullptr;
+
+    ListNode* res;
+    if (head->next != head) {
+      // more than one nodes, pop the second node.
+      res = head->next;
+      res->Remove();
+    } else {
+      // Just one node
+      res = head;
+      buckets_[bucket] = nullptr;
+    }
+
+    return res;
+  }
+
+  void PushBucket(size_t bucket, ListNode* ptr) {
+    auto& head = buckets_[bucket];
+    if (!head) {
+      head = ptr;
+      head->Init();
+    } else {
+      head->Append(ptr);
+    }
+  }
+
+  size_t GetBrotherNode(size_t node) { return ((node - 1) ^ 1) + 1; }
+
+  /** Split the bucket, and push the right child bucket to the free list */
+  void SplitBucket(size_t bucket, byte_t* ptr, size_t sub_bucket_size) {
+    size_t sub_bucket = BucketForRequest(sub_bucket_size);
+    size_t index = NodeForPtr(ptr, bucket);
+    is_splits_.Flip(index);
+    PushBucket(sub_bucket, reinterpret_cast<ListNode*>(ptr + sub_bucket_size));
+  }
+
+  /** Get the node's index for a memory address */
+  size_t NodeForPtr(byte_t* ptr, size_t bucket) {
+    auto offset = (ptr - buffer_) >> (max_mem_log_size_ - bucket);
+    return offset + (1 << bucket) - 1;
+  }
+
+  /**
+   * Get the memory address of a node.
+   */
+  byte_t* PtrForNode(size_t index, size_t bucket) {
+    return buffer_ +
+           ((index - (1 << bucket) + 1) << (max_mem_log_size_ - bucket));
+  }
+
+  byte_t* SystemAllocate(size_t size) {
+    auto* x = new byte_t[size];
+    PADDLE_ENFORCE(x, "system OOM! allocate %d bytes failed.", max_mem_size_);
+    return x;
+  }
+
+ private:
+  std::vector<ListNode*> buckets_;
+  std::vector<uint8_t> labels_;
+
+  // State represents is_split, one bit for each node.
+  BitSet is_splits_;
+
+  const int min_mem_log_size_;
+  const int max_mem_log_size_;
+  const size_t min_mem_size_;
+  const size_t max_mem_size_;
+  const uint32_t num_buckets_;
+
+  byte_t* buffer_{nullptr};
+
+  FRIEND_TEST(BuddyManager, test1);
+  FRIEND_TEST(BuddyManager, BucketForRequest);
+  FRIEND_TEST(BuddyManager, BucketSize);
+  FRIEND_TEST(BuddyManager, TestFirstBucket);
+  FRIEND_TEST(BuddyManager, PushBucket);
+  FRIEND_TEST(BuddyManager, PopBucket);
+  FRIEND_TEST(BuddyManager, GetBrotherNode);
+  FRIEND_TEST(BuddyManager, SplitBucket);
+  FRIEND_TEST(BuddyManager, NodeForPtr);
+  FRIEND_TEST(BuddyManager, PtrForNode);
+  FRIEND_TEST(BuddyManager, Malloc);
+  FRIEND_TEST(BuddyManager, Malloc1);
+};
+
+/** \brief An (best-fit)allocator with memory share enabled.
+ *
+ * This is an special best-fit allocator, it supports pile memory share.
+ * About pile memory share: the memory chunk be shared by multiple consumers.
+ * We will color the chunks with several labels, and determine which label can
+ * be shared while others cannot be shared.
+ */
+class PileAllocator : public Allocator {
+ public:
+  using byte_t = char;
+
+  PileAllocator(size_t max_memory_size = 1 << 20,
+                size_t basic_cluster_size = 1 << 10, size_t page_size = 64,
+                size_t init_mem_size = 1 << 20, size_t inc_size = 1 << 20)
+      : kMaxMemorySize(max_memory_size),
+        kBasicClusterSize(basic_cluster_size),
+        kPageSize(page_size),
+        kInitMemSize(init_mem_size),
+        kIncSize(inc_size) {}
+
+  AllocationPtr Allocate(size_t size, Allocator::Attr attr = kDefault) {
+    if (size > kMaxMemorySize) return nullptr;
+  }
+
+  bool IsAllocThreadSafe() const override { return false; }
+
+  Allocation* AllocateImpl(size_t size, Allocator::Attr attr) override {
+    return nullptr;
+  }
+
+ protected:
+  void* SystemAllocate(size_t size) {
+    auto* x = new byte_t[size];
+    PADDLE_ENFORCE(x, "system OOM! allocate %d bytes failed.", kInitMemSize);
+    return x;
+  }
+
+ private:
+  const size_t kMaxMemorySize;
+  const size_t kBasicClusterSize;
+  const uint32_t kPageSize{64};
+  const size_t kInitMemSize;
+  const size_t kIncSize;
+};
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/pile_allocator.h
+++ b/paddle/fluid/memory/allocation/pile_allocator.h
@@ -228,21 +228,6 @@ static std::shared_ptr<BuddyResource> CreateBuddyResource(
  * The underlying memory is an buffer allocated by system, the buckets is some
  * descriptions wraps it.
  *
- * There are several data structure on it:
- * - ListNode: the double-link list node, which help to maintain the free list
- * for buckets.
- * - Bucket: a free list of ListNodes.
- * - request: an size_t value which indicate the memory needed. For each
- *            allocated memory block, there is an 8-byte header ahead which
- *            store the `request`.
- * - memory pool: the memory buffer allocated from system, the BuddyManager will
- *                re-manage the allocation on it.
- *
- * For each free bucket, the memory is
- *   | ListNode |  ... rest memory of this bucket |
- * For each used bucket, the memory is
- *   | Request | ... rest memory of this bucket |
- *
  * Reallocation:
  * If the initial memory pool is full-filled, the extra memory pool is needed.
  * This will triger the system allocation, and put the memory pool reallcated to

--- a/paddle/fluid/memory/allocation/pile_allocator.h
+++ b/paddle/fluid/memory/allocation/pile_allocator.h
@@ -110,14 +110,14 @@ size_t ListGetSizeSlow(ListNode* head) {
  * For each used bucket, the memory is
  *   | Request | ... rest memory of this bucket |
  */
-struct BuddyManager {
+struct BuddySystem {
   using byte_t = uint8_t;
   // An integer is needed to store the size of request. We use a 8-byte header
   // to store this integer to keep memory aligned by 8.
   const uint32_t kHeaderSize{sizeof(size_t)};
 
-  BuddyManager(size_t min_mem_log_size, size_t max_mem_log_size,
-               size_t realloc_mem_log_size, bool allow_realloc = true)
+  BuddySystem(size_t min_mem_log_size, size_t max_mem_log_size,
+              size_t realloc_mem_log_size, bool allow_realloc = true)
       : min_mem_log_size_(min_mem_log_size),
         max_mem_log_size_(max_mem_log_size),
         min_mem_size_(1 << min_mem_log_size),
@@ -180,11 +180,10 @@ struct BuddyManager {
 
       // Here, the bucket is not used, remove the bucket from free list.
       size_t brother = GetBrotherNode(node);
-      auto* listnode =
+      auto* list_node =
           reinterpret_cast<ListNode*>(PtrForNode(brother, bucket, pool_idx));
-      PopBucket(bucket, listnode);
-      if (buckets_[bucket] == reinterpret_cast<ListNode*>(listnode))
-        buckets_[bucket] = nullptr;
+      PopBucket(bucket, list_node);
+      if (buckets_[bucket] == list_node) buckets_[bucket] = nullptr;
       // Jump to parent
       node = (node - 1) / 2;
       bucket--;
@@ -193,7 +192,7 @@ struct BuddyManager {
                reinterpret_cast<ListNode*>(PtrForNode(node, bucket, pool_idx)));
   }
 
-  ~BuddyManager() {
+  ~BuddySystem() {
     for (auto* v : buffer_) {
       delete[] v;
     }
@@ -376,8 +375,8 @@ struct BuddyManager {
     labels_.emplace_back();
     is_splits_.emplace_back();
 
-    labels_.back().Resize(realloc_mem_size_/min_mem_size_);
-    is_splits_.back().Resize(realloc_mem_size_/min_mem_size_);
+    labels_.back().Resize(realloc_mem_size_ / min_mem_size_);
+    is_splits_.back().Resize(realloc_mem_size_ / min_mem_size_);
   }
 
   byte_t* SystemAllocate(size_t size) {
@@ -406,19 +405,19 @@ struct BuddyManager {
 
   std::vector<byte_t*> buffer_;
 
-  FRIEND_TEST(BuddyManager, test1);
-  FRIEND_TEST(BuddyManager, BucketForRequest);
-  FRIEND_TEST(BuddyManager, BucketSize);
-  FRIEND_TEST(BuddyManager, TestFirstBucket);
-  FRIEND_TEST(BuddyManager, PushBucket);
-  FRIEND_TEST(BuddyManager, PopBucket);
-  FRIEND_TEST(BuddyManager, GetBrotherNode);
-  FRIEND_TEST(BuddyManager, SplitBucket);
-  FRIEND_TEST(BuddyManager, NodeForPtr);
-  FRIEND_TEST(BuddyManager, PtrForNode);
-  FRIEND_TEST(BuddyManager, Malloc);
-  FRIEND_TEST(BuddyManager, Malloc1);
-  FRIEND_TEST(BuddyManager, realloc);
+  FRIEND_TEST(BuddySystem, test1);
+  FRIEND_TEST(BuddySystem, BucketForRequest);
+  FRIEND_TEST(BuddySystem, BucketSize);
+  FRIEND_TEST(BuddySystem, TestFirstBucket);
+  FRIEND_TEST(BuddySystem, PushBucket);
+  FRIEND_TEST(BuddySystem, PopBucket);
+  FRIEND_TEST(BuddySystem, GetBrotherNode);
+  FRIEND_TEST(BuddySystem, SplitBucket);
+  FRIEND_TEST(BuddySystem, NodeForPtr);
+  FRIEND_TEST(BuddySystem, PtrForNode);
+  FRIEND_TEST(BuddySystem, Malloc);
+  FRIEND_TEST(BuddySystem, Malloc1);
+  FRIEND_TEST(BuddySystem, realloc);
 };
 
 /** \brief An (best-fit)allocator with memory share enabled.

--- a/paddle/fluid/memory/allocation/pile_allocator.h
+++ b/paddle/fluid/memory/allocation/pile_allocator.h
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include <gtest/gtest_prod.h>
 #include <list>
 #include <stack>
@@ -197,8 +211,8 @@ struct BuddyResource {
 
  private:
   const int min_mem_log_size_;
-  const int max_mem_log_size_;
   const int min_mem_size_;
+  const int max_mem_log_size_;
   const int max_mem_size_;
   const uint32_t num_buckets_;
   const int realloc_mem_log_size_;
@@ -246,8 +260,8 @@ struct BuddySystem {
         realloc_mem_log_size_(resource->realloc_mem_log_size()),
         realloc_mem_size_(resource->realloc_mem_size()),
         num_buckets_(resource->num_buckets()),
-        resource_(resource),
         allow_realloc_(allow_realloc),
+        resource_(resource),
         buffer_(&resource->buffer()) {
     is_splits_ = &resource->is_splits(pile_idx);
     buckets_ = &resource->buckets(pile_idx);
@@ -265,9 +279,9 @@ struct BuddySystem {
         max_mem_log_size_(max_mem_log_size),
         min_mem_size_(1 << min_mem_log_size),
         max_mem_size_(1 << max_mem_log_size),
-        num_buckets_(max_mem_log_size - min_mem_log_size + 1),
         realloc_mem_log_size_(realloc_mem_log_size),
         realloc_mem_size_(1 << realloc_mem_log_size),
+        num_buckets_(max_mem_log_size - min_mem_log_size + 1),
         allow_realloc_{allow_realloc} {
     resource_ = CreateBuddyResource(max_mem_log_size, min_mem_log_size,
                                     realloc_mem_log_size, 1);
@@ -459,6 +473,18 @@ struct BuddySystem {
   }
 
  private:
+  const int min_mem_log_size_;
+  const int max_mem_log_size_;
+  const size_t min_mem_size_;
+  const size_t max_mem_size_;
+  const int realloc_mem_log_size_;
+  const int realloc_mem_size_;
+
+  const uint32_t num_buckets_;
+  const bool allow_realloc_;
+
+  std::shared_ptr<BuddyResource> resource_;
+
   // All the memory pools shares the same buckets.
   std::vector<bucket_t>* buckets_{nullptr};
   // State represents is_split, one bit for each node.
@@ -467,19 +493,7 @@ struct BuddySystem {
   // map from allocated memory address to the requested memory size.
   std::unordered_map<byte_t*, uint32_t> ptr2request_;
 
-  const int min_mem_log_size_;
-  const int max_mem_log_size_;
-  const size_t min_mem_size_;
-  const size_t max_mem_size_;
-  const uint32_t num_buckets_;
-  const int realloc_mem_log_size_;
-  const int realloc_mem_size_;
-
-  const bool allow_realloc_;
-
   std::vector<byte_t*>* buffer_{nullptr};
-
-  std::shared_ptr<BuddyResource> resource_;
 
   FRIEND_TEST(BuddySystem, test1);
   FRIEND_TEST(BuddySystem, BucketForRequest);

--- a/paddle/fluid/memory/allocation/pile_allocator.h
+++ b/paddle/fluid/memory/allocation/pile_allocator.h
@@ -2,6 +2,7 @@
 #include <list>
 #include <stack>
 #include <unordered_map>
+#include <unordered_set>
 #include "paddle/fluid/memory/allocation/allocator.h"
 
 namespace paddle {
@@ -55,43 +56,168 @@ struct BitSet {
   size_t size_{0};
 };
 
-struct ListNode {
-  ListNode* pre;
-  ListNode* next;
+// Stack with Set.
+template <typename T>
+struct StackSet {
+  bool count(T t) { return map_.count(t); }
 
-  ListNode() { Init(); }
+  T top() const { return stack_.front(); }
 
-  void Init() {
-    pre = this;
-    next = this;
+  size_t size() const { return stack_.size(); }
+
+  void push(T v) {
+    stack_.push_front(v);
+    map_.emplace(v, stack_.begin());
   }
 
-  void Append(ListNode* other) {
-    auto* the_next = this->next;
-    other->pre = this;
-    this->next = other;
-    other->next = the_next;
-    the_next->pre = other;
+  void pop() {
+    auto v = stack_.front();
+    map_.erase(v);
+    stack_.pop_front();
   }
 
-  void Remove() {
-    auto* preone = pre;
-    preone->next = this->next;
-    this->next->pre = preone;
+  void pop(T v) {
+    auto it = map_.find(v);
+    CHECK(it != map_.end());
+    stack_.erase(it->second);
+    map_.erase(it);
   }
+
+  bool empty() const { return stack_.empty(); }
+
+ private:
+  std::list<T> stack_;
+  std::unordered_map<T, typename std::list<T>::iterator> map_;
 };
 
-size_t ListGetSizeSlow(ListNode* head) {
-  if (!head) return 0;
-  auto* p = head;
+/*
+ * The resource for buddy system, we split the resource from the buddy system
+ * for better reuse for mulitple ones.
+ * The same underlying memory pool can be reused that, each buddy system can
+ * allcate memory based on the same memory pool, regardless of others, so the
+ * same memory block can be allcated by more than one buddy systems, on
+ * condition that the buddy systems are used sequentially and individually.
+ */
+struct BuddyResource {
+  using byte_t = uint8_t;
+  using bucket_t = StackSet<byte_t*>;
 
-  size_t res = 0;
-  while (p) {
-    p = p->next;
-    ++res;
-    if (p == head) break;
+  BuddyResource(int max_mem_log_size, int min_mem_log_size,
+                int realloc_mem_log_size, int num_piled = 1)
+      : min_mem_log_size_(min_mem_log_size),
+        min_mem_size_(1 << min_mem_log_size),
+        max_mem_log_size_(max_mem_log_size),
+        max_mem_size_(1 << max_mem_log_size),
+        num_buckets_(max_mem_log_size - min_mem_log_size + 1),
+        realloc_mem_log_size_(realloc_mem_log_size),
+        realloc_mem_size_(1 << realloc_mem_log_size),
+        num_piled_(num_piled) {
+    buckets_.resize(num_piled_);
+    is_splits_.resize(num_piled_);
+
+    Init();
   }
-  return res;
+
+  ~BuddyResource() {
+    for (auto* v : buffer_) {
+      delete[] v;
+    }
+  }
+
+  std::vector<byte_t*>& buffer() { return buffer_; }
+  std::vector<bucket_t>& buckets(int idx) { return buckets_[idx]; }
+  std::vector<BitSet>& is_splits(int idx) { return is_splits_[idx]; }
+
+  byte_t* SystemAllocate(size_t size) {
+    auto* x = new byte_t[size];
+    PADDLE_ENFORCE(x, "system OOM! allocate %d bytes failed.", max_mem_size_);
+    return x;
+  }
+
+  void ReallocMemoryBuffer() {
+    LOG(INFO) << "Realloc one memory block";
+    PADDLE_ENFORCE_GT(buffer_.size(), 0UL,
+                      "should allocate the initial memory pool first.");
+    buffer_.push_back(SystemAllocate(realloc_mem_size_));
+    PushInitialBucket(max_mem_log_size() - realloc_mem_log_size(),
+                      buffer_.back());
+
+    // Add one is_splits for each pile system.
+    for (auto& is_splits : is_splits_) {
+      is_splits.emplace_back();
+      is_splits.back().Resize(
+          1 << (realloc_mem_log_size() - min_mem_log_size() + 1));
+    }
+  }
+
+#define GET_MEMBER(field__) \
+  int field__() const { return field__##_; }
+  GET_MEMBER(min_mem_log_size);
+  GET_MEMBER(max_mem_log_size);
+  GET_MEMBER(min_mem_size);
+  GET_MEMBER(max_mem_size);
+  GET_MEMBER(realloc_mem_log_size);
+  GET_MEMBER(realloc_mem_size);
+  GET_MEMBER(num_piled);
+  GET_MEMBER(num_buckets);
+#undef GET_MEMBER
+
+ protected:
+  void Init() {
+    // Init is_splits
+    for (auto& is_splits : is_splits_) {
+      PADDLE_ENFORCE(is_splits.empty());
+      is_splits.emplace_back();
+      is_splits.front().Resize(1 << num_buckets_);
+    }
+
+    // Init buckets
+    for (auto& buckets : buckets_) {
+      buckets.resize(num_buckets());
+    }
+
+    AllocInitialMemoryBuffer();
+  }
+
+  void AllocInitialMemoryBuffer() {
+    PADDLE_ENFORCE(buffer_.empty());
+    buffer_.push_back(SystemAllocate(max_mem_size_));
+    PushInitialBucket(0, buffer_.front());
+  }
+
+  // Push the bucket to all the pile systems' free buckets.
+  void PushInitialBucket(size_t bucket, byte_t* ptr) {
+    for (auto& buckets : buckets_) {
+      buckets[bucket].push(ptr);
+    }
+  }
+
+ private:
+  const int min_mem_log_size_;
+  const int max_mem_log_size_;
+  const int min_mem_size_;
+  const int max_mem_size_;
+  const uint32_t num_buckets_;
+  const int realloc_mem_log_size_;
+  const int realloc_mem_size_;
+
+  // number of the piled system that share the same memory buffer.
+  const int num_piled_;
+  // The buffer will shared by all the piled system.
+  std::vector<byte_t*> buffer_;
+  // All the memory pools shares the same buckets. The outer vector is for piled
+  // systems, the innser vector is for different size of buddies.
+  std::vector<std::vector<bucket_t>> buckets_;
+  // State represents is_split, one bit for each node. The outer vector is for
+  // multiple pile system, the inner vector is for multiple buffer.
+  std::vector<std::vector<BitSet>> is_splits_;
+};
+
+static std::shared_ptr<BuddyResource> CreateBuddyResource(
+    int max_mem_log_size, int min_mem_log_size, int realloc_mem_log_size,
+    int num_piled = 1) {
+  return std::make_shared<BuddyResource>(max_mem_log_size, min_mem_log_size,
+                                         realloc_mem_log_size, num_piled);
 }
 
 /**
@@ -102,19 +228,48 @@ size_t ListGetSizeSlow(ListNode* head) {
  * There are several data structure on it:
  * - ListNode: the double-link list node, which help to maintain the free list
  * for buckets.
- * - Bucket: a free list
- * - Request: an size_t value which indicate the memory used.
+ * - Bucket: a free list of ListNodes.
+ * - request: an size_t value which indicate the memory needed. For each
+ *            allocated memory block, there is an 8-byte header ahead which
+ *            store the `request`.
+ * - memory pool: the memory buffer allocated from system, the BuddyManager will
+ *                re-manage the allocation on it.
  *
  * For each free bucket, the memory is
  *   | ListNode |  ... rest memory of this bucket |
  * For each used bucket, the memory is
  *   | Request | ... rest memory of this bucket |
+ *
+ * Reallocation:
+ * If the initial memory pool is full-filled, the extra memory pool is needed.
+ * This will triger the system allocation, and put the memory pool reallcated to
+ * the free buckets.
  */
 struct BuddySystem {
   using byte_t = uint8_t;
-  // An integer is needed to store the size of request. We use a 8-byte header
-  // to store this integer to keep memory aligned by 8.
-  const uint32_t kHeaderSize{sizeof(size_t)};
+  using bucket_t = typename BuddyResource::bucket_t;
+
+  BuddySystem(const std::shared_ptr<BuddyResource>& resource,
+              size_t pile_idx = 0, bool allow_realloc = true)
+      : min_mem_log_size_(resource->min_mem_log_size()),
+        max_mem_log_size_(resource->max_mem_log_size()),
+        min_mem_size_(resource->min_mem_size()),
+        max_mem_size_(resource->max_mem_size()),
+        realloc_mem_log_size_(resource->realloc_mem_log_size()),
+        realloc_mem_size_(resource->realloc_mem_size()),
+        num_buckets_(resource->num_buckets()),
+        resource_(resource),
+        allow_realloc_(allow_realloc),
+        buffer_(&resource->buffer()) {
+    is_splits_ = &resource->is_splits(pile_idx);
+    buckets_ = &resource->buckets(pile_idx);
+
+    PADDLE_ENFORCE_NOT_NULL(is_splits_);
+    PADDLE_ENFORCE_NOT_NULL(buffer_);
+    PADDLE_ENFORCE_NOT_NULL(buckets_);
+    PADDLE_ENFORCE(!buffer_->empty(), "BuddyResource should be inited first.");
+    PADDLE_ENFORCE(!buckets_->front().empty());
+  }
 
   BuddySystem(size_t min_mem_log_size, size_t max_mem_log_size,
               size_t realloc_mem_log_size, bool allow_realloc = true)
@@ -126,42 +281,39 @@ struct BuddySystem {
         realloc_mem_log_size_(realloc_mem_log_size),
         realloc_mem_size_(1 << realloc_mem_log_size),
         allow_realloc_{allow_realloc} {
-    Init();
+    resource_ = CreateBuddyResource(max_mem_log_size, min_mem_log_size,
+                                    realloc_mem_log_size, 1);
+    is_splits_ = &resource_->is_splits(0);
+    buffer_ = &resource_->buffer();
+    buckets_ = &resource_->buckets(0);
+
+    PADDLE_ENFORCE_NOT_NULL(is_splits_);
+    PADDLE_ENFORCE_NOT_NULL(buffer_);
+    PADDLE_ENFORCE_NOT_NULL(buckets_);
+    PADDLE_ENFORCE(!buffer_->empty(), "BuddyResource should be inited first.");
+    PADDLE_ENFORCE(!buckets_->front().empty());
   }
 
   void* Malloc(size_t request) {
     if (request > max_mem_size_) {
       LOG(INFO) << "allocating raw large memory chunk";
-      return SystemAllocate(request);
+      return resource_->SystemAllocate(request);
     }
     auto* first_try = MallocImpl(request, 0);
     if (first_try) return first_try;
 
     if (!allow_realloc_) return nullptr;
-    ReallocMemoryBuffer();
+    resource_->ReallocMemoryBuffer();
     return MallocImpl(request, 0);
   }
 
-  // Label the allocated memory block.
-  void MarkAllocated(byte_t* ptr, bool flag) {
-    size_t request = *reinterpret_cast<size_t*>(ptr - kHeaderSize);
-    size_t pool_idx = PoolIdxForPtr(ptr);
-    auto node = NodeForPtr(ptr, BucketForRequest(request), pool_idx);
-    if (flag) {
-      labels_[pool_idx].Set(node);
-    } else {
-      labels_[pool_idx].UnSet(node);
-    }
-  }
-
   void Free(void* p) {
-    byte_t* ptr = static_cast<byte_t*>(p);
+    auto* ptr = static_cast<byte_t*>(p);
     // Ignore null.
     if (!ptr) return;
 
-    ptr = ptr - kHeaderSize;
-    size_t request = *reinterpret_cast<size_t*>(ptr);
-    size_t bucket = BucketForRequest(request + kHeaderSize);
+    size_t request = ptr2request_[ptr];
+    size_t bucket = BucketForRequest(request);
     int pool_idx = PoolIdxForPtr(ptr);
     // System allocated.
     if (pool_idx < 0) {
@@ -180,45 +332,25 @@ struct BuddySystem {
 
       // Here, the bucket is not used, remove the bucket from free list.
       size_t brother = GetBrotherNode(node);
-      auto* list_node =
-          reinterpret_cast<ListNode*>(PtrForNode(brother, bucket, pool_idx));
+      auto* list_node = PtrForNode(brother, bucket, pool_idx);
       PopBucket(bucket, list_node);
-      if (buckets_[bucket] == list_node) buckets_[bucket] = nullptr;
       // Jump to parent
       node = (node - 1) / 2;
       bucket--;
     }
-    PushBucket(bucket,
-               reinterpret_cast<ListNode*>(PtrForNode(node, bucket, pool_idx)));
-  }
-
-  ~BuddySystem() {
-    for (auto* v : buffer_) {
-      delete[] v;
-    }
+    PushBucket(bucket, PtrForNode(node, bucket, pool_idx));
   }
 
  protected:
-  /** The tree is always rooted at the largest bucket, and grow if needed. It
-   * will grow leefs until hit the bucket limit.
-   */
-  void Init() {
-    buckets_.resize(num_buckets_, nullptr);
-
-    AllocFirstBucket();
-    labels_.front().Resize(1 << num_buckets_);
-    is_splits_.front().Resize(1 << num_buckets_);
-  }
-
   void* MallocImpl(size_t request, size_t pool_idx) {
-    if (request + kHeaderSize > max_mem_size_) {
+    if (request > max_mem_size_) {
       LOG(ERROR) << "OOM";
       return nullptr;
     }
-    PADDLE_ENFORCE(!buffer_.empty());
+    PADDLE_ENFORCE(!buffer_->empty());
 
     // We should reserve the memory for Header of request.
-    size_t origin_bucket = BucketForRequest(request + kHeaderSize);
+    size_t origin_bucket = BucketForRequest(request);
     size_t bucket = origin_bucket;
 
     while (bucket + 1 != 0) {
@@ -241,36 +373,34 @@ struct BuddySystem {
         size_t index = NodeForPtr(ptr, bucket, pool_idx);
 
         VLOG(3) << "split bucket " << bucket << " node " << index << " fliped "
-                << is_splits_[pool_idx].Tell(index);
+                << is_splits_->at(pool_idx).Tell(index);
         bucket++;
       }
 
-      *reinterpret_cast<size_t*>(ptr) = request;
-      return ptr + kHeaderSize;
+      ptr2request_[ptr] = request;
+      return ptr;
     }
     return nullptr;
   }
 
-  // TODO(Superjomn) Optimize the performance here.
-  int PoolIdxForPtr(byte_t* ptr) {
-    if (buffer_.front() <= ptr && buffer_.front() + max_mem_size_ > ptr)
-      return 0;
-    for (int i = 1; i < buffer_.size(); i++) {
-      if (buffer_[i] <= ptr && buffer_[i] + realloc_mem_size_ > ptr) return i;
-    }
-    return -1;
+  byte_t* buffer(int idx) { return buffer_->at(idx); }
+
+  BitSet& is_splits(int idx) { return is_splits_->at(idx); }
+
+  bucket_t& buckets(int idx) {
+    PADDLE_ENFORCE_LT(idx, buckets_->size());
+    return buckets_->at(idx);
   }
 
-  /**
-   * Allocate the largest bucket, and add it to the free list.
-   */
-  void AllocFirstBucket() {
-    PADDLE_ENFORCE_GE(max_mem_size_, sizeof(ListNode));
-    AllocInitialMemoryBuffer();
-    PushBucket(0, reinterpret_cast<ListNode*>(buffer_.front()));
-
-    labels_.emplace_back();
-    is_splits_.emplace_back();
+  // TODO(Superjomn) Optimize the performance here.
+  int PoolIdxForPtr(byte_t* ptr) {
+    if (buffer_->front() <= ptr && buffer_->front() + max_mem_size_ > ptr)
+      return 0;
+    for (int i = 1; i < buffer_->size(); i++) {
+      if (buffer_->at(i) <= ptr && buffer_->at(i) + realloc_mem_size_ > ptr)
+        return i;
+    }
+    return -1;
   }
 
   /** Get the minest bucket that satisfy the request.
@@ -292,49 +422,25 @@ struct BuddySystem {
   void FlipParentIsSplit(size_t index, size_t pool_idx) {
     if (index == 0) return;
     index = (index - 1) / 2;
-    is_splits_[pool_idx].Flip(index);
+    is_splits_->at(pool_idx).Flip(index);
   }
 
   bool IsParentSplit(size_t index, size_t pool_idx) {
     index = (index - 1) / 2;
-    return is_splits_[pool_idx].Tell(index);
+    return is_splits_->at(pool_idx).Tell(index);
   }
 
-  ListNode* PopBucket(size_t bucket) {
-    auto* head = buckets_[bucket];
-    if (!head) return nullptr;
-
-    ListNode* res;
-    if (head->next != head) {
-      // more than one nodes, pop the second node.
-      res = head->next;
-      res->Remove();
-    } else {
-      // Just one node
-      res = head;
-      buckets_[bucket] = nullptr;
-    }
-
-    return res;
+  byte_t* PopBucket(size_t bucket) {
+    auto& the_bucket = buckets(bucket);
+    if (the_bucket.empty()) return nullptr;
+    auto* ptr = the_bucket.top();
+    the_bucket.pop();
+    return ptr;
   }
 
-  void PopBucket(size_t bucket, ListNode* ptr) {
-    if (ptr->next == ptr) {
-      buckets_[bucket] = nullptr;
-    } else {
-      ptr->Remove();
-    }
-  }
+  void PopBucket(size_t bucket, byte_t* ptr) { buckets(bucket).pop(ptr); }
 
-  void PushBucket(size_t bucket, ListNode* ptr) {
-    auto& head = buckets_[bucket];
-    if (!head) {
-      head = ptr;
-      head->Init();
-    } else {
-      head->Append(ptr);
-    }
-  }
+  void PushBucket(size_t bucket, byte_t* ptr) { buckets(bucket).push(ptr); }
 
   size_t GetBrotherNode(size_t node) { return ((node - 1) ^ 1) + 1; }
 
@@ -343,13 +449,16 @@ struct BuddySystem {
                    size_t pool_idx) {
     size_t sub_bucket = BucketForRequest(sub_bucket_size);
     size_t index = NodeForPtr(ptr, bucket, pool_idx);
-    is_splits_[pool_idx].Flip(index);
-    PushBucket(sub_bucket, reinterpret_cast<ListNode*>(ptr + sub_bucket_size));
+    LOG(INFO) << "index " << index;
+    PADDLE_ENFORCE_NOT_NULL(is_splits_);
+    PADDLE_ENFORCE_GT(is_splits_->size(), pool_idx);
+    is_splits_->at(pool_idx).Flip(index);
+    PushBucket(sub_bucket, ptr + sub_bucket_size);
   }
 
   /** Get the node's index for a memory address */
   size_t NodeForPtr(byte_t* ptr, size_t bucket, size_t pool_idx) {
-    auto offset = (ptr - buffer_[pool_idx]) >> (max_mem_log_size_ - bucket);
+    auto offset = (ptr - buffer_->at(pool_idx)) >> (max_mem_log_size_ - bucket);
     return offset + (1 << bucket) - 1;
   }
 
@@ -357,41 +466,18 @@ struct BuddySystem {
    * Get the memory address of a node.
    */
   byte_t* PtrForNode(size_t index, size_t bucket, size_t pool_idx) {
-    return buffer_[pool_idx] +
+    return buffer_->at(pool_idx) +
            ((index - (1 << bucket) + 1) << (max_mem_log_size_ - bucket));
-  }
-
-  void AllocInitialMemoryBuffer() {
-    buffer_.push_back(SystemAllocate(max_mem_size_));
-  }
-
-  void ReallocMemoryBuffer() {
-    LOG(INFO) << "Realloc one memory block";
-    PADDLE_ENFORCE_GT(buffer_.size(), 0UL,
-                      "should allocate the initial memory pool first.");
-    buffer_.push_back(SystemAllocate(realloc_mem_size_));
-    PushBucket(BucketForRequest(realloc_mem_size_),
-               reinterpret_cast<ListNode*>(buffer_.back()));
-    labels_.emplace_back();
-    is_splits_.emplace_back();
-
-    labels_.back().Resize(realloc_mem_size_ / min_mem_size_);
-    is_splits_.back().Resize(realloc_mem_size_ / min_mem_size_);
-  }
-
-  byte_t* SystemAllocate(size_t size) {
-    auto* x = new byte_t[size];
-    PADDLE_ENFORCE(x, "system OOM! allocate %d bytes failed.", max_mem_size_);
-    return x;
   }
 
  private:
   // All the memory pools shares the same buckets.
-  std::vector<ListNode*> buckets_;
+  std::vector<bucket_t>* buckets_{nullptr};
   // State represents is_split, one bit for each node.
-  std::vector<BitSet> is_splits_;
-  // Label which mark the nodes, we use a bitset to support an 0/1 label.
-  std::vector<BitSet> labels_;
+  std::vector<BitSet>* is_splits_{nullptr};
+
+  // map from allocated memory address to the requested memory size.
+  std::unordered_map<byte_t*, uint32_t> ptr2request_;
 
   const int min_mem_log_size_;
   const int max_mem_log_size_;
@@ -403,7 +489,9 @@ struct BuddySystem {
 
   const bool allow_realloc_;
 
-  std::vector<byte_t*> buffer_;
+  std::vector<byte_t*>* buffer_{nullptr};
+
+  std::shared_ptr<BuddyResource> resource_;
 
   FRIEND_TEST(BuddySystem, test1);
   FRIEND_TEST(BuddySystem, BucketForRequest);

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -340,6 +340,11 @@ TEST(BuddySystem, realloc) {
   ASSERT_EQ(manager.PoolIdxForPtr(static_cast<uint8_t*>(ptr1)), 1);
 }
 
+TEST(BuddySystem, resource_created_externally) {
+  auto resource = CreateBuddyResource(10, 2, 9, 4);
+  ASSERT_EQ(resource->num_piled(), 4);
+}
+
 }  // namespace allocation
 }  // namespace memory
 }  // namespace paddle

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -1,0 +1,229 @@
+#include "paddle/fluid/memory/allocation/pile_allocator.h"
+#include <gtest/gtest.h>
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+TEST(BitSet, main) {
+  BitSet bits(11);
+  ASSERT_EQ(bits.num_bytes(), 2);
+
+  for (int i = 0; i < 11; i++) {
+    ASSERT_FALSE(bits.Tell(i));
+  }
+
+  // Set one
+  bits.Set(3);
+  ASSERT_TRUE(bits.Tell(3));
+
+  bits.Flip(3);
+  ASSERT_FALSE(bits.Tell(3));
+  bits.Flip(3);
+  ASSERT_TRUE(bits.Tell(3));
+}
+
+TEST(BuddyManager, test1) {
+  BuddyManager manager(4, 10);
+  LOG(INFO) << "min mem: " << manager.min_mem_size_ << " "
+            << manager.min_mem_log_size_;
+  LOG(INFO) << "max mem: " << manager.max_mem_size_ << " "
+            << manager.max_mem_log_size_;
+}
+
+TEST(BuddyManager, BucketForRequest) {
+  BuddyManager manager(4, 10);
+  LOG(INFO) << "num buckets: " << manager.num_buckets_;
+  ASSERT_EQ(manager.BucketForRequest(1 << 10), 0);
+  ASSERT_EQ(manager.BucketForRequest(1 << 9), 1);
+  for (int i = 0; i < 1 << 8; i++) {
+    ASSERT_EQ(manager.BucketForRequest((1 << 9) - i), 1);
+  }
+}
+
+TEST(BuddyManager, BucketSize) {
+  BuddyManager manager(4, 10);
+  ASSERT_EQ(manager.BucketSize(0), 1 << 10);
+  ASSERT_EQ(manager.BucketSize(1), 1 << 9);
+}
+
+TEST(BuddyManager, TestFirstBucket) {
+  BuddyManager manager(4, 10);
+  ASSERT_EQ(manager.buckets_.size(), manager.num_buckets_);
+  // Only the first one bucket has one element.
+  for (int i = 1; i < manager.num_buckets_; i++) {
+    ASSERT_FALSE(manager.buckets_[i]);
+  }
+  ASSERT_TRUE(manager.buckets_.front());
+  ASSERT_EQ(ListGetSizeSlow(manager.buckets_.front()), 1UL);
+  // Pop the only one bucket
+  auto* res = manager.PopBucket(0);
+  ASSERT_TRUE(res);
+  // The first bucket just align from the head of the buffer.
+  ASSERT_EQ(reinterpret_cast<uint8_t*>(res), manager.buffer_);
+  ASSERT_EQ(res->next, res);
+  ASSERT_EQ(res->pre, res);
+  // Pop if there is no remaining buckets.
+  ASSERT_FALSE(manager.PopBucket(0));
+}
+
+TEST(BuddyManager, PushBucket) {
+  BuddyManager manager(4, 10);
+
+  // Push to the first bucket.
+  ASSERT_FALSE(manager.buckets_[1]);
+
+  manager.PushBucket(
+      1, reinterpret_cast<ListNode*>(manager.buffer_ + sizeof(ListNode)));
+  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1UL);
+  ASSERT_EQ(manager.buckets_[1]->next, manager.buckets_[1]);
+  ASSERT_EQ(manager.buckets_[1]->pre, manager.buckets_[1]);
+
+  // There are 1<<10 nodes for the 0th bucket.
+  for (int i = 2; i < 7; i++) {
+    manager.PushBucket(
+        1, reinterpret_cast<ListNode*>(manager.buffer_ + i * sizeof(ListNode)));
+    ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), i);
+  }
+}
+
+TEST(BuddyManager, PopBucket) {
+  BuddyManager manager(4, 10);
+  for (int i = 0; i < 4; i++) {
+    manager.PushBucket(
+        0, reinterpret_cast<ListNode*>(manager.buffer_ + i * sizeof(ListNode)));
+  }
+
+  for (int i = 0; i < 4; i++) {
+    manager.PopBucket(0);
+    ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 4 - i - 1);
+  }
+}
+
+TEST(BuddyManager, GetBrotherNode) {
+  BuddyManager manager(4, 10);
+  ASSERT_EQ(manager.GetBrotherNode(1), 2);
+  ASSERT_EQ(manager.GetBrotherNode(3), 4);
+  ASSERT_EQ(manager.GetBrotherNode(4), 3);
+  ASSERT_EQ(manager.GetBrotherNode(5), 6);
+  ASSERT_EQ(manager.GetBrotherNode(6), 5);
+  ASSERT_EQ(manager.GetBrotherNode(7), 8);
+  ASSERT_EQ(manager.GetBrotherNode(8), 7);
+}
+
+TEST(BuddyManager, SplitBucket) {
+  BuddyManager manager(4, 10);
+  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 1UL);
+  manager.SplitBucket(0, manager.buffer_, (1 << 10) / 2);
+  // The large bucket will not poped by default.
+  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1UL);
+  ASSERT_EQ(reinterpret_cast<uint8_t*>(manager.buckets_[1]),
+            manager.buffer_ + (1 << 10) / 2);
+
+  ASSERT_TRUE(manager.is_splits_.Tell(0));
+}
+
+TEST(BuddyManager, NodeForPtr) {
+  BuddyManager manager(4, 10);
+  ASSERT_EQ(
+      manager.NodeForPtr(manager.buffer_, manager.BucketForRequest(1 << 10)),
+      0UL);
+
+  ASSERT_EQ(
+      manager.NodeForPtr(manager.buffer_, manager.BucketForRequest(1 << 9)),
+      1UL);
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_ + (1 << 9),
+                               manager.BucketForRequest(1 << 9)),
+            2UL);
+  for (int i = 0; i < 4; i++) {
+    ASSERT_EQ(manager.NodeForPtr(manager.buffer_ + i * (1 << 8),
+                                 manager.BucketForRequest(1 << 8)),
+              2UL + i + 1);
+  }
+
+  for (int i = 0; i < 4 * 2; i++) {
+    ASSERT_EQ(manager.NodeForPtr(manager.buffer_ + i * (1 << 7),
+                                 manager.BucketForRequest(1 << 7)),
+              6UL + i + 1);
+  }
+}
+
+TEST(BuddyManager, PtrForNode) {
+  BuddyManager manager(4, 10);
+  // same start point with different buddy size.
+  ASSERT_EQ(manager.PtrForNode(0, 0), manager.buffer_);
+  ASSERT_EQ(manager.PtrForNode(1, 1), manager.buffer_);
+  ASSERT_EQ(manager.PtrForNode(2, 1), manager.buffer_ + (1 << 9));
+  ASSERT_EQ(manager.PtrForNode(3, 2), manager.buffer_);
+  ASSERT_EQ(manager.PtrForNode(4, 2), manager.buffer_ + 1 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(5, 2), manager.buffer_ + 2 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(6, 2), manager.buffer_ + 3 * (1 << 8));
+}
+
+TEST(BuddyManager, Malloc) {
+  BuddyManager manager(4, 10);
+  // OOM
+  ASSERT_FALSE(manager.Malloc(1 << 11));
+
+  auto* ptr = manager.Malloc((1 << 9) - manager.kHeaderSize);
+  ASSERT_EQ(ptr, manager.buffer_ + manager.kHeaderSize);
+  // The 1-th bucket should not be empty
+  ASSERT_TRUE(manager.buckets_[1]);
+  for (int i = 2; i < manager.num_buckets_; i++) {
+    ASSERT_FALSE(manager.buckets_[i]);
+  }
+
+  ptr = manager.Malloc((1 << 9) - manager.kHeaderSize);
+  ASSERT_EQ(ptr, manager.buffer_ + (1 << 9) + manager.kHeaderSize);
+
+  for (int i = 1; i < manager.num_buckets_; i++) {
+    ASSERT_FALSE(manager.buckets_[i]);
+  }
+
+  // OOM
+  ASSERT_FALSE(manager.Malloc(1 << 2));
+}
+
+TEST(BuddyManager, Malloc1) {
+  BuddyManager manager(2, 10);
+
+  auto ShowBuckets = [&] {
+    for (int i = 0; i < manager.num_buckets_; i++) {
+      LOG(INFO) << i << " " << ListGetSizeSlow(manager.buckets_[i])
+                << " bucket_size " << manager.BucketSize(i);
+    }
+
+    /*
+    LOG(INFO) << "is_splits ";
+    for (int i = 0; i < manager.is_splits_.size(); i++) {
+      LOG(INFO) << i << " " << manager.is_splits_.Tell(i);
+    }
+     */
+
+    for (int v : std::vector<int>({0, 1, 3, 7, 15})) {
+      LOG(INFO) << "node is flip " << v << " " << manager.is_splits_.Tell(v);
+    }
+  };
+
+  LOG(INFO) << "allocate " << (1 << 4) << " ----------------------------";
+  // need 1<<3 if Header included
+  auto* ptr = manager.Malloc(1 << 4);
+  // the 0th bucket will be splitted, and an 1th bucket will be added.
+  // the 1th bucket's buddy will be split to one 2th, one 3th, one 4th, one 5th
+  // buddies.
+  ShowBuckets();
+
+  LOG(INFO) << "free " << (1 << 4) << " ----------------------------";
+  manager.Free(ptr);
+  ShowBuckets();
+
+  manager.Malloc(1 << 4);
+  ShowBuckets();
+
+  manager.Malloc(1 << 4);
+  ShowBuckets();
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -30,7 +30,7 @@ TEST(BitSet, main) {
 }
 
 TEST(BuddyManager, test1) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   LOG(INFO) << "min mem: " << manager.min_mem_size_ << " "
             << manager.min_mem_log_size_;
   LOG(INFO) << "max mem: " << manager.max_mem_size_ << " "
@@ -38,7 +38,7 @@ TEST(BuddyManager, test1) {
 }
 
 TEST(BuddyManager, BucketForRequest) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   LOG(INFO) << "num buckets: " << manager.num_buckets_;
   ASSERT_EQ(manager.BucketForRequest(1 << 10), 0);
   ASSERT_EQ(manager.BucketForRequest(1 << 9), 1);
@@ -48,13 +48,13 @@ TEST(BuddyManager, BucketForRequest) {
 }
 
 TEST(BuddyManager, BucketSize) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.BucketSize(0), 1 << 10);
   ASSERT_EQ(manager.BucketSize(1), 1 << 9);
 }
 
 TEST(BuddyManager, TestFirstBucket) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.buckets_.size(), manager.num_buckets_);
   // Only the first one bucket has one element.
   for (int i = 1; i < manager.num_buckets_; i++) {
@@ -74,7 +74,7 @@ TEST(BuddyManager, TestFirstBucket) {
 }
 
 TEST(BuddyManager, PushBucket) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
 
   // Push to the first bucket.
   ASSERT_FALSE(manager.buckets_[1]);
@@ -94,7 +94,7 @@ TEST(BuddyManager, PushBucket) {
 }
 
 TEST(BuddyManager, PopBucket) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   for (int i = 0; i < 4; i++) {
     manager.PushBucket(0, reinterpret_cast<ListNode*>(manager.buffer_.front() +
                                                       i * sizeof(ListNode)));
@@ -107,7 +107,7 @@ TEST(BuddyManager, PopBucket) {
 }
 
 TEST(BuddyManager, GetBrotherNode) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.GetBrotherNode(1), 2);
   ASSERT_EQ(manager.GetBrotherNode(3), 4);
   ASSERT_EQ(manager.GetBrotherNode(4), 3);
@@ -118,7 +118,7 @@ TEST(BuddyManager, GetBrotherNode) {
 }
 
 TEST(BuddyManager, SplitBucket) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 1UL);
   manager.SplitBucket(0, manager.buffer_[0], (1 << 10) / 2, 0);
   // The large bucket will not poped by default.
@@ -130,7 +130,7 @@ TEST(BuddyManager, SplitBucket) {
 }
 
 TEST(BuddyManager, NodeForPtr) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front(),
                                manager.BucketForRequest(1 << 10), 0),
             0UL);
@@ -155,7 +155,7 @@ TEST(BuddyManager, NodeForPtr) {
 }
 
 TEST(BuddyManager, PtrForNode) {
-  BuddyManager manager(4, 10, 9);
+  BuddySystem manager(4, 10, 9);
   // same start point with different buddy size.
   ASSERT_EQ(manager.PtrForNode(0, 0, 0), manager.buffer_[0]);
   ASSERT_EQ(manager.PtrForNode(1, 1, 0), manager.buffer_[0]);
@@ -167,7 +167,7 @@ TEST(BuddyManager, PtrForNode) {
 }
 
 TEST(BuddyManager, Malloc) {
-  BuddyManager manager(4, 10, 9, false);
+  BuddySystem manager(4, 10, 9, false);
   // raw system allocation.
   auto raw_ptr = manager.Malloc(1 << 11);
   ASSERT_EQ(-1, manager.PoolIdxForPtr(static_cast<uint8_t*>(raw_ptr)));
@@ -192,7 +192,7 @@ TEST(BuddyManager, Malloc) {
 }
 
 TEST(BuddyManager, Malloc1) {
-  BuddyManager manager(2, 10, 9);
+  BuddySystem manager(2, 10, 9);
 
   auto ShowBuckets = [&] {
     for (int i = 0; i < manager.num_buckets_; i++) {
@@ -301,7 +301,7 @@ TEST(BuddyManager, Malloc1) {
 }
 
 TEST(BuddyManager, realloc) {
-  BuddyManager manager(2, 10, 9, true);
+  BuddySystem manager(2, 10, 9, true);
 
   auto ShowBuckets = [&] {
     for (int i = 0; i < manager.num_buckets_; i++) {

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -29,7 +29,25 @@ TEST(BitSet, main) {
   EXPECT_FALSE(bits.Tell(15));
 }
 
-TEST(BuddyManager, test1) {
+TEST(StackSet, test) {
+  StackSet<int> stack;
+  for (int i = 0; i < 10; i++) {
+    stack.push(i);
+  }
+
+  ASSERT_TRUE(stack.count(5));
+  ASSERT_TRUE(stack.count(8));
+
+  stack.pop(4);
+  ASSERT_FALSE(stack.count(4));
+}
+
+TEST(BuddyResource, test) {
+  auto resource = CreateBuddyResource(10, 2, 9, 2);
+  ASSERT_EQ(resource->num_buckets(), 10 - 2 + 1);
+}
+
+TEST(BuddySystem, test1) {
   BuddySystem manager(4, 10, 9);
   LOG(INFO) << "min mem: " << manager.min_mem_size_ << " "
             << manager.min_mem_log_size_;
@@ -37,7 +55,7 @@ TEST(BuddyManager, test1) {
             << manager.max_mem_log_size_;
 }
 
-TEST(BuddyManager, BucketForRequest) {
+TEST(BuddySystem, BucketForRequest) {
   BuddySystem manager(4, 10, 9);
   LOG(INFO) << "num buckets: " << manager.num_buckets_;
   ASSERT_EQ(manager.BucketForRequest(1 << 10), 0);
@@ -47,66 +65,60 @@ TEST(BuddyManager, BucketForRequest) {
   }
 }
 
-TEST(BuddyManager, BucketSize) {
+TEST(BuddySystem, BucketSize) {
   BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.BucketSize(0), 1 << 10);
   ASSERT_EQ(manager.BucketSize(1), 1 << 9);
 }
 
-TEST(BuddyManager, TestFirstBucket) {
+TEST(BuddySystem, TestFirstBucket) {
   BuddySystem manager(4, 10, 9);
-  ASSERT_EQ(manager.buckets_.size(), manager.num_buckets_);
+  ASSERT_EQ(manager.buckets_->size(), manager.num_buckets_);
   // Only the first one bucket has one element.
   for (int i = 1; i < manager.num_buckets_; i++) {
-    ASSERT_FALSE(manager.buckets_[i]);
+    ASSERT_FALSE(!manager.buckets(i).empty());
   }
-  ASSERT_TRUE(manager.buckets_.front());
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_.front()), 1UL);
+  ASSERT_TRUE(!manager.buckets_->front().empty());
+  ASSERT_EQ(manager.buckets_->front().size(), 1UL);
   // Pop the only one bucket
   auto* res = manager.PopBucket(0);
   ASSERT_TRUE(res);
   // The first bucket just align from the head of the buffer.
-  ASSERT_EQ(reinterpret_cast<uint8_t*>(res), manager.buffer_[0]);
-  ASSERT_EQ(res->next, res);
-  ASSERT_EQ(res->pre, res);
+  ASSERT_EQ(reinterpret_cast<uint8_t*>(res), manager.buffer(0));
   // Pop if there is no remaining buckets.
   ASSERT_FALSE(manager.PopBucket(0));
 }
 
-TEST(BuddyManager, PushBucket) {
+TEST(BuddySystem, PushBucket) {
   BuddySystem manager(4, 10, 9);
 
   // Push to the first bucket.
-  ASSERT_FALSE(manager.buckets_[1]);
+  ASSERT_FALSE(!manager.buckets(1).empty());
 
-  manager.PushBucket(1, reinterpret_cast<ListNode*>(manager.buffer_.front() +
-                                                    sizeof(ListNode)));
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1UL);
-  ASSERT_EQ(manager.buckets_[1]->next, manager.buckets_[1]);
-  ASSERT_EQ(manager.buckets_[1]->pre, manager.buckets_[1]);
+  manager.PushBucket(1, manager.buffer_->front());
+  ASSERT_EQ(manager.buckets(1).size(), 1UL);
 
   // There are 1<<10 nodes for the 0th bucket.
   for (int i = 2; i < 7; i++) {
-    manager.PushBucket(1, reinterpret_cast<ListNode*>(manager.buffer_.front() +
-                                                      i * sizeof(ListNode)));
-    ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), i);
+    manager.PushBucket(1, manager.buffer_->front());
+    ASSERT_EQ(manager.buckets(1).size(), i);
   }
 }
 
-TEST(BuddyManager, PopBucket) {
+TEST(BuddySystem, PopBucket) {
   BuddySystem manager(4, 10, 9);
   for (int i = 0; i < 4; i++) {
-    manager.PushBucket(0, reinterpret_cast<ListNode*>(manager.buffer_.front() +
-                                                      i * sizeof(ListNode)));
+    manager.PushBucket(0, manager.buffer_->front());
   }
+  ASSERT_EQ(manager.buckets(0).size(), 4 + 1);
 
   for (int i = 0; i < 4; i++) {
     manager.PopBucket(0);
-    ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 4 - i - 1);
+    ASSERT_EQ(manager.buckets(0).size(), 4 - i);
   }
 }
 
-TEST(BuddyManager, GetBrotherNode) {
+TEST(BuddySystem, GetBrotherNode) {
   BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.GetBrotherNode(1), 2);
   ASSERT_EQ(manager.GetBrotherNode(3), 4);
@@ -117,140 +129,140 @@ TEST(BuddyManager, GetBrotherNode) {
   ASSERT_EQ(manager.GetBrotherNode(8), 7);
 }
 
-TEST(BuddyManager, SplitBucket) {
+TEST(BuddySystem, SplitBucket) {
   BuddySystem manager(4, 10, 9);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 1UL);
-  manager.SplitBucket(0, manager.buffer_[0], (1 << 10) / 2, 0);
+  ASSERT_EQ(manager.buckets(0).size(), 1UL);
+  manager.SplitBucket(0, manager.buffer(0), (1 << 10) / 2, 0);
   // The large bucket will not poped by default.
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1UL);
-  ASSERT_EQ(reinterpret_cast<uint8_t*>(manager.buckets_[1]),
-            manager.buffer_[0] + (1 << 10) / 2);
+  ASSERT_EQ(manager.buckets(1).size(), 1UL);
+  ASSERT_EQ(reinterpret_cast<uint8_t*>(manager.buckets(1).top()),
+            manager.buffer(0) + (1 << 10) / 2);
 
-  ASSERT_TRUE(manager.is_splits_[0].Tell(0));
+  ASSERT_TRUE(manager.is_splits(0).Tell(0));
 }
 
-TEST(BuddyManager, NodeForPtr) {
+TEST(BuddySystem, NodeForPtr) {
   BuddySystem manager(4, 10, 9);
-  ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front(),
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_->front(),
                                manager.BucketForRequest(1 << 10), 0),
             0UL);
 
-  ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front(),
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_->front(),
                                manager.BucketForRequest(1 << 9), 0),
             1UL);
-  ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front() + (1 << 9),
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_->front() + (1 << 9),
                                manager.BucketForRequest(1 << 9), 0),
             2UL);
   for (int i = 0; i < 4; i++) {
-    ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front() + i * (1 << 8),
+    ASSERT_EQ(manager.NodeForPtr(manager.buffer_->front() + i * (1 << 8),
                                  manager.BucketForRequest(1 << 8), 0),
               2UL + i + 1);
   }
 
   for (int i = 0; i < 4 * 2; i++) {
-    ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front() + i * (1 << 7),
+    ASSERT_EQ(manager.NodeForPtr(manager.buffer_->front() + i * (1 << 7),
                                  manager.BucketForRequest(1 << 7), 0),
               6UL + i + 1);
   }
 }
 
-TEST(BuddyManager, PtrForNode) {
+TEST(BuddySystem, PtrForNode) {
   BuddySystem manager(4, 10, 9);
   // same start point with different buddy size.
-  ASSERT_EQ(manager.PtrForNode(0, 0, 0), manager.buffer_[0]);
-  ASSERT_EQ(manager.PtrForNode(1, 1, 0), manager.buffer_[0]);
-  ASSERT_EQ(manager.PtrForNode(2, 1, 0), manager.buffer_[0] + (1 << 9));
-  ASSERT_EQ(manager.PtrForNode(3, 2, 0), manager.buffer_[0]);
-  ASSERT_EQ(manager.PtrForNode(4, 2, 0), manager.buffer_[0] + 1 * (1 << 8));
-  ASSERT_EQ(manager.PtrForNode(5, 2, 0), manager.buffer_[0] + 2 * (1 << 8));
-  ASSERT_EQ(manager.PtrForNode(6, 2, 0), manager.buffer_[0] + 3 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(0, 0, 0), manager.buffer(0));
+  ASSERT_EQ(manager.PtrForNode(1, 1, 0), manager.buffer(0));
+  ASSERT_EQ(manager.PtrForNode(2, 1, 0), manager.buffer(0) + (1 << 9));
+  ASSERT_EQ(manager.PtrForNode(3, 2, 0), manager.buffer(0));
+  ASSERT_EQ(manager.PtrForNode(4, 2, 0), manager.buffer(0) + 1 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(5, 2, 0), manager.buffer(0) + 2 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(6, 2, 0), manager.buffer(0) + 3 * (1 << 8));
 }
 
-TEST(BuddyManager, Malloc) {
+TEST(BuddySystem, Malloc) {
   BuddySystem manager(4, 10, 9, false);
   // raw system allocation.
   auto raw_ptr = manager.Malloc(1 << 11);
   ASSERT_EQ(-1, manager.PoolIdxForPtr(static_cast<uint8_t*>(raw_ptr)));
 
-  auto* ptr = manager.Malloc((1 << 9) - manager.kHeaderSize);
-  ASSERT_EQ(ptr, manager.buffer_[0] + manager.kHeaderSize);
+  auto* ptr = manager.Malloc(1 << 9);
+  ASSERT_EQ(ptr, manager.buffer(0));
   // The 1-th bucket should not be empty
-  ASSERT_TRUE(manager.buckets_[1]);
+  ASSERT_TRUE(!manager.buckets(1).empty());
   for (int i = 2; i < manager.num_buckets_; i++) {
-    ASSERT_FALSE(manager.buckets_[i]);
+    ASSERT_FALSE(manager.buckets(i).top());
   }
 
-  ptr = manager.Malloc((1 << 9) - manager.kHeaderSize);
-  ASSERT_EQ(ptr, manager.buffer_[0] + (1 << 9) + manager.kHeaderSize);
+  ptr = manager.Malloc((1 << 9));
+  ASSERT_EQ(ptr, manager.buffer(0) + (1 << 9));
 
   for (int i = 1; i < manager.num_buckets_; i++) {
-    ASSERT_FALSE(manager.buckets_[i]);
+    ASSERT_FALSE(manager.buckets(i).top());
   }
 
   // OOM
   ASSERT_FALSE(manager.Malloc(1 << 2));
 }
 
-TEST(BuddyManager, Malloc1) {
+TEST(BuddySystem, Malloc1) {
   BuddySystem manager(2, 10, 9);
 
   auto ShowBuckets = [&] {
     for (int i = 0; i < manager.num_buckets_; i++) {
-      LOG(INFO) << i << " " << ListGetSizeSlow(manager.buckets_[i])
+      LOG(INFO) << i << " "
                 << " bucket_size " << manager.BucketSize(i);
     }
 
     for (int v : std::vector<int>({0, 1, 3, 7, 8, 15})) {
-      LOG(INFO) << "node is flip " << v << " " << manager.is_splits_[0].Tell(v);
+      LOG(INFO) << "node is flip " << v << " " << manager.is_splits(0).Tell(v);
     }
   };
 
   auto CheckIsSplits = [&](const std::unordered_set<int>& nodes) {
-    for (int i = 0; i < manager.is_splits_[0].num_bytes(); i++) {
+    for (int i = 0; i < manager.is_splits(0).num_bytes(); i++) {
       if (nodes.count(i)) {
-        if (!manager.is_splits_[0].Tell(i)) {
+        if (!manager.is_splits(0).Tell(i)) {
           LOG(ERROR) << "node " << i << " != true";
         }
-        EXPECT_TRUE(manager.is_splits_[0].Tell(i));
+        EXPECT_TRUE(manager.is_splits(0).Tell(i));
       } else {
-        if (manager.is_splits_[0].Tell(i)) {
+        if (manager.is_splits(0).Tell(i)) {
           LOG(ERROR) << "node " << i << " != false";
         }
-        EXPECT_FALSE(manager.is_splits_[0].Tell(i));
+        EXPECT_FALSE(manager.is_splits(0).Tell(i));
       }
     }
   };
 
-  LOG(INFO) << "allocate " << (1 << 5) << " ----------------------------";
+  LOG(INFO) << "allocate " << (1 << 6) << " ----------------------------";
   // need extra 1<<3 if Header included, so an 1<<6 block is needed.
   // The node 15 is used.
-  auto* node_15 = manager.Malloc(1 << 5);
+  auto* node_15 = manager.Malloc(1 << 6);
   ShowBuckets();
   CheckIsSplits({0, 1, 3, 7});
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 0);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1);  // 1<<9
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[2]), 1);  // 1<<8
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[3]), 1);  // 1<<7
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[4]), 1);  // 1<<6
+  ASSERT_EQ(manager.buckets(0).size(), 0);
+  ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
+  ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
+  ASSERT_EQ(manager.buckets(3).size(), 1);  // 1<<7
+  ASSERT_EQ(manager.buckets(4).size(), 1);  // 1<<6
 
-  LOG(INFO) << "allocate " << (1 << 5) << " ----------------------------";
+  LOG(INFO) << "allocate " << (1 << 6) << " ----------------------------";
   // Alloc another 1<<6 block, the node 16 is used, so the whole node 7 is used.
-  auto* node_16 = manager.Malloc(1 << 5);
+  auto* node_16 = manager.Malloc(1 << 6);
   ShowBuckets();
   CheckIsSplits({0, 1, 3});
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 0);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1);  // 1<<9
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[2]), 1);  // 1<<8
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[3]), 1);  // 1<<7
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[4]), 0);  // 1<<6
+  ASSERT_EQ(manager.buckets(0).size(), 0);
+  ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
+  ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
+  ASSERT_EQ(manager.buckets(3).size(), 1);  // 1<<7
+  ASSERT_EQ(manager.buckets(4).size(), 0);  // 1<<6
 
   // Alloc another 1<<6 block, the node 17 is used.
-  auto* node_17 = manager.Malloc(1 << 5);
+  auto* node_17 = manager.Malloc(1 << 6);
   ShowBuckets();
   CheckIsSplits({0, 1, 8});  // node 3 is used, so not split
   // Alloc another 1<<6 block, the node 18 is used, and the whole node 8 is
   // used.
-  auto* node_18 = manager.Malloc(1 << 5);
+  auto* node_18 = manager.Malloc(1 << 6);
   ShowBuckets();
   CheckIsSplits({0, 1});  // node 3 is used, so not split
 
@@ -258,21 +270,21 @@ TEST(BuddyManager, Malloc1) {
   manager.Free(node_17);
   ShowBuckets();
   CheckIsSplits({0, 1, 8});
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 0);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1);  // 1<<9
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[2]), 1);  // 1<<8
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[3]), 0);  // 1<<7
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[4]), 1);  // 1<<6, node17
+  ASSERT_EQ(manager.buckets(0).size(), 0);
+  ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
+  ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
+  ASSERT_EQ(manager.buckets(3).size(), 0);  // 1<<7
+  ASSERT_EQ(manager.buckets(4).size(), 1);  // 1<<6, node17
 
   // Free node 15
   manager.Free(node_15);
   ShowBuckets();
   CheckIsSplits({0, 1, 7, 8});
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 0);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1);  // 1<<9
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[2]), 1);  // 1<<8
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[3]), 0);  // 1<<7
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[4]),
+  ASSERT_EQ(manager.buckets(0).size(), 0);
+  ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
+  ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
+  ASSERT_EQ(manager.buckets(3).size(), 0);  // 1<<7
+  ASSERT_EQ(manager.buckets(4).size(),
             2);  // 1<<6, node17 and node15
 
   // Free node 16, that block should merge with the block of node15, and make
@@ -280,53 +292,51 @@ TEST(BuddyManager, Malloc1) {
   manager.Free(node_16);
   ShowBuckets();
   CheckIsSplits({0, 1, 3, 8});  // node7 is free, and make node3 split
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 0);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1);  // 1<<9
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[2]), 1);  // 1<<8
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[3]), 1);  // 1<<7
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[4]),
+  ASSERT_EQ(manager.buckets(0).size(), 0);
+  ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
+  ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
+  ASSERT_EQ(manager.buckets(3).size(), 1);  // 1<<7
+  ASSERT_EQ(manager.buckets(4).size(),
             1);  // 1<<6, node17 and node15
 
-  auto* node_4 = manager.Malloc((1 << 8) - manager.kHeaderSize);
+  auto* node_4 = manager.Malloc((1 << 8));
   ShowBuckets();
   CheckIsSplits({0, 3, 8});
 
   // Alloc node5 and node6, and that will make node2 used.
-  auto* node_5 = manager.Malloc((1 << 8) - manager.kHeaderSize);
-  auto* node_6 = manager.Malloc((1 << 8) - manager.kHeaderSize);
+  auto* node_5 = manager.Malloc((1 << 8));
+  auto* node_6 = manager.Malloc((1 << 8));
   ShowBuckets();
   CheckIsSplits({3, 8});
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 0);
-  ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 0);  // 1<<9, node2 is used.
+  ASSERT_EQ(manager.buckets(0).size(), 0);
+  ASSERT_EQ(manager.buckets(1).size(), 0);  // 1<<9, node2 is used.
 }
 
-TEST(BuddyManager, realloc) {
+TEST(BuddySystem, realloc) {
   BuddySystem manager(2, 10, 9, true);
 
   auto ShowBuckets = [&] {
     for (int i = 0; i < manager.num_buckets_; i++) {
-      LOG(INFO) << i << " " << ListGetSizeSlow(manager.buckets_[i])
-                << " bucket_size " << manager.BucketSize(i);
+      LOG(INFO) << i << " " << manager.buckets(i).size() << " bucket_size "
+                << manager.BucketSize(i);
     }
   };
 
   // Occupy the initial memory block.
-  auto* ptr = manager.Malloc((1 << 10) - manager.kHeaderSize);
+  auto* ptr = manager.Malloc((1 << 10));
   ASSERT_EQ(manager.PoolIdxForPtr(static_cast<uint8_t*>(ptr)), 0);
   ASSERT_TRUE(ptr);
-  ASSERT_EQ(manager.is_splits_.size(), 1UL);
-  ASSERT_EQ(manager.buffer_.size(), 1UL);
-  ASSERT_EQ(manager.labels_.size(), 1UL);
+  ASSERT_EQ(manager.is_splits_->size(), 1UL);
+  ASSERT_EQ(manager.buffer_->size(), 1UL);
   ShowBuckets();
 
-  auto* ptr1 = manager.Malloc((1 << 8) - manager.kHeaderSize);
+  auto* ptr1 = manager.Malloc((1 << 8));
   ASSERT_TRUE(ptr1);
-  ASSERT_EQ(manager.is_splits_.size(), 2UL);
-  ASSERT_EQ(manager.buffer_.size(), 2UL);
-  ASSERT_EQ(manager.labels_.size(), 2UL);
+  ASSERT_EQ(manager.is_splits_->size(), 2UL);
+  ASSERT_EQ(manager.buffer_->size(), 2UL);
   ASSERT_EQ(manager.PoolIdxForPtr(static_cast<uint8_t*>(ptr1)), 1);
 
-  auto* ptr2 = manager.Malloc((1 << 8) - manager.kHeaderSize);
+  auto* ptr2 = manager.Malloc((1 << 8));
   ASSERT_EQ(manager.PoolIdxForPtr(static_cast<uint8_t*>(ptr1)), 1);
 }
 

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -202,7 +202,7 @@ TEST(BuddySystem, Malloc) {
   ASSERT_EQ(ptr, manager.buffer(0));
   // The 1-th bucket should not be empty
   ASSERT_TRUE(!manager.buckets(1).empty());
-  for (int i = 2; i < manager.num_buckets_; i++) {
+  for (size_t i = 2; i < manager.num_buckets_; i++) {
     ASSERT_TRUE(manager.buckets(i).top());
   }
 
@@ -221,7 +221,7 @@ TEST(BuddySystem, Malloc1) {
   BuddySystem manager(2, 10, 9);
 
   auto ShowBuckets = [&] {
-    for (int i = 0; i < manager.num_buckets_; i++) {
+    for (size_t i = 0; i < manager.num_buckets_; i++) {
       LOG(INFO) << i << " "
                 << " bucket_size " << manager.BucketSize(i);
     }

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -1,3 +1,17 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "paddle/fluid/memory/allocation/pile_allocator.h"
 #include <gtest/gtest.h>
 #include <unordered_set>
@@ -75,7 +89,7 @@ TEST(BuddySystem, TestFirstBucket) {
   BuddySystem manager(4, 10, 9);
   ASSERT_EQ(manager.buckets_->size(), manager.num_buckets_);
   // Only the first one bucket has one element.
-  for (int i = 1; i < manager.num_buckets_; i++) {
+  for (size_t i = 1; i < manager.num_buckets_; i++) {
     ASSERT_FALSE(!manager.buckets(i).empty());
   }
   ASSERT_TRUE(!manager.buckets_->front().empty());
@@ -189,14 +203,14 @@ TEST(BuddySystem, Malloc) {
   // The 1-th bucket should not be empty
   ASSERT_TRUE(!manager.buckets(1).empty());
   for (int i = 2; i < manager.num_buckets_; i++) {
-    ASSERT_FALSE(manager.buckets(i).top());
+    ASSERT_TRUE(manager.buckets(i).top());
   }
 
   ptr = manager.Malloc((1 << 9));
   ASSERT_EQ(ptr, manager.buffer(0) + (1 << 9));
 
-  for (int i = 1; i < manager.num_buckets_; i++) {
-    ASSERT_FALSE(manager.buckets(i).top());
+  for (size_t i = 1; i < manager.num_buckets_; i++) {
+    ASSERT_TRUE(manager.buckets(i).top());
   }
 
   // OOM
@@ -262,7 +276,8 @@ TEST(BuddySystem, Malloc1) {
   CheckIsSplits({0, 1, 8});  // node 3 is used, so not split
   // Alloc another 1<<6 block, the node 18 is used, and the whole node 8 is
   // used.
-  auto* node_18 = manager.Malloc(1 << 6);
+  // auto* node_18 =
+  manager.Malloc(1 << 6);
   ShowBuckets();
   CheckIsSplits({0, 1});  // node 3 is used, so not split
 
@@ -284,8 +299,7 @@ TEST(BuddySystem, Malloc1) {
   ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
   ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
   ASSERT_EQ(manager.buckets(3).size(), 0);  // 1<<7
-  ASSERT_EQ(manager.buckets(4).size(),
-            2);  // 1<<6, node17 and node15
+  ASSERT_EQ(manager.buckets(4).size(), 2);  // 1<<6, node17 and node15
 
   // Free node 16, that block should merge with the block of node15, and make
   // the entire node7 free.
@@ -296,16 +310,18 @@ TEST(BuddySystem, Malloc1) {
   ASSERT_EQ(manager.buckets(1).size(), 1);  // 1<<9
   ASSERT_EQ(manager.buckets(2).size(), 1);  // 1<<8
   ASSERT_EQ(manager.buckets(3).size(), 1);  // 1<<7
-  ASSERT_EQ(manager.buckets(4).size(),
-            1);  // 1<<6, node17 and node15
+  ASSERT_EQ(manager.buckets(4).size(), 1);  // 1<<6, node17 and node15
 
-  auto* node_4 = manager.Malloc((1 << 8));
+  // auto* node_4 =
+  manager.Malloc((1 << 8));
   ShowBuckets();
   CheckIsSplits({0, 3, 8});
 
   // Alloc node5 and node6, and that will make node2 used.
-  auto* node_5 = manager.Malloc((1 << 8));
-  auto* node_6 = manager.Malloc((1 << 8));
+  // auto* node_5 =
+  manager.Malloc((1 << 8));
+  // auto* node_6 =
+  manager.Malloc((1 << 8));
   ShowBuckets();
   CheckIsSplits({3, 8});
   ASSERT_EQ(manager.buckets(0).size(), 0);
@@ -336,7 +352,8 @@ TEST(BuddySystem, realloc) {
   ASSERT_EQ(manager.buffer_->size(), 2UL);
   ASSERT_EQ(manager.PoolIdxForPtr(static_cast<uint8_t*>(ptr1)), 1);
 
-  auto* ptr2 = manager.Malloc((1 << 8));
+  // auto* ptr2 =
+  manager.Malloc((1 << 8));
   ASSERT_EQ(manager.PoolIdxForPtr(static_cast<uint8_t*>(ptr1)), 1);
 }
 

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -30,7 +30,7 @@ TEST(BitSet, main) {
 }
 
 TEST(BuddyManager, test1) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   LOG(INFO) << "min mem: " << manager.min_mem_size_ << " "
             << manager.min_mem_log_size_;
   LOG(INFO) << "max mem: " << manager.max_mem_size_ << " "
@@ -38,7 +38,7 @@ TEST(BuddyManager, test1) {
 }
 
 TEST(BuddyManager, BucketForRequest) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   LOG(INFO) << "num buckets: " << manager.num_buckets_;
   ASSERT_EQ(manager.BucketForRequest(1 << 10), 0);
   ASSERT_EQ(manager.BucketForRequest(1 << 9), 1);
@@ -48,13 +48,13 @@ TEST(BuddyManager, BucketForRequest) {
 }
 
 TEST(BuddyManager, BucketSize) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   ASSERT_EQ(manager.BucketSize(0), 1 << 10);
   ASSERT_EQ(manager.BucketSize(1), 1 << 9);
 }
 
 TEST(BuddyManager, TestFirstBucket) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   ASSERT_EQ(manager.buckets_.size(), manager.num_buckets_);
   // Only the first one bucket has one element.
   for (int i = 1; i < manager.num_buckets_; i++) {
@@ -66,7 +66,7 @@ TEST(BuddyManager, TestFirstBucket) {
   auto* res = manager.PopBucket(0);
   ASSERT_TRUE(res);
   // The first bucket just align from the head of the buffer.
-  ASSERT_EQ(reinterpret_cast<uint8_t*>(res), manager.buffer_);
+  ASSERT_EQ(reinterpret_cast<uint8_t*>(res), manager.buffer_[0]);
   ASSERT_EQ(res->next, res);
   ASSERT_EQ(res->pre, res);
   // Pop if there is no remaining buckets.
@@ -74,30 +74,30 @@ TEST(BuddyManager, TestFirstBucket) {
 }
 
 TEST(BuddyManager, PushBucket) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
 
   // Push to the first bucket.
   ASSERT_FALSE(manager.buckets_[1]);
 
-  manager.PushBucket(
-      1, reinterpret_cast<ListNode*>(manager.buffer_ + sizeof(ListNode)));
+  manager.PushBucket(1, reinterpret_cast<ListNode*>(manager.buffer_.front() +
+                                                    sizeof(ListNode)));
   ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1UL);
   ASSERT_EQ(manager.buckets_[1]->next, manager.buckets_[1]);
   ASSERT_EQ(manager.buckets_[1]->pre, manager.buckets_[1]);
 
   // There are 1<<10 nodes for the 0th bucket.
   for (int i = 2; i < 7; i++) {
-    manager.PushBucket(
-        1, reinterpret_cast<ListNode*>(manager.buffer_ + i * sizeof(ListNode)));
+    manager.PushBucket(1, reinterpret_cast<ListNode*>(manager.buffer_.front() +
+                                                      i * sizeof(ListNode)));
     ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), i);
   }
 }
 
 TEST(BuddyManager, PopBucket) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   for (int i = 0; i < 4; i++) {
-    manager.PushBucket(
-        0, reinterpret_cast<ListNode*>(manager.buffer_ + i * sizeof(ListNode)));
+    manager.PushBucket(0, reinterpret_cast<ListNode*>(manager.buffer_.front() +
+                                                      i * sizeof(ListNode)));
   }
 
   for (int i = 0; i < 4; i++) {
@@ -107,7 +107,7 @@ TEST(BuddyManager, PopBucket) {
 }
 
 TEST(BuddyManager, GetBrotherNode) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   ASSERT_EQ(manager.GetBrotherNode(1), 2);
   ASSERT_EQ(manager.GetBrotherNode(3), 4);
   ASSERT_EQ(manager.GetBrotherNode(4), 3);
@@ -118,61 +118,62 @@ TEST(BuddyManager, GetBrotherNode) {
 }
 
 TEST(BuddyManager, SplitBucket) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   ASSERT_EQ(ListGetSizeSlow(manager.buckets_[0]), 1UL);
-  manager.SplitBucket(0, manager.buffer_, (1 << 10) / 2);
+  manager.SplitBucket(0, manager.buffer_[0], (1 << 10) / 2, 0);
   // The large bucket will not poped by default.
   ASSERT_EQ(ListGetSizeSlow(manager.buckets_[1]), 1UL);
   ASSERT_EQ(reinterpret_cast<uint8_t*>(manager.buckets_[1]),
-            manager.buffer_ + (1 << 10) / 2);
+            manager.buffer_[0] + (1 << 10) / 2);
 
-  ASSERT_TRUE(manager.is_splits_.Tell(0));
+  ASSERT_TRUE(manager.is_splits_[0].Tell(0));
 }
 
 TEST(BuddyManager, NodeForPtr) {
-  BuddyManager manager(4, 10);
-  ASSERT_EQ(
-      manager.NodeForPtr(manager.buffer_, manager.BucketForRequest(1 << 10)),
-      0UL);
+  BuddyManager manager(4, 10, 9);
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front(),
+                               manager.BucketForRequest(1 << 10), 0),
+            0UL);
 
-  ASSERT_EQ(
-      manager.NodeForPtr(manager.buffer_, manager.BucketForRequest(1 << 9)),
-      1UL);
-  ASSERT_EQ(manager.NodeForPtr(manager.buffer_ + (1 << 9),
-                               manager.BucketForRequest(1 << 9)),
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front(),
+                               manager.BucketForRequest(1 << 9), 0),
+            1UL);
+  ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front() + (1 << 9),
+                               manager.BucketForRequest(1 << 9), 0),
             2UL);
   for (int i = 0; i < 4; i++) {
-    ASSERT_EQ(manager.NodeForPtr(manager.buffer_ + i * (1 << 8),
-                                 manager.BucketForRequest(1 << 8)),
+    ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front() + i * (1 << 8),
+                                 manager.BucketForRequest(1 << 8), 0),
               2UL + i + 1);
   }
 
   for (int i = 0; i < 4 * 2; i++) {
-    ASSERT_EQ(manager.NodeForPtr(manager.buffer_ + i * (1 << 7),
-                                 manager.BucketForRequest(1 << 7)),
+    ASSERT_EQ(manager.NodeForPtr(manager.buffer_.front() + i * (1 << 7),
+                                 manager.BucketForRequest(1 << 7), 0),
               6UL + i + 1);
   }
 }
 
 TEST(BuddyManager, PtrForNode) {
-  BuddyManager manager(4, 10);
+  BuddyManager manager(4, 10, 9);
   // same start point with different buddy size.
-  ASSERT_EQ(manager.PtrForNode(0, 0), manager.buffer_);
-  ASSERT_EQ(manager.PtrForNode(1, 1), manager.buffer_);
-  ASSERT_EQ(manager.PtrForNode(2, 1), manager.buffer_ + (1 << 9));
-  ASSERT_EQ(manager.PtrForNode(3, 2), manager.buffer_);
-  ASSERT_EQ(manager.PtrForNode(4, 2), manager.buffer_ + 1 * (1 << 8));
-  ASSERT_EQ(manager.PtrForNode(5, 2), manager.buffer_ + 2 * (1 << 8));
-  ASSERT_EQ(manager.PtrForNode(6, 2), manager.buffer_ + 3 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(0, 0, 0), manager.buffer_[0]);
+  ASSERT_EQ(manager.PtrForNode(1, 1, 0), manager.buffer_[0]);
+  ASSERT_EQ(manager.PtrForNode(2, 1, 0), manager.buffer_[0] + (1 << 9));
+  ASSERT_EQ(manager.PtrForNode(3, 2, 0), manager.buffer_[0]);
+  ASSERT_EQ(manager.PtrForNode(4, 2, 0), manager.buffer_[0] + 1 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(5, 2, 0), manager.buffer_[0] + 2 * (1 << 8));
+  ASSERT_EQ(manager.PtrForNode(6, 2, 0), manager.buffer_[0] + 3 * (1 << 8));
 }
 
 TEST(BuddyManager, Malloc) {
-  BuddyManager manager(4, 10);
-  // OOM
-  ASSERT_FALSE(manager.Malloc(1 << 11));
+  BuddyManager manager(4, 10, 9, false);
+  // raw system allocation.
+  auto raw_ptr = manager.Malloc(1 << 11);
+  ASSERT_EQ(-1, manager.PoolIdxForPtr(static_cast<uint8_t*>(raw_ptr)));
 
   auto* ptr = manager.Malloc((1 << 9) - manager.kHeaderSize);
-  ASSERT_EQ(ptr, manager.buffer_ + manager.kHeaderSize);
+  ASSERT_EQ(ptr, manager.buffer_[0] + manager.kHeaderSize);
   // The 1-th bucket should not be empty
   ASSERT_TRUE(manager.buckets_[1]);
   for (int i = 2; i < manager.num_buckets_; i++) {
@@ -180,7 +181,7 @@ TEST(BuddyManager, Malloc) {
   }
 
   ptr = manager.Malloc((1 << 9) - manager.kHeaderSize);
-  ASSERT_EQ(ptr, manager.buffer_ + (1 << 9) + manager.kHeaderSize);
+  ASSERT_EQ(ptr, manager.buffer_[0] + (1 << 9) + manager.kHeaderSize);
 
   for (int i = 1; i < manager.num_buckets_; i++) {
     ASSERT_FALSE(manager.buckets_[i]);
@@ -191,7 +192,7 @@ TEST(BuddyManager, Malloc) {
 }
 
 TEST(BuddyManager, Malloc1) {
-  BuddyManager manager(2, 10);
+  BuddyManager manager(2, 10, 9);
 
   auto ShowBuckets = [&] {
     for (int i = 0; i < manager.num_buckets_; i++) {
@@ -200,22 +201,22 @@ TEST(BuddyManager, Malloc1) {
     }
 
     for (int v : std::vector<int>({0, 1, 3, 7, 8, 15})) {
-      LOG(INFO) << "node is flip " << v << " " << manager.is_splits_.Tell(v);
+      LOG(INFO) << "node is flip " << v << " " << manager.is_splits_[0].Tell(v);
     }
   };
 
   auto CheckIsSplits = [&](const std::unordered_set<int>& nodes) {
-    for (int i = 0; i < manager.is_splits_.num_bytes(); i++) {
+    for (int i = 0; i < manager.is_splits_[0].num_bytes(); i++) {
       if (nodes.count(i)) {
-        if (!manager.is_splits_.Tell(i)) {
+        if (!manager.is_splits_[0].Tell(i)) {
           LOG(ERROR) << "node " << i << " != true";
         }
-        EXPECT_TRUE(manager.is_splits_.Tell(i));
+        EXPECT_TRUE(manager.is_splits_[0].Tell(i));
       } else {
-        if (manager.is_splits_.Tell(i)) {
+        if (manager.is_splits_[0].Tell(i)) {
           LOG(ERROR) << "node " << i << " != false";
         }
-        EXPECT_FALSE(manager.is_splits_.Tell(i));
+        EXPECT_FALSE(manager.is_splits_[0].Tell(i));
       }
     }
   };

--- a/paddle/fluid/memory/allocation/pile_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/pile_allocator_test.cc
@@ -379,6 +379,7 @@ TEST(PileAllocator, crazy_alloc) {
       LOG(INFO) << "free "
                 << " : " << last_ptr;
     }
+    LOG(INFO) << "frag ratio: " << allocator.frag_ratio(-1);
   }
 }
 


### PR DESCRIPTION
# Pile Allocator
This is a buddy-allocator based high-level memory allocator for both CPU and GPU memory.
Beside a normal memory allocator, it offers the ability to save memory consumption in some special scenarios:

- In inference, several models are executed in sequential, it can help to reuse the memory for temporary variables,
- In training, it can also squeeze the memory used by sequential models execution.

The example scenarios:
 
We have `N` models, each has an average memory size `W` for weight and `T` for temporary variables, and all these models are used in sequential. By default, these models will take `N*(W+T)` size of memory.

By using PileAllocator, we can share the temporary variable memory space for all the models, and in total these model will only take `N*W+T` size of memory. That effect is remarkable when `T` is large.

TODOs:

- TODO add performance benchmark
- TODO re-consider the overall allocator interface, it seems that the design of `Allocation` as the return type add the overhead, and make it less flexible.