### PR TITLE
improve efficiency of runtime InferVarType

### DIFF
--- a/paddle/fluid/framework/ir/graph_test.cc
+++ b/paddle/fluid/framework/ir/graph_test.cc
@@ -45,19 +45,20 @@ class SumOpMaker : public OpProtoAndCheckerMaker {
 class SumOpVarTypeInference : public VarTypeInference {
  public:
   void operator()(InferVarTypeContext *ctx) const override {
-    auto &inputs = ctx->Input("X");
+    // auto &inputs = ctx->Input("X");
     auto default_var_type = proto::VarType::SELECTED_ROWS;
 
-    bool any_input_is_lod_tensor = std::any_of(
-        inputs.begin(), inputs.end(), [&ctx](const std::string &name) {
-          return ctx->GetType(name) == proto::VarType::LOD_TENSOR;
-        });
-    if (any_input_is_lod_tensor) {
+    // bool any_input_is_lod_tensor = std::any_of(
+    //     inputs.begin(), inputs.end(), [&ctx](const std::string &name) {
+    //       return ctx->GetType(name) == proto::VarType::LOD_TENSOR;
+    //     });
+    // if (any_input_is_lod_tensor) {
+    if (ctx->InputTypeAnyOf("X", proto::VarType::LOD_TENSOR)) {
       default_var_type = proto::VarType::LOD_TENSOR;
     }
 
-    auto out_var_name = ctx->Output("Out").front();
-    ctx->SetType(out_var_name, default_var_type);
+    // auto out_var_name = ctx->Output("Out").front();
+    ctx->SetType("Out", default_var_type);
   }
 };
 

--- a/paddle/fluid/framework/ir/graph_test.cc
+++ b/paddle/fluid/framework/ir/graph_test.cc
@@ -51,7 +51,7 @@ class SumOpVarTypeInference : public VarTypeInference {
       default_var_type = proto::VarType::LOD_TENSOR;
     }
 
-    ctx->SetType("Out", default_var_type);
+    ctx->SetOutputType("Out", default_var_type);
   }
 };
 

