### PR TITLE
add decorator skip_check_grad_ci for test_group_norm 

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -152,7 +152,8 @@ class TestGroupNormOpBigEps3(TestGroupNormOp):
 
 
 @skip_check_grad_ci(
-    reason="Compare grads between CPU and GPU, check_grad is not required.")
+    reason="This test case is to compare whether the grads computation results between CPU and GPU are consistent in the same inputs, check_grad is not required."
+)
 class TestGroupNormOpLargeData(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 32, 64, 64)
@@ -193,7 +194,8 @@ class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
 
 
 @skip_check_grad_ci(
-    reason="Compare grads between CPU and GPU, check_grad is not required.")
+    reason="This test case is to compare whether the grads computation results between CPU and GPU are consistent in the same inputs, check_grad is not required."
+)
 class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 64, 32, 32)  # NCHW

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -19,7 +19,7 @@ import numpy as np
 from operator import mul
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 
 from testsuite import create_op
 
@@ -151,6 +151,8 @@ class TestGroupNormOpBigEps3(TestGroupNormOp):
         self.attrs['epsilon'] = 0.5
 
 
+@skip_check_grad_ci(
+    reason="Compare grads between CPU and GPU, check_grad is not required.")
 class TestGroupNormOpLargeData(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 32, 64, 64)
@@ -190,6 +192,8 @@ class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
         self.data_format = "NHWC"
 
 
+@skip_check_grad_ci(
+    reason="Compare grads between CPU and GPU, check_grad is not required.")
 class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 64, 32, 32)  # NCHW

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -152,8 +152,8 @@ class TestGroupNormOpBigEps3(TestGroupNormOp):
 
 
 @skip_check_grad_ci(
-    reason='''This test case is to compare whether the grads computation results between CPU and GPU  
-            are consistent when using the same inputs, check_grad is not required.'''
+    reason='''This test case is used to ensure whether the gradient checking results between CPU and GPU  
+            are consistent when using the same inputs, thus, it doesn't need to call check_grad.'''
 )
 class TestGroupNormOpLargeData(TestGroupNormOp):
     def init_test_case(self):
@@ -195,8 +195,8 @@ class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
 
 
 @skip_check_grad_ci(
-    reason='''This test case is to compare whether the grads computation results between CPU and GPU
-            are consistent when using the same inputs, check_grad is not required.'''
+    reason='''This test case is used to ensure whether the gradient checking results between CPU and GPU  
+            are consistent when using the same inputs, thus, it doesn't need to call check_grad.'''
 )
 class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -152,8 +152,8 @@ class TestGroupNormOpBigEps3(TestGroupNormOp):
 
 
 @skip_check_grad_ci(
-    reason="This test case is to compare whether the grads computation results between CPU and GPU are consistent in the same inputs, check_grad is not required."
-)
+    reason='''This test case is to compare whether the grads computation results between CPU and GPU  
+            are consistent in the same inputs, check_grad is not required.''')
 class TestGroupNormOpLargeData(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 32, 64, 64)
@@ -194,8 +194,8 @@ class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
 
 
 @skip_check_grad_ci(
-    reason="This test case is to compare whether the grads computation results between CPU and GPU are consistent in the same inputs, check_grad is not required."
-)
+    reason='''This test case is to compare whether the grads computation results between CPU and GPU
+            are consistent in the same inputs, check_grad is not required.''')
 class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 64, 32, 32)  # NCHW

--- a/python/paddle/fluid/tests/unittests/test_group_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op.py
@@ -153,7 +153,8 @@ class TestGroupNormOpBigEps3(TestGroupNormOp):
 
 @skip_check_grad_ci(
     reason='''This test case is to compare whether the grads computation results between CPU and GPU  
-            are consistent in the same inputs, check_grad is not required.''')
+            are consistent when using the same inputs, check_grad is not required.'''
+)
 class TestGroupNormOpLargeData(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 32, 64, 64)
@@ -195,7 +196,8 @@ class TestGroupNormOpBigEps3_With_NHWC(TestGroupNormOp):
 
 @skip_check_grad_ci(
     reason='''This test case is to compare whether the grads computation results between CPU and GPU
-            are consistent in the same inputs, check_grad is not required.''')
+            are consistent when using the same inputs, check_grad is not required.'''
+)
 class TestGroupNormOpLargeData_With_NHWC(TestGroupNormOp):
     def init_test_case(self):
         self.shape = (2, 64, 32, 32)  # NCHW


### PR DESCRIPTION
In test_group_norm, the TestGroupNormOpLargeData and TestGroupNormOpLargeData_With_NHWC two test cases just to compare grads between CPU and GPU, the check_grad is not required.