### PR TITLE
add input type and dtype check, enhance shape error message for concat_op

### DIFF
--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -67,8 +67,11 @@ class ConcatOp : public framework::OperatorWithKernel {
           if (check_shape) {
             // check all shape in run time
             PADDLE_ENFORCE_EQ(out_dims[j], ins[i][j],
-                              "Input tensors should have the same "
-                              "elements except the specify axis.");
+                              "ShapeError: Input tensors should have the same "
+                              "elements except the specify axis. "
+                              "But recevied axis = %s, input[0]'s shape = "
+                              "[%s], input[%s]'s shape = [%s]",
+                              axis, ins[0], i, ins[j]);
           }
         }
       }

--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -41,8 +41,9 @@ class ConcatOp : public framework::OperatorWithKernel {
                     static_cast<int64_t>(ins[0].size()));
 
     const size_t n = ins.size();
-
-    PADDLE_ENFORCE_GT(n, 0, "Input tensors count should > 0.");
+    PADDLE_ENFORCE_GT(n, 0,
+                      "ShapeError: Input tensors count should > 0. But "
+                      "recevied inputs' length is 0.");
     if (n == 1) {
       VLOG(3) << "Warning: concat op have only one input, may waste memory";
     }
@@ -66,12 +67,14 @@ class ConcatOp : public framework::OperatorWithKernel {
               ctx->IsRuntime() || (out_dims[j] > 0 && ins[i][j] > 0);
           if (check_shape) {
             // check all shape in run time
-            PADDLE_ENFORCE_EQ(out_dims[j], ins[i][j],
-                              "ShapeError: Input tensors should have the same "
-                              "elements except the specify axis. "
-                              "But recevied axis = %s, input[0]'s shape = "
-                              "[%s], input[%s]'s shape = [%s]",
-                              axis, ins[0], i, ins[j]);
+            PADDLE_ENFORCE_EQ(
+                out_dims[j], ins[i][j],
+                "ShapeError: Input tensors should have same "
+                "dimensions(or specific dimension = -1) except the axis. "
+                "But recevied axis = %s, input[0]'s shape = "
+                "[%s], input[%s]'s shape = [%s], the \"%s\" "
+                "dimension of input[%s] is unexpected",
+                axis, ins[0], i, ins[j], j, i);
           }
         }
       }

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -22,6 +22,8 @@ from ..initializer import Constant, force_init_on_cpu
 from ..core import VarDesc
 from .layer_function_generator import templatedoc
 import numpy
+import warnings
+from ..data_feeder import convert_dtype
 
 __all__ = [
     'create_tensor', 'create_parameter', 'create_global_var', 'cast',
@@ -202,6 +204,21 @@ def concat(input, axis=0, name=None):
             out = fluid.layers.concat(input=[a, b, c, d], axis=2)
     """
     helper = LayerHelper('concat', **locals())
+    for x in input:
+        if not isinstance(x, Variable):
+            raise TypeError(
+                "The type of x in 'input' in concat must be Variable, but received %s"
+                % (type(x)))
+        if convert_dtype(x.dtype) in ['float16']:
+            warnings.warn(
+                "The data type of x in 'input' in concat only support float16 on GPU now."
+            )
+        if convert_dtype(x.dtype) not in [
+                'float16', 'float32', 'float64', 'int32', 'int64'
+        ]:
+            raise TypeError(
+                "The data type of x in 'input' in concat must be float16(only support on GPU), float32, float64, int32, int64, but received %s."
+                % (convert_dtype(x.dtype)))
     out = helper.create_variable_for_type_inference(dtype=helper.input_dtype())
     helper.append_op(
         type='concat',

--- a/python/paddle/fluid/tests/unittests/test_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_concat_op.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 class TestConcatOp(OpTest):
@@ -111,6 +113,19 @@ create_test_fp16(TestConcatOp2)
 create_test_fp16(TestConcatOp3)
 create_test_fp16(TestConcatOp4)
 create_test_fp16(TestConcatOp5)
+
+
+class TestConcatOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of concat_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.concat, x1)
+            # The input dtype of concat_op must be float16(only support on GPU), float32, float64, int32, int64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype='float16')
+            self.assertRaises(TypeError, fluid.layers.softmax, x2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_concat_op.py
@@ -123,8 +123,8 @@ class TestConcatOpError(OpTest):
                 np.array([[-1]]), [[1]], fluid.CPUPlace())
             self.assertRaises(TypeError, fluid.layers.concat, x1)
             # The input dtype of concat_op must be float16(only support on GPU), float32, float64, int32, int64.
-            x2 = fluid.layers.data(name='x2', shape=[4], dtype='float16')
-            self.assertRaises(TypeError, fluid.layers.softmax, x2)
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype='uint8')
+            self.assertRaises(TypeError, fluid.layers.concat, x2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- 为concat python api的输入x加类型检查：

  - 检查类型是否为Variable
  - 检查数据类型是否为float16(gpu only), float32, float64, int32, int64
  - 在单测中覆盖类型错误和数据类型错误两个异常情况

- 为concat op的输入加shape检查
 
测试样例：
```
import paddle.fluid as fluid
import numpy as np

in1 = np.array([[1,2,3],
                [4,5,6]])
in2 = np.array([[1,2],
                [3,4],
                [5,6]])
with fluid.dygraph.guard():
    x1 = fluid.dygraph.to_variable(in1)
    x2 = fluid.dygraph.to_variable(in2)
    out = fluid.layers.concat(input=[x1,x2], axis=0)
    print(out.numpy())
```

修改前的报错信息：
```
Input tensors should have the same elements except the specify axis
```

修改后的报错信息：
```
Input tensors should have same dimensions(or specific dimension = -1) except the axis. But recevied axis = 0, input[0]'s shape = [2, 3], input[1]'s shape = [3, 2], the "1" dimension of input[1] is unexpected
```