### PR TITLE
bugfix: construct a new DistributedStrategy object if the passed one is None

### DIFF
--- a/python/paddle/fluid/incubate/fleet/collective/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/collective/__init__.py
@@ -69,6 +69,8 @@ class Collective(Fleet):
             "You should not call 'stop_worker' method for collective mode.")
 
     def distributed_optimizer(self, optimizer, strategy=None):
+        if strategy is None:
+            strategy = DistributedStrategy()
         self._optimizer = \
             CollectiveOptimizer(optimizer, strategy)
         return self._optimizer

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -142,6 +142,8 @@ class TestDistRunnerBase(object):
         print_to_err("gpu_fleet", "fleet.node_num:")
         # "fleet.node_id:", fleet.node_id(),
         # "fleet.trainer_num:", fleet.worker_num())
+        if args.use_none_strategy:
+            dist_strategy = None
 
         test_program, avg_cost, train_reader, test_reader, batch_acc, predict = \
             self.get_model(batch_size=args.batch_size, dist_strategy=dist_strategy)
@@ -420,6 +422,7 @@ def runtime_main(test_class):
     parser.add_argument('--gpu_fleet_api', action='store_true')
     parser.add_argument('--use_local_sgd', action='store_true')
     parser.add_argument('--ut4grad_allreduce', action='store_true')
+    parser.add_argument('--use_none_strategy', action='store_true')
     parser.add_argument(
         '--hallreduce_inter_nranks', type=int, required=False, default=2)
     parser.add_argument(
@@ -660,6 +663,9 @@ class TestDistBase(unittest.TestCase):
         if self._use_reader_alloc:
             tr0_cmd += " --use_reader_alloc"
             tr1_cmd += " --use_reader_alloc"
+        if self._use_none_strategy:
+            tr0_cmd += " --use_none_strategy"
+            tr1_cmd += " --use_none_strategy"
         if self.__use_cuda:
             tr0_cmd += " --use_cuda"
             tr1_cmd += " --use_cuda"

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -512,6 +512,7 @@ class TestDistBase(unittest.TestCase):
         self._use_hallreduce = False
         self._setup_config()
         self._after_setup_config()
+        self._use_none_strategy = False
 
     def _find_free_port(self):
         def __free_port():

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_fleetapi.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_fleetapi.py
@@ -24,6 +24,22 @@ class TestDistMnistNCCL2FleetApi(TestDistBase):
         self._use_reader_alloc = False
         self._nccl2_mode = True
         self._gpu_fleet_api = True
+        self._use_none_strategy = False
+
+    def test_dist_train(self):
+        import paddle.fluid as fluid
+        if fluid.core.is_compiled_with_cuda():
+            self.check_with_place("dist_mnist.py", delta=1e-5)
+
+
+class TestDistMnistNCCL2FleetApiNoneStrategy(TestDistBase):
+    def _setup_config(self):
+        self._sync_mode = True
+        self._use_reduce = False
+        self._use_reader_alloc = False
+        self._nccl2_mode = True
+        self._gpu_fleet_api = True
+        self._use_none_strategy = True
 
     def test_dist_train(self):
         import paddle.fluid as fluid


### PR DESCRIPTION
The CollectiveOptimizer object passed to the constructor of CollectiveOptimizer cannot be None.