### PR TITLE
unexpose tracer, test=develop

### DIFF
--- a/python/paddle/fluid/dygraph/__init__.py
+++ b/python/paddle/fluid/dygraph/__init__.py
@@ -49,7 +49,6 @@ __all__ += layers.__all__
 __all__ += base.__all__
 __all__ += container.__all__
 __all__ += nn.__all__
-__all__ += tracer.__all__
 __all__ += parallel.__all__
 __all__ += checkpoint.__all__
 __all__ += learning_rate_scheduler.__all__

--- a/python/paddle/fluid/dygraph/tracer.py
+++ b/python/paddle/fluid/dygraph/tracer.py
@@ -20,12 +20,16 @@ from collections import defaultdict
 from paddle.fluid import core
 from paddle.fluid import framework
 
-__all__ = ['Tracer']
-
 
 class Tracer(core.Tracer):
     """
-    Python wrapper of dygraph tracer
+    Tracer is used to execute and record the operators executed, to construct the 
+    computation graph in dygraph model. Tracer has two mode, :code:`train_mode`
+    and :code:`eval_mode`. In :code:`train_mode`, Tracer would add backward network 
+    automatically and perform AutoGrad by method :code:`loss.backward()`. 
+    In :code:`eval_mode`, Tracer would not add backward network.
+
+    This is a low level API, users don't need to use it directly.
     """
 
     def __init__(self):


### PR DESCRIPTION
`Tracer` is an internal API, users do not need to use it directly when programing in dygraph mode.
Further more, it may be deprecated in future.
So, this PR make it unexposed.