### PR TITLE
Fix inference c api PD_GetZeroCopyOutput lod

### DIFF
--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -232,7 +232,8 @@ void PD_SetZeroCopyInput(PD_Predictor* predictor,
 
   if (tensor->lod.length) {
     auto* lod_ptr = reinterpret_cast<size_t*>(tensor->lod.data);
-    std::vector<size_t> lod(lod_ptr, lod_ptr + tensor->lod.length);
+    std::vector<size_t> lod;
+    lod.assign(lod_ptr, lod_ptr + tensor->lod.length / sizeof(size_t));
     input->SetLoD({std::move(lod)});
   }
 }

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -399,3 +399,7 @@ if(WITH_MKLDNN)
             EXTRA_DEPS ${INFERENCE_EXTRA_DEPS} paddle_fluid_c
             ARGS --infer_model=${INT8_DATA_DIR}/resnet50/model)
  endif()
+
+inference_analysis_test(test_analyzer_capi_ner SRCS analyzer_capi_ner_tester.cc 
+        EXTRA_DEPS ${INFERENCE_EXTRA_DEPS} paddle_fluid_c
+        ARGS --infer_model=${CHINESE_NER_INSTALL_DIR}/model)

--- a/paddle/fluid/inference/tests/api/analyzer_capi_gpu_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_gpu_tester.cc
@@ -15,8 +15,6 @@ limitations under the License. */
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <fstream>
-#include <iostream>
 #include <string>
 #include <vector>
 #include "paddle/fluid/inference/capi/paddle_c_api.h"

--- a/paddle/fluid/inference/tests/api/analyzer_capi_int_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_int_tester.cc
@@ -15,8 +15,6 @@ limitations under the License. */
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <fstream>
-#include <iostream>
 #include <string>
 #include <vector>
 #include "paddle/fluid/inference/capi/paddle_c_api.h"

--- a/paddle/fluid/inference/tests/api/analyzer_capi_ner_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_ner_tester.cc
@@ -15,8 +15,6 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <fstream>
-#include <iostream>
 #include <string>
 #include <vector>
 #include "paddle/fluid/inference/capi/paddle_c_api.h"
