### PR TITLE
make deterministic op running order by rewrite hash function

### DIFF
--- a/paddle/fluid/framework/details/op_handle_base.cc
+++ b/paddle/fluid/framework/details/op_handle_base.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/fluid/framework/details/op_handle_base.h"
+#include <functional>
 #include <map>
 
 namespace paddle {
@@ -172,9 +173,14 @@ size_t OpHandleBase::NotReadyInputSize() const {
 }  // namespace framework
 }  // namespace paddle
 
-namespace std {
-size_t hash<paddle::framework::details::OpHandleBase *>::operator()(
+size_t std::hash<paddle::framework::details::OpHandleBase *>::operator()(
     paddle::framework::details::OpHandleBase *const &op_handle) const {
   return hash<paddle::framework::ir::Node *>()(op_handle->Node());
 }
-}  // namespace std
+
+bool std::less<paddle::framework::details::OpHandleBase *>::operator()(
+    paddle::framework::details::OpHandleBase *const &op_handle1,
+    paddle::framework::details::OpHandleBase *const &op_handle2) const {
+  return less<paddle::framework::ir::Node *>()(op_handle1->Node(),
+                                               op_handle2->Node());
+}

--- a/paddle/fluid/framework/details/op_handle_base.cc
+++ b/paddle/fluid/framework/details/op_handle_base.cc
@@ -171,3 +171,10 @@ size_t OpHandleBase::NotReadyInputSize() const {
 }  // namespace details
 }  // namespace framework
 }  // namespace paddle
+
+namespace std {
+size_t hash<paddle::framework::details::OpHandleBase *>::operator()(
+    paddle::framework::details::OpHandleBase *const &op_handle) const {
+  return hash<paddle::framework::ir::Node *>()(op_handle->Node());
+}
+}  // namespace std

--- a/paddle/fluid/framework/details/var_handle.cc
+++ b/paddle/fluid/framework/details/var_handle.cc
@@ -37,9 +37,14 @@ DummyVarHandle::~DummyVarHandle() {
 }  // namespace framework
 }  // namespace paddle
 
-namespace std {
-size_t hash<paddle::framework::details::VarHandleBase*>::operator()(
+size_t std::hash<paddle::framework::details::VarHandleBase*>::operator()(
     paddle::framework::details::VarHandleBase* const& var_handle) const {
   return hash<paddle::framework::ir::Node*>()(var_handle->Node());
 }
-}  // namespace std
+
+bool std::less<paddle::framework::details::VarHandleBase*>::operator()(
+    paddle::framework::details::VarHandleBase* const& var_handle1,
+    paddle::framework::details::VarHandleBase* const& var_handle2) const {
+  return less<paddle::framework::ir::Node*>()(var_handle1->Node(),
+                                              var_handle2->Node());
+}

--- a/paddle/fluid/framework/details/var_handle.cc
+++ b/paddle/fluid/framework/details/var_handle.cc
@@ -36,3 +36,10 @@ DummyVarHandle::~DummyVarHandle() {
 }  // namespace details
 }  // namespace framework
 }  // namespace paddle
+
+namespace std {
+size_t hash<paddle::framework::details::VarHandleBase*>::operator()(
+    paddle::framework::details::VarHandleBase* const& var_handle) const {
+  return hash<paddle::framework::ir::Node*>()(var_handle->Node());
+}
+}  // namespace std

