### PR TITLE
fix requests dependence and uint64_t build error

### DIFF
--- a/paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.h
+++ b/paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 #pragma once
 #include <algorithm>
+#include <stdint.h>
 
 namespace paddle {
 namespace framework {

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.9.2
+requests>=2.18
 numpy>=1.12
 protobuf>=3.1.0
 recordio>=0.1.0


### PR DESCRIPTION
modified paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.h: fix build error of 'uint64_t'
modified python/requirements.txt:  resolve #17815