### PR TITLE
Fix the accuracy issue of float value

### DIFF
--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -429,7 +429,9 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
                                // scale couldn't be calculated
         else
           output_shift_scale[i] =
-              scale_out_data / (scale_in_data * scale_weights_data[i]);
+              static_cast<float>(static_cast<double>(scale_out_data) /
+                                 (static_cast<double>(scale_in_data) *
+                                  static_cast<double>(scale_weights_data[i])));
       }
 
       auto user_src_md =


### PR DESCRIPTION
When we do the scale computing on CasadeLake platform, it will show the accuracy issue and generate the difference value. To improve the precision with double type can resolve it. As the detail, please refer the following test utility and result.

**Sample Code:**
```
#include <stdio.h>

#define max_range 80381.859375
#define scale_factor 3.7194467

#define weight_scale 632.9280395507812
#define src_scale 34.1448631287

void main()
{
  float f_max_range = max_range;
  float f_scale_factor = scale_factor;
  float f_weight_scale = weight_scale;
  float f_src_scale = src_scale;

  float f_faked_oscale = f_scale_factor / f_max_range;
  float f_real_oscale = 1.0 / (f_src_scale * f_weight_scale);
  printf("f_faked_oscale = \t%.15f\n", f_faked_oscale);
  printf("f_real_oscale = \t%.15f\n", f_real_oscale);

  float fd_faked_oscale = (float)((double)f_scale_factor / (double)f_max_range);
  float fd_real_oscale = (float)(1.0 / ((double)f_src_scale * (double)f_weight_scale));
  printf("fd_faked_oscale = \t%.15f\n", fd_faked_oscale);
  printf("fd_real_oscale = \t%.15f\n", fd_real_oscale);
 
}
```
**Result:**
```
f_faked_oscale =        0.000046272216423
f_real_oscale =         0.000046272212785
fd_faked_oscale =       0.000046272216423
fd_real_oscale =        0.000046272216423
```
