### PR TITLE
Remove self-set accuracy parameters of op tests: max_relative_error

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -43,7 +43,7 @@ class TestPadOp(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(['X'], 'Out', max_relative_error=0.006)
+        self.check_grad(['X'], 'Out')
 
     def initTestCase(self):
         self.shape = (16, 16)
@@ -83,7 +83,7 @@ def create_test_fp16(parent):
             return np.float16
 
         def test_check_grad_normal(self):
-            self.check_grad(['X'], 'Out', max_relative_error=0.3)
+            self.check_grad(['X'], 'Out')
 
     cls_name = "{0}_{1}".format(parent.__name__, "Fp16")
     TestPadFp16.__name__ = cls_name

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -83,7 +83,7 @@ def create_test_fp16(parent):
             return np.float16
 
         def test_check_grad_normal(self):
-            self.check_grad(['X'], 'Out')
+            self.check_grad(['X'], 'Out', max_relative_error=0.3)
 
     cls_name = "{0}_{1}".format(parent.__name__, "Fp16")
     TestPadFp16.__name__ = cls_name

--- a/python/paddle/fluid/tests/unittests/test_pool3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pool3d_op.py
@@ -261,10 +261,9 @@ class TestPool3d_Op(OpTest):
             return
         if self.has_cudnn() and self.pool_type != "max":
             place = core.CUDAPlace(0)
-            self.check_grad_with_place(
-                place, set(['X']), 'Out', max_relative_error=0.07)
+            self.check_grad_with_place(place, set(['X']), 'Out')
         elif self.pool_type != "max":
-            self.check_grad(set(['X']), 'Out', max_relative_error=0.07)
+            self.check_grad(set(['X']), 'Out')
 
     def init_data_format(self):
         self.data_format = "NCDHW"

--- a/python/paddle/fluid/tests/unittests/test_smooth_l1_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_smooth_l1_loss_op.py
@@ -88,7 +88,7 @@ class TestSmoothL1LossOp2(OpTest):
         self.check_output()
 
     def test_check_grad_normal(self):
-        self.check_grad(['X', 'Y'], 'Out', max_relative_error=0.03)
+        self.check_grad(['X', 'Y'], 'Out')
 
     def test_check_grad_ingore_x(self):
         self.check_grad(

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -151,7 +151,7 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
         self.check_output(atol=1e-2)
 
     def test_check_grad(self):
-        self.check_grad(["Logits"], "Loss")
+        self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
 
 
 class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
@@ -166,7 +166,7 @@ class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
         self.dtype = np.float16
 
     def test_check_grad(self):
-        self.check_grad(["Logits"], "Loss")
+        self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
 
 
 class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -151,7 +151,7 @@ class TestSoftmaxWithCrossEntropyOpFp16(TestSoftmaxWithCrossEntropyOp):
         self.check_output(atol=1e-2)
 
     def test_check_grad(self):
-        self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
+        self.check_grad(["Logits"], "Loss")
 
 
 class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
@@ -166,7 +166,7 @@ class TestSoftmaxWithCrossEntropyOpNoCudnnFp16(
         self.dtype = np.float16
 
     def test_check_grad(self):
-        self.check_grad(["Logits"], "Loss", max_relative_error=0.1)
+        self.check_grad(["Logits"], "Loss")
 
 
 class TestSoftmaxWithCrossEntropyOp2(TestSoftmaxWithCrossEntropyOp):


### PR DESCRIPTION
Remove self-set accuracy parameters of op tests: max_relative_error
pad_op
pool3d_op
smooth_l1_loss_op