### PR TITLE
Fix PADDLE_ENFORCE ci check bug

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -136,13 +136,12 @@ if [ ${HAS_DEFINE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
     fi
 fi
 
-HAS_PADDLE_ENFORCE_FLAG=`git diff -U0 upstream/$BRANCH |grep "+" |grep -v "PADDLE_ENFORCE_" |grep -o -m 1 "PADDLE_ENFORCE" || true`
-if [ ${HAS_PADDLE_ENFORCE_FLAG} ] && [ "${GIT_PR_ID}" != "" ]; then
+ALL_PADDLE_ENFORCE=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
+if [ "${ALL_PADDLE_ENFORCE}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
     python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`
     echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
     if [ "${APPROVALS}" == "FALSE" ]; then
-        ALL_PADDLE_ENFORCE=`git diff -U0 upstream/develop |grep "+" |grep -zoE "PADDLE_ENFORCE\(.[^,\);]+.[^;]*\);\s" || true`
         failed_num=`expr $failed_num + 1`
         echo_line="PADDLE_ENFORCE is not recommended. Please use PADDLE_ENFORCE_EQ/NE/GT/GE/LT/LE or PADDLE_ENFORCE_NOT_NULL or PADDLE_ENFORCE_CUDA_SUCCESS instead.\nYou must have one RD (chenwhql (Recommend) , luotao1 (Recommend) or lanxianghit) approval for the usage (either add or delete) of PADDLE_ENFORCE.\n${ALL_PADDLE_ENFORCE}\n"
         echo_list=(${echo_list[@]}$failed_num "." "$echo_line")

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -151,7 +151,7 @@ fi
 
 ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
 VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
-INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`
+INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vxF "$VALID_PADDLE_CHECK" || true`
 if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     APPROVALS=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000 | \
     python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 6836917 47554610 22561442`


### PR DESCRIPTION
This PR fix two problems:

1. Error specification check error

When PADDLE_ENFORCE contains array index [], the `grep -vx "$VALID_PADDLE_CHECK"` will treat it as a regular expression metacharacter, resulting in a judgment error. 

So this PR add `-F` to fix this problem.

```
  -F, --fixed-strings       PATTERN is a set of newline-separated strings
```

error example:
https://github.com/PaddlePaddle/Paddle/pull/20972
- : All PADDLE_ENFORCE{_*} this PR added
```
/work/paddle {gaowei/padding-fcc} ALL_PADDLE_CHECK=`git diff -U0 upstream/develop |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
/work/paddle {gaowei/padding-fcc} echo "$ALL_PADDLE_CHECK"
PADDLE_ENFORCE_GT(batch_size, 0, platform::errors::InvalidArgument(
+                                       "Batch size is illegal.", batch_size));
PADDLE_ENFORCE_EQ(
+            bias_dims[1], w_dims1,
+            platform::errors::InvalidArgument(
+                "The shape of Bias is invalid."
+                "The width of Bias should be equal to width of Weight."
+                "But reveived width of Bias is %d and width of Weight is %d.",
+                bias_dims[1], w_dims1));
PADDLE_ENFORCE_EQ(
+            bias_dims[0], w_dims1,
+            platform::errors::InvalidArgument(
+                "The shape of Bias is invalid."
+                "The height of Bias should be equal to the width of weight."
+                "But reveived height of Bias is %d and width of Weight is %d.",
+                bias_dims[0], w_dims1));
PADDLE_ENFORCE_EQ(in_mat_dims[1], w_dims0,
+                    platform::errors::InvalidArgument(
+                        "Fully Connected input and weigth size do not match. "
+                        "input width: %d,weight height: %d",
+                        in_mat_dims[1], w_dims0));
PADDLE_ENFORCE_EQ(
+        weight_padding, false,
+        platform::errors::PermissionDenied(
+            "Weight padding in fc can not be used in GPU scope."));
```
- : Valid PADDLE_ENFORCE{_*} this PR added
```
/work/paddle {gaowei/padding-fcc} VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
/work/paddle {gaowei/padding-fcc} echo "$VALID_PADDLE_CHECK"
PADDLE_ENFORCE_GT(batch_size, 0, platform::errors::InvalidArgument(
+                                       "Batch size is illegal.", batch_size));
PADDLE_ENFORCE_EQ(
+            bias_dims[1], w_dims1,
+            platform::errors::InvalidArgument(
+                "The shape of Bias is invalid."
+                "The width of Bias should be equal to width of Weight."
+                "But reveived width of Bias is %d and width of Weight is %d.",
+                bias_dims[1], w_dims1));
PADDLE_ENFORCE_EQ(
+            bias_dims[0], w_dims1,
+            platform::errors::InvalidArgument(
+                "The shape of Bias is invalid."
+                "The height of Bias should be equal to the width of weight."
+                "But reveived height of Bias is %d and width of Weight is %d.",
+                bias_dims[0], w_dims1));
PADDLE_ENFORCE_EQ(in_mat_dims[1], w_dims0,
+                    platform::errors::InvalidArgument(
+                        "Fully Connected input and weigth size do not match. "
+                        "input width: %d,weight height: %d",
+                        in_mat_dims[1], w_dims0));
PADDLE_ENFORCE_EQ(
+        weight_padding, false,
+        platform::errors::PermissionDenied(
+            "Weight padding in fc can not be used in GPU scope."));
```
- : Invalid PADDLE_ENFORCE{_*} this PR added (here
 are error match)
```
/work/paddle {gaowei/padding-fcc} INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vx "$VALID_PADDLE_CHECK" || true`
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
/work/paddle {gaowei/padding-fcc} echo "$INVALID_PADDLE_CHECK"
+            bias_dims[1], w_dims1,
+                bias_dims[1], w_dims1));
+            bias_dims[0], w_dims1,
+                bias_dims[0], w_dims1));
PADDLE_ENFORCE_EQ(in_mat_dims[1], w_dims0,
+                        in_mat_dims[1], w_dims0));
```

2. PADDLE_ENFORCE using check match non-code content

![image](https://user-images.githubusercontent.com/22561442/69121121-788ce480-0ad6-11ea-8393-fcec39785432.png)

Replace with a more precise regular expression