### PR TITLE
fix bug: the lod_tensor_to_array op will aplly a new var but not release when doing inference.

### DIFF
--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -131,9 +131,7 @@ class LoDTensorToArrayOp : public framework::OperatorBase {
       }
     }
 
-    auto &outputs = *const_cast<framework::Scope &>(scope)
-                         .Var()
-                         ->GetMutable<std::map<size_t, framework::Tensor>>();
+    std::map<size_t, framework::Tensor> outputs;
 
     for (size_t i = 0; i < max_seq_len; ++i) {
       auto &ranges = copy_ranges[i];


### PR DESCRIPTION
The lod_tensor_to_array op will aplly a new var but not release when doing inference.

So the memory will continue to grow when doing the inference.

