### PR TITLE
fix decay param in DecayAdagrad

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2098,7 +2098,8 @@ class DecayedAdagradOptimizer(Optimizer):
             },
             outputs={"ParamOut": param_and_grad[0],
                      "MomentOut": moment_acc},
-            attrs={"epsilon": self._epsilon},
+            attrs={"epsilon": self._epsilon,
+                   "decay": self._decay},
             stop_gradient=True)
 
         return decayed_adagrad_op


### PR DESCRIPTION
+ 修复了DecayAdagrad API接口中decay参数传入不生效问题

### 说明
+ 此decay参数在decay_adagrad_op中已实现，但api调用此op时未传入。
+ 此decay参数是固定的，不会在训练中更新