### PR TITLE
Use fraction of available GPU instead of total GPU

### DIFF
--- a/paddle/fluid/memory/detail/buddy_allocator.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator.cc
@@ -171,7 +171,10 @@ void BuddyAllocator::Free(void* p) {
   }
 }
 
-size_t BuddyAllocator::Used() { return total_used_; }
+size_t BuddyAllocator::Used() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  return total_used_;
+}
 size_t BuddyAllocator::GetMinChunkSize() { return min_chunk_size_; }
 size_t BuddyAllocator::GetMaxChunkSize() { return max_chunk_size_; }
 

--- a/paddle/fluid/memory/detail/buddy_allocator_test.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator_test.cc
@@ -23,6 +23,7 @@ limitations under the License. */
 
 #ifdef PADDLE_WITH_CUDA
 DECLARE_double(fraction_of_gpu_memory_to_use);
+DECLARE_uint64(gpu_max_chunk_size_in_mb);
 DECLARE_uint64(initial_gpu_memory_in_mb);
 DECLARE_uint64(reallocate_gpu_memory_in_mb);
 #endif
@@ -31,9 +32,11 @@ namespace paddle {
 namespace memory {
 namespace detail {
 
-constexpr static int test_gpu_id = 0;
+constexpr static int TEST_GPU_ID = 0;
+constexpr static bool USE_SYSTEM_ALLOCATOR = true;
 
-void TestBuddyAllocator(BuddyAllocator* allocator, size_t size_bytes) {
+void TestBuddyAllocator(BuddyAllocator* allocator, size_t size_bytes,
+                        bool use_system_allocator = false) {
   bool freed = false;
   size_t used_bytes = allocator->Used();
 
@@ -41,15 +44,18 @@ void TestBuddyAllocator(BuddyAllocator* allocator, size_t size_bytes) {
     void* p = allocator->Alloc(size_bytes);
 
     EXPECT_NE(p, nullptr);
+
 #ifdef PADDLE_WITH_CUDA
     if (size_bytes < platform::GpuMaxChunkSize()) {
 #else
     if (size_bytes < platform::CpuMaxChunkSize()) {
 #endif
       // Not allocate from SystemAllocator
+      EXPECT_FALSE(use_system_allocator);
       EXPECT_GE(allocator->Used(), used_bytes + size_bytes);
     } else {
       // Allocate from SystemAllocator doesn't count in Used()
+      EXPECT_TRUE(use_system_allocator);
       EXPECT_EQ(allocator->Used(), used_bytes);
     }
 
@@ -68,26 +74,40 @@ void TestBuddyAllocator(BuddyAllocator* allocator, size_t size_bytes) {
 
 #ifdef PADDLE_WITH_CUDA
 TEST(BuddyAllocator, GpuFraction) {
+  // In a 16 GB machine, the pool size will be about 160 MB
   FLAGS_fraction_of_gpu_memory_to_use = 0.01;
 
+  FLAGS_gpu_max_chunk_size_in_mb = 500;
+  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(500 << 20));
+
   BuddyAllocator buddy_allocator(
-      std::unique_ptr<SystemAllocator>(new GPUAllocator(test_gpu_id)),
+      std::unique_ptr<SystemAllocator>(new GPUAllocator(TEST_GPU_ID)),
       platform::GpuMinChunkSize(), platform::GpuMaxChunkSize());
 
+  // Less than pool size
   TestBuddyAllocator(&buddy_allocator, 10);
   TestBuddyAllocator(&buddy_allocator, 10 << 10);
   TestBuddyAllocator(&buddy_allocator, 10 << 20);
-  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30));
+
+  // Less than max chunk size but exceed pool size
+  TestBuddyAllocator(&buddy_allocator, 499 << 20);
+  TestBuddyAllocator(&buddy_allocator, 499 << 20);
+  TestBuddyAllocator(&buddy_allocator, 499 << 20);
+
+  // Greater than max chunk size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30),
+                     USE_SYSTEM_ALLOCATOR);
 }
 
 TEST(BuddyAllocator, InitRealloc) {
   FLAGS_initial_gpu_memory_in_mb = 100;
   FLAGS_reallocate_gpu_memory_in_mb = 50;
 
-  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(100 << 20));
+  FLAGS_gpu_max_chunk_size_in_mb = 500;
+  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(500 << 20));
 
   BuddyAllocator buddy_allocator(
-      std::unique_ptr<SystemAllocator>(new GPUAllocator(test_gpu_id)),
+      std::unique_ptr<SystemAllocator>(new GPUAllocator(TEST_GPU_ID)),
       platform::GpuMinChunkSize(), platform::GpuMaxChunkSize());
 
   // Less then initial size and reallocate size
@@ -96,36 +116,96 @@ TEST(BuddyAllocator, InitRealloc) {
   TestBuddyAllocator(&buddy_allocator, 80 << 20);
   // Less then reallocate size and exceed pool
   TestBuddyAllocator(&buddy_allocator, 40 << 20);
-  // Greater then reallocate size and exceed pool
+  // Greater than reallocate size and exceed pool
   TestBuddyAllocator(&buddy_allocator, 80 << 20);
-  // Greater then initial size and reallocate size
-  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30));
+  // Less than max chunk size and exceed pool
+  TestBuddyAllocator(&buddy_allocator, 499 << 20);
+  // Greater than max chunk size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30),
+                     USE_SYSTEM_ALLOCATOR);
 }
 
 TEST(BuddyAllocator, ReallocSizeGreaterThanInit) {
   FLAGS_initial_gpu_memory_in_mb = 5;
   FLAGS_reallocate_gpu_memory_in_mb = 10;
 
-  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(10 << 20));
+  FLAGS_gpu_max_chunk_size_in_mb = 500;
+  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(500 << 20));
 
   BuddyAllocator buddy_allocator(
-      std::unique_ptr<SystemAllocator>(new GPUAllocator(test_gpu_id)),
+      std::unique_ptr<SystemAllocator>(new GPUAllocator(TEST_GPU_ID)),
       platform::GpuMinChunkSize(), platform::GpuMaxChunkSize());
 
