### PR TITLE
[WIP] Dropout with seed

### DIFF
--- a/paddle/fluid/operators/dropout_with_seed_op.cc
+++ b/paddle/fluid/operators/dropout_with_seed_op.cc
@@ -152,7 +152,9 @@ class DropoutWithSeedGradOpMaker : public framework::SingleGradOpMaker {
 
 namespace ops = paddle::operators;
 REGISTER_OPERATOR(dropout_with_seed, ops::DropoutWithSeedOp,
-                  ops::DropoutWithSeedOpMaker, ops::DropoutWithSeedGradOpMaker);
+                  ops::DropoutWithSeedOpMaker,
+                  ops::DropoutWithSeedGradOpMaker<paddle::framework::OpDesc>,
+                  ops::DropoutWithSeedGradOpMaker<paddle::imperative::OpBase>);
 REGISTER_OPERATOR(dropout_with_seed_grad, ops::DropoutWithSeedOpGrad);
 REGISTER_OP_CPU_KERNEL(
     dropout_with_seed,

--- a/paddle/fluid/operators/dropout_with_seed_op.cc
+++ b/paddle/fluid/operators/dropout_with_seed_op.cc
@@ -42,6 +42,16 @@ class DropoutWithSeedOp : public framework::OperatorWithKernel {
     return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
                                    ctx.device_context());
   }
