### PR TITLE
Update the precision of pad, pad2d, pad_constant_like's unit tests from fp32 to fp64

### DIFF
--- a/paddle/fluid/operators/pad2d_op.cc
+++ b/paddle/fluid/operators/pad2d_op.cc
@@ -345,7 +345,7 @@ class Pad2dCPUKernel : public framework::OpKernel<T> {
     GetPaddings(pads, context);
     auto mode = context.Attr<std::string>("mode");
     auto data_format = context.Attr<std::string>("data_format");
-    T value = context.Attr<T>("pad_value");
+    T value = static_cast<T>(context.Attr<float>("pad_value"));
 
     auto* x = context.Input<Tensor>("X");
     auto in_dims = x->dims();

--- a/paddle/fluid/operators/pad2d_op.cu
+++ b/paddle/fluid/operators/pad2d_op.cu
@@ -314,7 +314,7 @@ class Pad2dCUDAKernel : public framework::OpKernel<T> {
     GetPaddings(pads, context);
     auto mode = context.Attr<std::string>("mode");
     auto data_format = context.Attr<std::string>("data_format");
-    T value = context.Attr<T>("pad_value");
+    T value = static_cast<T>(context.Attr<float>("pad_value"));
 
     auto* x = context.Input<Tensor>("X");
     auto in_dims = x->dims();

--- a/paddle/fluid/operators/pad_constant_like_op.h
+++ b/paddle/fluid/operators/pad_constant_like_op.h
@@ -38,7 +38,7 @@ class PadConstantLikeKernel : public framework::OpKernel<T> {
       return;
     }
 
-    T pad_value = context.Attr<T>("pad_value");
+    T pad_value = static_cast<T>(context.Attr<float>("pad_value"));
     out->mutable_data<T>(context.GetPlace());
 
     int rank = context.Input<framework::Tensor>("X")->dims().size();

--- a/python/paddle/fluid/tests/unittests/test_pad2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad2d_op.py
@@ -23,14 +23,15 @@ class TestPad2dOp(OpTest):
         self.variable_paddings = False
         self.initTestCase()
         self.op_type = "pad2d"
-        self.inputs = {'X': np.random.random(self.shape).astype("float32"), }
+        self.inputs = {'X': np.random.random(self.shape).astype("double")}
         self.attrs = {}
         if self.variable_paddings:
             self.attrs['paddings'] = []
             self.inputs['Paddings'] = np.array(self.paddings).flatten().astype(
                 "int32")
         else:
-            self.attrs['paddings'] = np.array(self.paddings).flatten()
+            self.attrs['paddings'] = np.array(self.paddings).flatten().astype(
+                "int32")
         self.attrs['pad_value'] = self.pad_value
         self.attrs['mode'] = self.mode
         self.attrs['data_format'] = self.data_format

--- a/python/paddle/fluid/tests/unittests/test_pad2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad2d_op.py
@@ -23,7 +23,7 @@ class TestPad2dOp(OpTest):
         self.variable_paddings = False
         self.initTestCase()
         self.op_type = "pad2d"
-        self.inputs = {'X': np.random.random(self.shape).astype("double")}
+        self.inputs = {'X': np.random.random(self.shape).astype("float64")}
         self.attrs = {}
         if self.variable_paddings:
             self.attrs['paddings'] = []

--- a/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
@@ -24,8 +24,8 @@ class TestPadOp(OpTest):
         self.initTestCase()
         self.op_type = "pad_constant_like"
         self.inputs = {
-            'X': np.random.random(self.x_shape).astype("float32"),
-            'Y': np.random.random(self.y_shape).astype("float32")
+            'X': np.random.random(self.x_shape).astype("float64"),
+            'Y': np.random.random(self.y_shape).astype("float64")
         }
         self.attrs = {}
         self.attrs['pad_value'] = self.pad_value

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -37,7 +37,7 @@ class TestPadOp(OpTest):
         }
 
     def get_dtype(self):
-        return np.float32
+        return np.float64
 
     def test_check_output(self):
         self.check_output()

--- a/python/paddle/fluid/tests/unittests/white_list/op_accuracy_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_accuracy_white_list.py
@@ -50,9 +50,6 @@ NO_FP64_CHECK_GRAD_OP_LIST = [
     'modified_huber_loss', \
     'mul', \
     'nce', \
-    'pad', \
-    'pad2d', \
-    'pad_constant_like', \
     'pool2d', \
     'pool3d', \
     'prroi_pool', \


### PR DESCRIPTION
According to [单测规范](https://github.com/PaddlePaddle/Paddle/wiki/Upgrade-OP-Precision-to-Float64), it's necessary to update the precision of pad, pad2d, pad_constant_like's unit tests from fp32 to fp64. 
What's more, fix the data type error caused by pad_value, which is float, but got by double. 