### PR TITLE
[MKL-DNN] Error throwing for NHWC layout for MKL-DNN ops

### DIFF
--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -154,9 +154,12 @@ framework::OpKernelType ConvOp::GetExpectedKernelType(
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
     PADDLE_ENFORCE_NE(data_format, "NHWC",
-                      "Conv MKLDNN does not support NHWC data format yet");
-    PADDLE_ENFORCE_NE(data_format, "NDHWC",
-                      "Conv MKLDNN does not support NDHWC data format yet");
+                      platform::errors::Unimplemented(
+                          "Conv MKLDNN does not support NHWC data format yet"));
+    PADDLE_ENFORCE_NE(
+        data_format, "NDHWC",
+        platform::errors::Unimplemented(
+            "Conv MKLDNN does not support NDHWC data format yet"));
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
     customized_type_value =
@@ -532,11 +535,14 @@ framework::OpKernelType ConvOpGrad::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format, "NHWC",
-                      "Conv MKLDNN grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        platform::errors::Unimplemented(
+            "Conv MKLDNN grad does not support NHWC data format yet"));
     PADDLE_ENFORCE_NE(
         data_format, "NDHWC",
-        "Conv MKLDNN Grad does not support NDHWC data format yet");
+        platform::errors::Unimplemented(
+            "Conv MKLDNN Grad does not support NDHWC data format yet"));
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
     customized_type_value = kConvMKLDNNFP32;

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -720,22 +720,6 @@ framework::OpKernelType ConvOpDoubleGrad::GetExpectedKernelType(
     library_ = framework::LibraryType::kCUDNN;
   }
 #endif
-#ifdef PADDLE_WITH_MKLDNN
-  if (library_ == framework::LibraryType::kPlain &&
-      platform::CanMKLDNNBeUsed(ctx)) {
-    // TODO(jczaja): Add support for NHWC and NDHWC
-    const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(
-        data_format, "NHWC",
-        "Conv MKLDNN Double Grad does not support NHWC data format yet");
-    PADDLE_ENFORCE_NE(
-        data_format, "NDHWC",
-        "Conv MKLDNN Double Grad does not support NDHWC data format yet");
-    library_ = framework::LibraryType::kMKLDNN;
-    layout_ = framework::DataLayout::kMKLDNN;
-    customized_type_value = kConvMKLDNNFP32;
-  }
-#endif
   auto type = framework::OpKernelType(
       OperatorWithKernel::IndicateVarDataType(ctx, "Input"), ctx.GetPlace(),
       layout_, library_, customized_type_value);

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -151,6 +151,12 @@ framework::OpKernelType ConvOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Conv MKLDNN does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(data_format, "NDHWC",
+                      "Conv MKLDNN does not support NDHWC data format yet");
     library = framework::LibraryType::kMKLDNN;
     layout = framework::DataLayout::kMKLDNN;
     customized_type_value =
@@ -524,6 +530,13 @@ framework::OpKernelType ConvOpGrad::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Conv MKLDNN grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NDHWC",
+        "Conv MKLDNN Grad does not support NDHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
     customized_type_value = kConvMKLDNNFP32;
@@ -710,6 +723,14 @@ framework::OpKernelType ConvOpDoubleGrad::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC and NDHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        "Conv MKLDNN Double Grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NDHWC",
+        "Conv MKLDNN Double Grad does not support NDHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
     customized_type_value = kConvMKLDNNFP32;

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -145,6 +145,11 @@ framework::OpKernelType ConvTransposeOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        "Conv Transpose MKLDNN does not support NHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/lrn_op.cc
+++ b/paddle/fluid/operators/lrn_op.cc
@@ -193,6 +193,10 @@ class LRNOp : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     if (library_ == framework::LibraryType::kPlain &&
         platform::CanMKLDNNBeUsed(ctx)) {
+      // TODO(jczaja): Add support for NHWC
+      const std::string data_format = ctx.Attr<std::string>("data_format");
+      PADDLE_ENFORCE_NE(data_format, "NHWC",
+                        "LRN MKLDNN does not support NHWC data format yet");
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }
@@ -311,6 +315,11 @@ class LRNOpGrad : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     if (library_ == framework::LibraryType::kPlain &&
         platform::CanMKLDNNBeUsed(ctx)) {
+      // TODO(jczaja): Add support for NHWC
+      const std::string data_format = ctx.Attr<std::string>("data_format");
+      PADDLE_ENFORCE_NE(
+          data_format, "NHWC",
+          "LRN MKLDNN grad does not support NHWC data format yet");
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }

