### PR TITLE
change the dtype of op's unittests from float to double, to get higher precision in gradiant check.

### DIFF
--- a/paddle/fluid/operators/cos_sim_op.cc
+++ b/paddle/fluid/operators/cos_sim_op.cc
@@ -169,7 +169,9 @@ REGISTER_OPERATOR(cos_sim, ops::CosSimOp, ops::CosSimOpMaker,
                   paddle::framework::DefaultGradOpDescMaker<true>);
 REGISTER_OPERATOR(cos_sim_grad, ops::CosSimOpGrad);
 REGISTER_OP_CPU_KERNEL(
-    cos_sim, ops::CosSimKernel<paddle::platform::CPUDeviceContext, float>);
+    cos_sim, ops::CosSimKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CosSimKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     cos_sim_grad,
-    ops::CosSimGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::CosSimGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CosSimGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/cos_sim_op.cu
+++ b/paddle/fluid/operators/cos_sim_op.cu
@@ -15,7 +15,9 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    cos_sim, ops::CosSimKernel<paddle::platform::CUDADeviceContext, float>);
+    cos_sim, ops::CosSimKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::CosSimKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
     cos_sim_grad,
-    ops::CosSimGradKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::CosSimGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::CosSimGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/crop_op.cc
+++ b/paddle/fluid/operators/crop_op.cc
@@ -207,6 +207,8 @@ REGISTER_OPERATOR(crop, ops::CropOp, ops::CropOpMaker,
                   ops::CropGradOpDescMaker);
 REGISTER_OPERATOR(crop_grad, ops::CropOpGrad);
 REGISTER_OP_CPU_KERNEL(
-    crop, ops::CropKernel<paddle::platform::CPUDeviceContext, float>);
+    crop, ops::CropKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CropKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
-    crop_grad, ops::CropGradKernel<paddle::platform::CPUDeviceContext, float>);
+    crop_grad, ops::CropGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CropGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/crop_op.cu
+++ b/paddle/fluid/operators/crop_op.cu
@@ -15,6 +15,8 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    crop, ops::CropKernel<paddle::platform::CUDADeviceContext, float>);
+    crop, ops::CropKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::CropKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
-    crop_grad, ops::CropGradKernel<paddle::platform::CUDADeviceContext, float>);
+    crop_grad, ops::CropGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::CropGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/detection/roi_perspective_transform_op.cc
+++ b/paddle/fluid/operators/detection/roi_perspective_transform_op.cc
@@ -648,6 +648,8 @@ REGISTER_OPERATOR(roi_perspective_transform, ops::ROIPerspectiveTransformOp,
 REGISTER_OPERATOR(roi_perspective_transform_grad,
                   ops::ROIPerspectiveTransformGradOp);
 REGISTER_OP_CPU_KERNEL(roi_perspective_transform,
-                       ops::CPUROIPerspectiveTransformOpKernel<float>);
+                       ops::CPUROIPerspectiveTransformOpKernel<float>,
+                       ops::CPUROIPerspectiveTransformOpKernel<double>);
 REGISTER_OP_CPU_KERNEL(roi_perspective_transform_grad,
-                       ops::CPUROIPerspectiveTransformGradOpKernel<float>);
+                       ops::CPUROIPerspectiveTransformGradOpKernel<float>,
+                       ops::CPUROIPerspectiveTransformGradOpKernel<double>);

--- a/paddle/fluid/operators/hinge_loss_op.cc
+++ b/paddle/fluid/operators/hinge_loss_op.cc
@@ -125,8 +125,9 @@ REGISTER_OPERATOR(hinge_loss, ops::HingeLossOp, ops::HingeLossOpMaker<float>,
                   ops::HingeLossGradOpDescMaker);
 REGISTER_OPERATOR(hinge_loss_grad, ops::HingeLossGradOp);
 REGISTER_OP_CPU_KERNEL(
-    hinge_loss,
-    ops::HingeLossKernel<paddle::platform::CPUDeviceContext, float>);
+    hinge_loss, ops::HingeLossKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::HingeLossKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     hinge_loss_grad,
-    ops::HingeLossGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::HingeLossGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::HingeLossGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/hinge_loss_op.cu
+++ b/paddle/fluid/operators/hinge_loss_op.cu
@@ -16,7 +16,9 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     hinge_loss,
-    ops::HingeLossKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::HingeLossKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::HingeLossKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
     hinge_loss_grad,
-    ops::HingeLossGradKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::HingeLossGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::HingeLossGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/im2sequence_op.cc
+++ b/paddle/fluid/operators/im2sequence_op.cc
@@ -172,7 +172,9 @@ REGISTER_OPERATOR(im2sequence, ops::Im2SequenceOp, ops::Im2SequenceOpMaker,
 REGISTER_OPERATOR(im2sequence_grad, ops::Im2SequenceGradOp);
 REGISTER_OP_CPU_KERNEL(
     im2sequence,
-    ops::Im2SequenceKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::Im2SequenceKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::Im2SequenceKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     im2sequence_grad,
-    ops::Im2SequenceGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::Im2SequenceGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::Im2SequenceGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/im2sequence_op.cu
+++ b/paddle/fluid/operators/im2sequence_op.cu
@@ -17,7 +17,9 @@ namespace ops = paddle::operators;
 
 REGISTER_OP_CUDA_KERNEL(
     im2sequence,
-    ops::Im2SequenceKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::Im2SequenceKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::Im2SequenceKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
     im2sequence_grad,
-    ops::Im2SequenceGradKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::Im2SequenceGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::Im2SequenceGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/l1_norm_op.cc
+++ b/paddle/fluid/operators/l1_norm_op.cc
@@ -87,7 +87,9 @@ REGISTER_OPERATOR(l1_norm, ops::L1NormOp, ops::L1NormOpMaker,
                   ops::L1NormGradDescMaker);
 REGISTER_OPERATOR(l1_norm_grad, ops::L1NormGradOp);
 REGISTER_OP_CPU_KERNEL(
-    l1_norm, ops::L1NormKernel<paddle::platform::CPUDeviceContext, float>);
+    l1_norm, ops::L1NormKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::L1NormKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     l1_norm_grad,
-    ops::L1NormGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::L1NormGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::L1NormGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/l1_norm_op.cu
+++ b/paddle/fluid/operators/l1_norm_op.cu
@@ -15,7 +15,9 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    l1_norm, ops::L1NormKernel<paddle::platform::CUDADeviceContext, float>);
+    l1_norm, ops::L1NormKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::L1NormKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
     l1_norm_grad,
-    ops::L1NormGradKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::L1NormGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::L1NormGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/maxout_op.cc
+++ b/paddle/fluid/operators/maxout_op.cc
@@ -102,7 +102,9 @@ REGISTER_OPERATOR(maxout, ops::MaxOutOp, ops::MaxOutOpMaker,
                   paddle::framework::DefaultGradOpDescMaker<true>);
 REGISTER_OPERATOR(maxout_grad, ops::MaxOutOpGrad);
 REGISTER_OP_CPU_KERNEL(
-    maxout, ops::MaxOutKernel<paddle::platform::CPUDeviceContext, float>);
+    maxout, ops::MaxOutKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::MaxOutKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     maxout_grad,
-    ops::MaxOutGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::MaxOutGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::MaxOutGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/metrics/auc_op.cc
+++ b/paddle/fluid/operators/metrics/auc_op.cc
@@ -110,4 +110,5 @@ There are two types of possible curves:
 
 namespace ops = paddle::operators;
 REGISTER_OP_WITHOUT_GRADIENT(auc, ops::AucOp, ops::AucOpMaker);
-REGISTER_OP_CPU_KERNEL(auc, ops::AucKernel<paddle::platform::CPUPlace, float>);
+REGISTER_OP_CPU_KERNEL(auc, ops::AucKernel<paddle::platform::CPUPlace, float>,
+                       ops::AucKernel<paddle::platform::CPUPlace, double>);

--- a/paddle/fluid/operators/minus_op.cc
+++ b/paddle/fluid/operators/minus_op.cc
@@ -107,4 +107,5 @@ class MinusGradMaker : public framework::GradOpDescMakerBase {
 namespace ops = paddle::operators;
 REGISTER_OPERATOR(minus, ops::MinusOp, ops::MinusOpMaker, ops::MinusGradMaker);
 REGISTER_OP_CPU_KERNEL(
-    minus, ops::MinusKernel<paddle::platform::CPUDeviceContext, float>);
+    minus, ops::MinusKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::MinusKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/minus_op.cu
+++ b/paddle/fluid/operators/minus_op.cu
@@ -16,4 +16,6 @@ limitations under the License. */
 
 REGISTER_OP_CUDA_KERNEL(
     minus,
-    paddle::operators::MinusKernel<paddle::platform::CUDADeviceContext, float>);
+    paddle::operators::MinusKernel<paddle::platform::CUDADeviceContext, float>,
+    paddle::operators::MinusKernel<paddle::platform::CUDADeviceContext,
+                                   double>);

--- a/paddle/fluid/operators/optimizers/ftrl_op.cc
+++ b/paddle/fluid/operators/optimizers/ftrl_op.cc
@@ -151,4 +151,5 @@ The paper that proposed Follow The Regularized Leader (FTRL):
 namespace ops = paddle::operators;
 REGISTER_OP_WITHOUT_GRADIENT(ftrl, ops::FTRLOp, ops::FTRLOpMaker);
 REGISTER_OP_CPU_KERNEL(
-    ftrl, ops::FTRLOpKernel<paddle::platform::CPUDeviceContext, float>);
+    ftrl, ops::FTRLOpKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::FTRLOpKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/ftrl_op.cu
+++ b/paddle/fluid/operators/optimizers/ftrl_op.cu
@@ -14,4 +14,5 @@ specific language governing permissions and limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    ftrl, ops::FTRLOpKernel<paddle::platform::CUDADeviceContext, float>);
+    ftrl, ops::FTRLOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::FTRLOpKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/proximal_adagrad_op.cc
+++ b/paddle/fluid/operators/optimizers/proximal_adagrad_op.cc
@@ -118,4 +118,5 @@ REGISTER_OP_WITHOUT_GRADIENT(proximal_adagrad, ops::ProximalAdagradOp,
                              ops::ProximalAdagradOpMaker);
 REGISTER_OP_CPU_KERNEL(
     proximal_adagrad,
-    ops::ProximalAdagradOpKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::ProximalAdagradOpKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::ProximalAdagradOpKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/proximal_adagrad_op.cu
+++ b/paddle/fluid/operators/optimizers/proximal_adagrad_op.cu
@@ -15,4 +15,5 @@ specific language governing permissions and limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     proximal_adagrad,
-    ops::ProximalAdagradOpKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::ProximalAdagradOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::ProximalAdagradOpKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/proximal_gd_op.cc
+++ b/paddle/fluid/operators/optimizers/proximal_gd_op.cc
@@ -99,4 +99,5 @@ REGISTER_OP_WITHOUT_GRADIENT(proximal_gd, ops::ProximalGDOp,
                              ops::ProximalGDOpMaker);
 REGISTER_OP_CPU_KERNEL(
     proximal_gd,
-    ops::ProximalGDOpKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::ProximalGDOpKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::ProximalGDOpKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/proximal_gd_op.cu
+++ b/paddle/fluid/operators/optimizers/proximal_gd_op.cu
@@ -15,4 +15,5 @@ specific language governing permissions and limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     proximal_gd,
-    ops::ProximalGDOpKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::ProximalGDOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::ProximalGDOpKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/rmsprop_op.cc
+++ b/paddle/fluid/operators/optimizers/rmsprop_op.cc
@@ -143,4 +143,5 @@ http://www.cs.toronto.edu/~tijmen/csc321/slides/lecture_slides_lec6.pdf)
 namespace ops = paddle::operators;
 REGISTER_OP_WITHOUT_GRADIENT(rmsprop, ops::RmspropOp, ops::RmspropOpMaker);
 REGISTER_OP_CPU_KERNEL(
-    rmsprop, ops::RmspropOpKernel<paddle::platform::CPUDeviceContext, float>);
+    rmsprop, ops::RmspropOpKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::RmspropOpKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/rmsprop_op.cu
+++ b/paddle/fluid/operators/optimizers/rmsprop_op.cu
@@ -15,4 +15,5 @@ limitations under the License. */
 
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
-    rmsprop, ops::RmspropOpKernel<paddle::platform::CUDADeviceContext, float>);
+    rmsprop, ops::RmspropOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::RmspropOpKernel<paddle::platform::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/row_conv_op.cc
+++ b/paddle/fluid/operators/row_conv_op.cc
@@ -292,7 +292,9 @@ REGISTER_OPERATOR(row_conv, ops::RowConvOp, ops::RowConvOpMaker,
                   ops::RowConvGradOpDescMaker);
 REGISTER_OPERATOR(row_conv_grad, ops::RowConvGradOp);
 REGISTER_OP_CPU_KERNEL(
-    row_conv, ops::RowConvKernel<paddle::platform::CPUDeviceContext, float>);
+    row_conv, ops::RowConvKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::RowConvKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     row_conv_grad,
-    ops::RowConvGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::RowConvGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::RowConvGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/scatter_op.cc
+++ b/paddle/fluid/operators/scatter_op.cc
@@ -135,5 +135,7 @@ REGISTER_OPERATOR(scatter, ops::ScatterOp, ops::ScatterOpMaker,
                   ops::ScatterGradDescMaker);
 REGISTER_OPERATOR(scatter_grad, ops::ScatterGradOp,
                   ops::ScatterGradNoNeedBufferVarsInference);
-REGISTER_OP_CPU_KERNEL(scatter, ops::ScatterOpKernel<float>);
-REGISTER_OP_CPU_KERNEL(scatter_grad, ops::ScatterGradientOpKernel<float>);
+REGISTER_OP_CPU_KERNEL(scatter, ops::ScatterOpKernel<float>,
+                       ops::ScatterOpKernel<double>);
+REGISTER_OP_CPU_KERNEL(scatter_grad, ops::ScatterGradientOpKernel<float>,
+                       ops::ScatterGradientOpKernel<double>);

--- a/paddle/fluid/operators/scatter_op.cu
+++ b/paddle/fluid/operators/scatter_op.cu
@@ -63,5 +63,7 @@ class ScatterGradOpCUDAKernel : public framework::OpKernel<T> {
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-REGISTER_OP_CUDA_KERNEL(scatter, ops::ScatterOpCUDAKernel<float>);
-REGISTER_OP_CUDA_KERNEL(scatter_grad, ops::ScatterGradOpCUDAKernel<float>);
+REGISTER_OP_CUDA_KERNEL(scatter, ops::ScatterOpCUDAKernel<float>,
+                        ops::ScatterOpCUDAKernel<double>);
+REGISTER_OP_CUDA_KERNEL(scatter_grad, ops::ScatterGradOpCUDAKernel<float>,
+                        ops::ScatterGradOpCUDAKernel<double>);

--- a/paddle/fluid/operators/sequence_ops/sequence_slice_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_slice_op.cc
@@ -146,7 +146,9 @@ REGISTER_OPERATOR(sequence_slice_grad, ops::SequenceSliceGradOp,
                   ops::SequenceSliceGradNoNeedBufferVarsInference);
 REGISTER_OP_CPU_KERNEL(
     sequence_slice,
-    ops::SequenceSliceOpKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::SequenceSliceOpKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SequenceSliceOpKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     sequence_slice_grad,
-    ops::SequenceSliceGradOpKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::SequenceSliceGradOpKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SequenceSliceGradOpKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/sequence_ops/sequence_slice_op.cu
+++ b/paddle/fluid/operators/sequence_ops/sequence_slice_op.cu
@@ -17,7 +17,10 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     sequence_slice,
-    ops::SequenceSliceOpKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::SequenceSliceOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::SequenceSliceOpKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
     sequence_slice_grad,
-    ops::SequenceSliceGradOpKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::SequenceSliceGradOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::SequenceSliceGradOpKernel<paddle::platform::CUDADeviceContext,
+                                   double>);

--- a/paddle/fluid/operators/split_selected_rows_op.cc
+++ b/paddle/fluid/operators/split_selected_rows_op.cc
@@ -94,4 +94,5 @@ REGISTER_OPERATOR(split_selected_rows, ops::SplitSelectedRowsOp,
                   ops::SplitSelectedRowsOpInferVarType);
 REGISTER_OP_CPU_KERNEL(
     split_selected_rows,
-    ops::SplitSelectedRowsOpKernel<paddle::platform::CPUPlace, float>);
+    ops::SplitSelectedRowsOpKernel<paddle::platform::CPUPlace, float>,
+    ops::SplitSelectedRowsOpKernel<paddle::platform::CPUPlace, double>);

--- a/paddle/fluid/operators/split_selected_rows_op.cu
+++ b/paddle/fluid/operators/split_selected_rows_op.cu
@@ -16,4 +16,6 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     split_selected_rows,
-    ops::SplitSelectedRowsOpKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::SplitSelectedRowsOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::SplitSelectedRowsOpKernel<paddle::platform::CUDADeviceContext,
+                                   double>);

--- a/paddle/fluid/operators/squared_l2_distance_op.cc
+++ b/paddle/fluid/operators/squared_l2_distance_op.cc
@@ -168,7 +168,10 @@ REGISTER_OPERATOR(squared_l2_distance_grad, ops::SquaredL2DistanceGradOp,
                   ops::SquaredL2DistanceGradOpNoBuffer);
 REGISTER_OP_CPU_KERNEL(
     squared_l2_distance,
-    ops::SquaredL2DistanceKernel<paddle::platform::CPUDeviceContext, float>);
-REGISTER_OP_CPU_KERNEL(squared_l2_distance_grad,
-                       ops::SquaredL2DistanceGradKernel<
-                           paddle::platform::CPUDeviceContext, float>);
+    ops::SquaredL2DistanceKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SquaredL2DistanceKernel<paddle::platform::CPUDeviceContext, double>);
+REGISTER_OP_CPU_KERNEL(
+    squared_l2_distance_grad,
+    ops::SquaredL2DistanceGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SquaredL2DistanceGradKernel<paddle::platform::CPUDeviceContext,
+                                     double>);

--- a/paddle/fluid/operators/squared_l2_distance_op.cu
+++ b/paddle/fluid/operators/squared_l2_distance_op.cu
@@ -16,7 +16,11 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     squared_l2_distance,
-    ops::SquaredL2DistanceKernel<paddle::platform::CUDADeviceContext, float>);
-REGISTER_OP_CUDA_KERNEL(squared_l2_distance_grad,
-                        ops::SquaredL2DistanceGradKernel<
-                            paddle::platform::CUDADeviceContext, float>);
+    ops::SquaredL2DistanceKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::SquaredL2DistanceKernel<paddle::platform::CUDADeviceContext, double>);
+REGISTER_OP_CUDA_KERNEL(
+    squared_l2_distance_grad,
+    ops::SquaredL2DistanceGradKernel<paddle::platform::CUDADeviceContext,
+                                     float>,
+    ops::SquaredL2DistanceGradKernel<paddle::platform::CUDADeviceContext,
+                                     double>);

--- a/paddle/fluid/operators/squared_l2_norm_op.cc
+++ b/paddle/fluid/operators/squared_l2_norm_op.cc
@@ -93,7 +93,9 @@ REGISTER_OPERATOR(squared_l2_norm, ops::SquaredL2NormOp,
 REGISTER_OPERATOR(squared_l2_norm_grad, ops::SquaredL2NormGradOp);
 REGISTER_OP_CPU_KERNEL(
     squared_l2_norm,
-    ops::SquaredL2NormKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::SquaredL2NormKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SquaredL2NormKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     squared_l2_norm_grad,
-    ops::SquaredL2NormGradKernel<paddle::platform::CPUDeviceContext, float>);
+    ops::SquaredL2NormGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::SquaredL2NormGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/squared_l2_norm_op.cu
+++ b/paddle/fluid/operators/squared_l2_norm_op.cu
@@ -16,7 +16,9 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     squared_l2_norm,
-    ops::SquaredL2NormKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::SquaredL2NormKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::SquaredL2NormKernel<paddle::platform::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
     squared_l2_norm_grad,
-    ops::SquaredL2NormGradKernel<paddle::platform::CUDADeviceContext, float>);
+    ops::SquaredL2NormGradKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::SquaredL2NormGradKernel<paddle::platform::CUDADeviceContext, double>);

--- a/python/paddle/fluid/tests/unittests/test_accuracy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_accuracy_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestAccuracyOp(OpTest):
     def setUp(self):
         self.op_type = "accuracy"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
         n = 8192
         infer = np.random.random((n, 1)).astype(self.dtype)

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -24,7 +24,7 @@ from scipy.special import expit, erf
 class TestActivation(OpTest):
     def setUp(self):
         self.op_type = "exp"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
         self.init_kernel_type()
 
@@ -43,7 +43,7 @@ class TestActivation(OpTest):
         self.check_grad(['X'], 'Out', max_relative_error=0.007)
 
     def init_dtype(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_kernel_type(self):
         pass
@@ -630,7 +630,7 @@ class TestHardSigmoid(TestActivation):
 
         self.relative_error = 0.002
 
-        X = np.random.uniform(-5, 5, [2, 2]).astype("float32")
+        X = np.random.uniform(-5, 5, [2, 2]).astype("float64")
         slope = 0.2
         offset = 0.5
         lower_threshold = -offset / slope

--- a/python/paddle/fluid/tests/unittests/test_adadelta_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adadelta_op.py
@@ -22,12 +22,12 @@ from op_test import OpTest
 class TestAdadeltaOp1(OpTest):
     def setUp(self):
         self.op_type = "adadelta"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The squared gradient is positive
-        avg_squared_grad = np.random.random((102, 105)).astype("float32")
+        avg_squared_grad = np.random.random((102, 105)).astype("float64")
         # The squared update is positive
-        avg_squared_update = np.random.random((102, 105)).astype("float32")
+        avg_squared_update = np.random.random((102, 105)).astype("float64")
 
         rho = 0.95
         epsilon = 1e-6
@@ -69,12 +69,12 @@ class TestAdadeltaOp2(OpTest):
 
     def setUp(self):
         self.op_type = "adadelta"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The squared gradient is positive
-        avg_squared_grad = np.random.random((102, 105)).astype("float32")
+        avg_squared_grad = np.random.random((102, 105)).astype("float64")
         # The squared update is positive
-        avg_squared_update = np.random.random((102, 105)).astype("float32")
+        avg_squared_update = np.random.random((102, 105)).astype("float64")
 
         rho = 0.95
         epsilon = 1e-6

--- a/python/paddle/fluid/tests/unittests/test_adagrad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adagrad_op.py
@@ -29,9 +29,9 @@ class TestAdagradOp1(OpTest):
     def setUp(self):
         self.op_type = "adagrad"
 
-        param = np.random.random((123, 321)).astype("float32")
-        grad = np.random.random((123, 321)).astype("float32")
-        moment = np.zeros((123, 321)).astype("float32")
+        param = np.random.random((123, 321)).astype("float64")
+        grad = np.random.random((123, 321)).astype("float64")
+        moment = np.zeros((123, 321)).astype("float64")
         lr = 0.01
         epsilon = 1e-8
 
@@ -39,7 +39,7 @@ class TestAdagradOp1(OpTest):
             'Param': param,
             'Grad': grad,
             'Moment': moment,
-            'LearningRate': np.array([lr]).astype("float32")
+            'LearningRate': np.array([lr]).astype("float64")
         }
 
         self.attrs = {'epsilon': epsilon}
@@ -60,9 +60,9 @@ class TestAdagradOp2(OpTest):
     def setUp(self):
         self.op_type = "adagrad"
 
-        param = np.random.random((123, 321)).astype("float32")
-        grad = np.random.random((123, 321)).astype("float32")
-        moment = np.zeros((123, 321)).astype("float32")
+        param = np.random.random((123, 321)).astype("float64")
+        grad = np.random.random((123, 321)).astype("float64")
+        moment = np.zeros((123, 321)).astype("float64")
         lr = 0.01
         epsilon = 1e-6
 
@@ -70,7 +70,7 @@ class TestAdagradOp2(OpTest):
             'Param': param,
             'Grad': grad,
             'Moment': moment,
-            'LearningRate': np.array([lr]).astype("float32")
+            'LearningRate': np.array([lr]).astype("float64")
         }
 
         self.attrs = {'epsilon': epsilon}
@@ -96,7 +96,7 @@ class TestSparseAdagradOp(unittest.TestCase):
         grad_selected_rows = scope.var('Grad').get_selected_rows()
         grad_selected_rows.set_height(height)
         grad_selected_rows.set_rows(rows)
-        np_array = np.ones((len(rows), row_numel)).astype("float32")
+        np_array = np.ones((len(rows), row_numel)).astype("float64")
         np_array[0, 0] = 2.0
         np_array[2, 8] = 4.0
 
@@ -105,17 +105,17 @@ class TestSparseAdagradOp(unittest.TestCase):
 
         # create and initialize Param Variable
         param = scope.var('Param').get_tensor()
-        param_array = np.full((height, row_numel), 5.0).astype("float32")
+        param_array = np.full((height, row_numel), 5.0).astype("float64")
         param.set(param_array, place)
 
         # create and initialize LeraningRate Variable
         lr = scope.var('LearningRate').get_tensor()
-        lr_array = np.full((1), 2.0).astype("float32")
+        lr_array = np.full((1), 2.0).astype("float64")
         lr.set(lr_array, place)
 
         # create and initialize moment Variable
         moment = scope.var('Moment').get_tensor()
-        moment_np_array = np.full((height, row_numel), 2.0).astype("float32")
+        moment_np_array = np.full((height, row_numel), 2.0).astype("float64")
         moment.set(moment_np_array, place)
 
         # create and run sgd operator

--- a/python/paddle/fluid/tests/unittests/test_adam_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adam_op.py
@@ -26,11 +26,11 @@ class TestAdamOp1(OpTest):
         '''Test Adam Op with supplied attributes
         '''
         self.op_type = "adam"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The second moment is positive
-        moment2 = np.random.random((102, 105)).astype("float32")
+        moment2 = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.004
         beta1 = 0.78
@@ -44,9 +44,9 @@ class TestAdamOp1(OpTest):
             'Grad': grad,
             'Moment1': moment1,
             'Moment2': moment2,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32"),
