### PR TITLE
fix py func bug when out is type[list] and add unitest case

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12542,7 +12542,9 @@ def py_func(func, x, out, backward_func=None, skip_vars_in_backward_input=None):
         out_list = [out]
     elif isinstance(out, tuple):
         out_list = list(out)
-    elif not isinstance(x, (list, tuple, Variable)):
+    elif isinstance(out, list):
+        out_list = out
+    else:
         raise TypeError(
             'Output must be Variable/list(Variable)/tuple(Variable)')
 


### PR DESCRIPTION
fix issue #22581 
fix py func when out is `type[list]`, out can be `Variable/tuple(Variable)/list(Variable)` type .
And add unittest case when `out=tuple(Variable)` or `out=list(Variable)`, and improve coverage.