### PR TITLE
Added function to store and parse error logs

### DIFF
--- a/tools/count_error_frequence.py
+++ b/tools/count_error_frequence.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+import sys
+import collections
+import paddle.compat as cpt
+
+ERROR_LOG_HOME = os.path.expanduser('~/.cache/paddle')
+
+
+def count_error_frequency(dirname):
+    if not os.path.exists(dirname):
+        return
+
+    error_freq_dict = collections.OrderedDict()
+    for filename in os.listdir(dirname):
+        filepath = os.path.join(dirname, filename)
+        if not os.path.isfile(filepath):
+            continue
+        print(filepath)
+        with open(filepath, 'rb') as f:
+            for line in f.readlines():
+                if line.startswith(b'FileLine:'):
+                    key_str = line[10:]
+                    if key_str not in error_freq_dict:
+                        error_freq_dict[key_str] = 1
+                    else:
+                        error_freq_dict[key_str] += 1
+    return error_freq_dict
+
+
+def cut_useless_prefix(filepath):
+    start_pos = filepath.rfind('paddle')
+    return filepath[start_pos:]
+
+
+def print_count_result(count_dict):
+    print("File:Line - Error Count")
+    for key, value in count_dict.items():
+        print("%s - %d" % (cut_useless_prefix(cpt.to_text(key)[:-1]), value))
+
+
+if __name__ == "__main__":
+    count_dict = count_error_frequency(ERROR_LOG_HOME)
+    print_count_result(count_dict)


### PR DESCRIPTION
In order to record which errors were triggered during the user's use of Paddle, find high-frequency trigger errors, optimize the high-frequency error information, and add the function of storing and parsing error logs.

- log saving path: `~/.cache/paddle/paddle-error-summary-2020-XX-XX.log`
- save format example:
```
λ yq01-gpu-255-137-12-00 /work/paddle/tools {develop} cat ~/.cache/paddle/paddle-error-summary-2020-01-14.log
FileLine: /work/paddle/paddle/fluid/operators/mul_op.cc:90
Summary: InvalidArgumentError: After flatten the input tensor X and Y to 2-D dimensions matrix X1 and Y1, the matrix X1's width must be equal with matrix Y1's height. But received X's shape = [10, 13], X1's shape = [10, 13], X1's width = 13; Y's shape = [12, 1], Y1's shape = [12, 1], Y1's height = 12.
  [Hint: Expected x_mat_dims[1] == y_mat_dims[0], but received x_mat_dims[1]:13 != y_mat_dims[0]:12.]

FileLine: /work/paddle/paddle/fluid/operators/mul_op.cc:90
Summary: InvalidArgumentError: After flatten the input tensor X and Y to 2-D dimensions matrix X1 and Y1, the matrix X1's width must be equal with matrix Y1's height. But received X's shape = [10, 13], X1's shape = [10, 13], X1's width = 13; Y's shape = [12, 1], Y1's shape = [12, 1], Y1's height = 12.
  [Hint: Expected x_mat_dims[1] == y_mat_dims[0], but received x_mat_dims[1]:13 != y_mat_dims[0]:12.]

FileLine: /work/paddle/paddle/fluid/operators/optimizers/sgd_op.cc:39
Summary: Error: Maybe the Input variable LearningRate has not been initialized. You may need to confirm if you put exe.run(startup_program) after optimizer.minimize function.
  [Hint: Expected framework::product(lr_dims) != 0, but received framework::product(lr_dims):0 == 0:0.]

FileLine: /work/paddle/paddle/fluid/operators/sequence_ops/sequence_pool_op.cc:37
Summary: Error: The LoD level Input(X) of sequence_pool should be larger than 0.
  [Hint: Expected in_lod_level > 0, but received in_lod_level:0 <= 0:0.]
```
- parse result example:
```
λ yq01-gpu-255-137-12-00 /work/paddle/tools {develop} python count_error_frequence.py
/root/.cache/paddle/paddle-error-summary-2020-01-14.log
File:Line - Error Count
paddle/fluid/operators/mul_op.cc:90 - 2
paddle/fluid/operators/optimizers/sgd_op.cc:39 - 1
paddle/fluid/operators/sequence_ops/sequence_pool_op.cc:37 - 1
```