### PR TITLE
add macro to ban windows

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -287,6 +287,11 @@ class TestDataNormOpWithSyncStats(OpTest):
     def test_sync_stats(self):
         if not core.is_compiled_with_cuda():
             return
+        if os.name == 'nt':
+            print(
+                'Skip TestDataNormOpWithSyncStats because nccl is not supported on windows'
+            )
+            return
         x = fluid.layers.data(name='x', shape=[1], dtype='int64', lod_level=0)
         emb = layers.embedding(
             input=x,


### PR DESCRIPTION
Since nccl cannot be used in windows, so we add macros to remove nccl related code in windows.