### PR TITLE
fix bug for test_elementwise_mul_op in dygraph, test=develop

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
@@ -190,6 +190,7 @@ class TestElementwiseMulOp_commonuse_1(ElementwiseMulOp):
             'Y': np.random.rand(1, 1, 4).astype(np.float64)
         }
         self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.init_kernel_type()
 
 
 class TestElementwiseMulOp_commonuse_2(ElementwiseMulOp):
@@ -200,6 +201,7 @@ class TestElementwiseMulOp_commonuse_2(ElementwiseMulOp):
             'Y': np.random.rand(2, 1, 4, 1).astype(np.float64)
         }
         self.outputs = {'Out': self.inputs['X'] * self.inputs['Y']}
+        self.init_kernel_type()
 
 
 class TestElementwiseMulOp_xsize_lessthan_ysize(ElementwiseMulOp):
@@ -215,6 +217,7 @@ class TestElementwiseMulOp_xsize_lessthan_ysize(ElementwiseMulOp):
         self.outputs = {
             'Out': self.inputs['X'].reshape(1, 1, 4, 5) * self.inputs['Y']
         }
+        self.init_kernel_type()
 
 
 class TestElementwiseMulOpError(OpTest):


### PR DESCRIPTION
fix bug for test_elementwise_mul_op.py
修复test_elementwise_mul_op单测在动态图下出现的问题，原因在于动态图不支持mkldnn类型的单测，需要通过self.use_mkldnn字段来判断是否需要跑动态图单测。但新增的TestElementwiseMulOp_commonuse_1、TestElementwiseMulOp_commonuse_2、TestElementwiseMulOp_xsize_lessthan_ysize没有设置该字段，导致判断出错。

CI日志：
![image](https://user-images.githubusercontent.com/16509038/69326289-7d909600-0c86-11ea-97b1-14fa6ff3afb1.png)
![image](https://user-images.githubusercontent.com/16509038/69326320-897c5800-0c86-11ea-9cb6-a472e7916d03.png)
![image](https://user-images.githubusercontent.com/16509038/69326343-9305c000-0c86-11ea-9861-62baa5f8a17e.png)

log链接：
http://ci.paddlepaddle.org/viewLog.html?buildId=225453&buildTypeId=PaddleMac_MacPrCi
http://ci.paddlepaddle.org/viewLog.html?buildId=225489&buildTypeId=PR_CI_Test_2
http://ci.paddlepaddle.org/viewLog.html?buildId=225418&buildTypeId=Paddle_PrCiPython35