### PR TITLE
Enable abs operator for a ngraph

### DIFF
--- a/paddle/fluid/operators/ngraph/ops/binary_unary_op.h
+++ b/paddle/fluid/operators/ngraph/ops/binary_unary_op.h
@@ -51,6 +51,7 @@ static void BuildUnaryNode(
 }  // namespace operators
 }  // namespace paddle
 
+REGISTER_NG_OP(abs, BuildUnaryNode<ngraph::op::Abs>);
 REGISTER_NG_OP(relu, BuildUnaryNode<ngraph::op::Relu>);
 REGISTER_NG_OP(tanh, BuildUnaryNode<ngraph::op::Tanh>);
 REGISTER_NG_OP(sigmoid, BuildUnaryNode<ngraph::op::Sigmoid>);

--- a/python/paddle/fluid/tests/unittests/ngraph/test_activation_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_activation_ngraph_op.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest
-from paddle.fluid.tests.unittests.test_activation_op import TestSigmoid, TestRelu, TestTanh
+from paddle.fluid.tests.unittests.test_activation_op import TestAbs, TestSigmoid, TestRelu, TestTanh
 
 
 class TestNGRAPHReluDim4(TestRelu):


### PR DESCRIPTION
Enable the abs operator for the nGraph bridge. BERT model uses it.