### PR TITLE
Update inplace grad test to fit new CompiledProgram API

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -506,7 +506,9 @@ class OpTest(unittest.TestCase):
                 build_strategy.enable_inplace = enable_inplace
                 compiled_program = fluid.CompiledProgram(
                     grad_program).with_data_parallel(
-                        build_strategy=build_strategy, places=place)
+                        loss_name="",
+                        build_strategy=build_strategy,
+                        places=place)
                 outs = exe.run(compiled_program,
                                feed=grad_feed_map,
                                fetch_list=grad_fetch_list,


### PR DESCRIPTION
[PR18919](https://github.com/PaddlePaddle/Paddle/pull/18919)  updates CompiledProgram, it assert sloss_name not None in `with_data_parallel`.
This PR updates inplace grad test to fit new CompiledProgram API by adding empty loss_name to `with_data_parallel`.