### PR TITLE
MKLDNN: Add UT for conv_transpose_mkldnn op.

### DIFF
--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -127,6 +127,12 @@ void Conv2DTransposeOpMaker::Make() {
       "output feature channels,"
       "H is the height of the filter, and W is the width of the filter. "
       "We enforce groups number == 1 in the convolution transpose scenario.");
+  AddInput("Bias",
+           "(Tensor) Bias to be added to each output of filter application."
+           "The format of output tensor is X (one-dimensional) of size equal"
+           "to the number of output channels. Only used with MKL-DNN.")
+      .AsDispensable();
+
   AddOutput("Output",
             "(Tensor) The output tensor of convolution transpose operator. "
             "The format of output tensor is also NCHW.");

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -80,23 +80,12 @@ class TestConv2dTransposeMKLDNNOp(TestConv2dTransposeOp):
         self.outputs['Output'] = output
 
 
-class TestMKLDNNFuseRelu(TestConv2dTransposeMKLDNNOp):
+class TestMKLDNNFuseBias(TestConv2dTransposeMKLDNNOp):
     def init_test_case(self):
         TestConv2dTransposeMKLDNNOp.init_test_case(self)
         self.pad = [1, 1]
-        self.fuse_relu = True
-
-
-class TestWithGroup(TestConv2dTransposeMKLDNNOp):
-    def init_test_case(self):
-        TestConv2dTransposeMKLDNNOp.init_test_case(self)
-        self.pad = [1, 1]
-        self.stride = [1, 1]
-        self.dilations = [1, 1]
-        self.groups = 2
-        self.input_size = [2, 4, 5, 5]  # NCHW
-        f_c = self.input_size[1]
-        self.filter_size = [f_c, 3, 3, 3]
+        self.fuse_bias = True
+        self.bias_size = [6]
 
 
 class TestMKLDNNWithPad(TestConv2dTransposeMKLDNNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -15,18 +15,22 @@
 from __future__ import print_function
 
 import unittest
+import numpy as np
+import paddle.fluid.core as core
+from paddle.fluid.tests.unittests.op_test import OpTest
 
-from paddle.fluid.tests.unittests.test_conv2d_transpose_op import TestConv2dTransposeOp, TestWithPad, TestWithStride
+from paddle.fluid.tests.unittests.test_conv2d_transpose_op import conv2dtranspose_forward_naive, TestConv2dTransposeOp
 
 
-class TestMKLDNN(TestConv2dTransposeOp):
-    def init_op_type(self):
-        self.is_test = True
-        self.use_mkldnn = True
-        self.data_format = "NCHW"
-        self.op_type = "conv2d_transpose"
-        self._cpu_only = True
+def conv2d_bias_naive(out, bias):
+    _, out_c, _, _ = out.shape
 
+    for l in range(out_c):
+        out[:, l, :, :] = out[:, l, :, :] + bias[l]
+    return out
+
+
+class TestConv2dTransposeMKLDNNOp(TestConv2dTransposeOp):
     def test_check_grad(self):
         return
 
@@ -36,42 +40,75 @@ class TestMKLDNN(TestConv2dTransposeOp):
     def test_check_grad_no_filter(self):
         return
 
-
-class TestMKLDNNWithPad(TestWithPad):
     def init_op_type(self):
-        self.is_test = True
-        self.use_mkldnn = True
         self.data_format = "NCHW"
         self.op_type = "conv2d_transpose"
         self._cpu_only = True
 
-    def test_check_grad(self):
-        return
-
-    def test_check_grad_no_input(self):
-        return
-
-    def test_check_grad_no_filter(self):
-        return
-
-
-class TestMKLDNNWithStride(TestWithStride):
-    def init_op_type(self):
-        self.is_test = True
+    def init_test_case(self):
         self.use_mkldnn = True
-        self.data_format = "NCHW"
-        self.op_type = "conv2d_transpose"
-        self._cpu_only = True
+        self.is_test = True
+        self.pad = [0, 0]
+        self.fuse_bias = False
+        self.bias_size = None
+        self.fuse_relu = False
+        self.stride = [1, 1]
+        self.dilations = [1, 1]
+        self.input_size = [2, 3, 5, 5]  # NCHW
+        f_c = self.input_size[1]
+        self.filter_size = [f_c, 6, 3, 3]
+        self.groups = 1
 
-    def test_check_grad(self):
-        return
+    def setUp(self):
+        TestConv2dTransposeOp.setUp(self)
 
-    def test_check_grad_no_input(self):
-        return
+        output = self.outputs['Output']
 
-    def test_check_grad_no_filter(self):
-        return
+        if self.fuse_bias and self.bias_size is not None:
+            bias = np.random.random(self.bias_size).astype(self.dtype)
+            output = conv2d_bias_naive(output, bias)
+            output = output.astype(self.dtype)
+            self.attrs['fuse_bias'] = self.fuse_bias
+            self.inputs['Bias'] = OpTest.np_dtype_to_fluid_dtype(bias)
+
+        if self.fuse_relu:
+            output = np.maximum(output, 0).astype(self.dtype)
+
+        self.attrs['fuse_bias'] = self.fuse_bias
+        self.attrs['fuse_relu'] = self.fuse_relu
+
+        self.outputs['Output'] = output
 
 
-if __name__ == '__main__':
-    unittest.main()
+class TestMKLDNNFuseRelu(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [1, 1]
+        self.fuse_relu = True
+
+
+class TestWithGroup(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [1, 1]
+        self.stride = [1, 1]
+        self.dilations = [1, 1]
+        self.groups = 2
+        self.input_size = [2, 4, 5, 5]  # NCHW
+        f_c = self.input_size[1]
+        self.filter_size = [f_c, 3, 3, 3]
+
+
+class TestMKLDNNWithPad(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [1, 1]
+        self.input_size = [2, 3, 10, 10]
+
+
+class TestMKLDNNWithStride(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [1, 1]
+        self.stride = [2, 2]
+        self.input_size = [2, 3, 6, 6]  # NCHW


### PR DESCRIPTION
Line coverage improved from 74% to 89.3%. 
Function coverage improved from 81.8% to 90.9%.

This PR is related to #15615