### PR TITLE
refine reshape_op shape error message

### DIFF
--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -29,10 +29,11 @@ inline std::vector<int> get_new_shape(
     auto tensor = list_new_shape_tensor[i];
     PADDLE_ENFORCE_EQ(
         tensor->dims(), framework::make_ddim({1}),
-        "ShapeError: If the element type of 'shape' in ReshapeOp is Tensor, "
-        "the element's shape must be [1]. But received the element's shape "
-        "is [%s]",
-        tensor->dims());
+        platform::errors::InvalidArgument(
+            "If the element type of 'shape' in ReshapeOp is Tensor, "
+            "the element's shape must be [1]. But received the element's shape "
+            "is [%s]",
+            tensor->dims()));
     if (platform::is_gpu_place(tensor->place())) {
       framework::Tensor temp;
       TensorCopySync(*tensor, platform::CPUPlace(), &temp);
@@ -64,10 +65,11 @@ class ReshapeOp : public framework::OperatorWithKernel {
       auto ShapeTensor = ctx->Inputs("ShapeTensor");
       PADDLE_ENFORCE_GT(
           ShapeTensor.size(), 0,
-          "ShapeError: When `shape` in ReshapeOp is a list or tuple "
-          "which contains Tensor, the shape's size can't be zero. "
-          "But received shape's size is %d.",
-          ShapeTensor.size());
+          platform::errors::InvalidArgument(
+              "When `shape` in ReshapeOp is a list or tuple "
+              "which contains Tensor, the shape's size can't be zero. "
+              "But received shape's size is %d.",
+              ShapeTensor.size()));
       auto infer_shape = ctx->Attrs().Get<std::vector<int>>("shape");
       const int64_t copy_dim_val = 0;
       auto in_dims = ctx->GetInputDim("X");
@@ -75,10 +77,11 @@ class ReshapeOp : public framework::OperatorWithKernel {
         if (infer_shape[i] == copy_dim_val) {
           PADDLE_ENFORCE_LT(
               static_cast<int>(i), in_dims.size(),
-              "ShapeError: The index of 0 in `shape` must be less than "
-              "the input tensor X's dimensions. But received shape[%d] "
-              "= 0, X's dimensions = %d, X's shape = [%s].",
-              i, in_dims.size(), in_dims);
+              platform::errors::InvalidArgument(
+                  "The index of 0 in `shape` must be less than "
+                  "the input tensor X's dimensions. But received shape[%d] "
+                  "= 0, X's dimensions = %d, X's shape = [%s].",
+                  i, in_dims.size(), in_dims));
           infer_shape[i] = in_dims[i];
         }
       }
@@ -108,10 +111,10 @@ class ReshapeOp : public framework::OperatorWithKernel {
       return;
     }
 
-    PADDLE_ENFORCE_EQ(
-        !shape.empty(), true,
-        "ShapeError: The parameter 'shape' in ReshapeOp must be set. "
-        "But received 'shape' is empty.");
+    PADDLE_ENFORCE_EQ(!shape.empty(), true,
+                      platform::errors::InvalidArgument(
+                          "The parameter 'shape' in ReshapeOp must be set. "
+                          "But received 'shape' is empty."));
     auto x_dims = ctx->GetInputDim("X");
     auto out_dims = ValidateShape(shape, x_dims);
     ctx->SetOutputDim("Out", out_dims);
