### PR TITLE
Optimize fused_elewise_activation_grad op.

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -1005,24 +1005,24 @@ template <typename T, typename DX_OP, typename DY_OP, typename DIntermediate_OP,
           bool UseIntermediateOut>
 struct FusedElemwiseAndActGradNoBroadcast {
   HOSTDEVICE void operator()(size_t i) {
+    T x_val = x_[i];
+    T y_val = y_[i];
+    T out_val = out_[i];
+    T dout_val = dout_[i];
+    T intermediate_out_val = UseIntermediateOut
+                                 ? intermediate_out_[i]
+                                 : dx_op_.GetIntermediateOut(x_val, y_val);
     if (dx_ != nullptr) {
-      dx_[i] = UseIntermediateOut
-                   ? dx_op_.UseIntermediateOut(
-                         x_[i], y_[i], intermediate_out_[i], out_[i], dout_[i])
-                   : dx_op_.Recompute(x_[i], y_[i], out_[i], dout_[i]);
+      dx_[i] = dx_op_.UseIntermediateOut(x_val, y_val, intermediate_out_val,
+                                         out_val, dout_val);
     }
     if (dy_ != nullptr) {
-      dy_[i] = UseIntermediateOut
-                   ? dy_op_.UseIntermediateOut(
-                         x_[i], y_[i], intermediate_out_[i], out_[i], dout_[i])
-                   : dy_op_.Recompute(x_[i], y_[i], out_[i], dout_[i]);
+      dy_[i] = dy_op_.UseIntermediateOut(x_val, y_val, intermediate_out_val,
+                                         out_val, dout_val);
     }
     if (dintermediate_ != nullptr) {
-      dintermediate_[i] =
-          UseIntermediateOut
-              ? dintermediate_op_.UseIntermediateOut(
-                    x_[i], intermediate_out_[i], out_[i], dout_[i])
-              : dintermediate_op_.Recompute(x_[i], y_[i], out_[i], dout_[i]);
+      dintermediate_[i] = dintermediate_op_.UseIntermediateOut(
+          x_val, intermediate_out_val, out_val, dout_val);
     }
   }
 

--- a/paddle/fluid/operators/math/compound_functors.h
+++ b/paddle/fluid/operators/math/compound_functors.h
@@ -74,6 +74,8 @@ struct BinaryCompoundGradDxFunctor {
     return dout * d_binary_fun_.Dx(x, intermediate_out);
   }
 
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return unary_fun_(y); }
+
  private:
   DBinaryFun d_binary_fun_;
   UnaryFun unary_fun_;
@@ -104,6 +106,8 @@ struct BinaryCompoundGradDyFunctor {
              d_unary_fun_.UseXAndOut(y, intermediate_out);
     }
   }
+
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return unary_fun_(y); }
 
  private:
   DBinaryFun d_binary_fun_;
@@ -143,6 +147,8 @@ struct UnaryCompoundGradDxFunctor {
     return base * d_binary_fun_.Dx(x, y);
   }
 
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return binary_fun_(x, y); }
+
  private:
   DUnaryFun d_unary_fun_;
   BinaryFun binary_fun_;
@@ -181,6 +187,8 @@ struct UnaryCompoundGradDyFunctor {
     return base * d_binary_fun_.Dy(x, y);
   }
 
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return binary_fun_(x, y); }
+
  private:
   DUnaryFun d_unary_fun_;
   BinaryFun binary_fun_;
@@ -202,6 +210,8 @@ struct BinaryCompoundGradDIntermedaiteOutFunctor {
                                          T dout) {
     return dout * d_binary_fun_.Dy(x, intermediate_out);
   }
+
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return unary_fun_(y); }
 
  private:
   DBinaryFun d_binary_fun_;
@@ -231,6 +241,8 @@ struct UnaryCompoundGradDIntermediateFunctor {
       return dout * d_unary_fun_.UseXAndOut(intermediate_out, out);
     }
   }
+
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return binary_fun_(x, y); }
 
  private:
   DUnaryFun d_unary_fun_;


### PR DESCRIPTION
1. Preload `x[i]`, `y[i]`, `out[i]`, `dout[i]` to register ahead to avoid reading from global memory several times.
2. Calculating the `intermediate_out` ahead to avoid being calculated many times.

