### PR TITLE
Enable flags benchmark in dygraph

### DIFF
--- a/paddle/fluid/imperative/prepared_operator.cc
+++ b/paddle/fluid/imperative/prepared_operator.cc
@@ -15,6 +15,8 @@
 #include "paddle/fluid/imperative/prepared_operator.h"
 #include <sstream>
 
+DECLARE_bool(benchmark);
+
 namespace paddle {
 namespace imperative {
 
@@ -126,6 +128,9 @@ void PreparedOp::Run(const NameVarBaseMap* in, const NameVarBaseMap* out,
 
   func_(DygraphExecutionContext(op_, scope, *dev_ctx_, ctx_, kernel_configs_,
                                 *in, *out, attrs));
+  if (FLAGS_benchmark) {
+    dev_ctx_->Wait();
+  }
 }
 
 }  // namespace imperative


### PR DESCRIPTION
Enable flags `benchmark` in dygraph mode, used by

```shell
export FLAGS_benchmark=1
```