### PR TITLE
Fix dygraph memory leak

### DIFF
--- a/paddle/fluid/platform/temporary_allocator.cc
+++ b/paddle/fluid/platform/temporary_allocator.cc
@@ -77,8 +77,8 @@ void TemporaryAllocator::Free(alloc::Allocation *allocation) {
                << "wait_delete_mem: " << wait_delete_mem;
     }
 
-    if (FLAGS_limit_of_tmp_allocation > 0 &&
-        wait_delete_mem > static_cast<size_t>(FLAGS_limit_of_tmp_allocation)) {
+    if (FLAGS_limit_of_tmp_allocation >= 0 &&
+        wait_delete_mem >= static_cast<size_t>(FLAGS_limit_of_tmp_allocation)) {
       PADDLE_ENFORCE(callback_ != nullptr, "The callback is non-initialized.");
       Release(callback_);
     }

--- a/python/paddle/fluid/dygraph/tracer.py
+++ b/python/paddle/fluid/dygraph/tracer.py
@@ -49,6 +49,10 @@ class Tracer(core.Tracer):
         return list((item for name, item in six.iteritems(self._vars)
                      if isinstance(item, framework.Parameter)))
 
+    def _clear_ops(self):
+        self._ops = defaultdict()
+        self._trace_id = 0
+
     def trace_op(self, op, inputs, outputs, stop_gradient=False):
         # TODO(minqiyang): remove this line after we take apart all
         # backward grads and forward variables

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -531,15 +531,12 @@ class Variable(object):
 
     def backward(self, backward_strategy=None):
         from .dygraph import BackwardStrategy
-        if isinstance(backward_strategy, BackwardStrategy):
-            self._ivar._run_backward(backward_strategy)
-        elif backward_strategy is not None:
-            raise TypeError(
-                "only BackwardStrategy type should be passed in backward")
-        else:
+        if backward_strategy is None:
             backward_strategy = BackwardStrategy()
             backward_strategy.sort_sum_gradient = False
-            self._ivar._run_backward(backward_strategy)
+
+        self._ivar._run_backward(backward_strategy)
+        _dygraph_tracer()._clear_ops()
 
     def gradient(self):
         new_ivar = self._ivar._grad_ivar()._copy_to(core.CPUPlace(), True)


### PR DESCRIPTION
In dygraph train mode, vars created in forward op without backward would not be released after each batch ends, which causes memory leak. Also, without calling `dev_ctx->Wait()` in GPU, memory allocated by `TemporaryAllocator` would not be released. This PR fixes these two bugs.