### PR TITLE
[Don't MERGE] compare attribute force_cpu True to false

### DIFF
--- a/paddle/fluid/operators/controlflow/compare_op.cc
+++ b/paddle/fluid/operators/controlflow/compare_op.cc
@@ -60,7 +60,7 @@ class CompareOpProtoMaker : public framework::OpProtoAndCheckerMaker {
                   "Force fill output variable to cpu "
                   "memory. Otherwise, fill output variable to the running "
                   "device [default true].")
-        .SetDefault(true);
+        .SetDefault(false);
     AddOutput("Out", string::Sprintf("n-dim bool tensor. Each element is %s",
                                      comment.equation));
     AddComment(string::Sprintf(R"DOC(


### PR DESCRIPTION
force_cpu 默认值等于true，会导致在任务中存在大量的cpu与gpu之间的copy，验证影响任务的训练速度