### PR TITLE
Add explicit conversion to InferNoNeedBufferVarsFN

### DIFF
--- a/paddle/fluid/framework/no_need_buffer_vars_inference.h
+++ b/paddle/fluid/framework/no_need_buffer_vars_inference.h
@@ -114,7 +114,7 @@ class InferNoNeedBufferVarsFN {
     return (*inferer_)(ctx);
   }
 
-  inline operator bool() const { return inferer_ != nullptr; }
+  inline explicit operator bool() const { return inferer_ != nullptr; }
 
   inline bool operator!() const { return inferer_ == nullptr; }
 


### PR DESCRIPTION
To avoid `InferNoNeedBufferVarsFN` convert to bool implicitly.

For example, the following codes would work previously:
```
void fun(int a) {...}

InferNoNeedBufferVarsFN f;
fun(f); // f is converted to int implicitly.
```

After this PR, the implicit conversion is prohibited. The codes above would not be compiled right.
