### PR TITLE
refine check_api_approvals.sh

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -81,7 +81,6 @@ fi
 
 for API_FILE in ${API_FILES[*]}; do
   API_CHANGE=`git diff --name-only upstream/$BRANCH | grep "${API_FILE}" | grep -v "/CMakeLists.txt" || true`
-  echo "checking ${API_FILE} change, PR: ${GIT_PR_ID}, changes: ${API_CHANGE}"
   if [ "${API_CHANGE}" ] && [ "${GIT_PR_ID}" != "" ]; then
       # NOTE: per_page=10000 should be ok for all cases, a PR review > 10000 is not human readable.
       # approval_user_list: XiaoguangHu01 46782768,Xreki 12538138,luotao1 6836917,sneaxiy 32832641,qingqing01 7845005,guoshengCS 14105589,heavengate 12605721,kuke 3064195,Superjomn 328693,lanxianghit 47554610,cyj1986 39645414,hutuxian 11195205,frankwhzhang 20274488,nepeplwu 45024560,Dianhai 38231817,JiabinYang 22361972,chenwhql 22561442,zhiqiu 6888866,seiriosPlus 5442383,gongweibao 10721757,saxon-zh 2870059,Boyan-Liu 2870059, zhouwei25 52485244, Aurelius84 9301846, liym27 33742067, zhhsplendid 7913861.
@@ -138,7 +137,7 @@ ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_EN
 VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
 INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vxF "$VALID_PADDLE_CHECK" || true`
 if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
-    echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified. Please read the specification [ https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification ], then refine the error message. If it is a mismatch, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDDLE_ENFORCE or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
+    echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified. Please read the specification [ https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification ], then refine the error message. If it is a mismatch, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDLE_ENFORCE{_**} or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"
     check_approval 1 6836917 47554610 22561442
 fi
 


### PR DESCRIPTION
- fix typo `PADDDLE_ENFORCE` to `PADDLE_ENFORCE{_**}`
- remove unused log to make CI cleaner
http://ci.paddlepaddle.org/viewLog.html?buildId=241984&tab=buildLog&buildTypeId=YYTest_PrCiCpuPy2&logTab=tail
```

[07:53:04]	[Step 1/1] checking paddle/fluid/framework/selected_rows.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/op_desc.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/block_desc.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/var_desc.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/scope.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/ir/node.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/ir/graph.h change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking paddle/fluid/framework/framework.proto change, PR: 21575, changes: 
[07:53:04]	[Step 1/1] checking python/requirements.txt change, PR: 21575, changes:
```