### PR TITLE
Update MKL-DNN to v1.2

### DIFF
--- a/cmake/external/mkldnn.cmake
+++ b/cmake/external/mkldnn.cmake
@@ -20,7 +20,7 @@ SET(MKLDNN_SOURCE_DIR     ${THIRD_PARTY_PATH}/mkldnn/src/extern_mkldnn)
 SET(MKLDNN_INSTALL_DIR    ${THIRD_PARTY_PATH}/install/mkldnn)
 SET(MKLDNN_INC_DIR        "${MKLDNN_INSTALL_DIR}/include" CACHE PATH "mkldnn include directory." FORCE)
 SET(MKLDNN_REPOSITORY     https://github.com/intel/mkl-dnn.git)
-SET(MKLDNN_TAG            52c3052df8ec1d5b8b45cb6c350a952840eabd42)
+SET(MKLDNN_TAG            75d0b1a7f3586c212e37acebbb8acd221cee7216)
 
 # Introduce variables:
 # * CMAKE_INSTALL_LIBDIR

--- a/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/fc_mkldnn_op.cc
@@ -252,7 +252,7 @@ class FCPrimitiveFactory {
     //     becuase we perform per-output-channel quantization
     int mask = CreateMask(0, scale_data.size() > 1);
     attributes.set_output_scales(mask, scale_data);
-    auto reorder = mkldnn::reorder({src_mem, dst_mem, attributes});
+    auto reorder = mkldnn::reorder(src_mem, dst_mem, attributes);
 
     mkldnn::stream astream(engine_);
     reorder.execute(astream,


### PR DESCRIPTION
This PR updates MKL-DNN to version 1.2. It will help with further refactoring.
@baojun-nervana 