### PR TITLE
[MKL-DNN] Thread ID is added for caching only ParallelExecutor based executions

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -188,6 +188,13 @@ bool AnalysisPredictor::PrepareExecutor() {
 void AnalysisPredictor::SetMkldnnThreadID(int tid) {
 #ifdef PADDLE_WITH_MKLDNN
   platform::set_cur_thread_id(tid);
+  // When MKL-DNN is used we are to cache MKL-DNN primitives
+  // For Analysis Predictor this will be done per MkldnnThreadID
+  platform::CPUPlace cpu;
+  platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+  auto *dev_ctx = static_cast<platform::MKLDNNDeviceContext *>(pool.Get(cpu));
+  dev_ctx->AppendPrefixFunction(
+      "AP", [](void) { return std::to_string(platform::get_cur_thread_id()); });
 #else
   LOG(ERROR) << "Please compile with MKLDNN first to use MKLDNN";
 #endif

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -408,6 +408,21 @@ thread_local int cur_thread_id = 0;
 void set_cur_thread_id(int tid) { cur_thread_id = tid; }
 int get_cur_thread_id(void) { return cur_thread_id; }
 
+void MKLDNNDeviceContext::AppendPrefixFunction(
+    const std::string& key, std::function<std::string()> func) {
+  std::lock_guard<std::mutex> lock(*p_mutex_);
+  prefixfunctions_[key] = func;
+}
+
+std::string MKLDNNDeviceContext::GetPrefix(void) const {
+  std::lock_guard<std::mutex> lock(*p_mutex_);
+  std::string prefix = "";
+  for (auto& func : prefixfunctions_) {
+    prefix += func.second();
+  }
+  return prefix;
+}
+
 void MKLDNNDeviceContext::SetBlob(const std::string& name,
                                   std::shared_ptr<void> data) const {
   BlobMap* pMap = p_blobmap_.get();

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -10,6 +10,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
 
+#include <functional>
 #include <future>  // NOLINT
 #include <memory>
 #include <mutex>  // NOLINT
@@ -394,6 +395,12 @@ class MKLDNNDeviceContext : public CPUDeviceContext {
   // Set data to blob (i.e. name/data pair). Create blob if not existing
   void SetBlob(const std::string& name, std::shared_ptr<void> data) const;
 
+  //
+  void AppendPrefixFunction(const std::string& key,
+                            std::function<std::string()> func);
+
+  std::string GetPrefix(void) const;
+
   // Find a saved blob. Return nullptr if not found
   std::shared_ptr<void> GetBlob(const std::string& name) const;
 
@@ -401,6 +408,8 @@ class MKLDNNDeviceContext : public CPUDeviceContext {
   mkldnn::engine engine_;
   std::shared_ptr<BlobMap> p_blobmap_;
   std::shared_ptr<std::mutex> p_mutex_;
+  std::unordered_map<std::string, std::function<std::string()>>
+      prefixfunctions_;
 };
 #endif
 

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -33,11 +33,7 @@ class MKLDNNHandler {
   MKLDNNHandler(const MKLDNNDeviceContext& dev_ctx, mkldnn::engine engine,
                 const std::string& base_key)
       : dev_ctx_(dev_ctx), engine_(engine), key_common_(base_key) {
-    // TODO(jczaja): Make it faster
-    auto tid = std::this_thread::get_id();
-    std::stringstream ss;
-    ss << tid;
-    key_ = key_common_ + "-t:" + ss.str();
+    key_ = key_common_ + dev_ctx.GetPrefix();
   }
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemory(


### PR DESCRIPTION
**This is Work in Progress**

This PR is to limit memory leaks caused by caching MKL-DNN primitives per thread-if as introduced #17965 . Here Parallel Executor still is caching MKL-DNN primitives per thread as there is a thread pool used and threads are reused after finishing tasks to execute next tasks. Change is when using Analysis Predictor then caching is done per mkldnn thread id (As set with setMklDnnThreadID()).

![Architectural chart of Key suffix generation for cache](https://github.com/jczaja/Paddle/blob/pictures/images/parallel_execution.svg)

