### PR TITLE
control flow: support optimizer called

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1182,6 +1182,7 @@ def append_backward(loss,
             if program._appending_grad_times > 1:
                 input_grad_names_set = set([_append_grad_suffix_(loss.name)])
 
+        # Todo: support _append_backward_ops_with_checkpoints_ in control flow
         if checkpoints != None and \
                 isinstance(checkpoints, list) and \
                 len(checkpoints) > 0:
@@ -1197,7 +1198,7 @@ def append_backward(loss,
                     checkpoints)
         else:
             _append_backward_ops_(
-                block,  # the block where forward ops are#
+                block,  # the block where forward ops are in
                 op_path_dict[block_idx],
                 target_grad_block,
                 no_grad_dict,
@@ -1205,14 +1206,15 @@ def append_backward(loss,
                 callbacks,
                 input_grad_names_set=input_grad_names_set)
 
-        # Because calc_gradient may be called multiple times,
-        # we need rename the internal gradient variables so that they have
-        # different names.
-        _rename_grad_(block, block_fwd_op_num_dict[block_idx], grad_to_var, {})
-
     grad_info_map = dict()
     fwd_op_num = block_fwd_op_num_dict[
         current_block_idx] if not is_in_control_flow else 0
+
+    # Because append_backward may be called multiple times,
+    # we need rename the internal gradient variables so that they have
+    # different names.
+    _rename_grad_(target_grad_block, fwd_op_num, grad_to_var, {})
+
     _append_backward_vars_(target_grad_block, fwd_op_num, grad_to_var,
                            grad_info_map)
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -958,7 +958,7 @@ def _append_backward_vars_(block, start_op_idx, grad_to_var, grad_info_map):
         for grad_var_name in op_desc.output_arg_names():
             if block.desc.has_var_recursive(cpt.to_bytes(
                     grad_var_name)) or grad_var_name == core.empty_var_name():
-                print("1. grad_var_name : ", grad_var_name)
+                # print("1. grad_var_name : ", grad_var_name)
                 continue
             block.desc.var(cpt.to_bytes(grad_var_name))
             new_vars.add(grad_var_name)
@@ -1343,7 +1343,7 @@ def _find_op_path_(block, outputs, inputs, no_grad_set):
     no_grad_set will also be changed
     """
     input_names = set([inp.name for inp in inputs])
-    output_names = set([out.name for out in outputs])
+    output_names = _get_output_names(block, outputs)
 
     relevant_op_flags = [True] * len(block.ops)
 

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -958,6 +958,7 @@ def _append_backward_vars_(block, start_op_idx, grad_to_var, grad_info_map):
         for grad_var_name in op_desc.output_arg_names():
             if block.desc.has_var_recursive(cpt.to_bytes(
                     grad_var_name)) or grad_var_name == core.empty_var_name():
+                print("1. grad_var_name : ", grad_var_name)
                 continue
             block.desc.var(cpt.to_bytes(grad_var_name))
             new_vars.add(grad_var_name)

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1299,22 +1299,25 @@ def _as_list(x):
 
 
 def _get_output_names(block, outputs):
-    current_block = outputs[0].block
+
     current_output_names = set([out.name for out in outputs])
 
-    while current_block.idx != block.idx:
-        link_output_names = set()
-        parent_block = block.program.blocks[current_block.parent_idx]
-        for i, op in reversed(list(enumerate(current_block.ops))):
-            if _some_in_set_(op.desc.output_arg_names(), current_output_names):
-                for name in op.desc.input_arg_names():
-                    current_output_names.add(name)
-                    if not current_block.desc.find_var(name.encode(
-                            "ascii")) and parent_block.desc.find_var(
-                                name.encode("ascii")):
-                        link_output_names.add(name)
-        current_output_names = link_output_names
-        current_block = parent_block
+    if outputs:
+        current_block = outputs[0].block
+        while current_block.idx != block.idx:
+            link_output_names = set()
+            parent_block = block.program.blocks[current_block.parent_idx]
+            for i, op in reversed(list(enumerate(current_block.ops))):
+                if _some_in_set_(op.desc.output_arg_names(),
+                                 current_output_names):
+                    for name in op.desc.input_arg_names():
+                        current_output_names.add(name)
+                        if not current_block.desc.find_var(
+                                name.encode("ascii")
+                        ) and parent_block.desc.find_var(name.encode("ascii")):
+                            link_output_names.add(name)
+            current_output_names = link_output_names
+            current_block = parent_block
     return current_output_names
 
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2232,6 +2232,14 @@ class Block(object):
         self.desc._set_forward_block_idx(idx)
 
     @property
+    def backward_block_idx(self):
+        cur_block_idx = self.idx
+        for block in self.program.blocks:
+            if block.forward_block_idx == cur_block_idx:
+                return block.idx
+        return -1
+
+    @property
     def idx(self):
         return self.desc.id
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -28,6 +28,8 @@ import warnings
 import six
 from functools import reduce, partial
 from ..data_feeder import convert_dtype, check_type_and_dtype
+from ... import compat as cpt
+from ..backward import _infer_var_data_type_shape_
 
 __all__ = [
     'While', 'Switch', 'increment', 'array_write', 'create_array', 'less_than',
@@ -1811,7 +1813,7 @@ class ConditionalBlock(object):
 
         step_scope = parent_block.create_var(
             type=core.VarDesc.VarType.STEP_SCOPES)
-        parent_block.append_op(
+        conditional_block_op = parent_block.append_op(
             type='conditional_block',
             inputs={
                 'Cond': self.inputs,
@@ -1823,6 +1825,75 @@ class ConditionalBlock(object):
                 'sub_block': inside_block,
                 'is_scalar_condition': self.is_scalar_condition
             })
+
+        if self.need_append_conditional_block_grad(inside_block):
+            self.append_conditional_block_grad(parent_block, inside_block,
+                                               conditional_block_op)
+
+    def need_append_conditional_block_grad(self, inside_block):
+        grad_sub_block_idx = inside_block.backward_block_idx
+
+        return grad_sub_block_idx != -1
+
+    def append_conditional_block_grad(self, parent_block, inside_block,
+                                      conditional_block_op):
+        grad_sub_block_idx = inside_block.backward_block_idx
+        grad_sub_block = self.helper.main_program.block(grad_sub_block_idx)
+
+        intermediate = set()
+        params = set()
+
+        for each_op in grad_sub_block.ops:
+            assert isinstance(each_op, Operator)
+            for iname in each_op.input_names:
+                for in_var_name in each_op.input(iname):
+                    if in_var_name not in intermediate:
+                        params.add(in_var_name)
+
+            for oname in each_op.output_names:
+                for out_var_name in each_op.output(oname):
+                    intermediate.add(out_var_name)
+
+        param_list = []
+        for inner_out_name in params:
+            inner_var = parent_block._find_var_recursive(inner_out_name)
+            if inner_var:
+                param_list.append(cpt.to_text(inner_var.name))
+
+        grad_op_desc, op_grad_to_var = core.get_grad_op_desc(
+            conditional_block_op.desc,
+            cpt.to_text(set()), [grad_sub_block.desc])
+
+        # append op_desc in grad_op_descs to target_block
+        op_role_attr_name = core.op_proto_and_checker_maker.kOpRoleAttrName()
+        backward = core.op_proto_and_checker_maker.OpRole.Backward
+        new_op_desc = parent_block.desc.append_op()
+        new_op_desc.copy_from(grad_op_desc[0])
+        new_op_desc._set_attr(op_role_attr_name, backward)
+
+        new_vars = set()
+        for grad_var_name in new_op_desc.output_arg_names():
+            if grad_sub_block.desc.has_var_recursive(
+                    cpt.to_bytes(grad_var_name)
+            ) or grad_var_name == core.empty_var_name():
+                continue
+            grad_sub_block.desc.var(cpt.to_bytes(grad_var_name))
+            new_vars.add(grad_var_name)
+            if grad_var_name not in op_grad_to_var:
+                continue
+
+        # infer_shape and infer_type
+        new_op_desc.infer_var_type(grad_sub_block.desc)
+        new_op_desc.infer_shape(grad_sub_block.desc)
+
+        # set input
+        new_op_desc.set_input('Input', param_list)
+
+        for arg in new_op_desc.output_arg_names():
+            if arg in new_vars:
+                _infer_var_data_type_shape_(arg, grad_sub_block)
+
+        self.helper.main_program._sync_with_cpp()
 
 
 def copy_var_to_parent_block(var, layer_helper):

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1872,8 +1872,8 @@ class ConditionalBlock(object):
                     intermediate.add(out_var_name)
 
         param_list = []
-        for inner_out_name in params:
-            inner_var = parent_block._find_var_recursive(inner_out_name)
+        for inner_input_name in params:
+            inner_var = parent_block._find_var_recursive(inner_input_name)
             if inner_var:
                 param_list.append(cpt.to_text(inner_var.name))
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1894,29 +1894,22 @@ class ConditionalBlock(object):
 
         new_vars = set()
         for grad_var_name in new_op_desc.output_arg_names():
-            if parent_block.desc.has_var_recursive(
+            if grad_sub_block.desc.has_var_recursive(
                     cpt.to_bytes(grad_var_name)
             ) or grad_var_name == core.empty_var_name():
                 continue
-            print("----- 2. block id : {}, grad_var_name : {} ".format(
-                parent_block.idx, grad_var_name))
-            parent_block.desc.var(cpt.to_bytes(grad_var_name))
+            grad_sub_block.desc.var(cpt.to_bytes(grad_var_name))
             new_vars.add(grad_var_name)
             if grad_var_name not in op_grad_to_var:
                 continue
 
         # infer_shape and infer_type
-        new_op_desc.infer_var_type(parent_block.desc)
-        new_op_desc.infer_shape(parent_block.desc)
-
-        # # set input and output manually
-        # new_op_desc.set_input('Input', param_list)
-        # new_op_desc.set_output('Input@GRAD',
-        #                        [param + "@GRAD" for param in param_list])
+        new_op_desc.infer_var_type(grad_sub_block.desc)
+        new_op_desc.infer_shape(grad_sub_block.desc)
 
         for arg in new_op_desc.output_arg_names():
             if arg in new_vars:
-                _infer_var_data_type_shape_(arg, parent_block)
+                _infer_var_data_type_shape_(arg, grad_sub_block)
 
         self.helper.main_program._sync_with_cpp()
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1922,12 +1922,6 @@ def copy_var_to_parent_block(var, layer_helper):
     assert parent_idx >= 0, "Got wrong parent block index when assigning var to parent scope in control_flow"
     parent_block = prog.block(parent_idx)
 
-    # No need to create parent_block_var if parent block already has the same var.
-    # Return parent block var directly.
-    if parent_block.has_var(var.name):
-        print("var already in parent block: {}".format(var.name))
-        return parent_block.var(var.name)
-
     parent_block_var = parent_block.create_var(
         dtype=var.dtype, shape=var.shape, type=var.type)
     assign(var, parent_block_var)

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -422,11 +422,22 @@ class Optimizer(object):
         # for parameters and extend _finish_update method to add custom ops.
 
         # Allways called under program_guard use global block as loss block
+        # But if current block is in control flow, append optimize op in the
+        # grad block of current block
+
         global_block = framework.default_main_program().global_block()
-        start = len(global_block.ops)
+        target_block = global_block
+        current_block = framework.default_main_program().current_block()
+        if current_block.idx != global_block.idx:
+            assert current_block.backward_block_idx != -1, \
+                "current block is not global_block, but it doesn't have backward block."
+            target_block = framework.default_main_program().blocks[
+                current_block.backward_block_idx]
+
+        start = len(target_block.ops)
         self.helper = LayerHelper(self.__class__.__name__)
         self._create_accumulators(
-            global_block,
+            target_block,
             [p[0] for p in parameters_and_grads if p[0].trainable])
         self._create_global_learning_rate()
 
@@ -438,7 +449,7 @@ class Optimizer(object):
                 with param_and_grad[0].block.program._optimized_guard(
                         param_and_grad):
                     if param_and_grad[0].trainable is True:
-                        optimize_op = self._append_optimize_op(global_block,
+                        optimize_op = self._append_optimize_op(target_block,
                                                                param_and_grad)
                         optimize_ops.append(optimize_op)
         else:
@@ -448,16 +459,16 @@ class Optimizer(object):
                 with param_and_grad[0].block.program._optimized_guard(
                         param_and_grad), name_scope("optimizer"):
                     if param_and_grad[0].trainable is True:
-                        optimize_op = self._append_optimize_op(global_block,
+                        optimize_op = self._append_optimize_op(target_block,
                                                                param_and_grad)
                         optimize_ops.append(optimize_op)
 
         # Get custom finish ops for subclasses
         # FIXME: Need to fix this once we figure out how to handle dependencies
-        self._finish_update(global_block, parameters_and_grads)
+        self._finish_update(target_block, parameters_and_grads)
 
-        end = len(global_block.ops)
-        return global_block._slice_ops(start, end)
+        end = len(target_block.ops)
+        return target_block._slice_ops(start, end)
 
     def _process_distribute_lookuptable(self, param_grads):
         """
@@ -1900,7 +1911,6 @@ class AdamaxOptimizer(Optimizer):
         """Update Beta1 Power accumulator
         """
         assert isinstance(block, framework.Block)
-        main_block = block.program.global_block()
         for param, grad in parameters_and_grads:
             if grad is None or param.trainable is False:
                 continue
@@ -1908,7 +1918,7 @@ class AdamaxOptimizer(Optimizer):
                 [param, grad]), name_scope('adamx'):
                 beta1_pow_acc = self._get_accumulator(self._beta1_pow_acc_str,
                                                       param)
-                main_block.append_op(
+                block.append_op(
                     type="scale",
                     inputs={"X": beta1_pow_acc},
                     outputs={"Out": beta1_pow_acc},

--- a/python/paddle/fluid/tests/unittests/test_case.py
+++ b/python/paddle/fluid/tests/unittests/test_case.py
@@ -238,7 +238,7 @@ class TestMutiTask(unittest.TestCase):
 
         switch_id = fluid.data(name='switch_id', shape=[1], dtype='int32')
 
-        one = layers.fill_constant(shape=[1], dtype='int32', value=0)
+        one = layers.fill_constant(shape=[1], dtype='int32', value=1)
         adam = optimizer.Adam(learning_rate=0.001)
         adagrad = optimizer.Adagrad(learning_rate=0.001)
 

--- a/python/paddle/fluid/tests/unittests/test_case.py
+++ b/python/paddle/fluid/tests/unittests/test_case.py
@@ -22,6 +22,7 @@ import paddle.fluid.core as core
 import paddle.fluid.layers as layers
 from paddle.fluid.framework import Program, program_guard
 from functools import partial
+import paddle.fluid.optimizer as optimizer
 
 
 class TestAPICase(unittest.TestCase):
@@ -221,6 +222,53 @@ class TestAPICase_Error(unittest.TestCase):
                 layers.case(pred_fn_pairs=[(pred_1, fn_1)], default=fn_1())
 
             self.assertRaises(TypeError, type_error_default)
+
+
+# when optimizer in case
+class TestMutiTask(unittest.TestCase):
+    def test_optimizer_in_case(self):
+        BATCH_SIZE = 1
+        INPUT_SIZE = 784
+        EPOCH_NUM = 2
+
+        x = fluid.data(
+            name='x', shape=[BATCH_SIZE, INPUT_SIZE], dtype='float32')
+        y = fluid.data(
+            name='y', shape=[BATCH_SIZE, INPUT_SIZE], dtype='float32')
+
+        switch_id = fluid.data(name='switch_id', shape=[1], dtype='int32')
+
+        one = layers.fill_constant(shape=[1], dtype='int32', value=0)
+        adam = optimizer.Adam(learning_rate=0.001)
+        adagrad = optimizer.Adagrad(learning_rate=0.001)
+
+        def fn_1():
+            sum = layers.elementwise_mul(x, y)
+            loss = layers.mean(sum, name="f_1_loss")
+            adam.minimize(loss)
+
+        def fn_2():
+            sum = layers.elementwise_mul(x, y)
+            loss = layers.mean(sum, name="f_2_loss")
+            adagrad.minimize(loss)
+
+        layers.case(pred_fn_pairs=[(switch_id == one, fn_1)], default=fn_2)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(fluid.default_startup_program())
+
+        for epoch in range(EPOCH_NUM):
+            np.random.seed(epoch)
+            feed_image = np.random.random(
+                size=[BATCH_SIZE, INPUT_SIZE]).astype('float32')
+            main_program = fluid.default_main_program()
+            out = exe.run(main_program,
+                          feed={
+                              'x': feed_image,
+                              'y': feed_image,
+                              'switch_id': np.array([epoch]).astype('int32')
+                          },
+                          fetch_list=[])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import unittest
+
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
+import paddle.fluid.optimizer as optimizer
+
+BATCH_SIZE = 1
+INPUT_SIZE = 784
+
+CLASS_NUM = 10
+FC_SIZE = 40
+EPOCH_NUM = 20
+Switch_ID = 3
+
+
+def random_input(seed,
+                 image_shape=[BATCH_SIZE, INPUT_SIZE],
+                 label_shape=[BATCH_SIZE, 1]):
+    np.random.seed(seed)
+    image_np = np.random.random(size=image_shape).astype('float32')
+    np.random.seed(seed)
+    label_np = np.random.random_integers(
+        low=0, high=CLASS_NUM - 1, size=label_shape).astype('int64')
+    return image_np, label_np
+
+
+def random_param(size, seed=100):
+    np.random.seed(seed)
+    np_param = np.random.random(size=size).astype('float32')
+    return np_param
+
+
+def static():
+    def simple_fc_net(image):
+        hidden = layers.fc(
+            image,
+            size=FC_SIZE,
+            act='relu',
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.99)),
+            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.5)),
+            name="hidden")
+
+        prediction = layers.fc(
+            hidden,
+            size=CLASS_NUM,
+            act='softmax',
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=1.2)),
+            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.8)),
+            name="prediction")
+        return hidden, prediction
+
+    image = fluid.data(
+        name='image', shape=[BATCH_SIZE, INPUT_SIZE], dtype='float32')
+    label = fluid.data(name='label', shape=[BATCH_SIZE, 1], dtype='int64')
+    switch_id = fluid.data(name='switch_id', shape=[1], dtype='int32')
+
+    id = layers.fill_constant(shape=[1], dtype='int32', value=Switch_ID)
+    hidden, prediction = simple_fc_net(image)
+
+    adam = optimizer.Adam(learning_rate=0.001)
+    adagrad = optimizer.Adagrad(learning_rate=0.001)
+
+    def fn_1():
+        cross_entropy_loss = layers.cross_entropy(input=prediction, label=label)
+        mean_cross_entropy_loss = layers.mean(
+            cross_entropy_loss, name="mean_cross_entropy_loss")
+        adam.minimize(mean_cross_entropy_loss)
+        return mean_cross_entropy_loss
+
+    def fn_2():
+        softmax_loss = layers.softmax_with_cross_entropy(
+            logits=prediction, label=label)
+        mean_softmax_loss = layers.mean(softmax_loss, name='mean_softmax_loss')
+        adagrad.minimize(mean_softmax_loss)
+        return mean_softmax_loss
+
+    avg_loss = layers.case([(switch_id == id, fn_2)], fn_1)
+
+    exe = fluid.Executor(fluid.CPUPlace())
+    exe.run(fluid.default_startup_program())
+
+    for epoch in range(EPOCH_NUM):
+        feed_image, feed_label = random_input(epoch)
+        main_program = fluid.default_main_program()
+        out = exe.run(main_program,
+                      feed={
+                          'image': feed_image,
+                          'label': feed_label,
+                          'switch_id': np.array([epoch]).astype('int32')
+                      },
+                      fetch_list=[
+                          hidden,
+                          prediction,
+                          avg_loss,
+                      ])
+        out_hidden, out_prediction, loss = out
+    return out_prediction, loss
+
+
+class MyLayer(fluid.dygraph.Layer):
+    def __init__(self, name_scope):
+        super(MyLayer, self).__init__(name_scope)
+        self.fc0 = fluid.dygraph.nn.FC(
+            self.full_name(),
+            size=FC_SIZE,
+            act='relu',
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.99)),
+            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.5)), )
+
+        self.pre = fluid.dygraph.nn.FC(
+            self.full_name(),
+            size=CLASS_NUM,
+            act='softmax',
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=1.2)),
+            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.8)))
+
+    def forward(self, inputs):
+        h_0 = self.fc0(inputs)
+        prediction = self.pre(h_0)
+        return h_0, prediction
+
+
+def dynamic():
+    with fluid.dygraph.guard():
+        adam = fluid.optimizer.AdamOptimizer(learning_rate=0.001)
+        adagrad = fluid.optimizer.Adagrad(learning_rate=0.001)
+        my_layer = MyLayer("my_layer")
+        for epoch in range(EPOCH_NUM):
+            image_data, label = random_input(epoch)
+            var_input = fluid.dygraph.to_variable(image_data)
+            var_lable = fluid.dygraph.to_variable(label)
+            h_0, prediction = my_layer(var_input)
+
+            if epoch != Switch_ID:
+                cross_entropy_loss = layers.cross_entropy(prediction, var_lable)
+                loss = layers.mean(cross_entropy_loss)
+                loss.backward()
+                adam.minimize(loss)
+            else:
+                softmax_loss = layers.softmax_with_cross_entropy(prediction,
+                                                                 var_lable)
+                loss = layers.mean(softmax_loss)
+                loss.backward()
+                adagrad.minimize(loss)
+
+            my_layer.clear_gradients()
+
+        return prediction.numpy(), loss.numpy()
+
+
+class TestMultiTask(unittest.TestCase):
+    def test_1(self):
+        pre_1, loss_1 = static()
+        pre_2, loss_2 = dynamic()
+        self.assertTrue(np.allclose(pre_1, pre_2))
+        self.assertTrue(np.allclose(loss_1, loss_2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
@@ -177,8 +177,16 @@ class TestMultiTask(unittest.TestCase):
     def test_1(self):
         pre_1, loss_1 = static()
         pre_2, loss_2 = dynamic()
-        self.assertTrue(np.allclose(pre_1, pre_2))
-        self.assertTrue(np.allclose(loss_1, loss_2))
+
+        print('pre_1 is {} \n pre_2 is {}'.format(pre_1, pre_2))
+        print('loss_1 is {} \n loss_2 is {}'.format(loss_1, loss_2))
+
+        self.assertTrue(
+            np.allclose(pre_1, pre_2),
+            msg='pre_1 is {} \n pre_2 is {}'.format(pre_1, pre_2))
+        self.assertTrue(
+            np.allclose(loss_1, loss_2),
+            msg='loss_1 is {} \n loss_2 is {}'.format(loss_1, loss_2))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
@@ -20,14 +20,17 @@ import unittest
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 import paddle.fluid.optimizer as optimizer
+from paddle.fluid.framework import Program, program_guard
 
 BATCH_SIZE = 1
 INPUT_SIZE = 784
 
 CLASS_NUM = 10
 FC_SIZE = 40
-EPOCH_NUM = 20
-Switch_ID = 3
+EPOCH_NUM = 5
+SWITCH_ID = 3
+SEED = 123
+LR = 0.001
 
 
 def random_input(seed,
@@ -53,88 +56,93 @@ def static():
             image,
             size=FC_SIZE,
             act='relu',
-            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-                value=0.99)),
-            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-                value=0.5)),
+            param_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.99)),
+            bias_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.5)),
             name="hidden")
 
         prediction = layers.fc(
             hidden,
             size=CLASS_NUM,
             act='softmax',
-            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-                value=1.2)),
-            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-                value=0.8)),
+            param_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=1.2)),
+            bias_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.8)),
             name="prediction")
         return hidden, prediction
 
