### PR TITLE
added mkldnn swish activation

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
@@ -61,6 +61,7 @@ void ConvActivationFusePass::ApplyImpl(ir::Graph* graph) const {
       desc->SetAttr("fuse_alpha",
                     boost::get<float>(activation->Op()->GetAttr("threshold")));
     } else if (activation_type() == "swish") {
+      // paddle uses beta but mkldnn uses alpha for swish
       desc->SetAttr("fuse_alpha",
                     activation->Op()->GetAttrIfExists<float>("beta"));
     } else {

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
@@ -60,6 +60,9 @@ void ConvActivationFusePass::ApplyImpl(ir::Graph* graph) const {
     if (activation_type() == "relu6") {
       desc->SetAttr("fuse_alpha",
                     boost::get<float>(activation->Op()->GetAttr("threshold")));
+    } else if (activation_type() == "swish") {
+      desc->SetAttr("fuse_alpha",
+                    activation->Op()->GetAttrIfExists<float>("beta"));
     } else {
       desc->SetAttr("fuse_alpha",
                     activation->Op()->GetAttrIfExists<float>("alpha"));
@@ -95,3 +98,6 @@ REGISTER_PASS(conv_leaky_relu_mkldnn_fuse_pass,
 
 REGISTER_PASS(conv_relu6_mkldnn_fuse_pass,
               paddle::framework::ir::Conv2DReLU6FusePass);
+
+REGISTER_PASS(conv_swish_mkldnn_fuse_pass,
+              paddle::framework::ir::Conv2DSwishFusePass);

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.h
@@ -50,6 +50,13 @@ class Conv2DReLU6FusePass : public ConvActivationFusePass {
  public:
   std::string activation_type() const { return "relu6"; }
 };
+/*
+ * Fuse Conv and Swish class
+ */
+class Conv2DSwishFusePass : public ConvActivationFusePass {
+ public:
+  std::string activation_type() const { return "swish"; }
+};
 }  // namespace ir
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass_tester.cc
@@ -41,7 +41,7 @@ void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
     } else if (type == "relu6") {
       op->SetAttr("threshold", 6.0f);
     } else if (type == "swish") {
-      op->SetAttr("beta", 1);
+      op->SetAttr("beta", 1.0f);
     }
   }
   op->SetOutput("Out", outputs);

--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass_tester.cc
@@ -40,6 +40,8 @@ void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
       op->SetAttr("alpha", 0.02f);
     } else if (type == "relu6") {
       op->SetAttr("threshold", 6.0f);
+    } else if (type == "swish") {
+      op->SetAttr("beta", 1);
     }
   }
   op->SetOutput("Out", outputs);
@@ -133,6 +135,7 @@ TEST(ConvActivationFusePass, conv_leaky_relu_fuse_pass) {
   MainTest("leaky_relu");
 }
 TEST(ConvActivationFusePass, conv_relu6_fuse_pass) { MainTest("relu6"); }
