### PR TITLE
Optimize the concat and split cuda implementation for cases when the number of inputs/outputs is less than 5

### DIFF
--- a/paddle/fluid/operators/math/concat_and_split.cu
+++ b/paddle/fluid/operators/math/concat_and_split.cu
@@ -78,6 +78,33 @@ __global__ void ConcatKernel(const T* input_addr0, const T* input_addr1,
 }
 
 template <typename T>
+__global__ void ConcatKernel(const T* input_addr0, const T* input_addr1,
+                             const T* input_addr2, const int fixed_in_col,
+                             const int out_rows, const int out_cols,
+                             T* output_data) {
+  const T* inputs_data[3];
+  inputs_data[0] = input_addr0;
+  inputs_data[1] = input_addr1;
+  inputs_data[2] = input_addr2;
+  ConcatKernelDetail<T>(inputs_data, fixed_in_col, out_rows, out_cols,
+                        output_data);
+}
+
+template <typename T>
+__global__ void ConcatKernel(const T* input_addr0, const T* input_addr1,
+                             const T* input_addr2, const T* input_addr3,
+                             const int fixed_in_col, const int out_rows,
+                             const int out_cols, T* output_data) {
+  const T* inputs_data[4];
+  inputs_data[0] = input_addr0;
+  inputs_data[1] = input_addr1;
+  inputs_data[2] = input_addr2;
+  inputs_data[3] = input_addr3;
+  ConcatKernelDetail<T>(inputs_data, fixed_in_col, out_rows, out_cols,
+                        output_data);
+}
+
+template <typename T>
 __global__ void ConcatKernel(const T** inputs_data, const int in_num,
                              const int fixed_in_col, const int out_rows,
                              const int out_cols, T* output_data) {
@@ -147,6 +174,31 @@ __global__ void SplitKernel(const T* input_data, const int in_row,
   SplitKernelDetail<T>(input_data, in_row, in_col, fixed_out_col, outputs_data);
 }
 
+template <typename T>
+__global__ void SplitKernel(const T* input_data, const int in_row,
+                            const int in_col, const int fixed_out_col,
+                            T* outputs_addr0, T* outputs_addr1,
+                            T* outputs_addr2) {
+  T* outputs_data[3];
+  outputs_data[0] = outputs_addr0;
+  outputs_data[1] = outputs_addr1;
+  outputs_data[2] = outputs_addr2;
+  SplitKernelDetail<T>(input_data, in_row, in_col, fixed_out_col, outputs_data);
+}
+
+template <typename T>
+__global__ void SplitKernel(const T* input_data, const int in_row,
+                            const int in_col, const int fixed_out_col,
+                            T* outputs_addr0, T* outputs_addr1,
+                            T* outputs_addr2, T* outputs_addr3) {
+  T* outputs_data[4];
+  outputs_data[0] = outputs_addr0;
+  outputs_data[1] = outputs_addr1;
+  outputs_data[2] = outputs_addr2;
+  outputs_data[3] = outputs_addr3;
+  SplitKernelDetail<T>(input_data, in_row, in_col, fixed_out_col, outputs_data);
+}
+
 static inline void GetBlockDims(const platform::CUDADeviceContext& context,
                                 int num_rows, int num_cols, dim3* block_dims,
                                 dim3* grid_dims) {
@@ -210,7 +262,7 @@ class ConcatFunctor<platform::CUDADeviceContext, T> {
 
     memory::allocation::AllocationPtr tmp_dev_ins_data;
     const T** dev_ins_data = nullptr;
-    if (!has_same_shape || (in_num != 2)) {
+    if (!has_same_shape || in_num < 2 || in_num > 4) {
       tmp_dev_ins_data =
           platform::DeviceTemporaryAllocator::Instance().Get(context).Allocate(
               inputs_data.size() * sizeof(T*));
@@ -226,6 +278,14 @@ class ConcatFunctor<platform::CUDADeviceContext, T> {
         ConcatKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
             inputs_data[0], inputs_data[1], in_col, out_row, out_col,
             output->data<T>());
+      } else if (in_num == 3) {
+        ConcatKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
+            inputs_data[0], inputs_data[1], inputs_data[2], in_col, out_row,
+            out_col, output->data<T>());
+      } else if (in_num == 4) {
+        ConcatKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
+            inputs_data[0], inputs_data[1], inputs_data[2], inputs_data[3],
+            in_col, out_row, out_col, output->data<T>());
       } else {
         ConcatKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
             dev_ins_data, in_num, in_col, out_row, out_col, output->data<T>());
@@ -294,7 +354,7 @@ class SplitFunctor<platform::CUDADeviceContext, T> {
 
     memory::allocation::AllocationPtr tmp_dev_outs_data;
     T** dev_out_gpu_data = nullptr;
-    if (!has_same_shape || (o_num != 2)) {
+    if (!has_same_shape || o_num < 2 || o_num > 4) {
       tmp_dev_outs_data =
           platform::DeviceTemporaryAllocator::Instance().Get(context).Allocate(
               outputs_data.size() * sizeof(T*));
@@ -310,6 +370,14 @@ class SplitFunctor<platform::CUDADeviceContext, T> {
         SplitKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
             input.data<T>(), in_row, in_col, out0_col, outputs_data[0],
             outputs_data[1]);
+      } else if (o_num == 3) {
+        SplitKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
+            input.data<T>(), in_row, in_col, out0_col, outputs_data[0],
+            outputs_data[1], outputs_data[2]);
+      } else if (o_num == 4) {
+        SplitKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
+            input.data<T>(), in_row, in_col, out0_col, outputs_data[0],
+            outputs_data[1], outputs_data[2], outputs_data[3]);
       } else {
         SplitKernel<<<grid_dims, block_dims, 0, context.stream()>>>(
             input.data<T>(), in_row, in_col, out0_col, dev_out_gpu_data);


### PR DESCRIPTION
I test this PR in PaddingRNN static small model.

- Before
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
concat                               840         28.735      27.255975 (0.948527)    1.479074 (0.051473)     0.0216      0.110421    0.0342084   0.0741009   
GpuMemcpyAsync:CPU->GPU              920         22.21       20.542034 (0.924902)    1.667925 (0.075098)     0.009919    10.0025     0.0241413   0.0572742   
split                                410         17.5877     16.903355 (0.961092)    0.684304 (0.038908)     0.034487    0.093865    0.0428967   0.0453544   
concat_grad                          410         12.7032     11.856577 (0.933350)    0.846667 (0.066650)     0.023675    0.090636    0.0309835   0.0327587 
```

- After
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
concat                               840         21.555      19.939527 (0.925053)    1.615477 (0.074947)     0.020565    0.117455    0.0256607   0.0680266     
split                                410         11.6328     10.803320 (0.928696)    0.829464 (0.071304)     0.023688    0.129473    0.0283726   0.0367125   
concat_grad                          410         11.3794     10.531710 (0.925511)    0.847642 (0.074489)     0.022291    0.089757    0.0277545   0.0359127  
GpuMemcpyAsync:CPU->GPU              120         2.10425     1.868308 (0.887872)     0.235946 (0.112128)     0.01087     0.082419    0.0175355   0.00664093  
```

But the codes are quite ugly, I will refine them in next PR.