### PR TITLE
only import used test case and function

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -15,7 +15,8 @@
 from __future__ import print_function
 
 import unittest
-from paddle.fluid.tests.unittests.test_pool2d_op import *
+import numpy as np
+from paddle.fluid.tests.unittests.test_pool2d_op import TestPool2D_Op, TestCase1, TestCase2, TestCase3, TestCase4, TestCase5, avg_pool2D_forward_naive
 
 
 def create_test_mkldnn_use_ceil_class(parent):


### PR DESCRIPTION
`import * ` will import all the cases in test_pool2d_op.py, however some cudnn cases and unused cases and functions should not be imported. In addition, some cases in test_pool2d_op.py do not check grad. When these cases are imported, check_grad CI will fail.



