### PR TITLE
Refine Error Message for New Data API

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -204,13 +204,14 @@ def check_feed_shape_type(var, feed):
     """
     if var.desc.need_check_feed():
         if not dimension_is_compatible_with(feed.shape(), var.shape):
-            raise ValueError('Cannot feed value of shape %r for Variable %r, '
-                             'which has shape %r' %
-                             (feed.shape, var.name, var.shape))
+            raise ValueError(
+                'ShapeError: The feeded Variable %r should have dimensions = '
+                '%d, shape = %r, but received feeded shape %r' %
+                (var.name, len(var.shape), var.shape, feed.shape()))
         if not dtype_is_compatible_with(feed._dtype(), var.dtype):
-            raise ValueError('Cannot feed value of type %r for Variable %r, '
-                             'which has type %r' %
-                             (feed._dtype(), var.name, var.dtype))
+            raise ValueError(
+                'The data type of feeded Variable %r must be %r, but received %r'
+                % (var.name, var.dtype, feed._dtype()))
     return True
 
 

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -22,6 +22,7 @@ import warnings
 import numpy as np
 from .wrapped_decorator import signature_safe_contextmanager
 import six
+from .data_feeder import convert_dtype
 from .framework import Program, default_main_program, Variable, convert_np_dtype_to_dtype_
 from . import core
 from . import compiler
@@ -205,13 +206,17 @@ def check_feed_shape_type(var, feed):
     if var.desc.need_check_feed():
         if not dimension_is_compatible_with(feed.shape(), var.shape):
             raise ValueError(
-                'ShapeError: The feeded Variable %r should have dimensions = '
-                '%d, shape = %r, but received feeded shape %r' %
+                'The feeded Variable %r should have dimensions = %d, shape = '
+                '%r, but received feeded shape %r' %
                 (var.name, len(var.shape), var.shape, feed.shape()))
         if not dtype_is_compatible_with(feed._dtype(), var.dtype):
+            var_dtype_format = convert_dtype(var.dtype) if isinstance(
+                var.dtype, core.VarDesc.VarType) else var.dtype
+            feed_dtype_format = convert_dtype(feed._dtype()) if isinstance(
+                feed._dtype(), core.VarDesc.VarType) else feed._dtype()
             raise ValueError(
                 'The data type of feeded Variable %r must be %r, but received %r'
-                % (var.name, var.dtype, feed._dtype()))
+                % (var.name, var_dtype_format, feed_dtype_format))
     return True
 
 

--- a/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
+++ b/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
@@ -97,8 +97,8 @@ class TestFeedData(unittest.TestCase):
                                                         use_parallel_executor)
                 self.assertEqual(
                     str(shape_mismatch_err.exception),
-                    "ShapeError: The feeded Variable %r should have dimensions"
-                    " = %r, shape = %r, but received feeded shape %r" %
+                    "The feeded Variable %r should have dimensions = %r, "
+                    "shape = %r, but received feeded shape %r" %
                     (u'data', len(in_shape_tuple), in_shape_tuple,
                      feed_shape_list))
 
@@ -107,8 +107,8 @@ class TestFeedData(unittest.TestCase):
                                                         use_parallel_executor)
                 self.assertEqual(
                     str(dtype_mismatch_err.exception),
-                    "The data type of feeded Variable %r must be "
-                    "VarType.INT64, but received VarType.FP64" % (u'label'))
+                    "The data type of feeded Variable %r must be 'int64', but "
+                    "received 'float64'" % (u'label'))
 
     def _test_feed_data_dtype_mismatch(self, use_cuda, use_parallel_executor):
         batch_size = self._get_batch_size(use_cuda, use_parallel_executor)


### PR DESCRIPTION
The shape doesn't match error will be like:

_"The Variable u'data' should have dimensions = 4, shape = (-1, 3, 4, 8), but received feeded shape [10, 3, 4, 5]"_

The dtype doesn't match error will be like:

_"The data type of feeded Variable u'label' must be 'int64', but received 'float64'"_