### PR TITLE
Fix the node's order issue when the content of graph is changed

### DIFF
--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -140,7 +140,7 @@ std::map<ir::Node *, std::unordered_set<ir::Node *>> BuildOperationAdjList(
         nodes.push_back(adj_n);
       }
     }
-    std::sort(nodes.begin(), nodes.end(), [](Node *node1, Node *node2) {
+    std::sort(nodes.begin(), nodes.end(), [](ir::Node *node1, ir::Node *node2) {
       return node1->id() > node2->id();
     });
     adj_list[n].insert(std::make_move_iterator(nodes.begin()),

--- a/paddle/fluid/framework/ir/graph_helper.cc
+++ b/paddle/fluid/framework/ir/graph_helper.cc
@@ -130,15 +130,21 @@ std::map<ir::Node *, std::unordered_set<ir::Node *>> BuildOperationAdjList(
     if (adj_list.find(n) == adj_list.end()) {
       adj_list[n] = std::unordered_set<ir::Node *>();
     }
+    std::vector<ir::Node *> nodes;
     for (auto &var : n->inputs) {
       for (auto &adj_n : var->inputs) {
         PADDLE_ENFORCE(adj_n->NodeType() == ir::Node::Type::kOperation);
         VLOG(4) << "adj " << adj_n->Name() << reinterpret_cast<void *>(adj_n)
                 << " -> " << n->Name() << reinterpret_cast<void *>(n)
                 << "  via " << var->Name() << reinterpret_cast<void *>(var);
-        adj_list[n].insert(adj_n);
+        nodes.push_back(adj_n);
       }
     }
+    std::sort(nodes.begin(), nodes.end(), [](Node *node1, Node *node2) {
+      return node1->id() > node2->id();
+    });
+    adj_list[n].insert(std::make_move_iterator(nodes.begin()),
+                       std::make_move_iterator(nodes.end()));
   }
   return adj_list;
 }


### PR DESCRIPTION
When [PR#15601](https://github.com/PaddlePaddle/Paddle/pull/15601) is run, we found that the compare result between native and analysis predictor be shown the accuracy issue. The reason is  that the changed order of operators result in the  difference when the same name of output variable was used other place. So far, this PR can be helpful for it.
   As detail, please refer the below figures that describe the key difference. We can easily find that **lookup_table(15)** and **lookup_table(20)** have the same name of output variable, named as **embedding_0.tmp_0**.  if **lookup_table(20)**(table: src_pos_enc_table(21)) is executed early than **lookup_table(15)**(table: src_word_emb_table(16)), it will result in the output of **lookup_table(15)** will be used by **scale(18)** and as one input of **elementwise_add(23)**. If the variable name is same, other operator can only get the last content.

Associated PR： [PR#15601](https://github.com/PaddlePaddle/Paddle/pull/15601)

![image](https://user-images.githubusercontent.com/4131969/53884945-9523e200-4057-11e9-8e70-5906a4d39049.png)
**Figure I: The result of native predictor**

![image](https://user-images.githubusercontent.com/4131969/53885021-c3092680-4057-11e9-8c52-1fc201aedacb.png)
**Figure II: The result of analysis predictor that the graph be changed**

![image](https://user-images.githubusercontent.com/4131969/53885495-d8328500-4058-11e9-9ebc-cc820ba55d68.png)
**Figure III: The topology of transformer graph**