### PR TITLE
[WIP] QAT Document improvement

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/QAT_mkldnn_int8_readme.md
+++ b/python/paddle/fluid/contrib/slim/tests/QAT_mkldnn_int8_readme.md
@@ -10,12 +10,40 @@ Notes:
 ## 0. Prerequisite
 You need to install at least PaddlePaddle-1.7.1 python package `pip install paddlepaddle==1.7.1`.
 
-## 1. How to generate INT8 MKL-DNN QAT model
-You can refer to the unit test in [test_quantization_mkldnn_pass.py](test_quantization_mkldnn_pass.py). Users firstly use PaddleSlim quantization strategy to get a saved fake QAT model by [QuantizationFreezePass](https://github.com/PaddlePaddle/models/tree/develop/PaddleSlim/quant_low_level_api), then use the `QatInt8MkldnnPass` (from QAT1.0 MKL-DNN) to get a graph which can be run with MKL-DNN INT8 kernel. In Paddle Release 1.6, this pass supports `conv2d` and `depthwise_conv2d` ops with channel-wise quantization for weights. Apart from it, another pass called `Qat2Int8MkldnnPass` (from QAT2.0 MKL-DNN) is available for use. In Release 1.6, this pass additionally supports `pool2d` op and allows users to transform their QAT model into a highly performance-optimized INT8 model that is ran using INT8 MKL-DNN kernels. In Release 1.7, a support for `fc`, `reshape2` and `transpose2` ops was added to the pass.
+## 1. How to generate your INT8 model
+
+PaddlePaddle provide two different kinds of quantization: [Post-training quantization](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/inference/tests/api/int8_mkldnn_quantization.md) and Quantization-aware training. In post-training quantization, we calibrate the scales of quantizable ops on warmup batches, because of this, the accuracy may be influenced by warmup batch size. In quantization-aware training, we insert fake quantization ops and train the model and calibrate the sacles during the whole process of training. In theory Quantization-aware training is more accurate. In both quantization methods, we do all potential fuses, such as conv + elementwise_add, etc. so that the performance will be improved further. In this document, we mainly focus on Quantization-aware training.
+
+### How to transform ordinary models to fake QAT models
+
+You can refer to the unit test in [test_quantization_mkldnn_pass.py](test_quantization_mkldnn_pass.py) [This test need to be improved]. Users firstly use passes in quantization_strategy.py and quantization_pass.py to insert fake ops and generate fake QAT model. 
+
+Until now, we support following quantizable ops:
+
+   * QuantizationTransformPass: `conv2d`, `depthwise_conv2d`, `mul`,
+   * AddQuantDequantPass: `pool2d`, `elementwise_add`, `concat`, `softmax`, `argmax`, `transpose`,
+        `equal`, `gather`, `greater_equal`, `greater_than`, `less_equal`,
+        `less_than`, `mean`, `not_equal`, `reshape`, `reshape2`,
+        `bilinear_interp`, `nearest_interp`, `trilinear_interp`, `slice`,
+        `squeeze`, `elementwise_sub`, `mul`, `matmul`
+
+The fake quantization ops inserted in quantization-aware training could have input `X` and `Inscale`, output `Out` and `OutScale`, attribute `bit_length`(means how many bits one wants to use for quantized ops. Until now, MKLDNN Quantization-aware training only support 8 bits). The formula to calculate the output is as follows:
+```bash
+$$scale = max(max(abs(x)), history_abs_max)$$
+$$range = 2^{bit_length - 1} - 1$$
+$$Out = round(X/scale * range)$$
+```
+
+### How to quantize fake QAT models to INT8 models
+
+* Simply speaking, user can use the `save_qat_model.py` script to transform the fake QAT model to INT8 model. The `--quantized_ops` is by default set to all MKL-DNN quantizable ops. 
+```bash
+python ../python/paddle/fluid/contrib/slim/tests/save_qat_model.py --qat_model_path=/PATH/TO/DOWNLOAD/MODEL/${QAT2_MODEL_NAME} --int8_model_save_path=/PATH/TO/${QAT2_MODEL_NAME}_qat_int8
+```
+* If user want to choose specific ops to quantize and leave others as fp32 ops, use the `Qat2Int8MkldnnPass` to convert. Until release/1.7, the pass supports following quantizable ops: `conv2d`, `depthwise_conv2d`, `pool2d`, `fc`, `reshape2`, `transpose2`, with all possible fusions. 
 
 ```python
     import paddle.fluid as fluid
-    from paddle.fluid.contrib.slim.quantization import QatInt8MkldnnPass
     from paddle.fluid.contrib.slim.quantization import Qat2Int8MkldnnPass
     from paddle.fluid.framework import IrGraph
     from paddle.fluid import core	
@@ -23,36 +51,18 @@ You can refer to the unit test in [test_quantization_mkldnn_pass.py](test_quanti
     # Create the IrGraph by Program
     graph = IrGraph(core.Graph(fluid.Program().desc), for_test=False)
     place = fluid.CPUPlace()
-    # Convert the IrGraph to MKL-DNN supported INT8 IrGraph by using
-    # QAT1.0 MKL-DNN
-    # QatInt8MkldnnPass
-    mkldnn_pass = QatInt8MkldnnPass(fluid.global_scope(), place)
-    # Apply QatInt8MkldnnPass to IrGraph
-    mkldnn_pass.apply(graph)
     # QAT2.0 MKL-DNN
     # Qat2Int8MkldnnPass, it requires a list of operators to be quantized
-    mkldnn_pass = Qat2Int8MkldnnPass({'conv2d', 'pool2d'}, fluid.global_scope(), place, fluid.core, False)
+    mkldnn_pass = Qat2Int8MkldnnPass({'conv2d', 'pool2d',...}, fluid.global_scope(), place, fluid.core, False)
     # Apply Qat2Int8MkldnnPass to IrGraph
     mkldnn_pass.apply(graph)
-
 ```
 
 ## 2. Accuracy and Performance benchmark
 
->**I. QAT1.0 MKL-DNN Accuracy on Intel(R) Xeon(R) Gold 6271**
+### Image classification QAT models benchmark resutls
 
-|     Model    | Fake QAT Top1 Accuracy | INT8 QAT Top1 Accuracy | Top1 Diff | Fake QAT Top5 Accuracy | INT8 QAT Top5 Accuracy | Top5 Diff |
-|:------------:|:----------------------:|:----------------------:|:---------:|:----------------------:|:----------------------:|:---------:|
-|   GoogleNet  |         70.40%         |         70.39%         |   -0.01%  |         89.46%         |         89.46%         |   0.00%   |
-| MobileNet-V1 |         70.84%         |         70.85%         |   +0.01%  |         89.59%         |         89.58%         |   -0.01%  |
-| MobileNet-V2 |         72.07%         |         72.06%         |   -0.01%  |         90.71%         |         90.69%         |   -0.02%  |
-|  ResNet-101  |         77.49%         |         77.52%         |   +0.03%  |         93.68%         |         93.67%         |   -0.01%  |
-|   ResNet-50  |         76.61%         |         76.62%         |   +0.01%  |         93.08%         |         93.10%         |   +0.02%  |
-|     VGG16    |         72.71%         |         72.69%         |   -0.02%  |         91.11%         |         91.09%         |   -0.02%  |
-|     VGG19    |         73.37%         |         73.37%         |   0.00%   |         91.40%         |         91.41%         |   +0.01%  |
-
-
->**II. QAT2.0 MKL-DNN Accuracy on Intel(R) Xeon(R) Gold 6271**
+>**I. QAT2.0 MKL-DNN Accuracy on Intel(R) Xeon(R) Gold 6271**
 
 |     Model    | Fake QAT Top1 Accuracy | INT8 QAT Top1 Accuracy | Top1 Diff | Fake QAT Top5 Accuracy | INT8 QAT Top5 Accuracy | Top5 Diff |
 |:------------:|:----------------------:|:----------------------:|:---------:|:----------------------:|:----------------------:|:---------:|
@@ -64,7 +74,7 @@ You can refer to the unit test in [test_quantization_mkldnn_pass.py](test_quanti
 |     VGG19    |         72.30%         |         72.09%         |   -0.21%  |         90.19%         |         90.13%         |   -0.06%  |
 
 
->**III. QAT2.0 MKL-DNN C-API Performance on Intel(R) Xeon(R) Gold 6271**
+>**II. QAT2.0 MKL-DNN C-API Performance on Intel(R) Xeon(R) Gold 6271**
 
 |     Model    |        FP32 Optimized Throughput     |       INT8 QAT Throughput     | Ratio(INT8/FP32) |
 |:------------:|:------------------------------------:|:-----------------------------:|:----------------:|
@@ -79,21 +89,24 @@ Notes:
 
 * FP32 Optimized Throughput (images/s) is from [int8_mkldnn_quantization.md](https://github.com/PaddlePaddle/Paddle/blob/develop/paddle/fluid/inference/tests/api/int8_mkldnn_quantization.md).
 
->**IV. Ernie QAT2.0 MKL-DNN Accuracy on Intel(R) Xeon(R) Gold 6271**
+### Natural language processing QAT models benchmark resutls
+
+>**I. Ernie QAT2.0 MKL-DNN Accuracy on Intel(R) Xeon(R) Gold 6271**
 
 |     Model    |  FP32 Accuracy | QAT INT8 Accuracy | Accuracy Diff |
 |:------------:|:----------------------:|:----------------------:|:---------:|
 |   Ernie      |      80.20%            |        79.96%         |  -0.24%   |               
 
 
->**V. Ernie QAT2.0 MKL-DNN Performance on Intel(R) Xeon(R) Gold 6271**
+>**II. Ernie QAT2.0 MKL-DNN Performance on Intel(R) Xeon(R) Gold 6271**
 
 |     Threads  | FP32 Latency (ms) | QAT INT8 Latency (ms)    | Ratio (FP32/INT8) |
 |:------------:|:----------------------:|:-------------------:|:---------:|
 | 1 thread     |        252.131         |         93.8023    |     2.687x   |
 | 20 threads   |        29.1853         |         17.3765    |     1.680x   |
 
-## 3. How to reproduce the results
+
+## 3. How to reproduce the benchmark results
 To reproduce the above-mentioned Image Classification models accuracy and performance, follow steps as below (taking ResNet50 as an example).
 To reproduce NLP models results (Ernie), please follow [How to reproduce Ernie QAT results on MKL-DNN](https://github.com/PaddlePaddle/benchmark/tree/master/Inference/c%2B%2B/ernie/mkldnn/README.md).
 
@@ -114,40 +127,27 @@ You can run the following commands to download ResNet50 model. The exemplary cod
 ```bash
 mkdir -p /PATH/TO/DOWNLOAD/MODEL/
 cd /PATH/TO/DOWNLOAD/MODEL/
-# uncomment for QAT1.0 MKL-DNN
-# export MODEL_NAME=ResNet50
-# export MODEL_FILE_NAME=QAT_models/${MODEL_NAME}_qat_model.tar.gz
 # uncomment for QAT2.0 MKL-DNN
 # export MODEL_NAME=resnet50
 # export MODEL_FILE_NAME=QAT2_models/${MODEL_NAME}_quant.tar.gz
 wget http://paddle-inference-dist.bj.bcebos.com/int8/${MODEL_FILE_NAME}
-mkdir ${MODEL_NAME} && tar -xvf ResNet50_qat_model.tar.gz -C ${MODEL_NAME}
 ```
 
 Extract the downloaded model to the folder. To verify all the 7 models, you need to set `MODEL_NAME` to one of the following values in command line:
 ```text
-QAT1.0 models
-MODEL_NAME=ResNet50, ResNet101, GoogleNet, MobileNetV1, MobileNetV2, VGG16, VGG19
 QAT2.0 models
 MODEL_NAME=resnet50, resnet101, mobilenetv1, mobilenetv2, vgg16, vgg19
 ```
 ### Commands to reproduce benchmark
 
 You can use the `qat_int8_image_classification_comparison.py` script to reproduce the accuracy result on ResNet50. The difference between commands usedin the QAT1.0 MKL-DNN and QAT2.0 MKL-DNN is that for QAT2.0 MKL-DNN two additional options are required: the `--qat2` option to enable QAT2.0 MKL-DNN, and the `--quantized_ops` option with a comma-separated list of operators to be quantized. To perform the QAT2.0 MKL-DNN performance test, the environment variable `OMP_NUM_THREADS=1` and `--batch_size=1` option should be set.
->*QAT1.0*
 
-- Accuracy benchmark command on QAT1.0 models
-
-```bash
-cd /PATH/TO/PADDLE
-OMP_NUM_THREADS=28 FLAGS_use_mkldnn=true python python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py --qat_model=/PATH/TO/DOWNLOAD/MODEL/${MODEL_NAME}/model --infer_data=$HOME/.cache/paddle/dataset/int8/download/int8_full_val.bin --batch_size=50 --batch_num=1000 --acc_diff_threshold=0.001
-```
 >*QAT2.0*
 
 - Accuracy benchamrk command on QAT2.0 models
 ```bash
 cd /PATH/TO/PADDLE
-OMP_NUM_THREADS=28 FLAGS_use_mkldnn=true python python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py ----qat_model=/PATH/TO/DOWNLOAD/MODEL/${MODEL_NAME}_quant --infer_data=$HOME/.cache/paddle/dataset/int8/download/int8_full_val.bin --batch_size=50 --batch_num=1000 --acc_diff_threshold=0.01 --qat2 --quantized_ops="conv2d,pool2d"
+OMP_NUM_THREADS=28 FLAGS_use_mkldnn=true python python/paddle/fluid/contrib/slim/tests/qat_int8_image_classification_comparison.py ----qat_model=/PATH/TO/DOWNLOAD/MODEL/${MODEL_NAME}_quant --infer_data=$HOME/.cache/paddle/dataset/int8/download/int8_full_val.bin --batch_size=50 --batch_num=1000 --acc_diff_threshold=0.01 --qat2
 ```
 
 * Performance benchmark command on QAT2.0 models
@@ -158,7 +158,7 @@ In order to run performance benchmark, follow the steps below.
 
    ```bash
    cd /PATH/TO/PADDLE/build
-   python ../python/paddle/fluid/contrib/slim/tests/save_qat_model.py --qat_model_path=/PATH/TO/DOWNLOAD/MODEL/${QAT2_MODEL_NAME} --int8_model_save_path=/PATH/TO/${QAT2_MODEL_NAME}_qat_int8 --quantized_ops="conv2d,pool2d"
+   python ../python/paddle/fluid/contrib/slim/tests/save_qat_model.py --qat_model_path=/PATH/TO/DOWNLOAD/MODEL/${QAT2_MODEL_NAME} --int8_model_save_path=/PATH/TO/${QAT2_MODEL_NAME}_qat_int8
    ```
 
 2. Run the QAT2.0 C-API test for performance benchmark.


### PR DESCRIPTION
WIP
Could Baidu provide script to transform normal model to fake QAT model(QAT2.0). I will add link to the document. @juncaipeng 
Also it seems this doc is the only doc in PaddlePaddle about QAT, do you think it is proper to write more details on how to generate correct fake QAT models. Like in Tensorflow QAT doc, I will not paste link, but you can found it by searching.