### PR TITLE
disable runtime_context_cache pass by default

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -86,8 +86,7 @@ const std::vector<std::string> kAnakinSubgraphPasses({
 
 GpuPassStrategy::GpuPassStrategy() : PassStrategy({}) {
   passes_.assign({
-    "infer_clean_graph_pass",          //
-        "runtime_context_cache_pass",  //
+    "infer_clean_graph_pass",  //
         //   "identity_scale_op_clean_pass",              //
         "conv_affine_channel_fuse_pass",             //
         "conv_eltwiseadd_affine_channel_fuse_pass",  //
@@ -117,11 +116,7 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
   // NOTE the large fusions should be located in the front, so that they will
   // not be damaged by smaller ones.
   passes_.assign({
-      "infer_clean_graph_pass",  //
-      // TODO(luotao): runtime_context_cache_pass should be located in the
-      // front, see https://github.com/PaddlePaddle/Paddle/issues/16609,
-      // will enhance this pass later.
-      "runtime_context_cache_pass",     //
+      "infer_clean_graph_pass",         //
       "attention_lstm_fuse_pass",       //
       "seqconv_eltadd_relu_fuse_pass",  //
       // "seqpool_concat_fuse_pass",    //

--- a/paddle/fluid/inference/tests/api/analyzer_pyramid_dnn_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_pyramid_dnn_tester.cc
@@ -110,6 +110,11 @@ void SetConfig(AnalysisConfig *cfg) {
   if (FLAGS_zero_copy) {
     cfg->SwitchUseFeedFetchOps(false);
   }
+  // Enable runtime_context_cache_pass, disabled by default since it doesn't
+  // cover all the cases.
+  // See detail: https://github.com/PaddlePaddle/Paddle/issues/16609
+  // https://github.com/PaddlePaddle/Paddle/issues/16841
+  cfg->pass_builder()->AppendPass("runtime_context_cache_pass");
 }
 
 void SetInput(std::vector<std::vector<PaddleTensor>> *inputs) {


### PR DESCRIPTION
Hotfix #16841 

For gpu inference, if a gpu model has an op which could only run on CPU, each result of different input will be the same with the first one.
analysis predictor gpu模式下，打开pass优化的时候，如果一个模型中有op只有cpu kernel， 会出现，所有的运行的结果和第一次运行的一样。

The reason is that if a gpu tensor is the input of a cpu kernel, we will create a new cpu tensor in new scope. if enable cache runtime context, we get the cpu tensor each time, not the gpu tensor.
一个gpu 的tensor 做为cpu kernel 输入的话，会在一个新的scope中创建一个新的cpu tensor， 如果进行cache runtime context, 下次直接拿到的是cpu tensor， 而不是gpu tensor
https://github.com/PaddlePaddle/Paddle/blob/4098ba29ed180e5035fc90573b8eeef8224f373e/paddle/fluid/framework/operator.cc#L1099-L1100