### PR TITLE
Control flow API: while_loop

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -915,7 +915,7 @@ class While(object):
 
 def while_loop(cond, body, loop_vars, name=None):
     """
-    while_loop is one of the control flow. Repeats while_loop `body` until `cond` returns False.
+    while_loop is one of the control flows. Repeats while_loop `body` until `cond` returns False.
 
     Args:
         cond(Callable): A callable returning a boolean tensor controlling whether to continue looping.
@@ -948,14 +948,13 @@ def while_loop(cond, body, loop_vars, name=None):
             main_program = fluid.default_main_program()
             startup_program = fluid.default_startup_program()
 
-            with program_guard(main_program, startup_program):
+            with fluid.program_guard(main_program, startup_program):
                 i = layers.fill_constant(shape=[1], dtype='int64', value=0)
                 ten = layers.fill_constant(shape=[1], dtype="int64", value=10)
                 out = layers.while_loop(cond, body, [i])
+                
                 exe = fluid.Executor(fluid.CPUPlace())
-                exe.run(fluid.default_startup_program)
-
-                res = exe.run(fluid.default_mian_program, feed={}, fetch_list=out)
+                res = exe.run(main_program, feed={}, fetch_list=out)
                 print(res) #[array([10])]
     """
     helper = LayerHelper('while_loop', **locals())

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -919,11 +919,17 @@ def while_loop(cond, body, loop_vars, name=None):
 
     Args:
         cond(Callable): A callable returning a boolean tensor controlling whether to continue looping.
-        body(Callable): A callable returning a tuple, namedtuple or list of tensors of the same arity(length and
-            structure) and types as `loops_vars`.
-        loop_vars(list|tuple): A list, namedtuple or tuple of tensors that is passed to both `cond` and `body`.
+        body(Callable): A callable returning a tuple or list of tensors of the same arity(length and structure)
+	    and types as `loops_vars`.
+        loop_vars(list|tuple): A list or tuple of tensors that is passed to both `cond` and `body`.
         name(str, optional): Normally there is no need for users to set this property. For more information, please
             refer to :ref:`api_guide_Name`. Default is None.
+    
+    Returns:
+        A list or tuple of tensors which returned by `body`.
+    
+    Returen type:
+        list or tuple.
 
     Raises:
         TypeError: If the type of `cond` is not callable.

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -920,24 +920,25 @@ def while_loop(cond, body, loop_vars, name=None):
     Args:
         cond(Callable): A callable returning a boolean tensor controlling whether to continue looping.
         body(Callable): A callable returning a tuple or list of tensors of the same arity(length and structure)
-	    and types as `loops_vars`.
-        loop_vars(list|tuple): A list or tuple of tensors that is passed to both `cond` and `body`.
+	    and types as ``loops_vars``.
+        loop_vars(list|tuple): A list or tuple of tensors that is passed to both ``cond`` and ``body``.
         name(str, optional): Normally there is no need for users to set this property. For more information, please
             refer to :ref:`api_guide_Name`. Default is None.
     
     Returns:
-        A list or tuple of tensors which returned by `body`.
+        A list or tuple of tensors which returned by ``body``.
     
     Returen type:
-        list or tuple.
+        list(Variable)|tuple(Variable).
 
     Raises:
-        TypeError: If the type of `cond` is not callable.
-        TypeError: If the type of `body` is not callable.
-        TypeError: If the type of `loop_vars` is not list or tuple.
-        TypeError: If the type of `cond` returns is not Variable.
-        TypeError: If the type of `cond` returns is not a boolean variable.
-        TypeError: If the shape of `cond` returns is not equals 1.
+        TypeError: If the type of ``cond`` is not callable.
+        TypeError: If the type of ``body`` is not callable.
+        TypeError: If the type of ``loop_vars`` is not list or tuple.
+        TypeError: If the type of ``cond`` returns is not Variable.
+        TypeError: If the type of ``cond`` returns is not a boolean variable.
+        TypeError: If the shape of ``cond`` returns is not equals 1.
+        ValueError: If the ``var_loops`` is empty.
 
     Examples:
         .. code-block:: python
