### PR TITLE
test=develop fix conv2d_transpose op unittest

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -62,6 +62,7 @@ class TestConv2dTransposeMKLDNNOp(TestConv2dTransposeOp):
         self.groups = 1
 
     def setUp(self):
+        self.dtype = np.float32
         TestConv2dTransposeOp.setUp(self)
 
         output = self.outputs['Output']

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -60,9 +60,9 @@ class TestConv2dTransposeMKLDNNOp(TestConv2dTransposeOp):
         f_c = self.input_size[1]
         self.filter_size = [f_c, 6, 3, 3]
         self.groups = 1
+        self.dtype = np.float32
 
     def setUp(self):
-        self.dtype = np.float32
 
         TestConv2dTransposeOp.setUp(self)
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -63,6 +63,7 @@ class TestConv2dTransposeMKLDNNOp(TestConv2dTransposeOp):
 
     def setUp(self):
         self.dtype = np.float32
+
         TestConv2dTransposeOp.setUp(self)
 
         output = self.outputs['Output']

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -108,6 +108,7 @@ def conv2dtranspose_forward_naive(input_, filter_, attrs):
 class TestConv2dTransposeOp(OpTest):
     def setUp(self):
         # init as conv transpose
+        self.dtype = np.float64
         self.is_test = False
         self.use_cudnn = False
         self.use_mkldnn = False
@@ -192,20 +193,6 @@ class TestConv2dTransposeOp(OpTest):
 
     def init_op_type(self):
         self.op_type = "conv2d_transpose"
-
-    def init_kernel_type(self):
-        self.dtype = np.float64
-
-
-'''
-class TestWithFloat32(TestConv2dTransposeOp):
-    def init_op_type(self):
-        self.op_type = "conv2d_transpose"
-        self.use_cudnn = True 
-
-    def init_kernel_type(self):
-        self.dtype = np.float32 
-'''
 
 
 class TestWithSymmetricPad(TestConv2dTransposeOp):

--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_op.py
@@ -78,7 +78,7 @@ def conv2dtranspose_forward_naive(input_, filter_, attrs):
         out_h = output_size[0] + pad_h_0 + pad_h_1
         out_w = output_size[1] + pad_w_0 + pad_w_1
 
-    out = np.zeros((in_n, out_c, out_h, out_w))
+    out = np.zeros((in_n, out_c, out_h, out_w), dtype=input_.dtype)
 
     for n in range(in_n):
         for i in range(in_h):
@@ -108,7 +108,6 @@ def conv2dtranspose_forward_naive(input_, filter_, attrs):
 class TestConv2dTransposeOp(OpTest):
     def setUp(self):
         # init as conv transpose
-        self.dtype = np.float32
         self.is_test = False
         self.use_cudnn = False
         self.use_mkldnn = False
@@ -119,8 +118,8 @@ class TestConv2dTransposeOp(OpTest):
         self.init_op_type()
         self.init_test_case()
 
-        input_ = np.random.random(self.input_size).astype("float32")
-        filter_ = np.random.random(self.filter_size).astype("float32")
+        input_ = np.random.random(self.input_size).astype(self.dtype)
+        filter_ = np.random.random(self.filter_size).astype(self.dtype)
 
         self.inputs = {'Input': input_, 'Filter': filter_}
         self.attrs = {
@@ -138,7 +137,7 @@ class TestConv2dTransposeOp(OpTest):
             self.attrs['output_size'] = self.output_size
 
         output = conv2dtranspose_forward_naive(input_, filter_,
-                                               self.attrs).astype('float32')
+                                               self.attrs).astype(self.dtype)
 
         self.outputs = {'Output': output}
 
@@ -193,6 +192,20 @@ class TestConv2dTransposeOp(OpTest):
 
     def init_op_type(self):
         self.op_type = "conv2d_transpose"
+
+    def init_kernel_type(self):
+        self.dtype = np.float64
+
+
+'''
+class TestWithFloat32(TestConv2dTransposeOp):
+    def init_op_type(self):
+        self.op_type = "conv2d_transpose"
+        self.use_cudnn = True 
+
+    def init_kernel_type(self):
+        self.dtype = np.float32 
+'''
 
 
 class TestWithSymmetricPad(TestConv2dTransposeOp):


### PR DESCRIPTION
1. conv2d_transpose op's unit test has one case have error, like 
![image](https://user-images.githubusercontent.com/48318485/71431767-27909180-270f-11ea-83f8-65b9cf0bdc6e.png)
2. conv mkldnn does not support fp64，so not removed from white list