### PR TITLE
Add detail log on parallel dygraph unit test when failed.

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -5,6 +5,8 @@ set(dist_ENVS http_proxy="" https_proxy="")
 
 file(GLOB DIST_TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_dist_*.py")
 string(REPLACE ".py" "" DIST_TEST_OPS "${DIST_TEST_OPS}")
+list(APPEND DIST_TEST_OPS test_parallel_dygraph_mnist)
+list(APPEND DIST_TEST_OPS test_parallel_dygraph_seresnext)
 set(MIXED_DIST_TEST_OPS ${DIST_TEST_OPS})
 #remove distribute unittests.
 list(APPEND MIXED_DIST_TEST_OPS test_dgc_op)

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -6,7 +6,7 @@ set(dist_ENVS http_proxy="" https_proxy="")
 file(GLOB DIST_TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_dist_*.py")
 string(REPLACE ".py" "" DIST_TEST_OPS "${DIST_TEST_OPS}")
 list(APPEND DIST_TEST_OPS test_parallel_dygraph_mnist)
-list(APPEND DIST_TEST_OPS test_parallel_dygraph_seresnext)
+list(APPEND DIST_TEST_OPS test_parallel_dygraph_se_resnext)
 set(MIXED_DIST_TEST_OPS ${DIST_TEST_OPS})
 #remove distribute unittests.
 list(APPEND MIXED_DIST_TEST_OPS test_dgc_op)

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_mnist.py
@@ -17,6 +17,9 @@ import unittest
 from test_dist_base import TestDistBase
 import paddle.fluid as fluid
 
+import os
+flag_name = os.path.splitext(__file__)[0]
+
 
 class TestParallelDygraphMnist(TestDistBase):
     def _setup_config(self):
@@ -26,7 +29,11 @@ class TestParallelDygraphMnist(TestDistBase):
 
     def test_mnist(self):
         if fluid.core.is_compiled_with_cuda():
-            self.check_with_place("parallel_dygraph_mnist.py", delta=1e-5)
+            self.check_with_place(
+                "parallel_dygraph_mnist.py",
+                delta=1e-5,
+                check_error_log=True,
+                log_name=flag_name)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_se_resnext.py
@@ -17,6 +17,9 @@ import unittest
 from test_dist_base import TestDistBase
 import paddle.fluid as fluid
 
+import os
+flag_name = os.path.splitext(__file__)[0]
+
 
 class TestParallelDygraphSeResNeXt(TestDistBase):
     def _setup_config(self):
@@ -26,7 +29,11 @@ class TestParallelDygraphSeResNeXt(TestDistBase):
 
     def test_se_resnext(self):
         if fluid.core.is_compiled_with_cuda():
-            self.check_with_place("parallel_dygraph_se_resnext.py", delta=0.01)
+            self.check_with_place(
+                "parallel_dygraph_se_resnext.py",
+                delta=0.01,
+                check_error_log=True,
+                log_name=flag_name)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the unit test failed, the test framework should print detailed logs for debugging.