### PR TITLE
Fix lod error of concat op (axis = 0)

### DIFF
--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -105,7 +105,7 @@ class ConcatKernel : public framework::OpKernel<T> {
     // If axis is 0, the lod of the output is not the same as inputs.
     if (axis == 0 && ins[0]->lod().size()) {
       bool lod_size = 1;
-      for (size_t i = 0; i < ins.size(); ++i) {
+      for (size_t i = 1; i < ins.size(); ++i) {
         if (ins[i]->lod().size() == 0) {
           lod_size = 0;
         }

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -17,7 +17,6 @@ limitations under the License. */
 #include <string>
 #include <utility>
 #include <vector>
-#include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/math/concat_and_split.h"
 #include "paddle/fluid/operators/strided_memcpy.h"

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -106,7 +106,7 @@ class ConcatKernel : public framework::OpKernel<T> {
     if (axis == 0 && ins[0]->lod().size()) {
       auto out_lod = ins[0]->lod();
       for (size_t i = 1; i < ins.size(); ++i) {
-        auto in_lod = ins[i]->lod();
+        const auto& in_lod = ins[i]->lod();
         for (size_t j = 0; j < in_lod.size(); j++) {
           size_t lod_s = out_lod[j][out_lod[j].size() - 1];
           for (size_t k = 1; k < in_lod[j].size(); k++) {

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -110,7 +110,7 @@ class ConcatKernel : public framework::OpKernel<T> {
         for (size_t j = 0; j < in_lod.size(); j++) {
           size_t lod_s = out_lod[j][out_lod[j].size() - 1];
           for (size_t k = 1; k < in_lod[j].size(); k++) {
-            out_lod[j].insert(out_lod[j].end(), lod_s + in_lod[j][k]);
+            out_lod[j].push_back(lod_s + in_lod[j][k]);
           }
         }
       }


### PR DESCRIPTION
**Fix lod error of concat op (axis = 0)**
concat: 当axis=0时，lod需要将所有输入变量的lod信息按照axis=0的维度连接起来。

Case1：
- x1: 
     取值：[[1.1],[2.2],[3.3],[4.4],[5.5]]
     LoD信息：[[ 2L, 3L]]

- x2:
     取值：[[6.1],[7.1],[8.1],[9.1],[10.1]]
     LoD信息：[[ 2L, 3L]]

- 修复前concat(axis = 0)结果：

     取值：[[1.1],[2.2],[3.3],[4.4],[5.5],[6.1],[7.1],[8.1],[9.1],[10.1]]
     LoD信息：[[2L, 3L]]

- 修复后concat(axis = 0)结果：

     取值：[[1.1],[2.2],[3.3],[4.4],[5.5],[6.1],[7.1],[8.1],[9.1],[10.1]]
     LoD信息：[[2L, 3L, 2L, 3L]]


Case2：
- x1: 
     取值：[[1.1],[2.2],[3.3],[4.4],[5.5]]
     LoD信息：[[2L, 1L], [1L, 1L, 3L]]

- x2:
     取值：[[6.1],[7.1],[8.1],[9.1],[10.1]]
     LoD信息：[[2L, 1L], [1L, 1L, 3L]]

- 修复前concat(axis = 0)结果：

     取值：[[1.1],[2.2],[3.3],[4.4],[5.5],[6.1],[7.1],[8.1],[9.1],[10.1]]
     LoD信息：[[2L, 1L], [1L, 1L, 3L]]

- 修复后concat(axis = 0)结果：

     取值：[[1.1],[2.2],[3.3],[4.4],[5.5],[6.1],[7.1],[8.1],[9.1],[10.1]]
     LoD信息：[[2L, 1L, 2L, 1L], [1L, 1L, 3L, 1L, 1L, 3L]]


### LoD特殊情况：

- 输入中有的lod_level>0，有的lod_level=0
   目前设置：只要有lod_level=0的情况，默认输出无lod信息。

- ins中都是lod_level>0，但lod_level不完全相同
   目前设置：进行lod level相等判断并报错：输入的lod_level需要相等。