### PR TITLE
Patch math method for VarBase using auto-generated op functions

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_pow_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_pow_op.h
@@ -12,58 +12,16 @@ limitations under the License. */
 #pragma once
 
 #include <cmath>
-#include <type_traits>
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
 
 namespace paddle {
 namespace operators {
 
-namespace details {
-
-// Only valid if T is an integral type.
-template <class T,
-          class = typename std::enable_if<std::is_integral<T>::value>::type>
-static inline HOSTDEVICE T ipow(T base, T exp) {
-  if (exp < 0) {
-    // Note(zhiqiu): In some library, like numpy and pytorch,
-    // integers to negative integer powers are not allowed.
-    // Since a^b = 1/(a^(-b)) when b < 0, it will truncate to 0.
-    // Return 0, for specialization to avoiding infinite loop.
-    return 0;
-  }
-
-  T result = 1;
-  while (exp) {
-    if (exp & 1) {
-      result *= base;
-    }
-    exp >>= 1;
-    base *= base;
-  }
-
-  return result;
-}
-
-template <typename T, bool kIsIntegral = false>
-struct PowFunctorImpl {
+template <typename T>
+struct PowFunctor {
   inline HOSTDEVICE T operator()(T a, T b) const { return std::pow(a, b); }
 };
-
-template <typename T>
-struct PowFunctorImpl<T, true> {
-  inline HOSTDEVICE T operator()(T a, T b) const {
-#ifdef __CUDA_ARCH__
-    return ipow(a, b);
-#else
-    return std::pow(a, b);
-#endif
-  }
-};
-}  // namespace details
-
-template <typename T>
-using PowFunctor = details::PowFunctorImpl<T, std::is_integral<T>::value>;
 
 template <typename DeviceContext, typename T>
 class ElementwisePowKernel : public framework::OpKernel<T> {

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -155,11 +155,6 @@ def monkey_patch_math_varbase():
                 other_var = tmp
 
             axis = -1
-            assert len(self.shape) >= len(other_var.shape), (
-                "The rank of the first argument of an binary operator cannot "
-                "be smaller than the rank of its second argument: %s vs %s" %
-                (len(self.shape), len(other_var.shape)))
-
             op = getattr(core.ops, op_type)
             inputs = {'X': [self], 'Y': [other_var]}
             attrs = {'axis': axis}

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -15,9 +15,8 @@
 from __future__ import print_function
 
 from .. import core
-from ..framework import Variable, unique_name, convert_np_dtype_to_dtype_
+from ..framework import Variable, convert_np_dtype_to_dtype_
 from ..layers.layer_function_generator import OpProtoHolder
-from ..initializer import force_init_on_cpu
 from . import to_variable, no_grad
 
 _supported_int_dtype_ = [
@@ -76,6 +75,21 @@ def monkey_patch_math_varbase():
             Variable: Variable with new dtype
 
         Examples:
+            In Static Graph Mode:
+
+            .. code-block:: python
+
+                import paddle.fluid as fluid
+
+                startup_prog = fluid.Program()
+                main_prog = fluid.Program()
+                with fluid.program_guard(startup_prog, main_prog):
+                    original_variable = fluid.data(name = "new_variable", shape=[2,2], dtype='float32')
+                    new_variable = original_variable.astype('int64')
+                    print("new var's dtype is: {}".format(new_variable.dtype))
+
+            In Dygraph Mode:
+
             .. code-block:: python
 
                 import paddle.fluid as fluid

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -18,6 +18,7 @@ from . import BackwardStrategy
 from ..framework import Variable, _getitem_impl_
 from .. import unique_name
 import numpy as np
+from math_op_patch import monkey_patch_math_varbase
 
 
 def monkey_patch_varbase():
@@ -214,3 +215,6 @@ def monkey_patch_varbase():
                                 ("__str__", __str__), ("to_string", to_string),
                                 ("__getitem__", __getitem__)):
         setattr(core.VarBase, method_name, method)
+
+    # patch math methods for varbase
+    monkey_patch_math_varbase()

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -18,7 +18,7 @@ from . import BackwardStrategy
 from ..framework import Variable, _getitem_impl_
 from .. import unique_name
 import numpy as np
-from math_op_patch import monkey_patch_math_varbase
+from .math_op_patch import monkey_patch_math_varbase
 
 
 def monkey_patch_varbase():

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 from .. import core
-from ..framework import Variable, unique_name, in_dygraph_mode, default_main_program
+from ..framework import Variable, unique_name
 from .layer_function_generator import OpProtoHolder
 from ..initializer import force_init_on_cpu
 
@@ -40,8 +40,6 @@ def monkey_patch_variable():
         return dtype
 
     def current_block(var):
-        if in_dygraph_mode():
-            return default_main_program().global_block()
         return var.block.program.current_block()
 
     def create_new_tmp_var(block, dtype):

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -1,0 +1,165 @@
+#   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+from decorator_helper import prog_scope
+import paddle.fluid as fluid
+import numpy as np
+
+
+class TestMathOpPatchesVarBase(unittest.TestCase):
+    def setUp(self):
+        self.shape = [512, 768]
+        self.dtype = np.float32
+
+    def test_add(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a + b
+            self.assertTrue(np.array_equal(res.numpy(), a_np + b_np))
+
+    def test_sub(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a - b
+            self.assertTrue(np.array_equal(res.numpy(), a_np - b_np))
+
+    def test_mul(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a * b
+            self.assertTrue(np.array_equal(res.numpy(), a_np * b_np))
+
+    def test_div(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a / b
+            self.assertTrue(np.array_equal(res.numpy(), a_np / b_np))
+
+    def test_add_scalar(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = 0.1
+            res = a + b
+            self.assertTrue(np.array_equal(res.numpy(), a_np + b))
+
+    # pow of float type, not equal
+    def test_pow1(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a**b
+            self.assertTrue(np.allclose(res.numpy(), a_np**b_np))
+
+    def test_floor_div(self):
+        a_np = np.random.randint(1, 100, size=self.shape)
+        b_np = np.random.randint(1, 100, size=self.shape)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a // b
+            self.assertTrue(np.array_equal(res.numpy(), a_np // b_np))
+
+    def test_mod(self):
+        a_np = np.random.randint(1, 100, size=self.shape)
+        b_np = np.random.randint(1, 100, size=self.shape)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = a % b
+            self.assertTrue(np.array_equal(res.numpy(), a_np % b_np))
+
+    # for logical compare
+    def test_equal(self):
+        a_np = np.asarray([1, 2, 3, 4, 5])
+        b_np = np.asarray([1, 2, 3, 4, 5])
+        c_np = np.asarray([1, 2, 2, 4, 5])
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            c = fluid.dygraph.to_variable(c_np)
+            res1 = (a == b)
+            res2 = (a == c)
+            self.assertTrue(np.array_equal(res1.numpy(), a_np == b_np))
+            self.assertTrue(np.array_equal(res2.numpy(), a_np == c_np))
+
+    def test_not_equal(self):
+        a_np = np.asarray([1, 2, 3, 4, 5])
+        b_np = np.asarray([1, 2, 3, 4, 5])
+        c_np = np.asarray([1, 2, 2, 4, 5])
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            c = fluid.dygraph.to_variable(c_np)
+            res1 = (a != b)
+            res2 = (a != c)
+            self.assertTrue(np.array_equal(res1.numpy(), a_np != b_np))
+            self.assertTrue(np.array_equal(res2.numpy(), a_np != c_np))
+
+    def test_less_than(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = (a < b)
+            self.assertTrue(np.array_equal(res.numpy(), a_np < b_np))
+
+    def test_less_equal(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = (a <= b)
+            self.assertTrue(np.array_equal(res.numpy(), a_np <= b_np))
+
+    def test_greater_than(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = (a > b)
+            self.assertTrue(np.array_equal(res.numpy(), a_np > b_np))
+
+    def test_greater_equal(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        b_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = fluid.dygraph.to_variable(b_np)
+            res = (a >= b)
+            self.assertTrue(np.array_equal(res.numpy(), a_np >= b_np))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -22,7 +22,7 @@ import numpy as np
 
 class TestMathOpPatchesVarBase(unittest.TestCase):
     def setUp(self):
-        self.shape = [512, 768]
+        self.shape = [10, 10]
         self.dtype = np.float32
 
     def test_add(self):
@@ -69,8 +69,33 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             res = a + b
             self.assertTrue(np.array_equal(res.numpy(), a_np + b))
 
+    def test_sub_scalar(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = 0.1
+            res = a - b
+            self.assertTrue(np.array_equal(res.numpy(), a_np - b))
+
+    def test_mul_scalar(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = 0.1
+            res = a * b
+            self.assertTrue(np.array_equal(res.numpy(), a_np * b))
+
+    # div_scalar, not equal
+    def test_div_scalar(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = 0.1
+            res = a / b
+            self.assertTrue(np.allclose(res.numpy(), a_np / b))
+
     # pow of float type, not equal
-    def test_pow1(self):
+    def test_pow(self):
         a_np = np.random.random(self.shape).astype(self.dtype)
         b_np = np.random.random(self.shape).astype(self.dtype)
         with fluid.dygraph.guard():

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -69,6 +69,14 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             res = a + b
             self.assertTrue(np.array_equal(res.numpy(), a_np + b))
 
+    def test_add_scalar_reverse(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = 0.1
+            res = b + a
+            self.assertTrue(np.array_equal(res.numpy(), b + a_np))
+
     def test_sub_scalar(self):
         a_np = np.random.random(self.shape).astype(self.dtype)
         with fluid.dygraph.guard():
@@ -76,6 +84,14 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
             b = 0.1
             res = a - b
             self.assertTrue(np.array_equal(res.numpy(), a_np - b))
+
+    def test_sub_scalar_reverse(self):
+        a_np = np.random.random(self.shape).astype(self.dtype)
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            b = 0.1
+            res = b - a
+            self.assertTrue(np.array_equal(res.numpy(), b - a_np))
 
     def test_mul_scalar(self):
         a_np = np.random.random(self.shape).astype(self.dtype)


### PR DESCRIPTION
This PR patches math methods, like `+, -, *, /`, for VarBase, and the patched methods will auto-generated op functions, as described in [PR21569](https://github.com/PaddlePaddle/Paddle/pull/21569).


Sample code.
```
import paddle.fluid as fluid
import numpy as np

a_np = np.asarray([3])
b_np = np.asarray([1])
place = fluid.CUDAPlace(0)
with fluid.dygraph.guard(place):
    a = fluid.dygraph.to_variable(a_np)
    b = fluid.dygraph.to_variable(b_np)
    res = a * b
    print(res.numpy())  # [3]
```

