### PR TITLE
use large input shape for accuracy test

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_affine_grid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_grid_op.py
@@ -63,8 +63,8 @@ class TestAffineGridOp(OpTest):
             max_relative_error=0.006)
 
     def initTestCase(self):
-        self.theta_shape = (3, 2, 3)
-        self.output_shape = np.array([3, 2, 5, 7]).astype("int32")
+        self.theta_shape = (17, 2, 3)
+        self.output_shape = np.array([17, 2, 5, 7]).astype("int32")
         self.dynamic_shape = False
 
 

--- a/python/paddle/fluid/tests/unittests/test_data_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_data_norm_op.py
@@ -182,12 +182,11 @@ class TestDataNormOp(OpTest):
         self.op_type = 'data_norm'
         self.use_mkldnn = False
         epsilon = 0.00001
-        x_shape = [2, 3]
-        scale_shape = [3]
+        x_shape = [10, 12]
+        scale_shape = [12]
         tp = np.float32
 
-        x_val = np.array([[-0.35702616, -0.42756206, -0.08306625],
-                          [0.41199666, -0.21719968, -0.10180971]]).astype(tp)
+        x_val = np.random.random(x_shape).astype(tp)
         batch_size = np.ones(scale_shape).astype(tp)
         batch_size *= 1e4
         batch_sum = np.zeros(scale_shape).astype(tp)
@@ -196,8 +195,8 @@ class TestDataNormOp(OpTest):
 
         y = np.array(x_val)
 
-        mean = np.array([[0, 0, 0], [0, 0, 0]]).astype(tp)
-        scale = np.array([[1, 1, 1], [1, 1, 1]]).astype(tp)
+        mean = np.zeros(x_shape).astype(tp)
+        scale = np.ones(x_shape).astype(tp)
 
         self.inputs = {
             "X": x_val,

--- a/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
@@ -28,7 +28,7 @@ import paddle.version as ver
 class TestFusedEmbeddingSeqPoolOp(OpTest):
     def setUp(self):
         self.op_type = "fused_embedding_seq_pool"
-        self.emb_size = 2
+        self.emb_size = 6
         self.table = np.random.random((17, self.emb_size)).astype("float32")
         self.ids = np.array([[[4], [3]], [[4], [3]], [[2], [1]],
                              [[16], [1]]]).astype("int64")

--- a/python/paddle/fluid/tests/unittests/test_label_smooth_op.py
+++ b/python/paddle/fluid/tests/unittests/test_label_smooth_op.py
@@ -23,7 +23,7 @@ class TestLabelSmoothOp(OpTest):
     def config(self):
         self.op_type = "label_smooth"
         self.epsilon = 0.1
-        batch_size, self.label_dim = 5, 10
+        batch_size, self.label_dim = 10, 12
         self.label = np.zeros((batch_size, self.label_dim)).astype("float64")
         nonzero_index = np.random.randint(self.label_dim, size=(batch_size))
         self.label[np.arange(batch_size), nonzero_index] = 1

--- a/python/paddle/fluid/tests/unittests/test_match_matrix_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_match_matrix_tensor_op.py
@@ -30,7 +30,7 @@ class TestMatchMatrixTensorOp(OpTest):
         self.op_type = "match_matrix_tensor"
 
     def set_data(self):
-        ix, iy, h, dim_t = [5, 8, 3, 4]
+        ix, iy, h, dim_t = [5, 8, 20, 4]
         x_lod = [[1, 2, 2]]
         y_lod = [[3, 1, 4]]
         self.init_data(ix, x_lod, iy, y_lod, h, dim_t)

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -121,7 +121,7 @@ class TestNearestInterpOp(OpTest):
 
     def init_test_case(self):
         self.interp_method = 'nearest'
-        self.input_shape = [2, 3, 4, 4]
+        self.input_shape = [2, 3, 4, 5]
         self.out_h = 2
         self.out_w = 2
         self.scale = 0.

--- a/python/paddle/fluid/tests/unittests/test_spectral_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_spectral_norm_op.py
@@ -73,9 +73,9 @@ class TestSpectralNormOpNoGrad(OpTest):
         self.check_output()
 
     def initTestCase(self):
-        self.weight_shape = (2, 3)
-        self.u_shape = (2, )
-        self.v_shape = (3, )
+        self.weight_shape = (10, 12)
+        self.u_shape = (10, )
+        self.v_shape = (12, )
         self.dim = 0
         self.power_iters = 5
         self.eps = 1e-12
@@ -100,9 +100,9 @@ class TestSpectralNormOp(TestSpectralNormOpNoGrad):
             max_relative_error=0.1)
 
     def initTestCase(self):
-        self.weight_shape = (2, 3)
-        self.u_shape = (2, )
-        self.v_shape = (3, )
+        self.weight_shape = (10, 12)
+        self.u_shape = (10, )
+        self.v_shape = (12, )
         self.dim = 0
         self.power_iters = 0
         self.eps = 1e-12

--- a/python/paddle/fluid/tests/unittests/test_var_conv_2d.py
+++ b/python/paddle/fluid/tests/unittests/test_var_conv_2d.py
@@ -29,7 +29,7 @@ class TestVarConv2dOp(OpTest):
         self.op_type = "var_conv_2d"
 
     def set_data(self):
-        input_channel = 3
+        input_channel = 8
         output_channel = 2
         filter_size = [2, 3]
         stride = [1, 1]

--- a/python/paddle/fluid/tests/unittests/test_warpctc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_warpctc_op.py
@@ -178,7 +178,7 @@ class CTCForward(object):
 class TestWarpCTCOp(OpTest):
     def config(self):
         self.batch_size = 4
-        self.num_classes = 8
+        self.num_classes = 12
         self.logits_lod = [[4, 1, 3, 3]]
         self.labels_lod = [[3, 1, 4, 4]]
         self.blank = self.num_classes - 1


### PR DESCRIPTION
- ops: affine_grid, label_smooth, spectral_norm, warpctc,
nearest_interp, data_norm, match_matrix_tensor,
var_conv_2d, fused_embedding_seq_pool
- fix https://github.com/PaddlePaddle/Paddle/pull/21391/files#r356043791