### PR TITLE
Add with_label to int8 UT, enabling models with one input [image] only

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
@@ -68,6 +68,7 @@ class TensorReader {
 
 std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
     const std::vector<std::vector<PaddleTensor>> &test_data,
+    bool with_label = FLAGS_with_label,
     int num_images = FLAGS_warmup_batch_size) {
   int test_data_batch_size = test_data[0][0].shape[0];
   auto iterations = test_data.size();
@@ -76,17 +77,13 @@ std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
       "The requested quantization warmup data size " +
           std::to_string(num_images) + " is bigger than all test data size.");
 
+  std::vector<PaddleTensor> warmup_data_vec;
+
   PaddleTensor images;
   images.name = "image";
   images.shape = {num_images, 3, 224, 224};
   images.dtype = PaddleDType::FLOAT32;
   images.data.Resize(sizeof(float) * num_images * 3 * 224 * 224);
-
-  PaddleTensor labels;
-  labels.name = "label";
-  labels.shape = {num_images, 1};
-  labels.dtype = PaddleDType::INT64;
-  labels.data.Resize(sizeof(int64_t) * num_images);
 
   for (int i = 0; i < num_images; i++) {
     auto batch = i / test_data_batch_size;
@@ -95,19 +92,35 @@ std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
                     element_in_batch * 3 * 224 * 224,
                 3 * 224 * 224,
                 static_cast<float *>(images.data.data()) + i * 3 * 224 * 224);
-
-    std::copy_n(static_cast<int64_t *>(test_data[batch][1].data.data()) +
-                    element_in_batch,
-                1, static_cast<int64_t *>(labels.data.data()) + i);
   }
+  warmup_data_vec.push_back(std::move(images));
 
