### PR TITLE
add data type for zero copy

### DIFF
--- a/paddle/fluid/inference/anakin/engine.cc
+++ b/paddle/fluid/inference/anakin/engine.cc
@@ -71,6 +71,7 @@ void AnakinEngine<TargetT, PrecisionType, RunType>::Execute(
     const std::map<std::string, framework::LoDTensor *> &inputs,
     const std::map<std::string, framework::LoDTensor *> &outputs,
     cudaStream_t stream) {
+  cudaDeviceSynchronize();
   for (const auto &input : inputs) {
     auto *tensor = input.second;
     auto *data = tensor->data<float>();

--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -74,6 +74,19 @@ T *ZeroCopyTensor::data(PaddlePlace *place, int *size) const {
   return res;
 }
 
+PaddleDType ZeroCopyTensor::type() {
+  EAGER_GET_TENSOR;
+  auto type = tensor->type();
+  if (type == framework::proto::VarType::FP32) {
+    return PaddleDType::FLOAT32;
+  } else if (type == framework::proto::VarType::INT64) {
+    return PaddleDType::INT64;
+  } else {
+    LOG(ERROR) << "unknown type, only support float32 and int64 now.";
+  }
+  return PaddleDType::FLOAT32;
+}
+
 template <typename T>
 void ZeroCopyTensor::copy_from_cpu(const T *data) {
   EAGER_GET_TENSOR;
@@ -119,6 +132,7 @@ void ZeroCopyTensor::copy_to_cpu(T *data) {
         static_cast<const platform::CUDADeviceContext *>(pool.Get(gpu_place));
     memory::Copy(platform::CPUPlace(), static_cast<void *>(data), gpu_place,
                  t_data, ele_num * sizeof(T), dev_ctx->stream());
+    cudaDeviceSynchronize();
 #else
     PADDLE_THROW("Not compile with CUDA, should not reach here.");
 #endif

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -176,6 +176,8 @@ class ZeroCopyTensor {
     device_ = device;
   }
 
+  PaddleDType type();
+
  protected:
   explicit ZeroCopyTensor(void* scope) : scope_{scope} {}
   void SetName(const std::string& name) { name_ = name; }
@@ -190,6 +192,7 @@ class ZeroCopyTensor {
   // performance.
   mutable void* tensor_{nullptr};
   PaddlePlace place_;
+  PaddleDType dtype_;
   int device_;
 };
 


### PR DESCRIPTION
zero copy 使用方式
```
   std::vector<PaddleTensor> inputs;

    std::vector<std::vector<float>> input(1);
    std::vector<std::vector<float>> output;

    input[0].resize(input_num);
    float sum_i = 0;
      for (int i = 0; i < input_num; i++) {
       //input[0][i] = Random(1, 128.);
        input[0][i] = 1;
       sum_i += input[0][i];
    }

    // set input
    auto input_names = predictor->GetInputNames();
    for (auto& name : input_names) {
      auto input_t = predictor->GetInputTensor(name);
      input_t->Reshape({batch_size, channels, height, width});
      input_t->copy_from_cpu(input[0].data());
    }

    // predict
    CHECK(predictor->ZeroCopyRun());
    // get output
    auto output_names = predictor->GetOutputNames();
    for (auto& name : output_names) {
      std::cout << name << std::endl;
      std::vector<float> temp_data;
      auto output_t = predictor->GetOutputTensor(name);
      PaddleDType output_type = output_t->type();
      std::cout << "Type: " << output_type << std::endl;
      std::vector<int> temp_shape = output_t->shape();
      int num = std::accumulate(temp_shape.begin(), temp_shape.end(), 1, std::multiplies<int>());
      temp_data.resize(num);

      output_t->copy_to_cpu(temp_data.data());
      output.push_back(temp_data);
    }
```