### PR TITLE
Correct the use of DeviceContext in unittest sequence_pooling_test and sequence_padding_test

### DIFF
--- a/paddle/fluid/memory/memcpy.cc
+++ b/paddle/fluid/memory/memcpy.cc
@@ -43,8 +43,10 @@ void Copy<platform::CPUPlace, platform::CUDAPlace>(
     platform::CPUPlace dst_place, void* dst, platform::CUDAPlace src_place,
     const void* src, size_t num, cudaStream_t stream) {
   if (UNLIKELY(num == 0)) return;
-  platform::SetDeviceId(src_place.device);
 
+  platform::SetDeviceId(src_place.device);
+  VLOG(4) << "memory::Copy " << num << " Bytes from " << src_place << " to "
+          << dst_place << " by thream(" << stream << ")";
   if (stream) {
     platform::RecordEvent record_event("GpuMemcpyAsync:GPU->CPU");
     platform::GpuMemcpyAsync(dst, src, num, cudaMemcpyDeviceToHost, stream);
@@ -65,6 +67,8 @@ void Copy<platform::CUDAPlace, platform::CPUPlace>(
   if (UNLIKELY(num == 0)) return;
 
   platform::SetDeviceId(dst_place.device);
+  VLOG(4) << "memory::Copy " << num << " Bytes from " << src_place << " to "
+          << dst_place << " by thream(" << stream << ")";
   if (stream) {
     platform::RecordEvent record_event("GpuMemcpyAsync:CPU->GPU");
     platform::GpuMemcpyAsync(dst, src, num, cudaMemcpyHostToDevice, stream);

--- a/paddle/fluid/operators/math/sequence_padding_test.cc
+++ b/paddle/fluid/operators/math/sequence_padding_test.cc
@@ -16,8 +16,9 @@ limitations under the License. */
 #include <gtest/gtest.h>
 #include <vector>
 
-template <typename DeviceContext, typename Place, typename T>
-void TestSequencePadding(const paddle::framework::LoD& lod,
+template <typename DeviceContext, typename T>
+void TestSequencePadding(const DeviceContext &context,
+                         const paddle::framework::LoD &lod,
                          const size_t sequence_width) {
   paddle::framework::LoDTensor cpu_seq;
   paddle::framework::LoDTensor cpu_seq_back;
@@ -38,12 +39,11 @@ void TestSequencePadding(const paddle::framework::LoD& lod,
     cpu_seq.data<T>()[i] = static_cast<T>(i);
   }
 
-  auto* place = new Place();
-  DeviceContext* context = new DeviceContext(*place);
-  if (paddle::platform::is_cpu_place(*place)) {
+  auto place = context.GetPlace();
+  if (paddle::platform::is_cpu_place(place)) {
     seq = cpu_seq;
   } else {
-    TensorCopySync(cpu_seq, *place, &seq);
+    TensorCopySync(cpu_seq, place, &seq);
     seq.set_lod(lod);
   }
 
@@ -55,28 +55,28 @@ void TestSequencePadding(const paddle::framework::LoD& lod,
                                     static_cast<int64_t>(num_sequences),
                                     static_cast<int64_t>(sequence_width)});
 
-  padding.mutable_data<T>(padding_dims, *place);
+  padding.mutable_data<T>(padding_dims, place);
 
-  T* pad_value_data =
+  T *pad_value_data =
       cpu_pad_value.mutable_data<T>({1}, paddle::platform::CPUPlace());
   *pad_value_data = static_cast<T>(0);
-  if (paddle::platform::is_cpu_place(*place)) {
+  if (paddle::platform::is_cpu_place(place)) {
     pad_value = cpu_pad_value;
   } else {
-    TensorCopySync(cpu_pad_value, *place, &pad_value);
+    TensorCopySync(cpu_pad_value, place, &pad_value);
   }
 
   paddle::operators::math::PaddingLoDTensorFunctor<DeviceContext, T>()(
-      *context, seq, &padding, pad_value, -1, 0, false,
+      context, seq, &padding, pad_value, -1, 0, false,
       paddle::operators::math::kLengthBatchWidth);
 
   seq_back.set_lod(lod);
-  seq_back.mutable_data<T>(seq_dims, *place);
+  seq_back.mutable_data<T>(seq_dims, place);
   paddle::operators::math::UnpaddingLoDTensorFunctor<DeviceContext, T>()(
-      *context, padding, &seq_back, -1, 0, false,
+      context, padding, &seq_back, -1, 0, false,
       paddle::operators::math::kLengthBatchWidth);
 
-  if (paddle::platform::is_cpu_place(*place)) {
+  if (paddle::platform::is_cpu_place(place)) {
     cpu_seq_back = seq_back;
   } else {
     TensorCopySync(seq_back, paddle::platform::CPUPlace(), &cpu_seq_back);
@@ -88,33 +88,38 @@ void TestSequencePadding(const paddle::framework::LoD& lod,
   for (int64_t i = 0; i < cpu_seq.numel(); ++i) {
     EXPECT_EQ(cpu_seq.data<T>()[i], cpu_seq_back.data<T>()[i]);
   }
-
-  delete place;
-  delete context;
 }
 
 TEST(Seq2BatchPadding, CPU) {
+  auto place = paddle::platform::CPUPlace();
+  auto *context = static_cast<paddle::platform::CPUDeviceContext *>(
+      paddle::platform::DeviceContextPool::Instance().Get(place));
+
   paddle::framework::LoD lod1;
   lod1.push_back(std::vector<size_t>{0, 10});
-  TestSequencePadding<paddle::platform::CPUDeviceContext,
-                      paddle::platform::CPUPlace, float>(lod1, 16);
+  TestSequencePadding<paddle::platform::CPUDeviceContext, float>(*context, lod1,
+                                                                 16);
 
   paddle::framework::LoD lod2;
   lod2.push_back(std::vector<size_t>{0, 2, 7, 10});
-  TestSequencePadding<paddle::platform::CPUDeviceContext,
-                      paddle::platform::CPUPlace, float>(lod2, 128);
+  TestSequencePadding<paddle::platform::CPUDeviceContext, float>(*context, lod2,
+                                                                 128);
 }
 
 #ifdef PADDLE_WITH_CUDA
 TEST(SequencePadding, CUDA) {
+  auto place = paddle::platform::CUDAPlace(0);
+  auto *context = static_cast<paddle::platform::CUDADeviceContext *>(
+      paddle::platform::DeviceContextPool::Instance().Get(place));
+
   paddle::framework::LoD lod1;
   lod1.push_back(std::vector<size_t>{0, 10});
-  TestSequencePadding<paddle::platform::CUDADeviceContext,
-                      paddle::platform::CUDAPlace, float>(lod1, 16);
+  TestSequencePadding<paddle::platform::CUDADeviceContext, float>(*context,
+                                                                  lod1, 16);
 
   paddle::framework::LoD lod2;
   lod2.push_back(std::vector<size_t>{0, 2, 7, 10});
-  TestSequencePadding<paddle::platform::CUDADeviceContext,
-                      paddle::platform::CUDAPlace, float>(lod2, 128);
+  TestSequencePadding<paddle::platform::CUDADeviceContext, float>(*context,
+                                                                  lod2, 128);
 }
 #endif

--- a/paddle/fluid/operators/math/sequence_pooling.cu
+++ b/paddle/fluid/operators/math/sequence_pooling.cu
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include <algorithm>
 #include <string>
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/operators/math/sequence_pooling.h"
@@ -166,7 +167,7 @@ class SequencePoolFunctor<platform::CUDADeviceContext, T> {
     auto& lod = input.lod()[lod_level - 1];
     const size_t item_dim = output->numel() / output->dims()[0];
     dim3 threads(1024, 1);
-    dim3 grid(lod.size(), 1);
+    dim3 grid(std::max(lod.size() - 1, 1UL), 1);
     if (pooltype == "MAX") {
       sequence_pool_kernel<
           T, MaxPoolFunctor<T>><<<grid, threads, 0, context.stream()>>>(
@@ -330,7 +331,7 @@ class SequencePoolGradFunctor<platform::CUDADeviceContext, T> {
     auto& lod = in_grad->lod()[lod_level - 1];
     const size_t item_dim = in_grad->numel() / in_grad->dims()[0];
     dim3 threads(1024, 1);
-    dim3 grid(lod.size(), 1);
+    dim3 grid(std::max(lod.size() - 1, 1UL), 1);
     if (pooltype == "MAX") {
       sequence_pool_grad_kernel<
           T, MaxPoolGradFunctor<T>><<<grid, threads, 0, context.stream()>>>(

--- a/paddle/fluid/operators/math/sequence_pooling_test.cc
+++ b/paddle/fluid/operators/math/sequence_pooling_test.cc
@@ -16,13 +16,14 @@ limitations under the License. */
 #include <gtest/gtest.h>
 #include <vector>
 
-template <typename DeviceContext, typename Place, typename T>
-void TestSequencePoolingSum(const paddle::framework::LoD& lod) {
+template <typename DeviceContext, typename T>
+void TestSequencePoolingSum(const DeviceContext &context,
+                            const paddle::framework::LoD &lod,
+                            const size_t second_dim) {
   paddle::framework::LoDTensor cpu_out_grad;
   paddle::framework::LoDTensor cpu_in_grad;
   paddle::framework::LoDTensor out_grad;
   paddle::framework::LoDTensor in_grad;
-  const size_t second_dim = 128u;
 
   // construct out_grad's tensor in cpu
   const size_t out_first_dim = lod[0].size() - 1;
@@ -35,19 +36,18 @@ void TestSequencePoolingSum(const paddle::framework::LoD& lod) {
   }
 
   // copy to dst out_grad
-  auto* place = new Place();
-  DeviceContext* context = new DeviceContext(*place);
-  if (paddle::platform::is_cpu_place(*place)) {
+  auto place = context.GetPlace();
+  if (paddle::platform::is_cpu_place(place)) {
     out_grad = cpu_out_grad;
   } else {
-    TensorCopySync(cpu_out_grad, *place, &out_grad);
+    TensorCopySync(cpu_out_grad, place, &out_grad);
   }
 
   // construct in_grad
   in_grad.set_lod(lod);
   auto in_dims = paddle::framework::make_ddim(
       {static_cast<int64_t>(lod[0].back()), static_cast<int64_t>(second_dim)});
-  in_grad.mutable_data<T>(in_dims, context->GetPlace());
+  in_grad.mutable_data<T>(in_dims, place);
 
   // check tensor contruction result
   PADDLE_ENFORCE_EQ(in_grad.dims().size(), out_grad.dims().size());
@@ -57,9 +57,9 @@ void TestSequencePoolingSum(const paddle::framework::LoD& lod) {
 
   // call functor
   paddle::operators::math::SequencePoolGradFunctor<DeviceContext, T>()(
-      *context, "SUM", out_grad, &in_grad);
+      context, "SUM", out_grad, &in_grad);
 
-  if (paddle::platform::is_cpu_place(*place)) {
+  if (paddle::platform::is_cpu_place(place)) {
     cpu_in_grad = in_grad;
   } else {
     TensorCopySync(in_grad, paddle::platform::CPUPlace(), &cpu_in_grad);
@@ -69,7 +69,7 @@ void TestSequencePoolingSum(const paddle::framework::LoD& lod) {
   EXPECT_EQ(in_grad.numel(), static_cast<int64_t>(lod[0].back() * second_dim));
   EXPECT_EQ(in_grad.lod(), lod);
 
-  if (paddle::platform::is_cpu_place(*place)) {
+  if (paddle::platform::is_cpu_place(place)) {
     for (size_t i = 0; i < in_grad.lod()[0].size() - 1; ++i) {
       int64_t begin = in_grad.lod()[0][i];
       int64_t end = in_grad.lod()[0][i + 1];
@@ -94,33 +94,40 @@ void TestSequencePoolingSum(const paddle::framework::LoD& lod) {
       }
     }
   }
-
-  delete place;
-  delete context;
 }
 
 TEST(SequencePoolingGrad, CPU_SUM) {
+  auto place = paddle::platform::CPUPlace();
+  auto *context = static_cast<paddle::platform::CPUDeviceContext *>(
+      paddle::platform::DeviceContextPool::Instance().Get(place));
+  const size_t second_dim = 128U;
+
   paddle::framework::LoD lod1;
   lod1.push_back(std::vector<size_t>{0, 10});
-  TestSequencePoolingSum<paddle::platform::CPUDeviceContext,
-                         paddle::platform::CPUPlace, float>(lod1);
+  TestSequencePoolingSum<paddle::platform::CPUDeviceContext, float>(
+      *context, lod1, second_dim);
 
   paddle::framework::LoD lod2;
   lod2.push_back(std::vector<size_t>{0, 2, 7, 10});
-  TestSequencePoolingSum<paddle::platform::CPUDeviceContext,
-                         paddle::platform::CPUPlace, float>(lod2);
+  TestSequencePoolingSum<paddle::platform::CPUDeviceContext, float>(
+      *context, lod2, second_dim);
 }
 
 #ifdef PADDLE_WITH_CUDA
 TEST(SequencePoolingGrad, CUDA_SUM) {
+  auto place = paddle::platform::CUDAPlace(0);
+  auto *context = static_cast<paddle::platform::CUDADeviceContext *>(
+      paddle::platform::DeviceContextPool::Instance().Get(place));
+  const size_t second_dim = 128U;
+
   paddle::framework::LoD lod1;
   lod1.push_back(std::vector<size_t>{0, 10});
-  TestSequencePoolingSum<paddle::platform::CUDADeviceContext,
-                         paddle::platform::CUDAPlace, float>(lod1);
+  TestSequencePoolingSum<paddle::platform::CUDADeviceContext, float>(
+      *context, lod1, second_dim);
 
   paddle::framework::LoD lod2;
   lod2.push_back(std::vector<size_t>{0, 2, 7, 10});
-  TestSequencePoolingSum<paddle::platform::CUDADeviceContext,
-                         paddle::platform::CUDAPlace, float>(lod2);
+  TestSequencePoolingSum<paddle::platform::CUDADeviceContext, float>(
+      *context, lod2, second_dim);
 }
 #endif


### PR DESCRIPTION
压测时，sequence_pooling_test和sequence_padding_test这两个单测会出现随机挂的问题，链接分别见[sequence_pooling_test](http://ci.paddlepaddle.org/viewLog.html?buildId=273027&buildTypeId=Paddle_PaddleManylinux_PrCiManylinuxCoverage&tab=buildLog)和[sequence_padding_test](http://ci.paddlepaddle.org/viewLog.html?buildId=276770&buildTypeId=Paddle_PaddleManylinux_PrCiManylinuxCoverage&tab=buildLog)。我添加了一些log并设置GLOG_v=4之后sequence_pooling_test的log如下：
```
[ RUN      ] SequencePoolingGrad.CUDA_SUM
I0205 04:54:38.279438  3901 dynamic_loader.cc:94] Try to find library: libcublas.so from default system path.
W0205 04:54:38.588321  3901 device_context.cc:237] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0
I0205 04:54:38.588366  3901 dynamic_loader.cc:94] Try to find library: libcudnn.so from default system path.
W0205 04:54:38.593174  3901 device_context.cc:245] device: 0, cuDNN Version: 7.6.
I0205 04:54:40.208264  3901 tensor_util.cu:129] TensorCopySync 1, 128 from CPUPlace to CUDAPlace(0)
I0205 04:54:40.208351  3901 auto_growth_best_fit_allocator.cc:97] Not found and reallocate 768, and remaining 256
I0205 04:54:40.208359  3901 memcpy.cc:69] memory::Copy 512 Bytes from CPUPlace to CUDAPlace(0) by thream(0)
I0205 04:54:40.208809  3901 auto_growth_best_fit_allocator.cc:97] Not found and reallocate 5376, and remaining 256
I0205 04:54:40.208859  3901 sequence_pooling.cu:346] lod: {{0, 10}}, stream:0x494e2b0
I0205 04:54:40.208871  3901 mixed_vector.h:389] cuda_place is boost::none
I0205 04:54:40.210078  3901 memcpy.cc:69] memory::Copy 16 Bytes from CPUPlace to CUDAPlace(0) by thream(0x4f95f660)
I0205 04:54:40.210178  3901 tensor_util.cu:129] TensorCopySync 10, 128 from CUDAPlace(0) to CPUPlace
I0205 04:54:40.210191  3901 memcpy.cc:48] memory::Copy 5120 Bytes from CUDAPlace(0) to CPUPlace by thream(0)
gridDim: [1, 1]; blockDim: [1024, 1]; blockIdx.x: 0, threadIdx.x: 0, start: 0, end = 10
I0205 04:54:40.212081  3901 tensor_util.cu:129] TensorCopySync 3, 128 from CPUPlace to CUDAPlace(0)
I0205 04:54:40.212105  3901 memcpy.cc:69] memory::Copy 1536 Bytes from CPUPlace to CUDAPlace(0) by thream(0)
I0205 04:54:40.212150  3901 auto_growth_best_fit_allocator.cc:97] Not found and reallocate 5376, and remaining 256
I0205 04:54:40.212194  3901 sequence_pooling.cu:346] lod: {{0, 2, 7, 10}}, stream:0x4e0aa940
I0205 04:54:40.212203  3901 mixed_vector.h:389] cuda_place is boost::none
I0205 04:54:40.212208  3901 memcpy.cc:69] memory::Copy 32 Bytes from CPUPlace to CUDAPlace(0) by thream(0x4f95f660)
I0205 04:54:40.212229  3901 tensor_util.cu:129] TensorCopySync 10, 128 from CUDAPlace(0) to CPUPlace
I0205 04:54:40.212236  3901 memcpy.cc:48] memory::Copy 5120 Bytes from CUDAPlace(0) to CPUPlace by thream(0)
gridDim: [3, 1]; blockDim: [1024, 1]; blockIdx.x: 0, threadIdx.x: 0, start: 0, end = 0
gridDim: [3, 1]; blockDim: [1024, 1]; blockIdx.x: 1, threadIdx.x: 0, start: 0, end = 0
/workspace/Paddle/paddle/fluid/operators/math/sequence_pooling_test.cc:98: Failure
Expected equality of these values:
  tmp.data<T>()[m + j * second_dim]
    Which is: 0
  cpu_out_grad.data<T>()[m + i * second_dim]
    Which is: 1
/workspace/Paddle/paddle/fluid/operators/math/sequence_pooling_test.cc:98: Failure
Expected equality of these values:
  tmp.data<T>()[m + j * second_dim]
    Which is: 0
  cpu_out_grad.data<T>()[m + i * second_dim]
    Which is: 2
```

从log中可以看出，单测出错时，CUDA Kernel里面不能拿到正确的start、end值，也就是lod数据。lod数据是`paddle::framework::Vector`类型，在调用`CUDAData(place)`时，会自动将CPU端的数据传输到GPU上，实现该功能的代码为：

https://github.com/PaddlePaddle/Paddle/blob/7bc4b095008058fdde05e3e9337e31845f1ce9b5/paddle/fluid/framework/mixed_vector.h#L257-L267

从log中，我们可以看出：

- **在sequence_pooling的计算kernel中使用的stream，和将lod数据从CPU传输到GPU的stream不是同一个。**
- 将lod数据从CPU传输到GPU，使用的是DeviceContextPool里面的DeviceContext的stream，而`sequence_pooling_test`里面自己new了一个DeviceContext用于计算。
- 只有在同一个stream上的任务，才能保证按照加入stream的顺序依次执行。lod数据传输和Kernel计算用的不是同一个stream，则不能保证在Kernel计算启动之前lod数据传输完毕。

修改后能保证单测中始终使用同一个stream，sequence_pooling_test的运行log如下：
```
I0205 05:36:28.279299 16052 dynamic_loader.cc:94] Try to find library: libcublas.so from default system path.
W0205 05:36:28.582180 16052 device_context.cc:237] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0
I0205 05:36:28.582227 16052 dynamic_loader.cc:94] Try to find library: libcudnn.so from default system path.
W0205 05:36:28.586313 16052 device_context.cc:245] device: 0, cuDNN Version: 7.6.
I0205 05:36:30.165423 16052 tensor_util.cu:129] TensorCopySync 1, 128 from CPUPlace to CUDAPlace(0)
I0205 05:36:30.165508 16052 auto_growth_best_fit_allocator.cc:97] Not found and reallocate 768, and remaining 256
I0205 05:36:30.165518 16052 memcpy.cc:69] memory::Copy 512 Bytes from CPUPlace to CUDAPlace(0) by thream(0)
I0205 05:36:30.165575 16052 auto_growth_best_fit_allocator.cc:97] Not found and reallocate 5376, and remaining 256
I0205 05:36:30.165621 16052 sequence_pooling.cu:346] lod: {{0, 10}}, stream:0x4489cf0
I0205 05:36:30.165632 16052 mixed_vector.h:389] cuda_place is boost::none
I0205 05:36:30.165637 16052 memcpy.cc:69] memory::Copy 16 Bytes from CPUPlace to CUDAPlace(0) by thream(0x4489cf0)
I0205 05:36:30.165729 16052 tensor_util.cu:129] TensorCopySync 10, 128 from CUDAPlace(0) to CPUPlace
I0205 05:36:30.165740 16052 memcpy.cc:48] memory::Copy 5120 Bytes from CUDAPlace(0) to CPUPlace by thream(0)
gridDim: [1, 1]; blockDim: [1024, 1]; blockIdx.x: 0, threadIdx.x: 0, start: 0, end = 10
I0205 05:36:30.165926 16052 tensor_util.cu:129] TensorCopySync 3, 128 from CPUPlace to CUDAPlace(0)
I0205 05:36:30.165935 16052 memcpy.cc:69] memory::Copy 1536 Bytes from CPUPlace to CUDAPlace(0) by thream(0)
I0205 05:36:30.165968 16052 auto_growth_best_fit_allocator.cc:97] Not found and reallocate 5376, and remaining 256
I0205 05:36:30.166014 16052 sequence_pooling.cu:346] lod: {{0, 2, 7, 10}}, stream:0x4489cf0
I0205 05:36:30.166021 16052 mixed_vector.h:389] cuda_place is boost::none
I0205 05:36:30.166028 16052 memcpy.cc:69] memory::Copy 32 Bytes from CPUPlace to CUDAPlace(0) by thream(0x4489cf0)
I0205 05:36:30.166050 16052 tensor_util.cu:129] TensorCopySync 10, 128 from CUDAPlace(0) to CPUPlace
I0205 05:36:30.166057 16052 memcpy.cc:48] memory::Copy 5120 Bytes from CUDAPlace(0) to CPUPlace by thream(0)
gridDim: [3, 1]; blockDim: [1024, 1]; blockIdx.x: 0, threadIdx.x: 0, start: 0, end = 2
gridDim: [3, 1]; blockDim: [1024, 1]; blockIdx.x: 1, threadIdx.x: 0, start: 2, end = 7
```

sequence_padding_test也是同样的错误。