-            'Beta2Pow': np.array([beta2_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64"),
+            'Beta2Pow': np.array([beta2_pow]).astype("float64")
         }
 
         self.attrs = {'epsilon': epsilon, 'beta1': beta1, 'beta2': beta2}
@@ -69,11 +69,11 @@ class TestAdamOp2(OpTest):
         '''Test Adam Op with supplied attributes
         '''
         self.op_type = "adam"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The second moment is positive
-        moment2 = np.random.random((102, 105)).astype("float32")
+        moment2 = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.001
         beta1 = 0.9
@@ -87,9 +87,9 @@ class TestAdamOp2(OpTest):
             'Grad': grad,
             'Moment1': moment1,
             'Moment2': moment2,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32"),
-            'Beta2Pow': np.array([beta2_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64"),
+            'Beta2Pow': np.array([beta2_pow]).astype("float64")
         }
 
         attributes = {'epsilon': epsilon, 'beta1': beta1, 'beta2': beta2}
@@ -114,11 +114,11 @@ class TestAdamOpMultipleSteps(OpTest):
         self.op_type = "adam"
         self.num_steps = 10
 
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The second moment is positive
-        moment2 = np.random.random((102, 105)).astype("float32")
+        moment2 = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.001
         beta1 = 0.9
@@ -132,9 +132,9 @@ class TestAdamOpMultipleSteps(OpTest):
             'Grad': grad,
             'Moment1': moment1,
             'Moment2': moment2,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32"),
-            'Beta2Pow': np.array([beta2_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64"),
+            'Beta2Pow': np.array([beta2_pow]).astype("float64")
         }
 
         self.attrs = {'epsilon': epsilon, 'beta1': beta1, 'beta2': beta2}
@@ -164,7 +164,7 @@ class TestAdamOpMultipleSteps(OpTest):
 
             # Randomize gradient for next step
             self.inputs['Grad'] = np.random.uniform(
-                -1, 1, (102, 105)).astype("float32")
+                -1, 1, (102, 105)).astype("float64")
 
 
 def adam_step(inputs, attributes):
@@ -233,7 +233,7 @@ def adam_step_sparse(inputs, attributes, height, rows, row_numel, np_grad,
             update_row(row_id, np_grad[idx])
     else:
         for row_id in range(param_out.shape[0]):
-            update_value = np.zeros(np_grad[0].shape).astype("float32")
+            update_value = np.zeros(np_grad[0].shape).astype("float64")
             if row_id in rows:
                 update_value = np_grad[rows.index(row_id)]
             update_row(row_id, update_value)
@@ -253,14 +253,14 @@ class TestSparseAdamOp(unittest.TestCase):
         row_numel = 12
         self.row_numel = row_numel
         self.dense_inputs = {
-            "Param": np.full((height, row_numel), 5.0).astype("float32"),
-            "Moment1": np.full((height, row_numel), 5.0).astype("float32"),
-            "Moment2": np.full((height, row_numel), 5.0).astype("float32"),
-            'Beta1Pow': np.array([beta1**10]).astype("float32"),
-            'Beta2Pow': np.array([beta2**10]).astype("float32"),
-            "LearningRate": np.full((1), 2.0).astype("float32")
+            "Param": np.full((height, row_numel), 5.0).astype("float64"),
+            "Moment1": np.full((height, row_numel), 5.0).astype("float64"),
+            "Moment2": np.full((height, row_numel), 5.0).astype("float64"),
+            'Beta1Pow': np.array([beta1**10]).astype("float64"),
+            'Beta2Pow': np.array([beta2**10]).astype("float64"),
+            "LearningRate": np.full((1), 2.0).astype("float64")
         }
-        self.init_output = np.full((height, row_numel), 0.0).astype("float32")
+        self.init_output = np.full((height, row_numel), 0.0).astype("float64")
         self.attrs = {
             'epsilon': epsilon,
             'beta1': beta1,
@@ -271,7 +271,7 @@ class TestSparseAdamOp(unittest.TestCase):
         grad_selected_rows = scope.var('Grad').get_selected_rows()
         grad_selected_rows.set_height(height)
         grad_selected_rows.set_rows(rows)
-        np_array = np.ones((len(rows), row_numel)).astype("float32")
+        np_array = np.ones((len(rows), row_numel)).astype("float64")
         np_array[0, 0] = 2.0
         np_array[2, 8] = 4.0
 

--- a/python/paddle/fluid/tests/unittests/test_adamax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adamax_op.py
@@ -24,11 +24,11 @@ class TestAdamaxOp1(OpTest):
         '''Test Adamax Operator with supplied attributes
         '''
         self.op_type = "adamax"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The infinity norm is positive
-        inf_norm = np.random.random((102, 105)).astype("float32")
+        inf_norm = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.002
         beta1 = 0.78
@@ -41,8 +41,8 @@ class TestAdamaxOp1(OpTest):
             'Grad': grad,
             'Moment': moment,
             'InfNorm': inf_norm,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64")
         }
 
         self.attrs = {'beta1': beta1, 'beta2': beta2, 'epsilon': epsilon}
@@ -66,11 +66,11 @@ class TestAdamaxOp2(OpTest):
 
     def setUp(self):
         self.op_type = "adamax"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The infinity norm is positive
-        inf_norm = np.random.random((102, 105)).astype("float32")
+        inf_norm = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.002
         beta1 = 0.9
@@ -83,8 +83,8 @@ class TestAdamaxOp2(OpTest):
             'Grad': grad,
             'Moment': moment,
             'InfNorm': inf_norm,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64")
         }
 
         attrs = {'beta1': beta1, 'beta2': beta2, 'epsilon': epsilon}
@@ -107,11 +107,11 @@ class TestAdamaxOpMultipleSteps(OpTest):
         self.op_type = "adamax"
         self.num_steps = 10
 
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment = np.random.uniform(-1, 1, (102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment = np.random.uniform(-1, 1, (102, 105)).astype("float64")
         # The infinity norm is positive
-        inf_norm = np.random.random((102, 105)).astype("float32")
+        inf_norm = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.002
         beta1 = 0.8
@@ -124,8 +124,8 @@ class TestAdamaxOpMultipleSteps(OpTest):
             'Grad': grad,
             'Moment': moment,
             'InfNorm': inf_norm,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64")
         }
 
         self.attrs = {'beta1': beta1, 'beta2': beta2, 'epsilon': epsilon}
@@ -154,7 +154,7 @@ class TestAdamaxOpMultipleSteps(OpTest):
 
             # Randomize gradient for next step
             self.inputs['Grad'] = np.random.uniform(
-                -1, 1, (102, 105)).astype("float32")
+                -1, 1, (102, 105)).astype("float64")
 
 
 def adamax_step(inputs, attributes):

--- a/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
+++ b/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
@@ -28,7 +28,7 @@ class TestAddPositionEncodingTensorOp(OpTest):
         the prepared section for add position encoding op
         """
         self.op_type = "add_position_encoding"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_input_output()
 
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(self.x), }
@@ -82,7 +82,7 @@ class TestAddPositionEncodingLoDTensorOp(OpTest):
         the prepared section for add position encoding LoDTensor op
         """
         self.op_type = "add_position_encoding"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_input_output()
 
         self.inputs = {'X': (self.x, self.lod), }

--- a/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
@@ -36,9 +36,9 @@ class TestAffineChannelOp(OpTest):
         self.op_type = "affine_channel"
         self.init_test_case()
 
-        x = np.random.random(self.shape).astype("float32")
-        scale = np.random.random(self.C).astype("float32")
-        bias = np.random.random(self.C).astype("float32")
+        x = np.random.random(self.shape).astype("float64")
+        scale = np.random.random(self.C).astype("float64")
+        bias = np.random.random(self.C).astype("float64")
 
         y = affine_channel(x, scale, bias, self.layout)
 

--- a/python/paddle/fluid/tests/unittests/test_affine_grid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_grid_op.py
@@ -34,16 +34,16 @@ def AffineGrid(theta, size):
     for i in range(len(theta)):
         ret[i] = np.dot(grid[i].reshape([h * w, 3]), theta[i])
 
-#    print ret.reshape([h * w, 2]).astype("float32")    
-    return ret.reshape([n, h, w, 2]).astype("float32")
+#    print ret.reshape([h * w, 2]).astype("float64")    
+    return ret.reshape([n, h, w, 2]).astype("float64")
 
 
 class TestAffineGridOp(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = "affine_grid"
-        theta = np.random.randint(1, 3, self.theta_shape).astype("float32")
-        theta = np.ones(self.theta_shape).astype("float32")
+        theta = np.random.randint(1, 3, self.theta_shape).astype("float64")
+        theta = np.ones(self.theta_shape).astype("float64")
         self.inputs = {'Theta': theta}
         self.attrs = {"use_cudnn": True}
         if self.dynamic_shape:

--- a/python/paddle/fluid/tests/unittests/test_alloc_continuous_space_op.py
+++ b/python/paddle/fluid/tests/unittests/test_alloc_continuous_space_op.py
@@ -25,7 +25,7 @@ alignment = 256
 class TestAllocContinuousSpace(OpTest):
     def setUp(self):
         self.op_type = "alloc_continuous_space"
-        self.dtype = np.float32
+        self.dtype = np.float64
         attrs = self.init_attr()
         self.copy_data = attrs["copy_data"]
         self.constant = attrs["constant"]
@@ -38,7 +38,7 @@ class TestAllocContinuousSpace(OpTest):
         self.outputs = {'Output': self.Outputs, 'FusedOutput': self.FusedOutput}
 
     def init_dtype(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_input(self):
         inputs = []

--- a/python/paddle/fluid/tests/unittests/test_arg_min_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_arg_min_max_op.py
@@ -23,7 +23,7 @@ class BaseTestCase(OpTest):
     def initTestCase(self):
         self.op_type = 'arg_min'
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = 'float64'
         self.axis = 0
 
     def setUp(self):
@@ -44,7 +44,7 @@ class TestCase0(BaseTestCase):
     def initTestCase(self):
         self.op_type = 'arg_max'
         self.dims = (3, 4, 5)
-        self.dtype = 'float32'
+        self.dtype = 'float64'
         self.axis = 0
 
 

--- a/python/paddle/fluid/tests/unittests/test_argsort_op.py
+++ b/python/paddle/fluid/tests/unittests/test_argsort_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestArgsortOp(OpTest):
     def setUp(self):
         self.init_axis()
-        x = np.random.random((2, 3, 4, 5, 10)).astype("float32")
+        x = np.random.random((2, 3, 4, 5, 10)).astype("float64")
         if self.axis < 0:
             self.axis = self.axis + len(x.shape)
         self.indices = np.argsort(x, kind='quicksort', axis=self.axis)

--- a/python/paddle/fluid/tests/unittests/test_array_read_write_op.py
+++ b/python/paddle/fluid/tests/unittests/test_array_read_write_op.py
@@ -68,7 +68,7 @@ class TestArrayReadWrite(unittest.TestCase):
 
         exe = Executor(cpu)
 
-        tensor = numpy.random.random(size=(100, 100)).astype('float32')
+        tensor = numpy.random.random(size=(100, 100)).astype('float64')
 
         outs = exe.run(feed={'x0': tensor,
                              'x1': tensor,

--- a/python/paddle/fluid/tests/unittests/test_attention_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_attention_lstm_op.py
@@ -82,8 +82,8 @@ def attention_lstm(
 
         start_offset += seq_len
 
-    hidden = np.array(hidden).astype('float32').reshape([T, D])
-    cell = np.array(cell).astype('float32').reshape([T, D])
+    hidden = np.array(hidden).astype('float64').reshape([T, D])
+    cell = np.array(cell).astype('float64').reshape([T, D])
     return hidden, cell
 
 
@@ -105,22 +105,22 @@ class TestAttentionLSTMOp(OpTest):
         T = sum(self.lod[0])
         bs = len(self.lod[0])
 
-        x = np.random.normal(size=(T, self.M)).astype('float32')
-        c0 = np.random.normal(size=(bs, self.D)).astype('float32')
+        x = np.random.normal(size=(T, self.M)).astype('float64')
+        c0 = np.random.normal(size=(bs, self.D)).astype('float64')
         if self.has_initial_hidden:
-            h0 = np.random.normal(size=(bs, self.D)).astype('float32')
+            h0 = np.random.normal(size=(bs, self.D)).astype('float64')
         else:
-            h0 = np.zeros((bs, self.D)).astype('float32')
+            h0 = np.zeros((bs, self.D)).astype('float64')
 
-        fcw1 = np.random.normal(size=(self.M + self.D, 1)).astype('float32')
-        fcb1 = np.random.normal(size=(1, 1)).astype('float32')
-        fcw2 = np.random.normal(size=(1, 1)).astype('float32')
-        fcb2 = np.random.normal(size=(1, 1)).astype('float32')
+        fcw1 = np.random.normal(size=(self.M + self.D, 1)).astype('float64')
+        fcb1 = np.random.normal(size=(1, 1)).astype('float64')
+        fcw2 = np.random.normal(size=(1, 1)).astype('float64')
+        fcb2 = np.random.normal(size=(1, 1)).astype('float64')
 
         # lstm weight and bias
         w = np.random.normal(size=(self.M + self.D,
-                                   self.D * 4)).astype('float32')
-        b = np.random.normal(size=(1, self.D * 4)).astype('float32')
+                                   self.D * 4)).astype('float64')
+        b = np.random.normal(size=(1, self.D * 4)).astype('float64')
 
         h, c = attention_lstm(x, self.lod, h0, c0, [fcw1, fcw2], [fcb1, fcb2],
                               w, b, ACTIVATION[self.act_gate],

--- a/python/paddle/fluid/tests/unittests/test_auc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_auc_op.py
@@ -23,7 +23,7 @@ from paddle.fluid import metrics
 class TestAucOp(OpTest):
     def setUp(self):
         self.op_type = "auc"
-        pred = np.random.random((128, 2)).astype("float32")
+        pred = np.random.random((128, 2)).astype("float64")
         labels = np.random.randint(0, 2, (128, 1)).astype("int64")
         num_thresholds = 200
 

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
@@ -157,7 +157,7 @@ def set_output_grad(scope, outputs, place, feed_dict=None):
             if out_dtype == core.VarDesc.VarType.FP64:
                 data = np.ones(out_tensor.shape(), dtype=np.float64)
             elif out_dtype == core.VarDesc.VarType.FP32:
-                data = np.ones(out_tensor.shape(), dtype=np.float32)
+                data = np.ones(out_tensor.shape(), dtype=np.float64)
             else:
                 raise ValueError("Not supported data type " + str(out_dtype))
         grad_tensor.set(data, place)
@@ -171,7 +171,7 @@ def set_output_grad(scope, outputs, place, feed_dict=None):
 
 class TestBatchNormOpInference(unittest.TestCase):
     def setUp(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.use_mkldnn = False
         self.fuse_with_relu = False
         self.init_kernel_type()
@@ -197,11 +197,11 @@ class TestBatchNormOpInference(unittest.TestCase):
         x_val = np.random.random_sample(x_shape).astype(dtype)
         # generate some negative values to test case with relu fused
         x_val = x_val - 0.5
-        scale_val = np.random.random_sample(scale_shape).astype(np.float32)
-        bias_val = np.random.random_sample(scale_shape).astype(np.float32)
+        scale_val = np.random.random_sample(scale_shape).astype(np.float64)
+        bias_val = np.random.random_sample(scale_shape).astype(np.float64)
 
-        mean = np.zeros(scale_shape).astype(np.float32)
-        variance = np.ones(scale_shape).astype(np.float32)
+        mean = np.zeros(scale_shape).astype(np.float64)
+        variance = np.ones(scale_shape).astype(np.float64)
 
         y_out = _reference_testing(x_val, scale_val, bias_val, mean, variance,
                                    epsilon, data_layout).astype(dtype)
@@ -338,8 +338,8 @@ class TestBatchNormOpTraining(unittest.TestCase):
         return y, mean_out, variance_out, saved_mean, saved_variance, x_grad, scale_grad, bias_grad
 
     def set_mean_variance(self, scale_shape, x, data_layout):
-        mean = np.zeros(scale_shape).astype(np.float32)
-        variance = np.ones(scale_shape).astype(np.float32)
+        mean = np.zeros(scale_shape).astype(np.float64)
+        variance = np.ones(scale_shape).astype(np.float64)
         # computing global mean/variance for one step
         if self.use_global_stats:
             mom = self.momentum
@@ -360,11 +360,11 @@ class TestBatchNormOpTraining(unittest.TestCase):
             scale_shape = [c]
 
             np.random.seed(123)
-            x = np.random.random_sample(shape).astype(np.float32)
-            scale = np.random.random_sample(scale_shape).astype(np.float32)
-            bias = np.random.random_sample(scale_shape).astype(np.float32)
+            x = np.random.random_sample(shape).astype(np.float64)
+            scale = np.random.random_sample(scale_shape).astype(np.float64)
+            bias = np.random.random_sample(scale_shape).astype(np.float64)
             mean, variance = self.set_mean_variance(scale_shape, x, data_layout)
-            y_grad = np.random.random_sample(shape).astype(np.float32)
+            y_grad = np.random.random_sample(shape).astype(np.float64)
 
             y, mean_out, variance_out, saved_mean, saved_variance, x_grad, scale_grad, bias_grad = self.ref_forward_backward(
                 x, y_grad, scale, bias, mean, variance, epsilon, momentum,
@@ -388,7 +388,7 @@ class TestBatchNormOpTraining(unittest.TestCase):
                 for name in ground_truth:
                     block.create_var(
                         name=name,
-                        dtype='float32',
+                        dtype='float64',
                         shape=ground_truth[name].shape)
                 bn_op = block.append_op(
                     type="batch_norm",
@@ -415,7 +415,7 @@ class TestBatchNormOpTraining(unittest.TestCase):
                         "fuse_with_relu": self.fuse_with_relu,
                         "use_global_stats": self.use_global_stats
                     })
-                block.create_var(name='y@GRAD', dtype='float32', shape=y.shape)
+                block.create_var(name='y@GRAD', dtype='float64', shape=y.shape)
 
                 # generate backward op_desc
                 grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(

--- a/python/paddle/fluid/tests/unittests/test_beam_search_decode_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_decode_op.py
@@ -44,35 +44,35 @@ class TestBeamSearchDecodeOp(unittest.TestCase):
             self.append_lod_tensor(
                 array, [[0, 1, 2], [0, 1, 2]], np.array(
                     [0, 0], dtype=dtype))
-            for array, dtype in ((ids, "int64"), (scores, "float32"))
+            for array, dtype in ((ids, "int64"), (scores, "float64"))
         ]
         [
             self.append_lod_tensor(
                 array, [[0, 1, 2], [0, 2, 4]],
                 np.array(
                     [2, 3, 4, 5], dtype=dtype))
-            for array, dtype in ((ids, "int64"), (scores, "float32"))
+            for array, dtype in ((ids, "int64"), (scores, "float64"))
         ]
         [
             self.append_lod_tensor(
                 array, [[0, 2, 4], [0, 2, 2, 4, 4]],
                 np.array(
                     [3, 1, 5, 4], dtype=dtype))
-            for array, dtype in ((ids, "int64"), (scores, "float32"))
+            for array, dtype in ((ids, "int64"), (scores, "float64"))
         ]
         [
             self.append_lod_tensor(
                 array, [[0, 2, 4], [0, 1, 2, 3, 4]],
                 np.array(
                     [1, 1, 3, 5], dtype=dtype))
-            for array, dtype in ((ids, "int64"), (scores, "float32"))
+            for array, dtype in ((ids, "int64"), (scores, "float64"))
         ]
         [
             self.append_lod_tensor(
                 array, [[0, 2, 4], [0, 0, 0, 2, 2]],
                 np.array(
                     [5, 1], dtype=dtype))
-            for array, dtype in ((ids, "int64"), (scores, "float32"))
+            for array, dtype in ((ids, "int64"), (scores, "float64"))
         ]
 
         sentence_ids = self.scope.var("sentence_ids").get_tensor()

--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
@@ -91,7 +91,7 @@ class TestBilinearInterpOp(OpTest):
         self.actual_shape = None
         self.init_test_case()
         self.op_type = "bilinear_interp"
-        input_np = np.random.random(self.input_shape).astype("float32")
+        input_np = np.random.random(self.input_shape).astype("float64")
 
         if self.scale > 0:
             out_h = int(self.input_shape[2] * self.scale)

--- a/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
@@ -26,11 +26,11 @@ class TestBilinearTensorProductOp(OpTest):
         size0 = 3
         size1 = 4
         size2 = 5
-        a = np.random.random((batch_size, size0)).astype("float32")
-        b = np.random.random((batch_size, size1)).astype("float32")
-        w = np.random.random((size2, size0, size1)).astype("float32")
-        bias = np.random.random((1, size2)).astype("float32")
-        output = np.zeros((batch_size, size2)).astype("float32")
+        a = np.random.random((batch_size, size0)).astype("float64")
+        b = np.random.random((batch_size, size1)).astype("float64")
+        w = np.random.random((size2, size0, size1)).astype("float64")
+        bias = np.random.random((1, size2)).astype("float64")
+        output = np.zeros((batch_size, size2)).astype("float64")
         for i in range(size2):
             w_i = w[i, :, :]
             output[:, i] = np.sum(np.matmul(a, w_i) * b, axis=1)

--- a/python/paddle/fluid/tests/unittests/test_bipartite_match_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bipartite_match_op.py
@@ -70,7 +70,7 @@ def batch_bipartite_match(distance, lod, match_type=None, dist_threshold=None):
     n = len(lod)
     m = distance.shape[1]
     match_indices = -1 * np.ones((n, m), dtype=np.int)
-    match_dist = np.zeros((n, m), dtype=np.float32)
+    match_dist = np.zeros((n, m), dtype=np.float64)
     cur_offset = 0
     for i in range(n):
         bipartite_match(distance[cur_offset:(cur_offset + lod[i]), :],
@@ -86,7 +86,7 @@ class TestBipartiteMatchOpWithLoD(OpTest):
     def setUp(self):
         self.op_type = 'bipartite_match'
         lod = [[5, 6, 12]]
-        dist = np.random.random((23, 217)).astype('float32')
+        dist = np.random.random((23, 217)).astype('float64')
         match_indices, match_dist = batch_bipartite_match(dist, lod[0])
 
         self.inputs = {'DistMat': (dist, lod)}
@@ -103,7 +103,7 @@ class TestBipartiteMatchOpWithoutLoD(OpTest):
     def setUp(self):
         self.op_type = 'bipartite_match'
         lod = [[8]]
-        dist = np.random.random((8, 17)).astype('float32')
+        dist = np.random.random((8, 17)).astype('float64')
         match_indices, match_dist = batch_bipartite_match(dist, lod[0])
 
         self.inputs = {'DistMat': dist}
@@ -120,7 +120,7 @@ class TestBipartiteMatchOpWithoutLoDLargeScaleInput(OpTest):
     def setUp(self):
         self.op_type = 'bipartite_match'
         lod = [[300]]
-        dist = np.random.random((300, 17)).astype('float32')
+        dist = np.random.random((300, 17)).astype('float64')
         match_indices, match_dist = batch_bipartite_match(dist, lod[0])
 
         self.inputs = {'DistMat': dist}
@@ -137,7 +137,7 @@ class TestBipartiteMatchOpWithPerPredictionType(OpTest):
     def setUp(self):
         self.op_type = 'bipartite_match'
         lod = [[5, 6, 12]]
-        dist = np.random.random((23, 237)).astype('float32')
+        dist = np.random.random((23, 237)).astype('float64')
         match_indices, match_dist = batch_bipartite_match(dist, lod[0],
                                                           'per_prediction', 0.5)
 

--- a/python/paddle/fluid/tests/unittests/test_box_clip_op.py
+++ b/python/paddle/fluid/tests/unittests/test_box_clip_op.py
@@ -38,7 +38,7 @@ def box_clip(input_box, im_info, output_box):
 def batch_box_clip(input_boxes, im_info, lod):
     n = input_boxes.shape[0]
     m = input_boxes.shape[1]
-    output_boxes = np.zeros((n, m, 4), dtype=np.float32)
+    output_boxes = np.zeros((n, m, 4), dtype=np.float64)
     cur_offset = 0
     for i in range(len(lod)):
         box_clip(input_boxes[cur_offset:(cur_offset + lod[i]), :, :],
@@ -60,8 +60,8 @@ class TestBoxClipOp(OpTest):
         output_boxes = batch_box_clip(input_boxes, im_info, lod[0])
 
         self.inputs = {
-            'Input': (input_boxes.astype('float32'), lod),
-            'ImInfo': im_info.astype('float32'),
+            'Input': (input_boxes.astype('float64'), lod),
+            'ImInfo': im_info.astype('float64'),
         }
         self.outputs = {'Output': output_boxes}
 

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -23,7 +23,7 @@ import paddle.fluid.core as core
 class TestCastOp1(op_test.OpTest):
     def setUp(self):
         ipt = np.random.random(size=[10, 10])
-        self.inputs = {'X': ipt.astype('float32')}
+        self.inputs = {'X': ipt.astype('float64')}
         self.outputs = {'Out': ipt.astype('float64')}
         self.attrs = {
             'in_dtype': int(core.VarDesc.VarType.FP32),
@@ -43,7 +43,7 @@ class TestCastOp2(op_test.OpTest):
         ipt = np.random.random(size=[10, 10])
         # numpy float16 is binded to fluid float16 via uint16
         self.inputs = {'X': ipt.astype('float16').view(np.uint16)}
-        self.outputs = {'Out': ipt.astype('float32')}
+        self.outputs = {'Out': ipt.astype('float64')}
         self.attrs = {
             'in_dtype': int(core.VarDesc.VarType.FP16),
             'out_dtype': int(core.VarDesc.VarType.FP32)
@@ -57,7 +57,7 @@ class TestCastOp2(op_test.OpTest):
 class TestCastOp3(op_test.OpTest):
     def setUp(self):
         ipt = np.random.random(size=[10, 10])
-        self.inputs = {'X': ipt.astype('float32')}
+        self.inputs = {'X': ipt.astype('float64')}
         self.outputs = {'Out': ipt.astype('float16')}
         self.attrs = {
             'in_dtype': int(core.VarDesc.VarType.FP32),

--- a/python/paddle/fluid/tests/unittests/test_chunk_eval_op.py
+++ b/python/paddle/fluid/tests/unittests/test_chunk_eval_op.py
@@ -160,11 +160,11 @@ class TestChunkEvalOp(OpTest):
             precision + recall) if self.num_correct_chunks else 0
         self.outputs = {
             'Precision': np.asarray(
-                [precision], dtype='float32'),
+                [precision], dtype='float64'),
             'Recall': np.asarray(
-                [recall], dtype='float32'),
+                [recall], dtype='float64'),
             'F1-Score': np.asarray(
-                [f1], dtype='float32'),
+                [f1], dtype='float64'),
             'NumInferChunks': np.asarray(
                 [self.num_infer_chunks], dtype='int64'),
             'NumLabelChunks': np.asarray(

--- a/python/paddle/fluid/tests/unittests/test_collect_fpn_proposals_op.py
+++ b/python/paddle/fluid/tests/unittests/test_collect_fpn_proposals_op.py
@@ -83,9 +83,9 @@ class TestCollectFPNProposalstOp(OpTest):
                     rois.append(roi)
                 bno += 1
                 scores_pb.extend(list(np.random.uniform(0.0, 1.0, roi_num)))
-            rois = np.array(rois).astype("float32")
+            rois = np.array(rois).astype("float64")
             self.roi_inputs.append(rois)
-            scores_pb = np.array(scores_pb).astype("float32")
+            scores_pb = np.array(scores_pb).astype("float64")
             self.scores.append(scores_pb)
 
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_compare_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_op.py
@@ -37,7 +37,7 @@ def create_test_class(op_type, typename, callback):
     globals()[cls_name] = Cls
 
 
-for _type_name in {'float32', 'float64', 'int32', 'int64'}:
+for _type_name in {'float64', 'float64', 'int32', 'int64'}:
     create_test_class('less_than', _type_name, lambda _a, _b: _a < _b)
     create_test_class('less_equal', _type_name, lambda _a, _b: _a <= _b)
     create_test_class('greater_than', _type_name, lambda _a, _b: _a > _b)

--- a/python/paddle/fluid/tests/unittests/test_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_concat_op.py
@@ -45,25 +45,25 @@ class TestConcatOp(OpTest):
         self.check_grad(['x2'], 'Out')
 
     def init_test_data(self):
-        self.x0 = np.random.random((2, 1, 4, 5)).astype('float32')
-        self.x1 = np.random.random((2, 2, 4, 5)).astype('float32')
-        self.x2 = np.random.random((2, 3, 4, 5)).astype('float32')
+        self.x0 = np.random.random((2, 1, 4, 5)).astype('float64')
+        self.x1 = np.random.random((2, 2, 4, 5)).astype('float64')
+        self.x2 = np.random.random((2, 3, 4, 5)).astype('float64')
         self.axis = 1
 
 
 class TestConcatOp2(TestConcatOp):
     def init_test_data(self):
-        self.x0 = np.random.random((2, 3, 4, 5)).astype('float32')
-        self.x1 = np.random.random((2, 3, 4, 5)).astype('float32')
-        self.x2 = np.random.random((2, 3, 4, 5)).astype('float32')
+        self.x0 = np.random.random((2, 3, 4, 5)).astype('float64')
+        self.x1 = np.random.random((2, 3, 4, 5)).astype('float64')
+        self.x2 = np.random.random((2, 3, 4, 5)).astype('float64')
         self.axis = 1
 
 
 class TestConcatOp3(TestConcatOp):
     def init_test_data(self):
-        self.x0 = np.random.random((1, 256, 170, 256)).astype('float32')
-        self.x1 = np.random.random((1, 128, 170, 256)).astype('float32')
-        self.x2 = np.random.random((1, 128, 170, 256)).astype('float32')
+        self.x0 = np.random.random((1, 256, 170, 256)).astype('float64')
+        self.x1 = np.random.random((1, 128, 170, 256)).astype('float64')
+        self.x2 = np.random.random((1, 128, 170, 256)).astype('float64')
         self.axis = 1
 
     def test_check_grad(self):
@@ -72,9 +72,9 @@ class TestConcatOp3(TestConcatOp):
 
 class TestConcatOp4(TestConcatOp):
     def init_test_data(self):
-        self.x0 = np.random.random((2, 3, 4, 5)).astype('float32')
-        self.x1 = np.random.random((2, 3, 4, 5)).astype('float32')
-        self.x2 = np.random.random((0, 3, 4, 5)).astype('float32')
+        self.x0 = np.random.random((2, 3, 4, 5)).astype('float64')
+        self.x1 = np.random.random((2, 3, 4, 5)).astype('float64')
+        self.x2 = np.random.random((0, 3, 4, 5)).astype('float64')
         self.axis = 0
 
     def test_check_grad(self):
@@ -83,9 +83,9 @@ class TestConcatOp4(TestConcatOp):
 
 class TestConcatOp5(TestConcatOp):
     def init_test_data(self):
-        self.x0 = np.random.random((2, 1, 4, 5)).astype('float32')
-        self.x1 = np.random.random((2, 2, 4, 5)).astype('float32')
-        self.x2 = np.random.random((2, 3, 4, 5)).astype('float32')
+        self.x0 = np.random.random((2, 1, 4, 5)).astype('float64')
+        self.x1 = np.random.random((2, 2, 4, 5)).astype('float64')
+        self.x2 = np.random.random((2, 3, 4, 5)).astype('float64')
         self.axis = -3
 
 

--- a/python/paddle/fluid/tests/unittests/test_conv2d_fusion_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_fusion_op.py
@@ -28,7 +28,7 @@ class TestConv2dFusionOp(OpTest):
         self.op_type = "conv2d_fusion"
         self.exhaustive_search = False
         self.data_format = "AnyLayout"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.activation = 'relu'
         self.add_bias = True
         self.add_residual_data = True

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -72,7 +72,7 @@ class TestConv2dOp(OpTest):
         self.use_mkldnn = False
         self.fuse_relu_before_depthwise_conv = False
         self.data_format = "AnyLayout"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -76,8 +76,8 @@ class TestConv2dTransposeOp(OpTest):
         self.init_op_type()
         self.init_test_case()
 
-        input_ = np.random.random(self.input_size).astype("float32")
-        filter_ = np.random.random(self.filter_size).astype("float32")
+        input_ = np.random.random(self.input_size).astype("float64")
+        filter_ = np.random.random(self.filter_size).astype("float64")
 
         self.inputs = {'Input': input_, 'Filter': filter_}
         self.attrs = {
@@ -94,7 +94,7 @@ class TestConv2dTransposeOp(OpTest):
             self.attrs['output_size'] = self.output_size
 
         output = conv2dtranspose_forward_naive(input_, filter_,
-                                               self.attrs).astype('float32')
+                                               self.attrs).astype('float64')
 
         self.outputs = {'Output': output}
 

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -76,7 +76,7 @@ class TestConv3dOp(OpTest):
         self.use_cudnn = False
         self.use_mkldnn = False
         self.data_format = "AnyLayout"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()

--- a/python/paddle/fluid/tests/unittests/test_conv3d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_transpose_op.py
@@ -74,8 +74,8 @@ class TestConv3dTransposeOp(OpTest):
         self.init_op_type()
         self.init_test_case()
 
-        input_ = np.random.random(self.input_size).astype("float32")
-        filter_ = np.random.random(self.filter_size).astype("float32")
+        input_ = np.random.random(self.input_size).astype("float64")
+        filter_ = np.random.random(self.filter_size).astype("float64")
 
         self.inputs = {'Input': input_, 'Filter': filter_}
         self.attrs = {
@@ -88,7 +88,7 @@ class TestConv3dTransposeOp(OpTest):
         }
 
         output = conv3dtranspose_forward_naive(input_, filter_,
-                                               self.attrs).astype("float32")
+                                               self.attrs).astype("float64")
 
         self.outputs = {'Output': output}
 

--- a/python/paddle/fluid/tests/unittests/test_cos_sim_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cos_sim_op.py
@@ -23,8 +23,8 @@ class TestCosSimOp(OpTest):
     def setUp(self):
         self.op_type = "cos_sim"
         self.inputs = {
-            'X': np.random.random((6, 5)).astype("float32"),
-            'Y': np.random.random((6, 5)).astype("float32")
+            'X': np.random.random((6, 5)).astype("float64"),
+            'Y': np.random.random((6, 5)).astype("float64")
         }
         expect_x_norm = np.linalg.norm(self.inputs['X'], axis=1)
         expect_y_norm = np.linalg.norm(self.inputs['Y'], axis=1)
@@ -55,8 +55,8 @@ class TestCosSimOp2(TestCosSimOp):
     def setUp(self):
         self.op_type = "cos_sim"
         self.inputs = {
-            'X': np.random.random((6, 5)).astype("float32"),
-            'Y': np.random.random((1, 5)).astype("float32")
+            'X': np.random.random((6, 5)).astype("float64"),
+            'Y': np.random.random((1, 5)).astype("float64")
         }
         expect_x_norm = np.linalg.norm(self.inputs['X'], axis=1)
         expect_y_norm = np.linalg.norm(self.inputs['Y'], axis=1)
@@ -73,8 +73,8 @@ class TestCosSimOp3(TestCosSimOp):
     def setUp(self):
         self.op_type = "cos_sim"
         self.inputs = {
-            'X': np.random.random((6, 5, 2)).astype("float32"),
-            'Y': np.random.random((6, 5, 2)).astype("float32")
+            'X': np.random.random((6, 5, 2)).astype("float64"),
+            'Y': np.random.random((6, 5, 2)).astype("float64")
         }
         expect_x_norm = np.linalg.norm(self.inputs['X'], axis=(1, 2))
         expect_y_norm = np.linalg.norm(self.inputs['Y'], axis=(1, 2))
@@ -91,8 +91,8 @@ class TestCosSimOp4(TestCosSimOp):
     def setUp(self):
         self.op_type = "cos_sim"
         self.inputs = {
-            'X': np.random.random((6, 5, 2)).astype("float32"),
-            'Y': np.random.random((1, 5, 2)).astype("float32")
+            'X': np.random.random((6, 5, 2)).astype("float64"),
+            'Y': np.random.random((1, 5, 2)).astype("float64")
         }
         expect_x_norm = np.linalg.norm(self.inputs['X'], axis=(1, 2))
         expect_y_norm = np.linalg.norm(self.inputs['Y'], axis=(1, 2))

--- a/python/paddle/fluid/tests/unittests/test_crop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_crop_op.py
@@ -49,13 +49,13 @@ class TestCropOp(OpTest):
         self.initTestCase()
         if self.crop_by_input:
             self.inputs = {
-                'X': np.random.random(self.x_shape).astype("float32"),
-                'Y': np.random.random(self.crop_shape).astype("float32")
+                'X': np.random.random(self.x_shape).astype("float64"),
+                'Y': np.random.random(self.crop_shape).astype("float64")
             }
         else:
             self.attrs['shape'] = self.crop_shape
             self.inputs = {
-                'X': np.random.random(self.x_shape).astype("float32"),
+                'X': np.random.random(self.x_shape).astype("float64"),
             }
         if self.offset_by_input:
             self.inputs['Offsets'] = np.array(self.offsets).astype('int32')

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_op.py
@@ -93,7 +93,7 @@ class TestCrossEntropyOp2(TestCrossEntropyOp):
         self.soft_label = True
 
     def init_dtype_type(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_bs_class_num(self):
         self.batch_size = 5
@@ -123,7 +123,7 @@ class TestCrossEntropyOp3(TestCrossEntropyOp):
         self.soft_label = True
 
     def init_dtype_type(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_bs_class_num(self):
         self.batch_size = 5
@@ -194,7 +194,7 @@ class TestCrossEntropyOp5(TestCrossEntropyOp):
         self.soft_label = True
 
     def init_dtype_type(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_bs_class_num(self):
         self.class_num = 37
@@ -234,7 +234,7 @@ class TestCrossEntropyOp6(TestCrossEntropyOp):
         self.soft_label = True
 
     def init_dtype_type(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_bs_class_num(self):
         self.class_num = 17

--- a/python/paddle/fluid/tests/unittests/test_cvm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cvm_op.py
@@ -23,7 +23,7 @@ def cvm_compute(X, item_width, use_cvm):
     cvm_offset = 0 if use_cvm else 2
     batch_size = X.shape[0]
 
-    Y = np.ones([batch_size, item_width - cvm_offset], np.float32)
+    Y = np.ones([batch_size, item_width - cvm_offset], np.float64)
 
     for idx in range(batch_size):
         if use_cvm:
@@ -38,7 +38,7 @@ def cvm_compute(X, item_width, use_cvm):
 
 def cvm_grad_compute(DY, CVM, item_width, use_cvm):
     batch_size = DY.shape[0]
-    DX = np.ones([batch_size, item_width], np.float32)
+    DX = np.ones([batch_size, item_width], np.float64)
 
     for idx in range(batch_size):
         DX[idx][0] = CVM[idx][0]
@@ -65,8 +65,8 @@ class TestCVMOpWithLodTensor(OpTest):
 
         lod = [[1]]
         self.inputs = {
-            'X': (np.random.uniform(0, 1, [1, dims]).astype("float32"), lod),
-            'CVM': np.array([[0.6, 0.4]]).astype("float32"),
+            'X': (np.random.uniform(0, 1, [1, dims]).astype("float64"), lod),
+            'CVM': np.array([[0.6, 0.4]]).astype("float64"),
         }
         self.attrs = {'use_cvm': False}
         out = []
@@ -91,9 +91,9 @@ class TestCVMOpWithOutLodTensor1(OpTest):
         item_width = 11
 
         input = np.random.uniform(0, 1,
-                                  (batch_size, item_width)).astype('float32')
+                                  (batch_size, item_width)).astype('float64')
         output = cvm_compute(input, item_width, self.use_cvm)
-        cvm = np.array([[0.6, 0.4]]).astype("float32")
+        cvm = np.array([[0.6, 0.4]]).astype("float64")
 
         self.inputs = {'X': input, 'CVM': cvm}
         self.attrs = {'use_cvm': self.use_cvm}
@@ -116,9 +116,9 @@ class TestCVMOpWithOutLodTensor2(OpTest):
         item_width = 11
 
         input = np.random.uniform(0, 1,
-                                  (batch_size, item_width)).astype('float32')
+                                  (batch_size, item_width)).astype('float64')
         output = cvm_compute(input, item_width, self.use_cvm)
-        cvm = np.array([[0.6, 0.4]]).astype("float32")
+        cvm = np.array([[0.6, 0.4]]).astype("float64")
 
         self.inputs = {'X': input, 'CVM': cvm}
         self.attrs = {'use_cvm': self.use_cvm}

--- a/python/paddle/fluid/tests/unittests/test_density_prior_box_op.py
+++ b/python/paddle/fluid/tests/unittests/test_density_prior_box_op.py
@@ -83,16 +83,16 @@ class TestDensityPriorBoxOp(OpTest):
     def init_test_input(self):
         self.image = np.random.random(
             (self.batch_size, self.image_channels, self.image_w,
-             self.image_h)).astype('float32')
+             self.image_h)).astype('float64')
 
         self.input = np.random.random(
             (self.batch_size, self.input_channels, self.layer_w,
-             self.layer_h)).astype('float32')
+             self.layer_h)).astype('float64')
 
     def init_test_output(self):
         out_dim = (self.layer_h, self.layer_w, self.num_priors, 4)
-        out_boxes = np.zeros(out_dim).astype('float32')
-        out_var = np.zeros(out_dim).astype('float32')
+        out_boxes = np.zeros(out_dim).astype('float64')
+        out_var = np.zeros(out_dim).astype('float64')
 
         step_average = int((self.step_w + self.step_h) * 0.5)
         for h in range(self.layer_h):
@@ -127,8 +127,8 @@ class TestDensityPriorBoxOp(OpTest):
             out_boxes = np.clip(out_boxes, 0.0, 1.0)
         out_var = np.tile(self.variances,
                           (self.layer_h, self.layer_w, self.num_priors, 1))
-        self.out_boxes = out_boxes.astype('float32')
-        self.out_var = out_var.astype('float32')
+        self.out_boxes = out_boxes.astype('float64')
+        self.out_var = out_var.astype('float64')
         if self.flatten_to_2d:
             self.out_boxes = self.out_boxes.reshape((-1, 4))
             self.out_var = self.out_var.reshape((-1, 4))

--- a/python/paddle/fluid/tests/unittests/test_detection_map_op.py
+++ b/python/paddle/fluid/tests/unittests/test_detection_map_op.py
@@ -29,15 +29,15 @@ class TestDetectionMAPOp(OpTest):
         self.class_num = 4
         self.init_test_case()
         self.mAP = [self.calc_map(self.tf_pos, self.tf_pos_lod)]
-        self.label = np.array(self.label).astype('float32')
-        self.detect = np.array(self.detect).astype('float32')
-        self.mAP = np.array(self.mAP).astype('float32')
+        self.label = np.array(self.label).astype('float64')
+        self.detect = np.array(self.detect).astype('float64')
+        self.mAP = np.array(self.mAP).astype('float64')
 
         if len(self.class_pos_count) > 0:
             self.class_pos_count = np.array(self.class_pos_count).astype(
                 'int32')
-            self.true_pos = np.array(self.true_pos).astype('float32')
-            self.false_pos = np.array(self.false_pos).astype('float32')
+            self.true_pos = np.array(self.true_pos).astype('float64')
+            self.false_pos = np.array(self.false_pos).astype('float64')
             self.has_state = np.array([1]).astype('int32')
 
             self.inputs = {
@@ -63,8 +63,8 @@ class TestDetectionMAPOp(OpTest):
 
         self.out_class_pos_count = np.array(self.out_class_pos_count).astype(
             'int')
-        self.out_true_pos = np.array(self.out_true_pos).astype('float32')
-        self.out_false_pos = np.array(self.out_false_pos).astype('float32')
+        self.out_true_pos = np.array(self.out_true_pos).astype('float64')
+        self.out_false_pos = np.array(self.out_false_pos).astype('float64')
 
         self.outputs = {
             'MAP': self.mAP,

--- a/python/paddle/fluid/tests/unittests/test_distribute_fpn_proposals_op.py
+++ b/python/paddle/fluid/tests/unittests/test_distribute_fpn_proposals_op.py
@@ -107,7 +107,7 @@ class TestDistributeFPNProposalsOp(OpTest):
                 roi = [bno, xy1[0], xy1[1], xy2[0], xy2[1]]
                 rois.append(roi)
             bno += 1
-        self.rois = np.array(rois).astype("float32")
+        self.rois = np.array(rois).astype("float64")
 
     def setUp(self):
         self.op_type = "distribute_fpn_proposals"

--- a/python/paddle/fluid/tests/unittests/test_eager_deletion_while_op.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_deletion_while_op.py
@@ -59,16 +59,16 @@ class TestEagerDeletionWhileOpBase(unittest.TestCase):
                 ))) if self.with_data_parallel else 1
 
         d0 = layers.data(
-            "d0", shape=[10], append_batch_size=False, dtype='float32')
+            "d0", shape=[10], append_batch_size=False, dtype='float64')
         d1 = layers.data(
-            "d1", shape=[10], append_batch_size=False, dtype='float32')
+            "d1", shape=[10], append_batch_size=False, dtype='float64')
         d2 = layers.data(
-            "d2", shape=[10], append_batch_size=False, dtype='float32')
+            "d2", shape=[10], append_batch_size=False, dtype='float64')
 
         i = layers.zeros(shape=[1], dtype='int64')
         i.stop_gradient = True
 
-        init = layers.zeros(shape=[10], dtype='float32')
+        init = layers.zeros(shape=[10], dtype='float64')
         mem_array = layers.array_write(x=init, i=i)
         data_array = layers.array_write(x=d0, i=i)
 
@@ -135,7 +135,7 @@ class TestEagerDeletionWhileOpBase(unittest.TestCase):
         for _ in range(5):
             d = []
             for i in range(3):
-                tmp = numpy.random.random(size=[10]).astype('float32')
+                tmp = numpy.random.random(size=[10]).astype('float64')
                 if not self.with_data_parallel:
                     d.append(tmp)
                 else:

--- a/python/paddle/fluid/tests/unittests/test_edit_distance_op.py
+++ b/python/paddle/fluid/tests/unittests/test_edit_distance_op.py
@@ -34,7 +34,7 @@ def Levenshtein(hyp, ref):
     if n == 0:
         return m
 
-    dist = np.zeros((m + 1, n + 1)).astype("float32")
+    dist = np.zeros((m + 1, n + 1)).astype("float64")
     for i in range(0, m + 1):
         dist[i][0] = i
     for j in range(0, n + 1):
@@ -62,7 +62,7 @@ class TestEditDistanceOp(OpTest):
         self.x2_lod = [3, 1]
 
         num_strs = len(self.x1_lod)
-        distance = np.zeros((num_strs, 1)).astype("float32")
+        distance = np.zeros((num_strs, 1)).astype("float64")
         sequence_num = np.array(2).astype("int64")
 
         x1_offset = 0
@@ -105,7 +105,7 @@ class TestEditDistanceOpNormalizedCase0(OpTest):
         self.reset_config()
 
         num_strs = len(self.x1_lod)
-        distance = np.zeros((num_strs, 1)).astype("float32")
+        distance = np.zeros((num_strs, 1)).astype("float64")
         sequence_num = np.array(num_strs).astype("int64")
 
         x1_offset = 0
@@ -159,7 +159,7 @@ class TestEditDistanceOpNormalizedTensor(OpTest):
         self.reset_config()
 
         num_strs = len(self.x1_lod)
-        distance = np.zeros((num_strs, 1)).astype("float32")
+        distance = np.zeros((num_strs, 1)).astype("float64")
         sequence_num = np.array(num_strs).astype("int64")
 
         for i in range(0, num_strs):

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -25,7 +25,7 @@ class TestElementwiseAddOp(OpTest):
 
     def setUp(self):
         self.op_type = "elementwise_add"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.axis = -1
         self.init_dtype()
         self.init_input_output()

--- a/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_div_op.py
@@ -21,12 +21,12 @@ from op_test import OpTest
 class ElementwiseDivOp(OpTest):
     def setUp(self):
         self.op_type = "elementwise_div"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
         """ Warning
         CPU gradient check error!
-        'X': np.random.random((32,84)).astype("float32"),
-        'Y': np.random.random((32,84)).astype("float32")
+        'X': np.random.random((32,84)).astype("float64"),
+        'Y': np.random.random((32,84)).astype("float64")
         """
         self.inputs = {
             'X': np.random.uniform(0.1, 1, [13, 17]).astype(self.dtype),
@@ -56,8 +56,8 @@ class TestElementwiseDivOp_scalar(ElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype(np.float32),
-            'Y': np.random.uniform(0.1, 1, [1]).astype(np.float32)
+            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype(np.float64),
+            'Y': np.random.uniform(0.1, 1, [1]).astype(np.float64)
         }
         self.outputs = {'Out': self.inputs['X'] / self.inputs['Y']}
 
@@ -66,8 +66,8 @@ class TestElementwiseDivOp_Vector(ElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [32]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [32]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [32]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [32]).astype("float64")
         }
         self.outputs = {'Out': np.divide(self.inputs['X'], self.inputs['Y'])}
 
@@ -76,8 +76,8 @@ class TestElementwiseDivOp_broadcast_0(ElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [2]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [2]).astype("float64")
         }
 
         self.attrs = {'axis': 0}
@@ -91,8 +91,8 @@ class TestElementwiseDivOp_broadcast_1(ElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [3]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [3]).astype("float64")
         }
 
         self.attrs = {'axis': 1}
@@ -106,8 +106,8 @@ class TestElementwiseDivOp_broadcast_2(ElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [4]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [2, 3, 4]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [4]).astype("float64")
         }
 
         self.outputs = {
@@ -120,8 +120,8 @@ class TestElementwiseDivOp_broadcast_3(ElementwiseDivOp):
     def setUp(self):
         self.op_type = "elementwise_div"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [2, 3, 4, 5]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [3, 4]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [2, 3, 4, 5]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [3, 4]).astype("float64")
         }
 
         self.attrs = {'axis': 1}

