### PR TITLE
Add Branch to avoid CPU profiler warning print

### DIFF
--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -471,7 +471,10 @@ void ParseEvents(const std::vector<std::vector<Event>> &events,
 
         if (rit != pushed_events.rend()) {
           double event_time = 0;
-          double gpu_time = rit->CudaElapsedMs((*analyze_events)[i][j]);
+          double gpu_time = 0.0f;
+#ifdef PADDLE_WITH_CUDA
+          gpu_time = rit->CudaElapsedMs((*analyze_events)[i][j]);
+#endif
           double cpu_time = rit->CpuElapsedMs((*analyze_events)[i][j]);
           if (g_state == ProfilerState::kCUDA) {
             event_time = gpu_time;

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -86,7 +86,6 @@ double Event::CudaElapsedMs(const Event &e) const {
 #ifdef PADDLE_WITH_CUPTI
   return gpu_ns_ / 1000000.0;
 #else
-  LOG_FIRST_N(WARNING, 1) << "CUDA CUPTI is not enabled";
   return 0;
 #endif
 }

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -86,6 +86,7 @@ double Event::CudaElapsedMs(const Event &e) const {
 #ifdef PADDLE_WITH_CUPTI
   return gpu_ns_ / 1000000.0;
 #else
+  LOG_FIRST_N(WARNING, 1) << "CUDA CUPTI is not enabled";
   return 0;
 #endif
 }


### PR DESCRIPTION
如果使用CPU编译的whl包，并在CPU模式下进行profiler，会出现CUPTI相关的错误。但CPU上本身就不需要装CUPTI，出现的warning会让用户很费解。

![image](https://user-images.githubusercontent.com/6836917/70203636-84c0a500-1758-11ea-9941-c5ad443e296c.png)