@@ -140,25 +143,28 @@ class ReshapeOp : public framework::OperatorWithKernel {
       if (shape[i] == unk_dim_val) {
         PADDLE_ENFORCE_EQ(
             unk_dim_idx, -1,
-            "ShapeError: Only one dimension value of 'shape' in ReshapeOp can "
-            "be -1. But received shape = [%s], shape[%d] is also -1.",
-            framework::make_ddim(shape), i);
+            platform::errors::InvalidArgument(
+                "Only one dimension value of 'shape' in ReshapeOp can "
+                "be -1. But received shape = [%s], shape[%d] is also -1.",
+                framework::make_ddim(shape), i));
         unk_dim_idx = i;
       } else if (shape[i] == copy_dim_val) {
         PADDLE_ENFORCE_LT(
             static_cast<int>(i), in_dims.size(),
-            "ShapeError: The index of 0 in `shape` must be less than "
-            "the input tensor X's dimensions. "
-            "But received shape = [%s], shape[%d] = 0, X's shape = [%s], "
-            "X's dimensions = %d.",
-            framework::make_ddim(shape), i, in_dims, in_dims.size());
+            platform::errors::InvalidArgument(
+                "The index of 0 in `shape` must be less than "
+                "the input tensor X's dimensions. "
+                "But received shape = [%s], shape[%d] = 0, X's shape = [%s], "
+                "X's dimensions = %d.",
+                framework::make_ddim(shape), i, in_dims, in_dims.size()));
       } else {
         PADDLE_ENFORCE_GT(
             shape[i], 0,
-            "ShapeError: Each dimension value of 'shape' in ReshapeOp must not "
-            "be negtive except one unknown dimension. "
-            "But received  shape = [%s], shape[%d] = %d.",
-            framework::make_ddim(shape), i, shape[i]);
+            platform::errors::InvalidArgument(
+                "Each dimension value of 'shape' in ReshapeOp must not "
+                "be negtive except one unknown dimension. "
+                "But received  shape = [%s], shape[%d] = %d.",
+                framework::make_ddim(shape), i, shape[i]));
       }
 
       capacity *= (shape[i] ? shape[i] : in_dims[i]);
@@ -180,8 +186,7 @@ class ReshapeOp : public framework::OperatorWithKernel {
                 "The input tensor X'size must be divisible by known "
                 "capacity of 'shape'. "
                 "But received X's shape = [%s], X's size = %d, "
-                "'shape' is [%s], known "
-                "capacity of 'shape' is %d.",
+                "'shape' is [%s], known capacity of 'shape' is %d.",
                 in_dims, in_size, framework::make_ddim(shape), capacity));
       } else {
         output_shape[unk_dim_idx] = -1;
@@ -190,12 +195,13 @@ class ReshapeOp : public framework::OperatorWithKernel {
       if (all_positive) {
         PADDLE_ENFORCE_EQ(
             capacity, in_size,
-            "ShapeError: The 'shape' in ReshapeOp is invalid. "
-            "The input tensor X'size must be equal to the capacity of 'shape'. "
-            "But received X's shape = [%s], X's size = %d, 'shape' is [%s], "
-            "the "
-            "capacity of 'shape' is %d.",
-            in_dims, in_size, framework::make_ddim(shape), capacity);
+            platform::errors::InvalidArgument(
+                "The 'shape' in ReshapeOp is invalid. "
+                "The input tensor X'size must be equal to the capacity of "
+                "'shape'. "
+                "But received X's shape = [%s], X's size = %d, 'shape' is "
+                "[%s], the capacity of 'shape' is %d.",
+                in_dims, in_size, framework::make_ddim(shape), capacity));
       }
     }
     return framework::make_ddim(output_shape);


### PR DESCRIPTION
## reshape op增强维度类报错信息
```
input = np.random.random([2, 25]).astype("float32")
x = fluid.layers.data(name="x", shape=[2, 25], append_batch_size=False, dtype="float32")
shape = fluid.layers.data(name="shape", shape=[1, 4], append_batch_size=False, dtype="float32")
fluid.layers.reshape(x, shape=shape)

cpu = fluid.core.CPUPlace()
exe = fluid.Executor(cpu)
```
1.6版本修复PR：#20099 
测试脚本：[test.py.zip](https://github.com/PaddlePaddle/Paddle/files/4165613/test.py.zip)

### 1.shape参数中元素不止一个为-1时
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([-1, -1, 5, 1]).astype("int32")})
```
- 1.6修改前报错：报错内容表述不清楚，没有打印维度信息
```
Only one input dimension of Attr(shape) can be unknown.
```

- 1.6修改后报错（如1.6版本没有修改，不需要写）
```
ShapeError: Only one dimension value of 'shape' in ReshapeOp can be -1. But received shape = [-1, -1, 5, 1], shape[1] is also -1.
```

- 本PR修改后报错
```
InvalidArgumentError: Only one dimension value of 'shape' in ReshapeOp can be -1. But received shape = [-1, -1, 5, 1], shape[1] is also -1.
  [Hint: Expected unk_dim_idx == -1, but received unk_dim_idx:0 != -1:-1.] at (/home/luotao/Paddle/paddle/fluid/operators/reshape_op.cc:149)
  [operator < reshape2 > error]
