### PR TITLE
fix the profiling bug test=develop

### DIFF
--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -498,7 +498,7 @@ void ParseEvents(const std::vector<std::vector<Event>> &events,
             event_idx[event_name] = event_items.size();
             EventItem event_item = {event_name, 1,          event_time,
                                     event_time, event_time, event_time,
-                                    gpu_time,   cpu_time,   0.};
+                                    cpu_time,   gpu_time,   0.};
             event_items.push_back(event_item);
           } else {
             int index = event_idx[event_name];


### PR DESCRIPTION
profiling wrong initilization make the cpu time and gpu time is wrong 
origin code
```
 EventItem event_item = {event_name, 1,          event_time,
                                    event_time, event_time, event_time,
                                    gpu_time,   cpu_time,   0.};
```


![image](https://user-images.githubusercontent.com/13411999/69694767-df348280-1114-11ea-9fa6-b0369f04dfa4.png)


It is not correspond to the defination