### PR TITLE
move use_cvm from trainer to device_worker, the reason is that use_cv…

### DIFF
--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -93,7 +93,7 @@ class PullDenseWorker {
 // should incorporate different type of device
 class DeviceWorker {
  public:
-  DeviceWorker() { use_cvm_ = false; }
+  DeviceWorker() {}
   virtual ~DeviceWorker() {}
   virtual void Initialize(const TrainerDesc& desc) = 0;
   virtual void SetDeviceIndex(int tid) = 0;
@@ -115,7 +115,6 @@ class DeviceWorker {
   std::shared_ptr<DataFeed> device_reader_;
   int64_t batch_num_;
   FetchConfig fetch_config_;
-  bool use_cvm_;
 };
 
 class CPUWorkerBase : public DeviceWorker {
@@ -194,6 +193,8 @@ class DownpourWorker : public HogwildWorker {
   std::shared_ptr<PullDenseWorker> _pull_dense_worker;
   std::vector<::std::future<int32_t>> push_sparse_status_;
   std::vector<::std::future<int32_t>> push_dense_status_;
+
+  bool use_cvm_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/downpour_worker.cc
+++ b/paddle/fluid/framework/downpour_worker.cc
@@ -60,10 +60,10 @@ void DownpourWorker::Initialize(const TrainerDesc& desc) {
 
   need_to_push_sparse_ = param_.push_sparse();
   need_to_push_dense_ = param_.push_dense();
+  use_cvm_ = param_.use_cvm();
 
   fleet_ptr_ = FleetWrapper::GetInstance();
   fetch_config_ = desc.fetch_config();
-  use_cvm_ = desc.use_cvm();
 }
 
 void DownpourWorker::CollectLabelInfo(size_t table_idx) {

--- a/paddle/fluid/framework/hogwild_worker.cc
+++ b/paddle/fluid/framework/hogwild_worker.cc
@@ -27,7 +27,6 @@ void HogwildWorker::Initialize(const TrainerDesc& desc) {
   for (size_t i = 0; i < param_.skip_ops_size(); ++i) {
     skip_ops_[i] = param_.skip_ops(i);
   }
-  use_cvm_ = desc.use_cvm();
 }
 
 void HogwildWorker::CreateThreadOperators(const ProgramDesc& program) {

--- a/paddle/fluid/framework/trainer_desc.proto
+++ b/paddle/fluid/framework/trainer_desc.proto
@@ -30,7 +30,6 @@ message TrainerDesc {
   repeated string filelist = 5;
   optional bool debug = 6 [ default = false ];
   optional FetchConfig fetch_config = 7;
-  optional bool use_cvm = 8 [ default = false ];
 
   // device worker parameters
   optional HogwildWorkerParameter hogwild_param = 101;
@@ -49,6 +48,7 @@ message DownpourWorkerParameter {
   repeated ProgramConfig program_config = 4;
   optional bool push_sparse = 5 [ default = true ];
   optional bool push_dense = 6 [ default = true ];
+  optional bool use_cvm = 7 [ default = false ];
 }
 
 message FetchConfig {

--- a/python/paddle/fluid/device_worker.py
+++ b/python/paddle/fluid/device_worker.py
@@ -156,6 +156,7 @@ class DownpourSGD(DeviceWorker):
         sparse_table.sparse_grad_name.extend(
             self._fleet_desc.trainer_param.sparse_table[0].slot_gradient)
         if opt_info["use_cvm"]:
+            downpour.use_cvm = True
             sparse_table.emb_dim = \
                 self._fleet_desc.server_param.downpour_server_param.downpour_table_param[
                 0].accessor.fea_dim

--- a/python/paddle/fluid/tests/test_trainer_factory.py
+++ b/python/paddle/fluid/tests/test_trainer_factory.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import paddle.fluid as fluid
+from paddle.fluid.trainer_factory import TrainerFactory
+from paddle.fluid.trainer_desc import MultiTrainer, DistMultiTrainer
+
+input_x = fluid.layers.data(name="input_x", shape=[1], lod_level=1)
+label = fluid.layers.data(name="label", shape=[1], lod_level=0)
+emb = fluid.layers.embedding(input=input_x, size=[10000, 10], is_sparse=True)
+bow = fluid.layers.sequence_pool(input=emb, pool_type='sum')
+bow_tanh = fluid.layers.tanh(bow)
+fc_1 = fluid.layers.fc(input=bow_tanh, size=100, act='tanh')
+cost = fluid.layers.cross_entropy(input=fc_1, label=label)
+avg_cost = fluid.layers.mean(x=cost)
+program = fluid.default_main_program()
+trainer = TrainerFactory()._create_trainer(program._fleet_opt)
+trainer._set_program(program)
+assert isinstance(trainer, MultiTrainer)
+
+from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet
+from paddle.fluid.incubate.fleet.parameter_server.pslib import DownpourOptimizer
+
+exe = fluid.Executor(place=fluid.CPUPlace())
+
+sgd_optimizer = fluid.optimizer.SGD(learning_rate=1e-4)
+sgd_optimizer = fleet.distributed_optimizer(
+    sgd_optimizer, strategy={"use_cvm": True})
+sgd_optimizer.minimize(avg_cost)
+fleet.init(exe)
+dist_trainer = TrainerFactory()._create_trainer(program._fleet_opt)
+dist_trainer._set_program(fluid.default_main_program())
+assert isinstance(dist_trainer, DistMultiTrainer)

--- a/python/paddle/fluid/trainer_desc.py
+++ b/python/paddle/fluid/trainer_desc.py
@@ -61,9 +61,6 @@ class TrainerDesc(object):
     def _set_program(self, program):
         self._program = program
 
-    def _set_use_cvm(self, use_cvm=False):
-        self.proto_desc.use_cvm = use_cvm
-
     def _desc(self):
         from google.protobuf import text_format
         return text_format.MessageToString(self.proto_desc)

--- a/python/paddle/fluid/trainer_factory.py
+++ b/python/paddle/fluid/trainer_factory.py
@@ -38,5 +38,4 @@ class TrainerFactory(object):
             device_worker._set_fleet_desc(opt_info["fleet_desc"])
             trainer._set_device_worker(device_worker)
             trainer._set_fleet_desc(opt_info["fleet_desc"])
-            trainer._set_use_cvm(opt_info["use_cvm"])
         return trainer


### PR DESCRIPTION
…m is a device_worker specific configuration, a trainer does not need to know this, and use_cvm can be configured in python API without any change in trainer

test=develop