### PR TITLE
Update reduce_sum and reduce_mean to save memory

### DIFF
--- a/paddle/fluid/op_use_default_grad_op_maker.spec
+++ b/paddle/fluid/op_use_default_grad_op_maker.spec
@@ -20,7 +20,6 @@ rank_loss
 reduce_max
 reduce_min
 reduce_prod
-reduce_sum
 reshape
 rnn_memory_helper
 sequence_softmax

--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op.part.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op.part.cu
@@ -15,12 +15,12 @@
 // .part used to speed up nvcc compile
 #include "paddle/fluid/operators/reduce_ops/reduce_mean_op.h"
 
-REGISTER_OP_CUDA_KERNEL(
-    reduce_mean_grad, ops::ReduceGradKernel<paddle::platform::CUDADeviceContext,
-                                            float, ops::MeanGradFunctor>,
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, double,
-                          ops::MeanGradFunctor>,
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, int,
-                          ops::MeanGradFunctor>,
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, int64_t,
-                          ops::MeanGradFunctor>);
+template <typename T>
+using CUDAReduceMeanGradKernel =
+    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, T,
+                          ops::MeanGradFunctor, true>;
+
+REGISTER_OP_CUDA_KERNEL(reduce_mean_grad, CUDAReduceMeanGradKernel<float>,
+                        CUDAReduceMeanGradKernel<double>,
+                        CUDAReduceMeanGradKernel<int>,
+                        CUDAReduceMeanGradKernel<int64_t>);

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
@@ -13,8 +13,47 @@
 // limitations under the License.
 
 #include "paddle/fluid/operators/reduce_ops/reduce_sum_op.h"
+#include <memory>
+#include <string>
 
-REGISTER_REDUCE_OP(reduce_sum);
+namespace paddle {
+namespace operators {
+
+// NOTE: Input(Out) is unnecessary in reduce_sum_grad, and Input(X) needs no
+// buffer
+class ReduceSumOpGradDescMaker : public framework::SingleGradOpDescMaker {
+ public:
+  using framework::SingleGradOpDescMaker::SingleGradOpDescMaker;
+
+ protected:
+  std::unique_ptr<framework::OpDesc> Apply() const override {
+    std::unique_ptr<framework::OpDesc> op(new framework::OpDesc());
+    op->SetType("reduce_sum_grad");
+    op->SetInput("X", Input("X"));
+    op->SetInput(framework::GradVarName("Out"), OutputGrad("Out"));
+    op->SetAttrMap(Attrs());
+    op->SetOutput(framework::GradVarName("X"), InputGrad("X"));
+    return op;
+  }
+};
+
+DECLARE_NO_NEED_BUFFER_VARS_INFERENCE(ReduceSumGradNoNeedBufferVarInference,
+                                      "X");
+
+}  // namespace operators
+}  // namespace paddle
+
+class ReduceSumOpMaker : public ops::ReduceOpMaker {
+ protected:
+  virtual std::string GetName() const { return "reduce_sum"; }
+  virtual std::string GetOpType() const { return "Reduce reduce_sum"; }
+};
+
+REGISTER_OPERATOR(reduce_sum, ops::ReduceOp, ReduceSumOpMaker,
+                  ops::ReduceSumOpGradDescMaker);
+REGISTER_OPERATOR(reduce_sum_grad, ops::ReduceGradOp,
+                  ops::ReduceSumGradNoNeedBufferVarInference);
+
 REGISTER_OP_CPU_KERNEL(
     reduce_sum, ops::ReduceKernel<paddle::platform::CPUDeviceContext, float,
                                   ops::SumFunctor>,
@@ -23,13 +62,13 @@ REGISTER_OP_CPU_KERNEL(
     ops::ReduceKernel<paddle::platform::CPUDeviceContext, int, ops::SumFunctor>,
     ops::ReduceKernel<paddle::platform::CPUDeviceContext, int64_t,
                       ops::SumFunctor>);
-REGISTER_OP_CPU_KERNEL(
-    reduce_sum_grad,
-    ops::ReduceSumGradKernel<paddle::platform::CPUDeviceContext, float,
-                             ops::SumGradFunctor>,
-    ops::ReduceSumGradKernel<paddle::platform::CPUDeviceContext, double,
-                             ops::SumGradFunctor>,
-    ops::ReduceSumGradKernel<paddle::platform::CPUDeviceContext, int,
-                             ops::SumGradFunctor>,
-    ops::ReduceSumGradKernel<paddle::platform::CPUDeviceContext, int64_t,
-                             ops::SumGradFunctor>);
+
+template <typename T>
+using CPUReduceSumGradKernel =
+    ops::ReduceSumGradKernel<paddle::platform::CPUDeviceContext, T,
+                             ops::SumGradFunctor, true>;
+
+REGISTER_OP_CPU_KERNEL(reduce_sum_grad, CPUReduceSumGradKernel<float>,
+                       CPUReduceSumGradKernel<double>,
+                       CPUReduceSumGradKernel<int>,
+                       CPUReduceSumGradKernel<int64_t>);

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.h
@@ -22,7 +22,8 @@ namespace paddle {
 namespace operators {
 
 // use for loop to speed up Eigen broadcast. 4 timer faster then broadcast
-template <typename DeviceContext, typename T, typename Functor>
+template <typename DeviceContext, typename T, typename Functor,
+          bool kNoNeedBufferX = false>
 class ReduceSumGradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
@@ -72,7 +73,7 @@ class ReduceSumGradKernel : public framework::OpKernel<T> {
     }
 
     // default use Eigen broadcast
-    ReduceGradKernel<DeviceContext, T, Functor> kernel;
+    ReduceGradKernel<DeviceContext, T, Functor, kNoNeedBufferX> kernel;
     kernel.Compute(context);
   }
 };

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.part.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.part.cu
@@ -15,12 +15,12 @@
 #include "paddle/fluid/operators/reduce_ops/cub_reduce.h"
 #include "paddle/fluid/operators/reduce_ops/reduce_sum_op.h"
 
-REGISTER_OP_CUDA_KERNEL(
-    reduce_sum_grad, ops::ReduceGradKernel<paddle::platform::CUDADeviceContext,
-                                           float, ops::SumGradFunctor>,
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, double,
-                          ops::SumGradFunctor>,
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, int,
-                          ops::SumGradFunctor>,
-    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, int64_t,
-                          ops::SumGradFunctor>);
+template <typename T>
+using CUDAReduceSumGradKernel =
+    ops::ReduceGradKernel<paddle::platform::CUDADeviceContext, T,
+                          ops::SumGradFunctor, true>;
+
+REGISTER_OP_CUDA_KERNEL(reduce_sum_grad, CUDAReduceSumGradKernel<float>,
+                        CUDAReduceSumGradKernel<double>,
+                        CUDAReduceSumGradKernel<int>,
+                        CUDAReduceSumGradKernel<int64_t>);


### PR DESCRIPTION
This PR updates `reduce_sum` and `reduce_mean` to save memory by adding `NoNeedBufferVarsIference` in corresponding `grad_op`.