### PR TITLE
fix unit tests that do not need to inherit OpTest 

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_accuracy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_accuracy_op.py
@@ -58,7 +58,7 @@ class TestAccuracyOpFp16(TestAccuracyOp):
         self.check_output(atol=1e-3)
 
 
-class TestAccuracyOpError(OpTest):
+class TestAccuracyOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of accuracy_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -23,7 +23,7 @@ import paddle.fluid as fluid
 from paddle.fluid import compiler, Program, program_guard
 
 
-class TestSqrtOpError(OpTest):
+class TestSqrtOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of sqrt op must be Variable or numpy.ndarray.
@@ -537,7 +537,7 @@ class TestELU(TestActivation):
         self.check_grad(['X'], 'Out', max_relative_error=0.02)
 
 
-class TestELUOpError(OpTest):
+class TestELUOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of elu_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
@@ -484,7 +484,7 @@ class TestBilinearInterp_attr_tensor_Case3(TestBilinearInterpOp_attr_tensor):
         self.scale_by_1Dtensor = True
 
 
-class TestBilinearInterpOpAPI(OpTest):
+class TestBilinearInterpOpAPI(unittest.TestCase):
     def test_case(self):
         x = fluid.data(name="x", shape=[2, 3, 6, 6], dtype="float32")
 

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -70,7 +70,7 @@ class TestCastOp3(op_test.OpTest):
         self.check_output(atol=1e-3)
 
 
-class TestCastOpError(op_test.OpTest):
+class TestCastOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of cast_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -718,7 +718,7 @@ class TestDepthwiseConvTransposeAsymmetricPad_NHWC(TestConv2dTransposeOp):
         self.data_format = 'NHWC'
 
 
-class TestConv2dTransposeAPI(OpTest):
+class TestConv2dTransposeAPI(unittest.TestCase):
     def test_case1(self):
         data1 = fluid.layers.data(
             name='data1', shape=[3, 5, 5], dtype='float32')
@@ -796,7 +796,7 @@ class TestConv2dTransposeAPI(OpTest):
         self.assertIsNotNone(results[6])
 
 
-class TestConv2dTransposeOpException(OpTest):
+class TestConv2dTransposeOpException(unittest.TestCase):
     def test_exception(self):
         data = fluid.layers.data(name='data', shape=[3, 5, 5], dtype="float32")
 

--- a/python/paddle/fluid/tests/unittests/test_conv3d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_transpose_op.py
@@ -563,7 +563,7 @@ class TestCUDNNWithGroups_NHWC(TestWithGroups):
         self.op_type = "conv3d_transpose"
 
 
-class TestConv3dTransposeAPI(OpTest):
+class TestConv3dTransposeAPI(unittest.TestCase):
     def test_case1(self):
         data1 = fluid.layers.data(
             name='data1', shape=[3, 5, 5, 5], dtype='float32')
@@ -642,7 +642,7 @@ class TestConv3dTransposeAPI(OpTest):
         self.assertIsNotNone(results[6])
 
 
-class TestConv3dTransposeOpException(OpTest):
+class TestConv3dTransposeOpException(unittest.TestCase):
     def test_exception(self):
         data = fluid.layers.data(
             name='data', shape=[3, 5, 5, 5], dtype="float32")

--- a/python/paddle/fluid/tests/unittests/test_crop_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_crop_tensor_op.py
@@ -217,7 +217,7 @@ class TestCropTensorOpTensorAttrCase4(TestCropTensorOpTensorAttr):
         self.OffsetsTensor = True
 
 
-class TestCropTensorException(OpTest):
+class TestCropTensorException(unittest.TestCase):
     def test_exception(self):
         input1 = fluid.data(name="input1", shape=[2, 3, 6, 6], dtype="float32")
         input2 = fluid.data(name="input2", shape=[2, 3, 6, 6], dtype="float16")

--- a/python/paddle/fluid/tests/unittests/test_downpoursgd.py
+++ b/python/paddle/fluid/tests/unittests/test_downpoursgd.py
@@ -31,7 +31,7 @@ from google.protobuf import text_format
 import paddle.fluid.incubate.fleet.parameter_server.pslib.ps_pb2 as pslib
 
 
-class TestListenAndServOp(OpTest):
+class TestListenAndServOp(unittest.TestCase):
     """TestListenAndServOp."""
 
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_expand_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_op.py
@@ -193,7 +193,7 @@ class TestExpandOpInt64_t(OpTest):
         self.check_output()
 
 
