### PR TITLE
Add _use_system_allocator to some op tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_batch_norm_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_batch_norm_mkldnn_op.py
@@ -19,10 +19,12 @@ import numpy as np
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest, _set_use_system_allocator
 from paddle.fluid.framework import grad_var_name
 from paddle.fluid.tests.unittests.test_batch_norm_op import TestBatchNormOpInference, TestBatchNormOpTraining, _reference_training, _reference_grad
 from mkldnn_op_test import check_if_mkldnn_batchnorm_primitives_exist_in_bwd
+
+_set_use_system_allocator(True)
 
 
 class TestMKLDNNBatchNormOpTraining(TestBatchNormOpTraining):

--- a/python/paddle/fluid/tests/unittests/ngraph/test_batch_norm_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_batch_norm_ngraph_op.py
@@ -16,6 +16,9 @@ from __future__ import print_function
 
 import unittest
 from paddle.fluid.tests.unittests.test_batch_norm_op import TestBatchNormOpTraining, TestBatchNormOpInference
+from paddle.fluid.tests.unittests.op_test import _set_use_system_allocator
+
+_set_use_system_allocator(True)
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
@@ -20,10 +20,12 @@ import numpy as np
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-from op_test import OpTest
+from op_test import OpTest, _set_use_system_allocator
 from paddle.fluid.framework import grad_var_name
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
+
+_set_use_system_allocator(True)
 
 
 def _reference_testing(x, scale, offset, mean, var, epsilon, data_format):

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -20,8 +20,11 @@ from operator import mul
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from functools import reduce
+from op_test import _set_use_system_allocator
 
 np.random.random(123)
+
+_set_use_system_allocator(True)
 
 
 def _reference_layer_norm_naive(x, scale, beta, epsilon, begin_norm_axis=1):

--- a/python/paddle/fluid/tests/unittests/test_sync_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sync_batch_norm_op.py
@@ -26,7 +26,9 @@ import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid import compiler
 
-from op_test import OpTest
+from op_test import OpTest, _set_use_system_allocator
+
+_set_use_system_allocator(True)
 
 
 def create_or_get_tensor(scope, var_name, var, place):


### PR DESCRIPTION
Add `_use_system_allocator(True)` in some op tests that do not use `OpTest` framework.