### PR TITLE
remove build_once & name_scope

### DIFF
--- a/python/paddle/fluid/contrib/layers/rnn_impl.py
+++ b/python/paddle/fluid/contrib/layers/rnn_impl.py
@@ -104,12 +104,12 @@ class BasicGRUUnit(Layer):
             dtype=self._dtype)
 
         self._gate_bias = self.create_parameter(
-            self._bias_attr,
+            attr=self._bias_attr,
             shape=[2 * self._hiden_size],
             dtype=self._dtype,
             is_bias=True)
         self._candidate_bias = self.create_parameter(
-            self._bias_attr,
+            attr=self._bias_attr,
             shape=[self._hiden_size],
             dtype=self._dtype,
             is_bias=True)

--- a/python/paddle/fluid/dygraph/checkpoint.py
+++ b/python/paddle/fluid/dygraph/checkpoint.py
@@ -48,7 +48,7 @@ def save_dygraph(state_dict, model_path):
             import paddle.fluid as fluid
 
             with fluid.dygraph.guard():
-                emb = fluid.dygraph.Embedding( "emb", [10, 10])
+                emb = fluid.dygraph.Embedding([10, 10])
 
                 state_dict = emb.state_dict()
                 fluid.save_dygraph( state_dict, "paddle_dy")
@@ -91,7 +91,7 @@ def load_dygraph(model_path):
             import paddle.fluid as fluid
             
             with fluid.dygraph.guard():
-                emb = fluid.dygraph.Embedding( "emb", [10, 10])
+                emb = fluid.dygraph.Embedding([10, 10])
 
                 state_dict = emb.state_dict()
                 fluid.save_dygraph( state_dict, "paddle_dy")

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -36,7 +36,7 @@ class Layer(core.Layer):
     Parameters:
         name_scope (str, optional): prefix name used by the layer to name parameters.
             If prefix is "my_layer", parameter name in MyLayer
-            can be "my_layer_0.w_n", where w is the parameter
+            can be "mylayer_0.w_n", where w is the parameter
             base name and n is an unique suffix auto-generated.
             If None, prefix name will be lower cased class name. Default: None.
         dtype(str or core.VarDesc.VarType, optional): data type of this parameter.
@@ -51,7 +51,11 @@ class Layer(core.Layer):
     def __init__(self, name_scope=None, dtype=core.VarDesc.VarType.FP32):
         if name_scope is None:
             name_scope = self.__class__.__name__.lower()
-        self._full_name = unique_name.generate(name_scope)
+            self._full_name = unique_name.generate(name_scope)
+        else:
+            # TODO: remove name_scope parameter and all hard-coded usages
+            self._full_name = unique_name.generate(name_scope + "/" +
+                                                   self.__class__.__name__)
         self._helper = LayerObjectHelper(self._full_name)
         self._built = False
         self._dtype = dtype

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -34,10 +34,11 @@ class Layer(core.Layer):
     """Dynamic graph Layer based on OOD, includes the parameters of the layer, the structure of the forward graph and so on.
 
     Parameters:
-        name_scope (str): prefix name used by the layer to name parameters.
-            If prefix is "my_model/layer_1", parameter name in MyLayer
-            can be "my_model/layer_1/MyLayer/w_n", where w is the parameter
+        name_scope (str, optional): prefix name used by the layer to name parameters.
+            If prefix is "my_layer", parameter name in MyLayer
+            can be "my_layer_0.w_n", where w is the parameter
             base name and n is an unique suffix auto-generated.
+            If None, prefix name will be lower cased class name. Default: None.
         dtype(str or core.VarDesc.VarType, optional): data type of this parameter.
                 If set str, it can be "bool",  "float16", "float32", "float64",
                 "int8", "int16", "int32", "int64", "uint8" or "uint16".
@@ -47,16 +48,17 @@ class Layer(core.Layer):
         None
     """
 
-    def __init__(self, name_scope, dtype=core.VarDesc.VarType.FP32):
-        self._full_name = unique_name.generate(name_scope + "/" +
-                                               self.__class__.__name__)
+    def __init__(self, name_scope=None, dtype=core.VarDesc.VarType.FP32):
+        if name_scope is None:
+            name_scope = self.__class__.__name__.lower()
+        self._full_name = unique_name.generate(name_scope)
+        self._helper = LayerObjectHelper(self._full_name)
         self._built = False
         self._dtype = dtype
+
         self._parameters = collections.OrderedDict()
         self._sub_layers = collections.OrderedDict()
         self._loaddict_holder = collections.OrderedDict()
-
-        self._helper = LayerObjectHelper(self._full_name)
 
     def train(self):
         framework._dygraph_tracer().train_mode()

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -79,23 +79,23 @@ class Layer(core.Layer):
         return self._full_name
 
     def create_parameter(self,
-                         attr,
                          shape,
-                         dtype,
+                         attr=None,
+                         dtype='float32',
                          is_bias=False,
                          default_initializer=None):
         """Create parameters for this layer.
         
         Parameters:
-            attr(ParamAttr): Parameter attribute of weight. Please refer to :ref:`api_fluid_ParamAttr`
-            shape(list): shape of the parameter
-            dtype(str or core.VarDesc.VarType): data type of this parameter.
+            shape(list): Shape of the parameter.
+            attr(ParamAttr, optional): Parameter attribute of weight. Please refer to :ref:`api_fluid_ParamAttr`. Default: None.
+            dtype(str or core.VarDesc.VarType or str, optional): Data type of this parameter.
                 If set str, it can be "bool",  "float16", "float32", "float64",
-                "int8", "int16", "int32", "int64", "uint8" or "uint16".
-            is_bias(bool, optional): if this is a bias parameter. Default: False
+                "int8", "int16", "int32", "int64", "uint8" or "uint16". Default: "float32".
+            is_bias(bool, optional): if this is a bias parameter. Default: False.
             default_initializer(Initializer, optional): the default initializer for this parameter.
                 If set None, default initializer will be set to :ref:`api_fluid_initializer_XavierInitializer` and :ref:`api_fluid_initializer_ConstantInitializer`
-                for non-bias and bias parameter, respectively. Default: None
+                for non-bias and bias parameter, respectively. Default: None.
 
         Returns:
             :ref:`api_guide_Variable_en` : created parameter.

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -301,7 +301,7 @@ class Layer(core.Layer):
 
                 import paddle.fluid as fluid
                 with fluid.dygraph.guard():
-                    emb = fluid.dygraph.Embedding( "emb", [10, 10])
+                    emb = fluid.dygraph.Embedding([10, 10])
 
                     state_dict = emb.state_dict()
                     fluid.save_dygraph( state_dict, "paddle_dy")
@@ -339,7 +339,7 @@ class Layer(core.Layer):
 
                 import paddle.fluid as fluid
                 with fluid.dygraph.guard():
-                    emb = fluid.dygraph.Embedding( "emb", [10, 10])
+                    emb = fluid.dygraph.Embedding([10, 10])
 
                     state_dict = emb.state_dict()
                     fluid.save_dygraph( state_dict, "paddle_dy")
@@ -368,7 +368,7 @@ class Layer(core.Layer):
 
                 import paddle.fluid as fluid
                 with fluid.dygraph.guard():
-                    emb = fluid.dygraph.Embedding( "emb", [10, 10])
+                    emb = fluid.dygraph.Embedding([10, 10])
 
                     state_dict = emb.state_dict()
                     fluid.save_dygraph( state_dict, "paddle_dy")

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -2138,16 +2138,18 @@ class BilinearTensorProduct(layers.Layer):
      - :math:`y^\mathrm{T}`: the transpose of :math:`y`.
 
     Parameters:
-       name_scope(str): The name of this class.
-       size (int): The dimension of this layer.
-       name (str): The default value is None. Normally there is no need for user 
-           to set this property. For more information, please refer to :ref:`api_guide_Name`.
+       input1_dim (int): The dimension of each first input.
+       input2_dim (int): The dimension of each second input.
+       output_dim (int): The dimension of output of this layer.
+       name (str, optional): The default value is None. Normally there is no need for user
+           to set this property. For more information, please refer to :ref:`api_guide_Name`. Default: None.
        act (str, optional): Activation to be applied to the output of this layer. The default value is None.
        param_attr (ParamAttr, optional): The parameter attribute for the learnable w, parameters/weights of 
            this layer. The default value is None.
        bias_attr (ParamAttr, optional): The parameter attribute for the bias
            of this layer. If it is set to False, no bias will be added to the output units.
            If it is set to None, the bias is initialized zero. The default value is None.
+       dtype (str, optional): Data type, it can be "float32" or "float64". Default: "float32".
 
     Attribute:
         **weight** (Parameter): the learnable weights of this layer.
@@ -2167,38 +2169,38 @@ class BilinearTensorProduct(layers.Layer):
              layer1 = numpy.random.random((5, 5)).astype('float32')
              layer2 = numpy.random.random((5, 4)).astype('float32')
              bilinearTensorProduct = fluid.dygraph.nn.BilinearTensorProduct(
-                    'BilinearTensorProduct', size=1000)
+                    input1_dim=5, input2_dim=4, output_dim=1000)
              ret = bilinearTensorProduct(fluid.dygraph.base.to_variable(layer1),
                                 fluid.dygraph.base.to_variable(layer2))
     """
 
     def __init__(self,
-                 name_scope,
-                 size,
+                 input1_dim,
+                 input2_dim,
+                 output_dim,
                  name=None,
                  act=None,
                  param_attr=None,
-                 bias_attr=None):
-        super(BilinearTensorProduct, self).__init__(name_scope)
+                 bias_attr=None,
+                 dtype='float32'):
+        super(BilinearTensorProduct, self).__init__()
         self._param_attr = param_attr
         self._bias_attr = bias_attr
         self._act = act
