### PR TITLE
fix the initialization process error.

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -383,7 +383,7 @@ class QuantizationTransformPass(object):
             data_type = 'float64' if var_node.dtype(
             ) == core.VarDesc.VarType.FP64 else 'float32'
             _init_var_node(
-                scale_in_node,
+                state_in_node,
                 np.ones(
                     [1], dtype=data_type),
                 self._scope,


### PR DESCRIPTION
In the function `_insert_quant_moving_average_abs_max_op`, L386 should initialize the var `state_in_node` not the `scale_in_node`.