### PR TITLE
make fleet support mpi job submit directly

### DIFF
--- a/python/paddle/fluid/incubate/fleet/base/role_maker.py
+++ b/python/paddle/fluid/incubate/fleet/base/role_maker.py
@@ -198,7 +198,7 @@ class MPIRoleMaker(RoleMakerBase):
         """
         finalize the current MPI instance.
         """
-        pass
+        self.MPI.Finalize()
 
     def _get_ips(self):
         """
@@ -356,6 +356,7 @@ class PaddleCloudRoleMaker(RoleMakerBase):
             print("PaddleCloudRoleMaker() endpoints: %s" % self.endpoints)
             self.endpoints = self.endpoints.split(",")
             self._server_endpoints = self.endpoints
+            self._worker_endpoints = self.endpoints
             if self.role.upper() == "PSERVER":
                 self._current_id = self.endpoints.index(self.current_endpoint)
                 self._role = Role.SERVER


### PR DESCRIPTION
test=develop
support qsub to submit mpi job, depend on mpi4py. 
```bash
mpirun -npernode 2 python trainer.py
```
will startup 2 process one for trainer, the other one for server.
A user has to use MPISymetricRoleMaker to initialize fleet.