@@ -955,13 +956,13 @@ def while_loop(cond, body, loop_vars, name=None):
             startup_program = fluid.default_startup_program()
 
             with fluid.program_guard(main_program, startup_program):
-                i = layers.fill_constant(shape=[1], dtype='int64', value=0)
-                ten = layers.fill_constant(shape=[1], dtype="int64", value=10)
+                i = layers.fill_constant(shape=[1], dtype='int64', value=0)     # loop counter
+                ten = layers.fill_constant(shape=[1], dtype='int64', value=10)  # loop length
                 out = layers.while_loop(cond, body, [i])
                 
                 exe = fluid.Executor(fluid.CPUPlace())
                 res = exe.run(main_program, feed={}, fetch_list=out)
-                print(res) #[array([10])]
+                print(res) # [array([10])]
     """
     helper = LayerHelper('while_loop', **locals())
 
@@ -971,6 +972,8 @@ def while_loop(cond, body, loop_vars, name=None):
         raise TypeError("body in while_loop should be callable")
     if not isinstance(loop_vars, (list, tuple)):
         raise TypeError("loop_vars in while_loop should be a list or tuple")
+    if len(loop_vars) == 0:
+        raise ValueError("loop_vars in while_loop should not be empty")
 
     pre_cond = cond(*loop_vars)
     if not isinstance(pre_cond, Variable):

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -915,28 +915,28 @@ class While(object):
 
 def while_loop(cond, body, loop_vars, name=None):
     """
-    while_loop control flow. Repeats while_loop `body` until `cond` return False.
+    while_loop is one of the control flow. Repeats while_loop `body` until `cond` returns False.
 
     Args:
         cond(Callable): A callable returning a boolean tensor controlling whether to continue looping.