-    image = fluid.data(
-        name='image', shape=[BATCH_SIZE, INPUT_SIZE], dtype='float32')
-    label = fluid.data(name='label', shape=[BATCH_SIZE, 1], dtype='int64')
-    switch_id = fluid.data(name='switch_id', shape=[1], dtype='int32')
+    main_program = Program()
+    main_program.random_seed = SEED
+    startup_program = Program()
+    startup_program.random_seed = SEED
+    with program_guard(main_program, startup_program):
+        image = fluid.data(
+            name='image', shape=[BATCH_SIZE, INPUT_SIZE], dtype='float32')
+        label = fluid.data(name='label', shape=[BATCH_SIZE, 1], dtype='int64')
+        id = fluid.data(name='id', shape=[1], dtype='int32')
 
-    id = layers.fill_constant(shape=[1], dtype='int32', value=Switch_ID)
-    hidden, prediction = simple_fc_net(image)
+        two = layers.fill_constant(shape=[1], dtype='int32', value=2)
+        hidden, prediction = simple_fc_net(image)
 
-    adam = optimizer.Adam(learning_rate=0.001)
-    adagrad = optimizer.Adagrad(learning_rate=0.001)
+        adam = optimizer.Adam(learning_rate=LR)
+        adagrad = optimizer.SGD(learning_rate=LR)
 
