### PR TITLE
Close socket connect

### DIFF
--- a/paddle/fluid/imperative/nccl_context.cc
+++ b/paddle/fluid/imperative/nccl_context.cc
@@ -93,6 +93,7 @@ void NCCLParallelContext::SendNCCLID(const std::string &ep,
     send(sock, buffer, NCCL_UNIQUE_ID_BYTES, 0);
     break;
   }
+  close(sock);
 }
 
 void NCCLParallelContext::BcastNCCLId(ncclUniqueId *nccl_id, int root) {


### PR DESCRIPTION
The socket should be closed, before the exit function.