### PR TITLE
fix C++ multicard  inference bug.

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -123,7 +123,7 @@ bool AnalysisPredictor::PrepareScope(
     status_is_cloned_ = true;
   } else {
     if (config_.use_gpu_) {
-      paddle::framework::InitDevices(false, {config_.device_id_});
+      paddle::framework::InitDevices(false);
     } else {
       paddle::framework::InitDevices(false, {});
     }
@@ -501,8 +501,6 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
       std::string flag = "--fraction_of_gpu_memory_to_use=" +
                          std::to_string(fraction_of_gpu_memory);
       flags.push_back(flag);
-      flags.push_back("--selected_gpus=" +
-                      std::to_string(config.gpu_device_id()));
       VLOG(3) << "set flag: " << flag;
       framework::InitGflags(flags);
     }


### PR DESCRIPTION
When we create two predictor on difference card, there is the bug:

For example:

```
void PrepareTRTConfig(AnalysisConfig *config, int batch_size, int id = 1) {
  config->SetModel(FLAGS_dirname + "/model",
                     FLAGS_dirname + "/params");
  config->EnableUseGpu(100, id);
  config->SwitchUseFeedFetchOps(false);
}

bool test_map_cnn(int batch_size, int repeat) {
  // create the predictor 1
  AnalysisConfig config;
  PrepareTRTConfig(&config, batch_size);
  auto predictor = CreatePaddlePredictor(config);

  // create the predictor 2
  AnalysisConfig config1;
  PrepareTRTConfig(&config1, batch_size, 2);
  auto predictor1 = CreatePaddlePredictor(config1);
  ....
  return true;
}
```