### PR TITLE
Implement StaticModelRunner to support dygraph fine-tune static graph pre-training model

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1605,6 +1605,8 @@ All parameter, weight, gradient are variables in Paddle.
                    t.set(np.ndarray([5, 30]), fluid.CPUPlace())
                    arr.append(t)
            )DOC")
+      .def("_resize",
+           [](LoDTensorArray &self, size_t size) { self.resize(size); })
       .def("_move_to_list",
            [](LoDTensorArray &self) -> py::list {
              py::list res(self.size());

--- a/python/paddle/fluid/dygraph/__init__.py
+++ b/python/paddle/fluid/dygraph/__init__.py
@@ -44,6 +44,9 @@ from .backward_strategy import *
 from . import jit
 from .jit import *
 
+from . import static_runner
+from .static_runner import *
+
 __all__ = []
 __all__ += layers.__all__
 __all__ += base.__all__
@@ -54,3 +57,4 @@ __all__ += checkpoint.__all__
 __all__ += learning_rate_scheduler.__all__
 __all__ += backward_strategy.__all__
 __all__ += jit.__all__
+__all__ += static_runner.__all__

--- a/python/paddle/fluid/dygraph/checkpoint.py
+++ b/python/paddle/fluid/dygraph/checkpoint.py
@@ -83,6 +83,12 @@ def save_dygraph(state_dict, model_path):
         name_table[k] = v.name
     model_dict["StructuredToParameterName@@"] = name_table
 
+    # print save vars
+    # dygraph state_dict use ordered dict
+    print("dygraoh save vars name (unordered):")
+    for k, v in name_table.items():
+        print("- %s" % v)
+
     file_name = model_path + suffix
     dir_name = os.path.dirname(file_name)
     if dir_name and not os.path.exists(dir_name):

--- a/python/paddle/fluid/dygraph/static_runner.py
+++ b/python/paddle/fluid/dygraph/static_runner.py
@@ -1,0 +1,526 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import collections
+import logging
+import numpy as np
+import os
+import six
+from . import base
+from . import layers
+from .. import core
+from .. import Executor
+from .. import framework
+from .. import io
+from ..proto import framework_pb2
+from ... import compat as cpt
+
+__all__ = ["StaticModelRunner"]
+
+no_kernel_op_set = {"read_from_array", "write_to_array"}
+
+control_flow_op_set = {"conditional_block", "while"}
+
+# Set Log level
+logging.getLogger().setLevel(logging.ERROR)
+
+
+class StaticModelRunner(layers.Layer):
+    def __init__(self, model_dir, model_filename=None, params_filename=None):
+        super(StaticModelRunner, self).__init__()
+        # Step 1. load program desc from disk
+        self._program_desc = self._load_static_model(model_dir, model_filename,
+                                                     params_filename)
+        # Step 2. load all parameters
+        self._load_persisitable_dict(self._program_desc, model_dir,
+                                     params_filename)
+        # Step 3. load network and config
+        self._output_names = set()
+        self._root_block_op_info = self._parse_root_block_ops()
+        # NOTE: the inputs and outputs of op with sub-block also in root block
+        self._sub_blocks_op_info = self._parse_sub_blocks_ops()
+        # debug info
+        self._print_execute_info()
+
+        # Other object variable
+        self._cur_inputs = {}
+
+    def forward(self, inputs):
+        # Step 1. check inputs
+        if not isinstance(inputs, dict):
+            raise TypeError(
+                "The type of inputs in StaticModelRunner.forward must be dict, but received %s."
+                % type(inputs))
+        for key, value in inputs.items():
+            if not isinstance(key, six.string_types):
+                raise TypeError(
+                    "The type of inputs.key in StaticModelRunner.forward must be str, but received %s."
+                    % type(key))
+            # key should be valid name
+            if key not in self._all_var_names():
+                raise ValueError(
+                    "The variable name %s is not in the loaded program." % key)
+            if not isinstance(value, (np.ndarray, core.VarBase)):
+                raise TypeError(
+                    "The type of inputs.value in StaticModelRunner.forward must be numpy array or Variable(VarBase), but received %s."
+                    % type(value))
+            # NOTE: In order to unify the API, firstly convert the input to VarBase
+            if isinstance(value, np.ndarray):
+                var = core.VarBase(
+                    value=value,
+                    name=key,
+                    persistable=False,
+                    place=framework._current_expected_place(),
+                    zero_copy=True)
+                inputs[key] = var
+
+        # Step 2. run ops
+        self._cur_inputs.update(inputs)
+        self._cur_inputs.update(self._parameters)
+        # TODO：Some variables may not only be used as input one time. 
+        # Here records the number of times all variables in the entire network
+        # will be used as input. If the number of times is zero, the variable
+        # can be cleaned
+        # TODO: Each block maintains its own variable life cycle
+        # root_block_var_life_count = collections.defaultdict(int)
+        for op_type, inputs_dict, outputs_dict, attrs in self._root_block_op_info:
+            # self._print_execute_op_info(op_type, inputs_dict, outputs_dict, attrs)
+            if self._is_control_flow_op(op_type):
+                logging.info("----------------\n- encounter control flow op: %s"
+                             % op_type)
+                if op_type == "while":
+                    self._run_while_block(inputs_dict, outputs_dict, attrs)
+                elif op_type == "conditional_block":
+                    self._run_cond_block()
+            else:
+                op_outputs = self._run_op(0, op_type, inputs_dict, outputs_dict,
+                                          attrs)
+
+            # add outputs into current inputs
+            for var in op_outputs.values():
+                self._cur_inputs[var.name] = var
+
+        # Step 3. contruct outputs
+        # NOTE: Only need to fetch targets as outputs
+        outputs = []
+        for var_name in self._output_names:
+            assert var_name in self._cur_inputs
+            outputs.append(self._cur_inputs[var_name])
+        if len(outputs) == 1:
+            outputs = outputs[0]
+
+        # Step 4. clear cur input dict
+        self._cur_inputs.clear()
+
+        return outputs
+
+    def _run_while_block(self, sub_inputs_dict, sub_outputs_dict, sub_attrs):
+        # get target block
+        sub_block_idx = int(sub_attrs['sub_block'])
+        cond_var_name = sub_inputs_dict['Condition'][0]
+        assert cond_var_name in self._cur_inputs
+        cond_var = self._cur_inputs[cond_var_name]
+        while cond_var.numpy()[0] == True:
+            for op_type, inputs_dict, outputs_dict, attrs in self._sub_blocks_op_info[
+                    sub_block_idx - 1]:
+                self._print_execute_op_info(op_type, inputs_dict, outputs_dict,
+                                            attrs)
+                if self._is_control_flow_op(op_type):
+                    logging.info(
+                        "----------------\n- encounter control flow op: %s" %
+                        op_type)
+                    if op_type == "while":
+                        self._run_while_block(inputs_dict, outputs_dict, attrs)
+                    elif op_type == "conditional_block":
+                        self._run_cond_block()
+                else:
+                    op_outputs = self._run_op(sub_block_idx, op_type,
+                                              inputs_dict, outputs_dict, attrs)
+
+                # add outputs into current inputs
+                for var in op_outputs.values():
+                    self._cur_inputs[var.name] = var
+
+            cond_var = self._cur_inputs[cond_var_name]
+            logging.info("while cond value: %r" % cond_var.numpy()[0])
+
+    def _run_cond_block(self):
+        pass
+
+    def _run_op(self, block_idx, op_type, inputs_dict, outputs_dict, attrs):
+        # Step 1. build op's inputs
+        skip_cur_op = False
+        # del_var_list = []
+        op_inputs = {}
+        for var_key, var_names in inputs_dict.items():
+            if len(var_names) == 0:
+                continue
+            # TODO: some variable have multiple arguments
+            if len(var_names) > 1:
+                logging.warning("Op %s's input %s has multiple args:" %
+                                (op_type, var_key))
+                for var_name in var_names:
+                    logging.warning("- %s" % var_name)
+            # NOTE: all args are valid input
+            vars = []
+            for var_name in var_names:
+                if var_name in self._cur_inputs:
+                    var = self._cur_inputs[var_name]
+                    # TODO: check shape, there is -1 axis
+                    # self._check_var_shape(self._var_desc(var_name), var)
+                    vars.append(var)
+                    # TODO: remove used input var from current input
+                    # if var_life_count[var_name] > 0:
+                    #     var_life_count[var_name] -= 1
+                    # if var_life_count[var_name] == 0:
+                    #     del_var_list.append(self._cur_inputs.pop(var_name))
+                else:
+                    # cannot find op's input, so skip this op
+                    logging.info("- cannot find %s's input %s, skip it" %
+                                 (op_type, var_names[0]))
+                    skip_cur_op = True
+                    break
+            if len(vars) == 1:
+                vars = vars[0]
+            op_inputs[var_key] = vars
+
+        # Step 2. build op's outputs
+        op_outputs = {}
+        # user may only input part of feed targets
+        if skip_cur_op is True:
+            return op_outputs
+
+        for var_key, var_names in outputs_dict.items():
+            # TODO: can output be null?
+            # TODO: can output have multiple name?
+            # TODO: need to deal with other block?
+            # NOTE: dtype, dims, name, type, persistable=False
+            assert len(var_names) == 1
+            name = var_names[0]
+            var_desc = self._var_desc(block_idx, name)
+            # NOTE: If the output variable already exists, use it directly
+            if name in self._cur_inputs:
+                var = self._cur_inputs[name]
+            else:
+                var = core.VarBase(var_desc.dtype(),
+                                   var_desc.shape(), name,
+                                   var_desc.type(), False)
+                var.stop_gradient = False
+            op_outputs[var_key] = var
+
+        # Step 3. run op
+        # logging.info("-------------------")
+        logging.info("- execute op %s" % op_type)
+        # for k, v in self._cur_inputs.items():
+        #     logging.info("- %s stop_gradient: %r" % (v.name, v.stop_gradient))
+        # NOTE: some op can't be executed directly
+        if self._is_no_kernel_op(op_type):
+            logging.info("----------------\n- encounter no kernel op: %s" %
+                         op_type)
+            if op_type == "write_to_array":
+                self._write_to_array(op_inputs, op_outputs, attrs)
+            elif op_type == "read_from_array":
+                self._read_from_array(op_inputs, op_outputs, attrs)
+        else:
+            framework._dygraph_tracer().trace_op(op_type, op_inputs, op_outputs,
+                                                 attrs)
+
+        # TODO: delete useless var
+        # for var in del_var_list:
+        #     del var
+
+        return op_outputs
+
+    def _write_to_array(self, inputs, outputs, attrs):
+        assert len(outputs) == 1
+        tensor_array = outputs['Out'].value().get_lod_tensor_array()
+        index = inputs['I'].numpy()[0]
+        tensor = inputs['X'].value().get_tensor()
+        if index >= len(tensor_array):
+            tensor_array._resize(index + 1)
+        tensor_array[index] = tensor
+
+    def _read_from_array(self, inputs, outputs, attrs):
+        assert len(outputs) == 1
+        tensor = outputs['Out'].value().get_tensor()
+        tensor_array = inputs['X'].value().get_lod_tensor_array()
+        index = inputs['I'].numpy()[0]
+        if index >= len(tensor_array):
+            raise ValueError(
+                "index is out or range in _read_from_array, index: %d, array len: %d"
+                % (index, len(tensor_array)))
+        tensor.set(tensor_array[index].__array__(),
+                   framework._current_expected_place())
+
+    def _parse_sub_blocks_ops(self):
+        result_list = []
+        for i in six.moves.range(1, self._program_desc.num_blocks()):
+            sub_block = self._program_desc.block(i)
+            result_list.append(self._parse_block_ops(sub_block))
+        return result_list
+
+    def _parse_root_block_ops(self):
+        root_block = self._program_desc.block(0)
+        return self._parse_block_ops(root_block)
+
+    def _parse_block_ops(self, block):
+        result_list = []
+        for i in six.moves.range(block.op_size()):
+            op = block.op(i)
+            if op.type() == 'feed' or op.type() == 'fetch':
+                continue
+            # remove useless scale-1 op
+            if op.type() == 'scale' and op.output(op.output_names()[0])[
+                    0].startswith('save_infer_model/scale_'):
+                # record fetch targets variable name
+                self._output_names.add(op.input('X')[0])
+                continue
+            inputs = {}
+            for i in six.moves.range(len(op.input_names())):
+                input_name = op.input_names()[i]
+                inputs[input_name] = op.input(input_name)
+                # TODO: Output as input count
+                # tmp_var_names = op.input(input_name)
+                # for tmp_var_name in tmp_var_names:
+                #     self._var_life_count[tmp_var_name] += 1
+            outputs = {}
+            for i in six.moves.range(len(op.output_names())):
+                output_name = op.output_names()[i]
+                outputs[output_name] = op.output(output_name)
+            attrs = {}
+            attr_names = sorted(op.attr_names())
+            for i in six.moves.range(len(attr_names)):
+                name = attr_names[i]
+                if name == "op_callstack":
+                    continue
+                attr_type = op.attr_type(name)
+                if attr_type == core.AttrType.BLOCK:
+                    attrs[name] = "{value}".format(
+                        value=op._block_attr_id(name))
+                elif attr_type == core.AttrType.BLOCKS:
+                    attrs[name] = "blocks[{value}]".format(
+                        value=op._block_attr_ids(name))
+                else:
+                    attrs[name] = op.attr(name)
+            op_info_tuple = (op.type(), inputs, outputs, attrs)
+            result_list.append(op_info_tuple)
+        return result_list
+
+    def _is_control_flow_op(self, op_type):
+        global control_flow_op_set
+        if op_type in control_flow_op_set:
+            return True
+        return False
+
+    def _is_no_kernel_op(self, op_type):
+        global no_kernel_op_set
+        if op_type in no_kernel_op_set:
+            return True
+        return False
+
+    def _check_var_shape(self, var_desc, var):
+        logging.info("-----------------\n%s:" % var_desc.name())
+        expected_shape = var_desc.shape()
+        true_shape = var.shape
+        logging.info("expected shape: {}".format(expected_shape))
+        logging.info("true shape: {}".format(true_shape))
+        for i, value in enumerate(expected_shape):
+            if value != true_shape[i]:
+                raise ValueError("The shape of input variable {} is invalid. \
+                    expected shape is {}, but receiveed shape is {}.".format(
+                    var_desc.name(), expected_shape, true_shape))
+
+    def _var_desc(self, block_idx, name):
+        cur_blcok_idx = block_idx
+        name = cpt.to_bytes(name)
+        var_desc = self._program_desc.block(cur_blcok_idx).find_var(name)
+        while var_desc is None:
+            parent_blcok_idx = self._program_desc.block(cur_blcok_idx).parent
+            logging.info("cur_blcok_idx: %d" % parent_blcok_idx)
+            if cur_blcok_idx == -1:
+                logging.info("var %s is not find." % name)
+                break
+            var_desc = self._program_desc.block(parent_blcok_idx).find_var(name)
+            cur_blcok_idx = parent_blcok_idx
+        return var_desc
+
+    def _all_var_names(self):
+        var_names = set()
+        for i in six.moves.range(self._program_desc.num_blocks()):
+            block = self._program_desc.block(i)
+            for var in block.all_vars():
+                var_names.add(var.name())
+        return var_names
+
+    def _next_execute_op_info(self):
+        def __reader__():
+            root_block = self._program_desc.block(0)
+            for i in six.moves.range(root_block.op_size()):
+                op = root_block.op(i)
+                if op.type() == 'feed' or op.type() == 'fetch':
+                    continue
+                # remove useless scale-1 op
+                if op.type() == 'scale' and op.output(op.output_names()[0])[
+                        0].startswith('save_infer_model/scale_'):
+                    # record fetch targets variable name
+                    self._output_names.add(op.input('X')[0])
+                    continue
+                inputs = {}
+                for i in six.moves.range(len(op.input_names())):
+                    input_name = op.input_names()[i]
+                    inputs[input_name] = op.input(input_name)
+                outputs = {}
+                for i in six.moves.range(len(op.output_names())):
+                    output_name = op.output_names()[i]
+                    outputs[output_name] = op.output(output_name)
+                attrs = {}
+                attr_names = sorted(op.attr_names())
+                for i in six.moves.range(len(attr_names)):
+                    name = attr_names[i]
+                    if name == "op_callstack":
+                        continue
+                    attr_type = op.attr_type(name)
+                    if attr_type == core.AttrType.BLOCK:
+                        attrs[name] = "block[{value}]".format(
+                            value=op._block_attr_id(name))
+                    elif attr_type == core.AttrType.BLOCKS:
+                        attrs[name] = "blocks[{value}]".format(
+                            value=op._block_attr_ids(name))
+                    else:
+                        attrs[name] = op.attr(name)
+                yield op.type(), inputs, outputs, attrs
+
+        return __reader__()
+
+    def _load_static_model(self,
+                           model_dir,
+                           model_filename=None,
+                           params_filename=None):
+        # Step 1. dir and filename check
+        load_dirname = os.path.normpath(model_dir)
+        if not os.path.isdir(load_dirname):
+            raise ValueError("There is no directory named '%s'", dirname)
+
+        if model_filename is not None:
+            model_filename = os.path.basename(model_filename)
+        else:
+            model_filename = "__model__"
+        model_filename = os.path.join(load_dirname, model_filename)
+
+        if params_filename is not None:
+            params_filename = os.path.basename(params_filename)
+
+        # Step 2. parse program desc
+        with open(model_filename, "rb") as f:
+            program_desc_str = f.read()
+
+        program_desc = core.ProgramDesc(program_desc_str)
+        if not core._is_program_version_supported(program_desc._version()):
+            raise ValueError("Unsupported program version: %d\n" %
+                             program_desc._version())
+
+        # Step 3. change all `is_test` attributes to False
+        self._change_is_test_status(program_desc)
+
+        return program_desc
+
+    def _is_persistable(self, var_desc):
+        if var_desc.type() == core.VarDesc.VarType.FEED_MINIBATCH or \
+                var_desc.type() == core.VarDesc.VarType.FETCH_LIST or \
+                var_desc.type() == core.VarDesc.VarType.READER or \
+                var_desc.type() == core.VarDesc.VarType.RAW:
+            return False
+        return var_desc.persistable()
+
+    def _change_is_test_status(self, program_desc):
+        # change all `is_test` attributes to True
+        for i in six.moves.range(program_desc.num_blocks()):
+            block = program_desc.block(i)
+            for j in six.moves.range(block.op_size()):
+                op = block.op(j)
+                if op.has_attr('is_test'):
+                    op._set_attr('is_test', False)
+
+    def _load_persisitable_dict(self,
+                                program_desc,
+                                model_dir,
+                                params_filename=None):
+        load_dirname = os.path.normpath(model_dir)
+        # TODO: 
+        # 1. control flow need to be deal with
+        # 2. persistable var may not be parameter
+        # 3. params_filename is not none
+        # 4. new parameter has redundant copy here
+        persis_vars = list(
+            filter(self._is_persistable, program_desc.block(0).all_vars()))
+        for each_var in persis_vars:
+            # logging.info("persis var name %s" % each_var.name())
+            attrs = {'file_path': os.path.join(load_dirname, each_var.name())}
+            out = core.ops.load({}, attrs)
+            var = out['Out'][0]
+            var.name = each_var.name()
+            # logging.info(var.name)
+            # logging.info(var)
+            param = framework.ParamBase(
+                name=var.name, shape=var.shape, dtype=var.dtype)
+            # there is redundant copy here
+            self._fill_param_with_var(param, var)
+            param = self.add_parameter(name=param.name, parameter=param)
+            param.stop_gradient = False
+            # del useless var
+            del var
+
+    def _fill_param_with_var(self, param, var):
+        param.value().get_tensor().set(var.numpy(),
+                                       framework._current_expected_place())
+
+    ##### Debug Functions #####
+
+    def _op_desc_to_string(self, desc):
+        protostr = desc.serialize_to_string()
+        proto = framework_pb2.OpDesc.FromString(six.binary_type(protostr))
+        return framework._debug_string_(proto, True)
+
+    def _print_all_op_info(self):
+        for i in six.moves.range(self._program_desc.num_blocks()):
+            block = self._program_desc.block(i)
+            for j in six.moves.range(block.op_size()):
+                op = block.op(j)
+                print(self._op_desc_to_string(op))
+
+    def _print_execute_op_info(self, op_type, inputs, outputs, attrs):
+        logging.info("-------------------------")
+        logging.info("Op Name: {}".format(op_type))
+        logging.info("Inputs: {}".format(inputs))
+        logging.info("Outputs: {}".format(outputs))
+        logging.info("Attrs: {}".format(attrs))
+        logging.info("-------------------------")
+
+    def _print_execute_info(self):
+        logging.info("---------root block op info-----------")
+        for t in self._root_block_op_info:
+            logging.info("{}".format(t))
+        logging.info("---------sub block op info-----------")
+        for i, block in enumerate(self._sub_blocks_op_info):
+            logging.info("block {}:".format(i))
+            for t in block:
+                logging.info("{}".format(t))
+        # logging.info("---------var life count-----------")
+        # for k, v in self._var_life_count.items():
+        #     logging.info("{}: {}".format(k, v))
+        logging.info("---------output names-----------")
+        logging.info(self._output_names)
+        logging.info("--------------------")

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4829,8 +4829,10 @@ class ParamBase(core.VarBase):
                                                                bool)
         tensor = self.value().get_tensor()
         if tensor._is_initialized():
-            return 'name %s, dtype: %s shape: %s %s' % (self.name, self.dtype,
-                                                        self.shape, str(tensor))
+            # return 'name %s, dtype: %s shape: %s %s' % (self.name, self.dtype,
+            #                                             self.shape, str(tensor))
+            return 'name %s, dtype: %s shape: %s' % (self.name, self.dtype,
+                                                     self.shape)
         else:
             return 'name %s, shape: %s, not inited' % (self.name, self.shape)
 
@@ -5055,6 +5057,18 @@ def _dygraph_place_guard(place):
     yield
 
     _dygraph_current_expected_place_ = tmp_place
+
+
+@signature_safe_contextmanager
+def _static_guard():
+    global _dygraph_tracer_
+    tmp_trace = _dygraph_tracer_
+    _dygraph_tracer_ = None
+    logging.info("_static_guard")
+
+    yield
+
+    _dygraph_tracer_ = tmp_trace
 
 
 def load_op_library(lib_filename):

--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -298,6 +298,14 @@ def save_vars(executor,
         save_program = Program()
         save_block = save_program.global_block()
 
+        # print all save vars name by order
+        save_var_name_list = []
+        for each_var in vars:
+            save_var_name_list.append(each_var.name)
+        # print("static save vars name (ordered):")
+        # for name in sorted(save_var_name_list):
+        #     print("- %s" % name)
+
         save_var_map = {}
         for each_var in vars:
             # NOTE: don't save the variable which type is RAW

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -193,6 +193,7 @@ list(REMOVE_ITEM TEST_OPS test_basic_lstm_api)
 list(REMOVE_ITEM TEST_OPS test_basic_lstm_unit_op)
 list(REMOVE_ITEM TEST_OPS test_imperative_debug_string)
 list(REMOVE_ITEM TEST_OPS test_fuse_bn_act_pass)
+list(REMOVE_ITEM TEST_OPS test_imperative_static_runner_mnist)
 
 if (APPLE OR WIN32)
   list(REMOVE_ITEM TEST_OPS test_dataset)
@@ -269,6 +270,8 @@ py_test_modules(test_install_check MODULES test_install_check ENVS
         FLAGS_cudnn_deterministic=1 SERIAL)
 set_tests_properties(test_install_check PROPERTIES LABELS "RUN_TYPE=DIST")
 py_test_modules(test_imperative_debug_string MODULES test_imperative_debug_string ENVS FLAGS_dygraph_debug=1)
+py_test_modules(test_imperative_static_runner_mnist MODULES test_imperative_static_runner_mnist ENVS
+    FLAGS_cudnn_deterministic=1)
 if(WITH_DISTRIBUTE)
     # FIXME(typhoonzero): add these tests back
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_transformer")

--- a/python/paddle/fluid/tests/unittests/test_imperative_static_runner_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_static_runner_mnist.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import contextlib
+import numpy as np
+import six
+
+import paddle
+import paddle.fluid as fluid
+from paddle.fluid import core
+from test_imperative_base import new_program_scope
+
+
+def softmax_regression(img, label):
+    prediction = fluid.layers.fc(input=img, size=10, act='softmax')
+    return prediction
+
+
+def convolutional_neural_network(img, label):
+    conv_pool_1 = fluid.nets.simple_img_conv_pool(
+        input=img,
+        filter_size=5,
+        num_filters=20,
+        pool_size=2,
+        pool_stride=2,
+        act="relu")
+    conv_pool_2 = fluid.nets.simple_img_conv_pool(
+        input=conv_pool_1,
+        filter_size=5,
+        num_filters=50,
+        pool_size=2,
+        pool_stride=2,
+        act="relu")
+    prediction = fluid.layers.fc(input=conv_pool_2, size=10, act='softmax')
+    return prediction
+
+
+class TestImperativeStaticModelRunnerMnist(unittest.TestCase):
+    def setUp(self):
+        self.seed = 90
+        self.epoch_num = 1
+        self.batch_size = 128
+        self.batch_num = 50
+        self.save_dirname = "mnist.inference.model"
+        self.params_filename = "mnist.params"
+
+    def reader_decorator(self, reader):
+        def _reader_impl():
+            for item in reader():
+                image = np.array(item[0]).reshape(1, 28, 28)
+                label = np.array(item[1]).astype('int64').reshape(1)
+                yield image, label
+
+        return _reader_impl
+
+    def train_and_save_model(self):
+        startup_program = fluid.default_startup_program()
+        main_program = fluid.default_main_program()
+
+        img = fluid.data(name='img', shape=[None, 1, 28, 28], dtype='float32')
+        label = fluid.data(name='label', shape=[None, 1], dtype='int64')
+
+        prediction = convolutional_neural_network(img, label)
+        # prediction = softmax_regression(img, label)
+
+        loss = fluid.layers.cross_entropy(input=prediction, label=label)
+        avg_loss = fluid.layers.mean(loss)
+
+        optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+        optimizer.minimize(avg_loss)
+
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+
+        exe = fluid.Executor(place)
+
+        feeder = fluid.DataFeeder(feed_list=[img, label], place=place)
+        exe.run(startup_program)
+
+        train_reader = paddle.batch(
+            paddle.reader.shuffle(
+                paddle.dataset.mnist.train(), buf_size=100),
+            batch_size=self.batch_size)
+
+        for _ in range(0, self.epoch_num):
+            for data in train_reader():
+                exe.run(main_program,
+                        feed=feeder.feed(data),
+                        fetch_list=[avg_loss])
+
+        fluid.io.save_inference_model(
+            self.save_dirname, ["img"], [prediction],
+            exe,
+            model_filename=None,
+            params_filename=None)
+
+    def load_and_train_dygraph(self):
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.dygraph.guard(place):
+            fluid.default_startup_program().random_seed = self.seed
+            fluid.default_main_program().random_seed = self.seed
+            backward_strategy = fluid.dygraph.BackwardStrategy()
+            backward_strategy.sort_sum_gradient = True
+
+            mnist = fluid.dygraph.StaticModelRunner(model_dir=self.save_dirname)
+
+            sgd = fluid.optimizer.SGD(learning_rate=0.001,
+                                      parameter_list=mnist.parameters())
+
+            train_reader = paddle.batch(
+                self.reader_decorator(paddle.dataset.mnist.train()),
+                batch_size=self.batch_size,
+                drop_last=True)
+            train_loader = fluid.io.DataLoader.from_generator(capacity=10)
+            train_loader.set_sample_list_generator(train_reader, places=place)
+
+            mnist.train()
+            dy_param_init_value = {}
+
+            for epoch in range(self.epoch_num):
+                for batch_id, data in enumerate(train_loader()):
+                    if batch_id >= self.batch_num:
+                        break
+                    img = data[0]
+                    dy_x_data = img.numpy()
+                    label = data[1]
+                    label.stop_gradient = True
+
+                    cost = mnist(inputs={"img": img})
+
+                    loss = fluid.layers.cross_entropy(cost, label)
+                    avg_loss = fluid.layers.mean(loss)
+
+                    dy_out = avg_loss.numpy()
+
+                    if epoch == 0 and batch_id == 0:
+                        for param in mnist.parameters():
+                            dy_param_init_value[param.name] = param.numpy()
+
+                    avg_loss.backward(backward_strategy)
+                    sgd.minimize(avg_loss)
+                    mnist.clear_gradients()
+
+                    dy_param_value = {}
+                    for param in mnist.parameters():
+                        dy_param_value[param.name] = param.numpy()
+
+        return dy_x_data, dy_out, dy_param_init_value, dy_param_value
+
+    def load_and_train_static(self):
+        with new_program_scope():
+            fluid.default_startup_program().random_seed = self.seed
+            fluid.default_main_program().random_seed = self.seed
+
+            img = fluid.data(
+                name='img', shape=[None, 1, 28, 28], dtype='float32')
+            label = fluid.data(name='label', shape=[None, 1], dtype='int64')
+
+            prediction = convolutional_neural_network(img, label)
+            # prediction = softmax_regression(img, label)
+
+            loss = fluid.layers.cross_entropy(input=prediction, label=label)
+            avg_loss = fluid.layers.mean(loss)
+
+            optimizer = fluid.optimizer.SGD(learning_rate=0.001)
+            optimizer.minimize(avg_loss)
+
+            place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+            ) else fluid.CPUPlace()
+
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+
+            fluid.io.load_params(
+                exe,
+                self.save_dirname,
+                main_program=fluid.default_main_program())
+
+            static_param_init_value = {}
+            static_param_name_list = []
+            for param in fluid.default_main_program().all_parameters():
+                static_param_name_list.append(param.name)
+                static_param_init_value[param.name] = fluid.executor._fetch_var(
+                    param.name)
+
+            train_reader = paddle.batch(
+                self.reader_decorator(paddle.dataset.mnist.train()),
+                batch_size=self.batch_size,
+                drop_last=True)
+
+            for epoch in range(self.epoch_num):
+                for batch_id, data in enumerate(train_reader()):
+                    if batch_id >= self.batch_num:
+                        break
+
+                    static_x_data = np.array([x[0] for x in data])
+                    y_data = np.array([x[1] for x in data]).reshape(
+                        [self.batch_size, 1])
+
+                    fetch_list = [avg_loss.name]
+                    fetch_list.extend(static_param_name_list)
+
+                    out = exe.run(fluid.default_main_program(),
+                                  feed={"img": static_x_data,
+                                        "label": y_data},
+                                  fetch_list=fetch_list)
+
+                    static_param_value = {}
+                    static_out = out[0]
+                    for i in range(1, len(out)):
+                        static_param_value[static_param_name_list[i - 1]] = out[
+                            i]
+
+        return static_x_data, static_out, static_param_init_value, static_param_value
+
+    def test_mnist_no_params_filename(self):
+        # Phase 1. run and save static model
+        self.train_and_save_model()
+
+        # Phase 2. load model & train dygraph
+        dy_x_data, dy_out, dy_param_init_value, dy_param_value = \
+            self.load_and_train_dygraph()
+
+        static_x_data, static_out, static_param_init_value, static_param_value = \
+            self.load_and_train_static()
+
+        # Phase 3. compare
+        self.assertTrue(np.array_equal(static_x_data, dy_x_data))
+
+        for key, value in six.iteritems(static_param_init_value):
+            self.assertTrue(np.array_equal(value, dy_param_init_value[key]))
+
+        self.assertTrue(np.allclose(static_out, dy_out))
+
+        for key, value in six.iteritems(static_param_value):
+            self.assertTrue(np.allclose(value, dy_param_value[key], atol=1e-5))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_imperative_static_runner_while.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_static_runner_while.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import contextlib
+import numpy as np
+
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
+import paddle.fluid.core as core
+from paddle.fluid.executor import Executor
+from paddle.fluid.backward import append_backward
+from test_imperative_base import new_program_scope
+
+
+def simple_while_net():
+    d0 = layers.data("d0", shape=[10], append_batch_size=False, dtype='float32')
+    d1 = layers.data("d1", shape=[10], append_batch_size=False, dtype='float32')
+    d2 = layers.data("d2", shape=[10], append_batch_size=False, dtype='float32')
+    i = layers.zeros(shape=[1], dtype='int64')
+    i.stop_gradient = True
+    init = layers.zeros(shape=[10], dtype='float32')
+    mem_array = layers.array_write(x=init, i=i)
+    data_array = layers.array_write(x=d0, i=i)
+    i = layers.increment(i)
+    layers.array_write(d1, i, array=data_array)
+    i = layers.increment(i)
+    layers.array_write(d2, i, array=data_array)
+    i = layers.zeros(shape=[1], dtype='int64')
+    i.stop_gradient = True
+    array_len = layers.fill_constant(shape=[1], dtype='int64', value=1)
+    array_len.stop_gradient = True
+    cond = layers.less_than(x=i, y=array_len)
+    j = layers.fill_constant(shape=[1], dtype='int64', value=1)
+    j.stop_gradient = True
+    array_len2 = layers.fill_constant(shape=[1], dtype='int64', value=3)
+    array_len2.stop_gradient = True
+    cond2 = layers.less_than(x=j, y=array_len2)
+    while_op = layers.While(cond=cond)
+    while_op2 = layers.While(cond=cond2)
+    with while_op.block():
+        d = layers.array_read(array=data_array, i=i)
+        prev = layers.array_read(array=mem_array, i=i)
+        result = layers.sums(input=[d, prev])
+
+        i = layers.increment(x=i, in_place=True)
+        layers.array_write(result, i=i, array=mem_array)
+        layers.less_than(x=i, y=array_len, cond=cond)
+
+        with while_op2.block():
+            d2 = layers.array_read(array=data_array, i=j)
+            prev2 = layers.array_read(array=mem_array, i=j)
+            result2 = layers.sums(input=[d2, prev2])
+
+            j = layers.increment(x=j, in_place=True)
+            layers.array_write(result2, i=j, array=mem_array)
+            layers.less_than(x=j, y=array_len2, cond=cond2)
+    sum_result = layers.array_read(array=mem_array, i=j)
+    return sum_result
+
+
+class TestImperativeStaticModelRunnerWhile(unittest.TestCase):
+    def setUp(self):
+        self.seed = 90
+        self.save_dirname = "while.inference.model"
+
+    def random_feed(self):
+        data = []
+        for i in range(3):
+            np.random.seed(90)
+            data.append(np.random.random(size=[10]).astype('float32'))
+        return data
+
+    def train_and_save_model(self):
+        sum_result = simple_while_net()
+        loss = layers.mean(sum_result)
+
+        append_backward(loss)
+
+        cpu = core.CPUPlace()
+        exe = Executor(cpu)
+
+        d = self.random_feed()
+
+        outs = exe.run(feed={'d0': d[0],
+                             'd1': d[1],
+                             'd2': d[2]},
+                       fetch_list=[sum_result])
+
+        fluid.io.save_inference_model(
+            self.save_dirname, ['d0', 'd1', 'd2'], [sum_result],
+            exe,
+            main_program=fluid.default_main_program(),
+            model_filename=None,
+            params_filename=None)
+
+    def load_and_train_dygraph(self):
+        with fluid.dygraph.guard(fluid.CPUPlace()):
+            fluid.default_startup_program().random_seed = self.seed
+            fluid.default_main_program().random_seed = self.seed
+            backward_strategy = fluid.dygraph.BackwardStrategy()
+            backward_strategy.sort_sum_gradient = True
+
+            while_net = fluid.dygraph.StaticModelRunner(self.save_dirname)
+
+            d = self.random_feed()
+
+            loss = while_net(inputs={'d0': d[0], 'd1': d[1], 'd2': d[2]})
+
+            avg_loss = fluid.layers.mean(loss)
+
+            avg_loss.backward()
+
+        return d, avg_loss.numpy()
+
+    def load_and_train_static(self):
+        with new_program_scope():
+            fluid.default_startup_program().random_seed = self.seed
+            fluid.default_main_program().random_seed = self.seed
+
+            loss = simple_while_net()
+            avg_loss = layers.mean(loss)
+
+            append_backward(avg_loss)
+
+            cpu = fluid.CPUPlace()
+            exe = Executor(cpu)
+
+            d = self.random_feed()
+
+            outs = exe.run(feed={'d0': d[0],
+                                 'd1': d[1],
+                                 'd2': d[2]},
+                           fetch_list=[avg_loss])
+
+        return d, outs[0]
+
+    def test_while_no_params_filename(self):
+        # Phase 1. run and save static model
+        self.train_and_save_model()
+
+        # Phase 2. load model & train dygraph
+        dy_input, dy_out = self.load_and_train_dygraph()
+
+        static_input, static_out = self.load_and_train_static()
+
+        # Phase 3. compare
+        self.assertTrue(np.array_equal(static_input, dy_input))
+
+        np_out = np.mean(np.sum(dy_input, axis=0))
+        self.assertEqual(static_out, np_out)
+        self.assertEqual(static_out, dy_out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The Paddle dynamic graph mode has been basically complete, and it will be promoted in the future. The PaddleHub and CV group's students want to make full use of the pre-trained static graph model in dynamic graph mode. It is expected to import the static graph pre-training model and perform fine-tune in dynamic graph mode. This PR fulfills this need.

The main idea is to parse the `__model__` file stored by `save_inference_model` to extract the information required for op execution, and execute them sequencely in dynamic graph mode:
- Extract the variable name information, load the corresponding stored parameters, and combine the user input data as the initial data input for ops
- The ops' order in program desc is topological order. With the initial input, the execution can be started sequentially.
- Part of the control flow op, such as `while, conditional_block`, etc., cannot be executed directly in the dynamic graph mode, and the dynamic graph does not have the concept of a sub-block, so special processing is required.
- Some ops do not have a kernel, such as `write_to_array, read_from_array`, etc., nor can they be executed directly in dynamic graph mode, so special processing is also required.

> Note: The requirement is not to rewrite the dynamic graph network, and then load the static graph pre-trained parameters to continue training, but to directly importing the static graph pre-trained model and parameters without writing a dynamic graph model, continue training in the form of a dynamic graph. Therefore, for scenarios that originally only called `save_params` or `save_persistables` to store parameters, this PR cannot directly support it. You need to run `save_inference_model` to store the model structure before you can use it.

----

中文介绍：

Paddle动态图模式已基本成熟，接下来会进行重点推广。而PaddleHub，CV组同学提出需求，想要在主推动态图的背景下，充分利用之前预训练完成的静态图模型，期望能够在动态图模式下导入静态图预训练模型并进行fine-tune，本PR实现此需求。

主要思路是，通过解析save_inference_model存储的__model__文件，提取op执行所需的信息，在动态图模式下依次执行：
- 提取变量名信息，载入相应存储的parameters，结合用户输入数据，作为op输入的初始数据
- program desc中的op顺序为拓扑序，在有初始输入的情况下，即可顺序启动执行
- 部分控制流op，例如while, conditional_block等，不能在动态图模式下直接执行，动态图也没有子block的概念，因此需要进行特殊处理
- 部分op没有kernel，例如write_to_array, read_from_array等，也不能在动态图模式下直接执行，也需要特殊处理

> 注意：该需求并不是重新编写动态图网络，然后load静态图预训练的参数，进而继续训练。而是在不编写动态图模型的前提下，直接导入静态图预训练的模型和参数，以动态图的形式继续训练。所以对于原先只调用save_params或者save_persistables，存储了参数的场景，本PR并不能直接支持，需要运行save_inference_model存储模型结构后，才能使用。