### PR TITLE
add input type and dtype check for softmax_op

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2252,11 +2252,11 @@ def softmax(input, use_cudnn=False, name=None, axis=-1):
     helper = LayerHelper('softmax', **locals())
     if not isinstance(input, Variable):
         raise TypeError(
-            "The type of input in softmax must be Variable, but received %s" %
+            "The type of 'input' in softmax must be Variable, but received %s" %
             (type(input)))
     if convert_dtype(input.dtype) not in ['float32', 'float64']:
         raise TypeError(
-            "The data type of input in softmax must be float32 or float64, but received %s."
+            "The data type of 'input' in softmax must be float32 or float64, but received %s."
             % (convert_dtype(input.dtype)))
 
     dtype = helper.input_dtype()

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -34,6 +34,7 @@ from .. import unique_name
 from functools import reduce
 from .. import core
 from ..dygraph import layers
+from ..data_feeder import convert_dtype
 
 __all__ = [
     'fc',
@@ -2249,6 +2250,15 @@ def softmax(input, use_cudnn=False, name=None, axis=-1):
 
     """
     helper = LayerHelper('softmax', **locals())
+    if not isinstance(input, Variable):
+        raise TypeError(
+            "The type of input in softmax must be Variable, but received %s" %
+            (type(input)))
+    if convert_dtype(input.dtype) not in ['float32', 'float64']:
+        raise TypeError(
+            "The data type of input in softmax must be float32 or float64, but received %s."
+            % (convert_dtype(input.dtype)))
+
     dtype = helper.input_dtype()
     softmax_out = helper.create_variable_for_type_inference(dtype)
     helper.append_op(

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -18,6 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 def stable_softmax(x):
@@ -72,6 +74,18 @@ class TestSoftmaxOp(OpTest):
                     place, ["X"], "Out", max_relative_error=0.01)
         else:
             self.check_grad(["X"], "Out", max_relative_error=0.01)
+
+
+class TestSoftmaxOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of softmax_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.softmax, x1)
+            # The input dtype of softmax_op must be float32 or float64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.softmax, x2)
 
 
 class TestSoftmaxOp2(TestSoftmaxOp):


### PR DESCRIPTION
为softmax python api的输入input加类型检查：
- 检查类型是否为Variable
- 检查数据类型是否为float32和float64
- 在单测中覆盖类型错误和数据类型错误两个异常情况
- 可手动运行示例，看下错误：
```
import paddle.fluid as fluid
x1 = fluid.create_lod_tensor(np.array([[-1]]), [[1]], fluid.CPUPlace())
fluid.layers.softmax(x1)
# TypeError: The type of ‘input’ in softmax must be Variable, but received <class 'paddle.fluid.core_avx.LoDTensor'>

import paddle.fluid as fluid
x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
fluid.layers.softmax(x2)
#TypeError: The data type of ‘input’ in softmax must be float32 or float64, but received int32.
```

注意：
1. 由于softmax的其他参数如use_cudnn, axis比较简单，本PR只检查input
2. 需要用单引号把输入'input'括起来，和input区分，避免用户不知道是哪个输入。其他输入名字如X，Y，也需要括起来。
