### PR TITLE
Add persistable variables initialized check in exe.run to polish the error message of run(startup_porgram) before optimizer.minimize

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -642,7 +642,7 @@ class Executor(object):
             if not program.is_startup_program() and \
                 not _all_persistable_vars_initialized(program, scope):
                 raise RuntimeError(
-                    "There are persistable variables in the current program that are not initialized. \n"
+                    "There are persistable variables in the current program that are not initialized. \n"\
                     "Please confirm that you have run startup_program and run it after fluid.optimizer.minimize()."
                 )
             program._add_new_elements = False

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -638,11 +638,14 @@ class Executor(object):
         if scope is None:
             scope = global_scope()
 
-        if not program.is_startup_program() and \
-            not _all_persistable_vars_initialized(program, scope):
-            raise RuntimeError(
-                "There are persistable variables in the current program that are not initialized. Please confirm that you have run startup_program and run it after fluid.optimizer.minimize()."
-            )
+        if program._add_new_elements:
+            if not program.is_startup_program() and \
+                not _all_persistable_vars_initialized(program, scope):
+                raise RuntimeError(
+                    "There are persistable variables in the current program that are not initialized. \n"
+                    "Please confirm that you have run startup_program and run it after fluid.optimizer.minimize()."
+                )
+            program._add_new_elements = False
 
         if fetch_list is not None:
             if isinstance(fetch_list, Variable) or isinstance(fetch_list, str):

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3581,6 +3581,13 @@ class Program(object):
             for each_var in list(each_block.vars.values()):
                 yield each_var
 
+    def is_startup_program(self):
+        for each_block in self.blocks:
+            for each_var in list(each_block.vars.values()):
+                if not each_var.persistable:
+                    return False
+        return True
+
 
 class Parameter(Variable):
     """

--- a/python/paddle/fluid/tests/unittests/test_persistable_vars_init_check.py
+++ b/python/paddle/fluid/tests/unittests/test_persistable_vars_init_check.py
@@ -1,0 +1,109 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import contextlib
+import numpy
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+
+
+class TestPersistableVarsInitCheck(unittest.TestCase):
+    def forward_net_func(self):
+        x = fluid.layers.data(name='X', shape=[13], dtype='float32')
+        y = fluid.layers.data(name='Y', shape=[1], dtype='float32')
+        y_ = fluid.layers.fc(input=x, size=1, act=None)
+        loss = fluid.layers.square_error_cost(input=y_, label=y)
+        avg_loss = fluid.layers.mean(loss)
+        return avg_loss
+
+    def test_run_startup_after_minimize(self):
+        with self.program_scope_guard():
+            place = core.CPUPlace()
+            exe = fluid.Executor(place)
+
+            avg_loss = self.forward_net_func()
+            fluid.optimizer.SGD(learning_rate=0.01).minimize(avg_loss)
+            exe.run(fluid.default_startup_program())
+
+            input_x = numpy.random.random(size=(10, 13)).astype('float32')
+            input_y = numpy.random.random(size=(10, 1)).astype('float32')
+            exe.run(fluid.default_main_program(),
+                    feed={'X': input_x,
+                          'Y': input_y},
+                    fetch_list=[avg_loss.name])
+
+    def test_run_startup_before_minimize(self):
+        with self.program_scope_guard():
+            place = core.CPUPlace()
+            exe = fluid.Executor(place)
+
+            avg_loss = self.forward_net_func()
+            exe.run(fluid.default_startup_program())
+            fluid.optimizer.SGD(learning_rate=0.01).minimize(avg_loss)
+
+            input_x = numpy.random.random(size=(10, 13)).astype('float32')
+            input_y = numpy.random.random(size=(10, 1)).astype('float32')
+            with self.assertRaisesRegexp(RuntimeError,
+                "There are persistable variables in the current program that are not initialized. \n"\
+                "Please confirm that you have run startup_program and run it after fluid.optimizer.minimize()."):
+                exe.run(fluid.default_main_program(),
+                        feed={'X': input_x,
+                              'Y': input_y},
+                        fetch_list=[avg_loss.name])
+
+    def test_add_new_elements_flag_state(self):
+        with self.program_scope_guard():
+            place = core.CPUPlace()
+            exe = fluid.Executor(place)
+            main_program = fluid.default_main_program()
+
+            avg_loss = self.forward_net_func()
+            self.assertTrue(main_program._add_new_elements)
+
+            input_x = numpy.random.random(size=(10, 13)).astype('float32')
+            input_y = numpy.random.random(size=(10, 1)).astype('float32')
+
+            exe.run(fluid.default_startup_program())
+            exe.run(fluid.default_main_program(),
+                    feed={'X': input_x,
+                          'Y': input_y},
+                    fetch_list=[avg_loss.name])
+            self.assertFalse(main_program._add_new_elements)
+
+            fluid.optimizer.SGD(learning_rate=0.01).minimize(avg_loss)
+            self.assertTrue(main_program._add_new_elements)
+
+            exe.run(fluid.default_startup_program())
+            exe.run(fluid.default_main_program(),
+                    feed={'X': input_x,
+                          'Y': input_y},
+                    fetch_list=[avg_loss.name])
+            self.assertFalse(main_program._add_new_elements)
+
+    @contextlib.contextmanager
+    def program_scope_guard(self):
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        scope = fluid.core.Scope()
+        with fluid.scope_guard(scope):
+            with fluid.program_guard(prog, startup_prog):
+                yield
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR wants to solve the `run(startup_program) ` position sensitive program. When `run(startup_program) ` is executed before `optimizer.minimize`, because the parameters added by `optimizer` are not initialized, which will cause run failed. The error message is like:

![image](https://user-images.githubusercontent.com/22561442/63743800-fe323700-c8cf-11e9-9694-1bd42884eb54.png)

this error occur to `RunTimeInferShape` phase. the program doesn't check whether the tensor in `LearningRate` variable is initialized, and get the dim of variable used to compare directly, which is the reason that this error messgae is not easy to understand. 

So this PR add persistable Input variables check in exe.run(main_program), the result after change is like：

![image](https://user-images.githubusercontent.com/22561442/63743922-6254fb00-c8d0-11e9-98fa-833423da4bd0.png)

This method is not very elegant, maybe there is a better way to solve this problem.
