### PR TITLE
support int type in interpolate op

### DIFF
--- a/paddle/fluid/operators/interpolate_op.cc
+++ b/paddle/fluid/operators/interpolate_op.cc
@@ -473,16 +473,22 @@ REGISTER_OPERATOR(trilinear_interp_grad, ops::InterpolateOpGrad,
                   ops::InterpolateGradNoNeedBufferVarsInference);
 REGISTER_OP_CPU_KERNEL(bilinear_interp, ops::InterpolateKernel<float>,
                        ops::InterpolateKernel<double>,
+                       ops::InterpolateKernel<int>,
                        ops::InterpolateKernel<uint8_t>);
 REGISTER_OP_CPU_KERNEL(bilinear_interp_grad, ops::InterpolateGradKernel<float>,
-                       ops::InterpolateGradKernel<double>);
+                       ops::InterpolateGradKernel<double>)
+, ops::InterpolateGradKernel<int>;
 REGISTER_OP_CPU_KERNEL(nearest_interp, ops::InterpolateKernel<float>,
                        ops::InterpolateKernel<double>,
-                       ops::InterpolateKernel<uint8_t>);
+                       ops::InterpolateKernel<uint8_t>)
+, ops::InterpolateKernel<int>;
 REGISTER_OP_CPU_KERNEL(nearest_interp_grad, ops::InterpolateGradKernel<float>,
-                       ops::InterpolateGradKernel<double>);
+                       ops::InterpolateGradKernel<double>)
+, ops::InterpolateGradKernel<int>;
 REGISTER_OP_CPU_KERNEL(trilinear_interp, ops::InterpolateKernel<float>,
                        ops::InterpolateKernel<double>,
+                       ops::InterpolateKernel<int>,
                        ops::InterpolateKernel<uint8_t>);
 REGISTER_OP_CPU_KERNEL(trilinear_interp_grad, ops::InterpolateGradKernel<float>,
-                       ops::InterpolateGradKernel<double>);
+                       ops::InterpolateGradKernel<double>)
+, ops::InterpolateGradKernel<int>;

--- a/paddle/fluid/operators/interpolate_op.cc
+++ b/paddle/fluid/operators/interpolate_op.cc
@@ -476,19 +476,19 @@ REGISTER_OP_CPU_KERNEL(bilinear_interp, ops::InterpolateKernel<float>,
                        ops::InterpolateKernel<int>,
                        ops::InterpolateKernel<uint8_t>);
 REGISTER_OP_CPU_KERNEL(bilinear_interp_grad, ops::InterpolateGradKernel<float>,
-                       ops::InterpolateGradKernel<double>)
-, ops::InterpolateGradKernel<int>;
+                       ops::InterpolateGradKernel<double>,
+                       ops::InterpolateGradKernel<int>);
 REGISTER_OP_CPU_KERNEL(nearest_interp, ops::InterpolateKernel<float>,
                        ops::InterpolateKernel<double>,
-                       ops::InterpolateKernel<uint8_t>)
-, ops::InterpolateKernel<int>;
+                       ops::InterpolateKernel<uint8_t>,
+                       ops::InterpolateKernel<int>);
 REGISTER_OP_CPU_KERNEL(nearest_interp_grad, ops::InterpolateGradKernel<float>,
-                       ops::InterpolateGradKernel<double>)
-, ops::InterpolateGradKernel<int>;
+                       ops::InterpolateGradKernel<double>,
+                       ops::InterpolateGradKernel<int>);
 REGISTER_OP_CPU_KERNEL(trilinear_interp, ops::InterpolateKernel<float>,
                        ops::InterpolateKernel<double>,
                        ops::InterpolateKernel<int>,
                        ops::InterpolateKernel<uint8_t>);
 REGISTER_OP_CPU_KERNEL(trilinear_interp_grad, ops::InterpolateGradKernel<float>,
-                       ops::InterpolateGradKernel<double>)
-, ops::InterpolateGradKernel<int>;
+                       ops::InterpolateGradKernel<double>,
+                       ops::InterpolateGradKernel<int>);

