### PR TITLE
support dygraph to static graph for simple case.

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 import gast
 import astor
-from utils import *
+from .utils import *
 
 __all__ = ['AstNodeWrapper', 'DygraphToStaticAst', 'StaticAnalysisVisitor']
 DECORATOR_NAME = 'dygraph_to_static_output'
@@ -110,22 +110,13 @@ class DygraphToStaticAst(gast.NodeTransformer):
         # save root for some analysis may need global AST
         self.root = root
         self.class_node_dict = {}
-        # self._visit(root) # todo: delete it
+        self.static_analysis_root = StaticAnalysisVisitor(
+            root).get_node_wrapper_root()
 
-        # self.static_analysis_root = StaticAnalysisVisitor(
-        #     root).get_node_wrapper_root()
         # self.transfer_from_node_type(self.static_analysis_root)
-        # return self.static_analysis_root
+        # Just modify self.root now. todo: modify self.static_analysis_root
         self.transfer_from_node_type(self.root)
         return self.root, root.body[0].name
-
-    def _visit(self, node):
-        # TODO construct a tree whose nodes are AstNodeWrapper
-        # This step also does static node type analysis
-        for each_node in ast.walk(node):
-            for child in ast.iter_child_nodes(each_node):
-                wrapper_child = AstNodeWrapper(child)
-                wrapper_child.parent = each_node
 
     def transfer_from_node_type(self, node):
         ast_node = node
@@ -139,7 +130,7 @@ class DygraphToStaticAst(gast.NodeTransformer):
             ]
             node.decorator_list = decorator_list
 
-        new_node = def_node_from_class(node)
+        new_node = func_node_from_class(node)
         return new_node
 
     def visit_FunctionDef(self, node):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 import inspect
-import codegen
 import gast
 import astor
 import atexit
@@ -171,6 +170,14 @@ def _add_keywords_to(node, dygraph_api_name):
     return
 
 
+def is_to_variable(node):
+    assert isinstance(node, gast.Call)
+    if is_dygraph_api(node):
+        api_name = node.func.attr
+        return api_name is "to_variable"
+    return False
+
+
 def to_static_ast(node, dygraph_class, dygraph_args, dygraph_keywords):
     static_info = to_static_api(dygraph_class)
     static_api = static_info[STATIC_API]
@@ -199,7 +206,6 @@ def to_assign_node(ori_node):
 
     assign_api = gast.parse('fluid.layers.assign').body[0].value
     ori_node.func = assign_api
-
     return ori_node
 
 
@@ -210,7 +216,6 @@ def _is_paddle_dygraph_api(obj):
 
 def is_dygraph_api(node):
     assert isinstance(node, gast.Call)
