### PR TITLE
[Bug Fix] Fix trt calib engine key bug

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -18,8 +18,10 @@
 #include <gtest/gtest_prod.h>
 #endif
 
+#include <map>
 #include <memory>
 #include <numeric>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -296,7 +298,7 @@ class GraphPatternDetector {
   using hit_rcd_t =
       std::pair<Node* /*node in graph*/, PDNode* /*node in pattern*/>;
   PDPattern pattern_;
-  std::unordered_map<const PDNode*, std::unordered_set<Node*>> pdnodes2nodes_;
+  std::map<const PDNode*, std::set<Node*>> pdnodes2nodes_;
 };
 
 // some helper methods.


### PR DESCRIPTION
**Bug:** Graph pattern detector uses `unordered_map` and `unordered_set` to store pdnodes-to-nodes mappings, where the sorting is unstable, causing TRT engine key to change even if the model stays the same. This bug causes TRT int8 calibration to generate table data while it already exists.
**Fix:** Changed the `unordered_map` and `unordered_set` of pdnodes-to-nodes mapping to `map` and `set`. Now TRT int8 calibration works properly.