### PR TITLE
fix bug in select_input: set var type of output to be the same as input

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -83,10 +83,14 @@ def select_input(inputs, mask):
     if isinstance(inputs, list) or isinstance(inputs, tuple):
         input_dtype = inputs[0].dtype
         input_shape = inputs[0].shape
+        input_type = inputs[0].type
     else:
         input_dtype = inputs.dtype
         input_shape = inputs.shape
-    out = helper.create_variable(dtype=input_dtype, shape=input_shape)
+        input_type = inputs.type
+
+    out = helper.create_variable(
+        dtype=input_dtype, shape=input_shape, type=input_type)
     helper.append_op(
         type='select_input',
         inputs={'X': inputs,


### PR DESCRIPTION
Before this PR, the output var type of `select_input` must be `core.VarDesc.VarType.LOD_TENSOR` which is default value.  But the output var type should be the same as input. 
The bug is fixed in this PR.