### PR TITLE
add input type and dtype check for  elu_op

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10156,6 +10156,17 @@ def elu(x, alpha=1.0, name=None):
             y = fluid.layers.elu(x, alpha=0.2)
     """
     helper = LayerHelper('elu', **locals())
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'x' in elu must be Variable, but received %s" %
+            (type(x)))
+    if convert_dtype(x.dtype) in ['float16']:
+        warnings.warn(
+            "The data type of 'x' in elu only support float16 in GPU now.")
+    if convert_dtype(x.dtype) not in ['float16', 'float32', 'float64']:
+        raise TypeError(
+            "The data type of 'x' in elu must be float16 (only support on GPU), float32 or float64, but received %s."
+            % (convert_dtype(x.dtype)))
     out = helper.create_variable_for_type_inference(dtype=x.dtype)
     helper.append_op(
         type='elu',

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -19,6 +19,8 @@ import numpy as np
 import paddle.fluid.core as core
 from op_test import OpTest
 from scipy.special import expit, erf
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 class TestActivation(OpTest):
@@ -517,6 +519,18 @@ class TestELU(TestActivation):
         if self.dtype == np.float16:
             return
         self.check_grad(['X'], 'Out', max_relative_error=0.02)
+
+
+class TestELUOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of softmax_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.elu, x1)
+            # The input dtype of softmax_op must be float32 or float64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.elu, x2)
 
 
 class TestReciprocal(TestActivation):

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -524,11 +524,11 @@ class TestELU(TestActivation):
 class TestELUOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input type of softmax_op must be Variable.
+            # The input type of elu_op must be Variable.
             x1 = fluid.create_lod_tensor(
                 np.array([[-1]]), [[1]], fluid.CPUPlace())
             self.assertRaises(TypeError, fluid.layers.elu, x1)
-            # The input dtype of softmax_op must be float32 or float64.
+            # The input dtype of elu_op must be float16 float32 or float64.
             x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
             self.assertRaises(TypeError, fluid.layers.elu, x2)
 


### PR DESCRIPTION
为elu python api的输入input加类型检查：
- 检查类型是否为Variable
- 检查数据类型是否为float16或float32和float64