### PR TITLE
Fix CI PR_CI_Document_Preview Job

### DIFF
--- a/tools/document_preview.sh
+++ b/tools/document_preview.sh
@@ -3,7 +3,8 @@ PADDLE_ROOT=/paddle
 cd ${PADDLE_ROOT}
 git clone https://github.com/PaddlePaddle/FluidDoc
 git clone https://github.com/tianshuo78520a/PaddlePaddle.org.git
-sh ${PADDLE_ROOT}/FluidDoc/doc/fluid/api/gen_doc.sh
+cd ${PADDLE_ROOT}/FluidDoc/doc/fluid/api
+sh gen_doc.sh
 pip install ${PADDLE_ROOT}/build/opt/paddle/share/wheels/*.whl
 apt-get update && apt-get install -y python-dev build-essential
 cd ${PADDLE_ROOT}/PaddlePaddle.org/portal

--- a/tools/document_preview.sh
+++ b/tools/document_preview.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-PADDLE_ROOT=/paddle
+PADDLE_ROOT=/home
+mkdir ${PADDLE_ROOT}
 cd ${PADDLE_ROOT}
+pip install /paddle/build/opt/paddle/share/wheels/*.whl
 git clone https://github.com/PaddlePaddle/FluidDoc
 git clone https://github.com/tianshuo78520a/PaddlePaddle.org.git
 cd ${PADDLE_ROOT}/FluidDoc/doc/fluid/api
 sh gen_doc.sh
-pip install ${PADDLE_ROOT}/build/opt/paddle/share/wheels/*.whl
 apt-get update && apt-get install -y python-dev build-essential
 cd ${PADDLE_ROOT}/PaddlePaddle.org/portal
 pip install -r requirements.txt


### PR DESCRIPTION
如果新添加的api之前是不能被访问的，必须要进入${PADDLE_ROOT}/FluidDoc/doc/fluid/api  才能执行 gen_doc.sh脚本，这个脚本会用到当前目录下的gen_doc.py，如果目录不对会报到不找gen_doc.py文件，导致新添加的api不能被读取。

![image](https://user-images.githubusercontent.com/29832297/58068810-7f897780-7bc5-11e9-910e-e2526fd15c96.png)
