### PR TITLE
Fix memory leak in test

### DIFF
--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -85,5 +85,12 @@ int main(int argc, char** argv) {
   char** new_argv_address = new_argv.data();
   google::ParseCommandLineFlags(&new_argc, &new_argv_address, false);
   paddle::framework::InitDevices(true);
+
+  for (int i = argc; i < new_argv.size(); ++i) {
+    if (new_argv[i]) {
+      free(new_argv[i]);
+    }
+  }
+
   return RUN_ALL_TESTS();
 }

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -61,23 +61,23 @@ int main(int argc, char** argv) {
   undefok.push_back("initial_cpu_memory_in_mb");
 #endif
 
-  std::string env_string = "--tryfromenv=";
   if (envs.size() > 0) {
+    std::string env_string = "--tryfromenv=";
     for (auto t : envs) {
       env_string += t + ",";
     }
     env_string = env_string.substr(0, env_string.length() - 1);
-    new_argv.push_back(const_cast<char*>(env_string.c_str()));
+    new_argv.push_back(strdup(env_string.c_str()));
     VLOG(1) << "gtest env_string:" << env_string;
   }
 
-  std::string undefok_string = "--undefok=";
   if (undefok.size() > 0) {
+    std::string undefok_string = "--undefok=";
     for (auto t : undefok) {
       undefok_string += t + ",";
     }
     undefok_string = undefok_string.substr(0, undefok_string.length() - 1);
-    new_argv.push_back(const_cast<char*>(undefok_string.c_str()));
+    new_argv.push_back(strdup(undefok_string.c_str()));
     VLOG(1) << "gtest undefok_string:" << undefok_string;
   }
 
@@ -86,5 +86,13 @@ int main(int argc, char** argv) {
   google::ParseCommandLineFlags(&new_argc, &new_argv_address, false);
   paddle::framework::InitDevices(true);
 
-  return RUN_ALL_TESTS();
+  int ret = RUN_ALL_TESTS();
+
+  for (int i = argc; i < new_argv.size(); ++i) {
+    if (new_argv[i]) {
+      free(new_argv[i]);
+    }
+  }
+
+  return ret;
 }

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -61,23 +61,23 @@ int main(int argc, char** argv) {
   undefok.push_back("initial_cpu_memory_in_mb");
 #endif
 
+  std::string env_string = "--tryfromenv=";
   if (envs.size() > 0) {
-    std::string env_string = "--tryfromenv=";
     for (auto t : envs) {
       env_string += t + ",";
     }
     env_string = env_string.substr(0, env_string.length() - 1);
-    new_argv.push_back(strdup(env_string.c_str()));
+    new_argv.push_back(const_cast<char*>(env_string.c_str()));
     VLOG(1) << "gtest env_string:" << env_string;
   }
 
+  std::string undefok_string = "--undefok=";
   if (undefok.size() > 0) {
-    std::string undefok_string = "--undefok=";
     for (auto t : undefok) {
       undefok_string += t + ",";
     }
     undefok_string = undefok_string.substr(0, undefok_string.length() - 1);
-    new_argv.push_back(strdup(undefok_string.c_str()));
+    new_argv.push_back(const_cast<char*>(undefok_string.c_str()));
     VLOG(1) << "gtest undefok_string:" << undefok_string;
   }
 
@@ -85,12 +85,6 @@ int main(int argc, char** argv) {
   char** new_argv_address = new_argv.data();
   google::ParseCommandLineFlags(&new_argc, &new_argv_address, false);
   paddle::framework::InitDevices(true);
-
-  for (int i = argc; i < new_argv.size(); ++i) {
-    if (new_argv[i]) {
-      free(new_argv[i]);
-    }
-  }
 
   return RUN_ALL_TESTS();
 }

--- a/paddle/testing/paddle_gtest_main.cc
+++ b/paddle/testing/paddle_gtest_main.cc
@@ -61,23 +61,27 @@ int main(int argc, char** argv) {
   undefok.push_back("initial_cpu_memory_in_mb");
 #endif
 
+  char* env_str = nullptr;
   if (envs.size() > 0) {
     std::string env_string = "--tryfromenv=";
     for (auto t : envs) {
       env_string += t + ",";
     }
     env_string = env_string.substr(0, env_string.length() - 1);
-    new_argv.push_back(strdup(env_string.c_str()));
+    env_str = strdup(env_string.c_str());
+    new_argv.push_back(env_str);
     VLOG(1) << "gtest env_string:" << env_string;
   }
 
+  char* undefok_str = nullptr;
   if (undefok.size() > 0) {
     std::string undefok_string = "--undefok=";
     for (auto t : undefok) {
       undefok_string += t + ",";
     }
     undefok_string = undefok_string.substr(0, undefok_string.length() - 1);
-    new_argv.push_back(strdup(undefok_string.c_str()));
+    undefok_str = strdup(undefok_string.c_str());
+    new_argv.push_back(undefok_str);
     VLOG(1) << "gtest undefok_string:" << undefok_string;
   }
 
@@ -88,11 +92,8 @@ int main(int argc, char** argv) {
 
   int ret = RUN_ALL_TESTS();
 
-  for (int i = argc; i < new_argv.size(); ++i) {
-    if (new_argv[i]) {
-      free(new_argv[i]);
-    }
-  }
+  if (env_str) free(env_str);
+  if (undefok_str) free(undefok_str);
 
   return ret;
 }


### PR DESCRIPTION
This PR fixes the memory leak in the module that initiates all unit tests.

The fix is not critical because the system will deallocate the memory when exiting the function, but limits the number of errors in the AddressSanitizer report: `==56712==ERROR: LeakSanitizer: detected memory leaks`