### PR TITLE
Fix conv2d+dequantize squash for residual fusion

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -177,7 +177,12 @@ void CPUQuantizeSquashPass::ConvDequantSquash(Graph* graph) const {
     GET_IR_NODE_FROM_SUBGRAPH(dequant_out, dequant_out, conv_dequant_pattern);
 
     // if conv2d has one output
-    if (conv_out->outputs.size() == 1) {
+    // and there is no fuse residual connection
+    // because residual fusion does not support force output with fp32
+    if (conv_out->outputs.size() == 1 &&
+        !(conv_op->Op()->HasAttr("fuse_residual_connection") &&
+          boost::get<bool>(
+              conv_op->Op()->GetAttr("fuse_residual_connection")))) {
       conv_op->Op()->SetAttr("force_fp32_output", true);
       conv_op->Op()->SetOutput("Output",
                                std::vector<std::string>({dequant_out->Name()}));

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -180,9 +180,7 @@ void CPUQuantizeSquashPass::ConvDequantSquash(Graph* graph) const {
     // and there is no fuse residual connection
     // because residual fusion does not support force output with fp32
     if (conv_out->outputs.size() == 1 &&
-        !(conv_op->Op()->HasAttr("fuse_residual_connection") &&
-          boost::get<bool>(
-              conv_op->Op()->GetAttr("fuse_residual_connection")))) {
+        !(conv_op->Op()->GetAttrIfExists<bool>("fuse_residual_connection"))) {
       conv_op->Op()->SetAttr("force_fp32_output", true);
       conv_op->Op()->SetOutput("Output",
                                std::vector<std::string>({dequant_out->Name()}));


### PR DESCRIPTION
It fix recently merged PR #18905
The squash `conv2d+dequantize` must be skipped if the `conv2d` op has the attribute `fuse_residual_connection` set to `true`, because residual fusion does not support force output with fp32.

There is no change in number of squashed pairs in mobilenet_ssd. 
