### PR TITLE
Fix the seqconv_eltadd_relu fault during cpu multi-threads inference

### DIFF
--- a/paddle/fluid/framework/ir/seqconv_eltadd_relu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/seqconv_eltadd_relu_fuse_pass.cc
@@ -42,12 +42,7 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope) {
     op_desc.SetAttr("contextLength", seqconv->Op()->GetAttr("contextLength"));
     op_desc.SetAttr("contextStart", seqconv->Op()->GetAttr("contextStart"));
     op_desc.SetAttr("contextStride", seqconv->Op()->GetAttr("contextStride"));
-    PADDLE_ENFORCE(graph->Has(kParamScopeAttr));
-    auto& scope = graph->Get<Scope>(kParamScopeAttr);
-    const std::string ColMat = patterns::UniqueKey("SeqConvColMat");
-    op_desc.SetOutput("ColMat", {ColMat});
     op_desc.SetOutput("Out", {relu_out->Name()});
-    scope.Var(ColMat)->GetMutable<LoDTensor>();
 
     auto* op = graph->CreateOpNode(&op_desc);
     IR_NODE_LINK_TO(input, op);


### PR DESCRIPTION
Fix the seqconv_eltadd_relu fault during cpu multi-threads inference. 

Before this PR, the seqconv_eltadd_relu_fuse_pass will randomly or occasionally cause a seg-fault during cpu multi-thread inference with cloned predictors. 

This PR fix this bug by removing the "ColMat" in AddOuput().AsIntermediate() and providing an intermediate tensor during kernel computing. 