### PR TITLE
Fill constant error message fix

### DIFF
--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -87,4 +87,5 @@ REGISTER_OP_CPU_KERNEL(fill_constant, ops::FillConstantKernel<float>,
                        ops::FillConstantKernel<double>,
                        ops::FillConstantKernel<int64_t>,
                        ops::FillConstantKernel<int>,
+                       ops::FillConstantKernel<bool>,
                        ops::FillConstantKernel<paddle::platform::float16>);

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -29,12 +29,16 @@ __all__ = ['DataFeeder']
 def convert_dtype(dtype):
     if isinstance(dtype, str):
         if dtype in [
-                'float32', 'int64', 'float64', 'float16', 'int32', 'uint8'
+                'float32', 'int64', 'float64', 'float16', 'int32', 'uint8',
+                'bool'
         ]:
             return dtype
         else:
-            raise ValueError("dtype must be any of [int32, float32, int64, "
-                             "float64, uint8]")
+            raise ValueError(
+                "dtype must be any of [bool, int32, float32, int64, "
+                "float64, uint8]")
+    elif dtype == core.VarDesc.VarType.BOOL:
+        return 'bool'
     elif dtype == core.VarDesc.VarType.FP32:
         return 'float32'
     elif dtype == core.VarDesc.VarType.INT64:
@@ -48,7 +52,7 @@ def convert_dtype(dtype):
     elif dtype == core.VarDesc.VarType.UINT8:
         return 'uint8'
     else:
