### PR TITLE
Fix op run log when memory optimization strategy is enabled

### DIFF
--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -128,3 +128,5 @@ endif()
 
 set(GLOB_OP_LIB ${OP_LIBRARY} CACHE INTERNAL "Global OP library")
 add_subdirectory(benchmark)
+
+cc_test(op_debug_string_test SRCS op_debug_string_test.cc DEPS elementwise_add_op)

--- a/paddle/fluid/operators/op_debug_string_test.cc
+++ b/paddle/fluid/operators/op_debug_string_test.cc
@@ -1,0 +1,71 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string>
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+
+USE_OP(elementwise_add_grad);
+
+namespace paddle {
+namespace operators {
+
+TEST(op_debug_str, test_unknown_dtype) {
+  platform::Place place = platform::CPUPlace();
+  framework::DDim dim{3, 4, 5, 6};
+  const std::string unknown_dtype = "unknown_dtype";
+
+  framework::OpDesc desc;
+  framework::Scope scope;
+
+  desc.SetType("elementwise_add_grad");
+  desc.SetInput("Y", {"Y"});
+  desc.SetInput(framework::GradVarName("Out"), {framework::GradVarName("Out")});
+  desc.SetOutput(framework::GradVarName("X"), {framework::GradVarName("X")});
+  desc.SetOutput(framework::GradVarName("Y"), {framework::GradVarName("Y")});
+  desc.SetAttr("axis", -1);
+  desc.SetAttr("use_mkldnn", false);
+  desc.SetAttr("x_data_format", "");
+  desc.SetAttr("y_data_format", "");
+
+  auto y_tensor = scope.Var("Y")->GetMutable<framework::LoDTensor>();
+  y_tensor->Resize(dim);
+  y_tensor->mutable_data<float>(place);
+
+  auto out_grad_tensor = scope.Var(framework::GradVarName("Out"))
+                             ->GetMutable<framework::LoDTensor>();
+  out_grad_tensor->Resize(dim);
+  out_grad_tensor->mutable_data<float>(place);
+
+  scope.Var(framework::GradVarName("X"))->GetMutable<framework::LoDTensor>();
+  scope.Var(framework::GradVarName("Y"))->GetMutable<framework::LoDTensor>();
+
+  auto op = framework::OpRegistry::CreateOp(desc);
+
+  auto before_run_str = op->DebugStringEx(&scope);
+  LOG(INFO) << before_run_str;
+  ASSERT_TRUE(before_run_str.find(unknown_dtype) != std::string::npos);
+
+  op->Run(scope, place);
+  platform::DeviceContextPool::Instance().Get(place)->Wait();
+
+  auto after_run_str = op->DebugStringEx(&scope);
+  LOG(INFO) << after_run_str;
+  ASSERT_TRUE(after_run_str.find(unknown_dtype) != std::string::npos);
+}
+
+}  // namespace operators
+}  // namespace paddle


### PR DESCRIPTION
When memory optimization strategy is enabled, data buffer of some tensors may be collected or reused in another thread, which causes the thread printing op running log raises error.

This PR fixes this bug. After this PR, the tensors collected before op runs would be printed as `unknown_dtype`.

```
I1017 09:26:49.364127 43469 operator.cc:162] CPUPlace Op(elementwise_add_grad), inputs:{Out@GRAD[Out@GRAD:float[2, 3, 4]({})], Y[Y:unknown_dtype[1, 1]({})]}, outputs:{X@GRAD[X@GRAD:[0]({})], Y@GRAD[Y@GRAD:[0]({})]}.
```

 