### PR TITLE
deprecated for distribute transpiler api (#22513)

### DIFF
--- a/python/paddle/fluid/transpiler/distribute_transpiler.py
+++ b/python/paddle/fluid/transpiler/distribute_transpiler.py
@@ -577,6 +577,15 @@ class DistributeTranspiler(object):
                     sync_mode=False,
                     current_endpoint="127.0.0.1:7000")
         """
+
+        err_msg = """
+
+API is deprecated since 2.0.0 Please use FleetAPI instead.
+WIKI: https://github.com/PaddlePaddle/Fleet/blob/develop/markdown_doc/transpiler
+
+        """
+        print(err_msg, file=sys.stderr)
+
         if program is None:
             program = default_main_program()
         if startup_program is None:


### PR DESCRIPTION
* add deprecated for distribute transpiler, will delete it after 2.0.0, test=develop