### PR TITLE
Remove useless code/message of openblas and fix the previous hard-code

### DIFF
--- a/cmake/cblas.cmake
+++ b/cmake/cblas.cmake
@@ -1,3 +1,17 @@
+# Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # Find the CBlas and lapack libraries
 #
 # It will search MKLML, atlas, OpenBlas, reference-cblas in order.
@@ -8,87 +22,111 @@
 #    CBLAS_LIBS      # a list of libraries should be linked by paddle.
 #                    # Each library should be full path to object file.
 
-set(CBLAS_FOUND OFF)
+set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/cblas_dummy.c)
+file(WRITE ${dummyfile} "const char *dummy_cblas = \"${dummyfile}\";")
+add_library(cblas STATIC ${dummyfile})
+
+if(WITH_LIBXSMM)
+  target_link_libraries(cblas ${LIBXSMM_LIBS})
+  add_dependencies(cblas extern_libxsmm)
+endif()
 
 ## Find MKLML First.
-if(WITH_MKLML AND MKLML_INC_DIR AND MKLML_LIB)
-  set(CBLAS_FOUND ON)
+if(WITH_MKLML)
+  include(external/mklml)       # download, install mklml package
   set(CBLAS_PROVIDER MKLML)
-  set(CBLAS_INC_DIR ${MKLML_INC_DIR})
+  set(CBLAS_INC_DIR  ${MKLML_INC_DIR})
   set(CBLAS_LIBRARIES ${MKLML_LIB})
 
   add_definitions(-DPADDLE_WITH_MKLML)
   add_definitions(-DLAPACK_FOUND)
 
+  add_dependencies(cblas mklml)
+  target_link_libraries(cblas dynload_mklml)
+
   message(STATUS "Found cblas and lapack in MKLML "
     "(include: ${CBLAS_INC_DIR}, library: ${CBLAS_LIBRARIES})")
-  return()
 endif()
 
 ## Then find openblas.
-set(OPENBLAS_ROOT $ENV{OPENBLAS_ROOT} CACHE PATH "Folder contains Openblas")
-set(OPENBLAS_INCLUDE_SEARCH_PATHS
-        ${OPENBLAS_ROOT}/include
-        /usr/include
-        /usr/include/openblas
-        /usr/local/opt/openblas/include)
-set(OPENBLAS_LIB_SEARCH_PATHS
-        ${OPENBLAS_ROOT}/lib
-        /usr/lib
-        /usr/lib/blas/openblas
-        /usr/lib/openblas
-        /usr/local/opt/openblas/lib)
+if(NOT DEFINED CBLAS_PROVIDER)
+  set(OPENBLAS_ROOT $ENV{OPENBLAS_ROOT} CACHE PATH "Folder contains Openblas")
+  set(OPENBLAS_INCLUDE_SEARCH_PATHS
+          ${OPENBLAS_ROOT}/include
+          /usr/include
+          /usr/include/openblas
+          /usr/local/opt/openblas/include)
+  set(OPENBLAS_LIB_SEARCH_PATHS
+          ${OPENBLAS_ROOT}/lib
+          /usr/lib
+          /usr/lib/blas/openblas
+          /usr/lib/openblas
+          /usr/local/opt/openblas/lib)
 
-find_path(OPENBLAS_INC_DIR NAMES cblas.h
-  PATHS ${OPENBLAS_INCLUDE_SEARCH_PATHS} NO_DEFAULT_PATH)
-find_path(OPENBLAS_LAPACKE_INC_DIR NAMES lapacke.h
-  PATHS ${OPENBLAS_INCLUDE_SEARCH_PATHS})
-find_library(OPENBLAS_LIB NAMES openblas
-  PATHS ${OPENBLAS_LIB_SEARCH_PATHS})
+  find_path(OPENBLAS_INC_DIR NAMES cblas.h
+    PATHS ${OPENBLAS_INCLUDE_SEARCH_PATHS} NO_DEFAULT_PATH)
+  find_path(OPENBLAS_LAPACKE_INC_DIR NAMES lapacke.h
+    PATHS ${OPENBLAS_INCLUDE_SEARCH_PATHS})
+  find_library(OPENBLAS_LIB NAMES openblas
+    PATHS ${OPENBLAS_LIB_SEARCH_PATHS})
 
