### PR TITLE
[MKL-DNN] Made Tensor::Resize() invalidate mkl-dnn related content

### DIFF
--- a/paddle/fluid/framework/tensor.cc
+++ b/paddle/fluid/framework/tensor.cc
@@ -96,7 +96,15 @@ Tensor Tensor::Slice(int64_t begin_idx, int64_t end_idx) const {
 }
 
 Tensor& Tensor::Resize(const DDim& dims) {
-  dims_ = dims;
+  if (dims_ != dims) {
+// When Tensor is to have different dimensions eg. 4D instead of 3D
+// then for MKL-DNN layout we invalidate format as
+// having eg. mkldnn::ncw for 4D data does not make sense
+#ifdef PADDLE_WITH_MKLDNN
+    mkldnn_reset();
+#endif
+    dims_ = dims;
+  }
   return *this;
 }
 

--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -44,6 +44,13 @@ class Tensor {
     format_ = format;
   }
 
+  inline void mkldnn_reset() {
+    if (layout_ == DataLayout::kMKLDNN) {
+      layout_ = DataLayout::kNCHW;
+      format_ = mkldnn::memory::format::format_undef;
+    }
+  }
+
  protected:
   /**
    * @brief the detail format of memory block which have layout as kMKLDNN


### PR DESCRIPTION
Changes discussed here are introducing invalidation of MKL-DNN format and layout stored in Tensor, when Tensor::Resize is called. Reason is that when Resize is called  Tensor dims are to change so
mkldnn format is no longer relevant. For example we have Tensor of 3D shape (mkldnn format: ncw) and then Resize is called to change Tensor dim's shape to 2D . Leaving format set to mkldnn::format::ncw may result in a functional problems later on.

Problem was detected when Transformer using MKL-DNN was executed, but using only
one mkldnn op: "elementwise_add". Result was a crash. With this fix crash is not appearing.

