### PR TITLE
fix api doc in slice op, test=develop

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -197,7 +197,7 @@ paddle.fluid.layers.gaussian_random (ArgSpec(args=['shape', 'mean', 'std', 'seed
 paddle.fluid.layers.sampling_id (ArgSpec(args=['x', 'min', 'max', 'seed', 'dtype'], varargs=None, keywords=None, defaults=(0.0, 1.0, 0, 'float32')), ('document', '35428949368cad5121dd37f8522ef8b0'))
 paddle.fluid.layers.gaussian_random_batch_size_like (ArgSpec(args=['input', 'shape', 'input_dim_idx', 'output_dim_idx', 'mean', 'std', 'seed', 'dtype'], varargs=None, keywords=None, defaults=(0, 0, 0.0, 1.0, 0, 'float32')), ('document', '9e520987168f8ddb7dd71ffd68aa352c'))
 paddle.fluid.layers.sum (ArgSpec(args=['x'], varargs=None, keywords=None, defaults=None), ('document', 'a418e3ccb5e2ac21bd60f5cc221d5860'))
-paddle.fluid.layers.slice (ArgSpec(args=['input', 'axes', 'starts', 'ends'], varargs=None, keywords=None, defaults=None), ('document', 'bcb6380dbcf288058f8c1e14b82cbe0d'))
+paddle.fluid.layers.slice (ArgSpec(args=['input', 'axes', 'starts', 'ends'], varargs=None, keywords=None, defaults=None), ('document', '3ca6a761570d86e303e473afba99bb49'))
 paddle.fluid.layers.shape (ArgSpec(args=['input'], varargs=None, keywords=None, defaults=None), ('document', 'bf61c8f79d795a8371bdb3b5468aa82b'))
 paddle.fluid.layers.rank (ArgSpec(args=['input'], varargs=None, keywords=None, defaults=None), ('document', 'ee1386c42ecc8f424fe3fb21862fefc2'))
 paddle.fluid.layers.logical_and (ArgSpec(args=['x', 'y', 'out', 'name'], varargs=None, keywords=None, defaults=(None, None)), ('document', 'cdcf20c494c92060d10feb9374532f42'))

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -97,27 +97,27 @@ the start or end indices, it represents number of elements before the end
 of that dimension. If the value passed to start or end is larger than
 the n (the number of elements in this dimension), it represents n.
 For slicing to the end of a dimension with unknown size, it is recommended
-to pass in INT_MAX. If axes are omitted, they are set to [0, ..., ndim-1].
+to pass in INT_MAX. The size of axes must be equal to starts\' and ends\'.
 Following examples will explain how slice works:
 
-    .. code-block:: text
+.. code-block:: text
 
-        Cast1:
-            Given:
-                data = [ [1, 2, 3, 4], [5, 6, 7, 8], ]
-                axes = [0, 1]
-                starts = [1, 0]
-                ends = [2, 3]
-            Then:
-                result = [ [5, 6, 7], ]
+    Case1:
+        Given:
+            data = [ [1, 2, 3, 4], [5, 6, 7, 8], ]
+            axes = [0, 1]
+            starts = [1, 0]
+            ends = [2, 3]
+        Then:
+            result = [ [5, 6, 7], ]
 
-        Cast2:
-            Given:
-                data = [ [1, 2, 3, 4], [5, 6, 7, 8], ]
-                starts = [0, 1]
-                ends = [-1, 1000]
-            Then:
-                result = [ [2, 3, 4], ]
+    Case2:
+        Given:
+            data = [ [1, 2, 3, 4], [5, 6, 7, 8], ]
+            starts = [0, 1]
+            ends = [-1, 1000]
+        Then:
+            result = [ [2, 3, 4], ]
 )DOC");
   }
 };

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -9547,8 +9547,39 @@ def sum(x):
 @templatedoc()
 def slice(input, axes, starts, ends):
     """
-    ${comment}
+    Slice Operator.
 
+    Produces a slice of the input tensor along multiple axes. Similar to numpy:
+    https://docs.scipy.org/doc/numpy/reference/arrays.indexing.html
+    Slice uses `axes`, `starts` and `ends` attributes to specify the start and
+    end dimension for each axis in the list of axes, it uses this information
+    to slice the input data tensor. If a negative value is passed for any of
+    the start or end indices, it represents number of elements before the end
+    of that dimension. If the value passed to start or end is larger than
+    the n (the number of elements in this dimension), it represents n.
+    For slicing to the end of a dimension with unknown size, it is recommended
+    to pass in INT_MAX. The size of axes must be equal to starts\' and ends\'.
+    Following examples will explain how slice works:
+
+    .. code-block:: text
+
+        Case1:
+            Given:
+                data = [ [1, 2, 3, 4], [5, 6, 7, 8], ]
+                axes = [0, 1]
+                starts = [1, 0]
+                ends = [2, 3]
+            Then:
+                result = [ [5, 6, 7], ]
+        
+        Case2:
+            Given:
+                data = [ [1, 2, 3, 4], [5, 6, 7, 8], ]
+                axes = [0, 1]
+                starts = [0, 1]
+                ends = [-1, 1000]
+            Then:
+                result = [ [2, 3, 4], ]
     Args:
         input (Variable): ${input_comment}.
         axes (List): ${axes_comment}


### PR DESCRIPTION
Fixed API doc. In slice op, input 'axes' must have the same length with 'starts' and 'ends', and it can not be omitted.
![image](https://user-images.githubusercontent.com/22989727/58794060-ec6f2980-8629-11e9-95fa-42b6511e377e.png)
![image](https://user-images.githubusercontent.com/22989727/58794071-f3963780-8629-11e9-9fc0-845826fa05cd.png)
