### PR TITLE
revise the cudnn conv choose algorithm to improve the performance(mask rcnn benchmark)

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_op.cu.cc
+++ b/paddle/fluid/operators/conv_cudnn_op.cu.cc
@@ -166,10 +166,23 @@ class CUDNNConvOpKernel : public framework::OpKernel<T> {
     // TODO(dangqingqing) simplify the following code by SearchAlgorithm in
     // conv_cudnn_helper.h
     if ((!exhaustive_search) && (!half_float)) {
-      CUDNN_ENFORCE(platform::dynload::cudnnGetConvolutionForwardAlgorithm(
+#if CUDNN_VERSION >= 7001
+      using perf_t = cudnnConvolutionFwdAlgoPerf_t;	
+      int perf_count;
+      int best_algo_idx = 0;
+      std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_FWD_ALGS]);	  
+      CUDNN_ENFORCE(platform::dynload::cudnnGetConvolutionForwardAlgorithm_v7(
+          handle, cudnn_input_desc, cudnn_filter_desc, cudnn_conv_desc,
+          cudnn_output_desc, kNUM_CUDNN_FWD_ALGS,
+          &perf_count, perf_results.get()));
+      algo = (perf_results.get())[best_algo_idx].algo;
+#else  
+    CUDNN_ENFORCE(platform::dynload::cudnnGetConvolutionForwardAlgorithm(
           handle, cudnn_input_desc, cudnn_filter_desc, cudnn_conv_desc,
           cudnn_output_desc, CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
           workspace_size_limit, &algo));
+#endif
+
       VLOG(3) << "cuDNN forward algo " << algo;
     } else if (exhaustive_search && (!half_float)) {
       AlgorithmsCache<cudnnConvolutionFwdAlgo_t>& algo_cache =
@@ -388,6 +401,30 @@ class CUDNNConvGradOpKernel : public framework::OpKernel<T> {
       } else if (FLAGS_cudnn_deterministic) {
         data_algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
       } else {
+#if CUDNN_VERSION >= 7001
+        using perf_t = cudnnConvolutionBwdDataAlgoPerf_t;	
+        int perf_count;
+	int best_algo_idx = 0;
+        std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_BWD_DATA_ALGS]);	  
+	CUDNN_ENFORCE(
+            platform::dynload::cudnnGetConvolutionBackwardDataAlgorithm_v7(
+                handle, cudnn_filter_desc,
+                // dyDesc: Handle to the previously initialized input
+                // differential
+                // tensor descriptor.
+                cudnn_output_grad_desc, cudnn_conv_desc,
+                // dxDesc: Handle to the previously initialized output tensor
+                // descriptor.
+                cudnn_input_desc,
+                kNUM_CUDNN_BWD_DATA_ALGS, &perf_count, perf_results.get()));  
+	data_algo = (perf_results.get())[best_algo_idx].algo;
+        int stride_dim = input->dims().size() - 2; 
+        bool blacklist = std::any_of(strides.begin(), strides.begin() + stride_dim, [=](int n){return n!= 1;});
+	if (blacklist && (static_cast<cudnnConvolutionBwdDataAlgo_t>(perf_results[best_algo_idx].algo) == CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING 
+		|| static_cast<cudnnConvolutionBwdDataAlgo_t>(perf_results[best_algo_idx].algo) == CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT)) {
+	           data_algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;	
+        }
+#else
         CUDNN_ENFORCE(
             platform::dynload::cudnnGetConvolutionBackwardDataAlgorithm(
                 handle, cudnn_filter_desc,
@@ -400,6 +437,7 @@ class CUDNNConvGradOpKernel : public framework::OpKernel<T> {
                 cudnn_input_desc,
                 CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
                 workspace_size_limit, &data_algo));
+#endif
       }
       CUDNN_ENFORCE(
           platform::dynload::cudnnGetConvolutionBackwardDataWorkspaceSize(
@@ -437,12 +475,26 @@ class CUDNNConvGradOpKernel : public framework::OpKernel<T> {
       } else if (FLAGS_cudnn_deterministic) {
         filter_algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1;
       } else {
+#if CUDNN_VERSION >= 7001
+        using perf_t = cudnnConvolutionBwdFilterAlgoPerf_t;
+        int perf_count;
+        int best_algo_idx = 0;
+	std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_BWD_FILTER_ALGS]);	  
+	  
+        CUDNN_ENFORCE(
+	  platform::dynload::cudnnGetConvolutionBackwardFilterAlgorithm_v7(
+                handle, cudnn_input_desc, cudnn_output_grad_desc,
+                cudnn_conv_desc, cudnn_filter_desc,
+                kNUM_CUDNN_BWD_FILTER_ALGS, &perf_count, perf_results.get()));  
+	filter_algo = (perf_results.get())[best_algo_idx].algo;
+#else
         CUDNN_ENFORCE(
             platform::dynload::cudnnGetConvolutionBackwardFilterAlgorithm(
                 handle, cudnn_input_desc, cudnn_output_grad_desc,
                 cudnn_conv_desc, cudnn_filter_desc,
                 CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
                 workspace_size_limit, &filter_algo));
+#endif
       }
       CUDNN_ENFORCE(
           platform::dynload::cudnnGetConvolutionBackwardFilterWorkspaceSize(

--- a/paddle/fluid/operators/conv_cudnn_op.cu.cc
+++ b/paddle/fluid/operators/conv_cudnn_op.cu.cc
@@ -167,17 +167,17 @@ class CUDNNConvOpKernel : public framework::OpKernel<T> {
     // conv_cudnn_helper.h
     if ((!exhaustive_search) && (!half_float)) {
 #if CUDNN_VERSION >= 7001
-      using perf_t = cudnnConvolutionFwdAlgoPerf_t;	
+      using perf_t = cudnnConvolutionFwdAlgoPerf_t;
       int perf_count;
       int best_algo_idx = 0;
-      std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_FWD_ALGS]);	  
+      std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_FWD_ALGS]);
       CUDNN_ENFORCE(platform::dynload::cudnnGetConvolutionForwardAlgorithm_v7(
           handle, cudnn_input_desc, cudnn_filter_desc, cudnn_conv_desc,
-          cudnn_output_desc, kNUM_CUDNN_FWD_ALGS,
-          &perf_count, perf_results.get()));
+          cudnn_output_desc, kNUM_CUDNN_FWD_ALGS, &perf_count,
+          perf_results.get()));
       algo = (perf_results.get())[best_algo_idx].algo;
