### PR TITLE
add input type, dtype and shape check for reshape op.

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7922,13 +7922,25 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             dim = fluid.layers.fill_constant([1], "int32", 5)
             reshaped_2 = fluid.layers.reshape(data_2, shape=[dim, 10])
     """
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'x' in reshape must be Variable, but received %s." %
+            (type(x)))
+
+    if convert_dtype(x.dtype) not in ['float32', 'float64', 'int32', 'int64']:
+        raise TypeError(
+            "The data type of 'x' in reshape must be float32, float64, int32 or int64, "
+            "but received %s." % (convert_dtype(x.dtype)))
 
     if not isinstance(shape, (list, tuple, Variable)):
         raise TypeError(
-            "Input shape must be an Variable or python list or tuple.")
+            "The type of 'shape' in reshape must be Variable, list or tuple, but "
+            "received %s." % (type(shape)))
 
     if not isinstance(actual_shape, Variable) and (actual_shape is not None):
-        raise TypeError("actual_shape should either be Variable or None.")
+        raise TypeError(
+            "The type of 'actual_shape' in reshape must be Variable "
+            "or None, but received %s." % (type(actual_shape)))
 
     helper = LayerHelper("reshape2", **locals())
     inputs = {"X": x}
@@ -7963,15 +7975,21 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
                 attrs_shape.append(dim_size)
                 if dim_size == -1:
                     assert unk_dim_idx == -1, (
-                        "Only one dimension in shape can be unknown.")
+                        "Only one dimension value of 'shape' in reshape can "
+                        "be -1. But received shape[%d] is also -1." % dim_idx)
                     unk_dim_idx = dim_idx
                 elif dim_size == 0:
                     assert dim_idx < len(x.shape), (
-                        "The indice of 0s in shape can not exceed Rank(X).")
+                        "The index of 0 in `shape` must be less than "
+                        "the input tensor X's dimensions. "
+                        "But received shape[%d] = 0, X's dimensions = %d." %
+                        (dim_idx, len(x.shape)))
                 else:
                     assert dim_size > 0, (
-                        "Each dimension size given in shape must not be negtive "
-                        "except one unknown dimension.")
+                        "Each dimension value of 'shape' in reshape must not "
+                        "be negtive except one unknown dimension. "
+                        "But received shape[%d] = %s." %
+                        (dim_idx, str(dim_size)))
         return attrs_shape
 
     if in_dygraph_mode():
@@ -7983,7 +8001,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             inputs["Shape"] = shape
         elif isinstance(shape, (list, tuple)):
             assert len(shape) > 0, (
-                "The size of argument(shape) can't be zero.")
+                "The size of 'shape' in reshape can't be zero, "
+                "but received %s." % len(shape))
             attrs["shape"] = get_attr_shape(shape)
             if contain_var(shape):
                 inputs['ShapeTensor'] = get_new_shape_tensor(shape)

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from op_test import OpTest
 import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 # situation 1: have shape( list, no tensor), no actual shape(Tensor)
@@ -202,10 +203,13 @@ class TestReshapeAPI(OpTest):
 
         # situation 1: have shape( list, no tensor), no actual shape(Tensor)
         out_1 = fluid.layers.reshape(x, shape)
+
         # situation 2: have shape(list, no tensor), have actual shape(Tensor)
         out_2 = fluid.layers.reshape(x, shape=shape, actual_shape=actual_shape)
+
         # Situation 3: have shape(list, have tensor), no actual shape(Tensor)
         out_3 = fluid.layers.reshape(x, shape=[positive_five, 10])
+
         # Situation 4: have shape(Tensor), no actual shape(Tensor)
         out_4 = fluid.layers.reshape(x, shape=actual_shape)
 
@@ -220,6 +224,66 @@ class TestReshapeAPI(OpTest):
         assert np.array_equal(res_2, input.reshape(shape))
         assert np.array_equal(res_3, input.reshape([5, 10]))
         assert np.array_equal(res_4, input.reshape(shape))
+
+
+# Test Input Error
+class TestReshapeOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The x type of reshape_op must be Variable.
+            def test_x_type():
+                x1 = fluid.create_lod_tensor(
+                    np.array([[-1]]), [[1]], fluid.CPUPlace())
+                fluid.layers.reshape(x1, shape=[1])
+
+            self.assertRaises(TypeError, test_x_type)
+
+            # The x dtype of reshape_op must be float32, float64, int32 or int64.
+            def test_x_dtype():
+                x2 = fluid.layers.data(
+                    name="x2",
+                    shape=[2, 25],
+                    append_batch_size=False,
+                    dtype="float16")
+                fluid.layers.reshape(x2, shape=[2, 5, 5])
+
+            self.assertRaises(TypeError, test_x_dtype)
+
+            x3 = fluid.layers.data(
+                name="x3",
+                shape=[2, 25],
+                append_batch_size=False,
+                dtype="float32")
+
+            # The argument shape's type of reshape_op must be list, tuple or Variable.
+            def test_shape_type():
+                fluid.layers.reshape(x3, shape=1)
+
+            self.assertRaises(TypeError, test_shape_type)
+
+            # The argument actual_shape's type of reshape_op must be Variable or None.
+            def test_actual_shape_type():
+                fluid.layers.reshape(x3, shape=[25, 2], actual_shape=1)
+
+            self.assertRaises(TypeError, test_actual_shape_type)
+
+            # The argument shape have more than one -1.
+            def test_shape_1():
+                fluid.layers.reshape(x3, shape=[-1, -1, 5])
+
+            self.assertRaises(AssertionError, test_shape_1)
+
+            # The argument shape have element 0 whose index exceed the input dimension.
+            def test_shape_2():
+                fluid.layers.reshape(x3, [2, 5, 5, 0])
+
+            self.assertRaises(AssertionError, test_shape_2)
+
+            # The argument shape have more than one negtive value.
+            def test_shape_3():
+                fluid.layers.reshape(x3, [-1, -2, 5])
+
+            self.assertRaises(AssertionError, test_shape_3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## reshape op增强输入类型检查
- 1. 检查类型是否为Variable
- 2. 检查数据类型是否为float32,float64, int32, int64

在单测中覆盖类型错误和数据类型错误两个异常情况
可手动运行示例，看下错误：
```
import paddle.fluid as fluid
x1 = fluid.create_lod_tensor(np.array([[-1]]), [[1]], fluid.CPUPlace())
fluid.layers.reshape(x1, shape=[1])
# TypeError: The type of ‘x’ in reshape must be Variable, but received <class 'paddle.fluid.core_avx.LoDTensor'>
```
```
import paddle.fluid as fluid
x2 = fluid.layers.data(
                    name="x",
                    shape=[2, 25],
                    append_batch_size=False,
                    dtype="float16")
fluid.layers.reshape(x2, shape=[2, 2, 5])
#TypeError: The data type of ‘x’ in reshape must be float32, float64, int32 or int64, but received float16.

```

## reshape op增强维度类报错信息
```
input = np.random.random([2, 25]).astype("float32")
x = fluid.layers.data(name="x", shape=[2, 25], append_batch_size=False, dtype="float32")
shape = fluid.layers.data(name="shape", shape=[1, 4], append_batch_size=False, dtype="float32")
fluid.layers.reshape(x, shape=shape)
```
#### 1.shape参数中元素不止一个为-1时
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([-1, -1, 5, 1]).astype("int32")})
```
> 修改前报错：报错内容表述不清楚，没有打印维度信息
Only one input dimension of Attr(shape) can be unknown.

> 修改后报错
ShapeError: Only one dimension value of 'shape' in ReshapeOp can be -1. But received shape = [-1, -1, 5, 1], shape[1] is also -1.

#### 2.shape参数中元素为0时，0所对应的维度出错
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([2, 5, 5, 0]).astype("int32")})
```
> 修改前报错：报错内容表述不清楚，没有打印维度信息
The index of dimension to copy from input shape must be less than the size of input shape.

> 修改后报错
ShapeError: The index of 0 in `shape` must be less than the input tensor X's dimensions. But received shape = [2, 5, 5, 0], shape[3] = 0, X's shape = [2, 25], X's dimensions = 2.

#### 3.shape参数有-1以外的负值
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([-1, -5, 5, 1]).astype("int32")})
```
> 修改前报错：
Each input dimension of Attr(shape) must not be negtive except one unknown dimension.

> 修改后报错
ShapeError: Each dimension value of 'shape' in ReshapeOp must not be negtive except one unknown dimension. But received  shape = [-1, -5, 5, 1], shape[1] = -5.

#### 4.传入无效的shape值，无法正确推断出-1对应的实际值
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([-1, 3, 5, 1]).astype("int32")})
```
> 修改前报错：
Invalid shape is given.

> 修改后报错
ShapeError: The 'shape' in ReshapeOp is invalid. The input tensor X'size must be divisible by known capacity of 'shape'. But received X's shape = [2, 25], X's size = 50, 'shape' is [-1, 3, 5, 1], known capacity of 'shape' is -15.


#### 5.传入无效的shape值，输入x的size与 shape不匹配
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([1, 3, 5, 1]).astype("int32")})
```
> 修改前报错：
Invalid shape is given.

> 修改后报错
ShapeError: The 'shape' in ReshapeOp is invalid. The input tensor X'size must be equal to the capacity of 'shape'. But received X's shape = [2, 25], X's size = 50, 'shape' is [1, 3, 5, 1], the capacity of 'shape' is 15.
