### PR TITLE
fix jit_kernel_benchmark deps compiler error

### DIFF
--- a/paddle/fluid/operators/jit/CMakeLists.txt
+++ b/paddle/fluid/operators/jit/CMakeLists.txt
@@ -5,7 +5,7 @@ file(APPEND ${jit_file} "\#pragma once\n")
 file(APPEND ${jit_file} "\#include \"paddle/fluid/operators/jit/helper.h\"\n")
 file(APPEND ${jit_file} "\#include \"paddle/fluid/operators/jit/registry.h\"\n\n")
 
-set(JIT_KERNEL_DEPS cpu_info cblas gflags enforce place xxhash)
+set(JIT_KERNEL_DEPS cpu_info cblas gflags enforce place xxhash dynload_mklml)
 
 file(GLOB jit_kernel_cc_srcs RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "*.cc")
 list(REMOVE_ITEM jit_kernel_cc_srcs test.cc benchmark.cc)


### PR DESCRIPTION
```
[11:51:07]	CMakeFiles/jit_kernel_benchmark.dir/benchmark.cc.o: In function `_GLOBAL__sub_I_benchmark.cc':
[11:51:07]	benchmark.cc:(.text.startup+0x576): undefined reference to `google::FlagRegisterer::FlagRegisterer<std::string>(char const*, char const*, char const*, std::string*, std::string*)'
[11:51:07]	../../platform/dynload/libdynamic_loader.a(dynamic_loader.cc.o): In function `_GLOBAL__sub_I_dynamic_loader.cc':
[11:51:07]	dynamic_loader.cc:(.text.startup+0x9c): undefined reference to `google::FlagRegisterer::FlagRegisterer<std::string>(char const*, char const*, char const*, std::string*, std::string*)'
[11:51:07]	dynamic_loader.cc:(.text.startup+0x13a): undefined reference to `google::FlagRegisterer::FlagRegisterer<std::string>(char const*, char const*, char const*, std::string*, std::string*)'
[11:51:07]	dynamic_loader.cc:(.text.startup+0x1d8): undefined reference to `google::FlagRegisterer::FlagRegisterer<std::string>(char const*, char const*, char const*, std::string*, std::string*)'
[11:51:07]	dynamic_loader.cc:(.text.startup+0x276): undefined reference to `google::FlagRegisterer::FlagRegisterer<std::string>(char const*, char const*, char const*, std::string*, std::string*)'
[11:51:07]	../../platform/dynload/libdynamic_loader.a(dynamic_loader.cc.o):dynamic_loader.cc:(.text.startup+0x314): more undefined references to `google::FlagRegisterer::FlagRegisterer<std::string>(char const*, char const*, char const*, std::string*, std::string*)' follow
[11:51:07]	collect2: error: ld returned 1 exit status
[11:51:07]	paddle/fluid/operators/jit/CMakeFiles/jit_kernel_benchmark.dir/build.make:155: recipe for target 'paddle/fluid/operators/jit/jit_kernel_benchmark' failed
[11:51:07]	make[2]: *** [paddle/fluid/operators/jit/jit_kernel_benchmark] Error 1
[11:51:07]	CMakeFiles/Makefile2:69574: recipe for target 'paddle/fluid/operators/jit/CMakeFiles/jit_kernel_benchmark.dir/all' failed
[11:51:07]	make[1]: *** [paddle/fluid/operators/jit/CMakeFiles/jit_kernel_benchmark.dir/all] Error 2
[11:51:07]	make[1]: *** Waiting for unfinished jobs....
```
http://ci.paddlepaddle.org/viewLog.html?buildId=132680&buildTypeId=Paddle_PrCi&tab=buildLog&_focus=2071