### PR TITLE
This PR improve performance of prior_box op about 1.25x faster on CPU.

### DIFF
--- a/paddle/fluid/operators/detection/prior_box_op.h
+++ b/paddle/fluid/operators/detection/prior_box_op.h
@@ -172,8 +172,9 @@ class PriorBoxOpKernel : public framework::OpKernel<T> {
         framework::make_ddim({1, static_cast<int>(variances.size())}),
         ctx.GetPlace());
     auto var_et = framework::EigenTensor<T, 2>::From(var_t);
- #ifdef PADDLE_WITH_MKLML
-    #pragma omp parallel for
+
+#ifdef PADDLE_WITH_MKLML
+#pragma omp parallel for
 #endif
     for (size_t i = 0; i < variances.size(); ++i) {
       var_et(0, i) = variances[i];
@@ -184,8 +185,9 @@ class PriorBoxOpKernel : public framework::OpKernel<T> {
     vars->Resize({box_num, static_cast<int>(variances.size())});
 
     auto e_vars = framework::EigenMatrix<T, Eigen::RowMajor>::From(*vars);
+
 #ifdef PADDLE_WITH_MKLML
-  #pragma omp parallel for collapse(2)
+#pragma omp parallel for collapse(2)
 #endif
     for (int i = 0; i < box_num; ++i) {
       for (int j = 0; j < variances.size(); ++j) {

--- a/paddle/fluid/operators/detection/prior_box_op.h
+++ b/paddle/fluid/operators/detection/prior_box_op.h
@@ -172,6 +172,9 @@ class PriorBoxOpKernel : public framework::OpKernel<T> {
         framework::make_ddim({1, static_cast<int>(variances.size())}),
         ctx.GetPlace());
     auto var_et = framework::EigenTensor<T, 2>::From(var_t);
+ #ifdef PADDLE_WITH_MKLML
+    #pragma omp parallel for
+#endif
     for (size_t i = 0; i < variances.size(); ++i) {
       var_et(0, i) = variances[i];
     }
@@ -181,8 +184,14 @@ class PriorBoxOpKernel : public framework::OpKernel<T> {
     vars->Resize({box_num, static_cast<int>(variances.size())});
 
     auto e_vars = framework::EigenMatrix<T, Eigen::RowMajor>::From(*vars);
-    e_vars = var_et.broadcast(Eigen::DSizes<int, 2>(box_num, 1));
-
+#ifdef PADDLE_WITH_MKLML
+  #pragma omp parallel for collapse(2)
+#endif
+    for (int i = 0; i < box_num; ++i) {
+      for (int j = 0; j < variances.size(); ++j) {
+        e_vars(i, j) = variances[j];
+      }
+    }
     vars->Resize(var_dim);
   }
 };  // namespace operators


### PR DESCRIPTION
* Test Env:SKX 8180 with fake data on 28 threads(bs=1).
* The below table shows the ~25% improvement in prior_box (SSD-MobileNet) which testing data generated by [eval_tp_fake_data.py](https://github.com/PaddlePaddle/Paddle/issues/15618#issuecomment-464613976).

| Type |Event | Calls |   Total     |  Min.    |   Max.      |  Ave.      |  Ratio.|
| ---------------- | ------------------ | ---- | ------- | -------- | -------- | ------------ | -------- |
| w/ optimization  | thread0::prior_box | 6000 | 921.201 | 0.110572 | 0.383402 | **0.153533** | 0.084585 |
| w/o optimization | thread0::prior_box | 6000 | 1151.85 | 0.102276 | 0.426702 | **0.191976** | 0.103337 |

test=develop