### PR TITLE
Revert flags.cmake to fix compilation error on unbuntu 16 gcc5.4

### DIFF
--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -148,6 +148,7 @@ set(COMMON_FLAGS
     -Wno-unused-parameter
     -Wno-unused-function
     -Wno-error=literal-suffix
+    -Wno-error=sign-compare
     -Wno-error=unused-local-typedefs
     -Wno-error=parentheses-equality # Warnings in pybind11
     -Wno-error=ignored-attributes  # Warnings in Eigen, gcc 6.3
@@ -182,6 +183,7 @@ set(GPU_COMMON_FLAGS
     -Wdelete-non-virtual-dtor
     -Wno-unused-parameter
     -Wno-unused-function
+    -Wno-error=sign-compare
     -Wno-error=literal-suffix
     -Wno-error=unused-local-typedefs
     -Wno-error=unused-function  # Warnings in Numpy Header.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10721757/69838393-56415680-128e-11ea-9ceb-5402a7f94389.png)
