### PR TITLE
Re-anble vgg16, vgg19 and resnet101 models download

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -249,20 +249,20 @@ if(WITH_MKLDNN)
  
   # resnet101 int8
   # TODO(grygielski) Enable after MKL-DNN 1.0 merge
-#   set(INT8_RESNET101_MODEL_DIR "${INT8_DATA_DIR}/resnet101")
-#   download_int8_data(${INT8_RESNET101_MODEL_DIR} "Res101_int8_model.tar.gz" )
+  set(INT8_RESNET101_MODEL_DIR "${INT8_DATA_DIR}/resnet101")
+  download_int8_data(${INT8_RESNET101_MODEL_DIR} "Res101_int8_model.tar.gz" )
 #   inference_analysis_api_int8_test_run(test_analyzer_int8_resnet101 ${INT8_IMG_CLASS_TEST_APP} ${INT8_RESNET101_MODEL_DIR} ${IMAGENET_DATA_PATH})
  
   # vgg16 int8
   # TODO(grygielski) Enable after MKL-DNN 1.0 merge
-#   set(INT8_VGG16_MODEL_DIR "${INT8_DATA_DIR}/vgg16")
-#   download_int8_data(${INT8_VGG16_MODEL_DIR} "VGG16_int8_model.tar.gz" )
+  set(INT8_VGG16_MODEL_DIR "${INT8_DATA_DIR}/vgg16")
+  download_int8_data(${INT8_VGG16_MODEL_DIR} "VGG16_int8_model.tar.gz" )
 #   inference_analysis_api_int8_test_run(test_analyzer_int8_vgg16 ${INT8_IMG_CLASS_TEST_APP} ${INT8_VGG16_MODEL_DIR} ${IMAGENET_DATA_PATH})
  
   # vgg19 int8
   # TODO(grygielski) Enable after MKL-DNN 1.0 merge
-#   set(INT8_VGG19_MODEL_DIR "${INT8_DATA_DIR}/vgg19")
-#   download_int8_data(${INT8_VGG19_MODEL_DIR} "VGG19_int8_model.tar.gz" )
+  set(INT8_VGG19_MODEL_DIR "${INT8_DATA_DIR}/vgg19")
+  download_int8_data(${INT8_VGG19_MODEL_DIR} "VGG19_int8_model.tar.gz" )
 #   inference_analysis_api_int8_test_run(test_analyzer_int8_vgg19 ${INT8_IMG_CLASS_TEST_APP} ${INT8_VGG19_MODEL_DIR} ${IMAGENET_DATA_PATH})
 
   # googlenet int8


### PR DESCRIPTION
The download of these models has been temporarily disabled by @grygielski during the introduction of MKL-DNN 1.0, but our validation team needs the models to be downloaded so that the performance and accuracy of these models can be assessed. 

For now the unit tests will remain disabled, but with enabled download, the models can be ran manually.