### PR TITLE
Fix allocator strategy comment

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -303,7 +303,7 @@ DEFINE_double(memory_fraction_of_eager_deletion, 1.0,
  * Allocator related FLAG
  * Name: FLAGS_allocator_strategy
  * Since Version: 1.2
- * Value Range: string, {naive_best_fit, auto_growth}, default=naive_best_fit
+ * Value Range: string, {naive_best_fit, auto_growth}, default=auto_growth
  * Example:
  * Note: For selecting allocator policy of PaddlePaddle.
  */


### PR DESCRIPTION
Fix comments of `FLAGS_allocator_strategy` since auto growth has been enabled by default https://github.com/PaddlePaddle/Paddle/pull/21837 .