### PR TITLE
Refine DeviceContext::Wait() exception thrown

### DIFF
--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -324,16 +324,10 @@ void CUDADeviceContext::Wait() const {
   }
 #endif
 
-  if (cudaSuccess != e_sync) {
-    LOG(FATAL) << "cudaStreamSynchronize " << cudaGetErrorString(e_sync)
-               << " errno: " << e_sync;
-  }
-
-  cudaError_t e_get = cudaGetLastError();
-  if (cudaSuccess != e_get) {
-    LOG(FATAL) << "cudaGetLastError  " << cudaGetErrorString(e_get)
-               << " errno: " << e_get;
-  }
+  PADDLE_ENFORCE_CUDA_SUCCESS(
+      e_sync, platform::errors::Fatal(
+                  "cudaStreamSynchronize raises error: %s, errono: %d",
+                  cudaGetErrorString(e_sync), static_cast<int>(e_sync)));
 }
 
 int CUDADeviceContext::GetComputeCapability() const {


### PR DESCRIPTION
Use standard Paddle exception handling method `PADDLE_ENFORCE` to throw exception thrown by `CUDADeviceContext::Wait()`. 