### PR TITLE
Disable cudnn for pool grad

### DIFF
--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -123,9 +123,12 @@ framework::OpKernelType PoolOpGrad::GetExpectedKernelType(
   framework::DataLayout layout_ = framework::StringToDataLayout(data_format);
 
 #ifdef PADDLE_WITH_CUDA
-  if (platform::CanCUDNNBeUsed(ctx)) {
+  // Cudnn pool performance poor, only use cudnn for fp16
+  if (platform::CanCUDNNBeUsed(ctx) &&
+      ctx.Input<Tensor>("X")->type() == framework::proto::VarType::FP16) {
     library_ = framework::LibraryType::kCUDNN;
   }
+
 #endif
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&


### PR DESCRIPTION
cudnnn performance is poor on pool grad, so disable it

test=develop


opt result:

模型SE-Resnext50(examples/s) | 单卡 | 多卡
-- | -- | --
Enaleb cudnngrad pool | 117.768 | 422.306
Disable cudnngrad pool | 157.56 | 423.96

不同模型结果对比：

模型 | resnext50 | Resnet50 | Resnet101 | AlexNet | mobilnet | GoogleNet | VGG11
-- | -- | -- | -- | -- | --| --|--
Enaleb cudnngrad pool | 0.26 | 0.11 | 0.19 | 0.61 | 0.31 | 0.33 | 0.18
Disable cudnngrad pool | 0.19 | 0.11 | 0.18 | 0.61 | 0.31 | 0.32 | 0.18
