### PR TITLE
fix runtime_context fails on cifar10_128_train_speed

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -890,7 +890,12 @@ RuntimeContext* OperatorWithKernel::GetRuntimeContext(
 
 void OperatorWithKernel::RunImpl(const Scope& scope,
                                  const platform::Place& place) const {
+#ifdef PADDLE_ON_INFERENCE
   auto runtime_ctx = GetRuntimeContext(scope);
+#else
+  RuntimeContext ctx(Inputs(), Outputs(), scope);
+  auto runtime_ctx = &ctx;
+#endif
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(place);
 


### PR DESCRIPTION
fix CE job failed. http://ce.paddlepaddle.org:8080/viewLog.html?buildId=32990&buildTypeId=PaddleCe_CEBuild
resnet50 vgg16

It runs successfully on `cifar10_128_train_speed` in http://ce.paddlepaddle.org:8080/viewLog.html?tab=buildLog&buildTypeId=PaddleModesl_ModelDebug_Model11Build&buildId=33079&_focus=13125
```
[13:02:26][Step 3/3] evaluation kpi info: True ['[cifar10_128_train_acc] pass', '[cifar10_128_train_speed] pass', '[cifar10_128_gpu_memory] pass', '[flowers_64_train_speed] pass', '[flowers_64_gpu_memory] pass'] ['cifar10_128_train_acc', 'cifar10_128_train_speed', 'cifar10_128_gpu_memory', 'flowers_64_train_speed', 'flowers_64_gpu_memory']
[13:02:26][Step 3/3] add evaluation model_ce_resnet50 result to mongodb
[13:02:26][Step 3/3] [<kpi.LessWorseKpi object at 0x7f84e9982d68>, <kpi.LessWorseKpi object at 0x7f84e0fdcfd0>, <kpi.GreaterWorseKpi object at 0x7f84ea8aa7f0>, <kpi.LessWorseKpi object at 0x7f84ea7807f0>, <kpi.GreaterWorseKpi object at 0x7f84e897b208>]
[13:02:26][Step 3/3] import from continuous_evaluation suc.
```