### PR TITLE
stronger the error message of tensor's mutable_data

### DIFF
--- a/paddle/fluid/framework/tensor.cc
+++ b/paddle/fluid/framework/tensor.cc
@@ -40,7 +40,9 @@ void* Tensor::mutable_data(platform::Place place, proto::VarType::Type type,
   PADDLE_ENFORCE_GE(numel(), 0,
                     "When calling this method, the Tensor's numel must be "
                     "equal or larger than zero. "
-                    "Please check Tensor::Resize has been called first.");
+                    "Please check Tensor::Resize has been called first. "
+                    "The Tensor's shape is [",
+                    dims(), "] now");
   size_t size = numel() * SizeOfType(type);
   if (requested_size) {
     PADDLE_ENFORCE_GE(requested_size, size);
@@ -57,8 +59,8 @@ void* Tensor::mutable_data(platform::Place place, proto::VarType::Type type,
 }
 
 void* Tensor::mutable_data(platform::Place place, size_t requested_size) {
-  PADDLE_ENFORCE(this->holder_ != nullptr,
-                 "Cannot invoke mutable data if current hold nothing.");
+  PADDLE_ENFORCE_NOT_NULL(
+      this->holder_, "Cannot invoke mutable data if current hold nothing.");
   return mutable_data(place, type_, requested_size);
 }
 

--- a/paddle/fluid/framework/tensor.cc
+++ b/paddle/fluid/framework/tensor.cc
@@ -40,8 +40,8 @@ void* Tensor::mutable_data(platform::Place place, proto::VarType::Type type,
   PADDLE_ENFORCE_GE(numel(), 0,
                     "When calling this method, the Tensor's numel must be "
                     "equal or larger than zero. "
-                    "Please check Tensor::Resize has been called first. "
-                    "The Tensor's shape is [",
+                    "Please check Tensor::dims, or Tensor::Resize has been "
+                    "called first. The Tensor's shape is [",
                     dims(), "] now");
   size_t size = numel() * SizeOfType(type);
   if (requested_size) {


### PR DESCRIPTION
mutable _data的错误，就是如果shape设置错了，mutable data的时候就会报错，说numel=-1，但是没有把具体的shape给出来 @phlrain 提出
![image](https://user-images.githubusercontent.com/6836917/63333850-b4e06580-c36c-11e9-911f-049aa92d7373.png)

这个PR会把shape打出。类似以下截图
![image](https://user-images.githubusercontent.com/6836917/63333945-e8bb8b00-c36c-11e9-84b3-57247031b688.png)

文字版类似：
```
30: C++ exception with description "Enforce failed. Expected numel() <= 0, but received numel():216 > 0:0.
30: When calling this method, the Tensor's numel must be equal or larger than zero. Please check Tensor::Resize has been called first. The Tensor's shape is [2, 3, 4, 9] now at [/home/luotao/Paddle/paddle/fluid/framework/tensor.cc:44]
```