### PR TITLE
append optimize op in the grad block of current block 

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2229,6 +2229,14 @@ class Block(object):
         self.desc._set_forward_block_idx(idx)
 
     @property
+    def backward_block_idx(self):
+        cur_block_idx = self.idx
+        for block in self.program.blocks:
+            if block.forward_block_idx == cur_block_idx:
+                return block.idx
+        return -1
+
+    @property
     def idx(self):
         return self.desc.id
 


### PR DESCRIPTION
 **Note**: Need complex tests for `optimizer`. The current tests are too simple to test optimier in control flow.

---

1. Change the block in which appended optimize op 
when append optimize ops such as `sgd`, `adam` or `scale` , if current block is in control flow, optimize op should be appended in  **the grad block of current block** not **global block**.

2. Add property `backward_block_idx` for class `Block`
backward block should be known when optimizer used in control flow.
