### PR TITLE
fix bug of the cmake variable protobuf_MSVC_STATIC_CRT

### DIFF
--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -194,7 +194,8 @@ FUNCTION(build_protobuf TARGET_NAME BUILD_FOR_HOST)
     IF(WIN32)
         SET(OPTIONAL_ARGS ${OPTIONAL_ARGS} 
             "-DCMAKE_GENERATOR=${CMAKE_GENERATOR}"
-            "-DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}")
+            "-DCMAKE_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}"
+            "-Dprotobuf_MSVC_STATIC_RUNTIME=${MSVC_STATIC_CRT}")
     ENDIF()
 
     SET(PROTOBUF_REPOSITORY  https://github.com/protocolbuffers/protobuf.git)
@@ -224,7 +225,6 @@ FUNCTION(build_protobuf TARGET_NAME BUILD_FOR_HOST)
                         -DCMAKE_INSTALL_PREFIX=${PROTOBUF_INSTALL_DIR}
                         -DCMAKE_INSTALL_LIBDIR=lib
                         -DBUILD_SHARED_LIBS=OFF
-                        -Dprotobuf_MSVC_STATIC_RUNTIME=${MSVC_STATIC_CRT}
         CMAKE_CACHE_ARGS
                         -DCMAKE_INSTALL_PREFIX:PATH=${PROTOBUF_INSTALL_DIR}
                         -DCMAKE_BUILD_TYPE:STRING=${THIRD_PARTY_BUILD_TYPE}


### PR DESCRIPTION
fix bug of the cmake variable `protobuf_MSVC_STATIC_CRT=MSVC_STATIC_CRT`, 
It is should only be set on Windows.
If on Linux, `MSVC_STATIC_CRT` will be empty, and set `protobuf_MSVC_STATIC_RUNTIME` be empty. It will effect the default value of `protobuf_MSVC_STATIC_RUNTIME` in `CMakeLists.txt` of protobuf repository.
![image](https://user-images.githubusercontent.com/52485244/74455586-7ad9c180-4ec0-11ea-9edf-dcdfda429f38.png)
These will make `PACKAGE_VERSION` unsuitable.
Expected:
![image](https://user-images.githubusercontent.com/52485244/74456805-55e64e00-4ec2-11ea-9044-748c41301c57.png)

It will result:
The protobuf compiled by PaddlePaddle can not be used by other projects, that is, `find_package (protobuf)` will report an error:
![image](https://user-images.githubusercontent.com/52485244/74518722-4eb95180-4f4f-11ea-97eb-dde868b4c23e.png)

This bug is feedback by internal RD.