### PR TITLE
cherry pick error info check of Print_op for release1.6

### DIFF
--- a/python/paddle/fluid/data_feeder.py
+++ b/python/paddle/fluid/data_feeder.py
@@ -20,6 +20,7 @@ import os
 import six
 from six.moves import zip, range, xrange
 import multiprocessing
+import warnings
 
 from .framework import Variable, default_main_program, _current_expected_place
 from .framework import _cpu_num, _cuda_ids
@@ -62,6 +63,39 @@ def convert_dtype(dtype):
     raise ValueError(
         "dtype must be any of [bool, float16, float32, float64, int8, int16, "
         "int32, int64, uint8]")
+
+
+def check_type_and_dtype(input,
+                         input_name,
+                         expected_type,
+                         expected_dtype,
+                         op_name,
+                         extra_message=''):
+    check_type(input, input_name, expected_type, op_name, extra_message)
+    check_dtype(input.dtype, input_name, expected_dtype, op_name, extra_message)
+
+
+def check_type(input, input_name, expected_type, op_name, extra_message=''):
+    if not isinstance(input, expected_type):
+        raise TypeError(
+            "The type of '%s' in %s must be %s, but received %s. %s" %
+            (input_name, op_name, expected_type, type(input), extra_message))
+
+
+def check_dtype(input_dtype,
+                input_name,
+                expected_dtype,
+                op_name,
+                extra_message=''):
+    if convert_dtype(input_dtype) in ['float16']:
+        warnings.warn(
+            "The data type of '%s' in %s only support float16 in GPU now. %s" %
+            (input_name, op_name, extra_message))
+    if convert_dtype(input_dtype) not in expected_dtype:
+        raise TypeError(
+            "The data type of '%s' in %s must be %s, but received %s. %s" %
+            (input_name, op_name, expected_dtype, convert_dtype(input_dtype),
+             extra_message))
 
 
 class DataToLoDTensorConverter(object):
@@ -352,15 +386,13 @@ class DataFeeder(object):
         """
         if isinstance(self.place, core.CUDAPlace):
             places = [
-                core.CUDAPlace(i)
-                for i in six.moves.xrange(
-                    self._get_number_of_places_(num_places))
+                core.CUDAPlace(i) for i in
+                six.moves.xrange(self._get_number_of_places_(num_places))
             ]
         else:
             places = [
-                core.CPUPlace()
-                for _ in six.moves.xrange(
-                    self._get_number_of_places_(num_places))
+                core.CPUPlace() for _ in
+                six.moves.xrange(self._get_number_of_places_(num_places))
             ]
 
         if len(iterable) != len(places):

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -25,7 +25,8 @@ from .nn import logical_and, logical_not, logical_or
 import numpy
 import warnings
 import six
-from functools import reduce
+from functools import reduce, partial
+from ..data_feeder import convert_dtype, check_type_and_dtype
 
 __all__ = [
     'While', 'Switch', 'increment', 'array_write', 'create_array', 'less_than',
@@ -197,6 +198,10 @@ def Print(input,
                data: 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, 
                
     '''
+    check_type_and_dtype(input, 'input', Variable,
+                         ['float32', 'float64', 'int32_t', 'int64_t', 'bool'],
+                         'fluid.layers.Print')
+
     helper = LayerHelper('print' + "_" + input.name, **locals())
     output = helper.create_variable_for_type_inference(input.dtype)
     helper.append_op(

--- a/python/paddle/fluid/tests/unittests/test_print_op.py
+++ b/python/paddle/fluid/tests/unittests/test_print_op.py
@@ -24,6 +24,8 @@ from paddle.fluid.framework import switch_main_program
 from paddle.fluid.framework import Program
 import numpy as np
 from simple_nets import simple_fc_net, init_data
+from paddle.fluid import compiler, Program, program_guard
+from op_test import OpTest
 
 
 class TestPrintOpCPU(unittest.TestCase):
@@ -78,6 +80,18 @@ class TestPrintOpCPU(unittest.TestCase):
         outs = exe.run(feed={'x': self.x_tensor},
                        fetch_list=[loss],
                        return_numpy=False)
+
+
+class TestPrintOpError(OpTest):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            # The input type of Print_op must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([[-1]]), [[1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, fluid.layers.Print, x1)
+            # The input dtype of Print_op must be float32, float64, int32_t, int64_t or bool.
+            x2 = fluid.layers.data(name='x2', shape=[4], dtype="float16")
+            self.assertRaises(TypeError, fluid.layers.Print, x2)
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),


### PR DESCRIPTION
cherry-pick from PR #21250

为Print python api的输入input加类型检查：
- 检查类型是否为Variable
- 检查数据类型是否为float32, float64, int32_t, int64_t, bool
- 在单测中覆盖类型错误和数据类型错误两个异常情况
- 可手动运行示例，看下错误：
```
import paddle.fluid as fluid
import numpy as np
x1 = fluid.create_lod_tensor(np.array([[-1]]), [[1]], fluid.CPUPlace())
fluid.layers.Print(x1)
```
> TypeError: The type of 'input' in fluid.layers.Print must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>.

```
import paddle.fluid as fluid
x2 = fluid.layers.data(name='x2', shape=[4], dtype="float16")
fluid.layers.Print(x2)
```
> TypeError: The data type of 'input' in fluid.layers.Print must be ['float32', 'float64', 'int32_t', 'int64_t', 'bool'], but received float16.