### PR TITLE
Remove error hint msg in ci check script

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -135,7 +135,7 @@ for API_FILE in ${API_FILES[*]}; do
         echo_line="You must have one RD (Shixiaowei02 (Recommend), luotao1 or phlrain) approval for the python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py, which manages the white list of no_grad_set without value in operators.\n"
         check_approval 1 39303645 6836917 43953930
       else
-          echo_line="It is an Op accuracy problem, please take care of it. You must have one RD (XiaoguangHu01,Xreki,luotao1,sneaxiy) approval for ${API_FILE}, which manages the underlying code for fluid.\n"
+          echo_line="You must have one RD (XiaoguangHu01,Xreki,luotao1,sneaxiy) approval for ${API_FILE}, which manages the underlying code for fluid.\n"
           check_approval 1 3048612 46782768 12538138 6836917 32832641
       fi
   fi


### PR DESCRIPTION
as title.
`It is an Op accuracy problem, please take care of it.` is no need in importent file checking.