### PR TITLE
[Paddle-TRT] Refine the error log about runtime batch and max_batch_size.

### DIFF
--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -279,16 +279,13 @@ class TensorRTEngineOp : public framework::OperatorBase {
             "setted by EnableTensorrtEngine()\n"
             "2. Check whether the model you are running has multiple trt "
             "subgraphs: \n "
-            "\tEg: Like the faster RCNN model, multiple subgraphs can be "
-            "detected using Paddle-TRT. Including the backbone part, as well "
-            "as the detection part.\n"
-            "\tThe runtime batch of the detection part and backbone part might "
-            "be diffent, for the runtime batch of the detection part depends "
-            "on the num of the generated proposals.\n"
-            "\tIf so, you can set the appropriate min_subgrpah_size(large than "
-            "the node num in detection part, less than the node num in "
-            "backbone part) using EnableTensorrtEngine to filter the detection "
-            "part.\n",
+            "\tIf there are multiple trt subgraphs, you need to ensure that "
+            "the first dimension of the input tensor of these subgraphs is "
+            "consistent.\n"
+            "\tIf there are inconsistent subgraphs, you need to filter them by "
+            "setting min_subgraph_size using EnableTensorrtEngine interface.\n"
+            "\tThe min_subgraph_size shouble to be greater than the number of "
+            "nodes in the inconsistent subgraph.\n",
             runtime_batch, max_batch_size_));
     // Execute the engine.
     engine->Execute(runtime_batch, &buffers, stream);


### PR DESCRIPTION
When run the model like faster_rcnn_r50_1x, there might be the error like this:

```
Error: An error occurred here. There is no accurate error hint for this error yet. We are continuously in the process of increasing hint for this kind of error check. It would be helpful if you could inform us of how this conversion went by opening a github issue. And we will resolve it with high priority.

  - New issue link: https://github.com/PaddlePaddle/Paddle/issues/new

  - Recommended issue content: all error stack information

  [Hint: Expected runtime_batch <= max_batch_size_, but received runtime_batch:1000 > max_batch_size_:1.] at (/ssd1/xiege/Paddle/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h:272)
```

Refine the log to:

```
InvalidArgumentError: The runtime batch size (1000) is greater than the max batch size(1).
There are two possible causes for this problem: 
1. Check whether the runtime batch is larger than the max_batch setted by EnableTensorrtEngine()
2. Check whether the model you are running has multiple trt subgraphs: 
 	Eg: Like the faster RCNN model, multiple subgraphs can be detected using Paddle-TRT. Including the backbone part, as well as the detection part.
	The runtime batch of the detection part and backbone part might be diffent, for the runtime batch of the detection part depends on the num of the generated proposals.
	If so, you can set the appropriate min_subgrpah_size(large than the node num in detection part, less than the node num in backbone part) using EnableTensorrtEngine to filter the detection part.

  [Hint: Expected runtime_batch <= max_batch_size_, but received runtime_batch:2 > max_batch_size_:1.] at (/paddle/fix_doc_pr/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h:280)
```

