### PR TITLE
Further simplify the C++ error info stack

### DIFF
--- a/paddle/fluid/platform/place.h
+++ b/paddle/fluid/platform/place.h
@@ -77,20 +77,21 @@ struct IsCUDAPinnedPlace : public boost::static_visitor<bool> {
 };
 
 class Place : public boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace> {
- public:
+ private:
   using PlaceBase = boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace>;
 
+ public:
   Place() = default;
   Place(const CPUPlace &cpu_place) : PlaceBase(cpu_place) {}     // NOLINT
   Place(const CUDAPlace &cuda_place) : PlaceBase(cuda_place) {}  // NOLINT
   Place(const CUDAPinnedPlace &cuda_pinned_place)                // NOLINT
       : PlaceBase(cuda_pinned_place) {}
 
-  bool operator<(const PlaceBase &place) const {
-    return PlaceBase::operator<(place);
+  bool operator<(const Place &place) const {
+    return PlaceBase::operator<(static_cast<const PlaceBase &>(place));
   }
-  bool operator==(const PlaceBase &place) const {
-    return PlaceBase::operator==(place);
+  bool operator==(const Place &place) const {
+    return PlaceBase::operator==(static_cast<const PlaceBase &>(place));
   }
 };
 

--- a/paddle/fluid/platform/place.h
+++ b/paddle/fluid/platform/place.h
@@ -76,7 +76,23 @@ struct IsCUDAPinnedPlace : public boost::static_visitor<bool> {
   bool operator()(const CUDAPinnedPlace &cuda_pinned) const { return true; }
 };
 
-typedef boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace> Place;
+class Place : public boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace> {
+ public:
+  using PlaceBase = boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace>;
+
+  Place() = default;
+  Place(const CPUPlace &cpu_place) : PlaceBase(cpu_place) {}     // NOLINT
+  Place(const CUDAPlace &cuda_place) : PlaceBase(cuda_place) {}  // NOLINT
+  Place(const CUDAPinnedPlace &cuda_pinned_place)                // NOLINT
+      : PlaceBase(cuda_pinned_place) {}
+
+  bool operator<(const PlaceBase &place) const {
+    return PlaceBase::operator<(place);
+  }
+  bool operator==(const PlaceBase &place) const {
+    return PlaceBase::operator==(place);
+  }
+};
 
 using PlaceList = std::vector<Place>;
 


### PR DESCRIPTION
### Chinese

经过之前对C++报错信息栈的简化，去掉了提示效用比较差的函数地址，代码偏移等信息，但是由于boost::variant的函数参数过多，C++信息栈中还是会出现很长的函数名，占据大片的内容，但是这些冗余的参数事实上是没有有效信息的，例如

3   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&, paddle::framework::RuntimeContext*) const

这行报错信息中，有效的只有以下内容，剩余的`boost::detail::variant::void_,`均不必显示

3   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace> const&, paddle::framework::RuntimeContext*) const

因此该PR通过将Place设计为继承`boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace>`的类，简化由于Place参数过长导致的C++信息栈信息密度低，阅读体验差的问题

> 正则表达式替换字符串在多平台上可能有风险，这种解决方法最安全
> 主要就是Place参数导致的信息冗长，没必要删除其他参数的前缀了

### English

The PR make `Place` class inherit `boost::variant<CUDAPlace, CPUPlace, CUDAPinnedPlace>`, simplifying the low information density of the C++ message stack due to excessive Place parameters and poor reading experience.

### C++ stack change Example

#### Original

0   std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > paddle::platform::GetTraceBackString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, char const*, int)
1   paddle::platform::EnforceNotMet::EnforceNotMet(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, int)
2   paddle::operators::MulOp::InferShape(paddle::framework::InferShapeContext*) const
3   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&, paddle::framework::RuntimeContext*) const
4   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&) const
5   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, boost::variant<paddle::platform::CUDAPlace, paddle::platform::CPUPlace, paddle::platform::CUDAPinnedPlace, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_, boost::detail::variant::void_> const&)
6   paddle::framework::Executor::RunPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, bool, bool, bool)
7   paddle::framework::Executor::Run(paddle::framework::ProgramDesc const&, paddle::framework::Scope*, int, bool, bool, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool)

#### New

0   std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > paddle::platform::GetTraceBackString<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&&, char const*, int)
1   paddle::platform::EnforceNotMet::EnforceNotMet(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*, int)
2   paddle::operators::MulOp::InferShape(paddle::framework::InferShapeContext*) const
3   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, **paddle::platform::Place const&,** paddle::framework::RuntimeContext*) const
4   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&) const
5   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, paddle::platform::Place const&)
6   paddle::framework::Executor::RunPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, bool, bool, bool)
7   paddle::framework::Executor::Run(paddle::framework::ProgramDesc const&, paddle::framework::Scope*, int, bool, bool, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > > const&, bool)