### PR TITLE
Add:GetInputTensorShape() and EnableProfile() for AnalysisPredictor, ZeroCopyTensor support uint8

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -65,6 +65,8 @@ class AnalysisPredictor : public PaddlePredictor {
   std::unique_ptr<ZeroCopyTensor> GetOutputTensor(
       const std::string &name) override;
 
+  std::map<std::string, std::vector<int64_t>> GetInputTensorShape() override;
+
   bool ZeroCopyRun() override;
 
   void CreateFeedFetchVar(framework::Scope *scope);

--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -43,6 +43,10 @@ void ZeroCopyTensor::Reshape(const std::vector<int> &shape) {
 template <typename T>
 T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
   EAGER_GET_TENSOR;
+  PADDLE_ENFORCE_GT(
+      tensor->numel(), 0,
+      "You should call ZeroCopyTensor::Reshape(const std::vector<int> &shape)"
+      "function before retrieving mutable_data from input tensor.");
   switch (static_cast<int>(place)) {
     case static_cast<int>(PaddlePlace::kCPU): {
       return tensor->mutable_data<T>(platform::CPUPlace());
@@ -83,8 +87,11 @@ PaddleDType ZeroCopyTensor::type() const {
     return PaddleDType::INT64;
   } else if (type == framework::proto::VarType::INT32) {
     return PaddleDType::INT32;
+  } else if (type == framework::proto::VarType::UINT8) {
+    return PaddleDType::UINT8;
   } else {
-    LOG(ERROR) << "unknown type, only support float32 and int64 now.";
+    LOG(ERROR) << "Unknown type. Currently support types: float32, int64, "
+                  "int32, uint8. Using float32 instead.";
   }
   return PaddleDType::FLOAT32;
 }
@@ -95,7 +102,7 @@ void ZeroCopyTensor::copy_from_cpu(const T *data) {
   PADDLE_ENFORCE_GE(
       tensor->numel(), 0,
       "You should call ZeroCopyTensor::Reshape(const std::vector<int> &shape)"
-      "function before copy data from cpu.");
+      "function before copying data from cpu.");
   size_t ele_size = tensor->numel() * sizeof(T);
 
   if (place_ == PaddlePlace::kCPU) {
@@ -112,7 +119,7 @@ void ZeroCopyTensor::copy_from_cpu(const T *data) {
     memory::Copy(gpu_place, static_cast<void *>(t_data), platform::CPUPlace(),
                  data, ele_size, dev_ctx->stream());
 #else
-    PADDLE_THROW("Not compile with CUDA, should not reach here.");
+    PADDLE_THROW("Not compiled with CUDA, should not reach here.");
 #endif
   }
 }
@@ -143,9 +150,11 @@ void ZeroCopyTensor::copy_to_cpu(T *data) {
 template void ZeroCopyTensor::copy_from_cpu<float>(const float *data);
 template void ZeroCopyTensor::copy_from_cpu<int64_t>(const int64_t *data);
 template void ZeroCopyTensor::copy_from_cpu<int32_t>(const int32_t *data);
+template void ZeroCopyTensor::copy_from_cpu<uint8_t>(const uint8_t *data);
 template void ZeroCopyTensor::copy_to_cpu<float>(float *data);
 template void ZeroCopyTensor::copy_to_cpu<int64_t>(int64_t *data);
 template void ZeroCopyTensor::copy_to_cpu<int32_t>(int32_t *data);
+template void ZeroCopyTensor::copy_to_cpu<uint8_t>(uint8_t *data);
 
 template float *ZeroCopyTensor::data<float>(PaddlePlace *place,
                                             int *size) const;
@@ -153,9 +162,12 @@ template int64_t *ZeroCopyTensor::data<int64_t>(PaddlePlace *place,
                                                 int *size) const;
 template int32_t *ZeroCopyTensor::data<int32_t>(PaddlePlace *place,
                                                 int *size) const;
+template uint8_t *ZeroCopyTensor::data<uint8_t>(PaddlePlace *place,
+                                                int *size) const;
 template float *ZeroCopyTensor::mutable_data<float>(PaddlePlace place);
 template int64_t *ZeroCopyTensor::mutable_data<int64_t>(PaddlePlace place);
 template int32_t *ZeroCopyTensor::mutable_data<int32_t>(PaddlePlace place);
+template uint8_t *ZeroCopyTensor::mutable_data<uint8_t>(PaddlePlace place);
 
 void *ZeroCopyTensor::FindTensor() const {
   PADDLE_ENFORCE(!name_.empty(),

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -101,13 +101,6 @@ struct AnalysisConfig {
    */
   float fraction_of_gpu_memory_for_pool() const;
 
-  /** Turn on CUDNN
-   */
-  void EnableCUDNN();
-  /** A boolean state telling whether to use cuDNN.
-   */
-  bool cudnn_enabled() const { return use_cudnn_; }
-
   /** \brief Control whether to perform IR graph optimization.
    *
    * If turned off, the AnalysisConfig will act just like a NativeConfig.
@@ -248,6 +241,16 @@ struct AnalysisConfig {
                          bool force_update_static_cache = false);
   /** Tell whether the memory optimization is activated. */
   bool enable_memory_optim() const;
+
+  /** \brief Turn on profiling report.
+   *
+   * If not turned on, no profiling report will be generateed.
+   */
+  void EnableProfile();
+  /** A boolean state telling whether the profiler is activated.
+   */
+  bool profile_enabled() const { return with_profile_; }
+
   void SetInValid() const { is_valid_ = false; }
   bool is_valid() const { return is_valid_; }
 
@@ -275,8 +278,6 @@ struct AnalysisConfig {
   bool use_gpu_{false};
   int device_id_{0};
   uint64_t memory_pool_init_size_mb_{100};  // initial size is 100MB.
-
-  bool use_cudnn_{false};
 
   // TensorRT related.
   bool use_tensorrt_{false};
@@ -315,6 +316,8 @@ struct AnalysisConfig {
   bool specify_input_name_{false};
 
   int cpu_math_library_num_threads_{1};
+
+  bool with_profile_{false};
 
   // A runtime cache, shouldn't be transferred to others.
   std::string serialized_info_cache_;

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -23,6 +23,7 @@
  */
 
 #include <cassert>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -37,6 +38,7 @@ enum PaddleDType {
   FLOAT32,
   INT64,
   INT32,
+  UINT8,
   // TODO(Superjomn) support more data types if needed.
 };
 
@@ -149,8 +151,8 @@ class ZeroCopyTensor {
 
   /** Get the memory in CPU or GPU with specific data type, should Reshape first
    * to tell the data size.
-   * Once can directly call this data to feed the data.
-   * This is for write the input tensor.
+   * One can directly call this data to feed the data.
+   * This is for writing the input tensor.
    */
   template <typename T>
   T* mutable_data(PaddlePlace place);
@@ -219,6 +221,12 @@ class PaddlePredictor {
   /** \brief Get input names of the model
    */
   virtual std::vector<std::string> GetInputNames() { return {}; }
+
+  /** \brief Get input shapes of the model
+   */
+  virtual std::map<std::string, std::vector<int64_t>> GetInputTensorShape() {
+    return {};
+  }
 
   /** \brief Get output names of the model
    */

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -269,17 +269,20 @@ download_model_and_data(${BERT_INSTALL_DIR} "bert_emb128_model.tar.gz" "bert_dat
 inference_analysis_api_test(test_analyzer_bert ${BERT_INSTALL_DIR} analyzer_bert_tester.cc)
 
 if(WITH_GPU AND TENSORRT_FOUND)
-    set(TRT_MODEL_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/trt")
+    set(TRT_MODEL_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/trt_inference_tests")
     if (NOT EXISTS ${TRT_MODEL_INSTALL_DIR})
-        inference_download_and_uncompress(${TRT_MODEL_INSTALL_DIR} ${INFERENCE_URL}/tensorrt_test "trt_test_models.tar.gz")
+        inference_download_and_uncompress(${TRT_MODEL_INSTALL_DIR} ${INFERENCE_URL}/tensorrt_test "trt_inference_test_models.tar.gz")
     endif()
     inference_analysis_test(trt_mobilenet_test SRCS trt_mobilenet_test.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
-            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_test_models)
+            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
     inference_analysis_test(trt_resnet50_test SRCS trt_resnet50_test.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
-            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_test_models)
+            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
     inference_analysis_test(trt_resnext_test SRCS trt_resnext_test.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
-            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_test_models)
+            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
+    inference_analysis_test(trt_fc_prelu_test SRCS trt_fc_prelu_test.cc
+            EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
+            ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
 endif()

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -128,6 +128,14 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
         }
         break;
       }
+      case PaddleDType::UINT8: {
+        uint8_t *pdata = static_cast<uint8_t *>(out.data.data());
+        uint8_t *pdata_ref = static_cast<uint8_t *>(ref_out.data.data());
+        for (size_t j = 0; j < size; ++j) {
+          EXPECT_EQ(pdata_ref[j], pdata[j]);
+        }
+        break;
+      }
     }
   }
 }
@@ -166,6 +174,15 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
       case PaddleDType::INT32: {
         int32_t *pdata = static_cast<int32_t *>(out.data.data());
         int32_t *pdata_ref = ref_out.data<int32_t>(&place, &ref_size);
+        EXPECT_EQ(size, ref_size);
+        for (size_t j = 0; j < size; ++j) {
+          EXPECT_EQ(pdata_ref[j], pdata[j]);
+        }
+        break;
+      }
+      case PaddleDType::UINT8: {
+        uint8_t *pdata = static_cast<uint8_t *>(out.data.data());
+        uint8_t *pdata_ref = ref_out.data<uint8_t>(&place, &ref_size);
         EXPECT_EQ(size, ref_size);
         for (size_t j = 0; j < size; ++j) {
           EXPECT_EQ(pdata_ref[j], pdata[j]);
@@ -286,6 +303,8 @@ void ConvertPaddleTensorToZeroCopyTensor(
       ZeroCopyTensorAssignData<float>(tensor.get(), input.data);
     } else if (input.dtype == PaddleDType::INT32) {
       ZeroCopyTensorAssignData<int32_t>(tensor.get(), input.data);
+    } else if (input.dtype == PaddleDType::UINT8) {
+      ZeroCopyTensorAssignData<uint8_t>(tensor.get(), input.data);
     } else {
       LOG(ERROR) << "unsupported feed type " << input.dtype;
     }

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -337,6 +337,7 @@ void BindAnalysisConfig(py::module *m) {
            py::arg("x") = true)
       .def("ir_optim", &AnalysisConfig::ir_optim)
       .def("enable_memory_optim", &AnalysisConfig::EnableMemoryOptim)
+      .def("enable_profile", &AnalysisConfig::EnableProfile)
       .def("set_optim_cache_dir", &AnalysisConfig::SetOptimCacheDir)
       .def("switch_use_feed_fetch_ops", &AnalysisConfig::SwitchUseFeedFetchOps,
            py::arg("x") = true)


### PR DESCRIPTION
-- added GetInputTensorShape() method for AnalysisPredictor.
-- added uint8 support for ZeroCopyTensor.
-- changed way of enabling profiling from setting GFLAGS to specifying AnalysisConfig options.Now one can turn on profiling by setting `config.EnableProfile()`.
-- added unittests for the features above.