### PR TITLE
delete recordio writer

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -114,7 +114,6 @@ __all__ = framework.__all__ + executor.__all__ + \
         'dygraph_grad_clip',
         'profiler',
         'unique_name',
-        'recordio_writer',
         'Scope',
         'install_check',
     ]


### PR DESCRIPTION
recordio_writer is out of date, and we remove it from the \_\_init\_\_.py file from now.