### PR TITLE
fix bug when iterate in locals_var.items() in python3

### DIFF
--- a/python/paddle/fluid/layers/ops.py
+++ b/python/paddle/fluid/layers/ops.py
@@ -89,7 +89,7 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0):
 
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
-    locals_var = locals()
+    locals_var = locals().copy()
     kwargs = dict()
     for name, val in locals_var.items():
         if val is not None:
@@ -103,7 +103,7 @@ _hard_shrink_ = generate_layer_fn('hard_shrink')
 
 
 def hard_shrink(x, threshold=None):
-    locals_var = locals()
+    locals_var = locals().copy()
     kwargs = dict()
     for name, val in locals_var.items():
         if val is not None:
@@ -124,7 +124,7 @@ _cum_sum_ = generate_layer_fn('cumsum')
 
 
 def cumsum(x, axis=None, exclusive=None, reverse=None):
-    locals_var = locals()
+    locals_var = locals().copy()
     kwargs = dict()
     for name, val in locals_var.items():
         if val is not None:
@@ -145,7 +145,7 @@ _thresholded_relu_ = generate_layer_fn('thresholded_relu')
 
 
 def thresholded_relu(x, threshold=None):
-    locals_var = locals()
+    locals_var = locals().copy()
     kwargs = dict()
     for name, val in locals_var.items():
         if val is not None:


### PR DESCRIPTION
for the codes in python/paddle/fluid/layers/ops.py, in several functions as following. It will lead to a mistake when run in python3 because locals_var.items() is of type dict_items, which can't be modified during iteration. But the code like "kwargs[name] = val" in the for loop will change locals() and lead to change in locals_var.items(). To solve this problem, just use locals_var = locals().copy() instead.

def hard_shrink(x, threshold=None):
    locals_var = locals() 
    kwargs = dict()
    for name, val in locals_var.items():
        if val is not None:
            kwargs[name] = val
    return _hard_shrink_(**kwargs)