### PR TITLE
Remove deprecated memory_optimize usages in test_py_func_op.py

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_py_func_op.py
+++ b/python/paddle/fluid/tests/unittests/test_py_func_op.py
@@ -142,10 +142,6 @@ def test_main(use_cuda, use_py_func_op, use_parallel_executor):
             exe = fluid.Executor(place)
             exe.run(fluid.default_startup_program())
 
-            #FIXME force use old memory optimzie strategy here to pass the unittest
-            #since open the new strategy will crash the unittest
-            fluid.memory_optimize(fluid.default_main_program())
-
             train_cp = fluid.default_main_program()
 
             if use_parallel_executor:


### PR DESCRIPTION
`fluid.memory_optimize` is deprecated. This PR removes its usage in `test_py_func_op.py`.