### PR TITLE
Add Warning Message When Initialize GLOG Failed.

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -47,6 +47,7 @@ namespace framework {
 
 std::once_flag gflags_init_flag;
 std::once_flag p2p_init_flag;
+std::once_flag glog_warning_once_flag;
 
 void InitGflags(std::vector<std::string> argv) {
   std::call_once(gflags_init_flag, [&]() {
@@ -202,6 +203,15 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
 void SignalHandle(const char *data, int size) {
   auto file_path = string::Sprintf("/tmp/paddle.%d.dump_info", ::getpid());
   try {
+    // The signal is coming line by line but we print general guide just once
+    std::call_once(glog_warning_once_flag, [&]() {
+      LOG(WARNING) << "Initialize GLOG failed, PaddlePaddle may not be able to "
+                      "print GLOG\n";
+      LOG(WARNING) << "You could check whether you killed GLOG initialize "
+                      "process or PaddlePaddle process accidentally\n";
+      LOG(WARNING) << "The detail failure signal is:\n\n";
+    });
+
     LOG(WARNING) << std::string(data, size);
     std::ofstream dump_info;
     dump_info.open(file_path, std::ios::app);


### PR DESCRIPTION
As the title, add warning message when initialize GLOG failed. The failure message will be like:

![image](https://user-images.githubusercontent.com/7913861/69953832-fddfb280-1534-11ea-9d33-d0193c3d16b2.png)
