### PR TITLE
fix analysis_predictor when InitDevices() is called multiple times

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -122,11 +122,7 @@ bool AnalysisPredictor::PrepareScope(
     scope_ = parent_scope;
     status_is_cloned_ = true;
   } else {
-    if (config_.use_gpu_) {
-      paddle::framework::InitDevices(false);
-    } else {
-      paddle::framework::InitDevices(false, {});
-    }
+    paddle::framework::InitDevices(false);
     scope_.reset(new paddle::framework::Scope());
     status_is_cloned_ = false;
   }


### PR DESCRIPTION
test=develop
[cherry-pick from #21663 ]

因为单例的存在，paddle::framework::InitDevices() 在同一进程中前后调用的行为是不一样的，所以不应使用 Predictor 配置内容决定 InitDevices 参数。否则，当 X86 PaddlePredictor 先于 CUDA AnalysisPredictor 初始化时，后者将无法向 DeviceContextPool 传入 CUDAPlace，进而导致 CUDA 模型运行失败。