### PR TITLE
Support Tensor.shape in dygraph_to_static

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -123,8 +123,7 @@ class DygraphToStaticAst(gast.NodeTransformer):
         self.static_analysis_visitor = StaticAnalysisVisitor(root)
         self.static_analysis_root = self.static_analysis_visitor.get_node_wrapper_root(
         )
-        # self.static_analysis_root = StaticAnalysisVisitor(
-        #     root).get_node_wrapper_root()
+
         self.decorate_func_name = None
         self.arg_name_to_idx = {}
         self.transfer_from_node_type(self.static_analysis_root)
@@ -194,9 +193,8 @@ class BasicApiTransformer(gast.NodeTransformer):
         self._run_static_visitor()
         self.name_to_tensor_shape = {}
 
-    # todo: change func name
     def _run_static_visitor(self):
-        # todo: if Tensor.shape used in sub function
+        # TODO: If Tensor.shape used in sub function
         var_env = self.static_analysis_visitor.get_var_env()
         var_env.cur_scope = var_env.cur_scope.sub_scopes[0]
         self.scope_var_type_dict = var_env.get_scope_var_type()
@@ -364,7 +362,7 @@ class BasicApiTransformer(gast.NodeTransformer):
 
     def _update_name_to_tensor_shape(self, node):
         assert isinstance(node, gast.Assign)
-        target_node = node.targets[0]  # todo: targets may more than one
+        target_node = node.targets[0]
         value_node = node.value
         target_id = target_node.id
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_utils.py
@@ -360,7 +360,9 @@ def ast_to_func(ast_root, func_name, delete_on_exit=True):
     # TODO(Aurelius84): more elegant way to transform ast into callable object
     import_str = "import paddle\n" \
                  "import paddle.fluid as fluid\n" \
-                 "import paddle.fluid.layers as layers\n"
+                 "import paddle.fluid.layers as layers\n" \
+                 "import numpy as np\n" \
+                 "import numpy\n"
     with f:
         module_name = os.path.basename(f.name[:-3])
         f.write(import_str)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -181,3 +181,12 @@ def update_args_of_func(node, dygraph_node, method_name):
 
     node.args = []
     node.keywords = added_keywords + node.keywords
+
+
+def create_api_shape_node(tensor_shape_node):
+    assert isinstance(tensor_shape_node, gast.Attribute)
+    api_shape_node = gast.Call(
+        func=gast.parse('fluid.layers.shape').body[0].value,
+        args=[tensor_shape_node.value],
+        keywords=[])
+    return api_shape_node

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -62,18 +62,21 @@ def dyfunc_tensor_shape_4(x):
     return res
 
 
-def dyfunc_tensor_shape(x):
+def dyfunc_tensor_shape_5(x):
     x = fluid.dygraph.to_variable(x)
-    s = x.shape[0]
-    res = fluid.layers.reshape(x, shape=(-1, s))
+    s1 = x.shape[0]
+    res = fluid.layers.reshape(x, shape=(-1, s1))
+    s2 = x.shape
+    res2 = fluid.layers.reshape(x, shape=s2)
     return res
 
 
-test_funcs = [dyfunc_tensor_shape]
+# test_funcs = [dyfunc_tensor_shape]
 
