### PR TITLE
Remove constraint that last dimension is forced to be 1 in one_hot

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -174,7 +174,7 @@ paddle.fluid.layers.group_norm (ArgSpec(args=['input', 'groups', 'epsilon', 'par
 paddle.fluid.layers.spectral_norm (ArgSpec(args=['weight', 'dim', 'power_iters', 'eps', 'name'], varargs=None, keywords=None, defaults=(0, 1, 1e-12, None)), ('document', '9461e67095a6fc5d568fb2ce8fef66ff'))
 paddle.fluid.layers.softmax_with_cross_entropy (ArgSpec(args=['logits', 'label', 'soft_label', 'ignore_index', 'numeric_stable_mode', 'return_softmax', 'axis'], varargs=None, keywords=None, defaults=(False, -100, True, False, -1)), ('document', '54e1675aa0364f4a78fa72804ec0f413'))
 paddle.fluid.layers.smooth_l1 (ArgSpec(args=['x', 'y', 'inside_weight', 'outside_weight', 'sigma'], varargs=None, keywords=None, defaults=(None, None, None)), ('document', 'ecb75c1b00c4c76c98b482f633b7a10c'))
-paddle.fluid.layers.one_hot (ArgSpec(args=['input', 'depth', 'allow_out_of_range'], varargs=None, keywords=None, defaults=(False,)), ('document', 'ec4115591be842868c86b2e5334245c6'))
+paddle.fluid.layers.one_hot (ArgSpec(args=['input', 'depth', 'allow_out_of_range'], varargs=None, keywords=None, defaults=(False,)), ('document', 'a6876d79c4c1b90375784306a707652f'))
 paddle.fluid.layers.autoincreased_step_counter (ArgSpec(args=['counter_name', 'begin', 'step'], varargs=None, keywords=None, defaults=(None, 1, 1)), ('document', '98e7927f09ee2270535b29f048e481ec'))
 paddle.fluid.layers.reshape (ArgSpec(args=['x', 'shape', 'actual_shape', 'act', 'inplace', 'name'], varargs=None, keywords=None, defaults=(None, None, False, None)), ('document', '6196c9ec3075ca5a9c058ea1f8492256'))
 paddle.fluid.layers.squeeze (ArgSpec(args=['input', 'axes', 'name'], varargs=None, keywords=None, defaults=(None,)), ('document', 'ebbac07662a6e22e8e299ced880c7775'))

--- a/paddle/fluid/operators/one_hot_op.cu
+++ b/paddle/fluid/operators/one_hot_op.cu
@@ -74,8 +74,7 @@ class OneHotCUDAKernel : public framework::OpKernel<T> {
         depth = *depth_tensor->data<int32_t>();
       }
 
-      auto in_dims = in->dims();
-      framework::DDim out_dims(in_dims);
+      auto out_dims = out->dims();
       out_dims[out_dims.size() - 1] = depth;
       out->Resize(out_dims);
     } else {

--- a/paddle/fluid/operators/one_hot_op.h
+++ b/paddle/fluid/operators/one_hot_op.h
@@ -76,8 +76,7 @@ class OneHotKernel : public framework::OpKernel<T> {
       auto* depth_tensor = context.Input<Tensor>("depth_tensor");
       auto* depth_data = depth_tensor->data<int32_t>();
       depth = depth_data[0];
-      auto in_dims = in->dims();
-      framework::DDim out_dims(in_dims);
+      auto out_dims = out->dims();
       out_dims[out_dims.size() - 1] = depth;
       out->Resize(out_dims);
     }

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6897,7 +6897,8 @@ def one_hot(input, depth, allow_out_of_range=False):
     This layer creates the one-hot representations for input indices.
 
     Args:
-        input(Variable): Input indices, last dimension must be 1.
+        input(Variable): Input indices represent locations, which takes value 1.0
+            in indices, while all other locations take value 0.
         depth(scalar): An interger defining the depth of the one-hot dimension.
         allow_out_of_range(bool): A bool value indicating whether the input
             indices could be out of range [0, depth). When input indices are

--- a/python/paddle/fluid/tests/unittests/test_one_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_op.py
@@ -48,6 +48,29 @@ class TestOneHotOp(OpTest):
         self.check_output()
 
 
+class TestOneHotOp_Rank1(OpTest):
+    def setUp(self):
+        self.op_type = 'one_hot'
+        depth = 10
+        depth_np = np.array(10).astype('int32')
+        dimension = 12
+        x_lod = [[4, 1, 3, 3]]
+        x = [np.random.randint(0, depth - 1) for i in range(sum(x_lod[0]))]
+        x = np.array(x).astype('int32')
+
+        out = np.zeros(shape=(np.product(x.shape), depth)).astype('float32')
+
+        for i in range(np.product(x.shape)):
+            out[i, x[i]] = 1.0
+
+        self.inputs = {'X': (x, x_lod), 'depth_tensor': depth_np}
+        self.attrs = {'dtype': int(core.VarDesc.VarType.FP32)}
+        self.outputs = {'Out': (out, x_lod)}
+
+    def test_check_output(self):
+        self.check_output()
+
+
 class TestOneHotOp_attr(OpTest):
     def setUp(self):
         self.op_type = 'one_hot'
@@ -83,6 +106,29 @@ class TestOneHotOp_default_dtype(OpTest):
 
         out = np.zeros(shape=(np.product(x.shape[:-1]),
                               depth)).astype('float32')
+
+        for i in range(np.product(x.shape)):
+            out[i, x[i]] = 1.0
+
+        self.inputs = {'X': (x, x_lod), 'depth_tensor': depth_np}
+        self.attrs = {}
+        self.outputs = {'Out': (out, x_lod)}
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestOneHotOp_default_dtype_rank1(OpTest):
+    def setUp(self):
+        self.op_type = 'one_hot'
+        depth = 10
+        depth_np = np.array(10).astype('int32')
+        dimension = 12
+        x_lod = [[4, 1, 3, 3]]
+        x = [np.random.randint(0, depth - 1) for i in range(sum(x_lod[0]))]
+        x = np.array(x).astype('int32')
+
+        out = np.zeros(shape=(np.product(x.shape), depth)).astype('float32')
 
         for i in range(np.product(x.shape)):
             out[i, x[i]] = 1.0

--- a/python/paddle/fluid/tests/unittests/test_runtime_and_compiletime_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_runtime_and_compiletime_exception.py
@@ -29,12 +29,12 @@ class TestRunTimeException(OpTest):
         train_program = fluid.Program()
         startup_program = fluid.Program()
         with fluid.program_guard(train_program, startup_program):
-            label = fluid.layers.data(name="label", shape=[1], dtype="int64")
-            fluid.layers.one_hot(input=label, depth=100)
+            x = fluid.layers.data(name="x", shape=[1], dtype="float32")
+            fluid.layers.fc(input=x, size=3)
 
         def _run_program():
-            x = np.random.random(size=(10)).astype('int64')
-            exe.run(train_program, feed={"label": x})
+            x = np.random.random(size=(10)).astype('float32')
+            exe.run(train_program, feed={"x": x})
 
         self.assertRaises(core.EnforceNotMet, _run_program)
 
@@ -47,9 +47,9 @@ class TestCompileTimeException(OpTest):
         train_program = fluid.Program()
         startup_program = fluid.Program()
         with fluid.program_guard(train_program, startup_program):
-            label = fluid.layers.data(
-                name="label", shape=[1], dtype="int64", append_batch_size=False)
-            fluid.layers.one_hot(input=label, depth=100)
+            x = fluid.layers.data(
+                name="x", shape=[1], dtype="float32", append_batch_size=False)
+            fluid.layers.fc(input=x, size=100)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**before：**
+ the `input` label must be tensor with last dimension forced to be 1, such as shape [batch_size, 1]
```python
import paddle.fluid as fluid

label = fluid.layers.data(name="label", shape=[1], dtype="int32")
one_hot_label = fluid.layers.one_hot(input=label, depth=10)

place = fluid.CPUPlace()
label_data = np.random.rand(10, 1).astype("int32")
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
ret = exe.run(feed={ 'label': label_data}, 
              fetch_list=[one_hot_label], return_numpy=False)
```

**after：**
+ the `input` label can be tensor with shape [batch_size, 1] or [batch_size]
```python
batch_size = 10
label = fluid.layers.data(name='label', shape=[batch_size],append_batch_size=False, dtype='int32')
...
label_data = np.random.rand(batch_size).astype("int32")
```