--- a/python/paddle/fluid/tests/unittests/test_elementwise_gradient_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_gradient_op.py
@@ -26,7 +26,7 @@ class TestElementWiseAddOp(unittest.TestCase):
 
     def check_forward_backward(self):
         def test_with_place(place):
-            out_grad = np.random.random_sample(self.x.shape).astype(np.float32)
+            out_grad = np.random.random_sample(self.x.shape).astype(np.float64)
             x_grad = out_grad
             sum_axis = list(range(0, len(self.x.shape)))
             del sum_axis[self.axis]
@@ -49,7 +49,7 @@ class TestElementWiseAddOp(unittest.TestCase):
                 for name in ground_truth:
                     block.create_var(
                         name=name,
-                        dtype='float32',
+                        dtype='float64',
                         shape=ground_truth[name].shape)
                 elementwise_add_op = block.append_op(
                     type="elementwise_add",
@@ -94,8 +94,8 @@ class TestElementWiseAddOp(unittest.TestCase):
 
     def test_check_forward_backward_with_scale_and_bias(self):
         np.random.seed(123)
-        self.x = np.random.random((4, 32, 220, 220)).astype(np.float32)
-        self.y = np.random.random((32)).astype(np.float32)
+        self.x = np.random.random((4, 32, 220, 220)).astype(np.float64)
+        self.y = np.random.random((32)).astype(np.float64)
         self.out = self.x + self.y.reshape(1, 32, 1, 1)
         self.axis = 1
         self.check_forward_backward()

--- a/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
@@ -25,9 +25,9 @@ class TestElementwiseOp(OpTest):
         # If x and y have the same value, the max() is not differentiable.
         # So we generate test data by the following method
         # to avoid them being too close to each other.
-        x = np.random.uniform(0.1, 1, [13, 17]).astype("float32")
-        sgn = np.random.choice([-1, 1], [13, 17]).astype("float32")
-        y = x + sgn * np.random.uniform(0.1, 1, [13, 17]).astype("float32")
+        x = np.random.uniform(0.1, 1, [13, 17]).astype("float64")
+        sgn = np.random.choice([-1, 1], [13, 17]).astype("float64")
+        y = x + sgn * np.random.uniform(0.1, 1, [13, 17]).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.maximum(self.inputs['X'], self.inputs['Y'])}
 
@@ -49,8 +49,8 @@ class TestElementwiseOp(OpTest):
 class TestElementwiseMaxOp_scalar(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
-        x = np.random.random_integers(-5, 5, [2, 3, 4]).astype("float32")
-        y = np.array([0.5]).astype("float32")
+        x = np.random.random_integers(-5, 5, [2, 3, 4]).astype("float64")
+        y = np.array([0.5]).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.maximum(self.inputs['X'], self.inputs['Y'])}
 
@@ -58,9 +58,9 @@ class TestElementwiseMaxOp_scalar(TestElementwiseOp):
 class TestElementwiseMaxOp_Vector(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
-        x = np.random.random((32, )).astype("float32")
-        sgn = np.random.choice([-1, 1], (32, )).astype("float32")
-        y = x + sgn * np.random.uniform(0.1, 1, (32, )).astype("float32")
+        x = np.random.random((32, )).astype("float64")
+        sgn = np.random.choice([-1, 1], (32, )).astype("float64")
+        y = x + sgn * np.random.uniform(0.1, 1, (32, )).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.maximum(self.inputs['X'], self.inputs['Y'])}
 
@@ -68,10 +68,10 @@ class TestElementwiseMaxOp_Vector(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_0(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
-        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (2, )).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (2, )).astype(np.float64)
         y = x[:, 0, 0] + sgn * \
-            np.random.uniform(1, 2, (2, )).astype(np.float32)
+            np.random.uniform(1, 2, (2, )).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.attrs = {'axis': 0}
@@ -84,10 +84,10 @@ class TestElementwiseMaxOp_broadcast_0(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_1(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
-        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (3, )).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (3, )).astype(np.float64)
         y = x[0, :, 0] + sgn * \
-            np.random.uniform(1, 2, (3, )).astype(np.float32)
+            np.random.uniform(1, 2, (3, )).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.attrs = {'axis': 1}
@@ -100,10 +100,10 @@ class TestElementwiseMaxOp_broadcast_1(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
-        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (4, )).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (4, )).astype(np.float64)
         y = x[0, 0, :] + sgn * \
-            np.random.uniform(1, 2, (4, )).astype(np.float32)
+            np.random.uniform(1, 2, (4, )).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.outputs = {
@@ -115,10 +115,10 @@ class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_3(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_max"
-        x = np.random.uniform(0.5, 1, (2, 3, 4, 5)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (3, 4)).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4, 5)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (3, 4)).astype(np.float64)
         y = x[0, :, :, 0] + sgn * \
-            np.random.uniform(1, 2, (3, 4)).astype(np.float32)
+            np.random.uniform(1, 2, (3, 4)).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.attrs = {'axis': 1}

--- a/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
@@ -25,9 +25,9 @@ class TestElementwiseOp(OpTest):
         # If x and y have the same value, the min() is not differentiable.
         # So we generate test data by the following method
         # to avoid them being too close to each other.
-        x = np.random.uniform(0.1, 1, [13, 17]).astype("float32")
-        sgn = np.random.choice([-1, 1], [13, 17]).astype("float32")
-        y = x + sgn * np.random.uniform(0.1, 1, [13, 17]).astype("float32")
+        x = np.random.uniform(0.1, 1, [13, 17]).astype("float64")
+        sgn = np.random.choice([-1, 1], [13, 17]).astype("float64")
+        y = x + sgn * np.random.uniform(0.1, 1, [13, 17]).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
@@ -49,8 +49,8 @@ class TestElementwiseOp(OpTest):
 class TestElementwiseMinOp_scalar(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.random_integers(-5, 5, [2, 3, 4]).astype("float32")
-        y = np.array([0.5]).astype("float32")
+        x = np.random.random_integers(-5, 5, [2, 3, 4]).astype("float64")
+        y = np.array([0.5]).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
@@ -58,9 +58,9 @@ class TestElementwiseMinOp_scalar(TestElementwiseOp):
 class TestElementwiseMaxOp_Vector(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.random((32, )).astype("float32")
-        sgn = np.random.choice([-1, 1], (32, )).astype("float32")
-        y = x + sgn * np.random.uniform(0.1, 1, (32, )).astype("float32")
+        x = np.random.random((32, )).astype("float64")
+        sgn = np.random.choice([-1, 1], (32, )).astype("float64")
+        y = x + sgn * np.random.uniform(0.1, 1, (32, )).astype("float64")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 
@@ -68,10 +68,10 @@ class TestElementwiseMaxOp_Vector(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_0(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (2, )).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (2, )).astype(np.float64)
         y = x[:, 0, 0] + sgn * \
-            np.random.uniform(1, 2, (2, )).astype(np.float32)
+            np.random.uniform(1, 2, (2, )).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.attrs = {'axis': 0}
@@ -84,10 +84,10 @@ class TestElementwiseMaxOp_broadcast_0(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_1(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (3, )).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (3, )).astype(np.float64)
         y = x[0, :, 0] + sgn * \
-            np.random.uniform(1, 2, (3, )).astype(np.float32)
+            np.random.uniform(1, 2, (3, )).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.attrs = {'axis': 1}
@@ -100,10 +100,10 @@ class TestElementwiseMaxOp_broadcast_1(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (4, )).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (4, )).astype(np.float64)
         y = x[0, 0, :] + sgn * \
-            np.random.uniform(1, 2, (4, )).astype(np.float32)
+            np.random.uniform(1, 2, (4, )).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.outputs = {
@@ -115,10 +115,10 @@ class TestElementwiseMaxOp_broadcast_2(TestElementwiseOp):
 class TestElementwiseMaxOp_broadcast_3(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.uniform(0.5, 1, (2, 3, 4, 5)).astype(np.float32)
-        sgn = np.random.choice([-1, 1], (3, 4)).astype(np.float32)
+        x = np.random.uniform(0.5, 1, (2, 3, 4, 5)).astype(np.float64)
+        sgn = np.random.choice([-1, 1], (3, 4)).astype(np.float64)
         y = x[0, :, :, 0] + sgn * \
-            np.random.uniform(1, 2, (3, 4)).astype(np.float32)
+            np.random.uniform(1, 2, (3, 4)).astype(np.float64)
         self.inputs = {'X': x, 'Y': y}
 
         self.attrs = {'axis': 1}

--- a/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
@@ -26,7 +26,7 @@ class ElementwiseMulOp(OpTest):
 
     def setUp(self):
         self.op_type = "elementwise_mul"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.axis = -1
         self.init_dtype()
         self.init_input_output()
@@ -68,8 +68,8 @@ class TestElementwiseMulOp_scalar(ElementwiseMulOp):
     def setUp(self):
         self.op_type = "elementwise_mul"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4).astype(np.float32),
-            'Y': np.random.rand(1).astype(np.float32)
+            'X': np.random.rand(2, 3, 4).astype(np.float64),
+            'Y': np.random.rand(1).astype(np.float64)
         }
         self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
 

--- a/python/paddle/fluid/tests/unittests/test_elementwise_pow_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_pow_op.py
@@ -22,8 +22,8 @@ class TestElementwisePowOp(OpTest):
     def setUp(self):
         self.op_type = "elementwise_pow"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [13, 17]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [13, 17]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [13, 17]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [13, 17]).astype("float64")
         }
         self.outputs = {'Out': np.power(self.inputs['X'], self.inputs['Y'])}
 
@@ -35,8 +35,8 @@ class TestElementwisePowOp_scalar(TestElementwisePowOp):
     def setUp(self):
         self.op_type = "elementwise_pow"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4).astype('float32'),
-            'Y': np.random.rand(1).astype('float32')
+            'X': np.random.rand(2, 3, 4).astype('float64'),
+            'Y': np.random.rand(1).astype('float64')
         }
         self.outputs = {'Out': np.power(self.inputs['X'], self.inputs['Y'])}
 

--- a/python/paddle/fluid/tests/unittests/test_elementwise_sub_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_sub_op.py
@@ -22,8 +22,8 @@ class TestElementwiseOp(OpTest):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.uniform(0.1, 1, [2, 3]).astype("float32"),
-            'Y': np.random.uniform(0.1, 1, [2, 3]).astype("float32")
+            'X': np.random.uniform(0.1, 1, [2, 3]).astype("float64"),
+            'Y': np.random.uniform(0.1, 1, [2, 3]).astype("float64")
         }
         self.outputs = {'Out': self.inputs['X'] - self.inputs['Y']}
 
@@ -46,8 +46,8 @@ class TestElementwiseSubOp_scalar(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4).astype(np.float32),
-            'Y': np.random.rand(1).astype(np.float32)
+            'X': np.random.rand(2, 3, 4).astype(np.float64),
+            'Y': np.random.rand(1).astype(np.float64)
         }
         self.outputs = {'Out': self.inputs['X'] - self.inputs['Y']}
 
@@ -56,8 +56,8 @@ class TestElementwiseSubOp_Vector(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.random((32, )).astype("float32"),
-            'Y': np.random.random((32, )).astype("float32")
+            'X': np.random.random((32, )).astype("float64"),
+            'Y': np.random.random((32, )).astype("float64")
         }
         self.outputs = {'Out': self.inputs['X'] - self.inputs['Y']}
 
@@ -66,8 +66,8 @@ class TestElementwiseSubOp_broadcast_0(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4).astype(np.float32),
-            'Y': np.random.rand(2).astype(np.float32)
+            'X': np.random.rand(2, 3, 4).astype(np.float64),
+            'Y': np.random.rand(2).astype(np.float64)
         }
 
         self.attrs = {'axis': 0}
