### PR TITLE
Add reshape int8 op

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1168,6 +1168,27 @@ PDNode *patterns::Transpose::operator()() {
   return transpose_out;
 }
 
+PDNode *patterns::Reshape::operator()() {
+  auto prev_op = pattern->NewNode(prev_op_repr())->assert_is_op();
+
+  auto reshape_op =
+      pattern->NewNode(reshape_op_repr())->assert_is_op("reshape2");
+
+  auto reshape_in = pattern->NewNode(reshape_in_repr())
+                        ->AsInput()
+                        ->assert_is_op_input("reshape2", "X");
+  auto reshape_out = pattern->NewNode(reshape_out_repr())
+                         ->AsOutput()
+                         ->assert_is_op_output("reshape2", "Out");
+
+  auto next_op = pattern->NewNode(next_op_repr())->assert_is_op();
+
+  prev_op->LinksTo({reshape_in});
+  reshape_op->LinksFrom({reshape_in}).LinksTo({reshape_out});
+  next_op->LinksFrom({reshape_out});
+  return reshape_out;
+}
+
 PDNode *patterns::ConvResidual::operator()(bool with_residual_data) {
   auto conv_op = pattern->NewNode(conv_op_repr())->assert_is_op("conv2d");
 

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -749,6 +749,21 @@ struct Transpose : public PatternBase {
   PATTERN_DECL_NODE(next_op);
 };
 
+// Reshape op
+// Forward pass for reshape.
+// reshape_out is a result of the operator.
+struct Reshape : public PatternBase {
+  Reshape(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "reshape2") {}
+
+  PDNode* operator()();
+  PATTERN_DECL_NODE(prev_op);
+  PATTERN_DECL_NODE(reshape_in);
+  PATTERN_DECL_NODE(reshape_op);
+  PATTERN_DECL_NODE(reshape_out);
+  PATTERN_DECL_NODE(next_op);
+};
+
 // Concat op
 // Forward pass for concat.
 // concat_out is a result of the operator.

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.h
@@ -56,6 +56,8 @@ class CPUQuantizePass : public FusePassBase {
 
   void QuantizeTranspose(Graph* graph) const;
 
+  void QuantizeReshape(Graph* graph) const;
+
   void QuantizeInput(Graph* g, Node* op, Node* input, std::string input_name,
                      double scale_to_one, bool is_unsigned,
                      std::string scale_attr_name = "") const;

--- a/paddle/fluid/inference/api/mkldnn_quantizer_config.cc
+++ b/paddle/fluid/inference/api/mkldnn_quantizer_config.cc
@@ -42,6 +42,12 @@ MkldnnQuantizerConfig::MkldnnQuantizerConfig() {
   rules_["fc"]["W"] = ScaleAlgo::MAX_CH_T;
   rules_["fc"]["Bias"] = ScaleAlgo::NONE;
   rules_["fc"]["Out"] = ScaleAlgo::KL;
+
+  rules_["reshape2"]["X"] = ScaleAlgo::KL;
+  rules_["reshape2"]["Shape"] = ScaleAlgo::NONE;
+  rules_["reshape2"]["ShapeTensor"] = ScaleAlgo::NONE;
+  rules_["reshape2"]["XShape"] = ScaleAlgo::NONE;
+  rules_["reshape2"]["Out"] = ScaleAlgo::NONE;
 }
 
 ScaleAlgo MkldnnQuantizerConfig::scale_algo(

--- a/paddle/fluid/inference/api/mkldnn_quantizer_config.cc
+++ b/paddle/fluid/inference/api/mkldnn_quantizer_config.cc
@@ -35,6 +35,8 @@ MkldnnQuantizerConfig::MkldnnQuantizerConfig() {
   rules_["prior_box"]["Boxes"] = ScaleAlgo::NONE;
   rules_["prior_box"]["Variances"] = ScaleAlgo::NONE;
 
+  // Transpose2 does not perform calculation on the data. Scale is calculated on
+  // input data and assign to Quantize and Dequantize scale.
   rules_["transpose2"]["X"] = ScaleAlgo::KL;
   rules_["transpose2"]["Out"] = ScaleAlgo::NONE;
 
@@ -43,6 +45,9 @@ MkldnnQuantizerConfig::MkldnnQuantizerConfig() {
   rules_["fc"]["Bias"] = ScaleAlgo::NONE;
   rules_["fc"]["Out"] = ScaleAlgo::KL;
 
+  // Reshape2 does not perform calculation on the data and shapes are not
+  // changed. Scale is calculated on input data and assign to Quantize and
+  // Dequantize scale.
   rules_["reshape2"]["X"] = ScaleAlgo::KL;
   rules_["reshape2"]["Shape"] = ScaleAlgo::NONE;
   rules_["reshape2"]["ShapeTensor"] = ScaleAlgo::NONE;

--- a/paddle/fluid/inference/tests/api/analyzer_int8_object_detection_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_int8_object_detection_tester.cc
@@ -269,7 +269,7 @@ TEST(Analyzer_int8_mobilenet_ssd, quantization) {
   q_cfg.EnableMkldnnQuantizer();
   q_cfg.mkldnn_quantizer_config();
   std::unordered_set<std::string> quantize_operators(
-      {"conv2d", "depthwise_conv2d", "prior_box", "transpose2"});
+      {"conv2d", "depthwise_conv2d", "prior_box", "transpose2", "reshape2"});
   q_cfg.mkldnn_quantizer_config()->SetEnabledOpTypes(quantize_operators);
   q_cfg.mkldnn_quantizer_config()->SetWarmupData(warmup_data);
   q_cfg.mkldnn_quantizer_config()->SetWarmupBatchSize(FLAGS_warmup_batch_size);

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -245,6 +245,13 @@ class ReshapeOpMaker : public framework::OpProtoAndCheckerMaker {
         "It has the lowest priority compare with Input(Shape) and "
         " Input(ShapeTensor).")
         .SetDefault({});
+    /* int8 parameters */
+    AddAttr<bool>("use_quantizer",
+                  "(bool, default false) "
+                  "Set to true for operators that should be quantized and use "
+                  "int8 kernel. "
+                  "Only used on CPU.")
+        .SetDefault(false);
     AddComment(R"DOC(
 Reshape Operator.
 
@@ -553,9 +560,12 @@ REGISTER_OPERATOR(reshape_grad, ops::ReshapeGradOp,
 
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape, float, ops::ReshapeKernel, double,
                                ops::ReshapeKernel, int, ops::ReshapeKernel,
-                               int64_t, ops::ReshapeKernel);
+                               int8_t, ops::ReshapeKernel, uint8_t,
+                               ops::ReshapeKernel, int64_t, ops::ReshapeKernel);
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape_grad, float, ops::ReshapeGradKernel,
                                double, ops::ReshapeGradKernel, int,
+                               ops::ReshapeGradKernel, int8_t,
+                               ops::ReshapeGradKernel, uint8_t,
                                ops::ReshapeGradKernel, int64_t,
                                ops::ReshapeGradKernel);
 REGISTER_OPERATOR(reshape2, ops::Reshape2Op, ops::Reshape2OpMaker,
@@ -570,15 +580,20 @@ REGISTER_OPERATOR(reshape2_grad_grad, ops::Reshape2DoubleGradOp,
                   ops::ReshapeDoubleGradInplaceInToOut);
 
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape2, float, ops::ReshapeKernel, double,
-                               ops::ReshapeKernel, int, ops::ReshapeKernel,
-                               int64_t, ops::ReshapeKernel);
+                               ops::ReshapeKernel, int8_t, ops::ReshapeKernel,
+                               uint8_t, ops::ReshapeKernel, int,
+                               ops::ReshapeKernel, int64_t, ops::ReshapeKernel);
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape2_grad, float, ops::ReshapeGradKernel,
                                double, ops::ReshapeGradKernel, int,
+                               ops::ReshapeGradKernel, int8_t,
+                               ops::ReshapeGradKernel, uint8_t,
                                ops::ReshapeGradKernel, int64_t,
                                ops::ReshapeGradKernel);
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape2_grad_grad, float,
                                ops::ReshapeDoubleGradKernel, double,
                                ops::ReshapeDoubleGradKernel, int,
+                               ops::ReshapeDoubleGradKernel, int8_t,
+                               ops::ReshapeDoubleGradKernel, uint8_t,
                                ops::ReshapeDoubleGradKernel, int64_t,
                                ops::ReshapeDoubleGradKernel);
 

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -245,13 +245,6 @@ class ReshapeOpMaker : public framework::OpProtoAndCheckerMaker {
         "It has the lowest priority compare with Input(Shape) and "
         " Input(ShapeTensor).")
         .SetDefault({});
-    /* int8 parameters */
-    AddAttr<bool>("use_quantizer",
-                  "(bool, default false) "
-                  "Set to true for operators that should be quantized and use "
-                  "int8 kernel. "
-                  "Only used on CPU.")
-        .SetDefault(false);
     AddComment(R"DOC(
 Reshape Operator.
 
@@ -426,6 +419,13 @@ class Reshape2OpMaker : public ReshapeOpMaker {
               "XShape is just used to store the shape and lod of X, which will "
               "be used in FlattenGradOp.")
         .AsIntermediate();
+    /* int8 parameters */
+    AddAttr<bool>("use_quantizer",
+                  "(bool, default false) "
+                  "Set to true for operators that should be quantized and use "
+                  "int8 kernel. "
+                  "Used only on CPU.")
+        .SetDefault(false);
   }
 };
 
