### PR TITLE
using MKLDNNMemoryFormat = mkldnn::memory::format changes

### DIFF
--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -18,7 +18,6 @@
 
 #include "paddle/fluid/operators/math/math_function.h"
 #ifdef PADDLE_WITH_MKLDNN
-#include "paddle/fluid/platform/mkldnn_helper.h"
 #include "paddle/fluid/platform/mkldnn_reuse.h"
 #endif
 
@@ -135,8 +134,8 @@ void innerTransDataLayoutFromMKLDNN(DataLayout in_layout, DataLayout out_layout,
                                     const Tensor& in, Tensor* out,
                                     platform::Place place) {
 #ifdef PADDLE_WITH_MKLDNN
-  PADDLE_ENFORCE(in.format() != memory::format::format_undef &&
-                     in.format() != memory::format::any,
+  PADDLE_ENFORCE(in.format() != MKLDNNMemoryFormat::format_undef &&
+                     in.format() != MKLDNNMemoryFormat::any,
                  "Input tensor should have specified memory format");
 
   // Set default as NCHW in case not specified
@@ -183,7 +182,7 @@ void innerTransDataLayoutFromMKLDNN(DataLayout in_layout, DataLayout out_layout,
   }
   out->set_layout(out_layout);
   // reset format since the out tensor will be feed to non-MKLDNN OPkernel
-  out->set_format(memory::format::format_undef);
+  out->set_format(MKLDNNMemoryFormat::format_undef);
 #endif
 }
 

--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -134,9 +134,10 @@ void innerTransDataLayoutFromMKLDNN(DataLayout in_layout, DataLayout out_layout,
                                     const Tensor& in, Tensor* out,
                                     platform::Place place) {
 #ifdef PADDLE_WITH_MKLDNN
-  PADDLE_ENFORCE(in.format() != MKLDNNMemoryFormat::format_undef &&
-                     in.format() != MKLDNNMemoryFormat::any,
-                 "Input tensor should have specified memory format");
+  PADDLE_ENFORCE_NE(in.format(), MKLDNNMemoryFormat::format_undef,
+                    "Input tensor should have specified memory format");
+  PADDLE_ENFORCE_NE(in.format(), MKLDNNMemoryFormat::any,
+                    "Input tensor should have specified memory format");
 
   // Set default as NCHW in case not specified
   out_layout =

--- a/paddle/fluid/framework/data_layout_transform.h
+++ b/paddle/fluid/framework/data_layout_transform.h
@@ -21,30 +21,33 @@
 #include "paddle/fluid/framework/tensor.h"
 #include "paddle/fluid/framework/variable.h"
 
+#ifdef PADDLE_WITH_MKLDNN
+#include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
 namespace paddle {
 namespace framework {
 
 #ifdef PADDLE_WITH_MKLDNN
-using MKLDNNFormat = mkldnn::memory::format;
 using MKLDNNDataType = mkldnn::memory::data_type;
 
-inline MKLDNNFormat ToMKLDNNFormat(const DataLayout& layout) {
+inline MKLDNNMemoryFormat ToMKLDNNFormat(const DataLayout& layout) {
   switch (layout) {
     case DataLayout::kNHWC:
-      return MKLDNNFormat::nhwc;
+      return MKLDNNMemoryFormat::nhwc;
     case DataLayout::kNCHW:
-      return MKLDNNFormat::nchw;
+      return MKLDNNMemoryFormat::nchw;
     default:
       PADDLE_THROW("Fail to convert layout %s to MKLDNN format",
                    DataLayoutToString(layout));
   }
 }
 
-inline DataLayout ToPaddleLayout(const MKLDNNFormat& format) {
+inline DataLayout ToPaddleLayout(const MKLDNNMemoryFormat& format) {
   switch (format) {
-    case MKLDNNFormat::nhwc:
+    case MKLDNNMemoryFormat::nhwc:
       return DataLayout::kNHWC;
-    case MKLDNNFormat::nchw:
+    case MKLDNNMemoryFormat::nchw:
       return DataLayout::kNCHW;
     default:
       PADDLE_THROW("Fail to convert MKLDNN format to paddle layout");

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -119,12 +119,15 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
       z->set_layout(DataLayout::kMKLDNN);
       z->set_format(format);
     } else {
-      PADDLE_ENFORCE(x->layout() == DataLayout::kMKLDNN &&
-                         x->format() != MKLDNNMemoryFormat::format_undef,
-                     "Wrong layout/format set for X tensor");
-      PADDLE_ENFORCE(y->layout() == DataLayout::kMKLDNN &&
-                         y->format() != MKLDNNMemoryFormat::format_undef,
-                     "Wrong layout/format set for Y tensor");
+      PADDLE_ENFORCE_EQ(x->layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for X tensor");
+      PADDLE_ENFORCE_NE(x->format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for X tensor");
+
+      PADDLE_ENFORCE_EQ(y->layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for Y tensor");
+      PADDLE_ENFORCE_NE(y->format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for Y tensor");
 
       std::vector<int> src_x_tz = framework::vectorize2int(x_dims);
       std::vector<int> src_y_tz = framework::vectorize2int(y_dims_untrimed);

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -55,20 +55,20 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
     // broadcast operations need to performed.
     if (x_dims != y_dims_untrimed) {
       Tensor _x;
-      mkldnn::memory::format format;
+      MKLDNNMemoryFormat format;
       std::vector<int> src_x_tz = framework::vectorize2int(x_dims);
 
       if ((src_x_tz.size() == 3 &&
-           x->format() != (format = memory::format::ncw)) ||
+           x->format() != (format = MKLDNNMemoryFormat::ncw)) ||
           (src_x_tz.size() == 4 &&
-           x->format() != (format = memory::format::nchw)) ||
+           x->format() != (format = MKLDNNMemoryFormat::nchw)) ||
           (src_x_tz.size() == 5 &&
-           x->format() != (format = memory::format::ncdhw))) {
+           x->format() != (format = MKLDNNMemoryFormat::ncdhw))) {
         _x.Resize(x_dims);
 
         mkldnn::memory::data_type in_type = platform::MKLDNNGetDataType<T>();
         auto out_format = platform::MKLDNNFormatForSize(
-            x_dims.size(), mkldnn::memory::format::nchw);
+            x_dims.size(), MKLDNNMemoryFormat::nchw);
 
         const std::string key = platform::ReorderMKLDNNHandler::GetHash(
             src_x_tz, x->format(), out_format, std::to_string(in_type));
@@ -120,10 +120,10 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
       z->set_format(format);
     } else {
       PADDLE_ENFORCE(x->layout() == DataLayout::kMKLDNN &&
-                         x->format() != memory::format::format_undef,
+                         x->format() != MKLDNNMemoryFormat::format_undef,
                      "Wrong layout/format set for X tensor");
       PADDLE_ENFORCE(y->layout() == DataLayout::kMKLDNN &&
-                         y->format() != memory::format::format_undef,
+                         y->format() != MKLDNNMemoryFormat::format_undef,
                      "Wrong layout/format set for Y tensor");
 
       std::vector<int> src_x_tz = framework::vectorize2int(x_dims);
@@ -148,7 +148,7 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
           paddle::platform::to_void_cast(y_data));
 
       auto dst_md = memory::desc({dst_tz}, platform::MKLDNNGetDataType<T>(),
-                                 memory::format::any);
+                                 MKLDNNMemoryFormat::any);
 
       auto sum_pd = handler.AcquireSumPrimitiveDescriptor(
           {src_x_memory, src_y_memory}, scales, dst_md);
@@ -164,8 +164,9 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
       stream(stream::kind::eager).submit(pipeline).wait();
 
       z->set_layout(DataLayout::kMKLDNN);
-      z->set_format(
-          (memory::format)dst_memory->get_primitive_desc().desc().data.format);
+      z->set_format((MKLDNNMemoryFormat)dst_memory->get_primitive_desc()
+                        .desc()
+                        .data.format);
     }
   }
 };

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_mul_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_mul_mkldnn_op.cc
@@ -37,7 +37,7 @@ static void UpdateDataFormat(const framework::ExecutionContext& ctx,
   if (ctx.op().HasAttr(attribute)) {
     auto format_as_string = ctx.Attr<std::string>(attribute);
     auto format = StringToMKLDNNFormat(&format_as_string);
-    if (format != memory::format::any) {
+    if (format != MKLDNNMemoryFormat::any) {
       tensor->set_format(format);
     }
   }
@@ -51,7 +51,8 @@ static void ReorderInput(framework::Tensor* tensor,
   auto dims = paddle::framework::vectorize2int(tensor->dims());
   framework::Tensor out_tensor;
   out_tensor.Resize(tensor->dims());
-  out_tensor.set_format(isFourDim ? memory::format::nchw : memory::format::nc);
+  out_tensor.set_format(isFourDim ? MKLDNNMemoryFormat::nchw
+                                  : MKLDNNMemoryFormat::nc);
   out_tensor.set_layout(tensor->layout());
   mkldnn::memory input_memory = {
       {{dims, platform::MKLDNNGetDataType<T>(), tensor->format()}, engine},
@@ -86,8 +87,8 @@ class ElementwiseMulMKLDNNKernel : public framework::OpKernel<T> {
 
     const bool is_avx512_enabled = platform::MayIUse(platform::avx512f);
     const bool are_dims_divisable = !(x_int_dims[1] % 16);
-    const bool is_x_format_correct = x->format() == memory::format::nChw16c;
-    const bool is_y_format_correct = y->format() == memory::format::nc;
+    const bool is_x_format_correct = x->format() == MKLDNNMemoryFormat::nChw16c;
+    const bool is_y_format_correct = y->format() == MKLDNNMemoryFormat::nc;
     if (is_x_format_correct && is_y_format_correct && are_dims_divisable &&
         is_avx512_enabled) {
       int pre, n, post;
@@ -133,12 +134,12 @@ class ElementwiseMulMKLDNNKernel : public framework::OpKernel<T> {
     } else {
       // Fallback to naive version:
       const bool are_inputs_in_same_format = x->format() == y->format();
-      const bool is_x_nchw = x->format() == memory::format::nchw;
-      const bool is_x_nc = x->format() == memory::format::nc;
-      const bool is_x_x = x->format() == memory::format::x;
-      const bool is_y_nchw = y->format() == memory::format::nchw;
-      const bool is_y_nc = y->format() == memory::format::nc;
-      const bool is_y_x = y->format() == memory::format::x;
+      const bool is_x_nchw = x->format() == MKLDNNMemoryFormat::nchw;
+      const bool is_x_nc = x->format() == MKLDNNMemoryFormat::nc;
+      const bool is_x_x = x->format() == MKLDNNMemoryFormat::x;
+      const bool is_y_nchw = y->format() == MKLDNNMemoryFormat::nchw;
+      const bool is_y_nc = y->format() == MKLDNNMemoryFormat::nc;
+      const bool is_y_x = y->format() == MKLDNNMemoryFormat::x;
       if (!are_inputs_in_same_format) {
         using platform::MKLDNNDeviceContext;
         auto& dev_ctx = ctx.template device_context<MKLDNNDeviceContext>();

--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -48,7 +48,7 @@ class MKLDNNActivationKernel
   void Compute(const framework::ExecutionContext &ctx) const override {
     const auto *x = ctx.Input<Tensor>("X");
     PADDLE_ENFORCE(x->layout() == DataLayout::kMKLDNN &&
-                       x->format() != memory::format::format_undef,
+                       x->format() != MKLDNNMemoryFormat::format_undef,
                    "Wrong layout/format set for Input x tensor");
 
     Functor functor;
@@ -63,7 +63,7 @@ class MKLDNNActivationGradKernel
   void Compute(const framework::ExecutionContext &ctx) const override {
     const auto *diff_y = ctx.Input<Tensor>(framework::GradVarName("Out"));
     PADDLE_ENFORCE(diff_y->layout() == DataLayout::kMKLDNN &&
-                       diff_y->format() != memory::format::format_undef,
+                       diff_y->format() != MKLDNNMemoryFormat::format_undef,
                    "Wrong layout/format set for Input OutGrad tensor");
 
     PADDLE_ENFORCE(
@@ -97,8 +97,7 @@ void eltwise_forward(const framework::ExecutionContext &ctx,
 
   std::vector<int> src_tz = framework::vectorize2int(x->dims());
 
-  auto src_format =
-      src_tz.size() == 2 ? mkldnn::memory::format::nc : x->format();
+  auto src_format = src_tz.size() == 2 ? MKLDNNMemoryFormat::nc : x->format();
 
   bool is_test = ctx.Attr<bool>("is_test");
 
@@ -152,10 +151,10 @@ void eltwise_grad(const framework::ExecutionContext &ctx,
 
   // diff_dst and src dims should be the same
   auto src_format =
-      diff_dst_tz.size() == 2 ? mkldnn::memory::format::nc : x->format();
+      diff_dst_tz.size() == 2 ? MKLDNNMemoryFormat::nc : x->format();
 
   auto diff_y_format =
-      diff_dst_tz.size() == 2 ? mkldnn::memory::format::nc : diff_y->format();
+      diff_dst_tz.size() == 2 ? MKLDNNMemoryFormat::nc : diff_y->format();
 
   auto diff_dst_md = platform::MKLDNNMemDesc(
       diff_dst_tz, platform::MKLDNNGetDataType<T>(), diff_y_format);

--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -47,9 +47,10 @@ class MKLDNNActivationKernel
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
     const auto *x = ctx.Input<Tensor>("X");
-    PADDLE_ENFORCE(x->layout() == DataLayout::kMKLDNN &&
-                       x->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input x tensor");
+    PADDLE_ENFORCE_EQ(x->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for X tensor");
+    PADDLE_ENFORCE_NE(x->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for X tensor");
 
     Functor functor;
     functor(ctx);
@@ -62,12 +63,13 @@ class MKLDNNActivationGradKernel
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
     const auto *diff_y = ctx.Input<Tensor>(framework::GradVarName("Out"));
-    PADDLE_ENFORCE(diff_y->layout() == DataLayout::kMKLDNN &&
-                       diff_y->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input OutGrad tensor");
+    PADDLE_ENFORCE_EQ(diff_y->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input OutGrad tensor");
+    PADDLE_ENFORCE_NE(diff_y->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input OutGrad tensor");
 
-    PADDLE_ENFORCE(
-        !ctx.Attr<bool>("is_test"),
+    PADDLE_ENFORCE_EQ(
+        ctx.Attr<bool>("is_test"), false,
         "is_test attribute should be set to False in training phase.");
 
     Functor functor;

--- a/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/batch_norm_mkldnn_op.cc
@@ -192,9 +192,10 @@ class BatchNormMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     const auto *scale = ctx.Input<Tensor>("Scale");
     const auto *shift = ctx.Input<Tensor>("Bias");
 
-    PADDLE_ENFORCE(x->layout() == DataLayout::kMKLDNN &&
-                       x->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input x tensor");
+    PADDLE_ENFORCE_EQ(x->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for X tensor");
+    PADDLE_ENFORCE_NE(x->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for X tensor");
 
     const T *x_data = x->data<T>();
     const T *mean_data = mean->data<T>();
@@ -332,9 +333,10 @@ class BatchNormMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     auto *diff_scale = ctx.Output<Tensor>(framework::GradVarName("Scale"));
     auto *diff_shift = ctx.Output<Tensor>(framework::GradVarName("Bias"));
 
-    PADDLE_ENFORCE(diff_y->layout() == DataLayout::kMKLDNN &&
-                       diff_y->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input diff_y tensor");
+    PADDLE_ENFORCE_EQ(diff_y->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input diff_y tensor");
+    PADDLE_ENFORCE_NE(diff_y->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input diff_y tensor");
 
     const T *x_data = x->data<T>();
     const T *diff_y_data = diff_y->data<T>();

--- a/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
@@ -32,7 +32,7 @@ static void EnforceLayouts(const std::vector<const Tensor*> inputs) {
   for (auto* input : inputs) {
     const bool is_layout_correct = input->layout() == DataLayout::kMKLDNN;
     const bool is_format_defined =
-        input->format() != memory::format::format_undef;
+        input->format() != MKLDNNMemoryFormat::format_undef;
     PADDLE_ENFORCE(is_layout_correct && is_format_defined,
                    "Wrong layout/format set for Input tensor");
   }
@@ -48,9 +48,9 @@ static memory::primitive_desc CreateMemPrimDesc(const Tensor& input,
   return mem_prim_desc;
 }
 
-static mkldnn::memory::format GetDstMemFormat(
+static MKLDNNMemoryFormat GetDstMemFormat(
     const concat::primitive_desc& concat_pd) {
-  return (memory::format)concat_pd.dst_primitive_desc().desc().data.format;
+  return (MKLDNNMemoryFormat)concat_pd.dst_primitive_desc().desc().data.format;
 }
 
 static platform::CPUPlace GetCpuPlace(
@@ -126,7 +126,7 @@ class ConcatPrimitiveFactory {
   memory::desc CreateDstMemDescriptor(Tensor* output,
                                       const memory::data_type& dt) {
     auto dst_dims = paddle::framework::vectorize2int(output->dims());
-    return memory::desc(dst_dims, dt, memory::format::any);
+    return memory::desc(dst_dims, dt, MKLDNNMemoryFormat::any);
   }
 
   mkldnn::memory CreateDstMemory(const concat::primitive_desc& concat_pd,

--- a/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
@@ -30,11 +30,10 @@ using platform::to_void_cast;
 
 static void EnforceLayouts(const std::vector<const Tensor*> inputs) {
   for (auto* input : inputs) {
-    const bool is_layout_correct = input->layout() == DataLayout::kMKLDNN;
-    const bool is_format_defined =
-        input->format() != MKLDNNMemoryFormat::format_undef;
-    PADDLE_ENFORCE(is_layout_correct && is_format_defined,
-                   "Wrong layout/format set for Input tensor");
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
   }
 }
 

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -129,22 +129,38 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    PADDLE_ENFORCE(input->layout() == DataLayout::kMKLDNN &&
-                       input->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input tensor");
-    PADDLE_ENFORCE(filter->layout() == DataLayout::kMKLDNN &&
-                       filter->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Filter tensor");
-    PADDLE_ENFORCE(input->dims().size() == 4 || input->dims().size() == 5,
-                   "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
-    PADDLE_ENFORCE(filter->dims().size() == 4 || filter->dims().size() == 5,
-                   "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
+
+    PADDLE_ENFORCE_EQ(filter->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Filter tensor");
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Filter tensor");
+
+    PADDLE_ENFORCE_GE(
+        input->dims().size(), 4,
+        "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
+    PADDLE_ENFORCE_LE(
+        input->dims().size(), 5,
+        "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
+
+    PADDLE_ENFORCE_GE(
+        filter->dims().size(), 4,
+        "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+    PADDLE_ENFORCE_LE(
+        filter->dims().size(), 5,
+        "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+
     if (bias) {
-      PADDLE_ENFORCE(bias->layout() == DataLayout::kMKLDNN &&
-                         bias->format() != MKLDNNMemoryFormat::format_undef,
-                     "Wrong layout/format set for Bias tensor");
-      PADDLE_ENFORCE(bias->dims().size() == 1,
-                     "Bias must only have 1 dimension, i.e. X");
+      PADDLE_ENFORCE_EQ(bias->layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for Bias tensor");
+      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for Bias tensor");
+
+      PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
+                        "Bias must only have 1 dimension, i.e. X");
     }
 
     std::vector<int> strides = ctx.Attr<std::vector<int>>("strides");
@@ -328,22 +344,38 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    PADDLE_ENFORCE(input->layout() == DataLayout::kMKLDNN &&
-                       input->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input tensor");
-    PADDLE_ENFORCE(filter->layout() == DataLayout::kMKLDNN &&
-                       filter->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Filter tensor");
-    PADDLE_ENFORCE(input->dims().size() == 4 || input->dims().size() == 5,
-                   "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
-    PADDLE_ENFORCE(filter->dims().size() == 4 || filter->dims().size() == 5,
-                   "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
+
+    PADDLE_ENFORCE_EQ(filter->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Filter tensor");
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Filter tensor");
+
+    PADDLE_ENFORCE_GE(
+        input->dims().size(), 4,
+        "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
+    PADDLE_ENFORCE_LE(
+        input->dims().size(), 5,
+        "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
+
+    PADDLE_ENFORCE_GE(
+        filter->dims().size(), 4,
+        "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+    PADDLE_ENFORCE_LE(
+        filter->dims().size(), 5,
+        "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+
     if (bias) {
-      PADDLE_ENFORCE(bias->layout() == DataLayout::kMKLDNN &&
-                         bias->format() != MKLDNNMemoryFormat::format_undef,
-                     "Wrong layout/format set for Bias tensor");
-      PADDLE_ENFORCE(bias->dims().size() == 1,
-                     "Bias must only have 1 dimension, i.e. X");
+      PADDLE_ENFORCE_EQ(bias->layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for Bias tensor");
+      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for Bias tensor");
+
+      PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
+                        "Bias must only have 1 dimension, i.e. X");
     }
 
     std::vector<int> strides = ctx.Attr<std::vector<int>>("strides");
@@ -640,19 +672,23 @@ class ConvMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     Tensor* input_grad = ctx.Output<Tensor>(framework::GradVarName("Input"));
     Tensor* filter_grad = ctx.Output<Tensor>(framework::GradVarName("Filter"));
 
-    PADDLE_ENFORCE(input->layout() == DataLayout::kMKLDNN &&
-                       input->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input tensor");
-    PADDLE_ENFORCE(filter->layout() == DataLayout::kMKLDNN &&
-                       filter->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Filter tensor");
-    PADDLE_ENFORCE(
-        output_grad->layout() == DataLayout::kMKLDNN &&
-            output_grad->format() != MKLDNNMemoryFormat::format_undef,
-        "Wrong layout/format set for output_grad tensor");
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
 
-    PADDLE_ENFORCE(
-        !ctx.Attr<bool>("is_test"),
+    PADDLE_ENFORCE_EQ(filter->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Filter tensor");
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Filter tensor");
+
+    PADDLE_ENFORCE_EQ(output_grad->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for output_grad tensor");
+    PADDLE_ENFORCE_NE(output_grad->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for output_grad tensor");
+
+    PADDLE_ENFORCE_EQ(
+        ctx.Attr<bool>("is_test"), false,
         "is_test attribute should be set to False in training phase.");
 
     if (!input_grad && !filter_grad) return;

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -45,23 +45,29 @@ class ConvTransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
-    PADDLE_ENFORCE(input->layout() == DataLayout::kMKLDNN &&
-                       input->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input tensor");
-    PADDLE_ENFORCE(filter->layout() == DataLayout::kMKLDNN &&
-                       filter->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Filter tensor");
-    PADDLE_ENFORCE(input->dims().size() == 4,
-                   "Input must be with 4 dimensions, i.e. NCHW");
-    PADDLE_ENFORCE(filter->dims().size() == 4,
-                   "Filter must be with 4 dimensions, i.e. OIHW");
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
+
+    PADDLE_ENFORCE_EQ(filter->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Filter tensor");
+    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Filter tensor");
+
+    PADDLE_ENFORCE_EQ(input->dims().size(), 4,
+                      "Input must be with 4 dimensions, i.e. NCHW");
+    PADDLE_ENFORCE_EQ(filter->dims().size(), 4,
+                      "Filter must be with 4 dimensions, i.e. OIHW");
 
     if (bias) {
-      PADDLE_ENFORCE(bias->layout() == DataLayout::kMKLDNN &&
-                         bias->format() != MKLDNNMemoryFormat::format_undef,
-                     "Wrong layout/format set for Bias tensor");
-      PADDLE_ENFORCE(bias->dims().size() == 1,
-                     "Bias must only have 1 dimension, i.e. X");
+      PADDLE_ENFORCE_EQ(bias->layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for Bias tensor");
+      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for Bias tensor");
+
+      PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
+                        "Bias must only have 1 dimension, i.e. X");
     }
 
     std::vector<int> strides = ctx.Attr<std::vector<int>>("strides");

--- a/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
@@ -63,7 +63,7 @@ class DeQuantOpKernel : public framework::OpKernel<T> {
     std::vector<int> dst_tz = paddle::framework::vectorize2int(output->dims());
     mkldnn::memory::data_type src_dt =
         paddle::framework::ToMKLDNNDataType(input->type());
-    mkldnn::memory::format src_fmt = input->format();
+    MKLDNNMemoryFormat src_fmt = input->format();
     std::string key = CreateKey(ctx, src_dt, src_tz, reorder_scale[0]);
     const std::string key_prim = key + "@reorder_p";
     const std::string key_src_mem = key + "@src_mem";
@@ -87,7 +87,7 @@ class DeQuantOpKernel : public framework::OpKernel<T> {
           std::shared_ptr<primitive::at>(new primitive::at(*src_memory));
 
       auto dst_md = platform::MKLDNNMemDesc({dst_tz}, memory::data_type::f32,
-                                            memory::format::nchw);
+                                            MKLDNNMemoryFormat::nchw);
       auto dst_pd = mkldnn::memory::primitive_desc(dst_md, engine);
       dst_memory = std::make_shared<mkldnn::memory>(
           dst_pd, to_void_cast<float>(output_data));

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -42,9 +42,10 @@ class PoolMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     const Tensor* input = ctx.Input<Tensor>("X");
     Tensor* output = ctx.Output<Tensor>("Out");
 
-    PADDLE_ENFORCE(input->layout() == DataLayout::kMKLDNN &&
-                       input->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input tensor");
+    PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
 
     std::string pooling_type = ctx.Attr<std::string>("pooling_type");
     std::vector<int> ksize = ctx.Attr<std::vector<int>>("ksize");
@@ -129,15 +130,18 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     const Tensor* out_grad = ctx.Input<Tensor>(framework::GradVarName("Out"));
     Tensor* in_x_grad = ctx.Output<Tensor>(framework::GradVarName("X"));
 
-    PADDLE_ENFORCE(in_x->layout() == DataLayout::kMKLDNN &&
-                       in_x->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input X tensor");
-    PADDLE_ENFORCE(out_grad->layout() == DataLayout::kMKLDNN &&
-                       out_grad->format() != MKLDNNMemoryFormat::format_undef,
-                   "Wrong layout/format set for Input output_grad tensor");
+    PADDLE_ENFORCE_EQ(in_x->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input tensor");
+    PADDLE_ENFORCE_NE(in_x->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input tensor");
 
-    PADDLE_ENFORCE(
-        !ctx.Attr<bool>("is_test"),
+    PADDLE_ENFORCE_EQ(out_grad->layout(), DataLayout::kMKLDNN,
+                      "Wrong layout set for Input output_grad tensor");
+    PADDLE_ENFORCE_NE(out_grad->format(), MKLDNNMemoryFormat::format_undef,
+                      "Wrong format set for Input output_grad tensor");
+
+    PADDLE_ENFORCE_EQ(
+        ctx.Attr<bool>("is_test"), false,
         "is_test attribute should be set to False in training phase.");
 
     std::string pooling_type = ctx.Attr<std::string>("pooling_type");

--- a/paddle/fluid/operators/mkldnn/requantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/requantize_mkldnn_op.cc
@@ -48,8 +48,8 @@ class ReQuantOpKernel : public framework::OpKernel<T> {
     mkldnn::memory::data_type src_dt =
         paddle::framework::ToMKLDNNDataType(input->type());
     mkldnn::memory::data_type dst_dt = src_dt;
-    mkldnn::memory::format src_fmt = memory::format::nhwc;
-    mkldnn::memory::format dst_fmt = memory::format::nhwc;
+    MKLDNNMemoryFormat src_fmt = MKLDNNMemoryFormat::nhwc;
+    MKLDNNMemoryFormat dst_fmt = MKLDNNMemoryFormat::nhwc;
 
     const T* input_data = input->data<T>();
     T* output_data = output->mutable_data<T>(ctx.GetPlace());

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -36,7 +36,7 @@ template <typename T>
 class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
  public:
   SoftmaxMKLDNNHandler(const std::vector<int>& dims,
-                       const mkldnn::memory::format fmt,
+                       const MKLDNNMemoryFormat fmt,
                        const platform::MKLDNNDeviceContext& dev_ctx,
                        mkldnn::engine engine, const std::string& base_key)
       : platform::MKLDNNHandler(dev_ctx, engine, base_key),
@@ -44,8 +44,8 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
         fmt_(fmt) {}
 
   SoftmaxMKLDNNHandler(const std::vector<int>& dims,
-                       const mkldnn::memory::format fmt,
-                       const mkldnn::memory::format diff_fmt,
+                       const MKLDNNMemoryFormat fmt,
+                       const MKLDNNMemoryFormat diff_fmt,
                        const platform::MKLDNNDeviceContext& dev_ctx,
                        mkldnn::engine engine, const std::string& base_key)
       : platform::MKLDNNHandler(dev_ctx, engine, base_key),
@@ -165,8 +165,8 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
 
  private:
   std::vector<int> dims_;
-  mkldnn::memory::format fmt_;
-  mkldnn::memory::format diff_fmt_;
+  mkldnn::MKLDNNMemoryFormat fmt_;
+  mkldnn::MKLDNNMemoryFormat diff_fmt_;
   std::shared_ptr<mkldnn::softmax_forward::primitive_desc> fwd_pd_;
 };
 
@@ -207,7 +207,7 @@ class SoftmaxMKLDNNKernel : public paddle::framework::OpKernel<T> {
     const std::string key =
         platform::MKLDNNHandler::GetHash(softmax_tz, ctx.op().Output("Out"));
 
-    SoftmaxMKLDNNHandler<T> handler(softmax_tz, mkldnn::memory::format::nc,
+    SoftmaxMKLDNNHandler<T> handler(softmax_tz, MKLDNNMemoryFormat::nc,
                                     dev_ctx, mkldnn_engine, key);
 
     // Currently only NC data format is supported
@@ -288,8 +288,8 @@ class SoftmaxMKLDNNGradKernel : public paddle::framework::OpKernel<T> {
     // TODO(jczaja): Add layouts support when there is a need to do so
     // Two dimensional softmax does support NC format
     // Normalization is made after innermost dimension eg. C out of NC
-    SoftmaxMKLDNNHandler<T> handler(softmax_tz, mkldnn::memory::format::nc,
-                                    mkldnn::memory::format::nc, dev_ctx,
+    SoftmaxMKLDNNHandler<T> handler(softmax_tz, MKLDNNMemoryFormat::nc,
+                                    MKLDNNMemoryFormat::nc, dev_ctx,
                                     mkldnn_engine, key);
 
     auto dst_memory_p = handler.AcquireDstMemory(to_void_cast<T>(dst_data));

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -165,8 +165,8 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
 
  private:
   std::vector<int> dims_;
-  mkldnn::MKLDNNMemoryFormat fmt_;
-  mkldnn::MKLDNNMemoryFormat diff_fmt_;
+  MKLDNNMemoryFormat fmt_;
+  MKLDNNMemoryFormat diff_fmt_;
   std::shared_ptr<mkldnn::softmax_forward::primitive_desc> fwd_pd_;
 };
 
@@ -207,8 +207,8 @@ class SoftmaxMKLDNNKernel : public paddle::framework::OpKernel<T> {
     const std::string key =
         platform::MKLDNNHandler::GetHash(softmax_tz, ctx.op().Output("Out"));
 
-    SoftmaxMKLDNNHandler<T> handler(softmax_tz, MKLDNNMemoryFormat::nc,
-                                    dev_ctx, mkldnn_engine, key);
+    SoftmaxMKLDNNHandler<T> handler(softmax_tz, MKLDNNMemoryFormat::nc, dev_ctx,
+                                    mkldnn_engine, key);
 
     // Currently only NC data format is supported
     auto softmax_src_memory_p =

--- a/paddle/fluid/operators/mkldnn/sum_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/sum_mkldnn_op.cc
@@ -70,22 +70,24 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       std::vector<memory::primitive_desc> srcs_mpd;
       std::vector<mkldnn::memory> srcs_mem;
 
-      PADDLE_ENFORCE(in_vars[0]->IsType<LoDTensor>(),
-                     "Input[0] must be LoDTensors");
+      PADDLE_ENFORCE_EQ(in_vars[0]->IsType<LoDTensor>(), true,
+                        "Input[0] must be LoDTensors");
       auto& input0 = in_vars[0]->Get<LoDTensor>();
-      PADDLE_ENFORCE(input0.layout() == DataLayout::kMKLDNN &&
-                         input0.format() != MKLDNNMemoryFormat::format_undef,
-                     "Wrong layout/format for inputs[0]");
+      PADDLE_ENFORCE_EQ(input0.layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for inputs[0] tensor");
+      PADDLE_ENFORCE_NE(input0.format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for inputs[0] tensor");
 
       MKLDNNMemoryFormat input_format = input0.format();
 
       for (int i = 0; i < N; i++) {
-        PADDLE_ENFORCE(in_vars[i]->IsType<LoDTensor>(),
-                       "all inputs must be all LoDTensors");
+        PADDLE_ENFORCE_EQ(in_vars[i]->IsType<LoDTensor>(), true,
+                          "all inputs must be all LoDTensors");
         auto& input = in_vars[i]->Get<LoDTensor>();
-        PADDLE_ENFORCE(input.layout() == DataLayout::kMKLDNN &&
-                           input.format() != MKLDNNMemoryFormat::format_undef,
-                       "Wrong layout/format for inputs");
+        PADDLE_ENFORCE_EQ(input.layout(), DataLayout::kMKLDNN,
+                          "Wrong layout set for inputs");
+        PADDLE_ENFORCE_NE(input.format(), MKLDNNMemoryFormat::format_undef,
+                          "Wrong format set for inputs");
 
         if (input.numel() == 0) {
           continue;

--- a/paddle/fluid/operators/mkldnn/sum_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/sum_mkldnn_op.cc
@@ -65,7 +65,7 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
 
       std::vector<int> dst_tz = framework::vectorize2int(output->dims());
       auto src_tz = dst_tz;
-      memory::format output_format{memory::format::format_undef};
+      MKLDNNMemoryFormat output_format{MKLDNNMemoryFormat::format_undef};
       std::vector<float> scales;
       std::vector<memory::primitive_desc> srcs_mpd;
       std::vector<mkldnn::memory> srcs_mem;
@@ -74,17 +74,17 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
                      "Input[0] must be LoDTensors");
       auto& input0 = in_vars[0]->Get<LoDTensor>();
       PADDLE_ENFORCE(input0.layout() == DataLayout::kMKLDNN &&
-                         input0.format() != memory::format::format_undef,
+                         input0.format() != MKLDNNMemoryFormat::format_undef,
                      "Wrong layout/format for inputs[0]");
 
-      memory::format input_format = input0.format();
+      MKLDNNMemoryFormat input_format = input0.format();
 
       for (int i = 0; i < N; i++) {
         PADDLE_ENFORCE(in_vars[i]->IsType<LoDTensor>(),
                        "all inputs must be all LoDTensors");
         auto& input = in_vars[i]->Get<LoDTensor>();
         PADDLE_ENFORCE(input.layout() == DataLayout::kMKLDNN &&
-                           input.format() != memory::format::format_undef,
+                           input.format() != MKLDNNMemoryFormat::format_undef,
                        "Wrong layout/format for inputs");
 
         if (input.numel() == 0) {
@@ -103,7 +103,7 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       }
 
       auto dst_md =
-          memory::desc(dst_tz, memory::data_type::f32, memory::format::any);
+          memory::desc(dst_tz, memory::data_type::f32, MKLDNNMemoryFormat::any);
 
       auto sum_pd = sum::primitive_desc(dst_md, scales, srcs_mpd);
 
@@ -119,7 +119,7 @@ class SumMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       }
 
       auto sum_prim = mkldnn::sum(sum_pd, inputs, *dst_mem);
-      output_format = (memory::format)platform::GetMKLDNNFormat(sum_pd);
+      output_format = (MKLDNNMemoryFormat)platform::GetMKLDNNFormat(sum_pd);
 
       primitive reorder_prim;
       std::shared_ptr<memory> target_mem;

--- a/paddle/fluid/operators/mkldnn/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/transpose_mkldnn_op.cc
@@ -64,7 +64,7 @@ class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     mkldnn::stream(mkldnn::stream::kind::eager).submit(pipeline).wait();
 
     output->set_layout(DataLayout::kNCHW);
-    output->set_format(mkldnn::memory::format::format_undef);
+    output->set_format(MKLDNNMemoryFormat::format_undef);
   }
 };
 

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -121,7 +121,7 @@ class MKLDNNHandler {
 
   std::shared_ptr<mkldnn::memory> AcquireMemory(
       const std::vector<int>& dims, const mkldnn::memory::data_type dtype,
-      const mkldnn::memory::format& fmt, void* ptr, const std::string& suffix) {
+      const MKLDNNMemoryFormat& fmt, void* ptr, const std::string& suffix) {
     /*Generate key*/
     auto local_key = key_ + suffix;
     auto mem_p =
@@ -236,7 +236,7 @@ class MKLDNNHandler {
       const mkldnn::memory::dims& weights_dims, const std::vector<int>& strides,
       const std::vector<int>& paddings, const std::vector<int>& dilations,
       const int& groups, const mkldnn::memory::data_type& srcdt,
-      const mkldnn::memory::format& format, const std::string& fuse_activation,
+      const MKLDNNMemoryFormat& format, const std::string& fuse_activation,
       const bool& residual, const std::string& suffix) {
     AppendKeyDims(key, input_dims);
 
@@ -454,9 +454,8 @@ class ActivationMKLDNNHandler : public MKLDNNHandler {
 
   static std::string GetHash(const memory::dims& input_dims,
                              const mkldnn::algorithm algorithm,
-                             const mkldnn::memory::format fmt,
-                             const float alpha, const float beta,
-                             const std::string& suffix) {
+                             const MKLDNNMemoryFormat fmt, const float alpha,
+                             const float beta, const std::string& suffix) {
     std::string key;
     key.reserve(platform::MKLDNNHandler::MaxKeyLength);
     platform::MKLDNNHandler::AppendKeyDims(&key, input_dims);
@@ -606,7 +605,7 @@ class LRNMKLDNNHandler : public MKLDNNHandler {
 
   static std::string GetHash(const memory::dims& input_dims, const int n,
                              const float alpha, const float beta, const float k,
-                             const memory::format& fmt,
+                             const MKLDNNMemoryFormat& fmt,
                              const std::string& suffix) {
     std::string key;
     key.reserve(platform::MKLDNNHandler::MaxKeyLength);
@@ -691,7 +690,7 @@ class PoolingMKLDNNHandler : public MKLDNNHandler {
         pooling_type_ == "max"
             ? fwd_pd_->workspace_primitive_desc()
             : mkldnn::memory::primitive_desc(
-                  {{}, dt_, mkldnn::memory::format::nchw}, engine_);
+                  {{}, dt_, MKLDNNMemoryFormat::nchw}, engine_);
     // Pooling PD has to be passed to Grad op that
     // may be executed by diffrent thread, hence
     // for that one we use key that does not contain TID
@@ -801,7 +800,7 @@ class PoolingMKLDNNHandler : public MKLDNNHandler {
       const memory::dims& input_dims, const std::string& pooling_type,
       const std::vector<int>& ksize, const std::vector<int>& strides,
       const std::vector<int>& paddings, const memory::data_type& dt,
-      const memory::format& fmt, const std::string& suffix) {
+      const MKLDNNMemoryFormat& fmt, const std::string& suffix) {
     std::string key;
     key.reserve(platform::MKLDNNHandler::MaxKeyLength);
     platform::MKLDNNHandler::AppendKeyDims(&key, input_dims);
@@ -855,7 +854,7 @@ class TransposeMKLDNNHandler : public MKLDNNHandler {
         logical_axis_(dims.size(), 0) {}
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemory(
-      const mkldnn::memory::format& fmt, void* ptr) {
+      const MKLDNNMemoryFormat& fmt, void* ptr) {
     auto local_key = key_ + "@user_src_mem_p";
     auto mem_p =
         std::static_pointer_cast<mkldnn::memory>(dev_ctx_.GetBlob(local_key));
@@ -865,7 +864,7 @@ class TransposeMKLDNNHandler : public MKLDNNHandler {
       for (size_t i = 0; i < logical_axis_.size(); ++i) {
         logical_axis_[i] = i;
       }
-      auto src_md = fmt != mkldnn::memory::format::nchw
+      auto src_md = fmt != MKLDNNMemoryFormat::nchw
                         ? platform::MKLDNNMemDesc(
                               dims_, platform::MKLDNNGetDataType<float>(), fmt)
                         : Axis2MemoryDesc(dims_, logical_axis_);
@@ -967,12 +966,12 @@ class ReorderMKLDNNHandler : public MKLDNNHandler {
         dtype_(dtype) {}
 
   std::shared_ptr<mkldnn::memory> AcquireSrcMemory(
-      const mkldnn::memory::format& fmt, void* ptr) {
+      const MKLDNNMemoryFormat& fmt, void* ptr) {
     return this->AcquireMemory(dims_, dtype_, fmt, ptr, "@user_src_mem_p");
   }
 
   std::shared_ptr<mkldnn::memory> AcquireDstMemory(
-      framework::Tensor* output, const mkldnn::memory::format& fmt,
+      framework::Tensor* output, const MKLDNNMemoryFormat& fmt,
       platform::Place place) {
     auto local_key = key_ + "@user_dst_mem_p";
     auto mem_p =
@@ -1007,8 +1006,8 @@ class ReorderMKLDNNHandler : public MKLDNNHandler {
   }
 
   static std::string GetHash(std::vector<int>& shape,  // NOLINT
-                             mkldnn::memory::format in_fmt,
-                             mkldnn::memory::format out_fmt,
+                             MKLDNNMemoryFormat in_fmt,
+                             MKLDNNMemoryFormat out_fmt,
                              const std::string& suffix) {
     return dims2str(shape) + std::to_string(in_fmt) + "->" +
            std::to_string(out_fmt) + "#" + suffix;
@@ -1071,8 +1070,8 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
     return conv_pd_->dst_primitive_desc().get_size();
   }
 
-  mkldnn::memory::format GetDstFormat() const {
-    return static_cast<mkldnn::memory::format>(
+  MKLDNNMemoryFormat GetDstFormat() const {
+    return static_cast<MKLDNNMemoryFormat>(
         conv_pd_->dst_primitive_desc().desc().data.format);
   }
 
@@ -1435,10 +1434,10 @@ static void SetDstMemoryQuantized(
     std::shared_ptr<mkldnn::memory>& dst_memory) {            // NOLINT
   T* output_data = output->mutable_data<T>(ctx.GetPlace());
   const size_t dst_dims = dst_tz.size();
-  memory::format dst_fmt;
+  MKLDNNMemoryFormat dst_fmt;
   PADDLE_ENFORCE(dst_dims <= 5,
                  "Dst memory for quantization can not have dims > 5");
-  dst_fmt = platform::MKLDNNFormatForSize(dst_dims, memory::format::nhwc);
+  dst_fmt = platform::MKLDNNFormatForSize(dst_dims, MKLDNNMemoryFormat::nhwc);
 
   auto dst_md = platform::MKLDNNMemDesc(
       {dst_tz}, paddle::framework::ToMKLDNNDataType(

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -1435,8 +1435,8 @@ static void SetDstMemoryQuantized(
   T* output_data = output->mutable_data<T>(ctx.GetPlace());
   const size_t dst_dims = dst_tz.size();
   MKLDNNMemoryFormat dst_fmt;
-  PADDLE_ENFORCE(dst_dims <= 5,
-                 "Dst memory for quantization can not have dims > 5");
+  PADDLE_ENFORCE_LE(dst_dims, 5,
+                    "Dst memory for quantization can not have dims > 5");
   dst_fmt = platform::MKLDNNFormatForSize(dst_dims, MKLDNNMemoryFormat::nhwc);
 
   auto dst_md = platform::MKLDNNMemDesc(


### PR DESCRIPTION
Suggested in https://github.com/PaddlePaddle/Paddle/pull/19510# changes to make it easier to switch to MKLDNN v1.0 in the future. I didn't change it in Tensor class because we plan to apply some changes there anyway and I was close to 20 file limit in this PR.