### PR TITLE
Temporally disable test_parallel_executor_fetch_feed in Windows CI

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -302,8 +302,6 @@ endif()
 
 py_test_modules(test_parallel_executor_crf MODULES test_parallel_executor_crf)
 py_test_modules(test_parallel_executor_crf_auto_growth MODULES test_parallel_executor_crf_auto_growth ENVS FLAGS_allocator_strategy=auto_growth)
-py_test_modules(test_parallel_executor_fetch_feed MODULES test_parallel_executor_fetch_feed)
-set_tests_properties(test_parallel_executor_fetch_feed PROPERTIES TIMEOUT 450)
 py_test_modules(test_parallel_executor_transformer MODULES test_parallel_executor_transformer)
 py_test_modules(test_parallel_executor_transformer_auto_growth MODULES test_parallel_executor_transformer_auto_growth ENVS FLAGS_allocator_strategy=auto_growth)
 py_test_modules(test_layers MODULES test_layers ENVS FLAGS_cudnn_deterministic=1)
@@ -313,6 +311,9 @@ py_test_modules(test_parallel_executor_seresnext_with_fuse_all_reduce_cpu MODULE
 
 if(NOT WIN32)
     py_test_modules(test_ir_memory_optimize_transformer MODULES test_ir_memory_optimize_transformer)
+    # FIXME(zcd): temporally disable test_parallel_executor_fetch_feed in Windows CI because of the random failure.
+    py_test_modules(test_parallel_executor_fetch_feed MODULES test_parallel_executor_fetch_feed)
+    set_tests_properties(test_parallel_executor_fetch_feed PROPERTIES TIMEOUT 450)
 endif()
 
 set_tests_properties(test_parallel_executor_seresnext_base_cpu PROPERTIES TIMEOUT 900)


### PR DESCRIPTION
cherry-pick https://github.com/PaddlePaddle/Paddle/pull/20288