### PR TITLE
fix bug that tuple(Variable) is converted to list(Variable) uncorrectly

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1833,7 +1833,7 @@ class Operator(object):
                         continue
                     out_args = outputs[out_proto.name]
                     if not isinstance(out_args, list):
-                        in_args = [in_args]
+                        out_args = [out_args]
                     if not out_proto.duplicable and len(out_args) > 1:
                         raise ValueError(
                             "Output %s expects only one output, but %d are given."

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1796,7 +1796,7 @@ class Operator(object):
                     if found:
                         in_args = inputs[in_proto.name]
                         if not isinstance(in_args, list):
-                            in_args = list(in_args)
+                            in_args = [in_args]
                         if not in_proto.duplicable and len(in_args) > 1:
                             raise ValueError(
                                 "Input %s expects only one input, but %d are given."
@@ -1833,7 +1833,7 @@ class Operator(object):
                         continue
                     out_args = outputs[out_proto.name]
                     if not isinstance(out_args, list):
-                        out_args = list(out_args)
+                        in_args = [in_args]
                     if not out_proto.duplicable and len(out_args) > 1:
                         raise ValueError(
                             "Output %s expects only one output, but %d are given."

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1796,7 +1796,7 @@ class Operator(object):
                     if found:
                         in_args = inputs[in_proto.name]
                         if not isinstance(in_args, list):
-                            in_args = [in_args]
+                            in_args = list(in_args)
                         if not in_proto.duplicable and len(in_args) > 1:
                             raise ValueError(
                                 "Input %s expects only one input, but %d are given."
@@ -1814,8 +1814,8 @@ class Operator(object):
                                     "The type of '%s' in operator %s should be "
                                     "one of [basestring(), str, Varibale] in python2, "
                                     "or one of [str, bytes, Variable] in python3."
-                                    "but received : " % (in_proto.name, type),
-                                    arg)
+                                    "but received : %s" %
+                                    (in_proto.name, type, arg))
                         self.desc.set_input(in_proto.name, in_arg_names)
                     else:
                         self.desc.set_input(in_proto.name, [])
@@ -1833,7 +1833,7 @@ class Operator(object):
                         continue
                     out_args = outputs[out_proto.name]
                     if not isinstance(out_args, list):
-                        out_args = [out_args]
+                        out_args = list(out_args)
                     if not out_proto.duplicable and len(out_args) > 1:
                         raise ValueError(
                             "Output %s expects only one output, but %d are given."

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12278,15 +12278,19 @@ def py_func(func, x, out, backward_func=None, skip_vars_in_backward_input=None):
     helper = LayerHelper('py_func', **locals())
     if x is None:
         x = []
-    elif isinstance(x, (Variable, tuple)):
+    elif isinstance(x, Variable):
         x = [x]
+    elif isinstance(x, tuple):
+        x = list(x)
     elif not isinstance(x, (list, tuple, Variable)):
         raise TypeError('Input must be Variable/list(Variable)/tuple(Variable)')
 
     if out is None:
         out_list = []
-    elif isinstance(out, (Variable, tuple)):
+    elif isinstance(out, Variable):
         out_list = [out]
+    elif isinstance(out, tuple):
+        out_list = list(out)
     elif not isinstance(x, (list, tuple, Variable)):
         raise TypeError(
             'Output must be Variable/list(Variable)/tuple(Variable)')

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12278,18 +12278,16 @@ def py_func(func, x, out, backward_func=None, skip_vars_in_backward_input=None):
     helper = LayerHelper('py_func', **locals())
     if x is None:
         x = []
-    elif isinstance(x, Variable):
+    elif isinstance(x, (Variable, tuple)):
         x = [x]
-    elif not isinstance(x, (list, tuple)):
+    elif not isinstance(x, (list, tuple, Variable)):
         raise TypeError('Input must be Variable/list(Variable)/tuple(Variable)')
 
     if out is None:
         out_list = []
-    elif isinstance(out, Variable):
+    elif isinstance(out, (Variable, tuple)):
         out_list = [out]
-    elif isinstance(out, (list, tuple)):
-        out_list = out
-    else:
+    elif not isinstance(x, (list, tuple, Variable)):
         raise TypeError(
             'Output must be Variable/list(Variable)/tuple(Variable)')
 


### PR DESCRIPTION
fix bug that tuple(Variable) is converted to list(Variable) uncorrectly.

It will result this problem when input tuple(Variable)  in py_func.
![image](https://user-images.githubusercontent.com/52485244/70614782-1c852e00-1c46-11ea-815a-5c94f95ce996.png)
