### PR TITLE
give warnings when save a model without any parameters

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -217,6 +217,12 @@ def save_vars(executor,
             vars=list(filter(predicate, main_program.list_vars())),
             filename=filename)
     else:
+        # give warning when there is no var in model      
+        if len(list(vars)) == 0:
+            warnings.warn(
+                "no variable in your model, please ensure there are any variables in your model to save"
+            )
+
         save_program = Program()
         save_block = save_program.global_block()
 


### PR DESCRIPTION
Fixed #19481
give warnings when save a model without any parameters