### PR TITLE
Add common CreateKey for MKLDNN handlers

### DIFF
--- a/paddle/fluid/framework/data_layout_transform.cc
+++ b/paddle/fluid/framework/data_layout_transform.cc
@@ -163,8 +163,8 @@ void innerTransDataLayoutFromMKLDNN(DataLayout in_layout, DataLayout out_layout,
 
   if (in_format != out_format) {
     void* in_data = GetDataFromTensor(in, in_type);
-    const std::string key = platform::ReorderMKLDNNHandler::GetHash(
-        in_tz, in_format, out_format, std::to_string(in_type));
+    const std::string key = platform::CreateKey(in_tz, in_format, out_format,
+                                                std::to_string(in_type));
 
     platform::ReorderMKLDNNHandler handler(in_tz, in.type(), in_type, *dev_ctx,
                                            cpu_engine, key);

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -70,7 +70,7 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
         auto out_format = platform::MKLDNNFormatForSize(
             x_dims.size(), MKLDNNMemoryFormat::nchw);
 
-        const std::string key = platform::ReorderMKLDNNHandler::GetHash(
+        const std::string key = platform::CreateKey(
             src_x_tz, x->format(), out_format, std::to_string(in_type));
 
         platform::ReorderMKLDNNHandler handler(src_x_tz, x->type(), in_type,
@@ -136,7 +136,7 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
       std::vector<memory::primitive_desc> srcs_pd;
       std::vector<float> scales = {1.0f, 1.0f};
 
-      const std::string key = platform::GetHash(
+      const std::string key = platform::CreateKey(
           src_x_tz, ctx.op().Output("Out") + std::to_string(x->format()) +
                         std::to_string(y->format()));
 

--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -27,20 +27,6 @@ using platform::GetMKLDNNFormat;
 using platform::MKLDNNDeviceContext;
 using platform::to_void_cast;
 
-namespace {
-std::string gethash(const mkldnn::memory::dims &operand_dims,
-                    const mkldnn::algorithm algorithm) {
-  auto dim2str = [](const mkldnn::memory::dims &operand_dims) {
-    std::string dstr = "";
-    for (size_t i = 0; i < operand_dims.size(); ++i) {
-      dstr += std::to_string(operand_dims[i]) + "-";
-    }
-    return dstr;
-  };
-  return dim2str(operand_dims) + std::to_string(algorithm);
-}
-}  // namespace
-
 template <typename Functor>
 class MKLDNNActivationKernel
     : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {

--- a/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
@@ -66,27 +66,6 @@ static const mkldnn::engine& GetMKLDNNEngine(
   return dev_ctx.GetEngine();
 }
 
-std::string CreateKey(const paddle::framework::ExecutionContext& ctx,
-                      const std::vector<const Tensor*> multi_input,
-                      const int64_t& concat_axis, const memory::data_type& dt) {
-  std::string key;
-  key.reserve(platform::MKLDNNHandler::MaxKeyLength);
-  for (size_t i = 0; i < multi_input.size(); i++) {
-    platform::AppendKeyDims(
-        &key, paddle::framework::vectorize<int>(multi_input[i]->dims()));
-  }
-  platform::AppendKey(&key, std::to_string(concat_axis));
-  platform::AppendKey(&key, ctx.op().Output("Out"));
-  platform::AppendKey(&key, std::to_string(dt));
-  platform::AppendKey(&key, std::to_string(multi_input[0]->format()));
-  if (platform::get_cur_mkldnn_session_id() ==
-      platform::kMKLDNNSessionID_Default) {
-    platform::AppendKey(&key, "-t:");
-    platform::AppendKey(&key, platform::ThreadIDasStr());
-  }
-  return key;
-}
-
 template <typename T>
 class ConcatPrimitiveFactory {
  public:
@@ -175,7 +154,10 @@ class ConcatMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         paddle::framework::ToMKLDNNDataType(multi_input[0]->type());
 
     ConcatPrimitiveFactory<T> prim_creator;
-    std::string key = CreateKey(ctx, multi_input, concat_axis, dt);
+    std::string key = platform::CreateKey(
+        paddle::framework::vectorize<int>(multi_input[0]->dims()), concat_axis,
+        ctx.op().Output("Out"), dt, multi_input[0]->format(),
+        platform::ThreadIDasStr());
     const std::string key_prim = key + "@concat_p";
     const std::string key_concat_pd = key + "@concat_pd";
     const std::string key_srcs = key + "@concat_srcs";

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -190,7 +190,7 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto dst_tz = paddle::framework::vectorize<int>(output->dims());
 
     // Get unique name for storing MKLDNN primitives
-    const std::string key = platform::ConvMKLDNNHandler::GetHash(
+    const std::string key = platform::CreateKey(
         src_tz, weights_tz, fuse_activation, strides, paddings, dilations,
         groups, ctx.op().Input("Input") + ctx.op().Input("Filter"));
 
@@ -415,10 +415,8 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         paddle::framework::ToMKLDNNDataType(input->type());
 
     // Get unique name for storing MKLDNN primitives
-    std::string key;
-    key.reserve(MaxKeyLength);
-    platform::ConvMKLDNNHandler::CreateKey(
-        &key, src_tz, weights_tz, strides, paddings, dilations, groups, src_dt,
+    const std::string key = platform::CreateKey(
+        src_tz, weights_tz, strides, paddings, dilations, groups, src_dt,
         input->format(), fuse_activation, fuse_residual_conn,
         ctx.op().Input("Input") + ctx.op().Input("Filter"));
 
@@ -715,7 +713,7 @@ class ConvMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     // Get an unique name from "argument" name of "input" and "Filter" variable
     // as well as attributes of primitive to be created
     // This name will be used as key when saving info into device context
-    const std::string key = platform::ConvMKLDNNHandler::GetHash(
+    const std::string key = platform::CreateKey(
         src_tz, weights_tz, "", strides, paddings, dilations, groups,
         ctx.op().Input("Input") + ctx.op().Input("Filter"));
 

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -127,9 +127,9 @@ class ConvTransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto dst_tz = paddle::framework::vectorize<int>(output->dims());
 
     // Get unique name for storing MKLDNN primitives
-    const std::string key = platform::ConvTransposeMKLDNNHandler::GetHash(
-        src_tz, weights_tz, strides, paddings, dilations, groups,
-        ctx.op().Output("Output"));
+    const std::string key =
+        platform::CreateKey(src_tz, weights_tz, strides, paddings, dilations,
+                            groups, ctx.op().Output("Output"));
 
     std::vector<mkldnn::primitive> pipeline;
 

--- a/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
@@ -31,18 +31,6 @@ using framework::DataLayout;
 using mkldnn::stream;
 using platform::GetMKLDNNFormat;
 
-std::string CreateKey(const paddle::framework::ExecutionContext& ctx,
-                      const mkldnn::memory::data_type& src_dt,
-                      const std::vector<int>& src_tz, const float scale_data) {
-  std::string key;
-  key.reserve(platform::MKLDNNHandler::MaxKeyLength);
-  platform::AppendKey(&key, std::to_string(src_dt));
-  platform::AppendKeyDims(&key, src_tz);
-  platform::AppendKey(&key, std::to_string(scale_data));
-  platform::AppendKey(&key, ctx.op().Output("Output"));
-  return key;
-}
-
 template <typename T>
 class DeQuantOpKernel : public framework::OpKernel<T> {
  public:
@@ -64,7 +52,8 @@ class DeQuantOpKernel : public framework::OpKernel<T> {
     mkldnn::memory::data_type src_dt =
         paddle::framework::ToMKLDNNDataType(input->type());
     MKLDNNMemoryFormat src_fmt = input->format();
-    std::string key = CreateKey(ctx, src_dt, src_tz, reorder_scale[0]);
+    std::string key = platform::CreateKey(src_dt, src_tz, reorder_scale[0],
+                                          ctx.op().Output("Output"));
     const std::string key_prim = key + "@reorder_p";
     const std::string key_src_mem = key + "@src_mem";
     const std::string key_dst_mem = key + "@dst_mem";

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -221,25 +221,14 @@ class FCPrimitiveFactory {
   boost::optional<inner_product_forward> fc_;
 };
 
-static std::string GetHash(const Tensor* input, const Tensor* weights,
-                           const std::string& suffix) {
-  auto dim2str = [](const DDim& operand_dims) {
-    std::string str = "";
-    for (size_t i = 0; i < operand_dims.size(); ++i) {
-      str += std::to_string(operand_dims[i]) + "-";
-    }
-    return str;
-  };
-  return std::to_string((unsigned)input->format()) + dim2str(weights->dims()) +
-         suffix;
-}
-
 template <typename T>
 std::shared_ptr<FCPrimitiveFactory<T>> GetPrimitiveFactory(
     const MKLDNNDeviceContext& dev_ctx, const ExecutionContext& ctx,
     const Tensor* input, const Tensor* weights,
     const mkldnn::engine& mkldnn_engine) {
-  const std::string key = GetHash(input, weights, ctx.op().Output("Out"));
+  const std::string key = platform::CreateKey(
+      input->format(), framework::vectorize<int>(weights->dims()),
+      ctx.op().Output("Out"));
 
   auto prim_creator =
       std::static_pointer_cast<FCPrimitiveFactory<T>>(dev_ctx.GetBlob(key));

--- a/paddle/fluid/operators/mkldnn/lrn_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/lrn_mkldnn_op.cc
@@ -62,7 +62,7 @@ class LRNMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto md = paddle::platform::MKLDNNMemDesc(
         dims, platform::MKLDNNGetDataType<T>(), x->format());
 
-    const std::string key = platform::LRNMKLDNNHandler::GetHash(
+    const std::string key = platform::CreateKey(
         dims, n, alpha, beta, k, x->format(), ctx.op().Output("Out"));
 
     platform::LRNMKLDNNHandler handler(ctx.Attr<bool>("is_test"), dev_ctx,
@@ -121,7 +121,7 @@ class LRNMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
 
     auto dims = paddle::framework::vectorize<int>(x->dims());
 
-    const std::string key = platform::LRNMKLDNNHandler::GetHash(
+    const std::string key = platform::CreateKey(
         dims, n, alpha, beta, k, x->format(), ctx.op().Input("Out"));
 
     platform::LRNMKLDNNHandler handler(false, dev_ctx, mkldnn_engine, key);

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -79,9 +79,9 @@ class PoolMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         paddle::framework::ToMKLDNNDataType(input->type());
     auto fmt = input->format();
 
-    const std::string key = platform::PoolingMKLDNNHandler::GetHash(
-        src_tz, pooling_type, ksize, strides, paddings, dt, fmt,
-        ctx.op().Output("Out"));
+    const std::string key =
+        platform::CreateKey(src_tz, pooling_type, ksize, strides, paddings, dt,
+                            fmt, ctx.op().Output("Out"));
 
     platform::PoolingMKLDNNHandler handler(pooling_type, dt,
                                            ctx.Attr<bool>("is_test"), dev_ctx,
@@ -171,7 +171,7 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
 
     // Get an unique name from "argument" name of "Out" variable
     // This name will be used as key when referring info from device context
-    const std::string key = platform::PoolingMKLDNNHandler::GetHash(
+    const std::string key = platform::CreateKey(
         diff_src_tz, pooling_type, ksize, strides, paddings,
         memory::data_type::f32, in_x->format(), ctx.op().Input("Out"));
 

--- a/paddle/fluid/operators/mkldnn/quantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/quantize_mkldnn_op.cc
@@ -30,18 +30,6 @@ using framework::DataLayout;
 using mkldnn::stream;
 using platform::GetMKLDNNFormat;
 
-std::string CreateKey(const paddle::framework::ExecutionContext& ctx,
-                      const std::vector<int>& src_tz, const float scale_data,
-                      const bool is_negative) {
-  std::string key;
-  key.reserve(platform::MKLDNNHandler::MaxKeyLength);
-  platform::AppendKeyDims(&key, src_tz);
-  platform::AppendKey(&key, std::to_string(scale_data));
-  platform::AppendKey(&key, std::to_string(is_negative));
-  platform::AppendKey(&key, ctx.op().Output("Output"));
-  return key;
-}
-
 template <typename T>
 class QuantOpKernel : public framework::OpKernel<T> {
  public:
@@ -60,7 +48,8 @@ class QuantOpKernel : public framework::OpKernel<T> {
     const T* input_data = input->data<T>();
 
     bool is_negative = ctx.Attr<bool>("is_negative_input");
-    std::string key = CreateKey(ctx, src_tz, scale_data, is_negative);
+    std::string key = platform::CreateKey(src_tz, scale_data, is_negative,
+                                          ctx.op().Output("Output"));
     const std::string key_prim = key + "@reorder_p";
     const std::string key_src_mem = key + "@src_mem";
     const std::string key_dst_mem = key + "@dst_mem";

--- a/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/softmax_mkldnn_op.cc
@@ -40,7 +40,7 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
                        const platform::MKLDNNDeviceContext& dev_ctx,
                        platform::Place cpu_place, const std::string& uniq_name)
       : platform::MKLDNNHandler(dev_ctx, dev_ctx.GetEngine(),
-                                platform::GetHash(dims, uniq_name)),
+                                platform::CreateKey(dims, uniq_name)),
         place_(cpu_place),
         fwd_pd_(nullptr),
         bwd_pd_(nullptr) {
@@ -53,7 +53,7 @@ class SoftmaxMKLDNNHandler : public platform::MKLDNNHandler {
                        const platform::MKLDNNDeviceContext& dev_ctx,
                        platform::Place cpu_place, const std::string& uniq_name)
       : platform::MKLDNNHandler(dev_ctx, dev_ctx.GetEngine(),
-                                platform::GetHash(dims, uniq_name)),
+                                platform::CreateKey(dims, uniq_name)),
         place_(cpu_place),
         fwd_pd_(nullptr),
         bwd_pd_(nullptr) {
@@ -218,6 +218,7 @@ class SoftmaxMKLDNNKernel : public paddle::framework::OpKernel<T> {
     auto dst_tz = src_tz;
     // Same memory descriptor to be used for input and output
     memory::dims softmax_tz = {src_tz[0], src_tz[1]};
+
     SoftmaxMKLDNNHandler<T> handler(softmax_tz, MKLDNNMemoryFormat::nc, dev_ctx,
                                     ctx.GetPlace(), ctx.op().Output("Out"));
     // Currently only NC data format is supported

--- a/paddle/fluid/operators/mkldnn/transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/transpose_mkldnn_op.cc
@@ -45,9 +45,9 @@ class TransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
 
     auto nchw_tz = paddle::framework::vectorize<int>(input->dims());
 
-    const std::string key = platform::TransposeMKLDNNHandler::GetHash(
-        nchw_tz, axis,
-        ctx.op().Output("Out") + std::to_string(input->format()));
+    const std::string key =
+        platform::CreateKey(nchw_tz, axis, ctx.op().Output("Out") +
+                                               std::to_string(input->format()));
 
     platform::TransposeMKLDNNHandler handler(nchw_tz, axis, dev_ctx,
                                              mkldnn_engine, key);
@@ -99,7 +99,7 @@ class TransposeMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
 
     auto nchw_tz = paddle::framework::vectorize<int>(out_grad->dims());
 
-    const std::string key = platform::TransposeMKLDNNHandler::GetHash(
+    const std::string key = platform::CreateKey(
         nchw_tz, axis, ctx.op().Output(framework::GradVarName("X")));
 
     platform::TransposeMKLDNNHandler handler(nchw_tz, reversed_axis, dev_ctx,

--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -184,27 +184,30 @@ inline std::string ThreadIDasStr(void) {
       std::hash<std::thread::id>()(std::this_thread::get_id()));
 }
 
-inline std::string dims2str(const mkldnn::memory::dims& operand_dims) {
-  std::string dstr = "";
-  for (size_t i = 0; i < operand_dims.size(); ++i) {
-    dstr += std::to_string(operand_dims[i]) + "-";
-  }
-  return dstr;
+template <typename T>
+inline void AppendKey(std::string* key, const T& num) {
+  key->append(std::to_string(num));
 }
 
-inline void AppendKey(std::string* key, const std::string& s) {
-  key->append(s);
+inline void AppendKey(std::string* key, const std::string& str) {
+  key->append(str);
 }
 
-inline std::string GetHash(const mkldnn::memory::dims& operand_dims,
-                           const std::string& suffix) {
-  return dims2str(operand_dims) + suffix;
-}
+inline void AppendKey(std::string* key, const char* str) { key->append(str); }
 
-inline void AppendKeyDims(std::string* key, const mkldnn::memory::dims& dims) {
-  for (unsigned int i = 0; i < dims.size(); i++) {
+inline void AppendKey(std::string* key, const std::vector<int>& dims) {
+  for (size_t i = 0; i < dims.size(); i++) {
     AppendKey(key, std::to_string(dims[i]));
   }
+}
+
+template <typename... ArgTypes>
+inline std::string CreateKey(ArgTypes&&... args) {
+  std::string key;
+  key.reserve(256);
+  using expand_type = int[];
+  expand_type{0, (AppendKey(&key, args), 0)...};
+  return key;
 }
 
 }  // namespace platform


### PR DESCRIPTION
This PR is next in series of refactoring, templatizing and preparing code for easier MKLDNN v1.0 update.
It implements common CreateKey() variadic template that accepts any number of parameters and create string key from them.