### PR TITLE
Fix synchronization problem in softmax_with_cross_entropy_op cuda kernel

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -200,6 +200,10 @@ static __global__ void RowReductionForDiffMaxSum(const T* logits_data,
     softmax[beg_idx] -= diff_max_sum;
     beg_idx += step;
   }
+
+  // Note(zhiqiu): since different threads may use max_data[blockIdx.x] to
+  // calculate diff_max_sum, __syncthreads() is needed here.
+  __syncthreads();
   if (threadIdx.x == 0) max_data[blockIdx.x] = 0;
 }
 


### PR DESCRIPTION
Original cuda kernel of softmax_with_cross_entropy op may produce wrong results when
(1) soft_label = False, (2) numeric_stable_mode = True, (3) axis_dim is large, (eg, axis_dim > 1000).

This PR fixes that problem by adding necessary synchronization in `RowReductionForDiffMaxSum`.
