### PR TITLE
fix Print_op input dtype list error test=develop

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -254,7 +254,7 @@ def Print(input,
                
     '''
     check_type_and_dtype(input, 'input', Variable,
-                         ['float32', 'float64', 'int32_t', 'int64_t', 'bool'],
+                         ['float32', 'float64', 'int32', 'int64', 'bool'],
                          'fluid.layers.Print')
 
     helper = LayerHelper('print' + "_" + input.name, **locals())


### PR DESCRIPTION
The data type should be int32 and int64, not  int32_t, int64_t 
related #21250