### PR TITLE
Remove signal raise msg

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -206,7 +206,7 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
 void SignalHandle(const char *data, int size) {
   auto file_path = string::Sprintf("/tmp/paddle.%d.dump_info", ::getpid());
   try {
-    LOG(WARNING) << "Signal raises!\n" + std::string(data, size);
+    LOG(WARNING) << std::string(data, size);
     std::ofstream dump_info;
     dump_info.open(file_path, std::ios::app);
     dump_info << std::string(data, size);


### PR DESCRIPTION
Previously, `Signal raises` would print too many times when signal raises. This PR removes it to guarantee the clean error message.

<img width="1268" alt="0c13dda6c20b9e24ff62886f1a4c8af8" src="https://user-images.githubusercontent.com/32832641/63987975-b3e9c980-cb0c-11e9-9b08-feb9a1d6cb0a.png">