@@ -80,8 +80,8 @@ class TestElementwiseSubOp_broadcast_1(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4).astype(np.float32),
-            'Y': np.random.rand(3).astype(np.float32)
+            'X': np.random.rand(2, 3, 4).astype(np.float64),
+            'Y': np.random.rand(3).astype(np.float64)
         }
 
         self.attrs = {'axis': 1}
@@ -94,8 +94,8 @@ class TestElementwiseSubOp_broadcast_2(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4).astype(np.float32),
-            'Y': np.random.rand(4).astype(np.float32)
+            'X': np.random.rand(2, 3, 4).astype(np.float64),
+            'Y': np.random.rand(4).astype(np.float64)
         }
 
         self.outputs = {
@@ -107,8 +107,8 @@ class TestElementwiseSubOp_broadcast_3(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_sub"
         self.inputs = {
-            'X': np.random.rand(2, 3, 4, 5).astype(np.float32),
-            'Y': np.random.rand(3, 4).astype(np.float32)
+            'X': np.random.rand(2, 3, 4, 5).astype(np.float64),
+            'Y': np.random.rand(3, 4).astype(np.float64)
         }
 
         self.attrs = {'axis': 1}

--- a/python/paddle/fluid/tests/unittests/test_expand_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestExpandOpRank1(OpTest):
     def setUp(self):
         self.op_type = "expand"
-        self.inputs = {'X': np.random.random(12).astype("float32")}
+        self.inputs = {'X': np.random.random(12).astype("float64")}
         self.attrs = {'expand_times': [2]}
         output = np.tile(self.inputs['X'], 2)
         self.outputs = {'Out': output}
@@ -38,7 +38,7 @@ class TestExpandOpRank1_tensor_attr(OpTest):
     def setUp(self):
         self.op_type = "expand"
         self.inputs = {
-            'X': np.random.random(12).astype("float32"),
+            'X': np.random.random(12).astype("float64"),
             'expand_times_tensor': [('x1', np.ones((1)).astype('int32') * 2)]
         }
         self.attrs = {}
@@ -55,7 +55,7 @@ class TestExpandOpRank1_tensor_attr(OpTest):
 class TestExpandOpRank2_Corner(OpTest):
     def setUp(self):
         self.op_type = "expand"
-        self.inputs = {'X': np.random.random((12, 14)).astype("float32")}
+        self.inputs = {'X': np.random.random((12, 14)).astype("float64")}
         self.attrs = {'expand_times': [1, 1]}
         output = np.tile(self.inputs['X'], (1, 1))
         self.outputs = {'Out': output}
@@ -71,7 +71,7 @@ class TestExpandOpRank2_Corner_tensor_attr(OpTest):
     def setUp(self):
         self.op_type = "expand"
         self.inputs = {
-            'X': np.random.random((12, 14)).astype("float32"),
+            'X': np.random.random((12, 14)).astype("float64"),
             'expand_times_tensor': [('x1', np.ones((1)).astype('int32')),
                                     ('x2', np.ones((1)).astype('int32'))]
         }
@@ -89,7 +89,7 @@ class TestExpandOpRank2_Corner_tensor_attr(OpTest):
 class TestExpandOpRank2(OpTest):
     def setUp(self):
         self.op_type = "expand"
-        self.inputs = {'X': np.random.random((12, 14)).astype("float32")}
+        self.inputs = {'X': np.random.random((12, 14)).astype("float64")}
         self.attrs = {'expand_times': [2, 3]}
         output = np.tile(self.inputs['X'], (2, 3))
         self.outputs = {'Out': output}
@@ -105,7 +105,7 @@ class TestExpandOpRank2_attr_tensor(OpTest):
     def setUp(self):
         self.op_type = "expand"
         self.inputs = {
-            'X': np.random.random((12, 14)).astype("float32"),
+            'X': np.random.random((12, 14)).astype("float64"),
             'expand_times_tensor': [('x1', np.ones((1)).astype('int32') * 2),
                                     ('x2', np.ones((1)).astype('int32') * 3)]
         }
@@ -123,7 +123,7 @@ class TestExpandOpRank2_attr_tensor(OpTest):
 class TestExpandOpRank3_Corner(OpTest):
     def setUp(self):
         self.op_type = "expand"
-        self.inputs = {'X': np.random.random((2, 4, 5)).astype("float32")}
+        self.inputs = {'X': np.random.random((2, 4, 5)).astype("float64")}
         self.attrs = {'expand_times': [1, 1, 1]}
         output = np.tile(self.inputs['X'], (1, 1, 1))
         self.outputs = {'Out': output}
@@ -138,7 +138,7 @@ class TestExpandOpRank3_Corner(OpTest):
 class TestExpandOpRank3(OpTest):
     def setUp(self):
         self.op_type = "expand"
-        self.inputs = {'X': np.random.random((2, 4, 5)).astype("float32")}
+        self.inputs = {'X': np.random.random((2, 4, 5)).astype("float64")}
         self.attrs = {'expand_times': [2, 1, 4]}
         output = np.tile(self.inputs['X'], (2, 1, 4))
         self.outputs = {'Out': output}
@@ -153,7 +153,7 @@ class TestExpandOpRank3(OpTest):
 class TestExpandOpRank4(OpTest):
     def setUp(self):
         self.op_type = "expand"
-        self.inputs = {'X': np.random.random((2, 4, 5, 7)).astype("float32")}
+        self.inputs = {'X': np.random.random((2, 4, 5, 7)).astype("float64")}
         self.attrs = {'expand_times': [3, 2, 1, 2]}
         output = np.tile(self.inputs['X'], (3, 2, 1, 2))
         self.outputs = {'Out': output}

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -36,9 +36,9 @@ def fc_refer(matrix, with_bias):
 
 class MatrixGenerate:
     def __init__(self, mb, ic, oc, h, w):
-        self.input = np.random.random((mb, ic, h, w)).astype("float32")
-        self.weights = np.random.random((ic * h * w, oc)).astype("float32")
-        self.bias = np.random.random((1, oc)).astype("float32")
+        self.input = np.random.random((mb, ic, h, w)).astype("float64")
+        self.weights = np.random.random((ic * h * w, oc)).astype("float64")
+        self.bias = np.random.random((1, oc)).astype("float64")
 
 
 class TestFCOp(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_batch_size_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_batch_size_like_op.py
@@ -22,10 +22,10 @@ from op_test import OpTest
 class TestFillConstantBatchSizeLikeWhenFirstDimIsBatchSize(OpTest):
     def setUp(self):
         self.op_type = "fill_constant_batch_size_like"
-        self.inputs = {'Input': np.random.random((219, 232)).astype("float32")}
+        self.inputs = {'Input': np.random.random((219, 232)).astype("float64")}
         self.attrs = {'value': 3.5, 'shape': [-1, 132, 7]}
 
-        out = np.random.random((219, 132, 7)).astype("float32")
+        out = np.random.random((219, 132, 7)).astype("float64")
         out.fill(3.5)
         self.outputs = {'Out': out}
 
@@ -36,7 +36,7 @@ class TestFillConstantBatchSizeLikeWhenFirstDimIsBatchSize(OpTest):
 class TestFillConstantBatchSizeLikeWhenSecondDimIsBatchSize(OpTest):
     def setUp(self):
         self.op_type = "fill_constant_batch_size_like"
-        self.inputs = {'Input': np.random.random((219, 232)).astype("float32")}
+        self.inputs = {'Input': np.random.random((219, 232)).astype("float64")}
         self.attrs = {
             'value': 3.5,
             'shape': [132, -1, 7],
@@ -44,7 +44,7 @@ class TestFillConstantBatchSizeLikeWhenSecondDimIsBatchSize(OpTest):
             'output_dim_idx': 1
         }
 
-        out = np.random.random((132, 219, 7)).astype("float32")
+        out = np.random.random((132, 219, 7)).astype("float64")
         out.fill(3.5)
         self.outputs = {'Out': out}
 
@@ -56,7 +56,7 @@ class TestFillConstantBatchSizeLikeWithLoDTensor(OpTest):
     def setUp(self):
         self.op_type = "fill_constant_batch_size_like"
         self.inputs = {
-            'Input': (np.random.random((31, 28)).astype("float32"),
+            'Input': (np.random.random((31, 28)).astype("float64"),
                       [[9, 14, 8]])
         }
         self.attrs = {
@@ -66,7 +66,7 @@ class TestFillConstantBatchSizeLikeWithLoDTensor(OpTest):
             'output_dim_idx': 0
         }
 
-        out = np.random.random((3, 16)).astype("float32")
+        out = np.random.random((3, 16)).astype("float64")
         out.fill(3.5)
         self.outputs = {'Out': out}
 

--- a/python/paddle/fluid/tests/unittests/test_fill_zeros_like2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_zeros_like2_op.py
@@ -23,7 +23,7 @@ from op_test import OpTest
 class TestFillZerosLike2Op(OpTest):
     def setUp(self):
         self.op_type = "fill_zeros_like2"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
         self.inputs = {'X': np.random.random((219, 232)).astype(self.dtype)}
         self.outputs = {'Out': np.zeros_like(self.inputs["X"])}

--- a/python/paddle/fluid/tests/unittests/test_fill_zeros_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_zeros_like_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestFillZerosLikeOp(OpTest):
     def setUp(self):
         self.op_type = "fill_zeros_like"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
         self.inputs = {'X': np.random.random((219, 232)).astype(self.dtype)}
         self.outputs = {'Out': np.zeros_like(self.inputs["X"])}

--- a/python/paddle/fluid/tests/unittests/test_flatten_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_op.py
@@ -24,11 +24,11 @@ class TestFlattenOp(OpTest):
     def setUp(self):
         self.op_type = "flatten2"
         self.init_test_case()
-        self.inputs = {"X": np.random.random(self.in_shape).astype("float32")}
+        self.inputs = {"X": np.random.random(self.in_shape).astype("float64")}
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
-            "XShape": np.random.random(self.in_shape).astype("float32")
+            "XShape": np.random.random(self.in_shape).astype("float64")
         }
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_ftrl_op.py
+++ b/python/paddle/fluid/tests/unittests/test_ftrl_op.py
@@ -22,11 +22,11 @@ from op_test import OpTest
 class TestFTRLOp(OpTest):
     def setUp(self):
         self.op_type = "ftrl"
-        w = np.random.random((102, 105)).astype("float32")
-        g = np.random.random((102, 105)).astype("float32")
-        sq_accum = np.full((102, 105), 0.1).astype("float32")
-        linear_accum = np.full((102, 105), 0.1).astype("float32")
-        lr = np.array([0.01]).astype("float32")
+        w = np.random.random((102, 105)).astype("float64")
+        g = np.random.random((102, 105)).astype("float64")
+        sq_accum = np.full((102, 105), 0.1).astype("float64")
+        linear_accum = np.full((102, 105), 0.1).astype("float64")
+        lr = np.array([0.01]).astype("float64")
         l1 = 0.1
         l2 = 0.2
         lr_power = -0.5

--- a/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
@@ -27,7 +27,7 @@ class TestFusedEmbeddingSeqPoolOp(OpTest):
     def setUp(self):
         self.op_type = "fused_embedding_seq_pool"
         self.emb_size = 2
-        table = np.random.random((17, self.emb_size)).astype("float32")
+        table = np.random.random((17, self.emb_size)).astype("float64")
         ids = np.array([[[4], [3]], [[4], [3]], [[2], [1]],
                         [[16], [1]]]).astype("int64")
         merged_ids = np.array([4, 2, 16]).astype("int64")

--- a/python/paddle/fluid/tests/unittests/test_fused_embedding_fc_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_embedding_fc_lstm_op.py
@@ -70,14 +70,14 @@ class TestFusionLSTMOp(OpTest):
         bs = len(self.lod[0])
 
         # this is the weight of fc
-        wx = np.random.normal(size=(self.M, 4 * self.D)).astype('float32')
+        wx = np.random.normal(size=(self.M, 4 * self.D)).astype('float64')
         # this is the bias of fc
-        bx = np.random.normal(size=(1, 4 * self.D)).astype('float32')
+        bx = np.random.normal(size=(1, 4 * self.D)).astype('float64')
 
         if self.use_peepholes:
-            b = np.random.normal(size=(1, 7 * self.D)).astype('float32')
+            b = np.random.normal(size=(1, 7 * self.D)).astype('float64')
         else:
-            b = np.random.normal(size=(1, 4 * self.D)).astype('float32')
+            b = np.random.normal(size=(1, 4 * self.D)).astype('float64')
         w_b = np.copy(b[:, 0:4 * self.D])
         w_c = b[:, 4 * self.D:] if self.use_peepholes else None
 
@@ -86,7 +86,7 @@ class TestFusionLSTMOp(OpTest):
             low=0, high=self.dict_size - 1, size=(T, 1)).astype("int64")
         # embeddings as they were trained , so each entry is of M size
         embeddings = np.random.random(
-            (self.dict_size, self.M)).astype("float32")
+            (self.dict_size, self.M)).astype("float64")
 
         # multiply embeddings via Weights
         fc_embeddings = np.dot(embeddings, wx)
@@ -101,13 +101,13 @@ class TestFusionLSTMOp(OpTest):
         fc_embeddings += broadcasted_biases
 
         if self.has_initial_state:
-            h0 = np.random.normal(size=(bs, self.D)).astype('float32')
-            c0 = np.random.normal(size=(bs, self.D)).astype('float32')
+            h0 = np.random.normal(size=(bs, self.D)).astype('float64')
+            c0 = np.random.normal(size=(bs, self.D)).astype('float64')
         else:
-            h0 = np.zeros((bs, self.D)).astype('float32')
-            c0 = np.zeros((bs, self.D)).astype('float32')
+            h0 = np.zeros((bs, self.D)).astype('float64')
+            c0 = np.zeros((bs, self.D)).astype('float64')
 
-        wh = np.random.normal(size=(self.D, 4 * self.D)).astype('float32')
+        wh = np.random.normal(size=(self.D, 4 * self.D)).astype('float64')
 
         h, c = fused_embedded_fc_lstm(
             ids, self.lod, embeddings, wx, bx, h0, c0, wh, w_b, w_c,

--- a/python/paddle/fluid/tests/unittests/test_fusion_gru_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_gru_op.py
@@ -37,7 +37,7 @@ def fusion_gru(
                h0,
                wh,
                np.zeros(
-                   (1, wh.shape[1]), dtype='float32'),
+                   (1, wh.shape[1]), dtype='float64'),
                is_reverse,
                act_state,
                act_gate)
@@ -62,15 +62,15 @@ class TestFusionGRUOp(OpTest):
         T = sum(self.lod[0])
         N = len(self.lod[0])
 
-        x = np.random.rand(T, self.M).astype('float32')
-        wx = np.random.rand(self.M, 3 * self.D).astype('float32')
-        wh = np.random.rand(self.D, 3 * self.D).astype('float32')
+        x = np.random.rand(T, self.M).astype('float64')
+        wx = np.random.rand(self.M, 3 * self.D).astype('float64')
+        wh = np.random.rand(self.D, 3 * self.D).astype('float64')
         bias = np.random.rand(
-            1, 3 * self.D).astype('float32') if self.with_bias else np.zeros(
-                (1, 3 * self.D), dtype='float32')
+            1, 3 * self.D).astype('float64') if self.with_bias else np.zeros(
+                (1, 3 * self.D), dtype='float64')
         h0 = np.random.rand(
-            N, self.D).astype('float32') if self.with_h0 else np.zeros(
-                (N, self.D), dtype='float32')
+            N, self.D).astype('float64') if self.with_h0 else np.zeros(
+                (N, self.D), dtype='float64')
 
         _, _, _, hidden = fusion_gru(
             x, self.lod, h0, wx, wh, bias, self.is_reverse,

--- a/python/paddle/fluid/tests/unittests/test_fusion_lstm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_lstm_op.py
@@ -63,28 +63,28 @@ class TestFusionLSTMOp(OpTest):
         T = sum(self.lod[0])
         bs = len(self.lod[0])
 
-        x = np.random.normal(size=(T, self.M)).astype('float32')
+        x = np.random.normal(size=(T, self.M)).astype('float64')
         if self.has_initial_state:
-            h0 = np.random.normal(size=(bs, self.D)).astype('float32')
-            c0 = np.random.normal(size=(bs, self.D)).astype('float32')
+            h0 = np.random.normal(size=(bs, self.D)).astype('float64')
+            c0 = np.random.normal(size=(bs, self.D)).astype('float64')
         else:
-            h0 = np.zeros((bs, self.D)).astype('float32')
-            c0 = np.zeros((bs, self.D)).astype('float32')
+            h0 = np.zeros((bs, self.D)).astype('float64')
+            c0 = np.zeros((bs, self.D)).astype('float64')
 
-        wh = np.random.normal(size=(self.D, 4 * self.D)).astype('float32')
+        wh = np.random.normal(size=(self.D, 4 * self.D)).astype('float64')
 
         if self.use_peepholes:
-            b = np.random.normal(size=(1, 7 * self.D)).astype('float32')
+            b = np.random.normal(size=(1, 7 * self.D)).astype('float64')
         else:
-            b = np.random.normal(size=(1, 4 * self.D)).astype('float32')
+            b = np.random.normal(size=(1, 4 * self.D)).astype('float64')
         w_b = np.copy(b[:, 0:4 * self.D])
         w_c = b[:, 4 * self.D:] if self.use_peepholes else None
 
         # this is the weight of fc
-        wx = np.random.normal(size=(self.M, 4 * self.D)).astype('float32')
+        wx = np.random.normal(size=(self.M, 4 * self.D)).astype('float64')
         # this is the bias of fc
         # and it should be manually added into the bias of this fusion LSTM
-        bx = np.random.normal(size=(1, 4 * self.D)).astype('float32')
+        bx = np.random.normal(size=(1, 4 * self.D)).astype('float64')
         b[0, 0:4 * self.D] += bx[0, :]
         h, c = fusion_lstm(x, self.lod, wx, bx, h0, c0, wh, w_b, w_c,
                            self.is_reverse, ACTIVATION[self.act_gate],

--- a/python/paddle/fluid/tests/unittests/test_fusion_seqconv_eltadd_relu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_seqconv_eltadd_relu_op.py
@@ -38,11 +38,11 @@ class TestSeqConvEltAddRelu(OpTest):
         assert self.context_stride == 1
 
         T = sum(self.lod[0])
-        x = np.random.uniform(-1, 1, [T, self.in_fea_size]).astype('float32')
+        x = np.random.uniform(-1, 1, [T, self.in_fea_size]).astype('float64')
         w = np.random.uniform(
             -1, 1, [self.in_fea_size * self.context_length,
-                    self.out_fea_size]).astype('float32')
-        b = np.random.uniform(-2, 1, [1, self.out_fea_size]).astype('float32')
+                    self.out_fea_size]).astype('float64')
+        b = np.random.uniform(-2, 1, [1, self.out_fea_size]).astype('float64')
         out = seqconv(x, self.lod, w, self.context_length, self.context_start)
         out = np.maximum(out + b, 0)
 

--- a/python/paddle/fluid/tests/unittests/test_fusion_seqpool_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_seqpool_concat_op.py
@@ -36,9 +36,9 @@ class TestFusionSeqPoolConcatOp(OpTest):
         for lod in self.lods:
             assert bs == len(lod[0]), 'All lod size should be equal'
             x = np.random.uniform(0.1, 1,
-                                  [sum(lod[0]), self.w]).astype('float32')
+                                  [sum(lod[0]), self.w]).astype('float64')
             offset = convert_to_offset(lod)
-            out = np.zeros((bs, self.w)).astype('float32')
+            out = np.zeros((bs, self.w)).astype('float64')
             if self.pooltype == "SUM":
                 compute_seqpool_sum(x, offset, out)
             elif self.pooltype == "AVERAGE":

--- a/python/paddle/fluid/tests/unittests/test_fusion_squared_mat_sub_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_squared_mat_sub_op.py
@@ -27,8 +27,8 @@ class TestFusionSquaredMatSubOp(OpTest):
         self.k = 4
         self.scalar = 0.5
         self.set_conf()
