### PR TITLE
fix test_conv2d_ngraph for grad diff and remove unused var for pool_with_index op

### DIFF
--- a/python/paddle/fluid/tests/unittests/ngraph/test_conv2d_ngraph_op.py
+++ b/python/paddle/fluid/tests/unittests/ngraph/test_conv2d_ngraph_op.py
@@ -23,30 +23,35 @@ class TestNGRAPHDepthwiseConv(TestDepthwiseConv):
     def init_test_case(self):
         super(TestNGRAPHDepthwiseConv, self).init_test_case()
         self.use_cuda = False
+        self.dtype = np.float32
 
 
 class TestNGRAPHDepthwiseConv2(TestDepthwiseConv2):
     def init_test_case(self):
         super(TestNGRAPHDepthwiseConv2, self).init_test_case()
         self.use_cuda = False
+        self.dtype = np.float32
 
 
 class TestNGRAPHDepthwiseConv3(TestDepthwiseConv3):
     def init_test_case(self):
         super(TestNGRAPHDepthwiseConv3, self).init_test_case()
         self.use_cuda = False
+        self.dtype = np.float32
 
 
 class TestNGRAPHDepthwiseConvWithDilation(TestDepthwiseConvWithDilation):
     def init_test_case(self):
         super(TestNGRAPHDepthwiseConvWithDilation, self).init_test_case()
         self.use_cuda = False
+        self.dtype = np.float32
 
 
 class TestNGRAPHDepthwiseConvWithDilation2(TestDepthwiseConvWithDilation2):
     def init_test_case(self):
         super(TestNGRAPHDepthwiseConvWithDilation2, self).init_test_case()
         self.use_cuda = False
+        self.dtype = np.float32
 
 
 del TestDepthwiseConv, TestDepthwiseConv2, TestDepthwiseConv3, TestDepthwiseConvWithDilation, TestDepthwiseConvWithDilation2


### PR DESCRIPTION
[CI failed ](http://ci.paddlepaddle.org/viewLog.html?buildId=259669&buildTypeId=Paddle_PrCiNight&tab=buildLog)

- fix test_conv2d_ngraph for grad diff
```
 test_conv2d_ngraph_op failed
[04:39:36] :	 [Step 1/1]  ........................................F.F.
[04:39:36] :	 [Step 1/1] ======================================================================
[04:39:36] :	 [Step 1/1] FAIL: test_check_grad (test_conv2d_op.TestWithStride)
[04:39:36] :	 [Step 1/1] ----------------------------------------------------------------------
[04:39:36] :	 [Step 1/1] Traceback (most recent call last):
[04:39:36] :	 [Step 1/1]   File "../test_conv2d_op.py", line 366, in test_check_grad
[04:39:36] :	 [Step 1/1]     check_dygraph=(self.use_mkldnn == False))
[04:39:36] :	 [Step 1/1]   File "../op_test.py", line 1219, in check_grad_with_place
[04:39:36] :	 [Step 1/1]     "Gradient Check On %s" % str(place))
[04:39:36] :	 [Step 1/1]   File "../op_test.py", line 1143, in _assert_is_close
[04:39:36] :	 [Step 1/1]     self.assertLessEqual(max_diff, max_relative_error, err_msg())
[04:39:36] :	 [Step 1/1] AssertionError: Gradient Check On CPUPlace Variable Filter max gradient diff 0.332759 over limit 0.020000, the first error element is 0, expected 0.041582, but got 0.044246
[04:39:36] :	 [Step 1/1] 
[04:39:36] :	 [Step 1/1] ======================================================================
[04:39:36] :	 [Step 1/1] FAIL: test_check_grad_no_input (test_conv2d_op.TestWithStride)
[04:39:36] :	 [Step 1/1] ----------------------------------------------------------------------
[04:39:36] :	 [Step 1/1] Traceback (most recent call last):
[04:39:36] :	 [Step 1/1]   File "../test_conv2d_op.py", line 389, in test_check_grad_no_input
[04:39:36] :	 [Step 1/1]     check_dygraph=(self.use_mkldnn == False))
[04:39:36] :	 [Step 1/1]   File "../op_test.py", line 1219, in check_grad_with_place
[04:39:36] :	 [Step 1/1]     "Gradient Check On %s" % str(place))
[04:39:36] :	 [Step 1/1]   File "../op_test.py", line 1143, in _assert_is_close
[04:39:36] :	 [Step 1/1]     self.assertLessEqual(max_diff, max_relative_error, err_msg())
[04:39:36] :	 [Step 1/1] AssertionError: Gradient Check On CPUPlace Variable Filter max gradient diff 0.657939 over limit 0.005000, the first error element is 0, expected 0.037855, but got 0.035458
```
- remove unused var for pool_with_index op
```
[19:08:35]	[Step 1/1] Error Message Summary:
[19:08:35]	[Step 1/1] ----------------------
[19:08:35]	[Step 1/1] PermissionDeniedError: Unused input variables check failed: Operator max_pool3d_with_index_grad has input(s) not uesed: X, please make sure it(they) is(are) needed. If not, remove it(them) from inputs of the operator; if yes, register NoNeedBufferVarsInference or add the operator to white list in unused_var_check.cc. See more details at [https://github.com/PaddlePaddle/Paddle/wiki/OP-Should-Not-Have-Unused-Input]
[19:08:35]	[Step 1/1]   [Hint: Expected unsed_input_var_names.size() == 0, but received unsed_input_var_names.size():1 != 0:0.] at (/paddle/paddle/fluid/framework/unused_var_check.cc:125)
[19:08:35]	[Step 1/1]   [operator < max_pool3d_with_index_grad > error]
```