```
### 2.shape参数中元素为0时，0所对应的维度出错
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([2, 5, 5, 0]).astype("int32")})
```
- 1.6 修改前报错：报错内容表述不清楚，没有打印维度信息
```
The index of dimension to copy from input shape must be less than the size of input shape.
```

-  1.6修改后报错（如1.6版本没有修改，不需要写）
```
ShapeError: The index of 0 in `shape` must be less than the input tensor X's dimensions. But received shape = [2, 5, 5, 0], shape[3] = 0, X's shape = [2, 25], X's dimensions = 2.
```
- 本PR修改后报错
```
InvalidArgumentError: The index of 0 in `shape` must be less than the input tensor X's dimensions. But received shape = [2, 5, 5, 0], shape[3] = 0, X's shape = [2, 25], X's dimensions = 2.
  [Hint: Expected static_cast<int>(i) < in_dims.size(), but received static_cast<int>(i):3 >= in_dims.size():2.] at (/home/luotao/Paddle/paddle/fluid/operators/reshape_op.cc:159)
  [operator < reshape2 > error]
```
### 3.shape参数有-1以外的负值
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([-1, -5, 5, 1]).astype("int32")})
```
- 1.6 修改前报错：
```
Each input dimension of Attr(shape) must not be negtive except one unknown dimension.
```

- 1.6修改后报错（如1.6版本没有修改，不需要写）
```
ShapeError: Each dimension value of 'shape' in ReshapeOp must not be negtive except one unknown dimension. But received  shape = [-1, -5, 5, 1], shape[1] = -5.
```
- 本PR修改后报错
```
InvalidArgumentError: Each dimension value of 'shape' in ReshapeOp must not be negtive except one unknown dimension. But received  shape = [-1, -5, 5, 1], shape[1] = -5.
  [Hint: Expected shape[i] > 0, but received shape[i]:-5 <= 0:0.] at (/home/luotao/Paddle/paddle/fluid/operators/reshape_op.cc:167)
  [operator < reshape2 > error]
```
### 4.传入无效的shape值，无法正确推断出-1对应的实际值
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([-1, 3, 5, 1]).astype("int32")})
```
- 1.6修改前报错：
```
Invalid shape is given.
```

- 1.6修改后报错（如1.6版本没有修改，不需要写）
```
ShapeError: The 'shape' in ReshapeOp is invalid. The input tensor X'size must be divisible by known capacity of 'shape'. But received X's shape = [2, 25], X's size = 50, 'shape' is [-1, 3, 5, 1], known capacity of 'shape' is -15.
```
- 本PR修改后报错
```
InvalidArgumentError: The 'shape' attribute in ReshapeOp is invalid. The input tensor X'size must be divisible by known capacity of 'shape'. But received X's shape = [2, 25], X's size = 50, 'shape' is [-1, 3, 5, 1], known capacity of 'shape' is -15.
  [Hint: Expected output_shape[unk_dim_idx] * capacity == -in_size, but received output_shape[unk_dim_idx] * capacity:-45 != -in_size:-50.] at (/home/luotao/Paddle/paddle/fluid/operators/reshape_op.cc:190)
  [operator < reshape2 > error]
```

### 5.传入无效的shape值，输入x的size与 shape不匹配
```
exe.run(fluid.default_main_program(), 
           feed={"x": input, 
                      "shape": np.array([1, 3, 5, 1]).astype("int32")})
```
- 1.6修改前报错：
```
Invalid shape is given.
```

- 1.6修改后报错（如1.6版本没有修改，不需要写）
```
ShapeError: The 'shape' in ReshapeOp is invalid. The input tensor X'size must be equal to the capacity of 'shape'. But received X's shape = [2, 25], X's size = 50, 'shape' is [1, 3, 5, 1], the capacity of 'shape' is 15.
```
- 本PR修改后报错
```
InvalidArgumentError: The 'shape' in ReshapeOp is invalid. The input tensor X'size must be equal to the capacity of 'shape'. But received X's shape = [2, 25], X's size = 50, 'shape' is [1, 3, 5, 1], the capacity of 'shape' is 15.
  [Hint: Expected capacity == in_size, but received capacity:15 != in_size:50.] at (/home/luotao/Paddle/paddle/fluid/operators/reshape_op.cc:204)
  [operator < reshape2 > error]
```