### PR TITLE
dygraph support while_loop op

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1010,7 +1010,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
                     "body in while_loop should return the same arity "
                     "(length and structure) and types as loop_vars")
             now_cond = cond(*output_vars).numpy()[0]
-            map_structure(assign, output_vars, loop_vars)
+            loop_vars = output_vars
         return loop_vars
 
     while_loop_block = While(pre_cond, is_test, name)


### PR DESCRIPTION
动态图下支持使用控制流op `while_loop`。

sample code:
```py
import paddle.fluid as fluid
import paddle.fluid.layers as layers

main_program = fluid.default_main_program()
startup_program = fluid.default_startup_program()
with fluid.program_guard(main_program, startup_program):
    i = layers.fill_constant(shape=[1], dtype='int64', value=0) # 循环计数器
    ten = layers.fill_constant(shape=[1], dtype='int64', value=10) # 循环次数
    def cond(i):
        return layers.less_than(i, ten)
    def body(i):
        return i + 1
    out = layers.while_loop(cond, body, [i])
    exe = fluid.Executor(fluid.CPUPlace())
    res = exe.run(main_program, feed={}, fetch_list=out)
    print(res) # [array([10])]


with fluid.dygraph.guard():
    i = layers.fill_constant(shape=[1], dtype='int64', value=0) # 循环计数器
    ten = layers.fill_constant(shape=[1], dtype='int64', value=10) # 循环次数
    def cond(i):
        return layers.less_than(i, ten)
    def body(i):
        return i + 1
    out = layers.while_loop(cond, body, [i])
    print(out) # [array([10])]
```