### PR TITLE
fix bug of communicator flag

### DIFF
--- a/paddle/fluid/operators/distributed/communicator.cc
+++ b/paddle/fluid/operators/distributed/communicator.cc
@@ -181,7 +181,7 @@ void Communicator::SendThread() {
 }
 
 void Communicator::RecvNonIndependent() {
-  if (!FLAGS_communicator_independent_recv_thread) {
+  if (FLAGS_communicator_independent_recv_thread) {
     return;
   }
 


### PR DESCRIPTION
修复communicator的FLAGS_communicator_independent_recv_thread定义与使用冲突的问题 