-# test_funcs = [
-#     dyfunc_tensor_shape_1, dyfunc_tensor_shape_2, dyfunc_tensor_shape_3,dyfunc_tensor_shape_4
-# ]
+test_funcs = [
+    dyfunc_tensor_shape_1, dyfunc_tensor_shape_2, dyfunc_tensor_shape_3,
+    dyfunc_tensor_shape_4, dyfunc_tensor_shape_5
+]
 
 
 class TestTensorShape(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -29,7 +29,9 @@ def dyfunc_tensor_shape_1(x):
 
 def dyfunc_tensor_shape_2(x):
     x = fluid.dygraph.to_variable(x)
-    res = fluid.layers.reshape(x, x.shape)
+    shape = x.shape
+    shape2 = shape
+    res = fluid.layers.reshape(x, shape2)
     return res
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -1,0 +1,93 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import numpy
+import paddle.fluid as fluid
+import unittest
+from paddle.fluid.dygraph.jit import dygraph_to_static_graph
+
+SEED = 2020
+numpy.random.seed(SEED)
+
+# def dyfunc_tensor_shape(x):
+#     expand_times = [1] * len(x.shape)
+#     x = fluid.dygraph.to_variable(x)
+#     a = x.shape
+#     res1 = fluid.layers.reshape(x, shape=x.shape)
+#     b = numpy.ones(5)
+#     c = fluid.layers.reshape(x, shape=b.shape)
+#     res3 = fluid.layers.reshape(x, x.shape)
+#     return res1
+
+
+def dyfunc_tensor_shape_1(x):
+    x = fluid.dygraph.to_variable(x)
+    res = fluid.layers.reshape(x, shape=x.shape)
+    return res
+
+
+def dyfunc_tensor_shape_2(x):
+    x = fluid.dygraph.to_variable(x)
+    res = fluid.layers.reshape(x, x.shape)
+    return res
+
+
+def dyfunc_tensor_shape_3(x):
+    x = fluid.dygraph.to_variable(x)
+    y = numpy.ones(5)
+    res = fluid.layers.reshape(x, shape=y.shape)
+    return res
+
+
+# test_funcs = [dyfunc_tensor_shape]
+test_funcs = [
+    dyfunc_tensor_shape_1, dyfunc_tensor_shape_2, dyfunc_tensor_shape_3
+]
+
+
+class TestTensorShape(unittest.TestCase):
+    def setUp(self):
+        self.input = numpy.ones(5).astype("int32")
+
+    def get_dygraph_output(self):
+        with fluid.dygraph.guard():
+            res = self.dygraph_func(self.input).numpy()
+            return res
+
+    def get_static_output(self):
+        main_program = fluid.Program()
+        main_program.random_seed = SEED
+        with fluid.program_guard(main_program):
+            static_out = dygraph_to_static_graph(self.dygraph_func)(self.input)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        static_res = exe.run(main_program, fetch_list=static_out)
+
+        return static_res[0]
+
+    def test_transformed_static_result(self):
+        for func in test_funcs:
+            self.dygraph_func = func
+            dygraph_res = self.get_dygraph_output()
+            static_res = self.get_static_output()
+            self.assertTrue(
+                numpy.allclose(dygraph_res, static_res),
+                msg='dygraph res is {}\nstatic_res is {}'.format(dygraph_res,
+                                                                 static_res))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -55,10 +55,17 @@ def dyfunc_tensor_shape_3(x):
     return res
 
 
+def dyfunc_tensor_shape_4(x):
+    x = fluid.dygraph.to_variable(x)
+    # res = fluid.layers.reshape(x, shape=(-1, len(x.shape[0])))
+    res = fluid.layers.reshape(x, shape=(-1, x.shape[0]))
+    return res
+
+
 def dyfunc_tensor_shape(x):
     x = fluid.dygraph.to_variable(x)
-    res = fluid.layers.reshape(x, shape=(-1, len(x.shape[0])))
-    res = fluid.layers.reshape(x, shape=(-1, x.shape))
+    s = x.shape[0]
+    res = fluid.layers.reshape(x, shape=(-1, s))
     return res
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -23,8 +23,11 @@ SEED = 2020
 numpy.random.seed(SEED)
 
 # def dyfunc_tensor_shape(x):
-#     expand_times = [1] * len(x.shape)
+#
+#
 #     x = fluid.dygraph.to_variable(x)
+#     expand_times = [1] * len(x.shape)
+#     fluid.layers.reshape(x, shape=(-1, x.shape[0]))
 #     a = x.shape
 #     res1 = fluid.layers.reshape(x, shape=x.shape)
 #     b = numpy.ones(5)
@@ -52,10 +55,18 @@ def dyfunc_tensor_shape_3(x):
     return res
 
 
-# test_funcs = [dyfunc_tensor_shape]
-test_funcs = [
-    dyfunc_tensor_shape_1, dyfunc_tensor_shape_2, dyfunc_tensor_shape_3
-]
+def dyfunc_tensor_shape(x):
+    x = fluid.dygraph.to_variable(x)
+    res = fluid.layers.reshape(x, shape=(-1, len(x.shape[0])))
+    res = fluid.layers.reshape(x, shape=(-1, x.shape))
+    return res
+
+
+test_funcs = [dyfunc_tensor_shape]
+
+# test_funcs = [
+#     dyfunc_tensor_shape_1, dyfunc_tensor_shape_2, dyfunc_tensor_shape_3,dyfunc_tensor_shape_4
+# ]
 
 
 class TestTensorShape(unittest.TestCase):
@@ -81,8 +92,8 @@ class TestTensorShape(unittest.TestCase):
     def test_transformed_static_result(self):
         for func in test_funcs:
             self.dygraph_func = func
-            dygraph_res = self.get_dygraph_output()
             static_res = self.get_static_output()
+            dygraph_res = self.get_dygraph_output()
             self.assertTrue(
                 numpy.allclose(dygraph_res, static_res),
                 msg='dygraph res is {}\nstatic_res is {}'.format(dygraph_res,

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -65,6 +65,8 @@ test_funcs = [
 class TestTensorShape(unittest.TestCase):
     def setUp(self):
         self.input = numpy.ones(5).astype("int32")
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
 
     def get_dygraph_output(self):
         with fluid.dygraph.guard():
@@ -76,7 +78,7 @@ class TestTensorShape(unittest.TestCase):
         with fluid.program_guard(main_program):
             static_out = dygraph_to_static_graph(self.dygraph_func)(self.input)
 
-        exe = fluid.Executor(fluid.CPUPlace())
+        exe = fluid.Executor(self.place)
         static_res = exe.run(main_program, fetch_list=static_out)
 
         return static_res[0]


### PR DESCRIPTION
Add basic support for `Tensor.shape` in translating dygraph to static.

1. Replace `tensor_x.shape` used in Paddle API with `fluid.layers.shape(tensor_x)`;

2. Replace `tensor_x.shape` used in the conditions of control flow.https://github.com/PaddlePaddle/Paddle/pull/22866