-  // Less then initial size and reallocate size
+  // Less than initial size and reallocate size
   TestBuddyAllocator(&buddy_allocator, 1 << 20);
   // Between initial size and reallocate size and not exceed pool
   TestBuddyAllocator(&buddy_allocator, 3 << 20);
-  // Less then initial size and exceed pool
+  // Less than initial size and exceed pool
   TestBuddyAllocator(&buddy_allocator, 3 << 20);
-  // Less then reallocate size and not exceed pool (now pool is 15 MB, used 7
+  // Less than reallocate size and not exceed pool (now pool is 15 MB, used 7
   // MB)
   TestBuddyAllocator(&buddy_allocator, 7 << 20);
   // Less then reallocate size and exceed pool
   TestBuddyAllocator(&buddy_allocator, 8 << 20);
-  // Greater then initial size and reallocate size
-  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30));
+  // Less than max chunk size and exceed pool
+  TestBuddyAllocator(&buddy_allocator, 499 << 20);
+  // Greater than max trunk size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30),
+                     USE_SYSTEM_ALLOCATOR);
 }
+
+TEST(BuddyAllocator, VerySmallMaxChunkSize) {
+  // Very small max chunk size should trigger system allocator again and again
+  FLAGS_gpu_max_chunk_size_in_mb = 1;
+  // In a 16 GB machine, the pool size will be about 160 MB
+  FLAGS_fraction_of_gpu_memory_to_use = 0.01;
+
+  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(1 << 20));
+
+  BuddyAllocator buddy_allocator(
+      std::unique_ptr<SystemAllocator>(new GPUAllocator(TEST_GPU_ID)),
+      platform::GpuMinChunkSize(), platform::GpuMaxChunkSize());
+
+  // Less than max chunk size and pool size
+  TestBuddyAllocator(&buddy_allocator, 1 << 10);
+  TestBuddyAllocator(&buddy_allocator, 2 << 10);
+  TestBuddyAllocator(&buddy_allocator, 3 << 10);
+
+  // Greater than max chunk size and less than the pool size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(2 << 20),
+                     USE_SYSTEM_ALLOCATOR);
+
+  // Greater tahn max chunk size and greater than the pool size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30),
+                     USE_SYSTEM_ALLOCATOR);
+}
+
+TEST(BuddyAllocator, VerySmallMaxChunkSizeRealloc) {
+  // Very small max chunk size should trigger system allocator again and again
+  FLAGS_gpu_max_chunk_size_in_mb = 2;
+  FLAGS_initial_gpu_memory_in_mb = 5;
+  FLAGS_reallocate_gpu_memory_in_mb = 8;
+
+  EXPECT_EQ(platform::GpuMaxChunkSize(), static_cast<size_t>(2 << 20));
+
+  BuddyAllocator buddy_allocator(
+      std::unique_ptr<SystemAllocator>(new GPUAllocator(TEST_GPU_ID)),
+      platform::GpuMinChunkSize(), platform::GpuMaxChunkSize());
+
+  // Less than max chunk size and pool size
+  TestBuddyAllocator(&buddy_allocator, 1 << 20);
+  // Greater than max chunk size and less than the pool size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(3 << 20),
+                     USE_SYSTEM_ALLOCATOR);
+  // Greater tahn max chunk size and greater than the pool size
+  TestBuddyAllocator(&buddy_allocator, 2 * static_cast<size_t>(1 << 30),
+                     USE_SYSTEM_ALLOCATOR);
+  // Less than max chunk size and exceed pool size to trigger refilling
+  for (int i = 0; i < 16; ++i) {
+    TestBuddyAllocator(&buddy_allocator, 1 << 20);
+  }
+}
+
 #endif
 
 }  // namespace detail

