### PR TITLE
Fix static graph dataloader early reset bug

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -618,6 +618,8 @@ class GeneratorLoader(DataLoaderBase):
         self._tensor_reader = None
         self._places = None
         self._thread = None
+        self._exited = False
+        self._exited_lock = threading.Lock()
         self._queue = None
         self._feed_list = feed_list
         if not capacity:
@@ -782,7 +784,11 @@ class GeneratorLoader(DataLoaderBase):
                     if not self._queue.push(array):
                         break
 
-                self._queue.close()
+                self._exited_lock.acquire()
+                if not self._exited:
+                    self._queue.close()
+                self._exited_lock.release()
+
                 self._thread = None
             except Exception as ex:
                 self._queue.kill()
@@ -795,10 +801,18 @@ class GeneratorLoader(DataLoaderBase):
         self._thread.start()
 
     def _reset(self):
+        self._exited_lock.acquire()
         self._reader.reset()
+        self._exited = True
+        self._exited_lock.release()
+
         thread = self._thread
         if thread is not None:
             thread.join()
+
+        self._exited_lock.acquire()
+        self._exited = False
+        self._exited_lock.release()
 
     def set_sample_generator(self,
                              reader,

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -618,8 +618,6 @@ class GeneratorLoader(DataLoaderBase):
         self._tensor_reader = None
         self._places = None
         self._thread = None
-        self._exited = False
-        self._exited_lock = threading.Lock()
         self._queue = None
         self._feed_list = feed_list
         if not capacity:
@@ -784,11 +782,7 @@ class GeneratorLoader(DataLoaderBase):
                     if not self._queue.push(array):
                         break
 
-                self._exited_lock.acquire()
-                if not self._exited:
-                    self._queue.close()
-                self._exited_lock.release()
-
+                self._queue.close()
                 self._thread = None
             except Exception as ex:
                 self._queue.kill()
@@ -801,18 +795,12 @@ class GeneratorLoader(DataLoaderBase):
         self._thread.start()
 
     def _reset(self):
-        self._exited_lock.acquire()
-        self._reader.reset()
-        self._exited = True
-        self._exited_lock.release()
-
+        self._queue.close()
         thread = self._thread
         if thread is not None:
             thread.join()
 
-        self._exited_lock.acquire()
-        self._exited = False
-        self._exited_lock.release()
+        self._reader.reset()
 
     def set_sample_generator(self,
                              reader,

--- a/python/paddle/fluid/tests/unittests/test_dataloader_early_reset.py
+++ b/python/paddle/fluid/tests/unittests/test_dataloader_early_reset.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid as fluid
+import paddle
+import numpy as np
+import unittest
+
+
+def infinite_reader():
+    num = 0
+    while True:
+        yield (np.ones([8, 32]) * num).astype('float32'),
+        num += 1
+
+
+class TestDataLoaderEarlyReset(unittest.TestCase):
+    def setUp(self):
+        self.stop_batch = 10
+        self.iterable = True
+
+    def build_network(self):
+        y = fluid.layers.fc(self.x, size=10)
+        loss = fluid.layers.reduce_mean(y)
+
+        optimizer = fluid.optimizer.SGD(learning_rate=1e-3)
+        optimizer.minimize(loss)
+
+    def get_place(self):
+        if fluid.is_compiled_with_cuda():
+            return fluid.CUDAPlace(0)
+        else:
+            return fluid.CPUPlace()
+
+    def create_data_loader(self):
+        self.x = fluid.data(name='x', shape=[None, 32], dtype='float32')
+        return fluid.io.DataLoader.from_generator(
+            feed_list=[self.x], capacity=10, iterable=self.iterable)
+
+    def test_main(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            with fluid.scope_guard(fluid.Scope()):
+                self.run_network()
+
+    def run_network(self):
+        loader = self.create_data_loader()
+        self.build_network()
+
+        exe = fluid.Executor(self.get_place())
+        exe.run(fluid.default_startup_program())
+
+        prog = fluid.default_main_program()
+
+        loader.set_batch_generator(infinite_reader, places=self.get_place())
+        for epoch_id in range(10):
+            batch_id = 0
+            if loader.iterable:
+                for data in loader():
+                    x_val, = exe.run(prog, feed=data, fetch_list=[self.x])
+                    self.assertTrue(np.all(x_val == batch_id))
+                    batch_id += 1
+                    if batch_id >= self.stop_batch:
+                        break
+            else:
+                loader.start()
+                while True:
+                    exe.run(prog, fetch_list=[self.x])
+                    batch_id += 1
+                    if batch_id >= self.stop_batch:
+                        break
+
+            self.assertEqual(batch_id, self.stop_batch)
+
+
+class TestDataLoaderEarlyReset2(TestDataLoaderEarlyReset):
+    def setUp(self):
+        self.stop_batch = 20
+        self.iterable = False
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_dataloader_early_reset.py
+++ b/python/paddle/fluid/tests/unittests/test_dataloader_early_reset.py
@@ -82,6 +82,9 @@ class TestDataLoaderEarlyReset(unittest.TestCase):
 
             self.assertEqual(batch_id, self.stop_batch)
 
+        if loader.iterable:
+            loader._reset()
+
 
 class TestDataLoaderEarlyReset2(TestDataLoaderEarlyReset):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dataloader_early_reset.py
+++ b/python/paddle/fluid/tests/unittests/test_dataloader_early_reset.py
@@ -78,6 +78,7 @@ class TestDataLoaderEarlyReset(unittest.TestCase):
                     exe.run(prog, fetch_list=[self.x])
                     batch_id += 1
                     if batch_id >= self.stop_batch:
+                        loader.reset()
                         break
 
             self.assertEqual(batch_id, self.stop_batch)


### PR DESCRIPTION
In static graph mode, non-iterable `DataLoader` cannot work well when `reset` is called when the thread does not ends. Because the `reset` method would close the queue first and reopen it. If the queue is not closed when calling `reset`, the thread which pushes data into the queue may hang.

This PR fixes this bug.