### PR TITLE
Fix dst memory allocation in elementwise_add

### DIFF
--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -43,7 +43,6 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
     auto* z = ctx.Output<Tensor>("Out");
     const T* x_data = x->data<T>();
     const T* y_data = y->data<T>();
-    T* z_data = z->mutable_data<T>(ctx.GetPlace());
 
     int axis = ctx.Attr<int>("axis");
 
@@ -92,6 +91,7 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
         _x.ShareDataWith(*x);
       }
 
+      z->mutable_data<T>(ctx.GetPlace());
       auto sum_func = [](T a, T b) -> T { return a + b; };
 
       TransformFunctor<decltype(sum_func), T,
@@ -154,6 +154,9 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
 
       auto sum_pd = handler.AcquireSumPrimitiveDescriptor(
           {src_x_memory, src_y_memory}, scales, dst_md);
+
+      T* z_data = z->mutable_data<T>(ctx.GetPlace(),
+                                     sum_pd->dst_primitive_desc().get_size());
 
       auto dst_memory = handler.AcquireDstMemoryFromPrimitive(z_data);
 


### PR DESCRIPTION
This patch temporarily fixes destination primitive memory allocation for 'elementwise_add' op. A final fix will be done by @jczaja and/or @grygielski with their gradual refactoring of the MKL-DNN-based operators.

(A fix for https://github.com/PaddlePaddle/Paddle/issues/20998)

test=develop