-if(OPENBLAS_LAPACKE_INC_DIR AND OPENBLAS_INC_DIR AND OPENBLAS_LIB)
-  set(CBLAS_FOUND ON)
-  set(CBLAS_PROVIDER OPENBLAS)
-  set(CBLAS_INC_DIR ${OPENBLAS_INC_DIR} ${OPENBLAS_LAPACKE_INC_DIR})
-  set(CBLAS_LIBRARIES ${OPENBLAS_LIB})
+  if(OPENBLAS_LAPACKE_INC_DIR AND OPENBLAS_INC_DIR AND OPENBLAS_LIB)
+    set(CBLAS_PROVIDER OPENBLAS)
+    set(CBLAS_INC_DIR ${OPENBLAS_INC_DIR} ${OPENBLAS_LAPACKE_INC_DIR})
+    set(CBLAS_LIBRARIES ${OPENBLAS_LIB})
 
-  add_definitions(-DPADDLE_USE_OPENBLAS)
-  add_definitions(-DLAPACK_FOUND)
+    add_definitions(-DPADDLE_USE_OPENBLAS)
+    add_definitions(-DLAPACK_FOUND)
 
-  message(STATUS "Found OpenBLAS (include: ${OPENBLAS_INC_DIR}, library: ${CBLAS_LIBRARIES})")
-  message(STATUS "Found lapack in OpenBLAS (include: ${OPENBLAS_LAPACKE_INC_DIR})")
-  return()
+    message(STATUS "Found OpenBLAS (include: ${OPENBLAS_INC_DIR}, library: ${CBLAS_LIBRARIES})")
+    message(STATUS "Found lapack in OpenBLAS (include: ${OPENBLAS_LAPACKE_INC_DIR})")
+  endif()
 endif()
 
+## Then find the reference-cblas if WITH_SYSTEM_BLAS.  www.netlib.org/blas/
+if(NOT DEFINED CBLAS_PROVIDER AND WITH_SYSTEM_BLAS)
+  set(REFERENCE_CBLAS_ROOT $ENV{REFERENCE_CBLAS_ROOT} CACHE PATH
+    "Folder contains reference-cblas")
+  set(REFERENCE_CBLAS_INCLUDE_SEARCH_PATHS
+    ${REFERENCE_CBLAS_ROOT}/include
+    /usr/include
+    /usr/include/cblas
+  )
+  set(REFERENCE_CBLAS_LIB_SEARCH_PATHS
+    ${REFERENCE_CBLAS_ROOT}/lib
+    /usr/lib
+    /usr/lib/blas/reference/
+    /usr/lib/reference/
+  )
 
-## Then find the reference-cblas.  www.netlib.org/blas/
-set(REFERENCE_CBLAS_ROOT $ENV{REFERENCE_CBLAS_ROOT} CACHE PATH
-  "Folder contains reference-cblas")
-set(REFERENCE_CBLAS_INCLUDE_SEARCH_PATHS
-  ${REFERENCE_CBLAS_ROOT}/include
-  /usr/include
-  /usr/include/cblas
-)
-
-set(REFERENCE_CBLAS_LIB_SEARCH_PATHS
-  ${REFERENCE_CBLAS_ROOT}/lib
-  /usr/lib
-  /usr/lib/blas/reference/
-  /usr/lib/reference/
-)
-
-if(WITH_SYSTEM_BLAS)
   find_path(REFERENCE_CBLAS_INCLUDE_DIR NAMES cblas.h PATHS
         ${REFERENCE_CBLAS_INCLUDE_SEARCH_PATHS})
   find_library(REFERENCE_CBLAS_LIBRARY NAMES cblas PATHS
         ${REFERENCE_CBLAS_LIB_SEARCH_PATHS})
 
   if(REFERENCE_CBLAS_INCLUDE_DIR AND REFERENCE_CBLAS_LIBRARY)
