### PR TITLE
Add error message for cublas inItizalize failed

### DIFF
--- a/paddle/fluid/platform/cuda_helper.h
+++ b/paddle/fluid/platform/cuda_helper.h
@@ -29,7 +29,11 @@ namespace platform {
 class CublasHandleHolder {
  public:
   CublasHandleHolder(cudaStream_t stream, cublasMath_t math_type) {
-    PADDLE_ENFORCE_CUDA_SUCCESS(dynload::cublasCreate(&handle_));
+    PADDLE_ENFORCE_CUDA_SUCCESS(platform::errors::External(
+        dynload::cublasCreate(&handle_),
+        "Cublas handle initialize failed. Please check that the hardware, an "
+        "appropriate version of the driver, and the cuBLAS library are "
+        "correctly installed."));
     PADDLE_ENFORCE_CUDA_SUCCESS(dynload::cublasSetStream(handle_, stream));
 #if CUDA_VERSION >= 9000
     if (math_type == CUBLAS_TENSOR_OP_MATH) {

--- a/paddle/fluid/platform/cuda_helper.h
+++ b/paddle/fluid/platform/cuda_helper.h
@@ -29,11 +29,12 @@ namespace platform {
 class CublasHandleHolder {
  public:
   CublasHandleHolder(cudaStream_t stream, cublasMath_t math_type) {
-    PADDLE_ENFORCE_CUDA_SUCCESS(platform::errors::External(
+    PADDLE_ENFORCE_CUDA_SUCCESS(
         dynload::cublasCreate(&handle_),
-        "Cublas handle initialize failed. Please check that the hardware, an "
-        "appropriate version of the driver, and the cuBLAS library are "
-        "correctly installed."));
+        platform::errors::External(
+            "Cublas handle initialize failed. Please check that the hardware, "
+            "an appropriate version of the driver, and the cuBLAS library are "
+            "correctly installed."));
     PADDLE_ENFORCE_CUDA_SUCCESS(dynload::cublasSetStream(handle_, stream));
 #if CUDA_VERSION >= 9000
     if (math_type == CUBLAS_TENSOR_OP_MATH) {

--- a/paddle/fluid/platform/cuda_helper.h
+++ b/paddle/fluid/platform/cuda_helper.h
@@ -32,9 +32,11 @@ class CublasHandleHolder {
     PADDLE_ENFORCE_CUDA_SUCCESS(
         dynload::cublasCreate(&handle_),
         platform::errors::External(
-            "Cublas handle initialize failed. Please check that the hardware, "
-            "an appropriate version of the driver, and the cuBLAS library are "
-            "correctly installed."));
+            "The cuBLAS library was not initialized. This is usually caused by "
+            "an error in the CUDA Runtime API called by the cuBLAS routine, or "
+            "an error in the hardware setup.\n"
+            "To correct: check that the hardware, an appropriate version of "
+            "the driver, and the cuBLAS library are correctly installed."));
     PADDLE_ENFORCE_CUDA_SUCCESS(dynload::cublasSetStream(handle_, stream));
 #if CUDA_VERSION >= 9000
     if (math_type == CUBLAS_TENSOR_OP_MATH) {


### PR DESCRIPTION
There is not error message when cublesCreate failed in cuda_helper.h, add it.

![image](https://user-images.githubusercontent.com/22561442/71516345-6f681200-28e3-11ea-88ac-3d064b17a318.png)
