### PR TITLE
Add PADDLE_ENFORCE to Check Sequence Length of RecurrentOp

### DIFF
--- a/paddle/fluid/operators/recurrent_op.cc
+++ b/paddle/fluid/operators/recurrent_op.cc
@@ -146,10 +146,11 @@ int64_t RecurrentBase::GetSequenceLength(const framework::Scope &scope) const {
     if (seq_len == -1) {
       seq_len = dim[0];
     } else {
-      PADDLE_ENFORCE_EQ(
-          seq_len, dim[0],
-          platform::errors::InvalidArgument(
-              "Sequence lengths of inputs of RecurrentOp are NOT equal"));
+      PADDLE_ENFORCE_EQ(seq_len, dim[0],
+                        platform::errors::InvalidArgument(
+                            "Sequence length of input %s in RecurrentOp is NOT "
+                            "equal to sequence length of previous input",
+                            iname));
     }
   }
   PADDLE_ENFORCE_GE(seq_len, 0,


### PR DESCRIPTION
1. Add PADDLE_ENFORCE to Check Sequence Length of RecurrentOp.
2. Also enrich PADDLE_ENFORCE error messages.

The main point of this PR is making sure the seq_len >= 0 to prevent potential dangerous behavior.
![image](https://user-images.githubusercontent.com/7913861/74931195-14055c80-541a-11ea-9b1d-ef7e6797fe7a.png)


test=develop