### PR TITLE
fix infer crashes caused by conv/pool upgrades, test=release/1.6

### DIFF
--- a/paddle/fluid/framework/op_compatible_info.cc
+++ b/paddle/fluid/framework/op_compatible_info.cc
@@ -234,8 +234,8 @@ bool ProgOptimUnsupported(std::shared_ptr<framework::ProgramDesc> program) {
     }
     if (op.HasAttr("data_format")) {
       auto data_format = boost::get<std::string>(op.GetAttr("data_format"));
-      if (data_format != "NCHW") {
-        VLOG(3) << "== data_format is not NCHW.";
+      if (data_format == "NHWC" || data_format == "NDHWC") {
+        VLOG(3) << "== data_format is NHWC or NDHWC.";
         return true;
       }
     }

--- a/paddle/fluid/framework/op_compatible_info.cc
+++ b/paddle/fluid/framework/op_compatible_info.cc
@@ -215,5 +215,50 @@ bool OpCompatibleMap::ReadFromProto(const proto::OpCompatibleMap& desc) {
   return true;
 }
 
+bool ProgOptimUnsupported(std::shared_ptr<framework::ProgramDesc> program) {
+  auto op_type_checker = [](const std::string& name) {
+    const std::vector<std::string> op_types({
+        "conv2d", "conv3d", "conv2d_transpose", "conv3d_transpose",
+        "depthwise_conv2d", "depthwise_conv2d_transpose", "pool2d", "pool3d",
+    });
+    return std::find(op_types.begin(), op_types.end(), name) != op_types.end();
+  };
+  auto checker = [](const framework::OpDesc& op) {
+    if (op.HasAttr("paddings") && op.HasAttr("strides")) {
+      auto paddings = boost::get<std::vector<int>>(op.GetAttr("paddings"));
+      auto strides = boost::get<std::vector<int>>(op.GetAttr("strides"));
+      if (paddings.size() != strides.size()) {
+        VLOG(3) << "== paddings size is not equal to strides size.";
+        return true;
+      }
+    }
+    if (op.HasAttr("data_format")) {
+      auto data_format = boost::get<std::string>(op.GetAttr("data_format"));
+      if (data_format != "NCHW") {
+        VLOG(3) << "== data_format is not NCHW.";
+        return true;
+      }
+    }
+    if (op.HasAttr("padding_algorithm")) {
+      auto padding_algorithm =
+          boost::get<std::string>(op.GetAttr("padding_algorithm"));
+      if (padding_algorithm != "EXPLICIT") {
+        VLOG(3) << "== padding_algorithm is not EXPLICIT.";
+        return true;
+      }
+    }
+    return false;
+  };
+  for (size_t i = 0; i < program->Size(); i++) {
+    const auto& block = program->Block(i);
+    for (auto* op : block.AllOps()) {
+      if ((op_type_checker(op->Type())) && checker(*op)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/op_compatible_info.h
+++ b/paddle/fluid/framework/op_compatible_info.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <map>
+#include <memory>
 #include <string>
 #include "paddle/fluid/framework/program_desc.h"
 
@@ -69,6 +70,10 @@ class OpCompatibleMap {
   std::map<std::string, CompatibleInfo> op_compatible_map_;
   std::string default_required_version_;
 };
+
+// Determine if the model contains operators that the optimization cannot
+// support.
+bool ProgOptimUnsupported(std::shared_ptr<framework::ProgramDesc> program);
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -145,7 +145,7 @@ bool AnalysisPredictor::PrepareProgram(
     // still need to create other persistable variables.
     // So in both case, create persistable variables at first.
     if (!CheckOperatorCompatible()) {
-      LOG(WARNING) << "WARNING: Results may be DIFF! "
+      LOG(WARNING) << "WARNING: Results may be incorrect! "
                       "Using same versions between model and lib.";
     }
     executor_->CreateVariables(*inference_program_, 0, true, sub_scope_);
@@ -458,6 +458,14 @@ void AnalysisPredictor::PrepareArgument() {
 
 // NOTE All the members in AnalysisConfig should be copied to Argument.
 void AnalysisPredictor::OptimizeInferenceProgram() {
+  if (ProgOptimUnsupported(inference_program_)) {
+    LOG(INFO) << "NOTICE: Your inference model contains parameters such "
+                 "as asymmetric padding, and ir optimization is temporarily "
+                 "not supported, "
+                 "so it is turned off.";
+    config_.SwitchIrOptim(false);
+    argument_.SetEnableAnalysisOptim(false);
+  }
   PrepareArgument();
   Analyzer().Run(&argument_);
 


### PR DESCRIPTION
**本 PR 提供了一种 1.6.0 版本卷积、池化算子升级引起预测不兼容的临时解决方案。**

下列情况使用训练前向算子进行预测，不再进行图优化：
```
模型 "conv2d", "conv3d", "conv2d_transpose", "conv3d_transpose", "depthwise_conv2d",
 "depthwise_conv2d_transpose", "pool2d", "pool3d" 任一算子类型满足下列条件之一：
1、paddings 参数长度不等于 strides；
2、data_format 等于 NDHWC 或 NHWC；
3、padding_algorithm 不等于 EXPLICIT。
```

当遇到上述情况时，提示用户如下：
```
I1101 17:35:35.841440 180794 analysis_predictor.cc:462] NOTICE: Your inference model contains parameters such as asymmetric padding, and ir optimization is temporarily not supported, so it is turned off.
I1101 17:35:35.841468 180794 analysis_predictor.cc:452] ir_optim is turned off, no IR pass will be executed
```

进行这种限制是因为预测专用的算子尚未对新增特性进行升级支持。本修改不会对之前的已有计算造成影响。此改动在下列模型中自测通过：
```
freeze_model3
freeze_model4
conv2d/dataformat_NHWC
conv2d/old
conv2d/padding_algorithm
conv2d/padding_asymmetry
conv3d/dataformat_NDHWC
conv3d/old
conv3d/padding_algorithm
conv3d/padding_asymmetry
pool2d_avg/old
pool2d_avg/padding_algorithm
pool2d_avg/padding_asymmetry
pool3d_avg/datafomat_NDHWC
pool3d_avg/old
pool3d_avg/padding_algorithm
pool3d_avg/padding_asymmetry
conv2d_transpose_model_nchw
conv2d_transpose_model_nhwc
conv2d_transpose_model_padding
small_dam
```