### PR TITLE
support fetch feed in dygraph to static graph

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -110,7 +110,7 @@ class DygraphToStaticAst(gast.NodeTransformer):
         # Transform basic api of dygraph to static graph
         basic_api_trans = BasicApiTransformer(node)
         basic_api_trans.ast_visit()
-        self.feed_name_to_arg_name = basic_api_trans._get_feed_name_to_arg_id()
+        self.feed_name_to_arg_name = basic_api_trans.get_feed_name_to_arg_id()
 
         # Transform all if/else statement of Dygraph into Static Graph.
         IfElseTransformer(node).ast_visit()
@@ -252,5 +252,5 @@ class BasicApiTransformer(gast.NodeTransformer):
         feed_var_name = unique_name.generate(var_name)  # eg: "a_0"
         self.feed_name_to_arg_id[feed_var_name] = var_name  # eg: "a_0" : "a"
 
-    def _get_feed_name_to_arg_id(self):
+    def get_feed_name_to_arg_id(self):
         return self.feed_name_to_arg_id

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -143,7 +143,7 @@ class DygraphToStaticAst(gast.NodeTransformer):
 
     def get_feed_name_to_idx(self):
         feed_name_to_idx = {}
-        for feed_name, arg_name in self.feed_name_to_arg_name.iteritems():
+        for feed_name, arg_name in self.feed_name_to_arg_name.items():
             feed_name_to_idx[feed_name] = self.arg_name_to_idx.get(arg_name)
         return feed_name_to_idx
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
@@ -19,49 +19,9 @@ import gast
 import inspect
 import six
 import warnings
+from .utils import is_paddle_api, is_dygraph_api, is_numpy_api
 
 __all__ = ['AstNodeWrapper', 'NodeVarType', 'StaticAnalysisVisitor']
-
-
-def _is_api_in_module_helper(obj, module_prefix):
-    m = inspect.getmodule(obj)
-    return m is not None and m.__name__.startswith(module_prefix)
-
-
-def is_api_in_module(node, module_prefix):
-    assert isinstance(node, gast.Call), "Input non-Call node for is_dygraph_api"
-    func_str = astor.to_source(gast.gast_to_ast(node.func))
-    try:
-        import paddle.fluid as fluid
-        import paddle
-        return eval("_is_api_in_module_helper({}, '{}')".format(func_str,
-                                                                module_prefix))
-    except NameError:
-        return False
-
-
-def is_dygraph_api(node):
-    return is_api_in_module(node, "paddle.fluid.dygraph")
-
-
-def is_paddle_api(node):
-    return is_api_in_module(node, "paddle.fluid")
-
-
-# Is numpy_api cannot reuse is_api_in_module because of numpy module problem
-def is_numpy_api(node):
-    assert isinstance(node, gast.Call), "Input non-Call node for is_numpy_api"
-    func_str = astor.to_source(gast.gast_to_ast(node.func))
-    try:
-        import numpy as np
-        module_result = eval("_is_api_in_module_helper({}, '{}')".format(
-            func_str, "numpy"))
-        # BUG: np.random.uniform doesn't have module and cannot be analyzed
-        # TODO: find a better way
-        if not module_result:
-            return func_str.startswith("numpy.") or func_str.startswith("np.")
-    except NameError:
-        return False
 
 
 class NodeVarType(object):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
@@ -23,15 +23,11 @@ import warnings
 __all__ = ['AstNodeWrapper', 'NodeVarType', 'StaticAnalysisVisitor']
 
 
-# TODO: _is_paddle_dygraph_api is duplicated in Yamei's utils.py. Merge the two
-# function code together when Yamei finish her PR.
 def _is_api_in_module_helper(obj, module_prefix):
     m = inspect.getmodule(obj)
     return m is not None and m.__name__.startswith(module_prefix)
 
 