--- a/paddle/fluid/framework/ir/graph_test.cc
+++ b/paddle/fluid/framework/ir/graph_test.cc
@@ -45,19 +45,12 @@ class SumOpMaker : public OpProtoAndCheckerMaker {
 class SumOpVarTypeInference : public VarTypeInference {
  public:
   void operator()(InferVarTypeContext *ctx) const override {
-    // auto &inputs = ctx->Input("X");
     auto default_var_type = proto::VarType::SELECTED_ROWS;
 
-    // bool any_input_is_lod_tensor = std::any_of(
-    //     inputs.begin(), inputs.end(), [&ctx](const std::string &name) {
-    //       return ctx->GetType(name) == proto::VarType::LOD_TENSOR;
-    //     });
-    // if (any_input_is_lod_tensor) {
     if (ctx->InputTypeAnyOf("X", proto::VarType::LOD_TENSOR)) {
       default_var_type = proto::VarType::LOD_TENSOR;
     }
 
-    // auto out_var_name = ctx->Output("Out").front();
     ctx->SetType("Out", default_var_type);
   }
 };

--- a/paddle/fluid/framework/var_type_inference.h
+++ b/paddle/fluid/framework/var_type_inference.h
@@ -172,8 +172,14 @@ class InferVarTypeContext {
                                  proto::VarType::Type type, int index = 0) {
     PADDLE_ENFORCE_NOT_NULL(
         op_, platform::errors::PreconditionNotMet("op_ should not be null"));
-    auto& var_name = op_->Output(name).at(index);
-    this->SetDataType(var_name, type);
+    if (ALL_ELEMENTS == index) {
+      for (const auto& var_name : op_->Output(name)) {
+        this->SetDataType(var_name, type);
+      }
+    } else {
+      auto& var_name = op_->Output(name).at(index);
+      this->SetDataType(var_name, type);
+    }
   }
 
   // not available in dygraph mode

--- a/paddle/fluid/framework/var_type_inference.h
+++ b/paddle/fluid/framework/var_type_inference.h
@@ -125,18 +125,18 @@ class InferVarTypeContext {
     return this->GetVarType(op_->Input(name).at(index));
   }
 
+  virtual proto::VarType::Type GetOutputType(const std::string& name,
+                                             const int& index = 0) const {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
+    return this->GetVarType(op_->Output(name).at(index));
+  }
+
   virtual proto::VarType::Type GetInputDataType(const std::string& name,
                                                 const int& index = 0) const {
     PADDLE_ENFORCE_NOT_NULL(
         op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetVarDataType(op_->Input(name).at(index));
-  }
-
-  virtual proto::VarType::Type GetOutputDataType(const std::string& name,
-                                                 const int& index = 0) const {
-    PADDLE_ENFORCE_NOT_NULL(
-        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
-    return this->GetVarDataType(op_->Output(name).at(index));
   }
 
   virtual void SetOutputDataType(const std::string& name,

--- a/paddle/fluid/framework/var_type_inference.h
+++ b/paddle/fluid/framework/var_type_inference.h
@@ -63,7 +63,8 @@ class InferVarTypeContext {
 
   virtual bool InputTypeAnyOf(const std::string& name,
                               proto::VarType::Type type) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     auto& inputs = op_->Input(name);
     return std::any_of(inputs.begin(), inputs.end(),
                        [this, &type](const std::string& name) {
@@ -73,7 +74,8 @@ class InferVarTypeContext {
 
   virtual bool InputTypeAllOf(const std::string& name,
                               proto::VarType::Type type) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     auto& inputs = op_->Input(name);
     return std::all_of(inputs.begin(), inputs.end(),
                        [this, &type](const std::string& name) {
@@ -83,20 +85,24 @@ class InferVarTypeContext {
 
   // not available in dygraph mode
   virtual const std::vector<std::string>& Input(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Input(name);
   }
 
   // not available in dygraph mode
   virtual const std::vector<std::string>& Output(
       const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Output(name);
   }
 
   virtual void SyncTypeAndDataType(const std::string& input_name,
                                    const std::string& output_name,
                                    int index = 0) {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     auto& x_name = op_->Input(input_name).at(index);
     auto& out_name = op_->Output(output_name).at(index);
 
@@ -122,80 +128,98 @@ class InferVarTypeContext {
   // legacy function, maybe removed in the future, don't use in new code
   // use SetOutputType instead
   virtual void SetType(const std::string& name, proto::VarType::Type type) {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(
+        block_, platform::errors::PreconditionNotMet("op_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetType(type);
   }
 
   virtual proto::VarType::Type GetInputType(const std::string& name,
                                             const int& index = 0) const {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetType(op_->Input(name).at(index));
   }
 
   // not available in dygraph mode
   virtual proto::VarType::Type GetType(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetType();
   }
 
   virtual proto::VarType::Type GetInputDataType(const std::string& name,
                                                 const int& index = 0) const {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetDataType(op_->Input(name).at(index));
   }
 
   virtual proto::VarType::Type GetOutputDataType(const std::string& name,
                                                  const int& index = 0) const {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return this->GetDataType(op_->Output(name).at(index));
   }
 
   // not available in dygraph mode
   virtual proto::VarType::Type GetDataType(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetDataType();
   }
 
   virtual void SetOutputDataType(const std::string& name,
                                  proto::VarType::Type type, int index = 0) {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     auto& var_name = op_->Output(name).at(index);
     this->SetDataType(var_name, type);
   }
 
   // not available in dygraph mode
   virtual void SetDataType(const std::string& name, proto::VarType::Type type) {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetDataType(type);
   }
 
   virtual std::vector<proto::VarType::Type> GetDataTypes(
       const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetDataTypes();
   }
 
   virtual void SetDataTypes(
       const std::string& name,
       const std::vector<proto::VarType::Type>& multiple_data_type) {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetDataTypes(multiple_data_type);
   }
 
   virtual std::vector<int64_t> GetShape(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetShape();
   }
 
   virtual void SetShape(const std::string& name,
                         const std::vector<int64_t>& dims) {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetShape(dims);
   }
 
   virtual int32_t GetLoDLevel(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     return block_->FindRecursiveOrCreateVar(name).GetLoDLevel();
   }
 
   virtual void SetLoDLevel(const std::string& name, int32_t lod_level) {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     block_->FindRecursiveOrCreateVar(name).SetLoDLevel(lod_level);
   }
 

--- a/paddle/fluid/framework/var_type_inference.h
+++ b/paddle/fluid/framework/var_type_inference.h
@@ -165,14 +165,6 @@ class InferVarTypeContext {
     block_->FindRecursiveOrCreateVar(name).SetDataType(type);
   }
 
-  virtual void SyncDataTypes(const std::string& input_name,
-                             const std::string& output_name,
-                             const int& index = 0) {
-    auto& input_var = op_->Input(input_name).at(index);
-    auto& output_var = op_->Output(input_name).at(index);
-    this->SetDataTypes(output_var, this->GetDataTypes(input_var));
-  }
-
   virtual std::vector<proto::VarType::Type> GetDataTypes(
       const std::string& name) const {
     PADDLE_ENFORCE_NOT_NULL(block_);
@@ -226,12 +218,6 @@ class PassInDtypeAndVarTypeToOutput : public framework::VarTypeInference {
     auto& in_out_var_names = this->GetInputOutputWithSameType();
 
     for (auto& i_o_n : in_out_var_names) {
-      // auto& x_name = ctx->Input(i_o_n.first).at(0);
-      // auto& out_name = ctx->Output(i_o_n.second).at(0);
-
-      // ctx->SetType(out_name, ctx->GetType(x_name));
-      // ctx->SetDataType(out_name, ctx->GetDataType(x_name));
-
       ctx->SyncTypeAndDataType(i_o_n.first, i_o_n.second);
     }
   }

--- a/paddle/fluid/framework/var_type_inference.h
+++ b/paddle/fluid/framework/var_type_inference.h
@@ -41,32 +41,37 @@ class InferVarTypeContext {
   virtual ~InferVarTypeContext() {}
 
   virtual Attribute GetAttr(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return op_->GetAttr(name);
   }
 
   virtual bool HasInput(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     auto& inputs = op_->Inputs();
     auto input = inputs.find(name);
     return input != inputs.end() && !input->second.empty();
   }
 
   virtual bool HasOutput(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     auto& outputs = op_->Outputs();
     auto output = outputs.find(name);
     return output != outputs.end() && !output->second.empty();
   }
 
   virtual size_t InputSize(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Inputs().at(name).size();
   }
 
   virtual const std::string& InputVarName(const std::string& name,
                                           const int index = 0) const {
-    PADDLE_ENFORCE_NOT_NULL(op_);
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     return op_->Inputs().at(name)[index];
   }
 
@@ -108,6 +113,8 @@ class InferVarTypeContext {
 
   virtual void SetOutputType(const std::string& name, proto::VarType::Type type,
                              int index = 0) {
+    PADDLE_ENFORCE_NOT_NULL(
+        op_, platform::errors::PreconditionNotMet("op_ should not be null"));
     if (ALL_ELEMENTS == index) {
       for (const auto& var_name : op_->Output(name)) {
         this->SetVarType(var_name, type);
@@ -214,7 +221,8 @@ class InferVarTypeContext {
 
  protected:
   virtual bool HasVar(const std::string& name) const {
-    PADDLE_ENFORCE_NOT_NULL(block_);
+    PADDLE_ENFORCE_NOT_NULL(block_, platform::errors::PreconditionNotMet(
+                                        "block_ should not be null"));
     return block_->FindVarRecursive(name) != nullptr;
   }
 

--- a/paddle/fluid/framework/var_type_inference_test.cc
+++ b/paddle/fluid/framework/var_type_inference_test.cc
@@ -251,5 +251,37 @@ TEST(InferVarType, multiple_api) {
   ASSERT_EQ(2, infer.GetLoDLevel(&ctx, "test2_a_out"));
 }
 
+TEST(InferVarType, test_enforce_check) {
+  InferVarTypeContext ctx(nullptr, nullptr);
+  ASSERT_ANY_THROW(ctx.HasInput("X"));
+  ASSERT_ANY_THROW(ctx.HasOutput("Out"));
+
+  ASSERT_ANY_THROW(ctx.InputSize("X"));
+  ASSERT_ANY_THROW(ctx.InputVarName("X"));
+
+  ASSERT_ANY_THROW(ctx.InputTypeAnyOf("X", proto::VarType::LOD_TENSOR));
+  ASSERT_ANY_THROW(ctx.InputTypeAllOf("X", proto::VarType::LOD_TENSOR));
+
+  ASSERT_ANY_THROW(ctx.SyncTypeAndDataType("X", "Out"));
+
+  ASSERT_ANY_THROW(ctx.SetOutputType("Out", proto::VarType::LOD_TENSOR));
+  ASSERT_ANY_THROW(ctx.GetInputType("X"));
+  ASSERT_ANY_THROW(ctx.GetOutputType("Out"));
+
+  ASSERT_ANY_THROW(ctx.GetInputDataType("X"));
+  ASSERT_ANY_THROW(ctx.SetOutputDataType("Out", proto::VarType::LOD_TENSOR));
+
+  ASSERT_ANY_THROW(ctx.GetInputDataTypes("X"));
+  ASSERT_ANY_THROW(ctx.SetOutputDataTypes("Out", {}));
+
+  ASSERT_ANY_THROW(ctx.GetInputShape("X"));
+  ASSERT_ANY_THROW(ctx.SetOutputShape("Out", {}));
+
+  ASSERT_ANY_THROW(ctx.GetInputLoDLevel("X"));
+  ASSERT_ANY_THROW(ctx.SetOutputLoDLevel("Out", 1));
+
+  ASSERT_ANY_THROW(ctx.InsertVar("var", proto::VarType::LOD_TENSOR));
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/var_type_inference_test.cc
+++ b/paddle/fluid/framework/var_type_inference_test.cc
@@ -45,19 +45,21 @@ class SumOpMaker : public OpProtoAndCheckerMaker {
 class SumOpVarTypeInference : public VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto &inputs = ctx->Input("X");
+    // auto &inputs = ctx->Input("X");
     auto default_var_type = proto::VarType::SELECTED_ROWS;
 
-    bool any_input_is_lod_tensor = std::any_of(
-        inputs.begin(), inputs.end(), [&ctx](const std::string &name) {
-          return ctx->GetType(name) == proto::VarType::LOD_TENSOR;
-        });
-    if (any_input_is_lod_tensor) {
+    // bool any_input_is_lod_tensor = std::any_of(
+    //     inputs.begin(), inputs.end(), [&ctx](const std::string &name) {
+    //       return ctx->GetType(name) == proto::VarType::LOD_TENSOR;
+    //     });
+    // if (any_input_is_lod_tensor) {
+    if (ctx->InputTypeAnyOf("X", proto::VarType::LOD_TENSOR)) {
       default_var_type = proto::VarType::LOD_TENSOR;
     }
 
-    auto out_var_name = ctx->Output("Out").front();
-    ctx->SetType(out_var_name, default_var_type);
+    // auto out_var_name = ctx->Output("Out").front();
+    // ctx->SetType(out_var_name, default_var_type);
+    ctx->SetOutputType("Out", default_var_type);
   }
 };
 }  // namespace framework

--- a/paddle/fluid/framework/var_type_inference_test.cc
+++ b/paddle/fluid/framework/var_type_inference_test.cc
@@ -192,6 +192,12 @@ TEST(InferVarType, multiple_api) {
 
   InferVarTypeContext ctx(op, block);
 
+  ASSERT_TRUE(ctx.HasInput("X"));
+  ASSERT_TRUE(ctx.HasOutput("Out"));
+
+  ASSERT_EQ(2u, ctx.InputSize("X"));
+  ASSERT_EQ("test2_a", ctx.InputVarName("X", 0));
+
   ASSERT_EQ(proto::VarType::SELECTED_ROWS, ctx.GetInputType("X"));
 
   ASSERT_TRUE(ctx.InputTypeAllOf("X", proto::VarType::SELECTED_ROWS));
@@ -199,24 +205,22 @@ TEST(InferVarType, multiple_api) {
 
   ctx.SyncTypeAndDataType("X", "Out");
 
-  ASSERT_EQ(proto::VarType::SELECTED_ROWS,
-            prog.MutableBlock(0)->Var("test2_a_out")->GetType());
-  ASSERT_EQ(proto::VarType::LOD_TENSOR,
-            prog.MutableBlock(0)->Var("test2_b_out")->GetType());
+  ASSERT_EQ(proto::VarType::SELECTED_ROWS, ctx.GetOutputType("Out"));
+  ASSERT_EQ(proto::VarType::LOD_TENSOR, ctx.GetOutputType("Out", 1));
 
   ctx.SetOutputType("Out", proto::VarType::SELECTED_ROWS, ALL_ELEMENTS);
   ctx.SetOutputType("Out", proto::VarType::LOD_TENSOR, 1);
-  ASSERT_EQ(proto::VarType::SELECTED_ROWS,
-            prog.MutableBlock(0)->Var("test2_a_out")->GetType());
-  ASSERT_EQ(proto::VarType::LOD_TENSOR,
-            prog.MutableBlock(0)->Var("test2_b_out")->GetType());
+  ASSERT_EQ(proto::VarType::SELECTED_ROWS, ctx.GetOutputType("Out"));
+  ASSERT_EQ(proto::VarType::LOD_TENSOR, ctx.GetOutputType("Out", 1));
 
   ASSERT_EQ(0, ctx.GetInputDataType("X"));
 
   ctx.SetOutputDataType("Out", proto::VarType::FP32, ALL_ELEMENTS);
   ctx.SetOutputDataType("Out", proto::VarType::INT8, 1);
-  ASSERT_EQ(proto::VarType::FP32, ctx.GetOutputDataType("Out"));
-  ASSERT_EQ(proto::VarType::INT8, ctx.GetOutputDataType("Out", 1));
+  ASSERT_EQ(proto::VarType::FP32,
+            prog.MutableBlock(0)->Var("test2_a_out")->GetDataType());
+  ASSERT_EQ(proto::VarType::INT8,
+            prog.MutableBlock(0)->Var("test2_b_out")->GetDataType());
 
   ASSERT_FALSE(ctx.IsDygraph());
 

--- a/paddle/fluid/framework/var_type_inference_test.cc
+++ b/paddle/fluid/framework/var_type_inference_test.cc
@@ -45,20 +45,12 @@ class SumOpMaker : public OpProtoAndCheckerMaker {
 class SumOpVarTypeInference : public VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto &inputs = ctx->Input("X");
     auto default_var_type = proto::VarType::SELECTED_ROWS;
 
-    // bool any_input_is_lod_tensor = std::any_of(
-    //     inputs.begin(), inputs.end(), [&ctx](const std::string &name) {
-    //       return ctx->GetType(name) == proto::VarType::LOD_TENSOR;
-    //     });
-    // if (any_input_is_lod_tensor) {
     if (ctx->InputTypeAnyOf("X", proto::VarType::LOD_TENSOR)) {
       default_var_type = proto::VarType::LOD_TENSOR;
     }
 
-    // auto out_var_name = ctx->Output("Out").front();
-    // ctx->SetType(out_var_name, default_var_type);
     ctx->SetOutputType("Out", default_var_type);
   }
 };

--- a/paddle/fluid/framework/var_type_inference_test.cc
+++ b/paddle/fluid/framework/var_type_inference_test.cc
@@ -135,14 +135,19 @@ TEST(InferVarType, multiple_api) {
   ASSERT_EQ(proto::VarType::LOD_TENSOR,
             prog.MutableBlock(0)->Var("test2_b_out")->GetType());
 
-  ctx.SetOutputType("Out", proto::VarType::SELECTED_ROWS, 1);
+  ctx.SetOutputType("Out", proto::VarType::SELECTED_ROWS, ALL_ELEMENTS);
+  ctx.SetOutputType("Out", proto::VarType::LOD_TENSOR, 1);
   ASSERT_EQ(proto::VarType::SELECTED_ROWS,
+            prog.MutableBlock(0)->Var("test2_a_out")->GetType());
+  ASSERT_EQ(proto::VarType::LOD_TENSOR,
             prog.MutableBlock(0)->Var("test2_b_out")->GetType());
 
   ASSERT_EQ(0, ctx.GetInputDataType("X"));
 
-  ctx.SetOutputDataType("Out", proto::VarType::FP32);
+  ctx.SetOutputDataType("Out", proto::VarType::FP32, ALL_ELEMENTS);
+  ctx.SetOutputDataType("Out", proto::VarType::INT8, 1);
   ASSERT_EQ(proto::VarType::FP32, ctx.GetOutputDataType("Out"));
+  ASSERT_EQ(proto::VarType::INT8, ctx.GetOutputDataType("Out", 1));
 
   ASSERT_FALSE(ctx.IsDygraph());
 }

--- a/paddle/fluid/imperative/infer_var_type_context.h
+++ b/paddle/fluid/imperative/infer_var_type_context.h
@@ -128,14 +128,14 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
     return inputs_.at(name)[index]->Type();
   }
 
+  framework::proto::VarType::Type GetOutputType(
+      const std::string& name, const int& index = 0) const override {
+    return outputs_.at(name)[index]->Type();
+  }
+
   framework::proto::VarType::Type GetInputDataType(
       const std::string& name, const int& index = 0) const override {
     return inputs_.at(name)[index]->DataType();
-  }
-
-  framework::proto::VarType::Type GetOutputDataType(
-      const std::string& name, const int& index = 0) const override {
-    return outputs_.at(name)[index]->DataType();
   }
 
   void SetOutputDataType(const std::string& name,

--- a/paddle/fluid/imperative/infer_var_type_context.h
+++ b/paddle/fluid/imperative/infer_var_type_context.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -35,30 +36,7 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
       : InferVarTypeContext(nullptr, nullptr),
         inputs_(inputs),
         outputs_(outputs),
-        attrs_(attrs_map),
-        input_names_(),
-        output_names_(),
-        var_set_() {
-    input_names_.reserve(inputs_.size());
-    for (auto& it : inputs_) {
-      for (auto& var : it.second) {
-        if (var) {
-          input_names_[it.first].emplace_back(var->Name());
-          var_set_[var->Name()] = var.get();
-        }
-      }
-    }
-
-    output_names_.reserve(outputs_.size());
-    for (auto& it : outputs_) {
-      for (auto& var : it.second) {
-        if (var) {
-          output_names_[it.first].emplace_back(var->Name());
-          var_set_[var->Name()] = var.get();
-        }
-      }
-    }
-  }
+        attrs_(attrs_map) {}
 
   virtual ~RuntimeInferVarTypeContext() {}
 
@@ -68,10 +46,6 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
         iter != attrs_.end(), true,
         platform::errors::NotFound("Cannot find attribute %s", name));
     return iter->second;
-  }
-
-  bool HasVar(const std::string& name) const override {
-    return var_set_.count(name) > 0;
   }
 
   bool HasInput(const std::string& name) const override {
@@ -84,93 +58,173 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
     return (it != outputs_.end() && it->second.size() > 0);
   }
 
-  const std::vector<std::string>& Input(
-      const std::string& name) const override {
-    auto iter = input_names_.find(name);
-    PADDLE_ENFORCE_EQ(
-        iter != input_names_.end(), true,
-        platform::errors::NotFound("Cannot find input var %s", name));
-    return iter->second;
+  size_t InputSize(const std::string& name) const {
+    return inputs_.at(name).size();
   }
 
-  const std::vector<std::string>& Output(
-      const std::string& name) const override {
-    auto iter = output_names_.find(name);
-
-    PADDLE_ENFORCE_EQ(
-        iter != output_names_.end(), true,
-        platform::errors::NotFound("Cannot find output var %s", name));
-    return iter->second;
+  const std::string& InputVarName(const std::string& name,
+                                  const int index = 0) const {
+    return inputs_.at(name)[index]->Name();
   }
 
-  framework::proto::VarType::Type GetType(
-      const std::string& name) const override {
-    auto iter = var_set_.find(name);
-
-    PADDLE_ENFORCE_EQ(
-        iter != var_set_.end(), true,
-        platform::errors::NotFound("Cannot find var %s in GetType", name));
-    return iter->second->Type();
+  bool InputTypeAnyOf(const std::string& name,
+                      framework::proto::VarType::Type type) const override {
+    auto& inputs = inputs_.at(name);
+    return std::any_of(inputs.begin(), inputs.end(),
+                       [&type](const std::shared_ptr<VarType>& var) {
+                         return var->Type() == type;
+                       });
   }
 
-  void SetType(const std::string& name,
-               framework::proto::VarType::Type type) override {
-    if (name == "kLookupTablePath") {
-      VLOG(2) << "SUPER UGLY FIX, remove this when move imperative mode in C++";
-    } else {
-      var_set_[name]->SetType(type);
-      if ((var_set_[name]->MutableVar()->IsInitialized() == true) &&
-          (var_set_[name]->MutableVar()->Type() != type)) {
-        var_set_[name]->MutableVar()->Clear();
-      }
+  bool InputTypeAllOf(const std::string& name,
+                      framework::proto::VarType::Type type) const override {
+    auto& inputs = inputs_.at(name);
+    return std::all_of(inputs.begin(), inputs.end(),
+                       [&type](const std::shared_ptr<VarType>& var) {
+                         return var->Type() == type;
+                       });
+  }
+
+  void SyncTypeAndDataType(const std::string& input_name,
+                           const std::string& output_name,
+                           int index = 0) override {
+    auto in_var = inputs_.at(input_name)[index];
+    auto out_var = outputs_.at(output_name)[index];
+    if (in_var != out_var) {
+      this->SetVarBaseType(out_var, in_var->Type());
+      this->SetVarBaseDataType(out_var, in_var->DataType());
     }
   }
 
-  framework::proto::VarType::Type GetDataType(
-      const std::string& name) const override {
-    auto iter = var_set_.find(name);
-
-    PADDLE_ENFORCE_EQ(
-        iter != var_set_.end(), true,
-        platform::errors::NotFound("Cannot find var %s in GetDataType", name));
-    return iter->second->DataType();
+  void SetOutputType(const std::string& name,
+                     framework::proto::VarType::Type type,
+                     int index = 0) override {
+    if (index == framework::ALL_ELEMENTS) {
+      for (auto& item : outputs_.at(name)) {
+        this->SetVarBaseType(item, type);
+      }
+    } else {
+      auto& var = outputs_.at(name)[index];
+      this->SetVarBaseType(var, type);
+    }
   }
 
-  void SetDataType(const std::string& name,
-                   framework::proto::VarType::Type type) override {
-    var_set_[name]->SetDataType(type);
+  void SetVarBaseType(std::shared_ptr<VarType> out,
+                      framework::proto::VarType::Type type) {
+    out->SetType(type);
+    if ((out->MutableVar()->IsInitialized() == true) &&
+        (out->MutableVar()->Type() != type)) {
+      out->MutableVar()->Clear();
+    }
   }
 
-  std::vector<framework::proto::VarType::Type> GetDataTypes(
+  void SetVarBaseDataType(std::shared_ptr<VarType> out,
+                          framework::proto::VarType::Type type) {
+    out->SetDataType(type);
+  }
+
+  framework::proto::VarType::Type GetInputType(
+      const std::string& name, const int& index = 0) const override {
+    return inputs_.at(name)[index]->Type();
+  }
+
+  framework::proto::VarType::Type GetInputDataType(
+      const std::string& name, const int& index = 0) const override {
+    return inputs_.at(name)[index]->DataType();
+  }
+
+  framework::proto::VarType::Type GetOutputDataType(
+      const std::string& name, const int& index = 0) const override {
+    return outputs_.at(name)[index]->DataType();
+  }
+
+  void SetOutputDataType(const std::string& name,
+                         framework::proto::VarType::Type type,
+                         int index = 0) override {
+    if (framework::ALL_ELEMENTS == index) {
+      for (auto& item : outputs_.at(name)) {
+        this->SetVarBaseDataType(item, type);
+      }
+    } else {
+      auto& var = outputs_.at(name)[index];
+      this->SetVarBaseDataType(var, type);
+    }
+  }
+
+  bool IsDygraph() const override { return true; }
+
+ protected:
+  bool HasVar(const std::string& name) const override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "HasVar is not supported in runtime InferVarType"));
+  }
+
+  const std::vector<std::string>& InputVars(
       const std::string& name) const override {
     PADDLE_THROW(platform::errors::PermissionDenied(
-        "GetDataTypes is not supported in runtime InferVarType"));
+        "InputVars is not supported in runtime InferVarType"));
   }
 
-  void SetDataTypes(const std::string& name,
-                    const std::vector<framework::proto::VarType::Type>&
-                        multiple_data_type) override {
+  const std::vector<std::string>& OutputVars(
+      const std::string& name) const override {
     PADDLE_THROW(platform::errors::PermissionDenied(
-        "SetDataTypes is not supported in runtime InferVarType"));
+        "OutputVars is not supported in runtime InferVarType"));
   }
 
-  std::vector<int64_t> GetShape(const std::string& name) const override {
+  framework::proto::VarType::Type GetVarType(
+      const std::string& name) const override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "Do not manipulate var in runtime InferVarType"));
+  }
+
+  void SetVarType(const std::string& name,
+                  framework::proto::VarType::Type type) override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "Do not manipulate var in runtime InferVarType"));
+  }
+
+  framework::proto::VarType::Type GetVarDataType(
+      const std::string& name) const override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "Do not manipulate var in runtime InferVarType"));
+  }
+
+  void SetVarDataType(const std::string& name,
+                      framework::proto::VarType::Type type) override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "Do not manipulate var in runtime InferVarType"));
+  }
+
+  std::vector<framework::proto::VarType::Type> GetVarDataTypes(
+      const std::string& name) const override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "GetVarDataTypes is not supported in runtime InferVarType"));
+  }
+
+  void SetVarDataTypes(const std::string& name,
+                       const std::vector<framework::proto::VarType::Type>&
+                           multiple_data_type) override {
+    PADDLE_THROW(platform::errors::PermissionDenied(
+        "SetVarDataTypes is not supported in runtime InferVarType"));
+  }
+
+  std::vector<int64_t> GetVarShape(const std::string& name) const override {
     PADDLE_THROW(platform::errors::PermissionDenied(
         "Do not handle Shape in runtime InferVarType"));
   }
 
-  void SetShape(const std::string& name,
-                const std::vector<int64_t>& dims) override {
+  void SetVarShape(const std::string& name,
+                   const std::vector<int64_t>& dims) override {
     PADDLE_THROW(platform::errors::PermissionDenied(
         "Do not handle Shape in runtime InferVarType"));
   }
 
-  int32_t GetLoDLevel(const std::string& name) const override {
+  int32_t GetVarLoDLevel(const std::string& name) const override {
     PADDLE_THROW(platform::errors::PermissionDenied(
         "Do not handle LoDLevel in runtime InferVarType"));
   }
 
-  void SetLoDLevel(const std::string& name, int32_t lod_level) override {
+  void SetVarLoDLevel(const std::string& name, int32_t lod_level) override {
     PADDLE_THROW(platform::errors::PermissionDenied(
         "Do not handle LoDLevel in runtime InferVarType"));
   }
@@ -179,9 +233,6 @@ class RuntimeInferVarTypeContext : public framework::InferVarTypeContext {
   const NameVarMap<VarType>& inputs_;
   const NameVarMap<VarType>& outputs_;
   const framework::AttributeMap& attrs_;
-  std::unordered_map<std::string, std::vector<std::string>> input_names_;
-  std::unordered_map<std::string, std::vector<std::string>> output_names_;
-  std::unordered_map<std::string, VarType*> var_set_;
 };
 
 }  // namespace imperative

--- a/paddle/fluid/imperative/tests/test_layer.cc
+++ b/paddle/fluid/imperative/tests/test_layer.cc
@@ -124,7 +124,6 @@ TEST(test_layer, test_runtime_context) {
   auto* ctx =
       new imperative::TestRuntimeInferVarTypeContext<imperative::VarBase>(
           ins, outs, attrs);
-  ASSERT_TRUE(ctx->HasVar("vin"));
 
   ASSERT_TRUE(ctx->HasInput("X"));
   ASSERT_TRUE(ctx->HasOutput("Out"));

--- a/paddle/fluid/imperative/tests/test_layer.cc
+++ b/paddle/fluid/imperative/tests/test_layer.cc
@@ -47,13 +47,15 @@ TEST(test_layer, test_runtime_context) {
   imperative::NameVarBaseMap ins = {in_pair};
   imperative::NameVarBaseMap outs = {out_pair};
   framework::AttributeMap attrs;
+
   auto *ctx = new imperative::RuntimeInferVarTypeContext<imperative::VarBase>(
       ins, outs, attrs);
   ASSERT_TRUE(ctx->HasVar("vin"));
+
   ASSERT_TRUE(ctx->HasInput("X"));
   ASSERT_TRUE(ctx->HasOutput("Out"));
 
-  ASSERT_ANY_THROW(ctx->GetDataTypes("vin"));
+  ASSERT_ANY_THROW(ctx->GetInputDataType("vin"));
   std::vector<framework::proto::VarType::Type> NullType;
   ASSERT_ANY_THROW(ctx->SetDataTypes("vin", NullType));
   ASSERT_ANY_THROW(ctx->GetShape("vin"));

--- a/paddle/fluid/imperative/tests/test_layer.cc
+++ b/paddle/fluid/imperative/tests/test_layer.cc
@@ -127,6 +127,10 @@ TEST(test_layer, test_runtime_context) {
 
   ASSERT_TRUE(ctx->HasInput("X"));
   ASSERT_TRUE(ctx->HasOutput("Out"));
+
+  ASSERT_EQ(2u, ctx->InputSize("X"));
+  ASSERT_EQ("vin", ctx->InputVarName("X", 0));
+
   ASSERT_TRUE(ctx->InputTypeAnyOf("X", framework::proto::VarType::LOD_TENSOR));
   ASSERT_TRUE(ctx->InputTypeAllOf("X", framework::proto::VarType::LOD_TENSOR));
 
@@ -135,9 +139,9 @@ TEST(test_layer, test_runtime_context) {
 
   ctx->SyncTypeAndDataType("X", "Out");
 
-  ASSERT_EQ(framework::proto::VarType::FP32, ctx->GetOutputDataType("Out"));
+  ASSERT_EQ(framework::proto::VarType::FP32, vout->DataType());
 
-  ASSERT_EQ(framework::proto::VarType::LOD_TENSOR, vout->Type());
+  ASSERT_EQ(framework::proto::VarType::LOD_TENSOR, ctx->GetOutputType("Out"));
 
   ctx->SetOutputType("Out", framework::proto::VarType::SELECTED_ROWS,
                      framework::ALL_ELEMENTS);
@@ -149,8 +153,8 @@ TEST(test_layer, test_runtime_context) {
                          framework::ALL_ELEMENTS);
   ctx->SetOutputDataType("Out", framework::proto::VarType::INT8);
 
-  ASSERT_EQ(framework::proto::VarType::INT8, ctx->GetOutputDataType("Out"));
-  ASSERT_EQ(framework::proto::VarType::FP64, ctx->GetOutputDataType("Out", 1));
+  ASSERT_EQ(framework::proto::VarType::INT8, vout->DataType());
+  ASSERT_EQ(framework::proto::VarType::FP64, vout_b->DataType());
 
   // no throw, but do nothing
   ASSERT_NO_THROW(
@@ -161,13 +165,17 @@ TEST(test_layer, test_runtime_context) {
   ASSERT_ANY_THROW(ctx->InputVars("X"));
   ASSERT_ANY_THROW(ctx->OutputVars("Out"));
   ASSERT_ANY_THROW(ctx->GetVarType("vin"));
+  ASSERT_ANY_THROW(
+      ctx->SetVarType("vin", framework::proto::VarType::LOD_TENSOR));
   ASSERT_ANY_THROW(ctx->GetVarDataType("vin"));
   ASSERT_ANY_THROW(
       ctx->SetVarDataType("vout", framework::proto::VarType::FP32));
-  ASSERT_ANY_THROW(ctx->GetInputDataType("vin"));
+
+  ASSERT_ANY_THROW(ctx->GetVarDataTypes("vin"));
   std::vector<framework::proto::VarType::Type> NullType;
   ASSERT_ANY_THROW(ctx->SetVarDataTypes("vin", NullType));
   ASSERT_ANY_THROW(ctx->GetVarShape("vin"));
+  ASSERT_ANY_THROW(ctx->SetVarShape("vin", {}));
   ASSERT_ANY_THROW(ctx->GetVarLoDLevel("vin"));
   ASSERT_ANY_THROW(ctx->SetVarLoDLevel("vin", 2));
 

--- a/paddle/fluid/imperative/tests/test_layer.cc
+++ b/paddle/fluid/imperative/tests/test_layer.cc
@@ -37,6 +37,72 @@ using vb_vector = std::vector<std::shared_ptr<imperative::VarBase>>;
 
 using var_pair = std::pair<std::string, vb_vector>;
 
+class TestRuntimeInferVarTypeContext : public RuntimeInferVarTypeContext {
+ public:
+  TestRuntimeInferVarTypeContext(const NameVarBaseMap& inputs,
+                                 const NameVarBaseMap* outputs,
+                                 const framework::AttributeMap& attrs_map)
+      : RuntimeInferVarTypeContext(inputs, outputs, attrs_map) {}
+
+  bool HasVar(const std::string& name) const {
+    return RuntimeInferVarTypeContext::HasVar(name);
+  }
+
+  const std::vector<std::string>& InputVars(const std::string& name) const {
+    return RuntimeInferVarTypeContext::InputVars(name);
+  }
+
+  const std::vector<std::string>& OutputVars(const std::string& name) const {
+    return RuntimeInferVarTypeContext::OutputVars(name);
+  }
+
+  framework::proto::VarType::Type GetVarType(const std::string& name) const {
+    return RuntimeInferVarTypeContext::GetVarType(name);
+  }
+
+  void SetVarType(const std::string& name,
+                  framework::proto::VarType::Type type) {
+    RuntimeInferVarTypeContext::SetVarType(name, type);
+  }
+
+  framework::proto::VarType::Type GetVarDataType(
+      const std::string& name) const {
+    return RuntimeInferVarTypeContext::GetVarDataType(name);
+  }
+
+  void SetVarDataType(const std::string& name,
+                      framework::proto::VarType::Type type) {
+    RuntimeInferVarTypeContext::SetVarDataType(name, type);
+  }
+
+  std::vector<framework::proto::VarType::Type> GetVarDataTypes(
+      const std::string& name) const {
+    return RuntimeInferVarTypeContext::GetVarDataTypes(name);
+  }
+
+  void SetVarDataTypes(
+      const std::string& name,
+      const std::vector<framework::proto::VarType::Type>& multiple_data_type) {
+    RuntimeInferVarTypeContext::SetVarDataTypes(name, multiple_data_type);
+  }
+
+  std::vector<int64_t> GetVarShape(const std::string& name) const {
+    return RuntimeInferVarTypeContext::GetVarShape(name);
+  }
+
+  void SetVarShape(const std::string& name, const std::vector<int64_t>& dims) {
+    RuntimeInferVarTypeContext::SetVarShape(name, dims);
+  }
+
+  int32_t GetVarLoDLevel(const std::string& name) const {
+    return RuntimeInferVarTypeContext::GetVarLoDLevel(name);
+  }
+
+  void SetVarLoDLevel(const std::string& name, int32_t lod_level) {
+    RuntimeInferVarTypeContext::SetVarLoDLevel(name, lod_level);
+  }
+};
+
 TEST(test_layer, test_runtime_context) {
   std::shared_ptr<imperative::VarBase> vin(
       new imperative::VarBase(false, "vin"));
@@ -84,21 +150,23 @@ TEST(test_layer, test_runtime_context) {
   ASSERT_EQ(framework::proto::VarType::FP64, ctx->GetOutputDataType("Out", 1));
 
   // no throw, but do nothing
-  ASSERT_NO_THROW(ctx->SetType("vout", framework::proto::VarType::LOD_TENSOR));
+  ASSERT_NO_THROW(
+      ctx->InsertVar("vout", framework::proto::VarType::LOD_TENSOR));
   ASSERT_EQ(framework::proto::VarType::LOD_TENSOR_ARRAY, vout->Type());
 
   ASSERT_ANY_THROW(ctx->HasVar("vin"));
-  ASSERT_ANY_THROW(ctx->Input("X"));
-  ASSERT_ANY_THROW(ctx->Output("Out"));
-  ASSERT_ANY_THROW(ctx->GetType("vin"));
-  ASSERT_ANY_THROW(ctx->GetDataType("vin"));
-  ASSERT_ANY_THROW(ctx->SetDataType("vout", framework::proto::VarType::FP32));
+  ASSERT_ANY_THROW(ctx->InputVars("X"));
+  ASSERT_ANY_THROW(ctx->OutputVars("Out"));
+  ASSERT_ANY_THROW(ctx->GetVarType("vin"));
+  ASSERT_ANY_THROW(ctx->GetVarDataType("vin"));
+  ASSERT_ANY_THROW(
+      ctx->SetVarDataType("vout", framework::proto::VarType::FP32));
   ASSERT_ANY_THROW(ctx->GetInputDataType("vin"));
   std::vector<framework::proto::VarType::Type> NullType;
-  ASSERT_ANY_THROW(ctx->SetDataTypes("vin", NullType));
-  ASSERT_ANY_THROW(ctx->GetShape("vin"));
-  ASSERT_ANY_THROW(ctx->GetLoDLevel("vin"));
-  ASSERT_ANY_THROW(ctx->SetLoDLevel("vin", 2));
+  ASSERT_ANY_THROW(ctx->SetVarDataTypes("vin", NullType));
+  ASSERT_ANY_THROW(ctx->GetVarShape("vin"));
+  ASSERT_ANY_THROW(ctx->GetVarLoDLevel("vin"));
+  ASSERT_ANY_THROW(ctx->SetVarLoDLevel("vin", 2));
 
   ASSERT_TRUE(ctx->IsDygraph());
 }

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -129,9 +129,10 @@ class ActivationOp : public framework::OperatorWithKernel {
 class ActivationOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/allclose_op.cc
+++ b/paddle/fluid/operators/allclose_op.cc
@@ -103,8 +103,7 @@ class AllcloseOp : public framework::OperatorWithKernel {
 class AllcloseOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto out_var_name = ctx->Output("Out").front();
-    ctx->SetDataType(out_var_name, framework::proto::VarType::BOOL);
+    ctx->SetOutputDataType("Out", framework::proto::VarType::BOOL);
   }
 };
 

--- a/paddle/fluid/operators/assign_op.cc
+++ b/paddle/fluid/operators/assign_op.cc
@@ -60,11 +60,7 @@ class AssignOp : public framework::OperatorWithKernel {
 class AssignInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto out_var_name = ctx->Output("Out")[0];
-    auto input_type = ctx->GetType(ctx->Input("X")[0]);
-    auto input_data_type = ctx->GetDataType(ctx->Input("X")[0]);
-    ctx->SetType(out_var_name, input_type);
-    ctx->SetDataType(out_var_name, input_data_type);
+    ctx->SyncTypeAndDataType("X", "Out");
   }
 };
 

--- a/paddle/fluid/operators/batch_norm_op.h
+++ b/paddle/fluid/operators/batch_norm_op.h
@@ -171,9 +171,10 @@ class BatchNormGradMaker : public framework::SingleGradOpMaker<T> {
 class BatchNormOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Y"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Y"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/beam_search_decode_op.cc
+++ b/paddle/fluid/operators/beam_search_decode_op.cc
@@ -204,12 +204,16 @@ class BeamSearchDecodeInferShape : public framework::InferShapeBase {
 class BeamSearchDecodeInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    for (auto& o : ctx->Output("SentenceIds")) {
-      ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    }
-    for (auto& o : ctx->Output("SentenceScores")) {
-      ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    }
+    // for (auto& o : ctx->Output("SentenceIds")) {
+    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
+    // }
+    // for (auto& o : ctx->Output("SentenceScores")) {
+    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
+    // }
+    ctx->SetOutputType("SentenceIds", framework::proto::VarType::LOD_TENSOR,
+                       framework::ALL_ELEMENTS);
+    ctx->SetOutputType("SentenceScores", framework::proto::VarType::LOD_TENSOR,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/beam_search_decode_op.cc
+++ b/paddle/fluid/operators/beam_search_decode_op.cc
@@ -204,12 +204,6 @@ class BeamSearchDecodeInferShape : public framework::InferShapeBase {
 class BeamSearchDecodeInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    // for (auto& o : ctx->Output("SentenceIds")) {
-    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    // }
-    // for (auto& o : ctx->Output("SentenceScores")) {
-    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    // }
     ctx->SetOutputType("SentenceIds", framework::proto::VarType::LOD_TENSOR,
                        framework::ALL_ELEMENTS);
     ctx->SetOutputType("SentenceScores", framework::proto::VarType::LOD_TENSOR,

--- a/paddle/fluid/operators/beam_search_op.cc
+++ b/paddle/fluid/operators/beam_search_op.cc
@@ -122,12 +122,16 @@ class BeamSearchOp : public framework::OperatorWithKernel {
 class BeamSearchInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    for (auto &o : ctx->Output("selected_ids")) {
-      ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    }
-    for (auto &o : ctx->Output("selected_scores")) {
-      ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    }
+    // for (auto &o : ctx->Output("selected_ids")) {
+    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
+    // }
+    // for (auto &o : ctx->Output("selected_scores")) {
+    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
+    // }
+    ctx->SetOutputType("selected_ids", framework::proto::VarType::LOD_TENSOR,
+                       framework::ALL_ELEMENTS);
+    ctx->SetOutputType("selected_scores", framework::proto::VarType::LOD_TENSOR,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/beam_search_op.cc
+++ b/paddle/fluid/operators/beam_search_op.cc
@@ -122,12 +122,6 @@ class BeamSearchOp : public framework::OperatorWithKernel {
 class BeamSearchInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // for (auto &o : ctx->Output("selected_ids")) {
-    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    // }
-    // for (auto &o : ctx->Output("selected_scores")) {
-    //   ctx->SetType(o, framework::proto::VarType::LOD_TENSOR);
-    // }
     ctx->SetOutputType("selected_ids", framework::proto::VarType::LOD_TENSOR,
                        framework::ALL_ELEMENTS);
     ctx->SetOutputType("selected_scores", framework::proto::VarType::LOD_TENSOR,

--- a/paddle/fluid/operators/controlflow/get_places_op.cc
+++ b/paddle/fluid/operators/controlflow/get_places_op.cc
@@ -94,9 +94,6 @@ execution.
 class GetPlacesInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // for (auto &o_name : ctx->Output("Out")) {
-    //   ctx->SetType(o_name, framework::proto::VarType::PLACE_LIST);
-    // }
     ctx->SetOutputType("Out", framework::proto::VarType::PLACE_LIST,
                        framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/controlflow/get_places_op.cc
+++ b/paddle/fluid/operators/controlflow/get_places_op.cc
@@ -94,9 +94,11 @@ execution.
 class GetPlacesInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    for (auto &o_name : ctx->Output("Out")) {
-      ctx->SetType(o_name, framework::proto::VarType::PLACE_LIST);
-    }
+    // for (auto &o_name : ctx->Output("Out")) {
+    //   ctx->SetType(o_name, framework::proto::VarType::PLACE_LIST);
+    // }
+    ctx->SetOutputType("Out", framework::proto::VarType::PLACE_LIST,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
+++ b/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
@@ -111,15 +111,15 @@ class WriteToArrayInferShape : public framework::InferShapeBase {
   }
 };
 
-class WriteToArrayInferVarType : public framework::VarTypeInference {
+class WriteToArrayInferVarType : public framework::StaticGraphVarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto x_name = ctx->Input("X")[0];
-    auto out_name = ctx->Output("Out")[0];
+    auto x_name = Input(ctx, "X")[0];
+    auto out_name = Output(ctx, "Out")[0];
     VLOG(10) << "Set Variable " << out_name << " as LOD_TENSOR_ARRAY";
-    ctx->SetType(out_name, framework::proto::VarType::LOD_TENSOR_ARRAY);
-    if (ctx->HasVar(x_name)) {
-      ctx->SetDataType(out_name, ctx->GetDataType(x_name));
+    SetType(ctx, out_name, framework::proto::VarType::LOD_TENSOR_ARRAY);
+    if (HasVar(ctx, x_name)) {
+      SetDataType(ctx, out_name, GetDataType(ctx, x_name));
     }
   }
 };

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -434,18 +434,19 @@ class WhileGradOpMaker : public framework::SingleGradOpMaker<T> {
   }
 };
 
-class WhileGradOpVarTypeInference : public framework::VarTypeInference {
+class WhileGradOpVarTypeInference
+    : public framework::StaticGraphVarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto p_names = ctx->Input(kX);
-    auto pg_ig_names = ctx->Output(framework::GradVarName(kX));
+    auto p_names = Input(ctx, kX);
+    auto pg_ig_names = Output(ctx, framework::GradVarName(kX));
 
     for (size_t i = 0; i < p_names.size(); ++i) {
-      if (ctx->HasVar(pg_ig_names[i])) {
+      if (HasVar(ctx, pg_ig_names[i])) {
         VLOG(5) << "Setting " << pg_ig_names[i] << " following " << p_names[i]
-                << " type: " << ctx->GetType(p_names[i]);
-        ctx->SetType(pg_ig_names[i], ctx->GetType(p_names[i]));
-        ctx->SetDataType(pg_ig_names[i], ctx->GetDataType(p_names[i]));
+                << " type: " << GetType(ctx, p_names[i]);
+        SetType(ctx, pg_ig_names[i], GetType(ctx, p_names[i]));
+        SetDataType(ctx, pg_ig_names[i], GetDataType(ctx, p_names[i]));
       }
     }
   }

--- a/paddle/fluid/operators/conv_op.h
+++ b/paddle/fluid/operators/conv_op.h
@@ -254,10 +254,11 @@ class Conv3DOpMaker : public framework::OpProtoAndCheckerMaker {
 
 class ConvOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{
+    static std::unordered_map<std::string, std::string> m{
         {"Input", /*->*/ "Output"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/cross_entropy_op.cc
+++ b/paddle/fluid/operators/cross_entropy_op.cc
@@ -177,9 +177,10 @@ class CrossEntropyGradientOpBase : public framework::OperatorWithKernel {
 class CrossEntropyOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Y"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Y"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/distributed_ops/merge_ids_op.cc
+++ b/paddle/fluid/operators/distributed_ops/merge_ids_op.cc
@@ -115,10 +115,8 @@ class MergeIdsOp : public framework::OperatorWithKernel {
 class MergeIdsOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto input_type = ctx->GetType(ctx->Input("Ids")[0]);
-    for (auto &out_var : ctx->Output("Out")) {
-      ctx->SetType(out_var, input_type);
-    }
+    auto input_type = ctx->GetInputType("Ids");
+    ctx->SetOutputType("Out", input_type, framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/distributed_ops/split_ids_op.cc
+++ b/paddle/fluid/operators/distributed_ops/split_ids_op.cc
@@ -73,10 +73,8 @@ class SplitIdsOp : public framework::OperatorWithKernel {
 class SplitIdsOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto input_type = ctx->GetType(ctx->Input("Ids")[0]);
-    for (auto &out_var : ctx->Output("Out")) {
-      ctx->SetType(out_var, input_type);
-    }
+    auto input_type = ctx->GetInputType("Ids");
+    ctx->SetOutputType("Out", input_type, framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/elementwise/elementwise_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op.h
@@ -119,9 +119,10 @@ class ElementwiseOp : public framework::OperatorWithKernel {
 class ElementwiseOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string> &GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/eye_op.cc
+++ b/paddle/fluid/operators/eye_op.cc
@@ -49,8 +49,8 @@ class EyeOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    auto& out_var_name = ctx->Output("Out").front();
-    ctx->SetDataType(out_var_name, data_type);
+    // auto& out_var_name = ctx->Output("Out").front();
+    ctx->SetOutputDataType("Out", data_type);
   }
 };
 

--- a/paddle/fluid/operators/eye_op.cc
+++ b/paddle/fluid/operators/eye_op.cc
@@ -49,7 +49,6 @@ class EyeOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    // auto& out_var_name = ctx->Output("Out").front();
     ctx->SetOutputDataType("Out", data_type);
   }
 };

--- a/paddle/fluid/operators/fill_any_like_op.cc
+++ b/paddle/fluid/operators/fill_any_like_op.cc
@@ -72,14 +72,12 @@ The output will have the same shape and dtype as the input.
 class FillAnyLikeVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto out_var_name = ctx->Output("Out").front();
     auto var_data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
     if (var_data_type < 0) {
-      const auto &input_var_name = ctx->Input("X").front();
-      ctx->SetDataType(out_var_name, ctx->GetDataType(input_var_name));
+      ctx->SetOutputDataType("Out", ctx->GetInputDataType("X"));
     } else {
-      ctx->SetDataType(out_var_name, var_data_type);
+      ctx->SetOutputDataType("Out", var_data_type);
     }
   }
 };

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -64,7 +64,6 @@ class FillConstantOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    // auto& out_var_name = ctx->Output("Out").front();
     ctx->SetOutputDataType("Out", data_type);
   }
 };

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -64,8 +64,8 @@ class FillConstantOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    auto& out_var_name = ctx->Output("Out").front();
-    ctx->SetDataType(out_var_name, data_type);
+    // auto& out_var_name = ctx->Output("Out").front();
+    ctx->SetOutputDataType("Out", data_type);
   }
 };
 

--- a/paddle/fluid/operators/fill_op.cc
+++ b/paddle/fluid/operators/fill_op.cc
@@ -63,8 +63,8 @@ class FillOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    auto& out_var_name = ctx->Output("Out").front();
-    ctx->SetDataType(out_var_name, data_type);
+    // auto& out_var_name = ctx->Output("Out").front();
+    ctx->SetOutputDataType("Out", data_type);
   }
 };
 

--- a/paddle/fluid/operators/fill_op.cc
+++ b/paddle/fluid/operators/fill_op.cc
@@ -63,7 +63,6 @@ class FillOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    // auto& out_var_name = ctx->Output("Out").front();
     ctx->SetOutputDataType("Out", data_type);
   }
 };

--- a/paddle/fluid/operators/flip_op.cc
+++ b/paddle/fluid/operators/flip_op.cc
@@ -114,9 +114,10 @@ class FlipOpMaker : public framework::OpProtoAndCheckerMaker {
 
 class FlipOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/fused/fused_bn_activation_op.h
+++ b/paddle/fluid/operators/fused/fused_bn_activation_op.h
@@ -87,7 +87,8 @@ class FusedBatchNormActOpInferVarType
  protected:
   std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Y"}};
+    std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Y"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/fused/fused_bn_activation_op.h
+++ b/paddle/fluid/operators/fused/fused_bn_activation_op.h
@@ -85,9 +85,9 @@ class FusedBatchNormActGradOpMaker : public framework::SingleGradOpMaker<T> {
 class FusedBatchNormActOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Y"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Y"}};
     return m;
   }
 };

--- a/paddle/fluid/operators/fused/fused_embedding_seq_pool_op.cc
+++ b/paddle/fluid/operators/fused/fused_embedding_seq_pool_op.cc
@@ -146,19 +146,20 @@ class FusedEmbeddingSeqPoolOpGradVarTypeInference
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    // auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
-    // auto attr = ctx->GetAttr("is_sparse");
-    // bool is_sparse = boost::get<bool>(attr);
-    // if (is_sparse) {
-    //   VLOG(3) << "fused_embedding_seq_pool_grad op "
-    //           << framework::GradVarName("W") << " is set to SelectedRows";
-    //   ctx->SetType(out_var_name, framework::proto::VarType::SELECTED_ROWS);
-    // } else {
-    //   VLOG(3) << "fused_embedding_seq_pool_grad op "
-    //           << framework::GradVarName("W") << " is set to LoDTensor";
-    //   ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
-    // }
-    // ctx->SetDataType(out_var_name, ctx->GetDataType(ctx->Input("W")[0]));
+    auto out_var_name = framework::GradVarName("W");
+    auto attr = ctx->GetAttr("is_sparse");
+    bool is_sparse = boost::get<bool>(attr);
+    if (is_sparse) {
+      VLOG(3) << "fused_embedding_seq_pool_grad op "
+              << framework::GradVarName("W") << " is set to SelectedRows";
+      ctx->SetOutputType(out_var_name,
+                         framework::proto::VarType::SELECTED_ROWS);
+    } else {
+      VLOG(3) << "fused_embedding_seq_pool_grad op "
+              << framework::GradVarName("W") << " is set to LoDTensor";
+      ctx->SetOutputType(out_var_name, framework::proto::VarType::LOD_TENSOR);
+    }
+    ctx->SetOutputDataType(out_var_name, ctx->GetInputDataType("W"));
   }
 };
 

--- a/paddle/fluid/operators/fused/fused_embedding_seq_pool_op.cc
+++ b/paddle/fluid/operators/fused/fused_embedding_seq_pool_op.cc
@@ -146,19 +146,19 @@ class FusedEmbeddingSeqPoolOpGradVarTypeInference
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
-    auto attr = ctx->GetAttr("is_sparse");
-    bool is_sparse = boost::get<bool>(attr);
-    if (is_sparse) {
-      VLOG(3) << "fused_embedding_seq_pool_grad op "
-              << framework::GradVarName("W") << " is set to SelectedRows";
-      ctx->SetType(out_var_name, framework::proto::VarType::SELECTED_ROWS);
-    } else {
-      VLOG(3) << "fused_embedding_seq_pool_grad op "
-              << framework::GradVarName("W") << " is set to LoDTensor";
-      ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
-    }
-    ctx->SetDataType(out_var_name, ctx->GetDataType(ctx->Input("W")[0]));
+    // auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
+    // auto attr = ctx->GetAttr("is_sparse");
+    // bool is_sparse = boost::get<bool>(attr);
+    // if (is_sparse) {
+    //   VLOG(3) << "fused_embedding_seq_pool_grad op "
+    //           << framework::GradVarName("W") << " is set to SelectedRows";
+    //   ctx->SetType(out_var_name, framework::proto::VarType::SELECTED_ROWS);
+    // } else {
+    //   VLOG(3) << "fused_embedding_seq_pool_grad op "
+    //           << framework::GradVarName("W") << " is set to LoDTensor";
+    //   ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
+    // }
+    // ctx->SetDataType(out_var_name, ctx->GetDataType(ctx->Input("W")[0]));
   }
 };
 

--- a/paddle/fluid/operators/get_tensor_from_selected_rows_op.cc
+++ b/paddle/fluid/operators/get_tensor_from_selected_rows_op.cc
@@ -83,11 +83,6 @@ class GetTensorFromSelectedRowsOpVarTypeInference
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const {  // NOLINT
-    // auto out_var_name = ctx->Output("Out").front();
-    // auto in_var_name = ctx->Input("X").front();
-
-    // ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
-    // ctx->SetDataType(out_var_name, ctx->GetDataType(in_var_name));
     ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR);
     ctx->SetOutputDataType("Out", ctx->GetInputDataType("X"));
   }

--- a/paddle/fluid/operators/get_tensor_from_selected_rows_op.cc
+++ b/paddle/fluid/operators/get_tensor_from_selected_rows_op.cc
@@ -83,11 +83,13 @@ class GetTensorFromSelectedRowsOpVarTypeInference
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const {  // NOLINT
-    auto out_var_name = ctx->Output("Out").front();
-    auto in_var_name = ctx->Input("X").front();
+    // auto out_var_name = ctx->Output("Out").front();
+    // auto in_var_name = ctx->Input("X").front();
 
-    ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
-    ctx->SetDataType(out_var_name, ctx->GetDataType(in_var_name));
+    // ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
+    // ctx->SetDataType(out_var_name, ctx->GetDataType(in_var_name));
+    ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR);
+    ctx->SetOutputDataType("Out", ctx->GetInputDataType("X"));
   }
 };
 

--- a/paddle/fluid/operators/group_norm_op.cc
+++ b/paddle/fluid/operators/group_norm_op.cc
@@ -216,9 +216,10 @@ DECLARE_INPLACE_OP_INFERER(GroupNormGradInplaceInToOut,
 class GroupNormOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string> &GetInputOutputWithSameType()
       const override {
-    return {{"X", /*->*/ "Y"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Y"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/hierarchical_sigmoid_op.cc
+++ b/paddle/fluid/operators/hierarchical_sigmoid_op.cc
@@ -229,31 +229,33 @@ class HierarchicalSigmoidGradOpGradVarTypeInference
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    auto w_grad_var_name = ctx->Output(framework::GradVarName("W")).front();
-    auto has_bias_grad_var = ctx->HasOutput(framework::GradVarName("Bias"));
-    std::string bias_grad_var_name;
-    bool hasBias = false;
-    if (has_bias_grad_var) {
-      hasBias = true;
-      bias_grad_var_name = ctx->Output(framework::GradVarName("Bias")).front();
+    // auto w_grad_var_name = ctx->Output(framework::GradVarName("W")).front();
+    // auto has_bias_grad_var = ctx->HasOutput(framework::GradVarName("Bias"));
+
+    auto w_grad_var_name = framework::GradVarName("W");
+    auto bias_grad_var_name = framework::GradVarName("Bias");
+    if (ctx->HasOutput(bias_grad_var_name)) {
+      VLOG(3) << "hierarchical_sigmoid_grad op "
+              << framework::GradVarName("Bias") << " is set to LoDTensor";
+      ctx->SetOutputType(bias_grad_var_name,
+                         framework::proto::VarType::LOD_TENSOR);
     }
+
     auto attr = ctx->GetAttr("is_sparse");
     bool is_sparse = boost::get<bool>(attr);
     if (is_sparse) {
       VLOG(3) << "hierarchical_sigmoid_grad op " << framework::GradVarName("W")
               << " is set to SelectedRows";
-      ctx->SetType(w_grad_var_name, framework::proto::VarType::SELECTED_ROWS);
+      ctx->SetOutputType(w_grad_var_name,
+                         framework::proto::VarType::SELECTED_ROWS);
     } else {
       VLOG(3) << "hierarchical_sigmoid_grad op " << framework::GradVarName("W")
               << " is set to LoDTensor";
-      ctx->SetType(w_grad_var_name, framework::proto::VarType::LOD_TENSOR);
+      ctx->SetOutputType(w_grad_var_name,
+                         framework::proto::VarType::LOD_TENSOR);
     }
-    if (hasBias) {
-      VLOG(3) << "hierarchical_sigmoid_grad op "
-              << framework::GradVarName("Bias") << " is set to LoDTensor";
-      ctx->SetType(bias_grad_var_name, framework::proto::VarType::LOD_TENSOR);
-    }
-    ctx->SetDataType(w_grad_var_name, ctx->GetDataType(ctx->Input("W")[0]));
+
+    ctx->SetOutputDataType(w_grad_var_name, ctx->GetInputDataType("W"));
   }
 };
 

--- a/paddle/fluid/operators/hierarchical_sigmoid_op.cc
+++ b/paddle/fluid/operators/hierarchical_sigmoid_op.cc
@@ -229,9 +229,6 @@ class HierarchicalSigmoidGradOpGradVarTypeInference
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    // auto w_grad_var_name = ctx->Output(framework::GradVarName("W")).front();
-    // auto has_bias_grad_var = ctx->HasOutput(framework::GradVarName("Bias"));
-
     auto w_grad_var_name = framework::GradVarName("W");
     auto bias_grad_var_name = framework::GradVarName("Bias");
     if (ctx->HasOutput(bias_grad_var_name)) {

--- a/paddle/fluid/operators/instance_norm_op.h
+++ b/paddle/fluid/operators/instance_norm_op.h
@@ -123,9 +123,10 @@ class InstanceNormDoubleGradMaker : public framework::SingleGradOpMaker<T> {
 class InstanceNormOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string> &GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", "Y"}};
+    static std::unordered_map<std::string, std::string> m{{"X", "Y"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/lod_rank_table_op.cc
+++ b/paddle/fluid/operators/lod_rank_table_op.cc
@@ -65,9 +65,6 @@ class LoDRankTableInferShape : public framework::InferShapeBase {
 class LoDRankTableInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // for (auto &o : ctx->Output("Out")) {
-    //   ctx->SetType(o, framework::proto::VarType::LOD_RANK_TABLE);
-    // }
     ctx->SetOutputType("Out", framework::proto::VarType::LOD_RANK_TABLE,
                        framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/lod_rank_table_op.cc
+++ b/paddle/fluid/operators/lod_rank_table_op.cc
@@ -65,9 +65,11 @@ class LoDRankTableInferShape : public framework::InferShapeBase {
 class LoDRankTableInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    for (auto &o : ctx->Output("Out")) {
-      ctx->SetType(o, framework::proto::VarType::LOD_RANK_TABLE);
-    }
+    // for (auto &o : ctx->Output("Out")) {
+    //   ctx->SetType(o, framework::proto::VarType::LOD_RANK_TABLE);
+    // }
+    ctx->SetOutputType("Out", framework::proto::VarType::LOD_RANK_TABLE,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/lod_reset_op.cc
+++ b/paddle/fluid/operators/lod_reset_op.cc
@@ -76,24 +76,25 @@ class LoDResetOp : public framework::OperatorWithKernel {
   }
 };
 
-class LoDResetOpVarTypeInference : public framework::VarTypeInference {
+class LoDResetOpVarTypeInference
+    : public framework::StaticGraphVarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto x_var_name = ctx->Input("X").front();
-    auto out_var_name = ctx->Output("Out").front();
+    auto x_var_name = Input(ctx, "X").front();
+    auto out_var_name = Output(ctx, "Out").front();
     bool append = boost::get<bool>(ctx->GetAttr("append"));
     if (ctx->HasInput("Y")) {
-      auto y_var_name = ctx->Input("Y").front();
-      auto y_lod_level = std::max(ctx->GetLoDLevel(y_var_name), 1);
-      ctx->SetLoDLevel(out_var_name, y_lod_level);
+      auto y_var_name = Input(ctx, "Y").front();
+      auto y_lod_level = std::max(GetLoDLevel(ctx, y_var_name), 1);
+      SetLoDLevel(ctx, out_var_name, y_lod_level);
     } else if (append) {
-      auto x_lod_level = std::max(ctx->GetLoDLevel(x_var_name), 1);
-      ctx->SetLoDLevel(out_var_name, x_lod_level);
+      auto x_lod_level = std::max(GetLoDLevel(ctx, x_var_name), 1);
+      SetLoDLevel(ctx, out_var_name, x_lod_level);
     } else {
-      ctx->SetLoDLevel(out_var_name, 1);
+      SetLoDLevel(ctx, out_var_name, 1);
     }
-    ctx->SetDataType(out_var_name, ctx->GetDataType(x_var_name));
-    ctx->SetType(out_var_name, paddle::framework::proto::VarType::LOD_TENSOR);
+    SetDataType(ctx, out_var_name, GetDataType(ctx, x_var_name));
+    SetType(ctx, out_var_name, paddle::framework::proto::VarType::LOD_TENSOR);
   }
 };
 

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -221,9 +221,6 @@ class LoDTensorToArrayInferShape : public framework::InferShapeBase {
 class LoDTensorToArrayInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // for (auto &out_var : ctx->Output("Out")) {
-    //   ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR_ARRAY);
-    // }
     ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR_ARRAY,
                        framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/lod_tensor_to_array_op.cc
+++ b/paddle/fluid/operators/lod_tensor_to_array_op.cc
@@ -221,9 +221,11 @@ class LoDTensorToArrayInferShape : public framework::InferShapeBase {
 class LoDTensorToArrayInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    for (auto &out_var : ctx->Output("Out")) {
-      ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR_ARRAY);
-    }
+    // for (auto &out_var : ctx->Output("Out")) {
+    //   ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR_ARRAY);
+    // }
+    ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR_ARRAY,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/lookup_table_op.cc
+++ b/paddle/fluid/operators/lookup_table_op.cc
@@ -173,7 +173,6 @@ class LookupTableOpGrad : public framework::OperatorWithKernel {
 class LookupTableOpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    // auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
     auto out_var_name = framework::GradVarName("W");
     auto attr = ctx->GetAttr("is_sparse");
     bool is_sparse = boost::get<bool>(attr);

--- a/paddle/fluid/operators/lookup_table_op.cc
+++ b/paddle/fluid/operators/lookup_table_op.cc
@@ -173,19 +173,21 @@ class LookupTableOpGrad : public framework::OperatorWithKernel {
 class LookupTableOpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
+    // auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
+    auto out_var_name = framework::GradVarName("W");
     auto attr = ctx->GetAttr("is_sparse");
     bool is_sparse = boost::get<bool>(attr);
     if (is_sparse) {
       VLOG(3) << "lookup_table_grad op " << framework::GradVarName("W")
               << " is set to SelectedRows";
-      ctx->SetType(out_var_name, framework::proto::VarType::SELECTED_ROWS);
+      ctx->SetOutputType(out_var_name,
+                         framework::proto::VarType::SELECTED_ROWS);
     } else {
       VLOG(3) << "lookup_table_grad op " << framework::GradVarName("W")
               << " is set to LoDTensor";
-      ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
+      ctx->SetOutputType(out_var_name, framework::proto::VarType::LOD_TENSOR);
     }
-    ctx->SetDataType(out_var_name, ctx->GetDataType(ctx->Input("W")[0]));
+    ctx->SetOutputDataType(out_var_name, ctx->GetInputDataType("W"));
   }
 };
 

--- a/paddle/fluid/operators/lookup_table_v2_op.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op.cc
@@ -160,7 +160,6 @@ class LookupTableV2OpGrad : public framework::OperatorWithKernel {
 class LookupTableV2OpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    // auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
     auto out_var_name = framework::GradVarName("W");
     auto attr = ctx->GetAttr("is_sparse");
     bool is_sparse = boost::get<bool>(attr);

--- a/paddle/fluid/operators/lookup_table_v2_op.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op.cc
@@ -160,19 +160,21 @@ class LookupTableV2OpGrad : public framework::OperatorWithKernel {
 class LookupTableV2OpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
+    // auto out_var_name = ctx->Output(framework::GradVarName("W")).front();
+    auto out_var_name = framework::GradVarName("W");
     auto attr = ctx->GetAttr("is_sparse");
     bool is_sparse = boost::get<bool>(attr);
     if (is_sparse) {
       VLOG(3) << "lookup_table_v2_grad op " << framework::GradVarName("W")
               << " is set to SelectedRows";
-      ctx->SetType(out_var_name, framework::proto::VarType::SELECTED_ROWS);
+      ctx->SetOutputType(out_var_name,
+                         framework::proto::VarType::SELECTED_ROWS);
     } else {
       VLOG(3) << "lookup_table_v2_grad op " << framework::GradVarName("W")
               << " is set to LoDTensor";
-      ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
+      ctx->SetOutputType(out_var_name, framework::proto::VarType::LOD_TENSOR);
     }
-    ctx->SetDataType(out_var_name, ctx->GetDataType(ctx->Input("W")[0]));
+    ctx->SetOutputDataType(out_var_name, ctx->GetInputDataType("W"));
   }
 };
 

--- a/paddle/fluid/operators/mean_op.cc
+++ b/paddle/fluid/operators/mean_op.cc
@@ -45,9 +45,10 @@ Mean Operator calculates the mean of all elements in X.
 
 class MeanOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/merge_selected_rows_op.cc
+++ b/paddle/fluid/operators/merge_selected_rows_op.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/merge_selected_rows_op.h"
+#include <unordered_map>
 
 namespace paddle {
 namespace operators {
@@ -79,9 +80,10 @@ Example:
 class MergeSelectedRowsOpInferVarType
     : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/mul_op.cc
+++ b/paddle/fluid/operators/mul_op.cc
@@ -200,9 +200,10 @@ or not. But the output only shares the LoD information with input $X$.
 
 class MulOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/nccl/nccl_op.cc
+++ b/paddle/fluid/operators/nccl/nccl_op.cc
@@ -61,8 +61,6 @@ class NCCLInitOp : public framework::OperatorBase {
 class NCCLInitOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto out_var_name = ctx->Output("Communicator").front();
-    // ctx->SetType(out_var_name, framework::proto::VarType::RAW);
     ctx->SetOutputType("Communicator", framework::proto::VarType::RAW);
   }
 };

--- a/paddle/fluid/operators/nccl/nccl_op.cc
+++ b/paddle/fluid/operators/nccl/nccl_op.cc
@@ -61,8 +61,9 @@ class NCCLInitOp : public framework::OperatorBase {
 class NCCLInitOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto out_var_name = ctx->Output("Communicator").front();
-    ctx->SetType(out_var_name, framework::proto::VarType::RAW);
+    // auto out_var_name = ctx->Output("Communicator").front();
+    // ctx->SetType(out_var_name, framework::proto::VarType::RAW);
+    ctx->SetOutputType("Communicator", framework::proto::VarType::RAW);
   }
 };
 

--- a/paddle/fluid/operators/nce_op.cc
+++ b/paddle/fluid/operators/nce_op.cc
@@ -280,7 +280,6 @@ class NCEOpGrad : public framework::OperatorWithKernel {
 class NCEOpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto weight_grad = ctx->Output(framework::GradVarName("Weight")).front();
     auto weight_grad = framework::GradVarName("Weight");
 
     auto attr = ctx->GetAttr("is_sparse");

--- a/paddle/fluid/operators/nce_op.cc
+++ b/paddle/fluid/operators/nce_op.cc
@@ -280,20 +280,21 @@ class NCEOpGrad : public framework::OperatorWithKernel {
 class NCEOpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto weight_grad = ctx->Output(framework::GradVarName("Weight")).front();
+    // auto weight_grad = ctx->Output(framework::GradVarName("Weight")).front();
+    auto weight_grad = framework::GradVarName("Weight");
 
     auto attr = ctx->GetAttr("is_sparse");
     bool is_sparse = boost::get<bool>(attr);
     if (is_sparse) {
       VLOG(3) << "nce_op_grad op " << weight_grad << " and "
               << " is set to SelectedRows";
-      ctx->SetType(weight_grad, framework::proto::VarType::SELECTED_ROWS);
+      ctx->SetOutputType(weight_grad, framework::proto::VarType::SELECTED_ROWS);
     } else {
       VLOG(3) << "nce_op_grad op " << weight_grad << " and "
               << " is set to LoDTensor";
-      ctx->SetType(weight_grad, framework::proto::VarType::LOD_TENSOR);
+      ctx->SetOutputType(weight_grad, framework::proto::VarType::LOD_TENSOR);
     }
-    ctx->SetDataType(weight_grad, ctx->GetDataType(ctx->Input("Input")[0]));
+    ctx->SetOutputDataType(weight_grad, ctx->GetInputDataType("Input"));
   }
 };
 

--- a/paddle/fluid/operators/optimizers/momentum_op.cc
+++ b/paddle/fluid/operators/optimizers/momentum_op.cc
@@ -22,18 +22,27 @@ using Tensor = framework::Tensor;
 class MomentumOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    auto& input_var = ctx->Input("Param")[0];
-    for (auto& out_var : ctx->Output("ParamOut")) {
-      if (ctx->GetType(input_var) == framework::proto::VarType::SELECTED_ROWS) {
-        ctx->SetType(out_var, framework::proto::VarType::SELECTED_ROWS);
-      } else if (ctx->GetType(input_var) ==
-                 framework::proto::VarType::LOD_TENSOR) {
-        ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR);
-      } else {
-        PADDLE_THROW(
-            "Only support LodTensor and SelectedRows, Unexpected Input Type.");
-      }
-    }
+    // auto& input_var = ctx->Input("Param")[0];
+    // for (auto& out_var : ctx->Output("ParamOut")) {
+    //   if (ctx->GetType(input_var) ==
+    //   framework::proto::VarType::SELECTED_ROWS) {
+    //     ctx->SetType(out_var, framework::proto::VarType::SELECTED_ROWS);
+    //   } else if (ctx->GetType(input_var) ==
+    //              framework::proto::VarType::LOD_TENSOR) {
+    //     ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR);
+    //   } else {
+    //     PADDLE_THROW(
+    //         "Only support LodTensor and SelectedRows, Unexpected Input
+    //         Type.");
+    //   }
+    // }
+    auto in_var_type = ctx->GetInputType("Param");
+    PADDLE_ENFORCE(
+        in_var_type == framework::proto::VarType::SELECTED_ROWS ||
+            in_var_type == framework::proto::VarType::LOD_TENSOR,
+        "Only support LodTensor and SelectedRows, Unexpected Input Type.");
+
+    ctx->SetOutputType("ParamOut", in_var_type, framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/optimizers/momentum_op.cc
+++ b/paddle/fluid/operators/optimizers/momentum_op.cc
@@ -23,9 +23,10 @@ class MomentumOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
     auto in_var_type = ctx->GetInputType("Param");
-    PADDLE_ENFORCE(
+    PADDLE_ENFORCE_EQ(
         in_var_type == framework::proto::VarType::SELECTED_ROWS ||
             in_var_type == framework::proto::VarType::LOD_TENSOR,
+        true,
         platform::errors::InvalidArgument(
             "Only support LodTensor and SelectedRows, Unexpected Input Type."));
 

--- a/paddle/fluid/operators/optimizers/momentum_op.cc
+++ b/paddle/fluid/operators/optimizers/momentum_op.cc
@@ -22,20 +22,6 @@ using Tensor = framework::Tensor;
 class MomentumOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    // auto& input_var = ctx->Input("Param")[0];
-    // for (auto& out_var : ctx->Output("ParamOut")) {
-    //   if (ctx->GetType(input_var) ==
-    //   framework::proto::VarType::SELECTED_ROWS) {
-    //     ctx->SetType(out_var, framework::proto::VarType::SELECTED_ROWS);
-    //   } else if (ctx->GetType(input_var) ==
-    //              framework::proto::VarType::LOD_TENSOR) {
-    //     ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR);
-    //   } else {
-    //     PADDLE_THROW(
-    //         "Only support LodTensor and SelectedRows, Unexpected Input
-    //         Type.");
-    //   }
-    // }
     auto in_var_type = ctx->GetInputType("Param");
     PADDLE_ENFORCE(
         in_var_type == framework::proto::VarType::SELECTED_ROWS ||

--- a/paddle/fluid/operators/optimizers/momentum_op.cc
+++ b/paddle/fluid/operators/optimizers/momentum_op.cc
@@ -26,7 +26,8 @@ class MomentumOpInferVarType : public framework::VarTypeInference {
     PADDLE_ENFORCE(
         in_var_type == framework::proto::VarType::SELECTED_ROWS ||
             in_var_type == framework::proto::VarType::LOD_TENSOR,
-        "Only support LodTensor and SelectedRows, Unexpected Input Type.");
+        platform::errors::InvalidArgument(
+            "Only support LodTensor and SelectedRows, Unexpected Input Type."));
 
     ctx->SetOutputType("ParamOut", in_var_type, framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/optimizers/sgd_op.cc
+++ b/paddle/fluid/operators/optimizers/sgd_op.cc
@@ -75,8 +75,6 @@ class SGDOp : public framework::OperatorWithKernel {
 class SGDOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto &input_var_n = ctx->Input("Param")[0];
-    // auto in_var_type = ctx->GetType(input_var_n);
     auto in_var_type = ctx->GetInputType("Param");
     PADDLE_ENFORCE(in_var_type == framework::proto::VarType::SELECTED_ROWS ||
                        in_var_type == framework::proto::VarType::LOD_TENSOR,
@@ -84,11 +82,6 @@ class SGDOpInferVarType : public framework::VarTypeInference {
                    " but the received type is %s",
                    in_var_type);
 
-    // for (auto &out_var_n : ctx->Output("ParamOut")) {
-    //   if (ctx->GetType(out_var_n) != in_var_type) {
-    //     ctx->SetType(out_var_n, in_var_type);
-    //   }
-    // }
     ctx->SetOutputType("ParamOut", in_var_type, framework::ALL_ELEMENTS);
   }
 };

--- a/paddle/fluid/operators/optimizers/sgd_op.cc
+++ b/paddle/fluid/operators/optimizers/sgd_op.cc
@@ -75,19 +75,21 @@ class SGDOp : public framework::OperatorWithKernel {
 class SGDOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto &input_var_n = ctx->Input("Param")[0];
-    auto in_var_type = ctx->GetType(input_var_n);
+    // auto &input_var_n = ctx->Input("Param")[0];
+    // auto in_var_type = ctx->GetType(input_var_n);
+    auto in_var_type = ctx->GetInputType("Param");
     PADDLE_ENFORCE(in_var_type == framework::proto::VarType::SELECTED_ROWS ||
                        in_var_type == framework::proto::VarType::LOD_TENSOR,
                    "The input Var's type should be LoDtensor or SelectedRows,"
-                   " but the received var(%s)'s type is %s",
-                   input_var_n, in_var_type);
+                   " but the received type is %s",
+                   in_var_type);
 
-    for (auto &out_var_n : ctx->Output("ParamOut")) {
-      if (ctx->GetType(out_var_n) != in_var_type) {
-        ctx->SetType(out_var_n, in_var_type);
-      }
-    }
+    // for (auto &out_var_n : ctx->Output("ParamOut")) {
+    //   if (ctx->GetType(out_var_n) != in_var_type) {
+    //     ctx->SetType(out_var_n, in_var_type);
+    //   }
+    // }
+    ctx->SetOutputType("ParamOut", in_var_type, framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/optimizers/sgd_op.cc
+++ b/paddle/fluid/operators/optimizers/sgd_op.cc
@@ -76,12 +76,12 @@ class SGDOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
     auto in_var_type = ctx->GetInputType("Param");
-    PADDLE_ENFORCE(in_var_type == framework::proto::VarType::SELECTED_ROWS ||
-                       in_var_type == framework::proto::VarType::LOD_TENSOR,
-                   platform::errors::InvalidArgument(
-                       "The input Var's type should be LoDtensor or "
-                       "SelectedRows, but the received type is %s",
-                       in_var_type));
+    PADDLE_ENFORCE_EQ(in_var_type == framework::proto::VarType::SELECTED_ROWS ||
+                          in_var_type == framework::proto::VarType::LOD_TENSOR,
+                      true, platform::errors::InvalidArgument(
+                                "The input Var's type should be LoDtensor or "
+                                "SelectedRows, but the received type is %s",
+                                in_var_type));
 
     ctx->SetOutputType("ParamOut", in_var_type, framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/optimizers/sgd_op.cc
+++ b/paddle/fluid/operators/optimizers/sgd_op.cc
@@ -78,9 +78,10 @@ class SGDOpInferVarType : public framework::VarTypeInference {
     auto in_var_type = ctx->GetInputType("Param");
     PADDLE_ENFORCE(in_var_type == framework::proto::VarType::SELECTED_ROWS ||
                        in_var_type == framework::proto::VarType::LOD_TENSOR,
-                   "The input Var's type should be LoDtensor or SelectedRows,"
-                   " but the received type is %s",
-                   in_var_type);
+                   platform::errors::InvalidArgument(
+                       "The input Var's type should be LoDtensor or "
+                       "SelectedRows, but the received type is %s",
+                       in_var_type));
 
     ctx->SetOutputType("ParamOut", in_var_type, framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -422,9 +422,10 @@ Example:
 
 class PoolOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/print_op.cc
+++ b/paddle/fluid/operators/print_op.cc
@@ -260,9 +260,10 @@ class PrintOpInferShape : public framework::InferShapeBase {
 class PrintOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto input_type = ctx->GetType(ctx->Input("In")[0]);
-    auto out_name = ctx->Output("Out").front();
-    ctx->SetType(out_name, input_type);
+    // auto input_type = ctx->GetType(ctx->Input("In")[0]);
+    // auto out_name = ctx->Output("Out").front();
+    // ctx->SetType(out_name, input_type);
+    ctx->SetOutputType("Out", ctx->GetInputType("In"));
   }
 };
 

--- a/paddle/fluid/operators/print_op.cc
+++ b/paddle/fluid/operators/print_op.cc
@@ -260,9 +260,6 @@ class PrintOpInferShape : public framework::InferShapeBase {
 class PrintOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto input_type = ctx->GetType(ctx->Input("In")[0]);
-    // auto out_name = ctx->Output("Out").front();
-    // ctx->SetType(out_name, input_type);
     ctx->SetOutputType("Out", ctx->GetInputType("In"));
   }
 };

--- a/paddle/fluid/operators/py_func_op.cc
+++ b/paddle/fluid/operators/py_func_op.cc
@@ -116,12 +116,11 @@ static void CallPythonFunc(py::object *callable,
   }
 }
 
-class PyFuncOpVarTypeInference : public framework::VarTypeInference {
+class PyFuncOpVarTypeInference : public framework::StaticGraphVarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    bool has_out = (ctx->HasOutput("Out") && !ctx->Output("Out").empty());
-
-    bool has_in = (ctx->HasInput("X") && !ctx->Input("X").empty());
+    bool has_out = ctx->HasOutput("Out");
+    bool has_in = ctx->HasInput("X");
 
     /**
      * X or Out can be empty, so that py_func can be more flexible
@@ -147,7 +146,7 @@ class PyFuncOpVarTypeInference : public framework::VarTypeInference {
      * the corresponding forward variable
      */
     const std::string kGradVarSuffix = framework::kGradVarSuffix;
-    auto &out_var_names = ctx->Output("Out");
+    auto &out_var_names = Output(ctx, "Out");
     for (auto &out_var_name : out_var_names) {
       if (out_var_name == framework::kEmptyVarName ||
           out_var_name.size() < kGradVarSuffix.size()) {
@@ -157,19 +156,19 @@ class PyFuncOpVarTypeInference : public framework::VarTypeInference {
       size_t len = out_var_name.size() - kGradVarSuffix.size();
       if (out_var_name.substr(len) == kGradVarSuffix) {
         auto fwd_var_name = out_var_name.substr(0, len);
-        PADDLE_ENFORCE_EQ(ctx->HasVar(out_var_name), true,
+        PADDLE_ENFORCE_EQ(HasVar(ctx, out_var_name), true,
                           platform::errors::InvalidArgument(
                               "Backward variable %s not found", out_var_name));
-        PADDLE_ENFORCE_EQ(ctx->HasVar(fwd_var_name), true,
+        PADDLE_ENFORCE_EQ(HasVar(ctx, fwd_var_name), true,
                           platform::errors::InvalidArgument(
                               "Backward variable %s not found", fwd_var_name));
         VLOG(10) << "Infer var_desc of Output(" << out_var_name << ") as Input("
                  << fwd_var_name << ")";
 
-        ctx->SetShape(out_var_name, ctx->GetShape(fwd_var_name));
-        ctx->SetDataType(out_var_name, ctx->GetDataType(fwd_var_name));
-        ctx->SetLoDLevel(out_var_name, ctx->GetLoDLevel(fwd_var_name));
-        ctx->SetType(out_var_name, ctx->GetType(fwd_var_name));
+        SetShape(ctx, out_var_name, GetShape(ctx, fwd_var_name));
+        SetDataType(ctx, out_var_name, GetDataType(ctx, fwd_var_name));
+        SetLoDLevel(ctx, out_var_name, GetLoDLevel(ctx, fwd_var_name));
+        SetType(ctx, out_var_name, GetType(ctx, fwd_var_name));
       }
     }
   }

--- a/paddle/fluid/operators/py_func_op.cc
+++ b/paddle/fluid/operators/py_func_op.cc
@@ -156,12 +156,10 @@ class PyFuncOpVarTypeInference : public framework::StaticGraphVarTypeInference {
       size_t len = out_var_name.size() - kGradVarSuffix.size();
       if (out_var_name.substr(len) == kGradVarSuffix) {
         auto fwd_var_name = out_var_name.substr(0, len);
-        PADDLE_ENFORCE_EQ(HasVar(ctx, out_var_name), true,
-                          platform::errors::InvalidArgument(
-                              "Backward variable %s not found", out_var_name));
-        PADDLE_ENFORCE_EQ(HasVar(ctx, fwd_var_name), true,
-                          platform::errors::InvalidArgument(
-                              "Backward variable %s not found", fwd_var_name));
+        OP_INOUT_CHECK(HasVar(ctx, out_var_name), "Var", out_var_name,
+                       "py_func");
+        OP_INOUT_CHECK(HasVar(ctx, fwd_var_name), "Var", fwd_var_name,
+                       "py_func");
         VLOG(10) << "Infer var_desc of Output(" << out_var_name << ") as Input("
                  << fwd_var_name << ")";
 

--- a/paddle/fluid/operators/randperm_op.cc
+++ b/paddle/fluid/operators/randperm_op.cc
@@ -75,8 +75,7 @@ class RandpermOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext *ctx) const override {
     auto var_data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
-    auto out_var_name = ctx->Output("Out").front();
-    ctx->SetDataType(out_var_name, var_data_type);
+    ctx->SetOutputDataType("Out", var_data_type);
   }
 };
 

--- a/paddle/fluid/operators/reader/read_op.cc
+++ b/paddle/fluid/operators/reader/read_op.cc
@@ -70,18 +70,18 @@ class ReadInferShape : public framework::InferShapeBase {
   }
 };
 
-class ReadInferVarType : public framework::VarTypeInference {
+class ReadInferVarType : public framework::StaticGraphVarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
     bool infer_out = boost::get<bool>(ctx->GetAttr("infer_out"));
     if (infer_out) {
-      std::string reader_name = ctx->Input("Reader")[0];
-      std::vector<std::string> out_names = ctx->Output("Out");
-      auto dtypes = ctx->GetDataTypes(reader_name);
+      std::string reader_name = Input(ctx, "Reader")[0];
+      auto& out_names = Output(ctx, "Out");
+      auto dtypes = GetDataTypes(ctx, reader_name);
       PADDLE_ENFORCE_EQ(dtypes.size(), out_names.size());
       for (size_t i = 0; i < dtypes.size(); ++i) {
-        ctx->SetType(out_names[i], framework::proto::VarType::LOD_TENSOR);
-        ctx->SetDataType(out_names[i], dtypes[i]);
+        SetType(ctx, out_names[i], framework::proto::VarType::LOD_TENSOR);
+        SetDataType(ctx, out_names[i], dtypes[i]);
       }
     }
   }

--- a/paddle/fluid/operators/reader/reader_op_registry.cc
+++ b/paddle/fluid/operators/reader/reader_op_registry.cc
@@ -100,8 +100,8 @@ void FileReaderInferShape::operator()(framework::InferShapeContext* ctx) const {
 
 void FileReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  std::string reader_name = ctx->Output("Out")[0];
-  ctx->SetType(reader_name, framework::proto::VarType::READER);
+  // std::string reader_name = ctx->Output("Out")[0];
+  ctx->SetOutputType("Out", framework::proto::VarType::READER);
 }
 
 void DecoratedReaderInferShape::operator()(
@@ -125,10 +125,10 @@ void DecoratedReaderInferShape::operator()(
 
 void DecoratedReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
-  const std::string& out_reader_name = ctx->Output("Out")[0];
-  ctx->SetType(out_reader_name, framework::proto::VarType::READER);
-  ctx->SetDataTypes(out_reader_name, ctx->GetDataTypes(in_reader_name));
+  // const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
+  // const std::string& out_reader_name = ctx->Output("Out")[0];
+  ctx->SetOutputType("Out", framework::proto::VarType::READER);
+  ctx->SetOutputDataTypes("Out", ctx->GetInputDataTypes("UnderlyingReader"));
 }
 
 void DecoratedReaderMakerBase::Make() {

--- a/paddle/fluid/operators/reader/reader_op_registry.cc
+++ b/paddle/fluid/operators/reader/reader_op_registry.cc
@@ -100,9 +100,8 @@ void FileReaderInferShape::operator()(framework::InferShapeContext* ctx) const {
 
 void FileReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  // std::string reader_name = ctx->Output("Out")[0];
-  // ctx->SetType(reader_name, framework::proto::VarType::READER);
-  ctx->SetOutputType("Out", framework::proto::VarType::READER);
+  std::string reader_name = ctx->Output("Out")[0];
+  ctx->SetType(reader_name, framework::proto::VarType::READER);
 }
 
 void DecoratedReaderInferShape::operator()(
@@ -126,12 +125,10 @@ void DecoratedReaderInferShape::operator()(
 
 void DecoratedReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  // const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
-  // const std::string& out_reader_name = ctx->Output("Out")[0];
-  // ctx->SetType(out_reader_name, framework::proto::VarType::READER);
-  // ctx->SetDataTypes(out_reader_name, ctx->GetDataTypes(in_reader_name));
-  ctx->SetOutputType("Out", framework::proto::VarType::READER);
-  ctx->SyncDataTypes("UnderlyingReader", "Out");
+  const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
+  const std::string& out_reader_name = ctx->Output("Out")[0];
+  ctx->SetType(out_reader_name, framework::proto::VarType::READER);
+  ctx->SetDataTypes(out_reader_name, ctx->GetDataTypes(in_reader_name));
 }
 
 void DecoratedReaderMakerBase::Make() {

--- a/paddle/fluid/operators/reader/reader_op_registry.cc
+++ b/paddle/fluid/operators/reader/reader_op_registry.cc
@@ -100,8 +100,9 @@ void FileReaderInferShape::operator()(framework::InferShapeContext* ctx) const {
 
 void FileReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  std::string reader_name = ctx->Output("Out")[0];
-  ctx->SetType(reader_name, framework::proto::VarType::READER);
+  // std::string reader_name = ctx->Output("Out")[0];
+  // ctx->SetType(reader_name, framework::proto::VarType::READER);
+  ctx->SetOutputType("Out", framework::proto::VarType::READER);
 }
 
 void DecoratedReaderInferShape::operator()(
@@ -125,10 +126,12 @@ void DecoratedReaderInferShape::operator()(
 
 void DecoratedReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
-  const std::string& out_reader_name = ctx->Output("Out")[0];
-  ctx->SetType(out_reader_name, framework::proto::VarType::READER);
-  ctx->SetDataTypes(out_reader_name, ctx->GetDataTypes(in_reader_name));
+  // const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
+  // const std::string& out_reader_name = ctx->Output("Out")[0];
+  // ctx->SetType(out_reader_name, framework::proto::VarType::READER);
+  // ctx->SetDataTypes(out_reader_name, ctx->GetDataTypes(in_reader_name));
+  ctx->SetOutputType("Out", framework::proto::VarType::READER);
+  ctx->SyncDataTypes("UnderlyingReader", "Out");
 }
 
 void DecoratedReaderMakerBase::Make() {

--- a/paddle/fluid/operators/reader/reader_op_registry.cc
+++ b/paddle/fluid/operators/reader/reader_op_registry.cc
@@ -100,7 +100,6 @@ void FileReaderInferShape::operator()(framework::InferShapeContext* ctx) const {
 
 void FileReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  // std::string reader_name = ctx->Output("Out")[0];
   ctx->SetOutputType("Out", framework::proto::VarType::READER);
 }
 
@@ -125,8 +124,6 @@ void DecoratedReaderInferShape::operator()(
 
 void DecoratedReaderInferVarType::operator()(
     framework::InferVarTypeContext* ctx) const {
-  // const std::string& in_reader_name = ctx->Input("UnderlyingReader")[0];
-  // const std::string& out_reader_name = ctx->Output("Out")[0];
   ctx->SetOutputType("Out", framework::proto::VarType::READER);
   ctx->SetOutputDataTypes("Out", ctx->GetInputDataTypes("UnderlyingReader"));
 }

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
@@ -58,8 +58,7 @@ class ReduceSumVarTypeInference : public paddle::framework::VarTypeInference {
     auto data_type = static_cast<paddle::framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("out_dtype")));
     if (data_type >= 0) {
-      auto& out_var_name = ctx->Output("Out").front();
-      ctx->SetDataType(out_var_name, data_type);
+      ctx->SetOutputDataType("Out", data_type);
     }
   }
 };

--- a/paddle/fluid/operators/save_combine_op.cc
+++ b/paddle/fluid/operators/save_combine_op.cc
@@ -85,9 +85,8 @@ to a file on disk.
 class SaveCombineOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    for (auto& o : ctx->Output("Y")) {
-      ctx->SetType(o, framework::proto::VarType::RAW);
-    }
+    ctx->SetOutputType("Y", framework::proto::VarType::RAW,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/save_op.cc
+++ b/paddle/fluid/operators/save_op.cc
@@ -73,7 +73,7 @@ class SaveOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
     auto var_type = framework::proto::VarType::RAW;
-    ctx->SetType(LOOKUP_TABLE_PATH, var_type);
+    ctx->InsertVar(LOOKUP_TABLE_PATH, var_type);
   }
 };
 

--- a/paddle/fluid/operators/scale_op.cc
+++ b/paddle/fluid/operators/scale_op.cc
@@ -82,13 +82,6 @@ $$Out = scale*(X + bias)$$
 class ScaleOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto &in_var_name = ctx->Input("X").front();
-    // auto out_var_name = ctx->Output("Out").front();
-
-    // if (in_var_name != out_var_name) {
-    //   ctx->SetType(out_var_name, ctx->GetType(in_var_name));
-    //   ctx->SetDataType(out_var_name, ctx->GetDataType(in_var_name));
-    // }
     ctx->SyncTypeAndDataType("X", "Out");
   }
 };

--- a/paddle/fluid/operators/scale_op.cc
+++ b/paddle/fluid/operators/scale_op.cc
@@ -82,13 +82,14 @@ $$Out = scale*(X + bias)$$
 class ScaleOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto &in_var_name = ctx->Input("X").front();
-    auto out_var_name = ctx->Output("Out").front();
+    // auto &in_var_name = ctx->Input("X").front();
+    // auto out_var_name = ctx->Output("Out").front();
 
-    if (in_var_name != out_var_name) {
-      ctx->SetType(out_var_name, ctx->GetType(in_var_name));
-      ctx->SetDataType(out_var_name, ctx->GetDataType(in_var_name));
-    }
+    // if (in_var_name != out_var_name) {
+    //   ctx->SetType(out_var_name, ctx->GetType(in_var_name));
+    //   ctx->SetDataType(out_var_name, ctx->GetDataType(in_var_name));
+    // }
+    ctx->SyncTypeAndDataType("X", "Out");
   }
 };
 

--- a/paddle/fluid/operators/selu_op.cc
+++ b/paddle/fluid/operators/selu_op.cc
@@ -45,9 +45,10 @@ class SeluOp : public framework::OperatorWithKernel {
 
 class SeluOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string> &GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/softmax_op.cc
+++ b/paddle/fluid/operators/softmax_op.cc
@@ -145,9 +145,10 @@ For each row $i$ and each column $j$ in the matrix, we have:
 
 class SoftmaxOpInferVarType : public framework::PassInDtypeAndVarTypeToOutput {
  protected:
-  std::unordered_map<std::string, std::string> GetInputOutputWithSameType()
+  std::unordered_map<std::string, std::string>& GetInputOutputWithSameType()
       const override {
-    return std::unordered_map<std::string, std::string>{{"X", /*->*/ "Out"}};
+    static std::unordered_map<std::string, std::string> m{{"X", /*->*/ "Out"}};
+    return m;
   }
 };
 

--- a/paddle/fluid/operators/split_selected_rows_op.cc
+++ b/paddle/fluid/operators/split_selected_rows_op.cc
@@ -64,9 +64,11 @@ class SplitSelectedRowsOp : public framework::OperatorWithKernel {
 class SplitSelectedRowsOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    for (auto &out_var : ctx->Output("Out")) {
-      ctx->SetType(out_var, framework::proto::VarType::SELECTED_ROWS);
-    }
+    // for (auto &out_var : ctx->Output("Out")) {
+    //   ctx->SetType(out_var, framework::proto::VarType::SELECTED_ROWS);
+    // }
+    ctx->SetOutputType("Out", framework::proto::VarType::SELECTED_ROWS,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/split_selected_rows_op.cc
+++ b/paddle/fluid/operators/split_selected_rows_op.cc
@@ -64,9 +64,6 @@ class SplitSelectedRowsOp : public framework::OperatorWithKernel {
 class SplitSelectedRowsOpInferVarType : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // for (auto &out_var : ctx->Output("Out")) {
-    //   ctx->SetType(out_var, framework::proto::VarType::SELECTED_ROWS);
-    // }
     ctx->SetOutputType("Out", framework::proto::VarType::SELECTED_ROWS,
                        framework::ALL_ELEMENTS);
   }

--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -228,7 +228,8 @@ class SumOpVarTypeInference : public framework::VarTypeInference {
               os << "    " << each << " type is " << ctx->GetType(each) << "\n";
             }
           }
-          PADDLE_THROW("Not all inputs are tensor array:\n%s", os.str());
+          PADDLE_THROW(platform::errors::InvalidArgument(
+              "Not all inputs are tensor array:\n%s", os.str()));
         }
         var_type = framework::proto::VarType::LOD_TENSOR_ARRAY;
       } else if (ctx->InputTypeAnyOf("X",

--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -212,9 +212,10 @@ class SumOpVarTypeInference : public framework::VarTypeInference {
   void operator()(framework::InferVarTypeContext* ctx) const override {
     if (!ctx->IsDygraph()) {
       auto var_type = framework::proto::VarType::SELECTED_ROWS;
-      if (VLOG_IS_ON(10) && !ctx->IsDygraph()) {
-        for (auto& name : ctx->Input("X")) {
-          VLOG(10) << name << " " << ctx->GetType(name);
+      if (VLOG_IS_ON(10)) {
+        for (size_t ind = 0; ind < ctx->InputSize("X"); ++ind) {
+          VLOG(10) << ctx->InputVarName("X", ind) << " "
+                   << ctx->GetInputType("X", ind);
         }
       }
 
@@ -223,10 +224,9 @@ class SumOpVarTypeInference : public framework::VarTypeInference {
         if (!ctx->InputTypeAllOf("X",
                                  framework::proto::VarType::LOD_TENSOR_ARRAY)) {
           std::ostringstream os;
-          if (!ctx->IsDygraph()) {
-            for (auto& each : ctx->Input("X")) {
-              os << "    " << each << " type is " << ctx->GetType(each) << "\n";
-            }
+          for (size_t ind = 0; ind < ctx->InputSize("X"); ++ind) {
+            os << "    " << ctx->InputVarName("X", ind) << " type is "
+               << ctx->GetInputType("X", ind) << "\n";
           }
           PADDLE_THROW(platform::errors::InvalidArgument(
               "Not all inputs are tensor array:\n%s", os.str()));

--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -211,29 +211,12 @@ class SumOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
     if (!ctx->IsDygraph()) {
-      // auto& inputs = ctx->Input("X");
       auto var_type = framework::proto::VarType::SELECTED_ROWS;
       if (VLOG_IS_ON(10) && !ctx->IsDygraph()) {
         for (auto& name : ctx->Input("X")) {
           VLOG(10) << name << " " << ctx->GetType(name);
         }
       }
-
-      // bool any_input_is_lod_tensor = std::any_of(
-      //     inputs.begin(), inputs.end(), [ctx](const std::string& name) {
-      //       return ctx->GetType(name) ==
-      //       framework::proto::VarType::LOD_TENSOR;
-      //     });
-
-      // auto is_tensor_array = [ctx](const std::string& name) {
-      //   return ctx->GetType(name) ==
-      //   framework::proto::VarType::LOD_TENSOR_ARRAY;
-      // };
-
-      // bool any_input_is_tensor_array =
-      //     std::any_of(inputs.begin(), inputs.end(), is_tensor_array);
-      // bool all_inputs_are_tensor_array =
-      //     std::all_of(inputs.begin(), inputs.end(), is_tensor_array);
 
       if (ctx->InputTypeAnyOf("X",
                               framework::proto::VarType::LOD_TENSOR_ARRAY)) {
@@ -253,7 +236,6 @@ class SumOpVarTypeInference : public framework::VarTypeInference {
         var_type = framework::proto::VarType::LOD_TENSOR;
       }
 
-      // auto out_var_name = ctx->Output("Out").front();
       ctx->SetOutputType("Out", var_type);
       ctx->SetOutputDataType("Out", ctx->GetInputDataType("X"));
     }

--- a/paddle/fluid/operators/sum_op.cc
+++ b/paddle/fluid/operators/sum_op.cc
@@ -210,43 +210,53 @@ class SumOpMaker : public framework::OpProtoAndCheckerMaker {
 class SumOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext* ctx) const override {
-    auto& inputs = ctx->Input("X");
-    auto var_type = framework::proto::VarType::SELECTED_ROWS;
-    for (auto& name : ctx->Input("X")) {
-      VLOG(10) << name << " " << ctx->GetType(name);
-    }
-
-    bool any_input_is_lod_tensor = std::any_of(
-        inputs.begin(), inputs.end(), [ctx](const std::string& name) {
-          return ctx->GetType(name) == framework::proto::VarType::LOD_TENSOR;
-        });
-
-    auto is_tensor_array = [ctx](const std::string& name) {
-      return ctx->GetType(name) == framework::proto::VarType::LOD_TENSOR_ARRAY;
-    };
-
-    bool any_input_is_tensor_array =
-        std::any_of(inputs.begin(), inputs.end(), is_tensor_array);
-    bool all_inputs_are_tensor_array =
-        std::all_of(inputs.begin(), inputs.end(), is_tensor_array);
-
-    if (any_input_is_tensor_array) {
-      if (!all_inputs_are_tensor_array) {
-        std::ostringstream os;
-        for (auto& each : inputs) {
-          os << "    " << each << " type is " << ctx->GetType(each) << "\n";
+    if (!ctx->IsDygraph()) {
+      // auto& inputs = ctx->Input("X");
+      auto var_type = framework::proto::VarType::SELECTED_ROWS;
+      if (VLOG_IS_ON(10) && !ctx->IsDygraph()) {
+        for (auto& name : ctx->Input("X")) {
+          VLOG(10) << name << " " << ctx->GetType(name);
         }
-        PADDLE_ENFORCE_EQ(all_inputs_are_tensor_array, true,
-                          "Not all inputs are tensor array:\n%s", os.str());
       }
-      var_type = framework::proto::VarType::LOD_TENSOR_ARRAY;
-    } else if (any_input_is_lod_tensor) {
-      var_type = framework::proto::VarType::LOD_TENSOR;
-    }
 
-    auto out_var_name = ctx->Output("Out").front();
-    ctx->SetType(out_var_name, var_type);
-    ctx->SetDataType(out_var_name, ctx->GetDataType(inputs.front()));
+      // bool any_input_is_lod_tensor = std::any_of(
+      //     inputs.begin(), inputs.end(), [ctx](const std::string& name) {
+      //       return ctx->GetType(name) ==
+      //       framework::proto::VarType::LOD_TENSOR;
+      //     });
+
+      // auto is_tensor_array = [ctx](const std::string& name) {
+      //   return ctx->GetType(name) ==
+      //   framework::proto::VarType::LOD_TENSOR_ARRAY;
+      // };
+
+      // bool any_input_is_tensor_array =
+      //     std::any_of(inputs.begin(), inputs.end(), is_tensor_array);
+      // bool all_inputs_are_tensor_array =
+      //     std::all_of(inputs.begin(), inputs.end(), is_tensor_array);
+
+      if (ctx->InputTypeAnyOf("X",
+                              framework::proto::VarType::LOD_TENSOR_ARRAY)) {
+        if (!ctx->InputTypeAllOf("X",
+                                 framework::proto::VarType::LOD_TENSOR_ARRAY)) {
+          std::ostringstream os;
+          if (!ctx->IsDygraph()) {
+            for (auto& each : ctx->Input("X")) {
+              os << "    " << each << " type is " << ctx->GetType(each) << "\n";
+            }
+          }
+          PADDLE_THROW("Not all inputs are tensor array:\n%s", os.str());
+        }
+        var_type = framework::proto::VarType::LOD_TENSOR_ARRAY;
+      } else if (ctx->InputTypeAnyOf("X",
+                                     framework::proto::VarType::LOD_TENSOR)) {
+        var_type = framework::proto::VarType::LOD_TENSOR;
+      }
+
+      // auto out_var_name = ctx->Output("Out").front();
+      ctx->SetOutputType("Out", var_type);
+      ctx->SetOutputDataType("Out", ctx->GetInputDataType("X"));
+    }
   }
 };
 

--- a/paddle/fluid/operators/tensor_array_to_tensor_op.cc
+++ b/paddle/fluid/operators/tensor_array_to_tensor_op.cc
@@ -213,9 +213,6 @@ class LoDTensorArray2TensorGradInferVarType
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // for (auto &out_var : ctx->Output(framework::GradVarName("X"))) {
-    //   ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR_ARRAY);
-    // }
     ctx->SetOutputType(framework::GradVarName("X"),
                        framework::proto::VarType::LOD_TENSOR_ARRAY,
                        framework::ALL_ELEMENTS);

--- a/paddle/fluid/operators/tensor_array_to_tensor_op.cc
+++ b/paddle/fluid/operators/tensor_array_to_tensor_op.cc
@@ -213,9 +213,12 @@ class LoDTensorArray2TensorGradInferVarType
     : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    for (auto &out_var : ctx->Output(framework::GradVarName("X"))) {
-      ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR_ARRAY);
-    }
+    // for (auto &out_var : ctx->Output(framework::GradVarName("X"))) {
+    //   ctx->SetType(out_var, framework::proto::VarType::LOD_TENSOR_ARRAY);
+    // }
+    ctx->SetOutputType(framework::GradVarName("X"),
+                       framework::proto::VarType::LOD_TENSOR_ARRAY,
+                       framework::ALL_ELEMENTS);
   }
 };
 

--- a/paddle/fluid/operators/uniform_random_op.cc
+++ b/paddle/fluid/operators/uniform_random_op.cc
@@ -232,15 +232,16 @@ uniform distribution. The random result is in set [min, max).
 class UniformRandomOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto out_var_name = ctx->Output("Out").front();
+    // auto out_var_name = ctx->Output("Out").front();
     auto var_data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
 
-    if (ctx->GetType(out_var_name) !=
+    // if (ctx->GetType(out_var_name) !=
+    if (ctx->GetOutputDataType("Out") !=
         framework::proto::VarType::SELECTED_ROWS) {
-      ctx->SetType(out_var_name, framework::proto::VarType::LOD_TENSOR);
+      ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR);
     }
-    ctx->SetDataType(out_var_name, var_data_type);
+    ctx->SetOutputDataType("Out", var_data_type);
   }
 };
 

--- a/paddle/fluid/operators/uniform_random_op.cc
+++ b/paddle/fluid/operators/uniform_random_op.cc
@@ -235,8 +235,7 @@ class UniformRandomOpVarTypeInference : public framework::VarTypeInference {
     auto var_data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
 
-    if (ctx->GetOutputDataType("Out") !=
-        framework::proto::VarType::SELECTED_ROWS) {
+    if (ctx->GetOutputType("Out") != framework::proto::VarType::SELECTED_ROWS) {
       ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR);
     }
     ctx->SetOutputDataType("Out", var_data_type);

--- a/paddle/fluid/operators/uniform_random_op.cc
+++ b/paddle/fluid/operators/uniform_random_op.cc
@@ -232,11 +232,9 @@ uniform distribution. The random result is in set [min, max).
 class UniformRandomOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    // auto out_var_name = ctx->Output("Out").front();
     auto var_data_type = static_cast<framework::proto::VarType::Type>(
         boost::get<int>(ctx->GetAttr("dtype")));
 
-    // if (ctx->GetType(out_var_name) !=
     if (ctx->GetOutputDataType("Out") !=
         framework::proto::VarType::SELECTED_ROWS) {
       ctx->SetOutputType("Out", framework::proto::VarType::LOD_TENSOR);


### PR DESCRIPTION
RuntimeInferVarType两个主要的性能瓶颈：
**1.  RuntimeInferVarTypeContext 的构造函数在整合Input和Output来适配静态图接口导致的高频unordered_map, vector的构造和析构**
【改动】
将原有的InferVarTypeContext接口根据使用场景是Input还是Output做了拆分:

- SetType = > SetOutputType
-  GetType =>  GetInputType
- ...

对于检查Input中是否存在/都是 某type类型的逻辑，抽象出新的接口在Context内部实现：
      
- InputTypeAnyOf
- InputTypeAllOf

通过拆分、新增接口达到动态图、静态图可以根据各自原有数据结构来实现接口逻辑的目的，动态图无需通过数据拷贝来适配静态图逻辑。

【遗留问题】
1. 一定程度上增加了InferVarType 逻辑实现的限制，改动之后逻辑更多在Context内部实现，不建议OP定制逻辑直接操作Input、Output内部的Var List
2. 暂时还保留了进行拆分的原有API，原有API改为在RuntimeInferVarType 中不可用
3. [save_op](https://github.com/PaddlePaddle/Paddle/blob/79d712346fbea3782f3bdda9bb42ad955a4dcb26/paddle/fluid/operators/save_op.cc#L76) 中使用SetType函数操作了非Input/Output中的Var - 直接创建了新的Var，因为这个原因，暂时在RuntimeInferVartype中保留了SetType函数，不做任何操作，跟此次修改前逻辑保持一致。


**2. PassInDtypeAndVarTypeToOutput ()operator中返回unordered_map导致的map反复创建和析构**
【改动】
本次的改动比较简单粗暴，将创建的映射表改为static，由返回拷贝改为返回引用
