### PR TITLE
Add default place to Executor

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -14,7 +14,7 @@ paddle.fluid.cuda_places (ArgSpec(args=['device_ids'], varargs=None, keywords=No
 paddle.fluid.cpu_places (ArgSpec(args=['device_count'], varargs=None, keywords=None, defaults=(None,)), ('document', '8b674e9a7ac7944c27fd853b675c2cb2'))
 paddle.fluid.cuda_pinned_places (ArgSpec(args=['device_count'], varargs=None, keywords=None, defaults=(None,)), ('document', 'cc83b6c5ba8be38ff3ee87e9cec9de5f'))
 paddle.fluid.in_dygraph_mode (ArgSpec(args=[], varargs=None, keywords=None, defaults=None), ('document', 'eddb7a1f0083dcc70e9f6c71ee003cb9'))
-paddle.fluid.Executor.__init__ (ArgSpec(args=['self', 'place'], varargs=None, keywords=None, defaults=None), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))
+paddle.fluid.Executor.__init__ (ArgSpec(args=['self', 'place'], varargs=None, keywords=None, defaults=(None,)), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))
 paddle.fluid.Executor.close (ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None), ('document', '3a584496aa1343f36eebf3c46b323a74'))
 paddle.fluid.Executor.infer_from_dataset (ArgSpec(args=['self', 'program', 'dataset', 'scope', 'thread', 'debug', 'fetch_list', 'fetch_info', 'print_period'], varargs=None, keywords=None, defaults=(None, None, None, 0, False, None, None, 100)), ('document', 'bedc29ad01c1b911e99032ee1e19ac59'))
 paddle.fluid.Executor.run (ArgSpec(args=['self', 'program', 'feed', 'fetch_list', 'feed_var_name', 'fetch_var_name', 'scope', 'return_numpy', 'use_program_cache'], varargs=None, keywords=None, defaults=(None, None, None, 'feed', 'fetch', None, True, False)), ('document', '4cfcd9c15b766a51b584cc46d38f1ad8'))
@@ -30,7 +30,7 @@ paddle.fluid.DistributeTranspiler.transpile (ArgSpec(args=['self', 'trainer_id',
 paddle.fluid.memory_optimize (ArgSpec(args=['input_program', 'skip_opt_set', 'print_log', 'level', 'skip_grads'], varargs=None, keywords=None, defaults=(None, False, 0, True)), ('document', '2348247f684bfd5bb9466470f35be064'))
 paddle.fluid.release_memory (ArgSpec(args=['input_program', 'skip_opt_set'], varargs=None, keywords=None, defaults=(None,)), ('document', 'd38c5b8b2b2e0bb19bcf1b581a80a7e4'))
 paddle.fluid.DistributeTranspilerConfig.__init__ 
-paddle.fluid.ParallelExecutor.__init__ (ArgSpec(args=['self', 'use_cuda', 'loss_name', 'main_program', 'share_vars_from', 'exec_strategy', 'build_strategy', 'num_trainers', 'trainer_id', 'scope'], varargs=None, keywords=None, defaults=(None, None, None, None, None, 1, 0, None)), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))
+paddle.fluid.ParallelExecutor.__init__ (ArgSpec(args=['self', 'use_cuda', 'loss_name', 'main_program', 'share_vars_from', 'exec_strategy', 'build_strategy', 'num_trainers', 'trainer_id', 'scope'], varargs=None, keywords=None, defaults=(None, None, None, None, None, None, 1, 0, None)), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))
 paddle.fluid.ParallelExecutor.drop_local_exe_scopes (ArgSpec(args=['self'], varargs=None, keywords=None, defaults=None), ('document', '77c739744ea5708b80fb1b37cc89db40'))
 paddle.fluid.ParallelExecutor.run (ArgSpec(args=['self', 'fetch_list', 'feed', 'feed_dict', 'return_numpy'], varargs=None, keywords=None, defaults=(None, None, True)), ('document', '33ce6ec50f8eeb05d340e6b114b026fd'))
 paddle.fluid.create_lod_tensor (ArgSpec(args=['data', 'recursive_seq_lens', 'place'], varargs=None, keywords=None, defaults=None), ('document', 'b82ea20e2dc5ff2372e0643169ca47ff'))
@@ -897,6 +897,7 @@ paddle.fluid.LoDTensorArray.append append(self: paddle.fluid.core_avx.LoDTensorA
 paddle.fluid.CPUPlace.__init__ __init__(self: paddle.fluid.core_avx.CPUPlace) -> None
 paddle.fluid.CUDAPlace.__init__ __init__(self: paddle.fluid.core_avx.CUDAPlace, arg0: int) -> None
 paddle.fluid.CUDAPinnedPlace.__init__ __init__(self: paddle.fluid.core_avx.CUDAPinnedPlace) -> None
+paddle.fluid.is_compiled_with_cuda is_compiled_with_cuda() -> bool
 paddle.fluid.ParamAttr.__init__ (ArgSpec(args=['self', 'name', 'initializer', 'learning_rate', 'regularizer', 'trainable', 'gradient_clip', 'do_model_average'], varargs=None, keywords=None, defaults=(None, None, 1.0, None, True, None, False)), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))
 paddle.fluid.WeightNormParamAttr.__init__ (ArgSpec(args=['self', 'dim', 'name', 'initializer', 'learning_rate', 'regularizer', 'trainable', 'gradient_clip', 'do_model_average'], varargs=None, keywords=None, defaults=(None, None, None, 1.0, None, True, None, False)), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))
 paddle.fluid.DataFeeder.__init__ (ArgSpec(args=['self', 'feed_list', 'place', 'program'], varargs=None, keywords=None, defaults=(None,)), ('document', '6adf97f83acf6453d4a6a4b1070f3754'))

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -792,7 +792,9 @@ All parameter, weight, gradient are variables in Paddle.
                  platform::GetCUDADeviceCount());
              new (&self) platform::CUDAPlace(dev_id);
 #else
