### PR TITLE
fix inference_lib deps error

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -159,7 +159,7 @@ copy(zlib_lib
 set(src_dir "${PADDLE_SOURCE_DIR}/paddle/fluid")
 set(dst_dir "${FLUID_INSTALL_DIR}/paddle/fluid")
 set(module "framework")
-set(framework_lib_deps framework_py_proto)
+set(framework_lib_deps framework_proto)
 
 copy(framework_lib DEPS ${framework_lib_deps}
         SRCS ${src_dir}/${module}/*.h ${src_dir}/${module}/details/*.h ${PADDLE_BINARY_DIR}/paddle/fluid/framework/framework.pb.h ${PADDLE_BINARY_DIR}/paddle/fluid/framework/data_feed.pb.h ${src_dir}/${module}/ir/memory_optimize_pass/*.h


### PR DESCRIPTION
```
[11:54:31]	copying /paddle/paddle/fluid/framework/details/*.h -> /paddle/build/fluid_install_dir/paddle/fluid/framework/details
[11:54:31]	copying /paddle/build/paddle/fluid/framework/framework.pb.h -> /paddle/build/fluid_install_dir/paddle/fluid/framework
[11:54:31]	cp: cannot stat '/paddle/build/paddle/fluid/framework/framework.pb.h': No such file or directory
[11:54:31]	make[3]: *** [framework_lib] Error 1
[11:54:31]	CMakeFiles/framework_lib.dir/build.make:61: recipe for target 'framework_lib' failed
[11:54:31]	CMakeFiles/Makefile2:104: recipe for target 'CMakeFiles/framework_lib.dir/all' failed
```
http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=PR_CI_Test_2&buildId=156882&_focus=689