### PR TITLE
Support  LoDTensorArray in stack/concat api for transformation of list dygraph_to_static

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -52,6 +52,16 @@ def test_list_in_for_loop(x, iter_num):
     return a
 
 
+def test_list_in_for_loop_with_concat(x, iter_num):
+    # Note: for_loop can't be transformed before PR22867 merged.
+    x = fluid.dygraph.to_variable(x)
+    a = []
+    for i in range(iter_num):
+        a.append(x)
+    out = fluid.layers.concat(a, axis=0)
+    return out
+
+
 def test_list_in_while_loop(x, iter_num):
     x = fluid.dygraph.to_variable(x)
     iter_num = fluid.layers.fill_constant(
@@ -67,12 +77,28 @@ def test_list_in_while_loop(x, iter_num):
     return a
 
 
+def test_list_in_while_loop_with_stack(x, iter_num):
+    x = fluid.dygraph.to_variable(x)
+    iter_num = fluid.layers.fill_constant(
+        shape=[1], value=iter_num, dtype="int32")
+    a = []
+    i = 0
+    while i < iter_num.numpy()[0]:
+        a.append(x)
+        i += 1
+    out = fluid.layers.stack(a, axis=1)
+    return out
+
+
 class TestListWithoutControlFlow(unittest.TestCase):
     def setUp(self):
         self.input = np.random.random((3)).astype('int32')
-        self.dygraph_func = test_list_without_control_flow
         self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
+        self.init_dygraph_func()
+
+    def init_dygraph_func(self):
+        self.dygraph_func = test_list_without_control_flow
 
     def run_dygraph_mode(self):
         with fluid.dygraph.guard():
@@ -100,11 +126,8 @@ class TestListWithoutControlFlow(unittest.TestCase):
 
 
 class TestListInIf(TestListWithoutControlFlow):
-    def setUp(self):
-        self.input = np.random.random((3)).astype('int32')
+    def init_dygraph_func(self):
         self.dygraph_func = test_list_in_if
-        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
 
     def run_static_mode(self):
         main_program = fluid.Program()
@@ -120,13 +143,16 @@ class TestListInIf(TestListWithoutControlFlow):
         return numpy_res[0]
 
 
-class TestListInWhileLoop(unittest.TestCase):
+class TestListInWhileLoop(TestListWithoutControlFlow):
     def setUp(self):
         self.iter_num = 3
         self.input = np.random.random((3)).astype('int32')
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        self.init_dygraph_func()
+
+    def init_dygraph_func(self):
         self.dygraph_func = test_list_in_while_loop
-        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
 
     def run_dygraph_mode(self):
         with fluid.dygraph.guard():
@@ -146,56 +172,40 @@ class TestListInWhileLoop(unittest.TestCase):
                         tensor_array,
                         i=fluid.layers.fill_constant(
                             shape=[1], value=i, dtype='int64')))
+
         exe = fluid.Executor(self.place)
         numpy_res = exe.run(main_program, fetch_list=static_outs)
         return numpy_res
 
-    def test_transformed_static_result(self):
-        static_res = self.run_static_mode()
-        dygraph_res = self.run_dygraph_mode()
-        self.assertTrue(
-            np.array_equal(dygraph_res, static_res),
-            msg='dygraph res is {}\nstatic_res is {}'.format(dygraph_res,
-                                                             static_res))
+
+class TestListInWhileLoopWithStack(TestListInWhileLoop):
+    def init_dygraph_func(self):
+        self.dygraph_func = test_list_in_while_loop_with_stack
+
+    def run_dygraph_mode(self):
+        with fluid.dygraph.guard():
+            var_res = self.dygraph_func(self.input, self.iter_num)
+            numpy_res = var_res.numpy()
+            return numpy_res
+
+    def run_static_mode(self):
+        main_program = fluid.Program()
+        with fluid.program_guard(main_program):
+            out_var = dygraph_to_static_graph(self.dygraph_func)(self.input,
+                                                                 self.iter_num)
+        exe = fluid.Executor(self.place)
+        numpy_res = exe.run(main_program, fetch_list=out_var)
+        return numpy_res[0]
 
 
-class TestListInForLoop(unittest.TestCase):
-    def setUp(self):
-        self.iter_num = 3
-        self.input = np.random.random((3)).astype('int32')
+class TestListInForLoop(TestListInWhileLoop):
+    def init_dygraph_func(self):
         self.dygraph_func = test_list_in_for_loop
-        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
 
-    def run_dygraph_mode(self):
-        with fluid.dygraph.guard():
-            var_res = self.dygraph_func(self.input, self.iter_num)
-            numpy_res = [ele.numpy() for ele in var_res]
-            return numpy_res
 
