### PR TITLE
Remove TensorRT lib from Paddle Inference libs

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -124,13 +124,6 @@ function(copy_part_of_thrid_party TARGET DST)
                 DSTS ${dst_dir} ${dst_dir})
     endif ()
 
-    if (TENSORRT_FOUND)
-        set(dst_dir "${DST}/third_party/install/tensorrt")
-        copy(${TARGET}
-                SRCS ${TENSORRT_INCLUDE_DIR}/Nv*.h ${TENSORRT_LIBRARY_DIR}/*nvinfer*
-                DSTS ${dst_dir}/include ${dst_dir}/lib)
-    endif ()
-
     if (LITE_BINARY_DIR)
         set(dst_dir "${DST}/third_party/install/lite")
         copy(${TARGET}
@@ -277,8 +270,7 @@ function(version version_file)
     endif()
     if(TENSORRT_FOUND)
         file(APPEND ${version_file}
-                "WITH_TENSORRT: ${TENSORRT_FOUND}\n"
-                "TENSORRT_ROOT: ${TENSORRT_ROOT}\n")
+                "WITH_TENSORRT: ${TENSORRT_FOUND}\n")
     endif()
     
 endfunction()


### PR DESCRIPTION
At the require of NVIDIA that TensorRT lib should only be downloaded from [NVIDIA official website](https://developer.nvidia.com/nvidia-tensorrt-download), Paddle Inference will not bundle TRT lib, starting from version 1.7.0. So we remove the copying of TRT lib during building Paddle Inference libs.