### PR TITLE
remove unused function find_fluid_thirdparties from generic.cmake

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -120,20 +120,6 @@ function(common_link TARGET_NAME)
   endif()
 endfunction()
 
-# find all third_party modules is used for paddle static library
-# for reduce the dependency when building the inference libs.
-set_property(GLOBAL PROPERTY FLUID_THIRD_PARTY)
-function(find_fluid_thirdparties TARGET_NAME)
-  get_filename_component(__target_path ${TARGET_NAME} ABSOLUTE)
-  string(REGEX REPLACE "^${PADDLE_SOURCE_DIR}/" "" __target_path ${__target_path})
-  string(FIND "${__target_path}" "third_party" pos)
-  if(pos GREATER 1)
-    get_property(fluid_ GLOBAL PROPERTY FLUID_THIRD_PARTY)
-    set(fluid_third_partys ${fluid_third_partys} ${TARGET_NAME})
-    set_property(GLOBAL PROPERTY FLUID_THIRD_PARTY "${fluid_third_partys}")
-  endif()
-endfunction(find_fluid_thirdparties)
-
 function(merge_static_libs TARGET_NAME)
   set(libs ${ARGN})
   list(REMOVE_DUPLICATES libs)

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -23,10 +23,6 @@ endif()
 
 get_property(fluid_modules GLOBAL PROPERTY FLUID_MODULES)
 get_property(cuda_modules GLOBAL PROPERTY CUDA_MODULES)
-get_property(fluid_third_partys GLOBAL PROPERTY FLUID_THRID_PARTYS)
-if (WIN32)
-list(APPEND fluid_third_partys gflags glog protobuf cblas)
-endif(WIN32)
 
 # paddle_fluid_origin exclude inference api interface
 if(WIN32)


### PR DESCRIPTION
remove unused function find_fluid_thirdparties from generic.cmake