### PR TITLE
add a new interface _prune_with_input

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3396,7 +3396,7 @@ class Program(object):
         Args:
             targets(list|Variable|Operator): A list of variables or operators
                 need to be pruned
-            feeded_var_names(list|string|None): A list of variable names from where
+            feeded_var_names(list|str|None): A list of variable names from where
                 pruning start
 
         Returns:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3440,7 +3440,8 @@ class Program(object):
     def _prune_with_input(self, feeded_var_names, targets):
         """
         Prune operators and variables which are not needed to generate
-        :code:`targets`.
+        :code:`targets`. Prune operators and variables which are needed 
+        to generate feeded_var 
 
         Notes: This is a very low level API. Users should not use this API
         directly. This API is in flux and not stable.

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3385,7 +3385,7 @@ class Program(object):
         p._copy_dist_param_info_from(self)
         return p
 
-    def _prune(self, feeded_var_names, targets):
+    def _prune(self, targets, feeded_var_names=None):
         """
         Prune operators and variables which are not needed to generate
         :code:`targets`.
@@ -3396,11 +3396,15 @@ class Program(object):
         Args:
             targets(list|Variable|Operator): A list of variables or operators
                 need to be pruned
+            feeded_var_names(list|string|None): A list of variable names from where
+                pruning start
 
         Returns:
             Program:  A new, pruned program.
 
         """
+        if feeded_var_names is None:
+            feeded_var_names = []
         if not isinstance(feeded_var_names, list):
             feeded_var_names = [feeded_var_names]
         if not isinstance(targets, list):

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3397,7 +3397,7 @@ class Program(object):
             targets(list|Variable|Operator): A list of variables or operators
                 need to be pruned
             feeded_var_names(list|str|None): A list of variable names from where
-                pruning start
+                pruning start, default value is None
 
         Returns:
             Program:  A new, pruned program.

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1097,7 +1097,7 @@ def save_inference_model(dirname,
         main_program.desc.flush()
 
         main_program = main_program._prune_with_input(
-            targets=target_vars, feeded_var_names=feeded_var_names)
+            feeded_var_names=feeded_var_names, targets=target_vars)
         main_program = main_program._inference_optimize(prune_read_op=True)
         fetch_var_names = [v.name for v in target_vars]
 

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1096,7 +1096,8 @@ def save_inference_model(dirname,
 
         main_program.desc.flush()
 
-        main_program = main_program._prune(feeded_var_names, target_vars)
+        main_program = main_program._prune(
+            targets=target_vars, feeded_var_names=feeded_var_names)
         main_program = main_program._inference_optimize(prune_read_op=True)
         fetch_var_names = [v.name for v in target_vars]
 

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1096,7 +1096,7 @@ def save_inference_model(dirname,
 
         main_program.desc.flush()
 
-        main_program = main_program._prune(
+        main_program = main_program._prune_with_input(
             targets=target_vars, feeded_var_names=feeded_var_names)
         main_program = main_program._inference_optimize(prune_read_op=True)
         fetch_var_names = [v.name for v in target_vars]

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -757,9 +757,9 @@ class TestRecomputeOptimizer(unittest.TestCase):
             stat_dict = {}
             recompute_optimizer.load(stat_dict)
         except NotImplementedError as e:
-            self.assertEqual("All targets of prune() can only be "
-                             "Variable or Operator.",
-                             cpt.get_exception_message(e))
+            self.assertEqual(
+                "load function is not supported by Recompute Optimizer for now",
+                cpt.get_exception_message(e))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -757,9 +757,9 @@ class TestRecomputeOptimizer(unittest.TestCase):
             stat_dict = {}
             recompute_optimizer.load(stat_dict)
         except NotImplementedError as e:
-            self.assertEqual(
-                "load function is not supported by Recompute Optimizer for now",
-                cpt.get_exception_message(e))
+            self.assertEqual("All targets of prune() can only be "
+                             "Variable or Operator.",
+                             cpt.get_exception_message(e))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_prune.py
+++ b/python/paddle/fluid/tests/unittests/test_prune.py
@@ -1,0 +1,66 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import paddle.fluid as fluid
+import paddle.fluid.framework as framework
+
+
+class TestPrune(unittest.TestCase):
+    def net(self):
+        x = fluid.layers.data(name='x', shape=[2], dtype='float32')
+        label = fluid.layers.data(name="label", shape=[1], dtype="int64")
+        y = fluid.layers.fc(input=[x], size=2, act="softmax")
+        loss = fluid.layers.cross_entropy(input=y, label=label)
+        loss = fluid.layers.mean(x=loss)
+        return x, y, label, loss
+
+    def test_prune_with_input(self):
+        program = framework.Program()
+        startup_program = framework.Program()
+        block = program.global_block()
+        with fluid.program_guard(program, startup_program):
+            (x, y, label, loss) = self.net()
+        self.assertEqual(len(block.ops), 5)
+        self.assertEqual([op.type for op in block.ops], [
+            "mul", "elementwise_add", "softmax", "cross_entropy2", "mean"
+        ])
+        pruned_program = program._prune_with_input(
+            feeded_var_names=[y.name, label.name], targets=[loss])
+        self.assertEqual(len(pruned_program.global_block().ops), 2)
+        self.assertEqual([op.type for op in pruned_program.global_block().ops],
+                         ["cross_entropy2", "mean"])
+
+    def test_prune(self):
+        program = framework.Program()
+        startup_program = framework.Program()
+        block = program.global_block()
+        with fluid.program_guard(program, startup_program):
+            (x, y, label, loss) = self.net()
+        self.assertEqual(len(block.ops), 5)
+        self.assertEqual([op.type for op in block.ops], [
+            "mul", "elementwise_add", "softmax", "cross_entropy2", "mean"
+        ])
+        pruned_program = program._prune(targets=[loss])
+        self.assertEqual(len(pruned_program.global_block().ops), 5)
+        self.assertEqual(
+            [op.type for op in pruned_program.global_block().ops],
+            ["mul", "elementwise_add", "softmax", "cross_entropy2", "mean"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
framework._prune() interface is modified by this PR: https://github.com/PaddlePaddle/Paddle/pull/19589. Some users gave feedback that the old usage as below does not work now:

```
new_prog = old_prog._prune(target_vars)
```

This PR adds a new API named _prune_with_input() and restore _prune() interface, that is, only use targets as it's input.