### PR TITLE
RecomputeOptimizer: rm unused ckpt and sort ckpt

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -131,10 +131,8 @@ class ProgramStats(object):
                 # input nodes
                 sorted_checkpoints.append((name, -1))
             else:
-                assert (len(self.var_op_deps[name]["var_as_output_ops"]) == 1
-                        ), "%s is output of multi ops, should not happen" % name
                 sorted_checkpoints.append(
-                    (name, self.var_op_deps[name]["var_as_output_ops"][0]))
+                    (name, max(self.var_op_deps[name]["var_as_output_ops"])))
         sorted_checkpoints = sorted(sorted_checkpoints, key=lambda x: x[1])
         return [x[0] for x in sorted_checkpoints]
 
@@ -607,6 +605,7 @@ def _append_backward_ops_with_checkpoints_(
     """
 
     checkpoints_name = [x.name for x in checkpoints]
+    checkpoints_name = list(set(checkpoints_name))
     local_block = block.program._create_block()
     buffer_block = block.program._create_block()
 
@@ -640,7 +639,6 @@ def _append_backward_ops_with_checkpoints_(
                 segments.append([min_idx, max_idx + 1])
             start_idx += 1
 
-    checkpoints_name = list(set(checkpoints_name))
     if segments != [] and segments[0][0] != 0:
         recompute_segments = [[0, segments[0][0]]] + segments
     else:

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -614,7 +614,7 @@ class TestLookaheadOptimizer(unittest.TestCase):
 
 
 class TestRecomputeOptimizer(unittest.TestCase):
-    def net(self):
+    def net(self, return_input=False):
         program = framework.Program()
         block = program.global_block()
         mul_x = block.create_parameter(
@@ -652,6 +652,8 @@ class TestRecomputeOptimizer(unittest.TestCase):
         block.append_op(
             type="mean", inputs={"X": b2_out}, outputs={"Out": mean_out})
 
+        if return_input == True:
+            return mul_x, mul_y, mul_out, b1_out, b2_out, mean_out
         return mul_out, b1_out, b2_out, mean_out
 
     def test_no_checkpoint(self):
@@ -737,6 +739,25 @@ class TestRecomputeOptimizer(unittest.TestCase):
         self.assertEqual([op.type for op in mean_out.block.ops], [
             "mul", "elementwise_add", "elementwise_add", "mean",
             "fill_constant", "mean_grad", "elementwise_add",
+            "elementwise_add_grad", "elementwise_add_grad", "mul_grad", "sgd",
+            "sgd", "sgd"
+        ])
+
+    def test_input_as_checkpoints(self):
+        mul_x, mul_y, mul_out, b1_out, b2_out, mean_out = self.net(
+            return_input=True)
+        self.assertEqual(len(mean_out.block.ops), 4)
+        self.assertEqual([op.type for op in mean_out.block.ops],
+                         ["mul", "elementwise_add", "elementwise_add", "mean"])
+        sgd_optimizer = optimizer.SGD(learning_rate=1.0)
+        recompute_optimizer = optimizer.RecomputeOptimizer(sgd_optimizer)
+        recompute_optimizer._set_checkpoints([mul_x, b2_out])
+        opts, params_grads = recompute_optimizer.minimize(mean_out)
+
+        self.assertEqual(len(mean_out.block.ops), 14)
+        self.assertEqual([op.type for op in mean_out.block.ops], [
+            "mul", "elementwise_add", "elementwise_add", "mean",
+            "fill_constant", "mean_grad", "mul", "elementwise_add",
             "elementwise_add_grad", "elementwise_add_grad", "mul_grad", "sgd",
             "sgd", "sgd"
         ])

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -653,7 +653,7 @@ class TestRecomputeOptimizer(unittest.TestCase):
             type="mean", inputs={"X": b2_out}, outputs={"Out": mean_out})
 
         if return_input == True:
-            return mul_x, mul_y, mul_out, b1_out, b2_out, mean_out
+            return mul_x, mul_out, b1_out, b2_out, mean_out
         return mul_out, b1_out, b2_out, mean_out
 
     def test_no_checkpoint(self):
@@ -744,8 +744,7 @@ class TestRecomputeOptimizer(unittest.TestCase):
         ])
 
     def test_input_as_checkpoints(self):
-        mul_x, mul_y, mul_out, b1_out, b2_out, mean_out = self.net(
-            return_input=True)
+        mul_x, mul_out, b1_out, b2_out, mean_out = self.net(return_input=True)
         self.assertEqual(len(mean_out.block.ops), 4)
         self.assertEqual([op.type for op in mean_out.block.ops],
                          ["mul", "elementwise_add", "elementwise_add", "mean"])

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -614,7 +614,7 @@ class TestLookaheadOptimizer(unittest.TestCase):
 
 
 class TestRecomputeOptimizer(unittest.TestCase):
-    def net(self, with_inplace=False):
+    def net(self):
         program = framework.Program()
         block = program.global_block()
         mul_x = block.create_parameter(
@@ -631,13 +631,6 @@ class TestRecomputeOptimizer(unittest.TestCase):
             dtype="float32", shape=[5, 8], lod_level=0, name="b2")
         b2_out = block.create_var(
             dtype="float32", shape=[5, 8], lod_level=0, name="b2_out")
-        if with_inplace == True:
-            inplace_b1 = block.create_parameter(
-                dtype="float32", shape=[5, 8], lod_level=0, name="inplace_b1")
-            inplace_b2 = block.create_parameter(
-                dtype="float32", shape=[5, 8], lod_level=0, name="inplace_b2")
-            inplace_b3 = block.create_parameter(
-                dtype="float32", shape=[5, 8], lod_level=0, name="inplace_b3")
         mean_out = block.create_var(
             dtype="float32", shape=[1], lod_level=0, name="mean.out")
         block.append_op(
@@ -646,34 +639,16 @@ class TestRecomputeOptimizer(unittest.TestCase):
                     "Y": mul_y},
             outputs={"Out": mul_out},
             attrs={"x_num_col_dims": 1})
-        if with_inplace == True:
-            block.append_op(
-                type="elementwise_add",
-                inputs={"X": mul_out,
-                        "Y": inplace_b1},
-                outputs={"Out": mul_out})
         block.append_op(
             type="elementwise_add",
             inputs={"X": mul_out,
                     "Y": b1},
             outputs={"Out": b1_out})
-        if with_inplace == True:
-            block.append_op(
-                type="elementwise_add",
-                inputs={"X": b1_out,
-                        "Y": inplace_b2},
-                outputs={"Out": b1_out})
         block.append_op(
             type="elementwise_add",
             inputs={"X": b1_out,
                     "Y": b2},
             outputs={"Out": b2_out})
-        if with_inplace == True:
-            block.append_op(
-                type="elementwise_add",
-                inputs={"X": b2_out,
-                        "Y": inplace_b3},
-                outputs={"Out": b2_out})
         block.append_op(
             type="mean", inputs={"X": b2_out}, outputs={"Out": mean_out})
 


### PR DESCRIPTION
RecomputeOptimizer has some bugs, this PR fixes them:

- some checkpoints are not used in the graph and should not be a checkpoint (This PR remove them from checkpoints list)

- If the checkpoints are not in order (the order they are generated), RecomputeOptimizer won't work correctly. (This PR sorts them)