### PR TITLE
fix the bug of conv_transpose cudnn kernel

### DIFF
--- a/paddle/fluid/operators/conv_transpose_cudnn_op.cu
+++ b/paddle/fluid/operators/conv_transpose_cudnn_op.cu
@@ -72,7 +72,7 @@ class CUDNNConvTransposeOpKernel : public framework::OpKernel<T> {
     const T* filter_data = filter->data<T>();
     const std::string data_layout_str = ctx.Attr<std::string>("data_format");
     const paddle::operators::DataLayout data_layout =
-        (data_layout_str == "NCHW" ? DataLayout::kNCHW : DataLayout::kNHWC);
+        (data_layout_str != "NHWC" ? DataLayout::kNCHW : DataLayout::kNHWC);
 
     // if channel_last, transpose to channel_first
     Tensor input_transpose;


### PR DESCRIPTION
**fix the bug of conv_transpose cudnn kernel**: before version 1.6,  the data_format is `AnyLayout` in inference model.  When use version 1.6 and load the model which is saved by previous version, the error occurs:
![image](https://user-images.githubusercontent.com/26615455/68008371-ac37d400-fcb9-11e9-87a9-a104cc0deca7.png)
This is because the  cudnn kernel in version 1.6 is not compitable with `Anylayout` setting. 
**问题来源**：
用户反馈：使用1.6版本运行1.4的模型，前向计算中，conv_transpose出现`CUDNN_STATUS_BAD_PARAM`错误。当使用1.6版本重新对模型进行转换后，问题解决了。
经排查：发现conv_transpose的cudnn kernel前向代码中，有一处逻辑未兼容到旧版本。该PR修复此问题。