### PR TITLE
update cmake from version 3.5.1 to 3.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,17 @@ RUN rm g++
 RUN ln -s gcc-4.8 gcc
 RUN ln -s g++-4.8 g++
 
+# Install cmake3.16.0
+RUN mkdir -p /root/cmake_build && wget -q https://cmake.org/files/v3.16/cmake-3.16.0.tar.gz && \
+    tar -zxvf cmake-3.16.0.tar.gz && rm cmake-3.16.0.tar.gz && \
+    cd cmake-3.16.0 && ./bootstrap > /dev/null && \
+    make -j8 > /dev/null && make install > /dev/null && \
+    ln -s /usr/local/bin/cmake /usr/bin/cmake
+
+ENV PATH=/usr/local/bin:$PATH
+
+RUN rm -r /root/cmake_build
+
 # Install Python3.6
 RUN mkdir -p /root/python_build/ && wget -q https://www.sqlite.org/2018/sqlite-autoconf-3250300.tar.gz && \
     tar -zxf sqlite-autoconf-3250300.tar.gz && cd sqlite-autoconf-3250300 && \
@@ -61,7 +72,7 @@ RUN apt-get update && \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \
     python-matplotlib gcc-4.8 g++-4.8 \
-    automake locales clang-format swig cmake  \
+    automake locales clang-format swig  \
     liblapack-dev liblapacke-dev \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
     net-tools libtool ccache && \
@@ -76,6 +87,7 @@ WORKDIR /home/Python-$version
 RUN ./configure --enable-unicode=ucs4 --enable-shared CFLAGS=-fPIC --prefix=/usr/local/python2.7.15
 RUN make && make install
 
+RUN echo "export PATH=/usr/local/bin:${PATH}" >> ~/.bashrc
 RUN echo "export PATH=/usr/local/python2.7.15/include:${PATH}" >> ~/.bashrc
 RUN echo "export PATH=/usr/local/python2.7.15/bin:${PATH}" >> ~/.bashrc
 RUN echo "export LD_LIBRARY_PATH=/usr/local/python2.7.15/lib:${LD_LIBRARY_PATH}" >> ~/.bashrc

--- a/tools/manylinux1/Dockerfile.GCC8
+++ b/tools/manylinux1/Dockerfile.GCC8
@@ -27,10 +27,10 @@ RUN apt-get install -y python-dev python-pip wget vim git
 
 # install cmake
 WORKDIR /home
-RUN wget -q https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.tar.gz
-RUN tar -xvf cmake-3.10.0-Linux-x86_64.tar.gz
+RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz
+RUN tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz
 RUN apt install libidn11
-ENV PATH=/home/cmake-3.10.0-Linux-x86_64/bin:$PATH
+ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 WORKDIR /usr/bin
 RUN wget -q http://mirror.linux-ia64.org/gnu/gcc/releases/gcc-8.2.0/gcc-8.2.0.tar.xz && \
   tar -xvf gcc-8.2.0.tar.xz && \
@@ -75,7 +75,7 @@ RUN apt-get update && \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \
     python-matplotlib \
-    automake locales clang-format swig cmake  \
+    automake locales clang-format swig  \
     liblapack-dev liblapacke-dev \
     net-tools libtool ccache module-init-tools && \
     apt-get clean -y

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -61,11 +61,18 @@ RUN apt-get update && \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \
     python-matplotlib gcc-4.8 g++-4.8 \
-    automake locales clang-format swig cmake  \
+    automake locales clang-format swig  \
     liblapack-dev liblapacke-dev \
     clang-3.8 llvm-3.8 libclang-3.8-dev \
     net-tools libtool ccache && \
     apt-get clean -y
+
+# install cmake
+WORKDIR /home
+RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz
+RUN tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz
+RUN rm cmake-3.16.0-Linux-x86_64.tar.gz
+ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 # Install Python2.7.15 to replace original python
 WORKDIR /home

--- a/tools/manylinux1/build_scripts/build.sh
+++ b/tools/manylinux1/build_scripts/build.sh
@@ -59,10 +59,12 @@ yum -y install bzip2 make git patch unzip bison yasm diffutils \
 # /bin/sh cmake-3.8.1-Linux-x86_64.sh --prefix=/usr/local --skip-license
 # rm cmake-3.8.1-Linux-x86_64.sh
 
-wget -q https://cmake.org/files/v3.5/cmake-3.5.2.tar.gz && tar xzf cmake-3.5.2.tar.gz && \
-cd cmake-3.5.2 && ./bootstrap && \
-make -j8 && make install && cd .. && rm cmake-3.5.2.tar.gz
-
+wget -q https://cmake.org/files/v3.16/cmake-3.16.0.tar.gz
+tar -zxvf cmake-3.16.0.tar.gz && rm cmake-3.16.0.tar.gz
+cd cmake-3.16.0 && ./bootstrap
+make -j `nproc` && make install
+ln -s /usr/local/bin/cmake /usr/bin/cmake
+PATH=/usr/local/bin:$PATH
 
 # Install newest autoconf
 build_autoconf $AUTOCONF_ROOT $AUTOCONF_HASH


### PR DESCRIPTION
- Update cmake from version 3.5.1 to 3.16.0.

- It will support more cmake grammar, such as SUBSOURCE_DIR. And faster compilation slightly.