### PR TITLE
Add support for asymetric padding in MKLDNN pool, conv and conv_transpose

### DIFF
--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -213,12 +213,24 @@ inline std::string CreateKey(ArgTypes&&... args) {
 
 inline std::vector<std::vector<int>> ToMkldnnPadding(
     const std::vector<int>& paddings) {
-  int padding_top = paddings[0];
-  int padding_bottom = paddings[1];
-  int padding_left = paddings[2];
-  int padding_right = paddings[3];
+  if (paddings.size() == 6) {
+    int padding_front = paddings[0];
+    int padding_back = paddings[1];
+    int padding_top = paddings[2];
+    int padding_bottom = paddings[3];
+    int padding_left = paddings[4];
+    int padding_right = paddings[5];
 
-  return {{padding_top, padding_left}, {padding_bottom, padding_right}};
+    return {{padding_front, padding_top, padding_left},
+            {padding_back, padding_bottom, padding_right}};
+  } else {
+    int padding_top = paddings[0];
+    int padding_bottom = paddings[1];
+    int padding_left = paddings[2];
+    int padding_right = paddings[3];
+
+    return {{padding_top, padding_left}, {padding_bottom, padding_right}};
+  }
 }
 
 }  // namespace platform

--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -211,5 +211,15 @@ inline std::string CreateKey(ArgTypes&&... args) {
   return key;
 }
 
+inline std::vector<std::vector<int>> ToMkldnnPadding(
+    const std::vector<int>& paddings) {
+  int padding_top = paddings[0];
+  int padding_bottom = paddings[1];
+  int padding_left = paddings[2];
+  int padding_right = paddings[3];
+
+  return {{padding_top, padding_left}, {padding_bottom, padding_right}};
+}
+
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -1036,17 +1036,19 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
           dev_ctx_.GetBlob(key_conv_pd));
       if (conv_pd_ == nullptr) {
         mkldnn::memory::dims stride_dims = strides;
-        mkldnn::memory::dims padding_dims = paddings;
+
+        auto mkldnn_paddings = ToMkldnnPadding(paddings);
 
         auto conv_desc =
-            bias ? typename forward_t::desc(
-                       fwd_prop_kind, convolutional_algorithm<forward_t>::T,
-                       src, weights, *bias, dst, stride_dims, padding_dims,
-                       padding_dims, mkldnn::padding_kind::zero)
-                 : typename forward_t::desc(
-                       fwd_prop_kind, convolutional_algorithm<forward_t>::T,
-                       src, weights, dst, stride_dims, padding_dims,
-                       padding_dims, mkldnn::padding_kind::zero);
+            bias
+                ? typename forward_t::desc(
+                      fwd_prop_kind, convolutional_algorithm<forward_t>::T, src,
+                      weights, *bias, dst, stride_dims, mkldnn_paddings[0],
+                      mkldnn_paddings[1], mkldnn::padding_kind::zero)
+                : typename forward_t::desc(
+                      fwd_prop_kind, convolutional_algorithm<forward_t>::T, src,
+                      weights, dst, stride_dims, mkldnn_paddings[0],
+                      mkldnn_paddings[1], mkldnn::padding_kind::zero);
 
         mkldnn::primitive_attr conv_attr =
             CreatePostOps(fuse_activation, fuse_alpha, fuse_beta,

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -540,13 +540,12 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
     auto dst_md =
         platform::MKLDNNMemDesc(dst_dims, dt, MKLDNNMemoryFormat::any);
 
-    std::vector<int> padding_left_top(paddings);
-    std::vector<int> padding_right_bottom(paddings);
+    auto mkldnn_paddings = ToMkldnnPadding(paddings);
+
     if (ceil_mode) {
       CorrectOutputSize(src_dims, dst_dims, ksize, paddings, strides,
-                        padding_right_bottom);
+                        mkldnn_paddings[1]);
     }
-
     this->AcquireForwardPrimitiveDescriptor(
         is_test ? mkldnn::prop_kind::forward_inference
                 : mkldnn::prop_kind::forward_training,
@@ -555,7 +554,7 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
             : (exclude_padding
                    ? mkldnn::algorithm::pooling_avg_exclude_padding
                    : mkldnn::algorithm::pooling_avg_include_padding),
-        src_md, dst_md, strides, ksize, padding_left_top, padding_right_bottom,
+        src_md, dst_md, strides, ksize, mkldnn_paddings[0], mkldnn_paddings[1],
         mkldnn::padding_kind::zero);
   }
 
