### PR TITLE
optimize the sum calculation of multiple inputs

### DIFF
--- a/paddle/fluid/operators/sum_op.h
+++ b/paddle/fluid/operators/sum_op.h
@@ -130,13 +130,13 @@ class SumKernel : public framework::OpKernel<T> {
       auto *out = out_var->GetMutable<framework::LoDTensor>();
       auto *out_ptr = out->mutable_data<T>(context.GetPlace());
 
-      std::vector<T *> tensor;
+      std::vector<const T *> tensor;
       std::vector<size_t> select_row;
       for (size_t i = 0; i < in_num; i++) {
         if (in_vars[i]->IsType<framework::LoDTensor>()) {
-          auto in_tensor = in_vars[i]->Get<framework::LoDTensor>();
+          const auto &in_tensor = in_vars[i]->Get<framework::LoDTensor>();
           if (in_tensor.numel()) {
-            auto in_data = in_tensor.data<T>();
+            const T *in_data = in_tensor.data<T>();
             tensor.push_back(in_data);
             item_size = in_tensor.numel();
           }
@@ -150,7 +150,7 @@ class SumKernel : public framework::OpKernel<T> {
         for (size_t i = 0; i < item_size; ++i) {
           T result_temp = tensor[0][i];
           for (size_t j = 1; j < tensor.size(); ++j) {
-            auto in0_ptr = tensor[j];
+            auto *in0_ptr = tensor[j];
             result_temp = result_temp + in0_ptr[i];
           }
           out_ptr[i] = result_temp;

--- a/paddle/fluid/operators/sum_op.h
+++ b/paddle/fluid/operators/sum_op.h
@@ -132,8 +132,6 @@ class SumKernel : public framework::OpKernel<T> {
 
       std::vector<T *> tensor;
       std::vector<size_t> select_row;
-      tensor.clear();
-      select_row.clear();
       for (size_t i = 0; i < in_num; i++) {
         if (in_vars[i]->IsType<framework::LoDTensor>()) {
           auto in_tensor = in_vars[i]->Get<framework::LoDTensor>();

--- a/paddle/fluid/operators/sum_op.h
+++ b/paddle/fluid/operators/sum_op.h
@@ -125,25 +125,31 @@ class SumKernel : public framework::OpKernel<T> {
     size_t in_num = in_vars.size();
     auto out_var = context.OutputVar("Out");
 
+    bool in_place = out_var == in_vars[0];
     size_t item_size = 0;
     if (out_var->IsType<framework::LoDTensor>()) {
       auto *out = out_var->GetMutable<framework::LoDTensor>();
       auto *out_ptr = out->mutable_data<T>(context.GetPlace());
       if (in_num >= 1 && in_vars[0]->IsType<framework::LoDTensor>()) {
         auto &in_0_tensor = in_vars[0]->Get<framework::LoDTensor>();
-        item_size = in_0_tensor.numel();
+        if (in_0_tensor.numel() > 0) {
+          in_place = (in_0_tensor.data<T>() == out_ptr);
+          item_size = in_0_tensor.numel();
+        }
       }
 
       std::vector<T *> tensor;
       std::vector<size_t> select_row;
       tensor.clear();
       select_row.clear();
-      for (size_t i = 0; i < in_num; i++) {
+      size_t start = in_place ? 1 : 0;
+      for (size_t i = start; i < in_num; i++) {
         if (in_vars[i]->IsType<framework::LoDTensor>()) {
           auto in_tensor = in_vars[i]->Get<framework::LoDTensor>();
           if (in_tensor.numel()) {
             auto in_data = in_tensor.data<T>();
             tensor.push_back(in_data);
+            item_size = in_tensor.numel();
           }
         } else if (in_vars[i]->IsType<framework::SelectedRows>()) {
           select_row.push_back(i);
@@ -151,7 +157,6 @@ class SumKernel : public framework::OpKernel<T> {
           PADDLE_THROW("Variable type must be LoDTensor/SelectedRows.");
         }
       }
-
       if (tensor.size()) {
         for (size_t i = 0; i < item_size; ++i) {
           T result_temp = 0;
@@ -159,9 +164,9 @@ class SumKernel : public framework::OpKernel<T> {
             auto in0_ptr = tensor[j];
             result_temp = result_temp + in0_ptr[i];
           }
-          out_ptr[i] = result_temp;
+          out_ptr[i] = in_place ? out_ptr[i] + result_temp : result_temp;
         }
-      } else if (!tensor.size()) {
+      } else if (!in_place) {
         math::SetConstant<DeviceContext, T> constant_functor;
         constant_functor(context.template device_context<DeviceContext>(), out,
                          static_cast<T>(0));


### PR DESCRIPTION
CPU SKX 6148型号：
优化前计算方式：
![eedb2262c0e783c9c7de3b0e6d80c327](https://user-images.githubusercontent.com/53294385/72578072-e6576000-390f-11ea-8366-8301c185c4f9.png)

优化后计算方式：
![4d61dcd479aa427de81630e462901383](https://user-images.githubusercontent.com/53294385/72579046-dee58600-3912-11ea-966c-989f1a5fb211.png)


3个Tensor尺寸[1280, 2560], 3次sum op调用。
优化前:  33.1969 ms, 优化后:  26.3337ms, 提升 20.67%
- 优化前
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by  in descending order in the same thread

Event                                               Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant                              3           190.968     190.968050 (1.000000)   0.000000 (0.000000)     2.81928     185.274     63.656      0.825612
thread0::sum                                        3           33.1969     33.196943 (1.000000)    0.000000 (0.000000)     11.0564     11.0796     11.0656     0.14352
thread0::fetch                                      1           7.13995     7.139947 (1.000000)     0.000000 (0.000000)     7.13995     7.13995     7.13995     0.0308681
```
- 优化后

```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Event                     Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant    3           173.255     173.254770 (1.000000)   0.000000 (0.000000)     2.7889      167.637     57.7516     0.839231
thread0::sum              3           26.3337     26.333724 (1.000000)    0.000000 (0.000000)     8.76836     8.7875      8.77791     0.127558
thread0::fetch            1           6.85611     6.856106 (1.000000)     0.000000 (0.000000)     6.85611     6.85611     6.85611     0.0332104
```

4个Tensor尺寸[1280, 2560], 4次sum op调用。
优化前: 62.8654 ms, 优化后:  43.336761 ms, 提升 31.06%
- 优化前
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by  in descending order in the same thread

Event                                               Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant                              3           190.968     190.968050 (1.000000)   0.000000 (0.000000)     2.81928     185.274     63.656      0.825612
thread0::sum                                        3           33.1969     33.196943 (1.000000)    0.000000 (0.000000)     11.0564     11.0796     11.0656     0.14352
thread0::fetch                                      1           7.13995     7.139947 (1.000000)     0.000000 (0.000000)     7.13995     7.13995     7.13995     0.0308681
```
- 优化后
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Event                     Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant    4           183.522     183.522086 (1.000000)   0.000000 (0.000000)     2.77571     175.089     45.8805     0.785169
thread0::sum              4           43.3368     43.336761 (1.000000)    0.000000 (0.000000)     10.7804     10.9012     10.8342     0.185409
thread0::fetch            1           6.87684     6.876843 (1.000000)     0.000000 (0.000000)     6.87684     6.87684     6.87684     0.0294215
```