### PR TITLE
update layers used in mnist dygraph model, test=develop

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .. import core
+from ..framework import dygraph_only
+
+
+@dygraph_only
+def _append_activation_in_dygraph(input,
+                                  act=None,
+                                  use_cudnn=False,
+                                  use_mkldnn=False):
+    """Append activation in dygraph mode.
+
+        Args:
+            input: the input variable. 
+            act: activation type
+            use_mkldnn: if use mkldnn
+            use_cudnn: if use cudnn
+
+    Return the Variable after append activation
+    """
+    if not act:
+        return input
+
+    attrs = {'use_cudnn': use_cudnn, 'use_mkldnn': use_mkldnn}
+    inputs = {"X": [input]}
+    act_op = getattr(core.ops, act)
+    res = act_op(inputs, attrs)
+    return res['Out'][0]
+
+
+@dygraph_only
+def _append_bias_in_dygraph(
+        input,
+        bias=None,
+        axis=1, ):
+    """Append bias operation in dygraph mode.
+
+        Args:
+            input: the input variable. 
+            bias:  the bias to be appended
+            axis:  the axis to perform operation
+
+    Return the Variable after bias operation
+    """
+    if not bias:
+        return input
+
+    attrs = {'axis': axis}
+    inputs = {'X': [input], 'Y': [bias]}
+    outs = core.ops.elementwise_add(inputs, attrs)
+    return outs['Out'][0]

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 from six.moves import reduce
 from .. import core
 from ..layers import utils
-from ..layers import nn
+from ..dygraph import dygraph_utils
 from . import layers
 from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer_
 from ..param_attr import ParamAttr
@@ -252,9 +252,11 @@ class Conv2D(layers.Layer):
             outs = core.ops.conv2d(inputs, attrs)
             pre_bias = outs['Output'][0]
 
-            pre_act = nn._append_bias_in_dygraph(pre_bias, self._bias_param)
+            pre_act = dygraph_utils._append_bias_in_dygraph(pre_bias,
+                                                            self._bias_param)
 
-            return nn._append_activation_in_dygraph(pre_act, self._act)
+            return dygraph_utils._append_activation_in_dygraph(pre_act,
+                                                               self._act)
 
         pre_bias = self._helper.create_variable_for_type_inference(
             dtype=self._dtype)
@@ -980,9 +982,10 @@ class Linear(layers.Layer):
             outs = core.ops.matmul(inputs, attrs)
             pre_bias = outs['Out'][0]
 
-            pre_act = nn._append_bias_in_dygraph(pre_bias, self.bias)
+            pre_act = dygraph_utils._append_bias_in_dygraph(pre_bias, self.bias)
 
-            return nn._append_activation_in_dygraph(pre_act, self._act)
+            return dygraph_utils._append_activation_in_dygraph(pre_act,
+                                                               self._act)
 
         tmp = self._helper.create_variable_for_type_inference(self._dtype)
         self._helper.append_op(

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -253,7 +253,7 @@ class Conv2D(layers.Layer):
             pre_bias = outs['Output'][0]
 
             pre_act = dygraph_utils._append_bias_in_dygraph(pre_bias,
-                                                            self._bias_param)
+                                                            self._bias_param, 1)
 
             return dygraph_utils._append_activation_in_dygraph(pre_act,
                                                                self._act)
@@ -982,7 +982,8 @@ class Linear(layers.Layer):
             outs = core.ops.matmul(inputs, attrs)
             pre_bias = outs['Out'][0]
 
-            pre_act = dygraph_utils._append_bias_in_dygraph(pre_bias, self.bias)
+            pre_act = dygraph_utils._append_bias_in_dygraph(
+                pre_bias, self.bias, axis=len(input.shape) - 1)
 
             return dygraph_utils._append_activation_in_dygraph(pre_act,
                                                                self._act)

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -15,9 +15,9 @@
 from __future__ import print_function
 
 from six.moves import reduce
-
 from .. import core
 from ..layers import utils
+from ..layers import nn
 from . import layers
 from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer_
 from ..param_attr import ParamAttr
@@ -235,6 +235,27 @@ class Conv2D(layers.Layer):
         self._bias_param = value
 
     def forward(self, input):
