### PR TITLE
Polish default error message & change cublas error hint to status code

### DIFF
--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -433,23 +433,23 @@ inline std::string build_ex_string(cublasStatus_t stat,
                                    const std::string& msg) {
   std::string err;
   if (stat == CUBLAS_STATUS_NOT_INITIALIZED) {
-    err = "CUBLAS: not initialized.";
+    err = "CUBLAS_STATUS_NOT_INITIALIZED";
   } else if (stat == CUBLAS_STATUS_ALLOC_FAILED) {
-    err = "CUBLAS: alloc failed.";
+    err = "CUBLAS_STATUS_ALLOC_FAILED";
   } else if (stat == CUBLAS_STATUS_INVALID_VALUE) {
-    err = "CUBLAS: invalid value.";
+    err = "CUBLAS_STATUS_INVALID_VALUE";
   } else if (stat == CUBLAS_STATUS_ARCH_MISMATCH) {
-    err = "CUBLAS: arch mismatch.";
+    err = "CUBLAS_STATUS_ARCH_MISMATCH";
   } else if (stat == CUBLAS_STATUS_MAPPING_ERROR) {
-    err = "CUBLAS: mapping error.";
+    err = "CUBLAS_STATUS_MAPPING_ERROR";
   } else if (stat == CUBLAS_STATUS_EXECUTION_FAILED) {
-    err = "CUBLAS: execution failed.";
+    err = "CUBLAS_STATUS_EXECUTION_FAILED";
   } else if (stat == CUBLAS_STATUS_INTERNAL_ERROR) {
-    err = "CUBLAS: internal error.";
+    err = "CUBLAS_STATUS_INTERNAL_ERROR";
   } else if (stat == CUBLAS_STATUS_NOT_SUPPORTED) {
-    err = "CUBLAS: not supported, ";
+    err = "CUBLAS_STATUS_NOT_SUPPORTED";
   } else if (stat == CUBLAS_STATUS_LICENSE_ERROR) {
-    err = "CUBLAS: license error.";
+    err = "CUBLAS_STATUS_LICENSE_ERROR";
   }
   return msg + "\n  [Hint: " + err + "]";
 }

--- a/paddle/fluid/platform/errors.h
+++ b/paddle/fluid/platform/errors.h
@@ -36,9 +36,14 @@ class ErrorSummary {
   ErrorSummary() {
     code_ = paddle::platform::error::LEGACY;
     msg_ =
-        "Paddle internal Check failed. (Please help us create a new issue, "
-        "here we need to find the developer to add a user friendly error "
-        "message)";
+        "An error occurred here. There is no accurate error hint for this "
+        "error yet. We are continuously in the process of increasing hint for "
+        "this kind of error check. It would be helpful if you could inform us "
+        "of how this conversion went by opening a github issue. And we will "
+        "resolve it with high priority.\n"
+        "  - New issue link: "
+        "https://github.com/PaddlePaddle/Paddle/issues/new\n"
+        "  - Recommended issue content: all error stack information";
   }
 
   // Note(chenweihang): Final deprecated constructor


### PR DESCRIPTION
This PR:
1. polish default error message to help users new issues easier
2. change cublas error hint to standard error code to help users search related error

- original:
```
13: ----------------------
13: Error Message Summary:
13: ----------------------
13: Error: Paddle internal Check failed. (Please help us create a new issue, here we need to find the developer to add a user friendly error message)
13:   [Hint: CUBLAS: not initialized.] at (/work/Paddle/paddle/fluid/platform/enforce_test.cc:280)
```
- new:
```
13: ----------------------
13: Error Message Summary:
13: ----------------------
13: Error: An error occurred here. There is no accurate error hint for this error yet. We are continuously in the process of increasing hint for this kind of error check. It would be helpful if you could inform us of how this conversion went by opening a github issue. And we will resolve it with high priority.
13:   - New issue link: https://github.com/PaddlePaddle/Paddle/issues/new
13:   - Recommended issue content: all error stack information
13:   [Hint: CUBLAS_STATUS_NOT_INITIALIZED] at (/work/paddle/paddle/fluid/platform/enforce_test.cc:280)
```