### PR TITLE
[cherry-pick]add input type, dtype and shape check for reshape op

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7904,13 +7904,25 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             dim = fluid.layers.fill_constant([1], "int32", 5)
             reshaped_2 = fluid.layers.reshape(data_2, shape=[dim, 10])
     """
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'x' in reshape must be Variable, but received %s." %
+            (type(x)))
+
+    if convert_dtype(x.dtype) not in ['float32', 'float64', 'int32', 'int64']:
+        raise TypeError(
+            "The data type of 'x' in reshape must be float32, float64, int32 or int64, "
+            "but received %s." % (convert_dtype(x.dtype)))
 
     if not isinstance(shape, (list, tuple, Variable)):
         raise TypeError(
-            "Input shape must be an Variable or python list or tuple.")
+            "The type of 'shape' in reshape must be Variable, list or tuple, but "
+            "received %s." % (type(shape)))
 
     if not isinstance(actual_shape, Variable) and (actual_shape is not None):
-        raise TypeError("actual_shape should either be Variable or None.")
+        raise TypeError(
+            "The type of 'actual_shape' in reshape must be Variable "
+            "or None, but received %s." % (type(actual_shape)))
 
     helper = LayerHelper("reshape2", **locals())
     inputs = {"X": x}
@@ -7945,15 +7957,21 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
                 attrs_shape.append(dim_size)
                 if dim_size == -1:
                     assert unk_dim_idx == -1, (
-                        "Only one dimension in shape can be unknown.")
+                        "Only one dimension value of 'shape' in reshape can "
+                        "be -1. But received shape[%d] is also -1." % dim_idx)
                     unk_dim_idx = dim_idx
                 elif dim_size == 0:
                     assert dim_idx < len(x.shape), (
-                        "The indice of 0s in shape can not exceed Rank(X).")
+                        "The index of 0 in `shape` must be less than "
+                        "the input tensor X's dimensions. "
+                        "But received shape[%d] = 0, X's dimensions = %d." %
+                        (dim_idx, len(x.shape)))
                 else:
                     assert dim_size > 0, (
-                        "Each dimension size given in shape must not be negtive "
-                        "except one unknown dimension.")
+                        "Each dimension value of 'shape' in reshape must not "
+                        "be negtive except one unknown dimension. "
+                        "But received shape[%d] = %s." %
+                        (dim_idx, str(dim_size)))
         return attrs_shape
 
     if in_dygraph_mode():
@@ -7965,7 +7983,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             inputs["Shape"] = shape
         elif isinstance(shape, (list, tuple)):
             assert len(shape) > 0, (
-                "The size of argument(shape) can't be zero.")
+                "The size of 'shape' in reshape can't be zero, "
+                "but received %s." % len(shape))
             attrs["shape"] = get_attr_shape(shape)
             if contain_var(shape):
                 inputs['ShapeTensor'] = get_new_shape_tensor(shape)

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from op_test import OpTest
 import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 
 
 # situation 1: have shape( list, no tensor), no actual shape(Tensor)
@@ -202,10 +203,13 @@ class TestReshapeAPI(OpTest):
 
         # situation 1: have shape( list, no tensor), no actual shape(Tensor)
         out_1 = fluid.layers.reshape(x, shape)
+
         # situation 2: have shape(list, no tensor), have actual shape(Tensor)
         out_2 = fluid.layers.reshape(x, shape=shape, actual_shape=actual_shape)
+
         # Situation 3: have shape(list, have tensor), no actual shape(Tensor)
         out_3 = fluid.layers.reshape(x, shape=[positive_five, 10])
+
         # Situation 4: have shape(Tensor), no actual shape(Tensor)
         out_4 = fluid.layers.reshape(x, shape=actual_shape)
 
@@ -220,6 +224,66 @@ class TestReshapeAPI(OpTest):
         assert np.array_equal(res_2, input.reshape(shape))
         assert np.array_equal(res_3, input.reshape([5, 10]))
         assert np.array_equal(res_4, input.reshape(shape))
+
+
+# Test Input Error
+class TestReshapeOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The x type of reshape_op must be Variable.
+            def test_x_type():
+                x1 = fluid.create_lod_tensor(
+                    np.array([[-1]]), [[1]], fluid.CPUPlace())
+                fluid.layers.reshape(x1, shape=[1])
+
+            self.assertRaises(TypeError, test_x_type)
+
+            # The x dtype of reshape_op must be float32, float64, int32 or int64.
+            def test_x_dtype():
+                x2 = fluid.layers.data(
+                    name="x2",
+                    shape=[2, 25],
+                    append_batch_size=False,
+                    dtype="float16")
+                fluid.layers.reshape(x2, shape=[2, 5, 5])
+
+            self.assertRaises(TypeError, test_x_dtype)
+
+            x3 = fluid.layers.data(
+                name="x3",
+                shape=[2, 25],
+                append_batch_size=False,
+                dtype="float32")
+
+            # The argument shape's type of reshape_op must be list, tuple or Variable.
+            def test_shape_type():
+                fluid.layers.reshape(x3, shape=1)
+
+            self.assertRaises(TypeError, test_shape_type)
+
+            # The argument actual_shape's type of reshape_op must be Variable or None.
+            def test_actual_shape_type():
+                fluid.layers.reshape(x3, shape=[25, 2], actual_shape=1)
+
+            self.assertRaises(TypeError, test_actual_shape_type)
+
+            # The argument shape have more than one -1.
+            def test_shape_1():
+                fluid.layers.reshape(x3, shape=[-1, -1, 5])
+
+            self.assertRaises(AssertionError, test_shape_1)
+
+            # The argument shape have element 0 whose index exceed the input dimension.
+            def test_shape_2():
+                fluid.layers.reshape(x3, [2, 5, 5, 0])
+
+            self.assertRaises(AssertionError, test_shape_2)
+
+            # The argument shape have more than one negtive value.
+            def test_shape_3():
+                fluid.layers.reshape(x3, [-1, -2, 5])
+
+            self.assertRaises(AssertionError, test_shape_3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
add input type and dtype check for reshape op. 
enhance shape error messages for reshape op.
chrry-pick [PR20099](https://github.com/PaddlePaddle/Paddle/pull/20099)