### PR TITLE
Enable cast operator for a NG bridge

### DIFF
--- a/python/paddle/fluid/tests/unittests/ngraph/test_cast_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_cast_ngraph_op.py
@@ -1,0 +1,21 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+from paddle.fluid.tests.unittests.test_cast_op import TestCastOp1
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enable the cast operator for the nGraph bridge. BERT model uses it. 