### PR TITLE
Add CI check for error message writing specification

### DIFF
--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -17,7 +17,6 @@ limitations under the License. */
 
 #include "gtest/gtest.h"
 #include "paddle/fluid/platform/enforce.h"
-#include "paddle/fluid/platform/errors.h"
 
 TEST(ENFORCE, OK) {
   PADDLE_ENFORCE(true, "Enforce is ok %d now %f", 123, 0.345);
@@ -360,103 +359,4 @@ TEST(enforce, cannot_to_string_type) {
   PADDLE_ENFORCE_EQ(list.begin(), list.end());
   list.push_back(4);
   PADDLE_ENFORCE_NE(list.begin(), list.end());
-}
-
-TEST(Enforce, CICheckRules) {
-  using namespace paddle;  // NOLINT
-
-  int var1 = 1, var2 = 1;
-  std::unique_ptr<int> ptr(new int);
-
-  /* PADDLE_THROW */
-  // correct cases:
-  PADDLE_THROW(platform::errors::PreconditionNotMet(
-      "This is a correct error message case."));
-  PADDLE_THROW(platform::errors::PreconditionNotMet(
-      "This is a correct error message case, var1(%d) is not equal to var2(%d)",
-      var1, var2));
-  // wrong cases:
-  PADDLE_THROW("");
-  PADDLE_THROW("msg is too short.");
-  PADDLE_THROW("var1(%d) is equal to var2(%d).", var1, var2);
-  PADDLE_THROW("This is a error message case.");
-  PADDLE_THROW("This is a error message case, %var1(%d) is equal to var2(%d)",
-               var1, var2);
-  PADDLE_THROW(platform::errors::PreconditionNotMet());
-  PADDLE_THROW(platform::errors::PreconditionNotMet(""));
-  PADDLE_THROW(platform::errors::PreconditionNotMet("msg is too short."));
-  PADDLE_THROW(
-      platform::errors::PreconditionNotMet("var1(%d)!=var2(%d)", var1, var2));
-
-  /* PADDLE_ENFORCE */
-  // correct cases:
-  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(
-                           "This is a correct error message case."));
-  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(
-                           "This is a correct error message case, var1(%d) is "
-                           "not equal to var2(%d)",
-                           var1, var2));
-  // wrong cases:
-  PADDLE_ENFORCE(true);
-  PADDLE_ENFORCE(true, "");
-  PADDLE_ENFORCE(true, "msg is too short.");
-  PADDLE_ENFORCE(true, "var1(%d) is equal to var2(%d).", var1, var2);
-  PADDLE_ENFORCE(true, "This is a error message case.");
-  PADDLE_ENFORCE(true,
-                 "This is a error message case, %var1(%d) is equal to var2(%d)",
-                 var1, var2);
-  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet());
-  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(""));
-  PADDLE_ENFORCE(true,
-                 platform::errors::PreconditionNotMet("msg is too short."));
-  PADDLE_ENFORCE(true,
-                 platform::errors::PreconditionNotMet("%d!=%d", var1, var2));
-
-  /* PADDLE_ENFORCE_NOT_NULL */
-  // correct cases:
-  PADDLE_ENFORCE_NOT_NULL(
-      ptr, platform::errors::NotFound("This is a correct error message case."));
-  PADDLE_ENFORCE_NOT_NULL(
-      ptr, platform::errors::NotFound("This is a correct error message case, "
-                                      "var1(%d) is not equal to var2(%d)",
-                                      var1, var2));
-  // wrong cases:
-  PADDLE_ENFORCE_NOT_NULL(ptr);
-  PADDLE_ENFORCE_NOT_NULL(ptr, "");
-  PADDLE_ENFORCE_NOT_NULL(ptr, "msg is too short.");
-  PADDLE_ENFORCE_NOT_NULL(ptr, "var1(%d) is equal to var2(%d).", var1, var2);
-  PADDLE_ENFORCE_NOT_NULL(ptr, "This is a error message case.");
-  PADDLE_ENFORCE_NOT_NULL(ptr,
-                          "This is a error message case, "
-                          "var1(%d)!=var2(%d)",
-                          var1, var2);
-  PADDLE_ENFORCE_NOT_NULL(ptr, platform::errors::NotFound());
-  PADDLE_ENFORCE_NOT_NULL(ptr, platform::errors::NotFound(""));
-  PADDLE_ENFORCE_NOT_NULL(ptr, platform::errors::NotFound("msg is too short."));
-  PADDLE_ENFORCE_NOT_NULL(ptr,
-                          platform::errors::NotFound("%d!=%d", var1, var2));
-
-  /* PADDLE_ENFORCE_EQ */
-  // correct cases:
-  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument(
-                                    "This is a correct error message case."));
-  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument(
-                                    "This is a correct error message case, "
-                                    "var1(%d) is not equal to var2(%d)",
-                                    var1, var2));
-  // wrong cases:
-  PADDLE_ENFORCE_EQ(var1, var2);
-  PADDLE_ENFORCE_EQ(var1, var2, "");
-  PADDLE_ENFORCE_EQ(var1, var2, "msg is too short.");
-  PADDLE_ENFORCE_EQ(var1, var2, "var1(%d) is equal to var2(%d).", var1, var2);
-  PADDLE_ENFORCE_EQ(var1, var2, "This is a error message case.");
-  PADDLE_ENFORCE_EQ(var1, var2,
-                    "This is a error message case, var1(%d)!=var2(%d)", var1,
-                    var2);
-  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument());
-  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument(""));
-  PADDLE_ENFORCE_EQ(var1, var2,
-                    platform::errors::InvalidArgument("msg is too short."));
-  PADDLE_ENFORCE_EQ(var1, var2,
-                    platform::errors::InvalidArgument("%d!=%d", var1, var2));
 }

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -409,8 +409,8 @@ TEST(Enforce, CICheckRules) {
   PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(""));
   PADDLE_ENFORCE(true,
                  platform::errors::PreconditionNotMet("msg is too short."));
