### PR TITLE
Adjust sleep time of main process in signal handler test

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
@@ -49,7 +49,7 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             test_process.start()
 
             set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(1)
+            time.sleep(3)
         except core.EnforceNotMet as ex:
             self.assertIn("FatalError", cpt.get_exception_message(ex))
             exception = ex
@@ -67,7 +67,7 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             test_process.start()
 
             set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(1)
+            time.sleep(3)
         except core.EnforceNotMet as ex:
             self.assertIn("FatalError", cpt.get_exception_message(ex))
             exception = ex


### PR DESCRIPTION
as title.
Extend the sleep time of the main process to avoid not catching child process errors