### PR TITLE
Expose fraction_of_cpu_memory_to_use to __init__.py

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -161,8 +161,9 @@ def __bootstrap__():
     sysstr = platform.system()
     read_env_flags = [
         'check_nan_inf', 'fast_check_nan_inf', 'benchmark',
-        'eager_delete_scope', 'initial_cpu_memory_in_mb', 'init_allocated_mem',
-        'paddle_num_threads', 'dist_threadpool_size', 'eager_delete_tensor_gb',
+        'eager_delete_scope', 'fraction_of_cpu_memory_to_use',
+        'initial_cpu_memory_in_mb', 'init_allocated_mem', 'paddle_num_threads',
+        'dist_threadpool_size', 'eager_delete_tensor_gb',
         'fast_eager_deletion_mode', 'memory_fraction_of_eager_deletion',
         'allocator_strategy', 'reader_queue_speed_test_mode',
         'print_sub_graph_dir', 'pe_profile_fname', 'inner_op_parallelism',


### PR DESCRIPTION
`FLAGS_fraction_of_cpu_memory_to_use` is a public FLAGS, but it is not added to `__init__.py`. So users cannot use this flag. This PR fixes the bug by adding `FLAGS_fraction_of_cpu_memory_to_use` to `__init__.py`.