### PR TITLE
Disable GRPC_ARG_ALLOW_REUSEPORT to avoid potencial problem.

### DIFF
--- a/paddle/fluid/operators/distributed/grpc/grpc_server.cc
+++ b/paddle/fluid/operators/distributed/grpc/grpc_server.cc
@@ -466,6 +466,7 @@ void AsyncGRPCServer::StartServer() {
     if (FLAGS_rpc_disable_reuse_port) {
       builder.SetOption(
           std::unique_ptr<::grpc::ServerBuilderOption>(new NoReusePortOption));
+      LOG(INFO) << "set FLAGS_rpc_disable_reuse_port";
     }
     builder.RegisterService(service.get());
 

--- a/paddle/fluid/operators/distributed/sendrecvop_utils.cc
+++ b/paddle/fluid/operators/distributed/sendrecvop_utils.cc
@@ -23,7 +23,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/distributed/variable_response.h"
 #include "paddle/fluid/platform/port.h"
 
-DEFINE_bool(rpc_disable_reuse_port, false, "Disable SO_REUSEPORT or not.");
+DEFINE_bool(rpc_disable_reuse_port, true, "Disable SO_REUSEPORT or not.");
 DEFINE_int32(rpc_retry_bind_port, 3,
              "Retry to bind the address if address is already used.");
 

--- a/paddle/fluid/operators/distributed/sendrecvop_utils.cc
+++ b/paddle/fluid/operators/distributed/sendrecvop_utils.cc
@@ -23,7 +23,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/distributed/variable_response.h"
 #include "paddle/fluid/platform/port.h"
 
-DEFINE_bool(rpc_disable_reuse_port, true, "Disable SO_REUSEPORT or not.");
+DEFINE_bool(rpc_disable_reuse_port, false, "Disable SO_REUSEPORT or not.");
 DEFINE_int32(rpc_retry_bind_port, 3,
              "Retry to bind the address if address is already used.");
 

--- a/python/paddle/fluid/tests/unittests/dist_test.sh
+++ b/python/paddle/fluid/tests/unittests/dist_test.sh
@@ -15,10 +15,6 @@ if [[ ${TEST_TIMEOUT}"x" == "x" ]]; then
 fi
 
 
-echo "before run ${name}"
-ps -aux
-netstat -anlp
-
 # rm flag file
 rm -f ${name}_*.log
 

--- a/python/paddle/fluid/tests/unittests/dist_test.sh
+++ b/python/paddle/fluid/tests/unittests/dist_test.sh
@@ -14,6 +14,10 @@ if [[ ${TEST_TIMEOUT}"x" == "x" ]]; then
     exit 1
 fi
 
+
+echo "before run ${name}"
+netstat -an
+
 # rm flag file
 rm -f ${name}_*.log
 
@@ -28,6 +32,7 @@ fi
 
 echo "${name} faild with ${exit_code}"
 
+echo "after run ${name}"
 netstat -an
 
 # paddle log

--- a/python/paddle/fluid/tests/unittests/dist_test.sh
+++ b/python/paddle/fluid/tests/unittests/dist_test.sh
@@ -16,7 +16,8 @@ fi
 
 
 echo "before run ${name}"
-netstat -an
+ps -aux
+netstat -anlp
 
 # rm flag file
 rm -f ${name}_*.log
@@ -33,7 +34,8 @@ fi
 echo "${name} faild with ${exit_code}"
 
 echo "after run ${name}"
-netstat -an
+ps -aux
+netstat -anlp
 
 # paddle log
 echo "${name} log"

--- a/python/paddle/fluid/tests/unittests/dist_test.sh
+++ b/python/paddle/fluid/tests/unittests/dist_test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 unset https_proxy http_proxy
+export FLAGS_rpc_disable_reuse_port=1
 
 name=${TEST_TARGET_NAME}
 TEST_TIMEOUT=${TEST_TIMEOUT}

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -848,6 +848,7 @@ class TestDistBase(unittest.TestCase):
             "FLAGS_rpc_deadline": "30000",  # 5sec to fail fast
             "FLAGS_rpc_retry_bind_port": "50",
             "FLAGS_cudnn_deterministic": "1",
+            "FLAGS_rpc_disable_reuse_port": "1",
             "http_proxy": "",
             "NCCL_P2P_DISABLE": "1",
             "NCCL_SHM_DISABLE": "1"

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -859,7 +859,7 @@ class TestDistBase(unittest.TestCase):
             required_envs["GLOG_vmodule"] = \
                 "fused_all_reduce_op_handle=10,all_reduce_op_handle=10,alloc_continuous_space_op=10,fuse_all_reduce_op_pass=10," \
                 "alloc_continuous_space_for_grad_pass=10,fast_threaded_ssa_graph_executor=10,executor=10,operator=10," \
-                "sparse_all_reduce_op_handle=10"
+                "sparse_all_reduce_op_handle=10,gen_nccl_id_op=10"
             required_envs["GLOG_logtostderr"] = "1"
 
         local_losses \


### PR DESCRIPTION
[Reference](https://www.softlab.ntua.gr/facilities/documentation/unix/unix-socket-faq/unix-socket-faq-4.html)
```
The SO_REUSEPORT flag allows multiple processes to bind to the same address provided all of them use the SO_REUSEPORT option.
```