### PR TITLE
resolve: #18624

### DIFF
--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -111,7 +111,8 @@ int GetCUDAComputeCapability(int id) {
   auto e = cudaGetDeviceProperties(&device_prop, id);
   int a = 10;
   char c[] = "helloworld";
-  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), a, c);
+  string str = "helloworld";
+  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), a, c, str);
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -110,7 +110,7 @@ int GetCUDAComputeCapability(int id) {
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
   int a = 10;
-  char c = '1';
+  char c[10] = "helloworld";
   PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), a, c);
   return device_prop.major * 10 + device_prop.minor;
 }

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -113,12 +113,13 @@ int GetCUDAComputeCapability(int id) {
   std::ostringstream ostr;
   ostr << "cudaGetDeviceProperties failed in"
           "paddle::platform::GetCUDAComputeCapability!"
-          "Error Type ID = " << e << " Please see detail in:"
-          "https://docs.nvidia.com/cuda/cuda-runtime-api/"
-          "group__CUDART__TYPES.html#group__CUDART__TYPES_"
-          "1g3f51e3575c2178246db0a94a430e0038");
+          "Error Type ID = "
+       << e << " Please see detail in:"
+               "https://docs.nvidia.com/cuda/cuda-runtime-api/"
+               "group__CUDART__TYPES.html#group__CUDART__TYPES_"
+               "1g3f51e3575c2178246db0a94a430e0038";
   ErrorLog = ostr.str();
-  PADDLE_ENFORCE(e, ErrorLog);
+  PADDLE_ENFORCE(e, "helllo");
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -110,7 +110,8 @@ int GetCUDAComputeCapability(int id) {
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
   int a = 10;
-  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), e);
+  char c = '1';
+  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), a, c);
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -110,7 +110,7 @@ int GetCUDAComputeCapability(int id) {
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
   int a = 10;
-  char c[10] = "helloworld";
+  char c[] = "helloworld";
   PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), a, c);
   return device_prop.major * 10 + device_prop.minor;
 }

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -109,10 +109,16 @@ int GetCUDAComputeCapability(int id) {
   PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
-  int a = 10;
-  char c[] = "helloworld";
-  string str = "helloworld";
-  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), a, c, str);
+  char ErrorLog[50];
+  snprintf(ErrorLog, sizeof(ErrorLog),
+           "cudaGetDeviceProperties failed in"
+           "paddle::platform::GetCUDAComputeCapability!"
+           "Error Type ID = %d , Detail:"
+           "https://docs.nvidia.com/cuda/cuda-runtime-api/"
+           "group__CUDART__TYPES.html#group__CUDART__TYPES_"
+           "1g3f51e3575c2178246db0a94a430e0038",
+           e);
+  PADDLE_ENFORCE(e, ErrorLog);
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -109,15 +109,15 @@ int GetCUDAComputeCapability(int id) {
   PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
-  char ErrorLog[50];
-  snprintf(ErrorLog, sizeof(ErrorLog),
-           "cudaGetDeviceProperties failed in"
-           "paddle::platform::GetCUDAComputeCapability!"
-           "Error Type ID = %d , Detail:"
-           "https://docs.nvidia.com/cuda/cuda-runtime-api/"
-           "group__CUDART__TYPES.html#group__CUDART__TYPES_"
-           "1g3f51e3575c2178246db0a94a430e0038",
-           e);
+  std::string ErrorLog;
+  std::ostringstream ostr;
+  ostr << "cudaGetDeviceProperties failed in"
+          "paddle::platform::GetCUDAComputeCapability!"
+          "Error Type ID = " << e << " Please see detail in:"
+          "https://docs.nvidia.com/cuda/cuda-runtime-api/"
+          "group__CUDART__TYPES.html#group__CUDART__TYPES_"
+          "1g3f51e3575c2178246db0a94a430e0038");
+  ErrorLog = ostr.str();
   PADDLE_ENFORCE(e, ErrorLog);
   return device_prop.major * 10 + device_prop.minor;
 }

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -109,9 +109,8 @@ int GetCUDAComputeCapability(int id) {
   PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
-  PADDLE_ENFORCE(
-      cudaGetDeviceProperties(&device_prop, id),
-      "cudaGetDeviceProperties failedp in cudaGetDeviceProperties failed in");
+  int a = 10;
+  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), "aaa", a);
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -110,7 +110,7 @@ int GetCUDAComputeCapability(int id) {
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
   int a = 10;
-  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), "aaa", e);
+  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), e);
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -110,7 +110,7 @@ int GetCUDAComputeCapability(int id) {
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
   int a = 10;
-  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), "aaa", a);
+  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id), "aaa", e);
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -109,13 +109,9 @@ int GetCUDAComputeCapability(int id) {
   PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
-  PADDLE_ENFORCE(cudaGetDeviceProperties(&device_prop, id),
-                 "cudaGetDeviceProperties failed in "
-                 "paddle::platform::GetCUDAComputeCapability!"
-                 "Error Type ID ="
-                 "https://docs.nvidia.com/cuda/cuda-runtime-api/"
-                 "group__CUDART__TYPES.html#group__CUDART__TYPES_"
-                 "1g3f51e3575c2178246db0a94a430e0038");
+  PADDLE_ENFORCE(
+      cudaGetDeviceProperties(&device_prop, id),
+      "cudaGetDeviceProperties failedp in cudaGetDeviceProperties failed in");
   return device_prop.major * 10 + device_prop.minor;
 }
 

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -109,7 +109,6 @@ int GetCUDAComputeCapability(int id) {
   PADDLE_ENFORCE_LT(id, GetCUDADeviceCount(), "id must less than GPU count");
   cudaDeviceProp device_prop;
   auto e = cudaGetDeviceProperties(&device_prop, id);
-  std::string ErrorLog;
   std::ostringstream ostr;
   ostr << "cudaGetDeviceProperties failed in"
           "paddle::platform::GetCUDAComputeCapability!"
@@ -118,8 +117,8 @@ int GetCUDAComputeCapability(int id) {
                "https://docs.nvidia.com/cuda/cuda-runtime-api/"
                "group__CUDART__TYPES.html#group__CUDART__TYPES_"
                "1g3f51e3575c2178246db0a94a430e0038";
-  ErrorLog = ostr.str();
-  PADDLE_ENFORCE(e, "helllo");
+  std::string ErrorLog = ostr.str();
+  PADDLE_ENFORCE(e, ErrorLog);
   return device_prop.major * 10 + device_prop.minor;
 }
 


### PR DESCRIPTION
Error log is currently only prompting the call to the CUDA API to fail. You can't see the detailed error information. It's not good for debug. Optimize it as follows:
Typing out the specific error types of calling CUDA API and prompting users to go to nvidia's official website to see the error value explanation.
For example: 
cudaGetDeviceProperties failed in paddle::platform::GetCUDAComputeCapability! 
Error Type ID = 1, Please see detail in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g3f51e3575c2178246db0a94a430e0038