-	body(Callable): A callable returning a tuple, namedtuple or list of tensors of the same arity(length and
+        body(Callable): A callable returning a tuple, namedtuple or list of tensors of the same arity(length and
             structure) and types as `loops_vars`.
-	loop_vars(list|tuple): A list, namedtuple or tuple of tensors that is passed to both `cond` and `body`.
-	name(str, optional): Normally there is no need for users to set this property. For more information, please
+        loop_vars(list|tuple): A list, namedtuple or tuple of tensors that is passed to both `cond` and `body`.
+        name(str, optional): Normally there is no need for users to set this property. For more information, please
             refer to :ref:`api_guide_Name`. Default is None.
 
     Raises:
         TypeError: If the type of `cond` is not callable.
-	TypeError: If the type of `body` is not callable.
-	TypeError: If the type of `loop_vars` is not list or tuple.
-	TypeError: If the type of `cond` returns is not Variable.
-	TypeError: If the type of `cond` returns is not a boolean variable.
-	TypeError: If the shape of `cond` returns is not equals 1.
+        TypeError: If the type of `body` is not callable.
+        TypeError: If the type of `loop_vars` is not list or tuple.
+        TypeError: If the type of `cond` returns is not Variable.
+        TypeError: If the type of `cond` returns is not a boolean variable.
+        TypeError: If the shape of `cond` returns is not equals 1.
 
     Examples:
         .. code-block:: python
 
-	    import paddle.fluid as fluid
+            import paddle.fluid as fluid
             import paddle.fluid.layers as layers
 
             def cond(i):
@@ -948,7 +948,7 @@ def while_loop(cond, body, loop_vars, name=None):
             main_program = fluid.default_main_program()
             startup_program = fluid.default_startup_program()
 
-	    with program_guard(main_program, startup_program):
+            with program_guard(main_program, startup_program):
                 i = layers.fill_constant(shape=[1], dtype='int64', value=0)
                 ten = layers.fill_constant(shape=[1], dtype="int64", value=10)
                 out = layers.while_loop(cond, body, [i])

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -961,11 +961,11 @@ def while_loop(cond, body, loop_vars, name=None):
     helper = LayerHelper('while_loop', **locals())
 
     if not callable(cond):
-        raise TypeError("cond should be callable")
+        raise TypeError("cond in while_loop should be callable")
     if not callable(body):
-        raise TypeError("body should be callable")
+        raise TypeError("body in while_loop should be callable")
     if not isinstance(loop_vars, (list, tuple)):
-        raise TypeError("loop_vars should be a list or tuple")
+        raise TypeError("loop_vars in while_loop should be a list or tuple")
 
     pre_cond = cond(*loop_vars)
     if not isinstance(pre_cond, Variable):

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -966,9 +966,13 @@ def while_loop(cond, body, loop_vars, name=None):
     while_loop_block = While(pre_cond)
     with while_loop_block.block():
         output_vars = body(*loop_vars)
-        for i in range(len(output_vars)):
-            assign(output_vars[i], loop_vars[i])
-        now_cond = cond(*output_vars)
+        if len(loop_vars) == 1:
+            assign(output_vars, loop_vars[0])
+            now_cond = cond(output_vars)
+        else:
+            for i in range(len(output_vars)):
+                assign(output_vars[i], loop_vars[i])
+            now_cond = cond(*output_vars)
         assign(now_cond, pre_cond)
 
     return loop_vars
@@ -1381,7 +1385,7 @@ def greater_than(x, y, cond=None):
 
           import paddle.fluid as fluid
           import numpy as np
-          label = fluid.layers.ssign(np.array([2, 3], dtype='int32'))
+          label = fluid.layers.assign(np.array([2, 3], dtype='int32'))
           limit = fluid.layers.assign(np.array([3, 2], dtype='int32'))
           out = fluid.layers.greater_than(x=label, y=limit) #out=[False, True]
           out1 = label > limit #out1=[False, True]

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -919,14 +919,14 @@ def while_loop(cond, body, loop_vars, name=None):
 
     Args:
         cond(Callable): A callable returning a boolean tensor controlling whether to continue looping.
-        body(Callable): A callable returning a tuple or list of tensors of the same arity(length and structure)
-	    and types as ``loops_vars``.
-        loop_vars(list|tuple): A list or tuple of tensors that is passed to both ``cond`` and ``body``.
+        body(Callable): A callable returning a tuple or list of tensors of the same arity (length and structure)
+            and types as ``loops_vars`` .
+        loop_vars(list|tuple): A list or tuple of tensors that is passed to both ``cond`` and ``body`` .
         name(str, optional): Normally there is no need for users to set this property. For more information, please
             refer to :ref:`api_guide_Name`. Default is None.
     
     Returns:
-        A list or tuple of tensors which returned by ``body``.
+        A list or tuple of tensors which returned by ``body`` .
     
     Returen type:
         list(Variable)|tuple(Variable).

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import print_function
+
+import numpy as np
+import unittest
+
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+import paddle.fluid.layers as layers
+import paddle.fluid.framework as framework
+from paddle.fluid.executor import Executor
+from paddle.fluid.framework import Program, program_guard
+
+
+class TestWhileLoop(unittest.TestCase):
+    def test_simple_net(self):
+        def cond(i):
+            return layers.less_than(i, ten)
+
+        def body(i):
+            return [layers.increment(i)]
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            i = layers.fill_constant(shape=[1], dtype='int64', value=0)
+            ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
+            out = layers.while_loop(cond, body, [i])
+
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        res = exe.run(main_program, fetch_list=out)
+        self.assertTrue(
+            np.allclose(np.asarray(res[0]), np.full((1), 10, np.int64)))
+
+    def test_simple_net2(self):
+        def cond1(i, j, init, sums):
+            return layers.less_than(i, loop_len1)
+
+        def body1(i, j, init, sums):
+            def cond2(j, init, sums):
+                return layers.less_than(j, loop_len2)
+
+            def body2(j, init, sums):
+                init = layers.elementwise_add(x=init, y=ones)
+                sums = layers.elementwise_add(x=init, y=sums)
+                j = layers.increment(j)
+                return [j, init, sums]
+
+            result = layers.while_loop(cond2, body2, [j, init, sums])
+            j = result[0]
+            init = result[1]
+            sums = result[2]
+            sums = layers.elementwise_add(x=init, y=sums)
+            i = layers.increment(i)
+            return [i, j, init, sums]
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            i = layers.zeros(shape=[1], dtype='int64')
+            j = layers.zeros(shape=[1], dtype='int64')
+            init = layers.data(name="init", shape=[3, 3], dtype='float32')
+            sums = layers.data(name="sums", shape=[3, 3], dtype='float32')
+            loop_len1 = layers.fill_constant(shape=[1], dtype='int64', value=2)
+            loop_len2 = layers.fill_constant(shape=[1], dtype='int64', value=3)
+            ones = layers.fill_constant(shape=[3, 3], dtype='float32', value=1)
+
+            res = layers.while_loop(cond1, body1, [i, j, init, sums])
+            #layers.Print(res[0])
+            #layers.Print(res[1])
+            #layers.Print(res[2])
+            #layers.Print(res[3])
+            data1 = np.random.rand(3, 3).astype('float32')
+            data2 = np.zeros([3, 3]).astype('float32')
+
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        ret = exe.run(main_program,
+                      feed={'init': data1,
+                            'sums': data2},
+                      fetch_list=res)
+        for i in range(3):
+            data1 = np.add(data1, 1)
+            data2 = np.add(data1, data2)
+        for j in range(2):
+            data2 = np.add(data1, data2)
+        self.assertTrue(np.allclose(np.asarray(ret[3]), data2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -175,6 +175,12 @@ class TestApiWhileLoop_Error(unittest.TestCase):
 
             self.assertRaises(TypeError, type_error_loop_vars)
 
+            # The value of `loop_vars` is empty
+            def value_error_loop_vars():
+                out = layers.while_loop(cond_returns_bool_tensor, body, [])
+
+            self.assertRaises(ValueError, value_error_loop_vars)
+
             # The type of `cond` returns in Op(while_loop) must be Variable
             def type_error_cond_returns_not_variable():
                 out = layers.while_loop(cond_returns_constant, body, [data_1d])

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -24,7 +24,7 @@ from paddle.fluid.executor import Executor
 from paddle.fluid.framework import Program, program_guard
 
 
-class TestAPIWhileLoop(unittest.TestCase):
+class TestApiWhileLoop(unittest.TestCase):
     def test_var_tuple(self):
         def cond(i):
             return layers.less_than(i, ten)
@@ -154,35 +154,41 @@ class TestAPIWhileLoop_Error(unittest.TestCase):
             ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
             ten_1 = layers.fill_constant(shape=[2, 2], dtype='int64', value=10)
 
-            def dtype_error_cond():
+            # The type of `cond` in Op(while_loop) must be callable 
+            def type_error_cond():
                 out = layers.while_loop(data1, body, [data2])
 
-            self.assertRaises(TypeError, dtype_error_cond)
+            self.assertRaises(TypeError, type_error_cond)
 
-            def dtype_error_body():
+            # The type of `body` in Op(while_loop) must be callable
+            def type_error_body():
                 out = layers.while_loop(cond3, data1, [data2])
 
-            self.assertRaises(TypeError, dtype_error_body)
+            self.assertRaises(TypeError, type_error_body)
 
-            def dtype_error_loop_vars():
+            # The type of `loop_vars` in Op(while_loop) must be list or tuple
+            def type_error_loop_vars():
                 out = layers.while_loop(cond3, body, data1)
 
-            self.assertRaises(TypeError, dtype_error_loop_vars)
+            self.assertRaises(TypeError, type_error_loop_vars)
 
-            def dtype_error_cond_return_1():
+            # The type of `cond` returns in Op(while_loop) must be Variable
+            def type_error_cond_returns_not_variable():
                 out = layers.while_loop(cond1, body, [data1])
 
-            self.assertRaises(TypeError, dtype_error_cond_return_1)
+            self.assertRaises(TypeError, type_error_cond_returns_not_variable)
 
-            def dtype_error_cond_return_2():
+            # The type of `cond` returns in Op(while_loop) must be a bollean variable
+            def type_error_cond_returns_not_boolean():
                 out = layers.while_loop(cond2, body, [data1])
 
-            self.assertRaises(TypeError, dtype_error_cond_return_2)
+            self.assertRaises(TypeError, type_error_cond_returns_not_boolean)
 
-            def dtype_error_cond_return_3():
+            # The shape of `cond` returns in Op(while_loop) must be 1
+            def type_error_shape_cond_returns_pair_1():
                 out = layers.while_loop(cond4, body, [data3])
 
-            self.assertRaises(TypeError, dtype_error_cond_return_3)
+            self.assertRaises(TypeError, type_error_shape_cond_returns_pair_1)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -24,20 +24,21 @@ from paddle.fluid.executor import Executor
 from paddle.fluid.framework import Program, program_guard
 
 
-class TestWhileLoop(unittest.TestCase):
-    def test_simple_net(self):
+class TestAPIWhileLoop(unittest.TestCase):
+    def test_var_tuple(self):
         def cond(i):
             return layers.less_than(i, ten)
 
         def body(i):
-            return layers.increment(i)
+            return layers.elementwise_add(x=i, y=one)
 
         main_program = Program()
         startup_program = Program()
         with program_guard(main_program, startup_program):
             i = layers.fill_constant(shape=[1], dtype='int64', value=0)
+            one = layers.fill_constant(shape=[1], dtype='int64', value=1)
             ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
-            out = layers.while_loop(cond, body, [i])
+            out = layers.while_loop(cond, body, (i, ))
 
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)
@@ -45,6 +46,36 @@ class TestWhileLoop(unittest.TestCase):
         self.assertTrue(
             np.allclose(np.asarray(res[0]), np.full((1), 10, np.int64)))
 
+    def test_var_list(self):
+        def cond(i, a):
+            return layers.less_than(i, ten)
+
+        def body(i, a):
+            a = layers.elementwise_add(x=a, y=one)
+            i = layers.increment(i)
+            return [i, a]
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            i = layers.zeros(shape=[1], dtype='int64')
+            ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
+            a = layers.data(name="a", shape=[10], dtype='float32')
+            one = layers.fill_constant(shape=[10], dtype='float32', value=1)
+            out = layers.while_loop(cond, body, [i, a])
+
+            data1 = np.random.rand(10).astype('float32')
+            data2 = np.ones(10).astype('float32')
+
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        res = exe.run(main_program, feed={'a': data1}, fetch_list=out)
+        for i in range(10):
+            data1 = np.add(data1, data2)
+        self.assertTrue(np.allclose(np.asarray(res[1]), data1))
+
+
+class TestAPIWhileLoop_Nested(unittest.TestCase):
     def test_simple_net2(self):
         def cond1(i, j, init, sums):
             return layers.less_than(i, loop_len1)
@@ -79,10 +110,7 @@ class TestWhileLoop(unittest.TestCase):
             ones = layers.fill_constant(shape=[3, 3], dtype='float32', value=1)
 
             res = layers.while_loop(cond1, body1, [i, j, init, sums])
-            #layers.Print(res[0])
-            #layers.Print(res[1])
-            #layers.Print(res[2])
-            #layers.Print(res[3])
+
             data1 = np.random.rand(3, 3).astype('float32')
             data2 = np.zeros([3, 3]).astype('float32')
 
@@ -98,6 +126,63 @@ class TestWhileLoop(unittest.TestCase):
         for j in range(2):
             data2 = np.add(data1, data2)
         self.assertTrue(np.allclose(np.asarray(ret[3]), data2))
+
+
+class TestAPIWhileLoop_Error(unittest.TestCase):
+    def test_error(self):
+        def cond1(i):
+            return 1
+
+        def cond2(i):
+            return layers.increment(i)
+
+        def cond3(i):
+            return layers.less_than(i, ten)
+
+        def cond4(i):
+            return layers.less_than(i, ten_1)
+
+        def body(i):
+            return layers.increment(i)
+
+        main_program = Program()
+        startup_program = Program()
+        with program_guard(main_program, startup_program):
+            data1 = layers.fill_constant(shape=[1], dtype='int64', value=1)
+            data2 = layers.fill_constant(shape=[1], dtype='int64', value=1)
+            data3 = layers.fill_constant(shape=[2, 2], dtype='int64', value=1)
+            ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
+            ten_1 = layers.fill_constant(shape=[2, 2], dtype='int64', value=10)
+
+            def dtype_error_cond():
+                out = layers.while_loop(data1, body, [data2])
+
+            self.assertRaises(TypeError, dtype_error_cond)
+
+            def dtype_error_body():
+                out = layers.while_loop(cond3, data1, [data2])
+
+            self.assertRaises(TypeError, dtype_error_body)
+
+            def dtype_error_loop_vars():
+                out = layers.while_loop(cond3, body, data1)
+
+            self.assertRaises(TypeError, dtype_error_loop_vars)
+
+            def dtype_error_cond_return_1():
+                out = layers.while_loop(cond1, body, [data1])
+
+            self.assertRaises(TypeError, dtype_error_cond_return_1)
+
+            def dtype_error_cond_return_2():
+                out = layers.while_loop(cond2, body, [data1])
+
+            self.assertRaises(TypeError, dtype_error_cond_return_2)
+
+            def dtype_error_cond_return_3():
+                out = layers.while_loop(cond4, body, [data3])
+
+            self.assertRaises(TypeError, dtype_error_cond_return_3)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -30,7 +30,7 @@ class TestWhileLoop(unittest.TestCase):
             return layers.less_than(i, ten)
 
         def body(i):
-            return [layers.increment(i)]
+            return layers.increment(i)
 
         main_program = Program()
         startup_program = Program()

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -75,7 +75,7 @@ class TestApiWhileLoop(unittest.TestCase):
         self.assertTrue(np.allclose(np.asarray(res[1]), data1))
 
 
-class TestAPIWhileLoop_Nested(unittest.TestCase):
+class TestApiWhileLoop_Nested(unittest.TestCase):
     def test_simple_net2(self):
         def cond1(i, j, init, sums):
             return layers.less_than(i, loop_len1)
@@ -128,7 +128,7 @@ class TestAPIWhileLoop_Nested(unittest.TestCase):
         self.assertTrue(np.allclose(np.asarray(ret[3]), data2))
 
 
-class TestAPIWhileLoop_Error(unittest.TestCase):
+class TestApiWhileLoop_Error(unittest.TestCase):
     def test_error(self):
         def cond1(i):
             return 1


### PR DESCRIPTION
* ### Add a control flow API : `while_loop`
```
 while_loop(cond, body, loop_vars, name=None)
```
This API's function is similar to `while`, the difference is the way of use. `while_loop` API passed function `cond` and `body` to the function, it's can realize the function without `with`keyword.

* ### API document
![172 18 25 94_8088_documentation_docs_en_api_layers_while_loop html](https://user-images.githubusercontent.com/52460041/70118605-6187ee00-16a3-11ea-8cc0-1aed74f2c9ca.png)

