### PR TITLE
Add TRT input shape check between model and runtime

### DIFF
--- a/paddle/fluid/inference/analysis/helper.cc
+++ b/paddle/fluid/inference/analysis/helper.cc
@@ -75,6 +75,18 @@ void SetAttr<std::vector<int>>(framework::proto::OpDesc *op,
   }
 }
 
+template <>
+void SetAttr<std::vector<int64_t>>(framework::proto::OpDesc *op,
+                                   const std::string &name,
+                                   const std::vector<int64_t> &data) {
+  auto *attr = op->add_attrs();
+  attr->set_name(name);
+  attr->set_type(paddle::framework::proto::AttrType::LONGS);
+  for (const auto i : data) {
+    attr->add_longs(i);
+  }
+}
+
 }  // namespace analysis
 }  // namespace inference
 }  // namespace paddle

--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -201,6 +201,15 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
   SetAttr(op_desc->Proto(), "output_name_mapping", output_mapping);
   SetAttr(op_desc->Proto(), "parameters", params);
 
+  // we record all inputs' shapes in attr to check if they are consistent
+  // with the real inputs' shapes retrieved from scope when trt runs.
+  for (auto *x : node->inputs) {
+    if (x->IsVar() && x->Var()) {
+      framework::VarDesc *var = x->Var();
+      SetAttr(op_desc->Proto(), var->Name() + "_shape", var->GetShape());
+    }
+  }
+
   auto use_static_engine = Get<bool>("use_static_engine");
   // TODO(NHZlX)
   // There are models with the same structure but the different parameters,

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -212,9 +212,11 @@ class TensorRTEngineOp : public framework::OperatorBase {
                                                i_shape.end());
         std::vector<int64_t> runtime_input_shape(t_shape.begin() + 1,
                                                  t_shape.end());
-        PADDLE_ENFORCE_EQ(model_input_shape == model_input_shape, true,
-                          "input shapes not consistent with the model. TRT5 "
-                          "does not support dynamic shapes.");
+        PADDLE_ENFORCE_EQ(model_input_shape == runtime_input_shape, true,
+                          "Input shapes are inconsistent with the model. TRT 5 "
+                          "or lower version "
+                          "does not support dynamic input shapes. Please check "
+                          "your input shapes.");
       }
 
       runtime_batch = t_shape[0];

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -183,7 +183,8 @@ class TensorRTEngineOp : public framework::OperatorBase {
     auto stream =
         reinterpret_cast<const platform::CUDADeviceContext &>(dev_ctx).stream();
 
-    PADDLE_ENFORCE(!input_names_.empty(), "should pass more than one inputs");
+    PADDLE_ENFORCE_EQ(input_names_.empty(), false,
+                      "should pass at least one input");
 
     std::vector<std::string> output_maps =
         Attr<std::vector<std::string>>("output_name_mapping");
@@ -203,7 +204,19 @@ class TensorRTEngineOp : public framework::OperatorBase {
       // convert input and copy to TRT engine's buffer
       auto &t =
           inference::analysis::GetFromScope<framework::LoDTensor>(scope, x);
-      auto t_shape = framework::vectorize(t.dims());
+      auto t_shape = framework::vectorize<int64_t>(t.dims());
+      // check if the input shapes are consistent with model.
+      if (HasAttr(x + "_shape")) {
+        std::vector<int64_t> i_shape = Attr<std::vector<int64_t>>(x + "_shape");
+        std::vector<int64_t> model_input_shape(i_shape.begin() + 1,
+                                               i_shape.end());
+        std::vector<int64_t> runtime_input_shape(t_shape.begin() + 1,
+                                                 t_shape.end());
+        PADDLE_ENFORCE_EQ(model_input_shape == model_input_shape, true,
+                          "input shapes not consistent with the model. TRT5 "
+                          "does not support dynamic shapes.");
+      }
+
       runtime_batch = t_shape[0];
 
       const int bind_index = engine->engine()->getBindingIndex(x.c_str());


### PR DESCRIPTION
Added shape check (the runtime input shape set by user should be consistent with the input shape in model description) for TRT engine, because TRT 5 or lower version doesn't support dynamic shapes of inputs.

Before this, when a user set the input shapes wrong, TRT engine wouldn't throw an error properly, but just went down while running, showing that some ops' dims are not matched, which might cause confusion to users.

Now the error message can be thrown correctly, guiding users to change their input shapes to be consistent with the model.