### PR TITLE
Remove reshape transpose in attention module for bert optimization

### DIFF
--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -71,6 +71,8 @@ pass_library(fillconstant_elementwisemul_fuse inference)
 pass_library(shuffle_channel_detect_pass inference)
 pass_library(delete_quant_dequant_op_pass inference)
 pass_library(simplify_with_basic_ops_pass base)
+pass_library(remove_reshape_transpose_pass)
+
 if(WITH_GPU)
     pass_library(cudnn_placement_pass base DEPS placement_pass_base)
 endif()

--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -71,7 +71,7 @@ pass_library(fillconstant_elementwisemul_fuse inference)
 pass_library(shuffle_channel_detect_pass inference)
 pass_library(delete_quant_dequant_op_pass inference)
 pass_library(simplify_with_basic_ops_pass base)
-pass_library(remove_reshape_transpose_pass)
+pass_library(remove_reshape_transpose_pass inference)
 
 if(WITH_GPU)
     pass_library(cudnn_placement_pass base DEPS placement_pass_base)
@@ -120,6 +120,8 @@ cc_test(test_seqpool_concat_fuse_pass SRCS seqpool_concat_fuse_pass_tester.cc DE
 cc_test(test_seqpool_cvm_concat_fuse_pass SRCS seqpool_cvm_concat_fuse_pass_tester.cc DEPS seqpool_cvm_concat_fuse_pass framework_proto)
 cc_test(test_is_test_pass SRCS is_test_pass_tester.cc DEPS is_test_pass)
 cc_test(test_simplify_with_basic_ops_pass SRCS simplify_with_basic_ops_pass_tester.cc DEPS simplify_with_basic_ops_pass)
+cc_test(test_remove_reshape_transpose_pass SRCS remove_reshape_transpose_pass_tester.cc DEPS remove_reshape_transpose_pass naive_executor)
+
 if(WITH_GPU)
     cc_test(test_cudnn_placement_pass SRCS cudnn_placement_pass_tester.cc DEPS cudnn_placement_pass)
 endif()

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1792,6 +1792,70 @@ PDNode *patterns::FillConstantElementWiseMulFuse::operator()(
   return elementwise_mul_out;
 }
 
+PDNode *patterns::RmReshapeTranspose::operator()(
+    PDNode *x, bool inverse, bool with_scale) {
+  auto reshape2_op =
+      pattern->NewNode(reshape2_repr())->assert_is_op("reshape2");
+  auto reshape2_out = pattern->NewNode(reshape2_repr())
+                          ->assert_is_op_output("reshape2")
+                          ->assert_is_op_input("transpose2","X")
+                          ->AsIntermediate();
+
+  auto transpose2_op =
+      pattern->NewNode(transpose2_repr())->assert_is_op("transpose2");
+  auto reshape2_out = pattern->NewNode(reshape2_repr())
+                          ->assert_is_op_output("transpose2")
+                          ->assert_is_op_input("matmul")
+                          ->AsIntermediate();
+
+  auto matmul_op =
+      pattern->NewNode(matmul_repr())->assert_is_op("matmul");
+  auto matmul_y = pattern->NewNode(matmul_y_repr())
+                          ->assert_is_op_nth_input("matmul","Y",0);
+  auto matmul_out = pattern->NewNode(matmul_out_repr())
+                          ->assert_is_op_output("matmul");
+  auto scale_op = pattern->NewNode(scale_repr())->assert_is_op("scale");
+  auto scale_out = pattern->NewNode(scale_out_repr())
+                          ->assert_is_op_output("scale")
+                          ->assert_is_op_input("matmul");
+  if(!inverse){
+      if(with_scale){
+          x->assert_is_op_input("reshape2","X");
+          reshape2_op->LinksFrom({x}).LinksTo({reshape2_out});
+          transpose2_op->LinksFrom({reshape2_out}).LinksTo({transpose2_out});
+          scale_op->LinksFrom({transpose2_out}).LinksTo({scale_out});
+          matmul_op->LinksFrom({scale_out}).LinksTo({matmul_out});
+          return matmul_out;
+      }
+      else{
+          x->assert_is_op_input("reshape2","X");
+          reshape2_op->LinksFrom({x}).LinksTo({reshape2_out});
+          transpose2_op->LinksFrom({reshape2_out}).LinksTo({transpose2_out});
+          matmul_op->LinksFrom({transpose2_out}).LinksTo({matmul_out});
+          return matmul_out;
+      }
+  } else{
+      x->assert_is_op_output("matmul", "Out");
+      transpose2_op->LinksFrom({x}).LinksTo({transpose2_out});
+      reshape2_op->LinksFrom({transpose2_out}).LinksTo({reshape2_out});
+      return reshape2_out;
+  }
+}
+
+PDNode *patterns::RmReshapeTranspose::operator()(PDNode *x) {
+    x->assert_is_op_input("stack","X");
+    auto stack_op = pattern->NewNode(stack_repr())->assert_is_op("stack");
+    auto stack_out = pattern->NewNode(stack_out_repr())
+                            ->assert_is_op_output("stack");
+
+    auto cast_op = pattern->NewNode(cast_repr())
+                          ->assert_is_op("cast");
+
+    stack_op->LinksFrom({x}).LinksTo({stack_out});
+    cast_op->LinksFrom({stack_out});
+    return cast_op;
+}
+
 void patterns::QuantDequantOpFuse::operator()(PDNode *quant_op_input,
                                               const std::string &op_type,
                                               const std::string &weight_name,

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -995,41 +995,38 @@ struct FillConstantElementWiseMulFuse : public PatternBase {
   PATTERN_DECL_NODE(elementwise_mul_out);
 };
 
-struct RmReshapeTranspose : public PatternBase{
-   RmReshapeTranspose(PDPattern* pattern,
-                      const std::string& name_scope)
-      : PatternBase(pattern, name_scope,
-                    "remove_reshape_transpose") {}
-   PDNode* operator()(PDNode* x, bool inversei, bool with_scale);
+struct RmReshapeTranspose : public PatternBase {
+  RmReshapeTranspose(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "remove_reshape_transpose") {}
+  PDNode* operator()(PDNode* x, bool inverse, bool with_scale);
 
-   // declare operator node's name
-   PATTERN_DECL_NODE(reshape2);
-   PATTERN_DECL_NODE(transpose2);
-   PATTERN_DECL_NODE(matmul);
-   PATTERN_DECL_NODE(scale);
-   // declare matmul input
-   PATTERN_DECL_NODE(matmal_y);
-   // declare operators' outputs
-   PATTERN_DECL_NODE(reshape2_out);
-   PATTERN_DECL_NODE(transpose2_out);
-   PATTERN_DECL_NODE(matmul_out);
-   PATTERN_DECL_NODE(scale_out);
-} 
+  // declare operator node's name
+  PATTERN_DECL_NODE(reshape2);
+  PATTERN_DECL_NODE(transpose2);
+  PATTERN_DECL_NODE(matmul);
+  PATTERN_DECL_NODE(scale);
+  // declare matmul input
+  PATTERN_DECL_NODE(matmal_y);
+  // declare operators' outputs
+  PATTERN_DECL_NODE(reshape2_out);
+  PATTERN_DECL_NODE(transpose2_out);
+  PATTERN_DECL_NODE(matmul_out);
+  PATTERN_DECL_NODE(scale_out);
+};
 
-struct RemoveStack : public PatternBase{
-   RemoveStack(PDPattern* pattern,
-                      const std::string& name_scope)
-      : PatternBase(pattern, name_scope,
-                    "remove_stack_for_attention") {}
-   PDNode* operator()(PDNode* x);
+struct RemoveStack : public PatternBase {
+  RemoveStack(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "remove_stack_for_attention") {}
+  PDNode* operator()(PDNode* x);
 
-   // declare operator node's name
-   PATTERN_DECL_NODE(stack);
-   PATTERN_DECL_NODE(cast);
-   // declare operators' outputs
-   PATTERN_DECL_NODE(stack_out);
-}
-
+  // declare operator node's name
+  PATTERN_DECL_NODE(stack);
+  PATTERN_DECL_NODE(cast);
+  PATTERN_DECL_NODE(elementwise_add);
+  // declare operators' outputs
+  PATTERN_DECL_NODE(stack_out);
+  PATTERN_DECL_NODE(cast_out);
+};
 
 struct QuantDequantOpFuse : public PatternBase {
   QuantDequantOpFuse(PDPattern* pattern, const std::string& name_scope)

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -995,6 +995,42 @@ struct FillConstantElementWiseMulFuse : public PatternBase {
   PATTERN_DECL_NODE(elementwise_mul_out);
 };
 
+struct RmReshapeTranspose : public PatternBase{
+   RmReshapeTranspose(PDPattern* pattern,
+                      const std::string& name_scope)
+      : PatternBase(pattern, name_scope,
+                    "remove_reshape_transpose") {}
+   PDNode* operator()(PDNode* x, bool inversei, bool with_scale);
+
+   // declare operator node's name
+   PATTERN_DECL_NODE(reshape2);
+   PATTERN_DECL_NODE(transpose2);
+   PATTERN_DECL_NODE(matmul);
+   PATTERN_DECL_NODE(scale);
+   // declare matmul input
+   PATTERN_DECL_NODE(matmal_y);
+   // declare operators' outputs
+   PATTERN_DECL_NODE(reshape2_out);
+   PATTERN_DECL_NODE(transpose2_out);
+   PATTERN_DECL_NODE(matmul_out);
+   PATTERN_DECL_NODE(scale_out);
+} 
+
+struct RemoveStack : public PatternBase{
+   RemoveStack(PDPattern* pattern,
+                      const std::string& name_scope)
+      : PatternBase(pattern, name_scope,
+                    "remove_stack_for_attention") {}
+   PDNode* operator()(PDNode* x);
+
+   // declare operator node's name
+   PATTERN_DECL_NODE(stack);
+   PATTERN_DECL_NODE(cast);
+   // declare operators' outputs
+   PATTERN_DECL_NODE(stack_out);
+}
+
+
 struct QuantDequantOpFuse : public PatternBase {
   QuantDequantOpFuse(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "quant_dequant_fuse") {}

--- a/paddle/fluid/framework/ir/remove_reshape_transpose_pass.cc
+++ b/paddle/fluid/framework/ir/remove_reshape_transpose_pass.cc
@@ -1,0 +1,192 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/ir/remove_reshape_transpose_pass.h"
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include "paddle/fluid/framework/ir/graph_helper.h"
+#include "paddle/fluid/platform/enforce.h"
+
+int head_number = 0;
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+void RemoveReshapeTransposeForAttentionPass::ReshapeTranspose(
+    Graph* graph) const {
+  GraphPatternDetector gpd;
+  auto* x = gpd.mutable_pattern()
+                ->NewNode("rm_head/x")
+                ->AsInput()
+                ->assert_is_op_input("reshape2", "X");
+  patterns::RmReshapeTranspose rm_reshape_transpose_pattern(
+      gpd.mutable_pattern(), "remove_reshape_transpose");
+  rm_reshape_transpose_pattern(x, false /*inverse*/, false);
+  int found_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    VLOG(4) << "handle remove reshape transpose pattern";
+    GET_IR_NODE_FROM_SUBGRAPH(reshape, reshape2, rm_reshape_transpose_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose, transpose2,
+                              rm_reshape_transpose_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul, matmul, rm_reshape_transpose_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(reshape_out, reshape2_out,
+                              rm_reshape_transpose_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose_out, transpose2_out,
+                              rm_reshape_transpose_pattern);
+
+    auto reshape_desc = reshape->Op();
+    head_number =
+        boost::get<std::vector<int>>(reshape_desc->GetAttr("shape")).at(2);
+    auto matmul_op_desc = matmul->Op();
+    matmul_op_desc->SetAttr("head_number", head_number);
+    matmul_op_desc->RenameInput(transpose_out->Name(), subgraph.at(x)->Name());
+
+    PADDLE_ENFORCE_NE(subgraph.count(x), 0);
+    IR_NODE_LINK_TO(subgraph.at(x), matmul);
+    GraphSafeRemoveNodes(graph,
+                         {reshape, transpose, reshape_out, transpose_out});
+    found_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_count);
+}
+
+void RemoveReshapeTransposeForAttentionPass::TransposeReshape(
+    Graph* graph) const {
+  GraphPatternDetector gpd;
+  auto* x = gpd.mutable_pattern()
+                ->NewNode("rm_inverse/x")
+                ->AsOutput()
+                ->assert_is_op_output("matmul", "Out");
+  patterns::RmReshapeTranspose rm_transpose_reshape_pattern(
+      gpd.mutable_pattern(), "remove_transpose_reshape");
+  rm_transpose_reshape_pattern(x, true, false);
+  int found_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    VLOG(4) << "handle remove transpose reshape pattern";
+    GET_IR_NODE_FROM_SUBGRAPH(reshape, reshape2, rm_transpose_reshape_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose, transpose2,
+                              rm_transpose_reshape_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(reshape_out, reshape2_out,
+                              rm_transpose_reshape_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose_out, transpose2_out,
+                              rm_transpose_reshape_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul_out, matmul_out,
+                              rm_transpose_reshape_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul, matmul, rm_transpose_reshape_pattern);
+
+    auto matmul_op_desc = matmul->Op();
+    matmul_op_desc->RenameOutput(matmul_out->Name(), reshape_out->Name());
+    IR_NODE_LINK_TO(matmul, reshape_out);
+    GraphSafeRemoveNodes(graph,
+                         {reshape, transpose, matmul_out, transpose_out});
+    found_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_count);
+}
+
+void RemoveReshapeTransposeForAttentionPass::ReshapeTransposeScale(
+    Graph* graph) const {
+  GraphPatternDetector gpd;
+  auto* x = gpd.mutable_pattern()
+                ->NewNode("rm_head_scale/x")
+                ->AsInput()
+                ->assert_is_op_input("reshape2", "X");
+  patterns::RmReshapeTranspose rm_reshape_transpose_scale_pattern(
+      gpd.mutable_pattern(), "remove_reshape_transpose_scale");
+  rm_reshape_transpose_scale_pattern(x, false /*inverse*/, true);
+  int found_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    VLOG(4) << "handle remove reshape transpose scale pattern";
+    GET_IR_NODE_FROM_SUBGRAPH(reshape, reshape2,
+                              rm_reshape_transpose_scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose, transpose2,
+                              rm_reshape_transpose_scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(reshape_out, reshape2_out,
+                              rm_reshape_transpose_scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose_out, transpose2_out,
+                              rm_reshape_transpose_scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(matmul, matmul,
+                              rm_reshape_transpose_scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(scale, scale, rm_reshape_transpose_scale_pattern);
+
+    auto reshape_desc = reshape->Op();
+    head_number =
+        boost::get<std::vector<int>>(reshape_desc->GetAttr("shape")).at(2);
+    auto matmul_op_desc = matmul->Op();
+    matmul_op_desc->SetAttr("head_number", head_number);
+    auto scale_op_desc = scale->Op();
+    scale_op_desc->RenameInput(transpose_out->Name(), subgraph.at(x)->Name());
+
+    PADDLE_ENFORCE_NE(subgraph.count(x), 0);
+    IR_NODE_LINK_TO(subgraph.at(x), scale);
+    GraphSafeRemoveNodes(graph,
+                         {reshape, transpose, reshape_out, transpose_out});
+    found_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_count);
+}
+
+void RemoveReshapeTransposeForAttentionPass::RemoveStack(Graph* graph) const {
+  GraphPatternDetector gpd;
+  auto* x = gpd.mutable_pattern()
+                ->NewNode("rm_stack/x")
+                ->AsInput()
+                ->assert_is_op_input("stack", "X");
+  patterns::RemoveStack remove_stack_pattern(gpd.mutable_pattern(),
+                                             "remove_stack_pattern");
+  remove_stack_pattern(x);
+  int found_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    VLOG(4) << "handle remove stack pattern";
+    GET_IR_NODE_FROM_SUBGRAPH(stack, stack, remove_stack_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(stack_out, stack_out, remove_stack_pattern);
+
+    auto stack_op_desc = stack->Op();
+    stack_op_desc->SetType("concat");
+    stack_op_desc->SetAttr("axis", 2);
+    stack_op_desc->SetOutput("Out",
+                             std::vector<std::string>({stack_out->Name()}));
+
+    found_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_count);
+}
+
+void RemoveReshapeTransposeForAttentionPass::ApplyImpl(ir::Graph* graph) const {
+  PADDLE_ENFORCE_NOT_NULL(graph);
+  FusePassBase::Init("remove_reshape_transpose", graph);
+
+  ReshapeTranspose(graph);
+  TransposeReshape(graph);
+  ReshapeTransposeScale(graph);
+  RemoveStack(graph);
+}
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
+
+REGISTER_PASS(remove_reshape_transpose_pass,
+              paddle::framework::ir::RemoveReshapeTransposeForAttentionPass);

--- a/paddle/fluid/framework/ir/remove_reshape_transpose_pass.h
+++ b/paddle/fluid/framework/ir/remove_reshape_transpose_pass.h
@@ -32,10 +32,6 @@ class RemoveReshapeTransposeForAttentionPass : public FusePassBase {
 
  protected:
   void ApplyImpl(ir::Graph* graph) const override;
-  void ReshapeTranspose(Graph* graph) const;
-  void TransposeReshape(Graph* graph) const;
-  void ReshapeTransposeScale(Graph* graph) const;
-  void RemoveStack(Graph* graph) const;
 };
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/remove_reshape_transpose_pass.h
+++ b/paddle/fluid/framework/ir/remove_reshape_transpose_pass.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/framework/ir/fuse_pass_base.h"
+#include "paddle/fluid/framework/ir/graph.h"
+#include "paddle/fluid/framework/ir/graph_pattern_detector.h"
+#include "paddle/fluid/framework/ir/pass.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+/*
+ * Fuse the MUL and ELEMENTWISE_ADD to a FCOp.
+ */
+class RemoveReshapeTransposeForAttentionPass : public FusePassBase {
+ public:
+  virtual ~RemoveReshapeTransposeForAttentionPass() {}
+
+ protected:
+  void ApplyImpl(ir::Graph* graph) const override;
+  void ReshapeTranspose(Graph* graph) const;
+  void TransposeReshape(Graph* graph) const;
+  void ReshapeTransposeScale(Graph* graph) const;
+  void RemoveStack(Graph* graph) const;
+};
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle

--- a/paddle/fluid/framework/ir/remove_reshape_transpose_pass_tester.cc
+++ b/paddle/fluid/framework/ir/remove_reshape_transpose_pass_tester.cc
@@ -1,0 +1,166 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/framework/ir/remove_reshape_transpose_pass.h"
+#include <gtest/gtest.h>
+#include "paddle/fluid/framework/naive_executor.h"
+#include "paddle/fluid/framework/op_proto_maker.h"
+
+namespace paddle {
+namespace framework {
+namespace ir {
+
+void SetOp(ProgramDesc* prog, const std::string& type,
+           const std::vector<std::string>& inputs,
+           const std::vector<std::string>& outputs) {
+  auto* op = prog->MutableBlock(0)->AppendOp();
+  op->SetType(type);
+  if (type == "matmul") {
+    op->SetInput("X", {inputs[0]});
+    op->SetInput("Y", {inputs[1]});
+  } else if (type == "transpose2") {
+    op->SetInput("X", inputs);
+    op->SetAttr("axis", std::vector<int>({0, 2, 1, 3}));
+  } else if (type == "reshape2") {
+    op->SetInput("X", inputs);
+    op->SetAttr("shape", std::vector<int>({0, 0, 2, 4}));
+  } else if (type == "scale") {
+    op->SetInput("X", inputs);
+    op->SetAttr("bias", 0.0f);
+    op->SetAttr("scale", 1.0f);
+  } else {
+    op->SetInput("X", inputs);
+  }
+  op->SetOutput("Out", outputs);
+  op->SetAttr(OpProtoAndCheckerMaker::OpRoleAttrName(),
+              static_cast<int>(OpRole::kForward));
+}
+
+// Forward:
+// a->reshape->b->transpose->c
+// (c, e)->matmul->f
+// IsScale:
+// a->reshape->b->transpose->c->scale->d
+// (d, e)->matmul->f
+// Forward_inverse:
+// (a, b)->matmul->c->transpose->d->reshape->e
+// Stack:
+// (g, h, i)->stack->j
+// (g, h),i)->concat->j
+ProgramDesc BuildProgramDesc(bool is_scale, bool is_out, bool is_x,
+                             bool is_stack) {
+  ProgramDesc prog;
+  for (auto& v : std::vector<std::string>(
+           {"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"})) {
+    auto* var = prog.MutableBlock(0)->Var(v);
+    var->SetType(proto::VarType::LOD_TENSOR);
+  }
+  if (is_out) {
+    SetOp(&prog, "matmul", std::vector<std::string>({"a", "b"}),
+          std::vector<std::string>({"c"}));
+    SetOp(&prog, "transpose2", std::vector<std::string>({"c"}),
+          std::vector<std::string>({"d"}));
+    SetOp(&prog, "reshape2", std::vector<std::string>({"d"}),
+          std::vector<std::string>({"e"}));
+  } else {
+    SetOp(&prog, "reshape2", std::vector<std::string>({"a"}),
+          std::vector<std::string>({"b"}));
+    SetOp(&prog, "transpose2", std::vector<std::string>({"b"}),
+          std::vector<std::string>({"c"}));
+    if (is_scale) {
+      SetOp(&prog, "scale", std::vector<std::string>({"c"}),
+            std::vector<std::string>({"d"}));
+      if (is_x) {
+        SetOp(&prog, "matmul", std::vector<std::string>({"d", "e"}),
+              std::vector<std::string>({"f"}));
+      } else {
+        SetOp(&prog, "matmul", std::vector<std::string>({"e", "d"}),
+              std::vector<std::string>({"f"}));
+      }
+    } else {
+      if (is_x) {
+        SetOp(&prog, "matmul", std::vector<std::string>({"c", "e"}),
+              std::vector<std::string>({"f"}));
+      } else {
+        SetOp(&prog, "matmul", std::vector<std::string>({"e", "c"}),
+              std::vector<std::string>({"f"}));
+      }
+    }
+    if (is_stack) {
+      SetOp(&prog, "stack", std::vector<std::string>({"g", "h", "i"}),
+            std::vector<std::string>({"j"}));
+    }
+  }
+
+  return prog;
+}
+
+void MainTest(bool is_scale = false, bool is_out = false, bool is_x = true,
+              bool is_stack = false) {
+  auto prog = BuildProgramDesc(is_scale, is_out, is_x, is_stack);
+  std::unique_ptr<ir::Graph> graph(new ir::Graph(prog));
+  auto place = paddle::platform::CPUPlace();
+  NaiveExecutor exe{place};
+  Scope scope;
+  // Init scope, as it is used in pass
+  exe.CreateVariables(prog, 0, true, &scope);
+  graph->Set(kParamScopeAttr, new framework::Scope*(&scope));
+
+  auto pass = PassRegistry::Instance().Get("remove_reshape_transpose_pass");
+
+  graph.reset(pass->Apply(graph.release()));
+
+  // Assert fused matmul op in newly generated graph
+  int found_op_count = 0;
+
+  for (auto* node : graph->Nodes()) {
+    if (node->IsOp() && (node->Op()->Type() == "transpose2" ||
+                         node->Op()->Type() == "reshape2")) {
+      ++found_op_count;
+    }
+  }
+  EXPECT_EQ(found_op_count, 0);
+  int found_stack_count = 0;
+  for (auto* node : graph->Nodes()) {
+    if (node->IsOp() && (node->Op()->Type() == "stack")) {
+      ++found_stack_count;
+    }
+  }
+  EXPECT_EQ(found_stack_count, 0);
+}
+
+TEST(ReshapeTransposeScaleMatmulFusePass, reshape_transpose_scale_matmul_x) {
+  MainTest(true, false, true, false);
+}
+TEST(ReshapeTransposeScaleMatmulFusePass, reshape_transpose_scale_matmul_y) {
+  MainTest(true, false, false, false);
+}
+TEST(ReshapeTransposeScaleMatmulFusePass, reshape_transpose_matmul_x) {
+  MainTest(false, false, true, false);
+}
+TEST(ReshapeTransposeScaleMatmulFusePass, reshape_transpose_matmul_y) {
+  MainTest(false, false, false, false);
+}
+TEST(ReshapeTransposeScaleMatmulFusePass, matmul_transpose_reshape) {
+  MainTest(false, true, false, false);
+}
+TEST(ReshapeTransposeScaleMatmulFusePass, replace_stack) {
+  MainTest(false, false, false, true);
+}
+
+}  // namespace ir
+}  // namespace framework
+}  // namespace paddle
+
+USE_PASS(remove_reshape_transpose_pass);

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -153,18 +153,18 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
                   // "seqpool_concat_fuse_pass",    //
                   "seqpool_cvm_concat_fuse_pass",  //
                   // "embedding_fc_lstm_fuse_pass", //
-                  "fc_lstm_fuse_pass",             //
-                  "mul_lstm_fuse_pass",            //
-                  "fc_gru_fuse_pass",              //
-                  "mul_gru_fuse_pass",             //
-                  "seq_concat_fc_fuse_pass",       //
-                  "fc_fuse_pass",                  //
-                  "repeated_fc_relu_fuse_pass",    //
-                  "squared_mat_sub_fuse_pass",     //
-                  "conv_bn_fuse_pass",             //
-                  "conv_eltwiseadd_bn_fuse_pass",  //
-                  "is_test_pass",                  //
-                  "remove_reshape_transpose_pass", //
+                  "fc_lstm_fuse_pass",              //
+                  "mul_lstm_fuse_pass",             //
+                  "fc_gru_fuse_pass",               //
+                  "mul_gru_fuse_pass",              //
+                  "seq_concat_fc_fuse_pass",        //
+                  "fc_fuse_pass",                   //
+                  "repeated_fc_relu_fuse_pass",     //
+                  "squared_mat_sub_fuse_pass",      //
+                  "conv_bn_fuse_pass",              //
+                  "conv_eltwiseadd_bn_fuse_pass",   //
+                  "is_test_pass",                   //
+                  "remove_reshape_transpose_pass",  //
                   // following pass should be located in the last, since
                   // it will work on all fused ops.
                   "runtime_context_cache_pass"});

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -164,6 +164,7 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
                   "conv_bn_fuse_pass",             //
                   "conv_eltwiseadd_bn_fuse_pass",  //
                   "is_test_pass",                  //
+                  "remove_reshape_transpose_pass", //
                   // following pass should be located in the last, since
                   // it will work on all fused ops.
                   "runtime_context_cache_pass"});

--- a/paddle/fluid/operators/math/blas.h
+++ b/paddle/fluid/operators/math/blas.h
@@ -125,7 +125,8 @@ class Blas {
                       const MatDescriptor& dim_a,
                       const framework::Tensor& mat_b,
                       const MatDescriptor& dim_b, T alpha, int head_number,
-                      framework::Tensor* mat_out, T beta) const;
+                      bool mat_y_split_vertical, framework::Tensor* mat_out,
+                      T beta) const;
 #endif
 #endif
 
@@ -194,9 +195,10 @@ class Blas {
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
   template <typename T>
   void BatchedGEMMWithHead(CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB,
-                           int M, int N, int K, T alpha, const T* A, const T* B,
-                           T beta, T* C, int batchCount, int64_t strideA,
-                           int64_t strideB, int64_t head_number) const;
+                           int W1, int H1, int W2, int H2, T alpha, const T* A,
+                           const T* B, T beta, T* C, int batchCount,
+                           int64_t strideA, int64_t strideB,
+                           int64_t head_number, bool split_b_vertical) const;
 #endif
 
   template <typename T>

--- a/paddle/fluid/operators/math/blas_impl.h
+++ b/paddle/fluid/operators/math/blas_impl.h
@@ -583,33 +583,68 @@ void Blas<platform::CPUDeviceContext>::BatchedGEMM(
 template <>
 template <typename T>
 void Blas<platform::CPUDeviceContext>::BatchedGEMMWithHead(
-    CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int M, int N, int K,
-    T alpha, const T *A, const T *B, T beta, T *C, int batchCount,
-    int64_t strideA, int64_t strideB, int64_t head_number) const {
-  int lda = (transA == CblasNoTrans) ? K : M;
-  int ldb = (transB == CblasNoTrans) ? N : K;
-  int ldc = N * head_number;
-  int sub_width = K / head_number;
-  auto a_array = std::vector<const T *>(batchCount);
-  auto b_array = std::vector<const T *>(batchCount);
-  auto c_array = std::vector<T *>(batchCount);
+    CBLAS_TRANSPOSE transA, CBLAS_TRANSPOSE transB, int W1, int H1, int W2,
+    int H2, T alpha, const T *A, const T *B, T beta, T *C, int batchCount,
+    int64_t strideA, int64_t strideB, int64_t head_number,
+    bool split_b_vertical) const {
+  if (split_b_vertical) {
+    int lda = (transA == CblasNoTrans) ? W1 : H1;
+    int ldb = (transB == CblasNoTrans) ? W2 : H2;
+    int ldc = W2;
+    int sub_width = W2 / head_number;
+    auto a_array = std::vector<const T *>(batchCount);
+    auto b_array = std::vector<const T *>(batchCount);
+    auto c_array = std::vector<T *>(batchCount);
 
-  for (int i = 0; i < head_number; i++) {
-    int sub_matA_offset = (transA == CblasNoTrans) ? i * (K / head_number)
-                                                   : i * (K / head_number) * M;
-    int sub_matB_offset = (transB == CblasNoTrans) ? i * (K / head_number) * N
-                                                   : i * (K / head_number);
-    int sub_matC_offset = i * N;
-    for (int k = 0; k < batchCount; ++k) {
-      a_array[k] = &A[k * strideA] + sub_matA_offset;
-      b_array[k] = &B[k * strideB] + sub_matB_offset;
-      c_array[k] = &C[k * M * head_number * N] + sub_matC_offset;
+    for (int i = 0; i < head_number; i++) {
+      int sub_matA_offset = (transA == CblasNoTrans)
+                                ? i * (W1 / head_number)
+                                : i * (W1 / head_number) * H1;
+      int sub_matB_offset = (transB == CblasNoTrans)
+                                ? i * (W2 / head_number)
+                                : i * (W2 / head_number) * H2;
+      int sub_matC_offset = i * W2 / head_number;
+      for (int k = 0; k < batchCount; ++k) {
+        a_array[k] = &A[k * strideA] + sub_matA_offset;
+        b_array[k] = &B[k * strideB] + sub_matB_offset;
+        c_array[k] = &C[k * H1 * W2] + sub_matC_offset;
+      }
+
+      CBlas<T>::GEMM_BATCH(CblasRowMajor, &transA, &transB, &H1, &sub_width,
+                           &H2, &alpha, a_array.data(), &lda, b_array.data(),
+                           &ldb, &beta, c_array.data(), &ldc,
+                           1 /* group_count */, &batchCount);
     }
 
-    CBlas<T>::GEMM_BATCH(CblasRowMajor, &transA, &transB, &M, &N, &sub_width,
-                         &alpha, a_array.data(), &lda, b_array.data(), &ldb,
-                         &beta, c_array.data(), &ldc, 1 /* group_count */,
-                         &batchCount);
+  } else {
+    PADDLE_ENFORCE_EQ(W1, H2);
+    int lda = (transA == CblasNoTrans) ? W1 : H1;
+    int ldb = (transB == CblasNoTrans) ? W2 : H2;
+    int ldc = W2 * head_number;
+    int sub_width = W1 / head_number;
+    auto a_array = std::vector<const T *>(batchCount);
+    auto b_array = std::vector<const T *>(batchCount);
+    auto c_array = std::vector<T *>(batchCount);
+
+    for (int i = 0; i < head_number; i++) {
+      int sub_matA_offset = (transA == CblasNoTrans)
+                                ? i * (W1 / head_number)
+                                : i * (W1 / head_number) * H1;
+      int sub_matB_offset = (transB == CblasNoTrans)
+                                ? i * (W1 / head_number) * W2
+                                : i * (W1 / head_number);
+      int sub_matC_offset = i * W2;
+      for (int k = 0; k < batchCount; ++k) {
+        a_array[k] = &A[k * strideA] + sub_matA_offset;
+        b_array[k] = &B[k * strideB] + sub_matB_offset;
+        c_array[k] = &C[k * H1 * head_number * W2] + sub_matC_offset;
+      }
+
+      CBlas<T>::GEMM_BATCH(CblasRowMajor, &transA, &transB, &H1, &W2,
+                           &sub_width, &alpha, a_array.data(), &lda,
+                           b_array.data(), &ldb, &beta, c_array.data(), &ldc,
+                           1 /* group_count */, &batchCount);
+    }
   }
 }
 #endif
@@ -690,51 +725,91 @@ void Blas<DeviceContext>::MatMul(const framework::Tensor &mat_a,
  * When user calls this API, the multiplication of two big matrixes is split
  * into multiplication of several (head_number_) small matrixes. e.g. if Mat A
  * is [3, 24] and Mat B is [24, 4], when multiple A and B with head_number as
- * 4, Mat A will be split as 4 matrix of [3, 6] and Mat B will be 4 matrix of
- * [6, 4]. The result of final matrix will be 4 matrix of [3, 4], i.e. [3, 16].
- *
+ * 4, Mat A will be splitted as 4 matrix of [3, 6] and Mat B will be
+ * (horizontally) splitted as 4 matrix of [6, 4]. The result of final matrix
+ * will be 4 matrix of [3, 4], i.e. [3, 16].
+ * Another example is A is [3, 8], B is [2, 16], head_number is 4. In this
+ * case, A will be splitted as [3, 2], B will be (vertically) splitted as
+ * [2, 4]. The final result will be 4 matrix of 4 matrix of [3,4], i.e. [3, 16]
  */
 template <typename DeviceContext>
 template <typename T>
 void Blas<DeviceContext>::MatMulWithHead(
     const framework::Tensor &mat_a, const MatDescriptor &dim_a,
     const framework::Tensor &mat_b, const MatDescriptor &dim_b, T alpha,
-    int head_number, framework::Tensor *mat_out, T beta) const {
-  PADDLE_ENFORCE_EQ(dim_a.width_, dim_b.height_);
+    int head_number, bool mat_b_split_vertical, framework::Tensor *mat_out,
+    T beta) const {
   PADDLE_ENFORCE_EQ(dim_a.width_ % head_number, 0);
   PADDLE_ENFORCE_GE(head_number, 1);
   PADDLE_ENFORCE_LE(head_number, dim_a.width_);
   CBLAS_TRANSPOSE transA = !dim_a.trans_ ? CblasNoTrans : CblasTrans;
   CBLAS_TRANSPOSE transB = !dim_b.trans_ ? CblasNoTrans : CblasTrans;
 
-  if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
-    for (int i = 0; i < head_number; i++) {
-      int sub_matA_offset =
-          dim_a.trans_ ? i * (dim_a.width_ / head_number) * dim_a.height_
-                       : i * (dim_a.width_ / head_number);
-      int sub_matB_offset =
-          dim_b.trans_ ? i * (dim_b.height_ / head_number)
-                       : i * (dim_b.height_ / head_number) * dim_b.width_;
-      int sub_matC_offset = i * dim_b.width_;
-      int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
-      int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
-      int ldc = head_number * dim_b.width_;
+  if (mat_b_split_vertical) {
+    PADDLE_ENFORCE_EQ(dim_b.height_, dim_a.width_ / head_number);
 
-      this->template GEMM<T>(transA, transB, dim_a.height_, dim_b.width_,
-                             dim_a.width_ / head_number, alpha,
-                             mat_a.data<T>() + sub_matA_offset, lda,
-                             mat_b.data<T>() + sub_matB_offset, ldb, beta,
-                             mat_out->data<T>() + sub_matC_offset, ldc);
+    if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
+      for (int i = 0; i < head_number; i++) {
+        int sub_matA_offset =
+            dim_a.trans_ ? i * (dim_a.width_ / head_number) * dim_a.height_
+                         : i * (dim_a.width_ / head_number);
+        int sub_matB_offset =
+            dim_b.trans_ ? i * (dim_b.width_ / head_number) * dim_b.height_
+                         : i * (dim_b.width_ / head_number);
+        int sub_matC_offset = i * dim_b.width_ / head_number;
+        int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
+        int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
+        int ldc = dim_b.width_;
+
+        this->template GEMM<T>(transA, transB, dim_a.height_,
+                               dim_b.width_ / head_number, dim_b.height_, alpha,
+                               mat_a.data<T>() + sub_matA_offset, lda,
+                               mat_b.data<T>() + sub_matB_offset, ldb, beta,
+                               mat_out->data<T>() + sub_matC_offset, ldc);
+      }
+    } else {
+      PADDLE_ENFORCE(dim_a.batch_size_ == dim_b.batch_size_ ||
+                     dim_a.batch_size_ == 0 || dim_b.batch_size_ == 0);
+
+      this->template BatchedGEMMWithHead<T>(
+          transA, transB, dim_a.width_, dim_a.height_, dim_b.width_,
+          dim_b.height_, alpha, mat_a.data<T>(), mat_b.data<T>(), beta,
+          mat_out->data<T>(),
+          dim_a.batch_size_ == 0 ? dim_b.batch_size_ : dim_a.batch_size_,
+          dim_a.stride_, dim_b.stride_, head_number, mat_b_split_vertical);
     }
-  } else {
-    PADDLE_ENFORCE(dim_a.batch_size_ == dim_b.batch_size_ ||
-                   dim_a.batch_size_ == 0 || dim_b.batch_size_ == 0);
 
-    this->template BatchedGEMMWithHead<T>(
-        transA, transB, dim_a.height_, dim_b.width_, dim_a.width_, alpha,
-        mat_a.data<T>(), mat_b.data<T>(), beta, mat_out->data<T>(),
-        dim_a.batch_size_ == 0 ? dim_b.batch_size_ : dim_a.batch_size_,
-        dim_a.stride_, dim_b.stride_, head_number);
+  } else {
+    if (dim_a.batch_size_ == 0 && dim_b.batch_size_ == 0) {
+      for (int i = 0; i < head_number; i++) {
+        int sub_matA_offset =
+            dim_a.trans_ ? i * (dim_a.width_ / head_number) * dim_a.height_
+                         : i * (dim_a.width_ / head_number);
+        int sub_matB_offset =
+            dim_b.trans_ ? i * (dim_b.height_ / head_number)
+                         : i * (dim_b.height_ / head_number) * dim_b.width_;
+        int sub_matC_offset = i * dim_b.width_;
+        int lda = !dim_a.trans_ ? dim_a.width_ : dim_a.height_;
+        int ldb = !dim_b.trans_ ? dim_b.width_ : dim_b.height_;
+        int ldc = head_number * dim_b.width_;
+
+        this->template GEMM<T>(transA, transB, dim_a.height_, dim_b.width_,
+                               dim_a.width_ / head_number, alpha,
+                               mat_a.data<T>() + sub_matA_offset, lda,
+                               mat_b.data<T>() + sub_matB_offset, ldb, beta,
+                               mat_out->data<T>() + sub_matC_offset, ldc);
+      }
+    } else {
+      PADDLE_ENFORCE(dim_a.batch_size_ == dim_b.batch_size_ ||
+                     dim_a.batch_size_ == 0 || dim_b.batch_size_ == 0);
+
+      this->template BatchedGEMMWithHead<T>(
+          transA, transB, dim_a.width_, dim_a.height_, dim_b.width_,
+          dim_b.height_, alpha, mat_a.data<T>(), mat_b.data<T>(), beta,
+          mat_out->data<T>(),
+          dim_a.batch_size_ == 0 ? dim_b.batch_size_ : dim_a.batch_size_,
+          dim_a.stride_, dim_b.stride_, head_number, mat_b_split_vertical);
+    }
   }
 }
 #endif

--- a/python/paddle/fluid/tests/unittests/test_matmul_op_with_head.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op_with_head.py
@@ -148,11 +148,147 @@ def inject_test_multiple_head(dim_x, dim_y, trans_x, trans_y, head_number):
     })
 
 
+def matmul_head2(X, Y, head_number=1):
+    x = []
+    y = []
+    z = []
+    sub_x_width = X.shape[-1] // head_number
+    sub_y_width = Y.shape[-1] // head_number
+    assert (sub_x_width == Y.shape[-2]
+            ), "Error: incompatible head number or matrix size!"
+    if np.ndim(X) == 2:
+        for i in range(0, head_number):
+            x.append(X[:, i * sub_x_width:i * sub_x_width + sub_x_width])
+            y.append(Y[:, i * sub_y_width:i * sub_y_width + sub_y_width])
+        for i in range(0, head_number):
+            z.append(np.matmul(x[i], y[i]))
+        Z = np.concatenate((z), axis=1)
+
+    elif np.ndim(X) == 3:
+        for i in range(0, head_number):
+            x.append(X[:, :, i * sub_x_width:i * sub_x_width + sub_x_width])
+            y.append(Y[:, :, i * sub_y_width:i * sub_y_width + sub_y_width])
+        for i in range(0, head_number):
+            z.append(np.matmul(x[i], y[i]))
+        Z = np.concatenate((z), axis=2)
+    else:
+        assert False, "ERROR: Not supported dimension!"
+    return Z
+
+
+def reference_matmul_mul_head2(X,
+                               Y,
+                               head_number=1,
+                               transpose_X=False,
+                               transpose_Y=False):
+    """Reference forward implementation using np.matmul."""
+    # np.matmul does not support the transpose flags, so we manually
+    # transpose X and Y appropriately.
+    if transpose_X:
+        X = transpose_mat(X)
+    if transpose_Y:
+        Y = transpose_mat(Y)
+
+    Out = matmul_head2(X, Y, head_number)
+    if not Out.shape:
+        # We do not support 0-dimensional Tensors (scalars). So where
+        # np.matmul outputs a scalar, we must convert to a Tensor of
+        # shape (1, ) instead.
+        # Everywhere else, we are compatible with np.matmul.
+        Out = np.array([Out], dtype="float32")
+    return Out
+
+
+def generate_compatible_shapes_mul_head2(dim_X, dim_Y, transpose_X,
+                                         transpose_Y):
+    BATCH_SIZE = 2
+    # Assume head number H is 4. We need make sure K1/H = M2
+    M1 = 3
+    K1 = 8
+    M2 = 2
+    K2 = 16
+
+    if dim_X >= 2:
+        if transpose_X:
+            shape_X = [K1, M1]
+        else:
+            shape_X = [M1, K1]
+    if dim_X == 3:
+        shape_X = [BATCH_SIZE] + shape_X
+    if dim_Y >= 2:
+        if transpose_Y:
+            shape_Y = [K2, M2]
+        else:
+            shape_Y = [M2, K2]
+    if dim_Y == 3:
+        shape_Y = [BATCH_SIZE] + shape_Y
+    return shape_X, shape_Y
+
+
+# Generator for multiple head, case 2 when width of X is not same as height of Y
+class GeneratorMulHead2(object):
+    def setUp(self):
+        self.op_type = "matmul"
+
+        X = np.zeros(self.shape_X)
+        Y = np.zeros(self.shape_Y)
+        if len(self.shape_X) == 2:
+            X = np.arange(
+                0, self.shape_X[-1] * self.shape_X[-2],
+                dtype=np.float32).reshape(self.shape_X)
+            Y = np.arange(
+                0, self.shape_Y[-1] * self.shape_Y[-2],
+                dtype=np.float32).reshape(self.shape_Y)
+        else:
+            for i in range(0, len(self.shape_X) - 1):
+                X[i, :, :] = np.arange(
+                    0, self.shape_X[-1] * self.shape_X[-2],
+                    dtype=np.float32).reshape(list(self.shape_X)[-2:])
+                Y[i, :, :] = np.arange(
+                    0, self.shape_Y[-1] * self.shape_Y[-2],
+                    dtype=np.float32).reshape(list(self.shape_Y)[-2:])
+
+        Out = reference_matmul_mul_head2(X, Y, 4, self.transpose_X,
+                                         self.transpose_Y)
+
+        self.inputs = {'X': X, 'Y': Y}
+        self.attrs = {
+            'transpose_X': self.transpose_X,
+            'transpose_Y': self.transpose_Y,
+            'head_number': self.head_number
+        }
+        self.outputs = {'Out': Out}
+
+    def test_check_output(self):
+        self.check_output(atol=1e-3)
+
+
+def inject_test_multiple_head2(dim_x, dim_y, trans_x, trans_y, head_number):
+    test_name = (
+        'TestMatMulOp_dimX_{}_dim_Y_{}_transX_{}_transY_{}_head2_{}'.format(
+            dim_x, dim_y, trans_x, trans_y, head_number))
+    shape_x, shape_y = generate_compatible_shapes_mul_head2(dim_x, dim_y,
+                                                            trans_x, trans_y)
+    globals()[test_name] = type(test_name, (GeneratorMulHead2, OpTest), {
+        'shape_X': shape_x,
+        'shape_Y': shape_y,
+        'transpose_X': trans_x,
+        'transpose_Y': trans_y,
+        'head_number': head_number
+    })
+
+
 #test case for multiple head
 for dim in (2, 3):
     for transose_x in (False, True):
         for transose_y in (False, True):
             inject_test_multiple_head(dim, dim, transose_x, transose_y, 4)
+
+#test case for multiple head when X.width != Y.height
+for dim in (2, 3):
+    for transose_x in (False, True):
+        for transose_y in (False, True):
+            inject_test_multiple_head2(dim, dim, transose_x, transose_y, 4)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR is to refactor the PR #16342, one PR #18570 for matmul kernel has been merged. This PR contains:

- Pass for modifying the graph

- A fix for the merged matmul kernel for supporting last dimension value is not equal

> This PR can be run with the ERNIE, and there is a little accuracy diff with this PASS are under fixing. 

**Pass for graph modification:**

- Before
![image](https://user-images.githubusercontent.com/33643817/64098855-7a2df280-cd9a-11e9-8e5f-24dea872d684.png)

- After
![image](https://user-images.githubusercontent.com/33643817/64098592-dcd2be80-cd99-11e9-86b5-2702bf59fa46.png)