-class TestExpandError(OpTest):
+class TestExpandError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             x1 = fluid.create_lod_tensor(
@@ -208,7 +208,7 @@ class TestExpandError(OpTest):
 
 
 # Test python API
-class TestExpandAPI(OpTest):
+class TestExpandAPI(unittest.TestCase):
     def test_api(self):
         input = np.random.random([12, 14]).astype("float32")
         x = fluid.layers.data(

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -131,7 +131,7 @@ class TestFCOpWithPadding(TestFCOp):
         self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
 
 
-class TestFCOpError(OpTest):
+class TestFCOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             input_data = np.random.random((2, 4)).astype("float32")

--- a/python/paddle/fluid/tests/unittests/test_fetch_var.py
+++ b/python/paddle/fluid/tests/unittests/test_fetch_var.py
@@ -21,7 +21,7 @@ import numpy
 import unittest
 
 
-class TestFetchVar(op_test.OpTest):
+class TestFetchVar(unittest.TestCase):
     def set_input(self):
         self.val = numpy.array([1, 3, 5]).astype(numpy.int32)
 

--- a/python/paddle/fluid/tests/unittests/test_fl_listen_and_serv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fl_listen_and_serv_op.py
@@ -91,7 +91,7 @@ def run_pserver(use_cuda, sync_mode, ip, port, trainers, trainer_id):
     exe.run(main_program)
 
 
-class TestFlListenAndServOp(OpTest):
+class TestFlListenAndServOp(unittest.TestCase):
     def setUp(self):
         self.ps_timeout = 5
         self.ip = "127.0.0.1"

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 import unittest
 import numpy as np
-import random
 
 from operator import mul
 import paddle.fluid.core as core
@@ -194,11 +193,7 @@ class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
         self.compare_between_place = True
 
 
-class TestGroupNormAPI_With_NHWC(unittest.TestCase):
-    def setUp(self):
-        np.random.seed(123)
-        random.seed(124)
-
+class TestGroupNormAPI_With_NHWC(OpTest):
     def test_case1(self):
         data1 = fluid.data(name='data1', shape=[None, 3, 3, 4], dtype='float32')
         out1 = fluid.layers.group_norm(

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -193,7 +193,7 @@ class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
         self.compare_between_place = True
 
 
-class TestGroupNormAPI_With_NHWC(OpTest):
+class TestGroupNormAPI_With_NHWC(unittest.TestCase):
     def test_case1(self):
         data1 = fluid.data(name='data1', shape=[None, 3, 3, 4], dtype='float32')
         out1 = fluid.layers.group_norm(
@@ -222,7 +222,7 @@ class TestGroupNormAPI_With_NHWC(OpTest):
         self.assertTrue(np.allclose(results[1], expect_res2[0]))
 
 
-class TestGroupNormException(OpTest):
+class TestGroupNormException(unittest.TestCase):
     # data_layout is not NHWC or NCHW
     def test_exception(self):
         data = fluid.data(name='data', shape=[None, 3, 3, 4], dtype="float32")

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import random
 
 from operator import mul
 import paddle.fluid.core as core
@@ -194,6 +195,10 @@ class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
 
 
 class TestGroupNormAPI_With_NHWC(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(123)
+        random.seed(124)
+
     def test_case1(self):
         data1 = fluid.data(name='data1', shape=[None, 3, 3, 4], dtype='float32')
         out1 = fluid.layers.group_norm(

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -214,7 +214,7 @@ class TestLookupTableApi(unittest.TestCase):
                       return_numpy=False)
 
 
-class TestEmbedOpError(OpTest):
+class TestEmbedOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             input_data = np.random.randint(0, 10, (4, 6)).astype("int64")

--- a/python/paddle/fluid/tests/unittests/test_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mul_op.py
@@ -51,7 +51,7 @@ class TestMulOp(OpTest):
             ['X'], 'Out', max_relative_error=0.5, no_grad_set=set('Y'))
 
 
-class TestMulOpError(OpTest):
+class TestMulOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of mul_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_one_hot_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_op.py
@@ -137,7 +137,7 @@ class TestOneHotOp_out_of_range(OpTest):
         self.check_output(check_dygraph=False)
 
 
-class TestOneHotOp_exception(OpTest):
+class TestOneHotOp_exception(unittest.TestCase):
     def setUp(self):
         self.op_type = 'one_hot'
         self.depth = 10

--- a/python/paddle/fluid/tests/unittests/test_one_hot_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_one_hot_v2_op.py
@@ -134,7 +134,7 @@ class TestOneHotOp_out_of_range(OpTest):
         self.check_output(check_dygraph=False)
 
 
-class TestOneHotOp_exception(OpTest):
+class TestOneHotOp_exception(unittest.TestCase):
     def setUp(self):
         self.op_type = 'one_hot_v2'
         self.depth = 10

--- a/python/paddle/fluid/tests/unittests/test_pool2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool2d_op.py
@@ -985,7 +985,7 @@ create_test_cudnn_padding_SAME_class(TestCase1_strides)
 
 
 # ----- test API
-class TestPool2dAPI(OpTest):
+class TestPool2dAPI(unittest.TestCase):
     def test_api(self):
         x_NHWC = np.random.random([2, 5, 5, 3]).astype("float32")
         x_NCHW = np.random.random([2, 3, 5, 5]).astype("float32")
@@ -1204,7 +1204,7 @@ class TestPool2dAPI(OpTest):
                 data_format="NHWC"))
 
 
-class TestPool2dAPI_Error(OpTest):
+class TestPool2dAPI_Error(unittest.TestCase):
     def test_api(self):
         input_NHWC = fluid.layers.data(
             name="input_NHWC",

--- a/python/paddle/fluid/tests/unittests/test_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reduce_op.py
@@ -414,7 +414,7 @@ class Test1DReduceWithAxes1(OpTest):
         self.check_grad(['X'], 'Out')
 
 
-class TestReduceSumOpError(OpTest):
+class TestReduceSumOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of reduce_sum_op must be Variable.
@@ -426,7 +426,7 @@ class TestReduceSumOpError(OpTest):
             self.assertRaises(TypeError, fluid.layers.reduce_sum, x2)
 
 
-class TestReduceMeanOpError(OpTest):
+class TestReduceMeanOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of reduce_mean_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -186,7 +186,7 @@ class TestReshapeOpDimInfer2_attr_OnlyShape(TestReshapeOp_attr_OnlyShape):
 
 
 # Test python API
-class TestReshapeAPI(OpTest):
+class TestReshapeAPI(unittest.TestCase):
     # situation 1: have shape( list, no tensor), no actual shape(Tensor)
     def test_1(self):
         input = np.random.random([2, 25]).astype("float32")
@@ -227,7 +227,7 @@ class TestReshapeAPI(OpTest):
 
 
 # Test Input Error
-class TestReshapeOpError(OpTest):
+class TestReshapeOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The x type of reshape_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_runtime_and_compiletime_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_runtime_and_compiletime_exception.py
@@ -21,7 +21,7 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 
 
-class TestRunTimeException(OpTest):
+class TestRunTimeException(unittest.TestCase):
     def test_run_time_exception(self):
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)
@@ -39,7 +39,7 @@ class TestRunTimeException(OpTest):
         self.assertRaises(core.EnforceNotMet, _run_program)
 
 
-class TestCompileTimeException(OpTest):
+class TestCompileTimeException(unittest.TestCase):
     def test_compile_time_exception(self):
         self.assertRaises(core.EnforceNotMet, self.build_model)
 

--- a/python/paddle/fluid/tests/unittests/test_scatter_nd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scatter_nd_op.py
@@ -158,7 +158,7 @@ class TestScatterNdAddWithHighRankDiff(OpTest):
 
 
 #Test Python API
-class TestScatterNdOpAPI(OpTest):
+class TestScatterNdOpAPI(unittest.TestCase):
     """
     test scatter_nd_add api and scatter_nd api
     """
@@ -231,7 +231,7 @@ class TestScatterNdOpAPI(OpTest):
 
 
 #Test Raise Error
-class TestScatterNdOpRaise(OpTest):
+class TestScatterNdOpRaise(unittest.TestCase):
     def test_check_raise(self):
         def check_raise_is_test():
             try:

--- a/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
@@ -438,7 +438,7 @@ class TestStridedSliceOp_strides_Tensor(OpTest):
 
 
 # Test python API
-class TestStridedSliceAPI(OpTest):
+class TestStridedSliceAPI(unittest.TestCase):
     def test_1(self):
         input = np.random.random([3, 4, 5, 6]).astype("float32")
         minus_1 = fluid.layers.fill_constant([1], "int32", -1)


### PR DESCRIPTION
There are unit tests that don't need to inherit OpTest class.
This PR fixes the problem to avoid CI failure in check_grad checking.

related with: [PR21455](https://github.com/PaddlePaddle/Paddle/pull/21455)