### PR TITLE
Fix sync_bn grad maker

### DIFF
--- a/paddle/fluid/operators/sync_batch_norm_op.cc
+++ b/paddle/fluid/operators/sync_batch_norm_op.cc
@@ -17,7 +17,7 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 template <typename T>
-class BatchNormGradMaker : public framework::SingleGradOpMaker<T> {
+class SyncBatchNormGradMaker : public framework::SingleGradOpMaker<T> {
  public:
   using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
 
@@ -55,6 +55,6 @@ class BatchNormGradMaker : public framework::SingleGradOpMaker<T> {
 namespace ops = paddle::operators;
 REGISTER_OPERATOR(sync_batch_norm, ops::BatchNormOp, ops::BatchNormOpMaker,
                   ops::BatchNormOpInferVarType,
-                  ops::BatchNormGradMaker<paddle::framework::OpDesc>,
-                  ops::BatchNormGradMaker<paddle::imperative::OpBase>);
+                  ops::SyncBatchNormGradMaker<paddle::framework::OpDesc>,
+                  ops::SyncBatchNormGradMaker<paddle::imperative::OpBase>);
 REGISTER_OPERATOR(sync_batch_norm_grad, ops::BatchNormGradOp);


### PR DESCRIPTION
`BatchNormGradMaker` is defined twice in `batch_norm_op.cc` and `sync_batch_norm_op.cc` respectively, which would make gcc link error. This PR fixes it.