### PR TITLE
Remove self-set accuracy parameters of op tests: max_relative_error

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
+++ b/python/paddle/fluid/tests/unittests/test_add_position_encoding_op.py
@@ -45,8 +45,7 @@ class TestAddPositionEncodingTensorOp(OpTest):
         """
         check the correctness of grad
         """
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=0.005, check_dygraph=False)
+        self.check_grad(['X'], 'Out', check_dygraph=False)
 
     def init_input_output(self):
         """
@@ -100,8 +99,7 @@ class TestAddPositionEncodingLoDTensorOp(OpTest):
         """
         check the correctness of grad
         """
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=0.005, check_dygraph=False)
+        self.check_grad(['X'], 'Out', check_dygraph=False)
 
     def init_input_output(self):
         """

--- a/python/paddle/fluid/tests/unittests/test_affine_grid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_grid_op.py
@@ -56,11 +56,7 @@ class TestAffineGridOp(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(
-            ['Theta'],
-            'Output',
-            no_grad_set=['OutputShape'],
-            max_relative_error=0.006)
+        self.check_grad(['Theta'], 'Output', no_grad_set=['OutputShape'])
 
     def initTestCase(self):
         self.theta_shape = (17, 2, 3)

--- a/python/paddle/fluid/tests/unittests/test_clip_op.py
+++ b/python/paddle/fluid/tests/unittests/test_clip_op.py
@@ -40,8 +40,7 @@ class TestClipOp(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=self.max_relative_error)
+        self.check_grad(['X'], 'Out')
 
     def initTestCase(self):
         self.shape = (4, 4)

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -50,10 +50,7 @@ class TestElementwiseAddOp(OpTest):
         if self.dtype == np.float16:
             return
         self.check_grad(
-            ['X', 'Y'],
-            'Out',
-            max_relative_error=0.005,
-            check_dygraph=(self.use_mkldnn == False))
+            ['X', 'Y'], 'Out', check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_ingore_x(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -62,7 +59,6 @@ class TestElementwiseAddOp(OpTest):
         self.check_grad(
             ['Y'],
             'Out',
-            max_relative_error=0.005,
             no_grad_set=set("X"),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -73,7 +69,6 @@ class TestElementwiseAddOp(OpTest):
         self.check_grad(
             ['X'],
             'Out',
-            max_relative_error=0.005,
             no_grad_set=set('Y'),
             check_dygraph=(self.use_mkldnn == False))
 

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -105,15 +105,13 @@ class TestGroupNormOp(OpTest):
             return
 
         place = core.CPUPlace()
-        self.check_grad_with_place(
-            place, set(['X', 'Scale', 'Bias']), 'Y', max_relative_error=0.01)
+        self.check_grad_with_place(place, set(['X', 'Scale', 'Bias']), 'Y')
         if core.is_compiled_with_cuda():
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
                 place,
                 set(['X', 'Scale', 'Bias']),
-                'Y',
-                max_relative_error=0.005)
+                'Y', )
 
     def init_test_case(self):
         pass

--- a/python/paddle/fluid/tests/unittests/test_kldiv_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_kldiv_loss_op.py
@@ -52,8 +52,7 @@ class TestKLDivLossOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'], 'Loss', no_grad_set=set(["Target"]), max_relative_error=0.06)
+        self.check_grad(['X'], 'Loss', no_grad_set=set(["Target"]))
 
     def initTestCase(self):
         self.x_shape = (4, 5, 5)

--- a/python/paddle/fluid/tests/unittests/test_l1_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_l1_norm_op.py
@@ -36,8 +36,7 @@ class TestL1NormOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=self.max_relative_error)
+        self.check_grad(['X'], 'Out')
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
@@ -183,7 +183,6 @@ class TestCUDNNLstmOp(OpTest):
         self.check_grad_with_place(
             place,
             set(['Input', 'W', 'InitH', 'InitC']), ['Out', 'last_h', 'last_c'],
-            max_relative_error=0.02,
             check_dygraph=False)
 
 

--- a/python/paddle/fluid/tests/unittests/test_match_matrix_tensor_op.py
+++ b/python/paddle/fluid/tests/unittests/test_match_matrix_tensor_op.py
@@ -74,8 +74,7 @@ class TestMatchMatrixTensorOp(OpTest):
         self.check_output(check_compile_vs_runtime=True, check_dygraph=False)
 
     def test_check_grad(self):
-        self.check_grad(
-            ['X', 'Y'], 'Out', max_relative_error=0.005, check_dygraph=False)
+        self.check_grad(['X', 'Y'], 'Out', check_dygraph=False)
 
 
 class TestMatchMatrixTensorOpCase1(TestMatchMatrixTensorOp):

--- a/python/paddle/fluid/tests/unittests/test_spectral_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_spectral_norm_op.py
@@ -96,8 +96,7 @@ class TestSpectralNormOp(TestSpectralNormOpNoGrad):
         self.check_grad(
             ['Weight'],
             'Out',
-            no_grad_set=set(["U", "V"]),
-            max_relative_error=0.1)
+            no_grad_set=set(["U", "V"]), )
 
     def initTestCase(self):
         self.weight_shape = (10, 12)


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests: max_relative_error
OP lists will be add later