### PR TITLE
Fix the elementwise_min doc api bug, correct the api used 

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10800,7 +10800,7 @@ Examples:
 
         x = fluid.data(name="x", shape=[3], dtype='float32')
         y = fluid.data(name="y", shape=[3], dtype='float32')
-        z = fluid.layers.elementwise_max(x, y)
+        z = fluid.layers.elementwise_min(x, y)
 
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)
@@ -10822,7 +10822,7 @@ Examples:
 
         x = fluid.data(name="x", shape=[2,3,4,5], dtype='float32')
         y = fluid.data(name="y", shape=[3,4], dtype='float32')
-        z = fluid.layers.elementwise_max(x, y, axis=1)
+        z = fluid.layers.elementwise_min(x, y, axis=1)
 
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)


### PR DESCRIPTION
In elementwise_min api doc has the error, all the api just use the  elementwise_max op, we just correct the doc.