### PR TITLE
[PROPOSAL] Add support for dynamic code analysis (Sanitizers)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,10 +73,7 @@ option(WITH_HIGH_LEVEL_API_TEST   "Test fluid python high-level api interface"  
 option(PY_VERSION       "Compile PaddlePaddle with python3 support"     ${PY_VERSION})
 option(WITH_FAST_MATH   "Make use of fast math library, might affect the precision to some extent" ON)
 option(WITH_DGC   "Use DGC(Deep Gradient Compression) or not" ON)
-option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets" OFF)
-option(SANITIZE_LEAK "Enable LeakSanitizer for sanitized targets" OFF)
-option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets" OFF)
-option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." OFF)
+option(SANITIZER_TYPE "Choose the type of sanitizer, options are: Address, Leak, Memory, Thread, Undefined" OFF)
 
 # PY_VERSION
 if(NOT PY_VERSION)
@@ -125,6 +122,12 @@ endif()
 if (REPLACE_ENFORCE_GLOG)
   add_definitions("-DREPLACE_ENFORCE_GLOG")
 endif()
+
+if (NOT "${SANITIZER_TYPE}" MATCHES "^(Address|Leak|Memory|Thread|Undefined)$")
+  message("Choose the correct type of sanitizer")
+  return()
+endif()
+
 ########################################################################################
 
 include(external/mklml)     # download mklml package

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,10 @@ option(WITH_HIGH_LEVEL_API_TEST   "Test fluid python high-level api interface"  
 option(PY_VERSION       "Compile PaddlePaddle with python3 support"     ${PY_VERSION})
 option(WITH_FAST_MATH   "Make use of fast math library, might affect the precision to some extent" ON)
 option(WITH_DGC   "Use DGC(Deep Gradient Compression) or not" ON)
+option(SANITIZE_ADDRESS "Enable AddressSanitizer for sanitized targets" OFF)
+option(SANITIZE_LEAK "Enable LeakSanitizer for sanitized targets" OFF)
+option(SANITIZE_MEMORY "Enable MemorySanitizer for sanitized targets" OFF)
+option(SANITIZE_THREAD "Enable ThreadSanitizer for sanitized targets." OFF)
 
 # PY_VERSION
 if(NOT PY_VERSION)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,7 @@ if (REPLACE_ENFORCE_GLOG)
   add_definitions("-DREPLACE_ENFORCE_GLOG")
 endif()
 
-if (NOT "${SANITIZER_TYPE}" MATCHES "^(Address|Leak|Memory|Thread|Undefined)$")
+if (SANITIZER_TYPE AND NOT "${SANITIZER_TYPE}" MATCHES "^(Address|Leak|Memory|Thread|Undefined)$")
   message("Choose the correct type of sanitizer")
   return()
 endif()

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -119,14 +119,17 @@ endif(BARRIER_FOUND)
 SET(CMAKE_EXTRA_INCLUDE_FILES "")
 
 # Only one sanitizer is allowed in compile time
-if(SANITIZE_ADDRESS)
+string(TOLOWER "${SANITIZER_TYPE}" sanitizer_type)
+if(sanitizer_type STREQUAL "address")
     set(fsanitize "-fsanitize=address")
-elseif(SANITIZE_LEAK)
+elseif(sanitizer_type STREQUAL "leak")
     set(fsanitize "-fsanitize=leak")
-elseif(SANITIZE_MEMORY)
+elseif(sanitizer_type STREQUAL "memory")
     set(fsanitize "-fsanitize=memory")
-elseif(SANITIZE_THREAD)
+elseif(sanitizer_type STREQUAL "thread")
     set(fsanitize "-fsanitize=thread")
+elseif(sanitizer_type STREQUAL "undefined")
+    set(fsanitize "-fsanitize=undefined")
 endif()
 
 # Common flags. the compiler flag used for C/C++ sources whenever release or debug


### PR DESCRIPTION
This PR adds support for Sanitizers:
- AddressSanitizer (for a fast memory error detector)
- LeakSanitizer (for a run-time memory leak detector)
- MemorySanitizer (for a detector of uninitialized reads)
- ThreadSanitizer (for detect data races)

These Sanitizers are based on compiler instrumentation, therefore a rebuild is required in order to use these tools. Sanitizers are implemented in Clang starting 3.1 and GCC starting 4.8 and supported on Linux x86_64 machines. AddressSanitizer and UndefinedBehaviorSanitizer are also available on macOS.

### Usage
You can enable the Sanitizers with SANITIZE_ADDRESS, SANITIZE_LEAK, SANITIZE_MEMORY, SANITIZE_THREAD options in your CMake configuration. You can do this by passing e.g. `-DSANITIZE_ADDRESS=ON` on your command line. The Sanitizers check your program, while it's running.
Only one Sanitizer is allowed in compile time.

Usefully option is `halt_on_error` e.g. for ThreadSanitizer `export TSAN_OPTIONS="halt_on_error=1"` to exit after first reported error.

IMO: maybe it would be nice to connect PaddlePaddle CI with these Sanitizers in future.
### Documentation
Comprehensive documentation is here https://github.com/google/sanitizers