### PR TITLE
Add new api and remove the previous gradient clipping interface

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -74,8 +74,8 @@ from .incubate import data_generator
 from .transpiler import DistributeTranspiler, \
     memory_optimize, release_memory, DistributeTranspilerConfig
 from .lod_tensor import create_lod_tensor, create_random_int_lodtensor
-from . import clip
-from . import dygraph_grad_clip
+from .clip import *
+from . import dygraph_grad_clip as clip
 from . import profiler
 from . import unique_name
 from . import parallel_executor

--- a/python/paddle/fluid/contrib/extend_optimizer/extend_optimizer_with_weight_decay.py
+++ b/python/paddle/fluid/contrib/extend_optimizer/extend_optimizer_with_weight_decay.py
@@ -90,9 +90,7 @@ class DecoupledWeightDecay(object):
                 paddle.fluid.layers.assign(input=updated_param, output=param)
 
         optimize_ops = self.apply_optimize(
-            loss=loss,
-            params_grads=params_grads,
-            startup_program=startup_program)
+            params_grads=params_grads, startup_program=startup_program)
         return optimize_ops, params_grads
 
     def __str__(self):

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2409,7 +2409,6 @@ class Block(object):
             trainable = v.trainable
             optimize_attr = v.optimize_attr
             regularizer = v.regularizer
-            gradient_clip_attr = v.gradient_clip_attr
             error_clip = v.error_clip
         elif type(v) == Variable:
             var_type = "Variable"
@@ -2432,7 +2431,6 @@ class Block(object):
                     trainable=trainable,
                     optimize_attr=optimize_attr,
                     regularizer=regularizer,
-                    gradient_clip_attr=gradient_clip_attr,
                     error_clip=error_clip)
             else:
                 var = Parameter(
@@ -2445,7 +2443,6 @@ class Block(object):
                     trainable=trainable,
                     optimize_attr=optimize_attr,
                     regularizer=regularizer,
-                    gradient_clip_attr=gradient_clip_attr,
                     error_clip=error_clip)
         elif var_type == "Variable":
             var = Variable(
@@ -2723,7 +2720,6 @@ class Block(object):
                     trainable=p.trainable,
                     optimize_attr=p.optimize_attr,
                     regularizer=p.regularizer,
-                    gradient_clip_attr=p.gradient_clip_attr,
                     error_clip=p.error_clip,
                     name=v.name)
             else:
@@ -2737,7 +2733,6 @@ class Block(object):
                     trainable=p.trainable,
                     optimize_attr=p.optimize_attr,
                     regularizer=p.regularizer,
-                    gradient_clip_attr=p.gradient_clip_attr,
                     error_clip=p.error_clip,
                     name=v.name)
             self.vars[new_p.name] = new_p
@@ -4646,8 +4641,6 @@ class Parameter(Variable):
             Default: {'learning_rate': 1.0}
         regularizer(WeightDecayRegularizer): The Regularizer which will
             be applied on the parameter. Default: None
-        gradient_clip_attr(BaseGradientClipAttr): The gradient clip strategy
-            which will be applied on the parameter. Default: None
         do_model_average(bool): True if the model average strategy will
             be applied on this parameter.
     """
@@ -4687,8 +4680,6 @@ class Parameter(Variable):
 
         self.regularizer = kwargs.get('regularizer', None)
 
-        self.gradient_clip_attr = kwargs.get('gradient_clip_attr', None)
-
         self.do_model_average = kwargs.get('do_model_average', None)
 
         self.is_distributed = False
@@ -4723,7 +4714,7 @@ class Parameter(Variable):
         if with_details:
             res_str = Variable.to_string(self, throw_on_error, True)
             additional_attr = ("trainable", "optimize_attr", "regularizer",
-                               "gradient_clip_attr", "do_model_average")
+                               "do_model_average")
             for attr_name in additional_attr:
                 res_str += "%s: %s\n" % (attr_name,
                                          cpt.to_text(getattr(self, attr_name)))
@@ -4752,8 +4743,6 @@ class ParamBase(core.VarBase):
             Default: {'learning_rate': 1.0}
         regularizer(WeightDecayRegularizer): The Regularizer which will
             be applied on the ParamBase. Default: None
-        gradient_clip_attr(BaseGradientClipAttr): The gradient clip strategy
-            which will be applied on the ParamBase. Default: None
         do_model_average(bool): True if the model average strategy will
             be applied on this ParamBase.
     """
