### PR TITLE
fix PythonAPI test in Op unittest

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
@@ -551,7 +551,7 @@ class TestBatchNormOpFreezeStatsAndScaleBiasTraining(
         self.fetch_list = ['y', 'mean', 'variance', 'x@GRAD']
 
 
-class TestBatchNormOpError(OpTest):
+class TestBatchNormOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # the input of batch_norm must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -103,7 +103,7 @@ class TestExpandAsOpRank4(OpTest):
 
 
 # Test python API
-class TestExpandAPI(OpTest):
+class TestExpandAPI(unittest.TestCase):
     def test_api(self):
         input1 = np.random.random([12, 14]).astype("float32")
         input2 = np.random.random([48, 14]).astype("float32")

--- a/python/paddle/fluid/tests/unittests/test_gather_nd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gather_nd_op.py
@@ -128,7 +128,7 @@ class TestGatherNdOpWithHighRankDiff(OpTest):
 
 
 #Test Python API
-class TestGatherNdOpAPI(OpTest):
+class TestGatherNdOpAPI(unittest.TestCase):
     def test_case1(self):
         x1 = fluid.layers.data(
             name='x1', shape=[30, 40, 50, 60], dtype='float32')
@@ -147,7 +147,7 @@ class TestGatherNdOpAPI(OpTest):
 
 
 #Test Raise Index Error
-class TestGatherNdOpRaise(OpTest):
+class TestGatherNdOpRaise(unittest.TestCase):
     def test_check_raise(self):
         def check_raise_is_test():
             try:

--- a/python/paddle/fluid/tests/unittests/test_locality_aware_nms_op.py
+++ b/python/paddle/fluid/tests/unittests/test_locality_aware_nms_op.py
@@ -307,7 +307,7 @@ class TestLocalAwareNMSOp4Points(OpTest):
         self.check_output()
 
 
-class TestLocalityAwareNMSAPI(OpTest):
+class TestLocalityAwareNMSAPI(unittest.TestCase):
     def test_api(self):
         boxes = fluid.data(name='bboxes', shape=[None, 81, 8], dtype='float32')
         scores = fluid.data(name='scores', shape=[None, 1, 81], dtype='float32')

--- a/python/paddle/fluid/tests/unittests/test_lrn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lrn_op.py
@@ -106,7 +106,7 @@ class TestLRNOpAttrDataFormat(TestLRNOp):
         self.data_format = 'NHWC'
 
 
-class TestLRNAPI(OpTest):
+class TestLRNAPI(unittest.TestCase):
     def test_case(self):
         data1 = fluid.data(name='data1', shape=[2, 4, 5, 5], dtype='float32')
         data2 = fluid.data(name='data2', shape=[2, 5, 5, 4], dtype='float32')

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -423,7 +423,7 @@ class TestNearestInterp_attr_tensor_Case3(TestNearestInterpOp_attr_tensor):
         self.scale_by_1Dtensor = True
 
 
-class TestNearestAPI(OpTest):
+class TestNearestAPI(unittest.TestCase):
     def test_case(self):
         x = fluid.data(name="x", shape=[2, 3, 6, 6], dtype="float32")
         y = fluid.data(name="y", shape=[2, 6, 6, 3], dtype="float32")
@@ -474,7 +474,7 @@ class TestNearestAPI(OpTest):
             self.assertTrue(np.allclose(results[i + 1], expect_res))
 
 
-class TestNearestInterpException(OpTest):
+class TestNearestInterpException(unittest.TestCase):
     def test_exception(self):
         input = fluid.data(name="input", shape=[1, 3, 6, 6], dtype="float32")
 

--- a/python/paddle/fluid/tests/unittests/test_print_op.py
+++ b/python/paddle/fluid/tests/unittests/test_print_op.py
@@ -82,7 +82,7 @@ class TestPrintOpCPU(unittest.TestCase):
                        return_numpy=False)
 
 
-class TestPrintOpError(OpTest):
+class TestPrintOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input type of Print_op must be Variable.

--- a/python/paddle/fluid/tests/unittests/test_unsqueeze2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unsqueeze2_op.py
@@ -203,7 +203,7 @@ class TestUnsqueezeOp4_AxesTensor(TestUnsqueezeOp_AxesTensor):
 
 
 # test api
-class TestUnsqueezeAPI(OpTest):
+class TestUnsqueezeAPI(unittest.TestCase):
     def test_api(self):
         input = np.random.random([3, 2, 5]).astype("float32")
         x = fluid.data(name='x', shape=[3, 2, 5], dtype="float32")

--- a/python/paddle/fluid/tests/unittests/test_zeros_op.py
+++ b/python/paddle/fluid/tests/unittests/test_zeros_op.py
@@ -24,7 +24,7 @@ import paddle.fluid as fluid
 from paddle.fluid import compiler, Program, program_guard
 
 
-class TestZerosOpError(OpTest):
+class TestZerosOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
             # The input dtype of zeros_op must be bool, float16, float32, float64, int32, int64.


### PR DESCRIPTION
There are PythonAPI tests in Op's unittest which don't need to inherit OpTest class.
This PR fixes the problem to avoid CI failure in check_grad checking.

related with: [PR21455](https://github.com/PaddlePaddle/Paddle/pull/21455)、[PR21460](https://github.com/PaddlePaddle/Paddle/pull/21460)