### PR TITLE
Enable logical operators for the nGraph Bridge

### DIFF
--- a/paddle/fluid/operators/ngraph/ops/binary_unary_op.h
+++ b/paddle/fluid/operators/ngraph/ops/binary_unary_op.h
@@ -55,3 +55,7 @@ REGISTER_NG_OP(abs, BuildUnaryNode<ngraph::op::Abs>);
 REGISTER_NG_OP(relu, BuildUnaryNode<ngraph::op::Relu>);
 REGISTER_NG_OP(tanh, BuildUnaryNode<ngraph::op::Tanh>);
 REGISTER_NG_OP(sigmoid, BuildUnaryNode<ngraph::op::Sigmoid>);
+
+REGISTER_NG_OP(logical_and, BuildBinaryNode<ngraph::op::And>);
+REGISTER_NG_OP(logical_or, BuildBinaryNode<ngraph::op::Or>);
+REGISTER_NG_OP(logical_not, BuildUnaryNode<ngraph::op::Not>);

--- a/python/paddle/fluid/tests/unittests/ngraph/test_logical_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_logical_ngraph_op.py
@@ -1,0 +1,28 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest, sys
+sys.path.append("../")
+import numpy as np
+
+from test_logical_op import create_test_class
+
+create_test_class('logical_and', lambda _a, _b: np.logical_and(_a, _b))
+create_test_class('logical_or', lambda _a, _b: np.logical_or(_a, _b))
+create_test_class('logical_not', lambda _a: np.logical_not(_a), False)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Enable logical operators for the nGraph Bridge. BERT model uses logical_not operator.