### PR TITLE
add decorator skip_check_grad_ci for test_group_norm test=develop

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -19,7 +19,7 @@ import numpy as np
 from operator import mul
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 
 from testsuite import create_op
 
@@ -151,6 +151,8 @@ class TestGroupNormOpBigEps3(TestGroupNormOp):
         self.attrs['epsilon'] = 0.5
 
 
+@skip_check_grad_ci(
+    reason="compare grads between CPU and GPU, check_grad is not required.")
 class TestGroupNormOpLargeData(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 32, 64, 64)
@@ -190,6 +192,8 @@ class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
         self.data_format = "NHWC"
 
 
+@skip_check_grad_ci(
+    reason="compare grads between CPU and GPU, check_grad is not required.")
 class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 64, 32, 32)  # NCHW


### PR DESCRIPTION
In test_group_norm, the TestGroupNormOpLargeData and TestGroupNormOpLargeData_With_NHWC two test cases just to compare grads between CPU and GPU, the check_grad is not required