### PR TITLE
Enable seresnext reduce test

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_gpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_gpu.py
@@ -18,8 +18,6 @@ from test_parallel_executor_seresnext_with_reduce_cpu import TestResnetWithReduc
 
 
 class TestResnetWithReduceGPU(TestResnetWithReduceBase):
-    # TODO(zcd): temporally disable reduce_and_allreduce test because of the random failure.
-    @unittest.skip("should fix this later.")
     def test_seresnext_with_reduce(self):
         self._compare_reduce_and_allreduce(use_cuda=True, delta2=1e-2)
 


### PR DESCRIPTION
Enable seresnext reduce test. I've run five times in the CI system, and this unit test has never failed.