### PR TITLE
deprecate attribute force_cpu in compare_op to be false

### DIFF
--- a/paddle/fluid/API.spec
+++ b/paddle/fluid/API.spec
@@ -339,7 +339,7 @@ paddle.fluid.layers.Switch.default (ArgSpec(args=['self'], varargs=None, keyword
 paddle.fluid.layers.increment (ArgSpec(args=['x', 'value', 'in_place'], varargs=None, keywords=None, defaults=(1.0, True)), ('document', 'f88b5787bb80ae6b8bf513a70dabbdc1'))
 paddle.fluid.layers.array_write (ArgSpec(args=['x', 'i', 'array'], varargs=None, keywords=None, defaults=(None,)), ('document', '3f913b5069ad40bd85d89b33e4aa5939'))
 paddle.fluid.layers.create_array (ArgSpec(args=['dtype'], varargs=None, keywords=None, defaults=None), ('document', '556de793fdf24d515f3fc91260e2c048'))
-paddle.fluid.layers.less_than (ArgSpec(args=['x', 'y', 'force_cpu', 'cond'], varargs=None, keywords=None, defaults=(None, None)), ('document', '04af32422c3a3d8f6040aeb406c82768'))
+paddle.fluid.layers.less_than (ArgSpec(args=['x', 'y', 'force_cpu', 'cond'], varargs=None, keywords=None, defaults=(None, None)), ('document', '0283e2341a4763de29a769b966b1dd1b'))
 paddle.fluid.layers.less_equal (ArgSpec(args=['x', 'y', 'cond'], varargs=None, keywords=None, defaults=(None,)), ('document', '7b6d952a9f6340a044cfb91c16aad842'))
 paddle.fluid.layers.greater_than (ArgSpec(args=['x', 'y', 'cond'], varargs=None, keywords=None, defaults=(None,)), ('document', '55710e2fafeda70cd1b53d7509712499'))
 paddle.fluid.layers.greater_equal (ArgSpec(args=['x', 'y', 'cond'], varargs=None, keywords=None, defaults=(None,)), ('document', '14bff27b2be5e60eaa30e41925265beb'))

--- a/paddle/fluid/operators/controlflow/compare_op.cc
+++ b/paddle/fluid/operators/controlflow/compare_op.cc
@@ -56,11 +56,13 @@ class CompareOpProtoMaker : public framework::OpProtoAndCheckerMaker {
         "The start dimension index for broadcasting Y onto X. [default -1]")
         .SetDefault(-1)
         .EqualGreaterThan(-1);
-    AddAttr<bool>("force_cpu",
-                  "Force fill output variable to cpu "
-                  "memory. Otherwise, fill output variable to the running "
-                  "device [default true].")
-        .SetDefault(true);
+    AddAttr<bool>(
+        "force_cpu",
+        "If true, the output variable is forced to be filled to cpu memory. If "
+        "false [default], the output variable is forced to be filled to the "
+        "running device. This attribute is deprecated and its value is always "
+        "false.")
+        .SetDefault(false);
     AddOutput("Out", string::Sprintf("n-dim bool tensor. Each element is %s",
                                      comment.equation));
     AddComment(string::Sprintf(R"DOC(

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1025,10 +1025,7 @@ def less_than(x, y, force_cpu=None, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_cpu is not None:
-        attrs['force_cpu'] = force_cpu
-    elif force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
+    attrs['force_cpu'] = False
 
     helper.append_op(
         type='less_than',
@@ -1067,8 +1064,7 @@ def less_equal(x, y, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
+    attrs['force_cpu'] = False
 
     helper.append_op(
         type='less_equal',
@@ -1107,8 +1103,7 @@ def greater_than(x, y, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
+    attrs['force_cpu'] = False
 
     helper.append_op(
         type='greater_than',
@@ -1148,8 +1143,7 @@ def greater_equal(x, y, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
+    attrs['force_cpu'] = False
 
     helper.append_op(
         type='greater_equal',


### PR DESCRIPTION
attribute force_cpu in `compare_op` is deprecated now. This PR:
- set the attribute in `compare_op` to be false, and refine the document.
- set the `attrs['force_cpu']=false` in `less_than`, `less_equal`, `greater_than` and `greater_equal`.