### PR TITLE
convert input vars' dtype for range op

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1176,10 +1176,16 @@ def range(start, end, step, dtype):
 
     if not isinstance(start, Variable):
         start = fill_constant([1], dtype, start)
+    elif convert_dtype(start.dtype) != dtype:
+        start = cast(x=start, dtype=dtype)
     if not isinstance(end, Variable):
         end = fill_constant([1], dtype, end)
+    elif convert_dtype(end.dtype) != dtype:
+        end = cast(x=end, dtype=dtype)
     if not isinstance(step, Variable):
         step = fill_constant([1], dtype, step)
+    elif convert_dtype(step.dtype) != dtype:
+        step = cast(x=step, dtype=dtype)
 
     out = helper.create_variable_for_type_inference(dtype=start.dtype)
 

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1178,10 +1178,12 @@ def range(start, end, step, dtype):
         start = fill_constant([1], dtype, start)
     elif convert_dtype(start.dtype) != dtype:
         start = cast(x=start, dtype=dtype)
+
     if not isinstance(end, Variable):
         end = fill_constant([1], dtype, end)
     elif convert_dtype(end.dtype) != dtype:
         end = cast(x=end, dtype=dtype)
+
     if not isinstance(step, Variable):
         step = fill_constant([1], dtype, step)
     elif convert_dtype(step.dtype) != dtype:

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1158,7 +1158,7 @@ def range(start, end, step, dtype):
                                  it is a 1-D Tensor with shape [1].
         step(float32 | float64 | int32 | int64 | Variable): Spacing between values. For any output out, this is the
                                   distance between two adjacent values, out[i+1] - out[i].
-        dtype(str): the data type of the output tensor, can be float32, float64, int32, int64.
+        dtype(str|core.VarDesc.VarType): the data type of the output tensor, can be float32, float64, int32, int64.
 
     Returns: a 1-D Tensor which is evenly spaced values within a given interval. Its data type is set by dtype.
     
@@ -1174,9 +1174,15 @@ def range(start, end, step, dtype):
     """
     helper = LayerHelper("range", **locals())
 
+    check_dtype(dtype, 'create data type',
+                ['float32', 'float64', 'int32', 'int64'], 'range')
+
+    dtype = convert_dtype(dtype)
     if not isinstance(start, Variable):
         start = fill_constant([1], dtype, start)
     elif convert_dtype(start.dtype) != dtype:
+        # make sure that start, end, step has the same dtype as
+        # `dtype`
         start = cast(x=start, dtype=dtype)
 
     if not isinstance(end, Variable):

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -2561,7 +2561,12 @@ class TestBook(LayerTest):
         with program_guard(fluid.default_main_program(),
                            fluid.default_startup_program()):
             layers.range(0, 10, 2, 'int32')
-            y = layers.range(0.1, 10.0, 0.2, 'float32')
+            layers.range(0.1, 10.0, 0.2, 'float32')
+            layers.range(0.1, 10.0, 0.2, 'float64')
+            start = layers.fill_constant(shape=[1], value=0.1, dtype="float32")
+            end = layers.fill_constant(shape=[1], value=10.0, dtype="float32")
+            step = layers.fill_constant(shape=[1], value=0.2, dtype="float32")
+            y = layers.range(start, end, step, 'float64')
             return y
 
     def make_spectral_norm(self):


### PR DESCRIPTION
There was an issue that if the input variables (`start`, `end`, `step`) of the `range` op hold different dtypes, an error occurs: 

```shell
------------------------------------------
Python Call Stacks (More useful to users):
------------------------------------------
  File "/home/mapingshuo/paddle_release_home/python-distribute/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2459, in append_op
    attrs=kwargs.get("attrs", None))
  File "/home/mapingshuo/paddle_release_home/python-distribute/lib/python2.7/site-packages/paddle/fluid/layer_helper.py", line 43, in append_op
    return self.main_program.current_block().append_op(*args, **kwargs)
  File "/home/mapingshuo/paddle_release_home/python-distribute/lib/python2.7/site-packages/paddle/fluid/layers/tensor.py", line 1202, in range
    outputs={'Out': [out]})
  File "demo.py", line 5, in <module>
    y = fluid.layers.range(0, x[0], 1, 'int64')

----------------------
Error Message Summary:
----------------------
PaddleCheckError: The DataType of range Op's duplicable Variable Start must be consistent. The current variable type is (int64_t), but the previous variable type is (int). at [/home/users/dongdaxiang/Paddle/paddle/fluid/framework/operator.cc:1151]
  [operator < range > error]
```

For details of this error, please see: https://github.com/PaddlePaddle/Paddle/issues/22004

This is because paddle requires the inputs of range op holds vars with the same dtype. I added a cast op to make them consistent.