### PR TITLE
refine cos_sim infershape

### DIFF
--- a/paddle/fluid/operators/cos_sim_op.cc
+++ b/paddle/fluid/operators/cos_sim_op.cc
@@ -74,6 +74,9 @@ class CosSimOpMaker : public framework::OpProtoAndCheckerMaker {
               "Norm of the second input, reduced along the 1st "
               "dimension.")
         .AsIntermediate();
+    AddAttr<bool>(framework::kAllKernelsMustComputeRuntimeShape,
+                  "Skip calling InferShape() function in the runtime.")
+        .SetDefault(true);
 
     AddComment(R"DOC(
 **Cosine Similarity Operator**


### PR DESCRIPTION
- follow #16154 to refine cos_sim infershape
### commands
`./paddle/fluid/inference/tests/api/test_analyzer_pyramid_dnn --infer_model=third_party/inference_demo/pyramid_dnn/model/ --infer_data=third_party/inference_demo/pyramid_dnn/data.txt --gtest_filter=Analyzer_Pyramid_DNN.profile --repeat=1000 --zero_copy=1 --profile`
### results:
- cos_sim from 5.63966ms to 3.66502ms.
- before:
```
Event                                Calls       Total       Min.        Max.        Ave.        Ratio.
thread0::hash                        12000       70.5663     0.004869    0.534644    0.00588052  0.332508
thread0::fused_embedding_seq_pool    16000       55.9146     0.002688    1.01338     0.00349466  0.26347
thread0::fc                          2000        29.2816     0.013631    0.15577     0.0146408   0.137975
thread0::sequence_enumerate          12000       28.6822     0.00211     0.22195     0.00239019  0.135151
thread0::sum                         2000        15.0158     0.006135    0.025463    0.00750788  0.0707543
thread0::softsign                    2000        7.12401     0.003273    0.04046     0.003562    0.0335683
thread0::cos_sim                     1000        5.63966     0.005461    0.010988    0.00563966  0.0265741
```
- after:
```
Event                                Calls       Total       Min.        Max.        Ave.        Ratio.
thread0::hash                        12000       69.3599     0.004778    0.543855    0.00578     0.337249
thread0::fused_embedding_seq_pool    16000       54.0699     0.002642    0.25023     0.00337937  0.262905
thread0::fc                          2000        28.7847     0.013455    0.023289    0.0143924   0.13996
thread0::sequence_enumerate          12000       28.1265     0.002109    0.109973    0.00234388  0.13676
thread0::sum                         2000        14.7141     0.00603     0.068643    0.00735705  0.0715445
thread0::softsign                    2000        6.94347     0.003177    0.139961    0.00347173  0.0337613
thread0::cos_sim                     1000        3.66502     0.003482    0.011168    0.00366502  0.0178205
```