### PR TITLE
Refine fast NAN/INF debugger

### DIFF
--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -475,6 +475,9 @@ class OperatorWithKernel : public OperatorBase {
   void RunImpl(const Scope& scope, const platform::Place& place,
                RuntimeContext* runtime_ctx) const;
 
+  void RunImplDebug(const Scope& scope, const platform::Place& place,
+                    RuntimeContext* runtime_ctx) const;
+
   /**
    * Transfer data from scope to a transfered scope. If there is no data need to
    * be tranfered, it returns nullptr.


### PR DESCRIPTION
I refine the recently implemented NAN/INF by:

1. adding try-catch to in ``runimpl" to handle some unexpected cases.

2. adding skip_list in debugger.py, to enable users to skip vars that they do not care.