### PR TITLE
Add api to clear intermediate tensors in AnalysisPredictor

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -749,6 +749,24 @@ bool AnalysisPredictor::LoadParameters() {
   return true;
 }
 
+void AnalysisPredictor::ClearIntermediateTensor() {
+  PADDLE_ENFORCE_NOT_NULL(inference_program_.get(),
+                          platform::errors::PreconditionNotMet(
+                              "The inference program should be loaded first."));
+  const auto &global_block = inference_program_->MutableBlock(0);
+  for (auto *var : global_block->AllVars()) {
+    if (!IsPersistable(var)) {
+      const std::string name = var->Name();
+      auto *variable = executor_->scope()->FindVar(name);
+      if (variable != nullptr && name != "feed" && name != "fetch") {
+        VLOG(3) << "Clear Intermediate Tensor: " << name;
+        auto *t = variable->GetMutable<framework::LoDTensor>();
+        t->clear();
+      }
+    }
+  }
+}
+
 #if PADDLE_WITH_TENSORRT
 bool AnalysisPredictor::SaveTrtCalibToDisk() {
   PADDLE_ENFORCE(config_.tensorrt_engine_enabled(),

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -758,7 +758,8 @@ void AnalysisPredictor::ClearIntermediateTensor() {
     if (!IsPersistable(var)) {
       const std::string name = var->Name();
       auto *variable = executor_->scope()->FindVar(name);
-      if (variable != nullptr && name != "feed" && name != "fetch") {
+      if (variable != nullptr && variable->IsType<framework::LoDTensor>() &&
+          name != "feed" && name != "fetch") {
         VLOG(3) << "Clear Intermediate Tensor: " << name;
         auto *t = variable->GetMutable<framework::LoDTensor>();
         t->clear();

--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -76,6 +76,8 @@ class AnalysisPredictor : public PaddlePredictor {
   void PrepareArgument();
   void OptimizeInferenceProgram();
 
+  void ClearIntermediateTensor();
+
   Argument &analysis_argument() { return argument_; }
 
   std::unique_ptr<PaddlePredictor> Clone() override;

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -268,6 +268,8 @@ class PaddlePredictor {
    */
   virtual bool ZeroCopyRun() { return false; }
 
+  virtual void ClearIntermediateTensor() {}
+
   /** Clone a predictor that share the model weights, the Cloned predictor
    * should be thread-safe.
    */

--- a/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
@@ -44,6 +44,7 @@ TEST(AnalysisPredictor, use_gpu) {
   for (auto& input : inputs_all) {
     ASSERT_TRUE(predictor->Run(input, &outputs));
   }
+  predictor->ClearIntermediateTensor();
 }
 
 }  // namespace inference


### PR DESCRIPTION
On some devices, memory/graphic-memory is limited. Instead of running paddle inference parallelly, we have to load, analyze, and run them one after another(with each one's resources released after running) on these devices to avoid OOM. In such situations, loading and analysis phases become bottleneck of latency. 
So we add an API to clear intermediate tensors, enabling AnalysisPredictor to load and analyze all models first, and run inference one by one(with each one's intermediate tensors released to graphic memory pool by calling ClearIntermediateTensor()) to cut the overhead mentioned above.