### PR TITLE
fix test_bilinear_tensor_product_op timeout

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
@@ -23,9 +23,9 @@ class TestBilinearTensorProductOp(OpTest):
     def setUp(self):
         self.op_type = "bilinear_tensor_product"
         batch_size = 6
-        size0 = 30
-        size1 = 20
-        size2 = 100
+        size0 = 5
+        size1 = 4
+        size2 = 5
         a = np.random.random((batch_size, size0)).astype("float64")
         b = np.random.random((batch_size, size1)).astype("float64")
         w = np.random.random((size2, size0, size1)).astype("float64")


### PR DESCRIPTION
- 缩小bilinear_tensor_product单测的输入shape，避免单测超时
```
[09:53:27]	169/200 Test #547: test_bilinear_tensor_product_op ...............   Passed  291.18 sec
```
http://ci.paddlepaddle.org/viewLog.html?buildId=261769&tab=buildLog&buildTypeId=Paddle_PrCiCoverage&logTab=tree&filter=all&_focus=8972#_state=81