### PR TITLE
enhance uniform_random op python api's check

### DIFF
--- a/paddle/fluid/operators/uniform_random_op.cc
+++ b/paddle/fluid/operators/uniform_random_op.cc
@@ -75,7 +75,11 @@ class CPUUniformRandomKernel : public framework::OpKernel<T> {
     auto diag_val = static_cast<T>(ctx.Attr<float>("diag_val"));
     if (diag_num > 0) {
       PADDLE_ENFORCE_GT(size, (diag_num - 1) * (diag_step + 1),
-                        "The index of diagonal elements is out of bounds");
+                        "ShapeError: the diagonal's elements is equal (num-1) "
+                        "* (step-1) with num %d, step %d,"
+                        "It should be smaller than %d, but received %d",
+                        diag_num, diag_step, (diag_num - 1) * (diag_step + 1),
+                        size);
       for (int64_t i = 0; i < diag_num; ++i) {
         int64_t pos = i * diag_step + i;
         data[pos] = diag_val;
@@ -118,9 +122,10 @@ class UniformRandomOp : public framework::OperatorWithKernel {
       auto shape_dims = ctx->GetInputDim("ShapeTensor");
       PADDLE_ENFORCE_EQ(
           shape_dims.size(), 1,
-          "Input(ShapeTensor)' dimension size of Op(uniform_random) must be 1."
-          "Please check the Attr(shape)'s dimension size of"
-          "Op(fluid.layers.uniform_random).)");
+          "ShapeError: Input(ShapeTensor)' dimension size of "
+          "Op(uniform_random) must be 1."
+          "But received ShapeTensor's dimensions = %d, shape = [%s]",
+          shape_dims.size(), shape_dims);
       int num_ele = 1;
       for (int i = 0; i < shape_dims.size(); ++i) {
         num_ele *= shape_dims[i];

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -15682,9 +15682,17 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0):
 
     """
     if not (isinstance(shape, (list, tuple, Variable))):
-        raise TypeError("Input shape must be a python list,Variable or tuple.")
+        raise TypeError(
+            "Input shape must be a python list,Variable or tuple. But received %s"
+            % (type(shape)))
+
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
+
+    if convert_dtype(dtype) not in ['float32', 'float64']:
+        raise TypeError(
+            "The attribute dtype in uniform_random op must be float32 or float64, but received %s."
+            % (convert_dtype(dtype)))
 
     def contain_var(one_list):
         for ele in one_list:

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
@@ -20,6 +20,7 @@ from op_test import OpTest
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 def output_hist(out):
@@ -114,6 +115,27 @@ class TestUniformRandomOp(OpTest):
         self.assertTrue(
             np.allclose(
                 hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
+
+
+class TestUniformRandomOpError(OpTest):
+    def test_errors(self):
+        main_prog = Program()
+        start_prog = Program()
+        with program_guard(main_prog, start_prog):
+
+            def test_Variable():
+                x1 = fluid.create_lod_tensor(
+                    np.zeros((4, 784)), [[1, 1, 1, 1]], fluid.CPUPlace())
+                fluid.layers.uniform_random(x1)
+
+            self.assertRaises(TypeError, test_Variable)
+
+            def test_dtype():
+                x2 = fluid.layers.data(
+                    name='x2', shape=[4, 784], dtype='float32')
+                fluid.layers.uniform_random(x2, 'int32')
+
+            self.assertRaises(TypeError, test_dtype)
 
 
 class TestUniformRandomOpWithDiagInit(TestUniformRandomOp):


### PR DESCRIPTION
为uniform_random python api的输入input加类型检查：

检查类型是否为Variable
检查数据类型是否为float32和float64
在单测中覆盖类型错误和数据类型错误两个异常情况
main_prog = Program()
start_prog = Program()
with program_guard(main_prog, start_prog):
    def test_Variable():
         x1 = fluid.create_lod_tensor(
             np.zeros((4, 784)), [[1, 1, 1, 1]], fluid.CPUPlace())
         fluid.layers.uniform_random(x1)
    self.assertRaises(TypeError, test_Variable)

    def test_dtype():
        x2 = fluid.layers.data(
            name='x2', shape=[4, 784], dtype='float32')
        fluid.layers.uniform_random(x2, 'int32')
    self.assertRaises(TypeError, test_dtype)