### PR TITLE
Fix gather op bug

### DIFF
--- a/paddle/fluid/operators/gather.cu.h
+++ b/paddle/fluid/operators/gather.cu.h
@@ -52,12 +52,12 @@ void GPUGather(const platform::DeviceContext& ctx, const Tensor& src,
   // check index of shape 1-D
   if (index.dims().size() == 1) {
     PADDLE_ENFORCE_GT(index.dims()[0], 0,
-                      "The index of gather_op should not be empty when "
-                      "index.dims().size() == 1.");
+                      "The index of gather_op should not be empty when the "
+                      "index's rank is 1.");
   } else if (index.dims().size() == 2) {
-    PADDLE_ENFORCE_EQ(
-        index.dims()[1], 1,
-        "If index.dims().size() is 2, the seconde dim should be 1.");
+    PADDLE_ENFORCE_EQ(index.dims()[1], 1,
+                      " If the index's rank of gather_op is 2, the second "
+                      "dimension should be 1.");
   }
 
   int index_size = index.dims()[0];

--- a/paddle/fluid/operators/gather.cu.h
+++ b/paddle/fluid/operators/gather.cu.h
@@ -53,6 +53,11 @@ void GPUGather(const platform::DeviceContext& ctx, const Tensor& src,
   // check index of shape 1-D
   PADDLE_ENFORCE((index.dims().size() == 1 && index.dims()[0] > 0) ||
                  (index.dims().size() == 2 && index.dims()[1] == 1));
+  if (index.dims().size() == 1) {
+    PADDLE_ENFORCE_GT(index.dims()[0], 0, "The index should not be empty.");
+  } else if (index.dims().size() == 2) {
+    PADDLE_ENFORCE_EQ(index.dims()[1], 1, "The index should be 1-D.");
+  }
 
   int index_size = index.dims()[0];
 

--- a/paddle/fluid/operators/gather.cu.h
+++ b/paddle/fluid/operators/gather.cu.h
@@ -51,7 +51,7 @@ void GPUGather(const platform::DeviceContext& ctx, const Tensor& src,
                const Tensor& index, Tensor* output) {
   // PADDLE_ENFORCE(platform::is_gpu_place(place));
   // check index of shape 1-D
-  PADDLE_ENFORCE(index.dims().size() == 1 ||
+  PADDLE_ENFORCE((index.dims().size() == 1 && index.dims()[0] > 0) ||
                  (index.dims().size() == 2 && index.dims()[1] == 1));
 
   int index_size = index.dims()[0];

--- a/paddle/fluid/operators/gather.cu.h
+++ b/paddle/fluid/operators/gather.cu.h
@@ -49,14 +49,15 @@ __global__ void GatherCUDAKernel(const T* params, const IndexT* indices,
 template <typename T, typename IndexT = int>
 void GPUGather(const platform::DeviceContext& ctx, const Tensor& src,
                const Tensor& index, Tensor* output) {
-  // PADDLE_ENFORCE(platform::is_gpu_place(place));
   // check index of shape 1-D
-  PADDLE_ENFORCE((index.dims().size() == 1 && index.dims()[0] > 0) ||
-                 (index.dims().size() == 2 && index.dims()[1] == 1));
   if (index.dims().size() == 1) {
-    PADDLE_ENFORCE_GT(index.dims()[0], 0, "The index should not be empty.");
+    PADDLE_ENFORCE_GT(index.dims()[0], 0,
+                      "The index of gather_op should not be empty when "
+                      "index.dims().size() == 1.");
   } else if (index.dims().size() == 2) {
-    PADDLE_ENFORCE_EQ(index.dims()[1], 1, "The index should be 1-D.");
+    PADDLE_ENFORCE_EQ(
+        index.dims()[1], 1,
+        "If index.dims().size() is 2, the seconde dim should be 1.");
   }
 
   int index_size = index.dims()[0];

--- a/paddle/fluid/operators/gather_op.cu
+++ b/paddle/fluid/operators/gather_op.cu
@@ -41,8 +41,6 @@ class GatherOpCUDAKernel : public framework::OpKernel<T> {
         paddle::framework::DataTypeToString(index_type),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT32),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT64));
-    PADDLE_ENFORCE_GT(index->numel(), 0,
-                      "The index of gather_op should not be empty.");
     if (index_type == framework::proto::VarType::INT32) {
       GPUGather<T, int>(ctx.device_context(), *x, *index, output);
     } else if (index_type == framework::proto::VarType::INT64) {

--- a/paddle/fluid/operators/gather_op.cu
+++ b/paddle/fluid/operators/gather_op.cu
@@ -41,6 +41,7 @@ class GatherOpCUDAKernel : public framework::OpKernel<T> {
         paddle::framework::DataTypeToString(index_type),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT32),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT64));
+    PADDLE_ENFORCE_GT(index->numel(), 0, "The index is empty.");
     if (index_type == framework::proto::VarType::INT32) {
       GPUGather<T, int>(ctx.device_context(), *x, *index, output);
     } else if (index_type == framework::proto::VarType::INT64) {

--- a/paddle/fluid/operators/gather_op.cu
+++ b/paddle/fluid/operators/gather_op.cu
@@ -41,7 +41,8 @@ class GatherOpCUDAKernel : public framework::OpKernel<T> {
         paddle::framework::DataTypeToString(index_type),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT32),
         paddle::framework::DataTypeToString(framework::proto::VarType::INT64));
-    PADDLE_ENFORCE_GT(index->numel(), 0, "The index is empty.");
+    PADDLE_ENFORCE_GT(index->numel(), 0,
+                      "The index of gather_op should not be empty.");
     if (index_type == framework::proto::VarType::INT32) {
       GPUGather<T, int>(ctx.device_context(), *x, *index, output);
     } else if (index_type == framework::proto::VarType::INT64) {


### PR DESCRIPTION
Related issue https://github.com/PaddlePaddle/Paddle/issues/19085.
The return of `DDim::size()` is the rank info, this is to say, if the `tensor` is empty, the `tensor.dims().size()` is 1.

https://github.com/PaddlePaddle/Paddle/blob/0019eb376ac83fda927025c1c5c3d8cd54fe4b66/paddle/fluid/framework/ddim.h#L61-L62