### PR TITLE
Remove _optimized_guard of append_regularization_ops in Dygraph mode

### DIFF
--- a/python/paddle/fluid/regularizer.py
+++ b/python/paddle/fluid/regularizer.py
@@ -21,6 +21,42 @@ from . import core
 __all__ = ['L1Decay', 'L2Decay', 'L1DecayRegularizer', 'L2DecayRegularizer']
 
 
+def create_regularization_of_grad(param, grad, regularization=None):
+    # If no gradient or no regularization is specified,  then we don't need to do anything
+    if grad is None or (param.regularizer is None and regularization is None):
+        return grad
+    regularization_term = None
+    if param.regularizer is not None:
+        # Add variable for regularization term in grad block
+        regularization_term = param.regularizer(param, grad, grad.block)
+    elif regularization is not None:
+        regularization_term = regularization(param, grad, grad.block)
+
+    assert regularization_term is not None
+
+    new_grad = grad
+    if grad.type == core.VarDesc.VarType.SELECTED_ROWS:
+        # FIXME(zcd): If the grad is SELECTED_ROWS, after regularization,
+        # the grad's type and name will be changed. But the gradient's name
+        # is used in ParallelExecutor Reduce mode, so I add a flag for
+        # the new_grad here.
+        new_grad = grad.block.create_var(
+            name=grad.name + core.kNewGradSuffix(),
+            dtype=param.dtype,
+            shape=param.shape,
+            lod_level=param.lod_level,
+            type=core.VarDesc.VarType.LOD_TENSOR)
+
+    inputs = {"X": [grad, regularization_term]}
+    outputs = {"Out": [new_grad]}
+    if in_dygraph_mode():
+        core.ops.sum(inputs, {}, outputs)
+    else:
+        grad.block.append_op(type='sum', inputs=inputs, outputs=outputs)
+
+    return new_grad
+
+
 def append_regularization_ops(parameters_and_grads, regularization=None):
     """Create and add backward regularization Operators
 
@@ -43,47 +79,19 @@ def append_regularization_ops(parameters_and_grads, regularization=None):
         Exception: Unknown regularization type
     """
     params_and_grads = []
-    for param, grad in parameters_and_grads:
-        # If no gradient then we don't need to do anything
-        if grad is None:
-            params_and_grads.append((param, grad))
-            continue
-        with param.block.program._optimized_guard(
-            [param, grad]), framework.name_scope('regularization'):
-            regularization_term = None
-            if param.regularizer is not None:
-                # Add variable for regularization term in grad block
-                regularization_term = param.regularizer(param, grad, grad.block)
-            elif regularization is not None:
-                regularization_term = regularization(param, grad, grad.block)
-
-            # If no regularization specified, then we don't need to do anything
-            if regularization_term is None:
-                params_and_grads.append((param, grad))
-                continue
-
-            new_grad = grad
-            if grad.type == core.VarDesc.VarType.SELECTED_ROWS:
-                # FIXME(zcd): If the grad is SELECTED_ROWS, after regularization,
-                # the grad's type and name will be changed. But the gradient's name
-                # is used in ParallelExecutor Reduce mode, so I add a flag for
-                # the new_grad here.
-                new_grad = grad.block.create_var(
-                    name=grad.name + core.kNewGradSuffix(),
-                    dtype=param.dtype,
-                    shape=param.shape,
-                    lod_level=param.lod_level,
-                    type=core.VarDesc.VarType.LOD_TENSOR)
-
-            inputs = {"X": [grad, regularization_term]}
-            outputs = {"Out": [new_grad]}
-            if in_dygraph_mode():
-                core.ops.sum(inputs, {}, outputs)
-            else:
-                grad.block.append_op(type='sum', inputs=inputs, outputs=outputs)
-
-            params_and_grads.append((param, new_grad))
-
+    if in_dygraph_mode():
+        with framework.name_scope('regularization'):
+            for param, grad in parameters_and_grads:
+                new_grad = create_regularization_of_grad(param, grad,
+                                                         regularization)
+                params_and_grads.append((param, new_grad))
+    else:
+        with framework.name_scope('regularization'):
+            for param, grad in parameters_and_grads:
+                with param.block.program._optimized_guard([param, grad]):
+                    new_grad = create_regularization_of_grad(param, grad,
+                                                             regularization)
+                    params_and_grads.append((param, new_grad))
     return params_and_grads
 
 

