### PR TITLE
set op_device for loss_op_desc

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -295,6 +295,8 @@ def _create_loss_op_desc_(loss):
             core.op_proto_and_checker_maker.kOpRoleAttrName():
             int(core.op_proto_and_checker_maker.OpRole.Backward) |
             int(core.op_proto_and_checker_maker.OpRole.Loss),
+            core.op_proto_and_checker_maker.kOpDeviceAttrName():
+            loss.op.attr(core.op_proto_and_checker_maker.kOpDeviceAttrName())
         })
     return op_desc
 

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -484,8 +484,7 @@ class Optimizer(object):
                     if param_name in input_arg_names:
                         self._param_device_map[param_name] = op.attr(
                             device_attr_name)
-                    else:
-                        self._param_device_map[param_name] = None
+                        break
 
     def _get_device_for_param(self, param_name):
         device = None


### PR DESCRIPTION
框架在添加反向Op时，会自动地append一个fill_constant op。以下面的代码为例，fill_constant会被添加在mean op之后，它的输出是loss的grad，因此需要设置op_device属性，保证fill_constant与loss对应的Op在同一个设备上。
```python
import paddle.fluid as fluid
import numpy
from paddle.fluid.transpiler.details.program_utils import program_to_code

with fluid.device_guard("cpu"):
    data1 = fluid.layers.data(name="data_1", shape=[2], dtype="float32")
    label = fluid.layers.data(name="label", shape=[1], dtype="int64")
    fc1 = fluid.layers.fc(input=data1, size=10)
with fluid.device_guard("gpu"):
    out = fluid.layers.softmax_with_cross_entropy(logits=fc1, label=label)
    loss = fluid.layers.mean(out)

opt = fluid.optimizer.SGDOptimizer(0.1)
opt.minimize(loss)

with open("main.program", "w") as fout:
    program_to_code(fluid.default_main_program(), fout)

place = fluid.CUDAPlace(0)
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
np_data1 = numpy.random.random(size=(1, 2)).astype("float32")
np_label = numpy.random.random(size=(1,1)).astype("int64")
exe.run(fluid.default_main_program(), feed={"data_1": np_data1, "label": np_label})
```
修改前的log，fill_constant缺少op_device属性
```
    {Loss=[u'softmax_with_cross_entropy_0.tmp_1'], Softmax=[u'softmax_with_cross_entropy_0.tmp_0']} = softmax_with_cross_entropy(inputs={Label=[u'label'], Logits=[u'fc_0.tmp_1']}, axis = -1, ignore_index = -100, numeric_stable_mode = True, op_device = gpu, op_namescope = /, op_role = 0, op_role_var = [], soft_label = False)
    {Out=[u'mean_0.tmp_0']} = mean(inputs={X=[u'softmax_with_cross_entropy_0.tmp_1']}, op_device = gpu, op_namescope = /, op_role = 256, op_role_var = [])
    {Out=[u'mean_0.tmp_0@GRAD']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_role = 257, shape = [1L], value = 1.0)
    {X@GRAD=[u'softmax_with_cross_entropy_0.tmp_1@GRAD']} = mean_grad(inputs={Out@GRAD=[u'mean_0.tmp_0@GRAD'], X=[u'softmax_with_cross_entropy_0.tmp_1']}, op_device = gpu, op_role = 1)
```
修改后的log，fill_constant的op_device属性已被添加和设置
```
    {Loss=[u'softmax_with_cross_entropy_0.tmp_1'], Softmax=[u'softmax_with_cross_entropy_0.tmp_0']} = softmax_with_cross_entropy(inputs={Label=[u'label'], Logits=[u'fc_0.tmp_1']}, axis = -1, ignore_index = -100, numeric_stable_mode = True, op_device = gpu, op_namescope = /, op_role = 0, op_role_var = [], soft_label = False)
    {Out=[u'mean_0.tmp_0']} = mean(inputs={X=[u'softmax_with_cross_entropy_0.tmp_1']}, op_device = gpu, op_namescope = /, op_role = 256, op_role_var = [])
    {Out=[u'mean_0.tmp_0@GRAD']} = fill_constant(inputs={}, dtype = 5, force_cpu = False, op_device = gpu, op_role = 257, shape = [1L], value = 1.0)
    {X@GRAD=[u'softmax_with_cross_entropy_0.tmp_1@GRAD']} = mean_grad(inputs={Out@GRAD=[u'mean_0.tmp_0@GRAD'], X=[u'softmax_with_cross_entropy_0.tmp_1']}, op_device = gpu, op_role = 1)
```
