### PR TITLE
add cudnn realization of dropout op 

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -137,7 +137,7 @@ paddle.fluid.layers.reduce_any (ArgSpec(args=['input', 'dim', 'keep_dim', 'name'
 paddle.fluid.layers.sequence_first_step (ArgSpec(args=['input'], varargs=None, keywords=None, defaults=None), ('document', 'f2dfd65b859de9844e7261e7a4503f63'))
 paddle.fluid.layers.sequence_last_step (ArgSpec(args=['input'], varargs=None, keywords=None, defaults=None), ('document', '1af2e3a887e4f914f9d6650406186ab6'))
 paddle.fluid.layers.sequence_slice (ArgSpec(args=['input', 'offset', 'length', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', '39fbc5437be389f6c0c769f82fc1fba2'))
-paddle.fluid.layers.dropout (ArgSpec(args=['x', 'dropout_prob', 'is_test', 'seed', 'name', 'dropout_implementation'], varargs=None, keywords=None, defaults=(False, None, None, 'downgrade_in_infer')), ('document', '558d13133596209190df9a624264f28f'))
+paddle.fluid.layers.dropout (ArgSpec(args=['x', 'dropout_prob', 'is_test', 'seed', 'name', 'dropout_implementation', 'use_cudnn'], varargs=None, keywords=None, defaults=(False, None, None, 'downgrade_in_infer', True)), ('document', 'd4c69741fd82686dcd6c1a02066fd5f1'))
 paddle.fluid.layers.split (ArgSpec(args=['input', 'num_or_sections', 'dim', 'name'], varargs=None, keywords=None, defaults=(-1, None)), ('document', '78cf3a7323d1a7697658242e13f63759'))
 paddle.fluid.layers.ctc_greedy_decoder (ArgSpec(args=['input', 'blank', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', '2bc3a59efa9d52b628a6255422d9f0e8'))
 paddle.fluid.layers.edit_distance (ArgSpec(args=['input', 'label', 'normalized', 'ignored_tokens', 'input_length', 'label_length'], varargs=None, keywords=None, defaults=(True, None, None, None)), ('document', '77cbfb28cd2fc589f589c7013c5086cd'))

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -180,6 +180,7 @@ class OperatorBase {
   //! Get an output which has multiple variables.
   //! TODO add a vector_view to prevent memory copy.
   const std::vector<std::string>& Outputs(const std::string& name) const;
+
   //! Get all outputs variable names
   virtual std::vector<std::string> OutputVars(bool has_intermediate) const;
 
@@ -294,6 +295,13 @@ class ExecutionContext {
     return var == nullptr ? nullptr : var->GetMutable<T>();
   }
 
+  const std::string InputVarName(const std::string& name) const {
+    return op_.Input(name);
+  }
+
+  const std::string OutputVarName(const std::string& name) const {
+    return op_.Output(name);
+  }
   template <typename T>
   const std::vector<const T*> MultiInput(const std::string& name) const {
     auto it = ctx_.inputs.find(name);

--- a/paddle/fluid/framework/var_type_traits.cc
+++ b/paddle/fluid/framework/var_type_traits.cc
@@ -28,6 +28,7 @@
 #include <cudnn.h>
 #include "paddle/fluid/operators/conv_cudnn_op_cache.h"
 #include "paddle/fluid/operators/cudnn_rnn_cache.h"
+#include "paddle/fluid/operators/dropout_op_cache.h"
 #endif
 
 namespace paddle {

--- a/paddle/fluid/framework/var_type_traits.h
+++ b/paddle/fluid/framework/var_type_traits.h
@@ -53,7 +53,7 @@ class Scope;
 namespace operators {
 
 class CudnnRNNCache;
-
+class CudnnDropoutCache;
 namespace reader {
 class LoDTensorBlockingQueueHolder;
 }  // namespace reader
@@ -143,7 +143,7 @@ using VarTypeRegistry = detail::VarTypeRegistryImpl<
 #ifndef _WIN32
     ncclUniqueId, platform::Communicator, platform::NCCLCommunicator,
 #endif
-    operators::CudnnRNNCache,
+    operators::CudnnRNNCache, operators::CudnnDropoutCache,
 #endif
     int, float>;
 

--- a/paddle/fluid/framework/var_type_traits_test.cc
+++ b/paddle/fluid/framework/var_type_traits_test.cc
@@ -30,6 +30,7 @@
 #endif
 #include "paddle/fluid/operators/conv_cudnn_op_cache.h"
 #include "paddle/fluid/operators/cudnn_rnn_cache.h"
+#include "paddle/fluid/operators/dropout_op_cache.h"
 #endif
 
 namespace paddle {

--- a/paddle/fluid/operators/dropout_cudnn_op.cu.cc
+++ b/paddle/fluid/operators/dropout_cudnn_op.cu.cc
@@ -1,0 +1,138 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#include <memory>
+#include <string>
+#include <vector>
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/dropout_op.h"
+#include "paddle/fluid/operators/dropout_op_cache.h"
+#include "paddle/fluid/platform/cudnn_desc.h"
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+using TensorDescriptor = platform::TensorDescriptor;
+using DataLayout = platform::DataLayout;
+
+template <typename T>
+class CUDNNDropoutOpKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    PADDLE_ENFORCE(platform::is_gpu_place(ctx.GetPlace()),
+                   "It must use CUDAPlace.");
+    const Tensor *x = ctx.Input<Tensor>("X");
+    Tensor *out = ctx.Output<Tensor>("Out");
+    Tensor *mask = ctx.Output<Tensor>("Mask");
+
+    const T *x_data = x->data<T>();
+    T *out_data = out->mutable_data<T>(ctx.GetPlace());
+
+    auto size_prod = x->numel();
+    float dropout_prob = ctx.Attr<float>("dropout_prob");
+    bool is_test = ctx.Attr<bool>("is_test");
+    if (is_test) {
+      TensorCopySync(*x, ctx.GetPlace(), out);
+      return;
+    }
+
+    auto &dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    auto handle = dev_ctx.cudnn_handle();
+    auto *cache_var = ctx.InputVar("Cache");
+    if (!cache_var) {
+      // The RAW type cache variable wouldn't be created and broadcasted on
+      // multi-devices before the first running.
+      // use parent scope to make cache persistable
+      auto *scope = const_cast<framework::Scope *>(ctx.scope().parent());
+      auto cache_var_name = ctx.InputVarName("Cache");
+      cache_var = scope->Var(cache_var_name);
+    }
+    CudnnDropoutCache *cudnn_dropout_cache = nullptr;
+    if (cache_var->IsInitialized()) {
+      cudnn_dropout_cache = const_cast<framework::Variable *>(cache_var)
+                                ->GetMutable<CudnnDropoutCache>();
+    } else {
+      cudnn_dropout_cache = const_cast<framework::Variable *>(cache_var)
+                                ->GetMutable<CudnnDropoutCache>();
+      auto &states_size_in_bytes = cudnn_dropout_cache->states_size_in_bytes_;
+      CUDNN_ENFORCE(platform::dynload::cudnnDropoutGetStatesSize(
+          handle, &states_size_in_bytes));
+      auto &states = cudnn_dropout_cache->states_;
+      states.Resize({static_cast<int64_t>(states_size_in_bytes)});
+      auto *states_data = states.mutable_data<uint8_t>(ctx.GetPlace());
+      std::random_device rnd;
+      int seed = ctx.Attr<bool>("fix_seed") ? ctx.Attr<int>("seed") : rnd();
+      CUDNN_ENFORCE(platform::dynload::cudnnSetDropoutDescriptor(
+          cudnn_dropout_cache->dropout_desc_, handle, dropout_prob, states_data,
+          states_size_in_bytes, static_cast<uint64_t>(seed)));
+    }
+    auto &cudnn_data_desc = cudnn_dropout_cache->data_desc_;
+    auto &reserve_space_size_in_bytes =
+        cudnn_dropout_cache->reserve_space_size_in_bytes_;
+    if (size_prod != cudnn_dropout_cache->input_size_) {
+      cudnn_dropout_cache->input_size_ = size_prod;
+      CUDNN_ENFORCE(platform::dynload::cudnnSetTensor4dDescriptor(
+          cudnn_data_desc, GetCudnnTensorFormat(DataLayout::kNCHW),
+          paddle::platform::CudnnDataType<T>::type, size_prod, 1, 1, 1));
+      CUDNN_ENFORCE(platform::dynload::cudnnDropoutGetReserveSpaceSize(
+          cudnn_data_desc, &reserve_space_size_in_bytes));
+    }
+    auto &cudnn_dropout_desc = cudnn_dropout_cache->dropout_desc_;
+    mask->Resize({static_cast<int64_t>(reserve_space_size_in_bytes)});
+    CUDNN_ENFORCE(platform::dynload::cudnnDropoutForward(
+        handle, cudnn_dropout_desc, cudnn_data_desc, x_data, cudnn_data_desc,
+        out_data, mask->mutable_data<uint8_t>(ctx.GetPlace()),
+        reserve_space_size_in_bytes));
+  }
+};
+
+template <typename T>
+class CUDNNDropoutGradOpKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    const Tensor *out_grad = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    const Tensor *mask = ctx.Input<Tensor>("Mask");
+    Tensor *x_grad = ctx.Output<Tensor>(framework::GradVarName("X"));
+
+    const T *out_grad_data = out_grad->data<T>();
+    T *x_grad_data = x_grad->mutable_data<T>(ctx.GetPlace());
+
+    auto &dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    auto handle = dev_ctx.cudnn_handle();
+    auto *cache_var = ctx.InputVar("Cache");
+    PADDLE_ENFORCE(cache_var->IsInitialized());
+    CudnnDropoutCache *cudnn_dropout_cache =
+        const_cast<framework::Variable *>(cache_var)
+            ->GetMutable<CudnnDropoutCache>();
+
+    auto &cudnn_data_desc = cudnn_dropout_cache->data_desc_;
+    auto &cudnn_dropout_desc = cudnn_dropout_cache->dropout_desc_;
+    auto &reserve_space_size_in_bytes =
+        cudnn_dropout_cache->reserve_space_size_in_bytes_;
+    CUDNN_ENFORCE(platform::dynload::cudnnDropoutBackward(
+        handle, cudnn_dropout_desc, cudnn_data_desc, out_grad_data,
+        cudnn_data_desc, x_grad_data,
+        const_cast<uint8_t *>(mask->data<uint8_t>()),
+        reserve_space_size_in_bytes));
+  }
+};
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OP_KERNEL(dropout, CUDNN, ::paddle::platform::CUDAPlace,
+                   ops::CUDNNDropoutOpKernel<float>,
+                   ops::CUDNNDropoutOpKernel<double>);
+REGISTER_OP_KERNEL(dropout_grad, CUDNN, ::paddle::platform::CUDAPlace,
+                   ops::CUDNNDropoutGradOpKernel<float>,
+                   ops::CUDNNDropoutGradOpKernel<double>);

--- a/paddle/fluid/operators/dropout_op.cc
+++ b/paddle/fluid/operators/dropout_op.cc
@@ -16,7 +16,7 @@ limitations under the License. */
 #include <memory>
 #include <string>
 
-#ifdef PADDLE_WITH_MKLDNN
+#ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/platform/cudnn_helper.h"
 #endif
 

--- a/paddle/fluid/operators/dropout_op_cache.h
+++ b/paddle/fluid/operators/dropout_op_cache.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/platform/cudnn_helper.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+
+struct CudnnDropoutCache {
+  CudnnDropoutCache() {
+    PADDLE_ENFORCE(platform::dynload::cudnnCreateTensorDescriptor(&data_desc_));
+    PADDLE_ENFORCE(
+        platform::dynload::cudnnCreateDropoutDescriptor(&dropout_desc_));
+  }
+  ~CudnnDropoutCache() {
+    PADDLE_ENFORCE(platform::dynload::cudnnDestroyTensorDescriptor(data_desc_));
+    PADDLE_ENFORCE(
+        platform::dynload::cudnnDestroyDropoutDescriptor(dropout_desc_));
+  }
+
+  cudnnTensorDescriptor_t data_desc_;
+  cudnnDropoutDescriptor_t dropout_desc_;
+  size_t states_size_in_bytes_, reserve_space_size_in_bytes_;
+  int64_t input_size_ = -1;
+  Tensor states_;  // dtype = uint8
+};
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/platform/dynload/cudnn.h
+++ b/paddle/fluid/platform/dynload/cudnn.h
@@ -113,9 +113,6 @@ extern void EnforceCUDNNLoaded(const char* fn_name);
   __macro(cudnnFindConvolutionBackwardFilterAlgorithmEx); \
   __macro(cudnnFindConvolutionBackwardDataAlgorithmEx);   \
   __macro(cudnnGetErrorString);                           \
-  __macro(cudnnCreateDropoutDescriptor);                  \
-  __macro(cudnnDropoutGetStatesSize);                     \
-  __macro(cudnnSetDropoutDescriptor);                     \
   __macro(cudnnCreateRNNDescriptor);                      \
   __macro(cudnnSetRNNDescriptor);                         \
   __macro(cudnnGetRNNParamsSize);                         \
@@ -125,8 +122,14 @@ extern void EnforceCUDNNLoaded(const char* fn_name);
   __macro(cudnnRNNBackwardData);                          \
   __macro(cudnnRNNBackwardWeights);                       \
   __macro(cudnnRNNForwardInference);                      \
+  __macro(cudnnDestroyRNNDescriptor);                     \
+  __macro(cudnnCreateDropoutDescriptor);                  \
   __macro(cudnnDestroyDropoutDescriptor);                 \
-  __macro(cudnnDestroyRNNDescriptor);
+  __macro(cudnnSetDropoutDescriptor);                     \
+  __macro(cudnnDropoutForward);                           \
+  __macro(cudnnDropoutBackward);                          \
+  __macro(cudnnDropoutGetReserveSpaceSize);               \
+  __macro(cudnnDropoutGetStatesSize);
 
 CUDNN_DNN_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 
@@ -184,7 +187,9 @@ CUDNN_DNN_ROUTINE_EACH_R6(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
   __macro(cudnnCTCLoss);                                  \
   __macro(cudnnGetConvolutionBackwardDataAlgorithm_v7);   \
   __macro(cudnnGetConvolutionBackwardFilterAlgorithm_v7); \
-  __macro(cudnnGetConvolutionForwardAlgorithm_v7);
+  __macro(cudnnGetConvolutionForwardAlgorithm_v7);        \
+  __macro(cudnnRestoreDropoutDescriptor);
+
 CUDNN_DNN_ROUTINE_EACH_R7(DECLARE_DYNAMIC_LOAD_CUDNN_WRAP)
 #endif
 

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -31,6 +31,7 @@ from paddle.fluid.op import Operator
 from paddle.fluid.executor import Executor
 from paddle.fluid.framework import Program, OpProtoHolder, Variable
 from testsuite import create_op, set_input, append_input_output, append_loss_ops
+from paddle.fluid.unique_name import generate
 
 
 def randomize_probability(batch_size, class_num, dtype='float32'):
@@ -218,11 +219,11 @@ class OpTest(unittest.TestCase):
                                      self.dtype)
         outputs = append_input_output(block, op_proto, self.outputs, False,
                                       self.dtype)
-
         if hasattr(self, "cache_name_list"):
             for name in self.cache_name_list:
+                unique_name = generate(name)
                 inputs[name] = block.create_var(
-                    name=name,
+                    name=unique_name,
                     persistable=True,
                     type=core.VarDesc.VarType.RAW,
                     stop_gradient=True)


### PR DESCRIPTION
1： add cudnn realization of dropout op 
2:   add use_cudnn option in python interface
3:   add some single Test in the dropout op test

using the dropout cudnn to speed up the transformer-big model(about  7% improvement)
