### PR TITLE
enhance generate proposal labels, test=develop

### DIFF
--- a/paddle/fluid/operators/detection/generate_proposal_labels_op.cc
+++ b/paddle/fluid/operators/detection/generate_proposal_labels_op.cc
@@ -394,6 +394,10 @@ class GenerateProposalLabelsKernel : public framework::OpKernel<T> {
     auto is_crowd_lod = is_crowd->lod().back();
     auto gt_boxes_lod = gt_boxes->lod().back();
     for (int i = 0; i < n; ++i) {
+      if (rpn_rois_lod[i] == rpn_rois_lod[i + 1]) {
+        lod0.emplace_back(num_rois);
+        continue;
+      }
       Tensor rpn_rois_slice =
           rpn_rois->Slice(rpn_rois_lod[i], rpn_rois_lod[i + 1]);
       Tensor gt_classes_slice =


### PR DESCRIPTION
When training FPN in batch size=2, the number of proposals in one batch may be zero. It will cause error in generate proposal labels because tensor.Slice only allow end > start. 