-    set(CBLAS_FOUND ON)
-    set(CBLAS_PROVIDER REFERENCE)
+    set(CBLAS_PROVIDER REFERENCE_CBLAS)
     set(CBLAS_INC_DIR ${REFERENCE_CBLAS_INCLUDE_DIR})
     set(CBLAS_LIBRARIES ${REFERENCE_CBLAS_LIBRARY})
     add_definitions(-DPADDLE_USE_REFERENCE_CBLAS)
     message(STATUS "Found reference-cblas (include: ${CBLAS_INC_DIR}, library: ${CBLAS_LIBRARIES})")
   endif()
+endif()
+
+## Then build openblas by external_project
+if(NOT DEFINED CBLAS_PROVIDER)
+  include(external/openblas)          # download, build, install openblas
+  set(CBLAS_PROVIDER EXTERN_OPENBLAS)
+  add_dependencies(cblas extern_openblas)
+  add_definitions(-DPADDLE_USE_OPENBLAS)
+  message(STATUS "Build OpenBLAS by External Project "
+    "(include: ${CBLAS_INC_DIR}, library: ${CBLAS_LIBRARIES})")
+endif()
+
+# FIXME(gangliao): generate cblas target to track all high performance
+# linear algebra libraries for cc_library(xxx SRCS xxx.c DEPS cblas)
+
+include_directories(${CBLAS_INC_DIR})
+if(NOT ${CBLAS_PROVIDER} STREQUAL MKLML)
+  target_link_libraries(cblas ${CBLAS_LIBRARIES})
 endif()

--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -11,27 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-INCLUDE(cblas)
 
-IF(NOT ${CBLAS_FOUND})
-    INCLUDE(ExternalProject)
+INCLUDE(ExternalProject)
 
-    SET(CBLAS_SOURCES_DIR ${THIRD_PARTY_PATH}/openblas)
-    SET(CBLAS_INSTALL_DIR ${THIRD_PARTY_PATH}/install/openblas)
-    SET(CBLAS_INC_DIR "${CBLAS_INSTALL_DIR}/include" CACHE PATH "openblas include directory." FORCE)
-
+SET(CBLAS_SOURCES_DIR ${THIRD_PARTY_PATH}/openblas)
+SET(CBLAS_INSTALL_DIR ${THIRD_PARTY_PATH}/install/openblas)
+IF(NOT WIN32)
     SET(CBLAS_LIBRARIES
         "${CBLAS_INSTALL_DIR}/lib/${CMAKE_STATIC_LIBRARY_PREFIX}openblas${CMAKE_STATIC_LIBRARY_SUFFIX}"
         CACHE FILEPATH "openblas library." FORCE)
-
-    ADD_DEFINITIONS(-DPADDLE_USE_OPENBLAS)
-
-    IF (WIN32)
-        SET(CBLAS_FOUND true)
-        MESSAGE(WARNING, "In windows, openblas only support msvc build, please build it manually and put it at " ${CBLAS_INSTALL_DIR})
-    ENDIF(WIN32)
-
-    IF (NOT WIN32)
+    SET(CBLAS_INC_DIR "${CBLAS_INSTALL_DIR}/include" CACHE PATH "openblas include directory." FORCE)
     SET(OPENBLAS_CC "${CMAKE_C_COMPILER} -Wno-unused-but-set-variable -Wno-unused-variable")
     SET(OPENBLAS_COMMIT "v0.2.20")
 
@@ -58,70 +47,31 @@ IF(NOT ${CBLAS_FOUND})
         UPDATE_COMMAND      ""
         CONFIGURE_COMMAND   ""
     )
