### PR TITLE
fix warning in test_install_check.py

### DIFF
--- a/python/paddle/fluid/install_check.py
+++ b/python/paddle/fluid/install_check.py
@@ -78,7 +78,6 @@ def run_check():
                 with unique_name.guard():
                     build_strategy = compiler.BuildStrategy()
                     build_strategy.enable_inplace = True
-                    build_strategy.memory_optimize = True
                     inp = layers.data(name="inp", shape=[2, 2])
                     simple_layer = SimpleLayer("simple_layer")
                     out = simple_layer(inp)


### PR DESCRIPTION
When user check paddle installation use fluid.install_check.run_check(), it will show warning message "Cross op memory reuse strategy is enabled, when build_strategy.memory_optimize = True or garbage collection strategy is disabled, which is not recommended". This PR fix it.

before:
![image](https://user-images.githubusercontent.com/16509038/71775637-d5792700-2fbe-11ea-8be9-6438870e3723.png)

after:
![image](https://user-images.githubusercontent.com/16509038/71777077-4546dc00-2fd6-11ea-98ba-6e729bb587a9.png)

