### PR TITLE
Memory leak query

### DIFF
--- a/paddle/fluid/framework/transfer_scope_cache.cc
+++ b/paddle/fluid/framework/transfer_scope_cache.cc
@@ -17,14 +17,17 @@
 namespace paddle {
 namespace framework {
 
+static std::unordered_map<size_t, Scope*>* x = nullptr;
+static std::unordered_set<Scope*>* y = nullptr;
+
 std::unordered_map<size_t, Scope*>& global_transfer_data_cache() {
-  thread_local auto* x = new std::unordered_map<size_t, Scope*>;
+  if (x == nullptr) x = new std::unordered_map<size_t, Scope*>;
   return *x;
 }
 
 std::unordered_set<Scope*>& global_transfer_scope_cache() {
-  thread_local auto* x = new std::unordered_set<Scope*>;
-  return *x;
+  if (y == nullptr) y = new std::unordered_set<Scope*>;
+  return *y;
 }
 
 Scope* TryCreateTransferScope(OpKernelType type0, OpKernelType type1,

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -155,6 +155,9 @@ if (NOT EXISTS ${MOBILENET_INSTALL_DIR})
 endif()
 inference_analysis_api_test_with_refer_result(test_analyzer_mobilenet_transpose ${MOBILENET_INSTALL_DIR} analyzer_vis_tester.cc)
 
+# detect
+inference_analysis_api_test_with_refer_result(test_analyzer_detect ${OCR_INSTALL_DIR} analyzer_detect_tester.cc)
+
 ### Image classification tests with fake data
 set(IMG_CLASS_TEST_APP "test_analyzer_image_classification")
 set(IMG_CLASS_TEST_APP_SRC "analyzer_image_classification_tester.cc")

--- a/paddle/fluid/inference/tests/api/analyzer_detect_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_detect_tester.cc
@@ -1,0 +1,143 @@
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <iostream>
+#include "paddle/fluid/inference/tests/api/tester_helper.h"
+DEFINE_string(infer_shape, "", "data shape file");
+DEFINE_int32(sample, 1, "number of sample");
+
+namespace paddle {
+namespace inference {
+namespace analysis {
+
+struct Record {
+  std::vector<float> data;
+  std::vector<int32_t> shape;
+};
+
+Record ProcessALine(const std::string &line, const std::string &shape_line) {
+  VLOG(3) << "process a line";
+  std::vector<std::string> columns;
+
+  Record record;
+  std::vector<std::string> data_strs;
+  split(line, ' ', &data_strs);
+  for (auto &d : data_strs) {
+    record.data.push_back(std::stof(d));
+  }
+
+  std::vector<std::string> shape_strs;
+  split(shape_line, ' ', &shape_strs);
+  for (auto &s : shape_strs) {
+    record.shape.push_back(std::stoi(s));
+  }
+  // VLOG(3) << "data size " << record.data.size();
+  // VLOG(3) << "data shape size " << record.shape.size();
+  // LOG(INFO) << "data shape size " << record.shape[3];
+  return record;
+}
+
+void SetConfig(AnalysisConfig *cfg) {
+  cfg->SetModel(FLAGS_infer_model + "/model", FLAGS_infer_model + "/params");
+  cfg->DisableGpu();
+  cfg->SwitchIrDebug();
+  cfg->SwitchSpecifyInputNames(false);
+  cfg->SetCpuMathLibraryNumThreads(FLAGS_paddle_num_threads);
+}
+
+void SetInput(std::vector<std::vector<PaddleTensor>> *inputs,
+              const std::string &line, const std::string &shape_line) {
+  auto record = ProcessALine(line, shape_line);
+
+  PaddleTensor input;
+  input.shape = record.shape;
+  input.dtype = PaddleDType::FLOAT32;
+  size_t input_size = record.data.size() * sizeof(float);
+  input.data.Resize(input_size);
+  memcpy(input.data.data(), record.data.data(), input_size);
+  std::vector<PaddleTensor> input_slots;
+  input_slots.assign({input});
+  (*inputs).emplace_back(input_slots);
+}
+
+// Easy for profiling independently.
+//  ocr, mobilenet and se_resnext50
+void profile(bool use_mkldnn = false) {
+  AnalysisConfig cfg;
+  SetConfig(&cfg);
+  if (use_mkldnn) {
+    cfg.EnableMKLDNN();
+    //    cfg.SetMKLDNNThreadId(-1);
+    std::unordered_set<std::string> op_list = {"concat"};
+    cfg.SetMKLDNNOp(op_list);
+  }
+  // cfg.pass_builder()->TurnOnDebug();
+  std::vector<std::vector<PaddleTensor>> outputs;
+  std::vector<std::vector<PaddleTensor>> input_slots_all;
+
+  Timer run_timer;
+  double elapsed_time = 0;
+
+  int iterations = FLAGS_sample;
+  int num_times = FLAGS_repeat;
+  auto predictor = CreatePaddlePredictor<AnalysisConfig>(cfg);
+  outputs.resize(iterations);
+
+  std::vector<std::thread> threads;
+
+  for (int j = 0; j < num_times; j++) {
+    std::ifstream file(FLAGS_infer_data);
+    std::ifstream infer_file(FLAGS_infer_shape);
+    std::string line;
+    std::string shape_line;
+
+    std::getline(file, line);
+    std::getline(infer_file, shape_line);
+    SetInput(&input_slots_all, line, shape_line);
+    for (int i = 0; i < iterations; i++) {
+      threads.emplace_back([&, i]() {
+        //       std::getline(file, line);
+        //       std::getline(infer_file, shape_line);
+        //       SetInput(&input_slots_all, line, shape_line);
+
+        run_timer.tic();
+        predictor->Run(input_slots_all[0], &outputs[0], FLAGS_batch_size);
+        elapsed_time += run_timer.toc();
+      });
+      threads[0].join();
+      threads.clear();
+      if (i % 100 == 0) LOG(INFO) << i << " samples";
+      //      std::vector<std::vector<PaddleTensor>>().swap(input_slots_all);
+    }
+
+    file.close();
+    infer_file.close();
+  }
+
+  auto batch_latency = elapsed_time / (iterations * num_times);
+  PrintTime(FLAGS_batch_size, num_times, FLAGS_num_threads, 0, batch_latency,
+            iterations, VarType::FP32);
+}
+
+TEST(Analyzer_vis, profile) { profile(); }
+
+#ifdef PADDLE_WITH_MKLDNN
+TEST(Analyzer_vis, profile_mkldnn) { profile(true /* use_mkldnn */); }
+#endif
+
+}  // namespace analysis
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
@@ -170,11 +170,12 @@ class ConcatMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto multi_input = ctx.MultiInput<Tensor>("X");
     EnforceLayouts(multi_input);
     Tensor* output = ctx.Output<Tensor>("Out");
-    int64_t concat_axis = static_cast<int64_t>(ctx.Attr<int>("axis"));
-    auto& dev_ctx =
-        ctx.template device_context<paddle::platform::MKLDNNDeviceContext>();
+    // int64_t concat_axis = static_cast<int64_t>(ctx.Attr<int>("axis"));
+    //    auto& dev_ctx =
+    //        ctx.template
+    //        device_context<paddle::platform::MKLDNNDeviceContext>();
     auto place = GetCpuPlace(ctx);
-
+#if 0
     memory::data_type dt =
         paddle::framework::ToMKLDNNDataType(multi_input[0]->type());
 
@@ -218,9 +219,10 @@ class ConcatMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     }
 
     stream(stream::kind::eager).submit({*concat_p}).wait();
-
+#endif
+    output->mutable_data<T>(place);
     output->set_layout(DataLayout::kMKLDNN);
-    output->set_format(GetDstMemFormat(*concat_pd));
+    output->set_format((memory::format)7);
   }
 };
 }  // namespace operators


### PR DESCRIPTION
在使用mkl的情况下，多线程执行同一个图片，用htop看，VIRT和RES都很稳定。
但是使用了mkldnn，并且只用到concat，同时concat内部任何mkldnn相关的操作都没有，只保留output tensor的mutable_data，RES会往上涨，VIRT也会隔一段时间往上涨。

命令行
./paddle/fluid/inference/tests/api/test_analyzer_detect --infer_model=/home/leozhao/tmp/densebox/ --infer_data=/home/leozhao/leo/detect_input.txt --infer_shape=/home/leozhao/leo/shape.txt --gtest_filter=Analyzer_vis.profile_mkldnn --paddle_num_threads=4 --repeat=1 --batch_size=1 --sample=5000