### PR TITLE
add feed_var_names to Prune interface

### DIFF
--- a/paddle/fluid/framework/prune.cc
+++ b/paddle/fluid/framework/prune.cc
@@ -185,8 +185,9 @@ void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
 }
 
 // TODO(fengjiayi): Prune() could be inplaced to avoid unnecessary copies
-void Prune(const proto::ProgramDesc& input, proto::ProgramDesc* output,
-           const std::set<std::string>& feed_var_names) {
+void Prune(const proto::ProgramDesc& input,
+           const std::set<std::string>& feed_var_names,
+           proto::ProgramDesc* output) {
   std::set<std::string> dependent_vars;
   output->clear_blocks();
   prune_impl(input, output, 0, -1, &dependent_vars, feed_var_names);

--- a/paddle/fluid/framework/prune.cc
+++ b/paddle/fluid/framework/prune.cc
@@ -68,7 +68,8 @@ bool HasSubBlock(const proto::OpDesc& op_desc) {
 // the child block to help pruning
 void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
                 int block_id, int parent_block_id,
-                std::set<std::string>* dependent_vars) {
+                std::set<std::string>* dependent_vars,
+                const std::set<std::string> feed_var_names) {
   auto& block = input.blocks(block_id);
   auto& ops = block.ops();
 
@@ -94,7 +95,9 @@ void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
       // insert its input to the dependency graph
       for (auto& var : op_desc.inputs()) {
         for (auto& argu : var.arguments()) {
-          dependent_vars->insert(argu);
+          if (feed_var_names.count(argu) == 0) {
+            dependent_vars->insert(argu);
+          }
         }
       }
       should_run.push_back(true);
@@ -127,18 +130,22 @@ void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
         std::set<std::string> sub_block_dependent_vars;
         for (auto& var : op->inputs()) {
           for (auto& argu : var.arguments()) {
-            sub_block_dependent_vars.insert(argu);
+            if (feed_var_names.count(argu) == 0) {
+              sub_block_dependent_vars.insert(argu);
+            }
           }
         }
         for (auto& var : op->outputs()) {
           for (auto& argu : var.arguments()) {
-            sub_block_dependent_vars.insert(argu);
+            if (feed_var_names.count(argu) == 0) {
+              sub_block_dependent_vars.insert(argu);
+            }
           }
         }
         // GetSubBlockIndex(*op) is the idx of the sub_block in the input desc
         // output_block_id is the idx of the current block in the output desc
         prune_impl(input, output, GetSubBlockIndex(*op), output_block_id,
-                   &sub_block_dependent_vars);
+                   &sub_block_dependent_vars, feed_var_names);
       }
     }
   }
@@ -178,10 +185,11 @@ void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
 }
 
 // TODO(fengjiayi): Prune() could be inplaced to avoid unnecessary copies
