### PR TITLE
add input type and dtype check for squeeze

### DIFF
--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -35,19 +35,19 @@ class SqueezeOp : public framework::OperatorWithKernel {
     const auto &x_dims = ctx->GetInputDim("X");
     // Check input tensor dims (<6) Eigen limit.
     PADDLE_ENFORCE_LE(x_dims.size(), 6,
-                      "ShapeError: the rank of Input(X) "
+                      "ShapeError: the dimensions of Input(X) "
                       "should be in the range of [1, 6] (Eigen limit)."
-                      "But received X's rank = %d.",
-                      x_dims.size());
+                      "But received X's dimensions = %d, X's shape=[%s].",
+                      x_dims.size(), x_dims);
 
     const auto &axes = ctx->Attrs().Get<std::vector<int>>("axes");
     for (int a : axes) {
       PADDLE_ENFORCE_LT(
           a, x_dims.size(),
           "ShapeError: The squeeze axis should be less than input "
-          "tensor's rank. But received axis = %d, input "
-          "tensor's rank = %d",
-          a, x_dims.size());
+          "tensor's dimensions. But received axis = %d, input "
+          "tensor's dimensions = %d, input tensor's shape = [%s].",
+          a, x_dims.size(), x_dims);
     }
 
     auto out_dims = GetOutputShape(axes, x_dims);
@@ -80,7 +80,9 @@ class SqueezeOp : public framework::OperatorWithKernel {
                                             : squeeze_dims[idx];
         // Check current index, the upper limit has beed checked in line 36.
         PADDLE_ENFORCE_GE(current, 0,
-                          "Invalid axis, the negative axis is out of range.");
+                          "Invalid axis, the negative axis is out of range."
+                          "Current axis is:%d, input tensor's shape = [%s].",
+                          current, in_dims);
 
         if (!(should_squeeze[current])) {
           ++cnt_squeezed_dims;
@@ -176,19 +178,19 @@ class Squeeze2Op : public framework::OperatorWithKernel {
     const auto &x_dims = ctx->GetInputDim("X");
     // Check input tensor dims (<6) Eigen limit.
     PADDLE_ENFORCE_LE(x_dims.size(), 6,
-                      "ShapeError: the rank of Input(X) "
+                      "ShapeError: the dimensions of Input(X) "
                       "should be in the range of [1, 6] (Eigen limit)."
-                      "But received X's rank = %d.",
-                      x_dims.size());
+                      "But received X's dimensions = %d, X's shape = [%s].",
+                      x_dims.size(), x_dims);
 
     const auto &axes = ctx->Attrs().Get<std::vector<int>>("axes");
     for (int a : axes) {
       PADDLE_ENFORCE_LT(
           a, x_dims.size(),
           "ShapeError: The squeeze axis should be less than input "
-          "tensor's rank. But received axis = %d, input "
-          "tensor's rank = %d",
-          a, x_dims.size());
+          "tensor's dimensions. But received axis = %d, input "
+          "tensor's dimensions = %d, input tensor's shape = [%s].",
+          a, x_dims.size(), x_dims);
     }
 
     auto out_dims = SqueezeOp::GetOutputShape(axes, x_dims);

