### PR TITLE
fix grad clip

### DIFF
--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -193,22 +193,22 @@ class GradientClipByNorm(BaseGradientClipAttr):
 
     .. math::
         Out =
-  	\\left \{
-  	\\begin{aligned}
-  	& X & & if (norm(X) \\leq clip\_norm) \\\\
-  	& \\frac{clip\_norm*X}{norm(X)} & & if (norm(X) > clip\_norm) \\\\
-  	\\end{aligned}
-  	\\right.
+        \\left \{
+        \\begin{aligned}
+        & X & & if (norm(X) \\leq clip\_norm) \\\\
+        & \\frac{clip\_norm*X}{norm(X)} & & if (norm(X) > clip\_norm) \\\\
+        \\end{aligned}
+        \\right.
 
 
     where :math:`norm(X)` represents the L2 norm of :math:`X`.
 
     .. math::
- 	norm(X) = ( \\sum_{i=1}^{n}|x\_i|^2)^{ \\frac{1}{2}}
+        norm(X) = ( \\sum_{i=1}^{n}|x\_i|^2)^{ \\frac{1}{2}}
 
     Args:
         clip_norm(float): The maximum norm value
-    
+
     Examples:
         .. code-block:: python
 
@@ -241,11 +241,11 @@ class GradientClipByNorm(BaseGradientClipAttr):
                 paddle.reader.shuffle(
                     paddle.dataset.mnist.train(), buf_size=8192),
                 batch_size=128)
-  
+
             exe = fluid.Executor(place)
             feeder = fluid.DataFeeder(feed_list=[image, label], place=place)
             exe.run(startup_program)
-  
+
             count = 0
             for data in train_reader():
                 count += 1
@@ -407,7 +407,9 @@ class GradientClipByGlobalNorm(BaseGradientClipAttr):
             self.context[group_scale_name] = group_scale_var
 
         new_grad = layers.elementwise_mul(
-            x=grad, y=self.context[group_scale_name])
+            x=grad,
+            y=self.context[group_scale_name],
+            name="@".join([grad.name, "clip"]))
 
         return param, new_grad
 
@@ -432,7 +434,7 @@ def set_gradient_clip(clip, param_list=None, program=None):
 
     Examples:
         .. code-block:: python
-            
+
             import paddle.fluid as fluid
 
             def network():

--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -2247,6 +2247,12 @@ class DistributeTranspiler(object):
                             origin_grad_name):
                         new_grad = pserver_block.var(origin_grad_name)
                         new_inputs[key] = new_grad
+                    elif "clip" in opt_op.attr[OP_ROLE_VAR_ATTR_NAME][1]:
+                        # Note! This is for gradient clip.
+                        # because it will create a new tensorfor gradient after clip 
+                        # but not inplace modify the origin one
+                        new_grad = pserver_block.var(origin_grad_name)
+                        new_inputs[key] = new_grad
                     else:
                         new_inputs[key] = merged_var
             elif key == "Param":


### PR DESCRIPTION
尝试修复Gradient Clip在多机下无法运行的问题，临时措施，使用clip关键字

- GradientClipByGlobalNorm 为新grad的name中加入了clip关键字

- distribute_transpiler 在切分pserver program时，会检测clip的关键字，如果有，则不会将Optimizer的Grad输入替换为 Merged var