### PR TITLE
Add Lod information for gather_nd & scatter_nd

### DIFF
--- a/paddle/fluid/operators/gather_nd_op.cc
+++ b/paddle/fluid/operators/gather_nd_op.cc
@@ -55,6 +55,7 @@ class GatherNdOp : public framework::OperatorWithKernel {
     }
 
     ctx->SetOutputDim("Out", framework::make_ddim(result_dims));
+    ctx->ShareLoD("X", /*->*/ "Out");
   }
 
  protected:

--- a/paddle/fluid/operators/scatter_nd_add_op.cc
+++ b/paddle/fluid/operators/scatter_nd_add_op.cc
@@ -64,6 +64,7 @@ class ScatterNdAddOp : public framework::OperatorWithKernel {
                         "Updates has wrong shape");
     }
     ctx->SetOutputDim("Out", ref_dims);
+    ctx->ShareLoD("X", /*->*/ "Out");
   }
 
  protected:

--- a/paddle/fluid/operators/scatter_nd_add_op.cc
+++ b/paddle/fluid/operators/scatter_nd_add_op.cc
@@ -86,12 +86,10 @@ class ScatterNdAddGradOp : public framework::OperatorWithKernel {
     if (ctx->HasOutput(framework::GradVarName("Updates"))) {
       ctx->SetOutputDim(framework::GradVarName("Updates"),
                         ctx->GetInputDim("Updates"));
-      ctx->ShareLoD("Updates", /*-->*/ framework::GradVarName("Updates"));
     }
     if (ctx->HasOutput(framework::GradVarName("X"))) {
       ctx->SetOutputDim(framework::GradVarName("X"),
                         ctx->GetInputDim(framework::GradVarName("Out")));
-      ctx->ShareLoD("Out", /*-->*/ framework::GradVarName("X"));
     }
   }
 

--- a/paddle/fluid/operators/scatter_nd_add_op.cc
+++ b/paddle/fluid/operators/scatter_nd_add_op.cc
@@ -91,7 +91,7 @@ class ScatterNdAddGradOp : public framework::OperatorWithKernel {
     if (ctx->HasOutput(framework::GradVarName("X"))) {
       ctx->SetOutputDim(framework::GradVarName("X"),
                         ctx->GetInputDim(framework::GradVarName("Out")));
-      ctx->ShareLoD("X", /*-->*/ framework::GradVarName("Out"));
+      ctx->ShareLoD("Out", /*-->*/ framework::GradVarName("X"));
     }
   }
 

--- a/paddle/fluid/operators/scatter_nd_add_op.cc
+++ b/paddle/fluid/operators/scatter_nd_add_op.cc
@@ -86,10 +86,12 @@ class ScatterNdAddGradOp : public framework::OperatorWithKernel {
     if (ctx->HasOutput(framework::GradVarName("Updates"))) {
       ctx->SetOutputDim(framework::GradVarName("Updates"),
                         ctx->GetInputDim("Updates"));
+      ctx->ShareLoD("Updates", /*-->*/ framework::GradVarName("Updates"));
     }
     if (ctx->HasOutput(framework::GradVarName("X"))) {
       ctx->SetOutputDim(framework::GradVarName("X"),
                         ctx->GetInputDim(framework::GradVarName("Out")));
+      ctx->ShareLoD("X", /*-->*/ framework::GradVarName("Out"));
     }
   }
 


### PR DESCRIPTION
Both `gather_nd` and `scatter_nd` don't save Lod information. When `LoDTensor` is input, they obtain the `Tensor` without Lod.
Issue: https://github.com/PaddlePaddle/Paddle/issues/21369