### PR TITLE
A fix for issue 66 from PaddleDetection

### DIFF
--- a/paddle/fluid/operators/roi_align_op.h
+++ b/paddle/fluid/operators/roi_align_op.h
@@ -154,8 +154,6 @@ class CPUROIAlignOpKernel : public framework::OpKernel<T> {
     int width = in_dims[3];
     int rois_num = rois->dims()[0];
 
-    if (rois_num == 0) return;
-
     auto in_stride = framework::stride(in_dims);
     auto roi_stride = framework::stride(rois->dims());
     auto out_stride = framework::stride(out->dims());

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_concat_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_concat_mkldnn_op.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 import unittest
-from paddle.fluid.tests.unittests.test_concat_op import TestConcatOp, TestConcatOp2, TestConcatOp3
+from paddle.fluid.tests.unittests.test_concat_op import TestConcatOp, TestConcatOp2, TestConcatOp3, TestConcatOp4
 
 
 class TestMKLDNNConcatOp(TestConcatOp):
@@ -42,7 +42,7 @@ class TestMKLDNNConcatOp2(TestConcatOp2):
         self._cpu_only = True
 
     def test_check_output(self):
-        # TODO(wangzhongpu): support mkldnn op in dygraph mode 
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output(check_dygraph=(self.attrs["use_mkldnn"] == False))
 
     def test_check_grad(self):
@@ -59,7 +59,24 @@ class TestMKLDNNConcatOp3(TestConcatOp3):
         self._cpu_only = True
 
     def test_check_output(self):
-        # TODO(wangzhongpu): support mkldnn op in dygraph mode 
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
+        self.check_output(check_dygraph=(self.attrs["use_mkldnn"] == False))
+
+    def test_check_grad(self):
+        pass
+
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
+
+class TestMKLDNNConcatOp4(TestConcatOp4):
+    def setUp(self):
+        super(TestMKLDNNConcatOp4, self).setUp()
+        self.attrs["use_mkldnn"] = True
+        self._cpu_only = True
+
+    def test_check_output(self):
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output(check_dygraph=(self.attrs["use_mkldnn"] == False))
 
     def test_check_grad(self):


### PR DESCRIPTION
This is a fix for https://github.com/PaddlePaddle/PaddleDetection/issues/66.

* Initialize output tensors for `roi_align` operators even when ROIs number equals to 0.
* In MKL-DNN concat, handle multi-inputs with empty inputs.

test=develop