### PR TITLE
add example for reshape op

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -5558,7 +5558,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             # the shape of reshaped_2 is [5,10].
 
             # example 3:
-            data_3 = fluid.data(name="data_3", shape=[2,4,6], dtype='float32')
+            data_3 = fluid.data(
+              name="data_3", shape=[2,4,6], dtype='float32')
             reshaped_3 = fluid.layers.reshape(x=data_3, shape=[6,8])
             # the shape of reshaped_3 is [6,8].
     """

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -5556,6 +5556,11 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             dim = fluid.layers.fill_constant([1], "int32", 5)
             reshaped_2 = fluid.layers.reshape(data_2, shape=[dim, 10])
             # the shape of reshaped_2 is [5,10].
+
+            # example 3:
+            data_3 = fluid.data(name="data_3", shape=[2,4,6], dtype='float32')
+            reshaped_3 = fluid.layers.reshape(x=data_3, shape=[6,8])
+            # the shape of reshaped_3 is [6,8].
     """
     if in_dygraph_mode():
         #TODO(zhiqiu): open inplace if we can.


### PR DESCRIPTION
用户问：请问一下，怎么reshape一个lodtensor，特别地，是将3维的降低成2维

经查，文档中有说明，但没有对应的示例

https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/layers_cn/reshape_cn.html

1. 给定一个形状为[2,4,6]的三维张量x，目标形状为[6,8]，则将x变换为形状为[6,8]的2-D张量，且x的数据保持不变。

补充示例如下：

![image](https://user-images.githubusercontent.com/23031310/71869565-7b5a9c00-314d-11ea-8b6e-84ec53ade3c3.png)

预览：

![image](https://user-images.githubusercontent.com/23031310/71880842-1d897c80-316c-11ea-8156-9122b1f432f7.png)

