### PR TITLE
Fix download.py empty line

### DIFF
--- a/python/paddle/dataset/common.py
+++ b/python/paddle/dataset/common.py
@@ -72,6 +72,9 @@ def download(url, module_name, md5sum, save_name=None):
                             url.split('/')[-1]
                             if save_name is None else save_name)
 
+    if os.path.exists(filename) and md5file(filename) == md5sum:
+        return filename
+
     retry = 0
     retry_limit = 3
     while not (os.path.exists(filename) and md5file(filename) == md5sum):


### PR DESCRIPTION
`paddle.dataset.xxx` apis would print an extra blank line even if the file has existed in local machine. This PR removes this blank line.