### PR TITLE
[MKL-DNN] Thread-Safety for MKL-DNN reusing Part 1

### DIFF
--- a/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
@@ -65,21 +65,21 @@ class BatchNormMKLDNNHandler : public platform::MKLDNNHandler {
     // may be executed by diffrent thread, hence
     // for that one we use key that does not contain TID
     const std::string key_batch_norm_fwd_pd = key_common_ + "@bn_fwd_pd";
-    batch_norm_pd_ =
-        std::static_pointer_cast<batch_norm_fwd::primitive_desc>(
-            dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
+    batch_norm_pd_ = std::static_pointer_cast<batch_norm_fwd::primitive_desc>(
+        dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
 
     if (batch_norm_pd_ == nullptr) {
       static std::mutex acquire_barrier;
-      std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
-      batch_norm_pd_ = std::static_pointer_cast<batch_norm_fwd::primitive_desc>(dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
+      std::lock_guard<std::mutex> block_threads_until_finish_this_job(
+          acquire_barrier);
+      batch_norm_pd_ = std::static_pointer_cast<batch_norm_fwd::primitive_desc>(
+          dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
       if (batch_norm_pd_ == nullptr) {
         batch_norm_pd_.reset(
             new batch_norm_fwd::primitive_desc(bn_fwd_desc, engine));
         dev_ctx_.SetBlob(key_batch_norm_fwd_pd, batch_norm_pd_);
       }
-
-    } 
+    }
     return batch_norm_pd_;
   }
 

--- a/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
@@ -72,7 +72,6 @@ class BatchNormMKLDNNHandler : public platform::MKLDNNHandler {
       dev_ctx_.SetBlob(key_batch_norm_fwd_pd, batch_norm_pd_);
     } else {
       batch_norm_pd_ = batch_norm_pd;
-      is_reusing_ = true;
     }
 
     return batch_norm_pd_;
@@ -86,9 +85,6 @@ class BatchNormMKLDNNHandler : public platform::MKLDNNHandler {
     auto prim_key = key_ + "@batch_norm_p";
     auto batch_norm_p =
         std::static_pointer_cast<batch_norm_fwd>(dev_ctx_.GetBlob(prim_key));
-
-    PADDLE_ENFORCE((batch_norm_p != nullptr) || !is_reusing_,
-                   "Fail to find batch norm primitive in device context");
 
     if (batch_norm_p == nullptr) {
       if (is_test) {
@@ -104,8 +100,6 @@ class BatchNormMKLDNNHandler : public platform::MKLDNNHandler {
       }
 
       dev_ctx_.SetBlob(prim_key, batch_norm_p);
-    } else {
-      is_reusing_ = true;
     }
 
     return batch_norm_p;

--- a/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
@@ -65,24 +65,21 @@ class BatchNormMKLDNNHandler : public platform::MKLDNNHandler {
     // may be executed by diffrent thread, hence
     // for that one we use key that does not contain TID
     const std::string key_batch_norm_fwd_pd = key_common_ + "@bn_fwd_pd";
-    auto batch_norm_pd =
+    batch_norm_pd_ =
         std::static_pointer_cast<batch_norm_fwd::primitive_desc>(
             dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
 
-    if (batch_norm_pd == nullptr) {
+    if (batch_norm_pd_ == nullptr) {
       static std::mutex acquire_barrier;
       std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
-      batch_norm_pd = std::static_pointer_cast<batch_norm_fwd::primitive_desc>(dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
-      if (batch_norm_pd == nullptr) {
+      batch_norm_pd_ = std::static_pointer_cast<batch_norm_fwd::primitive_desc>(dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
+      if (batch_norm_pd_ == nullptr) {
         batch_norm_pd_.reset(
             new batch_norm_fwd::primitive_desc(bn_fwd_desc, engine));
         dev_ctx_.SetBlob(key_batch_norm_fwd_pd, batch_norm_pd_);
       }
 
-    } else {
-      batch_norm_pd_ = batch_norm_pd;
-    }
-
+    } 
     return batch_norm_pd_;
   }
 

--- a/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
@@ -61,15 +61,24 @@ class BatchNormMKLDNNHandler : public platform::MKLDNNHandler {
   std::shared_ptr<batch_norm_fwd::primitive_desc>
   AcquireBatchNormPrimitiveDescriptor(const batch_norm_fwd::desc &bn_fwd_desc,
                                       const mkldnn::engine &engine) {
-    const std::string key_batch_norm_fwd_pd = key_ + "@bn_fwd_pd";
+    // BatchNorm PD has to be passed to Grad op that
+    // may be executed by diffrent thread, hence
+    // for that one we use key that does not contain TID
+    const std::string key_batch_norm_fwd_pd = key_common_ + "@bn_fwd_pd";
     auto batch_norm_pd =
         std::static_pointer_cast<batch_norm_fwd::primitive_desc>(
             dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
 
     if (batch_norm_pd == nullptr) {
-      batch_norm_pd_.reset(
-          new batch_norm_fwd::primitive_desc(bn_fwd_desc, engine));
-      dev_ctx_.SetBlob(key_batch_norm_fwd_pd, batch_norm_pd_);
+      static std::mutex acquire_barrier;
+      std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
+      batch_norm_pd = std::static_pointer_cast<batch_norm_fwd::primitive_desc>(dev_ctx_.GetBlob(key_batch_norm_fwd_pd));
+      if (batch_norm_pd == nullptr) {
+        batch_norm_pd_.reset(
+            new batch_norm_fwd::primitive_desc(bn_fwd_desc, engine));
+        dev_ctx_.SetBlob(key_batch_norm_fwd_pd, batch_norm_pd_);
+      }
+
     } else {
       batch_norm_pd_ = batch_norm_pd;
     }

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -65,7 +65,6 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
       dev_ctx_.SetBlob(key_softmax_pd, softmax_pd_);
     } else {
       softmax_pd_ = softmax_pd;
-      is_reusing_ = true;
     }
 
     return softmax_pd_;
@@ -79,15 +78,11 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
 
     auto softmax_p = std::static_pointer_cast<mkldnn::softmax_forward>(
         dev_ctx_.GetBlob(prim_key));
-    PADDLE_ENFORCE((softmax_p != nullptr) || (is_reusing_ == false),
-                   "Fail to find softmax primitive in device context");
     if (softmax_p == nullptr) {
       softmax_p = std::make_shared<mkldnn::softmax_forward>(
           *softmax_pd_, *(static_cast<mkldnn::memory*>(src_memory_p.get())),
           *(static_cast<mkldnn::memory*>(dst_memory_p.get())));
       dev_ctx_.SetBlob(prim_key, softmax_p);
-    } else {
-      is_reusing_ = true;
     }
 
     return softmax_p;
@@ -100,16 +95,12 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
     auto prim_key = key_ + "@softmax_bwd_p";
     auto softmax_bwd_p = std::static_pointer_cast<mkldnn::softmax_backward>(
         dev_ctx_.GetBlob(prim_key));
-    PADDLE_ENFORCE((softmax_bwd_p != nullptr) || (is_reusing_ == false),
-                   "Fail to find softmax backward primitive in device context");
     if (softmax_bwd_p == nullptr) {
       softmax_bwd_p = std::make_shared<mkldnn::softmax_backward>(
           *softmax_bwd_pd_, *dst_memory_p, *diff_dst_memory_p,
           *diff_src_memory_p);
       dev_ctx_.SetBlob(prim_key, softmax_bwd_p);
-    } else {
-      is_reusing_ = true;
-    }
+    } 
 
     return softmax_bwd_p;
   }

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -63,15 +63,16 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
         dev_ctx_.GetBlob(key_softmax_pd));
     if (softmax_pd_ == nullptr) {
       static std::mutex acquire_barrier;
-      std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
+      std::lock_guard<std::mutex> block_threads_until_finish_this_job(
+          acquire_barrier);
       softmax_pd_ = std::static_pointer_cast<softmax_forward::primitive_desc>(
-        dev_ctx_.GetBlob(key_softmax_pd));
+          dev_ctx_.GetBlob(key_softmax_pd));
       if (softmax_pd_ == nullptr) {
         softmax_pd_.reset(
             new softmax_forward::primitive_desc(softmax_desc, engine));
         dev_ctx_.SetBlob(key_softmax_pd, softmax_pd_);
       }
-    } 
+    }
 
     return softmax_pd_;
   }
@@ -106,7 +107,7 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
           *softmax_bwd_pd_, *dst_memory_p, *diff_dst_memory_p,
           *diff_src_memory_p);
       dev_ctx_.SetBlob(prim_key, softmax_bwd_p);
-    } 
+    }
 
     return softmax_bwd_p;
   }

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -55,7 +55,7 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
   AcquireSoftmaxPrimitiveDescriptor(const softmax_forward::desc& softmax_desc,
                                     const mkldnn::engine& engine) {
     // Softmax PD has to be passed to Grad op that
-    // may be exxecuted by diffrent thread, hence
+    // may be executed by diffrent thread, hence
     // for that one we use key that does not contain TID
     const std::string key_softmax_pd = key_common_ + "@softmax_pd";
 

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -59,21 +59,19 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
     // for that one we use key that does not contain TID
     const std::string key_softmax_pd = key_common_ + "@softmax_pd";
 
-    auto softmax_pd = std::static_pointer_cast<softmax_forward::primitive_desc>(
+    softmax_pd_ = std::static_pointer_cast<softmax_forward::primitive_desc>(
         dev_ctx_.GetBlob(key_softmax_pd));
-    if (softmax_pd == nullptr) {
+    if (softmax_pd_ == nullptr) {
       static std::mutex acquire_barrier;
       std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
-      softmax_pd = std::static_pointer_cast<softmax_forward::primitive_desc>(
+      softmax_pd_ = std::static_pointer_cast<softmax_forward::primitive_desc>(
         dev_ctx_.GetBlob(key_softmax_pd));
-      if (softmax_pd == nullptr) {
+      if (softmax_pd_ == nullptr) {
         softmax_pd_.reset(
             new softmax_forward::primitive_desc(softmax_desc, engine));
         dev_ctx_.SetBlob(key_softmax_pd, softmax_pd_);
       }
-    } else {
-      softmax_pd_ = softmax_pd;
-    }
+    } 
 
     return softmax_pd_;
   }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -33,7 +33,14 @@ class MKLDNNHandler {
                 const std::string& base_key)
       : dev_ctx_(dev_ctx),
         engine_(engine),
-        key_(base_key) {}
+        key_common_(base_key) 
+      {
+        // TODO(jczaja): Make it faster
+        auto tid = this_thread.get_id();
+        stringstream ss;
+        ss << tid;
+        key_ = key_common_ + "-t:" + ss.str();
+      }
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemory(
       const mkldnn::memory::desc& md, void* ptr) {
@@ -254,6 +261,7 @@ class MKLDNNHandler {
   const MKLDNNDeviceContext& dev_ctx_;
   mkldnn::engine engine_;
   std::string key_;
+  std::string key_common_;
 
  public:
   static constexpr int MaxKeyLength = 256;

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -671,16 +671,16 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
     // for that one we use key that does not contain TID
     const std::string key_conv_pd = key_common_ + "@conv_pd";
 
-    auto conv_pd = std::static_pointer_cast<typename forward_t::primitive_desc>(
+    conv_pd_ = std::static_pointer_cast<typename forward_t::primitive_desc>(
         dev_ctx_.GetBlob(key_conv_pd));
 
-    if (conv_pd == nullptr) {
+    if (conv_pd_ == nullptr) {
       static std::mutex acquire_barrier;
       std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
 
-      conv_pd = std::static_pointer_cast<typename forward_t::primitive_desc>(
+      conv_pd_ = std::static_pointer_cast<typename forward_t::primitive_desc>(
         dev_ctx_.GetBlob(key_conv_pd));
-      if (conv_pd == nullptr) {
+      if (conv_pd_ == nullptr) {
 
         mkldnn::memory::dims stride_dims = strides;
         mkldnn::memory::dims padding_dims = paddings;
@@ -703,9 +703,7 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
         // Save conv_pd/src_memory/weights_memory for backward pass
         dev_ctx_.SetBlob(key_conv_pd, conv_pd_);
       }
-    } else {
-      conv_pd_ = conv_pd;
-    }
+    } 
 
     return conv_pd_;
   }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -15,6 +15,7 @@ limitations under the License. */
 
 #include <memory>
 #include <string>
+#include <sstream>
 #include <vector>
 #include "boost/optional.hpp"
 #include "paddle/fluid/framework/data_layout_transform.h"

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -14,8 +14,8 @@ limitations under the License. */
 #pragma once
 
 #include <memory>
-#include <string>
 #include <sstream>
+#include <string>
 #include <vector>
 #include "boost/optional.hpp"
 #include "paddle/fluid/framework/data_layout_transform.h"
@@ -32,16 +32,13 @@ class MKLDNNHandler {
  public:
   MKLDNNHandler(const MKLDNNDeviceContext& dev_ctx, mkldnn::engine engine,
                 const std::string& base_key)
-      : dev_ctx_(dev_ctx),
-        engine_(engine),
-        key_common_(base_key) 
-      {
-        // TODO(jczaja): Make it faster
-        auto tid = std::this_thread::get_id();
-        std::stringstream ss;
-        ss << tid;
-        key_ = key_common_ + "-t:" + ss.str();
-      }
+      : dev_ctx_(dev_ctx), engine_(engine), key_common_(base_key) {
+    // TODO(jczaja): Make it faster
+    auto tid = std::this_thread::get_id();
+    std::stringstream ss;
+    ss << tid;
+    key_ = key_common_ + "-t:" + ss.str();
+  }
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemory(
       const mkldnn::memory::desc& md, void* ptr) {
@@ -676,34 +673,34 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
 
     if (conv_pd_ == nullptr) {
       static std::mutex acquire_barrier;
-      std::lock_guard<std::mutex> block_threads_until_finish_this_job(acquire_barrier);
+      std::lock_guard<std::mutex> block_threads_until_finish_this_job(
+          acquire_barrier);
 
       conv_pd_ = std::static_pointer_cast<typename forward_t::primitive_desc>(
-        dev_ctx_.GetBlob(key_conv_pd));
+          dev_ctx_.GetBlob(key_conv_pd));
       if (conv_pd_ == nullptr) {
-
         mkldnn::memory::dims stride_dims = strides;
         mkldnn::memory::dims padding_dims = paddings;
 
         auto conv_desc =
             bias ? typename forward_t::desc(
-                       fwd_prop_kind, convolutional_algorithm<forward_t>::T, src,
-                       weights, *bias, dst, stride_dims, padding_dims,
+                       fwd_prop_kind, convolutional_algorithm<forward_t>::T,
+                       src, weights, *bias, dst, stride_dims, padding_dims,
                        padding_dims, mkldnn::padding_kind::zero)
                  : typename forward_t::desc(
-                       fwd_prop_kind, convolutional_algorithm<forward_t>::T, src,
-                       weights, dst, stride_dims, padding_dims, padding_dims,
-                       mkldnn::padding_kind::zero);
+                       fwd_prop_kind, convolutional_algorithm<forward_t>::T,
+                       src, weights, dst, stride_dims, padding_dims,
+                       padding_dims, mkldnn::padding_kind::zero);
 
         mkldnn::primitive_attr conv_attr = CreatePostOps(
             fuse_relu, fuse_residual_conn, fuse_brelu, fuse_brelu_threshold);
 
-        conv_pd_.reset(
-            new typename forward_t::primitive_desc(conv_desc, conv_attr, engine));
+        conv_pd_.reset(new typename forward_t::primitive_desc(
+            conv_desc, conv_attr, engine));
         // Save conv_pd/src_memory/weights_memory for backward pass
         dev_ctx_.SetBlob(key_conv_pd, conv_pd_);
       }
-    } 
+    }
 
     return conv_pd_;
   }
@@ -755,7 +752,7 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
           *conv_bwd_weights_pd_, *src_memory_p, *diff_dst_memory_p,
           *diff_weights_memory_p);
       dev_ctx_.SetBlob(prim_key, conv_bwd_weights_p);
-    } 
+    }
     return conv_bwd_weights_p;
   }
 

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -37,8 +37,8 @@ class MKLDNNHandler {
         key_common_(base_key) 
       {
         // TODO(jczaja): Make it faster
-        auto tid = this_thread.get_id();
-        stringstream ss;
+        auto tid = std::this_thread::get_id();
+        std::stringstream ss;
         ss << tid;
         key_ = key_common_ + "-t:" + ss.str();
       }


### PR DESCRIPTION
This PR adress the issue reported in #17611 by making Reusing concept thread safe. Currently only
part of ops were adapted. After sorting out an issue #17960  additional PR for Relu, pooling and INT8 prims will be raised.

@luotao1 I have updated this branch couple of hours ago, so please double check if this PR works for you. If ContentDNN is not working then it means that Relu and other missing ops has to be updated as well. Anyway please share error messages if any.