-    def run_static_mode(self):
-        main_program = fluid.Program()
-        with fluid.program_guard(main_program):
-            tensor_array = dygraph_to_static_graph(self.dygraph_func)(
-                self.input, self.iter_num)
-            static_outs = []
-            for i in range(self.iter_num):
-                static_outs.append(
-                    fluid.layers.array_read(
-                        tensor_array,
-                        i=fluid.layers.fill_constant(
-                            shape=[1], value=i, dtype='int64')))
-        exe = fluid.Executor(self.place)
-        numpy_res = exe.run(main_program, fetch_list=static_outs)
-        return numpy_res
-
-    def test_transformed_static_result(self):
-        static_res = self.run_static_mode()
-        dygraph_res = self.run_dygraph_mode()
-        self.assertTrue(
-            np.array_equal(dygraph_res, static_res),
-            msg='dygraph res is {}\nstatic_res is {}'.format(dygraph_res,
-                                                             static_res))
+class TestListInForLoopWithConcat(TestListInWhileLoopWithStack):
+    def init_dygraph_func(self):
+        self.dygraph_func = test_list_in_for_loop_with_concat
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_stack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_stack_op.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from op_test import OpTest
 import numpy as np
 import unittest
+import paddle.fluid as fluid
+from op_test import OpTest
 
 
 class TestStackOpBase(OpTest):
@@ -86,6 +87,42 @@ class TestStackOp5(TestStackOpBase):
 class TestStackOp6(TestStackOpBase):
     def initParameters(self):
         self.axis = 3
+
+
+class TestStackAPIWithLoDTensorArray(unittest.TestCase):
+    """
+    Test stack api when the input(x) is a LoDTensorArray.
+    """
+
+    def setUp(self):
+        self.axis = 1
+        self.iter_num = 3
+        self.input_shape = [2, 3]
+        self.x = np.random.random(self.input_shape).astype("float32")
+        self.place = fluid.CUDAPlace(0) \
+            if fluid.is_compiled_with_cuda() else fluid.CPUPlace()
+        self.set_program()
+
+    def set_program(self):
+        self.program = fluid.Program()
+        with fluid.program_guard(self.program):
+            input = fluid.layers.assign(self.x)
+            tensor_array = fluid.layers.create_array(dtype='float32')
+            zero = fluid.layers.fill_constant(shape=[1], value=0, dtype="int64")
+
+            for i in range(self.iter_num):
+                fluid.layers.array_write(input, zero + i, tensor_array)
+
+            self.out_var = fluid.layers.stack(tensor_array, axis=self.axis)
+
+    def test_case(self):
+        self.assertTrue(self.out_var.shape[self.axis] == -1)
+        exe = fluid.Executor(self.place)
+        res = exe.run(self.program, fetch_list=self.out_var)
+        self.assertTrue(
+            np.array_equal(
+                res[0], np.stack(
+                    [self.x] * self.iter_num, axis=self.axis)))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In dygraph_to_static_graph, python `list` will be transformed into `LoDTensorArray`. In order to use `LoDTensorArray` like a python `list`,` LoDTensorArray` should be supported in api `stack` and `concat`.
（PR #22962 tries to modify c++ code of stack op to support LoDTensorArray, which is more complex than this. So this PR22987 is used finally）
#### Example: in control flow while

**Before this PR, this fuction `test_list_in_while_loop` will fail to run.**
```Python
@dygraph_to_static_graph
 def test_list_in_while_loop(x, iter_num):
    x = fluid.dygraph.to_variable(x)
    iter_num = fluid.layers.fill_constant(shape=[1], value=iter_num, dtype=
        'int32')
    a = []
    i = 0
    while i < iter_num.numpy()[0]:
        a.append(x)
        i += 1
    out = fluid.layers.concat(a, axis=0)
    return out
```
- transform `test_list_in_while_loop` into static graph
```Python
def test_list_in_while_loop(x, iter_num):
    x = fluid.layers.assign(x)
    iter_num = fluid.layers.fill_constant(shape=[1], value=iter_num, dtype=
        'int32')
    a = fluid.layers.create_array(dtype='float32')
    i = 0
    a = fluid.dygraph.dygraph_to_static.variable_trans_func.to_static_variable(
        a)
    x = fluid.dygraph.dygraph_to_static.variable_trans_func.to_static_variable(
        x)
    iter_num = (fluid.dygraph.dygraph_to_static.variable_trans_func.
        to_static_variable(iter_num))
    i = fluid.dygraph.dygraph_to_static.variable_trans_func.to_static_variable(
        i)

    def while_condition_0(a, x, iter_num, i):
        return i < iter_num[0]

    def while_body_0(a, x, iter_num, i):
        fluid.layers.array_write(x=x, i=fluid.layers.array_length(a), array=a)
        i += 1
        return a, x, iter_num, i
    a, x, iter_num, i = fluid.layers.while_loop(while_condition_0,
        while_body_0, [a, x, iter_num, i])
    out = fluid.layers.concat(a, axis=0)
    return out
```