### PR TITLE
reduce hasAttr elapsed time in RunImpl

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -884,6 +884,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   // result of HasAttr.
   if (!enable_cache_runtime_context && HasAttr(kEnableCacheRuntimeContext))
     enable_cache_runtime_context = true;
+  if (!enable_cache_expected_kernel && HasAttr(kEnableCacheExpectedKernel))
+    enable_cache_expected_kernel = true;
   if (!all_kernels_must_compute_runtime_shape &&
       HasAttr(kAllKernelsMustComputeRuntimeShape))
     all_kernels_must_compute_runtime_shape = true;
@@ -906,7 +908,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   platform::DeviceContextPool& pool = platform::DeviceContextPool::Instance();
   auto* dev_ctx = pool.Get(place);
 
-  if (!HasAttr(kEnableCacheExpectedKernel) || !kernel_type_) {
+  if (!enable_cache_expected_kernel || !kernel_type_) {
     ChooseKernel(*runtime_ctx, scope, place);
   }
 

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -507,6 +507,7 @@ class OperatorWithKernel : public OperatorBase {
   mutable std::unique_ptr<RuntimeContext> runtime_ctx_;
   mutable const Scope* pre_scope_ = nullptr;
   mutable bool enable_cache_runtime_context = false;
+  mutable bool enable_cache_expected_kernel = false;
   mutable bool all_kernels_must_compute_runtime_shape = false;
 };
 

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -495,6 +495,8 @@ class OperatorWithKernel : public OperatorBase {
   mutable OpKernelConfigsMap kernel_configs_map_;
   mutable std::unique_ptr<RuntimeContext> runtime_ctx_;
   mutable const Scope* pre_scope_ = nullptr;
+  mutable bool enable_cache_runtime_context = false;
+  mutable bool all_kernels_must_compute_runtime_shape = false;
 };
 
 extern bool OpSupportGPU(const std::string& op_type);


### PR DESCRIPTION
`HasAttr` costs a lot of time in some small model. For example, it costs 14% in pyramid_dnn inference.
![image](https://user-images.githubusercontent.com/6836917/55712812-fefe2580-5a21-11e9-9402-7f3a80d007c7.png)
The reason is that `std::unordered_map` is slow in `find`: https://stackoverflow.com/questions/35238001/why-does-the-unordered-map-perform-about-100-times-slower-than-a-2d-vector-for-l

This pr use two `bool` variable to record the result of `HasAttr`. Results:

| | 2620 v3 (ms per sample) |
|---|---|
|before| 0.186852 |
|after| 0.168889 | 
|speedup| 9.6%  |