### PR TITLE
Fix sync_batch_norm_op ncclallreduce error!

### DIFF
--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -288,15 +288,15 @@ bool ParallelExecutor::NeedCreateLocalExeScope() {
  * polished with a unified nccl management.
  */
 platform::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp(
-    framework::Scope *scope, size_t dev_id) {
+    framework::Scope *scope) {
   auto *nccl_id_var = scope->FindVar(NCCL_ID_VARNAME);
   if (nccl_id_var != nullptr) {
-    auto *nccl_ctx =
-        &member_->nccl_ctxs_.DefaultFlatCtx()->at(member_->places_[dev_id]);
-    return nccl_ctx;
+    return member_->nccl_ctxs_.DefaultFlatCtx();
   }
 
-  dev_nccl_ctxs_.reset(new platform::NCCLContextMap(member_->places_));
+  if (dev_nccl_ctxs_.get() == nullptr) {
+    dev_nccl_ctxs_.reset(new platform::NCCLContextMap(member_->places_));
+  }
   return dev_nccl_ctxs_.get();
 }
 
@@ -376,13 +376,14 @@ ParallelExecutor::ParallelExecutor(const std::vector<platform::Place> &places,
     // NOTE: NCCL group-calls and non-group-calls can not use the same
     // NCCL communicator, so for ParallelGraph and Multi-Process mode, re-use
     // same communicators.
+    auto *nccl_ctxs = GetNCCLContextForSyncbatchNomrOp(scope);
     for (size_t dev_id = 0; dev_id < member_->places_.size(); ++dev_id) {
-      auto *nccl_ctx = GetNCCLContextForSyncbatchNomrOp(scope, dev_id);
       platform::DeviceContextPool &pool =
           platform::DeviceContextPool::Instance();
       auto *dev_ctx = static_cast<platform::CUDADeviceContext *>(
           pool.Get(member_->places_[dev_id]));
-      dev_ctx->set_nccl_comm(nccl_ctx->comm());
+      auto &nccl_ctx = nccl_ctxs->at(member_->places_[dev_id]);
+      dev_ctx->set_nccl_comm(nccl_ctx.comm());
     }
 #endif
   }

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -287,7 +287,8 @@ bool ParallelExecutor::NeedCreateLocalExeScope() {
  * create a new nccl comm for sync_batch_norm_op. And these codes should be
  * polished with a unified nccl management.
  */
-platform::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp() {
+platform::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp(
+    framework::Scope *scope, size_t dev_id) {
   auto *nccl_id_var = scope->FindVar(NCCL_ID_VARNAME);
   if (nccl_id_var != nullptr) {
     auto *nccl_ctx =
@@ -375,8 +376,8 @@ ParallelExecutor::ParallelExecutor(const std::vector<platform::Place> &places,
     // NOTE: NCCL group-calls and non-group-calls can not use the same
     // NCCL communicator, so for ParallelGraph and Multi-Process mode, re-use
     // same communicators.
-    auto *nccl_ctx = GetNCCLContextForSyncbatchNomrOp();
     for (size_t dev_id = 0; dev_id < member_->places_.size(); ++dev_id) {
+      auto *nccl_ctx = GetNCCLContextForSyncbatchNomrOp(scope, dev_id);
       platform::DeviceContextPool &pool =
           platform::DeviceContextPool::Instance();
       auto *dev_ctx = static_cast<platform::CUDADeviceContext *>(

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -281,6 +281,7 @@ bool ParallelExecutor::NeedCreateLocalExeScope() {
   return executor && executor->NeedCreateLocalExeScope();
 }
 
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
 /*
  * When nccl inits nccl comm using ncclCommInitAll, it meets error when
  * allreduce ophandle and sync_batch_norm_op use ncclallreduce parallelly. So
@@ -299,6 +300,7 @@ platform::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp(
   }
   return dev_nccl_ctxs_.get();
 }
+#endif
 
 ParallelExecutor::ParallelExecutor(const std::vector<platform::Place> &places,
                                    const std::vector<std::string> &bcast_vars,

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -287,7 +287,7 @@ bool ParallelExecutor::NeedCreateLocalExeScope() {
  * create a new nccl comm for sync_batch_norm_op. And these codes should be
  * polished with a unified nccl management.
  */
-details::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp() {
+platform::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp() {
   auto *nccl_id_var = scope->FindVar(NCCL_ID_VARNAME);
   if (nccl_id_var != nullptr) {
     auto *nccl_ctx =

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -281,6 +281,24 @@ bool ParallelExecutor::NeedCreateLocalExeScope() {
   return executor && executor->NeedCreateLocalExeScope();
 }
 
+/*
+ * When nccl inits nccl comm using ncclCommInitAll, it meets error when
+ * allreduce ophandle and sync_batch_norm_op use ncclallreduce parallelly. So
+ * create a new nccl comm for sync_batch_norm_op. And these codes should be
+ * polished with a unified nccl management.
+ */
+details::NCCLContextMap *ParallelExecutor::GetNCCLContextForSyncbatchNomrOp() {
+  auto *nccl_id_var = scope->FindVar(NCCL_ID_VARNAME);
+  if (nccl_id_var != nullptr) {
+    auto *nccl_ctx =
+        &member_->nccl_ctxs_.DefaultFlatCtx()->at(member_->places_[dev_id]);
+    return nccl_ctx;
+  }
+
+  dev_nccl_ctxs_.reset(new platform::NCCLContextMap(member_->places_));
+  return dev_nccl_ctxs_.get();
+}
+
 ParallelExecutor::ParallelExecutor(const std::vector<platform::Place> &places,
                                    const std::vector<std::string> &bcast_vars,
                                    const std::string &loss_var_name,
@@ -357,14 +375,13 @@ ParallelExecutor::ParallelExecutor(const std::vector<platform::Place> &places,
     // NOTE: NCCL group-calls and non-group-calls can not use the same
     // NCCL communicator, so for ParallelGraph and Multi-Process mode, re-use
     // same communicators.
+    auto *nccl_ctx = GetNCCLContextForSyncbatchNomrOp();
     for (size_t dev_id = 0; dev_id < member_->places_.size(); ++dev_id) {
       platform::DeviceContextPool &pool =
           platform::DeviceContextPool::Instance();
       auto *dev_ctx = static_cast<platform::CUDADeviceContext *>(
           pool.Get(member_->places_[dev_id]));
-      auto &nccl_ctx =
-          member_->nccl_ctxs_.DefaultFlatCtx()->at(member_->places_[dev_id]);
-      dev_ctx->set_nccl_comm(nccl_ctx.comm());
+      dev_ctx->set_nccl_comm(nccl_ctx->comm());
     }
 #endif
   }

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -87,7 +87,10 @@ class ParallelExecutor {
 
   ParallelExecutorPrivate *member_;
   std::vector<std::unique_ptr<ir::Graph>> async_graphs_;
-};
 
+  // used for compatible with syncbatch norm op
+  std::unique_ptr<platform::NCCLContextMap> dev_nccl_ctxs_;
+  platform::NCCLContextMap *GetNCCLContextForSyncbatchNomrOp();
+};
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -91,7 +91,7 @@ class ParallelExecutor {
   // used for compatible with syncbatch norm op
   std::unique_ptr<platform::NCCLContextMap> dev_nccl_ctxs_;
   platform::NCCLContextMap *GetNCCLContextForSyncbatchNomrOp(
-      framework::Scope *scope);
+      framework::Scope *scope, size_t dev_id);
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -90,7 +90,8 @@ class ParallelExecutor {
 
   // used for compatible with syncbatch norm op
   std::unique_ptr<platform::NCCLContextMap> dev_nccl_ctxs_;
-  platform::NCCLContextMap *GetNCCLContextForSyncbatchNomrOp();
+  platform::NCCLContextMap *GetNCCLContextForSyncbatchNomrOp(
+      framework::Scope *scope);
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -88,10 +88,12 @@ class ParallelExecutor {
   ParallelExecutorPrivate *member_;
   std::vector<std::unique_ptr<ir::Graph>> async_graphs_;
 
+#if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
   // used for compatible with syncbatch norm op
   std::unique_ptr<platform::NCCLContextMap> dev_nccl_ctxs_;
   platform::NCCLContextMap *GetNCCLContextForSyncbatchNomrOp(
       framework::Scope *scope);
+#endif
 };
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -91,7 +91,7 @@ class ParallelExecutor {
   // used for compatible with syncbatch norm op
   std::unique_ptr<platform::NCCLContextMap> dev_nccl_ctxs_;
   platform::NCCLContextMap *GetNCCLContextForSyncbatchNomrOp(
-      framework::Scope *scope, size_t dev_id);
+      framework::Scope *scope);
 };
 }  // namespace framework
 }  // namespace paddle


### PR DESCRIPTION
**Fix sync_batch_norm_op ncclallreduce error**
When nccl inits nccl comm using ncclCommInitAll, it meets error when allreduce ophandle and sync_batch_norm_op use ncclallreduce parallelly. So create a new nccl comm for sync_batch_norm_op. And these codes should be polished with a unified nccl management.

Fix https://github.com/PaddlePaddle/models/issues/2338