### PR TITLE
fix bias_attr's bug of conv and conv_transpose

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2801,7 +2801,10 @@ def conv2d(input,
             "data_format": data_format,
         })
 
-    pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    if data_format == 'NCHW':
+        pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    else:
+        pre_act = helper.append_bias_op(pre_bias, dim_start=3, dim_end=4)
 
     return helper.append_activation(pre_act)
 
@@ -3049,7 +3052,10 @@ def conv3d(input,
             "data_format": data_format,
         })
 
-    pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    if data_format == 'NCDHW':
+        pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    else:
+        pre_act = helper.append_bias_op(pre_bias, dim_start=4, dim_end=5)
 
     return helper.append_activation(pre_act)
 
@@ -5148,7 +5154,10 @@ def conv2d_transpose(input,
             'data_format': data_format
         })
 
-    pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    if data_format == 'NCHW':
+        pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    else:
+        pre_act = helper.append_bias_op(pre_bias, dim_start=3, dim_end=4)
     out = helper.append_activation(pre_act)
     return out
 
@@ -5423,7 +5432,10 @@ def conv3d_transpose(input,
             'data_format': data_format
         })
 
-    pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    if data_format == 'NCHW':
+        pre_act = helper.append_bias_op(pre_bias, dim_start=1, dim_end=2)
+    else:
+        pre_act = helper.append_bias_op(pre_bias, dim_start=4, dim_end=5)
     out = helper.append_activation(pre_act)
     return out
 


### PR DESCRIPTION
**fix bug**：when data_format of input is channel_last，the shape of bias is wrong. 
**The API involved**: conv2d、conv3d、conv2d_transpose、conv3d_transpose
before: 
```python
data = fluid.data(name='data', dtype="float32", shape=[None, 224, 224, 3])
bias = fluid.ParamAttr(name='bias', initializer=None, learning_rate=1.0, regularizer=None, trainable=True, gradient_clip=None, do_model_average=False)
result = fluid.layers.conv2d(data, num_filters=6, filter_size=3, bias_attr=bias, data_format='NHWC')
exe = fluid.Executor(fluid.CPUPlace())
exe.run(fluid.default_startup_program())
print(numpy.array(fluid.global_scope().find_var('bias').get_tensor()).shape) 
# actual: (222,) but expect: (6,)
```