### PR TITLE
Save all input scales and quantization info in quantized op

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -182,8 +182,7 @@ class PostTrainingQuantization(object):
         else:
             self._quantizable_op_type = quantizable_op_type
             for op_type in self._quantizable_op_type:
-                assert op_type in supported_quantizable_op_type + \
-                    AddQuantDequantPass._activation_type, \
+                assert op_type in supported_quantizable_op_type, \
                     op_type + " is not supported for quantization."
 
         self._place = self._executor.place
@@ -454,7 +453,7 @@ class PostTrainingQuantization(object):
         '''
         Save output scale to the quantized op.
         '''
-        output_scale_name = "output_scale"
+        output_scale_name = "output_threshold"
         for op in self._program.global_block().ops:
             if op.type in self._quantizable_op_type:
                 output_name_list = self._op_real_in_out_name[op.type][1]

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -35,6 +35,10 @@ _fake_dequant_op_list = [
     'fake_dequantize_max_abs', 'fake_channel_wise_dequantize_max_abs'
 ]
 
+_fake_quant_dequant_op_list = [
+    'fake_quantize_dequantize_moving_average_abs_max'
+]
+
 _out_scale_op_list = [
     "mul", "conv2d", "pool2d", "relu", "softmax", "sigmoid", "depthwise_conv2d",
     "batch_norm", "concat", "tanh", "pad", "elementwise_add", "elementwise_mul",
@@ -236,6 +240,13 @@ class QuantizationTransformPass(object):
                 op_node.op()._set_attr("skip_quant", True)
 
         def _transform_forward(graph, op):
+            op.op()._set_attr("is_quantized_with_weight", True)
+            op.op()._set_attr("activation_bits", self._activation_bits)
+            op.op()._set_attr("weight_bits", self._weight_bits)
+            op.op()._set_attr("activation_quantize_type",
+                              self._activation_quantize_type)
+            op.op()._set_attr("weight_quantize_type",
+                              self._weight_quantize_type)
             for var_node in op.inputs:
                 if var_node.name() not in op.input_arg_names():
                     continue
@@ -290,7 +301,7 @@ class QuantizationTransformPass(object):
         # The loop for transforming the forward graph:
         for op in ops:
             if op.name() in self._quantizable_ops:
-                if not QuantizationTransformPass._is_skip_quant(graph, op):
+                if not self._is_skip_quant(graph, op):
                     _transform_forward(graph, op)
         # The loop for renaming the inputs of backward op.
         for op in ops:
@@ -636,8 +647,7 @@ class QuantizationTransformPass(object):
         """
         return "%s.scale" % (var_name)
 
-    @staticmethod
-    def _is_skip_quant(graph, op_node):
+    def _is_skip_quant(self, graph, op_node):
         """
         Analyse whether the op node skips quantization.
         """
@@ -650,20 +660,20 @@ class QuantizationTransformPass(object):
         if op_node.name() in ["mul", "matmul"] and \
             _is_input_all_not_persistable(graph, op_node):
             is_skip = True
+        if op_node.op().has_attr("is_quantized_without_weight") and \
+            op_node.op().attr("is_quantized_without_weight"):
+            is_skip = True
         return is_skip
 
 
 class QuantizationFreezePass(object):
-    _supported_quantizable_op_type = \
-        QuantizationTransformPass._supported_quantizable_op_type
-
     def __init__(self,
                  scope,
                  place,
                  weight_bits=8,
                  activation_bits=8,
                  weight_quantize_type='abs_max',
-                 quantizable_op_type=['conv2d', 'depthwise_conv2d', 'mul']):
+                 quantizable_op_type=None):
         """
         The freeze pass is used to adjust the quantize operator order, for example:
             1) `activation -> quant -> dequant -> conv2d` will be frozen into
