### PR TITLE
Fix SyntaxError in examples in retinanet_target_assign English API

### DIFF
--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -233,7 +233,7 @@ def retinanet_target_assign(bbox_pred,
                             dtype='float32')
           im_info = fluid.data(name='im_infoss', shape=[1, 3],
                             dtype='float32')
-          score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num =
+          score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num = \
                 fluid.layers.retinanet_target_assign(bbox_pred, cls_logits, anchor_box,
                 anchor_var, gt_boxes, gt_labels, is_crowd, im_info, 10)
 


### PR DESCRIPTION
There is a SyntaxError in the example for retinanet_target_assign english API, so we fix this error.
test=develop
PR for fixing syntaxerror in examples in retinanet_target_assign Chinese API: https://github.com/PaddlePaddle/FluidDoc/pull/1796
![image](https://user-images.githubusercontent.com/22235422/75343427-6ab7de00-58d3-11ea-8920-8672d6283b88.png)
![image](https://user-images.githubusercontent.com/22235422/75343512-9935b900-58d3-11ea-995e-438ef87329a7.png)
