### PR TITLE
[Bugfix] Preserve shape in inplace operators

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1086,7 +1086,9 @@ void OperatorWithKernel::TransferInplaceVarsBack(
     PADDLE_ENFORCE_NOT_NULL(var, "The var[%s] should not be nullptr.",
                             var_name);
     auto* transformed_tensor = GetLoDTensorOrSelectedRowsValueFromVar(*var);
+    auto original_dims = original_tensor->dims();
     original_tensor->ShareDataWith(*transformed_tensor);
+    original_tensor->Resize(original_dims);
   }
 }
 


### PR DESCRIPTION
TransferInplaceVarsBack() function doesn't preserve shape of original tensor. I've found this bug during preparing LayerNorm MKL-DNN kernel in Bert model.

For example, reshape operator in Bert model works inplace but now, only data pointer is preserved and changed shape of tensor is lost.