### PR TITLE
Fix Backward Bugs in Conditional Block

### DIFF
--- a/paddle/fluid/framework/details/op_registry.h
+++ b/paddle/fluid/framework/details/op_registry.h
@@ -221,7 +221,15 @@ struct OpInfoFiller<T, kGradOpDescMaker> {
 
     info->use_default_grad_op_desc_maker_ =
         std::is_base_of<DefaultGradOpMaker<OpDesc, true>, T>::value ||
-        std::is_base_of<DefaultGradOpMaker<OpDesc, false>, T>::value;
+        std::is_base_of<DefaultGradOpMaker<OpDesc, false>, T>::value ||
+        std::is_base_of<DefaultGradOpMaker<imperative::OpBase, true>,
+                        T>::value ||
+        std::is_base_of<DefaultGradOpMaker<imperative::OpBase, false>,
+                        T>::value;
+
+    info->use_empty_grad_op_desc_maker_ =
+        std::is_base_of<EmptyGradOpMaker<OpDesc>, T>::value ||
+        std::is_base_of<EmptyGradOpMaker<imperative::OpBase>, T>::value;
   }
 };
 

--- a/paddle/fluid/framework/load_op_lib.h
+++ b/paddle/fluid/framework/load_op_lib.h
@@ -101,6 +101,7 @@ void LoadOpLib(const std::string &dso_name) {
     info.infer_no_need_buffer_vars_ = n.second.infer_no_need_buffer_vars_;
     info.use_default_grad_op_desc_maker_ =
         n.second.use_default_grad_op_desc_maker_;
+    info.use_empty_grad_op_desc_maker_ = n.second.use_empty_grad_op_desc_maker_;
 
     info_map.Insert(type, info);
   }

--- a/paddle/fluid/framework/op_info.h
+++ b/paddle/fluid/framework/op_info.h
@@ -33,7 +33,8 @@ class InferShapeBase {
   virtual void operator()(InferShapeContext*) const = 0;
 };
 
