### PR TITLE
make omp thread num default 1 after inference run

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -234,6 +234,11 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
     tensor_array_batch_cleaner_.CollectNoTensorVars(sub_scope_);
   }
   tensor_array_batch_cleaner_.ResetNoTensorVars();
+
+  // recover the cpu_math_library_num_threads to 1, in order to avoid thread
+  // conflict when integrating it into deployment service.
+  paddle::platform::SetNumThreads(1);
+
   return true;
 }
 
@@ -586,6 +591,11 @@ bool AnalysisPredictor::ZeroCopyRun() {
   // Fix TensorArray reuse not cleaned bug.
   tensor_array_batch_cleaner_.CollectTensorArrays(sub_scope_);
   tensor_array_batch_cleaner_.ResetTensorArray();
+
+  // recover the cpu_math_library_num_threads to 1, in order to avoid thread
+  // conflict when integrating it into deployment service.
+  paddle::platform::SetNumThreads(1);
+
   return true;
 }
 


### PR DESCRIPTION
```
bool AnalysisPredictor::ZeroCopyRun() {
   paddle::platform::SetNumThreads(config_.cpu_math_library_num_threads());
   executor_->Run();
   ...
}
```
We `SetNumThreads` before ` executor_->Run();` in both `AnalysisPredictor::ZeroCopyRun()` and `AnalysisPredictor::Run()`. 

- Thus, for example, if `config_.cpu_math_library_num_threads()=8`, then, after we call `ZeroCopyRun()`, the omp threads number become 8 in environment. 
- In some deployment service, the change of omp threads to 8 will cause omp threads confict and affect performance with other modules. 
- So we  recover the cpu_math_library_num_threads to 1 to avoid thread conflict when integrating it into deployment service.