### PR TITLE
add more checks to create_parameter test=develop

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4025,6 +4025,14 @@ class Parameter(Variable):
             raise ValueError("Parameter shape cannot be empty")
 
         for each in shape:
+            if six.PY2:
+                if not isinstance(each, (int, long)):
+                    raise ValueError(
+                        "The shape of Parameter must be a list[int/long].")
+            elif six.PY3:
+                if not isinstance(each, int):
+                    raise ValueError(
+                        "The shape of Parameter must be a list[int].")
             if each < 0:
                 raise ValueError("Parameter shape should not be related with "
                                  "batch-size")

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4025,9 +4025,6 @@ class Parameter(Variable):
             raise ValueError("Parameter shape cannot be empty")
 
         for each in shape:
-            if not isinstance(each, (int, long)):
-                raise ValueError(
-                    "The shape of Parameter must be a list[int/long].")
             if each < 0:
                 raise ValueError("Parameter shape should not be related with "
                                  "batch-size")

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4017,25 +4017,19 @@ class Parameter(Variable):
 
     def __init__(self, block, shape, dtype, **kwargs):
         if shape is None:
-            raise ValueError("The shape of Parameter should not be None")
+            raise ValueError(
+                "ShapeError: the shape of Parameter should not be None")
         if dtype is None:
             raise ValueError("The dtype of Parameter should not be None")
 
         if len(shape) == 0:
-            raise ValueError("Parameter shape cannot be empty")
+            raise ValueError("ShapeError: Parameter shape cannot be empty")
 
         for each in shape:
-            if six.PY2:
-                if not isinstance(each, (int, long)):
-                    raise ValueError(
-                        "The shape of Parameter must be a list[int/long].")
-            elif six.PY3:
-                if not isinstance(each, int):
-                    raise ValueError(
-                        "The shape of Parameter must be a list[int].")
             if each < 0:
-                raise ValueError("Parameter shape should not be related with "
-                                 "batch-size")
+                raise ValueError(
+                    "ShapeError: Parameter shape should not be related with "
+                    "batch-size")
 
         Variable.__init__(
             self, block, persistable=True, shape=shape, dtype=dtype, **kwargs)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4017,19 +4017,19 @@ class Parameter(Variable):
 
     def __init__(self, block, shape, dtype, **kwargs):
         if shape is None:
-            raise ValueError(
-                "ShapeError: the shape of Parameter should not be None")
+            raise ValueError("The shape of Parameter should not be None")
         if dtype is None:
             raise ValueError("The dtype of Parameter should not be None")
 
         if len(shape) == 0:
-            raise ValueError("ShapeError: Parameter shape cannot be empty")
+            raise ValueError(
+                "The dimensions of shape for Parameter must be greater than 0")
 
         for each in shape:
             if each < 0:
                 raise ValueError(
-                    "ShapeError: Parameter shape should not be related with "
-                    "batch-size")
+                    "Each dimension of shape for Parameter must be greater than 0, but received %s"
+                    % list(shape))
 
         Variable.__init__(
             self, block, persistable=True, shape=shape, dtype=dtype, **kwargs)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4016,12 +4016,18 @@ class Parameter(Variable):
     """
 
     def __init__(self, block, shape, dtype, **kwargs):
-        if shape is None or dtype is None:
-            raise ValueError("Parameter must set shape and dtype")
+        if shape is None:
+            raise ValueError("The shape of Parameter should not be None")
+        if dtype is None:
+            raise ValueError("The dtype of Parameter should not be None")
+
         if len(shape) == 0:
             raise ValueError("Parameter shape cannot be empty")
 
         for each in shape:
+            if not isinstance(each, (int, long)):
+                raise ValueError(
+                    "The shape of Parameter must be a list[int/long].")
             if each < 0:
                 raise ValueError("Parameter shape should not be related with "
                                  "batch-size")

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -54,6 +54,12 @@ class TestParameter(unittest.TestCase):
         with self.assertRaises(ValueError):
             b.create_parameter(
                 name='test', shape=[1], dtype=None, initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=[], dtype='float32', initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=[-1], dtype='float32', initializer=None)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -54,9 +54,6 @@ class TestParameter(unittest.TestCase):
         with self.assertRaises(ValueError):
             b.create_parameter(
                 name='test', shape=[1], dtype=None, initializer=None)
-        with self.assertRaises(ValueError):
-            b.create_parameter(
-                name='test', shape=['name'], dtype='float32', initializer=None)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -54,6 +54,9 @@ class TestParameter(unittest.TestCase):
         with self.assertRaises(ValueError):
             b.create_parameter(
                 name='test', shape=[1], dtype=None, initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=['name'], dtype='float32', initializer=None)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -46,6 +46,15 @@ class TestParameter(unittest.TestCase):
         p = io.get_parameter_value_by_name('fc.w', exe, main_program)
         self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))
 
+    def test_exceptions(self):
+        b = main_program.global_block()
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=None, dtype='float32', initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=[1], dtype=None, initializer=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add more pre-checks to API create_parameter to enhance the readability and give more friendly feedbacks to users when exception caught. 
1. Add more checks to inputs.
2. Add more unit-test cases to cover extra code branches.