### PR TITLE
fix data_norm op to avoid impractical normalization result test=develop

### DIFF
--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -13,9 +13,9 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/data_norm_op.h"
+#include "paddle/fluid/framework/data_layout.h"
 #include <memory>
 #include <string>
-#include "paddle/fluid/framework/data_layout.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
 #endif
@@ -184,7 +184,7 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     auto *scales = ctx.Output<Tensor>("Scales");
 
     // alloc memory
-    T* y_data = y->mutable_data<T>(ctx.GetPlace());
+    T *y_data = y->mutable_data<T>(ctx.GetPlace());
 
     Eigen::Array<T, Eigen::Dynamic, 1> inv_std(C);
     ConstEigenVectorArrayMap<T> b_size_arr(
@@ -200,44 +200,45 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     means_arr = b_sum_arr / b_size_arr;
     scales_arr = (b_size_arr / b_square_sum_arr).sqrt();
 
-    const T* means_data = mean_out->data<T>();
-    const T* x_data = x->data<T>();
-    const T* scales_data = scales->data<T>();
+    const T *means_data = mean_out->data<T>();
+    const T *x_data = x->data<T>();
+    const T *scales_data = scales->data<T>();
     const int item_size = x->numel() / N;
     const int slot_dim = ctx.Attr<int>("slot_dim");
-    PADDLE_ENFORCE(item_size % slot_dim == 0, "slot_dim divisible by item_size");
+    PADDLE_ENFORCE(item_size % slot_dim == 0,
+                   "slot_dim divisible by item_size");
     T min_precision = 1e-7f;
     switch (data_layout) {
-      case DataLayout::kNCHW:  // It's two dimensions, so make no difference
-      case DataLayout::kNHWC: {
-        if (slot_dim > 0) {
-          int offset = 0;
-          for (int k = 0; k < N; ++k) {
-            for (int i = 0; i < item_size; i += slot_dim) {
-              if (x_data[offset + i] > -min_precision &&\
-                  x_data[offset + i] < min_precision) {
-                // show = 0
-                memset(y_data + offset + i, 0, sizeof(T) * slot_dim);
-              } else {
-                for (int j = i; j < i + slot_dim; ++j) {
-                  y_data[offset + j] =
+    case DataLayout::kNCHW: // It's two dimensions, so make no difference
+    case DataLayout::kNHWC: {
+      if (slot_dim > 0) {
+        int offset = 0;
+        for (int k = 0; k < N; ++k) {
+          for (int i = 0; i < item_size; i += slot_dim) {
+            if (x_data[offset + i] > -min_precision &&
+                x_data[offset + i] < min_precision) {
+              // show = 0
+              memset(y_data + offset + i, 0, sizeof(T) * slot_dim);
+            } else {
+              for (int j = i; j < i + slot_dim; ++j) {
+                y_data[offset + j] =
                     (x_data[offset + j] - means_data[j]) * scales_data[j];
-                }
               }
             }
-
-            offset += item_size;
           }
-        } else {
-          EigenArrayMap<T>(y_data, C, N) =
-              (ConstEigenArrayMap<T>(x->data<T>(), C, N).colwise() - means_arr)
-                  .colwise() *
-              scales_arr;
+
+          offset += item_size;
         }
-        break;
+      } else {
+        EigenArrayMap<T>(y_data, C, N) =
+            (ConstEigenArrayMap<T>(x->data<T>(), C, N).colwise() - means_arr)
+                .colwise() *
+            scales_arr;
       }
-      default:
-        PADDLE_THROW("Unknown storage order: %d", data_layout);
+      break;
+    }
+    default:
+      PADDLE_THROW("Unknown storage order: %d", data_layout);
     }
   }
 };
@@ -350,99 +351,95 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
     auto *d_batch_square_sum =
         ctx.Output<Tensor>(framework::GradVarName("BatchSquareSum"));
 
-    T* d_batch_size_data = d_batch_size->mutable_data<T>(ctx.GetPlace());
-    T* d_batch_sum_data = d_batch_sum->mutable_data<T>(ctx.GetPlace());
-    T* d_batch_square_sum_data =
+    T *d_batch_size_data = d_batch_size->mutable_data<T>(ctx.GetPlace());
+    T *d_batch_sum_data = d_batch_sum->mutable_data<T>(ctx.GetPlace());
+    T *d_batch_square_sum_data =
         d_batch_square_sum->mutable_data<T>(ctx.GetPlace());
-    EigenVectorArrayMap<T> d_batch_size_arr(
-        d_batch_size_data, C);
-    EigenVectorArrayMap<T> d_batch_sum_arr(
-        d_batch_sum_data, C);
-    EigenVectorArrayMap<T> d_batch_square_sum_arr(
-        d_batch_square_sum_data, C);
+    EigenVectorArrayMap<T> d_batch_size_arr(d_batch_size_data, C);
+    EigenVectorArrayMap<T> d_batch_sum_arr(d_batch_sum_data, C);
+    EigenVectorArrayMap<T> d_batch_square_sum_arr(d_batch_square_sum_data, C);
 
     d_batch_size_arr.setZero();
     d_batch_sum_arr.setZero();
     d_batch_square_sum_arr.setZero();
-    const T* x_data = x->data<T>();
-    const T* means_data = means->data<T>();
+    const T *x_data = x->data<T>();
+    const T *means_data = means->data<T>();
 
     const float epsilon = ctx.Attr<float>("epsilon");
     T min_precision = 1e-7f;
     const int item_size = x->numel() / N;
     const int slot_dim = ctx.Attr<int>("slot_dim");
-    PADDLE_ENFORCE(item_size % slot_dim == 0, "slot_dim divisible by item_size");
-    switch (
-        data_layout) {  // because it's two dimensions, so make no difference
-      case DataLayout::kNCHW:
-      case DataLayout::kNHWC: {
-        ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
-        ConstEigenVectorArrayMap<T> means_arr(means->data<T>(), C);
-        ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N);
-        ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), C, N);
-        if (d_x != nullptr) {
-          EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()), C, N);
-          d_x_arr.setZero();
-          for (int nc = 0; nc < N; ++nc) {
-            d_x_arr.col(nc) = d_y_arr.col(nc) * scales_arr;
-          }
+    PADDLE_ENFORCE(item_size % slot_dim == 0,
+                   "slot_dim divisible by item_size");
+    switch (data_layout) { // because it's two dimensions, so make no difference
+    case DataLayout::kNCHW:
+    case DataLayout::kNHWC: {
+      ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
+      ConstEigenVectorArrayMap<T> means_arr(means->data<T>(), C);
+      ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N);
+      ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), C, N);
+      if (d_x != nullptr) {
+        EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()), C, N);
+        d_x_arr.setZero();
+        for (int nc = 0; nc < N; ++nc) {
+          d_x_arr.col(nc) = d_y_arr.col(nc) * scales_arr;
         }
