### PR TITLE
fix input shape of op tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_center_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_center_loss.py
@@ -25,7 +25,7 @@ class TestCenterLossOp(OpTest):
         self.op_type = "center_loss"
         self.dtype = np.float32
         self.init_dtype_type()
-        batch_size = 6
+        batch_size = 12
         feet_dim = 10
         cluster_num = 8
         self.attrs = {}

--- a/python/paddle/fluid/tests/unittests/test_conv_shift_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv_shift_op.py
@@ -34,9 +34,9 @@ class TestConvShiftOp(OpTest):
     def setUp(self):
         self.op_type = "conv_shift"
 
-        batch_size = 4
+        batch_size = 10
         x_dim = 17
-        y_dim = 3  # must be odd and <= x_dim
+        y_dim = 11  # must be odd and <= x_dim
         x = np.random.random((batch_size, x_dim)).astype("float32")
         y = np.random.random((batch_size, y_dim)).astype("float32")
         self.inputs = {'X': x, 'Y': y}

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -33,8 +33,8 @@ def bcast(x, target_tensor):
 class TestExpandAsOpRank1(OpTest):
     def setUp(self):
         self.op_type = "expand_as"
-        x = np.random.rand(12).astype("float64")
-        target_tensor = np.random.rand(24).astype("float64")
+        x = np.random.rand(100).astype("float64")
+        target_tensor = np.random.rand(200).astype("float64")
         self.inputs = {'X': x, 'target_tensor': target_tensor}
         self.attrs = {}
         bcast_dims = bcast(x, target_tensor)

--- a/python/paddle/fluid/tests/unittests/test_gather_nd_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gather_nd_op.py
@@ -27,8 +27,7 @@ class TestGatherNdOpWithEmptyIndex(OpTest):
 
     def setUp(self):
         self.op_type = "gather_nd"
-        xnp = np.array(
-            [[65, 17, 2], [-14, -25, -1], [76, 22, 3]]).astype("float32")
+        xnp = np.random.random((5, 20)).astype("float32")
         self.inputs = {'X': xnp, 'Index': np.array([[], []]).astype("int32")}
         self.outputs = {
             'Out': np.vstack((xnp[np.newaxis, :], xnp[np.newaxis, :]))

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -45,7 +45,7 @@ class TestGroupNormOp(OpTest):
         self.op_type = "group_norm"
         self.data_format = "NCHW"
         self.dtype = np.float64
-        self.shape = (2, 4, 3, 3)
+        self.shape = (2, 4, 3, 5)
         self.attrs = {'epsilon': 1e-5, 'groups': 2, 'data_layout': "NCHW"}
         self.compare_between_place = False
         self.init_test_case()

--- a/python/paddle/fluid/tests/unittests/test_hinge_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hinge_loss_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestHingeLossOp(OpTest):
     def setUp(self):
         self.op_type = 'hinge_loss'
-        samples_num = 64
+        samples_num = 100
         logits = np.random.uniform(-10, 10, (samples_num, 1)).astype('float32')
         labels = np.random.randint(0, 2, (samples_num, 1)).astype('float32')
 

--- a/python/paddle/fluid/tests/unittests/test_huber_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_huber_loss_op.py
@@ -47,7 +47,7 @@ class TestHuberLossOp(OpTest):
         }
 
     def set_shape(self):
-        return (64, 1)
+        return (100, 1)
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/test_kldiv_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_kldiv_loss_op.py
@@ -56,7 +56,7 @@ class TestKLDivLossOp(OpTest):
             ['X'], 'Loss', no_grad_set=set(["Target"]), max_relative_error=0.06)
 
     def initTestCase(self):
-        self.x_shape = (2, 5, 5)
+        self.x_shape = (4, 5, 5)
         self.reduction = 'batchmean'
 
 

--- a/python/paddle/fluid/tests/unittests/test_modified_huber_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_modified_huber_loss_op.py
@@ -31,7 +31,7 @@ def modified_huber_loss_forward(val):
 class TestModifiedHuberLossOp(OpTest):
     def setUp(self):
         self.op_type = 'modified_huber_loss'
