### PR TITLE
Fix distiller soft_label_loss typo and exception strategy

### DIFF
--- a/python/paddle/fluid/contrib/slim/core/compressor.py
+++ b/python/paddle/fluid/contrib/slim/core/compressor.py
@@ -585,6 +585,7 @@ class Compressor(object):
         ]:
             return None
         start = context.epoch_id
+        exception_catched = None
         for epoch in range(start, self.epoch):
             context.epoch_id = epoch
             try:
@@ -596,9 +597,12 @@ class Compressor(object):
                 self._save_checkpoint(context)
                 for strategy in self.strategies:
                     strategy.on_epoch_end(context)
-            except Exception:
+            except Exception as e:
+                exception_catched = e
                 _logger.error(traceback.print_exc())
                 continue
         for strategy in self.strategies:
             strategy.on_compression_end(context)
+        if exception_catched is not None:
+            raise RuntimeError(exception_catched)
         return context.eval_graph

--- a/python/paddle/fluid/contrib/slim/distillation/distiller.py
+++ b/python/paddle/fluid/contrib/slim/distillation/distiller.py
@@ -269,7 +269,7 @@ class SoftLabelDistillerPass(object):
             t_fea = layers.softmax(teacher_feature_map /
                                    self.teacher_temperature)
             t_fea.stop_gradient = True
-            ce_loss = layres.reduce_mean(
+            ce_loss = layers.reduce_mean(
                 layers.cross_entropy(
                     s_fea, t_fea, soft_label=True))
             distillation_loss = ce_loss * self.distillation_loss_weight


### PR DESCRIPTION
Before this PR, the slim unit test can't catch any `Compressor` internal exception, so it always returns `OK`.
<img width="1094" alt="before" src="https://user-images.githubusercontent.com/28884066/68285273-ec33f800-00b9-11ea-9739-0258f9949746.png">
After this PR:
<img width="1079" alt="after" src="https://user-images.githubusercontent.com/28884066/68285275-efc77f00-00b9-11ea-90f8-f20c668c2ae6.png">
