### PR TITLE
fix print bug of profile report

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -173,7 +173,7 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
       platform::RecordEvent op_type_record_event(Type());
       auto op_name = platform::OpName(outputs_, Type());
       platform::RecordEvent op_name_record_event(
-          op_name, platform::RecordRole::kUniqueOp);
+          op_name, platform::EventRole::kUniqueOp);
       RunImpl(scope, place);
     }
 
@@ -957,7 +957,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   Scope* transfer_scope = nullptr;
   {
     platform::RecordEvent record_event("prepare_data",
-                                       platform::RecordRole::kInnerOp);
+                                       platform::EventRole::kInnerOp);
     transfer_scope = PrepareData(scope, *kernel_type_, &transfered_inplace_vars,
                                  runtime_ctx);
   }
@@ -971,7 +971,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   if (!all_kernels_must_compute_runtime_shape_) {
     platform::RecordEvent record_event("infer_shape",
-                                       platform::RecordRole::kInnerOp);
+                                       platform::EventRole::kInnerOp);
     RuntimeInferShapeContext infer_shape_ctx(*this, *runtime_ctx);
     this->InferShape(&infer_shape_ctx);
   }
@@ -984,7 +984,7 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   // not Scope. Imperative mode only pass inputs and get outputs.
   {
     platform::RecordEvent record_event("compute",
-                                       platform::RecordRole::kInnerOp);
+                                       platform::EventRole::kInnerOp);
     (*kernel_func_)(ExecutionContext(*this, exec_scope, *dev_ctx, *runtime_ctx,
                                      kernel_configs));
   }

