### PR TITLE
Add default pass attributes

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.cc
@@ -51,6 +51,9 @@ void CPUQuantizePlacementPass::ApplyImpl(ir::Graph* graph) const {
 REGISTER_PASS(cpu_quantize_placement_pass,
               paddle::framework::ir::CPUQuantizePlacementPass)
     // a vector of operator type names to be quantized ("conv2d" etc.)
-    .RequirePassAttr("quantize_enabled_op_types")
+    // the second param is the default value for this vector
+    .DefaultPassAttr("quantize_enabled_op_types",
+                     new std::unordered_set<std::string>())
     // a vector of operator ids that are to be excluded from quantization
-    .RequirePassAttr("quantize_excluded_op_ids");
+    // the second param is the default value for this vector
+    .DefaultPassAttr("quantize_excluded_op_ids", new std::unordered_set<int>());

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
@@ -113,15 +113,11 @@ void MainTest(std::initializer_list<std::string> quantize_enabled_op_types,
 
 void DefaultAttrTest(unsigned expected_use_quantizer_true_count) {
   auto prog = BuildProgramDesc();
-
   std::unique_ptr<ir::Graph> graph(new ir::Graph(prog));
-
   auto pass = PassRegistry::Instance().Get("cpu_quantize_placement_pass");
-
   graph.reset(pass->Apply(graph.release()));
 
   unsigned use_quantizer_true_count = 0;
-
   for (auto* node : graph->Nodes()) {
     if (node->IsOp()) {
       auto* op = node->Op();
@@ -131,7 +127,6 @@ void DefaultAttrTest(unsigned expected_use_quantizer_true_count) {
       }
     }
   }
-
   EXPECT_EQ(use_quantizer_true_count, expected_use_quantizer_true_count);
 }
 

--- a/paddle/fluid/framework/ir/pass_test.cc
+++ b/paddle/fluid/framework/ir/pass_test.cc
@@ -120,6 +120,17 @@ TEST(PassTest, TestPassAttrCheck) {
     exception = std::string(e.what());
   }
   ASSERT_TRUE(exception.find("shouldn't have cycle") != exception.npos);
+
+  pass = PassRegistry::Instance().Get("test_pass");
+  pass->Set<int>("test_pass_attr", new int);
+  try {
+    pass->Set<int>("test_pass_attr", new int);
+  } catch (paddle::platform::EnforceNotMet& e) {
+    exception = std::string(e.what());
+  }
+  ASSERT_TRUE(
+      exception.find("Attribute test_pass_attr already set in the pass") !=
+      exception.npos);
 }
 
 class TestPassWithDefault : public Pass {
@@ -145,6 +156,14 @@ TEST(PassTest, TestPassDefaultAttrCheck) {
   pass = PassRegistry::Instance().Get("test_pass_default_attr");
   pass->Set<int>("default_attr", new int{3});
   ASSERT_EQ(pass->Get<int>("default_attr"), 3);
+}
+
+TEST(PassTest, TestPassRegistrarDeconstructor) {
+  auto pass_registrary =
+      new PassRegistrar<paddle::framework::ir::TestPassWithDefault>(
+          "test_deconstructor");
+  pass_registrary->DefaultPassAttr("deconstructor_attr", new int{1});
+  pass_registrary->~PassRegistrar();
 }
 
 }  // namespace ir


### PR DESCRIPTION
This PR adds an option that allows adding a default value for pass attributes. Solves a python problem where an empty set is always a set of strings.

The default value is set when we register pass. Then PassRegistrary takes the ownership of the default value that will be used in the pass. Thanks to that, we don't have to set this attribute at all when we want to use the default setting. If we set a new value for this attribute it will override the default one. 

An example where we add the default value is `cpu_quantize_palcement_pass`:
```
REGISTER_PASS(cpu_quantize_placement_pass,
              paddle::framework::ir::CPUQuantizePlacementPass)
     // a vector of operator ids that are to be excluded from quantization
    // the second param is the default value for this vector
    .DefaultPassAttr("quantize_excluded_op_ids",
                      new std::unordered_set<int>());
```
