### PR TITLE
Optimize error message of mean_op and matmul_op, test=release/1.6

### DIFF
--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -303,21 +303,34 @@ class MatMulOp : public framework::OperatorWithKernel {
                                      context->Attrs().Get<bool>("transpose_Y"));
 
     if (context->IsRuntime()) {
-      PADDLE_ENFORCE(mat_dim_x.batch_size_ == mat_dim_y.batch_size_ ||
-                     mat_dim_x.batch_size_ == 0 || mat_dim_y.batch_size_ == 0);
+      PADDLE_ENFORCE(
+          mat_dim_x.batch_size_ == mat_dim_y.batch_size_ ||
+              mat_dim_x.batch_size_ == 0 || mat_dim_y.batch_size_ == 0,
+          "The condition that the matrix multiplication factor "
+          "batch size must be equal is not met. x_batch_size (%d) != "
+          "y_batch_size (%d).",
+          mat_dim_x.batch_size_, mat_dim_y.batch_size_);
     }
     std::vector<int64_t> dim_out;
     int64_t dim_out_y = mat_dim_y.width_;
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
     int head_number = context->Attrs().Get<int>("head_number");
     bool split_vertical_y = (mat_dim_x.width_ != mat_dim_y.height_);
-    PADDLE_ENFORCE_LE(head_number, mat_dim_x.width_);
+    PADDLE_ENFORCE_LE(
+        head_number, mat_dim_x.width_,
+        "Unsatisfied mkl acceleration library requirements: head_number "
+        "(%d) must be equal to x_width (%d).",
+        head_number, mat_dim_x.width_);
 
     if (!split_vertical_y && head_number > 0) {
       dim_out_y = head_number * mat_dim_y.width_;
     }
 #else
-    PADDLE_ENFORCE_EQ(mat_dim_x.width_, mat_dim_y.height_);
+    PADDLE_ENFORCE_EQ(
+        mat_dim_x.width_, mat_dim_y.height_,
+        "The shape of the matrix does not satisfy "
+        "the multiplication prerequisites. x_width (%d) != y_height (%d).",
+        mat_dim_x.width_, mat_dim_y.height_);
 #endif
 
     if (mat_dim_x.batch_size_ != 0) {

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -318,8 +318,8 @@ class MatMulOp : public framework::OperatorWithKernel {
           mat_dim_x.batch_size_ == mat_dim_y.batch_size_ ||
               mat_dim_x.batch_size_ == 0 || mat_dim_y.batch_size_ == 0,
           "ShapeError: The batch size of the two matrices should be equal, or "
-          "zero.\n"
-          "But received x_shape: %s, y_shape: %s.",
+          "at least one is zero.\n"
+          "But received X's shape: %s, Y's shape: %s.",
           DumpMatrixShape(mat_dim_x).c_str(),
           DumpMatrixShape(mat_dim_y).c_str());
     }
@@ -331,20 +331,20 @@ class MatMulOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_LE(
         head_number, mat_dim_x.width_,
         "ShapeError: Unsatisfied mkl acceleration library requirements: "
-        "head_number "
-        "(%d) must be equal to x_width. But received x_shape: %s.",
+        "The number of heads "
+        "(%d) must be equal to X's width. But received X's shape: %s.",
         head_number, DumpMatrixShape(mat_dim_x).c_str());
 
     if (!split_vertical_y && head_number > 0) {
       dim_out_y = head_number * mat_dim_y.width_;
     }
 #else
