### PR TITLE
Fix parallel compilation error of allocator

### DIFF
--- a/paddle/fluid/memory/detail/CMakeLists.txt
+++ b/paddle/fluid/memory/detail/CMakeLists.txt
@@ -1,9 +1,9 @@
-cc_library(memory_block SRCS memory_block.cc memory_block_desc.cc meta_cache.cc)
+cc_library(memory_block SRCS memory_block.cc memory_block_desc.cc meta_cache.cc DEPS place)
 
 if(${WITH_GPU})
-  nv_library(system_allocator SRCS system_allocator.cc DEPS gflags cpu_info gpu_info)
+  nv_library(system_allocator SRCS system_allocator.cc DEPS gflags cpu_info gpu_info place)
 else(${WITH_GPU})
-  cc_library(system_allocator SRCS system_allocator.cc DEPS gflags cpu_info)
+  cc_library(system_allocator SRCS system_allocator.cc DEPS gflags cpu_info place)
 endif(${WITH_GPU})
 
 cc_test(system_allocator_test SRCS system_allocator_test.cc DEPS system_allocator)


### PR DESCRIPTION
`system_allocator.cc` includes `place.h` but does not depend on its target, which makes compilation errors. This PR fixes it.
<img width="1047" alt="cb8a6da2b0eba1e2bfaa684550d4114b" src="https://user-images.githubusercontent.com/32832641/64094708-28339f80-cd8f-11e9-8c60-954c6eda5539.png">
