### PR TITLE
Remove InstallFailureSignalHandler in init.cc

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -206,9 +206,6 @@ void InitGLOG(const std::string &prog_name) {
   // glog will not hold the ARGV[0] inside.
   // Use strdup to alloc a new string.
   google::InitGoogleLogging(strdup(prog_name.c_str()));
-#ifndef _WIN32
-  google::InstallFailureSignalHandler();
-#endif
 }
 
 #if defined(PADDLE_WITH_DGC)


### PR DESCRIPTION
fix https://github.com/PaddlePaddle/Paddle/issues/16197
In Python scripts, starting multiple processes through the multiprocessing module results in the core appearing when the program exits, I found that this was caused by `InstallFailureSignalHandler()`. And I found that other framework, for example, Mxnet, TF, doesn't use this function.