### PR TITLE
Avoid the string as the key of map to improve the jit performance

### DIFF
--- a/paddle/fluid/operators/jit/helper.cc
+++ b/paddle/fluid/operators/jit/helper.cc
@@ -22,8 +22,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-std::unordered_map<std::string, std::shared_ptr<void>>& GetFuncCacheMap() {
-  static thread_local std::unordered_map<std::string, std::shared_ptr<void>>
+std::unordered_map<size_t, std::shared_ptr<void>>& GetFuncCacheMap() {
+  static thread_local std::unordered_map<size_t, std::shared_ptr<void>>
       g_func_cache_map;
   return g_func_cache_map;
 }

--- a/paddle/fluid/operators/jit/helper.cc
+++ b/paddle/fluid/operators/jit/helper.cc
@@ -22,9 +22,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-std::unordered_map<size_t, std::shared_ptr<void>>& GetFuncCacheMap() {
-  static thread_local std::unordered_map<size_t, std::shared_ptr<void>>
-      g_func_cache_map;
+std::map<size_t, std::shared_ptr<void>>& GetFuncCacheMap() {
+  static thread_local std::map<size_t, std::shared_ptr<void>> g_func_cache_map;
   return g_func_cache_map;
 }
 

--- a/paddle/fluid/operators/jit/helper.h
+++ b/paddle/fluid/operators/jit/helper.h
@@ -176,8 +176,7 @@ typename KernelTuple::func_type GetDefaultBestFunc(
   return funcs[0];
 }
 
-extern std::unordered_map<std::string, std::shared_ptr<void>>&
-GetFuncCacheMap();
+extern std::unordered_map<size_t, std::shared_ptr<void>>& GetFuncCacheMap();
 
 template <typename KernelTuple, typename PlaceType>
 class KernelFuncs {
@@ -185,7 +184,7 @@ class KernelFuncs {
   KernelFuncs() = default;
   static KernelFuncs& Cache() {
     auto& func_cache_map = GetFuncCacheMap();
-    std::string key = typeid(KernelFuncs<KernelTuple, PlaceType>).name();
+    auto key = typeid(KernelFuncs<KernelTuple, PlaceType>).hash_code();
     auto iter = func_cache_map.find(key);
     if (iter != func_cache_map.end()) {
       return *(KernelFuncs<KernelTuple, PlaceType>*)(iter->second.get());

--- a/paddle/fluid/operators/jit/helper.h
+++ b/paddle/fluid/operators/jit/helper.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <iostream>
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -176,7 +177,7 @@ typename KernelTuple::func_type GetDefaultBestFunc(
   return funcs[0];
 }
 
-extern std::unordered_map<size_t, std::shared_ptr<void>>& GetFuncCacheMap();
+extern std::map<size_t, std::shared_ptr<void>>& GetFuncCacheMap();
 
 template <typename KernelTuple, typename PlaceType>
 class KernelFuncs {

--- a/paddle/fluid/operators/jit/kernel_pool.cc
+++ b/paddle/fluid/operators/jit/kernel_pool.cc
@@ -21,9 +21,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-std::unordered_map<size_t, std::shared_ptr<void>>& GetJITCodesMap() {
-  static thread_local std::unordered_map<size_t, std::shared_ptr<void>>
-      g_jit_codes_map;
+std::map<size_t, std::shared_ptr<void>>& GetJITCodesMap() {
+  static thread_local std::map<size_t, std::shared_ptr<void>> g_jit_codes_map;
   return g_jit_codes_map;
 }
 

--- a/paddle/fluid/operators/jit/kernel_pool.cc
+++ b/paddle/fluid/operators/jit/kernel_pool.cc
@@ -21,8 +21,8 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-std::unordered_map<std::string, std::shared_ptr<void>>& GetJITCodesMap() {
-  static thread_local std::unordered_map<std::string, std::shared_ptr<void>>
+std::unordered_map<size_t, std::shared_ptr<void>>& GetJITCodesMap() {
+  static thread_local std::unordered_map<size_t, std::shared_ptr<void>>
       g_jit_codes_map;
   return g_jit_codes_map;
 }

--- a/paddle/fluid/operators/jit/kernel_pool.h
+++ b/paddle/fluid/operators/jit/kernel_pool.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <map>
 #include <memory>  // for unique_ptr
 #include <string>
 #include <unordered_map>
@@ -28,7 +29,7 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-extern std::unordered_map<size_t, std::shared_ptr<void>>& GetJITCodesMap();
+extern std::map<size_t, std::shared_ptr<void>>& GetJITCodesMap();
 
 template <KernelType KT>
 class JitCodePool {

--- a/paddle/fluid/operators/jit/kernel_pool.h
+++ b/paddle/fluid/operators/jit/kernel_pool.h
@@ -28,7 +28,7 @@ namespace paddle {
 namespace operators {
 namespace jit {
 
-extern std::unordered_map<std::string, std::shared_ptr<void>>& GetJITCodesMap();
+extern std::unordered_map<size_t, std::shared_ptr<void>>& GetJITCodesMap();
 
 template <KernelType KT>
 class JitCodePool {
@@ -39,7 +39,7 @@ class JitCodePool {
   JitCodePool() = default;
   static JitCodePool& Instance() {
     auto& jit_codes_map = GetJITCodesMap();
-    std::string key = typeid(JitCodePool<KT>).name();
+    auto key = typeid(JitCodePool<KT>).hash_code();
     auto iter = jit_codes_map.find(key);
     if (iter != jit_codes_map.end()) {
       return *(JitCodePool<KT>*)(iter->second.get());


### PR DESCRIPTION
As the description of [Issue#21266](https://github.com/PaddlePaddle/Paddle/issues/21266), it shows that the performance of Chinese_NER will be degressive after fixed some TLS section issue. To avoid the string as the key can be helpful the performance.

resolve #21266

CPU: Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz
Command：
```
   I. ./paddle/fluid/inference/tests/api/test_analyzer_ner --infer_model=third_party/inference_demo/chinese_ner/model --infer_data=third_party/inference_demo/chinese_ner/data.txt --gtest_filter=Analyzer_Chinese_ner.profile --batch_size=1 --repeat=2000 --num_threads=1 --test_all_data=true
   II. python chinese_ner_ce.py (changed repeat_times as 1000000 in chinese_ner_ce.py)
```
Tables:

I. Use Command I

Command   I |   |  
-- | -- | --
Mode | Latency(ms) | Percentage
Original | 0.0731486 | 0.00%
Fix TLS issue | 0.085967 | -17.52%
Improve   performance(unordered_map) | 0.0773406 | -5.73%
Improve   performance(map) | 0.0754822 | -3.19%

2. Use Command II with repeat_times=1000

Command   II |   |  
-- | -- | --
Mode | Latency(ms) | Percentage
Original | 0.09608269 | 0.00%
Fix TLS issue | 0.12087822 | -25.81%
Improve   performance(unordered_map) | 0.105142593 | -9.43%
Improve   performance(map) | 0.1039505 | -8.19%


3. Use Command II with repeat_times=1000000

Command   II |   |  
-- | -- | --
Mode | Latency(ms) | Percentage
Original | 0.10085106 | 0.00%
Fix TLS issue | 0.12207031 | -21.04%
Improve   performance(unordered_map) | 0.10585785 | -4.96%
Improve   performance(map) | 0.105142593 | -4.26%


