### PR TITLE
fix expand bug 

### DIFF
--- a/paddle/fluid/operators/expand_op.cc
+++ b/paddle/fluid/operators/expand_op.cc
@@ -226,8 +226,11 @@ REGISTER_OP_CPU_KERNEL(
     expand, ops::ExpandKernel<paddle::platform::CPUDeviceContext, float>,
     ops::ExpandKernel<paddle::platform::CPUDeviceContext, double>,
     ops::ExpandKernel<paddle::platform::CPUDeviceContext, int>,
+    ops::ExpandKernel<paddle::platform::CPUDeviceContext, int64_t>,
     ops::ExpandKernel<paddle::platform::CPUDeviceContext, bool>);
 REGISTER_OP_CPU_KERNEL(
     expand_grad,
     ops::ExpandGradKernel<paddle::platform::CPUDeviceContext, float>,
-    ops::ExpandGradKernel<paddle::platform::CPUDeviceContext, double>);
+    ops::ExpandGradKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::ExpandGradKernel<paddle::platform::CPUDeviceContext, int>,
+    ops::ExpandGradKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/expand_op.cu
+++ b/paddle/fluid/operators/expand_op.cu
@@ -18,8 +18,11 @@ REGISTER_OP_CUDA_KERNEL(
     expand, ops::ExpandKernel<paddle::platform::CUDADeviceContext, float>,
     ops::ExpandKernel<paddle::platform::CUDADeviceContext, double>,
     ops::ExpandKernel<paddle::platform::CUDADeviceContext, int>,
+    ops::ExpandKernel<paddle::platform::CUDADeviceContext, int64_t>,
     ops::ExpandKernel<paddle::platform::CUDADeviceContext, bool>);
 REGISTER_OP_CUDA_KERNEL(
     expand_grad,
     ops::ExpandGradKernel<paddle::platform::CUDADeviceContext, float>,
-    ops::ExpandGradKernel<paddle::platform::CUDADeviceContext, double>);
+    ops::ExpandGradKernel<paddle::platform::CUDADeviceContext, double>,
+    ops::ExpandGradKernel<paddle::platform::CUDADeviceContext, int>,
+    ops::ExpandGradKernel<paddle::platform::CUDADeviceContext, int64_t>);

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11673,10 +11673,19 @@ def expand(x, expand_times, name=None):
             expand_times = fluid.layers.fill_constant(shape=[2], dtype="int32", value=4)
             expanded_2 = fluid.layers.expand(data_2, expand_times=expand_times)
     """
-
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'input' in reduce_sum must be Variable, but received %s"
+            % (type(x)))
     if not isinstance(expand_times, (list, tuple, Variable)):
         raise ValueError(
             "Input expand_times must be an Variable, python list or tuple.")
+    if convert_dtype(x.dtype) not in ['bool', 'float32', 'float64', 'int32', 'int64']:
+        raise TypeError(
+            "The data type of 'input' in expand  must be one of bool float32, float64, int32 or int64, but received %s."
+            % (convert_dtype(x.dtype)))
+    if convert_dtype(x.dtype) == 'bool' and x.stop_gradient==True:
+        raise ValueError("expand bool date type must set the stop gradient to be False")
 
     helper = LayerHelper('expand', input=x, **locals())
     inputs = {"X": x}

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11683,10 +11683,10 @@ def expand(x, expand_times, name=None):
     if convert_dtype(
             x.dtype) not in ['bool', 'float32', 'float64', 'int32', 'int64']:
         raise TypeError(
-            "The data type of 'input' in expand  must be one of bool float32, float64, int32 or int64, but received %s."
+            "The data type of input  in expand  must be one of bool float32, float64, int32 or int64, but received %s."
             % (convert_dtype(x.dtype)))
     if convert_dtype(x.dtype) == 'bool' and x.stop_gradient==True:
-        raise ValueError("expand op bool date type must set the stop gradient to be False")
+        raise ValueError("expand op bool date type must set the stop_gradient to be False")
 
     helper = LayerHelper('expand', input=x, **locals())
     inputs = {"X": x}

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11685,8 +11685,9 @@ def expand(x, expand_times, name=None):
         raise TypeError(
             "The data type of input  in expand  must be one of bool float32, float64, int32 or int64, but received %s."
             % (convert_dtype(x.dtype)))
-    if convert_dtype(x.dtype) == 'bool' and x.stop_gradient==True:
-        raise ValueError("expand op bool date type must set the stop_gradient to be False")
+    if convert_dtype(x.dtype) == 'bool' and x.stop_gradient == True:
+        raise ValueError(
+            "expand op bool date type must set the stop_gradient to be False")
 
     helper = LayerHelper('expand', input=x, **locals())
     inputs = {"X": x}

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11680,12 +11680,13 @@ def expand(x, expand_times, name=None):
     if not isinstance(expand_times, (list, tuple, Variable)):
         raise ValueError(
             "Input expand_times must be an Variable, python list or tuple.")
-    if convert_dtype(x.dtype) not in ['bool', 'float32', 'float64', 'int32', 'int64']:
+    if convert_dtype(
+            x.dtype) not in ['bool', 'float32', 'float64', 'int32', 'int64']:
         raise TypeError(
             "The data type of 'input' in expand  must be one of bool float32, float64, int32 or int64, but received %s."
             % (convert_dtype(x.dtype)))
     if convert_dtype(x.dtype) == 'bool' and x.stop_gradient==True:
-        raise ValueError("expand bool date type must set the stop gradient to be False")
+        raise ValueError("expand op bool date type must set the stop gradient to be False")
 
     helper = LayerHelper('expand', input=x, **locals())
     inputs = {"X": x}

--- a/python/paddle/fluid/tests/unittests/test_expand_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_op.py
@@ -18,6 +18,7 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 # Situation 1: expand_times is a list(without tensor)
@@ -174,6 +175,35 @@ class TestExpandOpBoolean(OpTest):
 
     def test_check_output(self):
         self.check_output()
+
+
+# Situation 4: input x is Integer
+class TestExpandOpInt64_t(OpTest):
+    def setUp(self):
+        self.op_type = "expand"
+        self.inputs = {
+            'X': np.random.randint(
+                10, size=(2, 4, 5)).astype("int64")
+        }
+        self.attrs = {'expand_times': [2, 1, 4]}
+        output = np.tile(self.inputs['X'], (2, 1, 4))
+        self.outputs = {'Out': output}
+
+    def test_check_output(self):
+        self.check_output()
+
+class TestExpandError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            expand_times = [2, 2]
+            self.assertRaises(TypeError, fluid.layers.expand, x1, expand_times)
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
+            self.assertRaises(TypeError, fluid.layers.expand, x2, expand_times)
+            x3 = fluid.layers.data(name='x3', shape=[4], dtype="bool")
+            x3.stop_gradient = True
+            self.assertRaises(ValueError, fluid.layers.expand, x3, expand_times)
 
 
 # Test python API

--- a/python/paddle/fluid/tests/unittests/test_expand_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_op.py
@@ -177,7 +177,7 @@ class TestExpandOpBoolean(OpTest):
         self.check_output()
 
 
-# Situation 4: input x is Integer
+# Situation 56: input x is Integer
 class TestExpandOpInt64_t(OpTest):
     def setUp(self):
         self.op_type = "expand"
@@ -191,6 +191,7 @@ class TestExpandOpInt64_t(OpTest):
 
     def test_check_output(self):
         self.check_output()
+
 
 class TestExpandError(OpTest):
     def test_errors(self):


### PR DESCRIPTION
expand前向和后向传播类型不一致的bug修复 同时添加类型检查

需求描述：

1、expand的前向和后向注册的dtype  kernel不一致

2、期望加入规范，并且增加排查，如果特殊的可以单独说明

3、报错信息用户：该问题报错信息只能内部研发才能看得出原因，不利用用户自己排查问题



需求来源：

·        链接:https://github.com/PaddlePaddle/Paddle/issues/19878

·        问题：optimizer.minimize(avg_cost)无法反向传播

·        解答：maxdisp, mask_sum这些设置stop_gradient=True试下