-void Prune(const proto::ProgramDesc& input, proto::ProgramDesc* output) {
+void Prune(const proto::ProgramDesc& input, proto::ProgramDesc* output,
+           const std::set<std::string>& feed_var_names) {
   std::set<std::string> dependent_vars;
   output->clear_blocks();
-  prune_impl(input, output, 0, -1, &dependent_vars);
+  prune_impl(input, output, 0, -1, &dependent_vars, feed_var_names);
 }
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/prune.h
+++ b/paddle/fluid/framework/prune.h
@@ -22,8 +22,9 @@ limitations under the License. */
 namespace paddle {
 namespace framework {
 
-void Prune(const proto::ProgramDesc& input, proto::ProgramDesc* output,
-           const std::set<std::string>& feed_var_names);
+void Prune(const proto::ProgramDesc& input,
+           const std::set<std::string>& feed_var_names,
+           proto::ProgramDesc* output);
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/prune.h
+++ b/paddle/fluid/framework/prune.h
@@ -14,13 +14,16 @@ limitations under the License. */
 
 #pragma once
 
+#include <set>
+#include <string>
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/platform/enforce.h"
 
 namespace paddle {
 namespace framework {
 
-void Prune(const proto::ProgramDesc& input, proto::ProgramDesc* output);
+void Prune(const proto::ProgramDesc& input, proto::ProgramDesc* output,
+           const std::set<std::string>& feed_var_names);
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/prune_test.cc
+++ b/paddle/fluid/framework/prune_test.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/prune.h"
 
 #include <gtest/gtest.h>
+#include <set>
 #include <string>
 
 #include "paddle/fluid/framework/attribute.h"
@@ -58,12 +59,13 @@ TEST(Prune, one_operator) {
 
   f::proto::ProgramDesc *pdesc = program.Proto();
   f::proto::ProgramDesc pruned;
-
-  f::Prune(*pdesc, &pruned);
+  std::set<std::string> feed_var_names = {};
+  f::Prune(*pdesc, feed_var_names, &pruned);
   PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), 0);
 
+  feed_var_names.insert("a");
   pdesc->mutable_blocks(0)->mutable_ops(0)->set_is_target(true);
-  f::Prune(*pdesc, &pruned);
+  f::Prune(*pdesc, feed_var_names, &pruned);
   PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), 1);
 }
 
@@ -81,11 +83,11 @@ TEST(Prune, forward) {
         block);
 
   f::proto::ProgramDesc *pdesc = program.Proto();
-
+  std::set<std::string> feed_var_names = {"a"};
   for (int i = 0; i < pdesc->blocks(0).ops_size(); ++i) {
     f::proto::ProgramDesc pruned;
     pdesc->mutable_blocks(0)->mutable_ops(i)->set_is_target(true);
-    f::Prune(*pdesc, &pruned);
+    f::Prune(*pdesc, feed_var_names, &pruned);
     PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), i + 1);
   }
 }
@@ -107,7 +109,8 @@ TEST(Prune, multi_input_op) {
   pdesc->mutable_blocks(0)->mutable_ops(3)->set_is_target(true);
 
   f::proto::ProgramDesc pruned;
-  f::Prune(*pdesc, &pruned);
+  std::set<std::string> feed_var_names = {"a0", "a1", "a2"};
+  f::Prune(*pdesc, feed_var_names, &pruned);
   PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), 4);
 }
 
@@ -126,7 +129,8 @@ TEST(Prune, multi_output_op) {
   pdesc->mutable_blocks(0)->mutable_ops(2)->set_is_target(true);
 
   f::proto::ProgramDesc pruned;
-  f::Prune(*pdesc, &pruned);
+  std::set<std::string> feed_var_names = {"a"};
+  f::Prune(*pdesc, feed_var_names, &pruned);
   PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), 2);
 }
 
@@ -146,6 +150,6 @@ TEST(Prune, multi_target) {
   pdesc->mutable_blocks(0)->mutable_ops(2)->set_is_target(true);
 
   f::proto::ProgramDesc pruned;
-  f::Prune(*pdesc, &pruned);
+  std::set<std::string> feed_var_names = {"a"};
   PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), 3);
 }

--- a/paddle/fluid/framework/prune_test.cc
+++ b/paddle/fluid/framework/prune_test.cc
@@ -151,5 +151,6 @@ TEST(Prune, multi_target) {
 
   f::proto::ProgramDesc pruned;
   std::set<std::string> feed_var_names = {"a"};
+  f::Prune(*pdesc, feed_var_names, &pruned);
   PADDLE_ENFORCE_EQ(pruned.blocks(0).ops_size(), 3);
 }

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -756,7 +756,7 @@ All parameter, weight, gradient are variables in Paddle.
       prog_with_targets.MutableBlock(t[0])->Op(t[1])->SetIsTarget(true);
     }
     proto::ProgramDesc pruned_desc;
