### PR TITLE
Fix concat shape

### DIFF
--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -49,7 +49,15 @@ class ConcatOp : public framework::OperatorWithKernel {
     for (size_t i = 1; i < n; i++) {
       for (size_t j = 0; j < in_zero_dims_size; j++) {
         if (j == axis) {
-          out_dims[axis] += ins[i][j];
+          if (ctx->IsRuntime()) {
+            out_dims[axis] += ins[i][j];
+          } else {
+            if (out_dims[axis] == -1 || ins[i][j] == -1) {
+              out_dims[axis] = -1;
+            } else {
+              out_dims[axis] += ins[i][j];
+            }
+          }
         } else {
           if (ctx->IsRuntime()) {
             // check all shape in run time


### PR DESCRIPTION
修改concat 推导shape的行为

比如 [10, 10, -1], 与 [10, 10, 20]的矩阵按照最后一维 concat
在compile time的时候 会得到 [10, 10, 19]，这种推导是错误

新版修改之后会变为 [10, 10, -1]