### PR TITLE
Polish error messages of pool_2d/3d and add Raises in English document

### DIFF
--- a/paddle/fluid/operators/pool_op.h
+++ b/paddle/fluid/operators/pool_op.h
@@ -66,7 +66,7 @@ inline void UpdatePadding(std::vector<int>* paddings, const bool global_pooling,
   // set padding size == data_dims.size() * 2
   auto data_shape = framework::vectorize<int>(data_dims);
   if (paddings->size() == data_dims.size()) {
-    for (size_t i = 0; i < data_dims.size(); ++i) {
+    for (int i = 0; i < data_dims.size(); ++i) {
       int copy_pad = *(paddings->begin() + 2 * i);
       paddings->insert(paddings->begin() + 2 * i + 1, copy_pad);
     }
@@ -78,7 +78,7 @@ inline void UpdatePadding(std::vector<int>* paddings, const bool global_pooling,
 
   // when padding_desc is "VALID" or "SAME"
   if (padding_algorithm == "SAME") {
-    for (size_t i = 0; i < data_dims.size(); ++i) {
+    for (int i = 0; i < data_dims.size(); ++i) {
       int out_size = (data_dims[i] + strides[i] - 1) / strides[0];
       int pad_sum =
           std::max((out_size - 1) * strides[i] + ksize[i] - data_shape[i], 0);

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -3458,9 +3458,18 @@ def pool2d(input,
         Variable: The output tensor of pooling result. The data type is same as input tensor.
 
     Raises:
-        ValueError: If `pool_type` is not "max" nor "avg"
-        ValueError: If `global_pooling` is False and `pool_size` is -1
-        ValueError: If `use_cudnn` is not a bool value.
+        ValueError: If `pool_type` is not "max" nor "avg".
+        ValueError: If `global_pooling` is False and `pool_size` is -1.
+        TypeError: If `use_cudnn` is not a bool value.
+        ValueError: If `data_format` is not "NCHW" or "NHWC".
+        ValueError: If `pool_padding` is a string, but not "SAME" or "VALID".
+        ValueError: If `pool_padding` is "VALID", but `ceil_mode` is True.
+        ValueError: If `pool_padding` is a list or tuple, but the elements in the batch or channel dimensions are non-zero.
+        ShapeError: If the input is not a 4-D or 5-D Tensor.
+        ShapeError: If the dimension of input minus the size of `pool_stride` is not 2.
+        ShapeError: If the size of `pool_size` and `pool_stride` is not equal.
+        ShapeError: If the output's shape calculated is not greater than 0.
+
 
     Examples:
 
@@ -3523,8 +3532,8 @@ def pool2d(input,
             "and be a valid value. Received pool_size: %s." % str(pool_size))
 
     if not isinstance(use_cudnn, bool):
-        raise ValueError("Attr(use_cudnn) should be True or False. Received "
-                         "Attr(use_cudnn): %s." % str(use_cudnn))
+        raise TypeError("Attr(use_cudnn) should be True or False. Received "
+                        "Attr(use_cudnn): %s." % str(use_cudnn))
 
     if data_format not in ["NCHW", "NHWC"]:
         raise ValueError(
@@ -3663,6 +3672,19 @@ def pool3d(input,
     Returns:
         Variable: The output tensor of pooling result. The data type is same as input tensor.
 
+    Raises:
+        ValueError: If `pool_type` is not "max" nor "avg".
+        ValueError: If `global_pooling` is False and `pool_size` is -1.
+        TypeError: If `use_cudnn` is not a bool value.
+        ValueError: If `data_format` is not "NCDHW" or "NDHWC".
+        ValueError: If `pool_padding` is a string, but not "SAME" or "VALID".
+        ValueError: If `pool_padding` is "VALID", but `ceil_mode` is True.
+        ValueError: If `pool_padding` is a list or tuple, but the elements in the batch or channel dimensions are non-zero.
+        ShapeError: If the input is not a 4-D or 5-D Tensor.
+        ShapeError: If the dimension of input minus the size of `pool_stride` is not 2.
+        ShapeError: If the size of `pool_size` and `pool_stride` is not equal.
+        ShapeError: If the output's shape calculated is not greater than 0.
+
     Examples:
 
         .. code-block:: python
@@ -3730,8 +3752,8 @@ def pool3d(input,
             str(pool_size))
 
     if not isinstance(use_cudnn, bool):
-        raise ValueError("Attr(use_cudnn) should be True or False. Received "
-                         "Attr(use_cudnn): %s. " % str(use_cudnn))
+        raise TypeError("Attr(use_cudnn) should be True or False. Received "
+                        "Attr(use_cudnn): %s. " % str(use_cudnn))
 
     if data_format not in ["NCDHW", "NDHWC"]:
         raise ValueError(

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -1179,7 +1179,7 @@ class TestPool2dAPI_Error(OpTest):
             dtype="float32")
         ksize = [3, 3]
 
-        # cudnn value error
+        # cudnn type error
         def run_1():
             out_1 = fluid.layers.pool2d(
                 input=input_NHWC,
@@ -1189,7 +1189,7 @@ class TestPool2dAPI_Error(OpTest):
                 use_cudnn=[0],
                 data_format="NHWC")
 
-        self.assertRaises(ValueError, run_1)
+        self.assertRaises(TypeError, run_1)
 
         # data_format value error
         def run_2():

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -1086,7 +1086,7 @@ class TestPool3dAPI_Error(OpTest):
             dtype="float32")
         ksize = [3, 3, 3]
 
-        # cudnn value error
+        # cudnn type error
         def run_1():
             out_1 = fluid.layers.pool3d(
                 input=input_NDHWC,
@@ -1096,7 +1096,7 @@ class TestPool3dAPI_Error(OpTest):
                 use_cudnn=[0],
                 data_format="NDHWC")
 
-        self.assertRaises(ValueError, run_1)
+        self.assertRaises(TypeError, run_1)
 
         # data_format value error
         def run_2():


### PR DESCRIPTION
- 1. pool2d pool3d op增强维度类报错信息。
- 2. pool2d pool3d 英文文档中增加异常报错。
中文文档已修改 https://github.com/PaddlePaddle/FluidDoc/pull/1587
--- 
## 1. pool2d pool3d op增强维度类报错信息
**以pool3d为例**
```
import paddle.fluid as fluid
data = fluid.data(name='data', shape=[None, 3, 32, 32, 32], dtype='float32')
pool3d = fluid.layers.pool3d(
            input = data,
            pool_size = [2,2,2],
            pool_type = "max",
            pool_stride = [1,1,1],
            global_pooling=False)
```

#### 1. input 不是4-D 或 5-D
```
data = fluid.data(name='data', shape=[3, 32, 32], dtype='float32')
```
- 修改前报错
> Pooling intput should be 4-D or 5-D tensor.

- 修改后报错
> ShapeError: the input of Op(pool) should be 4-D or 5-D Tensor. But received: 3-D Tensor and it's shape is [3, 32, 32]
![image](https://user-images.githubusercontent.com/33742067/68198940-ff7e8f00-fff7-11e9-80be-d0f612e0cbcc.png)
 
#### 2. 输入维度应该比参数 `pool_ksize`的size大2
```
data = fluid.data(name='data', shape=[None, 3, 32, 32], dtype='float32')
```

- 修改前报错：
> Input size and pooling size should be consistent.

- 修改后报错：
> ShapeError: the dimension of input minus the size of Attr(ksize) must be euqal to 2 in Op(pool). But received: the dimension of input minus the size of Attr(ksize) is 1, the input's dimension is 4, the shape of input is [-1, 3, 32, 32], the Attr(ksize)'s size is 3, the Attr(ksize) is [2, 2, 2].

#### 3.  `strides` 和 `ksize` 的元素数目不相等
- 修改前报错：
> Strides size and pooling size should be the same.

- 修改后报错：
> ShapeError: the size of Attr(ksize) and Attr(strides) in Op(pool) must be equal. But received: Attr(ksize)'s size is 3, Attr(strides)'s size is 2, Attr(ksize) is [3, 3, 3], Attr(strides)is [1, 1].

#### 4. 计算出的输出值不大于0

- 修改前报错：
>Due to the settings of padding(0,0), filter_size(40) and stride(2), the output size is not greater than 0, please check again. Input_size:32.

- 修改后报错
> ShapeError: the output size must be greater than 0. But received: output_size = -3 due to the settings of input_size(32), padding(0,0), k_size(40) and stride(2). Please check again!

## 2. pool2d pool3d 英文文档中增加异常报错。
- pool2d
![image](https://user-images.githubusercontent.com/33742067/68203621-255c6180-0001-11ea-9fd9-7b73f84c2afd.png)

- pool3d
![image](https://user-images.githubusercontent.com/33742067/68203670-4624b700-0001-11ea-92e2-f49b66aaacc5.png)

