### PR TITLE
Fix auto growth allocator bug when using non zero gpu card

### DIFF
--- a/paddle/fluid/memory/allocation/cuda_allocator.cc
+++ b/paddle/fluid/memory/allocation/cuda_allocator.cc
@@ -33,6 +33,8 @@ void CUDAAllocator::FreeImpl(Allocation* allocation) {
 }
 
 Allocation* CUDAAllocator::AllocateImpl(size_t size) {
+  std::call_once(once_flag_, [this] { platform::SetDeviceId(place_.device); });
+
   platform::CUDADeviceGuard guard(place_.device);
   void* ptr;
   auto result = cudaMalloc(&ptr, size);

--- a/paddle/fluid/memory/allocation/cuda_allocator.h
+++ b/paddle/fluid/memory/allocation/cuda_allocator.h
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #pragma once
+#include <mutex>  // NOLINT
 #include "paddle/fluid/memory/allocation/allocator.h"
 #include "paddle/fluid/platform/place.h"
 
@@ -33,6 +34,7 @@ class CUDAAllocator : public Allocator {
 
  private:
   platform::CUDAPlace place_;
+  std::once_flag once_flag_;
 };
 
 }  // namespace allocation

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -330,5 +330,5 @@ set_tests_properties(test_parallel_executor_test_while_train test_parallel_execu
         test_parallel_executor_crf test_sync_batch_norm_op
         test_parallel_executor_feed_persistable_var
         test_parallel_executor_crf_auto_growth test_buffer_shared_memory_reuse_pass_and_fuse_optimization_op_pass
-        test_data_norm_op
+        test_data_norm_op test_imperative_using_non_zero_gpu
         test_buffer_shared_memory_reuse_pass PROPERTIES LABELS "RUN_TYPE=DIST")

--- a/python/paddle/fluid/tests/unittests/test_imperative_using_non_zero_gpu.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_using_non_zero_gpu.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import unittest
+from paddle.fluid.dygraph import to_variable, Embedding, guard
+import numpy as np
+
+
+class TestImperativeUsingNonZeroGpu(unittest.TestCase):
+    def run_main(self, np_arr, place):
+        with guard(place):
+            embedding = Embedding(size=[10, 10])
+            var = to_variable(np_arr)
+            self.assertTrue(np.array_equal(np_arr, var.numpy()))
+
+    def test_non_zero_gpu(self):
+        if not fluid.is_compiled_with_cuda():
+            return
+
+        np_arr = np.random.random([11, 13]).astype('float32')
+        self.run_main(np_arr, fluid.CUDAPlace(1))
+        self.run_main(np_arr, fluid.CUDAPlace(0))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The following codes would hang in dygraph mode when auto growth allocator is enabled:

```python
import paddle.fluid as fluid

with fluid.dygraph_guard(fluid.CUDAPlace(1)):
    emb = fluid.dygraph.Embedding(size=[10, 10])
    var = fluid.dygraph.to_variable(numpy.random.random([11, 13]).astype('float32'))
```

The hang happens when calling `cudaMemcpy` in `to_variable` method (found by gdb). It seems that `cudaMemcpy` would hang if the device id of the current cuda context is not right (for example, the device id is 0 but the pointer to be copied is located on device 1). 

It happens in auto growth allocator but does not happen in the previous allocator. It is because the previous `naive_best_fit` allocator would call `cudaSetDevice` when the first allocation request and call `platform::CUDADeviceGuard` before calling each `cudaMalloc`. But auto growth allocator would not call `cudaSetDevice` when the first allocation request and would call  `platform::CUDADeviceGuard` before calling each `cudaMalloc`. Supposing that the first allocation request is from device 1, `platform::CUDADeviceGuard` would make the current device id to be 0 (default device id of cuda) when destructed, which makes the wrong device id when calling the following `cudaMalloc`. 