### PR TITLE
Add free chunks to auto growth allocator

### DIFF
--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.cc
@@ -57,6 +57,7 @@ Allocation *AutoGrowthBestFitAllocator::AllocateImpl(size_t size) {
       block_it->is_free_ = false;
     }
   } else {
+    FreeIdleChunks();
     size_t realloc_size = std::max(size, chunk_size_);
 
     try {
@@ -117,6 +118,20 @@ void AutoGrowthBestFitAllocator::FreeImpl(Allocation *allocation) {
                        block_it);
 
   delete allocation;
+}
+
+void AutoGrowthBestFitAllocator::FreeIdleChunks() {
+  for (auto chunk_it = chunks_.begin(); chunk_it != chunks_.end();) {
+    auto &blocks = chunk_it->blocks_;
+    if (blocks.size() == 1) {
+      auto &block = *blocks.begin();
+      VLOG(2) << "Free chunk with size " << block.size_;
+      free_blocks_.erase(std::make_pair(block.size_, block.ptr_));
+      chunk_it = chunks_.erase(chunk_it);
+    } else {
+      ++chunk_it;
+    }
+  }
 }
 
 }  // namespace allocation

--- a/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h
+++ b/paddle/fluid/memory/allocation/auto_growth_best_fit_allocator.h
@@ -27,7 +27,7 @@ namespace allocation {
 
 class AutoGrowthBestFitAllocator : public Allocator {
  public:
-  explicit AutoGrowthBestFitAllocator(
+  AutoGrowthBestFitAllocator(
       const std::shared_ptr<Allocator> &underlying_allocator, size_t alignment,
       size_t chunk_size = 0);
 
@@ -39,6 +39,8 @@ class AutoGrowthBestFitAllocator : public Allocator {
   void FreeImpl(Allocation *allocation) override;
 
  private:
+  void FreeIdleChunks();
+
   template <typename T>
   using List = std::list<T>;
 


### PR DESCRIPTION
`AutoGrowthAllocator` would not release free idle chunks, which would make some network with input of various shapes failure. This PR tries to release free idle chunks before call `cudaMalloc`.