### PR TITLE
Support numpy bridge

### DIFF
--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -168,6 +168,8 @@ class Tensor {
 
   void ResetHolder(std::shared_ptr<memory::Allocation> holder);
 
+  void ResetType(const proto::VarType::Type type) { type_ = type; }
+
  private:
   /*! holds the memory block if allocated. */
   std::shared_ptr<memory::Allocation> holder_;

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -458,11 +458,12 @@ PYBIND11_MODULE(core_noavx, m) {
            })
       .def("_clear", &Tensor::clear)
       .def("set", SetTensorFromPyArray<paddle::platform::CPUPlace>,
-           py::arg("array"), py::arg("place"))
+           py::arg("array"), py::arg("place"), py::arg("zero_copy") = false)
       .def("set", SetTensorFromPyArray<paddle::platform::CUDAPlace>,
-           py::arg("array"), py::arg("place"))
+           py::arg("array"), py::arg("place"), py::arg("zero_copy") = false)
       .def("set", SetTensorFromPyArray<paddle::platform::CUDAPinnedPlace>,
-           py::arg("array"), py::arg("place"), R"DOC(
+           py::arg("array"), py::arg("place"), py::arg("zero_copy") = false,
+           R"DOC(
         Set the data of LoDTensor on place with given numpy array.
         
         Args:

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -13,6 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
+
+#ifndef NPY_NO_DEPRECATED_API
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+#endif
+
 #include <Python.h>
 #include <numpy/arrayobject.h>
 #include <algorithm>
@@ -69,7 +74,9 @@ class PYBIND11_HIDDEN NumpyAllocation : public memory::Allocation {
  public:
   explicit NumpyAllocation(PyObject *arr, size_t size,
                            paddle::platform::Place place)
-      : Allocation(PyArray_DATA(arr), size, place), arr_(arr) {}
+      : Allocation(PyArray_DATA(reinterpret_cast<PyArrayObject *>(arr)), size,
+                   place),
+        arr_(arr) {}
   ~NumpyAllocation() override {
     py::gil_scoped_acquire gil;
     Py_XDECREF(arr_);

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -66,8 +66,8 @@ namespace details {
 
 class PYBIND11_HIDDEN NumpyAllocation : public memory::Allocation {
  public:
-  explicit NumpyAllocation(std::shared_ptr<pybind11::array> arr, ssize_t size,
-                           paddle::platform::CPUPlace place)
+  explicit NumpyAllocation(std::shared_ptr<py::array> arr, size_t size,
+                           paddle::platform::Place place)
       : Allocation(
             const_cast<void *>(reinterpret_cast<const void *>(arr->data())),
             size, place),
@@ -78,7 +78,7 @@ class PYBIND11_HIDDEN NumpyAllocation : public memory::Allocation {
   }
 
  private:
-  std::shared_ptr<pybind11::array> arr_;
+  std::shared_ptr<py::array> arr_;
 };
 
 template <typename T>

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -199,8 +199,9 @@ void SetTensorFromPyArrayT(
 }
 
 template <typename P>
-void SetTensorFromPyArray(framework::Tensor *self, const py::array &array,
+void SetTensorFromPyArray(framework::Tensor *self, const py::object &obj,
                           const P &place, bool zero_copy) {
+  auto array = obj.cast<py::array>();
   if (py::isinstance<py::array_t<float>>(array)) {
     SetTensorFromPyArrayT<float, P>(self, array, place, zero_copy);
   } else if (py::isinstance<py::array_t<int>>(array)) {

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -160,7 +160,7 @@ def _print_debug_msg(limit=5, is_test=False):
 
 
 @framework.dygraph_only
-def to_variable(value, block=None, name=None, zero_copy=True):
+def to_variable(value, block=None, name=None, zero_copy=None):
     """
     The API will create a ``Variable`` object from numpy\.ndarray or Variable object.
 
@@ -168,7 +168,7 @@ def to_variable(value, block=None, name=None, zero_copy=True):
         value(ndarray): The numpy\.ndarray object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
         block(fluid.Block, optional): Which block this variable will be in. Default: None.
         name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`
-        zero_copy(bool, optional): Whether to share memory with the input numpy array. Default: True.
+        zero_copy(bool, optional): Whether to share memory with the input numpy array. This parameter only works with CPUPlace and will be set to True when it is None. Default: None.
 
     Returns:
         Variable: ``Tensor`` created from the specified numpy\.ndarray object, data type and shape is the same as ``value`` .
@@ -180,9 +180,14 @@ def to_variable(value, block=None, name=None, zero_copy=True):
         import numpy as np
         import paddle.fluid as fluid
 
-        with fluid.dygraph.guard():
+        with fluid.dygraph.guard(fluid.CPUPlace()):
             x = np.ones([2, 2], np.float32)
+            y = fluid.dygraph.to_variable(x, zero_copy=False)
+            x[0][0] = -1
+            y[0][0].numpy()  # array([1.], dtype=float32)
             y = fluid.dygraph.to_variable(x)
+            x[0][0] = 0
+            y[0][0].numpy()  # array([0.], dtype=float32)
 
     """
     if isinstance(value, np.ndarray):
@@ -200,7 +205,14 @@ def to_variable(value, block=None, name=None, zero_copy=True):
             stop_gradient=True)
         var = py_var._ivar.value()
         tensor = var.get_tensor()
-        tensor.set(value, framework._current_expected_place(), zero_copy)
+        if isinstance(framework._current_expected_place(),
+                      framework.core.CPUPlace):
+            if zero_copy is None:
+                zero_copy = True
+            tensor.set(value, framework._current_expected_place(), zero_copy)
+        else:
+            assert not zero_copy, "zero_copy mode can only be used with CPUPlace"
+            tensor.set(value, framework._current_expected_place(), False)
         return py_var
     elif isinstance(value, framework.Variable):
         return value

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -160,7 +160,7 @@ def _print_debug_msg(limit=5, is_test=False):
 
 
 @framework.dygraph_only
-def to_variable(value, block=None, name=None, zero_copy=None):
+def to_variable(value, block=None, name=None, zero_copy=False):
     """
     The API will create a ``Variable`` object from numpy\.ndarray or Variable object.
 
@@ -168,7 +168,7 @@ def to_variable(value, block=None, name=None, zero_copy=None):
         value(ndarray): The numpy\.ndarray object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
         block(fluid.Block, optional): Which block this variable will be in. Default: None.
         name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`
-        zero_copy(bool, optional): Whether to share memory with the input numpy array. This parameter only works with CPUPlace and will be set to True when it is None. Default: None.
+        zero_copy(bool, optional): Whether to share memory with the input numpy array. This parameter only works with CPUPlace. Default: False.
 
     Returns:
         Variable: ``Tensor`` created from the specified numpy\.ndarray object, data type and shape is the same as ``value`` .
@@ -182,10 +182,10 @@ def to_variable(value, block=None, name=None, zero_copy=None):
 
         with fluid.dygraph.guard(fluid.CPUPlace()):
             x = np.ones([2, 2], np.float32)
-            y = fluid.dygraph.to_variable(x, zero_copy=False)
+            y = fluid.dygraph.to_variable(x)
             x[0][0] = -1
             y[0][0].numpy()  # array([1.], dtype=float32)
-            y = fluid.dygraph.to_variable(x)
+            y = fluid.dygraph.to_variable(x, zero_copy=True)
             x[0][0] = 0
             y[0][0].numpy()  # array([0.], dtype=float32)
 
@@ -207,8 +207,6 @@ def to_variable(value, block=None, name=None, zero_copy=None):
         tensor = var.get_tensor()
         if isinstance(framework._current_expected_place(),
                       framework.core.CPUPlace):
-            if zero_copy is None:
-                zero_copy = True
             tensor.set(value, framework._current_expected_place(), zero_copy)
         else:
             assert not zero_copy, "zero_copy mode can only be used with CPUPlace"

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -160,7 +160,7 @@ def _print_debug_msg(limit=5, is_test=False):
 
 
 @framework.dygraph_only
-def to_variable(value, block=None, name=None):
+def to_variable(value, block=None, name=None, zero_copy=False):
     """
     The API will create a ``Variable`` object from numpy\.ndarray or Variable object.
 
@@ -168,6 +168,7 @@ def to_variable(value, block=None, name=None):
         value(ndarray): The numpy\.ndarray object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
         block(fluid.Block, optional): Which block this variable will be in. Default: None.
         name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`
+        zero_copy(bool, optional): Whether to share memory with the input numpy array. Default: False.
 
     Returns:
         Variable: ``Tensor`` created from the specified numpy\.ndarray object, data type and shape is the same as ``value`` .
@@ -199,7 +200,7 @@ def to_variable(value, block=None, name=None):
             stop_gradient=True)
         var = py_var._ivar.value()
         tensor = var.get_tensor()
-        tensor.set(value, framework._current_expected_place())
+        tensor.set(value, framework._current_expected_place(), zero_copy)
         return py_var
     elif isinstance(value, framework.Variable):
         return value

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -160,7 +160,7 @@ def _print_debug_msg(limit=5, is_test=False):
 
 
 @framework.dygraph_only
-def to_variable(value, block=None, name=None, zero_copy=False):
+def to_variable(value, block=None, name=None, zero_copy=True):
     """
     The API will create a ``Variable`` object from numpy\.ndarray or Variable object.
 
@@ -168,7 +168,7 @@ def to_variable(value, block=None, name=None, zero_copy=False):
         value(ndarray): The numpy\.ndarray object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
         block(fluid.Block, optional): Which block this variable will be in. Default: None.
         name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`
-        zero_copy(bool, optional): Whether to share memory with the input numpy array. Default: False.
+        zero_copy(bool, optional): Whether to share memory with the input numpy array. Default: True.
 
     Returns:
         Variable: ``Tensor`` created from the specified numpy\.ndarray object, data type and shape is the same as ``value`` .

--- a/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
@@ -20,7 +20,7 @@ import paddle.fluid as fluid
 class TestImperativeNumpyBridge(unittest.TestCase):
     def test_tensor_from_numpy(self):
         data_np = np.array([[2, 3, 1]]).astype('float32')
-        with fluid.dygraph.guard():
+        with fluid.dygraph.guard(fluid.CPUPlace()):
             var = fluid.dygraph.to_variable(data_np, zero_copy=True)
             self.assertTrue(np.array_equal(var.numpy(), data_np))
             data_np[0][0] = 4

--- a/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
@@ -27,6 +27,12 @@ class TestImperativeNumpyBridge(unittest.TestCase):
             self.assertEqual(data_np[0][0], 4)
             self.assertEqual(var[0][0].numpy()[0], 4)
             self.assertTrue(np.array_equal(var.numpy(), data_np))
+            var2 = fluid.dygraph.to_variable(data_np, zero_copy=False)
+            self.assertTrue(np.array_equal(var2.numpy(), data_np))
+            data_np[0][0] = -1
+            self.assertEqual(data_np[0][0], -1)
+            self.assertNotEqual(var2[0][0].numpy()[0], -1)
+            self.assertFalse(np.array_equal(var2.numpy(), data_np))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import paddle.fluid as fluid
+
+
+class TestImperativeNumpyBridge(unittest.TestCase):
+    def test_tensor_from_numpy(self):
+        data_np = np.array([[2, 3, 1]]).astype('float32')
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(data_np, zero_copy=True)
+            self.assertTrue(np.array_equal(var.numpy(), data_np))
+            data_np[0][0] = 4
+            self.assertEqual(data_np[0][0], 4)
+            self.assertEqual(var[0][0].numpy()[0], 4)
+            self.assertTrue(np.array_equal(var.numpy(), data_np))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
NumPy Bridge is used for zero-copy creation of a Tensor with a NumPy array.

The created Tensor and NumPy array will share their underlying memory locations (only when working with CPUPlace), and changing the NumPy array will change the Tensor.

`zero_copy` only works with CPUPlace.