### PR TITLE
update the infer shape of matmul, test=develop

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6902,11 +6902,11 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
         if transpose_y:
             y_shape[-2], y_shape[-1] = y_shape[-1], y_shape[-2]
         if x_shape[-1] != y_shape[-2]:
-            raise ValueError(
-                "After performing an optional transpose, Input X's width should be "
-                "equal to Y's width for multiplication "
-                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %
-                (x_shape, y_shape))
+            assert (x_shape[-1] == -1) or (y_shape[-2] == -1),                         \
+                "After performing an optional transpose, Input X's width should be "   \
+                "equal to Y's width for multiplication "                               \
+                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %         \
+                (x_shape, y_shape)
 
         if len(y_shape) > 2 and len(x_shape) > 2:
             for i, dim_x in enumerate(x_shape[:-2]):

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -129,7 +129,60 @@ class TestMatmulOpError(OpTest):
             fluid.layers.matmul(input3, input3)
 
 
-# Generate test cases for all possibilities
+# Negative dimension generation
+def negative_shapes_list(in_shape):
+    from itertools import combinations
+    size = len(in_shape)
+    indexs = list()
+    shapes = list()
+    for i in range(size):
+        indexs.extend(list(combinations([j for j in range(size)], i + 1)))
+    for idx in indexs:
+        shapes.append(
+            [in_shape[i] if i not in idx else -1 for i in range(size)])
+    return shapes
+
+
+# Build program with inputs sizes that contain negative numbers
+def test_negative_program(obj):
+    for shape_x in negative_shapes_list(obj.shape_X):
+        for shape_y in negative_shapes_list(obj.shape_Y):
+            X = np.random.random(obj.shape_X).astype("float32")
+            Y = np.random.random(obj.shape_Y).astype("float32")
+            Ref = reference_matmul(X, Y, obj.transpose_X, obj.transpose_Y)
+            with program_guard(Program(), Program()):
+                x = fluid.data(name='x', shape=shape_x, dtype='float32')
+                y = fluid.data(name='y', shape=shape_y, dtype='float32')
+                output = fluid.layers.matmul(x, y, obj.transpose_X,
+                                             obj.transpose_Y)
+                obj.assertEqual(len(Ref.shape), len(output.shape))
+                for idx in range(len(Ref.shape)):
+                    if output.shape[idx] != -1:
+                        obj.assertEqual(Ref.shape[idx], output.shape[idx])
+                exe = fluid.Executor(fluid.CPUPlace())
+                res, = exe.run(fluid.default_main_program(),
+                               feed={'x': X,
+                                     'y': Y},
+                               fetch_list=[output])
+                np.allclose(res, Ref, atol=1e-5)
+
+
+# Generate program api cases for all negative possibilities
+def api_test(dim_x, dim_y, trans_x, trans_y):
+    test_name = ('TestMatMulAPI_dimX_{}_dim_Y_{}_transX_{}_transY_{}'.format(
+        dim_x, dim_y, trans_x, trans_y))
+    shape_x, shape_y = generate_compatible_shapes(dim_x, dim_y, trans_x,
+                                                  trans_y)
+    globals()[test_name] = type(test_name, (OpTest, ), {
+        'shape_X': shape_x,
+        'shape_Y': shape_y,
+        'transpose_X': trans_x,
+        'transpose_Y': trans_y,
+        'test_propram': test_negative_program,
+    })
+
+
+# Generate operators cases for all possibilities
 def inject_test(dim_x, dim_y, trans_x, trans_y):
     test_name = ('TestMatMulOp_dimX_{}_dim_Y_{}_transX_{}_transY_{}'.format(
         dim_x, dim_y, trans_x, trans_y))
@@ -148,6 +201,7 @@ for dim_X in (1, 2, 3):
         for transose_x in (False, True):
             for transose_y in (False, True):
                 inject_test(dim_X, dim_Y, transose_x, transose_y)
+                api_test(dim_X, dim_Y, transose_x, transose_y)
 
 
 # Test case n-dim

--- a/python/paddle/fluid/tests/unittests/test_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matmul_op.py
@@ -130,7 +130,7 @@ class TestMatmulOpError(OpTest):
 
 
 # Negative dimension generation
-def negative_shapes_list(in_shape):
+def generate_negative_dims(in_shape):
     from itertools import combinations
     size = len(in_shape)
     indexs = list()
@@ -144,9 +144,9 @@ def negative_shapes_list(in_shape):
 
 
 # Build program with inputs sizes that contain negative numbers
-def test_negative_program(obj):
-    for shape_x in negative_shapes_list(obj.shape_X):
-        for shape_y in negative_shapes_list(obj.shape_Y):
+def test_negative_dims_program(obj):
+    for shape_x in generate_negative_dims(obj.shape_X):
+        for shape_y in generate_negative_dims(obj.shape_Y):
             X = np.random.random(obj.shape_X).astype("float32")
             Y = np.random.random(obj.shape_Y).astype("float32")
             Ref = reference_matmul(X, Y, obj.transpose_X, obj.transpose_Y)
@@ -178,7 +178,7 @@ def api_test(dim_x, dim_y, trans_x, trans_y):
         'shape_Y': shape_y,
         'transpose_X': trans_x,
         'transpose_Y': trans_y,
-        'test_propram': test_negative_program,
+        'test_propram': test_negative_dims_program,
     })
 
 


### PR DESCRIPTION
test=develop

Inferred support for non-essential dimensions (one of x_width and y_height) has been added.

`e.g.`
`x1_shape [-1, M, -1]，x2_shape [-1, K] ==> y_shape [-1, M, K]`
`x1_shape [-1, -1, -1]，x2_shape [N, K] ==> y_shape [-1, -1, K]`
`x1_shape [-1, -1]，x2_shape [N, K] ==> y_shape [-1, K]`
`x1_shape [M, N]，x2_shape [-1] ==> y_shape [M]`