### PR TITLE
reduce default attrs for dynamic graph

### DIFF
--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -367,7 +367,8 @@ class OpAttrChecker {
   // for explicit attribute, we mean the attribute added in the customized
   // op makers, usually it's defined in the overloaded Make method.
   // for implicit attribute, we mean the attribute added outside of the Make
-  // method like "op_role", "op_role_var"
+  // method like "op_role", "op_role_var", and they are useless in dynamic graph
+  // mode
   size_t explicit_checker_num_;
 };
 

--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -361,6 +361,13 @@ class OpAttrChecker {
 
  private:
   std::vector<AttrChecker> attr_checkers_;
+
+  // in order to improve the efficiency of dynamic graph mode,
+  // we divede the attribute into explicit type and implicit type.
+  // for explicit attribute, we mean the attribute added in the customized
+  // op makers, usually it's defined in the overloaded Make method.
+  // for implicit attribute, we mean the attribute added outside of the Make
+  // method like "op_role", "op_role_var"
   size_t explicit_checker_num_;
 };
 

--- a/paddle/fluid/framework/attribute.h
+++ b/paddle/fluid/framework/attribute.h
@@ -339,9 +339,11 @@ class OpAttrChecker {
     return *(checker.target<TypedAttrChecker<T>>());
   }
 
-  void Check(AttributeMap* attr_map) const {
-    for (const auto& checker : attr_checkers_) {
-      checker(attr_map, false);
+  void Check(AttributeMap* attr_map, bool explicit_only = false) const {
+    auto checker_num = attr_checkers_.size();
+    if (explicit_only) checker_num = explicit_checker_num_;
+    for (size_t i = 0; i < checker_num; ++i) {
+      attr_checkers_[i](attr_map, false);
     }
   }
 
@@ -353,8 +355,13 @@ class OpAttrChecker {
     return default_values_map;
   }
 
+  void RecordExplicitCheckerNum() {
+    explicit_checker_num_ = attr_checkers_.size();
+  }
+
  private:
   std::vector<AttrChecker> attr_checkers_;
+  size_t explicit_checker_num_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/op_proto_maker.cc
+++ b/paddle/fluid/framework/op_proto_maker.cc
@@ -62,6 +62,7 @@ void OpProtoAndCheckerMaker::operator()(proto::OpProto* proto,
   proto_ = proto;
   op_checker_ = attr_checker;
   Make();
+  op_checker_->RecordExplicitCheckerNum();
 
   AddAttr<int>(OpRoleAttrName(), "The role of this operator")
       .InEnum(

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -290,7 +290,7 @@ OpBase::OpBase(size_t id, const std::string& type, const NameVarBaseMap& ins,
 
   // Step 1: Run forward
   if (info.Checker() != nullptr) {
-    info.Checker()->Check(&attrs_);
+    info.Checker()->Check(&attrs_, true);
   }
 
   op_ = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
@@ -301,7 +301,7 @@ OpBase::OpBase(size_t id, const std::string& type, const NameVarBaseMap& ins,
 void OpBase::CreateOperatorBase() {
   const auto& info = framework::OpInfoMap::Instance().Get(type_);
   if (info.Checker() != nullptr) {
-    info.Checker()->Check(&attrs_);
+    info.Checker()->Check(&attrs_, true);
   }
   op_ = framework::OpRegistry::CreateOp(type_, {}, {}, {}, false);
 }


### PR DESCRIPTION
OpProtoAndCheckerMaker 的operator()逻辑中会增加四个默认属性，这四个默认属性在动态图逻辑中是没有用到的。
但是默认属性的添加会导致在每次动态图op运行中往attr map中做emplace操作，同时也会增加反向op创建时的拷贝数据量。

**改动：**
将OpProtoAndCheckerMaker operator()逻辑中，Make函数之后添加的属性视为implicit 属性，Make函数中通过AddAttr来注册的属性视为explicit属性，动态图逻辑中我们只对explicit属性来做检查

**收益：**
在ptb模型上有大概3.8%左右的提升

主要影响模块 | 原时长 | 优化后时长 | 收益
-- | -- | -- | --
SetAttrMap | 0.23s | 0.05s | 2.42% => 0.56%
OpAttrChecker | 0.54s | 0.34s | 5.81% => 3.80%

