### PR TITLE
And Enforce in fuse pass for DGC doesn't support fuse for now

### DIFF
--- a/paddle/fluid/framework/ir/multi_devices_graph_pass/fuse_all_reduce_op_pass.cc
+++ b/paddle/fluid/framework/ir/multi_devices_graph_pass/fuse_all_reduce_op_pass.cc
@@ -105,6 +105,12 @@ class FuseAllReduceOpPass : public ir::Pass {
         auto *all_reduce_op_handle = dynamic_cast<details::AllReduceOpHandle *>(
             &node->Wrapper<details::OpHandleBase>());
         if (all_reduce_op_handle) {
+#if defined(PADDLE_WITH_DGC)
+          PADDLE_ENFORCE_NE(
+              all_reduce_op_handle->Name(), "sparse_all_reduce",
+              "DGC doesn't support fuse for now, if you want to use DGC "
+              "you need set strategy.fuse_all_reduce_ops = False.");
+#endif
           auto inputs = details::DynamicCast<details::VarHandle>(
               all_reduce_op_handle->Inputs());
           PADDLE_ENFORCE_EQ(inputs.size(), num_place);


### PR DESCRIPTION
DGC doesn't support fuse for now, add PADDLE_ENFORCE_NE in fuse_all_reduce_op_pass.cc to judge if use DGC and fuse same time。