### PR TITLE
not use PERSISTENT in batch_norm. test=develop

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -79,11 +79,11 @@ class BatchNormKernel<platform::CUDADeviceContext, T>
     // TODO(dengkaipeng): use PERSISTENT mode in training may incur errors
     // in inference period, cuDNN fixed issues on PERSISTENT mode in version
     // 7.0.2, 7.0.4 and 7.3.0, we disable this mode currently.
-/* #if CUDNN_VERSION_MIN(7, 0, 0) */
-/*     mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT; */
-/* #else */
+    // #if CUDNN_VERSION_MIN(7, 0, 0)
+    //     mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
+    // #else
     mode_ = CUDNN_BATCHNORM_SPATIAL;
-/* #endif */
+    // #endif
 
     VLOG(3) << "Setting descriptors.";
     std::vector<int> dims;
@@ -306,14 +306,14 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
       }
       epsilon = std::max(epsilon, CUDNN_BN_MIN_EPSILON);
 
-    // TODO(dengkaipeng): use PERSISTENT mode in training may incur errors
-    // in inference period, cuDNN fixed issues on PERSISTENT mode in version
-    // 7.0.2, 7.0.4 and 7.3.0, we disable this mode currently.
-/* #if CUDNN_VERSION_MIN(7, 0, 0) */
-/*       mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT; */
-/* #else */
+      // TODO(dengkaipeng): use PERSISTENT mode in training may incur errors
+      // in inference period, cuDNN fixed issues on PERSISTENT mode in version
+      // 7.0.2, 7.0.4 and 7.3.0, we disable this mode currently.
+      // #if CUDNN_VERSION_MIN(7, 0, 0)
+      //       mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
+      // #else
       mode_ = CUDNN_BATCHNORM_SPATIAL;
-/* #endif */
+      // #endif
 
       CUDNN_ENFORCE(platform::dynload::cudnnSetTensorNdDescriptor(
           data_desc_, CudnnDataType<T>::type,

--- a/paddle/fluid/operators/batch_norm_op.cu
+++ b/paddle/fluid/operators/batch_norm_op.cu
@@ -75,11 +75,15 @@ class BatchNormKernel<platform::CUDADeviceContext, T>
                  << "CUDNN_BN_MIN_EPSILON instead.";
     }
     epsilon = std::max(epsilon, CUDNN_BN_MIN_EPSILON);
-#if CUDNN_VERSION_MIN(7, 0, 0)
-    mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
-#else
+
+    // TODO(dengkaipeng): use PERSISTENT mode in training may incur errors
+    // in inference period, cuDNN fixed issues on PERSISTENT mode in version
+    // 7.0.2, 7.0.4 and 7.3.0, we disable this mode currently.
+/* #if CUDNN_VERSION_MIN(7, 0, 0) */
+/*     mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT; */
+/* #else */
     mode_ = CUDNN_BATCHNORM_SPATIAL;
-#endif
+/* #endif */
 
     VLOG(3) << "Setting descriptors.";
     std::vector<int> dims;
@@ -301,11 +305,15 @@ class BatchNormGradKernel<platform::CUDADeviceContext, T>
                    << "CUDNN_BN_MIN_EPSILON instead.";
       }
       epsilon = std::max(epsilon, CUDNN_BN_MIN_EPSILON);
-#if CUDNN_VERSION_MIN(7, 0, 0)
-      mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT;
-#else
+
+    // TODO(dengkaipeng): use PERSISTENT mode in training may incur errors
+    // in inference period, cuDNN fixed issues on PERSISTENT mode in version
+    // 7.0.2, 7.0.4 and 7.3.0, we disable this mode currently.
+/* #if CUDNN_VERSION_MIN(7, 0, 0) */
+/*       mode_ = CUDNN_BATCHNORM_SPATIAL_PERSISTENT; */
+/* #else */
       mode_ = CUDNN_BATCHNORM_SPATIAL;
-#endif
+/* #endif */
 
       CUDNN_ENFORCE(platform::dynload::cudnnSetTensorNdDescriptor(
           data_desc_, CudnnDataType<T>::type,


### PR DESCRIPTION
cuDNN7中引入的batch_norm  CUDNN_BATCHNORM_SPATIAL_PERSISTENT模式，可能在inference过程中引入error，表现为stnet训练的epoch7在训练集上loss正常下降，在验证至上误差显著增大，将验证脚本中batch_norm的is_test修改为False合在训练过程中不使用CUDNN_BATCHNORM_SPATIAL_PERSISTENT 均能解决这个问题。

cuDNN在7.0.2，7.0.4，7.3.0中分别修复了CUDNN_BATCHNORM_SPATIAL_PERSISTENT模式相关的问题，尝试使用7.1.2版本没有解决这个问题，7.3.0版本会出nan。

https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_7.html#rel_7
https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_704.html#rel_704
https://docs.nvidia.com/deeplearning/sdk/cudnn-release-notes/rel_730.html#rel_730

测试CUDNN_BATCHNORM_SPATIAL_PERSISTENT模式对训练速度影响不明显，先禁用此模式
<img width="682" alt="屏幕快照 2019-03-18 下午1 09 29" src="https://user-images.githubusercontent.com/12605721/54508033-2ad83f00-497f-11e9-8206-4dc26e976ed8.png">

测试代码：
``` python
import paddle.fluid as fluid
from paddle.fluid.param_attr import ParamAttr
from paddle.fluid.initializer import Constant, Normal
import numpy as np
import time

ITER = 100
B = 4
C = 128
H = 512
W = 512

def test():

    np.random.seed(1000)
    input_np = np.random.random((B, C, H, W)).astype(np.float32)
    label_np = np.random.random((B, C, H, W)).astype(np.float32)

    input = fluid.layers.data(name='input', shape=[C, H, W], dtype='float32', stop_gradient=False)
    label = fluid.layers.data(name='label', shape=[C, H, W], dtype='float32')

    bn = fluid.layers.batch_norm(
            input=input,
            is_test=False,
            act=None,
            param_attr=ParamAttr(initializer=Constant(1.0)),
            bias_attr=ParamAttr(initializer=Constant(0.1)),
            moving_mean_name="testbn_mean",
            moving_variance_name="testbn_var")

    loss = bn - label
    avg_loss = fluid.layers.reduce_mean(loss)

    optimizer = fluid.optimizer.SGD(learning_rate=0.001)
    optimizer.minimize(avg_loss)

    place = fluid.CUDAPlace(0)
    exe = fluid.Executor(place)
    exe.run(fluid.default_startup_program())

    train_exe = fluid.ParallelExecutor(use_cuda=True, loss_name=avg_loss.name)

    fetch_list_train = [avg_loss.name]
    fluid.memory_optimize(fluid.default_main_program(), skip_opt_set=set(fetch_list_train))

    tic = time.time()
    for i in range(ITER):
        loss = train_exe.run(fetch_list_train, feed={'input':input_np, 'label':label_np})
        print("Iter {}: loss={}".format(i, np.mean(loss)))
    toc = time.time()
    print("Time cost per iter: {:.2f}s".format((toc - tic) / ITER))

test()
```