### PR TITLE
Add control flow api: case

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1798,14 +1798,15 @@ def cond(pred, true_fn=None, false_fn=None, name=None):
 
 
 def _error_message(what, arg_name, op_name, right_value, error_value):
-    raise TypeError(
-        "{what} of '{arg_name}' in Op({op_name}) "
-        "must be {right_value}, but received: {error_value}.".format(
-            what=what,
-            arg_name=arg_name,
-            op_name=op_name,
-            right_value=right_value,
-            error_value=error_value))
+    error_message = "{what} of '{arg_name}' in Op({op_name}) must be " \
+        "{right_value}, but received: {error_value}.".format(
+        what=what,
+        arg_name=arg_name,
+        op_name=op_name,
+        right_value=right_value,
+        error_value=error_value)
+
+    return error_message
 
 
 def case(pred_fn_pairs, default=None, name=None):

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1814,14 +1814,12 @@ def case(pred_fn_pairs, default=None, name=None):
     This operator works like an if-elif-elif-else chain.
 
     Args:
-        pred_fn_pairs(list|tuple): A list or tuple of (pred, fn) pairs. ``pred`` is a boolean Tensor with shape [1],  ``fn`` is callable.
-        All callables return the same structure of Tensors.
+        pred_fn_pairs(list|tuple): A list or tuple of (pred, fn) pairs. ``pred`` is a boolean Tensor with shape [1], ``fn`` is a callable. All callables return the same structure of Tensors.
         default(callable, optional): Callable that returns a structure of Tensors.
-        name(str, optional): The default value is None. Normally there is no need for user to set this property.
-                            For more information, please refer to :ref:`api_guide_Name`.
+        name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
-        Tensors returned by the callable from the first pair whose pred is True,
+        Variable|list(Variable): Tensors returned by the callable from the first pair whose pred is True,
         or Tensors returned by ``default`` if no pred in ``pred_fn_pairs`` is True and ``default`` is not None,
         or Tensors returned by the last callable in ``pred_fn_pairs``  if no pred in ``pred_fn_pairs`` is True and ``default`` is None.
 
@@ -1856,14 +1854,14 @@ def case(pred_fn_pairs, default=None, name=None):
 
                 pred_1 = layers.less_than(z, x)  # true: 0.2 < 0.3
                 pred_2 = layers.less_than(x, y)  # false: 0.3 < 0.1
-                pred_3 = layers.equal(x, y)  # false: 0.3 == 0.1
+                pred_3 = layers.equal(x, y)      # false: 0.3 == 0.1
 
                 # Call fn_1 because pred_1 is True
                 out_1 = layers.case(
                     pred_fn_pairs=[(pred_1, fn_1), (pred_2, fn_2)], default=fn_3)
 
-                # Argument default is None and no pred in ``pred_fn_pairs`` is True. fn_3 will be called.
-                # because fn_3 is the last callable in ``pred_fn_pairs``.
+                # Argument default is None and no pred in pred_fn_pairs is True. fn_3 will be called.
+                # because fn_3 is the last callable in pred_fn_pairs.
                 out_2 = layers.case(pred_fn_pairs=[(pred_2, fn_2), (pred_3, fn_3)])
 
                 exe = fluid.Executor(fluid.CPUPlace())

--- a/python/paddle/fluid/tests/unittests/test_case.py
+++ b/python/paddle/fluid/tests/unittests/test_case.py
@@ -144,7 +144,6 @@ class TestAPICase_Nested(unittest.TestCase):
                 fn_2, x=3)), (var_5 == var_6, partial(
                     layers.fill_constant, shape=[2], dtype='int32', value=7))])
             return out
-            #return layers.fill_constant(shape=[4, 3], dtype='int32', value=3)
 
         main_program = Program()
         startup_program = Program()

