### PR TITLE
Bug Fix: Paddle-TRT cannot handle adaptive pooling in pool2d op converter and "num" attribute in split op converter

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -213,7 +213,7 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
   for (auto *x : node->inputs) {
     if (x->IsVar() && x->Var()) {
       framework::VarDesc *var = x->Var();
-      SetAttr(op_desc->Proto(), var->Name() + "_shape", var->GetShape());
+      op_desc->SetAttr(var->Name() + "_shape", var->GetShape());
     }
   }
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -507,7 +507,6 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
     }
   }
   if (config.glog_info_disabled()) {
-    google::InitGoogleLogging("Init");
     FLAGS_logtostderr = 1;
     FLAGS_minloglevel = google::WARNING;
     LOG(WARNING) << " - GLOG's LOG(INFO) is disabled.";

--- a/paddle/fluid/inference/tensorrt/plugin/CMakeLists.txt
+++ b/paddle/fluid/inference/tensorrt/plugin/CMakeLists.txt
@@ -1,5 +1,5 @@
 nv_library(tensorrt_plugin
            SRCS trt_plugin.cc split_op_plugin.cu elementwise_op_plugin.cu
            prelu_op_plugin.cu  trt_plugin_factory.cc
-           avg_pool_op_plugin.cu swish_op_plugin.cu
+           pool_op_plugin.cu swish_op_plugin.cu
            DEPS enforce tensorrt_engine prelu)

--- a/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/pool_op_plugin.h
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #pragma once
+#include <stdio.h>
 #include <cassert>
+#include <string>
 #include <vector>
 #include "paddle/fluid/inference/tensorrt/plugin/trt_plugin.h"
 
@@ -22,18 +24,11 @@ namespace inference {
 namespace tensorrt {
 namespace plugin {
 
-class AvgPoolPlugin : public PluginTensorRT {
- private:
-  bool ceil_mode_;
-  std::vector<int> ksize_;
-  std::vector<int> strides_;
-  std::vector<int> paddings_;
-  std::vector<int> input_shape_;
-  std::vector<int> output_shape_;
-
+class PoolPlugin : public PluginTensorRT {
  protected:
   size_t getSerializationSize() override {
     return SerializedSize(getPluginType()) + SerializedSize(ceil_mode_) +
+           SerializedSize(pool_type_) + SerializedSize(adaptive_) +
            SerializedSize(ksize_) + SerializedSize(strides_) +
            SerializedSize(paddings_) + SerializedSize(input_shape_) +
            SerializedSize(output_shape_) + getBaseSerializationSize();
@@ -45,6 +40,8 @@ class AvgPoolPlugin : public PluginTensorRT {
     SerializeValue(&buffer, getPluginType());
     serializeBase(buffer);
     SerializeValue(&buffer, ceil_mode_);
+    SerializeValue(&buffer, pool_type_);
+    SerializeValue(&buffer, adaptive_);
     SerializeValue(&buffer, ksize_);
     SerializeValue(&buffer, strides_);
     SerializeValue(&buffer, paddings_);
@@ -53,41 +50,54 @@ class AvgPoolPlugin : public PluginTensorRT {
   }
 
  public:
-  AvgPoolPlugin() {}
-  AvgPoolPlugin(bool ceil_mode, std::vector<int> ksize,
-                std::vector<int> strides, std::vector<int> paddings,
-                std::vector<int> input_shape)
+  enum class PoolType {
+    max = 0,
+    avg,
+  };
+  PoolPlugin() {}
+  PoolPlugin(bool ceil_mode, PoolType pool_type, bool adaptive,
+             std::vector<int> ksize, std::vector<int> strides,
+             std::vector<int> paddings, std::vector<int> input_shape)
       : ceil_mode_(ceil_mode),
+        pool_type_(pool_type),
+        adaptive_(adaptive),
         ksize_(ksize),
         strides_(strides),
         paddings_(paddings),
         input_shape_(input_shape) {
-    int output_h, output_w;
     output_shape_ = input_shape_;
-    if (!ceil_mode_) {
-      output_h =
-          (input_shape[1] - ksize_[0] + 2 * paddings_[0]) / strides_[0] + 1;
-      output_w =
-          (input_shape[2] - ksize_[1] + 2 * paddings_[1]) / strides_[1] + 1;
+    if (adaptive_) {
+      output_shape_[1] = ksize[0];
+      output_shape_[2] = ksize[1];
     } else {
-      output_h =
-          (input_shape[1] - ksize_[0] + 2 * paddings_[0] + strides_[0] - 1) /
-              strides_[0] +
-          1;
-      output_w =
-          (input_shape[2] - ksize_[1] + 2 * paddings_[1] + strides_[1] - 1) /
-              strides_[1] +
-          1;
+      int output_h, output_w;
+      if (!ceil_mode_) {
+        output_h =
+            (input_shape[1] - ksize_[0] + 2 * paddings_[0]) / strides_[0] + 1;
+        output_w =
+            (input_shape[2] - ksize_[1] + 2 * paddings_[1]) / strides_[1] + 1;
+      } else {
+        output_h =
+            (input_shape[1] - ksize_[0] + 2 * paddings_[0] + strides_[0] - 1) /
+                strides_[0] +
+            1;
+        output_w =
+            (input_shape[2] - ksize_[1] + 2 * paddings_[1] + strides_[1] - 1) /
+                strides_[1] +
+            1;
+      }
+      output_shape_[1] = output_h;
+      output_shape_[2] = output_w;
     }
-    output_shape_[1] = output_h;
-    output_shape_[2] = output_w;
   }
 
   // It was used for tensorrt deserialization.
   // It should not be called by users.
-  AvgPoolPlugin(void const *serialData, size_t serialLength) {
+  PoolPlugin(void const *serialData, size_t serialLength) {
     deserializeBase(serialData, serialLength);
     DeserializeValue(&serialData, &serialLength, &ceil_mode_);
+    DeserializeValue(&serialData, &serialLength, &pool_type_);
+    DeserializeValue(&serialData, &serialLength, &adaptive_);
     DeserializeValue(&serialData, &serialLength, &ksize_);
     DeserializeValue(&serialData, &serialLength, &strides_);
     DeserializeValue(&serialData, &serialLength, &paddings_);
@@ -95,18 +105,28 @@ class AvgPoolPlugin : public PluginTensorRT {
     DeserializeValue(&serialData, &serialLength, &output_shape_);
   }
 
-  AvgPoolPlugin *clone() const override {
-    return new AvgPoolPlugin(ceil_mode_, ksize_, strides_, paddings_,
-                             input_shape_);
+  PoolPlugin *clone() const override {
+    return new PoolPlugin(ceil_mode_, pool_type_, adaptive_, ksize_, strides_,
+                          paddings_, input_shape_);
   }
 
-  const char *getPluginType() const override { return "avg_pool_plugin"; }
+  const char *getPluginType() const override { return "pool_plugin"; }
   int getNbOutputs() const override { return 1; }
   nvinfer1::Dims getOutputDimensions(int index, const nvinfer1::Dims *inputs,
                                      int nbInputDims) override;
   int initialize() override { return 0; }
   int enqueue(int batchSize, const void *const *inputs, void **outputs,
               void *workspace, cudaStream_t stream) override;
+
+ private:
+  bool ceil_mode_;
+  PoolType pool_type_;
+  bool adaptive_;
+  std::vector<int> ksize_;
+  std::vector<int> strides_;
+  std::vector<int> paddings_;
+  std::vector<int> input_shape_;
+  std::vector<int> output_shape_;
 };
 
 }  // namespace plugin

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -268,6 +268,10 @@ if(WITH_GPU AND TENSORRT_FOUND)
     if (NOT EXISTS ${TRT_MODEL_INSTALL_DIR})
         inference_download_and_uncompress(${TRT_MODEL_INSTALL_DIR} ${INFERENCE_URL}/tensorrt_test "trt_inference_test_models.tar.gz")
     endif()
+    set(TEST_SPLIT_CONVERTER_MODEL "${TRT_MODEL_INSTALL_DIR}/trt_split_op_converter_test")
+    if (NOT EXISTS ${TEST_SPLIT_CONVERTER_MODEL})
+        inference_download_and_uncompress(${TEST_SPLIT_CONVERTER_MODEL} ${INFERENCE_URL}/tensorrt_test "split_converter.tgz")
+    endif()
     inference_analysis_test(trt_mobilenet_test SRCS trt_mobilenet_test.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
             ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
@@ -283,6 +287,9 @@ if(WITH_GPU AND TENSORRT_FOUND)
     inference_analysis_test(trt_cascade_rcnn_test SRCS trt_cascade_rcnn_test.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
             ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)
+    inference_analysis_test(trt_split_converter_test SRCS trt_split_converter_test.cc
+            EXTRA_DEPS ${INFERENCE_EXTRA_DEPS} 
+            ARGS --infer_model=${TEST_SPLIT_CONVERTER_MODEL}/)
     inference_analysis_test(test_analyzer_capi_gpu SRCS analyzer_capi_gpu_tester.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS} paddle_fluid_c
             ARGS --infer_model=${TRT_MODEL_INSTALL_DIR}/trt_inference_test_models)

--- a/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
@@ -1,0 +1,52 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "paddle/fluid/inference/tests/api/trt_test_helper.h"
+
+namespace paddle {
+namespace inference {
+
+TEST(TensorRT, split_converter) {
+  std::string model_dir = FLAGS_infer_model + "/split_converter";
+  AnalysisConfig config;
+  int batch_size = 4;
+  config.EnableUseGpu(100, 0);
+  config.SetModel(model_dir);
+  config.SwitchUseFeedFetchOps(false);
+  config.EnableTensorRtEngine(1 << 20, batch_size, 1,
+                              AnalysisConfig::Precision::kFloat32, false);
+
+  auto predictor = CreatePaddlePredictor(config);
+
+  int channels = 4;
+  int height = 4;
+  int width = 4;
+  int input_num = batch_size * channels * height * width;
+  float *input = new float[input_num];
+  memset(input, 1.0, input_num * sizeof(float));
+
+  auto input_names = predictor->GetInputNames();
+  auto input_t = predictor->GetInputTensor(input_names[0]);
+  input_t->Reshape({batch_size, channels, height, width});
+  input_t->copy_from_cpu(input);
+
+  ASSERT_TRUE(predictor->ZeroCopyRun());
+}
+
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/operators/math/pooling.cu
+++ b/paddle/fluid/operators/math/pooling.cu
@@ -236,7 +236,8 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
     const T* input, const std::vector<int>& input_shape,
     const std::vector<int>& output_shape, const std::vector<int>& ksize,
     const std::vector<int>& strides, const std::vector<int>& paddings,
-    PoolProcess pool_compute, bool exclusive, T* output, cudaStream_t stream) {
+    PoolProcess pool_compute, bool exclusive, bool adaptive, T* output,
+    cudaStream_t stream) {
   const int batch_size = input_shape[0];
   const int input_channels = input_shape[1];
   const int input_height = input_shape[2];
@@ -259,7 +260,7 @@ void Pool2dDirectCUDAFunctor<PoolProcess, T>::operator()(
   KernelPool2D<PoolProcess, T><<<grid, threads, 0, stream>>>(
       nthreads, input, input_channels, input_height, input_width, output_height,
       output_width, ksize_height, ksize_width, stride_height, stride_width,
-      padding_height, padding_width, pool_compute, exclusive, false, output);
+      padding_height, padding_width, pool_compute, exclusive, adaptive, output);
 }
 
 /*

--- a/paddle/fluid/operators/math/pooling.h
+++ b/paddle/fluid/operators/math/pooling.h
@@ -105,7 +105,8 @@ class Pool2dDirectCUDAFunctor {
                   const std::vector<int>& ksize,
                   const std::vector<int>& strides,
                   const std::vector<int>& paddings, PoolProcess pool_compute,
-                  bool exclusive, T* output, cudaStream_t stream);
+                  bool exclusive, bool adaptive, T* output,
+                  cudaStream_t stream);
 };
 #endif
 


### PR DESCRIPTION
**Problem:** 
1、Paddle-TRT had no support for adaptive attribute for pool2d op, thus when it is included in models like pspnet, there will be diff.
2、Paddle-TRT had no support for `num` attribute in split op, so when a split op with `num` but not `section` attribute set, TRT split op converter will throw an EnforceNotMet error.
**Solution:** 
1、Added adaptive attribute in pool2d trt plugin and extended avgpool plugin to pool plugin. Now paddle-TRT can handle pool op with adaptive attribute properly, and is able to fully support pspnet.
2、Added support for `num` attribute in split op. Now TRT can handle split ops with either `num` or `section` properly.