### PR TITLE
Remove self-set accuracy parameters of op tests: max_relative_error

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_seq_conv.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_conv.py
@@ -135,10 +135,7 @@ class TestSeqProject(OpTest):
     def test_check_grad_padding_data(self):
         if self.padding_trainable:
             self.check_grad(
-                ['PaddingData'],
-                'Out',
-                max_relative_error=0.05,
-                no_grad_set=set(['X', 'Filter']))
+                ['PaddingData'], 'Out', no_grad_set=set(['X', 'Filter']))
 
     def test_check_grad_Filter(self):
         self.check_grad(


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests: max_relative_error
seq_conv