### PR TITLE
revert paddle_fluid.map, test=release/1.7

### DIFF
--- a/paddle/fluid/inference/paddle_fluid.map
+++ b/paddle/fluid/inference/paddle_fluid.map
@@ -2,9 +2,7 @@
 	global:
 		*paddle*;
 		*Pass*;
-		extern "C++" {
-			fL*::*;
-		};
+		*profile*;
 	local:
 		*;
 };


### PR DESCRIPTION
test=release/1.7

若 paddle/fluid/inference/paddle_fluid.map 不暴露 `fL::*` 符号，会导致用户 GFLAGS 全局变量设置不起作用；但符号暴露后，在静态链接 glog 版本不同情况下，有一定概率触发业务进程初始化段错误，所以仍需暂时隐藏 GFLAGS 符号。这是一个链接问题，与运行态结果测试无关。此问题需后续解决。

<img width="1066" alt="36241461e7a9ded773bcc72baec95e17" src="https://user-images.githubusercontent.com/39303645/72230063-23f57980-35ee-11ea-918c-f51936e31345.png">