### PR TITLE
Revert the ProgOptimUnsupported check, test=release/1.6

### DIFF
--- a/paddle/fluid/framework/op_compatible_info.h
+++ b/paddle/fluid/framework/op_compatible_info.h
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include <map>
-#include <memory>
 #include <string>
 #include "paddle/fluid/framework/program_desc.h"
 
@@ -70,10 +69,6 @@ class OpCompatibleMap {
   std::map<std::string, CompatibleInfo> op_compatible_map_;
   std::string default_required_version_;
 };
-
-// Determine if the model contains operators that the optimization cannot
-// support.
-bool ProgOptimUnsupported(std::shared_ptr<framework::ProgramDesc> program);
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -458,14 +458,6 @@ void AnalysisPredictor::PrepareArgument() {
 
 // NOTE All the members in AnalysisConfig should be copied to Argument.
 void AnalysisPredictor::OptimizeInferenceProgram() {
-  if (ProgOptimUnsupported(inference_program_)) {
-    LOG(INFO) << "NOTICE: Your inference model contains parameters such "
-                 "as asymmetric padding, and ir optimization is temporarily "
-                 "not supported, "
-                 "so it is turned off.";
-    config_.SwitchIrOptim(false);
-    argument_.SetEnableAnalysisOptim(false);
-  }
   PrepareArgument();
   Analyzer().Run(&argument_);
 


### PR DESCRIPTION
因算子兼容性问题已解决，所以在 1.6.2 版本撤销 #20969。