### PR TITLE
Change several tests to inherit the right parent class

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_by_norm_op.py
@@ -65,7 +65,7 @@ class TestCase3(TestClipByNormOp):
         self.max_norm = 1.0
 
 
-class TestClipByNormOpWithSelectedRows(OpTest):
+class TestClipByNormOpWithSelectedRows(unittest.TestCase):
     def check_with_place(self, place):
         self.config_test_case()
         scope = core.Scope()

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -150,6 +150,9 @@ class TestDropoutOp9(OpTest):
         self.check_output()
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() or not core.op_support_gpu("dropout"),
+    "core is not compiled with CUDA or core is not support dropout")
 class TestFP16DropoutOp(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -171,10 +174,12 @@ class TestFP16DropoutOp(OpTest):
         self.fix_seed = True
 
     def test_check_output(self):
-        if core.is_compiled_with_cuda() and core.op_support_gpu("dropout"):
-            self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+        self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
 
 
+@unittest.skipIf(
+    not core.is_compiled_with_cuda() or not core.op_support_gpu("dropout"),
+    "core is not compiled with CUDA or core is not support dropout")
 class TestFP16DropoutOp2(TestFP16DropoutOp):
     def init_test_case(self):
         self.input_size = [32, 64, 3]

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -81,7 +81,7 @@ class TestFillConstantOp4(OpTest):
         self.check_output()
 
 
-class TestFillConstantOpWithSelectedRows(OpTest):
+class TestFillConstantOpWithSelectedRows(unittest.TestCase):
     def check_with_place(self, place):
         scope = core.Scope()
         # create Out Variable

--- a/python/paddle/fluid/tests/unittests/test_fill_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_op.py
@@ -55,7 +55,7 @@ class TestFillOp2(OpTest):
         self.check_output(check_dygraph=False)
 
 
-class TestFillOp3(OpTest):
+class TestFillOp3(unittest.TestCase):
     def check_with_place(self, place, f_cpu):
         scope = core.Scope()
         # create Out Variable

--- a/python/paddle/fluid/tests/unittests/test_lookup_sparse_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_sparse_table_op.py
@@ -21,7 +21,7 @@ import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 
 
-class TestLookupSpraseTable(OpTest):
+class TestLookupSpraseTable(unittest.TestCase):
     def check_with_place(self, place):
         scope = core.Scope()
 

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -85,7 +85,7 @@ class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
         pass
 
 
-class TestLookupTableWIsSelectedRows(OpTest):
+class TestLookupTableWIsSelectedRows(unittest.TestCase):
     def prepare_ids(self, scope, place):
         ids_tensor = scope.var('Ids').get_tensor()
         ids_array = np.array([[0], [4], [3], [5]]).astype("int64")
@@ -250,7 +250,7 @@ class TestLookupTableOpWithTensorIdsAndPaddingInt8(
         pass
 
 
-class TestLookupTableWIsSelectedRowsInt8(OpTest):
+class TestLookupTableWIsSelectedRowsInt8(unittest.TestCase):
     def prepare_ids(self, scope, place):
         ids_tensor = scope.var('Ids').get_tensor()
         ids_array = np.array([[0], [4], [3], [5]]).astype("int64")

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -84,7 +84,7 @@ class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
         pass
 
 
-class TestLookupTableWIsSelectedRows(OpTest):
+class TestLookupTableWIsSelectedRows(unittest.TestCase):
     def prepare_ids(self, scope, place):
         ids_tensor = scope.var('Ids').get_tensor()
         ids_array = np.array([0, 4, 3, 5]).astype("int64")

--- a/python/paddle/fluid/tests/unittests/test_sum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sum_op.py
@@ -144,6 +144,7 @@ class TestLoDTensorAndSelectedRowsOp(TestSelectedRowsSumOp):
         self.height = 10
         self.row_numel = 12
         self.rows = [0, 1, 2, 2, 4, 5, 6]
+        self.dtype = np.float32
 
     def check_with_place(self, place, inplace):
         scope = core.Scope()

--- a/python/paddle/fluid/tests/unittests/test_sum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sum_op.py
@@ -48,7 +48,7 @@ class TestSumOp(OpTest):
         pass
 
 
-class TestSelectedRowsSumOp(OpTest):
+class TestSelectedRowsSumOp(unittest.TestCase):
     def setUp(self):
         self.height = 10
         self.row_numel = 12


### PR DESCRIPTION
如果单测没有使用OpTest类的方法和变量，则改成继承unittest.TestCase类

Change several tests to inherit the right parent class,  replacing OpTest with unittest.TestCase 