### PR TITLE
add `no_need_buffer_slots` interface to pybind

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1074,7 +1074,7 @@ All parameter, weight, gradient are variables in Paddle.
                      std::vector<float>, std::vector<std::string>, bool,
                      std::vector<bool>, BlockDesc *, int64_t,
                      std::vector<BlockDesc *>, std::vector<int64_t>>;
-  m.def("no_need_buffer_slots",
+  m.def("_no_need_buffer_slots",
         [](const std::string op_type,
            const std::map<std::string, std::vector<std::string>> &inputs,
            const std::map<std::string, std::vector<std::string>> &outputs,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1069,7 +1069,19 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("has_infer_inplace", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });
-
+  m.def("no_need_buffer_slots", [](const std::string op_type,
+                                   const framework::VariableNameMap &inputs,
+                                   const framework::VariableNameMap &outputs,
+                                   const framework::AttributeMap &attrs) {
+    auto infer_func =
+        framework::OpInfoMap::Instance().Get(op_type).NoNeedBufferVarsInferer();
+    if (infer_func) {
+      return infer_func(inputs, outputs, attrs);
+    } else {
+      std::unordered_set<std::string> empty = {};
+      return empty;
+    }
+  });
   m.def("prune", [](const ProgramDesc &origin,
                     const std::set<std::string> &feeded_var_names,
                     const std::vector<std::array<size_t, 2>> &targets) {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1074,7 +1074,7 @@ All parameter, weight, gradient are variables in Paddle.
         [](const std::string op_type,
            const std::map<std::string, std::vector<std::string>> &inputs,
            const std::map<std::string, std::vector<std::string>> &outputs,
-           const framework::AttributeMap &attr) {
+           const framework::AttributeMap &attrs) {
           auto infer_func = framework::OpInfoMap::Instance()
                                 .Get(op_type)
                                 .NoNeedBufferVarsInferer();

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -65,6 +65,7 @@ limitations under the License. */
 #include "paddle/fluid/pybind/imperative.h"
 #include "paddle/fluid/pybind/inference_api.h"
 #include "paddle/fluid/pybind/ir.h"
+#include "paddle/fluid/pybind/pybind_boost_headers.h"
 
 #ifndef _WIN32
 #include "paddle/fluid/pybind/nccl_wrapper_py.h"
@@ -1069,16 +1070,11 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("has_infer_inplace", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });
-  using Attribute =
-      boost::variant<boost::blank, int, float, std::string, std::vector<int>,
-                     std::vector<float>, std::vector<std::string>, bool,
-                     std::vector<bool>, BlockDesc *, int64_t,
-                     std::vector<BlockDesc *>, std::vector<int64_t>>;
   m.def("_no_need_buffer_slots",
         [](const std::string op_type,
            const std::map<std::string, std::vector<std::string>> &inputs,
            const std::map<std::string, std::vector<std::string>> &outputs,
-           const std::unordered_map<std::string, Attribute> &attrs) {
+           const framework::AttributeMap &attr) {
           auto infer_func = framework::OpInfoMap::Instance()
                                 .Get(op_type)
                                 .NoNeedBufferVarsInferer();

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1069,19 +1069,26 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("has_infer_inplace", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });
-  m.def("no_need_buffer_slots", [](const std::string op_type,
-                                   const framework::VariableNameMap &inputs,
-                                   const framework::VariableNameMap &outputs,
-                                   const framework::AttributeMap &attrs) {
-    auto infer_func =
-        framework::OpInfoMap::Instance().Get(op_type).NoNeedBufferVarsInferer();
-    if (infer_func) {
-      return infer_func(inputs, outputs, attrs);
-    } else {
-      std::unordered_set<std::string> empty = {};
-      return empty;
-    }
-  });
+  using Attribute =
+      boost::variant<boost::blank, int, float, std::string, std::vector<int>,
+                     std::vector<float>, std::vector<std::string>, bool,
+                     std::vector<bool>, BlockDesc *, int64_t,
+                     std::vector<BlockDesc *>, std::vector<int64_t>>;
+  m.def("no_need_buffer_slots",
+        [](const std::string op_type,
+           const std::map<std::string, std::vector<std::string>> &inputs,
+           const std::map<std::string, std::vector<std::string>> &outputs,
+           const std::unordered_map<std::string, Attribute> &attrs) {
+          auto infer_func = framework::OpInfoMap::Instance()
+                                .Get(op_type)
+                                .NoNeedBufferVarsInferer();
+          if (infer_func) {
+            return infer_func(inputs, outputs, attrs);
+          } else {
+            std::unordered_set<std::string> empty = {};
+            return empty;
+          }
+        });
   m.def("prune", [](const ProgramDesc &origin,
                     const std::set<std::string> &feeded_var_names,
                     const std::vector<std::array<size_t, 2>> &targets) {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1070,7 +1070,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("has_infer_inplace", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });
-  m.def("_no_need_buffer_slots",
+  m.def("infer_no_need_buffer_slots",
         [](const std::string op_type,
            const std::map<std::string, std::vector<std::string>> &inputs,
            const std::map<std::string, std::vector<std::string>> &outputs,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1071,9 +1071,8 @@ All parameter, weight, gradient are variables in Paddle.
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });
   m.def("infer_no_need_buffer_slots",
-        [](const std::string op_type,
-           const std::map<std::string, std::vector<std::string>> &inputs,
-           const std::map<std::string, std::vector<std::string>> &outputs,
+        [](const std::string op_type, const framework::VariableNameMap &inputs,
+           const framework::VariableNameMap &outputs,
            const framework::AttributeMap &attrs) {
           auto infer_func = framework::OpInfoMap::Instance()
                                 .Get(op_type)

--- a/python/paddle/fluid/tests/unittests/test_infer_no_need_buffer_slots.py
+++ b/python/paddle/fluid/tests/unittests/test_infer_no_need_buffer_slots.py
@@ -1,0 +1,71 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import paddle.fluid as fluid
+import paddle.fluid.framework as framework
+import paddle.compat as cpt
+import paddle.fluid.core as core
+
+
+class TestInferNoNeedBufferSlots(unittest.TestCase):
+    def net(self):
+        x1 = fluid.default_main_program().global_block().create_var(
+            dtype="float32", shape=[1], lod_level=0, name="x1")
+        x2 = fluid.default_main_program().global_block().create_var(
+            dtype="float32", shape=[1], lod_level=0, name="x2")
+        x = fluid.layers.elementwise_add(x1, x2)
+        return x
+
+    def test_infer_no_need_buffer_slots(self):
+        program = framework.Program()
+        startup_program = framework.Program()
+        with fluid.program_guard(program, startup_program):
+            loss = self.net()
+            sgd = fluid.optimizer.SGD(learning_rate=0.01)
+            sgd.minimize(loss)
+        block = program.global_block()
+        for idx, op in enumerate(block.ops):
+            op_desc = op.desc
+            inputs = {}
+            for input_name in op_desc.input_names():
+                inputs[input_name] = op_desc.input(input_name)
+            outputs = {}
+            for output_name in op_desc.output_names():
+                outputs[output_name] = op_desc.output(output_name)
+            attrs = {}
+            for attr_name in op_desc.attr_names():
+                attrs[attr_name] = op_desc.attr(attr_name)
+            if idx == 0:
+                # elementwise_add op
+                self.assertEqual(
+                    core.infer_no_need_buffer_slots(op.type, inputs, outputs,
+                                                    attrs), set([]))
+            elif idx == 1:
+                # fill constant op
+                self.assertEqual(
+                    core.infer_no_need_buffer_slots(op.type, inputs, outputs,
+                                                    attrs), set([]))
+            else:
+                # elementwise_add_grad op
+                self.assertEqual(
+                    core.infer_no_need_buffer_slots(op.type, inputs, outputs,
+                                                    attrs), set(['Y', 'X']))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_infer_no_need_buffer_slots.py
+++ b/python/paddle/fluid/tests/unittests/test_infer_no_need_buffer_slots.py
@@ -38,6 +38,7 @@ class TestInferNoNeedBufferSlots(unittest.TestCase):
             loss = self.net()
             sgd = fluid.optimizer.SGD(learning_rate=0.01)
             sgd.minimize(loss)
+
         block = program.global_block()
         for idx, op in enumerate(block.ops):
             op_desc = op.desc


### PR DESCRIPTION
The GC mechanism in Paddle cut the dependency between the no_need_buffer var and the particular op to save memories. We would like to add `infer_no_need_buffer_slots` interface to pybind so that those vars can be inferred from the Python script.

Usage:

```python
import paddle.fluid.core as core
core.infer_no_need_buffer_slots(op.type, inputs, outputs,  attrs)
```

Example

```python
import paddle.fluid as fluid
import numpy as np
import paddle.fluid.core as core

def _pretty_op_desc_(op_desc, prefix):
    out_s = "%s\tname:[%s]\n%s    \tinputs:[%s]\n%s    \toutputs:[%s]" % \
            (prefix + "_op", str(op_desc.type()), prefix + "_input", " ".join(op_desc.input_arg_names()),
             prefix + "_output", " ".join(op_desc.output_arg_names()))
    return out_s

np.random.seed(9000)

fluid.default_main_program().random_seed = 9000
fluid.default_startup_program().random_seed = 9000
def gen_data():
    return {"x": np.random.random(size=(32, 32)).astype('float32'),
            "y": np.random.randint(2, size=(32, 1)).astype('int64')}
def mlp(input_x, input_y, hid_dim=128, label_dim=2):
    fc_1_left = fluid.layers.fc(input=input_x, size=hid_dim)
    fc_1_right = fluid.layers.fc(input=input_x, size=hid_dim)
    fc_1 = fluid.layers.elementwise_add(fc_1_left, fc_1_right)
    prediction = fluid.layers.fc(input=[fc_1], size=label_dim, act='softmax')
    cost = fluid.layers.cross_entropy(input=prediction, label=input_y)
    sum_cost = fluid.layers.reduce_mean(cost)
    return sum_cost, fc_1, prediction

input_x = fluid.layers.data(name="x", shape=[32], dtype='float32')
input_y = fluid.layers.data(name="y", shape=[1], dtype='int64')
cost, fc_1, pred = mlp(input_x, input_y)

print("Finished FF")

sgd = fluid.optimizer.Adam(learning_rate=0.01)
sgd.minimize(cost)

place = fluid.CPUPlace()
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
step = 10

with open("main_program.txt", 'w') as f:
    f.write(str(fluid.default_main_program()))

for i in range(step):
    cost_val = exe.run(feed=gen_data(),
                       program=fluid.default_main_program(),
                       fetch_list=[cost.name])
    print("step=%d cost=%f" % (i, cost_val[0]))

# analysis
block = fluid.default_main_program().global_block()
for idx, op in enumerate(block.ops):
    print(idx, op.type)
    print(_pretty_op_desc_(op.desc, "a"))
    op_desc = op.desc
    inputs = {}
    for input_name in op_desc.input_names():
        inputs[input_name] = op_desc.input(input_name)
    outputs = {}
    for output_name in op_desc.output_names():
        outputs[output_name] = op_desc.output(output_name)
    attrs = {}
    for attr_name in op_desc.attr_names():
        attrs[attr_name] = op_desc.attr(attr_name)
    print("No need buffer slots: ", core.infer_no_need_buffer_slots(op.type, inputs, outputs,  attrs))
```