-# TODO: is_dygraph_api is duplicated in Yamei's utils.py. Merge the two
-# function code together when Yamei finish her PR.
 def is_api_in_module(node, module_prefix):
     assert isinstance(node, gast.Call), "Input non-Call node for is_dygraph_api"
     func_str = astor.to_source(gast.gast_to_ast(node.func))

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 import inspect
 import gast
 import astor
-from .static_analysis import is_dygraph_api
 
 dygraph_class_to_static_api = {
     "CosineDecay": "cosine_decay",
@@ -28,6 +27,47 @@ dygraph_class_to_static_api = {
     "PiecewiseDecay": "piecewise_decay",
     "PolynomialDecay": "polynomial_decay",
 }
+
+
+def _is_api_in_module_helper(obj, module_prefix):
+    m = inspect.getmodule(obj)
+    return m is not None and m.__name__.startswith(module_prefix)
+
+
+def is_api_in_module(node, module_prefix):
+    assert isinstance(node, gast.Call), "Input non-Call node for is_dygraph_api"
+    func_str = astor.to_source(gast.gast_to_ast(node.func))
+    try:
+        import paddle.fluid as fluid
+        import paddle
+        return eval("_is_api_in_module_helper({}, '{}')".format(func_str,
+                                                                module_prefix))
+    except NameError:
+        return False
+
+
+def is_dygraph_api(node):
+    return is_api_in_module(node, "paddle.fluid.dygraph")
+
+
+def is_paddle_api(node):
+    return is_api_in_module(node, "paddle.fluid")
+
+
+# Is numpy_api cannot reuse is_api_in_module because of numpy module problem
+def is_numpy_api(node):
+    assert isinstance(node, gast.Call), "Input non-Call node for is_numpy_api"
+    func_str = astor.to_source(gast.gast_to_ast(node.func))
+    try:
+        import numpy as np
+        module_result = eval("_is_api_in_module_helper({}, '{}')".format(
+            func_str, "numpy"))
+        # BUG: np.random.uniform doesn't have module and cannot be analyzed
+        # TODO: find a better way
+        if not module_result:
+            return func_str.startswith("numpy.") or func_str.startswith("np.")
+    except NameError:
+        return False
 
 
 def _delete_keywords_from(node):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -17,41 +17,22 @@ from __future__ import print_function
 import inspect
 import gast
 import astor
-import atexit
-import os
-import tempfile
-import six
-import imp
+from .static_analysis import is_dygraph_api
 
 dygraph_class_to_static_api = {
-    "BatchNorm": "batch_norm",
-    "BilinearTensorProduct": "bilinear_tensor_product",
-    "Conv2D": "conv2d",
-    "Conv3D": "conv3d",
-    "Conv2DTranspose": "conv2d_transpose",
-    "Conv3DTranspose": "conv3d_transpose",
     "CosineDecay": "cosine_decay",
-    "Embedding": "embedding",
     "ExponentialDecay": "exponential_decay",
-    "GroupNorm": "group_norm",
-    "GRUUnit": "gru_unit",
     "InverseTimeDecay": "inverse_time_decay",
-    "LayerNorm": "layer_norm",
-    "Linear": "fc",
     "NaturalExpDecay": "natural_exp_decay",
-    "NCE": "nce",
     "NoamDecay": "noam_decay",
     "PiecewiseDecay": "piecewise_decay",
     "PolynomialDecay": "polynomial_decay",
-    "Pool2D": "pool2d",
-    "PRelu": "prelu",
-    "SpectralNorm": "spectral_norm",
 }
 
 
 def _delete_keywords_from(node):
     assert isinstance(node, gast.Call)
-    func_src = astor.to_source(node.func)
+    func_src = astor.to_source(gast.gast_to_ast(node.func))
     import paddle.fluid as fluid
     full_args = eval("inspect.getargspec({})".format(func_src))
     full_args_name = full_args[0]
@@ -92,21 +73,6 @@ def _add_keywords_to(node, dygraph_api_name):
             if ast_keyword.arg == "input":
                 ast_keyword.arg = "x"
     return
-
-
-def _is_paddle_dygraph_api(obj):
-    m = inspect.getmodule(obj)
-    return m is not None and m.__name__.startswith("paddle.fluid.dygraph")
-
-
-def is_dygraph_api(node):
-    assert isinstance(node, gast.Call)
-    func_src = astor.to_source(node.func)
-    try:
-        import paddle.fluid as fluid
-        return eval("_is_paddle_dygraph_api({})".format(func_src))
-    except NameError:
-        return False
 
 
 def is_to_variable(node):
@@ -158,7 +124,7 @@ def update_args_of_func(node, dygraph_node, method_name):
             "The method name of class to update args should be '__init__' or 'forward'"
         )
 
