### PR TITLE
Make conv workspace size configurable

### DIFF
--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -318,7 +318,7 @@ void Conv2DOpMaker::Make() {
                "allocated/freed each time the operator runs, larger "
                "workspace size can increase performance but also requires "
                "better hardware. This size should be chosen carefully.")
-      .SetDefault(platform::kDefaultConvWorkspaceSizeLimitMB);
+      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
   AddAttr<bool>("exhaustive_search",
                 "(bool, default false) cuDNN has many algorithm to calculation "
                 "convolution, whether enable exhaustive search "
@@ -455,7 +455,7 @@ void Conv3DOpMaker::Make() {
                "allocated/freed each time the operator runs, larger "
                "workspace size can increase performance but also requires "
                "better hardware. This size should be chosen carefully.")
-      .SetDefault(platform::kDefaultConvWorkspaceSizeLimitMB);
+      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
   AddAttr<bool>("exhaustive_search",
                 "(bool, default false) cuDNN has many algorithm to calculation "
                 "convolution, whether enable exhaustive search "

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -222,7 +222,7 @@ void Conv2DTransposeOpMaker::Make() {
                "allocated/freed each time the operator runs, larger "
                "workspace size can increase performance but also requires "
                "better hardward. This size should be carefully setted.")
-      .SetDefault(platform::kDefaultConvWorkspaceSizeLimitMB);
+      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
   AddComment(R"DOC(
 Convolution2D Transpose Operator.
 
@@ -323,7 +323,7 @@ void Conv3DTransposeOpMaker::Make() {
                "allocated/freed each time the operator runs, larger "
                "workspace size can increase performance but also requires "
                "better hardward. This size should be carefully setted.")
-      .SetDefault(platform::kDefaultConvWorkspaceSizeLimitMB);
+      .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
   AddComment(R"DOC(
 Convolution3D Transpose Operator.
 

--- a/paddle/fluid/operators/fused/fusion_conv_inception_op.cc
+++ b/paddle/fluid/operators/fused/fusion_conv_inception_op.cc
@@ -96,7 +96,7 @@ class ConvInceptionFusionOpMaker : public framework::OpProtoAndCheckerMaker {
                  "allocated/freed each time the operator runs, larger "
                  "workspace size can increase performance but also requires "
                  "better hardware. This size should be chosen carefully.")
-        .SetDefault(platform::kDefaultConvWorkspaceSizeLimitMB);
+        .SetDefault(platform::GetDefaultConvWorkspaceSizeLimitMB());
     AddComment(R"DOC(
 )DOC");
   }

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -68,11 +68,13 @@ ELSE()
   set(STREAM_CALLBACK_DEPS)
 ENDIF()
 
+cc_library(cudnn_workspace_helper SRCS cudnn_workspace_helper.cc DEPS boost)
+
 # memcpy depends on device_context, here add deps individually for
 # avoiding cycle dependencies
 cc_library(device_context SRCS device_context.cc init.cc DEPS simple_threadpool malloc xxhash ${STREAM_CALLBACK_DEPS}
     place eigen3 stringpiece cpu_helper cpu_info framework_proto ${GPU_CTX_DEPS} ${MKLDNN_CTX_DEPS}
-    ${dgc_deps} dlpack)
+    ${dgc_deps} dlpack cudnn_workspace_helper)
 
 if (WITH_DISTRIBUTE)
   cc_library(collective_helper SRCS collective_helper.cc DEPS framework_proto  device_context enforce)

--- a/paddle/fluid/platform/cudnn_workspace_helper.cc
+++ b/paddle/fluid/platform/cudnn_workspace_helper.cc
@@ -12,14 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#pragma once
+#include "paddle/fluid/platform/cudnn_workspace_helper.h"
+#include <cstdlib>
+#include <string>
+#include "boost/lexical_cast.hpp"
 
 namespace paddle {
 namespace platform {
 
-static constexpr int kDefaultConvWorkspaceSizeLimitMB = 512;
+static int GetDefaultConvWorkspaceSizeLimitMBImpl() {
+  const char *env_str = std::getenv("FLAGS_conv_workspace_size_limit");
+  return env_str ? boost::lexical_cast<int>(std::string(env_str))
+                 : kDefaultConvWorkspaceSizeLimitMB;
+}
 
-int GetDefaultConvWorkspaceSizeLimitMB();
+int GetDefaultConvWorkspaceSizeLimitMB() {
+  static auto workspace_size = GetDefaultConvWorkspaceSizeLimitMBImpl();
+  return workspace_size;
+}
 
 }  // namespace platform
 }  // namespace paddle


### PR DESCRIPTION
The original implementation of conv workspace size cannot be higher than 512MB. This PR fixes the bug by controlling by `FLAGS_conv_workspace_size_limit`.