### PR TITLE
fix load_op_lib not support loading multi libs

### DIFF
--- a/paddle/fluid/framework/load_op_lib.h
+++ b/paddle/fluid/framework/load_op_lib.h
@@ -63,8 +63,12 @@ void LoadOpLib(const std::string &dso_name) {
         type == "conditional_block" || type == "conditional_block_grad") {
       continue;
     }
-    if (info_map.Has(n.first)) {
-      PADDLE_THROW("Op %s has been registered.");
+    // OpInfoMap is implemented in singleton mode, multi dso will use
+    // the same OpInfoMap, this may incur duplicate registration when
+    // loading latter dso, skip info_map processing if an Op is already
+    // regitered here.
+    if (info_map.Has(type)) {
+      continue;
     }
     OpInfo info;
     info.creator_ = n.second.creator_;


### PR DESCRIPTION
**fix load_op_lib not support loading multi libs**
OpInfoMap is implemented in singleton mode, multi dso will use the same OpInfoMap, this may incur duplicate registration when loading latter dso, skip info_map processing if an Op is already regitered here.

OpInfoMap defined at
https://github.com/PaddlePaddle/Paddle/blob/0aab2578f2479a559a1b08a031346b10a5a5a0b8/paddle/fluid/framework/op_info.cc#L27