-struct OpInfo {
+class OpInfo {
+ public:
   OpCreator creator_;
   GradOpMakerFN grad_op_maker_;
   proto::OpProto* proto_{nullptr};
@@ -47,6 +48,10 @@ struct OpInfo {
   // NOTE(zjl): this flag is added to check whether
   // the grad maker is the default one.
   bool use_default_grad_op_desc_maker_{false};
+
+  // NOTE(huihuangzheng): this flag is added to check whether
+  // the grad maker is the empty one.
+  bool use_empty_grad_op_desc_maker_{false};
 
   bool HasOpProtoAndChecker() const {
     return proto_ != nullptr && checker_ != nullptr;
@@ -82,8 +87,12 @@ struct OpInfo {
     return grad_op_maker_;
   }
 
-  // some op has no grad_op_maker, add check before use GradOpMaker()
+  // some ops don't have grad_op_maker, add check before use GradOpMaker()
   bool HasGradOpMaker() const { return grad_op_maker_ != nullptr; }
+
+  bool HasNonEmptyGradOpMaker() const {
+    return grad_op_maker_ != nullptr && !use_empty_grad_op_desc_maker_;
+  }
 
   const DygraphGradOpMakerFN& DygraphGradOpMaker() const {
     // Normally, proto_ should not be null, except some special operators, such
@@ -100,7 +109,7 @@ struct OpInfo {
   }
 
   bool HasDygraphGradOpMaker() const {
-    return dygraph_grad_op_maker_ != nullptr ? true : false;
+    return dygraph_grad_op_maker_ != nullptr;
   }
 
   bool HasInferInplace() const { return infer_inplace_ != nullptr; }

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1100,6 +1100,11 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("has_grad_op_maker", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasGradOpMaker();
   });
+  m.def("has_non_empty_grad_op_maker", [](const std::string op_type) {
+    return framework::OpInfoMap::Instance()
+        .Get(op_type)
+        .HasNonEmptyGradOpMaker();
+  });
   m.def("has_infer_inplace", [](const std::string op_type) {
     return framework::OpInfoMap::Instance().Get(op_type).HasInferInplace();
   });

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -497,7 +497,7 @@ def _find_not_need_ops(grad_op_descs, forward_ops, input_grad_names_set):
             to prune the unnecessary backward ops.
 
     Return:
-        (list[core.OpDesc]): A list of OpDescs which should be pruned.
+        (set[core.OpDesc]): A set of OpDescs which should be pruned.
     """
 
     class Var(object):
@@ -597,8 +597,13 @@ def _find_not_need_ops(grad_op_descs, forward_ops, input_grad_names_set):
                 break
         if remove_ops:
             not_need_op_descs.extend([node.op_desc for node in op_list])
-
-    return set(not_need_op_descs)
+    not_need_op_descs_set = set(not_need_op_descs)
+    grad_op_descs_set = set(grad_op_descs)
+    # If a backward computational graph is simply one sub-graph header, the
+    # not_need_op_descs will be whole graph, this IF clause avoids it. 
+    if grad_op_descs_set == not_need_op_descs_set:
+        return set()
+    return not_need_op_descs_set
 
 
 from .proto import framework_pb2
@@ -797,9 +802,10 @@ def _get_sub_block_path(sub_block, sub_block_op_desc, no_grad_set):
             for op_desc in sub_block.ops:
                 if op_desc.type == "assign" and var in op_desc.output_arg_names:
                     sub_assign_to_out_ops.append(op_desc)
-                    sub_outputs.extend([
-                        sub_block.var(name) for name in op_desc.input_arg_names
-                    ])
+                    for name in op_desc.input_arg_names:
+                        if sub_block.has_var(name):
+                            sub_outputs.append(sub_block.var(name))
+
         sub_block_op_path = _find_op_path_(sub_block, sub_outputs, [],
                                            no_grad_set)
         # TODO better way than finding in list
@@ -1241,7 +1247,9 @@ def _find_op_path_(block, outputs, inputs, no_grad_set):
     # All the inputs of the block are used if inputs is empty,
     if inputs:
         for i, op in enumerate(block.ops):
-            if _some_in_set_(op.desc.input_arg_names(), input_names):
+            if _some_in_set_(
+                    op.desc.input_arg_names(),
+                    input_names) and core.has_non_empty_grad_op_maker(op.type):
                 for name in op.desc.output_arg_names():
                     if name not in no_grad_set:
                         input_names.add(name)
@@ -1249,7 +1257,9 @@ def _find_op_path_(block, outputs, inputs, no_grad_set):
                 relevant_op_flags[i] = False
 
     for i, op in reversed(list(enumerate(block.ops))):
-        if _some_in_set_(op.desc.output_arg_names(), output_names):
+        if _some_in_set_(
+                op.desc.output_arg_names(),
+                output_names) and core.has_non_empty_grad_op_maker(op.type):
             for name in op.desc.input_arg_names():
                 if name not in no_grad_set:
                     output_names.add(name)


### PR DESCRIPTION
The fixed bugs:

1. The condition sub-graph is not pruned
When a condition block has operations, such as `out = layers.cond(a - b < -1.0, lambda: a, lambda: b)`, here `a - b < -1.0` will contain an "elementwise_sub_grad" op at backward stage but "less than" doesn't return any gradient since it is using an EmptyGradOpMaker, which can crash the program. We fixed it by pruning the backward graph:
![image](https://user-images.githubusercontent.com/7913861/71062437-6c637800-21a5-11ea-875f-5780b66de227.png)


2. When backward graph is extremely simple, the whole backward ops in a block are pruned. The very simple network is like `out = layers.cond(a < b, lambda: a, lambda: b)` or `y = x + 1`. We fixed it by:
![image](https://user-images.githubusercontent.com/7913861/71062366-44741480-21a5-11ea-918d-c0f372ac0b4b.png)

3. Also fix some tiny bugs, typos, and ugly codes. Such as English grammar "some op" -> "some ops", "return boolean_variable ? true : false;" -> "return boolean_variable", add C++ template classes when determine whether an op is using default grad op desc maker, _find_op_path_ should accept vars as inputs, not var_names. etc.
