### PR TITLE
Reset DeviceContext after quantization warmup

### DIFF
--- a/paddle/fluid/inference/api/mkldnn_quantizer.h
+++ b/paddle/fluid/inference/api/mkldnn_quantizer.h
@@ -68,6 +68,7 @@ class AnalysisPredictor::MkldnnQuantizer {
                             const framework::LoDTensor& var_tensor,
                             bool is_unsigned);
   void PrepareArgument() const;
+  void ClearDeviceContext() const;
   bool RunQuantizePasses() const;
 
   std::vector<int> ExpandQuantizedBins(std::vector<int> quantized_bins,

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -406,6 +406,8 @@ thread_local int cur_thread_id = 0;
 void set_cur_thread_id(int tid) { cur_thread_id = tid; }
 int get_cur_thread_id(void) { return cur_thread_id; }
 
+void MKLDNNDeviceContext::ResetBlobMap() const { p_blobmap_->clear(); }
+
 void MKLDNNDeviceContext::SetBlob(const std::string& name,
                                   std::shared_ptr<void> data) const {
   BlobMap* pMap = p_blobmap_.get();

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -391,6 +391,9 @@ class MKLDNNDeviceContext : public CPUDeviceContext {
   /* \brief  Get the active engine */
   const mkldnn::engine& GetEngine() const { return engine_; }
 
+  // Remove all entries from the blob map
+  void ResetBlobMap() const;
+
   // Set data to blob (i.e. name/data pair). Create blob if not existing
   void SetBlob(const std::string& name, std::shared_ptr<void> data) const;
 


### PR DESCRIPTION
Once the quantization warmup is perfromed using fp32 operators, some of the cached MKL-DNN primitvies are incorrectly reused as int8 operators. This PR clears device context cache after the execution of  warmup, so that the aformentioned doesn't occur.