### PR TITLE
support cond in clone, test=develop

### DIFF
--- a/paddle/fluid/framework/prune.cc
+++ b/paddle/fluid/framework/prune.cc
@@ -413,8 +413,9 @@ std::tuple<framework::ProgramDesc, std::map<int, int>> PruneBackward(
         auto parent_idx =
             FindMapByValue(pruned_progin_block_id_map, origin->parent_idx());
         PADDLE_ENFORCE_NE(parent_idx, -1,
-                          "The parent block id should be found in "
-                          "pruned_progin_block_id_map");
+                          platform::errors::NotFound(
+                              "The origin parent block id is not found in "
+                              "pruned_progin_block_id_map"));
         pruned_block->set_parent_idx(parent_idx);
       }
     }
@@ -432,8 +433,9 @@ std::tuple<framework::ProgramDesc, std::map<int, int>> PruneBackward(
         auto sub_idx =
             FindMapByValue(pruned_progin_block_id_map, origin_sub_idx);
         PADDLE_ENFORCE_NE(sub_idx, -1,
-                          "The origin sub block id should be found in "
-                          "pruned_progin_block_id_map");
+                          platform::errors::NotFound(
+                              "The origin sub block id is not found in "
+                              "pruned_progin_block_id_map"));
         SetSubBlockIndex(&op_desc, sub_idx);
       }
     }

--- a/paddle/fluid/framework/prune.h
+++ b/paddle/fluid/framework/prune.h
@@ -14,9 +14,11 @@ limitations under the License. */
 
 #pragma once
 
+#include <map>
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/platform/enforce.h"
@@ -28,7 +30,7 @@ void Prune(const proto::ProgramDesc& input,
            const std::set<std::string>& feed_var_names,
            proto::ProgramDesc* output);
 
-std::unique_ptr<framework::ProgramDesc> PruneBackward(
+std::tuple<framework::ProgramDesc, std::map<int, int>> PruneBackward(
     const framework::ProgramDesc& origin);
 
 }  // namespace framework

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1135,9 +1135,23 @@ All parameter, weight, gradient are variables in Paddle.
     Prune(*prog_with_targets.Proto(), feeded_var_names, &pruned_desc);
     return new ProgramDesc(pruned_desc);
   });
