### PR TITLE
fix merge conflict of 'Remove attribute in Allocator::Allocate' and elementwise_add_mkldnn_op

### DIFF
--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -70,8 +70,7 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
         auto x_memory_pd = memory::primitive_desc(
             {{src_x_tz}, memory::data_type::f32, format}, mkldnn_engine);
         auto size = x_memory_pd.get_size();
-        _x.mutable_data<T>(ctx.GetPlace(), paddle::memory::Allocator::kDefault,
-                           size);
+        _x.mutable_data<T>(ctx.GetPlace(), size);
         auto user_x_memory =
             memory(user_x_memory_pd, paddle::platform::to_void_cast<T>(x_data));
         auto x_memory = memory(x_memory_pd,


### PR DESCRIPTION
compile error:
```
/Paddle/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc: In member function ‘void paddle::operators::EltwiseAddMKLDNNKernel<T>::Compute(const paddle::framework::ExecutionContext&) const’:
/Paddle/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc:73:44: error: ‘kDefault’ is not a member of ‘paddle::memory::allocation::Allocator’
         _x.mutable_data<T>(ctx.GetPlace(), paddle::memory::Allocator::kDefault,
```
conflict by #17878 and #17833 