-
-        if (slot_dim > 0) {
-          int offset = 0;
-          for (int k = 0; k < N; ++k) {
-            for (int i = 0; i < item_size; i += slot_dim) {
-              if (!(x_data[offset + i] > -min_precision &&\
-                  x_data[offset + i] < min_precision)) {
-                // show != 0
-                for (int j = i; j < i + slot_dim; ++j) {
-                  d_batch_size_data[j] += 1;
-                  d_batch_sum_data[j] += x_data[offset + j];
-                  d_batch_square_sum_data[j] +=
-                    (x_data[offset + j] - means_data[j]) *\
-                    (x_data[offset + j] - means_data[j]);
-                }
-              }
-            }
-            offset += item_size;
-          }
-
-          for (int i = 0; i < item_size; i += slot_dim) {
-            for (int j = i; j < i + slot_dim; ++j) {
-              if (d_batch_size_data[j] >= 1) {
-                d_batch_sum_data[j] /= d_batch_size_data[j];
-                d_batch_square_sum_data[j] =
-                    d_batch_square_sum_data[j] / d_batch_size_data[j] +
-                    d_batch_size_data[j] * epsilon;
-                d_batch_size_data[j] = 1;
-              }
-            }
-          }
-        } else {
-          // calculate data sum and squre sum
-          ConstEigenVectorArrayMap<T> batch_size_arr(batch_size->data<T>(), C);
-          ConstEigenVectorArrayMap<T> batch_sum_arr(batch_sum->data<T>(), C);
-          ConstEigenVectorArrayMap<T> batch_square_sum_arr(
-              batch_square_sum->data<T>(), C);
-          Eigen::Array<T, Eigen::Dynamic, 1> sample_sum(C);
-          Eigen::Array<T, Eigen::Dynamic, 1> sample_square_sum(C);
-          // calculate data sample sum and square sum
-          sample_sum.setZero();
-          sample_square_sum.setZero();
-          for (int nc = 0; nc < N; ++nc) {
-            sample_sum += x_arr.col(nc);
-            sample_square_sum += (x_arr.col(nc) - means_arr).square();
-          }
-          // calculate gradient
-          d_batch_size_arr.setConstant(N);
-          d_batch_sum_arr = sample_sum;
-          d_batch_square_sum_arr =
-            sample_square_sum + d_batch_size_arr * epsilon;
-        }
-        break;
       }
-      default:
-        PADDLE_THROW("Unknown storage order: %s", data_layout_str);
+
+      if (slot_dim > 0) {
+        int offset = 0;
+        for (int k = 0; k < N; ++k) {
+          for (int i = 0; i < item_size; i += slot_dim) {
+            if (!(x_data[offset + i] > -min_precision &&
+                  x_data[offset + i] < min_precision)) {
+              // show != 0
+              for (int j = i; j < i + slot_dim; ++j) {
+                d_batch_size_data[j] += 1;
+                d_batch_sum_data[j] += x_data[offset + j];
+                d_batch_square_sum_data[j] +=
+                    (x_data[offset + j] - means_data[j]) *
+                    (x_data[offset + j] - means_data[j]);
+              }
+            }
+          }
+          offset += item_size;
+        }
+
+        for (int i = 0; i < item_size; i += slot_dim) {
+          for (int j = i; j < i + slot_dim; ++j) {
+            if (d_batch_size_data[j] >= 1) {
+              d_batch_sum_data[j] /= d_batch_size_data[j];
+              d_batch_square_sum_data[j] =
+                  d_batch_square_sum_data[j] / d_batch_size_data[j] +
+                  d_batch_size_data[j] * epsilon;
+              d_batch_size_data[j] = 1;
+            }
+          }
+        }
+      } else {
+        // calculate data sum and squre sum
+        ConstEigenVectorArrayMap<T> batch_size_arr(batch_size->data<T>(), C);
+        ConstEigenVectorArrayMap<T> batch_sum_arr(batch_sum->data<T>(), C);
+        ConstEigenVectorArrayMap<T> batch_square_sum_arr(
+            batch_square_sum->data<T>(), C);
+        Eigen::Array<T, Eigen::Dynamic, 1> sample_sum(C);
+        Eigen::Array<T, Eigen::Dynamic, 1> sample_square_sum(C);
+        // calculate data sample sum and square sum
+        sample_sum.setZero();
+        sample_square_sum.setZero();
+        for (int nc = 0; nc < N; ++nc) {
+          sample_sum += x_arr.col(nc);
+          sample_square_sum += (x_arr.col(nc) - means_arr).square();
+        }
+        // calculate gradient
+        d_batch_size_arr.setConstant(N);
+        d_batch_sum_arr = sample_sum;
+        d_batch_square_sum_arr = sample_square_sum + d_batch_size_arr * epsilon;
+      }
+      break;
+    }
+    default:
+      PADDLE_THROW("Unknown storage order: %s", data_layout_str);
     }
   }
 };

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -126,8 +126,8 @@ class DataNormOpMaker : public framework::OpProtoAndCheckerMaker {
                          "'epsilon' should be between 0.0 and 0.001.");
         });
     AddAttr<int>("slot_dim",
-                 "(int, default -1) Dimention of one slot if set, "
-                 "when the input is cocated by slot-wise embedding")
+                 "(int, default -1) Dimension of one slot if set, "
+                 "when the input is cocated by slot-wise embeddings")
         .SetDefault(-1);
     AddAttr<std::string>("data_layout", "").SetDefault("NCHW");
     AddAttr<bool>("use_mkldnn",

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -127,7 +127,7 @@ class DataNormOpMaker : public framework::OpProtoAndCheckerMaker {
         });
     AddAttr<int>("slot_dim",
                  "(int, default -1) Dimension of one slot if set, "
-                 "when the input is cocated by slot-wise embeddings")
+                 "when the input is concated by slot-wise embeddings")
         .SetDefault(-1);
     AddAttr<std::string>("data_layout", "").SetDefault("NCHW");
     AddAttr<bool>("use_mkldnn",
@@ -386,6 +386,8 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
         }
 
         if (slot_dim > 0 && N > 0) {
+          // if slot_dim is set and batch size is larger than zero, we choose
+          // to check if show number is zero, if so, skip update statistics.
           int offset = 0;
           const int item_size = x->numel() / N;
           for (int k = 0; k < N; ++k) {

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -222,7 +222,7 @@ class DataNormKernel<platform::CPUDeviceContext, T>
               } else {
                 for (int j = i; j < i + slot_dim; ++j) {
                   y_data[offset + j] =
-                    (x_data[offset + j] - means_data[j]) * scales_data[j];
+                      (x_data[offset + j] - means_data[j]) * scales_data[j];
                 }
               }
             }
