### PR TITLE
Hotfix to MKL-DNN pool2d tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -26,6 +26,9 @@ def create_test_mkldnn_use_ceil_class(parent):
         def init_ceil_mode(self):
             self.ceil_mode = True
 
+        def init_data_type(self):
+            self.dtype = np.float32
+
     cls_name = "{0}_{1}".format(parent.__name__, "MKLDNNCeilModeCast")
     TestMKLDNNPool2DUseCeilCase.__name__ = cls_name
     globals()[cls_name] = TestMKLDNNPool2DUseCeilCase
@@ -40,6 +43,9 @@ def create_test_mkldnn_class(parent):
     class TestMKLDNNCase(parent):
         def init_kernel_type(self):
             self.use_mkldnn = True
+
+        def init_data_type(self):
+            self.dtype = np.float32
 
     cls_name = "{0}_{1}".format(parent.__name__, "MKLDNNOp")
     TestMKLDNNCase.__name__ = cls_name
@@ -77,6 +83,9 @@ class TestAsymPad(TestPool2D_Op):
 
     def init_global_pool(self):
         self.global_pool = False
+
+    def init_data_type(self):
+        self.dtype = np.float32
 
 
 class TestAsymPadCase1(TestAsymPad):


### PR DESCRIPTION
test_pool2d_mkldnn_op.py wasn't running MKL-DNN kernels.
This PR will make CI_Coverage pass in https://github.com/PaddlePaddle/Paddle/pull/21747