-        self._size = size
         self._name = name
+        self._input1_dim = input1_dim
+        self._input2_dim = input2_dim
+        self._output_dim = output_dim
         self._inputs = dict()
+        self._dtype = dtype
 
-    def _build_once(self, x, y):
-        self._dtype = self._helper.input_dtype(x)
-
-        param_shape = [self._size, x.shape[1], y.shape[1]]
-
+        param_shape = [self._output_dim, self._input1_dim, self._input2_dim]
         self._w = self.create_parameter(
             attr=self._param_attr,
             shape=param_shape,
             dtype=self._dtype,
             is_bias=False)
-
-        bias_size = [1, self._size]
+        bias_size = [1, self._output_dim]
         self._bias_param = self.create_parameter(
             attr=self._bias_attr,
             shape=bias_size,

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -772,7 +772,6 @@ class Pool2D(layers.Layer):
             Output(i ,j) & = \\frac{sum(Input[hstart:hend, wstart:wend])}{(hend - hstart) * (wend - wstart)}
 
     Parameters:
-        name_scope(str) : The name of this class.
         pool_size (int or list or tuple, optional): The pool kernel size. If pool kernel size is a tuple or list,
             it must contain two integers, (pool_size_Height, pool_size_Width).
             Otherwise, the pool kernel size will be a square of an int. Default: -1.
@@ -791,7 +790,6 @@ class Pool2D(layers.Layer):
         ceil_mode (bool, optional): Whether to use the ceil function to calculate output height and width.
             False is the default. If it is set to False, the floor function will be used. Default: False.
         exclusive (bool, optional): Whether to exclude padding points in average pooling mode. Default: True.
-        dtype (str, optional): Data type, it can be "float32" or "float64". Default: "float32". 
 
     Returns:
         None
@@ -811,7 +809,7 @@ class Pool2D(layers.Layer):
 
           with fluid.dygraph.guard():
              data = numpy.random.random((3, 32, 32, 5)).astype('float32')
-             pool2d = fluid.dygraph.Pool2D("pool2d",pool_size=2,
+             pool2d = fluid.dygraph.Pool2D(pool_size=2,
                             pool_type='max',
                             pool_stride=1,
                             global_pooling=False)
@@ -820,7 +818,6 @@ class Pool2D(layers.Layer):
     """
 
     def __init__(self,
-                 name_scope,
                  pool_size=-1,
                  pool_type="max",
                  pool_stride=1,
@@ -828,8 +825,7 @@ class Pool2D(layers.Layer):
                  global_pooling=False,
                  use_cudnn=True,
                  ceil_mode=False,
-                 exclusive=True,
-                 dtype=core.VarDesc.VarType.FP32):
+                 exclusive=True):
         if pool_type not in ["max", "avg"]:
             raise ValueError(
                 "Unknown pool_type: '%s'. It can only be 'max' or 'avg'.",
@@ -843,7 +839,7 @@ class Pool2D(layers.Layer):
         if not isinstance(use_cudnn, bool):
             raise ValueError("use_cudnn should be True or False")
 
-        super(Pool2D, self).__init__(name_scope, dtype=dtype)
+        super(Pool2D, self).__init__()
 
         self._pool_type = pool_type
         self._pool_size = utils.convert_to_list(pool_size, 2, 'pool_size')
@@ -1139,7 +1135,6 @@ class BatchNorm(layers.Layer):
     - :math:`\\beta` : trainable deviation parameter
 
     Parameters:
-        name_scope(str): The name of this class.
         num_channels(int): Indicate the number of channels of the input ``Tensor``.
         act(str, optional): Activation to be applied to the output of batch normalizaiton. Default: None.
         is_test (bool, optional): A flag indicating whether it is in test phrase or not. Default: False.
@@ -1183,12 +1178,11 @@ class BatchNorm(layers.Layer):
           x = np.random.random(size=(3, 10, 3, 7)).astype('float32')
           with fluid.dygraph.guard():
               x = to_variable(x)
-              batch_norm = fluid.BatchNorm("batch_norm", 10)
+              batch_norm = fluid.BatchNorm(10)
               hidden1 = batch_norm(x)
     """
 
     def __init__(self,
-                 name_scope,
                  num_channels,
                  act=None,
                  is_test=False,
@@ -1204,7 +1198,7 @@ class BatchNorm(layers.Layer):
                  do_model_average_for_mean_and_var=True,
                  use_global_stats=False,
                  trainable_statistics=False):
-        super(BatchNorm, self).__init__(name_scope, dtype)
+        super(BatchNorm, self).__init__()
         self._param_attr = param_attr
         self._bias_attr = bias_attr
         self._act = act
@@ -1263,9 +1257,6 @@ class BatchNorm(layers.Layer):
         self._fuse_with_relu = False
         self._use_global_stats = use_global_stats
         self._trainable_statistics = trainable_statistics
-
-    def _build_once(self, input):
-        pass
 
     def forward(self, input):
         # create output

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -370,7 +370,7 @@ class Conv3D(layers.Layer):
           with fluid.dygraph.guard():
               data = numpy.random.random((5, 3, 12, 32, 32)).astype('float32')
               conv3d = fluid.dygraph.nn.Conv3D(
-                    'Conv3D', num_filters=2, filter_size=3, act="relu")
+                    num_channels=3, num_filters=2, filter_size=3, act="relu")
               ret = conv3d(fluid.dygraph.base.to_variable(data))
 
     """
@@ -615,9 +615,8 @@ class Conv3DTranspose(layers.Layer):
 
          with fluid.dygraph.guard():
              data = numpy.random.random((5, 3, 12, 32, 32)).astype('float32')
-
              conv3dTranspose = fluid.dygraph.nn.Conv3DTranspose(
-                    'Conv3DTranspose',
+                    num_channels=3,
                     num_filters=12,
                     filter_size=12,
                     use_cudnn=False)

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1567,15 +1567,17 @@ class LayerNorm(layers.Layer):
                 logging.warn("bias_attr are only avaliable with shift is True")
 
     def forward(self, input):
-        input_ndim = len(input.shape)
+        input_shape = list(input.shape)
+        input_ndim = len(input_shape)
         normalized_ndim = len(self._normalized_shape)
         self._begin_norm_axis = input_ndim - normalized_ndim
-        if input_ndim < normalized_ndim or input.shape[
+        if input_ndim < normalized_ndim or input_shape[
                 self._begin_norm_axis:] != self._normalized_shape:
             str_normalized_shape = str(self._normalized_shape)
-            raise ValueError('Given normalized_shape is ' + str_normalized_shape
-                             + ', expected input with shape [*, ' +
-                             str_normalized_shape[1:])
+            raise ValueError(
+                'Given normalized_shape is ' + str_normalized_shape +
+                ', expected input with shape [*, ' + str_normalized_shape[
+                    1:] + ', but got input shape ' + str(input_shape))
         inputs = dict()
         inputs['X'] = input
         if self._scale:

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1342,7 +1342,6 @@ class Embedding(layers.Layer):
         It will pad all-zero data when ids is 127.
 
     Parameters:
-        name_scope(str): The name of this class.
         size(tuple|list): The shape of the look up table parameter. It should have two elements which indicate the size
             of the dictionary of embeddings and the size of each embedding vector respectively.
         is_sparse(bool): The flag indicating whether to use sparse update. This parameter only
@@ -1387,7 +1386,6 @@ class Embedding(layers.Layer):
           dict_size = 20
           with fluid.dygraph.guard():
               emb = fluid.dygraph.Embedding(
-                  name_scope='embedding',
                   size=[dict_size, 32],
                   param_attr='emb.w',
                   is_sparse=False)
@@ -1402,7 +1400,6 @@ class Embedding(layers.Layer):
               trainable=True)
           with fluid.dygraph.guard():
               emb = fluid.dygraph.Embedding(
-                  name_scope='embedding',
                   size=[128, 100],
                   param_attr= w_param_attrs,
                   is_sparse=False)
@@ -1410,14 +1407,13 @@ class Embedding(layers.Layer):
     """
 
     def __init__(self,
-                 name_scope,
                  size,
                  is_sparse=False,
                  is_distributed=False,
                  padding_idx=None,
                  param_attr=None,
                  dtype='float32'):
-        super(Embedding, self).__init__(name_scope, dtype)
+        super(Embedding, self).__init__()
         self._size = size
         self._is_sparse = is_sparse
         self._is_distributed = is_distributed
@@ -1844,7 +1840,6 @@ class NCE(layers.Layer):
                     words.append(fluid.dygraph.base.to_variable(inp_word[i]))
 
                 emb = fluid.Embedding(
-                    'embedding',
                     size=[dict_size, 32],
                     param_attr='emb.w',
                     is_sparse=False)

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
@@ -34,7 +34,6 @@ from test_dist_base import runtime_main, TestParallelDyGraphRunnerBase
 
 class SimpleImgConvPool(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
                  num_channels,
                  num_filters,
                  filter_size,
@@ -51,10 +50,10 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
                  use_cudnn=False,
                  param_attr=None,
                  bias_attr=None):
-        super(SimpleImgConvPool, self).__init__(name_scope)
+        super(SimpleImgConvPool, self).__init__()
 
         self._conv2d = Conv2D(
-            self.full_name(),
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=filter_size,
             stride=conv_stride,
@@ -85,10 +84,10 @@ class MNIST(fluid.dygraph.Layer):
         super(MNIST, self).__init__(name_scope)
 
         self._simple_img_conv_pool_1 = SimpleImgConvPool(
-            self.full_name(), 1, 20, 5, 2, 2, act="relu")
+            1, 20, 5, 2, 2, act="relu")
 
         self._simple_img_conv_pool_2 = SimpleImgConvPool(
-            self.full_name(), 20, 50, 5, 2, 2, act="relu")
+            20, 50, 5, 2, 2, act="relu")
 
         pool_2_shape = 50 * 4 * 4
         SIZE = 10

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
@@ -65,7 +65,6 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
             use_cudnn=use_cudnn)
 
         self._pool2d = Pool2D(
-            self.full_name(),
             pool_size=pool_size,
             pool_type=pool_type,
             pool_stride=pool_stride,

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
@@ -27,7 +27,7 @@ import paddle.fluid as fluid
 import paddle.fluid.dygraph as dygraph
 from paddle.fluid import core
 from paddle.fluid.optimizer import SGDOptimizer
-from paddle.fluid.dygraph.nn import Conv2D, Pool2D, FC, LayerNorm
+from paddle.fluid.dygraph.nn import Conv2D, Pool2D, FC, BatchNorm
 from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.layer_helper import LayerHelper
 import math
@@ -79,11 +79,11 @@ class ConvBNLayer(fluid.dygraph.Layer):
             bias_attr=False,
             param_attr=fluid.ParamAttr(name="weights"))
 
