### PR TITLE
Remove is_mem_optimized in Program

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2854,10 +2854,6 @@ class Program(object):
         self._use_hierarchical_allreduce = False
         self._hierarchical_allreduce_inter_nranks = 0
 
-        # @deprecated(the python memory optimize transpiler is deprecated)
-        # whether the program is optimized by memory_optimize_transpiler
-        self.__is_mem_optimized = False
-
         # if this program has been optimized by distributed optimizer
         # fleet_opt will be given a value
         self._fleet_opt = None
@@ -2868,16 +2864,6 @@ class Program(object):
 
         # appending gradients times
         self._appending_grad_times = 0
-
-    @property
-    def _is_mem_optimized(self):
-        # if the program is optimized, operator input/outputs
-        # maybe same, which conflict with save_inference_model.
-        return self.__is_mem_optimized
-
-    @_is_mem_optimized.setter
-    def _is_mem_optimized(self, target):
-        self.__is_mem_optimized = target
 
     @property
     def _op_role(self):

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1028,13 +1028,6 @@ def save_inference_model(dirname,
 
     if main_program is None:
         main_program = default_main_program()
-        if main_program._is_mem_optimized:
-            warnings.warn(
-                "save_inference_model must put before you call memory_optimize. \
-                                            the memory_optimize will modify the original program, \
-                                            is not suitable for saving inference model \
-                                            we save the original program as inference model.",
-                RuntimeWarning)
 
     elif not isinstance(main_program, Program):
         raise TypeError("program should be as Program type or None")


### PR DESCRIPTION
`Program._is_mem_optimized` is a very fancy field that is not important to framework itself. This PR removes this field for clean codes.