### PR TITLE
Fix batch_num default value

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py
@@ -57,8 +57,9 @@ def parse_args():
     parser.add_argument(
         '--batch_num',
         type=int,
-        default=1,
-        help='Number of batches to process. 0 or less means all.')
+        default=0,
+        help='Number of batches to process. 0 or less means whole dataset. Default: 0.'
+    )
     parser.add_argument(
         '--acc_diff_threshold',
         type=float,

--- a/python/paddle/fluid/contrib/slim/tests/qat_int8_nlp_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat_int8_nlp_comparison.py
@@ -57,8 +57,9 @@ def parse_args():
     parser.add_argument(
         '--batch_num',
         type=int,
-        default=1,
-        help='Number of batches to process. 0 or less means all.')
+        default=0,
+        help='Number of batches to process. 0 or less means whole dataset. Default: 0.'
+    )
     parser.add_argument(
         '--acc_diff_threshold',
         type=float,


### PR DESCRIPTION
With this change, the default behavior of the accuracy benchmarking scripts for QAT image classification and QAT NLP will be to use the whole dataset instead of a single iteration.

test=develop