### PR TITLE
[cherry-pick] fix squared_mat_sub_fuse_pass bug when elementwise_op input is persistable param test=develop test=release/1.6

### DIFF
--- a/paddle/fluid/framework/ir/squared_mat_sub_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/squared_mat_sub_fuse_pass.cc
@@ -240,7 +240,8 @@ PDNode* BuildSquaredMatSubPattern(PDPattern* pattern,
       return false;
     }
     for (auto* in : x->inputs) {
-      if (in && in->inputs[0] && is_fusion_sub_op(in->inputs[0])) {
+      if (in && in->inputs.size() > 0 && in->inputs[0] &&
+          is_fusion_sub_op(in->inputs[0])) {
         return true;
       }
     }
@@ -262,7 +263,7 @@ PDNode* BuildSquaredMatSubPattern(PDPattern* pattern,
   auto* constant_op_out = pattern->NewNode(
       [=](Node* x) {
         return x && x->IsVar() && var_is_op_input(x, "elementwise_mul") &&
-               x->inputs[0] && x->inputs[0]->IsOp() &&
+               x->inputs.size() > 0 && x->inputs[0] && x->inputs[0]->IsOp() &&
                x->inputs[0]->Op()->Type() == "fill_constant" && x->outputs[0] &&
                is_fusion_element_op(x->outputs[0]);
       },


### PR DESCRIPTION
[cherry-pick] https://github.com/PaddlePaddle/Paddle/pull/20960
当elementwise的输入来自权重的时候，squared_mat_sub_fuse_pass会直接core掉。
经检查发现，当输入来自权重时，该pass中部分node->input的size为0，此时访问node->input[0]会挂掉，该pr对此进行检查，修复错误。