-    def fn_1():
-        cross_entropy_loss = layers.cross_entropy(input=prediction, label=label)
-        mean_cross_entropy_loss = layers.mean(
-            cross_entropy_loss, name="mean_cross_entropy_loss")
-        adam.minimize(mean_cross_entropy_loss)
-        return mean_cross_entropy_loss
+        def fn_1():
+            cross_entropy_loss = layers.cross_entropy(
+                input=prediction, label=label)
+            mean_cross_entropy_loss = layers.mean(
+                cross_entropy_loss, name="mean_cross_entropy_loss")
+            adam.minimize(mean_cross_entropy_loss)
+            return mean_cross_entropy_loss
 
-    def fn_2():
-        softmax_loss = layers.softmax_with_cross_entropy(
-            logits=prediction, label=label)
-        mean_softmax_loss = layers.mean(softmax_loss, name='mean_softmax_loss')
-        adagrad.minimize(mean_softmax_loss)
-        return mean_softmax_loss
+        def fn_2():
+            softmax_loss = layers.softmax_with_cross_entropy(
+                logits=prediction, label=label)
+            mean_softmax_loss = layers.mean(
+                softmax_loss, name='mean_softmax_loss')
+            adagrad.minimize(mean_softmax_loss)
+            return mean_softmax_loss
 
