### PR TITLE
fix cub/threadpool include_dir to match setup.py.in,test=develop

### DIFF
--- a/cmake/external/cub.cmake
+++ b/cmake/external/cub.cmake
@@ -23,7 +23,8 @@ cache_third_party(extern_cub
     TAG           ${CUB_TAG}
     DIR           ${CUB_PREFIX_DIR})
 
-include_directories(${CUB_SOURCE_DIR})
+SET(CUB_INCLUDE_DIR ${CUB_SOURCE_DIR})
+include_directories(${CUB_INCLUDE_DIR})
 
 ExternalProject_Add(
   extern_cub

--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -43,7 +43,7 @@ if(WITH_AMD_GPU)
         extern_eigen3
         ${EXTERNAL_PROJECT_LOG_ARGS}
         ${SHALLOW_CLONE}
-        "${DOWNLOAD_CMD}"
+        "${EIGEN_DOWNLOAD_CMD}"
         PREFIX          ${EIGEN_PREFIX_DIR}
         SOURCE_DIR      ${EIGEN_SOURCE_DIR}
         UPDATE_COMMAND    ""

--- a/cmake/external/mklml.cmake
+++ b/cmake/external/mklml.cmake
@@ -64,7 +64,6 @@ ExternalProject_Add(
 			  ${CMAKE_COMMAND} -E copy_directory ${MKLML_SOURCE_DIR}/lib ${MKLML_LIB_DIR}
 )
 
-
 INCLUDE_DIRECTORIES(${MKLML_INC_DIR})
 
 ADD_LIBRARY(mklml SHARED IMPORTED GLOBAL)

--- a/cmake/external/threadpool.cmake
+++ b/cmake/external/threadpool.cmake
@@ -15,17 +15,16 @@
 INCLUDE(ExternalProject)
 
 SET(THREADPOOL_PREFIX_DIR ${THIRD_PARTY_PATH}/threadpool)
-set(THREADPOOL_REPOSITORY https://github.com/progschj/ThreadPool.git)
-set(THREADPOOL_TAG        9a42ec1329f259a5f4881a291db1dcb8f2ad9040)
-
-INCLUDE_DIRECTORIES(${THREADPOOL_INCLUDE_DIR})
+SET(THREADPOOL_REPOSITORY https://github.com/progschj/ThreadPool.git)
+SET(THREADPOOL_TAG        9a42ec1329f259a5f4881a291db1dcb8f2ad9040)
 
 cache_third_party(extern_threadpool
     REPOSITORY   ${THREADPOOL_REPOSITORY}
     TAG          ${THREADPOOL_TAG}
     DIR          ${THREADPOOL_PREFIX_DIR})
 
-include_directories(${THREADPOOL_SOURCE_DIR})
+SET(THREADPOOL_INCLUDE_DIR ${THREADPOOL_SOURCE_DIR})
+INCLUDE_DIRECTORIES(${THREADPOOL_INCLUDE_DIR})
 
 ExternalProject_Add(
     extern_threadpool


### PR DESCRIPTION
THREADPOOL_INCLUDE_DIR has been used in file ### setup.py.in.

This PR add this variable.