### PR TITLE
fix the fill_constant op precious problem 

### DIFF
--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -80,25 +80,6 @@ struct ExtractAttribute<bool> {
 };
 
 template <>
-struct ExtractAttribute<std::string> {
-  explicit ExtractAttribute(const std::string& attr_name)
-      : attr_name_(attr_name) {}
-
-  std::string* operator()(Attribute& attr) const {
-    std::string* attr_value = nullptr;
-    try {
-      attr_value = &boost::get<std::string>(attr);
-    } catch (boost::bad_get& bad_get) {
-      PADDLE_THROW("Cannot get attribute %s by type string, its type is %s",
-                   attr_name_, paddle::platform::demangle(attr.type().name()));
-    }
-    return attr_value;
-  }
-
-  const std::string& attr_name_;
-};
-
-template <>
 struct ExtractAttribute<int64_t> {
   explicit ExtractAttribute(const std::string& attr_name)
       : attr_name_(attr_name) {}

--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -80,6 +80,25 @@ struct ExtractAttribute<bool> {
 };
 
 template <>
+struct ExtractAttribute<std::string> {
+  explicit ExtractAttribute(const std::string& attr_name)
+      : attr_name_(attr_name) {}
+
+  std::string* operator()(Attribute& attr) const {
+    std::string* attr_value = nullptr;
+    try {
+      attr_value = &boost::get<std::string>(attr);
+    } catch (boost::bad_get& bad_get) {
+      PADDLE_THROW("Cannot get attribute %s by type string, its type is %s",
+                   attr_name_, paddle::platform::demangle(attr.type().name()));
+    }
+    return attr_value;
+  }
+
+  const std::string& attr_name_;
+};
+
+template <>
 struct ExtractAttribute<int64_t> {
   explicit ExtractAttribute(const std::string& attr_name)
       : attr_name_(attr_name) {}

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -90,8 +90,12 @@ class FillConstantOpMaker : public framework::OpProtoAndCheckerMaker {
              "The shape of the element in vector must be [1].")
         .AsDuplicable()
         .AsDispensable();
-    AddAttr<float>("value", "(float, default 0) The value to be filled")
+    AddAttr<float>("value", "(float, default 0.0f) The value to be filled")
         .SetDefault(0.0f);
+    AddAttr<std::string>(
+        "str_value",
+        "(string, default empty) The str convert to value to be filled")
+        .SetDefault("");
     AddAttr<bool>("force_cpu",
                   "(bool, default false) Force fill output variable to cpu "
                   "memory. Otherwise, fill output variable to the running "

--- a/paddle/fluid/operators/fill_constant_op.h
+++ b/paddle/fluid/operators/fill_constant_op.h
@@ -14,8 +14,9 @@ limitations under the License. */
 
 #pragma once
 
+#include <sstream>
+#include <string>
 #include <vector>
-
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/math/math_function.h"
@@ -75,13 +76,28 @@ class FillConstantKernel : public framework::OpKernel<T> {
   void Compute(const paddle::framework::ExecutionContext &ctx) const override {
     auto data_type =
         static_cast<framework::proto::VarType::Type>(ctx.Attr<int>("dtype"));
-    auto value = ctx.Attr<float>("value");
+    auto str_value = ctx.Attr<std::string>("str_value");
+    auto float_value = ctx.Attr<float>("value");
     auto force_cpu = ctx.Attr<bool>("force_cpu");
-
     framework::Tensor *tensor = nullptr;
 
     framework::Variable *out_var = ctx.OutputVar("Out");
 
+    T value;
+    if (str_value.empty()) {
+      value = static_cast<T>(float_value);
+    } else {
+      std::stringstream convert_stream(str_value);
+      if (std::is_same<int64_t, T>::value) {
+        int64_t tmp_value;
+        convert_stream >> tmp_value;
+        value = static_cast<T>(tmp_value);
+      } else {
+        double tmp_value;
+        convert_stream >> tmp_value;
+        value = static_cast<T>(tmp_value);
+      }
+    }
     auto shape = GetShape(ctx);
 
     if (out_var->IsType<framework::LoDTensor>()) {
@@ -96,15 +112,22 @@ class FillConstantKernel : public framework::OpKernel<T> {
           "supports SelectedRows and LoDTensor");
     }
 
-    if (force_cpu) {
-      tensor->mutable_data(platform::CPUPlace(), data_type);
-    } else {
-      tensor->mutable_data(ctx.GetPlace(), data_type);
-    }
-
     platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(ctx.GetPlace());
-    math::set_constant(dev_ctx, tensor, value);
+    if (force_cpu || ctx.GetPlace() == platform::CPUPlace()) {
+      tensor->mutable_data(platform::CPUPlace(), data_type);
+      math::SetConstant<platform::CPUDeviceContext, T> functor;
+      functor(reinterpret_cast<const platform::CPUDeviceContext &>(dev_ctx),
+              tensor, static_cast<T>(value));
+    }
+#ifdef PADDLE_WITH_CUDA
+    if (ctx.GetPlace() == platform::CUDAPlace()) {
+      tensor->mutable_data(platform::CUDAPlace(), data_type);
+      math::SetConstant<platform::CUDADeviceContext, T> functor;
+      functor(reinterpret_cast<const platform::CUDADeviceContext &>(dev_ctx),
+              tensor, static_cast<T>(value));
+    }
+#endif
   }
 };
 }  // namespace operators

--- a/paddle/fluid/operators/fill_constant_op.h
+++ b/paddle/fluid/operators/fill_constant_op.h
@@ -114,15 +114,16 @@ class FillConstantKernel : public framework::OpKernel<T> {
 
     platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(ctx.GetPlace());
-    if (force_cpu || ctx.GetPlace() == platform::CPUPlace()) {
+    bool cpu_place = force_cpu || ctx.GetPlace() == platform::CPUPlace();
+    if (cpu_place) {
       tensor->mutable_data(platform::CPUPlace(), data_type);
       math::SetConstant<platform::CPUDeviceContext, T> functor;
       functor(reinterpret_cast<const platform::CPUDeviceContext &>(dev_ctx),
               tensor, static_cast<T>(value));
     }
 #ifdef PADDLE_WITH_CUDA
-    if (ctx.GetPlace() == platform::CUDAPlace()) {
-      tensor->mutable_data(platform::CUDAPlace(), data_type);
+    if (!cpu_place) {
+      tensor->mutable_data(ctx.GetPlace(), data_type);
       math::SetConstant<platform::CUDADeviceContext, T> functor;
       functor(reinterpret_cast<const platform::CUDADeviceContext &>(dev_ctx),
               tensor, static_cast<T>(value));

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -547,7 +547,10 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
                 'fill_constant')
     check_type(shape, 'shape', (Variable, list, tuple), 'fill_constant')
     inputs = {}
-    attrs = {'force_cpu': force_cpu or force_init_on_cpu()}
+    attrs = {
+        'value': float(value),
+        'force_cpu': force_cpu or force_init_on_cpu()
+    }
 
     if convert_dtype(dtype) in ['int64', 'int32']:
         attrs['str_value'] = str(int(value))

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -547,10 +547,12 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
                 'fill_constant')
     check_type(shape, 'shape', (Variable, list, tuple), 'fill_constant')
     inputs = {}
-    attrs = {
-        'value': float(value),
-        'force_cpu': force_cpu or force_init_on_cpu()
-    }
+    attrs = {'force_cpu': force_cpu or force_init_on_cpu()}
+
+    if convert_dtype(dtype) in ['int64', 'int32']:
+        attrs['str_value'] = str(int(value))
+    else:
+        attrs['str_value'] = str(float(value))
 
     def _contain_var(one_list):
         for ele in one_list:


### PR DESCRIPTION
To solve https://github.com/PaddlePaddle/Paddle/issues/21113, we use the str to pass the value and  we need pay atttention to the use of math::set_constant, the  ``value`` parameter is float and it is fixed, so we discard the usage of math::set_constant in fill_constant OP .