### PR TITLE
make PADDLE_ENFORCE ci check rule more robust

### DIFF
--- a/paddle/fluid/framework/async_executor.cc
+++ b/paddle/fluid/framework/async_executor.cc
@@ -78,10 +78,6 @@ void AsyncExecutor::RunFromFile(const ProgramDesc& main_program,
     auto var_desc = block.FindVar(var_name);
     PADDLE_ENFORCE_NOT_NULL(var_desc, "%s is not found.", var_name);
     auto shapes = var_desc->GetShape();
-    PADDLE_ENFORCE(shapes[shapes.size() - 1] == 1,
-                   "var %s: Fetched var has wrong shape, "
-                   "only variables with the last dimension size 1 supported",
-                   var_name);
   }
 
   DataFeedDesc data_feed_desc;

--- a/paddle/fluid/framework/async_executor.cc
+++ b/paddle/fluid/framework/async_executor.cc
@@ -82,7 +82,7 @@ void AsyncExecutor::RunFromFile(const ProgramDesc& main_program,
 
   DataFeedDesc data_feed_desc;
   bool success = data_feed_desc.ParseFromString(data_feed_desc_str);
-  PADDLE_ENFORCE(success, "Fail to parse DataFeedDesc from string:\n%s",
+  PADDLE_ENFORCE(success, "Change, Fail to parse DataFeedDesc from string:\n%s",
                  data_feed_desc_str.c_str());
 
   actual_thread_num_ = thread_num;

--- a/paddle/fluid/framework/async_executor.cc
+++ b/paddle/fluid/framework/async_executor.cc
@@ -78,16 +78,20 @@ void AsyncExecutor::RunFromFile(const ProgramDesc& main_program,
     auto var_desc = block.FindVar(var_name);
     PADDLE_ENFORCE_NOT_NULL(var_desc, "%s is not found.", var_name);
     auto shapes = var_desc->GetShape();
+    PADDLE_ENFORCE(shapes[shapes.size() - 1] == 1,
+                   "var %s: Fetched var has wrong shape, "
+                   "only variables with the last dimension size 1 supported",
+                   var_name);
   }
 
   DataFeedDesc data_feed_desc;
   bool success = data_feed_desc.ParseFromString(data_feed_desc_str);
-  PADDLE_ENFORCE(success, "Change, Fail to parse DataFeedDesc from string:\n%s",
+  PADDLE_ENFORCE(success, "Fail to parse DataFeedDesc from string:\n%s",
                  data_feed_desc_str.c_str());
 
   actual_thread_num_ = thread_num;
   int file_cnt = filelist.size();
-  PADDLE_ENFORCE_GT(file_cnt, 0, "File list cannot be empty");
+  PADDLE_ENFORCE(file_cnt > 0, "File list cannot be empty");
 
   if (actual_thread_num_ > file_cnt) {
     VLOG(1) << "Thread num = " << thread_num << ", file num = " << file_cnt

--- a/paddle/fluid/framework/async_executor.cc
+++ b/paddle/fluid/framework/async_executor.cc
@@ -87,7 +87,7 @@ void AsyncExecutor::RunFromFile(const ProgramDesc& main_program,
 
   actual_thread_num_ = thread_num;
   int file_cnt = filelist.size();
-  PADDLE_ENFORCE(file_cnt > 0, "File list cannot be empty");
+  PADDLE_ENFORCE_GT(file_cnt, 0, "File list cannot be empty");
 
   if (actual_thread_num_ > file_cnt) {
     VLOG(1) << "Thread num = " << thread_num << ", file num = " << file_cnt

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -116,7 +116,7 @@ if [ ${HAS_DEFINE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     fi
 fi
 
-HAS_PADDLE_ENFORCE_FLAG=`git diff -U0 upstream/$BRANCH |grep -v "PADDLE_ENFORCE_" |grep -o -m 1 "PADDLE_ENFORCE" || true`
+HAS_PADDLE_ENFORCE_FLAG=`git diff -U0 upstream/$BRANCH |grep "+" |grep -v "PADDLE_ENFORCE_" |grep -o -m 1 "PADDLE_ENFORCE" || true`
 if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
     python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`


### PR DESCRIPTION
#19088 中增加了对`PADDLE_ENFORCE`的检查，会检查`git diff`的内容。但如果删去了`PADDLE_ENFORCE`，也会触发这个规则。

因此这个PR做了加强，只检查`git diff "+"`的内容，即增加（更新）的部分，不再对删除部分进行检查。