### PR TITLE
Add choice of CUDA Place and remove fluid.layers.data for python API test of resize Ops

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
@@ -486,25 +486,13 @@ class TestBilinearInterp_attr_tensor_Case3(TestBilinearInterpOp_attr_tensor):
 
 class TestBilinearInterpOpAPI(OpTest):
     def test_case(self):
-        x = fluid.layers.data(name="x", shape=[3, 6, 6], dtype="float32")
+        x = fluid.data(name="x", shape=[1, 3, 6, 6], dtype="float32")
 
-        dim = fluid.layers.data(
-            name="dim", shape=[1], dtype="int32", append_batch_size=False)
-        shape_tensor = fluid.layers.data(
-            name="shape_tensor",
-            shape=[2],
-            dtype="int32",
-            append_batch_size=False)
-        actual_size = fluid.layers.data(
-            name="actual_size",
-            shape=[2],
-            dtype="int32",
-            append_batch_size=False)
-        scale_tensor = fluid.layers.data(
-            name="scale_tensor",
-            shape=[1],
-            dtype="float32",
-            append_batch_size=False)
+        dim = fluid.data(name="dim", shape=[1], dtype="int32")
+        shape_tensor = fluid.data(name="shape_tensor", shape=[2], dtype="int32")
+        actual_size = fluid.data(name="actual_size", shape=[2], dtype="int32")
+        scale_tensor = fluid.data(
+            name="scale_tensor", shape=[1], dtype="float32")
 
         out1 = fluid.layers.resize_bilinear(x, out_shape=[12, 12])
         out2 = fluid.layers.resize_bilinear(x, out_shape=[12, dim])
@@ -519,8 +507,12 @@ class TestBilinearInterpOpAPI(OpTest):
         actual_size_data = np.array([12, 12]).astype("int32")
         scale_data = np.array([2.0]).astype("float32")
 
-        place = core.CPUPlace()
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+        else:
+            place = core.CPUPlace()
         exe = fluid.Executor(place)
