### PR TITLE
Code Cleanup: delete three useless raw variables in Conv2D

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_op_cache.h
+++ b/paddle/fluid/operators/conv_cudnn_op_cache.h
@@ -27,10 +27,6 @@ DECLARE_int64(cudnn_exhaustive_search_times);
 namespace paddle {
 namespace operators {
 
-static constexpr char kCUDNNFwdAlgoCache[] = "kCUDNNFwdAlgoCache";
-static constexpr char kCUDNNBwdDataAlgoCache[] = "kCUDNNBwdDataAlgoCache";
-static constexpr char kCUDNNBwdFilterAlgoCache[] = "kCUDNNBwdFilterAlgoCache";
-
 #if CUDNN_VERSION_MIN(6, 0, 5)
 static constexpr size_t kNUM_CUDNN_FWD_ALGS = CUDNN_CONVOLUTION_FWD_ALGO_COUNT;
 static constexpr size_t kNUM_CUDNN_BWD_FILTER_ALGS =

--- a/python/paddle/fluid/contrib/slim/tests/test_graph_wrapper.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_graph_wrapper.py
@@ -92,7 +92,9 @@ class TestGraphWrapper(unittest.TestCase):
         # activation inplace has been disabled in python side
         # which may produce more variable in program_desc
         # update 90 => 94
-        self.assertEquals(len(self.train_graph.vars()), 94)
+        # delete three useless RAW variables in Conv2D
+        # update 94 => 91
+        self.assertEquals(len(self.train_graph.vars()), 91)
 
     def test_numel_params(self):
         self.build_program()

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -199,20 +199,6 @@ class Conv2D(layers.Layer):
             dtype=self._dtype,
             default_initializer=_get_default_param_initializer())
 
-        if self._use_cudnn:
-            self.create_variable(
-                name="kCUDNNFwdAlgoCache",
-                persistable=True,
-                type=core.VarDesc.VarType.RAW)
-            self.create_variable(
-                name="kCUDNNBwdDataAlgoCache",
-                persistable=True,
-                type=core.VarDesc.VarType.RAW)
-            self.create_variable(
-                name="kCUDNNBwdFilterAlgoCache",
-                persistable=True,
-                type=core.VarDesc.VarType.RAW)
-
         self._bias_param = self.create_parameter(
             attr=self._bias_attr,
             shape=[self._num_filters],

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2413,20 +2413,6 @@ def conv2d(input,
 
     pre_bias = helper.create_variable_for_type_inference(dtype)
 
-    if use_cudnn:
-        helper.create_variable(
-            name="kCUDNNFwdAlgoCache",
-            persistable=True,
-            type=core.VarDesc.VarType.RAW)
-        helper.create_variable(
-            name="kCUDNNBwdDataAlgoCache",
-            persistable=True,
-            type=core.VarDesc.VarType.RAW)
-        helper.create_variable(
-            name="kCUDNNBwdFilterAlgoCache",
-            persistable=True,
-            type=core.VarDesc.VarType.RAW)
-
     helper.append_op(
         type=l_type,
         inputs={


### PR DESCRIPTION
these three variables are no longer in use.

```
name: "kCUDNNBwdFilterAlgoCache"
type {
  type: RAW
}
persistable: true

name: "kCUDNNBwdDataAlgoCache"
type {
  type: RAW
}
persistable: true

name: "kCUDNNFwdAlgoCache"
type {
  type: RAW
}
persistable: true
```