### PR TITLE
fix to_source(gast) and remove some dygraph APIs 

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -192,7 +192,7 @@ class BasicApiTransformer(gast.NodeTransformer):
             node = to_assign_node(node)
             return node
 
-        func_name = astor.to_source(node.func)
+        func_name = astor.to_source(gast.gast_to_ast(node.func))
         if self._is_dygraph_forward(func_name):
             class_node = self._get_class_node(func_name)
             static_node = to_static_ast(node, class_node)
@@ -214,8 +214,11 @@ class BasicApiTransformer(gast.NodeTransformer):
                 return False
 
             if is_dygraph_api(node_value):
+                dygraph_api = node_value.func.attr
+                if not dygraph_class_to_static_api.get(dygraph_api):
+                    return False
                 update_args_of_func(node_value, node_value, "__init__")
-                target_str = astor.to_source(node.targets[0])
+                target_str = astor.to_source(gast.gast_to_ast(node.targets[0]))
                 self.class_node_dict[target_str] = node_value
                 return True
             # TODO: node.value is not dygraph class

--- a/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
@@ -23,18 +23,14 @@ import warnings
 __all__ = ['AstNodeWrapper', 'NodeVarType', 'StaticAnalysisVisitor']
 
 
-# TODO: _is_paddle_dygraph_api is duplicated in Yamei's utils.py. Merge the two
-# function code together when Yamei finish her PR.
 def _is_paddle_dygraph_api(obj):
     m = inspect.getmodule(obj)
     return m is not None and m.__name__.startswith("paddle.fluid.dygraph")
 
 
-# TODO: is_dygraph_api is duplicated in Yamei's utils.py. Merge the two
-# function code together when Yamei finish her PR.
 def is_dygraph_api(node):
     assert isinstance(node, gast.Call), "Input non-Call node for is_dygraph_api"
-    func_src = astor.to_source(node.func)
+    func_src = astor.to_source(gast.gast_to_ast(node.func))
     try:
         import paddle.fluid as fluid
         return eval("_is_paddle_dygraph_api({})".format(func_src))
@@ -49,7 +45,7 @@ def _is_numpy_api_helper(obj):
 
 def is_numpy_api(node):
     assert isinstance(node, gast.Call), "Input non-Call node for is_numpy_api"
-    func_str = astor.to_source(node.func)
+    func_str = astor.to_source(gast.gast_to_ast(node.func))
     try:
         import numpy as np
         module_result = eval("_is_numpy_api_helper({})".format(func_str))


### PR DESCRIPTION
1. modify `astor.to_source(gast_node)` to `astor.to_source(gast.gast_to_ast(ast_node))`, because astor.to_source() can't transform `gast_node`

2. Remove some dygraph APIs which don't have to be transformed
eg: `Conv2D`, `Linear`

3. Remove repetitive functions in file utils.py and static_analysis.py