### PR TITLE
Add lock to cudnn handle calls

### DIFF
--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -308,7 +308,7 @@ bool CUDADeviceContext::tensor_core_available() const {
 cudnnHandle_t CUDADeviceContext::cudnn_handle() const { return cudnn_handle_; }
 
 CudnnWorkspaceHandle CUDADeviceContext::cudnn_workspace_handle() const {
-  return CudnnWorkspaceHandle(*this);
+  return CudnnWorkspaceHandle(*this, &cudnn_handle_mtx_);
 }
 
 cudaStream_t CUDADeviceContext::stream() const { return stream_; }

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -218,6 +218,8 @@ class CudnnWorkspaceHandle {
     if (required_workspace_bytes <= WorkspaceSize()) {
       return;
     }
+    // reset allocation first before re-allocate to save memory
+    allocation_.reset();
     allocation_ = memory::Alloc(device_context_, required_workspace_bytes);
   }
 


### PR DESCRIPTION
`cudnnHandle_t` is not thread-safe. Please see https://docs.nvidia.com/deeplearning/sdk/cudnn-developer-guide/index.html and https://github.com/pytorch/pytorch/blob/master/caffe2/core/cudnn_wrappers.h. 

This PR adds lock to cudnn function calls.