### PR TITLE
Remove self-set accuracy parameters of op tests: atol

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -825,7 +825,7 @@ def create_test_act_fp16_class(parent,
             place = core.CUDAPlace(0)
             support_fp16 = core.is_float16_supported(place)
             if support_fp16:
-                self.check_output_with_place(place, atol=atol)
+                self.check_output_with_place(place)
 
         def test_check_grad(self):
             place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -145,7 +145,7 @@ def create_test_cudnn_fp16_class(parent, grad_check=True):
             if core.is_compiled_with_cuda():
                 place = core.CUDAPlace(0)
                 if core.is_float16_supported(place):
-                    self.check_output_with_place(place, atol=2e-2)
+                    self.check_output_with_place(place)
 
         def test_check_grad_no_filter(self):
             place = core.CUDAPlace(0)
@@ -215,7 +215,7 @@ def create_test_cudnn_channel_last_fp16_class(parent, grad_check=True):
             if core.is_compiled_with_cuda():
                 place = core.CUDAPlace(0)
                 if core.is_float16_supported(place):
-                    self.check_output_with_place(place, atol=2e-2)
+                    self.check_output_with_place(place)
 
         def test_check_grad_no_filter(self):
             place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_op.py
@@ -333,7 +333,7 @@ def create_test_class(parent, cls_name):
         def test_check_output(self):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=2e-1)
+                self.check_output_with_place(place)
 
         def test_check_grad(self):
             place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -195,7 +195,7 @@ class TestFP16DropoutOp(OpTest):
         self.fix_seed = True
 
     def test_check_output(self):
-        self.check_output_with_place(core.CUDAPlace(0), atol=1e-3)
+        self.check_output_with_place(core.CUDAPlace(0))
 
 
 @unittest.skipIf(

--- a/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
@@ -81,7 +81,7 @@ def create_test_class(test_case,
             if self.dtype == np.float16 and core.is_compiled_with_cuda():
                 place = core.CUDAPlace(0)
                 if core.is_float16_supported(place):
-                    self.check_output_with_place(place, atol=1e-3)
+                    self.check_output_with_place(place)
             else:
                 self.check_output()
 

--- a/python/paddle/fluid/tests/unittests/test_fused_fc_elementwise_layernorm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_fc_elementwise_layernorm_op.py
@@ -68,7 +68,7 @@ class TestFusedFCElementwiseLayerNormOp(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, atol=2e-3)
+        self.check_output_with_place(place)
 
 
 class TestFusedFCElementwiseLayerNormOp2(TestFusedFCElementwiseLayerNormOp):

--- a/python/paddle/fluid/tests/unittests/test_fused_multihead_matmul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_multihead_matmul_op.py
@@ -102,7 +102,7 @@ class TestFusedMultiheadMatmulOp(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, atol=2e-3)
+        self.check_output_with_place(place)
 
 
 class TestFusedMultiHeadMatmulOp2(TestFusedMultiheadMatmulOp):

--- a/python/paddle/fluid/tests/unittests/test_fusion_transpose_flatten_concat_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fusion_transpose_flatten_concat_op.py
@@ -51,7 +51,7 @@ class TestFusionTransposeFlattenConcationOp(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, 1e-6)
+        self.check_output_with_place(place)
 
     def init_test_case(self):
         self.shapes = [(3, 4, 17, 17), (3, 8, 7, 7), (3, 12, 5, 5)]

--- a/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
@@ -175,7 +175,7 @@ class TestCUDNNLstmOp(OpTest):
     def test_output_with_place(self):
         # depend on the scope structure
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, atol=1e-5, check_dygraph=False)
+        self.check_output_with_place(place, check_dygraph=False)
 
     def test_grad_with_place(self):
         # depend on the scope structure

--- a/python/paddle/fluid/tests/unittests/test_mean_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mean_op.py
@@ -64,7 +64,7 @@ class TestFP16MeanOp(TestMeanOp):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=2e-3)
+            self.check_output_with_place(place)
 
     def test_checkout_grad(self):
         place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mul_op.py