+        exe.run(fluid.default_startup_program())
         results = exe.run(fluid.default_main_program(),
                           feed={
                               "x": x_data,

--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
@@ -486,7 +486,7 @@ class TestBilinearInterp_attr_tensor_Case3(TestBilinearInterpOp_attr_tensor):
 
 class TestBilinearInterpOpAPI(OpTest):
     def test_case(self):
-        x = fluid.data(name="x", shape=[1, 3, 6, 6], dtype="float32")
+        x = fluid.data(name="x", shape=[2, 3, 6, 6], dtype="float32")
 
         dim = fluid.data(name="dim", shape=[1], dtype="int32")
         shape_tensor = fluid.data(name="shape_tensor", shape=[2], dtype="int32")
@@ -501,7 +501,7 @@ class TestBilinearInterpOpAPI(OpTest):
             x, out_shape=[4, 4], actual_shape=actual_size)
         out5 = fluid.layers.resize_bilinear(x, scale=scale_tensor)
 
-        x_data = np.random.random((1, 3, 6, 6)).astype("float32")
+        x_data = np.random.random((2, 3, 6, 6)).astype("float32")
         dim_data = np.array([12]).astype("int32")
         shape_data = np.array([12, 12]).astype("int32")
         actual_size_data = np.array([12, 12]).astype("int32")

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -453,7 +453,7 @@ class TestNearestAPI(OpTest):
         else:
             place = core.CPUPlace()
         exe = fluid.Executor(place)
-        # exe.run(fluid.default_startup_program())
+        exe.run(fluid.default_startup_program())
         results = exe.run(fluid.default_main_program(),
                           feed={
                               "x": x_data,

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -448,8 +448,12 @@ class TestNearestAPI(OpTest):
         actual_size_data = np.array([12, 12]).astype("int32")
         scale_data = np.array([2.0]).astype("float32")
 
-        place = core.CPUPlace()
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+        else:
+            place = core.CPUPlace()
         exe = fluid.Executor(place)
+        # exe.run(fluid.default_startup_program())
         results = exe.run(fluid.default_main_program(),
                           feed={
                               "x": x_data,

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -425,8 +425,8 @@ class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
 
 class TestNearestAPI(OpTest):
     def test_case(self):
-        x = fluid.data(name="x", shape=[1, 3, 6, 6], dtype="float32")
-        y = fluid.data(name="y", shape=[1, 6, 6, 3], dtype="float32")
+        x = fluid.data(name="x", shape=[2, 3, 6, 6], dtype="float32")
+        y = fluid.data(name="y", shape=[2, 6, 6, 3], dtype="float32")
 
         dim = fluid.data(name="dim", shape=[1], dtype="int32")
         shape_tensor = fluid.data(name="shape_tensor", shape=[2], dtype="int32")
@@ -442,7 +442,7 @@ class TestNearestAPI(OpTest):
             x, out_shape=[4, 4], actual_shape=actual_size)
         out5 = fluid.layers.resize_nearest(x, scale=scale_tensor)
 
-        x_data = np.random.random((1, 3, 6, 6)).astype("float32")
+        x_data = np.random.random((2, 3, 6, 6)).astype("float32")
         dim_data = np.array([12]).astype("int32")
         shape_data = np.array([12, 12]).astype("int32")
         actual_size_data = np.array([12, 12]).astype("int32")

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
@@ -570,25 +570,14 @@ class TestTrilinearInterp_attr_tensor_Case3(TestTrilinearInterpOp_attr_tensor):
 
 class TestTrilinearInterpAPI(OpTest):
     def test_case(self):
-        x = fluid.layers.data(name="x", shape=[3, 6, 9, 4], dtype="float32")
-        y = fluid.layers.data(name="y", shape=[6, 9, 4, 3], dtype="float32")
+        x = fluid.data(name="x", shape=[1, 3, 6, 9, 4], dtype="float32")
+        y = fluid.data(name="y", shape=[1, 6, 9, 4, 3], dtype="float32")
 
-        dim = fluid.layers.data(name="dim", shape=[1], dtype="int32")
-        shape_tensor = fluid.layers.data(
-            name="shape_tensor",
-            shape=[3],
-            dtype="int32",
-            append_batch_size=False)
-        actual_size = fluid.layers.data(
-            name="actual_size",
-            shape=[3],
-            dtype="int32",
-            append_batch_size=False)
-        scale_tensor = fluid.layers.data(
-            name="scale_tensor",
-            shape=[1],
-            dtype="float32",
-            append_batch_size=False)
+        dim = fluid.data(name="dim", shape=[1], dtype="int32")
+        shape_tensor = fluid.data(name="shape_tensor", shape=[3], dtype="int32")
+        actual_size = fluid.data(name="actual_size", shape=[3], dtype="int32")
+        scale_tensor = fluid.data(
+            name="scale_tensor", shape=[1], dtype="float32")
 
         out1 = fluid.layers.resize_trilinear(
             y, out_shape=[12, 18, 8], data_format='NDHWC')
@@ -604,8 +593,12 @@ class TestTrilinearInterpAPI(OpTest):
         actual_size_data = np.array([12, 18, 8]).astype("int32")
         scale_data = np.array([2.0]).astype("float32")
 
-        place = core.CPUPlace()
+        if core.is_compiled_with_cuda():
+            place = core.CUDAPlace(0)
+        else:
+            place = core.CPUPlace()
         exe = fluid.Executor(place)
+        exe.run(fluid.default_startup_program())
         results = exe.run(fluid.default_main_program(),
                           feed={
                               "x": x_data,
@@ -628,8 +621,7 @@ class TestTrilinearInterpAPI(OpTest):
 
 class TestTrilinearInterpOpException(OpTest):
     def test_exception(self):
-        input = fluid.layers.data(
-            name="input", shape=[3, 6, 9, 4], dtype="float32")
+        input = fluid.data(name="input", shape=[1, 3, 6, 9, 4], dtype="float32")
 
         def attr_data_format():
             # for 5-D input, data_format only can be NCDHW or NDHWC

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
@@ -570,8 +570,8 @@ class TestTrilinearInterp_attr_tensor_Case3(TestTrilinearInterpOp_attr_tensor):
 
 class TestTrilinearInterpAPI(OpTest):
     def test_case(self):
-        x = fluid.data(name="x", shape=[1, 3, 6, 9, 4], dtype="float32")
-        y = fluid.data(name="y", shape=[1, 6, 9, 4, 3], dtype="float32")
+        x = fluid.data(name="x", shape=[2, 3, 6, 9, 4], dtype="float32")
+        y = fluid.data(name="y", shape=[2, 6, 9, 4, 3], dtype="float32")
 
         dim = fluid.data(name="dim", shape=[1], dtype="int32")
         shape_tensor = fluid.data(name="shape_tensor", shape=[3], dtype="int32")
@@ -587,7 +587,7 @@ class TestTrilinearInterpAPI(OpTest):
             x, out_shape=[4, 4, 8], actual_shape=actual_size)
         out5 = fluid.layers.resize_trilinear(x, scale=scale_tensor)
 
-        x_data = np.random.random((1, 3, 6, 9, 4)).astype("float32")
+        x_data = np.random.random((2, 3, 6, 9, 4)).astype("float32")
         dim_data = np.array([18]).astype("int32")
         shape_data = np.array([12, 18, 8]).astype("int32")
         actual_size_data = np.array([12, 18, 8]).astype("int32")
@@ -621,7 +621,7 @@ class TestTrilinearInterpAPI(OpTest):
 
 class TestTrilinearInterpOpException(OpTest):
     def test_exception(self):
-        input = fluid.data(name="input", shape=[1, 3, 6, 9, 4], dtype="float32")
+        input = fluid.data(name="input", shape=[2, 3, 6, 9, 4], dtype="float32")
 
         def attr_data_format():
             # for 5-D input, data_format only can be NCDHW or NDHWC


### PR DESCRIPTION
modified unittests of resize_nearest/bilinear/trilinear
- add choice of CUDA Place for test of python API
- modified `fluid.layers.data` to `fluid.data`