### PR TITLE
fix deformable roi pooling bug for running doc example

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13534,7 +13534,7 @@ def deformable_roi_pooling(input,
     if position_sensitive == False:
         output_channels = input_channels
     else:
-        output_channels = input_channels / pooled_height / pooled_width
+        output_channels = int(input_channels / pooled_height / pooled_width)
 
     if part_size is None:
         part_height = pooled_height


### PR DESCRIPTION
fix deformable roi pooling bug for running doc example
![image](https://user-images.githubusercontent.com/17508662/75001177-a3068900-549b-11ea-8cee-0ca00e84edae.png)
