### PR TITLE
inference_shared_library support profile

### DIFF
--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -4,6 +4,9 @@ option(WITH_MKL        "Compile demo with MKL/OpenBlas support, default use MKL.
 option(WITH_GPU        "Compile demo with GPU/CPU, default use CPU."                    OFF)
 option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   ON)
 option(USE_TENSORRT "Compile demo with TensorRT."   OFF)
+if(NOT WITH_STATIC_LIB)
+  add_definitions("-DPADDLE_WITH_SHARED_LIB")
+endif()
 
 macro(safe_set_static_flag)
     foreach(flag_var

--- a/paddle/fluid/inference/api/demo_ci/vis_demo.cc
+++ b/paddle/fluid/inference/api/demo_ci/vis_demo.cc
@@ -30,6 +30,9 @@ DEFINE_string(
     "path of data; each line is a record, format is "
     "'<space splitted floats as data>\t<space splitted ints as shape'");
 DEFINE_bool(use_gpu, false, "Whether use gpu.");
+#ifdef PADDLE_WITH_SHARED_LIB
+DEFINE_bool(profile, false, "Whether use profile.");
+#endif
 
 namespace paddle {
 namespace demo {

--- a/paddle/fluid/inference/paddle_fluid.map
+++ b/paddle/fluid/inference/paddle_fluid.map
@@ -1,7 +1,8 @@
 {
 	global:
 		*paddle*;
-                *Pass*;
+		*Pass*;
+		*profile*;
 	local:
 		*;
 };


### PR DESCRIPTION
In demo_ci
- when use static library, we can use command like `/vis_demo --modeldir=../data/mobilenet/model --data=../data/mobilenet/data.txt --refer=../data/mobilenet/result.txt --use_gpu=0 --profile` to print profile result. 
- But when use shared library, the result of same command is `ERROR: unknown command line flag 'profile'`
This PR try to fix this problem.