### PR TITLE
add input type and input data type check for Print_op test=develop

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -27,7 +27,7 @@ import numpy
 import warnings
 import six
 from functools import reduce, partial
-from ..data_feeder import check_type_and_dtype
+from ..data_feeder import convert_dtype, check_type_and_dtype
 
 __all__ = [
     'While', 'Switch', 'increment', 'array_write', 'create_array', 'less_than',

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -27,7 +27,7 @@ import numpy
 import warnings
 import six
 from functools import reduce, partial
-from ..data_feeder import convert_dtype
+from ..data_feeder import check_type_and_dtype
 
 __all__ = [
     'While', 'Switch', 'increment', 'array_write', 'create_array', 'less_than',
@@ -253,16 +253,10 @@ def Print(input,
                data: 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, 
                
     '''
-    if not isinstance(input, Variable):
-        raise TypeError(
-            "The type of 'input' in Print must be Variable, but received %s" %
-            (type(input)))
-    if convert_dtype(input.dtype) not in [
-            'float32', 'float64', 'int32_t', 'int64_t', 'bool'
-    ]:
-        raise TypeError(
-            "The data type of 'input' in Print must be float32 or float64 or int32_t or int64_t or bool, but received %s."
-            % (convert_dtype(input.dtype)))
+    check_type_and_dtype(input, 'input', Variable,
+                         ['float32', 'float64', 'int32_t', 'int64_t', 'bool'],
+                         'fluid.layers.Print')
+
     helper = LayerHelper('print' + "_" + input.name, **locals())
     output = helper.create_variable_for_type_inference(input.dtype)
     helper.append_op(

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -253,6 +253,16 @@ def Print(input,
                data: 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, 
                
     '''
+    if not isinstance(input, Variable):
+        raise TypeError(
+            "The type of 'input' in Print must be Variable, but received %s" %
+            (type(input)))
+    if convert_dtype(input.dtype) not in [
+            'float32', 'float64', 'int32_t', 'int64_t', 'bool'
+    ]:
+        raise TypeError(
+            "The data type of 'input' in Print must be float32 or float64 or int32_t or int64_t or bool, but received %s."
+            % (convert_dtype(input.dtype)))
     helper = LayerHelper('print' + "_" + input.name, **locals())
     output = helper.create_variable_for_type_inference(input.dtype)
     helper.append_op(

--- a/python/paddle/fluid/tests/unittests/test_print_op.py
+++ b/python/paddle/fluid/tests/unittests/test_print_op.py
@@ -25,6 +25,7 @@ from paddle.fluid.framework import Program
 import numpy as np
 from simple_nets import simple_fc_net, init_data
 from paddle.fluid import compiler, Program, program_guard
+from op_test import OpTest
 
 
 class TestPrintOpCPU(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_print_op.py
+++ b/python/paddle/fluid/tests/unittests/test_print_op.py
@@ -24,6 +24,7 @@ from paddle.fluid.framework import switch_main_program
 from paddle.fluid.framework import Program
 import numpy as np
 from simple_nets import simple_fc_net, init_data
+from paddle.fluid import compiler, Program, program_guard
 
 
 class TestPrintOpCPU(unittest.TestCase):
@@ -78,6 +79,18 @@ class TestPrintOpCPU(unittest.TestCase):
         outs = exe.run(feed={'x': self.x_tensor},
                        fetch_list=[loss],
                        return_numpy=False)
+
+
+class TestPrintOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of Print_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.Print, x1)
+            # The input dtype of Print_op must be float32, float64, int32_t, int64_t or bool.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="float16")
+            self.assertRaises(TypeError, fluid.layers.Print, x2)
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),


### PR DESCRIPTION
为Print python api的输入input加类型检查：
- 检查类型是否为Variable
- 检查数据类型是否为float32, float64, int32_t, int64_t, bool
- 在单测中覆盖类型错误和数据类型错误两个异常情况
- 可手动运行示例，看下错误：
```
import paddle.fluid as fluid
import numpy as np
x1 = fluid.create_lod_tensor(np.array([[-1]]), [[1]], fluid.CPUPlace())
fluid.layers.Print(x1)
```
> TypeError: The type of 'input' in fluid.layers.Print must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>.

```
import paddle.fluid as fluid
x2 = fluid.layers.data(name='x2', shape=[4], dtype="float16")
fluid.layers.Print(x2)
```
> TypeError: The data type of 'input' in fluid.layers.Print must be ['float32', 'float64', 'int32_t', 'int64_t', 'bool'], but received float16.
