### PR TITLE
add trt fp16 support

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -196,7 +196,8 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
   SetAttr(op_desc->Proto(), "output_name_mapping", output_mapping);
   SetAttr(op_desc->Proto(), "parameters", params);
 
-  auto enable_int8 = Get<bool>("enable_int8");
+  std::string precision_mode = Get<std::string>("precision");
+  auto enable_int8 = precision_mode == "INT8";
   auto use_static_engine = Get<bool>("use_static_engine");
   auto engine_key = GenerateEngineKey(input_names_with_id, output_names_with_id,
                                       std::to_string(0));
@@ -211,6 +212,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
   SetAttr(op_desc->Proto(), "calibration_data", calibration_data);
 
   SetAttr(op_desc->Proto(), "enable_int8", enable_int8);
+  SetAttr(op_desc->Proto(), "precision", precision_mode);
   SetAttr(op_desc->Proto(), "engine_key", engine_key);
   std::string trt_engine_serialized_data = "";
   SetAttr(op_desc->Proto(), "engine_serialized_data",
@@ -253,8 +255,8 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
                "kernel etc). This process may cost a lot of time.";
   std::unique_ptr<tensorrt::TensorRTEngine> trt_engine(
       new tensorrt::TensorRTEngine(
-          Get<int>("max_batch_size"), Get<int>("workspace_size"), enable_int8,
-          calibrator.get(), Get<int>("gpu_device_id")));
+          Get<int>("max_batch_size"), Get<int>("workspace_size"),
+          precision_mode, calibrator.get(), Get<int>("gpu_device_id")));
   auto *scope = param_scope();
   framework::BlockDesc block_desc_temp(nullptr, block_desc.Proto());
   std::unordered_set<std::string> param_set(params.begin(), params.end());

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -46,6 +46,7 @@ struct AnalysisConfig {
   enum class Precision {
     kFloat32 = 0,
     kInt8,
+    kHalf,
   };
 
   /** Set model with a directory.

--- a/paddle/fluid/inference/tensorrt/convert/test_op_converter.cc
+++ b/paddle/fluid/inference/tensorrt/convert/test_op_converter.cc
@@ -12,10 +12,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#include "paddle/fluid/inference/tensorrt/convert/op_converter.h"
-
 #include <gtest/gtest.h>
 #include "paddle/fluid/framework/program_desc.h"
+#include "paddle/fluid/inference/tensorrt/convert/op_converter.h"
 
 namespace paddle {
 namespace inference {
@@ -27,10 +26,8 @@ TEST(OpConverter, ConvertBlock) {
   auto* conv2d_op = block->AppendOp();
 
   // init trt engine
-  cudaStream_t stream_;
   std::unique_ptr<TensorRTEngine> engine_;
-  PADDLE_ENFORCE_EQ(cudaStreamCreate(&stream_), 0);
-  engine_.reset(new TensorRTEngine(5, 1 << 15, stream_));
+  engine_.reset(new TensorRTEngine(5, 1 << 15));
   engine_->InitNetwork();
 
   engine_->DeclareInput("conv2d-X", nvinfer1::DataType::kFLOAT,

--- a/paddle/fluid/inference/tensorrt/convert/ut_helper.h
+++ b/paddle/fluid/inference/tensorrt/convert/ut_helper.h
@@ -82,7 +82,7 @@ class TRTConvertValidation {
         max_batch_size_(max_batch_size) {
     PADDLE_ENFORCE_EQ(cudaStreamCreate(&stream_), 0);
     engine_.reset(
-        new TensorRTEngine(max_batch_size, workspace_size, false, nullptr, 0));
+        new TensorRTEngine(max_batch_size, workspace_size, "FP32", nullptr, 0));
     engine_->InitNetwork();
   }
 

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -59,12 +59,13 @@ class TensorRTEngine {
     nvinfer1::Weights w_;
   };
 
-  TensorRTEngine(int max_batch, int max_workspace, bool enable_int8 = false,
+  TensorRTEngine(int max_batch, int max_workspace,
+                 std::string precision = "FP32",
                  TRTInt8Calibrator* calibrator = nullptr, int device_id = 0,
                  nvinfer1::ILogger& logger = NaiveLogger::Global())
       : max_batch_(max_batch),
         max_workspace_(max_workspace),
-        enable_int8_(enable_int8),
+        precision_(precision),
         calibrator_(calibrator),
         device_id_(device_id),
         logger_(logger) {}
@@ -153,7 +154,7 @@ class TensorRTEngine {
   // the max memory size the engine uses
   int max_workspace_;
 
-  bool enable_int8_;
+  std::string precision_;
   TRTInt8Calibrator* calibrator_;
   // batch size of the current data, will be updated each Executation.
   int batch_size_{-1};

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -31,7 +31,8 @@ struct SimpleOpTypeSetTeller : public Teller {
   std::unordered_set<std::string> teller_set{
       {"mul", "conv2d", "pool2d", "relu", "softmax", "sigmoid",
        "depthwise_conv2d", "batch_norm", "concat", "tanh", "pad",
-       "elementwise_add", "elementwise_mul", "dropout", "split", "prelu",
+       // "elementwise_add", "elementwise_mul", "dropout", "split", "prelu",
+       "elementwise_add", "elementwise_mul", "dropout", "prelu",
        "conv2d_transpose", "leaky_relu"}};
 };
 

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.cc
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.cc
@@ -39,7 +39,8 @@ class TensorRTEngineOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<int>("max_batch_size", "the maximum batch size.");
     AddAttr<int>("workspace_size", "the workspace size.");
     AddAttr<framework::BlockDesc *>("sub_block", "the trt block");
-    AddAttr<bool>("enable_int8", "whether swith to int8 mode");
+    AddAttr<std::string>("precision",
+                         "the trt engine runtime precision, FP32, INT8, FP16");
     AddComment("TensorRT engine operator.");
   }
 };

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op_test.cc
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op_test.cc
@@ -103,7 +103,7 @@ TEST(TensorRTEngineOp, manual) {
   engine_op_desc.SetAttr("parameters", std::vector<std::string>({}));
   engine_op_desc.SetAttr("engine_key", std::string("a_engine"));
   engine_op_desc.SetAttr("calibration_data", std::string(""));
-  engine_op_desc.SetAttr("enable_int8", static_cast<bool>(false));
+  engine_op_desc.SetAttr("precision", std::string("FP32"));
   engine_op_desc.SetAttr("output_name_mapping",
                          std::vector<std::string>({"z0"}));
   engine_op_desc.SetAttr("subgraph", std::string(block_->SerializeAsString()));
@@ -201,7 +201,7 @@ void Execute(int batch_size, int input_dim, int output_dim, int nlayers = 1) {
                          std::vector<std::string>({"y0", "y1", "y2", "y3"}));
   engine_op_desc.SetAttr("engine_key", std::string("b_engine"));
   engine_op_desc.SetAttr("calibration_data", std::string(""));
-  engine_op_desc.SetAttr("enable_int8", static_cast<bool>(false));
+  engine_op_desc.SetAttr("precision", std::string("FP32"));
   engine_op_desc.SetAttr("output_name_mapping",
                          std::vector<std::string>({"z3"}));
   engine_op_desc.SetAttr("subgraph", std::string(block_->SerializeAsString()));


### PR DESCRIPTION
Using trt fp16:

```
config->EnableTensorRtEngine(1 << 20, batch_size, 3, AnalysisConfig::Precision::kHalf);
```
When the hardward support fp16(V100 etc), the trt engine will execute on fp16 mode.