### PR TITLE
skip param checking in distribute mode

### DIFF
--- a/paddle/fluid/operators/uniform_random_op.cc
+++ b/paddle/fluid/operators/uniform_random_op.cc
@@ -74,12 +74,14 @@ class CPUUniformRandomKernel : public framework::OpKernel<T> {
         static_cast<unsigned int>(ctx.Attr<int>("diag_step"));
     auto diag_val = static_cast<T>(ctx.Attr<float>("diag_val"));
     if (diag_num > 0) {
+#ifndef PADDLE_WITH_DISTRIBUTE
       PADDLE_ENFORCE_GT(size, (diag_num - 1) * (diag_step + 1),
                         "ShapeError: the diagonal's elements is equal (num-1) "
                         "* (step-1) with num %d, step %d,"
                         "It should be smaller than %d, but received %d",
                         diag_num, diag_step, (diag_num - 1) * (diag_step + 1),
                         size);
+#endif
       for (int64_t i = 0; i < diag_num; ++i) {
         int64_t pos = i * diag_step + i;
         data[pos] = diag_val;


### PR DESCRIPTION
In distribute mode, tensor will be splited into many parts and initialized independently.

 And in this case, the numel of splitted tensor will be smaller than actual value, which leads `PADDLE_ENFORCE` will fail In distribute mode.

This PR skips the param checking in distribute mode.