### PR TITLE
Optimize adam speed

### DIFF
--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_adam_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_adam_op_pass.cc
@@ -39,6 +39,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       const std::vector<ir::Node *> &adam_ops, ir::Graph *graph) const {
     auto fused_adam_node =
         FuseAdamOps(aux_var_set, fused_vars_name, adam_ops, graph);
+    /*
     auto fused_scale1 =
         FuseScaleOps(aux_var_set.at("Beta1Pow"), fused_vars_name.at("Beta1Pow"),
                      adam_ops, graph);
@@ -46,6 +47,7 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
         FuseScaleOps(aux_var_set.at("Beta2Pow"), fused_vars_name.at("Beta2Pow"),
                      adam_ops, graph);
     RemoveCycleDepsBetweenOpNodes(graph, fused_scale1, fused_scale2);
+     */
     return fused_adam_node;
   }
 
@@ -139,6 +141,8 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
     adam_desc.SetOutput("ParamOut", {fused_vars_name.at(kParam)});
     adam_desc.SetOutput("Moment1Out", {fused_vars_name.at("Moment1")});
     adam_desc.SetOutput("Moment2Out", {fused_vars_name.at("Moment2")});
+    adam_desc.SetOutput("Beta1PowOut", {fused_vars_name.at("Beta1Pow")});
+    adam_desc.SetOutput("Beta2PowOut", {fused_vars_name.at("Beta2Pow")});
     adam_desc.SetAttr("beta1", beta1);
     adam_desc.SetAttr("beta2", beta2);
     adam_desc.SetAttr("epsilon", epsilon);

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_adam_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_adam_op_pass.cc
@@ -39,15 +39,6 @@ class FuseAdamOpPass : public FuseOptimizerOpPass {
       const std::vector<ir::Node *> &adam_ops, ir::Graph *graph) const {
     auto fused_adam_node =
         FuseAdamOps(aux_var_set, fused_vars_name, adam_ops, graph);
-    /*
-    auto fused_scale1 =
-        FuseScaleOps(aux_var_set.at("Beta1Pow"), fused_vars_name.at("Beta1Pow"),
-                     adam_ops, graph);
-    auto fused_scale2 =
-        FuseScaleOps(aux_var_set.at("Beta2Pow"), fused_vars_name.at("Beta2Pow"),
-                     adam_ops, graph);
-    RemoveCycleDepsBetweenOpNodes(graph, fused_scale1, fused_scale2);
-     */
     return fused_adam_node;
   }
 

--- a/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.cc
+++ b/paddle/fluid/framework/ir/fuse_optimizer_ops_pass/fuse_optimizer_op_pass.cc
@@ -416,6 +416,8 @@ void FuseOptimizerOpPass::FuseVarsToContinuousSpace(
       result->Get<details::ProgramDescs>(details::kProgramDescs).back();
   auto *global_block = program_desc.MutableBlock(0);
   for (auto &var_name : aux_var_names) {
+    VLOG(6) << "aux_var_names : " << var_name
+            << ". fused_vars_name: " << fused_vars_name.at(var_name);
     AppendCoalesceTensorOp(aux_var_map.at(var_name), aux_var_map.at(var_name),
                            fused_vars_name.at(var_name), dtype, global_block,
                            true);

--- a/paddle/fluid/operators/ngraph/ops/adam_op.h
+++ b/paddle/fluid/operators/ngraph/ops/adam_op.h
@@ -68,8 +68,8 @@ void BuildAdamNode(
   auto delta = ElementwiseScalar<ngraph::op::Multiply>(updated_lr, param_grad);
   auto param_out = std::make_shared<ngraph::op::Subtract>(param, delta);
 
-  auto beta1_pow_out = std::make_shared<ngraph::op::Multiply>(beta1, beta1pow);
-  auto beta2_pow_out = std::make_shared<ngraph::op::Multiply>(beta2, beta2pow);
+  auto beta1_pow_out = ElementwiseScalar<ngraph::op::Multiply>(beta1, beta1pow);
+  auto beta2_pow_out = ElementwiseScalar<ngraph::op::Multiply>(beta2, beta2pow);
 
   platform::SetOutputNode(op, "Moment1Out", moment1out, ngb_node_map);
   platform::SetOutputNode(op, "Moment2Out", moment2out, ngb_node_map);

--- a/paddle/fluid/operators/ngraph/ops/adam_op.h
+++ b/paddle/fluid/operators/ngraph/ops/adam_op.h
@@ -68,9 +68,14 @@ void BuildAdamNode(
   auto delta = ElementwiseScalar<ngraph::op::Multiply>(updated_lr, param_grad);
   auto param_out = std::make_shared<ngraph::op::Subtract>(param, delta);
 
+  auto beta1_pow_out = std::make_shared<ngraph::op::Multiply>(beta1, beta1pow);
+  auto beta2_pow_out = std::make_shared<ngraph::op::Multiply>(beta2, beta2pow);
+
   platform::SetOutputNode(op, "Moment1Out", moment1out, ngb_node_map);
   platform::SetOutputNode(op, "Moment2Out", moment2out, ngb_node_map);
   platform::SetOutputNode(op, "ParamOut", param_out, ngb_node_map);
+  platform::SetOutputNode(op, "Beta1PowOut", beta1_pow_out, ngb_node_map);
+  platform::SetOutputNode(op, "Beta2PowOut", beta2_pow_out, ngb_node_map);
 }
 }  // namespace ngraphs
 }  // namespace operators

--- a/paddle/fluid/operators/optimizers/adam_op.cc
+++ b/paddle/fluid/operators/optimizers/adam_op.cc
@@ -92,8 +92,8 @@ void AdamOp::InferShape(framework::InferShapeContext* ctx) const {
   PADDLE_ENFORCE_GE(framework::product(beta2_pow_dims), 1,
                     platform::errors::InvalidArgument(
                         "The size of Beta2 power accumulator should be greater "
-                        "than 0, but received %d."),
-                    framework::product(beta2_pow_dims));
+                        "than 0, but received %d.",
+                        framework::product(beta2_pow_dims)));
 
   auto param_dims = ctx->GetInputDim("Param");
   if (ctx->GetInputsVarType("Grad")[0] ==

--- a/paddle/fluid/operators/optimizers/adam_op.cc
+++ b/paddle/fluid/operators/optimizers/adam_op.cc
@@ -66,35 +66,57 @@ void AdamOp::InferShape(framework::InferShapeContext* ctx) const {
                         "Output(Moment2Out) of AdamOp should not be null."));
 
   auto lr_dims = ctx->GetInputDim("LearningRate");
