### PR TITLE
 fix model_stat module import bug

### DIFF
--- a/python/paddle/fluid/contrib/__init__.py
+++ b/python/paddle/fluid/contrib/__init__.py
@@ -32,6 +32,8 @@ from . import utils
 from .utils import *
 from . import extend_optimizer
 from .extend_optimizer import *
+from .import model_stat
+from .model_stat import * 
 
 __all__ = []
 __all__ += decoder.__all__


### PR DESCRIPTION
test=develop
resolve #15850
in contrib/init.py add importing to fix model_stat module can't import bug
from . import model_stat
from .model_stat import *

now we can use "from paddle.fluid.contrib.model_stat import summary" to summary model.