### PR TITLE
Change backward_guard to optimize_guard to maximize the allreduce overlap.

### DIFF
--- a/paddle/fluid/framework/operator_kernel_configs.h
+++ b/paddle/fluid/framework/operator_kernel_configs.h
@@ -21,6 +21,14 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
+  out << "[";
+  for (auto const& tmp : v) out << tmp << ",";
+  out << "]";
+  return out;
+}
+
 // Not thread-safe. Should be owned per-kernel.
 template <typename TAlgorithm>
 class AlgorithmsCache {
@@ -80,6 +88,8 @@ TAlgorithm framework::AlgorithmsCache<TAlgorithm>::GetAlgorithm(
 
   seed ^= hashFn(static_cast<int64_t>(algorithmFlags)) + 0x9e3779b9 +
           (seed << 6) + (seed >> 2) + 5;
+
+  VLOG(10) << "seed:" << seed;
 
   if (seed == 0) return gen_func();
 

--- a/paddle/fluid/framework/operator_kernel_configs.h
+++ b/paddle/fluid/framework/operator_kernel_configs.h
@@ -21,14 +21,6 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-template <typename T>
-std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
-  out << "[";
-  for (auto const& tmp : v) out << tmp << ",";
-  out << "]";
-  return out;
-}
-
 // Not thread-safe. Should be owned per-kernel.
 template <typename TAlgorithm>
 class AlgorithmsCache {
@@ -89,7 +81,7 @@ TAlgorithm framework::AlgorithmsCache<TAlgorithm>::GetAlgorithm(
   seed ^= hashFn(static_cast<int64_t>(algorithmFlags)) + 0x9e3779b9 +
           (seed << 6) + (seed >> 2) + 5;
 
-  VLOG(10) << "seed:" << seed;
+  VLOG(10) << "seed:" << seed << ", hash_.size:" << hash_.size();
 
   if (seed == 0) return gen_func();
 

--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -22,6 +22,14 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
+template <typename T>
+std::ostream& operator<<(std::ostream& out, const std::vector<T>& v) {
+  out << "[";
+  for (auto const& tmp : v) out << tmp << ",";
+  out << "]";
+  return out;
+}
+
 using framework::AlgorithmsCache;
 
 struct ConvArgs {
@@ -119,7 +127,8 @@ struct SearchAlgorithm<cudnnConvolutionFwdAlgoPerf_t> {
       auto x_dims = framework::vectorize(args.x->dims());
       auto w_dims = framework::vectorize(args.w->dims());
 
-      VLOG(10) << "cudnnConvolutionFwdAlgoPerf_t x_dims:" << x_dims
+      VLOG(10) << "cudnnConvolutionFwdAlgoPerf_t algo_cache_id:"
+               << algo_cache_id << ", x_dims:" << x_dims
                << ", w_dims:" << w_dims << ", args.s" << args.s << ", args.p"
                << args.p << ", args.d" << args.d;
 
@@ -251,7 +260,8 @@ struct SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t> {
       auto x_dims = framework::vectorize(args.x->dims());
       auto w_dims = framework::vectorize(args.w->dims());
 
-      VLOG(10) << "cudnnConvolutionBwdDataAlgoPerf_t x_dims:" << x_dims
+      VLOG(10) << "cudnnConvolutionFwdAlgoPerf_t algo_cache_id:"
+               << algo_cache_id << ", x_dims:" << x_dims
                << ", w_dims:" << w_dims << ", args.s" << args.s << ", args.p"
                << args.p << ", args.d" << args.d;
 
@@ -376,7 +386,8 @@ struct SearchAlgorithm<cudnnConvolutionBwdFilterAlgoPerf_t> {
       auto x_dims = framework::vectorize(args.x->dims());
       auto w_dims = framework::vectorize(args.w->dims());
 
-      VLOG(10) << "cudnnConvolutionBwdFilterAlgoPerf_t x_dims:" << x_dims
+      VLOG(10) << "cudnnConvolutionFwdAlgoPerf_t algo_cache_id:"
+               << algo_cache_id << ", x_dims:" << x_dims
                << ", w_dims:" << w_dims << ", args.s" << args.s << ", args.p"
                << args.p << ", args.d" << args.d;
 

--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -119,6 +119,10 @@ struct SearchAlgorithm<cudnnConvolutionFwdAlgoPerf_t> {
       auto x_dims = framework::vectorize(args.x->dims());
       auto w_dims = framework::vectorize(args.w->dims());
 
+      VLOG(10) << "cudnnConvolutionFwdAlgoPerf_t x_dims:" << x_dims
+               << ", w_dims:" << w_dims << ", args.s" << args.s << ", args.p"
+               << args.p << ", args.d" << args.d;
+
       algo = algo_cache.GetAlgorithm(
           x_dims, w_dims, args.s, args.p, args.d, 0, [&]() {
             int returned_algo_count;
@@ -247,6 +251,10 @@ struct SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t> {
       auto x_dims = framework::vectorize(args.x->dims());
       auto w_dims = framework::vectorize(args.w->dims());
 
+      VLOG(10) << "cudnnConvolutionBwdDataAlgoPerf_t x_dims:" << x_dims
+               << ", w_dims:" << w_dims << ", args.s" << args.s << ", args.p"
+               << args.p << ", args.d" << args.d;
+
       algo = algo_cache.GetAlgorithm(
           x_dims, w_dims, args.s, args.p, args.d, 0, [&]() {
             int returned_algo_count;
@@ -367,6 +375,10 @@ struct SearchAlgorithm<cudnnConvolutionBwdFilterAlgoPerf_t> {
 
       auto x_dims = framework::vectorize(args.x->dims());
       auto w_dims = framework::vectorize(args.w->dims());
+
+      VLOG(10) << "cudnnConvolutionBwdFilterAlgoPerf_t x_dims:" << x_dims
+               << ", w_dims:" << w_dims << ", args.s" << args.s << ", args.p"
+               << args.p << ", args.d" << args.d;
 
       algo = algo_cache.GetAlgorithm(
           x_dims, w_dims, args.s, args.p, args.d, 0, [&]() {

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
@@ -80,8 +80,11 @@ def create_master_params_grads(params_grads, main_prog, startup_prog,
         A list of master parameters and gradients. 
     """
     master_params_grads = []
-    with main_prog._backward_role_guard():
-        for p, g in params_grads:
+    #with main_prog._backward_role_guard():
+    #    for p, g in params_grads:
+    for p, g in params_grads:
+        # create master parameters
+        with main_prog._optimized_guard([p, g]):
             # create master parameters
             master_param = copy_to_master_param(p, main_prog.global_block())
             startup_master_param = startup_prog.global_block()._clone_variable(

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
@@ -80,8 +80,6 @@ def create_master_params_grads(params_grads, main_prog, startup_prog,
         A list of master parameters and gradients. 
     """
     master_params_grads = []
-    #with main_prog._backward_role_guard():
-    #    for p, g in params_grads:
     for p, g in params_grads:
         # create master parameters
         with main_prog._optimized_guard([p, g]):

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -278,8 +278,8 @@ class DataFeeder(object):
 
         for each_sample in iterable:
             assert len(each_sample) == len(converter), (
-                "The number of fields in data (%s) does not match " +
-                "len(feed_list) (%s)") % (len(each_sample), len(converter))
+                "The number of fields in data (%d) does not match " +
+                "len(feed_list) (%d)") % (len(each_sample), len(converter))
             for each_converter, each_slot in six.moves.zip(converter,
                                                            each_sample):
                 each_converter.feed(each_slot)


### PR DESCRIPTION
1. Change backward_guard to optimize_guard to maximize the allreduce overlap.
If we put `cast` operator in backward stage， it will wait for allredudce completion, and since paddle has only one compute stream, the stream will hang for waiting. So we need to put cast operator in optimize stage to avoid this.
![image](https://user-images.githubusercontent.com/10721757/64071265-21326180-cca9-11e9-819d-b745c6e49066.png)

2. Add more logs to locate potential problem.