### PR TITLE
Fix writing errors and remove useless parameters in fleetapi collective mode

### DIFF
--- a/python/paddle/fluid/incubate/fleet/collective/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/collective/__init__.py
@@ -118,10 +118,10 @@ class DistributedStrategy(fluid.BuildStrategy):
         self.exec_strategy = fluid.ExecutionStrategy()
         sync_allreduce = os.getenv("FLAGS_sync_nccl_allreduce")
         if sync_allreduce == "0":
-            self._exec_strategy.num_threads = self.nccl_comm_num + 1
-            if sef.use_hierarchical_allreduce:
-                self._exec_strategy.num_threads = 2 * self.nccl_comm_num + 1
-            if self._exec_strategy.num_threads > 4:
+            self.exec_strategy.num_threads = self.nccl_comm_num + 1
+            if self.use_hierarchical_allreduce:
+                self.exec_strategy.num_threads = 2 * self.nccl_comm_num + 1
+            if self.exec_strategy.num_threads > 4:
                 print(
                     sys.stderr,
                     "WARNING: if you use use_hierarchical_allreduce or "

--- a/python/paddle/fluid/incubate/fleet/collective/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/collective/__init__.py
@@ -118,10 +118,10 @@ class DistributedStrategy(fluid.BuildStrategy):
         self.exec_strategy = fluid.ExecutionStrategy()
         sync_allreduce = os.getenv("FLAGS_sync_nccl_allreduce")
         if sync_allreduce == "0":
-            self._exec_strategy.num_threads = self.nccl_comm_num + 1
+            self.exec_strategy.num_threads = self.nccl_comm_num + 1
             if sef.use_hierarchical_allreduce:
-                self._exec_strategy.num_threads = 2 * self.nccl_comm_num + 1
-            if self._exec_strategy.num_threads > 4:
+                self.exec_strategy.num_threads = 2 * self.nccl_comm_num + 1
+            if self.exec_strategy.num_threads > 4:
                 print(
                     sys.stderr,
                     "WARNING: if you use use_hierarchical_allreduce or "

--- a/python/paddle/fluid/incubate/fleet/collective/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/collective/__init__.py
@@ -102,9 +102,6 @@ class DistributedStrategy(fluid.BuildStrategy):
 
     def __init__(self):
         super(DistributedStrategy, self).__init__()
-        self.fuse_memory_size = -1
-        self.fuse_layer_size = 1
-
         self.use_local_sgd = False
         self.use_dist_fc = False
 
@@ -215,12 +212,6 @@ class CollectiveOptimizer(DistributedOptimizer):
         """
         Transpile the programs to distributed programs. And add the variables.
         """
-        if self._strategy.fuse_all_reduce_ops:
-            os.environ[
-                'FLAGS_fuse_parameter_memory_size'] = self.fuse_memory_size
-            os.environ[
-                'FLAGS_fuse_parameter_groups_size'] = self.fuse_layer_size
-
         worker_endpoints = fleet.worker_endpoints()
         trainer_id = fleet.worker_index()
         current_endpoint = fleet.worker_endpoints()[trainer_id]


### PR DESCRIPTION
fix small bugs in fleetapi collective mode:
- fix writing errors, like exec_strategy, self.
- remove fusion parameters and code which are not effective.