### PR TITLE
[Do not merge] fixed op test accuracy parameter (atol)

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -781,7 +781,7 @@ class OpTest(unittest.TestCase):
 
     def check_output_with_place(self,
                                 place,
-                                atol,
+                                atol=0,
                                 no_check_set=None,
                                 equal_nan=False,
                                 check_dygraph=True,
@@ -986,7 +986,7 @@ class OpTest(unittest.TestCase):
         return places
 
     def check_output(self,
-                     atol=1e-5,
+                     atol=0,
                      no_check_set=None,
                      equal_nan=False,
                      check_dygraph=True,


### PR DESCRIPTION
Fixed the default parameter value (atol) of the forward check output function (op_test.py).