### PR TITLE
high-performance dygraph slice

### DIFF
--- a/paddle/fluid/operators/strided_slice_op.h
+++ b/paddle/fluid/operators/strided_slice_op.h
@@ -60,16 +60,18 @@ static void StridedSliceOutDims(
       continue;
     }
 
-    if (stride_index < 0) {
-      start_index = start_index + 1;
-      end_index = end_index + 1;
-    }
-
     if (start_index < 0) {
       start_index = start_index + axis_size;
     }
     if (end_index < 0) {
-      end_index = end_index + axis_size;
+      if (!(end_index == -1 && stride_index < 0)) {  // skip None stop condition
+        end_index = end_index + axis_size;
+      }
+    }
+
+    if (stride_index < 0) {
+      start_index = start_index + 1;
+      end_index = end_index + 1;
     }
 
     bool zero_dim_condition =
@@ -109,6 +111,16 @@ static void StridedSliceFunctor(int* starts, int* ends, int* strides, int* axes,
         decrease_axis_affect = true;
       }
     }
+    // stride must not be zero
+    if (starts[axis_index] < 0) {
+      starts[axis_index] = starts[axis_index] + axis_size;
+    }
+    if (ends[axis_index] < 0) {
+      if (!(ends[axis_index] == -1 &&
+            strides[axis_index] < 0)) {  // skip None stop condition
+        ends[axis_index] = ends[axis_index] + axis_size;
+      }
+    }
     if (decrease_axis_affect) {
       if (strides[axis_index] < 0) {
         ends[axis_index] = starts[axis_index] - 1;
@@ -128,13 +140,6 @@ static void StridedSliceFunctor(int* starts, int* ends, int* strides, int* axes,
     } else {
       reverse_axis[axis_index] = 0;
       strides[axis_index] = strides[axis_index];
-    }
-    // stride must not be zero
-    if (starts[axis_index] < 0) {
-      starts[axis_index] = starts[axis_index] + axis_size;
-    }
-    if (ends[axis_index] < 0) {
-      ends[axis_index] = ends[axis_index] + axis_size;
     }
   }
 }

--- a/paddle/fluid/operators/strided_slice_op.h
+++ b/paddle/fluid/operators/strided_slice_op.h
@@ -60,16 +60,16 @@ static void StridedSliceOutDims(
       continue;
     }
 
+    if (stride_index < 0) {
+      start_index = start_index + 1;
+      end_index = end_index + 1;
+    }
+
     if (start_index < 0) {
       start_index = start_index + axis_size;
     }
     if (end_index < 0) {
       end_index = end_index + axis_size;
-    }
-
-    if (stride_index < 0) {
-      start_index = start_index + 1;
-      end_index = end_index + 1;
     }
 
     bool zero_dim_condition =
@@ -109,14 +109,6 @@ static void StridedSliceFunctor(int* starts, int* ends, int* strides, int* axes,
         decrease_axis_affect = true;
       }
     }
-    // stride must not be zero
-    if (starts[axis_index] < 0) {
-      starts[axis_index] = starts[axis_index] + axis_size;
-    }
-
-    if (ends[axis_index] < 0) {
-      ends[axis_index] = ends[axis_index] + axis_size;
-    }
     if (decrease_axis_affect) {
       if (strides[axis_index] < 0) {
         ends[axis_index] = starts[axis_index] - 1;
@@ -136,6 +128,13 @@ static void StridedSliceFunctor(int* starts, int* ends, int* strides, int* axes,
     } else {
       reverse_axis[axis_index] = 0;
       strides[axis_index] = strides[axis_index];
+    }
+    // stride must not be zero
+    if (starts[axis_index] < 0) {
+      starts[axis_index] = starts[axis_index] + axis_size;
+    }
+    if (ends[axis_index] < 0) {
+      ends[axis_index] = ends[axis_index] + axis_size;
     }
   }
 }

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -437,8 +437,13 @@ void BindImperative(py::module *m_ptr) {
              }
              if (!PyTuple_Check(_index.ptr())) Py_DecRef(index);
 
