### PR TITLE
Fix allocator unittests

### DIFF
--- a/paddle/fluid/memory/allocation/retry_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/retry_allocator_test.cc
@@ -127,7 +127,7 @@ TEST(RetryAllocator, RetryAllocatorLastAllocFailure) {
   {
     platform::CUDAPlace p(0);
     RetryAllocator allocator(std::make_shared<CUDAAllocator>(p), retry_ms);
-    size_t allocate_size = -1UL;  // Very large number
+    size_t allocate_size = (static_cast<size_t>(1) << 40);  // Very large number
     try {
       auto allocation = allocator.Allocate(allocate_size);
       ASSERT_TRUE(false);

--- a/paddle/fluid/memory/detail/system_allocator_test.cc
+++ b/paddle/fluid/memory/detail/system_allocator_test.cc
@@ -73,7 +73,7 @@ TEST(CUDAPinnedAllocator, Alloc) {
 TEST(GPUAllocator, AllocFailure) {
   paddle::memory::detail::GPUAllocator allocator(0);
   size_t index;
-  size_t alloc_size = -1UL;  // very large size
+  size_t alloc_size = (static_cast<size_t>(1) << 40);  // Very large number
   try {
     allocator.Alloc(&index, alloc_size);
     ASSERT_TRUE(false);


### PR DESCRIPTION
Do not know why, but `cudaMalloc` would cause seg fault when allocating -1UL on some machines.