### PR TITLE
Fix the definition issue when used mkl_scsrmm and mkl_dcsrmm functions.

### DIFF
--- a/paddle/fluid/platform/dynload/mklml.cc
+++ b/paddle/fluid/platform/dynload/mklml.cc
@@ -25,6 +25,11 @@ void* mklml_dso_handle = nullptr;
 
 MKLML_ROUTINE_EACH(DEFINE_WRAP);
 
+#if !defined(_WIN32)
+DEFINE_WRAP(mkl_scsrmm);
+DEFINE_WRAP(mkl_dcsrmm);
+#endif
+
 }  // namespace dynload
 }  // namespace platform
 }  // namespace paddle


### PR DESCRIPTION
After CI merged the patch provided by [PR#19533](https://github.com/PaddlePaddle/Paddle/pull/19533), it will be shown the link error of "mkl_scsrmm" and "mkl_dcsrmm" functions. Now this PR is for the issue.

resolve #19711