### PR TITLE
Refine some grad op makers

### DIFF
--- a/paddle/fluid/op_use_default_grad_op_maker.spec
+++ b/paddle/fluid/op_use_default_grad_op_maker.spec
@@ -1,10 +1,7 @@
 cos_sim
 fsp
 gru
-lstm_unit
 match_matrix_tensor
-max_pool2d_with_index
-max_pool3d_with_index
 maxout
 pool2d
 pool3d
@@ -15,6 +12,5 @@ reshape
 rnn_memory_helper
 sequence_softmax
 spp
-tensor_array_to_tensor
 transpose
 unsqueeze

--- a/paddle/fluid/operators/lstm_unit_op.cc
+++ b/paddle/fluid/operators/lstm_unit_op.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/lstm_unit_op.h"
+#include <memory>
 
 namespace paddle {
 namespace operators {
@@ -94,14 +95,34 @@ class LstmUnitGradOp : public framework::OperatorWithKernel {
   }
 };
 
+template <typename T>
+class LstmUnitGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  std::unique_ptr<T> Apply() const override {
+    std::unique_ptr<T> op(new T());
+    op->SetType("lstm_unit_grad");
+    op->SetInput("X", this->Input("X"));
+    op->SetInput("C_prev", this->Input("C_prev"));
+    op->SetInput("C", this->Output("C"));
+    op->SetInput(framework::GradVarName("H"), this->OutputGrad("H"));
+    op->SetInput(framework::GradVarName("C"), this->OutputGrad("C"));
+    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    op->SetOutput(framework::GradVarName("C_prev"), this->InputGrad("C_prev"));
+    op->SetAttrMap(this->Attrs());
+    return op;
+  }
+};
+
 }  // namespace operators
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-REGISTER_OPERATOR(
-    lstm_unit, ops::LstmUnitOp, ops::LstmUnitOpMaker,
-    paddle::framework::DefaultGradOpMaker<paddle::framework::OpDesc, true>,
-    paddle::framework::DefaultGradOpMaker<paddle::imperative::OpBase, true>);
+REGISTER_OPERATOR(lstm_unit, ops::LstmUnitOp, ops::LstmUnitOpMaker,
+                  ops::LstmUnitGradOpMaker<paddle::framework::OpDesc>,
+                  ops::LstmUnitGradOpMaker<paddle::imperative::OpBase>);
 REGISTER_OPERATOR(lstm_unit_grad, ops::LstmUnitGradOp);
 REGISTER_OP_CPU_KERNEL(lstm_unit,
                        ops::LstmUnitKernel<paddle::platform::CPUPlace, float>,

--- a/paddle/fluid/operators/lstm_unit_op.cu
+++ b/paddle/fluid/operators/lstm_unit_op.cu
@@ -62,9 +62,9 @@ __global__ void LSTMUnitKernel(const int nthreads, const int dim,
 template <typename T>
 __global__ void LSTMUnitGradientKernel(const int nthreads, const int dim,
                                        const T* C_prev, const T* X, const T* C,
-                                       const T* H, const T* C_diff,
-                                       const T* H_diff, T* C_prev_diff,
-                                       T* X_diff, const T forget_bias) {
+                                       const T* C_diff, const T* H_diff,
+                                       T* C_prev_diff, T* X_diff,
+                                       const T forget_bias) {
   CUDA_1D_KERNEL_LOOP(index, nthreads) {
     const int n = index / dim;
     const int d = index % dim;
@@ -146,7 +146,6 @@ class LstmUnitGradOpCUDAKernel : public framework::OpKernel<T> {
     auto* X = x_tensor->data<T>();
     auto* C_prev = c_prev_tensor->data<T>();
     auto* C = c_tensor->data<T>();
-    auto* H = h_tensor->data<T>();
 
     auto* H_diff = hdiff_tensor->data<T>();
     auto* C_diff = cdiff_tensor->data<T>();
@@ -163,9 +162,8 @@ class LstmUnitGradOpCUDAKernel : public framework::OpKernel<T> {
     int n = N * D;
     int grid = (n + block - 1) / block;
 
-    LSTMUnitGradientKernel<T><<<grid, block>>>(n, D, C_prev, X, C, H, C_diff,
-                                               H_diff, C_prev_diff, X_diff,
-                                               forget_bias);
+    LSTMUnitGradientKernel<T><<<grid, block>>>(
+        n, D, C_prev, X, C, C_diff, H_diff, C_prev_diff, X_diff, forget_bias);
   }
 };
 

--- a/paddle/fluid/operators/lstm_unit_op.h
+++ b/paddle/fluid/operators/lstm_unit_op.h
@@ -88,7 +88,6 @@ class LstmUnitGradKernel : public framework::OpKernel<T> {
     auto x_tensor = ctx.Input<Tensor>("X");
     auto c_prev_tensor = ctx.Input<Tensor>("C_prev");
     auto c_tensor = ctx.Input<Tensor>("C");
-    auto h_tensor = ctx.Input<Tensor>("H");
 
     auto hdiff_tensor = ctx.Input<Tensor>(framework::GradVarName("H"));
     auto cdiff_tensor = ctx.Input<Tensor>(framework::GradVarName("C"));
@@ -100,7 +99,6 @@ class LstmUnitGradKernel : public framework::OpKernel<T> {
     auto* X = x_tensor->data<T>();
     auto* C_prev = c_prev_tensor->data<T>();
     auto* C = c_tensor->data<T>();
-    auto* H = h_tensor->data<T>();
 
     auto* H_diff = hdiff_tensor->data<T>();
     auto* C_diff = cdiff_tensor->data<T>();
@@ -138,7 +136,6 @@ class LstmUnitGradKernel : public framework::OpKernel<T> {
       C_prev += D;
       X += 4 * D;
       C += D;
-      H += D;
       C_diff += D;
       H_diff += D;
       X_diff += 4 * D;

--- a/paddle/fluid/operators/tensor_array_to_tensor_op.cc
+++ b/paddle/fluid/operators/tensor_array_to_tensor_op.cc
@@ -273,6 +273,23 @@ class LoDTensorArray2TensorGradOp : public framework::OperatorBase {
   }
 };
 
+template <typename T>
+class TensorArrayToTensorGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  std::unique_ptr<T> Apply() const override {
+    std::unique_ptr<T> op(new T());
+    op->SetType("tensor_array_to_tensor_grad");
+    op->SetAttrMap(this->Attrs());
+    op->SetInput("X", this->Input("X"));
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    return op;
+  }
+};
+
 }  // namespace operators
 }  // namespace paddle
 USE_OP(concat);
@@ -281,8 +298,8 @@ namespace ops = paddle::operators;
 REGISTER_OPERATOR(
     tensor_array_to_tensor, ops::LoDTensorArray2TensorOp,
     ops::LoDTensorArray2TensorOpMaker, ops::LoDTensorArray2TensorOpInferShape,
-    paddle::framework::DefaultGradOpMaker<paddle::framework::OpDesc, true>,
-    paddle::framework::DefaultGradOpMaker<paddle::imperative::OpBase, true>);
+    ops::TensorArrayToTensorGradOpMaker<paddle::framework::OpDesc>,
+    ops::TensorArrayToTensorGradOpMaker<paddle::imperative::OpBase>);
 REGISTER_OPERATOR(tensor_array_to_tensor_grad, ops::LoDTensorArray2TensorGradOp,
                   ops::LoDTensorArray2TensorGradInferShape,
                   ops::LoDTensorArray2TensorGradInferVarType);


### PR DESCRIPTION
Refine some grad maker ops to remove unnecessary inputs, to save memory consumption of models.