### PR TITLE
Linear use mul op

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -923,14 +923,13 @@ class Linear(layers.Layer):
 
     def forward(self, input):
         attrs = {
-            "transpose_X": False,
-            "transpose_Y": False,
-            "alpha": 1,
+            "x_num_col_dims": len(input.shape) - 1,
+            "y_num_col_dims": 1,
         }
         inputs = {"X": [input], "Y": [self.weight]}
 
         if in_dygraph_mode():
-            outs = core.ops.matmul(inputs, attrs)
+            outs = core.ops.mul(inputs, attrs)
             pre_bias = outs['Out'][0]
 
             pre_act = dygraph_utils._append_bias_in_dygraph(
@@ -941,7 +940,7 @@ class Linear(layers.Layer):
 
         tmp = self._helper.create_variable_for_type_inference(self._dtype)
         self._helper.append_op(
-            type="matmul", inputs=inputs, outputs={"Out": tmp}, attrs=attrs)
+            type="mul", inputs=inputs, outputs={"Out": tmp}, attrs=attrs)
         if self.bias:
             pre_activation = self._helper.create_variable_for_type_inference(
                 dtype=self._dtype)

--- a/python/paddle/fluid/tests/unittests/test_imperative_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_optimizer.py
@@ -148,7 +148,7 @@ class TestImperativeOptimizerBase(unittest.TestCase):
             img = fluid.layers.data(
                 name='pixel', shape=[1, 28, 28], dtype='float32')
             label = fluid.layers.data(name='label', shape=[1], dtype='int64')
-            img = fluid.layers.reshape(img, shape=[batch_size, -1])
+            img = fluid.layers.reshape(img, shape=[batch_size, 784])
             cost = mlp(img)
             avg_loss = fluid.layers.reduce_mean(cost)
             optimizer.minimize(avg_loss)


### PR DESCRIPTION
当前`Linear`使用的`matmul`op的底层实现在存在>=3d的输入时，使用的是BatchedGEMM，不如`mul`使用GEMM高效。
此PR将`Linear`使用的op换成`mul`。