### PR TITLE
add decorator skip_check_grad_ci

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -142,6 +142,25 @@ def get_numeric_gradient(place,
     return gradient_flat.reshape(tensor_to_check.shape())
 
 
+def skip_check_grad_ci(func):
+    """Decorator to skip check_grd CI.
+       
+       Check_grad is required for Op test cases. However, there are specical cases 
+       that do not need to check_grad. The decorator is used to avoid failures of 
+       check_grad checking. 
+       
+       Note: the execution of unit test will not be skipped. It just avoids check_grad 
+       checking in tearDownClass method by setting a `no_need_check_grad` flag.
+
+    """
+
+    def wrapper(self, *args, **kw):
+        self.__class__.no_need_check_grad = True
+        return func(self, *args, **kw)
+
+    return wrapper
+
+
 class OpTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -171,7 +190,7 @@ class OpTest(unittest.TestCase):
                 " please set self.__class__.op_type=the_real_op_type manually.")
 
         # cases and ops do no need check_grad
-        if cls.__name__ in op_check_grad_white_list.NO_NEED_CHECK_GRAD_CASES \
+        if hasattr(cls, "no_need_check_grad") \
             or cls.op_type in op_check_grad_white_list.EMPTY_GRAD_OP_LIST:
             return
 

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -142,21 +142,26 @@ def get_numeric_gradient(place,
     return gradient_flat.reshape(tensor_to_check.shape())
 
 
-def skip_check_grad_ci(func):
-    """Decorator to skip check_grd CI.
+def skip_check_grad_ci(reason=None):
+    """Decorator to skip check_grad CI.
        
-       Check_grad is required for Op test cases. However, there are specical cases 
-       that do not need to check_grad. The decorator is used to avoid failures of 
-       check_grad checking. 
+       Check_grad is required for Op test cases. However, there are some special
+       cases that do not need to do check_grad. This decorator is used to skip the 
+       check_grad of the above cases.
        
        Note: the execution of unit test will not be skipped. It just avoids check_grad 
        checking in tearDownClass method by setting a `no_need_check_grad` flag.
 
+       Example:
+           @skip_check_grad_ci(reason="For inference, check_grad is not required.")
+           class TestInference(OpTest):
     """
+    if not isinstance(reason, str):
+        raise AssertionError("The reason for skipping check_grad is required.")
 
-    def wrapper(self, *args, **kw):
-        self.__class__.no_need_check_grad = True
-        return func(self, *args, **kw)
+    def wrapper(cls):
+        cls.no_need_check_grad = True
+        return cls
 
     return wrapper
 

--- a/python/paddle/fluid/tests/unittests/test_dropout_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dropout_op.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle.fluid.core as core
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 
@@ -61,6 +61,7 @@ class TestDropoutOp3(TestDropoutOp):
         }
 
 
+@skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOp4(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -74,6 +75,7 @@ class TestDropoutOp4(OpTest):
         self.check_output()
 
 
+@skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOp5(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -119,6 +121,7 @@ class TestDropoutOp7(TestDropoutOp):
         }
 
 
+@skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOp8(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -135,6 +138,7 @@ class TestDropoutOp8(OpTest):
         self.check_output()
 
 
+@skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestDropoutOp9(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -174,6 +178,7 @@ class TestDropoutOpWithSeed(OpTest):
 @unittest.skipIf(
     not core.is_compiled_with_cuda() or not core.op_support_gpu("dropout"),
     "core is not compiled with CUDA or core is not support dropout")
+@skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestFP16DropoutOp(OpTest):
     def setUp(self):
         self.op_type = "dropout"
@@ -201,6 +206,7 @@ class TestFP16DropoutOp(OpTest):
 @unittest.skipIf(
     not core.is_compiled_with_cuda() or not core.op_support_gpu("dropout"),
     "core is not compiled with CUDA or core is not support dropout")
+@skip_check_grad_ci(reason="For inference, check_grad is not required.")
 class TestFP16DropoutOp2(TestFP16DropoutOp):
     def init_test_case(self):
         self.input_size = [32, 64, 3]

--- a/python/paddle/fluid/tests/unittests/test_executor_return_tensor_not_overwriting.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_return_tensor_not_overwriting.py
@@ -17,9 +17,10 @@ import unittest
 import numpy as np
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 
 
+@skip_check_grad_ci(reason="Not op test but call the method of class OpTest.")
 class TestExecutorReturnTensorNotOverwritingWithOptest(OpTest):
     def setUp(self):
         pass

--- a/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_emb_seq_pool_op.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import platform
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.op import Operator
@@ -25,6 +25,8 @@ import paddle.compat as cpt
 import paddle.version as ver
 
 
+@skip_check_grad_ci(reason="check_grad is called when ver.mkl() == ON"
+                    "and 'Linux' in platform.platform().")
 class TestFusedEmbeddingSeqPoolOp(OpTest):
     def setUp(self):
         self.op_type = "fused_embedding_seq_pool"

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.compat as cpt
@@ -64,6 +64,7 @@ class TestLookupTableOpWithPadding(TestLookupTableOp):
         self.attrs = {'padding_idx': int(padding_idx)}
         self.check_output()
 
+    @skip_check_grad_ci
     def test_check_grad(self):
         # Since paddings are not trainable and fixed in forward, the gradient of
         # paddings makes no sense and we don't test the gradient here.
@@ -79,6 +80,7 @@ class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
         self.attrs = {'padding_idx': cpt.long_type(padding_idx)}
         self.check_output()
 
+    @skip_check_grad_ci
     def test_check_grad(self):
         # Since paddings are not trainable and fixed in forward, the gradient of
         # paddings makes no sense and we don't test the gradient here.

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -56,6 +56,10 @@ class TestLookupTableOpWithTensorIds(OpTest):
         self.check_grad(['W'], 'Out', no_grad_set=set('Ids'))
 
 
+@skip_check_grad_ci(
+    reason="Since paddings are not trainable and fixed in forward,"
+    "the gradient of paddings makes no sense and we don't "
+    "test the gradient here.")
 class TestLookupTableOpWithPadding(TestLookupTableOp):
     def test_check_output(self):
         ids = np.squeeze(self.inputs['Ids'])
@@ -64,13 +68,11 @@ class TestLookupTableOpWithPadding(TestLookupTableOp):
         self.attrs = {'padding_idx': int(padding_idx)}
         self.check_output()
 
-    @skip_check_grad_ci
-    def test_check_grad(self):
-        # Since paddings are not trainable and fixed in forward, the gradient of
-        # paddings makes no sense and we don't test the gradient here.
-        pass
 
-
+@skip_check_grad_ci(
+    reason="Since paddings are not trainable and fixed in forward,"
+    "the gradient of paddings makes no sense and we don't "
+    "test the gradient here.")
 class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
     def test_check_output(self):
         ids = self.inputs['Ids']
@@ -79,12 +81,6 @@ class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
         self.outputs['Out'][np.squeeze(ids == padding_idx)] = np.zeros(31)
         self.attrs = {'padding_idx': cpt.long_type(padding_idx)}
         self.check_output()
-
-    @skip_check_grad_ci
-    def test_check_grad(self):
-        # Since paddings are not trainable and fixed in forward, the gradient of
-        # paddings makes no sense and we don't test the gradient here.
-        pass
 
 
 class TestLookupTableWIsSelectedRows(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -55,6 +55,10 @@ class TestLookupTableOpWithTensorIds(OpTest):
         self.check_grad(['W'], 'Out', no_grad_set=set('Ids'))
 
 
+@skip_check_grad_ci(
+    reason="Since paddings are not trainable and fixed in forward,"
+    "the gradient of paddings makes no sense and we don't "
+    "test the gradient here.")
 class TestLookupTableOpWithPadding(TestLookupTableOp):
     def test_check_output(self):
         ids = np.squeeze(self.inputs['Ids'])
@@ -63,12 +67,11 @@ class TestLookupTableOpWithPadding(TestLookupTableOp):
         self.attrs = {'padding_idx': int(padding_idx)}
         self.check_output()
 
-    def test_check_grad(self):
-        # Since paddings are not trainable and fixed in forward, the gradient of
-        # paddings makes no sense and we don't test the gradient here.
-        pass
 
-
+@skip_check_grad_ci(
+    reason="Since paddings are not trainable and fixed in forward,"
+    "the gradient of paddings makes no sense and we don't "
+    "test the gradient here.")
 class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
     def test_check_output(self):
         ids = self.inputs['Ids']
@@ -77,11 +80,6 @@ class TestLookupTableOpWithTensorIdsAndPadding(TestLookupTableOpWithTensorIds):
         self.outputs['Out'][np.squeeze(ids == padding_idx)] = np.zeros(31)
         self.attrs = {'padding_idx': cpt.long_type(padding_idx)}
         self.check_output()
-
-    def test_check_grad(self):
-        # Since paddings are not trainable and fixed in forward, the gradient of
-        # paddings makes no sense and we don't test the gradient here.
-        pass
 
 
 class TestLookupTableWIsSelectedRows(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.fluid.op import Operator

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 from test_reorder_lod_tensor import convert_to_offset
 
 
@@ -355,6 +355,8 @@ class TestSeqMaxPool2DLen0LoDLevel2(TestSeqMaxPool2D):
         return [[1, 0, 2, 2], [0, 3, 0, 10, 0]]
 
 
+@skip_check_grad_ci(reason="Grad computation does not apply to Sequence MAX "
+                    "Pool executed when is_test is true.")
 class TestSeqMaxPool2DInference(TestSeqMaxPool2D):
     def compute(self, x, offset, out):
         self.attrs = {"pad_value": 1.0, 'pooltype': "MAX", 'is_test': True}
@@ -366,11 +368,6 @@ class TestSeqMaxPool2DInference(TestSeqMaxPool2D):
                 sub_x = np.reshape(x[offset[level][i]:offset[level][i + 1], :],
                                    (-1, 3 * 11))
                 out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
-
-    def test_check_grad(self):
-        """Grad computation does not apply to Sequence MAX 
-            Pool executed when is_test is true """
-        return
 
 
 class TestSeqMaxPool2DInferenceLen0(TestSeqMaxPool2DInference):

--- a/python/paddle/fluid/tests/unittests/test_seq_pool.py
+++ b/python/paddle/fluid/tests/unittests/test_seq_pool.py
@@ -369,6 +369,11 @@ class TestSeqMaxPool2DInference(TestSeqMaxPool2D):
                                    (-1, 3 * 11))
                 out[i] = np.reshape(np.amax(sub_x, axis=0), (3, 11))
 
+    def test_check_grad(self):
+        """Grad computation does not apply to Sequence MAX
+            Pool executed when is_test is true """
+        return
+
 
 class TestSeqMaxPool2DInferenceLen0(TestSeqMaxPool2DInference):
     def set_lod(self):

--- a/python/paddle/fluid/tests/unittests/white_list/op_check_grad_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_check_grad_white_list.py
@@ -56,10 +56,6 @@ EMPTY_GRAD_OP_LIST = [
 
 # Special cases do not need to check grad
 NO_NEED_CHECK_GRAD_CASES = [
-    'TestLookupTableOpWithPadding',
-    'TestLookupTableOpWithTensorIdsAndPadding',
-    'TestLookupTableOpWithPadding',
-    'TestLookupTableOpWithTensorIdsAndPadding',
     'TestSeqMaxPool2DInference',
     'TestSeqMaxPool2DInferenceLen0',
     'TestSeqMaxPool2DInferenceLen0LoDLevel2',

--- a/python/paddle/fluid/tests/unittests/white_list/op_check_grad_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_check_grad_white_list.py
@@ -53,30 +53,3 @@ EMPTY_GRAD_OP_LIST = [
     'hash', 'less_than', 'not_equal', 'eye', 'chunk_eval', 'is_empty',
     'proximal_gd', 'collect_fpn_proposals', 'unique_with_counts'
 ]
-
-# Special cases do not need to check grad
-NO_NEED_CHECK_GRAD_CASES = [
-    'TestSeqMaxPool2DInference',
-    'TestSeqMaxPool2DInferenceLen0',
-    'TestSeqMaxPool2DInferenceLen0LoDLevel2',
-    'TestDropoutOp4',
-    'TestDropoutOp5',
-    'TestDropoutOp8',
-    'TestDropoutOp9',
-    'TestFP16DropoutOp',
-    'TestFP16DropoutOp2',
-    'TestExpandOpBoolean',
-    'TestFusedEmbeddingSeqPoolOp',
-    'TestMKLDNNConcatOp',
-    'TestMKLDNNConcatOp',
-    'TestMKLDNNConcatOp3',
-    'TestElementwiseMulMKLDNNOp_Integrated_With_Convs',
-    'TestConv2dTransposeMKLDNNOp',
-    'TestMKLDNNFuseBias',
-    'TestMKLDNNWithPad',
-    'TestMKLDNNWithStride',
-    'TestMKLDNNWithAsymPad',
-    'TestMKLDNNWithSamePad',
-    'TestMKLDNNWithValidPad',
-    'TestMKLDNNWithValidPad_NHWC',
-]


### PR DESCRIPTION
**add decorator to skip check_grd CI**:
Check_grad is required for Op test cases. However, there are specical cases that do not need to check_grad. The decorator is used to avoid failures of check_grad checking. 

**Note**: The execution of unit test will not be skipped. It just avoids check_grad checking in tearDownClass method by setting a `no_need_check_grad` flag.