-        self._layer_norm = LayerNorm(self.full_name(), begin_norm_axis=1)
+        self._batch_norm = BatchNorm(num_filters, act=act)
 
     def forward(self, inputs):
         y = self._conv(inputs)
-        y = self._layer_norm(y)
+        y = self._batch_norm(y)
 
         return y
 

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
@@ -79,11 +79,12 @@ class ConvBNLayer(fluid.dygraph.Layer):
             bias_attr=False,
             param_attr=fluid.ParamAttr(name="weights"))
 
-        self._batch_norm = BatchNorm(num_filters, act=act)
+        # disable BatchNorm in multi-card. disable LayerNorm because of complex input_shape
+        # self._batch_norm = BatchNorm(num_filters, act=act)
 
     def forward(self, inputs):
         y = self._conv(inputs)
-        y = self._batch_norm(y)
+        # y = self._batch_norm(y)
 
         return y
 

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
@@ -60,16 +60,16 @@ def optimizer_setting(params):
 
 class ConvBNLayer(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
+                 num_channels,
                  num_filters,
                  filter_size,
                  stride=1,
                  groups=1,
                  act=None):
-        super(ConvBNLayer, self).__init__(name_scope)
+        super(ConvBNLayer, self).__init__()
 
         self._conv = Conv2D(
-            "conv2d",
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=filter_size,
             stride=stride,
@@ -119,29 +119,28 @@ class SqueezeExcitation(fluid.dygraph.Layer):
 
 class BottleneckBlock(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
                  num_channels,
                  num_filters,
                  stride,
                  cardinality,
                  reduction_ratio,
                  shortcut=True):
-        super(BottleneckBlock, self).__init__(name_scope)
+        super(BottleneckBlock, self).__init__()
 
         self.conv0 = ConvBNLayer(
-            self.full_name(),
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=1,
             act="relu")
         self.conv1 = ConvBNLayer(
-            self.full_name(),
+            num_channels=num_filters,
             num_filters=num_filters,
             filter_size=3,
             stride=stride,
             groups=cardinality,
             act="relu")
         self.conv2 = ConvBNLayer(
-            self.full_name(),
+            num_channels=num_filters,
             num_filters=num_filters * 2,
             filter_size=1,
             act=None)
@@ -153,7 +152,7 @@ class BottleneckBlock(fluid.dygraph.Layer):
 
         if not shortcut:
             self.short = ConvBNLayer(
-                self.full_name(),
+                num_channels=num_channels,
                 num_filters=num_filters * 2,
                 filter_size=1,
                 stride=stride)
@@ -192,7 +191,7 @@ class SeResNeXt(fluid.dygraph.Layer):
             depth = [3, 4, 6, 3]
             num_filters = [128, 256, 512, 1024]
             self.conv0 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=64,
                 filter_size=7,
                 stride=2,
@@ -209,7 +208,7 @@ class SeResNeXt(fluid.dygraph.Layer):
             depth = [3, 4, 23, 3]
             num_filters = [128, 256, 512, 1024]
             self.conv0 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=64,
                 filter_size=7,
                 stride=2,
@@ -226,19 +225,19 @@ class SeResNeXt(fluid.dygraph.Layer):
             depth = [3, 8, 36, 3]
             num_filters = [128, 256, 512, 1024]
             self.conv0 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=64,
                 filter_size=3,
                 stride=2,
                 act='relu')
             self.conv1 = ConvBNLayer(
-                self.full_name(),
+                num_channels=64,
                 num_filters=64,
                 filter_size=3,
                 stride=1,
                 act='relu')
             self.conv2 = ConvBNLayer(
-                self.full_name(),
+                num_channels=64,
                 num_filters=128,
                 filter_size=3,
                 stride=1,
@@ -258,7 +257,6 @@ class SeResNeXt(fluid.dygraph.Layer):
                 bottleneck_block = self.add_sublayer(
                     'bb_%d_%d' % (block, i),
                     BottleneckBlock(
-                        self.full_name(),
                         num_channels=num_channels,
                         num_filters=num_filters[block],
                         stride=2 if i == 0 and block != 0 else 1,

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_se_resnext.py
@@ -92,8 +92,7 @@ class SqueezeExcitation(fluid.dygraph.Layer):
     def __init__(self, name_scope, num_channels, reduction_ratio):
 
         super(SqueezeExcitation, self).__init__(name_scope)
-        self._pool = Pool2D(
-            self.full_name(), pool_size=0, pool_type='avg', global_pooling=True)
+        self._pool = Pool2D(pool_size=0, pool_type='avg', global_pooling=True)
         stdv = 1.0 / math.sqrt(num_channels * 1.0)
         self._squeeze = FC(
             self.full_name(),
@@ -197,11 +196,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 stride=2,
                 act='relu')
             self.pool = Pool2D(
-                self.full_name(),
-                pool_size=3,
-                pool_stride=2,
-                pool_padding=1,
-                pool_type='max')
+                pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
         elif layers == 101:
             cardinality = 32
             reduction_ratio = 16
@@ -214,11 +209,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 stride=2,
                 act='relu')
             self.pool = Pool2D(
-                self.full_name(),
-                pool_size=3,
-                pool_stride=2,
-                pool_padding=1,
-                pool_type='max')
+                pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
         elif layers == 152:
             cardinality = 64
             reduction_ratio = 16
@@ -243,11 +234,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 stride=1,
                 act='relu')
             self.pool = Pool2D(
-                self.full_name(),
-                pool_size=3,
-                pool_stride=2,
-                pool_padding=1,
-                pool_type='max')
+                pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
 
         self.bottleneck_block_list = []
         num_channels = 64
@@ -268,7 +255,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 shortcut = True
 
         self.pool2d_avg = Pool2D(
-            self.full_name(), pool_size=7, pool_type='avg', global_pooling=True)
+            pool_size=7, pool_type='avg', global_pooling=True)
         stdv = 1.0 / math.sqrt(2048 * 1.0)
 
         self.out = FC(self.full_name(),

--- a/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
@@ -23,7 +23,7 @@ from paddle.fluid.dygraph.nn import Conv2D, Pool2D, FC
 
 class SimpleImgConvPool(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
+                 num_channels,
                  num_filters,
                  filter_size,
                  pool_size,
@@ -43,7 +43,7 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
         super(SimpleImgConvPool, self).__init__(name_scope)
 
         self._conv2d = Conv2D(
-            self.full_name(),
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=filter_size,
             stride=conv_stride,
@@ -76,7 +76,7 @@ class MNIST(fluid.dygraph.Layer):
         super(MNIST, self).__init__(name_scope)
 
         self._simple_img_conv_pool_1 = SimpleImgConvPool(
-            self.full_name(),
+            num_channels=3,
             num_filters=20,
             filter_size=5,
             pool_size=2,
@@ -86,7 +86,7 @@ class MNIST(fluid.dygraph.Layer):
             use_cudnn=True)
 
         self._simple_img_conv_pool_2 = SimpleImgConvPool(
-            self.full_name(),
+            num_channels=20,
             num_filters=50,
             filter_size=5,
             pool_size=2,

--- a/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
@@ -40,7 +40,7 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
                  dtype='float32',
                  param_attr=None,
                  bias_attr=None):
-        super(SimpleImgConvPool, self).__init__(name_scope)
+        super(SimpleImgConvPool, self).__init__()
 
         self._conv2d = Conv2D(
             num_channels=num_channels,
@@ -57,7 +57,6 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
             act=act)
 
         self._pool2d = Pool2D(
-            self.full_name(),
             pool_size=pool_size,
             pool_type=pool_type,
             pool_stride=pool_stride,

--- a/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
@@ -30,7 +30,6 @@ from test_imperative_base import new_program_scope
 
 class SimpleImgConvPool(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
                  num_channels,
                  num_filters,
                  filter_size,
@@ -47,10 +46,10 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
                  use_cudnn=False,
                  param_attr=None,
                  bias_attr=None):
-        super(SimpleImgConvPool, self).__init__(name_scope)
+        super(SimpleImgConvPool, self).__init__()
 
         self._conv2d = Conv2D(
-            self.full_name(),
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=filter_size,
             stride=conv_stride,
@@ -81,10 +80,10 @@ class MNIST(fluid.dygraph.Layer):
         super(MNIST, self).__init__(name_scope)
 
         self._simple_img_conv_pool_1 = SimpleImgConvPool(
-            self.full_name(), 1, 20, 5, 2, 2, act="relu")
+            1, 20, 5, 2, 2, act="relu")
 
         self._simple_img_conv_pool_2 = SimpleImgConvPool(
-            self.full_name(), 20, 50, 5, 2, 2, act="relu")
+            20, 50, 5, 2, 2, act="relu")
 
         pool_2_shape = 50 * 4 * 4
         SIZE = 10

--- a/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
@@ -61,7 +61,6 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
             use_cudnn=use_cudnn)
 
         self._pool2d = Pool2D(
-            self.full_name(),
             pool_size=pool_size,
             pool_type=pool_type,
             pool_stride=pool_stride,

--- a/python/paddle/fluid/tests/unittests/test_imperative_auto_prune.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_auto_prune.py
@@ -100,8 +100,8 @@ class AutoPruneLayer3(fluid.Layer):
 class MyLayer(fluid.Layer):
     def __init__(self, name_scope, vocab_size, size, dtype="float32"):
         super(MyLayer, self).__init__(name_scope, dtype)
-        self.embed0 = fluid.Embedding(self.full_name(), size=(vocab_size, size))
-        self.embed1 = fluid.Embedding(self.full_name(), size=(vocab_size, size))
+        self.embed0 = fluid.Embedding(size=(vocab_size, size))
+        self.embed1 = fluid.Embedding(size=(vocab_size, size))
         self.fc0 = fluid.FC(self.full_name(), size=size, dtype=dtype)
         self.fc1 = fluid.FC(self.full_name(), size=size, dtype=dtype)
 
@@ -122,8 +122,8 @@ class MyLayer(fluid.Layer):
 class MyLayer2(fluid.Layer):
     def __init__(self, name_scope, vocab_size, size, dtype="float32"):
         super(MyLayer2, self).__init__(name_scope, dtype)
-        self.embed0 = fluid.Embedding(self.full_name(), size=(vocab_size, size))
-        self.embed1 = fluid.Embedding(self.full_name(), size=(vocab_size, size))
+        self.embed0 = fluid.Embedding(size=(vocab_size, size))
+        self.embed1 = fluid.Embedding(size=(vocab_size, size))
         self.fc0 = fluid.FC(self.full_name(), size=size, dtype=dtype)
         self.fc1 = fluid.FC(self.full_name(), size=size, dtype=dtype)
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_deepcf.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_deepcf.py
@@ -90,9 +90,9 @@ class DeepCF(fluid.Layer):
         self._num_users = num_users
         self._num_items = num_items
         self._rating_matrix = self.create_parameter(
-            fluid.ParamAttr(trainable=False),
-            matrix.shape,
-            matrix.dtype,
+            attr=fluid.ParamAttr(trainable=False),
+            shape=matrix.shape,
+            dtype=matrix.dtype,
             is_bias=False,
             default_initializer=fluid.initializer.NumpyArrayInitializer(matrix))
         self._rating_matrix.stop_gradient = True

--- a/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
@@ -62,7 +62,6 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
             use_cudnn=use_cudnn)
 
         self._pool2d = Pool2D(
-            self.full_name(),
             pool_size=pool_size,
             pool_type=pool_type,
             pool_stride=pool_stride,

--- a/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
@@ -31,7 +31,7 @@ from utils import DyGraphProgramDescTracerTestHelper
 
 class SimpleImgConvPool(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
+                 num_channels,
                  num_filters,
                  filter_size,
                  pool_size,
@@ -47,10 +47,10 @@ class SimpleImgConvPool(fluid.dygraph.Layer):
                  use_cudnn=False,
                  param_attr=None,
                  bias_attr=None):
-        super(SimpleImgConvPool, self).__init__(name_scope)
+        super(SimpleImgConvPool, self).__init__()
 
         self._conv2d = Conv2D(
-            self.full_name(),
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=filter_size,
             stride=conv_stride,
@@ -81,10 +81,10 @@ class MNIST(fluid.dygraph.Layer):
         super(MNIST, self).__init__(name_scope)
 
         self._simple_img_conv_pool_1 = SimpleImgConvPool(
-            self.full_name(), 20, 5, 2, 2, act="relu")
+            1, 20, 5, 2, 2, act="relu")
 
         self._simple_img_conv_pool_2 = SimpleImgConvPool(
-            self.full_name(), 50, 5, 2, 2, act="relu")
+            20, 50, 5, 2, 2, act="relu")
 
         pool_2_shape = 50 * 4 * 4
         SIZE = 10

--- a/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
@@ -57,7 +57,6 @@ class Config(object):
 
 class ConvBNPool(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
                  group,
                  out_ch,
                  channels,
@@ -65,7 +64,7 @@ class ConvBNPool(fluid.dygraph.Layer):
                  is_test=False,
                  pool=True,
                  use_cudnn=True):
-        super(ConvBNPool, self).__init__(name_scope)
+        super(ConvBNPool, self).__init__()
         self.group = group
         self.pool = pool
 
@@ -79,7 +78,7 @@ class ConvBNPool(fluid.dygraph.Layer):
             initializer=fluid.initializer.Normal(0.0, conv_std_1))
 
         self.conv_0_layer = Conv2D(
-            self.full_name(),
+            channels[0],
             out_ch[0],
             3,
             padding=1,
@@ -90,7 +89,7 @@ class ConvBNPool(fluid.dygraph.Layer):
         self.bn_0_layer = BatchNorm(
             self.full_name(), out_ch[0], act=act, is_test=is_test)
         self.conv_1_layer = Conv2D(
-            self.full_name(),
+            out_ch[0],
             num_filters=out_ch[1],
             filter_size=3,
             padding=1,
@@ -125,22 +124,12 @@ class OCRConv(fluid.dygraph.Layer):
     def __init__(self, name_scope, is_test=False, use_cudnn=True):
         super(OCRConv, self).__init__(name_scope)
         self.conv_bn_pool_1 = ConvBNPool(
-            self.full_name(),
-            2, [16, 16], [1, 16],
-            is_test=is_test,
-            use_cudnn=use_cudnn)
+            2, [16, 16], [1, 16], is_test=is_test, use_cudnn=use_cudnn)
         self.conv_bn_pool_2 = ConvBNPool(
-            self.full_name(),
-            2, [32, 32], [16, 32],
-            is_test=is_test,
-            use_cudnn=use_cudnn)
+            2, [32, 32], [16, 32], is_test=is_test, use_cudnn=use_cudnn)
         self.conv_bn_pool_3 = ConvBNPool(
-            self.full_name(),
-            2, [64, 64], [32, 64],
-            is_test=is_test,
-            use_cudnn=use_cudnn)
+            2, [64, 64], [32, 64], is_test=is_test, use_cudnn=use_cudnn)
         self.conv_bn_pool_4 = ConvBNPool(
-            self.full_name(),
             2, [128, 128], [64, 128],
             is_test=is_test,
             pool=False,

--- a/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
@@ -86,8 +86,7 @@ class ConvBNPool(fluid.dygraph.Layer):
             bias_attr=False,
             act=None,
             use_cudnn=use_cudnn)
