### PR TITLE
Expose set_gradient_clip API

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -24,6 +24,7 @@ from . import core
 from .dygraph.base import _not_support
 
 __all__ = [
+    'set_gradient_clip',
     'ErrorClipByValue',
     'GradientClipByValue',
     'GradientClipByNorm',


### PR DESCRIPTION
`set_gradient_clip` is not exposed because it is not inside `__all__`. This PR exposes it.