-    PADDLE_ENFORCE_EQ(mat_dim_x.width_, mat_dim_y.height_,
-                      "ShapeError: x_width should be equal to the y_height, "
-                      "but received x_shape: %s,"
-                      "y_shape: %s.",
-                      DumpMatrixShape(mat_dim_x).c_str(),
-                      DumpMatrixShape(mat_dim_y).c_str());
+    PADDLE_ENFORCE_EQ(
+        mat_dim_x.width_, mat_dim_y.height_,
+        "ShapeError: Input X's width should be equal to the Y's height, "
+        "but received X's shape: %s,"
+        "Y's shape: %s.",
+        DumpMatrixShape(mat_dim_x).c_str(), DumpMatrixShape(mat_dim_y).c_str());
 #endif
 
     if (mat_dim_x.batch_size_ != 0) {

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -488,15 +488,11 @@ REGISTER_OPERATOR(matmul, ops::MatMulOp, ops::MatMulOpMaker,
 REGISTER_OPERATOR(matmul_grad, ops::MatMulOpGrad);
 REGISTER_OP_CPU_KERNEL(
     matmul, ops::MatMulKernel<paddle::platform::CPUDeviceContext, float>,
-    ops::MatMulKernel<paddle::platform::CPUDeviceContext, double>,
-    ops::MatMulKernel<paddle::platform::CPUDeviceContext,
-                      paddle::platform::float16>);
+    ops::MatMulKernel<paddle::platform::CPUDeviceContext, double>);
 REGISTER_OP_CPU_KERNEL(
     matmul_grad,
     ops::MatMulGradKernel<paddle::platform::CPUDeviceContext, float>,
-    ops::MatMulGradKernel<paddle::platform::CPUDeviceContext, double>,
-    ops::MatMulGradKernel<paddle::platform::CPUDeviceContext,
-                          paddle::platform::float16>);
+    ops::MatMulGradKernel<paddle::platform::CPUDeviceContext, double>);
 
 #ifdef PADDLE_WITH_CUDA
 REGISTER_OP_CUDA_KERNEL(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6383,6 +6383,20 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
     """
 
     def __check_input(x, y):
+        var_names = {'x': x, 'y': y}
+        for name, val in var_names.items():
+            if not isinstance(val, Variable):
+                if isinstance(val, np.ndarray):
+                    val = assign(val)
+                else:
+                    raise TypeError(
+                        "The type of %s in sign_op must be Variable or numpy.ndarray, but received %s."
+                        % (name, (type(val))))
+            if convert_dtype(val.dtype) not in ['float32', 'float64']:
+                raise TypeError(
+                    "The data type of %s in sign_op must be float32 or float64, but received %s."
+                    % (name, (convert_dtype(val.dtype))))
+
         x_shape = list(x.shape)
         y_shape = list(y.shape)
         if len(x_shape) == 1:
@@ -6396,8 +6410,10 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
         if transpose_y:
             y_shape[-2], y_shape[-1] = y_shape[-1], y_shape[-2]
         if x_shape[-1] != y_shape[-2]:
-            raise ValueError("Invalid inputs for matmul. x: %s, y: %s\n" %
-                             (x_shape, y_shape))
+            raise ValueError(
+                "The shape of the matrix does not satisfy "
+                "the multiplication prerequisites. x_shape: %s, y_shape: %s\n" %
+                (x_shape, y_shape))
 
         if len(y_shape) > 2 and len(x_shape) > 2:
             for i, dim_x in enumerate(x_shape[:-2]):
@@ -6405,8 +6421,10 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
                 if dim_x < 0 or y_shape[i] < 0:
                     continue
                 if dim_x != y_shape[i]:
-                    raise ValueError("Invalid inputs for matmul. x(%s), y(%s)" %
-                                     (x.shape, y.shape))
+                    raise ValueError(
+                        "The shape of the matrix does not satisfy "
+                        "the multiplication prerequisites. x_shape: %s, y_shape: %s\n"
+                        % (x_shape, y_shape))
 
     __check_input(x, y)
 
@@ -13369,6 +13387,24 @@ def mean(x, name=None):
     """
 
     helper = LayerHelper("mean", **locals())
+
+    if not isinstance(x, Variable):
+        if isinstance(x, np.ndarray):
+            x = assign(x)
+        else:
+            raise TypeError(
+                "The type of 'x' in sign_op must be Variable or numpy.ndarray, but received %s."
+                % (type(x)))
+
+    if convert_dtype(x.dtype) not in ['float32', 'float64', 'float16']:
+        raise TypeError(
+            "The data type of 'x' in sign_op must be float32 or float64 or float16, but received %s."
+            % (convert_dtype(x.dtype)))
+    if name is not None:
+        if not isinstance(name, str):
+            raise TypeError(
+                "The type of 'name' in matmul layer must be str, but received %s"
+                % (type(x)))
 
     if name is None:
         out = helper.create_variable_for_type_inference(dtype=x.dtype)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6391,8 +6391,8 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
                     % (name, (type(val))))
             if convert_dtype(val.dtype) in ['float16']:
                 warnings.warn(
-                    "The data type of %s in matmul only support float16 in GPU now.",
-                    name)
+                    "The data type of %s in matmul only support float16 in GPU now."
+                    % name)
             if convert_dtype(
                     val.dtype) not in ['float16', 'float32', 'float64']:
                 raise TypeError(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6389,9 +6389,10 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
                 raise TypeError(
                     "The type of %s in matmul_op must be Variable, but received %s.\n"
                     % (name, (type(val))))
-            if convert_dtype(val.dtype) not in ['float32', 'float64']:
+            if convert_dtype(
+                    val.dtype) not in ['float16', 'float32', 'float64']:
                 raise TypeError(
-                    "The data type of %s in matmul_op must be float32 or float64, but received %s.\n"
+                    "The data type of %s in matmul_op must be float16, float32 or float64, but received %s.\n"
                     % (name, (convert_dtype(val.dtype))))
 
         x_shape = list(x.shape)
@@ -6408,8 +6409,9 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
             y_shape[-2], y_shape[-1] = y_shape[-1], y_shape[-2]
         if x_shape[-1] != y_shape[-2]:
             raise ValueError(
-                "x_shape[-1] should be equal to y_shape[-2] for multiplication "
-                "prerequisites. But received x_shape: %s, y_shape: %s\n" %
+                "After performing an optional transpose, Input X's width should be "
+                "equal to Y's width for multiplication "
+                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %
                 (x_shape, y_shape))
 
         if len(y_shape) > 2 and len(x_shape) > 2:
@@ -6421,8 +6423,8 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
                     raise ValueError(
                         "When the matrix is larger than 2 dimensions, the higher "
                         "dimensional values of the two matrices need to be equal. "
-                        "But received x_shape[%d] != y_shape[%d]. x_shape: %s, "
-                        "y_shape: %s.\n" % (i, i, x_shape, y_shape))
+                        "But received x_shape[%d] != y_shape[%d]. X's shape: %s, "
+                        "Y's shape: %s.\n" % (i, i, x_shape, y_shape))
 
     __check_input(x, y)
 
