### PR TITLE
Try to Fix Random Fail

### DIFF
--- a/paddle/fluid/framework/io/shell.cc
+++ b/paddle/fluid/framework/io/shell.cc
@@ -124,7 +124,8 @@ static int shell_popen_fork_internal(const char* real_cmd, bool do_read,
   }
 
   close_open_fds_internal();
-  PCHECK(execl("/bin/bash", "bash", "-c", real_cmd, NULL) >= 0);
+  PCHECK(execl("/bin/bash", "bash", "-c", real_cmd,
+               reinterpret_cast<char*>(NULL)) >= 0);
   exit(127);
 #endif
 }


### PR DESCRIPTION
Try to fix random fail UT(test_boxps), the failed reason is `execl("/bin/bash", "bash", "-c", real_cmd, NULL) >=0 : Bad address [14]`
The last parameter of execl should be cast to char*, due to https://linux.die.net/man/3/execl
