### PR TITLE
test=develop, fix mac ci will not uninstall dependency files

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -390,6 +390,19 @@ EOF
         ctest --output-on-failure -j $2
         # make install should also be test when unittest
         make install -j 8
+
+        set +ex
+        if [ "$1" == "cp27-cp27m" ]; then
+            pip uninstall -y paddlepaddle
+        elif [ "$1" == "cp35-cp35m" ]; then
+            pip3.5 uninstall -y paddlepaddle
+        elif [ "$1" == "cp36-cp36m" ]; then
+            pip3.6 uninstall -y paddlepaddle
+        elif [ "$1" == "cp37-cp37m" ]; then
+            pip3.7 uninstall -y paddlepaddle
+        fi
+        set -ex
+
         if [ "$1" == "cp27-cp27m" ]; then
             set -e
             pip install --user ${INSTALL_PREFIX:-/paddle/build}/opt/paddle/share/wheels/*.whl
@@ -403,16 +416,6 @@ EOF
         fi
 
         paddle version
-
-        if [ "$1" == "cp27-cp27m" ]; then
-            pip uninstall -y paddlepaddle
-        elif [ "$1" == "cp35-cp35m" ]; then
-            pip3.5 uninstall -y paddlepaddle
-        elif [ "$1" == "cp36-cp36m" ]; then
-            pip3.6 uninstall -y paddlepaddle
-        elif [ "$1" == "cp37-cp37m" ]; then
-            pip3.7 uninstall -y paddlepaddle
-        fi
     fi
 }
 


### PR DESCRIPTION
This PR will fill fix Mac ci will not uninstall dependency files when `paddle_version` exec failed, which may cause wrong dependency remained on Mac:
<img width="1117" alt="cbbd1c663dc029c9896d0cf79" src="https://user-images.githubusercontent.com/22361972/58456983-2a66dc00-8158-11e9-9485-8b2feab24bd8.png">
