### PR TITLE
Use sync copy in fetch_op_handle

### DIFF
--- a/paddle/fluid/framework/details/fetch_op_handle.cc
+++ b/paddle/fluid/framework/details/fetch_op_handle.cc
@@ -63,8 +63,7 @@ void FetchOpHandle::RunImpl() {
     auto &t = var->Get<framework::LoDTensor>();
     if (platform::is_gpu_place(t.place())) {
 #ifdef PADDLE_WITH_CUDA
-      TensorCopy(t, cpu, *dev_ctxes_.at(t.place()), &tensors_[i]);
-      dev_ctxes_.at(t.place())->Wait();
+      TensorCopy(t, cpu, &tensors_[i]);
 #endif
     } else {
       tensors_[i].ShareDataWith(t);


### PR DESCRIPTION
It seems that, in the origin implementation, the copy action is not synced.