### PR TITLE
Revert "open test_parallel_executor_fetch_feed for PR_Windows_CI. "

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -160,6 +160,7 @@ list(REMOVE_ITEM TEST_OPS test_warpctc_op)
 list(REMOVE_ITEM TEST_OPS test_parallel_executor_crf)
 list(REMOVE_ITEM TEST_OPS test_data_norm_op)
 list(REMOVE_ITEM TEST_OPS test_parallel_executor_crf_auto_growth)
+list(REMOVE_ITEM TEST_OPS test_parallel_executor_fetch_feed)
 list(REMOVE_ITEM TEST_OPS test_parallel_executor_transformer)
 list(REMOVE_ITEM TEST_OPS test_parallel_executor_transformer_auto_growth)
 list(REMOVE_ITEM TEST_OPS test_bilinear_interp_op)
@@ -306,8 +307,11 @@ py_test_modules(test_fuse_bn_act_pass MODULES test_fuse_bn_act_pass ENVS FLAGS_c
 
 if(NOT WIN32)
     py_test_modules(test_ir_memory_optimize_transformer MODULES test_ir_memory_optimize_transformer)
+    # FIXME(zcd): temporally disable test_parallel_executor_fetch_feed in Windows CI because of the random failure.
+    py_test_modules(test_parallel_executor_fetch_feed MODULES test_parallel_executor_fetch_feed)
+    set_tests_properties(test_parallel_executor_fetch_feed PROPERTIES TIMEOUT 450)
 endif()
-set_tests_properties(test_parallel_executor_fetch_feed PROPERTIES TIMEOUT 450)
+
 set_tests_properties(test_parallel_executor_seresnext_base_cpu PROPERTIES TIMEOUT 900)
 set_tests_properties(test_parallel_executor_seresnext_with_reduce_cpu PROPERTIES TIMEOUT 750)
 set_tests_properties(test_parallel_executor_seresnext_with_fuse_all_reduce_cpu PROPERTIES TIMEOUT 750)

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_fetch_feed.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_fetch_feed.py
@@ -68,7 +68,10 @@ class TestFetchAndFeed(unittest.TestCase):
         exe = fluid.Executor(place)
         exe.run(startup)
 
+        #FIXME force disable enable_inplace and memory_optimize to pass the unittest
         build_strategy = fluid.BuildStrategy()
+        build_strategy.enable_inplace = False
+        build_strategy.memory_optimize = False
         exec_strategy = fluid.ExecutionStrategy()
         exec_strategy.use_experimental_executor = use_faster_executor
         exec_strategy.num_threads = num_threads


### PR DESCRIPTION
if the configuration parameter `ON_INFER` is set from `OFF` to `ON`, `test_parallel_executor_fetch_feed`  fails on PR_Windows_CI. #22020

This PR revert "open test_parallel_executor_fetch_feed for PR_Windows_CI" now and bugs in test_parallel_executor_fetch_feed should be fixed later.