### PR TITLE
Fleet: deal with special case: strategy is None

### DIFF
--- a/python/paddle/fluid/incubate/fleet/collective/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/collective/__init__.py
@@ -152,7 +152,7 @@ class CollectiveOptimizer(DistributedOptimizer):
 
     def __init__(self, optimizer, strategy=DistributedStrategy()):
         super(CollectiveOptimizer, self).__init__(optimizer, strategy)
-        if strategy.forward_recompute:
+        if strategy is not None and strategy.forward_recompute:
             self.forward_recompute = True
             self.recompute_checkpoints = strategy.recompute_checkpoints
         else:

--- a/python/paddle/fluid/tests/unittests/test_fleet_api_input.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_api_input.py
@@ -22,6 +22,7 @@ from paddle.fluid.incubate.fleet.base.role_maker import UserDefinedCollectiveRol
 from paddle.fluid.incubate.fleet.base.role_maker import Role
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import TranspilerOptimizer
+from paddle.fluid.incubate.fleet.collective import CollectiveOptimizer
 
 
 class DistributeTranspilerConfigTest(unittest.TestCase):
@@ -202,6 +203,12 @@ class UserDefinedCollectiveRoleMakerTest(unittest.TestCase):
             current_id=1,
             worker_endpoints=["127.0.0.1:8080"]
         )  # current_id must be less than len(worker_endpoints)
+
+
+class CollectiveOptimizerTest(unittest.TestCase):
+    def test_ds_as_None(self):
+        optimizer = fluid.optimizer.AdamOptimizer()
+        dist_optimizer = CollectiveOptimizer(optimizer, strategy=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We need to deal with a special case that distribute strategy is None, when initializing an instance of DistributedOptimizer class.