### PR TITLE
cherry-pick #20230

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include <array>
 #include <memory>
 #include <vector>
 #include "paddle/fluid/framework/operator_kernel_configs.h"


### PR DESCRIPTION
fix compilation error on windows:
paddle/fluid/operators/conv_cudnn_helper.h(271): error : incomplete type is not allowed [paddle\fluid\operators\conv_op.vcxproj]