### PR TITLE
Fake isinstance method in dygraph

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -558,7 +558,24 @@ def _debug_string_(proto, throw_on_error=True):
     return proto.__str__()
 
 
+class VariableMetaClass(type):
+    @classmethod
+    def __instancecheck__(cls, instance):
+        t = type(instance)
+        if in_dygraph_mode():
+            return issubclass(t, Variable) or issubclass(t, core.VarBase)
+        else:
+            return issubclass(t, Variable)
+
+
+class ParameterMetaClass(VariableMetaClass):
+    @classmethod
+    def __instancecheck__(cls, instance):
+        return issubclass(type(instance), Parameter)
+
+
 class Variable(object):
+    __metaclass__ = VariableMetaClass
     """
     **Notes**:
         **The constructor of Variable should not be invoked directly.**
@@ -4457,6 +4474,7 @@ class Program(object):
 
 
 class Parameter(Variable):
+    __metaclass__ = ParameterMetaClass
     """
     Parameter is derived from Variable. A parameter is a persistable
     Variable, and will be updated by optimizers after each iteration.

--- a/python/paddle/fluid/tests/unittests/test_fake_dygraph_variable_instance_check.py
+++ b/python/paddle/fluid/tests/unittests/test_fake_dygraph_variable_instance_check.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+from paddle.fluid.framework import Variable
+from paddle.fluid.core import VarBase
+import paddle.fluid.dygraph as dygraph
+import numpy as np
+import unittest
+
+
+class TestIsInstanceVariable(unittest.TestCase):
+    def test_main(self):
+        with dygraph.guard():
+            var_base = dygraph.to_variable(np.array([3, 4, 5]))._ivar
+            self.assertTrue(isinstance(var_base, VarBase))
+            self.assertTrue(isinstance(var_base, Variable))
+            self.assertEqual(type(var_base), VarBase)
+
+        var = fluid.data(name='x', shape=[None, 1], dtype='float32')
+        self.assertFalse(isinstance(var, VarBase))
+        self.assertTrue(isinstance(var, Variable))
+        self.assertEqual(type(var), Variable)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR makes `isinstance(var, Variable)` return True when var is an object of `VarBase` in dygraph mode. It is prepared for moving `Variable` to `VarBase` in dygraph mode to improve performance.