### PR TITLE
Enhance the error message when GrapOpMaker is null.

### DIFF
--- a/paddle/fluid/framework/op_info.h
+++ b/paddle/fluid/framework/op_info.h
@@ -65,8 +65,14 @@ struct OpInfo {
   }
 
   const GradOpMakerFN& GradOpMaker() const {
-    PADDLE_ENFORCE_NOT_NULL(grad_op_maker_,
-                            "Operator GradOpMaker has not been registered.");
+    std::string type = proto_ ? proto_->type() : "unknown";
+    PADDLE_ENFORCE_NOT_NULL(
+        grad_op_maker_,
+        "Operator %s's GradOpMaker has not been "
+        "registered. Please check whether %s_op has "
+        "grad_op. If not, please set stop_gradient to True "
+        "for its input and output variables using var.step_gradient=True.",
+        type.c_str(), type.c_str());
     return grad_op_maker_;
   }
 

--- a/paddle/fluid/framework/op_info.h
+++ b/paddle/fluid/framework/op_info.h
@@ -52,26 +52,28 @@ struct OpInfo {
   }
 
   const proto::OpProto& Proto() const {
-    PADDLE_ENFORCE_NOT_NULL(proto_, "Operator Proto has not been registered");
+    PADDLE_ENFORCE_NOT_NULL(proto_, "Operator's Proto has not been registered");
     PADDLE_ENFORCE(proto_->IsInitialized(),
-                   "Operator Proto must be initialized in op info");
+                   "Operator's Proto must be initialized in op info");
     return *proto_;
   }
 
   const OpCreator& Creator() const {
     PADDLE_ENFORCE_NOT_NULL(creator_,
-                            "Operator Creator has not been registered");
+                            "Operator's Creator has not been registered");
     return creator_;
   }
 
   const GradOpMakerFN& GradOpMaker() const {
-    std::string type = Proto().type();
+    // Normally, proto_ should not be null, except some special operators, such
+    // as LeaklyReluDoubleGrad op.
+    std::string type = proto_ ? proto_->type() : "unknown";
     PADDLE_ENFORCE_NOT_NULL(
         grad_op_maker_,
         "Operator %s's GradOpMaker has not been "
         "registered.\nPlease check whether %s_op has "
         "grad_op.\nIf not, please set stop_gradient to True "
-        "for its input and output variables using var.step_gradient=True.",
+        "for its input and output variables using var.stop_gradient=True.",
         type.c_str(), type.c_str());
     return grad_op_maker_;
   }

