### PR TITLE
[cherry-pick] Fix multi-threads memory out of bounds error for passes

### DIFF
--- a/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_fc_lstm_fuse_pass.cc
@@ -127,35 +127,24 @@ static int BuildFusion(Graph* graph, const std::string& name_scope,
         embedding_data, k, weightx_data, n, beta, embeddings_data, n);
     op_desc.SetInput("Embeddings", {embeddings});
 
-    // Create temp variables.
-    const std::string BatchedInput = patterns::UniqueKey("BatchedInput");
-    const std::string BatchedCellPreAct =
-        patterns::UniqueKey("BatchedCellPreAct");
-    const std::string BatchedGate = patterns::UniqueKey("BatchedGate");
-
-    scope->Var(BatchedInput)->GetMutable<framework::LoDTensor>();
-    scope->Var(BatchedCellPreAct)->GetMutable<framework::LoDTensor>();
-    scope->Var(BatchedGate)->GetMutable<framework::LoDTensor>();
-
     op_desc.SetInput("H0", {});
     op_desc.SetInput("C0", {});
     op_desc.SetOutput("Hidden", {hidden->Name()});
     op_desc.SetOutput("Cell", {cell->Name()});
     op_desc.SetOutput("XX", {xx->Name()});
-    op_desc.SetOutput("BatchedGate", {BatchedGate});
-    op_desc.SetOutput("BatchCellPreAct", {BatchedCellPreAct});
-    op_desc.SetOutput("BatchedInput", {BatchedInput});
     op_desc.SetAttr("is_reverse", lstm->Op()->GetAttr("is_reverse"));
     op_desc.SetAttr("use_peepholes", lstm->Op()->GetAttr("use_peepholes"));
     // TODO(TJ): get from attr
     op_desc.SetAttr("use_seq", true);
 
