### PR TITLE
FIX BUG: "unknown data type " when doing  memory optimization during C++ inference.

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -101,6 +101,16 @@ int DataTypeToSpace(framework::proto::VarType_Type type) {
       return sizeof(int32_t);
     case framework::proto::VarType_Type_INT64:
       return sizeof(int64_t);
+    case framework::proto::VarType_Type_INT16:
+      return sizeof(int16_t);
+    case framework::proto::VarType_Type_FP16:
+      return sizeof(int16_t);
+    case framework::proto::VarType_Type_FP64:
+      return sizeof(double);
+    case framework::proto::VarType_Type_UINT8:
+      return sizeof(unsigned char);
+    case framework::proto::VarType_Type_INT8:
+      return sizeof(int8_t);
     default:
       PADDLE_THROW("Unknown data type");
   }


### PR DESCRIPTION
When doing memory optimization during inference, the vars was ranked according to their size  before generating optimization strategies. The size of the var can be calc by `sizeof(DATA_TYPE) * num_ele`; 

Before this pull request, the DATA_TYPE are limited，only FP32， BOOL，INT32, INT64 are supported.  If the var in the model is of other types, the  “unknown data type” error will be triggered.

So， We add more type support: INT16, FP16, FP64, UINT8, INT8.


fix this:https://github.com/PaddlePaddle/Paddle/issues/19525
