### PR TITLE
spectral_norm not need to check grad

### DIFF
--- a/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 # check no_grad_set is None
-NOT_CHECK_OP_LIST = ['deformable_conv']
+NOT_CHECK_OP_LIST = [
+    'deformable_conv',
+    # spectral_norm parameter U/V is not learnable, do not to
+    # calculate and check gradient.
+    'spectral_norm',
+]
 
 # TODO(Shixiaowei02): Check if the items do not need fix.
 # no_grad_set has value in NEED_TO_FIX_OP_LIST
@@ -65,6 +70,5 @@ NEED_TO_FIX_OP_LIST = [
     'row_conv',
     'sequence_conv',
     'smooth_l1_loss',
-    'spectral_norm'
 ]
 # yapf: enable


### PR DESCRIPTION
**spectral_norm not need to check grad**
Add spectral_norm to NOT_CHECK_OP_LIST for spectral_norm do not need check grad for spectral_norm parameter U/V is not learnable, do not need to calculate and check gradient.