@@ -560,12 +560,9 @@ REGISTER_OPERATOR(reshape_grad, ops::ReshapeGradOp,
 
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape, float, ops::ReshapeKernel, double,
                                ops::ReshapeKernel, int, ops::ReshapeKernel,
-                               int8_t, ops::ReshapeKernel, uint8_t,
-                               ops::ReshapeKernel, int64_t, ops::ReshapeKernel);
+                               int64_t, ops::ReshapeKernel);
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape_grad, float, ops::ReshapeGradKernel,
                                double, ops::ReshapeGradKernel, int,
-                               ops::ReshapeGradKernel, int8_t,
-                               ops::ReshapeGradKernel, uint8_t,
                                ops::ReshapeGradKernel, int64_t,
                                ops::ReshapeGradKernel);
 REGISTER_OPERATOR(reshape2, ops::Reshape2Op, ops::Reshape2OpMaker,
@@ -585,15 +582,11 @@ REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape2, float, ops::ReshapeKernel, double,
                                ops::ReshapeKernel, int64_t, ops::ReshapeKernel);
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape2_grad, float, ops::ReshapeGradKernel,
                                double, ops::ReshapeGradKernel, int,
-                               ops::ReshapeGradKernel, int8_t,
-                               ops::ReshapeGradKernel, uint8_t,
                                ops::ReshapeGradKernel, int64_t,
                                ops::ReshapeGradKernel);
 REGISTER_OP_CPU_KERNEL_FUNCTOR(reshape2_grad_grad, float,
                                ops::ReshapeDoubleGradKernel, double,
                                ops::ReshapeDoubleGradKernel, int,
-                               ops::ReshapeDoubleGradKernel, int8_t,
-                               ops::ReshapeDoubleGradKernel, uint8_t,
                                ops::ReshapeDoubleGradKernel, int64_t,
                                ops::ReshapeDoubleGradKernel);
 

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -40,7 +40,6 @@ class TestReshapeOp(OpTest):
         self.infered_shape = (5, 10)
 
     def test_check_output(self):
