### PR TITLE
Fix the bug of scatter_nd/scatter_nd_add

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7510,7 +7510,7 @@ def scatter_nd_add(ref, index, updates, name=None):
         raise ValueError("ref and updates must have same data type.")
 
     helper = LayerHelper('scatter_nd_add', **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='ref')
     if name is None:
         output = helper.create_variable_for_type_inference(dtype)
     else:


### PR DESCRIPTION
It can't obtain the exact `dtype`, so it should add `input_param_name` to resolve the bug.
the issue link: https://github.com/PaddlePaddle/Paddle/issues/21251