### PR TITLE
Fix multi-threads memory out of bounds error for passes

### DIFF
--- a/paddle/fluid/framework/ir/attention_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/attention_lstm_fuse_pass.cc
@@ -41,7 +41,7 @@ struct Param {
   std::string LSTMOUT = "at.lstmout.new";
 };
 
-void PrepareParameters(Graph* graph, const Param& param);
+void PrepareParameters(Graph* graph, const Param& param, ir::Node* lstm_op);
 
 void FindWhileOp(Graph* graph) {
   GraphPatternDetector gpd;
@@ -133,12 +133,14 @@ void PrepareLSTMBias(const LoDTensor& B_forget, const LoDTensor& B_input,
                      const LoDTensor& B_output, const LoDTensor& B_cell,
                      LoDTensor* out);
 
-void PrepareOutVars(Graph* graph, std::string name, ir::Node* lstm_op) {
+namespace {
+void PrepareOutVars(Graph* graph, const std::string name, ir::Node* op) {
   VarDesc key(name);
   key.SetPersistable(false);
   auto* key_node = graph->CreateVarNode(&key);
-  IR_NODE_LINK_TO(lstm_op, key_node);
+  IR_NODE_LINK_TO(op, key_node);
 }
+}  // namespace
 
 void PrepareParameters(Graph* graph, const Param& param, ir::Node* lstm_op) {
   // Check parameters

--- a/paddle/fluid/framework/ir/attention_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/attention_lstm_fuse_pass.cc
@@ -139,8 +139,8 @@ void PrepareParameters(Graph* graph, const Param& param) {
   auto& scope = graph->Get<Scope>(kParamScopeAttr);
 
   // Create new parameters.
-  scope.Var(param.LSTMWeight)->GetMutable<LoDTensor>();
-  scope.Var(param.LSTMBias)->GetMutable<LoDTensor>();
+  scope.Var(param.LSTMWeight)->GetMutable<LoDTensor>();  // input
+  scope.Var(param.LSTMBias)->GetMutable<LoDTensor>();    // input
   scope.Var(param.Hidden)->GetMutable<LoDTensor>();
   scope.Var(param.Cell)->GetMutable<LoDTensor>();
   scope.Var(param.AttentionedX)->GetMutable<LoDTensor>();

--- a/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
@@ -27,7 +27,7 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
-void PrepareOutVars(Graph* graph, std::string name, ir::Node* op) {
+void PrepareOutVars(Graph* graph, const std::string name, ir::Node* op) {
   VarDesc key(name);
   key.SetPersistable(false);
   auto* key_node = graph->CreateVarNode(&key);
@@ -165,7 +165,7 @@ static int BuildFusion(Graph* graph, const std::string& name_scope,
 #define OP_SET_OUT(x)                            \
   const std::string x = patterns::UniqueKey(#x); \
   op_desc.SetOutput(#x, {x});                    \
-  PrepareOutVars(graph, #x, op);
+  PrepareOutVars(graph, #x, op)
     OP_SET_OUT(BatchedCell);
     OP_SET_OUT(BatchedHidden);
     OP_SET_OUT(ReorderedH0);

--- a/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
@@ -153,9 +153,6 @@ static int BuildFusion(Graph* graph, const std::string& name_scope,
     // TODO(TJ): get from attr
     op_desc.SetAttr("use_seq", true);
 
-    PADDLE_ENFORCE(graph->Has(kParamScopeAttr));
-    auto& scope = graph->Get<Scope>(kParamScopeAttr);
-
     auto* op = graph->CreateOpNode(&op_desc);
 
     PrepareOutVars(graph, BatchedInput, op);

--- a/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
@@ -27,12 +27,14 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+namespace {
 void PrepareOutVars(Graph* graph, const std::string name, ir::Node* op) {
   VarDesc key(name);
   key.SetPersistable(false);
   auto* key_node = graph->CreateVarNode(&key);
   IR_NODE_LINK_TO(op, key_node);
 }
+}  // namespace
 
 static int BuildFusion(Graph* graph, const std::string& name_scope,
                        Scope* scope, bool with_fc_bias) {

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
@@ -21,6 +21,13 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+void PrepareOutVars(Graph* graph, const std::string name, ir::Node* op) {
+  VarDesc key(name);
+  key.SetPersistable(false);
+  auto* key_node = graph->CreateVarNode(&key);
+  IR_NODE_LINK_TO(op, key_node);
+}
+
 int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
                 bool with_fc_bias) {
   GraphPatternDetector gpd;
@@ -81,11 +88,6 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
     const std::string BatchedGate = patterns::UniqueKey("BatchedGate");
     const std::string CheckedCell = patterns::UniqueKey("CheckedCell");
 
-    scope->Var(BatchedInput)->GetMutable<framework::LoDTensor>();
-    scope->Var(BatchedCellPreAct)->GetMutable<framework::LoDTensor>();
-    scope->Var(BatchedGate)->GetMutable<framework::LoDTensor>();
-    scope->Var(CheckedCell)->GetMutable<framework::LoDTensor>();
-
     op_desc.SetInput("H0", {});
     op_desc.SetInput("C0", {});
     op_desc.SetOutput("Hidden", {hidden->Name()});
@@ -102,17 +104,23 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
 
     PADDLE_ENFORCE(graph->Has(kParamScopeAttr));
     auto& scope = graph->Get<Scope>(kParamScopeAttr);
+    auto* op = graph->CreateOpNode(&op_desc);
+
+    PrepareOutVars(graph, BatchedInput, op);
+    PrepareOutVars(graph, BatchedCellPreAct, op);
+    PrepareOutVars(graph, BatchedGate, op);
+    PrepareOutVars(graph, CheckedCell, op);
+
 #define OP_SET_OUT(x)                            \
   const std::string x = patterns::UniqueKey(#x); \
   op_desc.SetOutput(#x, {x});                    \
-  scope.Var(x)->GetMutable<LoDTensor>()
+  PrepareOutVars(graph, #x, op)
     OP_SET_OUT(BatchedCell);
     OP_SET_OUT(BatchedHidden);
     OP_SET_OUT(ReorderedH0);
     OP_SET_OUT(ReorderedC0);
 #undef OP_SET_OUT
 
-    auto* op = graph->CreateOpNode(&op_desc);
     IR_NODE_LINK_TO(input, op);
     IR_NODE_LINK_TO(weight_x, op);
     IR_NODE_LINK_TO(weight_h, op);

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
@@ -102,8 +102,6 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
     // TODO(TJ): get from attr
     op_desc.SetAttr("use_seq", true);
 
-    PADDLE_ENFORCE(graph->Has(kParamScopeAttr));
-    auto& scope = graph->Get<Scope>(kParamScopeAttr);
     auto* op = graph->CreateOpNode(&op_desc);
 
     PrepareOutVars(graph, BatchedInput, op);

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
@@ -21,15 +21,6 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
-namespace {
-void PrepareOutVars(Graph* graph, const std::string name, ir::Node* op) {
-  VarDesc key(name);
-  key.SetPersistable(false);
-  auto* key_node = graph->CreateVarNode(&key);
-  IR_NODE_LINK_TO(op, key_node);
-}
-}  // namespace
-
 int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
                 bool with_fc_bias) {
   GraphPatternDetector gpd;
@@ -83,49 +74,55 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
       op_desc.SetInput("Bias", {new_bias_var});
     }
 
-    // Create temp variables.
-    const std::string BatchedInput = patterns::UniqueKey("BatchedInput");
-    const std::string BatchedCellPreAct =
-        patterns::UniqueKey("BatchedCellPreAct");
-    const std::string BatchedGate = patterns::UniqueKey("BatchedGate");
-    const std::string CheckedCell = patterns::UniqueKey("CheckedCell");
-
     op_desc.SetInput("H0", {});
     op_desc.SetInput("C0", {});
     op_desc.SetOutput("Hidden", {hidden->Name()});
     op_desc.SetOutput("Cell", {cell->Name()});
     op_desc.SetOutput("XX", {xx->Name()});
-    op_desc.SetOutput("BatchedGate", {BatchedGate});
-    op_desc.SetOutput("BatchCellPreAct", {BatchedCellPreAct});
-    op_desc.SetOutput("BatchedInput", {BatchedInput});
-    op_desc.SetOutput("CheckedCell", {CheckedCell});
     op_desc.SetAttr("is_reverse", lstm->Op()->GetAttr("is_reverse"));
     op_desc.SetAttr("use_peepholes", lstm->Op()->GetAttr("use_peepholes"));
     // TODO(TJ): get from attr
     op_desc.SetAttr("use_seq", true);
 
-    auto* op = graph->CreateOpNode(&op_desc);
-
-    PrepareOutVars(graph, BatchedInput, op);
-    PrepareOutVars(graph, BatchedCellPreAct, op);
-    PrepareOutVars(graph, BatchedGate, op);
-    PrepareOutVars(graph, CheckedCell, op);
-
+// Create temp variables.
 #define OP_SET_OUT(x)                            \
   const std::string x = patterns::UniqueKey(#x); \
-  op_desc.SetOutput(#x, {x});                    \
-  PrepareOutVars(graph, #x, op)
+  op_desc.SetOutput(#x, {x});
+
+    OP_SET_OUT(BatchedGate);
+    OP_SET_OUT(BatchedCellPreAct);
+    OP_SET_OUT(BatchedInput);
+    OP_SET_OUT(CheckedCell);
     OP_SET_OUT(BatchedCell);
     OP_SET_OUT(BatchedHidden);
     OP_SET_OUT(ReorderedH0);
     OP_SET_OUT(ReorderedC0);
 #undef OP_SET_OUT
 
+    auto* op = graph->CreateOpNode(&op_desc);
+
     IR_NODE_LINK_TO(input, op);
     IR_NODE_LINK_TO(weight_x, op);
     IR_NODE_LINK_TO(weight_h, op);
     IR_NODE_LINK_TO(bias, op);
     IR_NODE_LINK_TO(op, hidden);
+
+#define IR_NODE(x)                                 \
+  VarDesc key_##x(x);                              \
+  key_##x.SetPersistable(false);                   \
+  auto* node_##x = graph->CreateVarNode(&key_##x); \
+  IR_NODE_LINK_TO(op, node_##x);
+
+    IR_NODE(BatchedGate);
+    IR_NODE(BatchedCellPreAct);
+    IR_NODE(BatchedInput);
+    IR_NODE(CheckedCell);
+    IR_NODE(BatchedCell);
+    IR_NODE(BatchedHidden);
+    IR_NODE(ReorderedH0);
+    IR_NODE(ReorderedC0);
+#undef IR_NODE
+
     return op;
   };
 

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
@@ -21,12 +21,14 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
+namespace {
 void PrepareOutVars(Graph* graph, const std::string name, ir::Node* op) {
   VarDesc key(name);
   key.SetPersistable(false);
   auto* key_node = graph->CreateVarNode(&key);
   IR_NODE_LINK_TO(op, key_node);
 }
+}  // namespace
 
 int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
                 bool with_fc_bias) {

--- a/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
@@ -229,7 +229,7 @@ void SeqConcatFcFusePass::ApplyImpl(ir::Graph* graph) const {
     IR_NODE_LINK_TO(sequence_expand0_in, op_node);
     IR_NODE_LINK_TO(sequence_expand1_in, op_node);
     IR_NODE_LINK_TO(op_node, fc_out);
-    IR_NODE_LINK_TO(op, fc_out_node);
+    IR_NODE_LINK_TO(op_node, fc_out_node);
 
     // Clean nodes.
     std::unordered_set<const Node*> marked_nodes;

--- a/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
@@ -214,7 +214,9 @@ void SeqConcatFcFusePass::ApplyImpl(ir::Graph* graph) const {
     op_desc.SetInput("FCWeight", {fc_w->Name()});
     op_desc.SetInput("FCBias", {fc_bias->Name()});
     const std::string fc_out_tmp = fc_out->Name() + ".tmp";
-    param_scope()->Var(fc_out_tmp)->GetMutable<framework::LoDTensor>();
+    VarDesc fc_out_key(fc_out_tmp);
+    fc_out_key.SetPersistable(false);
+    auto* fc_out_node = graph->CreateVarNode(&fc_out_key);
     op_desc.SetOutput("FCOut", {fc_out_tmp});
     op_desc.SetOutput("Out", {fc_out->Name()});
     op_desc.SetAttr("fc_activation", act->Op()->Type());
@@ -227,6 +229,7 @@ void SeqConcatFcFusePass::ApplyImpl(ir::Graph* graph) const {
     IR_NODE_LINK_TO(sequence_expand0_in, op_node);
     IR_NODE_LINK_TO(sequence_expand1_in, op_node);
     IR_NODE_LINK_TO(op_node, fc_out);
+    IR_NODE_LINK_TO(op, fc_out_node);
 
     // Clean nodes.
     std::unordered_set<const Node*> marked_nodes;


### PR DESCRIPTION
This PR is a supplement of #21841 .
Some passes tried to access memory during fusion-building and create a piece of memory for some variables. 
And when this operation is applied to an output variable, all cloned predictors in multi-threads can access the same memory and modify its dims or value. This may cause memory out-of-bounds. 
This PR tries to fix:
* seqconv_eltadd_relu_fuse_pass
* attention_lstm_fuse_pass
* embedding_fc_lstm_fuse_pass
* fc_lstm_fuse_pass
* seq_concat_fc_fuse_pass

We try to treat passes as ReadOnly. If it cannot be ReadOnly, only persistable variables are allowed to be modified. It's forbidden to create any intermediate variable in this scope. 