### PR TITLE
update layers used in transformer dygraph model, test=develop

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -2537,7 +2537,7 @@ class Conv2DTranspose(layers.Layer):
             dtype=input.dtype)
         self._helper.append_op(
             type=self._op_type,
-            inputs=attrs,
+            inputs=inputs,
             outputs={'Output': pre_bias},
             attrs=attrs)
 

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1867,9 +1867,22 @@ class GRUUnit(layers.Layer):
             attr=bias_attr, shape=bias_size, dtype=dtype, is_bias=True)
 
     def forward(self, input, hidden):
-        inputs = {'Input': input, 'HiddenPrev': hidden, 'Weight': self.weight}
+        inputs = {
+            'Input': [input],
+            'HiddenPrev': [hidden],
+            'Weight': [self.weight]
+        }
         if self.bias:
-            inputs['Bias'] = self.bias
+            inputs['Bias'] = [self.bias]
+        attrs = {
+            'activation': self.activation,
+            'gate_activation': self.gate_activation,
+        }
+
+        if in_dygraph_mode():
+            outs = core.ops.gru_unit(inputs, attrs)
+            return outs['Hidden'][0], outs['ResetHiddenPrev'][0], outs['Gate'][
+                0]
 
         gate = self._helper.create_variable_for_type_inference(self._dtype)
         reset_hidden_pre = self._helper.create_variable_for_type_inference(

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -19,7 +19,7 @@ from .. import core
 from ..layers import utils
 from ..dygraph import dygraph_utils
 from . import layers
-from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer_, _varbase_creator
+from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer, _varbase_creator
 from ..param_attr import ParamAttr
 from ..initializer import Normal, Constant, NumpyArrayInitializer
 from .. import unique_name
@@ -1372,10 +1372,11 @@ class BatchNorm(layers.Layer):
         }
 
         if in_dygraph_mode():
-            saved_mean = _varbase_creator(dtype=self._dtype, stop_gradient=True)
-            saved_variance = _varbase_creator(
-                dtype=self._dtype, stop_gradient=True)
+            attrs['is_test'] = not _dygraph_tracer()._train_mode
+            saved_mean = _varbase_creator(dtype=self._dtype)
+            saved_variance = _varbase_creator(dtype=self._dtype)
             batch_norm_out = _varbase_creator(dtype=self._dtype)
