### PR TITLE
add op_device attr for backward op_desc

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -273,10 +273,13 @@ def _create_op_desc_(op_type, inputs, outputs, attrs):
                     args)))
 
     op_role_attr_name = core.op_proto_and_checker_maker.kOpRoleAttrName()
+    op_device_attr_name = core.op_proto_and_checker_maker.kOpDeviceAttrName()
 
     if op_role_attr_name not in attrs:
         attrs[
             op_role_attr_name] = core.op_proto_and_checker_maker.OpRole.Backward
+    if op_device_attr_name not in attrs:
+        attrs[op_device_attr_name] = ""
     for name, val in six.iteritems(attrs):
         if isinstance(val, framework.Block):
             op_desc.set_block_attr(name, val.desc)

--- a/python/paddle/fluid/tests/unittests/test_device_guard.py
+++ b/python/paddle/fluid/tests/unittests/test_device_guard.py
@@ -144,16 +144,19 @@ class TestDeviceGuard(unittest.TestCase):
         for op in all_ops:
             self.assertEqual(op.desc.attr(device_attr_name), "gpu")
 
-    def test_loss_op_desc(self):
+    # check if op_descs have op_device attr
+    def test_op_descs_device_attr(self):
         main_program = fluid.Program()
         startup_program = fluid.Program()
         with fluid.program_guard(main_program, startup_program):
             data1 = fluid.layers.data(name="data_1", shape=[2], dtype="float32")
+            data2 = fluid.layers.data(name="data_2", shape=[2], dtype="float32")
             label = fluid.layers.data(name="label", shape=[1], dtype="int64")
             fc1 = fluid.layers.fc(input=data1, size=10)
+            fc2 = fluid.layers.fc(input=fc1, size=10)
             with fluid.device_guard("gpu"):
                 out = fluid.layers.softmax_with_cross_entropy(
-                    logits=fc1, label=label)
+                    logits=fc1 + fc2, label=label)
                 loss = fluid.layers.mean(out)
                 opt = fluid.optimizer.SGDOptimizer(0.1)
                 opt.minimize(loss)
@@ -162,6 +165,8 @@ class TestDeviceGuard(unittest.TestCase):
         device_attr_name = core.op_proto_and_checker_maker.kOpDeviceAttrName()
         for op in all_ops:
             self.assertEqual(True, op.desc.has_attr(device_attr_name))
+            # fill_constant(backward op) is append to mean op, which should have
+            # the same op_device value as mean op
             if op.desc == 'fill_constant':
                 self.assertEqual(op.desc.attr(device_attr_name), "gpu")
 


### PR DESCRIPTION
反向过程可能会添加一些额外的op，例如需要进行梯度累加时，会添加sum op。使用_create_op_desc_创建OpDesc时未添加op_device属性，因此在此PR中进行修复。
测试代码：
```python
with fluid.device_guard("cpu"):
    data1 = fluid.layers.data(name="data_1", shape=[2], dtype="float32")
    data2 = fluid.layers.data(name="data_2", shape=[2], dtype="float32")
    label = fluid.layers.data(name="label", shape=[1], dtype="int64")
    fc1 = fluid.layers.fc(input=data1, size=10)
    fc2 = fluid.layers.fc(input=fc1, size=10)
with fluid.device_guard("gpu"):
    out = fluid.layers.softmax_with_cross_entropy(logits=fc1+fc2, label=label)
    loss = fluid.layers.mean(out)

opt = fluid.optimizer.SGDOptimizer(0.1)
opt.minimize(loss)

with open("startup.program", "w") as fout:
    program_to_code(fluid.default_startup_program(), fout)
with open("main.program", "w") as fout:
    program_to_code(fluid.default_main_program(), fout)
```
修改前的log：sum op是反向过程被添加的，没有op_device属性
```
{X@GRAD=[u'fc_0.tmp_1@GRAD@RENAME@block0@1'], Y@GRAD=[u'fc_1.w_0@GRAD']} = mul_grad(inputs={Out@GRAD=[u'fc_1.tmp_0@GRAD'], X=[u'fc_0.tmp_1'], Y=[u'fc_1.w_0']}, force_fp32_output = False, op_device = cpu, op_namescope = /, op_role = 1, op_role_var = [u'fc_1.w_0', u'fc_1.w_0@GRAD'], scale_out = 1.0, scale_x = 1.0, scale_y = [1.0], use_mkldnn = False, x_num_col_dims = 1, y_num_col_dims = 1)
{Out=[u'fc_0.tmp_1@GRAD']} = sum(inputs={X=[u'fc_0.tmp_1@GRAD@RENAME@block0@0', u'fc_0.tmp_1@GRAD@RENAME@block0@1']}, op_role = 1, use_mkldnn = False)
```
修改后的log:
```
{X@GRAD=[u'fc_0.tmp_1@GRAD@RENAME@block0@1'], Y@GRAD=[u'fc_1.w_0@GRAD']} = mul_grad(inputs={Out@GRAD=[u'fc_1.tmp_0@GRAD'], X=[u'fc_0.tmp_1'], Y=[u'fc_1.w_0']}, force_fp32_output = False, op_device = cpu, op_namescope = /, op_role = 1, op_role_var = [u'fc_1.w_0', u'fc_1.w_0@GRAD'], scale_out = 1.0, scale_x = 1.0, scale_y = [1.0], use_mkldnn = False, x_num_col_dims = 1, y_num_col_dims = 1)
{Out=[u'fc_0.tmp_1@GRAD']} = sum(inputs={X=[u'fc_0.tmp_1@GRAD@RENAME@block0@0', u'fc_0.tmp_1@GRAD@RENAME@block0@1']}, op_device = , op_role = 1, use_mkldnn = False)
```
