### PR TITLE
delete mul_lstm_fuse_pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -123,7 +123,7 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
                   "seqconv_eltadd_relu_fuse_pass",  //
                   // "seqpool_concat_fuse_pass",    //
                   // "embedding_fc_lstm_fuse_pass", //
-                  "fc_lstm_fuse_pass",             //
+                  "fc_lstm_fuse_pass",  //
                   // "mul_lstm_fuse_pass",            //
                   "fc_gru_fuse_pass",              //
                   "mul_gru_fuse_pass",             //

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -124,7 +124,7 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
                   // "seqpool_concat_fuse_pass",    //
                   // "embedding_fc_lstm_fuse_pass", //
                   "fc_lstm_fuse_pass",             //
-                  "mul_lstm_fuse_pass",            //
+                  // "mul_lstm_fuse_pass",            //
                   "fc_gru_fuse_pass",              //
                   "mul_gru_fuse_pass",             //
                   "seq_concat_fc_fuse_pass",       //


### PR DESCRIPTION
Sometimes `mul_lstm_fuse_pass` result in the precision difference between CPU and GPU computation.

Disable it temporarily.  

TODO @fc500110 @lijianshe02 repair it.