-    avg_loss = layers.case([(switch_id == id, fn_2)], fn_1)
-    main_program = fluid.default_main_program()
+        cond = layers.elementwise_mod(id, two) == 0
+        avg_loss = layers.case([(cond, fn_2)], fn_1)
 
-    # print(main_program)
-    exe = fluid.Executor(fluid.CPUPlace())
-    exe.run(fluid.default_startup_program())
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(fluid.default_startup_program())
 
-    for epoch in range(EPOCH_NUM):
-        feed_image, feed_label = random_input(epoch)
-        main_program = fluid.default_main_program()
-        out = exe.run(main_program,
-                      feed={
-                          'image': feed_image,
-                          'label': feed_label,
-                          'switch_id': np.array([epoch]).astype('int32')
-                      },
-                      fetch_list=[
-                          hidden,
-                          prediction,
-                          avg_loss,
-                      ])
-        out_hidden, out_prediction, loss = out
-    return out_prediction, loss
+        for epoch in range(EPOCH_NUM):
+            feed_image, feed_label = random_input(epoch)
+            out = exe.run(main_program,
+                          feed={
+                              'image': feed_image,
+                              'label': feed_label,
+                              'id': np.array([epoch]).astype('int32')
+                          },
+                          fetch_list=[
+                              hidden,
+                              prediction,
+                              avg_loss,
+                          ])
+            out_hidden, out_prediction, loss = out
+    return out_hidden, out_prediction, loss
 
 
-class MyLayer(fluid.dygraph.Layer):
-    def __init__(self, name_scope):
-        super(MyLayer, self).__init__(name_scope)
-        self.fc0 = fluid.dygraph.nn.FC(
-            self.full_name(),
-            size=FC_SIZE,
+class DygraphLayer(fluid.dygraph.Layer):
+    def __init__(self):
+        super(DygraphLayer, self).__init__()
+        self.fc0 = fluid.dygraph.nn.Linear(
+            INPUT_SIZE,
+            FC_SIZE,
             act='relu',
             param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
                 value=0.99)),
             bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
                 value=0.5)), )
 
