### PR TITLE
cherry-pick enhance API create_parameter test=develop test=release/1.6

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4117,15 +4117,20 @@ class Parameter(Variable):
     """
 
     def __init__(self, block, shape, dtype, **kwargs):
-        if shape is None or dtype is None:
-            raise ValueError("Parameter must set shape and dtype")
+        if shape is None:
+            raise ValueError("The shape of Parameter should not be None")
+        if dtype is None:
+            raise ValueError("The dtype of Parameter should not be None")
+
         if len(shape) == 0:
-            raise ValueError("Parameter shape cannot be empty")
+            raise ValueError(
+                "The dimensions of shape for Parameter must be greater than 0")
 
         for each in shape:
             if each < 0:
-                raise ValueError("Parameter shape should not be related with "
-                                 "batch-size")
+                raise ValueError(
+                    "Each dimension of shape for Parameter must be greater than 0, but received %s"
+                    % list(shape))
 
         Variable.__init__(
             self, block, persistable=True, shape=shape, dtype=dtype, **kwargs)

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -46,6 +46,21 @@ class TestParameter(unittest.TestCase):
         p = io.get_parameter_value_by_name('fc.w', exe, main_program)
         self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))
 
+    def test_exceptions(self):
+        b = main_program.global_block()
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=None, dtype='float32', initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=[1], dtype=None, initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=[], dtype='float32', initializer=None)
+        with self.assertRaises(ValueError):
+            b.create_parameter(
+                name='test', shape=[-1], dtype='float32', initializer=None)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add more pre-checks to API create_parameter to enhance the readability and give more friendly feedbacks to users when exception caught.

Add more checks to inputs.
Add more unit-test cases to cover extra code branches.

cherry-pick: https://github.com/PaddlePaddle/Paddle/pull/20059