### PR TITLE
disable_fc_gru_fusion, test=develop

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -153,9 +153,9 @@ CpuPassStrategy::CpuPassStrategy() : PassStrategy({}) {
                   // "seqpool_concat_fuse_pass",    //
                   "seqpool_cvm_concat_fuse_pass",  //
                   // "embedding_fc_lstm_fuse_pass", //
-                  "fc_lstm_fuse_pass",                       //
-                  "mul_lstm_fuse_pass",                      //
-                  "fc_gru_fuse_pass",                        //
+                  "fc_lstm_fuse_pass",   //
+                  "mul_lstm_fuse_pass",  //
+                  // "fc_gru_fuse_pass",                     //
                   "mul_gru_fuse_pass",                       //
                   "seq_concat_fc_fuse_pass",                 //
                   "fc_fuse_pass",                            //


### PR DESCRIPTION
因为 fc + gru 的融合存在问题待修复，所以默认禁用。