### PR TITLE
all test cases with dtype int8 should inherit OpTestInt8

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_concat_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_concat_int8_mkldnn_op.py
@@ -16,10 +16,10 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTestInt8
 
 
-class TestConcatOp(OpTest):
+class TestConcatOp(OpTestInt8):
     def setUp(self):
         self.op_type = "concat"
         self.use_mkldnn = True

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_mul_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_mul_int8_mkldnn_op.py
@@ -17,13 +17,13 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTestInt8
 '''
  test case for s8 * s8
 '''
 
 
-class TestMKLDNNMulOpS8S8(OpTest):
+class TestMKLDNNMulOpS8S8(OpTestInt8):
     def setUp(self):
         self.op_type = "mul"
         self.init_kernel_type()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_int8_mkldnn_op.py
@@ -17,11 +17,11 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTestInt8
 from mkldnn_op_test import format_reorder
 
 
-class TestTransposeOp(OpTest):
+class TestTransposeOp(OpTestInt8):
     def setUp(self):
         self.init_op_type()
         self.initTestCase()

--- a/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_interp_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, OpTestInt8
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 
@@ -258,7 +258,7 @@ class TestBilinearInterpDataLayout(TestBilinearInterpOp):
         self.data_layout = "NHWC"
 
 
-class TestBilinearInterpOpUint8(OpTest):
+class TestBilinearInterpOpUint8(OpTestInt8):
     def setUp(self):
         self.out_size = None
         self.actual_shape = None

--- a/python/paddle/fluid/tests/unittests/test_dequantize_abs_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dequantize_abs_max_op.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import math
-from op_test import OpTest
+from op_test import OpTestInt8
 
 
 def quantize_max_abs(x, max_range):
@@ -31,7 +31,7 @@ def dequantize_max_abs(x, scale, max_range):
     return y
 
 
-class TestDequantizeMaxAbsOp(OpTest):
+class TestDequantizeMaxAbsOp(OpTestInt8):
     def set_args(self):
         self.num_bits = 8
         self.max_range = math.pow(2, self.num_bits - 1) - 1

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, OpTestInt8
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.compat as cpt
@@ -182,7 +182,7 @@ class TestEmbedOpError(unittest.TestCase):
             fluid.layers.embedding(input=input3, size=(10, 64), dtype='float16')
 
 
-class TestLookupTableOpInt8(OpTest):
+class TestLookupTableOpInt8(OpTestInt8):
     def setUp(self):
         self.op_type = "lookup_table"
         table = np.random.randint(
@@ -201,7 +201,7 @@ class TestLookupTableOpInt8(OpTest):
         pass
 
 
-class TestLookupTableOpWithTensorIdsInt8(OpTest):
+class TestLookupTableOpWithTensorIdsInt8(OpTestInt8):
     def setUp(self):
         self.op_type = "lookup_table"
         table = np.random.randint(

--- a/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_nearest_interp_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, OpTestInt8
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 
@@ -225,7 +225,7 @@ class TestNearestNeighborInterpDataLayout(TestNearestInterpOp):
         self.data_layout = "NHWC"
 
 
-class TestNearestInterpOpUint8(OpTest):
+class TestNearestInterpOpUint8(OpTestInt8):
     def setUp(self):
         self.out_size = None
         self.actual_shape = None

--- a/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_trilinear_interp_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, OpTestInt8
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 
@@ -319,7 +319,7 @@ class TestTrilinearInterpDatalayout(TestTrilinearInterpOp):
         self.data_layout = "NDHWC"
 
 
-class TestTrilinearInterpOpUint8(OpTest):
+class TestTrilinearInterpOpUint8(OpTestInt8):
     def setUp(self):
         self.out_size = None
         self.actual_shape = None


### PR DESCRIPTION
Precision of unit test need to be updated from float to double,  #21599  adds OpTestInt8 class, which is the parent class of the op test with int8 precision. This PR fix related test cases.