### PR TITLE
[BUG]: Multihead matmul op's ouput size should be BxSx(N*H)

### DIFF
--- a/paddle/fluid/operators/fused/multihead_matmul_op.cu
+++ b/paddle/fluid/operators/fused/multihead_matmul_op.cu
@@ -440,13 +440,11 @@ class MultiHeadMatMulV2Kernel : public framework::OpKernel<T> {
 
     auto &bias_qk = detail::Ref(context.Input<framework::Tensor>("BiasQK"),
                                 "Cannot find QK");
-    auto *out = context.Output<framework::Tensor>("Out");
 
     auto *input_d = input->data<T>();
     auto *w_d = w->data<T>();
     auto *bias_d = bias->data<T>();
     auto *bias_qk_d = bias_qk.data<T>();
-    auto *output_d = out->mutable_data<T>(context.GetPlace());
     T scale = static_cast<T>(context.Attr<float>("alpha"));
 
     int head_number = context.Attr<int>("head_number");
@@ -462,6 +460,10 @@ class MultiHeadMatMulV2Kernel : public framework::OpKernel<T> {
 
     int all_head_size = w_dims[2];
     int head_size = all_head_size / head_number;
+
+    auto *out = context.Output<framework::Tensor>("Out");
+    out->Resize({batch, seq_len, all_head_size});
+    auto *output_d = out->mutable_data<T>(context.GetPlace());
 
     // (B*S, hidden)
     const Tensor input_matrix =


### PR DESCRIPTION
We set the same dims of  Multihead matmul op 's input to output original.

eg:
```
 auto dim_input = context->GetInputDim("Input");
 context->SetOutputDim("Out", dim_input);
 context->ShareLoD("Input", /*->*/ "Out");
```
https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/operators/fused/multihead_matmul_op.cc#L80

The setting above is wrong. 

Let's first introduce some noun variables in Multihead matmul op:
```
1) Batch : the batch size.
2) SeqLen: the sequence length.
3) HiddenSize: the second dims size of the Embedding table.
4) HeadNumber: the head number of the encoder.
5) HeadSize: the size of each Head.
```
The Multihead matmul op's Input Dims is [Batch * SeqLen * HiddenSize], the Output Dim should be [Batch * SeqLen * (HeadNumber * HeadSize)].