-  PADDLE_ENFORCE_NE(framework::product(lr_dims), 0,
-                    "Maybe the Input variable LearningRate has not "
-                    "been initialized. You may need to confirm "
-                    "if you put exe.run(startup_program) "
-                    "after optimizer.minimize function.");
-  PADDLE_ENFORCE_EQ(framework::product(lr_dims), 1,
-                    "Learning rate should have 1 dimension");
+  PADDLE_ENFORCE_NE(
+      framework::product(lr_dims), 0,
+      platform::errors::InvalidArgument(
+          "The number of LearningRate shall not be 0, but received %d. Maybe "
+          "the Input variable LearningRate has not "
+          "been initialized. You may need to confirm "
+          "if you put exe.run(startup_program) "
+          "after optimizer.minimize function.",
+          framework::product(lr_dims)));
+  PADDLE_ENFORCE_EQ(
+      framework::product(lr_dims), 1,
+      platform::errors::InvalidArgument(
+          "Learning rate should have 1 dimension, but received %d",
+          framework::product(lr_dims)));
   auto beta1_pow_dims = ctx->GetInputDim("Beta1Pow");
   VLOG(3) << "dims of Beta1Pow : [" << beta1_pow_dims << "]";
   PADDLE_ENFORCE_GE(framework::product(beta1_pow_dims), 1,
-                    "Beta1 power accumulator should have 1 dimension");
+                    platform::errors::InvalidArgument(
+                        "The size of Beta1 power accumulator should be greater "
+                        "than 0, but received %d.",
+                        framework::product(beta1_pow_dims)));
   auto beta2_pow_dims = ctx->GetInputDim("Beta2Pow");
   VLOG(3) << "dims of Beta2Pow : [" << beta2_pow_dims << "]";
   PADDLE_ENFORCE_GE(framework::product(beta2_pow_dims), 1,
-                    "Beta2 power accumulator should have 1 dimension");
+                    platform::errors::InvalidArgument(
+                        "The size of Beta2 power accumulator should be greater "
+                        "than 0, but received %d."),
+                    framework::product(beta2_pow_dims));
 
   auto param_dims = ctx->GetInputDim("Param");
   if (ctx->GetInputsVarType("Grad")[0] ==
       framework::proto::VarType::LOD_TENSOR) {
     PADDLE_ENFORCE_EQ(
         param_dims, ctx->GetInputDim("Grad"),
-        "Param and Grad input of AdamOp should have same dimension");
+        platform::errors::InvalidArgument(
+            "Param and Grad input of AdamOp should have same dimension. But "
+            "received Param dims: [%s], Grad dims: [%s].",
+            param_dims, ctx->GetInputDim("Grad")));
   }
   PADDLE_ENFORCE_EQ(
       param_dims, ctx->GetInputDim("Moment1"),
-      "Param and Moment1 input of AdamOp should have same dimension");
+      platform::errors::InvalidArgument(
+          "Param and Moment1 input of AdamOp should have same dimension. But "
+          "received Param dims: [%s], Moment1 dims: [%s].",
+          param_dims, ctx->GetInputDim("Moment1")));
   PADDLE_ENFORCE_EQ(
       param_dims, ctx->GetInputDim("Moment2"),
-      "Param and Moment2 input of AdamOp should have same dimension");
+      platform::errors::InvalidArgument(
+          "Param and Moment2 input of AdamOp should have same dimension. But "
+          "received Param dims: [%s], Moment2 dims: [%s].",
+          param_dims, ctx->GetInputDim("Moment2")));
 
   ctx->SetOutputDim("ParamOut", param_dims);
   ctx->SetOutputDim("Moment1Out", param_dims);