@@ -49,7 +47,9 @@ TEST(PD_ZeroCopyRun, zero_copy_run) {
 
   // inputs[0]: word
   PD_InitZeroCopyTensor(&inputs[0]);
-  inputs[0].name = const_cast<char *>(PD_GetInputName(predictor, 0));
+  inputs[0].name = new char[5];
+  snprintf(inputs[0].name, sizeof(PD_GetInputName(predictor, 0)) + 1, "%s",
+           PD_GetInputName(predictor, 0));
 
   inputs[0].data.capacity = sizeof(int64_t) * 11 * 1;
   inputs[0].data.length = inputs[0].data.capacity;
@@ -73,7 +73,9 @@ TEST(PD_ZeroCopyRun, zero_copy_run) {
 
   // inputs[1]: mention
   PD_InitZeroCopyTensor(&inputs[1]);
-  inputs[1].name = const_cast<char *>(PD_GetInputName(predictor, 1));
+  inputs[1].name = new char[8];
+  snprintf(inputs[1].name, sizeof(PD_GetInputName(predictor, 1)) + 1, "%s",
+           PD_GetInputName(predictor, 1));
 
   inputs[1].data.capacity = sizeof(int64_t) * 11 * 1;
   inputs[1].data.length = inputs[1].data.capacity;
@@ -97,9 +99,11 @@ TEST(PD_ZeroCopyRun, zero_copy_run) {
   PD_ZeroCopyRun(predictor);
   PD_ZeroCopyTensor output;
   PD_InitZeroCopyTensor(&output);
-  output.name = const_cast<char *>(PD_GetOutputName(predictor, 0));
+  output.name = new char[21];
+  snprintf(output.name, sizeof("crf_decoding_0.tmp_0") + 1, "%s",
+           PD_GetOutputName(predictor, 0));
 
-  // for tests converage
+  // not necessary, just for converage tests
   output.lod.data = std::malloc(sizeof(size_t));
 
   PD_GetZeroCopyOutput(predictor, &output);

--- a/paddle/fluid/inference/tests/api/analyzer_capi_ner_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_ner_tester.cc
@@ -1,0 +1,113 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+#include "paddle/fluid/inference/capi/paddle_c_api.h"
+#include "paddle/fluid/inference/tests/api/tester_helper.h"
+
+namespace paddle {
+namespace inference {
+namespace analysis {
+
+void SetConfig(PD_AnalysisConfig *config) {
+  auto model_dir = FLAGS_infer_model;
+  PD_SetModel(config, (model_dir + "/__model__").c_str(),
+              (model_dir + "/param").c_str());
+  PD_SwitchUseFeedFetchOps(config, false);
+  PD_SwitchSpecifyInputNames(config, true);
+  PD_DisableGpu(config);
+}
+
+TEST(PD_ZeroCopyRun, zero_copy_run) {
+  PD_AnalysisConfig *config = PD_NewAnalysisConfig();
+  SetConfig(config);
+  PD_Predictor *predictor = PD_NewPredictor(config);
+
+  int input_num = PD_GetInputNum(predictor);
+  printf("Input num: %d\n", input_num);
+  int output_num = PD_GetOutputNum(predictor);
+  printf("Output num: %d\n", output_num);
+
+  PD_ZeroCopyTensor inputs[2];
+
+  // inputs[0]: word
+  PD_InitZeroCopyTensor(&inputs[0]);
+  inputs[0].name = const_cast<char *>(PD_GetInputName(predictor, 0));
+
+  inputs[0].data.capacity = sizeof(int64_t) * 11 * 1;
+  inputs[0].data.length = inputs[0].data.capacity;
+  inputs[0].data.data = malloc(inputs[0].data.capacity);
+  std::vector<int64_t> ref_word(
+      {12673, 9763, 905, 284, 45, 7474, 20, 17, 1, 4, 9});
+  inputs[0].data.data = reinterpret_cast<void *>(ref_word.data());
+
+  int shape0[] = {11, 1};
+  inputs[0].shape.data = reinterpret_cast<void *>(shape0);
+  inputs[0].shape.capacity = sizeof(shape0);
+  inputs[0].shape.length = sizeof(shape0);
+  inputs[0].dtype = PD_INT64;
+
+  size_t lod0[] = {0, 11};
+  inputs[0].lod.data = reinterpret_cast<void *>(lod0);
+  inputs[0].lod.capacity = sizeof(size_t) * 2;
+  inputs[0].lod.length = sizeof(size_t) * 2;
+
+  PD_SetZeroCopyInput(predictor, &inputs[0]);
+
+  // inputs[1]: mention
+  PD_InitZeroCopyTensor(&inputs[1]);
+  inputs[1].name = const_cast<char *>(PD_GetInputName(predictor, 1));
+
+  inputs[1].data.capacity = sizeof(int64_t) * 11 * 1;
+  inputs[1].data.length = inputs[1].data.capacity;
+  inputs[1].data.data = malloc(inputs[1].data.capacity);
+  std::vector<int64_t> ref_mention({27, 0, 0, 33, 34, 33, 0, 0, 0, 1, 2});
+  inputs[1].data.data = reinterpret_cast<void *>(ref_mention.data());
+
+  int shape1[] = {11, 1};
+  inputs[1].shape.data = reinterpret_cast<void *>(shape1);
+  inputs[1].shape.capacity = sizeof(shape1);
+  inputs[1].shape.length = sizeof(shape1);
+  inputs[1].dtype = PD_INT64;
+
+  size_t lod1[] = {0, 11};
+  inputs[1].lod.data = reinterpret_cast<void *>(lod1);
+  inputs[1].lod.capacity = sizeof(size_t) * 2;
+  inputs[1].lod.length = sizeof(size_t) * 2;
+
+  PD_SetZeroCopyInput(predictor, &inputs[1]);
+
+  PD_ZeroCopyRun(predictor);
+  PD_ZeroCopyTensor output;
+  PD_InitZeroCopyTensor(&output);
+  output.name = const_cast<char *>(PD_GetOutputName(predictor, 0));
+
+  // for tests converage
+  output.lod.data = std::malloc(sizeof(size_t));
+
+  PD_GetZeroCopyOutput(predictor, &output);
+  PD_DestroyZeroCopyTensor(&output);
+  PD_DeleteAnalysisConfig(config);
+  PD_DeletePredictor(predictor);
+}
+
+}  // namespace analysis
+}  // namespace inference
+}  // namespace paddle

--- a/paddle/fluid/inference/tests/api/analyzer_capi_ner_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_ner_tester.cc
@@ -48,7 +48,7 @@ TEST(PD_ZeroCopyRun, zero_copy_run) {
   // inputs[0]: word
   PD_InitZeroCopyTensor(&inputs[0]);
   inputs[0].name = new char[5];
-  snprintf(inputs[0].name, sizeof(PD_GetInputName(predictor, 0)) + 1, "%s",
+  snprintf(inputs[0].name, strlen(PD_GetInputName(predictor, 0)) + 1, "%s",
            PD_GetInputName(predictor, 0));
 
   inputs[0].data.capacity = sizeof(int64_t) * 11 * 1;
@@ -74,7 +74,7 @@ TEST(PD_ZeroCopyRun, zero_copy_run) {
   // inputs[1]: mention
   PD_InitZeroCopyTensor(&inputs[1]);
   inputs[1].name = new char[8];
-  snprintf(inputs[1].name, sizeof(PD_GetInputName(predictor, 1)) + 1, "%s",
+  snprintf(inputs[1].name, strlen(PD_GetInputName(predictor, 1)) + 1, "%s",
            PD_GetInputName(predictor, 1));
 
   inputs[1].data.capacity = sizeof(int64_t) * 11 * 1;
@@ -100,7 +100,7 @@ TEST(PD_ZeroCopyRun, zero_copy_run) {
   PD_ZeroCopyTensor output;
   PD_InitZeroCopyTensor(&output);
   output.name = new char[21];
-  snprintf(output.name, sizeof("crf_decoding_0.tmp_0") + 1, "%s",
+  snprintf(output.name, strlen(PD_GetOutputName(predictor, 0)) + 1, "%s",
            PD_GetOutputName(predictor, 0));
 
   // not necessary, just for converage tests

--- a/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
@@ -15,8 +15,6 @@ limitations under the License. */
 #include <stddef.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <fstream>
-#include <iostream>
 #include <string>
 #include <vector>
 #include "paddle/fluid/inference/capi/paddle_c_api.h"

--- a/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_capi_tester.cc
@@ -71,7 +71,7 @@ void zero_copy_run() {
   delete[] outputs;
 }
 
-TEST(PD_ZeroCopyRun, zero_copy_run) { zero_copy_run(); }
+TEST(PD_PredictorZeroCopyRun, zero_copy_run) { zero_copy_run(); }
 
 #ifdef PADDLE_WITH_MKLDNN
 TEST(PD_AnalysisConfig, profile_mkldnn) {


### PR DESCRIPTION
Fix inference c api `PD_GetZeroCopyOutput` obtaining lod.
Before this fix, if the lod of the output is empty, `lod.front()` will core when get output of the predictor. 
This PR fix this this problem. 
Moreover, add unit tests for new c api tests. 