### PR TITLE
refine error message for transpose_op

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7118,16 +7118,26 @@ def transpose(x, perm, name=None):
             x_transposed = fluid.layers.transpose(x, perm=[1, 0, 2])
     """
 
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'x' in transpose must be Variable, but received %s" %
+            (type(x)))
+    if convert_dtype(input.dtype) not in ['float32', 'float64']:
+        raise TypeError(
+            "The data type of 'input' in softmax must be float32 or float64, "
+            "but received %s." % (convert_dtype(input.dtype)))
     if len(perm) != len(x.shape):
         raise ValueError(
             "Input(perm) is the permutation of dimensions of Input(input). "
-            "Its length should be equal to Input(input)'s rank.")
+            "Its length should be equal to dimensions of Input(input). "
+            " But received dimension of Input(input) is %s, " % len(x.shape)
+            "the permutation of dimensions of Input(input) is %s." % len(perm))
     for idx, dim in enumerate(perm):
         if dim >= len(x.shape):
             raise ValueError(
-                "Each element in perm should be less than x's rank. "
-                "%d-th element in perm is %d which accesses x's rank %d." %
-                (idx, perm[idx], len(x.shape)))
+                "Each element in perm should be less than x's dimension. "
+                "%d-th element in perm is %d which accesses x's dimension "
+                "%d." % (idx, perm[idx], len(x.shape)))
 
     helper = LayerHelper('transpose', **locals())
     out = helper.create_variable_for_type_inference(x.dtype)

--- a/python/paddle/fluid/tests/unittests/test_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_transpose_op.py
@@ -47,6 +47,17 @@ class TestTransposeOp(OpTest):
         self.shape = (3, 4)
         self.axis = (1, 0)
 
+class TestTransposeOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of transpose_op must be Variable.
+            perm = [3, 4]
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.transpose, x1, perm)
+            # The input dtype of softmax_op must be float32 or float64.
+            x2 = fluid.layers.data(name='x2', shape=[4, 6], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.transpose, x2, perm)
 
 class TestCase0(TestTransposeOp):
     def initTestCase(self):


### PR DESCRIPTION
# Input检查

Transpose op，其Input包含输入的 `x` 和转置所需要指定的轴向变化参数 `perm` 。

## Input检查参数 `x`：类型检查

优化报错代码

```python
    if not isinstance(x, Variable):
        raise TypeError(
            "The type of 'x' in transpose must be Variable, but received %s" %
            (type(x)))
```

报错前后变化

```python
# 执行代码
x_transposed = fluid.layers.transpose("123", perm=[1, 0, 2, 4, 5])

# 优化前
AttributeError: 'str' object has no attribute 'shape'

# 优化后
TypeError: The type of 'x' in transpose must be Variable, but received <type 'str'>
```

## Input检查参数 `perm` ：1. 类型检查

优化报错代码

```python
    if not isinstance(perm, list):
        raise TypeError(
            "The type of 'perm' in transpose must be list, but received %s" %
            (type(perm)))
```

报错前后变化

```python
# 执行代码
x0 = fluid.layers.data(name='x0', shape=[5, 10, 15], dtype="float32", append_batch_size=False)
x_transposed = fluid.layers.transpose(x0, perm="[1, 0, 2]")

# 优化前
ValueError: Input(perm) is the permutation of dimensions of Input(input). Its length should be equal to Input(input)'s rank.

# 优化后
TypeError: The type of 'perm' in transpose must be list, but received <type 'str'>
```

## Input检查参数 `perm` ：2. 维度检查

优化报错代码

```python
    if len(perm) != len(x.shape):
        raise ValueError(
            "Input(perm) is the permutation of dimensions of Input(input), "
            "its length should be equal to dimensions of Input(input), "
            "but received dimension of Input(input) is %s, " % len(x.shape)
            "the permutation of dimensions of Input(input) is %s." % len(perm))
```

报错前后变化

```python
# 执行代码
x0 = fluid.layers.data(name='x0', shape=[5, 10, 15], dtype="float32", append_batch_size=False)
x_transposed = fluid.layers.transpose(x0, perm="[1, 0, 2]")

# 优化前
ValueError: Input(perm) is the permutation of dimensions of Input(input). Its length should be equal to Input(input)'s rank.

# 优化后
ValueError: Input(perm) is the permutation of dimensions of Input(input), its length should be equal to dimensions of Input(input), but received dimension of Input(input) is 3, the permutation of dimensions of Input(input) is 4.
```