### PR TITLE
Fix compatibility issue of fluid.io.save_vars on windows platform

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -217,13 +217,13 @@ def save_vars(executor,
                 continue
             new_var = _clone_var_in_block_(save_block, each_var)
             if filename is None:
+                save_file_path = os.path.join(save_dirname, new_var.name)
+                save_file_path = os.path.normpath(save_file_path)
                 save_block.append_op(
                     type='save',
                     inputs={'X': [new_var]},
                     outputs={},
-                    attrs={
-                        'file_path': os.path.join(save_dirname, new_var.name)
-                    })
+                    attrs={'file_path': save_file_path})
             else:
                 save_var_map[new_var.name] = new_var
 


### PR DESCRIPTION
Fix the problem of saving variables that has `/` in name when using fluid.io.save_vars under windows platform [#19180 ](https://github.com/PaddlePaddle/Paddle/issues/19180).

The reason for this problem is that Windows' default file separator is `\`, and fluid.io.save_vars does not normalize the save path. As a result, both `\` and `/` separators appear in the save path.

![593AF7049523271945AAD77537268820](https://user-images.githubusercontent.com/45024560/62931779-750c0200-bdf1-11e9-9617-0aa200278489.jpg)