### PR TITLE
Refactor Inplace test in OpTest and check grad inplace even if forward has no inplace

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_op.cu.cc
+++ b/paddle/fluid/operators/conv_cudnn_op.cu.cc
@@ -509,7 +509,8 @@ REGISTER_OP_KERNEL(conv3d, CUDNN, plat::CUDAPlace,
                    paddle::operators::CUDNNConvOpKernel<plat::float16>);
 REGISTER_OP_KERNEL(conv3d_grad, CUDNN, plat::CUDAPlace,
                    paddle::operators::CUDNNConvGradOpKernel<float>,
-                   paddle::operators::CUDNNConvGradOpKernel<double>);
+                   paddle::operators::CUDNNConvGradOpKernel<double>,
+                   paddle::operators::CUDNNConvGradOpKernel<plat::float16>);
 REGISTER_OP_KERNEL(
     conv3d_grad_grad, CUDNN, plat::CUDAPlace,
     paddle::operators::CUDNNConvDoubleGradOpKernel<float>,

--- a/paddle/fluid/operators/elementwise/elementwise_mul_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_mul_op.h
@@ -186,8 +186,7 @@ class ElementwiseMulDoubleGradKernel : public framework::OpKernel<T> {
   }
 };
 
-DECLARE_INPLACE_OP_INFERER(ElementwiseMulDoubleGradOpInplace, {"DDX", "DDOut"},
-                           {"X", framework::GradVarName("X")},
-                           {"Y", framework::GradVarName("Y")});
+DECLARE_INPLACE_OP_INFERER(ElementwiseMulDoubleGradOpInplace, {"DDX", "DDOut"});
+
 }  // namespace operators
 }  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -318,33 +318,6 @@ class OpTest(unittest.TestCase):
                 attrs=self.attrs)
             return outputs
 
