### PR TITLE
fix ZeroCopyTensor::mutable_data(), test=release/1.6

### DIFF
--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -52,7 +52,7 @@ T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
       return tensor->mutable_data<T>(platform::CPUPlace());
     }
     case static_cast<int>(PaddlePlace::kGPU): {
-      return tensor->mutable_data<T>(platform::CUDAPlace());
+      return tensor->mutable_data<T>(platform::CUDAPlace(device_));
     }
     default:
       PADDLE_THROW("Unsupported place: %d", static_cast<int>(place));

--- a/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
@@ -51,6 +51,7 @@ TEST(ZeroCopyTensor, uint8) {
   input_t->Reshape({batch_size, length});
   input_t->copy_from_cpu(input);
   input_t->type();
+  input_t->mutable_data<uint8_t>(PaddlePlace::kGPU);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 }


### PR DESCRIPTION
修复 ZeroCopyTensor::mutable_data() 接口因未传递设备号可能导致的错误。