### PR TITLE
fix the bug that when exec thread number set to 0, it m ay lead to no execute thread available for PE

### DIFF
--- a/paddle/fluid/framework/details/execution_strategy.h
+++ b/paddle/fluid/framework/details/execution_strategy.h
@@ -22,7 +22,8 @@ namespace details {
 struct ExecutionStrategy {
   enum ExecutorType { kDefault = 0, kExperimental = 1 };
 
-  size_t num_threads_{0};
+  // num_threads indicates the size of thread pool.
+  size_t num_threads_{1};
   bool use_cuda_{true};
   bool allow_op_delay_{false};
   // If we set this to 1, we will delete all variables when finish a batch. and


### PR DESCRIPTION
fix the PE issue when exec thread number set to 0
it may lead to no execute thread available for PE