### PR TITLE
[MKL-DNN] Error throwing on an attempt to usw MKL-DNN kernels with data_format set to NHWC/NDHWC 

### DIFF
--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -138,6 +138,9 @@ framework::OpKernelType BatchNormOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","Batch Norm MKLDNN does not support NHWC data format yet"); 
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
   }
@@ -427,6 +430,9 @@ framework::OpKernelType BatchNormGradOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","Batch Norm MKLDNN grad does not support NHWC data format yet"); 
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/batch_norm_op.cc
+++ b/paddle/fluid/operators/batch_norm_op.cc
@@ -140,7 +140,9 @@ framework::OpKernelType BatchNormOp::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","Batch Norm MKLDNN does not support NHWC data format yet"); 
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        "Batch Norm MKLDNN does not support NHWC data format yet");
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
   }
@@ -432,7 +434,9 @@ framework::OpKernelType BatchNormGradOp::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","Batch Norm MKLDNN grad does not support NHWC data format yet"); 
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        "Batch Norm MKLDNN grad does not support NHWC data format yet");
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -150,7 +150,10 @@ framework::OpKernelType ConvOp::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","Conv MKLDNN does not support NHWC data format yet"); 
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Conv MKLDNN does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(data_format, "NDHWC",
+                      "Conv MKLDNN does not support NDHWC data format yet");
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
     customized_type_value =
@@ -526,7 +529,11 @@ framework::OpKernelType ConvOpGrad::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","Conv MKLDNN grad does not support NHWC data format yet"); 
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Conv MKLDNN grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NDHWC",
+        "Conv MKLDNN Grad does not support NDHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
     customized_type_value = kConvMKLDNNFP32;
@@ -705,6 +712,14 @@ framework::OpKernelType ConvOpDoubleGrad::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC and NDHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        "Conv MKLDNN Double Grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NDHWC",
+        "Conv MKLDNN Double Grad does not support NDHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
     customized_type_value = kConvMKLDNNFP32;

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -148,6 +148,9 @@ framework::OpKernelType ConvOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","Conv MKLDNN does not support NHWC data format yet"); 
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
     customized_type_value =
@@ -521,6 +524,9 @@ framework::OpKernelType ConvOpGrad::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","Conv MKLDNN grad does not support NHWC data format yet"); 
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
     customized_type_value = kConvMKLDNNFP32;

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -129,7 +129,9 @@ framework::OpKernelType ConvTransposeOp::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","Conv Transpose MKLDNN does not support NHWC data format yet"); 
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        "Conv Transpose MKLDNN does not support NHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -127,6 +127,9 @@ framework::OpKernelType ConvTransposeOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","Conv Transpose MKLDNN does not support NHWC data format yet"); 
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/lrn_op.cc
+++ b/paddle/fluid/operators/lrn_op.cc
@@ -162,9 +162,10 @@ class LRNOp : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     if (library_ == framework::LibraryType::kPlain &&
         platform::CanMKLDNNBeUsed(ctx)) {
-    // TODO(jczaja): Add support for NHWC
-    const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","LRN MKLDNN does not support NHWC data format yet"); 
+      // TODO(jczaja): Add support for NHWC
+      const std::string data_format = ctx.Attr<std::string>("data_format");
+      PADDLE_ENFORCE_NE(data_format, "NHWC",
+                        "LRN MKLDNN does not support NHWC data format yet");
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }
@@ -284,9 +285,11 @@ class LRNOpGrad : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     if (library_ == framework::LibraryType::kPlain &&
         platform::CanMKLDNNBeUsed(ctx)) {
-    // TODO(jczaja): Add support for NHWC
-    const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","LRN MKLDNN grad does not support NHWC data format yet"); 
+      // TODO(jczaja): Add support for NHWC
+      const std::string data_format = ctx.Attr<std::string>("data_format");
+      PADDLE_ENFORCE_NE(
+          data_format, "NHWC",
+          "LRN MKLDNN grad does not support NHWC data format yet");
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }

--- a/paddle/fluid/operators/lrn_op.cc
+++ b/paddle/fluid/operators/lrn_op.cc
@@ -162,6 +162,9 @@ class LRNOp : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     if (library_ == framework::LibraryType::kPlain &&
         platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","LRN MKLDNN does not support NHWC data format yet"); 
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }
@@ -281,6 +284,9 @@ class LRNOpGrad : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     if (library_ == framework::LibraryType::kPlain &&
         platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","LRN MKLDNN grad does not support NHWC data format yet"); 
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -160,6 +160,9 @@ framework::OpKernelType PoolOpGrad::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format,"NHWC","Pool MKLDNN grad does not support NHWC data format yet"); 
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -129,6 +129,10 @@ framework::OpKernelType PoolOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Pool MKLDNN grad does not support NHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }
@@ -162,7 +166,8 @@ framework::OpKernelType PoolOpGrad::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format,"NHWC","Pool MKLDNN grad does not support NHWC data format yet"); 
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Pool MKLDNN grad does not support NHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }


### PR DESCRIPTION
Release 1.6 MKL-DNN integration is not compatible with data_format attributes ( Batch Norm, Conv, Conv transpose and LRN ) when set to NHWC or NDHWC. In that situation PADDLE_ERROR is raised.

This PR is relevant to #20964 