### PR TITLE
Fix jit tls issue

### DIFF
--- a/paddle/fluid/operators/jit/helper.cc
+++ b/paddle/fluid/operators/jit/helper.cc
@@ -22,7 +22,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-thread_local std::unordered_map<std::string, void*> g_func_cache_map;
+thread_local std::unordered_map<std::string, std::shared_ptr<void>>
+    g_func_cache_map;
 
 #define ONE_CASE(key) \
   case key:           \

--- a/paddle/fluid/operators/jit/helper.cc
+++ b/paddle/fluid/operators/jit/helper.cc
@@ -22,8 +22,11 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-thread_local std::unordered_map<std::string, std::shared_ptr<void>>
-    g_func_cache_map;
+std::unordered_map<std::string, std::shared_ptr<void>>& GetFuncCacheMap() {
+  static thread_local std::unordered_map<std::string, std::shared_ptr<void>>
+      g_func_cache_map;
+  return g_func_cache_map;
+}
 
 #define ONE_CASE(key) \
   case key:           \

--- a/paddle/fluid/operators/jit/helper.cc
+++ b/paddle/fluid/operators/jit/helper.cc
@@ -22,6 +22,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
+thread_local std::unordered_map<std::string, void*> g_func_cache_map;
+
 #define ONE_CASE(key) \
   case key:           \
     return #key

--- a/paddle/fluid/operators/jit/helper.h
+++ b/paddle/fluid/operators/jit/helper.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <iostream>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>  // for std::move

--- a/paddle/fluid/operators/jit/helper.h
+++ b/paddle/fluid/operators/jit/helper.h
@@ -176,22 +176,23 @@ typename KernelTuple::func_type GetDefaultBestFunc(
   return funcs[0];
 }
 
-extern thread_local std::unordered_map<std::string, std::shared_ptr<void>>
-    g_func_cache_map;
+extern std::unordered_map<std::string, std::shared_ptr<void>>&
+GetFuncCacheMap();
 
 template <typename KernelTuple, typename PlaceType>
 class KernelFuncs {
  public:
   KernelFuncs() = default;
   static KernelFuncs& Cache() {
+    auto& func_cache_map = GetFuncCacheMap();
     std::string key = typeid(KernelFuncs<KernelTuple, PlaceType>).name();
-    auto iter = g_func_cache_map.find(key);
-    if (iter != g_func_cache_map.end()) {
+    auto iter = func_cache_map.find(key);
+    if (iter != func_cache_map.end()) {
       return *(KernelFuncs<KernelTuple, PlaceType>*)(iter->second.get());
     } else {
       std::shared_ptr<void> cache =
           std::make_shared<KernelFuncs<KernelTuple, PlaceType>>();
-      g_func_cache_map.emplace(key, cache);
+      func_cache_map.emplace(key, cache);
       return *(KernelFuncs<KernelTuple, PlaceType>*)(cache.get());
     }
   }

--- a/paddle/fluid/operators/jit/helper.h
+++ b/paddle/fluid/operators/jit/helper.h
@@ -175,13 +175,22 @@ typename KernelTuple::func_type GetDefaultBestFunc(
   return funcs[0];
 }
 
+extern thread_local std::unordered_map<std::string, void*> g_func_cache_map;
+
 template <typename KernelTuple, typename PlaceType>
 class KernelFuncs {
  public:
   KernelFuncs() = default;
   static KernelFuncs& Cache() {
-    static thread_local KernelFuncs<KernelTuple, PlaceType> g_func_cache;
-    return g_func_cache;
+    std::string key = typeid(KernelFuncs<KernelTuple, PlaceType>).name();
+    if (g_func_cache_map.find(key) != g_func_cache_map.end()) {
+      auto func_cache = g_func_cache_map.at(key);
+      return *(KernelFuncs<KernelTuple, PlaceType>*)(func_cache);
+    } else {
+      auto cache = new KernelFuncs<KernelTuple, PlaceType>;
+      g_func_cache_map.insert(make_pair(key, std::move(cache)));
+      return *(KernelFuncs<KernelTuple, PlaceType>*)cache;
+    }
   }
 
   // the exposed interface to use

--- a/paddle/fluid/operators/jit/kernel_pool.cc
+++ b/paddle/fluid/operators/jit/kernel_pool.cc
@@ -21,7 +21,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-thread_local std::unordered_map<std::string, void*> g_jit_codes_map;
+thread_local std::unordered_map<std::string, std::shared_ptr<void>>
+    g_jit_codes_map;
 
 JitCodeCreatorPool& JitCodeCreatorPool::Instance() {
   static JitCodeCreatorPool g_creator_pool;

--- a/paddle/fluid/operators/jit/kernel_pool.cc
+++ b/paddle/fluid/operators/jit/kernel_pool.cc
@@ -21,8 +21,11 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-thread_local std::unordered_map<std::string, std::shared_ptr<void>>
-    g_jit_codes_map;
+std::unordered_map<std::string, std::shared_ptr<void>>& GetJITCodesMap() {
+  static thread_local std::unordered_map<std::string, std::shared_ptr<void>>
+      g_jit_codes_map;
+  return g_jit_codes_map;
+}
 
 JitCodeCreatorPool& JitCodeCreatorPool::Instance() {
   static JitCodeCreatorPool g_creator_pool;

--- a/paddle/fluid/operators/jit/kernel_pool.cc
+++ b/paddle/fluid/operators/jit/kernel_pool.cc
@@ -21,6 +21,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
+thread_local std::unordered_map<std::string, void*> g_jit_codes_map;
+
 JitCodeCreatorPool& JitCodeCreatorPool::Instance() {
   static JitCodeCreatorPool g_creator_pool;
   return g_creator_pool;

--- a/paddle/fluid/operators/jit/kernel_pool.h
+++ b/paddle/fluid/operators/jit/kernel_pool.h
@@ -28,8 +28,7 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-extern thread_local std::unordered_map<std::string, std::shared_ptr<void>>
-    g_jit_codes_map;
+extern std::unordered_map<std::string, std::shared_ptr<void>>& GetJITCodesMap();
 
 template <KernelType KT>
 class JitCodePool {
@@ -39,13 +38,14 @@ class JitCodePool {
  public:
   JitCodePool() = default;
   static JitCodePool& Instance() {
+    auto& jit_codes_map = GetJITCodesMap();
     std::string key = typeid(JitCodePool<KT>).name();
-    auto iter = g_jit_codes_map.find(key);
-    if (iter != g_jit_codes_map.end()) {
+    auto iter = jit_codes_map.find(key);
+    if (iter != jit_codes_map.end()) {
       return *(JitCodePool<KT>*)(iter->second.get());
     } else {
       std::shared_ptr<void> cache = std::make_shared<JitCodePool<KT>>();
-      g_jit_codes_map.emplace(key, cache);
+      jit_codes_map.emplace(key, cache);
       return *(JitCodePool<KT>*)(cache.get());
     }
   }


### PR DESCRIPTION
According to the description of [Issue#1360](https://github.com/PaddlePaddle/models/issues/1360), the TLS of core_avx.so will occupy more size. Now we modified the source code of jit to decrease the TLS section size.

Before:
![image](https://user-images.githubusercontent.com/4131969/68731147-07e35500-060a-11ea-8f5f-2b502c296d41.png)

After:
![image](https://user-images.githubusercontent.com/4131969/68860220-0a39d200-0724-11ea-9cf0-8db554cf2b8d.png)

