### PR TITLE
Fix the KL algorithm bug when calculated the size of tensor.

### DIFF
--- a/python/paddle/fluid/contrib/int8_inference/utility.py
+++ b/python/paddle/fluid/contrib/int8_inference/utility.py
@@ -634,6 +634,7 @@ class Calibrator(object):
                         break
                 starting_iter = int(0.6 * ending_iter)
         bin_width = hist_edeges[1] - hist_edeges[0]
+
         P_sum = len(np.array(activation_blob).ravel())
         min_kl_divergence = 0
         min_kl_index = 0

--- a/python/paddle/fluid/contrib/int8_inference/utility.py
+++ b/python/paddle/fluid/contrib/int8_inference/utility.py
@@ -634,7 +634,7 @@ class Calibrator(object):
                         break
                 starting_iter = int(0.6 * ending_iter)
         bin_width = hist_edeges[1] - hist_edeges[0]
-        P_sum = len(activation_blob)
+        P_sum = len(np.array(activation_blob).ravel())
         min_kl_divergence = 0
         min_kl_index = 0
         kl_inited = False


### PR DESCRIPTION
resolve #17184

Fix the KL algorithm bug when calculated the size of tensor.

With this fixing， below table shows the latest KL effort on mobilenetv1(measured via python api)

|  KL status  | top-1 | top-5 |
| :--- | :----: | ----: |
|Disabled| 70.22% | 89.46% |
| Enabled   | 70.48%      | 89.54%    |
