### PR TITLE
[cherry-pick] fix error message in expand API, and fix two error unit-tests

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12985,8 +12985,8 @@ def expand(x, expand_times, name=None):
     """
     if not isinstance(x, Variable):
         raise TypeError(
-            "The type of 'input' in reduce_sum must be Variable, but received %s"
-            % (type(x)))
+            "The type of 'input' in expand must be Variable, but received %s" %
+            (type(x)))
     if not isinstance(expand_times, (list, tuple, Variable)):
         raise ValueError(
             "Input expand_times must be an Variable, python list or tuple.")

--- a/python/paddle/fluid/tests/unittests/test_accuracy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_accuracy_op.py
@@ -64,13 +64,13 @@ class TestAccuracyOpError(OpTest):
             # The input type of accuracy_op must be Variable.
             x1 = fluid.create_lod_tensor(
                 np.array([[-1]]), [[1]], fluid.CPUPlace())
-            self.assertRaises(TypeError, fluid.layers.accuracy, x1)
-            # The input dtype of accuracy_op must be float32 or float64.
-            x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
-            self.assertRaises(TypeError, fluid.layers.accuracy, x2)
-            x3 = fluid.layers.data(name='input', shape=[-1, 2], dtype="float16")
             label = fluid.layers.data(
                 name='label', shape=[-1, 1], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.accuracy, x1, label)
+            # The input dtype of accuracy_op must be float32 or float64.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="int32")
+            self.assertRaises(TypeError, fluid.layers.accuracy, x2, label)
+            x3 = fluid.layers.data(name='input', shape=[-1, 2], dtype="float16")
             fluid.layers.accuracy(input=x3, label=label)
 
 

--- a/python/paddle/fluid/tests/unittests/test_zeros_op.py
+++ b/python/paddle/fluid/tests/unittests/test_zeros_op.py
@@ -28,10 +28,9 @@ class TestZerosOpError(OpTest):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input dtype of zeros_op must be bool, float16, float32, float64, int32, int64.
-            x1 = fluid.layers.data(name='x1', shape=[4], dtype="int8")
-            self.assertRaises(TypeError, fluid.layers.zeros, x1)
-            x2 = fluid.layers.data(name='x2', shape=[4], dtype="uint8")
-            self.assertRaises(TypeError, fluid.layers.zeros, x2)
+            shape = [4]
+            dtype = "int8"
+            self.assertRaises(TypeError, fluid.layers.zeros, shape, dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
cherry-pick 部分#21161
- 修复报错信息文案中写错类型名字
- 修复`test_accuracy_op.py`和`test_zeros_op.py`两个错误的报错单测。 