### PR TITLE
add sum op support for fusion group

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/code_generator.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.cc
@@ -66,10 +66,9 @@ std::vector<OperationExpression> CodeGenerator::ConvertToExpressions(
       for (auto& name : input_names) {
         // Some input vars are not used in grad ops, such as
         // "elementwise_add_grad", where "X", "Y" and "Out" are not used.
-        size_t op_input_size = op->Input(name).size();
 
-        if ((HasInput(node, name) && op_input_size >= 1U)) {
-          for (size_t i = 0; i < op_input_size; i++) {
+        if ((HasInput(node, name) && op->Input(name).size() >= 1U)) {
+          for (size_t i = 0; i < op->Input(name).size(); i++) {
             PADDLE_ENFORCE_NE(
                 var_ids.find(op->Input(name)[i]), var_ids.end(),
                 platform::errors::InvalidArgument(

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -33,8 +33,8 @@ static T StringTo(const std::string& str) {
   return value;
 }
 
-static std::string GetSumExpectedRHS(const std::string rhs,
-                                     const size_t input_size) {
+static std::string GetMultivariateRHS(const std::string rhs,
+                                      const size_t input_size) {
   int start_pos = rhs.find("[", 0);
   int end_pos = rhs.find("]", 0);
   std::string sum_rhs = rhs.substr(0, start_pos);
@@ -53,9 +53,10 @@ static std::string GetSumExpectedRHS(const std::string rhs,
 std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
                                         size_t exprs_index) const {
   auto rhs = OperationMap::Instance().Get(op_type_).exprs[exprs_index];
-  if (op_type_ == "sum") {
+  auto num_operands = OperationMap::Instance().Get(op_type_).num_operands;
+  if (num_operands == -1) {
     size_t input_size = input_ids_.size();
-    rhs = GetSumExpectedRHS(rhs, input_size);
+    rhs = GetMultivariateRHS(rhs, input_size);
   }
 
   for (size_t i = 0; i < rhs.size(); i++) {

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -50,12 +50,9 @@ std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
   auto rhs = OperationMap::Instance().Get(op_type_).exprs[exprs_index];
   if (op_type_ == "sum") {
     size_t input_size = input_ids_.size();
-    for (size_t i = 0; i < input_size; i++) {
-      VLOG(0) << "input id: " << input_ids_[i];
-    }
     rhs = GetSumExpectedRHS(rhs, input_size);
-    VLOG(0) << "sum rhs: " << rhs;
   }
+
   for (size_t i = 0; i < rhs.size(); i++) {
     size_t pos = i;
     if (rhs[pos] == '$' && rhs[pos + 1] == '{') {

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -35,13 +35,18 @@ static T StringTo(const std::string& str) {
 
 static std::string GetSumExpectedRHS(const std::string rhs,
                                      const size_t input_size) {
-  std::string sum_rhs = rhs;
-  int start_pos = sum_rhs.find("...", 0);
-  for (size_t i = 0; i < input_size; i++) {
-    sum_rhs = sum_rhs.replace(start_pos, 3, std::to_string(i)) + rhs;
-    start_pos = sum_rhs.find("...", 0);
+  int start_pos = rhs.find("[", 0);
+  int end_pos = rhs.find("]", 0);
+  std::string sum_rhs = rhs.substr(0, start_pos);
+  std::string sum_rhs_component =
+      rhs.substr(start_pos + 1, (end_pos - start_pos - 1));
+  int replace_pos = sum_rhs_component.find("?", 0);
+
+  for (size_t i = 1; i < input_size; i++) {
+    std::string append_str =
+        sum_rhs_component.replace(replace_pos, 1, std::to_string(i));
+    sum_rhs = sum_rhs + append_str;
   }
-  sum_rhs.replace(start_pos - 5, (sum_rhs.length() - start_pos + 5), "");
   return sum_rhs;
 }
 

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -33,9 +33,29 @@ static T StringTo(const std::string& str) {
   return value;
 }
 
+static std::string GetSumExpectedRHS(const std::string rhs,
+                                     const size_t input_size) {
+  std::string sum_rhs = rhs;
+  int start_pos = sum_rhs.find("...", 0);
+  for (size_t i = 0; i < input_size; i++) {
+    sum_rhs = sum_rhs.replace(start_pos, 3, std::to_string(i)) + rhs;
+    start_pos = sum_rhs.find("...", 0);
+  }
+  sum_rhs.replace(start_pos - 5, (sum_rhs.length() - start_pos + 5), "");
+  return sum_rhs;
+}
+
 std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
-                                        size_t i) const {
-  auto rhs = OperationMap::Instance().Get(op_type_).exprs[i];
+                                        size_t exprs_index) const {
+  auto rhs = OperationMap::Instance().Get(op_type_).exprs[exprs_index];
+  if (op_type_ == "sum") {
+    size_t input_size = input_ids_.size();
+    for (size_t i = 0; i < input_size; i++) {
+      VLOG(0) << "input id: " << input_ids_[i];
+    }
+    rhs = GetSumExpectedRHS(rhs, input_size);
+    VLOG(0) << "sum rhs: " << rhs;
+  }
   for (size_t i = 0; i < rhs.size(); i++) {
     size_t pos = i;
     if (rhs[pos] == '$' && rhs[pos + 1] == '{') {

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -33,8 +33,8 @@ static T StringTo(const std::string& str) {
   return value;
 }
 
-static std::string GetMultivariateRHS(const std::string rhs,
-                                      const size_t input_size) {
+static std::string ExpandMultivariateTemplate(const std::string rhs,
+                                              const size_t input_size) {
   int start_pos = rhs.find("[", 0);
   int end_pos = rhs.find("]", 0);
   std::string sum_rhs = rhs.substr(0, start_pos);
@@ -56,7 +56,7 @@ std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
   auto num_operands = OperationMap::Instance().Get(op_type_).num_operands;
   if (num_operands == -1) {
     size_t input_size = input_ids_.size();
-    rhs = GetMultivariateRHS(rhs, input_size);
+    rhs = ExpandMultivariateTemplate(rhs, input_size);
   }
 
   for (size_t i = 0; i < rhs.size(); i++) {

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
@@ -52,7 +52,8 @@ class OperationExpression {
 
  private:
   // TODO(wangchao): make offset more flexible we add stride and basic offset
-  std::string GetRHS(std::unordered_set<int>* used, size_t i = 0) const;
+  std::string GetRHS(std::unordered_set<int>* used,
+                     size_t exprs_index = 0) const;
   std::string GetLHS(size_t i = 0) const;
 
  private:

--- a/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
+++ b/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
@@ -79,39 +79,7 @@ static bool IsEqualAndNotEmpty(const std::vector<int64_t>& l,
   return l.size() != 0U && r.size() != 0U && l == r;
 }
 
-static bool IsBinaryOp(const Node* n) {
-  if (IsSpecifiedOp(GetBinaryOpTypes(), n)) {
-    if ((!IsGradOp(n) && n->inputs.size() != 2U) || n->inputs.size() == 0U) {
-      return false;
-    }
-
-    // The shape of all inputs should be the same.
-    std::vector<int64_t> shape_0;
-    for (size_t i = 0; i < n->inputs.size(); ++i) {
-      auto* in_i = n->inputs[i];
-      if (!(in_i && in_i->IsVar() && in_i->Var())) {
-        return false;
-      }
-
-      std::vector<int64_t> shape_i = in_i->Var()->GetShape();
-      if (i == 0U) {
-        shape_0 = shape_i;
-      } else {
-        if (!IsEqualAndNotEmpty(shape_0, shape_i)) {
-          return false;
-        }
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
-static bool IsUnaryOp(const Node* n) {
-  return IsSpecifiedOp(GetUnaryOpTypes(), n);
-}
-
-static bool IsMultivariateOp(const Node* n) {
+bool ElementwiseGroupDetector::IsElementwiseOp(const Node* n) {
   if (IsSpecifiedOp(GetMultivariateOpTypes(), n)) {
     std::vector<int64_t> shape_0;
     for (size_t i = 0; i < n->inputs.size(); ++i) {
@@ -132,10 +100,6 @@ static bool IsMultivariateOp(const Node* n) {
     return true;
   }
   return false;
-}
-
-bool ElementwiseGroupDetector::IsElementwiseOp(const Node* n) {
-  return IsBinaryOp(n) || IsUnaryOp(n) || IsMultivariateOp(n);
 }
 
 std::vector<std::vector<Node*>> ElementwiseGroupDetector::operator()(

--- a/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
+++ b/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
@@ -24,32 +24,13 @@ namespace framework {
 namespace ir {
 namespace fusion_group {
 
-static std::unordered_set<std::string> binary_op_types;
-static std::unordered_set<std::string> unary_op_types;
-static std::unordered_set<std::string> multivariate_op_types;
+static std::unordered_set<std::string> elementwise_op_types;
 
-static std::unordered_set<std::string>& GetBinaryOpTypes() {
-  if (binary_op_types.empty()) {
-    binary_op_types =
-        OperationMap::Instance().Find(/* type= */ 0, /* num_operands= */ 2);
+static std::unordered_set<std::string>& GetElementwiseOpTypes() {
+  if (elementwise_op_types.empty()) {
+    elementwise_op_types = OperationMap::Instance().Find(/* type= */ 0);
   }
-  return binary_op_types;
-}
-
-static std::unordered_set<std::string>& GetUnaryOpTypes() {
-  if (unary_op_types.empty()) {
-    unary_op_types =
-        OperationMap::Instance().Find(/* type= */ 0, /* num_operands= */ 1);
-  }
-  return unary_op_types;
-}
-
-static std::unordered_set<std::string>& GetMultivariateOpTypes() {
-  if (multivariate_op_types.empty()) {
-    multivariate_op_types =
-        OperationMap::Instance().Find(/* type= */ 0, /* num_operands= */ -1);
-  }
-  return multivariate_op_types;
+  return elementwise_op_types;
 }
 
 static bool IsSpecifiedOp(const std::unordered_set<std::string>& op_types,
@@ -80,7 +61,7 @@ static bool IsEqualAndNotEmpty(const std::vector<int64_t>& l,
 }
 
 bool ElementwiseGroupDetector::IsElementwiseOp(const Node* n) {
-  if (IsSpecifiedOp(GetMultivariateOpTypes(), n)) {
+  if (IsSpecifiedOp(GetElementwiseOpTypes(), n)) {
     std::vector<int64_t> shape_0;
     for (size_t i = 0; i < n->inputs.size(); ++i) {
       auto* in_i = n->inputs[i];

--- a/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
+++ b/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
@@ -26,7 +26,7 @@ namespace fusion_group {
 
 static std::unordered_set<std::string> binary_op_types;
 static std::unordered_set<std::string> unary_op_types;
-static std::unordered_set<std::string> special_op_types;
+static std::unordered_set<std::string> multivariate_op_types;
 
 static std::unordered_set<std::string>& GetBinaryOpTypes() {
   if (binary_op_types.empty()) {
@@ -44,12 +44,12 @@ static std::unordered_set<std::string>& GetUnaryOpTypes() {
   return unary_op_types;
 }
 
-static std::unordered_set<std::string>& GetSpecialOpTypes() {
-  if (special_op_types.empty()) {
-    special_op_types =
+static std::unordered_set<std::string>& GetMultivariateOpTypes() {
+  if (multivariate_op_types.empty()) {
+    multivariate_op_types =
         OperationMap::Instance().Find(/* type= */ 0, /* num_operands= */ -1);
   }
-  return special_op_types;
+  return multivariate_op_types;
 }
 
 static bool IsSpecifiedOp(const std::unordered_set<std::string>& op_types,
@@ -111,8 +111,8 @@ static bool IsUnaryOp(const Node* n) {
   return IsSpecifiedOp(GetUnaryOpTypes(), n);
 }
 
-static bool IsSpecialOp(const Node* n) {
-  if (IsSpecifiedOp(GetSpecialOpTypes(), n)) {
+static bool IsMultivariateOp(const Node* n) {
+  if (IsSpecifiedOp(GetMultivariateOpTypes(), n)) {
     std::vector<int64_t> shape_0;
     for (size_t i = 0; i < n->inputs.size(); ++i) {
       auto* in_i = n->inputs[i];
@@ -135,7 +135,7 @@ static bool IsSpecialOp(const Node* n) {
 }
 
 bool ElementwiseGroupDetector::IsElementwiseOp(const Node* n) {
-  return IsBinaryOp(n) || IsUnaryOp(n) || IsSpecialOp(n);
+  return IsBinaryOp(n) || IsUnaryOp(n) || IsMultivariateOp(n);
 }
 
 std::vector<std::vector<Node*>> ElementwiseGroupDetector::operator()(

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -160,10 +160,10 @@ void OperationMap::InsertSpecialElementwiseOperations() {
     int type = 0;
     int num_oprands = -1;
     // here ... represent the number of input is changed
-    Insert(type, num_oprands, op_type, expr, grad_exprs, {}, {"Out"});
+    Insert(type, num_oprands, op_type, expr, grad_exprs, {"X"}, {"Out"});
   };
 
-  insert_handler("sum", "${...} + ", {});
+  insert_handler("sum", "${0}[ + ${?}]", {});
 }
 
 }  // namespace fusion_group

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -28,11 +28,10 @@ OperationMap::OperationMap() {
   InsertMultivariateElementwiseOperations();
 }
 
-std::unordered_set<std::string> OperationMap::Find(int type, int num_operands) {
+std::unordered_set<std::string> OperationMap::Find(int type) {
   std::unordered_set<std::string> res;
   for (auto& t : operations_) {
-    if ((t.second.type == type) &&
-        (num_operands < 0 || t.second.num_operands == num_operands)) {
+    if (t.second.type == type) {
       res.insert(t.first);
     }
   }

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -25,6 +25,7 @@ OperationMap* OperationMap::map = nullptr;
 OperationMap::OperationMap() {
   InsertUnaryElementwiseOperations();
   InsertBinaryElementwiseOperations();
+  InsertSpecialElementwiseOperations();
 }
 
 std::unordered_set<std::string> OperationMap::Find(int type, int num_operands) {
@@ -151,6 +152,17 @@ void OperationMap::InsertBinaryElementwiseOperations() {
   //  dy = dout * (x <= y)
   insert_handler("elementwise_max", "${0} > ${1} ? ${0} : ${1}",
                  {"${3} * (${0} > ${1})", "${3} * (${0} <= ${1})"});
+}
+
+void OperationMap::InsertSpecialElementwiseOperations() {
+  auto insert_handler = [&](std::string op_type, std::string expr,
+                            std::vector<std::string> grad_exprs) {
+    int type = 0;
+    int num_oprands = -1;
+    Insert(type, num_oprands, op_type, expr, grad_exprs, {"X", "Y"}, {"Out"});
+  };
+
+  insert_handler("sum", "${...} + ", {});
 }
 
 }  // namespace fusion_group

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -25,7 +25,7 @@ OperationMap* OperationMap::map = nullptr;
 OperationMap::OperationMap() {
   InsertUnaryElementwiseOperations();
   InsertBinaryElementwiseOperations();
-  InsertSpecialElementwiseOperations();
+  InsertMultivariateElementwiseOperations();
 }
 
 std::unordered_set<std::string> OperationMap::Find(int type, int num_operands) {
@@ -154,7 +154,7 @@ void OperationMap::InsertBinaryElementwiseOperations() {
                  {"${3} * (${0} > ${1})", "${3} * (${0} <= ${1})"});
 }
 
-void OperationMap::InsertSpecialElementwiseOperations() {
+void OperationMap::InsertMultivariateElementwiseOperations() {
   auto insert_handler = [&](std::string op_type, std::string expr,
                             std::vector<std::string> grad_exprs) {
     int type = 0;

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -159,7 +159,8 @@ void OperationMap::InsertSpecialElementwiseOperations() {
                             std::vector<std::string> grad_exprs) {
     int type = 0;
     int num_oprands = -1;
-    Insert(type, num_oprands, op_type, expr, grad_exprs, {"X", "Y"}, {"Out"});
+    // here ... represent the number of input is changed
+    Insert(type, num_oprands, op_type, expr, grad_exprs, {}, {"Out"});
   };
 
   insert_handler("sum", "${...} + ", {});

--- a/paddle/fluid/framework/ir/fusion_group/operation.h
+++ b/paddle/fluid/framework/ir/fusion_group/operation.h
@@ -57,10 +57,6 @@ struct Operation {
     return true;
   }
 
-  void AddInputName(const std::string input_name) {
-    input_names.push_back(input_name);
-  }
-
   int type;
   int num_operands;
   std::string op_type;

--- a/paddle/fluid/framework/ir/fusion_group/operation.h
+++ b/paddle/fluid/framework/ir/fusion_group/operation.h
@@ -57,6 +57,10 @@ struct Operation {
     return true;
   }
 
+  void AddInputName(const std::string input_name) {
+    input_names.push_back(input_name);
+  }
+
   int type;
   int num_operands;
   std::string op_type;

--- a/paddle/fluid/framework/ir/fusion_group/operation.h
+++ b/paddle/fluid/framework/ir/fusion_group/operation.h
@@ -106,6 +106,7 @@ class OperationMap {
 
   void InsertUnaryElementwiseOperations();
   void InsertBinaryElementwiseOperations();
+  void InsertSpecialElementwiseOperations();
 
  private:
   static OperationMap* map;

--- a/paddle/fluid/framework/ir/fusion_group/operation.h
+++ b/paddle/fluid/framework/ir/fusion_group/operation.h
@@ -106,7 +106,7 @@ class OperationMap {
 
   void InsertUnaryElementwiseOperations();
   void InsertBinaryElementwiseOperations();
-  void InsertSpecialElementwiseOperations();
+  void InsertMultivariateElementwiseOperations();
 
  private:
   static OperationMap* map;

--- a/paddle/fluid/framework/ir/fusion_group/operation.h
+++ b/paddle/fluid/framework/ir/fusion_group/operation.h
@@ -84,7 +84,7 @@ class OperationMap {
     return *map;
   }
 
-  std::unordered_set<std::string> Find(int type, int num_operands = -1);
+  std::unordered_set<std::string> Find(int type);
 
   bool Has(std::string op_type) {
     return operations_.find(op_type) != operations_.end();

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
@@ -141,19 +141,6 @@ class FusionGroupPassTestFP16(FusionGroupPassTest):
 class FusionGroupPassSumTest(FusionGroupPassTest):
     def build_program(self, dtype):
         with fluid.program_guard(self.main_program, self.startup_program):
-            self.feed_vars = self._prepare_feed_vars([32, 128], dtype, 4)
-
-            tmp_0 = layers.elementwise_add(self.feed_vars[0], self.feed_vars[1])
-            tmp_1 = layers.sum([tmp_0, self.feed_vars[2], self.feed_vars[3]])
-            #tmp_1 = layers.sum([tmp_0, self.feed_vars[2], self.feed_vars[3]])
-
-        self.fetch_list = [tmp_0, tmp_1]
-        self.num_fused_ops = 1
-
-
-class FusionGroupPassSumTest1(FusionGroupPassTest):
-    def build_program(self, dtype):
-        with fluid.program_guard(self.main_program, self.startup_program):
             self.feed_vars = self._prepare_feed_vars([32, 128], dtype, 5)
 
             tmp_0 = layers.elementwise_add(self.feed_vars[0], self.feed_vars[1])

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
@@ -138,5 +138,31 @@ class FusionGroupPassTestFP16(FusionGroupPassTest):
         self.num_fused_ops = 1
 
 
+class FusionGroupPassSumTest(FusionGroupPassTest):
+    def build_program(self, dtype):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            self.feed_vars = self._prepare_feed_vars([32, 128], dtype, 4)
+
+            tmp_0 = layers.elementwise_add(self.feed_vars[0], self.feed_vars[1])
+            tmp_1 = layers.sum([tmp_0, self.feed_vars[2], self.feed_vars[3]])
+            #tmp_1 = layers.sum([tmp_0, self.feed_vars[2], self.feed_vars[3]])
+
+        self.fetch_list = [tmp_0, tmp_1]
+        self.num_fused_ops = 1
+
+
+class FusionGroupPassSumTest1(FusionGroupPassTest):
+    def build_program(self, dtype):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            self.feed_vars = self._prepare_feed_vars([32, 128], dtype, 5)
+
+            tmp_0 = layers.elementwise_add(self.feed_vars[0], self.feed_vars[1])
+            tmp_1 = layers.sum([tmp_0, self.feed_vars[2], self.feed_vars[3]])
+            tmp_2 = layers.sum([tmp_1, self.feed_vars[4]])
+
+        self.fetch_list = [tmp_0, tmp_1]
+        self.num_fused_ops = 1
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fusion group  now support simple elementwise OP. In this PR, we add sum op support for fusion group.
1. add codegen for sum op in a special way
2. add support of sum fusion in fusion group detection pattern 
3. add some unittest for sum fusion
```
W0228 04:12:07.934985 35030 device_context.cc:237] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 9.0
W0228 04:12:07.940497 35030 device_context.cc:245] device: 0, cuDNN Version: 7.5.
I0228 04:12:09.940064 35030 fusion_group_pass.cc:56] origin: Graph: {
    Node(sum_1.tmp_0{32x128}), inputs:{sum}, outputs:{}
    Node(elementwise_add_0{32x128}), inputs:{elementwise_add}, outputs:{sum}
    Node(data0{32x128}), inputs:{}, outputs:{elementwise_add}
    Node(data1{32x128}), inputs:{}, outputs:{elementwise_add}
  Node(Op(elementwise_add), inputs:{X[data0], Y[data1]}, outputs:{Out[elementwise_add_0]}), inputs:{data0, data1}, outputs:{elementwise_add_0}.
    Node(sum_0.tmp_0{32x128}), inputs:{sum}, outputs:{sum}
    Node(data3{32x128}), inputs:{}, outputs:{sum}
    Node(data2{32x128}), inputs:{}, outputs:{sum}
  Node(Op(sum), inputs:{X[elementwise_add_0, data2, data3]}, outputs:{Out[sum_0.tmp_0]}), inputs:{elementwise_add_0, data2, data3}, outputs:{sum_0.tmp_0}.
  Node(Op(sum), inputs:{X[sum_0.tmp_0, data4]}, outputs:{Out[sum_1.tmp_0]}), inputs:{sum_0.tmp_0, data4}, outputs:{sum_1.tmp_0}.
    Node(data4{32x128}), inputs:{}, outputs:{sum}
}
I0228 04:12:10.145560 35030 fusion_group_pass.cc:60] after code gen: Graph: {
    Node(sum_1.tmp_0{32x128}), inputs:{sum}, outputs:{}
    Node(elementwise_add_0{32x128}), inputs:{elementwise_add}, outputs:{sum}
    Node(data0{32x128}), inputs:{}, outputs:{elementwise_add}
    Node(data1{32x128}), inputs:{}, outputs:{elementwise_add}
  Node(Op(elementwise_add), inputs:{X[data0], Y[data1]}, outputs:{Out[elementwise_add_0]}), inputs:{data0, data1}, outputs:{elementwise_add_0}.
    Node(sum_0.tmp_0{32x128}), inputs:{sum}, outputs:{sum}
    Node(data3{32x128}), inputs:{}, outputs:{sum}
    Node(data2{32x128}), inputs:{}, outputs:{sum}
  Node(Op(sum), inputs:{X[elementwise_add_0, data2, data3]}, outputs:{Out[sum_0.tmp_0]}), inputs:{elementwise_add_0, data2, data3}, outputs:{sum_0.tmp_0}.
  Node(Op(sum), inputs:{X[sum_0.tmp_0, data4]}, outputs:{Out[sum_1.tmp_0]}), inputs:{sum_0.tmp_0, data4}, outputs:{sum_1.tmp_0}.
    Node(data4{32x128}), inputs:{}, outputs:{sum}
}
I0228 04:12:10.145742 35030 fusion_group_pass.cc:63] fusion group:Graph: {
  Node(Op(fusion_group), inputs:{Inputs[data2, data3, data4, data0, data1]}, outputs:{Outs[elementwise_add_0, sum_0.tmp_0, sum_1.tmp_0]}), inputs:{data2, data3, data4, data0, data1}, outputs:{elementwise_add_0, sum_0.tmp_0, sum_1.tmp_0}.
    Node(sum_1.tmp_0{32x128}), inputs:{fusion_group}, outputs:{}
    Node(elementwise_add_0{32x128}), inputs:{fusion_group}, outputs:{}
    Node(data0{32x128}), inputs:{}, outputs:{fusion_group}
    Node(data1{32x128}), inputs:{}, outputs:{fusion_group}
    Node(sum_0.tmp_0{32x128}), inputs:{fusion_group}, outputs:{}
    Node(data3{32x128}), inputs:{}, outputs:{fusion_group}
    Node(data2{32x128}), inputs:{}, outputs:{fusion_group}
    Node(data4{32x128}), inputs:{}, outputs:{fusion_group}
}
```

Gen Code
```cpp
__device__ inline float real_exp(float x) { return ::expf(x); }
__device__ inline float real_log(float x) { return ::logf(x); }


extern "C" __global__ void fused_elementwise_0(int N, float* arg0, float* arg1, float* arg2, float* arg3, float* arg4, float* arg5, float* arg6, float* arg7) {
  for(int idx = blockIdx.x * blockDim.x + threadIdx.x;
      idx < N;
      idx += gridDim.x * blockDim.x) {
    float tmp0 = arg0[idx];
    float tmp1 = arg1[idx];
    float tmp2 = arg2[idx];
    float tmp3 = arg3[idx];
    float tmp4 = arg4[idx];
    float tmp5 = tmp3 + tmp4;
    float tmp6 = tmp5 + tmp0 + tmp1;
    float tmp7 = tmp6 + tmp2;
    arg5[idx] = tmp5;
    arg6[idx] = tmp6;
    arg7[idx] = tmp7;
  }
}
```