@@ -679,9 +689,8 @@ class QuantizationFreezePass(object):
             weight_quantize_type(str): quantization type for weights, support 'abs_max' and 
                 'channel_wise_abs_max'. The 'range_abs_max' usually is not used for weight, 
                 since weights are fixed once the model is well trained.
-            quantizable_op_type(list[str]): List the type of ops that will be quantized. 
-                Default is ["conv2d", "depthwise_conv2d", "mul"]. The quantizable_op_type in
-                QuantizationTransformPass and ConvertToInt8Pass must be the same as this.
+            quantizable_op_type(list[str]): This input param will be removed latter. The pass
+                will process all quantized op, so it is not necessary to set the input param.
         """
         assert scope is not None, \
             'The scope cannot be set None.'
@@ -692,16 +701,14 @@ class QuantizationFreezePass(object):
         self._weight_bits = weight_bits
         self._activation_bits = activation_bits
         self._weight_quantize_type = weight_quantize_type
-        self._quantizable_ops = quantizable_op_type
-        for op in self._quantizable_ops:
-            assert op in QuantizationFreezePass._supported_quantizable_op_type, \
-                op + " is not supported for quantization."
         self._conv_ops = ['conv2d', 'depthwise_conv2d']
         self._fake_quant_op_names = _fake_quant_op_list
         self._fake_dequant_op_names = _fake_dequant_op_list
+        self._fake_quant_dequant_op_names = _fake_quant_dequant_op_list
         self._op_input_rename_map = collections.OrderedDict()
         self._op_output_rename_map = collections.OrderedDict()
-        self._var_scale_map = collections.OrderedDict()
+        self._quant_var_scale_map = collections.OrderedDict()
+        self._quant_dequant_var_scale_map = collections.OrderedDict()
 
     def apply(self, graph):
         """
