### PR TITLE
remove two memory optimization related flags

### DIFF
--- a/paddle/fluid/framework/ir/memory_optimize_pass/inplace_op_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/inplace_op_pass.cc
@@ -48,8 +48,6 @@ DEFINE_bool(
     "Such as scale, elementwise_add"
     "By default, it's turned off");
 
-DECLARE_string(memory_optimize_debug);
-
 namespace paddle {
 namespace framework {
 namespace ir {
@@ -458,13 +456,6 @@ void InplacePass::ApplyImpl(ir::Graph *graph) const {
                 << " is not the same size with "
                 << "Output(" << out_param << ")=" << out_arg << " in "
                 << op_type;
-        continue;
-      }
-
-      // Debug Interface. Which would be skipped by the pass.
-      if (out_arg == FLAGS_memory_optimize_debug) {
-        VLOG(4) << "Skiped var by force. FLAGS_memory_optimize_debug="
-                << out_node->Name();
         continue;
       }
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -139,8 +139,8 @@ def __bootstrap__():
         'allocator_strategy', 'reader_queue_speed_test_mode',
         'print_sub_graph_dir', 'pe_profile_fname', 'inner_op_parallelism',
         'enable_parallel_graph', 'fuse_parameter_groups_size',
-        'multiple_of_cupti_buffer_size', 'enable_subgraph_optimize',
-        'fuse_parameter_memory_size', 'tracer_profile_fname'
+        'multiple_of_cupti_buffer_size', 'fuse_parameter_memory_size',
+        'tracer_profile_fname'
     ]
     if 'Darwin' not in sysstr:
         read_env_flags.append('use_pinned_memory')
@@ -182,8 +182,8 @@ def __bootstrap__():
             'fraction_of_gpu_memory_to_use', 'initial_gpu_memory_in_mb',
             'reallocate_gpu_memory_in_mb', 'cudnn_deterministic',
             'enable_cublas_tensor_op_math', 'conv_workspace_size_limit',
-            'cudnn_exhaustive_search', 'memory_optimize_debug', 'selected_gpus',
-            'sync_nccl_allreduce', 'limit_of_tmp_allocation',
+            'cudnn_exhaustive_search', 'selected_gpus', 'sync_nccl_allreduce',
+            'limit_of_tmp_allocation',
             'times_excess_than_required_tmp_allocation',
             'enable_inplace_whitelist', 'cudnn_batchnorm_spatial_persistent'
         ]


### PR DESCRIPTION
remove FLAG_enable_subgraph_optimize and FLAG_memory_optimize_debug
these two flags are added by the original author for debug purpose, but they are rarely used. Delete them to reduce the total number of exposed flags