### PR TITLE
Reduce py_reader unittest time

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_decoupled_py_reader.py
+++ b/python/paddle/fluid/tests/unittests/test_decoupled_py_reader.py
@@ -21,12 +21,13 @@ import unittest
 
 EPOCH_NUM = 20
 BATCH_SIZE = 32
+BATCH_NUM = 20
 CLASS_NUM = 10
 
 
 def random_reader():
     np.random.seed(1)
-    for i in range(BATCH_SIZE * 40):
+    for i in range(BATCH_SIZE * BATCH_NUM):
         image = np.random.random([784])
         label = np.random.random_integers(low=0, high=CLASS_NUM - 1)
         yield image, label


### PR DESCRIPTION
This reduce time from 45.675s -> 25.396s in my P40 machine.