### PR TITLE
Fix seq_pool failed when input dims is too large

### DIFF
--- a/paddle/fluid/operators/jit/gen/seqpool.cc
+++ b/paddle/fluid/operators/jit/gen/seqpool.cc
@@ -66,7 +66,7 @@ class SeqPoolCreator : public JitCodeCreator<seq_pool_attr_t> {
            ((attr.w / YMM_FLOAT_BLOCK + 4 /* for rest */) *
                 4 /* load, mul and save */ +
             256) *
-               8;
+               16;
   }
   std::unique_ptr<GenBase> CreateJitCode(
       const seq_pool_attr_t& attr) const override {


### PR DESCRIPTION
resolve [#3023](https://github.com/PaddlePaddle/models/issues/3023)
The repetition code:
```python
import paddle
import paddle.fluid as fluid
import numpy as np

dim1 = 1024
dim2 = 256
x = fluid.layers.data(name='x', shape=[dim1, dim2], dtype='float32', lod_level=1)
y = fluid.layers.sequence_pool(x, 'sum')
d = []
for i in range(3):
    d1 = np.random.rand(i + 2, dim1, dim2)
    d.append((d1,))
place = fluid.CPUPlace()
feeder = fluid.DataFeeder(place=place, feed_list=[x])
exe = fluid.Executor(place=place)
exe.run(fluid.default_startup_program())
ret = exe.run(feed=feeder.feed(d), fetch_list=[y])
print(ret[0][0])
```
When running the above code on the CPU, the following error is reported：
![image](https://user-images.githubusercontent.com/9301846/62777056-f1939d80-bade-11e9-953f-7ada7e230d8d.png)

