### PR TITLE
fix paddle compile errors under some python versions

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -368,37 +368,21 @@ class InstallHeaders(Command):
 
 # we redirect setuptools log for non-windows
 if sys.platform != 'win32':
-    f_log = open('${SETUP_LOG_FILE}', 'w')
-    origin_stdout = sys.stdout
-    sys.stdout = f_log
-
-    setup(name='${PACKAGE_NAME}',
-        version='${PADDLE_VERSION}',
-        description='Parallel Distributed Deep Learning',
-        install_requires=setup_requires,
-        packages=packages,
-        ext_modules=ext_modules,
-        package_data=package_data,
-        package_dir=package_dir,
-        scripts=paddle_bins,
-        distclass=BinaryDistribution,
-        headers=headers,
-        cmdclass={
-            'install_headers': InstallHeaders,
-            'install': InstallCommand,
-        }
-    )
-
-    f_log = sys.stdout
-    sys.stdout = origin_stdout
-    f_log.close()
-
-    # As there are a lot of files in purelib which causes many logs,
-    # we don't print them on the screen, and you can open `setup.py.log` 
-    # for the full logs.
-    if os.path.exists('${SETUP_LOG_FILE}'):
-        os.system('grep -v "purelib" ${SETUP_LOG_FILE}')
+    @contextmanager
+    def redirect_stdout():
+        f_log = open('${SETUP_LOG_FILE}', 'w')
+        origin_stdout = sys.stdout
+        sys.stdout = f_log
+        yield
+        f_log = sys.stdout
+        sys.stdout = origin_stdout
+        f_log.close()
 else:
+    @contextmanager
+    def redirect_stdout():
+        yield
+
+with redirect_stdout():
     setup(name='${PACKAGE_NAME}',
         version='${PADDLE_VERSION}',
         description='Parallel Distributed Deep Learning',
@@ -415,3 +399,9 @@ else:
             'install': InstallCommand,
         }
     )
+
+# As there are a lot of files in purelib which causes many logs,
+# we don't print them on the screen, and you can open `setup.py.log` 
+# for the full logs.
+if os.path.exists('${SETUP_LOG_FILE}'):
+    os.system('grep -v "purelib" ${SETUP_LOG_FILE}')

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -368,19 +368,10 @@ class InstallHeaders(Command):
 
 # we redirect setuptools log for non-windows
 if sys.platform != 'win32':
-    @contextmanager
-    def redirect_stdout():
-        with open('${SETUP_LOG_FILE}', 'w') as f:
-            origin_stdout = sys.stdout
-            sys.stdout = f
-            yield
-            sys.stdout = origin_stdout
-else:
-    @contextmanager
-    def redirect_stdout():
-        yield
+    f_log = open('${SETUP_LOG_FILE}', 'w')
+    origin_stdout = sys.stdout
+    sys.stdout = f_log
 
-with redirect_stdout():
     setup(name='${PACKAGE_NAME}',
         version='${PADDLE_VERSION}',
         description='Parallel Distributed Deep Learning',
@@ -398,8 +389,29 @@ with redirect_stdout():
         }
     )
 
-# As there are a lot of files in purelib which causes many logs,
-# we don't print them on the screen, and you can open `setup.py.log` 
-# for the full logs.
-if os.path.exists('${SETUP_LOG_FILE}'):
-    os.system('grep -v "purelib" ${SETUP_LOG_FILE}')
+    f_log = sys.stdout
+    sys.stdout = origin_stdout
+    f_log.close()
+
+    # As there are a lot of files in purelib which causes many logs,
+    # we don't print them on the screen, and you can open `setup.py.log` 
+    # for the full logs.
+    if os.path.exists('${SETUP_LOG_FILE}'):
+        os.system('grep -v "purelib" ${SETUP_LOG_FILE}')
+else:
+    setup(name='${PACKAGE_NAME}',
+        version='${PADDLE_VERSION}',
+        description='Parallel Distributed Deep Learning',
+        install_requires=setup_requires,
+        packages=packages,
+        ext_modules=ext_modules,
+        package_data=package_data,
+        package_dir=package_dir,
+        scripts=paddle_bins,
+        distclass=BinaryDistribution,
+        headers=headers,
+        cmdclass={
+            'install_headers': InstallHeaders,
+            'install': InstallCommand,
+        }
+    )


### PR DESCRIPTION
修复paddle在某些python小版本下编译失败的问题。
目前已经发现的python小版本编译不过的情况：
centos7: python3.5.2
ubunbtu14: python3.5.2
ubunbtu16: python3.5.2、3.6.7
ubuntu18: python3.5.9、3.6.9等

![image](https://user-images.githubusercontent.com/16509038/70402597-e93c7680-1a6e-11ea-8081-5562193aafda.png)
![image](https://user-images.githubusercontent.com/16509038/70402610-f5283880-1a6e-11ea-950e-fefcf4a35136.png)
![image](https://user-images.githubusercontent.com/16509038/70402612-f78a9280-1a6e-11ea-9396-6df77b8cd237.png)
![image](https://user-images.githubusercontent.com/16509038/70402615-fa858300-1a6e-11ea-928c-5e2837556586.png)
经过log定位，发现是在调用setup的过程中，sys.stdout发生了detach，导致原来的文件无法正常close。
但是此时sys.stdout仍然指向未关闭的文件；所以可以将此时的sys.stdout赋值给文件，然后可以正常关闭。