### PR TITLE
fix constant precious problem 

### DIFF
--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -80,6 +80,25 @@ struct ExtractAttribute<bool> {
 };
 
 template <>
+struct ExtractAttribute<std::string> {
+  explicit ExtractAttribute(const std::string& attr_name)
+      : attr_name_(attr_name) {}
+
+  std::string* operator()(Attribute& attr) const {
+    std::string* attr_value = nullptr;
+    try {
+      attr_value = &boost::get<std::string>(attr);
+    } catch (boost::bad_get& bad_get) {
+      PADDLE_THROW("Cannot get attribute %s by type int64_t, its type is %s",
+                   attr_name_, paddle::platform::demangle(attr.type().name()));
+    }
+    return attr_value;
+  }
+
+  const std::string& attr_name_;
+};
+
+template <>
 struct ExtractAttribute<int64_t> {
   explicit ExtractAttribute(const std::string& attr_name)
       : attr_name_(attr_name) {}

--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -89,7 +89,7 @@ struct ExtractAttribute<std::string> {
     try {
       attr_value = &boost::get<std::string>(attr);
     } catch (boost::bad_get& bad_get) {
-      PADDLE_THROW("Cannot get attribute %s by type int64_t, its type is %s",
+      PADDLE_THROW("Cannot get attribute %s by type string, its type is %s",
                    attr_name_, paddle::platform::demangle(attr.type().name()));
     }
     return attr_value;

--- a/paddle/fluid/framework/ir/fillconstant_elementwisemul_fuse.cc
+++ b/paddle/fluid/framework/ir/fillconstant_elementwisemul_fuse.cc
@@ -49,13 +49,18 @@ void FillconstantElementwisemulFuse::ApplyImpl(ir::Graph* graph) const {
 
     PADDLE_ENFORCE(subgraph.count(x));
     auto* elementwise_in = subgraph.at(x);
-    float constant_value =
-        boost::get<float>(fill_constant->Op()->GetAttr("value"));
+    std::string constant_value =
+        boost::get<std::string>(fill_constant->Op()->GetAttr("value"));
+
+    std::stringstream convert_stream(constant_value);
+    float value = 1.0f;
+    convert_stream >> value;
+    paddle::framework::AttributeMap fill_constant_attrs{{"value", value}};
 
     framework::OpDesc new_op_desc;
     new_op_desc.SetType("scale");
     new_op_desc.SetInput("X", {elementwise_in->Name()});
-    new_op_desc.SetAttr("scale", constant_value);
+    new_op_desc.SetAttr("scale", fill_constant_attrs["value"]);
     new_op_desc.SetAttr("bias", static_cast<float>(0.0));
     new_op_desc.SetAttr("bias_after_scale", true);
     new_op_desc.SetOutput("Out", {elementwise_mul_out->Name()});

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -293,7 +293,7 @@ class WhileGradOp : public framework::OperatorBase {
             framework::AttributeMap attrs;
             attrs["dtype"] = inside_tensor.type();
             attrs["shape"] = framework::vectorize<int>(inside_tensor.dims());
-            attrs["value"] = 0.0f;
+            attrs["value"] = std::to_string(0.0f);
 
             auto var_name = pg_ig_names[param_id];
             auto zero_op = framework::OpRegistry::CreateOp(

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -90,8 +90,8 @@ class FillConstantOpMaker : public framework::OpProtoAndCheckerMaker {
              "The shape of the element in vector must be [1].")
         .AsDuplicable()
         .AsDispensable();
-    AddAttr<float>("value", "(float, default 0) The value to be filled")
-        .SetDefault(0.0f);
+    AddAttr<std::string>("value", "(float, default 0) The value to be filled")
+        .SetDefault("0.0");
     AddAttr<bool>("force_cpu",
                   "(bool, default false) Force fill output variable to cpu "
                   "memory. Otherwise, fill output variable to the running "

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -90,7 +90,7 @@ class FillConstantOpMaker : public framework::OpProtoAndCheckerMaker {
              "The shape of the element in vector must be [1].")
         .AsDuplicable()
         .AsDispensable();
-    AddAttr<std::string>("value", "(float, default 0) The value to be filled")
+    AddAttr<std::string>("value", "(string, default 0) The value to be filled")
         .SetDefault("0.0");
     AddAttr<bool>("force_cpu",
                   "(bool, default false) Force fill output variable to cpu "

--- a/paddle/fluid/operators/fill_constant_op.h
+++ b/paddle/fluid/operators/fill_constant_op.h
@@ -115,12 +115,15 @@ class FillConstantKernel : public framework::OpKernel<T> {
       math::SetConstant<platform::CPUDeviceContext, T> functor;
       functor(reinterpret_cast<const platform::CPUDeviceContext &>(dev_ctx),
               tensor, static_cast<T>(value));
-    } else {
+    }
+#ifdef PADDLE_WITH_CUDA
+    if (ctx.GetPlace() == platform::CUDAPlace()) {
       tensor->mutable_data(platform::CUDAPlace(), data_type);
       math::SetConstant<platform::CUDADeviceContext, T> functor;
       functor(reinterpret_cast<const platform::CUDADeviceContext &>(dev_ctx),
               tensor, static_cast<T>(value));
     }
+#endif
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/fill_constant_op.h
+++ b/paddle/fluid/operators/fill_constant_op.h
@@ -81,7 +81,6 @@ class FillConstantKernel : public framework::OpKernel<T> {
     framework::Tensor *tensor = nullptr;
 
     framework::Variable *out_var = ctx.OutputVar("Out");
-
     T value;
     std::stringstream convert_stream(str_value);
     if (std::is_same<int64_t, T>::value) {
@@ -89,11 +88,10 @@ class FillConstantKernel : public framework::OpKernel<T> {
       convert_stream >> tmp_value;
       value = static_cast<T>(tmp_value);
     } else {
-      float tmp_value;
+      double tmp_value;
       convert_stream >> tmp_value;
       value = static_cast<T>(tmp_value);
     }
-
     auto shape = GetShape(ctx);
 
     if (out_var->IsType<framework::LoDTensor>()) {

--- a/paddle/fluid/operators/recurrent_op.cc
+++ b/paddle/fluid/operators/recurrent_op.cc
@@ -398,7 +398,7 @@ void RecurrentGradOp::RunImpl(const framework::Scope &scope,
           framework::AttributeMap attrs;
           attrs["dtype"] = inside_tensor.type();
           attrs["shape"] = framework::vectorize<int>(inside_tensor.dims());
-          attrs["value"] = 0.0f;
+          attrs["value"] = std::to_string(0.0);
 
           auto zero_op = framework::OpRegistry::CreateOp(
               "fill_constant", framework::VariableNameMap{},

--- a/paddle/fluid/operators/rnn_memory_helper_op.cc
+++ b/paddle/fluid/operators/rnn_memory_helper_op.cc
@@ -108,7 +108,7 @@ class RNNMemoryHelperGradOp : public framework::OperatorBase {
       framework::AttributeMap attrs;
       attrs["dtype"] = in_var_tensor.type();
       attrs["shape"] = framework::vectorize<int>(in_var_tensor.dims());
-      attrs["value"] = 0.0f;
+      attrs["value"] = std::to_string(0.0f);
 
       auto zero_op = framework::OpRegistry::CreateOp(
           "fill_constant", {}, {{"Out", {in_grad_var_name}}}, attrs);

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -253,7 +253,7 @@ def _create_loss_op_desc_(loss):
     op_desc = _create_op_desc_(
         "fill_constant", {}, {"Out": [_append_grad_suffix_(loss.name)]}, {
             "shape": [1],
-            "value": 1.0,
+            "value": str(float(1.0)),
             "dtype": loss.dtype,
             "force_cpu": False,
             core.op_proto_and_checker_maker.kOpRoleAttrName():
@@ -1256,7 +1256,7 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
                                        {"ShapeTensor": [target_shape]},
                                        {"Out": [grad_name]}, {
                                            "shape": target.shape,
-                                           "value": 1.0,
+                                           "value": str(float(1.0)),
                                            "dtype": target.dtype,
                                        })
 

--- a/python/paddle/fluid/contrib/decoder/beam_search_decoder.py
+++ b/python/paddle/fluid/contrib/decoder/beam_search_decoder.py
@@ -134,7 +134,7 @@ class _ArrayState(object):
             attrs={
                 'shape': [1],
                 'dtype': self._counter.dtype,
-                'value': float(0.0),
+                'value': str(float(0.0)),
                 'force_cpu': True
             })
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1439,6 +1439,12 @@ class Variable(object):
         reverse_axis = []
 
         def fill_constant(shape, value, force_cpu=False, out=None):
+
+            str_value = "0.0f"
+            if convert_dtype(dtype) in ['int64']:
+                str_value = str(int(self.value))
+            else:
+                str_value = str(float(self.value))
             self.block.append_op(
                 type='fill_constant',
                 inputs={},
@@ -1446,7 +1452,7 @@ class Variable(object):
                 attrs={
                     'shape': shape,
                     'dtype': out.dtype,
-                    'value': float(value),
+                    'value': str_value,
                     'force_cpu': force_cpu
                 },
                 stop_gradient=True)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1440,11 +1440,12 @@ class Variable(object):
 
         def fill_constant(shape, value, force_cpu=False, out=None):
 
+            from .data_feeder import convert_dtype
             str_value = "0.0f"
-            if convert_dtype(dtype) in ['int64']:
-                str_value = str(int(self.value))
+            if convert_dtype(out.dtype) in ['int64']:
+                str_value = str(int(value))
             else:
-                str_value = str(float(self.value))
+                str_value = str(float(value))
             self.block.append_op(
                 type='fill_constant',
                 inputs={},

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1441,7 +1441,7 @@ class Variable(object):
         def fill_constant(shape, value, force_cpu=False, out=None):
 
             from .data_feeder import convert_dtype
-            str_value = "0.0f"
+            str_value = str(float(0.0))
             if convert_dtype(out.dtype) in ['int64']:
                 str_value = str(int(value))
             else:

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -19,6 +19,7 @@ import numpy as np
 from .wrapped_decorator import signature_safe_contextmanager
 from .core import VarDesc
 from . import unique_name
+from .data_feeder import convert_dtype
 
 __all__ = [
     'Constant', 'Uniform', 'Normal', 'TruncatedNormal', 'Xavier', 'Bilinear',
@@ -177,7 +178,7 @@ class ConstantInitializer(Initializer):
             out_var = var
 
         str_value = "0.0f"
-        if convert_dtype(dtype) in 'int64':
+        if convert_dtype(out_dtype) in ['int64']:
             str_value = str(int(self.value))
         else:
             str_value = str(float(self.value))

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -179,9 +179,9 @@ class ConstantInitializer(Initializer):
 
         str_value = "0.0f"
         if convert_dtype(out_dtype) in ['int64']:
-            str_value = str(int(self.value))
+            str_value = str(int(self._value))
         else:
-            str_value = str(float(self.value))
+            str_value = str(float(self._value))
         # Initialization Ops should be prepended and not appended
         op = block._prepend_op(
             type="fill_constant",

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -177,7 +177,7 @@ class ConstantInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
-        str_value = "0.0f"
+        str_value = str(float(0.0))
         if convert_dtype(out_dtype) in ['int64']:
             str_value = str(int(self._value))
         else:

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -176,6 +176,11 @@ class ConstantInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
+        str_value = "0.0f"
+        if convert_dtype(dtype) in 'int64':
+            str_value = str(int(self.value))
+        else:
+            str_value = str(float(self.value))
         # Initialization Ops should be prepended and not appended
         op = block._prepend_op(
             type="fill_constant",
@@ -183,7 +188,7 @@ class ConstantInitializer(Initializer):
             attrs={
                 "shape": var.shape,
                 "dtype": int(out_dtype),
-                "value": float(self._value),
+                "value": str_value,
                 'force_cpu': self._force_cpu or force_init_on_cpu()
             },
             stop_gradient=True)

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -2767,7 +2767,7 @@ class DynamicRNN(object):
                 attrs={
                     'shape': [1],
                     'dtype': self.zero_idx.dtype,
-                    'value': float(0),
+                    'value': str(float(0)),
                     'force_cpu': True
                 })
 

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -18,6 +18,7 @@ from .. import core
 from ..framework import Variable, unique_name
 from .layer_function_generator import OpProtoHolder
 from ..initializer import force_init_on_cpu
+from ..data_feeder import convert_dtype
 
 _supported_int_dtype_ = [
     core.VarDesc.VarType.UINT8,

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -50,7 +50,8 @@ def monkey_patch_variable():
     def create_tensor(block, value, dtype, shape):
         value = float(value)
         var = create_new_tmp_var(block, dtype)
-        str_value = "0.0f"
+
+        str_value = str(float(0.0))
         if convert_dtype(dtype) in 'int64':
             str_value = str(int(value))
         else:

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -49,13 +49,18 @@ def monkey_patch_variable():
     def create_tensor(block, value, dtype, shape):
         value = float(value)
         var = create_new_tmp_var(block, dtype)
+        str_value = "0.0f"
+        if convert_dtype(dtype) in 'int64':
+            str_value = str(int(self.value))
+        else:
+            str_value = str(float(self.value))
         block.append_op(
             type="fill_constant",
             outputs={'Out': [var]},
             attrs={
                 'dtype': var.dtype,
                 'shape': shape,
-                'value': value,
+                'value': str_value,
                 'force_cpu': force_init_on_cpu()
             },
             stop_gradient=True)

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -52,9 +52,9 @@ def monkey_patch_variable():
         var = create_new_tmp_var(block, dtype)
         str_value = "0.0f"
         if convert_dtype(dtype) in 'int64':
-            str_value = str(int(self.value))
+            str_value = str(int(value))
         else:
-            str_value = str(float(self.value))
+            str_value = str(float(value))
         block.append_op(
             type="fill_constant",
             outputs={'Out': [var]},

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -550,7 +550,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
 
     attrs = {'force_cpu': force_cpu or force_init_on_cpu()}
 
-    if convert_dtype(dtype) in 'int64':
+    if convert_dtype(dtype) in ['int64']:
         attrs['value'] = str(int(value))
     else:
         attrs['value'] = str(float(value))

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -143,7 +143,7 @@ def create_global_var(shape,
         stop_gradient=True)
     helper.set_variable_initializer(
         var, initializer=Constant(
-            value=float(value), force_cpu=force_cpu))
+            value=value, force_cpu=force_cpu))
 
     return var
 

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -547,10 +547,13 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
                 'fill_constant')
     check_type(shape, 'shape', (Variable, list, tuple), 'fill_constant')
     inputs = {}
-    attrs = {
-        'value': float(value),
-        'force_cpu': force_cpu or force_init_on_cpu()
-    }
+
+    attrs = {'force_cpu': force_cpu or force_init_on_cpu()}
+
+    if convert_dtype(dtype) in 'int64':
+        attrs['value'] = str(int(value))
+    else:
+        attrs['value'] = str(float(value))
 
     def _contain_var(one_list):
         for ele in one_list:

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -1377,7 +1377,7 @@ class AdagradOptimizer(Optimizer):
                                            param_and_grad[0])
         startup_block = framework.default_startup_program().global_block()
         str_value = "0.0f"
-        if convert_dtype(dtype) in ['int64']:
+        if convert_dtype(moment_acc.dtype) in ['int64']:
             str_value = str(int(self.initial_accumulator_value))
         else:
             str_value = str(float(self.initial_accumulator_value))

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -1375,13 +1375,18 @@ class AdagradOptimizer(Optimizer):
         moment_acc = self._get_accumulator(self._moment_acc_str,
                                            param_and_grad[0])
         startup_block = framework.default_startup_program().global_block()
+        str_value = "0.0f"
+        if convert_dtype(dtype) in ['int64']:
+            str_value = str(int(self.initial_accumulator_value))
+        else:
+            str_value = str(float(self.initial_accumulator_value))
         startup_block.append_op(
             type='fill_constant',
             inputs={},
             outputs={'Out': [moment_acc]},
             attrs={
                 'dtype': moment_acc.dtype,
-                'value': self.initial_accumulator_value,
+                'value': str_value,
                 'shape': moment_acc.shape,
             })
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -38,6 +38,7 @@ from paddle.fluid.layers import tensor
 from functools import reduce
 from .wrapped_decorator import signature_safe_contextmanager
 from .. import compat as cpt
+from .data_feeder import convert_dtype
 
 __all__ = [
     'SGD', 'Momentum', 'Adagrad', 'Adam', 'Adamax', 'Dpsgd', 'DecayedAdagrad',

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -1376,7 +1376,8 @@ class AdagradOptimizer(Optimizer):
         moment_acc = self._get_accumulator(self._moment_acc_str,
                                            param_and_grad[0])
         startup_block = framework.default_startup_program().global_block()
-        str_value = "0.0f"
+
+        str_value = str(float(0.0))
         if convert_dtype(moment_acc.dtype) in ['int64']:
             str_value = str(int(self.initial_accumulator_value))
         else:

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -32,7 +32,7 @@ class TestFillConstantOp1(OpTest):
         self.op_type = "fill_constant"
 
         self.inputs = {}
-        self.attrs = {'shape': [123, 92], 'value': 3.8}
+        self.attrs = {'shape': [123, 92], 'value': "3.8"}
         self.outputs = {'Out': np.full((123, 92), 3.8)}
 
     def test_check_output(self):
@@ -60,7 +60,7 @@ class TestFillConstantOp3(OpTest):
         self.op_type = "fill_constant"
 
         self.inputs = {}
-        self.attrs = {'shape': [123, 92], 'value': 10000000000}
+        self.attrs = {'shape': [123, 92], 'value': "10000000000"}
         self.outputs = {'Out': np.full((123, 92), 10000000000)}
 
     def test_check_output(self):
@@ -74,7 +74,7 @@ class TestFillConstantOp4(OpTest):
         self.op_type = "fill_constant"
 
         self.inputs = {}
-        self.attrs = {'shape': [123, 92], 'value': 3}
+        self.attrs = {'shape': [123, 92], 'value': "3"}
         self.outputs = {'Out': np.full((123, 92), 3)}
 
     def test_check_output(self):
@@ -89,12 +89,12 @@ class TestFillConstantOpWithSelectedRows(OpTest):
 
         # create and run fill_constant_op operator
         fill_constant_op = Operator(
-            "fill_constant", shape=[123, 92], value=3.8, Out='Out')
+            "fill_constant", shape=[123, 92], value="3.8", Out='Out')
         fill_constant_op.run(scope, place)
 
         # get result from Out
         result_array = np.array(out.get_tensor())
-        full_array = np.full((123, 92), 3.8, 'float32')
+        full_array = np.full((123, 92), "3.8", 'float32')
 
         self.assertTrue(np.array_equal(result_array, full_array))
 
@@ -120,13 +120,14 @@ class TestFillConstantOp1_ShapeTensorList(OpTest):
                 (1)).astype('int32') * ele))
 
         self.inputs = {"ShapeTensorList": shape_tensor_list}
-        self.attrs = {'shape': self.infer_shape, 'value': self.value}
+        self.attrs = {'shape': self.infer_shape, 'value': self.str_value}
         self.outputs = {'Out': np.full(self.shape, self.value)}
 
     def init_data(self):
         self.shape = [123, 92]
         self.infer_shape = [-1, 92]
         self.value = 3.8
+        self.str_value = str(float(self.value))
 
     def test_check_output(self):
         self.check_output()
@@ -150,6 +151,8 @@ class TestFillConstantOp2_ShapeTensorList(OpTest):
     def init_data(self):
         self.shape = [123, 92]
         self.infer_shape = [-1, -1]
+        self.value = 0.0
+        self.str_value = str(float(self.value))
 
     def test_check_output(self):
         self.check_output()
@@ -160,6 +163,7 @@ class TestFillConstantOp3_ShapeTensorList(TestFillConstantOp1_ShapeTensorList):
         self.shape = [123, 92]
         self.infer_shape = [123, -1]
         self.value = 10000000000
+        self.str_value = str(float(self.value))
 
 
 class TestFillConstantOp4_ShapeTensorList(TestFillConstantOp1_ShapeTensorList):
@@ -167,6 +171,7 @@ class TestFillConstantOp4_ShapeTensorList(TestFillConstantOp1_ShapeTensorList):
         self.shape = [123, 92]
         self.infer_shape = [123, -1]
         self.value = 3
+        self.str_value = str(float(self.value))
 
 
 # Situation 3: shape is a tensor
@@ -178,12 +183,13 @@ class TestFillConstantOp1_ShapeTensor(OpTest):
         self.init_data()
 
         self.inputs = {"ShapeTensor": np.array(self.shape).astype("int32")}
-        self.attrs = {'value': self.value}
+        self.attrs = {'value': self.str_value}
         self.outputs = {'Out': np.full(self.shape, self.value)}
 
     def init_data(self):
         self.shape = [123, 92]
         self.value = 3.8
+        self.str_value = str(float(self.value))
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/test_initializer.py
+++ b/python/paddle/fluid/tests/unittests/test_initializer.py
@@ -47,7 +47,7 @@ class TestConstantInitializer(unittest.TestCase):
         self.assertEqual(len(block.ops), num_ops)
         init_op = block.ops[0]
         self.assertEqual(init_op.type, 'fill_constant')
-        self.assertAlmostEqual(init_op.attr('value'), 0.0, delta=DELTA)
+        self.assertAlmostEqual(float(init_op.attr('value')), 0.0, delta=DELTA)
         return block
 
     def test_constant_initializer(self, dtype="float32"):
@@ -66,7 +66,7 @@ class TestConstantInitializer(unittest.TestCase):
         self.assertEqual(len(block.ops), num_ops)
         init_op = block.ops[0]
         self.assertEqual(init_op.type, 'fill_constant')
-        self.assertAlmostEqual(init_op.attr('value'), 2.3, delta=DELTA)
+        self.assertAlmostEqual(float(init_op.attr('value')), 2.3, delta=DELTA)
         return block
 
     def test_constant_initializer_fp16(self):

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -159,9 +159,9 @@ class TestMomentumOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 2)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
         self.assertEqual(init_ops[1].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[1].attr('value'), 0.0)
+        self.assertAlmostEqual(float(init_ops[1].attr('value')), 0.0)
 
     def test_nesterov_momentum_optimizer(self):
         init_program = framework.Program()
@@ -212,9 +212,9 @@ class TestMomentumOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 2)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
         self.assertEqual(init_ops[1].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[1].attr('value'), 0.0)
+        self.assertAlmostEqual(float(init_ops[1].attr('value')), 0.0)
 
 
 class TestAdagradOptimizer(unittest.TestCase):
@@ -272,9 +272,9 @@ class TestAdagradOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 3)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
         self.assertEqual(init_ops[1].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[1].attr('value'), 0.0)
+        self.assertAlmostEqual(float(init_ops[1].attr('value')), 0.0)
 
 
 class TestAdamOptimizer(unittest.TestCase):
@@ -340,7 +340,7 @@ class TestAdamOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 5)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
 
 
 class TestAdamaxOptimizer(unittest.TestCase):
@@ -405,7 +405,7 @@ class TestAdamaxOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 4)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
 
 
 class TestDpsgdOptimizer(unittest.TestCase):
@@ -505,9 +505,9 @@ class TestDecayedAdagradOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 2)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
         self.assertEqual(init_ops[1].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[1].attr('value'), 0.0)
+        self.assertAlmostEqual(float(init_ops[1].attr('value')), 0.0)
 
 
 class TestFtrlOptimizer(unittest.TestCase):
@@ -572,7 +572,7 @@ class TestFtrlOptimizer(unittest.TestCase):
         init_ops = init_program.global_block().ops
         self.assertEqual(len(init_ops), 3)
         self.assertEqual(init_ops[0].type, "fill_constant")
-        self.assertAlmostEqual(init_ops[0].attr('value'), learning_rate)
+        self.assertAlmostEqual(float(init_ops[0].attr('value')), learning_rate)
 
 
 class TestLookaheadOptimizer(unittest.TestCase):

--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -2424,7 +2424,7 @@ class DistributeTranspiler(object):
                                     self.startup_program.global_block().ops[
                                         i]._set_attr(
                                             'value',
-                                            float(0.0 - self.trainer_num))
+                                            str(float(0.0 - self.trainer_num)))
                     for var in all_trainer_counter_inputs:
                         if var.name == "%s.trainer_%d" % (counter_var.name,
                                                           self.trainer_id):


### PR DESCRIPTION
To solve https://github.com/PaddlePaddle/Paddle/issues/21113, we use the str to pass the value and  we need pay atttention to the use of math::set_constant, the  ``value`` parameter is float and it is fixed, so we discard the usage of math::set_constant in fill_constant OP .