-        self.pre = fluid.dygraph.nn.FC(
-            self.full_name(),
-            size=CLASS_NUM,
+        self.pre = fluid.dygraph.nn.Linear(
+            FC_SIZE,
+            CLASS_NUM,
             act='softmax',
             param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
                 value=1.2)),
@@ -149,46 +157,54 @@ class MyLayer(fluid.dygraph.Layer):
 
 def dynamic():
     with fluid.dygraph.guard():
-        adam = fluid.optimizer.AdamOptimizer(learning_rate=0.001)
-        adagrad = fluid.optimizer.Adagrad(learning_rate=0.001)
-        my_layer = MyLayer("my_layer")
+        fluid.default_startup_program().random_seed = SEED
+        fluid.default_main_program().random_seed = SEED
+        my_layer = DygraphLayer()
+        adam = fluid.optimizer.Adam(
+            learning_rate=LR, parameter_list=my_layer.parameters())
+        adagrad = fluid.optimizer.SGD(learning_rate=LR,
+                                      parameter_list=my_layer.parameters())
+
         for epoch in range(EPOCH_NUM):
             image_data, label = random_input(epoch)
             var_input = fluid.dygraph.to_variable(image_data)
-            var_lable = fluid.dygraph.to_variable(label)
-            h_0, prediction = my_layer(var_input)
+            var_label = fluid.dygraph.to_variable(label)
+            hidden, prediction = my_layer(var_input)
 
