### PR TITLE
update mul_op input data type check test=develop

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14705,6 +14705,29 @@ def mul(x, y, x_num_col_dims=1, y_num_col_dims=1, name=None):
 
     helper = LayerHelper("mul", **locals())
 
+    if not isinstance(x, Variable):
+        raise TypeError(
+            "The type of 'x' in mul must be Variable, but received %s" %
+            (type(x)))
+    if not isinstance(y, Variable):
+        raise TypeError(
+            "The type of 'y' in mul must be Variable, but received %s" %
+            (type(y)))
+    if convert_dtype(x.dtype) in ['float16']:
+        warnings.warn(
+            "The data type of 'x' in mul only support float16 in GPU now.")
+    if convert_dtype(y.dtype) in ['float16']:
+        warnings.warn(
+            "The data type of 'y' in mul only support float16 in GPU now.")
+    if convert_dtype(x.dtype) not in ['float16', 'float32', 'float64']:
+        raise TypeError(
+            "The data type of 'x' in mul must be float16, float32 or float64, but received %s."
+            % (convert_dtype(x.dtype)))
+    if convert_dtype(y.dtype) not in ['float16', 'float32', 'float64']:
+        raise TypeError(
+            "The data type of 'y' in mul must be float16, float32 or float64, but received %s."
+            % (convert_dtype(y.dtype)))
+
     if name is None:
         out = helper.create_variable_for_type_inference(dtype=x.dtype)
     else:


### PR DESCRIPTION
cherry-pick form PR #20552
fluid.layers.mul:

- Add data type check, error info as follows:
```
import paddle.fluid as fluid
from paddle.fluid import Program, program_guard
with program_guard(Program(), Program()):
    x = fluid.data(name='x', shape=[3,4],dtype='float16')
    y = fluid.data(name='y', shape=[3,4],dtype='int32')
    fluid.layers.mul(x=x, y=y)
```
>UserWarning: The data type of 'x' in mul only support float16 in GPU now.
>TypeError: The data type of 'y' in mul must be float16, float32 or float64, but received int32