@@ -578,14 +577,16 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
         mkldnn::memory::desc(diff_src_dims, platform::MKLDNNGetDataType<T>(),
                              MKLDNNMemoryFormat::any);
 
+    auto mkldnn_paddings = ToMkldnnPadding(paddings);
+
     this->AcquireBackwardPrimitiveDescriptor(
         pooling_type == "max"
             ? mkldnn::algorithm::pooling_max
             : (exclude_padding
                    ? mkldnn::algorithm::pooling_avg_exclude_padding
                    : mkldnn::algorithm::pooling_avg_include_padding),
-        diff_src_md, diff_dst_md, strides, ksize, paddings, paddings,
-        mkldnn::padding_kind::zero);
+        diff_src_md, diff_dst_md, strides, ksize, mkldnn_paddings[0],
+        mkldnn_paddings[1], mkldnn::padding_kind::zero);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireWorkspaceMemory(void) {

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
@@ -343,5 +343,27 @@ create_test_int8_class(TestWithGroup)
 create_test_int8_class(TestWith1x1)
 create_test_int8_class(TestWithInput1x1Filter1x1)
 
+
+class TestConv2dOp_AsyPadding_INT_MKLDNN(TestConv2dInt8Op):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
+    def init_paddings(self):
+        self.pad = [0, 0, 1, 2]
+        self.padding_algorithm = "EXPLICIT"
+
+
+class TestConv2dOp_Same_INT_MKLDNN(TestConv2dOp_AsyPadding_INT_MKLDNN):
+    def init_paddings(self):
+        self.pad = [0, 0]
+        self.padding_algorithm = "SAME"
+
+
+class TestConv2dOp_Valid_INT_MKLDNN(TestConv2dOp_AsyPadding_INT_MKLDNN):
+    def init_paddings(self):
+        self.pad = [1, 1]
+        self.padding_algorithm = "VALID"
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -19,7 +19,7 @@ import numpy as np
 
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest
-from paddle.fluid.tests.unittests.test_conv2d_op import TestConv2dOp
+from paddle.fluid.tests.unittests.test_conv2d_op import TestConv2dOp, TestConv2dOp_v2
 
 
 def conv2d_bias_naive(out, bias):
@@ -174,6 +174,27 @@ class TestWithInput1x1Filter1x1(TestConv2dMKLDNNOp):
 
     def init_group(self):
         self.groups = 3
+
+
+class TestConv2dOp_AsyPadding_MKLDNN(TestConv2dOp_v2):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
+    def init_paddings(self):
+        self.pad = [0, 0, 1, 2]
+        self.padding_algorithm = "EXPLICIT"
+
+
+class TestConv2dOp_Same_MKLDNN(TestConv2dOp_AsyPadding_MKLDNN):
+    def init_paddings(self):
+        self.pad = [0, 0]
+        self.padding_algorithm = "SAME"
+
+
+class TestConv2dOp_Valid_MKLDNN(TestConv2dOp_AsyPadding_MKLDNN):
+    def init_paddings(self):
+        self.pad = [1, 1]
+        self.padding_algorithm = "VALID"
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -105,3 +105,24 @@ class TestMKLDNNWithStride(TestConv2dTransposeMKLDNNOp):
         self.pad = [1, 1]
         self.stride = [2, 2]
         self.input_size = [2, 3, 6, 6]  # NCHW
+
+
+class TestMKLDNNWithAsymPad(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [0, 0, 1, 2]
+        self.padding_algorithm = "EXPLICIT"
+
+
+class TestMKLDNNWithSamePad(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [0, 0]
+        self.padding_algorithm = "SAME"
+
+
+class TestMKLDNNWithValidPad(TestConv2dTransposeMKLDNNOp):
+    def init_test_case(self):
+        TestConv2dTransposeMKLDNNOp.init_test_case(self)
+        self.pad = [1, 1]
+        self.padding_algorithm = "VALID"

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 
-from paddle.fluid.tests.unittests.test_conv3d_op import TestConv3dOp, TestCase1, TestWithGroup1, TestWithGroup2, TestWith1x1, TestWithInput1x1Filter1x1
+from paddle.fluid.tests.unittests.test_conv3d_op import TestConv3dOp, TestCase1, TestWithGroup1, TestWithGroup2, TestWith1x1, TestWithInput1x1Filter1x1, TestConv3dOp_2
 
 
 class TestMKLDNN(TestConv3dOp):
@@ -53,6 +53,28 @@ class TestMKLDNNWithInput1x1Filter1x1(TestWithInput1x1Filter1x1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+
+
+class TestConv3dOp_AsyPadding_MKLDNN(TestConv3dOp):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+        self.data_format = "NCHW"
+
+    def init_paddings(self):
+        self.pad = [1, 0, 1, 0, 0, 2]
+        self.padding_algorithm = "EXPLICIT"
+
+
+class TestConv3dOp_Same_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
+    def init_paddings(self):
+        self.pad = [0, 0, 0]
+        self.padding_algorithm = "SAME"
+
+
+class TestConv3dOp_Valid_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
+    def init_paddings(self):
+        self.pad = [1, 1, 1]
+        self.padding_algorithm = "VALID"
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 import unittest
-from paddle.fluid.tests.unittests.test_pool2d_op import TestPool2D_Op, TestCase1, TestCase2, TestCase3, TestCase4, TestCase5
+from paddle.fluid.tests.unittests.test_pool2d_op import *
 
 
 def create_test_mkldnn_use_ceil_class(parent):
@@ -52,6 +52,94 @@ create_test_mkldnn_class(TestCase2)
 create_test_mkldnn_class(TestCase3)
 create_test_mkldnn_class(TestCase4)
 create_test_mkldnn_class(TestCase5)
+
+
+class TestAsymPad(TestPool2D_Op):
+    def init_test_case(self):
+        self.ksize = [3, 3]
+        self.strides = [1, 1]
+
+    def init_paddings(self):
+        self.paddings = [1, 0, 1, 0]
+
+    def init_pool_type(self):
+        self.pool_type = "avg"
+        self.pool2D_forward_naive = avg_pool2D_forward_naive
+
+    def init_global_pool(self):
+        self.global_pool = False
+
+    def init_shape(self):
+        self.shape = [2, 3, 7, 7]
+
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
+    def init_global_pool(self):
+        self.global_pool = False
+
+
+class TestAsymPadCase1(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [1, 1, 0, 0]
+
+
+class TestAsymPadCase2(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [1, 0, 1, 2]
+
+
+class TestAsymPadCase3(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [1, 2, 1, 2]
+
+
+class TestAsymPadCase4(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [1, 0, 1, 2]
+
+
+class TestAsymPadCase5(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [2, 2, 1, 2]
+
+
+class TestAsymPadMaxCase1(TestAsymPadCase1):
+    def init_pool_type(self):
+        self.pool_type = "max"
+
+
+class TestAsymPadMaxCase2(TestAsymPadCase2):
+    def init_pool_type(self):
+        self.pool_type = "max"
+
+
+class TestAsymPadMaxCase3(TestAsymPadCase3):
+    def init_pool_type(self):
+        self.pool_type = "max"
+
+
+class TestAsymPadMaxCase4(TestAsymPadCase4):
+    def init_pool_type(self):
+        self.pool_type = "max"
+
+
+class TestAsymPadMaxCase5(TestAsymPadCase5):
+    def init_pool_type(self):
+        self.pool_type = "max"
+
+
+class TestAsymPadSame(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [0, 0]
+        self.padding_algorithm = "SAME"
+
+
+class TestAsymPadValid(TestAsymPad):
+    def init_paddings(self):
+        self.paddings = [0, 0, 0, 0]
+        self.padding_algorithm = "VALID"
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add support for asymetric padding (along with "VALID" and "SAME" padding algorithms) in MKL-DNN operators. 

**Current state:**

- [x] Pooling

- [x] Convolution

- [x] Convolution Transpose

**MKL-DNN operators with asymetric padding support:** pool2d, conv2d, conv3d, conv_transpose
**Possible improvements:** Add more UTs

@jczaja @luotao1 @bingyanghuang please review