### PR TITLE
fix the error message for reduce_mean and reduce_sum op

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -172,13 +172,6 @@ class ReduceOp : public framework::OperatorWithKernel {
                       x_rank, x_dims);
     auto dims = ctx->Attrs().Get<std::vector<int>>("dim");
 
-    PADDLE_ENFORCE_GT(
-        dims.size(), 0,
-        "ShapeError: The input dim dimensions of Reduce "
-        "shoud be greater than 0. But received the dim dimesions of Reduce "
-        " = %d",
-        dims.size());
-
     for (size_t i = 0; i < dims.size(); ++i) {
       PADDLE_ENFORCE_LT(dims[i], x_rank,
                         "ShapeError: The reduce dim index %d should be in the "

--- a/paddle/fluid/operators/reduce_ops/reduce_op.h
+++ b/paddle/fluid/operators/reduce_ops/reduce_op.h
@@ -180,12 +180,12 @@ class ReduceOp : public framework::OperatorWithKernel {
         dims.size());
 
     for (size_t i = 0; i < dims.size(); ++i) {
-      if (dims[i] < 0) dims[i] = x_rank + dims[i];
       PADDLE_ENFORCE_LT(dims[i], x_rank,
-                        "ShapeError: The reduce dim index  should be in the "
+                        "ShapeError: The reduce dim index %d should be in the "
                         "range [-dimension(X), dimension(X)]."
                         "which dimesion = %d, But received dim index = %d",
-                        x_rank, dims[i]);
+                        i, x_rank, dims[i]);
+      if (dims[i] < 0) dims[i] = x_rank + dims[i];
     }
     sort(dims.begin(), dims.end());
     bool reduce_all = ctx->Attrs().Get<bool>("reduce_all");
@@ -238,10 +238,10 @@ class ReduceGradOp : public framework::OperatorWithKernel {
     auto dims = ctx->Attrs().Get<std::vector<int>>("dim");
     for (size_t i = 0; i < dims.size(); ++i) {
       PADDLE_ENFORCE_LT(dims[i], x_rank,
-                        "ShapeError: The reduce dim index  should be in the "
+                        "ShapeError: The reduce dim index %d should be in the "
                         "range [-dimension(X), dimension(X)]."
                         "which dimesion = %d, But received dim index = %d",
-                        x_rank, dims[i]);
+                        i, x_rank, dims[i]);
       if (dims[i] < 0) dims[i] = x_rank + dims[i];
     }
     sort(dims.begin(), dims.end());

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -5074,6 +5074,15 @@ def reduce_sum(input, dim=None, keep_dim=False, name=None):
 
     """
     helper = LayerHelper('reduce_sum', **locals())
+    if not isinstance(input, Variable):
+        raise TypeError(
+            "The type of 'input' in reduce_sum must be Variable, but received %s"
+            % (type(input)))
+    if convert_dtype(
+            input.dtype) not in ['float32', 'float64', 'int32', 'int64']:
+        raise TypeError(
+            "The data type of 'input' in reduce_sum  must be float32 or float64 or int32 or int64, but received %s."
+            % (convert_dtype(input.dtype)))
     out = helper.create_variable_for_type_inference(dtype=helper.input_dtype())
     if dim is not None and not isinstance(dim, list):
         dim = [dim]
@@ -5133,6 +5142,15 @@ def reduce_mean(input, dim=None, keep_dim=False, name=None):
             fluid.layers.reduce_mean(y, dim=[0, 1]) # [4.0, 5.0]
     """
     helper = LayerHelper('reduce_mean', **locals())
+    if not isinstance(input, Variable):
+        raise TypeError(
+            "The type of 'input' in reduce_mean must be Variable, but received %s"
+            % (type(input)))
+    if convert_dtype(
+            input.dtype) not in ['float32', 'float64', 'int32', 'int64']:
+        raise TypeError(
+            "The data type of 'input' in reduce_mean  must be float32 or float64 or int32 or int64, but received %s."
+            % (convert_dtype(input.dtype)))
     out = helper.create_variable_for_type_inference(dtype=helper.input_dtype())
     if dim is not None and not isinstance(dim, list):
         dim = [dim]

--- a/python/paddle/fluid/tests/test_if_else_op.py
+++ b/python/paddle/fluid/tests/test_if_else_op.py
@@ -183,7 +183,7 @@ class TestIfElse(unittest.TestCase):
                 false_target = fluid.layers.tanh(false_target)
                 ie.output(false_target)
             if_out = ie()
-            out = layers.reduce_sum(if_out)
+            out = layers.reduce_sum(if_out[0])
 
             exe = fluid.Executor(place)
             exe.run(fluid.default_startup_program())

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -17,6 +17,9 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 class TestSumOp(OpTest):
@@ -409,6 +412,30 @@ class Test1DReduceWithAxes1(OpTest):
 
     def test_check_grad(self):
         self.check_grad(['X'], 'Out')
+
+
+class TestReduceSumOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of reduce_sum_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.reduce_sum, x1)
+            # The input dtype of reduce_sum_op  must be float32 or float64 or int32 or int64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
+            self.assertRaises(TypeError, fluid.layers.reduce_sum, x2)
+
+
+class TestReduceMeanOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of reduce_sum_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.reduce_mean, x1)
+            # The input dtype of reduce_sum_op  must be float32 or float64 or int32 or int64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
+            self.assertRaises(TypeError, fluid.layers.reduce_mean, x2)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -429,11 +429,11 @@ class TestReduceSumOpError(OpTest):
 class TestReduceMeanOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input type of reduce_sum_op must be Variable.