+TEST(ConvActivationFusePass, conv_swish_fuse_pass) { MainTest("swish"); }
 
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -196,6 +196,7 @@ void CpuPassStrategy::EnableMKLDNN() {
              "conv_relu_mkldnn_fuse_pass",        //
              "conv_leaky_relu_mkldnn_fuse_pass",  //
              "conv_relu6_mkldnn_fuse_pass",       //
+             "conv_swish_mkldnn_fuse_pass",       //
              // Disabled due to topology-dependent speed-up
              // "fc_mkldnn_pass"
          })) {

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -596,6 +596,13 @@ class SwishOpMaker : public framework::OpProtoAndCheckerMaker {
     AddInput("X", "Input of Swish operator");
     AddOutput("Out", "Output of Swish operator");
     AddAttr<float>("beta", "Constant beta of swish operator").SetDefault(1.0f);
+    AddAttr<bool>("use_mkldnn",
+                  "(bool, default false) Only used in mkldnn kernel")
+        .SetDefault(false);
+    AddAttr<bool>("is_test",
+                  "(bool, default false) Set to true for inference only, false "
+                  "for training. Some layers may run faster when this is true.")
+        .SetDefault(false);
     AddComment(R"DOC(
 Swish Activation Operator.
 

--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -77,7 +77,7 @@ void eltwise_forward(const framework::ExecutionContext &ctx,
   T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
 
   if (algorithm == mkldnn::algorithm::eltwise_swish) {
-      std::swap(alpha, beta);
+    std::swap(alpha, beta);
   }
 
   PADDLE_ENFORCE(
@@ -120,7 +120,7 @@ void eltwise_grad(const framework::ExecutionContext &ctx,
   T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
 
   if (algorithm == mkldnn::algorithm::eltwise_swish) {
-      std::swap(alpha, beta);
+    std::swap(alpha, beta);
   }
 
   auto diff_dst_tz = framework::vectorize<int64_t>(diff_y->dims());

--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -76,6 +76,7 @@ void eltwise_forward(const framework::ExecutionContext &ctx,
   T alpha = ctx.HasAttr("alpha") ? ctx.Attr<T>("alpha") : 0;
   T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
 
+  // paddle uses beta but mkldnn uses alpha for swish
   if (algorithm == mkldnn::algorithm::eltwise_swish) {
     std::swap(alpha, beta);
   }
@@ -119,6 +120,7 @@ void eltwise_grad(const framework::ExecutionContext &ctx,
   T alpha = ctx.HasAttr("alpha") ? ctx.Attr<T>("alpha") : 0;
   T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
 
+  // paddle uses beta but mkldnn uses alpha for swish
   if (algorithm == mkldnn::algorithm::eltwise_swish) {
     std::swap(alpha, beta);
   }

--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -73,8 +73,12 @@ void eltwise_forward(const framework::ExecutionContext &ctx,
   const auto *x = ctx.Input<Tensor>("X");
   auto *y = ctx.Output<Tensor>("Out");
 
-  const T alpha = ctx.HasAttr("alpha") ? ctx.Attr<T>("alpha") : 0;
-  const T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
+  T alpha = ctx.HasAttr("alpha") ? ctx.Attr<T>("alpha") : 0;
+  T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
+
+  if (algorithm == mkldnn::algorithm::eltwise_swish) {
+      std::swap(alpha, beta);
+  }
 
   PADDLE_ENFORCE(
       x->dims().size() == 2 || x->dims().size() == 3 || x->dims().size() == 4,
@@ -112,8 +116,12 @@ void eltwise_grad(const framework::ExecutionContext &ctx,
   const auto *diff_y = ctx.Input<Tensor>(framework::GradVarName("Out"));
   auto *diff_x = ctx.Output<Tensor>(framework::GradVarName("X"));
 
-  const T alpha = ctx.HasAttr("alpha") ? ctx.Attr<T>("alpha") : 0;
-  const T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
+  T alpha = ctx.HasAttr("alpha") ? ctx.Attr<T>("alpha") : 0;
+  T beta = ctx.HasAttr("beta") ? ctx.Attr<T>("beta") : 0;
+
+  if (algorithm == mkldnn::algorithm::eltwise_swish) {
+      std::swap(alpha, beta);
+  }
 
   auto diff_dst_tz = framework::vectorize<int64_t>(diff_y->dims());
 
@@ -163,6 +171,10 @@ using ReluMKLDNNFunctor =
     MKLDNNActivationFunc<T, mkldnn::algorithm::eltwise_relu>;
 
 template <typename T>
+using SwishMKLDNNFunctor =
+    MKLDNNActivationFunc<T, mkldnn::algorithm::eltwise_swish>;
+
+template <typename T>
 using TanhMKLDNNFunctor =
     MKLDNNActivationFunc<T, mkldnn::algorithm::eltwise_tanh>;
 
@@ -177,6 +189,10 @@ using AbsMKLDNNFunctor =
 template <typename T>
 using ReluMKLDNNGradFunctor =
     MKLDNNActivationGradFunc<T, mkldnn::algorithm::eltwise_relu>;
+
+template <typename T>
+using SwishMKLDNNGradFunctor =
+    MKLDNNActivationGradFunc<T, mkldnn::algorithm::eltwise_swish>;
 
 template <typename T>
 using TanhMKLDNNGradFunctor =
@@ -204,6 +220,7 @@ namespace ops = paddle::operators;
 #define FOR_EACH_MKLDNN_KERNEL_FUNCTOR(__macro)                  \
   __macro(relu, ReluMKLDNNFunctor, ReluMKLDNNGradFunctor);       \
   __macro(leaky_relu, ReluMKLDNNFunctor, ReluMKLDNNGradFunctor); \
+  __macro(swish, SwishMKLDNNFunctor, SwishMKLDNNGradFunctor);    \
   __macro(tanh, TanhMKLDNNFunctor, TanhMKLDNNGradFunctor);       \
   __macro(sqrt, SqrtMKLDNNFunctor, SqrtMKLDNNGradFunctor);       \
   __macro(abs, AbsMKLDNNFunctor, AbsMKLDNNGradFunctor);

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -979,11 +979,16 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
       post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_relu,
                                      fuse_alpha, fuse_beta);
     }
-
-    if (fuse_activation == "relu6") {
+    else if (fuse_activation == "relu6") {
       constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale,
                                      mkldnn::algorithm::eltwise_bounded_relu,
+                                     fuse_alpha, fuse_beta);
+    }
+    else if (fuse_activation == "swish") {
+      constexpr float scale = 1.0f;
+      post_operations.append_eltwise(scale,
+                                     mkldnn::algorithm::eltwise_swish,
                                      fuse_alpha, fuse_beta);
     }
     conv_attr.set_post_ops(post_operations);

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -978,14 +978,12 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
       constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_relu,
                                      fuse_alpha, fuse_beta);
-    }
-    else if (fuse_activation == "relu6") {
+    } else if (fuse_activation == "relu6") {
       constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale,
                                      mkldnn::algorithm::eltwise_bounded_relu,
                                      fuse_alpha, fuse_beta);
-    }
-    else if (fuse_activation == "swish") {
+    } else if (fuse_activation == "swish") {
       constexpr float scale = 1.0f;
       post_operations.append_eltwise(scale,
                                      mkldnn::algorithm::eltwise_swish,

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -985,8 +985,7 @@ class ConvMKLDNNTemplateHandler : public MKLDNNHandler {
                                      fuse_alpha, fuse_beta);
     } else if (fuse_activation == "swish") {
       constexpr float scale = 1.0f;
-      post_operations.append_eltwise(scale,
-                                     mkldnn::algorithm::eltwise_swish,
+      post_operations.append_eltwise(scale, mkldnn::algorithm::eltwise_swish,
                                      fuse_alpha, fuse_beta);
     }
     conv_attr.set_post_ops(post_operations);

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -126,14 +126,13 @@ class TestMKLDNNSwishDim2(TestSwish):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output()
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=0.007, check_dygraph=False)
+        self.check_grad(['X'], 'Out')
 
 
 class TestMKLDNNReluDim4(TestRelu):
@@ -267,14 +266,13 @@ class TestMKLDNNSwishDim4(TestSwish):
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_output(check_dygraph=False)
+        self.check_output()
 
     def test_check_grad(self):
         if self.dtype == np.float16:
             return
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
-        self.check_grad(
-            ['X'], 'Out', max_relative_error=0.007, check_dygraph=False)
+        self.check_grad(['X'], 'Out')
 
 
 # Check if primitives already exist in backward

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_activation_mkldnn_op.py
@@ -16,9 +16,10 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
+from scipy.special import expit
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.op_test import OpTest
-from paddle.fluid.tests.unittests.test_activation_op import TestRelu, TestTanh, TestSqrt, TestAbs, TestLeakyRelu
+from paddle.fluid.tests.unittests.test_activation_op import TestRelu, TestTanh, TestSqrt, TestAbs, TestLeakyRelu, TestSwish
 from mkldnn_op_test import check_if_mkldnn_primitives_exist_in_bwd
 
 
@@ -98,6 +99,30 @@ class TestMKLDNNAbsDim2(TestAbs):
     def setUp(self):
         super(TestMKLDNNAbsDim2, self).setUp()
         self.attrs = {"use_mkldnn": True}
+
+    def test_check_output(self):
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
+        self.check_output(check_dygraph=False)
+
+    def test_check_grad(self):
+        if self.dtype == np.float16:
+            return
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
+        self.check_grad(
+            ['X'], 'Out', max_relative_error=0.007, check_dygraph=False)
+
+
+class TestMKLDNNSwishDim2(TestSwish):
+    def setUp(self):
+        super(TestMKLDNNSwishDim2, self).setUp()
+
+        x = np.random.uniform(0.1, 1, [11, 17]).astype(self.dtype)
+        beta = 2.3
+        out = x * expit(beta * x)
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.outputs = {'Out': out}
+        self.attrs = {"use_mkldnn": True, "beta": beta}
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode
@@ -215,6 +240,30 @@ class TestMKLDNNAbsDim4(TestAbs):
         self.inputs = {'X': x}
         self.outputs = {'Out': np.abs(self.inputs['X'])}
         self.attrs = {"use_mkldnn": True}
+
+    def test_check_output(self):
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
+        self.check_output(check_dygraph=False)
+
+    def test_check_grad(self):
+        if self.dtype == np.float16:
+            return
+        # TODO(wangzhongpu): support mkldnn op in dygraph mode
+        self.check_grad(
+            ['X'], 'Out', max_relative_error=0.007, check_dygraph=False)
+
+
+class TestMKLDNNSwishDim4(TestSwish):
+    def setUp(self):
+        super(TestMKLDNNSwishDim4, self).setUp()
+
+        x = np.random.uniform(0.1, 1, [2, 4, 3, 5]).astype("float32")
+        beta = 2.3
+        out = x * expit(beta * x)
+
+        self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(x)}
+        self.outputs = {'Out': out}
+        self.attrs = {"use_mkldnn": True, "beta": beta}
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode


### PR DESCRIPTION
This PR adds 
* MKL-DNN support of Swish activation
* fuse of swish to conv2d.

This improves 1 core ShuffleNet performance by roughly 76% on Intel(R) Xeon(R) Gold 6248 CPU @ 2.50GHz

![image](https://user-images.githubusercontent.com/17185347/76777234-2f108580-67a8-11ea-9ddd-dc4627d0846d.png)


Test command:
```
./paddle/fluid/inference/tests/api/test_analyzer_int8_image_classification --batch_size=50 --infer_model /mnt/drive/PaddlePaddle/weights/generated_ShuffleNetV2_swish_layerwise --infer_data=/mnt/drive/data/ILSVRC2012/val.bin --iterations=200 --enable_int8=0
``` 
compared PR against this develop commit 99db0cf7623efd61de78e196897d61f7774f4f4b

I generated the model by taking weights from https://github.com/PaddlePaddle/models/blob/develop/PaddleCV/image_classification/README_en.md#shufflenet-series the last one and adding save_inference_model(...) in eval.py from PaddlePaddle/models repo.