### PR TITLE
Eliminate the impact on incremental compilation,test=develop

### DIFF
--- a/cmake/external/mklml.cmake
+++ b/cmake/external/mklml.cmake
@@ -60,12 +60,10 @@ ExternalProject_Add(
     CONFIGURE_COMMAND     ""
     BUILD_COMMAND         ""
     UPDATE_COMMAND        ""
-    INSTALL_COMMAND       ""
+    INSTALL_COMMAND       ${CMAKE_COMMAND} -E copy_directory ${MKLML_SOURCE_DIR}/include ${MKLML_INC_DIR} &&
+			  ${CMAKE_COMMAND} -E copy_directory ${MKLML_SOURCE_DIR}/lib ${MKLML_LIB_DIR}
 )
 
-add_custom_command(TARGET ${MKLML_PROJECT} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${MKLML_SOURCE_DIR}/include ${MKLML_INC_DIR}
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${MKLML_SOURCE_DIR}/lib ${MKLML_LIB_DIR})
 
 INCLUDE_DIRECTORIES(${MKLML_INC_DIR})
 


### PR DESCRIPTION
The copy operation refreshes the time-stamp, so that make does not perform incremental compilation.

This PR fix that, and Incremental compilation will not be affected, and non-incremental compilation can also be accelerated through caching.
fix https://github.com/PaddlePaddle/Paddle/pull/21190#issuecomment-558668368