-    Prune(*prog_with_targets.Proto(), &pruned_desc, feeded_var_names);
+    Prune(*prog_with_targets.Proto(), feeded_var_names, &pruned_desc);
     return new ProgramDesc(pruned_desc);
   });
   m.def("empty_var_name",

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -748,13 +748,15 @@ All parameter, weight, gradient are variables in Paddle.
 #endif
 
   m.def("prune", [](const ProgramDesc &origin,
+                    const std::set<std::string> &feeded_var_names,
                     const std::vector<std::array<size_t, 2>> &targets) {
     ProgramDesc prog_with_targets(origin);
+
     for (const auto &t : targets) {
       prog_with_targets.MutableBlock(t[0])->Op(t[1])->SetIsTarget(true);
     }
     proto::ProgramDesc pruned_desc;
-    Prune(*prog_with_targets.Proto(), &pruned_desc);
+    Prune(*prog_with_targets.Proto(), &pruned_desc, feeded_var_names);
     return new ProgramDesc(pruned_desc);
   });
   m.def("empty_var_name",

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3235,7 +3235,7 @@ class Program(object):
             targets = [targets]
 
         for var in feeded_var_names:
-            if not isinstance(var, str):
+            if not isinstance(var, six.string_types):
                 raise ValueError("All feeded_var_names of prune() can only be "
                                  "str.")
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3213,7 +3213,7 @@ class Program(object):
         p._copy_dist_param_info_from(self)
         return p
 
-    def _prune(self, targets):
+    def _prune(self, feeded_var_names, targets):
         """
         Prune operators and variables which are not needed to generate
         :code:`targets`.
@@ -3229,8 +3229,16 @@ class Program(object):
             Program:  A new, pruned program.
 
         """
+        if not isinstance(feeded_var_names, list):
+            feeded_var_names = [feeded_var_names]
         if not isinstance(targets, list):
             targets = [targets]
+
+        for var in feeded_var_names:
+            if not isinstance(var, str):
+                raise ValueError("All feeded_var_names of prune() can only be "
+                                 "str.")
+
         targets_idx = []
         for t in targets:
             if not isinstance(t, Operator):
@@ -3257,7 +3265,7 @@ class Program(object):
 
             targets_idx.append([t.block.idx, t.idx])
         res = Program()
-        res.desc = core.prune(self.desc, targets_idx)
+        res.desc = core.prune(self.desc, set(feeded_var_names), targets_idx)
         res.blocks = [
             Block(res, i) for i in six.moves.range(res.desc.num_blocks())
         ]

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1080,7 +1080,7 @@ def save_inference_model(dirname,
 
         main_program.desc.flush()
 
-        main_program = main_program._prune(targets=target_vars)
+        main_program = main_program._prune(feeded_var_names, target_vars)
         main_program = main_program._inference_optimize(prune_read_op=True)
         fetch_var_names = [v.name for v in target_vars]
 


### PR DESCRIPTION
Description of the requirement：https://github.com/PaddlePaddle/Paddle/issues/19362

Usage of the paddle::framework:: Prune() interface:
```cpp
proto::ProgramDesc pruned_desc;
Prune(original_program_desc, feeded_var_names, &pruned_desc);
```
`feeded_var_names` are Variables that we feed data in the inference program.
`original_program_desc` is the original program desc before pruning.
`pruned_desc` is the pruned program desc.

Usage of save_inference_model() interface remains the same. 

详细中文文档
----------------------------------
本Pull Request修复了prune接口无法无法指定feed_var的bug，修改后，其python端接口的使用方法为：
```python
    pruned_program = program._prune(feeded_var_names, targets)
```
其中，`feeded_var_names`是起始Variables的名字；targets为终止Variables，或者产生终止Variables的Operators。一个简单的例子可以说明本接口的使用方法：

```python
import paddle.fluid as fluid

x = fluid.layers.data(name='x', shape=[2], dtype='float32')
label = fluid.layers.data(name="label", shape=[1], dtype="int64")

# define net here
y = fluid.layers.fc(input=[x], size=2, act="softmax")
loss = fluid.layers.cross_entropy(input=y, label=label)
loss = fluid.layers.mean(x=loss)

sgd = fluid.optimizer.SGD(learning_rate=0.01)
sgd.minimize(loss)

with open("main_program", "w") as f:
    f.write(str(fluid.default_main_program()))

pruned_program = fluid.default_main_program()._prune(
                        feeded_var_names=[y.name, label.name],
                        targets = [loss])

with open("pruned_main_program", "w") as f:
    f.write(str(pruned_program))    
    
```
打印结果显示，裁剪后的模型的Operators只剩下`cross_entropy2`和`mean`，其余无关Operators和Variables都被裁剪掉了。