### PR TITLE
Revert "Enable SQRT operator for the nGraph Bridge"

### DIFF
--- a/paddle/fluid/operators/ngraph/ops/activation_op.h
+++ b/paddle/fluid/operators/ngraph/ops/activation_op.h
@@ -113,6 +113,5 @@ void BuildTanhGradNode(
 REGISTER_NG_OP(gelu, BuildGeluNode);
 REGISTER_NG_OP(gelu_grad, BuildGeluGradNode);
 REGISTER_NG_OP(relu_grad, BuildReluGradNode);
-REGISTER_NG_OP(sqrt, BuildUnaryNode<ngraph::op::Sqrt>);
 REGISTER_NG_OP(square, BuildSquareNode);
 REGISTER_NG_OP(tanh_grad, BuildTanhGradNode);

--- a/python/paddle/fluid/tests/unittests/ngraph/test_activation_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_activation_ngraph_op.py
@@ -18,7 +18,7 @@ import unittest
 import numpy as np
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest
-from paddle.fluid.tests.unittests.test_activation_op import TestAbs, TestGelu, TestSigmoid, TestSqrt, TestSquare, TestRelu, TestTanh
+from paddle.fluid.tests.unittests.test_activation_op import TestAbs, TestGelu, TestSigmoid, TestSquare, TestRelu, TestTanh
 
 
 class TestNGRAPHReluDim4(TestRelu):


### PR DESCRIPTION
Reverts PaddlePaddle/Paddle#17549
```
[22:16:34]	In file included from /paddle/build/paddle/fluid/operators/ngraph/ngraph_ops.h:12:0,
[22:16:34]	                 from /paddle/paddle/fluid/operators/ngraph/ngraph_bridge.cc:23:
[22:16:34]	/paddle/paddle/fluid/operators/ngraph/ops/activation_op.h: In constructor 'ng_sqrt_converter::ng_sqrt_converter()':
[22:16:34]	/paddle/paddle/fluid/operators/ngraph/ops/activation_op.h:116:101: error: 'BuildUnaryNode' is not a member of 'paddle::operators::ngraphs'
[22:16:34]	/paddle/paddle/fluid/operators/ngraph/ops/activation_op.h:116:160: error: expected primary-expression before '>' token
[22:16:34]	/paddle/paddle/fluid/operators/ngraph/ops/activation_op.h:116:161: error: expected primary-expression before ',' token
[22:16:34]	make[2]: *** [paddle/fluid/operators/ngraph/CMakeFiles/ngraph_bridge.dir/ngraph_bridge.cc.o] Error 1
[22:16:34]	paddle/fluid/operators/ngraph/CMakeFiles/ngraph_bridge.dir/build.make:62: recipe for target 'paddle/fluid/operators/ngraph/CMakeFiles/ngraph_bridge.dir/ngraph_bridge.cc.o' failed
[22:16:34]	make[1]: *** [paddle/fluid/operators/ngraph/CMakeFiles/ngraph_bridge.dir/all] Error 2
[22:16:34]	CMakeFiles/Makefile2:62623: recipe for target 'paddle/fluid/operators/ngraph/CMakeFiles/ngraph_bridge.dir/all' failed
[22:16:34]	make[1]: *** Waiting for unfinished jobs....
[22:16:35]	
```
http://ci.paddlepaddle.org/viewLog.html?buildId=105021&tab=buildLog&buildTypeId=Paddle_PrCi&logTab=tree&filter=all