### PR TITLE
fix load attr error. test=develop

### DIFF
--- a/python/paddle/fluid/layers/io.py
+++ b/python/paddle/fluid/layers/io.py
@@ -1286,4 +1286,4 @@ def load(out, file_path, load_as_fp16=None):
     attrs = {"file_path": file_path}
     if load_as_fp16 is not None:
         attrs['load_as_fp16'] = load_as_fp16
-    helper.append_op(type="load", inputs={}, output={"Out": out}, args=attrs)
+    helper.append_op(type="load", inputs={}, output={"Out": out}, attrs=attrs)


### PR DESCRIPTION
**fix load error**

fix https://github.com/PaddlePaddle/Paddle/issues/18448

```python
import paddle.fluid as fluid

tmp_tensor = fluid.layers.create_tensor(dtype='float32')
fluid.layers.load(tmp_tensor, file_path="/home/aistudio/data/data8770/fc_0.w_0")
```
```
EnforceNotMetTraceback (most recent call last)<ipython-input-1-816998c8ff4b> in <module>()
      2 import paddle.fluid as fluid
      3 tmp_tensor = fluid.layers.create_tensor(dtype='float32')
----> 4 fluid.layers.load(tmp_tensor, file_path="/home/aistudio/data/data8770/fc_0.w_0", load_as_fp16=True)
/opt/conda/envs/python27-paddle120-env/lib/python2.7/site-packages/paddle/fluid/layers/io.pyc in load(out, file_path, load_as_fp16)
   1214     if load_as_fp16 is not None:
   1215         attrs['load_as_fp16'] = load_as_fp16
-> 1216     helper.append_op(type="load", inputs={}, output={"Out": out}, args=attrs)
/opt/conda/envs/python27-paddle120-env/lib/python2.7/site-packages/paddle/fluid/layer_helper.pyc in append_op(self, *args, **kwargs)
     41 
     42     def append_op(self, *args, **kwargs):
---> 43         return self.main_program.current_block().append_op(*args, **kwargs)
     44 
     45     def multiple_input(self, input_param_name='input'):
/opt/conda/envs/python27-paddle120-env/lib/python2.7/site-packages/paddle/fluid/framework.pyc in append_op(self, *args, **kwargs)
   1652                 inputs=kwargs.get("inputs", None),
   1653                 outputs=kwargs.get("outputs", None),
-> 1654                 attrs=kwargs.get("attrs", None))
   1655 
   1656             self.ops.append(op)
/opt/conda/envs/python27-paddle120-env/lib/python2.7/site-packages/paddle/fluid/framework.pyc in __init__(***failed resolving arguments***)
   1053                     self._update_desc_attr(attr_name, attr_val)
   1054 
-> 1055             self.desc.check_attrs()
   1056             if self._has_kernel(type):
   1057                 self.desc.infer_var_type(self.block.desc)
EnforceNotMet: Attribute 'file_path' is required! at [/paddle/paddle/fluid/framework/attribute.h:
```