### PR TITLE
[cherry-pick1.7]fix bug that save_parms garbled chinese characters on windows

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -21,6 +21,7 @@ import six
 import logging
 import pickle
 import contextlib
+import platform
 from functools import reduce
 
 import numpy as np
@@ -314,11 +315,14 @@ def save_vars(executor,
             if filename is None and save_to_memory is False:
                 save_file_path = os.path.join(
                     os.path.normpath(dirname), new_var.name)
+                save_file_path = os.path.normpath(save_file_path)
+                if platform.system() == "Windows":
+                    save_file_path = save_file_path.encode(encoding="gbk")
                 save_block.append_op(
                     type='save',
                     inputs={'X': [new_var]},
                     outputs={},
-                    attrs={'file_path': os.path.normpath(save_file_path)})
+                    attrs={'file_path': save_file_path})
             else:
                 save_var_map[new_var.name] = new_var
 
@@ -330,6 +334,9 @@ def save_vars(executor,
             save_path = str()
             if save_to_memory is False:
                 save_path = os.path.join(os.path.normpath(dirname), filename)
+                save_path = os.path.normpath(save_path)
+                if platform.system() == "Windows":
+                    save_path = save_path.encode(encoding="gbk")
 
             saved_params = save_block.create_var(
                 type=core.VarDesc.VarType.RAW, name=params_var_name)
@@ -766,11 +773,16 @@ def load_vars(executor,
                     raise ValueError(
                         "The directory path and params cannot be None at the same time."
                     )
+                load_file_path = os.path.join(dirname, new_var.name)
+                load_file_path = os.path.normpath(load_file_path)
+                if platform.system() == "Windows":
+                    load_file_path = load_file_path.encode(encoding="gbk")
+
                 load_block.append_op(
                     type='load',
                     inputs={},
                     outputs={'Out': [new_var]},
-                    attrs={'file_path': os.path.join(dirname, new_var.name)})
+                    attrs={'file_path': load_file_path})
             else:
                 load_var_map[new_var.name] = new_var
 
@@ -781,6 +793,10 @@ def load_vars(executor,
 
             if vars_from_memory is False:
                 filename = os.path.join(dirname, filename)
+
+            filename = os.path.normpath(filename)
+            if platform.system() == "Windows":
+                filename = filename.encode(encoding="gbk")
 
             load_block.append_op(
                 type='load_combine',

--- a/python/paddle/fluid/tests/unittests/test_static_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load.py
@@ -25,9 +25,19 @@ from paddle.fluid.dygraph.base import to_variable
 from test_imperative_base import new_program_scope
 from paddle.fluid.executor import global_scope
 import numpy as np
+import contextlib
 import six
 import pickle
 import os
+import platform
+
+
+@contextlib.contextmanager
+def windows_guard():
+    previous = platform.system
+    platform.system = lambda: "Windows"
+    yield
+    platform.system = previous
 
 
 class SimpleLSTMRNN(fluid.Layer):
@@ -1253,6 +1263,14 @@ class TestProgramStateOldSaveSingleModel(unittest.TestCase):
 
             fluid.io.save_persistables(
                 exe, "test_program_2", main_program, filename="model_1")
+
+            with windows_guard():
+                fluid.io.save_persistables(
+                    exe, "test_program_3", main_program, filename="model_1")
+                fluid.io.save_persistables(exe, "test_program_4", main_program)
+                fluid.io.load_persistables(
+                    exe, "test_program_3", main_program, filename="model_1")
+                fluid.io.load_persistables(exe, "test_program_4", main_program)
 
             # set var to zero
             for var in main_program.list_vars():


### PR DESCRIPTION
cherry-pick #22686 

修复了`save_vars/save_persistable/save_params` 在Windows下出现中文乱码的bug。

Python3默认使用unicode编码，而Windows对C++代码使用gbk编码，因此当传入字符串到pybind时，已经乱码了，需要在python端先进行gbk编码。

修复前结果：
![BaiduHi_2020-2-19_22-36-14](https://user-images.githubusercontent.com/52485244/74844739-e14f5b80-5368-11ea-9478-82b0f8eeedcb.png)

修复后结果：
![BaiduHi_2020-2-19_22-34-51](https://user-images.githubusercontent.com/52485244/74844750-e4e2e280-5368-11ea-81b3-3f73b163b5f6.png)