### PR TITLE
test=develop, make test_imperative_se_resnet run in exclusive way

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -137,6 +137,7 @@ py_test_modules(test_imperative_mnist_sorted_gradient MODULES test_imperative_mn
         FLAGS_cudnn_deterministic=1)
 py_test_modules(test_imperative_se_resnext MODULES test_imperative_se_resnext ENVS
     FLAGS_cudnn_deterministic=1)
+set_tests_properties(test_imperative_se_resnext PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
 
 if(WITH_DISTRIBUTE)
     py_test_modules(test_dist_train MODULES test_dist_train)


### PR DESCRIPTION
This PR make `test_imperative_se_resnet` run by its own to avoid OOM issue on CUDA 9/10 test 

Test on K40:

<img width="600" alt="MacHi 2019-05-27 11-16-07" src="https://user-images.githubusercontent.com/22361972/58393370-ff558d00-8070-11e9-97d8-072ecbc646f5.png">