--- a/paddle/fluid/framework/details/var_handle.h
+++ b/paddle/fluid/framework/details/var_handle.h
@@ -27,6 +27,28 @@ namespace paddle {
 namespace framework {
 namespace details {
 class OpHandleBase;
+class VarHandleBase;
+}  // namespace details
+}  // namespace framework
+}  // namespace paddle
+
+namespace std {
+template <>
+struct hash<paddle::framework::details::VarHandleBase*> {
+  size_t operator()(
+      paddle::framework::details::VarHandleBase* const& var_handle) const;
+};
+
+template <>
+struct hash<paddle::framework::details::OpHandleBase*> {
+  size_t operator()(
+      paddle::framework::details::OpHandleBase* const& op_handle) const;
+};
+}  // namespace std
+
+namespace paddle {
+namespace framework {
+namespace details {
 
 // Wraps ir::Node and provide helper utilities.
 // It's responsible for populating necessary fields of ir::Node.

--- a/paddle/fluid/framework/details/var_handle.h
+++ b/paddle/fluid/framework/details/var_handle.h
@@ -32,6 +32,8 @@ class VarHandleBase;
 }  // namespace framework
 }  // namespace paddle
 
+// Define the hash function of VarHandleBase* and OpHandleBase*,
+// so the order of unordered_set(or map) is deterministic
 namespace std {
 template <>
 struct hash<paddle::framework::details::VarHandleBase*> {

--- a/paddle/fluid/framework/details/var_handle.h
+++ b/paddle/fluid/framework/details/var_handle.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -32,8 +33,8 @@ class VarHandleBase;
 }  // namespace framework
 }  // namespace paddle
 
-// Define the hash function of VarHandleBase* and OpHandleBase*,
-// so the order of unordered_set(or map) is deterministic
+// Define the hash and less function of VarHandleBase* and OpHandleBase*,
+// so the order of set(map) and unordered_set(or map) is deterministic
 namespace std {
 template <>
 struct hash<paddle::framework::details::VarHandleBase*> {
@@ -45,6 +46,20 @@ template <>
 struct hash<paddle::framework::details::OpHandleBase*> {
   size_t operator()(
       paddle::framework::details::OpHandleBase* const& op_handle) const;
+};
+
+template <>
+struct less<paddle::framework::details::VarHandleBase*> {
+  bool operator()(
+      paddle::framework::details::VarHandleBase* const& var_handle1,
+      paddle::framework::details::VarHandleBase* const& var_handle2) const;
+};
+
+template <>
+struct less<paddle::framework::details::OpHandleBase*> {
+  bool operator()(
+      paddle::framework::details::OpHandleBase* const& op_handle1,
+      paddle::framework::details::OpHandleBase* const& op_handle2) const;
 };
 }  // namespace std
 

--- a/paddle/fluid/framework/ir/graph.h
+++ b/paddle/fluid/framework/ir/graph.h
@@ -123,7 +123,6 @@ class Graph {
   ir::Node *CreateVarNode(VarDesc *var_desc) {
     PADDLE_ENFORCE(var_desc);
     auto *x = AddNode(new ir::Node(var_desc));
-    x->SetId(num_node_created_++);
     return x;
   }
 
@@ -131,7 +130,6 @@ class Graph {
   ir::Node *CreateOpNode(OpDesc *op_desc) {
     PADDLE_ENFORCE(op_desc);
     auto *x = AddNode(new ir::Node(op_desc));
-    x->SetId(num_node_created_++);
     return x;
   }
 
@@ -143,7 +141,6 @@ class Graph {
     const std::string name = string::Sprintf(
         "%s@%llu", ir::Node::kControlDepVarName, node_set_.size());
     auto *x = AddNode(new ir::Node(name, ir::Node::Type::kVariable));
-    x->SetId(num_node_created_++);
     return x;
   }
 
@@ -151,7 +148,6 @@ class Graph {
   // or "copy" from another node. Avoid using it if possible.
   ir::Node *CreateEmptyNode(const std::string &name, ir::Node::Type type) {
     auto *x = AddNode(new ir::Node(name, type));
-    x->SetId(num_node_created_++);
     return x;
   }
 
@@ -192,6 +188,7 @@ class Graph {
 
   // This method takes ownership of `node`.
   ir::Node *AddNode(ir::Node *node) {
+    node->SetId(num_node_created_++);
     PADDLE_ENFORCE(node_set_.find(node) == node_set_.end());
     nodes_[node].reset(node);
     node_set_.insert(node);

--- a/paddle/fluid/framework/ir/node.cc
+++ b/paddle/fluid/framework/ir/node.cc
@@ -46,3 +46,9 @@ size_t std::hash<paddle::framework::ir::Node *>::operator()(
     paddle::framework::ir::Node *const &node) const {
   return static_cast<size_t>(node->id());
 }
+
+bool std::less<paddle::framework::ir::Node *>::operator()(
+    paddle::framework::ir::Node *const &node1,
+    paddle::framework::ir::Node *const &node2) const {
+  return node1->id() < node2->id();
+}

--- a/paddle/fluid/framework/ir/node.cc
+++ b/paddle/fluid/framework/ir/node.cc
@@ -41,3 +41,8 @@ std::unique_ptr<Node> CreateNodeForTest(OpDesc *op_desc) {
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle
+
+size_t std::hash<paddle::framework::ir::Node *>::operator()(
+    paddle::framework::ir::Node *const &node) const {
+  return static_cast<size_t>(node->id());
+}

--- a/paddle/fluid/framework/ir/node.cc
+++ b/paddle/fluid/framework/ir/node.cc
@@ -44,7 +44,7 @@ std::unique_ptr<Node> CreateNodeForTest(OpDesc *op_desc) {
 
 size_t std::hash<paddle::framework::ir::Node *>::operator()(
     paddle::framework::ir::Node *const &node) const {
-  return static_cast<size_t>(node->id());
+  return node->id();
 }
 
 bool std::less<paddle::framework::ir::Node *>::operator()(

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -163,8 +163,6 @@ std::unique_ptr<Node> CreateNodeForTest(OpDesc* op_desc);
 namespace std {
 template <>
 struct hash<paddle::framework::ir::Node*> {
-  size_t operator()(paddle::framework::ir::Node* const& node) const {
-    return static_cast<size_t>(node->id());
-  }
+  size_t operator()(paddle::framework::ir::Node* const& node) const;
 };
 }

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -116,11 +116,11 @@ class Node {
   std::unique_ptr<VarDesc> var_desc_;
   std::unique_ptr<OpDesc> op_desc_;
   Type type_;
-  int id_;
+  size_t id_;
 
  private:
   // ID can only set by a Graph.
-  void SetId(int id) { id_ = id; }
+  void SetId(size_t id) { id_ = id; }
 
   friend class Graph;
   friend std::unique_ptr<Node> CreateNodeForTest(const std::string& name,

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -160,6 +160,8 @@ std::unique_ptr<Node> CreateNodeForTest(OpDesc* op_desc);
 }  // namespace framework
 }  // namespace paddle
 
+// Define the hash function of Node*, so the order of unordered_set(or map) is
+// deterministic
 namespace std {
 template <>
 struct hash<paddle::framework::ir::Node*> {

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -159,3 +159,12 @@ std::unique_ptr<Node> CreateNodeForTest(OpDesc* op_desc);
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle
+
+namespace std {
+template <>
+struct hash<paddle::framework::ir::Node*> {
+  size_t operator()(paddle::framework::ir::Node* const& node) const {
+    return static_cast<size_t>(node->id());
+  }
+};
+}

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -99,7 +99,7 @@ class Node {
   }
 
   // Please don't use this API!
-  int id() const { return id_; }
+  size_t id() const { return id_; }
 
   bool IsOp() const { return type_ == Type::kOperation; }
   bool IsVar() const { return type_ == Type::kVariable; }

--- a/paddle/fluid/framework/ir/node.h
+++ b/paddle/fluid/framework/ir/node.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <functional>
 #include <string>
 #include <typeindex>
 #include <typeinfo>
@@ -160,11 +161,17 @@ std::unique_ptr<Node> CreateNodeForTest(OpDesc* op_desc);
 }  // namespace framework
 }  // namespace paddle
 
-// Define the hash function of Node*, so the order of unordered_set(or map) is
-// deterministic
+// Define the hash and less function of Node*, so the order of set(map) and
+// unordered_set(or map) is deterministic
 namespace std {
 template <>
 struct hash<paddle::framework::ir::Node*> {
   size_t operator()(paddle::framework::ir::Node* const& node) const;
 };
-}
+
+template <>
+struct less<paddle::framework::ir::Node*> {
+  bool operator()(paddle::framework::ir::Node* const& node1,
+                  paddle::framework::ir::Node* const& node2) const;
+};
+}  // namespace std

--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -112,7 +112,7 @@ void NaiveExecutor::CreateOps(const ProgramDesc &desc, int block_id,
 LoDTensor *NaiveExecutor::FindTensor(const std::string &name) {
   PADDLE_ENFORCE(scope_, "Need to init scope first");
   auto *var = scope_->FindVar(name);
-  PADDLE_ENFORCE(var, "No variable [%s] in the scope");
+  PADDLE_ENFORCE(var, "No variable [%s] in the scope", name.c_str());
   auto *tensor = const_cast<LoDTensor *>(&var->Get<LoDTensor>());
   return tensor;
 }


### PR DESCRIPTION
Currently, unordered_set are widely used in Executor. However, unordered_set<SomeType*> is not deterministic, 
rewriting hash function for unordered_set of Node and VarHandle and OpHandle can make op running order more stable.

This is good for debugging and also may have some beneficiations when using distribution.