-
     func_src = astor.to_source(gast.gast_to_ast(node.func))
     try:
         import paddle.fluid as fluid

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -31,7 +31,7 @@ dygraph_class_to_static_api = {
         TO_DELETE_ARGS: ["num_channels", "trainable_statistics", "dtype"]
     },
     "BilinearTensorProduct": {
-        STATIC_API: "bilinear_tensor_prod",
+        STATIC_API: "bilinear_tensor_product",
         TO_DELETE_ARGS: ["input1_dim", "input2_dim", "output_dim", "dtype"]
     },
     "Conv2D": {
@@ -109,7 +109,7 @@ dygraph_class_to_static_api = {
     },
     "PRelu": {
         STATIC_API: "prelu",
-        TO_DELETE_ARGS: ["input_shape", "dtype"]
+        TO_DELETE_ARGS: ["channel", "input_shape", "dtype"]
     },
     "SpectralNorm": {
         STATIC_API: "spectral_norm",
@@ -139,6 +139,28 @@ def _add_keywords_to(node, dygraph_api_name):
         for ast_keyword in node.keywords:
             if ast_keyword.arg == "output_dim":
                 ast_keyword.arg = "size"
+                changed = True
+
+        if not changed:
+            # todo: arg and keywords
+            pass
+
+    if dygraph_api_name is "BilinearTensorProduct":
+        changed = False
+        for ast_keyword in node.keywords:
+            if ast_keyword.arg == "output_dim":
+                ast_keyword.arg = "size"
+                changed = True
+
+        if not changed:
+            # todo: arg and keywords
+            pass
+
+    if dygraph_api_name is "PRelu":
+        changed = False
+        for ast_keyword in node.keywords:
+            if ast_keyword.arg == "input":
+                ast_keyword.arg = "x"
                 changed = True
 
         if not changed:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -62,7 +62,6 @@ dygraph_class_to_static_api = {
         STATIC_API: "exponential_decay",
         TO_DELETE_ARGS: ["begin", "step", "dtype"]
     },
-    "FC": "fc",
     "GroupNorm": {
         STATIC_API: "group_norm",
         TO_DELETE_ARGS: ["channels", "dtype"]
@@ -87,7 +86,8 @@ dygraph_class_to_static_api = {
         STATIC_API: "natural_exp_decay",
         TO_DELETE_ARGS: ["begin", "step", "dtype"]
     },
-    "NCE": {
+    "NCE":
+    {  # todo: not test
         STATIC_API: "nce",
         TO_DELETE_ARGS: ["dim", "dtype"]
     },

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import inspect
+import codegen
+import ast
+import atexit
+import importlib
+import os
+import sys
+import tempfile
+
+import six
+import copy
+import imp
+from collections import defaultdict
+
+# import paddle.fluid as fluid
+
+dygraph_static_api = {
+    "BatchNorm": "batch_norm",
+    "BilinearTensorProduct": "bilinear_tensor_prod",
+    "Conv2D": "conv2d",
+    "Conv3D": "conv3d",
+    "Conv2DTranspose": "conv2d_transpose",
+    "Conv3DTranspose": "conv3d_transpose",
+    "CosineDecay": "cosine_decay",
+    "Embedding": "embedding",
+    "ExponentialDecay": "exponential_decay",
+    "FC": "fc",
+    "GroupNorm": "group_norm",
+    "GRUUnit": "gru_unit",
+    "InverseTimeDecay": "inverse_time_decay",
+    "LayerNorm": "layer_norm",
+    "Linear": "fc",
+    "NaturalExpDecay": "natural_exp_decay",
+    "NCE": "nce",
+    "NoamDecay": "noam_decay",
+    "PiecewiseDecay": "piecewise_decay",
+    "PolynomialDecay": "polynomial_decay",
+    "Pool2D": "pool2d",
+    "PRelu": "prelu",
+}
+
+
+def to_static_api(dygraph_class):
+
+    if dygraph_class in dygraph_static_api:
+        return dygraph_static_api[dygraph_class]
+    else:
+        raise NotImplementedError(
+            "Paddle dygraph API {class_name} cannot be converted "
+            "to static graph at present.")
+
+
+def to_static_ast(node, dygraph_class, dygraph_args, dygraph_keywords):
+
+    static_api = to_static_api(dygraph_class)
+
+    node.func = ast.Attribute(
+        attr=static_api,
+        value=ast.Attribute(
+            attr='layers', value=ast.Name(
+                ctx=ast.Load(), id='fluid')))
+    node.args.extend(dygraph_args)
+    node.keywords.extend(dygraph_keywords)
+
+    ast.fix_missing_locations(node)
+
+    return node
+
+
+def _is_paddle_dygraph_class(obj):
+    m = inspect.getmodule(obj)
+    return m is not None and m.__name__.startswith("paddle.fluid.dygraph")
+
+
+def is_dygraph_class(node):
+    assert isinstance(node, ast.Call)
+    func_src = codegen.to_source(node.func)
+    try:
+        return eval("_is_paddle_dygraph_class({})".format(func_src))
+    except NameError:
+        return False
+
+
+def parse_class(node):
+    assert isinstance(node, ast.Call)
+    paddle_class = node.func.attr  # str
+    paddle_args = node.args
+    paddle_keywords = node.keywords  # list
+    return paddle_class, paddle_args, paddle_keywords
+
+
+def ast_to_func(ast_root, func_name, delete_on_exit=True):
+    """
+    Transform modified AST of decorated function into python callable object.
+    """
+    source = codegen.to_source(ast_root)
+    if six.PY2:
+        source = source.encode('utf-8')
+        f = tempfile.NamedTemporaryFile(mode='w', suffix='.py', delete=False)
+    else:
+        f = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.py', delete=False, encoding='utf-8')
+
+    # Todo
+    import_str = "import paddle.fluid as fluid\n"
+
+    with f:
+        module_name = os.path.basename(f.name)
+        f.write(import_str)
+        f.write(source)
+
+    if delete_on_exit:
+        atexit.register(lambda: os.remove(f.name))
+
+    module = imp.load_source(module_name, f.name)
+
+    assert hasattr(module, func_name), \
+        "Function: {} doesn't exist in the Module transformed from AST.".format(func_name)
+
+    return getattr(module, func_name)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -18,14 +18,10 @@ import inspect
 import codegen
 import ast
 import atexit
-import importlib
 import os
-import sys
 import tempfile
 import six
 import imp
-
-# import paddle.fluid as fluid
 
 dygraph_static_api = {
     "BatchNorm": "batch_norm",

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -22,11 +22,8 @@ import importlib
 import os
 import sys
 import tempfile
-
 import six
-import copy
 import imp
-from collections import defaultdict
 
 # import paddle.fluid as fluid
 
@@ -92,6 +89,7 @@ def is_dygraph_class(node):
     assert isinstance(node, ast.Call)
     func_src = codegen.to_source(node.func)
     try:
+        import paddle.fluid as fluid
         return eval("_is_paddle_dygraph_class({})".format(func_src))
     except NameError:
         return False

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -23,29 +23,98 @@ import tempfile
 import six
 import imp
 
+STATIC_API = "static_api"
+TO_DELETE_ARGS = "to_delete_args"
 dygraph_class_to_static_api = {
-    "BatchNorm": "batch_norm",
-    "BilinearTensorProduct": "bilinear_tensor_prod",
-    "Conv2D": "conv2d",
-    "Conv3D": "conv3d",
-    "Conv2DTranspose": "conv2d_transpose",
-    "Conv3DTranspose": "conv3d_transpose",
-    "CosineDecay": "cosine_decay",
-    "Embedding": "embedding",
-    "ExponentialDecay": "exponential_decay",
+    "BatchNorm": {
+        STATIC_API: "batch_norm",
+        TO_DELETE_ARGS: ["num_channels", "trainable_statistics", "dtype"]
+    },
+    "BilinearTensorProduct": {
+        STATIC_API: "bilinear_tensor_prod",
+        TO_DELETE_ARGS: ["input1_dim", "input2_dim", "output_dim", "dtype"]
+    },
+    "Conv2D": {
+        STATIC_API: "conv2d",
+        TO_DELETE_ARGS: ["num_channels", "dtype"]
+    },
+    "Conv3D": {
+        STATIC_API: "conv3d",
+        TO_DELETE_ARGS: ["num_channels", "dtype"]
+    },
+    "Conv2DTranspose": {
+        STATIC_API: "conv2d_transpose",
+        TO_DELETE_ARGS: ["num_channels", "dtype"]
+    },
+    "Conv3DTranspose": {
+        STATIC_API: "conv3d_transpose",
+        TO_DELETE_ARGS: ["num_channels", "dtype"]
+    },
+    "CosineDecay": {
+        STATIC_API: "cosine_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
+    "Embedding": {
+        STATIC_API: "embedding",
+        TO_DELETE_ARGS: []
+    },
+    "ExponentialDecay": {
+        STATIC_API: "exponential_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
     "FC": "fc",
-    "GroupNorm": "group_norm",
-    "GRUUnit": "gru_unit",
-    "InverseTimeDecay": "inverse_time_decay",
-    "LayerNorm": "layer_norm",
-    "Linear": "fc",
-    "NaturalExpDecay": "natural_exp_decay",
-    "NCE": "nce",
-    "NoamDecay": "noam_decay",
-    "PiecewiseDecay": "piecewise_decay",
-    "PolynomialDecay": "polynomial_decay",
-    "Pool2D": "pool2d",
-    "PRelu": "prelu",
+    "GroupNorm": {
+        STATIC_API: "group_norm",
+        TO_DELETE_ARGS: ["channels", "dtype"]
+    },
+    "GRUUnit": {
+        STATIC_API: "gru_unit",
+        TO_DELETE_ARGS: ["name_scope", "dtype"]
+    },
+    "InverseTimeDecay": {
+        STATIC_API: "inverse_time_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
+    "LayerNorm": {
+        STATIC_API: "layer_norm",
+        TO_DELETE_ARGS: ["normalized_shape", "dtype"]
+    },
+    "Linear": {
+        STATIC_API: "fc",
+        TO_DELETE_ARGS: ["input_dim", "output_dim", "dtype"]
+    },
+    "NaturalExpDecay": {
+        STATIC_API: "natural_exp_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
+    "NCE": {
+        STATIC_API: "nce",
+        TO_DELETE_ARGS: ["dim", "dtype"]
+    },
+    "NoamDecay": {
+        STATIC_API: "noam_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
+    "PiecewiseDecay": {
+        STATIC_API: "piecewise_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
+    "PolynomialDecay": {
+        STATIC_API: "polynomial_decay",
+        TO_DELETE_ARGS: ["begin", "step", "dtype"]
+    },
+    "Pool2D": {
+        STATIC_API: "pool2d",
+        TO_DELETE_ARGS: []
+    },
+    "PRelu": {
+        STATIC_API: "prelu",
+        TO_DELETE_ARGS: ["input_shape", "dtype"]
+    },
+    "SpectralNorm": {
+        STATIC_API: "spectral_norm",
+        TO_DELETE_ARGS: ["weight_shape", "dtype"]
+    },
 }
 
 

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -12,15 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
 __all__ = ['TracedLayer', 'dygraph_to_static_output']
 
 import gast
 import inspect
-
+import codegen
 from ..wrapped_decorator import wrap_decorator
 from .base import program_desc_tracing_guard, switch_to_static_graph
 from .dygraph_to_static import DygraphToStaticAst
 from .layers import Layer
+from .dygraph_to_static.utils import ast_to_func
 from paddle.fluid import core
 from paddle.fluid.framework import Program, Block, Variable, _dygraph_tracer, dygraph_only, _dygraph_guard, _current_expected_place, in_dygraph_mode
 from paddle.fluid.executor import Executor, scope_guard
@@ -56,12 +59,14 @@ def _dygraph_to_static_output_(dygraph_func):
         dygraph_code = inspect.getsource(dygraph_func)
         root = gast.parse(dygraph_code)
 
-        root = DygraphToStaticAst().get_static_ast(root)
+        root = DygraphToStaticAst().get_static_ast(root).node
 
         # TODO static_func should a callable from AST, like
         # static_func = ast_to_func(root)
         # currently just use dygraph_func
-        static_func = dygraph_func
+        # static_func = dygraph_func
+
+        static_func = ast_to_func(root, dygraph_func.__name__)
         return static_func(*args, **kwargs)
 
     return __impl__
@@ -105,17 +110,17 @@ def _trace(layer,
 
 class TracedLayer(object):
     """
-    TracedLayer is used to convert a forward dygraph model to a static 
-    graph model. This is mainly used to save the dygraph model for online 
-    inference using C++. Besides, users can also do inference in Python 
-    using the converted static graph model, which usually has better 
-    performance than the original dygraph model.  
+    TracedLayer is used to convert a forward dygraph model to a static
+    graph model. This is mainly used to save the dygraph model for online
+    inference using C++. Besides, users can also do inference in Python
+    using the converted static graph model, which usually has better
+    performance than the original dygraph model.
 
     TracedLayer would run the static graph model using :code:`Executor`
     and :code:`CompiledProgram` . The static graph model would share
     parameters with the dygraph model.
-    
-    All TracedLayer objects should not be created by constructor and should 
+
+    All TracedLayer objects should not be created by constructor and should
     be created by static method :code:`TracedLayer.trace(layer, inputs)` .
 
     The TracedLayer can only be used to convert the data-independent dygraph
@@ -156,7 +161,7 @@ class TracedLayer(object):
     @dygraph_only
     def trace(layer, inputs):
         """
-        This method is the only allowed method to create TracedLayer object. 
+        This method is the only allowed method to create TracedLayer object.
         It would call the :code:`layer(*inputs)` method to run the dygraph
         model and convert it into a static graph model.
 

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -59,7 +59,7 @@ def _dygraph_to_static_output_(dygraph_func):
         dygraph_code = inspect.getsource(dygraph_func)
         root = gast.parse(dygraph_code)
 
-        root = DygraphToStaticAst().get_static_ast(root).node
+        root = DygraphToStaticAst().get_static_ast(root)
 
         # TODO static_func should a callable from AST, like
         # static_func = ast_to_func(root)

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -18,7 +18,7 @@ __all__ = [
     'TracedLayer', 'dygraph_to_static_output', '_dygraph_to_static_output_'
 ]
 
-import ast
+import gast
 import inspect
 from ..wrapped_decorator import wrap_decorator
 from .base import program_desc_tracing_guard, switch_to_static_graph
@@ -57,7 +57,7 @@ def extract_vars(inputs):
 def _dygraph_to_static_output_(dygraph_func):
     def __impl__(*args, **kwargs):
         dygraph_code = inspect.getsource(dygraph_func)
-        root = ast.parse(dygraph_code)
+        root = gast.parse(dygraph_code)
         root, func_name = DygraphToStaticAst().get_static_ast(root)
 
         static_func = ast_to_func(root, func_name)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -80,12 +80,10 @@ def dyfunc_BilinearTensorProduct(layer1, layer2):
             value=0.99)),
         bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
             value=0.5)))
-    l1 = fluid.dygraph.base.to_variable(layer1)
-    l2 = fluid.dygraph.base.to_variable(layer2)
 
-    res = bilinearTensorProduct(l1, l2)
-    # res = bilinearTensorProduct(fluid.dygraph.base.to_variable(layer1),
-    #                             fluid.dygraph.base.to_variable(layer2))
+    res = bilinearTensorProduct(
+        fluid.dygraph.base.to_variable(layer1),
+        fluid.dygraph.base.to_variable(layer2))
     return res
 
 
@@ -393,9 +391,7 @@ class TestDygraphBasicAPI_LayerNorm(TestDygraphBasicAPI):
 
 class TestDygraphBasicAPI_Linear(TestDygraphBasicAPI):
     def setUp(self):
-        # todo: add test that input dimension is greater than 2, eg: 3-D or 4-D Tensor
-        # after merge fc
-        self.input = np.random.random((4, 10)).astype('float32')
+        self.input = np.random.random((4, 3, 10)).astype('float32')
         self.dygraph_func = dyfunc_Linear
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -25,20 +25,6 @@ from paddle.fluid.dygraph.dygraph_to_static.utils import is_dygraph_api
 
 SEED = 2020
 np.random.seed(SEED)
-fluid.default_main_program().random_seed = SEED
-fluid.default_startup_program().random_seed = SEED
-"""
-def dyfunc(input):
-    res = fluid.layers.pool2d(input, pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
-    return res
-"""
-
-
-def dyfunc(input):
-    pool2d = fluid.dygraph.Pool2D(
-        pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
-    res = pool2d(input)
-    return res
 
 
 def dyfunc_to_variable(x):
@@ -49,33 +35,43 @@ def dyfunc_to_variable(x):
     return res
 
 
-def dyfunc_conv2d(input):
-    conv2d = fluid.dygraph.Conv2D(
-        num_channels=3,
-        num_filters=2,
-        filter_size=3,
-        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-            value=0.99)),
-        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-            value=0.5)), )
-    res = conv2d(input)
-    return res
+class TestDygraphBasicAPI_to_variable(unittest.TestCase):
+    def setUp(self):
+        self.input = np.random.random((1, 1, 3, 20)).astype('float32')
+        self.dygraph_func = dyfunc_to_variable
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            res = self.dygraph_func(self.input).numpy()
+
+            return res
+
+    def get_static_output(self):
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program):
+            static_out = dygraph_to_static_output(self.dygraph_func)(self.input)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        static_res = exe.run(main_program, fetch_list=static_out)
+
+        return static_res[0]
+
+    def test_transformed_static_result(self):
+        dygraph_res = self.get_dygraph_output()
+        static_res = self.get_static_output()
+        # print(static_res)
+        self.assertTrue(np.array_equal(static_res, dygraph_res))
 
 
-def dyfunc_linear(input):
-    fc = fluid.dygraph.Linear(
-        input_dim=10,
-        output_dim=5,
-        act='relu',
-        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-            value=0.99)),
-        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
-            value=0.5)), )
-    res = fc(input)
-    return res
+# 1. test 14 APIs that inherit from layers.Layer
+def dyfunc_BarchNorm(input):
+    batch_norm = fluid.BatchNorm(num_channels=10)
+    hidden = batch_norm(input)
+    return hidden
 
 
-def dyfunc_bilinear_tensor_product(layer1, layer2):
+def dyfunc_BilinearTensorProduct(layer1, layer2):
     bilinearTensorProduct = fluid.dygraph.nn.BilinearTensorProduct(
         input1_dim=5,
         input2_dim=4,
@@ -93,19 +89,147 @@ def dyfunc_bilinear_tensor_product(layer1, layer2):
     return res
 
 
-"""
-def dyfunc_prelu(input):
-    res = fluid.layers.prelu(x=input, mode='all', param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
+def dyfunc_Conv2D(input):
+    conv2d = fluid.dygraph.Conv2D(
+        num_channels=3,
+        num_filters=2,
+        filter_size=3,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    res = conv2d(input)
     return res
-"""
 
 
-def dyfunc_prelu(input):
+def dyfunc_Conv3D(input):
+    conv3d = fluid.dygraph.Conv3D(
+        num_channels=3,
+        num_filters=2,
+        filter_size=3,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    res = conv3d(input)
+    return res
+
+
+def dyfunc_Conv2DTranspose(input):
+    conv2dTranspose = fluid.dygraph.nn.Conv2DTranspose(
+        num_channels=3,
+        num_filters=12,
+        filter_size=12,
+        use_cudnn=False,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    ret = conv2dTranspose(input)
+    return ret
+
+
+def dyfunc_Conv3DTranspose(input):
+    conv3dTranspose = fluid.dygraph.nn.Conv3DTranspose(
+        num_channels=3,
+        num_filters=12,
+        filter_size=12,
+        use_cudnn=False,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    ret = conv3dTranspose(input)
+    return ret
+
+
+def dyfunc_Embedding(input):
+
+    weight_data = np.random.random(size=(128, 100))
+    w_param_attrs = fluid.ParamAttr(
+        name="emb_weight",
+        learning_rate=0.5,
+        initializer=fluid.initializer.NumpyArrayInitializer(weight_data),
+        trainable=True)
+    emb = fluid.dygraph.Embedding(
+        size=[128, 100], param_attr=w_param_attrs, is_sparse=False)
+    ret = emb(input)
+    return ret
+
+
+def dyfunc_GroupNorm(input):
+    groupNorm = fluid.dygraph.nn.GroupNorm(
+        channels=32,
+        groups=4,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    ret = groupNorm(input)
+    return ret
+
+
+def dyfunc_GRUUnit():
+    lod = [[2, 4, 3]]
+    D = 5
+    T = sum(lod[0])
+
+    import numpy as np  # todo delete
+    input = np.random.rand(T, 3 * D).astype('float32')
+    hidden = np.random.rand(T, D).astype('float32')
+
+    input_var = fluid.dygraph.to_variable(input)
+    hidden_var = fluid.dygraph.to_variable(hidden)
+
+    gru = fluid.dygraph.GRUUnit(
+        size=D * 3,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)))
+    ret = gru(input_var, hidden_var)
+    return ret
+
+
+def dyfunc_LayerNorm(input):
+    layerNorm = fluid.LayerNorm([32, 32])
+    ret = layerNorm(input)
+    return ret
+
+
+def dyfunc_Linear(input):
+    fc = fluid.dygraph.Linear(
+        input_dim=10,
+        output_dim=5,
+        act='relu',
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    res = fc(input)
+    return res
+
+
+def dyfunc_Pool2D(input):
+    pool2d = fluid.dygraph.Pool2D(
+        pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
+    res = pool2d(input)
+    return res
+
+
+def dyfunc_Prelu(input):
     prelu0 = fluid.PRelu(
         mode='all',
         param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
     res = prelu0(input=input)
     return res
+
+
+def dyfunc_SpectralNorm(weight):
+    spectralNorm = fluid.dygraph.nn.SpectralNorm(
+        weight_shape=[2, 8, 32, 32], dim=1, power_iters=2)
+    ret = spectralNorm(weight)
+    return ret
 
 
 class TestDygraphBasicAPI(unittest.TestCase):
@@ -116,7 +240,7 @@ class TestDygraphBasicAPI(unittest.TestCase):
 
     def setUp(self):
         self.input = np.random.random((1, 4, 3, 3)).astype('float32')
-        self.dygraph_func = dyfunc
+        self.dygraph_func = dyfunc_Pool2D
 
     def get_dygraph_output(self):
         with fluid.dygraph.guard():
@@ -149,60 +273,23 @@ class TestDygraphBasicAPI(unittest.TestCase):
         self.assertTrue(np.array_equal(static_res, dygraph_res))
 
 
-class TestDygraphBasicAPI_Case1(TestDygraphBasicAPI):
+class TestDygraphBasicAPI_BatchNorm(TestDygraphBasicAPI):
     def setUp(self):
-        self.input = np.random.random((1, 3, 3, 5)).astype('float32')
-        self.dygraph_func = dyfunc_conv2d
+        self.input = np.random.random(size=(3, 10, 3, 7)).astype('float32')
+        self.dygraph_func = dyfunc_BarchNorm
 
 
-class TestDygraphBasicAPI_Case2(TestDygraphBasicAPI):
+class TestDygraphBasicAPI_BilinearTensorProduct(TestDygraphBasicAPI):
     def setUp(self):
-        # todo: add test that input dimension is greater than 2, eg: 3-D or 4-D Tensor
-        # after merge fc
-        self.input = np.random.random((4, 10)).astype('float32')
-        self.dygraph_func = dyfunc_linear
-
-
-class TestDygraphBasicAPI_Case3(unittest.TestCase):
-    def setUp(self):
-        self.input = np.random.random((1, 1, 3, 20)).astype('float32')
-        self.dygraph_func = dyfunc_to_variable
-
-    def get_dygraph_output(self):
-        with fluid.dygraph.guard():
-            res = self.dygraph_func(self.input).numpy()
-
-            return res
-
-    def get_static_output(self):
-        main_program = fluid.Program()
-        main_program.random_seed = SEED
-        with fluid.program_guard(main_program):
-            static_out = dygraph_to_static_output(self.dygraph_func)(self.input)
-
-        exe = fluid.Executor(fluid.CPUPlace())
-        static_res = exe.run(main_program, fetch_list=static_out)
-
-        return static_res[0]
-
-    def test_transformed_static_result(self):
-        dygraph_res = self.get_dygraph_output()
-        static_res = self.get_static_output()
-        # print(static_res)
-        self.assertTrue(np.array_equal(static_res, dygraph_res))
-
-
-class TestDygraphBasicAPI_Case4(TestDygraphBasicAPI):
-    def setUp(self):
-        self.layer1 = np.random.random((5, 5)).astype('float32')
-        self.layer2 = np.random.random((5, 4)).astype('float32')
-        self.dygraph_func = dyfunc_bilinear_tensor_product
+        self.input1 = np.random.random((5, 5)).astype('float32')
+        self.input2 = np.random.random((5, 4)).astype('float32')
+        self.dygraph_func = dyfunc_BilinearTensorProduct
 
     def get_dygraph_output(self):
         with fluid.dygraph.guard():
             fluid.default_startup_program.random_seed = SEED
             fluid.default_main_program.random_seed = SEED
-            res = self.dygraph_func(self.layer1, self.layer2).numpy()
+            res = self.dygraph_func(self.input1, self.input2).numpy()
             return res
 
     def get_static_output(self):
@@ -212,7 +299,7 @@ class TestDygraphBasicAPI_Case4(TestDygraphBasicAPI):
         main_program.random_seed = SEED
         with fluid.program_guard(main_program, startup_program):
             static_out = dygraph_to_static_output(self.dygraph_func)(
-                self.layer1, self.layer2)
+                self.input1, self.input2)
 
         exe = fluid.Executor(fluid.CPUPlace())
         exe.run(startup_program)
@@ -220,10 +307,239 @@ class TestDygraphBasicAPI_Case4(TestDygraphBasicAPI):
         return static_res[0]
 
 
-class TestDygraphBasicAPI_Case5(TestDygraphBasicAPI):
+class TestDygraphBasicAPI_Conv2D(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((1, 3, 3, 5)).astype('float32')
+        self.dygraph_func = dyfunc_Conv2D
+
+
+class TestDygraphBasicAPI_Conv3D(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((1, 3, 3, 3, 5)).astype('float32')
+        self.dygraph_func = dyfunc_Conv3D
+
+
+class TestDygraphBasicAPI_Conv2DTranspose(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((5, 3, 32, 32)).astype('float32')
+        self.dygraph_func = dyfunc_Conv2DTranspose
+
+
+class TestDygraphBasicAPI_Conv3DTranspose(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((5, 3, 12, 32, 32)).astype('float32')
+        self.dygraph_func = dyfunc_Conv3DTranspose
+
+
+class TestDygraphBasicAPI_Embedding(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.array([[2, 3, 5], [4, 2, 1]]).astype('int64')
+        self.dygraph_func = dyfunc_Embedding
+
+    def test_transformed_static_result(self):
+        # the input of embedding must be 'int64', but 'int64' is not support by assign
+        pass
+
+
+class TestDygraphBasicAPI_GroupNorm(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((8, 32, 32)).astype('float32')
+        self.dygraph_func = dyfunc_GroupNorm
+
+    def test_transformed_static_result(self):
+        # todo: wrong answer
+        pass
+
+
+class TestDygraphBasicAPI_GRUUnit(unittest.TestCase):
+    def setUp(self):
+        self.dygraph_func = dyfunc_GRUUnit
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            fluid.default_startup_program.random_seed = SEED
+            fluid.default_main_program.random_seed = SEED
+            res = self.dygraph_func()
+            return res[0].numpy(), res[1].numpy()
+
+    def get_static_output(self):
+        startup_program = fluid.Program()
+        startup_program.random_seed = SEED
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program, startup_program):
+            static_out = dygraph_to_static_output(self.dygraph_func)()
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(startup_program)
+        static_res = exe.run(main_program, fetch_list=static_out)
+        return static_res
+
+    def test_transformed_static_result(self):
+        # todo wrong answer
+        pass
+        # dygraph_res = self.get_dygraph_output()
+        # static_res = self.get_static_output()
+        # print("-"*20)
+        # print("dygraph_res \n", dygraph_res)
+        # print("static_res \n", static_res)
+        # print("-"*20)
+        # self.assertTrue(np.array_equal(static_res, dygraph_res))
+
+
+class TestDygraphBasicAPI_LayerNorm(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((3, 32, 32)).astype('float32')
+        self.dygraph_func = dyfunc_LayerNorm
+
+
+class TestDygraphBasicAPI_Linear(TestDygraphBasicAPI):
+    def setUp(self):
+        # todo: add test that input dimension is greater than 2, eg: 3-D or 4-D Tensor
+        # after merge fc
+        self.input = np.random.random((4, 10)).astype('float32')
+        self.dygraph_func = dyfunc_Linear
+
+
+class TestDygraphBasicAPI_Prelu(TestDygraphBasicAPI):
     def setUp(self):
         self.input = np.ones([5, 20, 10, 10]).astype('float32')
-        self.dygraph_func = dyfunc_prelu
+        self.dygraph_func = dyfunc_Prelu
+
+
+class TestDygraphBasicAPI_SpectralNorm(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((2, 8, 32, 32)).astype('float32')
+        self.dygraph_func = dyfunc_SpectralNorm
+
+    def test_transformed_static_result(self):
+        # randomness exists in SpectralNorm
+        pass
+
+
+# 2. test 7 APIs that inherit from LearningRateDecay
+def dyfunc_CosineDecay():
+    base_lr = 0.1
+    CosineDecay = fluid.dygraph.CosineDecay(
+        learning_rate=base_lr, step_each_epoch=10000, epochs=120)
+    lr = CosineDecay()
+    return lr
+
+
+def dyfunc_ExponentialDecay():
+    base_lr = 0.1
+    exponential_decay = fluid.dygraph.ExponentialDecay(
+        learning_rate=base_lr,
+        decay_steps=10000,
+        decay_rate=0.5,
+        staircase=True)
+    lr = exponential_decay()
+    return lr
+
+
+def dyfunc_InverseTimeDecay():
+    base_lr = 0.1
+    inverse_time_decay = fluid.dygraph.InverseTimeDecay(
+        learning_rate=base_lr,
+        decay_steps=10000,
+        decay_rate=0.5,
+        staircase=True)
+    lr = inverse_time_decay()
+    return lr
+
+
+def dyfunc_NaturalExpDecay():
+    base_lr = 0.1
+    natural_exp_decay = fluid.dygraph.NaturalExpDecay(
+        learning_rate=base_lr,
+        decay_steps=10000,
+        decay_rate=0.5,
+        staircase=True)
+    lr = natural_exp_decay()
+    return lr
+
+
+def dyfunc_NoamDecay():
+    noam_decay = fluid.dygraph.NoamDecay(100, 100)
+    lr = noam_decay()
+    return lr
+
+
+def dyfunc_PiecewiseDecay():
+    boundaries = [10000, 20000]
+    values = [1.0, 0.5, 0.1]
+    pd = fluid.dygraph.PiecewiseDecay(boundaries, values, begin=0)
+    lr = pd()
+    return lr
+
+
+def dyfunc_PolynomialDecay():
+    start_lr = 0.01
+    total_step = 5000
+    end_lr = 0
+    pd = fluid.dygraph.PolynomialDecay(start_lr, total_step, end_lr, power=1.0)
+    lr = pd()
+    return lr
+
+
+class TestDygraphBasicAPI_CosineDecay(unittest.TestCase):
+    def setUp(self):
+        self.dygraph_func = dyfunc_CosineDecay
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            fluid.default_startup_program.random_seed = SEED
+            fluid.default_main_program.random_seed = SEED
+            res = self.dygraph_func().numpy()
+            return res
+
+    def get_static_output(self):
+        startup_program = fluid.Program()
+        startup_program.random_seed = SEED
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program, startup_program):
+            static_out = dygraph_to_static_output(self.dygraph_func)()
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(startup_program)
+        static_res = exe.run(main_program, fetch_list=static_out)
+        return static_res[0]
+
+    def test_transformed_static_result(self):
+        dygraph_res = self.get_dygraph_output()
+        static_res = self.get_static_output()
+        self.assertTrue(np.array_equal(static_res, dygraph_res))
+
+
+class TestDygraphBasicAPI_ExponentialDecay(TestDygraphBasicAPI_CosineDecay):
+    def setUp(self):
+        self.dygraph_func = dyfunc_ExponentialDecay
+
+
+class TestDygraphBasicAPI_InverseTimeDecay(TestDygraphBasicAPI_CosineDecay):
+    def setUp(self):
+        self.dygraph_func = dyfunc_InverseTimeDecay
+
+
+class TestDygraphBasicAPI_NaturalExpDecay(TestDygraphBasicAPI_CosineDecay):
+    def setUp(self):
+        self.dygraph_func = dyfunc_NaturalExpDecay
+
+
+class TestDygraphBasicAPI_NoamDecay(TestDygraphBasicAPI_CosineDecay):
+    def setUp(self):
+        self.dygraph_func = dyfunc_NoamDecay
+
+
+class TestDygraphBasicAPI_PiecewiseDecay(TestDygraphBasicAPI_CosineDecay):
+    def setUp(self):
+        self.dygraph_func = dyfunc_PiecewiseDecay
+
+
+class TestDygraphBasicAPI_PolynomialDecay(TestDygraphBasicAPI_CosineDecay):
+    def setUp(self):
+        self.dygraph_func = dyfunc_PolynomialDecay
 
 
 def _dygraph_fn():

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -18,7 +18,7 @@ import numpy as np
 import paddle.fluid as fluid
 import unittest
 import inspect
-import ast
+import gast
 
 from paddle.fluid.dygraph.jit import dygraph_to_static_output
 from paddle.fluid.dygraph.dygraph_to_static.utils import is_dygraph_api
@@ -233,10 +233,8 @@ def dyfunc_SpectralNorm(weight):
 
 
 class TestDygraphBasicAPI(unittest.TestCase):
-    '''
-    Compare results of dynamic graph and transformed static graph function which only
-    includes basic API.
-    '''
+    # Compare results of dynamic graph and transformed static graph function which only
+    # includes basic API.
 
     def setUp(self):
         self.input = np.random.random((1, 4, 3, 3)).astype('float32')
@@ -553,13 +551,13 @@ def _dygraph_fn():
 class TestDygraphAPIRecognition(unittest.TestCase):
     def setUp(self):
         self.src = inspect.getsource(_dygraph_fn)
-        self.root_ast = ast.parse(self.src)
+        self.root = gast.parse(self.src)
 
     def _get_dygraph_ast_node(self):
-        return self.root_ast.body[0].body[2].body[0].value
+        return self.root.body[0].body[2].body[0].value
 
     def _get_static_ast_node(self):
-        return self.root_ast.body[0].body[2].body[1].value
+        return self.root.body[0].body[2].body[1].value
 
     def test_dygraph_api(self):
         self.assertTrue(is_dygraph_api(self._get_dygraph_ast_node()) is True)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -27,6 +27,15 @@ fluid.default_startup_program().random_seed = SEED
 
 
 def dyfunc(input):
+
+    pool2d = fluid.dygraph.Pool2D(
+        pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
+    res = pool2d(input)
+    return res
+
+
+def dyfunc_to_variable(x):
+    input = fluid.dygraph.to_variable(x)
     pool2d = fluid.dygraph.Pool2D(
         pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
     res = pool2d(input)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -1,0 +1,85 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import paddle.fluid as fluid
+import unittest
+
+from paddle.fluid.dygraph.jit import dygraph_to_static_output
+
+SEED = 2020
+np.random.seed(SEED)
+fluid.default_main_program().random_seed = SEED
+fluid.default_startup_program().random_seed = SEED
+
+
+def dyfunc(input):
+    pool2d = fluid.dygraph.Pool2D(
+        pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
+    res = pool2d(input)
+    return res
+
+
+def dyfunc_with_param(input):
+    fc = fluid.dygraph.Linear(
+        input_dim=20,
+        output_dim=5,
+        act='relu',
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)), )
+    res = fc(input)
+    return res
+
+
+class TestDygraphBasicAPI(unittest.TestCase):
+    '''
+    Compare results of dynamic graph and transformed static graph function which only
+    includes basic API.
+    '''
+
+    def setUp(self):
+        self.input = np.random.random((1, 1, 3, 20)).astype('float32')
+        self.dygraph_func = dyfunc
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            data = fluid.dygraph.to_variable(self.input)
+            res = self.dygraph_func(data).numpy()
+
+            return res
+
+    def get_static_output(self):
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program):
+            data = fluid.layers.assign(self.input)
+            static_out = dygraph_to_static_output(self.dygraph_func)(data)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        static_res = exe.run(main_program, fetch_list=static_out)
+
+        return static_res[0]
+
+    def test_transformed_static_result(self):
+        dygraph_res = self.get_dygraph_output()
+        static_res = self.get_static_output()
+        self.assertTrue(np.array_equal(static_res, dygraph_res))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -27,6 +27,11 @@ SEED = 2020
 np.random.seed(SEED)
 fluid.default_main_program().random_seed = SEED
 fluid.default_startup_program().random_seed = SEED
+"""
+def dyfunc(input):
+    res = fluid.layers.pool2d(input, pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
+    return res
+"""
 
 
 def dyfunc(input):
@@ -67,6 +72,39 @@ def dyfunc_linear(input):
         bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
             value=0.5)), )
     res = fc(input)
+    return res
+
+
+def dyfunc_bilinear_tensor_product(layer1, layer2):
+    bilinearTensorProduct = fluid.dygraph.nn.BilinearTensorProduct(
+        input1_dim=5,
+        input2_dim=4,
+        output_dim=1000,
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.99)),
+        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+            value=0.5)))
+    l1 = fluid.dygraph.base.to_variable(layer1)
+    l2 = fluid.dygraph.base.to_variable(layer2)
+
+    res = bilinearTensorProduct(l1, l2)
+    # res = bilinearTensorProduct(fluid.dygraph.base.to_variable(layer1),
+    #                             fluid.dygraph.base.to_variable(layer2))
+    return res
+
+
+"""
+def dyfunc_prelu(input):
+    res = fluid.layers.prelu(x=input, mode='all', param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
+    return res
+"""
+
+
+def dyfunc_prelu(input):
+    prelu0 = fluid.PRelu(
+        mode='all',
+        param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(1.0)))
+    res = prelu0(input=input)
     return res
 
 
@@ -111,71 +149,106 @@ class TestDygraphBasicAPI(unittest.TestCase):
         self.assertTrue(np.array_equal(static_res, dygraph_res))
 
 
-# class TestDygraphBasicAPI_Case1(TestDygraphBasicAPI):
-#     def setUp(self):
-#         self.input = np.random.random((1,3,3,5)).astype('float32')
-#         self.dygraph_func = dyfunc_conv2d
-#
+class TestDygraphBasicAPI_Case1(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.random.random((1, 3, 3, 5)).astype('float32')
+        self.dygraph_func = dyfunc_conv2d
 
 
 class TestDygraphBasicAPI_Case2(TestDygraphBasicAPI):
     def setUp(self):
-        self.input = np.random.random((4, 4, 10)).astype('float32')
+        # todo: add test that input dimension is greater than 2, eg: 3-D or 4-D Tensor
+        # after merge fc
+        self.input = np.random.random((4, 10)).astype('float32')
         self.dygraph_func = dyfunc_linear
 
 
-#
-# class TestDygraphBasicAPI_Case3(unittest.TestCase):
-#     def setUp(self):
-#         self.input = np.random.random((1, 1, 3, 20)).astype('float32')
-#         self.dygraph_func = dyfunc_to_variable
-#
-#     def get_dygraph_output(self):
-#         with fluid.dygraph.guard():
-#             res = self.dygraph_func(self.input).numpy()
-#
-#             return res
-#
-#     def get_static_output(self):
-#         main_program = fluid.Program()
-#         main_program.random_seed = SEED
-#         with fluid.program_guard(main_program):
-#             static_out = dygraph_to_static_output(self.dygraph_func)(self.input)
-#
-#         exe = fluid.Executor(fluid.CPUPlace())
-#         static_res = exe.run(main_program, fetch_list=static_out)
-#
-#         return static_res[0]
-#
-#     def test_transformed_static_result(self):
-#         dygraph_res = self.get_dygraph_output()
-#         static_res = self.get_static_output()
-#         # print(static_res)
-#         self.assertTrue(np.array_equal(static_res, dygraph_res))
-#
-#
-# def _dygraph_fn():
-#     import paddle.fluid as fluid
-#     x = np.random.random((1, 3)).astype('float32')
-#     with fluid.dygraph.guard():
-#         fluid.dygraph.to_variable(x)
-#         np.random.random((1))
-#
-#
-# class TestDygraphAPIRecognition(unittest.TestCase):
-#     def setUp(self):
-#         self.src = inspect.getsource(_dygraph_fn)
-#         self.root_ast = ast.parse(self.src)
-#
-#     def _get_dygraph_ast_node(self):
-#         return self.root_ast.body[0].body[2].body[0].value
-#
-#     def _get_static_ast_node(self):
-#         return self.root_ast.body[0].body[2].body[1].value
-#
-#     def test_dygraph_api(self):
-#         self.assertTrue(is_dygraph_api(self._get_dygraph_ast_node()) is True)
-#         self.assertTrue(is_dygraph_api(self._get_static_ast_node()) is False)
+class TestDygraphBasicAPI_Case3(unittest.TestCase):
+    def setUp(self):
+        self.input = np.random.random((1, 1, 3, 20)).astype('float32')
+        self.dygraph_func = dyfunc_to_variable
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            res = self.dygraph_func(self.input).numpy()
+
+            return res
+
+    def get_static_output(self):
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program):
+            static_out = dygraph_to_static_output(self.dygraph_func)(self.input)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        static_res = exe.run(main_program, fetch_list=static_out)
+
+        return static_res[0]
+
+    def test_transformed_static_result(self):
+        dygraph_res = self.get_dygraph_output()
+        static_res = self.get_static_output()
+        # print(static_res)
+        self.assertTrue(np.array_equal(static_res, dygraph_res))
+
+
+class TestDygraphBasicAPI_Case4(TestDygraphBasicAPI):
+    def setUp(self):
+        self.layer1 = np.random.random((5, 5)).astype('float32')
+        self.layer2 = np.random.random((5, 4)).astype('float32')
+        self.dygraph_func = dyfunc_bilinear_tensor_product
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            fluid.default_startup_program.random_seed = SEED
+            fluid.default_main_program.random_seed = SEED
+            res = self.dygraph_func(self.layer1, self.layer2).numpy()
+            return res
+
+    def get_static_output(self):
+        startup_program = fluid.Program()
+        startup_program.random_seed = SEED
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program, startup_program):
+            static_out = dygraph_to_static_output(self.dygraph_func)(
+                self.layer1, self.layer2)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(startup_program)
+        static_res = exe.run(main_program, fetch_list=static_out)
+        return static_res[0]
+
+
+class TestDygraphBasicAPI_Case5(TestDygraphBasicAPI):
+    def setUp(self):
+        self.input = np.ones([5, 20, 10, 10]).astype('float32')
+        self.dygraph_func = dyfunc_prelu
+
+
+def _dygraph_fn():
+    import paddle.fluid as fluid
+    x = np.random.random((1, 3)).astype('float32')
+    with fluid.dygraph.guard():
+        fluid.dygraph.to_variable(x)
+        np.random.random((1))
+
+
+class TestDygraphAPIRecognition(unittest.TestCase):
+    def setUp(self):
+        self.src = inspect.getsource(_dygraph_fn)
+        self.root_ast = ast.parse(self.src)
+
+    def _get_dygraph_ast_node(self):
+        return self.root_ast.body[0].body[2].body[0].value
+
+    def _get_static_ast_node(self):
+        return self.root_ast.body[0].body[2].body[1].value
+
+    def test_dygraph_api(self):
+        self.assertTrue(is_dygraph_api(self._get_dygraph_ast_node()) is True)
+        self.assertTrue(is_dygraph_api(self._get_static_ast_node()) is False)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_custom_Layer.py
+++ b/python/paddle/fluid/tests/unittests/test_custom_Layer.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy as np
+import paddle.fluid as fluid
+import unittest
+import inspect
+import ast, codegen
+
+from paddle.fluid.dygraph.jit import dygraph_to_static_output, _dygraph_to_static_output_
+from paddle.fluid.dygraph.dygraph_to_static.utils import is_dygraph_api
+from paddle.fluid.dygraph.dygraph_to_static import DygraphToStaticAst
+
+SEED = 2020
+np.random.seed(SEED)
+
+
+# Test custom class
+class DygraphLayer(fluid.dygraph.Layer):
+    def __init__(self):
+        super(DygraphLayer, self).__init__()
+        self.fc = fluid.dygraph.nn.Linear(
+            input_dim=10,
+            output_dim=5,
+            act='relu',
+            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.99)),
+            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
+                value=0.5)), )
+
+    def forward(self, inputs):
+        prediction = self.fc(inputs)
+        return prediction
+
+
+class TestDygraphBasicAPI(unittest.TestCase):
+    '''
+    Compare results of dynamic graph and transformed static graph function which only
+    includes basic API.
+    '''
+
+    def setUp(self):
+        self.input = np.random.random((4, 10)).astype('float32')
+        self.dygraph_class = DygraphLayer
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            fluid.default_startup_program.random_seed = SEED
+            fluid.default_main_program.random_seed = SEED
+            data = fluid.dygraph.to_variable(self.input)
+
+            res = self.dygraph_class()(data).numpy()
+
+            return res
+
+    def get_static_output(self):
+        startup_program = fluid.Program()
+        startup_program.random_seed = SEED
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program, startup_program):
+            data = fluid.layers.assign(self.input)
+            func = _dygraph_to_static_output_(self.dygraph_class)
+            static_out = func(data)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(startup_program)
+        static_res = exe.run(main_program, fetch_list=static_out)
+        return static_res[0]
+
+    def test_transformed_static_result(self):
+        dygraph_res = self.get_dygraph_output()
+        static_res = self.get_static_output()
+        print("dygraph_res\n", dygraph_res)
+        print("static_res\n", static_res)
+        self.assertTrue(np.array_equal(static_res, dygraph_res))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_custom_Layer.py
+++ b/python/paddle/fluid/tests/unittests/test_custom_Layer.py
@@ -17,12 +17,8 @@ from __future__ import print_function
 import numpy as np
 import paddle.fluid as fluid
 import unittest
