### PR TITLE
Updated AUTHORS from PP Poland

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -16,15 +16,17 @@
 | gongweibao | Wei-Bao Gong |
 | guru4elephant | Daxiang Dong |
 | Guo Sheng | Sheng Guo |
+| [grygielski](https://raw.githubusercontent.com/jczaja/Paddle/paddle-poland-team/doc/images/paddle_poland_team.jpg)| Adam Grygielski |
 | Haichao-Zhang | Hai-Chao Zhang |
 | hedaoyuan | Dao-Yuan He |
 | helinwang | He-Lin Wang |
 | jacquesqiao | Long-Fei Qiao |
-| jczaja | Jacek Czaja |
+| [jczaja](https://raw.githubusercontent.com/jczaja/Paddle/paddle-poland-team/doc/images/paddle_poland_team.jpg) | Jacek Czaja |
 | JiayiFeng | Jia-Yi Feng |
 | kbinias | Krzysztof Binias |
 | kexinzhao | Ke-Xin Zhao |
 | kuke | Yi-Bing Liu |
+| [lidanqing](https://raw.githubusercontent.com/jczaja/Paddle/paddle-poland-team/doc/images/paddle_poland_team.jpg) | DanQing Li |
 | lcy-seso | Ying Cao |
 | cjld | Dun Liang |
 | lipeng-unisound | Peng Li |
@@ -42,11 +44,12 @@
 | pengli09 | Peng Li |
 | pkuyym | Ya-Ming Yang |
 | pzelazko-intel | Pawel Zelazko |
+| [pawelpiotrowicz](https://raw.githubusercontent.com/jczaja/Paddle/paddle-poland-team/doc/images/paddle_poland_team.jpg)  | Pawel Piotrowicz |
 | QiJune | Jun Qi |
 | qingqing01 | Qing-Qing Dang |
 | reyoung | Yang Yu |
-| Sand3r- | Michal Gallus |
-| sfraczek | Sylwester Fraczek |
+| [Sand3r-](https://raw.githubusercontent.com/jczaja/Paddle/paddle-poland-team/doc/images/paddle_poland_team.jpg)| Michal Gallus |
+| [sfraczek](https://raw.githubusercontent.com/jczaja/Paddle/paddle-poland-team/doc/images/paddle_poland_team.jpg)| Sylwester Fraczek |
 | sneaxiy | Jin-Le Zeng |
 | Superjom | Chun-Wei Yan |
 | tensor-tang | Jian Tang |
@@ -59,6 +62,7 @@
 | wangzhen-nlp | Zhen Wang |
 | wen-bo-yang | Wen-Bo Yang |
 | wojtuss | Wojciech Uss |
+| wozna | Joanna Wozna |
 | wwhu | Wei-Wei Hu |
 | xinghai-sun | Xing-Hai Sun |
 | Xreki | Yi-Qun Liu |


### PR DESCRIPTION
This PR is updating Paddle authors list and additionaly introducing group picture from our recent paddle like integration event.

Rendered version:
https://github.com/jczaja/Paddle/blob/prv-paddle-poland-team/AUTHORS.md

@grygielski , @wozna , @marekstrachacki, @pawelpiotrowicz ,@trochumski, @ddokupil, @lidanqing-intel  Please review
