### PR TITLE
Fix the gather op grad calc bug when has same index

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -153,7 +153,7 @@ paddle.fluid.layers.image_resize (ArgSpec(args=['input', 'out_shape', 'scale', '
 paddle.fluid.layers.image_resize_short (ArgSpec(args=['input', 'out_short_len', 'resample'], varargs=None, keywords=None, defaults=('BILINEAR',)), ('document', '099b9f051e6247ae661e4a7b4fd3f89a'))
 paddle.fluid.layers.resize_bilinear (ArgSpec(args=['input', 'out_shape', 'scale', 'name', 'actual_shape', 'align_corners', 'align_mode'], varargs=None, keywords=None, defaults=(None, None, None, None, True, 1)), ('document', '746bf58fdb1bd475f8c5f996b05b0e52'))
 paddle.fluid.layers.resize_nearest (ArgSpec(args=['input', 'out_shape', 'scale', 'name', 'actual_shape', 'align_corners'], varargs=None, keywords=None, defaults=(None, None, None, None, True)), ('document', '9baf9288c862161ff850d45228047a5e'))
-paddle.fluid.layers.gather (ArgSpec(args=['input', 'index'], varargs=None, keywords=None, defaults=None), ('document', '01a198d6fff38d5f0d8180a40b228085'))
+paddle.fluid.layers.gather (ArgSpec(args=['input', 'index', 'overwrite'], varargs=None, keywords=None, defaults=(True,)), ('document', '936aee93c8e4b5b4c6c88c91d50b335e'))
 paddle.fluid.layers.scatter (ArgSpec(args=['input', 'index', 'updates', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', '65f8e9d8ddfd0b412f940579c4faa342'))
 paddle.fluid.layers.sequence_scatter (ArgSpec(args=['input', 'index', 'updates', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', '71df5136cf03b06c65027b692fe78f1a'))
 paddle.fluid.layers.random_crop (ArgSpec(args=['x', 'shape', 'seed'], varargs=None, keywords=None, defaults=(None,)), ('document', 'c9ab9e460ef0a1823249935a30e82c66'))

--- a/paddle/fluid/operators/gather_op.cc
+++ b/paddle/fluid/operators/gather_op.cc
@@ -74,6 +74,13 @@ class GatherOpMaker : public framework::OpProtoAndCheckerMaker {
     AddInput("X", "The source input of gather op");
     AddInput("Index", "The index input of gather op");
     AddOutput("Out", "The output of gather op");
+    AddAttr<bool>(
+        "overwrite",
+        "(bool, defalut: False) "
+        "In backward process, calc the grad when has same index,"
+        "If true, update the grad using the overwrite mode in same index,"
+        "If false, using the accumulate mode in same index.")
+        .SetDefault(true);
     AddComment(R"DOC(
 Gather Operator.
 

--- a/paddle/fluid/operators/gather_op.cu
+++ b/paddle/fluid/operators/gather_op.cu
@@ -76,9 +76,11 @@ class GatherGradOpCUDAKernel : public framework::OpKernel<T> {
         paddle::framework::DataTypeToString(framework::proto::VarType::INT32),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT64));
     if (index_type == framework::proto::VarType::INT32) {
-      GPUScatterAssign<T, int>(ctx.device_context(), *dO, *index, dX);
+      GPUScatterAssign<T, int>(ctx.device_context(), *dO, *index, dX,
+                               ctx.Attr<bool>("overwrite"));
     } else if (index_type == framework::proto::VarType::INT64) {
-      GPUScatterAssign<T, int64_t>(ctx.device_context(), *dO, *index, dX);
+      GPUScatterAssign<T, int64_t>(ctx.device_context(), *dO, *index, dX,
+                                   ctx.Attr<bool>("overwrite"));
     }
   }
 };

--- a/paddle/fluid/operators/gather_op.h
+++ b/paddle/fluid/operators/gather_op.h
@@ -71,6 +71,7 @@ class GatherGradientOpKernel : public framework::OpKernel<T> {
                        .eigen_device();
     dxt.device(place) = dxt.constant(static_cast<T>(0));
     if (dO->numel() == 0) return;
+    double overwrite = ctx.Attr<bool>("overwrite");
 
     const auto &index_type = index->type();
     bool index_type_match = index_type == framework::proto::VarType::INT32 ||
@@ -82,9 +83,17 @@ class GatherGradientOpKernel : public framework::OpKernel<T> {
         paddle::framework::DataTypeToString(framework::proto::VarType::INT32),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT64));
     if (index_type == framework::proto::VarType::INT32) {
-      ScatterAssign<T, int>(ctx.device_context(), *dO, *index, dX);
+      if (overwrite) {
+        ScatterAssign<T, int>(ctx.device_context(), *dO, *index, dX);
+      } else {
+        ScatterAssignAdd<T, int>(ctx, *dO, *index, dX);
+      }
     } else if (index_type == framework::proto::VarType::INT64) {
-      ScatterAssign<T, int64_t>(ctx.device_context(), *dO, *index, dX);
+      if (overwrite) {
+        ScatterAssign<T, int64_t>(ctx.device_context(), *dO, *index, dX);
+      } else {
+        ScatterAssignAdd<T, int64_t>(ctx, *dO, *index, dX);
+      }
     }
   }
 };

--- a/paddle/fluid/operators/scatter.h
+++ b/paddle/fluid/operators/scatter.h
@@ -14,16 +14,62 @@ limitations under the License. */
 
 #pragma once
 #include <cstring>
+#include <string>
 
 #include "paddle/fluid/framework/ddim.h"
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/operators/math/blas.h"
 #include "paddle/fluid/platform/place.h"
+#include "unordered_set"
 
 namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
+
+/**
+  * Return the updated array pointer, use blas or eigen lib to optimize time
+ * cost
+ */
+
+template <typename T, typename IndexT = int>
+typename std::enable_if<std::is_floating_point<T>::value>::type
+elementwise_inner_add(const framework::ExecutionContext& ctx,
+                      const framework::Tensor& src, framework::Tensor* dist,
+                      const int& src_index, const IndexT& dist_index,
+                      const int& slice_size, const size_t& slice_bytes) {
+  // use blas lib to add
+  auto blas = math::GetBlas<platform::CPUDeviceContext, T>(ctx);
+
+  // new array to save tmp add result
+  T* tmp_add_pointer = new T[slice_size];
+  const T* src_pointer = src.data<T>();
+  const T* dist_pointer = dist->data<T>();
+
+  blas.VADD(slice_size, src_pointer + src_index * slice_size,
+            dist_pointer + dist_index * slice_size, tmp_add_pointer);
+
+  memcpy(dist->data<T>() + dist_index * slice_size, tmp_add_pointer,
+         slice_bytes);
+  // free tmp memory
+  delete[] tmp_add_pointer;
+}
+
+template <typename T, typename IndexT = int>
+typename std::enable_if<!std::is_floating_point<T>::value>::type
+elementwise_inner_add(const framework::ExecutionContext& ctx,
+                      const framework::Tensor& src, framework::Tensor* dist,
+                      const int& src_index, const IndexT& dist_index,
+                      const int& slice_size, const size_t& slice_bytes) {
+  auto src_slice = src.Slice(src_index, src_index + 1);
+  auto dist_slice = dist->Slice(dist_index, dist_index + 1);
+
+  auto eigen_src = framework::EigenVector<T>::Flatten(src_slice);
+  auto eigen_dist = framework::EigenVector<T>::Flatten(dist_slice);
+
+  eigen_dist += eigen_src;
+}
 
 /**
  * Return a updated tensor from source tensor, scattered according to index:
@@ -61,6 +107,65 @@ void ScatterAssign(const platform::DeviceContext& ctx, const Tensor& src,
   for (int i = 0; i < index_size; ++i) {
     IndexT index_ = p_index[i];
     memcpy(p_output + index_ * slice_size, p_src + i * slice_size, slice_bytes);
+  }
+}
+
+template <typename T, typename IndexT = int>
+void ScatterAssignAdd(const framework::ExecutionContext& ctx, const Tensor& src,
+                      const Tensor& index, Tensor* output) {
+  PADDLE_ENFORCE(platform::is_cpu_place(ctx.device_context().GetPlace()));
+  // check index of shape 1-D
+  PADDLE_ENFORCE(index.dims().size() == 1 ||
+                 (index.dims().size() == 2 && index.dims()[1] == 1));
+  int index_size = index.dims()[0];
+
+  auto src_dims = src.dims();
+  auto dst_dims = output->dims();
+
+  const T* p_src = src.data<T>();
+  const IndexT* p_index = index.data<IndexT>();
+
+  bool overwrite = true;
+
+  // if find duplicate index, can not use overwrite mode
+  std::unordered_set<IndexT> index_count;
+  for (int i = 0; i < index_size; ++i) {
+    if (index_count.count(p_index[i]) > 0) {
+      overwrite = false;
+      break;
+    } else {
+      index_count.emplace(p_index[i]);
+    }
+  }
+
+  T* p_output = output->data<T>();
+
+  // check src shape and dst shape should match
+  for (int i = 1; i < src_dims.size(); i++)
+    PADDLE_ENFORCE(src_dims[i] == dst_dims[i]);
+
+  // slice size
+  size_t slice_size = 1;
+  for (int i = 1; i < src_dims.size(); ++i) slice_size *= src_dims[i];
+
+  // if in not in overwrite mode, need init output
+  if (!overwrite) {
+    memset(p_output, 0, output->numel() * sizeof(T));
+  }
+
+  const size_t& slice_bytes = slice_size * sizeof(T);
+
+  for (int i = 0; i < index_size; ++i) {
+    const IndexT& index_ = p_index[i];
+
+    // if in overwrite mode, can copy data directly
+    if (overwrite) {
+      memcpy(p_output + index_ * slice_size, p_src + i * slice_size,
+             slice_bytes);
+    } else {
+      elementwise_inner_add<T, IndexT>(ctx, src, output, i, index_, slice_size,
+                                       slice_bytes);
+    }
   }
 }
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7782,7 +7782,7 @@ def image_resize_short(input, out_short_len, resample='BILINEAR'):
     return image_resize(input=input, out_shape=out_shape, resample=resample)
 
 
-def gather(input, index):
+def gather(input, index, overwrite=True):
     """
     **Gather Layer**
 
@@ -7813,6 +7813,12 @@ def gather(input, index):
     Args:
         input (Variable): The source input with rank>=1.
         index (Variable): The index input with rank=1.
+        overwrite (bool): The mode that update the grad when has same index.
+            If True, use the overwrite mode to update the grad of the same index,
+	    if False, use the accumulate mode to update the grad of the same index. 
+	    Default value is True.
+	    
+
 
     Returns:
         output (Variable): The output is a tensor with the same rank as input.
@@ -7832,7 +7838,8 @@ def gather(input, index):
         type="gather",
         inputs={"X": input,
                 "Index": index},
-        outputs={"Out": out})
+        outputs={"Out": out},
+        attrs={'overwrite': overwrite})
     return out
 
 

--- a/python/paddle/fluid/tests/unittests/test_gather_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gather_op.py
@@ -79,5 +79,23 @@ class TestCase3(TestGatherOp):
         self.index_type = "int64"
 
 
+class TestCase4(TestGatherOp):
+    def config(self):
+        self.x_shape = (10, 20)
+        self.attrs = {'overwrite': False}
+        self.x_type = "double"
+        self.index = [1, 1]
+        self.index_type = "int32"
+
+
+class TestCase5(TestGatherOp):
+    def config(self):
+        self.x_shape = (10, 20)
+        self.attrs = {'overwrite': False}
+        self.x_type = "float"
+        self.index = [1, 1, 3]
+        self.index_type = "int32"
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
test=develop
The gather op has indices input，when the indices has same index, calculate the grad has a bug，just use overwrite mode to calculate the same index grad, fix this bug using the accumulate mode to calculate the same index grad. At the same time, using the lib of open-blas and eigen to optimize the time cost in accumulate mode