### PR TITLE
add ssl to requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,3 +17,4 @@ pyyaml
 decorator
 prettytable
 objgraph
+ssl

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,4 +17,4 @@ pyyaml
 decorator
 prettytable
 objgraph
-ssl
+ssl ; python_version>"2.3.4" and python_version<"2.6"


### PR DESCRIPTION
The [pr#20942](https://github.com/PaddlePaddle/Paddle/pull/20942) fixed the [issue#20749](https://github.com/PaddlePaddle/Paddle/issues/20749) but introduced the dependency on ssl. So, we have to add ssl to requirements.txt.