@@ -712,6 +719,7 @@ class QuantizationFreezePass(object):
         Returns:
             None
         """
+        # Get input scales in fake quant op and process weights
         persistable_vars = [p.name() for p in graph.all_persistable_nodes()]
         ops = graph.all_op_nodes()
         for op_node in ops:
@@ -721,19 +729,19 @@ class QuantizationFreezePass(object):
                 if input_arg_name in persistable_vars:
                     if self._weight_quantize_type == 'abs_max':
                         param = self._load_var(input_arg_name)
-                        scale_v = np.max(np.abs(param))
+                        scale_v = float(np.max(np.abs(param)))
                     elif self._weight_quantize_type == 'channel_wise_abs_max':
                         param = self._load_var(input_arg_name)
                         if len(param.shape) == 4:  # conv2d or depthwise_conv2d
                             scale_v = []
                             for i in range(param.shape[0]):
-                                scale_v.append(np.max(np.abs(param[i])))
+                                scale_v.append(float(np.max(np.abs(param[i]))))
                         else:
-                            scale_v = np.max(np.abs(param))
+                            scale_v = float(np.max(np.abs(param)))
                     else:
-                        scale_v = self._load_var(
-                            op_node.output('OutScale')[0])[0]
-                    self._var_scale_map[input_arg_name] = scale_v
+                        scale_v = float(
+                            self._load_var(op_node.output('OutScale')[0])[0])
+                    self._quant_var_scale_map[input_arg_name] = scale_v
                     self._remove_fake_quant_and_dequant_op(graph, op_node)
                     # quantize weight and restore
                     param_v = self._load_var(input_arg_name)
@@ -743,37 +751,75 @@ class QuantizationFreezePass(object):
                 else:
                     scale_v = graph._find_node_by_name(
                         op_node.outputs, op_node.output('OutScale')[0])
-                    self._var_scale_map[input_arg_name] = scale_v
+                    self._quant_var_scale_map[input_arg_name] = scale_v
 
+        # Remove all fake dequant op
         ops = graph.all_op_nodes()
         for op_node in ops:
             op_name = op_node.name()
             if op_name in self._fake_dequant_op_names:
                 self._remove_fake_quant_and_dequant_op(graph, op_node)
 
+        # Insert post dequant op
         ops = graph.all_op_nodes()
         for op_node in ops:
-            op_name = op_node.name()
-            if op_name in self._quantizable_ops:
-                # only process the node that is quantized by QuantizationTransformPass
-                is_op_node_quantized = False
-                for var_node in op_node.inputs:
-                    var_name = var_node.name()
-                    if var_name.endswith('.dequantized'):
-                        is_op_node_quantized = True
-                if is_op_node_quantized:
-                    if self._weight_quantize_type == 'channel_wise_abs_max' and op_name in self._conv_ops:
-                        self._insert_post_channel_dequant_op(graph, op_node)
-                    else:
-                        self._insert_post_dequant_op(graph, op_node)
+            op_node_desc = op_node.op()
+            if op_node_desc.has_attr("is_quantized_with_weight") and \
+                op_node_desc.attr("is_quantized_with_weight"):
+                if self._weight_quantize_type == 'channel_wise_abs_max' \
+                    and op_node.name() in self._conv_ops:
+                    self._insert_post_channel_dequant_op(graph, op_node)
+                else:
+                    self._insert_post_dequant_op(graph, op_node)
 
+        # Rename inputs of the followed ops after inserting dequant_op after fc/conv
         for op_node in ops:
-            # insert dequant_op after fc/conv, need to rename inputs of the followed ops
             for var_node in op_node.inputs:
                 if var_node.node in self._op_output_rename_map:
                     old_in = var_node
                     new_in = self._op_output_rename_map[var_node.node]
                     graph.update_input_link(old_in, new_in, op_node)
+
+        # Get input scales in fake quant_dequant op 
+        ops = graph.all_op_nodes()
+        for op_node in ops:
+            op_name = op_node.name()
+            if op_name in self._fake_quant_dequant_op_names:
+                scale_v = float(
+                    self._load_var(op_node.output('OutScale')[0])[0])
+                input_arg_name = op_node.input('X')[0]
+                self._quant_dequant_var_scale_map[input_arg_name] = scale_v
+
+        # Save all input scales in quantized op
+        ops = graph.all_op_nodes()
+        for op_node in ops:
+            op_node_desc = op_node.op()
+            if op_node_desc.has_attr("is_quantized_with_weight") and \
+                op_node_desc.attr("is_quantized_with_weight"):
+                for input_arg_name in op_node.input_arg_names():
+                    # The input var name of fake_quant op is original_var_name
+                    original_var_name = self._original_var_name(input_arg_name)
+                    scale_item = self._quant_var_scale_map[original_var_name]
+                    if isinstance(scale_item, IrNode):
+                        if scale_item.name() in persistable_vars:
+                            scale_value = float(
+                                self._load_var(scale_item.name())[0])
+                        else:
+                            continue
+                    else:
+                        scale_value = scale_item
+                    op_node_desc._set_attr(
+                        original_var_name + ".input_threshold", scale_value)
+            if op_node_desc.has_attr("is_quantized_without_weight") and \
+                op_node_desc.attr("is_quantized_without_weight"):
+                for var_node in op_node.inputs:
+                    # use the input var name of fake_quant_dequant op 
+                    # as the scale name
+                    quant_dequant_op_node = var_node.inputs[0]
+                    original_var_name = quant_dequant_op_node.input('X')[0]
+                    op_node_desc._set_attr(
+                        original_var_name + ".input_threshold",
+                        self._quant_dequant_var_scale_map[original_var_name])
 
         # remove the unused var node in the graph
         self._remove_unused_var_nodes(graph)
@@ -802,7 +848,7 @@ class QuantizationFreezePass(object):
                 new_in.clear_outputs()
                 graph.update_input_link(old_in, new_in, op_node)
             original_var_name = self._original_var_name(name)
-            scale_v = self._var_scale_map[original_var_name]
+            scale_v = self._quant_var_scale_map[original_var_name]
             if original_var_name in persistable_vars:
                 assert isinstance(
                     scale_v,
@@ -811,7 +857,7 @@ class QuantizationFreezePass(object):
                 channel_scale = np.array(scale_v)
             else:
                 assert isinstance(scale_v, IrNode)
-                scale_var_node = self._var_scale_map[original_var_name]
+                scale_var_node = self._quant_var_scale_map[original_var_name]
 
         if len(op_node.output_arg_names()) != 1:
             raise ValueError("Only support one output, but op %s has"
@@ -867,7 +913,7 @@ class QuantizationFreezePass(object):
                 new_in.clear_outputs()
                 graph.update_input_link(old_in, new_in, op_node)
             original_var_name = self._original_var_name(name)
-            scale_v = self._var_scale_map[original_var_name]
+            scale_v = self._quant_var_scale_map[original_var_name]
             if original_var_name in persistable_vars:
                 assert self._is_float(
                     scale_v), 'The scale of parameter %s is not a float.' % (
@@ -876,7 +922,7 @@ class QuantizationFreezePass(object):
             else:
                 max_range *= act_range
                 assert isinstance(scale_v, IrNode)
-                scale_var_node = self._var_scale_map[original_var_name]
+                scale_var_node = self._quant_var_scale_map[original_var_name]
 
         if len(op_node.output_arg_names()) != 1:
             raise ValueError("Only support one output, but op %s has"
@@ -940,6 +986,8 @@ class QuantizationFreezePass(object):
             return var_name[:-len('.dequantized')]
         if var_name.endswith('.scale'):
             return var_name[:-len('.scale')]
+        if var_name.endswith('.quant_dequant'):
+            return var_name[:-len('.quant_dequant')]
         else:
             return var_name
 
@@ -963,13 +1011,7 @@ class QuantizationFreezePass(object):
 
 
 class ConvertToInt8Pass(object):
-    _supported_quantizable_op_type = \
-        QuantizationTransformPass._supported_quantizable_op_type
-
-    def __init__(self,
-                 scope,
-                 place,
-                 quantizable_op_type=['conv2d', 'depthwise_conv2d', 'mul']):
+    def __init__(self, scope, place, quantizable_op_type=None):
         """
         Convert the weights into int8_t type.
 
