### PR TITLE
Fix softmax segmentation fault in AVX

### DIFF
--- a/paddle/fluid/operators/math/cpu_vec.h
+++ b/paddle/fluid/operators/math/cpu_vec.h
@@ -160,7 +160,7 @@ inline void vec_sum<float, platform::avx>(const size_t n, const float* x,
   end = n & ~(block - 1);
   __m256 tmp = _mm256_setzero_ps();
   for (i = 0; i < end; i += block) {
-    tmp = _mm256_add_ps(tmp, _mm256_load_ps(x + i));
+    tmp = _mm256_add_ps(tmp, _mm256_loadu_ps(x + i));
   }
 
   __m256 hsum = _mm256_hadd_ps(tmp, tmp);


### PR DESCRIPTION
`_mm256_load_ps` would raise `SIGSEG` when the address is not aligned, which makes softmax op segmentation fault when compiled with debug mode. This PR fixes it by using `_mm256_loadu_ps `.

<img width="1422" alt="8b2fc171ab8248a42954fec5dce84127" src="https://user-images.githubusercontent.com/32832641/63833433-a108b500-c9a5-11e9-8212-b2d0cfd6fefe.png">
