### PR TITLE
Fix sequence mask in dygraph

### DIFF
--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -144,6 +144,15 @@ class DataParallel(layers.Layer):
         self._layers = layers
         self._strategy = strategy
 
+    def __getattr__(self, key):
+        if key in self.__dict__:
+            return object.__getattribute__(self, key)
+        elif key is '_layers':
+            return object.__getattribute__(self, "_sub_layers")["_layers"]
+        else:
+            return getattr(
+                object.__getattribute__(self, "_sub_layers")["_layers"], key)
+
     def forward(self, *inputs, **kwargs):
         return self._layers(*inputs, **kwargs)
 

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -144,15 +144,6 @@ class DataParallel(layers.Layer):
         self._layers = layers
         self._strategy = strategy
 
-    def __getattr__(self, key):
-        if key in self.__dict__:
-            return object.__getattribute__(self, key)
-        elif key is '_layers':
-            return object.__getattribute__(self, "_sub_layers")["_layers"]
-        else:
-            return getattr(
-                object.__getattribute__(self, "_sub_layers")["_layers"], key)
-
     def forward(self, *inputs, **kwargs):
         return self._layers(*inputs, **kwargs)
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -9646,9 +9646,6 @@ def sequence_mask(x, maxlen=None, dtype='int64', name=None):
             mask = layers.sequence_mask(x=x)
 
     """
-    assert not in_dygraph_mode(), (
-        "sequence layer is not supported in dygraph mode yet.")
-
     helper = LayerHelper('sequence_mask', **locals())
     if name is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)


### PR DESCRIPTION
One fix:

- The wrong assertion that cannot use `sequence_mask` op in dygraph, for this op has nothing to do `LoDTensor`, not like other sequence ops. 