@@ -977,9 +1019,8 @@ class ConvertToInt8Pass(object):
             scope(fluid.Scope): scope is used to get the weight tensor values.
             place(fluid.CPUPlace|fluid.CUDAPlace): place is used to restore the
                 8bits weight tensors.
-            quantizable_op_type(list[str]): List the type of ops that will be quantized. 
-                Default is ["conv2d", "depthwise_conv2d", "mul"]. The quantizable_op_type in
-                QuantizationTransformPass and QuantizationFreezePass must be the same as this.
+            quantizable_op_type(list[str]): This input param will be removed latter. The pass
+                will process all quantized op, so it is not necessary to set the input param.
         """
         assert scope is not None, \
             'The scope cannot be set None.'
@@ -987,10 +1028,6 @@ class ConvertToInt8Pass(object):
             'The place cannot be set None.'
         self._scope = scope
         self._place = place
-        self._quantizable_ops = quantizable_op_type
-        for op in self._quantizable_ops:
-            assert op in ConvertToInt8Pass._supported_quantizable_op_type, \
-                op + " is not supported for quantization."
 
     def apply(self, graph):
         """
@@ -1006,10 +1043,8 @@ class ConvertToInt8Pass(object):
         ops = graph.all_op_nodes()
         input_map = {}
         for op_node in ops:
-            op_name = op_node.name()
-            if op_name in self._quantizable_ops:
-                if QuantizationTransformPass._is_skip_quant(graph, op_node):
-                    continue
+            if op_node.op().has_attr("is_quantized_with_weight") and \
+                op_node.op().attr("is_quantized_with_weight"):
                 for var_node in op_node.inputs:
                     name = var_node.name()
                     if name in persistable_vars:
