### PR TITLE
fix compilation issue in windows vs2017

### DIFF
--- a/cmake/external/gtest.cmake
+++ b/cmake/external/gtest.cmake
@@ -48,7 +48,7 @@ IF(WITH_TESTING OR (WITH_DISTRIBUTE AND NOT WITH_GRPC))
         ${EXTERNAL_PROJECT_LOG_ARGS}
         DEPENDS         ${GTEST_DEPENDS}
         GIT_REPOSITORY  "https://github.com/google/googletest.git"
-        GIT_TAG         "release-1.8.0"
+        GIT_TAG         "release-1.8.1"
         PREFIX          ${GTEST_SOURCES_DIR}
         UPDATE_COMMAND  ""
         CMAKE_ARGS      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/cmake/external/gtest.cmake
+++ b/cmake/external/gtest.cmake
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 #FIXME:(gongwb) Move brpc's gtest dependency.
+
+include(GNUInstallDirs)
+
 IF(WITH_TESTING OR (WITH_DISTRIBUTE AND NOT WITH_GRPC))
     IF(WITH_TESTING)
         ENABLE_TESTING()
@@ -28,14 +31,14 @@ IF(WITH_TESTING OR (WITH_DISTRIBUTE AND NOT WITH_GRPC))
 
     IF(WIN32)
         set(GTEST_LIBRARIES
-            "${GTEST_INSTALL_DIR}/lib/gtest.lib" CACHE FILEPATH "gtest libraries." FORCE)
+            "${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/gtest.lib" CACHE FILEPATH "gtest libraries." FORCE)
         set(GTEST_MAIN_LIBRARIES
-            "${GTEST_INSTALL_DIR}/lib/gtest_main.lib" CACHE FILEPATH "gtest main libraries." FORCE)
+            "${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/gtest_main.lib" CACHE FILEPATH "gtest main libraries." FORCE)
     ELSE(WIN32)
         set(GTEST_LIBRARIES
-            "${GTEST_INSTALL_DIR}/lib/libgtest.a" CACHE FILEPATH "gtest libraries." FORCE)
+            "${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libgtest.a" CACHE FILEPATH "gtest libraries." FORCE)
         set(GTEST_MAIN_LIBRARIES
-            "${GTEST_INSTALL_DIR}/lib/libgtest_main.a" CACHE FILEPATH "gtest main libraries." FORCE)
+            "${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/libgtest_main.a" CACHE FILEPATH "gtest main libraries." FORCE)
     ENDIF(WIN32)
 
     IF(WITH_MKLML)

--- a/paddle/fluid/framework/ir/memory_optimize_pass/memory_optimization_var_info.h
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/memory_optimization_var_info.h
@@ -58,7 +58,7 @@ class MemOptVarInfo {
 };
 
 using MemOptVarInfoMapList = std::vector<
-    std::unordered_map<std::string, std::unique_ptr<MemOptVarInfo>>>;
+    std::unordered_map<std::string, std::shared_ptr<MemOptVarInfo>>>;
 
 class SkipMemOptVarsGuard {
  public:


### PR DESCRIPTION
1. upgrade the version of gtest to avoid compilation issue when compiling with msvc141+ (vs2017+)
2. unique_ptr in unordered_map will cause "attempting to reference a deleted function" error, change it to shared_ptr.