### PR TITLE
Fix gc bug in controlflow ops

### DIFF
--- a/paddle/fluid/framework/executor.cc
+++ b/paddle/fluid/framework/executor.cc
@@ -78,10 +78,11 @@ void ExecutorPrepareContext::PrepareUnusedVars(
   // If gc is enabled and block size > 1
   if (prog_.Size() > 1) {
     operators::PrepareSafeEagerDeletionOnConditionalOpAndConditionalGradOp(
-        block_id_, ops_);
-    operators::PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(block_id_, ops_);
+        prog_, block_id_, ops_);
+    operators::PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(prog_, block_id_,
+                                                               ops_);
     operators::PrepareSafeEagerDeletionOnRecurrentOpAndRecurrentGradOp(
-        block_id_, ops_);
+        prog_, block_id_, ops_);
   }
   unused_vars_ = GetUnusedVars(prog_.Block(block_id_), ops_, keep_vars);
 }

--- a/paddle/fluid/framework/ir/memory_optimize_pass/conditional_block_op_eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/conditional_block_op_eager_deletion_pass.cc
@@ -48,7 +48,7 @@ class ConditionalOpEagerDeletionPass : public Pass {
       auto &ifelse_ops = ops_pair.second.first;
       auto &ifelse_grad_ops = ops_pair.second.second;
       operators::PrepareSafeEagerDeletionOnConditionalOpAndConditionalGradOp(
-          ifelse_ops, ifelse_grad_ops);
+          graph->OriginProgram(), ifelse_ops, ifelse_grad_ops);
     }
   }
 };

--- a/paddle/fluid/framework/ir/memory_optimize_pass/recurrent_op_eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/recurrent_op_eager_deletion_pass.cc
@@ -40,7 +40,8 @@ void RecurrentOpEagerDeletionPass::ApplyImpl(Graph *graph) const {
     // Prepare safe eager deletion on different devices because the garbage
     // collection may be different across devices
     OpAndGradOpPair &op_pair = entry.second;
-    PrepareSafeEagerDeletionOnRecurrentOpAndRecurrentGradOp(&op_pair);
+    PrepareSafeEagerDeletionOnRecurrentOpAndRecurrentGradOp(
+        graph->OriginProgram(), &op_pair);
   }
 }
 

--- a/paddle/fluid/framework/ir/memory_optimize_pass/while_op_eager_deletion_pass.cc
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/while_op_eager_deletion_pass.cc
@@ -47,7 +47,7 @@ class WhileOpEagerDeletionPass : public ir::Pass {
       auto &while_ops = ops_pair.second.first;
       auto &while_grad_ops = ops_pair.second.second;
       operators::PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
-          while_ops, while_grad_ops);
+          graph->OriginProgram(), while_ops, while_grad_ops);
     }
   }
 };

