### PR TITLE
[WIP]RecomputeOptimizer: recompute with checkpoints for very large batch training

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -36,6 +36,7 @@ from . import unique_name
 
 __all__ = [
     'Program',
+    'Variable',
     'default_startup_program',
     'default_main_program',
     'program_guard',

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -23,7 +23,7 @@ from paddle.fluid.framework import Program, Variable, name_scope, default_main_p
 from . import framework
 from . import layers
 from . import unique_name
-from .backward import append_backward, _some_in_set_, _append_grad_suffix_
+from .backward import append_backward, append_backward_with_forward_recomputation, _some_in_set_, _append_grad_suffix_
 from .clip import append_gradient_clip_ops, error_clip_callback
 from .framework import program_guard
 from .initializer import Constant
@@ -2954,7 +2954,7 @@ class PipelineOptimizer(object):
         }
 
 
-class RecomputeOptimizer(Optimizer):
+class RecomputeOptimizer(object):
     """
     Recompute Optimizer Wrapper
     """
@@ -2989,7 +2989,7 @@ class RecomputeOptimizer(Optimizer):
                 # TODO(guru4elephant): should add grad_clip for static graph
                 pass
 
-        optimize_ops = self.apply_optimize(
+        optimize_ops = self._optimizer.apply_optimize(
             loss, startup_program=startup_program, params_grads=params_grads)
 
         return optimize_ops, params_grads

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2988,7 +2988,9 @@ class RecomputeOptimizer(object):
             if grad_clip:
                 # TODO(guru4elephant): should add grad_clip for static graph
                 pass
-
+        for param, grads in params_grads:
+            print(param)
+            print(grads)
         optimize_ops = self._optimizer.apply_optimize(
             loss, startup_program=startup_program, params_grads=params_grads)
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2982,8 +2982,8 @@ class RecomputeOptimizer(Optimizer):
         self._dtype = loss.dtype
         program = loss.block.program
         with program_guard(program, startup_program):
-            params_grads = append_backward_with_checkpoints(
-                loss, parameter_list, no_grad_set, callbacks, self._checkpoints)
+            params_grads = append_backward_with_forward_recomputation(
+                loss, parameter_list, no_grad_set, self._checkpoints)
 
             if grad_clip:
                 # TODO(guru4elephant): should add grad_clip for static graph
@@ -2992,5 +2992,4 @@ class RecomputeOptimizer(Optimizer):
         optimize_ops = self.apply_optimize(
             loss, startup_program=startup_program, params_grads=params_grads)
 
-        return optimize_ops, params_grads
         return optimize_ops, params_grads

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -43,7 +43,7 @@ __all__ = [
     'AdamaxOptimizer', 'DecayedAdagradOptimizer', 'RMSPropOptimizer',
     'FtrlOptimizer', 'Adadelta', 'ModelAverage', 'LarsMomentum',
     'LarsMomentumOptimizer', 'DGCMomentumOptimizer', 'LambOptimizer',
-    'ExponentialMovingAverage', 'PipelineOptimizer'
+    'ExponentialMovingAverage', 'PipelineOptimizer', 'RecomputeOptimizer'
 ]
 
 
@@ -2952,3 +2952,39 @@ class PipelineOptimizer(object):
             "sync_steps": self._sync_steps,
             "param_need_sync": param_need_sync
         }
+
+
+class RecomputeOptimizer(Optimizer):
+    """
+    Recompute Optimizer Wrapper
+    """
+
+    def __init__(self, optimizer, checkpoints):
+        self._optimizer = optimizer
+        self._checkpoints = checkpoints
+
+    def minimize(self,
+                 loss,
+                 startup_program=None,
+                 parameter_list=None,
+                 no_grad_set=None,
+                 grad_clip=None):
+        if framework.in_dygraph_mode():
+            raise NotImplementedError(
+                "DyGraph current does not support recompute")
+
+        self._dtype = loss.dtype
+        program = loss.block.program
+        with program_guard(program, startup_program):
+            params_grads = append_backward_with_checkpoints(
+                loss, parameter_list, no_grad_set, callbacks, self._checkpoints)
+
+            if grad_clip:
+                # TODO(guru4elephant): should add grad_clip for static graph
+                pass
+
+        optimize_ops = self.apply_optimize(
+            loss, startup_program=startup_program, params_grads=params_grads)
+
+        return optimize_ops, params_grads
+        return optimize_ops, params_grads

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2988,9 +2988,6 @@ class RecomputeOptimizer(object):
             if grad_clip:
                 # TODO(guru4elephant): should add grad_clip for static graph
                 pass
-        for param, grads in params_grads:
-            print(param)
-            print(grads)
         optimize_ops = self._optimizer.apply_optimize(
             loss, startup_program=startup_program, params_grads=params_grads)
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2959,8 +2959,11 @@ class RecomputeOptimizer(Optimizer):
     Recompute Optimizer Wrapper
     """
 
-    def __init__(self, optimizer, checkpoints):
+    def __init__(self, optimizer):
         self._optimizer = optimizer
+        self._checkpoints = None
+
+    def _set_checkpoints(self, checkpoints):
         self._checkpoints = checkpoints
 
     def minimize(self,
@@ -2969,6 +2972,9 @@ class RecomputeOptimizer(Optimizer):
                  parameter_list=None,
                  no_grad_set=None,
                  grad_clip=None):
+        if self._checkpoints == None:
+            raise ValueError("You should call _set_checkpoints first")
+
         if framework.in_dygraph_mode():
             raise NotImplementedError(
                 "DyGraph current does not support recompute")


### PR DESCRIPTION
add recompute based checkpoints methods for large batch training
test=develop

example for usage

```python
import paddle.fluid as fluid

def mlp(input_x, input_y, hid_dim=128, label_dim=2):
    fc_1 = fluid.layers.fc(input=input_x, size=hid_dim)
    prediction = fluid.layers.fc(input=[fc_1], size=label_dim, act='softmax')
    cost = fluid.layers.cross_entropy(input=prediction, label=input_y)
    sum_cost = fluid.layers.reduce_sum(cost)
    return sum_cost, fc_1, prediction

input_x = fluid.layers.data(name="x", shape=[32], dtype='float32')
input_y = fluid.layers.data(name="y", shape=[1], dtype='int64')

cost, fc_1, pred = mlp(input_x, input_y)

sgd = fluid.optimizer.SGD(learning_rate=0.01)
sgd = fluid.optimizer.RecomputeOptimizer(sgd)
sgd._set_checkpoints([fc_1, pred])
sgd.minimize(cost)
```