### PR TITLE
Reduce thread num of retry_allocator_test

### DIFF
--- a/paddle/fluid/memory/allocation/retry_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/retry_allocator_test.cc
@@ -43,7 +43,7 @@ TEST(RetryAllocator, RetryAllocator) {
   std::unique_ptr<LockedAllocator> locked_allocator(
       new LockedAllocator(std::move(best_fit_allocator)));
 
-  size_t thread_num = 8;
+  size_t thread_num = 4;
   size_t sleep_time = 40;
   size_t extra_time = 10;
 


### PR DESCRIPTION
`retry_allocator_test` fails randomly in CI. Maybe it is because there are too many threads to allocate the same memory size. This PR reduces the thread number from 8 to 4.