### PR TITLE
Add more traceback to py_reader error msg

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -46,6 +46,7 @@
 | reyoung | Yang Yu |
 | Sand3r- | Michal Gallus |
 | sfraczek | Sylwester Fraczek |
+| sneaxiy | Jin-Le Zeng |
 | Superjom | Chun-Wei Yan |
 | tensor-tang | Jian Tang |
 | tianbingsz | Tian-Bing Xu |

--- a/python/paddle/fluid/layers/io.py
+++ b/python/paddle/fluid/layers/io.py
@@ -17,6 +17,7 @@ from ..wrapped_decorator import signature_safe_contextmanager
 import multiprocessing
 import os
 import six
+import sys
 import threading
 
 from ..data_feeder import DataFeeder
@@ -595,7 +596,7 @@ def _py_reader(capacity,
             except Exception as ex:
                 feed_queue.close()
                 logging.warn('Your decorated reader has raised an exception!')
-                raise ex
+                six.reraise(*sys.exc_info())
 
         reader.thread = threading.Thread(target=__provider_thread__)
         reader.thread.daemon = True

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from . import core, dygraph
+import sys
 import six
 import warnings
 import numpy as np
@@ -443,7 +444,7 @@ class PyReader(object):
             except Exception as ex:
                 self._queue.close()
                 logging.warn('Your decorated reader has raised an exception!')
-                raise ex
+                six.reraise(*sys.exc_info())
 
         self._thread = threading.Thread(target=__thread_main__)
         self._thread.daemon = True


### PR DESCRIPTION
Before this PR, the error message is something like:
```
WARNING:root:Your decorated reader has raised an exception!
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/reader.py", line 448, in __thread_main__
    raise ex
AttributeError: 'int' object has no attribute 'unknown'
```

As you can see, there is no useful traceback for debugging. 

After this PR, the error message becomes:
```
WARNING:root:Your decorated reader has raised an exception!
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 754, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/reader.py", line 448, in __thread_main__
    six.reraise(*sys.exc_info())
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/reader.py", line 431, in __thread_main__
    for tensors in self._tensor_reader():
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/reader.py", line 610, in __tensor_reader_impl__
    for slots in paddle_reader():
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/data_feeder.py", line 418, in __reader_creator__
    for item in reader():
  File "/usr/local/lib/python2.7/dist-packages/paddle/batch.py", line 35, in batch_reader
    for instance in r:
  File "py_reader_error_msg.py", line 17, in fake_reader
    call2(i)
  File "py_reader_error_msg.py", line 12, in call2
    call1(i)
  File "py_reader_error_msg.py", line 9, in call1
    call0(i)
  File "py_reader_error_msg.py", line 6, in call0
    print(i.unknown)
AttributeError: 'int' object has no attribute 'unknown'
```

More detailed stack tracing can be found (call0, call1, call2 are functions I use to simulate nested function calls).

Fix #18320.