### PR TITLE
Regroup fusion by date type.

### DIFF
--- a/paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.cc
+++ b/paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.cc
@@ -287,15 +287,11 @@ class AllocContinuousSpaceForGradPass : public ir::Pass {
 
     size_t j = 0;
     while (j < group_params_grads->size()) {
-      VLOG(10) << "j:" << j
-               << ", group_params_grads->size():" << group_params_grads->size();
       local_group_params_grads.emplace_back();
       auto &group_p_g = local_group_params_grads.back();
 
       size_t local_group_memory_size = 0;
       while (j < group_params_grads->size()) {
-        VLOG(10) << "second j:" << j << ", group_params_grads->size():"
-                 << group_params_grads->size();
         std::for_each(
             group_params_grads->at(j).begin(), group_params_grads->at(j).end(),
             [&local_group_memory_size,
@@ -348,7 +344,6 @@ class AllocContinuousSpaceForGradPass : public ir::Pass {
       const std::unordered_map<std::string, ir::Node *> &var_nodes,
       const details::ParamsAndGrads &params_grads,
       details::GroupParamsAndGrads *group_params_grads) const {
-    VLOG(10) << "begin ReGroupByMemoryOrLayerSize";
     if (IsUnifiedDtype(params_grads, var_nodes)) {
       VLOG(1) << "needn't regroup fusion params_grads";
       return;
@@ -384,8 +379,6 @@ class AllocContinuousSpaceForGradPass : public ir::Pass {
                                     local_group_params_grads.end());
     }
 
-    VLOG(10) << "final new_group_params_grads size:"
-             << new_group_params_grads.size();
     std::swap(*group_params_grads, new_group_params_grads);
 
     if (VLOG_IS_ON(10)) {

--- a/paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.cc
+++ b/paddle/fluid/framework/ir/alloc_continuous_space_for_grad_pass.cc
@@ -287,11 +287,15 @@ class AllocContinuousSpaceForGradPass : public ir::Pass {
 
     size_t j = 0;
     while (j < group_params_grads->size()) {
+      VLOG(10) << "j:" << j
+               << ", group_params_grads->size():" << group_params_grads->size();
       local_group_params_grads.emplace_back();
       auto &group_p_g = local_group_params_grads.back();
 
       size_t local_group_memory_size = 0;
       while (j < group_params_grads->size()) {
+        VLOG(10) << "second j:" << j << ", group_params_grads->size():"
+                 << group_params_grads->size();
         std::for_each(
             group_params_grads->at(j).begin(), group_params_grads->at(j).end(),
             [&local_group_memory_size,
@@ -344,15 +348,16 @@ class AllocContinuousSpaceForGradPass : public ir::Pass {
       const std::unordered_map<std::string, ir::Node *> &var_nodes,
       const details::ParamsAndGrads &params_grads,
       details::GroupParamsAndGrads *group_params_grads) const {
+    VLOG(10) << "begin ReGroupByMemoryOrLayerSize";
     if (IsUnifiedDtype(params_grads, var_nodes)) {
       VLOG(1) << "needn't regroup fusion params_grads";
       return;
     }
 
-    std::map<proto::VarType::Type, size_t> type_idx;
     details::GroupParamsAndGrads new_group_params_grads;
 
     for (auto &group_p_g : *group_params_grads) {
+      std::map<proto::VarType::Type, size_t> type_idx;
       details::GroupParamsAndGrads local_group_params_grads;
 
       for (auto &p_g : group_p_g) {
@@ -372,11 +377,15 @@ class AllocContinuousSpaceForGradPass : public ir::Pass {
         local.emplace_back(p_g);
       }
 
+      VLOG(10) << "local_group_params_grads size:"
+               << local_group_params_grads.size();
       new_group_params_grads.insert(new_group_params_grads.end(),
                                     local_group_params_grads.begin(),
                                     local_group_params_grads.end());
     }
 
+    VLOG(10) << "final new_group_params_grads size:"
+             << new_group_params_grads.size();
     std::swap(*group_params_grads, new_group_params_grads);
 
     if (VLOG_IS_ON(10)) {


### PR DESCRIPTION
A network may use various types which will break our group method and then the memory size and layer size method is not valid. So In this pr, I group the tensor first and then split them by the various types. The related pr is https://github.com/PaddlePaddle/Paddle/pull/17652.