### PR TITLE
[DNNL] Draft of DNNL Memory optimizer - Part 1

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -524,6 +524,10 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
     return nullptr;
   }
 
+#ifdef PADDLE_WITH_MKLDNN
+  // TODO(jczaja): Enable memory optimizer for MKL-DNN/DNNL INT8 ops
+  platform::enable_mkldnn_memory_optimizer(!config.mkldnn_quantizer_enabled());
+#endif
   if (config.mkldnn_quantizer_enabled() && !predictor_p->MkldnnQuantize()) {
     return nullptr;
   }

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -285,7 +285,7 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto src_memory_p =
         handler.AcquireSrcMemoryFromPrimitive(user_src_memory_p, pipeline);
     auto weights_memory_p = handler.AcquireWeightsMemoryFromPrimitive(
-        user_weights_memory_p, pipeline, is_test);
+        filter, user_weights_memory_p, pipeline, is_test);
 
     std::shared_ptr<mkldnn::memory> dst_memory_p, user_residual_memory_p;
 
@@ -591,8 +591,8 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       int mask_reorder =
           is_multi_channel ? ((g != 1) ? (1 << 1) + (1 << 0) : 1 << 0) : 0;
       weights_memory_p = handler->AcquireWeightsMemoryFromPrimitive(
-          user_weights_memory_p, pipeline, is_test, true, scale_weights_data,
-          mask_reorder);
+          filter, user_weights_memory_p, pipeline, is_test, true,
+          scale_weights_data, mask_reorder);
 
       if (fuse_residual_conn) {
         auto residual_param = ctx.Input<Tensor>("ResidualData");

--- a/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_transpose_mkldnn_op.cc
@@ -208,7 +208,7 @@ class ConvTransposeMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     auto src_memory_p =
         handler.AcquireSrcMemoryFromPrimitive(user_src_memory_p, pipeline);
     auto weights_memory_p = handler.AcquireWeightsMemoryFromPrimitive(
-        user_weights_memory_p, pipeline, is_test);
+        filter, user_weights_memory_p, pipeline, is_test);
 
     auto output_data =
         output->mutable_data<T>(ctx.GetPlace(), handler.GetDstMemorySize());

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -404,7 +404,16 @@ thread_local int cur_input_shape_cache_capacity = 1;
 // know for converting MKL-DNN Tensor to non MKL-DNN
 thread_local paddle::framework::DataLayout cur_paddle_data_layout =
     paddle::framework::DataLayout::kNCHW;
+thread_local bool memory_mkldnn_optimizer_enabled = false;
 }  // namespace
+
+void enable_mkldnn_memory_optimizer(bool state) {
+  VLOG(2) << "Enabling MKL-DNN memory optimizer: " << state;
+  memory_mkldnn_optimizer_enabled = state;
+}
+bool is_mkldnn_memory_optimizer_enabled() {
+  return memory_mkldnn_optimizer_enabled;
+}
 
 void set_cur_mkldnn_session_id(size_t sid) { cur_mkldnn_session_id = sid; }
 size_t get_cur_mkldnn_session_id(void) { return cur_mkldnn_session_id; }

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -300,6 +300,8 @@ void set_cur_input_shape_str(std::string input_shape_str);
 void set_cur_input_shape_cache_capacity(int input_shape_cache_capacity);
 void set_cur_paddle_data_layout(framework::DataLayout);
 framework::DataLayout get_cur_paddle_data_layout(void);
+void enable_mkldnn_memory_optimizer(bool state);
+bool is_mkldnn_memory_optimizer_enabled(void);
 
 class MKLDNNDeviceContext : public CPUDeviceContext {
  public:


### PR DESCRIPTION
This is first PR trying to reduce MKL-DNN memory consumption to the level quite close to native CPU Paddle implementation. Relevant discussion takes place at #21493. 

 Changes introduced are very limited e.g.
* only inference of fp32 is supported (no int8 support yet)
* Memory savings happen only when original model params size is the same as DNNL weights size.

Both of limitations can be overcomed with more changes in core of PaddlePaddle.

Model | Peak memory cosumption : develop | Peak memory consumption: this PR
------------ | -------------|--------
googlenetv1 | 600 MB| 580 MB
demark | 622 MB | 600 MB
mobilenetv1 | 640 MB | 580 MB

I would appreciate if @LeoZhao-Intel  and @zhangting2020  would express their opinion on those changes.  Please tell me if this kind of changes are conceptually fine to you. In short : original model's param  is replaced  with DNNL's params.

CI can only pass with approval.