### PR TITLE
Refine default MKL-DNN Pass order

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -117,6 +117,8 @@ class CpuPassStrategy : public PassStrategy {
 
       for (auto &pass : std::vector<std::string>(
                {"depthwise_conv_mkldnn_pass",    //
+                "conv_bn_fuse_pass",             //
+                "conv_eltwiseadd_bn_fuse_pass",  //
                 "conv_bias_mkldnn_fuse_pass",    //
                 "conv3d_bias_mkldnn_fuse_pass",  //
                 "conv_relu_mkldnn_fuse_pass",    //

--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -117,8 +117,8 @@ class CpuPassStrategy : public PassStrategy {
 
       for (auto &pass : std::vector<std::string>(
                {"depthwise_conv_mkldnn_pass",    //
-                "conv_bn_fuse_pass",             //
-                "conv_eltwiseadd_bn_fuse_pass",  //
+                "conv_bn_fuse_pass",             // Execute BN passes again to
+                "conv_eltwiseadd_bn_fuse_pass",  // preserve correct pass order
                 "conv_bias_mkldnn_fuse_pass",    //
                 "conv3d_bias_mkldnn_fuse_pass",  //
                 "conv_relu_mkldnn_fuse_pass",    //


### PR DESCRIPTION
As mentioned in the https://github.com/PaddlePaddle/Paddle/pull/16399#issuecomment-476702198
> I have refined the default pass order, by adding conv batch norm passes to the list of mkl-dnn passes. That way:
> 
> * The correct order of pass execution is preserved and the fusings behave as intended
> * There is no need for user to manually set passes for his/her application

