### PR TITLE
scale is no longer added when saving inference model, test=develop

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1129,17 +1129,6 @@ def save_inference_model(dirname,
             )
             break
 
-    # fix the bug that the activation op's output as target will be pruned.
-    # will affect the inference performance.
-    # TODO(Superjomn) add an IR pass to remove 1-scale op.
-    with program_guard(main_program):
-        uniq_target_vars = []
-        for i, var in enumerate(target_vars):
-            if isinstance(var, Variable):
-                var = layers.scale(
-                    var, 1., name="save_infer_model/scale_{}".format(i))
-            uniq_target_vars.append(var)
-        target_vars = uniq_target_vars
     target_var_name_list = [var.name for var in target_vars]
 
     # when a pserver and a trainer running on the same machine, mkdir may conflict


### PR DESCRIPTION
<img width="557" alt="image" src="https://user-images.githubusercontent.com/39303645/73827256-2be5b980-483a-11ea-8de6-bd87a062e9ce.png">

较旧的 Fluid 版本中 activation helper 会添加 inplace 算子，裁剪时可能会错误地将模型最后的 activation 舍弃（https://github.com/PaddlePaddle/Paddle/pull/9740 https://github.com/PaddlePaddle/Paddle/issues/12609 ）。为规避此问题，保存预测模型时添加了一个 scale 层（https://github.com/PaddlePaddle/Paddle/pull/15365 ），但这改变了原有的模型结构。

<img width="422" alt="image" src="https://user-images.githubusercontent.com/39303645/73827302-415ae380-483a-11ea-9aa1-4f3d9344b64e.png">

如上图，现在 https://github.com/PaddlePaddle/Paddle/pull/16410 禁用了原地激活，此问题不再存在；所以删除这部分临时代码。