### PR TITLE
Remove so many logs of memory optimization in parallel_executor.cc

### DIFF
--- a/paddle/fluid/framework/parallel_executor.cc
+++ b/paddle/fluid/framework/parallel_executor.cc
@@ -34,6 +34,8 @@ limitations under the License. */
 
 DECLARE_bool(use_ngraph);
 
+DECLARE_double(eager_delete_tensor_gb);
+
 #ifdef WITH_GPERFTOOLS
 #include "gperftools/profiler.h"
 #endif
@@ -282,8 +284,8 @@ ir::Graph *ParallelExecutorPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
     VLOG(10) << "Start to apply buffer_shared_inplace_pass";
     graph = inplace_pass->Apply(graph);
     VLOG(10) << "buffer_shared_inplace_pass Applied";
-    LOG(INFO) << "Inplace strategy is enabled, when "
-                 "build_strategy.enable_inplace = True";
+    LOG_FIRST_N(INFO, 1) << "Inplace strategy is enabled, when "
+                            "build_strategy.enable_inplace = True";
   }
 
   /**
@@ -365,9 +367,9 @@ ir::Graph *ParallelExecutorPrivate::ApplyMemoryOptimizePass(ir::Graph *graph) {
     eager_deletion_pass->SetNotOwned(ir::kAllPlaces, &places_);
     graph = eager_deletion_pass->Apply(graph);
     VLOG(10) << "EagerDeletionPass Applied";
-    LOG(INFO) << "Garbage collection strategy is enabled, when "
-              << "FLAGS_eager_delete_tensor_gb = "
-              << (static_cast<double>(GetEagerDeletionThreshold()) / (1 << 30));
+    LOG_FIRST_N(INFO, 1) << "Garbage collection strategy is enabled, when "
+                         << "FLAGS_eager_delete_tensor_gb = "
+                         << FLAGS_eager_delete_tensor_gb;
   }
   return graph;
 }


### PR DESCRIPTION
Use `LOG_FIRST_N(INFO, 1)` instead of `LOG(INFO)` to avoid too many logs when too many `ParallelExecutor` creates.