### PR TITLE
Add clear ops in dygraph optimizer

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -499,6 +499,9 @@ class Optimizer(object):
         optimize_ops = self.apply_optimize(
             loss, startup_program=startup_program, params_grads=params_grads)
 
+        if framework.in_dygraph_mode():
+            framework._dygraph_tracer()._clear_ops()
+
         return optimize_ops, params_grads
 
 


### PR DESCRIPTION
To prevent memory leak in dygraph mode.