### PR TITLE
update the infer shape of matmul, test=release/1.6

### DIFF
--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -313,6 +313,13 @@ class MatMulOp : public framework::OperatorWithKernel {
         math::CreateMatrixDescriptor(ColumnMatrixFromVector(dim_y), 0,
                                      context->Attrs().Get<bool>("transpose_Y"));
 
+    if (mat_dim_x.width_ == -1) {
+      mat_dim_x.width_ = mat_dim_y.height_;
+    }
+    if (mat_dim_y.height_ == -1) {
+      mat_dim_y.height_ = mat_dim_x.width_;
+    }
+
     if (context->IsRuntime()) {
       PADDLE_ENFORCE(
           mat_dim_x.batch_size_ == mat_dim_y.batch_size_ ||

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -330,20 +330,21 @@ class MatMulOp : public framework::OperatorWithKernel {
           DumpMatrixShape(mat_dim_x).c_str(),
           DumpMatrixShape(mat_dim_y).c_str());
     }
-    std::vector<int64_t> dim_out;
     int64_t dim_out_y = mat_dim_y.width_;
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
     int head_number = context->Attrs().Get<int>("head_number");
     bool split_vertical_y = (mat_dim_x.width_ != mat_dim_y.height_);
-    PADDLE_ENFORCE_LE(
-        head_number, mat_dim_x.width_,
-        "ShapeError: Unsatisfied mkl acceleration library requirements: "
-        "The number of heads "
-        "(%d) must be equal to X's width. But received X's shape: %s.",
-        head_number, DumpMatrixShape(mat_dim_x).c_str());
+    if (context->IsRuntime()) {
+      PADDLE_ENFORCE_LE(
+          head_number, mat_dim_x.width_,
+          "ShapeError: Unsatisfied mkl acceleration library requirements: "
+          "The number of heads "
+          "(%d) must be equal to X's width. But received X's shape: %s.",
+          head_number, DumpMatrixShape(mat_dim_x).c_str());
 
-    if (!split_vertical_y && head_number > 0) {
-      dim_out_y = head_number * mat_dim_y.width_;
+      if (!split_vertical_y && head_number > 0) {
+        dim_out_y = head_number * mat_dim_y.width_;
+      }
     }
 #else
     PADDLE_ENFORCE_EQ(
@@ -354,6 +355,7 @@ class MatMulOp : public framework::OperatorWithKernel {
         DumpMatrixShape(mat_dim_x).c_str(), DumpMatrixShape(mat_dim_y).c_str());
 #endif
 
+    std::vector<int64_t> dim_out;
     if (mat_dim_x.batch_size_ != 0) {
       dim_out = framework::vectorize(dim_x);
       dim_out[dim_out.size() - 2] = mat_dim_x.height_;

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6929,11 +6929,11 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
         if transpose_y:
             y_shape[-2], y_shape[-1] = y_shape[-1], y_shape[-2]
         if x_shape[-1] != y_shape[-2]:
-            raise ValueError(
-                "After performing an optional transpose, Input X's width should be "
-                "equal to Y's width for multiplication "
-                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %
-                (x_shape, y_shape))
+            assert (x_shape[-1] == -1) or (y_shape[-2] == -1),                         \
+                "After performing an optional transpose, Input X's width should be "   \
+                "equal to Y's width for multiplication "                               \
+                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %         \
+                (x_shape, y_shape)
 
         if len(y_shape) > 2 and len(x_shape) > 2:
             for i, dim_x in enumerate(x_shape[:-2]):

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -178,7 +178,7 @@ class ModelTestGenerator(object):
                                    feed={'x': X,
                                          'y': Y},
                                    fetch_list=[output])
-                    np.testing.assert_array_almost_equal(res, Ref, decimal=3)
+                    np.allclose(res, Ref, atol=1e-5)
 
 
 # Generate test cases for all possibilities


### PR DESCRIPTION
Inferred support for non-essential dimensions (one of x_width and y_height) has been added.

`e.g.`
`x1_shape [-1, M, -1]，x2_shape [-1, K] ==> y_shape [-1, M, K]`
`x1_shape [-1, -1, -1]，x2_shape [N, K] ==> y_shape [-1, -1, K]`
`x1_shape [-1, -1]，x2_shape [N, K] ==> y_shape [-1, K]`
`x1_shape [M, N]，x2_shape [-1] ==> y_shape [M]`