### PR TITLE
Disable memory opt pass when DNNL is on

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -324,7 +324,7 @@ void AnalysisConfig::Update() {
   }
 
 #ifdef PADDLE_WITH_MKLDNN
-  // Do not optimize before quantization
+  // Do not optimize when mkldnn is on
   if (enable_memory_optim_ && !use_mkldnn_) {
 #else
   if (enable_memory_optim_) {

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -325,7 +325,7 @@ void AnalysisConfig::Update() {
 
 #ifdef PADDLE_WITH_MKLDNN
   // Do not optimize before quantization
-  if (enable_memory_optim_ && !use_mkldnn_quantizer_) {
+  if (enable_memory_optim_ && !use_mkldnn_) {
 #else
   if (enable_memory_optim_) {
 #endif


### PR DESCRIPTION
Temoparily disables memory optimization pass when DNNL is on. This is a temporary fix for until the memory optim pass will be fixed.