### PR TITLE
Fix transpose conv

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -503,6 +503,7 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
       flags.push_back(flag);
       flags.push_back("--selected_gpus=" +
                       std::to_string(config.gpu_device_id()));
+      flags.push_back("--cudnn_deterministic=True");
       VLOG(3) << "set flag: " << flag;
       framework::InitGflags(flags);
     }

--- a/paddle/fluid/operators/conv_transpose_cudnn_op.cu
+++ b/paddle/fluid/operators/conv_transpose_cudnn_op.cu
@@ -243,7 +243,7 @@ class CUDNNConvTransposeOpKernel : public framework::OpKernel<T> {
         cudnn_output_desc, CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
         workspace_size_limit, &algo));
 
-    if (algo == 0) {
+    if (algo == 0 && FLAGS_cudnn_deterministic) {
       algo = static_cast<cudnnConvolutionBwdDataAlgo_t>(1);
     }
 

--- a/paddle/fluid/operators/conv_transpose_cudnn_op.cu
+++ b/paddle/fluid/operators/conv_transpose_cudnn_op.cu
@@ -243,6 +243,10 @@ class CUDNNConvTransposeOpKernel : public framework::OpKernel<T> {
         cudnn_output_desc, CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
         workspace_size_limit, &algo));
 
+    if (algo == 0) {
+      algo = static_cast<cudnnConvolutionBwdDataAlgo_t>(1);
+    }
+
     // get workspace size able to allocate
     CUDNN_ENFORCE(
         platform::dynload::cudnnGetConvolutionBackwardDataWorkspaceSize(


### PR DESCRIPTION
CUDNN_CONVOLUTION_BWD_DATA_ALGO_0  is not stable in compute transpose convolution, so if search algorithm find CUDNN_CONVOLUTION_BWD_DATA_ALGO_0 as compute algorithm, change it to CUDNN_CONVOLUTION_BWD_DATA_ALGO_1 manully.

fix https://github.com/PaddlePaddle/Paddle/issues/21334