### PR TITLE
Add signal message to stderr

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -206,6 +206,7 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
 static void SignalHandle(const char *data, int size) {
   auto file_path = string::Sprintf("/tmp/paddle.%d.dump_info", ::getpid());
   try {
+    LOG(WARNING) << "Signal raises!\n" + std::string(data, size);
     std::ofstream dump_info;
     dump_info.open(file_path, std::ios::app);
     dump_info << std::string(data, size);

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -203,7 +203,7 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
 }
 
 #ifndef _WIN32
-static void SignalHandle(const char *data, int size) {
+void SignalHandle(const char *data, int size) {
   auto file_path = string::Sprintf("/tmp/paddle.%d.dump_info", ::getpid());
   try {
     LOG(WARNING) << "Signal raises!\n" + std::string(data, size);

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -32,5 +32,9 @@ void InitDevices(bool init_p2p, const std::vector<int> devices);
 
 void InitDGC();
 
+#ifndef _WIN32
+void SignalHandle(const char *data, int size);
+#endif
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/platform/init_test.cc
+++ b/paddle/fluid/platform/init_test.cc
@@ -38,3 +38,10 @@ TEST(InitDevices, CUDA) {
   ASSERT_EQ(pool.size(), 1U + static_cast<unsigned>(count));
 #endif
 }
+
+#ifndef _WIN32
+TEST(SignalHandle, SignalHandle) {
+  std::string msg = "Signal raises";
+  paddle::framework::SignalHandle(msg.c_str(), msg.size());
+}
+#endif


### PR DESCRIPTION
Originally, messages of `SIGSEG` or other signals would be written to file. This is not helpful for debugging CI unittests, which would randomly fail due to segmentation fault. This PR prints the signal messages to `stderr` before they are written to file.