### PR TITLE
Add SelectedRows support for dygraph DebugString 

### DIFF
--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -140,6 +140,22 @@ static std::string DebugString(
         ss << "NOT_INITED";
       }
       ss << ">";
+    } else if (var.IsType<framework::SelectedRows>()) {
+      ss << "SelectedRows<";
+      auto& selected_rows = var.Get<framework::SelectedRows>();
+      auto& tensor = selected_rows.value();
+      auto& rows = selected_rows.rows();
+      if (tensor.IsInitialized()) {
+        ss << framework::DataTypeToString(tensor.type()) << ", ";
+        ss << tensor.place() << ", ";
+        ss << "height(" << selected_rows.height() << "), rows(";
+        std::for_each(rows.cbegin(), rows.cend(),
+                      [&ss](const int64_t r) { ss << r << " "; });
+        ss << "), dims(" << tensor.dims() << ")";
+      } else {
+        ss << "NOT_INITED";
+      }
+      ss << ">";
     } else {
       ss << "UNRESOLVED_TYPE";
     }

--- a/paddle/fluid/imperative/tests/test_layer.cc
+++ b/paddle/fluid/imperative/tests/test_layer.cc
@@ -61,7 +61,7 @@ std::string LayerDebugString(const std::string& op_type,
                              const NameVarBaseMap& ins,
                              const NameVarBaseMap& outs);
 
-TEST(test_layer, test_debug_string_test_debug_Test) {
+TEST(test_layer, test_debug_string) {
   platform::CPUPlace place;
   std::shared_ptr<imperative::VarBase> vin(
       new imperative::VarBase(false, "vin"));


### PR DESCRIPTION
DebugString interface is used in GLOG for printing log, This PR add SelectedRows parse code in DebugString for selected support work later.

original:

I1127 11:24:20.558859 29918 layer.cc:321] Op(lookup_table_grad): Inputs: Ids{_generated_var_0[LoDTensor<int64_t, CUDAPlace(0), (4, 3, 1)>]}, Out@GRAD{tmp_0@GRAD[LoDTensor<float, CUDAPlace(0), (4, 3, 10)>]}, W{simple_net/SimpleNet_0/Embedding_0.embedding_para[LoDTensor<NOT_INITED>]},   Outputs: W@GRAD{Gtmp@[UNRESOLVED_TYPE]}


new:

I1128 04:17:59.010835 26518 layer.cc:337] Op(lookup_table_grad): Inputs: Ids{_generated_var_0[LoDTensor<int64_t, CUDAPlace(0), (4, 3, 1)>]}, Out@GRAD{tmp_0@GRAD[LoDTensor<float, CUDAPlace(0), (4, 3, 10)>]}, W{simple_net/SimpleNet_0/Embedding_0.embedding_para[LoDTensor<NOT_INITED>]},   Outputs: W@GRAD{Gtmp@[SelectedRows<float, CUDAPlace(0), height(1000), rows(0 1 2 3 4 5 6 7 8 9 10 11 ), dims(12, 10)>]}