--- a/paddle/fluid/platform/event.h
+++ b/paddle/fluid/platform/event.h
@@ -25,18 +25,27 @@ namespace platform {
 
 enum class EventType { kMark, kPushRange, kPopRange };
 
+enum class EventRole {
+  kOrdinary,  // only record op time with op type key
+  kInnerOp,   // record op detail time with op type key
+  kUniqueOp,  // record op detail time with op unique name key
+};
+
 class Event {
  public:
   // The DeviceContext is used to get the cuda stream.
   // If CPU profiling mode, can pass nullptr.
-  Event(EventType type, std::string name, uint32_t thread_id);
+  Event(EventType type, std::string name, uint32_t thread_id,
+        EventRole role = EventRole::kOrdinary);
 
   const EventType& type() const;
   Event* parent() const { return parent_; }
   void set_parent(Event* parent) { parent_ = parent; }
   std::string name() const { return name_; }
+  EventRole role() const { return role_; }
   uint32_t thread_id() const { return thread_id_; }
   void set_name(std::string name) { name_ = name; }
+  void set_role(EventRole role) { role_ = role; }
 
 #ifdef PADDLE_WITH_CUDA
 #ifndef PADDLE_WITH_CUPTI
@@ -53,6 +62,7 @@ class Event {
   std::string name_{};
   Event* parent_{nullptr};
   uint32_t thread_id_;
+  EventRole role_{};
   int64_t cpu_ns_;
   bool visited_status_{false};
 #ifdef PADDLE_WITH_CUDA

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -43,12 +43,6 @@ enum class ProfilerState {
   kAll,       // Profile both CPU and GPU. (Currently experimental).
 };
 
-enum class RecordRole {
-  kOrdinary,  // only record op time with op type key
-  kInnerOp,   // record op detail time with op type key
-  kUniqueOp,  // record op detail time with op unique name key
-};
-
 // it is the flag to control to print the profiling result
 enum class TracerOption {
   kDefault,      // print the different op type profiling result
@@ -86,6 +80,7 @@ struct EventItem {
   double cpu_time;
   double gpu_time;
   float ratio;
+  EventRole role;
 };
 
 struct OverHead {
@@ -128,7 +123,7 @@ struct MemEvenRecorder {
 
 struct RecordEvent {
   RecordEvent(const std::string& name,
-              const RecordRole role = RecordRole::kOrdinary);
+              const EventRole role = EventRole::kOrdinary);
 
   ~RecordEvent();
 
@@ -139,7 +134,7 @@ struct RecordEvent {
   // Need to distinguish name by op type, block_id, program_id and perhaps
   // different kernel invocations within an op.
   std::string full_name_;
-  RecordRole role_{RecordRole::kOrdinary};
+  EventRole role_{EventRole::kOrdinary};
 };
 
 class RecordRPCEvent {
@@ -201,7 +196,7 @@ void PushMemEvent(uint64_t start_ns, uint64_t end_ns, size_t bytes,
                   const Place& place, const std::string& annotation);
 void PopMemEvent(uint64_t start_ns, uint64_t end_ns, size_t bytes,
                  const Place& place, const std::string& annotation);
-Event* PushEvent(const std::string& name);
+Event* PushEvent(const std::string& name, const EventRole role);
 void PopEvent(const std::string& name);
 // Return the event list of all threads. Assumed the returned value calls
 // event_lists, event_lists[i][j] represents the j-th Event of i-th thread.

--- a/paddle/fluid/platform/profiler_helper.h
+++ b/paddle/fluid/platform/profiler_helper.h
@@ -304,9 +304,9 @@ void SetEvent(bool merge_thread, Event analyze_event, size_t *max_name_width,
 
       if (event_idx->find(event_name) == event_idx->end()) {
         event_idx->insert({event_name, event_items->size()});
-        EventItem event_item = {event_name, 1,          event_time,
-                                event_time, event_time, event_time,
-                                cpu_time,   gpu_time,   0.};
+        EventItem event_item = {event_name, 1,          event_time, event_time,
+                                event_time, event_time, cpu_time,   gpu_time,
+                                0.,         rit->role()};
         event_items->push_back(event_item);
       } else {
         int index = event_idx->at(event_name);
@@ -335,8 +335,10 @@ void SetEvent(bool merge_thread, Event analyze_event, size_t *max_name_width,
 
 void ComputeOverhead(const std::multimap<std::string, EventItem> &sub_child_map,
                      OverHead *overhead) {
-  EventItem memcpy_async = {"GpuMemcpyAsync", 0, 0., 0., 0., 0., 0., 0., 0.0f};
-  EventItem memcpy_sync = {"GpuMemcpySync", 0, 0., 0., 0., 0., 0., 0., 0.0f};
+  EventItem memcpy_async = {
+      "GpuMemcpyAsync", 0, 0., 0., 0., 0., 0., 0., 0.0f, EventRole::kOrdinary};
+  EventItem memcpy_sync = {"GpuMemcpySync",     0, 0., 0., 0., 0., 0., 0., 0.0f,
+                           EventRole::kOrdinary};
   for (auto it = sub_child_map.begin(); it != sub_child_map.end(); it++) {
     if (it->second.name.find("compute") != std::string::npos) {
       overhead->compute_ratio += it->second.ratio;
@@ -359,6 +361,29 @@ void ComputeOverhead(const std::multimap<std::string, EventItem> &sub_child_map,
   overhead->sub_memcpy_items = {memcpy_async, memcpy_sync};
 }
 
+std::string FindOrdinaryParent(
+    const std::multimap<std::string, EventItem> &sub_child_map,
+    std::string name) {
+  bool find_name = false;
+  std::string parent = name;
+  EventRole role;
+  for (auto it = sub_child_map.begin(); it != sub_child_map.end(); it++) {
+    if (it->second.name == name) {
+      role = it->second.role;
+      parent = it->first;
+      find_name = true;
+      break;
+    }
+  }
+  if (find_name && role == EventRole::kOrdinary) {
+    return name;
+  } else if (find_name && role != EventRole::kOrdinary) {
+    return FindOrdinaryParent(sub_child_map, parent);
+  } else {
+    return parent;
+  }
+}
+
 // When TracerOption is KDefault, OpDetail will be recorded but only default
 // profile result will be printed.
 // GpuMemcpy should be printed in kDefault setting, however it offten occurs
@@ -376,11 +401,7 @@ void GetChildMap(const std::multimap<std::string, EventItem> &sub_child_map,
   } else {
     for (auto it = sub_child_map.begin(); it != sub_child_map.end(); it++) {
       if (it->second.name.find("GpuMemcpy") != std::string::npos) {
-        std::string parent_name = it->first;
-        auto left_pos = it->first.find("/");
-        if (left_pos != std::string::npos) {
-          parent_name = it->first.substr(0, left_pos);
-        }
+        std::string parent_name = FindOrdinaryParent(sub_child_map, it->first);
         auto item = it->second;
         auto right_pos = item.name.rfind("/");
         if (right_pos != std::string::npos) {
@@ -389,6 +410,9 @@ void GetChildMap(const std::multimap<std::string, EventItem> &sub_child_map,
           item.name = parent_name + "/" + child_name;
         }
         child_map->insert(std::pair<std::string, EventItem>(parent_name, item));
+      } else if (it->second.role == EventRole::kOrdinary) {
+        child_map->insert(
+            std::pair<std::string, EventItem>(it->first, it->second));
       }
     }
   }

--- a/paddle/fluid/platform/profiler_test.cc
+++ b/paddle/fluid/platform/profiler_test.cc
@@ -40,6 +40,7 @@ TEST(RecordEvent, RecordEvent) {
   using paddle::platform::PopEvent;
   using paddle::platform::ProfilerState;
   using paddle::platform::EventSortingKey;
+  using paddle::platform::EventRole;
 
   ProfilerState state = ProfilerState::kCPU;
   EnableProfiler(state);
@@ -55,7 +56,7 @@ TEST(RecordEvent, RecordEvent) {
   for (int loop = 0; loop < 3; ++loop) {
     for (int i = 1; i < 5; ++i) {
       std::string name = "op_" + std::to_string(i);
-      PushEvent(name);
+      PushEvent(name, EventRole::kOrdinary);
       int counter = 1;
       while (counter != i * 1000) counter++;
       PopEvent(name);
@@ -107,7 +108,7 @@ TEST(RecordEvent, RecordEvent) {
   }
 
   // Bad Usage:
-  PushEvent("event_without_pop");
+  PushEvent("event_without_pop", EventRole::kOrdinary);
   PopEvent("event_without_push");
   std::vector<std::vector<Event>> events = paddle::platform::GetAllEvents();
 


### PR DESCRIPTION
fix print bug of profile report:
- before：some events of kOrdinary is not printed.
![image](https://user-images.githubusercontent.com/26615455/75639223-c20ad500-5c6a-11ea-919f-f90319c935bd.png)
- after:
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Total time: 3.0977
  Computation time       Total: 2.34272     Ratio: 75.6277%
  Framework overhead     Total: 0.754981    Ratio: 24.3723%

-------------------------     GpuMemCpy Summary     -------------------------

GpuMemcpy                Calls: 3           Total: 0.125296    Ratio: 4.04481%
  GpuMemcpyAsync         Calls: 3           Total: 0.125296    Ratio: 4.04481%

-------------------------       Event Summary       -------------------------

Event                                                                         Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
thread0::lookup_table                                                         1           1.58523     1.579889 (0.996629)     0.005344 (0.003371)     1.58523     1.58523     1.58523     0.511745
thread0::recurrent                                                            1           1.23992     1.157229 (0.933310)     0.082690 (0.066690)     1.23992     1.23992     1.23992     0.400271
  thread0::recurrent/mul                                                      2           0.455774    0.388764 (0.852975)     0.067010 (0.147025)     0.146808    0.308966    0.227887    0.147133
  thread0::recurrent/sum                                                      1           0.133077    0.130037 (0.977156)     0.003040 (0.022844)     0.133077    0.133077    0.133077    0.0429599
  thread0::recurrent/elementwise_add                                          1           0.114945    0.111457 (0.969655)     0.003488 (0.030345)     0.114945    0.114945    0.114945    0.0371066
  thread0::recurrent/relu                                                     1           0.081749    0.078773 (0.963596)     0.002976 (0.036404)     0.081749    0.081749    0.081749    0.0263902
  thread0::recurrent/rnn_memory_helper                                        2           0.134996    0.130548 (0.967051)     0.004448 (0.032949)     0.046149    0.088847    0.067498    0.0435794
    thread0::recurrent/rnn_memory_helper/GpuMemcpyAsync(same_gpu):GPU->GPU    2           0.091876    0.087428 (0.951587)     0.004448 (0.048413)     0.030929    0.060947    0.045938    0.0296594
  thread0::recurrent/GpuMemcpyAsync(same_gpu):GPU->GPU                        1           0.03342     0.031692 (0.948294)     0.001728 (0.051706)     0.03342     0.03342     0.03342     0.0107886
thread0::transpose2                                                           1           0.162743    0.158871 (0.976208)     0.003872 (0.023792)     0.162743    0.162743    0.162743    0.0525367
thread0::fill_constant_batch_size_like                                        1           0.084823    0.082391 (0.971329)     0.002432 (0.028671)     0.084823    0.084823    0.084823    0.0273826
thread0::feed                                                                 1           0.024982    0.024982 (1.000000)     0.000000 (0.000000)     0.024982    0.024982    0.024982    0.00806469
```


