### PR TITLE
fix the CI risk that network cannot be connected

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -540,14 +540,16 @@ function check_approvals_of_unittest() {
     check_times=$1
     if [ $check_times == 1 ]; then
         approval_line=`curl -H "Authorization: token ${GITHUB_API_TOKEN}" https://api.github.com/repos/PaddlePaddle/Paddle/pulls/${GIT_PR_ID}/reviews?per_page=10000`
-        APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 22165420 52485244 6836917`
-        set +x
-        echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
-        if [ "${APPROVALS}" == "TRUE" ]; then
-            echo "==================================="
-            echo -e "\n current pr ${GIT_PR_ID} has got approvals. So, Pass CI directly!\n"
-            echo "==================================="
-            exit 0
+        if [ "${approval_line}" != "" ]; then
+            APPROVALS=`echo ${approval_line}|python ${PADDLE_ROOT}/tools/check_pr_approval.py 1 22165420 52485244 6836917`
+            set +x
+            echo "current pr ${GIT_PR_ID} got approvals: ${APPROVALS}"
+            if [ "${APPROVALS}" == "TRUE" ]; then
+                echo "==================================="
+                echo -e "\n current pr ${GIT_PR_ID} has got approvals. So, Pass CI directly!\n"
+                echo "==================================="
+                exit 0
+            fi
         fi
     elif [ $check_times == 2 ]; then
         unittest_spec_diff=`python ${PADDLE_ROOT}/tools/diff_unittest.py ${PADDLE_ROOT}/paddle/fluid/UNITTEST_DEV.spec ${PADDLE_ROOT}/paddle/fluid/UNITTEST_PR.spec`


### PR DESCRIPTION
在CI单测数量的检查中：

每一个PR均会检查是否已经approve了，从而节省时间。但有可能存在网络连接不好。使得approve_line=   
，这种情况下直接放弃第一次approve，出错后重新排队更为浪费时间。第二次approve则会始终执行。

如log中的情况（网络没连上）：无需第一次approve：
http://10.87.145.41:8111/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiCoverage&buildId=284575&_focus=308