-  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(
-                           "var1(%d)!=var2(%d)", var1, var2));
+  PADDLE_ENFORCE(true,
+                 platform::errors::PreconditionNotMet("%d!=%d", var1, var2));
 
   /* PADDLE_ENFORCE_NOT_NULL */
   // correct cases:

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -17,6 +17,7 @@ limitations under the License. */
 
 #include "gtest/gtest.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/errors.h"
 
 TEST(ENFORCE, OK) {
   PADDLE_ENFORCE(true, "Enforce is ok %d now %f", 123, 0.345);
@@ -359,4 +360,103 @@ TEST(enforce, cannot_to_string_type) {
   PADDLE_ENFORCE_EQ(list.begin(), list.end());
   list.push_back(4);
   PADDLE_ENFORCE_NE(list.begin(), list.end());
+}
+
+TEST(Enforce, CICheckRules) {
+  using namespace paddle;  // NOLINT
+
+  int var1 = 1, var2 = 1;
+  std::unique_ptr<int> ptr(new int);
+
+  /* PADDLE_THROW */
+  // correct cases:
+  PADDLE_THROW(platform::errors::PreconditionNotMet(
+      "This is a correct error message case."));
+  PADDLE_THROW(platform::errors::PreconditionNotMet(
+      "This is a correct error message case, var1(%d) is not equal to var2(%d)",
+      var1, var2));
+  // wrong cases:
+  PADDLE_THROW("");
+  PADDLE_THROW("msg is too short.");
+  PADDLE_THROW("var1(%d) is equal to var2(%d).", var1, var2);
+  PADDLE_THROW("This is a error message case.");
+  PADDLE_THROW("This is a error message case, %var1(%d) is equal to var2(%d)",
+               var1, var2);
+  PADDLE_THROW(platform::errors::PreconditionNotMet());
+  PADDLE_THROW(platform::errors::PreconditionNotMet(""));
+  PADDLE_THROW(platform::errors::PreconditionNotMet("msg is too short."));
+  PADDLE_THROW(
+      platform::errors::PreconditionNotMet("var1(%d)!=var2(%d)", var1, var2));
+
+  /* PADDLE_ENFORCE */
+  // correct cases:
+  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(
+                           "This is a correct error message case."));
+  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(
+                           "This is a correct error message case, var1(%d) is "
+                           "not equal to var2(%d)",
+                           var1, var2));
+  // wrong cases:
+  PADDLE_ENFORCE(true);
+  PADDLE_ENFORCE(true, "");
+  PADDLE_ENFORCE(true, "msg is too short.");
+  PADDLE_ENFORCE(true, "var1(%d) is equal to var2(%d).", var1, var2);
+  PADDLE_ENFORCE(true, "This is a error message case.");
+  PADDLE_ENFORCE(true,
+                 "This is a error message case, %var1(%d) is equal to var2(%d)",
+                 var1, var2);
+  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet());
+  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(""));
+  PADDLE_ENFORCE(true,
+                 platform::errors::PreconditionNotMet("msg is too short."));
+  PADDLE_ENFORCE(true, platform::errors::PreconditionNotMet(
+                           "var1(%d)!=var2(%d)", var1, var2));
+
+  /* PADDLE_ENFORCE_NOT_NULL */
+  // correct cases:
+  PADDLE_ENFORCE_NOT_NULL(
+      ptr, platform::errors::NotFound("This is a correct error message case."));
+  PADDLE_ENFORCE_NOT_NULL(
+      ptr, platform::errors::NotFound("This is a correct error message case, "
+                                      "var1(%d) is not equal to var2(%d)",
+                                      var1, var2));
+  // wrong cases:
+  PADDLE_ENFORCE_NOT_NULL(ptr);
+  PADDLE_ENFORCE_NOT_NULL(ptr, "");
+  PADDLE_ENFORCE_NOT_NULL(ptr, "msg is too short.");
+  PADDLE_ENFORCE_NOT_NULL(ptr, "var1(%d) is equal to var2(%d).", var1, var2);
+  PADDLE_ENFORCE_NOT_NULL(ptr, "This is a error message case.");
+  PADDLE_ENFORCE_NOT_NULL(ptr,
+                          "This is a error message case, "
+                          "var1(%d)!=var2(%d)",
+                          var1, var2);
+  PADDLE_ENFORCE_NOT_NULL(ptr, platform::errors::NotFound());
+  PADDLE_ENFORCE_NOT_NULL(ptr, platform::errors::NotFound(""));
+  PADDLE_ENFORCE_NOT_NULL(ptr, platform::errors::NotFound("msg is too short."));
+  PADDLE_ENFORCE_NOT_NULL(ptr,
+                          platform::errors::NotFound("%d!=%d", var1, var2));
+
+  /* PADDLE_ENFORCE_EQ */
+  // correct cases:
+  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument(
+                                    "This is a correct error message case."));
+  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument(
+                                    "This is a correct error message case, "
+                                    "var1(%d) is not equal to var2(%d)",
+                                    var1, var2));
+  // wrong cases:
+  PADDLE_ENFORCE_EQ(var1, var2);
+  PADDLE_ENFORCE_EQ(var1, var2, "");
+  PADDLE_ENFORCE_EQ(var1, var2, "msg is too short.");
+  PADDLE_ENFORCE_EQ(var1, var2, "var1(%d) is equal to var2(%d).", var1, var2);
+  PADDLE_ENFORCE_EQ(var1, var2, "This is a error message case.");
+  PADDLE_ENFORCE_EQ(var1, var2,
+                    "This is a error message case, var1(%d)!=var2(%d)", var1,
+                    var2);
+  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument());
+  PADDLE_ENFORCE_EQ(var1, var2, platform::errors::InvalidArgument(""));
+  PADDLE_ENFORCE_EQ(var1, var2,
+                    platform::errors::InvalidArgument("msg is too short."));
+  PADDLE_ENFORCE_EQ(var1, var2,
+                    platform::errors::InvalidArgument("%d!=%d", var1, var2));
 }

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -159,7 +159,7 @@ if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
         ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
         failed_num=`expr $failed_num + 1`
         echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_CUDA_SUCCESS instead.\nYou must have one RD (chenwhql (Recommend) , luotao1 (Recommend) or lanxianghit) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n${ALL_PADDLE_ENFORCE}\n"
