### PR TITLE
Add dtype for coalesce_tensor_op

### DIFF
--- a/paddle/fluid/framework/ir/coalesce_grad_tensor_pass.cc
+++ b/paddle/fluid/framework/ir/coalesce_grad_tensor_pass.cc
@@ -492,7 +492,7 @@ class CoalesceGradTensorPass : public ir::Pass {
     op_desc->SetInput("Input", params_name);
     op_desc->SetOutput("Output", grads_name);
     op_desc->SetOutput("FusedOutput", {fused_var_name});
-    op_desc->SetAttr("dtype", dtype);
+    op_desc->SetAttr("dtype", static_cast<int>(dtype));
   }
 };
 }  // namespace ir

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.h
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.h
@@ -64,27 +64,36 @@ class FuseOptimizerOpPass : public ir::Pass {
   void AppendAllocContinuousSpace(const std::vector<std::string> &in_args,
                                   const std::vector<std::string> &out_args,
                                   const std::string &fused_out_arg,
+                                  const proto::VarType::Type &dtype,
                                   BlockDesc *global_block, bool copy_data,
                                   bool check_name = true) const;
 
   void InitFusedGradsAndAllocSpaceForGrads(
       const std::vector<std::string> &params,
       const std::vector<std::string> &grads, const std::string &fused_grad_name,
-      ir::Graph *result) const;
+      const proto::VarType::Type &dtype, ir::Graph *result) const;
 
   void InitFusedVarsAndAllocSpaceForVars(
       const std::vector<std::string> &aux_var_names,
       const std::unordered_map<std::string, std::vector<std::string>>
           &aux_var_set,
       const std::unordered_map<std::string, std::string> &fused_vars_name,
-      ir::Graph *result) const;
+      const proto::VarType::Type &dtype, ir::Graph *result) const;
 
   std::unordered_map<std::string, std::vector<Node *>> GetVarInfo(
       const Graph &result) const;
 
+  proto::VarType::Type GetDtypeOfVar(
+      const std::unordered_map<std::string, std::vector<ir::Node *>> &vars_info,
+      const std::string &name) const;
+
   proto::VarType::Type GetTypeOfVar(
       const std::unordered_map<std::string, std::vector<Node *>> &var_nodes,
       const std::string &name) const;