@@ -13390,6 +13392,10 @@ def mean(x, name=None):
         raise TypeError(
             "The type of 'x' in mean_op must be Variable, but received %s.\n" %
             (type(x)))
+
+    if convert_dtype(x.dtype) in ['float16']:
+        warnings.warn(
+            "The data type of 'x' in softmax only support float16 in GPU now.")
 
     if convert_dtype(x.dtype) not in ['float16', 'float32', 'float64']:
         raise TypeError(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6386,15 +6386,12 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
         var_names = {'x': x, 'y': y}
         for name, val in var_names.items():
             if not isinstance(val, Variable):
-                if isinstance(val, np.ndarray):
-                    val = assign(val)
-                else:
-                    raise TypeError(
-                        "The type of %s in sign_op must be Variable or numpy.ndarray, but received %s."
-                        % (name, (type(val))))
+                raise TypeError(
+                    "The type of %s in matmul_op must be Variable, but received %s.\n"
+                    % (name, (type(val))))
             if convert_dtype(val.dtype) not in ['float32', 'float64']:
                 raise TypeError(
-                    "The data type of %s in sign_op must be float32 or float64, but received %s."
+                    "The data type of %s in matmul_op must be float32 or float64, but received %s.\n"
                     % (name, (convert_dtype(val.dtype))))
 
         x_shape = list(x.shape)
@@ -6411,8 +6408,8 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
             y_shape[-2], y_shape[-1] = y_shape[-1], y_shape[-2]
         if x_shape[-1] != y_shape[-2]:
             raise ValueError(
-                "The shape of the matrix does not satisfy "
-                "the multiplication prerequisites. x_shape: %s, y_shape: %s\n" %
+                "x_shape[-1] should be equal to y_shape[-2] for multiplication "
+                "prerequisites. But received x_shape: %s, y_shape: %s\n" %
                 (x_shape, y_shape))
 
         if len(y_shape) > 2 and len(x_shape) > 2:
@@ -6422,9 +6419,10 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
                     continue
                 if dim_x != y_shape[i]:
                     raise ValueError(
-                        "The shape of the matrix does not satisfy "
-                        "the multiplication prerequisites. x_shape: %s, y_shape: %s\n"
-                        % (x_shape, y_shape))
+                        "When the matrix is larger than 2 dimensions, the higher "
+                        "dimensional values of the two matrices need to be equal. "
+                        "But received x_shape[%d] != y_shape[%d]. x_shape: %s, "
+                        "y_shape: %s.\n" % (i, i, x_shape, y_shape))
 
     __check_input(x, y)
 
