### PR TITLE
remove -Wmaybe-uninitialized warning

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -155,7 +155,6 @@ set(COMMON_FLAGS
     -Wno-error=terminate  # Warning in PADDLE_ENFORCE
     -Wno-error=int-in-bool-context # Warning in Eigen gcc 7.2
     -Wimplicit-fallthrough=0 # Warning in tinyformat.h
-    -Wno-error=maybe-uninitialized # Warning in boost gcc 7.2
     ${fsanitize}
 )
 

--- a/paddle/fluid/framework/details/scale_loss_grad_op_handle.cc
+++ b/paddle/fluid/framework/details/scale_loss_grad_op_handle.cc
@@ -38,13 +38,11 @@ struct ScaleLossGradFunctor {
   float coeff_;
   Tensor *out_;
   platform::Place place_;
-  OpHandleBase *op_handle_;
   proto::VarType::Type out_dtype_;
   platform::DeviceContext *ctx_;
 
   ScaleLossGradFunctor(float coeff, Tensor *out, platform::Place place,
-                       OpHandleBase *op_handle, proto::VarType::Type dtype,
-                       platform::DeviceContext *ctx)
+                       proto::VarType::Type dtype, platform::DeviceContext *ctx)
       : coeff_(coeff), out_(out), place_(place), out_dtype_(dtype), ctx_(ctx) {}
 
   template <typename OutT>
@@ -76,11 +74,11 @@ void ScaleLossGradOpHandle::RunImpl() {
   tensor->Resize(make_ddim({1}));
 
 #ifdef PADDLE_WITH_CUDA
-  ScaleLossGradFunctor func(coeff_, tensor, place_, this, out_dtype_,
+  ScaleLossGradFunctor func(coeff_, tensor, place_, out_dtype_,
                             this->dev_ctxes_.at(place_));
   this->RunAndRecordEvent([&] { framework::VisitDataType(out_dtype_, func); });
 #else
-  ScaleLossGradFunctor func(coeff_, tensor, place_, this, out_dtype_, nullptr);
+  ScaleLossGradFunctor func(coeff_, tensor, place_, out_dtype_, nullptr);
   framework::VisitDataType(out_dtype_, func);
 #endif
 }

--- a/paddle/fluid/operators/distributed/parameter_prefetch.cc
+++ b/paddle/fluid/operators/distributed/parameter_prefetch.cc
@@ -215,7 +215,7 @@ void prefetchs(const std::vector<std::string>& id_var_names,
   std::unordered_set<int64_t> s(ids_union.begin(), ids_union.end());
   ids_union.assign(s.begin(), s.end());
 
-  for (int i; i < table_names.size(); i++) {
+  for (int i = 0; i < table_names.size(); i++) {
     tables.push_back(std::make_pair(table_names[i], endpoints[i]));
   }
 

--- a/paddle/fluid/operators/linear_chain_crf_op.h
+++ b/paddle/fluid/operators/linear_chain_crf_op.h
@@ -91,7 +91,7 @@ class LinearChainCRFOpKernel : public framework::OpKernel<T> {
     size_t seq_num = 0;
     size_t batch_size;
     size_t tag_num;
-    const int64_t* length_data;
+    const int64_t* length_data = nullptr;
     framework::Vector<size_t> in_lod;
     if (ctx.HasInput("length")) {
       const Tensor* label_length = ctx.Input<framework::Tensor>("length");
@@ -260,7 +260,7 @@ class LinearChainCRFGradOpKernel : public framework::OpKernel<T> {
     // getting seq_num  using padding or not
     size_t seq_num = 0;
     framework::Vector<size_t> lod;
-    const int64_t* length_data;
+    const int64_t* length_data = nullptr;
     if (ctx.HasInput("length")) {
       const Tensor* label_length = ctx.Input<framework::Tensor>("length");
       length_data = label_length->data<int64_t>();


### PR DESCRIPTION
- fix -Wmaybe-uninitialized warning
http://ci.paddlepaddle.org/viewLog.html?buildId=156973&buildTypeId=PR_CI_Test_2&tab=buildLog&_focus=1829#_state=79
```
[13:18:49]	In file included from /paddle/paddle/fluid/operators/linear_chain_crf_op.cc:15:0:
[13:18:49]	/paddle/paddle/fluid/operators/linear_chain_crf_op.h: In member function 'void paddle::operators::LinearChainCRFOpKernel<DeviceContext, T>::Compute(const paddle::framework::ExecutionContext&) const [with DeviceContext = paddle::platform::CPUDeviceContext; T = float]':
[13:18:49]	/paddle/paddle/fluid/operators/linear_chain_crf_op.h:148:9: warning: 'length_data' may be used uninitialized in this function [-Wmaybe-uninitialized]
[13:18:49]	         if (length_data[i] == 0) continue;
[13:18:49]	         ^
[13:18:49]	In file included from /paddle/paddle/fluid/operators/linear_chain_crf_op.cc:15:0:
[13:18:49]	/paddle/paddle/fluid/operators/linear_chain_crf_op.h:94:20: note: 'length_data' was declared here
[13:18:49]	     const int64_t* length_data;
[13:18:49]	                    ^
[13:18:49]	In file included from /paddle/paddle/fluid/operators/linear_chain_crf_op.cc:15:0:
[13:18:49]	/paddle/paddle/fluid/operators/linear_chain_crf_op.h: In member function 'void paddle::operators::LinearChainCRFGradOpKernel<DeviceContext, T>::Compute(const paddle::framework::ExecutionContext&) const [with DeviceContext = paddle::platform::CPUDeviceContext; T = float]':
[13:18:49]	/paddle/paddle/fluid/operators/linear_chain_crf_op.h:307:9: warning: 'length_data' may be used uninitialized in this function [-Wmaybe-uninitialized]
[13:18:49]	         if (length_data[i] == 0) continue;
[13:18:49]	         ^
[13:18:49]	In file included from /paddle/paddle/fluid/operators/linear_chain_crf_op.cc:15:0:
```
- make this `-Wmaybe-uninitialized` warning as error, in order to decrease the compiler warning in the future.