### PR TITLE
add fp64 check_grad for conv2d, conv3d

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -62,6 +62,7 @@ class TestConv2dMKLDNNOp(TestConv2dOp):
         self.fuse_brelu_threshold = 6.0
         self.fuse_residual_connection = False
         self.input_residual_size = None
+        self.dtype = np.float32
         TestConv2dOp.setUp(self)
 
         output = self.outputs['Output']

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -44,6 +44,7 @@ class TestConv2dMKLDNNOp(TestConv2dOp):
         self.data_format = "NCHW"
         self.use_mkldnn = True
         self._cpu_only = True
+        self.dtype = np.float32
 
     def init_test_case(self):
         self.pad = [0, 0]
@@ -62,7 +63,7 @@ class TestConv2dMKLDNNOp(TestConv2dOp):
         self.fuse_brelu_threshold = 6.0
         self.fuse_residual_connection = False
         self.input_residual_size = None
-        self.dtype = np.float32
+
         TestConv2dOp.setUp(self)
 
         output = self.outputs['Output']

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_mkldnn_op.py
@@ -180,6 +180,7 @@ class TestWithInput1x1Filter1x1(TestConv2dMKLDNNOp):
 class TestConv2dOp_AsyPadding_MKLDNN(TestConv2dOp_v2):
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.dtype = np.float32
 
     def init_paddings(self):
         self.pad = [0, 0, 1, 2]

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -76,6 +76,9 @@ class TestConv3dOp_Same_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
     def init_paddings(self):
         self.pad = [0, 0, 0]
         self.padding_algorithm = "SAME"
+
+    def init_kernel_type(self):
+        self.use_mkldnn = True
         self.dtype = np.float32
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -79,6 +79,7 @@ class TestConv3dOp_Same_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
 
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.data_format = "NCHW"
         self.dtype = np.float32
 
 
@@ -89,6 +90,7 @@ class TestConv3dOp_Valid_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
 
     def init_kernel_type(self):
         self.use_mkldnn = True
+        self.data_format = "NCHW"
         self.dtype = np.float32
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 
 import unittest
