### PR TITLE
Set lod_level of Out in compile time of sequence_pool_op

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc
@@ -31,9 +31,11 @@ class SequencePoolOp : public framework::OperatorWithKernel {
 
     if (!ctx->IsRuntime()) {
       // Check the lod_level for compile-time.
+      auto in_lod_level = ctx->GetLoDLevel("X");
       PADDLE_ENFORCE_GT(
-          ctx->GetLoDLevel("X"), 0,
+          in_lod_level, 0,
           "The LoD level Input(X) of sequence_pool should be larger than 0.");
+      ctx->SetLoDLevel("Out", in_lod_level - 1);
     }
 
     ctx->SetOutputDim("Out", ctx->GetInputDim("X"));


### PR DESCRIPTION
+ Fix compile error  if input `lod_level > 1`
```cpp
ctx->SetLoDLevel("Out", in_lod_level - 1);
```