### PR TITLE
Update Tensor.set() to support float16

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -400,55 +400,9 @@ PYBIND11_MODULE(core_noavx, m) {
              return reinterpret_cast<uintptr_t>(self.mutable_data(place, type));
            })
       .def("_clear", &Tensor::clear)
-      .def("set", PyCPUTensorSetFromArray<float>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<int>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<double>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<int64_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<bool>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<uint16_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<uint8_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCPUTensorSetFromArray<int8_t>, py::arg("array"),
-           py::arg("place"))
-#ifdef PADDLE_WITH_CUDA
-      .def("set", PyCUDATensorSetFromArray<float>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<int>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<double>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<int64_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<bool>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<uint16_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<uint8_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDATensorSetFromArray<int8_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<float>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<int>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<double>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<int64_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<bool>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<uint16_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<uint8_t>, py::arg("array"),
-           py::arg("place"))
-      .def("set", PyCUDAPinnedTensorSetFromArray<int8_t>, py::arg("array"),
-           py::arg("place"), R"DOC(
+      .def("set", SetTensorFromPyArray<paddle::platform::CPUPlace>, py::arg("array"), py::arg("place"))
+      .def("set", SetTensorFromPyArray<paddle::platform::CUDAPlace>, py::arg("array"), py::arg("place"))
+      .def("set", SetTensorFromPyArray<paddle::platform::CUDAPinnedPlace>, py::arg("array"), py::arg("place"), R"DOC(
         Set the data of LoDTensor on place with given numpy array.
         
         Args:
@@ -468,7 +422,7 @@ PYBIND11_MODULE(core_noavx, m) {
                 t = fluid.LoDTensor()
                 t.set(np.ndarray([5, 30]), fluid.CPUPlace())
           )DOC")
-#endif
+
       .def("shape", [](Tensor &self) { return vectorize(self.dims()); }, R"DOC(
            Return the shape of LoDTensor.
 

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -400,9 +400,12 @@ PYBIND11_MODULE(core_noavx, m) {
              return reinterpret_cast<uintptr_t>(self.mutable_data(place, type));
            })
       .def("_clear", &Tensor::clear)
-      .def("set", SetTensorFromPyArray<paddle::platform::CPUPlace>, py::arg("array"), py::arg("place"))
-      .def("set", SetTensorFromPyArray<paddle::platform::CUDAPlace>, py::arg("array"), py::arg("place"))
-      .def("set", SetTensorFromPyArray<paddle::platform::CUDAPinnedPlace>, py::arg("array"), py::arg("place"), R"DOC(
+      .def("set", SetTensorFromPyArray<paddle::platform::CPUPlace>,
+           py::arg("array"), py::arg("place"))
+      .def("set", SetTensorFromPyArray<paddle::platform::CUDAPlace>,
+           py::arg("array"), py::arg("place"))
+      .def("set", SetTensorFromPyArray<paddle::platform::CUDAPinnedPlace>,
+           py::arg("array"), py::arg("place"), R"DOC(
         Set the data of LoDTensor on place with given numpy array.
         
         Args:

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -199,8 +199,6 @@ def to_variable(value, block=None, name=None):
             stop_gradient=True)
         var = py_var._ivar.value()
         tensor = var.get_tensor()
-        if value.dtype == np.float16:
-            value = value.view(np.uint16)
         tensor.set(value, framework._current_expected_place())
         return py_var
     elif isinstance(value, framework.Variable):

--- a/python/paddle/fluid/tests/unittests/gradient_checker.py
+++ b/python/paddle/fluid/tests/unittests/gradient_checker.py
@@ -64,7 +64,7 @@ def _set_item(t, i, e, np_dtype):
         shape = np_t.shape
         np_t = np_t.flatten()
         np_t[i] = e
-        np_t = np_t.reshape(shape).view(np.uint16)
+        np_t = np_t.reshape(shape)
         t.set(np_t, place)
     elif np_dtype == np.float32:
         t._set_float_element(i, e)

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -99,7 +99,7 @@ def get_numeric_gradient(place,
             shape = numpy_tensor.shape
             numpy_tensor = numpy_tensor.flatten()
             numpy_tensor[i] = e
-            numpy_tensor = numpy_tensor.reshape(shape).view(np.uint16)
+            numpy_tensor = numpy_tensor.reshape(shape)
             tensor.set(numpy_tensor, place)
         elif tensor_to_check_dtype == np.float32:
             tensor._set_float_element(i, e)
@@ -155,11 +155,6 @@ class OpTest(unittest.TestCase):
         if not self.call_once:
             self.call_once = True
             self.dtype = data_type
-            # See the comment of np_dtype_to_fluid_dtype
-            # If the input type is uint16, we assume use float16
-            # for lodtensor dtype.
-            if self.dtype == np.uint16:
-                self.dtype == np.float16
 
     def infer_dtype_from_inputs_outputs(self, inputs, outputs):
         def infer_dtype(numpy_dict):
@@ -972,39 +967,14 @@ class OpTest(unittest.TestCase):
 
     @staticmethod
     def np_dtype_to_fluid_dtype(input):
-        """Change the dtype of float16 numpy array
-
-        numpy float16 is binded to paddle::platform::float16
-        in tensor_py.h via the help of uint16 data type since
-        the internal memory representation of float16 is
-        uint16_t in paddle and np.uint16 in numpy, which are
-        themselves binded together by pybind.
-
-        Args:
-            input: input numpy array
-
-        Returns:
-            input: The dtype of input will be changed to np.uint16 if
-                it is originally np.float16, such that the internal memory
-                of input will be reinterpreted as of dtype np.uint16.
-        """
-        if input.dtype == np.float16:
-            input.dtype = np.uint16
         return input
 
     @staticmethod
     def fluid_dtype_to_np_dtype(self, dtype):
-        """
-        See above, convert the dtype to normal type.
-        """
-        if dtype == np.uint16:
-            dtype = np.float16
         return dtype
 
     @staticmethod
     def np_value_to_fluid_value(input):
-        if input.dtype == np.float16:
-            input = input.view(np.uint16)
         return input
 
     def _get_gradient(self,

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -188,25 +188,19 @@ class OpTest(unittest.TestCase):
                 for name, np_value in self.inputs[var_name]:
                     tensor = core.LoDTensor()
                     if isinstance(np_value, tuple):
-                        tensor.set(
-                            OpTest.np_value_to_fluid_value(np_value[0]), place)
+                        tensor.set(np_value[0], place)
                         tensor.set_recursive_sequence_lengths(np_value[1])
                     else:
-                        tensor.set(
-                            OpTest.np_value_to_fluid_value(np_value), place)
+                        tensor.set(np_value, place)
                     feed_map[name] = tensor
             else:
                 tensor = core.LoDTensor()
                 if isinstance(self.inputs[var_name], tuple):
-                    tensor.set(
-                        OpTest.np_value_to_fluid_value(self.inputs[var_name][
-                            0]), place)
+                    tensor.set(self.inputs[var_name][0], place)
                     tensor.set_recursive_sequence_lengths(self.inputs[var_name][
                         1])
                 else:
-                    tensor.set(
-                        OpTest.np_value_to_fluid_value(self.inputs[var_name]),
-                        place)
+                    tensor.set(self.inputs[var_name], place)
                 feed_map[var_name] = tensor
 
         return feed_map

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -43,8 +43,7 @@ class TestCastOp1(op_test.OpTest):
 class TestCastOp2(op_test.OpTest):
     def setUp(self):
         ipt = np.random.random(size=[10, 10])
-        # numpy float16 is binded to fluid float16 via uint16
-        self.inputs = {'X': ipt.astype('float16').view(np.uint16)}
+        self.inputs = {'X': ipt.astype('float16')}
         self.outputs = {'Out': ipt.astype('float32')}
         self.attrs = {
             'in_dtype': int(core.VarDesc.VarType.FP16),

--- a/python/paddle/fluid/tests/unittests/test_fake_quantize_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fake_quantize_op.py
@@ -132,10 +132,9 @@ class TestFakeQuantizeRangeAbsMaxOp2(OpTest):
         }
         x = (np.random.random((8, 16, 7, 7)) - 0.5) * 10
         x = x.astype("float32")
-        scale = np.max(np.abs(x)).astype("float32") - 1.0
+        scale = np.array([np.max(np.abs(x)).astype("float32") - 1.0])
         out_scales = np.zeros(self.attrs['window_size']).astype("float32")
         out_scales[0] = scale
-
         self.inputs = {
             'X': x,
             'Iter': np.zeros(1).astype("int64"),

--- a/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
+++ b/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
@@ -71,7 +71,7 @@ class TestResnet(TestParallelExecutorBase):
     def check_model(self, use_cuda):
         img, label = init_data(
             batch_size=batch_size, img_shape=img_shape, label_range=9)
-        img = np.float16(img).view(np.uint16)
+        img = np.float16(img)
         feed_dict = {"image": img, "label": label}
 
         TestParallelExecutorBase.check_network_convergence(

--- a/python/paddle/fluid/tests/unittests/test_mse_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_mse_loss.py
@@ -34,16 +34,14 @@ class TestMseLoss(unittest.TestCase):
         input_var = layers.create_tensor(dtype="float32", name="input")
         label_var = layers.create_tensor(dtype="float32", name="label")
 
-        layers.assign(input=input_val, output=input_var)
-        layers.assign(input=label_val, output=label_var)
         output = layers.mse_loss(input=input_var, label=label_var)
         for use_cuda in ([False, True]
                          if core.is_compiled_with_cuda() else [False]):
             place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
             exe = Executor(place)
             result = exe.run(fluid.default_main_program(),
-                             feed={"input": input_var,
-                                   "label": label_var},
+                             feed={"input": input_val,
+                                   "label": label_val},
                              fetch_list=[output])
 
             self.assertTrue(np.isclose(np_result, result).all())

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -128,10 +128,7 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
 
         loss = cross_entropy(softmax, labels, self.soft_label, self.axis)
 
-        self.inputs = {
-            "Logits": logits.astype(self.dtype).view(np.uint16),
-            "Label": labels
-        }
+        self.inputs = {"Logits": logits.astype(self.dtype), "Label": labels}
         self.outputs = {
             "Softmax": softmax.astype(self.dtype),
             "Loss": loss.astype(self.dtype)

--- a/python/paddle/fluid/tests/unittests/test_square_error_cost.py
+++ b/python/paddle/fluid/tests/unittests/test_square_error_cost.py
@@ -33,9 +33,6 @@ class TestSquareErrorCost(unittest.TestCase):
 
         input_var = layers.create_tensor(dtype="float32", name="input")
         label_var = layers.create_tensor(dtype="float32", name="label")
-
-        layers.assign(input=input_val, output=input_var)
-        layers.assign(input=label_val, output=label_var)
         output = layers.square_error_cost(input=input_var, label=label_var)
 
         for use_cuda in ([False, True]
@@ -44,8 +41,8 @@ class TestSquareErrorCost(unittest.TestCase):
             place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
             exe = Executor(place)
             result = exe.run(fluid.default_main_program(),
-                             feed={"input": input_var,
-                                   "label": label_var},
+                             feed={"input": input_val,
+                                   "label": label_val},
                              fetch_list=[output])
 
             self.assertTrue(np.isclose(np_result, result).all())


### PR DESCRIPTION
Original implementation of Tensor.set() use template specialization to support different dtype, like int, float. It has some problems:

- It expose 24 APIs in total.

- Since float16 is not a builtin type in C++, Paddle uses uint16_t to 'represent' float16
in [PR9017](https://github.com/PaddlePaddle/Paddle/pull/9017). As a result, numpy.float16 is set to float32, and uint16 is set to float16.  This is not convenient and may cause errors if users don't know.
![image](https://user-images.githubusercontent.com/6888866/65592330-f8a83980-dfc0-11e9-89db-e59035f5d4ac.png)

This PR did the followings.


- Registers `paddle::platform::float16` as `numpy.float16`, so users can feed float16 tensor directly, no need to view as uint16. For compatibility, keeps uint16-float16 hacking temporarily.

- Reduces the  number of set() API to 3, 

- Updates some unit tests (test_npair_loss_op.py, test_square_error_cost.py, test_mse_loss.py), which feed Variable to program.

