### PR TITLE
fix mkldnn include. test=develop

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -286,7 +286,7 @@ headers = (
     list(find_files('*', '${GLOG_INSTALL_DIR}/include')) + # glog
     list(find_files('*', '${BOOST_INCLUDE_DIR}/boost')) + # boost
     list(find_files('*', '${XXHASH_INSTALL_DIR}/include')) + # xxhash
-    list(find_files('mkldnn.h', '${MKLDNN_INSTALL_DIR}/include')) + # mkldnn
+    list(find_files('*', '${MKLDNN_INSTALL_DIR}/include')) + # mkldnn
     list(find_files('*', '${PROTOBUF_INCLUDE_DIR}')) + # protobuf
     list(find_files('*', '${DLPACK_INCLUDE_DIR}')) + # dlpack 
     list(find_files('*.h', '${THREADPOOL_INCLUDE_DIR}'))) # threadpool

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -286,10 +286,12 @@ headers = (
     list(find_files('*', '${GLOG_INSTALL_DIR}/include')) + # glog
     list(find_files('*', '${BOOST_INCLUDE_DIR}/boost')) + # boost
     list(find_files('*', '${XXHASH_INSTALL_DIR}/include')) + # xxhash
-    list(find_files('*', '${MKLDNN_INSTALL_DIR}/include')) + # mkldnn
     list(find_files('*', '${PROTOBUF_INCLUDE_DIR}')) + # protobuf
     list(find_files('*', '${DLPACK_INCLUDE_DIR}')) + # dlpack 
     list(find_files('*.h', '${THREADPOOL_INCLUDE_DIR}'))) # threadpool
+
+if '${WITH_MKLDNN}' == 'ON':
+    headers += list(find_files('*', '${MKLDNN_INSTALL_DIR}/include')) # mkldnn
 
 
 class InstallCommand(InstallCommandBase):


### PR DESCRIPTION
**fix compile error when enable PADDLE_WITH_MKLDNN**
use `*` instead of `mkldnn.h` to match all mkldnn head files