### PR TITLE
enhance shape error message of fc API

### DIFF
--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -48,11 +48,12 @@ class SumOp : public framework::OperatorWithKernel {
     auto x_dims = ctx->GetInputsDim("X");
 
     auto N = x_dims.size();
-    PADDLE_ENFORCE_GT(N, 0,
-                      "ShapeError: The input tensor X's dimensions of SumOp "
-                      "should be larger than 0."
-                      "But received X's dimensions %d.",
-                      N);
+    PADDLE_ENFORCE_GT(
+        N, 0,
+        "ShapeError: The input tensor X's dimensions of SumOp "
+        "should be larger than 0. But received X's dimensions %d. "
+        "X's shape = %s.",
+        N, x_dims);
     if (N == 1) {
       VLOG(3) << "Warning: SumOp have only one input, may waste memory";
     }

--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -51,9 +51,9 @@ class SumOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_GT(
         N, 0,
         "ShapeError: The input tensor X's dimensions of SumOp "
-        "should be larger than 0. But received X's dimensions %d. "
-        "X's shape = %s.",
-        N, x_dims);
+        "should be larger than 0. But received X's dimensions %d, "
+        "X's shape = [%s].",
+        N, &x_dims);
     if (N == 1) {
       VLOG(3) << "Warning: SumOp have only one input, may waste memory";
     }
@@ -76,15 +76,15 @@ class SumOp : public framework::OperatorWithKernel {
           PADDLE_ENFORCE_EQ(
               in_dim, x_dim,
               "ShapeError: The input tensor X of SumOp must have same shape."
-              "But received X[0]'s shape = %s, X[%d]'s shape = %s.",
+              "But received X[0]'s shape = [%s], X[%d]'s shape = [%s].",
               in_dim, i, x_dim);
         } else {
           PADDLE_ENFORCE_EQ(
               in_dim.size(), x_dim.size(),
               "ShapeError: The input tensor X of SumOp must have same "
-              "dimensions."
-              "But received X[0]'s dimensions = %d, X[%d]'s dimensions = %d.",
-              in_dim.size(), i, x_dim.size());
+              "dimensions. But received X[0]'s dimensions = %d, X[0]'s shape = "
+              "[%s], X[%d]'s dimensions = %d, X[%d]'s shape = [%s].",
+              in_dim.size(), in_dim, i, x_dim.size(), i, x_dim);
           // if in_dim or x_dim has -1, not check equal
           for (int j = 0; j < x_dim.size(); ++j) {
             if (x_dim[j] == -1 || in_dim[j] == -1) {
@@ -94,7 +94,7 @@ class SumOp : public framework::OperatorWithKernel {
                 in_dim[j], x_dim[j],
                 "ShapeError: The input tensor X of SumOp must have same shape "
                 "if not -1."
-                "But received X[0]'s shape = %s, X[%d]'s shape = %s.",
+                "But received X[0]'s shape = [%s], X[%d]'s shape = [%s].",
                 in_dim, i, x_dim);
           }
         }

