### PR TITLE
resolve #15618

### DIFF
--- a/paddle/fluid/operators/detection/box_coder_op.h
+++ b/paddle/fluid/operators/detection/box_coder_op.h
@@ -18,10 +18,7 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
-enum class BoxCodeType {
-  kEncodeCenterSize = 0,
-  kDecodeCenterSize = 1
-};
+enum class BoxCodeType { kEncodeCenterSize = 0, kDecodeCenterSize = 1 };
 
 inline BoxCodeType GetBoxCodeType(const std::string &type) {
   if (type == "encode_center_size") {
@@ -39,8 +36,7 @@ class BoxCoderKernel : public framework::OpKernel<T> {
                         const framework::Tensor *prior_box,
                         const framework::Tensor *prior_box_var,
                         const bool normalized,
-                        const std::vector<float> variance,
-                        T *output) const {
+                        const std::vector<float> variance, T *output) const {
     int64_t row = target_box->dims()[0];
     int64_t col = prior_box->dims()[0];
     int64_t len = prior_box->dims()[1];
@@ -116,8 +112,7 @@ class BoxCoderKernel : public framework::OpKernel<T> {
   void DecodeCenterSize(const framework::Tensor *target_box,
                         const framework::Tensor *prior_box,
                         const framework::Tensor *prior_box_var,
-                        const bool normalized,
-                        std::vector<float> variance,
+                        const bool normalized, std::vector<float> variance,
                         T *output) const {
     int64_t row = target_box->dims()[0];
     int64_t col = target_box->dims()[1];
@@ -189,8 +184,8 @@ class BoxCoderKernel : public framework::OpKernel<T> {
     std::vector<float> variance = context.Attr<std::vector<float>>("variance");
     const int axis = context.Attr<int>("axis");
     if (target_box->lod().size()) {
-      PADDLE_ENFORCE_EQ(
-          target_box->lod().size(), 1UL, "Only support 1 level of LoD.");
+      PADDLE_ENFORCE_EQ(target_box->lod().size(), 1UL,
+                        "Only support 1 level of LoD.");
     }
     if (prior_box_var) {
       PADDLE_ENFORCE(variance.empty(),
@@ -215,56 +210,32 @@ class BoxCoderKernel : public framework::OpKernel<T> {
 
     T *output = output_box->data<T>();
     if (code_type == BoxCodeType::kEncodeCenterSize) {
-      EncodeCenterSize(
-          target_box, prior_box, prior_box_var, normalized, variance, output);
+      EncodeCenterSize(target_box, prior_box, prior_box_var, normalized,
+                       variance, output);
     } else if (code_type == BoxCodeType::kDecodeCenterSize) {
       if (prior_box_var) {
         if (axis == 0) {
-          DecodeCenterSize<0, 2>(target_box,
-                                 prior_box,
-                                 prior_box_var,
-                                 normalized,
-                                 variance,
-                                 output);
+          DecodeCenterSize<0, 2>(target_box, prior_box, prior_box_var,
+                                 normalized, variance, output);
         } else {
-          DecodeCenterSize<1, 2>(target_box,
-                                 prior_box,
-                                 prior_box_var,
-                                 normalized,
-                                 variance,
-                                 output);
+          DecodeCenterSize<1, 2>(target_box, prior_box, prior_box_var,
+                                 normalized, variance, output);
         }
       } else if (!(variance.empty())) {
         if (axis == 0) {
-          DecodeCenterSize<0, 1>(target_box,
-                                 prior_box,
-                                 prior_box_var,
-                                 normalized,
-                                 variance,
-                                 output);
+          DecodeCenterSize<0, 1>(target_box, prior_box, prior_box_var,
+                                 normalized, variance, output);
         } else {
-          DecodeCenterSize<1, 1>(target_box,
-                                 prior_box,
-                                 prior_box_var,
-                                 normalized,
-                                 variance,
-                                 output);
+          DecodeCenterSize<1, 1>(target_box, prior_box, prior_box_var,
+                                 normalized, variance, output);
         }
       } else {
         if (axis == 0) {
-          DecodeCenterSize<0, 0>(target_box,
-                                 prior_box,
-                                 prior_box_var,
-                                 normalized,
-                                 variance,
-                                 output);
+          DecodeCenterSize<0, 0>(target_box, prior_box, prior_box_var,
+                                 normalized, variance, output);
         } else {
-          DecodeCenterSize<1, 0>(target_box,
-                                 prior_box,
-                                 prior_box_var,
-                                 normalized,
-                                 variance,
-                                 output);
+          DecodeCenterSize<1, 0>(target_box, prior_box, prior_box_var,
+                                 normalized, variance, output);
         }
       }
     }

--- a/paddle/fluid/operators/detection/box_coder_op.h
+++ b/paddle/fluid/operators/detection/box_coder_op.h
@@ -40,11 +40,47 @@ class BoxCoderKernel : public framework::OpKernel<T> {
     int64_t row = target_box->dims()[0];
     int64_t col = prior_box->dims()[0];
     int64_t len = prior_box->dims()[1];
-    auto *target_box_data = target_box->data<T>();
-    auto *prior_box_data = prior_box->data<T>();
-    const T *prior_box_var_data = nullptr;
+
+#ifdef PADDLE_WITH_MKLML
+#pragma omp parallel for collapse(2)
+#endif
+    for (int64_t i = 0; i < row; ++i) {
+      for (int64_t j = 0; j < col; ++j) {
+        auto *target_box_data = target_box->data<T>();
+        auto *prior_box_data = prior_box->data<T>();
+        size_t offset = i * col * len + j * len;
+        T prior_box_width = prior_box_data[j * len + 2] -
+                            prior_box_data[j * len] + (normalized == false);
+        T prior_box_height = prior_box_data[j * len + 3] -
+                             prior_box_data[j * len + 1] +
+                             (normalized == false);
+        T prior_box_center_x = prior_box_data[j * len] + prior_box_width / 2;
+        T prior_box_center_y =
+            prior_box_data[j * len + 1] + prior_box_height / 2;
+
+        T target_box_center_x =
+            (target_box_data[i * len + 2] + target_box_data[i * len]) / 2;
+        T target_box_center_y =
+            (target_box_data[i * len + 3] + target_box_data[i * len + 1]) / 2;
+        T target_box_width = target_box_data[i * len + 2] -
+                             target_box_data[i * len] + (normalized == false);
+        T target_box_height = target_box_data[i * len + 3] -
+                              target_box_data[i * len + 1] +
+                              (normalized == false);
+
+        output[offset] =
+            (target_box_center_x - prior_box_center_x) / prior_box_width;
+        output[offset + 1] =
+            (target_box_center_y - prior_box_center_y) / prior_box_height;
+        output[offset + 2] =
+            std::log(std::fabs(target_box_width / prior_box_width));
+        output[offset + 3] =
+            std::log(std::fabs(target_box_height / prior_box_height));
+      }
+    }
+
     if (prior_box_var) {
-      prior_box_var_data = prior_box_var->data<T>();
+      const T *prior_box_var_data = prior_box_var->data<T>();
 #ifdef PADDLE_WITH_MKLML
 #pragma omp parallel for collapse(3)
 #endif
@@ -69,42 +105,6 @@ class BoxCoderKernel : public framework::OpKernel<T> {
           }
         }
       }
-    } else {
-#ifdef PADDLE_WITH_MKLML
-#pragma omp parallel for collapse(2)
-#endif
-      for (int64_t i = 0; i < row; ++i) {
-        for (int64_t j = 0; j < col; ++j) {
-          size_t offset = i * col * len + j * len;
-          T prior_box_width = prior_box_data[j * len + 2] -
-                              prior_box_data[j * len] + (normalized == false);
-          T prior_box_height = prior_box_data[j * len + 3] -
-                               prior_box_data[j * len + 1] +
-                               (normalized == false);
-          T prior_box_center_x = prior_box_data[j * len] + prior_box_width / 2;
-          T prior_box_center_y =
-              prior_box_data[j * len + 1] + prior_box_height / 2;
-
-          T target_box_center_x =
-              (target_box_data[i * len + 2] + target_box_data[i * len]) / 2;
-          T target_box_center_y =
-              (target_box_data[i * len + 3] + target_box_data[i * len + 1]) / 2;
-          T target_box_width = target_box_data[i * len + 2] -
-                               target_box_data[i * len] + (normalized == false);
-          T target_box_height = target_box_data[i * len + 3] -
-                                target_box_data[i * len + 1] +
-                                (normalized == false);
-
-          output[offset] =
-              (target_box_center_x - prior_box_center_x) / prior_box_width;
-          output[offset + 1] =
-              (target_box_center_y - prior_box_center_y) / prior_box_height;
-          output[offset + 2] =
-              std::log(std::fabs(target_box_width / prior_box_width));
-          output[offset + 3] =
-              std::log(std::fabs(target_box_height / prior_box_height));
-        }
-      }
     }
   }
 
@@ -118,22 +118,16 @@ class BoxCoderKernel : public framework::OpKernel<T> {
     int64_t col = target_box->dims()[1];
     int64_t len = target_box->dims()[2];
 
-    auto *target_box_data = target_box->data<T>();
-    auto *prior_box_data = prior_box->data<T>();
-
-    T var_data[4] = {1., 1., 1., 1.};
-    T *var_ptr = var_data;
-    if (var_size == 2) {
-      var_ptr = const_cast<T *>(prior_box_var->data<T>());
-    } else if (var_size == 1) {
-      var_ptr = reinterpret_cast<T *>(variance.data());
-    }
-
 #ifdef PADDLE_WITH_MKLML
 #pragma omp parallel for collapse(2)
 #endif
     for (int64_t i = 0; i < row; ++i) {
       for (int64_t j = 0; j < col; ++j) {
+        auto *target_box_data = target_box->data<T>();
+        auto *prior_box_data = prior_box->data<T>();
+
+        T var_data[4] = {1., 1., 1., 1.};
+        T *var_ptr = var_data;
         size_t offset = i * col * len + j * len;
         int prior_box_offset = axis == 0 ? j * len : i * len;
         T prior_box_width = prior_box_data[prior_box_offset + 2] -
@@ -149,7 +143,13 @@ class BoxCoderKernel : public framework::OpKernel<T> {
 
         T target_box_center_x = 0, target_box_center_y = 0;
         T target_box_width = 0, target_box_height = 0;
-
+        int prior_var_offset = axis == 0 ? j * len : i * len;
+        if (var_size == 2) {
+          var_ptr =
+              const_cast<T *>(prior_box_var->data<T>() + prior_var_offset);
+        } else if (var_size == 1) {
+          var_ptr = reinterpret_cast<T *>(variance.data());
+        }
         T box_var_x = *var_ptr;
         T box_var_y = *(var_ptr + 1);
         T box_var_w = *(var_ptr + 2);

--- a/paddle/fluid/operators/detection/box_coder_op.h
+++ b/paddle/fluid/operators/detection/box_coder_op.h
@@ -130,7 +130,7 @@ class BoxCoderKernel : public framework::OpKernel<T> {
         T *var_ptr = var_data;
         size_t offset = i * col * len + j * len;
         int prior_box_offset = axis == 0 ? j * len : i * len;
-        
+
         T prior_box_width = prior_box_data[prior_box_offset + 2] -
                             prior_box_data[prior_box_offset] +
                             (normalized == false);

--- a/paddle/fluid/operators/detection/box_coder_op.h
+++ b/paddle/fluid/operators/detection/box_coder_op.h
@@ -146,8 +146,8 @@ class BoxCoderKernel : public framework::OpKernel<T> {
         T target_box_width = 0, target_box_height = 0;
         int prior_var_offset = axis == 0 ? j * len : i * len;
         if (var_size == 2) {
-          var_ptr =
-              const_cast<T *>(prior_box_var->data<T>() + prior_var_offset);
+          std::memcpy(var_ptr, prior_box_var->data<T>() + prior_var_offset,
+                      4 * sizeof(T));
         } else if (var_size == 1) {
           var_ptr = reinterpret_cast<T *>(variance.data());
         }

--- a/paddle/fluid/operators/detection/box_coder_op.h
+++ b/paddle/fluid/operators/detection/box_coder_op.h
@@ -130,6 +130,7 @@ class BoxCoderKernel : public framework::OpKernel<T> {
         T *var_ptr = var_data;
         size_t offset = i * col * len + j * len;
         int prior_box_offset = axis == 0 ? j * len : i * len;
+        
         T prior_box_width = prior_box_data[prior_box_offset + 2] -
                             prior_box_data[prior_box_offset] +
                             (normalized == false);


### PR DESCRIPTION
resolve #15618
Backgroud: the PR #15398 raised the box_coder op performance regression, we optimized the code via the more efficency leveraging opemmp.

* Test Env:SKX 8180 with fake data on 28 threads(bs=1/32/256).
* The below table shows the box_coder op performance has been improved massively compare to the current HEAD(4f3c8a41bef21baeec308338d94ce5f328329260)

| Type |Batch size | Event | Calls |   Total     |  Min.    |   Max.      |  Ave.      |  Ratio |
| ---------------- | ------------------ | ---- | ------- | -------- | -------- | ------------ | -------- | ---- |
| with optimization   |1 |thread0::box_coder  |   500 |   15.3449  |   0.028966 |   0.037312  |  **0.0306897**|   0.00434202|
| without optimization|1 |thread0::box_coder | 500  | 87.3473  | 0.17186  | 0.182247  | **0.174695**  | 0.0242312|
| with optimization   |32|thread0::box_coder  |  500|136.237| 0.264745 |0.564132|**0.272473**| 0.00489434|
| without optimization|32 |thread0::box_coder  |  500   |  2652.95   |  5.11728  |   5.61542  |   **5.30591** |    0.0870159|
| with optimization   | 256 |thread0::box_coder |  500|   967.843 |  1.91136 | 2.96198 |**1.93569**  | 0.00478883|
| without optimization|256 |thread0::box_coder | 500  |19420  | 38.727 |39.0971 |**38.84** | 0.0877227|

test=develop