+            # The input type of reduce_mean_op must be Variable.
             x1 = fluid.create_lod_tensor(
                 np.array([[-1]]), [[1]], fluid.CPUPlace())
             self.assertRaises(TypeError, fluid.layers.reduce_mean, x1)
-            # The input dtype of reduce_sum_op  must be float32 or float64 or int32 or int64.
+            # The input dtype of reduce_mean_op  must be float32 or float64 or int32 or int64.
             x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
             self.assertRaises(TypeError, fluid.layers.reduce_mean, x2)
 


### PR DESCRIPTION
we  need to fix the error message according the to some standard

检查Input变量类型
检查Input中dtype的类型
本次紧急修复只检查Input，其他输入参数可以参数不做检查
此项需要增加相应的单测监控到所有异常分支，以通过CI覆盖率测试


报错信息变化

1.对于input 维度信息
Code
```
import paddle.fluid as fluid
x = fluid.layers.data(name="x",shape=[1, 2, 3, 4, 5, 6, 7], append_batch_size=False, dtype='float32')
y = fluid.layers.reduce_sum(x)
```
报错信息：
```
PaddleCheckError: Expected x_rank <= 6, but received x_rank:7 > 6:6.
ShapeError: The input tensor X's dimensions of Reduce should be less equal than 6. But received X's dimensions = 7, X's shape = [1, 2, 3, 4, 5, 6, 7]. at [/workspace/codegen/Paddle/paddle/fluid/operators/reduce_ops/reduce_op.h:172]
  [operator < reduce_sum > error]
```
2.对于reduce的dim 信息报错信息进行变更
Code
```
import paddle.fluid as fluid
x = fluid.layers.data(name="x",shape=[2, 3], append_batch_size=False, dtype='float32')
y = fluid.layers.reduce_sum(x, [3])
```
报错信息：
```
PaddleCheckError: Expected dims[i] < x_rank, but received dims[i]:3 >= x_rank:2.
ShapeError: The reduce dim index 0 should be in the range [-dimension(X), dimension(X)].which dimesion = 2, But received dim index = 3 at [/workspace/codegen/Paddle/paddle/fluid/operators/reduce_ops/reduce_op.h:187]
  [operator < reduce_sum > error]
```
Python 端：（以reduce sum为例子）
1添加了对Input类型的检查    
code:
```
import paddle.fluid as fluid
import numpy as np
x = fluid.create_lod_tensor(
                        np.array([[-1]]), [[1]], fluid.CPUPlace())
y = fluid.layers.reduce_sum(x,)
````
报错信息：
```
TypeError: The type of 'input' in reduce_sum must be Variable, but received <class 'paddle.fluid.core_avx.LoDTensor'>
```
2.添加了对输入Tensor的数据类型的检查            
code 
```
import paddle.fluid as fluid
x = fluid.layers.data(name="x",shape=[2, 3], append_batch_size=False, dtype='uint8')
y = fluid.layers.reduce_sum(x, [1])
```
报错信息：
```
TypeError: The data type of 'input' in reduce_sum  must be float32 or float64 or int32 or int64, but received uint8.
```



