### PR TITLE
Add masked select api

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13700,3 +13700,64 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0):
         outputs={"Out": out})
 
     return helper.append_activation(out)
+
+
+def masked_select(input, mask):
+    """
+    This OP selects elements of the input tensor according to the mask tensor.
+    The shapes of the mask tensor don't have to match shapes of input tensor, but they must be broadcastable, and the result is a new 1-D tensor.
+    NOTE: The broadcastable concept is consistent with expand_as.
+
+    Parameters:
+
+        input(Variable): The input tensor, the data type should be float32.
+        mask(Variable): The boolean mask tensor, the data type should be bool.
+
+    Returns:
+        Variable: masked select tensor.
+
+    Examples:
+
+        ..code-block:: python
+
+            import paddle.fluid as fluid
+            import numpy as np
+            mask_shape = [4,1]
+            shape = [4,4]
+            data = np.random.random(mask_shape).astype("float32")
+            input_data = np.random.randint(5,size=shape).astype("float32")
+            mask_data = data > 0.5
+
+            # print(input_data)
+            # [[0.38972723 0.36218056 0.7892614  0.50122297]
+            #  [0.14408113 0.85540855 0.30984417 0.7577004 ]
+            #  [0.97263193 0.5248062  0.07655851 0.75549215]
+            #  [0.26214206 0.32359877 0.6314582  0.2128865 ]]
+
+            # print(mask_data)
+            # [[ True]
+            #  [ True]
+            #  [False]
+            #  [ True]]
+
+            input = fluid.data(name="input",shape=[4,4],dtype="float32")
+            mask = fluid.data(name="mask",shape=[4,1],dtype="bool")
+            result = fluid.layers.masked_select(input=input, mask=mask)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            start = fluid.default_startup_program()
+            main = fluid.default_main_program()
+            exe.run(start)
+            masked_select_result= exe.run(main, feed={'input':input_data, 'mask':mask_data}, fetch_list=[result])
+            # print(masked_select)
+            # [0.38972723 0.36218056 0.7892614  0.50122297 0.14408113 0.85540855
+               0.30984417 0.7577004  0.26214206 0.32359877 0.6314582  0.2128865 ]
+
+
+    """
+    mask_cast = fluid.layers.cast(x=mask, dtype="float32")
+    mask_expand = fluid.layers.expand_as(x=mask_cast, target_tensor=input)
+    mask_expand_cast_back_bool = fluid.layers.cast(x=mask_expand, dtype="bool")
+    select = fluid.layers.where(mask_expand_cast_back_bool)
+    result = fluid.layers.gather_nd(input, select)
+    return result

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13751,7 +13751,7 @@ def masked_select(input, mask):
             masked_select_result= exe.run(main, feed={'input':input_data, 'mask':mask_data}, fetch_list=[result])
             # print(masked_select)
             # [0.38972723 0.36218056 0.7892614  0.50122297 0.14408113 0.85540855
-               0.30984417 0.7577004  0.26214206 0.32359877 0.6314582  0.2128865 ]
+            #   0.30984417 0.7577004  0.26214206 0.32359877 0.6314582  0.2128865 ]
 
     """
     mask_cast = fluid.layers.cast(x=mask, dtype="float32")

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13707,7 +13707,8 @@ def masked_select(input, mask):
     """
     This OP selects elements of the input tensor according to the mask tensor.
     The shapes of the mask tensor don't have to match shapes of input tensor, but they must be broadcastable, and the result is a new 1-D tensor.
-    NOTE: The broadcastable concept is consistent with expand_as.
+
+    NOTE: The meaning of broadcastable is consistent with expand_as.
 
     Parameters:
 
@@ -13715,7 +13716,7 @@ def masked_select(input, mask):
         mask(Variable): The boolean mask tensor, the data type should be bool.
 
     Returns:
-        Variable: masked select tensor.
+        Variable: masked select tensor, its data type is same as the input.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13470,7 +13470,7 @@ def masked_select(input, mask):
 
     Parameters:
 
-        input(Variable): The input tensor, the data type should be float32.
+        input(Variable): The input tensor, the data type should be int32, float32, float64.
         mask(Variable): The boolean mask tensor, the data type should be bool.
 
     Returns:
@@ -13508,12 +13508,12 @@ def masked_select(input, mask):
             main = fluid.default_main_program()
             exe.run(start)
             masked_select_result= exe.run(main, feed={'input':input_data, 'mask':mask_data}, fetch_list=[result])
-            # print(masked_select)
+            # print(masked_select_result)
             # [0.38972723 0.36218056 0.7892614  0.50122297 0.14408113 0.85540855
             #   0.30984417 0.7577004  0.26214206 0.32359877 0.6314582  0.2128865 ]
 
     """
-    mask_cast = cast(x=mask, dtype="float32")
+    mask_cast = cast(x=mask, dtype=input.dtype)
     mask_expand = expand_as(x=mask_cast, target_tensor=input)
     mask_expand_cast_back_bool = cast(x=mask_expand, dtype="bool")
     select = where(mask_expand_cast_back_bool)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13718,8 +13718,7 @@ def masked_select(input, mask):
         Variable: masked select tensor.
 
     Examples:
-
-        ..code-block:: python
+        .. code-block:: python
 
             import paddle.fluid as fluid
             import numpy as np
@@ -13753,7 +13752,6 @@ def masked_select(input, mask):
             # print(masked_select)
             # [0.38972723 0.36218056 0.7892614  0.50122297 0.14408113 0.85540855
                0.30984417 0.7577004  0.26214206 0.32359877 0.6314582  0.2128865 ]
-
 
     """
     mask_cast = fluid.layers.cast(x=mask, dtype="float32")

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -28,7 +28,7 @@ from ..framework import Variable, OpProtoHolder, in_dygraph_mode
 from ..dygraph import base
 from ..param_attr import ParamAttr
 from .layer_function_generator import autodoc, templatedoc, _generate_doc_string_
