### PR TITLE
fix backward bug for dygraph, test=develop

### DIFF
--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -53,6 +53,7 @@ static void ClearNoNeedBufferInputs(OpBase* op) {
           new_var->MutableVar()->GetMutable<framework::LoDTensor>();
       auto& old_tensor = var.Get<framework::LoDTensor>();
       new_tensor->Resize(old_tensor.dims());
+      new_tensor->set_lod(old_tensor.lod());
       each_var.reset(new_var);
     }
   }


### PR DESCRIPTION
fix backward bug for dygraph.
ClearNoNeedBufferInputs function lose the lod infomation of the input.