### PR TITLE
enable kldiv_loss_op unittests. test=develop

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -53,7 +53,6 @@ endif()
 list(REMOVE_ITEM TEST_OPS test_seq_concat_op) # FIXME(helin): https://github.com/PaddlePaddle/Paddle/issues/8290
 list(REMOVE_ITEM TEST_OPS test_lstm_unit_op) # # FIXME(qijun) https://github.com/PaddlePaddle/Paddle/issues/5185
 list(REMOVE_ITEM TEST_OPS test_cond_op) # FIXME(qijun): https://github.com/PaddlePaddle/Paddle/issues/5101#issuecomment-339814957
-list(REMOVE_ITEM TEST_OPS test_kldiv_loss_op) # FIXME(dengkaipeng): https://github.com/PaddlePaddle/Paddle/issues/21750
 
 list(REMOVE_ITEM TEST_OPS op_test) # op_test is a helper python file, not a test
 list(REMOVE_ITEM TEST_OPS decorator_helper) # decorator_helper is a helper python file, not a test


### PR DESCRIPTION
**enable kldiv_loss_op unittests**
kldiv_loss OP grad unittests diff has been fixed since #21783 merged
fix https://github.com/PaddlePaddle/Paddle/issues/21750

test 1000 times, all passed
test code:
```
export CUDA_VISIBLE_DEVICES=0,1,2,3

for i in $(seq 1 1000)
do
make test ARGS="-R test_kldiv_loss_op -V" 2>&1 >> kldiv_loss_op.log
done
```
[kldiv_loss_op.log](https://github.com/PaddlePaddle/Paddle/files/4008886/kldiv_loss_op.log)