### PR TITLE
update the infer shape of matmul, test=release/1.6

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6929,11 +6929,11 @@ def matmul(x, y, transpose_x=False, transpose_y=False, alpha=1.0, name=None):
         if transpose_y:
             y_shape[-2], y_shape[-1] = y_shape[-1], y_shape[-2]
         if x_shape[-1] != y_shape[-2]:
-            raise ValueError(
-                "After performing an optional transpose, Input X's width should be "
-                "equal to Y's width for multiplication "
-                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %
-                (x_shape, y_shape))
+            assert (x_shape[-1] == -1) or (y_shape[-2] == -1),                         \
+                "After performing an optional transpose, Input X's width should be "   \
+                "equal to Y's width for multiplication "                               \
+                "prerequisites. But received X's shape: %s, Y's shape: %s\n" %         \
+                (x_shape, y_shape)
 
         if len(y_shape) > 2 and len(x_shape) > 2:
             for i, dim_x in enumerate(x_shape[:-2]):


### PR DESCRIPTION
Inferred support for non-essential dimensions (one of x_width and y_height) has been added.

`e.g.`
`x1_shape [-1, M, -1]，x2_shape [-1, K] ==> y_shape [-1, M, K]`
`x1_shape [-1, -1, -1]，x2_shape [N, K] ==> y_shape [-1, -1, K]`
`x1_shape [-1, -1]，x2_shape [N, K] ==> y_shape [-1, K]`
`x1_shape [M, N]，x2_shape [-1] ==> y_shape [M]`