### PR TITLE
unify operator behavior with element op, test=develop

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -14,6 +14,8 @@
 
 from __future__ import print_function
 
+import logging
+
 from .. import core
 from ..framework import Variable, unique_name
 from .layer_function_generator import OpProtoHolder
@@ -28,6 +30,29 @@ _supported_int_dtype_ = [
 ]
 
 compare_ops = ['__eq__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__']
+
+EXPRESSION_MAP = {
+    "__add__": "A + B",
+    "__radd__": "A += B",
+    "__sub__": "A - B",
+    "__rsub__": "A -= B",
+    "__mul__": "A * B",
+    "__rmul__": "A *= B",
+    "__div__": "A / B",
+    "__truediv__": "A / B",
+    "__rdiv__": "A /= B",
+    "__rtruediv__": "A /= B",
+    "__pow__": "A ** B",
+    "__rpow__": "A **= B",
+    "__floordiv__": "A //B",
+    "__mod__": "A % B",
+    "__eq__": "A == B",
+    "__ne__": "A != B",
+    "__lt__": "A < B",
+    "__le__": "A <= B",
+    "__gt__": "A > B",
+    "__ge__": "A >= B"
+}
 
 
 def monkey_patch_variable():
@@ -234,7 +259,12 @@ def monkey_patch_variable():
 
             axis = -1
             if other_var.shape[0] == -1:
-                axis = 0
+                logging.warning(
+                    "The behavior of expression %s has been unified with %s(X, Y, axis=-1) from Paddle 2.0. "
+                    "If your code works well in the older versions but wrong in this version, try to use "
+                    "%s(X, Y, axis=0) instead of %s. This transitional warning will be dropped in the future."
+                    % (EXPRESSION_MAP[method_name], op_type, op_type,
+                       EXPRESSION_MAP[method_name]))
             current_block(self).append_op(
                 type=op_type,
                 inputs={'X': [self],

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import logging
+import inspect
 
 from .. import core
 from ..framework import Variable, unique_name
@@ -259,12 +260,15 @@ def monkey_patch_variable():
 
             axis = -1
             if other_var.shape[0] == -1:
+                stack = inspect.stack()[1]
+                file_name = stack[1]
+                line_num = stack[2]
                 logging.warning(
-                    "The behavior of expression %s has been unified with %s(X, Y, axis=-1) from Paddle 2.0. "
-                    "If your code works well in the older versions but wrong in this version, try to use "
+                    "%s:%s\nThe behavior of expression %s has been unified with %s(X, Y, axis=-1) from Paddle 2.0. "
+                    "If your code works well in the older versions but crashes in this version, try to use "
                     "%s(X, Y, axis=0) instead of %s. This transitional warning will be dropped in the future."
-                    % (EXPRESSION_MAP[method_name], op_type, op_type,
-                       EXPRESSION_MAP[method_name]))
+                    % (file_name, line_num, EXPRESSION_MAP[method_name],
+                       op_type, op_type, EXPRESSION_MAP[method_name]))
             current_block(self).append_op(
                 type=op_type,
                 inputs={'X': [self],


### PR DESCRIPTION
In paddle 1.x, operator behavior is different with elementwise op. For example

```python
import paddle.fluid as fluid
import numpy as np
x = fluid.data(name="x", shape=[20, 10, 10], dtype='float32')
y = fluid.data(name="y", shape=[-1, 10], dtype='float32')
c = fluid.layers.elementwise_add( x, y )
d = x + y
place = fluid.CPUPlace()
exe = fluid.Executor(place)
x_np = np.random.uniform( -1, 1, [20, 10, 10]).astype("float32")
y_np = np.random.uniform( -1, 1, [1, 10]).astype("float32")
out = exe.run(feed={ "x" : x_np , "y" : y_np }, fetch_list=[ c, d] )
print( np.array_equal( out[0], out[1])) ## result is False
```

In this PR, they are unified. Some warning logs will be print to  prompt Paddle 1.x users：

![image](https://user-images.githubusercontent.com/11913168/76832389-34330a80-6864-11ea-98c8-03645a22aa80.png)
