### PR TITLE
make reverse op support negative axis

### DIFF
--- a/paddle/fluid/operators/reverse_op.cc
+++ b/paddle/fluid/operators/reverse_op.cc
@@ -30,9 +30,9 @@ class ReverseOp : public framework::OperatorWithKernel {
     const auto& axis = ctx->Attrs().Get<std::vector<int>>("axis");
     PADDLE_ENFORCE(!axis.empty(), "'axis' can not be empty.");
     for (int a : axis) {
-      PADDLE_ENFORCE_LT(a, x_dims.size(),
+      PADDLE_ENFORCE_LT(a, x_dims.size(), paddle::platform::errors::OutOfRange(
                         "The axis must be less than input tensor's rank.");
-      PADDLE_ENFORCE_GE(a, -x_dims.size(),
+      PADDLE_ENFORCE_GE(a, -x_dims.size(), paddle::platform::errors::OutOfRange(
                         "The axis must be greater than the negative number of "
                         "input tensor's rank.");
     }

--- a/paddle/fluid/operators/reverse_op.cc
+++ b/paddle/fluid/operators/reverse_op.cc
@@ -32,6 +32,9 @@ class ReverseOp : public framework::OperatorWithKernel {
     for (int a : axis) {
       PADDLE_ENFORCE_LT(a, x_dims.size(),
                         "The axis must be less than input tensor's rank.");
+      PADDLE_ENFORCE_GE(a, -x_dims.size(),
+                        "The axis must be greater than the negetive number of "
+                        "input tensor's rank.");
     }
     ctx->SetOutputDim("Out", x_dims);
   }

--- a/paddle/fluid/operators/reverse_op.cc
+++ b/paddle/fluid/operators/reverse_op.cc
@@ -30,11 +30,14 @@ class ReverseOp : public framework::OperatorWithKernel {
     const auto& axis = ctx->Attrs().Get<std::vector<int>>("axis");
     PADDLE_ENFORCE(!axis.empty(), "'axis' can not be empty.");
     for (int a : axis) {
-      PADDLE_ENFORCE_LT(a, x_dims.size(), paddle::platform::errors::OutOfRange(
-                        "The axis must be less than input tensor's rank.");
-      PADDLE_ENFORCE_GE(a, -x_dims.size(), paddle::platform::errors::OutOfRange(
-                        "The axis must be greater than the negative number of "
-                        "input tensor's rank.");
+      PADDLE_ENFORCE_LT(a, x_dims.size(),
+                        paddle::platform::errors::OutOfRange(
+                            "The axis must be less than input tensor's rank."));
+      PADDLE_ENFORCE_GE(
+          a, -x_dims.size(),
+          paddle::platform::errors::OutOfRange(
+              "The axis must be greater than the negative number of "
+              "input tensor's rank."));
     }
     ctx->SetOutputDim("Out", x_dims);
   }

--- a/paddle/fluid/operators/reverse_op.cc
+++ b/paddle/fluid/operators/reverse_op.cc
@@ -33,7 +33,7 @@ class ReverseOp : public framework::OperatorWithKernel {
       PADDLE_ENFORCE_LT(a, x_dims.size(),
                         "The axis must be less than input tensor's rank.");
       PADDLE_ENFORCE_GE(a, -x_dims.size(),
-                        "The axis must be greater than the negetive number of "
+                        "The axis must be greater than the negative number of "
                         "input tensor's rank.");
     }
     ctx->SetOutputDim("Out", x_dims);

--- a/paddle/fluid/operators/reverse_op.h
+++ b/paddle/fluid/operators/reverse_op.h
@@ -28,7 +28,11 @@ struct ReverseFunctor {
       reverse_axis[i] = false;
     }
     for (int a : axis) {
-      reverse_axis[a] = true;
+      if (a >= 0) {
+        reverse_axis[a] = true;
+      } else {
+        reverse_axis[Rank + a] = true;
+      }
     }
 
     auto in_eigen = framework::EigenTensor<T, Rank>::From(in);

--- a/python/paddle/fluid/tests/unittests/test_reverse_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reverse_op.py
@@ -47,10 +47,22 @@ class TestCase0(TestReverseOp):
         self.axis = [1]
 
 
+class TestCase0(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((3, 40)).astype('float64')
+        self.axis = [-1]
+
+
 class TestCase1(TestReverseOp):
     def initTestCase(self):
         self.x = np.random.random((3, 40)).astype('float64')
         self.axis = [0, 1]
+
+
+class TestCase0(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((3, 40)).astype('float64')
+        self.axis = [0, -1]
 
 
 class TestCase2(TestReverseOp):
@@ -59,10 +71,22 @@ class TestCase2(TestReverseOp):
         self.axis = [0, 2]
 
 
+class TestCase2(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((3, 4, 10)).astype('float64')
+        self.axis = [0, -2]
+
+
 class TestCase3(TestReverseOp):
     def initTestCase(self):
         self.x = np.random.random((3, 4, 10)).astype('float64')
         self.axis = [1, 2]
+
+
+class TestCase3(TestReverseOp):
+    def initTestCase(self):
+        self.x = np.random.random((3, 4, 10)).astype('float64')
+        self.axis = [-1, -2]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix bug that reverse op does not support negative axis. Here are some examples before I fix this bug:

For dygraph program:

reproduce:

```python
import numpy as np
from paddle import fluid
import paddle.fluid.layers as F
import paddle.fluid.dygraph as dg

x = np.reshape(np.arange(20), (4, 5)).astype(np.float32)
print(x)
place = fluid.CPUPlace()
with dg.guard(place):
    x_var = dg.to_variable(x)
    y_var = F.reverse(x_var, axis=-1)
    y_np = y_var.numpy()
    print(y_np)
```

output:
```text
[[ 0.  1.  2.  3.  4.]
 [ 5.  6.  7.  8.  9.]
 [10. 11. 12. 13. 14.]
 [15. 16. 17. 18. 19.]]

[[ 0.  1.  2.  3.  4.]
 [ 5.  6.  7.  8.  9.]
 [10. 11. 12. 13. 14.]
 [15. 16. 17. 18. 19.]]
```

expected ouput:

```text
[[ 0.  1.  2.  3.  4.]
 [ 5.  6.  7.  8.  9.]
 [10. 11. 12. 13. 14.]
 [15. 16. 17. 18. 19.]]

[[ 4.  3.  2.  1.  0.]
 [ 9.  8.  7.  6.  5.]
 [14. 13. 12. 11. 10.]
 [19. 18. 17. 16. 15.]]
```

for static program:

```python
import paddle.fluid as fluid
import numpy as np
np.random.seed(9000)

fluid.default_main_program().random_seed = 9000
fluid.default_startup_program().random_seed = 9000
def gen_data():
    return {"x": np.reshape(np.arange(20), (4, 5)).astype(np.float32)}

input_x = fluid.layers.data(name="x", shape=[32], dtype='float32')
reverse = fluid.layers.reverse(input_x, axis=-1)

print("Finished FF")

place = fluid.CPUPlace()
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())

with open("main_program.txt", 'w') as f:
    f.write(str(fluid.default_main_program()))

data = gen_data()
reverse_np = exe.run(feed=data,
                       program=fluid.default_main_program(),
                       fetch_list=[reverse])
print(data["x"])
print(reverse_np)
```

```shell

[[ 0.  1.  2.  3.  4.]
 [ 5.  6.  7.  8.  9.]
 [10. 11. 12. 13. 14.]
 [15. 16. 17. 18. 19.]]
[array([[ 0.,  1.,  2.,  3.,  4.],
       [ 5.,  6.,  7.,  8.,  9.],
       [10., 11., 12., 13., 14.],
       [15., 16., 17., 18., 19.]], dtype=float32)]
```

for more details, see this issue： https://github.com/PaddlePaddle/Paddle/issues/21906