### PR TITLE
remove unnecessary cases with no_grad_set for prelu

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_prelu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_prelu_op.py
@@ -55,14 +55,8 @@ class PReluTest(OpTest):
     def test_check_output(self):
         self.check_output()
 
-    def test_check_grad_1_ignore_x(self):
-        self.check_grad(['Alpha'], 'Out', no_grad_set=set('X'))
-
-    def test_check_grad_2(self):
+    def test_check_grad(self):
         self.check_grad(['X', 'Alpha'], 'Out')
-
-    def test_check_grad_3_ignore_alpha(self):
-        self.check_grad(['X'], 'Out', no_grad_set=set('Alpha'))
 
 
 # TODO(minqiyang): Resume these test cases after fixing Python3 CI job issues

--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -60,7 +60,6 @@ NEED_TO_FIX_OP_LIST = [
     'matmul',
     'mul',
     'multiplex',
-    'prelu',
     'rank_loss',
     'row_conv',
     'sequence_conv',


### PR DESCRIPTION
- 移除了没有必要的单测case。check_grad可以检查所有输入的反向，不需要单独设置no_grad_set的case。