-    def _compare_expect_and_actual_outputs(self,
-                                           place,
-                                           fetch_list,
-                                           expect_outs,
-                                           actual_outs,
-                                           inplace_atol=None):
-        # compare expect_outs and actual_outs
-        for i, name in enumerate(fetch_list):
-            if inplace_atol is not None:
-                self.assertTrue(
-                    np.allclose(
-                        np.array(expect_outs[i]),
-                        np.array(actual_outs[i]),
-                        atol=inplace_atol),
-                    "Output (" + name + ") has diff at " + str(place) +
-                    " when using and not using inplace" + "\nExpect " +
-                    str(expect_outs[i]) + "\n" + "But Got" + str(actual_outs[i])
-                    + " in class " + self.__class__.__name__)
-            else:
-                self.assertTrue(
-                    np.array_equal(
-                        np.array(expect_outs[i]), np.array(actual_outs[i])),
-                    "Output (" + name + ") has diff at " + str(place) +
-                    " when using and not using inplace" + "\nExpect " +
-                    str(expect_outs[i]) + "\n" + "But Got" + str(actual_outs[i])
-                    + " in class " + self.__class__.__name__ + '\n')
-
     def _calc_output(self,
                      place,
                      parallel=False,
@@ -411,64 +384,161 @@ class OpTest(unittest.TestCase):
         else:
             return outs, fetch_list
 
+    def _compare_expect_and_actual_outputs(self,
+                                           place,
+                                           fetch_list,
+                                           expect_outs,
+                                           actual_outs,
+                                           inplace_atol=None):
+        # compare expect_outs and actual_outs
+        for i, name in enumerate(fetch_list):
+            if inplace_atol is not None:
+                self.assertTrue(
+                    np.allclose(
+                        np.array(expect_outs[i]),
+                        np.array(actual_outs[i]),
+                        atol=inplace_atol),
+                    "Output (" + name + ") has diff at " + str(place) +
+                    " when using and not using inplace" + "\nExpect " +
+                    str(expect_outs[i]) + "\n" + "But Got" + str(actual_outs[i])
+                    + " in class " + self.__class__.__name__)
+            else:
+                self.assertTrue(
+                    np.array_equal(
+                        np.array(expect_outs[i]), np.array(actual_outs[i])),
+                    "Output (" + name + ") has diff at " + str(place) +
+                    " when using and not using inplace" + "\nExpect " +
+                    str(expect_outs[i]) + "\n" + "But Got" + str(actual_outs[i])
+                    + " in class " + self.__class__.__name__ + '\n')
+
+    def _construct_grad_program_from_forward(self, fwd_program, grad_op_desc,
+                                             op_grad_to_var):
+        # create grad program
+        grad_program = Program()
+        grad_block = grad_program.global_block()
+        new_op_desc = grad_block.desc.append_op()
+        new_op_desc.copy_from(grad_op_desc)
+        grad_program._sync_with_cpp()
+
+        # create grad vars based on fwd vars (shape and dtype)
+        for arg in grad_op_desc.input_arg_names(
+        ) + grad_op_desc.output_arg_names():
+            fwd_var_name = op_grad_to_var.get(arg, None)
+            if fwd_var_name is None:
+                fwd_var_name = arg
+            fwd_var = fwd_program.global_block().vars.get(fwd_var_name)
+            assert fwd_var is not None, "{} cannot be found".format(
+                fwd_var_name)
+            grad_var = grad_block.create_var(
+                name=arg,
+                dtype=fwd_var.dtype,
+                shape=fwd_var.shape,
+                type=fwd_var.type,
+                persistable=False)
+            # some variables' tensors hold no buffer (tensor's _holder is NULL), like XShape in reshape2 op, 
+            # and the shapes of those variables contain 0 (eg. Xshape.shape = [0, 2, 5]). 
+            # set persistable for those variables in order to get them from global_scope for inplace grad test directly other than feed them,
+            # since feed op calls check_memory_size() which fails when tensor's holder_ is NULL.
+            if 0 in grad_var.shape:
+                grad_var.persistable = True
+        grad_program._sync_with_cpp()
+        return grad_program
+
+    def _construct_grad_feed_map_from_forward(
+            self, place, fwd_feed_map, fwd_fetch_list, fwd_outs, fwd_program,
+            grad_op_desc, op_grad_to_var):
+        # generate grad_feed_map for grad_program
+        # since we don`t really check gradient accuracy, but the consistency when using and not using inplace
+        # we use fwd outs (also inputs sometimes) as grad (fake) feeds
+        p = core.Place()
+        p.set_place(place)
+        grad_feed_map = {}
+        for arg in grad_op_desc.input_arg_names():
+            if arg in fwd_feed_map.keys():
+                grad_feed_map[arg] = fwd_feed_map[arg]._copy(p)
+            else:
+                fwd_var_name = op_grad_to_var.get(arg, None)
+                if fwd_var_name is None:
+                    fwd_var_name = arg
+
+                for i, out_name in enumerate(fwd_fetch_list):
+                    if out_name == fwd_var_name:
+                        # don't feed variables whose tensors hold no buffer (shape contains 0 like shape = [0,2,5] and holder_ is NULL), like XShape in reshape2 op.
+                        # get them from global_scope directly since we have set them persistable in fwd execution
+                        if 0 in fwd_program.global_block().var(out_name).shape:
+                            continue
+                        else:
+                            grad_feed_map[arg] = fwd_outs[i]._copy(p)
+        return grad_feed_map
+
     def check_inplace_output_with_place(self,
                                         place,
                                         no_check_set=None,
                                         inplace_atol=None):
-        # can`t enable inplace 
-        if not fluid.core.has_infer_inplace(self.op_type):
-            return
-        expect_res = self._calc_output(
-            place,
-            no_check_set=no_check_set,
-            enable_inplace=False,
-            for_inplace_test=True)
-        actual_res = self._calc_output(
-            place,
-            no_check_set=no_check_set,
-            enable_inplace=True,
-            for_inplace_test=True)
+        has_infer_inplace = fluid.core.has_infer_inplace(self.op_type)
+        has_grad_op_maker = fluid.core.has_grad_op_maker(self.op_type)
 
-        # compare expect_outs and actual_outs
-        self._compare_expect_and_actual_outputs(
-            place,
-            expect_res[1],
-            expect_res[0],
-            actual_res[0],
-            inplace_atol=inplace_atol)
-
-        # check grad
-        # TODO(zhiqiu): enhance inplace_grad test for ops (sum and activation) using mkldnn
-        # skip use_mkldnn currently
-        flags_use_mkldnn = fluid.core.get_flags_use_mkldnn()
-        attrs_use_mkldnn = hasattr(
-            self, 'attrs') and bool(self.attrs.get('use_mkldnn', False))
-        if flags_use_mkldnn or attrs_use_mkldnn:
-            warnings.warn(
-                "check inplace_grad for ops using mkldnn is not supported")
+        # op has neither inplace nor grad_op
+        if not (has_infer_inplace or has_grad_op_maker):
             return
-        use_ngraph = fluid.core.is_compiled_with_ngraph(
-        ) and fluid.core.get_flags_use_ngraph()
-        if use_ngraph:
-            warnings.warn(
-                "check inplace_grad for ops using ngraph is not supported")
-            return
+        else:
+            expect_res = self._calc_output(
+                place,
+                no_check_set=no_check_set,
+                enable_inplace=False,
+                for_inplace_test=True)
 
-        fwd_outs = expect_res[0]
-        fwd_fetch_list = expect_res[1]
-        fwd_feed_map = expect_res[2]
-        fwd_program = expect_res[3]
-        fwd_op_desc = expect_res[4]
-        self.check_inplace_grad_output_using_fwd_inputs_outputs(
-            place,
-            fwd_feed_map,
-            fwd_fetch_list,
-            fwd_outs,
-            fwd_program,
-            fwd_op_desc,
-            no_check_set=no_check_set,
-            inplace_atol=inplace_atol,
-            depth=0)
+            # op has inplace, check forward inplace
+            if has_infer_inplace:
+                actual_res = self._calc_output(
+                    place,
+                    no_check_set=no_check_set,
+                    enable_inplace=True,
+                    for_inplace_test=True)
+                # compare expect_outs and actual_outs
+                self._compare_expect_and_actual_outputs(
+                    place,
+                    expect_res[1],
+                    expect_res[0],
+                    actual_res[0],
+                    inplace_atol=inplace_atol)
+
+            elif has_grad_op_maker:
+                # we should check grad, even if forward can not inplace
+                # TODO(zhiqiu): enhance inplace_grad test for ops (sum and activation) using mkldnn
+                # skip use_mkldnn currently
+                flags_use_mkldnn = fluid.core.get_flags_use_mkldnn()
+                attrs_use_mkldnn = hasattr(
+                    self,
+                    'attrs') and bool(self.attrs.get('use_mkldnn', False))
+                if flags_use_mkldnn or attrs_use_mkldnn:
+                    warnings.warn(
+                        "check inplace_grad for ops using mkldnn is not supported"
+                    )
+                    return
+                use_ngraph = fluid.core.is_compiled_with_ngraph(
+                ) and fluid.core.get_flags_use_ngraph()
+                if use_ngraph:
+                    warnings.warn(
+                        "check inplace_grad for ops using ngraph is not supported"
+                    )
+                    return
+
+                fwd_outs = expect_res[0]
+                fwd_fetch_list = expect_res[1]
+                fwd_feed_map = expect_res[2]
+                fwd_program = expect_res[3]
+                fwd_op_desc = expect_res[4]
+                self.check_inplace_grad_output_using_fwd_inputs_outputs(
+                    place,
+                    fwd_feed_map,
+                    fwd_fetch_list,
+                    fwd_outs,
+                    fwd_program,
+                    fwd_op_desc,
+                    no_check_set=no_check_set,
+                    inplace_atol=inplace_atol,
+                    depth=0)
 
     def check_inplace_grad_output_using_fwd_inputs_outputs(self,
                                                            place,
@@ -486,110 +556,65 @@ class OpTest(unittest.TestCase):
         if depth >= 2:
             return
         # get grad_op 
-        if not fluid.core.has_grad_op_maker(fwd_op_desc.type()):
-            return
         grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(fwd_op_desc,
                                                                   set(), [])
         # has grad_op_maker but no grad_op 
         if not grad_op_desc_list:
             return
         for i, grad_op_desc in enumerate(grad_op_desc_list):
-            # grad_op can not inplace
-            if not fluid.core.has_infer_inplace(grad_op_desc.type()):
+            has_infer_inplace = fluid.core.has_infer_inplace(grad_op_desc.type(
+            ))
+            has_grad_op_maker = fluid.core.has_grad_op_maker(grad_op_desc.type(
+            ))
+            # op has neither inplace nor grad_op
+            if not (has_infer_inplace or has_grad_op_maker):
                 continue
+            else:
+                grad_program = self._construct_grad_program_from_forward(
+                    fwd_program, grad_op_desc, op_grad_to_var)
+                grad_feed_map = self._construct_grad_feed_map_from_forward(
+                    place, fwd_feed_map, fwd_fetch_list, fwd_outs, fwd_program,
+                    grad_op_desc, op_grad_to_var)
+                grad_fetch_list = grad_op_desc.output_arg_names()
 
-            # create grad program
-            grad_program = Program()
-            grad_block = grad_program.global_block()
-            new_op_desc = grad_block.desc.append_op()
-            new_op_desc.copy_from(grad_op_desc)
-            grad_program._sync_with_cpp()
+                def _calc_grad_output(enable_inplace=None):
+                    exe = Executor(place)
+                    build_strategy = fluid.BuildStrategy()
+                    build_strategy.enable_inplace = enable_inplace
+                    compiled_program = fluid.CompiledProgram(
+                        grad_program).with_data_parallel(
+                            loss_name="",
+                            build_strategy=build_strategy,
+                            places=place)
+                    outs = exe.run(compiled_program,
+                                   feed=grad_feed_map,
+                                   fetch_list=grad_fetch_list,
+                                   return_numpy=False)
+                    return outs
 
-            # create grad vars based on fwd vars (shape and dtype)
-            for arg in grad_op_desc.input_arg_names(
-            ) + grad_op_desc.output_arg_names():
-                fwd_var_name = op_grad_to_var.get(arg, None)
-                if fwd_var_name is None:
-                    fwd_var_name = arg
-                fwd_var = fwd_program.global_block().vars.get(fwd_var_name)
-                assert fwd_var is not None, "{} cannot be found".format(
-                    fwd_var_name)
-                grad_var = grad_block.create_var(
-                    name=arg,
-                    dtype=fwd_var.dtype,
-                    shape=fwd_var.shape,
-                    type=fwd_var.type,
-                    persistable=False)
-                # some variables' tensors hold no buffer (tensor's _holder is NULL), like XShape in reshape2 op, 
-                # and the shapes of those variables contain 0 (eg. Xshape.shape = [0, 2, 5]). 
-                # set persistable for those variables in order to get them from global_scope for inplace grad test directly other than feed them,
-                # since feed op calls check_memory_size() which fails when tensor's holder_ is NULL.
-                if 0 in grad_var.shape:
-                    grad_var.persistable = True
-            grad_program._sync_with_cpp()
-            grad_fetch_list = grad_op_desc.output_arg_names()
-
-            # generate grad_feed_map for grad_program
-            # since we don`t really check gradient accuracy, but the consistency when using and not using inplace
-            # we use fwd outs (also inputs sometimes) as grad (fake) feeds
-            p = core.Place()
-            p.set_place(place)
-            grad_feed_map = {}
-            for arg in grad_op_desc.input_arg_names():
-                if arg in fwd_feed_map.keys():
-                    grad_feed_map[arg] = fwd_feed_map[arg]._copy(p)
-                else:
-                    fwd_var_name = op_grad_to_var.get(arg, None)
-                    if fwd_var_name is None:
-                        fwd_var_name = arg
-
-                    for i, out_name in enumerate(fwd_fetch_list):
-                        if out_name == fwd_var_name:
-                            # don't feed variables whose tensors hold no buffer (shape contains 0 like shape = [0,2,5] and holder_ is NULL), like XShape in reshape2 op.
-                            # get them from global_scope directly since we have set them persistable in fwd execution
-                            if 0 in fwd_program.global_block().var(
-                                    out_name).shape:
-                                continue
-                            else:
-                                grad_feed_map[arg] = fwd_outs[i]._copy(p)
-
-            def _calc_grad_output(enable_inplace=None):
-                exe = Executor(place)
-                build_strategy = fluid.BuildStrategy()
-                build_strategy.enable_inplace = enable_inplace
-                compiled_program = fluid.CompiledProgram(
-                    grad_program).with_data_parallel(
-                        loss_name="",
-                        build_strategy=build_strategy,
-                        places=place)
-                outs = exe.run(compiled_program,
-                               feed=grad_feed_map,
-                               fetch_list=grad_fetch_list,
-                               return_numpy=False)
-                return outs
-
-            expect_outs = _calc_grad_output(enable_inplace=False)
-            actual_outs = _calc_grad_output(enable_inplace=True)
-
-            # compare expect_outs and actual_outs
-            self._compare_expect_and_actual_outputs(
-                place,
-                grad_fetch_list,
-                expect_outs,
-                actual_outs,
-                inplace_atol=inplace_atol)
-
-            # check grad of grad, recursively
-            self.check_inplace_grad_output_using_fwd_inputs_outputs(
-                place,
-                grad_feed_map,
-                grad_fetch_list,
-                expect_outs,
-                grad_program,
-                grad_op_desc,
-                no_check_set=no_check_set,
-                inplace_atol=inplace_atol,
-                depth=depth + 1)
+                expect_outs = _calc_grad_output(enable_inplace=False)
+                if has_infer_inplace:
+                    actual_outs = _calc_grad_output(enable_inplace=True)
+                    # compare expect_outs and actual_outs
+                    self._compare_expect_and_actual_outputs(
+                        place,
+                        grad_fetch_list,
+                        expect_outs,
+                        actual_outs,
+                        inplace_atol=inplace_atol)
+                elif has_grad_op_maker:
+                    # we should check grad, even if forward can not inplace
+                    # check grad of grad, recursively
+                    self.check_inplace_grad_output_using_fwd_inputs_outputs(
+                        place,
+                        grad_feed_map,
+                        grad_fetch_list,
+                        expect_outs,
+                        grad_program,
+                        grad_op_desc,
+                        no_check_set=no_check_set,
+                        inplace_atol=inplace_atol,
+                        depth=depth + 1)
 
     def check_output_with_place(self,
                                 place,


### PR DESCRIPTION
Before this PR, OpTest stops  `inplace` checking for grad op when forward op has no `inplace`, and stops `inplace` checking for double_grad op when grad op has no `inplace` (e.g., elementwise_div_grad_grad),  and so on.

This PR fixes that problem and refactors `inplace test` code for better modularity and understanding.
