### PR TITLE
refine some usage of enum to avoid the implict convertion

### DIFF
--- a/paddle/fluid/platform/cudnn_helper.h
+++ b/paddle/fluid/platform/cudnn_helper.h
@@ -75,7 +75,7 @@ enum class PoolingMode {
   kAverageInclusive,
 };
 
-enum ActivationMode {
+enum class ActivationMode {
   kNone,  // activation identity
   kSigmoid,
   kRelu,

--- a/paddle/fluid/platform/event.h
+++ b/paddle/fluid/platform/event.h
@@ -23,7 +23,7 @@ limitations under the License. */
 namespace paddle {
 namespace platform {
 
-enum EventType { kMark, kPushRange, kPopRange };
+enum class EventType { kMark, kPushRange, kPopRange };
 
 class Event {
  public:

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -340,8 +340,7 @@ void PrintProfiler(const std::vector<std::vector<EventItem>> &events_table,
     } else {
       PADDLE_THROW(platform::errors::InvalidArgument(
           "Except profiler state must to be one of ['CPU', 'GPU' 'ALL'], but "
-          "received Invalid profiler state %s",
-          g_state));
+          "received Invalid profiler state"));
     }
 
     if (merge_thread) {

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -32,7 +32,7 @@ limitations under the License. */
 namespace paddle {
 namespace platform {
 
-enum ProfilerState {
+enum class ProfilerState {
   kDisabled,  // disabled state
   kCPU,       // CPU profiling state
   kCUDA,      // GPU profiling state
@@ -116,7 +116,7 @@ struct RecordBlock {
 std::vector<std::vector<Event>> GetAllEvents();
 
 // Candidate keys to sort the profiling report
-enum EventSortingKey {
+enum class EventSortingKey {
   kDefault,
   kCalls,
   kTotal,


### PR DESCRIPTION
use C++11 enum class to refine the code
一个是防止隐私的转换 第二就是在某些情况下防止重复 比如 enum A {default}  enum B{default}这种使用会有歧义 