### PR TITLE
fix model_stat module can't import bug

### DIFF
--- a/python/paddle/fluid/contrib/__init__.py
+++ b/python/paddle/fluid/contrib/__init__.py
@@ -30,6 +30,8 @@ from . import slim
 from .slim import *
 from . import utils
 from .utils import *
+from . import model_stat
+from .model_stat import *
 
 __all__ = []
 __all__ += decoder.__all__

--- a/python/paddle/fluid/contrib/__init__.py
+++ b/python/paddle/fluid/contrib/__init__.py
@@ -30,6 +30,8 @@ from . import slim
 from .slim import *
 from . import utils
 from .utils import *
+from . import extend_optimizer
+from .extend_optimizer import *
 from . import model_stat
 from .model_stat import *
 


### PR DESCRIPTION
test=develop
fix model_stat module can't import bug
add import in python/paddle/fluid/contrib/__init__.py, 
and can use 'from paddle.fluid.contrib.model_stat import summary' 