### PR TITLE
Remove reshape2_grad infershape special handling 

### DIFF
--- a/paddle/fluid/operators/ngraph/ngraph_engine.cc
+++ b/paddle/fluid/operators/ngraph/ngraph_engine.cc
@@ -38,14 +38,8 @@ namespace operators {
 
 static ngraph::Shape Ddim2Shape(const framework::DDim& dims) {
   ngraph::Shape sp;
-  if (dims.size() == 1 && dims[0] == 0) {
-    sp.emplace_back(0);
-    return sp;
-  }
   for (int i = 0; i < dims.size(); ++i) {
-    int k = dims[i];
-    k = k == 0 ? 1 : k;
-    sp.emplace_back(k);
+    sp.emplace_back(dims[i]);
   }
   return sp;
 }
@@ -639,17 +633,7 @@ void NgraphEngine::Run(const framework::Scope& scope,
 
   for (auto& op : fused_ops_) {
     framework::RuntimeContext ctx(op->Inputs(), op->Outputs(), scope_);
-    if (op->Type() == "reshape2_grad") {
-      auto xshape_name = op->Inputs().at("XShape").at(0);
-      auto* xshape_var = scope_.FindVar(xshape_name);
-      auto* xshape_tensor = GetLoDTensorOrSelectedRowsValueFromVar(*xshape_var);
-      auto& xshape_ddim = xshape_tensor->dims();
-      auto xgrad_name = op->Outputs().at(framework::GradVarName("X")).at(0);
-      auto* xgrad_var = scope_.FindVar(xgrad_name);
-      xgrad_var->GetMutable<framework::LoDTensor>()->Resize(xshape_ddim);
-    } else {
-      op->RuntimeInferShape(scope_, place_, ctx);
-    }
+    op->RuntimeInferShape(scope_, place_, ctx);
   }
 
   std::vector<std::shared_ptr<ngraph::runtime::Tensor>> t_out = {};

--- a/paddle/fluid/operators/ngraph/ops/transpose_op.h
+++ b/paddle/fluid/operators/ngraph/ops/transpose_op.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <memory>
 #include <string>
@@ -50,7 +51,12 @@ static void BuildTransposeNode(
   x_transpose = platform::NgReshaper(x_transpose, x_reshape_shape);
   platform::SetOutputNode(op, "Out", x_transpose, ngb_node_map);
   if (is_v2) {
-    platform::SetOutputNode(op, "XShape", input, ngb_node_map);
+    ngraph::Shape input_xshape(input_shape.size() + 1);
+    input_xshape[0] = 0;
+    std::copy(input_shape.begin(), input_shape.end(), input_xshape.begin() + 1);
+    auto xshape_node = std::make_shared<ngraph::op::Constant>(
+        input->get_element_type(), input_xshape, std::vector<std::string>{});
+    platform::SetOutputNode(op, "XShape", xshape_node, ngb_node_map);
   }
 }
 
@@ -71,7 +77,10 @@ static void BuildTransposeGradNode(
 
   ngraph::Shape out_shape;
   if (is_v2) {
-    out_shape = platform::GetInputNode(op, "XShape", ngb_node_map)->get_shape();
+    auto& xshape =
+        platform::GetInputNode(op, "XShape", ngb_node_map)->get_shape();
+    out_shape.resize(xshape.size() - 1);
+    std::copy(xshape.begin() + 1, xshape.end(), out_shape.begin());
   } else {
     out_shape = platform::GetInputNode(op, "X", ngb_node_map)->get_shape();
   }


### PR DESCRIPTION
There was a reshape2_grad infershape special handling in ngraph engine as it has a dimension element of 0. This PR is to remove that special handling. reshape, transpose and gather ops are updated accordingly.