### PR TITLE
Fix CI DefaultGradOpMaker check

### DIFF
--- a/paddle/fluid/op_use_default_grad_op_maker.spec
+++ b/paddle/fluid/op_use_default_grad_op_maker.spec
@@ -1,17 +1,13 @@
 cos_sim
-flatten
 fsp
 gru
-lrn
 lstm_unit
 match_matrix_tensor
 max_pool2d_with_index
 max_pool3d_with_index
 maxout
-nce
 pool2d
 pool3d
-prelu
 reduce_max
 reduce_min
 reduce_prod
@@ -19,9 +15,6 @@ reshape
 rnn_memory_helper
 sequence_softmax
 spp
-squeeze
 tensor_array_to_tensor
 transpose
-unpool
 unsqueeze
-var_conv_2d

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -496,14 +496,9 @@ function generate_api_spec() {
     fi   
 
     # TODO(paddle-dev): remove op_use_default_grad_op_maker.spec 
-    # Currently, we only check in PR_CI python 2.7
-    if [ "spec_kind" == "PR" ]; then
-        if [ "$SYSTEM" != "Darwin" ]; then
-            if [ "$1" == "" ] || [ "$1" == "cp27-cp27m" ] || [ "$1" == "cp27-cp27mu" ]; then
-                python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py \
-                    ${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_op_maker.spec
-            fi
-        fi
+    if [ "$spec_kind" == "PR" ]; then
+        python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py \
+            ${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_op_maker.spec
     fi
     deactivate
 }


### PR DESCRIPTION
CI does not check `DefaultGradOpMaker` any more because of some bugs in `paddle_build.sh`. This PR fixes it.