### PR TITLE
fix the computation for dx (grad for x) for prelu operation.

### DIFF
--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -18,7 +18,7 @@ namespace paddle {
 namespace operators {
 namespace math {
 
-static constexpr int PD_CUDA_NUM_THREADS = 1024;
+#define CUDA_NUM_THREADS 1024
 
 // CUDA: grid stride looping
 #define CUDA_KERNEL_LOOP(i, n)                                 \
@@ -26,7 +26,7 @@ static constexpr int PD_CUDA_NUM_THREADS = 1024;
        i += blockDim.x * gridDim.x)
 
 inline static int PADDLE_GET_BLOCKS(const int N) {
-  return (N + PD_CUDA_NUM_THREADS - 1) / PD_CUDA_NUM_THREADS;
+  return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
 }
 
 template <typename T>
@@ -74,7 +74,7 @@ void PreluChannelWiseDirectCUDAFunctor<T>::operator()(
   size_t plane_size = input_shape[2] * input_shape[3];
   size_t spatial_size = input_shape[1] * plane_size;
   size_t numel = input_shape[0] * spatial_size;
-  PReluChannelWiseKernel<<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0,
+  PReluChannelWiseKernel<<<PADDLE_GET_BLOCKS(numel), CUDA_NUM_THREADS, 0,
                            stream>>>(input, alpha, output, input_shape[1],
                                      plane_size, numel);
 }
@@ -86,7 +86,7 @@ void PreluElementWiseDirectCUDAFunctor<T>::operator()(
   size_t plane_size = input_shape[2] * input_shape[3];
   size_t spatial_size = input_shape[1] * plane_size;
   size_t numel = input_shape[0] * spatial_size;
-  PReluElementWiseKernel<<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0,
+  PReluElementWiseKernel<<<PADDLE_GET_BLOCKS(numel), CUDA_NUM_THREADS, 0,
                            stream>>>(input, alpha, output, spatial_size, numel);
 }
 
@@ -98,8 +98,8 @@ void PreluScalarDirectCUDAFunctor<T>::operator()(cudaStream_t stream,
   size_t plane_size = input_shape[2] * input_shape[3];
   size_t spatial_size = input_shape[1] * plane_size;
   size_t numel = input_shape[0] * spatial_size;
-  PReluScalarKernel<<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0,
-                      stream>>>(input, alpha, output, numel);
+  PReluScalarKernel<<<PADDLE_GET_BLOCKS(numel), CUDA_NUM_THREADS, 0, stream>>>(
+      input, alpha, output, numel);
 }
 
 template class PreluChannelWiseDirectCUDAFunctor<float>;

--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -27,11 +27,15 @@ inline static int GET_NUM_BLOCKS(const int N) {
 template <typename T>
 __global__ void PReluChannelWiseKernel(const T *input, const T *alpha,
                                        T *output, int channel,
-                                       size_t spatial_size) {
+                                       size_t plane_size, size_t spatial_size,
+                                       bool use_spatial_size) {
   size_t offset = blockIdx.x * spatial_size;
   const T *in = input + offset;
   T *out = output + offset;
   T scale = alpha[blockIdx.x % channel];
+  if (use_spatial_size) {
+    scale = alpha[spatial_size / plane_size];
+  }
 
   for (size_t i = threadIdx.x; i < spatial_size; i += blockDim.x) {
     T x = in[i];
@@ -41,7 +45,9 @@ __global__ void PReluChannelWiseKernel(const T *input, const T *alpha,
 
 template <typename T>
 __global__ void PReluElementWiseKernel(const T *input, const T *alpha,
-                                       T *output, size_t spatial_size) {
+                                       T *output, size_t plane_size,
+                                       size_t spatial_size,
+                                       bool use_spatial_size) {
   size_t offset = blockIdx.x * spatial_size;
   const T *in = input + offset;
   const T *scale = alpha + offset;
@@ -55,7 +61,8 @@ __global__ void PReluElementWiseKernel(const T *input, const T *alpha,
 
 template <typename T>
 __global__ void PReluScalarKernel(const T *input, const T *alpha, T *output,
-                                  size_t spatial_size) {
+                                  size_t plane_size, size_t spatial_size,
+                                  bool use_spatial_size) {
   size_t offset = blockIdx.x * spatial_size;
   const T *in = input + offset;
   T scale = *alpha;
@@ -68,47 +75,24 @@ __global__ void PReluScalarKernel(const T *input, const T *alpha, T *output,
 }
 
 template <typename T>
-static inline void PReluChannelWise(cudaStream_t stream, const T *input,
-                                    const T *alpha, T *output,
-                                    std::vector<int> input_shape) {
-  size_t unroll = input_shape[0] * input_shape[1];
-  size_t spatial_size = input_shape[2] * input_shape[3];
-  CHECK_LT(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluChannelWiseKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
-      input, alpha, output, input_shape[1], spatial_size);
-}
-
-template <typename T>
-static inline void PReluElementWise(cudaStream_t stream, const T *input,
-                                    const T *alpha, T *output,
-                                    std::vector<int> input_shape) {
-  size_t unroll = input_shape[0] * input_shape[1];
-  size_t spatial_size = input_shape[2] * input_shape[3];
-  CHECK_LT(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluElementWiseKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
-      input, alpha, output, spatial_size);
-}
-
-template <typename T>
-static inline void PReluScalar(cudaStream_t stream, const T *input,
-                               const T *alpha, T *output,
-                               std::vector<int> input_shape) {
-  size_t unroll = input_shape[0] * input_shape[1];
-  size_t spatial_size = input_shape[2] * input_shape[3];
-  CHECK_LT(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluScalarKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
-      input, alpha, output, spatial_size);
-}
-
-template <typename T>
 void PreluChannelWiseDirectCUDAFunctor<T>::operator()(
     cudaStream_t stream, const T *input, const T *alpha, T *output,
     std::vector<int> input_shape) {
   size_t unroll = input_shape[0] * input_shape[1];
-  size_t spatial_size = input_shape[2] * input_shape[3];
-  CHECK_LT(unroll, CUDA_MAX_NUM_BLOCKS);
+  size_t plane_size = input_shape[2] * input_shape[3];
+  size_t spatial_size = plane_size;
+  bool use_spatial_size = false;
+  if (unroll > CUDA_MAX_NUM_BLOCKS) {
+    unroll = input_shape[0];
+    spatial_size = input_shape[1] * input_shape[2] * input_shape[3];
+    use_spatial_size = true;
+  }
+  size_t num_threads = CUDA_NUM_THREADS;
+  if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
+  CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
   PReluChannelWiseKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
-      input, alpha, output, input_shape[1], spatial_size);
+      input, alpha, output, input_shape[1], plane_size, spatial_size,
+      use_spatial_size);
 }
 
 template <typename T>
@@ -116,10 +100,19 @@ void PreluElementWiseDirectCUDAFunctor<T>::operator()(
     cudaStream_t stream, const T *input, const T *alpha, T *output,
     std::vector<int> input_shape) {
   size_t unroll = input_shape[0] * input_shape[1];
-  size_t spatial_size = input_shape[2] * input_shape[3];
-  CHECK_LT(unroll, CUDA_MAX_NUM_BLOCKS);
+  size_t plane_size = input_shape[2] * input_shape[3];
+  size_t spatial_size = plane_size;
+  bool use_spatial_size = false;
+  if (unroll > CUDA_MAX_NUM_BLOCKS) {
+    unroll = input_shape[0];
+    spatial_size = input_shape[1] * input_shape[2] * input_shape[3];
+    use_spatial_size = true;
+  }
+  size_t num_threads = CUDA_NUM_THREADS;
+  if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
+  CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
   PReluElementWiseKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
-      input, alpha, output, spatial_size);
+      input, alpha, output, plane_size, spatial_size, use_spatial_size);
 }
 
 template <typename T>
@@ -128,10 +121,19 @@ void PreluScalarDirectCUDAFunctor<T>::operator()(cudaStream_t stream,
                                                  T *output,
                                                  std::vector<int> input_shape) {
   size_t unroll = input_shape[0] * input_shape[1];
-  size_t spatial_size = input_shape[2] * input_shape[3];
-  CHECK_LT(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluScalarKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
-      input, alpha, output, spatial_size);
+  size_t plane_size = input_shape[2] * input_shape[3];
+  size_t spatial_size = plane_size;
+  bool use_spatial_size = false;
+  if (unroll > CUDA_MAX_NUM_BLOCKS) {
+    unroll = input_shape[0];
+    spatial_size = input_shape[1] * input_shape[2] * input_shape[3];
+    use_spatial_size = true;
+  }
+  size_t num_threads = CUDA_NUM_THREADS;
+  if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
+  CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
+  PReluScalarKernel<<<unroll, num_threads, 0, stream>>>(
+      input, alpha, output, plane_size, spatial_size, use_spatial_size);
 }
 
 template class PreluChannelWiseDirectCUDAFunctor<float>;

--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -18,10 +18,15 @@ namespace paddle {
 namespace operators {
 namespace math {
 
-static const int CUDA_NUM_THREADS = 1024;
-static const int CUDA_MAX_NUM_BLOCKS = 65535;
-inline static int GET_NUM_BLOCKS(const int N) {
-  return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
+static constexpr int PD_CUDA_NUM_THREADS = 1024;
+
+// CUDA: grid stride looping
+#define CUDA_KERNEL_LOOP(i, n)                                 \
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); \
+       i += blockDim.x * gridDim.x)
+
+inline static int PADDLE_GET_BLOCKS(const int N) {
+  return (N + PD_CUDA_NUM_THREADS - 1) / PD_CUDA_NUM_THREADS;
 }
 
 template <typename T>
@@ -69,7 +74,7 @@ void PreluChannelWiseDirectCUDAFunctor<T>::operator()(
   size_t plane_size = input_shape[2] * input_shape[3];
   size_t spatial_size = input_shape[1] * plane_size;
   size_t numel = input_shape[0] * spatial_size;
-  PReluChannelWiseKernel<<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0,
+  PReluChannelWiseKernel<<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0,
                            stream>>>(input, alpha, output, input_shape[1],
                                      plane_size, numel);
 }
@@ -81,7 +86,7 @@ void PreluElementWiseDirectCUDAFunctor<T>::operator()(
   size_t plane_size = input_shape[2] * input_shape[3];
   size_t spatial_size = input_shape[1] * plane_size;
   size_t numel = input_shape[0] * spatial_size;
-  PReluElementWiseKernel<<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0,
+  PReluElementWiseKernel<<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0,
                            stream>>>(input, alpha, output, spatial_size, numel);
 }
 
@@ -93,7 +98,7 @@ void PreluScalarDirectCUDAFunctor<T>::operator()(cudaStream_t stream,
   size_t plane_size = input_shape[2] * input_shape[3];
   size_t spatial_size = input_shape[1] * plane_size;
   size_t numel = input_shape[0] * spatial_size;
-  PReluScalarKernel<<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0,
+  PReluScalarKernel<<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0,
                       stream>>>(input, alpha, output, numel);
 }
 

--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -26,57 +26,39 @@ inline static int GET_NUM_BLOCKS(const int N) {
 
 template <typename T>
 __global__ void PReluChannelWiseKernel(const T *input, const T *alpha,
-                                       T *output, int channel_num,
-                                       size_t plane_size, size_t spatial_size,
-                                       bool use_plane_size) {
-  size_t offset = blockIdx.x * spatial_size;
-  const T *in = input + offset;
-  T *out = output + offset;
-  T scale = alpha[blockIdx.x % channel_num];
-
-  for (size_t i = threadIdx.x; i < spatial_size; i += blockDim.x) {
-    T x = in[i];
-    if (use_plane_size) {
-      T s = alpha[i / plane_size];
-      out[i] = (x > 0) ? x : s * x;
-    } else {
-      out[i] = (x > 0) ? x : scale * x;
-    }
+                                       T *output, size_t channel_num,
+                                       size_t plane_size, size_t numel) {
+  size_t index;
+  CUDA_KERNEL_LOOP(index, numel) {
+    size_t temp = index / plane_size;
+    size_t channel_index = temp % channel_num;
+    T scale = alpha[channel_index];
+    T x = input[index];
+    output[index] = (x > 0) ? x : scale * x;
   }
 }
 
 template <typename T>
 __global__ void PReluElementWiseKernel(const T *input, const T *alpha,
-                                       T *output, int channel_num,
-                                       size_t plane_size, size_t spatial_size,
-                                       bool use_plane_size) {
-  size_t offset = blockIdx.x * spatial_size;
-  const T *in = input + offset;
-  auto channel_index = blockIdx.x % channel_num;
-  const T *scale = alpha + channel_index * spatial_size;
-
-  if (use_plane_size) scale = alpha;
-
-  T *out = output + offset;
-
-  for (size_t i = threadIdx.x; i < spatial_size; i += blockDim.x) {
-    T x = in[i];
-    out[i] = (x > 0) ? x : scale[i] * x;
+                                       T *output, size_t spatial_size,
+                                       size_t numel) {
+  size_t index;
+  CUDA_KERNEL_LOOP(index, numel) {
+    size_t elment_index = index % spatial_size;
+    T scale = alpha[element_index];
+    T x = input[index];
+    output[index] = (x > 0) ? x : scale * x;
   }
 }
 
 template <typename T>
 __global__ void PReluScalarKernel(const T *input, const T *alpha, T *output,
-                                  size_t plane_size, size_t spatial_size,
-                                  bool use_plane_size) {
-  size_t offset = blockIdx.x * spatial_size;
-  const T *in = input + offset;
-  T scale = *alpha;
-  T *out = output + offset;
-
-  for (size_t i = threadIdx.x; i < spatial_size; i += blockDim.x) {
-    T x = in[i];
-    out[i] = (x > 0) ? x : scale * x;
+                                  size_t numel) {
+  T scale = alpha[0];
+  size_t index;
+  CUDA_KERNEL_LOOP(index, numel) {
+    T x = input[index];
+    output[index] = (x > 0) ? x : scale * x;
   }
 }
 
@@ -84,42 +66,23 @@ template <typename T>
 void PreluChannelWiseDirectCUDAFunctor<T>::operator()(
     cudaStream_t stream, const T *input, const T *alpha, T *output,
     std::vector<int> input_shape) {
-  size_t unroll = input_shape[0] * input_shape[1];
   size_t plane_size = input_shape[2] * input_shape[3];
-  size_t spatial_size = plane_size;
-  bool use_plane_size = false;
-  if (unroll > CUDA_MAX_NUM_BLOCKS) {
-    unroll = input_shape[0];
-    spatial_size = input_shape[1] * input_shape[2] * input_shape[3];
-    use_plane_size = true;
-  }
-  size_t num_threads = CUDA_NUM_THREADS;
-  if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
-  CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluChannelWiseKernel<<<unroll, num_threads, 0, stream>>>(
-      input, alpha, output, input_shape[1], plane_size, spatial_size,
-      use_plane_size);
+  size_t spatial_size = input_shape[1] * plane_size;
+  size_t numel = input_shape[0] * spatial_size;
+  PReluChannelWiseKernel<<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0,
+                           stream>>>(input, alpha, output, input_shape[1],
+                                     plane_size, numel);
 }
 
 template <typename T>
 void PreluElementWiseDirectCUDAFunctor<T>::operator()(
     cudaStream_t stream, const T *input, const T *alpha, T *output,
     std::vector<int> input_shape) {
-  size_t unroll = input_shape[0] * input_shape[1];
   size_t plane_size = input_shape[2] * input_shape[3];
-  size_t spatial_size = plane_size;
-  bool use_plane_size = false;
-  if (unroll > CUDA_MAX_NUM_BLOCKS) {
-    unroll = input_shape[0];
-    spatial_size = input_shape[1] * input_shape[2] * input_shape[3];
-    use_plane_size = true;
-  }
-  size_t num_threads = CUDA_NUM_THREADS;
-  if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
-  CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluElementWiseKernel<<<unroll, num_threads, 0, stream>>>(
-      input, alpha, output, input_shape[1], plane_size, spatial_size,
-      use_plane_size);
+  size_t spatial_size = input_shape[1] * plane_size;
+  size_t numel = input_shape[0] * spatial_size;
+  PReluElementWiseKernel<<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0,
+                           stream>>>(input, alpha, output, spatial_size, numel);
 }
 
 template <typename T>
@@ -127,20 +90,11 @@ void PreluScalarDirectCUDAFunctor<T>::operator()(cudaStream_t stream,
                                                  const T *input, const T *alpha,
                                                  T *output,
                                                  std::vector<int> input_shape) {
-  size_t unroll = input_shape[0] * input_shape[1];
   size_t plane_size = input_shape[2] * input_shape[3];
-  size_t spatial_size = plane_size;
-  bool use_plane_size = false;
-  if (unroll > CUDA_MAX_NUM_BLOCKS) {
-    unroll = input_shape[0];
-    spatial_size = input_shape[1] * input_shape[2] * input_shape[3];
-    use_plane_size = true;
-  }
-  size_t num_threads = CUDA_NUM_THREADS;
-  if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
-  CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluScalarKernel<<<unroll, num_threads, 0, stream>>>(
-      input, alpha, output, plane_size, spatial_size, use_plane_size);
+  size_t spatial_size = input_shape[1] * plane_size;
+  size_t numel = input_shape[0] * spatial_size;
+  PReluScalarKernel<<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0,
+                      stream>>>(input, alpha, output, numel);
 }
 
 template class PreluChannelWiseDirectCUDAFunctor<float>;

--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -47,12 +47,12 @@ __global__ void PReluChannelWiseKernel(const T *input, const T *alpha,
 
 template <typename T>
 __global__ void PReluElementWiseKernel(const T *input, const T *alpha,
-                                       T *output, int batch_size,
+                                       T *output, int channel_num,
                                        size_t plane_size, size_t spatial_size,
                                        bool use_plane_size) {
   size_t offset = blockIdx.x * spatial_size;
   const T *in = input + offset;
-  auto channel_index = blockIdx.x % batch_size;
+  auto channel_index = blockIdx.x % channel_num;
   const T *scale = alpha + channel_index * spatial_size;
 
   if (use_plane_size) scale = alpha;
@@ -118,7 +118,7 @@ void PreluElementWiseDirectCUDAFunctor<T>::operator()(
   if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
   CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
   PReluElementWiseKernel<<<unroll, num_threads, 0, stream>>>(
-      input, alpha, output, input_shape[0], plane_size, spatial_size,
+      input, alpha, output, input_shape[1], plane_size, spatial_size,
       use_plane_size);
 }
 

--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -44,7 +44,7 @@ __global__ void PReluElementWiseKernel(const T *input, const T *alpha,
                                        size_t numel) {
   size_t index;
   CUDA_KERNEL_LOOP(index, numel) {
-    size_t elment_index = index % spatial_size;
+    size_t element_index = index % spatial_size;
     T scale = alpha[element_index];
     T x = input[index];
     output[index] = (x > 0) ? x : scale * x;

--- a/paddle/fluid/operators/math/prelu.cu
+++ b/paddle/fluid/operators/math/prelu.cu
@@ -90,7 +90,7 @@ void PreluChannelWiseDirectCUDAFunctor<T>::operator()(
   size_t num_threads = CUDA_NUM_THREADS;
   if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
   CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluChannelWiseKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
+  PReluChannelWiseKernel<<<unroll, num_threads, 0, stream>>>(
       input, alpha, output, input_shape[1], plane_size, spatial_size,
       use_spatial_size);
 }
@@ -111,7 +111,7 @@ void PreluElementWiseDirectCUDAFunctor<T>::operator()(
   size_t num_threads = CUDA_NUM_THREADS;
   if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
   CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
-  PReluElementWiseKernel<<<unroll, CUDA_NUM_THREADS, 0, stream>>>(
+  PReluElementWiseKernel<<<unroll, num_threads, 0, stream>>>(
       input, alpha, output, plane_size, spatial_size, use_spatial_size);
 }
 

--- a/paddle/fluid/operators/math/prelu.h
+++ b/paddle/fluid/operators/math/prelu.h
@@ -43,17 +43,6 @@ class PreluScalarDirectCUDAFunctor {
                   T *output, std::vector<int> input_shape);
 };
 
-#define PADDLE_CUDA_NUM_THREADS 1024
-
-// CUDA: grid stride looping
-#define CUDA_KERNEL_LOOP(i, n)                                 \
-  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); \
-       i += blockDim.x * gridDim.x)
-
-inline int PADDLE_GET_BLOCKS(const int N) {
-  return (N + PADDLE_CUDA_NUM_THREADS - 1) / PADDLE_CUDA_NUM_THREADS;
-}
-
 #endif
 
 }  // namespace math

--- a/paddle/fluid/operators/math/prelu.h
+++ b/paddle/fluid/operators/math/prelu.h
@@ -42,6 +42,18 @@ class PreluScalarDirectCUDAFunctor {
   void operator()(cudaStream_t stream, const T *input, const T *alpha,
                   T *output, std::vector<int> input_shape);
 };
+
+#define PADDLE_CUDA_NUM_THREADS 1024
+
+// CUDA: grid stride looping
+#define CUDA_KERNEL_LOOP(i, n)                                 \
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); \
+       i += blockDim.x * gridDim.x)
+
+inline int PADDLE_GET_BLOCKS(const int N) {
+  return (N + PADDLE_CUDA_NUM_THREADS - 1) / PADDLE_CUDA_NUM_THREADS;
+}
+
 #endif
 
 }  // namespace math

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -51,8 +51,8 @@ class PReluOp : public framework::OperatorWithKernel {
                         "For element-wise mode, rank of weight Alpha must be ",
                         "equal to the rank of input.");
       for (int64_t i = x_rank - 1; i > 0; i--) {
-        x_product *= x_dim[x_rank];
-        alpha_product *= alpha_dim[x_rank];
+        x_product *= x_dim[i];
+        alpha_product *= alpha_dim[i];
       }
       PADDLE_ENFORCE_EQ(x_product, alpha_product,
                         "For element-wise mode, size of weight Alpha must be "

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -11,7 +11,6 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/prelu_op.h"
 #include <string>
-#include "paddle/fluid/operators/math/prelu.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -11,6 +11,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/prelu_op.h"
 #include <string>
+#include "paddle/fluid/operators/math/prelu.h"
 
 namespace paddle {
 namespace operators {

--- a/paddle/fluid/operators/prelu_op.cc
+++ b/paddle/fluid/operators/prelu_op.cc
@@ -42,10 +42,21 @@ class PReluOp : public framework::OperatorWithKernel {
                      "equal to the number of channels, should be %d",
                      x_dim[1]);
     } else if (mode == "element") {
-      PADDLE_ENFORCE(product(ctx->GetInputDim("Alpha")) == product(x_dim),
-                     "For element-wise mode, size of weight Alpha must be "
-                     "equal to the number of input, should be %d",
-                     product(x_dim));
+      auto alpha_dim = ctx->GetInputDim("Alpha");
+      auto alpha_rank = alpha_dim.size();
+      auto x_rank = x_dim.size();
+      size_t x_product = 1;
+      size_t alpha_product = 1;
+      PADDLE_ENFORCE_EQ(alpha_rank, x_rank,
+                        "For element-wise mode, rank of weight Alpha must be ",
+                        "equal to the rank of input.");
+      for (int64_t i = x_rank - 1; i > 0; i--) {
+        x_product *= x_dim[x_rank];
+        alpha_product *= alpha_dim[x_rank];
+      }
+      PADDLE_ENFORCE_EQ(x_product, alpha_product,
+                        "For element-wise mode, size of weight Alpha must be "
+                        "equal to the number of input.");
     } else {
       PADDLE_THROW("Unkown mode %s", mode);
     }

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -67,47 +67,54 @@ struct ScalarMode {};
 
 template <typename T, typename M>
 struct AlphaFunctor {
-  HOSTDEVICE inline T operator()(const T* alpha, size_t channel,
-                                 size_t plane_size, size_t spatial_size,
-                                 bool use_spatial_size, size_t idx) const {}
+  HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
+                                 size_t batch_size, size_t plane_size,
+                                 size_t spatial_size, bool use_spatial_size,
+                                 size_t idx) const {}
 };
 
 template <typename T>
 struct AlphaFunctor<T, prelu::ElementWiseMode> {
-  HOSTDEVICE inline T operator()(const T* alpha, size_t channel,
-                                 size_t plane_size, size_t spatial_size,
-                                 bool use_spatial_size, size_t idx) const {
-    return alpha[blockIdx.x * spatial_size + idx];
+  HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
+                                 size_t batch_size, size_t plane_size,
+                                 size_t spatial_size, bool use_spatial_size,
+                                 size_t idx) const {
+    if (use_spatial_size) {
+      return alpha[idx];
+    }
+    size_t channel_index =
+        blockIdx.x %
+        batch_size return alpha[channel_index * spatial_size + idx];
   }
 };
 
 template <typename T>
 struct AlphaFunctor<T, prelu::ChannelMode> {
-  HOSTDEVICE inline T operator()(const T* alpha, size_t channel,
-                                 size_t plane_size, size_t spatial_size,
-                                 bool use_spatial_size, size_t idx) const {
-    T ret = alpha[blockIdx.x % channel];
-    if (use_spatial_size) ret = alpha[spatial_size / plane_size];
+  HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
+                                 size_t batch_size, size_t plane_size,
+                                 size_t spatial_size, bool use_spatial_size,
+                                 size_t idx) const {
+    T ret = alpha[blockIdx.x % channel_num];
+    if (use_spatial_size) ret = alpha[idx / plane_size];
     return ret;
   }
 };
 
 template <typename T>
 struct AlphaFunctor<T, prelu::ScalarMode> {
-  HOSTDEVICE inline T operator()(const T* alpha, size_t channel,
-                                 size_t plane_size, size_t spatial_size,
-                                 bool use_spatial_size, size_t idx) const {
+  HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
+                                 size_t batch_size, size_t plane_size,
+                                 size_t spatial_size, bool use_spatial_size,
+                                 size_t idx) const {
     return alpha[0];
   }
 };
 
 template <typename T, typename M>
-__global__ void PReluGradElementWiseKernel(const T* x_ptr, const T* y_ptr,
-                                           const T* alpha_ptr, const T* dy_ptr,
-                                           T* dx_ptr, T* dalpha_ptr,
-                                           size_t channel, size_t plane_size,
-                                           size_t spatial_size,
-                                           bool use_spatial_size) {
+__global__ void PReluGradElementWiseKernel(
+    const T* x_ptr, const T* y_ptr, const T* alpha_ptr, const T* dy_ptr,
+    T* dx_ptr, T* dalpha_ptr, size_t channel_num, size_t batch_size,
+    size_t plane_size, size_t spatial_size, bool use_spatial_size) {
   size_t offset = blockIdx.x * spatial_size;
   AlphaFunctor<T, M> alpha_func;
 
@@ -115,8 +122,8 @@ __global__ void PReluGradElementWiseKernel(const T* x_ptr, const T* y_ptr,
     T y = y_ptr[offset + i];
     T x = x_ptr[offset + i];
     T dy = dy_ptr[offset + i];
-    T alpha = alpha_func(alpha_ptr, channel, plane_size, spatial_size,
-                         use_spatial_size, i);
+    T alpha = alpha_func(alpha_ptr, channel_num, batch_size, plane_size,
+                         spatial_size, use_spatial_size, i);
     if (dx_ptr != nullptr) dx_ptr[offset + i] = (x > 0) ? dy : alpha * dy;
     if (dalpha_ptr != nullptr) dalpha_ptr[offset + i] = (x > 0) ? 0 : x * dy;
   }
@@ -140,8 +147,8 @@ class PreluGradElementwiseFunctor {
     if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
     CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
     PReluGradElementWiseKernel<T, M><<<unroll, num_threads, 0, stream>>>(
-        x, y, alpha, dy, dx, dalpha, input_shape[1], plane_size, spatial_size,
-        use_spatial_size);
+        x, y, alpha, dy, dx, dalpha, input_shape[1], input_shape[0], plane_size,
+        spatial_size, use_spatial_size);
   }
 };
 
@@ -202,11 +209,12 @@ class CUDAPReluGradKernel : public framework::OpKernel<T> {
                  dalpha_tmp_ptr, input_shape);
     }
 
-    if (mode == "element" || dalpha_tmp_ptr == nullptr) return;
+    if (dalpha_tmp_ptr == nullptr) return;
 
     std::vector<int> reduce_dims;
     for (size_t i = 0; i < input_shape.size(); i++) {
       if (mode == "channel" && i == 1) continue;
+      if (mode == "element" && i != 0) continue;
       reduce_dims.push_back(i);
     }
 

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -82,9 +82,8 @@ struct AlphaFunctor<T, prelu::ElementWiseMode> {
     if (use_spatial_size) {
       return alpha[idx];
     }
-    size_t channel_index =
-        blockIdx.x %
-        batch_size return alpha[channel_index * spatial_size + idx];
+    size_t channel_index = blockIdx.x % batch_size;
+    return alpha[channel_index * spatial_size + idx];
   }
 };
 

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -61,7 +61,7 @@ __global__ void PReluGradKernel(const T* x_ptr, const T* y_ptr,
                                 const T* alpha_ptr, const T* dy_ptr, T* dx_ptr,
                                 T* dalpha_ptr, size_t channel_num,
                                 size_t plane_size, size_t spatial_size,
-                                size_t numel, string mode) {
+                                size_t numel, std::string mode) {
   size_t index;
   CUDA_KERNEL_LOOP(index, numel) {
     T scale;
@@ -87,7 +87,7 @@ class PreluGradFunctor {
  public:
   void operator()(cudaStream_t stream, const T* x, const T* y, const T* alpha,
                   const T* dy, T* dx, T* dalpha, std::vector<int> input_shape,
-                  string mode) {
+                  std::string mode) {
     size_t plane_size = input_shape[2] * input_shape[3];
     size_t spatial_size = plane_size * input_shape[1];
     size_t numel = spatial_size * input_shape[0];

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -56,12 +56,6 @@ class CUDAPReluKernel : public framework::OpKernel<T> {
   }
 };
 
-namespace prelu {
-struct ElementWiseMode {};
-struct ChannelMode {};
-struct ScalarMode {};
-} /* namespace prelu */
-
 template <typename T>
 __global__ void PReluGradKernel(const T* x_ptr, const T* y_ptr,
                                 const T* alpha_ptr, const T* dy_ptr, T* dx_ptr,

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -92,7 +92,7 @@ class PreluGradFunctor {
     size_t spatial_size = plane_size * input_shape[1];
     size_t numel = spatial_size * input_shape[0];
     PReluGradKernel<
-        T, M><<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
+        T><<<PADDLE_GET_BLOCKS(numel), PADDLE_CUDA_NUM_THREADS, 0, stream>>>(
         x, y, alpha, dy, dx, dalpha, input_shape[1], plane_size, spatial_size,
         numel, mode);
   }

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -22,7 +22,7 @@ namespace operators {
 
 using Tensor = framework::Tensor;
 
-static constexpr int PD_CUDA_NUM_THREADS = 1024;
+#define CUDA_NUM_THREADS 1024
 
 // CUDA: grid stride looping
 #define CUDA_KERNEL_LOOP(i, n)                                 \
@@ -30,7 +30,7 @@ static constexpr int PD_CUDA_NUM_THREADS = 1024;
        i += blockDim.x * gridDim.x)
 
 inline static int PADDLE_GET_BLOCKS(const int N) {
-  return (N + PD_CUDA_NUM_THREADS - 1) / PD_CUDA_NUM_THREADS;
+  return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
 }
 
 template <typename DeviceContext, typename T>
@@ -105,7 +105,7 @@ class PreluOpGradFunctor {
     size_t spatial_size = plane_size * input_shape[1];
     size_t numel = spatial_size * input_shape[0];
     PReluOpGradKernel<
-        T><<<PADDLE_GET_BLOCKS(numel), PD_CUDA_NUM_THREADS, 0, stream>>>(
+        T><<<PADDLE_GET_BLOCKS(numel), CUDA_NUM_THREADS, 0, stream>>>(
         x, y, alpha, dy, dx, dalpha, input_shape[1], plane_size, spatial_size,
         numel, mode);
   }

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -68,21 +68,19 @@ struct ScalarMode {};
 template <typename T, typename M>
 struct AlphaFunctor {
   HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
-                                 size_t batch_size, size_t plane_size,
-                                 size_t spatial_size, bool use_plane_size,
-                                 size_t idx) const {}
+                                 size_t plane_size, size_t spatial_size,
+                                 bool use_plane_size, size_t idx) const {}
 };
 
 template <typename T>
 struct AlphaFunctor<T, prelu::ElementWiseMode> {
   HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
-                                 size_t batch_size, size_t plane_size,
-                                 size_t spatial_size, bool use_plane_size,
-                                 size_t idx) const {
+                                 size_t plane_size, size_t spatial_size,
+                                 bool use_plane_size, size_t idx) const {
     if (use_plane_size) {
       return alpha[idx];
     }
-    size_t channel_index = blockIdx.x % batch_size;
+    size_t channel_index = blockIdx.x % channel_num;
     return alpha[channel_index * spatial_size + idx];
   }
 };
@@ -90,9 +88,8 @@ struct AlphaFunctor<T, prelu::ElementWiseMode> {
 template <typename T>
 struct AlphaFunctor<T, prelu::ChannelMode> {
   HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
-                                 size_t batch_size, size_t plane_size,
-                                 size_t spatial_size, bool use_plane_size,
-                                 size_t idx) const {
+                                 size_t plane_size, size_t spatial_size,
+                                 bool use_plane_size, size_t idx) const {
     T ret = alpha[blockIdx.x % channel_num];
     if (use_plane_size) ret = alpha[idx / plane_size];
     return ret;
@@ -102,9 +99,8 @@ struct AlphaFunctor<T, prelu::ChannelMode> {
 template <typename T>
 struct AlphaFunctor<T, prelu::ScalarMode> {
   HOSTDEVICE inline T operator()(const T* alpha, size_t channel_num,
-                                 size_t batch_size, size_t plane_size,
-                                 size_t spatial_size, bool use_plane_size,
-                                 size_t idx) const {
+                                 size_t plane_size, size_t spatial_size,
+                                 bool use_plane_size, size_t idx) const {
     return alpha[0];
   }
 };
@@ -112,8 +108,8 @@ struct AlphaFunctor<T, prelu::ScalarMode> {
 template <typename T, typename M>
 __global__ void PReluGradElementWiseKernel(
     const T* x_ptr, const T* y_ptr, const T* alpha_ptr, const T* dy_ptr,
-    T* dx_ptr, T* dalpha_ptr, size_t channel_num, size_t batch_size,
-    size_t plane_size, size_t spatial_size, bool use_plane_size) {
+    T* dx_ptr, T* dalpha_ptr, size_t channel_num, size_t plane_size,
+    size_t spatial_size, bool use_plane_size) {
   size_t offset = blockIdx.x * spatial_size;
   AlphaFunctor<T, M> alpha_func;
 
@@ -121,8 +117,8 @@ __global__ void PReluGradElementWiseKernel(
     T y = y_ptr[offset + i];
     T x = x_ptr[offset + i];
     T dy = dy_ptr[offset + i];
-    T alpha = alpha_func(alpha_ptr, channel_num, batch_size, plane_size,
-                         spatial_size, use_plane_size, i);
+    T alpha = alpha_func(alpha_ptr, channel_num, plane_size, spatial_size,
+                         use_plane_size, i);
     if (dx_ptr != nullptr) dx_ptr[offset + i] = (x > 0) ? dy : alpha * dy;
     if (dalpha_ptr != nullptr) dalpha_ptr[offset + i] = (x > 0) ? 0 : x * dy;
   }
@@ -146,8 +142,8 @@ class PreluGradElementwiseFunctor {
     if (spatial_size < CUDA_NUM_THREADS) num_threads = spatial_size;
     CHECK_LE(unroll, CUDA_MAX_NUM_BLOCKS);
     PReluGradElementWiseKernel<T, M><<<unroll, num_threads, 0, stream>>>(
-        x, y, alpha, dy, dx, dalpha, input_shape[1], input_shape[0], plane_size,
-        spatial_size, use_plane_size);
+        x, y, alpha, dy, dx, dalpha, input_shape[1], plane_size, spatial_size,
+        use_plane_size);
   }
 };
 

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -109,7 +109,7 @@ __global__ void PReluGradElementWiseKernel(const T* x_ptr, const T* y_ptr,
     T x = x_ptr[offset + i];
     T dy = dy_ptr[offset + i];
     T alpha = alpha_func(alpha_ptr, channel, spatial_size, i);
-    if (dx_ptr != nullptr) dx_ptr[offset + i] = (y > 0) ? dy : alpha * dy;
+    if (dx_ptr != nullptr) dx_ptr[offset + i] = (x > 0) ? dy : alpha * dy;
     if (dalpha_ptr != nullptr) dalpha_ptr[offset + i] = (x > 0) ? 0 : x * dy;
   }
 }

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -141,7 +141,7 @@ class CUDAPReluGradKernel : public framework::OpKernel<T> {
       dalpha_tmp_ptr = dalpha_tmp.mutable_data<T>(context.GetPlace());
     }
 
-    PreluGradFunctor<T, prelu::ElementWiseMode> prelu_grad;
+    PreluGradFunctor<T> prelu_grad;
     prelu_grad(stream, x_ptr, y_ptr, alpha_ptr, dy_ptr, dx_ptr, dalpha_tmp_ptr,
                input_shape, mode);
 

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -186,7 +186,7 @@ class CUDAPReluGradKernel : public framework::OpKernel<T> {
 
     T* dalpha_tmp_ptr;
     Tensor dalpha_tmp;
-    if (mode == "element" || dalpha_ptr == nullptr) {
+    if (dalpha_ptr == nullptr) {
       dalpha_tmp_ptr = dalpha_ptr;
     } else {
       auto& dev_ctx = context.template device_context<DeviceContext>();

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -88,6 +88,7 @@ struct AlphaFunctor<T, prelu::ChannelMode> {
                                  bool use_spatial_size, size_t idx) const {
     T ret = alpha[blockIdx.x % channel];
     if (use_spatial_size) ret = alpha[spatial_size / plane_size];
+    return ret
   }
 };
 

--- a/paddle/fluid/operators/prelu_op.cu
+++ b/paddle/fluid/operators/prelu_op.cu
@@ -88,7 +88,7 @@ struct AlphaFunctor<T, prelu::ChannelMode> {
                                  bool use_spatial_size, size_t idx) const {
     T ret = alpha[blockIdx.x % channel];
     if (use_spatial_size) ret = alpha[spatial_size / plane_size];
-    return ret
+    return ret;
   }
 };
 

--- a/paddle/fluid/operators/prelu_op.h
+++ b/paddle/fluid/operators/prelu_op.h
@@ -109,8 +109,9 @@ class PReluGradKernel : public framework::OpKernel<T> {
           dalpha_ptr[index] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
         }
       } else if (mode == "element") {
+        temp = numel / dim[0];
         for (i = 0; i < numel; i++) {
-          index = i % dim[0];
+          index = i % temp;
           dalpha_ptr[index] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
         }
       } else {

--- a/paddle/fluid/operators/prelu_op.h
+++ b/paddle/fluid/operators/prelu_op.h
@@ -64,12 +64,10 @@ class PReluGradKernel : public framework::OpKernel<T> {
     auto* dx = context.Output<Tensor>(framework::GradVarName("X"));
     auto* dout = context.Input<Tensor>(framework::GradVarName("Out"));
     auto* dalpha = context.Output<Tensor>(framework::GradVarName("Alpha"));
-    auto* out = context.Input<Tensor>("Out");
     auto* alpha = context.Input<Tensor>("Alpha");
     const T* alpha_ptr = alpha->data<T>();
     const T* x_ptr = x->data<T>();
     const T* dout_ptr = dout->data<T>();
-    const T* out_ptr = out->data<T>();
     std::string mode = context.Attr<std::string>("mode");
     int numel = x->numel();
     auto dim = x->dims();
@@ -83,15 +81,15 @@ class PReluGradKernel : public framework::OpKernel<T> {
           temp = numel / (dim[0] * dim[1]);
           index = (i / temp) % dim[1];
           dx_ptr[i] =
-              out_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[index] * dout_ptr[i];
+              x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[index] * dout_ptr[i];
         }
       } else if (mode == "element") {
         for (i = 0; i < numel; i++) {
-          dx_ptr[i] = out_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[i] * dout_ptr[i];
+          dx_ptr[i] = x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[i] * dout_ptr[i];
         }
       } else {
         for (i = 0; i < numel; i++) {
-          dx_ptr[i] = out_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[0] * dout_ptr[i];
+          dx_ptr[i] = x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[0] * dout_ptr[i];
         }
       }
     }
@@ -105,15 +103,15 @@ class PReluGradKernel : public framework::OpKernel<T> {
         for (i = 0; i < numel; i++) {
           temp = numel / (dim[0] * dim[1]);
           index = (i / temp) % dim[1];
-          dalpha_ptr[index] += out_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
+          dalpha_ptr[index] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
         }
       } else if (mode == "element") {
         for (i = 0; i < numel; i++) {
-          dalpha_ptr[i] += out_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
+          dalpha_ptr[i] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
         }
       } else {
         for (i = 0; i < numel; i++) {
-          dalpha_ptr[0] += out_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
+          dalpha_ptr[0] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
         }
       }
     }

--- a/paddle/fluid/operators/prelu_op.h
+++ b/paddle/fluid/operators/prelu_op.h
@@ -45,8 +45,9 @@ class PReluKernel : public framework::OpKernel<T> {
         o_ptr[i] = x_ptr[i] > 0 ? x_ptr[i] : alpha_ptr[index] * x_ptr[i];
       }
     } else if (mode == "element") {
+      int temp = numel / dim[0];
       for (i = 0; i < numel; i++) {
-        index = i % dim[0];
+        index = i % temp;
         o_ptr[i] = x_ptr[i] > 0 ? x_ptr[i] : alpha_ptr[index] * x_ptr[i];
       }
     } else {

--- a/paddle/fluid/operators/prelu_op.h
+++ b/paddle/fluid/operators/prelu_op.h
@@ -86,8 +86,9 @@ class PReluGradKernel : public framework::OpKernel<T> {
               x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[index] * dout_ptr[i];
         }
       } else if (mode == "element") {
+        temp = numel / dim[0];
         for (i = 0; i < numel; i++) {
-          index = i % dim[0];
+          index = i % temp;
           dx_ptr[i] =
               x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[index] * dout_ptr[i];
         }

--- a/paddle/fluid/operators/prelu_op.h
+++ b/paddle/fluid/operators/prelu_op.h
@@ -46,7 +46,8 @@ class PReluKernel : public framework::OpKernel<T> {
       }
     } else if (mode == "element") {
       for (i = 0; i < numel; i++) {
-        o_ptr[i] = x_ptr[i] > 0 ? x_ptr[i] : alpha_ptr[i] * x_ptr[i];
+        index = i % dim[0];
+        o_ptr[i] = x_ptr[i] > 0 ? x_ptr[i] : alpha_ptr[index] * x_ptr[i];
       }
     } else {
       for (i = 0; i < numel; i++) {
@@ -85,7 +86,9 @@ class PReluGradKernel : public framework::OpKernel<T> {
         }
       } else if (mode == "element") {
         for (i = 0; i < numel; i++) {
-          dx_ptr[i] = x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[i] * dout_ptr[i];
+          index = i % dim[0];
+          dx_ptr[i] =
+              x_ptr[i] > 0 ? dout_ptr[i] : alpha_ptr[index] * dout_ptr[i];
         }
       } else {
         for (i = 0; i < numel; i++) {
@@ -107,7 +110,8 @@ class PReluGradKernel : public framework::OpKernel<T> {
         }
       } else if (mode == "element") {
         for (i = 0; i < numel; i++) {
-          dalpha_ptr[i] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
+          index = i % dim[0];
+          dalpha_ptr[index] += x_ptr[i] > 0 ? 0 : x_ptr[i] * dout_ptr[i];
         }
       } else {
         for (i = 0; i < numel; i++) {

--- a/paddle/fluid/operators/reduce_ops/cub_reduce.h
+++ b/paddle/fluid/operators/reduce_ops/cub_reduce.h
@@ -66,6 +66,7 @@ __global__ void ReduceKernel2D(const Tx* x, Ty* y, ReduceOp reducer,
   Ty reduce_var = init;
   for (int idx_y = threadIdx.x; idx_y < reduce_num; idx_y += BlockDim)
     reduce_var = reducer(reduce_var, transformer(x[idx_x + idx_y]));
+  __syncthreads();
 
   reduce_var =
       cub::BlockReduce<Ty, BlockDim>(temp_storage).Reduce(reduce_var, reducer);
@@ -113,6 +114,7 @@ __global__ void ReduceKernel(const Tx* x, Ty* y, ReduceOp reducer,
     for (int k = 0; k < Rank; ++k) idx_x += (sub_index[k] * x_strides[k]);
     reduce_var = static_cast<Ty>(reducer(reduce_var, transformer(x[idx_x])));
   }
+  __syncthreads();
 
   reduce_var =
       cub::BlockReduce<Ty, BlockDim>(temp_storage).Reduce(reduce_var, reducer);

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12278,7 +12278,7 @@ def swish(x, beta=1.0, name=None):
     return out
 
 
-def prelu(x, mode, param_attr=None, name=None):
+def prelu(x, mode, param_attr=None, name=None, batch_size=None):
     """
     Equation:
 
@@ -12328,7 +12328,9 @@ def prelu(x, mode, param_attr=None, name=None):
     if mode == 'channel':
         alpha_shape = [1, x.shape[1], 1, 1]
     elif mode == 'element':
-        alpha_shape = x.shape
+        assert batch_size is not None and batch_size > 0, \
+            "For the element mode for prelu, a positive batch-size must be set."
+        alpha_shape = [batch_size] + list(x.shape[1:])
     dtype = helper.input_dtype(input_param_name='x')
     alpha = helper.create_parameter(
         attr=helper.param_attr,

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12335,7 +12335,7 @@ def prelu(x, mode, param_attr=None, name=None):
         shape=alpha_shape,
         dtype='float32',
         is_bias=False,
-        default_initializer=Constant(1.0))
+        default_initializer=Constant(0.25))
     out = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type="prelu",

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12278,7 +12278,7 @@ def swish(x, beta=1.0, name=None):
     return out
 
 
-def prelu(x, mode, param_attr=None, name=None, batch_size=None):
+def prelu(x, mode, param_attr=None, name=None):
     """
     Equation:
 
@@ -12328,9 +12328,7 @@ def prelu(x, mode, param_attr=None, name=None, batch_size=None):
     if mode == 'channel':
         alpha_shape = [1, x.shape[1], 1, 1]
     elif mode == 'element':
-        assert batch_size is not None and batch_size > 0, \
-            "For the element mode for prelu, a positive batch-size must be set."
-        alpha_shape = [batch_size] + list(x.shape[1:])
+        alpha_shape = x.shape[1:]
     dtype = helper.input_dtype(input_param_name='x')
     alpha = helper.create_parameter(
         attr=helper.param_attr,

--- a/python/paddle/fluid/tests/unittests/test_prelu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_prelu_op.py
@@ -37,7 +37,8 @@ class PReluTest(OpTest):
             alpha_np = np.random.rand(1, x_np.shape[1], 1, 1).astype("float32")
             self.inputs = {'X': x_np, 'Alpha': alpha_np}
         else:
-            alpha_np = np.random.rand(*x_np.shape).astype("float32")
+            alpha_np = np.random.rand(1, x_np.shape[1], x_np.shape[2], \
+                x_np.shape[3]).astype("float32")
             self.inputs = {'X': x_np, 'Alpha': alpha_np}
 
         out_np = np.maximum(self.inputs['X'], 0.)


### PR DESCRIPTION
For prelu:
f(x) = x if x > 0 else _a_*x, where _a_ is a learnable parameter.
so df(x) = 1 if x > 0 else _a_.

Todo：
- Replace the macro definition of CUDA_NUM_THREADS with the constant PADDLE_CUDA_NUM_THREADS;
- Remove the _PADDLE_ prefix of the PADDLE_GET_BLOCKS function or define the function as a global function.