### PR TITLE
fix bug in the transformation from to_variable to assign

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -267,15 +267,20 @@ class BasicApiTransformer(gast.NodeTransformer):
     def _update_feed_dict(self, node):
         assert isinstance(node, gast.Call)
 
-        var_name = None
+        value_node = None
         for kw in node.keywords:
             if kw.arg == 'value':
-                var_name = kw.value.id  # eg: 'a' for "value=a "
-        if not var_name:
-            var_name = node.args[0].id
+                value_node = kw.value  # eg: `a` for "value=a "
+        if not value_node:
+            value_node = node.args[0]
 
-        feed_var_name = unique_name.generate(var_name)  # eg: "a_0"
-        self.feed_name_to_arg_id[feed_var_name] = var_name  # eg: "a_0" : "a"
+        if not isinstance(value_node, gast.Name):
+            return
+        else:
+            var_name = value_node.id
+            feed_var_name = unique_name.generate(var_name)  # eg: "a_0"
+            self.feed_name_to_arg_id[
+                feed_var_name] = var_name  # eg: "a_0" : "a"
 
     def get_feed_name_to_arg_id(self):
         return self.feed_name_to_arg_id

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_utils.py
@@ -360,7 +360,9 @@ def ast_to_func(ast_root, func_name, delete_on_exit=True):
     # TODO(Aurelius84): more elegant way to transform ast into callable object
     import_str = "import paddle\n" \
                  "import paddle.fluid as fluid\n" \
-                 "import paddle.fluid.layers as layers\n"
+                 "import paddle.fluid.layers as layers\n" \
+                 "import numpy as np\n" \
+                 "import numpy\n"
     with f:
         module_name = os.path.basename(f.name[:-3])
         f.write(import_str)


### PR DESCRIPTION
1. Support the input of `fluid.dygraph.to_variable` is a numpy statement in the transformation of dygraph to static graph;
2. Align parameters between api `to_variable` and `assign`.