### PR TITLE
Add use_ngraph option to image classification unit tests

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
@@ -28,6 +28,9 @@ void SetConfig(AnalysisConfig *cfg) {
   cfg->SwitchSpecifyInputNames();
   cfg->SetCpuMathLibraryNumThreads(FLAGS_paddle_num_threads);
   cfg->EnableMKLDNN();
+#ifdef PADDLE_WITH_NGRAPH
+  if (FLAGS_use_ngraph) cfg->EnableNgraph();
+#endif
 }
 
 template <typename T>

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -58,6 +58,9 @@ DEFINE_bool(zero_copy, false, "Use ZeroCopy to speedup Feed/Fetch.");
 DEFINE_bool(warmup, false,
             "Use warmup to calculate elapsed_time more accurately. "
             "To reduce CI time, it sets false in default.");
+#ifdef PADDLE_WITH_NGRAPH
+DEFINE_bool(use_ngraph, false, "Use nGraph to run the inference program.");
+#endif
 
 DECLARE_bool(profile);
 DECLARE_int32(paddle_num_threads);


### PR DESCRIPTION
This patch adds an option to enable NGraph in unit tests for image classification FP32&INT8 inference.

test=develop