### PR TITLE
Fix elementwise_pow bug on CUDA place with integer

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_pow_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_pow_op.h
@@ -57,13 +57,10 @@ struct PowGradDX {
   HOSTDEVICE T operator()(T x, T y, T out, T dout) const {
 #ifdef __CUDA_ARCH__
     if (std::is_integral<T>::value) {
-      std::llrint(dout * y * std::pow(x, y - 1));
-    } else {
-      return dout * y * std::pow(x, y - 1);
+      return std::llrint(dout * y * std::pow(x, y - 1));
     }
-#else
-    return dout * y * std::pow(x, y - 1);
 #endif
+    return dout * y * std::pow(x, y - 1);
   }
 };
 
@@ -72,15 +69,12 @@ struct PowGradDY {
   HOSTDEVICE T operator()(T x, T y, T out, T dout) const {
 #ifdef __CUDA_ARCH__
     if (std::is_integral<T>::value) {
-      std::llrint(dout * std::log(x) * std::pow(x, y));
-    } else {
-      return dout * std::log(x) * std::pow(x, y);
+      return std::llrint(dout * std::log(x) * std::pow(x, y));
     }
-#else
-    return dout * std::log(x) * std::pow(x, y);
 #endif
+    return dout * std::log(x) * std::pow(x, y);
   }
-};
+};  // namespace operators
 
 template <typename DeviceContext, typename T>
 class ElementwisePowGradKernel : public ElemwiseGradKernel<T> {

--- a/python/paddle/fluid/tests/unittests/test_elementwise_pow_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_pow_op.py
@@ -34,6 +34,16 @@ class TestElementwisePowOp(OpTest):
         self.check_grad(['X', 'Y'], 'Out')
 
 
+class TestElementwisePowOp(OpTest):
+    def setUp(self):
+        self.op_type = "elementwise_pow"
+        self.inputs = {'X': np.asarray([1, 2, 3]), 'Y': np.asarray([1, 1, 1])}
+        self.outputs = {'Out': np.power(self.inputs['X'], self.inputs['Y'])}
+
+    def test_check_output(self):
+        self.check_output()
+
+
 class TestElementwisePowOp_scalar(TestElementwisePowOp):
     def setUp(self):
         self.op_type = "elementwise_pow"


### PR DESCRIPTION
On CUDA place, `elementwise_pow` fails when input integers, for example,
![image](https://user-images.githubusercontent.com/6888866/70537369-4897a500-1b9b-11ea-8839-acb17f103261.png)

![image](https://user-images.githubusercontent.com/6888866/70532545-3ebd7400-1b92-11ea-8b97-0ef7cd8ed9ea.png)

This PR fixes that.