--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -50,7 +50,7 @@ class SumOp : public framework::OperatorWithKernel {
     auto N = x_dims.size();
     PADDLE_ENFORCE_GT(N, 0,
                       "ShapeError: The input tensor X's dimensions of SumOp "
-                      "shoud be larger than 0."
+                      "should be larger than 0."
                       "But received X's dimensions %d.",
                       N);
     if (N == 1) {

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -329,8 +329,22 @@ def fc(input,
           fc = fluid.layers.fc(input=[data_1, data_2], size=1000, act="tanh")
     """
     helper = LayerHelper("fc", **locals())
-
+    if isinstance(input, (list, tuple)):
+        for i, input_x in enumerate(input):
+            if not isinstance(input_x, Variable):
+                raise TypeError(
+                    "The type of input[%d] in fc must be Variable, but received %s"
+                    % (i, type(input_x)))
+    else:
+        if not isinstance(input, Variable):
+            raise TypeError(
+                "The type of 'input' in fc must be Variable, but received %s" %
+                (type(input)))
     dtype = helper.input_dtype()
+    if convert_dtype(dtype) not in ['float32', 'float64']:
+        raise TypeError(
+            "The data type of 'input' in fc must be float32 or float64, but received %s."
+            % (convert_dtype(dtype)))
 
     mul_results = []
     for input_var, param_attr in helper.iter_inputs_and_params():

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -15,6 +15,8 @@
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 def fc_refer(matrix, with_bias, with_relu=False):
@@ -120,6 +122,31 @@ class TestFCOpWithBias3(TestFCOp):
         self.with_bias = True
         self.with_relu = True
         self.matrix = MatrixGenerate(1, 64, 32, 3, 3, 1)
+
+
+class TestFCOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            input_data = np.random.random((2, 4)).astype("float32")
+
+            def test_Variable():
+                # the input type must be Variable
+                fluid.layers.fc(input=input_data, size=1)
+
+            self.assertRaises(TypeError, test_Variable)
+
+            def test_input_list():
+                # each of input(list) must be Variable
+                fluid.layers.fc(input=[input_data], size=1)
+
+            self.assertRaises(TypeError, test_input_list)
+
+            def test_type():
+                # dtype must be float32 or float64
+                x2 = fluid.layers.data(name='x2', shape=[4], dtype='int32')
+                fluid.layers.fc(input=x2, size=1)
+
+            self.assertRaises(TypeError, test_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**fluid.layers.fc**:
+ Add input type check, error info as follows:
```python
import paddle.fluid as fluid
from paddle.fluid import Program, program_guard
with program_guard(Program(), Program()):
    input_data = np.random.random((2, 4)).astype("float32")
    fluid.layers.fc(input=input_data, size=1)
```
`TypeError: The type of 'input' in fc must be Variable, but received <type 'numpy.ndarray'>`
+ if input is list, error info as follows:
```python
import paddle.fluid as fluid
from paddle.fluid import Program, program_guard
with program_guard(Program(), Program()):
    input_data = np.random.random((2, 4)).astype("float32")
    fluid.layers.fc(input=[input_data], size=1)
```
`TypeError: The type of input[0] in fc must be Variable, but received <type 'numpy.ndarray'>`
+ Add data type check, error info as follows:
```python
import paddle.fluid as fluid
from paddle.fluid import Program, program_guard
with program_guard(Program(), Program()):
    x = fluid.data(name='x', shape=[3,4],dtype='int32')
    fluid.layers.fc(input=x, size=1)
```
`TypeError: The data type of 'input' in fc must be float32 or float64, but received int32.`

**sum OP**：Enhance error message in InferShape of SumOp
+ should have same shape
```python
import paddle.fluid as fluid
import paddle.fluid.layers as layers
import numpy as np
input0 = layers.data(name="input0", shape=[-1,13], dtype='float32')
input1 = layers.data(name="input1", shape=[-1,13], dtype='float32')
out = layers.sum([input0, input1])
place = fluid.CPUPlace()
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
input0_data = np.random.random([6, 13]).astype("float64")
input1_data = np.random.random([2, 13]).astype("float64")
ret = exe.run(
    feed={
        'input0': input0_data,
        'input1': input1_data
    },
    fetch_list=[out],
    return_numpy=False)
```
**before:** `PaddleCheckError: Expected in_dim == x_dim, but received in_dim:6, 13 != x_dim:2, 13.`
**after:** `ShapeError: The input tensor X of SumOp must have same shape.But received X[0]'s shape = [6, 13], X[1]'s shape = [2, 13].`
+ should have same dimensions
```python
ShapeError: The input tensor X of SumOp must have same shape.But received X[0]'s shape = [6, 13], X[1]'s shape = [2, 13]
```
**before:** `PaddleCheckError: Expected in_dim[j] == x_dim[j], but received in_dim[j]:12 != x_dim[j]:13`
**after:** `ShapeError: The input tensor X of SumOp must have same shape if not -1.But received X[0]'s shape = [-1, 12], X[1]'s shape = [-1, 13].`

```python
ShapeError: The input tensor X of SumOp must have same shape.But received X[0]'s shape = [6, 13], X[1]'s shape = [2, 13]
```
**before:** `PaddleCheckError: Expected in_dim.size() == x_dim.size(), but received in_dim.size():3 != x_dim.size():2`
**after:** `ShapeError: The input tensor X of SumOp must have same dimensions. But received X[0]'s dimensions = 3, X[0]'s shape = [-1, 12, 13], X[1]'s dimensions = 2, X[1]'s shape = [-1, 13]`