-    ELSE(NOT WIN32)
-        SET(CBLAS_FOUND false)
-        SET(CBLAS_LIBRARIES
-            "${CBLAS_INSTALL_DIR}/lib/openblas${CMAKE_STATIC_LIBRARY_SUFFIX}"
-            CACHE FILEPATH "openblas library." FORCE)
-        INCLUDE_DIRECTORIES(${CBLAS_INC_DIR}/openblas) # For openbals code to include its own headers.
-        INCLUDE_DIRECTORIES(${THIRD_PARTY_PATH}/install)
-        ExternalProject_Add(
-            extern_openblas
-            ${EXTERNAL_PROJECT_LOG_ARGS}
-            GIT_REPOSITORY      https://github.com/xianyi/OpenBLAS.git
-            GIT_TAG            "v0.3.7"
-            PREFIX              ${CBLAS_SOURCES_DIR}
-            INSTALL_DIR         ${CBLAS_INSTALL_DIR}
-            BUILD_IN_SOURCE     0
-            UPDATE_COMMAND      ""
-            CMAKE_ARGS          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-                                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-                                    -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-                                    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-                                    -DCMAKE_INSTALL_PREFIX=${CBLAS_INSTALL_DIR}
-                                    -DCMAKE_POSITION_INDEPENDENT_CODE=ON
-                                    -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
-                                    -DBUILD_SHARED_LIBS=ON
-                                    -DMSVC_STATIC_CRT=${MSVC_STATIC_CRT}
-                                    ${EXTERNAL_OPTIONAL_ARGS}
-                CMAKE_CACHE_ARGS    -DCMAKE_INSTALL_PREFIX:PATH=${CBLAS_INSTALL_DIR}
-                                    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-                                    -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
-            )
-        add_custom_command(TARGET extern_openblas POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy ${CBLAS_INSTALL_DIR}/bin/openblas${CMAKE_SHARED_LIBRARY_SUFFIX}  ${CBLAS_INSTALL_DIR}/lib )
-        ADD_LIBRARY(openblas STATIC IMPORTED GLOBAL)
-        SET_PROPERTY(TARGET openblas PROPERTY IMPORTED_LOCATION ${CBLAS_LIBRARIES})
-        ADD_DEPENDENCIES(openblas extern_openblas)
-    ENDIF(NOT WIN32)
-    SET(CBLAS_PROVIDER openblas)
-ENDIF(NOT ${CBLAS_FOUND})
-
-MESSAGE(STATUS "BLAS library: ${CBLAS_LIBRARIES}")
-MESSAGE(STATUS "BLAS Include: ${CBLAS_INC_DIR}")
-INCLUDE_DIRECTORIES(${CBLAS_INC_DIR})
-
-# FIXME(gangliao): generate cblas target to track all high performance
-# linear algebra libraries for cc_library(xxx SRCS xxx.c DEPS cblas)
-SET(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/cblas_dummy.c)
-FILE(WRITE ${dummyfile} "const char *dummy_cblas = \"${dummyfile}\";")
-ADD_LIBRARY(cblas STATIC ${dummyfile})
-
-IF("${CBLAS_PROVIDER}" STREQUAL "MKLML")
-  TARGET_LINK_LIBRARIES(cblas dynload_mklml)
-ELSE()
-  TARGET_LINK_LIBRARIES(cblas ${CBLAS_LIBRARIES})
-ENDIF("${CBLAS_PROVIDER}" STREQUAL "MKLML")
-
-IF(WITH_LIBXSMM)
-  TARGET_LINK_LIBRARIES(cblas ${LIBXSMM_LIBS})
-  ADD_DEPENDENCIES(cblas extern_libxsmm)
-ENDIF()
-
-IF(NOT ${CBLAS_FOUND})
-    ADD_DEPENDENCIES(cblas extern_openblas)
-ELSE()
-    IF("${CBLAS_PROVIDER}" STREQUAL "MKLML")
-        ADD_DEPENDENCIES(cblas mklml)
-    ENDIF()
-ENDIF(NOT ${CBLAS_FOUND})
+ELSE(NOT WIN32)
+    SET(CBLAS_LIBRARIES
+        "${CBLAS_INSTALL_DIR}/lib/openblas${CMAKE_STATIC_LIBRARY_SUFFIX}"
+        CACHE FILEPATH "openblas library." FORCE)
+    SET(CBLAS_INC_DIR "${CBLAS_INSTALL_DIR}/include/openblas" CACHE PATH "openblas include directory." FORCE)
+    ExternalProject_Add(
+        extern_openblas
+        ${EXTERNAL_PROJECT_LOG_ARGS}
+        GIT_REPOSITORY      https://github.com/xianyi/OpenBLAS.git
+        GIT_TAG            "v0.3.7"
+        PREFIX              ${CBLAS_SOURCES_DIR}
+        INSTALL_DIR         ${CBLAS_INSTALL_DIR}
+        BUILD_IN_SOURCE     0
+        UPDATE_COMMAND      ""
+        CMAKE_ARGS          -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                            -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
+                            -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+                            -DCMAKE_INSTALL_PREFIX=${CBLAS_INSTALL_DIR}
+                            -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+                            -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
+                            -DMSVC_STATIC_CRT=${MSVC_STATIC_CRT}
+                            ${EXTERNAL_OPTIONAL_ARGS}
+        CMAKE_CACHE_ARGS    -DCMAKE_INSTALL_PREFIX:PATH=${CBLAS_INSTALL_DIR}
+                            -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+                            -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
+        )
+ENDIF(NOT WIN32)

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -76,8 +76,8 @@ if(WIN32 OR APPLE)
 endif()
 
 set(WITH_MKLML ${WITH_MKL})
