### PR TITLE
fix scipy version for python2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,7 +4,7 @@ protobuf>=3.1.0
 recordio>=0.1.0
 matplotlib==2.2.3 # TODO: let python3 paddlepaddle package use latest matplotlib
 rarfile
-scipy>=0.19.0
+scipy>=0.19.0,<=1.2.1
 Pillow
 nltk>=3.2.2
 graphviz


### PR DESCRIPTION
The latest releases will support only Python3.