--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -78,7 +78,6 @@ class SqueezeOp : public framework::OperatorWithKernel {
       for (size_t idx = 0; idx < num_squeeze_dims; ++idx) {
         int current = squeeze_dims[idx] < 0 ? squeeze_dims[idx] + in_dims.size()
                                             : squeeze_dims[idx];
-        // Check current index, the upper limit has beed checked in line 45.
         PADDLE_ENFORCE_GE(current, 0,
                           "Invalid axis, the axis should >= 0."
                           "Current axis is:%d, input tensor's shape = [%s].",

--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -35,14 +35,19 @@ class SqueezeOp : public framework::OperatorWithKernel {
     const auto &x_dims = ctx->GetInputDim("X");
     // Check input tensor dims (<6) Eigen limit.
     PADDLE_ENFORCE_LE(x_dims.size(), 6,
-                      "Invalid dimnesions, the rank of Input(X) "
-                      "should be in the range of [1, 6] (Eigen limit).");
+                      "ShapeError: the rank of Input(X) "
+                      "should be in the range of [1, 6] (Eigen limit)."
+                      "But received X's rank = %d.",
+                      x_dims.size());
 
     const auto &axes = ctx->Attrs().Get<std::vector<int>>("axes");
     for (int a : axes) {
-      PADDLE_ENFORCE_LT(a, x_dims.size(),
-                        "The squeeze axis should be less than input "
-                        "tensor's rank.");
+      PADDLE_ENFORCE_LT(
+          a, x_dims.size(),
+          "ShapeError: The squeeze axis should be less than input "
+          "tensor's rank. But received axis = %d, input "
+          "tensor's rank = %d",
+          a, x_dims.size());
     }
 
     auto out_dims = GetOutputShape(axes, x_dims);
@@ -171,14 +176,19 @@ class Squeeze2Op : public framework::OperatorWithKernel {
     const auto &x_dims = ctx->GetInputDim("X");
     // Check input tensor dims (<6) Eigen limit.
     PADDLE_ENFORCE_LE(x_dims.size(), 6,
-                      "Invalid dimnesions, the rank of Input(X) "
-                      "should be in the range of [1, 6] (Eigen limit).");
+                      "ShapeError: the rank of Input(X) "
+                      "should be in the range of [1, 6] (Eigen limit)."
+                      "But received X's rank = %d.",
+                      x_dims.size());
 
     const auto &axes = ctx->Attrs().Get<std::vector<int>>("axes");
     for (int a : axes) {
-      PADDLE_ENFORCE_LT(a, x_dims.size(),
-                        "The squeeze axis should be less than input "
-                        "tensor's rank.");
+      PADDLE_ENFORCE_LT(
+          a, x_dims.size(),
+          "ShapeError: The squeeze axis should be less than input "
+          "tensor's rank. But received axis = %d, input "
+          "tensor's rank = %d",
+          a, x_dims.size());
     }
 
     auto out_dims = SqueezeOp::GetOutputShape(axes, x_dims);

--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -78,9 +78,9 @@ class SqueezeOp : public framework::OperatorWithKernel {
       for (size_t idx = 0; idx < num_squeeze_dims; ++idx) {
         int current = squeeze_dims[idx] < 0 ? squeeze_dims[idx] + in_dims.size()
                                             : squeeze_dims[idx];
-        // Check current index, the upper limit has beed checked in line 36.
+        // Check current index, the upper limit has beed checked in line 45.
         PADDLE_ENFORCE_GE(current, 0,
-                          "Invalid axis, the negative axis is out of range."
+                          "Invalid axis, the axis should >= 0."
                           "Current axis is:%d, input tensor's shape = [%s].",
                           current, in_dims);
 

--- a/paddle/fluid/operators/squeeze_op.h
+++ b/paddle/fluid/operators/squeeze_op.h
@@ -63,11 +63,15 @@ class SqueezeKernel : public framework::OpKernel<T> {
                                             : squeeze_dims[idx];
         // Check current index, the upper limit has beed checked in line 36.
         PADDLE_ENFORCE_GE(current, 0,
-                          "Invalid axis, the negative axis is out of range.");
+                          "Invalid axis, the negative axis is out of range."
+                          "Current axis is:%d, input tensor's shape = [%s].",
+                          current, in_dims);
 
         PADDLE_ENFORCE_EQ(in_dims[current], 1,
                           "Invalid axis index, the axis that will be squeezed "
-                          "should be equal to 1.");
+                          "should be equal to 1. But current axis = %d,"
+                          "input tensor's shape = [%s].",
+                          in_dims[current], in_dims);
 
         if (!(should_squeeze[current])) {
           ++cnt_squeezed_dims;

--- a/paddle/fluid/operators/squeeze_op.h
+++ b/paddle/fluid/operators/squeeze_op.h
@@ -61,9 +61,9 @@ class SqueezeKernel : public framework::OpKernel<T> {
       for (size_t idx = 0; idx < num_squeeze_dims; ++idx) {
         int current = squeeze_dims[idx] < 0 ? squeeze_dims[idx] + in_dims.size()
                                             : squeeze_dims[idx];
-        // Check current index, the upper limit has beed checked in line 36.
+
         PADDLE_ENFORCE_GE(current, 0,
-                          "Invalid axis, the negative axis is out of range."
+                          "Invalid axis, the axis should >= 0."
                           "Current axis is:%d, input tensor's shape = [%s].",
                           current, in_dims);
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7451,6 +7451,23 @@ def squeeze(input, axes, name=None):
     assert not in_dygraph_mode(), (
         "squeeze layer is not supported in dygraph mode yet.")
     helper = LayerHelper("squeeze", **locals())
+
+    if not isinstance(input, Variable):
+        raise TypeError(
+            "The type of 'input' in squeeze must be Variable, but received %s" %
+            (type(input)))
+
+    if convert_dtype(input.dtype
+                     ) not in ['float32', 'float64', 'int8', 'int32', 'int64']:
+        raise TypeError(
+            "The data type of 'input' in squeeze must be float32, float64, int8, int32,"
+            "int64, but received %s." % (convert_dtype(input.dtype)))
+
+    if not isinstance(axes, list):
+        raise TypeError(
+            "The type of 'axes' in squeeze must be list, but received %s" %
+            (type(axes)))
+
     out = helper.create_variable_for_type_inference(dtype=input.dtype)
     x_shape = helper.create_variable_for_type_inference(dtype=input.dtype)
     helper.append_op(

--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -16,6 +16,8 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 from op_test import OpTest
 
@@ -66,6 +68,18 @@ class TestSqueezeOp3(TestSqueezeOp):
         self.ori_shape = (3, 1, 5, 1, 4, 1)
         self.axes = (1, -1)
         self.new_shape = (3, 5, 1, 4)
+
+
+class TestSqueezeOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of softmax_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.squeeze, x1)
+            # The input axes of squeeze must be list.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.squeeze, x2, axes=0)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -80,6 +80,9 @@ class TestSqueezeOpError(OpTest):
             # The input axes of squeeze must be list.
             x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
             self.assertRaises(TypeError, fluid.layers.squeeze, x2, axes=0)
+            # The input dtype of squeeze not support float16.
+            x3 = fluid.layers.data(name='x3', shape=[4], dtype="float16")
+            self.assertRaises(TypeError, fluid.layers.squeeze, x3, axes=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
为squeeze python api的输入input加类型检查：

- 检查类型是否为Variable
- 检查数据类型是否为float16
- 在单测中覆盖类型错误和数据类型错误两个异常情况
可手动运行示例，看下错误：

```
import paddle.fluid as fluid
x1 = fluid.create_lod_tensor(np.array([[-1]]), [[1]], fluid.CPUPlace())
fluid.layers.squeeze(x1)
# TypeError: The type of ‘input’ in squeeze must be Variable, but received <class 'paddle.fluid.core_avx.LoDTensor'>

import paddle.fluid as fluid
x2 = fluid.layers.data(name='x2', shape=[4], dtype="float16")
fluid.layers.squeeze(x2)
#TypeError: The data type of ‘input’ in squeeze must be int8, int32, int64, float32 or float64, but received float16.

```
注意：

需要用单引号把输入'input'括起来，和input区分，避免用户不知道是哪个输入。其他输入名字如X，Y，也需要括起来。

test=develop