-        self.bn_0_layer = BatchNorm(
-            self.full_name(), out_ch[0], act=act, is_test=is_test)
+        self.bn_0_layer = BatchNorm(out_ch[0], act=act, is_test=is_test)
         self.conv_1_layer = Conv2D(
             out_ch[0],
             num_filters=out_ch[1],
@@ -97,12 +96,10 @@ class ConvBNPool(fluid.dygraph.Layer):
             bias_attr=False,
             act=None,
             use_cudnn=use_cudnn)
-        self.bn_1_layer = BatchNorm(
-            self.full_name(), out_ch[1], act=act, is_test=is_test)
+        self.bn_1_layer = BatchNorm(out_ch[1], act=act, is_test=is_test)
 
         if self.pool:
             self.pool_layer = Pool2D(
-                self.full_name(),
                 pool_size=2,
                 pool_type='max',
                 pool_stride=2,

--- a/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
@@ -369,8 +369,7 @@ class OCRAttention(fluid.dygraph.Layer):
                      bias_attr=False,
                      act='relu')
         self.embedding = Embedding(
-            self.full_name(), [Config.num_classes + 2, Config.word_vector_dim],
-            dtype='float32')
+            [Config.num_classes + 2, Config.word_vector_dim], dtype='float32')
         self.gru_decoder_with_attention = GRUDecoderWithAttention(
             self.full_name(), Config.decoder_size, Config.num_classes)
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ocr_attention_model.py
@@ -155,7 +155,6 @@ class DynamicGRU(fluid.dygraph.Layer):
         super(DynamicGRU, self).__init__(scope_name)
 
         self.gru_unit = GRUUnit(
-            self.full_name(),
             size * 3,
             param_attr=param_attr,
             bias_attr=bias_attr,
@@ -323,10 +322,7 @@ class GRUDecoderWithAttention(fluid.dygraph.Layer):
                              size=decoder_size * 3,
                              bias_attr=False)
         self.gru_unit = GRUUnit(
-            self.full_name(),
-            size=decoder_size * 3,
-            param_attr=None,
-            bias_attr=None)
+            size=decoder_size * 3, param_attr=None, bias_attr=None)
         self.out_layer = FC(self.full_name(),
                             size=num_classes + 2,
                             bias_attr=None,

--- a/python/paddle/fluid/tests/unittests/test_imperative_ptb_rnn.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ptb_rnn.py
@@ -156,7 +156,6 @@ class PtbModel(fluid.Layer):
             init_scale=init_scale,
             dropout=dropout)
         self.embedding = Embedding(
-            self.full_name(),
             size=[vocab_size, hidden_size],
             dtype='float32',
             is_sparse=False,

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -90,7 +90,7 @@ class ConvBNLayer(fluid.Layer):
             bias_attr=None,
             use_cudnn=False)
 
