### PR TITLE
[Bug-fix][1.6] Improve QAT accuracy

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -381,13 +381,13 @@ class FakeQAT2MkldnnINT8PerfPass(object):
                 next_op = op_out.outputs[0]
                 if next_op.name() not in self._mul_ops:
                     self._remove_fake_quantize(graph, op)
-                else:
-                    quant_op = self._transform_to_quantize_mkldnn(graph, op)
-                    self._transform_to_mul_mkldnn(graph, next_op, quant_op)
 
         for op in graph.all_op_nodes():
             if op.name() in self._fake_dequantize_types:
-                self._remove_fake_dequantize(graph, op)
+                op_in = graph._find_node_by_name(op.inputs, op.input("X")[0])
+                prev_op = op_in.inputs[0]
+                if prev_op.name() not in self._mul_ops:
+                    self._remove_fake_dequantize(graph, op)
         return graph
 
     def _remove_fake_quantize(self, graph, op):

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -378,13 +378,13 @@ class FakeQAT2MkldnnINT8PerfPass(object):
                 next_op = op_out.outputs[0]
                 if next_op.name() not in self._mul_ops:
                     self._remove_fake_quantize(graph, op)
+                else:
+                    quant_op = self._transform_to_quantize_mkldnn(graph, op)
+                    self._transform_to_mul_mkldnn(graph, next_op, quant_op)
 
         for op in graph.all_op_nodes():
             if op.name() in self._fake_dequantize_types:
-                op_in = graph._find_node_by_name(op.inputs, op.input("X")[0])
-                prev_op = op_in.inputs[0]
-                if prev_op.name() not in self._mul_ops:
-                    self._remove_fake_dequantize(graph, op)
+                self._remove_fake_dequantize(graph, op)
         return graph
 
     def _remove_fake_quantize(self, graph, op):

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -470,9 +470,8 @@ class FakeQAT2MkldnnINT8PerfPass(object):
     def _apply_pass(self, graph, pass_name, attrs=None, attr_values=None):
         ir_pass = core.get_pass(pass_name)
         cpp_graph = graph.graph
