### PR TITLE
fix cp directory bug of warpctc

### DIFF
--- a/cmake/external/warpctc.cmake
+++ b/cmake/external/warpctc.cmake
@@ -41,7 +41,7 @@ if(WIN32)
     file(TO_NATIVE_PATH ${WARPCTC_SOURCE_DIR} native_dst)
     set(WARPCTC_PATCH_COMMAND xcopy ${native_src} ${native_dst} /E/Y)
 else()
-    set(WARPCTC_PATCH_COMMAND cp -r ${PADDLE_SOURCE_DIR}/patches/warpctc/ ${WARPCTC_SOURCE_DIR})
+    set(WARPCTC_PATCH_COMMAND cp -r ${PADDLE_SOURCE_DIR}/patches/warpctc/. ${WARPCTC_SOURCE_DIR})
 endif()
 
 ExternalProject_Add(


### PR DESCRIPTION
fix cp directory bug of warpctc.

**It result:** 

![1bb4f369326306aba7d9dcd73ea4cee0](https://user-images.githubusercontent.com/52485244/71367845-2d885480-25e1-11ea-988a-c718be9d2605.png)

**After this PR:**
![image](https://user-images.githubusercontent.com/52485244/71392013-7d970380-2641-11ea-8cf7-4c1fb348389e.png)
