### PR TITLE
decrease the train loop number to avoid run too long to fail the ci p…

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -231,7 +231,8 @@ class TestDygraphResnet(unittest.TestCase):
         seed = 90
 
         batch_size = train_parameters["batch_size"]
-        batch_num = 20
+        batch_num = 10
+
         with fluid.dygraph.guard():
             fluid.default_startup_program().random_seed = seed
             fluid.default_main_program().random_seed = seed

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet_sorted_gradient.py
@@ -71,7 +71,7 @@ class TestDygraphResnetSortGradient(unittest.TestCase):
         seed = 90
 
         batch_size = train_parameters["batch_size"]
-        batch_num = 20
+        batch_num = 10
         with fluid.dygraph.guard():
             fluid.default_startup_program().random_seed = seed
             fluid.default_main_program().random_seed = seed

--- a/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
@@ -315,7 +315,7 @@ class TestImperativeResneXt(unittest.TestCase):
         seed = 90
 
         batch_size = train_parameters["batch_size"]
-        batch_num = 2
+        batch_num = 1
         epoch_num = 1
         with fluid.dygraph.guard():
             fluid.default_startup_program().random_seed = seed


### PR DESCRIPTION
…rocess test=develop

some imperative unit test may run too long to fail the CI, decrease the run loop times to fix, and would not affect the final result.

![image](https://user-images.githubusercontent.com/23548796/58162568-00736c80-7cb5-11e9-989c-684cd6e3b207.png)
