### PR TITLE
add no_check_list for no_grad_set rule

### DIFF
--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 
 # check no_grad_set is None
-NOT_CHECK_OP_LIST = [
-    'deformable_conv'
-]
+NOT_CHECK_OP_LIST = ['deformable_conv']
+
 # TODO(Shixiaowei02): Check if the items do not need fix.
 # no_grad_set has value in NEED_TO_FIX_OP_LIST
 # yapf: disable

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -13,41 +13,25 @@
 # limitations under the License.
 
 # check no_grad_set is None
-NOT_CHECK_OP_LIST = []
-# TODO(Shixiaowei02): Check if the items do not need fix.
-# no_grad_set has value in NEED_TO_FIX_OP_LIST
-# yapf: disable
-NEED_TO_FIX_OP_LIST = [
+NOT_CHECK_OP_LIST = [
     'affine_channel',
     'affine_grid',
-    'backward',
     'batch_norm',
     'conv_shift',
-    'conv2d',
-    'conv2d_transpose',
-    'conv3d',
-    'conv3d_transpose',
     'cos_sim',
     'cross_entropy',
-    'cross_entropy2',
     'data_norm',
     'deformable_conv',
     'deformable_conv_v1',
-    'depthwise_conv2d',
-    'depthwise_conv2d_transpose',
     'elementwise_add',
     'elementwise_div',
     'elementwise_max',
     'elementwise_min',
     'elementwise_mul',
     'elementwise_sub',
-    'filter_by_instag',
     'fused_elemwise_activation',
     'fused_emb_seq_pool',
     'fused_embedding_seq_pool',
-    'gru_unit',
-    'hierarchical_sigmoid',
-    'hsigmoid',
     'huber_loss',
     'instance_norm',
     'kldiv_loss',
@@ -61,11 +45,28 @@ NEED_TO_FIX_OP_LIST = [
     'matmul',
     'mul',
     'multiplex',
-    'prelu',
     'rank_loss',
-    'row_conv',
-    'sequence_conv',
     'smooth_l1_loss',
     'spectral_norm'
+]
+# TODO(Shixiaowei02): Check if the items do not need fix.
+# no_grad_set has value in NEED_TO_FIX_OP_LIST
+# yapf: disable
+NEED_TO_FIX_OP_LIST = [
+    'backward',
+    'conv2d',
+    'conv2d_transpose',
+    'conv3d',
+    'conv3d_transpose',
+    'cross_entropy2',
+    'depthwise_conv2d',
+    'depthwise_conv2d_transpose',
+    'filter_by_instag',
+    'gru_unit',
+    'hierarchical_sigmoid',
+    'hsigmoid',
+    'prelu',
+    'row_conv',
+    'sequence_conv'
 ]
 # yapf: enable

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -14,24 +14,41 @@
 
 # check no_grad_set is None
 NOT_CHECK_OP_LIST = [
+    'deformable_conv'
+]
+# TODO(Shixiaowei02): Check if the items do not need fix.
+# no_grad_set has value in NEED_TO_FIX_OP_LIST
+# yapf: disable
+NEED_TO_FIX_OP_LIST = [
     'affine_channel',
     'affine_grid',
+    'backward',
     'batch_norm',
     'conv_shift',
+    'conv2d',
+    'conv2d_transpose',
+    'conv3d',
+    'conv3d_transpose',
     'cos_sim',
     'cross_entropy',
+    'cross_entropy2',
     'data_norm',
-    'deformable_conv',
     'deformable_conv_v1',
+    'depthwise_conv2d',
+    'depthwise_conv2d_transpose',
     'elementwise_add',
     'elementwise_div',
     'elementwise_max',
     'elementwise_min',
     'elementwise_mul',
     'elementwise_sub',
+    'filter_by_instag',
     'fused_elemwise_activation',
     'fused_emb_seq_pool',
     'fused_embedding_seq_pool',
+    'gru_unit',
+    'hierarchical_sigmoid',
+    'hsigmoid',
     'huber_loss',
     'instance_norm',
     'kldiv_loss',
@@ -45,28 +62,11 @@ NOT_CHECK_OP_LIST = [
     'matmul',
     'mul',
     'multiplex',
+    'prelu',
     'rank_loss',
+    'row_conv',
+    'sequence_conv',
     'smooth_l1_loss',
     'spectral_norm'
-]
-# TODO(Shixiaowei02): Check if the items do not need fix.
-# no_grad_set has value in NEED_TO_FIX_OP_LIST
-# yapf: disable
-NEED_TO_FIX_OP_LIST = [
-    'backward',
-    'conv2d',
-    'conv2d_transpose',
-    'conv3d',
-    'conv3d_transpose',
-    'cross_entropy2',
-    'depthwise_conv2d',
-    'depthwise_conv2d_transpose',
-    'filter_by_instag',
-    'gru_unit',
-    'hierarchical_sigmoid',
-    'hsigmoid',
-    'prelu',
-    'row_conv',
-    'sequence_conv'
 ]
 # yapf: enable

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -132,7 +132,7 @@ for API_FILE in ${API_FILES[*]}; do
           echo_line="You must have one RD (songyouwei, luotao1 or phlrain) approval for ${API_FILE}, which manages the white list of batch size 1 input for sequence op test. For more information, please refer to [https://github.com/PaddlePaddle/Paddle/wiki/It-is-required-to-include-LoDTensor-input-with-batch_size=1-in-sequence-OP-test]. \n"
           check_approval 1 2573291 6836917 43953930
       elif [ "${API_FILE}" == "python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py" ];then
-        echo_line="You must have one RD (Shixiaowei02 (Recommend), luotao1 or phlrain) approval for the python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py, which manages the white list of no_grad_set without value in operators.\n"
+        echo_line="You must have one RD (Shixiaowei02 (Recommend), luotao1 or phlrain) approval for the python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py, which manages the white list of no_grad_set without value in operators. For more information, please refer to[https://github.com/PaddlePaddle/Paddle/wiki/It's-recommend-to-set-no_grad_set-to-be-None].\n"
         check_approval 1 39303645 6836917 43953930
       else
           echo_line="It is an Op accuracy problem, please take care of it. You must have one RD (XiaoguangHu01,Xreki,luotao1,sneaxiy) approval for ${API_FILE}, which manages the underlying code for fluid.\n"


### PR DESCRIPTION
according to reason of no_grad_set  relu, add NO_CHECK_LIST for no_grad_set  relu in no_grad_set_white_list

如果单测的时候发现某个变量的反向出错了，且把这些变量加到这个no_grad_set 里面，则单测就不会做检查 ，也不会发现此错误。
故为了防止大家乱用 no_grad _set，添加no_grad_set specification规则。在OpTest中添加了相应检测方法，在CI中添加了对本规范白名单的检查。

错误示例：
将所有输入赋值给no_grad_set，这是不可取的。
在python/paddle/fluid/tests/unittests/sequence/test_sequence_conv.py中：
<img width="610" alt="1" src="https://user-images.githubusercontent.com/38650344/74407156-5c49db00-4e6c-11ea-959e-5acfc503b97d.png">
<img width="742" alt="2" src="https://user-images.githubusercontent.com/38650344/74408451-6a4d2b00-4e6f-11ea-9637-b904d752df21.png">

He adds the certain variable to the no_grad_set，when running a test, he finds that the reverse of this variable is wrong, the test will not check and the error will not be found. 
In order to avoid the indiscriminate use of the no_grad_set value, the specification that the value of no_grad_set must be None is proposed. The corresponding detections are added to Op tests, and CI will check the white list of this specification

Error example：
That the value of no_grad_set is the all input of OP is not possible
python/paddle/fluid/tests/unittests/sequence/test_sequence_conv.py：
<img width="610" alt="1" src="https://user-images.githubusercontent.com/38650344/74407156-5c49db00-4e6c-11ea-959e-5acfc503b97d.png">
<img width="742" alt="2" src="https://user-images.githubusercontent.com/38650344/74408451-6a4d2b00-4e6f-11ea-9637-b904d752df21.png">
