### PR TITLE
Enable elementwise min operator test=develop

### DIFF
--- a/paddle/fluid/operators/ngraph/ops/elementwise_node.h
+++ b/paddle/fluid/operators/ngraph/ops/elementwise_node.h
@@ -67,3 +67,5 @@ void BuildElementwiseCompareNode(
 
 REGISTER_NG_OP(elementwise_max,
                BuildElementwiseBinaryNode<ngraph::op::Maximum>);
+REGISTER_NG_OP(elementwise_min,
+               BuildElementwiseBinaryNode<ngraph::op::Minimum>);

--- a/python/paddle/fluid/tests/unittests/ngraph/test_elementwise_min_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_elementwise_min_ngraph_op.py
@@ -1,0 +1,22 @@
+#	Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest, sys
+sys.path.append("../")
+from test_elementwise_min_op import *
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enable the elementwise min operator for the nGraph bridge. BERT model uses it.