### PR TITLE
fix input shape of op tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -232,7 +232,7 @@ class TestAbs(TestActivation):
         self.op_type = "abs"
         self.init_dtype()
 
-        x = np.random.uniform(-1, 1, [4, 4]).astype(self.dtype)
+        x = np.random.uniform(-1, 1, [4, 25]).astype(self.dtype)
         # Because we set delta = 0.005 in calculating numeric gradient,
         # if x is too small, such as 0.002, x_neg will be -0.003
         # x_pos will be 0.007, so the numeric gradient is inaccurate.

--- a/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
@@ -23,7 +23,7 @@ class TestBilinearTensorProductOp(OpTest):
     def setUp(self):
         self.op_type = "bilinear_tensor_product"
         batch_size = 6
-        size0 = 3
+        size0 = 5
         size1 = 4
         size2 = 5
         a = np.random.random((batch_size, size0)).astype("float32")

--- a/python/paddle/fluid/tests/unittests/test_cos_sim_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cos_sim_op.py
@@ -23,8 +23,8 @@ class TestCosSimOp(OpTest):
     def setUp(self):
         self.op_type = "cos_sim"
         self.inputs = {
-            'X': np.random.random((6, 5)).astype("float32"),
-            'Y': np.random.random((6, 5)).astype("float32")
+            'X': np.random.random((6, 20)).astype("float32"),
+            'Y': np.random.random((6, 20)).astype("float32")
         }
         expect_x_norm = np.linalg.norm(self.inputs['X'], axis=1)
         expect_y_norm = np.linalg.norm(self.inputs['Y'], axis=1)

