### PR TITLE
[MKL-DNN] Fix to crash of Transformer when mkldnn is to be used

### DIFF
--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -44,6 +44,11 @@ void TensorCopy(const Tensor& src, const platform::Place& dst_place,
               << dst_place;
       return;
     }
+#ifdef PADDLE_WITH_MKLDNN
+    if (src.layout() == DataLayout::kMKLDNN) {
+      dst->set_mkldnn_prim_desc(src.get_mkldnn_prim_desc());
+    }
+#endif
     memory::Copy(boost::get<platform::CPUPlace>(dst_place), dst_ptr,
                  boost::get<platform::CPUPlace>(src_place), src_ptr, size);
   }

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -110,7 +110,7 @@ set(TRANSFORMER_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/transformer")
 download_model_and_data(${TRANSFORMER_INSTALL_DIR} "temp%2Ftransformer_model.tar.gz" "temp%2Ftransformer_data.txt.tar.gz")
 inference_analysis_test(test_analyzer_transformer SRCS analyzer_transformer_tester.cc 
   EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
-  ARGS --infer_model=${TRANSFORMER_INSTALL_DIR}/model --infer_data=${TRANSFORMER_INSTALL_DIR}/data.txt --batch_size=8)
+  ARGS --infer_model=${TRANSFORMER_INSTALL_DIR}/model --infer_data=${TRANSFORMER_INSTALL_DIR}/data.txt --batch_size=8 SERIAL)
 
 # ocr
 set(OCR_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/ocr")

--- a/paddle/fluid/inference/tests/api/analyzer_transformer_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_transformer_tester.cc
@@ -183,16 +183,25 @@ void SetInput(std::vector<std::vector<PaddleTensor>> *inputs) {
 }
 
 // Easy for profiling independently.
-TEST(Analyzer_Transformer, profile) {
-  AnalysisConfig cfg;
-  SetConfig(&cfg);
-  std::vector<PaddleTensor> outputs;
-
-  std::vector<std::vector<PaddleTensor>> input_slots_all;
-  SetInput(&input_slots_all);
-  TestPrediction(reinterpret_cast<const PaddlePredictor::Config *>(&cfg),
-                 input_slots_all, &outputs, FLAGS_num_threads);
+void profile(bool use_mkldnn = false) AnalysisConfig cfg;
+SetConfig(&cfg);
+std::vector<PaddleTensor> outputs;
+if (use_mkldnn) {
+  cfg.EnableMKLDNN();
+  std::unordered_set<std::string> op_list = {"transpose2"};
+  cfg.SetMKLDNNOp(op_list);
 }
+
+std::vector<std::vector<PaddleTensor>> input_slots_all;
+SetInput(&input_slots_all);
+TestPrediction(reinterpret_cast<const PaddlePredictor::Config *>(&cfg),
+               input_slots_all, &outputs, FLAGS_num_threads);
+}
+
+TEST(Analyzer_Transformer, profile) { profile(); }
+#ifdef PADDLE_WITH_MKLDNN
+TEST(Analyzer_Transformer, profile_mkldnn) { profile(true); }
+#endif
 
 // Check the fuse status
 TEST(Analyzer_Transformer, fuse_statis) {
@@ -206,15 +215,25 @@ TEST(Analyzer_Transformer, fuse_statis) {
 }
 
 // Compare result of NativeConfig and AnalysisConfig
-TEST(Analyzer_Transformer, compare) {
+void compare(bool use_mkldnn = false) {
   AnalysisConfig cfg;
   SetConfig(&cfg);
+  if (use_mkldnn) {
+    cfg.EnableMKLDNN();
+    std::unordered_set<std::string> op_list = {"transpose2"};
+    cfg.SetMKLDNNOp(op_list);
+  }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;
   SetInput(&input_slots_all);
   CompareNativeAndAnalysis(
       reinterpret_cast<const PaddlePredictor::Config *>(&cfg), input_slots_all);
 }
+
+TEST(Analyzer_Transformer, compare) { compare(); }
+#ifdef PADDLE_WITH_MKLDNN
+TEST(Analyzer_Transformer, compare_mkldnn) { compare(true /* use_mkldnn */); }
+#endif
 
 }  // namespace inference
 }  // namespace paddle

--- a/paddle/fluid/inference/tests/api/analyzer_transformer_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_transformer_tester.cc
@@ -183,19 +183,20 @@ void SetInput(std::vector<std::vector<PaddleTensor>> *inputs) {
 }
 
 // Easy for profiling independently.
-void profile(bool use_mkldnn = false) AnalysisConfig cfg;
-SetConfig(&cfg);
-std::vector<PaddleTensor> outputs;
-if (use_mkldnn) {
-  cfg.EnableMKLDNN();
-  std::unordered_set<std::string> op_list = {"transpose2"};
-  cfg.SetMKLDNNOp(op_list);
-}
+void profile(bool use_mkldnn = false) {
+  AnalysisConfig cfg;
+  SetConfig(&cfg);
+  std::vector<PaddleTensor> outputs;
+  if (use_mkldnn) {
+    cfg.EnableMKLDNN();
+    std::unordered_set<std::string> op_list = {"transpose2"};
+    cfg.SetMKLDNNOp(op_list);
+  }
 
-std::vector<std::vector<PaddleTensor>> input_slots_all;
-SetInput(&input_slots_all);
-TestPrediction(reinterpret_cast<const PaddlePredictor::Config *>(&cfg),
-               input_slots_all, &outputs, FLAGS_num_threads);
+  std::vector<std::vector<PaddleTensor>> input_slots_all;
+  SetInput(&input_slots_all);
+  TestPrediction(reinterpret_cast<const PaddlePredictor::Config *>(&cfg),
+                 input_slots_all, &outputs, FLAGS_num_threads);
 }
 
 TEST(Analyzer_Transformer, profile) { profile(); }

--- a/paddle/fluid/inference/tests/api/analyzer_transformer_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_transformer_tester.cc
@@ -189,8 +189,6 @@ void profile(bool use_mkldnn = false) {
   std::vector<PaddleTensor> outputs;
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    std::unordered_set<std::string> op_list = {"transpose2"};
-    cfg.SetMKLDNNOp(op_list);
   }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;
@@ -221,8 +219,6 @@ void compare(bool use_mkldnn = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    std::unordered_set<std::string> op_list = {"transpose2"};
-    cfg.SetMKLDNNOp(op_list);
   }
 
   std::vector<std::vector<PaddleTensor>> input_slots_all;


### PR DESCRIPTION
This PR is fixing transformer analyzer test when MKL-DNN is to be used. Root cause of crash was that  TensorCopy was not setting MKLDNN primitive descriptor when layout was to be kMKLDNN

