### PR TITLE
Add dependency for error_codes.proto

### DIFF
--- a/paddle/fluid/operators/math/detail/CMakeLists.txt
+++ b/paddle/fluid/operators/math/detail/CMakeLists.txt
@@ -1,1 +1,1 @@
-cc_library(activation_functions SRCS avx_functions.cc DEPS enforce error_codes_proto)
+cc_library(activation_functions SRCS avx_functions.cc)

--- a/paddle/fluid/operators/math/detail/CMakeLists.txt
+++ b/paddle/fluid/operators/math/detail/CMakeLists.txt
@@ -1,1 +1,1 @@
-cc_library(activation_functions SRCS avx_functions.cc DEPS enforce)
+cc_library(activation_functions SRCS avx_functions.cc DEPS enforce error_codes_proto)

--- a/paddle/fluid/operators/math/detail/CMakeLists.txt
+++ b/paddle/fluid/operators/math/detail/CMakeLists.txt
@@ -1,1 +1,1 @@
-cc_library(activation_functions SRCS avx_functions.cc)
+cc_library(activation_functions SRCS avx_functions.cc DEPS enforce)

--- a/paddle/fluid/operators/math/detail/activation_functions.h
+++ b/paddle/fluid/operators/math/detail/activation_functions.h
@@ -14,9 +14,9 @@ limitations under the License. */
 
 #pragma once
 #include <math.h>
+#include <stdexcept>
 #include <string>
 #include "paddle/fluid/platform/cpu_info.h"
-#include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/hostdevice.h"
 
 namespace paddle {
@@ -45,7 +45,7 @@ inline ActivationType GetActivationType(const std::string &type) {
   } else if (type == "identity" || type == "") {
     return ActivationType::kIdentity;
   }
-  PADDLE_THROW("Not support type %s.", type);
+  throw std::invalid_argument("The input type is not supported");
 }
 
 namespace forward {


### PR DESCRIPTION
Add dependency for error_codes.proto to fix inference CI compile faild.
![image](https://user-images.githubusercontent.com/6836917/68454778-a6e80580-0234-11ea-8823-b8d538dba24e.png)
http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&logTab=tree&filter=debug&expand=all&buildId=215415