### PR TITLE
disable seqpool concat pass by default saving CI time

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -123,8 +123,8 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
       // will enhance this pass later.
       "runtime_context_cache_pass",     //
       "attention_lstm_fuse_pass",       //
-      "seqpool_concat_fuse_pass",       //
       "seqconv_eltadd_relu_fuse_pass",  //
+      // "seqpool_concat_fuse_pass",    //
       // "embedding_fc_lstm_fuse_pass", //
       "fc_lstm_fuse_pass",             //
       "mul_lstm_fuse_pass",            //

--- a/paddle/fluid/inference/tests/api/analyzer_seq_pool1_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_seq_pool1_tester.cc
@@ -150,6 +150,9 @@ void SetConfig(AnalysisConfig *cfg, bool use_mkldnn = false) {
   if (use_mkldnn) {
     cfg->EnableMKLDNN();
   }
+  // Enable seqpool_concat_fuse_pass, disabled by default since it takes much
+  // time
+  cfg->pass_builder()->InsertPass(2, "seqpool_concat_fuse_pass");
 }
 
 void profile(bool use_mkldnn = false) {


### PR DESCRIPTION
follow https://github.com/PaddlePaddle/Paddle/issues/16586#issuecomment-481112680

Saving test analyzer time more than 2X.

Before, http://ci.paddlepaddle.org/viewLog.html?buildId=80268&buildTypeId=Paddle_PrCi&tab=buildLog&branch_Paddle=pull%2F16684：
```
[20:19:06] :	 [Step 1/1]         Start 153: test_analyzer_small_dam
[20:19:24] :	 [Step 1/1] 600/622 Test #153: test_analyzer_small_dam .............................   Passed   18.82 sec
[20:19:24] :	 [Step 1/1]         Start 160: test_analyzer_transformer
[20:20:48] :	 [Step 1/1] 601/622 Test #160: test_analyzer_transformer ...........................   Passed   83.41 sec
```
After, http://ci.paddlepaddle.org/viewLog.html?buildId=81880&buildTypeId=Paddle_PrCi&tab=buildLog&branch_Paddle=pull%2F16684:
```
[11:30:25] :	 [Step 1/1]         Start 154: test_analyzer_small_dam
[11:30:29] :	 [Step 1/1] 602/624 Test #154: test_analyzer_small_dam .............................   Passed    4.18 sec
[11:30:29] :	 [Step 1/1]         Start 161: test_analyzer_transformer
[11:31:11] :	 [Step 1/1] 603/624 Test #161: test_analyzer_transformer ...........................   Passed   41.19 sec
```