### PR TITLE
Fix openblas bug to support compile on windows when WITH_MKL=OFF

### DIFF
--- a/cmake/external/openblas.cmake
+++ b/cmake/external/openblas.cmake
@@ -68,10 +68,12 @@ ELSE(NOT WIN32)
                             -DCMAKE_INSTALL_PREFIX=${CBLAS_INSTALL_DIR}
                             -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                             -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
+                            -DBUILD_SHARED_LIBS=ON
                             -DMSVC_STATIC_CRT=${MSVC_STATIC_CRT}
                             ${EXTERNAL_OPTIONAL_ARGS}
         CMAKE_CACHE_ARGS    -DCMAKE_INSTALL_PREFIX:PATH=${CBLAS_INSTALL_DIR}
                             -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
                             -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}
         )
+    SET(OPENBLAS_SHARED_LIB  ${CBLAS_INSTALL_DIR}/bin/openblas${CMAKE_SHARED_LIBRARY_SUFFIX})
 ENDIF(NOT WIN32)

--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -71,9 +71,15 @@ function(copy_part_of_thrid_party TARGET DST)
         endif()
     elseif(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
         set(dst_dir "${DST}/third_party/install/openblas")
+	if(WIN32)
+            copy(${TARGET}
+                    SRCS ${CBLAS_INSTALL_DIR}/lib ${OPENBLAS_SHARED_LIB} ${CBLAS_INSTALL_DIR}/include
+                    DSTS ${dst_dir} ${dst_dir}/lib ${dst_dir})
+	else()
             copy(${TARGET}
                     SRCS ${CBLAS_INSTALL_DIR}/lib ${CBLAS_INSTALL_DIR}/include
                     DSTS ${dst_dir} ${dst_dir})
+	endif()
     endif()
 
     if(WITH_MKLDNN)

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -34,7 +34,6 @@ if (WITH_DISTRIBUTE)
 endif()
 
 if(WITH_PYTHON)
-
   # generate op pybind functions automatically for dygraph.
   set(OP_FUNCTION_GENERETOR_DEPS pybind proto_desc executor layer tracer engine imperative_profiler imperative_flag)
   list(APPEND OP_FUNCTION_GENERETOR_DEPS ${GLOB_OP_LIB})
@@ -45,32 +44,31 @@ if(WITH_PYTHON)
   endif(NOT WIN32)
 
   add_executable(op_function_generator op_function_generator.cc)
-  target_link_libraries(op_function_generator ${OP_FUNCTION_GENERETOR_DEPS} )
+  target_link_libraries(op_function_generator ${OP_FUNCTION_GENERETOR_DEPS})
   get_property (os_dependency_modules GLOBAL PROPERTY OS_DEPENDENCY_MODULES)
   target_link_libraries(op_function_generator ${os_dependency_modules})
 
-  if (WIN32)
+  if(WIN32)
     add_custom_target(op_function_cmd 
       COMMAND "${CMAKE_BINARY_DIR}/paddle/fluid/pybind/${CMAKE_BUILD_TYPE}/op_function_generator" 
-      "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
+              "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
     add_dependencies(op_function_cmd op_function_generator)
-    if(WITH_MKL)
-      add_custom_target(copy_mkl 
+    if(${CBLAS_PROVIDER} STREQUAL MKLML)
+      add_custom_command(TARGET op_function_generator POST_BUILD
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-            )
-    else()
-      message("${CMAKE_COMMAND} -E copy ${OPENBLAS_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
-      add_custom_target(copy_mkl 
+          )
+    else(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
+      add_custom_command(TARGET op_function_generator POST_BUILD 
             COMMAND ${CMAKE_COMMAND} -E copy ${OPENBLAS_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-      )
-    endif(WITH_MKL)
+          )
+    endif()
     if(WITH_MKLDNN)
-      add_custom_target(copy_mkldnn
+      add_custom_command(TARGET op_function_generator POST_BUILD 
           COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
           )
-    endif(WITH_MKLDNN)
+    endif()
   else(WIN32)
     # If there are no *.so in /usr/lib or LD_LIBRARY_PATH, 
     # copy these *.so to current directory and append current directory to
@@ -78,30 +76,21 @@ if(WITH_PYTHON)
     # *.dll in current directory automatically.
     add_custom_target(op_function_cmd 
       COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:."
-      "${CMAKE_CURRENT_BINARY_DIR}/op_function_generator"
-      "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
+              "${CMAKE_CURRENT_BINARY_DIR}/op_function_generator"
+              "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
     add_dependencies(op_function_cmd op_function_generator)
     if(WITH_MKL)
-      add_custom_target(copy_mkl
+      add_custom_command(TARGET op_function_generator POST_BUILD 
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
             )
     endif(WITH_MKL)
     if(WITH_MKLDNN)
-      add_custom_target(copy_mkldnn
+      add_custom_command(TARGET op_function_generator POST_BUILD 
           COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
           )
     endif(WITH_MKLDNN)
   endif(WIN32)
-
-  add_dependencies(copy_mkl op_function_generator)
-  add_dependencies(op_function_cmd copy_mkl)
-
-  if(WITH_MKLDNN)
-    add_dependencies(copy_mkldnn op_function_generator)
-    add_dependencies(op_function_cmd copy_mkldnn)  
-  endif(WITH_MKLDNN)
-
 
   if(WITH_AMD_GPU)
     hip_library(paddle_pybind SHARED
@@ -120,6 +109,5 @@ if(WITH_PYTHON)
 
   get_property (os_dependency_modules GLOBAL PROPERTY OS_DEPENDENCY_MODULES)
   target_link_libraries(paddle_pybind ${os_dependency_modules})
-  add_dependencies(paddle_pybind op_function_cmd) 
-
+  add_dependencies(paddle_pybind op_function_cmd)
 endif(WITH_PYTHON)

--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -53,13 +53,18 @@ if(WITH_PYTHON)
     add_custom_target(op_function_cmd 
       COMMAND "${CMAKE_BINARY_DIR}/paddle/fluid/pybind/${CMAKE_BUILD_TYPE}/op_function_generator" 
       "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
-      add_dependencies(op_function_cmd op_function_generator)
+    add_dependencies(op_function_cmd op_function_generator)
     if(WITH_MKL)
-    add_custom_target(copy_mkl 
-          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
-          )
+      add_custom_target(copy_mkl 
+            COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+            COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB_DEPS} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+            COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+            )
+    else()
+      message("${CMAKE_COMMAND} -E copy ${OPENBLAS_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}")
+      add_custom_target(copy_mkl 
+            COMMAND ${CMAKE_COMMAND} -E copy ${OPENBLAS_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
+      )
     endif(WITH_MKL)
     if(WITH_MKLDNN)
       add_custom_target(copy_mkldnn
@@ -75,12 +80,12 @@ if(WITH_PYTHON)
       COMMAND ${CMAKE_COMMAND} -E env "LD_LIBRARY_PATH=$ENV{LD_LIBRARY_PATH}:."
       "${CMAKE_CURRENT_BINARY_DIR}/op_function_generator"
       "${CMAKE_SOURCE_DIR}/paddle/fluid/pybind/op_function_impl.h") 
-      add_dependencies(op_function_cmd op_function_generator)
+    add_dependencies(op_function_cmd op_function_generator)
     if(WITH_MKL)
-    add_custom_target(copy_mkl
-          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
-          COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
-          )
+      add_custom_target(copy_mkl
+            COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
+            )
     endif(WITH_MKL)
     if(WITH_MKLDNN)
       add_custom_target(copy_mkldnn
@@ -89,14 +94,12 @@ if(WITH_PYTHON)
     endif(WITH_MKLDNN)
   endif(WIN32)
 
-  if(WITH_MKL)
   add_dependencies(copy_mkl op_function_generator)
   add_dependencies(op_function_cmd copy_mkl)
-  endif(WITH_MKL)
 
   if(WITH_MKLDNN)
-  add_dependencies(copy_mkldnn op_function_generator)
-  add_dependencies(op_function_cmd copy_mkldnn)  
+    add_dependencies(copy_mkldnn op_function_generator)
+    add_dependencies(op_function_cmd copy_mkldnn)  
   endif(WITH_MKLDNN)
 
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -190,7 +190,7 @@ if '${WITH_MKL}' == 'ON':
 else:
     if os.name == 'nt':
         # copy the openblas.dll
-        shutil.copy(os.path.dirname('${CBLAS_LIBRARIES}') + '/openblas' + ext_name, libs_path)
+        shutil.copy('${OPENBLAS_SHARED_LIB}', libs_path)
         package_data['paddle.libs'] += ['openblas' + ext_name]
 
 if '${WITH_PSLIB}' == 'ON':


### PR DESCRIPTION
Fix openblas bug to support compile on windows, now it will cause error when compile on windows **-DWITH_MKL=OFF**:

The new target **op_function_cmd** shoulde add the case of  openblas, otherwise it can't be compiled when **WITH_MKL=OFF** ：
![F165F6961DEA5564864E74119005BD19](https://user-images.githubusercontent.com/52485244/71368159-15650500-25e2-11ea-9cd2-da72c5eaeed4.png)

**shutil.copy(os.path.dirname('${CBLAS_LIBRARIES}') + '/openblas' + ext_name, libs_path)**  will have this problem:
![BaiduHi_2019-12-26_10-40-58](https://user-images.githubusercontent.com/52485244/71454601-7b14e500-27cc-11ea-9b66-8439020481b9.png)

After this PR, **PR_Windows_CI_OPENBLAS** will start to check Openblas on windows every night, so that error can be detected earlily.