### PR TITLE
Fix the bug of memory constrained in post training quantization and support the input be different for the same model

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -86,7 +86,7 @@ class PostTrainingQuantization(object):
                 is_full_quantized as False, only apply quantization to the op type 
                 according to the input quantizable_op_type.
             is_memory_constrained(bool, optional): If set is_memory_constrained as False,
-                all temp data will save in memory. If set is_save_sample_data as True,
+                all temp data will be saved in memory. If set is_save_sample_data as True,
                 it will save temp data to disk. When the fp32 model is complex or
                 the number of calibrate data is large, we should set is_save_sample_data
                 as True. Defalut is False.

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -336,9 +336,7 @@ class PostTrainingQuantization(object):
                     if re.match(var_name + '_[0-9]+.npy', f)]
                 for filename in filenames:
                     load_path = os.path.join(self._temp_dir, filename)
-                    print(load_path)
                     var_data = np.concatenate((var_data, np.load(load_path)))
-                    print(var_data.shape)
 
                 if self._algo == "KL":
                     self._quantized_var_scale_factor[var_name] = \

--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
+import os
+import re
 import logging
 import numpy as np
 from ....executor import global_scope
@@ -43,7 +45,9 @@ class PostTrainingQuantization(object):
                  scope=None,
                  algo="KL",
                  quantizable_op_type=["conv2d", "depthwise_conv2d", "mul"],
-                 is_full_quantize=False):
+                 is_full_quantize=False,
+                 is_memory_constrained=False,
+                 temp_dir="./temp_post_training"):
         '''
         The class utilizes post training quantization methon to quantize the 
         fp32 model. It uses calibrate data to calculate the scale factor of 
@@ -78,9 +82,16 @@ class PostTrainingQuantization(object):
                 that will be quantized. Default is ["conv2d", "depthwise_conv2d", 
                 "mul"].
             is_full_quantized(bool, optional): If set is_full_quantized as True, 
-                apply quantization to all supported quantizable op type. If set 
+                apply quantization to all supported quantizable op type. If set
                 is_full_quantized as False, only apply quantization to the op type 
                 according to the input quantizable_op_type.
+            is_memory_constrained(bool, optional): If set is_memory_constrained as False,
+                all temp data will save in memory. If set is_save_sample_data as True,
+                it will save temp data to disk. When the fp32 model is complex or
+                the number of calibrate data is large, we should set is_save_sample_data
+                as True. Defalut is False.
+            temp_dir(str, optional): When is_memory_constrained is True, set temp_dir as
+                the directory for saving temp data. Default is ./temp_post_training.
         Returns:
             None
 
@@ -129,6 +140,10 @@ class PostTrainingQuantization(object):
         self._batch_nums = batch_nums
         self._scope = global_scope() if scope == None else scope
         self._algo = algo
+        self._is_memory_constrained = is_memory_constrained
+        self._temp_dir = temp_dir
+        if self._is_memory_constrained and not os.path.exists(self._temp_dir):
+            os.mkdir(self._temp_dir)
 
         supported_quantizable_op_type = \
             QuantizationTransformPass._supported_quantizable_op_type + \
@@ -174,7 +189,8 @@ class PostTrainingQuantization(object):
                                feed=data,
                                fetch_list=self._fetch_list,
                                return_numpy=False)
-            self._sample_data()
+            self._sample_data(batch_id)
+
             if batch_id % 5 == 0:
                 _logger.info("run batch: " + str(batch_id))
             batch_id += 1
@@ -271,7 +287,7 @@ class PostTrainingQuantization(object):
             if var.name in self._quantized_act_var_name:
                 var.persistable = True
 
-    def _sample_data(self):
+    def _sample_data(self, iter):
         '''
         Sample the tensor data of quantized variables, 
         applied in every iteration.
@@ -281,11 +297,22 @@ class PostTrainingQuantization(object):
                 var_tensor = self._load_var_value(var_name)
                 self._sampling_data[var_name] = var_tensor
 
