### PR TITLE
fix traced layer with non persistable vars

### DIFF
--- a/paddle/fluid/imperative/jit/program_desc_tracer.h
+++ b/paddle/fluid/imperative/jit/program_desc_tracer.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <tuple>
 #include <utility>
@@ -34,10 +35,14 @@ using VarDescMetaMap =
     std::map<std::weak_ptr<VarBase>, std::unique_ptr<framework::VarDesc>,
              std::owner_less<std::weak_ptr<VarBase>>>;
 
+using VarBaseSet = std::set<std::shared_ptr<VarBase>,
+                            std::owner_less<std::shared_ptr<VarBase>>>;
+
 using TracedProgramTuple =
     std::tuple<std::unique_ptr<framework::ProgramDesc> /*program*/,
                std::vector<std::string> /*feed_var_names*/,
-               std::vector<std::string> /*fetch_var_names*/>;
+               std::vector<std::string> /*fetch_var_names*/,
+               std::vector<std::shared_ptr<VarBase>> /*persistable_vars*/>;
 
 class ProgramDescTracer {
   DISABLE_COPY_AND_ASSIGN(ProgramDescTracer);
@@ -58,11 +63,13 @@ class ProgramDescTracer {
   void Reset();
 
  private:
-  void InsertVarIfNotExist(const std::shared_ptr<VarBase> &new_var);
+  void InsertVarIfNotExist(const std::shared_ptr<VarBase> &new_var,
+                           bool is_input);
 
  private:
   std::vector<std::unique_ptr<OpDescMeta>> ops_;
   VarDescMetaMap vars_;
+  VarBaseSet non_exist_input_vars_;
 };
 
 }  // namespace jit

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -93,14 +93,14 @@ def _trace(layer,
             outputs = original_outputs
         out_vars = [var for var in outputs]
 
-        program_desc, feed_names, fetch_names = tracer.create_program_desc(
+        program_desc, feed_names, fetch_names, parameters = tracer.create_program_desc(
             var_list, feed_prefix, out_vars, fetch_prefix, tmp_prefix)
         tracer.reset()
 
     with _dygraph_guard(None):
         program = create_program_from_desc(program_desc)
 
-    return original_outputs, program, feed_names, fetch_names
+    return original_outputs, program, feed_names, fetch_names, parameters
 
 
 class TracedLayer(object):
@@ -199,8 +199,8 @@ class TracedLayer(object):
                     # save the static graph model for inference
                     static_layer.save_inference_model(dirname='./saved_infer_model')
         """
-        outs, prog, feed, fetch = _trace(layer, inputs)
-        traced = TracedLayer(prog, layer.parameters(), feed, fetch)
+        outs, prog, feed, fetch, parameters = _trace(layer, inputs)
+        traced = TracedLayer(prog, parameters, feed, fetch)
         return outs, traced
 
     def set_strategy(self, build_strategy=None, exec_strategy=None):

--- a/python/paddle/fluid/tests/unittests/test_imperative_trace_non_persistable_inputs.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_trace_non_persistable_inputs.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import paddle.fluid as fluid
+import numpy as np
+import six
+import os
+
+
+class SimpleFCLayer(fluid.dygraph.Layer):
+    def __init__(self, feature_size, batch_size, fc_size):
+        super(SimpleFCLayer, self).__init__()
+        self._linear = fluid.dygraph.Linear(feature_size, fc_size)
+        self._offset = fluid.dygraph.to_variable(
+            np.random.random((batch_size, fc_size)).astype('float32'))
+
+    def forward(self, x):
+        fc = self._linear(x)
+        return fc + self._offset
+
+
+class TestTracedLayerRecordNonPersistableInput(unittest.TestCase):
+    def test_main(self):
+        traced_layer = None
+        with fluid.dygraph.guard():
+            feature_size = 3
+            batch_size = 4
+            fc_size = 2
+            layer = SimpleFCLayer(feature_size, batch_size, fc_size)
+            optimizer = fluid.optimizer.SGD(learning_rate=1e-3,
+                                            parameter_list=layer.parameters())
+
+            expected_persistable_vars = set([
+                layer._linear.weight.name, layer._linear.bias.name,
+                layer._offset.name
+            ])
+
+            for _ in six.moves.range(10):
+                in_x = fluid.dygraph.to_variable(
+                    np.random.random((batch_size, feature_size)).astype(
+                        'float32'))
+                if traced_layer is None:
+                    dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                        layer, [in_x])
+                else:
+                    dygraph_out = layer(in_x)
+                dygraph_out_numpy = dygraph_out.numpy()
+                static_out = traced_layer([in_x])[0]
+                self.assertTrue(np.array_equal(dygraph_out_numpy, static_out))
+
+                loss = fluid.layers.reduce_mean(dygraph_out)
+                loss.backward()
+
+                optimizer.minimize(loss)
+
+            del layer
+
+        program = traced_layer.program
+        actual_persistable_vars = set()
+        for var in program.list_vars():
+            if var.persistable:
+                actual_persistable_vars.add(var.name)
+
+        self.assertEqual(actual_persistable_vars, expected_persistable_vars)
+
+        dirname = './traced_layer_test_non_persistable_vars'
+        traced_layer.save_inference_model(dirname=dirname)
+        filenames = set([f for f in os.listdir(dirname) if f != '__model__'])
+        self.assertEqual(filenames, expected_persistable_vars)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Some dygraph network may use some non-persistable variables (for example, the variables are the data member of `Layer`) as the inputs of op. These variables cannot be saved when using `TracedLayer`. This PR fixes it.