### PR TITLE
Disable fuse optimization option

### DIFF
--- a/paddle/fluid/framework/details/build_strategy.cc
+++ b/paddle/fluid/framework/details/build_strategy.cc
@@ -77,7 +77,7 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
     // Specifies the restrictions between different pass.
     if (strategy_.enable_parallel_graph_) {
       VLOG_IF(3, strategy_.fuse_all_optimizer_ops_)
-          << "Currently, fuse_all_optimizer_ops doesn't works under "
+          << "Currently, fuse_all_optimizer_ops doesn't work under "
              "parallel_graph.";
       strategy_.fuse_all_optimizer_ops_ = false;
     }
@@ -95,6 +95,12 @@ class ParallelExecutorPassBuilder : public ir::PassBuilder {
       VLOG_IF(3, strategy_.fuse_all_reduce_ops_)
           << "fuse_all_optimizer_ops only work in Reducer mode.";
       strategy_.fuse_all_reduce_ops_ = false;
+    }
+    if (strategy_.async_mode_) {
+      VLOG_IF(3, strategy_.fuse_all_optimizer_ops_)
+          << "Currently, fuse_all_optimizer_ops doesn't work under "
+             "async mode.";
+      strategy_.fuse_all_optimizer_ops_ = false;
     }
   }
 

--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -89,7 +89,7 @@ struct BuildStrategy {
   bool fuse_elewise_add_act_ops_{false};
   // Fuse_all_optimizer_ops and fuse_all_reduce_ops require that gradients
   // should not be sparse types
-  bool fuse_all_optimizer_ops_{true};
+  bool fuse_all_optimizer_ops_{false};
   bool fuse_all_reduce_ops_{false};
   // fuse_relu_depthwise_conv can fuse the `relu ->
   // depthwise_conv`


### PR DESCRIPTION
enable_sequential_execution + fuse_all_optimizer_ops results in a cycle structure in the computational graph.
This bug will take a long time to fix, so turn off this option first, and open it after fixing the bug.

fix https://github.com/PaddlePaddle/Paddle/issues/18876