### PR TITLE
fix scope lock bug on infer

### DIFF
--- a/paddle/fluid/framework/scope.h
+++ b/paddle/fluid/framework/scope.h
@@ -141,9 +141,12 @@ class Scope {
 
   DISABLE_COPY_AND_ASSIGN(Scope);
 
+#ifndef PADDLE_ON_INFERENCE
+
  private:
   mutable RWLock kids_lock_;
   mutable RWLock vars_lock_;
+#endif
 };
 
 // Generate some debug string about the inherience structure of scope, quite


### PR DESCRIPTION
According to https://github.com/PaddlePaddle/Paddle/blob/4cfe432cad1f6ec91cfd2add6cbbdf17f9645bec/paddle/fluid/framework/scope.cc#L36-L61

so, this should be a bug when on_infer=ON.

The problem raised:

![image](https://user-images.githubusercontent.com/21351065/64230384-4f20db80-cf1f-11e9-9cf4-e2bccf0fb943.png)

![image](https://user-images.githubusercontent.com/21351065/64230406-5cd66100-cf1f-11e9-8d9d-96bd5f0c33fb.png)

