### PR TITLE
Add multiple quantize operators fuse

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1658,6 +1658,24 @@ PDNode *patterns::DequantAny::operator()() {
   return dequant_out;
 }
 
+PDNode *patterns::MultipleQuantize::operator()() {
+  auto *prev_op = pattern->NewNode(prev_op_repr())->assert_is_op();
+
+  auto *prev_out = pattern->NewNode(prev_out_repr())->AsOutput();
+
+  // find operators with more than one quantization operator as output
+  prev_out->assert_more([&](Node *node) {
+    int counter = std::count_if(
+        node->outputs.begin(), node->outputs.end(),
+        [&](Node const *iter) { return iter->Name() == "quantize"; });
+    return (counter > 1);
+  });
+
+  prev_op->LinksTo({prev_out});
+
+  return prev_out;
+}
+
 // a -> transpose_op(1) -> transpose_out_a -> flatten_op(1) -> flatten_out_a
 // b -> transpose_op(2) -> transpose_out_b -> flatten_op(2) -> flatten_out_b
 // ...

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1659,19 +1659,16 @@ PDNode *patterns::DequantAny::operator()() {
 }
 
 PDNode *patterns::MultipleQuantize::operator()() {
-  auto *prev_op = pattern->NewNode(prev_op_repr())->assert_is_op();
-
   auto *prev_out = pattern->NewNode(prev_out_repr())->AsOutput();
 
-  // find operators with more than one quantization operator as output
+  // find nodes that are inputs to quantize operators
   prev_out->assert_more([&](Node *node) {
     int counter = std::count_if(
-        node->outputs.begin(), node->outputs.end(),
-        [&](Node const *iter) { return iter->Name() == "quantize"; });
+        node->outputs.begin(), node->outputs.end(), [&](Node const *iter) {
+          return iter && iter->IsOp() && iter->Op()->Type() == "quantize";
+        });
     return (counter > 1);
   });
-
-  prev_op->LinksTo({prev_out});
 
   return prev_out;
 }

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -1011,7 +1011,6 @@ struct MultipleQuantize : public PatternBase {
       : PatternBase(pattern, name_scope, "multiple_quantize") {}
   PDNode* operator()();
 
-  PATTERN_DECL_NODE(prev_op);
   PATTERN_DECL_NODE(prev_out);
 };
 

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -1004,6 +1004,17 @@ struct DequantAny : public PatternBase {
   PATTERN_DECL_NODE(next_op);
 };
 
+// anyOp + more then one quantize op
+// This pattern is used for squashing multiple quantize with the same scale.
+struct MultipleQuantize : public PatternBase {
+  MultipleQuantize(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "multiple_quantize") {}
+  PDNode* operator()();
+
+  PATTERN_DECL_NODE(prev_op);
+  PATTERN_DECL_NODE(prev_out);
+};
+
 struct TransposeFlattenConcat : public PatternBase {
   TransposeFlattenConcat(PDPattern* pattern, const std::string& name_scope)
       : PatternBase(pattern, name_scope, "transpose_flatten_concat") {}

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -228,6 +228,49 @@ void CPUQuantizeSquashPass::FcDequantSquash(Graph* graph) const {
                   found_fc_dequant_squash_count);
 }
 
+void CPUQuantizeSquashPass::MultipleQuantizeSquash(Graph* graph) const {
+  GraphPatternDetector gpd;
+  patterns::MultipleQuantize multiple_quantize_pattern{gpd.mutable_pattern(),
+                                                       "multiple_quantize"};
+  multiple_quantize_pattern();
+
+  int found_multiple_quantize_squash_count = 0;
+  int removed_quantize = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    VLOG(4) << "fuse multiple quantize ops";
+
+    GET_IR_NODE_FROM_SUBGRAPH(prev_op, prev_op, multiple_quantize_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(prev_out, prev_out, multiple_quantize_pattern);
+
+    auto* first_quant_op =
+        *(std::find_if(prev_out->outputs.begin(), prev_out->outputs.end(),
+                       [&](Node* node) { return node->Name() == "quantize"; }));
+    auto* first_quant_out = first_quant_op->outputs[0];
+    float scale = first_quant_op->Op()->GetAttrIfExists<float>("Scale");
+
+    for (int iter = prev_out->outputs.size() - 1; iter >= 0; iter--) {
+      auto quant_op = prev_out->outputs[iter];
+      if (quant_op->Name() == "quantize" &&
+          quant_op->id() != first_quant_op->id() &&
+          quant_op->Op()->GetAttrIfExists<float>("Scale") == scale) {
+        auto quant_out = quant_op->outputs[0];
+        auto last_op = quant_out->outputs[0];
+        last_op->Op()->SetInput(
+            "Input", std::vector<std::string>({first_quant_out->Name()}));
+        IR_NODE_LINK_TO(first_quant_out, last_op);
+        GraphSafeRemoveNodes(graph, {quant_out});
+        GraphSafeRemoveNodes(graph, {quant_op});
+        removed_quantize++;
+      }
+    }
+    found_multiple_quantize_squash_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_multiple_quantize_squash_count);
+  PrettyLogDetail("---    removed %d quantize op", removed_quantize);
+}
+
 void CPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   PADDLE_ENFORCE_NOT_NULL(
       graph,
@@ -240,6 +283,7 @@ void CPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   DequantQuantSquash(graph, &nodes_keep_counter);
   ConvDequantSquash(graph);
   FcDequantSquash(graph);
+  MultipleQuantizeSquash(graph);
 }
 
 }  // namespace ir

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.h
@@ -65,6 +65,11 @@ class CPUQuantizeSquashPass : public FusePassBase {
   */
   void FcDequantSquash(Graph* graph) const;
 
+  /*
+  *  Squash quantize if several quatize ops have the same scale
+  */
+  void MultipleQuantizeSquash(Graph* graph) const;
+
   const std::string name_scope_{"squash"};
 };
 


### PR DESCRIPTION
It is pass that fuses multiple quantize operators with the same scale into a single one quantize operator.
In Ernie model it removes 24 quantize operators.


Graph below explains the transformation.
![image](https://user-images.githubusercontent.com/33838455/71689739-172d8600-2da3-11ea-9f16-87c85ca953b6.png)
