### PR TITLE
Feature/add op mem cost

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -988,12 +988,6 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   kernel_iter->second(
       ExecutionContext(*this, exec_scope, *dev_ctx, ctx, kernel_configs));
 
-  if (FLAGS_benchmark && platform::is_gpu_place(place)) {
-    auto device = boost::get<platform::CUDAPlace>(place).device;
-    after_mem_cost =
-        memory::allocation::GPUMemMonitor.GetCurrentMemUsage(device);
-  }
-
   if (!transfered_inplace_vars.empty()) {
     // there is inplace variable has been transfered.
     TransferInplaceVarsBack(scope, transfered_inplace_vars, *transfer_scope);
@@ -1004,6 +998,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
     dev_ctx->Wait();
 
     auto device = boost::get<platform::CUDAPlace>(place).device;
+    after_mem_cost =
+      memory::allocation::GPUMemMonitor.GetCurrentMemUsage(device);
     VLOG(3) << "op : " << type_ << " Device : " << device
             << " Peak Memory Usage : "
             << ((after_mem_cost - init_mem_cost) >> 20) << " MiB";

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -999,7 +999,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
     auto device = boost::get<platform::CUDAPlace>(place).device;
     after_mem_cost =
-      memory::allocation::GPUMemMonitor.GetCurrentMemUsage(device);
+        memory::allocation::GPUMemMonitor.GetCurrentMemUsage(device);
     VLOG(3) << "op : " << type_ << " Device : " << device
             << " Peak Memory Usage : "
             << ((after_mem_cost - init_mem_cost) >> 20) << " MiB";

--- a/paddle/fluid/memory/allocation/legacy_allocator.cc
+++ b/paddle/fluid/memory/allocation/legacy_allocator.cc
@@ -14,6 +14,7 @@
 
 #include "paddle/fluid/memory/allocation/legacy_allocator.h"
 
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>

--- a/paddle/fluid/memory/allocation/legacy_allocator.cc
+++ b/paddle/fluid/memory/allocation/legacy_allocator.cc
@@ -391,7 +391,7 @@ uint64_t LegacyMemMonitor::GetMemUsage(const int &device) const {
 uint64_t LegacyMemMonitor::GetCurrentMemUsage(const int &device) const {
   return gpu_mem_info_.find(device) == gpu_mem_info_.end()
              ? 0UL
-             : gpu_mem_info_.at(device)->GetCurrentMemUsage();
+             : gpu_mem_info_.at(device)->GetUsage();
 }
 
 void LegacyMemMonitor::PrintMemUsage() {

--- a/paddle/fluid/memory/allocation/legacy_allocator.cc
+++ b/paddle/fluid/memory/allocation/legacy_allocator.cc
@@ -358,6 +358,8 @@ void MemInfo::Minus(const size_t &size) {
 
 uint64_t MemInfo::GetPeakUsage() const { return peak_usage_; }
 
+uint64_t MemInfo::GetUsage() const { return usage_; }
+
 LegacyMemMonitor::~LegacyMemMonitor() {
   for (auto &item : gpu_mem_info_) delete item.second;
 }
@@ -382,8 +384,14 @@ void LegacyMemMonitor::Minus(const int &device, const size_t &size) {
 
 uint64_t LegacyMemMonitor::GetMemUsage(const int &device) const {
   return gpu_mem_info_.find(device) == gpu_mem_info_.end()
-             ? 0
+             ? 0UL
              : gpu_mem_info_.at(device)->GetPeakUsage();
+}
+
+uint64_t LegacyMemMonitor::GetCurrentMemUsage(const int &device) const {
+  return gpu_mem_info_.find(device) == gpu_mem_info_.end()
+             ? 0UL
+             : gpu_mem_info_.at(device)->GetCurrentMemUsage();
 }
 
 void LegacyMemMonitor::PrintMemUsage() {

--- a/paddle/fluid/memory/allocation/legacy_allocator.h
+++ b/paddle/fluid/memory/allocation/legacy_allocator.h
@@ -33,6 +33,7 @@ class MemInfo {
   void Minus(const size_t &);
 
   uint64_t GetPeakUsage() const;
+  uint64_t GetUsage() const;
 
  private:
   /* current memory usage*/
@@ -56,6 +57,7 @@ class LegacyMemMonitor {
   void Add(const int &, const size_t &);
   void Minus(const int &, const size_t &);
 
+  uint64_t GetCurrentMemUsage(const int &) const;
   uint64_t GetMemUsage(const int &) const;
 
   void PrintMemUsage();


### PR DESCRIPTION
add op level memory debug info
usage:
```txt
export FLAGS_benchmark=true
GLOG_vmodule=operator=3 GLOG_logtostderr=1
```

Then it will print each op gpu memory cost during running.  

Even more, if u set the debug level to 4, then it will print the detail in infer_shape, kernel_running phases.(because infershape allocate lod memory)