### PR TITLE
Hide the process of program compiling in fleet

### DIFF
--- a/python/paddle/fluid/incubate/fleet/collective/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/collective/__init__.py
@@ -16,6 +16,7 @@ import logging
 import paddle.fluid as fluid
 import paddle.fluid.io as io
 import paddle.fluid.transpiler.distribute_transpiler as dist_transpiler
+import paddle.fluid.compiler as compiler
 
 from paddle.fluid.incubate.fleet.base.fleet_base import Fleet
 from paddle.fluid.incubate.fleet.base.fleet_base import Mode
@@ -32,6 +33,14 @@ class DistributedStrategy(object):
         self.dgc = False
         # communication topology configs
         self.h_allreduce = False
+        self.h_allreduce_inter_nranks = 8
+        # number of nccl2 communicators
+        self.nccl_comm_num = 1
+        # configurations for BuildStrategy
+        self.enable_backward_optimizer_op_deps = False
+        self.fuse_all_reduce_ops = False
+        # configurations for ExecutorStrategy
+        self.use_experimental_executor = False
 
     def build(self):
         self.strategy_map = {}
@@ -46,6 +55,7 @@ class DistributedStrategy(object):
         self.strategy_map["localsgd"] = self.local_sgd
         self.strategy_map["dgc"] = self.dgc
         self.strategy_map["h_allreduce"] = self.h_allreduce
+        self.strategy_map["fuse"] = self.fuse_all_reduce_ops
 
 
 class DistributedOptimizerFactory(object):
@@ -55,9 +65,13 @@ class DistributedOptimizerFactory(object):
     def strategy_to_optimizer_map(self):
         pattern = {}
         pattern["fp16"] = ["FP16SGDOptimizer", "FP16LocalSGDOptimizer"]
-        pattern["fp32"] = ["FP32SGDOptimizer", "FP32LocalSGDOptimizer"]
+        pattern["fp32"] = [
+            "CollectiveOptimizer", "FP32SGDOptimizer", "FP32LocalSGDOptimizer"
+        ]
         pattern["localsgd"] = ["FP16LocalSGDOptimizer", "FP32LocalSGDOptimizer"]
