### PR TITLE
Fix test_parallel_executor_test_while_train

### DIFF
--- a/paddle/fluid/framework/details/broadcast_op_handle.cc
+++ b/paddle/fluid/framework/details/broadcast_op_handle.cc
@@ -126,6 +126,9 @@ void BroadcastOpHandle::BroadcastOneVar(
             &VariableVisitor::GetMutableTensor(out_var));
       }
     });
+    for (auto &p : places_) {
+      nccl_ctxs_->DevCtx(p)->Wait();
+    }
 #else
     PADDLE_THROW("CUDA is not enabled.");
 #endif

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py
@@ -84,8 +84,6 @@ class ParallelExecutorTestingDuringTraining(unittest.TestCase):
         self.check_network_convergence(
             use_cuda=False, build_strategy=build_strategy)
 
-    # FIXME(zcd): This unit test random failed.
-    @unittest.skip("should fix this later.")
     def test_parallel_testing_with_new_strategy_gpu(self):
         build_strategy = fluid.BuildStrategy()
         build_strategy.reduce_strategy = fluid.BuildStrategy.ReduceStrategy.Reduce


### PR DESCRIPTION
Fix random failed:
```
[05:32:06]	test_parallel_executor_test_while_train failed
[05:32:06]	 .F
[05:32:06]	======================================================================
[05:32:06]	FAIL: test_parallel_testing_with_new_strategy (test_parallel_executor_test_while_train.ParallelExecutorTestingDuringTraining)
[05:32:06]	----------------------------------------------------------------------
[05:32:06]	Traceback (most recent call last):
[05:32:06]	  File "/paddle/build/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py", line 92, in test_parallel_testing_with_new_strategy
[05:32:06]	    use_cuda=True, build_strategy=build_strategy)
[05:32:06]	  File "/paddle/build/python/paddle/fluid/tests/unittests/test_parallel_executor_test_while_train.py", line 76, in check_network_convergence
[05:32:06]	    str(test_loss))
[05:32:06]	AssertionError: Train loss: [3.623197  3.6158953]
[05:32:06]	 Test loss:[3.637395  3.6158953]
[05:32:06]	
[05:32:06]	----------------------------------------------------------------------
[05:32:06]	Ran 2 tests in 11.937s
[05:32:06]	
[05:32:06]	FAILED (failures=1)
```