### PR TITLE
Fix seg fault of share lod when memory optimization pass is enabled

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -648,7 +648,7 @@ class RuntimeInferShapeContext : public InferShapeContext {
     Variable* out_var = out_it->second.at(j);
     PADDLE_ENFORCE(out_var->IsType<LoDTensor>(),
                    "The %d-th output of Output(%s) must be LoDTensor.", j, out);
-    auto in_tensor = in_var->Get<LoDTensor>();
+    auto& in_tensor = in_var->Get<LoDTensor>();
     auto* out_tensor = out_var->GetMutable<LoDTensor>();
     out_tensor->set_lod(in_tensor.lod());
 


### PR DESCRIPTION
`ShareLoD` may cause segmentation fault because it reads the `std::shared_ptr<Allocation>`, which may be written at the same time in other thread, when memory optimization pass is enabled. This PR fixes it. The error log is:
```
*** Aborted at 1567274665 (unix time) try "date -d @1567274665" if you are using GNU date ***
     @                0x0 (unknown)
*** SIGSEGV (@0x0) received by PID 74408 (TID 0x70000b132000) stack trace: ***
     @        0x101c2ab3d _sigtramp
     @        0x12f9c804f std::__1::__shared_ptr_pointer<>::__on_zero_shared()
     @        0x13024b187 paddle::framework::RuntimeInferShapeContext::ShareLoD()
     @        0x12f6175d1 paddle::operators::MeanGradOp::InferShape()
     @        0x130247471 paddle::framework::OperatorWithKernel::RunImpl()
     @        0x130247208 paddle::framework::OperatorWithKernel::RunImpl()
     @        0x130243632 paddle::framework::OperatorBase::Run()
     @        0x1300ba5c2 paddle::framework::details::ComputationOpHandle::RunImpl()
     @        0x1300781db paddle::framework::details::FastThreadedSSAGraphExecutor::RunOpSync()
     @        0x130077f83 paddle::framework::details::FastThreadedSSAGraphExecutor::RunOp()
     @        0x13007a356 _ZNSt3__120__packaged_task_funcINS_6__bindIZN6paddle9framework7details28FastThreadedSSAGraphExecutor10RunOpAsyncEPNS_13unordered_mapIPNS4_12OpHandleBaseENS_6atomicIiEENS_4hashIS8_EENS_8equal_toIS8_EENS_9allocatorINS_4pairIKS8_SA_EEEEEES8_RKNS_10shared_ptrINS3_13BlockingQueueImEEEEE3$_0JEEENSF_IST_EEFvvEEclEv
     @        0x12ef53809 std::__1::packaged_task<>::operator()()
     @        0x12ee099fa _ZZN10ThreadPoolC1EmENKUlvE_clEv
     @        0x12ee0977d _ZNSt3__114__thread_proxyINS_5tupleIJNS_10unique_ptrINS_15__thread_structENS_14default_deleteIS3_EEEEZN10ThreadPoolC1EmEUlvE_EEEEEPvSA_
     @        0x101c3b339 _pthread_body
     @        0x101c3e2a7 _pthread_start
Segmentation fault
```