-
         self.check_output(no_check_set=['XShape'])
 
     def test_check_grad(self):
@@ -183,6 +182,51 @@ class TestReshapeOpDimInfer2_attr_OnlyShape(TestReshapeOp_attr_OnlyShape):
         self.new_shape = (2, 0, 3, -1)
         self.infered_shape = (2, 2, 3, -1)
         self.shape = (2, 0, 3, -1)
+
+
+class TestReshapeInt8Op(OpTest):
+    def setUp(self):
+        self.init_data()
+        self.dtype = np.int8
+        self.op_type = "reshape2"
+        input = (
+            np.random.randint(0, 127, self.ori_shape) - 127).astype(self.dtype)
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(input)}
+        self.attrs = {'shape': self.new_shape}
+        self.outputs = {
+            "Out": self.inputs["X"].reshape(self.infered_shape),
+            'XShape': np.random.random(self.ori_shape).astype(np.float32)
+        }
+
+    def init_data(self):
+        self.ori_shape = (2, 2, 6)
+        self.new_shape = (2, 0, 3, -1)
+        self.infered_shape = (2, 2, 3, -1)
+
+    def test_check_output(self):
+        self.check_output(no_check_set=['XShape'])
+
+
+class TestReshapeUint8Op(OpTest):
+    def setUp(self):
+        self.init_data()
+        self.dtype = np.uint8
+        self.op_type = "reshape2"
+        input = np.random.randint(0, 127, self.ori_shape).astype(self.dtype)
+        self.inputs = {'X': input}
+        self.attrs = {'shape': self.new_shape}
+        self.outputs = {
+            "Out": self.inputs["X"].reshape(self.infered_shape),
+            'XShape': np.random.random(self.ori_shape).astype(np.float32)
+        }
+
+    def init_data(self):
+        self.ori_shape = (2, 2, 6)
+        self.new_shape = (2, 0, 3, -1)
+        self.infered_shape = (2, 2, 3, -1)
+
+    def test_check_output(self):
+        self.check_output(no_check_set=['XShape'])
 
 
 # Test python API

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -189,10 +189,15 @@ class TestReshapeInt8Op(OpTest):
     def setUp(self):
         self.init_dtype()
         self.init_data()
