### PR TITLE
Optimize the computing kernel of sequence_reverse operator

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <memory>
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/math/algorithm.h"
 #include "paddle/fluid/platform/for_range.h"

--- a/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
@@ -109,7 +109,6 @@ class SequenceReverseOpKernel : public framework::OpKernel<T> {
     PADDLE_ENFORCE_EQ(x.lod().size(), 1,
                       "SequenceReverse Op only support one level lod.");
 
-    auto &dev_ctx = ctx.template device_context<DeviceContext>();
     const size_t *lod;
     size_t lod_count = x.lod()[0].size();
 
@@ -131,10 +130,25 @@ class SequenceReverseOpKernel : public framework::OpKernel<T> {
     PADDLE_ENFORCE_NE(x_data, y_data,
                       "SequenceReverse Op does not support in-place operation");
 
-    SequenceReverseFunctor<T> functor(x_data, y_data, lod, lod_count,
-                                      row_numel);
-    platform::ForRange<DeviceContext> for_range(dev_ctx, limit);
-    for_range(functor);
+    if (platform::is_cpu_place(ctx.GetPlace())) {
+      for (auto idx = 0; idx < lod_count - 1; idx++) {
+        auto start_pos = lod[idx];
+        auto end_pos = lod[idx + 1];
+        for (auto pos = start_pos; pos < end_pos; pos++) {
+          auto cur_pos = end_pos - pos - 1 + start_pos;
+          memcpy(y_data + pos * row_numel, x_data + cur_pos * row_numel,
+                 row_numel * sizeof(T));
+        }
+      }
+
+    } else {
+      auto &dev_ctx = ctx.template device_context<DeviceContext>();
+
+      SequenceReverseFunctor<T> functor(x_data, y_data, lod, lod_count,
+                                        row_numel);
+      platform::ForRange<DeviceContext> for_range(dev_ctx, limit);
+      for_range(functor);
+    }
   }
 };
 

--- a/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
@@ -136,11 +136,10 @@ class SequenceReverseOpKernel : public framework::OpKernel<T> {
         auto end_pos = lod[idx + 1];
         for (auto pos = start_pos; pos < end_pos; pos++) {
           auto cur_pos = end_pos - pos - 1 + start_pos;
-          memcpy(y_data + pos * row_numel, x_data + cur_pos * row_numel,
-                 row_numel * sizeof(T));
+          std::memcpy(y_data + pos * row_numel, x_data + cur_pos * row_numel,
+                      row_numel * sizeof(T));
         }
       }
-
     } else {
       auto &dev_ctx = ctx.template device_context<DeviceContext>();
 

--- a/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_reverse_op.h
@@ -132,7 +132,7 @@ class SequenceReverseOpKernel : public framework::OpKernel<T> {
                       "SequenceReverse Op does not support in-place operation");
 
     if (platform::is_cpu_place(ctx.GetPlace())) {
-      for (auto idx = 0; idx < lod_count - 1; idx++) {
+      for (size_t idx = 0; idx < lod_count - 1; idx++) {
         auto start_pos = lod[idx];
         auto end_pos = lod[idx + 1];
         for (auto pos = start_pos; pos < end_pos; pos++) {


### PR DESCRIPTION
As the performance requirement of ContentDNN, it uses memcpy function to replace functor.

resolve #17270