-             PADDLE_THROW("Cannot use CUDAPlace in CPU only version");
+             PADDLE_THROW(
+                 "Cannot use GPUPlace because you have installed CPU version "
+                 "PaddlePaddle");
 #endif
            })
       .def("_type", &PlaceIndex<platform::CUDAPlace>)
@@ -835,7 +837,9 @@ All parameter, weight, gradient are variables in Paddle.
       .def("__init__",
            [](platform::CUDAPinnedPlace &self) {
 #ifndef PADDLE_WITH_CUDA
-             PADDLE_THROW("Cannot use CUDAPinnedPlace in CPU only version");
+             PADDLE_THROW(
+                 "Cannot use CUDAPinnedPlace because you have installed CPU "
+                 "version PaddlePaddle");
 #endif
              new (&self) platform::CUDAPinnedPlace();
            })

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -65,7 +65,7 @@ from . import incubate
 from . import distribute_lookup_table
 from .param_attr import ParamAttr, WeightNormParamAttr
 from .data_feeder import DataFeeder
-from .core import LoDTensor, LoDTensorArray, CPUPlace, CUDAPlace, CUDAPinnedPlace, Scope, _Scope
+from .core import LoDTensor, LoDTensorArray, CPUPlace, CUDAPlace, CUDAPinnedPlace, Scope, _Scope, is_compiled_with_cuda
 from .incubate import fleet
 from .incubate import data_generator
 from .transpiler import DistributeTranspiler, \
@@ -86,6 +86,7 @@ from .dygraph.nn import *
 from .dygraph.layers import *
 
 Tensor = LoDTensor
+GPUPlace = CUDAPlace
 
 __all__ = framework.__all__ + executor.__all__ + \
     trainer_desc.__all__ + inferencer.__all__ + transpiler.__all__ + \
@@ -106,7 +107,9 @@ __all__ = framework.__all__ + executor.__all__ + \
         'LoDTensorArray',
         'CPUPlace',
         'CUDAPlace',
+        'GPUPlace',
         'CUDAPinnedPlace',
+        'is_compiled_with_cuda',
         'Tensor',
         'ParamAttr',
         'WeightNormParamAttr',

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -353,11 +353,20 @@ class Executor(object):
                                fetch_list=[loss.name])
 
     Args:
