### PR TITLE
Fix typo of allocator

### DIFF
--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -123,7 +123,7 @@ void* GPUAllocator::Alloc(size_t* index, size_t size) {
         " MB GPU memory. Please shrink "
         "FLAGS_fraction_of_gpu_memory_to_use or "
         "FLAGS_initial_gpu_memory_in_mb or "
-        "FLAGS_reallocate_gpu_memory_in_mb"
+        "FLAGS_reallocate_gpu_memory_in_mb "
         "environment variable to a lower value. " +
         "Current FLAGS_fraction_of_gpu_memory_to_use value is " +
         std::to_string(FLAGS_fraction_of_gpu_memory_to_use) +


### PR DESCRIPTION
Change error string of "FLAGS_reallocate_gpu_memory_in_mbenvironment variable to a lower value" to be "FLAGS_reallocate_gpu_memory_in_mb environment variable to a lower value".

Scripts on benchmark repo have been revised in [#benchmark/189](https://github.com/PaddlePaddle/benchmark/pull/189).