### PR TITLE
Update sentiment.py

### DIFF
--- a/python/paddle/dataset/sentiment.py
+++ b/python/paddle/dataset/sentiment.py
@@ -25,7 +25,7 @@ from __future__ import print_function
 import six
 import collections
 from itertools import chain
-
+from functools import cmp_to_key
 import nltk
 from nltk.corpus import movie_reviews
 
@@ -68,7 +68,7 @@ def get_word_dict():
             for words in movie_reviews.words(field):
                 word_freq_dict[words] += 1
     words_sort_list = list(six.iteritems(word_freq_dict))
-    words_sort_list.sort(cmp=lambda a, b: b[1] - a[1])
+    words_sort_list.sort(key=cmp_to_key(lambda a, b: b[1] - a[1]))
     for index, word in enumerate(words_sort_list):
         words_freq_sorted.append((word[0], index))
     return words_freq_sorted


### PR DESCRIPTION
solve TypeError: 'cmp' in Python3 . The functools.cmp_to_key() utility is available to convert a 2.x style cmp function to a key function