@@ -4791,8 +4780,6 @@ class ParamBase(core.VarBase):
         self.optimize_attr = kwargs.get('optimize_attr', {'learning_rate': 1.0})
 
         self.regularizer = kwargs.get('regularizer', None)
-
-        self.gradient_clip_attr = kwargs.get('gradient_clip_attr', None)
 
         self.do_model_average = kwargs.get('do_model_average', None)
 

--- a/python/paddle/fluid/param_attr.py
+++ b/python/paddle/fluid/param_attr.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import six
+import warnings
 
 from .initializer import Initializer, Xavier, Constant
 from .regularizer import WeightDecayRegularizer
@@ -43,8 +44,10 @@ class ParamAttr(object):
         regularizer (WeightDecayRegularizer, optional): Regularization factor. Default None, meaning
                 there is no regularization.
         trainable (bool): Whether this parameter is trainable. Default True.
-        gradient_clip (BaseGradientClipAttr, optional): The method to clip this parameter's
-                gradient. Default None, meaning that there is no gradient clip.
+        gradient_clip (BaseGradientClipAttr, optional): This attribute is deprecated since 2.0. 
+                Please do not use it. The better gradient clip strategy is to clip gradient by 
+                :ref:`api_fluid_grad_clip_value` , :ref:`api_fluid_grad_clip_norm` , 
+                :ref:`api_fluid_grad_clip_global_norm` .
         do_model_average (bool): Whether this parameter should do model average
                 when model average is enabled. Default False.
 
@@ -78,8 +81,19 @@ class ParamAttr(object):
         self.learning_rate = learning_rate
         self.regularizer = regularizer
         self.trainable = trainable
-        self.gradient_clip = gradient_clip
         self.do_model_average = do_model_average
+
+        if gradient_clip is not None:
+            warnings.warn(
+                "Caution! gradient_clip of paddle.fluid.ParamAttr() is deprecated since 2.0 "
+                "and not maintained any more, because it is easily to be misused.\n"
+                "After that, we recommend a new gradient clipping strategy where you "
+                "do gradient clipping through the following API:\n"
+                "1. paddle.fluid.grad_clip_value: clip gradient by value.\n"
+                "2. paddle.fluid.grad_clip_norm: clip gradient by norm.\n"
+                "3. paddle.fluid.grad_clip_global_norm: clip gradient by global norm.\n"
+                "This method can reduce the mistakes, please see documention of these "
+                "gradient clip APIs")
 
     def _set_default_initializer(self, initializer):
         """
@@ -176,7 +190,6 @@ class ParamAttr(object):
             },
             'regularizer': self.regularizer,
             'trainable': self.trainable,
-            'gradient_clip_attr': self.gradient_clip,
             'do_model_average': self.do_model_average
         }
         if with_initializer:

--- a/python/paddle/fluid/tests/unittests/test_dgc_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_dgc_optimizer.py
@@ -82,8 +82,7 @@ class TestDGCMomentumOptimizer(unittest.TestCase):
         self.assertEqual(len(params_grads), 1)
         self.assertEqual(
             len(dgc_momentum_optimizer.get_accumulators()), accumulator_count)
-        with framework.program_guard(program, init_program):
-            opts = dgc_momentum_optimizer.apply_gradients(params_grads)
+        opts = dgc_momentum_optimizer.apply_optimize(params_grads, init_program)
         self.assertEqual(len(opts), 2)
         sgd_op = opts[-1]
         self.assertEqual([op.type for op in opts], ["scale", name])

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -23,7 +23,7 @@ import six
 from fake_reader import fake_imdb_reader
 
 
-def bow_net(data,
+def bow_net(words,
             label,
             dict_dim,
             emb_dim=128,
@@ -36,7 +36,7 @@ def bow_net(data,
     fluid/PaddleNLP/text_classification/nets.py
     """
     emb = fluid.layers.embedding(
-        input=data, is_sparse=True, size=[dict_dim, emb_dim])
+        input=words, is_sparse=True, size=[dict_dim, emb_dim])
     bow = fluid.layers.sequence_pool(input=emb, pool_type='sum')
     bow_tanh = fluid.layers.tanh(bow)
     fc_1 = fluid.layers.fc(input=bow_tanh, size=hid_dim, act="tanh")
