### PR TITLE
fix bug in Class MultiSlotDataGenerator's function _gen_str, test=develop

### DIFF
--- a/python/paddle/fluid/incubate/data_generator/__init__.py
+++ b/python/paddle/fluid/incubate/data_generator/__init__.py
@@ -312,7 +312,7 @@ class MultiSlotDataGenerator(DataGenerator):
                     )
                 if name != self._proto_info[index][0]:
                     raise ValueError(
-                        "the field name of two given line are not match: require<%s>, get<%d>."
+                        "the field name of two given line are not match: require<%s>, get<%s>."
                         % (self._proto_info[index][0], name))
                 if output:
                     output += " "


### PR DESCRIPTION
函数`_gen_str`里的name变量是str类型，使用`%d`打印会报错。