-        matx = np.random.random((self.m, self.k)).astype("float32")
-        maty = np.random.random((self.k, self.n)).astype("float32")
+        matx = np.random.random((self.m, self.k)).astype("float64")
+        maty = np.random.random((self.k, self.n)).astype("float64")
 
         self.inputs = {'X': matx, 'Y': maty}
         self.outputs = {

--- a/python/paddle/fluid/tests/unittests/test_fusion_transpose_flatten_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_transpose_flatten_concat_op.py
@@ -29,7 +29,7 @@ class TestFusionTransposeFlattenConcationOp(OpTest):
         flats = []
         for i in range(len(self.shapes)):
             in_shape = self.shapes[i]
-            a = np.random.random(in_shape).astype("float32")
+            a = np.random.random(in_shape).astype("float64")
             ins.append(("x%d" % i, a))
 
             b = a.transpose(self.trans_axis)

--- a/python/paddle/fluid/tests/unittests/test_gather_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gather_op.py
@@ -41,7 +41,7 @@ class TestGatherOp(OpTest):
         For multi-dimension input
         """
         self.x_shape = (10, 20)
-        self.x_type = "float32"
+        self.x_type = "float64"
         self.index = [1, 3, 5]
         self.index_type = "int32"
 
@@ -52,7 +52,7 @@ class TestCase1(TestGatherOp):
         For one dimension input
         """
         self.x_shape = (10)
-        self.x_type = "float32"
+        self.x_type = "float64"
         self.index = [1, 3, 5]
         self.index_type = "int32"
 
@@ -63,7 +63,7 @@ class TestCase2(TestGatherOp):
         For int64_t index type
         """
         self.x_shape = (10)
-        self.x_type = "float32"
+        self.x_type = "float64"
         self.index = [1, 3, 5]
         self.index_type = "int64"
 

--- a/python/paddle/fluid/tests/unittests/test_gaussian_random_batch_size_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gaussian_random_batch_size_like_op.py
@@ -22,9 +22,9 @@ from op_test import OpTest
 class TestGaussianRandomBatchSizeLike(OpTest):
     def setUp(self):
         self.op_type = "gaussian_random_batch_size_like"
-        self.inputs = {'Input': np.zeros((500, 2000), dtype="float32")}
+        self.inputs = {'Input': np.zeros((500, 2000), dtype="float64")}
         self.attrs = {'mean': 1., 'std': 2., 'shape': [-1, 2000]}
-        self.outputs = {'Out': np.zeros((500, 2000), dtype='float32')}
+        self.outputs = {'Out': np.zeros((500, 2000), dtype='float64')}
 
     def test_check_output(self):
         self.check_output_customized(self.verify_output)
@@ -32,11 +32,11 @@ class TestGaussianRandomBatchSizeLike(OpTest):
     def verify_output(self, outs):
         self.assertEqual(outs[0].shape, (500, 2000))
         hist, _ = np.histogram(outs[0], range=(-3, 5))
-        hist = hist.astype("float32")
+        hist = hist.astype("float64")
         hist /= float(outs[0].size)
         data = np.random.normal(size=(500, 2000), loc=1, scale=2)
         hist2, _ = np.histogram(data, range=(-3, 5))
-        hist2 = hist2.astype("float32")
+        hist2 = hist2.astype("float64")
         hist2 /= float(outs[0].size)
         self.assertTrue(
             np.allclose(

--- a/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
@@ -179,7 +179,7 @@ def _compute_targets(roi_boxes, gt_boxes, labels, bbox_reg_weights):
         ex_boxes=roi_boxes, gt_boxes=gt_boxes, weights=bbox_reg_weights)
 
     return np.hstack([labels[:, np.newaxis], targets]).astype(
-        np.float32, copy=False)
+        np.float64, copy=False)
 
 
 def _box_to_delta(ex_boxes, gt_boxes, weights):
@@ -277,7 +277,7 @@ class TestGenerateProposalLabelsOp(OpTest):
         gt_nums = 6  # Keep same with batch_size_per_im for unittest
         proposal_nums = 2000 if not self.is_cascade_rcnn else 512  #self.batch_size_per_im - gt_nums
         images_shape = [[64, 64]]
-        self.im_info = np.ones((len(images_shape), 3)).astype(np.float32)
+        self.im_info = np.ones((len(images_shape), 3)).astype(np.float64)
         for i in range(len(images_shape)):
             self.im_info[i, 0] = images_shape[i][0]
             self.im_info[i, 1] = images_shape[i][1]
@@ -350,7 +350,7 @@ def _generate_boxes(image_size, box_nums):
     boxes = np.hstack([xy1, xy2])
     boxes[:, [0, 2]] = np.minimum(width - 1., np.maximum(0., boxes[:, [0, 2]]))
     boxes[:, [1, 3]] = np.minimum(height - 1., np.maximum(0., boxes[:, [1, 3]]))
-    return boxes.astype(np.float32)
+    return boxes.astype(np.float64)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_get_tensor_from_selected_rows_op.py
+++ b/python/paddle/fluid/tests/unittests/test_get_tensor_from_selected_rows_op.py
@@ -33,7 +33,7 @@ class TestGetTensorFromSelectedRows(unittest.TestCase):
         height = 20
         row_numel = 2
 
-        np_array = np.ones((len(x_rows), row_numel)).astype("float32")
+        np_array = np.ones((len(x_rows), row_numel)).astype("float64")
         np_array[1, :] = 2.0
         np_array[2, :] = 3.0
         np_array[3, :] = 4.0

--- a/python/paddle/fluid/tests/unittests/test_grid_sampler_op.py
+++ b/python/paddle/fluid/tests/unittests/test_grid_sampler_op.py
@@ -34,7 +34,7 @@ def AffineGrid(theta, size):
     for i in range(len(theta)):
         ret[i] = np.dot(grid[i].reshape([h * w, 3]), theta[i])
 
-    return ret.reshape([n, h, w, 2]).astype("float32")
+    return ret.reshape([n, h, w, 2]).astype("float64")
 
 
 def getGridPointValue(data, x, y):
@@ -68,8 +68,8 @@ def GridSampler(data, grid):
     y_max = H - 1
     x_max = W - 1
 
-    x = 0.5 * ((x.astype('float32') + 1.0) * x_max)
-    y = 0.5 * ((y.astype('float32') + 1.0) * y_max)
+    x = 0.5 * ((x.astype('float64') + 1.0) * x_max)
+    y = 0.5 * ((y.astype('float64') + 1.0) * y_max)
 
     x0 = np.floor(x).astype('int32')
     x1 = x0 + 1
@@ -86,7 +86,7 @@ def GridSampler(data, grid):
     vc = getGridPointValue(data, x1, y0)
     vd = getGridPointValue(data, x1, y1)
 
-    out = (wa * va + wb * vb + wc * vc + wd * vd).astype('float32')
+    out = (wa * va + wb * vb + wc * vc + wd * vd).astype('float64')
     return out
 
 
@@ -94,9 +94,9 @@ class TestGridSamplerOp(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = 'grid_sampler'
-        x = np.random.randint(0, 255, self.x_shape).astype('float32')
+        x = np.random.randint(0, 255, self.x_shape).astype('float64')
 
-        theta = np.zeros(self.theta_shape).astype('float32')
+        theta = np.zeros(self.theta_shape).astype('float64')
         for i in range(self.theta_shape[0]):
             for j in range(2):
                 for k in range(3):

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -40,7 +40,7 @@ class TestGroupNormOp(OpTest):
     def setUp(self):
         self.op_type = "group_norm"
         self.data_format = "NCHW"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.shape = (2, 4, 3, 3)
         self.attrs = {'epsilon': 1e-5, 'groups': 2}
         self.compare_between_place = False

--- a/python/paddle/fluid/tests/unittests/test_gru_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gru_op.py
@@ -31,7 +31,7 @@ def gru(
         is_reverse,
         act_state,
         act_gate,
-        dtype='float32',
+        dtype='float64',
         origin_mode=False):
     def _seq_to_batch(lod, is_reverse):
         idx_in_seq_list = []
@@ -169,20 +169,20 @@ class TestGRUOriginMode(TestGRUOp):
 class TestGRUOp2(TestGRUOp):
     def set_confs(self):
         self.D = 19
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestGRUOp2Len0(TestGRUOp):
     def set_confs(self):
         self.D = 19
         self.lod = [[2, 0, 4]]
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestGRUOp2OriginMode(TestGRUOp):
     def set_confs(self):
         self.D = 19
-        self.dtype = 'float32'
+        self.dtype = 'float64'
         self.origin_mode = True
 
 
@@ -190,7 +190,7 @@ class TestGRUOp2OriginModeLen0(TestGRUOp):
     def set_confs(self):
         self.D = 19
         self.lod = [[0, 3, 4]]
-        self.dtype = 'float32'
+        self.dtype = 'float64'
         self.origin_mode = True
 
 
@@ -198,7 +198,7 @@ class TestGRUOp2OriginModeLastLen0(TestGRUOp):
     def set_confs(self):
         self.D = 19
         self.lod = [[0, 3, 0]]
-        self.dtype = 'float32'
+        self.dtype = 'float64'
         self.origin_mode = True
 
 

--- a/python/paddle/fluid/tests/unittests/test_hinge_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hinge_loss_op.py
@@ -23,8 +23,8 @@ class TestHingeLossOp(OpTest):
     def setUp(self):
         self.op_type = 'hinge_loss'
         samples_num = 64
-        logits = np.random.uniform(-10, 10, (samples_num, 1)).astype('float32')
-        labels = np.random.randint(0, 2, (samples_num, 1)).astype('float32')
+        logits = np.random.uniform(-10, 10, (samples_num, 1)).astype('float64')
+        labels = np.random.randint(0, 2, (samples_num, 1)).astype('float64')
 
         self.inputs = {
             'Logits': logits,

--- a/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
@@ -71,7 +71,7 @@ def hsigmoid(x, w, label, bias, num_classes):
     code_table = [0 for _ in range(code_length)]
     pre_output = np.zeros((batch_size, code_length))
     pre_sum = np.zeros((batch_size, 1))
-    out = np.zeros((batch_size, 1)).astype("float32")
+    out = np.zeros((batch_size, 1)).astype("float64")
     for i in range(batch_size):
         code_table = CodeTable(num_classes, label[i])
         length = code_table.get_length()
@@ -110,7 +110,7 @@ def hsigmoidWithCustomTree(x, w, path_table, path_code, label, bias,
     # init pre_out with shape [N, code_length]
     pre_output = np.zeros((batch_size, code_length))
     pre_sum = np.zeros((batch_size, 1))
-    out = np.zeros((batch_size, 1)).astype("float32")
+    out = np.zeros((batch_size, 1)).astype("float64")
     if isinstance(bias, np.ndarray):
         for i in range(batch_size):
             code_table = CodeTableWithCustomTree(path_table, path_code, i)
@@ -148,11 +148,11 @@ class TestHSigmoidOp(OpTest):
         num_classes = 6
         feature_size = 8
         batch_size = 4
-        x = np.random.random((batch_size, feature_size)).astype("float32") * 2
+        x = np.random.random((batch_size, feature_size)).astype("float64") * 2
         w = np.random.random(
-            (num_classes - 1, feature_size)).astype("float32") * 2
+            (num_classes - 1, feature_size)).astype("float64") * 2
         label = np.random.randint(0, num_classes, (batch_size, 1))
-        bias = np.random.random((num_classes - 1, 1)).astype("float32")
+        bias = np.random.random((num_classes - 1, 1)).astype("float64")
         self.attrs = {'num_classes': num_classes, 'is_sparse': False}
         self.inputs = {'X': x, 'W': w, 'Label': label, 'Bias': bias}
         pre_output, out = hsigmoid(x, w, label, bias, num_classes)
@@ -171,8 +171,8 @@ class TestHSigmoidOpSparse(OpTest):
         num_classes = 6  #using 1,2,3,4,5,6 to build a huffman tree and select 1,2,5,6 as sample
         feature_size = 8
         batch_size = 4
-        x = np.random.random((batch_size, feature_size)).astype("float32")
-        w = np.random.random((num_classes - 1, feature_size)).astype("float32")
+        x = np.random.random((batch_size, feature_size)).astype("float64")
+        w = np.random.random((num_classes - 1, feature_size)).astype("float64")
         label = np.array([0, 1, 4, 5])
         path_table = np.array(
             [(0, 2, -1, -1, -1), (0, 1, 3, -1, -1), (0, 1, 4, -1, -1),
@@ -180,7 +180,7 @@ class TestHSigmoidOpSparse(OpTest):
               -1)])  #np.array to store 1,2,5,6s' non-leaf path(root -> leaf)
         path_code = np.array([(0, 0, -1, -1, -1), (1, 1, 1, -1, -1), (
             1, 0, 0, -1, -1), (0, 1, -1, -1, -1)])  #np.array to store 
-        bias = np.random.random((num_classes - 1, 1)).astype("float32")
+        bias = np.random.random((num_classes - 1, 1)).astype("float64")
         self.attrs = {'num_classes': num_classes, 'is_sparse': True}
         self.inputs = {
             'X': x,
@@ -272,9 +272,9 @@ class TestHSigmoidOpWithCostumTree(OpTest):
         num_classes = 6  #using 1,2,3,4,5,6 to build a huffman tree and select 1,2,5,6 as sample
         feature_size = 8
         batch_size = 4
-        x = np.random.random((batch_size, feature_size)).astype("float32") * 2
+        x = np.random.random((batch_size, feature_size)).astype("float64") * 2
         w = np.random.random(
-            (num_classes - 1, feature_size)).astype("float32") * 2
+            (num_classes - 1, feature_size)).astype("float64") * 2
         label = np.array([0, 1, 4, 5])
         path_table = np.array(
             [(0, 2, -1, -1, -1), (0, 1, 3, -1, -1), (0, 1, 4, -1, -1),
@@ -282,7 +282,7 @@ class TestHSigmoidOpWithCostumTree(OpTest):
               -1)])  #np.array to store 1,2,5,6s' non-leaf path(root -> leaf)
         path_code = np.array([(0, 0, -1, -1, -1), (1, 1, 1, -1, -1), (
             1, 0, 0, -1, -1), (0, 1, -1, -1, -1)])  #np.array to store 
-        bias = np.random.random((num_classes - 1, 1)).astype("float32")
+        bias = np.random.random((num_classes - 1, 1)).astype("float64")
         self.attrs = {'num_classes': num_classes, 'is_sparse': False}
         self.inputs = {
             'X': x,
@@ -309,9 +309,9 @@ class TestHSigmoidOpWithCostumTreeWithoutBias(OpTest):
         num_classes = 6  #using 1,2,3,4,5,6 to build a huffman tree and select 1,2,5,6 as sample
         feature_size = 8
         batch_size = 4
-        x = np.random.random((batch_size, feature_size)).astype("float32") * 2
+        x = np.random.random((batch_size, feature_size)).astype("float64") * 2
         w = np.random.random(
-            (num_classes - 1, feature_size)).astype("float32") * 2
+            (num_classes - 1, feature_size)).astype("float64") * 2
         label = np.array([0, 1, 4, 5])
         path_table = np.array(
             [(0, 2, -1, -1, -1), (0, 1, 3, -1, -1), (0, 1, 4, -1, -1),
@@ -319,7 +319,7 @@ class TestHSigmoidOpWithCostumTreeWithoutBias(OpTest):
               -1)])  #np.array to store 1,2,5,6s' non-leaf path(root -> leaf)
         path_code = np.array([(0, 0, -1, -1, -1), (1, 1, 1, -1, -1), (
             1, 0, 0, -1, -1), (0, 1, -1, -1, -1)])  #np.array to store 
-        # bias = np.random.random((num_classes - 1, 1)).astype("float32")
+        # bias = np.random.random((num_classes - 1, 1)).astype("float64")
         self.attrs = {'num_classes': num_classes, 'is_sparse': False}
         self.inputs = {
             'X': x,

--- a/python/paddle/fluid/tests/unittests/test_im2sequence_op.py
+++ b/python/paddle/fluid/tests/unittests/test_im2sequence_op.py
@@ -112,7 +112,7 @@ def Im2Sequence(inputs, img_real_size, attrs):
         tmp = np.zeros([
             output_height[0, index], output_width[0, index], img_channels,
             attrs['kernels'][0], attrs['kernels'][1]
-        ]).astype("float32")
+        ]).astype("float64")
         out.append(tmp)
     for index in range(len(inputs)):
         im2col(attrs, inputs[index], out[index])
@@ -141,9 +141,9 @@ class TestBlockExpandOp(OpTest):
         self.op_type = "im2sequence"
         x = np.random.uniform(0.1, 1, [
             self.batch_size, self.img_channels, self.img_height, self.img_width
-        ]).astype("float32")
+        ]).astype("float64")
 
-        real_size = np.array([]).astype("float32")
+        real_size = np.array([]).astype("float64")
         out = Im2Sequence(x, real_size, self.attrs)
         self.inputs = {'X': x}
         self.outputs = {'Out': out}
@@ -212,8 +212,8 @@ class TestBlockExpandOpCase5(OpTest):
         self.op_type = "im2sequence"
         x = np.random.uniform(0.1, 1, [
             self.batch_size, self.img_channels, self.img_height, self.img_width
-        ]).astype("float32")
-        real_size = np.array([[8, 10], [5, 8]]).astype("float32")
+        ]).astype("float64")
+        real_size = np.array([[8, 10], [5, 8]]).astype("float64")
         out = np.array(Im2Sequence(x, real_size, self.attrs))
         self.inputs = {'X': x, 'Y': real_size}  #l ??
         self.outputs = {'Out': out}
@@ -240,8 +240,8 @@ class TestBlockExpandOpCase6(OpTest):
         self.op_type = "im2sequence"
         x = np.random.uniform(0.1, 1, [
             self.batch_size, self.img_channels, self.img_height, self.img_width
-        ]).astype("float32")
-        real_size = np.array([[8, 10], [5, 8], [5, 8]]).astype("float32")
+        ]).astype("float64")
+        real_size = np.array([[8, 10], [5, 8], [5, 8]]).astype("float64")
         out = np.array(Im2Sequence(x, real_size, self.attrs))
         self.inputs = {'X': x, 'Y': real_size}  #l ??
         self.outputs = {'Out': out}
@@ -268,8 +268,8 @@ class TestBlockExpandOpCase7(OpTest):
         self.op_type = "im2sequence"
         x = np.random.uniform(0.1, 1, [
             self.batch_size, self.img_channels, self.img_height, self.img_width
-        ]).astype("float32")
-        real_size = np.array([[6, 6], [4, 4]]).astype("float32")
+        ]).astype("float64")
+        real_size = np.array([[6, 6], [4, 4]]).astype("float64")
         out = np.array(Im2Sequence(x, real_size, self.attrs))
         self.inputs = {'X': x, 'Y': real_size}
         self.outputs = {'Out': out}

--- a/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
@@ -28,9 +28,9 @@ class TestIOUSimilarityOp(OpTest):
 
     def setUp(self):
         self.op_type = "iou_similarity"
-        self.boxes1 = random.rand(2, 4).astype('float32')
-        self.boxes2 = random.rand(3, 4).astype('float32')
-        self.output = random.rand(2, 3).astype('float32')
+        self.boxes1 = random.rand(2, 4).astype('float64')
+        self.boxes2 = random.rand(3, 4).astype('float64')
+        self.output = random.rand(2, 3).astype('float64')
         for row in range(self.boxes1.shape[0]):
             for col in range(self.boxes2.shape[0]):
                 xmin1, ymin1, xmax1, ymax1 = self.boxes1[row]

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_ifelse_op.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_ifelse_op.py
@@ -40,7 +40,7 @@ class TestIrMemoryOptimizeIfElseOp(unittest.TestCase):
         prog.random_seed = 100
         startup_prog.random_seed = 100
         with program_guard(prog, startup_prog):
-            image = layers.data(name='x', shape=[784], dtype='float32')
+            image = layers.data(name='x', shape=[784], dtype='float64')
 
             label = layers.data(name='y', shape=[1], dtype='int64')
 
@@ -88,7 +88,7 @@ class TestIrMemoryOptimizeIfElseOp(unittest.TestCase):
             ret = []
             for pass_id in range(PASS_NUM):
                 for data in train_reader():
-                    x_data = np.array([x[0] for x in data]).astype("float32")
+                    x_data = np.array([x[0] for x in data]).astype("float64")
                     y_data = np.array([x[1] for x in data]).astype("int64")
                     y_data = y_data.reshape((y_data.shape[0], 1))
 

--- a/python/paddle/fluid/tests/unittests/test_isfinite_op.py
+++ b/python/paddle/fluid/tests/unittests/test_isfinite_op.py
@@ -20,7 +20,7 @@ from op_test import OpTest
 class TestInf(OpTest):
     def setUp(self):
         self.op_type = "isinf"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
 
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
@@ -45,7 +45,7 @@ class TestFP16Inf(TestInf):
 class TestNAN(OpTest):
     def setUp(self):
         self.op_type = "isnan"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
 
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
@@ -70,7 +70,7 @@ class TestFP16NAN(TestNAN):
 class TestIsfinite(OpTest):
     def setUp(self):
         self.op_type = "isfinite"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
 
         x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)

--- a/python/paddle/fluid/tests/unittests/test_kldiv_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_kldiv_loss_op.py
@@ -36,8 +36,8 @@ class TestKLDivLossOp(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = 'kldiv_loss'
-        x = np.random.uniform(-10, 10, self.x_shape).astype('float32')
-        target = np.random.uniform(-10, 10, self.x_shape).astype('float32')
+        x = np.random.uniform(-10, 10, self.x_shape).astype('float64')
+        target = np.random.uniform(-10, 10, self.x_shape).astype('float64')
 
         self.attrs = {"reduction": self.reduction}
 
@@ -46,7 +46,7 @@ class TestKLDivLossOp(OpTest):
             'Target': target,
         }
         loss = kldiv_loss(x, target, self.reduction)
-        self.outputs = {'Loss': loss.astype('float32')}
+        self.outputs = {'Loss': loss.astype('float64')}
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/test_l1_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_l1_norm_op.py
@@ -27,7 +27,7 @@ class TestL1NormOp(OpTest):
         self.op_type = "l1_norm"
         self.max_relative_error = 0.005
 
-        X = np.random.uniform(-1, 1, (13, 19)).astype("float32")
+        X = np.random.uniform(-1, 1, (13, 19)).astype("float64")
         X[np.abs(X) < self.max_relative_error] = 0.1
         self.inputs = {'X': X}
         self.outputs = {'Out': np.sum(np.abs(X))}

--- a/python/paddle/fluid/tests/unittests/test_lamb_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lamb_op.py
@@ -34,10 +34,10 @@ class TestLambOp1(OpTest):
         '''Test Lamb Op with supplied attributes
         '''
         self.op_type = "lamb"
-        param = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        grad = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float32")
-        moment2 = np.random.random((102, 105)).astype("float32")
+        param = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        grad = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment1 = np.random.uniform(-1, 1, (102, 105)).astype("float64")
+        moment2 = np.random.random((102, 105)).astype("float64")
 
         learning_rate = 0.001
         self.set_attrs()
@@ -49,9 +49,9 @@ class TestLambOp1(OpTest):
             'Grad': grad,
             'Moment1': moment1,
             'Moment2': moment2,
-            'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32"),
-            'Beta2Pow': np.array([beta2_pow]).astype("float32")
+            'LearningRate': np.array([learning_rate]).astype("float64"),
+            'Beta1Pow': np.array([beta1_pow]).astype("float64"),
+            'Beta2Pow': np.array([beta2_pow]).astype("float64")
         }
 
 
@@ -113,7 +113,7 @@ class TestLambOpMultipleSteps(TestLambOp1):
 
             # Randomize gradient for next step
             self.inputs['Grad'] = np.random.uniform(
-                -1, 1, (102, 105)).astype("float32")
+                -1, 1, (102, 105)).astype("float64")
 
 
 def lamb_step(inputs, attributes):
@@ -196,7 +196,7 @@ def lamb_step_sparse(inputs, attributes, height, rows, row_numel, np_grad):
             np.sqrt(moment2_out) + epsilon) + weight_decay * param)
 
     for row_id in range(param_out.shape[0]):
-        update_value = np.zeros(np_grad[0].shape).astype("float32")
+        update_value = np.zeros(np_grad[0].shape).astype("float64")
         if row_id in rows:
             update_value = np_grad[rows.index(row_id)]
         update_mom(row_id, update_value)
@@ -218,14 +218,14 @@ class TestSparseLambOp(unittest.TestCase):
         row_numel = 12
         self.row_numel = row_numel
         self.dense_inputs = {
-            "Param": np.full((height, row_numel), 5.0).astype("float32"),
-            "Moment1": np.full((height, row_numel), 5.0).astype("float32"),
-            "Moment2": np.full((height, row_numel), 5.0).astype("float32"),
-            'Beta1Pow': np.array([beta1**10]).astype("float32"),
-            'Beta2Pow': np.array([beta2**10]).astype("float32"),
-            "LearningRate": np.full((1), 2.0).astype("float32")
+            "Param": np.full((height, row_numel), 5.0).astype("float64"),
+            "Moment1": np.full((height, row_numel), 5.0).astype("float64"),
+            "Moment2": np.full((height, row_numel), 5.0).astype("float64"),
+            'Beta1Pow': np.array([beta1**10]).astype("float64"),
+            'Beta2Pow': np.array([beta2**10]).astype("float64"),
+            "LearningRate": np.full((1), 2.0).astype("float64")
         }
-        self.init_output = np.full((height, row_numel), 0.0).astype("float32")
+        self.init_output = np.full((height, row_numel), 0.0).astype("float64")
         self.attrs = {
             'epsilon': epsilon,
             'beta1': beta1,
@@ -236,7 +236,7 @@ class TestSparseLambOp(unittest.TestCase):
         grad_selected_rows = scope.var('Grad').get_selected_rows()
         grad_selected_rows.set_height(height)
         grad_selected_rows.set_rows(rows)
-        np_array = np.ones((len(rows), row_numel)).astype("float32")
+        np_array = np.ones((len(rows), row_numel)).astype("float64")
         np_array[0, 0] = 2.0
         np_array[2, 8] = 4.0
 

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -87,10 +87,10 @@ class TestLayerNormdOp(unittest.TestCase):
             scale_shape = [D]
 
             np.random.seed(123)
-            x = np.random.random_sample(x_shape).astype(np.float32)
-            scale = np.random.random_sample(scale_shape).astype(np.float32)
-            bias = np.random.random_sample(scale_shape).astype(np.float32)
-            y_grad = np.random.random_sample(x_shape).astype(np.float32)
+            x = np.random.random_sample(x_shape).astype(np.float64)
+            scale = np.random.random_sample(scale_shape).astype(np.float64)
+            bias = np.random.random_sample(scale_shape).astype(np.float64)
+            y_grad = np.random.random_sample(x_shape).astype(np.float64)
 
             # reference forward & backward
             y, mean, variance = _reference_layer_norm_naive(
@@ -111,7 +111,7 @@ class TestLayerNormdOp(unittest.TestCase):
                 for name in ground_truth:
                     block.create_var(
                         name=name,
-                        dtype='float32',
+                        dtype='float64',
                         shape=ground_truth[name].shape)
                 layer_norm_op = block.append_op(
                     type="layer_norm",

--- a/python/paddle/fluid/tests/unittests/test_lod_reset_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lod_reset_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestLodResetOpByAttr(OpTest):
     def setUp(self):
         self.op_type = "lod_reset"
-        x = np.random.random((10, 20)).astype("float32")
+        x = np.random.random((10, 20)).astype("float64")
         lod = [[3, 2, 5]]
         # target_offset_lod and target_lod are the same lod info represented
         # in offset-based format and length-based format, respectively.
@@ -43,7 +43,7 @@ class TestLodResetOpByAttr(OpTest):
 class TestLodResetOpByInput(OpTest):
     def setUp(self):
         self.op_type = "lod_reset"
-        x = np.random.random((10, 20)).astype("float32")
+        x = np.random.random((10, 20)).astype("float64")
         lod = [[3, 2, 5]]
         # target_offset_lod and target_lod are the same lod info represented
         # in offset-based format and length-based format, respectively.
@@ -65,7 +65,7 @@ class TestLodResetOpByInput(OpTest):
 class TestLodResetOpBoth(OpTest):
     def setUp(self):
         self.op_type = "lod_reset"
-        x = np.random.random((10, 20)).astype("float32")
+        x = np.random.random((10, 20)).astype("float64")
         lod = [[3, 2, 5]]
         target_offset_lod_attr = [0, 7, 10]
         target_offset_lod_in = [0, 4, 7, 10]
@@ -87,9 +87,9 @@ class TestLodResetOpBoth(OpTest):
 class TestLodResetOpYIsLoDTensor(OpTest):
     def setUp(self):
         self.op_type = "lod_reset"
-        x = np.random.random((10, 20)).astype("float32")
+        x = np.random.random((10, 20)).astype("float64")
         lod = [[3, 2, 5]]
-        y = np.random.random((10, 10)).astype("float32")
+        y = np.random.random((10, 10)).astype("float64")
         target_lod = [[4, 3, 3]]
         self.inputs = {'X': (x, lod), 'Y': (y, target_lod)}
         self.outputs = {'Out': (x, target_lod)}

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -25,7 +25,7 @@ import paddle.compat as cpt
 class TestLookupTableOp(OpTest):
     def setUp(self):
         self.op_type = "lookup_table"
-        table = np.random.random((17, 31)).astype("float32")
+        table = np.random.random((17, 31)).astype("float64")
         ids = np.random.randint(0, 17, 4).astype("int64")
         ids_expand = np.expand_dims(ids, axis=1)
         self.inputs = {'W': table, 'Ids': ids_expand}
@@ -41,7 +41,7 @@ class TestLookupTableOp(OpTest):
 class TestLookupTableOpWithTensorIds(OpTest):
     def setUp(self):
         self.op_type = "lookup_table"
-        table = np.random.random((17, 31)).astype("float32")
+        table = np.random.random((17, 31)).astype("float64")
         ids = np.random.randint(
             low=0, high=17, size=(2, 4, 5, 1)).astype("int64")
         self.inputs = {'W': table, 'Ids': ids}
@@ -97,7 +97,7 @@ class TestLookupTableWIsSelectedRows(OpTest):
         w_selected_rows = scope.var('W').get_selected_rows()
         w_selected_rows.set_height(len(rows))
         w_selected_rows.set_rows(rows)
-        w_array = np.ones((len(rows), row_numel)).astype("float32")
+        w_array = np.ones((len(rows), row_numel)).astype("float64")
         for i in range(len(rows)):
             w_array[i] *= i
         w_tensor = w_selected_rows.get_tensor()

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -80,15 +80,15 @@ def reference_matmul(X, Y, transpose_X=False, transpose_Y=False):
         # np.matmul outputs a scalar, we must convert to a Tensor of
         # shape (1, ) instead.
         # Everywhere else, we are compatible with np.matmul.
-        Out = np.array([Out], dtype="float32")
+        Out = np.array([Out], dtype="float64")
     return Out
 
 
 class Generator(object):
     def setUp(self):
         self.op_type = "matmul"
-        X = np.random.random(self.shape_X).astype("float32")
-        Y = np.random.random(self.shape_Y).astype("float32")
+        X = np.random.random(self.shape_X).astype("float64")
+        Y = np.random.random(self.shape_Y).astype("float64")
         Out = reference_matmul(X, Y, self.transpose_X, self.transpose_Y)
         self.inputs = {'X': X, 'Y': Y}
         self.attrs = {

--- a/python/paddle/fluid/tests/unittests/test_maxout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_maxout_op.py
@@ -29,13 +29,13 @@ class TestMaxOutOp(OpTest):
     def setUp(self):
         self.op_type = "maxout"
         self.init_test_case()
-        input = np.random.random(self.shape).astype("float32")
-        output = self.MaxOut_forward_naive(input, self.groups).astype("float32")
+        input = np.random.random(self.shape).astype("float64")
+        output = self.MaxOut_forward_naive(input, self.groups).astype("float64")
 
         self.inputs = {'X': input}
         self.attrs = {'groups': self.groups}
 
-        self.outputs = {'Out': output.astype('float32')}
+        self.outputs = {'Out': output.astype('float64')}
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -23,7 +23,7 @@ import paddle.fluid.core as core
 class TestMeanOp(OpTest):
     def setUp(self):
         self.op_type = "mean"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {'X': np.random.random((10, 10)).astype(self.dtype)}
         self.outputs = {'Out': np.mean(self.inputs["X"])}

--- a/python/paddle/fluid/tests/unittests/test_merge_selectedrows_op.py
+++ b/python/paddle/fluid/tests/unittests/test_merge_selectedrows_op.py
@@ -34,7 +34,7 @@ class TestMergeSelectedRows(unittest.TestCase):
         height = 20
         row_numel = 2
 
-        np_array = np.ones((len(x_rows), row_numel)).astype("float32")
+        np_array = np.ones((len(x_rows), row_numel)).astype("float64")
         np_array[1, :] = 2.0
         np_array[2, :] = 3.0
         np_array[3, :] = 4.0

--- a/python/paddle/fluid/tests/unittests/test_mine_hard_examples_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mine_hard_examples_op.py
@@ -59,13 +59,13 @@ class TestMineHardExamplesOp(OpTest):
         self.sample_size = 0
         self.mining_type = "max_negative"
         self.cls_loss = np.array([[0.1, 0.1, 0.3],
-                                  [0.3, 0.1, 0.1]]).astype('float32')
+                                  [0.3, 0.1, 0.1]]).astype('float64')
 
         self.loc_loss = np.array([[0.1, 0.2, 0.3],
-                                  [0.3, 0.4, 0.1]]).astype('float32')
+                                  [0.3, 0.4, 0.1]]).astype('float64')
 
         self.match_dis = np.array([[0.2, 0.4, 0.8],
-                                   [0.1, 0.9, 0.3]]).astype('float32')
+                                   [0.1, 0.9, 0.3]]).astype('float64')
 
         self.match_indices = np.array([[0, -1, -1],
                                        [-1, 0, -1]]).astype('int32')
@@ -83,10 +83,10 @@ class TestMineHardExamplesOpHardExample(TestMineHardExamplesOp):
         self.sample_size = 2
 
         self.cls_loss = np.array([[0.5, 0.1, 0.3],
-                                  [0.3, 0.1, 0.1]]).astype('float32')
+                                  [0.3, 0.1, 0.1]]).astype('float64')
 
         self.loc_loss = np.array([[0.2, 0.2, 0.3],
-                                  [0.3, 0.1, 0.2]]).astype('float32')
+                                  [0.3, 0.1, 0.2]]).astype('float64')
 
         self.match_indices = np.array([[0, -1, -1],
                                        [-1, 0, -1]]).astype('int32')

--- a/python/paddle/fluid/tests/unittests/test_momentum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_momentum_op.py
@@ -24,7 +24,7 @@ from op_test import OpTest
 class TestMomentumOp1(OpTest):
     def setUp(self):
         self.op_type = "momentum"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
 
         param = np.random.random((123, 321)).astype(self.dtype)
@@ -74,10 +74,10 @@ class TestMomentumOp2(OpTest):
     def setUp(self):
         self.op_type = "momentum"
 
-        param = np.random.random((123, 321)).astype("float32")
-        grad = np.random.random((123, 321)).astype("float32")
-        velocity = np.zeros((123, 321)).astype("float32")
-        learning_rate = np.array([0.001]).astype("float32")
+        param = np.random.random((123, 321)).astype("float64")
+        grad = np.random.random((123, 321)).astype("float64")
+        velocity = np.zeros((123, 321)).astype("float64")
+        learning_rate = np.array([0.001]).astype("float64")
         mu = 0.0001
         use_nesterov = True
 
@@ -107,10 +107,10 @@ class TestLarsMomentumOp(OpTest):
     def setUp(self):
         self.op_type = "lars_momentum"
 
-        param = np.random.random((123, 321)).astype("float32")
-        grad = np.random.random((123, 321)).astype("float32")
-        velocity = np.zeros((123, 321)).astype("float32")
-        learning_rate = np.array([0.001]).astype("float32")
+        param = np.random.random((123, 321)).astype("float64")
+        grad = np.random.random((123, 321)).astype("float64")
+        velocity = np.zeros((123, 321)).astype("float64")
+        learning_rate = np.array([0.001]).astype("float64")
         mu = 0.0001
         lars_coeff = 0.001
         lars_weight_decay = 0.0005
@@ -158,32 +158,32 @@ class TestSparseMomentumOp(unittest.TestCase):
 
         # create and initialize Param Variable
         param = scope.var('Param').get_tensor()
-        param_array = np.full((height, row_numel), 5.0).astype("float32")
+        param_array = np.full((height, row_numel), 5.0).astype("float64")
         param.set(param_array, place)
         param_out = scope.var("ParamOut").get_tensor()
-        param_out_array = np.full((height, row_numel), 0.0).astype("float32")
+        param_out_array = np.full((height, row_numel), 0.0).astype("float64")
         param_out.set(param_out_array, place)
 
         grad_selected_rows = scope.var('Grad').get_selected_rows()
         grad_selected_rows.set_height(height)
         grad_selected_rows.set_rows(rows)
-        grad_np_array = np.ones((len(rows), row_numel)).astype("float32")
+        grad_np_array = np.ones((len(rows), row_numel)).astype("float64")
         grad_np_array[0, 0] = 2.0
         grad_np_array[2, 8] = 4.0
         grad_tensor = grad_selected_rows.get_tensor()
         grad_tensor.set(grad_np_array, place)
 
         velocity = scope.var('Velocity').get_tensor()
-        velocity_np_array = np.ones((height, row_numel)).astype("float32")
+        velocity_np_array = np.ones((height, row_numel)).astype("float64")
         velocity.set(velocity_np_array, place)
         velocity_out = scope.var('VelocityOut').get_tensor()
         velocity_out_np_array = np.full((height, row_numel),
-                                        0.0).astype("float32")
+                                        0.0).astype("float64")
         velocity_out.set(velocity_out_np_array, place)
 
         # create and initialize LeraningRate Variable
         lr = scope.var('LearningRate').get_tensor()
-        lr_array = np.full((1), 2.0).astype("float32")
+        lr_array = np.full((1), 2.0).astype("float64")
         lr.set(lr_array, place)
 
         # create and run operator
@@ -205,7 +205,7 @@ class TestSparseMomentumOp(unittest.TestCase):
 
         # TODO(dzh): add a more suitable general numpy interface
         # for sparse update.
-        _grad_np_array = np.full((height, row_numel), 0.0).astype("float32")
+        _grad_np_array = np.full((height, row_numel), 0.0).astype("float64")
         for i in range(len(rows)):
             _grad_np_array[rows[i]] = grad_np_array[i]
         _velocity_out = mu * velocity_np_array + _grad_np_array

--- a/python/paddle/fluid/tests/unittests/test_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mul_op.py
@@ -23,7 +23,7 @@ from op_test import OpTest
 class TestMulOp(OpTest):
     def setUp(self):
         self.op_type = "mul"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
             'X': np.random.random((2, 5)).astype(self.dtype),
@@ -52,7 +52,7 @@ class TestMulOp(OpTest):
 class TestMulOp2(OpTest):
     def setUp(self):
         self.op_type = "mul"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {
             'X': np.random.random((3, 4, 4, 3)).astype(self.dtype),

--- a/python/paddle/fluid/tests/unittests/test_multiclass_nms_op.py
+++ b/python/paddle/fluid/tests/unittests/test_multiclass_nms_op.py
@@ -247,7 +247,7 @@ class TestMulticlassNMSOp(OpTest):
         keep_top_k = 200
         score_threshold = self.score_threshold
 
-        scores = np.random.random((N * M, C)).astype('float32')
+        scores = np.random.random((N * M, C)).astype('float64')
 
         def softmax(x):
             shiftx = x - np.max(x).clip(-64.)
@@ -258,7 +258,7 @@ class TestMulticlassNMSOp(OpTest):
         scores = np.reshape(scores, (N, M, C))
         scores = np.transpose(scores, (0, 2, 1))
 
-        boxes = np.random.random((N, M, BOX_SIZE)).astype('float32')
+        boxes = np.random.random((N, M, BOX_SIZE)).astype('float64')
         boxes[:, :, 0:2] = boxes[:, :, 0:2] * 0.5
         boxes[:, :, 2:4] = boxes[:, :, 2:4] * 0.5 + 0.5
 
@@ -266,7 +266,7 @@ class TestMulticlassNMSOp(OpTest):
                                                  score_threshold, nms_threshold,
                                                  nms_top_k, keep_top_k)
         nmsed_outs = [-1] if not nmsed_outs else nmsed_outs
-        nmsed_outs = np.array(nmsed_outs).astype('float32')
+        nmsed_outs = np.array(nmsed_outs).astype('float64')
 
         self.op_type = 'multiclass_nms'
         self.inputs = {'BBoxes': boxes, 'Scores': scores}
@@ -309,7 +309,7 @@ class TestMulticlassNMSLoDInput(OpTest):
         score_threshold = self.score_threshold
         normalized = False
 
-        scores = np.random.random((M, C)).astype('float32')
+        scores = np.random.random((M, C)).astype('float64')
 
         def softmax(x):
             shiftx = x - np.max(x).clip(-64.)
@@ -318,7 +318,7 @@ class TestMulticlassNMSLoDInput(OpTest):
 
         scores = np.apply_along_axis(softmax, 1, scores)
 
-        boxes = np.random.random((M, C, BOX_SIZE)).astype('float32')
+        boxes = np.random.random((M, C, BOX_SIZE)).astype('float64')
         boxes[:, :, 0] = boxes[:, :, 0] * 10
         boxes[:, :, 1] = boxes[:, :, 1] * 10
         boxes[:, :, 2] = boxes[:, :, 2] * 10 + 10
@@ -328,7 +328,7 @@ class TestMulticlassNMSLoDInput(OpTest):
             boxes, scores, background, score_threshold, nms_threshold,
             nms_top_k, keep_top_k, box_lod, normalized)
         nmsed_outs = [-1] if not nmsed_outs else nmsed_outs
-        nmsed_outs = np.array(nmsed_outs).astype('float32')
+        nmsed_outs = np.array(nmsed_outs).astype('float64')
         self.op_type = 'multiclass_nms'
         self.inputs = {
             'BBoxes': (boxes, box_lod),
@@ -351,11 +351,11 @@ class TestMulticlassNMSLoDInput(OpTest):
 
 class TestIOU(unittest.TestCase):
     def test_iou(self):
-        box1 = np.array([4.0, 3.0, 7.0, 5.0]).astype('float32')
-        box2 = np.array([3.0, 4.0, 6.0, 8.0]).astype('float32')
+        box1 = np.array([4.0, 3.0, 7.0, 5.0]).astype('float64')
+        box2 = np.array([3.0, 4.0, 6.0, 8.0]).astype('float64')
 
-        expt_output = np.array([2.0 / 16.0]).astype('float32')
-        calc_output = np.array([iou(box1, box2, True)]).astype('float32')
+        expt_output = np.array([2.0 / 16.0]).astype('float64')
+        calc_output = np.array([iou(box1, box2, True)]).astype('float64')
         self.assertTrue(np.allclose(calc_output, expt_output))
 
 

--- a/python/paddle/fluid/tests/unittests/test_multiplex_op.py
+++ b/python/paddle/fluid/tests/unittests/test_multiplex_op.py
@@ -26,10 +26,10 @@ class TestMultiplexOp(OpTest):
         index = np.arange(0, rows).astype('int32')
         np.random.shuffle(index)
         index = np.reshape(index, (rows, 1))
-        ins1 = np.random.random((rows, 10)).astype("float32")
-        ins2 = np.random.random((rows, 10)).astype("float32")
-        ins3 = np.random.random((rows, 10)).astype("float32")
-        ins4 = np.random.random((rows, 10)).astype("float32")
+        ins1 = np.random.random((rows, 10)).astype("float64")
+        ins2 = np.random.random((rows, 10)).astype("float64")
+        ins3 = np.random.random((rows, 10)).astype("float64")
+        ins4 = np.random.random((rows, 10)).astype("float64")
         self.inputs = {
             'Ids': index,
             'X': [('x1', ins1), ('x2', ins2), ('x3', ins3), ('x4', ins4)]

--- a/python/paddle/fluid/tests/unittests/test_one_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_op.py
@@ -35,7 +35,7 @@ class TestOneHotOp(OpTest):
         x = np.array(x).astype('int32').reshape([sum(x_lod[0]), 1])
 
         out = np.zeros(shape=(np.product(x.shape[:-1]),
-                              depth)).astype('float32')
+                              depth)).astype('float64')
 
         for i in range(np.product(x.shape)):
             out[i, x[i]] = 1.0
@@ -58,7 +58,7 @@ class TestOneHotOp_attr(OpTest):
         x = np.array(x).astype('int32').reshape([sum(x_lod[0]), 1])
 
         out = np.zeros(shape=(np.product(x.shape[:-1]),
-                              depth)).astype('float32')
+                              depth)).astype('float64')
 
         for i in range(np.product(x.shape)):
             out[i, x[i]] = 1.0
@@ -82,7 +82,7 @@ class TestOneHotOp_default_dtype(OpTest):
         x = np.array(x).astype('int32').reshape([sum(x_lod[0]), 1])
 
         out = np.zeros(shape=(np.product(x.shape[:-1]),
-                              depth)).astype('float32')
+                              depth)).astype('float64')
 
         for i in range(np.product(x.shape)):
             out[i, x[i]] = 1.0
@@ -105,7 +105,7 @@ class TestOneHotOp_default_dtype_attr(OpTest):
         x = np.array(x).astype('int32').reshape([sum(x_lod[0]), 1])
 
         out = np.zeros(shape=(np.product(x.shape[:-1]),
-                              depth)).astype('float32')
+                              depth)).astype('float64')
 
         for i in range(np.product(x.shape)):
             out[i, x[i]] = 1.0
@@ -135,12 +135,12 @@ class TestOneHotOp_exception(OpTest):
         program = Program()
         with program_guard(program):
             x = fluid.layers.data(
-                name='x', shape=[self.dimension], dtype='float32', lod_level=1)
+                name='x', shape=[self.dimension], dtype='float64', lod_level=1)
             block = program.current_block()
             one_hot_out = block.create_var(
                 name="one_hot_out",
                 type=core.VarDesc.VarType.LOD_TENSOR,
-                dtype='float32')
+                dtype='float64')
             block.append_op(
                 type='one_hot',
                 inputs={'X': x},

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -178,7 +178,7 @@ class TestPool2D_Op(OpTest):
         pass
 
     def init_data_type(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def init_pool_type(self):
         self.pool_type = "avg"

--- a/python/paddle/fluid/tests/unittests/test_pool_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool_max_op.py
@@ -140,11 +140,11 @@ class TestMaxPoolWithIndex_Op(OpTest):
         self.init_global()
         self.init_adaptive()
 
-        input = np.random.random(self.shape).astype("float32")
+        input = np.random.random(self.shape).astype("float64")
         output, mask = self.pool_forward_naive(input, self.ksize, self.strides,
                                                self.paddings, self.global_pool,
                                                self.adaptive)
-        output = output.astype("float32")
+        output = output.astype("float64")
         mask = mask.astype("int32")
 
         self.attrs = {

--- a/python/paddle/fluid/tests/unittests/test_positive_negative_pair_op.py
+++ b/python/paddle/fluid/tests/unittests/test_positive_negative_pair_op.py
@@ -26,7 +26,7 @@ def py_pnpair_op(score, label, query, column=-1, weight=None):
     predictions = {}
     batch_size = label.shape[0]
     if weight is None:
-        weight = np.ones(shape=(batch_size, 1)).astype('float32')
+        weight = np.ones(shape=(batch_size, 1)).astype('float64')
     for s, l, q, w in zip(score, label, query, weight):
         s, l, q, w = s[column], l[0], q[0], w[0]
         if q not in predictions:
@@ -48,8 +48,8 @@ def py_pnpair_op(score, label, query, column=-1, weight=None):
             else:
                 neg += w
 
-    return np.array(pos).astype('float32'), np.array(neg).astype(
-        'float32'), np.array(neu).astype('float32')
+    return np.array(pos).astype('float64'), np.array(neg).astype(
+        'float64'), np.array(neu).astype('float64')
 
 
 class TestPositiveNegativePairOp(OpTest):
@@ -57,8 +57,8 @@ class TestPositiveNegativePairOp(OpTest):
         self.op_type = 'positive_negative_pair'
         batch_size = 20
         max_query_id = 5
-        score = np.random.normal(size=(batch_size, 1)).astype('float32')
-        label = np.random.normal(size=(batch_size, 1)).astype('float32')
+        score = np.random.normal(size=(batch_size, 1)).astype('float64')
+        label = np.random.normal(size=(batch_size, 1)).astype('float64')
         query = np.array(
             [np.random.randint(max_query_id) for i in range(batch_size)])
         query = np.reshape(query, newshape=(batch_size, 1)).astype('int64')
@@ -83,18 +83,18 @@ class TestPositiveNegativePairOpAccumulateWeight(OpTest):
         max_query_id = 5
         max_random_num = 2 << 15
         score_dim = 2
-        score = np.random.normal(size=(batch_size, 2)).astype('float32')
-        label = np.random.normal(size=(batch_size, 1)).astype('float32')
-        weight = np.random.normal(size=(batch_size, 1)).astype('float32')
+        score = np.random.normal(size=(batch_size, 2)).astype('float64')
+        label = np.random.normal(size=(batch_size, 1)).astype('float64')
+        weight = np.random.normal(size=(batch_size, 1)).astype('float64')
         query = np.array(
             [np.random.randint(max_query_id) for i in range(batch_size)])
         query = np.reshape(query, newshape=(batch_size, 1)).astype('int64')
         acc_pos = np.reshape(
-            np.random.randint(max_random_num), newshape=(1)).astype('float32')
+            np.random.randint(max_random_num), newshape=(1)).astype('float64')
         acc_neg = np.reshape(
-            np.random.randint(max_random_num), newshape=(1)).astype('float32')
+            np.random.randint(max_random_num), newshape=(1)).astype('float64')
         acc_neu = np.reshape(
-            np.random.randint(max_random_num), newshape=(1)).astype('float32')
+            np.random.randint(max_random_num), newshape=(1)).astype('float64')
         column = np.random.randint(score_dim)
 
         pos, neg, neu = py_pnpair_op(

--- a/python/paddle/fluid/tests/unittests/test_precision_recall_op.py
+++ b/python/paddle/fluid/tests/unittests/test_precision_recall_op.py
@@ -40,7 +40,7 @@ def calc_f1_score(precision, recall):
 def get_states(idxs, labels, cls_num, weights=None):
     ins_num = idxs.shape[0]
     # TP FP TN FN
-    states = np.zeros((cls_num, 4)).astype('float32')
+    states = np.zeros((cls_num, 4)).astype('float64')
     for i in range(ins_num):
         w = weights[i] if weights is not None else 1.0
         idx = idxs[i][0]
@@ -83,7 +83,7 @@ def compute_metrics(states, cls_num):
     micro_avg_recall = calc_recall(total_tp_count, total_fn_count)
     metrics.append(micro_avg_recall)
     metrics.append(calc_f1_score(micro_avg_precision, micro_avg_recall))
-    return np.array(metrics).astype('float32')
+    return np.array(metrics).astype('float64')
 
 
 class TestPrecisionRecallOp_0(OpTest):
@@ -91,7 +91,7 @@ class TestPrecisionRecallOp_0(OpTest):
         self.op_type = "precision_recall"
         ins_num = 64
         cls_num = 10
-        max_probs = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float32')
+        max_probs = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float64')
         idxs = np.random.choice(range(cls_num), ins_num).reshape(
             (ins_num, 1)).astype('int32')
         labels = np.random.choice(range(cls_num), ins_num).reshape(
@@ -118,10 +118,10 @@ class TestPrecisionRecallOp_1(OpTest):
         self.op_type = "precision_recall"
         ins_num = 64
         cls_num = 10
-        max_probs = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float32')
+        max_probs = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float64')
         idxs = np.random.choice(range(cls_num), ins_num).reshape(
             (ins_num, 1)).astype('int32')
-        weights = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float32')
+        weights = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float64')
         labels = np.random.choice(range(cls_num), ins_num).reshape(
             (ins_num, 1)).astype('int32')
 
@@ -152,13 +152,13 @@ class TestPrecisionRecallOp_2(OpTest):
         self.op_type = "precision_recall"
         ins_num = 64
         cls_num = 10
-        max_probs = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float32')
+        max_probs = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float64')
         idxs = np.random.choice(range(cls_num), ins_num).reshape(
             (ins_num, 1)).astype('int32')
-        weights = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float32')
+        weights = np.random.uniform(0, 1.0, (ins_num, 1)).astype('float64')
         labels = np.random.choice(range(cls_num), ins_num).reshape(
             (ins_num, 1)).astype('int32')
-        states = np.random.randint(0, 30, (cls_num, 4)).astype('float32')
+        states = np.random.randint(0, 30, (cls_num, 4)).astype('float64')
 
         accum_states = get_states(idxs, labels, cls_num, weights)
         batch_metrics = compute_metrics(accum_states, cls_num)

--- a/python/paddle/fluid/tests/unittests/test_print_op.py
+++ b/python/paddle/fluid/tests/unittests/test_print_op.py
@@ -30,12 +30,12 @@ class TestPrintOpCPU(unittest.TestCase):
     def setUp(self):
         self.place = core.CPUPlace()
         self.x_tensor = core.LoDTensor()
-        tensor_np = np.random.random(size=(2, 3)).astype('float32')
+        tensor_np = np.random.random(size=(2, 3)).astype('float64')
         self.x_tensor.set(tensor_np, self.place)
         self.x_tensor.set_recursive_sequence_lengths([[1, 1]])
 
     def build_network(self, only_forward, **kargs):
-        x = layers.data('x', shape=[3], dtype='float32', lod_level=1)
+        x = layers.data('x', shape=[3], dtype='float64', lod_level=1)
         x.stop_gradient = False
         layers.Print(input=x, **kargs)
         loss = layers.mean(x)
@@ -59,7 +59,7 @@ class TestPrintOpCPU(unittest.TestCase):
                        return_numpy=False)
 
     def test_all_parameters(self):
-        x = layers.data('x', shape=[3], dtype='float32', lod_level=1)
+        x = layers.data('x', shape=[3], dtype='float64', lod_level=1)
         x.stop_gradient = False
 
         for print_tensor_name in [True, False]:
@@ -86,7 +86,7 @@ class TestPrintOpGPU(TestPrintOpCPU):
     def setUp(self):
         self.place = core.CUDAPlace(0)
         self.x_tensor = core.LoDTensor()
-        tensor_np = np.random.random(size=(2, 3)).astype('float32')
+        tensor_np = np.random.random(size=(2, 3)).astype('float64')
         self.x_tensor.set(tensor_np, self.place)
         self.x_tensor.set_recursive_sequence_lengths([[1, 1]])
 

--- a/python/paddle/fluid/tests/unittests/test_proximal_adagrad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_proximal_adagrad_op.py
@@ -22,10 +22,10 @@ from op_test import OpTest
 class TestProximalAdagradOp(OpTest):
     def setUp(self):
         self.op_type = "proximal_adagrad"
-        w = np.random.random((102, 105)).astype("float32")
-        m = np.random.random((102, 105)).astype("float32")
-        g = np.random.random((102, 105)).astype("float32")
-        lr = np.array([0.1]).astype("float32")
+        w = np.random.random((102, 105)).astype("float64")
+        m = np.random.random((102, 105)).astype("float64")
+        g = np.random.random((102, 105)).astype("float64")
+        lr = np.array([0.1]).astype("float64")
         l1 = 0.1
         l2 = 0.2
 

--- a/python/paddle/fluid/tests/unittests/test_proximal_gd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_proximal_gd_op.py
@@ -22,9 +22,9 @@ from op_test import OpTest
 class TestProximalGDOp(OpTest):
     def setUp(self):
         self.op_type = "proximal_gd"
-        w = np.random.random((102, 105)).astype("float32")
-        g = np.random.random((102, 105)).astype("float32")
-        lr = np.array([0.1]).astype("float32")
+        w = np.random.random((102, 105)).astype("float64")
+        g = np.random.random((102, 105)).astype("float64")
+        lr = np.array([0.1]).astype("float64")
         l1 = 0.1
         l2 = 0.2
 

--- a/python/paddle/fluid/tests/unittests/test_psroi_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_psroi_pool_op.py
@@ -47,7 +47,7 @@ class TestPSROIPoolOp(OpTest):
         self.pooled_height = 2
         self.pooled_width = 2
 
-        self.x = np.random.random(self.x_dim).astype('float32')
+        self.x = np.random.random(self.x_dim).astype('float64')
 
     def make_rois(self):
         rois = []
@@ -67,7 +67,7 @@ class TestPSROIPoolOp(OpTest):
                 roi = [bno, x1, y1, x2, y2]
                 rois.append(roi)
         self.rois_num = len(rois)
-        self.rois = np.array(rois).astype('float32')
+        self.rois = np.array(rois).astype('float64')
 
     def calc_psroi_pool(self):
         output_shape = (self.rois_num, self.output_channels, self.pooled_height,
@@ -117,7 +117,7 @@ class TestPSROIPoolOp(OpTest):
                         bin_area = (hend - hstart) * (wend - wstart)
                         out_data[i, c, ph, pw] = 0. if is_empty else (
                             out_sum / float(bin_area))
-        self.outs = out_data.astype('float32')
+        self.outs = out_data.astype('float64')
 
     def setUp(self):
         self.op_type = 'psroi_pool'

--- a/python/paddle/fluid/tests/unittests/test_py_reader_push_pop.py
+++ b/python/paddle/fluid/tests/unittests/test_py_reader_push_pop.py
@@ -32,7 +32,7 @@ class TestPyReader(unittest.TestCase):
         self.batch_size_max = 20
         self.shapes = [(-1, 3, 2, 1), (-1, 1)]
         self.lod_levels = [0, 0]
-        self.dtypes = ['float32', 'int64']
+        self.dtypes = ['float64', 'int64']
         self.iterations = 20
 
     def test_single_thread_main(self):

--- a/python/paddle/fluid/tests/unittests/test_recurrent_op.py
+++ b/python/paddle/fluid/tests/unittests/test_recurrent_op.py
@@ -28,8 +28,8 @@ np.random.seed(123)
 
 class PyRNNBase(object):
     def __init__(self, input_shape, output_shape):
-        self.x = np.ones(shape=input_shape).astype("float32")
-        self.y = np.zeros(shape=output_shape).astype("float32")
+        self.x = np.ones(shape=input_shape).astype("float64")
+        self.y = np.zeros(shape=output_shape).astype("float64")
 
     def step(self, step_id, x):
         raise NotImplementedError
@@ -49,11 +49,11 @@ class PySimpleRNN1(PyRNNBase):
 
         seq_len, batch_size, input_dim = input_shape
         self.h_boot = np.random.normal(size=(batch_size,
-                                             input_dim)).astype("float32")
+                                             input_dim)).astype("float64")
 
         self.scale = 1.0 / 2.0
         men_dim = (seq_len, batch_size, input_dim)
-        self.mems = np.zeros(shape=men_dim).astype("float32")
+        self.mems = np.zeros(shape=men_dim).astype("float64")
 
     def step(self, step_id, x):
         if step_id == 0:
@@ -69,20 +69,20 @@ class PySimpleRNN2(PyRNNBase):
         super(PySimpleRNN2, self).__init__(input_shape, output_shape)
 
         seq_len, batch_size, input_dim = input_shape
-        self.W = np.random.normal(size=(input_dim, input_dim)).astype("float32")
-        self.U = np.random.normal(size=(input_dim, input_dim)).astype("float32")
-        self.h_boot = np.ones(shape=(batch_size, input_dim)).astype("float32")
+        self.W = np.random.normal(size=(input_dim, input_dim)).astype("float64")
+        self.U = np.random.normal(size=(input_dim, input_dim)).astype("float64")
+        self.h_boot = np.ones(shape=(batch_size, input_dim)).astype("float64")
 
         men_dim = (seq_len, batch_size, input_dim)
-        self.mems = np.zeros(shape=men_dim).astype("float32")
+        self.mems = np.zeros(shape=men_dim).astype("float64")
 
     def step(self, step_id, x):
         if step_id > 0:
             pre_mem = self.mems[step_id - 1]
         else:
             pre_mem = self.h_boot
-        xW = np.matmul(x, self.W).astype("float32")
-        hU = np.matmul(pre_mem, self.U).astype("float32")
+        xW = np.matmul(x, self.W).astype("float64")
+        hU = np.matmul(pre_mem, self.U).astype("float64")
 
         def py_sigmoid(x):
             return 1. / (1. + np.exp(-x))
@@ -133,12 +133,12 @@ class RecurrentOpTest1(unittest.TestCase):
     def create_rnn_op(self):
         x = layers.data(
             shape=[self.sent_len, self.batch_size, self.input_dim],
-            dtype='float32',
+            dtype='float64',
             name='x',
             append_batch_size=False)
         x.stop_gradient = False
         h_boot = layers.data(
-            shape=[self.input_dim], dtype='float32', name='h_boot')
+            shape=[self.input_dim], dtype='float64', name='h_boot')
         h_boot.stop_gradient = False
 
         rnn = layers.StaticRNN()
@@ -263,12 +263,12 @@ class RecurrentOpTest2(RecurrentOpTest1):
     def create_rnn_op(self):
         x = layers.data(
             shape=[self.sent_len, self.batch_size, self.input_dim],
-            dtype='float32',
+            dtype='float64',
             name='x',
             append_batch_size=False)
         x.stop_gradient = False
         h_boot = layers.data(
-            shape=[self.input_dim], dtype='float32', name='h_boot')
+            shape=[self.input_dim], dtype='float64', name='h_boot')
         h_boot.stop_gradient = False
 
         rnn = layers.StaticRNN()
@@ -318,13 +318,13 @@ class RecurrentOpMultipleMemoryTest(RecurrentOpTest1):
 
             seq_len, batch_size, input_dim = input_shape
             self.h_boot1 = np.random.normal(size=(batch_size,
-                                                  input_dim)).astype("float32")
+                                                  input_dim)).astype("float64")
             self.h_boot2 = np.random.normal(size=(batch_size,
-                                                  input_dim)).astype("float32")
+                                                  input_dim)).astype("float64")
 
             men_dim = (seq_len, batch_size, input_dim)
-            self.mems1 = np.zeros(shape=men_dim).astype("float32")
-            self.mems2 = np.zeros(shape=men_dim).astype("float32")
+            self.mems1 = np.zeros(shape=men_dim).astype("float64")
+            self.mems2 = np.zeros(shape=men_dim).astype("float64")
 
         def step(self, step_id, x):
             if step_id == 0:
@@ -357,19 +357,19 @@ class RecurrentOpMultipleMemoryTest(RecurrentOpTest1):
     def create_rnn_op(self):
         x = layers.data(
             shape=[self.sent_len, self.batch_size, self.input_dim],
-            dtype='float32',
+            dtype='float64',
             name='x',
             append_batch_size=False)
         x.stop_gradient = False
         h_boot1 = layers.data(
             shape=[self.batch_size, self.input_dim],
-            dtype='float32',
+            dtype='float64',
             name='h_boot1',
             append_batch_size=False)
         h_boot1.stop_gradient = False
         h_boot2 = layers.data(
             shape=[self.batch_size, self.input_dim],
-            dtype='float32',
+            dtype='float64',
             name='h_boot2',
             append_batch_size=False)
         h_boot2.stop_gradient = False
@@ -410,7 +410,7 @@ class RecurrentOpNoMemBootTest(RecurrentOpTest1):
             super(RecurrentOpNoMemBootTest.PySimpleRNN4, self).__init__(
                 input_shape, output_shape)
             men_dim = input_shape
-            self.mems = np.zeros(shape=men_dim).astype("float32")
+            self.mems = np.zeros(shape=men_dim).astype("float64")
 
         def step(self, step_id, x):
             if step_id == 0:
@@ -440,7 +440,7 @@ class RecurrentOpNoMemBootTest(RecurrentOpTest1):
     def create_rnn_op(self):
         x = layers.data(
             shape=[self.sent_len, self.batch_size, self.input_dim],
-            dtype='float32',
+            dtype='float64',
             name='x',
             append_batch_size=False)
         x.stop_gradient = False

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -24,11 +24,11 @@ class TestReshapeOp(OpTest):
     def setUp(self):
         self.init_data()
         self.op_type = "reshape2"
-        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
         self.attrs = {"shape": self.new_shape}
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.infered_shape),
-            'XShape': np.random.random(self.ori_shape).astype("float32")
+            'XShape': np.random.random(self.ori_shape).astype("float64")
         }
 
     def init_data(self):
@@ -66,14 +66,14 @@ class TestReshapeOpWithInputShape(OpTest):
 
         self.op_type = "reshape2"
         self.inputs = {
-            "X": np.random.random(ori_shape).astype("float32"),
+            "X": np.random.random(ori_shape).astype("float64"),
             "Shape": np.array(
                 actual_shape, dtype="int32")
         }
         self.attrs = {"shape": new_shape}
         self.outputs = {
             "Out": self.inputs["X"].reshape(actual_shape),
-            'XShape': np.random.random(ori_shape).astype("float32")
+            'XShape': np.random.random(ori_shape).astype("float64")
         }
 
     def test_check_output(self):
@@ -94,13 +94,13 @@ class TestReshapeOp_attr_tensor(OpTest):
                 (1)).astype('int32') * ele))
 
         self.inputs = {
-            "X": np.random.random(self.ori_shape).astype("float32"),
+            "X": np.random.random(self.ori_shape).astype("float64"),
             'ShapeTensor': shape_tensor
         }
         self.attrs = {}
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.infered_shape),
-            'XShape': np.random.random(self.ori_shape).astype("float32")
+            'XShape': np.random.random(self.ori_shape).astype("float64")
         }
 
     def init_data(self):

--- a/python/paddle/fluid/tests/unittests/test_reverse_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reverse_op.py
@@ -21,7 +21,7 @@ from op_test import OpTest
 
 class TestReverseOp(OpTest):
     def initTestCase(self):
-        self.x = np.random.random((3, 4)).astype('float32')
+        self.x = np.random.random((3, 4)).astype('float64')
         self.axis = [0]
 
     def setUp(self):
@@ -43,25 +43,25 @@ class TestReverseOp(OpTest):
 
 class TestCase0(TestReverseOp):
     def initTestCase(self):
-        self.x = np.random.random((3, 4)).astype('float32')
+        self.x = np.random.random((3, 4)).astype('float64')
         self.axis = [1]
 
 
 class TestCase1(TestReverseOp):
     def initTestCase(self):
-        self.x = np.random.random((3, 4)).astype('float32')
+        self.x = np.random.random((3, 4)).astype('float64')
         self.axis = [0, 1]
 
 
 class TestCase2(TestReverseOp):
     def initTestCase(self):
-        self.x = np.random.random((3, 4, 5)).astype('float32')
+        self.x = np.random.random((3, 4, 5)).astype('float64')
         self.axis = [0, 2]
 
 
 class TestCase3(TestReverseOp):
     def initTestCase(self):
-        self.x = np.random.random((3, 4, 5)).astype('float32')
+        self.x = np.random.random((3, 4, 5)).astype('float64')
         self.axis = [1, 2]
 
 

--- a/python/paddle/fluid/tests/unittests/test_rmsprop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_rmsprop_op.py
@@ -29,13 +29,13 @@ def create_selected_rows_and_tensor(scope, place, height, row_num,
 
     rows = np.random.random_integers(
         low=0, high=height - 1, size=[row_num, ]).astype('int64')
-    sr_val = np.random.random(size=[row_num, embedding_size]).astype('float32')
+    sr_val = np.random.random(size=[row_num, embedding_size]).astype('float64')
 
     sr.set_height(height)
     sr.set_rows(rows)
     sr.get_tensor().set(sr_val, place)
 
-    tensor_val = np.zeros(shape=[height, embedding_size], dtype='float32')
+    tensor_val = np.zeros(shape=[height, embedding_size], dtype='float64')
     for i in range(row_num):
         row = rows[i]
         tensor_val[row, :] = tensor_val[row, :] + sr_val[i, :]
@@ -58,17 +58,17 @@ class TestBase(unittest.TestCase):
         self.place = place
 
         self.param_name = "param"
-        self.param = np.random.random(size).astype("float32")
+        self.param = np.random.random(size).astype("float64")
 
         self.mean_square_name = "mean_square"
         self.mean_square = np.random.uniform(
-            low=1, high=2, size=size).astype("float32")
+            low=1, high=2, size=size).astype("float64")
 
         self.mean_grad_name = "mean_grad"
-        self.mean_grad = np.random.random(size).astype("float32")
+        self.mean_grad = np.random.random(size).astype("float64")
 
         self.lr_name = "lr"
-        self.learning_rate = np.array([0.01]).astype("float32")
+        self.learning_rate = np.array([0.01]).astype("float64")
 
         self.grad_name = "grad"
 
@@ -78,13 +78,13 @@ class TestBase(unittest.TestCase):
             self.grad, self.grad_sr = create_selected_rows_and_tensor(
                 self.scope, place, size[0], row_num, size[1])
         else:
-            self.grad = np.random.random(size).astype("float32")
+            self.grad = np.random.random(size).astype("float64")
             grad_tensor = self.scope.var(self.grad_name).get_tensor()
             grad_tensor.set(self.grad, place)
 
         self.moment_name = "moment"
         self.moment = np.random.uniform(
-            low=0, high=1, size=size).astype("float32")
+            low=0, high=1, size=size).astype("float64")
 
         self.epsilon = epsilon
         self.decay = 0.9

--- a/python/paddle/fluid/tests/unittests/test_rnn_memory_helper_op.py
+++ b/python/paddle/fluid/tests/unittests/test_rnn_memory_helper_op.py
@@ -29,9 +29,9 @@ class RNNMemoryHelperOpTest(unittest.TestCase):
         self.place = core.CPUPlace()
 
         self.X = self.program.global_block().create_var(
-            name='X', shape=[2, 3], dtype='float32')
+            name='X', shape=[2, 3], dtype='float64')
         self.Out = self.program.global_block().create_var(
-            name='Out', shape=[2, 3], dtype='float32')
+            name='Out', shape=[2, 3], dtype='float64')
         self.program.global_block().append_op(
             type='rnn_memory_helper',
             inputs={"X": self.X},
@@ -39,7 +39,7 @@ class RNNMemoryHelperOpTest(unittest.TestCase):
             attrs={})
 
     def test_forward(self):
-        x_np = np.random.normal(size=(2, 3)).astype("float32")
+        x_np = np.random.normal(size=(2, 3)).astype("float64")
         self.feed_map = {'X': x_np}
         self.fetch_list = [self.Out]
         exe = Executor(self.place)
@@ -57,14 +57,14 @@ class RNNMemoryHelperGradOpTest(unittest.TestCase):
         self.input_names = ['X', 'Out', 'Out@GRAD']
         self.input_vars = {
             name: self.program.global_block().create_var(
-                name=name, shape=[2, 3], dtype='float32')
+                name=name, shape=[2, 3], dtype='float64')
             for name in self.input_names
         }
 
         self.output_names = ['X@GRAD']
         self.output_vars = {
             name: self.program.global_block().create_var(
-                name=name, shape=[2, 3], dtype='float32')
+                name=name, shape=[2, 3], dtype='float64')
             for name in self.output_names
         }
 
@@ -76,7 +76,7 @@ class RNNMemoryHelperGradOpTest(unittest.TestCase):
 
     def test_backward(self):
         self.feed_map = {
-            name: np.random.normal(size=(2, 3)).astype("float32")
+            name: np.random.normal(size=(2, 3)).astype("float64")
             for name in self.input_names
         }
         self.fetch_list = [self.output_vars['X@GRAD']]
@@ -97,17 +97,17 @@ class RNNMemoryHelperGradOpWithoutInputTest(unittest.TestCase):
         self.input_names = ['X', 'Out']
         self.input_vars = {
             name: self.program.global_block().create_var(
-                name=name, shape=[2, 3], dtype='float32')
+                name=name, shape=[2, 3], dtype='float64')
             for name in self.input_names
         }
         self.input_vars["Out@GRAD"] = \
             self.fake_program.global_block().create_var(
-                name="Out@GRAD", shape=[2, 3], dtype='float32')
+                name="Out@GRAD", shape=[2, 3], dtype='float64')
 
         self.output_names = ['X@GRAD']
         self.output_vars = {
             name: self.program.global_block().create_var(
-                name=name, shape=[2, 3], dtype='float32')
+                name=name, shape=[2, 3], dtype='float64')
             for name in self.output_names
         }
 
@@ -119,7 +119,7 @@ class RNNMemoryHelperGradOpWithoutInputTest(unittest.TestCase):
 
     def test_backward(self):
         self.feed_map = {
-            name: np.random.normal(size=(2, 3)).astype("float32")
+            name: np.random.normal(size=(2, 3)).astype("float64")
             for name in ['X', 'Out']
         }
         self.fetch_list = [self.output_vars['X@GRAD']]
@@ -130,7 +130,7 @@ class RNNMemoryHelperGradOpWithoutInputTest(unittest.TestCase):
                       fetch_list=self.fetch_list)
         self.assertTrue(
             np.allclose(
-                out[0], np.zeros(shape=(2, 3)).astype("float32"), rtol=1e-5))
+                out[0], np.zeros(shape=(2, 3)).astype("float64"), rtol=1e-5))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_roi_align_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roi_align_op.py
@@ -50,16 +50,16 @@ class TestROIAlignOp(OpTest):
         self.pooled_width = 2
         self.sampling_ratio = -1
 
-        self.x = np.random.random(self.x_dim).astype('float32')
+        self.x = np.random.random(self.x_dim).astype('float64')
 
     def pre_calc(self, x_i, roi_xmin, roi_ymin, roi_bin_grid_h, roi_bin_grid_w,
                  bin_size_h, bin_size_w):
         count = roi_bin_grid_h * roi_bin_grid_w
         bilinear_pos = np.zeros(
             [self.channels, self.pooled_height, self.pooled_width, count, 4],
-            np.float32)
+            np.float64)
         bilinear_w = np.zeros(
-            [self.pooled_height, self.pooled_width, count, 4], np.float32)
+            [self.pooled_height, self.pooled_width, count, 4], np.float64)
         for ph in range(self.pooled_width):
             for pw in range(self.pooled_height):
                 c = 0
@@ -109,7 +109,7 @@ class TestROIAlignOp(OpTest):
     def calc_roi_align(self):
         self.out_data = np.zeros(
             (self.rois_num, self.channels, self.pooled_height,
-             self.pooled_width)).astype('float32')
+             self.pooled_width)).astype('float64')
 
         for i in range(self.rois_num):
             roi = self.rois[i]
@@ -157,7 +157,7 @@ class TestROIAlignOp(OpTest):
                 roi = [bno, x1, y1, x2, y2]
                 rois.append(roi)
         self.rois_num = len(rois)
-        self.rois = np.array(rois).astype("float32")
+        self.rois = np.array(rois).astype("float64")
 
     def setUp(self):
         self.op_type = "roi_align"

--- a/python/paddle/fluid/tests/unittests/test_roi_perspective_transform_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roi_perspective_transform_op.py
@@ -225,7 +225,7 @@ def roi_transform(in_data, rois, rois_lod, transformed_height,
                     else:
                         out[n][c][out_h][out_w] = 0.0
                         mask[n][0][out_h][out_w] = 0
-    return out.astype("float32"), mask, matrix
+    return out.astype("float64"), mask, matrix
 
 
 class TestROIPoolOp(OpTest):
@@ -262,7 +262,7 @@ class TestROIPoolOp(OpTest):
         self.transformed_height = 2
         self.transformed_width = 3
 
-        self.x = np.random.random(self.x_dim).astype('float32')
+        self.x = np.random.random(self.x_dim).astype('float64')
 
     def make_rois(self):
         rois = []
@@ -297,7 +297,7 @@ class TestROIPoolOp(OpTest):
                 roi = [x1, y1, x2, y2, x3, y3, x4, y4]
                 rois.append(roi)
         self.rois_num = len(rois)
-        self.rois = np.array(rois).astype("float32")
+        self.rois = np.array(rois).astype("float64")
 
     def setUp(self):
         self.op_type = "roi_perspective_transform"
@@ -310,7 +310,7 @@ class TestROIPoolOp(OpTest):
         self.outputs['Out2InIdx'] = np.zeros(
             [np.product(self.outputs['Out'].shape), 4]).astype("int32")
         self.outputs['Out2InWeights'] = np.zeros(
-            [np.product(self.outputs['Out'].shape), 4]).astype("float32")
+            [np.product(self.outputs['Out'].shape), 4]).astype("float64")
         self.check_grad(['X'], 'Out')
 
 

--- a/python/paddle/fluid/tests/unittests/test_roi_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roi_pool_op.py
@@ -51,7 +51,7 @@ class TestROIPoolOp(OpTest):
         self.pooled_height = 2
         self.pooled_width = 2
 
-        self.x = np.random.random(self.x_dim).astype('float32')
+        self.x = np.random.random(self.x_dim).astype('float64')
 
     def calc_roi_pool(self):
         out_data = np.zeros((self.rois_num, self.channels, self.pooled_height,
@@ -103,7 +103,7 @@ class TestROIPoolOp(OpTest):
                                     argmax_data[i, c, ph,
                                                 pw] = h * self.width + w
 
-        self.outs = out_data.astype('float32')
+        self.outs = out_data.astype('float64')
         self.argmaxes = argmax_data.astype('int64')
 
     def make_rois(self):
@@ -125,7 +125,7 @@ class TestROIPoolOp(OpTest):
                 roi = [bno, x1, y1, x2, y2]
                 rois.append(roi)
         self.rois_num = len(rois)
-        self.rois = np.array(rois).astype("float32")
+        self.rois = np.array(rois).astype("float64")
 
     def setUp(self):
         self.op_type = "roi_pool"

--- a/python/paddle/fluid/tests/unittests/test_rpn_target_assign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_rpn_target_assign_op.py
@@ -53,7 +53,7 @@ def rpn_target_assign(anchor_by_gt_overlap,
 
     labels[disable_inds] = -1
     fg_inds = np.where(labels == 1)[0]
-    bbox_inside_weight = np.zeros((len(fg_inds), 4), dtype=np.float32)
+    bbox_inside_weight = np.zeros((len(fg_inds), 4), dtype=np.float64)
 
     num_bg = rpn_batch_size_per_im - np.sum(labels == 1)
     bg_inds = np.where(anchor_to_gt_max < rpn_negative_overlap)[0]
@@ -85,7 +85,7 @@ def rpn_target_assign(anchor_by_gt_overlap,
 
 
 def get_anchor(n, c, h, w):
-    input_feat = np.random.random((n, c, h, w)).astype('float32')
+    input_feat = np.random.random((n, c, h, w)).astype('float64')
     anchors, _ = anchor_generator_in_python(
         input_feat=input_feat,
         anchor_sizes=[32., 64.],
@@ -184,7 +184,7 @@ def retinanet_target_assign(anchor_by_gt_overlap, gt_labels, positive_overlap,
     labels[anchor_to_gt_max >= positive_overlap] = 1
 
     fg_inds = np.where(labels == 1)[0]
-    bbox_inside_weight = np.zeros((len(fg_inds), 4), dtype=np.float32)
+    bbox_inside_weight = np.zeros((len(fg_inds), 4), dtype=np.float64)
 
     bg_inds = np.where(anchor_to_gt_max < negative_overlap)[0]
     enable_inds = bg_inds
@@ -280,7 +280,7 @@ class TestRpnTargetAssignOp(OpTest):
         lod = [0, 4, 8]
         #lod = [0, 4]
 
-        im_info = np.ones((len(images_shape), 3)).astype(np.float32)
+        im_info = np.ones((len(images_shape), 3)).astype(np.float64)
         for i in range(len(images_shape)):
             im_info[i, 0] = images_shape[i][0]
             im_info[i, 1] = images_shape[i][1]
@@ -288,8 +288,8 @@ class TestRpnTargetAssignOp(OpTest):
         gt_boxes = np.vstack([v['boxes'] for v in groundtruth])
         is_crowd = np.hstack([v['is_crowd'] for v in groundtruth])
 
-        all_anchors = all_anchors.astype('float32')
-        gt_boxes = gt_boxes.astype('float32')
+        all_anchors = all_anchors.astype('float64')
+        gt_boxes = gt_boxes.astype('float64')
 
         rpn_straddle_thresh = 0.0
         rpn_batch_size_per_im = 256
@@ -324,9 +324,9 @@ class TestRpnTargetAssignOp(OpTest):
         self.outputs = {
             'LocationIndex': loc_index.astype('int32'),
             'ScoreIndex': score_index.astype('int32'),
-            'TargetBBox': tgt_bbox.astype('float32'),
+            'TargetBBox': tgt_bbox.astype('float64'),
             'TargetLabel': labels.astype('int32'),
-            'BBoxInsideWeight': bbox_inside_weights.astype('float32')
+            'BBoxInsideWeight': bbox_inside_weights.astype('float64')
         }
 
     def test_check_output(self):
@@ -345,7 +345,7 @@ class TestRetinanetTargetAssignOp(OpTest):
         groundtruth, lod = _generate_groundtruth(images_shape, 3, 4)
         lod = [0, 4, 8]
 
-        im_info = np.ones((len(images_shape), 3)).astype(np.float32)
+        im_info = np.ones((len(images_shape), 3)).astype(np.float64)
         for i in range(len(images_shape)):
             im_info[i, 0] = images_shape[i][0]
             im_info[i, 1] = images_shape[i][1]
@@ -357,8 +357,8 @@ class TestRetinanetTargetAssignOp(OpTest):
             for v in groundtruth
         ])
         gt_labels = gt_labels.reshape(len(gt_labels), 1)
-        all_anchors = all_anchors.astype('float32')
-        gt_boxes = gt_boxes.astype('float32')
+        all_anchors = all_anchors.astype('float64')
+        gt_boxes = gt_boxes.astype('float64')
         gt_labels = gt_labels.astype('int32')
 
         positive_overlap = 0.5
@@ -383,9 +383,9 @@ class TestRetinanetTargetAssignOp(OpTest):
         self.outputs = {
             'LocationIndex': loc_index.astype('int32'),
             'ScoreIndex': score_index.astype('int32'),
-            'TargetBBox': tgt_bbox.astype('float32'),
+            'TargetBBox': tgt_bbox.astype('float64'),
             'TargetLabel': labels.astype('int32'),
-            'BBoxInsideWeight': bbox_inside_weights.astype('float32'),
+            'BBoxInsideWeight': bbox_inside_weights.astype('float64'),
             'ForegroundNumber': fg_num.astype('int32')
         }
 

--- a/python/paddle/fluid/tests/unittests/test_sampling_id_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sampling_id_op.py
@@ -26,7 +26,7 @@ class TestSamplingIdOp(OpTest):
         self.op_type = "sampling_id"
         self.use_mkldnn = False
         self.init_kernel_type()
-        self.X = np.random.random((100, 10)).astype('float32')
+        self.X = np.random.random((100, 10)).astype('float64')
         self.inputs = {"X": self.X}
         self.Y = np.random.random(100).astype('int64')
         self.outputs = {'Out': self.Y}
@@ -60,7 +60,7 @@ class TestSamplingIdOp(OpTest):
 
 class TestSamplingIdShape(unittest.TestCase):
     def test_shape(self):
-        x = fluid.layers.data(name='x', shape=[3], dtype='float32')
+        x = fluid.layers.data(name='x', shape=[3], dtype='float64')
         output = fluid.layers.sampling_id(x)
 
         place = fluid.CPUPlace()
@@ -69,7 +69,7 @@ class TestSamplingIdShape(unittest.TestCase):
 
         feed = {
             'x': np.array(
-                [[0.2, 0.3, 0.5], [0.2, 0.3, 0.4]], dtype='float32')
+                [[0.2, 0.3, 0.5], [0.2, 0.3, 0.4]], dtype='float64')
         }
         output_np = exe.run(feed=feed, fetch_list=[output])[0]
 

--- a/python/paddle/fluid/tests/unittests/test_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scale_op.py
@@ -24,7 +24,7 @@ from paddle.fluid.op import Operator
 class TestScaleOp(OpTest):
     def setUp(self):
         self.op_type = "scale"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype_type()
         self.inputs = {'X': np.random.random((10, 10)).astype(self.dtype)}
         self.attrs = {'scale': -2.3}
@@ -49,7 +49,7 @@ class TestScaleOpSelectedRows(unittest.TestCase):
     def check_with_place(self, place, in_name, out_name):
         scope = core.Scope()
 
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype_type()
 
         # create and initialize Grad Variable

--- a/python/paddle/fluid/tests/unittests/test_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scatter_op.py
@@ -23,9 +23,9 @@ import paddle.fluid.core as core
 class TestScatterOp(OpTest):
     def setUp(self):
         self.op_type = "scatter"
-        ref_np = np.ones((3, 3)).astype("float32")
+        ref_np = np.ones((3, 3)).astype("float64")
         index_np = np.array([1, 2]).astype("int32")
-        updates_np = np.random.random((2, 3)).astype("float32")
+        updates_np = np.random.random((2, 3)).astype("float64")
         output_np = np.copy(ref_np)
         output_np[index_np] = updates_np
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
@@ -41,9 +41,9 @@ class TestScatterOp(OpTest):
 class TestScatterOp0(OpTest):
     def setUp(self):
         self.op_type = "scatter"
-        ref_np = np.ones((3, 3)).astype("float32")
+        ref_np = np.ones((3, 3)).astype("float64")
         index_np = np.array([1, 2]).astype("int32")
-        updates_np = np.random.random((2, 3)).astype("float32")
+        updates_np = np.random.random((2, 3)).astype("float64")
         output_np = np.copy(ref_np)
         output_np[index_np] = updates_np
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
@@ -60,10 +60,10 @@ class TestScatterOp0(OpTest):
 class TestScatterOp1(OpTest):
     def setUp(self):
         self.op_type = "scatter"
-        ref_np = np.ones((3, 3)).astype("float32")
-        zeros_np = np.zeros([2, 3]).astype('float32')
+        ref_np = np.ones((3, 3)).astype("float64")
+        zeros_np = np.zeros([2, 3]).astype('float64')
         index_np = np.array([1, 1]).astype("int32")
-        updates_np = np.random.random((2, 3)).astype("float32")
+        updates_np = np.random.random((2, 3)).astype("float64")
         output_np = np.copy(ref_np)
         output_np[index_np] = zeros_np
         for i in range(0, len(index_np)):
@@ -84,9 +84,9 @@ class TestScatterOp1(OpTest):
 class TestScatterOp2(OpTest):
     def setUp(self):
         self.op_type = "scatter"
-        ref_np = np.ones((3, 3)).astype("float32")
+        ref_np = np.ones((3, 3)).astype("float64")
         index_np = np.array([1, 2]).astype("int32")
-        updates_np = np.random.random((2, 3)).astype("float32")
+        updates_np = np.random.random((2, 3)).astype("float64")
         output_np = np.copy(ref_np)
         output_np[index_np] = updates_np
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}
@@ -108,10 +108,10 @@ class TestScatterOp2(OpTest):
 class TestScatterOp3(OpTest):
     def setUp(self):
         self.op_type = "scatter"
-        ref_np = np.ones((3, 3)).astype("float32")
-        zeros_np = np.zeros([2, 3]).astype('float32')
+        ref_np = np.ones((3, 3)).astype("float64")
+        zeros_np = np.zeros([2, 3]).astype('float64')
         index_np = np.array([1, 1]).astype("int32")
-        updates_np = np.random.random((2, 3)).astype("float32")
+        updates_np = np.random.random((2, 3)).astype("float64")
         output_np = np.copy(ref_np)
         output_np[index_np] = zeros_np
         for i in range(0, len(index_np)):

--- a/python/paddle/fluid/tests/unittests/test_selu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_selu_op.py
@@ -24,7 +24,7 @@ class SeluTest(OpTest):
     def setUp(self):
         self.op_type = "selu"
         self.x_shape = [3, 5, 5, 10]
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_x_shape()
         self.init_dtype()
 

--- a/python/paddle/fluid/tests/unittests/test_sequence_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_pad_op.py
@@ -23,7 +23,7 @@ class TestSequencePadOp(OpTest):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0]
         self.padded_length = -1
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
     def set_data(self):
         x_data = np.random.uniform(0.1, 0.5, self.x_shape).astype(self.dtype)
@@ -84,7 +84,7 @@ class TestSequencePadOp2(TestSequencePadOp):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0, 2.0, 3.0, 4.0]
         self.padded_length = -1
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestSequencePadOp3(TestSequencePadOp):
@@ -93,7 +93,7 @@ class TestSequencePadOp3(TestSequencePadOp):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0]
         self.padded_length = 7
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestSequencePadOp4(TestSequencePadOp):
@@ -102,7 +102,7 @@ class TestSequencePadOp4(TestSequencePadOp):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0, 2.0, 3.0, 4.0]
         self.padded_length = 7
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestSequencePadOp5(TestSequencePadOp):
@@ -111,7 +111,7 @@ class TestSequencePadOp5(TestSequencePadOp):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0]
         self.padded_length = -1
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestSequencePadOp6(TestSequencePadOp):
@@ -120,7 +120,7 @@ class TestSequencePadOp6(TestSequencePadOp):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [[1.0, 2.0], [3.0, 4.0]]
         self.padded_length = -1
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestSequencePadOp7(TestSequencePadOp):
@@ -129,7 +129,7 @@ class TestSequencePadOp7(TestSequencePadOp):
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0]
         self.padded_length = 7
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 class TestSequencePadOp8(TestSequencePadOp):
@@ -138,7 +138,7 @@ class TestSequencePadOp8(TestSequencePadOp):
         self.x_len_lod = [[0, 8, 0, 4, 0]]
         self.pad_value = [1.0]
         self.padded_length = 10
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_sequence_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_scatter_op.py
@@ -24,12 +24,12 @@ class TestSequenceScatterOp(OpTest):
     def setUp(self):
         self.op_type = "sequence_scatter"
 
-        X_data = np.random.uniform(0.1, 1.0, [3, 6]).astype('float32')
+        X_data = np.random.uniform(0.1, 1.0, [3, 6]).astype('float64')
         Ids_data = np.array([[0], [1], [2], [5], [4], [3], [0], [1], [3], [2],
                              [5], [4]]).astype('int64')
         Ids_lod = self.init_lod()
 
-        Updates_data = np.random.uniform(0.1, 1.0, [12, 1]).astype('float32')
+        Updates_data = np.random.uniform(0.1, 1.0, [12, 1]).astype('float64')
         Updates_lod = Ids_lod
 
         Out_data = np.copy(X_data)

--- a/python/paddle/fluid/tests/unittests/test_sequence_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_slice_op.py
@@ -24,13 +24,13 @@ class TestSequenceSliceOp(OpTest):
     def set_data(self):
         self.init_test_case()
         # only supprot one level LoD
-        x = np.random.random(self.x_dim).astype('float32')
+        x = np.random.random(self.x_dim).astype('float64')
         lod = self.x_lod
         offset = np.array(self.offset).astype("int64")
         length = np.array(self.length).astype("int64")
 
         self.inputs = {'X': (x, lod), 'Offset': offset, 'Length': length}
-        outs = []  #np.zeros((100, 3, 2)).astype('float32')
+        outs = []  #np.zeros((100, 3, 2)).astype('float64')
         out_lod = [[]]
         lod_offset = 0
         for i in range(len(offset)):

--- a/python/paddle/fluid/tests/unittests/test_sequence_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_softmax_op.py
@@ -27,9 +27,9 @@ class TestSequenceSoftmaxOp(OpTest):
         self.use_cudnn = False
         self.init_op_type()
 
-        x = np.random.uniform(0.1, 1, (11, 1)).astype("float32")
+        x = np.random.uniform(0.1, 1, (11, 1)).astype("float64")
         self.init_lod()
-        out = np.zeros((11, 1)).astype("float32")
+        out = np.zeros((11, 1)).astype("float64")
         offset = 0
         for i in range(len(self.lod[0])):
             if (self.lod[0][i] == 0):

--- a/python/paddle/fluid/tests/unittests/test_sequence_unpad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_unpad_op.py
@@ -22,7 +22,7 @@ class TestSequenceUnpadOp(OpTest):
     def init(self):
         self.length = [2, 3, 4]
         self.x_shape = (3, 5)
-        self.dtype = "float32"
+        self.dtype = "float64"
 
     def compute(self):
         assert len(self.length) == self.x_shape[0]
@@ -61,7 +61,7 @@ class TestSequenceUnpadOp2(TestSequenceUnpadOp):
     def init(self):
         self.length = [2, 3, 4]
         self.x_shape = (3, 5, 4, 3)
-        self.dtype = "float32"
+        self.dtype = "float64"
 
 
 class TestSequenceUnpadOp3(TestSequenceUnpadOp):

--- a/python/paddle/fluid/tests/unittests/test_sgd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sgd_op.py
@@ -25,9 +25,9 @@ class TestSGDOp(OpTest):
     def setUp(self):
         self.op_type = "sgd"
         self.conf()
-        w = np.random.random((self.h, self.w)).astype("float32")
-        g = np.random.random((self.h, self.w)).astype("float32")
-        lr = np.array([0.1]).astype("float32")
+        w = np.random.random((self.h, self.w)).astype("float64")
+        g = np.random.random((self.h, self.w)).astype("float64")
+        lr = np.array([0.1]).astype("float64")
 
         self.inputs = {'Param': w, 'Grad': g, 'LearningRate': lr}
         self.outputs = {'ParamOut': w - lr * g}
@@ -58,7 +58,7 @@ class TestSparseSGDOp(unittest.TestCase):
         grad_selected_rows = scope.var('Grad').get_selected_rows()
         grad_selected_rows.set_height(height)
         grad_selected_rows.set_rows(rows)
-        np_array = np.ones((len(rows), self.row_numel)).astype("float32")
+        np_array = np.ones((len(rows), self.row_numel)).astype("float64")
         np_array[0, 0] = 2.0
         np_array[2, 8] = 4.0
 
@@ -67,12 +67,12 @@ class TestSparseSGDOp(unittest.TestCase):
 
         # create and initialize Param Variable
         param = scope.var('Param').get_tensor()
-        param_array = np.full((height, self.row_numel), 5.0).astype("float32")
+        param_array = np.full((height, self.row_numel), 5.0).astype("float64")
         param.set(param_array, place)
 
         # create and initialize LeraningRate Variable
         lr = scope.var('LearningRate').get_tensor()
-        lr_array = np.full((1), 2.0).astype("float32")
+        lr_array = np.full((1), 2.0).astype("float64")
         lr.set(lr_array, place)
 
         # create and run sgd operator
@@ -130,7 +130,7 @@ class TestSGDOpOptimizeSelectedRows(unittest.TestCase):
         grad_selected_rows = scope.var('Grad').get_selected_rows()
         grad_selected_rows.set_height(grad_height)
         grad_selected_rows.set_rows(grad_rows)
-        grad_array = np.ones((len(grad_rows), row_width)).astype("float32")
+        grad_array = np.ones((len(grad_rows), row_width)).astype("float64")
         grad_array[0, 0] = 2.0
         grad_array[2, 8] = 4.0
 
@@ -146,7 +146,7 @@ class TestSGDOpOptimizeSelectedRows(unittest.TestCase):
         w_selected_rows.set_height(len(param_rows))
         w_selected_rows.set_rows(param_rows)
         w_selected_rows.sync_index()
-        w_array = np.ones((len(param_rows), row_width)).astype("float32")
+        w_array = np.ones((len(param_rows), row_width)).astype("float64")
         for i in range(len(param_rows)):
             w_array[i] *= i
         w_tensor = w_selected_rows.get_tensor()
@@ -157,7 +157,7 @@ class TestSGDOpOptimizeSelectedRows(unittest.TestCase):
         # create and initialize LeraningRate Variable
         lr_value = 0.1
         lr = scope.var('LearningRate').get_tensor()
-        lr_array = np.full((1), lr_value).astype("float32")
+        lr_array = np.full((1), lr_value).astype("float64")
         lr.set(lr_array, place)
 
         # optimize with Python

--- a/python/paddle/fluid/tests/unittests/test_sign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sign_op.py
@@ -23,7 +23,7 @@ class TestSignOp(OpTest):
     def setUp(self):
         self.op_type = "sign"
         self.inputs = {
-            'X': np.random.uniform(-10, 10, (10, 10)).astype("float32")
+            'X': np.random.uniform(-10, 10, (10, 10)).astype("float64")
         }
         self.outputs = {'Out': np.sign(self.inputs['X'])}
 

--- a/python/paddle/fluid/tests/unittests/test_similarity_focus_op.py
+++ b/python/paddle/fluid/tests/unittests/test_similarity_focus_op.py
@@ -38,7 +38,7 @@ class TestSimilarityFocusOp(OpTest):
 
         output = None
         for batch in range(batch_size):
-            res = np.zeros((1, y_dim, z_dim)).astype("float32").reshape(-1)
+            res = np.zeros((1, y_dim, z_dim)).astype("float64").reshape(-1)
             for index in self.attrs['indexes']:
                 channel = self.inputs['X'][batch, index, :, :].reshape(-1).copy(
                 )
@@ -76,7 +76,7 @@ class TestSimilarityFocusOp_axis1(OpTest):
         x_dim, y_dim, z_dim = 4, 5, 6
         self.inputs = {
             'X': np.random.random(
-                (batch_size, x_dim, y_dim, z_dim)).astype("float32"),
+                (batch_size, x_dim, y_dim, z_dim)).astype("float64"),
         }
         self.attrs = {
             'axis': 1,
@@ -85,7 +85,7 @@ class TestSimilarityFocusOp_axis1(OpTest):
 
         output = None
         for batch in range(batch_size):
-            res = np.zeros((1, y_dim, z_dim)).astype("float32").reshape(-1)
+            res = np.zeros((1, y_dim, z_dim)).astype("float64").reshape(-1)
             for index in self.attrs['indexes']:
                 channel = self.inputs['X'][batch, index, :, :].reshape(-1).copy(
                 )
@@ -124,7 +124,7 @@ class TestSimilarityFocusOp_axis2(OpTest):
         x_dim, y_dim, z_dim = 7, 8, 9
         self.inputs = {
             'X': np.random.random(
-                (batch_size, x_dim, y_dim, z_dim)).astype("float32"),
+                (batch_size, x_dim, y_dim, z_dim)).astype("float64"),
         }
         self.attrs = {
             'axis': 2,
@@ -133,7 +133,7 @@ class TestSimilarityFocusOp_axis2(OpTest):
 
         output = None
         for batch in range(batch_size):
-            res = np.zeros((x_dim, 1, z_dim)).astype("float32").reshape(-1)
+            res = np.zeros((x_dim, 1, z_dim)).astype("float64").reshape(-1)
             for index in self.attrs['indexes']:
                 channel = self.inputs['X'][batch, :, index, :].reshape(-1).copy(
                 )
@@ -172,7 +172,7 @@ class TestSimilarityFocusOp_axis3(OpTest):
         x_dim, y_dim, z_dim = 48, 48, 13
         self.inputs = {
             'X': np.random.random(
-                (batch_size, x_dim, y_dim, z_dim)).astype("float32"),
+                (batch_size, x_dim, y_dim, z_dim)).astype("float64"),
         }
         self.attrs = {
             'axis': 3,
@@ -181,7 +181,7 @@ class TestSimilarityFocusOp_axis3(OpTest):
 
         output = None
         for batch in range(batch_size):
-            res = np.zeros((x_dim, y_dim, 1)).astype("float32").reshape(-1)
+            res = np.zeros((x_dim, y_dim, 1)).astype("float64").reshape(-1)
             for index in self.attrs['indexes']:
                 channel = self.inputs['X'][batch, :, :, index].reshape(-1).copy(
                 )

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -33,7 +33,7 @@ class TestSliceOp(OpTest):
         }
 
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [1, 0, 2]
         self.ends = [3, 3, 4]
         self.axes = [0, 1, 2]
@@ -60,7 +60,7 @@ class TestSliceOp_decs_dim(OpTest):
         }
 
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [1, 0, 2]
         self.ends = [2, 3, 4]
         self.axes = [0, 1, 2]
@@ -88,7 +88,7 @@ class TestSliceOp_decs_dim_2(OpTest):
         }
 
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [1, 0, 2]
         self.ends = [2, 1, 4]
         self.axes = [0, 1, 2]
@@ -116,7 +116,7 @@ class TestSliceOp_decs_dim_3(OpTest):
         }
 
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [-1, 0, 2]
         self.ends = [1000000, 1, 4]
         self.axes = [0, 1, 2]
@@ -144,7 +144,7 @@ class TestSliceOp_decs_dim_5(OpTest):
         }
 
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [-1]
         self.ends = [1000000]
         self.axes = [3]
@@ -172,7 +172,7 @@ class TestSliceOp_decs_dim_6(OpTest):
         }
 
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [0, 1, 2, 3]
         self.ends = [1, 2, 3, 4]
         self.axes = [0, 1, 2, 3]
@@ -188,7 +188,7 @@ class TestSliceOp_decs_dim_6(OpTest):
 
 class TestCase1(TestSliceOp):
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [-3, 0, 2]
         self.ends = [3, 100, -1]
         self.axes = [0, 1, 2]
@@ -197,7 +197,7 @@ class TestCase1(TestSliceOp):
 
 class TestCase2(TestSliceOp):
     def config(self):
-        self.input = np.random.random([3, 4, 5, 6]).astype("float32")
+        self.input = np.random.random([3, 4, 5, 6]).astype("float64")
         self.starts = [-3, 0, 2]
         self.ends = [3, 100, -1]
         self.axes = [0, 1, 3]

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -38,7 +38,7 @@ class TestSoftmaxOp(OpTest):
         self.op_type = "softmax"
         self.use_cudnn = False
         self.use_mkldnn = False
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.shape = self.get_x_shape()
         self.axis = self.get_axis()

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -118,8 +118,8 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
         self.initParams()
         self.op_type = "softmax_with_cross_entropy"
 
-        # NOTE: numpy float16 have very low accuracy, use float32 for numpy check.
-        logits = np.random.uniform(0.1, 1.0, self.shape).astype(np.float32)
+        # NOTE: numpy float16 have very low accuracy, use float64 for numpy check.
+        logits = np.random.uniform(0.1, 1.0, self.shape).astype(np.float64)
         softmax = np.apply_along_axis(stable_softmax, self.axis, logits)
 
         axis_dim = self.shape[self.axis]

--- a/python/paddle/fluid/tests/unittests/test_space_to_depth_op.py
+++ b/python/paddle/fluid/tests/unittests/test_space_to_depth_op.py
@@ -58,9 +58,9 @@ class TestSpaceToDepthOp(OpTest):
         self.one_d_len = 32 * 48 * 3 * 3
 
         self.blocksize = 2
-        self.x = np.random.random(self.ori_shape).astype('float32')
+        self.x = np.random.random(self.ori_shape).astype('float64')
         self.x_1d = np.reshape(self.x, self.one_d_len)
-        self.out = np.zeros(self.infered_shape).astype('float32')
+        self.out = np.zeros(self.infered_shape).astype('float64')
         self.out_1d = np.reshape(self.out, self.one_d_len)
         self.forward = 1
 
@@ -82,9 +82,9 @@ class TestSpaceToDepthOpBasic(TestSpaceToDepthOp):
         self.one_d_len = 32 * 32 * 3 * 3
 
         self.blocksize = 2
-        self.x = np.random.random(self.ori_shape).astype('float32')
+        self.x = np.random.random(self.ori_shape).astype('float64')
         self.x_1d = np.reshape(self.x, self.one_d_len)
-        self.out = np.zeros(self.infered_shape).astype('float32')
+        self.out = np.zeros(self.infered_shape).astype('float64')
         self.out_1d = np.reshape(self.out, self.one_d_len)
         self.forward = 1
 
@@ -110,9 +110,9 @@ class TestSpaceToDepthOpWithStride3(TestSpaceToDepthOp):
         self.one_d_len = 32 * 81 * 2 * 2
 
         self.blocksize = 3
-        self.x = np.random.random(self.ori_shape).astype('float32')
+        self.x = np.random.random(self.ori_shape).astype('float64')
         self.x_1d = np.reshape(self.x, self.one_d_len)
-        self.out = np.zeros(self.infered_shape).astype('float32')
+        self.out = np.zeros(self.infered_shape).astype('float64')
         self.out_1d = np.reshape(self.out, self.one_d_len)
         self.forward = 1
 
@@ -124,9 +124,9 @@ class TestSpaceToDepthOpWithNotSquare(TestSpaceToDepthOp):
         self.one_d_len = 32 * 81 * 3 * 2
 
         self.blocksize = 3
-        self.x = np.random.random(self.ori_shape).astype('float32')
+        self.x = np.random.random(self.ori_shape).astype('float64')
         self.x_1d = np.reshape(self.x, self.one_d_len)
-        self.out = np.zeros(self.infered_shape).astype('float32')
+        self.out = np.zeros(self.infered_shape).astype('float64')
         self.out_1d = np.reshape(self.out, self.one_d_len)
         self.forward = 1
 

--- a/python/paddle/fluid/tests/unittests/test_spectral_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_spectral_norm_op.py
@@ -49,9 +49,9 @@ class TestSpectralNormOpNoGrad(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = 'spectral_norm'
-        weight = np.random.random(self.weight_shape).astype('float32')
-        u = np.random.normal(0., 1., self.u_shape).astype('float32')
-        v = np.random.normal(0., 1., self.v_shape).astype('float32')
+        weight = np.random.random(self.weight_shape).astype('float64')
+        u = np.random.normal(0., 1., self.u_shape).astype('float64')
+        v = np.random.normal(0., 1., self.v_shape).astype('float64')
 
         self.attrs = {
             "dim": self.dim,

--- a/python/paddle/fluid/tests/unittests/test_split_and_merge_lod_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_split_and_merge_lod_tensor_op.py
@@ -139,7 +139,7 @@ class TestCPUSplitMergeLoDTensorGrad(unittest.TestCase):
         program = Program()
         with program_guard(program):
             x = layers.data(
-                name='x', shape=[1], dtype='float32', stop_gradient=False)
+                name='x', shape=[1], dtype='float64', stop_gradient=False)
             y = layers.data(
                 name='y', shape=[1], dtype='bool', stop_gradient=False)
 
@@ -153,7 +153,7 @@ class TestCPUSplitMergeLoDTensorGrad(unittest.TestCase):
             append_backward(mean)
 
         tensor = core.LoDTensor()
-        tensor.set(np.arange(10).reshape(10, 1).astype('float32'), place)
+        tensor.set(np.arange(10).reshape(10, 1).astype('float64'), place)
         tensor.set_recursive_sequence_lengths([[3, 6, 1]])
 
         mask_np = np.array([0, 1, 0]).astype('bool')

--- a/python/paddle/fluid/tests/unittests/test_split_op.py
+++ b/python/paddle/fluid/tests/unittests/test_split_op.py
@@ -23,7 +23,7 @@ class TestSplitOp(OpTest):
     def setUp(self):
         self._set_op_type()
         axis = 1
-        x = np.random.random((4, 5, 6)).astype('float32')
+        x = np.random.random((4, 5, 6)).astype('float64')
         out = np.split(x, [2, 3], axis)
         self.inputs = {'X': x}
         self.attrs = {'axis': axis, 'sections': [2, 1, 2]}

--- a/python/paddle/fluid/tests/unittests/test_split_selected_rows_op.py
+++ b/python/paddle/fluid/tests/unittests/test_split_selected_rows_op.py
@@ -45,7 +45,7 @@ class TestSpliteSelectedRows(unittest.TestCase):
         x = scope.var('X').get_selected_rows()
         x.set_rows(rows)
         x.set_height(height)
-        np_array = np.ones((len(rows), row_numel)).astype("float32")
+        np_array = np.ones((len(rows), row_numel)).astype("float64")
         np_array[0, 0] = 2.0
         np_array[2, 1] = 4.0
         np_array[4, 1] = 8.0
@@ -103,7 +103,7 @@ class TestSpliteSelectedRows(unittest.TestCase):
         out0_grad.set_rows(rows0)
         out0_grad.set_height(height)
         out0_grad_tensor = out0_grad.get_tensor()
-        np_array = np.ones((len(rows0), row_numel)).astype("float32")
+        np_array = np.ones((len(rows0), row_numel)).astype("float64")
         out0_grad_tensor.set(np_array, place)
 
         out1_grad = scope.var("out1@GRAD").get_selected_rows()
@@ -111,7 +111,7 @@ class TestSpliteSelectedRows(unittest.TestCase):
         out1_grad.set_rows(rows1)
         out1_grad.set_height(height)
         out1_grad_tensor = out1_grad.get_tensor()
-        np_array = np.ones((len(rows1), row_numel)).astype("float32")
+        np_array = np.ones((len(rows1), row_numel)).astype("float64")
         out1_grad_tensor.set(np_array, place)
 
         x_grad = scope.var("X@GRAD").get_selected_rows()

--- a/python/paddle/fluid/tests/unittests/test_spp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_spp_op.py
@@ -25,7 +25,7 @@ class TestSppOp(OpTest):
     def setUp(self):
         self.op_type = "spp"
         self.init_test_case()
-        input = np.random.random(self.shape).astype("float32")
+        input = np.random.random(self.shape).astype("float64")
         nsize, csize, hsize, wsize = input.shape
         out_level_flatten = []
         for i in range(self.pyramid_height):
@@ -50,13 +50,13 @@ class TestSppOp(OpTest):
             else:
                 output = np.concatenate((output, out_level_flatten[i]), 1)
         # output = np.concatenate(out_level_flatten.tolist(), 0);
-        self.inputs = {'X': input.astype('float32'), }
+        self.inputs = {'X': input.astype('float64'), }
         self.attrs = {
             'pyramid_height': self.pyramid_height,
             'pooling_type': self.pool_type
         }
 
-        self.outputs = {'Out': output.astype('float32')}
+        self.outputs = {'Out': output.astype('float64')}
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/test_squared_l2_distance_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squared_l2_distance_op.py
@@ -23,8 +23,8 @@ class TestSquaredL2DistanceOp_f0(OpTest):
     def setUp(self):
         self.op_type = "squared_l2_distance"
         self.inputs = {
-            'X': np.random.uniform(0.1, 0.6, (2, 3)).astype("float32"),
-            'Y': np.random.uniform(0.1, 0.6, (2, 3)).astype("float32")
+            'X': np.random.uniform(0.1, 0.6, (2, 3)).astype("float64"),
+            'Y': np.random.uniform(0.1, 0.6, (2, 3)).astype("float64")
         }
         sub_res = self.inputs['X'] - self.inputs['Y']
         output = sub_res * sub_res
@@ -44,8 +44,8 @@ class TestSquaredL2DistanceOp_f1(OpTest):
     def setUp(self):
         self.op_type = "squared_l2_distance"
         self.inputs = {
-            'X': np.random.uniform(0.1, 0.6, (2, 3)).astype("float32"),
-            'Y': np.random.uniform(0.1, 0.6, (1, 3)).astype("float32")
+            'X': np.random.uniform(0.1, 0.6, (2, 3)).astype("float64"),
+            'Y': np.random.uniform(0.1, 0.6, (1, 3)).astype("float64")
         }
         sub_res = self.inputs['X'] - self.inputs['Y']
         output = sub_res * sub_res
@@ -65,8 +65,8 @@ class TestSquaredL2DistanceOp_f2(OpTest):
     def setUp(self):
         self.op_type = "squared_l2_distance"
         self.inputs = {
-            'X': np.random.uniform(0.1, 0.6, (2, 3, 4)).astype("float32"),
-            'Y': np.random.uniform(0.1, 0.6, (1, 3, 4)).astype("float32")
+            'X': np.random.uniform(0.1, 0.6, (2, 3, 4)).astype("float64"),
+            'Y': np.random.uniform(0.1, 0.6, (1, 3, 4)).astype("float64")
         }
         sub_res = self.inputs['X'] - self.inputs['Y']
         sub_res = sub_res.reshape((2, 3 * 4))

--- a/python/paddle/fluid/tests/unittests/test_squared_l2_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squared_l2_norm_op.py
@@ -28,7 +28,7 @@ class TestL2LossOp(OpTest):
         self.op_type = "squared_l2_norm"
         self.max_relative_error = 0.05
 
-        X = np.random.uniform(-1, 1, (13, 19)).astype("float32")
+        X = np.random.uniform(-1, 1, (13, 19)).astype("float64")
         X[np.abs(X) < self.max_relative_error] = 0.1
         self.inputs = {'X': X}
         self.outputs = {'Out': np.square(LA.norm(X))}

--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -25,11 +25,11 @@ class TestSqueezeOp(OpTest):
     def setUp(self):
         self.op_type = "squeeze2"
         self.init_test_case()
-        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
-            "XShape": np.random.random(self.ori_shape).astype("float32")
+            "XShape": np.random.random(self.ori_shape).astype("float64")
         }
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_sum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sum_op.py
@@ -36,7 +36,7 @@ class TestSumOp(OpTest):
         self.attrs = {'use_mkldnn': self.use_mkldnn}
 
     def init_kernel_type(self):
-        self.dtype = np.float32
+        self.dtype = np.float64
 
     def test_check_output(self):
         self.check_output()
@@ -53,7 +53,7 @@ class TestSelectedRowsSumOp(OpTest):
         self.height = 10
         self.row_numel = 12
         self.rows = [0, 1, 2, 3, 4, 5, 6]
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
 
     def check_with_place(self, place, inplace):

--- a/python/paddle/fluid/tests/unittests/test_sync_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sync_batch_norm_op.py
@@ -25,7 +25,7 @@ from paddle.fluid import compiler
 
 class TestSyncBatchNormOpTraining(unittest.TestCase):
     def setUp(self):
-        #self.dtype = np.float32
+        #self.dtype = np.float64
         self.dtype = np.float64
         self.N = 32
         self.C = 16

--- a/python/paddle/fluid/tests/unittests/test_teacher_student_sigmoid_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_teacher_student_sigmoid_loss_op.py
@@ -33,9 +33,9 @@ class TestTeacherStudentSigmoidLossOp(OpTest):
         self.inputs = {
             'X': logit(
                 np.random.uniform(0, 1, (batch_size, num_classes))
-                .astype("float32")),
+                .astype("float64")),
             'Label': np.random.uniform(0, 2, (batch_size, num_classes))
-            .astype("float32")
+            .astype("float64")
         }
         outs = []
         for index, label in enumerate(self.inputs["Label"]):

--- a/python/paddle/fluid/tests/unittests/test_temporal_shift_op.py
+++ b/python/paddle/fluid/tests/unittests/test_temporal_shift_op.py
@@ -39,7 +39,7 @@ class TestTemporalShift(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = 'temporal_shift'
-        x = np.random.random(self.x_shape).astype('float32')
+        x = np.random.random(self.x_shape).astype('float64')
 
         self.attrs = {
             "seg_num": self.seg_num,

--- a/python/paddle/fluid/tests/unittests/test_top_k_op.py
+++ b/python/paddle/fluid/tests/unittests/test_top_k_op.py
@@ -24,7 +24,7 @@ class TestTopkOp(OpTest):
         self.variable_k = False
         self.set_args()
         self.op_type = "top_k"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_dtype()
 
         k = self.top_k
@@ -65,7 +65,7 @@ class TestTopkOp3d(OpTest):
     def setUp(self):
         self.op_type = "top_k"
         k = 1
-        input = np.random.random((32, 2, 84)).astype("float32")
+        input = np.random.random((32, 2, 84)).astype("float64")
         input_flat_2d = input.reshape(64, 84)
         output = np.ndarray((64, k))
         indices = np.ndarray((64, k)).astype("int64")
@@ -92,7 +92,7 @@ class TestTopkOp1(OpTest):
         self.op_type = "top_k"
         k = 2
         m = 2056
-        input = np.random.random(m).astype("float32")
+        input = np.random.random(m).astype("float64")
         output = np.ndarray(k)
         indices = np.ndarray(k).astype("int64")
 
@@ -114,7 +114,7 @@ class TestTopkOp2(OpTest):
         self.op_type = "top_k"
         k = 1
         m = 2056
-        input = np.random.random((m, 84)).astype("float32")
+        input = np.random.random((m, 84)).astype("float64")
         output = np.ndarray((m, k))
         indices = np.ndarray((m, k)).astype("int64")
 

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -23,13 +23,13 @@ class TestTransposeOp(OpTest):
     def setUp(self):
         self.init_op_type()
         self.initTestCase()
-        self.inputs = {'X': np.random.random(self.shape).astype("float32")}
+        self.inputs = {'X': np.random.random(self.shape).astype("float64")}
         self.attrs = {
             'axis': list(self.axis),
             'use_mkldnn': self.use_mkldnn,
         }
         self.outputs = {
-            'XShape': np.random.random(self.shape).astype("float32"),
+            'XShape': np.random.random(self.shape).astype("float64"),
             'Out': self.inputs['X'].transpose(self.axis)
         }
 

--- a/python/paddle/fluid/tests/unittests/test_tree_conv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_tree_conv_op.py
@@ -64,19 +64,19 @@ class TestTreeConvOp(OpTest):
         adj = np.tile(adj, (self.batch_size, 1, 1))
         self.op_type = 'tree_conv'
         vectors = np.random.random(
-            (self.batch_size, self.n, self.fea_size)).astype('float32')
+            (self.batch_size, self.n, self.fea_size)).astype('float64')
         self.inputs = {
             'EdgeSet': adj,
             'NodesVector': vectors,
             'Filter': np.random.random((self.fea_size, 3, self.output_size,
-                                        self.num_filters)).astype('float32')
+                                        self.num_filters)).astype('float64')
         }
         self.attrs = {'max_depth': self.max_depth}
         vectors = []
         for i in range(self.batch_size):
             vector = self.get_output_naive(i)
             vectors.append(vector)
-        self.outputs = {'Out': np.array(vectors).astype('float32'), }
+        self.outputs = {'Out': np.array(vectors).astype('float64'), }
 
     def test_check_output(self):
         self.check_output()
@@ -91,7 +91,7 @@ class TestTreeConvOp(OpTest):
         for e in st:
             og[e[0]].append(e[1])
         patches = collect_node_patch(og, self.max_depth)
-        W = np.array(self.inputs['Filter']).astype('float32')
+        W = np.array(self.inputs['Filter']).astype('float64')
         W = np.transpose(W, axes=[1, 0, 2, 3])
         vec = []
         for i, patch in enumerate(patches, 1):
@@ -103,7 +103,7 @@ class TestTreeConvOp(OpTest):
                 eta_r = (1.0 - eta_t) * (1.0 - eta_l)
                 x = self.inputs['NodesVector'][batch_id][v[0] - 1]
                 eta = np.array([eta_l, eta_r, eta_t]).reshape(
-                    (3, 1)).astype('float32')
+                    (3, 1)).astype('float64')
                 Wconvi = np.tensordot(eta, W, axes=([0], [0]))
                 x = np.array(x).reshape((1, 1, self.fea_size))
                 res = np.tensordot(x, Wconvi, axes=2)
@@ -114,7 +114,7 @@ class TestTreeConvOp(OpTest):
             [
                 vec, np.zeros(
                     (self.n - vec.shape[0], W.shape[2], W.shape[3]),
-                    dtype='float32')
+                    dtype='float64')
             ],
             axis=0)
         return vec

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_batch_size_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_batch_size_like_op.py
@@ -22,9 +22,9 @@ from op_test import OpTest
 class TestUniformRandomBatchSizeLike(OpTest):
     def setUp(self):
         self.op_type = "uniform_random_batch_size_like"
-        self.inputs = {'Input': np.zeros((500, 2000), dtype="float32")}
+        self.inputs = {'Input': np.zeros((500, 2000), dtype="float64")}
         self.attrs = {'min': 1., 'max': 2., 'shape': [-1, 2000]}
-        self.outputs = {'Out': np.zeros((500, 2000), dtype='float32')}
+        self.outputs = {'Out': np.zeros((500, 2000), dtype='float64')}
 
     def test_check_output(self):
         self.check_output_customized(self.verify_output)
@@ -32,7 +32,7 @@ class TestUniformRandomBatchSizeLike(OpTest):
     def verify_output(self, outs):
         self.assertEqual(outs[0].shape, (500, 2000))
         hist, _ = np.histogram(outs[0], range=(1, 2))
-        hist = hist.astype("float32")
+        hist = hist.astype("float64")
         hist /= float(outs[0].size)
         prob = 0.1 * np.ones((10))
         self.assertTrue(

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
@@ -23,7 +23,7 @@ from paddle.fluid.op import Operator
 
 def output_hist(out):
     hist, _ = np.histogram(out, range=(-5, 10))
-    hist = hist.astype("float32")
+    hist = hist.astype("float64")
     hist /= float(out.size)
     prob = 0.1 * np.ones((10))
     return hist, prob
@@ -39,7 +39,7 @@ class TestUniformRandomOp(OpTest):
             "max": 10.0,
             "seed": 10
         }
-        self.outputs = {"Out": np.zeros((1000, 784)).astype("float32")}
+        self.outputs = {"Out": np.zeros((1000, 784)).astype("float64")}
 
     def test_check_output(self):
         self.check_output_customized(self.verify_output)

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -41,7 +41,7 @@ class TestUnpoolOp(OpTest):
     def setUp(self):
         self.op_type = "unpool"
         self.init_test_case()
-        pre_input = np.random.random(self.shape).astype("float32")
+        pre_input = np.random.random(self.shape).astype("float64")
         nsize, csize, hsize, wsize = pre_input.shape
         hsize_out = (hsize - self.ksize[0] + 2 * self.paddings[0]) // \
                 self.strides[0] + 1
@@ -67,9 +67,9 @@ class TestUnpoolOp(OpTest):
                                 (r_start + arg // self.ksize[1]) * wsize + \
                                 c_start + arg % self.ksize[1]
         output = self.unpool2d_forward_naive(input, indices, self.ksize, \
-                self.strides, self.paddings).astype("float32")
+                self.strides, self.paddings).astype("float64")
         self.inputs = {
-            'X': input.astype('float32'),
+            'X': input.astype('float64'),
             'Indices': indices.astype('int32')
         }
         self.attrs = {
@@ -78,7 +78,7 @@ class TestUnpoolOp(OpTest):
             'ksize': self.ksize,
             'unpooling_type': self.unpooling_type,
         }
-        self.outputs = {'Out': output.astype('float32')}
+        self.outputs = {'Out': output.astype('float64')}
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
@@ -25,11 +25,11 @@ class TestUnsqueezeOp(OpTest):
     def setUp(self):
         self.init_test_case()
         self.op_type = "unsqueeze2"
-        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float64")}
         self.init_attrs()
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.new_shape),
-            "XShape": np.random.random(self.ori_shape).astype("float32")
+            "XShape": np.random.random(self.ori_shape).astype("float64")
         }
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_unstack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unstack_op.py
@@ -21,7 +21,7 @@ class TestUnStackOpBase(OpTest):
     def initDefaultParameters(self):
         self.input_dim = (5, 6, 7)
         self.axis = 0
-        self.dtype = 'float32'
+        self.dtype = 'float64'
 
     def initParameters(self):
         pass

--- a/python/paddle/fluid/tests/unittests/test_while_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_op.py
@@ -25,16 +25,16 @@ import numpy
 class TestWhileOp(unittest.TestCase):
     def test_simple_forward(self):
         d0 = layers.data(
-            "d0", shape=[10], append_batch_size=False, dtype='float32')
+            "d0", shape=[10], append_batch_size=False, dtype='float64')
         d1 = layers.data(
-            "d1", shape=[10], append_batch_size=False, dtype='float32')
+            "d1", shape=[10], append_batch_size=False, dtype='float64')
         d2 = layers.data(
-            "d2", shape=[10], append_batch_size=False, dtype='float32')
+            "d2", shape=[10], append_batch_size=False, dtype='float64')
 
         i = layers.zeros(shape=[1], dtype='int64')
         i.stop_gradient = True
 
-        init = layers.zeros(shape=[10], dtype='float32')
+        init = layers.zeros(shape=[10], dtype='float64')
         mem_array = layers.array_write(x=init, i=i)
         data_array = layers.array_write(x=d0, i=i)
 
@@ -88,7 +88,7 @@ class TestWhileOp(unittest.TestCase):
         d = []
 
         for i in range(3):
-            d.append(numpy.random.random(size=[10]).astype('float32'))
+            d.append(numpy.random.random(size=[10]).astype('float64'))
 
         outs = exe.run(feed={'d0': d[0],
                              'd1': d[1],

--- a/python/paddle/fluid/tests/unittests/test_yolo_box_op.py
+++ b/python/paddle/fluid/tests/unittests/test_yolo_box_op.py
@@ -53,7 +53,7 @@ def YoloBox(x, img_size, attrs):
     pred_conf = sigmoid(x[:, :, :, :, 4:5])
     pred_conf[pred_conf < conf_thresh] = 0.
     pred_score = sigmoid(x[:, :, :, :, 5:]) * pred_conf
-    pred_box = pred_box * (pred_conf > 0.).astype('float32')
+    pred_box = pred_box * (pred_conf > 0.).astype('float64')
 
     pred_box = pred_box.reshape((n, -1, 4))
     pred_box[:, :, :2], pred_box[:, :, 2:4] = \
@@ -79,7 +79,7 @@ class TestYoloBoxOp(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = 'yolo_box'
-        x = np.random.random(self.x_shape).astype('float32')
+        x = np.random.random(self.x_shape).astype('float64')
         img_size = np.random.randint(10, 20, self.imgsize_shape).astype('int32')
 
         self.attrs = {


### PR DESCRIPTION
change the dtype of op's unittests from float to double, and registe double for the operaters which support double computing, test=develop