### PR TITLE
add package for centerloss

### DIFF
--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -22,7 +22,8 @@ from ..layer_helper import LayerHelper
 from ..framework import Variable
 from ..data_feeder import check_type_and_dtype
 from ..param_attr import ParamAttr
-from ..initializer import NumpyArrayInitializer
+from ..initializer import NumpyArrayInitializer, Constant
+from .. import core
 
 __all__ = [
     'center_loss',


### PR DESCRIPTION
Because the `center loss`  moves to `loss.py`, the `core` and `Constant` are discarded. Thus, we should add them to `loss.py` to avoid the bug.