### PR TITLE
add elementwise_mod OP support float/double

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_mod_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_mod_op.cc
@@ -33,4 +33,6 @@ REGISTER_OP_WITHOUT_GRADIENT(elementwise_mod, ops::ElementwiseOp,
 REGISTER_OP_CPU_KERNEL(
     elementwise_mod,
     ops::ElementwiseModKernel<paddle::platform::CPUDeviceContext, int>,
-    ops::ElementwiseModKernel<paddle::platform::CPUDeviceContext, int64_t>);
+    ops::ElementwiseModKernel<paddle::platform::CPUDeviceContext, int64_t>,
+    ops::ElementwiseModFPKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::ElementwiseModFPKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/elementwise/elementwise_mod_op.cu
+++ b/paddle/fluid/operators/elementwise/elementwise_mod_op.cu
@@ -19,4 +19,6 @@ namespace plat = paddle::platform;
 
 REGISTER_OP_CUDA_KERNEL(
     elementwise_mod, ops::ElementwiseModKernel<plat::CUDADeviceContext, int>,
-    ops::ElementwiseModKernel<plat::CUDADeviceContext, int64_t>);
+    ops::ElementwiseModKernel<plat::CUDADeviceContext, int64_t>,
+    ops::ElementwiseModFPKernel<plat::CUDADeviceContext, float>,
+    ops::ElementwiseModFPKernel<plat::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/elementwise/elementwise_mod_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_mod_op.h
@@ -27,6 +27,11 @@ struct ModFunctor {
   inline HOSTDEVICE T operator()(T a, T b) const { return a % b; }
 };
 
+template <typename T>
+struct ModFunctorFP {
+  inline HOSTDEVICE T operator()(T a, T b) const { return std::fmod(a, b); }
+};
+
 template <typename DeviceContext, typename T>
 void elementwise_mod(const framework::ExecutionContext &ctx,
                      const framework::Tensor *x, const framework::Tensor *y,
@@ -34,6 +39,15 @@ void elementwise_mod(const framework::ExecutionContext &ctx,
   int axis = ctx.Attr<int>("axis");
   ElementwiseComputeEx<ModFunctor<T>, DeviceContext, T>(ctx, x, y, axis,
                                                         ModFunctor<T>(), z);
+}
+
+template <typename DeviceContext, typename T>
+void elementwise_mod_fp(const framework::ExecutionContext &ctx,
+                        const framework::Tensor *x, const framework::Tensor *y,
+                        framework::Tensor *z) {
+  int axis = ctx.Attr<int>("axis");
+  ElementwiseComputeEx<ModFunctorFP<T>, DeviceContext, T>(ctx, x, y, axis,
+                                                          ModFunctorFP<T>(), z);
 }
 
 template <typename DeviceContext, typename T>
@@ -48,6 +62,21 @@ class ElementwiseModKernel : public framework::OpKernel<T> {
 
     // dtype of x and y is int64 or int32
     elementwise_mod<DeviceContext, T>(ctx, x, y, z);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class ElementwiseModFPKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    auto *x = ctx.Input<framework::LoDTensor>("X");
+    auto *y = ctx.Input<framework::LoDTensor>("Y");
+    auto *z = ctx.Output<framework::LoDTensor>("Out");
+
+    z->mutable_data<T>(ctx.GetPlace());
+
+    // dtype of x and y is float or double
+    elementwise_mod_fp<DeviceContext, T>(ctx, x, y, z);
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/test_elementwise_mod_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_mod_op.py
@@ -27,7 +27,6 @@ class TestElementwiseModOp(OpTest):
 
     def setUp(self):
         self.op_type = "elementwise_mod"
-        self.dtype = np.int32
         self.axis = -1
         self.init_dtype()
         self.init_input_output()
@@ -50,7 +49,7 @@ class TestElementwiseModOp(OpTest):
         self.out = np.mod(self.x, self.y)
 
     def init_dtype(self):
-        pass
+        self.dtype = np.int32
 
     def init_axis(self):
         pass
@@ -63,6 +62,24 @@ class TestElementwiseModOp_scalar(TestElementwiseModOp):
         self.x = (np.random.rand(2, 3, 4) * scale_x).astype(self.dtype)
         self.y = (np.random.rand(1) * scale_y + 1).astype(self.dtype)
         self.out = np.mod(self.x, self.y)
+
+
+class TestElementwiseModOpFloat(TestElementwiseModOp):
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def init_input_output(self):
+        self.x = np.random.uniform(-1000, 1000, [10, 10]).astype(self.dtype)
+        self.y = np.random.uniform(-100, 100, [10, 10]).astype(self.dtype)
+        self.out = np.fmod(self.x, self.y)
+
+    def test_check_output(self):
+        self.check_output(atol=2e-5)
+
+
+class TestElementwiseModOpDouble(TestElementwiseModOpFloat):
+    def init_dtype(self):
+        self.dtype = np.float64
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**elementwise_mod OP add float/double support**

mod for float/double is supported by numpy and pytorch, calcualte as:
```
np.fmod(a, b) = a - np.floor(a/b) * b
```
use `std::fmod` implement elemenwise_mod kernel for float/double in c++ code