### PR TITLE
refine the ifelse op error log info.

### DIFF
--- a/paddle/fluid/operators/merge_lod_tensor_op.cc
+++ b/paddle/fluid/operators/merge_lod_tensor_op.cc
@@ -190,9 +190,23 @@ class MergeLoDTensorInferShape : public framework::InferShapeBase {
                    "MergeLoDTensorOp must has output Out");
 
     auto mask_dim = context->GetInputDim("Mask");
-    PADDLE_ENFORCE_EQ(mask_dim.size(), 2);
+    PADDLE_ENFORCE_EQ(mask_dim.size(), 2,
+                      "If you are using IfElse OP:"
+                      "\n\nie = fluid.layers.IfElse(cond=cond)\nwith "
+                      "ie.true_block():\n    out_1 = ie.input(x)\n\n"
+                      "Please ensure that the cond should be a 2-D tensor and "
+                      "the second dim size of cond should be 1. "
+                      "But now the cond's shape is [",
+                      *mask_dim.Get(), "].\n");
     if (context->IsRuntime() || mask_dim[1] > 0) {
-      PADDLE_ENFORCE_EQ(mask_dim[1], 1);
+      PADDLE_ENFORCE_EQ(mask_dim[1], 1,
+                        "If you are using IfElse OP:"
+                        "\n\nie = fluid.layers.IfElse(cond=cond)\nwith "
+                        "ie.true_block():\n    out_1 = ie.input(x)\n\n"
+                        "Please ensure that the cond should be a 2-D tensor "
+                        "and the second dim size of cond should be 1. "
+                        "But now the cond's shape is [",
+                        *mask_dim.Get(), "].\n");
     }
 
     context->SetOutputDim("Out", context->GetInputDim("InTrue"));

--- a/paddle/fluid/operators/split_lod_tensor_op.cc
+++ b/paddle/fluid/operators/split_lod_tensor_op.cc
@@ -156,9 +156,23 @@ class SplitLoDTensorInferShape : public framework::InferShapeBase {
                    "SplitLoDTensorOp must has output OutFalse.");
 
     auto mask_dim = context->GetInputDim("Mask");
-    PADDLE_ENFORCE_EQ(mask_dim.size(), 2);
+    PADDLE_ENFORCE_EQ(mask_dim.size(), 2,
+                      "If you are using IfElse OP:"
+                      "\n\nie = fluid.layers.IfElse(cond=cond)\nwith "
+                      "ie.true_block():\n    out_1 = ie.input(x)\n\n"
+                      "Please ensure that the cond should be a 2-D tensor and "
+                      "the second dim size of cond should be 1. "
+                      "But now the cond's shape is [",
+                      *mask_dim.Get(), "].\n");
     if (context->IsRuntime()) {
-      PADDLE_ENFORCE_EQ(mask_dim[1], 1);
+      PADDLE_ENFORCE_EQ(mask_dim[1], 1,
+                        "If you are using IfElse OP:"
+                        "\n\nie = fluid.layers.IfElse(cond=cond)\nwith "
+                        "ie.true_block():\n    out_1 = ie.input(x)\n\n"
+                        "Please ensure that the cond should be a 2-D tensor "
+                        "and the second dim size of cond should be 1. "
+                        "But now the cond's shape is [",
+                        *mask_dim.Get(), "].\n");
     }
 
     context->SetOutputDim("OutTrue", context->GetInputDim("X"));


### PR DESCRIPTION
https://github.com/PaddlePaddle/Paddle/issues/19832
if we run the code following:

```
import numpy as np
import paddle.fluid as fluid

a = np.array([3, 5, -1, -3]).astype(np.float32)

out = fluid.layers.create_tensor("float32")
fluid.layers.assign(a, out)

out_zeros = fluid.layers.zeros_like(out)
cond = fluid.layers.greater_than(out, out_zeros)

ie = fluid.layers.IfElse(cond)
with ie.true_block():
    out_great = ie.input(out)
    ie.output(out_great)
    
with ie.false_block():
    out_less = ie.input(out)
    ie.output(out_less + 10)

output = ie()

exe = fluid.Executor(fluid.CPUPlace())
exe.run(fluid.default_startup_program())
res = exe.run(fluid.default_main_program(), fetch_list=[output[0]])
print res
```

the original bug info is: 

```
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/layers/control_flow.py", line 1650, in input
    attrs={'level': 0})
  File "test.py", line 16, in <module>
    out_great = ie.input(out)
C++ Call stacks: 
Enforce failed. Expected mask_dim.size() == 2, but received mask_dim.size():1 != 2:2.
 at [/paddle/paddle_anakin_many_linux2/paddle/fluid/operators/split_lod_tensor_op.cc:159]
PaddlePaddle Call Stacks: 
0       0x7f444f6bd23dp std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > paddle::platform::GetTraceBackString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, int) + 509
```

now: 

```
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/layers/control_flow.py", line 1650, in input
    attrs={'level': 0})
  File "test.py", line 16, in <module>
    out_great = ie.input(out)
C++ Call stacks: 
Enforce failed. Expected mask_dim.size() == 2, but received mask_dim.size():1 != 2:2.
If you are using IfElse OP:

ie = fluid.layers.IfElse(cond=cond)
with ie.true_block():
    out_1 = ie.input(x)

Please ensure that the cond should be a 2-D tensor and the second dim size of cond should be 1. But now the cond's shape is [4].
 at [/paddle/paddle_anakin_many_linux2/paddle/fluid/operators/split_lod_tensor_op.cc:164]

```