### PR TITLE
Reduce test_buffer_shared_memory_reuse_pass unittest time cost

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_buffer_shared_memory_reuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_buffer_shared_memory_reuse_pass.py
@@ -98,7 +98,7 @@ class InplaceTestBase(unittest.TestCase):
                 compiled_programs.append(compiled_prog)
 
         all_vars_name = self.get_all_vars(prog1)
-        repeated_var_names = all_vars_name * 4
+        repeated_var_names = all_vars_name * 2
         random.shuffle(repeated_var_names)  # add some random 
 
         for fetch_var in repeated_var_names:
@@ -144,7 +144,7 @@ class InplaceTestBase(unittest.TestCase):
                         places=places)
                 compiled_programs.append(compiled_program)
 
-        repeated_var_names = self.get_all_vars(prog1) * 4
+        repeated_var_names = self.get_all_vars(prog1) * 2
         random.shuffle(repeated_var_names)  # add some random 
 
         for fetch_var in repeated_var_names:


### PR DESCRIPTION
Time cost:  78.471s -> 44.971s.

This PR tries to fix timeout of `test_buffer_shared_memory_reuse_pass` in CI.

CI link: http://ci.paddlepaddle.org/viewLog.html?buildId=136171&buildTypeId=Paddle_PrCi      

<img width="1171" alt="8918c7472da99896cff71241900b7517" src="https://user-images.githubusercontent.com/32832641/62448758-131d1e00-b79b-11e9-9a01-913a635a6db9.png">
