### PR TITLE
fix libps.so path problem

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -185,6 +185,10 @@ else:
         shutil.copy(os.path.dirname('${CBLAS_LIBRARIES}') + '/openblas' + ext_name, libs_path)
         package_data['paddle.libs'] += ['openblas' + ext_name]
 
+if '${WITH_PSLIB}' == 'ON':
+    shutil.copy('${PSLIB_LIB}', libs_path)
+    package_data['paddle.libs'] += ['libps' + ext_name]
+
 if '${WITH_MKLDNN}' == 'ON':
     if '${CMAKE_BUILD_TYPE}' == 'Release' and os.name != 'nt':
         # only change rpath in Release mode.


### PR DESCRIPTION
before fix this , we only can run fleet pslib mode using  1/2/3  in which is train.py，and a third_party dir which contains libps.so.

after fix this 1/2/3 dir and third_party are no longer needed.