### PR TITLE
Add functional dygraph mode api

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -86,6 +86,7 @@ from paddle.fluid.layers.math_op_patch import monkey_patch_variable
 from . import install_check
 from .dygraph.nn import *
 from .dygraph.layers import *
+from .dygraph.base import enable_dygraph, disable_dygraph
 from .io import save, load, load_program_state, set_program_state
 from .dygraph.checkpoint import save_dygraph, load_dygraph
 from .dygraph.varbase_patch_methods import monkey_patch_varbase
@@ -103,6 +104,8 @@ __all__ = framework.__all__ + executor.__all__ + \
         'contrib',
         'data',
         'dygraph',
+        'enable_dygraph',
+        'disable_dygraph',
         'transpiler',
         'nets',
         'optimizer',

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -74,9 +74,7 @@ def enabled():
         .. code-block:: python
 
             import paddle.fluid as fluid
-            import numpy as np
 
-            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
             fluid.enable_dygraph()  # Now we are in dygragh mode
             print(fluid.dygraph.enabled())  # True
             fluid.disable_dygraph()
@@ -100,14 +98,11 @@ def enable_dygraph(place=None):
         .. code-block:: python
 
             import paddle.fluid as fluid
-            import numpy as np
 
-            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
             fluid.enable_dygraph()  # Now we are in dygragh mode
-            data = fluid.dygraph.to_variable(data, name='data')
-            print(fluid.dygraph.enabled())  # True
+            print(fluid.in_dygraph_mode())  # True
             fluid.disable_dygraph()
-            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
+            print(fluid.in_dygraph_mode())  # False
     """
     global _functional_dygraph_context_manager
     _functional_dygraph_context_manager = guard(place=place)
@@ -125,14 +120,11 @@ def disable_dygraph():
         .. code-block:: python
 
             import paddle.fluid as fluid
-            import numpy as np
 
-            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
             fluid.enable_dygraph()  # Now we are in dygragh mode
-            data = fluid.dygraph.to_variable(data, name='data')
-            print(fluid.dygraph.enabled())  # True
+            print(fluid.in_dygraph_mode())  # True
             fluid.disable_dygraph()
-            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
+            print(fluid.in_dygraph_mode())  # False
     """
     global _functional_dygraph_context_manager
     if _functional_dygraph_context_manager is not None:

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -74,10 +74,13 @@ def enabled():
         .. code-block:: python
 
             import paddle.fluid as fluid
-            if fluid.in_dygraph_mode():
-                print('running in dygraph mode')
-            else:
-                print('not running in dygraph mode')
+            import numpy as np
+
+            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
+            fluid.dygraph.enable()  # Now we are in dygragh mode
+            print(fluid.dygraph.enabled())  # True
+            fluid.dygraph.disable()
+            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
     """
     return framework.in_dygraph_mode()
 
@@ -92,6 +95,19 @@ def enable(place=None):
 
     return:
         None
+
+    Examples:
+        .. code-block:: python
+
+            import paddle.fluid as fluid
+            import numpy as np
+
+            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
+            fluid.dygraph.enable()  # Now we are in dygragh mode
+            data = fluid.dygraph.to_variable(data, name='data')
+            print(fluid.dygraph.enabled())  # True
+            fluid.dygraph.disable()
+            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
     """
     global _functional_dygraph_context_manager
     _functional_dygraph_context_manager = guard(place=place)
@@ -104,6 +120,19 @@ def disable():
 
     return:
         None
+
+    Examples:
+        .. code-block:: python
+
+            import paddle.fluid as fluid
+            import numpy as np
+
+            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
+            fluid.dygraph.enable()  # Now we are in dygragh mode
+            data = fluid.dygraph.to_variable(data, name='data')
+            print(fluid.dygraph.enabled())  # True
+            fluid.dygraph.disable()
+            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
     """
     global _functional_dygraph_context_manager
     assert _functional_dygraph_context_manager is not None

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -24,8 +24,8 @@ import objgraph
 __all__ = [
     'no_grad',
     'guard',
-    'enable',
-    'disable',
+    'enable_dygraph',
+    'disable_dygraph',
     'enabled',
     'to_variable',
 ]
@@ -77,15 +77,15 @@ def enabled():
             import numpy as np
 
             data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
-            fluid.dygraph.enable()  # Now we are in dygragh mode
+            fluid.enable_dygraph()  # Now we are in dygragh mode
             print(fluid.dygraph.enabled())  # True
-            fluid.dygraph.disable()
-            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
+            fluid.disable_dygraph()
+            print(fluid.dygraph.enabled())  # False
     """
     return framework.in_dygraph_mode()
 
 
-def enable(place=None):
+def enable_dygraph(place=None):
     """
     This function enables dynamic graph mode.
 
@@ -103,10 +103,10 @@ def enable(place=None):
             import numpy as np
 
             data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
-            fluid.dygraph.enable()  # Now we are in dygragh mode
+            fluid.enable_dygraph()  # Now we are in dygragh mode
             data = fluid.dygraph.to_variable(data, name='data')
             print(fluid.dygraph.enabled())  # True
-            fluid.dygraph.disable()
+            fluid.disable_dygraph()
             data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
     """
     global _functional_dygraph_context_manager
@@ -114,7 +114,7 @@ def enable(place=None):
     _functional_dygraph_context_manager.__enter__()
 
 
-def disable():
+def disable_dygraph():
     """
     This function disables dynamic graph mode.
 
@@ -128,15 +128,16 @@ def disable():
             import numpy as np
 
             data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
-            fluid.dygraph.enable()  # Now we are in dygragh mode
+            fluid.enable_dygraph()  # Now we are in dygragh mode
             data = fluid.dygraph.to_variable(data, name='data')
             print(fluid.dygraph.enabled())  # True
-            fluid.dygraph.disable()
+            fluid.disable_dygraph()
             data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
     """
     global _functional_dygraph_context_manager
