### PR TITLE
reduce make install time in CI

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -301,7 +301,6 @@ function build_base() {
         make clean
     fi
 
-    make -j ${parallel_number}
     make install -j ${parallel_number}
 }
 
@@ -327,7 +326,6 @@ EOF
     if [[ "$ENABLE_MAKE_CLEAN" != "OFF" ]]; then
         make clean
     fi
-    make -j 8
     make install -j 8
 }
 
@@ -910,7 +908,7 @@ EOF
         xz-utils tk-dev libffi-dev liblzma-dev
     RUN mkdir -p /root/python_build/ && wget -q https://www.sqlite.org/2018/sqlite-autoconf-3250300.tar.gz && \
         tar -zxf sqlite-autoconf-3250300.tar.gz && cd sqlite-autoconf-3250300 && \
-        ./configure -prefix=/usr/local && make -j8 && make install && cd ../ && rm sqlite-autoconf-3250300.tar.gz && \
+        ./configure -prefix=/usr/local && make install -j8 && cd ../ && rm sqlite-autoconf-3250300.tar.gz && \
         wget -q https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz && \
         tar -xzf Python-3.6.0.tgz && cd Python-3.6.0 && \
         CFLAGS="-Wformat" ./configure --prefix=/usr/local/ --enable-shared > /dev/null && \


### PR DESCRIPTION
由于`make install`命令包含了`make`，因此可以省略`make`命令而直接使用 make install 进行安装
目前CI中，`make install`额外的时间为10分钟。
```
[01:52:48]W:	 [Step 1/1] + make install -j 16
....
[02:01:46]W:	 [Step 1/1] fatal: no tag exactly matches '25920195ed4d463a9147ea6f978a39fa8e3b10b4'
[02:02:19] :	 [Step 1/1] running bdist_wheel
[02:02:19] :	 [Step 1/1] running build
[02:02:19] :	 [Step 1/1] running build_py
```