### PR TITLE
change ci check rule of deleting uni-test

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1152,7 +1152,12 @@ function main() {
         check_style
         ;;
       cicheck)
-        check_approvals_of_unittest 1
+        cmake_gen ${PYTHON_ABI:-""}
+        build ${parallel_number}
+        enable_unused_var_check
+        parallel_test
+        ;;
+      cicheck_coverage)
         cmake_gen ${PYTHON_ABI:-""}
         build ${parallel_number}
         enable_unused_var_check

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -411,6 +411,7 @@ function run_mac_test() {
     ========================================
 EOF
         #remove proxy here to fix dist error on mac
+        my_proxy=$http_proxy
         export http_proxy=
         export https_proxy=
         # make install should also be test when unittest
@@ -442,6 +443,9 @@ EOF
 
         ctest --output-on-failure -j $2
         paddle version
+        # Recovery proxy to avoid failure in later steps
+        export http_proxy=$my_proxy
+        export https_proxy=$my_proxy
     fi
 }
 
@@ -513,6 +517,10 @@ function generate_api_spec() {
 }
 
 function check_approvals_of_unittest() {
+    set +x
+    if [ "$GITHUB_API_TOKEN" == "" ] || [ "$GIT_PR_ID" == "" ]; then
+        return 0
+    fi
     # approval_user_list: XiaoguangHu01 46782768,luotao1 6836917,phlrain 43953930,lanxianghit 47554610, zhouwei25 52485244, kolinwei 22165420
     approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
     check_times=$1
@@ -526,7 +534,9 @@ function check_approvals_of_unittest() {
             exit 0
         fi
     elif [ $1 == 2 ]; then
+        set -x
         unittest_spec_diff=`python ${PADDLE_ROOT}/tools/diff_unittest.py ${PADDLE_ROOT}/paddle/fluid/UNITTEST_DEV.spec ${PADDLE_ROOT}/paddle/fluid/UNITTEST_PR.spec`
+        set +x
         if [ "$unittest_spec_diff" != "" ]; then
             APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 22165420 52485244 6836917`
             echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
@@ -542,18 +552,16 @@ function check_approvals_of_unittest() {
             fi
         fi
     fi
+    set -x
 }
 
 function check_change_of_unittest() {
-    set +x
     generate_unittest_spec "PR"
     fetch_upstream_develop_if_not_exist
-    git fetch upstream
     git reset --hard upstream/$BRANCH
     cmake_gen $1
     generate_unittest_spec "DEV"
     check_approvals_of_unittest 2
-    set +x
 }
 
 function generate_unittest_spec() {
@@ -1158,6 +1166,7 @@ function main() {
         parallel_test
         ;;
       cicheck_coverage)
+        check_approvals_of_unittest 1
         cmake_gen ${PYTHON_ABI:-""}
         build ${parallel_number}
         enable_unused_var_check

--- a/tools/diff_unittest.py
+++ b/tools/diff_unittest.py
@@ -18,12 +18,12 @@ diffs = []
 for each_diff in result:
     if each_diff[0] == '-':  # delete unit test is not allowed
         error = True
-        diffs.append(each_diff[2])
+        diffs.append(each_diff)
 '''
 If you delete the unit test, such as commenting it out, 
 please ask for approval of one RD below for passing CI:
 
-    - XiaoguangHu01 or luotao1 or phlrain or lanxianghit or zhouwei25
+    - kolinwei(recommended) or zhouwei25 or luotao1
 '''
 if error:
     for each_diff in diffs:


### PR DESCRIPTION
Change ci check rule of deleting uni-test.

- The **ci_check_coverage** should be separated **with ci_check**.

- Maccheck should add http_proxy to get **approval_line** from github.com.