--- a/paddle/fluid/operators/optimizers/adam_op.cc
+++ b/paddle/fluid/operators/optimizers/adam_op.cc
@@ -74,10 +74,12 @@ void AdamOp::InferShape(framework::InferShapeContext* ctx) const {
   PADDLE_ENFORCE_EQ(framework::product(lr_dims), 1,
                     "Learning rate should have 1 dimension");
   auto beta1_pow_dims = ctx->GetInputDim("Beta1Pow");
-  PADDLE_ENFORCE_EQ(framework::product(beta1_pow_dims), 1,
+  VLOG(3) << "dims of Beta1Pow : [" << beta1_pow_dims << "]";
+  PADDLE_ENFORCE_GE(framework::product(beta1_pow_dims), 1,
                     "Beta1 power accumulator should have 1 dimension");
   auto beta2_pow_dims = ctx->GetInputDim("Beta2Pow");
-  PADDLE_ENFORCE_EQ(framework::product(beta2_pow_dims), 1,
+  VLOG(3) << "dims of Beta2Pow : [" << beta2_pow_dims << "]";
+  PADDLE_ENFORCE_GE(framework::product(beta2_pow_dims), 1,
                     "Beta2 power accumulator should have 1 dimension");
 
   auto param_dims = ctx->GetInputDim("Param");
@@ -97,6 +99,8 @@ void AdamOp::InferShape(framework::InferShapeContext* ctx) const {
   ctx->SetOutputDim("ParamOut", param_dims);
   ctx->SetOutputDim("Moment1Out", param_dims);
   ctx->SetOutputDim("Moment2Out", param_dims);
+  ctx->SetOutputDim("Beta1PowOut", beta1_pow_dims);
+  ctx->SetOutputDim("Beta2PowOut", beta2_pow_dims);
 }
 
 framework::OpKernelType AdamOp::GetExpectedKernelType(
@@ -130,6 +134,8 @@ class AdamOpMaker : public framework::OpProtoAndCheckerMaker {
     AddOutput("ParamOut", "(Tensor) Output parameter");
     AddOutput("Moment1Out", "(Tensor) Output first moment");
     AddOutput("Moment2Out", "(Tensor) Output second moment");
+    AddOutput("Beta1PowOut", "(Tensor) Output beta1 power accumulator");
+    AddOutput("Beta2PowOut", "(Tensor) Output beta2 power accumulator");
 
     AddAttr<float>("beta1",
                    "(float, default 0.9) "

--- a/paddle/fluid/operators/optimizers/adam_op.h
+++ b/paddle/fluid/operators/optimizers/adam_op.h
@@ -51,14 +51,12 @@ class AdamOp : public framework::OperatorWithKernel {
 struct GPUAdam;
 struct CPUAdam;
 
-template <typename T>
-struct BetaPowFunctor;
-
 template <typename T, typename Flavour>
-struct AdamFunctor;
+class AdamFunctor;
 
 template <typename T>
-struct BetaPowFunctor {
+class BetaPowFunctor {
+ private:
   T beta1_;
   T beta2_;
   const T* beta1_pow_;
@@ -66,6 +64,7 @@ struct BetaPowFunctor {
   T* beta1_pow_out_;
   T* beta2_pow_out_;
 
+ public:
   BetaPowFunctor(T beta1, T beta2, const T* beta1_pow, const T* beta2_pow,
                  T* beta1_pow_out, T* beta2_pow_out)
       : beta1_(beta1),
@@ -93,7 +92,8 @@ struct BetaPowFunctor {
 };
 
 template <typename T>
-struct AdamFunctor<T, GPUAdam> {
+class AdamFunctor<T, GPUAdam> {
+ private:
   T beta1_;
   T beta2_;
   T epsilon_;
@@ -109,6 +109,7 @@ struct AdamFunctor<T, GPUAdam> {
   const T* param_;
   T* param_out_;
 
+ public:
   AdamFunctor(T beta1, T beta2, T epsilon, const T* beta1_pow,
               const T* beta2_pow, const T* mom1, T* mom1_out, const T* mom2,
               T* mom2_out, const T* lr, const T* grad, const T* param,
@@ -152,7 +153,8 @@ struct AdamFunctor<T, GPUAdam> {
 };
 
 template <typename T>
-struct AdamFunctor<T, CPUAdam> {
+class AdamFunctor<T, CPUAdam> {
+ private:
   T beta1_;
   T beta2_;
   T epsilon_;
@@ -168,6 +170,7 @@ struct AdamFunctor<T, CPUAdam> {
   const T* param_;
   T* param_out_;
 
+ public:
   AdamFunctor(T beta1, T beta2, T epsilon, const T* beta1_pow,
               const T* beta2_pow, const T* mom1, T* mom1_out, const T* mom2,
               T* mom2_out, const T* lr, const T* grad, const T* param,
@@ -217,10 +220,11 @@ struct AdamFunctor<T, CPUAdam> {
 };
 
 template <typename T, typename Flavour>
-struct SparseAdamFunctor;
+class SparseAdamFunctor;
 
 template <typename T>
-struct SparseAdamFunctor<T, GPUAdam> {
+class SparseAdamFunctor<T, GPUAdam> {
+ private:
   T beta1_;
   T beta2_;
   T epsilon_;
@@ -241,6 +245,7 @@ struct SparseAdamFunctor<T, GPUAdam> {
   int64_t row_count_;
   bool lazy_mode_;
 
+ public:
   SparseAdamFunctor(T beta1, T beta2, T epsilon, const T* beta1_pow,
                     const T* beta2_pow, const T* mom1, T* mom1_out,
                     const T* mom2, T* mom2_out, const T* lr, const T* grad,
@@ -299,7 +304,8 @@ struct SparseAdamFunctor<T, GPUAdam> {
 };
 
 template <typename T>
-struct SparseAdamFunctor<T, CPUAdam> {
+class SparseAdamFunctor<T, CPUAdam> {
+ private:
   T beta1_;
   T beta2_;
   T epsilon_;
@@ -319,6 +325,7 @@ struct SparseAdamFunctor<T, CPUAdam> {
   int64_t row_numel_;
   int64_t row_count_;
 
+ public:
   SparseAdamFunctor(T beta1, T beta2, T epsilon, const T* beta1_pow,
                     const T* beta2_pow, const T* mom1, T* mom1_out,
                     const T* mom2, T* mom2_out, const T* lr, const T* grad,

--- a/paddle/fluid/operators/optimizers/adam_op.h
+++ b/paddle/fluid/operators/optimizers/adam_op.h
@@ -51,8 +51,46 @@ class AdamOp : public framework::OperatorWithKernel {
 struct GPUAdam;
 struct CPUAdam;
 
+template <typename T>
+struct BetaPowFunctor;
+
 template <typename T, typename Flavour>
 struct AdamFunctor;
+
+template <typename T>
+struct BetaPowFunctor {
+  T beta1_;
+  T beta2_;
+  const T* beta1_pow_;
+  const T* beta2_pow_;
+  T* beta1_pow_out_;
+  T* beta2_pow_out_;
+
+  BetaPowFunctor(T beta1, T beta2, const T* beta1_pow, const T* beta2_pow,
+                 T* beta1_pow_out, T* beta2_pow_out)
+      : beta1_(beta1),
+        beta2_(beta2),
+        beta1_pow_(beta1_pow),
+        beta2_pow_(beta2_pow),
+        beta1_pow_out_(beta1_pow_out),
+        beta2_pow_out_(beta2_pow_out) {}
+
+  inline HOSTDEVICE void update_step(size_t i) const {
+    T beta1_pow_i = beta1_pow_[i];
+    T beta2_pow_i = beta2_pow_[i];
+
+    beta1_pow_out_[i] = beta1_pow_i * beta1_;
+    beta2_pow_out_[i] = beta2_pow_i * beta2_;
+  }
+
+  inline HOSTDEVICE void operator()(size_t i) const { update_step(i); }
+
+  inline HOSTDEVICE void apply_update(size_t limit) const {
+    for (size_t i = 0; i < limit; ++i) {
+      update_step(i);
+    }
+  }
+};
 
 template <typename T>
 struct AdamFunctor<T, GPUAdam> {
@@ -397,6 +435,10 @@ class AdamOpKernel : public framework::OpKernel<T> {
         Ref(ctx.Output<LoDTensor>("Moment1Out"), "Must set Moment1Out");
     auto& mom2_out =
         Ref(ctx.Output<LoDTensor>("Moment2Out"), "Must set Moment1Out");
+    auto& beta1_pow_out =
+        Ref(ctx.Output<LoDTensor>("Beta1PowOut"), "Must set Beta1PowOut");
+    auto& beta2_pow_out =
+        Ref(ctx.Output<LoDTensor>("Beta2PowOut"), "Must set Beta2PowOut");
 
     T beta1 = static_cast<T>(ctx.Attr<float>("beta1"));
     if (ctx.HasInput("Beta1Tensor")) {
@@ -408,6 +450,14 @@ class AdamOpKernel : public framework::OpKernel<T> {
       auto* beta2_tensor = ctx.Input<framework::Tensor>("Beta2Tensor");
       beta2 = static_cast<T>(GetAttrFromTensor(beta2_tensor));
     }
+    VLOG(3) << "beta1_pow.numel() : " << beta1_pow.numel()
+            << "beta2_pow.numel() : " << beta2_pow.numel();
+    VLOG(3) << "param.numel(): " << param.numel();
+    BetaPowFunctor<T> beta_functor(
+        beta1, beta2, beta1_pow.template data<T>(),
+        beta2_pow.template data<T>(),
+        beta1_pow_out.template mutable_data<T>(ctx.GetPlace()),
+        beta2_pow_out.template mutable_data<T>(ctx.GetPlace()));
 
     if (grad_var->IsType<framework::LoDTensor>()) {
       auto& grad = Ref(ctx.Input<LoDTensor>("Grad"), "Must set Grad");
@@ -423,6 +473,7 @@ class AdamOpKernel : public framework::OpKernel<T> {
             param.template data<T>(),
             param_out.template mutable_data<T>(ctx.GetPlace()));
         functor(param.numel());
+        beta_functor.apply_update(beta2_pow.numel());
       } else if (platform::is_gpu_place(ctx.GetPlace())) {
         AdamFunctor<T, GPUAdam> functor(
             beta1, beta2, epsilon, beta1_pow.template data<T>(),
@@ -433,11 +484,16 @@ class AdamOpKernel : public framework::OpKernel<T> {
             lr.template data<T>(), grad.template data<T>(),
             param.template data<T>(),
             param_out.template mutable_data<T>(ctx.GetPlace()));
-
+        // update param and moment
         platform::ForRange<DeviceContext> for_range(
             static_cast<const DeviceContext&>(ctx.device_context()),
             param.numel());
         for_range(functor);
+        // update beta1 and beta2
+        platform::ForRange<DeviceContext> for_range_beta(
+            static_cast<const DeviceContext&>(ctx.device_context()),
+            beta2_pow.numel());
+        for_range_beta(beta_functor);
       }
     } else if (grad_var->IsType<framework::SelectedRows>()) {
       auto& grad =
@@ -483,8 +539,12 @@ class AdamOpKernel : public framework::OpKernel<T> {
             mom2.template data<T>(),
             mom2_out.template mutable_data<T>(ctx.GetPlace()),
             lr.template data<T>(), grad_data, param.template data<T>(),
-            param_out.template mutable_data<T>(ctx.GetPlace()), rows, row_numel,
-            grad_merge.rows().size(), lazy_mode);
+            param_out.template mutable_data<T>(ctx.GetPlace()),
+            beta1_pow_out.template mutable_data<T>(ctx.GetPlace()),
+            beta2_pow_out.template mutable_data<T>(ctx.GetPlace()), rows,
+            row_numel, grad_merge.rows().size(), lazy_mode);
+        // update beta1 and beta2
+        beta_functor.apply_update(beta2_pow.numel());
         if (lazy_mode) {
           VLOG(3) << "run cpu lazy mode";
           size_t row_count = grad_merge.rows().size();
@@ -566,14 +626,21 @@ class AdamOpKernel : public framework::OpKernel<T> {
             mom2.template data<T>(),
             mom2_out.template mutable_data<T>(ctx.GetPlace()),
             lr.template data<T>(), grad_data, param.template data<T>(),
-            param_out.template mutable_data<T>(ctx.GetPlace()), rows, row_numel,
-            grad_merge.rows().size(), lazy_mode);
+            param_out.template mutable_data<T>(ctx.GetPlace()),
+            beta1_pow_out.template mutable_data<T>(ctx.GetPlace()),
+            beta2_pow_out.template mutable_data<T>(ctx.GetPlace()), rows,
+            row_numel, grad_merge.rows().size(), lazy_mode);
 
         // FIXME(minqiyang): remove BinarySearch in GPU later
         platform::ForRange<DeviceContext> for_range(
             static_cast<const DeviceContext&>(ctx.device_context()),
             param.numel());
         for_range(functor);
+        // update beta1 and beta2
+        platform::ForRange<DeviceContext> for_range_beta(
+            static_cast<const DeviceContext&>(ctx.device_context()),
+            beta2_pow.numel());
+        for_range_beta(beta_functor);
       }
     } else {
       PADDLE_THROW("Variable type not supported by adam_op");

--- a/paddle/fluid/operators/optimizers/adam_op.h
+++ b/paddle/fluid/operators/optimizers/adam_op.h
@@ -539,10 +539,8 @@ class AdamOpKernel : public framework::OpKernel<T> {
             mom2.template data<T>(),
             mom2_out.template mutable_data<T>(ctx.GetPlace()),
             lr.template data<T>(), grad_data, param.template data<T>(),
-            param_out.template mutable_data<T>(ctx.GetPlace()),
-            beta1_pow_out.template mutable_data<T>(ctx.GetPlace()),
-            beta2_pow_out.template mutable_data<T>(ctx.GetPlace()), rows,
-            row_numel, grad_merge.rows().size(), lazy_mode);
+            param_out.template mutable_data<T>(ctx.GetPlace()), rows, row_numel,
+            grad_merge.rows().size(), lazy_mode);
         // update beta1 and beta2
         beta_functor.apply_update(beta2_pow.numel());
         if (lazy_mode) {
@@ -626,10 +624,8 @@ class AdamOpKernel : public framework::OpKernel<T> {
             mom2.template data<T>(),
             mom2_out.template mutable_data<T>(ctx.GetPlace()),
             lr.template data<T>(), grad_data, param.template data<T>(),
-            param_out.template mutable_data<T>(ctx.GetPlace()),
-            beta1_pow_out.template mutable_data<T>(ctx.GetPlace()),
-            beta2_pow_out.template mutable_data<T>(ctx.GetPlace()), rows,
-            row_numel, grad_merge.rows().size(), lazy_mode);
+            param_out.template mutable_data<T>(ctx.GetPlace()), rows, row_numel,
+            grad_merge.rows().size(), lazy_mode);
 
         // FIXME(minqiyang): remove BinarySearch in GPU later
         platform::ForRange<DeviceContext> for_range(

--- a/paddle/fluid/operators/optimizers/lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/lamb_op.cc
@@ -92,8 +92,8 @@ class LambOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_GE(framework::product(beta2_pow_dims), 1,
                       platform::errors::InvalidArgument(
                           "The size of Beta2 power accumulator should be "
-                          "greater than 0, but received %d."),
-                      framework::product(beta2_pow_dims));
+                          "greater than 0, but received %d.",
+                          framework::product(beta2_pow_dims)));
 
     auto param_dims = ctx->GetInputDim("Param");
     if (ctx->GetInputsVarType("Grad")[0] ==

--- a/paddle/fluid/operators/optimizers/lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/lamb_op.cc
@@ -13,10 +13,101 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/optimizers/lamb_op.h"
-#include "paddle/fluid/operators/optimizers/adam_op.h"
 
 namespace paddle {
 namespace operators {
+
+class LambOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Param"), true,
+                      platform::errors::NotFound(
+                          "Input(Param) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Grad"), true,
+                      platform::errors::NotFound(
+                          "Input(Grad) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Moment1"), true,
+                      platform::errors::NotFound(
+                          "Input(Moment1) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Moment2"), true,
+                      platform::errors::NotFound(
+                          "Input(Moment2) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("LearningRate"), true,
+                      platform::errors::NotFound(
+                          "Input(LearningRate) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Beta1Pow"), true,
+                      platform::errors::NotFound(
+                          "Input(Beta1Pow) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Beta2Pow"), true,
+                      platform::errors::NotFound(
+                          "Input(Beta2Pow) of LambOp should not be null."));
+
+    if (ctx->IsRuntime() && ctx->HasInput("Beta1Tensor")) {
+      auto beta1 = ctx->Inputs("Beta1Tensor");
+      PADDLE_ENFORCE_EQ(beta1.size(), 1,
+                        platform::errors::InvalidArgument(
+                            "Input(Beta1Tensor) size must be 1"));
+    }
+    if (ctx->IsRuntime() && ctx->HasInput("Beta2Tensor")) {
+      auto beta2 = ctx->Inputs("Beta2Tensor");
+      PADDLE_ENFORCE_EQ(beta2.size(), 1,
+                        platform::errors::InvalidArgument(
+                            "Input(Beta2Tensor) size must be 1"));
+    }
+
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("ParamOut"), true,
+                      platform::errors::NotFound(
+                          "Output(ParamOut) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Moment1Out"), true,
+                      platform::errors::NotFound(
+                          "Output(Moment1Out) of LambOp should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Moment2Out"), true,
+                      platform::errors::NotFound(
+                          "Output(Moment2Out) of LambOp should not be null."));
+
+    auto lr_dims = ctx->GetInputDim("LearningRate");
+    PADDLE_ENFORCE_NE(framework::product(lr_dims), 0,
+                      "Maybe the Input variable LearningRate has not "
+                      "been initialized. You may need to confirm "
+                      "if you put exe.run(startup_program) "
+                      "after optimizer.minimize function.");
+    PADDLE_ENFORCE_EQ(framework::product(lr_dims), 1,
+                      "Learning rate should have 1 dimension");
+    auto beta1_pow_dims = ctx->GetInputDim("Beta1Pow");
+    PADDLE_ENFORCE_EQ(framework::product(beta1_pow_dims), 1,
+                      "Beta1 power accumulator should have 1 dimension");
+    auto beta2_pow_dims = ctx->GetInputDim("Beta2Pow");
+    PADDLE_ENFORCE_EQ(framework::product(beta2_pow_dims), 1,
+                      "Beta2 power accumulator should have 1 dimension");
+
+    auto param_dims = ctx->GetInputDim("Param");
+    if (ctx->GetInputsVarType("Grad")[0] ==
+        framework::proto::VarType::LOD_TENSOR) {
+      PADDLE_ENFORCE_EQ(
+          param_dims, ctx->GetInputDim("Grad"),
+          "Param and Grad input of LambOp should have same dimension");
+    }
+    PADDLE_ENFORCE_EQ(
+        param_dims, ctx->GetInputDim("Moment1"),
+        "Param and Moment1 input of LambOp should have same dimension");
+    PADDLE_ENFORCE_EQ(
+        param_dims, ctx->GetInputDim("Moment2"),
+        "Param and Moment2 input of LambOp should have same dimension");
+
+    ctx->SetOutputDim("ParamOut", param_dims);
+    ctx->SetOutputDim("Moment1Out", param_dims);
+    ctx->SetOutputDim("Moment2Out", param_dims);
+  }
+
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const {
+    auto input_data_type =
+        OperatorWithKernel::IndicateVarDataType(ctx, "Param");
+    return framework::OpKernelType(input_data_type, ctx.GetPlace());
+  }
+};
 
 class LambOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
@@ -79,7 +170,7 @@ learning rate, $\lambda$ the weight decay rate.
 }  // namespace paddle
 
 namespace ops = paddle::operators;
-REGISTER_OP_WITHOUT_GRADIENT(lamb, ops::AdamOp, ops::LambOpMaker);
+REGISTER_OP_WITHOUT_GRADIENT(lamb, ops::LambOp, ops::LambOpMaker);
 REGISTER_OP_CPU_KERNEL(
     lamb, ops::LambOpKernel<paddle::platform::CPUDeviceContext, float>,
     ops::LambOpKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/optimizers/lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/lamb_op.cc
@@ -101,20 +101,20 @@ class LambOp : public framework::OperatorWithKernel {
       PADDLE_ENFORCE_EQ(
           param_dims, ctx->GetInputDim("Grad"),
           platform::errors::InvalidArgument(
-              "Param and Grad input of AdamOp should have same dimension. But "
+              "Param and Grad input of LambOp should have same dimension. But "
               "received Param dims: [%s], Grad dims: [%s].",
               param_dims, ctx->GetInputDim("Grad")));
     }
     PADDLE_ENFORCE_EQ(
         param_dims, ctx->GetInputDim("Moment1"),
         platform::errors::InvalidArgument(
-            "Param and Moment1 input of AdamOp should have same dimension. But "
+            "Param and Moment1 input of LambOp should have same dimension. But "
             "received Param dims: [%s], Moment1 dims: [%s].",
             param_dims, ctx->GetInputDim("Moment1")));
     PADDLE_ENFORCE_EQ(
         param_dims, ctx->GetInputDim("Moment2"),
         platform::errors::InvalidArgument(
-            "Param and Moment2 input of AdamOp should have same dimension. But "
+            "Param and Moment2 input of LambOp should have same dimension. But "
             "received Param dims: [%s], Moment2 dims: [%s].",
             param_dims, ctx->GetInputDim("Moment2")));
 

--- a/paddle/fluid/operators/optimizers/lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/lamb_op.cc
@@ -68,33 +68,55 @@ class LambOp : public framework::OperatorWithKernel {
                           "Output(Moment2Out) of LambOp should not be null."));
 
     auto lr_dims = ctx->GetInputDim("LearningRate");
-    PADDLE_ENFORCE_NE(framework::product(lr_dims), 0,
-                      "Maybe the Input variable LearningRate has not "
-                      "been initialized. You may need to confirm "
-                      "if you put exe.run(startup_program) "
-                      "after optimizer.minimize function.");
-    PADDLE_ENFORCE_EQ(framework::product(lr_dims), 1,
-                      "Learning rate should have 1 dimension");
+    PADDLE_ENFORCE_NE(
+        framework::product(lr_dims), 0,
+        platform::errors::InvalidArgument(
+            "The number of LearningRate shall not be 0, but received %d. Maybe "
+            "the Input variable LearningRate has not "
+            "been initialized. You may need to confirm "
+            "if you put exe.run(startup_program) "
+            "after optimizer.minimize function.",
+            framework::product(lr_dims)));
+    PADDLE_ENFORCE_EQ(
+        framework::product(lr_dims), 1,
+        platform::errors::InvalidArgument(
+            "Learning rate should have 1 dimension, but received %d.",
+            framework::product(lr_dims)));
     auto beta1_pow_dims = ctx->GetInputDim("Beta1Pow");
-    PADDLE_ENFORCE_EQ(framework::product(beta1_pow_dims), 1,
-                      "Beta1 power accumulator should have 1 dimension");
+    PADDLE_ENFORCE_GE(framework::product(beta1_pow_dims), 1,
+                      platform::errors::InvalidArgument(
+                          "The size of Beta1 power accumulator should be "
+                          "greater than 0, but received %d.",
+                          framework::product(beta1_pow_dims)));
     auto beta2_pow_dims = ctx->GetInputDim("Beta2Pow");
-    PADDLE_ENFORCE_EQ(framework::product(beta2_pow_dims), 1,
-                      "Beta2 power accumulator should have 1 dimension");
+    PADDLE_ENFORCE_GE(framework::product(beta2_pow_dims), 1,
+                      platform::errors::InvalidArgument(
+                          "The size of Beta2 power accumulator should be "
+                          "greater than 0, but received %d."),
+                      framework::product(beta2_pow_dims));
 
     auto param_dims = ctx->GetInputDim("Param");
     if (ctx->GetInputsVarType("Grad")[0] ==
         framework::proto::VarType::LOD_TENSOR) {
       PADDLE_ENFORCE_EQ(
           param_dims, ctx->GetInputDim("Grad"),
-          "Param and Grad input of LambOp should have same dimension");
+          platform::errors::InvalidArgument(
+              "Param and Grad input of AdamOp should have same dimension. But "
+              "received Param dims: [%s], Grad dims: [%s].",
+              param_dims, ctx->GetInputDim("Grad")));
     }
     PADDLE_ENFORCE_EQ(
         param_dims, ctx->GetInputDim("Moment1"),
-        "Param and Moment1 input of LambOp should have same dimension");
+        platform::errors::InvalidArgument(
+            "Param and Moment1 input of AdamOp should have same dimension. But "
+            "received Param dims: [%s], Moment1 dims: [%s].",
+            param_dims, ctx->GetInputDim("Moment1")));
     PADDLE_ENFORCE_EQ(
         param_dims, ctx->GetInputDim("Moment2"),
-        "Param and Moment2 input of LambOp should have same dimension");
+        platform::errors::InvalidArgument(
+            "Param and Moment2 input of AdamOp should have same dimension. But "
+            "received Param dims: [%s], Moment2 dims: [%s].",
+            param_dims, ctx->GetInputDim("Moment2")));
 
     ctx->SetOutputDim("ParamOut", param_dims);
     ctx->SetOutputDim("Moment1Out", param_dims);

--- a/paddle/fluid/operators/optimizers/lamb_op.cc
+++ b/paddle/fluid/operators/optimizers/lamb_op.cc
@@ -44,19 +44,6 @@ class LambOp : public framework::OperatorWithKernel {
                       platform::errors::NotFound(
                           "Input(Beta2Pow) of LambOp should not be null."));
 
-    if (ctx->IsRuntime() && ctx->HasInput("Beta1Tensor")) {
-      auto beta1 = ctx->Inputs("Beta1Tensor");
-      PADDLE_ENFORCE_EQ(beta1.size(), 1,
-                        platform::errors::InvalidArgument(
-                            "Input(Beta1Tensor) size must be 1"));
-    }
-    if (ctx->IsRuntime() && ctx->HasInput("Beta2Tensor")) {
-      auto beta2 = ctx->Inputs("Beta2Tensor");
-      PADDLE_ENFORCE_EQ(beta2.size(), 1,
-                        platform::errors::InvalidArgument(
-                            "Input(Beta2Tensor) size must be 1"));
-    }
-
     PADDLE_ENFORCE_EQ(ctx->HasOutput("ParamOut"), true,
                       platform::errors::NotFound(
                           "Output(ParamOut) of LambOp should not be null."));

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -1668,7 +1668,9 @@ class AdamOptimizer(Optimizer):
         outputs = {
             "ParamOut": param_and_grad[0],
             "Moment1Out": moment1,
-            "Moment2Out": moment2
+            "Moment2Out": moment2,
+            "Beta1PowOut": beta1_pow_acc,
+            "Beta2PowOut": beta2_pow_acc,
         }
         attrs = {
             "epsilon": self._epsilon,
@@ -1697,6 +1699,8 @@ class AdamOptimizer(Optimizer):
     def _finish_update(self, block, param_and_grads):
         """Update Beta1 and Beta2 Power accumulators
         """
+        pass
+        '''
         assert isinstance(block, framework.Block)
         main_block = block.program.global_block()
         for param, grad in param_and_grads:
@@ -1733,6 +1737,7 @@ class AdamOptimizer(Optimizer):
                     outputs={"Out": beta2_pow_acc},
                     attrs=attrs,
                     stop_gradient=True)
+        '''
 
 
 class AdamaxOptimizer(Optimizer):

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -1696,49 +1696,6 @@ class AdamOptimizer(Optimizer):
 
         return adam_op
 
-    def _finish_update(self, block, param_and_grads):
-        """Update Beta1 and Beta2 Power accumulators
-        """
-        pass
-        '''
-        assert isinstance(block, framework.Block)
-        main_block = block.program.global_block()
-        for param, grad in param_and_grads:
-            if grad is None or param.trainable is False:
-                continue
-            with param.block.program._optimized_guard(
-                [param, grad]), name_scope("optimizer"):
-                beta1_pow_acc = self._get_accumulator(self._beta1_pow_acc_str,
-                                                      param)
-                beta2_pow_acc = self._get_accumulator(self._beta2_pow_acc_str,
-                                                      param)
-                inputs = {"X": beta1_pow_acc}
-                attrs = {}
-                if isinstance(self._beta1, Variable):
-                    inputs['ScaleTensor'] = self._beta1
-                else:
-                    attrs['scale'] = self._beta1
-                main_block.append_op(
-                    type="scale",
-                    inputs=inputs,
-                    outputs={"Out": beta1_pow_acc},
-                    attrs=attrs,
-                    stop_gradient=True)
-
-                inputs = {"X": beta2_pow_acc}
-                attrs = {}
-                if isinstance(self._beta2, Variable):
-                    inputs['ScaleTensor'] = self._beta2
-                else:
-                    attrs['scale'] = self._beta2
-                main_block.append_op(
-                    type="scale",
-                    inputs=inputs,
-                    outputs={"Out": beta2_pow_acc},
-                    attrs=attrs,
-                    stop_gradient=True)
-        '''
-
 
 class AdamaxOptimizer(Optimizer):
     """

--- a/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
+++ b/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
@@ -69,8 +69,8 @@ class TestParallelExecutorBase(unittest.TestCase):
         startup.random_seed = 1
         main.random_seed = 1
         with fluid.program_guard(main, startup):
-            feed_dict, loss, fetch_var_list = cls.build_model(
-                feed_dict, get_data_from_feeder, main, method, optimizer)
+            feed_dict, loss = cls.build_model(feed_dict, get_data_from_feeder,
+                                              main, method, optimizer)
 
         place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
         exe = fluid.Executor(place)
@@ -197,5 +197,4 @@ class TestParallelExecutorBase(unittest.TestCase):
         if get_data_from_feeder is not None:
             assert feed_dict is None
             feed_dict = get_data_from_feeder()
-
         return feed_dict, loss

--- a/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
+++ b/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
@@ -96,12 +96,12 @@ class TestParallelExecutorBase(unittest.TestCase):
                 os.environ.get('CPU_NUM', multiprocessing.cpu_count()))
 
         begin = time.time()
-        first_loss = run_executor(
-            exe=exe, binary=binary, feed=feed_dict, fetch_list=[loss])
+        first_loss, = run_executor(
+            exe=exe, binary=binary, feed=feed_dict, fetch_list=[loss.name])
         for _ in range(iter):
             run_executor(exe=exe, binary=binary, feed=feed_dict, fetch_list=[])
-        last_loss = run_executor(
-            exe=exe, binary=binary, feed=feed_dict, fetch_list=[loss])
+        last_loss, = run_executor(
+            exe=exe, binary=binary, feed=feed_dict, fetch_list=[loss.name])
         end = time.time()
 
         if batch_size is not None:
@@ -114,10 +114,7 @@ class TestParallelExecutorBase(unittest.TestCase):
                 float(avg_first_loss_val)):
             sys.exit("got NaN loss, training failed.")
 
-        first_loss = [val[0] for val in first_loss]
-        last_loss = [val[0] for val in last_loss]
-        print("first loss: ", first_loss)
-        print("last loss: ", last_loss)
+        print(first_loss, last_loss)
         # self.assertGreater(first_loss[0], last_loss[0])
         return first_loss, last_loss
 
@@ -141,8 +138,8 @@ class TestParallelExecutorBase(unittest.TestCase):
         main = fluid.Program()
         startup = fluid.Program()
         with fluid.program_guard(main, startup):
-            feed_dict, loss, fetch_list = cls.build_model(
-                feed_dict, get_data_from_feeder, main, method, optimizer)
+            feed_dict, loss = cls.build_model(feed_dict, get_data_from_feeder,
+                                              main, method, optimizer)
 
         place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
         exe = fluid.Executor(place)
@@ -194,19 +191,11 @@ class TestParallelExecutorBase(unittest.TestCase):
         # We set loss.persistable = False here to verify our memory
         # optimization strategies intentionally.
         loss.persistable = False
-        test_optimizer = None
         if optimizer:
-            test_optimizer = optimizer()
-            test_optimizer.minimize(loss)
+            optimizer().minimize(loss)
 
         if get_data_from_feeder is not None:
             assert feed_dict is None
             feed_dict = get_data_from_feeder()
-        var_list = []
-        if test_optimizer is not None:
-            for k, v in test_optimizer._accumulators.items():
-                # TODO(Aurelius84): FIX ME hard code test for adam and adamMax
-                if k == "beta1_pow_acc" or k == "beta2_pow_acc":
-                    for k1, v1 in v.items():
-                        var_list.append(v1)
-        return feed_dict, loss, var_list
+
+        return feed_dict, loss

--- a/python/paddle/fluid/tests/unittests/test_adam_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adam_op.py
@@ -58,7 +58,9 @@ class TestAdamOp1(OpTest):
         self.outputs = {
             'Moment1Out': moment1_out,
             'Moment2Out': moment2_out,
-            'ParamOut': param_out
+            'ParamOut': param_out,
+            'Beta1PowOut': np.array([beta1_pow]).astype("float32") * beta1,
+            'Beta2PowOut': np.array([beta2_pow]).astype("float32") * beta2
         }
 
     def test_check_output(self):
@@ -101,7 +103,9 @@ class TestAdamOp2(OpTest):
         self.outputs = {
             'Moment1Out': moment1_out,
             'Moment2Out': moment2_out,
-            'ParamOut': param_out
+            'ParamOut': param_out,
+            'Beta1PowOut': np.array([beta1_pow]).astype("float32") * beta1,
+            'Beta2PowOut': np.array([beta2_pow]).astype("float32") * beta2
         }
 
     def test_check_output(self):
@@ -122,11 +126,11 @@ class TestAdamOpMultipleSteps(OpTest):
         moment2 = np.random.random((102, 105)).astype("float32")
 
         learning_rate = 0.001
-        beta1 = 0.9
-        beta2 = 0.999
+        self.beta1 = 0.9
+        self.beta2 = 0.999
         epsilon = 1e-8
-        beta1_pow = beta1**10
-        beta2_pow = beta2**10
+        self.beta1_pow = self.beta1**10
+        self.beta2_pow = self.beta2**10
 
         self.inputs = {
             'Param': param,
@@ -134,21 +138,29 @@ class TestAdamOpMultipleSteps(OpTest):
             'Moment1': moment1,
             'Moment2': moment2,
             'LearningRate': np.array([learning_rate]).astype("float32"),
-            'Beta1Pow': np.array([beta1_pow]).astype("float32"),
-            'Beta2Pow': np.array([beta2_pow]).astype("float32")
+            'Beta1Pow': np.array([self.beta1_pow]).astype("float32"),
+            'Beta2Pow': np.array([self.beta2_pow]).astype("float32")
         }
 
-        self.attrs = {'epsilon': epsilon, 'beta1': beta1, 'beta2': beta2}
+        self.attrs = {
+            'epsilon': epsilon,
+            'beta1': self.beta1,
+            'beta2': self.beta2
+        }
 
     def test_check_output(self):
         for _ in range(self.num_steps):
             param_out, moment1_out, \
                 moment2_out = adam_step(self.inputs, self.attrs)
 
+            beta1_pow_out = self.inputs['Beta1Pow'] * self.beta1
+            beta2_pow_out = self.inputs['Beta2Pow'] * self.beta2
             self.outputs = {
                 'Moment1Out': moment1_out,
                 'Moment2Out': moment2_out,
-                'ParamOut': param_out
+                'ParamOut': param_out,
+                'Beta1PowOut': beta1_pow_out,
+                'Beta2PowOut': beta2_pow_out
             }
 
             # Verify output for this step
@@ -160,8 +172,8 @@ class TestAdamOpMultipleSteps(OpTest):
             self.inputs['Moment2'] = moment2_out
 
             # Update powers of Beta1 and Beta2 for next time step
-            self.inputs['Beta1Pow'] *= self.attrs['beta1']
-            self.inputs['Beta2Pow'] *= self.attrs['beta1']
+            self.inputs['Beta1Pow'] = beta1_pow_out
+            self.inputs['Beta2Pow'] = beta2_pow_out
 
             # Randomize gradient for next step
             self.inputs['Grad'] = np.random.uniform(
@@ -254,6 +266,8 @@ class TestSparseAdamOp(unittest.TestCase):
         beta1 = 0.78
         beta2 = 0.836
         epsilon = 1e-4
+        beta1_pow = np.array([beta1**10]).astype("float32")
+        beta2_pow = np.array([beta2**10]).astype("float32")
 
         height = 10
         rows = [0, 4, 7]
@@ -264,8 +278,8 @@ class TestSparseAdamOp(unittest.TestCase):
             "Param": np.full((height, row_numel), 5.0).astype("float32"),
             "Moment1": np.full((height, row_numel), 5.0).astype("float32"),
             "Moment2": np.full((height, row_numel), 5.0).astype("float32"),
-            'Beta1Pow': np.array([beta1**10]).astype("float32"),
-            'Beta2Pow': np.array([beta2**10]).astype("float32"),
+            'Beta1Pow': beta1_pow,
+            'Beta2Pow': beta2_pow,
             "LearningRate": np.full((1), 2.0).astype("float32")
         }
         self.init_output = np.full((height, row_numel), 0.0).astype("float32")
@@ -294,7 +308,9 @@ class TestSparseAdamOp(unittest.TestCase):
         self.outputs = {
             "ParamOut": param_out,
             "Moment1Out": mom1,
-            "Moment2Out": mom2
+            "Moment2Out": mom2,
+            'Beta1PowOut': beta1_pow * beta1,
+            'Beta2PowOut': beta2_pow * beta2
         }
 
     def check_with_place(self, place, lazy_mode):
@@ -376,7 +392,9 @@ class TestAdamOpBetaVariable(OpTest):
         self.outputs = {
             'Moment1Out': moment1_out,
             'Moment2Out': moment2_out,
-            'ParamOut': param_out
+            'ParamOut': param_out,
+            'Beta1PowOut': np.array([beta1_pow]).astype("float32") * beta1,
+            'Beta2PowOut': np.array([beta2_pow]).astype("float32") * beta2
         }
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -320,9 +320,8 @@ class TestAdamOptimizer(unittest.TestCase):
         self.assertEqual(len(adam_optimizer.get_accumulators()), 0)
         with framework.program_guard(program, init_program):
             opts = adam_optimizer.apply_gradients(params_grads)
-        self.assertEqual(len(opts), 4)
-        self.assertEqual([op.type for op in opts],
-                         ["scale", "adam", "scale", "scale"])
+        self.assertEqual(len(opts), 2)
+        self.assertEqual([op.type for op in opts], ["scale", "adam"])
 
         # Check accumulators
         accumulators = adam_optimizer.get_accumulators()

--- a/python/paddle/fluid/tests/unittests/test_trainable.py
+++ b/python/paddle/fluid/tests/unittests/test_trainable.py
@@ -68,7 +68,7 @@ class TestTrainable(unittest.TestCase):
             test_trainable,
             feed_dict,
             op_count={'adam': 1,
-                      'scale': 2,
+                      'scale': 0,
                       'mul_grad': 0})
         self.check_trainable(
             test_trainable,


### PR DESCRIPTION
Before, `_finish_update()` is called to scale `beta1` and `beta2` every iteration when applying `adam.minimize()`. 

Two `scale_op` kernel  are launched here that may slow down the training. Because the launched process may exhaust more time than calculation indeed.

In this PR, we remove the two `scale_op` in `_finish_update()` and fuse it into `adam_op` to decrease the numbers of launched kernel.

> Note: regularizer is removed while testing.

#### 1. Dynamic Graph

The cost time of `minimizer` in `dyraph_mode` by `Dialogue-PLATO` model with single P40 GPU.

![image](https://user-images.githubusercontent.com/9301846/71067650-e1d44600-21af-11ea-9810-ec0634695815.png)

| minimize时间(s) | 优化前    | 优化后   |  提升 | 
|:-----------:|:------:|:------:|:------:|
| 1           | 0.070 | 0.038 | **45.7%** |

**we  trained 100 batches iteratively and sum up the total time. See details as follows:**
`total time = forward + optimize`

| 总时间(s) | 优化前    | 优化后   |  提升 | 
|:-----------:|:------:|:------:|:------:|
| 1           | 10.877 | 9.825 | **9.67%** |

**Conclusion:** This PR is with higher performance improvement mainly in dynamic graph mode.

#### 2. Static Graph
Also, we compared the running time on the static graph mode by `resNet50` model with 4 P40 GPU. 
> Note: Not all train dataset of ImageNet-2012 was used in above experiment，actually only 256000 pictures was used.

| 总时间(s/epoch) | 优化前    | 优化后   |  提升 |
|:-----------:|:------:|:------:|:------:|
| 1           | 850.96 | 848.94 ||
| 2           | 852.79 | 848.41 ||
| 3           | 853.53 | 850.20 ||
| 4           | 852.96 | 851.89 ||
| 5           | 852.92 | 850.98 ||
|平均值   | **852.63**|  **850.08** |0.3%|

We also compare the performance while turning on the `fuse_all_optimizer_ops = True` by `resNet50` model with 4 P40 GPU. 
> Note: Here only 25600 pictures was used to speed up the testing process.

| 总时间(s/epoch) | 优化前    | 优化后   |  提升 |
|:-----------:|:------:|:------:|:------:|
| 1           | 86.70 | 86.30 ||
| 2           | 86.60 | 86.46 ||
| 3           | 86.18 | 85.85 ||
| 4           | 86.44 | 85.97 ||
| 5           | 86.57 | 85.49 ||
|平均值   | **86.498**|  **86.014** |0.56%|

**Conclusion:** This PR will not affect the performance of static graphs too much.