--- a/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
@@ -49,7 +49,7 @@ class TestElementwiseOp(OpTest):
 class TestElementwiseMinOp_scalar(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.random_integers(-5, 5, [2, 3, 4]).astype("float32")
+        x = np.random.random_integers(-5, 5, [10, 3, 4]).astype("float32")
         y = np.array([0.5]).astype("float32")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
@@ -58,9 +58,9 @@ class TestElementwiseMinOp_scalar(TestElementwiseOp):
 class TestElementwiseMinOp_Vector(TestElementwiseOp):
     def setUp(self):
         self.op_type = "elementwise_min"
-        x = np.random.random((32, )).astype("float32")
-        sgn = np.random.choice([-1, 1], (32, )).astype("float32")
-        y = x + sgn * np.random.uniform(0.1, 1, (32, )).astype("float32")
+        x = np.random.random((100, )).astype("float32")
+        sgn = np.random.choice([-1, 1], (100, )).astype("float32")
+        y = x + sgn * np.random.uniform(0.1, 1, (100, )).astype("float32")
         self.inputs = {'X': x, 'Y': y}
         self.outputs = {'Out': np.minimum(self.inputs['X'], self.inputs['Y'])}
 

--- a/python/paddle/fluid/tests/unittests/test_expand_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_op.py
@@ -33,7 +33,7 @@ class TestExpandOpRank1(OpTest):
         self.outputs = {'Out': output}
 
     def init_data(self):
-        self.ori_shape = [12]
+        self.ori_shape = [100]
         self.expand_times = [2]
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_flatten2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten2_op.py
@@ -38,9 +38,9 @@ class TestFlattenOp(OpTest):
         self.check_grad(["X"], "Out")
 
     def init_test_case(self):
-        self.in_shape = (3, 2, 2, 5)
+        self.in_shape = (3, 2, 4, 5)
         self.axis = 1
-        self.new_shape = (3, 20)
+        self.new_shape = (3, 40)
 
     def init_attrs(self):
         self.attrs = {"axis": self.axis}
@@ -48,9 +48,9 @@ class TestFlattenOp(OpTest):
 
 class TestFlattenOp(TestFlattenOp):
     def init_test_case(self):
-        self.in_shape = (3, 2, 2, 3)
+        self.in_shape = (3, 2, 5, 4)
         self.axis = 0
-        self.new_shape = (1, 36)
+        self.new_shape = (1, 120)
 
 
 class TestFlattenOpWithDefaultAxis(TestFlattenOp):

--- a/python/paddle/fluid/tests/unittests/test_flatten_op.py
+++ b/python/paddle/fluid/tests/unittests/test_flatten_op.py
@@ -35,9 +35,9 @@ class TestFlattenOp(OpTest):
         self.check_grad(["X"], "Out")
 
     def init_test_case(self):
-        self.in_shape = (3, 2, 2, 5)
+        self.in_shape = (3, 2, 2, 10)
         self.axis = 1
-        self.new_shape = (3, 20)
+        self.new_shape = (3, 40)
 
     def init_attrs(self):
         self.attrs = {"axis": self.axis}
@@ -45,9 +45,9 @@ class TestFlattenOp(OpTest):
 
 class TestFlattenOp(TestFlattenOp):
     def init_test_case(self):
-        self.in_shape = (3, 2, 2, 3)
+        self.in_shape = (3, 2, 2, 10)
         self.axis = 0
-        self.new_shape = (1, 36)
+        self.new_shape = (1, 120)
 
 
 class TestFlattenOpWithDefaultAxis(TestFlattenOp):

--- a/python/paddle/fluid/tests/unittests/test_im2sequence_op.py
+++ b/python/paddle/fluid/tests/unittests/test_im2sequence_op.py
@@ -129,7 +129,7 @@ class TestBlockExpandOp(OpTest):
         self.batch_size = 1
         self.img_channels = 3
         self.img_height = 4
-        self.img_width = 4
+        self.img_width = 10
         self.attrs = {
             'kernels': [2, 2],
             'strides': [1, 1],

--- a/python/paddle/fluid/tests/unittests/test_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_norm_op.py
@@ -44,7 +44,7 @@ class TestNormOp(OpTest):
         self.check_grad(['X'], 'Out')
 
     def init_test_case(self):
-        self.shape = [2, 3, 4, 4]
+        self.shape = [2, 3, 4, 5]
         self.axis = 1
         self.epsilon = 1e-8
 

--- a/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
@@ -51,8 +51,8 @@ class TestPadOp(OpTest):
 
 class TestCase1(TestPadOp):
     def initTestCase(self):
-        self.x_shape = (4, 3, 4, 4)
-        self.y_shape = (2, 3, 4, 4)
+        self.x_shape = (4, 3, 4, 5)
+        self.y_shape = (2, 3, 4, 5)
         self.paddings = [(0, 2), (0, 0), (0, 0), (0, 0)]
         self.pad_value = 0.5
 

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -53,7 +53,7 @@ class TestPadOp(OpTest):
 
 class TestCase1(TestPadOp):
     def initTestCase(self):
-        self.shape = (2, 3, 4, 4)
+        self.shape = (2, 3, 4, 5)
         self.paddings = [(0, 1), (2, 3), (2, 1), (1, 1)]
         self.pad_value = 0.5
 

--- a/python/paddle/fluid/tests/unittests/test_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scatter_op.py
@@ -23,9 +23,9 @@ import paddle.fluid.core as core
 class TestScatterOp(OpTest):
     def setUp(self):
         self.op_type = "scatter"
-        ref_np = np.ones((3, 3)).astype("float32")
+        ref_np = np.ones((3, 50)).astype("float32")
         index_np = np.array([1, 2]).astype("int32")
-        updates_np = np.random.random((2, 3)).astype("float32")
+        updates_np = np.random.random((2, 50)).astype("float32")
         output_np = np.copy(ref_np)
         output_np[index_np] = updates_np
         self.inputs = {'X': ref_np, 'Ids': index_np, 'Updates': updates_np}

--- a/python/paddle/fluid/tests/unittests/test_sequence_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_pad_op.py
@@ -19,7 +19,7 @@ from op_test import OpTest
 
 class TestSequencePadOp(OpTest):
     def set_attr(self):
-        self.x_shape = [12, 4]
+        self.x_shape = [12, 10]
         self.x_len_lod = [[2, 3, 4, 3]]
         self.pad_value = [1.0]
         self.padded_length = -1

--- a/python/paddle/fluid/tests/unittests/test_sequence_unpad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_unpad_op.py
@@ -21,7 +21,7 @@ from op_test import OpTest
 class TestSequenceUnpadOp(OpTest):
     def init(self):
         self.length = [2, 3, 4]
-        self.x_shape = (3, 5)
+        self.x_shape = (3, 40)
         self.dtype = "float32"
 
     def compute(self):

--- a/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
@@ -75,7 +75,7 @@ class TestStrideSliceOp(OpTest):
         self.check_grad(set(['Input']), 'Out')
 
     def initTestCase(self):
-        self.input = np.random.rand(6)
+        self.input = np.random.rand(100)
         self.axes = [0]
         self.starts = [-4]
         self.ends = [-3]

--- a/python/paddle/fluid/tests/unittests/test_unpool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unpool_op.py
@@ -89,7 +89,7 @@ class TestUnpoolOp(OpTest):
     def init_test_case(self):
         self.unpool2d_forward_naive = unpool2dmax_forward_naive
         self.unpooling_type = "max"
-        self.shape = [6, 4, 5, 5]
+        self.shape = [6, 4, 7, 7]
         self.ksize = [3, 3]
         self.strides = [2, 2]
         self.paddings = [0, 0]


### PR DESCRIPTION
- fix input shape of op tests for scatter, sequence_pad, sequence_unpad, expand, pad, pad_constant_like, norm, bilinear_tensor_product, flatten2, im2sequence, unpool, cos_sim, strided_slice, flatten, elementwise_min, abs, acos
- fix https://github.com/PaddlePaddle/Paddle/pull/21391/files#r356043791