### PR TITLE
Enabled elementwise max operator test=develop

### DIFF
--- a/paddle/fluid/operators/ngraph/ops/elementwise_node.h
+++ b/paddle/fluid/operators/ngraph/ops/elementwise_node.h
@@ -14,10 +14,13 @@ limitations under the License. */
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "ngraph/ngraph.hpp"
 #include "paddle/fluid/operators/ngraph/ops/elementwise_binary_prepare_node.h"
+#include "paddle/fluid/operators/ngraph/ops/op_bridge.h"
 #include "paddle/fluid/platform/ngraph_helper.h"
 
 namespace paddle {
@@ -61,3 +64,6 @@ void BuildElementwiseCompareNode(
 }  // namespace ngraphs
 }  // namespace operators
 }  // namespace paddle
+
+REGISTER_NG_OP(elementwise_max,
+               BuildElementwiseBinaryNode<ngraph::op::Maximum>);

--- a/python/paddle/fluid/tests/unittests/ngraph/test_elementwise_max_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_elementwise_max_ngraph_op.py
@@ -1,0 +1,22 @@
+#	Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest, sys
+sys.path.append("../")
+from test_elementwise_max_op import *
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enable the elementwise max operator for the nGraph bridge. BERT model uses it.