### PR TITLE
add check of executor

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -179,9 +179,6 @@ def save_vars(executor,
     """
     save_dirname = os.path.normpath(dirname)
 
-    if not isinstance(executor, Executor):
-        raise TypeError("executor should be as Executor")
-
     if vars is None:
         if main_program is None:
             main_program = default_main_program()
@@ -432,9 +429,6 @@ def _save_distributed_persistables(executor, dirname, main_program):
     if not isinstance(main_program, Program):
         raise TypeError("'main_program' should be an instance of Program.")
 
-    if not isinstance(executor, Executor):
-        raise TypeError("executor should be as Executor")
-
     if not main_program._is_distributed:
         raise ValueError(
             "'_save_distributed_persistables' just be designed for distributed training."
@@ -603,9 +597,6 @@ def load_vars(executor,
     """
     load_dirname = os.path.normpath(dirname)
 
-    if not isinstance(executor, Executor):
-        raise TypeError("executor should be as Executor")
-
     if vars is None:
         if main_program is None:
             main_program = default_main_program()
@@ -624,6 +615,7 @@ def load_vars(executor,
 
         if main_program is None:
             main_program = default_main_program()
+
         if not isinstance(main_program, Program):
             raise TypeError("program should be as Program type or None")
 
@@ -858,9 +850,6 @@ def _load_distributed_persistables(executor, dirname, main_program=None):
 
     if not isinstance(main_program, Program):
         raise TypeError("'main_program' should be an instance of Program.")
-
-    if not isinstance(executor, Executor):
-        raise TypeError("executor should be as Executor")
 
     if not main_program._is_distributed:
         raise ValueError(

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -178,6 +178,10 @@ def save_vars(executor,
             # saved in the same file named 'var_file' in the path "./my_paddle_vars".
     """
     save_dirname = os.path.normpath(dirname)
+
+    if not isinstance(executor, Executor):
+        raise TypeError("executor should be as Executor")
+
     if vars is None:
         if main_program is None:
             main_program = default_main_program()
@@ -426,7 +430,10 @@ def _save_distributed_persistables(executor, dirname, main_program):
         return is_valid
 
     if not isinstance(main_program, Program):
-        raise ValueError("'main_program' should be an instance of Program.")
+        raise TypeError("'main_program' should be an instance of Program.")
+
+    if not isinstance(executor, Executor):
+        raise TypeError("executor should be as Executor")
 
     if not main_program._is_distributed:
         raise ValueError(
@@ -595,6 +602,10 @@ def load_vars(executor,
             # been saved in the same file named 'var_file' in the path "./my_paddle_vars".
     """
     load_dirname = os.path.normpath(dirname)
+
+    if not isinstance(executor, Executor):
+        raise TypeError("executor should be as Executor")
+
     if vars is None:
         if main_program is None:
             main_program = default_main_program()
@@ -846,7 +857,10 @@ def _load_distributed_persistables(executor, dirname, main_program=None):
         executor.run(load_prog)
 
     if not isinstance(main_program, Program):
-        raise ValueError("'main_program' should be an instance of Program.")
+        raise TypeError("'main_program' should be an instance of Program.")
+
+    if not isinstance(executor, Executor):
+        raise TypeError("executor should be as Executor")
 
     if not main_program._is_distributed:
         raise ValueError(
@@ -1009,6 +1023,9 @@ def save_inference_model(dirname,
                                             is not suitable for saving inference model \
                                             we save the original program as inference model.",
                 RuntimeWarning)
+
+    elif not isinstance(main_program, Program):
+        raise TypeError("program should be as Program type or None")
 
     # fix the bug that the activation op's output as target will be pruned.
     # will affect the inference performance.

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -177,6 +177,10 @@ def save_vars(executor,
             # saved in the same file named 'var_file' in the path "./my_paddle_vars".
     """
     save_dirname = os.path.normpath(dirname)
+
+    if not isinstance(executor, Executor):
+        raise TypeError("executor should be as Executor")
+
     if vars is None:
         if main_program is None:
             main_program = default_main_program()
@@ -594,6 +598,10 @@ def load_vars(executor,
             # been saved in the same file named 'var_file' in the path "./my_paddle_vars".
     """
     load_dirname = os.path.normpath(dirname)
+
+    if not isinstance(executor, Executor):
+        raise TypeError("executor should be as Executor")
+
     if vars is None:
         if main_program is None:
             main_program = default_main_program()

--- a/python/paddle/fluid/tests/unittests/test_inference_model_io.py
+++ b/python/paddle/fluid/tests/unittests/test_inference_model_io.py
@@ -140,12 +140,10 @@ class TestInstance(unittest.TestCase):
         cp_prog = CompiledProgram(program).with_data_parallel(
             loss_name=avg_cost.name)
 
-        self.assertRaises(TypeError,
-                          save_inference_model(MODEL_DIR, ["x", "y"],
-                                               [avg_cost], exe, cp_prog))
-        self.assertRaises(TypeError,
-                          save_inference_model(MODEL_DIR, ["x", "y"],
-                                               [avg_cost], [], cp_prog))
+        self.assertRaises(TypeError, save_inference_model,
+                          [MODEL_DIR, ["x", "y"], [avg_cost], exe, cp_prog])
+        self.assertRaises(TypeError, save_inference_model,
+                          [MODEL_DIR, ["x", "y"], [avg_cost], [], cp_prog])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_inference_model_io.py
+++ b/python/paddle/fluid/tests/unittests/test_inference_model_io.py
@@ -23,6 +23,7 @@ import paddle.fluid.core as core
 import paddle.fluid.executor as executor
 import paddle.fluid.layers as layers
 import paddle.fluid.optimizer as optimizer
+from paddle.fluid.compiler import CompiledProgram
 from paddle.fluid.framework import Program, program_guard
 from paddle.fluid.io import save_inference_model, load_inference_model
 from paddle.fluid.transpiler import memory_optimize
@@ -112,6 +113,39 @@ class TestSaveInferenceModel(unittest.TestCase):
         self.assertEqual(program._is_mem_optimized, True)
         # will print warning message
         save_inference_model(MODEL_DIR, ["x", "y"], [avg_cost], exe, program)
+
+
+class TestInstance(unittest.TestCase):
+    def test_save_inference_model(self):
+        MODEL_DIR = "./tmp/inference_model3"
+        init_program = Program()
+        program = Program()
+
+        # fake program without feed/fetch
+        with program_guard(program, init_program):
+            x = layers.data(name='x', shape=[2], dtype='float32')
+            y = layers.data(name='y', shape=[1], dtype='float32')
+
+            y_predict = layers.fc(input=x, size=1, act=None)
+
+            cost = layers.square_error_cost(input=y_predict, label=y)
+            avg_cost = layers.mean(cost)
+
+        place = core.CPUPlace()
+        exe = executor.Executor(place)
+        exe.run(init_program, feed={}, fetch_list=[])
+
+        # will print warning message
+
+        cp_prog = CompiledProgram(program).with_data_parallel(
+            loss_name=avg_cost.name)
+
+        self.assertRaises(TypeError,
+                          save_inference_model(MODEL_DIR, ["x", "y"],
+                                               [avg_cost], exe, cp_prog))
+        self.assertRaises(TypeError,
+                          save_inference_model(MODEL_DIR, ["x", "y"],
+                                               [avg_cost], [], cp_prog))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
修复用户误传 parallelexecutor 入需要指定为 executor的方法/函数中。
主要相关的方法为 save/load infernece model, save/load persistables.