### PR TITLE
Fix op_compatiable_compile_error

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -223,7 +223,7 @@ endif (NOT WIN32)
 cc_library(dlpack_tensor SRCS dlpack_tensor.cc DEPS tensor dlpack)
 cc_test(dlpack_tensor_test SRCS dlpack_tensor_test.cc DEPS dlpack_tensor glog)
 
-cc_library(op_compatible_info SRCS op_compatible_info DEPS string_helper)
+cc_library(op_compatible_info SRCS op_compatible_info DEPS string_helper proto_desc)
 cc_test(op_compatible_info_test SRCS op_compatible_info_test.cc DEPS op_compatible_info proto_desc string_helper glog)
 
 # Get the current working branch


### PR DESCRIPTION
`op_compatible_info` should depend on `proto_desc`. Otherwise, compilation would be wrong.
http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiPython35Night&buildId=178789

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/32832641/65825930-8335b500-e2af-11e9-93c9-e3dfbd5a01a5.png">
