### PR TITLE
fix concat_mkldnn op. test=develop

### DIFF
--- a/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/concat_mkldnn_op.cc
@@ -142,9 +142,12 @@ class ConcatMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         paddle::framework::ToMKLDNNDataType(multi_input[0]->type());
 
     ConcatPrimitiveFactory<T> prim_creator;
+    // If one of the multiple inputs of concat has an input size of 0, the
+    // actual size of the multi_input will change
     std::string key = platform::CreateKey(
         paddle::framework::vectorize<int>(multi_input[0]->dims()),
-        ctx.OutputName("Out"), dt, platform::ThreadIDasStr());
+        multi_input.size(), ctx.OutputName("Out"), dt,
+        platform::ThreadIDasStr());
 
     const std::string key_prim = key + "@concat_p";
     const std::string key_concat_pd = key + "@concat_pd";


### PR DESCRIPTION
当启用mkldnn预测时，如果concat的多个输入中，有一个size为0，则实际concat_mkldnn kernel在Compute计算过程中其输入multi_input的实际size就会减一。如果预测多个图片，且该shape的key_prim已经设置过，则当遇到有输入size为0的情况，则再取输入的数据指针即multi_input[i]->data<T>()会core掉。此时应当初始化新的key_prim。

When mkldnn prediction is enabled, if the size of one of the inputs of concat is 0, the actual size of the input `multi_input` of the concat_mkldnn kernel during Compute calculation will be reduced by one. As shown in the figure below, although there are 4 inputs, only 3 are valid in the end.
If multiple sets of data are predicted continuously, and the `key_prim` of the shape has been set, when one of the multiple inputs has an input size of 0, then taking the input data pointer, which is `multi_input [i]-> data()` will failure. A new `key_prim` should be initialized at this point.

![image](https://user-images.githubusercontent.com/26377421/74912293-5d917f80-53f9-11ea-98c2-234040408f65.png)

问题来源：卡片4155