--- a/python/paddle/fluid/regularizer.py
+++ b/python/paddle/fluid/regularizer.py
@@ -21,7 +21,11 @@ from . import core
 __all__ = ['L1Decay', 'L2Decay', 'L1DecayRegularizer', 'L2DecayRegularizer']
 
 
-def create_regularization_of_grad(param, grad, regularization=None):
+def _create_regularization_of_grad(param, grad, regularization=None):
+    """ Create and add backward regularization Operators
+
+    Function helper of append_regularization_ops.
+    """
     # If no gradient or no regularization is specified,  then we don't need to do anything
     if grad is None or (param.regularizer is None and regularization is None):
         return grad
@@ -82,15 +86,15 @@ def append_regularization_ops(parameters_and_grads, regularization=None):
     if in_dygraph_mode():
         with framework.name_scope('regularization'):
             for param, grad in parameters_and_grads:
-                new_grad = create_regularization_of_grad(param, grad,
+                new_grad = _create_regularization_of_grad(param, grad,
                                                          regularization)
                 params_and_grads.append((param, new_grad))
     else:
         with framework.name_scope('regularization'):
             for param, grad in parameters_and_grads:
                 with param.block.program._optimized_guard([param, grad]):
-                    new_grad = create_regularization_of_grad(param, grad,
-                                                             regularization)
+                    new_grad = _create_regularization_of_grad(param, grad,
+                                                              regularization)
                     params_and_grads.append((param, new_grad))
     return params_and_grads
 

--- a/python/paddle/fluid/regularizer.py
+++ b/python/paddle/fluid/regularizer.py
@@ -84,11 +84,10 @@ def append_regularization_ops(parameters_and_grads, regularization=None):
     """
     params_and_grads = []
     if in_dygraph_mode():
-        with framework.name_scope('regularization'):
-            for param, grad in parameters_and_grads:
-                new_grad = _create_regularization_of_grad(param, grad,
-                                                         regularization)
-                params_and_grads.append((param, new_grad))
+        for param, grad in parameters_and_grads:
+            new_grad = _create_regularization_of_grad(param, grad,
+                                                      regularization)
+            params_and_grads.append((param, new_grad))
     else:
         with framework.name_scope('regularization'):
             for param, grad in parameters_and_grads:


### PR DESCRIPTION
与 https://github.com/PaddlePaddle/Paddle/pull/22143 类似，移除了动态图下频繁调用无用`_optimized_guard`的语句，减少训练耗时。

测试方法和过程同 https://github.com/PaddlePaddle/Paddle/pull/22143 ：
batch_size:  64， iter_num: 400

|  时间(s)   | forward | backward | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 | 26.766 | 8.429   | 22.303  | 57.500 |
| PR后 | 27.027  | 8.581  | 17.251  | 52.861 |
| 提升  | -    | -     | 22.6%    | 8.0%  |


batch_size:  256， iter_num: 100

|  时间(s)   | forward | backward | minimize | total  |
|:---:|:-------:|:--------:|:--------:|:------:|
| PR前 | 6.726 | 6.970   | 24.506  | 38.203 |
| PR后 | 6.904  | 6.955  | 24.562  | 38.422|
| 提升  | -    | -     | -0.2%    | -0.5%  |

**结论**：小batch_size下（如64），整体训练速度有8%左右的提升；当batch_size递增到256，无明显收益。
