### PR TITLE
fix test_fusion_seqpool_concat lod level between compile and runtime.…

### DIFF
--- a/paddle/fluid/operators/fused/fusion_seqpool_concat_op.cc
+++ b/paddle/fluid/operators/fused/fusion_seqpool_concat_op.cc
@@ -42,6 +42,12 @@ void FusionSeqPoolConcatOp::InferShape(
   PADDLE_ENFORCE_EQ(ins_dims[0].size(), 2,
                     "The dims size of first input should be 2.");
   ctx->SetOutputDim("Out", {-1, ins_dims[0][axis] * static_cast<int>(n)});
+
+  if (!ctx->IsRuntime()) {
+    // when compiling, the LodLevel of Out is set to be 1, which is consistent
+    // with that in running time.
+    ctx->SetLoDLevel("Out", 1);
+  }
 }
 
 framework::OpKernelType FusionSeqPoolConcatOp::GetExpectedKernelType(

--- a/python/paddle/fluid/tests/unittests/white_list/compile_vs_runtime_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/compile_vs_runtime_white_list.py
@@ -23,8 +23,7 @@ COMPILE_RUN_OP_WHITE_LIST = [
     'sequence_reshape', 'generate_proposals', 'mine_hard_examples',
     'retinanet_detection_output', 'ctc_align', 'fusion_seqpool_cvm_concat',
     'gru', 'sequence_erase', 'rpn_target_assign', 'retinanet_target_assign',
-    'filter_by_instag', 'fusion_seqpool_concat', 'multiclass_nms',
-    'multiclass_nms2', 'im2sequence', 'generate_proposal_labels',
-    'distribute_fpn_proposals', 'detection_map', 'locality_aware_nms',
-    'var_conv_2d'
+    'filter_by_instag', 'multiclass_nms', 'multiclass_nms2', 'im2sequence',
+    'generate_proposal_labels', 'distribute_fpn_proposals', 'detection_map',
+    'locality_aware_nms', 'var_conv_2d'
 ]


### PR DESCRIPTION
【OP单测规范修改】OP规范中规定编译时和运行是Lod_level一致，当前不能一致。不能通过一致性规范的OP请参考本PR的实现方式修改OP的实现
【一般修改方法描述】
错误原因：编译时与运行时输出的lod_level不一致
对应代码：infershape函数中未针对compile-time时设置lod_level.
修改方法：
1. 在OP的infershape函数中，添加编译时lod_level的设置方法
```
      // when compiling, the LodLevel of Out is set to be 1, which is consistent
      // with that in running time.
      ctx->SetLoDLevel("Out", 1);
```     
2. 修改完成后，在白名单文件python/paddle/fluid/tests/unittests/white_list/compile_vs_runtime_white_list.py中除去修复的OP名称。
