### PR TITLE
enhance shape error message of mul_op

### DIFF
--- a/paddle/fluid/operators/mul_op.cc
+++ b/paddle/fluid/operators/mul_op.cc
@@ -47,23 +47,27 @@ class MulOp : public framework::OperatorWithKernel {
             << " x_num_col_dims=" << x_num_col_dims
             << " y_num_col_dims=" << y_num_col_dims;
 
-    PADDLE_ENFORCE_GT(
-        x_dims.size(), x_num_col_dims,
-        "The input tensor X's rank of MulOp should be larger than "
-        "x_num_col_dims.");
-    PADDLE_ENFORCE_GT(
-        y_dims.size(), y_num_col_dims,
-        "The input tensor Y's rank of MulOp should be larger than "
-        "y_num_col_dims: %ld vs %ld",
-        y_dims.size(), y_num_col_dims);
+    PADDLE_ENFORCE_GT(x_dims.size(), x_num_col_dims,
+                      "ShapeError: The input tensor X's dimensions of MulOp "
+                      "should be larger than x_num_col_dims. But received X's "
+                      "dimensions = %d, X's shape = [%s], x_num_col_dims = %d.",
+                      x_dims.size(), x_dims, x_num_col_dims);
+    PADDLE_ENFORCE_GT(y_dims.size(), y_num_col_dims,
+                      "ShapeError: The input tensor Y's dimensions of MulOp "
+                      "should be larger than y_num_col_dims. But received Y's "
+                      "dimensions = %d, Y's shape = [%s], y_num_col_dims = %d.",
+                      y_dims.size(), y_dims, y_num_col_dims);
 
     auto x_mat_dims = framework::flatten_to_2d(x_dims, x_num_col_dims);
     auto y_mat_dims = framework::flatten_to_2d(y_dims, y_num_col_dims);
 
-    PADDLE_ENFORCE_EQ(x_mat_dims[1], y_mat_dims[0],
-                      "First matrix's width must be equal with second matrix's "
-                      "height. %s, %s",
-                      x_mat_dims[1], y_mat_dims[0]);
+    PADDLE_ENFORCE_EQ(
+        x_mat_dims[1], y_mat_dims[0],
+        "ShapeError: After flatten the input tensor X and Y to 2-D dimensions "
+        "matrix X1 and Y1, the matrix X1's width must be equal with matrix "
+        "Y1's height. But received X's shape = [%s], X1's shape = [%s], X1's "
+        "width = %s; Y's shape = [%s], Y1's shape = [%s], Y1's height = %s.",
+        x_dims, x_mat_dims, x_mat_dims[1], y_dims, y_mat_dims, y_mat_dims[0]);
     std::vector<int64_t> output_dims;
     output_dims.reserve(
         static_cast<size_t>(x_num_col_dims + y_dims.size() - y_num_col_dims));


### PR DESCRIPTION
增强维度类报错信息的示例：
### 涉及维度的所有报错（包括比较共多少维、比较其中一维等），都需要打出具体的维度信息，方便用户查看。
```
x=fluid.layers.data(name='x', append_batch_size = False, shape=[2, 5], dtype='float64')
y=fluid.layers.data(name='y', append_batch_size = False, shape=[5, 3], dtype='float64')
mul=fluid.layers.mul(x=x, y=y, x_num_col_dims=2)
```
- 修改前报错: 仅有一句话，没说X的维度是什么， x_num_col_dims是什么
```
The input tensor X's rank of MulOp should be larger than x_num_col_dims.
```
- 修改后报错：打出具体X共2维，shape是多少，x_num_col_dims是多少。
```
ShapeError: The input tensor X's dimensions of MulOp should be larger than x_num_col_dims. But 
received X's dimensions = 2, X's shape = [2, 5], x_num_col_dims = 2.
```
### 如果维度做了一些变化，需要打出原始维度和变化后维度的具体信息，方便用户查看。
```
x=fluid.layers.data(name='x', append_batch_size = False, shape=[2, 5, 4, 3], dtype='float64')
y=fluid.layers.data(name='y', append_batch_size = False, shape=[2, 4, 4, 3], dtype='float64')
mul=fluid.layers.mul(x=x, y=y, x_num_col_dims=2, y_num_col_dims=2)
```
- 修改前报错: 只说修改后第一个矩阵的宽对应补上第二个矩阵的高，宽是12，高是8。对用户来说，无法和输入的shape联系上。
```
First matrix's width must be equal with second matrix's height. 12, 8. 
```
- 修改后报错：打出做了flatten前后X和Y的shape变化，指出具体哪一维出错。
```
ShapeError: After flatten the input tensor X and Y to 2-D dimensions matrix X1 and Y1. The matrix
 X1's width must be equal with matrix Y1's height. But received X's shape = [2, 5, 4, 3], X1's shape 
= [10, 12], X1's width = 12, Y's shape = [2, 4, 4, 3], Y1's shape = [8, 12], Y1's height = 8.
```
### Shape报错信息格式规范
```
ShapeError: 检查内容. But received 现状。
```
- 统一以`ShapeError: `开头，先报出是类型错误。
- 其次打印检查的内容，即哪里失败了。
- 最后用`But received`开头，报出现有的类型信息。
- 尽量用简单的词汇，如dimensions比rank更容易懂。