### PR TITLE
remove force_init_on_cpu from APIs about comparison

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -20,7 +20,6 @@ from .tensor import assign, cast, fill_constant
 from .. import core
 from ..framework import Program, Variable, Operator
 from ..layer_helper import LayerHelper, unique_name
-from ..initializer import force_init_on_cpu
 from .nn import logical_and, logical_not, logical_or
 from .utils import assert_same_structure, map_structure
 import numpy
@@ -1340,8 +1339,6 @@ def less_than(x, y, force_cpu=None, cond=None):
     attrs = dict()
     if force_cpu is not None:
         attrs['force_cpu'] = force_cpu
-    elif force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
 
     helper.append_op(
         type='less_than',
@@ -1384,8 +1381,6 @@ def less_equal(x, y, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
 
     helper.append_op(
         type='less_equal',
@@ -1427,8 +1422,6 @@ def greater_than(x, y, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
 
     helper.append_op(
         type='greater_than',
@@ -1472,8 +1465,6 @@ def greater_equal(x, y, cond=None):
         cond.stop_gradient = True
 
     attrs = dict()
-    if force_init_on_cpu():
-        attrs['force_cpu'] = force_init_on_cpu()
 
     helper.append_op(
         type='greater_equal',


### PR DESCRIPTION
`force_init_on_cpu` returns global flag `_force_init_on_cpu` that has default value `False`. This flag is set to `True` only when `init_on_cpu` is used, for example:
```python
with init_on_cpu():
    out = fluid.layers.less_than(x, y)
```
However `force_init_on_cpu` is redundant for `less_than`, `less_equal`, `greater_than` and `greater_equal`. Because the attribute `force_cpu` of the compare Op is set to `True` by default.
https://github.com/PaddlePaddle/Paddle/blob/b0b27ff699fb80da055f1910a73fa1baee4dd04a/python/paddle/fluid/layers/control_flow.py#L1387-L1388