-             const auto &tracer = imperative::GetCurrentTracer();
-             std::shared_ptr<imperative::VarBase> out(&self);
+             auto tracer = imperative::GetCurrentTracer();
+             std::shared_ptr<imperative::VarBase> out(
+                 new imperative::VarBase(tracer->GenerateUniqueName()));
+             out->MutableVar()
+                 ->GetMutable<framework::LoDTensor>()
+                 ->ShareDataWith(
+                     *(self.MutableVar()->GetMutable<framework::LoDTensor>()));
              if (!slice_axis.empty()) {
                imperative::NameVarBaseMap ins = {{"Input", {out}}};
                framework::AttributeMap attrs = {
@@ -449,8 +454,7 @@ void BindImperative(py::module *m_ptr) {
                out = std::shared_ptr<imperative::VarBase>(
                    new imperative::VarBase(tracer->GenerateUniqueName()));
                imperative::NameVarBaseMap outs = {{"Out", {out}}};
-               tracer->TraceOp("slice", std::move(ins), std::move(outs),
-                               std::move(attrs));
+               tracer->TraceOp("slice", ins, outs, std::move(attrs));
              }
              if (!reverse_axis.empty()) {
                imperative::NameVarBaseMap ins = {{"X", {out}}};
@@ -458,8 +462,7 @@ void BindImperative(py::module *m_ptr) {
                out = std::shared_ptr<imperative::VarBase>(
                    new imperative::VarBase(tracer->GenerateUniqueName()));
                imperative::NameVarBaseMap outs = {{"Out", {out}}};
-               tracer->TraceOp("slice", std::move(ins), std::move(outs),
-                               std::move(attrs));
+               tracer->TraceOp("slice", ins, outs, std::move(attrs));
              }
              return out;
 

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -204,73 +204,9 @@ def monkey_patch_varbase():
                 return 'name %s, shape: %s, not inited' % (self.name,
                                                            self.shape)
 
-    def __getitem__(self, item):
-        if not isinstance(item, tuple):
-            item = [item]
-
-        decrease_axis = []
-        slice_axis = []
-        slice_start = []
-        slice_end = []
-        reverse_axis = []
-
-        for dim, slice_item in enumerate(item):
-            if isinstance(slice_item, slice):
-                start = slice_item.start
-                end = slice_item.stop
-                step = slice_item.step if slice_item.step else 1
-
-                assert (step == 1 or step == -1)
-
-                if step == -1:
-                    reverse_axis.append(dim)
-                    assert (start is None and end is None)
-
-                if start is None and end is None:
-                    continue
-
-                if start is None:
-                    start = 0
-
-                if end is None:
-                    end = 10000000
-
-                slice_axis.append(dim)
-                slice_start.append(start)
-                slice_end.append(end)
-            else:
-                # int
-                decrease_axis.append(dim)
-                slice_axis.append(dim)
-                slice_start.append(slice_item)
-                slice_end.append(slice_item + 1
-                                 if slice_item != -1 else 10000000)
-
-        out = self
-        if len(slice_axis) > 0:
-            # append slice_op here
-            inputs = {'Input': [out]}
-            attrs = {
-                'axes': slice_axis,
-                'starts': slice_start,
-                'ends': slice_end,
-                'decrease_axis': decrease_axis
-            }
-            outs = core.ops.slice(inputs, attrs)
-            out = outs['Out'][0]
-
-        if len(reverse_axis) > 0:
-            inputs = {'X': [out]}
-            attrs = {'axis': reverse_axis}
-            outs = core.ops.reverse(inputs, attrs)
-            out = outs['Out'][0]
-
-        return out
-
     for method_name, method in (("set_value", set_value), ("block", block),
                                 ("backward", backward), ("gradient", gradient),
-                                ("__str__", __str__), ("to_string", to_string),
-                                ("__getitem__", __getitem__)):
+                                ("__str__", __str__), ("to_string", to_string)):
         setattr(core.VarBase, method_name, method)
 
     # patch math methods for varbase

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -96,8 +96,88 @@ class TestVarBase(unittest.TestCase):
             self.assertEqual(var.block,
                              fluid.default_main_program().global_block())
 
+    def _test_slice(self):
+        w = fluid.dygraph.to_variable(
+            np.random.random((784, 100, 100)).astype('float64'))
+
+        for i in range(3):
+            nw = w[i]
+            self.assertEqual((100, 100), tuple(nw.shape))
+
+        nw = w[:]
+        self.assertEqual((784, 100, 100), tuple(nw.shape))
+
+        nw = w[:, :]
+        self.assertEqual((784, 100, 100), tuple(nw.shape))
+
+        nw = w[:, :, -1]
+        self.assertEqual((784, 100), tuple(nw.shape))
+
+        nw = w[1, 1, 1]
+
+        self.assertEqual(len(nw.shape), 1)
+        self.assertEqual(nw.shape[0], 1)
+
+        nw = w[:, :, :-1]
+        self.assertEqual((784, 100, 99), tuple(nw.shape))
+
+        tensor_array = np.array(
+            [[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+             [[10, 11, 12], [13, 14, 15], [16, 17, 18]],
+             [[19, 20, 21], [22, 23, 24], [25, 26, 27]]]).astype('float32')
+        var = fluid.dygraph.to_variable(tensor_array)
+        var1 = var[0, 1, 1]
+        var2 = var[1:]
+        var3 = var[0:1]
+        var4 = var[::-1]
+        var5 = var[1, 1:, 1:]
+        var_reshape = fluid.layers.reshape(var, [3, -1, 3])
+        var6 = var_reshape[:, :, -1]
+        var7 = var[:, :, :-1]
+        var8 = var[:1, :1, :1]
+        var9 = var[:-1, :-1, :-1]
+        var10 = var[::-1, :1, :-1]
+        var11 = var[:-1, ::-1, -1:]
+        var12 = var[1:2, 2:, ::-1]
+        var13 = var[2:10, 2:, -2:-1]
+        var14 = var[1:-1, 0:2, ::-1]
+        var15 = var[::-1, ::-1, ::-1]
+
+        vars = [
+            var, var1, var2, var3, var4, var5, var6, var7, var8, var9, var10,
+            var11, var12, var13, var14, var15
+        ]
+        local_out = [var.numpy() for var in vars]
+
+        self.assertTrue(np.array_equal(local_out[1], tensor_array[0, 1, 1:2]))
+        self.assertTrue(np.array_equal(local_out[2], tensor_array[1:]))
+        self.assertTrue(np.array_equal(local_out[3], tensor_array[0:1]))
+        self.assertTrue(np.array_equal(local_out[4], tensor_array[::-1]))
+        self.assertTrue(np.array_equal(local_out[5], tensor_array[1, 1:, 1:]))
+        self.assertTrue(
+            np.array_equal(local_out[6],
+                           tensor_array.reshape((3, -1, 3))[:, :, -1]))
+        self.assertTrue(np.array_equal(local_out[7], tensor_array[:, :, :-1]))
+        self.assertTrue(np.array_equal(local_out[8], tensor_array[:1, :1, :1]))
+        self.assertTrue(
+            np.array_equal(local_out[9], tensor_array[:-1, :-1, :-1]))
+        self.assertTrue(
+            np.array_equal(local_out[10], tensor_array[::-1, :1, :-1]))
+        self.assertTrue(
+            np.array_equal(local_out[11], tensor_array[:-1, ::-1, -1:]))
+        self.assertTrue(
+            np.array_equal(local_out[12], tensor_array[1:2, 2:, ::-1]))
+        self.assertTrue(
+            np.array_equal(local_out[13], tensor_array[2:10, 2:, -2:-1]))
+        self.assertTrue(
+            np.array_equal(local_out[14], tensor_array[1:-1, 0:2, ::-1]))
+        self.assertTrue(
+            np.array_equal(local_out[15], tensor_array[::-1, ::-1, ::-1]))
+
     def test_slice(self):
         with fluid.dygraph.guard():
+            self._test_slice()
+
             var = fluid.dygraph.to_variable(self.array)
             self.assertTrue(np.array_equal(var[1, :].numpy(), self.array[1, :]))
             self.assertTrue(np.array_equal(var[::-1].numpy(), self.array[::-1]))


### PR DESCRIPTION
- 优化了动态图`Variable.__getitem__`的性能
  - 调整至cpp端实现，耗时减少约40%
- 支持step为-1以及其他负数，`start/end`可以不为`None`
- 优化了`strided_slice`op，支持`step`为负数且`end`省略时的特殊情况，可避免额外的reverse
  - 如`::-1`，`start`会解析为`length-1`，`end`会解析为`-1`（[see cpython impl](https://github.com/python/cpython/blob/bed4817d52d7b5a383b1b61269c1337b61acc493/Objects/sliceobject.c#L165-L195)）