--- a/paddle/fluid/operators/controlflow/conditional_block_op_helper.h
+++ b/paddle/fluid/operators/controlflow/conditional_block_op_helper.h
@@ -23,10 +23,11 @@ namespace paddle {
 namespace operators {
 
 void PrepareSafeEagerDeletionOnConditionalOpAndConditionalGradOp(
-    int block_id,
+    const framework::ProgramDesc &program, int block_id,
     const std::vector<std::unique_ptr<framework::OperatorBase>> &all_ops);
 
 void PrepareSafeEagerDeletionOnConditionalOpAndConditionalGradOp(
+    const framework::ProgramDesc &program,
     const std::vector<framework::OperatorBase *> &ifelse_ops,
     const std::vector<framework::OperatorBase *> &ifelse_grad_ops);
 

--- a/paddle/fluid/operators/controlflow/recurrent_op_helper.h
+++ b/paddle/fluid/operators/controlflow/recurrent_op_helper.h
@@ -37,14 +37,14 @@ using OpAndGradOpPair = std::pair<OpVariantSet, OpVariantSet>;
 // recurrent_grad ops at block 0 and the function will find all recurrent and
 // recurrent_grad ops across blocks.
 void PrepareSafeEagerDeletionOnRecurrentOpAndRecurrentGradOp(
-    OpAndGradOpPair *op_pair);
+    const framework::ProgramDesc &program, OpAndGradOpPair *op_pair);
 
 // Set vars to skip eager deletion on input recurrent and recurrent_grad for
 // preparing safe eager deletion. The input block_id must be 0 and caller can
 // input all ops in the block. The function will find all recurrent and
 // recurrent_grad ops across blocks.
 void PrepareSafeEagerDeletionOnRecurrentOpAndRecurrentGradOp(
-    int block_id,
+    const framework::ProgramDesc &program, int block_id,
     const std::vector<std::unique_ptr<paddle::framework::OperatorBase>>
         &all_ops);
 

--- a/paddle/fluid/operators/controlflow/while_op_helper.cc
+++ b/paddle/fluid/operators/controlflow/while_op_helper.cc
@@ -100,16 +100,12 @@ static void ModifyWhileOpAndWhileGradOpAttr(const OpVariant &fwd_op,
 // Find all while_ops and while_grad_ops in the graph or program
 // The while_grad_op and while_op may located in different blocks
 // So we should traverse all blocks in the program and find them out.
-static void FindAllWhileAndWhileGradOp(std::vector<OpVariant> *while_ops,
+static void FindAllWhileAndWhileGradOp(const framework::ProgramDesc &program,
+                                       std::vector<OpVariant> *while_ops,
                                        std::vector<OpVariant> *while_grad_ops) {
   PADDLE_ENFORCE_GE(while_ops->size(), while_grad_ops->size());
-
-  if (while_ops->empty()) return;
-
-  const auto *program =
-      while_ops->front().Attr<framework::BlockDesc *>(kStepBlock)->Program();
-  for (size_t i = 1; i < program->Size(); ++i) {
-    auto &block = program->Block(i);
+  for (size_t i = 1; i < program.Size(); ++i) {
+    auto &block = program.Block(i);
     for (size_t j = 0; j < block.OpSize(); ++j) {
       auto *op = block.Op(j);
       if (op->Type() == "while") {
@@ -125,8 +121,9 @@ static void FindAllWhileAndWhileGradOp(std::vector<OpVariant> *while_ops,
 }
 
 static void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOpImpl(
-    std::vector<OpVariant> *while_ops, std::vector<OpVariant> *while_grad_ops) {
-  FindAllWhileAndWhileGradOp(while_ops, while_grad_ops);
+    const framework::ProgramDesc &program, std::vector<OpVariant> *while_ops,
+    std::vector<OpVariant> *while_grad_ops) {
+  FindAllWhileAndWhileGradOp(program, while_ops, while_grad_ops);
 
   VLOG(2) << "Found while op num: " << while_ops->size()
           << ", while grad op num: " << while_grad_ops->size();
@@ -155,7 +152,7 @@ static void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOpImpl(
 }
 
 void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
-    int block_id,
+    const framework::ProgramDesc &program, int block_id,
     const std::vector<std::unique_ptr<framework::OperatorBase>> &all_ops) {
   // If block_id is not 0, returns
   // This is because all while_ops and while_grad_ops in the whole program
@@ -176,10 +173,12 @@ void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
       bwd_ops.emplace_back(op.get());
     }
   }
-  PrepareSafeEagerDeletionOnWhileOpAndWhileGradOpImpl(&fwd_ops, &bwd_ops);
+  PrepareSafeEagerDeletionOnWhileOpAndWhileGradOpImpl(program, &fwd_ops,
+                                                      &bwd_ops);
 }
 
 void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
+    const framework::ProgramDesc &program,
     const std::vector<framework::OperatorBase *> &while_ops,
     const std::vector<framework::OperatorBase *> &while_grad_ops) {
   std::vector<OpVariant> fwd_ops, bwd_ops;
@@ -193,7 +192,8 @@ void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
     bwd_ops.emplace_back(op);
   }
 
-  PrepareSafeEagerDeletionOnWhileOpAndWhileGradOpImpl(&fwd_ops, &bwd_ops);
+  PrepareSafeEagerDeletionOnWhileOpAndWhileGradOpImpl(program, &fwd_ops,
+                                                      &bwd_ops);
 }
 
 }  // namespace operators

--- a/paddle/fluid/operators/controlflow/while_op_helper.h
+++ b/paddle/fluid/operators/controlflow/while_op_helper.h
@@ -32,10 +32,11 @@ static constexpr char kOutputs[] = "Out";
 static constexpr char kSkipEagerDeletionVars[] = "skip_eager_deletion_vars";
 
 void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
-    int block_id,
+    const framework::ProgramDesc &program, int block_id,
     const std::vector<std::unique_ptr<framework::OperatorBase>> &all_ops);
 
 void PrepareSafeEagerDeletionOnWhileOpAndWhileGradOp(
+    const framework::ProgramDesc &program,
     const std::vector<framework::OperatorBase *> &while_ops,
     const std::vector<framework::OperatorBase *> &while_grad_ops);
 


### PR DESCRIPTION
Some control-flow ops may be nested inside other control-flow ops, so that they cannot be found in block 0 when gc is enabled. This PR traverse all blocks to find out all control-flow ops to avoid this bug.