### PR TITLE
Fix bug of getting bool Flags from os.environ

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -86,6 +86,9 @@ DEFINE_bool(reader_queue_speed_test_mode, false,
             "If set true, the queue.pop will only get data from queue but not "
             "remove the data from queue for speed testing");
 DECLARE_bool(use_mkldnn);
+#ifdef PADDLE_WITH_NGRAPH
+DECLARE_bool(use_ngraph);
+#endif
 
 // disable auto conversion to list in Python
 PYBIND11_MAKE_OPAQUE(paddle::framework::LoDTensorArray);
@@ -740,6 +743,9 @@ All parameter, weight, gradient are variables in Paddle.
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });
   m.def("get_flags_use_mkldnn", []() { return FLAGS_use_mkldnn; });
+#ifdef PADDLE_WITH_NGRAPH
+  m.def("get_flags_use_ngraph", []() { return FLAGS_use_ngraph; });
+#endif
 
   m.def("prune", [](const ProgramDesc &origin,
                     const std::vector<std::array<size_t, 2>> &targets) {

--- a/python/paddle/fluid/contrib/slim/tests/test_mkldnn_int8_quantization_strategy.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_mkldnn_int8_quantization_strategy.py
@@ -162,7 +162,7 @@ class TestMKLDNNPostTrainingQuantStrategy(unittest.TestCase):
                  fetch_targets] = fluid.io.load_inference_model(
                      model_path, exe, 'model', 'params')
 
-            use_mkldnn = bool(os.getenv("FLAGS_use_mkldnn", False))
+            use_mkldnn = fluid.core.get_flags_use_mkldnn()
             if (use_mkldnn):
                 graph = IrGraph(
                     core.Graph(inference_program.desc), for_test=True)

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -506,7 +506,9 @@ class OpTest(unittest.TestCase):
                 build_strategy.enable_inplace = enable_inplace
                 compiled_program = fluid.CompiledProgram(
                     grad_program).with_data_parallel(
-                        build_strategy=build_strategy, places=place)
+                        loss_name="",
+                        build_strategy=build_strategy,
+                        places=place)
                 outs = exe.run(compiled_program,
                                feed=grad_feed_map,
                                fetch_list=grad_fetch_list,

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -678,7 +678,8 @@ class OpTest(unittest.TestCase):
                 return []
         places = [fluid.CPUPlace()]
         cpu_only = self._cpu_only if hasattr(self, '_cpu_only') else False
-        use_ngraph = bool(os.getenv("FLAGS_use_ngraph", False))
+        use_ngraph = fluid.core.is_compiled_with_ngraph(
+        ) and fluid.core.get_flags_use_ngraph()
         if use_ngraph:
             cpu_only = True
         if core.is_compiled_with_cuda() and core.op_support_gpu(self.op_type)\


### PR DESCRIPTION
This PR fix a bug of getting bool Flags from os.environ. For example, original code use 
`use_ngraph = bool(os.getenv("FLAGS_use_ngraph", False))` 
`use_mkldnn = bool(os.getenv("FLAGS_use_mkldnn", False))`
to get bool Flags from os.environ, but when user set `export FLAGS_use_mkldnn=False`, the code becomes `use_mkldnn = bool('False')` which returns True, and it is wrong.

Since paddle use `gflags` to handle commandline flags in C++, to keep the consistency of flags processing logic between Python and C++, this PR create methods in `pybind.cc` to get the `Flags_xx` processed by C++.