### PR TITLE
fix fill_constant shape with -1 and enhance cross_entropy

### DIFF
--- a/paddle/fluid/operators/cross_entropy_op.cc
+++ b/paddle/fluid/operators/cross_entropy_op.cc
@@ -136,8 +136,8 @@ class CrossEntropyGradientOpBase : public framework::OperatorWithKernel {
                       "Input(Y@Grad) and Input(Y) should have the same rank.");
 
     bool check = true;
-    if ((!ctx->IsRuntime()) && (framework::product(x_dims) <= 0 ||
-                                framework::product(label_dims) <= 0)) {
+    if ((!ctx->IsRuntime()) &&
+        (framework::product(x_dims) <= 0 || framework::product(dy_dims) <= 0)) {
       check = false;
     }
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1251,7 +1251,7 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
             op_desc = _create_op_desc_("fill_constant",
                                        {"ShapeTensor": [target_shape.name]},
                                        {"Out": [grad_name]}, {
-                                           "shape": [],
+                                           "shape": target.shape,
                                            "value": 1.0,
                                            "dtype": target.dtype,
                                        })


### PR DESCRIPTION
+ Fix target@Grad shape in `calc_gradient` .
    + Before this PR,  It will replace `batch_size` with `-1` even if input.batch_size is explicitly given.
    + And now fill_constant will firstly use `target.shape` to fill grad value.
```python
target.shape = [10, 1]
# now fake grad data in calc_gradient
# before this PR:
target@Grad.shape = [-1, -1]  # in compileTime
# after this PR:
target@Grad.shape = [10, 1] # in compileTime
```

+ Fix inferShape bug in `cross_entropyGradKernel`.