### PR TITLE
Modify the dropout op to multi-thread

### DIFF
--- a/paddle/fluid/operators/dropout_op.h
+++ b/paddle/fluid/operators/dropout_op.h
@@ -77,13 +77,18 @@ class CPUDropoutKernel : public framework::OpKernel<T> {
         }
       }
     } else {
-      auto X = EigenMatrix<T>::Reshape(*x, 1);
-      auto Y = EigenMatrix<T>::Reshape(*y, 1);
-      auto& place =
-          *context.template device_context<DeviceContext>().eigen_device();
       if (upscale_in_train) {
-        Y.device(place) = X;
+        const auto* X_data = x->data<T>();
+        auto* Y_data = y->mutable_data<T>(context.GetPlace());
+#pragma omp parallel for
+        for (int i = 0; i < x->numel(); i++) {
+          Y_data[i] = X_data[i];
+        }
       } else {
+        auto X = EigenMatrix<T>::Reshape(*x, 1);
+        auto Y = EigenMatrix<T>::Reshape(*y, 1);
+        auto& place =
+            *context.template device_context<DeviceContext>().eigen_device();
         Y.device(place) = X * static_cast<T>(1.0f - dropout_prob);
       }
     }


### PR DESCRIPTION
Modify the dropout with multi-thread (paddle/fluid/operators/dropout_op.h).
Performance update for 20 threads:
62.6822 ms->54.5076 ms
优化前profile：
![屏幕快照 2019-08-28 16 53 20](https://user-images.githubusercontent.com/53294385/63840893-60646800-c9b4-11e9-813c-ca9be7feb9b8.png)


优化后profile:
![屏幕快照 2019-08-28 16 46 14](https://user-images.githubusercontent.com/53294385/63840783-327f2380-c9b4-11e9-94d0-84e87cd05519.png)