### PR TITLE
Add sub-scope check in RecurrentOp 

### DIFF
--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -62,6 +62,17 @@ class WhileOp : public framework::OperatorBase {
 
     auto step_scopes =
         scope.FindVar(Output(kStepScopes))->GetMutable<StepScopeVar>();
+
+    if (step_scopes->size() > 0) {
+      platform::DeviceContextPool::Instance().Get(dev_place)->Wait();
+      for (auto &s : *step_scopes) {
+        if (scope.HasKid(s)) {
+          scope.DeleteScope(s);
+        }
+      }
+      step_scopes->clear();
+    }
+
     PADDLE_ENFORCE_EQ(step_scopes->size(), 0, "The StepScope should be empty.");
     PADDLE_ENFORCE(platform::is_cpu_place(cond.place()),
                    "Condition of while op must in CPU memory.");

--- a/paddle/fluid/operators/recurrent_op.cc
+++ b/paddle/fluid/operators/recurrent_op.cc
@@ -48,7 +48,9 @@ static void ClearStepScopes(const platform::DeviceContext &dev_ctx,
   dev_ctx.Wait();
 
   for (auto *sub_scope : *step_scopes) {
-    parent_scope->DeleteScope(sub_scope);
+    if (parent_scope->HasKid(sub_scope)) {
+      parent_scope->DeleteScope(sub_scope);
+    }
   }
 
   step_scopes->clear();

--- a/python/paddle/fluid/tests/unittests/test_while_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_op.py
@@ -18,46 +18,38 @@ import unittest
 import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
 import paddle.fluid.core as core
+import paddle.fluid as fluid
 from paddle.fluid.backward import append_backward
 import numpy
 
 
 class TestWhileOp(unittest.TestCase):
-    def test_simple_forward(self):
+    def simple_net(self):
         d0 = layers.data(
             "d0", shape=[10], append_batch_size=False, dtype='float32')
         d1 = layers.data(
             "d1", shape=[10], append_batch_size=False, dtype='float32')
         d2 = layers.data(
             "d2", shape=[10], append_batch_size=False, dtype='float32')
-
         i = layers.zeros(shape=[1], dtype='int64')
         i.stop_gradient = True
-
         init = layers.zeros(shape=[10], dtype='float32')
         mem_array = layers.array_write(x=init, i=i)
         data_array = layers.array_write(x=d0, i=i)
-
         i = layers.increment(i)
         layers.array_write(d1, i, array=data_array)
-
         i = layers.increment(i)
         layers.array_write(d2, i, array=data_array)
-
         i = layers.zeros(shape=[1], dtype='int64')
         i.stop_gradient = True
-
         array_len = layers.fill_constant(shape=[1], dtype='int64', value=1)
         array_len.stop_gradient = True
         cond = layers.less_than(x=i, y=array_len)
-
         j = layers.fill_constant(shape=[1], dtype='int64', value=1)
         j.stop_gradient = True
-
         array_len2 = layers.fill_constant(shape=[1], dtype='int64', value=3)
         array_len2.stop_gradient = True
         cond2 = layers.less_than(x=j, y=array_len2)
-
         while_op = layers.While(cond=cond)
         while_op2 = layers.While(cond=cond2)
         with while_op.block():
@@ -77,24 +69,47 @@ class TestWhileOp(unittest.TestCase):
                 j = layers.increment(x=j, in_place=True)
                 layers.array_write(result2, i=j, array=mem_array)
                 layers.less_than(x=j, y=array_len2, cond=cond2)
-
         sum_result = layers.array_read(array=mem_array, i=j)
         loss = layers.mean(sum_result)
+        return loss, sum_result
 
-        append_backward(loss)
+    def test_simple_net(self):
+        main_program = fluid.Program()
+        startup_program = fluid.Program()
+        with fluid.program_guard(main_program, startup_program):
+            loss, sum_result = self.simple_net()
 
-        cpu = core.CPUPlace()
-        exe = Executor(cpu)
-        d = []
+            append_backward(loss)
 
-        for i in range(3):
-            d.append(numpy.random.random(size=[10]).astype('float32'))
+            cpu = core.CPUPlace()
+            exe = Executor(cpu)
+            d = []
 
-        outs = exe.run(feed={'d0': d[0],
-                             'd1': d[1],
-                             'd2': d[2]},
-                       fetch_list=[sum_result])
-        self.assertAlmostEqual(numpy.sum(d), numpy.sum(outs[0]), delta=0.01)
+            for i in range(3):
+                d.append(numpy.random.random(size=[10]).astype('float32'))
+
+            outs = exe.run(feed={'d0': d[0],
+                                 'd1': d[1],
+                                 'd2': d[2]},
+                           fetch_list=[sum_result])
+            self.assertAlmostEqual(numpy.sum(d), numpy.sum(outs[0]), delta=0.01)
+
+    def test_simple_net_forward(self):
+        main_program = fluid.Program()
+        startup_program = fluid.Program()
+        with fluid.program_guard(main_program, startup_program):
+            self.simple_net()
+            binary = fluid.compiler.CompiledProgram(main_program)
+
+            cpu = core.CPUPlace()
+            exe = Executor(cpu)
+            d = []
+
+            for i in range(3):
+                d.append(numpy.random.random(size=[10]).astype('float32'))
+
+            for _ in range(2):
+                exe.run(binary, feed={'d0': d[0], 'd1': d[1], 'd2': d[2]})
 
     def test_exceptions(self):
         i = layers.zeros(shape=[2], dtype='int64')


### PR DESCRIPTION

```
I1011 02:03:28.972664   721 parallel_executor.cc:368] Garbage collection strategy is enabled, when FLAGS_eager_delete_tensor_gb = 0
[INFO: metrics_util.py:  440]: [TEST] test_iter 0     Loss = 8.52670574
/usr/local/lib/python2.7/dist-packages/paddle/fluid/executor.py:738: UserWarning: The following exception is not an EOF exception.
  "The following exception is not an EOF exception.")
Traceback (most recent call last):
  File "train.py", line 253, in <module>
    train(args)
  File "train.py", line 241, in train
    test_metrics=valid_metrics)
  File "/docker_mount/ets/models/PaddleCV/PaddleVideo/utils/train_utils.py", line 127, in train_with_pyreader
    save_model_name)
  File "/docker_mount/ets/models/PaddleCV/PaddleVideo/utils/train_utils.py", line 65, in test_with_pyreader
    feed=data)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/executor.py", line 739, in run
    six.reraise(*sys.exc_info())
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/executor.py", line 734, in run
    use_program_cache=use_program_cache)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/executor.py", line 793, in _run_impl
    return_numpy=return_numpy)
  File "/usr/local/lib/python2.7/dist-packages/paddle/fluid/executor.py", line 657, in _run_parallel
    tensors = exe.run(fetch_var_names)._move_to_list()
paddle.fluid.core_avx.EnforceNotMet: 0   std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > paddle::platform::GetTraceBackString<char const*>(char const*&&, char const*, int)
1   paddle::platform::EnforceNotMet::EnforceNotMet(std::__exception_ptr::exception_ptr, char const*, int)
2   paddle::framework::Scope::DeleteScope(paddle::framework::Scope*) const
3   paddle::operators::StepScopes::StepScopes(paddle::platform::DeviceContext const&, paddle::framework::Scope const&, std::vector<paddle::framework::Scope*, std::allocator<paddle::framework::Scope*> >*, bool, unsigned long, bool)
4   paddle::operators::RecurrentOp::CreateStepScopes(paddle::platform::DeviceContext const&, paddle::framework::Scope const&, unsigned long) const
5   paddle::operators::RecurrentOp::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&) const
6   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&)
7   paddle::framework::details::ComputationOpHandle::RunImpl()
8   paddle::framework::details::FastThreadedSSAGraphExecutor::RunOpSync(paddle::framework::details::OpHandleBase*)
9   paddle::framework::details::FastThreadedSSAGraphExecutor::RunOp(paddle::framework::details::OpHandleBase*, std::shared_ptr<paddle::framework::BlockingQueue<unsigned long> > const&, unsigned long*)
10  std::__future_base::_State_baseV2::_M_do_set(std::function<std::unique_ptr<std::__future_base::_Result_base, std::__future_base::_Result_base::_Deleter> ()>*, bool*)
11  std::thread::_Impl<std::_Bind_simple<ThreadPool::ThreadPool(unsigned long)::{lambda()#1} ()> >::_M_run()
PaddleCheckError: 0x5b446a20 Cannot find 0x7fe4c4002db0 as kid scope at [/docker_mount/doc_en/Paddle/paddle/fluid/framework/scope.cc:124]
```