### PR TITLE
Fix the compiling issue with AVX512F macro

### DIFF
--- a/paddle/fluid/operators/jit/more/intrinsic/crf_decoding.cc
+++ b/paddle/fluid/operators/jit/more/intrinsic/crf_decoding.cc
@@ -46,7 +46,7 @@ void CRFDecoding(const int seq_len, const float* x, const float* w,
     x_content = _mm512_loadu_ps(x + i_offset);
     alpha_content = _mm512_add_ps(w_content, x_content);
     // Save the alpha value.
-    _mm512_storeu_ps(alpha_value + i_offset, alpha_content);
+    _mm512_storeu_ps(alpha + i_offset, alpha_content);
 #else
     // AVX or AVX2
     // weights, input and alpha values.
@@ -131,13 +131,12 @@ void CRFDecoding(const int seq_len, const float* x, const float* w,
       }
 /* Update the alpha and track values. */
 #ifdef __AVX512F__
-      __m512 x_content =
-          _mm512_loadu_ps(x + seq_offset + this->num_ + j_offset);
+      __m512 x_content = _mm512_loadu_ps(x + seq_offset + tag_num + j_offset);
       max_score = _mm512_add_ps(max_score, x_content);
-      _mm512_storeu_ps(alpha + seq_offset + this->num_ + j_offset, max_score);
-      _mm512_storeu_si512(reinterpret_cast<__m512i*>(track + seq_offset +
-                                                     this->num_ + j_offset),
-                          max_j);
+      _mm512_storeu_ps(alpha + seq_offset + tag_num + j_offset, max_score);
+      _mm512_storeu_si512(
+          reinterpret_cast<__m512i*>(track + seq_offset + tag_num + j_offset),
+          max_j);
 #else
       __m256 x_content = _mm256_loadu_ps(x + seq_offset + tag_num + j_offset);
       max_score = _mm256_add_ps(max_score, x_content);


### PR DESCRIPTION
When enabled the AVX512 flags, it shows the compile error.  Now we provided this PR for it.

The below patch is to enable AVX512F flag to verify this PR.
```
diff --git a/cmake/configure.cmake b/cmake/configure.cmake
index 5f7b4a4..d2ee77b 100644
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -28,7 +28,10 @@ if(NOT WITH_PROFILER)
add_definitions(-DPADDLE_DISABLE_PROFILER)
endif(NOT WITH_PROFILER)

-if(WITH_AVX AND AVX_FOUND)
+if(WITH_AVX AND AVX512F_FOUND)
+set(SIMD_FLAG ${AVX512F_FLAG})
+add_definitions(-DPADDLE_WITH_AVX)
+elseif(WITH_AVX AND AVX_FOUND)
set(SIMD_FLAG ${AVX_FLAG})
add_definitions(-DPADDLE_WITH_AVX)
elseif(SSE3_FOUND)
```