### PR TITLE
[cherry-pick] Fix xception precision problem

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1441,6 +1441,7 @@ PDNode *patterns::ConvElementwiseadd::operator()(PDNode *conv_in) {
   auto elementwise_add_op = pattern->NewNode(elementwise_add_op_repr())
                                 ->assert_is_op("elementwise_add");
   auto elementwise_add_in_y = pattern->NewNode(elementwise_add_in_y_repr())
+                                  ->assert_is_persistable_var()
                                   ->assert_is_op_input("elementwise_add", "Y")
                                   ->AsInput();
   auto elementwise_add_out = pattern->NewNode(elementwise_add_out_repr())


### PR DESCRIPTION
cherry-pick #22124 
Before this fix, Xception models may face a precision problem when using python inference api.

Reason:
The diff is caused by conv_elementwise_add_fuse_pass.
conv_elementwise_add_fuse_pass only supports elementwise_add op as conv's bias to trigger the fuse pattern.
But in Xception models, conv_elementwise_add_fuse_pass was also triggered by doing elementwise_add between conv's result and an input variable(tensor).

Before this fix:
![image](https://user-images.githubusercontent.com/7160927/72034896-4f682380-32d1-11ea-88e9-96ee6189340d.png)
After this fix:
![image](https://user-images.githubusercontent.com/7160927/72034926-5d1da900-32d1-11ea-9d36-ea682bb77431.png)