### PR TITLE
Add platform limit for cleanup function

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -137,7 +137,9 @@ class CleanupFuncRegistrar():
 # BlockingQueue) may not be completely released, resulting in the corresponding
 # memory-mapped file remaining on the disk (/dev/shm), so register this function
 # to clean up shared memory objects in these two queues before the python interpreter exits.
-CleanupFuncRegistrar.register(_cleanup)
+# NOTE: Currently multi-process DataLoader only supports Linux platform
+if not (sys.platform == 'darwin' or sys.platform == 'win32'):
+    CleanupFuncRegistrar.register(_cleanup)
 
 
 class DataLoaderBase(object):


### PR DESCRIPTION
The `_cleanup` function in reader.py only need to be executed on linux.