### PR TITLE
[MKL-DNN] Fix to int8 performance regression (#18698)

### DIFF
--- a/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
@@ -83,11 +83,9 @@ std::string CreateKey(const paddle::framework::ExecutionContext& ctx,
                                      std::to_string(multi_input[0]->format()));
   if (platform::get_cur_mkldnn_session_id() ==
       platform::kMKLDNNSessionID_Default) {
-    auto tid = std::this_thread::get_id();
-    std::stringstream ss;
-    ss << tid;
     platform::MKLDNNHandler::AppendKey(&key, "-t:");
-    platform::MKLDNNHandler::AppendKey(&key, ss.str());
+    platform::MKLDNNHandler::AppendKey(
+        &key, platform::MKLDNNHandler::ThreadIDasStr());
   }
   return key;
 }

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -408,12 +408,21 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     std::shared_ptr<mkldnn::convolution_forward::primitive_desc> conv_pd;
     std::shared_ptr<platform::ConvMKLDNNHandler> handler;
 
-    auto prim_key = key + "@conv_p";
-    auto dst_key = key + "@dst_mem_p";
-    auto src_key = key + "@src_mem_p";
-    auto user_src_key = key + "@user_src_mem_p";
-    auto src_reorder_key = key + "@src_mem_preorder_p";
-    auto residual_reorder_key = key + "@residual_data_mem_preorder_p";
+    // This is workaround for hacky implementation
+    // of conv int8 mkl-dnn. Once conv fp32 and conv int8
+    // are merged/unified, this will disappear
+    std::string key_tid = "";
+    if (platform::get_cur_mkldnn_session_id() ==
+        platform::kMKLDNNSessionID_Default) {
+      key_tid = "-t:" + platform::MKLDNNHandler::ThreadIDasStr();
+    }
+
+    auto prim_key = key + key_tid + "@conv_p";
+    auto dst_key = key + key_tid + "@dst_mem_p";
+    auto src_key = key + key_tid + "@src_mem_p";
+    auto user_src_key = key + key_tid + "@user_src_mem_p";
+    auto src_reorder_key = key + key_tid + "@src_mem_preorder_p";
+    auto residual_reorder_key = key + key_tid + "@residual_data_mem_preorder_p";
 
     conv_p = std::static_pointer_cast<mkldnn::convolution_forward>(
         dev_ctx.GetBlob(prim_key));

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -34,14 +34,11 @@ class MKLDNNHandler {
   MKLDNNHandler(const MKLDNNDeviceContext& dev_ctx, mkldnn::engine engine,
                 const std::string& base_key)
       : dev_ctx_(dev_ctx), engine_(engine), key_common_(base_key) {
-    // TODO(jczaja): Make it faster
-    auto tid = std::this_thread::get_id();
-    std::stringstream ss;
-    ss << tid;
-    key_ = key_common_ + "-t:" + ss.str();
     if (platform::get_cur_mkldnn_session_id() !=
         platform::kMKLDNNSessionID_Default) {
       key_ = key_common_;
+    } else {
+      key_ = key_common_ + "-t:" + MKLDNNHandler::ThreadIDasStr();
     }
   }
 
@@ -203,6 +200,11 @@ class MKLDNNHandler {
       }
     }
     return target_memory_p;
+  }
+
+  static std::string ThreadIDasStr(void) {
+    return std::to_string(
+        std::hash<std::thread::id>()(std::this_thread::get_id()));
   }
 
   static std::string GetHash(mkldnn::memory::dims& operand_dims,  // NOLINT


### PR DESCRIPTION
Changes here are restoring performance of int8 convolution caused by muli-threading mechanisms introduction (issue #18698). 

Internal testing proved that there is performance improvement for int8 convolutional models