### PR TITLE
Enable less_than ngraph operator

### DIFF
--- a/paddle/fluid/operators/ngraph/ops/elementwise_node.h
+++ b/paddle/fluid/operators/ngraph/ops/elementwise_node.h
@@ -72,3 +72,4 @@ REGISTER_NG_OP(elementwise_sub,
                BuildElementwiseBinaryNode<ngraph::op::Subtract>);
 REGISTER_NG_OP(elementwise_min,
                BuildElementwiseBinaryNode<ngraph::op::Minimum>);
+REGISTER_NG_OP(less_than, BuildElementwiseCompareNode<ngraph::op::Less>);

--- a/python/paddle/fluid/tests/unittests/ngraph/test_compare_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_compare_ngraph_op.py
@@ -1,0 +1,24 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy
+import sys
+sys.path.append("../")
+import test_compare_op
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/ngraph/test_compare_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_compare_ngraph_op.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 import unittest
-import numpy
 import sys
 sys.path.append("../")
 import test_compare_op


### PR DESCRIPTION
This PR is to enable less_than op for ngraph engine, it is needed for BERT model