-    class_src = astor.to_source(dygraph_node.func)
+    class_src = astor.to_source(gast.gast_to_ast(dygraph_node.func))
     import paddle.fluid as fluid
     if method_name == "__init__" or eval(
             "issubclass({}, fluid.dygraph.Layer)".format(class_src)):

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -75,7 +75,7 @@ def _dygraph_to_static_output_(dygraph_func):
         else:
             feed_name_to_idx = dygraph_to_static.get_feed_name_to_idx()
             feed_dict = {}
-            for feed_name, idx in feed_name_to_idx.iteritems():
+            for feed_name, idx in feed_name_to_idx.items():
                 feed_dict[feed_name] = args[idx]
 
             # Run static_func in static mode
@@ -99,7 +99,7 @@ def run_static_func(main_program, startup_program, static_func, args, kwargs,
 
     with fluid.program_guard(main_program, startup_program):
         args_list = list(args)
-        for var_name, value in feed_dict.iteritems():
+        for var_name, value in feed_dict.items():
             idx = feed_name_to_idx[var_name]
             args_list[idx] = fluid.data(
                 name=var_name, shape=value.shape, dtype=str(value.dtype))

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -337,6 +337,7 @@ set_tests_properties(test_parallel_executor_seresnext_with_reduce_cpu PROPERTIES
 set_tests_properties(test_parallel_executor_seresnext_with_fuse_all_reduce_cpu PROPERTIES TIMEOUT 750)
 
 add_subdirectory(sequence)
+add_subdirectory(dygraph_to_static)
 
 if (WITH_NGRAPH)
     add_subdirectory(ngraph)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/CMakeLists.txt
@@ -1,0 +1,6 @@
+file(GLOB TEST_OPS RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}" "test_*.py")
+string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
+
+foreach(TEST_OP ${TEST_OPS})
+    py_test_modules(${TEST_OP} MODULES ${TEST_OP})
+endforeach(TEST_OP)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fetch_feed.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fetch_feed.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from paddle.fluid.dygraph.jit import dygraph_to_static_output, dygraph_run_in_static_mode
+
+import numpy as np
+import unittest
+
+import paddle.fluid as fluid
+
+SEED = 2020
+
+
+class MyPool2D(fluid.dygraph.Layer):
+    def __init__(self):
+        super(MyPool2D, self).__init__()
+        self.pool2d = fluid.dygraph.Pool2D(
+            pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
+
+    @dygraph_run_in_static_mode
+    def forward(self, x):
+        inputs = fluid.dygraph.to_variable(x)
+        hidden = self.pool2d(inputs)
+        return hidden, inputs
+
+
+# without Param
+class TestPool2D(unittest.TestCase):
+    def setUp(self):
+        self.dygraph_class = MyPool2D
+        self.data = np.random.random((1, 2, 4, 4)).astype('float32')
+
+    def run_dygraph_mode(self):
+        with fluid.dygraph.guard():
+            dy_layer = self.dygraph_class()
+            for _ in range(1):
+                _, prediction = dy_layer(self.data)
+                return prediction
+
+    def run_static_mode(self):
+        startup_prog = fluid.Program()
+        main_prog = fluid.Program()
+        with fluid.program_guard(main_prog, startup_prog):
+            dy_layer = self.dygraph_class()
+            out, _ = dy_layer(self.data)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            res = exe.run(main_prog, fetch_list=out)
+            return res
+
+    def test_static_output(self):
+        dygraph_res = self.run_dygraph_mode()
+        static_res = self.run_static_mode()
+        self.assertTrue(
+            np.allclose(dygraph_res[0], static_res[0]),
+            msg='dygraph is {}\n static_res is \n{}'.format(dygraph_res,
+                                                            static_res))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fetch_feed.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_fetch_feed.py
@@ -24,15 +24,26 @@ import paddle.fluid as fluid
 SEED = 2020
 
 
-class MyPool2D(fluid.dygraph.Layer):
+class Pool2D(fluid.dygraph.Layer):
     def __init__(self):
-        super(MyPool2D, self).__init__()
-        # self.pool2d = fluid.dygraph.Pool2D(
-        #     pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
+        super(Pool2D, self).__init__()
+        self.pool2d = fluid.dygraph.Pool2D(
+            pool_size=2, pool_type='avg', pool_stride=1, global_pooling=False)
 
     @dygraph_to_static_output
     def forward(self, x):
-        self.fc = fluid.dygraph.Linear(
+        inputs = fluid.dygraph.to_variable(x)
+        pre = self.pool2d(inputs)
+        return pre
+
+
+class Linear(fluid.dygraph.Layer):
+    def __init__(self):
+        super(Linear, self).__init__()
+
+    @dygraph_to_static_output
+    def forward(self, x):
+        fc = fluid.dygraph.Linear(
             input_dim=10,
             output_dim=5,
             act='relu',
@@ -41,16 +52,14 @@ class MyPool2D(fluid.dygraph.Layer):
             bias_attr=fluid.ParamAttr(initializer=fluid.initializer.Constant(
                 value=0.5)))
         inputs = fluid.dygraph.to_variable(x)
-        # hidden = self.pool2d(inputs)
-        pre = self.fc(inputs)
+        pre = fc(inputs)
         return pre
 
 
 class TestPool2D(unittest.TestCase):
     def setUp(self):
-        self.dygraph_class = MyPool2D
-        # self.data = np.random.random((1, 2, 4, 4)).astype('float32')
-        self.data = np.random.random((4, 10)).astype('float32')
+        self.dygraph_class = Pool2D
+        self.data = np.random.random((1, 2, 4, 4)).astype('float32')
 
     def run_dygraph_mode(self):
         with fluid.dygraph.guard():
@@ -58,7 +67,6 @@ class TestPool2D(unittest.TestCase):
             for _ in range(1):
 
                 prediction = dy_layer(x=self.data)
-                print("*" * 20)
                 return prediction
 
     def run_static_mode(self):
@@ -74,12 +82,18 @@ class TestPool2D(unittest.TestCase):
 
     def test_static_output(self):
         dygraph_res = self.run_dygraph_mode()
-        # static_res = self.run_static_mode()
-        # self.assertTrue(
-        #     np.allclose(dygraph_res[0], static_res[0]),
-        #     msg='dygraph is {}\n static_res is \n{}'.format(dygraph_res,
-        #                                                     static_res))
-        # return
+        static_res = self.run_static_mode()
+        self.assertTrue(
+            np.allclose(dygraph_res[0], static_res[0]),
+            msg='dygraph is {}\n static_res is \n{}'.format(dygraph_res,
+                                                            static_res))
+        return
+
+
+class TestLinear(unittest.TestCase):
+    def setUp(self):
+        self.dygraph_class = Linear
+        self.data = np.random.random((4, 10)).astype('float32')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Support fetch and feed data in dygraph mode when `dygraph_to_static_output` is called.

2. Remove some dygraph APIs which don't have to be transformed
eg: Conv2D, Linear

3. Remove repetitive functions in file utils.py and static_analysis.py