### PR TITLE
Fix order of mkldnn passes

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -115,11 +115,10 @@ class CpuPassStrategy : public PassStrategy {
       passes_.insert(passes_.begin(), "mkldnn_placement_pass");
 
       for (auto &pass : std::vector<std::string>(
-               {"depthwise_conv_mkldnn_pass",    //
-                "conv_bias_mkldnn_fuse_pass",    //
-                "conv3d_bias_mkldnn_fuse_pass",  //
-                "conv_relu_mkldnn_fuse_pass",    //
-                "conv_elementwise_add_mkldnn_fuse_pass"})) {
+               {"depthwise_conv_mkldnn_pass", "conv_bias_mkldnn_fuse_pass",
+                "conv3d_bias_mkldnn_fuse_pass",
+                "conv_elementwise_add_mkldnn_fuse_pass",
+                "conv_relu_mkldnn_fuse_pass"})) {
         passes_.push_back(pass);
       }
     }


### PR DESCRIPTION
This patch sets the mkldnn passes in correct order.
With the previous order the relu op was not fused in ResNet50 model.

test=develop