### PR TITLE
update iou_similarity op

### DIFF
--- a/paddle/fluid/operators/detection/iou_similarity_op.cc
+++ b/paddle/fluid/operators/detection/iou_similarity_op.cc
@@ -61,7 +61,10 @@ class IOUSimilarityOpMaker : public framework::OpProtoAndCheckerMaker {
              "[xmin, ymin] is the left top coordinate of the box if the "
              "input is image feature map, and [xmax, ymax] is the right "
              "bottom coordinate of the box.");
-
+    AddAttr<bool>("box_normalized",
+                  "(bool, default true) "
+                  "whether treat the priorbox as a noramlized box")
+        .SetDefault(true);
     AddOutput("Out",
               "(LoDTensor, the lod is same as input X) The output of "
               "iou_similarity op, a tensor with shape [N, M] "

--- a/paddle/fluid/operators/detection/iou_similarity_op.h
+++ b/paddle/fluid/operators/detection/iou_similarity_op.h
@@ -36,6 +36,10 @@ inline HOSTDEVICE T IOUSimilarity(T xmin1, T ymin1, T xmax1, T ymax1, T xmin2,
   T inter_ymin = ymin1 > ymin2 ? ymin1 : ymin2;
   T inter_height = inter_ymax - inter_ymin;
   T inter_width = inter_xmax - inter_xmin;
+  if (normalized) {
+    inter_height = inter_height + 1;
+    inter_width = inter_width + 1;
+  }
   inter_height = inter_height > zero ? inter_height : zero;
   inter_width = inter_width > zero ? inter_width : zero;
   T inter_area = inter_width * inter_height;

--- a/paddle/fluid/operators/detection/iou_similarity_op.h
+++ b/paddle/fluid/operators/detection/iou_similarity_op.h
@@ -18,10 +18,18 @@ limitations under the License. */
 
 template <typename T>
 inline HOSTDEVICE T IOUSimilarity(T xmin1, T ymin1, T xmax1, T ymax1, T xmin2,
-                                  T ymin2, T xmax2, T ymax2) {
+                                  T ymin2, T xmax2, T ymax2, bool normalized) {
   constexpr T zero = static_cast<T>(0);
-  T area1 = (ymax1 - ymin1) * (xmax1 - xmin1);
-  T area2 = (ymax2 - ymin2) * (xmax2 - xmin2);
+  T area1;
+  T area2;
+  if (normalized) {
+    area1 = (ymax1 - ymin1 + 1) * (xmax1 - xmin1 + 1);
+    area2 = (ymax2 - ymin2 + 1) * (xmax2 - xmin2 + 1);
+  } else {
+    area1 = (ymax1 - ymin1) * (xmax1 - xmin1);
+    area2 = (ymax2 - ymin2) * (xmax2 - xmin2);
+  }
+
   T inter_xmax = xmax1 > xmax2 ? xmax2 : xmax1;
   T inter_ymax = ymax1 > ymax2 ? ymax2 : ymax1;
   T inter_xmin = xmin1 > xmin2 ? xmin1 : xmin2;
@@ -38,8 +46,12 @@ inline HOSTDEVICE T IOUSimilarity(T xmin1, T ymin1, T xmax1, T ymax1, T xmin2,
 
 template <typename T>
 struct IOUSimilarityFunctor {
-  IOUSimilarityFunctor(const T* x, const T* y, T* z, int cols)
-      : x_(x), y_(y), z_(z), cols_(static_cast<size_t>(cols)) {}
+  IOUSimilarityFunctor(const T* x, const T* y, T* z, int cols, bool normalized)
+      : x_(x),
+        y_(y),
+        z_(z),
+        cols_(static_cast<size_t>(cols)),
+        normalized_(normalized) {}
 
   inline HOSTDEVICE void operator()(size_t tid) const {
     size_t row_id = tid / cols_;
@@ -56,7 +68,7 @@ struct IOUSimilarityFunctor {
     T y_max2 = y_[col_id * 4 + 3];
 
     T sim = IOUSimilarity(x_min1, y_min1, x_max1, y_max1, x_min2, y_min2,
-                          x_max2, y_max2);
+                          x_max2, y_max2, normalized_);
 
     z_[row_id * cols_ + col_id] = sim;
   }
@@ -64,6 +76,7 @@ struct IOUSimilarityFunctor {
   const T* y_;
   T* z_;
   const size_t cols_;
+  bool normalized_;
 };
 
 namespace paddle {
@@ -75,12 +88,14 @@ class IOUSimilarityKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     const framework::LoDTensor* in_x = ctx.Input<framework::LoDTensor>("X");
     const framework::Tensor* in_y = ctx.Input<framework::Tensor>("Y");
+    bool normalized = ctx.Attr<bool>("box_normalized");
     framework::LoDTensor* out = ctx.Output<framework::LoDTensor>("Out");
 
     int x_n = in_x->dims()[0];
     int y_n = in_y->dims()[0];
     IOUSimilarityFunctor<T> functor(in_x->data<T>(), in_y->data<T>(),
-                                    out->mutable_data<T>(ctx.GetPlace()), y_n);
+                                    out->mutable_data<T>(ctx.GetPlace()), y_n,
+                                    normalized);
 
     platform::ForRange<DeviceContext> for_range(
         static_cast<const DeviceContext&>(ctx.device_context()), x_n * y_n);

--- a/paddle/fluid/operators/detection/iou_similarity_op.h
+++ b/paddle/fluid/operators/detection/iou_similarity_op.h
@@ -22,7 +22,7 @@ inline HOSTDEVICE T IOUSimilarity(T xmin1, T ymin1, T xmax1, T ymax1, T xmin2,
   constexpr T zero = static_cast<T>(0);
   T area1;
   T area2;
-  if (normalized) {
+  if (!normalized) {
     area1 = (ymax1 - ymin1 + 1) * (xmax1 - xmin1 + 1);
     area2 = (ymax2 - ymin2 + 1) * (xmax2 - xmin2 + 1);
   } else {
@@ -36,7 +36,7 @@ inline HOSTDEVICE T IOUSimilarity(T xmin1, T ymin1, T xmax1, T ymax1, T xmin2,
   T inter_ymin = ymin1 > ymin2 ? ymin1 : ymin2;
   T inter_height = inter_ymax - inter_ymin;
   T inter_width = inter_xmax - inter_xmin;
-  if (normalized) {
+  if (!normalized) {
     inter_height = inter_height + 1;
     inter_width = inter_width + 1;
   }

--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -653,14 +653,15 @@ def detection_output(loc,
 
 
 @templatedoc()
-def iou_similarity(x, y, name=None):
+def iou_similarity(x, y, box_normalized=False, name=None):
     """
     ${comment}
 
     Args:
         x (Variable): ${x_comment}.The data type is float32 or float64.
         y (Variable): ${y_comment}.The data type is float32 or float64.
-
+        box_normalized(bool): Whether treat the priorbox as a noramlized box.
+            Set true by default.
     Returns:
         Variable: ${out_comment}.The data type is same with x.
 
@@ -700,7 +701,7 @@ def iou_similarity(x, y, name=None):
         type="iou_similarity",
         inputs={"X": x,
                 "Y": y},
-        attrs={},
+        attrs={"box_normalized": box_normalized},
         outputs={"Out": out})
     return out
 

--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -653,7 +653,7 @@ def detection_output(loc,
 
 
 @templatedoc()
-def iou_similarity(x, y, box_normalized=False, name=None):
+def iou_similarity(x, y, box_normalized=True, name=None):
     """
     ${comment}
 

--- a/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
@@ -43,7 +43,7 @@ class TestIOUSimilarityOp(OpTest):
             for col in range(self.boxes2.shape[0]):
                 xmin1, ymin1, xmax1, ymax1 = self.boxes1[row]
                 xmin2, ymin2, xmax2, ymax2 = self.boxes2[col]
-                if self.box_normalized:
+                if not self.box_normalized:
                     area1 = (ymax1 - ymin1 + 1) * (xmax1 - xmin1 + 1)
                     area2 = (ymax2 - ymin2 + 1) * (xmax2 - xmin2 + 1)
                 else:
@@ -56,7 +56,7 @@ class TestIOUSimilarityOp(OpTest):
                 inter_ymin = max(ymin1, ymin2)
                 inter_height = inter_ymax - inter_ymin
                 inter_width = inter_xmax - inter_xmin
-                if self.box_normalized:
+                if not self.box_normalized:
                     inter_height += 1
                     inter_width += 1
                 inter_height = max(inter_height, 0)

--- a/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
@@ -31,27 +31,40 @@ class TestIOUSimilarityOp(OpTest):
         self.boxes1 = random.rand(2, 4).astype('float32')
         self.boxes2 = random.rand(3, 4).astype('float32')
         self.output = random.rand(2, 3).astype('float32')
+        self.box_normalized = False
+        # run python iou computation 
+        self._compute_iou()
+        self.inputs = {'X': self.boxes1, 'Y': self.boxes2}
+        self.attrs = {"box_normalized": self.box_normalized}
+        self.outputs = {'Out': self.output}
+
+    def _compute_iou(self, ):
         for row in range(self.boxes1.shape[0]):
             for col in range(self.boxes2.shape[0]):
                 xmin1, ymin1, xmax1, ymax1 = self.boxes1[row]
                 xmin2, ymin2, xmax2, ymax2 = self.boxes2[col]
-                area1 = (ymax1 - ymin1) * (xmax1 - xmin1)
-                area2 = (ymax2 - ymin2) * (xmax2 - xmin2)
+                if self.box_normalized:
+                    area1 = (ymax1 - ymin1 + 1) * (xmax1 - xmin1 + 1)
+                    area2 = (ymax2 - ymin2 + 1) * (xmax2 - xmin2 + 1)
+                else:
+                    area1 = (ymax1 - ymin1) * (xmax1 - xmin1)
+                    area2 = (ymax2 - ymin2) * (xmax2 - xmin2)
+
                 inter_xmax = min(xmax1, xmax2)
                 inter_ymax = min(ymax1, ymax2)
                 inter_xmin = max(xmin1, xmin2)
                 inter_ymin = max(ymin1, ymin2)
                 inter_height = inter_ymax - inter_ymin
                 inter_width = inter_xmax - inter_xmin
+                if self.box_normalized:
+                    inter_height += 1
+                    inter_width += 1
                 inter_height = max(inter_height, 0)
                 inter_width = max(inter_width, 0)
                 inter_area = inter_width * inter_height
                 union_area = area1 + area2 - inter_area
                 sim_score = inter_area / union_area
                 self.output[row, col] = sim_score
-        self.inputs = {'X': self.boxes1, 'Y': self.boxes2}
-        self.attrs = {"box_normalized": False}
-        self.outputs = {'Out': self.output}
 
 
 class TestIOUSimilarityOpWithLoD(TestIOUSimilarityOp):
@@ -62,9 +75,27 @@ class TestIOUSimilarityOpWithLoD(TestIOUSimilarityOp):
         super(TestIOUSimilarityOpWithLoD, self).setUp()
         self.boxes1_lod = [[1, 1]]
         self.output_lod = [[1, 1]]
-
+        self.box_normalized = False
+        # run python iou computation 
+        self._compute_iou()
         self.inputs = {'X': (self.boxes1, self.boxes1_lod), 'Y': self.boxes2}
-        self.attrs = {"box_normalized": False}
+        self.attrs = {"box_normalized": self.box_normalized}
+        self.outputs = {'Out': (self.output, self.output_lod)}
+
+
+class TestIOUSimilarityOpWithBoxNormalized(TestIOUSimilarityOp):
+    def test_check_output(self):
+        self.check_output(check_dygraph=False)
+
+    def setUp(self):
+        super(TestIOUSimilarityOpWithBoxNormalized, self).setUp()
+        self.boxes1_lod = [[1, 1]]
+        self.output_lod = [[1, 1]]
+        self.box_normalized = True
+        # run python iou computation 
+        self._compute_iou()
+        self.inputs = {'X': (self.boxes1, self.boxes1_lod), 'Y': self.boxes2}
+        self.attrs = {"box_normalized": self.box_normalized}
         self.outputs = {'Out': (self.output, self.output_lod)}
 
 

--- a/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
+++ b/python/paddle/fluid/tests/unittests/test_iou_similarity_op.py
@@ -50,7 +50,7 @@ class TestIOUSimilarityOp(OpTest):
                 sim_score = inter_area / union_area
                 self.output[row, col] = sim_score
         self.inputs = {'X': self.boxes1, 'Y': self.boxes2}
-
+        self.attrs = {"box_normalized": False}
         self.outputs = {'Out': self.output}
 
 
@@ -64,6 +64,7 @@ class TestIOUSimilarityOpWithLoD(TestIOUSimilarityOp):
         self.output_lod = [[1, 1]]
 
         self.inputs = {'X': (self.boxes1, self.boxes1_lod), 'Y': self.boxes2}
+        self.attrs = {"box_normalized": False}
         self.outputs = {'Out': (self.output, self.output_lod)}
 
 


### PR DESCRIPTION
Fix  https://github.com/PaddlePaddle/PaddleDetection/issues/85

add an argument "box_normalized" and it means whether box is normalized.
if box_normalized:
  area = (xmax-xmin+1) * (ymax-ymin+1)
else:
  area = (xmax-xmin) * (ymax-ymin)

update doc cn https://github.com/PaddlePaddle/FluidDoc/pull/1674
![image](https://user-images.githubusercontent.com/48318485/70962976-07832180-20c2-11ea-92d3-5ee50e991188.png)


