### PR TITLE
Fix INF bug of softmax_cross_entropy_op

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -172,6 +172,12 @@ static __global__ void RowReductionForDiffMaxSum(const T* logits_data,
   auto block_max = max_data[blockIdx.x];
   int step = BlockDim * remain;
 
+  // In numeric stable mode softmax_with_loss, we calc loss with
+  // tmp_i_j = x_i_j - max_i - logDiffMaxSum_i, instead of
+  // log(exp(x_i_j - max_i)/DiffMaxSum_i). Therefore, log(0) will not occur.
+  // Also we calc softmax_i_j = e^{tmp_i_j}, the maximum and minimum value will
+  // be 1.0 and 0.0, represent prob is 1.0 and 0.0.
+  // So there is no need to clip on shift_softmax.
   softmax[beg_idx] = logits_data[beg_idx] - block_max;
   T diff_max_sum = exp_on_device(softmax[beg_idx]);
   auto idx = beg_idx + step;

--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -150,10 +150,7 @@ static __global__ void RowReductionForMax(const T* logits_data, T* max_data,
 
   cur_max = BlockReduce<T, BlockDim>(temp_storage).Reduce(cur_max, cub::Max());
 
-  if (threadIdx.x == 0) {
-    max_data[blockIdx.x] =
-        cur_max < static_cast<T>(-64) ? static_cast<T>(-64) : cur_max;
-  }
+  if (threadIdx.x == 0) max_data[blockIdx.x] = cur_max;
 }
 
 // Make sure that BlockDim <= axis_dim

--- a/python/paddle/fluid/tests/unittests/test_fused_multihead_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multihead_matmul_op.py
@@ -25,7 +25,9 @@ np.random.random(123)
 
 def stable_softmax(x):
     """Compute the softmax of vector x in a numerically stable way."""
-    shiftx = x - np.max(x).clip(-64.)
+    # clip to shiftx, otherwise, when calc loss with
+    # log(exp(shiftx)), may get log(0)=INF
+    shiftx = (x - np.max(x)).clip(-64.)
     exps = np.exp(shiftx)
     return exps / np.sum(exps)
 

--- a/python/paddle/fluid/tests/unittests/test_locality_aware_nms_op.py
+++ b/python/paddle/fluid/tests/unittests/test_locality_aware_nms_op.py
@@ -200,7 +200,9 @@ class TestLocalAwareNMSOp(OpTest):
         scores = np.random.random((N * M, C)).astype('float32')
 
         def softmax(x):
-            shiftx = x - np.max(x).clip(-64.)
+            # clip to shiftx, otherwise, when calc loss with
+            # log(exp(shiftx)), may get log(0)=INF
+            shiftx = (x - np.max(x)).clip(-64.)
             exps = np.exp(shiftx)
             return exps / np.sum(exps)
 

--- a/python/paddle/fluid/tests/unittests/test_multiclass_nms_op.py
+++ b/python/paddle/fluid/tests/unittests/test_multiclass_nms_op.py
@@ -19,6 +19,14 @@ import copy
 from op_test import OpTest
 
 
+def softmax(x):
+    # clip to shiftx, otherwise, when calc loss with
+    # log(exp(shiftx)), may get log(0)=INF
+    shiftx = (x - np.max(x)).clip(-64.)
+    exps = np.exp(shiftx)
+    return exps / np.sum(exps)
+
+
 def iou(box_a, box_b, norm):
     """Apply intersection-over-union overlap between box_a and box_b
     """
@@ -254,11 +262,6 @@ class TestMulticlassNMSOp(OpTest):
 
         scores = np.random.random((N * M, C)).astype('float32')
 
-        def softmax(x):
-            shiftx = x - np.max(x).clip(-64.)
-            exps = np.exp(shiftx)
-            return exps / np.sum(exps)
-
         scores = np.apply_along_axis(softmax, 1, scores)
         scores = np.reshape(scores, (N, M, C))
         scores = np.transpose(scores, (0, 2, 1))
@@ -317,11 +320,6 @@ class TestMulticlassNMSLoDInput(OpTest):
         normalized = False
 
         scores = np.random.random((M, C)).astype('float32')
-
-        def softmax(x):
-            shiftx = x - np.max(x).clip(-64.)
-            exps = np.exp(shiftx)
-            return exps / np.sum(exps)
 
         scores = np.apply_along_axis(softmax, 1, scores)
 
@@ -382,11 +380,6 @@ class TestMulticlassNMS2Op(TestMulticlassNMSOp):
 
         scores = np.random.random((N * M, C)).astype('float32')
 
-        def softmax(x):
-            shiftx = x - np.max(x).clip(-64.)
-            exps = np.exp(shiftx)
-            return exps / np.sum(exps)
-
         scores = np.apply_along_axis(softmax, 1, scores)
         scores = np.reshape(scores, (N, M, C))
         scores = np.transpose(scores, (0, 2, 1))
@@ -446,11 +439,6 @@ class TestMulticlassNMS2LoDInput(TestMulticlassNMSLoDInput):
         normalized = False
 
         scores = np.random.random((M, C)).astype('float32')
-
-        def softmax(x):
-            shiftx = x - np.max(x).clip(-64.)
-            exps = np.exp(shiftx)
-            return exps / np.sum(exps)
 
         scores = np.apply_along_axis(softmax, 1, scores)
 

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -24,7 +24,9 @@ from paddle.fluid import compiler, Program, program_guard
 
 def stable_softmax(x):
     """Compute the softmax of vector x in a numerically stable way."""
-    shiftx = x - np.max(x).clip(-64.)
+    # clip to shiftx, otherwise, when calc loss with
+    # log(exp(shiftx)), may get log(0)=INF
+    shiftx = (x - np.max(x)).clip(-64.)
     exps = np.exp(shiftx)
     return exps / np.sum(exps)
 


### PR DESCRIPTION
1. Fix INF bug in softmax_cross_entropy_op.
3. Repair softmax test bug.
2. Add boundary tests to softmax_cross_entropy_op, make sure no INF.

https://github.com/PaddlePaddle/Paddle/blob/fff270eacd83384ad9a62db1af38d7db65dd2cd3/paddle/fluid/operators/softmax_with_cross_entropy_op.cu#L155
计算max_data<-64时会将其强制截断为-64。实测expf(-104.0f)时就会出现数值下溢为0, 假如softmax前面全连接层获得的logits数值都<= (-64-104)，就会出现expf数值下溢，进而导致sum(expf(logits - max_data))=0, log(0)出现-inf。
最终 sofmax -= log(0)，出现inf，导致后面反向出现inf，最终训练出现nan。

按代码意思其实应该是对(logits - max_data)做clip，避免计算loss时出现log(exp(softmax))出现log(0)的现象。数值稳定版本的softmax_cross_entropy_op见新加注释可以不需要clip。test的softmax函数已按(logits - max_data)做clip进行修改。