@@ -13389,22 +13387,14 @@ def mean(x, name=None):
     helper = LayerHelper("mean", **locals())
 
     if not isinstance(x, Variable):
-        if isinstance(x, np.ndarray):
-            x = assign(x)
-        else:
-            raise TypeError(
-                "The type of 'x' in sign_op must be Variable or numpy.ndarray, but received %s."
-                % (type(x)))
-
-    if convert_dtype(x.dtype) not in ['float32', 'float64', 'float16']:
         raise TypeError(
-            "The data type of 'x' in sign_op must be float32 or float64 or float16, but received %s."
+            "The type of 'x' in mean_op must be Variable, but received %s.\n" %
+            (type(x)))
+
+    if convert_dtype(x.dtype) not in ['float16', 'float32', 'float64']:
+        raise TypeError(
+            "The data type of 'x' in mean_op must be float16 or float32 or float64, but received %s.\n"
             % (convert_dtype(x.dtype)))
-    if name is not None:
-        if not isinstance(name, str):
-            raise TypeError(
-                "The type of 'name' in matmul layer must be str, but received %s"
-                % (type(x)))
 
     if name is None:
         out = helper.create_variable_for_type_inference(dtype=x.dtype)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6387,12 +6387,16 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
         for name, val in var_names.items():
             if not isinstance(val, Variable):
                 raise TypeError(
-                    "The type of %s in matmul_op must be Variable, but received %s.\n"
+                    "The type of %s in matmul must be Variable, but received %s.\n"
                     % (name, (type(val))))
+            if convert_dtype(val.dtype) in ['float16']:
+                warnings.warn(
+                    "The data type of %s in matmul only support float16 in GPU now.",
+                    name)
             if convert_dtype(
                     val.dtype) not in ['float16', 'float32', 'float64']:
                 raise TypeError(
-                    "The data type of %s in matmul_op must be float16, float32 or float64, but received %s.\n"
+                    "The data type of %s in matmul must be float16 or float32 or float64, but received %s.\n"
                     % (name, (convert_dtype(val.dtype))))
 
         x_shape = list(x.shape)
@@ -13390,16 +13394,16 @@ def mean(x, name=None):
 
     if not isinstance(x, Variable):
         raise TypeError(
-            "The type of 'x' in mean_op must be Variable, but received %s.\n" %
+            "The type of 'x' in mean must be Variable, but received %s.\n" %
             (type(x)))
 
     if convert_dtype(x.dtype) in ['float16']:
         warnings.warn(
-            "The data type of 'x' in softmax only support float16 in GPU now.")
+            "The data type of 'x' in mean only support float16 in GPU now.")
 
     if convert_dtype(x.dtype) not in ['float16', 'float32', 'float64']:
         raise TypeError(
-            "The data type of 'x' in mean_op must be float16 or float32 or float64, but received %s.\n"
+            "The data type of 'x' in mean must be float16 or float32 or float64, but received %s.\n"
             % (convert_dtype(x.dtype)))
 
     if name is None:

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -122,8 +122,11 @@ class TestMatmulOpError(OpTest):
             self.assertRaises(TypeError, fluid.layers.matmul, input1, input1)
             # The inputs dtype of matmul_op must be float32, float64.
             input2 = fluid.layers.data(
-                name='input2', shape=[12, 10], dtype="int32")
+                name='input2', shape=[10, 10], dtype="int32")
             self.assertRaises(TypeError, fluid.layers.matmul, input2, input2)
+            input3 = fluid.layers.data(
+                name='input3', shape=[2, 2], dtype="float16")
+            fluid.layers.matmul(input3, input3)
 
 
 # Generate test cases for all possibilities

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -117,10 +117,10 @@ class Generator(object):
 class TestMatmulOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The inputs type of sign_op must be Variable or numpy.ndarray.
+            # The inputs type of matmul_op must be Variable.
             input1 = 12
             self.assertRaises(TypeError, fluid.layers.matmul, input1, input1)