-        place(fluid.CPUPlace|fluid.CUDAPlace(n)): indicate the executor run on which device.
+        place(None|fluid.CPUPlace|fluid.CUDAPlace(n)): indicate the 
+            executor run on which device. If place is None, place would 
+            be CUDAPlace(0) if Paddle is compiled with CUDA. Otherwise,
+            CPUPlace is chosen.   
 
     """
 
-    def __init__(self, place):
+    def __init__(self, place=None):
+        if place is None:
+            if core.is_compiled_with_cuda():
+                place = core.CUDAPlace(0)
+            else:
+                place = core.CPUPlace()
+
         self.place = place
         self.program_caches = dict()
         self.ctx_caches = dict()

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -41,6 +41,7 @@ __all__ = [
     'program_guard',
     'name_scope',
     'cuda_places',
+    'gpu_places',
     'cpu_places',
     'cuda_pinned_places',
     'in_dygraph_mode',
@@ -137,6 +138,9 @@ def cuda_places(device_ids=None):
     elif not isinstance(device_ids, (list, tuple)):
         device_ids = [device_ids]
     return [core.CUDAPlace(dev_id) for dev_id in device_ids]
+
+
+gpu_places = cuda_places
 
 
 def cpu_places(device_count=None):

--- a/python/paddle/fluid/parallel_executor.py
+++ b/python/paddle/fluid/parallel_executor.py
@@ -116,7 +116,7 @@ class ParallelExecutor(object):
     """
 
     def __init__(self,
-                 use_cuda,
+                 use_cuda=None,
                  loss_name=None,
                  main_program=None,
                  share_vars_from=None,
@@ -125,6 +125,9 @@ class ParallelExecutor(object):
                  num_trainers=1,
                  trainer_id=0,
                  scope=None):
+        if use_cuda is None:
+            use_cuda = core.is_compiled_with_cuda()
+
         if build_strategy is None:
             build_strategy = BuildStrategy()
 

--- a/python/paddle/fluid/tests/unittests/test_default_executor_place.py
+++ b/python/paddle/fluid/tests/unittests/test_default_executor_place.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import unittest
+
+
+def get_default_place():
+    return fluid.GPUPlace(0) if fluid.is_compiled_with_cuda(
+    ) else fluid.CPUPlace()
+
+
+class Test(unittest.TestCase):
+    def test_executor(self):
+        e = fluid.Executor()
+        self.assertTrue(e.place._equals(get_default_place()))
+
+        if fluid.is_compiled_with_cuda():
+            p = fluid.GPUPlace(0)
+            e = fluid.Executor(p)
+            self.assertTrue(e.place._equals(p))
+
+        p = fluid.CPUPlace()
+        e = fluid.Executor(p)
+        self.assertTrue(e.place._equals(p))
+
+    def test_pe(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            x = fluid.layers.data(shape=[-1, 32], name='x', dtype='float32')
+            y = fluid.layers.fc(x, size=16)
+            loss = fluid.layers.reduce_mean(y)
+            optimizer = fluid.optimizer.SGD(learning_rate=1e-3)
+            optimizer.minimize(loss)
+
+            places = [None, fluid.CPUPlace()]
+            if fluid.is_compiled_with_cuda():
+                places.append(fluid.GPUPlace(0))
+
+            for p in places:
+                if p is None:
+                    use_cuda = None
+                    use_cuda_actual = isinstance(get_default_place(),
+                                                 fluid.GPUPlace)
+                else:
+                    use_cuda = isinstance(p, fluid.GPUPlace)
+                    use_cuda_actual = use_cuda
+
+                pe = fluid.ParallelExecutor(
+                    use_cuda=use_cuda, loss_name=loss.name)
+                self.assertEquals(pe._compiled_program._exec_strategy.use_cuda,
+                                  use_cuda_actual)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR add default place to Executor. If Paddle is compiled with CUDA, default place would be `GPUPlace(0)`. Otherwise, `CPUPlace()` would be chosen.