### PR TITLE
fix_depthwise_conv_cudnn

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_op.cu
+++ b/paddle/fluid/operators/conv_cudnn_op.cu
@@ -265,6 +265,16 @@ class CUDNNConvOpKernel : public framework::OpKernel<T> {
     algo = search::Find<T>(args, exhaustive_search, false, 0, ctx);
     workspace_size = search::GetWorkspaceSize(args, algo);
 
+#if CUDNN_VERSION_MIN(7, 0, 1)
+    // when groups > 1, SearchAlgorithm find algo is CUDNN_CONVOLUTION_\
+    // FWD_ALGO_WINOGRAD_NONFUSED, but this kind of algorithm is unstable
+    // in forward computation, so change the algorithm to CUDNN_CONVOLUTION_\
+    // FWD_ALGO_IMPLICIT_GEMM manually.
+    if (ctx.Attr<int>("groups") > 1) {
+      algo = static_cast<cudnnConvolutionFwdAlgo_t>(0);
+    }
+#endif
+
     // ------------------- cudnn conv forward ---------------------
     ScalingParamType<T> alpha = 1.0f, beta = 0.0f;
     for (int i = 0; i < groups; i++) {
@@ -805,6 +815,7 @@ class CUDNNConvDoubleGradOpKernel : public framework::OpKernel<T> {
 #if CUDNN_VERSION_MIN(7, 0, 1)
     iwo_group = 1;
     c_group = groups;
+    groups = 1;
 #endif
     auto dtype = platform::CudnnDataType<T>::type;
 


### PR DESCRIPTION
when groups > 1, SearchAlgorithm find algo is CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED, but this kind of algorithm is unstable in groups convolution computation, so change the algorithm to CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM manually.

fix https://github.com/PaddlePaddle/Paddle/issues/18939

test environment Paddle 1.6, P40, cuda9.0 cudnn 7.5
test code:

```python
import paddle.fluid as fluid
import time

def test(place, data, use_cudnn):
    input = fluid.layers.create_global_var(dtype='float32', shape=[5, 384, 28, 28], name='data', persistable=True, value=1.0)
    result = fluid.layers.conv2d(input, bias_attr=False, param_attr="depthwise_kernel",
        num_filters=384, filter_size=[5, 5], stride=[1, 1], groups=384, use_cudnn=use_cudnn)

    exe = fluid.Executor(place)
    exe.run(fluid.default_startup_program())

    np_input = fluid.global_scope().find_var('data').get_tensor()
    np_input.set(data, place)

    fluid.io.load_params(executor=exe, dirname='test_model', main_program=fluid.default_main_program())

    for i in range(10):
        exe.run(fluid.default_main_program())

    s_time = time.time()
    for i in range(10):
        exe.run(fluid.default_main_program())
    print("time: ", (time.time() - s_time) / float(10))

import numpy
numpy.random.seed(13)
data = numpy.random.rand(5, 384, 28, 28).astype('float32')
test(fluid.CUDAPlace(0), data, True)
#test(fluid.CUDAPlace(0), data, False)
```

                     |  after(GEMM)   |before(WINOGRAD)
    use_cudnn=True   |  0.00147512    |  0.0144635
    use_cudnn=False  |  0.00173819    |  0.00183482