### PR TITLE
fix windows python setup issue caused by (#20641)

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -72,21 +72,18 @@ add_custom_command(OUTPUT ${FLUID_CORE}
 add_custom_target(copy_paddle_pybind ALL DEPENDS ${FLUID_CORE_DEPS})
 
 IF(WIN32)
-    add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
-            COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python/paddle/
-            COMMAND ${CMAKE_COMMAND} -E env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
-            COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
-            COMMAND ${CMAKE_COMMAND} -E remove_directory ${PADDLE_PYTHON_BUILD_DIR}/lib-python
-            DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
+  add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
+    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python/paddle/
+    COMMAND ${CMAKE_COMMAND} -E env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
+    COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
+    DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
 ELSE(WIN32)
-	add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
-		COMMAND touch stub.cc
-		COMMAND cp -r ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python
-		COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
-		COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
-		COMMAND ${CMAKE_COMMAND} -E remove_directory ${PADDLE_PYTHON_BUILD_DIR}/lib-python
-		COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_PYTHON_BUILD_DIR}/lib* ${PADDLE_PYTHON_BUILD_DIR}/lib-python
-		DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
+  add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
+    COMMAND touch stub.cc
+    COMMAND cp -r ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python
+    COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
+    COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
+    DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
 ENDIF()
 
 add_custom_target(paddle_python ALL DEPENDS ${PADDLE_PYTHON_BUILD_DIR}/.timestamp)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -74,14 +74,14 @@ add_custom_target(copy_paddle_pybind ALL DEPENDS ${FLUID_CORE_DEPS})
 IF(WIN32)
   add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python/paddle/
-    COMMAND ${CMAKE_COMMAND} -E env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
+    COMMAND ${CMAKE_COMMAND} -E env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel
     COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
     DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
 ELSE(WIN32)
   add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
     COMMAND touch stub.cc
     COMMAND cp -r ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python
-    COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
+    COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel
     COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
     DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
 ENDIF()

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,6 +10,8 @@ else()
   SET(PACKAGE_NAME "paddlepaddle")
 endif()
 
+set(SETUP_LOG_FILE "setup.py.log")
+
 set(FLUID_CORE_NAME "core")
 if(WITH_AVX AND AVX_FOUND)
   set(FLUID_CORE_NAME "${FLUID_CORE_NAME}_avx")
@@ -72,7 +74,7 @@ add_custom_target(copy_paddle_pybind ALL DEPENDS ${FLUID_CORE_DEPS})
 IF(WIN32)
     add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
             COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python/paddle/
-            COMMAND ${CMAKE_COMMAND} -E env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel
+            COMMAND ${CMAKE_COMMAND} -E env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
             COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
             COMMAND ${CMAKE_COMMAND} -E remove_directory ${PADDLE_PYTHON_BUILD_DIR}/lib-python
             DEPENDS copy_paddle_pybind ${FLUID_CORE} framework_py_proto profiler_py_proto ${PY_FILES})
