### PR TITLE
Add c++ unique_name_generator for dygraph

### DIFF
--- a/paddle/fluid/imperative/tests/test_tracer.cc
+++ b/paddle/fluid/imperative/tests/test_tracer.cc
@@ -187,6 +187,16 @@ TEST(test_tracer, test_trace_op_with_multi_device_inputs) {
   }
 }
 #endif
+
+TEST(test_tracer, test_unique_name_generator) {
+  // generate two unique names
+  imperative::Tracer tracer;
+  auto fc_1 = tracer.GenerateUniqueName("fc");
+  auto fc_2 = tracer.GenerateUniqueName("fc");
+  ASSERT_STREQ("fc_1", fc_1.c_str());
+  ASSERT_STREQ("fc_2", fc_2.c_str());
+}
+
 }  // namespace imperative
 }  // namespace paddle
 

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -29,13 +29,26 @@
 namespace paddle {
 namespace imperative {
 
+class UniqueNameGenerator {
+ public:
+  explicit UniqueNameGenerator(std::string prefix = "") : prefix_(prefix) {}
+  std::string Generate(std::string key = "tmp") {
+    return prefix_ + key + "_" + std::to_string(++id_);
+  }
+
+ private:
+  std::atomic<int> id_{0};
+  std::string prefix_;
+};
+
 class Tracer {
   DISABLE_COPY_AND_ASSIGN(Tracer);
 
  public:
   Tracer()
       : engine_(new BasicEngine()),
-        program_desc_tracer_(new jit::ProgramDescTracer()) {}
+        program_desc_tracer_(new jit::ProgramDescTracer()),
+        generator_(new UniqueNameGenerator()) {}
 
   ~Tracer() = default;
 
@@ -64,6 +77,10 @@ class Tracer {
     return program_desc_tracer_.get();
   }
 
+  std::string GenerateUniqueName(std::string key = "tmp") {
+    return generator_->Generate(key);
+  }
+
  private:
   static size_t GenerateUniqueId() {
     static std::atomic<size_t> id{0};
@@ -74,6 +91,7 @@ class Tracer {
   std::unique_ptr<Engine> engine_;
   std::unique_ptr<jit::ProgramDescTracer> program_desc_tracer_;
   bool enable_program_desc_tracing_{false};
+  std::unique_ptr<UniqueNameGenerator> generator_;
 };
 
 }  // namespace imperative


### PR DESCRIPTION
This PR adds c++ `unique name generator `  in dygraph mode, so we can create outputs in future.