@@ -1259,9 +1294,9 @@ class AddQuantDequantPass(object):
         "equal", "gather", "greater_equal", "greater_than", "less_equal",
         "less_than", "mean", "not_equal", "reshape", "reshape2",
         "bilinear_interp", "nearest_interp", "trilinear_interp", "slice",
-        "squeeze", "elementwise_sub", "mul", "matmul"
+        "squeeze", "elementwise_sub", "mul", "matmul", "relu", "relu6",
+        "leaky_relu", "tanh", "swish"
     ]
-    _activation_type = ["relu", "relu6", "leaky_relu", "tanh", "swish"]
 
     def __init__(self,
                  scope=None,
@@ -1307,8 +1342,7 @@ class AddQuantDequantPass(object):
         else:
             self._quantizable_op_type = quantizable_op_type
             for op_type in quantizable_op_type:
-                assert op_type in AddQuantDequantPass._supported_quantizable_op_type + \
-                    AddQuantDequantPass._activation_type, \
+                assert op_type in AddQuantDequantPass._supported_quantizable_op_type, \
                     op_type + " is not supported for quantization."
         self._quantizable_grad_op_type = [
             '%s_grad' % (op) for op in self._quantizable_op_type
@@ -1343,17 +1377,14 @@ class AddQuantDequantPass(object):
                 elif isinstance(self._skip_pattern, str):
                     is_skip = op_node.op().has_attr("op_namescope") and \
                                    op_node.op().attr("op_namescope").find(self._skip_pattern) != -1
-
-                is_op_node_quantized = False
-                for var_node in op_node.inputs:
-                    var_name = var_node.name()
-                    if var_name.endswith('.dequantized'):
-                        is_op_node_quantized = True
-
-                if is_skip or is_op_node_quantized or \
+                is_quantized = op_node.op().has_attr("is_quantized_with_weight") and \
+                    op_node.op().attr("is_quantized_with_weight")
+                if is_skip or is_quantized or \
                     (not _is_input_all_not_persistable(graph, op_node)):
                     continue
 
+                op_node.op()._set_attr("is_quantized_without_weight", True)
+                op_node.op()._set_attr("activation_bits", self._quant_bits)
                 input_name_list = _op_real_in_out_name[op_node.name()][0]
                 arg_names = []
                 for input_name in input_name_list:

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -310,7 +310,7 @@ class TestPostTrainingForMobilenetv1(TestPostTrainingQuantization):
         quantizable_op_type = [
             "conv2d", "depthwise_conv2d", "mul", "pool2d", "elementwise_add"
         ]
-        is_full_quantize = True
+        is_full_quantize = False
         is_use_cache_file = False
         self.run_test(model, algo, data_urls, data_md5s, quantizable_op_type,
                       is_full_quantize, is_use_cache_file)

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
@@ -20,7 +20,7 @@ from test_post_training_quantization_mobilenetv1 import TestPostTrainingQuantiza
 class TestPostTrainingForResnet50(TestPostTrainingQuantization):
     def test_post_training_resnet50(self):
         model = "ResNet-50"
-        algo = "direct"
+        algo = "min_max"
         data_urls = [
             'http://paddle-inference-dist.bj.bcebos.com/int8/resnet50_int8_model.tar.gz'
         ]


### PR DESCRIPTION
* Save all input scales  and quantization info in quantized op.
* Quantized ops with weight have attrs: is_quantized_with_weight, activation_bits, weight_bits, activation_quantize_type, weight_quantize_type
* For quantized ops without weight have attrs: is_quantized_without_weight, activation_bits
* All quantized ops have the input threshold (KL threshold or abs_max value), the name of input threshold is the intput var name of fake_quant/fake_quant_dequant.