Unit: sec/epoch

| model | Paddle develop + benchmark master | Paddle #18041 + benchmark master | Paddle #18041 + benchmark #113 |
|-------|------|------|-------|
| PaddingRNN, static, small | 36.75 | 37.69 | 35.12 |
| PaddingRNN, static, large | 73.70 | 73.33 | 72.62 |

NOTE: there may be some error in the statistical time, because there are several developers using the same server.

#### PaddingRNN static small model:
- Paddle develop, `save_intermediate_out=True`
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
matmul_grad                          410         53.9775     34.529910 (0.639710)    19.447571 (0.360290)    0.08791     1.31069     0.131652    0.155       
fused_elemwise_activation_grad       1200        38.868      36.397355 (0.936434)    2.470671 (0.063566)     0.026639    0.098368    0.03239     0.111613    
fused_elemwise_activation            1200        32.1527     30.485537 (0.948148)    1.667192 (0.051852)     0.021963    0.044187    0.0267939   0.092329    
matmul                               410         31.1614     19.607714 (0.629231)    11.553675 (0.370769)    0.051497    0.764902    0.0760034   0.0894823   
concat                               840         23.3175     21.697272 (0.930514)    1.620251 (0.069486)     0.020795    0.171168    0.027759    0.066958    
elementwise_add_grad                 810         22.6189     20.727812 (0.916393)    1.891106 (0.083607)     0.02019     0.093607    0.0279246   0.0649519   
sum                                  830         21.2828     19.217185 (0.902943)    2.065647 (0.097057)     0.01798     0.12913     0.025642    0.0611153   
elementwise_add                      810         20.6822     18.842179 (0.911035)    1.839981 (0.088965)     0.018214    0.083307    0.0255335   0.0593904 
```

- This PR + `save_intermediate_out=True`
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
matmul_grad                          410         53.4151     34.060176 (0.637650)    19.354973 (0.362350)    0.087586    1.41184     0.130281    0.151474    
fused_elemwise_activation_grad       1200        38.3713     36.315743 (0.946430)    2.055541 (0.053570)     0.025294    0.145992    0.0319761   0.108813    
fused_elemwise_activation            1200        33.4607     31.755013 (0.949024)    1.705703 (0.050976)     0.02224     0.082504    0.0278839   0.0948875   
matmul                               410         31.9135     20.230705 (0.633924)    11.682763 (0.366076)    0.052139    0.768003    0.0778377   0.0904998   
concat                               840         23.5842     21.925304 (0.929663)    1.658849 (0.070337)     0.02131     0.192967    0.0280764   0.0668796   
elementwise_add_grad                 810         22.7532     20.853623 (0.916515)    1.899537 (0.083485)     0.020392    0.107745    0.0280903   0.0645231   
elementwise_add                      810         21.3757     19.501001 (0.912299)    1.874669 (0.087701)     0.01806     0.101596    0.0263897   0.0606168
```

