### PR TITLE
Refine Tensor method

### DIFF
--- a/paddle/fluid/framework/selected_rows.h
+++ b/paddle/fluid/framework/selected_rows.h
@@ -58,7 +58,7 @@ class SelectedRows {
     rwlock_.reset(new RWLock);
   }
 
-  platform::Place place() const { return value_->place(); }
+  const platform::Place& place() const { return value_->place(); }
 
   const Tensor& value() const { return *value_; }
 

--- a/paddle/fluid/framework/tensor.cc
+++ b/paddle/fluid/framework/tensor.cc
@@ -34,8 +34,8 @@ size_t Tensor::memory_size() const {
   return holder_ == nullptr ? 0UL : holder_->size() - offset_;
 }
 
-void* Tensor::mutable_data(platform::Place place, proto::VarType::Type type,
-                           size_t requested_size) {
+void* Tensor::mutable_data(const platform::Place& place,
+                           proto::VarType::Type type, size_t requested_size) {
   type_ = type;
   PADDLE_ENFORCE_GE(numel(), 0,
                     "When calling this method, the Tensor's numel must be "
@@ -60,7 +60,8 @@ void* Tensor::mutable_data(platform::Place place, proto::VarType::Type type,
                                  offset_);
 }
 
-void* Tensor::mutable_data(platform::Place place, size_t requested_size) {
+void* Tensor::mutable_data(const platform::Place& place,
+                           size_t requested_size) {
   PADDLE_ENFORCE_NOT_NULL(
       this->holder_, "Cannot invoke mutable data if current hold nothing.");
   return mutable_data(place, type_, requested_size);

--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -87,12 +87,12 @@ class Tensor {
    * @note    If not exist, then allocation.
    */
   template <typename T>
-  T* mutable_data(platform::Place place, size_t requested_size = 0);
+  T* mutable_data(const platform::Place& place, size_t requested_size = 0);
 
-  void* mutable_data(platform::Place place, proto::VarType::Type type,
+  void* mutable_data(const platform::Place& place, proto::VarType::Type type,
                      size_t requested_size = 0);
 
-  void* mutable_data(platform::Place place, size_t requested_size = 0);
+  void* mutable_data(const platform::Place& place, size_t requested_size = 0);
 
   /**
    * @brief     Return a pointer to mutable memory block.
@@ -104,7 +104,8 @@ class Tensor {
    * @note      If not exist, then allocation.
    */
   template <typename T>
-  T* mutable_data(DDim dims, platform::Place place, size_t requested_size = 0);
+  T* mutable_data(const DDim& dims, const platform::Place& place,
+                  size_t requested_size = 0);
 
   /*! Return the dimensions of the memory block. */
   const DDim& dims() const;
@@ -128,7 +129,7 @@ class Tensor {
    */
   Tensor Slice(int64_t begin_idx, int64_t end_idx) const;
 
-  platform::Place place() const {
+  const platform::Place& place() const {
     PADDLE_ENFORCE_NOT_NULL(
         holder_, "Tensor not initialized yet when Tensor::place() is called.");
     return holder_->place();

--- a/paddle/fluid/framework/tensor_impl.h
+++ b/paddle/fluid/framework/tensor_impl.h
@@ -48,7 +48,7 @@ inline T* Tensor::data() {
 }
 
 template <typename T>
-inline T* Tensor::mutable_data(DDim dims, platform::Place place,
+inline T* Tensor::mutable_data(const DDim& dims, const platform::Place& place,
                                size_t requested_size) {
   static_assert(std::is_pod<T>::value, "T must be POD");
   Resize(dims);
@@ -56,7 +56,8 @@ inline T* Tensor::mutable_data(DDim dims, platform::Place place,
 }
 
 template <typename T>
-inline T* Tensor::mutable_data(platform::Place place, size_t requested_size) {
+inline T* Tensor::mutable_data(const platform::Place& place,
+                               size_t requested_size) {
   static_assert(std::is_pod<T>::value, "T must be POD");
   return reinterpret_cast<T*>(
       mutable_data(place, DataTypeTrait<T>::DataType(), requested_size));


### PR DESCRIPTION
Change the parameter of some methods in Tensor to be reference instead of copy to avoid deep copy.