### PR TITLE
fix bug that save_parms garbled chinese characters on windows

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_static_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load.py
@@ -25,9 +25,19 @@ from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 from paddle.fluid.executor import global_scope
 import numpy as np
+import contextlib
 import six
 import pickle
 import os
+import platform
+
+
+@contextlib.contextmanager
+def windows_guard():
+    previous = platform.system
+    platform.system = lambda: "Windows"
+    yield
+    platform.system = previous
 
 
 class SimpleLSTMRNN(fluid.Layer):
@@ -1294,6 +1304,22 @@ class TestProgramStateOldSaveSingleModel(unittest.TestCase):
                         main_program.global_block().create_var(
                             name="fake_var_name", persistable=True)
                     ])
+
+            with windows_guard():
+                fluid.io.save_persistables(
+                    exe,
+                    dirname="test_program_3",
+                    main_program=main_program,
+                    filename="model_1")
+                fluid.io.save_persistables(
+                    exe, dirname="test_program_4", main_program=main_program)
+                fluid.io.load_persistables(
+                    exe,
+                    dirname="test_program_3",
+                    main_program=main_program,
+                    filename="model_1")
+                fluid.io.load_persistables(
+                    exe, dirname="test_program_4", main_program=main_program)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
修复了`save_vars/save_persistable/save_params` 在Windows下出现中文乱码的bug。

Python3默认使用unicode编码，而Windows对C++代码使用gbk编码，因此当传入字符串到pybind时，已经乱码了，需要在python端先进行gbk编码。

测试代码：
`import paddle.fluid as fluid`
`dir_path = "./测试路径"`
`file_name = "persistables"`
`image = fluid.layers.data(name='img', shape=[1, 28, 28], dtype='float32')`
`label = fluid.layers.data(name='label', shape=[1], dtype='int64')`
`feeder = fluid.DataFeeder(feed_list=[image, label], place=fluid.CPUPlace())`
`predict = fluid.layers.fc(input=image, size=10, act='softmax')`
`loss = fluid.layers.cross_entropy(input=predict, label=label)`
`avg_loss = fluid.layers.mean(loss)`
`exe = fluid.Executor(fluid.CPUPlace())`
`exe.run(fluid.default_startup_program())`
`fluid.io.save_persistables(executor=exe, dirname=dir_path)`

修复前结果：
![BaiduHi_2020-2-19_22-36-14](https://user-images.githubusercontent.com/52485244/74844739-e14f5b80-5368-11ea-9478-82b0f8eeedcb.png)

修复后结果：
![BaiduHi_2020-2-19_22-34-51](https://user-images.githubusercontent.com/52485244/74844750-e4e2e280-5368-11ea-81b3-3f73b163b5f6.png)