### PR TITLE
Fix fc padding bug during inference fusion

### DIFF
--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -124,6 +124,7 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
         delete[] weight_data_tmp;
         desc.SetInput("W", {w_name});
         desc.SetAttr("padding_weights", true);
+        desc.Flush();
       }
     }
 
@@ -156,9 +157,10 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
 
     IR_NODE_LINK_TO(subgraph.at(x), fc_node);
     if (desc.GetAttrIfExists<bool>("padding_weights")) {
+      GraphSafeRemoveNodes(graph, {w});
       IR_NODE_LINK_TO(w_node, fc_node);
     } else {
-      w_key.SetPersistable(false);
+      GraphSafeRemoveNodes(g, {w_node});
       IR_NODE_LINK_TO(w, fc_node);
     }
     IR_NODE_LINK_TO(bias, fc_node);

--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -74,54 +74,9 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     OpDesc desc;
     desc.SetType("fc");
 
-    // This is to add padding for dimension 128 on concern of MKL performance
-    bool use_gpu = Has("use_gpu") ? Get<bool>("use_gpu") : false;
-    bool use_fc_padding =
-        Has("use_fc_padding") ? Get<bool>("use_fc_padding") : true;
-    if (!use_gpu && use_fc_padding) {
-      auto* scope = param_scope();
-      const std::string& w_name = patterns::UniqueKey("fc_weight");
-      auto* w_var = scope->Var(w_name);
-      auto* w_tensor = w_var->GetMutable<framework::LoDTensor>();
-
-      auto* fc_w_var = scope->FindVar(w->Name());
-      const auto& fc_w_tensor = fc_w_var->Get<framework::LoDTensor>();
-
-      w_tensor->Resize(fc_w_tensor.dims());
-      auto* data = w_tensor->mutable_data<float>(platform::CPUPlace());
-      for (int i = 0; i < w_tensor->numel(); i++) {
-        data[i] = fc_w_tensor.data<float>()[i];
-      }
-      desc.SetInput("W", {w_name});
-
-      auto* weight = scope->FindVar(w_name)->GetMutable<LoDTensor>();
-      auto* weight_data = weight->data<float>();
-      auto weight_dims = weight->dims();
-      int weight_num = product(weight_dims);
-      int w_h = weight_dims[0];
-      int w_w = weight_dims[1];
-      if (w_h % 128 == 0 && w_w % 128 == 0) {
-        auto* weight_data_tmp = new float[weight_num];
-        for (int i = 0; i < w_h; i++) {
-          memcpy(weight_data_tmp + i * w_w, weight_data + i * w_w,
-                 w_w * sizeof(float));
-        }
-        weight->Resize(DDim{weight_dims[0] + 4, weight_dims[1] + 4});
-        auto* weight_data_new =
-            weight->mutable_data<float>(platform::CPUPlace());
-        for (int i = 0; i < w_h; i++) {
-          memcpy(weight_data_new + i * (w_w + 4), weight_data_tmp + i * w_w,
-                 w_w * sizeof(float));
-        }
-        delete[] weight_data_tmp;
-        desc.SetAttr("padding_weights", true);
-      }
-    } else {
-      desc.SetInput("W", {w->Name()});
-    }
-
     // Set inputs of fc
     desc.SetInput("Input", {subgraph.at(x)->Name()});
+    desc.SetInput("W", {w->Name()});
     desc.SetInput("Bias", {bias->Name()});
 
     // Set output of fc
@@ -133,6 +88,41 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     desc.SetAttr("in_num_col_dims", mul->Op()->GetAttr("x_num_col_dims"));
     std::string activation_type = with_relu ? "relu" : "";
     desc.SetAttr("activation_type", activation_type);
+
+    // This is to add padding for dimension 128 on concern of MKL performance
+    bool use_gpu = Has("use_gpu") ? Get<bool>("use_gpu") : false;
+    bool use_fc_padding =
+        Has("use_fc_padding") ? Get<bool>("use_fc_padding") : true;
+    if (!use_gpu && use_fc_padding) {
+      auto* scope = param_scope();
+      auto* weight = scope->FindVar(w->Name())->GetMutable<LoDTensor>();
+      auto* weight_data = weight->data<float>();
+      auto weight_dims = weight->dims();
+      int weight_num = product(weight_dims);
+      int w_h = weight_dims[0];
+      int w_w = weight_dims[1];
+      if (w_h % 128 == 0 && w_w % 128 == 0) {
+        const std::string& w_name = patterns::UniqueKey(w->Name());
+        auto* w_var = scope->Var(w_name);
+        auto* w_tensor = w_var->GetMutable<framework::LoDTensor>();
+
+        auto* weight_data_tmp = new float[weight_num];
+        for (int i = 0; i < w_h; i++) {
+          memcpy(weight_data_tmp + i * w_w, weight_data + i * w_w,
+                 w_w * sizeof(float));
+        }
+        w_tensor->Resize(DDim{weight_dims[0] + 4, weight_dims[1] + 4});
+        auto* weight_data_new =
+            w_tensor->mutable_data<float>(platform::CPUPlace());
+        for (int i = 0; i < w_h; i++) {
+          memcpy(weight_data_new + i * (w_w + 4), weight_data_tmp + i * w_w,
+                 w_w * sizeof(float));
+        }
+        delete[] weight_data_tmp;
+        desc.SetInput("W", {w_name});
+        desc.SetAttr("padding_weights", true);
+      }
+    }
 
     // For anakin subgraph int8
     // When in anakin subgraph int8 mode, the pattern like "fake_quant + mul +

--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -157,7 +157,6 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
 
     IR_NODE_LINK_TO(subgraph.at(x), fc_node);
     if (desc.GetAttrIfExists<bool>("padding_weights")) {
-      GraphSafeRemoveNodes(graph, {w});
       IR_NODE_LINK_TO(w_node, fc_node);
     } else {
       GraphSafeRemoveNodes(g, {w_node});


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7160927/75941245-18298380-5eca-11ea-96ea-2c46e6a4e8da.png)

根据上图中的模型结构，两个 mul op 的 weight_shape 是 128\*128，即在 fuse 成 fc 的时候，在 fc_fuse_pass.cc 里面会执行 padding 操作。并且名称也是相同的，都是 tanh.w，于是 `w->Name()` 得到的名称相同。
在第一个 mul+elementwise_add 的结构在 fuse 为 fc 做了 padding 之后，名为 tanh.w 的 var_shape 已经变成了 132\*132 。指定 padding_weight 为 true。
第二个相同的结构过来的时候，使用 `w->Name()` 获取的 shape 就是 132\*132，不会再做 padding，即 padding_weight 为 false，程序不知道这个结构也要做 padding ，所以 kernel 计算的时候 shape 对不上了。故报错。
![image](https://user-images.githubusercontent.com/7160927/75942802-5759d380-5ece-11ea-8145-b234cd25705a.png)

这个 PR 修复了这个问题。