### PR TITLE
Reduce bug fix

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -197,6 +197,9 @@ class ReduceOp : public framework::OperatorWithKernel {
             remove(dims_vector.begin(), dims_vector.end(), kDelFlag),
             dims_vector.end());
       }
+      if (!keep_dim && dims_vector.size() == 0) {
+        dims_vector.push_back(1);
+      }
       auto out_dims = framework::make_ddim(dims_vector);
       ctx->SetOutputDim("Out", out_dims);
       if (dims[0] != 0) {

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -397,5 +397,19 @@ class TestReduceAll(OpTest):
         self.check_grad(['X'], 'Out')
 
 
+class Test1DReduceWithAxes1(OpTest):
+    def setUp(self):
+        self.op_type = "reduce_sum"
+        self.inputs = {'X': np.random.random(1).astype("float64")}
+        self.attrs = {'dim': [0], 'keep_dim': False}
+        self.outputs = {'Out': self.inputs['X'].sum(axis=0)}
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad(self):
+        self.check_grad(['X'], 'Out')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
reduce_max/reduce_min/reduce_mean/reduce_sum/reduce_any/reduce_all/reduce_prod 等系列op，若input是1维tensor，dim=[0]，keep_dim=False，反向梯度计算会报错：

这种情况下，应该等价于dim=None的情况。

