### PR TITLE
Correct Role Enum for role_maker, test=develop.

### DIFF
--- a/python/paddle/fluid/incubate/fleet/base/role_maker.py
+++ b/python/paddle/fluid/incubate/fleet/base/role_maker.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 class Role(Enum):
-    WORKER = 1,
+    WORKER = 1
     SERVER = 2
 
 


### PR DESCRIPTION
For Enum, it should not contain comma in its member defination.