### PR TITLE
[MKL-DNN]Bump up mkl-dnn to 0.20

### DIFF
--- a/cmake/external/mkldnn.cmake
+++ b/cmake/external/mkldnn.cmake
@@ -66,7 +66,7 @@ ExternalProject_Add(
     ${EXTERNAL_PROJECT_LOG_ARGS}
     DEPENDS             ${MKLDNN_DEPENDS}
     GIT_REPOSITORY      "https://github.com/intel/mkl-dnn.git"
-    GIT_TAG             "863ff6e7042cec7d2e29897fe9f0872e0888b0fc"
+    GIT_TAG             "aef88b7c233f48f8b945da310f1b973da31ad033"
     PREFIX              ${MKLDNN_SOURCES_DIR}
     UPDATE_COMMAND      ""
     CMAKE_ARGS          -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -640,7 +640,7 @@ class PoolingMKLDNNHandler : public MKLDNNHandler {
       int desired_size = ComputeCeiledOutput(src_tz[i + 2], kernel_size[i],
                                              paddings[i], strides[i]);
       if (desired_size != dst_tz[i + 2]) {
-        right_bot_padding[i] += strides[i];
+        right_bot_padding[i] += strides[i] - 1;
       }
     }
   }


### PR DESCRIPTION
Those changes are updating MKL-DNN from 0.19 to 0.20. 

Justification:
- Some new post operations (needed for some int8 workloads)
- better performance of sofmax & transpose ops (AVX512 platforms)
- inner product does work on 3D,4D,5D.. dimensional data so we can enable some workloads like BERT to use mkl-dnn FC more (enabling to be done after this is merged)
