### PR TITLE
remove inplace_atol for group_norm op

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -68,17 +68,12 @@ class TestGroupNormOp(OpTest):
         self.attrs['data_layout'] = self.data_format
 
     def test_check_output(self):
-        atol = 1e-4
-        inplace_atol = 1e-4
         place = core.CPUPlace()
-        # add inplace_atol bacause group_norm doesn't ensure computational consistency
-        self.check_output_with_place(
-            place, atol=atol, inplace_atol=inplace_atol)
+        self.check_output_with_place(place, atol=0)
 
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(
-                place, atol=atol, inplace_atol=inplace_atol)
+            self.check_output_with_place(place, atol=0)
 
     def do_compare_between_place(self):
         if not core.is_compiled_with_cuda(): return


### PR DESCRIPTION
**DO NOT MERGE**
related #21502
在#21608 把group_norm op单测中输入数据类型从float32修改为float64, 并修改反向梯度精度对比时的max_relative_error值从0.01降低到0.005后，可以去掉单测中的`inplace_atol`.