-#else  
-    CUDNN_ENFORCE(platform::dynload::cudnnGetConvolutionForwardAlgorithm(
+#else
+      CUDNN_ENFORCE(platform::dynload::cudnnGetConvolutionForwardAlgorithm(
           handle, cudnn_input_desc, cudnn_filter_desc, cudnn_conv_desc,
           cudnn_output_desc, CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
           workspace_size_limit, &algo));
@@ -402,11 +402,12 @@ class CUDNNConvGradOpKernel : public framework::OpKernel<T> {
         data_algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
       } else {
 #if CUDNN_VERSION >= 7001
-        using perf_t = cudnnConvolutionBwdDataAlgoPerf_t;	
+        using perf_t = cudnnConvolutionBwdDataAlgoPerf_t;
         int perf_count;
-	int best_algo_idx = 0;
-        std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_BWD_DATA_ALGS]);	  
-	CUDNN_ENFORCE(
+        int best_algo_idx = 0;
+        std::unique_ptr<perf_t[]> perf_results(
+            new perf_t[kNUM_CUDNN_BWD_DATA_ALGS]);
+        CUDNN_ENFORCE(
             platform::dynload::cudnnGetConvolutionBackwardDataAlgorithm_v7(
                 handle, cudnn_filter_desc,
                 // dyDesc: Handle to the previously initialized input
@@ -415,14 +416,20 @@ class CUDNNConvGradOpKernel : public framework::OpKernel<T> {
                 cudnn_output_grad_desc, cudnn_conv_desc,
                 // dxDesc: Handle to the previously initialized output tensor
                 // descriptor.
-                cudnn_input_desc,
-                kNUM_CUDNN_BWD_DATA_ALGS, &perf_count, perf_results.get()));  
-	data_algo = (perf_results.get())[best_algo_idx].algo;
-        int stride_dim = input->dims().size() - 2; 
-        bool blacklist = std::any_of(strides.begin(), strides.begin() + stride_dim, [=](int n){return n!= 1;});
-	if (blacklist && (static_cast<cudnnConvolutionBwdDataAlgo_t>(perf_results[best_algo_idx].algo) == CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING 
-		|| static_cast<cudnnConvolutionBwdDataAlgo_t>(perf_results[best_algo_idx].algo) == CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT)) {
-	           data_algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;	
+                cudnn_input_desc, kNUM_CUDNN_BWD_DATA_ALGS, &perf_count,
+                perf_results.get()));
+        data_algo = (perf_results.get())[best_algo_idx].algo;
+        int stride_dim = input->dims().size() - 2;
+        bool blacklist =
+            std::any_of(strides.begin(), strides.begin() + stride_dim,
+                        [=](int n) { return n != 1; });
+        if (blacklist && (static_cast<cudnnConvolutionBwdDataAlgo_t>(
+                              perf_results[best_algo_idx].algo) ==
+                              CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING ||
+                          static_cast<cudnnConvolutionBwdDataAlgo_t>(
+                              perf_results[best_algo_idx].algo) ==
+                              CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT)) {
+          data_algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_1;
         }
 #else
         CUDNN_ENFORCE(
@@ -479,14 +486,15 @@ class CUDNNConvGradOpKernel : public framework::OpKernel<T> {
         using perf_t = cudnnConvolutionBwdFilterAlgoPerf_t;
         int perf_count;
         int best_algo_idx = 0;
-	std::unique_ptr<perf_t[]> perf_results(new perf_t[kNUM_CUDNN_BWD_FILTER_ALGS]);	  
-	  
+        std::unique_ptr<perf_t[]> perf_results(
+            new perf_t[kNUM_CUDNN_BWD_FILTER_ALGS]);
+
         CUDNN_ENFORCE(
-	  platform::dynload::cudnnGetConvolutionBackwardFilterAlgorithm_v7(
+            platform::dynload::cudnnGetConvolutionBackwardFilterAlgorithm_v7(
                 handle, cudnn_input_desc, cudnn_output_grad_desc,
-                cudnn_conv_desc, cudnn_filter_desc,
-                kNUM_CUDNN_BWD_FILTER_ALGS, &perf_count, perf_results.get()));  
-	filter_algo = (perf_results.get())[best_algo_idx].algo;
+                cudnn_conv_desc, cudnn_filter_desc, kNUM_CUDNN_BWD_FILTER_ALGS,
+                &perf_count, perf_results.get()));
+        filter_algo = (perf_results.get())[best_algo_idx].algo;
 #else
         CUDNN_ENFORCE(
             platform::dynload::cudnnGetConvolutionBackwardFilterAlgorithm(

--- a/paddle/fluid/platform/dynload/cudnn.h
+++ b/paddle/fluid/platform/dynload/cudnn.h
@@ -172,19 +172,19 @@ CUDNN_DNN_ROUTINE_EACH_R6(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 #endif
 
 #if CUDNN_VERSION >= 7001
-#define CUDNN_DNN_ROUTINE_EACH_R7(__macro)        \
-  __macro(cudnnSetConvolutionGroupCount);         \
-  __macro(cudnnSetConvolutionMathType);           \
-  __macro(cudnnConvolutionBiasActivationForward); \
-  __macro(cudnnCreateCTCLossDescriptor);          \
-  __macro(cudnnDestroyCTCLossDescriptor);         \
-  __macro(cudnnGetCTCLossDescriptor);             \
-  __macro(cudnnSetCTCLossDescriptor);             \
-  __macro(cudnnGetCTCLossWorkspaceSize);          \
-  __macro(cudnnCTCLoss);                          \
-  __macro(cudnnGetConvolutionBackwardDataAlgorithm_v7);       \
-  __macro(cudnnGetConvolutionBackwardFilterAlgorithm_v7);     \
-  __macro(cudnnGetConvolutionForwardAlgorithm_v7);  
+#define CUDNN_DNN_ROUTINE_EACH_R7(__macro)                \
+  __macro(cudnnSetConvolutionGroupCount);                 \
+  __macro(cudnnSetConvolutionMathType);                   \
+  __macro(cudnnConvolutionBiasActivationForward);         \
+  __macro(cudnnCreateCTCLossDescriptor);                  \
+  __macro(cudnnDestroyCTCLossDescriptor);                 \
+  __macro(cudnnGetCTCLossDescriptor);                     \
+  __macro(cudnnSetCTCLossDescriptor);                     \
+  __macro(cudnnGetCTCLossWorkspaceSize);                  \
+  __macro(cudnnCTCLoss);                                  \
+  __macro(cudnnGetConvolutionBackwardDataAlgorithm_v7);   \
+  __macro(cudnnGetConvolutionBackwardFilterAlgorithm_v7); \
+  __macro(cudnnGetConvolutionForwardAlgorithm_v7);
 CUDNN_DNN_ROUTINE_EACH_R7(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 #endif
 

--- a/paddle/fluid/platform/dynload/cudnn.h
+++ b/paddle/fluid/platform/dynload/cudnn.h
@@ -181,7 +181,10 @@ CUDNN_DNN_ROUTINE_EACH_R6(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
   __macro(cudnnGetCTCLossDescriptor);             \
   __macro(cudnnSetCTCLossDescriptor);             \
   __macro(cudnnGetCTCLossWorkspaceSize);          \
-  __macro(cudnnCTCLoss);
+  __macro(cudnnCTCLoss);                          \
+  __macro(cudnnGetConvolutionBackwardDataAlgorithm_v7);       \
+  __macro(cudnnGetConvolutionBackwardFilterAlgorithm_v7);     \
+  __macro(cudnnGetConvolutionForwardAlgorithm_v7);  
 CUDNN_DNN_ROUTINE_EACH_R7(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 #endif
 


### PR DESCRIPTION
conv algorithm can affect the performace of convolution layer. When the cudnn version is above 7, we need to use the new API  to choose the conv algorithm . For the mask RCNN model, the performance improve in both cuda9.0 environment and cuda9.2 environment(cuda 9.0 have 25% performance boost)





测试数据：

[13:18:48] :	 [Step 1/1] models: bert, run_machine_type: ONE_GPU, index: mem, result: 6586
[13:18:48] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU, index: maxbs, result: 0
[13:18:48] :	 [Step 1/1] models: paddingrnn_large_static, run_machine_type: ONE_GPU, index: speed, result: 16.823
[13:18:48] :	 [Step 1/1] models: yolov3, run_machine_type: ONE_GPU, index: mem, result: 10670
[13:18:48] :	 [Step 1/1] models: paddingrnn_small_static, run_machine_type: ONE_GPU, index: speed, result: 54.440
[13:18:48] :	 [Step 1/1] models: ddpg_deep_explore, run_machine_type: ONE_GPU, index: speed, result: 1.479
[13:18:48] :	 [Step 1/1] models: mask_rcnn, run_machine_type: ONE_GPU, index: speed, result: 3.728
[13:18:48] :	 [Step 1/1] models: transformer, run_machine_type: MULTI_GPU_MULTI_PROCESS, index: speed, result: 4.414
[13:18:48] :	 [Step 1/1] models: transformer, run_machine_type: ONE_GPU, index: maxbs, result: 12000
[13:18:48] :	 [Step 1/1] models: DeepLab_V3+, run_machine_type: ONE_GPU, index: maxbs, result: 9
[13:18:48] :	 [Step 1/1] models: bert, run_machine_type: MULTI_GPU, index: mem, result: 6732
[13:18:48] :	 [Step 1/1] models: SE-ResNeXt50, run_machine_type: MULTI_GPU, index: maxbs, result: 896
[13:18:48] :	 [Step 1/1] models: paddingrnn_large_padding, run_machine_type: ONE_GPU, index: speed, result: 10.306
[13:18:48] :	 [Step 1/1] models: mask_rcnn, run_machine_type: ONE_GPU, index: maxbs, result: 5
[13:18:48] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU, index: speed, result: 59.156
[13:18:48] :	 [Step 1/1] models: bert, run_machine_type: MULTI_GPU_MULTI_PROCESS, index: speed, result: 3.420
[13:18:48] :	 [Step 1/1] models: paddingrnn_large_padding, run_machine_type: ONE_GPU, index: mem, result: 6930
[13:18:48] :	 [Step 1/1] models: SE-ResNeXt50, run_machine_type: ONE_GPU, index: mem, result: 5548
[13:18:48] :	 [Step 1/1] models: transformer, run_machine_type: ONE_GPU, index: mem, result: 6506
[13:18:48] :	 [Step 1/1] models: bert, run_machine_type: ONE_GPU, index: speed, result: 4.035
[13:18:48] :	 [Step 1/1] models: yolov3, run_machine_type: ONE_GPU, index: maxbs, result: 14
[13:18:48] :	 [Step 1/1] models: CycleGAN, run_machine_type: ONE_GPU, index: speed, result: 7.357
[13:18:48] :	 [Step 1/1] models: SE-ResNeXt50, run_machine_type: MULTI_GPU, index: mem, result: 5622
[13:18:48] :	 [Step 1/1] models: transformer, run_machine_type: ONE_GPU, index: speed, result: 4.842
[13:18:48] :	 [Step 1/1] models: bert, run_machine_type: MULTI_GPU, index: speed, result: 1.847
[13:18:48] :	 [Step 1/1] models: yolov3, run_machine_type: ONE_GPU, index: speed, result: 30.278
[13:18:48] :	 [Step 1/1] models: mask_rcnn, run_machine_type: MULTI_GPU, index: maxbs, result: 40
[13:18:48] :	 [Step 1/1] models: DeepLab_V3+, run_machine_type: ONE_GPU, index: mem, result: 5188
[13:18:48] :	 [Step 1/1] models: bert, run_machine_type: ONE_GPU, index: maxbs, result: 9984
[13:18:48] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU_MULTI_PROCESS, index: speed, result: 
[13:18:48] :	 [Step 1/1] models: SE-ResNeXt50, run_machine_type: ONE_GPU, index: maxbs, result: 112
[13:18:48] :	 [Step 1/1] models: DeepLab_V3+, run_machine_type: ONE_GPU, index: speed, result: 13.544
[13:18:48] :	 [Step 1/1] models: transformer, run_machine_type: MULTI_GPU, index: mem, result: 6596
[13:18:48] :	 [Step 1/1] models: paddingrnn_large_static, run_machine_type: ONE_GPU, index: mem, result: 6108
[13:18:48] :	 [Step 1/1] models: mask_rcnn, run_machine_type: MULTI_GPU, index: mem, result: 4102
[13:18:48] :	 [Step 1/1] models: paddingrnn_small_padding, run_machine_type: ONE_GPU, index: speed, result: 22.243
[13:18:48] :	 [Step 1/1] models: DeepLab_V3+, run_machine_type: MULTI_GPU, index: maxbs, result: 72
[13:18:48] :	 [Step 1/1] models: CycleGAN, run_machine_type: ONE_GPU, index: mem, result: 2512
[13:18:48] :	 [Step 1/1] models: paddingrnn_small_static, run_machine_type: ONE_GPU, index: mem, result: 714
[13:18:48] :	 [Step 1/1] models: mask_rcnn, run_machine_type: MULTI_GPU, index: speed, result: 18.588
[13:18:48] :	 [Step 1/1] models: DeepLab_V3+, run_machine_type: MULTI_GPU, index: mem, result: 5294
[13:18:48] :	 [Step 1/1] models: SE-ResNeXt50, run_machine_type: ONE_GPU, index: speed, result: 117.381
[13:18:48] :	 [Step 1/1] models: mask_rcnn, run_machine_type: ONE_GPU, index: mem, result: 3888
[13:18:49] :	 [Step 1/1] models: bert, run_machine_type: MULTI_GPU, index: maxbs, result: 79872
[13:18:49] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU, index: mem, result: 10790
[13:18:49] :	 [Step 1/1] models: DeepLab_V3+, run_machine_type: MULTI_GPU, index: speed, result: 57.588
[13:18:49] :	 [Step 1/1] models: transformer, run_machine_type: MULTI_GPU, index: speed, result: 4.073
[13:18:49] :	 [Step 1/1] models: mask_rcnn, run_machine_type: MULTI_GPU_MULTI_PROCESS, index: speed, result: 20.040
[13:18:49] :	 [Step 1/1] models: transformer, run_machine_type: MULTI_GPU, index: maxbs, result: 96000
[13:18:49] :	 [Step 1/1] models: paddingrnn_small_padding, run_machine_type: ONE_GPU, index: mem, result: 730
[13:18:49] :	 [Step 1/1] models: ddpg_deep_explore, run_machine_type: ONE_GPU, index: mem, result: 598
[13:18:49] :	 [Step 1/1] models: SE-ResNeXt50, run_machine_type: MULTI_GPU, index: speed, result: 423.781




[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU, index: maxbs, result: 112
[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: ONE_GPU, index: mem, result: 10642
[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU, index: speed, result: 59.208
[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: ONE_GPU, index: maxbs, result: 14
[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: ONE_GPU, index: speed, result: 30.129
[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU_MULTI_PROCESS, index: speed, result: 77.606
[01:10:40] :	 [Step 1/1] models: yolov3, run_machine_type: MULTI_GPU, index: mem, result: 10784
