### PR TITLE
fix copyfile.py, because it may cause an error when the directory is denied to remove

### DIFF
--- a/cmake/copyfile.py
+++ b/cmake/copyfile.py
@@ -26,18 +26,25 @@ def main():
         dst = os.path.join(dst, pathList[-1])
         if not os.path.exists(dst):
             shutil.copytree(src, dst)
-            print("first copy directory: {0} --->>> {1}".format(src, dst))
+            print("copying directory: {0} -> {1}".format(src, dst))
         else:
-            shutil.rmtree(dst)
-            shutil.copytree(src, dst)
-            print("overwritten copy directory: {0} --->>> {1}".format(src, dst))
+            print(
+                "abandon copying! because directory {0} has already been copied to {1}".
+                format(src, dst))
     else:  #copy file, wildcard
         if not os.path.exists(dst):
             os.makedirs(dst)
         srcFiles = glob.glob(src)
         for srcFile in srcFiles:
-            shutil.copy(srcFile, dst)
-            print("copy file: {0} --->>> {1}".format(srcFile, dst))
+            fileName = os.path.split(srcFile)[-1]
+            dstFile = os.path.join(dst, fileName)
+            if not os.path.exists(dstFile):
+                shutil.copy(srcFile, dst)
+                print("copying file: {0} -> {1}".format(srcFile, dst))
+            else:
+                print(
+                    "abandon copying! because file {0} has already been copied to {1}".
+                    format(srcFile, dst))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently, it may lead to an error: 
when copyfile.py is copying src directory to another dst directory, if the dst directory is existing, it will be removed first, but this operation may be denied.
---
Therefore, I have made the following changes: 
Instead of making repeated copies, I only print the prompt message, which reduces the error rate and time.