### PR TITLE
Change select_rows add from math::scatter::MergeAdd to SelectedRowsAd…

### DIFF
--- a/paddle/fluid/operators/math/selected_rows_functor.cc
+++ b/paddle/fluid/operators/math/selected_rows_functor.cc
@@ -154,7 +154,7 @@ template struct SelectedRowsAddTo<platform::CPUDeviceContext, int64_t>;
 template <typename T>
 struct SelectedRowsSumTo<platform::CPUDeviceContext, T> {
   void operator()(const platform::CPUDeviceContext& context,
-                  const std::vector<framework::SelectedRows*>& input1,
+                  const std::vector<const framework::SelectedRows*>& input1,
                   const std::vector<int64_t>& input2_offsets,
                   framework::SelectedRows* input2) {
     // Ensure all selected rows have the same height

--- a/paddle/fluid/operators/math/selected_rows_functor.h
+++ b/paddle/fluid/operators/math/selected_rows_functor.h
@@ -59,7 +59,7 @@ struct SelectedRowsAddTo {
 template <typename DeviceContext, typename T>
 struct SelectedRowsSumTo {
   void operator()(const DeviceContext& context,
-                  const std::vector<framework::SelectedRows*>& input1,
+                  const std::vector<const framework::SelectedRows*>& input1,
                   const std::vector<int64_t>& input2_offsets,
                   framework::SelectedRows* input2);
 };

--- a/paddle/fluid/operators/sum_op.h
+++ b/paddle/fluid/operators/sum_op.h
@@ -57,27 +57,37 @@ void SelectedRowsCompute(const framework::ExecutionContext &context) {
     for (auto &in_var : in_vars) {
       auto &in = in_var->Get<SelectedRows>();
       if (in.rows().size() > 0) {
-        inputs.push_back(&in_var->Get<SelectedRows>());
+        inputs.push_back(&in);
       }
     }
   }
 
   auto *out = context.Output<SelectedRows>("Out");
   out->mutable_rows()->clear();
-
+  std::vector<int64_t> input1_offsize;
   bool has_data = false;
-  for (auto &in : inputs) {
-    if (in->rows().size() > 0) {
-      has_data = true;
-      break;
+  framework::DDim out_dim;
+
+  for (size_t idx = 0; idx < inputs.size(); ++idx) {
+    has_data = true;
+    out_dim = inputs[idx]->value().dims();
+    if (idx == 0) {
+      input1_offsize.push_back(0);
+    } else {
+      input1_offsize.push_back(inputs[idx - 1]->value().numel());
     }
   }
   if (has_data) {
-    math::scatter::MergeAdd<DeviceContext, T> merge_add;
-    merge_add(context.template device_context<DeviceContext>(), inputs, out);
-
-    out->SyncIndex();
-
+    int64_t row_num = 0;
+    for (auto &in : inputs) {
+      row_num += in->rows().size();
+    }
+    out_dim[0] = row_num;
+    out->mutable_value()->Resize(out_dim);
+    out->mutable_value()->mutable_data<T>(context.GetPlace());
+    paddle::operators::math::SelectedRowsSumTo<DeviceContext, T> add_functor;
+    add_functor(context.template device_context<DeviceContext>(), inputs,
+                input1_offsize, out);
   } else {
     // no data, just set a empty out tensor.
     out->mutable_value()->mutable_data<T>(framework::make_ddim({0}),


### PR DESCRIPTION
…dTo() on select_rows_function.h. test=develop

From profile test, after change it, the compute speed is 20 times faster than before.
Before change:
<img width="1163" alt="profile1" src="https://user-images.githubusercontent.com/1527350/62108487-c1791d00-b2dc-11e9-85f3-9dd141034682.png">

After change:
![Uploading profile2.png…]()
