### PR TITLE
enable cpu machine to run paddle in gpu lib

### DIFF
--- a/paddle/fluid/platform/gpu_info.cc
+++ b/paddle/fluid/platform/gpu_info.cc
@@ -39,6 +39,14 @@ inline std::string CudaErrorWebsite() {
 }
 
 static int GetCUDADeviceCountImpl() {
+  int driverVersion = 0;
+  cudaError_t status = cudaDriverGetVersion(&driverVersion);
+
+  if (!(status == cudaSuccess && driverVersion != 0)) {
+    // No GPU driver
+    return 0;
+  }
+
   const auto *cuda_visible_devices = std::getenv("CUDA_VISIBLE_DEVICES");
   if (cuda_visible_devices != nullptr) {
     std::string cuda_visible_devices_str(cuda_visible_devices);


### PR DESCRIPTION
cpu机器在gpu库上运行paddle出core，原因是由于缺失显卡driver，显卡driver与cuda driver不匹配

加上driver check解决该问题