### PR TITLE
Enable In-Place for MKLDNN Op. (solution2)

### DIFF
--- a/paddle/fluid/framework/data_transform.h
+++ b/paddle/fluid/framework/data_transform.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include <functional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -32,7 +33,9 @@ namespace framework {
 
 void TransformData(const OpKernelType &expected_kernel_type,
                    const OpKernelType &kernel_type_for_var,
-                   const Tensor &input_tensor, Tensor *out);
+                   const Tensor &input_tensor, Tensor *out, RuntimeContext *ctx,
+                   const VariableNameMap &outputs_map, Variable *input_var,
+                   const std::string &var_name, const bool is_inplace);
 
 /**
  * Set OutVar from InVar, except the tensor is shared with `tensor`

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1068,8 +1068,11 @@ Scope* OperatorWithKernel::PrepareData(
       }
 
       auto out_var_names = OutputVars(true);
+      bool is_inplace = false;  // Output variable of in-place op should be
+                                // transfered as well.
       if (std::find(out_var_names.begin(), out_var_names.end(), var_name) !=
           out_var_names.end()) {
+        is_inplace = true;
         transfered_inplace_vars->emplace_back(var_name);
       }
 
@@ -1099,8 +1102,11 @@ Scope* OperatorWithKernel::PrepareData(
       auto* trans_var = new_scope->Var(var_name);
       input_vars[i] = trans_var;
 
+      const VariableNameMap& outputs_map = Outputs();
+
       Tensor out;
-      TransformData(expected_kernel_key, kernel_type_for_var, *tensor_in, &out);
+      TransformData(expected_kernel_key, kernel_type_for_var, *tensor_in, &out,
+                    ctx, outputs_map, input_vars[i], var_name, is_inplace);
       SetTensorToVariable(*var, out, trans_var);
     }
   }


### PR DESCRIPTION
test=develop

We met in-place issue when enable MKLDNN Reshape OP.
For the case: no-mkldnn op ---> mkldnn op ( Reshape or other in-place supported Ops).

We investigated this issue and found the "data transform" will generate new tensor and change the input tensor of Reshape Op, while the output not, which will break the in-place between input and output.

We developed two solutions to solve this problem, current PR is the second solution and the first solutions is #16914.
We also file issue #16916 to track it.