-            # The inputs dtype of sign_op must be float32, float64.
+            # The inputs dtype of matmul_op must be float32, float64.
             input2 = fluid.layers.data(
                 name='input2', shape=[12, 10], dtype="int32")
             self.assertRaises(TypeError, fluid.layers.matmul, input2, input2)

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -17,6 +17,8 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 def generate_compatible_shapes(dim_X, dim_Y, transpose_X, transpose_Y):
@@ -110,6 +112,18 @@ class Generator(object):
     def test_check_grad_ignore_y(self):
         self.check_grad(
             ['X'], 'Out', max_relative_error=1e-3, no_grad_set=set('Y'))
+
+
+class TestMatmulOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The inputs type of sign_op must be Variable or numpy.ndarray.
+            input1 = 12
+            self.assertRaises(TypeError, fluid.layers.matmul, input1, input1)
+            # The inputs dtype of sign_op must be float32, float64.
+            input2 = fluid.layers.data(
+                name='input2', shape=[12, 10], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.matmul, input2, input2)
 
 
 # Generate test cases for all possibilities

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -43,17 +43,13 @@ class TestMeanOp(OpTest):
 class TestMeanOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
-            # The input type of sign_op must be Variable or numpy.ndarray.
+            # The input type of mean_op must be Variable.
             input1 = 12
             self.assertRaises(TypeError, fluid.layers.mean, input1)
-            # The input dtype of sign_op must be float32, float64, float16.
+            # The input dtype of mean_op must be float16, float32, float64.
             input2 = fluid.layers.data(
                 name='input2', shape=[12, 10], dtype="int32")
             self.assertRaises(TypeError, fluid.layers.mean, input2)
-            # The name of sign_op must be str.
-            input3 = fluid.layers.data(
-                name='input3', shape=[2, 1], dtype="float32")
-            self.assertRaises(TypeError, fluid.layers.mean, input3, name=1)
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -18,6 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 class TestMeanOp(OpTest):
@@ -36,6 +38,22 @@ class TestMeanOp(OpTest):
 
     def test_checkout_grad(self):
         self.check_grad(['X'], 'Out')
+
+
+class TestMeanOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of sign_op must be Variable or numpy.ndarray.
+            input1 = 12
+            self.assertRaises(TypeError, fluid.layers.mean, input1)
+            # The input dtype of sign_op must be float32, float64, float16.
+            input2 = fluid.layers.data(
+                name='input2', shape=[12, 10], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.mean, input2)
+            # The name of sign_op must be str.
+            input3 = fluid.layers.data(
+                name='input3', shape=[2, 1], dtype="float32")
+            self.assertRaises(TypeError, fluid.layers.mean, input3, name=1)
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -50,6 +50,9 @@ class TestMeanOpError(OpTest):
             input2 = fluid.layers.data(
                 name='input2', shape=[12, 10], dtype="int32")
             self.assertRaises(TypeError, fluid.layers.mean, input2)
+            input3 = fluid.layers.data(
+                name='input3', shape=[4], dtype="float16")
+            fluid.layers.softmax(input3)
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),


