### PR TITLE
change the default value of summarize from -1 to 20 in Print API to improve ease of use

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -351,7 +351,7 @@ paddle.fluid.layers.StaticRNN.step_input (ArgSpec(args=['self', 'x'], varargs=No
 paddle.fluid.layers.StaticRNN.step_output (ArgSpec(args=['self', 'o'], varargs=None, keywords=None, defaults=None), ('document', '252890d4c3199a7623ab8667e13fd837'))
 paddle.fluid.layers.StaticRNN.update_memory (ArgSpec(args=['self', 'mem', 'var'], varargs=None, keywords=None, defaults=None), ('document', '7a0000520f179f35239956a5ba55119f'))
 paddle.fluid.layers.reorder_lod_tensor_by_rank (ArgSpec(args=['x', 'rank_table'], varargs=None, keywords=None, defaults=None), ('document', '5b552a1f0f7eb4dacb768a975ba15d08'))
-paddle.fluid.layers.Print (ArgSpec(args=['input', 'first_n', 'message', 'summarize', 'print_tensor_name', 'print_tensor_type', 'print_tensor_shape', 'print_tensor_lod', 'print_phase'], varargs=None, keywords=None, defaults=(-1, None, 20, True, True, True, True, 'both')), ('document', '75276e836af5b2c6ca51dd0e7b2c9bfd'))
+paddle.fluid.layers.Print (ArgSpec(args=['input', 'first_n', 'message', 'summarize', 'print_tensor_name', 'print_tensor_type', 'print_tensor_shape', 'print_tensor_lod', 'print_phase'], varargs=None, keywords=None, defaults=(-1, None, 20, True, True, True, True, 'both')), ('document', '3130bed32922b9fd84ce2dea6250f635'))
 paddle.fluid.layers.is_empty (ArgSpec(args=['x', 'cond'], varargs=None, keywords=None, defaults=(None,)), ('document', '3011dc695f490afdf504dc24f628319a'))
 paddle.fluid.layers.sigmoid (ArgSpec(args=['x', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', 'd894323f31a913c4a5bd4cc764f6a76a'))
 paddle.fluid.layers.logsigmoid (ArgSpec(args=['x', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', 'd083538e3439ed6b28b00207e0f321d5'))

--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -351,7 +351,7 @@ paddle.fluid.layers.StaticRNN.step_input (ArgSpec(args=['self', 'x'], varargs=No
 paddle.fluid.layers.StaticRNN.step_output (ArgSpec(args=['self', 'o'], varargs=None, keywords=None, defaults=None), ('document', '252890d4c3199a7623ab8667e13fd837'))
 paddle.fluid.layers.StaticRNN.update_memory (ArgSpec(args=['self', 'mem', 'var'], varargs=None, keywords=None, defaults=None), ('document', '7a0000520f179f35239956a5ba55119f'))
 paddle.fluid.layers.reorder_lod_tensor_by_rank (ArgSpec(args=['x', 'rank_table'], varargs=None, keywords=None, defaults=None), ('document', '5b552a1f0f7eb4dacb768a975ba15d08'))
-paddle.fluid.layers.Print (ArgSpec(args=['input', 'first_n', 'message', 'summarize', 'print_tensor_name', 'print_tensor_type', 'print_tensor_shape', 'print_tensor_lod', 'print_phase'], varargs=None, keywords=None, defaults=(-1, None, -1, True, True, True, True, 'both')), ('document', 'ee6c70867d317b0a87094ed23546215f'))
+paddle.fluid.layers.Print (ArgSpec(args=['input', 'first_n', 'message', 'summarize', 'print_tensor_name', 'print_tensor_type', 'print_tensor_shape', 'print_tensor_lod', 'print_phase'], varargs=None, keywords=None, defaults=(-1, None, 20, True, True, True, True, 'both')), ('document', '75276e836af5b2c6ca51dd0e7b2c9bfd'))
 paddle.fluid.layers.is_empty (ArgSpec(args=['x', 'cond'], varargs=None, keywords=None, defaults=(None,)), ('document', '3011dc695f490afdf504dc24f628319a'))
 paddle.fluid.layers.sigmoid (ArgSpec(args=['x', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', 'd894323f31a913c4a5bd4cc764f6a76a'))
 paddle.fluid.layers.logsigmoid (ArgSpec(args=['x', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', 'd083538e3439ed6b28b00207e0f321d5'))

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -179,18 +179,26 @@ def Print(input,
            
            import paddle.fluid as fluid
            
-           input = fluid.layers.data(name="input", shape=[1, 28, 28], dtype='float32')
+           input = fluid.layers.fill_constant(shape=[10,2], value=3, dtype='int64')
            input = fluid.layers.Print(input, message="The content of input layer:")
-    
-    Output at runtime:
-        .. code-block:: console 
            
-           1564546375  The content of input layer:     The place is:CPUPlace
-           Tensor[input]
-               shape: [64,1,28,28]
-               dtype: f
-               data: -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
+           main_program = fluid.default_main_program()
+           exe = fluid.Executor(fluid.CPUPlace())
+           exe.run(main_program)
 
+    Output at runtime:
+        .. code-block:: bash 
+           
+           1564546375   The content of input layer:     The place is:CPUPlace
+           Tensor[fill_constant_0.tmp_0]
+               shape: [10,2,]
+               dtype: x
+               data: 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, 
+               
+           # The information of dtype at runtime may vary in different environments.
+           # Eg: 
+           #    If the dtype='int64' of Tensor y, the corresponding c++ type is int64_t.
+           #    The dtype of output is "x" ("x" is typeid(int64_t).name()) with MacOS and gcc4.8.2
     '''
     helper = LayerHelper('print' + "_" + input.name, **locals())
     output = helper.create_variable_for_type_inference(input.dtype)

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -137,7 +137,7 @@ def merge_lod_tensor(in_true, in_false, x, mask, level=0):
 def Print(input,
           first_n=-1,
           message=None,
-          summarize=-1,
+          summarize=20,
           print_tensor_name=True,
           print_tensor_type=True,
           print_tensor_shape=True,
@@ -179,11 +179,17 @@ def Print(input,
            
            import paddle.fluid as fluid
            
-           input = fluid.layers.data(name="input", shape=[4, 32, 32], dtype="float32")
-           input = fluid.layers.Print(input, message = "The content of input layer:")
-           # value = some_layer(...)
-           # Print(value, summarize=10,
-           #    message="The content of some_layer: ")
+           input = fluid.layers.data(name="input", shape=[1, 28, 28], dtype='float32')
+           input = fluid.layers.Print(input, message="The content of input layer:")
+    
+    Output at runtime:
+        .. code-block:: console 
+           
+           1564546375  The content of input layer:     The place is:CPUPlace
+           Tensor[input]
+               shape: [64,1,28,28]
+               dtype: f
+               data: -1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,
 
     '''
     helper = LayerHelper('print' + "_" + input.name, **locals())


### PR DESCRIPTION
**1.  change the default value:**

In API Print `paddle.fluid.layers.Print(input, first_n=-1, message=None, summarize=-1, print_tensor_name=True, print_tensor_type=True, print_tensor_shape=True, print_tensor_lod=True, print_phase='both'`
For example:  if the default value of summarize is -1, all elements of input x  will be  printed, it's not easy to use for users.
![image](https://user-images.githubusercontent.com/33742067/61679693-a71dcd00-ad39-11e9-8e0b-85a2e05372be.png)

If the default value of summarize is 20, 20 elements of input x  will be  printed by fault, which is better.
![image](https://user-images.githubusercontent.com/33742067/61679812-0a0f6400-ad3a-11e9-92b4-a8699b139d2c.png)

**2. change the doc of API Print**

- **before**

![image](https://user-images.githubusercontent.com/33742067/61969374-fa7b6e00-b00c-11e9-99c4-35a072917469.png)


- **after**
![image](https://user-images.githubusercontent.com/33742067/62788837-56102600-bafa-11e9-8d4c-b8835260f668.png)

![image](https://user-images.githubusercontent.com/33742067/62788844-59a3ad00-bafa-11e9-9d4b-05790abe74b0.png)


