### PR TITLE
[WIP]Generate op functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ paddle/fluid/operators/distributed/send_recv.proto
 paddle/fluid/API.spec
 paddle/fluid/API_DEV.spec
 paddle/fluid/API_PR.spec
+paddle/fluid/pybind/op_function_impl.h
 *.DS_Store
 *.vs
 build/

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -29,22 +29,26 @@ if (WITH_DISTRIBUTE)
 endif()
 
 if(WITH_PYTHON)
+  list(APPEND PYBIND_DEPS ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS})
+  get_property(os_dependency_modules GLOBAL PROPERTY OS_DEPENDENCY_MODULES)
+  list(APPEND PYBIND_DEPS ${os_dependency_modules})
+
+  add_executable(op_function_generator op_function_generator.cc)
+  target_link_libraries(op_function_generator ${PYBIND_DEPS})
+
+  add_custom_target(op_function_cmd 
+    COMMAND "${CMAKE_BINARY_DIR}/paddle/fluid/pybind/op_function_generator" 
+    "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
+  add_dependencies(op_function_cmd op_function_generator)
+
   if(WITH_AMD_GPU)
-    hip_library(paddle_pybind SHARED
-      SRCS ${PYBIND_SRCS}
-      DEPS ARCHIVE_START ${PYBIND_DEPS}
-      ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS} ARCHIVE_END)
+    hip_library(paddle_pybind SHARED SRCS ${PYBIND_SRCS} DEPS ARCHIVE_START ${PYBIND_DEPS} ARCHIVE_END)
   else()
-    cc_library(paddle_pybind SHARED
-      SRCS ${PYBIND_SRCS}
-      DEPS ${PYBIND_DEPS}
-      ${GLOB_OP_LIB} ${GLOB_OPERATOR_DEPS})
+    cc_library(paddle_pybind SHARED SRCS ${PYBIND_SRCS} DEPS ${PYBIND_DEPS})
     if(NOT APPLE AND NOT WIN32)
       target_link_libraries(paddle_pybind rt)
-    endif(NOT APPLE AND NOT WIN32)
-  endif(WITH_AMD_GPU)
+    endif()
+  endif()
 
-  get_property (os_dependency_modules GLOBAL PROPERTY OS_DEPENDENCY_MODULES)
-  target_link_libraries(paddle_pybind ${os_dependency_modules})
-
+  add_dependencies(paddle_pybind op_function_cmd) 
 endif(WITH_PYTHON)

--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle/fluid/framework/attribute.h"
+#include "paddle/fluid/framework/op_info.h"
+#include "paddle/fluid/framework/variable.h"
+#include "pybind11/pybind11.h"
+
+// This include must be the last line
+#include "paddle/fluid/pybind/op_function_impl.h"

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -1,0 +1,99 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fstream>
+#include <iostream>
+#include "paddle/fluid/framework/op_info.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/framework/variable.h"
+#include "paddle/fluid/pybind/pybind.h"
+#include "paddle/fluid/string/string_helper.h"
+
+static std::string RefineName(std::string name) {
+  for (auto &e : name) {
+    if (e == '-' || e == '@') {
+      e = '_';
+    }
+  }
+  return name;
+}
+
+static std::vector<std::string> GenerateOpFunctions(
+    const std::string &module_name) {
+  auto &op_info_map = paddle::framework::OpInfoMap::Instance().map();
+
+  std::vector<std::string> op_function_list;
+  for (auto &pair : op_info_map) {
+    auto &op_info = pair.second;
+    auto op_proto = op_info.proto_;
+    if (op_proto == nullptr) {
+      continue;
+    }
+
+    std::string result =
+        "  " + module_name + ".def(\"" + op_proto->type() + "\", [](";
+    for (auto &input : op_proto->inputs()) {
+      result += ("const paddle::framework::Variable *" +
+                 RefineName(input.name()) + ",");
+    }
+
+    for (auto &output : op_proto->outputs()) {
+      result +=
+          ("paddle::framework::Variable *" + RefineName(output.name()) + ",");
+    }
+
+    if (result.back() == ',') {
+      result.pop_back();
+    }
+
+    result += ") {});\n";
+    op_function_list.emplace_back(std::move(result));
+  }
+
+  return op_function_list;
+}
+
+int main(int argc, char *argv[]) {
+  if (argc != 2) {
+    std::cerr << "argc must be 2" << std::endl;
+    return -1;
+  }
+
+  std::vector<std::string> headers{};
+
+  std::ofstream out(argv[1], std::ios::out);
+
+  out << "#pragma once\n\n";
+
+  for (auto &header : headers) {
+    out << "#include \"" + header + "\"\n";
+  }
+
+  out << "namespace paddle {\n"
+      << "namespace pybind {\n"
+      << "\n"
+      << "inline void BindOpFunctions(pybind11::module *module) {\n"
+      << "  auto m = module->def_submodule(\"ops\");\n\n";
+
+  auto op_funcs = GenerateOpFunctions("m");
+  out << paddle::string::join_strings(op_funcs, '\n');
+
+  out << "}\n\n"
+      << "} // namespace pybind\n"
+      << "} // namespace paddle\n";
+
+  out.close();
+  return 0;
+}

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -85,6 +85,7 @@ limitations under the License. */
 #ifdef PADDLE_WITH_DISTRIBUTE
 #include "paddle/fluid/pybind/communicator_py.h"
 #endif
+#include "paddle/fluid/pybind/op_function.h"
 
 #include "pybind11/stl.h"
 
@@ -339,6 +340,8 @@ PYBIND11_MODULE(core_noavx, m) {
                py::capsule([]() { ScopePool::Instance().Clear(); }));
 
   m.def("_set_paddle_lib_path", &paddle::platform::dynload::SetPaddleLibPath);
+
+  BindOpFunctions(&m);
 
   BindImperative(&m);
 


### PR DESCRIPTION
Try to expose all ops to `core.ops`. Thus, we can invoke `conv2d` operator by writing `core.ops.conv2d(....)` directly instead of using `LayerHelper`, which may save some times in Python.

The generated `paddle/fluid/pybind/op_function_impl.h` is something like:
```C++
#pragma once

namespace paddle {
namespace pybind {

inline void BindOpFunctions(pybind11::module *module) {
  auto m = module->def_submodule("ops");

  m.def("logical_xor", [](const paddle::framework::Variable *X,const paddle::framework::Variable *Y,paddle::framework::Variable *Out) {});
 
  // All other ops
}

} // namespace pybind
} // namespace paddle
```