-  m.def("prune_backward", [](const framework::ProgramDesc &program) {
-    return PruneBackward(program);
-  });
+  m.def("prune_backward",
+        [](const framework::ProgramDesc &program) {
+          return PruneBackward(program);
+        },
+        R"DOC(
+             Prune the backward part of a program, mostly called in
+             program.clone(for_test=True).
+              
+             Args:
+                   program (ProgramDesc): The original program.
+
+             Returns:
+                   tuple(ProgramDesc, map<int, int>): The first part is 
+                   the pruned program desc, and the second part is a map
+                   which contains the id pair of pruned block and corresponding
+                   origin block.
+           )DOC");
   m.def("empty_var_name",
         []() { return std::string(framework::kEmptyVarName); });
   m.def("grad_var_suffix",

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1209,8 +1209,8 @@ def append_backward(loss,
     is_in_control_flow = current_block_idx != 0
 
     # Double grad is not supported in sub-block (control flow)
-    # Note(zhiqiu): This should be refined. 
-    program._appending_grad_times += 1
+    if not is_in_control_flow:
+        program._appending_grad_times += 1
 
     if no_grad_set is None:
         no_grad_set = set()

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1209,9 +1209,8 @@ def append_backward(loss,
     is_in_control_flow = current_block_idx != 0
 
     # Double grad is not supported in sub-block (control flow)
-    if not is_in_control_flow:
-        # _appending_grad_times used for double grad
-        program._appending_grad_times += 1
+    # Note(zhiqiu): This should be refined. 
+    program._appending_grad_times += 1
 
     if no_grad_set is None:
         no_grad_set = set()

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1210,6 +1210,7 @@ def append_backward(loss,
 
     # Double grad is not supported in sub-block (control flow)
     if not is_in_control_flow:
+        # _appending_grad_times used for double grad
         program._appending_grad_times += 1
 
     if no_grad_set is None:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4020,11 +4020,6 @@ class Program(object):
 
             p._sync_with_cpp()
 
-        if not pruned_origin_block_id_map:
-            pruned_origin_block_id_map = {
-                i: i
-                for i in six.moves.range(self.desc.num_blocks())
-            }
         p._copy_param_info_from(self)
         p._copy_data_info_from(self, pruned_origin_block_id_map)
         p._copy_dist_param_info_from(self)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3993,18 +3993,15 @@ class Program(object):
         """
         pruned_origin_block_id_map = None
         if for_test:
-            if self._appending_grad_times > 0:
-                forward_prog = Program()
-                forward_prog.desc, pruned_origin_block_id_map = core.prune_backward(
-                    self.desc)
-                forward_prog.blocks = [
-                    Block(forward_prog, i)
-                    for i in six.moves.range(forward_prog.desc.num_blocks())
-                ]
-                forward_prog._sync_with_cpp()
-                p = forward_prog._inference_optimize(prune_read_op=False)
-            else:
-                p = self._inference_optimize(prune_read_op=False)
+            forward_prog = Program()
+            forward_prog.desc, pruned_origin_block_id_map = core.prune_backward(
+                self.desc)
+            forward_prog.blocks = [
+                Block(forward_prog, i)
+                for i in six.moves.range(forward_prog.desc.num_blocks())
+            ]
+            forward_prog._sync_with_cpp()
+            p = forward_prog._inference_optimize(prune_read_op=False)
         else:
             p = Program()
             p.current_block_idx = self.current_block_idx
@@ -4469,7 +4466,7 @@ class Program(object):
         self._ps_endpoint = other._ps_endpoint
         self._distributed_lookup_table = other._distributed_lookup_table
 
-    def _copy_data_info_from(self, other, pruned_origin_block_id_map={}):
+    def _copy_data_info_from(self, other, pruned_origin_block_id_map=None):
         """
         Copy the information of data variables from other program.
 
@@ -4478,9 +4475,9 @@ class Program(object):
 
         Args:
             other(Program): Other program
-            pruned_origin_block_id_map(map{int:int}): A map from block id in self 
-            to block id in other. For example, {0:0, 1:1, 2:3} means block 0 in self is 
-            cloned from block 0 in other, etc. Default is {}, means default mapped, 
+            pruned_origin_block_id_map(dict{int:int}): A dict which maps the block id in program
+            self to the block id in program other. For example, {0:0, 1:1, 2:3} means block 0 in self is 
+            cloned from block 0 in other, etc. Default is None, which means default mapped, 
             {0:0, 1:1,..., n:n}.
 
         Returns:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3736,7 +3736,7 @@ class Program(object):
         self._current_role = tmp_role
 
     @signature_safe_contextmanager
-    def _lr_schedule_guard(self, is_with_opt=True):
+    def _lr_schedule_guard(self, is_with_opt=False):
         """
         A with guard to set :code:`LRSched` :code:`OpRole` and
         :code:`OpRoleVar` automatically. The :code:`OpRoleVar` is
@@ -4474,7 +4474,7 @@ class Program(object):
         self._ps_endpoint = other._ps_endpoint
         self._distributed_lookup_table = other._distributed_lookup_table
 
-    def _copy_data_info_from(self, other, pruned_origin_block_id_map):
+    def _copy_data_info_from(self, other, pruned_origin_block_id_map={}):
         """
         Copy the information of data variables from other program.
 
@@ -4483,6 +4483,10 @@ class Program(object):
 
         Args:
             other(Program): Other program
+            pruned_origin_block_id_map(map{int:int}): A map from block id in self 
+            to block id in other. For example, {0:0, 1:1, 2:3} means block 0 in self is 
+            cloned from block 0 in other, etc. Default is {}, means default mapped, 
+            {0:0, 1:1,..., n:n}.
 
         Returns:
             None
@@ -4490,6 +4494,12 @@ class Program(object):
         if not isinstance(other, Program):
             raise TypeError("_copy_data_info_from should be invoked with "
                             "Program")
+
+        if not pruned_origin_block_id_map:
+            pruned_origin_block_id_map = {
+                i: i
+                for i in six.moves.range(self.desc.num_blocks())
+            }
 
         # NOTE(zhiqiu): All vars in cloned program exist in original program.
         # The reverse is not true, due to backward pruning.

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3736,7 +3736,7 @@ class Program(object):
         self._current_role = tmp_role
 
     @signature_safe_contextmanager
-    def _lr_schedule_guard(self, is_with_opt=False):
+    def _lr_schedule_guard(self, is_with_opt=True):
         """
         A with guard to set :code:`LRSched` :code:`OpRole` and
         :code:`OpRoleVar` automatically. The :code:`OpRoleVar` is
@@ -3991,10 +3991,12 @@ class Program(object):
 
         The two code snippets above will generate and print same programs.
         """
+        pruned_origin_block_id_map = None
         if for_test:
             if self._appending_grad_times > 0:
                 forward_prog = Program()
-                forward_prog.desc = core.prune_backward(self.desc)
+                forward_prog.desc, pruned_origin_block_id_map = core.prune_backward(
+                    self.desc)
                 forward_prog.blocks = [
                     Block(forward_prog, i)
                     for i in six.moves.range(forward_prog.desc.num_blocks())
@@ -4018,8 +4020,13 @@ class Program(object):
 
             p._sync_with_cpp()
 
+        if not pruned_origin_block_id_map:
+            pruned_origin_block_id_map = {
+                i: i
+                for i in six.moves.range(self.desc.num_blocks())
+            }
         p._copy_param_info_from(self)
-        p._copy_data_info_from(self)
+        p._copy_data_info_from(self, pruned_origin_block_id_map)
         p._copy_dist_param_info_from(self)
         return p
 
@@ -4445,9 +4452,6 @@ class Program(object):
             raise TypeError("_copy_param_info_from should be invoked with "
                             "Program")
 
-        if len(self.blocks) != len(other.blocks):
-            raise ValueError("_copy_param_info_from should be invoked with two "
-                             "program, with represent the same topology")
         self.global_block()._copy_param_info_from(other.global_block())
 
     def _copy_dist_param_info_from(self, other):
@@ -4470,7 +4474,7 @@ class Program(object):
         self._ps_endpoint = other._ps_endpoint
         self._distributed_lookup_table = other._distributed_lookup_table
 
-    def _copy_data_info_from(self, other):
+    def _copy_data_info_from(self, other, pruned_origin_block_id_map):
         """
         Copy the information of data variables from other program.
 
@@ -4487,22 +4491,18 @@ class Program(object):
             raise TypeError("_copy_data_info_from should be invoked with "
                             "Program")
 
-        if len(self.blocks) != len(other.blocks):
-            raise ValueError("_copy_data_info_from should be invoked with two "
-                             "program, with represent the same topology")
-
         # NOTE(zhiqiu): All vars in cloned program exist in original program.
         # The reverse is not true, due to backward pruning.
-        for i, block in enumerate(other.blocks):
+        for i, block in enumerate(self.blocks):
+            other_block = other.blocks[pruned_origin_block_id_map[i]]
             for var in list(block.vars.values()):
-                if not self.blocks[i].has_var(var.name):
-                    continue
-                if var.is_data:
-                    self.blocks[i].var(var.name).is_data = True
-                if var.desc.need_check_feed():
-                    self.blocks[i].var(var.name).desc.set_need_check_feed(True)
-                if var.stop_gradient:
-                    self.blocks[i].var(var.name).stop_gradient = True
+                other_var = other_block.var(var.name)
+                if other_var.is_data:
+                    var.is_data = True
+                if other_var.desc.need_check_feed():
+                    var.desc.set_need_check_feed(True)
+                if other_var.stop_gradient:
+                    var.stop_gradient = True
 
     @dygraph_not_support
     def list_vars(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/mkldnn_op_test.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/mkldnn_op_test.py
@@ -128,9 +128,9 @@ def check_if_mkldnn_batchnorm_primitives_exist_in_bwd(
         for arg in grad_op_desc.output_arg_names():
             grad_var = block.desc.find_var(arg.encode("ascii"))
             grad_var.set_dtype(core.VarDesc.VarType.FP32)
+        program._sync_with_cpp()
 
         exe = fluid.Executor(place)
-
         # Do at least 2 iterations
         for i in range(2):
             out = exe.run(

--- a/python/paddle/fluid/tests/unittests/seresnext_net.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_net.py
@@ -18,7 +18,7 @@ fluid.core._set_eager_deletion_mode(-1, -1, False)
 
 import paddle.fluid.layers.ops as ops
 from paddle.fluid.initializer import init_on_cpu
-from paddle.fluid.layers.learning_rate_scheduler import _decay_step_counter
+from paddle.fluid.layers.learning_rate_scheduler import cosine_decay
 from simple_nets import init_data
 import math
 import os
@@ -159,20 +159,6 @@ def SE_ResNeXt50Small(use_feed):
     loss = fluid.layers.cross_entropy(input=prediction, label=label)
     loss = fluid.layers.mean(loss)
     return loss
-
-
-def cosine_decay(learning_rate, step_each_epoch, epochs=120):
-    """
-    Applies cosine decay to the learning rate.
-    lr = 0.05 * (math.cos(epoch * (math.pi / 120)) + 1)
-    """
-    global_step = _decay_step_counter()
-
-    with init_on_cpu():
-        epoch = ops.floor(global_step / step_each_epoch)
-        decayed_lr = learning_rate * \
-                     (ops.cos(epoch * (math.pi / epochs)) + 1)/2
-    return decayed_lr
 
 
 def optimizer(learning_rate=0.01):

--- a/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
@@ -253,7 +253,7 @@ class TestProgramPruneBackward(unittest.TestCase):
 
     def test_cond(self):
         def optimizer():
-            optimizer = fluid.optimizer.SGD(learning_rate=0.01, )
+            optimizer = fluid.optimizer.SGD(learning_rate=0.01)
             return optimizer
 
         with self.program_scope_guard():
@@ -289,11 +289,7 @@ class TestProgramPruneBackward(unittest.TestCase):
                                        feed=feed_dict,
                                        fetch_list=[loss.name])
 
-        import paddle.fluid.transpiler.details.program_utils as pu
-        pu.program_to_code(test_prog_orig, skip_op_callstack=True)
-        pu.program_to_code(test_prog_prune, skip_op_callstack=True)
         self.program_compare(test_prog_orig, test_prog_prune)
-
         self.assertEqual(loss_data_orig, loss_data_prune)
 
     @contextlib.contextmanager

--- a/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
@@ -134,7 +134,6 @@ class TestProgramPruneBackward(unittest.TestCase):
 
         self.assertEqual(len(program_a.blocks), len(program_b.blocks))
         for idx in range(len(program_a.blocks)):
-            print(idx)
             block_a = program_a.blocks[idx]
             block_b = program_b.blocks[idx]
             self.assertEqual(len(block_a.ops), len(block_b.ops))
@@ -143,7 +142,6 @@ class TestProgramPruneBackward(unittest.TestCase):
                 self.assertEqual(block_a.ops[op_idx].type,
                                  block_b.ops[op_idx].type)
             for var_key in list(block_a.vars.keys()):
-                print(var_key)
                 self.assertTrue(block_b.has_var(var_key))
 
     def check_prune_correctness(self, method, feed_dict, optimizer):
@@ -154,9 +152,6 @@ class TestProgramPruneBackward(unittest.TestCase):
         optimizer().minimize(loss)
         test_prog_prune = main_program.clone(for_test=True)
 
-        import paddle.fluid.transpiler.details.program_utils as pu
-        pu.program_to_code(test_prog_orig, skip_op_callstack=True)
-        pu.program_to_code(test_prog_prune, skip_op_callstack=True)
         self.program_compare(test_prog_orig, test_prog_prune)
 
         place = core.CPUPlace()

--- a/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
@@ -71,6 +71,58 @@ def simple_fc_net_with_accuracy(use_feed):
     return loss
 
 
+def cond_net(use_feed=None):
+    x = fluid.layers.data(name="x", shape=[4], dtype='float32')
+    label = fluid.layers.data('label', shape=[1], dtype='int64')
+    prediction = fluid.layers.fc(input=x, size=1, act=None)
+
+    def loss1(pred, label):
+        x = fluid.layers.data(name="x", shape=[4], dtype='float32')
+        loss = fluid.layers.cross_entropy(input=pred, label=label)
+        avg_loss = fluid.layers.mean(loss, name='mean_cross_entropy_loss')
+        return avg_loss
+
+    def loss2(pred, label):
+        loss = fluid.layers.softmax_with_cross_entropy(logits=pred, label=label)
+        avg_loss = fluid.layers.mean(loss, name='mean_softmax_loss')
+        return avg_loss
+
+    two = fluid.layers.fill_constant([1], 'int32', 2)
+    pred = (two == 0)
+    avg_loss = fluid.layers.case([(pred, lambda: loss1(prediction, label))],
+                                 lambda: loss2(prediction, label))
+    return avg_loss
+
+
+def optimization_in_cond_net(with_optimize=False):
+    x = fluid.layers.data(name="x", shape=[4], dtype='float32')
+    label = fluid.layers.data('label', shape=[1], dtype='int64')
+    prediction = fluid.layers.fc(input=x, size=1, act=None)
+
+    def loss1(opt, pred, label, with_optimize):
+        x = fluid.layers.data(name="x", shape=[4], dtype='float32')
+        loss = fluid.layers.cross_entropy(input=pred, label=label)
+        avg_loss = fluid.layers.mean(loss, name='mean_cross_entropy_loss')
+        if with_optimize:
+            opt.minimize(avg_loss)
+        return avg_loss
+
+    def loss2(opt, pred, label, with_optimize):
+        loss = fluid.layers.softmax_with_cross_entropy(logits=pred, label=label)
+        avg_loss = fluid.layers.mean(loss, name='mean_softmax_loss')
+        if with_optimize:
+            opt.minimize(avg_loss)
+        return avg_loss
+
+    sgd = fluid.optimizer.SGD(learning_rate=0.1)
+    two = fluid.layers.fill_constant([1], 'int32', 2)
+    pred = (two == 0)
+    avg_loss = fluid.layers.case(
+        [(pred, lambda: loss1(sgd, prediction, label, with_optimize))],
+        lambda: loss2(sgd, prediction, label, with_optimize))
+    return avg_loss
+
+
 class TestProgramPruneBackward(unittest.TestCase):
     def program_compare(self, program_a, program_b):
         assert isinstance(
@@ -82,6 +134,7 @@ class TestProgramPruneBackward(unittest.TestCase):
 
         self.assertEqual(len(program_a.blocks), len(program_b.blocks))
         for idx in range(len(program_a.blocks)):
+            print(idx)
             block_a = program_a.blocks[idx]
             block_b = program_b.blocks[idx]
             self.assertEqual(len(block_a.ops), len(block_b.ops))
@@ -90,6 +143,7 @@ class TestProgramPruneBackward(unittest.TestCase):
                 self.assertEqual(block_a.ops[op_idx].type,
                                  block_b.ops[op_idx].type)
             for var_key in list(block_a.vars.keys()):
+                print(var_key)
                 self.assertTrue(block_b.has_var(var_key))
 
     def check_prune_correctness(self, method, feed_dict, optimizer):
@@ -99,6 +153,10 @@ class TestProgramPruneBackward(unittest.TestCase):
         test_prog_orig = main_program.clone(for_test=True)
         optimizer().minimize(loss)
         test_prog_prune = main_program.clone(for_test=True)
+
+        import paddle.fluid.transpiler.details.program_utils as pu
+        pu.program_to_code(test_prog_orig, skip_op_callstack=True)
+        pu.program_to_code(test_prog_prune, skip_op_callstack=True)
         self.program_compare(test_prog_orig, test_prog_prune)
 
         place = core.CPUPlace()
@@ -198,6 +256,51 @@ class TestProgramPruneBackward(unittest.TestCase):
             self.check_prune_correctness(
                 method=lstm_net, feed_dict=feed_data, optimizer=optimizer)
 
+    def test_cond(self):
+        def optimizer():
+            optimizer = fluid.optimizer.SGD(learning_rate=0.01, )
+            return optimizer
+
+        with self.program_scope_guard():
+            x_in = np.random.random(size=(10, 4)).astype('float32')
+            label_in = np.random.randint(1, size=(10, 1)).astype('int64')
+            feed_dict = {'x': x_in, 'label': label_in}
+            self.check_prune_correctness(
+                method=cond_net, feed_dict=feed_dict, optimizer=optimizer)
+
+    def test_optimization_in_cond(self):
+        x_in = np.random.random(size=(10, 4)).astype('float32')
+        label_in = np.random.randint(1, size=(10, 1)).astype('int64')
+        feed_dict = {'x': x_in, 'label': label_in}
+        with self.program_scope_guard():
+            loss = optimization_in_cond_net(False)
+            main_program = fluid.default_main_program()
+            test_prog_orig = main_program.clone(for_test=True)
+            place = core.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+            loss_data_orig, = exe.run(test_prog_orig,
+                                      feed=feed_dict,
+                                      fetch_list=[loss.name])
+
+        with self.program_scope_guard():
+            loss = optimization_in_cond_net(True)
+            main_program = fluid.default_main_program()
+            test_prog_prune = main_program.clone(for_test=True)
+            place = core.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+            loss_data_prune, = exe.run(test_prog_prune,
+                                       feed=feed_dict,
+                                       fetch_list=[loss.name])
+
+        import paddle.fluid.transpiler.details.program_utils as pu
+        pu.program_to_code(test_prog_orig, skip_op_callstack=True)
+        pu.program_to_code(test_prog_prune, skip_op_callstack=True)
+        self.program_compare(test_prog_orig, test_prog_prune)
+
+        self.assertEqual(loss_data_orig, loss_data_prune)
+
     @contextlib.contextmanager
     def program_scope_guard(self):
         prog = fluid.Program()
@@ -205,7 +308,8 @@ class TestProgramPruneBackward(unittest.TestCase):
         scope = fluid.core.Scope()
         with fluid.scope_guard(scope):
             with fluid.program_guard(prog, startup_prog):
-                yield
+                with fluid.unique_name.guard():
+                    yield
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When `clone(for_test=True)` called after minimize, the appended backward part should be pruned correctly. 
The origin implementation cannot handle program with conditional block. For example, it raises error like this,
![image](https://user-images.githubusercontent.com/6888866/75148007-9010e480-5739-11ea-8d86-917a2b851b91.png)

The main problem is that, the loss may not occur in global block and the number of blocks in cloned program will be less than the original program. 
 There are two cases,

1. Without minimize in conditional block

```
def gen_loss1: ...
def gen_loss2: ...
sgd = fluid.optimizer.SGD()
# 在运行时根据pred选择执行gen_loss1还是gen_loss2
loss = fluid.layers.cond(pred, gen_loss1, gen_loss2)
sgd.minimize(loss) 

for i in range(10):
	res = exe.run(feed, fetch_list=[loss.name])
```
![image](https://user-images.githubusercontent.com/6888866/74901336-84da5380-53dd-11ea-83f9-7e60f4372bf2.png)
In this case, the id of a block in cloned program and its corresponding origin one are identical, though the number of blocks is decreased.

2. With minimize in conditional block

```
def gen_loss1: 
	loss1 = Net1()
	sgd,m.minimize(loss1)
return loss1def gen_loss2: 
	loss2 = Net1()
	sgd.minimize(loss2)
	return loss2
# 在运行时根据pred选择执行gen_loss1还是gen_loss2
loss = fluid.layers.cond(pred, gen_loss1, gen_loss2)

for i in range(10):
	res = exe.run(feed, fetch_list=[loss.name])
```
![image](https://user-images.githubusercontent.com/6888866/74901292-62483a80-53dd-11ea-8582-be183c510431.png)
In this case, the id of a block in cloned program and its corresponding origin one are not identical.

This PR handles both cases.
