### PR TITLE
add  flag to control  profile level in python API

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -185,10 +185,13 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
     }
 
     {
+      // TODO(wangchaochaohu) : refine code to use only one RecordEvent)
+      // in order to record different op type cost time
+      // and different op name cost time,we set two event.
       platform::RecordEvent record_event(Type());
       auto type_name = GetTypeName(outputs_, Type());
       platform::RecordEvent detail_record_event(
-          type_name, platform::RecordType::kUniqueOP);
+          type_name, platform::RecordRole::kUniqueOP);
       RunImpl(scope, place);
     }
 
@@ -972,7 +975,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   Scope* transfer_scope = nullptr;
   {
     platform::RecordEvent record_event("prepare_data",
-                                       platform::RecordType::kInnerOP);
+                                       platform::RecordRole::kInnerOP);
     transfer_scope = PrepareData(scope, *kernel_type_, &transfered_inplace_vars,
                                  runtime_ctx);
   }
@@ -986,7 +989,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   if (!all_kernels_must_compute_runtime_shape_) {
     platform::RecordEvent record_event("infer_shape",
-                                       platform::RecordType::kInnerOP);
+                                       platform::RecordRole::kInnerOP);
     RuntimeInferShapeContext infer_shape_ctx(*this, *runtime_ctx);
     this->InferShape(&infer_shape_ctx);
   }
@@ -999,7 +1002,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   // not Scope. Imperative mode only pass inputs and get outputs.
   {
     platform::RecordEvent record_event("compute",
-                                       platform::RecordType::kInnerOP);
+                                       platform::RecordRole::kInnerOP);
     (*kernel_func_)(ExecutionContext(*this, exec_scope, *dev_ctx, *runtime_ctx,
                                      kernel_configs));
   }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -173,7 +173,7 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
       platform::RecordEvent op_type_record_event(Type());
       auto op_name = platform::OpName(outputs_, Type());
       platform::RecordEvent op_name_record_event(
-          op_name, platform::RecordRole::kUniqueOP);
+          op_name, platform::RecordRole::kUniqueOp);
       RunImpl(scope, place);
     }
 
@@ -957,7 +957,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   Scope* transfer_scope = nullptr;
   {
     platform::RecordEvent record_event("prepare_data",
-                                       platform::RecordRole::kInnerOP);
+                                       platform::RecordRole::kInnerOp);
     transfer_scope = PrepareData(scope, *kernel_type_, &transfered_inplace_vars,
                                  runtime_ctx);
   }
@@ -971,7 +971,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   if (!all_kernels_must_compute_runtime_shape_) {
     platform::RecordEvent record_event("infer_shape",
-                                       platform::RecordRole::kInnerOP);
+                                       platform::RecordRole::kInnerOp);
     RuntimeInferShapeContext infer_shape_ctx(*this, *runtime_ctx);
     this->InferShape(&infer_shape_ctx);
   }
@@ -984,7 +984,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   // not Scope. Imperative mode only pass inputs and get outputs.
   {
     platform::RecordEvent record_event("compute",
-                                       platform::RecordRole::kInnerOP);
+                                       platform::RecordRole::kInnerOp);
     (*kernel_func_)(ExecutionContext(*this, exec_scope, *dev_ctx, *runtime_ctx,
                                      kernel_configs));
   }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -75,6 +75,23 @@ static DDim GetDimsDebug(const Scope& scope, const std::string& name,
     return DDim({-1});
   }
 }
