### PR TITLE
fix ci document_preview job error

### DIFF
--- a/tools/document_preview.sh
+++ b/tools/document_preview.sh
@@ -5,6 +5,8 @@ cd ${PADDLE_ROOT}
 pip install /paddle/build/opt/paddle/share/wheels/*.whl
 git clone https://github.com/PaddlePaddle/FluidDoc
 git clone https://github.com/tianshuo78520a/PaddlePaddle.org.git
+cd  ${PADDLE_ROOT}/PaddlePaddle.org.git/
+git reset 3feaa68376d8423e41d076814e901e6bf108c705
 cd ${PADDLE_ROOT}/FluidDoc/doc/fluid/api
 sh gen_doc.sh
 apt-get update && apt-get install -y python-dev build-essential

--- a/tools/document_preview.sh
+++ b/tools/document_preview.sh
@@ -5,7 +5,7 @@ cd ${PADDLE_ROOT}
 pip install /paddle/build/opt/paddle/share/wheels/*.whl
 git clone https://github.com/PaddlePaddle/FluidDoc
 git clone https://github.com/tianshuo78520a/PaddlePaddle.org.git
-cd  ${PADDLE_ROOT}/PaddlePaddle.org.git/
+cd  ${PADDLE_ROOT}/PaddlePaddle.org
 git reset 3feaa68376d8423e41d076814e901e6bf108c705
 cd ${PADDLE_ROOT}/FluidDoc/doc/fluid/api
 sh gen_doc.sh


### PR DESCRIPTION
1.5版本后 发现官网预览方法有问题，不能正常预览。
解决办法：把paddlepaddle.org 回滚到旧版本，可以正常预览。