### PR TITLE
Change ShareDataWith() to TensorCopy() in ref_by_trainer_id

### DIFF
--- a/paddle/fluid/operators/distributed_ops/ref_by_trainer_id_op.h
+++ b/paddle/fluid/operators/distributed_ops/ref_by_trainer_id_op.h
@@ -40,7 +40,8 @@ class RefByTrainerIdKernel : public framework::OpKernel<T> {
     }
     PADDLE_ENFORCE_LT((size_t)trainer_id, in_list.size());
     out->mutable_data<T>(context.GetPlace());
-    out->ShareDataWith(*(in_list[trainer_id]));
+    framework::TensorCopy(*(in_list[trainer_id]), in_list[trainer_id]->place(),
+                          out);
   }
 };
 


### PR DESCRIPTION
根据Op开发准则：[Op内部禁止调用ShareDataWith方法](https://github.com/PaddlePaddle/Paddle/wiki/ShareDataWith-and-ShareBufferWith-are-prohibited-in-OP)，将ref_by_trainer_id Op内ShareDataWith()改写成TensorCopy()