### PR TITLE
CHERRY_PICK: Fix the bug for inference when using auto grwoth allocator

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -505,8 +505,6 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
       std::string flag = "--fraction_of_gpu_memory_to_use=" +
                          std::to_string(fraction_of_gpu_memory);
       flags.push_back(flag);
-      // use auto growth strategy here.
-      flags.push_back("--allocator_strategy=auto_growth");
       flags.push_back("--cudnn_deterministic=True");
       VLOG(3) << "set flag: " << flag;
       framework::InitGflags(flags);


### PR DESCRIPTION
when using auto grwoth allocator for inference. There is a bug for paddle-trt Caleb int8:

```
W1208 07:56:08.780930 20350 device_context.cc:236] Please NOTE: device: 0, CUDA Capability: 61, Driver API Version: 10.1, Runtime API Version: 10.1
W1208 07:56:08.781249 20350 device_context.cc:244] device: 0, cuDNN Version: 7.5.
I1208 07:56:10.034545 20350 tensorrt_engine_op.h:135] This process is generating calibration table for Paddle TRT int8...
I1208 07:56:10.034902 20355 tensorrt_engine_op.h:293] Prepare TRT engine (Optimize model structure, Select OP kernel etc). This process may cost a lot of time.
E1208 07:56:11.885713 20355 helper.h:65] engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:11.886142 20355 helper.h:65] Failure while trying to emit debug blob.
engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:11.886241 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:11.886278 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:11.929420 20355 helper.h:65] engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:11.929497 20355 helper.h:65] Failure while trying to emit debug blob.
engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:11.929560 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:11.929586 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:11.972728 20355 helper.h:65] engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:11.973096 20355 helper.h:65] Failure while trying to emit debug blob.
engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:11.973150 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:11.973212 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:12.016093 20355 helper.h:65] engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:12.016418 20355 helper.h:65] Failure while trying to emit debug blob.
engine.cpp (572) - Cuda Error in commonEmitTensor: 1 (invalid argument)
E1208 07:56:12.016489 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
E1208 07:56:12.016516 20355 helper.h:65] cuda/customWinogradConvActLayer.cpp (342) - Cuda Error in execute: 1 (invalid argument)
I1208 07:56:12.021083 20350 analysis_predictor.cc:766] Wait for calib threads done.

```

Using the best fit allocator instead.