### PR TITLE
Fix gpu_info PADDLE_ENFORCE_GT when fraction_of_gpu_memory_to_use=1.0

### DIFF
--- a/paddle/fluid/memory/detail/buddy_allocator_test.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator_test.cc
@@ -209,7 +209,9 @@ TEST(BuddyAllocator, AllocFromAvailable) {
   TestBuddyAllocator(&buddy_allocator, 10 << 20);
   TestBuddyAllocator(&buddy_allocator, static_cast<size_t>(1 << 30));
 
-  EXPECT_TRUE(cudaFree(p) == cudaSuccess);
+  if (p) {
+    EXPECT_TRUE(cudaFree(p) == cudaSuccess);
+  }
 }
 
 TEST(BuddyAllocator, AllocFromAvailableWhenFractionIsOne) {
@@ -218,7 +220,7 @@ TEST(BuddyAllocator, AllocFromAvailableWhenFractionIsOne) {
   FLAGS_reallocate_gpu_memory_in_mb = 0;
 
   void* p = nullptr;
-  EXPECT_TRUE(cudaMalloc(&p, static_cast<size_t>(1) << 29) == cudaSuccess);
+  EXPECT_TRUE(cudaMalloc(&p, static_cast<size_t>(4) << 30) == cudaSuccess);
 
   // BuddyAllocator should be able to alloc the remaining GPU
   BuddyAllocator buddy_allocator(

--- a/paddle/fluid/memory/detail/buddy_allocator_test.cc
+++ b/paddle/fluid/memory/detail/buddy_allocator_test.cc
@@ -208,6 +208,29 @@ TEST(BuddyAllocator, AllocFromAvailable) {
   TestBuddyAllocator(&buddy_allocator, 10 << 10);
   TestBuddyAllocator(&buddy_allocator, 10 << 20);
   TestBuddyAllocator(&buddy_allocator, static_cast<size_t>(1 << 30));
+
+  EXPECT_TRUE(cudaFree(p) == cudaSuccess);
+}
+
+TEST(BuddyAllocator, AllocFromAvailableWhenFractionIsOne) {
+  FLAGS_fraction_of_gpu_memory_to_use = 1.0;
+  FLAGS_initial_gpu_memory_in_mb = 0;
+  FLAGS_reallocate_gpu_memory_in_mb = 0;
+
+  void* p = nullptr;
+  EXPECT_TRUE(cudaMalloc(&p, static_cast<size_t>(1) << 29) == cudaSuccess);
+
+  // BuddyAllocator should be able to alloc the remaining GPU
+  BuddyAllocator buddy_allocator(
+      std::unique_ptr<SystemAllocator>(new GPUAllocator(TEST_GPU_ID)),
+      platform::GpuMinChunkSize(), platform::GpuMaxChunkSize());
+
+  TestBuddyAllocator(&buddy_allocator, static_cast<size_t>(1) << 30);
+  TestBuddyAllocator(&buddy_allocator, static_cast<size_t>(5) << 30);
+
+  if (p) {
+    EXPECT_TRUE(cudaFree(p) == cudaSuccess);
+  }
 }
 
 #endif

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -255,7 +255,7 @@ static size_t GpuAllocSize(bool realloc) {
   size_t alloc_bytes =
       (flag_mb > 0ul ? flag_mb << 20 : available_to_alloc *
                                            FLAGS_fraction_of_gpu_memory_to_use);
-  PADDLE_ENFORCE_GT(available_to_alloc, alloc_bytes,
+  PADDLE_ENFORCE_GE(available_to_alloc, alloc_bytes,
                     "No enough available GPU memory");
   VLOG(10) << "Alloc size is " << (alloc_bytes >> 20)
            << " MiB, is it Re-alloc: " << realloc;

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -231,11 +231,14 @@ size_t GpuAvailableMemToAlloc() {
   size_t total = 0;
   size_t available = 0;
   GpuMemoryUsage(&available, &total);
-  size_t reserving = static_cast<size_t>(fraction_reserve_gpu_memory * total);
+  size_t reserving =
+      static_cast<size_t>(fraction_reserve_gpu_memory * available);
   // If available size is less than minimum chunk size, no usable memory exists
+  size_t available_to_alloc = available - reserving;
   size_t min_chunk_size = GpuMinChunkSize();
-  size_t available_to_alloc =
-      std::min(available > min_chunk_size ? available : 0, total - reserving);
+  if (available_to_alloc < min_chunk_size) {
+    available_to_alloc = 0;
+  }
   VLOG(10) << "GPU usage " << (available >> 20) << "M/" << (total >> 20)
            << "M, " << (available_to_alloc >> 20) << "M available to allocate";
   return available_to_alloc;

--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -230,8 +230,8 @@ void GpuMemoryUsage(size_t *available, size_t *total) {
 size_t GpuAvailableMemToAlloc() {
   size_t total = 0;
   size_t available = 0;
-  size_t reserving = static_cast<size_t>(fraction_reserve_gpu_memory * total);
   GpuMemoryUsage(&available, &total);
+  size_t reserving = static_cast<size_t>(fraction_reserve_gpu_memory * total);
   // If available size is less than minimum chunk size, no usable memory exists
   size_t min_chunk_size = GpuMinChunkSize();
   size_t available_to_alloc =


### PR DESCRIPTION
As title. Bug fix for benchmark.

If `FLAGS_fraction_of_gpu_memory_to_use=1`, the previous logic would throw exceptions instead of trying to call `cudaMalloc`. This makes benchmark models fail.

<img width="424" alt="fcd57c18891919bb0775633878d90741" src="https://user-images.githubusercontent.com/32832641/62448682-f254c880-b79a-11e9-870f-115f1a457202.png">