### PR TITLE
Add parameter init check add run_startup_progrom error message for fc(mul)

### DIFF
--- a/paddle/fluid/operators/mul_op.cc
+++ b/paddle/fluid/operators/mul_op.cc
@@ -49,6 +49,12 @@ class MulOp : public framework::OperatorWithKernel {
             << " x_num_col_dims=" << x_num_col_dims
             << " y_num_col_dims=" << y_num_col_dims;
 
+    PADDLE_ENFORCE_NE(framework::product(y_dims), 0,
+                      "Maybe the Input variable Y(%s) has not "
+                      "been initialized. You may need to confirm "
+                      "if you put exe.run(startup_program) "
+                      "after optimizer.minimize function.",
+                      ctx->Inputs("Y").front());
     PADDLE_ENFORCE_GT(x_dims.size(), x_num_col_dims,
                       "ShapeError: The input tensor X's dimensions of MulOp "
                       "should be larger than x_num_col_dims. But received X's "


### PR DESCRIPTION
Related issue: https://github.com/PaddlePaddle/Paddle/issues/11371#issuecomment-547769713

Add user-friendly error message hint for fc(mul) when users not invoke `exe.run(startup_progrom)`.
The result is as follow:

```
----------------------
Error Message Summary:
----------------------
PaddleCheckError: Expected framework::product(y_dims) != 0, but received framework::product(y_dims):0 == 0:0.
Maybe the Input variable Y(fc_0.w_0) has not been initialized. You may need to confirm if you put exe.run(startup_program) after optimizer.minimize function. at [/work/paddle/paddle/fluid/operators/mul_op.cc:56]
  [operator < mul > error]
```