### PR TITLE
Fix test_profiler when the machine has many cores.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler.py
@@ -26,6 +26,10 @@ import paddle.fluid.proto.profiler.profiler_pb2 as profiler_pb2
 
 
 class TestProfiler(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        os.environ['CPU_NUM'] = str(4)
+
     def net_profiler(self, state, use_parallel_executor=False):
         profile_path = os.path.join(tempfile.gettempdir(), "profile")
         open(profile_path, "w").write("")


### PR DESCRIPTION
http://ci.paddlepaddle.org/viewLog.html?buildId=82557&tab=buildLog&buildTypeId=Paddle_PrCi&logTab=tail

error:

```
[08:09:23] :	 [Step 1/1] ERROR: test_cpu_profiler (test_profiler.TestProfiler)
[08:09:23] :	 [Step 1/1] ----------------------------------------------------------------------
[08:09:23] :	 [Step 1/1] Traceback (most recent call last):
[08:09:23] :	 [Step 1/1]   File "/paddle/build/python/paddle/fluid/tests/unittests/test_profiler.py", line 110, in test_cpu_profiler
[08:09:23] :	 [Step 1/1]     self.net_profiler('CPU', use_parallel_executor=True)
[08:09:23] :	 [Step 1/1]   File "/paddle/build/python/paddle/fluid/tests/unittests/test_profiler.py", line 82, in net_profiler
[08:09:23] :	 [Step 1/1]     pe.run(feed={'x': x, 'y': y}, fetch_list=[avg_cost.name])
[08:09:23] :	 [Step 1/1]   File "/paddle/build/python/paddle/fluid/parallel_executor.py", line 205, in run
[08:09:23] :	 [Step 1/1]     return_numpy=return_numpy)
[08:09:23] :	 [Step 1/1]   File "/paddle/build/python/paddle/fluid/executor.py", line 544, in run
[08:09:23] :	 [Step 1/1]     return_numpy=return_numpy)
[08:09:23] :	 [Step 1/1]   File "/paddle/build/python/paddle/fluid/executor.py", line 421, in _run_parallel
[08:09:23] :	 [Step 1/1]     exe.feed_and_split_tensor_into_local_scopes(feed_tensor_dict)
[08:09:23] :	 [Step 1/1] EnforceNotMet: Enforce failed. Expected member_->places_.size() == lod_tensors.size(), but received member_->places_.size():56 != lod_tensors.size():32.
[08:09:23] :	 [Step 1/1] The number of samples of current batch is less than the count of devices, currently, it is not allowed. (56 vs 32) at [/paddle/paddle/fluid/framework/
```