### PR TITLE
add skip_check_grad_ci of var_conv_2d

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_var_conv_2d.py
+++ b/python/paddle/fluid/tests/unittests/test_var_conv_2d.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, skip_check_grad_ci
 
 
 class TestVarConv2dOp(OpTest):
@@ -244,6 +244,9 @@ class TestVarConv2dOpCase5(TestVarConv2dOp):
                        col)
 
 
+@skip_check_grad_ci(
+    reason="[skip shape check] Use shape of input_channel, row and col all is 1 to test special LoDTensor."
+)
 class TestVarConv2dOpCase6(TestVarConv2dOp):
     def set_data(self):
         input_channel = 1

--- a/python/paddle/fluid/tests/unittests/white_list/check_shape_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/check_shape_white_list.py
@@ -36,5 +36,4 @@ NEED_TO_FIX_OP_LIST = [
     'spp',
     'squared_l2_distance',
     'tree_conv',
-    'var_conv_2d',
 ]


### PR DESCRIPTION
参考[OP单测规范：OP单测必须使用大尺寸输入](https://github.com/PaddlePaddle/Paddle/wiki/OP-test-input-shape-requirements)，对`TestVarConv2dOpCase6 ` 添加`skip_check_grad_ci `跳过shape大于100检查。

原因：
+ 此Case为了测试输入的LoDTensor的input_channel、row、col均为1时的逻辑正确性
+ 其他Case均满足shape>100的要求