### PR TITLE
cuda kernel refine for mod in elementwise_op

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -41,7 +41,7 @@ constexpr int ELEMWISE_MAX_BLOCK_DIM = 1024;
   do {                                         \
     const auto dividend_copy = dividend;       \
     *div = dividend_copy / divisor;            \
-    *mod = dividend_copy % divisor;            \
+    *mod = dividend_copy - divisor * (*div);   \
   } while (0)
 
 namespace paddle {


### PR DESCRIPTION
in cuda kernel, mod operation is cost time longer, so wo use minus and multiple to replace this operation