### PR TITLE
[WIP] Add 3-dimension ncw format and use naive version

### DIFF
--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_mul_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_mul_mkldnn_op.cc
@@ -52,8 +52,10 @@ static void ReorderInput(framework::Tensor* tensor,
   framework::Tensor out_tensor;
   out_tensor.Resize(tensor->dims());
   auto dims_size = dims.size();
-  out_tensor.set_format(dims_size==4 ? MKLDNNMemoryFormat::nchw : 
-  (dims_size==3 ? MKLDNNMemoryFormat::ncw : MKLDNNMemoryFormat::nc));
+  out_tensor.set_format(dims_size == 4
+                            ? MKLDNNMemoryFormat::nchw
+                            : (dims_size == 3 ? MKLDNNMemoryFormat::ncw
+                                              : MKLDNNMemoryFormat::nc));
   out_tensor.set_layout(tensor->layout());
   mkldnn::memory input_memory = {
       {{dims, platform::MKLDNNGetDataType<T>(), tensor->format()}, engine},
@@ -151,9 +153,11 @@ class ElementwiseMulMKLDNNKernel : public framework::OpKernel<T> {
         auto& dev_ctx = ctx.template device_context<MKLDNNDeviceContext>();
         const auto& mkldnn_engine = dev_ctx.GetEngine();
         if (!(is_x_nchw || is_x_ncw || is_x_nwc || is_x_nc || is_x_x))
-          ReorderInput<T>(const_cast<Tensor*>(x), ctx.GetPlace(), mkldnn_engine);
-        if (!(is_y_nchw || is_y_ncw ||is_y_nwc || is_y_nc || is_y_x))
-          ReorderInput<T>(const_cast<Tensor*>(y), ctx.GetPlace(), mkldnn_engine);
+          ReorderInput<T>(const_cast<Tensor*>(x), ctx.GetPlace(),
+                          mkldnn_engine);
+        if (!(is_y_nchw || is_y_ncw || is_y_nwc || is_y_nc || is_y_x))
+          ReorderInput<T>(const_cast<Tensor*>(y), ctx.GetPlace(),
+                          mkldnn_engine);
       }
 
       auto mul_func = [](T a, T b) -> T { return a * b; };


### PR DESCRIPTION
Related to #20842  ernie large model issue.
Problem: Slow latency. We are trying to use 3-dimension MKLDNN mul.

Hi, sorry, I forgot I was on my own machine i9 and got slow latency. On 6148, `num_threads=10` latency is as follow. The latency with `num_threads=1` is in later comments.

```
I1101 10:09:51.044067  5401 analysis_predictor.cc:474] ======= optimize end =======
I1101 10:09:51.050020  5401 inference.cc:213] Load 10 samples from /home/lidanqing/data/test_ds_10
I1101 10:09:58.605739  5401 inference.cc:353] Run 10 samples, average latency: 755.564 ms per sample.
I1101 10:09:58.605875  5401 inference.cc:358] Run 5 samples, average latency [exclude 5 warmup steps]: 559.852
ms per sample.
```