### PR TITLE
Open test dygraph mnist fp16

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
@@ -117,8 +117,6 @@ class MNIST(fluid.dygraph.Layer):
 
 
 class TestMnist(unittest.TestCase):
-    # FIXME(zcd): disable this random failed test temporally.
-    @unittest.skip("should fix this later")
     def test_mnist_fp16(self):
         if not fluid.is_compiled_with_cuda():
             return


### PR DESCRIPTION
as title, to remove `@unittest.skip` in paddle