### PR TITLE
[Bug fix] Disable memory reuse on feeded variables

### DIFF
--- a/paddle/fluid/framework/details/eager_deletion_op_handle.cc
+++ b/paddle/fluid/framework/details/eager_deletion_op_handle.cc
@@ -96,7 +96,8 @@ void EagerDeletionOpHandle::RunImpl() {
   std::deque<std::shared_ptr<memory::Allocation>> garbages;
   for (size_t i = 0; i < var_infos_.size(); ++i) {
     auto *var_info = var_infos_[i];
-    if (var_info->IsSkipped() || !var_info->DecreaseRefCnt()) {
+    if (var_info->IsSkippedAllMemoryOptimization() ||
+        !var_info->DecreaseRefCnt()) {
       continue;
     }
 

--- a/paddle/fluid/framework/details/share_tensor_buffer_functor.cc
+++ b/paddle/fluid/framework/details/share_tensor_buffer_functor.cc
@@ -100,7 +100,7 @@ void ShareTensorBufferFunctor::operator()(Scope *exec_scope) {
     auto *out_tensor = GetMutableTensorFromVar(in_out_vars_[i].second);
     auto *in_var_info = in_var_infos_[i];
 
-    if (UNLIKELY(in_var_info->IsSkipped())) {
+    if (UNLIKELY(in_var_info->IsSkippedMemoryReuse())) {
       // If in_var is inplaced in the previous batch and we want to fetch
       // in_var in the current batch, we have to reset memory of out_var
       // to avoid wrong calculation result.

--- a/paddle/fluid/framework/ir/memory_optimize_pass/memory_optimization_var_info.h
+++ b/paddle/fluid/framework/ir/memory_optimize_pass/memory_optimization_var_info.h
@@ -68,6 +68,20 @@ class MemOptVarInfo {
 
  private:
   std::string name_;
+
+  /**
+   * ref_cnt_ is the total number of last-lived ops of variable. It would not
+   * be changed during iterations.
+   *
+   * runtime_ref_cnt_ is the runtime reference count of variable, which would
+   * decrease 1 when each EagerDeletionOpHandle runs. As a result, it should
+   * be reset to ref_cnt_ after each iteration ends. Since operators are
+   * scheduled in many threads inside ParallelExecutor, runtime_ref_cnt_
+   * must be an atomic integer to guarantee the thread safety and visibility.
+   *
+   * Speciallly, if ref_cnt_ is 1, we do not need to reset runtime_ref_cnt_
+   * after iteration ends.
+   */
   size_t ref_cnt_;
   std::atomic<size_t> runtime_ref_cnt_;
   bool skip_memory_reuse_{false};

--- a/python/paddle/fluid/tests/unittests/test_memory_reuse_exclude_feed_var.py
+++ b/python/paddle/fluid/tests/unittests/test_memory_reuse_exclude_feed_var.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import numpy as np
+import unittest
+
+
+class TestMemoryReuseExcludeFeedVar(unittest.TestCase):
+    def setUp(self):
+        self.image_shape = [28, 28]
+        self.iteration = 10
+
+    def main_impl(self, place):
+        image = fluid.layers.data(
+            name='image', shape=self.image_shape, dtype='float32')
+        relu_image = fluid.layers.relu(image)
+        loss = fluid.layers.reduce_mean(relu_image)
+
+        build_strategy = fluid.BuildStrategy()
+        build_strategy.enable_inplace = True
+        build_strategy.memory_optimize = True
+
+        exe = fluid.Executor(place)
+        exe.run(fluid.default_startup_program())
+
+        compiled_prog = fluid.CompiledProgram(fluid.default_main_program(
+        )).with_data_parallel(
+            loss_name=loss.name, build_strategy=build_strategy)
+
+        image_tensor = fluid.LoDTensor()
+        np_image = np.random.uniform(
+            low=-10, high=10, size=self.image_shape).astype('float32')
+        image_tensor.set(np_image, place)
+
+        feed_dict = [{image.name: image_tensor}]
+
+        for _ in range(self.iteration):
+            exe.run(compiled_prog, feed=feed_dict, fetch_list=[loss.name])
+            self.assertTrue(np.array_equal(np.array(image_tensor), np_image))
+
+    def test_main(self):
+        places = [fluid.CPUPlace()]
+        if fluid.is_compiled_with_cuda():
+            places.append(fluid.CUDAPlace(0))
+
+        for p in places:
+            with fluid.program_guard(fluid.Program(), fluid.Program()):
+                with fluid.unique_name.guard():
+                    with fluid.scope_guard(fluid.Scope()):
+                        self.main_impl(p)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
It is better that memory reuse passes do not reuse the variable that users feeds, because users may feed them to another network, which may cause calculation errors. This PR disables memory reuse on feeded variables.

For example:

```Python
tensor = fluid.LoDTensor()
... 

# If tensor is reused by other variables, its data would be changed.
exe.run(program1, feed={'image': tensor})

# The following training may be wrong if tensor is reused in the previous network.
# However, users may not know tensor has been changed.
exe.run(program2, feed={'image': tensor})
```

Although memory reuse is disabled in feeded variables, garbage collection still works on them.