### PR TITLE
[Cherry-pick #18041] Optimize fused_elewise_activation_grad op.

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -1005,24 +1005,24 @@ template <typename T, typename DX_OP, typename DY_OP, typename DIntermediate_OP,
           bool UseIntermediateOut>
 struct FusedElemwiseAndActGradNoBroadcast {
   HOSTDEVICE void operator()(size_t i) {
+    T x_val = x_[i];
+    T y_val = y_[i];
+    T out_val = out_[i];
+    T dout_val = dout_[i];
+    T intermediate_out_val = UseIntermediateOut
+                                 ? intermediate_out_[i]
+                                 : dx_op_.GetIntermediateOut(x_val, y_val);
     if (dx_ != nullptr) {
-      dx_[i] = UseIntermediateOut
-                   ? dx_op_.UseIntermediateOut(
-                         x_[i], y_[i], intermediate_out_[i], out_[i], dout_[i])
-                   : dx_op_.Recompute(x_[i], y_[i], out_[i], dout_[i]);
+      dx_[i] = dx_op_.UseIntermediateOut(x_val, y_val, intermediate_out_val,
+                                         out_val, dout_val);
     }
     if (dy_ != nullptr) {
-      dy_[i] = UseIntermediateOut
-                   ? dy_op_.UseIntermediateOut(
-                         x_[i], y_[i], intermediate_out_[i], out_[i], dout_[i])
-                   : dy_op_.Recompute(x_[i], y_[i], out_[i], dout_[i]);
+      dy_[i] = dy_op_.UseIntermediateOut(x_val, y_val, intermediate_out_val,
+                                         out_val, dout_val);
     }
     if (dintermediate_ != nullptr) {
-      dintermediate_[i] =
-          UseIntermediateOut
-              ? dintermediate_op_.UseIntermediateOut(
-                    x_[i], intermediate_out_[i], out_[i], dout_[i])
-              : dintermediate_op_.Recompute(x_[i], y_[i], out_[i], dout_[i]);
+      dintermediate_[i] = dintermediate_op_.UseIntermediateOut(
+          x_val, intermediate_out_val, out_val, dout_val);
     }
   }
 

--- a/paddle/fluid/operators/math/compound_functors.h
+++ b/paddle/fluid/operators/math/compound_functors.h
@@ -74,6 +74,8 @@ struct BinaryCompoundGradDxFunctor {
     return dout * d_binary_fun_.Dx(x, intermediate_out);
   }
 
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return unary_fun_(y); }
+
  private:
   DBinaryFun d_binary_fun_;
   UnaryFun unary_fun_;
@@ -104,6 +106,8 @@ struct BinaryCompoundGradDyFunctor {
              d_unary_fun_.UseXAndOut(y, intermediate_out);
     }
   }
+
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return unary_fun_(y); }
 
  private:
   DBinaryFun d_binary_fun_;
@@ -143,6 +147,8 @@ struct UnaryCompoundGradDxFunctor {
     return base * d_binary_fun_.Dx(x, y);
   }
 
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return binary_fun_(x, y); }
+
  private:
   DUnaryFun d_unary_fun_;
   BinaryFun binary_fun_;
@@ -181,6 +187,8 @@ struct UnaryCompoundGradDyFunctor {
     return base * d_binary_fun_.Dy(x, y);
   }
 
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return binary_fun_(x, y); }
+
  private:
   DUnaryFun d_unary_fun_;
   BinaryFun binary_fun_;
@@ -202,6 +210,8 @@ struct BinaryCompoundGradDIntermedaiteOutFunctor {
                                          T dout) {
     return dout * d_binary_fun_.Dy(x, intermediate_out);
   }
+
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return unary_fun_(y); }
 
  private:
   DBinaryFun d_binary_fun_;
@@ -231,6 +241,8 @@ struct UnaryCompoundGradDIntermediateFunctor {
       return dout * d_unary_fun_.UseXAndOut(intermediate_out, out);
     }
   }
+
+  inline HOSTDEVICE T GetIntermediateOut(T x, T y) { return binary_fun_(x, y); }
 
  private:
   DUnaryFun d_unary_fun_;


### PR DESCRIPTION
Cherry-pick https://github.com/PaddlePaddle/Paddle/pull/18041.
Also fix the bug in `fused_elewise_activeation` op for the case when `save_intermedia_out` is false.