### PR TITLE
test=develop,Optimized error reporting information

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -11,6 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+print_info =""
+if os.name=='nt':
+    try:
+        import scipy.io as scio
+    except ImportError as e:
+        print_info =str(e)
+    if(len(print_info)>0):
+        if 'DLL load failed' in print_info:
+            raise ImportError(print_info+"\nplease download visual C++ Redistributable for vs 2015, https://www.microsoft.com/en-us/download/details.aspx?id=48145")
+
 try:
     from paddle.version import full_version as __version__
     from paddle.version import commit as __git_commit__


### PR DESCRIPTION
将paddle windows安装成功但import出现dll相关的错误信息进行了优化，并给出了visual C++ Redistributable的下载地址，出现该错误的原因是缺少相关dll文件，需要下载visual C++ Redistributable