### PR TITLE
revert a+b axis change

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -225,13 +225,15 @@ def monkey_patch_variable():
                 other_var = tmp
 
             out = create_new_tmp_var(current_block(self), dtype=lhs_dtype)
-
+            axis = -1
+            if other_var.shape[0] == -1:
+                axis = 0
             current_block(self).append_op(
                 type=op_type,
                 inputs={'X': [self],
                         'Y': [other_var]},
                 outputs={'Out': out},
-                attrs={'axis': -1})
+                attrs={'axis': axis})
             return out
 
         comment = OpProtoHolder.instance().get_op_proto(op_type).comment


### PR DESCRIPTION
在重载python的 +-*/ 等运算符的时候，有一些特殊的处理

以 a + b 举例， b.shape[0] == -1 axis 强制置为 0

#21517 去除了这种修改，导致一些模型出现问题

这个pr 回滚了  #21517 的修改



