### PR TITLE
Remove self-set accuracy parameters of op tests: max_relative_error

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -373,6 +373,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
+            max_relative_error=0.02,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -801,8 +801,8 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            no_grad_set=set(['Filter']),
             max_relative_error=0.02,
+            no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_input(self):

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -151,19 +151,13 @@ def create_test_cudnn_fp16_class(parent, grad_check=True):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place) and grad_check:
                 self.check_grad_with_place(
-                    place, ['Input'],
-                    'Output',
-                    max_relative_error=0.02,
-                    no_grad_set=set(['Filter']))
+                    place, ['Input'], 'Output', no_grad_set=set(['Filter']))
 
         def test_check_grad_no_input(self):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place) and grad_check:
                 self.check_grad_with_place(
-                    place, ['Filter'],
-                    'Output',
-                    max_relative_error=0.02,
-                    no_grad_set=set(['Input']))
+                    place, ['Filter'], 'Output', no_grad_set=set(['Input']))
 
     cls_name = "{0}_{1}".format(parent.__name__, "CUDNNFp16")
     TestConv2DCUDNNFp16.__name__ = cls_name
@@ -221,19 +215,13 @@ def create_test_cudnn_channel_last_fp16_class(parent, grad_check=True):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place) and grad_check:
                 self.check_grad_with_place(
-                    place, ['Input'],
-                    'Output',
-                    max_relative_error=0.02,
-                    no_grad_set=set(['Filter']))
+                    place, ['Input'], 'Output', no_grad_set=set(['Filter']))
 
         def test_check_grad_no_input(self):
             place = core.CUDAPlace(0)
             if core.is_float16_supported(place) and grad_check:
                 self.check_grad_with_place(
-                    place, ['Filter'],
-                    'Output',
-                    max_relative_error=0.02,
-                    no_grad_set=set(['Input']))
+                    place, ['Filter'], 'Output', no_grad_set=set(['Input']))
 
         def init_data_format(self):
             self.data_format = "NHWC"
@@ -385,7 +373,6 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.02,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -397,7 +384,6 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -815,8 +801,8 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.02,
             no_grad_set=set(['Filter']),
+            max_relative_error=0.02,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_input(self):
@@ -827,7 +813,6 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -154,31 +154,17 @@ class TestConv2dTransposeOp(OpTest):
         if self.use_cudnn:
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, ['Filter'],
-                'Output',
-                max_relative_error=0.02,
-                no_grad_set=set(['Input']))
+                place, ['Filter'], 'Output', no_grad_set=set(['Input']))
         else:
-            self.check_grad(
-                ['Filter'],
-                'Output',
-                max_relative_error=0.02,
-                no_grad_set=set(['Input']))
+            self.check_grad(['Filter'], 'Output', no_grad_set=set(['Input']))
 
     def test_check_grad_no_filter(self):
         if self.use_cudnn:
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, ['Input'],
-                'Output',
-                max_relative_error=0.02,
-                no_grad_set=set(['Filter']))
+                place, ['Input'], 'Output', no_grad_set=set(['Filter']))
         else:
-            self.check_grad(
-                ['Input'],
-                'Output',
-                max_relative_error=0.02,
-                no_grad_set=set(['Filter']))
+            self.check_grad(['Input'], 'Output', no_grad_set=set(['Filter']))
 
     def test_check_grad(self):
         if self.use_cudnn:

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -154,7 +154,10 @@ class TestConv2dTransposeOp(OpTest):
         if self.use_cudnn:
             place = core.CUDAPlace(0)
             self.check_grad_with_place(
-                place, ['Filter'], 'Output', no_grad_set=set(['Input']))
+                place, ['Filter'],
+                'Output',
+                max_relative_error=0.02,
+                no_grad_set=set(['Input']))
         else:
             self.check_grad(['Filter'], 'Output', no_grad_set=set(['Input']))
 


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests: max_relative_error
conv2d_op
conv2d_transpose_op