### PR TITLE
Fix the usage of out_grad lod in sequence_slice_op.

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_slice_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_slice_op.h
@@ -135,7 +135,8 @@ class SequenceSliceGradOpKernel : public framework::OpKernel<T> {
     }
 
     auto lod = in->lod();
-    auto out_lod = out_grad->lod();
+    // to avoid out_grad missing lod, compute lod again
+    auto out_lod = SequenceSliceLoD(*in, offset_data, length_data);
 
     if (x_grad) {
       x_grad->mutable_data<T>(ctx.GetPlace());


### PR DESCRIPTION
Fix #17561 
Fix the usage of out_grad lod in sequence_slice_op. Re-compute the lod of output rather than getting from out_grad to aviod missing lod.