-        samples_num = 32
+        samples_num = 100
 
         x_np = np.random.uniform(-2., 2., (samples_num, 1)).astype('float32')
         y_np = np.random.choice([0, 1], samples_num).reshape(

--- a/python/paddle/fluid/tests/unittests/test_multiplex_op.py
+++ b/python/paddle/fluid/tests/unittests/test_multiplex_op.py
@@ -26,10 +26,10 @@ class TestMultiplexOp(OpTest):
         index = np.arange(0, rows).astype('int32')
         np.random.shuffle(index)
         index = np.reshape(index, (rows, 1))
-        ins1 = np.random.random((rows, 10)).astype("float32")
-        ins2 = np.random.random((rows, 10)).astype("float32")
-        ins3 = np.random.random((rows, 10)).astype("float32")
-        ins4 = np.random.random((rows, 10)).astype("float32")
+        ins1 = np.random.random((rows, 25)).astype("float32")
+        ins2 = np.random.random((rows, 25)).astype("float32")
+        ins3 = np.random.random((rows, 25)).astype("float32")
+        ins4 = np.random.random((rows, 25)).astype("float32")
         self.inputs = {
             'Ids': index,
             'X': [('x1', ins1), ('x2', ins2), ('x3', ins3), ('x4', ins4)]

--- a/python/paddle/fluid/tests/unittests/test_nce.py
+++ b/python/paddle/fluid/tests/unittests/test_nce.py
@@ -88,7 +88,7 @@ class TestNCE(OpTest):
         }
 
     def set_data(self):
-        self.generate_data(5, 5, 4, 1, 2, False)
+        self.generate_data(5, 25, 4, 1, 2, False)
 
     def compute(self):
         out = nce(self.inputs['Input'], self.inputs['Weight'],

--- a/python/paddle/fluid/tests/unittests/test_rank_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_rank_loss_op.py
@@ -22,7 +22,7 @@ from op_test import OpTest
 class TestRankLossOp(OpTest):
     def setUp(self):
         self.op_type = "rank_loss"
-        shape = (5, 1)
+        shape = (100, 1)
         # labels_{i} = {0, 1.0} or {0, 0.5, 1.0}
         label_shape, left_shape, right_shape = self.set_shape()
         label = np.random.randint(0, 2, size=shape).astype("float32")
@@ -38,7 +38,7 @@ class TestRankLossOp(OpTest):
         self.outputs = {'Out': loss.reshape(label_shape)}
 
     def set_shape(self):
-        batch_size = 5
+        batch_size = 100
         return (batch_size, 1), (batch_size, 1), (batch_size, 1)
 
     def test_check_output(self):
@@ -56,31 +56,31 @@ class TestRankLossOp(OpTest):
 
 class TestRankLossOp1(TestRankLossOp):
     def set_shape(self):
-        batch_size = 5
+        batch_size = 100
         return (batch_size), (batch_size, 1), (batch_size, 1)
 
 
 class TestRankLossOp2(TestRankLossOp):
     def set_shape(self):
-        batch_size = 5
+        batch_size = 100
         return (batch_size, 1), (batch_size), (batch_size, 1)
 
 
 class TestRankLossOp3(TestRankLossOp):
     def set_shape(self):
-        batch_size = 5
+        batch_size = 100
         return (batch_size, 1), (batch_size, 1), (batch_size)
 
 
 class TestRankLossOp4(TestRankLossOp):
     def set_shape(self):
-        batch_size = 5
+        batch_size = 100
         return (batch_size), (batch_size), (batch_size, 1)
 
 
 class TestRankLossOp5(TestRankLossOp):
     def set_shape(self):
-        batch_size = 5
+        batch_size = 100
         return (batch_size), (batch_size), (batch_size)
 
 

--- a/python/paddle/fluid/tests/unittests/test_sequence_expand.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_expand.py
@@ -21,7 +21,7 @@ from op_test import OpTest
 
 class TestSequenceExpand(OpTest):
     def set_data(self):
-        x_data = np.random.uniform(0.1, 1, [3, 1]).astype('float32')
+        x_data = np.random.uniform(0.1, 1, [3, 40]).astype('float32')
         y_data = np.random.uniform(0.1, 1, [8, 1]).astype('float32')
         y_lod = [[1, 3, 4]]
         self.inputs = {'X': x_data, 'Y': (y_data, y_lod)}

--- a/python/paddle/fluid/tests/unittests/test_sequence_expand_as.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_expand_as.py
@@ -26,7 +26,7 @@ class TestSequenceExpandAs(OpTest):
         self.compute()
 
     def set_data(self):
-        x_data = np.random.uniform(0.1, 1, [3, 1]).astype('float32')
+        x_data = np.random.uniform(0.1, 1, [3, 40]).astype('float32')
         y_data = np.random.uniform(0.1, 1, [8, 1]).astype('float32')
         y_lod = [[1, 3, 4]]
         self.inputs = {'X': x_data, 'Y': (y_data, y_lod)}

--- a/python/paddle/fluid/tests/unittests/test_sequence_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_softmax_op.py
@@ -27,9 +27,9 @@ class TestSequenceSoftmaxOp(OpTest):
         self.use_cudnn = False
         self.init_op_type()
 
-        x = np.random.uniform(0.1, 1, (11, 1)).astype("float32")
+        x = np.random.uniform(0.1, 1, (110, 1)).astype("float32")
         self.init_lod()
-        out = np.zeros((11, 1)).astype("float32")
+        out = np.zeros((110, 1)).astype("float32")
         offset = 0
         for i in range(len(self.lod[0])):
             if (self.lod[0][i] == 0):
@@ -46,7 +46,7 @@ class TestSequenceSoftmaxOp(OpTest):
         self.attrs = {'use_cudnn': self.use_cudnn, }
 
     def init_lod(self):
-        self.lod = [[4, 1, 3, 3]]
+        self.lod = [[40, 10, 30, 30]]
 
     def init_op_type(self):
         pass
@@ -77,17 +77,17 @@ class TestSequenceSoftmaxCUDNNOp(TestSequenceSoftmaxOp):
 
 class TestSequenceSoftmaxOpSeqLen0Case0(TestSequenceSoftmaxOp):
     def init_lod(self):
-        self.lod = [[4, 0, 4, 3]]
+        self.lod = [[40, 0, 40, 30]]
 
 
 class TestSequenceSoftmaxOpSeqLen0Case1(TestSequenceSoftmaxOp):
     def init_lod(self):
-        self.lod = [[0, 4, 7, 0]]
+        self.lod = [[0, 40, 70, 0]]
 
 
 class TestSequenceSoftmaxOpSeqLen0Case2(TestSequenceSoftmaxOp):
     def init_lod(self):
-        self.lod = [[0, 0, 0, 11]]
+        self.lod = [[0, 0, 0, 110]]
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_smooth_l1_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_smooth_l1_loss_op.py
@@ -30,7 +30,7 @@ def smooth_l1_loss_forward(val, sigma2):
 class TestSmoothL1LossOp1(OpTest):
     def setUp(self):
         self.op_type = "smooth_l1_loss"
-        dims = (5, 10)
+        dims = (5, 20)
         self.inputs = {
             'X': np.random.random(dims).astype("float32"),
             'Y': np.random.random(dims).astype("float32")

--- a/python/paddle/fluid/tests/unittests/test_spp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_spp_op.py
@@ -66,7 +66,7 @@ class TestSppOp(OpTest):
             self.check_grad(['X'], 'Out', max_relative_error=0.05)
 
     def init_test_case(self):
-        self.shape = [3, 2, 4, 4]
+        self.shape = [4, 2, 4, 4]
         self.pyramid_height = 3
         self.pool2D_forward_naive = max_pool2D_forward_naive
         self.pool_type = "max"

--- a/python/paddle/fluid/tests/unittests/test_squared_l2_distance_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squared_l2_distance_op.py
@@ -23,8 +23,8 @@ class TestSquaredL2DistanceOp_f0(OpTest):
     def setUp(self):
         self.op_type = "squared_l2_distance"
         self.inputs = {
-            'X': np.random.uniform(0.1, 0.6, (2, 3)).astype("float32"),
-            'Y': np.random.uniform(0.1, 0.6, (2, 3)).astype("float32")
+            'X': np.random.uniform(0.1, 0.6, (5, 20)).astype("float32"),
+            'Y': np.random.uniform(0.1, 0.6, (5, 20)).astype("float32")
         }
         sub_res = self.inputs['X'] - self.inputs['Y']
         output = sub_res * sub_res


### PR DESCRIPTION
- fix input shape of op tests for sequence_expand, sequence_expand_as, squared_l2_distance, gather_nd, center_loss, rank_loss, conv_shift, spp, modified_huber_loss, smooth_l1_loss, multiplex, sequence_softmax, nce, huber_loss, group_norm, kldiv_loss, hinge_loss, expand_as
- fix https://github.com/PaddlePaddle/Paddle/pull/21391/files#r356043791