### PR TITLE
Fix the bug of test_conv2d_int8_mkldnn case which raised by improper parameter passing

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
@@ -104,6 +104,7 @@ class TestConv2dInt8Op(TestConv2dOp):
                 conv2d_param).astype(np.float32)
             output1_tmp = np.round(output1 * (
                 self.scale_out / (self.scale_in * self.scale_weights[0])))
+
             if self.fuse_residual:
                 input_residual = np.random.randint(
                     0, 10, self.input_residual_size).astype(self.srctype)


### PR DESCRIPTION
resolve #17057

~~Fixed the bug that fuse_relu/fuse_residual option couldn't be passed to class TestConv2dInt8Op.~~
Fix the bug of test_conv2d_int8_mkldnn case which raised by improper parameter passing.

test=develop