### PR TITLE
deprecated for distribute transpiler api

### DIFF
--- a/python/paddle/fluid/annotations.py
+++ b/python/paddle/fluid/annotations.py
@@ -32,9 +32,6 @@ def deprecated(since, instead, extra_message=""):
             print(err_msg, file=sys.stderr)
             return func(*args, **kwargs)
 
-        if wrapper.__doc__ == None:
-            wrapper.__doc__ = ""
-
         wrapper.__doc__ += "\n    "
         wrapper.__doc__ += err_msg
         return wrapper

--- a/python/paddle/fluid/annotations.py
+++ b/python/paddle/fluid/annotations.py
@@ -32,6 +32,9 @@ def deprecated(since, instead, extra_message=""):
             print(err_msg, file=sys.stderr)
             return func(*args, **kwargs)
 
+        if wrapper.__doc__ == None:
+            wrapper.__doc__ = ""
+
         wrapper.__doc__ += "\n    "
         wrapper.__doc__ += err_msg
         return wrapper

--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -44,6 +44,7 @@ import numpy as np
 from .ps_dispatcher import RoundRobin, PSDispatcher
 from .. import core, framework, unique_name, initializer
 from ..annotations import deprecated
+from ..wrapped_decorator import signature_safe_contextmanager
 from ..framework import Program, default_main_program, \
     default_startup_program, Block, Parameter, grad_var_name
 from .details import wait_server_ready, UnionFind, VarStruct, VarsDistributed
@@ -542,6 +543,7 @@ class DistributeTranspiler(object):
         instead="FleetAPI",
         extra_message="WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler"
     )
+    @signature_safe_contextmanager
     def transpile(self,
                   trainer_id,
                   program=None,

--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -43,8 +43,6 @@ import numpy as np
 
 from .ps_dispatcher import RoundRobin, PSDispatcher
 from .. import core, framework, unique_name, initializer
-from ..annotations import deprecated
-from ..wrapped_decorator import signature_safe_contextmanager
 from ..framework import Program, default_main_program, \
     default_startup_program, Block, Parameter, grad_var_name
 from .details import wait_server_ready, UnionFind, VarStruct, VarsDistributed
@@ -538,12 +536,6 @@ class DistributeTranspiler(object):
                 return True
         return False
 
-    @deprecated(
-        since="1.8.0",
-        instead="FleetAPI",
-        extra_message="WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler"
-    )
-    @signature_safe_contextmanager
     def transpile(self,
                   trainer_id,
                   program=None,
@@ -585,6 +577,15 @@ class DistributeTranspiler(object):
                     sync_mode=False,
                     current_endpoint="127.0.0.1:7000")
         """
+
+        err_msg = """
+
+API is deprecated since 2.0.0 Please use FleetAPI instead.
+WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler
+
+        """
+        print(print(err_msg, file=sys.stderr))
+
         if program is None:
             program = default_main_program()
         if startup_program is None:

--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -43,6 +43,7 @@ import numpy as np
 
 from .ps_dispatcher import RoundRobin, PSDispatcher
 from .. import core, framework, unique_name, initializer
+from ..annotations import deprecated
 from ..framework import Program, default_main_program, \
     default_startup_program, Block, Parameter, grad_var_name
 from .details import wait_server_ready, UnionFind, VarStruct, VarsDistributed
@@ -536,6 +537,11 @@ class DistributeTranspiler(object):
                 return True
         return False
 
+    @deprecated(
+        since="1.8.0",
+        instead="FleetAPI",
+        extra_message="WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler"
+    )
     def transpile(self,
                   trainer_id,
                   program=None,

--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -584,7 +584,7 @@ API is deprecated since 2.0.0 Please use FleetAPI instead.
 WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler
 
         """
-        print(print(err_msg, file=sys.stderr))
+        print(err_msg, file=sys.stderr)
 
         if program is None:
             program = default_main_program()


### PR DESCRIPTION
API is deprecated since 1.8.0 Please use FleetAPI instead.
WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler