### PR TITLE
[MKL-DNN] Fix to performance regression of #16248

### DIFF
--- a/paddle/fluid/framework/data_layout_transform.h
+++ b/paddle/fluid/framework/data_layout_transform.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <map>
+#include <unordered_map>
 #include <vector>
 #include "paddle/fluid/framework/op_kernel_type.h"
 #include "paddle/fluid/framework/tensor.h"
@@ -36,17 +37,6 @@ inline MKLDNNFormat ToMKLDNNFormat(const DataLayout& layout) {
     default:
       PADDLE_THROW("Fail to convert layout %s to MKLDNN format",
                    DataLayoutToString(layout));
-  }
-}
-
-inline DataLayout ToPaddleLayout(const MKLDNNFormat& format) {
-  switch (format) {
-    case MKLDNNFormat::nhwc:
-      return DataLayout::kNHWC;
-    case MKLDNNFormat::nchw:
-      return DataLayout::kNCHW;
-    default:
-      PADDLE_THROW("Fail to convert MKLDNN format to paddle layout");
   }
 }
 

--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -20,6 +20,7 @@ limitations under the License. */
 
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
+#include "paddle/fluid/platform/mkldnn_utils.h"
 #endif
 
 namespace paddle {
@@ -52,30 +53,13 @@ void TransformData(const OpKernelType &expected_kernel_type,
         // Case1 - transform from Non-MKLDNN OPKernel to MKLDNN OPKernel
         // Just set layout/format. No real transform occur
         out.ShareDataWith(input_tensor);
-        // TODO(jczaja): Remove that once all mkldnn ops
-        // are modified to work with mkldnn_blocked
-        auto mkldnn_fmt = [&](int rank) {
-          switch (rank) {
-            case 5:
-              return mkldnn::memory::format::ncdhw;
-            case 4:
-              return mkldnn::memory::format::nchw;
-            case 3:
-              return mkldnn::memory::format::ncw;
-            case 2:
-              return mkldnn::memory::format::nc;
-            case 1:
-              return mkldnn::memory::format::x;
-            default:
-              return mkldnn::memory::format::blocked;
-          }
-        };
 
         auto out_mem_pd = paddle::platform::create_prim_desc_from_dims(
             paddle::framework::vectorize2int(out.dims()),
-            mkldnn_fmt(out.dims().size()));
+            paddle::platform::mkldnn_fmt(out.dims().size()),
+            paddle::framework::ToMKLDNNDataType(in.type()));
 
-        out.set_mkldnn_prim_desc(out_mem_pd);
+        out.set_mkldnn_prim_desc(*out_mem_pd);
 #endif
       } else {
         // Case2 - transfrom from MKLDNN OPKernel to Non-MKLDNN OPKernel

--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -18,6 +18,7 @@ limitations under the License. */
 #include <cstring>
 #include <memory>
 #include <typeindex>
+#include <utility>
 #include <vector>
 #include "paddle/fluid/framework/data_layout.h"
 #include "paddle/fluid/framework/ddim.h"
@@ -41,7 +42,6 @@ class Tensor {
 #ifdef PADDLE_WITH_MKLDNN
 
  public:
-  // TODO(jczaja): This is depracted and will be removed
   inline mkldnn::memory::format format() const {
     if (layout_ == DataLayout::kMKLDNN) {
       return static_cast<mkldnn::memory::format>(mem_pd_.desc().data.format);
@@ -50,16 +50,7 @@ class Tensor {
     }
   }
 
-  // TODO(jczaja): This is depracted and will be removed
-  inline void set_format(
-      const mkldnn::memory::format fmt,
-      mkldnn::memory::data_type data_type = mkldnn::memory::f32) {
-    mem_pd_ = paddle::platform::create_prim_desc_from_format(
-        paddle::framework::vectorize2int(dims()), fmt, data_type);
-    layout_ = DataLayout::kMKLDNN;
-  }
-
-  inline mkldnn::memory::primitive_desc get_mkldnn_prim_desc() const {
+  inline mkldnn::memory::primitive_desc& get_mkldnn_prim_desc() const {
     return mem_pd_;
   }
 

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -628,8 +628,7 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       output->mutable_data<uint8_t>(ctx.GetPlace());
     }
 
-    output->set_layout(DataLayout::kMKLDNN);
-    output->set_format(GetMKLDNNFormat(*dst_memory_p));
+    output->set_mkldnn_prim_desc(dst_memory_p->get_primitive_desc());
   }
 
  private:

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -147,8 +147,7 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     // For convolution with groups we need to recreate primitive descriptor
     // as Paddle tensor is not having group dims while mkldnn treats
     // group as another dimensions
-    mkldnn::memory::primitive_desc user_weights_mpd =
-        filter->get_mkldnn_prim_desc();
+    auto user_weights_mpd = filter->get_mkldnn_prim_desc();
     if (g > 1) {
       mkldnn::memory::format weights_format =
           GetWeightsFormat(filter->format(), g, is_conv3d);

--- a/paddle/fluid/operators/mkldnn/gaussian_random_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/gaussian_random_mkldnn_op.cc
@@ -47,7 +47,7 @@ class GaussianMKLDNNKernel : public paddle::framework::OpKernel<T> {
     auto tensor_mem_pd = paddle::platform::create_prim_desc_from_dims(
         paddle::framework::vectorize2int(tensor->dims()),
         mkldnn::memory::format::oihw);
-    tensor->set_mkldnn_prim_desc(tensor_mem_pd);
+    tensor->set_mkldnn_prim_desc(*tensor_mem_pd);
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/quantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/quantize_mkldnn_op.cc
@@ -75,9 +75,7 @@ class QuantOpKernel : public framework::OpKernel<T> {
       int mask = 0;
       attri.set_output_scales(mask, {scale_data});
 
-      auto src_md = platform::MKLDNNMemDesc({src_tz}, memory::data_type::f32,
-                                            input->format());
-      auto src_pd = mkldnn::memory::primitive_desc(src_md, engine);
+      auto src_pd = input->get_mkldnn_prim_desc();
       src_memory =
           std::make_shared<mkldnn::memory>(src_pd, to_void_cast<T>(input_data));
       std::shared_ptr<primitive::at> src_memory_p =
@@ -116,8 +114,7 @@ class QuantOpKernel : public framework::OpKernel<T> {
 
     pipeline.push_back(*reorder_p);
     stream(stream::kind::eager).submit(pipeline).wait();
-    output->set_layout(DataLayout::kMKLDNN);
-    output->set_format(GetMKLDNNFormat(*dst_memory));
+    output->set_mkldnn_prim_desc(dst_memory->get_primitive_desc());
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 #include "mkldnn.hpp"
 #include "paddle/fluid/operators/softmax_op.h"
 #include "paddle/fluid/platform/mkldnn_reuse.h"
+#include "paddle/fluid/platform/mkldnn_utils.h"
 
 namespace paddle {
 namespace operators {
@@ -163,8 +164,8 @@ class SoftmaxMKLDNNKernel : public paddle::framework::OpKernel<T> {
     // have 2,3,4+ dims
     auto output_mem_pd = paddle::platform::create_prim_desc_from_dims(
         paddle::framework::vectorize2int(output->dims()),
-        mkldnn::memory::format::blocked);
-    output->set_mkldnn_prim_desc(output_mem_pd);
+        paddle::platform::mkldnn_fmt(output->dims().size()));
+    output->set_mkldnn_prim_desc(*output_mem_pd);
 
     std::vector<primitive> pipeline{
         *(static_cast<softmax_forward::primitive*>(softmax_p.get()))};

--- a/paddle/fluid/operators/mkldnn/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/transpose_mkldnn_op.cc
@@ -69,7 +69,7 @@ class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto output_mem_pd = paddle::platform::create_prim_desc_from_dims(
         paddle::framework::vectorize2int(output->dims()),
         mkldnn::memory::format::blocked);
-    output->set_mkldnn_prim_desc(output_mem_pd);
+    output->set_mkldnn_prim_desc(*output_mem_pd);
   }
 };
 
@@ -91,8 +91,6 @@ class TransposeINT8MKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto* input = ctx.Input<Tensor>("X");
     auto* output = ctx.Output<Tensor>("Out");
     output->ShareDataWith(*input);
-    output->set_layout(DataLayout::kMKLDNN);
-    output->set_format(input->format());
   }
 };
 
@@ -153,7 +151,7 @@ class TransposeMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     auto x_grad_mem_pd = paddle::platform::create_prim_desc_from_dims(
         paddle::framework::vectorize2int(x_grad->dims()),
         mkldnn::memory::format::blocked);
-    x_grad->set_mkldnn_prim_desc(x_grad_mem_pd);
+    x_grad->set_mkldnn_prim_desc(*x_grad_mem_pd);
   }
 };
 

--- a/paddle/fluid/platform/mkldnn_utils.h
+++ b/paddle/fluid/platform/mkldnn_utils.h
@@ -14,43 +14,75 @@ limitations under the License. */
 
 #pragma once
 #include <mkldnn.h>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace paddle {
 namespace platform {
 
-inline mkldnn::memory::primitive_desc create_prim_desc_from_dims(
+// TODO(jczaja): Move This to mkldnn_reuse.h
+static std::string pddims2str(const mkldnn::memory::dims& operand_dims) {
+  std::string dstr = "";
+  for (size_t i = 0; i < operand_dims.size(); ++i) {
+    dstr += std::to_string(operand_dims[i]) + "-";
+  }
+  return dstr;
+}
+
+// TODO(jczaja): Move This to mkldnn_reuse.h
+static std::string pdGetHash(
+    const mkldnn::memory::dims& operand_dims,  // NOLINT
+    const std::string& suffix) {
+  return pddims2str(operand_dims) + suffix;
+}
+
+inline std::shared_ptr<mkldnn::memory::primitive_desc>
+create_prim_desc_from_dims(
     const std::vector<int>& ltz, mkldnn::memory::format fmt,
     mkldnn::memory::data_type data_type = mkldnn::memory::data_type::f32) {
-  mkldnn_memory_desc_t mem_fmt;
-
-  mem_fmt.primitive_kind = mkldnn_memory;
-  mem_fmt.ndims = ltz.size();
-  for (unsigned int i = 0; i < ltz.size(); ++i) {
-    mem_fmt.dims[i] = ltz[i];  // logical dimensions (nchw format,
-                               // regardless physical layout)
-  }
-  mem_fmt.data_type = static_cast<mkldnn_data_type_t>(data_type);
-  mem_fmt.format = static_cast<mkldnn_memory_format_t>(fmt);
-
-  unsigned int total_stride = 1;
-  for (int i = ltz.size() - 1; i >= 0; --i) {
-    mem_fmt.layout_desc.blocking.padding_dims[i] =
-        ltz[i];  // logical dimensions (nchw format, regardless physical
-                 // layout)
-    mem_fmt.layout_desc.blocking.block_dims[i] = 1;
-    mem_fmt.layout_desc.blocking.offset_padding_to_data[i] = 0;  // no offset
-    mem_fmt.layout_desc.blocking.strides[0][i] = total_stride;
-    mem_fmt.layout_desc.blocking.strides[1][i] = 1;
-    total_stride *= ltz[i];
-  }
-  mem_fmt.layout_desc.blocking.offset_padding = 0;  // no initial offset
-
+  // Make hash of PD
+  auto key = std::string("PD-") +
+             pdGetHash(ltz, std::to_string(static_cast<int>(fmt)) + "-" +
+                                std::to_string(static_cast<int>(data_type)));
+  // If there is PD registered then return reference to it
   auto& pool = platform::DeviceContextPool::Instance();
   auto place = paddle::platform::CPUPlace();
-  auto* dev_ctx = dynamic_cast<platform::MKLDNNDeviceContext*>(pool.Get(place));
-  auto& cpu_engine = dev_ctx->GetEngine();
-  return mkldnn::memory::primitive_desc(mem_fmt, cpu_engine);
+  auto dev_ctx = dynamic_cast<platform::MKLDNNDeviceContext*>(pool.Get(place));
+
+  auto mpd = std::static_pointer_cast<mkldnn::memory::primitive_desc>(
+      dev_ctx->GetBlob(key));
+  // if there is no PD then create one
+  if (mpd == nullptr) {
+    mkldnn_memory_desc_t mem_fmt;
+
+    mem_fmt.primitive_kind = mkldnn_memory;
+    mem_fmt.ndims = ltz.size();
+    for (unsigned int i = 0; i < ltz.size(); ++i) {
+      mem_fmt.dims[i] = ltz[i];  // logical dimensions (nchw format,
+                                 // regardless physical layout)
+    }
+    mem_fmt.data_type = static_cast<mkldnn_data_type_t>(data_type);
+    mem_fmt.format = static_cast<mkldnn_memory_format_t>(fmt);
+
+    unsigned int total_stride = 1;
+    for (int i = ltz.size() - 1; i >= 0; --i) {
+      mem_fmt.layout_desc.blocking.padding_dims[i] =
+          ltz[i];  // logical dimensions (nchw format, regardless physical
+                   // layout)
+      mem_fmt.layout_desc.blocking.block_dims[i] = 1;
+      mem_fmt.layout_desc.blocking.offset_padding_to_data[i] = 0;  // no offset
+      mem_fmt.layout_desc.blocking.strides[0][i] = total_stride;
+      mem_fmt.layout_desc.blocking.strides[1][i] = 1;
+      total_stride *= ltz[i];
+    }
+    auto& cpu_engine = dev_ctx->GetEngine();
+    mem_fmt.layout_desc.blocking.offset_padding = 0;  // no initial offset
+    mpd = std::make_shared<mkldnn::memory::primitive_desc>(mem_fmt, cpu_engine);
+    dev_ctx->SetBlob(key, mpd);
+  }
+
+  return mpd;
 }
 
 inline mkldnn::memory::primitive_desc create_prim_desc_from_format(
@@ -63,6 +95,23 @@ inline mkldnn::memory::primitive_desc create_prim_desc_from_format(
   PADDLE_ENFORCE_NOT_NULL(dev_ctx, "Could not get valid device");
   auto& cpu_engine = dev_ctx->GetEngine();
   return mkldnn::memory::primitive_desc(md, cpu_engine);
+}
+
+inline mkldnn::memory::format mkldnn_fmt(int rank) {
+  switch (rank) {
+    case 5:
+      return mkldnn::memory::format::ncdhw;
+    case 4:
+      return mkldnn::memory::format::nchw;
+    case 3:
+      return mkldnn::memory::format::ncw;
+    case 2:
+      return mkldnn::memory::format::nc;
+    case 1:
+      return mkldnn::memory::format::x;
+    default:
+      return mkldnn::memory::format::blocked;
+  }
 }
 
 }  // namespace platform

--- a/paddle/fluid/platform/mkldnn_utils.h
+++ b/paddle/fluid/platform/mkldnn_utils.h
@@ -16,6 +16,7 @@ limitations under the License. */
 #include <mkldnn.h>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace paddle {
@@ -98,20 +99,15 @@ inline mkldnn::memory::primitive_desc create_prim_desc_from_format(
 }
 
 inline mkldnn::memory::format mkldnn_fmt(int rank) {
-  switch (rank) {
-    case 5:
-      return mkldnn::memory::format::ncdhw;
-    case 4:
-      return mkldnn::memory::format::nchw;
-    case 3:
-      return mkldnn::memory::format::ncw;
-    case 2:
-      return mkldnn::memory::format::nc;
-    case 1:
-      return mkldnn::memory::format::x;
-    default:
-      return mkldnn::memory::format::blocked;
-  }
+  static std::unordered_map<int, mkldnn::memory::format> dict{
+      {5, mkldnn::memory::format::ncdhw},
+      {4, mkldnn::memory::format::nchw},
+      {3, mkldnn::memory::format::ncw},
+      {2, mkldnn::memory::format::nc},
+      {1, mkldnn::memory::format::x}};
+  auto iter = dict.find(static_cast<int>(rank));
+  if (iter != dict.end()) return iter->second;
+  return mkldnn::memory::format::blocked;
 }
 
 }  // namespace platform


### PR DESCRIPTION
This PR introduces changes to  performance issue described in #16248 . Changes here Are adapting  mkl-dnn ops to tensor modifications so overhead by setting legacy function: set_format() is removed. 
Also set_format() is removed .

@xiaolil1 If you could run same performance experiement (just Int8 part) as You did in #16248
It would be helpful confirmation that modifications are going into good direction.
