### PR TITLE
add input type and dtype check for cast_op

### DIFF
--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -27,21 +27,24 @@ __all__ = ['DataFeeder']
 
 
 def convert_dtype(dtype):
-    if dtype == core.VarDesc.VarType.FP32:
-        return 'float32'
-    elif dtype == core.VarDesc.VarType.INT64:
-        return 'int64'
-    elif dtype == core.VarDesc.VarType.FP64:
-        return 'float64'
+    if dtype == core.VarDesc.VarType.BOOL:
+        return 'bool'
     elif dtype == core.VarDesc.VarType.FP16:
         return 'float16'
+    elif dtype == core.VarDesc.VarType.FP32:
+        return 'float32'
+    elif dtype == core.VarDesc.VarType.FP64:
+        return 'float64'
     elif dtype == core.VarDesc.VarType.INT32:
         return 'int32'
+    elif dtype == core.VarDesc.VarType.INT64:
+        return 'int64'
     elif dtype == core.VarDesc.VarType.UINT8:
         return 'uint8'
     else:
-        raise ValueError("dtype must be any of [int32, float32, int64, "
-                         "float64, uint8]")
+        raise ValueError(
+            "dtype must be any of [bool, float16, float32, float64, int32, int64, uint8]"
+        )
 
 
 class DataToLoDTensorConverter(object):

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -21,6 +21,7 @@ from ..framework import Variable
 from ..initializer import Constant, force_init_on_cpu
 from ..core import VarDesc
 from .layer_function_generator import templatedoc
+from ..data_feeder import convert_dtype
 import numpy
 
 __all__ = [
@@ -165,6 +166,17 @@ def cast(x, dtype):
             result = fluid.layers.cast(x=data, dtype='float64')
     """
     helper = LayerHelper('cast', **locals())
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'x' in cast must be Variable, but received %s" %
+            (type(x)))
+    if convert_dtype(x.dtype) not in [
+            'bool', 'float16', 'float32', 'float64', 'int32', 'int64', 'uint8'
+    ]:
+        raise TypeError(
+            "The data type of 'x' in cast must be bool, float16, float32, float64, int32, int64, uint8, but received %s."
+            % (convert_dtype(x.dtype)))
+
     out = helper.create_variable_for_type_inference(dtype=dtype)
     helper.append_op(
         type='cast',

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -18,6 +18,8 @@ import op_test
 import unittest
 import numpy as np
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 class TestCastOp1(op_test.OpTest):
@@ -67,6 +69,18 @@ class TestCastOp3(op_test.OpTest):
 
     def test_check_output(self):
         self.check_output(atol=1e-3)
+
+
+class TestCastOpError(op_test.OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of cast_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.cast, x1)
+            # The input dtype of softmax_op must be bool, float16, float32, float64, int32, int64, uint8.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="int8")
+            self.assertRaises(TypeError, fluid.layers.cast, x2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
为cast python api的输入input加类型检查：

- 检查类型是否为Variable
- 检查数据类型是否为bool, float16, float32, float64, int32, int64, uint8
- 在单测中覆盖类型错误和数据类型错误两个异常情况
- 在convert_dtype中增加bool类型的判断