### PR TITLE
Enable reshape operator test=develop

### DIFF
--- a/paddle/fluid/operators/ngraph/ngraph_bridge.cc
+++ b/paddle/fluid/operators/ngraph/ngraph_bridge.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include <algorithm>
 #include <functional>
 #include <memory>
+#include <unordered_set>
 #include <vector>
 
 #include "ngraph/ngraph.hpp"
@@ -24,11 +25,41 @@ limitations under the License. */
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/ngraph_helper.h"
 
+constexpr int64_t kNoPadding = -1;
+
 namespace paddle {
 namespace operators {
 
 bool NgraphBridge::isRegister(const std::string& str) {
   return ops::NgraphSingleton::Lookup(str);
+}
+
+bool NgraphBridge::isSupported(
+    const std::unique_ptr<framework::OperatorBase>& op) {
+  static std::unordered_set<std::string> skip_op_list{"reshape", "reshape2",
+                                                      "lookup_table"};
+  bool result = true;
+  auto& op_type = op->Type();
+  auto op_attrs = paddle::framework::AttrReader(op->Attrs());
+  if (!isRegister(op_type)) {
+    if (skip_op_list.count(op_type)) {
+      if (op_type == "lookup_table") {
+        if (op_attrs.Get<bool>("is_sparse") ||
+            (op_attrs.Get<int64_t>("padding_idx") != kNoPadding)) {
+          result = false;
+        }
+      } else if ((op_type == "reshape") || (op_type == "reshape2")) {
+        if (op->Input("Shape") != paddle::framework::kEmptyVarName) {
+          result = false;
+        }
+      } else {
+        result = false;
+      }
+    }
+  } else {
+    result = false;
+  }
+  return result;
 }
 
 void NgraphBridge::BuildNgNode(

--- a/paddle/fluid/operators/ngraph/ngraph_bridge.h
+++ b/paddle/fluid/operators/ngraph/ngraph_bridge.h
@@ -39,6 +39,8 @@ class NgraphBridge {
 
   static bool isRegister(const std::string& str);
 
+  static bool isSupported(const std::unique_ptr<framework::OperatorBase>& op);
+
  private:
   std::shared_ptr<
       std::unordered_map<std::string, std::shared_ptr<ngraph::Node>>>

--- a/paddle/fluid/operators/ngraph/ngraph_engine.cc
+++ b/paddle/fluid/operators/ngraph/ngraph_engine.cc
@@ -134,12 +134,11 @@ static std::vector<std::vector<int>> NgraphOpIntervals(
   int pivot = left;
   while (pivot < right) {
     auto op_type = ops->at(pivot)->Type();
-    if (NgraphBridge::isRegister(op_type)) {
+    if (!NgraphBridge::isSupported(ops->at(pivot))) {
       ++pivot;
     } else {
       int start = pivot, end = start;
-      while (pivot < right &&
-             (!NgraphBridge::isRegister(ops->at(pivot)->Type()))) {
+      while (pivot < right && (NgraphBridge::isSupported(ops->at(pivot)))) {
         ++pivot;
         ++end;
       }

--- a/paddle/fluid/operators/ngraph/ops/reshape_op.h
+++ b/paddle/fluid/operators/ngraph/ops/reshape_op.h
@@ -1,0 +1,107 @@
+/*Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "ngraph/ngraph.hpp"
+#include "paddle/fluid/operators/ngraph/ops/op_bridge.h"
+#include "paddle/fluid/platform/ngraph_helper.h"
+
+namespace paddle {
+namespace operators {
+namespace ngraphs {
+
+ngraph::Shape calc_output_shape(const ngraph::Shape& input_shape,
+                                const std::vector<int>& v_shape) {
+  auto out_shape = v_shape;
+  for (size_t i = 0; i < v_shape.size(); ++i) {
+    if (v_shape[i] == 0) {
+      out_shape[i] = input_shape[i];
+    }
+  }
+  int size_input = ngraph::shape_size(input_shape);
+  int size_out = 1;
+  for (auto o : out_shape) {
+    if (o > 0) size_out *= o;
+  }
+  for (auto& o : out_shape) {
+    if (o == -1) o = size_input / size_out;
+  }
+  return ngraph::Shape(out_shape.begin(), out_shape.end());
+}
+
+template <bool is_v2>
+static void BuildReshapeNode(
+    const std::shared_ptr<framework::OperatorBase>& op,
+    std::shared_ptr<
+        std::unordered_map<std::string, std::shared_ptr<ngraph::Node>>>
+        ngb_node_map) {
+  std::shared_ptr<ngraph::Node> input =
+      platform::GetInputNode(op, "X", ngb_node_map);
+  auto input_shape = input->get_shape();
+  // TODO(mozga-intel) The vector of shape is not supported yet, that's
+  // asDispensable() operator"
+  std::shared_ptr<ngraph::Node> shape =
+      platform::GetInputNode(op, "Shape", ngb_node_map);
+
+  auto op_attrs = framework::AttrReader(op->Attrs());
+  std::vector<int> v_shape = op_attrs.Get<std::vector<int>>("shape");
+  auto out = input;
+  if (shape != nullptr) {
+    ngraph::Shape new_shape;
+    for (auto& it : shape->get_shape()) {
+      new_shape.push_back(it);
+    }
+    out = platform::NgReshaper(input, shape->get_shape());
+  } else {
+    auto out_shape = calc_output_shape(input_shape, v_shape);
+    out = platform::NgReshaper(input, out_shape);
+  }
+
+  if (is_v2) {
+    platform::SetOutputNode(op, "XShape", input, ngb_node_map);
+  }
+  platform::SetOutputNode(op, "Out", out, ngb_node_map);
+}
+
+template <bool is_v2>
+void BuildReshapeGradNode(
+    const std::shared_ptr<paddle::framework::OperatorBase>& op,
+    std::shared_ptr<
+        std::unordered_map<std::string, std::shared_ptr<ngraph::Node>>>
+        ngb_node_map) {
+  auto dout = paddle::platform::GetInputNode(op, "Out@GRAD", ngb_node_map);
+  std::shared_ptr<ngraph::Node> input;
+  if (is_v2) {
+    input = paddle::platform::GetInputNode(op, "XShape", ngb_node_map);
+  } else {
+    input = paddle::platform::GetInputNode(op, "X", ngb_node_map);
+  }
+  auto dx = platform::NgReshaper(dout, input->get_shape());
+  paddle::platform::SetOutputNode(op, "X@GRAD", dx, ngb_node_map);
+}
+}  // namespace ngraphs
+}  // namespace operators
+}  // namespace paddle
+
+REGISTER_NG_OP(reshape, BuildReshapeNode<false>);
+REGISTER_NG_OP(reshape2, BuildReshapeNode<true>);
+REGISTER_NG_OP(reshape_grad, BuildReshapeGradNode<false>);
+REGISTER_NG_OP(reshape2_grad, BuildReshapeGradNode<true>);

--- a/paddle/fluid/platform/ngraph_helper.h
+++ b/paddle/fluid/platform/ngraph_helper.h
@@ -77,9 +77,7 @@ std::shared_ptr<ngraph::Node> GetNode(
         std::unordered_map<std::string, std::shared_ptr<ngraph::Node>>>
         ngb_node_map) {
   auto& var_names = var_map.at(name);
-  PADDLE_ENFORCE_EQ(var_names.size(), 1,
-                    "op %s name %s expects one associated var", op->Type(),
-                    name);
+  if (var_names.size() == 0) return nullptr;
   if (ngb_node_map->find(var_names[0]) != ngb_node_map->end()) {
     return (*ngb_node_map)[var_names[0]];
   } else {
@@ -188,6 +186,22 @@ inline void TrimTrailingSingularDims(ngraph::Shape* shape) {
       shape->pop_back();
     }
   }
+}
+
+ngraph::element::Type GetNgType(paddle::framework::proto::VarType::Type dtype) {
+  ngraph::element::Type ng_dtype;
+  if (dtype == paddle::framework::proto::VarType::FP32) {
+    ng_dtype = ngraph::element::f32;
+  } else if (dtype == paddle::framework::proto::VarType::FP64) {
+    ng_dtype = ngraph::element::f64;
+  } else if (dtype == paddle::framework::proto::VarType::INT64) {
+    ng_dtype = ngraph::element::i64;
+  } else if (dtype == paddle::framework::proto::VarType::INT32) {
+    ng_dtype = ngraph::element::i32;
+  } else {
+    PADDLE_THROW("unsupported data type: %s", dtype);
+  }
+  return ng_dtype;
 }
 }  // namespace platform
 }  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/ngraph/test_reshape_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_reshape_ngraph_op.py
@@ -1,0 +1,23 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest, sys
+sys.path.append("../")
+
+from test_reshape_op import TestReshapeOp, TestReshapeOpDimInfer1, TestReshapeOpDimInfer2, TestReshapeOpWithInputShape
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enable the reshape operator for the nGraph bridge. BERT model uses it.