### PR TITLE
change get hash key inputName to tensor pointer; test=develop

### DIFF
--- a/paddle/fluid/operators/mkldnn/lrn_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/lrn_mkldnn_op.cc
@@ -63,7 +63,8 @@ class LRNMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         dims, platform::MKLDNNGetDataType<T>(), x->format());
 
     const std::string key = platform::LRNMKLDNNHandler::GetHash(
-        dims, n, alpha, beta, k, x->format(), ctx.op().Output("Out"));
+        dims, n, alpha, beta, k, x->format(),
+        std::to_string(*reinterpret_cast<int*> out));
 
     platform::LRNMKLDNNHandler handler(ctx.Attr<bool>("is_test"), dev_ctx,
                                        mkldnn_engine, key);
@@ -121,8 +122,10 @@ class LRNMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
 
     auto dims = paddle::framework::vectorize2int(x->dims());
 
+    auto orig_out = ctx.Input<Tensor>("Out");
     const std::string key = platform::LRNMKLDNNHandler::GetHash(
-        dims, n, alpha, beta, k, x->format(), ctx.op().Input("Out"));
+        dims, n, alpha, beta, k, x->format(),
+        std::to_string(*reinterpret_cast<int*> orig_out));
 
     platform::LRNMKLDNNHandler handler(false, dev_ctx, mkldnn_engine, key);
 


### PR DESCRIPTION
### 背景
在动态图模式下，OperatorBase在每一个op中，都会被构造和析构，OperatorBase中保存了两个成员变量，VariableNameMap inputs_, outputs_, 这两个成员变量的构造和析构花费了很多时间，大约有30%的c++端的开销。

在后续版本中，input_, output_ 成员变量以及相关的函数 Input(), Output()会被移除。

这个PR改动了MKLDNN相关的部分，想请Intel的人看下改动是否可以。

### Background:
In dygraph mode, `OperatorBase` will be constructed and destructed in each Op. About 30% time cost on the construction and destruction of `VariableNameMap inputs_`  and `VariableNameMap ouputs_`.

Thus, `Input()`/`Output()` interface, and `input_`/`output_` variable will be removed from OperatorBase later.

This PR modify the MKLDNN related codes, @jczaja @jianhang-liu Could you please review it?