+
+  const VarDesc *GetVarDescFromVarsInfo(
+      const std::unordered_map<std::string, std::vector<Node *>> &vars_info,
+      const std::string &var_name) const;
 
   void GradientsFilter(const std::vector<size_t> &new_grad_idx,
                        std::vector<Node *> *opt_nodes,

--- a/paddle/fluid/operators/coalesce_tensor_op.cc
+++ b/paddle/fluid/operators/coalesce_tensor_op.cc
@@ -164,7 +164,7 @@ class AllocContinuousSpaceOpMaker : public framework::OpProtoAndCheckerMaker {
               "(LoDTensor) The output tensor "
               "of coalesce_tensor operator. And the tensors of"
               " Output is sliced from the tensor of FusedOutput.");
-    AddAttr<int>("dtype", "input data type");
+    AddAttr<int>("dtype", "The output data type.");
     AddAttr<bool>("copy_data", "Whether to copy the Input value to Output.")
         .SetDefault(false);
     AddAttr<bool>("set_constant",

--- a/paddle/fluid/operators/coalesce_tensor_op.cc
+++ b/paddle/fluid/operators/coalesce_tensor_op.cc
@@ -23,9 +23,6 @@
 namespace paddle {
 namespace operators {
 
-static framework::proto::VarType::Type kDefaultDtype =
-    framework::proto::VarType::Type::VarType_Type_BOOL;
-
 template <typename DeviceContext, typename T>
 class CoalesceTensorOp : public framework::OpKernel<T> {
  public:
@@ -66,8 +63,10 @@ class CoalesceTensorOp : public framework::OpKernel<T> {
 
     // Get numel and dtype
     size_t numel = 0;
-    auto dtype = kDefaultDtype;
-    GetMemSizeAndDtype(in_tensors, in_var_names, &numel, &dtype,
+    auto dtype = static_cast<framework::proto::VarType::Type>(
+        context.Attr<int>("dtype"));
+    size_t size_of_dtype = framework::SizeOfType(dtype);
+    GetMemSizeAndDtype(in_tensors, in_var_names, &numel, size_of_dtype,
                        context.GetPlace());
 
     // Alloc the continuous space
@@ -78,7 +77,6 @@ class CoalesceTensorOp : public framework::OpKernel<T> {
     // Init the continuous space
     auto out_tensors = context.MultiOutput<framework::LoDTensor>("Output");
     size_t offset = 0;
-    size_t size_of_dtype = framework::SizeOfType(dtype);
     if (context.Attr<bool>("copy_data")) {
       for (size_t i = 0; i < in_var_names.size(); ++i) {
         size_t len = static_cast<size_t>(in_tensors[i]->numel());
@@ -120,26 +118,14 @@ class CoalesceTensorOp : public framework::OpKernel<T> {
   void GetMemSizeAndDtype(
       const std::vector<const framework::LoDTensor *> &lod_tensors,
       const std::vector<std::string> var_names, size_t *numel,
-      framework::proto::VarType::Type *dtype,
-      const platform::Place &place) const {
+      const size_t &size_of_dtype, const platform::Place &place) const {
     PADDLE_ENFORCE_EQ(lod_tensors.size(), var_names.size());
     *numel = 0;
-    size_t size_of_dtype = 0;
-
     std::stringstream ss;
     ss << "alloc_space_for_vars: ";
     for (size_t i = 0; i < var_names.size(); ++i) {
       PADDLE_ENFORCE(lod_tensors[i]->IsInitialized(), "%s is not initialized.",
                      var_names[i]);
-
-      auto p_dtype = lod_tensors[i]->type();
-      if (*dtype == kDefaultDtype) {
-        PADDLE_ENFORCE_NE(p_dtype, kDefaultDtype, "%s's type should not be %s.",
-                          var_names[i], kDefaultDtype);
-        *dtype = p_dtype;
-        size_of_dtype = framework::SizeOfType(p_dtype);
-      }
-      PADDLE_ENFORCE_EQ(p_dtype, *dtype, "Input vars is not equal.");
 
       auto size = lod_tensors[i]->numel();
       PADDLE_ENFORCE_GT(size, 0);
@@ -178,6 +164,7 @@ class AllocContinuousSpaceOpMaker : public framework::OpProtoAndCheckerMaker {
               "(LoDTensor) The output tensor "
               "of coalesce_tensor operator. And the tensors of"
               " Output is sliced from the tensor of FusedOutput.");
+    AddAttr<int>("dtype", "input data type");
     AddAttr<bool>("copy_data", "Whether to copy the Input value to Output.")
         .SetDefault(false);
     AddAttr<bool>("set_constant",

--- a/python/paddle/fluid/tests/unittests/test_coalesce_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_coalesce_tensor_op.py
@@ -25,7 +25,7 @@ alignment = 256
 class TestAllocContinuousSpace(OpTest):
     def setUp(self):
         self.op_type = "coalesce_tensor"
-        self.dtype = np.float32
+        self.dtype, self.fluid_dtype = self.init_dtype()
         attrs = self.init_attr()
         self.copy_data = attrs["copy_data"]
         self.constant = attrs["constant"]
@@ -38,7 +38,7 @@ class TestAllocContinuousSpace(OpTest):
         self.outputs = {'Output': self.Outputs, 'FusedOutput': self.FusedOutput}
 
     def init_dtype(self):
-        self.dtype = np.float32
+        return np.float32, int(core.VarDesc.VarType.FP32)
 
     def init_input(self):
         inputs = []
@@ -51,7 +51,12 @@ class TestAllocContinuousSpace(OpTest):
         return inputs
 
     def init_attr(self):
-        return {"copy_data": True, "set_constant": False, "constant": 0.0}
+        return {
+            "copy_data": True,
+            "set_constant": False,
+            "constant": 0.0,
+            "dtype": self.fluid_dtype
+        }
 
     def init_output(self, input_list, set_constant, constant):
         inputs = []
@@ -82,7 +87,12 @@ class TestAllocContinuousSpace(OpTest):
 
 class TestAllocContinuousSpace2(TestAllocContinuousSpace):
     def init_attr(self):
-        return {"copy_data": False, "set_constant": True, "constant": 0.5}
+        return {
+            "copy_data": False,
+            "set_constant": True,
+            "constant": 0.5,
+            "dtype": self.fluid_dtype
+        }
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():


### PR DESCRIPTION
Add dtype in coalesce_tensor_op, because the output data type may be different from the data type of the input tensors.