--- a/paddle/fluid/operators/lrn_op.cc
+++ b/paddle/fluid/operators/lrn_op.cc
@@ -195,8 +195,10 @@ class LRNOp : public framework::OperatorWithKernel {
         platform::CanMKLDNNBeUsed(ctx)) {
       // TODO(jczaja): Add support for NHWC
       const std::string data_format = ctx.Attr<std::string>("data_format");
-      PADDLE_ENFORCE_NE(data_format, "NHWC",
-                        "LRN MKLDNN does not support NHWC data format yet");
+      PADDLE_ENFORCE_NE(
+          data_format, "NHWC",
+          platform::errors::Unimplemented(
+              "LRN MKLDNN does not support NHWC data format yet"));
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }
@@ -319,7 +321,8 @@ class LRNOpGrad : public framework::OperatorWithKernel {
       const std::string data_format = ctx.Attr<std::string>("data_format");
       PADDLE_ENFORCE_NE(
           data_format, "NHWC",
-          "LRN MKLDNN grad does not support NHWC data format yet");
+          platform::errors::Unimplemented(
+              "LRN MKLDNN grad does not support NHWC data format yet"));
       library_ = framework::LibraryType::kMKLDNN;
       layout_ = framework::DataLayout::kMKLDNN;
     }

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -148,8 +148,10 @@ framework::OpKernelType PoolOp::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format, "NHWC",
-                      "Pool MKLDNN grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        platform::errors::Unimplemented(
+            "Pool MKLDNN grad does not support NHWC data format yet"));
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }
@@ -183,8 +185,10 @@ framework::OpKernelType PoolOpGrad::GetExpectedKernelType(
       platform::CanMKLDNNBeUsed(ctx)) {
     // TODO(jczaja): Add support for NHWC
     const std::string data_format = ctx.Attr<std::string>("data_format");
-    PADDLE_ENFORCE_NE(data_format, "NHWC",
-                      "Pool MKLDNN grad does not support NHWC data format yet");
+    PADDLE_ENFORCE_NE(
+        data_format, "NHWC",
+        platform::errors::Unimplemented(
+            "Pool MKLDNN grad does not support NHWC data format yet"));
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -146,6 +146,10 @@ framework::OpKernelType PoolOp::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Pool MKLDNN grad does not support NHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }
@@ -177,6 +181,10 @@ framework::OpKernelType PoolOpGrad::GetExpectedKernelType(
 #ifdef PADDLE_WITH_MKLDNN
   if (library_ == framework::LibraryType::kPlain &&
       platform::CanMKLDNNBeUsed(ctx)) {
+    // TODO(jczaja): Add support for NHWC
+    const std::string data_format = ctx.Attr<std::string>("data_format");
+    PADDLE_ENFORCE_NE(data_format, "NHWC",
+                      "Pool MKLDNN grad does not support NHWC data format yet");
     library_ = framework::LibraryType::kMKLDNN;
     layout_ = framework::DataLayout::kMKLDNN;
   }

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -197,5 +197,21 @@ class TestConv2dOp_Valid_MKLDNN(TestConv2dOp_AsyPadding_MKLDNN):
         self.padding_algorithm = "VALID"
 
 
+# Designed to Fail
+# TODO(jczaja): Once mkl-dnn integration support NHWC input
+# then those tests should be changed to actual functional positive tests
+class TestConv2dOp_NHWC_MKLDNN(TestConv2dOp_v2):
+    def init_data_format(self):
+        self.data_format = "NHWC"
+
+    # GetExpectedKernelType should throw an exception on lack of support
+    # to NHWC inputs in con2d mkldnn kernel
+    def test_check_output(self):
+        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output)
+
+    def test_check_grad(self):
+        pass
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -197,24 +197,5 @@ class TestConv2dOp_Valid_MKLDNN(TestConv2dOp_AsyPadding_MKLDNN):
         self.padding_algorithm = "VALID"
 
 
-# Designed to Fail
-# TODO(jczaja): Once mkl-dnn integration support NHWC input
-# then those tests should be changed to actual functional positive tests
-class TestConv2dOp_NHWC_MKLDNN(TestConv2dOp_v2):
-    def init_kernel_type(self):
-        self.use_mkldnn = True
-
-    def init_data_format(self):
-        self.data_format = "NHWC"
-
-    # GetExpectedKernelType should throw an exception on lack of support
-    # to NHWC inputs in con2d mkldnn kernel
-    def test_check_output(self):
-        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output)
-
-    def test_check_grad(self):
-        pass
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -201,6 +201,9 @@ class TestConv2dOp_Valid_MKLDNN(TestConv2dOp_AsyPadding_MKLDNN):
 # TODO(jczaja): Once mkl-dnn integration support NHWC input
 # then those tests should be changed to actual functional positive tests
 class TestConv2dOp_NHWC_MKLDNN(TestConv2dOp_v2):
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
     def init_data_format(self):
         self.data_format = "NHWC"
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -53,6 +53,15 @@ class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
 
         self.assertRaises(AttributeError, check_raise_is_test)
 
+# Designed to Fail
+# TODO(jczaja): Once mkl-dnn integration support NHWC input
+# then those tests should be changed to actual functional positive tests
+class TestLRNMKLDNNOpNHWC(TestLRNMKLDNNOp):
+    def init_test_case(self):
+        self.data_format = 'NHWC'
+
+    def test_check_output(self):
+        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output);            
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -63,5 +63,9 @@ class TestLRNMKLDNNOpNHWC(TestLRNMKLDNNOp):
     def test_check_output(self):
         self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output);            
 
