### PR TITLE
specify the highest numpy version under python 2.x

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,6 @@
 requests>=2.20.0
-numpy>=1.12
+numpy>=1.12, <=1.16.4 ; python_version<"3.5"
+numpy>=1.12 ; python_version>="3.5"
 protobuf>=3.1.0
 recordio>=0.1.0
 matplotlib<=2.2.4 ; python_version<"3.6"


### PR DESCRIPTION
As mentioned in [this link](https://www.scipy.org/scipylib/faq.html#python-version-support), the last version of NumPy to support Python 2.7 is numpy 1.16.x.