### PR TITLE
reduce the input size of interpolate unit test to pass CI

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
@@ -178,9 +178,9 @@ class TestBilinearInterpCase2(TestBilinearInterpOp):
 class TestBilinearInterpCase3(TestBilinearInterpOp):
     def init_test_case(self):
         self.interp_method = 'bilinear'
-        self.input_shape = [1, 1, 128, 64]
+        self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
-        self.out_w = 128
+        self.out_w = 32
         self.scale = 0.
         self.align_corners = True
         self.align_mode = 1
@@ -213,11 +213,11 @@ class TestBilinearInterpCase5(TestBilinearInterpOp):
 class TestBilinearInterpCase6(TestBilinearInterpOp):
     def init_test_case(self):
         self.interp_method = 'bilinear'
-        self.input_shape = [1, 1, 128, 64]
+        self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
-        self.out_w = 128
+        self.out_w = 32
         self.scale = 0.
-        self.out_size = np.array([65, 129]).astype("int32")
+        self.out_size = np.array([65, 33]).astype("int32")
         self.align_corners = True
         self.align_mode = 1
 
@@ -225,8 +225,8 @@ class TestBilinearInterpCase6(TestBilinearInterpOp):
 class TestBilinearInterpSame(TestBilinearInterpOp):
     def init_test_case(self):
         self.interp_method = 'bilinear'
-        self.input_shape = [2, 3, 128, 64]
-        self.out_h = 128
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 32
         self.out_w = 64
         self.scale = 0.
         self.align_corners = True
@@ -307,9 +307,9 @@ class TestBilinearInterpOpUint8(OpTest):
 class TestBilinearInterpCase1Uint8(TestBilinearInterpOpUint8):
     def init_test_case(self):
         self.interp_method = 'bilinear'
-        self.input_shape = [2, 3, 128, 64]
-        self.out_h = 120
-        self.out_w = 50
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 64
+        self.out_w = 32
         self.scale = 0.
         self.align_corners = True
         self.align_mode = 1

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -152,9 +152,9 @@ class TestNearestNeighborInterpCase2(TestNearestInterpOp):
 class TestNearestNeighborInterpCase3(TestNearestInterpOp):
     def init_test_case(self):
         self.interp_method = 'nearest'
-        self.input_shape = [1, 1, 128, 64]
+        self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
-        self.out_w = 128
+        self.out_w = 32
         self.scale = 0.
         self.align_corners = True
 
@@ -184,9 +184,9 @@ class TestNearestNeighborInterpCase5(TestNearestInterpOp):
 class TestNearestNeighborInterpCase6(TestNearestInterpOp):
     def init_test_case(self):
         self.interp_method = 'nearest'
-        self.input_shape = [1, 1, 128, 64]
+        self.input_shape = [1, 1, 32, 64]
         self.out_h = 64
-        self.out_w = 128
+        self.out_w = 32
         self.scale = 0.
         self.out_size = np.array([65, 129]).astype("int32")
         self.align_corners = True
@@ -195,8 +195,8 @@ class TestNearestNeighborInterpCase6(TestNearestInterpOp):
 class TestNearestNeighborInterpSame(TestNearestInterpOp):
     def init_test_case(self):
         self.interp_method = 'nearest'
-        self.input_shape = [2, 3, 128, 64]
-        self.out_h = 128
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 32
         self.out_w = 64
         self.scale = 0.
         self.align_corners = True
@@ -271,9 +271,9 @@ class TestNearestInterpOpUint8(OpTest):
 class TestNearestNeighborInterpCase1Uint8(TestNearestInterpOpUint8):
     def init_test_case(self):
         self.interp_method = 'nearest'
-        self.input_shape = [2, 3, 128, 64]
-        self.out_h = 120
-        self.out_w = 50
+        self.input_shape = [2, 3, 32, 64]
+        self.out_h = 80
+        self.out_w = 40
         self.scale = 0.
         self.align_corners = True
 

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
@@ -428,8 +428,8 @@ class TestTrilinearInterpScale2(TestTrilinearInterpOp):
     def init_test_case(self):
         self.interp_method = 'trilinear'
         self.input_shape = [2, 3, 5, 7, 9]
-        self.out_d = 82
-        self.out_h = 60
+        self.out_d = 60
+        self.out_h = 40
         self.out_w = 25
         self.scale = 1.
         self.align_corners = True
@@ -440,8 +440,8 @@ class TestTrilinearInterpScale3(TestTrilinearInterpOp):
     def init_test_case(self):
         self.interp_method = 'trilinear'
         self.input_shape = [2, 3, 5, 7, 9]
-        self.out_d = 82
-        self.out_h = 60
+        self.out_d = 60
+        self.out_h = 40
         self.out_w = 25
         self.scale = 1.5
         self.align_corners = True
@@ -452,8 +452,8 @@ class TestTrilinearInterpZero(TestTrilinearInterpOp):
     def init_test_case(self):
         self.interp_method = 'trilinear'
         self.input_shape = [2, 3, 5, 7, 11]
-        self.out_d = 82
-        self.out_h = 60
+        self.out_d = 60
+        self.out_h = 40
         self.out_w = 25
         self.scale = 0.2
         self.align_corners = False


### PR DESCRIPTION
- reduce the input size(128->32) of interpolate unit test to pass CI.