### PR TITLE
Speed up the matmul op, use the gemm replace the batch gemm

### DIFF
--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -80,7 +80,7 @@ class MatMulKernel : public framework::OpKernel<T> {
     const auto &x_dims = x.dims();
     const auto &y_dims = y.dims();
     if (head_number <= 1 && x_dims.size() == 3 && y_dims.size() <= 2) {
-      // the transpose_X must be true, if is true, the transpose cost much time
+      // the transpose_X must be false, if is true, the transpose cost much time
       if (!context.Attr<bool>("transpose_X")) {
          mat_dim_a.height_ *= mat_dim_a.batch_size_;
          mat_dim_a.batch_size_ = 0;
@@ -230,7 +230,7 @@ class MatMulGradKernel : public framework::OpKernel<T> {
     #endif
 
     if (head_number <= 1 && a.dims().size() == 3 && b.dims().size() <= 2) {
-      // the transpose_X must be true, if is true, the transpose cost much time
+      // the transpose_X must be false, if is true, the transpose cost much time
       if (!trans_a) {
         mat_dim_a.height_ *= mat_dim_a.batch_size_;
         mat_dim_a.batch_size_ = 0;

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -82,8 +82,8 @@ class MatMulKernel : public framework::OpKernel<T> {
     if (head_number <= 1 && x_dims.size() == 3 && y_dims.size() <= 2) {
       // the transpose_X must be false, if is true, the transpose cost much time
       if (!context.Attr<bool>("transpose_X")) {
-         mat_dim_a.height_ *= mat_dim_a.batch_size_;
-         mat_dim_a.batch_size_ = 0;
+        mat_dim_a.height_ *= mat_dim_a.batch_size_;
+        mat_dim_a.batch_size_ = 0;
       }
     }
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
@@ -225,9 +225,9 @@ class MatMulGradKernel : public framework::OpKernel<T> {
     auto mat_dim_b = math::CreateMatrixDescriptor(b.dims(), 0, trans_b);
 
     int head_number = 1;
-    #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
-       head_number = context.Attr<int>("head_number");
-    #endif
+#if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
+    head_number = context.Attr<int>("head_number");
+#endif
 
     if (head_number <= 1 && a.dims().size() == 3 && b.dims().size() <= 2) {
       // the transpose_X must be false, if is true, the transpose cost much time

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -72,8 +72,21 @@ class MatMulKernel : public framework::OpKernel<T> {
         ColumnMatrixFromVector(y.dims()), 0, context.Attr<bool>("transpose_Y"));
     auto scale = static_cast<T>(context.Attr<float>("alpha"));
 
+    int head_number = 1;
 #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
-    int head_number = context.Attr<int>("head_number");
+    head_number = context.Attr<int>("head_number");
+#endif
+
+    const auto &x_dims = x.dims();
+    const auto &y_dims = y.dims();
+    if (head_number <= 1 && x_dims.size() == 3 && y_dims.size() <= 2) {
+      // the transpose_X must be true, if is true, the transpose cost much time
+      if (!context.Attr<bool>("transpose_X")) {
+         mat_dim_a.height_ *= mat_dim_a.batch_size_;
+         mat_dim_a.batch_size_ = 0;
+      }
+    }
+#if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
     bool split_vertical_y = (mat_dim_a.width_ != mat_dim_b.height_);
 
     if (head_number > 1) {
@@ -210,6 +223,19 @@ class MatMulGradKernel : public framework::OpKernel<T> {
     auto blas = math::GetBlas<DeviceContext, T>(context);
     auto mat_dim_a = math::CreateMatrixDescriptor(a.dims(), 0, trans_a);
     auto mat_dim_b = math::CreateMatrixDescriptor(b.dims(), 0, trans_b);
+
+    int head_number = 1;
+    #if defined(PADDLE_WITH_MKLML) && !defined(PADDLE_WITH_CUDA)
+       head_number = context.Attr<int>("head_number");
+    #endif
+
+    if (head_number <= 1 && a.dims().size() == 3 && b.dims().size() <= 2) {
+      // the transpose_X must be true, if is true, the transpose cost much time
+      if (!trans_a) {
+        mat_dim_a.height_ *= mat_dim_a.batch_size_;
+        mat_dim_a.batch_size_ = 0;
+      }
+    }
     blas.MatMul(a, mat_dim_a, b, mat_dim_b,
                 static_cast<T>(context.Attr<float>("alpha")), out, T(0));
   }


### PR DESCRIPTION
matmul性能优化
1.性能对比1 
X = [1024, 10, 12]
Y = [12, 10]

未优化前
matmul gpu_time  0.591ms

优化后
matmul gpu_time  0.326ms

速度提升 1.8x

2.性能对比2 
X = [128, 50, 1000]
Y = [1000, 1000]

未优化前
matmul gpu_time  20.9ms 

优化后
matmul gpu_time  15.6ms

速度提升 1.34x

3.性能对比3
X = [512, 50, 1000]
Y = [1000, 1000]

未优化前
matmul gpu_time  61.3ms 

优化后
matmul gpu_time  43.2ms

速度提升 1.41x
