### PR TITLE
fix runtimeerror in uniform_random

### DIFF
--- a/python/paddle/fluid/layers/ops.py
+++ b/python/paddle/fluid/layers/ops.py
@@ -86,12 +86,11 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0):
             result = fluid.layers.uniform_random(shape=[32, 784])
     """
 
-    locals_var = locals().keys()
+    locals_var = locals()
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
     kwargs = dict()
-    for name in locals_var:
-        val = locals()[name]
+    for name, val in locals_var.items():
         if val is not None:
             kwargs[name] = val
     return _uniform_random_(**kwargs)


### PR DESCRIPTION
fix runtimeerror : dictionary changed size during iteration when calling uniform_random in python3+