### PR TITLE
remove OpProtoAndCheckerMaker for grad op, test=develop

### DIFF
--- a/paddle/fluid/operators/rnn_memory_helper_op.cc
+++ b/paddle/fluid/operators/rnn_memory_helper_op.cc
@@ -123,22 +123,6 @@ class RNNMemoryHelperGradOp : public framework::OperatorBase {
   }
 };
 
-class RNNMemoryHelperGradOpInfoMaker
-    : public framework::OpProtoAndCheckerMaker {
- public:
-  void Make() override {
-    AddInput(framework::GradVarName("Out"), "");
-    AddInput("X", "");
-    AddInput("Out", "");
-    AddOutput(framework::GradVarName("X"), "");
-    AddAttr<int>("dtype",
-                 "(int, default 5 (FP32)) "
-                 "Output data type")
-        .SetDefault(framework::proto::VarType::FP32);
-    AddComment("");
-  }
-};
-
 class RNNMemoryHelperGradOpShapeInference : public framework::InferShapeBase {
  public:
   void operator()(framework::InferShapeContext *ctx) const override {
@@ -164,5 +148,4 @@ REGISTER_OPERATOR(
     paddle::framework::DefaultGradOpMaker<paddle::imperative::OpBase, true>);
 REGISTER_OPERATOR(rnn_memory_helper_grad,
                   paddle::operators::RNNMemoryHelperGradOp,
-                  paddle::operators::RNNMemoryHelperGradOpInfoMaker,
                   paddle::operators::RNNMemoryHelperGradOpShapeInference);

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1747,7 +1747,7 @@ class Operator(object):
                                 outputs={"Out": [var1]})
     """
     OP_WITHOUT_KERNEL_SET = {
-        'feed', 'fetch', 'recurrent', 'go', 'rnn_memory_helper_grad',
+        'feed', 'fetch', 'recurrent', 'go', 'rnn_memory_helper',
         'conditional_block', 'while', 'send', 'recv', 'listen_and_serv',
         'fl_listen_and_serv', 'ncclInit', 'select', 'checkpoint_notify',
         'gen_nccl_id', 'c_gen_nccl_id', 'c_comm_init', 'c_sync_calc_stream',


### PR DESCRIPTION
Att, `OpProtoAndCheckerMaker` is not used for grad op, `GradOpMaker` is used instead.
This PR removes `OpProtoAndCheckerMaker` for `rnn_memory_helper_grad`.