### PR TITLE
Fix bug in sequence_unpad op

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_unpad_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_unpad_op.h
@@ -33,7 +33,6 @@ class SequenceUnpadOpKernel : public framework::OpKernel<T> {
     auto* x_t = ctx.Input<LoDTensor>("X");
     auto* len_t = ctx.Input<LoDTensor>("Length");
     auto* out_t = ctx.Output<LoDTensor>("Out");
-    out_t->mutable_data<T>(ctx.GetPlace());
 
     const int64_t* seq_len_ptr = nullptr;
     if (platform::is_gpu_place(ctx.GetPlace())) {
@@ -66,6 +65,9 @@ class SequenceUnpadOpKernel : public framework::OpKernel<T> {
       }
     }
     out_t->Resize(framework::make_ddim(out_dims_vec));
+
+    // after set the lod of output, allocate the memory
+    out_t->mutable_data<T>(ctx.GetPlace());
 
     int64_t padded_length = x_t->dims()[1];
     math::UnpaddingLoDTensorFunctor<DeviceContext, T>()(


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/17955

Fix bug in sequence_unpad op, when allocate the output memory do not match actual memory, check memory failed. Fix this bug by allocating the output memeory in correct code position.