-        for var_name in self._quantized_act_var_name:
-            if var_name not in self._sampling_data:
-                self._sampling_data[var_name] = []
-            var_tensor = self._load_var_value(var_name)
-            self._sampling_data[var_name].append(var_tensor)
+        if self._is_memory_constrained:
+            for var_name in self._quantized_act_var_name:
+                var_tensor = self._load_var_value(var_name)
+                var_tensor = var_tensor.ravel()
+                save_path = os.path.join(self._temp_dir,
+                                         var_name + "_" + str(iter) + ".npy")
+                np.save(save_path, var_tensor)
+        else:
+            for var_name in self._quantized_act_var_name:
+                var_tensor = self._load_var_value(var_name)
+                var_tensor = var_tensor.ravel()
+                if var_name not in self._sampling_data:
+                    self._sampling_data[var_name] = var_tensor
+                else:
+                    self._sampling_data[var_name] = np.concatenate(
+                        (self._sampling_data[var_name], var_tensor))
 
     def _calculate_scale_factor(self):
         '''
@@ -302,13 +329,31 @@ class PostTrainingQuantization(object):
                 var_name] = scale_factor_per_channel
 
         # apply kl quantization for activation
-        for var_name in self._quantized_act_var_name:
-            if self._algo == "KL":
-                self._quantized_var_scale_factor[var_name] = \
-                    self._get_kl_scaling_factor(np.abs(self._sampling_data[var_name]))
-            else:
-                self._quantized_var_scale_factor[var_name] = \
-                    np.max(np.abs(self._sampling_data[var_name]))
+        if self._is_memory_constrained:
+            for var_name in self._quantized_act_var_name:
+                var_data = np.array([])
+                filenames = [f for f in os.listdir(self._temp_dir) \
+                    if re.match(var_name + '_[0-9]+.npy', f)]
+                for filename in filenames:
+                    load_path = os.path.join(self._temp_dir, filename)
+                    print(load_path)
+                    var_data = np.concatenate((var_data, np.load(load_path)))
+                    print(var_data.shape)
+
+                if self._algo == "KL":
+                    self._quantized_var_scale_factor[var_name] = \
+                        self._get_kl_scaling_factor(np.abs(var_data))
+                else:
+                    self._quantized_var_scale_factor[var_name] = \
+                        np.max(np.abs(var_data))
+        else:
+            for var_name in self._quantized_act_var_name:
+                if self._algo == "KL":
+                    self._quantized_var_scale_factor[var_name] = \
+                        self._get_kl_scaling_factor(np.abs(self._sampling_data[var_name]))
+                else:
+                    self._quantized_var_scale_factor[var_name] = \
+                        np.max(np.abs(self._sampling_data[var_name]))
 
     def _update_program(self):
         '''

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -309,7 +309,7 @@ class TestPostTrainingForMobilenetv1(TestPostTrainingQuantization):
         ]
         data_md5s = ['13892b0716d26443a8cdea15b3c6438b']
         is_full_quantize = True
-        is_memory_constrained = True
+        is_memory_constrained = False
         self.run_test(model, algo, data_urls, data_md5s, is_full_quantize,
                       is_memory_constrained)
 

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -238,7 +238,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
                                  model_path,
                                  algo="KL",
                                  is_full_quantize=False,
-                                 is_memory_constrained=False):
+                                 is_use_cache_file=False):
         try:
             os.system("mkdir " + self.int8_model)
         except Exception as e:
@@ -261,12 +261,12 @@ class TestPostTrainingQuantization(unittest.TestCase):
             algo=algo,
             quantizable_op_type=quantizable_op_type,
             is_full_quantize=is_full_quantize,
-            is_memory_constrained=is_memory_constrained)
+            is_use_cache_file=is_use_cache_file)
         ptq.quantize()
         ptq.save_quantized_model(self.int8_model)
 
     def run_test(self, model, algo, data_urls, data_md5s, is_full_quantize,
-                 is_memory_constrained):
+                 is_use_cache_file):
         infer_iterations = self.infer_iterations
         batch_size = self.batch_size
         sample_iterations = self.sample_iterations
@@ -281,7 +281,7 @@ class TestPostTrainingQuantization(unittest.TestCase):
         print("Start INT8 post training quantization for {0} on {1} images ...".
               format(model, sample_iterations * batch_size))
         self.generate_quantized_model(model_cache_folder + "/model", algo,
-                                      is_full_quantize, is_memory_constrained)
+                                      is_full_quantize, is_use_cache_file)
 
         print("Start INT8 inference for {0} on {1} images ...".format(
             model, infer_iterations * batch_size))