--- a/paddle/fluid/operators/interpolate_op.cu
+++ b/paddle/fluid/operators/interpolate_op.cu
@@ -952,7 +952,7 @@ REGISTER_OP_CUDA_KERNEL(bilinear_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
                         ops::InterpolateGradOpCUDAKernel<double>,
                         ops::InterpolateGradOpCUDAKernel<int>,
-                        ops::InterpolateOpCUDAKernel<uint8_t>);
+                        ops::InterpolateGradOpCUDAKernel<uint8_t>);
 REGISTER_OP_CUDA_KERNEL(nearest_interp, ops::InterpolateOpCUDAKernel<float>,
                         ops::InterpolateOpCUDAKernel<double>,
                         ops::InterpolateOpCUDAKernel<int>,
@@ -960,8 +960,8 @@ REGISTER_OP_CUDA_KERNEL(nearest_interp, ops::InterpolateOpCUDAKernel<float>,
 REGISTER_OP_CUDA_KERNEL(nearest_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
                         ops::InterpolateGradOpCUDAKernel<double>;
-                        ops::InterpolateOpCUDAKernel<uint8_t>,
-                        ops::InterpolateOpCUDAKernel<int>);
+                        ops::InterpolateGradOpCUDAKernel<uint8_t>,
+                        ops::InterpolateGradOpCUDAKernel<int>);
 REGISTER_OP_CUDA_KERNEL(trilinear_interp, ops::InterpolateOpCUDAKernel<float>,
                         ops::InterpolateOpCUDAKernel<double>,
                         ops::InterpolateOpCUDAKernel<int>,
@@ -970,4 +970,4 @@ REGISTER_OP_CUDA_KERNEL(trilinear_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
                         ops::InterpolateGradOpCUDAKernel<double>,
                         ops::InterpolateGradOpCUDAKernel<int>,
-                        ops::InterpolateOpCUDAKernel<uint8_t>);
+                        ops::InterpolateGradOpCUDAKernel<uint8_t>);

--- a/paddle/fluid/operators/interpolate_op.cu
+++ b/paddle/fluid/operators/interpolate_op.cu
@@ -946,19 +946,28 @@ class InterpolateGradOpCUDAKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(bilinear_interp, ops::InterpolateOpCUDAKernel<float>,
                         ops::InterpolateOpCUDAKernel<double>,
-                        ops::InterpolateOpCUDAKernel<int>);
+                        ops::InterpolateOpCUDAKernel<int>,
+                        ops::InterpolateOpCUDAKernel<uint8_t>);
 REGISTER_OP_CUDA_KERNEL(bilinear_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
-                        ops::InterpolateGradOpCUDAKernel<double>);
+                        ops::InterpolateGradOpCUDAKernel<double>,
+                        ops::InterpolateGradOpCUDAKernel<int>,
+                        ops::InterpolateOpCUDAKernel<uint8_t>);
 REGISTER_OP_CUDA_KERNEL(nearest_interp, ops::InterpolateOpCUDAKernel<float>,
                         ops::InterpolateOpCUDAKernel<double>,
-                        ops::InterpolateOpCUDAKernel<int>);
+                        ops::InterpolateOpCUDAKernel<int>,
+                        ops::InterpolateOpCUDAKernel<uint8_t>);
 REGISTER_OP_CUDA_KERNEL(nearest_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
-                        ops::InterpolateGradOpCUDAKernel<double>);
+                        ops::InterpolateGradOpCUDAKernel<double>;
+                        ops::InterpolateOpCUDAKernel<uint8_t>,
+                        ops::InterpolateOpCUDAKernel<int>);
 REGISTER_OP_CUDA_KERNEL(trilinear_interp, ops::InterpolateOpCUDAKernel<float>,
                         ops::InterpolateOpCUDAKernel<double>,
-                        ops::InterpolateOpCUDAKernel<int>);
+                        ops::InterpolateOpCUDAKernel<int>,
+                        ops::InterpolateOpCUDAKernel<uint8_t>);
 REGISTER_OP_CUDA_KERNEL(trilinear_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
-                        ops::InterpolateGradOpCUDAKernel<double>);
+                        ops::InterpolateGradOpCUDAKernel<double>,
+                        ops::InterpolateGradOpCUDAKernel<int>,
+                        ops::InterpolateOpCUDAKernel<uint8_t>);

--- a/paddle/fluid/operators/interpolate_op.cu
+++ b/paddle/fluid/operators/interpolate_op.cu
@@ -959,7 +959,7 @@ REGISTER_OP_CUDA_KERNEL(nearest_interp, ops::InterpolateOpCUDAKernel<float>,
                         ops::InterpolateOpCUDAKernel<uint8_t>);
 REGISTER_OP_CUDA_KERNEL(nearest_interp_grad,
                         ops::InterpolateGradOpCUDAKernel<float>,
-                        ops::InterpolateGradOpCUDAKernel<double>;
+                        ops::InterpolateGradOpCUDAKernel<double>,
                         ops::InterpolateGradOpCUDAKernel<uint8_t>,
                         ops::InterpolateGradOpCUDAKernel<int>);
 REGISTER_OP_CUDA_KERNEL(trilinear_interp, ops::InterpolateOpCUDAKernel<float>,


### PR DESCRIPTION
Refine the interpolate op
- support int type(int 32 and int64) when running on the CPU 
- support uint8 type when running on the GPU.