### PR TITLE
improve the error message when handling ndarray with unsupported dtype 

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -458,14 +458,15 @@ class GeneratorLoader(DataLoaderBase):
                     array = core.LoDTensorArray()
                     for item in tensors:
                         if not isinstance(item, core.LoDTensor):
-                            if type(item
-                                    ) == np.ndarray and item.dtype == np.object:
+                            arr = np.array(item)
+                            if arr.dtype == np.object:
                                 raise TypeError((
-                                    "ndarray with dtype of numpy.object"
-                                    "is not supported, please assign a specific dtype. If you are "
-                                    "passing a nested list with different lengths of elements, please "
-                                    "use 'fluid.create_lod_tensor' to covert it to a LoD-Tensor. "
-                                    "Data : {0}").format(item))
+                                    "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
+                                    "this means the input data contains nested lists with different lengths. "
+                                    "\n\t* Check the reader function passed to 'decorate_batch_generator'"
+                                    " to locate the data causes this issue.\n\t* Please consider using "
+                                    "'fluid.create_lod_tensor' to convert it to a LoD-Tensor."
+                                ))
                             tmp = core.LoDTensor()
                             tmp.set(item, core.CPUPlace())
                             item = tmp

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -459,8 +459,12 @@ class GeneratorLoader(DataLoaderBase):
                     for item in tensors:
                         if not isinstance(item, core.LoDTensor):
                             if type(item) == np.ndarray:
-                                assert item.dtype != np.object, "ndarray with dtype of numpy.object is not supported, please assign a specific dtype. If you are passing a nested list with different lengths of elements, please use 'fluid.create_lod_tensor' to covert it to a LoD-Tensor. Data : {0}".format(
-                                    item)
+                                assert item.dtype != np.object, (
+                                    "ndarray with dtype of numpy.object"
+                                    "is not supported, please assign a specific dtype. If you are "
+                                    "passing a nested list with different lengths of elements, please "
+                                    "use 'fluid.create_lod_tensor' to covert it to a LoD-Tensor. "
+                                    "Data : {0}").format(item)
                             tmp = core.LoDTensor()
                             tmp.set(item, core.CPUPlace())
                             item = tmp

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -458,6 +458,9 @@ class GeneratorLoader(DataLoaderBase):
                     array = core.LoDTensorArray()
                     for item in tensors:
                         if not isinstance(item, core.LoDTensor):
+                            if type(item) == np.ndarray:
+                                assert item.dtype != np.object, "ndarray with dtype of numpy.object is not supported, please assign a specific dtype. If you are passing a nested list with different lengths of elements, please use 'fluid.create_lod_tensor' to covert it to a LoD-Tensor. Data : {0}".format(
+                                    item)
                             tmp = core.LoDTensor()
                             tmp.set(item, core.CPUPlace())
                             item = tmp

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -458,13 +458,14 @@ class GeneratorLoader(DataLoaderBase):
                     array = core.LoDTensorArray()
                     for item in tensors:
                         if not isinstance(item, core.LoDTensor):
-                            if type(item) == np.ndarray:
-                                assert item.dtype != np.object, (
+                            if type(item
+                                    ) == np.ndarray and item.dtype == np.object:
+                                raise TypeError((
                                     "ndarray with dtype of numpy.object"
                                     "is not supported, please assign a specific dtype. If you are "
                                     "passing a nested list with different lengths of elements, please "
                                     "use 'fluid.create_lod_tensor' to covert it to a LoD-Tensor. "
-                                    "Data : {0}").format(item)
+                                    "Data : {0}").format(item))
                             tmp = core.LoDTensor()
                             tmp.set(item, core.CPUPlace())
                             item = tmp

--- a/python/paddle/fluid/tests/unittests/test_py_reader_error_msg.py
+++ b/python/paddle/fluid/tests/unittests/test_py_reader_error_msg.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import unittest
+import numpy as np
+
+
+class TestPyReaderErrorMsg(unittest.TestCase):
+    def test_check_input_array(self):
+        fluid.reader.GeneratorLoader._check_input_array([
+            np.random.randint(
+                100, size=[2]), np.random.randint(
+                    100, size=[2]), np.random.randint(
+                        100, size=[2])
+        ])
+        self.assertRaises(
+            TypeError,
+            fluid.reader.GeneratorLoader._check_input_array, [
+                np.random.randint(
+                    100, size=[2]), np.random.randint(
+                        100, size=[1]), np.random.randint(
+                            100, size=[3])
+            ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
the dtype of ndarray with different lengths of elements will be set to numpy.object automatically which will then be parsed as bool by pybind:
we should force the user pass ndarray with a specific dtype(int64, float32, bool...)

![image](https://user-images.githubusercontent.com/46661762/65481066-91a65a00-dec6-11e9-86aa-1602f139854a.png)

报错示例：
![image](https://user-images.githubusercontent.com/46661762/65602345-51360180-dfd6-11e9-98ff-9c4647eb181b.png)
