### PR TITLE
update docker image of CI_py35 and CI_inference

### DIFF
--- a/tools/manylinux1/Dockerfile.CI35-GCC4.8
+++ b/tools/manylinux1/Dockerfile.CI35-GCC4.8
@@ -18,8 +18,7 @@ RUN yum install -y curl-devel
 
 COPY tools/manylinux1/build_scripts ./build_scripts
 
-RUN bash build_scripts/build.sh && \
-  bash build_scripts/install_nccl2.sh && rm -rf build_scripts
+RUN bash build_scripts/build.sh && bash build_scripts/install_nccl2.sh && rm -rf build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 

--- a/tools/manylinux1/Dockerfile.CI35-GCC8
+++ b/tools/manylinux1/Dockerfile.CI35-GCC8
@@ -16,8 +16,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 RUN yum install -y sqlite-devel zlib-devel openssl-devel pcre-devel vim tk-devel tkinter libtool xz graphviz gettext-devel expat-devel cpio perl curl-devel
 
 COPY tools/manylinux1/build_scripts /build_scripts
-RUN bash build_scripts/build.sh && \
-  bash build_scripts/install_nccl2.sh && rm -rf build_scripts
+RUN bash build_scripts/build.sh && bash build_scripts/install_nccl2.sh && rm -rf build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 

--- a/tools/manylinux1/Dockerfile.x64
+++ b/tools/manylinux1/Dockerfile.x64
@@ -15,8 +15,7 @@ ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 
 RUN yum install -y sqlite-devel zlib-devel openssl-devel pcre-devel vim tk-devel tkinter libtool xz graphviz
 COPY build_scripts /build_scripts
-RUN bash build_scripts/build.sh && \
-  bash build_scripts/install_nccl2.sh && rm -rf build_scripts
+RUN bash build_scripts/build.sh && bash build_scripts/install_nccl2.sh && rm -rf build_scripts
 
 ENV SSL_CERT_FILE=/opt/_internal/certs.pem
 


### PR DESCRIPTION
update docker image of CI_py35 and CI_inference, because it has updated cmake version from 3.5.1 to 3.16.0 before.