### PR TITLE
remove _optimized_guard in dygrahpe_mode

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -446,8 +446,6 @@ class Optimizer(object):
             for param_and_grad in parameters_and_grads:
                 if param_and_grad[1] is None:
                     continue
-                # with param_and_grad[0].block.program._optimized_guard(
-                #         param_and_grad):
                 if param_and_grad[0].trainable is True:
                     optimize_op = self._append_optimize_op(target_block,
                                                            param_and_grad)

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -446,8 +446,7 @@ class Optimizer(object):
                 if param_and_grad[1] is None:
                     continue
                 if param_and_grad[0].trainable is True:
-                    optimize_op = self._append_optimize_op(target_block,
-                                                           param_and_grad)
+                    self._append_optimize_op(target_block, param_and_grad)
         else:
             for param_and_grad in parameters_and_grads:
                 if param_and_grad[1] is None:
@@ -455,8 +454,7 @@ class Optimizer(object):
                 with param_and_grad[0].block.program._optimized_guard(
                         param_and_grad), name_scope("optimizer"):
                     if param_and_grad[0].trainable is True:
-                        optimize_op = self._append_optimize_op(target_block,
-                                                               param_and_grad)
+                        self._append_optimize_op(target_block, param_and_grad)
 
         # Get custom finish ops for subclasses
         # FIXME: Need to fix this once we figure out how to handle dependencies

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -441,7 +441,6 @@ class Optimizer(object):
             [p[0] for p in parameters_and_grads if p[0].trainable])
         self._create_global_learning_rate()
 
-        optimize_ops = []
         if framework.in_dygraph_mode():
             for param_and_grad in parameters_and_grads:
                 if param_and_grad[1] is None:
@@ -449,7 +448,6 @@ class Optimizer(object):
                 if param_and_grad[0].trainable is True:
                     optimize_op = self._append_optimize_op(target_block,
                                                            param_and_grad)
-                    optimize_ops.append(optimize_op)
         else:
             for param_and_grad in parameters_and_grads:
                 if param_and_grad[1] is None:
@@ -459,7 +457,6 @@ class Optimizer(object):
                     if param_and_grad[0].trainable is True:
                         optimize_op = self._append_optimize_op(target_block,
                                                                param_and_grad)
-                        optimize_ops.append(optimize_op)
 
         # Get custom finish ops for subclasses
         # FIXME: Need to fix this once we figure out how to handle dependencies

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -446,12 +446,12 @@ class Optimizer(object):
             for param_and_grad in parameters_and_grads:
                 if param_and_grad[1] is None:
                     continue
-                with param_and_grad[0].block.program._optimized_guard(
-                        param_and_grad):
-                    if param_and_grad[0].trainable is True:
-                        optimize_op = self._append_optimize_op(target_block,
-                                                               param_and_grad)
-                        optimize_ops.append(optimize_op)
+                # with param_and_grad[0].block.program._optimized_guard(
+                #         param_and_grad):
+                if param_and_grad[0].trainable is True:
+                    optimize_op = self._append_optimize_op(target_block,
+                                                           param_and_grad)
+                    optimize_ops.append(optimize_op)
         else:
             for param_and_grad in parameters_and_grads:
                 if param_and_grad[1] is None:


### PR DESCRIPTION
目前，反向的op均是在`_create_optimization_pass`中调用`_append_optimize_op`来创建
```python
with param_and_grad[0].block.program._optimized_guard(
        param_and_grad), name_scope("optimizer"):
        optimize_op = self._append_optimize_op(target_block, param_and_grad)
        optimize_ops.append(optimize_op)
```
其中的`_optimized_guard`的主要作用：标识`optimize_op`的`OpRole`，以保证静态图ParallelExecutor下的所有设备上参数梯度计算和更新操作，都merge到一台device上，之后再进行broadcast分发。

动态图下不走此逻辑，故不需要在`with`语法下调用`_append_optimize_op`。

