### PR TITLE
fix generate doc error in activation ops

### DIFF
--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -37,7 +37,7 @@ using paddle::framework::Tensor;
           "(bool, default false) Set to true for inference only, false " \
           "for training. Some layers may run faster when this is true.") \
           .SetDefault(false);                                            \
-      AddComment(#OP_COMMENT);                                           \
+      AddComment(OP_COMMENT);                                            \
     }                                                                    \
   }
 
@@ -124,7 +124,7 @@ class ActivationOpGrad : public framework::OperatorWithKernel {
 UNUSED constexpr char SigmoidDoc[] = R"DOC(
 Sigmoid Activation Operator
 
-$$out = \frac{1}{1 + e^{-x}}$$
+$$out = \\frac{1}{1 + e^{-x}}$$
 
 )DOC";
 
@@ -187,14 +187,14 @@ $out = |x|$
 UNUSED constexpr char CeilDoc[] = R"DOC(
 Ceil Activation Operator.
 
-$out = ceil(x)$
+$out = \left \lceil x \right \rceil$
 
 )DOC";
 
 UNUSED constexpr char FloorDoc[] = R"DOC(
 Floor Activation Operator.
 
-$out = floor(x)$
+$out = \left \lfloor x \right \rfloor$
 
 )DOC";
 
@@ -252,7 +252,7 @@ $out = \ln(1 + e^{x})$
 UNUSED constexpr char SoftsignDoc[] = R"DOC(
 Softsign Activation Operator.
 
-$$out = \frac{x}{1 + |x|}$$
+$$out = \\frac{x}{1 + \|x\|}$$
 
 )DOC";
 


### PR DESCRIPTION
- fix generate doc error in several activation ops
- fix the wrong formula in sigmoid, soft sign, ceil, floor
- before:
![image](https://user-images.githubusercontent.com/6836917/52685177-c727b400-2f83-11e9-9f8b-1c5f84f6091d.png)
http://www.paddlepaddle.org/documentation/docs/en/1.2/api/layers.html#permalink-184-sigmoid
- after:
![image](https://user-images.githubusercontent.com/6836917/52687084-600dfd80-2f8b-11e9-8d78-c5371c368d3e.png)
![image](https://user-images.githubusercontent.com/6836917/52687110-7025dd00-2f8b-11e9-9121-ce4350fab5a8.png)
![image](https://user-images.githubusercontent.com/6836917/52687783-54700600-2f8e-11e9-93cd-02cb2f2a09f7.png)
![image](https://user-images.githubusercontent.com/6836917/52687793-6356b880-2f8e-11e9-8cb3-925ddab418e7.png)