### PR TITLE
Reduce default value of maximum cudnn workspace size

### DIFF
--- a/paddle/fluid/platform/cudnn_workspace_helper.h
+++ b/paddle/fluid/platform/cudnn_workspace_helper.h
@@ -17,7 +17,7 @@
 namespace paddle {
 namespace platform {
 
-static constexpr int kDefaultConvWorkspaceSizeLimitMB = 4096;
+static constexpr int kDefaultConvWorkspaceSizeLimitMB = 512;
 
 }  // namespace platform
 }  // namespace paddle


### PR DESCRIPTION
The default value of maximum cudnn workspace size is 4096MB, which is too large for most models. This PR reduces the default value to be 512MB. This makes maximum batch size of ResNet50/ResNet101 models increase about 10%.