### PR TITLE
fix elementwise_mod float point kernel

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_mod_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_mod_op.h
@@ -29,7 +29,9 @@ struct ModFunctor {
 
 template <typename T>
 struct ModFunctorFP {
-  inline HOSTDEVICE T operator()(T a, T b) const { return std::fmod(a, b); }
+  inline HOSTDEVICE T operator()(T a, T b) const {
+    return fmod(b + fmod(a, b), b);
+  }
 };
 
 template <typename DeviceContext, typename T>

--- a/python/paddle/fluid/tests/unittests/test_elementwise_mod_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_mod_op.py
@@ -71,7 +71,7 @@ class TestElementwiseModOpFloat(TestElementwiseModOp):
     def init_input_output(self):
         self.x = np.random.uniform(-1000, 1000, [10, 10]).astype(self.dtype)
         self.y = np.random.uniform(-100, 100, [10, 10]).astype(self.dtype)
-        self.out = np.fmod(self.x, self.y)
+        self.out = np.fmod(self.y + np.fmod(self.x, self.y), self.y)
 
     def test_check_output(self):
         self.check_output(atol=2e-5)


### PR DESCRIPTION
**fix elementwise_mod float point kernel**

use `fmod(b + fmod(a, b), b)` to calcualte positive stable mod value
same as pytorch https://github.com/pytorch/pytorch/blob/f3b15727c58ab9d0010a03fd90c124f0727826e3/torch/csrc/jit/register_prim_ops.cpp#L2844