### PR TITLE
remove assert statement to support sqeeze op in drgraph

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -8952,8 +8952,6 @@ def squeeze(input, axes, name=None):
             y = layers.squeeze(input=x, axes=[2]) # y.shape=[None, 5, 10]
 
     """
-    assert not in_dygraph_mode(), (
-        "squeeze layer is not supported in dygraph mode yet.")
     helper = LayerHelper("squeeze", **locals())
 
     if not isinstance(input, Variable):


### PR DESCRIPTION
remove assert statement in squeeze function (python/paddle/fluid/layers/nn.py) to support sqeeze op in drgraph.