### PR TITLE
Refine print_signatures.py to remove ComposeNotAligned

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -455,8 +455,6 @@ function assert_api_not_changed() {
         sed -i 's/arg0: str/arg0: unicode/g' new.spec
         sed -i "s/\(.*Transpiler.*\).__init__ (ArgSpec(args=\['self'].*/\1.__init__ /g" new.spec
     fi
-    # ComposeNotAligned has significant difference between py2 and py3
-    sed -i '/.*ComposeNotAligned.*/d' new.spec
 
     python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API.spec new.spec
 

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -30,6 +30,12 @@ member_dict = collections.OrderedDict()
 
 experimental_namespace = {"paddle.fluid.LoDTensorset"}
 
+# APIs that should not be printed into API.spec 
+omitted_list = [
+    "paddle.fluid.io.ComposeNotAligned",
+    "paddle.fluid.io.ComposeNotAligned.__init__",
+]
+
 
 def md5(doc):
     hash = hashlib.md5()
@@ -38,6 +44,9 @@ def md5(doc):
 
 
 def queue_dict(member, cur_name):
+    if cur_name in omitted_list:
+        return
+
     try:
         doc = ('document', md5(member.__doc__))
         if inspect.isclass(member):
@@ -47,8 +56,6 @@ def queue_dict(member, cur_name):
         all = (args, doc)
         member_dict[cur_name] = all
     except TypeError:  # special for PyBind method
-        if cur_name in check_modules_list:
-            return
         member_dict[cur_name] = "  ".join([
             line.strip() for line in pydoc.render_doc(member).split('\n')
             if "->" in line
@@ -90,7 +97,6 @@ def visit_all_module(mod):
             visit_member(mod.__name__, instance)
 
 
-check_modules_list = ["paddle.reader.ComposeNotAligned.__init__"]
 modules = sys.argv[1].split(",")
 for m in modules:
     visit_all_module(importlib.import_module(m))

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -28,10 +28,9 @@ import hashlib
 
 member_dict = collections.OrderedDict()
 
-experimental_namespace = {"paddle.fluid.LoDTensorset"}
-
 # APIs that should not be printed into API.spec 
 omitted_list = [
+    "paddle.fluid.LoDTensor.set",  # Do not know why it should be omitted
     "paddle.fluid.io.ComposeNotAligned",
     "paddle.fluid.io.ComposeNotAligned.__init__",
 ]
@@ -63,8 +62,6 @@ def queue_dict(member, cur_name):
 
 
 def visit_member(parent_name, member):
-    if parent_name + member.__name__ in experimental_namespace:
-        return
     cur_name = ".".join([parent_name, member.__name__])
     if inspect.isclass(member):
         queue_dict(member, cur_name)
@@ -82,8 +79,6 @@ def visit_member(parent_name, member):
 
 
 def visit_all_module(mod):
-    if (mod.__name__ in experimental_namespace):
-        return
     for member_name in (
             name
             for name in (mod.__all__ if hasattr(mod, "__all__") else dir(mod))


### PR DESCRIPTION
`print_signatures.py` would create `ComposeNotAligned` in Python 2. This PR refines the scripts to remove it.