### PR TITLE
[Cherry-pick] Fix fc padding bug during inference fusion

### DIFF
--- a/paddle/fluid/framework/ir/fc_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/fc_fuse_pass.cc
@@ -100,22 +100,31 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     bool use_gpu = Has("use_gpu") ? Get<bool>("use_gpu") : false;
     bool use_fc_padding =
         Has("use_fc_padding") ? Get<bool>("use_fc_padding") : true;
+    const std::string& w_name = patterns::UniqueKey(w->Name());
+    VarDesc w_key(w_name);
+    w_key.SetPersistable(true);
+    auto* w_node = g->CreateVarNode(&w_key);
     if (!use_gpu && use_fc_padding) {
       if (w_h % 128 == 0 && w_w % 128 == 0) {
+        auto* w_var = scope->Var(w_name);
+        auto* w_tensor = w_var->GetMutable<framework::LoDTensor>();
+
         auto* weight_data_tmp = new float[weight_num];
         for (int i = 0; i < w_h; i++) {
           memcpy(weight_data_tmp + i * w_w, weight_data + i * w_w,
                  w_w * sizeof(float));
         }
-        weight->Resize(DDim{weight_dims[0] + 4, weight_dims[1] + 4});
+        w_tensor->Resize(DDim{weight_dims[0] + 4, weight_dims[1] + 4});
         auto* weight_data_new =
-            weight->mutable_data<float>(platform::CPUPlace());
+            w_tensor->mutable_data<float>(platform::CPUPlace());
         for (int i = 0; i < w_h; i++) {
           memcpy(weight_data_new + i * (w_w + 4), weight_data_tmp + i * w_w,
                  w_w * sizeof(float));
         }
         delete[] weight_data_tmp;
+        desc.SetInput("W", {w_name});
         desc.SetAttr("padding_weights", true);
+        desc.Flush();
       }
     }
 
@@ -147,7 +156,12 @@ int FCFusePass::ApplyFCPattern(Graph* graph, bool with_relu) const {
     }
 
     IR_NODE_LINK_TO(subgraph.at(x), fc_node);
-    IR_NODE_LINK_TO(w, fc_node);
+    if (desc.GetAttrIfExists<bool>("padding_weights")) {
+      IR_NODE_LINK_TO(w_node, fc_node);
+    } else {
+      GraphSafeRemoveNodes(g, {w_node});
+      IR_NODE_LINK_TO(w, fc_node);
+    }
     IR_NODE_LINK_TO(bias, fc_node);
     if (with_relu) {
       IR_NODE_LINK_TO(fc_node, relu_out);


### PR DESCRIPTION
cherry-pick #22860  
![image](https://user-images.githubusercontent.com/7160927/75941245-18298380-5eca-11ea-96ea-2c46e6a4e8da.png)

根据上图中的模型结构，两个 mul op 的 weight_shape 是 128\*128，即在 fuse 成 fc 的时候，在 fc_fuse_pass.cc 里面会执行 padding 操作。并且名称也是相同的，都是 tanh.w，于是 `w->Name()` 得到的名称相同。
在第一个 mul+elementwise_add 的结构在 fuse 为 fc 做了 padding 之后，名为 tanh.w 的 var_shape 已经变成了 132\*132 。指定 padding_weight 为 true。
第二个相同的结构过来的时候，使用 `w->Name()` 获取的 shape 就是 132\*132，不会再做 padding，即 padding_weight 为 false，程序不知道这个结构也要做 padding ，所以 kernel 计算的时候 shape 对不上了。故报错。
![image](https://user-images.githubusercontent.com/7160927/75942802-5759d380-5ece-11ea-8145-b234cd25705a.png)

这个 PR 将修复 cherry-pick 到 1.7。