### PR TITLE
fix windows compilation issue when compile with VS2015

### DIFF
--- a/paddle/fluid/operators/instance_norm_op.cu
+++ b/paddle/fluid/operators/instance_norm_op.cu
@@ -18,7 +18,6 @@ limitations under the License. */
 #include <vector>
 #include "cub/cub.cuh"
 #include "paddle/fluid/framework/data_layout.h"
-#include "paddle/fluid/operators/batch_norm_op.h"
 #include "paddle/fluid/operators/instance_norm_op.h"
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/platform/cudnn_helper.h"


### PR DESCRIPTION
remove unnecessary header "paddle/fluid/operators/batch_norm_op.h" in file instance_norm_op.cu to fix compilation issue on vs 2015