### PR TITLE
polish cmake, test=develop

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -49,22 +49,44 @@ if (WIN32)
     "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
     add_dependencies(op_function_cmd op_function_generator)
   if(WITH_MKL)
-  add_custom_target(copy_dll 
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+  add_custom_target(copy_mkl 
         COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
         COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
         COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
         )
-  add_dependencies(copy_dll op_function_generator)
-  add_dependencies(op_function_cmd copy_dll)
   endif(WITH_MKL)
+  if(WITH_MKLDNN)
+    add_custom_target(copy_mkldnn
+        COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+        )
+  endif(WITH_MKLDNN)
 else(WIN32)
   add_custom_target(op_function_cmd 
     COMMAND "${CMAKE_CURRENT_BINARY_DIR}/op_function_generator" 
     "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
     add_dependencies(op_function_cmd op_function_generator)
+  if(WITH_MKL)
+  add_custom_target(copy_mkl
+        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+        )
+  endif(WITH_MKL)
+  if(WITH_MKLDNN)
+    add_custom_target(copy_mkldnn
+        COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+        )
+  endif(WITH_MKLDNN)
 endif(WIN32)
 
+if(WITH_MKL)
+add_dependencies(copy_mkl op_function_generator)
+add_dependencies(op_function_cmd copy_mkl)
+endif(WITH_MKL)
+
+if(WITH_MKLDNN)
+add_dependencies(copy_mkldnn op_function_generator)
+add_dependencies(op_function_cmd copy_mkldnn)  
+endif(WITH_MKLDNN)
 
 if(WITH_PYTHON)
   if(WITH_AMD_GPU)

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -33,62 +33,73 @@ if (WITH_DISTRIBUTE)
   list(APPEND PYBIND_SRCS communicator_py.cc)
 endif()
 
-# generate op pybind functions automatically for dygraph.
-set(OP_FUNCTION_GENERETOR_DEPS pybind proto_desc executor layer tracer engine imperative_profiler imperative_flag)
-list(APPEND OP_FUNCTION_GENERETOR_DEPS ${GLOB_OP_LIB})
-list(APPEND OP_FUNCTION_GENERETOR_DEPS ${GLOB_OPERATOR_DEPS})
-
-add_executable(op_function_generator op_function_generator.cc)
-target_link_libraries(op_function_generator ${OP_FUNCTION_GENERETOR_DEPS} )
-get_property (os_dependency_modules GLOBAL PROPERTY OS_DEPENDENCY_MODULES)
-target_link_libraries(op_function_generator ${os_dependency_modules})
-
-if (WIN32)
-  add_custom_target(op_function_cmd 
-    COMMAND "${CMAKE_BINARY_DIR}/paddle/fluid/pybind/${CMAKE_BUILD_TYPE}/op_function_generator" 
-    "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
-    add_dependencies(op_function_cmd op_function_generator)
-  if(WITH_MKL)
-  add_custom_target(copy_mkl 
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-        )
-  endif(WITH_MKL)
-  if(WITH_MKLDNN)
-    add_custom_target(copy_mkldnn
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-        )
-  endif(WITH_MKLDNN)
-else(WIN32)
-  add_custom_target(op_function_cmd 
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/op_function_generator" 
-    "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
-    add_dependencies(op_function_cmd op_function_generator)
-  if(WITH_MKL)
-  add_custom_target(copy_mkl
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
-        )
-  endif(WITH_MKL)
-  if(WITH_MKLDNN)
-    add_custom_target(copy_mkldnn
-        COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
-        )
-  endif(WITH_MKLDNN)
-endif(WIN32)
-
-if(WITH_MKL)
-add_dependencies(copy_mkl op_function_generator)
-add_dependencies(op_function_cmd copy_mkl)
-endif(WITH_MKL)
-
-if(WITH_MKLDNN)
-add_dependencies(copy_mkldnn op_function_generator)
-add_dependencies(op_function_cmd copy_mkldnn)  
-endif(WITH_MKLDNN)
-
 if(WITH_PYTHON)
+
+  # generate op pybind functions automatically for dygraph.
+  set(OP_FUNCTION_GENERETOR_DEPS pybind proto_desc executor layer tracer engine imperative_profiler imperative_flag)
+  list(APPEND OP_FUNCTION_GENERETOR_DEPS ${GLOB_OP_LIB})
+  list(APPEND OP_FUNCTION_GENERETOR_DEPS ${GLOB_OPERATOR_DEPS})
+
+  if(NOT WIN32)
+    list(APPEND OP_FUNCTION_GENERETOR_DEPS nccl_context)
+  endif(NOT WIN32)
+
+  add_executable(op_function_generator op_function_generator.cc)
+  target_link_libraries(op_function_generator ${OP_FUNCTION_GENERETOR_DEPS} )
+  get_property (os_dependency_modules GLOBAL PROPERTY OS_DEPENDENCY_MODULES)
+  target_link_libraries(op_function_generator ${os_dependency_modules})
+
+  if (WIN32)
+    add_custom_target(op_function_cmd 
+      COMMAND "${CMAKE_BINARY_DIR}/paddle/fluid/pybind/${CMAKE_BUILD_TYPE}/op_function_generator" 
+      "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
+      add_dependencies(op_function_cmd op_function_generator)
+    if(WITH_MKL)
+    add_custom_target(copy_mkl 
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+          )
+    endif(WITH_MKL)
+    if(WITH_MKLDNN)
+      add_custom_target(copy_mkldnn
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+          )
+    endif(WITH_MKLDNN)
+  else(WIN32)
+    # If there are no *.so in /usr/lib or LD_LIBRARY_PATH, 
+    # copy these *.so to current directory and append current directory to
+    # LD_LIBRARY_PATH. This is different with Windows platformm, which search 
+    # *.dll in current directory automatically.
+    add_custom_target(op_function_cmd 
+      COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:."
+      "${CMAKE_CURRENT_BINARY_DIR}/op_function_generator"
+      "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
+      add_dependencies(op_function_cmd op_function_generator)
+    if(WITH_MKL)
+    add_custom_target(copy_mkl
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+          )
+    endif(WITH_MKL)
+    if(WITH_MKLDNN)
+      add_custom_target(copy_mkldnn
+          COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+          )
+    endif(WITH_MKLDNN)
+  endif(WIN32)
+
+  if(WITH_MKL)
+  add_dependencies(copy_mkl op_function_generator)
+  add_dependencies(op_function_cmd copy_mkl)
+  endif(WITH_MKL)
+
+  if(WITH_MKLDNN)
+  add_dependencies(copy_mkldnn op_function_generator)
+  add_dependencies(op_function_cmd copy_mkldnn)  
+  endif(WITH_MKLDNN)
+
+
   if(WITH_AMD_GPU)
     hip_library(paddle_pybind SHARED
       SRCS ${PYBIND_SRCS}


### PR DESCRIPTION
The `op_function_generator` presented in  [PR21569](https://github.com/PaddlePaddle/Paddle/pull/21569) needs liboimp5.so(.dll on windows) and libmkldnn.so (.dll on windows) when `WITH_MKL` and `WITH_MKLDNN` is on.

This PR carefully copy these dynamic library to the directory where `op_function_generator` is, and add that directory to `LD_LIBRARY_PATH`, so `op_function_generator` can run.

This also fixes #21692.