-
+import numpy as np
 from paddle.fluid.tests.unittests.test_conv3d_op import TestConv3dOp, TestCase1, TestWithGroup1, TestWithGroup2, TestWith1x1, TestWithInput1x1Filter1x1, TestConv3dOp_2
 
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv3d_mkldnn_op.py
@@ -23,42 +23,49 @@ class TestMKLDNN(TestConv3dOp):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
 
 class TestMKLDNNCase1(TestCase1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
 
 class TestMKLDNNGroup1(TestWithGroup1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
 
 class TestMKLDNNGroup2(TestWithGroup2):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
 
 class TestMKLDNNWith1x1(TestWith1x1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
 
 class TestMKLDNNWithInput1x1Filter1x1(TestWithInput1x1Filter1x1):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
 
 class TestConv3dOp_AsyPadding_MKLDNN(TestConv3dOp):
     def init_kernel_type(self):
         self.use_mkldnn = True
         self.data_format = "NCHW"
+        self.dtype = np.float32
 
     def init_paddings(self):
         self.pad = [1, 0, 1, 0, 0, 2]
@@ -69,12 +76,17 @@ class TestConv3dOp_Same_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
     def init_paddings(self):
         self.pad = [0, 0, 0]
         self.padding_algorithm = "SAME"
+        self.dtype = np.float32
 
 
 class TestConv3dOp_Valid_MKLDNN(TestConv3dOp_AsyPadding_MKLDNN):
     def init_paddings(self):
         self.pad = [1, 1, 1]
         self.padding_algorithm = "VALID"
+
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+        self.dtype = np.float32
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -352,7 +352,7 @@ class TestConv2dOp(OpTest):
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output_with_place(
-            place, atol=0, check_dygraph=(self.use_mkldnn == False))
+            place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -362,7 +362,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -373,7 +373,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -385,7 +385,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -782,7 +782,7 @@ class TestConv2dOp_v2(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         self.check_output_with_place(
-            place, atol=0, check_dygraph=(self.use_mkldnn == False))
+            place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -792,7 +792,7 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -803,7 +803,7 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -815,7 +815,7 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -298,7 +298,7 @@ class TestConv2dOp(OpTest):
         self.use_mkldnn = False
         self.fuse_relu_before_depthwise_conv = False
         self.data_format = "AnyLayout"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()
@@ -352,7 +352,7 @@ class TestConv2dOp(OpTest):
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         self.check_output_with_place(
-            place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
+            place, atol=0, check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -362,7 +362,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=1e-7,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -373,7 +373,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=1e-7,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -385,6 +385,7 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
+            max_relative_error=1e-7,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -723,7 +724,7 @@ class TestConv2dOp_v2(OpTest):
         self.use_cuda = False
         self.use_mkldnn = False
         self.fuse_relu_before_depthwise_conv = False
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()
@@ -781,7 +782,7 @@ class TestConv2dOp_v2(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         place = core.CUDAPlace(0) if self.has_cuda() else core.CPUPlace()
         self.check_output_with_place(
-            place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
+            place, atol=0, check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -791,7 +792,7 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=1e-7,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -802,7 +803,7 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=1e-7,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -814,6 +815,7 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
+            max_relative_error=1e-7,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 

--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -385,7 +385,6 @@ class TestConv2dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -815,7 +814,6 @@ class TestConv2dOp_v2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -234,7 +234,7 @@ class TestConv3dOp(OpTest):
         self.use_cudnn = False
         self.use_mkldnn = False
         self.data_format = "AnyLayout"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()
@@ -276,7 +276,7 @@ class TestConv3dOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_output_with_place(
-            place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
+            place, atol=0, check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -286,7 +286,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=0.03,
+            max_relative_error=1e-7,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -297,7 +297,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.03,
+            max_relative_error=1e-7,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -309,7 +309,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.03,
+            max_relative_error=1e-7,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -525,7 +525,7 @@ class TestConv3dOp_2(OpTest):
         self.use_cudnn = False
         self.use_mkldnn = False
         self.data_format = "NCDHW"
-        self.dtype = np.float32
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()
@@ -568,14 +568,14 @@ class TestConv3dOp_2(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
-        self.check_output_with_place(place, atol=1e-5)
+        self.check_output_with_place(place, atol=0)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.03)
+            place, {'Input', 'Filter'}, 'Output', max_relative_error=1e-7)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
@@ -584,7 +584,7 @@ class TestConv3dOp_2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.03,
+            max_relative_error=1e-7,
             no_grad_set=set(['Filter']))
 
     def test_check_grad_no_input(self):
@@ -594,7 +594,7 @@ class TestConv3dOp_2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.03,
+            max_relative_error=1e-7,
             no_grad_set=set(['Input']))
 
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -234,7 +234,7 @@ class TestConv3dOp(OpTest):
         self.use_cudnn = False
         self.use_mkldnn = False
         self.data_format = "AnyLayout"
-        self.init_dtype()
+        self.dtype = np.float64
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()
@@ -332,9 +332,6 @@ class TestConv3dOp(OpTest):
 
     def init_kernel_type(self):
         pass
-
-    def init_dtype(self):
-        self.dtype = np.float64
 
 
 class TestCase1(TestConv3dOp):

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -276,7 +276,7 @@ class TestConv3dOp(OpTest):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_output_with_place(
-            place, atol=0, check_dygraph=(self.use_mkldnn == False))
+            place, atol=1e-5, check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad(self):
         if self.dtype == np.float16:
@@ -286,7 +286,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -297,7 +297,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -309,7 +309,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -568,14 +568,14 @@ class TestConv3dOp_2(OpTest):
 
     def test_check_output(self):
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
-        self.check_output_with_place(place, atol=0)
+        self.check_output_with_place(place, atol=1e-5)
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=1e-7)
+            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.02)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
@@ -584,7 +584,7 @@ class TestConv3dOp_2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Filter']))
 
     def test_check_grad_no_input(self):
@@ -594,7 +594,7 @@ class TestConv3dOp_2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=1e-7,
+            max_relative_error=0.02,
             no_grad_set=set(['Input']))
 
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -286,7 +286,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, {'Input', 'Filter'},
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=0.03,
             check_dygraph=(self.use_mkldnn == False))
 
     def test_check_grad_no_filter(self):
@@ -297,7 +297,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=0.03,
             no_grad_set=set(['Filter']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -309,7 +309,7 @@ class TestConv3dOp(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=0.03,
             no_grad_set=set(['Input']),
             check_dygraph=(self.use_mkldnn == False))
 
@@ -575,7 +575,7 @@ class TestConv3dOp_2(OpTest):
             return
         place = core.CUDAPlace(0) if self.has_cudnn() else core.CPUPlace()
         self.check_grad_with_place(
-            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.02)
+            place, {'Input', 'Filter'}, 'Output', max_relative_error=0.03)
 
     def test_check_grad_no_filter(self):
         if self.dtype == np.float16:
@@ -584,7 +584,7 @@ class TestConv3dOp_2(OpTest):
         self.check_grad_with_place(
             place, ['Input'],
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=0.03,
             no_grad_set=set(['Filter']))
 
     def test_check_grad_no_input(self):
@@ -594,7 +594,7 @@ class TestConv3dOp_2(OpTest):
         self.check_grad_with_place(
             place, ['Filter'],
             'Output',
-            max_relative_error=0.02,
+            max_relative_error=0.03,
             no_grad_set=set(['Input']))
 
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/test_conv3d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv3d_op.py
@@ -234,7 +234,7 @@ class TestConv3dOp(OpTest):
         self.use_cudnn = False
         self.use_mkldnn = False
         self.data_format = "AnyLayout"
-        self.dtype = np.float64
+        self.init_dtype()
         self.init_kernel_type()
         self.init_group()
         self.init_dilation()
@@ -332,6 +332,9 @@ class TestConv3dOp(OpTest):
 
     def init_kernel_type(self):
         pass
+
+    def init_dtype(self):
+        self.dtype = np.float64
 
 
 class TestCase1(TestConv3dOp):


### PR DESCRIPTION
1. add fp64 check_grad for conv2d, conv3d based on https://github.com/PaddlePaddle/Paddle/wiki/Upgrade-OP-Precision-to-Float64
2. conv mkldnn does not support fp64，so not removed from white list