### PR TITLE
fix sigmoid_focal_loss gamma bug

### DIFF
--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -432,7 +432,7 @@ def rpn_target_assign(bbox_pred,
     return predicted_cls_logits, predicted_bbox_pred, target_label, target_bbox, bbox_inside_weight
 
 
-def sigmoid_focal_loss(x, label, fg_num, gamma=2, alpha=0.25):
+def sigmoid_focal_loss(x, label, fg_num, gamma=2., alpha=0.25):
     """
     **Sigmoid Focal Loss Operator.**
 


### PR DESCRIPTION
sigmoid_focal_loss的gamma参数默认为2，int类型
若外部调用时使用默认gamma值，则会出现错误：

paddle.fluid.core_avx.EnforceNotMet: Cannot get attribute gamma by type float, its type is int at [/paddle/paddle/fluid/framework/attribute.h:42]

因此将gamma默认值修改为"2."