### PR TITLE
Enable CI check to match PADDLE_ENFORCE_CUDA_SUCCESS

### DIFF
--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -300,16 +300,6 @@ TEST(enforce, cuda_success) {
 }
 #endif
 
-TEST(enforce, cuda_success_check) {
-  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess);
-  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess, "cuda test");
-  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess,
-                              paddle::platform::errors::External("cuda test"));
-  PADDLE_ENFORCE_CUDA_SUCCESS(
-      cudaSuccess,
-      paddle::platform::errors::External("paddle enforce cuda success test"));
-}
-
 struct CannotToStringType {
   explicit CannotToStringType(int num) : num_(num) {}
 

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -300,6 +300,17 @@ TEST(enforce, cuda_success) {
 }
 #endif
 
+TEST(enforce, cuda_success_check) {
+  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess);               // no msg
+  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess, "cuda test");  // no error type
+  PADDLE_ENFORCE_CUDA_SUCCESS(
+      cudaSuccess,
+      paddle::platform::errors::External("cuda test"));  // msg is too short
+  PADDLE_ENFORCE_CUDA_SUCCESS(
+      cudaSuccess, paddle::platform::errors::External(
+                       "paddle enforce cuda success test"));  // correct
+}
+
 struct CannotToStringType {
   explicit CannotToStringType(int num) : num_(num) {}
 

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -301,14 +301,13 @@ TEST(enforce, cuda_success) {
 #endif
 
 TEST(enforce, cuda_success_check) {
-  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess);               // no msg
-  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess, "cuda test");  // no error type
+  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess);
+  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess, "cuda test");
+  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess,
+                              paddle::platform::errors::External("cuda test"));
   PADDLE_ENFORCE_CUDA_SUCCESS(
       cudaSuccess,
-      paddle::platform::errors::External("cuda test"));  // msg is too short
-  PADDLE_ENFORCE_CUDA_SUCCESS(
-      cudaSuccess, paddle::platform::errors::External(
-                       "paddle enforce cuda success test"));  // correct
+      paddle::platform::errors::External("paddle enforce cuda success test"));
 }
 
 struct CannotToStringType {

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -153,8 +153,8 @@ if [ "${ALL_PADDLE_ENFORCE}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     check_approval 1 6836917 47554610 22561442
 fi
 
-ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
-VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
+ALL_PADDLE_CHECK=`git diff -U0 upstream/$BRANCH |grep "+" |grep -zoE "(PADDLE_ENFORCE[A-Z_]*|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" || true`
+VALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]*|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' || true`
 INVALID_PADDLE_CHECK=`echo "$ALL_PADDLE_CHECK" |grep -vxF "$VALID_PADDLE_CHECK" || true`
 if [ "${INVALID_PADDLE_CHECK}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     echo_line="The error message you wrote in PADDLE_ENFORCE{_**} or PADDLE_THROW does not meet our error message writing specification. Possible errors include 1. the error message is empty / 2. the error message is too short / 3. the error type is not specified. Please read the specification [ https://github.com/PaddlePaddle/Paddle/wiki/Paddle-Error-Message-Writing-Specification ], then refine the error message. If it is a mismatch, please specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\nThe PADDLE_ENFORCE{_**} or PADDLE_THROW entries that do not meet the specification are as follows:\n${INVALID_PADDLE_CHECK}\n"

--- a/tools/count_invalid_enforce.sh
+++ b/tools/count_invalid_enforce.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-ALL_PADDLE_CHECK=`grep -r -zoE "(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" ../paddle/fluid || true`
+ALL_PADDLE_CHECK=`grep -r -zoE "(PADDLE_ENFORCE[A-Z_]*|PADDLE_THROW)\(.[^,\);]*.[^;]*\);\s" ../paddle/fluid || true`
 ALL_PADDLE_CHECK_CNT=`echo "$ALL_PADDLE_CHECK" | grep -cE "(PADDLE_ENFORCE|PADDLE_THROW)" || true`
-VALID_PADDLE_CHECK_CNT=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]{0,9}|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' | grep -cE "(PADDLE_ENFORCE|PADDLE_THROW)" || true`
+VALID_PADDLE_CHECK_CNT=`echo "$ALL_PADDLE_CHECK" | grep -zoE '(PADDLE_ENFORCE[A-Z_]*|PADDLE_THROW)\((.[^,;]+,)*.[^";]*(errors::).[^"]*".[^";]{20,}.[^;]*\);\s' | grep -cE "(PADDLE_ENFORCE|PADDLE_THROW)" || true`
 
 echo "----------------------------"
 echo "PADDLE ENFORCE & THROW COUNT"


### PR DESCRIPTION
as title, polish error message CI check rule, let CI check can match PADDLE_ENFORCE_CUDA_SUCCESS.

- test case:
```
TEST(enforce, cuda_success_check) {
  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess);               // no msg
  PADDLE_ENFORCE_CUDA_SUCCESS(cudaSuccess, "cuda test");  // no error type
  PADDLE_ENFORCE_CUDA_SUCCESS(
      cudaSuccess,
      paddle::platform::errors::External("cuda test"));  // msg is too short
  PADDLE_ENFORCE_CUDA_SUCCESS(
      cudaSuccess, paddle::platform::errors::External(
                       "paddle enforce cuda success test"));  // correct
}
```
- test result

http://ci.paddlepaddle.org/viewLog.html?buildId=264034&tab=buildLog&buildTypeId=YYTest_PrCiCpuPy2&logTab=tail

![image](https://user-images.githubusercontent.com/22561442/71867669-0df73d00-3146-11ea-93b8-17be16e3ebae.png)