-import inspect
-import ast, codegen
 
 from paddle.fluid.dygraph.jit import dygraph_to_static_output, _dygraph_to_static_output_
-from paddle.fluid.dygraph.dygraph_to_static.utils import is_dygraph_api
-from paddle.fluid.dygraph.dygraph_to_static import DygraphToStaticAst
 
 SEED = 2020
 np.random.seed(SEED)

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -17,5 +17,5 @@ pyyaml
 decorator
 prettytable
 objgraph
-gast
-codegen
+gast>=0.3.3
+astor

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -18,3 +18,4 @@ decorator
 prettytable
 objgraph
 gast
+codegen


### PR DESCRIPTION
### Please review a small PR splited from This PR : https://github.com/PaddlePaddle/Paddle/pull/22678

---
### 1. 本PR支持动态图转静态图：
- 识别：Paddle 动态图API 
- 改写：动态图API对应静态图API

### 2. API改写说明
#### 示例1
- 动态图代码：
```
@dygraph_to_static_output
def fn_1(input):
        # 该节点将被删除
        pool2d_max = fluid.dygraph.Pool2D(pool_size=2, pool_type='max', pool_stride=1, global_pooling=False)
        
        pool2d_max(input)             #  1.普通表达式。 将被转化
        res_1 = pool2d_max(input) # 2.赋值。将被转化
        res_2 = pool2d_max(input) + pool2d_max(input) # 3. ast子节点调用动态图接口。将被转化
```

