### PR TITLE
Add config option in AnalysisConfig to disable GLOG INFO

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -93,8 +93,7 @@ void GraphPatternDetector::operator()(Graph *graph,
   ValidateByNodeRole(&subgraphs);
 
   if (subgraphs.empty()) return;
-  PrettyLogEndl(Style::detail(), "---  detected %d subgraphs",
-                subgraphs.size());
+  LOG(INFO) << "---  detected " << subgraphs.size() << " subgraphs";
   int id = 0;
   for (auto &g : subgraphs) {
     VLOG(3) << "optimizing #" << id++ << " subgraph";

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -131,6 +131,9 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
   // profile related.
   CP_MEMBER(with_profile_);
 
+  // glog related.
+  CP_MEMBER(with_glog_info_);
+
   // Ir related.
   CP_MEMBER(enable_ir_optim_);
   CP_MEMBER(use_feed_fetch_ops_);
@@ -382,6 +385,8 @@ std::string AnalysisConfig::SerializeInfoCache() {
 
   ss << with_profile_;
 
+  ss << with_glog_info_;
+
   ss << enable_ir_optim_;
   ss << use_feed_fetch_ops_;
   ss << ir_debug_;
@@ -455,6 +460,11 @@ void AnalysisConfig::SwitchIrDebug(int x) {
 
 void AnalysisConfig::EnableProfile() {
   with_profile_ = true;
+  Update();
+}
+
+void AnalysisConfig::DisableGlogInfo() {
+  with_glog_info_ = false;
   Update();
 }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -506,6 +506,12 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
       framework::InitGflags(flags);
     }
   }
+  if (config.glog_info_disabled()) {
+    google::InitGoogleLogging("Init");
+    FLAGS_logtostderr = 1;
+    FLAGS_minloglevel = google::WARNING;
+    LOG(WARNING) << " - GLOG's LOG(INFO) is disabled.";
+  }
 
   std::unique_ptr<PaddlePredictor> predictor(new AnalysisPredictor(config));
   // Each config can only be used for one predictor.

--- a/paddle/fluid/inference/api/paddle_analysis_config.h
+++ b/paddle/fluid/inference/api/paddle_analysis_config.h
@@ -257,6 +257,15 @@ struct AnalysisConfig {
    */
   bool profile_enabled() const { return with_profile_; }
 
+  /** \brief Disable GLOG information output for security.
+   *
+   * If called, no LOG(INFO) logs will be generated.
+   */
+  void DisableGlogInfo();
+  /** A boolean state telling whether the GLOG info is disabled.
+   */
+  bool glog_info_disabled() const { return !with_glog_info_; }
+
   void SetInValid() const { is_valid_ = false; }
   bool is_valid() const { return is_valid_; }
 
@@ -324,6 +333,8 @@ struct AnalysisConfig {
   int cpu_math_library_num_threads_{1};
 
   bool with_profile_{false};
+
+  bool with_glog_info_{true};
 
   // A runtime cache, shouldn't be transferred to others.
   std::string serialized_info_cache_;

--- a/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
@@ -35,6 +35,7 @@ TEST(ZeroCopyTensor, uint8) {
   config.SetModel(model_dir);
   config.SwitchUseFeedFetchOps(false);
   config.EnableProfile();
+  config.DisableGlogInfo();
 
   std::vector<std::vector<PaddleTensor>> inputs_all;
   auto predictor = CreatePaddlePredictor(config);

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -338,6 +338,7 @@ void BindAnalysisConfig(py::module *m) {
       .def("ir_optim", &AnalysisConfig::ir_optim)
       .def("enable_memory_optim", &AnalysisConfig::EnableMemoryOptim)
       .def("enable_profile", &AnalysisConfig::EnableProfile)
+      .def("disable_glog_info", &AnalysisConfig::DisableGlogInfo)
       .def("set_optim_cache_dir", &AnalysisConfig::SetOptimCacheDir)
       .def("switch_use_feed_fetch_ops", &AnalysisConfig::SwitchUseFeedFetchOps,
            py::arg("x") = true)


### PR DESCRIPTION
**Problem:** The LOG(INFO) and VLOG outputs in paddle inference contains information of models(such as OP or OP fusion), which might compromise the confidentiality of the models.

**Solution:** Added DisableGlogInfo() interface in AnalysisConfig. Now one can call this function if the inner structure of his/her inference models must be strictly confidential, and no LOG(INFO) or VLOG logs will ever show during inference.