### PR TITLE
support control flow cond in dygraph mode

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -2028,12 +2028,16 @@ def cond(pred, true_fn=None, false_fn=None, name=None):
         if pred:
             if true_fn is not None:
                 if not callable(true_fn):
-                    raise TypeError("The true_fn in cond must be callable")
+                    raise TypeError(
+                        "The true_fn in cond must be callable, but received {}".
+                        format(type(true_fn).__name__))
                 return true_fn()
         else:
             if false_fn is not None:
                 if not callable(false_fn):
-                    raise TypeError("The false_fn in cond must be callable")
+                    raise TypeError(
+                        "The false_fn in cond must be callable, but received {}".
+                        format(type(false_fn).__name__))
                 return false_fn()
         return None
 
@@ -2043,7 +2047,9 @@ def cond(pred, true_fn=None, false_fn=None, name=None):
     copy_to_parent_func = lambda var: copy_var_to_parent_block(var, helper)
     if true_fn is not None:
         if not callable(true_fn):
-            raise TypeError("The true_fn in cond must be callable")
+            raise TypeError(
+                "The true_fn in cond must be callable, but received {}".format(
+                    type(true_fn).__name__))
         true_cond_block = ConditionalBlock([pred], is_scalar_condition=True)
         with true_cond_block.block():
             origin_true_output = true_fn()
@@ -2052,7 +2058,9 @@ def cond(pred, true_fn=None, false_fn=None, name=None):
                                             origin_true_output)
     if false_fn is not None:
         if not callable(false_fn):
-            raise TypeError("The false_fn in cond must be callable")
+            raise TypeError(
+                "The false_fn in cond must be callable, but received {}".format(
+                    type(false_fn).__name__))
         false_cond_block = ConditionalBlock(
             [logical_not(pred)], is_scalar_condition=True)
         with false_cond_block.block():

--- a/python/paddle/fluid/tests/unittests/test_cond.py
+++ b/python/paddle/fluid/tests/unittests/test_cond.py
@@ -192,15 +192,11 @@ class TestCondInputOutput(unittest.TestCase):
         with program_guard(main_program, startup_program):
             i = fluid.data(name="i", shape=[1], dtype='int32')
             pred = ((i % 2) == 0)
-            with self.assertRaises(Exception) as e:
+            with self.assertRaises(TypeError):
                 out = layers.cond(pred, i, func_return_one_tensor)
-            self.assertEqual("The true_fn in cond must be callable",
-                             str(e.exception))
 
-            with self.assertRaises(Exception) as e:
+            with self.assertRaises(TypeError):
                 out = layers.cond(pred, func_return_one_tensor, np.asarray([3]))
-            self.assertEqual("The false_fn in cond must be callable",
-                             str(e.exception))
 
             with self.assertRaises(Exception) as e:
                 out = layers.cond(pred, func_return_none,

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1517,7 +1517,11 @@ class TestLayer(LayerTest):
             b = fluid.dygraph.to_variable(np.array([0.23]).astype('float32'))
             out = layers.cond(a < b, lambda: less_than_branch(a, b),
                               lambda: greater_equal_branch(a, b))
+            out2 = layers.cond(a >= b, lambda: greater_equal_branch(a, b),
+                               lambda: less_than_branch(a, b))
             dynamic_res = out.numpy()
+            dynamic_res2 = out2.numpy()
+            self.assertTrue(np.array_equal(dynamic_res, dynamic_res2))
             with self.assertRaises(TypeError):
                 layers.cond(a < b, 'str', 'str')
                 layers.cond(a >= b, 'str', 'str')

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1524,6 +1524,7 @@ class TestLayer(LayerTest):
             self.assertTrue(np.array_equal(dynamic_res, dynamic_res2))
             with self.assertRaises(TypeError):
                 layers.cond(a < b, 'str', 'str')
+            with self.assertRaises(TypeError):
                 layers.cond(a >= b, 'str', 'str')
 
         self.assertTrue(np.array_equal(static_res, dynamic_res))

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -1504,8 +1504,8 @@ class TestLayer(LayerTest):
                 shape=[1], dtype='float32', value=0.1)
             b = fluid.layers.fill_constant(
                 shape=[1], dtype='float32', value=0.23)
-            out = fluid.layers.cond(a < b, lambda: less_than_branch(a, b),
-                                    lambda: greater_equal_branch(a, b))
+            out = fluid.layers.cond(a >= b, lambda: greater_equal_branch(a, b),
+                                    lambda: less_than_branch(a, b))
             place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
             ) else fluid.CPUPlace()
             exe = fluid.Executor(place)
