### PR TITLE
fix bug: add attr_error only when default value is None. 

### DIFF
--- a/tools/check_op_desc.py
+++ b/tools/check_op_desc.py
@@ -110,7 +110,7 @@ def diff_attr(ori_attrs, new_attrs):
         attr_deleted_error_massage.append(attr_name)
 
     for attr_name in attrs_only_in_new:
-        if not new_attrs.get(attr_name).get(DEFAULT_VALUE):
+        if new_attrs.get(attr_name).get(DEFAULT_VALUE) == None:
             error, attr_error = True, True
             attr_added_error_massage.append(attr_name)
 


### PR DESCRIPTION
- Before:
The error message will be added if default value is `{}` ,`[]` or `None`. But only `None`  should be added in error message.

- This PR:
fix this bug.