### PR TITLE
[Cherry-pick] Disable cudnn_conv in Parallel Executor Unit Tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/seresnext_net.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_net.py
@@ -36,8 +36,14 @@ remove_dropout = False
 # and Executor is different.
 remove_bn = False
 
+# FIXME(huihuangzheng): Temporarily disable cudnn of conv2d in unit test because
+# it will cause random test failure. We have to re-enable it after someone fixs
+# cudnn_conv
+remove_cudnn_conv = False
+
 remove_dropout = True
 remove_bn = True
+remove_cudnn_conv = True
 
 
 def squeeze_excitation(input, num_channels, reduction_ratio):
@@ -69,6 +75,7 @@ def conv_bn_layer(input, num_filters, filter_size, stride=1, groups=1,
         padding=(filter_size - 1) // 2,
         groups=groups,
         act=None,
+        use_cudnn=(not remove_cudnn_conv),
         bias_attr=False)
     return conv if remove_bn else fluid.layers.batch_norm(
         input=conv, act=act, momentum=0.1)


### PR DESCRIPTION
Cherry-pick of #21080 

Disable cudnn_conv in Parallel Executor Unit Tests.

TODO: fix cudnn_conv and re-enable it
http://ci.paddlepaddle.org/viewLog.html?buildId=213668&tab=buildLog&buildTypeId=Paddle_PrCiCoverage&logTab=tree&filter=all
```
[17:29:57]	W1106 17:29:53.005095 114886 init.cc:205] *** Aborted at 1573061393 (unix time) try "date -d @1573061393" if you are using GNU date ***
[17:29:57]	W1106 17:29:53.008186 114886 init.cc:205] PC: @                0x0 (unknown)
[17:29:57]	W1106 17:29:53.024883 114886 init.cc:205] *** SIGSEGV (@0x1021) received by PID 114571 (TID 0x7f8f62dfa700) from PID 4129; stack trace: ***
[17:29:57]	W1106 17:29:53.030458 114886 init.cc:205]     @     0x7f91a624b390 (unknown)
[17:29:57]	W1106 17:29:53.031530 114886 init.cc:205]     @     0x7f90d6c878c0 (unknown)
[17:29:57]	W1106 17:29:53.031757 114886 init.cc:205]     @     0x7f90d6c896e9 (unknown)
[17:29:57]	W1106 17:29:53.031898 114886 init.cc:205]     @     0x7f90d6c89f9a (unknown)
[17:29:57]	W1106 17:29:53.032027 114886 init.cc:205]     @     0x7f90d751d7c9 (unknown)
[17:29:57]	W1106 17:29:53.032176 114886 init.cc:205]     @     0x7f90d751df9c (unknown)
[17:29:57]	W1106 17:29:53.032305 114886 init.cc:205]     @     0x7f90d7406cb6 (unknown)
[17:29:57]	W1106 17:29:53.032433 114886 init.cc:205]     @     0x7f90d6af7a2d (unknown)
[17:29:57]	W1106 17:29:53.032580 114886 init.cc:205]     @     0x7f90d6af833c (unknown)
[17:29:57]	W1106 17:29:53.032711 114886 init.cc:205]     @     0x7f90d6af916a cudnnConvolutionForward
[17:29:57]	W1106 17:29:53.321544 114886 init.cc:205]     @     0x7f913998694f paddle::operators::CUDNNConvOpKernel<>::Compute()
[17:29:57]	W1106 17:29:53.462957 114886 init.cc:205]     @     0x7f9139987683 _ZNSt17_Function_handlerIFvRKN6paddle9framework16ExecutionContextEEZNKS1_24OpKernelRegistrarFunctorINS0_8platform9CUDAPlaceELb0ELm0EJNS0_9operators17CUDNNConvOpKernelIfEENSA_IdEENSA_INS7_7float16EEEEEclEPKcSH_iEUlS4_E_E9_M_invokeERKSt9_Any_dataS4_
[17:29:57]	W1106 17:29:53.603665 114886 init.cc:205]     @     0x7f913b6891a5 paddle::framework::OperatorWithKernel::RunImpl()
[17:29:57]	W1106 17:29:53.710417 114886 init.cc:205]     @     0x7f913b689d61 paddle::framework::OperatorWithKernel::RunImpl()
[17:29:57]	W1106 17:29:53.846120 114886 init.cc:205]     @     0x7f913b6819cc paddle::framework::OperatorBase::Run()
```
