### PR TITLE
fix analysis_predictor ci, test=release/1.6

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor_tester.cc
+++ b/paddle/fluid/inference/api/analysis_predictor_tester.cc
@@ -71,9 +71,6 @@ TEST(AnalysisPredictor, analysis_on) {
   auto _predictor = CreatePaddlePredictor<AnalysisConfig>(config);
   auto* predictor = static_cast<AnalysisPredictor*>(_predictor.get());
 
-  if (predictor->inference_program_->Version() == 0) {
-    ASSERT_FALSE(predictor->CheckOperatorCompatible());
-  }
   ASSERT_TRUE(predictor->scope_);
   ASSERT_TRUE(predictor->sub_scope_);
   ASSERT_EQ(predictor->scope_->parent(), nullptr);


### PR DESCRIPTION
<img width="651" alt="2111" src="https://user-images.githubusercontent.com/39303645/66363884-60e01d80-e9ba-11e9-9421-81dc0cea5f6e.png">

在 Paddle 库版本为 1.6.0、模型版本为 0.0.0 时，根据模型文件内部算子兼容信息，应该有警告 (模型由 1.6.x develop 生成) 或兼容 (模型由 1.5.x develop 生成) 两种可能。单元测试 ASSERT_FALSE 忽略了上述兼容的情况，导致 CI 不通过。经过对这两种情况再次测试，确认报错是单测自身的问题。这个 PR 删除了这项检查。