### PR TITLE
Remove self-set accuracy parameters of op tests: max_relative_error

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_max_op.py
@@ -35,7 +35,7 @@ class TestElementwiseOp(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.005)
+        self.check_grad(['X', 'Y'], 'Out')
 
     def test_check_grad_ingore_x(self):
         self.check_grad(

--- a/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_min_op.py
@@ -35,7 +35,7 @@ class TestElementwiseOp(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.005)
+        self.check_grad(['X', 'Y'], 'Out')
 
     def test_check_grad_ingore_x(self):
         self.check_grad(

--- a/python/paddle/fluid/tests/unittests/test_elementwise_sub_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_sub_op.py
@@ -31,7 +31,7 @@ class TestElementwiseOp(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.005)
+        self.check_grad(['X', 'Y'], 'Out')
 
     def test_check_grad_ingore_x(self):
         self.check_grad(

--- a/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
@@ -90,9 +90,9 @@ def create_test_class(test_case,
             if not grad_chek:
                 return
             if self.attrs["save_intermediate_out"]:
-                self.check_grad(['X', 'Y'], ['Out'], max_relative_error=0.005)
+                self.check_grad(['X', 'Y'], ['Out'])
             else:
-                self.check_grad(['X', 'Y'], ['Out'], max_relative_error=0.005)
+                self.check_grad(['X', 'Y'], ['Out'])
 
         def test_check_grad_ingore_x(self):
             if not grad_chek:

--- a/python/paddle/fluid/tests/unittests/test_sequence_topk_avg_pooling.py
+++ b/python/paddle/fluid/tests/unittests/test_sequence_topk_avg_pooling.py
@@ -116,7 +116,7 @@ class TestSequenceTopkAvgPoolingOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(['X'], 'Out', max_relative_error=0.005)
+        self.check_grad(['X'], 'Out')
 
 
 class TestSequenceTopkAvgPoolingOpCase1(TestSequenceTopkAvgPoolingOp):


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests:
elementwise_max_op
elementwise_min_op
elementwise_sub_op
fused_elemwise_activation_op
sequence_topk_avg_pooling