### PR TITLE
Fix the CAPI ZeroCopy shape error and reuse the code to get output

### DIFF
--- a/paddle/fluid/inference/capi/c_api.h
+++ b/paddle/fluid/inference/capi/c_api.h
@@ -104,7 +104,7 @@ PADDLE_CAPI_EXPORT extern bool PD_PredictorRun(const PD_AnalysisConfig* config,
 
 PADDLE_CAPI_EXPORT extern bool PD_PredictorZeroCopyRun(
     const PD_AnalysisConfig* config, PD_ZeroCopyData* inputs, int in_size,
-    PD_ZeroCopyData** output, int** out_size);
+    PD_ZeroCopyData** output, int* out_size);
 
 // AnalysisConfig
 enum Precision { kFloat32 = 0, kInt8, kHalf };

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -70,7 +70,6 @@ struct PD_ZeroCopyFunctor {
     output_i->data = reinterpret_cast<void*>(malloc(out_num * sizeof(OutT)));
     memmove(static_cast<OutT*>(output_i->data), out_data.data(),
             out_num * sizeof(OutT));
-    LOG(INFO) << out_data[0];
   }
 };
 
@@ -153,7 +152,6 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
   auto output_names = predictor->GetOutputNames();
   int osize = output_names.size();
   *out_size = osize;
-  LOG(INFO) << "output size is: " << osize;
   *output = new PD_ZeroCopyData[osize];
   VLOG(3) << "The output size is " << osize;
   for (int i = 0; i < *out_size; ++i) {

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -68,8 +68,8 @@ struct PD_ZeroCopyFunctor {
     out_data.resize(out_num);
     output_t->copy_to_cpu(out_data.data());
     output_i->data = reinterpret_cast<void*>(malloc(out_num * sizeof(OutT)));
-    std::copy_n(out_data.data(), out_num * sizeof(OutT),
-                static_cast<OutT*>(output_i->data));
+    memmove(static_cast<OutT*>(output_i->data), out_data.data(),
+            out_num * sizeof(OutT));
     LOG(INFO) << out_data[0];
   }
 };

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -46,9 +46,7 @@ inline void VisitDataType(PD_DataType type, Visitor visitor) {
 
   _DataType_(VisitDataTypeCallback);
 #undef VisitDataTypeCallback
-  LOG(ERROR)
-      << "Unsupported data type. The Predictor will treat input as float. ";
-  visitor.template apply<float>();
+  PADDLE_THROW_ERROR("Unsupported data type. ");
 }
 
 struct PD_ZeroCopyFunctor {
@@ -103,7 +101,6 @@ bool PD_PredictorRun(const PD_AnalysisConfig* config, PD_Tensor* inputs,
     *out_size = osize;
     return true;
   }
-  VLOG(3) << "The predictor runs but failed. ";
   return false;
 }
 

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -14,17 +14,65 @@
 
 #include <algorithm>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <vector>
 #include "paddle/fluid/inference/capi/c_api.h"
 #include "paddle/fluid/inference/capi/c_api_internal.h"
 
+#define _ForEachDataTypeHelper_(callback, cpp_type, pd_type) \
+  callback(cpp_type, PD_DataType::pd_type);
+
+#define _ForEachDataType_(callback)                     \
+  _ForEachDataTypeHelper_(callback, float, PD_FLOAT32); \
+  _ForEachDataTypeHelper_(callback, int32_t, PD_INT32); \
+  _ForEachDataTypeHelper_(callback, int64_t, PD_INT64); \
+  _ForEachDataTypeHelper_(callback, uint8_t, PD_UINT8);
+
+template <typename Visitor>
+inline void VisitDataType(PD_DataType type, Visitor visitor) {
+#define VisitDataTypeCallback(cpp_type, pd_type) \
+  do {                                           \
+    if (type == pd_type) {                       \
+      visitor.template apply<cpp_type>();        \
+      return;                                    \
+    }                                            \
+  } while (0)
+
+  _ForEachDataType_(VisitDataTypeCallback);
+#undef VisitDataTypeCallback
+  PADDLE_THROW("Not supported %d", type);
+}
+
 using paddle::ConvertToPaddleDType;
 using paddle::ConvertToPDDataType;
 using paddle::ConvertToACPrecision;
 
