### PR TITLE
Uniform append_backward & gradients parameter_list type to Variable

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1174,7 +1174,7 @@ def append_backward(loss,
             else:
                 raise TypeError(
                     "The type of parameter_list's member must be paddle.fluid.Variable or str, but received %s."
-                    % (type(param_name)))
+                    % (type(param)))
     else:
         params = program.global_block().all_parameters()
         parameters = [param.name for param in params if param.trainable]

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1169,7 +1169,7 @@ def append_backward(loss,
         for i, param in enumerate(parameter_list):
             if isinstance(param, framework.Variable):
                 parameters.append(param.name)
-            elif isinstance(param, (str, unicode)):
+            elif isinstance(param, six.string_types):
                 parameters.append(param)
             else:
                 raise TypeError(

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1161,7 +1161,20 @@ def append_backward(loss,
     program._sync_with_cpp()
 
     if parameter_list is not None:
-        parameters = parameter_list
+        if not isinstance(parameter_list, (list, tuple, set)):
+            raise TypeError(
+                "The type of parameter_list argument must be list or tuple or set, but received %s."
+                % (type(parameter_list)))
+        parameters = []
+        for i, param in enumerate(parameter_list):
+            if isinstance(param, framework.Variable):
+                parameters.append(param.name)
+            elif isinstance(param, (str, unicode)):
+                parameters.append(param)
+            else:
+                raise TypeError(
+                    "The type of parameter_list's member must be paddle.fluid.Variable or str, but received %s."
+                    % (type(param_name)))
     else:
         params = program.global_block().all_parameters()
         parameters = [param.name for param in params if param.trainable]

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1021,18 +1021,18 @@ def append_backward(loss,
 
     Parameters:
         loss( :ref:`api_guide_Variable_en` ): The loss variable of the network.
-        parameter_list(list of str, optional): Names of parameters that need
-                                           to be updated by optimizers.
+        parameter_list(list[Variable|str], optional): List of Parameters or Parameter.names
+                                           that need to be updated by optimizers.
                                            If it is None, all parameters
                                            will be updated.
                                            Default: None.
-        no_grad_set(set of str, optional): Variable names in the :ref:`api_guide_Block_en` 0 whose gradients
+        no_grad_set(set[str], optional): Variable names in the :ref:`api_guide_Block_en` 0 whose gradients
                                should be ignored. All variables with
                                `stop_gradient=True` from all blocks will
                                be automatically added into this set.
                                If this parameter is not None, the names in this set will be added to the default set.
                                Default: None.
-        callbacks(list of callable object, optional): List of callback functions.
+        callbacks(list[callable object], optional): List of callback functions.
                                                The callbacks are used for
                                                doing some custom jobs during
                                                backward part building. All

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -505,7 +505,7 @@ class Optimizer(object):
             startup_program (Program, optional): :ref:`api_fluid_Program` for
                 initializing parameters in ``parameter_list``. The default value
                 is None, at this time :ref:`api_fluid_default_startup_program` will be used.
-            parameter_list (list, optional): List of ``Variable`` names to update
+            parameter_list (list, optional): List of ``Variable`` or ``Variable.name`` to update
                 to minimize ``loss``. The default value is None, at this time all parameters
                 will be updated.
             no_grad_set (set, optional): Set of ``Variable`` objects that don't need
@@ -657,7 +657,7 @@ class Optimizer(object):
             startup_program (Program, optional): :ref:`api_fluid_Program` for
                 initializing parameters in ``parameter_list``. The default value
                 is None, at this time :ref:`api_fluid_default_startup_program` will be used.
-            parameter_list (list, optional): List of ``Variable`` names to update
+            parameter_list (list, optional): List of ``Variable`` or ``Variable.name`` to update
                 to minimize ``loss``. The default value is None, at this time all parameters
                 will be updated.
             no_grad_set (set, optional): Set of ``Variable`` objects that don't need

--- a/python/paddle/fluid/tests/unittests/test_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_backward.py
@@ -128,6 +128,37 @@ class TestBackward(unittest.TestCase):
         return no_grad_vars
 
 
+class TestBackwardInputsCheck(unittest.TestCase):
+    def check_backward_with_error_param_list(self, parameter_list):
+        batch_size = 2
+        img, label = init_data(batch_size, img_shape=[784], label_range=9)
+        feed_dict = {'image': img, 'label': label}
+
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+
+        main = fluid.Program()
+        startup = fluid.Program()
+
+        with fluid.program_guard(main, startup):
+            loss = case1_fill_grad_vars()
+
+            optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            optimizer.minimize(loss, parameter_list=parameter_list)
+
+            exe.run(fluid.default_startup_program())
+            exe.run(feed=feed_dict)
+
+    def test_parameter_list_type_error(self):
+        # The type of parameter_list argument must be list or tuple
+        self.assertRaises(TypeError, self.check_backward_with_error_param_list,
+                          "test")
+        # The type of parameter_list's member must be varable or str
+        test = fluid.data(None, 1, 28, 28)
+        self.assertRaises(TypeError, self.check_backward_with_error_param_list,
+                          [test, "test", 3])
+
+
 class SimpleNet(BackwardNet):
     def __init__(self):
         super(BackwardNet, self).__init__()

--- a/python/paddle/fluid/tests/unittests/test_unstack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unstack_op.py
@@ -54,7 +54,7 @@ class TestUnStackOpBase(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad('X', self.get_y_names())
+        self.check_grad(['X'], self.get_y_names())
 
 
 class TestStackOp3(TestUnStackOpBase):


### PR DESCRIPTION
uniform `fluid.backward.append_backward` and `fluid.backward.gradients` input parameter type to `Variable`:
- make `fluid.backward.append_backward`'s parameter_list can be `list[Variable]`

![image](https://user-images.githubusercontent.com/22561442/71580089-34abe700-2b3a-11ea-96df-b755c9ad67bc.png)
![image](https://user-images.githubusercontent.com/22561442/71580123-5ad18700-2b3a-11ea-9621-c29ac6eadb2c.png)
