### PR TITLE
Enable MKL-DNN for slim FP32 vs. INT8 tests

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -1,14 +1,23 @@
 file(GLOB TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_*.py")
 string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 
-function(inference_analysis_python_api_int8_test target model_dir data_dir filename)
+function(_inference_analysis_python_api_int8_test target model_dir data_dir filename use_mkldnn)
     py_test(${target} SRCS ${filename}
         ENVS CPU_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
+             FLAGS_use_mkldnn=${use_mkldnn}
         ARGS --infer_model ${model_dir}/model
              --infer_data ${data_dir}/data.bin
              --int8_model_save_path int8_models/${target}
              --warmup_batch_size 100
              --batch_size 50)
+endfunction()
+
+function(inference_analysis_python_api_int8_test target model_dir data_dir filename)
+    _inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_dir} ${filename} False)
+endfunction()
+
+function(inference_analysis_python_api_int8_test_mkldnn target model_dir data_dir filename)
+    _inference_analysis_python_api_int8_test(${target} ${model_dir} ${data_dir} ${filename} True)
 endfunction()
 
 function(inference_qat_int8_test target model_dir data_dir test_script use_mkldnn)
@@ -44,6 +53,7 @@ if(LINUX AND WITH_MKLDNN)
   # mobilenet int8
   set(INT8_MOBILENET_MODEL_DIR "${INT8_DATA_DIR}/mobilenetv1")
   inference_analysis_python_api_int8_test(test_slim_int8_mobilenet ${INT8_MOBILENET_MODEL_DIR} ${INT8_DATA_DIR} ${MKLDNN_INT8_TEST_FILE})
+  inference_analysis_python_api_int8_test_mkldnn(test_slim_int8_mobilenet_mkldnn ${INT8_MOBILENET_MODEL_DIR} ${INT8_DATA_DIR} ${MKLDNN_INT8_TEST_FILE})
 
   # temporarily adding WITH_SLIM_MKLDNN_FULL_TEST FLAG for QA testing the following UTs locally,
   # since the following UTs cost too much time on CI test.

--- a/python/paddle/fluid/contrib/slim/tests/slim_int8_mkldnn_post_training_quantization.md
+++ b/python/paddle/fluid/contrib/slim/tests/slim_int8_mkldnn_post_training_quantization.md
@@ -128,3 +128,4 @@ python ./test_mkldnn_int8_quantization_strategy.py --infer_model /PATH/TO/DOWNLO
 Notes:
 
 * The above commands will cost maybe several hours in the prediction stage (include int8 prediction and fp32 prediction) since there have 50000 pictures need to be predicted in `int8_full_val.bin`
+* Running the above command with environment variable `FLAGS_use_mkldnn=true` will make the FP32 part of the test running using MKL-DNN (the INT8 part uses MKL-DNN either way).


### PR DESCRIPTION
With this patch, MKL-DNN is enabled for `test_slim_int8_*` tests via `FLAGS_use_mkldnn=true` env variable, i.e. the FP32 part of the test runs with MKL-DNN when `FLAGS_use_mkldnn=true`, the INT8 part runs with MKL-DNN either way.

Also, a test case with MKL-DNN is added for MobileNetV1.

test=develop