@@ -80,7 +82,7 @@ ELSE(WIN32)
 	add_custom_command(OUTPUT ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
 		COMMAND touch stub.cc
 		COMMAND cp -r ${PADDLE_SOURCE_DIR}/python/paddle ${PADDLE_BINARY_DIR}/python
-		COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel
+		COMMAND env ${py_env} ${PYTHON_EXECUTABLE} setup.py bdist_wheel > ${SETUP_LOG_FILE}
 		COMMAND ${CMAKE_COMMAND} -E touch ${PADDLE_PYTHON_BUILD_DIR}/.timestamp
 		COMMAND ${CMAKE_COMMAND} -E remove_directory ${PADDLE_PYTHON_BUILD_DIR}/lib-python
 		COMMAND ${CMAKE_COMMAND} -E copy_directory ${PADDLE_PYTHON_BUILD_DIR}/lib* ${PADDLE_PYTHON_BUILD_DIR}/lib-python

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -365,10 +365,10 @@ if sys.platform != 'win32':
     @contextmanager
     def redirect_stdout():
         with open('${SETUP_LOG_FILE}', 'w') as f:
-            orign_stdout = sys.stdout
+            origin_stdout = sys.stdout
             sys.stdout = f
             yield
-            sys.stdout = orign_stdout
+            sys.stdout = origin_stdout
 else:
     @contextmanager
     def redirect_stdout():

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import os.path
 import re
 import shutil
 import sys
@@ -358,14 +359,6 @@ class InstallHeaders(Command):
     def get_outputs(self):
         return self.outfiles
 
-# Saving the installation log generated from setup.py to log_file.
-# The log_file is ${PADDLE_BINARY_DIR}/python/setup.py.log.
-stdout = sys.stdout
-stderr = sys.stderr
-log_file = open('setup.py.log', 'w')
-sys.stdout = log_file
-sys.stderr = log_file
-
 setup(name='${PACKAGE_NAME}',
       version='${PADDLE_VERSION}',
       description='Parallel Distributed Deep Learning',
@@ -383,11 +376,8 @@ setup(name='${PACKAGE_NAME}',
       }
 )
 
-log_file.close()
-# Revert back the stdout/stderr to their default references.
-sys.stdout = stdout
-sys.stderr = stderr
 # As there are a lot of files in purelib which causes many logs,
 # we don't print them on the screen, and you can open `setup.py.log` 
 # for the full logs.
-os.system('grep -v "purelib" setup.py.log')
+if sys.platform != 'win32' and os.path.exists('${SETUP_LOG_FILE}'):
+    os.system('grep -v "purelib" ${SETUP_LOG_FILE}')

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -6,6 +6,7 @@ import shutil
 import sys
 import fnmatch
 
+from contextlib import contextmanager
 from setuptools import Command
 from setuptools import setup, Distribution, Extension
 from setuptools.command.install import install as InstallCommandBase
@@ -359,25 +360,40 @@ class InstallHeaders(Command):
     def get_outputs(self):
         return self.outfiles
 
-setup(name='${PACKAGE_NAME}',
-      version='${PADDLE_VERSION}',
-      description='Parallel Distributed Deep Learning',
-      install_requires=setup_requires,
-      packages=packages,
-      ext_modules=ext_modules,
-      package_data=package_data,
-      package_dir=package_dir,
-      scripts=paddle_bins,
-      distclass=BinaryDistribution,
-      headers=headers,
-      cmdclass={
-          'install_headers': InstallHeaders,
-          'install': InstallCommand,
-      }
-)
+# we redirect setuptools log for non-windows
+if sys.platform != 'win32':
+    @contextmanager
+    def redirect_stdout():
+        with open('${SETUP_LOG_FILE}', 'w') as f:
+            orign_stdout = sys.stdout
+            sys.stdout = f
+            yield
+            sys.stdout = orign_stdout
+else:
+    @contextmanager
+    def redirect_stdout():
+        yield
+
+with redirect_stdout():
+    setup(name='${PACKAGE_NAME}',
+        version='${PADDLE_VERSION}',
+        description='Parallel Distributed Deep Learning',
+        install_requires=setup_requires,
+        packages=packages,
+        ext_modules=ext_modules,
+        package_data=package_data,
+        package_dir=package_dir,
+        scripts=paddle_bins,
+        distclass=BinaryDistribution,
+        headers=headers,
+        cmdclass={
+            'install_headers': InstallHeaders,
+            'install': InstallCommand,
+        }
+    )
 
 # As there are a lot of files in purelib which causes many logs,
 # we don't print them on the screen, and you can open `setup.py.log` 
 # for the full logs.
-if sys.platform != 'win32' and os.path.exists('${SETUP_LOG_FILE}'):
+if os.path.exists('${SETUP_LOG_FILE}'):
     os.system('grep -v "purelib" ${SETUP_LOG_FILE}')


### PR DESCRIPTION
1. redirect stdout cause "ValueError: underlying buffer has been detached" on windows, similar issue: link[https://github.com/clab/dynet/issues/962](url)
2. grep is only suppored on Linux