### PR TITLE
[bug fix] identity_scale_op_clean_pass test=develop

### DIFF
--- a/paddle/fluid/framework/ir/identity_scale_op_clean_pass.cc
+++ b/paddle/fluid/framework/ir/identity_scale_op_clean_pass.cc
@@ -23,15 +23,13 @@ namespace ir {
 void IdentityScaleOpCleanPass::ApplyImpl(ir::Graph* graph) const {
   FusePassBase::Init("identity_scale_op_clean", graph);
 
-  // pre_op -> scale_in -> scale_op -> scale_out
-  // ->
-  // pre_op -> scale_out
+  // scale_in -> scale_op -> scale_out -> fetch_op
+  // ==>
+  // scale_in -> fetch_op
   GraphPatternDetector detector;
-  auto pre_op = detector.mutable_pattern()->NewNode("pre_op")->assert_is_op();
   auto scale_in = detector.mutable_pattern()
                       ->NewNode("scale_in")
-                      ->assert_is_op_input("scale")
-                      ->AsIntermediate();
+                      ->assert_is_op_input("scale");
   auto scale_op = detector.mutable_pattern()
                       ->NewNode("scale_fuse")
                       ->assert_is_op("scale")
@@ -41,34 +39,36 @@ void IdentityScaleOpCleanPass::ApplyImpl(ir::Graph* graph) const {
       detector.mutable_pattern()
           ->NewNode("scale_out")
           ->assert_is_op_output("scale")
+          ->AsIntermediate()
           // scale's output var should has only one consumer, or it can't be
           // removed.
           ->assert_more([](Node* x) { return x->outputs.size() == 1UL; });
+  auto behind_op =
+      detector.mutable_pattern()->NewNode("behind_op")->assert_is_op("fetch");
 
-  pre_op->LinksTo({scale_in});
   scale_op->LinksFrom({scale_in}).LinksTo({scale_out});
+  behind_op->LinksFrom({scale_out});
 
   GraphPatternDetector::handle_t handler = [&](
       const GraphPatternDetector::subgraph_t& subgraph, Graph* graph) {
     Node* scale_op_var = subgraph.at(scale_op);
     Node* scale_in_var = subgraph.at(scale_in);
     Node* scale_out_var = subgraph.at(scale_out);
-    Node* pre_op_var = subgraph.at(pre_op);
+    Node* behind_op_var = subgraph.at(behind_op);
     // Link pre_op directly to scale_out
     const std::string scale_in_name = scale_in_var->Name();
     const std::string scale_out_name = scale_out_var->Name();
     // Remove links in graph
-    GraphSafeRemoveNodes(graph, {scale_in_var, scale_op_var});
+    GraphSafeRemoveNodes(graph, {scale_op_var, scale_out_var});
     // Modify proto message
-    auto* pre_op_desc = pre_op_var->Op();
-    for (auto& parameter : *pre_op_desc->Proto()->mutable_outputs()) {
+    auto* behind_op_desc = behind_op_var->Op();
+    for (auto& parameter : *behind_op_desc->Proto()->mutable_inputs()) {
       auto* arguments = parameter.mutable_arguments();
-      auto it = std::find(arguments->begin(), arguments->end(), scale_in_name);
+      auto it = std::find(arguments->begin(), arguments->end(), scale_out_name);
       PADDLE_ENFORCE(it != arguments->end());
-      *it = scale_out_name;
+      *it = scale_in_name;
     }
-
-    IR_NODE_LINK_TO(pre_op_var, scale_out_var);
+    IR_NODE_LINK_TO(scale_in_var, behind_op_var);
   };
 
   detector(graph, handler);

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -104,8 +104,8 @@ const std::vector<std::string> kAnakinSubgraphPasses({
 
 GpuPassStrategy::GpuPassStrategy() : PassStrategy({}) {
   passes_.assign({
-    "infer_clean_graph_pass",  //
-        //   "identity_scale_op_clean_pass",              //
+    "infer_clean_graph_pass",                        //
+        "identity_scale_op_clean_pass",              //
         "conv_affine_channel_fuse_pass",             //
         "conv_eltwiseadd_affine_channel_fuse_pass",  //
         "conv_bn_fuse_pass",                         //
@@ -141,6 +141,7 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
   // NOTE the large fusions should be located in the front, so that they will
   // not be damaged by smaller ones.
   passes_.assign({"infer_clean_graph_pass",         //
+                  "identity_scale_op_clean_pass",   //
                   "attention_lstm_fuse_pass",       //
                   "seqconv_eltadd_relu_fuse_pass",  //
                   // "seqpool_concat_fuse_pass",    //


### PR DESCRIPTION
Fix the identity_scale_op_clean_pass. We need to run CE before the merge.

**[Before]**
pre_op -> scale_in -> scale_op -> scale_out
==>
pre_op -> scale_out
(It can't handle the case where the _scale_in_ node is multi-connected.)

**[Fixed]**
scale_in -> scale_op -> scale_out -> fetch_op
==>
scale_in -> fetch_op