### PR TITLE
Change select_rows add from math::scatter::MergeAdd to SelectedRowsAd…

### DIFF
--- a/paddle/fluid/operators/sum_op.h
+++ b/paddle/fluid/operators/sum_op.h
@@ -16,6 +16,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/operators/math/selected_rows_functor.h"
+#include "paddle/fluid/platform/profiler.h"
 
 namespace paddle {
 namespace operators {
@@ -37,9 +38,8 @@ void SelectedRowsCompute(const framework::ExecutionContext &context) {
     return;
   }
 
-  std::vector<const paddle::framework::SelectedRows *> inputs;
+  std::vector<paddle::framework::SelectedRows *> inputs;
   SelectedRows temp_in0;
-
   if (in_place) {
     auto &in0 = in_vars[0]->Get<SelectedRows>();
     temp_in0.set_height(in0.height());
@@ -50,34 +50,52 @@ void SelectedRowsCompute(const framework::ExecutionContext &context) {
     for (size_t i = 1; i < in_vars.size(); ++i) {
       auto &in = in_vars[i]->Get<SelectedRows>();
       if (in.rows().size() > 0) {
-        inputs.push_back(&in);
+          temp_in0.set_height(in.height());
+          temp_in0.set_rows(in.rows());
+          framework::TensorCopy(in.value(), in.place(), context.device_context(),
+                          temp_in0.mutable_value());
+         inputs.push_back(&temp_in0);
       }
     }
   } else {
     for (auto &in_var : in_vars) {
       auto &in = in_var->Get<SelectedRows>();
       if (in.rows().size() > 0) {
-        inputs.push_back(&in_var->Get<SelectedRows>());
+          temp_in0.set_height(in.height());
+          temp_in0.set_rows(in.rows());
+          framework::TensorCopy(in.value(), in.place(), context.device_context(),
+                          temp_in0.mutable_value());
+          inputs.push_back(&temp_in0);
       }
     }
   }
 
-  auto *out = context.Output<SelectedRows>("Out");
+  auto out = context.Output<SelectedRows>("Out");
   out->mutable_rows()->clear();
-
+  std::vector<int64_t> input1_offsize; 
   bool has_data = false;
-  for (auto &in : inputs) {
-    if (in->rows().size() > 0) {
+  framework::DDim out_dim;
+ 
+  for (size_t idx = 0; idx < inputs.size(); ++idx) {
       has_data = true;
-      break;
-    }
+      out_dim = inputs[idx]->value().dims();
+      if (idx == 0) {
+          input1_offsize.push_back(0);
+      } else {
+          input1_offsize.push_back(inputs[idx-1]->value().numel());
+      }
   }
   if (has_data) {
-    math::scatter::MergeAdd<DeviceContext, T> merge_add;
-    merge_add(context.template device_context<DeviceContext>(), inputs, out);
-
-    out->SyncIndex();
-
+    int64_t row_num = 0;
+    for (auto &in : inputs) {
+        row_num += in->rows().size();
+    }
+      
+    out_dim[0] = row_num;
+    out->mutable_value()->Resize(out_dim);
+    out->mutable_value()->mutable_data<T>(context.GetPlace());
+    paddle::operators::math::SelectedRowsSumTo<DeviceContext,float>add_functor;
+    add_functor(context.template device_context<DeviceContext>(), inputs, input1_offsize, out);
   } else {
     // no data, just set a empty out tensor.
     out->mutable_value()->mutable_data<T>(framework::make_ddim({0}),

--- a/paddle/fluid/operators/sum_op.h
+++ b/paddle/fluid/operators/sum_op.h
@@ -16,7 +16,6 @@ limitations under the License. */
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/operators/math/selected_rows_functor.h"
-#include "paddle/fluid/platform/profiler.h"
 
 namespace paddle {
 namespace operators {


### PR DESCRIPTION
…dTo() on select_rows_function.h.

From profile test, after change it, the compute speed is 20 times faster than before.
test=develop
Before change:
<img width="1163" alt="profile2" src="https://user-images.githubusercontent.com/1527350/61294804-3c383780-a809-11e9-964d-16a46f62a660.png">
After change:
<img width="1179" alt="profile1" src="https://user-images.githubusercontent.com/1527350/61294823-43f7dc00-a809-11e9-8710-dd1bad8d21e9.png">
