### PR TITLE
Fix the initialization of Anakin subgraph

### DIFF
--- a/paddle/fluid/inference/anakin/engine.h
+++ b/paddle/fluid/inference/anakin/engine.h
@@ -114,12 +114,13 @@ class AnakinEngine {
 
  private:
   bool initialized_{false};
+  int device_;
   int max_batch_size_;
   std::map<std::string, std::vector<int>> max_input_shape_;
-  int device_;
+  std::vector<std::string> program_inputs_;
   std::unique_ptr<GraphT> graph_;
   std::unique_ptr<NetT> net_;
-  std::vector<std::string> program_inputs_;
+  static std::once_flag init_anakin_;
   std::unordered_map<std::string, float> tensor_scales_;
   // Always be false in gpu mode but true in most cpu cases.
   bool auto_config_layout_;

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -369,6 +369,7 @@ float AnalysisConfig::fraction_of_gpu_memory_for_pool() const {
   // Get the GPU memory details and calculate the fraction of memory for the
   // GPU memory pool.
   size_t gpu_used, gpu_available;
+  platform::SetDeviceId(device_id_);
   platform::GpuMemoryUsage(&gpu_used, &gpu_available);
   double total_gpu_memory = (gpu_used + gpu_available) / 1024. / 1024.;
   float fraction_of_gpu_memory =


### PR DESCRIPTION
1. Fixed the memory initialization function to release the memory of the unused graphics cards.
2. Fixed the initialization of the Anakin subgraph to properly use multiple graphics contexts.

test=develop