### PR TITLE
Upload async

### DIFF
--- a/python/paddle/fluid/incubate/fleet/utils/hdfs.py
+++ b/python/paddle/fluid/incubate/fleet/utils/hdfs.py
@@ -511,6 +511,7 @@ class HDFSClient(object):
             multi_processes(int|5): the upload data process at the same time, default=5
             overwrite(bool|False): will overwrite file on HDFS or not
             retry_times(int): upload file max retry time.
+            async_upload(bool|False):using async thread to upload files
 
         Returns:
             None


### PR DESCRIPTION
支持分布式下模型上传hdfs以异步模式进行，主进程不会hang住，由此减小0号节点与其他节点因模型上传造成的速度差异。