@@ -371,7 +371,7 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
     const int slot_dim = ctx.Attr<int>("slot_dim");
     PADDLE_ENFORCE(item_size % slot_dim == 0,
                    "slot_dim divisible by item_size");
-    switch (data_layout) { // because it's two dimensions, so make no difference
+    switch (data_layout) { // it's two dimensions, make no difference
       case DataLayout::kNCHW:
       case DataLayout::kNHWC: {
         ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
@@ -391,14 +391,14 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
           for (int k = 0; k < N; ++k) {
             for (int i = 0; i < item_size; i += slot_dim) {
               if (!(x_data[offset + i] > -min_precision &&
-                  x_data[offset + i] < min_precision)) {
+                    x_data[offset + i] < min_precision)) {
                 // show != 0
                 for (int j = i; j < i + slot_dim; ++j) {
                   d_batch_size_data[j] += 1;
                   d_batch_sum_data[j] += x_data[offset + j];
                   d_batch_square_sum_data[j] +=
                     (x_data[offset + j] - means_data[j]) *
-                    (x_data[offset + j] - means_data[j]);
+                      (x_data[offset + j] - means_data[j]);
                 }
               }
             }

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -371,7 +371,7 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
     const int slot_dim = ctx.Attr<int>("slot_dim");
     PADDLE_ENFORCE(item_size % slot_dim == 0,
                    "slot_dim divisible by item_size");
-    switch (data_layout) { // it's two dimensions, make no difference
+    switch (data_layout) {  // it's two dimensions, make no difference
       case DataLayout::kNCHW:
       case DataLayout::kNHWC: {
         ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
@@ -397,7 +397,7 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
                   d_batch_size_data[j] += 1;
                   d_batch_sum_data[j] += x_data[offset + j];
                   d_batch_square_sum_data[j] +=
-                    (x_data[offset + j] - means_data[j]) *
+                      (x_data[offset + j] - means_data[j]) *
                       (x_data[offset + j] - means_data[j]);
                 }
               }
@@ -435,7 +435,7 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
           d_batch_size_arr.setConstant(N);
           d_batch_sum_arr = sample_sum;
           d_batch_square_sum_arr =
-            sample_square_sum + d_batch_size_arr * epsilon;
+              sample_square_sum + d_batch_size_arr * epsilon;
         }
         break;
       }

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -204,8 +204,8 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     const T* x_data = x->data<T>();
     const T* scales_data = scales->data<T>();
     const int item_size = x->numel() / N;
-    PADDLE_ENFORCE(item_size % slot_dim == 0, "slot_dim divisible by item_size");
     const int slot_dim = ctx.Attr<int>("slot_dim");
+    PADDLE_ENFORCE(item_size % slot_dim == 0, "slot_dim divisible by item_size");
     T min_precision = 1e-7f;
     switch (data_layout) {
       case DataLayout::kNCHW:  // It's two dimensions, so make no difference
@@ -334,6 +334,7 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
     const auto &x_dims = x->dims();
     PADDLE_ENFORCE(x_dims.size() == 2, "The Input dim size should be 2");
     const int N = x_dims[0];
+    PADDLE_ENFORCE(N > 0, "The Input dim[0] size should be larger than 0");
     const int C =
         (data_layout == DataLayout::kNCHW ? x_dims[1]
                                           : x_dims[x_dims.size() - 1]);
@@ -370,6 +371,7 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
     T min_precision = 1e-7f;
     const int item_size = x->numel() / N;
     const int slot_dim = ctx.Attr<int>("slot_dim");
+    PADDLE_ENFORCE(item_size % slot_dim == 0, "slot_dim divisible by item_size");
     switch (
         data_layout) {  // because it's two dimensions, so make no difference
       case DataLayout::kNCHW:

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -81,7 +81,7 @@ class DataNormOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
-    auto input_data_type = OperatorWithKernel::IndicateVarDataType(ctx, "X");
+    auto input_data_type = ctx.Input<Tensor>("X")->type();
     // By default, the type of the scale, bias, mean,
     // and var tensors should both be float. (For float or float16 input tensor)
     // or double (For double input tensor).
@@ -89,14 +89,12 @@ class DataNormOp : public framework::OperatorWithKernel {
     if (input_data_type == framework::proto::VarType::FP64) {
       dn_param_type = framework::proto::VarType::FP64;
     }
-    PADDLE_ENFORCE_EQ(dn_param_type,
-                      OperatorWithKernel::IndicateVarDataType(ctx, "BatchSize"),
+    PADDLE_ENFORCE_EQ(dn_param_type, ctx.Input<Tensor>("BatchSize")->type(),
                       "BatchSize input should be of float type");
-    PADDLE_ENFORCE_EQ(dn_param_type,
-                      OperatorWithKernel::IndicateVarDataType(ctx, "BatchSum"),
+    PADDLE_ENFORCE_EQ(dn_param_type, ctx.Input<Tensor>("BatchSum")->type(),
                       "BatchSum input should be of float type");
-    PADDLE_ENFORCE_EQ(dn_param_type, OperatorWithKernel::IndicateVarDataType(
-                                         ctx, "BatchSquareSum"),
+    PADDLE_ENFORCE_EQ(dn_param_type,
+                      ctx.Input<Tensor>("BatchSquareSum")->type(),
                       "BatchSquareSum input should be of float type");
 
     // TODO(pzelazko-intel): enable MKLDNN layout when it's ready
@@ -182,7 +180,8 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     auto *scales = ctx.Output<Tensor>("Scales");
 
     // alloc memory
-    y->mutable_data<T>(ctx.GetPlace());
+    //y->mutable_data<T>(ctx.GetPlace());
+    T* y_data = y->mutable_data<T>(ctx.GetPlace());
 
     Eigen::Array<T, Eigen::Dynamic, 1> inv_std(C);
     ConstEigenVectorArrayMap<T> b_size_arr(
@@ -191,6 +190,7 @@ class DataNormKernel<platform::CPUDeviceContext, T>
         ctx.Input<Tensor>("BatchSum")->data<T>(), C);
     ConstEigenVectorArrayMap<T> b_square_sum_arr(
         ctx.Input<Tensor>("BatchSquareSum")->data<T>(), C);
+
     EigenVectorArrayMap<T> means_arr(mean_out->mutable_data<T>(ctx.GetPlace()),
                                      C);
     EigenVectorArrayMap<T> scales_arr(scales->mutable_data<T>(ctx.GetPlace()),
@@ -198,14 +198,46 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     means_arr = b_sum_arr / b_size_arr;
     scales_arr = (b_size_arr / b_square_sum_arr).sqrt();
 
+    const T* means_data = mean_out->data<T>();
+    const T* x_data = x->data<T>();
+    const T* scales_data = scales->data<T>();
+    const int item_size = x->numel() / N;
+    // const int slot_size = 11;
+    const int slot_size = ctx.Attr<int>("slot_dim");
+    T min_precision = 1e-7f;  
+    //printf("item_size=%d, N=%d, num=%lu\n", item_size, N, x->numel());
+
     switch (data_layout) {
       case DataLayout::kNCHW:  // because it's two dimensions, so make no
                                // difference
       case DataLayout::kNHWC: {
-        EigenArrayMap<T>(y->mutable_data<T>(ctx.GetPlace()), C, N) =
-            (ConstEigenArrayMap<T>(x->data<T>(), C, N).colwise() - means_arr)
-                .colwise() *
-            scales_arr;
+        if (slot_size > 0) {
+          int offset = 0;
+          for (int k = 0; k < N; ++k) {
+            //batch
+            for (int i = 0; i < item_size; i += slot_size) {
+              // slot11
+              if (x_data[offset + i] > -min_precision && x_data[offset + i] < min_precision) {
+                // show = 0
+                memset(y_data + offset + i, 0, sizeof(T) * slot_size);
+                //printf("x_data(%d,%d) = %f, y_data=%f, mean=%f, scale=%f\n", k, i, x_data[offset+i], y_data[offset+i], means_data[i], scales_data[i]);
+              } else {
+                for ( int j = i; j < i + slot_size; ++j) {
+                  y_data[offset + j] = (x_data[offset + j] - means_data[j]) * scales_data[j];
+                  //printf("x_data(%d,%d,%d) = %f, y_data=%f, mean=%f, scale=%f\n", k, i, j, x_data[offset+j], y_data[offset+j], means_data[j], scales_data[j]);
+                }
+              }
+            }
+
+            offset += item_size;
+          }
+            
+        } else {
+          EigenArrayMap<T>(y_data, C, N) =
+              (ConstEigenArrayMap<T>(x->data<T>(), C, N).colwise() - means_arr)
+                  .colwise() *
+              scales_arr;
+        }
         break;
       }
       default:
@@ -278,9 +310,8 @@ class DataNormGradOp : public framework::OperatorWithKernel {
     }
 #endif
 
-    return framework::OpKernelType(
-        OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),
-        layout, library);
+    return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
+                                   ctx.GetPlace(), layout, library);
   }
 };
 
@@ -321,52 +352,112 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
     auto *d_batch_square_sum =
         ctx.Output<Tensor>(framework::GradVarName("BatchSquareSum"));
 
+    T* d_batch_size_data = d_batch_size->mutable_data<T>(ctx.GetPlace());
+    T* d_batch_sum_data = d_batch_sum->mutable_data<T>(ctx.GetPlace());
+    T* d_batch_square_sum_data = d_batch_square_sum->mutable_data<T>(ctx.GetPlace());
     EigenVectorArrayMap<T> d_batch_size_arr(
-        d_batch_size->mutable_data<T>(ctx.GetPlace()), C);
+        d_batch_size_data, C);
     EigenVectorArrayMap<T> d_batch_sum_arr(
-        d_batch_sum->mutable_data<T>(ctx.GetPlace()), C);
+        d_batch_sum_data, C);
     EigenVectorArrayMap<T> d_batch_square_sum_arr(
-        d_batch_square_sum->mutable_data<T>(ctx.GetPlace()), C);
+        d_batch_square_sum_data, C);
 
     d_batch_size_arr.setZero();
     d_batch_sum_arr.setZero();
     d_batch_square_sum_arr.setZero();
+    const T* x_data = x->data<T>();
+    const T* means_data = means->data<T>();
+    //const T* d_y_data = d_y->data<T>();
 
     const float epsilon = ctx.Attr<float>("epsilon");
+    T min_precision = 1e-7f;  
+    const int item_size = x->numel() / N;
+    // const int slot_size = 11;
+    const int slot_size = ctx.Attr<int>("slot_dim");
     switch (
         data_layout) {  // because it's two dimensions, so make no difference
       case DataLayout::kNCHW:
       case DataLayout::kNHWC: {
-        ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
-        ConstEigenVectorArrayMap<T> means_arr(means->data<T>(), C);
-        ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N);
-        ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), C, N);
-        if (d_x != nullptr) {
-          EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()), C, N);
-          d_x_arr.setZero();
-          for (int nc = 0; nc < N; ++nc) {
-            d_x_arr.col(nc) = d_y_arr.col(nc) * scales_arr;
-          }
-        }
+        if (slot_size > 0) {
+          int offset = 0;
+          for (int k = 0; k < N; ++k) {
+            //batch
+            for (int i = 0; i < item_size; i += slot_size) {
+              // slot11
+              if (!(x_data[offset + i] > -min_precision && x_data[offset + i] < min_precision)) {
+                 //skip grad
+                 //&& !(d_y_data[offset + i] > -min_precision && d_y_data[offset + i] < min_precision)) {
+                // show != 0 & d_y != 0
+                for ( int j = i; j < i + slot_size; ++j) {
+                  //printf("x_data(%d,%d,%d) = %f, y_data=%f, mean=%f\n", k, i, j, x_data[offset+j], d_y_data[offset+j], means_data[j]);
+                  d_batch_size_data[j] += 1;
+                  d_batch_sum_data[j] += x_data[offset + j];
+                  d_batch_square_sum_data[j] += (x_data[offset + j] - means_data[j]) * (x_data[offset + j] - means_data[j]);
+                }
+              } 
+            }
 
-        // calculate data sum and squre sum
-        ConstEigenVectorArrayMap<T> batch_size_arr(batch_size->data<T>(), C);
-        ConstEigenVectorArrayMap<T> batch_sum_arr(batch_sum->data<T>(), C);
-        ConstEigenVectorArrayMap<T> batch_square_sum_arr(
-            batch_square_sum->data<T>(), C);
-        Eigen::Array<T, Eigen::Dynamic, 1> sample_sum(C);
-        Eigen::Array<T, Eigen::Dynamic, 1> sample_square_sum(C);
-        // calculate data sample sum and square sum
-        sample_sum.setZero();
-        sample_square_sum.setZero();
-        for (int nc = 0; nc < N; ++nc) {
-          sample_sum += x_arr.col(nc);
-          sample_square_sum += (x_arr.col(nc) - means_arr).square();
+            offset += item_size;
+          }
+
+          for (int i = 0; i < item_size; i += slot_size) {
+              //if (!(d_batch_size_data[i] > -min_precision && d_batch_size_data[i] < min_precision)) {
+                 //n != 0
+                 for (int j = i; j < i + slot_size; ++j) {
+                   if (d_batch_size_data[j] >= 1) {
+                     d_batch_sum_data[j] /= d_batch_size_data[j]; 
+                     d_batch_square_sum_data[j] = d_batch_square_sum_data[j] / d_batch_size_data[j] + d_batch_size_data[j] * epsilon;
+                     d_batch_size_data[j] = 1;
+                   }
+                 }
+              //}
+          }
+          //d_batch_square_sum_arr += cur_n * epsilon;
+
+          ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
+          ConstEigenVectorArrayMap<T> means_arr(means->data<T>(), C);
+          ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N);
+          ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), C, N);
+          if (d_x != nullptr) {
+            EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()), C, N);
+            d_x_arr.setZero();
+            for (int nc = 0; nc < N; ++nc) {
+              d_x_arr.col(nc) = d_y_arr.col(nc) * scales_arr;
+            }
+          }
+
+        } else {
+          ConstEigenVectorArrayMap<T> scales_arr(scales->data<T>(), C);
+          ConstEigenVectorArrayMap<T> means_arr(means->data<T>(), C);
+          ConstEigenArrayMap<T> x_arr(x->data<T>(), C, N);
+          ConstEigenArrayMap<T> d_y_arr(d_y->data<T>(), C, N);
+          if (d_x != nullptr) {
+            EigenArrayMap<T> d_x_arr(d_x->mutable_data<T>(ctx.GetPlace()), C, N);
+            d_x_arr.setZero();
+            for (int nc = 0; nc < N; ++nc) {
+              d_x_arr.col(nc) = d_y_arr.col(nc) * scales_arr;
+            }
+          }
+
+          // calculate data sum and squre sum
+          ConstEigenVectorArrayMap<T> batch_size_arr(batch_size->data<T>(), C);
+          ConstEigenVectorArrayMap<T> batch_sum_arr(batch_sum->data<T>(), C);
+          ConstEigenVectorArrayMap<T> batch_square_sum_arr(
+              batch_square_sum->data<T>(), C);
+          Eigen::Array<T, Eigen::Dynamic, 1> sample_sum(C);
+          Eigen::Array<T, Eigen::Dynamic, 1> sample_square_sum(C);
+          // calculate data sample sum and square sum
+          sample_sum.setZero();
+          sample_square_sum.setZero();
+          for (int nc = 0; nc < N; ++nc) {
+            sample_sum += x_arr.col(nc);
+            sample_square_sum += (x_arr.col(nc) - means_arr).square();
+          }
+          // calculate gradient
+          d_batch_size_arr.setConstant(N);
+          d_batch_sum_arr = sample_sum;
+          d_batch_square_sum_arr = sample_square_sum + d_batch_size_arr * epsilon;
         }
