### PR TITLE
Fix dismatch error of std::max's arguments type on windows.

### DIFF
--- a/paddle/fluid/operators/math/sequence_pooling.cu
+++ b/paddle/fluid/operators/math/sequence_pooling.cu
@@ -167,7 +167,7 @@ class SequencePoolFunctor<platform::CUDADeviceContext, T> {
     auto& lod = input.lod()[lod_level - 1];
     const size_t item_dim = output->numel() / output->dims()[0];
     dim3 threads(1024, 1);
-    dim3 grid(std::max(lod.size() - 1, 1UL), 1);
+    dim3 grid(std::max(static_cast<int>(lod.size()) - 1, 1), 1);
     if (pooltype == "MAX") {
       sequence_pool_kernel<
           T, MaxPoolFunctor<T>><<<grid, threads, 0, context.stream()>>>(
@@ -331,7 +331,7 @@ class SequencePoolGradFunctor<platform::CUDADeviceContext, T> {
     auto& lod = in_grad->lod()[lod_level - 1];
     const size_t item_dim = in_grad->numel() / in_grad->dims()[0];
     dim3 threads(1024, 1);
-    dim3 grid(std::max(lod.size() - 1, 1UL), 1);
+    dim3 grid(std::max(static_cast<int>(lod.size()) - 1, 1), 1);
     if (pooltype == "MAX") {
       sequence_pool_grad_kernel<
           T, MaxPoolGradFunctor<T>><<<grid, threads, 0, context.stream()>>>(


### PR DESCRIPTION
错误详情为：
![image](https://user-images.githubusercontent.com/12538138/74079638-4bb4f180-4a75-11ea-90d5-7bc6a44ca929.png)

原代码为：
```cpp
std::max(lod.size() - 1, 1UL)
```

其中`lod.size()`为`size_t`，windows上解析成`unsigned long long`类型，`1UL`解析成`unsigned long`类型，因此出现参数类型不一致的错误。错误根源是不同系统上整数的位数不相同。解决方法是将参数都强制转换成`int`类型。