### PR TITLE
Disable fuse_all_optimizer_ops

### DIFF
--- a/paddle/fluid/framework/details/build_strategy.h
+++ b/paddle/fluid/framework/details/build_strategy.h
@@ -89,7 +89,7 @@ struct BuildStrategy {
   bool fuse_elewise_add_act_ops_{false};
   // Fuse_all_optimizer_ops and fuse_all_reduce_ops require that gradients
   // should not be sparse types
-  boost::optional<bool> fuse_all_optimizer_ops_{boost::none};
+  boost::optional<bool> fuse_all_optimizer_ops_{false};
   boost::optional<bool> fuse_all_reduce_ops_{boost::none};
   // fuse_relu_depthwise_conv can fuse the `relu ->
   // depthwise_conv`


### PR DESCRIPTION
Temporally disable fuse_all_optimizer_ops, because in some case, the parameter's gradients of the model are in different Place, for example, g0 and g1 are in CPU but g2 and g3 are in GPU0, this is because the generation op of g0 and g1 only have CPU kernel, in this case, the current implementation of fuse_all_optimizer_ops can not deal with it.