### 性能测试
#### 1. 环境
+ python version: 3.6
+ 基线 develop commit: 2a47cc5fc4b0484faa4315008a8e370acab1d533 （1月6日）
+ model:  [Transformer](https://github.com/Aurelius84/models/tree/develop/dygraph/transformer)
+ 重复测试：4次求平均

#### 2. 方法：
+ cProfile
```bash
// 在train.py中添加 import cProfile
// 执行训练：
env CUDA_VISIBLE_DEVICES=7 python -m cProfile train.py > guard_log/profile400.log

// develop日志，batch_size:  32
ncalls  tottime  percall  cumtime  percall filename:lineno(function)
299200    0.499    0.000    2.284    0.000 framework.py:3690(_optimized_guard)
// PR日志
149600    0.203    0.000    1.013    0.000 framework.py:3690(_optimized_guard)
```

+ forward, backward, minimize训练耗时统计
```python
# 在train.py里添加如下时间统计代码
fw_s = time.time()
dy_sum_cost, dy_avg_cost, dy_predict, dy_token_num = transformer(enc_inputs, dec_inputs, label, weights)
fw += (time.time() - fw_s)  # 前向时间
......
 bw_s = time.time()
dy_avg_cost.backward()
bw += (time.time() - bw_s)  # 反向时间
......
 mm_s = time.time()
optimizer.minimize(dy_avg_cost)
mm += (time.time() - mm_s)  # minimize时间
```
### 3.结果
在相同环境，分别PR前后编译的whl重复测4次，取耗时平均值，结果如下：
batch_size:  32， iter_num: 100

|  时间(s)   | forward | backward | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 | 6.861 | 2.114   | 5.744   | 14.719 |
| PR后 | 6.855  | 2.125   | 4.486  | 13.466 |
| 提升  | -    | -     | 21.9%    | 8.5%  |

batch_size:  64， iter_num: 100

|  时间(s)   | forward | backward | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 | 6.873 | 2.125   | 5.682  | 14.681 |
| PR后 | 6.897  | 2.122   | 4.493  | 13.515 |
| 提升  | -    | -     | 20.9%    | 7.9%  |

batch_size:  128， iter_num: 100

|  时间(s)   | forward | backward | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 | 6.879 | 2.130   | 9.502  | 18.512 |
| PR后 | 6.883  | 2.129  | 9.464 | 18.476|
| 提升  | -    | -     | 0.4%    | 0.19%  |


batch_size:  256， iter_num: 100

|  时间(s)   | forward | backward | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 | 6.726 | 6.970   | 24.506   | 38.203 |
| PR后 | 6.868  | 6.794   | 24.460  | 38.123 |
| 提升  | -    | -     | 0.18%    | 0.2%  |



在batch_size=32时，`_optimized_guard`均在`minimize`过程中调用，故在`forward`和`backward`两个维度上耗时基本不变（波动），在`minimize`维度速度提升23.8%，在Transformer动态图整体训练速度上，提升8.5%.

但随着batch_size的增大，收益明显递减。因为优化`_optimized_guard`带来的耗时收益是与batch_size无关的（分子），但随着batch_size的增大，minimize和整体时增加比较明显（分母），故随着batch_size的增大，收益明显递减。

基于Transformer模型在batch_size=64, iter_num=400，P40GPU单卡下，测试了其他优化器的收益，结果如下：

|  速度提升   | Adam | AdaGrad | Momentum | SGD  |
|:---:|:-------:|:--------:|:--------:|:------:|
| minimize | 21.2% | 17.9%   | 24.4%   | 24.0%|
| total | 8.1% | 6.6%  | 7.2% | 5.2% |

## 4. 复测
在Dialogue-PLATO动态图模型（@phlrain提供）上也进行了复测。
测试环境：P40单卡（同上，同台机器）
batch_size: 12 （模型默认配置）
数据统计方法：4次，每次10个batch，共40组数据求平均时间

|  时间(s)   | forward | optimize | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 |  0.12845  | 0.113225   | 0.08515   | 0.241675 |
| PR后 | 0.126875  | 0.106975   | 0.078275  | 0.23385 |
| 提升  | 1.23%   | 5.52%   | 8.07%    | 3.24%  |

结论：移除optimized_guard无用代码不会有性能上的损耗。且在小batch_size下，有速度的收益（transformer有5~8%的速度提升；Dialogue-PLATO有3%左右的提升），很大batch_size下可能无明显收益。