### PR TITLE
Added an option to use external FP32 model in QAT comparison test

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py
@@ -49,6 +49,12 @@ def parse_args():
     parser.add_argument(
         '--qat_model', type=str, default='', help='A path to a QAT model.')
     parser.add_argument(
+        '--fp32_model',
+        type=str,
+        default='',
+        help='A path to an FP32 model. If empty, the QAT model will be used for FP32 inference.'
+    )
+    parser.add_argument(
         '--qat2',
         action='store_true',
         help='If used, the QAT model is treated as a second generation model for performance optimization.'
@@ -289,7 +295,10 @@ class QatInt8ImageClassificationComparisonTest(unittest.TestCase):
             return
 
         qat_model_path = test_case_args.qat_model
+        assert qat_model_path, 'The QAT model path cannot be empty. Please, use the --qat_model option.'
+        fp32_model_path = test_case_args.fp32_model if test_case_args.fp32_model else qat_model_path
         data_path = test_case_args.infer_data
+        assert data_path, 'The dataset path cannot be empty. Please, use the --infer_data option.'
         batch_size = test_case_args.batch_size
         batch_num = test_case_args.batch_num
         skip_batch_num = test_case_args.skip_batch_num
@@ -299,6 +308,7 @@ class QatInt8ImageClassificationComparisonTest(unittest.TestCase):
 
         _logger.info('QAT FP32 & INT8 prediction run.')
         _logger.info('QAT model: {0}'.format(qat_model_path))
+        _logger.info('FP32 model: {0}'.format(fp32_model_path))
         _logger.info('Dataset: {0}'.format(data_path))
         _logger.info('Batch size: {0}'.format(batch_size))
         _logger.info('Batch number: {0}'.format(batch_num))
@@ -310,11 +320,14 @@ class QatInt8ImageClassificationComparisonTest(unittest.TestCase):
             self._reader_creator(data_path), batch_size=batch_size)
         fp32_output, fp32_acc1, fp32_acc5, fp32_fps, fp32_lat = self._predict(
             val_reader,
-            qat_model_path,
+            fp32_model_path,
             batch_size,
             batch_num,
             skip_batch_num,
             transform_to_int8=False)
+        _logger.info(
+            'FP32: avg top1 accuracy: {0:.4f}, avg top5 accuracy: {1:.4f}'.
+            format(fp32_acc1, fp32_acc5))
         _logger.info('--- QAT INT8 prediction start ---')
         val_reader = paddle.batch(
             self._reader_creator(data_path), batch_size=batch_size)
@@ -325,6 +338,9 @@ class QatInt8ImageClassificationComparisonTest(unittest.TestCase):
             batch_num,
             skip_batch_num,
             transform_to_int8=True)
+        _logger.info(
+            'INT8: avg top1 accuracy: {0:.4f}, avg top5 accuracy: {1:.4f}'.
+            format(int8_acc1, int8_acc5))
 
         self._summarize_performance(fp32_fps, fp32_lat, int8_fps, int8_lat)
         self._compare_accuracy(fp32_acc1, fp32_acc5, int8_acc1, int8_acc5,

--- a/python/paddle/fluid/contrib/slim/tests/qat_int8_nlp_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat_int8_nlp_comparison.py
@@ -48,6 +48,12 @@ def parse_args():
     parser.add_argument(
         '--qat_model', type=str, default='', help='A path to a QAT model.')
     parser.add_argument(
+        '--fp32_model',
+        type=str,
+        default='',
+        help='A path to an FP32 model. If empty, the QAT model will be used for FP32 inference.'
+    )
+    parser.add_argument(
         '--save_model',
         action='store_true',
         help='If used, the QAT model will be saved after all transformations')
@@ -240,7 +246,10 @@ class QatInt8NLPComparisonTest(unittest.TestCase):
             return
 
         qat_model_path = test_case_args.qat_model
+        assert qat_model_path, 'The QAT model path cannot be empty. Please, use the --qat_model option.'
+        fp32_model_path = test_case_args.fp32_model if test_case_args.fp32_model else qat_model_path
         data_path = test_case_args.infer_data
+        assert data_path, 'The dataset path cannot be empty. Please, use the --infer_data option.'
         labels_path = test_case_args.labels
         batch_size = test_case_args.batch_size
         batch_num = test_case_args.batch_num
@@ -251,6 +260,7 @@ class QatInt8NLPComparisonTest(unittest.TestCase):
 
         _logger.info('QAT FP32 & INT8 prediction run.')
         _logger.info('QAT model: {0}'.format(qat_model_path))
+        _logger.info('FP32 model: {0}'.format(fp32_model_path))
         _logger.info('Dataset: {0}'.format(data_path))
         _logger.info('Labels: {0}'.format(labels_path))
         _logger.info('Batch size: {0}'.format(batch_size))
@@ -263,11 +273,12 @@ class QatInt8NLPComparisonTest(unittest.TestCase):
             self._reader_creator(data_path, labels_path), batch_size=batch_size)
         fp32_acc, fp32_pps, fp32_lat = self._predict(
             val_reader,
-            qat_model_path,
+            fp32_model_path,
             batch_size,
             batch_num,
             skip_batch_num,
             transform_to_int8=False)
+        _logger.info('FP32: avg accuracy: {0:.6f}'.format(fp32_acc))
         _logger.info('--- QAT INT8 prediction start ---')
         val_reader = paddle.batch(
             self._reader_creator(data_path, labels_path), batch_size=batch_size)
@@ -278,6 +289,7 @@ class QatInt8NLPComparisonTest(unittest.TestCase):
             batch_num,
             skip_batch_num,
             transform_to_int8=True)
+        _logger.info('INT8: avg accuracy: {0:.6f}'.format(int8_acc))
 
         self._summarize_performance(fp32_pps, fp32_lat, int8_pps, int8_lat)
         self._compare_accuracy(fp32_acc, int8_acc, acc_diff_threshold)

--- a/python/paddle/fluid/contrib/slim/tests/qat_int8_nlp_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat_int8_nlp_comparison.py
@@ -53,10 +53,6 @@ def parse_args():
         default='',
         help='A path to an FP32 model. If empty, the QAT model will be used for FP32 inference.'
     )
-    parser.add_argument(
-        '--save_model',
-        action='store_true',
-        help='If used, the QAT model will be saved after all transformations')
     parser.add_argument('--infer_data', type=str, default='', help='Data file.')
     parser.add_argument(
         '--labels', type=str, default='', help='File with labels.')


### PR DESCRIPTION
With this patch, when running the Ernie QAT INT8 comparison test, a user can use the `--fp32_model` option to provide an FP32 model for accuracy measurement and comparison with an INT8 model obtained from the QAT model (passed by `--qat_model` option). If the `--fp32_model` option is not used (the default in QAT INT8 tests), the QAT model accuracy will be measured and compared.

It also adds printing average accuracy result after each (FP32 and INT8) inference run.

test=develop