-        self._batch_norm = BatchNorm(self.full_name(), num_filters, act=act)
+        self._batch_norm = BatchNorm(num_filters, act=act)
 
     def forward(self, inputs):
         y = self._conv(inputs)
@@ -166,11 +166,7 @@ class ResNet(fluid.Layer):
         self.conv = ConvBNLayer(
             num_channels=3, num_filters=64, filter_size=7, stride=2, act='relu')
         self.pool2d_max = Pool2D(
-            self.full_name(),
-            pool_size=3,
-            pool_stride=2,
-            pool_padding=1,
-            pool_type='max')
+            pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
 
         self.bottleneck_block_list = []
         for block in range(len(depth)):
@@ -188,7 +184,7 @@ class ResNet(fluid.Layer):
                 shortcut = True
 
         self.pool2d_avg = Pool2D(
-            self.full_name(), pool_size=7, pool_type='avg', global_pooling=True)
+            pool_size=7, pool_type='avg', global_pooling=True)
 
         import math
         stdv = 1.0 / math.sqrt(2048 * 1.0)

--- a/python/paddle/fluid/tests/unittests/test_imperative_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_save_load.py
@@ -156,7 +156,6 @@ class PtbModel(fluid.Layer):
             init_scale=init_scale,
             dropout=dropout)
         self.embedding = Embedding(
-            self.full_name(),
             size=[vocab_size, hidden_size],
             dtype='float32',
             is_sparse=False,
@@ -890,7 +889,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
 
     def testOnlyLoadParams(self):
         with fluid.dygraph.guard():
-            emb = fluid.dygraph.Embedding("emb", [10, 10])
+            emb = fluid.dygraph.Embedding([10, 10])
             state_dict = emb.state_dict()
             fluid.save_dygraph(state_dict, "emb_dy")
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
@@ -63,16 +63,16 @@ def optimizer_setting(params):
 
 class ConvBNLayer(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
+                 num_channels,
                  num_filters,
                  filter_size,
                  stride=1,
                  groups=1,
                  act=None):
-        super(ConvBNLayer, self).__init__(name_scope)
+        super(ConvBNLayer, self).__init__()
 
         self._conv = Conv2D(
-            self.full_name(),
+            num_channels=num_channels,
             num_filters=num_filters,
             filter_size=filter_size,
             stride=stride,
@@ -119,25 +119,24 @@ class SqueezeExcitation(fluid.dygraph.Layer):
 
 class BottleneckBlock(fluid.dygraph.Layer):
     def __init__(self,
-                 name_scope,
                  num_channels,
                  num_filters,
                  stride,
                  cardinality,
                  reduction_ratio,
                  shortcut=True):
-        super(BottleneckBlock, self).__init__(name_scope)
+        super(BottleneckBlock, self).__init__()
 
         self.conv0 = ConvBNLayer(
-            self.full_name(), num_filters=num_filters, filter_size=1)
+            num_channels=num_channels, num_filters=num_filters, filter_size=1)
         self.conv1 = ConvBNLayer(
-            self.full_name(),
+            num_channels=num_filters,
             num_filters=num_filters,
             filter_size=3,
             stride=stride,
             groups=cardinality)
         self.conv2 = ConvBNLayer(
-            self.full_name(),
+            num_channels=num_filters,
             num_filters=num_filters * 4,
             filter_size=1,
             act='relu')
@@ -149,7 +148,7 @@ class BottleneckBlock(fluid.dygraph.Layer):
 
         if not shortcut:
             self.short = ConvBNLayer(
-                self.full_name(),
+                num_channels=num_channels,
                 num_filters=num_filters * 4,
                 filter_size=1,
                 stride=stride)
@@ -191,7 +190,7 @@ class SeResNeXt(fluid.dygraph.Layer):
             depth = [3, 4, 6, 3]
             num_filters = [128, 256, 512, 1024]
             self.conv0 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=64,
                 filter_size=7,
                 stride=2,
@@ -208,7 +207,7 @@ class SeResNeXt(fluid.dygraph.Layer):
             depth = [3, 4, 23, 3]
             num_filters = [128, 256, 512, 1024]
             self.conv0 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=3,
                 filter_size=7,
                 stride=2,
@@ -225,19 +224,19 @@ class SeResNeXt(fluid.dygraph.Layer):
             depth = [3, 8, 36, 3]
             num_filters = [128, 256, 512, 1024]
             self.conv0 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=3,
                 filter_size=7,
                 stride=2,
                 act='relu')
             self.conv1 = ConvBNLayer(
-                self.full_name(),
+                num_channels=3,
                 num_filters=3,
                 filter_size=7,
                 stride=2,
                 act='relu')
             self.conv2 = ConvBNLayer(
-                self.full_name(),
+                num_channels=7,
                 num_filters=3,
                 filter_size=7,
                 stride=2,
@@ -257,7 +256,6 @@ class SeResNeXt(fluid.dygraph.Layer):
                 bottleneck_block = self.add_sublayer(
                     'bb_%d_%d' % (block, i),
                     BottleneckBlock(
-                        self.full_name(),
                         num_channels=num_channels,
                         num_filters=num_filters[block],
                         stride=2 if i == 0 and block != 0 else 1,

--- a/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_se_resnext.py
@@ -81,7 +81,7 @@ class ConvBNLayer(fluid.dygraph.Layer):
             act=None,
             bias_attr=None)
 
-        self._batch_norm = BatchNorm(self.full_name(), num_filters, act=act)
+        self._batch_norm = BatchNorm(num_filters, act=act)
 
     def forward(self, inputs):
         y = self._conv(inputs)
@@ -94,8 +94,7 @@ class SqueezeExcitation(fluid.dygraph.Layer):
     def __init__(self, name_scope, num_channels, reduction_ratio):
 
         super(SqueezeExcitation, self).__init__(name_scope)
-        self._pool = Pool2D(
-            self.full_name(), pool_size=0, pool_type='avg', global_pooling=True)
+        self._pool = Pool2D(pool_size=0, pool_type='avg', global_pooling=True)
         self._squeeze = FC(
             self.full_name(),
             size=num_channels // reduction_ratio,
@@ -196,11 +195,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 stride=2,
                 act='relu')
             self.pool = Pool2D(
-                self.full_name(),
-                pool_size=3,
-                pool_stride=2,
-                pool_padding=1,
-                pool_type='max')
+                pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
         elif layers == 101:
             cardinality = 32
             reduction_ratio = 16
@@ -213,11 +208,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 stride=2,
                 act='relu')
             self.pool = Pool2D(
-                self.full_name(),
-                pool_size=3,
-                pool_stride=2,
-                pool_padding=1,
-                pool_type='max')
+                pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
         elif layers == 152:
             cardinality = 64
             reduction_ratio = 16
@@ -242,11 +233,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 stride=2,
                 act='relu')
             self.pool = Pool2D(
-                self.full_name(),
-                pool_size=3,
-                pool_stride=2,
-                pool_padding=1,
-                pool_type='max')
+                pool_size=3, pool_stride=2, pool_padding=1, pool_type='max')
 
         self.bottleneck_block_list = []
         num_channels = 64
