### PR TITLE
make parallel_executor support FLAGS_use_mkldnn

### DIFF
--- a/paddle/fluid/framework/details/build_strategy.cc
+++ b/paddle/fluid/framework/details/build_strategy.cc
@@ -62,9 +62,18 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
     if (FLAGS_use_mkldnn) {
       VLOG(5) << "Add mkldnn_placement_pass";
       AppendPass("mkldnn_placement_pass");
+    } else if (!strategy_.mkldnn_enabled_op_types_.empty()) {
+      LOG(WARNING)
+          << "mkldnn_enabled_op_types specify the operator type list to "
+             "use MKLDNN acceleration. It is null in default, means "
+             "that all the operators supported by MKLDNN will be "
+             "accelerated. And it should not be set when "
+             "FLAGS_use_mkldnn=false.";
     }
+#else
+    PADDLE_ENFORCE(!FLAGS_use_mkldnn,
+                   "Please compile with MKLDNN first to use MKLDNN");
 #endif
-
     if (strategy_.enable_sequential_execution_) {
       VLOG(5) << "Add sequential_execution_pass";
       AppendPass("sequential_execution_pass");

--- a/paddle/fluid/framework/details/build_strategy.cc
+++ b/paddle/fluid/framework/details/build_strategy.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <glog/logging.h>
 #include <memory>
+#include <unordered_set>
 #include <utility>
 #include "paddle/fluid/framework/details/reduce_op_handle.h"
 #include "paddle/fluid/framework/ir/graph.h"
@@ -25,6 +26,8 @@ limitations under the License. */
 #include "paddle/fluid/framework/ir/memory_optimize_pass/memory_optimize_helper.h"
 #include "paddle/fluid/framework/ir/multi_devices_graph_pass/multi_devices_graph_pass.h"
 #include "paddle/fluid/framework/ir/multi_devices_graph_pass/multi_devices_graph_print_pass.h"
+
+DECLARE_bool(use_mkldnn);
 
 namespace paddle {
 namespace framework {
@@ -54,6 +57,13 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
 
     // Note(zcd): record_skip_memory_opt_vars_pass should be the first pass.
     AppendPass("record_skip_memory_opt_vars_pass");
+
+#ifdef PADDLE_WITH_MKLDNN
+    if (FLAGS_use_mkldnn) {
+      VLOG(5) << "Add mkldnn_placement_pass";
+      AppendPass("mkldnn_placement_pass");
+    }
+#endif
 
     if (strategy_.enable_sequential_execution_) {
       VLOG(5) << "Add sequential_execution_pass";
@@ -313,6 +323,9 @@ ir::Graph *BuildStrategy::Apply(ir::Graph *graph,
     } else if (pass->Type() == "inplace_pass") {
       pass->Erase(ir::kUseCuda);
       pass->Set<bool>(ir::kUseCuda, new bool(use_cuda));
+    } else if (pass->Type() == "mkldnn_placement_pass") {
+      pass->Set("mkldnn_enabled_op_types",
+                new std::unordered_set<std::string>(mkldnn_enabled_op_types_));
     }
     VLOG(3) << "Start Apply Pass " << pass->Type();
     graph = pass->Apply(graph);
@@ -351,3 +364,6 @@ USE_PASS(fuse_all_reduce_op_pass);
 USE_PASS(runtime_context_cache_pass);
 USE_PASS(expected_kernel_cache_pass);
 USE_PASS(record_skip_memory_opt_vars_pass);
+#ifdef PADDLE_WITH_MKLDNN
+USE_PASS(mkldnn_placement_pass);
+#endif

--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -16,6 +16,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 #include "paddle/fluid/framework/ir/pass_builder.h"
@@ -109,6 +110,7 @@ struct BuildStrategy {
 
   bool cache_runtime_context_{false};
   bool cache_expected_kernel_{true};
+  std::unordered_set<std::string> mkldnn_enabled_op_types_;
 
   // NOTE:
   // Before you add new options, think if it's a general strategy that works

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1483,6 +1483,15 @@ All parameter, weight, gradient are variables in Paddle.
           "cache_expected_kernel",
           [](const BuildStrategy &self) { return self.cache_expected_kernel_; },
           [](BuildStrategy &self, bool b) { self.cache_expected_kernel_ = b; })
+      .def_property(
+          "mkldnn_enabled_op_types",
+          [](const BuildStrategy &self) {
+            return self.mkldnn_enabled_op_types_;
+          },
+          [](BuildStrategy &self,
+             const std::unordered_set<std::string> &mkldnn_enabled_op_types) {
+            self.mkldnn_enabled_op_types_ = mkldnn_enabled_op_types;
+          })
       .def("_finalize_strategy_and_create_passes",
            [](BuildStrategy &self) -> std::shared_ptr<ir::PassBuilder> {
              return self.CreatePassesFromStrategy(true);


### PR DESCRIPTION
make parallel_executor support `FLAGS_use_mkldnn` by appending `mkldnn_placement_pass`.
Usage: `FLAGS_use_mkldnn=true python xxx.py`.
Besides, you can set `mkldnn_enabled_op_types` in `build_strategy`:
```
build_strategy.mkldnn_enabled_op_types = set(['softmax', 'softmax_grad', 'transpose2', 'transposes2_grad'])
```