@@ -1518,6 +1518,9 @@ class TestLayer(LayerTest):
             out = layers.cond(a < b, lambda: less_than_branch(a, b),
                               lambda: greater_equal_branch(a, b))
             dynamic_res = out.numpy()
+            with self.assertRaises(TypeError):
+                layers.cond(a < b, 'str', 'str')
+                layers.cond(a >= b, 'str', 'str')
 
         self.assertTrue(np.array_equal(static_res, dynamic_res))
 


### PR DESCRIPTION
动态图下支持使用控制流op `cond`。依赖此op的`case`、`switch_case` op也一并支持。

`cond` sample:
```py
import paddle.fluid as fluid
import paddle.fluid.layers as layers
import numpy as np

#
# pseudocode:
# if 0.1 < 0.23:
#     return 1, True
# else:
#     return 3, 2
#

def true_func():
    return layers.fill_constant(
        shape=[1, 2], dtype='int32', value=1), layers.fill_constant(
            shape=[2, 3], dtype='bool', value=True)

def false_func():
    return layers.fill_constant(
        shape=[3, 4], dtype='float32', value=3), layers.fill_constant(
            shape=[4, 5], dtype='int64', value=2)

with fluid.dygraph.guard():
    x = fluid.dygraph.to_variable(np.array([0.1]))
    y = fluid.dygraph.to_variable(np.array([0.23]))
    pred = layers.less_than(x, y)
    out = layers.cond(pred, true_func, false_func)
    # out is a tuple containing 2 tensors
    # out[0] = [[1 1]]
    # out[1] = [[ True  True  True]
    #           [ True  True  True]]
```

`switch_case` sample:
```py
import paddle.fluid as fluid
import paddle.fluid.layers as layers

def fn_1():
    return layers.fill_constant(shape=[1, 2], dtype='float32', value=1)

def fn_2():
    return layers.fill_constant(shape=[2, 2], dtype='int32', value=2)

def fn_3():
    return layers.fill_constant(shape=[3], dtype='int32', value=3)

with fluid.dygraph.guard():
    index_1 = layers.fill_constant(shape=[1], dtype='int32', value=1)
    index_2 = layers.fill_constant(shape=[1], dtype='int32', value=2)

    out_1 = layers.switch_case(
        branch_index=index_1,
        branch_fns={1: fn_1, 2: fn_2},
        default=fn_3)

    out_2 = layers.switch_case(
        branch_index=index_2,
        branch_fns=[(1, fn_1), (2, fn_2)],
        default=fn_3)

    # Argument default is None and no index matches. fn_3 will be called because of the max index 7.
    out_3 = layers.switch_case(
        branch_index=index_2,
        branch_fns=[(0, fn_1), (4, fn_2), (7, fn_3)])

    print(out_1.numpy())  # [[1. 1.]]
    print(out_2.numpy())  # [[2 2] [2 2]]
    print(out_3.numpy())  # [3 3 3]
```

`case` sample:
```py
import paddle.fluid as fluid
import paddle.fluid.layers as layers

def fn_1():
    return layers.fill_constant(shape=[1, 2], dtype='float32', value=1)

def fn_2():
    return layers.fill_constant(shape=[2, 2], dtype='int32', value=2)

def fn_3():
    return layers.fill_constant(shape=[3], dtype='int32', value=3)

with fluid.dygraph.guard():
    x = layers.fill_constant(shape=[1], dtype='float32', value=0.3)
    y = layers.fill_constant(shape=[1], dtype='float32', value=0.1)
    z = layers.fill_constant(shape=[1], dtype='float32', value=0.2)

    pred_1 = layers.less_than(z, x)  # true: 0.2 < 0.3
    pred_2 = layers.less_than(x, y)  # false: 0.3 < 0.1
    pred_3 = layers.equal(x, y)      # false: 0.3 == 0.1

    # Call fn_1 because pred_1 is True
    out_1 = layers.case(
        pred_fn_pairs=[(pred_1, fn_1), (pred_2, fn_2)], default=fn_3)

    # Argument default is None and no pred in pred_fn_pairs is True. fn_3 will be called.
    # because fn_3 is the last callable in pred_fn_pairs.
    out_2 = layers.case(pred_fn_pairs=[(pred_2, fn_2), (pred_3, fn_3)])

    print(out_1.numpy())  # [[1. 1.]]
    print(out_2.numpy())  # [3 3 3]
```