### PR TITLE
fix kernel config bug in dygraph mode

### DIFF
--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -376,8 +376,8 @@ std::vector<VarBasePtrMap> OpBase::ApplyGrad(
     framework::Scope scope;
     PreparedOp p = PreparedOp::Prepare(ctx, *op_kernel, place_);
     p.op.RuntimeInferShape(scope, place_, ctx);
-    p.func(
-        framework::ExecutionContext(p.op, scope, *p.dev_ctx, p.ctx, nullptr));
+    p.func(framework::ExecutionContext(p.op, scope, *p.dev_ctx, p.ctx,
+                                       p.kernel_configs));
   }
 
   platform::RecordEvent record_event("merge_grads");

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -98,6 +98,7 @@ class PreparedOp {
     }
     std::vector<framework::KernelConfig>* kernel_configs =
         op.GetKernelConfig(expected_kernel_key);
+
     return PreparedOp(op, ctx, kernel_iter->second, dev_ctx, kernel_configs);
   }
 


### PR DESCRIPTION
kernel config 在动态图下面没有透传到 executionContext