+    #TODO(jczaja): Enable once GRAD op is adjusted
+    def test_check_grad_normal(self):
+        pass
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -54,6 +54,7 @@ class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
 
         self.assertRaises(AttributeError, check_raise_is_test)
 
+
 # Designed to Fail
 # TODO(jczaja): Once mkl-dnn integration support NHWC input
 # then those tests should be changed to actual functional positive tests
@@ -62,11 +63,12 @@ class TestLRNMKLDNNOpNHWC(TestLRNMKLDNNOp):
         self.data_format = 'NHWC'
 
     def test_check_output(self):
-        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output);            
+        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output)
 
     #TODO(jczaja): Enable once GRAD op is adjusted
     def test_check_grad_normal(self):
         pass
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import unittest
 from paddle.fluid.tests.unittests.test_lrn_op import TestLRNOp
+import paddle.fluid as fluid
 
 
 class TestLRNMKLDNNOp(TestLRNOp):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_lrn_mkldnn_op.py
@@ -55,7 +55,6 @@ class TestLRNMKLDNNOpWithIsTest(TestLRNMKLDNNOp):
         self.assertRaises(AttributeError, check_raise_is_test)
 
 
-# Designed to Fail
 # TODO(jczaja): Once mkl-dnn integration support NHWC input
 # then those tests should be changed to actual functional positive tests
 class TestLRNMKLDNNOpNHWC(TestLRNMKLDNNOp):
@@ -63,11 +62,12 @@ class TestLRNMKLDNNOpNHWC(TestLRNMKLDNNOp):
         self.data_format = 'NHWC'
 
     def test_check_output(self):
-        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output)
-
-    #TODO(jczaja): Enable once GRAD op is adjusted
-    def test_check_grad_normal(self):
         pass
+
+    # Grad tests both FWD and BWD ops kernels creation
+    def test_check_grad_normal(self):
+        with self.assertRaises(fluid.core_avx.EnforceNotMet):
+            self.check_grad(['X'], 'Out', max_relative_error=0.01)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -140,6 +140,7 @@ class TestAsymPadValid(TestAsymPad):
         self.paddings = [0, 0, 0, 0]
         self.padding_algorithm = "VALID"
 
+
 # Designed to Fail
 # TODO(jczaja): Once mkl-dnn integration support NHWC input
 # then those tests should be changed to actual functional positive tests
@@ -153,7 +154,7 @@ class TestAsymPadValidNHWC(TestAsymPadValid):
     # GetExpectedKernelType should throw an exception on lack of support
     # to NHWC inputs in pool mkldnn kernel
     def test_check_output(self):
-        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output);            
+        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output)
 
     def test_check_grad(self):
         pass

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -141,5 +141,17 @@ class TestAsymPadValid(TestAsymPad):
         self.padding_algorithm = "VALID"
 
 
+class TestAsymPadValidNHWC(TestAsymPadValid):
+    def init_data_format(self):
+        self.data_format = "NHWC"
+
+    def init_shape(self):
+        self.shape = [2, 7, 7, 3]
+
+    #TODO(jczaja): Enable once GRAD op is adjusted
+    def test_check_grad(self):
+        pass
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -151,13 +151,15 @@ class TestAsymPadValidNHWC(TestAsymPadValid):
     def init_shape(self):
         self.shape = [2, 7, 7, 3]
 
+    def test_check_output(self):
+        pass
+
+    # Grad tests both FWD and BWD ops kernels creation
     # GetExpectedKernelType should throw an exception on lack of support
     # to NHWC inputs in pool mkldnn kernel
-    def test_check_output(self):
-        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output)
-
     def test_check_grad(self):
-        pass
+        with self.assertRaises(fluid.core_avx.EnforceNotMet):
+            super(TestAsymPadValidNHWC, self).test_check_grad()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -140,7 +140,9 @@ class TestAsymPadValid(TestAsymPad):
         self.paddings = [0, 0, 0, 0]
         self.padding_algorithm = "VALID"
 
-
+# Designed to Fail
+# TODO(jczaja): Once mkl-dnn integration support NHWC input
+# then those tests should be changed to actual functional positive tests
 class TestAsymPadValidNHWC(TestAsymPadValid):
     def init_data_format(self):
         self.data_format = "NHWC"
@@ -148,7 +150,11 @@ class TestAsymPadValidNHWC(TestAsymPadValid):
     def init_shape(self):
         self.shape = [2, 7, 7, 3]
 
-    #TODO(jczaja): Enable once GRAD op is adjusted
+    # GetExpectedKernelType should throw an exception on lack of support
+    # to NHWC inputs in pool mkldnn kernel
+    def test_check_output(self):
+        self.assertRaises(fluid.core_avx.EnforceNotMet, self.check_output);            
+
     def test_check_grad(self):
         pass
 


### PR DESCRIPTION
This is PR to throw an error when MKL-DNN kernels are to be used but with data_format="NHWC". 