-        raise ValueError("dtype must be any of [int32, float32, int64, "
+        raise ValueError("dtype must be any of [bool,int32, float32, int64, "
                          "float64, uint8]")
 
 

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -27,6 +27,14 @@ __all__ = ['DataFeeder']
 
 
 def convert_dtype(dtype):
+    if isinstance(dtype, str) and dtype in [
+            'float32', 'int64', 'float64', 'float16', 'int32', 'uint8'
+    ]:
+        return dtype
+    else:
+        raise ValueError("dtype must be any of [int32, float32, int64, "
+                         "float64, uint8]")
+
     if dtype == core.VarDesc.VarType.FP32:
         return 'float32'
     elif dtype == core.VarDesc.VarType.INT64:

--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -27,15 +27,15 @@ __all__ = ['DataFeeder']
 
 
 def convert_dtype(dtype):
-    if isinstance(dtype, str) and dtype in [
-            'float32', 'int64', 'float64', 'float16', 'int32', 'uint8'
-    ]:
-        return dtype
-    else:
-        raise ValueError("dtype must be any of [int32, float32, int64, "
-                         "float64, uint8]")
-
-    if dtype == core.VarDesc.VarType.FP32:
+    if isinstance(dtype, str):
+        if dtype in [
+                'float32', 'int64', 'float64', 'float16', 'int32', 'uint8'
+        ]:
+            return dtype
+        else:
+            raise ValueError("dtype must be any of [int32, float32, int64, "
+                             "float64, uint8]")
+    elif dtype == core.VarDesc.VarType.FP32:
         return 'float32'
     elif dtype == core.VarDesc.VarType.INT64:
         return 'int64'

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -398,10 +398,11 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
     """
 
     helper = LayerHelper("fill_constant", **locals())
-    if convert_dtype(
-            dtype) not in ['float16', 'float32', 'float64', 'int32', 'int64']:
+    if convert_dtype(dtype) not in [
+            'bool', 'float16', 'float32', 'float64', 'int32', 'int64'
+    ]:
         raise TypeError(
-            "The create data type in fill_constant must be one of float16, float32,"
+            "The create data type in fill_constant must be one of 'bool', float16, float32,"
             "float64, int32 or int64, but received %s." % convert_dtype(
                 (dtype)))
     if out is None:

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -405,7 +405,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
             'float16', 'float32', 'float64', 'int32', 'int64'
     ]:
         raise TypeError(
-            "The data type of 'input' in fill_constant must be float32 or float64, but received %s."
+            "The data type of 'input' in fill_constant must be float16 or float32 or float64 or int32 or int64  but received %s."
             % (convert_dtype(input.dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -397,6 +397,16 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
     """
 
     helper = LayerHelper("fill_constant", **locals())
+    if not isinstance(input, Variable):
+        raise TypeError(
+            "The type of 'input' in fill_constant  must be Variable, but received %s"
+            % (type(input)))
+    if convert_dtype(input.dtype) not in [
+            'float16', 'float32', 'float64', 'int32', 'int64'
+    ]:
+        raise TypeError(
+            "The data type of 'input' in fill_constant must be float32 or float64, but received %s."
+            % (convert_dtype(input.dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)
     helper.append_op(

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -397,17 +397,10 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
     """
 
     helper = LayerHelper("fill_constant", **locals())
-    if not isinstance(input, Variable):
+    if dtype not in ['float16', 'float32', 'float64', 'int32', 'int64']:
         raise TypeError(
-            "The type of 'input' in fill_constant  must be Variable, but received %s"
-            % (type(input)))
-    if convert_dtype(input.dtype) not in [
-            'float16', 'float32', 'float64', 'int32', 'int64'
-    ]:
-        raise TypeError(
-            "The data type of 'input' in fill_constant must be float16 or float32"
-            "or float64 or int32 or int64  but received %s." %
-            (convert_dtype(input.dtype)))
+            "The create data type in fill_constant must be float16 or float32"
+            "or float64 or int32 or int64  but received %s." % ((dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)
     helper.append_op(

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -405,8 +405,9 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
             'float16', 'float32', 'float64', 'int32', 'int64'
     ]:
         raise TypeError(
-            "The data type of 'input' in fill_constant must be float16 or float32 or float64 or int32 or int64  but received %s."
-            % (convert_dtype(input.dtype)))
+            "The data type of 'input' in fill_constant must be float16 or float32"
+            "or float64 or int32 or int64  but received %s." %
+            (convert_dtype(input.dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)
     helper.append_op(

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -21,6 +21,7 @@ from ..framework import Variable
 from ..initializer import Constant, force_init_on_cpu
 from ..core import VarDesc
 from .layer_function_generator import templatedoc
+from ..data_feeder import convert_dtype
 import numpy
 
 __all__ = [
@@ -397,12 +398,20 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
     """
 
     helper = LayerHelper("fill_constant", **locals())
-    if dtype not in ['float16', 'float32', 'float64', 'int32', 'int64']:
+    if convert_dtype(
+            dtype) not in ['float16', 'float32', 'float64', 'int32', 'int64']:
         raise TypeError(
             "The create data type in fill_constant must be float16 or float32"
-            "or float64 or int32 or int64  but received %s." % ((dtype)))
+            "or float64 or int32 or int64  but received %s." % conver_dtype(
+                (dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)
+    else:
+        if (convert_dtype(dtype) == convert_dtype(out.dtype)):
+            raise TypeError(
+                "The create data type in op must be same with out type2"
+                "but received %s and out dtype %s." % (conver_dtype(
+                    (dtype), convert_dtype(out.type))))
     helper.append_op(
         type='fill_constant',
         inputs={},

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -401,15 +401,15 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
     if convert_dtype(
             dtype) not in ['float16', 'float32', 'float64', 'int32', 'int64']:
         raise TypeError(
-            "The create data type in fill_constant must be float16 or float32"
-            "or float64 or int32 or int64  but received %s." % convert_dtype(
+            "The create data type in fill_constant must be one of float16, float32,"
+            "float64, int32 or int64, but received %s." % convert_dtype(
                 (dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)
     else:
         if not (convert_dtype(dtype) == convert_dtype(out.dtype)):
             raise TypeError(
-                "The create data type in op must be same with out type2"
+                "The create data type in op must be same with out type"
                 "but received %s and out dtype %s." % (convert_dtype(
                     (dtype), convert_dtype(out.dtype))))
     helper.append_op(

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -402,16 +402,16 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
             dtype) not in ['float16', 'float32', 'float64', 'int32', 'int64']:
         raise TypeError(
             "The create data type in fill_constant must be float16 or float32"
-            "or float64 or int32 or int64  but received %s." % conver_dtype(
+            "or float64 or int32 or int64  but received %s." % convert_dtype(
                 (dtype)))
     if out is None:
         out = helper.create_variable_for_type_inference(dtype=dtype)
     else:
-        if (convert_dtype(dtype) == convert_dtype(out.dtype)):
+        if not (convert_dtype(dtype) == convert_dtype(out.dtype)):
             raise TypeError(
                 "The create data type in op must be same with out type2"
-                "but received %s and out dtype %s." % (conver_dtype(
-                    (dtype), convert_dtype(out.type))))
+                "but received %s and out dtype %s." % (convert_dtype(
+                    (dtype), convert_dtype(out.dtype))))
     helper.append_op(
         type='fill_constant',
         inputs={},

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -109,11 +109,11 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 class TestFillConstantOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input type of softmax_op must be Variable.
+            # The input type of fill_constant must be Variable.
             x1 = fluid.create_lod_tensor(
                 np.array([[-1]]), [[1]], fluid.CPUPlace())
             self.assertRaises(TypeError, fluid.layers.fill_constant, x1)
-            # The input dtype of softmax_op must be float32 or float64.
+            # The input dtype of fill_constant must be float32 or float64.
             x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
             self.assertRaises(TypeError, fluid.layers.fill_constant, x2)
 

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -109,11 +109,8 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 class TestFillConstantOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input type of fill_constant must be Variable.
-            x1 = fluid.create_lod_tensor(
-                np.array([[-1]]), [[1]], fluid.CPUPlace())
-            self.assertRaises(TypeError, fluid.layers.fill_constant, x1)
-            # The input dtype of fill_constant must be float32 or float64.
+            # The input dtype of fill_constant must be float16 or float32 or float64.
+            #or int32 or int64
             x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
             self.assertRaises(TypeError, fluid.layers.fill_constant, x2)
 

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -109,8 +109,8 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 class TestFillConstantOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input dtype of fill_constant must be float16 or float32 or float64.
-            #or int32 or int64
+            # The input dtype of fill_constant must be one of float16, 
+            #float32, float64, int32 or int64
             x2 = fluid.layers.data(name='x2', shape=[1], dtype="int32")
             self.assertRaises(
                 TypeError,

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -111,8 +111,20 @@ class TestFillConstantOpError(OpTest):
         with program_guard(Program(), Program()):
             # The input dtype of fill_constant must be float16 or float32 or float64.
             #or int32 or int64
-            x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
-            self.assertRaises(TypeError, fluid.layers.fill_constant, x2)
+            x2 = fluid.layers.data(name='x2', shape=[1], dtype="int32")
+            self.assertRaises(
+                TypeError,
+                fluid.layers.fill_constant,
+                shape=[1],
+                value=5,
+                dtype='uint8')
+            self.assertRaises(
+                TypeError,
+                fluid.layers.fill_constant,
+                shape=[1],
+                value=5,
+                dtype='float64',
+                out=x2)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -109,7 +109,7 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 class TestFillConstantOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input dtype of fill_constant must be one of float16, 
+            # The input dtype of fill_constant must be one of bool, float16, 
             #float32, float64, int32 or int64
             x2 = fluid.layers.data(name='x2', shape=[1], dtype="int32")
             self.assertRaises(

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -20,6 +20,8 @@ from op_test import OpTest
 
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 class TestFillConstantOp1(OpTest):
@@ -102,6 +104,18 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 
         for place in places:
             self.check_with_place(place)
+
+
+class TestFillConstantOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of softmax_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.fill_constant, x1)
+            # The input dtype of softmax_op must be float32 or float64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
+            self.assertRaises(TypeError, fluid.layers.fill_constant, x2)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -109,6 +109,21 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 class TestFillConstantOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
+            #for ci coverage 
+            x1 = fluid.layers.data(name='x1', shape=[1], dtype="int16")
+            self.assertRaises(
+                ValueError,
+                fluid.layers.fill_constant,
+                shape=[1],
+                value=5,
+                dtype='uint4')
+            self.assertRaises(
+                ValueError,
+                fluid.layers.fill_constant,
+                shape=[1],
+                value=5,
+                dtype='int16',
+                out=x1)
             # The input dtype of fill_constant must be one of bool, float16, 
             #float32, float64, int32 or int64
             x2 = fluid.layers.data(name='x2', shape=[1], dtype="int32")


### PR DESCRIPTION
fill_constant OP 报错信息添加
1 .添加了对输入Tensor的数据类型的检查 
代码：
```
import paddle.fluid as fluid
import numpy as np
fluid.layers.fill_constant(shape=[1], value=5, dtype='uint8')
```
报错信息: 
```
TypeError: The create data type in fill_constant must be float16 or float32or float64 or int32 or int64  but received uint8.
```