--- a/paddle/fluid/framework/op_info.h
+++ b/paddle/fluid/framework/op_info.h
@@ -65,12 +65,12 @@ struct OpInfo {
   }
 
   const GradOpMakerFN& GradOpMaker() const {
-    std::string type = proto_ ? proto_->type() : "unknown";
+    std::string type = Proto().type();
     PADDLE_ENFORCE_NOT_NULL(
         grad_op_maker_,
         "Operator %s's GradOpMaker has not been "
-        "registered. Please check whether %s_op has "
-        "grad_op. If not, please set stop_gradient to True "
+        "registered.\nPlease check whether %s_op has "
+        "grad_op.\nIf not, please set stop_gradient to True "
         "for its input and output variables using var.step_gradient=True.",
         type.c_str(), type.c_str());
     return grad_op_maker_;


### PR DESCRIPTION
If user uses a op which does not have grad_op, and forgets to set stop_gradient to True, the train process will crash.

The error message is:
```text
Traceback (most recent call last):
  File "./train_gpu_paddle.py", line 471, in <module>
    train(n_token, cutoffs)
  File "./train_gpu_paddle.py", line 254, in train
    decr_ratio=FLAGS.decr_ratio)
  File "/home/dingsiyu/project/python/transformer-xl-paddlepaddle/optimization.py", line 151, in optimization
    _, param_grads = optimizer.minimize(loss)
  File "<decorator-gen-20>", line 2, in minimize
  File "/home/dingsiyu/bin/anaconda3/lib/python3.6/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/home/dingsiyu/bin/anaconda3/lib/python3.6/site-packages/paddle/fluid/dygraph/base.py", line 88, in __impl__
    return func(*args, **kwargs)
  File "/home/dingsiyu/bin/anaconda3/lib/python3.6/site-packages/paddle/fluid/optimizer.py", line 593, in minimize
    no_grad_set=no_grad_set)
  File "/home/dingsiyu/bin/anaconda3/lib/python3.6/site-packages/paddle/fluid/optimizer.py", line 493, in backward
    no_grad_set, callbacks)
  File "/home/dingsiyu/bin/anaconda3/lib/python3.6/site-packages/paddle/fluid/backward.py", line 570, in append_backward
    input_grad_names_set=input_grad_names_set)
  File "/home/dingsiyu/bin/anaconda3/lib/python3.6/site-packages/paddle/fluid/backward.py", line 310, in _append_backward_ops_
    op.desc, cpt.to_text(no_grad_dict[block.idx]), grad_sub_block_list)
paddle.fluid.core_avx.EnforceNotMet: grad_op_maker_ should not be null
Operator GradOpMaker has not been registered. at [/paddle/paddle/fluid/framework/op_info.h:69]
PaddlePaddle Call Stacks: 
0       0x7ff346440948p void paddle::platform::EnforceNotMet::Init<std::string>(std::string, char const*, int) + 360
1       0x7ff346440c97p paddle::platform::EnforceNotMet::EnforceNotMet(std::string const&, char const*, int) + 87
2       0x7ff346441c5cp paddle::framework::OpInfo::GradOpMaker() const + 108
3       0x7ff34643935ep
4       0x7ff346472de6p
5       0x7ff381de7744p _PyCFunction_FastCallDict + 340
6       0x7ff381e7593cp
7       0x7ff381e99a7ap _PyEval_EvalFrameDefault + 762
```

There is no useful information for users to fix. After this PR, error message is:
```
Traceback (most recent call last):
  File "./train_gpu_paddle.py", line 471, in <module>
    train(n_token, cutoffs)
  File "./train_gpu_paddle.py", line 254, in train
    decr_ratio=FLAGS.decr_ratio)
  File "/work/Paddle/build_paddle/test/users/transformer-xl-paddlepaddle-lyq/optimization.py", line 151, in optimization
    _, param_grads = optimizer.minimize(loss)
  File "</usr/local/lib/python2.7/dist-packages/decorator.pyc:decorator-gen-20>", line 2, in minimize
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/dygraph/base.py", line 86, in __impl__
    return func(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/optimizer.py", line 594, in minimize
    no_grad_set=no_grad_set)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/optimizer.py", line 493, in backward
    no_grad_set, callbacks)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/backward.py", line 699, in append_backward
    input_grad_names_set=input_grad_names_set)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/backward.py", line 432, in _append_backward_ops_
    op.desc, cpt.to_text(no_grad_dict[block.idx]), grad_sub_block_list)
paddle.fluid.core_avx.EnforceNotMet: grad_op_maker_ should not be null 
Operator range's GradOpMaker has not been registered.                                                                                                                                        
Please check whether range_op has grad_op.
If not, please set stop_gradient to True for its input and output variables using var.step_gradient=True. at [/paddle/paddle/fluid/framework/op_info.h:75]
PaddlePaddle Call Stacks: 
0       0x7f6ffa355188p void paddle::platform::EnforceNotMet::Init<std::string>(std::string, char const*, int) + 360
1       0x7f6ffa3554d7p paddle::platform::EnforceNotMet::EnforceNotMet(std::string const&, char const*, int) + 87 
2       0x7f6ffa356ad9p paddle::framework::OpInfo::GradOpMaker() const + 233
3       0x7f6ffa34db9ep
4       0x7f6ffa3881e6p
```