### PR TITLE
fix multi-thread exec of trt, test=release/1.5

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -35,8 +35,15 @@ void TensorRTEngine::Build(const DescType &paddle_model) {
 void TensorRTEngine::Execute(int batch_size, std::vector<void *> *buffers,
                              cudaStream_t stream) {
   freshDeviceId();
+  const std::thread::id tid = std::this_thread::get_id();
   batch_size_ = batch_size;
-  infer_context_->enqueue(batch_size, buffers->data(), stream, nullptr);
+  if (infer_context_.find(tid) == infer_context_.end()) {
+    PADDLE_ENFORCE_NOT_NULL(
+        infer_engine_,
+        "You should build engine first and then set the context.");
+    infer_context_[tid].reset(infer_engine_->createExecutionContext());
+  }
+  infer_context_[tid]->enqueue(batch_size, buffers->data(), stream, nullptr);
   cudaStreamSynchronize(stream);
   SetRuntimeBatch(batch_size);
 }
@@ -91,8 +98,6 @@ void TensorRTEngine::FreezeNetwork() {
 
   infer_engine_.reset(infer_builder_->buildCudaEngine(*infer_network_));
   PADDLE_ENFORCE(infer_engine_ != nullptr, "build cuda engine failed!");
-
-  infer_context_.reset(infer_engine_->createExecutionContext());
 }
 
 nvinfer1::ITensor *TensorRTEngine::DeclareInput(const std::string &name,

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -125,7 +125,6 @@ class TensorRTEngine {
         &inference::Singleton<plugin::PluginFactoryTensorRT>::Global()));
     PADDLE_ENFORCE(infer_engine_ != nullptr,
                    "build cuda engine failed when deserialize engine info.!");
-    infer_context_.reset(infer_engine_->createExecutionContext());
   }
 
   void SetRuntimeBatch(size_t batch_size);
@@ -197,7 +196,8 @@ class TensorRTEngine {
   infer_ptr<nvinfer1::IBuilder> infer_builder_;
   infer_ptr<nvinfer1::INetworkDefinition> infer_network_;
   infer_ptr<nvinfer1::ICudaEngine> infer_engine_;
-  infer_ptr<nvinfer1::IExecutionContext> infer_context_;
+  std::unordered_map<std::thread::id, infer_ptr<nvinfer1::IExecutionContext>>
+      infer_context_;
   infer_ptr<nvinfer1::IHostMemory> ihost_memory_;
   std::unordered_map<nvinfer1::ITensor*, float> quant_dynamic_range_;
 };  // class TensorRTEngine


### PR DESCRIPTION
[Cherry-pick of commit e1eca83, test=release/1.5]

The problem is only triggered by TensorRT and Clone(), and the user feedbacks that using version 1.4 can avoid this problem. There are two reasons for the final confirmation:

TensorRT uses the uniqueness of the molecular graph of the predictor_id area. Predictor::Clone() will change the predictor_id value, but the logic of TensorRT subgraph passes the predictor_id by value when Pass, and the Clone() does not re-trigger Pass, so the uniqueness fails.
Prior to commit ae576f3, the Deserialize() call to the TensorRT subgraph occurred at tensorrt_engine_op.h, once for each cloned-predictor. After this commit, the call occurred at tensorrt_subgraph_pass.cc, only once in ir_pass of master-predictor.
This pull request fixed the bug.