### PR TITLE
fix bug when build openblas with a computer that has installed openblas before

### DIFF
--- a/cmake/cblas.cmake
+++ b/cmake/cblas.cmake
@@ -14,7 +14,7 @@
 
 # Find the CBlas and lapack libraries
 #
-# It will search MKLML, atlas, OpenBlas, reference-cblas in order.
+# It will search MKLML, OpenBlas, reference-cblas, extern-openblas in order.
 #
 # If any cblas implementation found, the following variable will be set.
 #    CBLAS_PROVIDER  # one of MKLML, OPENBLAS, REFERENCE

--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -75,25 +75,26 @@ copy(inference_lib_dist
         SRCS ${DLPACK_INCLUDE_DIR}/dlpack
         DSTS ${dst_dir})
 
-if(WITH_MKLML)
+
+if(${CBLAS_PROVIDER} STREQUAL MKLML)
     set(dst_dir "${FLUID_INFERENCE_INSTALL_DIR}/third_party/install/mklml")
     if(WIN32)
         copy(inference_lib_dist
                 SRCS ${MKLML_LIB} ${MKLML_IOMP_LIB} ${MKLML_SHARED_LIB}
-                ${MKLML_SHARED_LIB_DEPS} ${MKLML_SHARED_IOMP_LIB} ${MKLML_INC_DIR}
+                  ${MKLML_SHARED_LIB_DEPS} ${MKLML_SHARED_IOMP_LIB} ${MKLML_INC_DIR}
                 DSTS ${dst_dir}/lib ${dst_dir}/lib ${dst_dir}/lib
-                ${dst_dir}/lib ${dst_dir}/lib ${dst_dir})
+                  ${dst_dir}/lib ${dst_dir}/lib ${dst_dir})
     else()
         copy(inference_lib_dist
                 SRCS ${MKLML_LIB} ${MKLML_IOMP_LIB} ${MKLML_INC_DIR}
                 DSTS ${dst_dir}/lib ${dst_dir}/lib ${dst_dir})
     endif()
-elseif (NOT CBLAS_FOUND OR WIN32)
+elseif(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
     set(dst_dir "${FLUID_INFERENCE_INSTALL_DIR}/third_party/install/openblas")
-    copy(inference_lib_dist
-            SRCS ${CBLAS_INSTALL_DIR}/lib ${CBLAS_INSTALL_DIR}/include
-            DSTS ${dst_dir} ${dst_dir})
-endif ()
+        copy(inference_lib_dist
+                SRCS ${CBLAS_INSTALL_DIR}/lib ${CBLAS_INSTALL_DIR}/include
+                DSTS ${dst_dir} ${dst_dir})
+endif()
 
 if(WITH_MKLDNN)
     set(dst_dir "${FLUID_INFERENCE_INSTALL_DIR}/third_party/install/mkldnn")

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -116,8 +116,7 @@ endif()
 include(cblas)              	# find first, then download, build, install openblas
 if(${CBLAS_PROVIDER} STREQUAL MKLML)
     list(APPEND third_party_deps extern_mklml)
-endif()
-if(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
+elseif(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
     list(APPEND third_party_deps extern_openblas)
 endif()
 


### PR DESCRIPTION
fix bug when build paddle with openblas:
### **/Paddle/build/third_party/openblas/lib  doesn't exists and can't be copied to /Paddle/build/fluid_install_dir/third_party/openblas/lib**

if compile paddle **-DWITH_MKL=OFF，and  your computer has installed openblas before**, this bug will appear. 