### PR TITLE
Make PaddleBuf's malloc consistent with paddle_api.h

### DIFF
--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -85,7 +85,7 @@ void PaddleBuf::Resize(size_t length) {
   if (length_ >= length) return;
   if (memory_owned_) {
     Free();
-    data_ = malloc(length);
+    data_ = new void *[length];
     length_ = length;
     memory_owned_ = true;
   } else {
@@ -103,7 +103,7 @@ void PaddleBuf::Reset(void *data, size_t length) {
 void PaddleBuf::Free() {
   if (memory_owned_ && data_) {
     PADDLE_ENFORCE_GT(length_, 0UL);
-    free(static_cast<char *>(data_));
+    delete static_cast<char *>(data_);
     data_ = nullptr;
     length_ = 0;
   }

--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -85,7 +85,7 @@ void PaddleBuf::Resize(size_t length) {
   if (length_ >= length) return;
   if (memory_owned_) {
     Free();
-    data_ = new void *[length];
+    data_ = new char[length];
     length_ = length;
     memory_owned_ = true;
   } else {

--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -103,7 +103,7 @@ void PaddleBuf::Reset(void *data, size_t length) {
 void PaddleBuf::Free() {
   if (memory_owned_ && data_) {
     PADDLE_ENFORCE_GT(length_, 0UL);
-    delete static_cast<char *>(data_);
+    delete[] static_cast<char *>(data_);
     data_ = nullptr;
     length_ = 0;
   }


### PR DESCRIPTION
In api.cc, `malloc/free` are used for initializing `PaddleBuf` while in paddle_api.h, `new/delete` are involved. 
Since the valgrind will regard this inconsistency as memory leaking, this PR tries to fix this. 