### PR TITLE
refine core cmake warning and print more info

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -14,8 +14,12 @@ set(FLUID_CORE_NAME "core")
 if(WITH_AVX AND AVX_FOUND)
   set(FLUID_CORE_NAME "${FLUID_CORE_NAME}_avx")
   if(NOT DEFINED NOAVX_CORE_FILE OR NOAVX_CORE_FILE STREQUAL "")
-    message(WARNING "You are building AVX version without NOAVX core, \
-      and the wheel package may fail on NOAVX machine.")
+    message(STATUS "WARNING: This is just a warning for publishing release.
+      You are building AVX version without NOAVX core.
+      So the wheel package may fail on NOAVX machine.
+      You can add -DFLUID_CORE_NAME=/path/to/your/core_noavx.* in cmake command
+      to get a full wheel package to resolve this warning.
+      While, this version will still work on local machine.")
   endif()
 
   if(NOAVX_CORE_FILE AND NOT EXISTS "${NOAVX_CORE_FILE}")

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import os
 import sys
 
-# The legacy core need be removed before import core,
+# The legacy core need to be removed before "import core",
 # in case of users installing paddlepadde without -U option
 core_suffix = 'so'
 if os.name == 'nt':

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -14,6 +14,23 @@
 
 from __future__ import print_function
 import os
+import sys
+
+# The legacy core need be removed before import core,
+# in case of users installing paddlepadde without -U option
+core_suffix = 'so'
+if os.name == 'nt':
+    core_suffix = 'pyd'
+
+legacy_core = os.path.abspath(os.path.dirname(
+    __file__)) + os.sep + 'core.' + core_suffix
+if os.path.exists(legacy_core):
+    sys.stderr.write('Deleting legacy file ' + legacy_core + '\n')
+    try:
+        os.remove(legacy_core)
+    except Exception as e:
+        raise e
+
 # import all class inside framework into fluid module
 from . import framework
 from .framework import *

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -103,7 +103,7 @@ if load_noavx:
     except ImportError as e:
         if has_noavx_core:
             sys.stderr.write(
-                'Error: Can not import noavx core while this file exsits ' +
+                'Error: Can not import noavx core while this file exists ' +
                 current_path + os.sep + 'core_noavx.' + core_suffix + '\n')
         raise e
     except Exception as e:


### PR DESCRIPTION
- refine the cmake warning
- print more info if failed loading
- do not need remove build/python
- do not need -U when install