### PR TITLE
Fix dygraph unique name bug

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -41,6 +41,7 @@ class Layer(core.Layer):
     def __init__(self, name_scope, dtype=core.VarDesc.VarType.FP32):
         self._full_name = unique_name.generate(name_scope + "/" +
                                                self.__class__.__name__)
+        self._unique_name_generator = unique_name.UniqueNameGenerator()
         self._built = False
         self._dtype = dtype
         self._parameters = collections.OrderedDict()
@@ -104,11 +105,10 @@ class Layer(core.Layer):
 
         Returns created Variable.
         """
-        if name is not None:
-            var_name = ".".join([self._full_name, name])
-        else:
-            var_name = unique_name.generate(".".join(
-                [self._full_name, "_generated_var"]))
+        if name is None:
+            name = self._unique_name_generator("_generated_var")
+
+        var_name = ".".join([self._full_name, name])
 
         return self._helper.main_program.current_block().create_var(
             name=var_name, persistable=persistable, dtype=dtype, type=type)

--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -29,8 +29,11 @@ class LayerHelperBase(object):
         self._name = name
         self._unique_name_generator = unique_name.UniqueNameGenerator()
 
-    def _generate_unique_name(self, name, separator='.'):
-        return self._name + separator + self._unique_name_generator(name)
+    def _generate_unique_partial_name(self, name):
+        return self._unique_name_generator(name)
+
+    def generate_unique_name(self, name, separator='.'):
+        return self._name + separator + self._generate_unique_partial_name(name)
 
     @property
     def name(self):
@@ -89,17 +92,17 @@ class LayerHelperBase(object):
                       block=self.startup_program.global_block()):
             if out is None:
                 out = block.create_var(
-                    name=self._generate_unique_name('weight_norm_norm'),
+                    name=self.generate_unique_name('weight_norm_norm'),
                     dtype=dtype,
                     persistable=False)
             abs_out = block.create_var(
-                name=self._generate_unique_name('weight_norm_abs'),
+                name=self.generate_unique_name('weight_norm_abs'),
                 dtype=dtype,
                 persistable=False)
             block.append_op(
                 type='abs', inputs={'X': x}, outputs={'Out': abs_out})
             pow_out = block.create_var(
-                name=self._generate_unique_name('weight_norm_pow'),
+                name=self.generate_unique_name('weight_norm_pow'),
                 dtype=dtype,
                 persistable=False)
             block.append_op(
@@ -108,7 +111,7 @@ class LayerHelperBase(object):
                 outputs={'Out': pow_out},
                 attrs={'factor': float(p)})
             sum_out = block.create_var(
-                name=self._generate_unique_name('weight_norm_sum'),
+                name=self.generate_unique_name('weight_norm_sum'),
                 dtype=dtype,
                 persistable=False)
             block.append_op(
@@ -133,7 +136,7 @@ class LayerHelperBase(object):
                          block=self.startup_program.global_block()):
             if out is None:
                 out = block.create_var(
-                    name=self._generate_unique_name('weight_norm_reshape'),
+                    name=self.generate_unique_name('weight_norm_reshape'),
                     dtype=dtype,
                     persistable=False)
             block.append_op(
@@ -149,7 +152,7 @@ class LayerHelperBase(object):
                            block=self.startup_program.global_block()):
             if out is None:
                 out = block.create_var(
-                    name=self._generate_unique_name('weight_norm_transpose'),
+                    name=self.generate_unique_name('weight_norm_transpose'),
                     dtype=dtype,
                     persistable=False)
             block.append_op(
@@ -166,7 +169,7 @@ class LayerHelperBase(object):
             """Computes the norm over all dimensions except dim"""
             if out is None:
                 out = block.create_var(
-                    name=self._generate_unique_name('weight_norm_norm'),
+                    name=self.generate_unique_name('weight_norm_norm'),
                     dtype=dtype,
                     persistable=False)
             if dim is None:
@@ -271,7 +274,7 @@ class LayerHelperBase(object):
         assert isinstance(attr, ParamAttr)
         suffix = 'b' if is_bias else 'w'
         if attr.name is None:
-            attr.name = self._generate_unique_name(suffix)
+            attr.name = self.generate_unique_name(suffix)
 
         if default_initializer is None and attr.initializer is None:
             if isinstance(dtype, core.VarDesc.VarType):
@@ -324,7 +327,7 @@ class LayerHelperBase(object):
             infer_var_type.
         """
         return self.main_program.current_block().create_var(
-            name=self._generate_unique_name('tmp'),
+            name=self.generate_unique_name('tmp'),
             dtype=dtype,
             type=core.VarDesc.VarType.LOD_TENSOR,
             persistable=False,

--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -27,6 +27,10 @@ class LayerHelperBase(object):
     def __init__(self, name, layer_type):
         self._layer_type = layer_type
         self._name = name
+        self._unique_name_generator = unique_name.UniqueNameGenerator()
+
+    def _generate_unique_name(self, name, separator='.'):
+        return self._name + separator + self._unique_name_generator(name)
 
     @property
     def name(self):
@@ -85,20 +89,17 @@ class LayerHelperBase(object):
                       block=self.startup_program.global_block()):
             if out is None:
                 out = block.create_var(
-                    name=unique_name.generate(".".join(
-                        [self.name, 'weight_norm_norm'])),
+                    name=self._generate_unique_name('weight_norm_norm'),
                     dtype=dtype,
                     persistable=False)
             abs_out = block.create_var(
-                name=unique_name.generate(".".join(
-                    [self.name, 'weight_norm_abs'])),
+                name=self._generate_unique_name('weight_norm_abs'),
                 dtype=dtype,
                 persistable=False)
             block.append_op(
                 type='abs', inputs={'X': x}, outputs={'Out': abs_out})
             pow_out = block.create_var(
-                name=unique_name.generate(".".join(
-                    [self.name, 'weight_norm_pow'])),
+                name=self._generate_unique_name('weight_norm_pow'),
                 dtype=dtype,
                 persistable=False)
             block.append_op(
@@ -107,8 +108,7 @@ class LayerHelperBase(object):
                 outputs={'Out': pow_out},
                 attrs={'factor': float(p)})
             sum_out = block.create_var(
-                name=unique_name.generate(".".join(
-                    [self.name, 'weight_norm_sum'])),
+                name=self._generate_unique_name('weight_norm_sum'),
                 dtype=dtype,
                 persistable=False)
             block.append_op(
@@ -133,8 +133,7 @@ class LayerHelperBase(object):
                          block=self.startup_program.global_block()):
             if out is None:
                 out = block.create_var(
-                    name=unique_name.generate(".".join(
-                        [self.name, 'weight_norm_reshape'])),
+                    name=self._generate_unique_name('weight_norm_reshape'),
                     dtype=dtype,
                     persistable=False)
             block.append_op(
@@ -150,8 +149,7 @@ class LayerHelperBase(object):
                            block=self.startup_program.global_block()):
             if out is None:
                 out = block.create_var(
-                    name=unique_name.generate(".".join(
-                        [self.name, 'weight_norm_transpose'])),
+                    name=self._generate_unique_name('weight_norm_transpose'),
                     dtype=dtype,
                     persistable=False)
             block.append_op(
@@ -168,8 +166,7 @@ class LayerHelperBase(object):
             """Computes the norm over all dimensions except dim"""
             if out is None:
                 out = block.create_var(
-                    name=unique_name.generate(".".join(
-                        [self.name, 'weight_norm_norm'])),
+                    name=self._generate_unique_name('weight_norm_norm'),
                     dtype=dtype,
                     persistable=False)
             if dim is None:
@@ -274,7 +271,7 @@ class LayerHelperBase(object):
         assert isinstance(attr, ParamAttr)
         suffix = 'b' if is_bias else 'w'
         if attr.name is None:
-            attr.name = unique_name.generate(".".join([self.name, suffix]))
+            attr.name = self._generate_unique_name(suffix)
 
         if default_initializer is None and attr.initializer is None:
             if isinstance(dtype, core.VarDesc.VarType):
@@ -327,7 +324,7 @@ class LayerHelperBase(object):
             infer_var_type.
         """
         return self.main_program.current_block().create_var(
-            name=unique_name.generate(".".join([self.name, 'tmp'])),
+            name=self._generate_unique_name('tmp'),
             dtype=dtype,
             type=core.VarDesc.VarType.LOD_TENSOR,
             persistable=False,

--- a/python/paddle/fluid/layers/collective.py
+++ b/python/paddle/fluid/layers/collective.py
@@ -32,6 +32,9 @@ def _allreduce(x, out=None, reduce_type="sum", sync_mode=False):
         raise TypeError("reduce type can only be [sum|prod|max|min]")
 
     if out is None:
+        # FIXME(zjl): in dygraph mode, if x is not gradient of parameter,
+        # memory leak would occur in unique_name, which makes the dygraph
+        # program run slower and slower as batch increases.
         out = helper.create_variable(
             name=unique_name.generate(".".join([x.name, 'tmp'])),
             shape=x.shape,

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -368,8 +368,7 @@ class StaticRNN(object):
                 raise ValueError(
                     "if init is None, memory at least need shape and batch_ref")
             parent_block = self._parent_block()
-            var_name = unique_name.generate("@".join(
-                [self.helper.name, "memory_boot"]))
+            var_name = self.helper.generate_unique_name("memory_boot", "@")
             boot_var = parent_block.create_var(
                 name=var_name,
                 shape=shape,
@@ -391,7 +390,7 @@ class StaticRNN(object):
             return self.memory(init=boot_var)
         else:
             pre_mem = self.helper.create_variable(
-                name=unique_name.generate("@".join([self.helper.name, "mem"])),
+                name=self.helper.generate_unique_name("mem", "@"),
                 dtype=init.dtype,
                 shape=init.shape)
             self.memories[pre_mem.name] = StaticRNNMemoryLink(
@@ -1536,11 +1535,11 @@ class IfElse(object):
         if id(x) not in self.input_table:
             parent_block = self._parent_block()
             out_true = parent_block.create_var(
-                name=unique_name.generate('ifelse_input' + self.helper.name),
+                name='ifelse_input' + self.helper.generate_unique_name('', ''),
                 dtype=x.dtype)
 
             out_false = parent_block.create_var(
-                name=unique_name.generate('ifelse_input' + self.helper.name),
+                name='ifelse_input' + self.helper.generate_unique_name('', ''),
                 dtype=x.dtype)
             parent_block.append_op(
                 type='split_lod_tensor',
@@ -1582,8 +1581,7 @@ class IfElse(object):
                 raise TypeError("Each output should be a variable")
             # create outside tensor
             outside_out = parent_block.create_var(
-                name=unique_name.generate("_".join(
-                    [self.helper.name, 'output'])),
+                name=self.helper.generate_unique_name('output', '_'),
                 dtype=each_out.dtype)
             out_table.append(outside_out)
 
@@ -1659,6 +1657,8 @@ class DynamicRNN(object):
 
     def __init__(self, name=None):
         self.helper = LayerHelper('dynamic_rnn', name=name)
+        self.output_helper = LayerHelper(
+            'dynamic_rnn_layer', name=self.helper.name + "_output_array")
         self.status = DynamicRNN.BEFORE_RNN
         self.lod_rank_table = None
         self.max_seq_len = None
@@ -1975,8 +1975,7 @@ class DynamicRNN(object):
         parent_block = self._parent_block_()
         for each in outputs:
             outside_array = parent_block.create_var(
-                name=unique_name.generate("_".join(
-                    [self.helper.name, "output_array", each.name])),
+                name=self.output_helper.generate_unique_name(each.name, '_'),
                 type=core.VarDesc.VarType.LOD_TENSOR_ARRAY,
                 dtype=each.dtype)
             array_write(x=each, i=self.step_idx, array=outside_array)

--- a/python/paddle/fluid/layers/device.py
+++ b/python/paddle/fluid/layers/device.py
@@ -29,8 +29,7 @@ __all__ = []
 @autodoc()
 def get_places(device_count=None, device_type=None):
     helper = LayerHelper('get_places', **locals())
-    out_places = helper.create_variable(
-        name=unique_name.generate(helper.name + ".out"))
+    out_places = helper.create_variable(name=helper.generate_unique_name('out'))
     attrs = dict()
     if device_count is not None:
         attrs['device_count'] = int(device_count)

--- a/python/paddle/fluid/layers/learning_rate_scheduler.py
+++ b/python/paddle/fluid/layers/learning_rate_scheduler.py
@@ -29,7 +29,7 @@ from . import nn
 from . import ops
 from . import tensor
 from ..initializer import init_on_cpu
-from ..framework import default_main_program, Parameter, unique_name, name_scope
+from ..framework import default_main_program, Parameter, name_scope
 from ..dygraph import base as imperative_base
 from ..dygraph import learning_rate_scheduler as imperate_lr
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -9747,7 +9747,7 @@ def clip(x, min, max, name=None):
     helper = LayerHelper("clip", **locals())
 
     if name is None:
-        name = unique_name.generate(".".join([helper.name, 'tmp']))
+        name = helper.generate_unique_name('tmp')
 
     out = helper.create_variable(
         type=x.type, name=name, dtype=x.dtype, persistable=False)
@@ -9786,7 +9786,7 @@ def clip_by_norm(x, max_norm, name=None):
     helper = LayerHelper("clip_by_norm", **locals())
 
     if name is None:
-        name = unique_name.generate(".".join([helper.name, 'tmp']))
+        name = helper.generate_unique_name('tmp')
 
     out = helper.create_variable(
         type=x.type, name=name, dtype=x.dtype, persistable=False)

--- a/python/paddle/fluid/metrics.py
+++ b/python/paddle/fluid/metrics.py
@@ -703,7 +703,7 @@ class DetectionMAP(object):
         Returns: State variable
         """
         state = self.helper.create_variable(
-            name="_".join([unique_name.generate(self.helper.name), suffix]),
+            name="_".join([self.helper.generate_unique_name('', ''), suffix]),
             persistable=True,
             dtype=dtype,
             shape=shape)

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -839,7 +839,7 @@ class DGCMomentumOptimizer(MomentumOptimizer):
         helper = LayerHelper("dgc_clip_by_norm_op", **args)
 
         if name is None:
-            name = unique_name.generate(".".join([helper.name, 'tmp']))
+            name = helper.generate_unique_name('tmp')
 
         out = helper.create_variable(
             type=x.type, name=name, dtype=x.dtype, persistable=False)

--- a/python/paddle/fluid/tests/unittests/test_unique_name.py
+++ b/python/paddle/fluid/tests/unittests/test_unique_name.py
@@ -43,3 +43,7 @@ class TestUniqueName(unittest.TestCase):
             name3 = fluid.unique_name.generate('tmp')
             self.assertNotEqual(name1, name2)
             self.assertEqual(name1[-2:], name3[-2:])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`unique_name.ids` increases as batch increases, which make memory leak in dygraph mode since dygraph mode creates new variables across batches. This bug makes ptb model run slower as batch increases. This PR fixes this bug.