### PR TITLE
fix input shape of test_log_loss_op

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_log_loss_op.py
+++ b/python/paddle/fluid/tests/unittests/test_log_loss_op.py
@@ -19,15 +19,19 @@ import numpy as np
 from op_test import OpTest
 
 
+def sigmoid_array(x):
+    return 1 / (1 + np.exp(-x))
+
+
 class TestLogLossOp(OpTest):
     def setUp(self):
         self.op_type = 'log_loss'
-        samples_num = 32
+        samples_num = 100
 
-        predicted = np.random.uniform(0.1, 1.0,
-                                      (samples_num, 1)).astype("float32")
+        x = np.random.random((samples_num, 1)).astype("float32")
+        predicted = sigmoid_array(x)
         labels = np.random.randint(0, 2, (samples_num, 1)).astype("float32")
-        epsilon = 1e-4
+        epsilon = 1e-7
         self.inputs = {
             'Predicted': predicted,
             'Labels': labels,

--- a/python/paddle/fluid/tests/unittests/white_list/check_shape_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/check_shape_white_list.py
@@ -18,7 +18,7 @@ NOT_CHECK_OP_LIST = [
 ]
 
 NEED_TO_FIX_OP_LIST = [
-    'sequence_scatter', 'log_loss', 'sequence_topk_avg_pooling', 'matmul',
+    'sequence_scatter', 'sequence_topk_avg_pooling', 'matmul',
     'add_position_encoding', 'margin_rank_loss', 'elementwise_pow',
     'fused_elemwise_activation', 'mul'
 ]


### PR DESCRIPTION
The prediction input of log_loss must be the outputs of sigmoid function, so in this PR not only fix input shape of test_log_loss_op from 32 to 100, but also add sigmoid implementation for the input data