### PR TITLE
Minor MKL-DNN conv int8 performance fixes

### DIFF
--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -338,19 +338,12 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     const auto& mkldnn_engine = dev_ctx.GetEngine();
 
     auto* input = ctx.Input<Tensor>("Input");
-    auto* filter = ctx.Input<Tensor>("Filter");
-    auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
     auto* output = ctx.Output<Tensor>("Output");
 
     PADDLE_ENFORCE_EQ(input->layout(), DataLayout::kMKLDNN,
                       "Wrong layout set for Input tensor");
     PADDLE_ENFORCE_NE(input->format(), MKLDNNMemoryFormat::format_undef,
                       "Wrong format set for Input tensor");
-
-    PADDLE_ENFORCE_EQ(filter->layout(), DataLayout::kMKLDNN,
-                      "Wrong layout set for Filter tensor");
-    PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::format_undef,
-                      "Wrong format set for Filter tensor");
 
     PADDLE_ENFORCE_GE(
         input->dims().size(), 4,
@@ -359,57 +352,14 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         input->dims().size(), 5,
         "Input must be with 4 or 5 dimensions, i.e. NCHW or NCDHW");
 
-    PADDLE_ENFORCE_GE(
-        filter->dims().size(), 4,
-        "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
-    PADDLE_ENFORCE_LE(
-        filter->dims().size(), 5,
-        "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
-
-    if (bias) {
-      PADDLE_ENFORCE_EQ(bias->layout(), DataLayout::kMKLDNN,
-                        "Wrong layout set for Bias tensor");
-      PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::format_undef,
-                        "Wrong format set for Bias tensor");
-
-      PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
-                        "Bias must only have 1 dimension, i.e. X");
-    }
-
-    std::vector<int> strides = ctx.Attr<std::vector<int>>("strides");
-    std::vector<int> paddings = ctx.Attr<std::vector<int>>("paddings");
-    std::vector<int> dilations = ctx.Attr<std::vector<int>>("dilations");
-    int groups = ctx.Attr<int>("groups");
     std::string fuse_activation = ctx.Attr<std::string>("fuse_activation");
-    float fuse_alpha = ctx.Attr<float>("fuse_alpha");
-    float fuse_beta = ctx.Attr<float>("fuse_beta");
     bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
-    bool force_fp32_output = ctx.Attr<bool>("force_fp32_output");
     bool unsigned_output =
         (fuse_activation == "relu" || fuse_activation == "relu6");
-
-    PADDLE_ENFORCE(!fuse_residual_conn || !force_fp32_output,
-                   "residual fusion does not support force output with fp32");
-
-    bool is_conv3d = strides.size() == 3U;
-    PADDLE_ENFORCE(
-        is_conv3d
-            ? dilations.size() == 3 && dilations[0] == 1 && dilations[1] == 1 &&
-                  dilations[2] == 1
-            : dilations.size() == 2 && dilations[0] == 1 && dilations[1] == 1,
-        "dilation in convolution is not implemented yet");
-
-    PADDLE_ENFORCE_NE(is_conv3d, true,
-                      "int8 does not support conv3d currently");
 
     const T* input_data = input->data<T>();
 
     auto src_tz = paddle::framework::vectorize<int>(input->dims());
-    auto weights_tz = paddle::framework::vectorize<int>(filter->dims());
-    int g = std::max(groups, 1);
-
-    GetWeightsTz(weights_tz, g, is_conv3d);
-    auto dst_tz = paddle::framework::vectorize<int>(output->dims());
 
     mkldnn::memory::data_type src_dt =
         paddle::framework::ToMKLDNNDataType(input->type());
