### PR TITLE
Fix dgc accuracy by mv regularization to local

### DIFF
--- a/paddle/fluid/operators/dgc_op.cc
+++ b/paddle/fluid/operators/dgc_op.cc
@@ -29,6 +29,8 @@ class DGCOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE(ctx->HasInput("V"), "Input(V) of DGCop should not be null.");
     PADDLE_ENFORCE(ctx->HasInput("Grad"),
                    "Input(Grad) of DGCop should not be null.");
+    PADDLE_ENFORCE(ctx->HasInput("Param"),
+                   "Input(Param) of DGCop should not be null.");
     PADDLE_ENFORCE(ctx->HasInput("current_step"),
                    "Input(current_step) of DGCop should not be null.");
     PADDLE_ENFORCE_EQ(ctx->HasInput("nranks"), true,
@@ -66,6 +68,7 @@ class DGCOpMaker : public framework::OpProtoAndCheckerMaker {
     AddInput("U", "(Tensor) U velocity tensor of DGC");
     AddInput("V", "(Tensor) V velocity tensor of DGC");
     AddInput("Grad", "(Tensor) Input gradient");
+    AddInput("Param", "(Tensor) Input parameter");
     AddInput("current_step", "(Tensor) Current step.");
     AddInput("nranks", "(Tensor) nranks.");
 
@@ -98,6 +101,16 @@ class DGCOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<float>("rampup_step",
                    "(float, 0.0)"
                    "The period when begin k_select.");
+
+    AddAttr<float>("regular_coeff",
+                   "(float, 0.0)"
+                   "The coeff of regularization.")
+        .SetDefault(0.0);
+
+    AddAttr<int>("regular_type",
+                 "(int, 0)"
+                 "The type of regularization, {0:None, 1:L1Decay, 2:L2Decay")
+        .SetDefault(0);
 
     AddComment(R"DOC(
     Original paper is https://arxiv.org/abs/1712.01887

--- a/paddle/fluid/operators/dgc_op.cc
+++ b/paddle/fluid/operators/dgc_op.cc
@@ -29,8 +29,9 @@ class DGCOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE(ctx->HasInput("V"), "Input(V) of DGCop should not be null.");
     PADDLE_ENFORCE(ctx->HasInput("Grad"),
                    "Input(Grad) of DGCop should not be null.");
-    PADDLE_ENFORCE(ctx->HasInput("Param"),
-                   "Input(Param) of DGCop should not be null.");
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput("Param"), true,
+        platform::errors::NotFound("Input(Param) of DGCop is not found."));
     PADDLE_ENFORCE(ctx->HasInput("current_step"),
                    "Input(current_step) of DGCop should not be null.");
     PADDLE_ENFORCE_EQ(ctx->HasInput("nranks"), true,
@@ -104,7 +105,7 @@ class DGCOpMaker : public framework::OpProtoAndCheckerMaker {
 
     AddAttr<float>("regular_coeff",
                    "(float, 0.0)"
-                   "The coeff of regularization.")
+                   "The coeff of regularization, weight decay parameter")
         .SetDefault(0.0);
 
     AddAttr<int>("regular_type",

--- a/paddle/fluid/operators/dgc_op.h
+++ b/paddle/fluid/operators/dgc_op.h
@@ -75,6 +75,10 @@ class DGCOpKernel : public framework::OpKernel<T> {
     // need to /nranks, can prevent precision loss. For coeff often equal
     // with 1e-4, if nranks=32, coeff/nranks will be 3.125e-6, the numerical
     // accuracy of coeff/nranks will be too low.
+    PADDLE_ENFORCE_EQ(regular_type >= 0 && regular_type <= 2, true,
+                      platform::errors::InvalidArgument(
+                          "DGC only support one of None|L1Decay|L2Decay "
+                          "Regularization for now."));
     if (regular_type == 0) {
       grad_out_e.device(eigen_ctx) = (1.0 * nranks) * g_e;
     } else if (regular_type == 1) {
@@ -84,9 +88,6 @@ class DGCOpKernel : public framework::OpKernel<T> {
     } else if (regular_type == 2) {
       // L2Decay. grad = grad + coeff * param
       grad_out_e.device(eigen_ctx) = (1.0 * nranks) * g_e + regular_coeff * p_e;
-    } else {
-      PADDLE_ENFORCE_EQ(regular_type >= 0 && regular_type <= 2, true,
-                        "Regularization must be one of None|L1Decay|L2Decay");
     }
 
     // current step

--- a/paddle/fluid/operators/dgc_op.h
+++ b/paddle/fluid/operators/dgc_op.h
@@ -43,6 +43,8 @@ class DGCOpKernel : public framework::OpKernel<T> {
     auto v = ctx.Input<framework::Tensor>("V");
     auto g = ctx.Input<framework::Tensor>("Grad");
 
+    auto grad_out = ctx.Output<framework::Tensor>("Grad_out");
+
     // attrs
     float m = ctx.Attr<float>("m");
     bool use_nesterov = ctx.Attr<bool>("use_nesterov");
@@ -54,6 +56,38 @@ class DGCOpKernel : public framework::OpKernel<T> {
     auto nranks_tensor = ctx.Input<framework::Tensor>("nranks");
     const int nranks = static_cast<const int>(*nranks_tensor->data<float>());
     PADDLE_ENFORCE_GT(nranks, 1, "DGC is not useful when num_trainers <= 1");
+
+    // regularization
+    auto p = ctx.Input<framework::Tensor>("Param");
+    float regular_coeff = ctx.Attr<float>("regular_coeff");
+    int regular_type = ctx.Attr<int>("regular_type");
+
+    auto p_e = framework::EigenVector<T>::Flatten(*p);
+    auto g_e = framework::EigenVector<T>::Flatten(*g);
+    auto grad_out_e = framework::EigenVector<T>::Flatten(*grad_out);
+
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
+    auto& eigen_ctx = *dev_ctx.eigen_device();
+
+    // NOTE. In paddle, loss has divided by nranks. Because dgc_op is before
+    // allreduce, so local regular_coeff need div nranks too. But now we
+    // multi grad with nranks in dgc_op, in that case regular_coeff don't
+    // need to /nranks, can prevent precision loss. For coeff often equal
+    // with 1e-4, if nranks=32, coeff/nranks will be 3.125e-6, the numerical
+    // accuracy of coeff/nranks will be too low.
+    if (regular_type == 0) {
+      grad_out_e.device(eigen_ctx) = (1.0 * nranks) * g_e;
+    } else if (regular_type == 1) {
+      // L1Decay. grad = grad + coeff * sign(param)
+      grad_out_e.device(eigen_ctx) =
+          (1.0 * nranks) * g_e + regular_coeff * p_e.sign();
+    } else if (regular_type == 2) {
+      // L2Decay. grad = grad + coeff * param
+      grad_out_e.device(eigen_ctx) = (1.0 * nranks) * g_e + regular_coeff * p_e;
+    } else {
+      PADDLE_ENFORCE_EQ(regular_type >= 0 && regular_type <= 2, true,
+                        "Regularization must be one of None|L1Decay|L2Decay");
+    }
 
     // current step
     auto current_step_tensor = ctx.Input<framework::Tensor>("current_step");
@@ -91,19 +125,17 @@ class DGCOpKernel : public framework::OpKernel<T> {
     // FIXME(gongwb): use cublas.
     auto u_out_e = framework::EigenVector<T>::Flatten(*u_out);
     auto u_e = framework::EigenVector<T>::Flatten(*u);
-    auto g_e = framework::EigenVector<T>::Flatten(*g);
-    auto& dev_ctx = ctx.template device_context<DeviceContext>();
-    auto& eigen_ctx = *dev_ctx.eigen_device();
 
-    if (static_cast<int>(*current_step) ==
-        static_cast<int>(rampup_begin_step)) {
-      // calc local momentum from global momentum
-      u_out_e.device(eigen_ctx) = (1.0 / nranks) * u_e;
-    }
+    // calc local momentum from global momentum
+    // NOTE. If grad not multi nranks, need add below code.
+    // if (static_cast<int>(*current_step) ==
+    //     static_cast<int>(rampup_begin_step)) {
+    //   u_out_e.device(eigen_ctx) = (1.0 / nranks) * u_e;
+    // }
 
     if (use_nesterov) {
       // u = m * (u + g)
-      u_out_e.device(eigen_ctx) = m * (u_e + g_e);
+      u_out_e.device(eigen_ctx) = m * (u_e + grad_out_e);
 
       // v = u + v + g
       ElementwiseComputeEx<AddFunctor<T>, DeviceContext, T>(
@@ -113,7 +145,7 @@ class DGCOpKernel : public framework::OpKernel<T> {
           ctx, g, v, 0, AddFunctor<T>(), v_out);
     } else {
       // u = m * u + g
-      u_out_e.device(eigen_ctx) = m * u_e + g_e;
+      u_out_e.device(eigen_ctx) = m * u_e + grad_out_e;
 
       // v = u + v
       ElementwiseComputeEx<AddFunctor<T>, DeviceContext, T>(
@@ -138,7 +170,6 @@ class DGCOpKernel : public framework::OpKernel<T> {
       LOG(FATAL) << "v_out numel:" << v_out->numel();
     }
 
-    auto grad_out = ctx.Output<framework::Tensor>("Grad_out");
     math::SetConstant<DeviceContext, T> tset;
     tset(dev_ctx, grad_out, static_cast<T>(0));
   }

--- a/paddle/fluid/operators/optimizers/dgc_momentum_op.cc
+++ b/paddle/fluid/operators/optimizers/dgc_momentum_op.cc
@@ -27,13 +27,18 @@ class DGCMomentumOp : public MomentumOp {
   void InferShape(framework::InferShapeContext* ctx) const override {
     PADDLE_ENFORCE_EQ(ctx->HasInput("current_step"), true,
                       "current_step should be set.");
+    PADDLE_ENFORCE_EQ(ctx->HasInput("nranks"), true,
+                      "Input(nranks) should be set.");
+
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Grad_out"), true,
+                      "Output(Grad_out) should be set.");
     return MomentumOp::InferShape(ctx);
   }
 
   framework::OpKernelType GetKernelTypeForVar(
       const std::string& var_name, const framework::Tensor& tensor,
       const framework::OpKernelType& expected_kernel_type) const override {
-    if (var_name == "current_step") {
+    if (var_name == "current_step" || var_name == "nranks") {
       VLOG(10) << "var_name:" << var_name << " need not to transform";
       return expected_kernel_type;
     }
@@ -47,6 +52,10 @@ class DGCMomentumOpMaker : public MomentumOpMaker {
  public:
   void Make() override {
     AddInput("current_step", "(Tensor) Current step.");
+    AddInput("nranks", "(Tensor) nranks.");
+
+    AddOutput("Grad_out", "(Tensor) Output grad gradient");
+
     AddAttr<float>("rampup_begin_step",
                    "(float, -1.0)"
                    "The period when begin DGC.")

--- a/paddle/fluid/operators/optimizers/dgc_momentum_op.cc
+++ b/paddle/fluid/operators/optimizers/dgc_momentum_op.cc
@@ -28,10 +28,12 @@ class DGCMomentumOp : public MomentumOp {
     PADDLE_ENFORCE_EQ(ctx->HasInput("current_step"), true,
                       "current_step should be set.");
     PADDLE_ENFORCE_EQ(ctx->HasInput("nranks"), true,
-                      "Input(nranks) should be set.");
+                      platform::errors::NotFound(
+                          "Input(nranks) of DGCMomentumOp is not found."));
 
     PADDLE_ENFORCE_EQ(ctx->HasOutput("Grad_out"), true,
-                      "Output(Grad_out) should be set.");
+                      platform::errors::NotFound(
+                          "Output(Grad_out) of DGCMomentumOp is not found."));
     return MomentumOp::InferShape(ctx);
   }
 
@@ -52,7 +54,7 @@ class DGCMomentumOpMaker : public MomentumOpMaker {
  public:
   void Make() override {
     AddInput("current_step", "(Tensor) Current step.");
-    AddInput("nranks", "(Tensor) nranks.");
+    AddInput("nranks", "(Tensor) The number of trainers.");
 
     AddOutput("Grad_out", "(Tensor) Output grad gradient");
 

--- a/paddle/fluid/operators/optimizers/dgc_momentum_op.h
+++ b/paddle/fluid/operators/optimizers/dgc_momentum_op.h
@@ -41,7 +41,11 @@ class DGCMomentumKernel : public framework::OpKernel<T> {
     // nranks
     auto nranks_tensor = context.Input<framework::Tensor>("nranks");
     const int nranks = static_cast<const int>(*nranks_tensor->data<float>());
-    PADDLE_ENFORCE_GT(nranks, 1, "DGC is not useful when num_trainers <= 1");
+    PADDLE_ENFORCE_GT(
+        nranks, 1,
+        platform::errors::InvalidArgument(
+            "DGC is not useful when num_trainers <= 1, but now nranks=%d",
+            nranks));
 
     const framework::Tensor* g = context.Input<framework::Tensor>("Grad");
     framework::Tensor* g_out = context.Output<framework::Tensor>("Grad_out");

--- a/paddle/fluid/operators/optimizers/dgc_momentum_op.h
+++ b/paddle/fluid/operators/optimizers/dgc_momentum_op.h
@@ -38,6 +38,22 @@ class DGCMomentumKernel : public framework::OpKernel<T> {
     auto current_step_tensor = context.Input<framework::Tensor>("current_step");
     auto* current_step = current_step_tensor->data<T>();
 
+    // nranks
+    auto nranks_tensor = context.Input<framework::Tensor>("nranks");
+    const int nranks = static_cast<const int>(*nranks_tensor->data<float>());
+    PADDLE_ENFORCE_GT(nranks, 1, "DGC is not useful when num_trainers <= 1");
+
+    const framework::Tensor* g = context.Input<framework::Tensor>("Grad");
+    framework::Tensor* g_out = context.Output<framework::Tensor>("Grad_out");
+    auto g_e = framework::EigenVector<T>::Flatten(*g);
+    auto g_out_e = framework::EigenVector<T>::Flatten(*g_out);
+
+    auto& dev_ctx = context.template device_context<DeviceContext>();
+    auto& eigen_ctx = *dev_ctx.eigen_device();
+
+    // NOTE. In dgc_op we multi grad with nranks, so we need /nranks here.
+    g_out_e.device(eigen_ctx) = (1.0 / nranks) * g_e;
+
     VLOG(10) << "current_step:" << *current_step
              << ", rampup_begin_step:" << rampup_begin_step;
 

--- a/python/paddle/fluid/tests/unittests/test_dgc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dgc_op.py
@@ -44,6 +44,9 @@ class TestDGCOp(unittest.TestCase):
         self.grad_name = "Grad"
         self.grad = np.random.random(size).astype("float32")
 
+        self.param_name = "Param"
+        self.param = np.random.random(size).astype("float32")
+
         self.current_step_name = "current_step"
         self.current_step = np.full((1), 0.0).astype("float32")
 
@@ -65,6 +68,9 @@ class TestDGCOp(unittest.TestCase):
 
         self.grad_tensor = self.scope.var(self.grad_name).get_tensor()
         self.grad_tensor.set(self.grad, place)
+
+        self.param_tensor = self.scope.var(self.param_name).get_tensor()
+        self.param_tensor.set(self.param, place)
 
         self.current_step_tensor = self.scope.var(
             self.current_step_name).get_tensor()
@@ -96,6 +102,7 @@ class TestDGCOp(unittest.TestCase):
             'U': self.u_name,
             'V': self.v_name,
             'Grad': self.grad_name,
+            'Param': self.param_name,
             'current_step': self.current_step_name,
             'nranks': self.nranks_name,
 
@@ -113,6 +120,8 @@ class TestDGCOp(unittest.TestCase):
             'use_nesterov': True,
             'rampup_begin_step': float(0.0),
             'rampup_step': float(10.0),
+            'regular_coeff': float(1e-4),
+            'regular_type': int(2),
         }
 
         dgc_op = Operator('dgc', **kwargs)


### PR DESCRIPTION
1. Regularization is part of loss, but its derivative equation is certain. So paddle add weight decay to grad before optimizer after allreduce. Because weight decay is part of grad, so we need to move it to the local before local grad accumulates. Otherwise, the model is very likely overfitting, harm test convergence. In resnet50 imagnet dataset, DGC loss 2% test accuracy before we apply this change because of overfitting.

2. In paddle, loss has divided by nranks. Because dgc_op is before allreduce, so local regular_coeff need div nranks too. But now we multi grad with nranks in dgc_op, in that case, regular_coeff don't need to /nranks, can prevent precision loss. For coeff often equal with 1e-4, if nranks=32, coeff/nranks will be 3.125e-6, the numerical accuracy of coeff/nranks will be too low. In resnet50 imagenet dataset, DGC loss 0.6% test accuracy before we multi grad with nranks because of precision loss.

After the above repair, DGC accuracy fully matches the baseline in resnet50 imagenet dataset.