+
+  framework::OpKernelType GetKernelTypeForVar(
+      const std::string& var_name, const Tensor& tensor,
+      const framework::OpKernelType& expected_kernel_type) const override {
+    if (var_name == "Seed") {
+      return expected_kernel_type;
+    }
+    return framework::OpKernelType(expected_kernel_type.data_type_,
+                                   tensor.place(), tensor.layout());
+  }
 };
 
 class DropoutWithSeedOpMaker : public framework::OpProtoAndCheckerMaker {

--- a/paddle/fluid/operators/dropout_with_seed_op.cc
+++ b/paddle/fluid/operators/dropout_with_seed_op.cc
@@ -131,7 +131,7 @@ class DropoutWithSeedOpGrad : public framework::OperatorWithKernel {
 };
 
 template <typename T>
-class DropoutWithSeedGradOpMaker : public framework::SingleGradOpMaker {
+class DropoutWithSeedGradOpMaker : public framework::SingleGradOpMaker<T> {
  public:
   using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
 

--- a/paddle/fluid/operators/dropout_with_seed_op.cc
+++ b/paddle/fluid/operators/dropout_with_seed_op.cc
@@ -43,15 +43,15 @@ class DropoutWithSeedOp : public framework::OperatorWithKernel {
                                    ctx.device_context());
   }
 
-  framework::OpKernelType GetKernelTypeForVar(
-      const std::string& var_name, const Tensor& tensor,
-      const framework::OpKernelType& expected_kernel_type) const override {
-    if (var_name == "Seed") {
-      return expected_kernel_type;
-    }
-    return framework::OpKernelType(expected_kernel_type.data_type_,
-                                   tensor.place(), tensor.layout());
-  }
+  // framework::OpKernelType GetKernelTypeForVar(
+  //    const std::string& var_name, const Tensor& tensor,
+  //    const framework::OpKernelType& expected_kernel_type) const override {
+  //  if (var_name == "Seed") {
+  //    return expected_kernel_type;
+  //  }
+  //  return framework::OpKernelType(expected_kernel_type.data_type_,
+  //                                 tensor.place(), tensor.layout());
+  //}
 };
 
 class DropoutWithSeedOpMaker : public framework::OpProtoAndCheckerMaker {

--- a/paddle/fluid/operators/dropout_with_seed_op.cc
+++ b/paddle/fluid/operators/dropout_with_seed_op.cc
@@ -1,0 +1,161 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/dropout_with_seed_op.h"
+#include <memory>
+#include <string>
+
+namespace paddle {
+namespace operators {
+
+using framework::Tensor;
+
+class DropoutWithSeedOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE(ctx->HasInput("X"), "Input(X) must not be null.");
+
+    auto x_dims = ctx->GetInputDim("X");
+    ctx->SetOutputDim("Out", x_dims);
+    if (ctx->Attrs().Get<bool>("is_test") == false) {
+      ctx->SetOutputDim("Mask", x_dims);
+    }
+    ctx->ShareLoD("X", /*->*/ "Out");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(ctx.Input<Tensor>("X")->type(),
+                                   ctx.device_context());
+  }
+};
+
+class DropoutWithSeedOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "The input of dropout_with_seed op.");
+    AddInput("Seed", "The seed of dropout_with_seed op.");
+    AddOutput("Out", "The output of dropout_with_seed op.");
+    AddOutput("Mask", "The random sampled dropout mask.").AsIntermediate();
+
+    AddAttr<float>("dropout_prob", "Probability of setting units to zero.")
+        .SetDefault(.5f)
+        .AddCustomChecker([](const float& drop_p) {
+          PADDLE_ENFORCE(drop_p >= 0.0f && drop_p <= 1.0f,
+                         "'dropout_prob' must be between 0.0 and 1.0.");
+        });
+    AddAttr<bool>("is_test",
+                  "(bool, default false) Set to true for inference only, false "
+                  "for training. Some layers may run faster when this is true.")
+        .SetDefault(false);
+    AddAttr<std::string>(
+        "dropout_implementation",
+        "[\"downgrade_in_infer\"|\"upscale_in_train\"]"
+        "There are two kinds of ways to implement dropout"
+        "(the mask below is a tensor have the same shape with input"
+        "the value of mask is 0 or 1, the ratio of 0 is dropout_prob)"
+        "1. downgrade_in_infer(default), downgrade the outcome at inference "
+        "time"
+        "   train: out = input * mask"
+        "   inference: out = input * (1.0 - dropout_prob)"
+        "2. upscale_in_train, upscale the outcome at training time, do nothing "
+        "in inference"
+        "   train: out = input * mask / ( 1.0 - dropout_prob )"
+        "   inference: out = input"
+        "   dropout op can be removed from the program. the program will be "
+        "efficient")
+        .SetDefault("downgrade_in_infer")
+        .AddCustomChecker([](const std::string& type) {
+          PADDLE_ENFORCE(
+              type == "downgrade_in_infer" || type == "upscale_in_train",
+              "dropout_implementation can only be downgrade_in_infer or "
+              "upscale_in_train");
+        });
+
+    AddComment(R"DOC(
+DropoutWithSeed Operator.
+
+DropoutWithSeed refers to randomly dropping out units in a nerual network. It is a
+regularization technique for reducing overfitting by preventing neuron
+co-adaption during training. The dropout operator randomly set (according to
+the given dropout probability) the outputs of some units to zero, while others
+are set equal to their corresponding inputs.
+
+)DOC");
+  }
+};
+
+class DropoutWithSeedOpGrad : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(ctx->Attrs().Get<bool>("is_test"), false,
+                      "GradOp is only callable when is_test is false");
+
+    PADDLE_ENFORCE(ctx->HasInput("Mask"), "Mask must not be null.");
+    PADDLE_ENFORCE(ctx->HasInput(framework::GradVarName("Out")),
+                   "Input(Out@GRAD) must not be null.");
+
+    auto out_dims = ctx->GetInputDim(framework::GradVarName("Out"));
+
+    ctx->SetOutputDim(framework::GradVarName("X"), out_dims);
+    ctx->ShareLoD(framework::GradVarName("Out"),
+                  /*->*/ framework::GradVarName("X"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(
+        ctx.Input<framework::Tensor>(framework::GradVarName("Out"))->type(),
+        ctx.GetPlace());
+  }
+};
+
+class DropoutWithSeedGradOpDescMaker : public framework::SingleGradOpDescMaker {
+ public:
+  using framework::SingleGradOpDescMaker::SingleGradOpDescMaker;
+
+ protected:
+  std::unique_ptr<framework::OpDesc> Apply() const override {
+    std::unique_ptr<framework::OpDesc> op(new framework::OpDesc());
+    op->SetType("dropout_with_seed_grad");
+    op->SetInput(framework::GradVarName("Out"), OutputGrad("Out"));
+    op->SetInput("Mask", Output("Mask"));
+    op->SetOutput(framework::GradVarName("X"), InputGrad("X"));
+    op->SetAttrMap(Attrs());
+    return op;
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(dropout_with_seed, ops::DropoutWithSeedOp,
+                  ops::DropoutWithSeedOpMaker,
+                  ops::DropoutWithSeedGradOpDescMaker);
+REGISTER_OPERATOR(dropout_with_seed_grad, ops::DropoutWithSeedOpGrad);
+REGISTER_OP_CPU_KERNEL(
+    dropout_with_seed,
+    ops::CPUDropoutWithSeedKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CPUDropoutWithSeedKernel<paddle::platform::CPUDeviceContext, double>);
+REGISTER_OP_CPU_KERNEL(
+    dropout_with_seed_grad,
+    ops::DropoutWithSeedGradKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::DropoutWithSeedGradKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/dropout_with_seed_op.cu
+++ b/paddle/fluid/operators/dropout_with_seed_op.cu
@@ -1,0 +1,132 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#include <cuda.h>
+#include <curand_kernel.h>
+#include <thrust/device_ptr.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/random.h>
+#include <thrust/transform.h>
+#include <string>
+#include "paddle/fluid/operators/dropout_with_seed_op.h"
+#include "paddle/fluid/platform/dynload/curand.h"
+#include "paddle/fluid/platform/float16.h"
+namespace paddle {
+namespace operators {
+
+template <typename T, typename MaskType>
+__global__ void RandomGenerator(const size_t n, const int seed,
+                                const float dropout_prob, const T* src,
+                                MaskType* mask_data, T* dst,
+                                bool is_upscale_in_train) {
+  curandStatePhilox4_32_10_t state;
+  int idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int step_size = 0;
+
+  MaskType mask;
+  T dest;
+  for (; idx < n; idx += blockDim.x * gridDim.x) {
+    T s = src[idx];
+    if (step_size == 0) {
+      curand_init(seed, idx, idx, &state);
+      step_size = blockDim.x * gridDim.x;
+    } else {
+      curand_init(seed, idx, step_size, &state);
+    }
+    if (curand_uniform(&state) < dropout_prob) {
+      mask = 0;
+      dest = 0;
+    } else {
+      mask = 1;
+      if (is_upscale_in_train) {
+        dest = s / static_cast<T>(1.0f - dropout_prob);
+      } else {
+        dest = s;
+      }
+    }
+    mask_data[idx] = mask;
+    dst[idx] = dest;
+  }
+}
+
+// It seems that Eigen::Tensor::setRandom in GPU will SEGFAULT.
+// Use std::random and thrust::random(thrust is a std library in CUDA) to
+// implement uniform random.
+template <typename Place, typename T>
+class GPUDropoutWithSeedKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* x = context.Input<Tensor>("X");
+    auto* seed = context.Input<Tensor>("Seed");
+    auto* y = context.Output<Tensor>("Out");
+    y->mutable_data<T>(context.GetPlace());
+    float dropout_prob = context.Attr<float>("dropout_prob");
+
+    auto& dropout_implementation =
+        context.Attr<std::string>("dropout_implementation");
+    bool upscale_in_train = (dropout_implementation == "upscale_in_train");
+
+    auto& place = *context.template device_context<Place>().eigen_device();
+    if (!context.Attr<bool>("is_test")) {
+      int64_t x_numel = x->numel();
+      auto stream = context.cuda_device_context().stream();
+
+      auto* mask = context.Output<Tensor>("Mask");
+      auto* mask_data = mask->mutable_data<uint8_t>(context.GetPlace());
+      size_t size = framework::product(mask->dims());
+      auto* x_data = x->data<T>();
+      auto* y_data = y->mutable_data<T>(context.GetPlace());
+      if (dropout_prob == 1.0f) {
+        PADDLE_ENFORCE_CUDA_SUCCESS(
+            cudaMemsetAsync(y_data, 0, x_numel * sizeof(T), stream));
+        PADDLE_ENFORCE_CUDA_SUCCESS(cudaMemsetAsync(
+            mask_data, 0, x_numel * sizeof(*mask_data), stream));
+        return;
+      }
+
+      // std::random_device rnd;
+      // int seed =
+      //    context.Attr<bool>("fix_seed") ? context.Attr<int>("seed") : rnd();
+
+      int threads = 512;
+      int grid = (x_numel + threads - 1) / threads;
+      RandomGenerator<T, uint8_t><<<grid, threads, 0, stream>>>(
+          size, seed, dropout_prob, x_data, mask_data, y_data,
+          upscale_in_train);
+    } else {
+      auto X = EigenMatrix<T>::Reshape(*x, 1);
+      auto Y = EigenMatrix<T>::Reshape(*y, 1);
+      if (upscale_in_train) {
+        Y.device(place) = X;
+      } else {
+        Y.device(place) = X * static_cast<T>(1.0f - dropout_prob);
+      }
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+REGISTER_OP_CUDA_KERNEL(
+    dropout_with_seed,
+    ops::GPUDropoutWithSeedKernel<plat::CUDADeviceContext, float>,
+    ops::GPUDropoutWithSeedKernel<plat::CUDADeviceContext, plat::float16>,
+    ops::GPUDropoutWithSeedKernel<plat::CUDADeviceContext, double>);
+REGISTER_OP_CUDA_KERNEL(
+    dropout_with_seed_grad,
+    ops::DropoutWithSeedGradKernel<plat::CUDADeviceContext, float>,
+    ops::DropoutWithSeedGradKernel<plat::CUDADeviceContext, plat::float16>,
+    ops::DropoutWithSeedGradKernel<plat::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/dropout_with_seed_op.cu
+++ b/paddle/fluid/operators/dropout_with_seed_op.cu
@@ -92,7 +92,6 @@ class GPUDropoutWithSeedKernel : public framework::OpKernel<T> {
     if (!context.Attr<bool>("is_test")) {
       VLOG(3) << "is not test";
       int64_t x_numel = x->numel();
-      auto stream = context.cuda_device_context().stream();
 
       auto* mask = context.Output<Tensor>("Mask");
       auto* mask_data = mask->mutable_data<uint8_t>(context.GetPlace());
@@ -101,13 +100,16 @@ class GPUDropoutWithSeedKernel : public framework::OpKernel<T> {
       auto* x_data = x->data<T>();
       VLOG(3) << "x data";
       VLOG(3) << "try to print x";
-      VLOG(3) << "X data: " << *x;
+      // VLOG(3) << "X data: " << *x;
       VLOG(3) << "Seed data";
       const auto* seed_data = seed->data<int>();
       auto* y_data = y->mutable_data<T>(context.GetPlace());
       VLOG(3) << "try to print seed";
-      VLOG(3) << "Seed data: " << *seed;
+      // VLOG(3) << "Seed data: " << *seed;
       VLOG(3) << "y data";
+
+      // int* seed_data_dev = get_new_data_from_tensor(seed);
+      auto stream = context.cuda_device_context().stream();
       if (dropout_prob == 1.0f) {
         PADDLE_ENFORCE_CUDA_SUCCESS(
             cudaMemsetAsync(y_data, 0, x_numel * sizeof(T), stream));

--- a/paddle/fluid/operators/dropout_with_seed_op.cu
+++ b/paddle/fluid/operators/dropout_with_seed_op.cu
@@ -85,6 +85,7 @@ class GPUDropoutWithSeedKernel : public framework::OpKernel<T> {
       auto* mask_data = mask->mutable_data<uint8_t>(context.GetPlace());
       size_t size = framework::product(mask->dims());
       auto* x_data = x->data<T>();
+      const auto* seed_data = seed->data<int>();
       auto* y_data = y->mutable_data<T>(context.GetPlace());
       if (dropout_prob == 1.0f) {
         PADDLE_ENFORCE_CUDA_SUCCESS(
@@ -101,7 +102,7 @@ class GPUDropoutWithSeedKernel : public framework::OpKernel<T> {
       int threads = 512;
       int grid = (x_numel + threads - 1) / threads;
       RandomGenerator<T, uint8_t><<<grid, threads, 0, stream>>>(
-          size, seed, dropout_prob, x_data, mask_data, y_data,
+          size, *seed_data, dropout_prob, x_data, mask_data, y_data,
           upscale_in_train);
     } else {
       auto X = EigenMatrix<T>::Reshape(*x, 1);

--- a/paddle/fluid/operators/dropout_with_seed_op.h
+++ b/paddle/fluid/operators/dropout_with_seed_op.h
@@ -1,0 +1,136 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#pragma once
+
+#include <cstring>
+#include <random>
+#include <string>
+
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+template <typename T, int MajorType = Eigen::RowMajor,
+          typename IndexType = Eigen::DenseIndex>
+using EigenMatrix = framework::EigenMatrix<T, MajorType, IndexType>;
+
+template <typename DeviceContext, typename T>
+class CPUDropoutWithSeedKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* x = context.Input<Tensor>("X");
+    auto* seed = context.Input<Tensor>("Seed");
+    auto* y = context.Output<Tensor>("Out");
+    const auto* x_data = x->data<T>();
+    const auto* seed_data = seed->data<int>();
+    auto* y_data = y->mutable_data<T>(context.GetPlace());
+    float dropout_prob = context.Attr<float>("dropout_prob");
+
+    auto& dropout_implementation =
+        context.Attr<std::string>("dropout_implementation");
+    bool upscale_in_train = (dropout_implementation == "upscale_in_train");
+    if (!context.Attr<bool>("is_test")) {
+      auto* mask = context.Output<Tensor>("Mask");
+      auto* mask_data = mask->mutable_data<uint8_t>(context.GetPlace());
+      size_t size = framework::product(mask->dims());
+
+      // Special case when dropout_prob is 1.0
+      if (dropout_prob == 1.0f) {
+        std::memset(y_data, 0, size * sizeof(*y_data));        // NOLINT
+        std::memset(mask_data, 0, size * sizeof(*mask_data));  // NOLINT
+        return;
+      }
+
+      // NOTE: fixed seed should only be used in unittest or for debug.
+      // Guarantee to use random seed in training.
+      // std::random_device rnd;
+      std::minstd_rand engine;
+      engine.seed(*seed_data);
+
+      std::uniform_real_distribution<float> dist(0, 1);
+
+      for (size_t i = 0; i < size; ++i) {
+        if (dist(engine) < dropout_prob) {
+          mask_data[i] = 0;
+          y_data[i] = 0;
+        } else {
+          mask_data[i] = 1;
+          if (upscale_in_train) {
+            y_data[i] = x_data[i] / static_cast<T>(1.0f - dropout_prob);
+          } else {
+            y_data[i] = x_data[i];
+          }
+        }
+      }
+    } else {
+      if (upscale_in_train) {
+        const auto* X_data = x->data<T>();
+        auto* Y_data = y->mutable_data<T>(context.GetPlace());
+#ifdef PADDLE_WITH_MKLML
+#pragma omp parallel for
+#endif
+        for (int i = 0; i < x->numel(); i++) {
+          Y_data[i] = X_data[i];
+        }
+      } else {
+        auto X = EigenMatrix<T>::Reshape(*x, 1);
+        auto Y = EigenMatrix<T>::Reshape(*y, 1);
+        auto& place =
+            *context.template device_context<DeviceContext>().eigen_device();
+        Y.device(place) = X * static_cast<T>(1.0f - dropout_prob);
+      }
+    }
+  }
+};
+
+template <typename DeviceContext, typename T>
+class DropoutWithSeedGradKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    PADDLE_ENFORCE(!context.Attr<bool>("is_test"),
+                   "GradOp is only callable when is_test is false");
+
+    auto* grad_x = context.Output<Tensor>(framework::GradVarName("X"));
+    auto* grad_y = context.Input<Tensor>(framework::GradVarName("Out"));
+    auto* mask = context.Input<Tensor>("Mask");
+    grad_x->mutable_data<T>(context.GetPlace());
+
+    auto M = EigenMatrix<uint8_t>::Reshape(*mask, 1);
+    auto dX = EigenMatrix<T>::Reshape(*grad_x, 1);
+    auto dY = EigenMatrix<T>::Reshape(*grad_y, 1);
+
+    auto& place =
+        *context.template device_context<DeviceContext>().eigen_device();
+
+    auto& dropout_implementation =
+        context.Attr<std::string>("dropout_implementation");
+    if (dropout_implementation == "upscale_in_train") {
+      float dropout_prob = context.Attr<float>("dropout_prob");
+      if (dropout_prob == 1.0f) {
+        dX.device(place) = static_cast<T>(0) * dY;
+      } else {
+        dX.device(place) =
+            dY * M.cast<T>() / static_cast<T>(1.0f - dropout_prob);
+      }
+    } else {
+      dX.device(place) = dY * M.cast<T>();
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/seed_op.cc
+++ b/paddle/fluid/operators/seed_op.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/seed_op.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+class SeedOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    // std::vector<int> dim_vec {1};
+    const framework::DDim& dims = framework::DDim({1});
+    ctx->SetOutputDim("Out", dims);
+    // ctx->ShareLoD("X", /*->*/ "Out");
+    // LodLevel=0
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(framework::proto::VarType::INT32,
+                                   ctx.GetPlace());
+  }
+};
+
+class SeedOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddOutput("Out", "The output of seed op.");
+    AddAttr<int>("seed", "Dropout random seed.").SetDefault(0);
+    AddComment(R"DOC(
+Seed Operator.
+)DOC");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+// No grad op
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(seed, ops::SeedOp, ops::SeedOpMaker,
+                  paddle::framework::EmptyGradOpMaker);
+
+REGISTER_OP_CPU_KERNEL(
+    seed, ops::CPUSeedKernel<paddle::platform::CPUDeviceContext, int>);

--- a/paddle/fluid/operators/seed_op.cc
+++ b/paddle/fluid/operators/seed_op.cc
@@ -54,8 +54,9 @@ Seed Operator.
 
 // No grad op
 namespace ops = paddle::operators;
-REGISTER_OPERATOR(seed, ops::SeedOp, ops::SeedOpMaker,
-                  paddle::framework::EmptyGradOpMaker);
-
+REGISTER_OPERATOR(
+    seed, ops::SeedOp, ops::SeedOpMaker,
+    paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
+    paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
 REGISTER_OP_CPU_KERNEL(
     seed, ops::CPUSeedKernel<paddle::platform::CPUDeviceContext, int>);

--- a/paddle/fluid/operators/seed_op.cc
+++ b/paddle/fluid/operators/seed_op.cc
@@ -34,7 +34,7 @@ class SeedOp : public framework::OperatorWithKernel {
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext& ctx) const override {
     return framework::OpKernelType(framework::proto::VarType::INT32,
-                                   ctx.GetPlace());
+                                   platform::CPUPlace());
   }
 };
 

--- a/paddle/fluid/operators/seed_op.h
+++ b/paddle/fluid/operators/seed_op.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#pragma once
+
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+using Tensor = framework::Tensor;
+
+template <typename DeviceContext, typename T>
+class CPUSeedKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto* out = context.Output<Tensor>("Out");
+    auto* out_data = out->mutable_data<T>(context.GetPlace());
+    int user_seed = context.Attr<int>("seed");
+
+    // NOTE: fixed seed should only be used in unittest or for debug.
+    // Guarantee to use random seed in training.
+    std::random_device rnd;
+    std::minstd_rand engine;
+    int seed;
+    if (user_seed != 0) {
+      seed = user_seed;
+    } else {
+      seed = rnd();
+    }
+    out_data[0] = seed;
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -56,7 +56,7 @@ class ProgramStats(object):
     def get_reserved_vars(self):
         var_name = []
         for op in self.ops:
-            if op.desc.type() == "dropout":
+            if op.desc.type() == "seed":
                 var_name.extend(op.desc.output_arg_names())
         return var_name
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -136,6 +136,52 @@ class ProgramStats(object):
         sorted_checkpoints = sorted(sorted_checkpoints, key=lambda x: x[1])
         return [x[0] for x in sorted_checkpoints]
 
+    def modify_forward_desc_for_recompute(self):
+        op_types = [op.desc.type() for op in self.ops]
+        if "dropout" not in op_types:
+            return
+
+        op_idx = 0
+        while (op_idx < len(self.ops)):
+            op = self.ops[op_idx]
+            if op.desc.type() != "dropout":
+                op_idx += 1
+                continue
+            op_unique_name = unique_name.generate("seed")
+            var_unique_name = unique_name.generate_with_ignorable_key(".".join(
+                [op_unique_name, 'tmp']))
+            added_var = self.block.create_var(
+                name=var_unique_name,
+                dtype='int32',
+                type=core.VarDesc.VarType.LOD_TENSOR,
+                persistable=False,
+                stop_gradient=False)
+            seed = 0 if op.attr("fix_seed") is False else int(op.attr("seed"))
+            added_op = self.block._insert_op(
+                index=op.idx,
+                type='seed',
+                inputs={},
+                outputs={'Out': [added_var]},
+                attrs={'seed': seed})
+            self.ops.insert(op_idx, added_op)
+            op.desc.set_type("dropout_with_seed")
+            op.desc.set_input("Seed", [var_unique_name])
+            op.desc.remove_attr("fix_seed")
+            op.desc.remove_attr("seed")
+            self.block._sync_with_cpp()
+            #self.block._insert_op(op_idx, added_op)
+            op_idx += 2
+            #dtype=dtype,
+            #type=core.VarDesc.VarType.LOD_TENSOR,
+            #persistable=False,
+            #stop_gradient=stop_gradient) 
+
+        #for op in self.ops:
+
+        #print([op for op in self.ops if op.desc.type() == "dropout"])
+
+        #print("dropout in ops")
+
 
 def _pretty_op_desc_(op_desc, prefix):
     out_s = "%s\tname:[%s]\n%s    \tinputs:[%s]\n%s    \toutputs:[%s]" % \
@@ -588,6 +634,7 @@ def _append_backward_ops_with_checkpoints_(
         checkpoints: variables that a user defined as checkpoint for forward recomputation
 
     Algorithms:
+        0) deal with forward recomputing program descs
         1) find ops between checkpoints, i.e. recompute_segments
         2) go through all forward ops and induct all variables that will be hold in memory
             a. variables that are used across segments will be held in memory
@@ -608,10 +655,15 @@ def _append_backward_ops_with_checkpoints_(
     checkpoints_name = list(set(checkpoints_name))
     local_block = block.program._create_block()
     buffer_block = block.program._create_block()
-
-    # 1) find ops between checkpoints, i.e. recompute_segments
+    # 0) deal with forward recomputing program descs  
     program_stat = ProgramStats(block, ops)
+    program_stat.modify_forward_desc_for_recompute()
     program_stat.build_stats()
+
+    #with open("main_program.txt", 'w') as f:
+    #    f.write(str(block.program)) 
+    #exit()
+    # 1) find ops between checkpoints, i.e. recompute_segments
     checkpoints_name = program_stat.sort_checkpoints(checkpoints_name)
     segments = []
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -63,7 +63,6 @@ __all__ = [
     'reduce_all',
     'reduce_any',
     'dropout',
-    'dropout_with_seed',
     'split',
     'ctc_greedy_decoder',
     'l2_normalize',
@@ -825,56 +824,6 @@ def dropout(x,
             'is_test': is_test,
             'fix_seed': seed is not None,
             'seed': seed if seed is not None else 0,
-            'dropout_implementation': dropout_implementation,
-        })
-    return out
-
-
-def dropout_with_seed(x,
-                      dropout_prob,
-                      is_test=False,
-                      seed=None,
-                      name=None,
-                      dropout_implementation="downgrade_in_infer"):
-
-    helper = LayerHelper('dropout_with_seed', **locals())
-
-    if not isinstance(x, Variable):
-        raise TypeError(
-            "The type of 'input' in dropout must be Variable, but received %s" %
-            (type(x)))
-    if convert_dtype(x.dtype) in ['float16']:
-        warnings.warn(
-            "The data type of 'input' in dropout only support float16 on GPU now."
-        )
-    if convert_dtype(x.dtype) not in ['float16', 'float32', 'float64']:
-        raise TypeError(
-            "The data type of 'input' in dropout must be float16 or float32 or float64, but received %s."
-            % (convert_dtype(x.dtype)))
-
-    seed_var = helper.create_variable_for_type_inference(dtype='int32')
-    out = helper.create_variable_for_type_inference(dtype=x.dtype)
-    mask = helper.create_variable_for_type_inference(
-        dtype=core.VarDesc.VarType.UINT8, stop_gradient=True)
-
-    if (seed is None or seed == 0) and helper.main_program.random_seed != 0:
-        seed = helper.main_program.random_seed
-
-    helper.append_op(
-        type='seed',
-        inputs={},
-        outputs={'Out': [seed_var]},
-        attrs={'seed': seed if seed is not None else 0, })
-
-    helper.append_op(
-        type='dropout_with_seed',
-        inputs={'X': [x],
-                'Seed': [seed_var]},
-        outputs={'Out': [out],
-                 'Mask': [mask]},
-        attrs={
-            'dropout_prob': dropout_prob,
-            'is_test': is_test,
             'dropout_implementation': dropout_implementation,
         })
     return out

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -837,7 +837,7 @@ def dropout_with_seed(x,
                       name=None,
                       dropout_implementation="downgrade_in_infer"):
 
-    helper = LayerHelper('dropout', **locals())
+    helper = LayerHelper('dropout_with_seed', **locals())
 
     if not isinstance(x, Variable):
         raise TypeError(

--- a/python/paddle/fluid/tests/unittests/test_dropout_with_seed_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_with_seed_op.py
@@ -1,0 +1,362 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle.fluid.core as core
+from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
+
+
+class TestDropoutWithSeedOp(OpTest):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = self.input_x
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {'dropout_prob': 0.0, 'is_test': False}
+        self.outputs = {
+            'Out': self.output_out,
+            'Mask': np.ones((32, 64)).astype('uint8')
+        }
+
+    def test_check_output(self):
+        self.check_output(check_dygraph=False)
+
+    def test_check_grad_normal(self):
+        self.check_grad(['X'], 'Out', max_relative_error=0.05)
+
+
+class TestDropoutWithSeedOp2(TestDropoutWithSeedOp):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = np.zeros((32, 64)).astype('float32')
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {'dropout_prob': 1.0, 'is_test': False}
+        self.outputs = {
+            'Out': self.output_out,
+            'Mask': np.zeros((32, 64)).astype('uint8')
+        }
+
+
+class TestDropoutWithSeedOp3(TestDropoutWithSeedOp):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64, 2)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = self.input_x
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {'dropout_prob': 0.0, 'is_test': False}
+        self.outputs = {
+            'Out': self.output_out,
+            'Mask': np.ones((32, 64, 2)).astype('uint8')
+        }
+
+
+class TestDropoutWithSeedOp4(OpTest):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {'dropout_prob': 0.35, 'is_test': True}
+        self.output_out = self.input_x * (1.0 - self.attrs['dropout_prob'])
+        self.outputs = {'Out': self.output_out, }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestDropoutWithSeedOp5(OpTest):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64, 3)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {'dropout_prob': 0.35, 'is_test': True}
+        self.output_out = self.input_x * (1.0 - self.attrs['dropout_prob'])
+        self.outputs = {'Out': self.output_out, }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestDropoutWithSeedOp6(TestDropoutWithSeedOp):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = np.zeros((32, 64)).astype('float32')
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {
+            'dropout_prob': 1.0,
+            'is_test': False,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {
+            'Out': self.output_out,
+            'Mask': np.zeros((32, 64)).astype('uint8')
+        }
+
+
+class TestDropoutWithSeedOp7(TestDropoutWithSeedOp):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64, 2)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = self.input_x
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {
+            'dropout_prob': 0.0,
+            'is_test': False,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {
+            'Out': self.output_out,
+            'Mask': np.ones((32, 64, 2)).astype('uint8')
+        }
+
+
+class TestDropoutWithSeedOp8(OpTest):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = self.input_x
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {
+            'dropout_prob': 0.35,
+            'is_test': True,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {'Out': self.output_out, }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestDropoutWithSeedOp9(OpTest):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64, 2)).astype("float32")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.output_out = self.input_x
+        self.inputs = {'X': self.input_x, 'Seed': self.input_seed}
+        self.attrs = {
+            'dropout_prob': 0.75,
+            'is_test': True,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {'Out': self.output_out, }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestFP16DropoutWithSeedOp(OpTest):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64)).astype("float16")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.inputs = {
+            'X': OpTest.np_dtype_to_fluid_dtype(self.input_x),
+            'Seed': self.input_seed
+        }
+        self.attrs = {'dropout_prob': 0.35, 'is_test': True}
+        self.output_out = self.input_x * (1.0 - self.attrs['dropout_prob'])
+        self.outputs = {'Out': self.output_out, }
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda() and core.op_support_gpu(
+                "dropout_with_seed"):
+            self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+
+
+class TestFP16DropoutWithSeedOp2(TestFP16DropoutWithSeedOp):
+    def setUp(self):
+        self.op_type = "dropout_with_seed"
+        self.input_x = np.random.random((32, 64, 3)).astype("float16")
+        self.input_seed = np.asarray([0], dtype="int32")
+        self.inputs = {
+            'X': OpTest.np_dtype_to_fluid_dtype(self.input_x),
+            'Seed': self.input_seed
+        }
+        self.attrs = {'dropout_prob': 0.75, 'is_test': True}
+        self.output_out = self.input_x * (1.0 - self.attrs['dropout_prob'])
+        self.outputs = {'Out': self.output_out, }
+
+
+"""
+class TestDropoutOp3(TestDropoutOp):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64, 2)).astype("float32")}
+        self.attrs = {'dropout_prob': 0.0, 'fix_seed': True, 'is_test': False}
+        self.outputs = {
+            'Out': self.inputs['X'],
+            'Mask': np.ones((32, 64, 2)).astype('uint8')
+        }
+
+
+class TestDropoutOp4(OpTest):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64)).astype("float32")}
+        self.attrs = {'dropout_prob': 0.35, 'fix_seed': True, 'is_test': True}
+        self.outputs = {
+            'Out': self.inputs['X'] * (1.0 - self.attrs['dropout_prob'])
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestDropoutOp5(OpTest):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64, 3)).astype("float32")}
+        self.attrs = {'dropout_prob': 0.75, 'is_test': True}
+        self.outputs = {
+            'Out': self.inputs['X'] * (1.0 - self.attrs['dropout_prob'])
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestDropoutOp6(TestDropoutOp):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64)).astype("float32")}
+        self.attrs = {
+            'dropout_prob': 1.0,
+            'fix_seed': True,
+            'is_test': False,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {
+            'Out': np.zeros((32, 64)).astype('float32'),
+            'Mask': np.zeros((32, 64)).astype('uint8')
+        }
+
+
+class TestDropoutOp7(TestDropoutOp):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64, 2)).astype("float32")}
+        self.attrs = {
+            'dropout_prob': 0.0,
+            'fix_seed': True,
+            'is_test': False,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {
+            'Out': self.inputs['X'],
+            'Mask': np.ones((32, 64, 2)).astype('uint8')
+        }
+
+
+class TestDropoutOp8(OpTest):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64)).astype("float32")}
+        self.attrs = {
+            'dropout_prob': 0.35,
+            'fix_seed': True,
+            'is_test': True,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {'Out': self.inputs['X']}
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestDropoutOp9(OpTest):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.inputs = {'X': np.random.random((32, 64, 3)).astype("float32")}
+        self.attrs = {
+            'dropout_prob': 0.75,
+            'is_test': True,
+            'dropout_implementation': 'upscale_in_train'
+        }
+        self.outputs = {'Out': self.inputs['X']}
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestFP16DropoutOp(OpTest):
+    def setUp(self):
+        self.op_type = "dropout"
+        self.init_test_case()
+
+        x = np.random.random(self.input_size).astype("float16")
+        out = x * (1.0 - self.prob)
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.attrs = {
+            'dropout_prob': self.prob,
+            'fix_seed': self.fix_seed,
+            'is_test': True
+        }
+        self.outputs = {'Out': out}
+
+    def init_test_case(self):
+        self.input_size = [32, 64]
+        self.prob = 0.35
+        self.fix_seed = True
+
+    def test_check_output(self):
+        if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
+            self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+
+
+class TestFP16DropoutOp2(TestFP16DropoutOp):
+    def init_test_case(self):
+        self.input_size = [32, 64, 3]
+        self.prob = 0.75
+        self.fix_seed = False
+
+
+class TestDropoutOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+
+            def test_Variable():
+                # the input of dropout must be Variable.
+                x1 = fluid.create_lod_tensor(
+                    np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
+                fluid.layers.dropout(x1, dropout_prob=0.5)
+
+            self.assertRaises(TypeError, test_Variable)
+
+            def test_dtype():
+                # the input dtype of dropout must be float16 or float32 or float64
+                # float16 only can be set on GPU place
+                x2 = fluid.layers.data(
+                    name='x2', shape=[3, 4, 5, 6], dtype="int32")
+                fluid.layers.dropout(x2, dropout_prob=0.5)
+
+            self.assertRaises(TypeError, test_dtype)
+"""
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -614,7 +614,7 @@ class TestLookaheadOptimizer(unittest.TestCase):
 
 
 class TestRecomputeOptimizer(unittest.TestCase):
-    def net(self, return_input=False):
+    def net(self, return_input=False, with_dropout=False):
         program = framework.Program()
         block = program.global_block()
         mul_x = block.create_parameter(
@@ -623,6 +623,14 @@ class TestRecomputeOptimizer(unittest.TestCase):
             dtype="float32", shape=[10, 8], lod_level=0, name="mul.y")
         mul_out = block.create_var(
             dtype="float32", shape=[5, 8], lod_level=0, name="mul.out")
+        if with_dropout == True:
+            mul_out_drop = block.create_var(
+                dtype="float32",
+                shape=[5, 8],
+                lod_level=0,
+                name="mul.out.dropout")
+            mul_out_mask = block.create_var(
+                dtype="uint8", shape=[5, 8], lod_level=0, name="mul.out.mask")
         b1 = block.create_parameter(
             dtype="float32", shape=[5, 8], lod_level=0, name="b1")
         b1_out = block.create_var(
@@ -639,11 +647,24 @@ class TestRecomputeOptimizer(unittest.TestCase):
                     "Y": mul_y},
             outputs={"Out": mul_out},
             attrs={"x_num_col_dims": 1})
-        block.append_op(
-            type="elementwise_add",
-            inputs={"X": mul_out,
-                    "Y": b1},
-            outputs={"Out": b1_out})
+        if with_dropout == True:
+            block.append_op(
+                type='dropout',
+                inputs={'X': [mul_out]},
+                outputs={'Out': [mul_out_drop],
+                         'Mask': [mul_out_mask]},
+                attrs={'dropout_prob': 0.5, })
+            block.append_op(
+                type="elementwise_add",
+                inputs={"X": mul_out_drop,
+                        "Y": b1},
+                outputs={"Out": b1_out})
+        else:
+            block.append_op(
+                type="elementwise_add",
+                inputs={"X": mul_out,
+                        "Y": b1},
+                outputs={"Out": b1_out})
         block.append_op(
             type="elementwise_add",
             inputs={"X": b1_out,
@@ -798,6 +819,30 @@ class TestRecomputeOptimizer(unittest.TestCase):
             self.assertEqual(
                 "load function is not supported by Recompute Optimizer for now",
                 cpt.get_exception_message(e))
+
+    def test_dropout(self):
+        """
+        If there are dropout layers in the forward nets, we should replace it
+        with seed op and dropout_with_seed op
+        """
+        mul_out, b1_out, b2_out, mean_out = self.net(with_dropout=True)
+        self.assertEqual(len(mean_out.block.ops), 5)
+        self.assertEqual(
+            [op.type for op in mean_out.block.ops],
+            ["mul", "dropout", "elementwise_add", "elementwise_add", "mean"])
+        sgd_optimizer = optimizer.SGD(learning_rate=1.0)
+        recompute_optimizer = optimizer.RecomputeOptimizer(sgd_optimizer)
+        recompute_optimizer._set_checkpoints([b1_out])
+        opts, params_grads = recompute_optimizer.minimize(mean_out)
+
+        self.assertEqual(len(mean_out.block.ops), 17)
+        self.assertEqual([op.type for op in mean_out.block.ops], [
+            "mul", "seed", "dropout_with_seed", "elementwise_add",
+            "elementwise_add", "mean", "fill_constant", "mean_grad",
+            "elementwise_add_grad", "mul", "dropout_with_seed",
+            "elementwise_add_grad", "dropout_with_seed_grad", "mul_grad", "sgd",
+            "sgd", "sgd"
+        ])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_seed_op.py
+++ b/python/paddle/fluid/tests/unittests/test_seed_op.py
@@ -1,0 +1,46 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+from op_test import OpTest
+import paddle.fluid as fluid
+
+
+class TestSeedOpFixSeed(OpTest):
+    def setUp(self):
+        self.op_type = "seed"
+        self.inputs = {}
+        self.attrs = {"seed": 123}
+        self.outputs = {"Out": np.asarray((123)).astype('int32')}
+
+    def test_check_output(self):
+        self.check_output()
+
+
+class TestSeedOpDiffSeed(OpTest):
+    def setUp(self):
+        self.op_type = "seed"
+        self.inputs = {}
+        self.attrs = {"seed": 0}
+        self.outputs = {"Out": np.asarray((123)).astype('int32')}
+
+    def test_check_output(self):
+        self.check_output(no_check_set=["Out"])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## 设计

Dropout目前的设计是产生一个伪随机数作为seed，在这个seed的初始下产生一系列随机的0和1（Mask）。

![image](https://user-images.githubusercontent.com/23031310/69336673-08c75700-0c9a-11ea-8828-12a27a7330ec.png)


它的缺点是每次compute这个recompute op，都要重新生成一遍seed，两个dropout op无法产生一样的mask，不能满足重计算要求。

对Recompute来说，我们要保证第二次重计算的时候Dropout产生相同的Mask, 必须使两个dropout op拥有一样的seed，对此可以通过添加seed op的方式实现。

![image](https://user-images.githubusercontent.com/23031310/69336685-0d8c0b00-0c9a-11ea-905b-92e1815d6277.png)

## 实验结果