@@ -54,6 +54,10 @@ class TestGradientClip(unittest.TestCase):
         self.BATCH_SIZE = 2
         reader = fake_imdb_reader(self.word_dict_len, self.BATCH_SIZE * 100)
         self.train_data = paddle.batch(reader, batch_size=self.BATCH_SIZE)
+        self.init()
+
+    def init(self):
+        pass
 
     def get_places(self):
         places = [core.CPUPlace()]
@@ -61,15 +65,19 @@ class TestGradientClip(unittest.TestCase):
             places.append(core.CUDAPlace(0))
         return places
 
-    def check_operators(self, place):
-        CLIP = 1
+    def gradient_clip(self, params_grads):
+        pass
 
+    def check_output(self, out, out_clip):
+        pass
+
+    def check_gradient_clip(self, place):
         prog = fluid.framework.Program()
         startup_program = fluid.framework.Program()
         with fluid.program_guard(
                 main_program=prog, startup_program=startup_program):
-            image = fluid.layers.data(name='x', shape=[784], dtype='float32')
-            label = fluid.layers.data(name='y', shape=[1], dtype='int64')
+            image = fluid.data(name='x', shape=[-1, 784], dtype='float32')
+            label = fluid.data(name='y', shape=[-1, 1], dtype='int64')
 
             hidden1 = fluid.layers.fc(input=image, size=128, act='relu')
             hidden2 = fluid.layers.fc(input=hidden1, size=64, act='relu')
@@ -84,11 +92,11 @@ class TestGradientClip(unittest.TestCase):
         p_g = fluid.backward.append_backward(loss=avg_cost)
         p_g_clip = fluid.backward.append_backward(loss=avg_cost_clip)
 
+        p_g = sorted(p_g, key=lambda x: x[0].name)
+        p_g_clip = sorted(p_g_clip, key=lambda x: x[0].name)
         with fluid.program_guard(
                 main_program=prog_clip, startup_program=startup_program):
-            fluid.clip.set_gradient_clip(
-                fluid.clip.GradientClipByGlobalNorm(clip_norm=CLIP))
-            p_g_clip = fluid.clip.append_gradient_clip_ops(p_g_clip)
+            p_g_clip = self.gradient_clip(p_g_clip)
 
         grad_list = [elem[1] for elem in p_g]
         grad_clip_list = [elem[1] for elem in p_g_clip]
@@ -102,60 +110,282 @@ class TestGradientClip(unittest.TestCase):
         feeder = fluid.DataFeeder(feed_list=[image, label], place=place)
         exe.run(startup_program)
 
-        count = 0
-        for data in train_reader():
-            count += 1
-            if count > 5:
-                break
-            out = exe.run(prog, feed=feeder.feed(data), fetch_list=grad_list)
-            out_clip = exe.run(prog_clip,
-                               feed=feeder.feed(data),
-                               fetch_list=grad_clip_list)
-            global_norm = 0
-            for v in out:
-                global_norm += np.sum(np.power(v, 2))
-            global_norm = np.sqrt(global_norm)
+        data = next(train_reader())
+        out = exe.run(prog, feed=feeder.feed(data), fetch_list=grad_list)
+        out_clip = exe.run(prog_clip,
+                           feed=feeder.feed(data),
+                           fetch_list=grad_clip_list)
 
-            global_norm_clip = 0
-            for v in out_clip:
-                global_norm_clip += np.sum(np.power(v, 2))
-            global_norm_clip = np.sqrt(global_norm_clip)
+    def backward_and_optimize(cost):
+        pass
 
