### PR TITLE
Avoid treating broadcast as initialization operation

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1833,6 +1833,11 @@ class Block(object):
                 init_ops = []
                 for op in block.ops:
                     if var.name in op.output_arg_names:
+                        #In startup_program, "c_broadcast" and "c_sync_comm_stream"
+                        #are treated as initialization ops that cause error. 
+                        #Think of "c_broadcast" and "c_sync_comm_stream" as a special case here.
+                        if op.type in ["c_broadcast", "c_sync_comm_stream"]:
+                            continue
                         init_ops.append(op)
                 return init_ops
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1833,9 +1833,9 @@ class Block(object):
                 init_ops = []
                 for op in block.ops:
                     if var.name in op.output_arg_names:
-                        #In startup_program, "c_broadcast" and "c_sync_comm_stream"
-                        #are treated as initialization ops that cause error. 
-                        #Think of "c_broadcast" and "c_sync_comm_stream" as a special case here.
+                        # In startup_program, "c_broadcast" and "c_sync_comm_stream"
+                        # are treated as initialization ops that cause error. 
+                        # Think of "c_broadcast" and "c_sync_comm_stream" as a special case here.
                         if op.type in ["c_broadcast", "c_sync_comm_stream"]:
                             continue
                         init_ops.append(op)

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -39,6 +39,7 @@ if(WIN32)
     LIST(REMOVE_ITEM TEST_OPS test_boxps)
     LIST(REMOVE_ITEM TEST_OPS test_trainer_desc)
     LIST(REMOVE_ITEM TEST_OPS test_multiprocess_reader_exception)
+    LIST(REMOVE_ITEM TEST_OPS test_avoid_broadcast)
 endif()
 
 LIST(REMOVE_ITEM TEST_OPS test_launch)

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -39,7 +39,7 @@ if(WIN32)
     LIST(REMOVE_ITEM TEST_OPS test_boxps)
     LIST(REMOVE_ITEM TEST_OPS test_trainer_desc)
     LIST(REMOVE_ITEM TEST_OPS test_multiprocess_reader_exception)
-    LIST(REMOVE_ITEM TEST_OPS test_avoid_broadcast)
+    LIST(REMOVE_ITEM TEST_OPS test_avoid_twice_initialization)
 endif()
 
 LIST(REMOVE_ITEM TEST_OPS test_launch)

--- a/python/paddle/fluid/tests/unittests/test_avoid_broadcast.py
+++ b/python/paddle/fluid/tests/unittests/test_avoid_broadcast.py
@@ -1,0 +1,50 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import paddle.fluid as fluid
+
+
+class Test_Avoid_Broadcast(unittest.TestCase):
+    def test_avoid_broadcast(self):
+        cur_program = fluid.Program()
+        cur_block = cur_program.current_block()
+        var = cur_block.create_parameter(
+            initializer=fluid.initializer.Constant(value=0.01),
+            shape=[4, 2],
+            dtype='float32',
+            name='var_a')
+        cur_block.append_op(
+            type="c_broadcast",
+            inputs={"X": [var]},
+            outputs={"Out": [var]},
+            attrs={'root': 0,
+                   'ring_id': 0,
+                   'use_calc_stream': False})
+        cur_block.append_op(
+            type="c_sync_comm_stream",
+            inputs={'X': [var]},
+            outputs={'Out': [var]},
+            attrs={'ring_id': 0})
+        var2 = cur_block.create_parameter(
+            initializer=fluid.initializer.Constant(value=0.01),
+            shape=[4, 2],
+            dtype='float32',
+            name='var_a')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_avoid_twice_initialization.py
+++ b/python/paddle/fluid/tests/unittests/test_avoid_twice_initialization.py
@@ -18,8 +18,8 @@ import unittest
 import paddle.fluid as fluid
 
 
-class Test_Avoid_Broadcast(unittest.TestCase):
-    def test_avoid_broadcast(self):
+class TestAvoidTwiceInitialization(unittest.TestCase):
+    def test_avoid_twice_initialization(self):
         cur_program = fluid.Program()
         cur_block = cur_program.current_block()
         var = cur_block.create_parameter(

--- a/python/paddle/fluid/tests/unittests/test_avoid_twice_initialization.py
+++ b/python/paddle/fluid/tests/unittests/test_avoid_twice_initialization.py
@@ -24,7 +24,7 @@ class TestAvoidTwiceInitialization(unittest.TestCase):
         cur_block = cur_program.current_block()
         var = cur_block.create_parameter(
             initializer=fluid.initializer.Constant(value=0.01),
-            shape=[4, 2],
+            shape=[2, 2],
             dtype='float32',
             name='var_a')
         cur_block.append_op(
@@ -41,7 +41,7 @@ class TestAvoidTwiceInitialization(unittest.TestCase):
             attrs={'ring_id': 0})
         var2 = cur_block.create_parameter(
             initializer=fluid.initializer.Constant(value=0.01),
-            shape=[4, 2],
+            shape=[2, 2],
             dtype='float32',
             name='var_a')
 


### PR DESCRIPTION
When the mode is collective mode, an error of two initializations will occur. The broadcast should be treated as a non-initialized operation here. Think of broadcast as a special case here.
<img width="1288" alt="MacHi 2019-09-18 17-31-10" src="https://user-images.githubusercontent.com/19485646/65136454-2ed24000-da3a-11e9-9af0-154d06270c70.png">
