### PR TITLE
add check for infer data

### DIFF
--- a/paddle/fluid/inference/api/helper.h
+++ b/paddle/fluid/inference/api/helper.h
@@ -181,10 +181,28 @@ int VecReduceToInt(const std::vector<T> &v) {
 }
 
 template <typename T>
+void CheckAssignedData(const std::vector<std::vector<T>> &data,
+                       const int num_elems) {
+  int num = 0;
+  for (auto it = data.begin(); it != data.end(); ++it) {
+    num += (*it).size();
+  }
+  PADDLE_ENFORCE_EQ(
+      num, num_elems,
+      platform::errors::OutOfRange(
+          "The number of elements out of bounds. "
+          "Expected number of elements = %d. But received %d. Suggested Fix: "
+          "If the tensor is expected to assign %d elements, check the number "
+          "of elements of your 'infer_data'.",
+          num_elems, num, num_elems));
+}
+
+template <typename T>
 static void TensorAssignData(PaddleTensor *tensor,
                              const std::vector<std::vector<T>> &data) {
   // Assign buffer
   int num_elems = VecReduceToInt(tensor->shape);
+  CheckAssignedData(data, num_elems);
   tensor->data.Resize(sizeof(T) * num_elems);
   int c = 0;
   for (const auto &f : data) {


### PR DESCRIPTION
There will be an OOB error in `TensorAssignData`(In `paddle/fluid/inference/api/helper.h`), this PR adds check for assigned data.

When the number of elements of `infer_data` is out of bounds, the error will be given. 
![image](https://user-images.githubusercontent.com/26615455/76395717-e83f1c00-63b2-11ea-8d2a-737f2b7d4331.png)

