### PR TITLE
enhance shape check if use user_defined_grads in check_grad

### DIFF
--- a/python/paddle/fluid/tests/unittests/white_list/check_shape_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/check_shape_white_list.py
@@ -31,4 +31,5 @@ NEED_TO_FIX_OP_LIST = [
     'soft_relu',
     'squared_l2_distance',
     'tree_conv',
+    'cvm',
 ]


### PR DESCRIPTION
- 单测中使用user_defined_grads设置反向参考值时，计算反向数值解的函数get_numeric_gradient不会被调用，导致没有进行input_shape的检测。因此，将shape检查从get_numeric_gradient移动到check_grad_with_place函数中
- 新增待修复OP：cvm