### PR TITLE
add paddle cloud role maker for customized usage, note this is only f…

### DIFF
--- a/python/paddle/fluid/incubate/fleet/base/fleet_base.py
+++ b/python/paddle/fluid/incubate/fleet/base/fleet_base.py
@@ -188,17 +188,7 @@ class Fleet(object):
         if role_maker and not isinstance(role_maker, RoleMakerBase):
             raise ValueError("role_maker must be an instance of RoleMakerBase")
 
-        if isinstance(role_maker, MPISymetricRoleMaker):
-            self._role_maker = role_maker
-            self._role_maker.generate_role()
-
-        elif isinstance(role_maker, UserDefinedRoleMaker):
-            self._role_maker = role_maker
-
-        else:
-            raise ValueError(
-                "role_maker must be an instance of UserDefinedRoleMaker/MPISymetricRoleMaker"
-            )
+        self._role_maker.generate_role()
 
         self._is_initialized = True
 

--- a/python/paddle/fluid/incubate/fleet/base/role_maker.py
+++ b/python/paddle/fluid/incubate/fleet/base/role_maker.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 __all__ = [
     'Role', 'RoleMakerBase', 'MPISymetricRoleMaker', 'UserDefinedRoleMaker',
-    'UserDefinedCollectiveRoleMaker'
+    'UserDefinedCollectiveRoleMaker', 'PaddleCloudRoleMaker'
 ]
 
 
@@ -292,6 +292,50 @@ class MPISymetricRoleMaker(MPIRoleMaker):
             self._role_is_generated = True
 
 
+class PaddleCloudRoleMaker(RoleMakerBase):
+    def __init__(self):
+        super(PaddleCloudRoleMaker, self).__init__()
+
+    def generate_role(self):
+        if not self._role_is_generated:
+            self.port = os.getenv("PADDLE_PORT", "6174")
+            self.pserver_ips = os.getenv("PADDLE_PSERVERS", "")
+            eplist = []
+            for ip in pserver_ips.split(","):
+                eplist.append(':'.join([ip, port]))
+                self.endpoints = ",".join(eplist)
+                self.trainers = int(os.getenv("PADDLE_TRAINERS_NUM", "1"))
+                self.current_endpoint = os.getenv("POD_IP",
+                                                  "localhost") + ":" + port
+                self.role = os.getenv("TRAINING_ROLE", "TRAINER")
+                self.trainer_id = int(os.getenv("PADDLE_TRAINER_ID", "0"))
+            self.eplist = eplist
+            self.endpoints = self.endpoints.split(",")
+            if self.role.upper() == "PSERVER":
+                self.current_id = self.endpoints.index(self.current_endpoint)
+            else:
+                self.current_id = self.trainer_id
+            self._role_is_generated = True
+
+    def is_wokrer(self):
+        return self._role == Role.WORKER
+
+    def is_server(self):
+        return self._role == Role.SERVER
+
+    def is_first_worker(self):
+        return self._role == Role.WORKER and self._current_id == 0
+
+    def worker_index(self):
+        return self._current_id
+
+    def server_index(self):
+        return self._current_id
+
+    def worker_num(self):
+        return self._worker_num
+
+
 class UserDefinedRoleMaker(RoleMakerBase):
     def __init__(self,
                  current_id=0,
@@ -328,6 +372,9 @@ class UserDefinedRoleMaker(RoleMakerBase):
             raise TypeError("server_endpoints must be as string list")
         else:
             self._server_endpoints = server_endpoints
+
+    def generate_role(self):
+        self._role_is_generated = True
 
     def is_worker(self):
         return self._role == Role.WORKER
@@ -368,6 +415,9 @@ class UserDefinedCollectiveRoleMaker(RoleMakerBase):
         else:
             self._worker_endpoints = worker_endpoints
         self._worker_num = len(self._worker_endpoints)
+
+    def generate_role(self):
+        self._role_is_generated = True
 
     def is_worker(self):
         return True


### PR DESCRIPTION
…or industrial users that have cloud environment pre-configuration

test=develop

before this role maker, a user has to write duplicate code for every model
```
import paddle.fluid.incubate.fleet.base.role_maker as role_maker
from paddle.fluid.incubate.fleet.parameter_server.distributed_transpiler import fleet
args = parse_args()

if args.cloud_train:
    # the port of all pservers, needed by both trainer and pserver
    port = os.getenv("PADDLE_PORT", "6174")
    # comma separated ips of all pservers, needed by trainer and
    pserver_ips = os.getenv("PADDLE_PSERVERS", "")
    eplist = []
    for ip in pserver_ips.split(","):
        eplist.append(':'.join([ip, port]))
    args.endpoints = ",".join(eplist)
    args.trainers = int(os.getenv("PADDLE_TRAINERS_NUM", "1"))
    args.current_endpoint = os.getenv("POD_IP", "localhost") + ":" + port
    args.role = os.getenv("TRAINING_ROLE", "TRAINER")
    args.trainer_id = int(os.getenv("PADDLE_TRAINER_ID", "0"))

# init role maker
endpoints = args.endpoints.split(",")
if args.role.upper() == "PSERVER":
    current_id = endpoints.index(args.current_endpoint)
else:
    current_id = args.trainer_id
role = role_maker.UserDefinedRoleMaker(
    current_id=current_id,
    role=role_maker.Role.WORKER
    if args.role.upper() == "TRAINER" else role_maker.Role.SERVER,
    worker_num=args.trainers,
    server_endpoints=endpoints)
fleet.init(role)
```
with this customized role maker, a user with cloud configuration can write simple code
```
import paddle.fluid.incubate.fleet.base.role_maker as role_maker
from paddle.fluid.incubate.fleet.parameter_server.distributed_transpiler import fleet

role = role_maker.PaddleCloudRoleMaker()
fleet.init(role)
```