+        pattern["fuse"] = ["CollectiveOptimizer"]
         pattern["h_allreduce"] = [
+            "CollectiveOptimizer",
             "FP32SGDOptimizer",
             "FP32LocalSGDOptimizer",
             "FP16SGDOptimizer",
@@ -74,13 +88,14 @@ class DistributedOptimizerFactory(object):
             if strategy.strategy_map[key]:
                 strategy_list.append(self.pattern[key])
         classname = list(set.intersection(*map(set, strategy_list)))[0]
+        print("classname: {}".format(classname))
         return globals()[classname](optimizer, strategy)
 
 
 class Collective(Fleet):
     def __init__(self):
         super(Collective, self).__init__(Mode.COLLECTIVE)
-        self._local_ip = 0
+        self.main_program = None
 
     def init_worker(self):
         logging.warn(
@@ -212,7 +227,7 @@ class FP32SGDOptimizer(CollectiveOpBasedOptimizer):
         return opts, param_and_grads
 
 
-class CollectiveOptimizer(DistributedOptimizer):
+class CollectiveOptimizer(CollectiveOpBasedOptimizer):
     """
     DistributedOptimizer is a wrapper for paddle.fluid.optimizer
     A user should pass a paddle.fluid.optimizer to DistributedOptimizer
@@ -226,18 +241,6 @@ class CollectiveOptimizer(DistributedOptimizer):
     def __init__(self, optimizer, strategy=None):
         super(CollectiveOptimizer, self).__init__(optimizer, strategy)
         self.strategy = strategy
-
-    def backward(self,
-                 loss,
-                 startup_program=None,
-                 parameter_list=None,
-                 no_grad_set=None,
-                 callbacks=None):
-        return self._optimizer.backward(loss, startup_program, parameter_list,
-                                        no_grad_set, callbacks)
-
-    def apply_gradients(self, params_grads):
-        return self._optimizer.apply_gradients(params_grads)
 
     def minimize(self,
                  loss,
@@ -273,11 +276,41 @@ class CollectiveOptimizer(DistributedOptimizer):
         # call transpiler
         config = dist_transpiler.DistributeTranspilerConfig()
         config.mode = "nccl2"
+        config.nccl_comm_num = self.strategy.nccl_comm_num
+        num_trainers = len(worker_endpoints)
+        if self.strategy.h_allreduce and \
+            self.strategy.h_allreduce_inter_nranks > 1 and \
+            num_trainers > self.strategy.h_allreduce_inter_nranks:
+            config.use_hierarchical_allreduce = True
+            config.hierarchical_allreduce_inter_nranks = \
+                self.strategy.h_allreduce_inter_nranks
+            assert num_trainers % config.hierarchical_allreduce_inter_nranks == 0
+
         t = dist_transpiler.DistributeTranspiler(config=config)
         t.transpile(
             trainer_id,
             trainers=','.join(worker_endpoints),
             startup_program=startup_program,
             current_endpoint=current_endpoint)
+
+        # Compiling main program
+        exec_strategy = fluid.ExecutionStrategy()
+        if self.strategy.use_experimental_executor:
+            exec_strategy.use_experimental_executor = True
+        build_strategy = fluid.BuildStrategy()
+        build_strategy.num_trainers = num_trainers
+        build_strategy.trainer_id = trainer_id
+        if self.strategy.enable_backward_optimizer_op_deps:
+            build_strategy.enable_backward_op_deps = True
+        if self.strategy.fuse_all_reduce_ops:
+            build_strategy.fuse_all_reduce_ops = True
+
+        print("wawa")
+        main_program = loss.block.program
+        fleet.main_program = compiler.CompiledProgram(main_program)
+        fleet.main_program.with_data_parallel(
+            loss_name=loss.name,
+            build_strategy=build_strategy,
+            exec_strategy=exec_strategy)
 
         return optimize_ops, param_grads

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -22,6 +22,7 @@ if(NOT WITH_DISTRIBUTE)
     LIST(REMOVE_ITEM TEST_OPS test_nce_remote_table_op)
     LIST(REMOVE_ITEM TEST_OPS test_hsigmoid_remote_table_op)
     LIST(REMOVE_ITEM TEST_OPS test_dist_fleet_ctr)
+    LIST(REMOVE_ITEM TEST_OPS test_dist_fleet_mnist)
 endif(NOT WITH_DISTRIBUTE)
 
 if(NOT WITH_GPU OR WIN32)

--- a/python/paddle/fluid/tests/unittests/dist_fleet_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_mnist.py
@@ -1,0 +1,117 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import shutil
+import tempfile
+import time
+
+import paddle.fluid as fluid
+import os
+
+from test_dist_fleet_collective_base import runtime_main, FleetDistRunnerBase
+
+DTYPE = "float32"
+paddle.dataset.mnist.fetch()
+
+# Fix seed for test
+fluid.default_startup_program().random_seed = 1
+fluid.default_main_program().random_seed = 1
+
+
+class TestDistCollective2x2(FleetDistRunnerBase):
+    def net(self, lr=0.01):
+        # Input data
+        data = fluid.layers.data(name='pixel', shape=[1, 28, 28], dtype=DTYPE)
+        label = fluid.layers.data(name='label', shape=[1], dtype='int64')
+
+        conv_pool_1 = fluid.nets.simple_img_conv_pool(
+            input=data,
+            filter_size=5,
+            num_filters=20,
+            pool_size=2,
+            pool_stride=2,
+            act="relu",
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.01)))
+        conv_pool_2 = fluid.nets.simple_img_conv_pool(
+            input=conv_pool_1,
+            filter_size=5,
+            num_filters=50,
+            pool_size=2,
+            pool_stride=2,
+            act="relu",
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.01)))
+
+        SIZE = 10
+        input_shape = conv_pool_2.shape
+        param_shape = [reduce(lambda a, b: a * b, input_shape[1:], 1)] + [SIZE]
+        scale = (2.0 / (param_shape[0]**2 * SIZE))**0.5
+
+        predict = fluid.layers.fc(
+            input=conv_pool_2,
+            size=SIZE,
+            act="softmax",
+            param_attr=fluid.param_attr.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.01)))
+
+        cost = fluid.layers.cross_entropy(input=predict, label=label)
+        avg_cost = fluid.layers.mean(x=cost)
+        self.predict = predict
+        self.avg_cost = avg_cost
+
+        # Reader
+        train_reader = paddle.batch(
+            paddle.dataset.mnist.test(), batch_size=batch_size)
+
+        return avg_cost
+
+    def do_training(self, fleet):
+        device_id = int(os.getenv("FLAGS_selected_gpus", "0"))
+        place = fluid.CUDAPlace(device_id)
+
+        exe = fluid.Executor(place)
+        exe.run(fleet.startup_program)
+
+        feed_var_list = [
+            var for var in trainer_prog.global_block().vars.values()
+            if var.is_data
+        ]
+
+        feeder = fluid.DataFeeder(feed_var_list, place)
+        reader_generator = train_reader()
+
+        def get_data():
+            origin_batch = next(reader_generator)
+            if args.update_method != "local" and args.use_reader_alloc:
+                new_batch = []
+                for offset, item in enumerate(origin_batch):
+                    if offset % 2 == args.trainer_id:
+                        new_batch.append(item)
+                return new_batch
+            else:
+                return origin_batch
+
+        for epoch_id in range(2):
+            pass_start = time.time()
+            exe.run(program=fleet.main_program,
+                    fetch_list=[self.avg_cost],
+                    feed=feeder.feed(get_data()))
+            pass_time = time.time() - pass_start
+
+
+if __name__ == "__main__":
+    runtime_main(TestDistCollective2x2)

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_collective_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_collective_base.py
@@ -1,0 +1,212 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import argparse
+import os
+import pickle
+import subprocess
+import sys
+import time
+import traceback
+import math
+import collections
+import socket
+from contextlib import closing
+
+import six
+import unittest
+import numpy as np
+
+import paddle.fluid as fluid
+from paddle.fluid.incubate.fleet.base.role_maker import UserDefinedCollectiveRoleMaker
+from paddle.fluid.incubate.fleet.collective import fleet
+from paddle.fluid.incubate.fleet.collective import DistributedStrategy
+
+RUN_STEP = 5
+LEARNING_RATE = 0.01
+
+
+class FleetDistRunnerBase(object):
+    def run_trainer(self, args):
+        role = role_maker.UserDefinedCollectiveRoleMaker(
+            current_id=args.current_id,
+            worker_endpoints=args.endpoints.split(","))
+
+        fleet.init(role)
+
+        strategy = DistributedStrategy()
+        strategy.use_tensor_fusion = args.use_tensor_fusion
+
+        avg_cost = self.net()
+
+        optimizer = fluid.optimizer.SGD(LEARNING_RATE)
+        optimizer = fleet.distributed_optimizer(optimizer, strategy)
+        optimizer.minimize(avg_cost)
+
+        self.do_training(fleet)
+        # out = self.do_training(fleet)
+
+    def net(self, lr=0.01):
+        raise NotImplementedError(
+            "get_model should be implemented by child classes.")
+
+    def do_training(self, fleet):
+        raise NotImplementedError(
+            "do_training should be implemented by child classes.")
+
+
+class TestFleetBase(unittest.TestCase):
+    def _setup_config(self):
+        raise NotImplementedError("tests should have _setup_config implemented")
+
+    def setUp(self):
+        self._trainers = 2
+        self._port_set = set()
+        self._worker_endpoints = "127.0.0.1:%s,127.0.0.1:%s" % (
+            self._find_free_port(), self._find_free_port())
+        self._python_interp = sys.executable
+        self._setup_config()
+
+    def _find_free_port(self):
+        def __free_port():
+            with closing(socket.socket(socket.AF_INET,
+                                       socket.SOCK_STREAM)) as s:
+                s.bind(('', 0))
+                return s.getsockname()[1]
+
+        while True:
+            port = __free_port()
+            if port not in self._port_set:
+                self._port_set.add(port)
+                return port
+
+    def _start_trainer(self, cmd, required_envs):
+        tr0_cmd, tr1_cmd = cmd.format(0), cmd.format(1)
+
+        tr0_pipe = open("/tmp/tr0_err.log", "wb+")
+        tr1_pipe = open("/tmp/tr1_err.log", "wb+")
+
+        tr0_proc = subprocess.Popen(
+            tr0_cmd.strip().split(" "),
+            stdout=subprocess.PIPE,
+            stderr=tr0_pipe,
+            env=required_envs)
+        tr1_proc = subprocess.Popen(
+            tr1_cmd.strip().split(" "),
+            stdout=subprocess.PIPE,
+            stderr=tr1_pipe,
+            env=required_envs)
+
+        return tr0_proc, tr1_proc, tr0_pipe, tr1_pipe
+
+    def _run_cluster(self, model, envs):
+        env = {
+            "PATH": os.getenv("PATH", ""),
+            "PYTHONPATH": os.getenv("PYTHONPATH", ""),
+            "LD_LIBRARY_PATH": os.getenv("LD_LIBRARY_PATH", ""),
+            "FLAGS_rpc_deadline": "5000",  # 5sec to fail fast
+            "http_proxy": ""
+        }
+
+        env.update(envs)
+
+        tr_cmd = "{0} {1} --endpoints {2} --current_id {{}} --trainers {3}".format(
+            self._python_interp, model, self._worker_endpoints, self._trainers)
+
+        # Run dist train to compare with local results
+        tr0, tr1, tr0_pipe, tr1_pipe = self._start_trainer(tr_cmd, env)
+
+        # Wait until trainer process terminate
+        while True:
+            stat0 = tr0.poll()
+            time.sleep(0.1)
+            if stat0 is not None:
+                break
+        while True:
+            stat1 = tr1.poll()
+            time.sleep(0.1)
+            if stat1 is not None:
+                break
+
+        tr0_out, tr0_err = tr0.communicate()
+        tr1_out, tr1_err = tr1.communicate()
+
+        # close trainer file
+        tr0_pipe.close()
+        tr1_pipe.close()
+        '''
+        with open("/tmp/tr0_out.log", "wb+") as wn:
+            wn.write(tr0_out)
+        with open("/tmp/tr1_out.log", "wb+") as wn:
+            wn.write(tr1_out)
+        # print server log
+        '''
+
+        # print server log
+        '''
+        with open("/tmp/ps0_err.log", "r") as fn:
+            sys.stderr.write("ps0 stderr: %s\n" % fn.read())
+        with open("/tmp/ps1_err.log", "r") as fn:
+            sys.stderr.write("ps1 stderr: %s\n" % fn.read())
+        '''
+
+        # print log
+        '''
+        with open("/tmp/tr0_err.log", "r") as fn:
+            sys.stderr.write('trainer 0 stderr: %s\n' % fn.read())
+        with open("/tmp/tr1_err.log", "r") as fn:
+            sys.stderr.write('trainer 1 stderr: %s\n' % fn.read())
+        '''
+
+        return 0, 0
+
+    def check_with_place(self,
+                         model_file,
+                         delta=1e-3,
+                         check_error_log=False,
+                         need_envs={}):
+        required_envs = {
+            "PATH": os.getenv("PATH", ""),
+            "PYTHONPATH": os.getenv("PYTHONPATH", ""),
+            "LD_LIBRARY_PATH": os.getenv("LD_LIBRARY_PATH", ""),
+            "FLAGS_rpc_deadline": "5000",  # 5sec to fail fast
+            "http_proxy": ""
+        }
+
+        required_envs.update(need_envs)
+
+        if check_error_log:
+            required_envs["GLOG_v"] = "3"
+            required_envs["GLOG_logtostderr"] = "1"
+
+        tr0_losses, tr1_losses = self._run_cluster(model_file, required_envs)
+
+
+def runtime_main(test_class):
+    parser = argparse.ArgumentParser(description='Run Fleet test.')
+    parser.add_argument('--endpoints', type=str, required=False, default="")
+    parser.add_argument('--current_id', type=int, required=False, default=0)
+    parser.add_argument('--trainers', type=int, required=False, default=1)
+    parser.add_argument(
+        '--use_tensor_fusion',
+        type=ast.literal_eval,
+        required=False,
+        default=False)
+
+    args = parser.parse_args()
+
+    model = test_class()
+    model.run_trainer(args)

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_mnist.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import unittest
+from test_dist_fleet_collective_base import TestFleetBase
+
+
+class TestDistMnist2x2(TestFleetBase):
+    def _setup_config(self):
+        self._sync_mode = False
+
+    def test_dist_train(self):
+        self.check_with_place(
+            "dist_fleet_mnist.py", delta=1e-5, check_error_log=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hide the process of program compiling in fleet to unify the interface so that users can use only executor both in singe machine training and distributed training. 