### PR TITLE
test=release/1.5, fix problem that get_attr method can't using defaul…

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -212,6 +212,8 @@ class Layer(core.Layer):
             return self._parameters[name]
         elif name in self._sub_layers:
             return self._sub_layers[name]
+        else:
+            return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
         if isinstance(value, framework.Parameter):

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -2403,9 +2403,9 @@ class GroupNorm(layers.Layer):
 
     def forward(self, input):
         inputs = {'X': input}
-        if self._bias:
+        if self._bias_attr:
             inputs['Bias'] = self._bias
-        if self._scale:
+        if self._param_attr:
             inputs['Scale'] = self._scale
 
         # create output

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -405,6 +405,13 @@ class TestImperative(unittest.TestCase):
         self.assertTrue(np.allclose(dy_grad_h2h2, static_grad_h2h))
         self.assertTrue(np.allclose(dy_grad_i2h2, static_grad_i2h))
 
+    def test_layer_attrs(self):
+        layer = fluid.dygraph.Layer("test")
+        layer.test_attr = 1
+        self.assertFalse(hasattr(layer, "whatever"))
+        self.assertTrue(hasattr(layer, "test_attr"))
+        self.assertEqual(layer.test_attr, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_imperative_deepcf.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_deepcf.py
@@ -73,7 +73,6 @@ class MLP(fluid.Layer):
                 self.add_sublayer(
                     'match_layer_%d' % i,
                     fluid.FC(self.full_name(), self._hid_sizes[i], act='relu')))
-        self._mat
 
     def forward(self, users, items):
         users = self._user_latent(users)


### PR DESCRIPTION
cherry-pick fix problem that get_attr method can't using defaulmode when we call has_attr in dygraph (#19328)

* add default getItem

* test=develop, fix has_attr disabled error in Layer

* test=develop, fix GroupNorm and deepcf bug on attrs