### PR TITLE
add check for input channels and Attr(groups)

### DIFF
--- a/paddle/fluid/operators/maxout_op.cc
+++ b/paddle/fluid/operators/maxout_op.cc
@@ -82,6 +82,14 @@ class MaxOutOp : public framework::OperatorWithKernel {
     // check groups > 1
     PADDLE_ENFORCE_GT(groups, 1,
                       "Attr(groups) of Op(maxout) should be larger than 1.");
+    PADDLE_ENFORCE_EQ(
+        in_x_dims[axis] % groups, 0,
+        "ValueError: The number of input channels for Op(maxout) "
+        "should be divisible by Attr(groups). But received: the "
+        "input's channels is [%d], the shape of input is [%s], "
+        "the Attr(groups) is [%d], the Attr(axis) is [%d]. The "
+        "error may come from wrong Attr(groups) or Attr(axis) setting.",
+        in_x_dims[axis], in_x_dims, groups, axis);
     std::vector<int64_t> output_shape(
         {in_x_dims[0], in_x_dims[1], in_x_dims[2], in_x_dims[3]});
     output_shape[axis] = in_x_dims[axis] / groups;


### PR DESCRIPTION
Add check for input channels and Attr(groups). 
In maxout Op, there is no check for input channels and Attr(groups). If use below code, segmentation fault occurs. because the input channel(1) can not be divisible by `groups`.
```python
input = fluid.data(name='data', shape=[1, 1, 10, 10], dtype='float32')
out = fluid.layers.maxout(input, groups=5, axis=1) 
```
This PR add the check. When running above code, it will print the message:
![image](https://user-images.githubusercontent.com/26615455/68467659-8d08eb80-0251-11ea-959f-cea9db38396b.png)