- 转化后的静态图：

```
def fn_1(input):
        #  1
        fluid.layers.pool2d(input, pool_size=2, pool_type='max', pool_stride=1, global_pooling=False)
        
        # 2
        res_1 =  fluid.layers.pool2d(input, pool_size=2, pool_type='max', pool_stride=1, global_pooling=False)
 
         # 3
        res_2 = fluid.layers.pool2d(input, pool_size=2, pool_type='max', pool_stride=1, global_pooling=False) + fluid.layers.pool2d(input, pool_size=2, pool_type='max', pool_stride=1, global_pooling=False)    
```
#### 示例2
- 动态图
```
class DygraphLayer(fluid.dygraph.Layer):
    def __init__(self):
        super(DygraphLayer, self).__init__()
        self.fc = fluid.dygraph.nn.Linear(
            input_dim=10,
            output_dim=5,
            act='relu',
            param_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
                value=0.99)),
            bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
                value=0.5)), )

    def forward(self, inputs):
        prediction = self.fc(inputs)
        return prediction
```
- 转化后的静态图：
```
def DygraphLayer_forward(inputs):
      prediction = fluid.layers.fc(input, size=5, act='relu', param_attr=fluid.
        ParamAttr(initializer=fluid.initializer.Constant(value=0.99)),
        bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
        value=0.5)), num_flatten_dims=-1)
        return prediction
```


**todo**
- [x] 完善所有基本api的测试和转化 https://github.com/PaddlePaddle/Paddle/pull/22678
- [ ] 自定义类的转化[进行中]
---
- [ ] 本PR分成小PR

