### PR TITLE
Modify the way to skip CI in distributed unittests

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dist_ctr.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_ctr.py
@@ -22,17 +22,6 @@ import os
 flag_name = os.path.splitext(__file__)[0]
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistCTR2x2(TestDistBase):
     def _setup_config(self):
         self._sync_mode = True
@@ -43,7 +32,7 @@ class TestDistCTR2x2(TestDistBase):
             "dist_ctr.py", delta=1e-2, check_error_log=True, log_name=flag_name)
 
 
-@skip_ci
+@unittest.skip(reason="Skip unstable ci")
 class TestDistCTRWithL2Decay2x2(TestDistBase):
     def _setup_config(self):
         self._sync_mode = True

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_ctr.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_ctr.py
@@ -19,17 +19,6 @@ import unittest
 from test_dist_fleet_base import TestFleetBase
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistMnist2x2(TestFleetBase):
     def _setup_config(self):
         self._sync_mode = False

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_geo.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_geo.py
@@ -24,17 +24,6 @@ from test_dist_fleet_base import TestFleetBase
 from dist_simnet_bow import train_network
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistGeoCtr_2x2(TestFleetBase):
     def _setup_config(self):
         self._sync_mode = False

--- a/python/paddle/fluid/tests/unittests/test_dist_se_resnext_async.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_se_resnext_async.py
@@ -20,23 +20,12 @@ import os
 flag_name = os.path.splitext(__file__)[0]
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistSeResneXt2x2Async(TestDistBase):
     def _setup_config(self):
         self._sync_mode = False
         self._use_reader_alloc = False
 
-    @skip_ci
+    @unittest.skip(reason="Skip unstable ci")
     def test_dist_train(self):
         self.check_with_place(
             "dist_se_resnext.py",

--- a/python/paddle/fluid/tests/unittests/test_dist_se_resnext_dgc.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_se_resnext_dgc.py
@@ -21,17 +21,6 @@ import os
 flag_name = os.path.splitext(__file__)[0]
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistSeResnetNCCL2DGC(TestDistBase):
     def _setup_config(self):
         self._sync_mode = True
@@ -40,7 +29,7 @@ class TestDistSeResnetNCCL2DGC(TestDistBase):
         self._nccl2_mode = True
         self._use_dgc = True
 
-    @skip_ci
+    @unittest.skip(reason="Skip unstable ci")
     def test_dist_train(self):
         import paddle.fluid as fluid
         if fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_dist_se_resnext_nccl.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_se_resnext_nccl.py
@@ -21,24 +21,13 @@ import os
 flag_name = os.path.splitext(__file__)[0]
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistSeResneXtNCCL(TestDistBase):
     def _setup_config(self):
         self._sync_mode = True
         self._use_reader_alloc = False
         self._nccl2_mode = True
 
-    @skip_ci
+    @unittest.skip(reason="Skip unstable ci")
     def test_dist_train(self):
         import paddle.fluid as fluid
         if fluid.core.is_compiled_with_cuda():
@@ -56,7 +45,7 @@ class TestDistSeResneXtNCCLMP(TestDistBase):
         self._nccl2_mode = True
         self._mp_mode = True
 
-    @skip_ci
+    @unittest.skip(reason="Skip unstable ci")
     def test_dist_train(self):
         import paddle.fluid as fluid
         if fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_dist_se_resnext_sync.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_se_resnext_sync.py
@@ -21,23 +21,12 @@ import os
 flag_name = os.path.splitext(__file__)[0]
 
 
-def skip_ci(func):
-    on_ci = bool(int(os.environ.get("SKIP_UNSTABLE_CI", '0')))
-
-    def __func__(*args, **kwargs):
-        if on_ci:
-            return
-        return func(*args, **kwargs)
-
-    return __func__
-
-
 class TestDistSeResneXt2x2(TestDistBase):
     def _setup_config(self):
         self._sync_mode = True
         self._use_reader_alloc = False
 
-    @skip_ci
+    @unittest.skip(reason="Skip unstable ci")
     def test_dist_train(self):
         self.check_with_place(
             "dist_se_resnext.py",


### PR DESCRIPTION
1. Modify the way to skip CI in distributed unittests
2. change skip_ci to unittest.skip
3. remove the function of skip_ci