### PR TITLE
Remove unused parameter in to_variable

### DIFF
--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -172,20 +172,19 @@ def _print_debug_msg(limit=5, is_test=False):
         return unique_name_size, tracer_var_size, alive_cpp_var_size
 
 
-# TODO(zhiqiu): Param 'block' should be deprecated, since block is meaningless in dygraph 
 @framework.dygraph_only
-def to_variable(value, block=None, name=None, zero_copy=None):
+def to_variable(value, name=None, zero_copy=None):
     """
     The API will create a ``Variable`` object from numpy\.ndarray or Variable object.
 
     Parameters:
-        value(ndarray): The numpy\.ndarray object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
-        block(fluid.Block, optional): Which block this variable will be in. Default: None.
+        value(ndarray|Variable): The numpy\.ndarray or Variable object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
         name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`
         zero_copy(bool, optional): Whether to share memory with the input numpy array. This parameter only works with CPUPlace and will be set to True when it is None. Default: None.
 
     Returns:
-        Variable: ``Tensor`` created from the specified numpy\.ndarray object, data type and shape is the same as ``value`` .
+        Variable: If ``value`` is a numpy\.ndarray object, return ``Tensor`` created from the specified numpy\.ndarray object, which has same data type and shape with ``value``. If ``value`` is a Variable object, just return ``value``.
+
 
     Examples:
 

--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -50,7 +50,6 @@ class LayerHelperBase(object):
 
         Parameters:
             value(ndarray): The numpy\.ndarray object that needs to be converted, it can be multi-dimension, and the data type is one of numpy\.{float16, float32, float64, int16, int32, int64, uint8, uint16}.
-            block(fluid.Block, optional): Which block this variable will be in. Default: None.
             name(str, optional): The default value is None. Normally there is no need for user to set this property. For more information, please refer to :ref:`api_guide_Name`
 
         Returns:


### PR DESCRIPTION
As the title, `block` is not used in `to_variable` and it is meaningless to set block for `VarBase` in dygraph mode, so this PR removes it. 

The related FluidDoc [PR1688](https://github.com/PaddlePaddle/FluidDoc/pull/1688).

The updated API docs are as follows.

![image](https://user-images.githubusercontent.com/6888866/71479853-366f6500-2831-11ea-9b82-482ab2874a89.png)

![image](https://user-images.githubusercontent.com/6888866/71480251-193b9600-2833-11ea-886f-50f2b129675e.png)
