### PR TITLE
fix bug of checking op desc: not DUPLICABLE but DISPENSABLE.

### DIFF
--- a/tools/check_op_desc.py
+++ b/tools/check_op_desc.py
@@ -65,7 +65,7 @@ def diff_vars(origin_vars, new_vars):
         var_deleted_error_massage.append(var_name)
 
     for var_name in vars_name_only_in_new:
-        if not new_vars.get(var_name).get(DUPLICABLE):
+        if not new_vars.get(var_name).get(DISPENSABLE):
             error, var_error = True, True
             var_added_error_massage.append(var_name)
 


### PR DESCRIPTION
The added Input of OP must be dispensable. Fix bug in check_op_desc.py.

This bug is found in PR https://github.com/PaddlePaddle/Paddle/pull/21420
![image](https://user-images.githubusercontent.com/33742067/71650163-3c90a480-2d4f-11ea-913f-65d24b574f8d.png)

![image](https://user-images.githubusercontent.com/33742067/71650153-2f73b580-2d4f-11ea-9cc1-4b59ff912c20.png)
