### PR TITLE
Modify the while_loop API

### DIFF
--- a/paddle/fluid/operators/controlflow/while_op_helper.cc
+++ b/paddle/fluid/operators/controlflow/while_op_helper.cc
@@ -208,7 +208,7 @@ bool GetCondData(const framework::LoDTensor &cond) {
   framework::TensorCopySync(cond, platform::CPUPlace(), cpu_cond.get());
 #else
   PADDLE_THROW(platform::errors::PreconditionNotMet(
-      "This version of PaddlePaddle doen NOT support GPU but got GPU tensor "
+      "This version of PaddlePaddle does NOT support GPU but got GPU tensor "
       "Cond in WhileOp. Please compile WITH_GPU option"));
 #endif
   return cpu_cond->data<bool>()[0];

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -829,7 +829,7 @@ class While(object):
 
     Args:
         cond(Variable): A Tensor whose data type is bool controlling whether to continue looping.
-        is_test(bool, optional): A flag indicating whether execution is in test phase. Default value is None.
+        is_test(bool, optional): A flag indicating whether execution is in test phase. Default value is False.
         name(str, optional): The default value is None.  Normally there is no need for user to set this property.  For more information, please refer to :ref:`api_guide_Name` .
 
     Examples:
@@ -928,7 +928,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
         body(Callable): A callable returning a tuple or list of tensors of the same arity (length and structure)
             and types as ``loops_vars`` .
         loop_vars(list|tuple): A list or tuple of tensors that is passed to both ``cond`` and ``body`` .
-        is_test(bool, optional): A flag indicating whether execution is in test phase. Default value is None.
+        is_test(bool, optional): A flag indicating whether execution is in test phase. Default value is False.
         name(str, optional): Normally there is no need for users to set this property. For more information, please
             refer to :ref:`api_guide_Name`. Default is None.
     

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -919,7 +919,7 @@ class While(object):
                    "is_test": self.is_test})
 
 
-def while_loop(cond, body, loop_vars, name=None):
+def while_loop(cond, body, loop_vars, is_test=False, name=None):
     """
     while_loop is one of the control flows. Repeats while_loop `body` until `cond` returns False.
 
@@ -928,6 +928,7 @@ def while_loop(cond, body, loop_vars, name=None):
         body(Callable): A callable returning a tuple or list of tensors of the same arity (length and structure)
             and types as ``loops_vars`` .
         loop_vars(list|tuple): A list or tuple of tensors that is passed to both ``cond`` and ``body`` .
+        is_test(bool, optional): A flag indicating whether execution is in test phase. Default value is None.
         name(str, optional): Normally there is no need for users to set this property. For more information, please
             refer to :ref:`api_guide_Name`. Default is None.
     
@@ -991,7 +992,7 @@ def while_loop(cond, body, loop_vars, name=None):
             "the shape of the variable returned by cond should be [],"
             "but given shape as {0}.".format(list(pre_cond.shape)))
 
-    while_loop_block = While(pre_cond)
+    while_loop_block = While(pre_cond, is_test, name)
     with while_loop_block.block():
         output_vars = body(*loop_vars)
         if len(loop_vars) == 1:


### PR DESCRIPTION
- 为while_loop API补充添加变量：is_test，
当is_test=True时，while_loop只进行前向计算，不计算反向，当前向计算结束后便会删除scope，可降低运行时的显存
- 修改其英文文档中错误
- 修复While OP英文文档默认值的错误（中文文档无此错误）
￼
![image](https://user-images.githubusercontent.com/52460041/71344330-2fc8bf80-259d-11ea-8d22-e57d559c0a32.png)
