### PR TITLE
[Bug Fix] Fix trt instance_norm serialize bug

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
@@ -41,7 +41,8 @@ class InstanceNormPlugin : public PluginTensorRT {
  protected:
   size_t getSerializationSize() override {
     return getBaseSerializationSize() + SerializedSize(eps_) +
-           SerializedSize(scale_) + SerializedSize(bias_);
+           SerializedSize(scale_) + SerializedSize(bias_) +
+           SerializedSize(getPluginType());
   }
 
   // TRT will call this func when we need to serialize the configuration of


### PR DESCRIPTION
Add plugin type size to instance_norm serialized size to fix double-free in serializing