### PR TITLE
fix communicator when break under pyreder mode

### DIFF
--- a/paddle/fluid/operators/distributed/communicator.cc
+++ b/paddle/fluid/operators/distributed/communicator.cc
@@ -70,7 +70,7 @@ void AsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   recv_scope_ = std::move(recv_scope);
 
   if (send_varname_to_ctx.size() == 0) {
-    VLOG(1) << "nothing need to be send, will not start send_thread";
+    VLOG(0) << "nothing need to be send, will not start send_thread";
   } else {
     send_scope_.reset(new Scope());
     for (auto &iter : send_varname_to_ctx_) {
@@ -82,7 +82,7 @@ void AsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   }
 
   if (recv_varname_to_ctx.size() == 0) {
-    VLOG(1) << "nothing need to be received, will not start recv_thread";
+    VLOG(0) << "nothing need to be received, will not start recv_thread";
   } else {
     recv_threadpool_.reset(new ::ThreadPool(thread_pool_size_));
   }
@@ -269,7 +269,7 @@ void AsyncCommunicator::RecvAll() {
 void AsyncCommunicator::Start() {
   VLOG(1) << "Communicator start";
   if (!communicator_) {
-    VLOG(1) << "Communicator is not inited, do nothing";
+    VLOG(0) << "Communicator is not inited, do nothing";
   } else {
     VLOG(1) << "start send thread and recv thread";
     running_ = true;
@@ -287,7 +287,7 @@ void AsyncCommunicator::Stop() {
   VLOG(1) << "Communicator stop";
   running_ = false;
   if (!communicator_) {
-    VLOG(1) << "Communicator is not inited, do nothing";
+    VLOG(0) << "Communicator is not inited, do nothing";
   } else {
     if (send_thread_) {
       VLOG(1) << "stop send thread";
@@ -387,7 +387,7 @@ void GeoSgdCommunicator::InitImpl(const paddle::framework::ProgramDesc &program,
 void GeoSgdCommunicator::Start() {
   VLOG(1) << "Geo Sgd Communicator start";
   if (!communicator_) {
-    VLOG(1) << "Geo Sgd Communicator is not inited, do nothing";
+    VLOG(0) << "Geo Sgd Communicator is not inited, do nothing";
   } else {
     VLOG(1) << "start send thread ";
     running_ = true;
@@ -401,7 +401,7 @@ void GeoSgdCommunicator::Stop() {
   VLOG(1) << "Geo Sgd Communicator stop";
   running_ = false;
   if (!communicator_) {
-    VLOG(1) << "Geo Sgd Communicator is not inited, do nothing";
+    VLOG(0) << "Geo Sgd Communicator is not inited, do nothing";
   } else {
     if (send_thread_) {
       VLOG(1) << "stop send thread";
@@ -954,7 +954,7 @@ void HalfAsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   recv_scope_ = std::move(recv_scope);
 
   if (send_varname_to_ctx.size() == 0) {
-    VLOG(1) << "nothing need to be send, will not start send_thread";
+    VLOG(0) << "nothing need to be send, will not start send_thread";
   } else {
     send_scope_.reset(new Scope());
     for (auto &iter : send_varname_to_ctx_) {
@@ -967,7 +967,7 @@ void HalfAsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   }
 
   if (recv_varname_to_ctx.size() == 0) {
-    VLOG(1) << "nothing need to be received, will not start recv_thread";
+    VLOG(0) << "nothing need to be received, will not start recv_thread";
   } else {
     recv_threadpool_.reset(new ::ThreadPool(thread_pool_size_));
   }
@@ -1195,7 +1195,7 @@ void HalfAsyncCommunicator::BarrierWeakUp() {
 void HalfAsyncCommunicator::Start() {
   VLOG(1) << "Communicator start";
   if (!communicator_) {
-    VLOG(1) << "Communicator is not inited, do nothing";
+    VLOG(0) << "Communicator is not inited, do nothing";
   } else {
     VLOG(1) << "start send thread and recv thread";
 
@@ -1210,7 +1210,7 @@ void HalfAsyncCommunicator::Stop() {
   VLOG(1) << "Communicator stop";
   running_ = false;
   if (!communicator_) {
-    VLOG(1) << "Communicator is not inited, do nothing";
+    VLOG(0) << "Communicator is not inited, do nothing";
   } else {
     if (consume_thread_) {
       VLOG(4) << "stop send thread";

--- a/paddle/fluid/operators/distributed/communicator.cc
+++ b/paddle/fluid/operators/distributed/communicator.cc
@@ -70,7 +70,7 @@ void AsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   recv_scope_ = std::move(recv_scope);
 
   if (send_varname_to_ctx.size() == 0) {
-    VLOG(0) << "nothing need to be send, will not start send_thread";
+    VLOG(1) << "nothing need to be send, will not start send_thread";
   } else {
     send_scope_.reset(new Scope());
     for (auto &iter : send_varname_to_ctx_) {
@@ -82,7 +82,7 @@ void AsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   }
 
   if (recv_varname_to_ctx.size() == 0) {
-    VLOG(0) << "nothing need to be received, will not start recv_thread";
+    VLOG(1) << "nothing need to be received, will not start recv_thread";
   } else {
     recv_threadpool_.reset(new ::ThreadPool(thread_pool_size_));
   }
@@ -213,7 +213,7 @@ void AsyncCommunicator::SendThread() {
             << after_run_send_graph - before_run_send_graph;
     Recv();
   }
-  VLOG(0) << "communicator stopped, send thread exit";
+  VLOG(1) << "communicator stopped, send thread exit";
 }
 
 void AsyncCommunicator::RecvThread() {
@@ -227,7 +227,7 @@ void AsyncCommunicator::RecvThread() {
       std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
   }
-  VLOG(0) << "communicator stopped, recv thread exit";
+  VLOG(1) << "communicator stopped, recv thread exit";
 }
 
 void AsyncCommunicator::Recv() {
@@ -267,9 +267,9 @@ void AsyncCommunicator::RecvAll() {
 }
 
 void AsyncCommunicator::Start() {
-  VLOG(0) << "Communicator start";
+  VLOG(1) << "Communicator start";
   if (!communicator_) {
-    VLOG(0) << "Communicator is not inited, do nothing";
+    VLOG(1) << "Communicator is not inited, do nothing";
   } else {
     VLOG(1) << "start send thread and recv thread";
     running_ = true;
@@ -284,10 +284,10 @@ void AsyncCommunicator::Start() {
 }
 
 void AsyncCommunicator::Stop() {
-  VLOG(0) << "Communicator stop";
+  VLOG(1) << "Communicator stop";
   running_ = false;
   if (!communicator_) {
-    VLOG(0) << "Communicator is not inited, do nothing";
+    VLOG(1) << "Communicator is not inited, do nothing";
   } else {
     if (send_thread_) {
       VLOG(1) << "stop send thread";
@@ -300,7 +300,7 @@ void AsyncCommunicator::Stop() {
       recv_thread_.reset(nullptr);
     }
   }
-  VLOG(0) << "Communicator stop done";
+  VLOG(1) << "Communicator stop done";
 }
 
 void AsyncCommunicator::Send(const std::vector<std::string> &var_names,
@@ -385,11 +385,11 @@ void GeoSgdCommunicator::InitImpl(const paddle::framework::ProgramDesc &program,
 }
 
 void GeoSgdCommunicator::Start() {
-  VLOG(0) << "Geo Sgd Communicator start";
+  VLOG(1) << "Geo Sgd Communicator start";
   if (!communicator_) {
-    VLOG(0) << "Geo Sgd Communicator is not inited, do nothing";
+    VLOG(1) << "Geo Sgd Communicator is not inited, do nothing";
   } else {
-    VLOG(0) << "start send thread ";
+    VLOG(1) << "start send thread ";
     running_ = true;
     // start send and recv thread
     send_thread_.reset(
@@ -398,10 +398,10 @@ void GeoSgdCommunicator::Start() {
 }
 
 void GeoSgdCommunicator::Stop() {
-  VLOG(0) << "Geo Sgd Communicator stop";
+  VLOG(1) << "Geo Sgd Communicator stop";
   running_ = false;
   if (!communicator_) {
-    VLOG(0) << "Geo Sgd Communicator is not inited, do nothing";
+    VLOG(1) << "Geo Sgd Communicator is not inited, do nothing";
   } else {
     if (send_thread_) {
       VLOG(1) << "stop send thread";
@@ -409,7 +409,7 @@ void GeoSgdCommunicator::Stop() {
       send_thread_.reset(nullptr);
     }
   }
-  VLOG(0) << "Geo Sgd Communicator stop done";
+  VLOG(1) << "Geo Sgd Communicator stop done";
 }
 
 void GeoSgdCommunicator::Send(const std::vector<std::string> &sparse_var_names,
@@ -463,7 +463,7 @@ void GeoSgdCommunicator::Send(const std::vector<std::string> &sparse_var_names,
 }
 
 void GeoSgdCommunicator::SendThread() {
-  VLOG(0) << "SendThread start!";
+  VLOG(1) << "SendThread start!";
   auto before_run_training = GetCurrentUS();
 
   while (running_) {
@@ -954,7 +954,7 @@ void HalfAsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   recv_scope_ = std::move(recv_scope);
 
   if (send_varname_to_ctx.size() == 0) {
-    VLOG(0) << "nothing need to be send, will not start send_thread";
+    VLOG(1) << "nothing need to be send, will not start send_thread";
   } else {
     send_scope_.reset(new Scope());
     for (auto &iter : send_varname_to_ctx_) {
@@ -967,7 +967,7 @@ void HalfAsyncCommunicator::InitImpl(const RpcCtxMap &send_varname_to_ctx,
   }
 
   if (recv_varname_to_ctx.size() == 0) {
-    VLOG(0) << "nothing need to be received, will not start recv_thread";
+    VLOG(1) << "nothing need to be received, will not start recv_thread";
   } else {
     recv_threadpool_.reset(new ::ThreadPool(thread_pool_size_));
   }
@@ -1022,6 +1022,17 @@ void HalfAsyncCommunicator::InitImpl(
 HalfAsyncCommunicator::~HalfAsyncCommunicator() {
   running_ = false;
   if (consume_thread_) consume_thread_->join();
+}
+
+void HalfAsyncCommunicator::Clean() {
+  for (auto &iter : send_varname_to_queue_) {
+    auto &var_name = iter.first;
+    auto &var_queue = iter.second;
+
+    while (var_queue->Size() > 0) {
+      var_queue->Pop();
+    }
+  }
 }
 
 void HalfAsyncCommunicator::ConsumeThread() {
@@ -1099,7 +1110,10 @@ void HalfAsyncCommunicator::ConsumeThread() {
     BarrierRecv();
     BarrierWeakUp();
   }
-  VLOG(0) << "communicator stopped, send thread exit";
+
+  Clean();
+
+  VLOG(1) << "communicator stopped, send thread exit";
 }
 
 void HalfAsyncCommunicator::Send(const std::vector<std::string> &var_names,
@@ -1146,6 +1160,12 @@ void HalfAsyncCommunicator::Recv() {
 
 void HalfAsyncCommunicator::Barrier() {
   barrier_counter_++;
+
+  if (!running_) {
+    VLOG(3) << "Communicator is not running, release barrier";
+    return;
+  }
+
   {
     std::unique_lock<std::mutex> lk(barrier_mutex_);
     barrier_cond_.wait(lk, [this] { return (barrier_counter_ == 0); });
@@ -1171,9 +1191,9 @@ void HalfAsyncCommunicator::BarrierWeakUp() {
 }
 
 void HalfAsyncCommunicator::Start() {
-  VLOG(0) << "Communicator start";
+  VLOG(1) << "Communicator start";
   if (!communicator_) {
-    VLOG(0) << "Communicator is not inited, do nothing";
+    VLOG(1) << "Communicator is not inited, do nothing";
   } else {
     VLOG(1) << "start send thread and recv thread";
 
@@ -1185,10 +1205,10 @@ void HalfAsyncCommunicator::Start() {
 }
 
 void HalfAsyncCommunicator::Stop() {
-  VLOG(0) << "Communicator stop";
+  VLOG(1) << "Communicator stop";
   running_ = false;
   if (!communicator_) {
-    VLOG(0) << "Communicator is not inited, do nothing";
+    VLOG(1) << "Communicator is not inited, do nothing";
   } else {
     if (consume_thread_) {
       VLOG(4) << "stop send thread";
@@ -1196,7 +1216,7 @@ void HalfAsyncCommunicator::Stop() {
       consume_thread_.reset(nullptr);
     }
   }
-  VLOG(0) << "Communicator stop done";
+  VLOG(1) << "Communicator stop done";
 }
 
 void SyncCommunicator::BarrierSend() {

--- a/paddle/fluid/operators/distributed/communicator.cc
+++ b/paddle/fluid/operators/distributed/communicator.cc
@@ -1032,6 +1032,8 @@ void HalfAsyncCommunicator::Clean() {
     while (var_queue->Size() > 0) {
       var_queue->Pop();
     }
+
+    VLOG(3) << "clean var: " << var_name << " done";
   }
 }
 

--- a/paddle/fluid/operators/distributed/communicator.h
+++ b/paddle/fluid/operators/distributed/communicator.h
@@ -183,6 +183,8 @@ class Communicator {
   virtual void Stop() = 0;
   virtual bool IsRunning() { return running_; }
 
+  virtual void Clean() {}
+
   virtual void Send(const std::vector<std::string>& var_names,
                     const std::vector<std::string>& var_tables,
                     const framework::Scope& scope) = 0;
@@ -308,6 +310,8 @@ class HalfAsyncCommunicator : public Communicator {
   ~HalfAsyncCommunicator();
   void Start() override;
   void Stop() override;
+
+  void Clean() override;
 
   void Send(const std::vector<std::string>& var_names,
             const std::vector<std::string>& var_tables,


### PR DESCRIPTION
1. 修复部分LOG级别过低的问题， 0 -> 1
2. 修复Pyreader训练的情况下，用户中途break训练，导致core的问题
3. 用户在中途break的情况下，依然需要调用fleet.stop_worker()来结束训练