### PR TITLE
Add lod check for some multiple-input ops

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -134,15 +134,15 @@ def __bootstrap__():
     os.environ['OMP_NUM_THREADS'] = str(num_threads)
     sysstr = platform.system()
     read_env_flags = [
-        'check_nan_inf', 'benchmark', 'eager_delete_scope',
-        'initial_cpu_memory_in_mb', 'init_allocated_mem', 'free_idle_memory',
-        'paddle_num_threads', "dist_threadpool_size", 'eager_delete_tensor_gb',
-        'fast_eager_deletion_mode', 'memory_fraction_of_eager_deletion',
-        'allocator_strategy', 'reader_queue_speed_test_mode',
-        'print_sub_graph_dir', 'pe_profile_fname', 'inner_op_parallelism',
-        'enable_parallel_graph', 'fuse_parameter_groups_size',
-        'multiple_of_cupti_buffer_size', 'fuse_parameter_memory_size',
-        'tracer_profile_fname'
+        'check_nan_inf', 'check_multi_src_lods', 'benchmark',
+        'eager_delete_scope', 'initial_cpu_memory_in_mb', 'init_allocated_mem',
+        'free_idle_memory', 'paddle_num_threads', "dist_threadpool_size",
+        'eager_delete_tensor_gb', 'fast_eager_deletion_mode',
+        'memory_fraction_of_eager_deletion', 'allocator_strategy',
+        'reader_queue_speed_test_mode', 'print_sub_graph_dir',
+        'pe_profile_fname', 'inner_op_parallelism', 'enable_parallel_graph',
+        'fuse_parameter_groups_size', 'multiple_of_cupti_buffer_size',
+        'fuse_parameter_memory_size', 'tracer_profile_fname'
     ]
     if 'Darwin' not in sysstr:
         read_env_flags.append('use_pinned_memory')


### PR DESCRIPTION
Example:

```
import numpy as np
import paddle.fluid as fluid

x = fluid.layers.data(name="X", shape=[-1, 2], lod_level=1, dtype="float32")
y = fluid.layers.data(name="Y", shape=[-1, 2], lod_level=1, dtype="float32")
z = fluid.layers.data(name="Z", shape=[-1, 2], lod_level=1, dtype="float32")

add_xy = x + y
add_xz = x + z

sum_xy = fluid.layers.sums(input=[x, y])
sum_xz = fluid.layers.sums(input=[x, z])

concat_xy = fluid.layers.concat(input=[x, y])
concat_xz = fluid.layers.concat(input=[x, z])

place = fluid.CPUPlace()
exe = fluid.Executor(place)
data = np.random.random((13, 2)).astype("float32")

# same data, but y has different lod
x_dat = fluid.create_lod_tensor(data, [[3, 10]], place)
y_dat = fluid.create_lod_tensor(data, [[5, 3, 5]], place)
z_dat = fluid.create_lod_tensor(data, [[3, 10]], place)

outputs = exe.run(feed={"X": x_dat, "Y": y_dat, "Z": z_dat},
                  fetch_list=[add_xy.name, sum_xy.name, concat_xy.name],
                  return_numpy=False)

```
Enable lod check
```
export FLAGS_check_multi_src_lods=1
```
Output
```
W0609 17:19:49.547400 16726 operator.cc:903] The input LoDTensors of OP[elementwise_add] doesn't have identical LoDs. Tensor X's LoD: {{0, 3, 13}} vs. Tensor Y's LoD: {{0, 5, 8, 13}}.
W0609 17:19:49.547768 16726 operator.cc:903] The input LoDTensors of OP[sum] doesn't have identical LoDs. Tensor X's LoD: {{0, 3, 13}} vs. Tensor Y's LoD: {{0, 5, 8, 13}}.
W0609 17:19:49.547827 16726 operator.cc:903] The input LoDTensors of OP[concat] doesn't have identical LoDs. Tensor X's LoD: {{0, 3, 13}} vs. Tensor Y's LoD: {{0, 5, 8, 13}}.
```