### PR TITLE
Refine reallocate of cudnn workspace

### DIFF
--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -218,6 +218,8 @@ class CudnnWorkspaceHandle {
     if (required_workspace_bytes <= WorkspaceSize()) {
       return;
     }
+    // reset allocation first before re-allocate to save memory
+    allocation_.reset();
     allocation_ = memory::Alloc(device_context_, required_workspace_bytes);
   }
 


### PR DESCRIPTION
Cudnn workspace can be freed before re-allocation to save memory usages of models.