### PR TITLE
use prefetch to load next mem into cache

### DIFF
--- a/paddle/fluid/operators/pyramid_hash_op.cc
+++ b/paddle/fluid/operators/pyramid_hash_op.cc
@@ -172,12 +172,8 @@ class CPUPyramidHashOPKernel : public framework::OpKernel<T> {
 
       unsigned int pos3 =
           XXH32(hash_id, len * sizeof(T), j + 2 * _rand_len) % _space_len;
-      if (_rand_len == 16) {
-        memcpy(top_pos + j, const_cast<float*>(weights + pos1), 16 * sizeof(T));
-      } else {
-        memcpy(top_pos + j, const_cast<float*>(weights + pos1),
-               _rand_len * sizeof(T));
-      }
+      memcpy(top_pos + j, const_cast<float*>(weights + pos1),
+             _rand_len * sizeof(T));
       pos1 = pos2;
       pos2 = pos3;
     }

--- a/paddle/fluid/operators/pyramid_hash_op.cc
+++ b/paddle/fluid/operators/pyramid_hash_op.cc
@@ -161,14 +161,25 @@ class CPUPyramidHashOPKernel : public framework::OpKernel<T> {
   void hash_embedding_ff(const T* hash_id, int len, T* top_pos,
                          const T* weights, int _num_emb, int _rand_len,
                          int _space_len) const {
+    unsigned int pos1 = XXH32(hash_id, len * sizeof(T), 0) % _space_len;
+    unsigned int pos2 = XXH32(hash_id, len * sizeof(T), _rand_len) % _space_len;
+
     for (unsigned int j = 0; j != _num_emb; j += _rand_len) {
-      unsigned int pos = XXH32(hash_id, len * sizeof(T), j) % _space_len;
+      if (j + _rand_len < _num_emb) {
+        __builtin_prefetch(weights + pos2);
+        __builtin_prefetch(top_pos + j + _rand_len);
+      }
+
+      unsigned int pos3 =
+          XXH32(hash_id, len * sizeof(T), j + 2 * _rand_len) % _space_len;
       if (_rand_len == 16) {
-        memcpy(top_pos + j, const_cast<float*>(weights + pos), 16 * sizeof(T));
+        memcpy(top_pos + j, const_cast<float*>(weights + pos1), 16 * sizeof(T));
       } else {
-        memcpy(top_pos + j, const_cast<float*>(weights + pos),
+        memcpy(top_pos + j, const_cast<float*>(weights + pos1),
                _rand_len * sizeof(T));
       }
+      pos1 = pos2;
+      pos2 = pos3;
     }
   }
 


### PR DESCRIPTION
memcpy usage in hash_embedding_ff of Pyramid DNN is a typical random memory access case, which makes cache miss frequently. Before each memcpy, it uses a hash func to calculate next position for mem read, this position is not continuous, so each time L1 cache need refresh and access cache line to read next mem block, it costs time, and make memcpy perf bad.

The good thing is the hashed position is predictable, we can use XXH32() to predict next position in last memcpy, by using prefetch(), we can let system preload next mem into cache during current memcpy, it saves time and reduce cache miss rate.
   
test=develop