@@ -267,7 +254,7 @@ class SeResNeXt(fluid.dygraph.Layer):
                 shortcut = True
 
         self.pool2d_avg = Pool2D(
-            self.full_name(), pool_size=7, pool_type='avg', global_pooling=True)
+            pool_size=7, pool_type='avg', global_pooling=True)
         import math
         stdv = 1.0 / math.sqrt(2048 * 1.0)
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
@@ -354,8 +354,7 @@ class PrePostProcessLayer(Layer):
         for cmd in process_cmd:
             if cmd == "n":
                 self._layer_norm = LayerNorm(
-                    (shape_len - 1) * [-1] + [d_model],
-                    begin_norm_axis=shape_len - 1,
+                    normalized_shape=d_model,
                     param_attr=fluid.ParamAttr(
                         initializer=fluid.initializer.Constant(1.)),
                     bias_attr=fluid.ParamAttr(

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -800,19 +800,13 @@ class TestLayer(LayerTest):
         with self.static_graph():
             data_t = layers.data(name='word', shape=[1], dtype='int64')
             emb2 = nn.Embedding(
-                name_scope='embedding',
-                size=[dict_size, 32],
-                param_attr='emb.w',
-                is_sparse=False)
+                size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
             emb_rlt = emb2(data_t)
             static_rlt2 = self.get_static_graph_result(
                 feed={'word': inp_word}, fetch_list=[emb_rlt])[0]
         with self.dynamic_graph():
             emb2 = nn.Embedding(
-                name_scope='embedding',
-                size=[dict_size, 32],
-                param_attr='emb.w',
-                is_sparse=False)
+                size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
             dy_rlt = emb2(base.to_variable(inp_word))
             dy_rlt_value = dy_rlt.numpy()
 
@@ -824,13 +818,9 @@ class TestLayer(LayerTest):
             weight_attr = fluid.ParamAttr(
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
-            emb1 = nn.Embedding(
-                name_scope='embedding', size=[dict_size, 32], is_sparse=False)
+            emb1 = nn.Embedding(size=[dict_size, 32], is_sparse=False)
             emb2 = nn.Embedding(
-                name_scope='embedding',
-                size=[dict_size, 32],
-                param_attr=weight_attr,
-                is_sparse=False)
+                size=[dict_size, 32], param_attr=weight_attr, is_sparse=False)
             rep1 = emb1(base.to_variable(inp_word))
             rep2 = emb2(base.to_variable(inp_word))
             self.assertFalse(np.array_equal(emb1.weight.numpy(), custom_weight))
@@ -896,10 +886,7 @@ class TestLayer(LayerTest):
             sample_weights = layers.fill_constant(
                 shape=[5, 1], dtype='float32', value=1)
             emb = nn.Embedding(
-                'embedding',
-                size=[dict_size, 32],
-                param_attr='emb.w',
-                is_sparse=False)
+                size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
 
             embs2 = []
             for i in range(window_size):
@@ -935,10 +922,7 @@ class TestLayer(LayerTest):
             sample_weights = layers.fill_constant(
                 shape=[5, 1], dtype='float32', value=1)
             emb = nn.Embedding(
-                'embedding',
-                size=[dict_size, 32],
-                param_attr='emb.w',
-                is_sparse=False)
+                size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
 
             embs3 = []
             for i in range(window_size):
@@ -976,10 +960,7 @@ class TestLayer(LayerTest):
             sample_weights = layers.fill_constant(
                 shape=[5, 1], dtype='float32', value=1)
             emb = nn.Embedding(
-                'embedding',
-                size=[dict_size, 32],
-                param_attr='emb.w',
-                is_sparse=False)
+                size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
 
             embs3 = []
             for i in range(window_size):

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -299,7 +299,8 @@ class TestLayer(LayerTest):
 
         with self.static_graph():
             images = layers.data(name='pixel', shape=[3, 5, 5], dtype='float32')
-            conv2d = nn.Conv2D('conv2d', num_filters=3, filter_size=[2, 2])
+            conv2d = nn.Conv2D(
+                num_channels=3, num_filters=3, filter_size=[2, 2])
             ret = conv2d(images)
             static_ret2 = self.get_static_graph_result(
                 feed={'pixel': np.ones(
@@ -308,14 +309,18 @@ class TestLayer(LayerTest):
 
         with self.dynamic_graph():
             images = np.ones([2, 3, 5, 5], dtype='float32')
-            conv2d = nn.Conv2D('conv2d', num_filters=3, filter_size=[2, 2])
+            conv2d = nn.Conv2D(
+                num_channels=3, num_filters=3, filter_size=[2, 2])
             dy_ret = conv2d(base.to_variable(images))
             dy_ret_value = dy_ret.numpy()
 
         with self.dynamic_graph():
             images = np.ones([2, 3, 5, 5], dtype='float32')
             conv2d = nn.Conv2D(
-                'conv2d', num_filters=3, filter_size=[2, 2], bias_attr=False)
+                num_channels=3,
+                num_filters=3,
+                filter_size=[2, 2],
+                bias_attr=False)
             dy_ret = conv2d(base.to_variable(images))
             self.assertTrue(conv2d._bias_param is None)
 
@@ -328,9 +333,10 @@ class TestLayer(LayerTest):
             weight_attr = fluid.ParamAttr(
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
-            conv2d1 = nn.Conv2D('conv2d1', num_filters=3, filter_size=[2, 2])
+            conv2d1 = nn.Conv2D(
+                num_channels=3, num_filters=3, filter_size=[2, 2])
             conv2d2 = nn.Conv2D(
-                'conv2d2',
+                num_channels=3,
                 num_filters=3,
                 filter_size=[2, 2],
                 param_attr=weight_attr)

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -222,7 +222,7 @@ class TestLayer(LayerTest):
                 dtype='float32',
                 append_batch_size=False)
             lm = nn.LayerNorm(
-                'layer_norm',
+                input_shape=t.shape,
                 bias_attr=fluid.initializer.ConstantInitializer(value=1),
                 act='sigmoid')
             ret = lm(t)
@@ -230,14 +230,14 @@ class TestLayer(LayerTest):
                 feed={'data': inp}, fetch_list=[ret])[0]
         with self.dynamic_graph():
             lm = nn.LayerNorm(
-                'layer_norm',
+                input_shape=inp.shape,
                 bias_attr=fluid.initializer.ConstantInitializer(value=1),
                 act='sigmoid')
             dy_ret = lm(base.to_variable(inp))
             dy_ret_value = dy_ret.numpy()
         with self.dynamic_graph():
             lm = nn.LayerNorm(
-                'layer_norm',
+                input_shape=inp.shape,
                 shift=False,
                 scale=False,
                 param_attr=fluid.initializer.ConstantInitializer(value=1),

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1041,7 +1041,7 @@ class TestLayer(LayerTest):
         with self.static_graph():
             images = layers.data(
                 name='pixel', shape=[3, 6, 6, 6], dtype='float32')
-            conv3d = nn.Conv3D('conv3d', num_filters=3, filter_size=2)
+            conv3d = nn.Conv3D(num_channels=3, num_filters=3, filter_size=2)
             ret = conv3d(images)
             static_ret2 = self.get_static_graph_result(
                 feed={'pixel': np.ones(
@@ -1050,7 +1050,7 @@ class TestLayer(LayerTest):
 
         with self.dynamic_graph():
             images = np.ones([2, 3, 6, 6, 6], dtype='float32')
-            conv3d = nn.Conv3D('conv3d', num_filters=3, filter_size=2)
+            conv3d = nn.Conv3D(num_channels=3, num_filters=3, filter_size=2)
             dy_ret = conv3d(base.to_variable(images))
             dy_rlt_value = dy_ret.numpy()
 
@@ -1063,9 +1063,12 @@ class TestLayer(LayerTest):
             weight_attr = fluid.ParamAttr(
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
-            conv3d1 = nn.Conv3D('conv3d1', num_filters=3, filter_size=2)
+            conv3d1 = nn.Conv3D(num_channels=3, num_filters=3, filter_size=2)
             conv3d2 = nn.Conv3D(
-                'conv3d2', num_filters=3, filter_size=2, param_attr=weight_attr)
+                num_channels=3,
+                num_filters=3,
+                filter_size=2,
+                param_attr=weight_attr)
             dy_ret1 = conv3d1(base.to_variable(images))
             dy_ret2 = conv3d2(base.to_variable(images))
             self.assertFalse(np.array_equal(dy_ret1.numpy(), dy_ret2.numpy()))
@@ -1360,19 +1363,13 @@ class TestLayer(LayerTest):
         with self.static_graph():
             img = layers.data(name='pixel', shape=[3, 2, 2, 2], dtype='float32')
             conv3d_transpose = nn.Conv3DTranspose(
-                'Conv3DTranspose',
-                num_filters=12,
-                filter_size=12,
-                use_cudnn=False)
+                num_channels=3, num_filters=12, filter_size=12, use_cudnn=False)
             out = conv3d_transpose(img)
             static_rlt2 = self.get_static_graph_result(
                 feed={'pixel': input_array}, fetch_list=[out])[0]
         with self.dynamic_graph():
             conv3d_transpose = nn.Conv3DTranspose(
-                'Conv3DTranspose',
-                num_filters=12,
-                filter_size=12,
-                use_cudnn=False)
+                num_channels=3, num_filters=12, filter_size=12, use_cudnn=False)
             dy_rlt = conv3d_transpose(base.to_variable(input_array))
             dy_rlt_value = dy_rlt.numpy()
         self.assertTrue(np.allclose(static_rlt2, static_rlt))
@@ -1385,13 +1382,13 @@ class TestLayer(LayerTest):
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
             conv3d1 = nn.Conv3DTranspose(
-                'conv3d1',
+                num_channels=3,
                 num_filters=3,
                 filter_size=2,
                 bias_attr='conv3d1_b',
                 use_cudnn=False)
             conv3d2 = nn.Conv3DTranspose(
-                'conv3d2',
+                num_channels=3,
                 num_filters=3,
                 filter_size=2,
                 param_attr=weight_attr,

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1273,7 +1273,7 @@ class TestLayer(LayerTest):
                 lod_level=1,
                 append_batch_size=False)
             treeConv = nn.TreeConv(
-                'TreeConv', output_size=6, num_filters=1, max_depth=2)
+                feature_size=5, output_size=6, num_filters=1, max_depth=2)
             ret = treeConv(NodesVector, EdgeSet)
             static_ret2 = self.get_static_graph_result(
                 feed={
@@ -1287,7 +1287,7 @@ class TestLayer(LayerTest):
 
         with self.dynamic_graph():
             treeConv = nn.TreeConv(
-                'SpectralNorm', output_size=6, num_filters=1, max_depth=2)
+                feature_size=5, output_size=6, num_filters=1, max_depth=2)
             dy_ret = treeConv(base.to_variable(vectors), base.to_variable(adj))
             dy_rlt_value = dy_ret.numpy()
 
@@ -1300,13 +1300,13 @@ class TestLayer(LayerTest):
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
             treeConv1 = nn.TreeConv(
-                'SpectralNorm1',
+                feature_size=5,
                 output_size=6,
                 num_filters=1,
                 max_depth=2,
                 bias_attr='tc1_b')
             treeConv2 = nn.TreeConv(
-                'SpectralNorm2',
+                feature_size=5,
                 output_size=6,
                 num_filters=1,
                 max_depth=2,

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1152,7 +1152,7 @@ class TestLayer(LayerTest):
                 dtype='float32',
                 lod_level=1,
                 append_batch_size=False)
-            groupNorm = nn.GroupNorm('GroupNorm', groups=2)
+            groupNorm = nn.GroupNorm(channels=shape[1], groups=2)
             ret = groupNorm(X)
             static_ret2 = self.get_static_graph_result(
                 feed={
@@ -1163,7 +1163,7 @@ class TestLayer(LayerTest):
                 with_lod=True)[0]
 
         with self.dynamic_graph():
-            groupNorm = nn.GroupNorm('GroupNorm', groups=2)
+            groupNorm = nn.GroupNorm(channels=shape[1], groups=2)
             dy_ret = groupNorm(base.to_variable(input))
             dy_rlt_value = dy_ret.numpy()
 
@@ -1203,7 +1203,7 @@ class TestLayer(LayerTest):
                 dtype='float32',
                 lod_level=1,
                 append_batch_size=False)
-            spectralNorm = nn.SpectralNorm('SpectralNorm', dim=1, power_iters=2)
+            spectralNorm = nn.SpectralNorm(shape, dim=1, power_iters=2)
             ret = spectralNorm(Weight)
             static_ret2 = self.get_static_graph_result(
                 feed={
@@ -1214,7 +1214,7 @@ class TestLayer(LayerTest):
                 with_lod=True)[0]
 
         with self.dynamic_graph():
-            spectralNorm = nn.SpectralNorm('SpectralNorm', dim=1, power_iters=2)
+            spectralNorm = nn.SpectralNorm(shape, dim=1, power_iters=2)
             dy_ret = spectralNorm(base.to_variable(input))
             dy_rlt_value = dy_ret.numpy()
 

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -545,7 +545,7 @@ class TestLayer(LayerTest):
             out = layers.conv2d_transpose(
                 input=img,
                 num_filters=10,
-                output_size=28,
+                filter_size=27,
                 act='sigmoid',
                 bias_attr=fluid.initializer.ConstantInitializer(value=1))
             static_rlt = self.get_static_graph_result(
@@ -553,9 +553,9 @@ class TestLayer(LayerTest):
         with self.static_graph():
             img = layers.data(name='pixel', shape=[3, 2, 2], dtype='float32')
             conv2d_transpose = nn.Conv2DTranspose(
-                'conv2d_transpose',
+                num_channels=3,
                 num_filters=10,
-                output_size=28,
+                filter_size=27,
                 act='sigmoid',
                 bias_attr=fluid.initializer.ConstantInitializer(value=1))
             out = conv2d_transpose(img)
@@ -563,9 +563,9 @@ class TestLayer(LayerTest):
                 feed={'pixel': inp_np}, fetch_list=[out])[0]
         with self.dynamic_graph():
             conv2d_transpose = nn.Conv2DTranspose(
-                'conv2d_transpose',
+                num_channels=3,
                 num_filters=10,
-                output_size=28,
+                filter_size=27,
                 act='sigmoid',
                 bias_attr=fluid.initializer.ConstantInitializer(value=1))
             dy_rlt = conv2d_transpose(base.to_variable(inp_np))
@@ -580,9 +580,9 @@ class TestLayer(LayerTest):
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
             conv2d1 = nn.Conv2DTranspose(
-                'conv2d1', num_filters=3, filter_size=[2, 2])
+                num_channels=3, num_filters=3, filter_size=[2, 2])
             conv2d2 = nn.Conv2DTranspose(
-                'conv2d2',
+                num_channels=3,
                 num_filters=3,
                 filter_size=[2, 2],
                 param_attr=weight_attr)

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -740,8 +740,8 @@ class TestLayer(LayerTest):
                 append_batch_size=False)
             mode = 'channel'
             prelu = nn.PRelu(
-                'prelu',
                 mode=mode,
+                input_shape=data_t.shape,
                 param_attr=ParamAttr(initializer=Constant(1.0)))
             out = prelu(data_t)
             static_rlt2 = self.get_static_graph_result(
@@ -750,8 +750,8 @@ class TestLayer(LayerTest):
         with self.dynamic_graph():
             mode = 'channel'
             prelu = nn.PRelu(
-                'prelu',
                 mode=mode,
+                input_shape=inp_np.shape,
                 param_attr=ParamAttr(initializer=Constant(1.0)))
             dy_rlt = prelu(base.to_variable(inp_np))
             dy_rlt_value = dy_rlt.numpy()
@@ -764,12 +764,12 @@ class TestLayer(LayerTest):
             inp = base.to_variable(inp_np)
             mode = 'channel'
             prelu1 = nn.PRelu(
-                'prelu1',
                 mode=mode,
+                input_shape=inp_np.shape,
                 param_attr=ParamAttr(initializer=Constant(2.0)))
             prelu2 = nn.PRelu(
-                'prelu2',
                 mode=mode,
+                input_shape=inp_np.shape,
                 param_attr=ParamAttr(initializer=Constant(1.0)))
             dy_rlt1 = prelu1(inp)
             dy_rlt2 = prelu2(inp)

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -222,7 +222,7 @@ class TestLayer(LayerTest):
                 dtype='float32',
                 append_batch_size=False)
             lm = nn.LayerNorm(
-                input_shape=t.shape,
+                normalized_shape=[32, 32],
                 bias_attr=fluid.initializer.ConstantInitializer(value=1),
                 act='sigmoid')
             ret = lm(t)
@@ -230,14 +230,14 @@ class TestLayer(LayerTest):
                 feed={'data': inp}, fetch_list=[ret])[0]
         with self.dynamic_graph():
             lm = nn.LayerNorm(
-                input_shape=inp.shape,
+                normalized_shape=[32, 32],
                 bias_attr=fluid.initializer.ConstantInitializer(value=1),
                 act='sigmoid')
             dy_ret = lm(base.to_variable(inp))
             dy_ret_value = dy_ret.numpy()
         with self.dynamic_graph():
             lm = nn.LayerNorm(
-                input_shape=inp.shape,
+                normalized_shape=[32, 32],
                 shift=False,
                 scale=False,
                 param_attr=fluid.initializer.ConstantInitializer(value=1),
@@ -250,6 +250,14 @@ class TestLayer(LayerTest):
 
         self.assertTrue(np.array_equal(static_ret, static_ret2))
         self.assertTrue(np.array_equal(dy_ret_value, static_ret2))
+
+        with self.dynamic_graph():
+            lm = nn.LayerNorm(
+                normalized_shape=[16, 32],
+                bias_attr=fluid.initializer.ConstantInitializer(value=1),
+                act='sigmoid')
+            with self.assertRaises(ValueError):
+                lm(base.to_variable(inp))
 
     def test_relu(self):
         with self.static_graph():

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -387,7 +387,7 @@ class TestLayer(LayerTest):
             hidden = layers.data(name='hidden', shape=[-1, D], dtype='float32')
             updated_hidden, reset_hidden_pre, gate = layers.gru_unit(
                 input=x, hidden=hidden, size=D * 3)
-            gru = nn.GRUUnit('gru', size=D * 3)
+            gru = nn.GRUUnit(size=D * 3)
             updated_hidden, reset_hidden_pre, gate = gru(x, hidden)
 
             static_ret2 = self.get_static_graph_result(
@@ -396,7 +396,7 @@ class TestLayer(LayerTest):
                 fetch_list=[updated_hidden, reset_hidden_pre, gate])
 
         with self.dynamic_graph():
-            gru = nn.GRUUnit('gru', size=D * 3)
+            gru = nn.GRUUnit(size=D * 3)
             dy_ret = gru(
                 base.to_variable(input), base.to_variable(hidden_input))
             dy_ret_value = []
@@ -412,8 +412,8 @@ class TestLayer(LayerTest):
             weight_attr = fluid.ParamAttr(
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
-            gru1 = nn.GRUUnit('gru1', size=D * 3)
-            gru2 = nn.GRUUnit('gru2', size=D * 3, param_attr=weight_attr)
+            gru1 = nn.GRUUnit(size=D * 3)
+            gru2 = nn.GRUUnit(size=D * 3, param_attr=weight_attr)
             dy_ret1 = gru1(
                 base.to_variable(input), base.to_variable(hidden_input))
             dy_ret2 = gru2(
@@ -897,8 +897,8 @@ class TestLayer(LayerTest):
                 embs2.append(emb_rlt)
 
             embs2 = layers.concat(input=embs2, axis=1)
-            nce = nn.NCE('nce',
-                         num_total_classes=dict_size,
+            nce = nn.NCE(num_total_classes=dict_size,
+                         dim=embs2.shape[1],
                          num_neg_samples=2,
                          sampler="custom_dist",
                          custom_dist=nid_freq_arr.tolist(),
@@ -933,8 +933,8 @@ class TestLayer(LayerTest):
                 embs3.append(emb_rlt)
 
             embs3 = layers.concat(input=embs3, axis=1)
-            nce = nn.NCE('nce',
-                         num_total_classes=dict_size,
+            nce = nn.NCE(num_total_classes=dict_size,
+                         dim=embs3.shape[1],
                          num_neg_samples=2,
                          sampler="custom_dist",
                          custom_dist=nid_freq_arr.tolist(),
@@ -971,8 +971,8 @@ class TestLayer(LayerTest):
                 embs3.append(emb_rlt)
 
             embs3 = layers.concat(input=embs3, axis=1)
-            nce1 = nn.NCE('nce1',
-                          num_total_classes=dict_size,
+            nce1 = nn.NCE(num_total_classes=dict_size,
+                          dim=embs3.shape[1],
                           num_neg_samples=2,
                           sampler="custom_dist",
                           custom_dist=nid_freq_arr.tolist(),
@@ -981,13 +981,13 @@ class TestLayer(LayerTest):
                           bias_attr='nce1.b',
                           sample_weight=sample_weights)
 
-            nce2 = nn.NCE('nce2',
-                          param_attr=weight_attr,
-                          num_total_classes=dict_size,
+            nce2 = nn.NCE(num_total_classes=dict_size,
+                          dim=embs3.shape[1],
                           num_neg_samples=2,
                           sampler="custom_dist",
                           custom_dist=nid_freq_arr.tolist(),
                           seed=seed,
+                          param_attr=weight_attr,
                           bias_attr='nce2.b',
                           sample_weight=sample_weights)
 

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -647,7 +647,8 @@ class TestLayer(LayerTest):
                 dtype="float32",
                 append_batch_size=False)
             btp = nn.BilinearTensorProduct(
-                'btp',
+                3,
+                3,
                 6,
                 bias_attr=fluid.initializer.ConstantInitializer(value=1),
                 act='sigmoid')
@@ -657,14 +658,15 @@ class TestLayer(LayerTest):
                       'y': inp_np_y}, fetch_list=[out])[0]
         with self.dynamic_graph():
             btp = nn.BilinearTensorProduct(
-                'btp',
+                3,
+                3,
                 6,
                 bias_attr=fluid.initializer.ConstantInitializer(value=1),
                 act='sigmoid')
             dy_rlt = btp(base.to_variable(inp_np_x), base.to_variable(inp_np_y))
             dy_rlt_value = dy_rlt.numpy()
         with self.dynamic_graph():
-            btp2 = nn.BilinearTensorProduct('btp', 6, act='sigmoid')
+            btp2 = nn.BilinearTensorProduct(3, 3, 6, act='sigmoid')
             dy_rlt2 = btp2(
                 base.to_variable(inp_np_x), base.to_variable(inp_np_y))
             dy_rlt2_value = dy_rlt2.numpy()
@@ -695,9 +697,9 @@ class TestLayer(LayerTest):
             weight_attr = fluid.ParamAttr(
                 initializer=fluid.initializer.NumpyArrayInitializer(
                     custom_weight))
-            btp1 = nn.BilinearTensorProduct('btp1', 6, act='sigmoid')
+            btp1 = nn.BilinearTensorProduct(3, 3, 6, act='sigmoid')
             btp2 = nn.BilinearTensorProduct(
-                'btp2', 6, act='sigmoid', param_attr=weight_attr)
+                3, 3, 6, act='sigmoid', param_attr=weight_attr)
             dy_rlt1 = btp1(
                 base.to_variable(inp_np_x), base.to_variable(inp_np_y))
             dy_rlt2 = btp2(

--- a/python/paddle/fluid/tests/unittests/test_static_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load.py
@@ -158,7 +158,6 @@ class PtbModel(fluid.Layer):
             init_scale=init_scale,
             dropout=dropout)
         self.embedding = Embedding(
-            self.full_name(),
             size=[vocab_size, hidden_size],
             dtype='float32',
             is_sparse=False,


### PR DESCRIPTION
## Motivation

In dygraph, most `Parameter`s of `Layer`s are created when the `__call__` is first invoked, thus part of the shape of the `Parameter`s can be derived from the input, which is similar to paddle's static graph API.
This design pattern introduces many problems. The model depends on data, when a complex model (a subclass of layer) is inited, there are no parameters in it, and we can't load the previously saved checkpoint before a `__call__`. It also brings troubles to the initialization of custom Parameters.
The creation of `Layer` also requires the `name_scope` parameter, which is unnecessary and troublesome for users.

This PR removes `build_once` function and `name_scope` parameter.

## API changes

### `fluid.dygraph.Layer`
1. `name_scope` parameter is not required in `Layer`'s `__init__`
2. simplify `create_parameter` api, only `shape` is required

### `__init__` of `fluid.dygraph.nn.*`
1. For all subclasses of `Layer`: `name_scope`s are removed, all missing optional `dtype` parameters are added.
1. `Conv2D`, `Conv2DTranspose`, `Conv3D` and `Conv3DTranspose`: add `num_channels` (int): The number of channels in the input image.
1. `LayerNorm`: remove `begin_norm_axis`, add `normalized_shape` (int or list or tuple): Input shape from an expected input of size :math:`[*, normalized_shape[0], normalized_shape[1], ..., normalized_shape[-1]]`. If it is a single integer, this module will normalize over the last dimension which is expected to be of that specific size.
1. `NCE`: add `dim` (int): Dimension of input (possibly embedding dim).
1. `PRelu`: add `input_shape`(list or tuple, optional): The shape of input. This parameter is required when mode is not "all". Default: None.
1. `BilinearTensorProduct`: remove `size`. add `input1_dim` (int): The dimension of each first input. add `input2_dim` (int): The dimension of each second input.
1. `GroupNorm`: add `channels` (int): The number of channels of input.
1. `SpectralNorm`: add `weight_shape` (list or tuple): The shape of weight parameter.
1. `TreeConv`: add `feature_size` (int): last dimension of nodes_vector.

## Migrating

### For existing subclasses of `Layer`:
1. remove `build_once` function, and move `Parameter` creations into `__init__`.
2. avoid positional arguments for `Layer.create_parameter` function, and only `shape` is required.

### For constructions of `Layer`'s subclasses in dygraph models:
1. remove `name_scope` parameter of `__init__`
2. add possible new parameters of `__init__` (these parameters are input shape related)

#### Example (Conv2D)
**before**
```python
import paddle.fluid as fluid
import numpy as np
data = np.random.uniform(-1, 1, [10, 3, 32, 32]).astype('float32')
with fluid.dygraph.guard():
    data = fluid.to_variable(data)
    conv2d = fluid.Conv2D("conv2d", 2, 3)
    conv = conv2d(data)
```

**after**
```python
import paddle.fluid as fluid
import numpy as np
data = np.random.uniform(-1, 1, [10, 3, 32, 32]).astype('float32')
with fluid.dygraph.guard():
    data = fluid.to_variable(data)
    conv2d = fluid.Conv2D(3, 2, 3)  # "conv2d" removed, and 3 is num_channels
    conv = conv2d(data)
```