### PR TITLE
Use 2 cards for hallreduce unit test.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -809,13 +809,13 @@ class TestDistBase(unittest.TestCase):
 
             global DIST_UT_PORT
             if DIST_UT_PORT == 0:
-                for i in range(0, 4):
+                for i in range(0, 2):
                     self._ps_endpoints += "127.0.0.1:%s," % (
                         self._find_free_port())
             else:
-                for i in range(0, 4):
+                for i in range(0, 2):
                     self._ps_endpoints += "127.0.0.1:%s," % (DIST_UT_PORT + i)
-                DIST_UT_PORT += 4
+                DIST_UT_PORT += 2
             self._ps_endpoints = self._ps_endpoints[:-1]
 
         # NOTE: we reuse ps_endpoints as nccl2 worker endpoints

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -766,7 +766,7 @@ class TestDistBase(unittest.TestCase):
         if self.__use_cuda:
             tr_cmd += " --use_cuda"
             env.update({
-                "CUDA_VISIBLE_DEVICES": "{}".format(trainer_id),
+                "CUDA_VISIBLE_DEVICES": "{}".format(trainer_id % 2),
                 "PADDLE_TRAINERS_NUM": "{}".format(trainer_num),
                 "PADDLE_TRAINER_ID": "{}".format(trainer_id),
                 "PADDLE_TRAINER_ENDPOINTS": self._ps_endpoints,
@@ -779,7 +779,7 @@ class TestDistBase(unittest.TestCase):
             tr_cmd += " --use_dgc"
 
         if self._mp_mode:
-            env = {"FLAGS_selected_gpus": "{}".format(trainer_id)}
+            env = {"FLAGS_selected_gpus": "{}".format(trainer_id % 2)}
 
         if self._nccl_comm_num > 1:
             tr_cmd += " --nccl_comm_num {}".format(self._nccl_comm_num)
@@ -809,13 +809,13 @@ class TestDistBase(unittest.TestCase):
 
             global DIST_UT_PORT
             if DIST_UT_PORT == 0:
-                for i in range(0, 2):
+                for i in range(0, 4):
                     self._ps_endpoints += "127.0.0.1:%s," % (
                         self._find_free_port())
             else:
-                for i in range(0, 2):
+                for i in range(0, 4):
                     self._ps_endpoints += "127.0.0.1:%s," % (DIST_UT_PORT + i)
-                DIST_UT_PORT += 2
+                DIST_UT_PORT += 4
             self._ps_endpoints = self._ps_endpoints[:-1]
 
         # NOTE: we reuse ps_endpoints as nccl2 worker endpoints

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_hallreduce.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_hallreduce.py
@@ -26,7 +26,8 @@ class TestDistMnistNCCL2HAllreduce(TestDistBase):
         self._use_reduce = False
         self._use_reader_alloc = False
         self._nccl2_mode = True
-        self._use_hallreduce = True
+        # FIXME(gongwb): change to True use 2 cards
+        self._use_hallreduce = False
 
     def test_dist_train(self):
         import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_hallreduce.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_hallreduce.py
@@ -26,8 +26,7 @@ class TestDistMnistNCCL2HAllreduce(TestDistBase):
         self._use_reduce = False
         self._use_reader_alloc = False
         self._nccl2_mode = True
-        # FIXME(gongwb): change to True use 2 cards
-        self._use_hallreduce = False
+        self._use_hallreduce = True
 
     def test_dist_train(self):
         import paddle.fluid as fluid


### PR DESCRIPTION
The hierarchical allreduce uses 4 cards, but we only have two. So I try to load two processed on one card.