### PR TITLE
fix: fail to call ZeroCopyTensor::mutable_data() when device_id is no…

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -52,7 +52,7 @@ T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
       return tensor->mutable_data<T>(platform::CPUPlace());
     }
     case static_cast<int>(PaddlePlace::kGPU): {
-      return tensor->mutable_data<T>(platform::CUDAPlace());
+      return tensor->mutable_data<T>(platform::CUDAPlace(device_));
     }
     default:
       PADDLE_THROW("Unsupported place: %d", static_cast<int>(place));

--- a/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
@@ -51,6 +51,7 @@ TEST(ZeroCopyTensor, uint8) {
   input_t->Reshape({batch_size, length});
   input_t->copy_from_cpu(input);
   input_t->type();
+  input_t->mutable_data<uint8_t>(PaddlePlace::kGPU);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 }


### PR DESCRIPTION
allocator may check faild, because devide 0 is not initialized.

Error: Paddle internal Check failed. (Please help us create a new issue, here we need to find the developer to add a user friendly error message)
[Hint: Expected pos < devices_.size(), but received pos:1 >= devices_.size():1.] at (baidu/paddlepaddle/paddle/paddle/fluid/memory/allocation/naive_best_fit_allocator.cc:128)