### PR TITLE
fix unittets. test=develop

### DIFF
--- a/paddle/fluid/inference/lite/tensor_utils.cc
+++ b/paddle/fluid/inference/lite/tensor_utils.cc
@@ -166,10 +166,10 @@ void TensorCopyAsync(paddle::lite::Tensor* dst, const framework::LoDTensor& src,
 template <>
 void TensorCopyAsync(framework::LoDTensor* dst, const paddle::lite::Tensor& src,
                      const platform::DeviceContext& ctx) {
+  dst->Resize(paddle::framework::make_ddim(src.dims().Vectorize()));
   InitDstTensor(dst, src);
   const platform::Place& src_place = GetNativePlace(src.target());
   const platform::Place& dst_place = dst->place();
-  dst->Resize(paddle::framework::make_ddim(src.dims().Vectorize()));
   const size_t bytes =
       static_cast<size_t>(src.numel()) * framework::SizeOfType(dst->type());
   const void* src_data = src.raw_data();


### PR DESCRIPTION
lite_resnet50单侧随即挂。 当单侧失败的时候，发现从lite到fluid的拷贝过程中，fluid端的dst_tensor的place_为空，多次测试发现不使用zeroallocator后可避免随即挂，深层原因有待继续调查