### PR TITLE
Enhance concat op to support empty input.

### DIFF
--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -37,7 +37,7 @@ class ConcatKernel : public framework::OpKernel<T> {
     if (axis == 0 && ins.size() < 10) {
       size_t output_offset = 0;
       for (auto* in : ins) {
-        if (in->numel() == 0UL) {
+        if (!in || in->numel() == 0UL) {
           continue;
         }
         auto in_stride = framework::stride_numel(in->dims());
@@ -50,10 +50,10 @@ class ConcatKernel : public framework::OpKernel<T> {
     } else {
       std::vector<framework::Tensor> inputs;
       for (size_t j = 0; j < ins.size(); ++j) {
-        if (ins[j]->numel() == 0UL) {
-          continue;
-        } else {
+        if (ins[j] || ins[j]->numel() > 0) {
           inputs.push_back(*ins[j]);
+        } else {
+          continue;
         }
       }
       auto& dev_ctx = ctx.template device_context<DeviceContext>();

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -37,6 +37,9 @@ class ConcatKernel : public framework::OpKernel<T> {
     if (axis == 0 && ins.size() < 10) {
       size_t output_offset = 0;
       for (auto* in : ins) {
+        if (in->numel() == 0UL) {
+          continue;
+        }
         auto in_stride = framework::stride_numel(in->dims());
         auto out_stride = framework::stride_numel(out->dims());
         StridedNumelCopyWithAxis<T>(ctx.device_context(), axis,
@@ -45,9 +48,13 @@ class ConcatKernel : public framework::OpKernel<T> {
         output_offset += in_stride[axis];
       }
     } else {
-      std::vector<framework::Tensor> inputs(ins.size());
+      std::vector<framework::Tensor> inputs;
       for (size_t j = 0; j < ins.size(); ++j) {
-        inputs[j] = *ins[j];
+        if (ins[j]->numel() == 0UL) {
+          continue;
+        } else {
+          inputs.push_back(*ins[j]);
+        }
       }
       auto& dev_ctx = ctx.template device_context<DeviceContext>();
       paddle::operators::math::ConcatFunctor<DeviceContext, T> concat_functor;
@@ -82,7 +89,8 @@ class ConcatGradKernel : public framework::OpKernel<T> {
     // get output tensor that the name is not kEmptyVarName
     std::vector<framework::Tensor*> outputs;
     for (size_t j = 0; j < outs.size(); ++j) {
-      if (out_var_names[j] != framework::kEmptyVarName) {
+      if (out_var_names[j] != framework::kEmptyVarName &&
+          outs[j]->numel() != 0UL) {
         outs[j]->mutable_data<T>(ctx.GetPlace());
         outputs.push_back(outs[j]);
       } else {

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -50,7 +50,7 @@ class ConcatKernel : public framework::OpKernel<T> {
     } else {
       std::vector<framework::Tensor> inputs;
       for (size_t j = 0; j < ins.size(); ++j) {
-        if (ins[j] || ins[j]->numel() > 0) {
+        if (ins[j] && ins[j]->numel() > 0) {
           inputs.push_back(*ins[j]);
         } else {
           continue;

--- a/python/paddle/fluid/tests/unittests/test_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_concat_op.py
@@ -64,5 +64,16 @@ class TestConcatOp3(TestConcatOp):
         pass
 
 
+class TestConcatOp4(TestConcatOp):
+    def init_test_data(self):
+        self.x0 = np.random.random((2, 3, 4, 5)).astype('float32')
+        self.x1 = np.random.random((2, 3, 4, 5)).astype('float32')
+        self.x2 = np.random.random((0, 3, 4, 5)).astype('float32')
+        self.axis = 0
+
+    def test_check_grad(self):
+        pass
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Enhance concat op to allow empty variable in inputs.
For example, In Faster-RCNN-FPN model, RoIs are distributed onto different levels and get roi features by roi_align. In such case, the number of rois in one level might be 0, then causes empty input and output in roi_align. As result, we should support empty variable when use concat op to concatenate roi features.