### PR TITLE
Remove `no_grad_set` usage from "conv_shift" op tests

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_conv_shift_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv_shift_op.py
@@ -51,10 +51,10 @@ class TestConvShiftOp(OpTest):
         self.check_grad(['X', 'Y'], 'Out')
 
     def test_check_grad_ignore_x(self):
-        self.check_grad(['Y'], 'Out', max_relative_error=0.05)
+        self.check_grad(['Y'], 'Out')
 
     def test_check_grad_ignore_y(self):
-        self.check_grad(['X'], 'Out', max_relative_error=0.05)
+        self.check_grad(['X'], 'Out')
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_conv_shift_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv_shift_op.py
@@ -51,12 +51,10 @@ class TestConvShiftOp(OpTest):
         self.check_grad(['X', 'Y'], 'Out')
 
     def test_check_grad_ignore_x(self):
-        self.check_grad(
-            ['Y'], 'Out', max_relative_error=0.05, no_grad_set=set("X"))
+        self.check_grad(['Y'], 'Out', max_relative_error=0.05)
 
     def test_check_grad_ignore_y(self):
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=0.05, no_grad_set=set('Y'))
+        self.check_grad(['X'], 'Out', max_relative_error=0.05)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -23,7 +23,6 @@ NEED_TO_FIX_OP_LIST = [
     'affine_grid',
     'backward',
     'batch_norm',
-    'conv_shift',
     'conv2d',
     'conv2d_transpose',
     'conv3d',


### PR DESCRIPTION
Latest paddle code convention recommends `no_grad_set` usage in tests be avoided, this PR addresses this in `conv_shift` op tests.