### PR TITLE
fix fuse_reduce_op quantization bug 

### DIFF
--- a/python/paddle/fluid/contrib/slim/core/compressor.py
+++ b/python/paddle/fluid/contrib/slim/core/compressor.py
@@ -480,9 +480,12 @@ class Compressor(object):
         executor = SlimGraphExecutor(self.place)
 
         if context.optimize_graph.compiled_graph is None:
+            build_strategy = compiler.BuildStrategy()
+            build_strategy.fuse_all_reduce_ops = False
             context.optimize_graph.compiled_graph = compiler.CompiledProgram(
                 context.optimize_graph.program).with_data_parallel(
-                    loss_name=context.optimize_graph.out_nodes['loss'])
+                    loss_name=context.optimize_graph.out_nodes['loss'],
+                    build_strategy=build_strategy)
 
         if isinstance(context.train_reader, Variable) or (
                 isinstance(context.train_reader,

--- a/python/paddle/fluid/contrib/slim/graph/graph_wrapper.py
+++ b/python/paddle/fluid/contrib/slim/graph/graph_wrapper.py
@@ -263,6 +263,7 @@ class GraphWrapper(object):
             build_strategy = compiler.BuildStrategy()
             build_strategy.enable_inplace = mem_opt
             build_strategy.memory_optimize = mem_opt
+            build_strategy.fuse_all_reduce_ops = False
             #            build_strategy.async_mode = False
             self.compiled_graph = compiler.CompiledProgram(
                 target).with_data_parallel(

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_strategy.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_strategy.py
@@ -138,6 +138,7 @@ class QuantizationStrategy(Strategy):
         build_strategy = BuildStrategy()
         build_strategy.enable_inplace = False
         build_strategy.memory_optimize = False
+        build_strategy.fuse_all_reduce_ops = False
         # for quantization training
         context.optimize_graph.compiled_graph = CompiledProgram(
             train_ir_graph.graph).with_data_parallel(


### PR DESCRIPTION
fix fuse_reduce_op quantization bug, because build_strategy.fuse_all_reduce_ops's default value  changes to 'True' from v1.6.