### PR TITLE
Refine error message of allocator

### DIFF
--- a/paddle/fluid/memory/detail/meta_cache.cc
+++ b/paddle/fluid/memory/detail/meta_cache.cc
@@ -24,13 +24,15 @@ MetadataCache::MetadataCache(bool uses_gpu) : uses_gpu_(uses_gpu) {}
 
 MemoryBlock::Desc* MetadataCache::LoadDesc(MemoryBlock* block) {
   if (uses_gpu_) {
-    auto existing_desc = cache_.find(block);
-    PADDLE_ENFORCE_EQ(existing_desc->second.CheckGuards(), true);
-    return &(existing_desc->second);
+    auto iter = cache_.find(block);
+    PADDLE_ENFORCE_NE(iter, cache_.end());
+    auto* desc = &(iter->second);
+    PADDLE_ENFORCE_EQ(desc->CheckGuards(), true, "Invalid CPU memory access");
+    return desc;
   } else {
     auto* desc = reinterpret_cast<MemoryBlock::Desc*>(block);
     VLOG(10) << "Load MemoryBlock::Desc type=" << desc->type;
-    PADDLE_ENFORCE_EQ(desc->CheckGuards(), true);
+    PADDLE_ENFORCE_EQ(desc->CheckGuards(), true, "Invalid CPU memory access");
     return reinterpret_cast<MemoryBlock::Desc*>(block);
   }
 }


### PR DESCRIPTION
Refine error message of allocator, to alarm developers that there is invalid memory access.