### PR TITLE
fix elementwise broadcast bug

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_add_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.h
@@ -25,7 +25,9 @@ void default_elementwise_add(const framework::ExecutionContext &ctx,
                              const framework::Tensor *x,
                              const framework::Tensor *y, framework::Tensor *z) {
   int axis = ctx.Attr<int>("axis");
-  if (x->numel() >= y->numel()) {
+  auto x_dims = x->dims();
+  auto y_dims = y->dims();
+  if (x_dims.size() >= y_dims.size()) {
     ElementwiseComputeEx<AddFunctor<T>, DeviceContext, T>(ctx, x, y, axis,
                                                           AddFunctor<T>(), z);
   } else {

--- a/paddle/fluid/operators/elementwise/elementwise_div_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op.h
@@ -31,7 +31,9 @@ void default_elementwise_div(const framework::ExecutionContext& ctx,
                              const framework::Tensor* x,
                              const framework::Tensor* y, framework::Tensor* z) {
   int axis = ctx.Attr<int>("axis");
-  if (x->numel() >= y->numel()) {
+  auto x_dims = x->dims();
+  auto y_dims = y->dims();
+  if (x_dims.size() >= y_dims.size()) {
     ElementwiseComputeEx<DivFunctor<T>, DeviceContext, T>(ctx, x, y, axis,
                                                           DivFunctor<T>(), z);
   } else {

--- a/paddle/fluid/operators/elementwise/elementwise_mul_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_mul_op.h
@@ -71,7 +71,9 @@ void default_elementwise_mul(const framework::ExecutionContext& ctx,
                              const framework::Tensor* x,
                              const framework::Tensor* y, framework::Tensor* z) {
   int axis = ctx.Attr<int>("axis");
-  if (x->numel() >= y->numel()) {
+  auto x_dims = x->dims();
+  auto y_dims = y->dims();
+  if (x_dims.size() >= y_dims.size()) {
     ElementwiseComputeEx<MulFunctor<T>, DeviceContext, T>(ctx, x, y, axis,
                                                           MulFunctor<T>(), z);
   } else {
@@ -118,7 +120,8 @@ class ElementwiseMulKernel : public framework::OpKernel<T> {
     }
 
     z->mutable_data<T>(ctx.GetPlace());
-    if (x.numel() == y->numel()) {
+    auto dims_equal = x.dims() == y->dims();
+    if (dims_equal) {
       SameDimsElemwiseMul<DeviceContext, T> same_dims_mul;
       same_dims_mul(ctx, &x, y, z);
     } else {

--- a/paddle/fluid/operators/elementwise/elementwise_sub_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_sub_op.h
@@ -26,7 +26,9 @@ void default_elementwise_sub(const framework::ExecutionContext& ctx,
                              const framework::Tensor* x,
                              const framework::Tensor* y, framework::Tensor* z) {
   int axis = ctx.Attr<int>("axis");
-  if (x->numel() >= y->numel()) {
+  auto x_dims = x->dims();
+  auto y_dims = y->dims();
+  if (x_dims.size() >= y_dims.size()) {
     ElementwiseComputeEx<SubFunctor<T>, DeviceContext, T>(ctx, x, y, axis,
                                                           SubFunctor<T>(), z);
   } else {


### PR DESCRIPTION
1. fix bug when x and y need do broadcast but do same-dimension function during x.numel() == y.numel() in elementwise_mul.
2. fig bug in elementwise_add/sub/mul/div default_elementwise_x function:change numel into size.