### PR TITLE
fix integer overflow in match_matrix

### DIFF
--- a/paddle/fluid/operators/match_matrix_tensor_op.cc
+++ b/paddle/fluid/operators/match_matrix_tensor_op.cc
@@ -206,7 +206,7 @@ class CPUMatchMatrixTensorOPKernel : public framework::OpKernel<T> {
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
       for (int t = 0; t < dim_t; t++) {
         size_t len_l = offset_l[b + 1] - offset_l[b];
-        sizt_t len_r = offset_r[b + 1] - offset_r[b];
+        size_t len_r = offset_r[b + 1] - offset_r[b];
         auto* top_data = out_data + top_offset[b] + t * len_l * len_r;
         const auto* l_t_data =
             bottom_l_trans_data + offset_l[b] * dim_t * dim_in + t * dim_in;

--- a/paddle/fluid/operators/match_matrix_tensor_op.cc
+++ b/paddle/fluid/operators/match_matrix_tensor_op.cc
@@ -174,7 +174,7 @@ class CPUMatchMatrixTensorOPKernel : public framework::OpKernel<T> {
     auto* tmp = ctx.Output<LoDTensor>("Tmp");
 
     int dim_t = ctx.Attr<int>("dim_t");
-    auto dim_in = x->dims()[1];
+    int64_t dim_in = x->dims()[1];
 
     const auto& offset_l = x->lod()[0];
     const auto& offset_r = y->lod()[0];
@@ -183,8 +183,8 @@ class CPUMatchMatrixTensorOPKernel : public framework::OpKernel<T> {
     size_t top_size = 0;
     top_offset.push_back(top_size);
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
-      auto len_l = offset_l[b + 1] - offset_l[b];
-      auto len_r = offset_r[b + 1] - offset_r[b];
+      size_t len_l = offset_l[b + 1] - offset_l[b];
+      size_t len_r = offset_r[b + 1] - offset_r[b];
       top_size += dim_t * len_l * len_r;
       top_offset.push_back(top_size);
     }
@@ -205,8 +205,8 @@ class CPUMatchMatrixTensorOPKernel : public framework::OpKernel<T> {
 
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
       for (int t = 0; t < dim_t; t++) {
-        auto len_l = offset_l[b + 1] - offset_l[b];
-        auto len_r = offset_r[b + 1] - offset_r[b];
+        size_t len_l = offset_l[b + 1] - offset_l[b];
+        sizt_t len_r = offset_r[b + 1] - offset_r[b];
         auto* top_data = out_data + top_offset[b] + t * len_l * len_r;
         const auto* l_t_data =
             bottom_l_trans_data + offset_l[b] * dim_t * dim_in + t * dim_in;
@@ -235,7 +235,7 @@ class CPUMatchMatrixTensorOPGradKernel : public framework::OpKernel<T> {
     auto* tmp = ctx.Input<LoDTensor>("Tmp");
 
     int dim_t = ctx.Attr<int>("dim_t");
-    auto dim_in = x->dims()[1];
+    int64_t dim_in = x->dims()[1];
 
     const auto& offset_l = x->lod()[0];
     const auto& offset_r = y->lod()[0];
@@ -243,8 +243,8 @@ class CPUMatchMatrixTensorOPGradKernel : public framework::OpKernel<T> {
     size_t top_size = 0;
     top_offset.push_back(top_size);
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
-      auto len_l = offset_l[b + 1] - offset_l[b];
-      auto len_r = offset_r[b + 1] - offset_r[b];
+      size_t len_l = offset_l[b + 1] - offset_l[b];
+      size_t len_r = offset_r[b + 1] - offset_r[b];
       top_size += dim_t * len_l * len_r;
       top_offset.push_back(top_size);
     }
@@ -271,8 +271,8 @@ class CPUMatchMatrixTensorOPGradKernel : public framework::OpKernel<T> {
 
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
       for (int t = 0; t < dim_t; t++) {
-        auto len_l = offset_l[b + 1] - offset_l[b];
-        auto len_r = offset_r[b + 1] - offset_r[b];
+        size_t len_l = offset_l[b + 1] - offset_l[b];
+        size_t len_r = offset_r[b + 1] - offset_r[b];
 
         for (size_t i = 0; i < len_l; i++) {
           for (size_t j = 0; j < len_r; j++) {

--- a/paddle/fluid/operators/match_matrix_tensor_op.cc
+++ b/paddle/fluid/operators/match_matrix_tensor_op.cc
@@ -56,8 +56,8 @@ void MatchMatrixTensorOP::InferShape(framework::InferShapeContext* ctx) const {
   PADDLE_ENFORCE_EQ(w_dims[2], y_dims[1],
                     "W 's shape must satisfy: W[2] = Y[1]");
 
-  int out_dim_0 = -1;
-  int tmp_dim_0 = -1;
+  int64_t out_dim_0 = -1;
+  int64_t tmp_dim_0 = -1;
   if (ctx->IsRuntime()) {
     framework::Variable* x_var =
         boost::get<framework::Variable*>(ctx->GetInputVarPtrs("X")[0]);
@@ -86,8 +86,8 @@ void MatchMatrixTensorOP::InferShape(framework::InferShapeContext* ctx) const {
 
     out_dim_0 = 0;
     for (size_t i = 1; i < x_lod_0.size(); i++) {
-      int x_len = x_lod_0[i] - x_lod_0[i - 1];
-      int y_len = y_lod_0[i] - y_lod_0[i - 1];
+      int64_t x_len = x_lod_0[i] - x_lod_0[i - 1];
+      int64_t y_len = y_lod_0[i] - y_lod_0[i - 1];
       out_dim_0 += (x_len * y_len);
     }
     out_dim_0 *= dim_t;
@@ -174,17 +174,17 @@ class CPUMatchMatrixTensorOPKernel : public framework::OpKernel<T> {
     auto* tmp = ctx.Output<LoDTensor>("Tmp");
 
     int dim_t = ctx.Attr<int>("dim_t");
-    int dim_in = x->dims()[1];
+    auto dim_in = x->dims()[1];
 
     const auto& offset_l = x->lod()[0];
     const auto& offset_r = y->lod()[0];
 
     std::vector<size_t> top_offset;
-    int top_size = 0;
+    size_t top_size = 0;
     top_offset.push_back(top_size);
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
-      int len_l = offset_l[b + 1] - offset_l[b];
-      int len_r = offset_r[b + 1] - offset_r[b];
+      auto len_l = offset_l[b + 1] - offset_l[b];
+      auto len_r = offset_r[b + 1] - offset_r[b];
       top_size += dim_t * len_l * len_r;
       top_offset.push_back(top_size);
     }
@@ -205,8 +205,8 @@ class CPUMatchMatrixTensorOPKernel : public framework::OpKernel<T> {
 
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
       for (int t = 0; t < dim_t; t++) {
-        int len_l = offset_l[b + 1] - offset_l[b];
-        int len_r = offset_r[b + 1] - offset_r[b];
+        auto len_l = offset_l[b + 1] - offset_l[b];
+        auto len_r = offset_r[b + 1] - offset_r[b];
         auto* top_data = out_data + top_offset[b] + t * len_l * len_r;
         const auto* l_t_data =
             bottom_l_trans_data + offset_l[b] * dim_t * dim_in + t * dim_in;
@@ -235,16 +235,16 @@ class CPUMatchMatrixTensorOPGradKernel : public framework::OpKernel<T> {
     auto* tmp = ctx.Input<LoDTensor>("Tmp");
 
     int dim_t = ctx.Attr<int>("dim_t");
-    int dim_in = x->dims()[1];
+    auto dim_in = x->dims()[1];
 
     const auto& offset_l = x->lod()[0];
     const auto& offset_r = y->lod()[0];
-    std::vector<int> top_offset;
-    int top_size = 0;
+    std::vector<size_t> top_offset;
+    size_t top_size = 0;
     top_offset.push_back(top_size);
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
-      int len_l = offset_l[b + 1] - offset_l[b];
-      int len_r = offset_r[b + 1] - offset_r[b];
+      auto len_l = offset_l[b + 1] - offset_l[b];
+      auto len_r = offset_r[b + 1] - offset_r[b];
       top_size += dim_t * len_l * len_r;
       top_offset.push_back(top_size);
     }
@@ -271,11 +271,11 @@ class CPUMatchMatrixTensorOPGradKernel : public framework::OpKernel<T> {
 
     for (size_t b = 0; b < x->lod()[0].size() - 1; b++) {
       for (int t = 0; t < dim_t; t++) {
-        int len_l = offset_l[b + 1] - offset_l[b];
-        int len_r = offset_r[b + 1] - offset_r[b];
+        auto len_l = offset_l[b + 1] - offset_l[b];
+        auto len_r = offset_r[b + 1] - offset_r[b];
 
-        for (int i = 0; i < len_l; i++) {
-          for (int j = 0; j < len_r; j++) {
+        for (size_t i = 0; i < len_l; i++) {
+          for (size_t j = 0; j < len_r; j++) {
             auto diff =
                 top_diff[top_offset[b] + t * len_l * len_r + i * len_r + j];
             auto* l_trans_data = bottom_l_trans_data +
@@ -327,11 +327,7 @@ REGISTER_OPERATOR(match_matrix_tensor_grad, ops::MatchMatrixTensorOpGrad);
 REGISTER_OP_CPU_KERNEL(match_matrix_tensor,
                        ops::CPUMatchMatrixTensorOPKernel<
                            paddle::platform::CPUDeviceContext, float>);
-//     ops::CPUMatchMatrixTensorOPKernel<paddle::platform::CPUDeviceContext,
-//                                       double>
 
 REGISTER_OP_CPU_KERNEL(match_matrix_tensor_grad,
                        ops::CPUMatchMatrixTensorOPGradKernel<
                            paddle::platform::CPUDeviceContext, float>);
-//     ops::CPUMatchMatrixTensorOPGradKernel<paddle::platform::CPUDeviceContext,
-//                                           double>


### PR DESCRIPTION
+ 修复了op在输入lod值过大时integer overflow问题。

### BUG复现
match_matrix_tensor_op.cc中MatchMatrixTensorOP::InferShape在处理生成`out_dim_0`时存在integer overflow，精心构造out张量的tensor shape

在Compute时memset out_data的size比较小，可导致Compute调用`call_gemm_with_lda`时由于使用到out_data数据而造成崩溃出错

例子：精心设置X的dims为{1789569713, 1}，lods为{1, 1073741823, 1789569713}，Y的dims为{6, 3}，lods为{1, 3, 6}，dim_t属性为1，这样在计算out_dim_0时由于整型溢出最终获得值为18


### 测试用例
将`test_match_matrix_tensor_op.py`代码改为如下：
```
class TestMatchMatrixTensorOpCase4(TestMatchMatrixTensorOp):
    def set_data(self):
        ix, iy, h, dim_t = [5, 9, 32, 1]
        x_lod = [[1, 2, 2]]
        y_lod = [[3, 2, 4]]
        self.init_data(ix, x_lod, iy, y_lod, h, dim_t)
    def test_api(self):
        x_lod_tensor = fluid.layers.data(name='x', shape=[1], lod_level=1)
        y_lod_tensor = fluid.layers.data(name='y', shape=[1], lod_level=1)
        out, out_tmp = fluid.contrib.match_matrix_tensor(
            x=x_lod_tensor, y=y_lod_tensor, channel_num=1)

        place = fluid.CPUPlace()
        x_data = np.random.rand(1789569713, 1).astype('float32')
        y_data = np.random.rand(6, 1).astype('float32')
        x = fluid.create_lod_tensor(x_data, [[1073741823, 715827890]], place)
        y = fluid.create_lod_tensor(y_data, [[2, 4]], place)

        exe = fluid.Executor(place=place)
        exe.run(fluid.default_startup_program())
        ret = exe.run(feed={'x': x,
                            'y': y},
                      fetch_list=[out],
                      return_numpy=False)
```