-extern "C" {
+struct PD_ZeroCopyFunctor {
+  PD_ZeroCopyData* output_i;
+  paddle::ZeroCopyTensor* output_t;
 
+  PD_ZeroCopyFunctor(PD_ZeroCopyData* output_i_,
+                     paddle::ZeroCopyTensor* output_t_)
+      : output_i(output_i_), output_t(output_t_) {}
+
+  template <typename OutT>
+  void apply() {
+    std::vector<OutT> out_data;
+    int out_num =
+        std::accumulate(output_i->shape, output_i->shape + output_i->shape_size,
+                        1, std::multiplies<int>());
+    out_data.resize(out_num);
+    output_t->copy_to_cpu(out_data.data());
+    memmove(static_cast<OutT*>(output_i->data), out_data.data(),
+            out_num * sizeof(OutT));
+    // std::copy_n(out_data.data(), out_num * sizeof(OutT),
+    //             static_cast<OutT*>(output_i->data));
+    LOG(INFO) << out_data[0];
+  }
+};
+
+extern "C" {
 bool PD_PredictorRun(const PD_AnalysisConfig* config, PD_Tensor* inputs,
                      int in_size, PD_Tensor** output_data, int* out_size,
                      int batch_size) {
@@ -55,9 +103,15 @@ bool PD_PredictorRun(const PD_AnalysisConfig* config, PD_Tensor* inputs,
 
 bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
                              PD_ZeroCopyData* inputs, int in_size,
-                             PD_ZeroCopyData** output, int** out_size) {
+                             PD_ZeroCopyData** output, int* out_size) {
   PADDLE_ENFORCE_NOT_NULL(config);
-  auto predictor = paddle::CreatePaddlePredictor(config->config);
+  static std::map<std::string, std::unique_ptr<paddle::PaddlePredictor>>
+      predictors;
+  if (!predictors.count(config->config.model_dir())) {
+    predictors[config->config.model_dir()] =
+        paddle::CreatePaddlePredictor(config->config);
+  }
+  auto& predictor = predictors[config->config.model_dir()];
   auto input_names = predictor->GetInputNames();
   VLOG(3) << "The inputs' size is " << input_names.size();
   PADDLE_ENFORCE_EQ(
@@ -90,10 +144,11 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
   CHECK(predictor->ZeroCopyRun());
   auto output_names = predictor->GetOutputNames();
   int osize = output_names.size();
-  *out_size = &osize;
+  *out_size = osize;
+  LOG(INFO) << "output size is: " << osize;
   *output = new PD_ZeroCopyData[osize];
   VLOG(3) << "The output size is " << osize;
-  for (int i = 0; i < osize; ++i) {
+  for (int i = 0; i < *out_size; ++i) {
     auto& output_i = (*output)[i];
     output_i.name = new char[output_names[i].length() + 1];
     snprintf(output_i.name, output_names[i].length() + 1, "%s",
@@ -102,45 +157,12 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
     output_i.dtype = ConvertToPDDataType(output_t->type());
     std::vector<int> output_shape = output_t->shape();
     output_i.shape = new int[output_shape.size()];
-    output_i.shape = output_shape.data();
+    std::copy_n(output_shape.data(), output_shape.size() * sizeof(int),
+                output_i.shape);
+    // output_i.shape = output_shape.data();
     output_i.shape_size = output_shape.size();
-    switch (output_i.dtype) {
-      case PD_FLOAT32: {
-        std::vector<float> out_data;
-        int out_num = std::accumulate(output_shape.begin(), output_shape.end(),
-                                      1, std::multiplies<int>());
-        out_data.resize(out_num);
-        output_t->copy_to_cpu(out_data.data());
-        output_i.data = static_cast<void*>(out_data.data());
-      } break;
-      case PD_INT32: {
-        std::vector<int32_t> out_data;
-        int out_num = std::accumulate(output_shape.begin(), output_shape.end(),
-                                      1, std::multiplies<int>());
-        out_data.resize(out_num);
-        output_t->copy_to_cpu(out_data.data());
-        output_i.data = static_cast<void*>(out_data.data());
-      } break;
-      case PD_INT64: {
-        std::vector<int64_t> out_data;
-        int out_num = std::accumulate(output_shape.begin(), output_shape.end(),
-                                      1, std::multiplies<int>());
-        out_data.resize(out_num);
-        output_t->copy_to_cpu(out_data.data());
-        output_i.data = static_cast<void*>(out_data.data());
-      } break;
-      case PD_UINT8: {
-        std::vector<uint8_t> out_data;
-        int out_num = std::accumulate(output_shape.begin(), output_shape.end(),
-                                      1, std::multiplies<int>());
-        out_data.resize(out_num);
-        output_t->copy_to_cpu(out_data.data());
-        output_i.data = static_cast<void*>(out_data.data());
-      } break;
-      default:
-        CHECK(false) << "Unsupport data type.";
-        break;
-    }
+    VisitDataType(output_i.dtype,
+                  PD_ZeroCopyFunctor(&output_i, std::move(output_t.get())));
   }
   return true;
 }

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -154,22 +154,19 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
   int osize = output_names.size();
   *out_size = osize;
   LOG(INFO) << "output size is: " << osize;
-  *output = reinterpret_cast<PD_ZeroCopyData*>(
-      malloc(osize * sizeof(PD_ZeroCopyData)));
+  *output = new PD_ZeroCopyData[osize];
   VLOG(3) << "The output size is " << osize;
   for (int i = 0; i < *out_size; ++i) {
     auto& output_i = (*output)[i];
-    output_i.name = reinterpret_cast<char*>(
-        malloc((output_names[i].length() + 1) * sizeof(char)));
+    output_i.name = new char[output_names[i].length() + 1];
     snprintf(output_i.name, output_names[i].length() + 1, "%s",
              output_names[i].c_str());
     auto output_t = predictor->GetOutputTensor(output_names[i]);
     output_i.dtype = ConvertToPDDataType(output_t->type());
     std::vector<int> output_shape = output_t->shape();
-    output_i.shape =
-        reinterpret_cast<int*>(malloc(output_shape.size() * sizeof(int)));
-    std::copy_n(output_shape.data(), output_shape.size() * sizeof(int),
-                output_i.shape);
+    output_i.shape = new int[output_shape.size()];
+    memmove(output_i.shape, output_shape.data(),
+            output_shape.size() * sizeof(int));
     output_i.shape_size = output_shape.size();
     VisitDataType(output_i.dtype,
                   PD_ZeroCopyFunctor(&output_i, std::move(output_t.get())));

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -20,6 +20,11 @@
 #include "paddle/fluid/inference/capi/c_api.h"
 #include "paddle/fluid/inference/capi/c_api_internal.h"
 
+using paddle::ConvertToPaddleDType;
+using paddle::ConvertToPDDataType;
+using paddle::ConvertToACPrecision;
+
+namespace {
 #define _ForEachDataTypeHelper_(callback, cpp_type, pd_type) \
   callback(cpp_type, PD_DataType::pd_type);
 
@@ -44,10 +49,6 @@ inline void VisitDataType(PD_DataType type, Visitor visitor) {
   PADDLE_THROW("Not supported %d", type);
 }
 
-using paddle::ConvertToPaddleDType;
-using paddle::ConvertToPDDataType;
-using paddle::ConvertToACPrecision;
-
 struct PD_ZeroCopyFunctor {
   PD_ZeroCopyData* output_i;
   paddle::ZeroCopyTensor* output_t;
@@ -71,6 +72,8 @@ struct PD_ZeroCopyFunctor {
     LOG(INFO) << out_data[0];
   }
 };
+
+}  // namespace
 
 extern "C" {
 bool PD_PredictorRun(const PD_AnalysisConfig* config, PD_Tensor* inputs,

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -65,10 +65,9 @@ struct PD_ZeroCopyFunctor {
                         1, std::multiplies<int>());
     out_data.resize(out_num);
     output_t->copy_to_cpu(out_data.data());
-    memmove(static_cast<OutT*>(output_i->data), out_data.data(),
-            out_num * sizeof(OutT));
-    // std::copy_n(out_data.data(), out_num * sizeof(OutT),
-    //             static_cast<OutT*>(output_i->data));
+    output_i->data = reinterpret_cast<void*>(malloc(out_num * sizeof(OutT)));
+    std::copy_n(out_data.data(), out_num * sizeof(OutT),
+                static_cast<OutT*>(output_i->data));
     LOG(INFO) << out_data[0];
   }
 };
@@ -149,20 +148,22 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
   int osize = output_names.size();
   *out_size = osize;
   LOG(INFO) << "output size is: " << osize;
-  *output = new PD_ZeroCopyData[osize];
+  *output = reinterpret_cast<PD_ZeroCopyData*>(
+      malloc(osize * sizeof(PD_ZeroCopyData)));
   VLOG(3) << "The output size is " << osize;
   for (int i = 0; i < *out_size; ++i) {
     auto& output_i = (*output)[i];
-    output_i.name = new char[output_names[i].length() + 1];
+    output_i.name = reinterpret_cast<char*>(
+        malloc((output_names[i].length() + 1) * sizeof(char)));
     snprintf(output_i.name, output_names[i].length() + 1, "%s",
              output_names[i].c_str());
     auto output_t = predictor->GetOutputTensor(output_names[i]);
     output_i.dtype = ConvertToPDDataType(output_t->type());
     std::vector<int> output_shape = output_t->shape();
-    output_i.shape = new int[output_shape.size()];
+    output_i.shape =
+        reinterpret_cast<int*>(malloc(output_shape.size() * sizeof(int)));
     std::copy_n(output_shape.data(), output_shape.size() * sizeof(int),
                 output_i.shape);
-    // output_i.shape = output_shape.data();
     output_i.shape_size = output_shape.size();
     VisitDataType(output_i.dtype,
                   PD_ZeroCopyFunctor(&output_i, std::move(output_t.get())));

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -313,13 +313,9 @@ if(WITH_GPU AND TENSORRT_FOUND)
             ARGS --infer_model=${TRT_MODEL_QUANT_RESNET_DIR})
 endif()
 
-set(CAPI_MODEL_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/capi_tests_models")
-if (NOT EXISTS ${CAPI_MODEL_INSTALL_DIR})
-    inference_download_and_uncompress(${CAPI_MODEL_INSTALL_DIR} ${INFERENCE_URL}/tensorrt_test "trt_inference_test_models.tar.gz")
-endif()
 inference_analysis_test(test_analyzer_capi SRCS analyzer_capi_tester.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS} paddle_fluid_c
-            ARGS --infer_model=${CAPI_MODEL_INSTALL_DIR}/trt_inference_test_models)
+            ARGS --infer_model=${RESNET50_MODEL_DIR}/model)
 
 inference_analysis_test(test_analyzer_capi_pd_tensor SRCS analyzer_capi_pd_tensor_tester.cc
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS} paddle_fluid_c

--- a/paddle/fluid/inference/tests/api/analyzer_capi_int_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_int_tester.cc
@@ -50,9 +50,9 @@ void zero_copy_run() {
   int shape[4] = {batch_size, channels, height, width};
   int shape_size = 4;
   int in_size = 2;
-  int *out_size;
+  int out_size;
   PD_ZeroCopyData *inputs = new PD_ZeroCopyData[2];
-  PD_ZeroCopyData *outputs = new PD_ZeroCopyData;
+  PD_ZeroCopyData *outputs = nullptr;
   inputs[0].data = static_cast<void *>(input);
   std::string nm = typeid(T).name();
   if ("f" == nm) {
@@ -94,8 +94,19 @@ void zero_copy_run() {
 
   PD_PredictorZeroCopyRun(config, inputs, in_size, &outputs, &out_size);
 
+  LOG(INFO) << "output size is: " << out_size;
   LOG(INFO) << outputs[0].name;
-  LOG(INFO) << outputs[0].shape_size;
+  for (int j = 0; j < out_size; ++j) {
+    LOG(INFO) << "output[" << j
+              << "]'s shape_size is: " << outputs[j].shape_size;
+    for (int i = 0; i < outputs[0].shape_size; ++i) {
+      LOG(INFO) << "output[" << j << "]'s shape is: " << outputs[j].shape[i];
+    }
+    LOG(INFO) << "output[" << j
+              << "]'s DATA is: " << *(static_cast<float *>(outputs[j].data));
+  }
+  delete[] outputs;
+  delete[] inputs;
 }
 
 TEST(PD_ZeroCopyRun, zero_copy_run) {

--- a/paddle/fluid/inference/tests/api/analyzer_capi_int_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_int_tester.cc
@@ -18,7 +18,6 @@ limitations under the License. */
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <typeinfo>
 #include <vector>
 #include "paddle/fluid/inference/capi/c_api.h"
 #include "paddle/fluid/inference/tests/api/tester_helper.h"
@@ -27,7 +26,6 @@ namespace paddle {
 namespace inference {
 namespace analysis {
 
-template <typename T>
 void zero_copy_run() {
   std::string model_dir = FLAGS_infer_model;
   PD_AnalysisConfig *config = PD_NewAnalysisConfig();
@@ -46,7 +44,7 @@ void zero_copy_run() {
   const int channels = 3;
   const int height = 224;
   const int width = 224;
-  T input[batch_size * channels * height * width] = {0};
+  float input[batch_size * channels * height * width] = {0};
   int shape[4] = {batch_size, channels, height, width};
   int shape_size = 4;
   int in_size = 2;
@@ -54,18 +52,7 @@ void zero_copy_run() {
   PD_ZeroCopyData *inputs = new PD_ZeroCopyData[2];
   PD_ZeroCopyData *outputs = nullptr;
   inputs[0].data = static_cast<void *>(input);
-  std::string nm = typeid(T).name();
-  if ("f" == nm) {
-    inputs[0].dtype = PD_FLOAT32;
-  } else if ("i" == nm) {
-    inputs[0].dtype = PD_INT32;
-  } else if ("x" == nm) {
-    inputs[0].dtype = PD_INT64;
-  } else if ("h" == nm) {
-    inputs[0].dtype = PD_UINT8;
-  } else {
-    CHECK(false) << "Unsupport dtype. ";
-  }
+  inputs[0].dtype = PD_FLOAT32;
   inputs[0].name = new char[6];
   inputs[0].name[0] = 'i';
   inputs[0].name[1] = 'm';
@@ -109,11 +96,9 @@ void zero_copy_run() {
   delete[] inputs;
 }
 
-TEST(PD_ZeroCopyRun, zero_copy_run) {
-  // zero_copy_run<int32_t>();
-  // zero_copy_run<int64_t>();
-  zero_copy_run<float>();
-}
+#ifdef PADDLE_WITH_MKLDNN
+TEST(PD_ZeroCopyRun, zero_copy_run) { zero_copy_run(); }
+#endif
 
 }  // namespace analysis
 }  // namespace inference

--- a/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
@@ -51,7 +51,7 @@ void zero_copy_run() {
   int shape[4] = {batch_size, channels, height, width};
   int shape_size = 4;
   int in_size = 1;
-  int *out_size;
+  int out_size;
   PD_ZeroCopyData *inputs = new PD_ZeroCopyData;
   PD_ZeroCopyData *outputs = new PD_ZeroCopyData;
   inputs->data = static_cast<void *>(input);
@@ -75,6 +75,9 @@ void zero_copy_run() {
   inputs->shape_size = shape_size;
 
   PD_PredictorZeroCopyRun(config, inputs, in_size, &outputs, &out_size);
+
+  delete[] inputs;
+  delete[] outputs;
 }
 
 TEST(PD_ZeroCopyRun, zero_copy_run) { zero_copy_run<float>(); }

--- a/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
@@ -18,7 +18,6 @@ limitations under the License. */
 #include <fstream>
 #include <iostream>
 #include <string>
-#include <typeinfo>
 #include <vector>
 #include "paddle/fluid/inference/capi/c_api.h"
 #include "paddle/fluid/inference/tests/api/tester_helper.h"
@@ -27,16 +26,17 @@ namespace paddle {
 namespace inference {
 namespace analysis {
 
-template <typename T>
 void zero_copy_run() {
-  std::string model_dir = FLAGS_infer_model + "/mobilenet";
+  std::string model_dir = FLAGS_infer_model;
+  std::string prog_file = model_dir + "/model";
+  std::string params_file = model_dir + "/params";
   PD_AnalysisConfig *config = PD_NewAnalysisConfig();
   PD_DisableGpu(config);
   PD_SetCpuMathLibraryNumThreads(config, 10);
   PD_SwitchUseFeedFetchOps(config, false);
   PD_SwitchSpecifyInputNames(config, true);
   PD_SwitchIrDebug(config, true);
-  PD_SetModel(config, model_dir.c_str());  //, params_file1.c_str());
+  PD_SetModel(config, prog_file.c_str(), params_file.c_str());
   bool use_feed_fetch = PD_UseFeedFetchOpsEnabled(config);
   CHECK(!use_feed_fetch) << "NO";
   bool specify_input_names = PD_SpecifyInputName(config);
@@ -44,9 +44,9 @@ void zero_copy_run() {
 
   const int batch_size = 1;
   const int channels = 3;
-  const int height = 224;
-  const int width = 224;
-  T input[batch_size * channels * height * width] = {0};
+  const int height = 318;
+  const int width = 318;
+  float input[batch_size * channels * height * width] = {0};
 
   int shape[4] = {batch_size, channels, height, width};
   int shape_size = 4;
@@ -55,21 +55,13 @@ void zero_copy_run() {
   PD_ZeroCopyData *inputs = new PD_ZeroCopyData;
   PD_ZeroCopyData *outputs = new PD_ZeroCopyData;
   inputs->data = static_cast<void *>(input);
-  std::string nm = typeid(T).name();
-  if ("f" == nm) {
-    inputs->dtype = PD_FLOAT32;
-  } else if ("i" == nm) {
-    inputs->dtype = PD_INT32;
-  } else if ("x" == nm) {
-    inputs->dtype = PD_INT64;
-  } else if ("h" == nm) {
-    inputs->dtype = PD_UINT8;
-  } else {
-    CHECK(false) << "Unsupport dtype. ";
-  }
-  inputs->name = new char[2];
-  inputs->name[0] = 'x';
-  inputs->name[1] = '\0';
+  inputs->dtype = PD_FLOAT32;
+  inputs->name = new char[5];
+  inputs->name[0] = 'd';
+  inputs->name[1] = 'a';
+  inputs->name[2] = 't';
+  inputs->name[3] = 'a';
+  inputs->name[4] = '\0';
   LOG(INFO) << inputs->name;
   inputs->shape = shape;
   inputs->shape_size = shape_size;
@@ -80,11 +72,13 @@ void zero_copy_run() {
   delete[] outputs;
 }
 
-TEST(PD_ZeroCopyRun, zero_copy_run) { zero_copy_run<float>(); }
+TEST(PD_ZeroCopyRun, zero_copy_run) { zero_copy_run(); }
 
 #ifdef PADDLE_WITH_MKLDNN
 TEST(PD_AnalysisConfig, profile_mkldnn) {
-  std::string model_dir = FLAGS_infer_model + "/mobilenet";
+  std::string model_dir = FLAGS_infer_model;
+  std::string prog_file = model_dir + "/model";
+  std::string params_file = model_dir + "/params";
   PD_AnalysisConfig *config = PD_NewAnalysisConfig();
   PD_DisableGpu(config);
   PD_SetCpuMathLibraryNumThreads(config, 10);
@@ -98,7 +92,7 @@ TEST(PD_AnalysisConfig, profile_mkldnn) {
   bool quantizer_enable = PD_MkldnnQuantizerEnabled(config);
   CHECK(quantizer_enable) << "NO";
   PD_SetMkldnnCacheCapacity(config, 0);
-  PD_SetModel(config, model_dir.c_str());
+  PD_SetModel(config, prog_file.c_str(), params_file.c_str());
   PD_EnableAnakinEngine(config);
   bool anakin_enable = PD_AnakinEngineEnabled(config);
   LOG(INFO) << anakin_enable;

--- a/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
@@ -62,7 +62,6 @@ void zero_copy_run() {
   inputs->name[2] = 't';
   inputs->name[3] = 'a';
   inputs->name[4] = '\0';
-  LOG(INFO) << inputs->name;
   inputs->shape = shape;
   inputs->shape_size = shape_size;
 


### PR DESCRIPTION
Fix the CAPI ZeroCopy shape error and reconstruct the method to get output.

* Before this fix, the shape data return to the user is wrong number and the shape size is wrong, too. Now, it not just assigns the value to shape, but use memmove to actually state a memory for shape. And problem solved.

* Reconstruct the method to obtain the predictor's output to simplify the code and make it can be reused by different output type and increase the file's unit tests coverages.

* Fix the unit tests' template to float. Since the output of typeid(T).name() is different from Linux and Windows, the unit tests may not be suitable for both platform.