-    assert _functional_dygraph_context_manager is not None
-    _functional_dygraph_context_manager.__exit__(*sys.exc_info())
+    if _functional_dygraph_context_manager is not None:
+        _functional_dygraph_context_manager.__exit__(*sys.exc_info())
+        _functional_dygraph_context_manager = None
 
 
 @contextlib.contextmanager

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -184,13 +184,11 @@ def in_dygraph_mode():
         .. code-block:: python
 
             import paddle.fluid as fluid
-            import numpy as np
 
-            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
-            fluid.dygraph.enable()  # Now we are in dygragh mode
+            fluid.enable_dygraph()  # Now we are in dygragh mode
             print(fluid.in_dygraph_mode())  # True
-            fluid.dygraph.disable()
-            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
+            fluid.disable_dygraph()
+            print(fluid.in_dygraph_mode())  # False
     """
     return _dygraph_tracer_ is not None
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -173,7 +173,9 @@ def require_version(min_version, max_version=None):
 def in_dygraph_mode():
     """
     This function checks whether the program runs in dynamic graph mode or not.
-    You can turn on dynamic graph mode with :ref:`api_fluid_dygraph_guard` api.
+    You can enter dynamic graph mode with :ref:`api_fluid_dygraph_guard` api,
+    or enable and disable dynamic graph mode with :ref:`api_fluid_dygraph_enable`
+    and :ref:`api_fluid_dygraph_disable` api .
 
     Returns:
         bool: Whether the program is running in dynamic graph mode.

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -184,11 +184,13 @@ def in_dygraph_mode():
         .. code-block:: python
 
             import paddle.fluid as fluid
-            if fluid.in_dygraph_mode():
-                print('running in dygraph mode')
-            else:
-                print('not running in dygraph mode')
+            import numpy as np
 
+            data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')
+            fluid.dygraph.enable()  # Now we are in dygragh mode
+            print(fluid.in_dygraph_mode())  # True
+            fluid.dygraph.disable()
+            data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
     """
     return _dygraph_tracer_ is not None
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -177,6 +177,31 @@ class SimpleRNN(fluid.Layer):
 
 
 class TestImperative(unittest.TestCase):
+    def test_functional_dygraph_context(self):
+        self.assertFalse(fluid.dygraph.enabled())
+        fluid.dygraph.enable()
+        self.assertTrue(fluid.dygraph.enabled())
+        np_inp = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+        var_inp = fluid.dygraph.base.to_variable(np_inp)
+        mlp = MLP(input_size=2)
+        out = mlp(var_inp)
+        dy_out1 = out.numpy()
+        out.backward()
+        dy_grad1 = mlp._linear1.weight.gradient()
+        fluid.dygraph.disable()
+        self.assertFalse(fluid.dygraph.enabled())
+        with fluid.dygraph.guard():
+            self.assertTrue(fluid.dygraph.enabled())
+            var_inp = fluid.dygraph.base.to_variable(np_inp)
+            mlp = MLP(input_size=2)
+            out = mlp(var_inp)
+            dy_out2 = out.numpy()
+            out.backward()
+            dy_grad2 = mlp._linear1.weight.gradient()
+        self.assertFalse(fluid.dygraph.enabled())
+        self.assertTrue(np.array_equal(dy_out1, dy_out2))
+        self.assertTrue(np.array_equal(dy_grad1, dy_grad2))
+
     def test_isinstance(self):
         var = fluid.layers.data(shape=[1], name='x', dtype='float32')
         self.assertTrue(isinstance(var, fluid.Variable))

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -179,7 +179,7 @@ class SimpleRNN(fluid.Layer):
 class TestImperative(unittest.TestCase):
     def test_functional_dygraph_context(self):
         self.assertFalse(fluid.dygraph.enabled())
-        fluid.dygraph.enable()
+        fluid.enable_dygraph()
         self.assertTrue(fluid.dygraph.enabled())
         np_inp = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
         var_inp = fluid.dygraph.base.to_variable(np_inp)
@@ -188,7 +188,7 @@ class TestImperative(unittest.TestCase):
         dy_out1 = out.numpy()
         out.backward()
         dy_grad1 = mlp._linear1.weight.gradient()
-        fluid.dygraph.disable()
+        fluid.disable_dygraph()
         self.assertFalse(fluid.dygraph.enabled())
         with fluid.dygraph.guard():
             self.assertTrue(fluid.dygraph.enabled())


### PR DESCRIPTION
新增`enable_dygraph`和`disable_dygraph`接口，支持函数式启动关闭动态图模式

sample code:
```py
import paddle.fluid as fluid
import numpy as np

data = np.random.uniform( -1, 1, [30, 10, 32] ).astype('float32')

fluid.enable_dygraph()  # Now we are in dygragh mode
data = fluid.dygraph.to_variable(data, name='data')
print(fluid.in_dygraph_mode())  # True

fluid.disable_dygraph()
data = fluid.dygraph.to_variable(data, name='data')  # AssertionError
```

![10 88 157 35_8080_documentation_docs_en_api_fluid_disable_dygraph html](https://user-images.githubusercontent.com/2573291/75745681-0376af80-5d53-11ea-8b10-7f00ec190370.png)

![10 88 157 35_8080_documentation_docs_en_api_fluid_enable_dygraph html](https://user-images.githubusercontent.com/2573291/75745707-0f627180-5d53-11ea-8d13-26d2724ee0c8.png)