@@ -448,6 +398,63 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         dev_ctx.GetBlob(prim_key));
 
     if (conv_p == nullptr || !is_test) {
+      float fuse_alpha = ctx.Attr<float>("fuse_alpha");
+      float fuse_beta = ctx.Attr<float>("fuse_beta");
+      bool force_fp32_output = ctx.Attr<bool>("force_fp32_output");
+
+      auto* filter = ctx.Input<Tensor>("Filter");
+
+      PADDLE_ENFORCE_EQ(filter->layout(), DataLayout::kMKLDNN,
+                        "Wrong layout set for Filter tensor");
+      PADDLE_ENFORCE_NE(filter->format(), MKLDNNMemoryFormat::format_undef,
+                        "Wrong format set for Filter tensor");
+
+      PADDLE_ENFORCE_GE(
+          filter->dims().size(), 4,
+          "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+      PADDLE_ENFORCE_LE(
+          filter->dims().size(), 5,
+          "Filter must be with 4 or 5 dimensions, i.e. OIHW or OIDHW");
+
+      PADDLE_ENFORCE_EQ(
+          !fuse_residual_conn || !force_fp32_output, true,
+          "residual fusion does not support force output with fp32");
+
+      auto* bias = ctx.HasInput("Bias") ? ctx.Input<Tensor>("Bias") : nullptr;
+
+      if (bias) {
+        PADDLE_ENFORCE_EQ(bias->layout(), DataLayout::kMKLDNN,
+                          "Wrong layout set for Bias tensor");
+        PADDLE_ENFORCE_NE(bias->format(), MKLDNNMemoryFormat::format_undef,
+                          "Wrong format set for Bias tensor");
+
+        PADDLE_ENFORCE_EQ(bias->dims().size(), 1,
+                          "Bias must only have 1 dimension, i.e. X");
+      }
+
+      std::vector<int> paddings = ctx.Attr<std::vector<int>>("paddings");
+      std::vector<int> dilations = ctx.Attr<std::vector<int>>("dilations");
+      std::vector<int> strides = ctx.Attr<std::vector<int>>("strides");
+
+      bool is_conv3d = strides.size() == 3U;
+
+      PADDLE_ENFORCE_NE(is_conv3d, true,
+                        "int8 does not support conv3d currently");
+
+      int groups = ctx.Attr<int>("groups");
+      auto weights_tz = paddle::framework::vectorize<int>(filter->dims());
+      int g = std::max(groups, 1);
+
+      GetWeightsTz(weights_tz, g, is_conv3d);
+      auto dst_tz = paddle::framework::vectorize<int>(output->dims());
+
+      PADDLE_ENFORCE_EQ(
+          is_conv3d
+              ? dilations.size() == 3 && dilations[0] == 1 &&
+                    dilations[1] == 1 && dilations[2] == 1
+              : dilations.size() == 2 && dilations[0] == 1 && dilations[1] == 1,
+          true, "dilation in convolution is not implemented yet");
+
       const K* filter_data = filter->data<K>();
       auto scale_in_data = ctx.Attr<float>("Scale_in");
       auto scale_in_eltwise_data = ctx.Attr<float>("Scale_in_eltwise");

--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -205,7 +205,7 @@ inline void AppendKey(std::string* key, const std::vector<int>& dims) {
 template <typename... ArgTypes>
 inline std::string CreateKey(ArgTypes&&... args) {
   std::string key;
-  key.reserve(256);
+  key.reserve(64);
   using expand_type = int[];
   expand_type{0, (AppendKey(&key, std::forward<ArgTypes>(args)), 0)...};
   return key;


### PR DESCRIPTION
Some minor conv int8 code reorders in order to get closer to 1.5.0 tag performance.
**Test machine:** Xeon Gold 6248
**Dataset:** Full validation dataset (50k images)
**Target release:** ?
```
MOBILENET V1
Develop:
I1019 08:51:21.215854 215101 tester_helper.h:490] FP32: avg fps: 76.7701, avg latency: 13.0259 ms
I1019 08:51:21.215874 215101 tester_helper.h:490] INT8: avg fps: 218.5339, avg latency: 4.5759 ms

TAG 1.5.0:
I1019 09:13:37.712121 215210 tester_helper.h:469] FP32: avg fps: 74.9883, avg latency: 13.3354 ms
I1019 09:13:37.712128 215210 tester_helper.h:472] INT8: avg fps: 230.3150, avg latency: 4.3419 ms

Fix:
I1019 09:42:01.112879 230507 tester_helper.h:490] FP32: avg fps: 76.5687, avg latency: 13.0602 ms
I1019 09:42:01.112900 230507 tester_helper.h:490] INT8: avg fps: 225.9895, avg latency: 4.4250 ms
```
```
MOBILENET V2
Develop:
I1019 14:20:57.676785 361283 tester_helper.h:490] FP32: avg fps: 89.4302, avg latency: 11.1819 ms
I1019 14:20:57.676810 361283 tester_helper.h:490] INT8: avg fps: 198.5545, avg latency: 5.0364 ms

TAG 1.5.0:
I1019 14:36:31.470321 361845 tester_helper.h:469] FP32: avg fps: 89.9544, avg latency: 11.1167 ms
I1019 14:36:31.470330 361845 tester_helper.h:472] INT8: avg fps: 210.2631, avg latency: 4.7559 ms

Fix:
I1019 15:27:58.629585 371148 tester_helper.h:490] FP32: avg fps: 88.2552, avg latency: 11.3308 ms
I1019 15:27:58.629611 371148 tester_helper.h:490] INT8: avg fps: 204.0604, avg latency: 4.9005 ms
```