### PR TITLE
Allow Layer attr shadow

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -369,7 +369,7 @@ class Layer(core.Layer):
             return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
-        def _remove_from(*dicts):
+        def _remove_if_exist(*dicts):
             for d in dicts:
                 if name in d:
                     del d[name]
@@ -387,7 +387,7 @@ class Layer(core.Layer):
 
                 value.set_value(self._loaddict_holder[value.name])
 
-            _remove_from(self.__dict__, self._sub_layers)
+            _remove_if_exist(self.__dict__, self._sub_layers)
             params[name] = value
         elif isinstance(value, core.Layer):
             layers = self.__dict__.get('_sub_layers', None)
@@ -395,7 +395,7 @@ class Layer(core.Layer):
                 raise ValueError(
                     "super(YourLayer, self).__init__() should be called first")
 
-            _remove_from(self.__dict__, self._parameters)
+            _remove_if_exist(self.__dict__, self._parameters)
             layers[name] = value
         else:
             object.__setattr__(self, name, value)

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -369,6 +369,11 @@ class Layer(core.Layer):
             return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
+        def _remove_from(*dicts):
+            for d in dicts:
+                if name in d:
+                    del d[name]
+
         if isinstance(getattr(type(self), name, None), property):
             object.__setattr__(self, name, value)
         if isinstance(value, framework.Parameter):
@@ -382,12 +387,15 @@ class Layer(core.Layer):
 
                 value.set_value(self._loaddict_holder[value.name])
 
+            _remove_from(self.__dict__, self._sub_layers)
             params[name] = value
         elif isinstance(value, core.Layer):
             layers = self.__dict__.get('_sub_layers', None)
             if layers is None:
                 raise ValueError(
                     "super(YourLayer, self).__init__() should be called first")
+
+            _remove_from(self.__dict__, self._parameters)
             layers[name] = value
         else:
             object.__setattr__(self, name, value)

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -37,6 +37,7 @@ class MyLayer(fluid.Layer):
 class MLP(fluid.Layer):
     def __init__(self, input_size):
         super(MLP, self).__init__()
+        self._linear1 = None
         self._linear1 = Linear(
             input_size,
             3,
@@ -71,6 +72,7 @@ class SimpleRNNCell(fluid.Layer):
         i2h_param_shape = [self.step_input_size, self.hidden_size]
         h2h_param_shape = [self.hidden_size, self.hidden_size]
         h2o_param_shape = [self.output_size, self.hidden_size]
+        self._i2h_w = None
         self._i2h_w = self.create_parameter(
             attr=self.param_attr,
             shape=i2h_param_shape,


### PR DESCRIPTION
修正`Layer.__setattr__`，允许动态图`Layer`在设置属性时覆盖掉已有的`object`的属性、或已注册的`Layer`或`Parameter`。