### PR TITLE
fix multi-thread error of fc_gru_fuse_pass.cc, test=develop

### DIFF
--- a/paddle/fluid/framework/ir/fc_gru_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_gru_fuse_pass.cc
@@ -92,8 +92,12 @@ static int BuildFusion(Graph* graph, const std::string& name_scope,
     }
 #undef GET_NODE
 
-#define NEW_IMTERMEDIATE_OUT(key) \
-  scope.Var(NEW_NAME(key))->GetMutable<framework::LoDTensor>()
+#define NEW_IMTERMEDIATE_OUT(key)                \
+  VarDesc key(NEW_NAME(key));                    \
+  key.SetPersistable(false);                     \
+  auto* key##_node = graph->CreateVarNode(&key); \
+  IR_NODE_LINK_TO(op, key##_node);
+
     NEW_IMTERMEDIATE_OUT(ReorderedH0);
     NEW_IMTERMEDIATE_OUT(XX);
     NEW_IMTERMEDIATE_OUT(BatchedInput);

--- a/paddle/fluid/inference/api/demo_ci/vis_demo.cc
+++ b/paddle/fluid/inference/api/demo_ci/vis_demo.cc
@@ -31,7 +31,7 @@ DEFINE_string(
     "'<space splitted floats as data>\t<space splitted ints as shape'");
 DEFINE_bool(use_gpu, false, "Whether use gpu.");
 #ifdef PADDLE_WITH_SHARED_LIB
-DEFINE_bool(profile, false, "Whether use profile.");
+DECLARE_bool(profile);
 #endif
 
 namespace paddle {

--- a/paddle/fluid/inference/paddle_fluid.map
+++ b/paddle/fluid/inference/paddle_fluid.map
@@ -2,7 +2,10 @@
 	global:
 		*paddle*;
 		*Pass*;
-		*profile*;
+		extern "C++" {
+			fL*::*;
+		};
 	local:
 		*;
 };
+


### PR DESCRIPTION
Pass 在 Parent Scope 创建中间变量，会引起克隆时 Scope 错误，引起计算错误或多线程访问越界。

由于 Pass 执行时不知道 Sub Scope 的地址，最初有以下两种修复方案：
```
1、在 Pass 中添加一个回调函数，在克隆时二次运行 Pass。但这样可能需要添加注册单例，比较繁琐。
2、克隆时同时克隆主 Predictor 的 SubScope。这种方案涉及到 Scope 的改动或 Variable 的深拷贝问题，考虑不周会影响全局。
```


经过比较，最终使用第三种方案，对 Pass 的使用做限定（尽量将 Scope 作为只读，在非只读时，限定对 persistable variable 进行改动。禁止 Pass 在 Scope 中创建临时中间变量）。这样不改变 Pass 设计初衷，也可以最小化代码变动范围。

这个 PR 可以让 fc_gru_fuse_pass 满足上述要求。