--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -37,6 +37,11 @@ DEFINE_double(fraction_of_cpu_memory_to_use, 1,
               "reserve the rest for page tables, etc");
 DEFINE_uint64(initial_cpu_memory_in_mb, 500ul,
               "Initial CPU memory for PaddlePaddle, in MD unit.");
+DEFINE_uint64(cpu_max_chunk_size_in_mb, 4096ul,
+              "PaddlePaddle uses a memory pool to pre-load the CPU/GPU memory "
+              "to speed up memory allocation. But for large memory chunk whose"
+              " size is greater than this flag value, PaddlePaddle doesn't keep"
+              " the large chunk in the pool in order to save user's memory");
 
 DEFINE_double(
     fraction_of_cuda_pinned_memory_to_use, 0.5,

--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -37,11 +37,6 @@ DEFINE_double(fraction_of_cpu_memory_to_use, 1,
               "reserve the rest for page tables, etc");
 DEFINE_uint64(initial_cpu_memory_in_mb, 500ul,
               "Initial CPU memory for PaddlePaddle, in MD unit.");
-DEFINE_uint64(cpu_max_chunk_size_in_mb, 4096ul,
-              "PaddlePaddle uses a memory pool to pre-load the CPU/GPU memory "
-              "to speed up memory allocation. But for large memory chunk whose"
-              " size is greater than this flag value, PaddlePaddle doesn't keep"
-              " the large chunk in the pool in order to save user's memory");
 
 DEFINE_double(
     fraction_of_cuda_pinned_memory_to_use, 0.5,

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -60,7 +60,7 @@ DEFINE_uint64(reallocate_gpu_memory_in_mb, 0ul,
               "FLAGS_fraction_of_gpu_memory_to_use");
 
 DEFINE_uint64(gpu_max_chunk_size_in_mb, 4096ul,
-              "PaddlePaddle uses a memory pool to pre-load the CPU/GPU memory "
+              "PaddlePaddle uses a memory pool to pre-load the GPU memory "
               "to speed up memory allocation. But for large memory chunk whose"
               " size is greater than this flag value, PaddlePaddle doesn't keep"
               " the large chunk in the pool in order to save user's memory");

--- a/paddle/fluid/platform/gpu_info.h
+++ b/paddle/fluid/platform/gpu_info.h
@@ -72,6 +72,9 @@ size_t GpuMinChunkSize();
 //! Get the maximum chunk size for GPU buddy allocator.
 size_t GpuMaxChunkSize();
 
+//! Clear the stored GPU max chunk size
+void ResetGpuMaxChunkSize();
+
 //! Copy memory from address src to dst asynchronously.
 void GpuMemcpyAsync(void *dst, const void *src, size_t count,
                     enum cudaMemcpyKind kind, cudaStream_t stream);


### PR DESCRIPTION
Use fraction of available GPU instead fraction of total GPU. Because max_chunk_size may change when available GPU size changes, we set it by a flag.

test=develop