@@ -309,9 +309,9 @@ class TestPostTrainingForMobilenetv1(TestPostTrainingQuantization):
         ]
         data_md5s = ['13892b0716d26443a8cdea15b3c6438b']
         is_full_quantize = True
-        is_memory_constrained = False
+        is_use_cache_file = False
         self.run_test(model, algo, data_urls, data_md5s, is_full_quantize,
-                      is_memory_constrained)
+                      is_use_cache_file)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -237,7 +237,8 @@ class TestPostTrainingQuantization(unittest.TestCase):
     def generate_quantized_model(self,
                                  model_path,
                                  algo="KL",
-                                 is_full_quantize=False):
+                                 is_full_quantize=False,
+                                 is_memory_constrained=False):
         try:
             os.system("mkdir " + self.int8_model)
         except Exception as e:
@@ -259,11 +260,13 @@ class TestPostTrainingQuantization(unittest.TestCase):
             model_dir=model_path,
             algo=algo,
             quantizable_op_type=quantizable_op_type,
-            is_full_quantize=is_full_quantize)
+            is_full_quantize=is_full_quantize,
+            is_memory_constrained=is_memory_constrained)
         ptq.quantize()
         ptq.save_quantized_model(self.int8_model)
 
-    def run_test(self, model, algo, data_urls, data_md5s):
+    def run_test(self, model, algo, data_urls, data_md5s, is_full_quantize,
+                 is_memory_constrained):
         infer_iterations = self.infer_iterations
         batch_size = self.batch_size
         sample_iterations = self.sample_iterations
@@ -277,8 +280,8 @@ class TestPostTrainingQuantization(unittest.TestCase):
 
         print("Start INT8 post training quantization for {0} on {1} images ...".
               format(model, sample_iterations * batch_size))
-        self.generate_quantized_model(
-            model_cache_folder + "/model", algo=algo, is_full_quantize=True)
+        self.generate_quantized_model(model_cache_folder + "/model", algo,
+                                      is_full_quantize, is_memory_constrained)
 
         print("Start INT8 inference for {0} on {1} images ...".format(
             model, infer_iterations * batch_size))
@@ -305,7 +308,10 @@ class TestPostTrainingForMobilenetv1(TestPostTrainingQuantization):
             'http://paddle-inference-dist.bj.bcebos.com/int8/mobilenetv1_int8_model.tar.gz'
         ]
         data_md5s = ['13892b0716d26443a8cdea15b3c6438b']
-        self.run_test(model, algo, data_urls, data_md5s)
+        is_full_quantize = True
+        is_memory_constrained = True
+        self.run_test(model, algo, data_urls, data_md5s, is_full_quantize,
+                      is_memory_constrained)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
@@ -25,7 +25,10 @@ class TestPostTrainingForResnet50(TestPostTrainingQuantization):
             'http://paddle-inference-dist.bj.bcebos.com/int8/resnet50_int8_model.tar.gz'
         ]
         data_md5s = ['4a5194524823d9b76da6e738e1367881']
-        self.run_test(model, algo, data_urls, data_md5s)
+        is_full_quantize = False
+        is_memory_constrained = True
+        self.run_test(model, algo, data_urls, data_md5s, is_full_quantize,
+                      is_memory_constrained)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
@@ -26,9 +26,9 @@ class TestPostTrainingForResnet50(TestPostTrainingQuantization):
         ]
         data_md5s = ['4a5194524823d9b76da6e738e1367881']
         is_full_quantize = False
-        is_memory_constrained = True
+        is_use_cache_file = True
         self.run_test(model, algo, data_urls, data_md5s, is_full_quantize,
-                      is_memory_constrained)
+                      is_use_cache_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
For post training quantization:
* fix the bug of memory constrained
* support the input be different for the same model

离线量化：
* 修复离线量化中校准数据量过大的内存限制问题，将采样数据保存到磁盘
* 支持同一个模型设置任何尺寸的输出