### PR TITLE
enhance generate mask labels, test=develop

### DIFF
--- a/paddle/fluid/operators/detection/generate_mask_labels_op.cc
+++ b/paddle/fluid/operators/detection/generate_mask_labels_op.cc
@@ -323,6 +323,10 @@ class GenerateMaskLabelsKernel : public framework::OpKernel<T> {
     auto gt_segms_lod = gt_segms->lod();
 
     for (int i = 0; i < n; ++i) {
+      if (rois_lod[i] == rois_lod[i + 1]) {
+        lod0.emplace_back(num_mask);
+        continue;
+      }
       Tensor im_info_slice = im_info->Slice(i, i + 1);
       Tensor gt_classes_slice =
           gt_classes->Slice(gt_classes_lod[i], gt_classes_lod[i + 1]);


### PR DESCRIPTION
Similar with https://github.com/PaddlePaddle/Paddle/pull/17011
When training mask-rcnn FPN in batch size=2, the number of proposals in one batch may be zero. It will cause error in generate mask labels because tensor.Slice only allow end > start.