### PR TITLE
Enable In-Place for MKLDNN Op. (solution1)

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1106,10 +1106,10 @@ Scope* OperatorWithKernel::PrepareData(
         for (auto& out_var_name_item : Outputs()) {
           std::vector<Variable*>& output_vars =
               ctx->outputs[out_var_name_item.first];
-          for (size_t i = 0; i < out_var_name_item.second.size(); ++i) {
-            auto& out_var_name = out_var_name_item.second[i];
+          for (size_t id = 0; id < out_var_name_item.second.size(); ++id) {
+            auto& out_var_name = out_var_name_item.second[id];
             if (out_var_name == var_name) {
-              output_vars[i] = trans_var;
+              output_vars[id] = trans_var;
             }
           }
         }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1109,7 +1109,7 @@ Scope* OperatorWithKernel::PrepareData(
           for (size_t i = 0; i < out_var_name_item.second.size(); ++i) {
             auto& out_var_name = out_var_name_item.second[i];
             if (out_var_name == var_name) {
-              output_vars[i] = input_vars[i];
+              output_vars[i] = trans_var;
             }
           }
         }


### PR DESCRIPTION
test=develop

We met in-place issue when enable MKLDNN Reshape OP. 
For the case: no-mkldnn op ---> mkldnn op ( Reshape or other in-place supported Ops).

We investigated this issue and found the "data transform" will generate new tensor and change the input tensor of Reshape Op, while the output not, which will break the in-place between input and output.

We submit this PR solve this problem.
We also filed issue #16916 to track it.