### PR TITLE
download to generate, test=develop

### DIFF
--- a/paddle/fluid/train/demo/run.sh
+++ b/paddle/fluid/train/demo/run.sh
@@ -6,12 +6,14 @@ PADDLE_ROOT=$1
 TURN_ON_MKL=$2 # use MKL or Openblas
 
 # download models
-function download() {
-    wget -q http://paddle-tar.bj.bcebos.com/train_demo/LR/main_program
-    wget -q http://paddle-tar.bj.bcebos.com/train_demo/LR/startup_program
-}
+#function download() {
+#    wget -q http://paddle-tar.bj.bcebos.com/train_demo/LR/main_program
+#    wget -q http://paddle-tar.bj.bcebos.com/train_demo/LR/startup_program
+#}
 
-download
+#download
+
+python demo_network.py
 
 # build demo trainer
 fluid_install_dir=${PADDLE_ROOT}/build/fluid_install_dir


### PR DESCRIPTION
After we modify some operators' interface, the old main_program_desc does not work in CI system, we try to generate new main_program_desc by python script. 