### PR TITLE
Add cpu_info without XBYAK

### DIFF
--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -139,6 +139,31 @@ bool MayIUse(const cpu_isa_t cpu_isa) {
   if (cpu_isa == isa_any) {
     return true;
   } else {
+    int reg[4];
+    cpuid(reg, 0);
+    int nIds = reg[0];
+    if (nIds >= 0x00000001) {
+      // EAX = 1
+      cpuid(reg, 0x00000001);
+      // AVX: ECX Bit 28
+      if (cpu_isa == avx) {
+        int avx_mask = (1 << 28);
+        return (reg[2] & avx_mask) != 0;
+      }
+    }
+    if (nIds >= 0x00000007) {
+      // EAX = 7
+      cpuid(reg, 0x00000007);
+      if (cpu_isa == avx2) {
+        // AVX2: EBX Bit 5
+        int avx2_mask = (1 << 5);
+        return (reg[1] & avx2_mask) != 0;
+      } else if (cpu_isa == avx512f) {
+        // AVX512F: EBX Bit 16
+        int avx512f_mask = (1 << 16);
+        return (reg[1] & avx512f_mask) != 0;
+      }
+    }
     return false;
   }
 }

--- a/paddle/fluid/platform/cpu_info.h
+++ b/paddle/fluid/platform/cpu_info.h
@@ -18,9 +18,9 @@ limitations under the License. */
 
 #ifdef _WIN32
 #if defined(__AVX2__)
-#include <immintrin.h>  //avx2
+#include <immintrin.h>  // avx2
 #elif defined(__AVX__)
-#include <intrin.h>  //avx
+#include <intrin.h>  // avx
 #endif               // AVX
 #else                // WIN32
 #ifdef __AVX__
@@ -35,6 +35,17 @@ limitations under the License. */
 #define ALIGN32_BEG
 #define ALIGN32_END __attribute__((aligned(32)))
 #endif  // _WIN32
+
+#ifndef PADDLE_WITH_XBYAK
+#ifdef _WIN32
+#define cpuid(reg, x) __cpuidex(reg, x, 0)
+#else
+#include <cpuid.h>
+inline void cpuid(int reg[4], int x) {
+  __cpuid_count(x, 0, reg[0], reg[1], reg[2], reg[3]);
+}
+#endif
+#endif
 
 namespace paddle {
 namespace platform {


### PR DESCRIPTION
Add functionality inside `MayIUse()` function allowing to check for AVX flags when Paddle is built without XBYAK.