### PR TITLE
Fix memory overwriting of tensors returned by executor

### DIFF
--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -683,8 +683,9 @@ void ParallelExecutor::BCastParamsToDevices(
   }
 }
 
-void ParallelExecutor::Run(const std::vector<std::string> &fetch_tensors,
-                           const std::string &fetched_var_name) {
+FeedFetchList ParallelExecutor::Run(
+    const std::vector<std::string> &fetch_tensors,
+    const std::string &fetched_var_name) {
   VLOG(3) << "enter ParallelExecutor Run";
 #ifdef WITH_GPERFTOOLS
   if (gProfileStarted) {
@@ -699,8 +700,7 @@ void ParallelExecutor::Run(const std::vector<std::string> &fetch_tensors,
 
   VLOG(3) << "ParallelExecutor begin to run member_->executor_->Run";
   auto fetch_data = member_->executor_->Run(fetch_tensors);
-  *member_->global_scope_->Var(fetched_var_name)->GetMutable<FeedFetchList>() =
-      fetch_data;
+  return fetch_data;
 }
 
 void ParallelExecutor::FeedTensorsIntoLocalScopes(

--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -684,8 +684,7 @@ void ParallelExecutor::BCastParamsToDevices(
 }
 
 FeedFetchList ParallelExecutor::Run(
-    const std::vector<std::string> &fetch_tensors,
-    const std::string &fetched_var_name) {
+    const std::vector<std::string> &fetch_tensors) {
   VLOG(3) << "enter ParallelExecutor Run";
 #ifdef WITH_GPERFTOOLS
   if (gProfileStarted) {

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -25,6 +25,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/details/execution_strategy.h"
 #include "paddle/fluid/framework/details/op_handle_base.h"
 #include "paddle/fluid/framework/executor.h"
+#include "paddle/fluid/framework/feed_fetch_type.h"
 #include "paddle/fluid/framework/op_info.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/framework/scope.h"
@@ -74,8 +75,8 @@ class ParallelExecutor {
   void FeedAndSplitTensorIntoLocalScopes(
       const std::unordered_map<std::string, LoDTensor> &tensors);
 
-  void Run(const std::vector<std::string> &fetch_tensors,
-           const std::string &fetched_var_name);
+  FeedFetchList Run(const std::vector<std::string> &fetch_tensors,
+                    const std::string &fetched_var_name);
 
  private:
   // broadcast the parameters from the 0th device.

--- a/paddle/fluid/framework/parallel_executor.h
+++ b/paddle/fluid/framework/parallel_executor.h
@@ -75,8 +75,7 @@ class ParallelExecutor {
   void FeedAndSplitTensorIntoLocalScopes(
       const std::unordered_map<std::string, LoDTensor> &tensors);
 
-  FeedFetchList Run(const std::vector<std::string> &fetch_tensors,
-                    const std::string &fetched_var_name);
+  FeedFetchList Run(const std::vector<std::string> &fetch_tensors);
 
  private:
   // broadcast the parameters from the 0th device.

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1069,8 +1069,8 @@ All parameter, weight, gradient are variables in Paddle.
                    t.set(np.ndarray([5, 30]), fluid.CPUPlace())
                    arr.append(t)
            )DOC")
-      .def("move", [](LoDTensorArray &self, LoDTensorArray &dst) {
-        dst = std::move(self);
+      .def("_move", [](LoDTensorArray &self) -> LoDTensorArray {
+        return std::move(self);
       });
 
   m.def("IsInplace",
@@ -1653,10 +1653,9 @@ All parameter, weight, gradient are variables in Paddle.
       .def("feed_and_split_tensor_into_local_scopes",
            &ParallelExecutor::FeedAndSplitTensorIntoLocalScopes)
       .def("run", [](ParallelExecutor &self,
-                     const std::vector<std::string> &fetch_tensors,
-                     const std::string &fetched_var_name) {
+                     const std::vector<std::string> &fetch_tensors) {
         pybind11::gil_scoped_release release;
-        return self.Run(fetch_tensors, fetched_var_name);
+        return self.Run(fetch_tensors);
       });
 
   BindRecordIOWriter(&m);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1068,7 +1068,10 @@ All parameter, weight, gradient are variables in Paddle.
                    t = fluid.LoDTensor()
                    t.set(np.ndarray([5, 30]), fluid.CPUPlace())
                    arr.append(t)
-           )DOC");
+           )DOC")
+      .def("move", [](LoDTensorArray &self, LoDTensorArray &dst) {
+        dst = std::move(self);
+      });
 
   m.def("IsInplace",
         [](std::string op) -> bool { return operators::IsInplace(op); });
@@ -1653,7 +1656,7 @@ All parameter, weight, gradient are variables in Paddle.
                      const std::vector<std::string> &fetch_tensors,
                      const std::string &fetched_var_name) {
         pybind11::gil_scoped_release release;
-        self.Run(fetch_tensors, fetched_var_name);
+        return self.Run(fetch_tensors, fetched_var_name);
       });
 
   BindRecordIOWriter(&m);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1069,9 +1069,16 @@ All parameter, weight, gradient are variables in Paddle.
                    t.set(np.ndarray([5, 30]), fluid.CPUPlace())
                    arr.append(t)
            )DOC")
-      .def("_move", [](LoDTensorArray &self) -> LoDTensorArray {
-        return std::move(self);
-      });
+      .def("_move_to_list",
+           [](LoDTensorArray &self) -> py::list {
+             py::list res(self.size());
+             for (size_t i = 0; i < self.size(); ++i) {
+               res[i] = py::cast(std::move(self[i]));
+             }
+             self.clear();
+             return res;
+           },
+           py::return_value_policy::take_ownership);
 
   m.def("IsInplace",
         [](std::string op) -> bool { return operators::IsInplace(op); });

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -527,12 +527,12 @@ class Executor(object):
             exe.feed_tensors_into_local_scopes(res)
 
         fetch_var_names = list(map(_to_name_str, fetch_list))
-        exe.run(fetch_var_names, fetch_var_name)
-        arr = scope.find_var(fetch_var_name).get_lod_tensor_array()
+        arr = exe.run(fetch_var_names, fetch_var_name)
 
         if return_numpy:
             return as_numpy(arr)
-        return [arr[i] for i in range(len(arr))]
+        else:
+            return arr
 
     def run(self,
             program=None,
@@ -745,9 +745,12 @@ class Executor(object):
             exe.run(program.desc, scope, 0, True, True, fetch_var_name)
         else:
             exe.run_cached_prepared_ctx(ctx, scope, False, False, False)
-        outs = self._fetch_data(fetch_list, fetch_var_name, scope)
+        arr = scope.find_var(fetch_var_name).get_lod_tensor_array()
         if return_numpy:
-            outs = as_numpy(outs)
+            outs = as_numpy(arr)
+        else:
+            outs = core.LoDTensorArray()
+            arr.move(outs)
         return outs
 
     def _run_inference(self, exe, feed):

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -527,12 +527,12 @@ class Executor(object):
             exe.feed_tensors_into_local_scopes(res)
 
         fetch_var_names = list(map(_to_name_str, fetch_list))
-        arr = exe.run(fetch_var_names)
+        tensors = exe.run(fetch_var_names)._move_to_list()
 
         if return_numpy:
-            return as_numpy(arr)
+            return as_numpy(tensors)
         else:
-            return arr
+            return tensors
 
     def run(self,
             program=None,
@@ -746,10 +746,11 @@ class Executor(object):
         else:
             exe.run_cached_prepared_ctx(ctx, scope, False, False, False)
         arr = scope.find_var(fetch_var_name).get_lod_tensor_array()
+        tensors = arr._move_to_list()
         if return_numpy:
-            return as_numpy(arr)
+            return as_numpy(tensors)
         else:
-            return arr._move()
+            return tensors
 
     def _run_inference(self, exe, feed):
         return exe.run(feed)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -527,7 +527,7 @@ class Executor(object):
             exe.feed_tensors_into_local_scopes(res)
 
         fetch_var_names = list(map(_to_name_str, fetch_list))
-        arr = exe.run(fetch_var_names, fetch_var_name)
+        arr = exe.run(fetch_var_names)
 
         if return_numpy:
             return as_numpy(arr)
@@ -747,11 +747,9 @@ class Executor(object):
             exe.run_cached_prepared_ctx(ctx, scope, False, False, False)
         arr = scope.find_var(fetch_var_name).get_lod_tensor_array()
         if return_numpy:
-            outs = as_numpy(arr)
+            return as_numpy(arr)
         else:
-            outs = core.LoDTensorArray()
-            arr.move(outs)
-        return outs
+            return arr._move()
 
     def _run_inference(self, exe, feed):
         return exe.run(feed)

--- a/python/paddle/fluid/tests/unittests/test_fetch_list.py
+++ b/python/paddle/fluid/tests/unittests/test_fetch_list.py
@@ -1,0 +1,70 @@
+#  Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import numpy as np
+import paddle.fluid.core as core
+from op_test import OpTest
+
+
+class TestFetchList(OpTest):
+    def setUp(self):
+        pass
+
+    def calc_add_out(self, place=None, parallel=None):
+        self.x = np.random.random((2, 5)).astype(np.float32)
+        self.y = np.random.random((2, 5)).astype(np.float32)
+        self.out = np.add(self.x, self.y)
+        self.inputs = {
+            'X': OpTest.np_dtype_to_fluid_dtype(self.x),
+            'Y': OpTest.np_dtype_to_fluid_dtype(self.y)
+        }
+        self.outputs = {'Out': self.out}
+        self.op_type = "elementwise_add"
+        self.dtype = np.float32
+        outs, fetch_list = self._calc_output(place, parallel=parallel)
+        return outs
+
+    def calc_mul_out(self, place=None, parallel=None):
+        self.x = np.random.random((2, 5)).astype(np.float32)
+        self.y = np.random.random((5, 2)).astype(np.float32)
+        self.out = np.dot(self.x, self.y)
+        self.inputs = {
+            'X': OpTest.np_dtype_to_fluid_dtype(self.x),
+            'Y': OpTest.np_dtype_to_fluid_dtype(self.y)
+        }
+        self.outputs = {'Out': self.out}
+        self.op_type = "elementwise_mul"
+        self.dtype = np.float32
+        outs, fetch_list = self._calc_output(place, parallel=parallel)
+        return outs
+
+    def test_fetch_list(self):
+        places = [core.CPUPlace()]
+        if core.is_compiled_with_cuda() and core.op_support_gpu(
+                "elementwise_add") and core.op_support_gpu("elementwise_mul"):
+            places.append(core.CUDAPlace(0))
+
+        for place in places:
+            for parallel in [True, False]:
+                add_out = self.calc_add_out(place, parallel)
+                add_out1 = np.array(add_out[0])
+                mul_out = self.calc_mul_out(place, parallel)
+                add_out2 = np.array(add_out[0])
+                self.assertTrue(np.array_equal(add_out1, add_out2))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The original fetch behavior in executor.run() creates a persistable variable named 'fetch', and returns reference of the tensors held in 'fetch'; thus when two program executed, memory overwriting of tensors returned may appear when executors run with`return_numpy=False`.

This PR adds a unittest `(test_executor_return_tensor_not_overwriting.py)` to test memory overwriting behavior, which fails on original code,   and it fixes the bug by returning different tensors in executor.run().

Plus, this PR fixes wrong usage of ParallelExecutor in op_test.py. It seems the unittests of operators never run in parallel mode.