### PR TITLE
QAT int8 accuracy little improvement 

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_mkldnn_pass.py
@@ -514,11 +514,11 @@ class FakeQAT2MkldnnINT8PerfPass(object):
                     weights = np.array(
                         self._load_param(self._scope, weight_var_name))
                     scales = 1.0 / np.amax(
-                        np.abs(weights.reshape(weights.shape[0], -1)),
+                        np.abs(weights.reshape(weights.shape[0], -1)).astype(
+                            np.float64),
                         axis=axis)
 
-                    lod_tensor = self._convert_scale2tensor(
-                        scales.astype(np.float64))
+                    lod_tensor = self._convert_scale2tensor(scales)
                     use_unsigned_int = False
                     self._var_quant_scales[weight_var_name] = (use_unsigned_int,
                                                                lod_tensor)


### PR DESCRIPTION
This PR converts one variable to float64 before divide operation. Thanks that we have better scale precision.

There are some results on full dataset on Shanghai machine.

**VGG19** 
`BEFORE INT8: avg top1 accuracy: 0.7209, avg top5 accuracy: 0.9011`
`AFTER    INT8: avg top1 accuracy: 0.7212, avg top5 accuracy: 0.9015`

**RESNET101**
`BEFORE INT8: avg top1 accuracy: 0.7759, avg top5 accuracy: 0.9354`
`AFTER   INT8: avg top1 accuracy: 0.7764, avg top5 accuracy: 0.9358`

