### PR TITLE
optimize error message for "embedding" and "cross_entropy" OP

### DIFF
--- a/paddle/fluid/operators/cross_entropy_op.h
+++ b/paddle/fluid/operators/cross_entropy_op.h
@@ -155,8 +155,11 @@ struct HardLabelCrossEntropyForwardFunctor {
   HOSTDEVICE void operator()(int64_t idx) const {
     auto label = label_[idx];
     if (label != ignore_index_) {
-      PADDLE_ASSERT_MSG(label >= 0 && label < feature_size_,
-                        "The label is out of the range.", label);
+      PADDLE_ASSERT_MSG(
+          label >= 0 && label < feature_size_,
+          "Received label(%ld) must be greater than or equal to zero, "
+          "and less than feature size(%ld)",
+          label, feature_size_);
       auto match_x = x_[idx * feature_size_ + label];
       y_[idx] = -math::TolerableValue<T>()(real_log(match_x));
       match_x_[idx] = match_x;

--- a/paddle/fluid/operators/cross_entropy_op.h
+++ b/paddle/fluid/operators/cross_entropy_op.h
@@ -155,11 +155,11 @@ struct HardLabelCrossEntropyForwardFunctor {
   HOSTDEVICE void operator()(int64_t idx) const {
     auto label = label_[idx];
     if (label != ignore_index_) {
-      PADDLE_ASSERT_MSG(
-          label >= 0 && label < feature_size_,
-          "Received label(%ld) must be greater than or equal to zero, "
-          "and less than feature size(%ld)",
-          label, feature_size_);
+      PADDLE_ASSERT_MSG(label >= 0 && label < feature_size_,
+                        "Variable value (label) of "
+                        "OP(fluid.layers.cross_entropy) expected >= 0 "
+                        "and < %ld, but got %ld. Please check label value.",
+                        feature_size_, label);
       auto match_x = x_[idx * feature_size_ + label];
       y_[idx] = -math::TolerableValue<T>()(real_log(match_x));
       match_x_[idx] = match_x;

--- a/paddle/fluid/operators/lookup_table_op.cu
+++ b/paddle/fluid/operators/lookup_table_op.cu
@@ -32,8 +32,12 @@ __global__ void LookupTable(T *output, const T *table, const int64_t *ids,
 
   while (idy < K) {
     int64_t id = ids[idy];
-    PADDLE_ASSERT_MSG(id >= 0, "received id:", id);
-    PADDLE_ASSERT_MSG(id < N, "received id:", id);
+    PADDLE_ASSERT_MSG(id >= 0, "Received id(%ld) must be greater than zero.",
+                      id);
+    PADDLE_ASSERT_MSG(id < N,
+                      "Received id(%ld) must be less than the first "
+                      "dimension size(%ld) of table.",
+                      id, N);
     T *out = output + idy * D;
     const T *tab = table + id * D;
     for (int i = idx; i < D; i += BlockDimX) {
@@ -59,9 +63,13 @@ __global__ void LookupTableGrad(T *table, const T *output, const int64_t *ids,
 
   while (idy < K) {
     int64_t id = ids[idy];
-    PADDLE_ASSERT_MSG(id >= 0, "received id:", id);
-    PADDLE_ASSERT_MSG(id < N, "received id:", id);
     const T *out = output + idy * D;
+    PADDLE_ASSERT_MSG(id >= 0, "Received id(%ld) must be greater than zero.",
+                      id);
+    PADDLE_ASSERT_MSG(id < N,
+                      "Received id(%ld) must be less than the first "
+                      "dimension size(%ld) of table.",
+                      id, N);
     T *tab = table + id * D;
     for (int i = idx; i < D; i += BlockDimX) {
       paddle::platform::CudaAtomicAdd(&tab[i], out[i]);

--- a/paddle/fluid/operators/lookup_table_op.cu
+++ b/paddle/fluid/operators/lookup_table_op.cu
@@ -32,12 +32,16 @@ __global__ void LookupTable(T *output, const T *table, const int64_t *ids,
 
   while (idy < K) {
     int64_t id = ids[idy];
-    PADDLE_ASSERT_MSG(id >= 0, "Received id(%ld) must be greater than zero.",
-                      id);
-    PADDLE_ASSERT_MSG(id < N,
-                      "Received id(%ld) must be less than the first "
-                      "dimension size(%ld) of table.",
-                      id, N);
+    PADDLE_ASSERT_MSG(
+        id >= 0,
+        "Variable value (input) of OP(fluid.layers.embedding) "
+        "expected >= 0 and < %ld, but got %ld. Please check input value.",
+        N, id);
+    PADDLE_ASSERT_MSG(
+        id < N,
+        "Variable value (input) of OP(fluid.layers.embedding) "
+        "expected >= 0 and < %ld, but got %ld. Please check input value.",
+        N, id);
     T *out = output + idy * D;
     const T *tab = table + id * D;
     for (int i = idx; i < D; i += BlockDimX) {
@@ -63,13 +67,17 @@ __global__ void LookupTableGrad(T *table, const T *output, const int64_t *ids,
 
   while (idy < K) {
     int64_t id = ids[idy];
+    PADDLE_ASSERT_MSG(
+        id >= 0,
+        "Variable value (input) of OP(fluid.layers.embedding) "
+        "expected >= 0 and < %ld, but got %ld. Please check input value.",
+        N, id);
+    PADDLE_ASSERT_MSG(
+        id < N,
+        "Variable value (input) of OP(fluid.layers.embedding) "
+        "expected >= 0 and < %ld, but got %ld. Please check input value.",
+        N, id);
     const T *out = output + idy * D;
-    PADDLE_ASSERT_MSG(id >= 0, "Received id(%ld) must be greater than zero.",
-                      id);
-    PADDLE_ASSERT_MSG(id < N,
-                      "Received id(%ld) must be less than the first "
-                      "dimension size(%ld) of table.",
-                      id, N);
     T *tab = table + id * D;
     for (int i = idx; i < D; i += BlockDimX) {
       paddle::platform::CudaAtomicAdd(&tab[i], out[i]);

--- a/paddle/fluid/operators/lookup_table_op.h
+++ b/paddle/fluid/operators/lookup_table_op.h
@@ -85,8 +85,18 @@ class LookupTableKernel : public framework::OpKernel<T> {
           if (padding_idx != kNoPadding && ids[i] == padding_idx) {
             memset(output + i * row_width, 0, row_width * sizeof(T));
           } else {
-            PADDLE_ENFORCE_LT(ids[i], row_number);
-            PADDLE_ENFORCE_GE(ids[i], 0, "ids %d", i);
+            PADDLE_ENFORCE_LT(
+                ids[i], row_number,
+                "Variable value (input) of OP(fluid.layers.embedding) "
+                "expected >= 0 and < %ld, but got %ld. Please check input "
+                "value.",
+                row_number, ids[i]);
+            PADDLE_ENFORCE_GE(
+                ids[i], 0,
+                "Variable value (input) of OP(fluid.layers.embedding) "
+                "expected >= 0 and < %ld, but got %ld. Please check input "
+                "value.",
+                row_number, ids[i]);
             memcpy(output + i * row_width, table + ids[i] * row_width,
                    row_width * sizeof(T));
           }
@@ -181,8 +191,8 @@ class LookupTableGradKernel : public framework::OpKernel<T> {
 
       auto *ids_data = ids->data<int64_t>();
 
-      int N = table_dim[0];
-      int D = table_dim[1];
+      int64_t N = table_dim[0];
+      int64_t D = table_dim[1];
 
       auto *d_output_data = d_output->data<T>();
       auto *d_table_data = d_table->mutable_data<T>(context.GetPlace());
@@ -194,8 +204,16 @@ class LookupTableGradKernel : public framework::OpKernel<T> {
           // the gradient of padding_idx should be 0, already done by memset, so
           // do nothing.
         } else {
-          PADDLE_ENFORCE_LT(ids_data[i], N);
-          PADDLE_ENFORCE_GE(ids_data[i], 0);
+          PADDLE_ENFORCE_LT(
+              ids_data[i], N,
+              "Variable value (input) of OP(fluid.layers.embedding) "
+              "expected >= 0 and < %ld, but got %ld. Please check input value.",
+              N, ids_data[i]);
+          PADDLE_ENFORCE_GE(
+              ids_data[i], 0,
+              "Variable value (input) of OP(fluid.layers.embedding) "
+              "expected >= 0 and < %ld, but got %ld. Please check input value.",
+              N, ids_data[i]);
           for (int j = 0; j < D; ++j) {
             d_table_data[ids_data[i] * D + j] += d_output_data[i * D + j];
           }

--- a/paddle/fluid/platform/assert.h
+++ b/paddle/fluid/platform/assert.h
@@ -38,11 +38,11 @@ limitations under the License. */
   } while (0)
 
 // NOTE: PADDLE_ASSERT is mainly used in CUDA Kernel or HOSTDEVICE function.
-#define PADDLE_ASSERT_MSG(_IS_NOT_ERROR, __MSG, __VAL)                       \
-  do {                                                                       \
-    if (!(_IS_NOT_ERROR)) {                                                  \
-      printf("Exception: %s:%d Assertion `%s` failed (%s %ld).\n", __FILE__, \
-             __LINE__, TOSTRING(_IS_NOT_ERROR), __MSG, __VAL);               \
-      EXIT();                                                                \
-    }                                                                        \
+#define PADDLE_ASSERT_MSG(_IS_NOT_ERROR, __FORMAT, ...)                   \
+  do {                                                                    \
+    if (!(_IS_NOT_ERROR)) {                                               \
+      printf("Exception: %s:%d Assertion `%s` failed. " __FORMAT "\n",    \
+             __FILE__, __LINE__, TOSTRING(_IS_NOT_ERROR), ##__VA_ARGS__); \
+      EXIT();                                                             \
+    }                                                                     \
   } while (0)


### PR DESCRIPTION
- optimize error message of `fluid.layers.embedding` OP and `fluid.layers.cross_entropy` OP
- modified `PADDLE_ASSERT_MSG` macro definition