-            if epoch != Switch_ID:
-                cross_entropy_loss = layers.cross_entropy(prediction, var_lable)
+            if epoch % 2 != 0:
+                cross_entropy_loss = layers.cross_entropy(prediction, var_label)
                 loss = layers.mean(cross_entropy_loss)
                 loss.backward()
                 adam.minimize(loss)
             else:
                 softmax_loss = layers.softmax_with_cross_entropy(prediction,
-                                                                 var_lable)
+                                                                 var_label)
                 loss = layers.mean(softmax_loss)
                 loss.backward()
                 adagrad.minimize(loss)
 
             my_layer.clear_gradients()
-
-        return prediction.numpy(), loss.numpy()
+        return hidden.numpy(), prediction.numpy(), loss.numpy()
 
 
 class TestMultiTask(unittest.TestCase):
     def test_1(self):
-        pre_1, loss_1 = static()
-        pre_2, loss_2 = dynamic()
+        hidden_1, pre_1, loss_1 = static()
 
-        print('pre_1 is {} \n pre_2 is {}'.format(pre_1, pre_2))
-        print('loss_1 is {} \n loss_2 is {}'.format(loss_1, loss_2))
+        hidden_2, pre_2, loss_2 = dynamic()
 
+        self.assertTrue(
+            np.allclose(hidden_1, hidden_2),
+            msg='static hidden is {} \n dynamic hidden is {}'.format(hidden_1,
+                                                                     hidden_2))
         self.assertTrue(
             np.allclose(pre_1, pre_2),
-            msg='pre_1 is {} \n pre_2 is {}'.format(pre_1, pre_2))
+            msg='static prediction is {} \n dynamic prediction is {}'.format(
+                pre_1, pre_2))
         self.assertTrue(
             np.allclose(loss_1, loss_2),
-            msg='loss_1 is {} \n loss_2 is {}'.format(loss_1, loss_2))
+            msg='static loss is {} \n dynamic loss is {}'.format(loss_1,
+                                                                 loss_2))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
@@ -96,7 +96,9 @@ def static():
         return mean_softmax_loss
 
     avg_loss = layers.case([(switch_id == id, fn_2)], fn_1)
