### PR TITLE
Fix shape check in load_vars when the params is not initialized before loadding.

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -661,9 +661,9 @@ def load_vars(executor,
 
             if isinstance(each_var, Parameter):
                 var_temp = paddle.fluid.global_scope().find_var(each_var.name)
-                assert var_temp != None, "can't not find var: " + each_var.name
-                orig_para_shape[each_var.name] = (
-                    np.array(var_temp.get_tensor())).shape
+                if var_temp is not None:
+                    orig_para_shape[each_var.name] = (
+                        np.array(var_temp.get_tensor())).shape
             new_var = _clone_var_in_block_(load_block, each_var)
             if filename is None:
                 load_block.append_op(
@@ -692,16 +692,16 @@ def load_vars(executor,
         for each_var in vars:
             if not isinstance(each_var, Parameter):
                 continue
-            var_temp = paddle.fluid.global_scope().find_var(each_var.name)
-            assert var_temp != None, "can't not find var: " + each_var.name
-            new_shape = (np.array(var_temp.get_tensor())).shape
-            assert each_var.name in orig_para_shape, earch_var.name + "MUST in var list"
-            orig_shape = orig_para_shape.get(each_var.name)
-            if new_shape != orig_shape:
-                raise RuntimeError(
-                    "Shape not matching: the Program requires a parameter with a shape of ({}), "
-                    "while the loaded parameter (namely [ {} ]) has a shape of  ({}).".
-                    format(orig_shape, each_var.name, new_shape))
+            if each_var.name in orig_para_shape:
+                var_temp = paddle.fluid.global_scope().find_var(each_var.name)
+                assert var_temp != None, "can't not find var: " + each_var.name
+                new_shape = (np.array(var_temp.get_tensor())).shape
+                orig_shape = orig_para_shape.get(each_var.name)
+                if new_shape != orig_shape:
+                    raise RuntimeError(
+                        "Shape not matching: the Program requires a parameter with a shape of ({}), "
+                        "while the loaded parameter (namely [ {} ]) has a shape of  ({}).".
+                        format(orig_shape, each_var.name, new_shape))
 
 
 def load_params(executor, dirname, main_program=None, filename=None):


### PR DESCRIPTION
https://github.com/PaddlePaddle/Paddle/pull/19936 的PR改动导致一些场景会挂。

需要修复原因：无法始终保证 Parameter 在load之前是初始过的。

应用场景:
没有shape check之前的逻辑支持:   在模型评估时，不run startup_program初始化参数，只load_params/persistable加载模型，做评估。

加了shape check之后，如果不run startup_program初始化参数，直接load_params/persistable加载模型，会挂。

可通过图像分类模型快速验证。