### PR TITLE
 fix the unittest of test_check_import_scipy on V100

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_check_import_scipy.py
+++ b/python/paddle/fluid/tests/unittests/test_check_import_scipy.py
@@ -11,22 +11,22 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#import paddle
-#from paddle.importScipy import funcImportScipy
 import six.moves.builtins as builtins
 from paddle.check_import_scipy import check_import_scipy
 import unittest
 
 
 def my_import(name, globals=None, locals=None, fromlist=(), level=0):
-    raise ImportError('DLL load failed,unittest: import scipy  failed')
+    raise ImportError('DLL load failed, unittest: import scipy failed')
 
 
 class importTest(unittest.TestCase):
     def test_import(self):
         testOsName = 'nt'
+        old_import = builtins.__import__
         builtins.__import__ = my_import
         self.assertRaises(ImportError, check_import_scipy, testOsName)
+        builtins.__import__ = old_import
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 fix the unittest of test_check_import_scipy on V100 and  remove useless comments