### PR TITLE
[Bug fix] paddle-TRT set duplicate weight name into cpu

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -211,7 +211,8 @@ float *TensorRTEngine::GetWeightCPUData(const std::string &name,
                                         const std::vector<float> &scale) {
   static int name_suffix_counter = 0;
   std::string name_suffix = std::to_string(name_suffix_counter);
-  std::string name_with_suffix = name + name_suffix;
+  std::string splitter = "__";
+  std::string name_with_suffix = name + splitter + name_suffix;
   auto w_dims = weight_tensor->dims();
   platform::CPUPlace cpu_place;
   PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/inference/tensorrt/engine.h
+++ b/paddle/fluid/inference/tensorrt/engine.h
@@ -159,7 +159,8 @@ class TensorRTEngine {
                   std::unique_ptr<framework::Tensor> w_tensor) {
     static int suffix_counter = 0;
     std::string suffix = std::to_string(suffix_counter);
-    weight_map[w_name + suffix] = std::move(w_tensor);
+    std::string splitter = "__";
+    weight_map[w_name + splitter + suffix] = std::move(w_tensor);
     suffix_counter += 1;
   }
 


### PR DESCRIPTION
**Problem**: previously added suffix number is mixed with earlier suffix number added in ir passes, which may cause conflict in very rare situation.
e.g.: `conv_bn_fuse/eltwise_add_in/10129` is both the 9th `conv_bn_fuse/eltwise_add_in/1012` and the 29th `conv_bn_fuse/eltwise_add_in/101`
**Solution**: added splitter "__" between weight name and suffix number to avoid conflicts.