+        inputs = {
+            'Input': [input],
+            'Filter': [self._filter_param],
+        }
+        attrs = {
+            'strides': self._stride,
+            'paddings': self._padding,
+            'dilations': self._dilation,
+            'groups': self._groups if self._groups else 1,
+            'use_cudnn': self._use_cudnn,
+            'use_mkldnn': False,
+        }
+
+        if in_dygraph_mode():
+            outs = core.ops.conv2d(inputs, attrs)
+            pre_bias = outs['Output'][0]
+
+            pre_act = nn._append_bias_in_dygraph(pre_bias, self._bias_param)
+
+            return nn._append_activation_in_dygraph(pre_act, self._act)
+
         pre_bias = self._helper.create_variable_for_type_inference(
             dtype=self._dtype)
 
@@ -245,14 +266,7 @@ class Conv2D(layers.Layer):
                 'Filter': self._filter_param,
             },
             outputs={"Output": pre_bias},
-            attrs={
-                'strides': self._stride,
-                'paddings': self._padding,
-                'dilations': self._dilation,
-                'groups': self._groups if self._groups else 1,
-                'use_cudnn': self._use_cudnn,
-                'use_mkldnn': False,
-            })
+            attrs=attrs)
 
         if self._bias_param is not None:
             pre_act = self._helper.create_variable_for_type_inference(
@@ -858,23 +872,30 @@ class Pool2D(layers.Layer):
         self._l_type = 'pool2d'
 
     def forward(self, input):
+        attrs = {
+            "pooling_type": self._pool_type,
+            "ksize": self._pool_size,
+            "global_pooling": self._global_pooling,
+            "strides": self._pool_stride,
+            "paddings": self._pool_padding,
+            "use_cudnn": self._use_cudnn,
+            "ceil_mode": self._ceil_mode,
+            "use_mkldnn": False,
+            "exclusive": self._exclusive,
+        }
+        inputs = {"X": [input]}
+
+        if in_dygraph_mode():
+            outs = core.ops.pool2d(inputs, attrs)
+            return outs['Out'][0]
+
         pool_out = self._helper.create_variable_for_type_inference(self._dtype)
 
         self._helper.append_op(
             type=self._l_type,
             inputs={"X": input},
             outputs={"Out": pool_out},
-            attrs={
-                "pooling_type": self._pool_type,
-                "ksize": self._pool_size,
-                "global_pooling": self._global_pooling,
-                "strides": self._pool_stride,
-                "paddings": self._pool_padding,
-                "use_cudnn": self._use_cudnn,
-                "ceil_mode": self._ceil_mode,
-                "use_mkldnn": False,
-                "exclusive": self._exclusive,
-            })
+            attrs=attrs)
         return pool_out
 
 
@@ -948,17 +969,24 @@ class Linear(layers.Layer):
             shape=[output_dim], attr=bias_attr, dtype=dtype, is_bias=True)
 
     def forward(self, input):
+        attrs = {
+            "transpose_X": False,
+            "transpose_Y": False,
+            "alpha": 1,
+        }
+        inputs = {"X": [input], "Y": [self.weight]}
+
+        if in_dygraph_mode():
+            outs = core.ops.matmul(inputs, attrs)
+            pre_bias = outs['Out'][0]
+
+            pre_act = nn._append_bias_in_dygraph(pre_bias, self.bias)
+
+            return nn._append_activation_in_dygraph(pre_act, self._act)
+
         tmp = self._helper.create_variable_for_type_inference(self._dtype)
         self._helper.append_op(
-            type="matmul",
-            inputs={"X": input,
-                    "Y": self.weight},
-            outputs={"Out": tmp},
-            attrs={
-                "transpose_X": False,
-                "transpose_Y": False,
-                "alpha": 1,
-            })
+            type="matmul", inputs=inputs, outputs={"Out": tmp}, attrs=attrs)
         if self.bias:
             pre_activation = self._helper.create_variable_for_type_inference(
                 dtype=self._dtype)
@@ -1548,6 +1576,7 @@ class Embedding(layers.Layer):
             'remote_prefetch': self._remote_prefetch,
             'padding_idx': self._padding_idx
         }
