### PR TITLE
Make GPU Allocator retry time configurable

### DIFF
--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -37,7 +37,7 @@
 #endif
 
 DEFINE_int64(
-    gpu_allocator_retry_time, 100,
+    gpu_allocator_retry_time, 10000,
     "The retry time (milliseconds) when allocator fails "
     "to allocate memory. No retry if this value is not greater than 0");
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -204,7 +204,7 @@ def __bootstrap__():
             'cudnn_exhaustive_search', 'selected_gpus', 'sync_nccl_allreduce',
             'limit_of_tmp_allocation',
             'times_excess_than_required_tmp_allocation',
-            'cudnn_batchnorm_spatial_persistent'
+            'cudnn_batchnorm_spatial_persistent', 'gpu_allocator_retry_time'
         ]
     core.init_gflags([sys.argv[0]] +
                      ["--tryfromenv=" + ",".join(read_env_flags)])


### PR DESCRIPTION
This PR works for:
- Expose `FLAGS_gpu_allocator_retry_time` to Python.
- Make default value of `FLAGS_gpu_allocator_retry_time` to be 10s, which is the same as TensorFlow.