### PR TITLE
Add initialize check for the persistable variables created by optimizer to polish the error message of run(startup_porgram) position sensitive program

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -398,6 +398,12 @@ const Tensor* GetLoDTensorOrSelectedRowsValueFromVar(const Variable& var) {
   }
 }
 
+bool TensorInVarIsInitialized(const Variable* var) {
+  auto* tensor_in = GetLoDTensorOrSelectedRowsValueFromVar(*var);
+  if (!tensor_in->IsInitialized()) return false;
+  return true;
+}
+
 Tensor* GetMutableLoDTensorOrSelectedRowsValueFromVar(Variable* var) {
   if (var->IsType<LoDTensor>()) {
     return var->GetMutable<LoDTensor>();
@@ -704,6 +710,8 @@ class RuntimeInferShapeContext : public InferShapeContext {
     PADDLE_ENFORCE_EQ(vars.size(), 1UL,
                       "Input(%s) should hold one element, but now it holds %d",
                       name, vars.size());
+    PADDLE_ENFORCE_EQ(TensorInVarIsInitialized(vars[0]), true,
+                      "Input variable %s has not been initialized.", name);
     return this->GetDim(vars[0]);
   }
 


### PR DESCRIPTION
This PR wants to solve the `run(startup_program) ` position sensitive program. When `run(startup_program) ` is executed before `optimizer.minimize`, because the parameters added by `optimizer` are not initialized, which will cause run failed. The error message is like:

![image](https://user-images.githubusercontent.com/22561442/63696775-03e73880-c84e-11e9-80d1-d9ba94b0a1f6.png)

this error occur to `RunTimeInferShape` phase. the program doesn't check whether the tensor in `LearningRate` variable is initialized, and get the dim of variable used to compare directly, which is the reason that this error messgae is not easy to understand. So this PR add the `tensor->IsInitialized` for persistable Input variable check in optimize ops to provide a clear error messgae.

I add `tensor->IsInitialized` check into `GetInputDim` function, the result after change is like：



I think it's not very good to put the `tensor->Initialized check`  into `infershape check` phase, and I try to add the similar check in `op->RunImpl` or `ctx->HasInput`, but it will introduce heavy time costs. Maybe there is a better way to solve this problem.