+static std::string GetTypeName(const VariableNameMap& name_map,
+                               const std::string& type_name) {
+  if (platform::GetTracerOption() != platform::TracerOption::kDetail) return "";
+  std::string ret = type_name + "%";
+  for (auto it = name_map.begin(); it != name_map.end(); it++) {
+    auto name_outputs = it->second;
+    if (!name_outputs.empty() &&
+        type_name.length() < name_outputs[0].length()) {
+      char split_ch = '.';
+      size_t split_pos = name_outputs[0].find(split_ch);
+      ret = ret + name_outputs[0].substr(0, split_pos);
+      break;
+    }
+  }
+  ret = ret + "%";
+  return ret;
+}
 
 static bool VarInited(const Scope& scope, const std::string& name) {
   Variable* var = scope.FindVar(name);
@@ -168,6 +185,8 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
 
     {
       platform::RecordEvent record_event(Type());
+      auto type_name = GetTypeName(outputs_, Type());
+      platform::RecordEvent detail_record_event(type_name);
       RunImpl(scope, place);
     }
 

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -77,7 +77,8 @@ static DDim GetDimsDebug(const Scope& scope, const std::string& name,
 }
 static std::string GetTypeName(const VariableNameMap& name_map,
                                const std::string& type_name) {
-  if (platform::GetTracerOption() != platform::TracerOption::kDetail) return "";
+  if (platform::GetTracerOption() != platform::TracerOption::kAllOPDetail)
+    return "";
 
   std::string ret = type_name + "%";
   for (auto it = name_map.begin(); it != name_map.end(); it++) {
@@ -85,9 +86,6 @@ static std::string GetTypeName(const VariableNameMap& name_map,
     if (!name_outputs.empty() &&
         type_name.length() < name_outputs[0].length()) {
       ret = ret + name_outputs[0];
-      // char split_ch = '.';
-      // size_t split_pos = name_outputs[0].find(split_ch);
-      // ret = ret + name_outputs[0].substr(0, split_pos);
       break;
     }
   }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -170,9 +170,9 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
       // TODO(wangchaochaohu) : refine code to use only one RecordEvent)
       // in order to record different op type cost time
       // and different op name cost time,we set two event.
-      platform::RecordEvent record_event(Type());
+      platform::RecordEvent op_type_record_event(Type());
       auto op_name = platform::OpName(outputs_, Type());
-      platform::RecordEvent detail_record_event(
+      platform::RecordEvent op_name_record_event(
           op_name, platform::RecordRole::kUniqueOP);
       RunImpl(scope, place);
     }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -78,18 +78,21 @@ static DDim GetDimsDebug(const Scope& scope, const std::string& name,
 static std::string GetTypeName(const VariableNameMap& name_map,
                                const std::string& type_name) {
   if (platform::GetTracerOption() != platform::TracerOption::kDetail) return "";
+
   std::string ret = type_name + "%";
   for (auto it = name_map.begin(); it != name_map.end(); it++) {
     auto name_outputs = it->second;
     if (!name_outputs.empty() &&
         type_name.length() < name_outputs[0].length()) {
-      char split_ch = '.';
-      size_t split_pos = name_outputs[0].find(split_ch);
-      ret = ret + name_outputs[0].substr(0, split_pos);
+      ret = ret + name_outputs[0];
+      // char split_ch = '.';
+      // size_t split_pos = name_outputs[0].find(split_ch);
+      // ret = ret + name_outputs[0].substr(0, split_pos);
       break;
     }
   }
   ret = ret + "%";
+
   return ret;
 }
 
@@ -186,7 +189,8 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
     {
       platform::RecordEvent record_event(Type());
       auto type_name = GetTypeName(outputs_, Type());
-      platform::RecordEvent detail_record_event(type_name);
+      platform::RecordEvent detail_record_event(
+          type_name, platform::RecordType::kUniqueOP);
       RunImpl(scope, place);
     }
 
@@ -969,7 +973,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   std::vector<std::string> transfered_inplace_vars;
   Scope* transfer_scope = nullptr;
   {
-    platform::RecordEvent record_event("prepare_data_inner_op");
+    platform::RecordEvent record_event("prepare_data",
+                                       platform::RecordType::kInnerOP);
     transfer_scope = PrepareData(scope, *kernel_type_, &transfered_inplace_vars,
                                  runtime_ctx);
   }
@@ -982,7 +987,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   }
 
   if (!all_kernels_must_compute_runtime_shape_) {
-    platform::RecordEvent record_event("infer_shape_inner_op");
+    platform::RecordEvent record_event("infer_shape",
+                                       platform::RecordType::kInnerOP);
     RuntimeInferShapeContext infer_shape_ctx(*this, *runtime_ctx);
     this->InferShape(&infer_shape_ctx);
   }
@@ -994,7 +1000,8 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   // TODO(panyx0718): ExecutionContext should only depend on RuntimeContext
   // not Scope. Imperative mode only pass inputs and get outputs.
   {
-    platform::RecordEvent record_event("compute_inner_op");
+    platform::RecordEvent record_event("compute",
+                                       platform::RecordType::kInnerOP);
     (*kernel_func_)(ExecutionContext(*this, exec_scope, *dev_ctx, *runtime_ctx,
                                      kernel_configs));
   }

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -75,24 +75,6 @@ static DDim GetDimsDebug(const Scope& scope, const std::string& name,
     return DDim({-1});
   }
 }
-static std::string GetTypeName(const VariableNameMap& name_map,
-                               const std::string& type_name) {
-  if (platform::GetTracerOption() != platform::TracerOption::kAllOPDetail)
-    return "";
-
-  std::string ret = type_name + "%";
-  for (auto it = name_map.begin(); it != name_map.end(); it++) {
-    auto name_outputs = it->second;
-    if (!name_outputs.empty() &&
-        type_name.length() < name_outputs[0].length()) {
-      ret = ret + name_outputs[0];
-      break;
-    }
-  }
-  ret = ret + "%";
-
-  return ret;
-}
 
 static bool VarInited(const Scope& scope, const std::string& name) {
   Variable* var = scope.FindVar(name);
@@ -189,9 +171,9 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
       // in order to record different op type cost time
       // and different op name cost time,we set two event.
       platform::RecordEvent record_event(Type());
-      auto type_name = GetTypeName(outputs_, Type());
+      auto op_name = platform::OpName(outputs_, Type());
       platform::RecordEvent detail_record_event(
-          type_name, platform::RecordRole::kUniqueOP);
+          op_name, platform::RecordRole::kUniqueOP);
       RunImpl(scope, place);
     }
 

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -141,8 +141,8 @@ void PopEvent(const std::string &name) {
 RecordEvent::RecordEvent(const std::string &name, const RecordRole role)
     : is_enabled_(false), start_ns_(PosixInNsec()), role_(role) {
   if (g_state == ProfilerState::kDisabled || name.empty()) return;
-  if ((g_tracer_option == TracerOption::kOPDetail &&
-       role_ != RecordRole::kInnerOP) ||
+  if ((g_tracer_option == TracerOption::kOpDetail &&
+       role_ != RecordRole::kInnerOp) ||
       (g_tracer_option == TracerOption::kDefault &&
        role != RecordRole::kOrdinary))
     return;
@@ -789,7 +789,7 @@ int64_t ListenerId() { return profiler_lister_id; }
 
 std::string OpName(const framework::VariableNameMap &name_map,
                    const std::string &type_name) {
-  if (platform::GetTracerOption() != platform::TracerOption::kAllOPDetail)
+  if (platform::GetTracerOption() != platform::TracerOption::kAllOpDetail)
     return "";
 
   std::string ret = type_name + "%";

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -735,18 +735,22 @@ void DisableProfiler(EventSortingKey sorted_key,
     for (size_t j = 0; j < (all_events)[i].size(); j++) {
       std::string event_name = (all_events)[i][j].name();
       size_t start = event_name.find('%', 0);
-      size_t end = event_name.rfind('%', event_name.length() - 1);
-      if (start == std::string::npos || end == std::string::npos) continue;
-      std::string search_str = event_name.substr(start, end - start + 1);
-      auto it = find(op_name.begin(), op_name.end(), search_str);
-      std::string replace_str;
-      if (it != op_name.end()) {
-        replace_str = std::to_string(std::distance(op_name.begin(), it));
-      } else {
-        replace_str = std::to_string(op_name.size());
-        op_name.push_back(search_str);
+      size_t end = event_name.find('%', start + 1);
+      while (start != std::string::npos && end != std::string::npos) {
+        auto search_str = event_name.substr(start, end - start + 1);
+        auto it = find(op_name.begin(), op_name.end(), search_str);
+        std::string replace_str;
+        if (it != op_name.end()) {
+          replace_str = std::to_string(std::distance(op_name.begin(), it));
+        } else {
+          replace_str = std::to_string(op_name.size());
+          op_name.push_back(search_str);
+        }
+        event_name.replace(start, end - start + 1, replace_str);
+        start = start + 1;
+        start = event_name.find('%', start);
+        end = event_name.find('%', start + 1);
       }
-      event_name.replace(start, end - start + 1, replace_str);
       (all_events)[i][j].set_name(event_name);
     }
   }

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -724,7 +724,6 @@ void DisableProfiler(EventSortingKey sorted_key,
   DeviceTracer *tracer = GetDeviceTracer();
   if (tracer->IsEnabled()) {
     tracer->Disable();
-    tracer->GenProfile(profile_path);
     tracer->GenEventKernelCudaElapsedTime();
   }
 
@@ -755,6 +754,7 @@ void DisableProfiler(EventSortingKey sorted_key,
     }
   }
 
+  tracer->GenProfile(profile_path);
   ParseEvents(all_events, true, sorted_key);
   ParseEvents(all_events, false, sorted_key);
   if (VLOG_IS_ON(5)) {

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -138,23 +138,6 @@ void PopEvent(const std::string &name) {
   GetEventList().Record(EventType::kPopRange, name, g_thread_id);
 }
 
-RecordEvent::RecordEvent(const std::string &name)
-    : is_enabled_(false), start_ns_(PosixInNsec()) {
-  if (g_state == ProfilerState::kDisabled || name.empty()) return;
-  if ((g_tracer_option == TracerOption::kOPDetail &&
-       r_type_ == RecordRole::kInnerOP) ||
-      (g_tracer_option == TracerOption::kDefault &&
-       r_type_ != RecordRole::kOrdinary))
-    return;
-  // lock is not needed, the code below is thread-safe
-
-  is_enabled_ = true;
-  Event *e = PushEvent(name);
-  // Maybe need the same push/pop behavior.
-  SetCurAnnotation(e);
-  name_ = e->name();
-}
-
 RecordEvent::RecordEvent(const std::string &name, const RecordRole r_type)
     : is_enabled_(false), start_ns_(PosixInNsec()), r_type_(r_type) {
   if (g_state == ProfilerState::kDisabled || name.empty()) return;

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -142,9 +142,9 @@ RecordEvent::RecordEvent(const std::string &name)
     : is_enabled_(false), start_ns_(PosixInNsec()) {
   if (g_state == ProfilerState::kDisabled || name.empty()) return;
   if ((g_tracer_option == TracerOption::kOPDetail &&
-       r_type_ == RecordType::kInnerOP) ||
+       r_type_ == RecordRole::kInnerOP) ||
       (g_tracer_option == TracerOption::kDefault &&
-       r_type_ != RecordType::kOrdinary))
+       r_type_ != RecordRole::kOrdinary))
     return;
   // lock is not needed, the code below is thread-safe
 
@@ -155,13 +155,13 @@ RecordEvent::RecordEvent(const std::string &name)
   name_ = e->name();
 }
 
-RecordEvent::RecordEvent(const std::string &name, const RecordType r_type)
+RecordEvent::RecordEvent(const std::string &name, const RecordRole r_type)
     : is_enabled_(false), start_ns_(PosixInNsec()), r_type_(r_type) {
   if (g_state == ProfilerState::kDisabled || name.empty()) return;
   if ((g_tracer_option == TracerOption::kOPDetail &&
-       r_type_ != RecordType::kInnerOP) ||
+       r_type_ != RecordRole::kInnerOP) ||
       (g_tracer_option == TracerOption::kDefault &&
-       r_type != RecordType::kOrdinary))
+       r_type != RecordRole::kOrdinary))
     return;
   // lock is not needed, the code below is thread-safe
   is_enabled_ = true;

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -42,6 +42,7 @@ static int64_t profiler_lister_id = 0;
 static bool should_send_profile_state = false;
 std::mutex profiler_mu;
 
+static TracerOption g_tracer_option = TracerOption::kWhole;
 // The profiler state, the initial value is ProfilerState::kDisabled
 static ProfilerState g_state = ProfilerState::kDisabled;
 // The thread local event list only can be accessed by the specific thread
@@ -372,7 +373,7 @@ void PrintProfiler(const std::vector<std::vector<EventItem>> &events_table,
       std::vector<std::vector<EventItem>> child_table;
       std::vector<EventItem> table;
       bool do_next = false;
-      std::string op_end_str = "inner_op";
+      std::string op_end_str = "----inner_op";
       for (auto it = child_map.begin(); it != child_map.end(); it++) {
         if (it->first == event_item.name) {
           table.push_back(it->second);
@@ -774,5 +775,11 @@ void SetProfileListener() {
 }
 int64_t ListenerId() { return profiler_lister_id; }
 
+void SetTracerOption(TracerOption option) {
+  std::lock_guard<std::mutex> l(profiler_mu);
+  g_tracer_option = option;
+}
+
+platform::TracerOption GetTracerOption() { return g_tracer_option; }
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -42,15 +42,15 @@ enum ProfilerState {
 
 enum class RecordRole {
   kOrdinary,  // only record op time with op type key
-  kInnerOP,   // record op detail time with op type key
-  kUniqueOP,  // record op detail time with op unique name key
+  kInnerOp,   // record op detail time with op type key
+  kUniqueOp,  // record op detail time with op unique name key
 };
 
 // it is the flag to control to print the profiling result
 enum class TracerOption {
   kDefault,      // print the different op type profiling result
-  kOPDetail,     // print the detail profiling result of different op type
-  kAllOPDetail,  // print the detail profiling result of different op name
+  kOpDetail,     // print the detail profiling result of different op type
+  kAllOpDetail,  // print the detail profiling result of different op name
 };
 
 void Mark(const std::string& name);

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -39,16 +39,17 @@ enum ProfilerState {
   kAll,       // Profile both CPU and GPU. (Currently experimental).
 };
 
-enum RecordType {
-  kOrdinary,
-  kInnerOP,
-  kUniqueOP,
+enum class RecordRole {
+  kOrdinary,  // only record op time with op type key
+  kInnerOP,   // record op detail time with op type key
+  kUniqueOP,  // record op detail time with op unique name key
 };
 
+// it is the flag to control to print the profiling result
 enum class TracerOption {
-  kDefault,
-  kOPDetail,
-  kAllOPDetail,
+  kDefault,      // print the different op type profiling result
+  kOPDetail,     // print the detail profiling result of different op type
+  kAllOPDetail,  // print the detail profiling result of different op name
 };
 
 void Mark(const std::string& name);
@@ -92,7 +93,7 @@ void PopEvent(const std::string& name);
 
 struct RecordEvent {
   explicit RecordEvent(const std::string& name);
-  explicit RecordEvent(const std::string& name, const RecordType r_type);
+  explicit RecordEvent(const std::string& name, const RecordRole r_type);
 
   ~RecordEvent();
 
@@ -103,7 +104,7 @@ struct RecordEvent {
   // Need to distinguish name by op type, block_id, program_id and perhaps
   // different kernel invocations within an op.
   std::string full_name_;
-  RecordType r_type_{RecordType::kOrdinary};
+  RecordRole r_type_{RecordRole::kOrdinary};
 };
 
 class RecordRPCEvent {

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -92,8 +92,8 @@ Event* PushEvent(const std::string& name);
 void PopEvent(const std::string& name);
 
 struct RecordEvent {
-  explicit RecordEvent(const std::string& name);
-  explicit RecordEvent(const std::string& name, const RecordRole r_type);
+  RecordEvent(const std::string& name,
+              const RecordRole r_type = RecordRole::kOrdinary);
 
   ~RecordEvent();
 

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -23,6 +23,7 @@ limitations under the License. */
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include "paddle/fluid/framework/type_defs.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/event.h"
 #include "paddle/fluid/platform/place.h"
@@ -104,7 +105,7 @@ struct RecordEvent {
   // Need to distinguish name by op type, block_id, program_id and perhaps
   // different kernel invocations within an op.
   std::string full_name_;
-  RecordRole r_type_{RecordRole::kOrdinary};
+  RecordRole role_{RecordRole::kOrdinary};
 };
 
 class RecordRPCEvent {
@@ -196,6 +197,8 @@ bool ShouldSendProfileState();
 void SetProfileListener();
 int64_t ListenerId();
 
+std::string OpName(const framework::VariableNameMap& name_map,
+                   const std::string& type_name);
 void SetTracerOption(TracerOption option);
 platform::TracerOption GetTracerOption();
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -44,10 +44,11 @@ enum RecordType {
   kInnerOP,
   kUniqueOP,
 };
-enum TracerOption {
-  kWhole,
-  kOP,
-  kDetail,
+
+enum class TracerOption {
+  kDefault,
+  kOPDetail,
+  kAllOPDetail,
 };
 
 void Mark(const std::string& name);

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -39,6 +39,12 @@ enum ProfilerState {
   kAll,       // Profile both CPU and GPU. (Currently experimental).
 };
 
+enum TracerOption {
+  kWhole,
+  kOP,
+  kDetail,
+};
+
 void Mark(const std::string& name);
 
 void PushMemEvent(uint64_t start_ns, uint64_t end_ns, size_t bytes,
@@ -181,6 +187,8 @@ bool ShouldSendProfileState();
 void SetProfileListener();
 int64_t ListenerId();
 
+void SetTracerOption(TracerOption option);
+platform::TracerOption GetTracerOption();
 #ifdef PADDLE_WITH_CUDA
 void DummyKernelAndEvent();
 #endif

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -39,6 +39,11 @@ enum ProfilerState {
   kAll,       // Profile both CPU and GPU. (Currently experimental).
 };
 
+enum RecordType {
+  kOrdinary,
+  kInnerOP,
+  kUniqueOP,
+};
 enum TracerOption {
   kWhole,
   kOP,
@@ -86,6 +91,7 @@ void PopEvent(const std::string& name);
 
 struct RecordEvent {
   explicit RecordEvent(const std::string& name);
+  explicit RecordEvent(const std::string& name, const RecordType r_type);
 
   ~RecordEvent();
 
@@ -96,6 +102,7 @@ struct RecordEvent {
   // Need to distinguish name by op type, block_id, program_id and perhaps
   // different kernel invocations within an op.
   std::string full_name_;
+  RecordType r_type_{RecordType::kOrdinary};
 };
 
 class RecordRPCEvent {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1557,8 +1557,8 @@ All parameter, weight, gradient are variables in Paddle.
 
   py::enum_<platform::TracerOption>(m, "TracerOption", py::arithmetic())
       .value("kDefault", platform::TracerOption::kDefault)
-      .value("kOPDetail", platform::TracerOption::kOPDetail)
-      .value("kAllOPDetail", platform::TracerOption::kAllOPDetail)
+      .value("kOpDetail", platform::TracerOption::kOpDetail)
+      .value("kAllOpDetail", platform::TracerOption::kAllOpDetail)
       .export_values();
 
   py::enum_<platform::ProfilerState>(m, "ProfilerState", py::arithmetic())

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1555,6 +1555,12 @@ All parameter, weight, gradient are variables in Paddle.
 #endif
 #endif
 
+  py::enum_<platform::TracerOption>(m, "TracerOption", py::arithmetic())
+      .value("kWhole", platform::TracerOption::kWhole)
+      .value("kOP", platform::TracerOption::kOP)
+      .value("kDetail", platform::TracerOption::kDetail)
+      .export_values();
+
   py::enum_<platform::ProfilerState>(m, "ProfilerState", py::arithmetic())
       .value("kDisabled", platform::ProfilerState::kDisabled)
       .value("kCPU", platform::ProfilerState::kCPU)
@@ -1571,6 +1577,7 @@ All parameter, weight, gradient are variables in Paddle.
       .value("kAve", platform::EventSortingKey::kAve)
       .export_values();
 
+  m.def("set_tracer_option", platform::SetTracerOption);
   m.def("enable_profiler", platform::EnableProfiler);
   m.def("disable_profiler", platform::DisableProfiler);
   m.def("is_profiler_enabled", platform::IsProfileEnabled);

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1556,9 +1556,9 @@ All parameter, weight, gradient are variables in Paddle.
 #endif
 
   py::enum_<platform::TracerOption>(m, "TracerOption", py::arithmetic())
-      .value("kWhole", platform::TracerOption::kWhole)
-      .value("kOP", platform::TracerOption::kOP)
-      .value("kDetail", platform::TracerOption::kDetail)
+      .value("kDefault", platform::TracerOption::kDefault)
+      .value("kOPDetail", platform::TracerOption::kOPDetail)
+      .value("kAllOPDetail", platform::TracerOption::kAllOPDetail)
       .export_values();
 
   py::enum_<platform::ProfilerState>(m, "ProfilerState", py::arithmetic())

--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -169,7 +169,8 @@ def start_profiler(state, tracer_option="Default"):
         prof_state = core.ProfilerState.kAll
 
     if tracer_option not in ["Default", "OPDetail", "AllOPDetail"]:
-        raise ValueError("tracer option must be 'Whole', 'OP', 'Detail'.")
+        raise ValueError(
+            "tracer option must be 'Default', 'OPDetail', 'AllOPDetail'.")
     if tracer_option == "Default":
         prof_tracer_option = core.TracerOption.kDefault
     elif tracer_option == "OPDetail":
@@ -241,7 +242,7 @@ def stop_profiler(sorted_key=None, profile_path='/tmp/profile'):
 def profiler(state,
              sorted_key=None,
              profile_path='/tmp/profile',
-             tracer_option="OP"):
+             tracer_option="Default"):
     """
     The profiler interface. Different from `fluid.profiler.cuda_profiler`, 
     this profiler can be used to profile both CPU and GPU program.
@@ -262,7 +263,7 @@ def profiler(state,
             The `ave` means sorting by the average execution time.
         profile_path (str, optional) : If state == 'All', it will generate timeline,
             and write it into `profile_path`. The default profile_path is `/tmp/profile`. 
-        tracer_option (str) : tracer_option can be one of ['Whole', 'OP', 'Detail'], it
+        tracer_option (str) : tracer_option can be one of ['Default', 'OPDetail', 'AllOPDetail'], it
             can control the profile level and print the different level profile result.
 
     Raises:

--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -137,14 +137,15 @@ def start_profiler(state, tracer_option='Default'):
             or 'All'. 'CPU' means only profiling CPU; 'GPU' means profiling
             both CPU and GPU; 'All' means profiling both CPU and GPU, and 
             generates timeline as well.
-        tracer_option (str) : tracer_option can be one of ['Default', 'OPDetail', 'AllOPDetail'], it
+        tracer_option (str) : tracer_option can be one of ['Default', 'OpDetail', 'AllOpDetail'], it
             can control the profile level and print the different level profile result.Default option print 
-            the different OP type profiling result and the OPDetail option print the detail profiling 
-            result of different op type  such as compute and data transform, AllOPDetail option 
-            print the detail profiling result of different op name same as OPDetail.
+            the different Op type profiling result and the OpDetail option print the detail profiling 
+            result of different op type  such as compute and data transform, AllOpDetail option 
+            print the detail profiling result of different op name same as OpDetail.
 
     Raises:
         ValueError: If `state` is not in ['CPU', 'GPU', 'All'].
+        ValueError: If `tracer_option` is not in ['Default', 'OpDetail', 'AllOpDetail']
 
     Examples:
 
@@ -160,7 +161,7 @@ def start_profiler(state, tracer_option='Default'):
                 # except each iteration
             profiler.stop_profiler('total', '/tmp/profile')
             
-            profiler.start_profiler('GPU', "OPDetail")
+            profiler.start_profiler('GPU', "OpDetail")
             for iter in range(10):
                 if iter == 2:
                     profiler.reset_profiler()
@@ -178,15 +179,15 @@ def start_profiler(state, tracer_option='Default'):
     else:
         prof_state = core.ProfilerState.kAll
 
-    if tracer_option not in ['Default', 'OPDetail', 'AllOPDetail']:
+    if tracer_option not in ['Default', 'OpDetail', 'AllOpDetail']:
         raise ValueError(
-            "tracer option must be 'Default', 'OPDetail', 'AllOPDetail'.")
+            "tracer option must be 'Default', 'OpDetail', 'AllOpDetail'.")
     if tracer_option == "Default":
         prof_tracer_option = core.TracerOption.kDefault
-    elif tracer_option == "OPDetail":
-        prof_tracer_option = core.TracerOption.kOPDetail
+    elif tracer_option == "OpDetail":
+        prof_tracer_option = core.TracerOption.kOpDetail
     else:
-        prof_tracer_option = core.TracerOption.kAllOPDetail
+        prof_tracer_option = core.TracerOption.kAllOpDetail
 
     core.set_tracer_option(prof_tracer_option)
     core.enable_profiler(prof_state)
@@ -273,11 +274,11 @@ def profiler(state,
             The `ave` means sorting by the average execution time.
         profile_path (str, optional) : If state == 'All', it will generate timeline,
             and write it into `profile_path`. The default profile_path is `/tmp/profile`. 
-        tracer_option (str) : tracer_option can be one of ['Default', 'OPDetail', 'AllOPDetail'], it
+        tracer_option (str) : tracer_option can be one of ['Default', 'OpDetail', 'AllOpDetail'], it
             can control the profile level and print the different level profile result.Default option print 
-            the different OP type profiling result and the OPDetail option print the detail profiling 
-            result of different op type  such as compute and data transform, AllOPDetail option 
-            print the detail profiling result of different op name same as OPDetail.
+            the different Op type profiling result and the OpDetail option print the detail profiling 
+            result of different op type  such as compute and data transform, AllOpDetail option 
+            print the detail profiling result of different op name same as OpDetail.
 
     Raises:
         ValueError: If `state` is not in ['CPU', 'GPU', 'All']. If `sorted_key` is

--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -126,7 +126,7 @@ def reset_profiler():
     core.reset_profiler()
 
 
-def start_profiler(state, tracer_option="Whole"):
+def start_profiler(state, tracer_option="Default"):
     """
     Enable the profiler. Uers can use `fluid.profiler.start_profiler` and
     `fluid.profiler.stop_profiler` to profile, which is equal to the usage 
@@ -137,7 +137,7 @@ def start_profiler(state, tracer_option="Whole"):
             or 'All'. 'CPU' means only profiling CPU; 'GPU' means profiling
             both CPU and GPU; 'All' means profiling both CPU and GPU, and 
             generates timeline as well.
-        tracer_option (str) : tracer_option can be one of ['Whole', 'OP', 'Detail'], it
+        tracer_option (str) : tracer_option can be one of ['Default', 'OPDetail', 'AllOPDetail'], it
             can control the profile level and print the different level profile result.
 
     Raises:
@@ -168,14 +168,14 @@ def start_profiler(state, tracer_option="Whole"):
     else:
         prof_state = core.ProfilerState.kAll
 
-    if tracer_option not in ["Whole", "OP", "Detail"]:
+    if tracer_option not in ["Default", "OPDetail", "AllOPDetail"]:
         raise ValueError("tracer option must be 'Whole', 'OP', 'Detail'.")
-    if tracer_option == "Whole":
-        prof_tracer_option = core.TracerOption.kWhole
-    elif tracer_option == "OP":
-        prof_tracer_option = core.TracerOption.kOP
+    if tracer_option == "Default":
+        prof_tracer_option = core.TracerOption.kDefault
+    elif tracer_option == "OPDetail":
+        prof_tracer_option = core.TracerOption.kOPDetail
     else:
-        prof_tracer_option = core.TracerOption.kDetail
+        prof_tracer_option = core.TracerOption.kAllOPDetail
 
     core.set_tracer_option(prof_tracer_option)
     core.enable_profiler(prof_state)

--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -138,9 +138,9 @@ def start_profiler(state, tracer_option='Default'):
             both CPU and GPU; 'All' means profiling both CPU and GPU, and 
             generates timeline as well.
         tracer_option (str) : tracer_option can be one of ['Default', 'OpDetail', 'AllOpDetail'], it
-            can control the profile level and print the different level profile result.Default option print 
+            can control the profile level and print the different level profile result. Default option print 
             the different Op type profiling result and the OpDetail option print the detail profiling 
-            result of different op type  such as compute and data transform, AllOpDetail option 
+            result of different op types such as compute and data transform, AllOpDetail option 
             print the detail profiling result of different op name same as OpDetail.
 
     Raises:
@@ -275,9 +275,9 @@ def profiler(state,
         profile_path (str, optional) : If state == 'All', it will generate timeline,
             and write it into `profile_path`. The default profile_path is `/tmp/profile`. 
         tracer_option (str) : tracer_option can be one of ['Default', 'OpDetail', 'AllOpDetail'], it
-            can control the profile level and print the different level profile result.Default option print 
+            can control the profile level and print the different level profile result. Default option print 
             the different Op type profiling result and the OpDetail option print the detail profiling 
-            result of different op type  such as compute and data transform, AllOpDetail option 
+            result of different op types such as compute and data transform, AllOpDetail option 
             print the detail profiling result of different op name same as OpDetail.
 
     Raises:

--- a/python/paddle/fluid/profiler.py
+++ b/python/paddle/fluid/profiler.py
@@ -126,7 +126,7 @@ def reset_profiler():
     core.reset_profiler()
 
 
-def start_profiler(state, tracer_option="Default"):
+def start_profiler(state, tracer_option='Default'):
     """
     Enable the profiler. Uers can use `fluid.profiler.start_profiler` and
     `fluid.profiler.stop_profiler` to profile, which is equal to the usage 
@@ -138,7 +138,10 @@ def start_profiler(state, tracer_option="Default"):
             both CPU and GPU; 'All' means profiling both CPU and GPU, and 
             generates timeline as well.
         tracer_option (str) : tracer_option can be one of ['Default', 'OPDetail', 'AllOPDetail'], it
-            can control the profile level and print the different level profile result.
+            can control the profile level and print the different level profile result.Default option print 
+            the different OP type profiling result and the OPDetail option print the detail profiling 
+            result of different op type  such as compute and data transform, AllOPDetail option 
+            print the detail profiling result of different op name same as OPDetail.
 
     Raises:
         ValueError: If `state` is not in ['CPU', 'GPU', 'All'].
@@ -156,6 +159,13 @@ def start_profiler(state, tracer_option="Default"):
                     profiler.reset_profiler()
                 # except each iteration
             profiler.stop_profiler('total', '/tmp/profile')
+            
+            profiler.start_profiler('GPU', "OPDetail")
+            for iter in range(10):
+                if iter == 2:
+                    profiler.reset_profiler()
+                # except each iteration
+            profiler.stop_profiler('total', '/tmp/profile')
     """
     if core.is_profiler_enabled():
         return
@@ -168,7 +178,7 @@ def start_profiler(state, tracer_option="Default"):
     else:
         prof_state = core.ProfilerState.kAll
 
-    if tracer_option not in ["Default", "OPDetail", "AllOPDetail"]:
+    if tracer_option not in ['Default', 'OPDetail', 'AllOPDetail']:
         raise ValueError(
             "tracer option must be 'Default', 'OPDetail', 'AllOPDetail'.")
     if tracer_option == "Default":
@@ -242,7 +252,7 @@ def stop_profiler(sorted_key=None, profile_path='/tmp/profile'):
 def profiler(state,
              sorted_key=None,
              profile_path='/tmp/profile',
-             tracer_option="Default"):
+             tracer_option='Default'):
     """
     The profiler interface. Different from `fluid.profiler.cuda_profiler`, 
     this profiler can be used to profile both CPU and GPU program.
@@ -264,7 +274,10 @@ def profiler(state,
         profile_path (str, optional) : If state == 'All', it will generate timeline,
             and write it into `profile_path`. The default profile_path is `/tmp/profile`. 
         tracer_option (str) : tracer_option can be one of ['Default', 'OPDetail', 'AllOPDetail'], it
-            can control the profile level and print the different level profile result.
+            can control the profile level and print the different level profile result.Default option print 
+            the different OP type profiling result and the OPDetail option print the detail profiling 
+            result of different op type  such as compute and data transform, AllOPDetail option 
+            print the detail profiling result of different op name same as OPDetail.
 
     Raises:
         ValueError: If `state` is not in ['CPU', 'GPU', 'All']. If `sorted_key` is
@@ -287,7 +300,7 @@ def profiler(state,
             exe = fluid.Executor(place)
             exe.run(fluid.default_startup_program())
 
-            with profiler.profiler('CPU', 'total', '/tmp/profile') as prof:
+            with profiler.profiler('CPU', 'total', '/tmp/profile', 'Default') as prof:
                 for i in range(epoc):
                     input = np.random.random(dshape).astype('float32')
                     exe.run(fluid.default_main_program(), feed={'data': input})

--- a/python/paddle/fluid/tests/unittests/test_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler.py
@@ -116,20 +116,20 @@ class TestProfiler(unittest.TestCase):
                     print("Warning: unregister", event.name)
 
     def test_cpu_profiler(self):
-        self.net_profiler('CPU', "Whole")
-        self.net_profiler('CPU', "Whole", use_parallel_executor=True)
+        self.net_profiler('CPU', "Default")
+        self.net_profiler('CPU', "Default", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_cuda_profiler(self):
-        self.net_profiler('GPU', "OP")
-        self.net_profiler('GPU', "OP", use_parallel_executor=True)
+        self.net_profiler('GPU', "OPDetail")
+        self.net_profiler('GPU', "OPDetail", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_all_profiler(self):
-        self.net_profiler('All', "Detail")
-        self.net_profiler('All', "Detail", use_parallel_executor=True)
+        self.net_profiler('All', "AllOPDetail")
+        self.net_profiler('All', "AllOPDetail", use_parallel_executor=True)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler.py
@@ -22,6 +22,7 @@ import paddle.fluid as fluid
 import paddle.fluid.profiler as profiler
 import paddle.fluid.layers as layers
 import paddle.fluid.core as core
+from paddle.fluid import compiler, Program, program_guard
 import paddle.fluid.proto.profiler.profiler_pb2 as profiler_pb2
 
 
@@ -30,7 +31,11 @@ class TestProfiler(unittest.TestCase):
     def setUpClass(cls):
         os.environ['CPU_NUM'] = str(4)
 
-    def net_profiler(self, state, use_parallel_executor=False):
+    def net_profiler(self,
+                     state,
+                     option,
+                     iter_range=None,
+                     use_parallel_executor=False):
         profile_path = os.path.join(tempfile.gettempdir(), "profile")
         open(profile_path, "w").write("")
         startup_program = fluid.Program()
@@ -75,7 +80,7 @@ class TestProfiler(unittest.TestCase):
                 main_program=main_program)
 
         pass_acc_calculator = fluid.average.WeightedAverage()
-        with profiler.profiler(state, 'total', profile_path) as prof:
+        with profiler.profiler(state, 'total', profile_path, option) as prof:
             for iter in range(10):
                 if iter == 2:
                     profiler.reset_profiler()
@@ -94,36 +99,37 @@ class TestProfiler(unittest.TestCase):
                 pass_acc_calculator.add(value=acc, weight=b_size)
                 pass_acc = pass_acc_calculator.eval()
         data = open(profile_path, 'rb').read()
-        self.assertGreater(len(data), 0)
-        profile_pb = profiler_pb2.Profile()
-        profile_pb.ParseFromString(data)
-        self.assertGreater(len(profile_pb.events), 0)
-        for event in profile_pb.events:
-            if event.type == profiler_pb2.Event.GPUKernel:
-                if not event.detail_info and not event.name.startswith("MEM"):
-                    raise Exception(
-                        "Kernel %s missing event. Has this kernel been recorded by RecordEvent?"
-                        % event.name)
-            elif event.type == profiler_pb2.Event.CPU and (
-                    event.name.startswith("Driver API") or
-                    event.name.startswith("Runtime API")):
-                print("Warning: unregister", event.name)
+        if (len(data) > 0):
+            profile_pb = profiler_pb2.Profile()
+            profile_pb.ParseFromString(data)
+            self.assertGreater(len(profile_pb.events), 0)
+            for event in profile_pb.events:
+                if event.type == profiler_pb2.Event.GPUKernel:
+                    if not event.detail_info and not event.name.startswith(
+                            "MEM"):
+                        raise Exception(
+                            "Kernel %s missing event. Has this kernel been recorded by RecordEvent?"
+                            % event.name)
+                elif event.type == profiler_pb2.Event.CPU and (
+                        event.name.startswith("Driver API") or
+                        event.name.startswith("Runtime API")):
+                    print("Warning: unregister", event.name)
 
     def test_cpu_profiler(self):
-        self.net_profiler('CPU')
-        self.net_profiler('CPU', use_parallel_executor=True)
+        self.net_profiler('CPU', "Whole")
+        self.net_profiler('CPU', "Whole", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_cuda_profiler(self):
-        self.net_profiler('GPU')
-        self.net_profiler('GPU', use_parallel_executor=True)
+        self.net_profiler('GPU', "OP")
+        self.net_profiler('GPU', "OP", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_all_profiler(self):
-        self.net_profiler('All')
-        self.net_profiler('All', use_parallel_executor=True)
+        self.net_profiler('All', "Detail")
+        self.net_profiler('All', "Detail", use_parallel_executor=True)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler.py
@@ -122,14 +122,14 @@ class TestProfiler(unittest.TestCase):
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_cuda_profiler(self):
-        self.net_profiler('GPU', "OPDetail")
-        self.net_profiler('GPU', "OPDetail", use_parallel_executor=True)
+        self.net_profiler('GPU', "OpDetail")
+        self.net_profiler('GPU', "OpDetail", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_all_profiler(self):
-        self.net_profiler('All', "AllOPDetail")
-        self.net_profiler('All', "AllOPDetail", use_parallel_executor=True)
+        self.net_profiler('All', "AllOpDetail")
+        self.net_profiler('All', "AllOpDetail", use_parallel_executor=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It's the split of https://github.com/PaddlePaddle/Paddle/pull/21941, add three trace option to control the profile level.


整体实现思路:通过RecordRole去控制我们记录不同的Event,如是否是需要记录OP运行中的compute.
RecordRole分为三类: 分别是kDefault记录不同op_type运行时间, kinnerOP用于记录OP里详细信息如compute的运行时间， 最后kUnqiueOP时标识记录的时间是不同OP name而不是不同的OP type.

关于网络中不同的OP如何区分：这里的实现时通过不同OP的输出的name是不同的进行区分的。



Python端目前有三个Option进行控制：分别是Default OpDetail AllOpDetaial
```
import paddle.fluid as fluid
import numpy as np
from paddle.fluid import profiler
#profiler.start_profiler("All", "Default")
#profiler.start_profiler("All", "OpDetail")
profiler.start_profiler("All", "AllOpDetail")
x0 = fluid.layers.fill_constant(shape=[128, 256], dtype='int64', value=10)
x1 = fluid.layers.fill_constant(shape=[128, 256], dtype='int64', value=100)
x2 = fluid.layers.fill_constant(shape=[128, 256], dtype='int64', value=200)
x3 = fluid.layers.fill_constant(shape=[128, 256], dtype='int64', value=300)
result = fluid.layers.sum([x0, x1, x2, x3])
exe = fluid.Executor(fluid.CPUPlace())
exe.run(fluid.default_startup_program())
all_result, = exe.run(fetch_list=[result])
print(all_result)
profiler.stop_profiler("total", "/profile/sum")
```

Default:
```

------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Event                                             Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant                            4           1.1566      1.156596 (1.000000)     0.000000 (0.000000)     0.19958     0.551349    0.289149    0.784418
thread0::sum                                      1           0.286198    0.286198 (1.000000)     0.000000 (0.000000)     0.286198    0.286198    0.286198    0.194103
thread0::fetch                                    1           0.031669    0.031669 (1.000000)     0.000000 (0.000000)     0.031669    0.031669    0.031669    0.0214783
```

OpDetail
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Event                                             Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant                            4           1.24034     1.240343 (1.000000)     0.000000 (0.000000)     0.217738    0.567601    0.310086    0.762623
  thread0::fill_constant/data_transform           4           0.009819    0.009819 (1.000000)     0.000000 (0.000000)     0.001369    0.005022    0.0012555   0.0060372
  thread0::fill_constant/runtime_infer_shape      4           0.023054    0.023054 (1.000000)     0.000000 (0.000000)     0.001629    0.016149    0.00403725  0.0141747
  thread0::fill_constant/compute                  4           1.16234     1.162345 (1.000000)     0.000000 (0.000000)     0.20965     0.52093     0.130233    0.714666
thread0::sum                                      1           0.351347    0.351347 (1.000000)     0.000000 (0.000000)     0.351347    0.351347    0.351347    0.216025
  thread0::sum/data_transform                     1           0.001463    0.001463 (1.000000)     0.000000 (0.000000)     0.001463    0.001463    0.001463    0.000899523
  thread0::sum/runtime_infer_shape                1           0.011573    0.011573 (1.000000)     0.000000 (0.000000)     0.011573    0.011573    0.011573    0.00711564
  thread0::sum/compute                            1           0.322641    0.322641 (1.000000)     0.000000 (0.000000)     0.322641    0.322641    0.322641    0.198375
thread0::fetch                                    1           0.034727    0.034727 (1.000000)     0.000000 (0.000000)     0.034727    0.034727    0.034727    0.0213518
```

AllOpDetail
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Event                                                     Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::fill_constant                                    4           1.66654     1.666539 (1.000000)     0.000000 (0.000000)     0.226436    0.942276    0.416635    0.800918
  thread0::fill_constant/fill_constant0                   1           0.937816    0.937816 (1.000000)     0.000000 (0.000000)     0.937816    0.937816    0.937816    0.450703
    thread0::fill_constant/fill_constant0/prepare_data    1           0.0035      0.003500 (1.000000)     0.000000 (0.000000)     0.0035      0.0035      0.0035      0.00168206
    thread0::fill_constant/fill_constant0/infer_shape     1           0.010721    0.010721 (1.000000)     0.000000 (0.000000)     0.010721    0.010721    0.010721    0.00515238
    thread0::fill_constant/fill_constant0/compute         1           0.89758     0.897580 (1.000000)     0.000000 (0.000000)     0.89758     0.89758     0.89758     0.431366
  thread0::fill_constant/fill_constant1                   1           0.262611    0.262611 (1.000000)     0.000000 (0.000000)     0.262611    0.262611    0.262611    0.126208
    thread0::fill_constant/fill_constant1/prepare_data    1           0.00174     0.001740 (1.000000)     0.000000 (0.000000)     0.00174     0.00174     0.00174     0.000836223
    thread0::fill_constant/fill_constant1/infer_shape     1           0.003249    0.003249 (1.000000)     0.000000 (0.000000)     0.003249    0.003249    0.003249    0.00156143
    thread0::fill_constant/fill_constant1/compute         1           0.24793     0.247930 (1.000000)     0.000000 (0.000000)     0.24793     0.24793     0.24793     0.119152
  thread0::fill_constant/fill_constant2                   1           0.224757    0.224757 (1.000000)     0.000000 (0.000000)     0.224757    0.224757    0.224757    0.108015
    thread0::fill_constant/fill_constant2/prepare_data    1           0.001352    0.001352 (1.000000)     0.000000 (0.000000)     0.001352    0.001352    0.001352    0.000649755
    thread0::fill_constant/fill_constant2/infer_shape     1           0.002045    0.002045 (1.000000)     0.000000 (0.000000)     0.002045    0.002045    0.002045    0.000982802
    thread0::fill_constant/fill_constant2/compute         1           0.215799    0.215799 (1.000000)     0.000000 (0.000000)     0.215799    0.215799    0.215799    0.10371
  thread0::fill_constant/fill_constant3                   1           0.231639    0.231639 (1.000000)     0.000000 (0.000000)     0.231639    0.231639    0.231639    0.111323
    thread0::fill_constant/fill_constant3/prepare_data    1           0.001175    0.001175 (1.000000)     0.000000 (0.000000)     0.001175    0.001175    0.001175    0.000564691
    thread0::fill_constant/fill_constant3/infer_shape     1           0.001865    0.001865 (1.000000)     0.000000 (0.000000)     0.001865    0.001865    0.001865    0.000896296
    thread0::fill_constant/fill_constant3/compute         1           0.224329    0.224329 (1.000000)     0.000000 (0.000000)     0.224329    0.224329    0.224329    0.10781
thread0::sum                                              1           0.331996    0.331996 (1.000000)     0.000000 (0.000000)     0.331996    0.331996    0.331996    0.159553
  thread0::sum/sum0                                       1           0.33034     0.330340 (1.000000)     0.000000 (0.000000)     0.33034     0.33034     0.33034     0.158757
    thread0::sum/sum0/prepare_data                        1           0.001882    0.001882 (1.000000)     0.000000 (0.000000)     0.001882    0.001882    0.001882    0.000904466
    thread0::sum/sum0/infer_shape                         1           0.011765    0.011765 (1.000000)     0.000000 (0.000000)     0.011765    0.011765    0.011765    0.00565412
    thread0::sum/sum0/compute                             1           0.296439    0.296439 (1.000000)     0.000000 (0.000000)     0.296439    0.296439    0.296439    0.142465
thread0::fetch                                            1           0.08225     0.082250 (1.000000)     0.000000 (0.000000)     0.08225     0.08225     0.08225     0.0395284
  thread0::fetch/fetch0                                   1           0.080725    0.080725 (1.000000)     0.000000 (0.000000)     0.080725    0.080725    0.080725    0.0387955
```




```
------------------------->     Profiling Report     <-------------------------

Note! This Report merge all thread info into one.
Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Event                                                                          Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
recurrent_grad                                                                 21          804.499     732.342569 (0.910309)   72.156746 (0.089691)    37.4012     44.5308     38.3095     0.300716
  recurrent_grad/rnn_memory_helper_grad                                        3780        88.6926     82.921616 (0.934932)    5.771012 (0.065068)     0.017645    0.095397    0.0234637   0.0331527
    recurrent_grad/rnn_memory_helper_grad/fill_constant                        84          2.19308     2.079226 (0.948084)     0.113855 (0.051916)     0.018138    0.065305    0.0261081   0.000819758
    recurrent_grad/rnn_memory_helper_grad/GpuMemcpyAsync(same_gpu):GPU->GPU    3696        63.9933     58.336174 (0.911598)    5.657157 (0.088402)     0.013034    0.060898    0.0173142   0.0239203
  recurrent_grad/sum                                                           4200        168.533     149.187670 (0.885212)   19.345654 (0.114788)    0.019326    0.116065    0.040127    0.0629966
    recurrent_grad/sum/GpuMemcpyAsync:CPU->GPU                                 2520        28.9229     24.245900 (0.838293)    4.677037 (0.161707)     0.009189    0.041825    0.0114774   0.0108112
  recurrent_grad/elementwise_mul_grad                                          2520        58.2094     52.814118 (0.907312)    5.395306 (0.092688)     0.018886    0.062501    0.023099    0.0217583
  recurrent_grad/sigmoid_grad                                                  2520        51.9775     47.899904 (0.921550)    4.077621 (0.078450)     0.016988    0.125729    0.020626    0.0194288
  recurrent_grad/tanh_grad                                                     1680        40.9605     38.281651 (0.934598)    2.678897 (0.065402)     0.017356    6.81093     0.0243813   0.0153108
  recurrent_grad/elementwise_add_grad                                          1680        41.3084     38.129379 (0.923041)    3.179058 (0.076959)     0.019306    0.061272    0.0245884   0.0154408
  recurrent_grad/slice_grad                                                    3360        80.6059     73.544686 (0.912399)    7.061190 (0.087601)     0.019501    0.079179    0.0239898   0.0301299
  recurrent_grad/matmul_grad                                                   840         75.9349     53.409658 (0.703361)    22.525228 (0.296639)    0.080266    0.174377    0.0903987   0.0283839
  recurrent_grad/concat_grad                                                   840         24.3729     22.541760 (0.924869)    1.831165 (0.075131)     0.024272    0.058545    0.0290154   0.00911043
  recurrent_grad/fill_constant                                                 84          1.93193     1.793243 (0.928213)     0.138687 (0.071787)     0.018427    0.04727     0.0229992   0.000722142
  recurrent_grad/GpuMemcpyAsync(same_gpu):GPU->GPU                             105         1.8919      1.738972 (0.919167)     0.152928 (0.080833)     0.013232    0.045659    0.0180181   0.000707179
BufferedReader:MemoryCopy                                                      22          609.897     609.800802 (0.999843)   0.096000 (0.000157)     0.061339    607.719     27.7226     0.227975
  BufferedReader:MemoryCopy/GpuMemcpyAsync:CUDAPinned->GPU                     44          1.25889     1.162895 (0.923743)     0.096000 (0.076257)     0.011581    0.14307     0.0286112   0.000470566
read                                                                           21          608.286     608.286491 (1.000000)   0.000000 (0.000000)     0.014595    607.926     28.966      0.227373
  read/read                                                                    21          608.195     608.195499 (1.000000)   0.000000 (0.000000)     0.011688    607.91      28.9617     0.227339
recurrent                                                                      21          468.932     431.181769 (0.919497)   37.750525 (0.080503)    21.5075     23.9174     22.3301     0.175284
  recurrent/concat                                                             840         22.8466     21.100668 (0.923581)    1.745911 (0.076419)     0.021729    0.082435    0.0271983   0.00853989
  recurrent/matmul                                                             840         44.1465     33.380341 (0.756126)    10.766166 (0.243874)    0.04636     0.278332    0.0525554   0.0165017
  recurrent/elementwise_add                                                    1680        43.655      40.760898 (0.933706)    2.894069 (0.066294)     0.015978    0.080906    0.0259851   0.0163179
  recurrent/slice                                                              3360        81.5592     75.267763 (0.922861)    6.291393 (0.077139)     0.019488    0.352633    0.0242736   0.0304862
  recurrent/sigmoid                                                            2520        48.119      43.677122 (0.907690)    4.441870 (0.092310)     0.015676    0.055061    0.0190948   0.0179865
  recurrent/elementwise_mul                                                    2520        49.7041     46.058434 (0.926652)    3.645676 (0.073348)     0.016281    0.083136    0.0197239   0.018579
  recurrent/tanh                                                               1680        30.4703     27.778421 (0.911655)    2.691894 (0.088345)     0.015139    0.043247    0.0181371   0.0113896
  recurrent/rnn_memory_helper                                                  3780        80.2626     75.132245 (0.936080)    5.130346 (0.063920)     0.016639    0.056485    0.0212335   0.0300016
    recurrent/rnn_memory_helper/GpuMemcpyAsync(same_gpu):GPU->GPU              3780        61.8347     56.704378 (0.917031)    5.130346 (0.082969)     0.012705    0.051586    0.0163584   0.0231134
  recurrent/GpuMemcpyAsync(same_gpu):GPU->GPU                                  105         1.5872      1.444002 (0.909778)     0.143200 (0.090222)     0.012865    0.024577    0.0151162   0.000593285
matmul                                                                         21          68.2534     51.003761 (0.747270)    17.249686 (0.252730)    0.850361    51.0589     3.25016     0.0255127
matmul_grad                                                                    21          35.2415     8.469105 (0.240316)     26.772437 (0.759684)    1.32352     8.52611     1.67817     0.013173
reduce_sum                                                                     168         8.39984     7.312456 (0.870547)     1.087388 (0.129453)     0.027478    0.137556    0.0499991   0.0031398
Fetch                                                                          84          5.88186     5.623299 (0.956041)     0.258559 (0.043959)     0.02957     0.158373    0.0700221   0.0021986
  Fetch/GpuMemcpyAsync:GPU->CPU                                                84          2.87234     2.613780 (0.909983)     0.258559 (0.090017)     0.022581    0.086288    0.0341945   0.00107366
softmax_with_cross_entropy                                                     21          5.1931      1.298397 (0.250023)     3.894703 (0.749977)     0.233333    0.282427    0.24729     0.00194114
elementwise_mul                                                                147         5.17641     3.920612 (0.757399)     1.255802 (0.242601)     0.024971    0.07038     0.0352137   0.00193491
InitLocalVars                                                                  1           4.7726      4.695419 (0.983828)     0.077184 (0.016172)     4.7726      4.7726      4.7726      0.00178396
  InitLocalVars/coalesce_tensor                                                2           4.69863     4.621446 (0.983573)     0.077184 (0.016427)     0.636069    4.06256     2.34932     0.00175631
    InitLocalVars/coalesce_tensor/GpuMemcpyAsync(same_gpu):GPU->GPU            7           3.66131     3.584131 (0.978919)     0.077184 (0.021081)     0.014428    3.49022     0.523045    0.00136857
square                                                                         147         4.68509     3.551941 (0.758137)     1.133149 (0.241863)     0.015942    0.614926    0.0318714   0.00175125
slice                                                                          168         4.67706     4.300196 (0.919423)     0.376862 (0.080577)     0.021064    0.065048    0.0278396   0.00174825
transpose2                                                                     126         3.75139     3.431012 (0.914597)     0.320381 (0.085403)     0.01965     0.171499    0.029773    0.00140224
FastThreadedSSAGraphExecutorPrepare                                            21          3.14129     3.128329 (0.995874)     0.012960 (0.004126)     0.038794    2.14711     0.149585    0.00117419
eager_deletion                                                                 1239        3.13613     3.136126 (1.000000)     0.000000 (0.000000)     0.000677    0.044846    0.00253118  0.00117226
GpuMemcpyAsync:CPU->GPU                                                        63          2.22477     1.961862 (0.881826)     0.262911 (0.118174)     0.008906    0.900797    0.0353139   0.000831604
slice_grad                                                                     84          2.18278     1.958490 (0.897247)     0.224287 (0.102753)     0.021172    0.044573    0.0259854   0.000815906
reshape2                                                                       210         2.13232     2.132318 (1.000000)     0.000000 (0.000000)     0.006424    0.033824    0.0101539   0.000797045
sgd                                                                            21          2.10217     0.648419 (0.308452)     1.453754 (0.691548)     0.094382    0.107731    0.100103    0.000785777
concat                                                                         42          1.93438     1.820136 (0.940942)     0.114240 (0.059058)     0.038686    0.06037     0.0460566   0.000723056
  concat/GpuMemcpyAsync(same_gpu):GPU->GPU                                     84          1.37641     1.262171 (0.917002)     0.114240 (0.082998)     0.013009    0.023551    0.0163858   0.000514493
sum                                                                            63          1.90346     1.722149 (0.904746)     0.181312 (0.095254)     0.018376    0.070048    0.0302137   0.0007115
  sum/GpuMemcpyAsync:CPU->GPU                                                  21          0.425       0.385960 (0.908141)     0.039040 (0.091859)     0.016901    0.041143    0.0202381   0.000158862
fill_zeros_like                                                                84          1.87061     1.754516 (0.937937)     0.116095 (0.062063)     0.015757    0.05073     0.0222692   0.000699221
softmax_with_cross_entropy_grad                                                21          1.81656     0.850897 (0.468412)     0.965661 (0.531588)     0.078479    0.105546    0.0865028   0.000679016
elementwise_add_grad                                                           21          1.71805     0.565833 (0.329345)     1.152221 (0.670655)     0.075629    0.105023    0.0818121   0.000642196
elementwise_add                                                                21          1.6083      0.751088 (0.467007)     0.857213 (0.532993)     0.07034     0.142045    0.0765858   0.000601171
reshape2_grad                                                                  210         1.50326     1.503255 (1.000000)     0.000000 (0.000000)     0.004194    0.032083    0.00715836  0.000561906
lookup_table                                                                   21          1.50021     1.287094 (0.857940)     0.213120 (0.142060)     0.049158    0.317096    0.0714388   0.000560769
transpose2_grad                                                                42          1.42251     1.295635 (0.910806)     0.126880 (0.089194)     0.020189    0.07086     0.0338694   0.000531726
lookup_table_grad                                                              21          1.40221     0.966946 (0.689588)     0.435263 (0.310412)     0.055309    0.095548    0.0667719   0.000524136
reduce_mean                                                                    21          0.891259    0.812539 (0.911676)     0.078720 (0.088324)     0.03226     0.079033    0.0424409   0.000333146
fill_constant                                                                  21          0.823349    0.794678 (0.965178)     0.028671 (0.034822)     0.028475    0.083696    0.0392071   0.000307762
elementwise_max                                                                21          0.768219    0.732315 (0.953263)     0.035904 (0.046737)     0.029203    0.049307    0.0365819   0.000287155
reduce_sum_grad                                                                21          0.717217    0.674241 (0.940080)     0.042976 (0.059920)     0.027304    0.051985    0.0341532   0.000268091
reduce_mean_grad                                                               21          0.697338    0.627066 (0.899228)     0.070272 (0.100772)     0.027578    0.052866    0.0332066   0.00026066
Scale LossGrad                                                                 21          0.6671      0.628412 (0.942006)     0.038688 (0.057994)     0.024711    0.051828    0.0317667   0.000249357
  Scale LossGrad/GpuMemcpyAsync:CPU->GPU                                       21          0.460216    0.421528 (0.915935)     0.038688 (0.084065)     0.017492    0.03235     0.021915    0.000172025
elementwise_div                                                                21          0.577775    0.544399 (0.942234)     0.033376 (0.057766)     0.021048    0.049099    0.0275131   0.000215968
sqrt                                                                           21          0.529517    0.494797 (0.934431)     0.034720 (0.065569)     0.021175    0.032621    0.0252151   0.00019793
create_double_buffer_reader                                                    21          0.236608    0.236608 (1.000000)     0.000000 (0.000000)     0.003251    0.124986    0.011267    8.84424e-05
ScopeBufferedMonitor::post_local_exec_scopes_process                           21          0.090864    0.090864 (1.000000)     0.000000 (0.000000)     0.002433    0.012034    0.00432686  3.39643e-05
ScopeBufferedMonitor::pre_local_exec_scopes_process                            21          0.032946    0.032946 (1.000000)     0.000000 (0.000000)     0.001107    0.002758    0.00156886  1.2315e-05




```


![image](https://user-images.githubusercontent.com/13411999/74621674-b8687400-5178-11ea-9f59-e48a7148b6a4.png)


![image](https://user-images.githubusercontent.com/13411999/74621685-c5856300-5178-11ea-9ac4-4fdf8116bcbf.png)