+
         if in_dygraph_mode():
             inputs = {'Ids': [input], 'W': [self._w]}
             outs = core.ops.lookup_table_v2(inputs, attrs)

--- a/python/paddle/fluid/layers/metric_op.py
+++ b/python/paddle/fluid/layers/metric_op.py
@@ -20,7 +20,8 @@ from __future__ import print_function
 import warnings
 from ..layer_helper import LayerHelper
 from ..initializer import Normal, Constant
-from ..framework import Variable
+from ..framework import Variable, in_dygraph_mode, _varbase_creator
+from .. import core
 from ..param_attr import ParamAttr
 from . import nn
 from ..data_feeder import check_type_and_dtype
@@ -71,6 +72,26 @@ def accuracy(input, label, k=1, correct=None, total=None):
 
             #[array([0.6666667], dtype=float32)]
     """
+    if in_dygraph_mode():
+        topk_out, topk_indices = nn.topk(input, k=k)
+        inputs = {
+            "Out": [topk_out],
+            "Indices": [topk_indices],
+            "Label": [label]
+        }
+        acc_out = _varbase_creator(dtype="float32")
+        if correct is None:
+            correct = _varbase_creator(dtype="int64")
+        if total is None:
+            total = _varbase_creator(dtype="int64")
+        outputs = {
+            "Accuracy": [acc_out],
+            "Correct": [correct],
+            "Total": [total]
+        }
+        outs = core.ops.accuracy(inputs, {}, outputs)
+        return outs['Accuracy'][0]
+
     helper = LayerHelper("accuracy", **locals())
     check_type_and_dtype(input, 'input', Variable,
                          ['float16', 'float32', 'float64'], 'accuracy')

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -26,6 +26,7 @@ from ..layer_helper import LayerHelper
 from ..initializer import Normal, Constant, NumpyArrayInitializer
 from ..framework import Variable, OpProtoHolder, in_dygraph_mode, dygraph_only, _dygraph_tracer, default_main_program
 from ..dygraph import base
+from ..dygraph import dygraph_utils
 from ..param_attr import ParamAttr
 from .layer_function_generator import autodoc, templatedoc, _generate_doc_string_
 from .tensor import concat, assign, fill_constant, zeros
@@ -187,54 +188,6 @@ __all__ = [
 
 
 @dygraph_only
-def _append_activation_in_dygraph(input,
-                                  act=None,
-                                  use_cudnn=False,
-                                  use_mkldnn=False):
-    """Append activation in dygraph mode.
-
-        Args:
-            input: the input variable. 
-            act: activation type
-            use_mkldnn: if use mkldnn
-            use_cudnn: if use cudnn
-
-    Return the Variable after append activation
-    """
-    if not act:
-        return input
-
-    attrs = {'use_cudnn': use_cudnn, 'use_mkldnn': use_mkldnn}
-    inputs = {"X": [input]}
-    act_op = getattr(core.ops, act)
-    res = act_op(inputs, attrs)
-    return res['Out'][0]
-
-
-@dygraph_only
-def _append_bias_in_dygraph(
-        input,
-        bias=None,
-        axis=1, ):
-    """Append bias operation in dygraph mode.
-
-        Args:
-            input: the input variable. 
-            bias:  the bias to be appended
-            axis:  the axis to perform operation
-
-    Return the Variable after bias operation
-    """
-    if not bias:
-        return input
-
-    attrs = {'axis': axis}
-    inputs = {'X': [input], 'Y': [bias]}
-    outs = core.ops.elementwise_add(inputs, attrs)
-    return outs['Out'][0]
-
-
-@dygraph_only
 def _elementwise_op_in_dygraph(x,
                                y,
                                axis=-1,
@@ -247,7 +200,8 @@ def _elementwise_op_in_dygraph(x,
     outs = op(inputs, attrs)
     out = outs['Out'][0]
 
-    return _append_activation_in_dygraph(out, act, use_mkldnn=use_mkldnn)
+    return dygraph_utils._append_activation_in_dygraph(
+        out, act, use_mkldnn=use_mkldnn)
 
 
 def fc(input,
@@ -5625,7 +5579,7 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
         inputs = {'X': [x]}
         outs = core.ops.reshape2(inputs, attrs)
         out = outs['Out'][0]
-        return _append_activation_in_dygraph(out, act)
+        return dygraph_utils._append_activation_in_dygraph(out, act)
 
     check_type_and_dtype(x, 'x', Variable,
                          ['float16', 'float32', 'float64', 'int32', 'int64'],

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -1672,20 +1672,20 @@ class AdamOptimizer(Optimizer):
 
         # create the adam optimize op
         inputs = {
-            "Param": param_and_grad[0],
-            "Grad": param_and_grad[1],
-            "LearningRate": self._create_param_lr(param_and_grad),
-            "Moment1": moment1,
-            "Moment2": moment2,
-            "Beta1Pow": beta1_pow_acc,
-            "Beta2Pow": beta2_pow_acc
+            "Param": [param_and_grad[0]],
+            "Grad": [param_and_grad[1]],
+            "LearningRate": [self._create_param_lr(param_and_grad)],
+            "Moment1": [moment1],
+            "Moment2": [moment2],
+            "Beta1Pow": [beta1_pow_acc],
+            "Beta2Pow": [beta2_pow_acc]
         }
         outputs = {
-            "ParamOut": param_and_grad[0],
-            "Moment1Out": moment1,
-            "Moment2Out": moment2,
-            "Beta1PowOut": beta1_pow_acc,
-            "Beta2PowOut": beta2_pow_acc,
+            "ParamOut": [param_and_grad[0]],
+            "Moment1Out": [moment1],
+            "Moment2Out": [moment2],
+            "Beta1PowOut": [beta1_pow_acc],
+            "Beta2PowOut": [beta2_pow_acc],
         }
         attrs = {
             "epsilon": self._epsilon,
@@ -1701,6 +1701,10 @@ class AdamOptimizer(Optimizer):
             inputs['Beta2Tensor'] = self._beta2
         else:
             attrs['beta2'] = self._beta2
+
+        if framework.in_dygraph_mode():
+            core.ops.adam(inputs, attrs, outputs)
+            return None
 
         adam_op = block.append_op(
             type=self.type,

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -275,7 +275,7 @@ class TestDygraphResnet(unittest.TestCase):
                 if traced_layer is not None:
                     resnet.eval()
                     traced_layer._switch(is_test=True)
-                    out_dygraph = resnet([img])
+                    out_dygraph = resnet(img)
                     out_static = traced_layer([img])
                     traced_layer._switch(is_test=False)
                     helper.assertEachVar(out_dygraph, out_static)

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1625,6 +1625,34 @@ class TestLayer(LayerTest):
             self.assertIsNotNone(out2)
             self.assertIsNotNone(out3)
 
+    def test_accuracy(self):
+        x = np.random.rand(3, 32, 32).astype("float32")
+        y = np.array([[1], [0], [1]])
+        with self.static_graph():
+            data = fluid.data(name="input", shape=[-1, 32, 32], dtype="float32")
+            label = fluid.data(name="label", shape=[-1, 1], dtype="int")
+            fc_out = fluid.layers.fc(input=data, size=10)
+            predict = fluid.layers.softmax(input=fc_out)
+            result = fluid.layers.accuracy(input=predict, label=label, k=5)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+
+            exe.run(fluid.default_startup_program())
+            x = np.random.rand(3, 32, 32).astype("float32")
+            y = np.array([[1], [0], [1]])
+            static_out = exe.run(feed={"input": x,
+                                       "label": y},
+                                 fetch_list=result[0])
+
+        with self.dynamic_graph():
+            data = base.to_variable(x)
+            label = base.to_variable(y)
+            fc_out = fluid.layers.fc(data, size=10)
+            predict = fluid.layers.softmax(fc_out)
+            dynamic_out = fluid.layers.accuracy(input=predict, label=label, k=5)
+
+        self.assertTrue(np.array_equal(static_out[0], dynamic_out.numpy()))
+
 
 class TestBook(LayerTest):
     def test_all_layers(self):


### PR DESCRIPTION
As the title, this PR updates several layers used in `mnist` model.
Before this PR, in dygraph mode, the layers reuse the same logic with static graph, which slow down the execution efficiency.
After this PR, in dygraph mode, these layers use core.ops.xx directly in order to execute more efficiently.