-            assert np.isclose(
-                a=global_norm_clip, b=np.minimum(global_norm, CLIP), rtol=5e-3)
-
-    def check_sparse_gradient_clip(self, place):
+    def check_with_optimize(self, place):
         prog = fluid.framework.Program()
         startup_program = fluid.framework.Program()
         with fluid.program_guard(
                 main_program=prog, startup_program=startup_program):
-            data = fluid.layers.data(
-                name="words", shape=[1], dtype="int64", lod_level=1)
-            label = fluid.layers.data(name="label", shape=[1], dtype="int64")
-            cost = bow_net(data, label, self.word_dict_len)
-
-            fluid.clip.set_gradient_clip(
-                clip=fluid.clip.GradientClipByGlobalNorm(clip_norm=5.0))
-
-            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.01)
-            sgd_optimizer.minimize(cost)
+            words = fluid.data(
+                name="words", shape=[-1, 1], dtype="int64", lod_level=1)
+            label = fluid.data(name="label", shape=[-1, 1], dtype="int64")
+            cost = bow_net(words, label, self.word_dict_len)
+            self.backward_and_optimize(cost)
 
         exe = fluid.Executor(place)
-        feeder = fluid.DataFeeder(feed_list=[data, label], place=place)
+        feeder = fluid.DataFeeder(feed_list=[words, label], place=place)
         exe.run(startup_program)
 
         data = next(self.train_data())
         val = exe.run(prog, feed=feeder.feed(data), fetch_list=[cost])[0]
-        self.assertEqual((1, ), val.shape)
-        print(val)
-        self.assertFalse(np.isnan(val))
+        self.assertEqual((1, ), val.shape, "the shape of loss is not [1]")
+        self.assertFalse(np.isnan(val), "the loss of network is nan")
 
-    def test_operators(self):
-        self.check_operators(core.CPUPlace())
 
-    def test_sparse_gradient_clip(self):
+class TestGradientClipByGlobalNorm(TestGradientClip):
+    def init(self):
+        self.clip_norm = 1.0
+
+    def gradient_clip(self, params_grads):
+        return fluid.grad_clip_global_norm(
+            params_grads, clip_norm=self.clip_norm)
+
+    def check_output(self, out, out_clip):
+        global_norm = 0
+        for v in out:
+            global_norm += np.sum(np.power(v, 2))
+        global_norm = np.sqrt(global_norm)
+
+        global_norm_clip = 0
+        for v in out_clip:
+            global_norm_clip += np.sum(np.power(v, 2))
+        global_norm_clip = np.sqrt(global_norm_clip)
+
+        a = np.minimum(global_norm, self.clip_norm)
+        b = global_norm_clip
+        self.assertTrue(
+            np.isclose(
+                a=a, b=b, rtol=5e-3),
+            "gradient clip by global norm has wrong results, expetcd:%f, but recieved:%f"
+            % (a, b))
+
+    def test_gradient_clip(self):
+        self.check_gradient_clip(core.CPUPlace())
+
+    def test_gradient_clip_with_optimize_1(self):
+        def func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            params_grads = sgd_optimizer.backward(cost)
+            params_grads = fluid.grad_clip_global_norm(
+                params_grads, clip_norm=self.clip_norm)
+            sgd_optimizer.apply_optimize(params_grads)
+
+        self.backward_and_optimize = func
         for place in self.get_places():