### PR DESCRIPTION
[Cherryy-pick from #20413 ]

本 PR 检查了 Matmul 实际上不能支持 CPU FP16 计算，所以删除。

网络结构：
```
import paddle.fluid as fluid

x = fluid.data(name='x', shape=[4, 2], dtype='float16')
y = fluid.data(name='y', shape=[2, 4], dtype='float16')
output = fluid.layers.matmul(x, y)
exe = fluid.Executor(fluid.CPUPlace())
```

报错如下：
```
======================================================================
ERROR: test_check_grad_normal (__main__.TestMatMulOp_dimX_1_dim_Y_1_transX_True_transY_False)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./paddle/fluid/tests/unittests/test_matmul_op.py", line 106, in test_check_grad_normal
    self.check_grad(['X', 'Y'], 'Out', max_relative_error=1e-3)
  File "/shixiaowei02/Paddle_matmul_info/Paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 920, in check_grad
    user_defined_grads)
  File "/shixiaowei02/Paddle_matmul_info/Paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 962, in check_grad_with_place
    in_place=in_place) for input_to_check in inputs_to_check
  File "/shixiaowei02/Paddle_matmul_info/Paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 120, in get_numeric_gradient
    y_pos = get_output()
  File "/shixiaowei02/Paddle_matmul_info/Paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 77, in get_output
    op.run(scope, place)
EnforceNotMet:

--------------------------------------------
C++ Call Stacks (More useful to developers):
--------------------------------------------
0   std::string paddle::platform::GetTraceBackString<std::string const&>(std::string const&, char const*, int)
1   paddle::platform::EnforceNotMet::EnforceNotMet(std::string const&, char const*, int)
2   paddle::operators::math::CBlas<paddle::platform::float16>::GEMM(...)
3   void paddle::operators::math::Blas<paddle::platform::CPUDeviceContext>::MatMul<paddle::platform::float16>(paddle::framework::Tensor const&, paddle::operators::math::MatDescriptor const&, paddle::framework::Tensor const&, paddle::operators::math::MatDescriptor const&, paddle::platform::float16, paddle::framework::Tensor*, paddle::platform::float16) const
4   paddle::operators::MatMulKernel<paddle::platform::CPUDeviceContext, paddle::platform::float16>::Compute(paddle::framework::ExecutionContext const&) const
5   std::_Function_handler<void (paddle::framework::ExecutionContext const&), paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 2ul, paddle::operators::MatMulKernel<paddle::platform::CPUDeviceContext, float>, paddle::operators::MatMulKernel<paddle::platform::CPUDeviceContext, double>, paddle::operators::MatMulKernel<paddle::platform::CPUDeviceContext, paddle::platform::float16> >::operator()(char const*, char const*, int) const::{lambda(paddle::framework::ExecutionContext const&)#1}>::_M_invoke(std::_Any_data const&, paddle::framework::ExecutionContext const&)
6   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&, paddle::framework::RuntimeContext*) const
7   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&) const
8   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&)

----------------------
Error Message Summary:
----------------------
PaddleCheckError: float16 GEMM not supported on CPU at [/shixiaowei02/Paddle_matmul_info/Paddle/paddle/fluid/operators/math/blas_impl.h:321]
```


=====================================

修改 MatMul 报错信息，添加 Mean 输入类型检查。MatMul 报错前后变化如下。

1、原报错：
`ValueError: Invalid inputs for matmul. x: [-1L, 3L, 2L], y: [-1L, 1L, 5L]`
现报错：
`ValueError: x_shape[-1] should be equal to y_shape[-2] for multiplication prerequisites. But received x_shape: [3L, 2L], y_shape: [1L, 5L]`

2、原报错：
`ValueError: Invalid inputs for matmul. x((-1L, 1L, 2L, 3L)), y((-1L, 5L, 3L, 2L))`
现报错：
`ValueError: When the matrix is larger than 2 dimensions, the higher dimensional values of the two matrices need to be equal. But received x_shape: [1L, 3L, 2L], y_shape: [5L, 2L, 3L]`

3、原报错：
```
----------------------
Error Message Summary:
----------------------
PaddleCheckError:  at [/shixiaowei02/Paddle_matmul_info/Paddle/paddle/fluid/operators/matmul_op.cc:309]
  [operator < matmul > error]
```
现报错：
```
----------------------
Error Message Summary:
----------------------
PaddleCheckError: ShapeError: The batch size of the two matrices should be equal, or zero.
But received x_shape: [1, 4, 2], y_shape: [2, 2, 4]. at [/shixiaowei02/Paddle_matmul_info/Paddle/paddle/fluid/operators/matmul_op.cc:326]
  [operator < matmul > error]
```

4、原报错：
```
----------------------
Error Message Summary:
----------------------
PaddleCheckError: Expected 10 <= mat_dim_x.width_, but received 10:10 > mat_dim_x.width_:2.
 at [/shixiaowei02/Paddle_matmul_info/Paddle/paddle/fluid/operators/matmul_op.cc:313]
  [operator < matmul > error]
```
现报错：
```
----------------------
Error Message Summary:
----------------------
PaddleCheckError: Expected head_number <= mat_dim_x.width_, but received head_number:10 > mat_dim_x.width_:2.
ShapeError: Unsatisfied mkl acceleration library requirements: head_number (10) must be equal to x_width. But received x_shape: [0, 4, 2]. at [/shixiaowei02/Paddle_matmul_info/Paddle/paddle/fluid/operators/matmul_op.cc:334]
  [operator < matmul > error]
```