-        if cpp_graph.has('__param_scope__'):
-            cpp_graph.erase('__param_scope__')
-        cpp_graph.set_not_owned('__param_scope__', self._scope)
+        if not cpp_graph.has('__param_scope__'):
+            cpp_graph.set_not_owned('__param_scope__', self._scope)
         if attrs:
             assert attr_values and len(attrs) == len(
                 attr_values
@@ -480,7 +479,6 @@ class FakeQAT2MkldnnINT8PerfPass(object):
             for attr, value in zip(attrs, attr_values):
                 ir_pass.set(attr, value)
         ir_pass.apply(cpp_graph)
-        graph = IrGraph(cpp_graph, for_test=True)
         if self._debug:
             graph.draw('.', 'qat_fp32_{}'.format(pass_name),
                        graph.all_op_nodes())
@@ -574,7 +572,6 @@ class FakeQAT2MkldnnINT8PerfPass(object):
         ir_pass.set('quantize_excluded_op_ids',
                     self._find_avg_pooling_ids(graph))
         ir_pass.apply(cpp_graph)
-        graph = IrGraph(cpp_graph, for_test=True)
         if self._debug:
             graph.draw('.', 'qat_int8_{}'.format(ir_pass.type()),
                        graph.all_op_nodes())

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -378,13 +378,13 @@ class FakeQAT2MkldnnINT8PerfPass(object):
                 next_op = op_out.outputs[0]
                 if next_op.name() not in self._mul_ops:
                     self._remove_fake_quantize(graph, op)
-                else:
-                    quant_op = self._transform_to_quantize_mkldnn(graph, op)
-                    self._transform_to_mul_mkldnn(graph, next_op, quant_op)
 
         for op in graph.all_op_nodes():
             if op.name() in self._fake_dequantize_types:
-                self._remove_fake_dequantize(graph, op)
+                op_in = graph._find_node_by_name(op.inputs, op.input("X")[0])
+                prev_op = op_in.inputs[0]
+                if prev_op.name() not in self._mul_ops:
+                    self._remove_fake_dequantize(graph, op)
         return graph
 
     def _remove_fake_quantize(self, graph, op):

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -351,8 +351,8 @@ class FakeQAT2MkldnnINT8PerfPass(object):
                 use_unsigned_int = False
                 self._var_quant_scales[input_name] = (use_unsigned_int,
                                                       lod_tensor)
-                self._var_quant_scales[scale_name.replace(".scale", "")] = (use_unsigned_int,
-                                                      lod_tensor)
+                self._var_quant_scales[scale_name.replace(".scale", "")] = (
+                    use_unsigned_int, lod_tensor)
 
             if op.name() in self._fake_dequantize_types:
                 input_name = op.input("X")[0]

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -350,6 +350,8 @@ class FakeQAT2MkldnnINT8PerfPass(object):
                 use_unsigned_int = False
                 self._var_quant_scales[input_name] = (use_unsigned_int,
                                                       lod_tensor)
+                self._var_quant_scales[scale_name.replace(".scale", "")] = (use_unsigned_int,
+                                                      lod_tensor)
 
             if op.name() in self._fake_dequantize_types:
                 input_name = op.input("X")[0]

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -560,16 +560,6 @@ class FakeQAT2MkldnnINT8PerfPass(object):
         graph.safe_remove_nodes(op_node)
         return quant_op_node
 
-    def _transform_to_mul_mkldnn(self, graph, op_node, quantize_node):
-        output_name = op_node.output("Out")[0]
-        scale_in = quantize_node.op().attr("Scale")
-        self._dequantize_mul_weights(graph, op_node)
-        op_node.set_attr("scale_y",
-                         [self._weight_scales[output_name] / self._s8_max])
-        op_node.set_attr("scale_x", self._s8_max / scale_in)
-        op_node.set_attr("scale_out", 1.0)
-        op_node.set_attr("force_fp32_output", True)
-
     def _update_conv_relu_scales(self, graph):
         for op in graph.all_op_nodes():
             if op.name() in self._conv_ops:

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -533,7 +533,7 @@ class FakeQAT2MkldnnINT8PerfPass(object):
             if op.name() in self._pool_ops:
                 if op.op().attr("pooling_type") == "avg":
                     ids.append(op.id())
-        return set(ids)
+        return set(ids) if len(ids) else set([-1])
 
     def _transform_to_quantize_mkldnn(self, graph, op_node):
         """

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -470,8 +470,9 @@ class FakeQAT2MkldnnINT8PerfPass(object):
     def _apply_pass(self, graph, pass_name, attrs=None, attr_values=None):
         ir_pass = core.get_pass(pass_name)
         cpp_graph = graph.graph
-        if not cpp_graph.has('__param_scope__'):
-            cpp_graph.set_not_owned('__param_scope__', self._scope)
+        if cpp_graph.has('__param_scope__'):
+            cpp_graph.erase('__param_scope__')
+        cpp_graph.set_not_owned('__param_scope__', self._scope)
         if attrs:
             assert attr_values and len(attrs) == len(
                 attr_values
@@ -479,6 +480,7 @@ class FakeQAT2MkldnnINT8PerfPass(object):
             for attr, value in zip(attrs, attr_values):
                 ir_pass.set(attr, value)
         ir_pass.apply(cpp_graph)
+        graph = IrGraph(cpp_graph, for_test=True)
         if self._debug:
             graph.draw('.', 'qat_fp32_{}'.format(pass_name),
                        graph.all_op_nodes())
@@ -572,6 +574,7 @@ class FakeQAT2MkldnnINT8PerfPass(object):
         ir_pass.set('quantize_excluded_op_ids',
                     self._find_avg_pooling_ids(graph))
         ir_pass.apply(cpp_graph)
+        graph = IrGraph(cpp_graph, for_test=True)
         if self._debug:
             graph.draw('.', 'qat_int8_{}'.format(ir_pass.type()),
                        graph.all_op_nodes())


### PR DESCRIPTION
Provides a fix for accuracy drop obtained with QAT models by enabling uint8 variable type on conv-relu outputs.
Also enables executing VGG16 and VGG19 by:
* Adding additional way of fetching scales (by associating tensor with its tensor scale by the *.scale suffix)
* Fixing bug with empty list of disabled op ids
Restores fake-quant mul to achieve best accuracy.

## Accuracy comparison
### Resnet50
|                 | top1 acc | top 5 acc |
|-----------------|----------|-----------|
| Original QAT    | 0.7655   | 0.9304    |
| Transformed QAT | 0.7653   | 0.9298    |
| Diff            | 0.0002   | 0.0006    |

### Mobilenet V1
|                 | top1 acc | top 5 acc |
|-----------------|----------|-----------|
| Original QAT    | 0.7077   | 0.8954    |
| Transformed QAT | 0.7076   | 0.8943    |
| Diff            | 0.0001   | 0.0011    |

