### PR TITLE
[Cherry-pick 1.7] Fix problem use recompute and dgc same time

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -3899,6 +3899,9 @@ class RecomputeOptimizer(Optimizer):
                 parameter_list,
                 no_grad_set,
                 checkpoints=self._checkpoints)
+            # Note: since we can't use all_reduce_op now,
+            #  dgc_op should be the last op of one grad.
+            self._optimizer._append_dgc_ops(params_grads)
         return params_grads
 
     def apply_optimize(self, loss, startup_program, params_grads):


### PR DESCRIPTION
Cherry-pick from #23010
Fix the problem which when Recompute and DGC use at the same time will be wrong.