### PR TITLE
Fix init_loss_scaling value bug.

### DIFF
--- a/python/paddle/fluid/contrib/mixed_precision/decorator.py
+++ b/python/paddle/fluid/contrib/mixed_precision/decorator.py
@@ -217,7 +217,7 @@ class OptimizerWithMixedPrecision(object):
 
 def decorate(optimizer,
              amp_lists=None,
-             init_loss_scaling=1.0,
+             init_loss_scaling=2**15,
              incr_every_n_steps=1000,
              decr_every_n_nan_or_inf=2,
              incr_ratio=2.0,


### PR DESCRIPTION
The mixed precision interface will adapt to scaling value when it is greater than 1.0. So the initialization value can't be 1.0. It should be a greater value.