### PR TITLE
remove warning C4273 when compile dll on windows,test=develop

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -2,6 +2,7 @@ if(WITH_TESTING)
   include(tests/test.cmake) # some generic cmake funtion for inference
 endif()
 
+add_definitions(-DPADDLE_DLL_EXPORT)  # export dll when compile paddle_fluid.dll && paddle_fluid_c.dll on windows
 set(FLUID_CORE_MODULES proto_desc memory lod_tensor executor data_feed_proto)
 
 # TODO(panyx0718): Should this be called paddle_fluid_inference_api_internal?

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -2,7 +2,7 @@ if(WITH_TESTING)
   include(tests/test.cmake) # some generic cmake funtion for inference
 endif()
 
-add_definitions(-DPADDLE_DLL_EXPORT)  # export dll when compile paddle_fluid.dll && paddle_fluid_c.dll on windows
+add_definitions(-DPADDLE_DLL_EXPORT)  # compile dynamic library of inference on windows
 set(FLUID_CORE_MODULES proto_desc memory lod_tensor executor data_feed_proto)
 
 # TODO(panyx0718): Should this be called paddle_fluid_inference_api_internal?

--- a/paddle/fluid/inference/capi/c_api.h
+++ b/paddle/fluid/inference/capi/c_api.h
@@ -19,7 +19,7 @@
 #include <stdio.h>
 
 #if defined(_WIN32)
-#ifdef PADDLE_ON_INFERENCE
+#ifdef PADDLE_DLL_EXPORT
 #define PADDLE_CAPI_EXPORT __declspec(dllexport)
 #else
 #define PADDLE_CAPI_EXPORT __declspec(dllimport)

--- a/paddle/fluid/inference/capi/c_api.h
+++ b/paddle/fluid/inference/capi/c_api.h
@@ -23,7 +23,7 @@
 #define PADDLE_CAPI_EXPORT __declspec(dllexport)
 #else
 #define PADDLE_CAPI_EXPORT __declspec(dllimport)
-#endif  // PADDLE_ON_INFERENCE
+#endif  // PADDLE_DLL_EXPORT
 #else
 #define PADDLE_CAPI_EXPORT __attribute__((visibility("default")))
 #endif  // _WIN32


### PR DESCRIPTION
- Now, when compile paddle_fluid_c.dll, there are many warning affecting developers view log.

- macro PADDLE_ON_INFERENCE can be opened and closed by ON_INFER, but when compile Paddle, it should be **dllexport** rather than **dllimport**. When compile train.exe of user, it will be 
**dllimport**. 

- So, there can be macro always defined in Paddle, it can be  **PADDLE_DLL_EXPORT** in paddle/fluid/inference/CMakeLists.txt.

![image](https://user-images.githubusercontent.com/52485244/71513391-1e512180-28d5-11ea-90c5-7447a702ec56.png)