--- a/python/paddle/fluid/tests/unittests/test_case.py
+++ b/python/paddle/fluid/tests/unittests/test_case.py
@@ -1,0 +1,228 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+import paddle.fluid.layers as layers
+from paddle.fluid.framework import Program, program_guard
+from functools import partial
+
+
+class TestAPICase(unittest.TestCase):
+    def test_return_single_var(self):
+        def fn_1():
+            return layers.fill_constant(shape=[4, 2], dtype='int32', value=1)
+
+        def fn_2():
+            return layers.fill_constant(shape=[4, 2], dtype='int32', value=2)
+
+        def fn_3():
+            return layers.fill_constant(shape=[4, 3], dtype='int32', value=3)
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            x = layers.fill_constant(shape=[1], dtype='float32', value=0.3)
+            y = layers.fill_constant(shape=[1], dtype='float32', value=0.1)
+            z = layers.fill_constant(shape=[1], dtype='float32', value=0.2)
+            pred_2 = layers.less_than(x, y)  # false: 0.3 < 0.1
+            pred_1 = layers.less_than(z, x)  # true: 0.2 < 0.3
+
+            # call fn_1
+            out_0 = layers.case(
+                pred_fn_pairs=[(pred_1, fn_1), (pred_1, fn_2)], default=fn_3)
+
+            # call fn_2
+            out_1 = layers.case(
+                pred_fn_pairs=[(pred_2, fn_1), (pred_1, fn_2)], default=fn_3)
+
+            # call default fn_3
+            out_2 = layers.case(
+                pred_fn_pairs=((pred_2, fn_1), (pred_2, fn_2)), default=fn_3)
+
+            # no default, call fn_2
+            out_3 = layers.case(pred_fn_pairs=[(pred_1, fn_2)])
+
+            # no default, call fn_2. but pred_2 is false
+            out_4 = layers.case(pred_fn_pairs=[(pred_2, fn_2)])
+
+            place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+            ) else fluid.CPUPlace()
+            exe = fluid.Executor(place)
+
+            res = exe.run(main_program,
+                          fetch_list=[out_0, out_1, out_2, out_3, out_4])
+
+            self.assertTrue(np.allclose(res[0], 1))
+            self.assertTrue(np.allclose(res[1], 2))
+            self.assertTrue(np.allclose(res[2], 3))
+            self.assertTrue(np.allclose(res[3], 2))
+            self.assertTrue(np.allclose(res[4], 2))
+
+    def test_return_var_tuple(self):
+        def fn_1():
+            return layers.fill_constant(
+                shape=[1, 2], dtype='int32', value=1), layers.fill_constant(
+                    shape=[2, 3], dtype='float32', value=2)
+
+        def fn_2():
+            return layers.fill_constant(
+                shape=[3, 4], dtype='int32', value=3), layers.fill_constant(
+                    shape=[4, 5], dtype='float32', value=4)
+
+        def fn_3():
+            return layers.fill_constant(
+                shape=[5], dtype='int32', value=5), layers.fill_constant(
+                    shape=[5, 6], dtype='float32', value=6)
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            x = layers.fill_constant(shape=[1], dtype='float32', value=1)
+            y = layers.fill_constant(shape=[1], dtype='float32', value=1)
+            z = layers.fill_constant(shape=[1], dtype='float32', value=3)
+
+            pred_1 = layers.equal(x, y)  # true
+            pred_2 = layers.equal(x, z)  # false
+
+            out = layers.case(((pred_1, fn_1), (pred_2, fn_2)), fn_3)
+
+            place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+            ) else fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            ret = exe.run(main_program, fetch_list=out)
+
+            self.assertTrue(
+                np.allclose(np.asarray(ret[0]), np.full((1, 2), 1, np.int32)))
+            self.assertTrue(
+                np.allclose(
+                    np.asarray(ret[1]), np.full((2, 3), 2, np.float32)))
+
+
+class TestAPICase_Nested(unittest.TestCase):
+    def test_nested_case(self):
+        def fn_1(x=1):
+            var_5 = layers.fill_constant(shape=[1], dtype='int32', value=5)
+            var_6 = layers.fill_constant(shape=[1], dtype='int32', value=6)
+            out = layers.case(pred_fn_pairs=[(var_5 < var_6, partial(
+                layers.fill_constant, shape=[1], dtype='int32', value=x)),
+                                             (var_5 == var_6, partial(
+                                                 layers.fill_constant,
+                                                 shape=[2],
+                                                 dtype='int32',
+                                                 value=x))])
+            return out
+
+        def fn_2(x=2):
+            var_5 = layers.fill_constant(shape=[1], dtype='int32', value=5)
+            var_6 = layers.fill_constant(shape=[1], dtype='int32', value=6)
+            out = layers.case(pred_fn_pairs=[(var_5 < var_6, partial(
+                fn_1, x=x)), (var_5 == var_6, partial(
+                    layers.fill_constant, shape=[2], dtype='int32', value=x))])
+            return out
+
+        def fn_3():
+            var_5 = layers.fill_constant(shape=[1], dtype='int32', value=5)
+            var_6 = layers.fill_constant(shape=[1], dtype='int32', value=6)
+            out = layers.case(pred_fn_pairs=[(var_5 < var_6, partial(
+                fn_2, x=3)), (var_5 == var_6, partial(
+                    layers.fill_constant, shape=[2], dtype='int32', value=7))])
+            return out
+            #return layers.fill_constant(shape=[4, 3], dtype='int32', value=3)
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            x = layers.fill_constant(shape=[1], dtype='float32', value=0.3)
+            y = layers.fill_constant(shape=[1], dtype='float32', value=0.1)
+            z = layers.fill_constant(shape=[1], dtype='float32', value=0.2)
+            pred_2 = layers.less_than(x, y)  # false: 0.3 < 0.1
+            pred_1 = layers.less_than(z, x)  # true: 0.2 < 0.3
+
+            out_1 = layers.case(
+                pred_fn_pairs=[(pred_1, fn_1), (pred_2, fn_2)], default=fn_3)
+
+            out_2 = layers.case(
+                pred_fn_pairs=[(pred_2, fn_1), (pred_1, fn_2)], default=fn_3)
+
+            out_3 = layers.case(
+                pred_fn_pairs=[(x == y, fn_1), (x == z, fn_2)], default=fn_3)
+
+            place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+            ) else fluid.CPUPlace()
+            exe = fluid.Executor(place)
+
+            res = exe.run(main_program, fetch_list=[out_1, out_2, out_3])
+
+            self.assertTrue(np.allclose(res[0], 1))
+            self.assertTrue(np.allclose(res[1], 2))
+            self.assertTrue(np.allclose(res[2], 3))
+
+
+class TestAPICase_Error(unittest.TestCase):
+    def test_error(self):
+        def fn_1():
+            return layers.fill_constant(shape=[4, 2], dtype='int32', value=1)
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            x = layers.fill_constant(shape=[1], dtype='float32', value=0.23)
+            z = layers.fill_constant(shape=[1], dtype='float32', value=0.2)
+            pred_1 = layers.less_than(z, x)  # true
+
+            # The type of 'pred_fn_pairs' in case must be list or  tuple
+            def type_error_pred_fn_pairs():
+                layers.case(pred_fn_pairs=1, default=fn_1)
+
+            self.assertRaises(TypeError, type_error_pred_fn_pairs)
+
+            # The elements' type of 'pred_fn_pairs' in Op(case) must be tuple
+            def type_error_pred_fn_1():
+                layers.case(pred_fn_pairs=[1], default=fn_1)
+
+            self.assertRaises(TypeError, type_error_pred_fn_1)
+
+            # The tuple's size of 'pred_fn_pairs' in Op(case) must be 2
+            def type_error_pred_fn_2():
+                layers.case(pred_fn_pairs=[(1, 2, 3)], default=fn_1)
+
+            self.assertRaises(TypeError, type_error_pred_fn_2)
+
+            # The pred's type of 'pred_fn_pairs' in Op(case) must be bool Variable
+            def type_error_pred():
+                layers.case(pred_fn_pairs=[(1, fn_1)], default=fn_1)
+
+            self.assertRaises(TypeError, type_error_pred)
+
+            # The function of pred_fn_pairs in case must be callable
+            def type_error_fn():
+                layers.case(pred_fn_pairs=[(pred_1, 2)], default=fn_1)
+
+            self.assertRaises(TypeError, type_error_fn)
+
+            # The default in Op(case) must be callable
+            def type_error_default():
+                layers.case(pred_fn_pairs=[(pred_1, fn_1)], default=fn_1())
+
+            self.assertRaises(TypeError, type_error_default)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- ### Add a control flow API: `case`
```
case(pred_fn_pairs, default=None, name=None)
```
> #### `case` works like an `if-elif-elif-else` chain.
- ### API document
- Chinese Docment: https://github.com/PaddlePaddle/FluidDoc/pull/1629

- English docment:
![image](https://user-images.githubusercontent.com/33742067/68769524-6be43880-065f-11ea-9765-2e5951ad702b.png)

