### PR TITLE
Turn off fuse_all_reduce_ops in the test_quantization_pass UT.

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -178,3 +178,5 @@ list(REMOVE_ITEM TEST_OPS qat_int8_comparison.py)
 foreach(src ${TEST_OPS})
     py_test(${src} SRCS ${src}.py)
 endforeach()
+
+set_tests_properties(test_quantization_pass PROPERTIES LABELS "RUN_TYPE=DIST")

--- a/python/paddle/fluid/contrib/slim/tests/test_quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quantization_pass.py
@@ -27,8 +27,7 @@ from paddle.fluid.contrib.slim.quantization import TransformForMobilePass
 from paddle.fluid.contrib.slim.quantization import AddQuantDequantPass
 from paddle.fluid import core
 
-os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-os.environ["CPU_NUM"] = "1"
+os.environ["CPU_NUM"] = "2"
 
 
 def linear_fc(num):
@@ -283,6 +282,7 @@ class TestQuantizationFreezePass(unittest.TestCase):
         build_strategy = fluid.BuildStrategy()
         build_strategy.memory_optimize = False
         build_strategy.enable_inplace = False
+        build_strategy.fuse_all_reduce_ops = False
         binary = fluid.CompiledProgram(main_graph.graph).with_data_parallel(
             loss_name=loss.name, build_strategy=build_strategy)
         quantized_test_program = test_graph.to_program()


### PR DESCRIPTION
* Use multi-cards to run the test_quantization_pass UT.
* The fuse_all_reduce_ops have some bugs, and need to be fixed.