### PR TITLE
fix sigmoid cudnn bug

### DIFF
--- a/paddle/fluid/operators/activation_cudnn_op.cu.cc
+++ b/paddle/fluid/operators/activation_cudnn_op.cu.cc
@@ -171,9 +171,9 @@ class CudnnActivationGradKernel
 namespace plat = paddle::platform;
 namespace ops = paddle::operators;
 
-#define FOR_EACH_CUDNN_OP_FUNCTOR(__macro)                  \
-  __macro(relu, CudnnReluFunctor, CudnnReluGradFunctor);    \
-  __macro(relu6, CudnnRelu6Functor, CudnnRelu6GradFunctor); \
+#define FOR_EACH_CUDNN_OP_FUNCTOR(__macro)                        \
+  __macro(relu, CudnnReluFunctor, CudnnReluGradFunctor);          \
+  __macro(relu6, CudnnRelu6Functor, CudnnRelu6GradFunctor);       \
   __macro(sigmoid, CudnnSigmoidFunctor, CudnnSigmoidGradFunctor); \
   __macro(tanh, CudnnTanhFunctor, CudnnTanhGradFunctor)
 

--- a/paddle/fluid/operators/activation_cudnn_op.cu.cc
+++ b/paddle/fluid/operators/activation_cudnn_op.cu.cc
@@ -174,7 +174,7 @@ namespace ops = paddle::operators;
 #define FOR_EACH_CUDNN_OP_FUNCTOR(__macro)                  \
   __macro(relu, CudnnReluFunctor, CudnnReluGradFunctor);    \
   __macro(relu6, CudnnRelu6Functor, CudnnRelu6GradFunctor); \
-  __macro(sigmoid, CudnnTanhFunctor, CudnnTanhGradFunctor); \
+  __macro(sigmoid, CudnnSigmoidFunctor, CudnnSigmoidGradFunctor); \
   __macro(tanh, CudnnTanhFunctor, CudnnTanhGradFunctor)
 
 #define REGISTER_ACTIVATION_CUDNN_KERNEL(act_type, functor, grad_functor) \


### PR DESCRIPTION
Sigmoid activation was calling the wrong CUDNN functor. This PR fixes the bug and ensures it calls the correct Sigmoid Functor and Sigmoid Grad Functor.

Same with #22403