### PR TITLE
tweak cmake of protobuf and xxhash to fix compatibility on windows

### DIFF
--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -197,9 +197,6 @@ FUNCTION(build_protobuf TARGET_NAME BUILD_FOR_HOST)
             ${EXTERNAL_OPTIONAL_ARGS})
         SET(OPTIONAL_CACHE_ARGS "-DZLIB_ROOT:STRING=${ZLIB_ROOT}")
     ENDIF()
-    IF(WIN32)
-        SET(OPTIONAL_ARGS ${OPTIONAL_ARGS} "-DCMAKE_GENERATOR_PLATFORM=x64")
-    ENDIF()
 
     SET(PROTOBUF_REPO "https://github.com/protocolbuffers/protobuf.git")
     SET(PROTOBUF_TAG "9f75c5aa851cd877fb0d93ccc31b8567a6706546")
@@ -207,28 +204,25 @@ FUNCTION(build_protobuf TARGET_NAME BUILD_FOR_HOST)
     ExternalProject_Add(
         ${TARGET_NAME}
         ${EXTERNAL_PROJECT_LOG_ARGS}
-        PREFIX          ${PROTOBUF_SOURCES_DIR}
-        UPDATE_COMMAND  ""
-        DEPENDS         zlib
-        GIT_REPOSITORY  ${PROTOBUF_REPO}
-        GIT_TAG         ${PROTOBUF_TAG}
-        CONFIGURE_COMMAND
-        ${CMAKE_COMMAND} ${PROTOBUF_SOURCES_DIR}/src/${TARGET_NAME}/cmake
-            ${OPTIONAL_ARGS}
-            -Dprotobuf_BUILD_TESTS=OFF
-            -DCMAKE_SKIP_RPATH=ON
-            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-            -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
-            -DCMAKE_INSTALL_PREFIX=${PROTOBUF_INSTALL_DIR}
-            -DCMAKE_INSTALL_LIBDIR=lib
-            -DBUILD_SHARED_LIBS=OFF
-            -Dprotobuf_MSVC_STATIC_RUNTIME=${MSVC_STATIC_CRT}
-        CMAKE_CACHE_ARGS
-            -DCMAKE_INSTALL_PREFIX:PATH=${PROTOBUF_INSTALL_DIR}
-            -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
-            -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-            -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-            ${OPTIONAL_CACHE_ARGS}
+        PREFIX           ${PROTOBUF_SOURCES_DIR}
+        DEPENDS          zlib
+        GIT_REPOSITORY   ${PROTOBUF_REPO}
+        GIT_TAG          ${PROTOBUF_TAG}
+        SOURCE_SUBDIR    cmake
+        CMAKE_ARGS       ${OPTIONAL_ARGS}
+                         -Dprotobuf_BUILD_TESTS=OFF
+                         -DCMAKE_SKIP_RPATH=ON
+                         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                         -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
+                         -DCMAKE_INSTALL_PREFIX=${PROTOBUF_INSTALL_DIR}
+                         -DCMAKE_INSTALL_LIBDIR=lib
+                         -DBUILD_SHARED_LIBS=OFF
+                         -Dprotobuf_MSVC_STATIC_RUNTIME=${MSVC_STATIC_CRT}
+        CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${PROTOBUF_INSTALL_DIR}
+                         -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
+                         -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+                         -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+                         ${OPTIONAL_CACHE_ARGS}
     )
 ENDFUNCTION()
 

--- a/cmake/external/xxhash.cmake
+++ b/cmake/external/xxhash.cmake
@@ -22,20 +22,14 @@ if(WIN32)
           GIT_TAG         "v0.6.5"
           PREFIX          ${XXHASH_SOURCE_DIR}
           DOWNLOAD_NAME   "xxhash"
-          UPDATE_COMMAND  ""
           BUILD_IN_SOURCE 1
-          PATCH_COMMAND
-          CONFIGURE_COMMAND
-          ${CMAKE_COMMAND} ${XXHASH_SOURCE_DIR}/src/extern_xxhash/cmake_unofficial
-          -DCMAKE_INSTALL_PREFIX:PATH=${XXHASH_INSTALL_DIR}
-          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
-          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
-          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-          -DBUILD_XXHSUM=OFF
-          -DCMAKE_GENERATOR_PLATFORM=x64
-          -DBUILD_SHARED_LIBS=OFF
-          ${OPTIONAL_CACHE_ARGS}
-          TEST_COMMAND      ""
+          SOURCE_SUBDIR   cmake_unofficial
+          CMAKE_ARGS      -DCMAKE_INSTALL_PREFIX:PATH=${XXHASH_INSTALL_DIR}
+                          -DCMAKE_BUILD_TYPE:STRING=${CMAKE_BUILD_TYPE}
+                          -DCMAKE_VERBOSE_MAKEFILE:BOOL=OFF
+                          -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+                          -DBUILD_XXHSUM=OFF
+                          -DBUILD_SHARED_LIBS=OFF
   )
 else()
   ExternalProject_Add(


### PR DESCRIPTION
1. if we customize cmake command for external projec, then we also need to pass the ${CMAKE_GENERATOR}.
2. For protobuf and xxhash, the reason we need to customize configure command is that the CmakeLists.txt exists in a sub-folder. A cleaner method to do this is to define SOURCE_SUBDIR.

for issue 1, if vs2017 and vs2015 are both installed, the below issue maybe encounterd in linking stage - protobuf is compiled/linked in vs2017, but other parts are compiled/linked in VS2015: 
![image](https://user-images.githubusercontent.com/46661762/66987481-75779080-f0f3-11e9-878d-3b82ea381cce.png)
