### PR TITLE
Modify format of GPU allocation failure log.

### DIFF
--- a/paddle/fluid/memory/allocation/legacy_allocator.cc
+++ b/paddle/fluid/memory/allocation/legacy_allocator.cc
@@ -200,12 +200,12 @@ void *Alloc<platform::CUDAPlace>(const platform::CUDAPlace &place,
     platform::GpuMemoryUsage(&avail, &total);
     LOG(FATAL) << "Cannot allocate " << string::HumanReadableSize(size)
                << " in GPU " << place.device << ", available "
-               << string::HumanReadableSize(avail) << "total " << total
-               << "GpuMinChunkSize "
+               << string::HumanReadableSize(avail) << ", total "
+               << string::HumanReadableSize(total) << ", GpuMinChunkSize "
                << string::HumanReadableSize(buddy_allocator->GetMinChunkSize())
-               << "GpuMaxChunkSize "
+               << ", GpuMaxChunkSize "
                << string::HumanReadableSize(buddy_allocator->GetMaxChunkSize())
-               << "GPU memory used: "
+               << ", GPU memory used: "
                << string::HumanReadableSize(Used<platform::CUDAPlace>(place));
   } else {
     if (FLAGS_benchmark) {


### PR DESCRIPTION
The old log format is not beautiful: 

![26a2a35b23943bbbf57692f330ecb5ca](https://user-images.githubusercontent.com/7913861/59339473-d0107280-8d36-11e9-8c94-202ef6d2b95c.png)


test=develop