### PR TITLE
Fix two graphics memory problem When doing inference.

### DIFF
--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -3,11 +3,13 @@ cc_library(ir_analysis_pass SRCS ir_analysis_pass.cc DEPS analysis_pass argument
 cc_library(memory_optim_pass SRCS memory_optimize_pass.cc DEPS analysis_pass zero_copy_tensor)
 cc_library(ir_params_sync_among_devices_pass SRCS ir_params_sync_among_devices_pass.cc DEPS analysis_pass argument ir_pass_manager)
 cc_library(ir_graph_to_program_pass SRCS ir_graph_to_program_pass.cc DEPS analysis_pass graph_to_program_pass)
+cc_library(adjust_cudnn_workspace_size_pass SRCS adjust_cudnn_workspace_size_pass.cc DEPS analysis_pass graph_to_program_pass)
 
 cc_library(analysis_passes SRCS passes.cc DEPS
   ir_graph_build_pass
   ir_analysis_pass
   ir_params_sync_among_devices_pass
+  adjust_cudnn_workspace_size_pass
   memory_optim_pass
   ir_graph_to_program_pass
 )

--- a/paddle/fluid/inference/analysis/passes/adjust_cudnn_workspace_size_pass.h
+++ b/paddle/fluid/inference/analysis/passes/adjust_cudnn_workspace_size_pass.h
@@ -14,29 +14,26 @@
 
 #pragma once
 
-#include <memory>
 #include <string>
-#include <unordered_map>
+#include <vector>
+
+#include "paddle/fluid/framework/ir/fuse_pass_base.h"
+#include "paddle/fluid/framework/scope.h"
 #include "paddle/fluid/inference/analysis/analysis_pass.h"
+#include "paddle/fluid/platform/place.h"
 
 namespace paddle {
 namespace inference {
 namespace analysis {
 
-struct PassRegistry {
-  PassRegistry();
-
-  AnalysisPass* Retreive(const std::string& pass_type) {
-    return passes_[pass_type].get();
-  }
-
-  static PassRegistry& Global() {
-    static auto* x = new PassRegistry;
-    return *x;
-  }
-
- private:
-  std::unordered_map<std::string, std::unique_ptr<AnalysisPass>> passes_;
+/*
+ * The default cudnn workspace is 4G, we set it to 64M in this pass, which
+ * is applicable for most inference tasks.
+ */
+class AdjustCudnnWorkSpacePass : public AnalysisPass {
+ public:
+  void RunImpl(Argument *argument) override;
+  std::string repr() const override;
 };
 
 }  // namespace analysis

--- a/paddle/fluid/inference/analysis/passes/passes.cc
+++ b/paddle/fluid/inference/analysis/passes/passes.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/inference/analysis/passes/passes.h"
+#include "paddle/fluid/inference/analysis/passes/adjust_cudnn_workspace_size_pass.h"
 #include "paddle/fluid/inference/analysis/passes/ir_analysis_pass.h"
 #include "paddle/fluid/inference/analysis/passes/ir_graph_build_pass.h"
 #include "paddle/fluid/inference/analysis/passes/ir_graph_to_program_pass.h"
@@ -35,6 +36,8 @@ PassRegistry::PassRegistry() {
   passes_.emplace(
       "ir_params_sync_among_devices_pass",
       std::unique_ptr<AnalysisPass>(new IrParamsSyncAmongDevicesPass));
+  passes_.emplace("adjust_cudnn_workspace_size_pass",
+                  std::unique_ptr<AnalysisPass>(new AdjustCudnnWorkSpacePass));
   passes_.emplace(
       "ir_graph_to_program_pass",
       std::unique_ptr<IrGraphToProgramPass>(new IrGraphToProgramPass));

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -120,7 +120,11 @@ bool AnalysisPredictor::PrepareScope(
     scope_ = parent_scope;
     status_is_cloned_ = true;
   } else {
-    paddle::framework::InitDevices(false);
+    if (config_.use_gpu_) {
+      paddle::framework::InitDevices(false, {config_.device_id_});
+    } else {
+      paddle::framework::InitDevices(false, {});
+    }
     scope_.reset(new paddle::framework::Scope());
     status_is_cloned_ = false;
   }
@@ -459,6 +463,8 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
       std::string flag = "--fraction_of_gpu_memory_to_use=" +
                          std::to_string(fraction_of_gpu_memory);
       flags.push_back(flag);
+      flags.push_back("--selected_gpus=" +
+                      std::to_string(config.gpu_device_id()));
       VLOG(3) << "set flag: " << flag;
       framework::InitGflags(flags);
     }

--- a/paddle/fluid/inference/api/paddle_pass_builder.h
+++ b/paddle/fluid/inference/api/paddle_pass_builder.h
@@ -73,7 +73,8 @@ class PaddlePassBuilder {
  protected:
   std::vector<std::string> analysis_passes_{
       {"ir_graph_build_pass", "ir_analysis_pass",
-       "ir_params_sync_among_devices_pass"}};
+       "ir_params_sync_among_devices_pass",
+       "adjust_cudnn_workspace_size_pass"}};
   std::vector<std::string> passes_;
 };
 


### PR DESCRIPTION
1. infernce multi card occupy
We specific gpu id using `config->EnableUseGpu(0 /*gpu_id*/, 10);`, but multiple cards will be occupied when during inference.

2. the facebox model  occupy too much graphic memory when during inference.

The reason is that the default value of conv attr "workspace_size_MB" is 4G, we modify this attr's value to 64M, which is applicable for most inference tasks..
