### PR TITLE
Add relative error measure when (value > 1)

### DIFF
--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -92,6 +92,14 @@ void PrintConfig(const PaddlePredictor::Config *config, bool use_analysis) {
   LOG(INFO) << analysis_config->ToNativeConfig();
 }
 
+void CheckError(float data_ref, float data) {
+  if (std::abs(data_ref) > 1) {
+    CHECK_LE(std::abs((data_ref - data) / data_ref), FLAGS_accuracy);
+  } else {
+    CHECK_LE(std::abs(data_ref - data), FLAGS_accuracy);
+  }
+}
+
 // Compare result between two PaddleTensor
 void CompareResult(const std::vector<PaddleTensor> &outputs,
                    const std::vector<PaddleTensor> &ref_outputs) {
@@ -118,12 +126,7 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
         float *pdata = static_cast<float *>(out.data.data());
         float *pdata_ref = static_cast<float *>(ref_out.data.data());
         for (size_t j = 0; j < size; ++j) {
-          if (std::abs(pdata_ref[j]) > 1) {
-            CHECK_LE(std::abs((pdata_ref[j] - pdata[j]) / pdata_ref[j]),
-                     FLAGS_accuracy);
-          } else {
-            CHECK_LE(std::abs(pdata_ref[j] - pdata[j]), FLAGS_accuracy);
-          }
+          CheckError(pdata_ref[j], pdata[j]);
         }
         break;
       }
@@ -174,12 +177,7 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
         float *pdata_ref = ref_out.data<float>(&place, &ref_size);
         EXPECT_EQ(size, ref_size);
         for (size_t j = 0; j < size; ++j) {
-          if (std::abs(pdata_ref[j]) > 1) {
-            CHECK_LE(std::abs((pdata_ref[j] - pdata[j]) / pdata_ref[j]),
-                     FLAGS_accuracy);
-          } else {
-            CHECK_LE(std::abs(pdata_ref[j] - pdata[j]), FLAGS_accuracy);
-          }
+          CheckError(pdata_ref[j], pdata[j]);
         }
         break;
       }

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -118,7 +118,12 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
         float *pdata = static_cast<float *>(out.data.data());
         float *pdata_ref = static_cast<float *>(ref_out.data.data());
         for (size_t j = 0; j < size; ++j) {
-          CHECK_LE(std::abs(pdata_ref[j] - pdata[j]), FLAGS_accuracy);
+          if (std::abs(pdata_ref[j]) > 1) {
+            CHECK_LE(std::abs((pdata_ref[j] - pdata[j]) / pdata_ref[j]),
+                     FLAGS_accuracy);
+          } else {
+            CHECK_LE(std::abs(pdata_ref[j] - pdata[j]), FLAGS_accuracy);
+          }
         }
         break;
       }
@@ -169,7 +174,12 @@ void CompareResult(const std::vector<PaddleTensor> &outputs,
         float *pdata_ref = ref_out.data<float>(&place, &ref_size);
         EXPECT_EQ(size, ref_size);
         for (size_t j = 0; j < size; ++j) {
-          CHECK_LE(std::abs(pdata_ref[j] - pdata[j]), FLAGS_accuracy);
+          if (std::abs(pdata_ref[j]) > 1) {
+            CHECK_LE(std::abs((pdata_ref[j] - pdata[j]) / pdata_ref[j]),
+                     FLAGS_accuracy);
+          } else {
+            CHECK_LE(std::abs(pdata_ref[j] - pdata[j]), FLAGS_accuracy);
+          }
         }
         break;
       }


### PR DESCRIPTION
This PR resolves problem with tests failing when compared values are large in magnitude because checking for absolute error between them is often wrong due to floating point calculation precision.