@@ -111,7 +111,7 @@ class TestFP16MulOp1(TestMulOp):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=1e-1)
+            self.check_output_with_place(place)
 
     def test_check_grad_normal(self):
         place = core.CUDAPlace(0)
@@ -147,7 +147,7 @@ class TestFP16MulOp2(TestMulOp2):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=2e-1)
+            self.check_output_with_place(place)
 
     def test_check_grad_normal(self):
         place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -385,7 +385,7 @@ def create_test_cudnn_fp16_class(parent):
             if core.is_compiled_with_cuda():
                 place = core.CUDAPlace(0)
                 if core.is_float16_supported(place):
-                    self.check_output_with_place(place, atol=1e-3)
+                    self.check_output_with_place(place)
 
     cls_name = "{0}_{1}".format(parent.__name__, "CUDNNFp16Op")
     TestCUDNNFp16Case.__name__ = cls_name

--- a/python/paddle/fluid/tests/unittests/test_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scale_op.py
@@ -133,7 +133,7 @@ class TestScaleFp16Op(TestScaleOp):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=0.002)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scatter_op.py
@@ -95,7 +95,7 @@ class TestScatterOp2(OpTest):
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=1e-3)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -123,7 +123,7 @@ class TestScatterOp3(OpTest):
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=1e-3)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():
@@ -165,7 +165,7 @@ class TestScatterOp5(OpTest):
     def test_check_output(self):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
-            self.check_output_with_place(place, atol=1e-3)
+            self.check_output_with_place(place)
 
     def test_check_grad(self):
         if core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_sigmoid_focal_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sigmoid_focal_loss_op.py
@@ -99,7 +99,7 @@ class TestSigmoidFocalLossOp1(OpTest):
 class TestSigmoidFocalLossOp2(TestSigmoidFocalLossOp1):
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, atol=2e-3)
+        self.check_output_with_place(place)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)
@@ -120,7 +120,7 @@ class TestSigmoidFocalLossOp3(TestSigmoidFocalLossOp1):
 class TestSigmoidFocalLossOp4(TestSigmoidFocalLossOp3):
     def test_check_output(self):
         place = core.CUDAPlace(0)
-        self.check_output_with_place(place, atol=2e-3)
+        self.check_output_with_place(place)
 
     def test_check_grad(self):
         place = core.CUDAPlace(0)

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -173,7 +173,7 @@ class TestSoftmaxFP16Op(TestSoftmaxOp):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=1e-3)
+                self.check_output_with_place(place)
 
     # FIXME: If the x_shape is [10, 10], gradient failed.
     def test_check_grad(self):
@@ -190,7 +190,7 @@ class TestSoftmaxFP16Op2(TestSoftmaxOp):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=1e-3)
+                self.check_output_with_place(place)
 
     def get_x_shape(self):
         return [2, 3, 4, 5]
@@ -207,7 +207,7 @@ class TestSoftmaxFP16CUDNNOp(TestSoftmaxOp):
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place):
-                self.check_output_with_place(place, atol=1e-3)
+                self.check_output_with_place(place)
 
 
 @unittest.skipIf(not core.is_compiled_with_cuda(),

--- a/python/paddle/fluid/tests/unittests/test_sum_op.py
+++ b/python/paddle/fluid/tests/unittests/test_sum_op.py
@@ -195,7 +195,7 @@ class TestFP16SumOp(TestSumOp):
     def test_check_output(self):
         place = core.CUDAPlace(0)
         if core.is_float16_supported(place):
-            self.check_output_with_place(place, atol=2e-2)
+            self.check_output_with_place(place)
 
     # FIXME: Because of the precision fp16, max_relative_error
     # should be 0.15 here.


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests:
The op lists will be added later.