### PR TITLE
BugFix: there's a logic error in 'softrelu' backward

### DIFF
--- a/paddle/fluid/operators/activation_op.h
+++ b/paddle/fluid/operators/activation_op.h
@@ -966,7 +966,7 @@ struct SoftReluGradFunctor : public BaseActivationFunctor<T> {
             typename dX>
   void operator()(Device d, X x, Out out, dOut dout, dX dx) const {
     auto tmp = static_cast<T>(threshold);
-    auto temp = ((out > -tmp) * (out < tmp)).template cast<T>().eval();
+    auto temp = ((x > -tmp) * (x < tmp)).template cast<T>().eval();
     dx.device(d) = dout * (static_cast<T>(1) - (-out).exp()) * temp;
   }
 


### PR DESCRIPTION
there's a logic error in 'softrelu' backward: we can't use 'out' to determine whether the gradiant is 0, since the out is not equal to input 'x' as in relu.