### PR TITLE
support op_device attr for _create_loss_op_desc_ and gradient accumulation

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -484,8 +484,7 @@ class Optimizer(object):
                     if param_name in input_arg_names:
                         self._param_device_map[param_name] = op.attr(
                             device_attr_name)
-                    else:
-                        self._param_device_map[param_name] = None
+                        break
 
     def _get_device_for_param(self, param_name):
         device = None


### PR DESCRIPTION
- _create_loss_op_desc method do not set `op_device` for loss OpDesc. This PR fix it.
- when parameter's gradients need to be added up, the sum op will be append. `op_device` needs to be set:
  - If these parameter's gradients are on the same device, the `op_device` of `sum` will be the same as those of the parameter's gradients.
  - If these parameter's gradients are not on the same device, the `op_device` of `sum` will not be set. So the sum op will run on the same device as the executor.