### PR TITLE
Add parameter_list input type check for backward

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1071,7 +1071,7 @@ def append_backward(loss,
                 "The type of parameter_list argument must be list, but received %s."
                 % (type(parameter_list)))
         for i, param_name in enumerate(parameter_list):
-            if not isinstance(param_name, str):
+            if not isinstance(param_name, (str, unicode)):
                 raise TypeError(
                     "The type of parameter_list's member must be str, but received %s."
                     % (type(param_name)))

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1066,6 +1066,15 @@ def append_backward(loss,
     program._sync_with_cpp()
 
     if parameter_list is not None:
+        if not isinstance(parameter_list, list):
+            raise TypeError(
+                "The type of parameter_list argument must be list, but received %s."
+                % (type(parameter_list)))
+        for i, param_name in enumerate(parameter_list):
+            if not isinstance(param_name, str):
+                raise TypeError(
+                    "The type of parameter_list's member must be str, but received %s."
+                    % (type(param_name)))
         parameters = parameter_list
     else:
         params = program.global_block().all_parameters()

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -472,6 +472,15 @@ class Optimizer(object):
         self._dtype = loss.dtype
         if framework.in_dygraph_mode():
             if parameter_list is not None:
+                if not isinstance(parameter_list, list):
+                    raise TypeError(
+                        "The type of parameter_list argument must be list, but received %s."
+                        % (type(parameter_list)))
+                for i, param_name in enumerate(parameter_list):
+                    if not isinstance(param_name, str):
+                        raise TypeError(
+                            "The type of parameter_list's member must be str, but received %s."
+                            % (type(param_name)))
                 parameters = parameter_list
             else:
                 parameters = framework._dygraph_tracer().all_parameters()
@@ -614,7 +623,10 @@ class Optimizer(object):
             tuple: (optimize_ops, params_grads) which are, list of operators appended;
             and list of (param, grad) Variables pair for optimization.
         """
-        assert isinstance(loss, Variable), "The loss should be an Variable."
+        if not isinstance(loss, Variable):
+            raise TypeError(
+                "The loss should be an paddle.fluid.Variable, but received %s" %
+                type((loss)))
         params_grads = self.backward(
             loss,
             startup_program=startup_program,

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -472,15 +472,6 @@ class Optimizer(object):
         self._dtype = loss.dtype
         if framework.in_dygraph_mode():
             if parameter_list is not None:
-                if not isinstance(parameter_list, list):
-                    raise TypeError(
-                        "The type of parameter_list argument must be list, but received %s."
-                        % (type(parameter_list)))
-                for i, param_name in enumerate(parameter_list):
-                    if not isinstance(param_name, str):
-                        raise TypeError(
-                            "The type of parameter_list's member must be str, but received %s."
-                            % (type(param_name)))
                 parameters = parameter_list
             else:
                 parameters = framework._dygraph_tracer().all_parameters()

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -330,7 +330,7 @@ class TestConv2dOp(OpTest):
             return
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.02)
+            place, ['Input', 'Filter'], 'Output', max_relative_error=0.02)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
@@ -751,7 +751,7 @@ class TestConv2dOp_v2(OpTest):
             return
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.02)
+            place, ['Input', 'Filter'], 'Output', max_relative_error=0.02)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -186,13 +186,10 @@ class TestConv2dTransposeOp(OpTest):
         if self.use_cudnn:
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place,
-                set(['Input', 'Filter']),
-                'Output',
-                max_relative_error=0.02)
+                place, ['Input', 'Filter'], 'Output', max_relative_error=0.02)
         else:
             self.check_grad(
-                set(['Input', 'Filter']), 'Output', max_relative_error=0.02)
+                ['Input', 'Filter'], 'Output', max_relative_error=0.02)
 
     def init_test_case(self):
         self.pad = [0, 0]

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -283,7 +283,7 @@ class TestConv3dOp(OpTest):
             return
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.03)
+            place, ['Input', 'Filter'], 'Output', max_relative_error=0.03)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
@@ -547,7 +547,7 @@ class TestConv3dOp_2(OpTest):
             return
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.03)
+            place, ['Input', 'Filter'], 'Output', max_relative_error=0.03)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:

--- a/python/paddle/fluid/tests/unittests/test_conv3d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_transpose_op.py
@@ -151,13 +151,10 @@ class TestConv3dTransposeOp(OpTest):
         if self.use_cudnn:
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place,
-                set(['Input', 'Filter']),
-                'Output',
-                max_relative_error=0.03)
+                place, ['Input', 'Filter'], 'Output', max_relative_error=0.03)
         else:
             self.check_grad(
-                set(['Input', 'Filter']), 'Output', max_relative_error=0.03)
+                ['Input', 'Filter'], 'Output', max_relative_error=0.03)
 
     def test_check_grad_no_filter(self):
         if self.use_cudnn:

--- a/python/paddle/fluid/tests/unittests/test_deformable_conv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_deformable_conv_op.py
@@ -150,7 +150,7 @@ class TestModulatedDeformableConvOp(OpTest):
 
     def test_check_grad(self):
         self.check_grad(
-            {'Input', 'Offset', 'Mask', 'Filter'},
+            ['Input', 'Offset', 'Mask', 'Filter'],
             'Output',
             max_relative_error=0.05)
 

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -106,14 +106,11 @@ class TestGroupNormOp(OpTest):
 
         place = core.CPUPlace()
         self.check_grad_with_place(
-            place, set(['X', 'Scale', 'Bias']), 'Y', max_relative_error=0.01)
+            place, ['X', 'Scale', 'Bias'], 'Y', max_relative_error=0.01)
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place,
-                set(['X', 'Scale', 'Bias']),
-                'Y',
-                max_relative_error=0.01)
+                place, ['X', 'Scale', 'Bias'], 'Y', max_relative_error=0.01)
 
     def init_test_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -90,7 +90,7 @@ class TestGroupNormOp(OpTest):
         op_attrs = self.attrs if hasattr(self, "attrs") else dict()
         self.op = create_op(self.scope, self.op_type, op_inputs, op_outputs,
                             op_attrs)
-        inputs_to_check = set(['X', 'Scale', 'Bias'])
+        inputs_to_check = ['X', 'Scale', 'Bias']
         output_names = 'Y'
         cpu_grads = self._get_gradient(inputs_to_check, place, output_names,
                                        None)

--- a/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
@@ -179,8 +179,7 @@ class TestCUDNNLstmOp(OpTest):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place,
-                set(['Input', 'W', 'InitH', 'InitC']),
+                place, ['Input', 'W', 'InitH', 'InitC'],
                 ['Out', 'last_h', 'last_c'],
                 max_relative_error=0.02)
 

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -428,7 +428,7 @@ def create_test_cudnn_fp16_class(parent, check_grad=True):
             if core.is_float16_supported(
                     place) and self.pool_type != "max" and check_grad:
                 self.check_grad_with_place(
-                    place, set(['X']), 'Out', max_relative_error=0.07)
+                    place, ['X'], 'Out', max_relative_error=0.07)
 
     cls_name = "{0}_{1}".format(parent.__name__, "CUDNNFp16Op")
     TestCUDNNFp16Case.__name__ = cls_name

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -287,9 +287,9 @@ class TestPool2D_Op(OpTest):
         if self.has_cudnn() and self.pool_type != "max":
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, set(['X']), 'Out', max_relative_error=0.07)
+                place, ['X'], 'Out', max_relative_error=0.07)
         elif self.pool_type != "max":
-            self.check_grad(set(['X']), 'Out', max_relative_error=0.07)
+            self.check_grad(['X'], 'Out', max_relative_error=0.07)
 
     def init_data_format(self):
         self.data_format = "NCHW"
@@ -702,9 +702,9 @@ class TestCase5_Max(TestCase2):
         if self.has_cudnn() and self.pool_type == "max":
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, set(['X']), 'Out', max_relative_error=1.00)
+                place, ['X'], 'Out', max_relative_error=1.00)
         elif self.pool_type == "max":
-            self.check_grad(set(['X']), 'Out', max_relative_error=1.00)
+            self.check_grad(['X'], 'Out', max_relative_error=1.00)
 
 
 class TestCase5_channel_last_Max(TestCase5_Max):

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -259,9 +259,9 @@ class TestPool3d_Op(OpTest):
         if self.has_cudnn() and self.pool_type != "max":
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, set(['X']), 'Out', max_relative_error=0.07)
+                place, ['X'], 'Out', max_relative_error=0.07)
         elif self.pool_type != "max":
-            self.check_grad(set(['X']), 'Out', max_relative_error=0.07)
+            self.check_grad(['X'], 'Out', max_relative_error=0.07)
 
     def init_data_format(self):
         self.data_format = "NCDHW"
@@ -647,9 +647,9 @@ class TestCase5_Max(TestCase2):
         if self.has_cudnn() and self.pool_type == "max":
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, set(['X']), 'Out', max_relative_error=1.00)
+                place, ['X'], 'Out', max_relative_error=1.00)
         elif self.pool_type == "max":
-            self.check_grad(set(['X']), 'Out', max_relative_error=1.00)
+            self.check_grad(['X'], 'Out', max_relative_error=1.00)
 
 
 class TestCase5_channel_last_Max(TestCase5_Max):

--- a/python/paddle/fluid/tests/unittests/test_seq_conv.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_conv.py
@@ -122,8 +122,7 @@ class TestSeqProject(OpTest):
 
     def test_check_grad(self):
         if self.padding_trainable:
-            self.check_grad(
-                set(self.inputs_val), 'Out', max_relative_error=0.05)
+            self.check_grad(self.inputs_val, 'Out', max_relative_error=0.05)
 
     def test_check_grad_input(self):
         self.check_grad(

--- a/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
@@ -72,7 +72,7 @@ class TestStrideSliceOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(set(['Input']), 'Out')
+        self.check_grad(['Input'], 'Out')
 
     def initTestCase(self):
         self.input = np.random.rand(6)

--- a/python/paddle/fluid/tests/unittests/test_unstack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unstack_op.py
@@ -54,7 +54,7 @@ class TestUnStackOpBase(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad('X', self.get_y_names())
+        self.check_grad(['X'], self.get_y_names())
 
 
 class TestStackOp3(TestUnStackOpBase):


### PR DESCRIPTION
This RP is to solve the problem in icafe 1977 card.
The demand is that the `append_backward` in backward.py should has `parameter_list` input check, so this PR add related checking. But in fact, users rarely use `parameter_list` argument directly.