-            self.check_sparse_gradient_clip(place)
+            self.check_with_optimize(place)
+
+    def test_gradient_clip_with_optimize_2(self):
+        def func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            clip = fluid.clip.GradClipByGlobalNorm(clip_norm=self.clip_norm)
+            sgd_optimizer.minimize(cost, grad_clip=clip)
+
+        self.backward_and_optimize = func
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+
+class TestGradientClipByNorm(TestGradientClip):
+    def init(self):
+        self.clip_norm = 1.0
+
+    def gradient_clip(self, params_grads):
+        return fluid.grad_clip_norm(params_grads, clip_norm=self.clip_norm)
+
+    def check_output(self, out, out_clip):
+        self.assertTrue(
+            len(out) == len(out_clip),
+            "Number of gradient changed after clipping, before clip:%d, after clip:%d"
+            % (len(out), len(out_clip)))
+        for u, v in zip(out, out_clip):
+            a = np.sqrt(np.sum(np.power(u, 2)))
+            a = np.minimum(a, self.clip_norm)
+            b = np.sqrt(np.sum(np.power(v, 2)))
+            self.assertTrue(
+                np.isclose(
+                    a=a, b=b, rtol=5e-3),
+                "gradient clip by norm has wrong results, expetcd:%f, but recieved:%f"
+                % (a, b))
+
+    def test_gradient_clip(self):
+        self.check_gradient_clip(core.CPUPlace())
+
+    def test_gradient_clip_with_optimize_1(self):
+        def func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            params_grads = sgd_optimizer.backward(cost)
+            params_grads = fluid.grad_clip_norm(
+                params_grads, clip_norm=self.clip_norm)
+            sgd_optimizer.apply_optimize(params_grads)
+
+        self.backward_and_optimize = func
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+    def test_gradient_clip_with_optimize_2(self):
+        def func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            clip = fluid.clip.GradClipByNorm(clip_norm=self.clip_norm)
+            sgd_optimizer.minimize(cost, grad_clip=clip)
+
+        self.backward_and_optimize = func
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+
+class TestGradientClipByValue(TestGradientClip):
+    def init(self):
+        self.max = 1.0
+        self.min = 0.1
+
+    def gradient_clip(self, params_grads):
+        return fluid.grad_clip_value(params_grads, max=self.max, min=self.min)
+
+    def check_output(self, out, out_clip):
+        for i, v in enumerate(out):
+            out[i] = np.clip(v, self.min, self.max)
+
+        self.assertTrue(
+            len(out) == len(out_clip),
+            "Number of gradient changed after clipping, before clip:%d, after clip:%d"
+            % (len(out), len(out_clip)))
+        for u, v in zip(out, out_clip):
+            self.assertTrue(
+                np.allclose(
+                    a=u, b=v, rtol=5e-3),
+                "gradient clip by value has wrong results")
+
+    def test_gradient_clip(self):
+        self.check_gradient_clip(core.CPUPlace())
+
+    def test_gradient_clip_with_optimize_1(self):
+        def func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            params_grads = sgd_optimizer.backward(cost)
+            params_grads = fluid.grad_clip_value(
+                params_grads, max=self.max, min=self.min)
+            sgd_optimizer.apply_optimize(params_grads)
+
+        self.backward_and_optimize = func
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+    def test_gradient_clip_with_optimize_2(self):
+        def func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            clip = fluid.clip.GradClipByValue(
+                min_value=self.min, max_value=self.max)
+            sgd_optimizer.minimize(cost, grad_clip=clip)
+
+        self.backward_and_optimize = func
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+
+class TestDygraphGradientClip(unittest.TestCase):
+    def setUp(self):
+        self.clip_norm = 1.0
+        self.clip = fluid.clip.GradClipByGlobalNorm(clip_norm=self.clip_norm)
+
+    def test_gradient_clip(self):
+        with fluid.dygraph.guard():
+            linear = fluid.dygraph.Linear(10, 10)
+            inputs = fluid.layers.uniform_random([32, 10]).astype('float32')
+            out = linear(fluid.dygraph.to_variable(inputs))
+            loss = fluid.layers.reduce_mean(out)
+            loss.backward()
+            sgd_optimizer = fluid.optimizer.SGD(
+                learning_rate=0.1, parameter_list=linear.parameters())
+            self.check_output(loss, sgd_optimizer)
+
+    def check_output(self, loss, optimizer):
+        optimizer.minimize(loss, grad_clip=self.clip)
+        self.assertEqual((1, ),
+                         loss.numpy().shape, "the shape of loss is not [1]")
+        self.assertFalse(
+            np.isnan(loss.numpy()), "the loss of dygraph network is nan")
+
+
+class TestDygraphGradientClipByGlobalNorm(TestDygraphGradientClip):
+    def check_output(self, loss, optimizer):
+        params_grads = optimizer.backward(loss)
+        _, grads = zip(*params_grads)
+        params_grads = self.clip(params_grads)
+        _, grads_clip = zip(*params_grads)
+
+        global_norm = 0
+        for v in grads:
+            v = v.numpy()
+            global_norm += np.sum(np.power(v, 2))
+        global_norm = np.sqrt(global_norm)
+
+        global_norm_clip = 0
+        for v in grads_clip:
+            v = v.numpy()
+            global_norm_clip += np.sum(np.power(v, 2))
+        global_norm_clip = np.sqrt(global_norm_clip)
+
+        a = np.minimum(global_norm, self.clip_norm)
+        b = global_norm_clip
+        self.assertTrue(
+            np.isclose(
+                a=a, b=b, rtol=5e-3),
+            "gradient clip by global norm has wrong results, expetcd:%f, but recieved:%f"
+            % (a, b))
+
+
+class TestDygraphGradientClipByNorm(TestDygraphGradientClip):
+    def setUp(self):
+        self.clip_norm = 1.0
+        self.clip = fluid.clip.GradClipByNorm(clip_norm=self.clip_norm)
+
+    def check_output(self, loss, optimizer):
+        params_grads = optimizer.backward(loss)
+        _, grads = zip(*params_grads)
+        params_grads = self.clip(params_grads)
+        _, grads_clip = zip(*params_grads)
+
+        for u, v in zip(grads, grads_clip):
+            u = u.numpy()
+            v = v.numpy()
+            a = np.sqrt(np.sum(np.power(u, 2)))
+            a = np.minimum(a, self.clip_norm)
+            b = np.sqrt(np.sum(np.power(v, 2)))
+            self.assertTrue(
+                np.isclose(
+                    a=a, b=b, rtol=5e-3),
+                "gradient clip by norm has wrong results, expetcd:%f, but recieved:%f"
+                % (a, b))
+
+
+class TestDygraphGradientClipByValue(TestDygraphGradientClip):
+    def setUp(self):
+        self.max = 1.0
+        self.min = 0.1
+        self.clip = fluid.clip.GradClipByValue(
+            min_value=self.min, max_value=self.max)
+
+    def check_output(self, loss, optimizer):
+        params_grads = optimizer.backward(loss)
+        _, grads = zip(*params_grads)
+        params_grads = self.clip(params_grads)
+        _, grads_clip = zip(*params_grads)
+
+        for u, v in zip(grads, grads_clip):
+            a = np.clip(u.numpy(), self.min, self.max)
+            b = v.numpy()
+            self.assertTrue(
+                np.allclose(
+                    a=a, b=b, rtol=5e-3),
+                "gradient clip by value has wrong results")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
当前的梯度裁剪API `set_gradient_clip` 存在一些问题，因为 `set_gradient_clip` 是一个隐式地API，其本质是设置一个参数的属性，然后在`minimize中`操作该属性来生效，因而对位置的要求很高。

- **问题1**：set_gradient_clip必须位于minimize之前，否则不会生效。
- **问题2**：set_gradient_clip必须位于组网之后，否则此时参数未更新，也不会生效。
- **问题3**：set_gradient_clip会重置掉ParamAttr所设的值，导致ParamAttr的grad_clip_attr失效。
而且这些问题对用户不会有提醒。

因此新增了三个API做手动梯度裁剪：
- fluid.grad_clip_by_global_norm(params_grads, clip_norm=1.0) 
- fluid.grad_clip_by_norm(params_grads, clip_norm=1.0) 
- fluid.grad_clip_by_value(params_grads, max=1.0, min=0.5) 

新的梯度裁剪调用方法为：
```
params_grads = optimizer.backward(loss)                #step 1
params_grads = fluid.grad_clip_by_norm(params_grads, clip_norm=1.0)      #step 2
optimizer.apply_optimize(params_grads)               #step 3
```
API之间存在顺序调用关系，则不会出现上述错误。

对于旧的接口：`set_gradient_clip`，fluid.ParamAttr()中的`grad_clip`属性，采取不兼容的升级，将进行废弃，并且会打出warning提示用户。

`Caution! paddle.fluid.clip.set_gradient_clip is deprecated since 2.0...`
