### PR TITLE
support backward hook for dygraph

### DIFF
--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -233,6 +233,7 @@ class VarBase {
 
   void RegisterBackwardHooks(const std::function<void()>& func, int id) {
     backward_hooks_[id] = func;
+    VLOG(9) << "Register Backward Hook for Var: " << Name() << std::endl;
   }
 
   int Get_Hooks_Id() {
@@ -245,6 +246,7 @@ class VarBase {
     for (iter = backward_hooks_.begin(); iter != backward_hooks_.end();
          iter++) {
       (iter->second)();
+      VLOG(9) << "Invoke Backward Hook for Var: " << Name() << std::endl;
     }
   }
 
@@ -262,6 +264,7 @@ class VarBase {
   // grad_op indicates which grad_op will this var be used as input
   std::vector<std::weak_ptr<OpBase>> grad_ops_;
 
+  // add next_hooks_id_ and backward_hooks_ to support backward hook.
   int next_hooks_id_;
   std::map<int, std::function<void()>> backward_hooks_;
   // add this property for users may set stop_gradient themselves and this

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -60,16 +60,11 @@ class RemovablePyCallableObject {
  public:
   RemovablePyCallableObject(std::map<int, std::function<void()>>* hooks,
                             int hooks_id)
-      : hooks_(hooks), hooks_id_(hooks_id) {
-    VLOG(2) << "RemovablePyCallableObject address: " << (hooks_) << std::endl;
-  }
+      : hooks_(hooks), hooks_id_(hooks_id) {}
 
   int Get_Hooks_Id() { return hooks_id_; }
 
-  void Remove() {
-    int a = hooks_->erase(hooks_id_);
-    VLOG(2) << "delete id: " << a << std::endl;
-  }
+  void Remove() { hooks_->erase(hooks_id_); }
 
   ~RemovablePyCallableObject() {}
 
@@ -237,7 +232,6 @@ class VarBase {
                                       const bool blocking) const;
 
   void RegisterBackwardHooks(const std::function<void()>& func, int id) {
-    // backward_hooks_.emplace_back(func);
     backward_hooks_[id] = func;
   }
 
@@ -252,9 +246,6 @@ class VarBase {
          iter++) {
       (iter->second)();
     }
-    // for (const auto& func : backward_hooks_) {
-    //  func();
-    // }
   }
 
   std::map<int, std::function<void()>>& GetBackwardHooks() {
@@ -270,8 +261,8 @@ class VarBase {
 
   // grad_op indicates which grad_op will this var be used as input
   std::vector<std::weak_ptr<OpBase>> grad_ops_;
+
   int next_hooks_id_;
-  // std::vector<std::function<void()>> backward_hooks_;
   std::map<int, std::function<void()>> backward_hooks_;
   // add this property for users may set stop_gradient themselves and this
   // should override the
@@ -648,18 +639,6 @@ class OpBase : public std::enable_shared_from_this<OpBase> {
   const NameVarBaseMap& GetOutsMap() { return outs_; }
   const platform::Place& place() const { return place_; }
 
-  // TODO(jiabin) prepare for backward hook
-  void RegisterBackwardHooks(const std::function<void()>& func) {
-    backward_hooks_.emplace_back(func);
-  }
-
-  void InvokeBackwardHooks() {
-    for (const auto& func : backward_hooks_) {
-      func();
-      VLOG(5) << "Invoke Backward Hook for: " << Type() << std::endl;
-    }
-  }
-
  private:
   OpBase(size_t id, const std::string& type, const NameVarBaseMap& ins,
          const NameVarBaseMap& outs, const framework::AttributeMap& attrs,
@@ -713,7 +692,6 @@ class OpBase : public std::enable_shared_from_this<OpBase> {
 
   std::unique_ptr<framework::OperatorBase> op_;
 
-  std::vector<std::function<void()>> backward_hooks_;
   platform::Place place_;
 
   // Not need to be std::weak_ptr, because op is binded to a certain Tracer,

--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -55,6 +55,7 @@ void PreparedOp::PrepareData(
           }
         }
       }
+      var_base->InvokeBackwardHooks();
     }
   }
 }

--- a/python/paddle/fluid/tests/unittests/test_imperative_backward_hook.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_backward_hook.py
@@ -1,0 +1,112 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid.dygraph import nn
+from paddle.fluid.optimizer import SGDOptimizer
+from paddle.fluid.dygraph.base import to_variable
+import numpy as np
+
+
+class SimpleNet(fluid.Layer):
+    def __init__(self, input_size, linear1_size=4):
+        super(SimpleNet, self).__init__()
+        self.linear1 = nn.Linear(input_size, linear1_size, bias_attr=False)
+        self.linear2 = nn.Linear(linear1_size, 1, bias_attr=False)
+
+    def forward(self,
+                x,
+                register_hook1=False,
+                remove_hook1=False,
+                register_hook2=False,
+                remove_hook2=False,
+                hook1=None,
+                hook2=None):
+        ret = self.linear1(x)
+        if register_hook1:
+            removable_hook1 = ret.register_hook(hook1)
+        if register_hook2:
+            removable_hook2 = ret.register_hook(hook2)
+        if remove_hook1:
+            removable_hook1.remove()
+        if remove_hook2:
+            removable_hook2.remove()
+        ret = self.linear2(ret)
+        return ret
+
+
+def hook_fn1(grad1):
+    print(2 * grad1)
+
+
+def hook_fn2(grad2):
+    print(4 * grad2)
+
+
+def hook_fn3(grad3):
+    grad3 = grad3 * 2
+    return grad3
+
+
+def hook_fn4(grad4):
+    grad4 = grad4 * 4
+    return grad4
+
+
+class TestBackwardHook(unittest.TestCase):
+    def register_remove_hook(self, register_hook1, remove_hook1, register_hook2,
+                             remove_hook2, hook1, hook2):
+        seed = 100
+        fluid.default_startup_program().random_seed = seed
+        fluid.default_main_program().random_seed = seed
+
+        simple_net = SimpleNet(input_size=3)
+        sgd = SGDOptimizer(
+            learning_rate=1e-3, parameter_list=simple_net.parameters())
+
+        x_data = np.arange(9).reshape(3, 3).astype('float32')
+        x = to_variable(x_data)
+        outs = simple_net(x, register_hook1, remove_hook1, register_hook2,
+                          remove_hook2, hook1, hook2)
+        dy_loss = outs
+        dy_loss.backward()
+        print(simple_net.linear1.weight._grad_ivar())
+        sgd.minimize(dy_loss)
+        sgd.clear_gradients()
+
+    def test_backeard_hook_for_varbase(self):
+        places = [fluid.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(fluid.CUDAPlace(0))
+
+        for place in places:
+            with fluid.dygraph.guard(place):
+                self.register_remove_hook(True, True, True, True, hook_fn1,
+                                          hook_fn2)
+                self.register_remove_hook(True, True, True, False, hook_fn1,
+                                          hook_fn2)
+                self.register_remove_hook(True, False, True, False, hook_fn1,
+                                          hook_fn3)
+                self.register_remove_hook(True, True, True, False, hook_fn1,
+                                          hook_fn4)
+                self.register_remove_hook(True, False, True, False, hook_fn4,
+                                          hook_fn1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**This PR support backward hook for dygraph.**

The backward hook will be called every time a gradient will respect to the Variable is computed. The hook shold have the following signature:
- hook(grad) -> Variable or None
The hook should not modify its param, but it can optionally return a new gradient which will change the  Variable's value.

`register_hook` function will return a RemovablePyCallableObject object with method `remove` that can remove the hook from the VarBase.

`execute_hooks` function will exectute the hook functions from the Variable.

```
import paddle.fluid as fluid
import numpy as np

def hook1(g):
        g = 2 * g
        print g
        return g

def hook2(g):
        g = 4 * g
        print g

with fluid.dygraph.guard():
        # var's type is VarBase
        remove_hook1 = var.register_hook(hook1)
        remove_hook2 = var.register_hook(hook2)
        remove_hook1.remove()
        remove_hook2.remove()
```