### PR TITLE
Simplify third_party path in Python package

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -328,14 +328,14 @@ class InstallHeaders(Command):
         else:
             # third_party
             install_dir = re.sub('${THIRD_PARTY_PATH}', 'third_party', header)
-            patters = ['eigen3/src/extern_eigen3', 'boost/src/extern_boost',
+            patterns = ['eigen3/src/extern_eigen3', 'boost/src/extern_boost',
                        'dlpack/src/extern_dlpack/include',
                        'install/protobuf/include',
                        'install/gflags/include',
                        'install/glog/include', 'install/xxhash/include',
                        'threadpool/src/extern_threadpool']
-            for patter in patters:
-                install_dir = re.sub(patter, '', install_dir)
+            for pattern in patterns:
+                install_dir = re.sub(pattern, '', install_dir)
         install_dir = os.path.join(self.install_dir, os.path.dirname(install_dir))
         if not os.path.exists(install_dir):
             self.mkpath(install_dir)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -328,9 +328,14 @@ class InstallHeaders(Command):
         else:
             # third_party
             install_dir = re.sub('${THIRD_PARTY_PATH}', 'third_party', header)
-            install_dir = re.sub('src/extern_eigen3/', '', install_dir)
-            install_dir = re.sub('src/extern_boost/', '', install_dir)
-            install_dir = re.sub('src/extern_dlpack/', '', install_dir)
+            patters = ['eigen3/src/extern_eigen3', 'boost/src/extern_boost',
+                       'dlpack/src/extern_dlpack/include',
+                       'install/protobuf/include',
+                       'install/gflags/include',
+                       'install/glog/include', 'install/xxhash/include',
+                       'threadpool/src/extern_threadpool']
+            for patter in patters:
+                install_dir = re.sub(patter, '', install_dir)
         install_dir = os.path.join(self.install_dir, os.path.dirname(install_dir))
         if not os.path.exists(install_dir):
             self.mkpath(install_dir)


### PR DESCRIPTION
Before:

```
pyenv/lib/python2.7/site-packages/paddle/include/third_party/
|-- boost
|   `-- boost
|-- eigen3
|   |-- Eigen
|   `-- unsupported
|-- install
|   |-- gflags
|   |-- glog
|   |-- protobuf
|   `-- xxhash
`-- threadpool
    `-- src
```

编译时include较多:

```
    -I ${include_dir}/third_party/install \
    -I ${include_dir}/third_party/install/gflags/include \
    -I ${include_dir}/third_party/install/glog/include \
    -I ${include_dir}/third_party/install/protobuf/include \
    -I ${include_dir}/third_party/install/xxhash/include \
    -I ${include_dir}/third_party/install/xxhash/include \
    -I ${include_dir}/third_party/boost \
    -I ${include_dir}/third_party/eigen3 \
    -I ${include_dir}/third_party/dlpack/include \
    -I ${include_dir}/third_party/threadpool/src/extern_threadpool \
    -I ${include_dir} \
```


After:

```
/paddle/pyenv/lib/python2.7/site-packages/paddle/include/third_party/
|-- Eigen
|-- boost
|-- dlpack
|-- gflags
|-- glog
|-- google
`-- unsupported
```

编译时include较少:

```
  -I ${include_dir} \
  -I ${include_dir}/third_party \
```