### PR TITLE
support num_flatten_dims=-1 of API fc.

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -326,6 +326,8 @@ def fc(input,
     mul_results = []
     for input_var, param_attr in helper.iter_inputs_and_params():
         input_shape = input_var.shape
+        if num_flatten_dims == -1:
+            num_flatten_dims = len(input_shape) - 1
         param_shape = [
             reduce(lambda a, b: a * b, input_shape[num_flatten_dims:], 1)
         ] + [size]

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -18,6 +18,8 @@ from op_test import OpTest
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 
+SEED = 2020
+
 
 def fc_refer(matrix, with_bias, with_relu=False):
     in_n, in_c, in_h, in_w = matrix.input.shape
@@ -129,6 +131,34 @@ class TestFCOpWithPadding(TestFCOp):
         self.with_bias = True
         self.with_relu = True
         self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
+
+
+class TestFcAPI(unittest.TestCase):
+    # test for parameter num_flatten_dims=-1
+    def test_api(self):
+        startup_program = Program()
+        main_program = Program()
+        startup_program.random_seed = SEED
+        main_program.random_seed = SEED
+
+        with program_guard(main_program, startup_program):
+            input = np.random.random([2, 2, 25]).astype("float32")
+            x = fluid.layers.data(
+                name="x",
+                shape=[2, 2, 25],
+                append_batch_size=False,
+                dtype="float32")
+
+            out_1 = fluid.layers.fc(input=x, size=1, num_flatten_dims=-1)
+            out_2 = fluid.layers.fc(input=x, size=1, num_flatten_dims=2)
+
+        exe = fluid.Executor(place=fluid.CPUPlace())
+        exe.run(startup_program)
+        res_1, res_2 = exe.run(main_program,
+                               feed={"x": input},
+                               fetch_list=[out_1, out_2])
+
+        assert np.array_equal(res_1, res_2)
 
 
 class TestFCOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_fc_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fc_op.py
@@ -16,7 +16,7 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.fluid import Program, program_guard, core
 
 SEED = 2020
 
@@ -133,8 +133,7 @@ class TestFCOpWithPadding(TestFCOp):
         self.matrix = MatrixGenerate(1, 4, 3, 128, 128, 2)
 
 
-class TestFcAPI(unittest.TestCase):
-    # test for parameter num_flatten_dims=-1
+class TestFcOp_NumFlattenDims_NegOne(unittest.TestCase):
     def test_api(self):
         startup_program = Program()
         main_program = Program()
@@ -152,7 +151,9 @@ class TestFcAPI(unittest.TestCase):
             out_1 = fluid.layers.fc(input=x, size=1, num_flatten_dims=-1)
             out_2 = fluid.layers.fc(input=x, size=1, num_flatten_dims=2)
 
-        exe = fluid.Executor(place=fluid.CPUPlace())
+        place = fluid.CPUPlace() if not core.is_compiled_with_cuda(
+        ) else fluid.CUDAPlace(0)
+        exe = fluid.Executor(place=place)
         exe.run(startup_program)
         res_1, res_2 = exe.run(main_program,
                                feed={"x": input},


### PR DESCRIPTION
**This PR** : support `num_flatten_dims`=-1 of static graph API [fluid.layers.fc](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/layers/fc.html)


The corresponding dygraph API [Linear](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/api/dygraph/Linear.html) doesn't have parameter `num_flatten_dims`. And the default output of `Linear` is not equal to `fc`.

- fc
```
paddle.fluid.layers.fc(input, size, num_flatten_dims=1, param_attr=None, bias_attr=None, act=None, name=None)
```
- Linear
```
class paddle.fluid.dygraph.Linear(input_dim, output_dim, param_attr=None, bias_attr=None, act=None, dtype='float32')
```

support `num_flatten_dims`=-1 so that the output of `Linear` and `fc` is the same.

