### PR TITLE
fix bug for test_dygraph_mnist_fp16.py

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
@@ -121,7 +121,7 @@ class TestMnist(unittest.TestCase):
         if not fluid.is_compiled_with_cuda():
             return
         x = np.random.randn(1, 3, 224, 224).astype("float16")
-        y = np.random.randn(1, 1).astype("int64")
+        y = np.random.randint(10, size=[1, 1], dtype="int64")
         with fluid.dygraph.guard(fluid.CUDAPlace(0)):
             model = MNIST(dtype="float16")
             x = fluid.dygraph.to_variable(x)


### PR DESCRIPTION
#22163 open the test_dygraph_mnist_fp16 optest, but there is a bug in generation of input data y. In mnist model, the output size of the last layer(Linear) is 10, so the range of input data y is 0-9.
But if program use np.random.randn(1, 1).astype("int64") function to generate y, the number generated may not be in this range.

![image](https://user-images.githubusercontent.com/16509038/72175559-62850b80-3417-11ea-857b-3f806cc464fe.png)

error message in http://ci.paddlepaddle.org/viewLog.html?buildId=267450&buildTypeId=Paddle_PrCiCoverage&tab=buildLog&branch_Paddle=pull%2F22163 and http://ci.paddlepaddle.org/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiCoverage&buildId=267450 :

![image](https://user-images.githubusercontent.com/16509038/72175756-dcb59000-3417-11ea-958e-765f021bacbf.png)