-    PADDLE_ENFORCE(graph->Has(kParamScopeAttr));
-    auto& scope = graph->Get<Scope>(kParamScopeAttr);
+// Create temp variables.
 #define OP_SET_OUT(x)                            \
   const std::string x = patterns::UniqueKey(#x); \
-  op_desc.SetOutput(#x, {x});                    \
-  scope.Var(x)->GetMutable<LoDTensor>()
+  op_desc.SetOutput(#x, {x});
+
+    OP_SET_OUT(BatchedGate);
+    OP_SET_OUT(BatchCellPreAct);
+    OP_SET_OUT(BatchedInput);
     OP_SET_OUT(BatchedCell);
     OP_SET_OUT(BatchedHidden);
     OP_SET_OUT(ReorderedH0);
@@ -163,11 +152,28 @@ static int BuildFusion(Graph* graph, const std::string& name_scope,
 #undef OP_SET_OUT
 
     auto* op = graph->CreateOpNode(&op_desc);
+
     IR_NODE_LINK_TO(input, op);
     IR_NODE_LINK_TO(weight_x, op);
     IR_NODE_LINK_TO(weight_h, op);
     IR_NODE_LINK_TO(bias, op);
     IR_NODE_LINK_TO(op, hidden);
+
+#define IR_NODE(x)                                 \
+  VarDesc key_##x(x);                              \
+  key_##x.SetPersistable(false);                   \
+  auto* node_##x = graph->CreateVarNode(&key_##x); \
+  IR_NODE_LINK_TO(op, node_##x);
+
+    IR_NODE(BatchedGate);
+    IR_NODE(BatchCellPreAct);
+    IR_NODE(BatchedInput);
+    IR_NODE(BatchedCell);
+    IR_NODE(BatchedHidden);
+    IR_NODE(ReorderedH0);
+    IR_NODE(ReorderedC0);
+#undef IR_NODE
+
     return op;
   };
 

--- a/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_lstm_fuse_pass.cc
@@ -74,38 +74,25 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
       op_desc.SetInput("Bias", {new_bias_var});
     }
 
-    // Create temp variables.
-    const std::string BatchedInput = patterns::UniqueKey("BatchedInput");
-    const std::string BatchedCellPreAct =
-        patterns::UniqueKey("BatchedCellPreAct");
-    const std::string BatchedGate = patterns::UniqueKey("BatchedGate");
-    const std::string CheckedCell = patterns::UniqueKey("CheckedCell");
-
-    scope->Var(BatchedInput)->GetMutable<framework::LoDTensor>();
-    scope->Var(BatchedCellPreAct)->GetMutable<framework::LoDTensor>();
-    scope->Var(BatchedGate)->GetMutable<framework::LoDTensor>();
-    scope->Var(CheckedCell)->GetMutable<framework::LoDTensor>();
-
     op_desc.SetInput("H0", {});
     op_desc.SetInput("C0", {});
     op_desc.SetOutput("Hidden", {hidden->Name()});
     op_desc.SetOutput("Cell", {cell->Name()});
     op_desc.SetOutput("XX", {xx->Name()});
-    op_desc.SetOutput("BatchedGate", {BatchedGate});
-    op_desc.SetOutput("BatchCellPreAct", {BatchedCellPreAct});
-    op_desc.SetOutput("BatchedInput", {BatchedInput});
-    op_desc.SetOutput("CheckedCell", {CheckedCell});
     op_desc.SetAttr("is_reverse", lstm->Op()->GetAttr("is_reverse"));
     op_desc.SetAttr("use_peepholes", lstm->Op()->GetAttr("use_peepholes"));
     // TODO(TJ): get from attr
     op_desc.SetAttr("use_seq", true);
 
-    PADDLE_ENFORCE(graph->Has(kParamScopeAttr));
-    auto& scope = graph->Get<Scope>(kParamScopeAttr);
+// Create temp variables.
 #define OP_SET_OUT(x)                            \
   const std::string x = patterns::UniqueKey(#x); \
-  op_desc.SetOutput(#x, {x});                    \
-  scope.Var(x)->GetMutable<LoDTensor>()
+  op_desc.SetOutput(#x, {x});
+
+    OP_SET_OUT(BatchedGate);
+    OP_SET_OUT(BatchedCellPreAct);
+    OP_SET_OUT(BatchedInput);
+    OP_SET_OUT(CheckedCell);
     OP_SET_OUT(BatchedCell);
     OP_SET_OUT(BatchedHidden);
     OP_SET_OUT(ReorderedH0);
@@ -113,11 +100,29 @@ int BuildFusion(Graph* graph, const std::string& name_scope, Scope* scope,
 #undef OP_SET_OUT
 
     auto* op = graph->CreateOpNode(&op_desc);
+
     IR_NODE_LINK_TO(input, op);
     IR_NODE_LINK_TO(weight_x, op);
     IR_NODE_LINK_TO(weight_h, op);
     IR_NODE_LINK_TO(bias, op);
     IR_NODE_LINK_TO(op, hidden);
+
+#define IR_NODE(x)                                 \
+  VarDesc key_##x(x);                              \
+  key_##x.SetPersistable(false);                   \
+  auto* node_##x = graph->CreateVarNode(&key_##x); \
+  IR_NODE_LINK_TO(op, node_##x);
+
+    IR_NODE(BatchedGate);
+    IR_NODE(BatchedCellPreAct);
+    IR_NODE(BatchedInput);
+    IR_NODE(CheckedCell);
+    IR_NODE(BatchedCell);
+    IR_NODE(BatchedHidden);
+    IR_NODE(ReorderedH0);
+    IR_NODE(ReorderedC0);
+#undef IR_NODE
+
     return op;
   };
 

--- a/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/seq_concat_fc_fuse_pass.cc
@@ -214,7 +214,9 @@ void SeqConcatFcFusePass::ApplyImpl(ir::Graph* graph) const {
     op_desc.SetInput("FCWeight", {fc_w->Name()});
     op_desc.SetInput("FCBias", {fc_bias->Name()});
     const std::string fc_out_tmp = fc_out->Name() + ".tmp";
-    param_scope()->Var(fc_out_tmp)->GetMutable<framework::LoDTensor>();
+    VarDesc fc_out_key(fc_out_tmp);
+    fc_out_key.SetPersistable(false);
+    auto* fc_out_node = graph->CreateVarNode(&fc_out_key);
     op_desc.SetOutput("FCOut", {fc_out_tmp});
     op_desc.SetOutput("Out", {fc_out->Name()});
     op_desc.SetAttr("fc_activation", act->Op()->Type());
@@ -227,6 +229,7 @@ void SeqConcatFcFusePass::ApplyImpl(ir::Graph* graph) const {
     IR_NODE_LINK_TO(sequence_expand0_in, op_node);
     IR_NODE_LINK_TO(sequence_expand1_in, op_node);
     IR_NODE_LINK_TO(op_node, fc_out);
+    IR_NODE_LINK_TO(op_node, fc_out_node);
 
     // Clean nodes.
     std::unordered_set<const Node*> marked_nodes;


### PR DESCRIPTION
cherry-pick #21920
Some passes tried to access memory during fusion-building and create a piece of memory for some variables. 
And when this operation is applied to an output variable, all cloned predictors in multi-threads can access the same memory and modify its dims or value. This may cause memory out-of-bounds. 
This PR tries to fix:
* seqconv_eltadd_relu_fuse_pass
* attention_lstm_fuse_pass
* embedding_fc_lstm_fuse_pass
* fc_lstm_fuse_pass
* seq_concat_fc_fuse_pass

We try to treat passes as ReadOnly. If it cannot be ReadOnly, only persistable variables are allowed to be modified. It's forbidden to create any intermediate variable in this scope. 