### PR TITLE
Fix tensor_py.h

### DIFF
--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -431,14 +431,14 @@ inline void PyCUDAPinnedTensorSetFromArray(
 namespace details {
 
 template <typename T>
-constexpr bool IsValidDTypeToPyArray() {
-  return false;
-}
+struct IsValidDTypeToPyArray {
+  static constexpr bool kValue = false;
+};
 
-#define DECLARE_VALID_DTYPE_TO_PY_ARRAY(type)    \
-  template <>                                    \
-  constexpr bool IsValidDTypeToPyArray<type>() { \
-    return true;                                 \
+#define DECLARE_VALID_DTYPE_TO_PY_ARRAY(type) \
+  template <>                                 \
+  struct IsValidDTypeToPyArray<type> {        \
+    static constexpr bool kValue = true;      \
   }
 
 DECLARE_VALID_DTYPE_TO_PY_ARRAY(platform::float16);
@@ -457,7 +457,8 @@ inline std::string TensorDTypeToPyDTypeStr(
     if (std::is_same<T, platform::float16>::value) {                    \
       return "e";                                                       \
     } else {                                                            \
-      PADDLE_ENFORCE(IsValidDTypeToPyArray<T>,                          \
+      constexpr auto kIsValidDType = IsValidDTypeToPyArray<T>::kValue;  \
+      PADDLE_ENFORCE(kIsValidDType,                                     \
                      "This type of tensor cannot be expose to Python"); \
       return py::format_descriptor<T>::format();                        \
     }                                                                   \

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -431,13 +431,13 @@ inline void PyCUDAPinnedTensorSetFromArray(
 namespace details {
 
 template <typename T>
-struct IsValidDTypeToPyArray {
+struct ValidDTypeToPyArrayChecker {
   static constexpr bool kValue = false;
 };
 
 #define DECLARE_VALID_DTYPE_TO_PY_ARRAY(type) \
   template <>                                 \
-  struct IsValidDTypeToPyArray<type> {        \
+  struct ValidDTypeToPyArrayChecker<type> {   \
     static constexpr bool kValue = true;      \
   }
 
@@ -452,16 +452,16 @@ DECLARE_VALID_DTYPE_TO_PY_ARRAY(int64_t);
 
 inline std::string TensorDTypeToPyDTypeStr(
     framework::proto::VarType::Type type) {
-#define TENSOR_DTYPE_TO_PY_DTYPE(T, proto_type)                         \
-  if (type == proto_type) {                                             \
-    if (std::is_same<T, platform::float16>::value) {                    \
-      return "e";                                                       \
-    } else {                                                            \
-      constexpr auto kIsValidDType = IsValidDTypeToPyArray<T>::kValue;  \
-      PADDLE_ENFORCE(kIsValidDType,                                     \
-                     "This type of tensor cannot be expose to Python"); \
-      return py::format_descriptor<T>::format();                        \
-    }                                                                   \
+#define TENSOR_DTYPE_TO_PY_DTYPE(T, proto_type)                             \
+  if (type == proto_type) {                                                 \
+    if (std::is_same<T, platform::float16>::value) {                        \
+      return "e";                                                           \
+    } else {                                                                \
+      constexpr auto kIsValidDType = ValidDTypeToPyArrayChecker<T>::kValue; \
+      PADDLE_ENFORCE(kIsValidDType,                                         \
+                     "This type of tensor cannot be expose to Python");     \
+      return py::format_descriptor<T>::format();                            \
+    }                                                                       \
   }
 
   _ForEachDataType_(TENSOR_DTYPE_TO_PY_DTYPE);


### PR DESCRIPTION
Previously, `PADDLE_ENFORCE(IsValidDTypeToPyArray<T>, ...)` is wrong because it is checking whether the function pointer is nullptr, but not checking whether the returned value of the function is true. This PR fixes it.