-from .tensor import concat, assign, fill_constant, zeros
+from .tensor import concat, assign, fill_constant, zeros, cast
 from . import utils
 from .. import unique_name
 from functools import reduce
@@ -13755,9 +13755,9 @@ def masked_select(input, mask):
             #   0.30984417 0.7577004  0.26214206 0.32359877 0.6314582  0.2128865 ]
 
     """
-    mask_cast = fluid.layers.cast(x=mask, dtype="float32")
-    mask_expand = fluid.layers.expand_as(x=mask_cast, target_tensor=input)
-    mask_expand_cast_back_bool = fluid.layers.cast(x=mask_expand, dtype="bool")
-    select = fluid.layers.where(mask_expand_cast_back_bool)
-    result = fluid.layers.gather_nd(input, select)
+    mask_cast = cast(x=mask, dtype="float32")
+    mask_expand = expand_as(x=mask_cast, target_tensor=input)
+    mask_expand_cast_back_bool = cast(x=mask_expand, dtype="bool")
+    select = where(mask_expand_cast_back_bool)
+    result = gather_nd(input, select)
     return result

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -183,6 +183,7 @@ __all__ = [
     'hard_swish',
     'gather_tree',
     'uniform_random',
+    'masked_select',
 ]
 
 

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -2544,6 +2544,14 @@ class TestBook(LayerTest):
             out = layers.square_error_cost(input=x, label=y)
             return (out)
 
+    def make_masked_select(self):
+        with program_guard(fluid.default_main_program(),
+                           fluid.default_startup_program()):
+            input = self._get_data(name="input", shape=[4, 4], dtype="float32")
+            mask = self._get_data(name="mask", shape=[1, 4], dtype="bool")
+            out = layers.masked_select(input=input, mask=mask)
+            return (out)
+
     def test_dynamic_lstmp(self):
         # TODO(minqiyang): dygraph do not support lod now
         with self.static_graph():

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1640,6 +1640,9 @@ class TestBook(LayerTest):
         elif dtype == 'int64':
             return np.random.randint(self._low_data_bound,
                                      self._high_data_bound, shape).astype(dtype)
+        elif dtype == 'bool':
+            return np.random.randint(self._low_data_bound,
+                                     self._high_data_bound, shape).astype(dtype)
 
     def _get_data(self,
                   name,

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -2547,9 +2547,9 @@ class TestBook(LayerTest):
     def make_masked_select(self):
         with program_guard(fluid.default_main_program(),
                            fluid.default_startup_program()):
-            input = self._get_data(name="input", shape=[4, 4], dtype="float32")
-            mask = self._get_data(name="mask", shape=[1, 4], dtype="bool")
-            out = layers.masked_select(input=input, mask=mask)
+            x = self._get_data(name="X", shape=[4, 4], dtype="float32")
+            y = self._get_data(name="Y", shape=[1, 4], dtype="bool")
+            out = layers.masked_select(input=x, mask=y)
             return (out)
 
     def test_dynamic_lstmp(self):

--- a/python/paddle/fluid/tests/unittests/test_masked_select.py
+++ b/python/paddle/fluid/tests/unittests/test_masked_select.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import sys
+import paddle.fluid.core as core
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
+from paddle.fluid.executor import Executor
+
+
+class TestMaskedSelect(unittest.TestCase):
+    def test_masked_select(self):
+
+        mask_shape = [4, 1]
+        shape = [4, 4]
+        data = np.random.random(mask_shape).astype("float32")
+        input_data = np.random.random(shape).astype("float32")
+        mask_data = data > 0.5
+        mask_data_b = np.broadcast_to(mask_data, shape)
+        npresult = input_data[np.where(mask_data_b)]
+
+        input_var = layers.create_tensor(dtype="float32", name="input")
+        mask_var = layers.create_tensor(dtype="bool", name="mask")
+
+        output = layers.masked_select(input=input_var, mask=mask_var)
+        for use_cuda in ([False, True]
+                         if core.is_compiled_with_cuda() else [False]):
+            place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
+            exe = Executor(place)
+            result = exe.run(fluid.default_main_program(),
+                             feed={"input": input_data,
+                                   "mask": mask_data},
+                             fetch_list=[output])
+
+            self.assertTrue(np.isclose(np_result, result).all())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_masked_select.py
+++ b/python/paddle/fluid/tests/unittests/test_masked_select.py
@@ -47,7 +47,7 @@ class TestMaskedSelect(unittest.TestCase):
                                    "mask": mask_data},
                              fetch_list=[output])
 
-            self.assertTrue(np.isclose(np_result, result).all())
+            self.assertTrue(np.isclose(npresult, result).all())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
It selects elements of the input tensor according to the mask tensor.
Note: The shapes of the mask tensor don't have to match the shapes of input tensor, but they must be broadcastable, and the result is a new 1-D tensor.

NOTE: As the broadcast function is not elegantly implemented in PaddlePaddle, we assume the broadcastable concept in here is consistent with [**api:expand_as**](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api_cn/layers_cn/expand_as_cn.html#expand-as)

![image](https://user-images.githubusercontent.com/13645332/68858662-7ca8b300-0720-11ea-986b-291280b43cb7.png)
