### PR TITLE
add combine_avx_noavx build to dockerfile

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -996,9 +996,11 @@ function main() {
         ;;
       combine_avx_noavx)
         combine_avx_noavx_build
+        gen_dockerfile ${PYTHON_ABI:-""}
         ;;
       combine_avx_noavx_build_and_test)
         combine_avx_noavx_build
+        gen_dockerfile ${PYTHON_ABI:-""}
         parallel_test_base
         ;;
       test)


### PR DESCRIPTION
需要在avx_noavx build时候，生成dockerfile。
使用combine_avx_noavx 参数生成whl后发现不能build镜像，原因：没有生成dockerfile。需要添加生成dockerfile选项。
![image](https://user-images.githubusercontent.com/29832297/60096800-7e2f0a00-9784-11e9-85bd-0b4171362a7a.png)