- This PR + `save_intermediate_out=False` (benchmark #113)
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
matmul_grad                          410         52.3121     32.928528 (0.629463)    19.383566 (0.370537)    0.085087    1.24945     0.12759     0.159821    
fused_elemwise_activation_grad       1200        33.2169     31.190765 (0.939004)    2.026107 (0.060996)     0.023229    0.069318    0.0276807   0.101482    
matmul                               410         30.9772     19.400738 (0.626292)    11.576416 (0.373708)    0.050812    0.758494    0.075554    0.0946395   
fused_elemwise_activation            1200        28.0395     26.418432 (0.942188)    1.621019 (0.057812)     0.019756    0.074654    0.0233662   0.0856644   
concat                               840         22.3439     20.725727 (0.927578)    1.618190 (0.072422)     0.020658    0.127324    0.0265999   0.0682637   
elementwise_add_grad                 810         21.6433     19.761692 (0.913063)    1.881592 (0.086937)     0.019532    0.095799    0.0267201   0.0661232   
elementwise_add                      810         21.4141     19.575779 (0.914155)    1.838295 (0.085845)     0.017605    0.706031    0.0264371   0.0654229 
```

#### PaddingRNN static large model:
- Paddle develop, `save_intermediate_out=True`
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
matmul_grad                          710         283.279     64.407701 (0.227365)    218.871256 (0.772635)   0.325793    4.32491     0.398984    0.251808    
matmul                               710         169.094     36.671805 (0.216872)    132.422408 (0.783128)   0.152573    5.45866     0.238161    0.150309    
sum                                  1430        100.333     32.893559 (0.327845)    67.439187 (0.672155)    0.018842    3.3353      0.0701628   0.0891864   
Fetch                                20          76.0689     68.477694 (0.900206)    7.591182 (0.099794)     0.033964    7.88103     3.80344     0.0676181   
fused_elemwise_activation_grad       2100        69.7327     64.789774 (0.929116)    4.942960 (0.070884)     0.028025    0.083794    0.0332061   0.0619858   
fused_elemwise_activation            2100        60.2557     56.776686 (0.942262)    3.479021 (0.057738)     0.023575    0.064189    0.0286932   0.0535617   
concat                               1440        46.2327     39.134321 (0.846465)    7.098345 (0.153535)     0.022497    0.245287    0.032106    0.0410965   
elementwise_add_grad                 1410        41.4331     36.736966 (0.886657)    4.696132 (0.113343)     0.020936    0.133408    0.0293852   0.0368301   
elementwise_add                      1410        38.9378     34.721266 (0.891712)    4.216512 (0.108288)     0.018559    0.124585    0.0276154   0.034612  
```

- This PR + `save_intermediate_out=True`
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
matmul_grad                          710         284.033     65.944231 (0.232171)    218.088589 (0.767829)   0.324283    4.30178     0.400046    0.247044    
matmul                               710         169.218     37.246895 (0.220112)    131.970642 (0.779888)   0.151092    5.43705     0.238335    0.147181    
sum                                  1430        101.782     34.411669 (0.338093)    67.370030 (0.661907)    0.018392    3.39341     0.071176    0.0885269   
Fetch                                20          74.9138     67.352671 (0.899069)    7.561132 (0.100931)     0.034512    8.8114      3.74569     0.0651579   
fused_elemwise_activation_grad       2100        71.994      67.932827 (0.943590)    4.061161 (0.056410)     0.026495    0.100162    0.0342829   0.0626183   
fused_elemwise_activation            2100        62.2231     58.750997 (0.944200)    3.472066 (0.055800)     0.022166    0.120231    0.02963     0.0541199   
concat                               1440        47.9454     40.468447 (0.844052)    7.476999 (0.155948)     0.02112     0.300353    0.0332954   0.0417016   
elementwise_add_grad                 1410        43.0008     38.331391 (0.891411)    4.669407 (0.108589)     0.020519    0.149738    0.030497    0.0374009   
elementwise_add                      1410        40.3266     36.128342 (0.895893)    4.198301 (0.104107)     0.017762    0.145633    0.0286005   0.035075 
```

- This PR + `save_intermediate_out=False` (benchmark #113)
```
Event                                Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
matmul_grad                          710         284.574     62.894014 (0.221011)    221.680174 (0.778989)   0.322721    4.72915     0.400809    0.250552    
matmul                               710         172.049     37.329641 (0.216971)    134.719741 (0.783029)   0.151856    5.98718     0.242323    0.15148     
sum                                  1430        99.6974     32.111774 (0.322092)    67.585620 (0.677908)    0.01801     3.33095     0.0697185   0.0877782   
Fetch                                20          86.1083     75.111730 (0.872294)    10.996548 (0.127706)    0.034492    10.9965     4.30541     0.0758137   
fused_elemwise_activation_grad       2100        66.9978     62.907219 (0.938945)    4.090559 (0.061055)     0.025252    0.13235     0.0319037   0.058988    
fused_elemwise_activation            2100        56.7844     53.402969 (0.940451)    3.381472 (0.059549)     0.020628    0.130451    0.0270402   0.0499957   
concat                               1440        45.9186     38.788339 (0.844719)    7.130267 (0.155281)     0.021282    0.199649    0.0318879   0.0404289   
elementwise_add_grad                 1410        41.9644     37.193427 (0.886309)    4.770963 (0.113691)     0.020294    0.154765    0.029762    0.0369474   
elementwise_add                      1410        40.379      36.073771 (0.893378)    4.305275 (0.106622)     0.017702    0.146557    0.0286376   0.0355516  
```