-        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
+        echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
     fi
 fi
 
@@ -181,7 +181,7 @@ fi
 
 if [ -n "${echo_list}" ];then
   echo "****************"
-  echo -e ${echo_list[@]}
+  echo -e "${echo_list[@]}"
   echo "There are ${failed_num} approved errors."
   echo "****************"
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -136,15 +136,29 @@ if [ ${HAS_DEFINE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     fi
 fi
 
+ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
+VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
+INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`if [ ${INVALID_PADDLE_CHECK} ] && [ "${GIT_PR_ID}" != "" ]; then
+    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
+    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
+    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
+    if [ "${APPROVALS}" == "FALSE" ]; then
+        failed_num=`expr $failed_num + 1`
+        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
+        echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
+    fi
+fi
+
 HAS_PADDLE_ENFORCE_FLAG=`git diff -U0 upstream/$BRANCH |grep "+" |grep -v "PADDLE_ENFORCE_" |grep -o -m 1 "PADDLE_ENFORCE" || true`
 if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
     python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
     if [ "${APPROVALS}" == "FALSE" ]; then
+        ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
         failed_num=`expr $failed_num + 1`
-        echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_CUDA_SUCCESS instead.\nYou must have one RD (chenwhql (Recommend) , luotao1 (Recommend) or lanxianghit) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n"
-        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
+        echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_CUDA_SUCCESS instead.\nYou must have one RD (chenwhql (Recommend) , luotao1 (Recommend) or lanxianghit) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n${ALL_PADDLE_ENFORCE}\n"
+        echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
     fi
 fi
 
@@ -164,39 +178,10 @@ if [ "${NEW_OP_ADDED}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     fi
 fi
 
-ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE[A-Z_]{0,9}\(.[^,\);]+.[^;]*\);\s" || true`
-VALID_PADDLE_ENFORCE=`echo "$ALL_PADDLE_ENFORCE" | grep -zoE 'PADDLE_ENFORCE[A-Z_]{0,9}\((.[^,;]+,)+.[^";]*(InvalidArgument|NotFound|OutOfRange|AlreadyExists|ResourceExhausted|PreconditionNotMet|PermissionDenied|ExecutionTimeout|Unimplemented|Unavailable|Fatal|External).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
-INVALID_PADDLE_ENFORCE=`echo "$ALL_PADDLE_ENFORCE" | grep -vx "$VALID_PADDLE_ENFORCE" || true`
-if [ ${INVALID_PADDLE_ENFORCE} ] && [ "${GIT_PR_ID}" != "" ]; then
-    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
-    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
-    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
-    if [ "${APPROVALS}" == "FALSE" ]; then
-        failed_num=`expr $failed_num + 1`
-        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\n The PADDDLE_ENFORCE entries that do not meet the specification are as follows:\n ${INVALID_PADDLE_ENFORCE} \n"
-        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
-    fi
-fi
-
-ALL_PADDLE_THROW=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_THROW\(.[^;]*\);\s" || true`
-VALID_PADDLE_THROW=`echo "$ALL_PADDLE_THROW" |grep -zoE 'PADDLE_THROW\(.[^";]*(InvalidArgument|NotFound|OutOfRange|AlreadyExists|ResourceExhausted|PreconditionNotMet|PermissionDenied|ExecutionTimeout|Unimplemented|Unavailable|Fatal|External).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
-INVALID_PADDLE_THROW=`echo "$ALL_PADDLE_THROW" |grep -vx "$VALID_PADDLE_THROW" || true`
-if [ ${INVALID_PADDLE_THROW} ] && [ "${GIT_PR_ID}" != "" ]; then
-    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
-    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
-    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
-    if [ "${APPROVALS}" == "FALSE" ]; then
-        failed_num=`expr $failed_num + 1`
-        echo_line="The error message you wrote in PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\n The PADDDLE_THROW entries that do not meet the specification are as follows:\n ${INVALID_PADDLE_THROW} \n"
-        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
-    fi
-fi
-
 if [ -n "${echo_list}" ];then
   echo "****************"
   echo -e ${echo_list[@]}
-  git diff -U0 upstream/$BRANCH |grep "+" |grep -v "PADDLE_ENFORCE_" |grep "PADDLE_ENFORCE"
-  echo "There are ${failed_num} approved errors."
+  echo "There are ${failed_num}git g approved errors."
   echo "****************"
 fi
 

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -138,7 +138,8 @@ fi
 
 ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
 VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
-INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`if [ ${INVALID_PADDLE_CHECK} ] && [ "${GIT_PR_ID}" != "" ]; then
+INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`
+if [ ${INVALID_PADDLE_CHECK} ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
     python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -145,7 +145,7 @@ if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
     if [ "${APPROVALS}" == "FALSE" ]; then
         failed_num=`expr $failed_num + 1`
-        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
+        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n"${INVALID_PADDLE_CHECK}"\n"
         echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
     fi
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -139,7 +139,7 @@ fi
 ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
 VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
 INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`
-if [ ${INVALID_PADDLE_CHECK} ] && [ "${GIT_PR_ID}" != "" ]; then
+if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
     python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
@@ -159,7 +159,7 @@ if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
         ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
         failed_num=`expr $failed_num + 1`
         echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_CUDA_SUCCESS instead.\nYou must have one RD (chenwhql (Recommend) , luotao1 (Recommend) or lanxianghit) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n${ALL_PADDLE_ENFORCE}\n"
-        echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
+        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
     fi
 fi
 

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -136,20 +136,6 @@ if [ ${HAS_DEFINE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     fi
 fi
 
-ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
-VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
-INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`
-if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
-    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
-    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
-    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
-    if [ "${APPROVALS}" == "FALSE" ]; then
-        failed_num=`expr $failed_num + 1`
-        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n"${INVALID_PADDLE_CHECK}"\n"
-        echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
-    fi
-fi
-
 HAS_PADDLE_ENFORCE_FLAG=`git diff -U0 upstream/$BRANCH |grep "+" |grep -v "PADDLE_ENFORCE_" |grep -o -m 1 "PADDLE_ENFORCE" || true`
 if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
@@ -159,6 +145,20 @@ if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
         ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
         failed_num=`expr $failed_num + 1`
         echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_CUDA_SUCCESS instead.\nYou must have one RD (chenwhql (Recommend) , luotao1 (Recommend) or lanxianghit) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n${ALL_PADDLE_ENFORCE}\n"
+        echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
+    fi
+fi
+
+ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
+VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
+INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`
+if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
+    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
+    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
+    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
+    if [ "${APPROVALS}" == "FALSE" ]; then
+        failed_num=`expr $failed_num + 1`
+        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
         echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
     fi
 fi

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -181,7 +181,7 @@ fi
 if [ -n "${echo_list}" ];then
   echo "****************"
   echo -e ${echo_list[@]}
-  echo "There are ${failed_num}git g approved errors."
+  echo "There are ${failed_num} approved errors."
   echo "****************"
 fi
 

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -164,6 +164,34 @@ if [ "${NEW_OP_ADDED}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     fi
 fi
 
+ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE[A-Z_]{0,9}\(.[^,\);]+.[^;]*\);\s" || true`
+VALID_PADDLE_ENFORCE=`echo "$ALL_PADDLE_ENFORCE" | grep -zoE 'PADDLE_ENFORCE[A-Z_]{0,9}\((.[^,;]+,)+.[^";]*(InvalidArgument|NotFound|OutOfRange|AlreadyExists|ResourceExhausted|PreconditionNotMet|PermissionDenied|ExecutionTimeout|Unimplemented|Unavailable|Fatal|External).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
+INVALID_PADDLE_ENFORCE=`echo "$ALL_PADDLE_ENFORCE" | grep -vx "$VALID_PADDLE_ENFORCE" || true`
+if [ ${INVALID_PADDLE_ENFORCE} ] && [ "${GIT_PR_ID}" != "" ]; then
+    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
+    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
+    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
+    if [ "${APPROVALS}" == "FALSE" ]; then
+        failed_num=`expr $failed_num + 1`
+        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\n The PADDDLE_ENFORCE entries that do not meet the specification are as follows:\n ${INVALID_PADDLE_ENFORCE} \n"
+        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
+    fi
+fi
+
+ALL_PADDLE_THROW=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_THROW\(.[^;]*\);\s" || true`
+VALID_PADDLE_THROW=`echo "$ALL_PADDLE_THROW" |grep -zoE 'PADDLE_THROW\(.[^";]*(InvalidArgument|NotFound|OutOfRange|AlreadyExists|ResourceExhausted|PreconditionNotMet|PermissionDenied|ExecutionTimeout|Unimplemented|Unavailable|Fatal|External).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
+INVALID_PADDLE_THROW=`echo "$ALL_PADDLE_THROW" |grep -vx "$VALID_PADDLE_THROW" || true`
+if [ ${INVALID_PADDLE_THROW} ] && [ "${GIT_PR_ID}" != "" ]; then
+    APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
+    python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
+    echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
+    if [ "${APPROVALS}" == "FALSE" ]; then
+        failed_num=`expr $failed_num + 1`
+        echo_line="The error message you wrote in PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\n The PADDDLE_THROW entries that do not meet the specification are as follows:\n ${INVALID_PADDLE_THROW} \n"
+        echo_list=(${echo_list[@]}$failed_num "." $echo_line)
+    fi
+fi
+
 if [ -n "${echo_list}" ];then
   echo "****************"
   echo -e ${echo_list[@]}

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -158,7 +158,7 @@ if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
     if [ "${APPROVALS}" == "FALSE" ]; then
         failed_num=`expr $failed_num + 1`
-        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified / 4. the internal variable name is used / 5. the English grammar is wrong, etc. Please read the specification [ http://agroup.baidu.com/paddlepaddle/md/article/2267381 ], then refine the error message. If a mismatch occurs, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
+        echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified. Please read the specification [ https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification ], then refine the error message. If it is a mismatch, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
         echo_list=(${echo_list[@]}$failed_num "." "$echo_line")
     fi
 fi


### PR DESCRIPTION
为了规范Paddle的报错信息，我们制订了报错信息文案的书写规范，该PR将规范中可监控的规则加入到了CI检查中。( In order to standardize Paddle's error message, we have written a specification for the error message writing. This PR adds the rules that can be monitored in the specification to the CI check. )

新增的CI检查规则只检查一个PR中新增代码中的Enforce，不涉及存量问题的处理。

CI检查点包括：
- 没有报错信息
- 错信息长度不足20个字符
- 没有指定错误类型
- 有错误类型，但是没有报错信息
- 有错误类型，但是报错信息长度不足20个字符

最新的CI检查失败提示：
The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified. Please read the specification [ https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification ], then refine the error message. If it is a mismatch, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
 

CI检查触发示例
http://ci.paddlepaddle.org/viewLog.html?buildId=217373&buildTypeId=YYTest_PrCiCpuPy2&tab=buildLog
![image](https://user-images.githubusercontent.com/22561442/68589098-0741a600-04c6-11ea-8a5b-f209fca0c933.png)