+            batch_norm_out.stop_gradient = False
             # inplace is not supported currently
         else:
             saved_mean = self._helper.create_variable_for_type_inference(

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -567,19 +567,15 @@ def _varbase_creator(type=core.VarDesc.VarType.LOD_TENSOR,
                      shape=None,
                      dtype=None,
                      persistable=None,
-                     stop_gradient=None,
                      **kwargs):
     if dtype is not None:
         if not isinstance(dtype, core.VarDesc.VarType):
             dtype = convert_np_dtype_to_dtype_(dtype)
 
-    var = core.VarBase(dtype if dtype else core.VarDesc.VarType.FP32,
-                       list(shape) if shape else [], name, type
-                       if type else core.VarDesc.VarType.LOD_TENSOR, True
-                       if persistable else False)
-    if stop_gradient is not None:
-        var.stop_gradient = stop_gradient
-    return var
+    return core.VarBase(dtype if dtype else core.VarDesc.VarType.FP32,
+                        list(shape) if shape else [], name, type
+                        if type else core.VarDesc.VarType.LOD_TENSOR, True
+                        if persistable else False)
 
 
 class VariableMetaClass(type):

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -567,15 +567,19 @@ def _varbase_creator(type=core.VarDesc.VarType.LOD_TENSOR,
                      shape=None,
                      dtype=None,
                      persistable=None,
+                     stop_gradient=None,
                      **kwargs):
     if dtype is not None:
         if not isinstance(dtype, core.VarDesc.VarType):
             dtype = convert_np_dtype_to_dtype_(dtype)
 
-    return core.VarBase(dtype if dtype else core.VarDesc.VarType.FP32,
-                        list(shape) if shape else [], name, type
-                        if type else core.VarDesc.VarType.LOD_TENSOR, True
-                        if persistable else False)
+    var = core.VarBase(dtype if dtype else core.VarDesc.VarType.FP32,
+                       list(shape) if shape else [], name, type
+                       if type else core.VarDesc.VarType.LOD_TENSOR, True
+                       if persistable else False)
+    if stop_gradient is not None:
+        var.stop_gradient = stop_gradient
+    return var
 
 
 class VariableMetaClass(type):

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7850,6 +7850,11 @@ def log(x, name=None):
             res_val, = exe.run(fluid.default_main_program(), feed={'x':x_i}, fetch_list=[res])
             print(res_val) # [[0.], [0.6931472]]
     """
+    inputs = {'X': [x]}
+    if in_dygraph_mode():
+        outs = core.ops.log(inputs)
+        return outs['Out'][0]
+
     helper = LayerHelper('log', **locals())
     dtype = helper.input_dtype(input_param_name='x')
     out = helper.create_variable_for_type_inference(dtype)
@@ -7885,6 +7890,11 @@ def relu(x, name=None):
                 # [[0.  0. ]
                 #  [1.  2.6]]
 """
+    inputs = {'X': [x]}
+    if in_dygraph_mode():
+        outs = core.ops.relu(inputs)
+        return outs['Out'][0]
+
     helper = LayerHelper('relu', **locals())
     dtype = helper.input_dtype(input_param_name='x')
     out = helper.create_variable_for_type_inference(dtype)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -8485,13 +8485,13 @@ def pad2d(input,
     """
     attrs = {'mode': mode, 'pad_value': pad_value, 'data_format': data_format}
     inputs = {'X': [input]}
+    if isinstance(paddings, Variable):
+        inputs['Paddings'] = [paddings]
+        attrs['paddings'] = []
+    else:
+        attrs['paddings'] = paddings
+
     if in_dygraph_mode():
-        if isinstance(paddings, (list, tuple)):
-            attrs['paddings'] = paddings
-        else:
-            raise TypeError(
-                "The type of 'paddings' in pad2d must be list[int] in Dygraph mode, but "
-                "received %s." % type(paddings))
         outs = core.ops.pad2d(inputs, attrs)
         return outs['Out'][0]
 
@@ -8502,12 +8502,6 @@ def pad2d(input,
 
     dtype = helper.input_dtype(input_param_name='input')
     out = helper.create_variable_for_type_inference(dtype)
-
-    if isinstance(paddings, Variable):
-        inputs['Paddings'] = paddings
-        attrs['paddings'] = []
-    else:
-        attrs['paddings'] = paddings
 
     helper.append_op(
         type='pad2d', inputs=inputs, outputs={"Out": out}, attrs=attrs)

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -569,7 +569,7 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
     else:
         attrs['str_value'] = str(float(value))
 
-    if False and in_dygraph_mode():
+    if in_dygraph_mode():
         if isinstance(shape, (list, tuple)):
             contain_var = _contain_var(shape)
             if contain_var:
@@ -582,7 +582,8 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None):
                 "The type of 'shape' in fill_constant must be list[int] or tuple(int) in Dygraph mode, but "
                 "received %s." % type(shape))
         if out is None:
-            _varbase_creator(dtype=dtype)
+            out = _varbase_creator(dtype=dtype)
+        attrs['dtype'] = out.dtype
         outputs = {'Out': [out]}
         outs = core.ops.fill_constant({}, attrs, outputs)
         out.stop_gradient = True

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -27,6 +27,8 @@ from test_imperative_base import new_program_scope
 from utils import DyGraphProgramDescTracerTestHelper, is_equal_program
 from paddle.fluid.dygraph import TracedLayer
 
+#NOTE(zhiqiu): run with FLAGS_cudnn_deterministic=1
+
 batch_size = 8
 train_parameters = {
     "input_size": [3, 224, 224],


### PR DESCRIPTION
As the title, this PR updates several layers used in some dygraph models, include 
`transformer`,  `ocr_recognition`, `reinforcement_learning`, `se_resnet`, `se_resnet`, `cycle_gan.`

Before this PR, in dygraph mode, the layers reuse the same logic with static graph, which slow down the execution efficiency.
After this PR, in dygraph mode, these layers use core.ops.xx directly in order to execute more efficiently.