### PR TITLE
fix PythonAPI test in Op unittest

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_compare_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_op.py
@@ -48,7 +48,7 @@ for _type_name in {'float32', 'float64', 'int32', 'int64'}:
     create_test_class('not_equal', _type_name, lambda _a, _b: _a != _b)
 
 
-class TestCompareOpError(op_test.OpTest):
+class TestCompareOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input x and y of compare_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_concat_op.py
@@ -150,7 +150,7 @@ create_test_fp16(TestConcatOp4)
 create_test_fp16(TestConcatOp5)
 
 
-class TestConcatOpError(OpTest):
+class TestConcatOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of concat_op should be list.
@@ -177,7 +177,7 @@ class TestConcatOpError(OpTest):
             self.assertRaises(TypeError, test_axis_type)
 
 
-class TestConcatAPI(OpTest):
+class TestConcatAPI(unittest.TestCase):
     def test_api(self):
         x_1 = fluid.data(shape=[None, 1, 4, 5], dtype='int32', name='x_1')
         fluid.layers.concat([x_1, x_1], 0)

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -1250,7 +1250,7 @@ create_test_cudnn_channel_last_fp16_class(
 
 
 # --------- test python API ---------------
-class TestConv2dAPI(OpTest):
+class TestConv2dAPI(unittest.TestCase):
     def test_api(self):
 
         input_NHWC = fluid.layers.data(
@@ -1326,7 +1326,7 @@ class TestConv2dAPI(OpTest):
             data_format="NCHW")
 
 
-class TestConv2dAPI_Error(OpTest):
+class TestConv2dAPI_Error(unittest.TestCase):
     def test_api(self):
         input = fluid.layers.data(
             name="input",

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -755,7 +755,7 @@ create_test_cudnn_channel_last_class(TestWith1x1_AsyPadding)
 
 
 # --------- test python API ---------------
-class TestConv3dAPI(OpTest):
+class TestConv3dAPI(unittest.TestCase):
     def test_api(self):
 
         input_NDHWC = fluid.layers.data(
@@ -831,7 +831,7 @@ class TestConv3dAPI(OpTest):
             data_format="NCDHW")
 
 
-class TestConv3dAPI_Error(OpTest):
+class TestConv3dAPI_Error(unittest.TestCase):
     def test_api(self):
         input = fluid.layers.data(
             name="input",

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -182,7 +182,7 @@ class TestFP16DropoutOp2(TestFP16DropoutOp):
         self.fix_seed = False
 
 
-class TestDropoutOpError(OpTest):
+class TestDropoutOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
 

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -356,7 +356,7 @@ class TestElementwiseAddOp_xsize_lessthan_ysize_add(TestElementwiseAddOp):
         self.axis = 2
 
 
-class TestElementwiseAddOpError(OpTest):
+class TestElementwiseAddOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # the input of elementwise_add must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_mul_op.py
@@ -220,7 +220,7 @@ class TestElementwiseMulOp_xsize_lessthan_ysize(ElementwiseMulOp):
         self.init_kernel_type()
 
 
-class TestElementwiseMulOpError(OpTest):
+class TestElementwiseMulOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # the input of elementwise_mul must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -190,7 +190,7 @@ class TestFillConstantOp1_ShapeTensor(OpTest):
 
 
 # Test python API
-class TestFillConstantAPI(OpTest):
+class TestFillConstantAPI(unittest.TestCase):
     def test_api(self):
         positive_2_int32 = fluid.layers.fill_constant([1], "int32", 2)
 
@@ -232,7 +232,7 @@ class TestFillConstantAPI(OpTest):
         assert np.array_equal(res_5, np.full([1, 2], 1.1, dtype="float32"))
 
 
-class TestFillConstantOpError(OpTest):
+class TestFillConstantOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             #for ci coverage

--- a/python/paddle/fluid/tests/unittests/test_gather_tree_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gather_tree_op.py
@@ -49,7 +49,7 @@ class TestGatherTreeOp(OpTest):
         return out
 
 
-class TestGatherTreeOpAPI(OpTest):
+class TestGatherTreeOpAPI(unittest.TestCase):
     def test_case(self):
         ids = fluid.layers.data(
             name='ids', shape=[5, 2, 2], dtype='int64', append_batch_size=False)

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -152,7 +152,7 @@ class TestLookupTableWithTensorIdsWIsSelectedRows(
             assert (row == result_array[idx]).all()
 
 
-class TestEmbedOpError(OpTest):
+class TestEmbedOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             input_data = np.random.randint(0, 10, (4, 1)).astype("int64")

--- a/python/paddle/fluid/tests/unittests/test_maxout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_maxout_op.py
@@ -64,7 +64,7 @@ class TestMaxOutOpAxis(TestMaxOutOp):
         self.axis = 3
 
 
-class TestMaxOutOpAxisAPI(OpTest):
+class TestMaxOutOpAxisAPI(unittest.TestCase):
     def test_axis(self):
         data1 = fluid.data(name='data1', shape=[3, 6, 2, 2], dtype='float32')
         data2 = fluid.data(name='data2', shape=[3, 2, 2, 6], dtype='float32')

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -40,7 +40,7 @@ class TestMeanOp(OpTest):
         self.check_grad(['X'], 'Out')
 
 
-class TestMeanOpError(OpTest):
+class TestMeanOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of mean_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -891,7 +891,7 @@ create_test_cudnn_padding_VALID_class(TestCase5_channel_last)
 
 
 #test API
-class TestPool3dAPI(OpTest):
+class TestPool3dAPI(unittest.TestCase):
     def test_api(self):
         x_NDHWC = np.random.random([2, 5, 5, 5, 3]).astype("float32")
         x_NCDHW = np.random.random([2, 3, 5, 5, 5]).astype("float32")
@@ -1076,7 +1076,7 @@ class TestPool3dAPI(OpTest):
             atol=1e-05)
 
 
-class TestPool3dAPI_Error(OpTest):
+class TestPool3dAPI_Error(unittest.TestCase):
     def test_api(self):
         input_NDHWC = fluid.layers.data(
             name="input_NDHWC",

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -481,7 +481,7 @@ class TestFP16_2(OpTest):
 
 
 # Test python API
-class TestSliceAPI(OpTest):
+class TestSliceAPI(unittest.TestCase):
     def test_1(self):
         input = np.random.random([3, 4, 5, 6]).astype("float32")
         minus_1 = fluid.layers.fill_constant([1], "int32", -1)

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -88,7 +88,7 @@ class TestSoftmaxOp(OpTest):
                 check_dygraph=(self.use_mkldnn == False))
 
 
-class TestSoftmaxOpError(OpTest):
+class TestSoftmaxOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of softmax_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_split_op.py
+++ b/python/paddle/fluid/tests/unittests/test_split_op.py
@@ -225,7 +225,7 @@ def create_test_fp16(parent):
 create_test_fp16(TestSplitOp)
 
 
-class TestSplitAPI(OpTest):
+class TestSplitAPI(unittest.TestCase):
     def test_api(self):
         input_1 = np.random.random([4, 5, 6]).astype("int32")
         positive_1_int32 = fluid.layers.fill_constant([1], "int32", 1)
@@ -259,7 +259,7 @@ class TestSplitAPI(OpTest):
         assert np.array_equal(res_5, out[2])
 
 
-class TestSplitOpError(OpTest):
+class TestSplitOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The type of axis in split_op should be int or Variable.

--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -70,7 +70,7 @@ class TestSqueezeOp3(TestSqueezeOp):
         self.new_shape = (3, 5, 1, 4)
 
 
-class TestSqueezeOpError(OpTest):
+class TestSqueezeOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of softmax_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
@@ -568,7 +568,7 @@ class TestTrilinearInterp_attr_tensor_Case3(TestTrilinearInterpOp_attr_tensor):
         self.scale_by_1Dtensor = True
 
 
-class TestTrilinearInterpAPI(OpTest):
+class TestTrilinearInterpAPI(unittest.TestCase):
     def test_case(self):
         x = fluid.data(name="x", shape=[2, 3, 6, 9, 4], dtype="float32")
         y = fluid.data(name="y", shape=[2, 6, 9, 4, 3], dtype="float32")
@@ -619,7 +619,7 @@ class TestTrilinearInterpAPI(OpTest):
             self.assertTrue(np.allclose(results[i + 1], expect_res))
 
 
-class TestTrilinearInterpOpException(OpTest):
+class TestTrilinearInterpOpException(unittest.TestCase):
     def test_exception(self):
         input = fluid.data(name="input", shape=[2, 3, 6, 9, 4], dtype="float32")
 

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
@@ -164,7 +164,7 @@ class TestUniformRandomOp(OpTest):
                 hist, prob, rtol=0, atol=0.01), "hist: " + str(hist))
 
 
-class TestUniformRandomOpError(OpTest):
+class TestUniformRandomOpError(unittest.TestCase):
     def test_errors(self):
         main_prog = Program()
         start_prog = Program()


### PR DESCRIPTION
There are PythonAPI tests in Op's unittest which don't need to inherit OpTest class.
This PR fixes the problem to avoid CI failure in check_grad checking.