### PR TITLE
Add PADDLE ENFORCE count script

### DIFF
--- a/tools/count_invalid_enforce.sh
+++ b/tools/count_invalid_enforce.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+ALL_PADDLE_CHECK=`grep -r -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" ../paddle/fluid || true`
+ALL_PADDLE_CHECK_CNT=`echo "$ALL_PADDLE_CHECK" | grep -cE "(PADDLE_ENFORCE|PADDLE_THROW)" || true`
+VALID_PADDLE_CHECK_CNT=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' | grep -cE "(PADDLE_ENFORCE|PADDLE_THROW)" || true`
+
+echo "----------------------------"
+echo "PADDLE ENFORCE & THROW COUNT"
+echo "----------------------------"
+echo "All PADDLE_ENFORCE{_**} & PADDLE_THROW Count: ${ALL_PADDLE_CHECK_CNT}"
+echo "Valid PADDLE_ENFORCE{_**} & PADDLE_THROW Count: ${VALID_PADDLE_CHECK_CNT}"
+echo "Invalid PADDLE_ENFORCE{_**} & PADDLE_THROW Count: $(($ALL_PADDLE_CHECK_CNT-$VALID_PADDLE_CHECK_CNT))"


### PR DESCRIPTION
In order to verify the effect of [Paddle Error Message Writing Specification](https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification), this PR adds a script to count the number of PADDLE_ENFORCE{_**} and PADDLE_THROW entries, run this script to get the total number of PADDLE_ENFORCE{_**} and PADDLE_THROW entries, the number of valid entries and the number of invalid entries.

The example:

```
----------------------------
PADDLE ENFORCE & THROW COUNT
----------------------------
All PADDLE_ENFORCE{_**} & PADDLE_THROW Count: 5650
Valid PADDLE_ENFORCE{_**} & PADDLE_THROW Count: 23
Invalid PADDLE_ENFORCE{_**} & PADDLE_THROW Count: 5627
```