### PR TITLE
Remove the warning for reminding user to avoid using the OriginProgram method.

### DIFF
--- a/paddle/fluid/framework/ir/graph.h
+++ b/paddle/fluid/framework/ir/graph.h
@@ -200,12 +200,7 @@ class Graph {
   // WARN: After a series of passes, the current graph can be quite
   // different from OriginProgram. Caller shouldn't assume much from
   // the returned OriginProgram.
-  const ProgramDesc &OriginProgram() const {
-    LOG(WARNING) << "WARN: After a series of passes, the current graph can be "
-                    "quite different from OriginProgram. So, please avoid "
-                    "using the `OriginProgram()` method!";
-    return program_;
-  }
+  const ProgramDesc &OriginProgram() const { return program_; }
 
   // This method takes ownership of `node`.
   ir::Node *AddNode(ir::Node *node) {


### PR DESCRIPTION
Remove the warning for reminding user to avoid using the OriginProgram method.  fixed #19245