### PR TITLE
fix: fail to call ZeroCopyTensor::mutable_data() when device_id != 0

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -41,7 +41,8 @@ void ZeroCopyTensor::Reshape(const std::vector<int> &shape) {
   auto *tensor = static_cast<framework::LoDTensor *>(tensor_);
 
 template <typename T>
-T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
+T *ZeroCopyTensor::mutable_data(PaddlePlace place, int device) {
+  SetPlace(place, device);
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_GT(
       tensor->numel(), 0,
@@ -52,7 +53,7 @@ T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
       return tensor->mutable_data<T>(platform::CPUPlace());
     }
     case static_cast<int>(PaddlePlace::kGPU): {
-      return tensor->mutable_data<T>(platform::CUDAPlace());
+      return tensor->mutable_data<T>(platform::CUDAPlace(device));
     }
     default:
       PADDLE_THROW("Unsupported place: %d", static_cast<int>(place));
@@ -161,10 +162,10 @@ template int32_t *ZeroCopyTensor::data<int32_t>(PaddlePlace *place,
                                                 int *size) const;
 template uint8_t *ZeroCopyTensor::data<uint8_t>(PaddlePlace *place,
                                                 int *size) const;
-template float *ZeroCopyTensor::mutable_data<float>(PaddlePlace place);
-template int64_t *ZeroCopyTensor::mutable_data<int64_t>(PaddlePlace place);
-template int32_t *ZeroCopyTensor::mutable_data<int32_t>(PaddlePlace place);
-template uint8_t *ZeroCopyTensor::mutable_data<uint8_t>(PaddlePlace place);
+template float *ZeroCopyTensor::mutable_data<float>(PaddlePlace place, int device);
+template int64_t *ZeroCopyTensor::mutable_data<int64_t>(PaddlePlace place, int device);
+template int32_t *ZeroCopyTensor::mutable_data<int32_t>(PaddlePlace place, int device);
+template uint8_t *ZeroCopyTensor::mutable_data<uint8_t>(PaddlePlace place, int device);
 
 void *ZeroCopyTensor::FindTensor() const {
   PADDLE_ENFORCE(!name_.empty(),

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -155,7 +155,17 @@ class ZeroCopyTensor {
    * This is for writing the input tensor.
    */
   template <typename T>
-  T* mutable_data(PaddlePlace place);
+  T* mutable_data(PaddlePlace place, int device);
+
+  template <typename T>
+  T* mutable_data(PaddlePlace place) {
+    return mutable_data<T>(place, device());
+  }
+
+  template <typename T>
+  T* mutable_data() {
+    return mutable_data<T>(place(), device());
+  }
   /** Get the memory directly, will return the place and element size by
    * pointer.
    * This is for reading the output tensor.
@@ -177,6 +187,12 @@ class ZeroCopyTensor {
   void SetPlace(PaddlePlace place, int device = -1) {
     place_ = place;
     device_ = device;
+  }
+  PaddlePlace place() const {
+      return place_;
+  }
+  int device() const {
+      return device_;
   }
 
   PaddleDType type() const;


### PR DESCRIPTION
allocator may check faild, because devide 0 is not initialized. 

Error: Paddle internal Check failed. (Please help us create a new issue, here we need to find the developer to add a user friendly error message)
  [Hint: Expected pos < devices_.size(), but received pos:1 >= devices_.size():1.] at (baidu/paddlepaddle/paddle/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc:128)