### PR TITLE
Fix math_op_patch division between integers

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -143,7 +143,11 @@ def monkey_patch_variable():
                                   reverse=False,
                                   scalar_method=None):
         def __impl__(self, other_var):
-            if scalar_method is not None:
+            # FIXME(zjl): elementwise_div between integers cannot be converted to scale,
+            # which may lose accuracy. This is a hot fix for release 1.6.
+            if scalar_method is not None and not (
+                    op_type == 'elementwise_div' and
+                    self.dtype in _supported_int_dtype_):
                 if isinstance(other_var, float):
                     if self.dtype in _supported_int_dtype_:
                         assert other_var == int(other_var), \

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch.py
@@ -186,6 +186,20 @@ class TestMathOpPatches(unittest.TestCase):
                        fetch_list=[c])
         self.assertTrue(numpy.allclose(a_np - b_np, c_np))
 
+    @prog_scope()
+    def test_integer_div(self):
+        a = fluid.layers.data(name="a", shape=[1], dtype='int64')
+        b = a / 7
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        a_np = numpy.array([3, 4, 10, 14, 9, 18]).astype('int64')
+        b_np, = exe.run(fluid.default_main_program(),
+                        feed={"a": a_np},
+                        fetch_list=[b])
+
+        b_np_actual = (a_np / 7).astype('int64')
+        self.assertTrue(numpy.array_equal(b_np, b_np_actual))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The previous implementation of `a / 7` would be converted to `scale(a, 1.0/7)`. But inside `scale` op, `1.0/7` would be cast to be `0` when `a` is a Tensor of integers, which loses accuracy.

This PR is a hot fix of math_op_path division between integers. 