### PR TITLE
Remove self-set accuracy parameters of op tests: max_relative_erro

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_lstmp_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstmp_op.py
@@ -196,7 +196,6 @@ class TestLstmpOp(LstmTest.TestLstmOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Input', 'Weight', 'ProjWeight', 'Bias'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             check_dygraph=False)
 
@@ -216,7 +215,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             ['Input', 'Weight', 'ProjWeight', 'Bias', 'H0', 'C0'],
             ['Projection'],
             numeric_grad_delta=0.0000005,
-            max_relative_error=1e-2,
             check_dygraph=False)
 
     def test_check_grad_ingore_bias(self):
@@ -227,7 +225,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Input', 'ProjWeight', 'Weight'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             no_grad_set=set('Bias'),
             check_dygraph=False)
@@ -240,7 +237,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Input', 'ProjWeight', 'Bias'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             no_grad_set=set('Weight'),
             check_dygraph=False)
@@ -253,7 +249,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Input', 'Weight', 'Bias'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             no_grad_set=set('ProjWeight'),
             check_dygraph=False)
@@ -266,7 +261,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Weight', 'ProjWeight', 'Bias'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             no_grad_set=set('Input'),
             check_dygraph=False)
@@ -279,7 +273,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Input', 'Weight', 'ProjWeight', 'Bias', 'C0'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             no_grad_set=set('H0'),
             check_dygraph=False)
@@ -292,7 +285,6 @@ class TestLstmpOpHasInitial(TestLstmpOp):
             (N, self.D)).astype('float64')
         self.check_grad(
             ['Input', 'Weight', 'ProjWeight', 'Bias', 'H0'], ['Projection'],
-            max_relative_error=1e-2,
             numeric_grad_delta=0.0000005,
             no_grad_set=set('C0'),
             check_dygraph=False)

--- a/python/paddle/fluid/tests/unittests/test_row_conv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_row_conv_op.py
@@ -107,16 +107,16 @@ class TestRowConvOp2(OpTest):
         self.check_grad(
             ['Filter'],
             'Out',
-            no_grad_set=set('X'),
             max_relative_error=0.06,
+            no_grad_set=set('X'),
             check_dygraph=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(
             ['X'],
             'Out',
-            no_grad_set=set('Filter'),
             max_relative_error=0.06,
+            no_grad_set=set('Filter'),
             check_dygraph=False)
 
 

--- a/python/paddle/fluid/tests/unittests/test_row_conv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_row_conv_op.py
@@ -63,27 +63,15 @@ class TestRowConvOp1(OpTest):
         self.check_output(check_dygraph=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(
-            ['X', 'Filter'],
-            'Out',
-            max_relative_error=0.05,
-            check_dygraph=False)
+        self.check_grad(['X', 'Filter'], 'Out', check_dygraph=False)
 
     def test_check_grad_ignore_x(self):
         self.check_grad(
-            ['Filter'],
-            'Out',
-            max_relative_error=0.05,
-            no_grad_set=set('X'),
-            check_dygraph=False)
+            ['Filter'], 'Out', no_grad_set=set('X'), check_dygraph=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(
-            ['X'],
-            'Out',
-            max_relative_error=0.05,
-            no_grad_set=set('Filter'),
-            check_dygraph=False)
+            ['X'], 'Out', no_grad_set=set('Filter'), check_dygraph=False)
 
 
 class TestRowConvOp2(OpTest):
@@ -119,16 +107,16 @@ class TestRowConvOp2(OpTest):
         self.check_grad(
             ['Filter'],
             'Out',
-            max_relative_error=0.06,
             no_grad_set=set('X'),
+            max_relative_error=0.06,
             check_dygraph=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(
             ['X'],
             'Out',
-            max_relative_error=0.06,
             no_grad_set=set('Filter'),
+            max_relative_error=0.06,
             check_dygraph=False)
 
 
@@ -169,26 +157,14 @@ class TestRowOpWithTensorInput(OpTest):
 
     def test_check_grad_ignore_x(self):
         self.check_grad(
-            ['Filter'],
-            'Out',
-            max_relative_error=0.05,
-            no_grad_set=set('X'),
-            check_dygraph=False)
+            ['Filter'], 'Out', no_grad_set=set('X'), check_dygraph=False)
 
     def test_check_grad_normal(self):
-        self.check_grad(
-            ['X', 'Filter'],
-            'Out',
-            max_relative_error=0.05,
-            check_dygraph=False)
+        self.check_grad(['X', 'Filter'], 'Out', check_dygraph=False)
 
     def test_check_grad_ignore_wt(self):
         self.check_grad(
-            ['X'],
-            'Out',
-            max_relative_error=0.05,
-            no_grad_set=set('Filter'),
-            check_dygraph=False)
+            ['X'], 'Out', no_grad_set=set('Filter'), check_dygraph=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests: max_relative_error
lstmp_op
row_conv_op