### PR TITLE
Support uninitialized grad in optimizer ops

### DIFF
--- a/paddle/fluid/operators/controlflow/conditional_block_op.cc
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.cc
@@ -139,7 +139,7 @@ class ConditionalBlockGradOp : public ConditionalOp {
       return;
     }
 
-    AssignZeroToParentScope(dev_place, scope, inputs, outside_grads);
+    //    AssignZeroToParentScope(dev_place, scope, inputs, outside_grads);
   }
 
  private:

--- a/paddle/fluid/operators/optimizers/adam_op.cc
+++ b/paddle/fluid/operators/optimizers/adam_op.cc
@@ -97,7 +97,8 @@ void AdamOp::InferShape(framework::InferShapeContext* ctx) const {
 
   auto param_dims = ctx->GetInputDim("Param");
   if (ctx->GetInputsVarType("Grad")[0] ==
-      framework::proto::VarType::LOD_TENSOR) {
+          framework::proto::VarType::LOD_TENSOR &&
+      framework::product(ctx->GetInputDim("Grad")) > 0) {
     PADDLE_ENFORCE_EQ(
         param_dims, ctx->GetInputDim("Grad"),
         platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/optimizers/adam_op.h
+++ b/paddle/fluid/operators/optimizers/adam_op.h
@@ -468,6 +468,8 @@ class AdamOpKernel : public framework::OpKernel<T> {
 
     if (grad_var->IsType<framework::LoDTensor>()) {
       auto& grad = Ref(ctx.Input<LoDTensor>("Grad"), "Must set Grad");
+      VLOG(4) << "grad Tensor is initialized: " << grad.IsInitialized();
+      if (!grad.IsInitialized()) return;
 
       if (platform::is_cpu_place(ctx.GetPlace())) {
         AdamFunctor<T, CPUAdam> functor(
@@ -505,6 +507,9 @@ class AdamOpKernel : public framework::OpKernel<T> {
     } else if (grad_var->IsType<framework::SelectedRows>()) {
       auto& grad =
           Ref(ctx.Input<framework::SelectedRows>("Grad"), "Must set Grad");
+      VLOG(4) << "grad SelectedRows is initialized: "
+              << grad.value().IsInitialized();
+      if (!grad.value().IsInitialized()) return;
       if (grad.rows().size() == 0) {
         VLOG(3) << "grad row size is 0!!";
         return;

--- a/paddle/fluid/operators/optimizers/sgd_op.cc
+++ b/paddle/fluid/operators/optimizers/sgd_op.cc
@@ -41,7 +41,8 @@ class SGDOp : public framework::OperatorWithKernel {
                       "Learning rate should have 1 element");
     auto param_dim = ctx->GetInputDim("Param");
     if (ctx->GetInputsVarType("Grad")[0] ==
-        framework::proto::VarType::LOD_TENSOR) {
+            framework::proto::VarType::LOD_TENSOR &&
+        framework::product(ctx->GetInputDim("Grad")) > 0) {
       PADDLE_ENFORCE_EQ(
           param_dim, ctx->GetInputDim("Grad"),
           platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/optimizers/sgd_op.cu
+++ b/paddle/fluid/operators/optimizers/sgd_op.cu
@@ -97,8 +97,8 @@ class SGDOpKernel<platform::CUDADeviceContext, T>
       PADDLE_ENFORCE_EQ(param, param_out);
       auto* grad = ctx.Input<framework::SelectedRows>("Grad");
       VLOG(4) << "grad SelectedRows is initialized: "
-              << grad.value().IsInitialized();
-      if (!grad.value().IsInitialized()) return;
+              << grad->value().IsInitialized();
+      if (!grad->value().IsInitialized()) return;
 
       auto in_height = grad->height();
       auto out_dims = param_out->dims();

--- a/paddle/fluid/operators/optimizers/sgd_op.cu
+++ b/paddle/fluid/operators/optimizers/sgd_op.cu
@@ -73,6 +73,8 @@ class SGDOpKernel<platform::CUDADeviceContext, T>
     if (grad_var->IsType<framework::LoDTensor>()) {
       param_out->mutable_data<T>(ctx.GetPlace());
       auto* grad = ctx.Input<framework::Tensor>("Grad");
+      VLOG(4) << "grad Tensor is initialized: " << grad->IsInitialized();
+      if (!grad->IsInitialized()) return;
       // LOG(ERROR) << "grad";
       // LOG(ERROR) << ctx.op().Input("Grad");
       auto* grad_data = grad->data<T>();
@@ -94,6 +96,9 @@ class SGDOpKernel<platform::CUDADeviceContext, T>
       // It's better to find a more elegant solution.
       PADDLE_ENFORCE_EQ(param, param_out);
       auto* grad = ctx.Input<framework::SelectedRows>("Grad");
+      VLOG(4) << "grad SelectedRows is initialized: "
+              << grad.value().IsInitialized();
+      if (!grad.value().IsInitialized()) return;
 
       auto in_height = grad->height();
       auto out_dims = param_out->dims();

--- a/paddle/fluid/operators/optimizers/sgd_op.h
+++ b/paddle/fluid/operators/optimizers/sgd_op.h
@@ -36,6 +36,8 @@ class SGDOpKernel<platform::CPUDeviceContext, T>
 
     const auto *param_var = ctx.InputVar("Param");
     const auto *grad_var = ctx.InputVar("Grad");
+    VLOG(4) << "grad_var is initialized: " << grad_var->IsInitialized();
+    VLOG(4) << "param_var is initialized: " << param_var->IsInitialized();
 
     if (param_var->IsType<framework::LoDTensor>()) {
       const auto *param = ctx.Input<framework::Tensor>("Param");
@@ -43,6 +45,8 @@ class SGDOpKernel<platform::CPUDeviceContext, T>
       // Actually, all tensors are LoDTensor except SelectedRows.
       if (grad_var->IsType<framework::LoDTensor>()) {
         const auto *grad = ctx.Input<framework::Tensor>("Grad");
+        VLOG(4) << "grad Tensor is initialized: " << grad->IsInitialized();
+        if (!grad->IsInitialized()) return;
         auto sz = param_out->numel();
         PADDLE_ENFORCE_EQ(param->numel(), sz);
         PADDLE_ENFORCE_EQ(grad->numel(), sz);
@@ -64,6 +68,9 @@ class SGDOpKernel<platform::CPUDeviceContext, T>
         // It's better to find a more elegant solution.
         PADDLE_ENFORCE_EQ(param, param_out);
         const auto *grad = ctx.Input<framework::SelectedRows>("Grad");
+        VLOG(4) << "grad SelectedRows is initialized: "
+                << grad->value().IsInitialized();
+        if (!grad->value().IsInitialized()) return;
         auto &grad_rows = grad->rows();
 
         // for distributed training, a sparse var may be empty,
@@ -103,6 +110,9 @@ class SGDOpKernel<platform::CPUDeviceContext, T>
       const auto &param = param_var->Get<framework::SelectedRows>();
       auto *param_out = ctx.Output<framework::SelectedRows>("ParamOut");
       const auto &grad = grad_var->Get<framework::SelectedRows>();
+      VLOG(4) << "grad SelectedRows is initialized: "
+              << grad.value().IsInitialized();
+      if (!grad.value().IsInitialized()) return;
 
       // for distributed training, a sparse var may be empty,
       // just skip updating.


### PR DESCRIPTION
### 背景
在控制流中（如cond、switch等），如果某些分支不会实际运行，则为了保证框架兼容性，对此分支内的`Variable`的反向`grad`进行了值为0.的初始化。避免由于反向`grad`未初始化导致输入到其他op时，在runtime infershape时挂掉，尤其对于优化器op。

相关PR：
+ https://github.com/PaddlePaddle/Paddle/pull/21532

但是，这种方式，会带来性能上的损失。因为控制流的False分支里的所有`param`都会对应一个优化器Op，并进行了梯度值为0的更新计算。

### 目标
因为，此PR旨在对optimizer ops进行优化，支持未初始化grad（参考sum_op），以避免优化器op的`Compute`函数调用。

### 方案
修改optimizer op里的infershape和Compute函数，对grad是否初始化进行判断。若未初始化，则直接return。

目前仅对`SGD`和`Adam`两个op进行升级测试。

### 存在问题
+ 如果fetch 控制流False分支的反向grad值，则返回为`None`，而非之前的全0值
+ 需要sum op支持全未初始化的Tensor Array。由于在optimizer.py中会对部分同名grad作梯度聚合，有可能输入sum的所有同名梯度都是未初始化的（目前sum的输入至少一个是初始化的）
+ 允许在runtime期间grad未初始化，可能存在输入到其他op的情况（如assign，cast等），需评估是否需要同步修改此类op支持未初始化tensor。
+ **可能需要给出更加优雅的兼容方式，比如在optimizer.py对False分支的参数梯度进行剪枝**