### PR TITLE
Fix retry_allocator_test failure by removing glog envs

### DIFF
--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -51,7 +51,6 @@ if (WITH_TESTING)
   endif()
 
   set_tests_properties(retry_allocator_test PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
-  set_property(TEST retry_allocator_test PROPERTY ENVIRONMENT GLOG_vmodule=retry_allocator=10)
 endif()
 
 cc_test(allocator_facade_abs_flags_test SRCS allocator_facade_abs_flags_test.cc DEPS allocator_facade)


### PR DESCRIPTION
`retry_allocator_test.cc` fails randomly. It may be because that there are too many logs printed out. This PR removes logs to fix the unittest. 
```
[23:40:06] :	 [Step 1/1]  1/18 Test   #6: retry_allocator_test .....................***Exception: Other  0.91 sec
[23:40:06] :	 [Step 1/1] WARNING: Logging before InitGoogleLogging() is written to STDERR
[23:40:06] :	 [Step 1/1] W0902 23:40:05.685518 60902 init.cc:87] Cannot enable P2P access from 0 to 1
[23:40:06] :	 [Step 1/1] W0902 23:40:05.685658 60902 init.cc:87] Cannot enable P2P access from 1 to 0
[23:40:06] :	 [Step 1/1] W0902 23:40:05.685885 60902 init.cc:165] AVX is available, Please re-compile on local machine
[23:40:06] :	 [Step 1/1] [==========] Running 2 tests from 1 test case.
[23:40:06] :	 [Step 1/1] [----------] Global test environment set-up.
[23:40:06] :	 [Step 1/1] [----------] 2 tests from RetryAllocator
[23:40:06] :	 [Step 1/1] [ RUN      ] RetryAllocator.RetryAllocator
[23:40:06] :	 [Step 1/1] I0902 23:40:05.690207 60926 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 1048575
[23:40:06] :	 [Step 1/1] I0902 23:40:05.692308 60927 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 2097150
[23:40:06] :	 [Step 1/1] I0902 23:40:05.694507 60928 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 3145725
[23:40:06] :	 [Step 1/1] I0902 23:40:05.696591 60929 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 4194300
[23:40:06] :	 [Step 1/1] I0902 23:40:05.698662 60930 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 5242875
[23:40:06] :	 [Step 1/1] I0902 23:40:05.701369 60931 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 6291450
[23:40:06] :	 [Step 1/1] I0902 23:40:05.703577 60932 retry_allocator.cc:63] Allocation failed when allocating 1048575 bytes, waited_allocate_size_ = 7340025
[23:40:06] :	 [Step 1/1] I0902 23:40:05.737440 60925 retry_allocator.cc:45] Free 1048575 bytes and notify all waited threads, where waited_allocate_size_ = 7340025
[23:40:06] :	 [Step 1/1] I0902 23:40:05.762646 60927 retry_allocator.cc:81] Allocation failed when retrying 1 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.781383 60928 retry_allocator.cc:81] Allocation failed when retrying 1 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.787297 60930 retry_allocator.cc:81] Allocation failed when retrying 1 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.824486 60929 retry_allocator.cc:81] Allocation failed when retrying 1 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.843446 60931 retry_allocator.cc:81] Allocation failed when retrying 1 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.844951 60932 retry_allocator.cc:81] Allocation failed when retrying 1 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.847081 60926 retry_allocator.cc:45] Free 1048575 bytes and notify all waited threads, where waited_allocate_size_ = 6291450
[23:40:06] :	 [Step 1/1] I0902 23:40:05.854657 60930 retry_allocator.cc:81] Allocation failed when retrying 2 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.881997 60928 retry_allocator.cc:81] Allocation failed when retrying 2 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.890427 60929 retry_allocator.cc:81] Allocation failed when retrying 2 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.891391 60931 retry_allocator.cc:81] Allocation failed when retrying 2 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.893709 60932 retry_allocator.cc:81] Allocation failed when retrying 2 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.893733 60927 retry_allocator.cc:45] Free 1048575 bytes and notify all waited threads, where waited_allocate_size_ = 5242875
[23:40:06] :	 [Step 1/1] I0902 23:40:05.896116 60928 retry_allocator.cc:81] Allocation failed when retrying 3 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.898438 60929 retry_allocator.cc:81] Allocation failed when retrying 3 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.900740 60931 retry_allocator.cc:81] Allocation failed when retrying 3 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.903113 60932 retry_allocator.cc:81] Allocation failed when retrying 3 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.933938 60930 retry_allocator.cc:45] Free 1048575 bytes and notify all waited threads, where waited_allocate_size_ = 4194300
[23:40:06] :	 [Step 1/1] I0902 23:40:05.936380 60929 retry_allocator.cc:81] Allocation failed when retrying 4 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.938699 60931 retry_allocator.cc:81] Allocation failed when retrying 4 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.941016 60932 retry_allocator.cc:81] Allocation failed when retrying 4 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.974114 60928 retry_allocator.cc:45] Free 1048575 bytes and notify all waited threads, where waited_allocate_size_ = 3145725
[23:40:06] :	 [Step 1/1] I0902 23:40:05.981104 60931 retry_allocator.cc:81] Allocation failed when retrying 5 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:05.983373 60932 retry_allocator.cc:81] Allocation failed when retrying 5 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:06.014286 60929 retry_allocator.cc:45] Free 1048575 bytes and notify all waited threads, where waited_allocate_size_ = 2097150
[23:40:06] :	 [Step 1/1] I0902 23:40:06.023663 60932 retry_allocator.cc:81] Allocation failed when retrying 6 times when allocating 1048575 bytes. Wait still.
[23:40:06] :	 [Step 1/1] I0902 23:40:06.053655 60932 retry_allocator.cc:89] Allocation failed because of timeout when allocating 1048575 bytes.
[23:40:06] :	 [Step 1/1] terminate called after throwing an instance of 'paddle::memory::allocation::BadAlloc'
[23:40:06] :	 [Step 1/1]   what():  Cannot allocate 1048575, All fragments size is 1 at [/paddle/paddle/fluid/memory/allocation/best_fit_allocator.cc:154]
[23:40:06] :	 [Step 1/1] PaddlePaddle Call Stacks: 
[23:40:06] :	 [Step 1/1] 0             0x5373c0p std::string paddle::platform::GetTraceBackString<std::string>(std::string&&, char const*, int) + 656
[23:40:06] :	 [Step 1/1] 1            0x1bfde88p paddle::memory::allocation::BestFitAllocator::AllocateImpl(unsigned long) + 376
[23:40:06] :	 [Step 1/1] 2             0x53c735p paddle::memory::allocation::LockedAllocator::AllocateImpl(unsigned long) + 69
[23:40:06] :	 [Step 1/1] 3             0x53c35fp paddle::memory::allocation::Allocator::Allocate(unsigned long) + 31
[23:40:06] :	 [Step 1/1] 4             0x53c1f8p paddle::memory::allocation::RetryAllocator::AllocateImpl(unsigned long) + 952
[23:40:06] :	 [Step 1/1] 5             0x5312fep
[23:40:06] :	 [Step 1/1] 6       0x7f4a5451e470p
[23:40:06] :	 [Step 1/1] 7       0x7f4a54b81aa1p
[23:40:06] :	 [Step 1/1] 8       0x7f4a53d22c4dp clone + 109
```