### PR TITLE
Fix compiling error with cuDNN v5.

### DIFF
--- a/paddle/fluid/platform/cudnn_desc.h
+++ b/paddle/fluid/platform/cudnn_desc.h
@@ -183,15 +183,17 @@ class ConvolutionDescriptor {
     CUDNN_ENFORCE(dynload::cudnnSetConvolutionNdDescriptor(
         desc, pads.size(), pads.data(), strides.data(), dilations.data(),
         CUDNN_CROSS_CORRELATION, compute_type));
-    CUDNN_ENFORCE(platform::dynload::cudnnSetConvolutionMathType(
-        desc, CUDNN_DEFAULT_MATH));
 #if CUDNN_VERSION_MIN(7, 0, 1)
     CUDNN_ENFORCE(
         platform::dynload::cudnnSetConvolutionGroupCount(desc, groups));
+#if CUDA_VERSION >= 9000 && CUDNN_VERSION_MIN(7, 0, 1)
+    CUDNN_ENFORCE(platform::dynload::cudnnSetConvolutionMathType(
+        desc, CUDNN_DEFAULT_MATH));
     if (dtype == CUDNN_DATA_HALF) {
       CUDNN_ENFORCE(platform::dynload::cudnnSetConvolutionMathType(
           desc, CUDNN_TENSOR_OP_MATH));
     }
+#endif
 #endif
   }
 


### PR DESCRIPTION
 Fix compiling error with cuDNN v5:

```
2:21:26]W:	 [Step 1/5] /paddle/paddle/fluid/platform/cudnn_desc.h:186:19: error: ‘cudnnSetConvolutionMathType’ is not a member of ‘paddle::platform::dynload’
[22:21:26]W:	 [Step 1/5]      CUDNN_ENFORCE(platform::dynload::cudnnSetConvolutionMathType(
[22:21:26]W:	 [Step 1/5]                    ^
[22:21:26]W:	 [Step 1/5] /paddle/paddle/fluid/platform/cudnn_helper.h:65:19: note: in definition of macro ‘CUDNN_ENFORCE’
[22:21:26]W:	 [Step 1/5]      auto status = condition;                                         \
[22:21:26]W:	 [Step 1/5]                    ^
[22:21:26]W:	 [Step 1/5] /paddle/paddle/fluid/platform/cudnn_desc.h:187:15: error: ‘CUDNN_DEFAULT_MATH’ was not declared in this scope
[22:21:26]W:	 [Step 1/5]          desc, CUDNN_DEFAULT_MATH));
[22:21:26]W:	 [Step 1/5]                ^
[22:21:26]W:	 [Step 1/5] /paddle/paddle/fluid/platform/cudnn_helper.h:65:19: note: in definition of macro ‘CUDNN_ENFORCE’
[22:21:26]W:	 [Step 1/5]      auto status = condition;                                         \
[22:21:26]W:	 [Step 1/5]                    ^
```