### PR TITLE
Disable the test_parallel_executor_test_while_train temporarily

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py
@@ -86,12 +86,16 @@ class ParallelExecutorTestingDuringTraining(unittest.TestCase):
 
     # FIXME(zcd): This unit test random failed.
     @unittest.skip("should fix this later.")
-    def test_parallel_testing_with_new_strategy(self):
+    def test_parallel_testing_with_new_strategy_gpu(self):
         build_strategy = fluid.BuildStrategy()
         build_strategy.reduce_strategy = fluid.BuildStrategy.ReduceStrategy.Reduce
         if core.is_compiled_with_cuda():
             self.check_network_convergence(
                 use_cuda=True, build_strategy=build_strategy)
+
+    def test_parallel_testing_with_new_strategy_cpu(self):
+        build_strategy = fluid.BuildStrategy()
+        build_strategy.reduce_strategy = fluid.BuildStrategy.ReduceStrategy.Reduce
         self.check_network_convergence(
             use_cuda=False, build_strategy=build_strategy)
 

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py
@@ -84,6 +84,8 @@ class ParallelExecutorTestingDuringTraining(unittest.TestCase):
         self.check_network_convergence(
             use_cuda=False, build_strategy=build_strategy)
 
+    # FIXME(zcd): This unit test random failed.
+    @unittest.skip("should fix this later.")
     def test_parallel_testing_with_new_strategy(self):
         build_strategy = fluid.BuildStrategy()
         build_strategy.reduce_strategy = fluid.BuildStrategy.ReduceStrategy.Reduce


### PR DESCRIPTION
Disable the test_parallel_executor_test_while_train temporarily because of the random failure in CI system.
The reason for random failure in CI system is not found, and I can not reproduce this error in my development machine, I had tried to run this unit test on P40 and V100, and compiled the source code with `Release`, `Debug`, `RelWithDebug`.

**TODO: Find the reason for the random failure, and open this unit test.**