### PR TITLE
Fix training validation convergence - v1.4 bug fix

### DIFF
--- a/paddle/fluid/operators/ngraph/ngraph_engine.h
+++ b/paddle/fluid/operators/ngraph/ngraph_engine.h
@@ -57,6 +57,7 @@ class NgraphEngine {
 
   void Run(const framework::Scope& scope, const platform::Place& place) const;
 
+  static bool is_training;
   static const framework::BlockDesc* p_bdesc;
   static std::vector<std::string> feed_vars, fetch_vars;
 


### PR DESCRIPTION
This is a bug fix for v1.4 release ("overfitting" issue).
In inference, the intermediate mkldnn layout was saved for performance boost.  In training, the feature needs to be disabled as the weights will be updated each iteration. 

This fix is to disable the intermediate layout save, so the validation will be done correctly. Thus this will resolve the "overfitting" issue. The updated convergence curve will be sent for review as I had collected more data points.

Another change in this PR is the "read" op was included to check inputs as py_reader uses read op instead of feed op.

CC. @mozga-intel @jianhang-liu 