### PR TITLE
Refine multihead kernel, align block to 32

### DIFF
--- a/paddle/fluid/operators/fused/multihead_matmul_op.cc
+++ b/paddle/fluid/operators/fused/multihead_matmul_op.cc
@@ -91,27 +91,30 @@ class MultiHeadMatMulOp : public framework::OperatorWithKernel {
     int b_indx = dim_bias_q.size() - 1;
     int indx = dim_q.size() - 1;
 
-    PADDLE_ENFORCE_EQ(dim_bias_q[b_indx], dim_q[indx],
-                      platform::errors::InvalidArgument(
-                          "bias_q's last dim size should equal to"
-                          " q last dim size, but bias_q's size is:%d q is:%d",
-                          dim_bias_q[b_indx], dim_q[indx]));
-    PADDLE_ENFORCE_EQ(dim_bias_k[b_indx], dim_k[indx],
-                      platform::errors::InvalidArgument(
-                          "bias_k's last dim size should equal to"
-                          " k last dim size, but bias_k's size is:%d k is:%d",
-                          dim_bias_k[b_indx], dim_k[indx]));
-    PADDLE_ENFORCE_EQ(dim_bias_v[b_indx], dim_v[indx],
-                      platform::errors::InvalidArgument(
-                          "bias_v's last dim size should equal to"
-                          " v last dim size, but bias_v's size is:%d v is:%d",
-                          dim_bias_v[b_indx], dim_v[indx]));
+    PADDLE_ENFORCE_EQ(
+        dim_bias_q[b_indx], dim_q[indx],
+        platform::errors::InvalidArgument(
+            "bias_q's last dim size should equal to"
+            " q last dim size, but received bias_q's size is:%d q is:%d",
+            dim_bias_q[b_indx], dim_q[indx]));
+    PADDLE_ENFORCE_EQ(
+        dim_bias_k[b_indx], dim_k[indx],
+        platform::errors::InvalidArgument(
+            "bias_k's last dim size should equal to"
+            " k last dim size, but received bias_k's size is:%d k is:%d",
+            dim_bias_k[b_indx], dim_k[indx]));
+    PADDLE_ENFORCE_EQ(
+        dim_bias_v[b_indx], dim_v[indx],
+        platform::errors::InvalidArgument(
+            "bias_v's last dim size should equal to"
+            " v last dim size, but received bias_v's size is:%d v is:%d",
+            dim_bias_v[b_indx], dim_v[indx]));
 
     PADDLE_ENFORCE_EQ(dim_q[0], dim_bias_qk[0],
                       platform::errors::InvalidArgument(
                           "q should have same batch size"
-                          "with bias_qk, but q's batch size:%d not equal to "
-                          "bias_qk's batch size:%d",
+                          "with bias_qk, but received q's batch size is:%d "
+                          "bias_qk's batch size is:%d",
                           dim_q[0], dim_bias_qk[0]));
 
     int head_number = context->Attrs().Get<int>("head_number");

--- a/paddle/fluid/operators/fused/multihead_matmul_op.cc
+++ b/paddle/fluid/operators/fused/multihead_matmul_op.cc
@@ -88,24 +88,24 @@ class MultiHeadMatMulOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE_GT(dim_bias_qk.size(), 3,
                       "Multihead input bias qk should be at least 4-D tensor.");
 
-    int b_size = dim_bias_q.size() - 1;
-    int size = dim_q.size() - 1;
+    int b_indx = dim_bias_q.size() - 1;
+    int indx = dim_q.size() - 1;
 
-    PADDLE_ENFORCE_EQ(dim_bias_q[b_size], dim_q[size],
+    PADDLE_ENFORCE_EQ(dim_bias_q[b_indx], dim_q[indx],
                       platform::errors::InvalidArgument(
                           "bias_q's last dim size should equal to"
                           " q last dim size, but bias_q's size is:%d q is:%d",
-                          dim_bias_q[b_size], dim_q[size]));
-    PADDLE_ENFORCE_EQ(dim_bias_k[b_size], dim_k[size],
+                          dim_bias_q[b_indx], dim_q[indx]));
+    PADDLE_ENFORCE_EQ(dim_bias_k[b_indx], dim_k[indx],
                       platform::errors::InvalidArgument(
                           "bias_k's last dim size should equal to"
                           " k last dim size, but bias_k's size is:%d k is:%d",
-                          dim_bias_k[b_size], dim_k[size]));
-    PADDLE_ENFORCE_EQ(dim_bias_v[b_size], dim_v[size],
+                          dim_bias_k[b_indx], dim_k[indx]));
+    PADDLE_ENFORCE_EQ(dim_bias_v[b_indx], dim_v[indx],
                       platform::errors::InvalidArgument(
                           "bias_v's last dim size should equal to"
                           " v last dim size, but bias_v's size is:%d v is:%d",
-                          dim_bias_v[b_size], dim_v[size]));
+                          dim_bias_v[b_indx], dim_v[indx]));
 
     PADDLE_ENFORCE_EQ(dim_q[0], dim_bias_qk[0],
                       platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/fused/multihead_matmul_op.cu
+++ b/paddle/fluid/operators/fused/multihead_matmul_op.cu
@@ -262,10 +262,10 @@ void MatMulWithHeadQK(const platform::CUDADeviceContext &context, int head_num,
   int block = seq_len;
 
   // Align block to 32, also limit seq_len to max block size.
-  PADDLE_ENFORCE_LE(seq_len, 1024,
-                    platform::errors::InvalidArgument("seq_len should <= 1024, "
-                                                      "but seq_len is:%d",
-                                                      seq_len));
+  PADDLE_ENFORCE_LE(seq_len, 1024, platform::errors::InvalidArgument(
+                                       "seq_len should <= 1024, "
+                                       "but received seq_len is:%d",
+                                       seq_len));
   if (seq_len <= 32)
     block = 32;
   else if (seq_len > 32 && seq_len <= 64)


### PR DESCRIPTION
Align blocksize to 32 as cuda run with 32 threads together, also no need to set lane mask.
Refine some log code.

test=develop

Signed-off-by: zhaoyuchen <zhaoyuchen01@baidu.com>