### PR TITLE
Expose `mutable_data` as python binding

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -235,6 +235,21 @@ PYBIND11_MODULE(core_noavx, m) {
            [](Tensor &self, paddle::platform::CUDAPinnedPlace &place) {
              self.mutable_data<float>(place);
            })
+      .def("_mutable_data",
+           [](Tensor &self, paddle::platform::CPUPlace &place,
+              paddle::framework::proto::VarType::Type type) {
+             return reinterpret_cast<uintptr_t>(self.mutable_data(place, type));
+           })
+      .def("_mutable_data",
+           [](Tensor &self, paddle::platform::CUDAPlace &place,
+              paddle::framework::proto::VarType::Type type) {
+             return reinterpret_cast<uintptr_t>(self.mutable_data(place, type));
+           })
+      .def("_mutable_data",
+           [](Tensor &self, paddle::platform::CUDAPinnedPlace &place,
+              paddle::framework::proto::VarType::Type type) {
+             return reinterpret_cast<uintptr_t>(self.mutable_data(place, type));
+           })
       .def("_clear", &Tensor::clear)
       .def("set", PyCPUTensorSetFromArray<float>)
       .def("set", PyCPUTensorSetFromArray<int>)

--- a/python/paddle/fluid/tests/unittests/test_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor.py
@@ -18,6 +18,7 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 import unittest
 import numpy
+import numbers
 
 
 class TestTensor(unittest.TestCase):
@@ -262,13 +263,18 @@ class TestTensor(unittest.TestCase):
         place = core.CPUPlace()
         tensor = var.get_tensor()
         dtype = core.VarDesc.VarType.FP32
-        self.assertTrue(isinstance(tensor._mutable_data(place, dtype), int))
+        self.assertTrue(
+            isinstance(tensor._mutable_data(place, dtype), numbers.Integral))
 
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.assertTrue(isinstance(tensor._mutable_data(place, dtype), int))
+            self.assertTrue(
+                isinstance(
+                    tensor._mutable_data(place, dtype), numbers.Integral))
             place = core.CUDAPinnedPlace()
-            self.assertTrue(isinstance(tensor._mutable_data(place, dtype), int))
+            self.assertTrue(
+                isinstance(
+                    tensor._mutable_data(place, dtype), numbers.Integral))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor.py
@@ -171,7 +171,6 @@ class TestTensor(unittest.TestCase):
         var = scope.var("test_tensor")
 
         tensor = var.get_tensor()
-
         tensor._set_dims([0, 1])
         tensor._alloc_float(place)
 
@@ -255,6 +254,21 @@ class TestTensor(unittest.TestCase):
             tensor.set(tensor_array, core.CUDAPlace(0))
             print(tensor)
             self.assertTrue(isinstance(str(tensor), str))
+
+    def test_tensor_poiter(self):
+        place = core.CPUPlace()
+        scope = core.Scope()
+        var = scope.var("test_tensor")
+        place = core.CPUPlace()
+        tensor = var.get_tensor()
+        dtype = core.VarDesc.VarType.FP32
+        self.assertTrue(isinstance(tensor._mutable_data(place, dtype), int))
+
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+            self.assertTrue(isinstance(tensor._mutable_data(place, dtype), int))
+            place = core.CUDAPinnedPlace()
+            self.assertTrue(isinstance(tensor._mutable_data(place, dtype), int))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
this commit mainly serves 2 purposes:
1. allow third party data loader (e.g., nvidia DALI) to shared data with LoD Tensors
2. allow `py_func` to pass device pointers to native functions