-if (NOT DEFINED WITH_MKLDNN)
-    if (WITH_MKL AND AVX2_FOUND)
+if(NOT DEFINED WITH_MKLDNN)
+    if(WITH_MKL AND AVX2_FOUND)
         set(WITH_MKLDNN ON)
     else()
         message(STATUS "Do not have AVX2 intrinsics and disabled MKL-DNN")
@@ -109,12 +109,11 @@ if(WITH_AMD_GPU)
     list(APPEND third_party_deps extern_rocprim)
 endif()
 
-if(WITH_MKLML)
-    include(external/mklml)     # download, install mklml package
+include(cblas)              	# find first, then download, build, install openblas
+if(${CBLAS_PROVIDER} STREQUAL MKLML)
     list(APPEND third_party_deps extern_mklml)
 endif()
-include(external/openblas)      # find first, then download, build, install openblas
-if(NOT CBLAS_FOUND)
+if(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
     list(APPEND third_party_deps extern_openblas)
 endif()
 
@@ -123,7 +122,7 @@ if(WITH_MKLDNN)
     list(APPEND third_party_deps extern_mkldnn)
 endif()
 
-include(external/protobuf)  # find first, then download, build, install protobuf
+include(external/protobuf)  	# find first, then download, build, install protobuf
 if(NOT PROTOBUF_FOUND OR WIN32)
     list(APPEND third_party_deps extern_protobuf)
 endif()
@@ -185,18 +184,18 @@ if(WITH_NGRAPH)
 endif()
 
 if(WITH_XBYAK)
-    include(external/xbyak)     # download, build, install xbyak
+    include(external/xbyak)         # download, build, install xbyak
     list(APPEND third_party_deps extern_xbyak)
 endif()
 
 if(WITH_LIBXSMM)
-    include(external/libxsmm)   # download, build, install libxsmm
+    include(external/libxsmm)       # download, build, install libxsmm
     list(APPEND third_party_deps extern_libxsmm)
 endif()
 
 if(WITH_DGC)
     message(STATUS "add dgc lib.")
-    include(external/dgc)       # download, build, install dgc
+    include(external/dgc)           # download, build, install dgc
     add_definitions(-DPADDLE_WITH_DGC)
     list(APPEND third_party_deps extern_dgc)
 endif()


### PR DESCRIPTION
Fix some problems of and **cblas.cmake** **openblas.cmake** file:

**openblas.cmake** has these problem: 
 - 1. The previous error message no longer applies to the current version and is incorrect;
 - 2. Some useless code doesn't work, which should be removed;
 a. include_directories(${THIRD_PARTY_PATH}/install) should not be here.
 b. the import library(openblas) has never been used and have no meaning.
 c. add_custom_command for extern_openblas have no meaning, because the library has been linked to cblas.
 - 3. No indentation in the code;

**cblas.cmake** has these problem:
- The execution sequence of finding and building cblas is moved into **cbals.cmake**, and **openblas.cmake** is only an external project and no longer contains other code.