### PR TITLE
Refine executor bug info

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -621,11 +621,15 @@ class Executor(object):
         if self._closed:
             raise RuntimeError("Attempted to use a closed Executor")
 
+        use_default_main_program = program is None
         if program is None:
             program = default_main_program()
-        if isinstance(program,Program) and \
+        if isinstance(program, Program) and \
                         len(program.global_block().ops) == 0:
-            warnings.warn("The current program is empty.")
+            error_info = "The current program is empty."
+            if use_default_main_program:
+                error_info += " Maybe you should pass the Program or the CompiledProgram manually."
+            warnings.warn(error_info)
 
         if scope is None:
             scope = global_scope()


### PR DESCRIPTION
Refine executor bug info.

使用compiled_program时，exe.run的代码处需要显式的指定program为创建的complied_program，用户忘记指定时（普通Executor不用指定），会报“Cannot find fetch variable in scope”，让用户误以为是要fetch的variable出了问题。除非用户对paddle框架运行机制非常熟悉，否则很难联想到真实错误位置。

本PR在exe.run里加上判断的warning，如果program为空，会提示用户传入program或compiled_program。