### PR TITLE
support set param with None value

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -500,9 +500,15 @@ class TestImperative(unittest.TestCase):
         my_layer = MyLayer()
         my_layer.w1 = my_layer.create_parameter([3, 3])
         my_layer.add_parameter('w2', None)
-        self.assertRaises(TypeError, my_layer.add_parameter, 'w3', 'str')
+        self.assertEqual(len(my_layer.parameters()), 1)
+        self.assertRaises(TypeError, my_layer.__setattr__, 'w1', 'str')
+        my_layer.w1 = None
+        self.assertEqual(len(my_layer.parameters()), 0)
         my_layer.l1 = fluid.dygraph.Linear(3, 3)
+        self.assertEqual(len(my_layer.sublayers()), 1)
         self.assertRaises(TypeError, my_layer.__setattr__, 'l1', 'str')
+        my_layer.l1 = None
+        self.assertEqual(len(my_layer.sublayers()), 0)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -497,6 +497,13 @@ class TestImperative(unittest.TestCase):
         self.assertTrue(hasattr(layer, "test_attr"))
         self.assertEqual(layer.test_attr, 1)
 
+        my_layer = MyLayer()
+        my_layer.w1 = my_layer.create_parameter([3, 3])
+        my_layer.add_parameter('w2', None)
+        self.assertRaises(TypeError, my_layer.add_parameter, 'w3', 'str')
+        my_layer.l1 = fluid.dygraph.Linear(3, 3)
+        self.assertRaises(TypeError, my_layer.__setattr__, 'l1', 'str')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- 支持Layer注册`None`的参数，或将已有的参数设置为`None`
- 修正`parameters`和`sublayers`接口，和`named_`接口一致，返回结果排除了可能包含的`None`值