### PR TITLE
test=develop, bug fix for trainer_factory

### DIFF
--- a/python/paddle/fluid/trainer_factory.py
+++ b/python/paddle/fluid/trainer_factory.py
@@ -43,7 +43,7 @@ class TrainerFactory(object):
     def _create_trainer(self, opt_info=None):
         trainer = None
         device_worker = None
-        if opt_info == None:
+        if not opt_info:
             # default is MultiTrainer + Hogwild
             trainer = MultiTrainer()
             device_worker = Hogwild()


### PR DESCRIPTION
修复语法错误：
trainer_factory._create_trainer方法中，判断是否用默认值的方法是：opt_info == None；该写法无法正确识别opt_info 为空字符、空字典、空列表等case。