### PR TITLE
add no_grad_set value check in op_test

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -34,7 +34,7 @@ from paddle.fluid.framework import Program, OpProtoHolder, Variable
 from testsuite import create_op, set_input, append_input_output, append_loss_ops
 from paddle.fluid import unique_name
 from white_list import op_accuracy_white_list, check_shape_white_list, compile_vs_runtime_white_list, no_check_set_white_list
-from white_list import op_threshold_white_list
+from white_list import op_threshold_white_list, no_grad_set_white_list
 
 
 def _set_use_system_allocator(value=None):
@@ -147,12 +147,12 @@ def get_numeric_gradient(place,
 
 def skip_check_grad_ci(reason=None):
     """Decorator to skip check_grad CI.
-       
+
        Check_grad is required for Op test cases. However, there are some special
-       cases that do not need to do check_grad. This decorator is used to skip the 
+       cases that do not need to do check_grad. This decorator is used to skip the
        check_grad of the above cases.
-       
-       Note: the execution of unit test will not be skipped. It just avoids check_grad 
+
+       Note: the execution of unit test will not be skipped. It just avoids check_grad
        checking in tearDownClass method by setting a `no_need_check_grad` flag.
 
        Example:
@@ -336,7 +336,7 @@ class OpTest(unittest.TestCase):
             inputs=inputs,
             outputs=outputs,
             attrs=self.attrs if hasattr(self, "attrs") else dict())
-        # infer variable type and infer shape in compile-time 
+        # infer variable type and infer shape in compile-time
         op.desc.infer_var_type(block.desc)
         op.desc.infer_shape(block.desc)
 
@@ -550,8 +550,8 @@ class OpTest(unittest.TestCase):
         feed_map = self.feed_var(inputs, place)
 
         if for_inplace_test:
-            # Some variables' tensors hold no buffer (tensor's _holder is NULL), like XShape in reshape2 op, 
-            # and the shapes of those variables contain 0 (eg. Xshape.shape = [0, 2, 5]). 
+            # Some variables' tensors hold no buffer (tensor's _holder is NULL), like XShape in reshape2 op,
+            # and the shapes of those variables contain 0 (eg. Xshape.shape = [0, 2, 5]).
             # Set persistable for those variables in order to get them from global_scope for inplace grad test directly other than feed them,
             # since feed op calls check_memory_size() which fails when tensor's holder_ is NULL.
             for out_name in op.output_arg_names:
@@ -612,7 +612,7 @@ class OpTest(unittest.TestCase):
         """Compare expect outs and actual outs of an tested op.
 
         Args:
-            place (CPUPlace | CUDAPlace): The place where the op runs. 
+            place (CPUPlace | CUDAPlace): The place where the op runs.
             fetch_list (list): The outputs of tested op.
             expect_outs (list): The expect outs of tested op.
             actual_outs (list): The actual outs of tested op.
@@ -623,7 +623,7 @@ class OpTest(unittest.TestCase):
         """
         # compare expect_outs and actual_outs
         for i, name in enumerate(fetch_list):
-            # Note(zhiqiu): inplace_atol should be only set when op doesn't ensure 
+            # Note(zhiqiu): inplace_atol should be only set when op doesn't ensure
             # computational consistency.
             # When inplace_atol is not None, the inplace check uses numpy.allclose
             # to check inplace result instead of numpy.array_equal.
@@ -653,7 +653,7 @@ class OpTest(unittest.TestCase):
         Args:
             fwd_program (tuple): The program that contains grad_op_desc's corresponding forward op.
             grad_op_desc (OpDesc): The OpDesc of grad op.
-            op_grad_to_var (dict): The relation of variables in grad op and its forward op. 
+            op_grad_to_var (dict): The relation of variables in grad op and its forward op.
 
         Returns:
             grad_program (program): The program which contains the grad_op.
@@ -680,8 +680,8 @@ class OpTest(unittest.TestCase):
                 type=fwd_var.type,
                 persistable=False)
 
-            # Some variables' tensors hold no buffer (tensor's _holder is NULL), like XShape in reshape2 op, 
-            # and the shapes of those variables contain 0 (eg. Xshape.shape = [0, 2, 5]). 
+            # Some variables' tensors hold no buffer (tensor's _holder is NULL), like XShape in reshape2 op,
+            # and the shapes of those variables contain 0 (eg. Xshape.shape = [0, 2, 5]).
             # Set persistable for those variables in order to get them from global_scope for inplace grad test directly other than feed them,
             # since feed op calls check_memory_size() which fails when tensor's holder_ is NULL.
             if 0 in grad_var.shape:
@@ -697,11 +697,11 @@ class OpTest(unittest.TestCase):
         we use fwd outs (also inputs sometimes) to construct grad inputs.
 
         Args:
-            place (CPUPlace | CUDAPlace): The place where the op runs. 
+            place (CPUPlace | CUDAPlace): The place where the op runs.
             fwd_res (tuple): The outputs of its forward op, in the same form as returns of _calc_outputs() when for_inplace_test is True.
                 i.e., tuple(fwd_outs, fwd_fetch_list, fwd_feed_map, fwd_program, fwd_op_desc)
             grad_op_desc (OpDesc): The OpDesc of grad op.
-            op_grad_to_var (dict): The relation of variables in grad op and its fwd_op. 
+            op_grad_to_var (dict): The relation of variables in grad op and its fwd_op.
 
         Returns:
             grad_feed_map (dict): The feed_map of grad_op.
@@ -733,12 +733,12 @@ class OpTest(unittest.TestCase):
         An op needs to run druing inplace check if,
         (1) it has infer_inplace,
         (2) it has infer_inplace in its grad descendants. (since we need its outputs as to construct its grad's inputs)
-        
+
         Args:
-            op_desc (OpDesc): The op_desc of current op. 
-            fwd_op_desc (OpDesc): The op_desc of current op's forward op, None if current op has no forward op. 
+            op_desc (OpDesc): The op_desc of current op.
+            fwd_op_desc (OpDesc): The op_desc of current op's forward op, None if current op has no forward op.
                 Eg. relu's fwd_op is None, relu_grad's fwd_op is relu, relu_grad_grad's fwd_op is relu_grad, etc.
-            
+
         Returns:
             need_run_ops (list[(op_desc, fwd_op_desc)]): The ops that need to run during inplace test.
         """
@@ -753,7 +753,7 @@ class OpTest(unittest.TestCase):
             if not has_grad_op_maker:
                 has_infer_inplace_in_descendants = False
             else:
-                # get grad_op_desc 
+                # get grad_op_desc
                 grad_op_desc_list, op_grad_to_var = core.get_grad_op_desc(
                     op_desc, set(), [])
                 if not grad_op_desc_list:
@@ -779,15 +779,15 @@ class OpTest(unittest.TestCase):
                                inplace_atol=None):
         """Chech the inplace correctness of given op (self.op_type).
         Run the op twice with same inputs, one enable inplace and another disable, compare their outputs.
-        
+
         Args:
-            place (CPUPlace | CUDAPlace): The place where the op runs. 
+            place (CPUPlace | CUDAPlace): The place where the op runs.
             no_check_set (list): The names of outputs that needn't check, like XShape of reshape op.
             inplace_atol (float): The tolerable error, only set when op doesn't ensure computational consistency, like group_norm op.
 
         Returns:
-            expect_res (tuple(outs, fetch_list, feed_map, program, op_desc)): The results of given op. 
-                We return this to construct grad_program and grad_feed_map for grad inplace check. 
+            expect_res (tuple(outs, fetch_list, feed_map, program, op_desc)): The results of given op.
+                We return this to construct grad_program and grad_feed_map for grad inplace check.
         """
         # _calc_output() returns in the form tuple(outs, fetch_list, feed_map, program, op_desc) when for_inplace_test=True.
         expect_res = self._calc_output(
@@ -820,7 +820,7 @@ class OpTest(unittest.TestCase):
         we use fwd outs (also inputs sometimes) to construct grad inputs.
 
         Args:
-            place (CPUPlace | CUDAPlace): The place where the op runs. 
+            place (CPUPlace | CUDAPlace): The place where the op runs.
             fwd_res (tuple): The outputs of its forward op, in the same form as returns of _calc_outputs() when for_inplace_test is True.
                 i.e., tuple(fwd_outs, fwd_fetch_list, fwd_feed_map, fwd_program, fwd_op_desc).
             grad_op_desc (OpDesc): The OpDesc of grad op.
@@ -864,15 +864,15 @@ class OpTest(unittest.TestCase):
         So we define a new function for grad, grad_grad, etc.
 
         Args:
-            place (CPUPlace | CUDAPlace): The place where the op runs. 
+            place (CPUPlace | CUDAPlace): The place where the op runs.
             fwd_res (tuple): The outputs of its forward op, in the same form as returns of _calc_outputs() when for_inplace_test is True.
                 i.e., tuple(fwd_outs, fwd_fetch_list, fwd_feed_map, fwd_program, fwd_op_desc).
             grad_op_desc (OpDesc): The OpDesc of grad op.
             inplace_atol (float): The tolerable error, only set when op doesn't ensure computational consistency, like group_norm op.
 
         Returns:
-            expect_res (tuple(outs, fetch_list, feed_map, program, op_desc)): The results of given op. 
-                We return this to construct grad_program and grad_feed_map for grad inplace check. 
+            expect_res (tuple(outs, fetch_list, feed_map, program, op_desc)): The results of given op.
+                We return this to construct grad_program and grad_feed_map for grad inplace check.
         """
         expect_res = self._calc_grad_output(
             place, fwd_res, grad_op_desc, enable_inplace=False)
@@ -896,7 +896,7 @@ class OpTest(unittest.TestCase):
         (2) Run op in need_run_ops, and do inplace check if it has infer_inplace.
 
         Args:
-            place (CPUPlace | CUDAPlace): The place where the op runs. 
+            place (CPUPlace | CUDAPlace): The place where the op runs.
             no_check_set (list): The names of outputs that needn't check, like XShape of reshape op.
             inplace_atol (float): The tolerable error, only set when op doesn't ensure computational consistency, like group_norm op.
 
@@ -1088,10 +1088,10 @@ class OpTest(unittest.TestCase):
                             "Output (" + out_name + ") has different lod at " +
                             str(place) + " in dygraph mode")
 
-        # Note(zhiqiu): inplace_atol should be only set when op doesn't ensure 
+        # Note(zhiqiu): inplace_atol should be only set when op doesn't ensure
         # computational consistency.
         # For example, group_norm uses AtomicAdd on CUDAPlace, which do not ensure
-        # computation order when multiple threads write the same address. So the 
+        # computation order when multiple threads write the same address. So the
         # result of group_norm is non-deterministic when datatype is float.
         # When inplace_atol is not None, the inplace check uses numpy.allclose
         # to check inplace result instead of numpy.array_equal.
@@ -1100,7 +1100,7 @@ class OpTest(unittest.TestCase):
                 "inplace_atol should only be set when op doesn't ensure computational consistency, please check it!"
             )
         # Check inplace for given op, its grad op, its grad_grad op, etc.
-        # No effect on original OpTest 
+        # No effect on original OpTest
         self.check_inplace_output_with_place(
             place, no_check_set=no_check_set, inplace_atol=inplace_atol)
 
@@ -1291,6 +1291,12 @@ class OpTest(unittest.TestCase):
 
         if no_grad_set is None:
             no_grad_set = set()
+        else:
+            if (self.op_type not in no_grad_set_white_list.NEED_TO_FIX_OP_LIST
+                ) and (self.op_type not in
+                       no_grad_set_white_list.NOT_CHECK_OP_LIST):
+                raise AssertionError("no_grad_set muste be None, op_type is " +
+                                     self.op_type + " Op.")
 
         if not type(output_names) is list:
             output_names = [output_names]

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# check no_grad_set is None
+NOT_CHECK_OP_LIST = []
+# no_grad_set has value in NEED_TO_FIX_OP_LIST
+NEED_TO_FIX_OP_LIST = [
+    'row_conv', 'mul', 'smooth_l1_loss', 'multiplex', 'sequence_conv',
+    'conv_shift', 'margin_rank_loss', 'lstm', 'lstmp', 'lod_reset',
+    'filter_by_instag', 'elementwise_div', 'elementwise_max', 'elementwise_min',
+    'elementwise_add', 'elementwise_sub', 'elementwise_mul', 'affine_channel',
+    'fused_emb_seq_pool', 'huber_loss', 'rank_loss',
+    'fused_elemwise_activation', 'prelu', 'cos_sim', 'deformable_conv',
+    'matmul', 'hsigmoid', 'kldiv_loss', 'affine_grad', 'conv3d_transpose',
+    'conv2d_transpose', 'spectral_norm', 'cross_entropy2', 'linear_chain_crf',
+    'lookup_table_v2', 'conv2d', 'gru_unit', 'lookup_table', 'conv3d',
+    'deformable_conv_v1', 'depthwise_conv2d', 'depthwise_conv2d_transpose',
+    'hierarchical_sigmoid', 'affine_grid', 'data_norm'
+]

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -26,5 +26,5 @@ NEED_TO_FIX_OP_LIST = [
     'conv2d_transpose', 'spectral_norm', 'cross_entropy2', 'linear_chain_crf',
     'lookup_table_v2', 'conv2d', 'gru_unit', 'lookup_table', 'conv3d',
     'deformable_conv_v1', 'depthwise_conv2d', 'depthwise_conv2d_transpose',
-    'hierarchical_sigmoid', 'affine_grid', 'data_norm'
+    'hierarchical_sigmoid', 'affine_grid', 'data_norm', 'fused_embedding_seq_pool'
 ]

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -26,5 +26,6 @@ NEED_TO_FIX_OP_LIST = [
     'conv2d_transpose', 'spectral_norm', 'cross_entropy2', 'linear_chain_crf',
     'lookup_table_v2', 'conv2d', 'gru_unit', 'lookup_table', 'conv3d',
     'deformable_conv_v1', 'depthwise_conv2d', 'depthwise_conv2d_transpose',
-    'hierarchical_sigmoid', 'affine_grid', 'data_norm', 'fused_embedding_seq_pool'
+    'hierarchical_sigmoid', 'affine_grid', 'data_norm', 
+    'fused_embedding_seq_pool'
 ]

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -33,6 +33,7 @@ API_FILES=("CMakeLists.txt"
            "python/paddle/fluid/tests/unittests/white_list/check_op_sequence_instance_0_input_white_list.py"
            "python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py"
            "python/paddle/fluid/tests/unittests/white_list/check_op_sequence_batch_1_input_white_list.py"
+           "python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py"
            )
 
 approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
@@ -60,17 +61,17 @@ function add_failed(){
 if [[ $git_files -gt 19 || $git_count -gt 999 ]];then
     echo_line="You must have Dianhai approval for change 20+ files or add than 1000+ lines of content.\n"
     check_approval 1 38231817
-fi    
+fi
 
-api_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.api  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.api` 
+api_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.api  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.api`
 if [ "$api_spec_diff" != "" ]; then
     echo_line="You must have one RD (XiaoguangHu01 or lanxianghit) and one TPM (saxon-zh or Boyan-Liu or swtkiwi) approval for the api change for the management reason of API interface.\n"
     check_approval 1 46782768 47554610
     echo_line=""
-    check_approval 1 2870059 2870059 27208573 
+    check_approval 1 2870059 2870059 27208573
 fi
 
-api_doc_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.doc  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.doc` 
+api_doc_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.doc  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.doc`
 if [ "$api_doc_spec_diff" != "" ]; then
     echo_line="You must have one TPM (saxon-zh or Boyan-Liu or swtkiwi) approval for the api change for the management reason of API document.\n"
     check_approval 1 31623103 2870059 27208573
@@ -130,6 +131,9 @@ for API_FILE in ${API_FILES[*]}; do
       elif [ "${API_FILE}" == "python/paddle/fluid/tests/unittests/white_list/check_op_sequence_batch_1_input_white_list.py" ];then
           echo_line="You must have one RD (songyouwei, luotao1 or phlrain) approval for ${API_FILE}, which manages the white list of batch size 1 input for sequence op test. For more information, please refer to [https://github.com/PaddlePaddle/Paddle/wiki/It-is-required-to-include-LoDTensor-input-with-batch_size=1-in-sequence-OP-test]. \n"
           check_approval 1 2573291 6836917 43953930
+      elif [ "${API_FILE}" == "python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py" ];then
+          echo_line="You must have one RD (chenjiaoAngel (Recommend), luotao1 or phlrain) approval for the python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py, which manages the white list of no_grad_set without value in operators.\n"
+           check_approval 1 38650344 6836917 43953930
       else
           echo_line="It is an Op accuracy problem, please take care of it. You must have one RD (XiaoguangHu01,Xreki,luotao1,sneaxiy) approval for ${API_FILE}, which manages the underlying code for fluid.\n"
           check_approval 1 3048612 46782768 12538138 6836917 32832641
@@ -228,7 +232,7 @@ if [ "${NEW_OP_TEST_ADDED}" != "" ] && [ "${GIT_PR_ID}" != "" ]; then
     CHECK_GRAD_CHECK=`git diff -U5 --diff-filter=AMR upstream/$BRANCH |grep -A2 -E "checker\.double_grad_check"|grep "eps=|atol=|rtol=" |grep "+" || true`
     CHECK_WHOLE=$CHECK_OUTPUT$CHECK_OUTPUT_WITH_PLACE$CHECK_GRAD$CHECK_GRAD_CHECK
     if [ "${CHECK_WHOLE}" != "" ] ; then
-        CHECK_OP=${CHECK_WHOLE//+/'\n+'}       
+        CHECK_OP=${CHECK_WHOLE//+/'\n+'}
         echo_line="Please use the default precision parameters of 'atol, rtol, eps, max_relative_error'. If you don't use the default value, you must have one RD (Xreki (Recommend), luotao1, lanxianghit or phlrain) approval for the usage of other values. The detailed information is in the link: https://github.cor/PaddlePaddle/Paddle/wiki/OP-test-accuracy-requirements. The error line is ${CHECK_OP}\n"
         check_approval 1 6836917 47554610 12538138 43953930
     fi
@@ -252,9 +256,9 @@ fi
 
 DEV_OP_USE_DEFAULT_GRAD_MAKER_SPEC=${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_maker_DEV.spec
 PR_OP_USE_DEFAULT_GRAD_MAKER_SPEC=${PADDLE_ROOT}/paddle/fluid/op_use_default_grad_maker_PR.spec
-ADDED_OP_USE_DEFAULT_GRAD_MAKER=`python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py ${DEV_OP_USE_DEFAULT_GRAD_MAKER_SPEC} ${PR_OP_USE_DEFAULT_GRAD_MAKER_SPEC}` 
+ADDED_OP_USE_DEFAULT_GRAD_MAKER=`python ${PADDLE_ROOT}/tools/diff_use_default_grad_op_maker.py ${DEV_OP_USE_DEFAULT_GRAD_MAKER_SPEC} ${PR_OP_USE_DEFAULT_GRAD_MAKER_SPEC}`
 if [ "${ADDED_OP_USE_DEFAULT_GRAD_MAKER}" != "" ]; then
-  echo_line="You must have one RD (sneaxiy (Recommend) or luotao1) approval because you use DefaultGradOpMaker for ${ADDED_OP_USE_DEFAULT_GRAD_MAKER}, which manages the grad_op memory optimization.\n" 
+  echo_line="You must have one RD (sneaxiy (Recommend) or luotao1) approval because you use DefaultGradOpMaker for ${ADDED_OP_USE_DEFAULT_GRAD_MAKER}, which manages the grad_op memory optimization.\n"
   check_approval 1 32832641 6836917
 fi
 


### PR DESCRIPTION
add no_grad_set_white_list value check in check_api_approve

no_grad_set字段值必须为None，不允许开发者给no_grad_set字段赋值，该字段默认设置为None。如果需要改动no_grad_set字段，需要对应审核人review。(The no_grad_set field must be None. The developer is not allowed to set the no_grad_set field. By default, this field is set to None)

新增的CI检查规则只检查一个PR中新增代码中是否给no_grad_set字段赋值

**CI检查失败提示：**
0. You must have one RD (chenjiaoAngel (Recommend), luotao1 or phlrain) approval for the python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py, which manages the white list of no_grad_set without value in operators.

Traceback (most recent call last):
[11:21:34]	  File "test_fused_emb_seq_pool_op.py", line 58, in test_check_grad
[11:21:34]	    ['W'], 'Out', no_grad_set=('Ids'), check_dygraph=False)
[11:21:34]	  File "op_test.py", line 1258, in check_grad
[11:21:34]	    user_defined_grads, check_dygraph)
[11:21:34]	  File "op_test.py", line 1299, in check_grad_with_place
[11:21:34]	    self.op_type + " Op.")
[11:21:34]	AssertionError: no_grad_set muste be None, op_type is fused_embedding_seq_pool Op.

**CI检查触发示例:**
http://ci.paddlepaddle.org/viewLog.html?buildId=272699&tab=buildLog&buildTypeId=Paddle_PrCiCoverage&logTab=tree&filter=allhttp://ci.paddlepaddle.org/viewLog.html?buildId=272699&tab=buildLog&buildTypeId=Paddle_PrCiCoverage&logTab=tree&filter=all
<img width="734" alt="image" src="https://user-images.githubusercontent.com/38650344/72658366-f7c16a80-39ea-11ea-81de-7275093f88c9.png">

