### PR TITLE
remove incorrect new in c style

### DIFF
--- a/paddle/fluid/inference/capi/c_api.h
+++ b/paddle/fluid/inference/capi/c_api.h
@@ -37,7 +37,7 @@ typedef struct PD_PaddleBuf PD_PaddleBuf;
 typedef struct PD_AnalysisConfig PD_AnalysisConfig;
 
 typedef struct PD_ZeroCopyData {
-  char* name = new char[50];
+  char* name;
   void* data;
   PD_DataType dtype;
   int* shape;


### PR DESCRIPTION
In C language, there should be a malloc, not new. The "new" in C api file is put in the c_api.h file by mistake by me. Remove incorrect new in C style for inference c api. 