### PR TITLE
Correct the wrong name in the flag comment

### DIFF
--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -171,9 +171,9 @@ DEFINE_bool(cudnn_batchnorm_spatial_persistent, false,
 
 /**
  * NCCL related FLAG
- * Name: FLAGS_enable_cublas_tensor_op_math
- * Since Version:
- * Value Range:
+ * Name: FLAGS_sync_nccl_allreduce
+ * Since Version: 1.3
+ * Value Range: bool, default=true
  * Example:
  * Note: asynchronous nccl allreduce or synchronous issue:
  *       https://github.com/PaddlePaddle/Paddle/issues/15049


### PR DESCRIPTION
根据官网中[`FLAGS_sync_nccl_allreduce`](https://www.paddlepaddle.org.cn/documentation/docs/zh/advanced_guide/flags/others_cn.html#flags-sync-nccl-allreduce)的相关信息修改其注释中的错误

![image](https://user-images.githubusercontent.com/52460041/76524659-61b73700-64a5-11ea-8a0b-043f1210a897.png)
