### PR TITLE
Refine VarBase init function

### DIFF
--- a/paddle/fluid/imperative/tests/test_tracer.cc
+++ b/paddle/fluid/imperative/tests/test_tracer.cc
@@ -274,8 +274,8 @@ TEST(test_tracer, test_unique_name_generator) {
   imperative::Tracer tracer;
   auto fc_1 = tracer.GenerateUniqueName("fc");
   auto fc_2 = tracer.GenerateUniqueName("fc");
-  ASSERT_STREQ("fc_1", fc_1.c_str());
-  ASSERT_STREQ("fc_2", fc_2.c_str());
+  ASSERT_STREQ("fc_0", fc_1.c_str());
+  ASSERT_STREQ("fc_1", fc_2.c_str());
 }
 
 TEST(test_tracer, test_current_tracer) {

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -33,7 +33,7 @@ class UniqueNameGenerator {
  public:
   explicit UniqueNameGenerator(std::string prefix = "") : prefix_(prefix) {}
   std::string Generate(std::string key = "tmp") {
-    return prefix_ + key + "_" + std::to_string(++id_);
+    return prefix_ + key + "_" + std::to_string(id_++);
   }
 
  private:

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -31,17 +31,12 @@ limitations under the License. */
 #include "paddle/fluid/imperative/tracer.h"
 #include "paddle/fluid/imperative/type_defs.h"
 #include "paddle/fluid/pybind/pybind_boost_headers.h"
+#include "paddle/fluid/pybind/tensor_py.h"
 
 namespace paddle {
 namespace pybind {
 
 namespace py = ::pybind11;
-
-template <typename P>
-extern void SetTensorFromPyArray(framework::Tensor *self, const py::object &obj,
-                                 const P &place, bool zero_copy);
-extern py::array TensorToPyArray(const framework::Tensor &tensor,
-                                 bool need_deep_copy = false);
 
 class Layer : public imperative::Layer {
  public:

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -294,9 +294,9 @@ void _concatCompute(const std::vector<paddle::framework::Tensor> &ins,
   }
 }
 
-void _getSliceinfo(const framework::Tensor &self, py::object obj,
-                   const int64_t dim, int64_t *pstart, int64_t *pstop,
-                   int64_t *pstep, int64_t *pslicelength) {
+inline void _getSliceinfo(const framework::Tensor &self, py::object obj,
+                          const int64_t dim, int64_t *pstart, int64_t *pstop,
+                          int64_t *pstep, int64_t *pslicelength) {
   auto &start = *pstart;
   auto &stop = *pstop;
   auto &step = *pstep;

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -172,6 +172,7 @@ def _print_debug_msg(limit=5, is_test=False):
         return unique_name_size, tracer_var_size, alive_cpp_var_size
 
 
+# TODO(zhiqiu): Param 'block' should be deprecated, since block is meaningless in dygraph 
 @framework.dygraph_only
 def to_variable(value, block=None, name=None, zero_copy=None):
     """
@@ -215,10 +216,10 @@ def to_variable(value, block=None, name=None, zero_copy=None):
             zero_copy = False
         py_var = core.VarBase(
             value=value,
-            name=name,
-            persistable=False,
             place=framework._current_expected_place(),
-            zero_copy=zero_copy)
+            persistable=False,
+            zero_copy=zero_copy,
+            name=name if name else '')
         return py_var
     elif isinstance(value, (core.VarBase, framework.Variable)):
         return value

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -221,7 +221,7 @@ def _current_expected_place():
     return _dygraph_current_expected_place_
 
 
-# NOTE(zhiqiu): this is deprecated, use var_base.numpy() directly.
+# TODO(zhiqiu): remove this function.
 def _var_base_to_np(var_base):
     """	
     convert VarBase tp numpy	
@@ -230,6 +230,11 @@ def _var_base_to_np(var_base):
         var_base(VarBase) : the VarBase to convert	
     Returns (np.ndarray): the np.ndarray contain the value of VarBase	
     """
+
+    warnings.warn(
+        "paddle.fluid.framework._var_base_to_np is deprecated, please use var_base.numpy() instead of _var_base_to_np(var_base)."
+    )
+
     return var_base.numpy()
 
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -221,6 +221,18 @@ def _current_expected_place():
     return _dygraph_current_expected_place_
 
 
+# NOTE(zhiqiu): this is deprecated, use var_base.numpy() directly.
+def _var_base_to_np(var_base):
+    """	
+    convert VarBase tp numpy	
+    	
+    Args:	
+        var_base(VarBase) : the VarBase to convert	
+    Returns (np.ndarray): the np.ndarray contain the value of VarBase	
+    """
+    return var_base.numpy()
+
+
 def _cpu_num():
     if "CPU_NUM" not in os.environ.keys():
         if multiprocessing.cpu_count() > 1:

--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -73,7 +73,7 @@ class LayerHelperBase(object):
             ), "to_variable could only be called in dygraph mode"
             py_var = core.VarBase(
                 value=value,
-                name=name,
+                name=name if name else '',
                 persistable=False,
                 place=_current_expected_place(),
                 zero_copy=False)

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -1,0 +1,106 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+from paddle.fluid.framework import default_main_program, Program, convert_np_dtype_to_dtype_, in_dygraph_mode
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
+import paddle.fluid.core as core
+import numpy as np
+
+
+class TestVarBase(unittest.TestCase):
+    def setUp(self):
+        self.shape = [512, 1234]
+        self.dtype = np.float32
+        self.array = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
+
+    def test_to_variable(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array, name="abc")
+            self.assertTrue(np.array_equal(var.numpy(), self.array))
+            self.assertEqual(var.name, 'abc')
+            # default value
+            self.assertEqual(var.persistable, False)
+            self.assertEqual(var.stop_gradient, True)
+            self.assertEqual(var.shape, self.shape)
+            self.assertEqual(var.dtype, core.VarDesc.VarType.FP32)
+            self.assertEqual(var.type, core.VarDesc.VarType.LOD_TENSOR)
+
+    def test_write_property(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+
+            self.assertEqual(var.name, 'generated_var_0')
+            var.name = 'test'
+            self.assertEqual(var.name, 'test')
+
+            self.assertEqual(var.persistable, False)
+            var.persistable = True
+            self.assertEqual(var.persistable, True)
+
+            self.assertEqual(var.stop_gradient, True)
+            var.stop_gradient = False
+            self.assertEqual(var.stop_gradient, False)
+
+    # test some patched methods
+    def test_set_value(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            tmp1 = np.random.uniform(0.1, 1, [2, 2, 3]).astype(self.dtype)
+            self.assertRaises(AssertionError, var.set_value, tmp1)
+
+            tmp2 = np.random.uniform(0.1, 1, self.shape).astype(self.dtype)
+            var.set_value(tmp2)
+            self.assertTrue(np.array_equal(var.numpy(), tmp2))
+
+    def test_to_string(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            self.assertTrue(isinstance(str(var.to_string(True)), str))
+
+    def test_backward(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            var.stop_gradient = False
+            loss = fluid.layers.relu(var)
+            loss.backward()
+            grad_var = var._grad_ivar()
+            self.assertEqual(grad_var.shape, self.shape)
+
+    def test_gradient(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            var.stop_gradient = False
+            loss = fluid.layers.relu(var)
+            loss.backward()
+            grad_var = var.gradient()
+            self.assertEqual(grad_var.shape, self.array.shape)
+
+    def test_block(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            self.assertEqual(var.block,
+                             fluid.default_main_program().global_block())
+
+    def test_slice(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            self.assertTrue(np.array_equal(var[1, :].numpy(), self.array[1, :]))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -101,6 +101,13 @@ class TestVarBase(unittest.TestCase):
             var = fluid.dygraph.to_variable(self.array)
             self.assertTrue(np.array_equal(var[1, :].numpy(), self.array[1, :]))
 
+    def test_var_base_to_np(self):
+        with fluid.dygraph.guard():
+            var = fluid.dygraph.to_variable(self.array)
+            self.assertTrue(
+                np.array_equal(var.numpy(),
+                               fluid.framework._var_base_to_np(var)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
1. As the title, make it more robust and readable.
2. Add more unittests for VarBase.
3. Temporarily, revert `_var_base_to_np`, which should be deprecated.