+    main_program = fluid.default_main_program()
 
+    # print(main_program)
     exe = fluid.Executor(fluid.CPUPlace())
     exe.run(fluid.default_startup_program())
 


### PR DESCRIPTION
## Support that `optimizer` is called and loss is created in control flow `switch`.

Example 1:  `loss` and `optimizer` are both in control flow
```
def fn_1():
    loss = layers.mean(cross_entropy_loss)
    adam.minimize(loss)

def fn_2():
    loss = layers.mean(softmax_loss)
    adagrad.minimize(loss)

layers.case([(switch_id==id, fn_2)], fn_1)
```
Example 2:   `optimizer`is in control flow, but `loss` is in parent block
```
loss = layers.mean(cross_entropy_loss)
def fn_1():
    adam.minimize(loss)

def fn_2():
    adagrad.minimize(loss)

layers.case([(switch_id==id, fn_2)], fn_1)
```
### (1) backward network
**Before:**   if loss is in control flow,  the grad ops corresponding to foreward ops in parent block are not appended.
**This PR:**  append all needed grad ops and build a complete backward network.

### (2) optimize ops
**Before:**   if `optimizer` is in control flow,  the optimize ops appended in **global block**
**This PR:**  The optimize ops appended in **sub grad block**
small PR https://github.com/PaddlePaddle/Paddle/pull/21791

### (3) conditional_block_grad
Grad op `conditional_block_grad` can't be appended when calling `optimizer.minimize()`,  manually append `conditional_block_grad` in control flow.
small PR https://github.com/PaddlePaddle/Paddle/pull/21798
...

---
### CE log: click [here](http://ce.paddlepaddle.org:8080/viewLog.html?tab=buildLog&buildTypeId=PaddleModesl_ModelDebug_Model11Build&buildId=74600&_focus=16760)
> model_ocr_recognition failed but model_ocr_recognition is instable and often failed randomly. 

![image](https://user-images.githubusercontent.com/33742067/71469712-fe522d00-2804-11ea-8f13-367ff0b263f3.png)