-        // calculate gradient
-        d_batch_size_arr.setConstant(N);
-        d_batch_sum_arr = sample_sum;
-        d_batch_square_sum_arr = sample_square_sum + d_batch_size_arr * epsilon;
         break;
       }
       default:
@@ -375,35 +466,32 @@ class DataNormGradKernel<platform::CPUDeviceContext, T>
   }
 };
 
-template <typename T>
-class DataNormGradMaker : public framework::SingleGradOpMaker<T> {
+class DataNormGradMaker : public framework::SingleGradOpDescMaker {
  public:
-  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+  using framework::SingleGradOpDescMaker::SingleGradOpDescMaker;
 
  protected:
-  std::unique_ptr<T> Apply() const override {
-    auto *op = new T();
+  std::unique_ptr<framework::OpDesc> Apply() const override {
+    auto *op = new framework::OpDesc();
     op->SetType("data_norm_grad");
-    op->SetInput("X", this->Input("X"));
-    op->SetInput(framework::GradVarName("Y"), this->OutputGrad("Y"));
+    op->SetInput("X", Input("X"));
+    op->SetInput(framework::GradVarName("Y"), OutputGrad("Y"));
 
-    op->SetInput("BatchSize", this->Input("BatchSize"));
-    op->SetInput("BatchSum", this->Input("BatchSum"));
-    op->SetInput("BatchSquareSum", this->Input("BatchSquareSum"));
-    op->SetInput("Scales", this->Output("Scales"));
-    op->SetInput("Means", this->Output("Means"));
+    op->SetInput("BatchSize", Input("BatchSize"));
+    op->SetInput("BatchSum", Input("BatchSum"));
+    op->SetInput("BatchSquareSum", Input("BatchSquareSum"));
+    op->SetInput("Scales", Output("Scales"));
+    op->SetInput("Means", Output("Means"));
 
-    op->SetAttrMap(this->Attrs());
+    op->SetAttrMap(Attrs());
 
-    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
-    op->SetOutput(framework::GradVarName("BatchSize"),
-                  this->InputGrad("BatchSize"));
-    op->SetOutput(framework::GradVarName("BatchSum"),
-                  this->InputGrad("BatchSum"));
+    op->SetOutput(framework::GradVarName("X"), InputGrad("X"));
+    op->SetOutput(framework::GradVarName("BatchSize"), InputGrad("BatchSize"));
+    op->SetOutput(framework::GradVarName("BatchSum"), InputGrad("BatchSum"));
     op->SetOutput(framework::GradVarName("BatchSquareSum"),
-                  this->InputGrad("BatchSquareSum"));
+                  InputGrad("BatchSquareSum"));
 
-    return std::unique_ptr<T>(op);
+    return std::unique_ptr<framework::OpDesc>(op);
   }
 };
 
@@ -412,8 +500,7 @@ class DataNormGradMaker : public framework::SingleGradOpMaker<T> {
 
 namespace ops = paddle::operators;
 REGISTER_OPERATOR(data_norm, ops::DataNormOp, ops::DataNormOpMaker,
-                  ops::DataNormGradMaker<paddle::framework::OpDesc>,
-                  ops::DataNormGradMaker<paddle::imperative::OpBase>);
+                  ops::DataNormGradMaker);
 REGISTER_OPERATOR(data_norm_grad, ops::DataNormGradOp);
 
 REGISTER_OP_CPU_KERNEL(

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -175,6 +175,7 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     const auto &x_dims = x->dims();
     PADDLE_ENFORCE(x_dims.size() == 2, "The Input dim size should be 2");
     const int N = x_dims[0];
+    PADDLE_ENFORCE(N > 0, "The Input dim[0] size should be larger than 0");
     const int C =
         (data_layout == DataLayout::kNCHW ? x_dims[1]
                                           : x_dims[x_dims.size() - 1]);
@@ -203,6 +204,7 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     const T* x_data = x->data<T>();
     const T* scales_data = scales->data<T>();
     const int item_size = x->numel() / N;
+    PADDLE_ENFORCE(item_size % slot_dim == 0, "slot_dim divisible by item_size");
     const int slot_dim = ctx.Attr<int>("slot_dim");
     T min_precision = 1e-7f;
     switch (data_layout) {

--- a/paddle/fluid/operators/data_norm_op.cc
+++ b/paddle/fluid/operators/data_norm_op.cc
@@ -207,7 +207,7 @@ class DataNormKernel<platform::CPUDeviceContext, T>
     switch (data_layout) {
       case DataLayout::kNCHW:  // It's two dimensions, so make no difference
       case DataLayout::kNHWC: {
-        if (slot_dim > 0 && N > 0) { 
+        if (slot_dim > 0 && N > 0) {
           const int item_size = x->numel() / N;
           int offset = 0;
           for (int k = 0; k < N; ++k) {

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2741,7 +2741,8 @@ def data_norm(input,
               name=None,
               moving_mean_name=None,
               moving_variance_name=None,
-              do_model_average_for_mean_and_var=True):
+              do_model_average_for_mean_and_var=True,
+              slot_dim=-1):
     """
     **Data Normalization Layer**
 
@@ -2854,7 +2855,8 @@ def data_norm(input,
         outputs={"Y": data_norm_out,
                  "Means": means,
                  "Scales": scales},
-        attrs={"epsilon": epsilon})
+        attrs={"epsilon": epsilon,
+               "slot_dim": slot_dim})
 
     return helper.append_activation(data_norm_out)
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2709,6 +2709,8 @@ def data_norm(input,
         moving_variance_name(string, Default None): The name of the moving_variance which store the global Variance.
         do_model_average_for_mean_and_var(bool, Default True): Whether parameter mean and variance
             should do model average when model average is enabled.
+        slot_dim(int): The dimention of one slots used for judging if the show num is zero to skip
+            normalization.
 
     Returns:
         Variable: A tensor variable which is the result after applying data normalization on the input.

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2709,9 +2709,9 @@ def data_norm(input,
         moving_variance_name(string, Default None): The name of the moving_variance which store the global Variance.
         do_model_average_for_mean_and_var(bool, Default True): Whether parameter mean and variance
             should do model average when model average is enabled.
-        slot_dim(int): The embedding dimention of one slot. Slot is a set of one specific feature. In pslib mode, we 
-            distinguish feature ids by slot and pull there embeddings from parameter server (pslib). The first
-            place of the embedding is the historical show number (occurance time of this feature id with a lable 0).
+        slot_dim(int): The embedding dimension of one slot. Slot is a set of one specific feature. In pslib mode, we 
+            distinguish feature ids by slot and pull their embeddings from parameter server (pslib). The first
+            place of the embedding is the historical show number (occurence time of this feature id with a label 0).
             If the input of this op is concated by slot-wise embeddings, and the show number is zero when this slot 
             is new or empty, the normalization result may be impractical. To avoid this, we add slot_dim to locate 
             the show number and judge if the show number is zero. If so, we choose to skip normalization on this

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2709,8 +2709,13 @@ def data_norm(input,
         moving_variance_name(string, Default None): The name of the moving_variance which store the global Variance.
         do_model_average_for_mean_and_var(bool, Default True): Whether parameter mean and variance
             should do model average when model average is enabled.
-        slot_dim(int): The dimention of one slots used for judging if the show num is zero to skip
-            normalization.
+        slot_dim(int): The embedding dimention of one slot. Slot is a set of one specific feature. In pslib mode, we 
+            distinguish feature ids by slot and pull there embeddings from parameter server (pslib). The first
+            place of the embedding is the historical show number (occurance time of this feature id with a lable 0).
+            If the input of this op is concated by slot-wise embeddings, and the show number is zero when this slot 
+            is new or empty, the normalization result may be impractical. To avoid this, we add slot_dim to locate 
+            the show number and judge if the show number is zero. If so, we choose to skip normalization on this
+            embedding.
 
     Returns:
         Variable: A tensor variable which is the result after applying data normalization on the input.

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -39,8 +39,8 @@ def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):
             for j in range(0, x_shape[1], slot_dim):
                 if x[i][j] <= -1e-7 or x[i][j] > 1e-7:
                     for k in range(0, slot_dim):
-                        y[i][j + k] = (x[i][j + k] -
-                                       means_arr[j + k]) * scales_arr[j + k]
+                        y[i][j + k] = (
+                            x[i][j + k] - means_arr[j + k]) * scales_arr[j + k]
     return y
 
 
@@ -58,6 +58,7 @@ class TestDataNormOpInference(unittest.TestCase):
     test class for data norm op
     test forward
     """
+
     def setUp(self):
         """
         init members of this class
@@ -108,11 +109,11 @@ class TestDataNormOpInference(unittest.TestCase):
                                         OpTest.np_dtype_to_fluid_dtype(x_val),
                                         place)
         batch_size_tensor = create_or_get_tensor(
-            scope, "batch_size", OpTest.np_dtype_to_fluid_dtype(batch_size),
-            place)
+            scope, "batch_size",
+            OpTest.np_dtype_to_fluid_dtype(batch_size), place)
         batch_sum_tensor = create_or_get_tensor(
-            scope, "batch_sum", OpTest.np_dtype_to_fluid_dtype(batch_sum),
-            place)
+            scope, "batch_sum",
+            OpTest.np_dtype_to_fluid_dtype(batch_sum), place)
         batch_square_sum_tensor = create_or_get_tensor(
             scope, "batch_square_sum",
             OpTest.np_dtype_to_fluid_dtype(batch_square_sum), place)
@@ -141,12 +142,13 @@ class TestDataNormOpInference(unittest.TestCase):
         data_norm_op.run(scope, place)
 
         # check inference result
-        self.__assert_close(y_tensor,
-                            y_out,
-                            "inference output are different at " + str(place) +
-                            ", " + data_layout + ", " + str(np.dtype(dtype)) +
-                            str(np.array(y_tensor)) + str(y_out),
-                            atol=1e-3)
+        self.__assert_close(
+            y_tensor,
+            y_out,
+            "inference output are different at " + str(place) + ", " +
+            data_layout + ", " + str(np.dtype(dtype)) +
+            str(np.array(y_tensor)) + str(y_out),
+            atol=1e-3)
 
     def test_check_output(self):
         """
@@ -156,10 +158,11 @@ class TestDataNormOpInference(unittest.TestCase):
         for place in places:
             for data_format in ["NCHW", "NHWC"]:
                 for slot_dim in [-1, 1]:
-                    self.check_with_place(place,
-                                          data_format,
-                                          self.dtype, [2, 3],
-                                          slot_dim=slot_dim)
+                    self.check_with_place(
+                        place,
+                        data_format,
+                        self.dtype, [2, 3],
+                        slot_dim=slot_dim)
 
 
 class TestDataNormOp(OpTest):
@@ -167,6 +170,7 @@ class TestDataNormOp(OpTest):
     test class for data norm op
     test forward and backward
     """
+
     def setUp(self):
         """
         init data norm op test env
@@ -218,6 +222,7 @@ class TestDataNormOpWithSlotDim(OpTest):
     test class for data norm op
     test forward and backward
     """
+
     def setUp(self):
         """
         init data norm op test env

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -38,8 +38,9 @@ def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):
         for i in range(x_shape[0]):
             for j in range(0, x_shape[1], slot_dim):
                 if x[i][j] <= -1e-7 or x[i][j] > 1e-7:
-                    for k in range(0,slot_dim):
-                        y[i][j+k] = (x[i][j+k] - means_arr[j+k]) * scales_arr[j+k]
+                    for k in range(0, slot_dim):
+                        y[i][j + k] = (x[i][j + k] -
+                                       means_arr[j + k]) * scales_arr[j + k]
     return y
 
 
@@ -57,7 +58,6 @@ class TestDataNormOpInference(unittest.TestCase):
     test class for data norm op
     test forward
     """
-
     def setUp(self):
         """
         init members of this class
@@ -108,11 +108,11 @@ class TestDataNormOpInference(unittest.TestCase):
                                         OpTest.np_dtype_to_fluid_dtype(x_val),
                                         place)
         batch_size_tensor = create_or_get_tensor(
-            scope, "batch_size",
-            OpTest.np_dtype_to_fluid_dtype(batch_size), place)
+            scope, "batch_size", OpTest.np_dtype_to_fluid_dtype(batch_size),
+            place)
         batch_sum_tensor = create_or_get_tensor(
-            scope, "batch_sum",
-            OpTest.np_dtype_to_fluid_dtype(batch_sum), place)
+            scope, "batch_sum", OpTest.np_dtype_to_fluid_dtype(batch_sum),
+            place)
         batch_square_sum_tensor = create_or_get_tensor(
             scope, "batch_square_sum",
             OpTest.np_dtype_to_fluid_dtype(batch_square_sum), place)
@@ -141,13 +141,12 @@ class TestDataNormOpInference(unittest.TestCase):
         data_norm_op.run(scope, place)
 
         # check inference result
-        self.__assert_close(
-            y_tensor,
-            y_out,
-            "inference output are different at " + str(place) + ", " +
-            data_layout + ", " + str(np.dtype(dtype)) +
-            str(np.array(y_tensor)) + str(y_out),
-            atol=1e-3)
+        self.__assert_close(y_tensor,
+                            y_out,
+                            "inference output are different at " + str(place) +
+                            ", " + data_layout + ", " + str(np.dtype(dtype)) +
+                            str(np.array(y_tensor)) + str(y_out),
+                            atol=1e-3)
 
     def test_check_output(self):
         """
@@ -156,8 +155,11 @@ class TestDataNormOpInference(unittest.TestCase):
         places = [core.CPUPlace()]
         for place in places:
             for data_format in ["NCHW", "NHWC"]:
-                for slot_dim in [-1, 1]: 
-                    self.check_with_place(place, data_format, self.dtype, [2, 3], slot_dim=slot_dim)
+                for slot_dim in [-1, 1]:
+                    self.check_with_place(place,
+                                          data_format,
+                                          self.dtype, [2, 3],
+                                          slot_dim=slot_dim)
 
 
 class TestDataNormOp(OpTest):
@@ -165,7 +167,6 @@ class TestDataNormOp(OpTest):
     test class for data norm op
     test forward and backward
     """
-
     def setUp(self):
         """
         init data norm op test env
@@ -217,7 +218,6 @@ class TestDataNormOpWithSlotDim(OpTest):
     test class for data norm op
     test forward and backward
     """
-
     def setUp(self):
         """
         init data norm op test env
@@ -250,7 +250,11 @@ class TestDataNormOpWithSlotDim(OpTest):
             "BatchSquareSum": batch_square_sum
         }
         self.outputs = {"Y": y, "Means": mean, "Scales": scale}
-        self.attrs = {"epsilon": epsilon, "use_mkldnn": self.use_mkldnn, "slot_dim": slot_dim}
+        self.attrs = {
+            "epsilon": epsilon,
+            "use_mkldnn": self.use_mkldnn,
+            "slot_dim": slot_dim
+        }
 
     def test_check_output(self):
         """
@@ -263,6 +267,7 @@ class TestDataNormOpWithSlotDim(OpTest):
         test check backward, check grad
         """
         self.check_grad(['X'], 'Y', no_grad_set=set([]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -77,6 +77,7 @@ class TestDataNormOpInference(unittest.TestCase):
             data_layout(str): NCHW or NWHC
             dtype(dtype): np.float32
             shape(list): input shape
+            slot_dim(int): dim for one slot
 
         """
         epsilon = 0.00001
@@ -210,6 +211,58 @@ class TestDataNormOp(OpTest):
         """
         self.check_grad(['X'], 'Y', no_grad_set=set([]))
 
+
+class TestDataNormOpWithSlotDim(OpTest):
+    """
+    test class for data norm op
+    test forward and backward
+    """
+
+    def setUp(self):
+        """
+        init data norm op test env
+        """
+        self.op_type = 'data_norm'
+        self.use_mkldnn = False
+        epsilon = 0.00001
+        slot_dim = 1
+        x_shape = [2, 3]
+        scale_shape = [3]
+        tp = np.float32
+
+        x_val = np.array([[-0.35702616, 0.0, -0.08306625],
+                          [0.41199666, 0.0, -0.10180971]]).astype(tp)
+        batch_size = np.ones(scale_shape).astype(tp)
+        batch_size *= 1e4
+        batch_sum = np.zeros(scale_shape).astype(tp)
+        batch_square_sum = np.ones(scale_shape).astype(tp)
+        batch_square_sum *= 1e4
+
+        y = np.array(x_val)
+
+        mean = np.array([[0, 0, 0], [0, 0, 0]]).astype(tp)
+        scale = np.array([[1, 1, 1], [1, 1, 1]]).astype(tp)
+
+        self.inputs = {
+            "X": x_val,
+            "BatchSize": batch_size,
+            "BatchSum": batch_sum,
+            "BatchSquareSum": batch_square_sum
+        }
+        self.outputs = {"Y": y, "Means": mean, "Scales": scale}
+        self.attrs = {"epsilon": epsilon, "use_mkldnn": self.use_mkldnn, "slot_dim": slot_dim}
+
+    def test_check_output(self):
+        """
+        test check forward, check output
+        """
+        self.check_output()
+
+    def test_check_grad(self):
+        """
+        test check backward, check grad
+        """
+        self.check_grad(['X'], 'Y', no_grad_set=set([]))
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -28,6 +28,7 @@ def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):
     x_shape = x.shape
     means_arr = batch_sum / batch_size
     scales_arr = np.sqrt(batch_size / batch_square_sum)
+    min_precision = 1e-7
     if slot_dim <= 0:
         for i in range(x_shape[0]):
             x[i] -= means_arr
@@ -37,7 +38,7 @@ def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):
         y = np.zeros(x_shape).astype(np.float32)
         for i in range(x_shape[0]):
             for j in range(0, x_shape[1], slot_dim):
-                if x[i][j] <= -1e-7 or x[i][j] > 1e-7:
+                if x[i][j] <= -min_precision or x[i][j] > min_precision:
                     for k in range(0, slot_dim):
                         y[i][j + k] = (
                             x[i][j + k] - means_arr[j + k]) * scales_arr[j + k]
@@ -78,7 +79,8 @@ class TestDataNormOpInference(unittest.TestCase):
             data_layout(str): NCHW or NWHC
             dtype(dtype): np.float32
             shape(list): input shape
-            slot_dim(int): dim for one slot
+            slot_dim(int): dimension of one slot. Refer to data_norm api.
+
 
         """
         epsilon = 0.00001

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -38,7 +38,7 @@ def _reference_testing(x, batch_size, batch_sum, batch_square_sum, slot_dim=-1):
         y = np.zeros(x_shape).astype(np.float32)
         for i in range(x_shape[0]):
             for j in range(0, x_shape[1], slot_dim):
-                if x[i][j] <= -min_precision or x[i][j] > min_precision:
+                if x[i][j] <= -min_precision or x[i][j] >= min_precision:
                     for k in range(0, slot_dim):
                         y[i][j + k] = (
                             x[i][j + k] - means_arr[j + k]) * scales_arr[j + k]


### PR DESCRIPTION
In data_norm op, which is usually used with pslib mode. we force to change the distribution of embedding by the historical mean and square sum without doing scale and shift. So in some case, when the slot is empty or new, the value after normalization may be impractical.
To fix this bug, we determine to do this normalization  by judging if the show num of slots is zero.  if  zero, we skip the forward normalization and backward update of these statistic values