### PR TITLE
Add fc padding to improve mkl GEMM's performance when N and K are multiple of 128.

### DIFF
--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -93,12 +93,13 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     auto* scope = param_scope();
     auto* weight = scope->FindVar(w->Name())->GetMutable<LoDTensor>();
     auto place = weight->place();
+    bool use_gpu = Get<bool>("use_gpu");
     auto weight_data = weight->data<float>();
     auto weight_dims = weight->dims();
     int weight_num = product(weight_dims);
     int w_h = weight_dims[0];
     int w_w = weight_dims[1];
-    if (platform::is_cpu_place(place)) {
+    if (!use_gpu) {
       if (w_h % 128 == 0 && w_w % 128 == 0) {
         float* weight_data_tmp = new float[weight_num];
         for (int i = 0; i < w_h; i++) {

--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -89,6 +89,34 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     std::string activation_type = with_relu ? "relu" : "";
     desc.SetAttr("activation_type", activation_type);
 
+    // This is to add padding for dimension 128 on concern of MKL performance
+    auto* scope = param_scope();
+    auto* weight = scope->FindVar(w->Name())->GetMutable<LoDTensor>();
+    auto place = weight->place();
+    auto weight_data = weight->data<float>();
+    auto weight_dims = weight->dims();
+    int weight_num = product(weight_dims);
+    int w_h = weight_dims[0];
+    int w_w = weight_dims[1];
+    if (platform::is_cpu_place(place)) {
+      if (w_h % 128 == 0 && w_w % 128 == 0) {
+        float* weight_data_tmp = new float[weight_num];
+        for (int i = 0; i < w_h; i++) {
+          memcpy(weight_data_tmp + i * w_w, weight_data + i * w_w,
+                 w_w * sizeof(float));
+        }
+        weight->Resize(DDim{weight_dims[0] + 4, weight_dims[1] + 4});
+        auto weight_data_new =
+            weight->mutable_data<float>(platform::CPUPlace());
+        for (int i = 0; i < w_h; i++) {
+          memcpy(weight_data_new + i * (w_w + 4), weight_data_tmp + i * w_w,
+                 w_w * sizeof(float));
+        }
+        delete[] weight_data_tmp;
+        desc.SetAttr("padding_weights", true);
+      }
+    }
+
     // For anakin subgraph int8
     // When in anakin subgraph int8 mode, the pattern like "fake_quant + mul +
     // fake_dequant" can be detected by the quant_dequant_fuse_pass. This pass

--- a/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
@@ -21,6 +21,24 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+void AddVarToScope(Scope* param_scope, const std::string& name,
+                   const DDim& dims) {
+  auto* tensor = param_scope->Var(name)->GetMutable<LoDTensor>();
+  tensor->Resize(dims);
+  tensor->mutable_data<float>(platform::CPUPlace());
+}
+
+Scope* CreateParamScope() {
+  auto param_scope = new Scope();
+  AddVarToScope(param_scope, "conv2d_filters_0", {});
+  AddVarToScope(param_scope, "conv2d_bias_0", {});
+  AddVarToScope(param_scope, "weights_0", {});
+  AddVarToScope(param_scope, "weights_1", {});
+  AddVarToScope(param_scope, "bias_1", {});
+  AddVarToScope(param_scope, "bias_2", {});
+  return param_scope;
+}
+
 TEST(FCFusePass, basic) {
   // inputs                     operator            output
   // --------------------------------------------------------
@@ -49,6 +67,7 @@ TEST(FCFusePass, basic) {
   VLOG(4) << add_out_1;
 
   std::unique_ptr<ir::Graph> graph(new ir::Graph(layers.main_program()));
+  graph->Set("__param_scope__", CreateParamScope());
   auto pass = PassRegistry::Instance().Get("fc_fuse_pass");
   int num_nodes_before = graph->Nodes().size();
   int num_mul_nodes_before = GetNumOpNodes(graph, "mul");

--- a/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
@@ -68,7 +68,7 @@ TEST(FCFusePass, basic) {
 
   std::unique_ptr<ir::Graph> graph(new ir::Graph(layers.main_program()));
   auto pass = PassRegistry::Instance().Get("fc_fuse_pass");
-  pass->Set("use_gpu", new bool(false));
+  pass->Set("use_gpu", new bool(true));
   graph->Set("__param_scope__", CreateParamScope());
   int num_nodes_before = graph->Nodes().size();
   int num_mul_nodes_before = GetNumOpNodes(graph, "mul");

--- a/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass_tester.cc
@@ -67,8 +67,9 @@ TEST(FCFusePass, basic) {
   VLOG(4) << add_out_1;
 
   std::unique_ptr<ir::Graph> graph(new ir::Graph(layers.main_program()));
-  graph->Set("__param_scope__", CreateParamScope());
   auto pass = PassRegistry::Instance().Get("fc_fuse_pass");
+  pass->Set("use_gpu", new bool(false));
+  graph->Set("__param_scope__", CreateParamScope());
   int num_nodes_before = graph->Nodes().size();
   int num_mul_nodes_before = GetNumOpNodes(graph, "mul");
   VLOG(3) << DebugString(graph);

--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -147,6 +147,9 @@ void IRPassManager::CreatePasses(Argument *argument,
       pass->Set("auto_config_layout",
                 new bool(argument->anakin_auto_config_layout()));
     }
+    if (pass_name == "fc_fuse_pass") {
+      pass->Set("use_gpu", new bool(argument->use_gpu()));
+    }
 
     pre_pass = pass_name;
 

--- a/paddle/fluid/inference/tests/api/analyzer_bert_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_bert_tester.cc
@@ -153,7 +153,6 @@ void profile(bool use_mkldnn = false, bool use_ngraph = false) {
 
   if (use_mkldnn) {
     config.EnableMKLDNN();
-    config.pass_builder()->AppendPass("fc_mkldnn_pass");
   }
 
   if (use_ngraph) {
@@ -193,7 +192,6 @@ void compare(bool use_mkldnn = false, bool use_ngraph = false) {
   SetConfig(&cfg);
   if (use_mkldnn) {
     cfg.EnableMKLDNN();
-    cfg.pass_builder()->AppendPass("fc_mkldnn_pass");
   }
 
   if (use_ngraph) {

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -32,11 +32,11 @@ class FCOp : public framework::OperatorWithKernel {
 
     auto in_dims = ctx->GetInputDim("Input");
     auto w_dims = ctx->GetInputDim("W");
-    bool weight_pass = ctx->Attrs().Get<bool>("padding_weights");
+    bool padding_weights = ctx->Attrs().Get<bool>("padding_weights");
 
     if (ctx->HasInput("Bias")) {
       auto bias_dims = ctx->GetInputDim("Bias");
-      auto w_dims1 = weight_pass ? w_dims[1] - 4 : w_dims[1];
+      auto w_dims1 = padding_weights ? w_dims[1] - 4 : w_dims[1];
       if (bias_dims.size() == 2) {
         PADDLE_ENFORCE_EQ(bias_dims[0], 1,
                           platform::errors::InvalidArgument(
@@ -81,7 +81,8 @@ class FCOp : public framework::OperatorWithKernel {
         "in_num_col_dims.");
 
     std::vector<int64_t> output_dims;
-    FCOutputSize(in_dims, w_dims, output_dims, in_num_col_dims, weight_pass);
+    FCOutputSize(in_dims, w_dims, output_dims, in_num_col_dims,
+                 padding_weights);
 
     ctx->SetOutputDim("Out", framework::make_ddim(output_dims));
     ctx->ShareLoD("Input", "Out");
@@ -124,7 +125,8 @@ class FCOpMaker : public framework::OpProtoAndCheckerMaker {
                   "(bool, default false) Only used in mkldnn kernel")
         .SetDefault(false);
     AddAttr<bool>("padding_weights",
-                  "(bool, default false) Only used when weight padding in pass")
+                  "(bool, default false) When weight padding is used in pass, "
+                  "'padding_weights' attribute is true.")
         .SetDefault(false);
     AddAttr<bool>(framework::kAllKernelsMustComputeRuntimeShape,
                   "Skip calling InferShape() function in the runtime.")

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -40,16 +40,25 @@ class FCOp : public framework::OperatorWithKernel {
       if (bias_dims.size() == 2) {
         PADDLE_ENFORCE_EQ(bias_dims[0], 1,
                           platform::errors::InvalidArgument(
-                              "The shape of Bias should be [1, dim]."));
+                              "The shape of Bias is invalid."
+                              "The height of Bias should be 1."
+                              "But reveived height of Bias is %d.",
+                              bias_dims[0]));
         PADDLE_ENFORCE_EQ(
             bias_dims[1], w_dims1,
             platform::errors::InvalidArgument(
-                "The width of Bias should be equal to width of Weight."));
+                "The shape of Bias is invalid."
+                "The width of Bias should be equal to width of Weight."
+                "But reveived width of Bias is %d and width of Weight is %d.",
+                bias_dims[1], w_dims1));
       } else if (bias_dims.size() == 1) {
         PADDLE_ENFORCE_EQ(
             bias_dims[0], w_dims1,
             platform::errors::InvalidArgument(
-                "The shape of Bias should be equal to the width of weight."));
+                "The shape of Bias is invalid."
+                "The height of Bias should be equal to the width of weight."
+                "But reveived height of Bias is %d and width of Weight is %d.",
+                bias_dims[0], w_dims1));
       }
     }
 

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -42,14 +42,14 @@ class FCOp : public framework::OperatorWithKernel {
                           platform::errors::InvalidArgument(
                               "The shape of Bias is invalid."
                               "The height of Bias should be 1."
-                              "But reveived height of Bias is %d.",
+                              "But received height of Bias is %d.",
                               bias_dims[0]));
         PADDLE_ENFORCE_EQ(
             bias_dims[1], w_dims1,
             platform::errors::InvalidArgument(
                 "The shape of Bias is invalid."
                 "The width of Bias should be equal to width of Weight."
-                "But reveived width of Bias is %d and width of Weight is %d.",
+                "But received width of Bias is %d and width of Weight is %d.",
                 bias_dims[1], w_dims1));
       } else if (bias_dims.size() == 1) {
         PADDLE_ENFORCE_EQ(
@@ -57,7 +57,7 @@ class FCOp : public framework::OperatorWithKernel {
             platform::errors::InvalidArgument(
                 "The shape of Bias is invalid."
                 "The height of Bias should be equal to the width of weight."
-                "But reveived height of Bias is %d and width of Weight is %d.",
+                "But received height of Bias is %d and width of Weight is %d.",
                 bias_dims[0], w_dims1));
       }
     }

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -41,9 +41,10 @@ class FCOp : public framework::OperatorWithKernel {
         PADDLE_ENFORCE_EQ(bias_dims[0], 1,
                           platform::errors::InvalidArgument(
                               "The shape of Bias should be [1, dim]."));
-        PADDLE_ENFORCE_EQ(bias_dims[1], w_dims1,
-                          platform::errors::InvalidArgument(
-                              "The width of Bias should be equal to Weight."));
+        PADDLE_ENFORCE_EQ(
+            bias_dims[1], w_dims1,
+            platform::errors::InvalidArgument(
+                "The width of Bias should be equal to width of Weight."));
       } else if (bias_dims.size() == 1) {
         PADDLE_ENFORCE_EQ(
             bias_dims[0], w_dims1,
@@ -116,10 +117,6 @@ class FCOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("padding_weights",
                   "(bool, default false) Only used when weight padding in pass")
         .SetDefault(false);
-    AddAttr<bool>(
-        "use_gpu",
-        "(bool, default true) Guaranteed weight padding is used in cpu scope")
-        .SetDefault(true);
     AddAttr<bool>(framework::kAllKernelsMustComputeRuntimeShape,
                   "Skip calling InferShape() function in the runtime.")
         .SetDefault(true);

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -36,26 +36,19 @@ class FCOp : public framework::OperatorWithKernel {
 
     if (ctx->HasInput("Bias")) {
       auto bias_dims = ctx->GetInputDim("Bias");
-      if (weight_pass) {
-        if (bias_dims.size() == 2) {
-          PADDLE_ENFORCE_EQ(bias_dims[0], 1,
-                            "The shape of Bias must be [1, dim].");
-          PADDLE_ENFORCE_EQ(bias_dims[1], w_dims[1] - 4,
-                            "The shape of Bias must be [1, dim].");
-        } else if (bias_dims.size() == 1) {
-          PADDLE_ENFORCE_EQ(bias_dims[0], w_dims[1] - 4,
-                            "The shape of Bias must be [1, dim].");
-        }
-      } else {
-        if (bias_dims.size() == 2) {
-          PADDLE_ENFORCE_EQ(bias_dims[0], 1,
-                            "The shape of Bias must be [1, dim].");
-          PADDLE_ENFORCE_EQ(bias_dims[1], w_dims[1],
-                            "The shape of Bias must be [1, dim].");
-        } else if (bias_dims.size() == 1) {
-          PADDLE_ENFORCE_EQ(bias_dims[0], w_dims[1],
-                            "The shape of Bias must be [1, dim].");
-        }
+      auto w_dims1 = weight_pass ? w_dims[1] - 4 : w_dims[1];
+      if (bias_dims.size() == 2) {
+        PADDLE_ENFORCE_EQ(bias_dims[0], 1,
+                          platform::errors::InvalidArgument(
+                              "The shape of Bias should be [1, dim]."));
+        PADDLE_ENFORCE_EQ(bias_dims[1], w_dims1,
+                          platform::errors::InvalidArgument(
+                              "The width of Bias should be equal to Weight."));
+      } else if (bias_dims.size() == 1) {
+        PADDLE_ENFORCE_EQ(
+            bias_dims[0], w_dims1,
+            platform::errors::InvalidArgument(
+                "The shape of Bias should be equal to the width of weight."));
       }
     }
 
@@ -123,6 +116,10 @@ class FCOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("padding_weights",
                   "(bool, default false) Only used when weight padding in pass")
         .SetDefault(false);
+    AddAttr<bool>(
+        "use_gpu",
+        "(bool, default true) Guaranteed weight padding is used in cpu scope")
+        .SetDefault(true);
     AddAttr<bool>(framework::kAllKernelsMustComputeRuntimeShape,
                   "Skip calling InferShape() function in the runtime.")
         .SetDefault(true);

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -124,9 +124,10 @@ class FCOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("use_mkldnn",
                   "(bool, default false) Only used in mkldnn kernel")
         .SetDefault(false);
-    AddAttr<bool>("padding_weights",
-                  "(bool, default false) When weight padding is used in pass, "
-                  "'padding_weights' attribute is true.")
+    AddAttr<bool>(
+        "padding_weights",
+        "(bool, default false) When padding weights in the fc fuse pass, "
+        "the 'padding_weights' attribute is set as true.")
         .SetDefault(false);
     AddAttr<bool>(framework::kAllKernelsMustComputeRuntimeShape,
                   "Skip calling InferShape() function in the runtime.")

--- a/paddle/fluid/operators/fc_op.h
+++ b/paddle/fluid/operators/fc_op.h
@@ -31,10 +31,11 @@ inline void FCOutputSize(const framework::DDim& in_dims,
   auto in_mat_dims = framework::flatten_to_2d(in_dims, in_num_col_dims);
   auto w_dims0 = weight_pass ? w_dims[0] - 4 : w_dims[0];
   auto w_dims1 = weight_pass ? w_dims[1] - 4 : w_dims[1];
-  PADDLE_ENFORCE_EQ(
-      in_mat_dims[1], w_dims0,
-      platform::errors::InvalidArgument(
-          "Fully Connected input and weigth size do not match. %s, %s"));
+  PADDLE_ENFORCE_EQ(in_mat_dims[1], w_dims0,
+                    platform::errors::InvalidArgument(
+                        "Fully Connected input and weigth size do not match. "
+                        "input width: %d,weight height: %d",
+                        in_mat_dims[1], w_dims0));
 
   out_dims.reserve(static_cast<size_t>(in_num_col_dims + 1));
   for (int i = 0; i < in_num_col_dims; ++i) {

--- a/paddle/fluid/operators/math/fc.cc
+++ b/paddle/fluid/operators/math/fc.cc
@@ -25,9 +25,28 @@ class FCFunctor<platform::CPUDeviceContext, T> {
  public:
   void operator()(const platform::CPUDeviceContext& context, const int M,
                   const int N, const int K, const T* X, const T* W, T* Y,
-                  const T* B = nullptr, bool relu = false) {
+                  const T* B = nullptr, bool relu = false,
+                  bool weight_pass = false) {
     auto blas = math::GetBlas<platform::CPUDeviceContext, T>(context);
-    blas.MatMul(M, N, K, X, W, Y);
+    framework::Tensor X1, Y1;
+    X1.Resize({M * (K + 4)});
+    T* X1_data = X1.mutable_data<T>(platform::CPUPlace());
+    Y1.Resize({M * (N + 4)});
+    T* Y1_data = Y1.mutable_data<T>(platform::CPUPlace());
+    if (weight_pass) {
+      const int NN = N + 4;
+      const int KK = K + 4;
+#ifdef PADDLE_WITH_MKLML
+#pragma omp parallel for
+#endif
+      for (int i = 0; i < M; i++) {
+        memcpy(X1_data + i * KK, X + i * K, K * sizeof(X[0]));
+      }
+      blas.GEMM(false, false, M, N, K, static_cast<T>(1.0), X1_data, KK, W, NN,
+                static_cast<T>(0.0), Y1_data, NN);
+    } else {
+      blas.MatMul(M, N, K, X, W, Y);
+    }
     if (B == NULL) {
       return;
     }
@@ -37,7 +56,12 @@ class FCFunctor<platform::CPUDeviceContext, T> {
               .At(N);
       for (int i = 0; i < M; i++) {
         T* dst = Y + i * N;
-        compute(B, dst, dst, N);
+        T* src = nullptr;
+        if (weight_pass)
+          src = Y1_data + i * (N + 4);
+        else
+          src = dst;
+        compute(B, src, dst, N);
       }
     } else {
       auto compute =
@@ -48,7 +72,12 @@ class FCFunctor<platform::CPUDeviceContext, T> {
 #endif
       for (int i = 0; i < M; i++) {
         T* dst = Y + i * N;
-        compute(B, dst, dst, N);
+        T* src = nullptr;
+        if (weight_pass)
+          src = Y1_data + i * (N + 4);
+        else
+          src = dst;
+        compute(B, src, dst, N);
       }
     }
   }

--- a/paddle/fluid/operators/math/fc.cu
+++ b/paddle/fluid/operators/math/fc.cu
@@ -41,7 +41,12 @@ class FCFunctor<platform::CUDADeviceContext, T> {
  public:
   void operator()(const platform::CUDADeviceContext& context, const int M,
                   const int N, const int K, const T* X, const T* W, T* Y,
-                  const T* B = nullptr, bool relu = false) {
+                  const T* B = nullptr, bool relu = false,
+                  bool weight_padding = false) {
+    PADDLE_ENFORCE_EQ(
+        weight_padding, false,
+        platform::errors::PermissionDenied(
+            "Weight padding in fc can not be used in GPU scope."));
     auto blas = math::GetBlas<platform::CUDADeviceContext, T>(context);
     blas.GEMM(false, false, M, N, K, static_cast<T>(1.0), X, K, W, N,
               static_cast<T>(0.0), Y, N);

--- a/paddle/fluid/operators/math/fc.cu
+++ b/paddle/fluid/operators/math/fc.cu
@@ -42,9 +42,9 @@ class FCFunctor<platform::CUDADeviceContext, T> {
   void operator()(const platform::CUDADeviceContext& context, const int M,
                   const int N, const int K, const T* X, const T* W, T* Y,
                   const T* B = nullptr, bool relu = false,
-                  bool weight_padding = false) {
+                  bool padding_weights = false) {
     PADDLE_ENFORCE_EQ(
-        weight_padding, false,
+        padding_weights, false,
         platform::errors::PermissionDenied(
             "Weight padding in fc can not be used in GPU scope."));
     auto blas = math::GetBlas<platform::CUDADeviceContext, T>(context);

--- a/paddle/fluid/operators/math/fc.h
+++ b/paddle/fluid/operators/math/fc.h
@@ -26,7 +26,8 @@ class FCFunctor {
  public:
   void operator()(const DeviceContext& context, const int M, const int N,
                   const int K, const T* X, const T* W, T* Y,
-                  const T* B = nullptr, bool relu = false);
+                  const T* B = nullptr, bool relu = false,
+                  bool weight_pass = false);
 };
 
 }  // namespace math

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -207,10 +207,13 @@ class FCPrimitiveFactory {
   void RecomputeOutputDims(const ExecutionContext& ctx, const LoDTensor* input,
                            const Tensor* w, LoDTensor* output) {
     int in_num_col_dims = ctx.Attr<int>("in_num_col_dims");
-    bool weight_pass = ctx.Attr<bool>("padding_weights");
+    bool padding_weights = ctx.Attr<bool>("padding_weights");
+    PADDLE_ENFORCE_EQ(padding_weights, false,
+                      platform::errors::PermissionDenied(
+                          "Weight padding in fc can not be used in MKLDNN."));
     std::vector<int64_t> output_dims;
     FCOutputSize(input->dims(), w->dims(), output_dims, in_num_col_dims,
-                 weight_pass);
+                 padding_weights);
     output->Resize(framework::make_ddim(output_dims));
     output->set_lod(input->lod());
   }

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -207,8 +207,10 @@ class FCPrimitiveFactory {
   void RecomputeOutputDims(const ExecutionContext& ctx, const LoDTensor* input,
                            const Tensor* w, LoDTensor* output) {
     int in_num_col_dims = ctx.Attr<int>("in_num_col_dims");
+    bool weight_pass = ctx.Attr<bool>("padding_weights");
     std::vector<int64_t> output_dims;
-    FCOutputSize(input->dims(), w->dims(), output_dims, in_num_col_dims);
+    FCOutputSize(input->dims(), w->dims(), output_dims, in_num_col_dims,
+                 weight_pass);
     output->Resize(framework::make_ddim(output_dims));
     output->set_lod(input->lod());
   }

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -72,14 +72,14 @@ class TestFCOp(OpTest):
             activation_type = "relu"
         else:
             activation_type = ""
-        self.attrs = {'use_mkldnn': False, 'activation_type': activation_type}
+        self.attrs = {
+            'use_mkldnn': False,
+            'activation_type': activation_type,
+        }
 
         self.outputs = {
             'Out': fc_refer(self.matrix, self.with_bias, self.with_relu)
         }
-
-    def padding(self):
-        self.attrs = {'padding_weights': False}
 
     def test_check_output(self):
         self.check_output()
@@ -132,16 +132,6 @@ class TestFCOpWithPadding(TestFCOp):
         self.with_bias = True
         self.with_relu = True
         self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
-
-
-class TestFCOpWithPadding2(TestFCOp):
-    def config(self):
-        self.with_bias = True
-        self.with_relu = True
-        self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
-
-    def padding(self):
-        self.attrs = {'padding_weights': True}
 
 
 class TestFCOpError(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -78,6 +78,9 @@ class TestFCOp(OpTest):
             'Out': fc_refer(self.matrix, self.with_bias, self.with_relu)
         }
 
+    def padding(self):
+        self.attrs = {'padding_weights': False}
+
     def test_check_output(self):
         self.check_output()
 
@@ -122,6 +125,23 @@ class TestFCOpWithBias3(TestFCOp):
         self.with_bias = True
         self.with_relu = True
         self.matrix = MatrixGenerate(1, 64, 32, 3, 3, 1)
+
+
+class TestFCOpWithPadding(TestFCOp):
+    def config(self):
+        self.with_bias = True
+        self.with_relu = True
+        self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
+
+
+class TestFCOpWithPadding2(TestFCOp):
+    def config(self):
+        self.with_bias = True
+        self.with_relu = True
+        self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
+
+    def padding(self):
+        self.attrs = {'padding_weights': True}
 
 
 class TestFCOpError(OpTest):

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -72,10 +72,7 @@ class TestFCOp(OpTest):
             activation_type = "relu"
         else:
             activation_type = ""
-        self.attrs = {
-            'use_mkldnn': False,
-            'activation_type': activation_type,
-        }
+        self.attrs = {'use_mkldnn': False, 'activation_type': activation_type}
 
         self.outputs = {
             'Out': fc_refer(self.matrix, self.with_bias, self.with_relu)


### PR DESCRIPTION
当使用MKL计算的矩阵的尺寸是128的倍数时，内存存取的时间会大大增加。
优化方案是内存尺寸为128的倍数时，做尺寸加4的padding。内存调用的时间会减少。
[Intel MKL内存调用分析](https://software.intel.com/en-us/articles/a-simple-example-to-measure-the-performance-of-an-intel-mkl-function)

预测模型ERNIE padding优化前后性能对比：

|线程数 | 优化前 | 优化后 |提升|
|---|---|---|---|
| 单线程| 276.253 ms | 251.464ms | 8.97%|
| 20线程| 52.1854ms| 29.9978ms |42.52%| 

经过测试，需要同时对FC计算中的W和X同时做Padding，才有较好的性能提升。

|线程数 | 优化前 | 只padding w 不padding x |只padding x 不padding w |
|---|---|---|---|
| 20线程| 52.1854ms| 53.2533ms |50.9526ms| 