+        self.use_mkldnn = True
+        self._cpu_only = True
         self.op_type = "reshape2"
         input = np.random.randint(0, 127, self.ori_shape).astype(self.dtype)
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(input)}
-        self.attrs = {'shape': self.new_shape}
+        self.attrs = {
+            'shape': self.new_shape,
+            'use_mkldnn': self.use_mkldnn,
+        }
         self.outputs = {
             "Out": self.inputs["X"].reshape(self.infered_shape),
             'XShape': np.random.random(self.ori_shape).astype(np.float32)

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -184,13 +184,13 @@ class TestReshapeOpDimInfer2_attr_OnlyShape(TestReshapeOp_attr_OnlyShape):
         self.shape = (2, 0, 3, -1)
 
 
+# test int8 data type on CPU
 class TestReshapeInt8Op(OpTest):
     def setUp(self):
+        self.init_dtype()
         self.init_data()
-        self.dtype = np.int8
         self.op_type = "reshape2"
-        input = (
-            np.random.randint(0, 127, self.ori_shape) - 127).astype(self.dtype)
+        input = np.random.randint(0, 127, self.ori_shape).astype(self.dtype)
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(input)}
         self.attrs = {'shape': self.new_shape}
         self.outputs = {
@@ -198,35 +198,26 @@ class TestReshapeInt8Op(OpTest):
             'XShape': np.random.random(self.ori_shape).astype(np.float32)
         }
 
+    def init_dtype(self):
+        self.dtype = np.int8
+
     def init_data(self):
         self.ori_shape = (2, 2, 6)
         self.new_shape = (2, 0, 3, -1)
         self.infered_shape = (2, 2, 3, -1)
 
     def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
+        self.check_output_with_place(
+            fluid.core.CPUPlace(), atol=1e-5, no_check_set=['XShape'])
+
+    def test_check_grad(self):
+        pass
 
 
-class TestReshapeUint8Op(OpTest):
-    def setUp(self):
-        self.init_data()
+# test unt8 data type on CPU
+class TestReshapeUint8Op(TestReshapeInt8Op):
+    def init_dtype(self):
         self.dtype = np.uint8
-        self.op_type = "reshape2"
-        input = np.random.randint(0, 127, self.ori_shape).astype(self.dtype)
-        self.inputs = {'X': input}
-        self.attrs = {'shape': self.new_shape}
-        self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
-            'XShape': np.random.random(self.ori_shape).astype(np.float32)
-        }
-
-    def init_data(self):
-        self.ori_shape = (2, 2, 6)
-        self.new_shape = (2, 0, 3, -1)
-        self.infered_shape = (2, 2, 3, -1)
-
-    def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
 
 
 # Test python API


### PR DESCRIPTION
This PR enables quantization of reshape2 operator. Type int8 is not added in MLKDNN operator implementation, but in global implementation.  
Reshape and transpose ops are quantized only if previous operator or next operator is quantized. Thanks that we avoid situation where there is one int8 operators between two fp32 operators. 