### PR TITLE
monitoring changes of unittest, delete one unittest will need approve

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -79,7 +79,7 @@ for API_FILE in ${API_FILES[*]}; do
   echo "checking ${API_FILE} change, PR: ${GIT_PR_ID}, changes: ${API_CHANGE}"
   if [ "${API_CHANGE}" ] && [ "${GIT_PR_ID}" != "" ]; then
       # NOTE: per_page=10000 should be ok for all cases, a PR review > 10000 is not human readable.q
-      # approval_user_list: XiaoguangHu01 46782768,Xreki 12538138,luotao1 6836917,sneaxiy 32832641,qingqing01 7845005,guoshengCS 14105589,heavengate 12605721,kuke 3064195,Superjomn 328693,lanxianghit 47554610,cyj1986 39645414,hutuxian 11195205,frankwhzhang 20274488,nepeplwu 45024560,Dianhai 38231817,JiabinYang 22361972,chenwhql 22561442,zhiqiu 6888866,seiriosPlus 5442383,gongweibao 10721757,saxon-zh 2870059,Boyan-Liu 2870059, Aurelius84 9301846, liym27 33742067, zhhsplendid 7913861.
+      # approval_user_list: XiaoguangHu01 46782768,Xreki 12538138,luotao1 6836917,sneaxiy 32832641,qingqing01 7845005,guoshengCS 14105589,heavengate 12605721,kuke 3064195,Superjomn 328693,lanxianghit 47554610,cyj1986 39645414,hutuxian 11195205,frankwhzhang 20274488,nepeplwu 45024560,Dianhai 38231817,JiabinYang 22361972,chenwhql 22561442,zhiqiu 6888866,seiriosPlus 5442383,gongweibao 10721757,saxon-zh 2870059,Boyan-Liu 2870059, zhouwei25 52485244, Aurelius84 9301846, liym27 33742067, zhhsplendid 7913861.
       if [ "${API_FILE}" == "paddle/fluid/op_use_default_grad_op_maker.spec" ];then
           echo_line="You must have one RD (sneaxiy (Recommend) or luotao1) approval for op_use_default_grad_op_maker.spec, which manages the grad_op memory optimization.\n"
           check_approval 1 32832641 6836917

--- a/tools/diff_unittest.py
+++ b/tools/diff_unittest.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+import difflib
+import sys
+
+with open(sys.argv[1], 'r') as f:
+    origin = f.read()
+    origin = origin.splitlines()
+
+with open(sys.argv[2], 'r') as f:
+    new = f.read()
+    new = new.splitlines()
+
+differ = difflib.Differ()
+result = differ.compare(origin, new)
+
+error = False
+diffs = []
+for each_diff in result:
+    if each_diff[0] == '-':  # delete unit test is not allowed
+        error = True
+        diffs.append(each_diff)
+'''
+If you delete the unit test, such as commenting it out, 
+please ask for approval of one RD below for passing CI:
+
+    - XiaoguangHu01 or luotao1 or phlrain or lanxianghit or zhouwei25
+'''
+if error:
+    print('Deleted Unit test is: ')
+    for each_diff in diffs:
+        print(each_diff)


### PR DESCRIPTION
- Monitoring changes of unittest, delete one unittest will need approve.

- Unit tests are often commented out, but this is not allowed. In the new ci monitoring, if the number of unit tests is reduced, the review of the designated RD will be required.

- The unit tests that are commented out will be displayed.