### PR TITLE
reduce unittest time by rename testcuda to has_cuda

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_conv2d_fusion_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_fusion_op.py
@@ -90,11 +90,11 @@ class TestConv2dFusionOp(OpTest):
 
         self.set_outputs()
 
-    def testcuda(self):
+    def has_cuda(self):
         return core.is_compiled_with_cuda()
 
     def test_check_output(self):
-        if self.testcuda():
+        if self.has_cuda():
             place = core.CUDAPlace(0)
             self.check_output_with_place(place, atol=1e-5)
         else:

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -108,24 +108,24 @@ class TestConv3dOp(OpTest):
         }
         self.outputs = {'Output': output}
 
-    def testcudnn(self):
+    def has_cudnn(self):
         return core.is_compiled_with_cuda() and self.use_cudnn
 
     def test_check_output(self):
-        place = core.CUDAPlace(0) if self.testcudnn() else core.CPUPlace()
+        place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_output_with_place(place, atol=1e-5)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        place = core.CUDAPlace(0) if self.testcudnn() else core.CPUPlace()
+        place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
             place, {'Input', 'Filter'}, 'Output', max_relative_error=0.03)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
             return
-        place = core.CUDAPlace(0) if self.testcudnn() else core.CPUPlace()
+        place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
@@ -135,7 +135,7 @@ class TestConv3dOp(OpTest):
     def test_check_grad_no_input(self):
         if self.dtype == np.float16:
             return
-        place = core.CUDAPlace(0) if self.testcudnn() else core.CPUPlace()
+        place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
             place, ['Input'],
             'Output',

--- a/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
@@ -171,7 +171,7 @@ class TestCUDNNLstmOp(OpTest):
         }
 
     def test_output_with_place(self):
-        if self.testcuda():
+        if self.has_cuda():
             place = core.CUDAPlace(0)
             self.check_output_with_place(place, atol=1e-5)
 
@@ -184,7 +184,7 @@ class TestCUDNNLstmOp(OpTest):
                 ['Out', 'last_h', 'last_c'],
                 max_relative_error=0.02)
 
-    def testcuda(self):
+    def has_cuda(self):
         return core.is_compiled_with_cuda()
 
 

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -148,11 +148,11 @@ class TestPool2D_Op(OpTest):
 
         self.outputs = {'Out': output}
 
-    def testcudnn(self):
+    def has_cudnn(self):
         return core.is_compiled_with_cuda() and self.use_cudnn
 
     def test_check_output(self):
-        if self.testcudnn():
+        if self.has_cudnn():
             place = core.CUDAPlace(0)
             self.check_output_with_place(place, atol=1e-5)
         else:
@@ -161,7 +161,7 @@ class TestPool2D_Op(OpTest):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        if self.testcudnn() and self.pool_type != "max":
+        if self.has_cudnn() and self.pool_type != "max":
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
                 place, set(['X']), 'Out', max_relative_error=0.07)

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -172,11 +172,11 @@ class TestPool3d_Op(OpTest):
 
         self.outputs = {'Out': output}
 
-    def testcudnn(self):
+    def has_cudnn(self):
         return core.is_compiled_with_cuda() and self.use_cudnn
 
     def test_check_output(self):
-        if self.testcudnn():
+        if self.has_cudnn():
             place = core.CUDAPlace(0)
             self.check_output_with_place(place, atol=1e-5)
         else:
@@ -185,7 +185,7 @@ class TestPool3d_Op(OpTest):
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
-        if self.testcudnn() and self.pool_type != "max":
+        if self.has_cudnn() and self.pool_type != "max":
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
                 place, set(['X']), 'Out', max_relative_error=0.07)


### PR DESCRIPTION
Inspired by #16994, rename `testcuda` to `has_cuda` and `testcudnn` to `has_cudnn` to reduce CI time.
fix #16987 