-  auto warmup_data = std::make_shared<std::vector<PaddleTensor>>(2);
-  (*warmup_data)[0] = std::move(images);
-  (*warmup_data)[1] = std::move(labels);
-  return warmup_data;
+  if (with_label) {
+    PADDLE_ENFORCE_EQ(static_cast<size_t>(test_data[0].size()), size_t{2},
+                      "The requested quantization warmup data size " +
+                          std::to_string(num_images) +
+                          " is bigger than all test data size.");
+    PaddleTensor labels;
+    labels.name = "label";
+    labels.shape = {num_images, 1};
+    labels.dtype = PaddleDType::INT64;
+    labels.data.Resize(sizeof(int64_t) * num_images);
+
+    for (int i = 0; i < num_images; i++) {
+      auto batch = i / test_data_batch_size;
+      auto element_in_batch = i % test_data_batch_size;
+      std::copy_n(static_cast<int64_t *>(test_data[batch][1].data.data()) +
+                      element_in_batch,
+                  1, static_cast<int64_t *>(labels.data.data()) + i);
+    }
+    warmup_data_vec.push_back(std::move(labels));
+  }
+  return std::make_shared<std::vector<PaddleTensor>>(
+      std::move(warmup_data_vec));
 }
 
 void SetInput(std::vector<std::vector<PaddleTensor>> *inputs,
+              bool with_label = FLAGS_with_label,
               int32_t batch_size = FLAGS_batch_size) {
   std::ifstream file(FLAGS_infer_data, std::ios::binary);
   if (!file) {
@@ -121,24 +134,30 @@ void SetInput(std::vector<std::vector<PaddleTensor>> *inputs,
   std::vector<int> image_batch_shape{batch_size, 3, 224, 224};
   std::vector<int> label_batch_shape{batch_size, 1};
   auto images_offset_in_file = static_cast<size_t>(file.tellg());
-  auto labels_offset_in_file =
-      images_offset_in_file + sizeof(float) * total_images * 3 * 224 * 224;
 
   TensorReader<float> image_reader(file, images_offset_in_file,
                                    image_batch_shape, "image");
-  TensorReader<int64_t> label_reader(file, labels_offset_in_file,
-                                     label_batch_shape, "label");
 
   auto iterations_max = total_images / batch_size;
   auto iterations = iterations_max;
   if (FLAGS_iterations > 0 && FLAGS_iterations < iterations_max) {
     iterations = FLAGS_iterations;
   }
+
+  auto labels_offset_in_file =
+      images_offset_in_file + sizeof(float) * total_images * 3 * 224 * 224;
+
+  TensorReader<int64_t> label_reader(file, labels_offset_in_file,
+                                     label_batch_shape, "label");
   for (auto i = 0; i < iterations; i++) {
     auto images = image_reader.NextBatch();
-    auto labels = label_reader.NextBatch();
-    inputs->emplace_back(
-        std::vector<PaddleTensor>{std::move(images), std::move(labels)});
+    std::vector<PaddleTensor> tmp_vec;
+    tmp_vec.push_back(std::move(images));
+    if (with_label) {
+      auto labels = label_reader.NextBatch();
+      tmp_vec.push_back(std::move(labels));
+    }
+    inputs->push_back(std::move(tmp_vec));
   }
 }
 
@@ -155,6 +174,7 @@ TEST(Analyzer_int8_image_classification, quantization) {
 
   // prepare warmup batch from input data read earlier
   // warmup batch size can be different than batch size
+
   std::shared_ptr<std::vector<PaddleTensor>> warmup_data =
       GetWarmupData(input_slots_all);
 
@@ -163,7 +183,7 @@ TEST(Analyzer_int8_image_classification, quantization) {
   q_cfg.mkldnn_quantizer_config()->SetWarmupData(warmup_data);
   q_cfg.mkldnn_quantizer_config()->SetWarmupBatchSize(FLAGS_warmup_batch_size);
 
-  CompareQuantizedAndAnalysis(&cfg, &q_cfg, input_slots_all);
+  CompareQuantizedAndAnalysis(&cfg, &q_cfg, input_slots_all, FLAGS_with_label);
 }
 
 }  // namespace analysis

--- a/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_image_classification_tester.cc
@@ -97,9 +97,8 @@ std::shared_ptr<std::vector<PaddleTensor>> GetWarmupData(
 
   if (with_label) {
     PADDLE_ENFORCE_EQ(static_cast<size_t>(test_data[0].size()), size_t{2},
-                      "The requested quantization warmup data size " +
-                          std::to_string(num_images) +
-                          " is bigger than all test data size.");
+                      "FLAGS_with_label is set to true, but the input size is" +
+                          std::to_string(test_data[0].size()));
     PaddleTensor labels;
     labels.name = "label";
     labels.shape = {num_images, 1};
@@ -183,7 +182,9 @@ TEST(Analyzer_int8_image_classification, quantization) {
   q_cfg.mkldnn_quantizer_config()->SetWarmupData(warmup_data);
   q_cfg.mkldnn_quantizer_config()->SetWarmupBatchSize(FLAGS_warmup_batch_size);
 
-  CompareQuantizedAndAnalysis(&cfg, &q_cfg, input_slots_all, FLAGS_with_label);
+  // 0 is avg_cost, 1 is top1_acc, 2 is top5_acc or mAP
+  CompareQuantizedAndAnalysis(&cfg, &q_cfg, input_slots_all, FLAGS_with_label,
+                              1);
 }
 
 }  // namespace analysis

--- a/paddle/fluid/inference/tests/api/analyzer_int8_object_detection_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_object_detection_tester.cc
@@ -275,7 +275,8 @@ TEST(Analyzer_int8_mobilenet_ssd, quantization) {
   q_cfg.mkldnn_quantizer_config()->SetWarmupBatchSize(FLAGS_warmup_batch_size);
 
   // 0 is avg_cost, 1 is top1_acc, 2 is top5_acc or mAP
-  CompareQuantizedAndAnalysis(&cfg, &q_cfg, input_slots_all, 2);
+  CompareQuantizedAndAnalysis(&cfg, &q_cfg, input_slots_all, FLAGS_with_label,
+                              2);
 }
 
 }  // namespace analysis

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -42,6 +42,7 @@ DEFINE_string(infer_model, "", "model path");
 DEFINE_string(infer_data, "", "data file");
 DEFINE_string(refer_result, "", "reference result for comparison");
 DEFINE_int32(batch_size, 1, "batch size");
+DEFINE_bool(with_label, true, "with label or not");
 DEFINE_bool(enable_fp32, true, "Enable FP32 type prediction");
 DEFINE_bool(enable_int8, true, "Enable INT8 type prediction");
 DEFINE_int32(warmup_batch_size, 100, "batch size for quantization warmup");
@@ -602,7 +603,7 @@ void CompareNativeAndAnalysis(
 void CompareQuantizedAndAnalysis(
     const AnalysisConfig *config, const AnalysisConfig *qconfig,
     const std::vector<std::vector<PaddleTensor>> &inputs,
-    const int compared_idx = 1) {
+    const bool with_label = FLAGS_with_label, const int compared_idx = 1) {
   PADDLE_ENFORCE_EQ(inputs[0][0].shape[0], FLAGS_batch_size,
                     "Input data has to be packed batch by batch.");
   LOG(INFO) << "FP32 & INT8 prediction run: batch_size " << FLAGS_batch_size
@@ -630,8 +631,9 @@ void CompareQuantizedAndAnalysis(
                             VarType::INT8, &sample_latency_int8);
   }
   SummarizePerformance(sample_latency_fp32, sample_latency_int8);
-
-  CompareAccuracy(quantized_outputs, analysis_outputs, compared_idx);
+  if (with_label) {
+    CompareAccuracy(quantized_outputs, analysis_outputs, compared_idx);
+  }
 }
 
 void CompareNativeAndAnalysis(


### PR DESCRIPTION
Add "with_label" param in the UT so that it could be used by one input models (QAT models).

Command:
`
/home/lidanqing/Paddle/build/paddle/fluid/inference/tests/api/test_analyzer_int8_image_classification "ARGS" "--infer_model=/home/lidanqing/transformed_qat_int8_model" "--infer_data=/home/lidanqing/.cache/paddle/dataset/int8/download/int8_full_val.bin" "--warmup_batch_size=100" "--batch_size=1" "--paddle_num_threads=1" "--iterations=100" "--with_label=false"
`
