### PR TITLE
[Dy2Stat]Support LoDTensorArray for slice op

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -168,8 +168,8 @@ class SliceOp : public framework::OperatorWithKernel {
 class SliceOpVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto x_name = ctx->Input("Input")[0];
-    auto out_name = ctx->Output("Out")[0];
+    auto x_name = "Input";
+    auto out_name = "Out";
     auto decrease_axis = ctx->GetAttr("decrease_axis");
     auto not_decrease = boost::get<std::vector<int>>(decrease_axis).size() == 0;
     if (not_decrease) {
@@ -178,8 +178,8 @@ class SliceOpVarTypeInference : public framework::VarTypeInference {
       // LoDTensor, the type of out should be the same as input.
       // For example, input is a LoDTensorArray and no axis is decreased, the
       // output should be a LoDTensorArray.
-      ctx->SetType(out_name, ctx->GetType(x_name));
-      ctx->SetDataType(out_name, ctx->GetDataType(x_name));
+      ctx->SetOutputType(out_name, ctx->GetInputType(x_name));
+      ctx->SetOutputDataType(out_name, ctx->GetInputDataType(x_name));
     }
   }
 };
@@ -311,15 +311,15 @@ class SliceOpGrad : public framework::OperatorWithKernel {
 class SliceOpGradVarTypeInference : public framework::VarTypeInference {
  public:
   void operator()(framework::InferVarTypeContext *ctx) const override {
-    auto x_name = ctx->Input("Input")[0];
-    auto out_name = ctx->Output(framework::GradVarName("Input"))[0];
-    auto d_out_name = ctx->Input(framework::GradVarName("Out"))[0];
+    auto x = "Input";
+    auto d_out = framework::GradVarName("Out");
+    auto out = framework::GradVarName("Input");
     // The types of grad_input and input should always be the same.
     // The default type of out is LoDTensor, but the type of input can be
     // LoDTensor or LoDTensorArray,
     // so set the type of both to be the same.
-    ctx->SetType(out_name, ctx->GetType(x_name));
-    ctx->SetDataType(out_name, ctx->GetDataType(d_out_name));
+    ctx->SetOutputType(out, ctx->GetInputType(x));
+    ctx->SetOutputDataType(out, ctx->GetInputDataType(d_out));
   }
 };
 

--- a/paddle/fluid/operators/slice_op.h
+++ b/paddle/fluid/operators/slice_op.h
@@ -17,6 +17,7 @@ limitations under the License. */
 #include <utility>
 #include <vector>
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/math/math_function.h"
 
 namespace paddle {
 namespace operators {
@@ -58,7 +59,12 @@ template <typename DeviceContext, typename T>
 class SliceKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    int rank = ctx.Input<framework::Tensor>("Input")->dims().size();
+    const framework::Variable* input_var = ctx.InputVar("Input");
+    bool is_tensor_array = input_var->IsType<framework::LoDTensorArray>();
+    int rank = is_tensor_array
+                   ? 1
+                   : ctx.Input<framework::Tensor>("Input")->dims().size();
+
     switch (rank) {
       case 1:
         SliceCompute<1>(ctx);
@@ -86,16 +92,63 @@ class SliceKernel : public framework::OpKernel<T> {
   void SliceCompute(const framework::ExecutionContext& context) const {
     auto& place =
         *context.template device_context<DeviceContext>().eigen_device();
-    auto in = context.Input<framework::Tensor>("Input");
-    auto out = context.Output<framework::Tensor>("Out");
-    auto out_dims = out->dims();
-    auto in_dims = in->dims();
+    const framework::Variable* input_var = context.InputVar("Input");
+    framework::Variable* out_var = context.OutputVar("Out");
+    bool input_is_tensor_array = input_var->IsType<framework::LoDTensorArray>();
+    bool out_is_tensor_array = out_var->IsType<framework::LoDTensorArray>();
 
     auto axes = context.Attr<std::vector<int>>("axes");
     auto starts = context.Attr<std::vector<int>>("starts");
+
     auto ends = context.Attr<std::vector<int>>("ends");
     auto decrease_axis = context.Attr<std::vector<int>>("decrease_axis");
     auto infer_flags = context.Attr<std::vector<int>>("infer_flags");
+
+    if (input_is_tensor_array) {
+      auto in_array = context.Input<framework::LoDTensorArray>("Input");
+      // If the input is LoDTensorArray, the rank of input is 1.
+      int in_size = in_array->size();
+      int start = starts[0] < 0 ? (starts[0] + in_size) : starts[0];
+      int end = ends[0] < 0 ? (ends[0] + in_size) : ends[0];
+      start = std::max(start, 0);
+      end = std::max(end, 0);
+      end = std::min(end, in_size);
+
+      PADDLE_ENFORCE_GT(end, start,
+                        platform::errors::InvalidArgument(
+                            "Attr(ends) should be greater than attr(starts) in "
+                            "slice op. But received ends = %d, starts = %d.",
+                            end, start));
+      int out_size = end - start;
+
+      if (out_is_tensor_array) {
+        auto out_array = context.Output<framework::LoDTensorArray>("Out");
+        out_array->resize(out_size);
+
+        for (int i = 0; i < out_size; ++i) {
+          auto* out_tensor = &out_array->at(i);
+          auto in_tensor = in_array->at(i + start);
+          out_tensor->set_lod(in_tensor.lod());
+          if (in_tensor.memory_size() > 0) {
+            TensorCopy(in_tensor, context.GetPlace(), out_tensor);
+          } else {
+            VLOG(10)
+                << "WARNING: The input tensor 'x_tensor' holds no memory, so "
+                   "nothing has been written to output array["
+                << i << "].";
+          }
+        }
+      } else {
+        auto out = context.Output<framework::Tensor>("Out");
+        auto in_tensor = in_array->at(start);
+        TensorCopy(in_tensor, context.GetPlace(), out);
+      }
+
+      return;
+    }
+
+    auto in = context.Input<framework::Tensor>("Input");
+    auto out = context.Output<framework::Tensor>("Out");
 
     auto list_new_ends_tensor =
         context.MultiInput<framework::Tensor>("EndsTensorList");
@@ -109,7 +162,8 @@ class SliceKernel : public framework::OpKernel<T> {
     if (list_new_starts_tensor.size() > 0 || list_new_ends_tensor.size() > 0) {
       need_infer = true;
     }
-
+    auto out_dims = out->dims();
+    auto in_dims = in->dims();
     if (need_infer) {
       if (context.HasInput("StartsTensor")) {
         auto* starts_tensor = context.Input<framework::Tensor>("StartsTensor");
@@ -233,7 +287,12 @@ template <typename DeviceContext, typename T>
 class SliceGradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    size_t rank = ctx.Input<framework::Tensor>("Input")->dims().size();
+    const framework::Variable* input_var = ctx.InputVar("Input");
+    bool is_tensor_array = input_var->IsType<framework::LoDTensorArray>();
+    size_t rank = is_tensor_array
+                      ? 1
+                      : ctx.Input<framework::Tensor>("Input")->dims().size();
+
     switch (rank) {
       case 1:
         SliceCompute<1>(ctx);
@@ -261,16 +320,59 @@ class SliceGradKernel : public framework::OpKernel<T> {
   void SliceCompute(const framework::ExecutionContext& context) const {
     auto& place =
         *context.template device_context<DeviceContext>().eigen_device();
-    auto* d_out =
-        context.Input<framework::Tensor>(framework::GradVarName("Out"));
-    auto* d_input =
-        context.Output<framework::Tensor>(framework::GradVarName("Input"));
-    d_input->mutable_data<T>(context.GetPlace());
-    auto out_dims = d_out->dims();
-    auto in_dims = d_input->dims();
     auto axes = context.Attr<std::vector<int>>("axes");
     auto starts = context.Attr<std::vector<int>>("starts");
     auto ends = context.Attr<std::vector<int>>("ends");
+
+    framework::Variable* d_input_var =
+        context.OutputVar(framework::GradVarName("Input"));
+    const framework::Variable* d_out_var =
+        context.InputVar(framework::GradVarName("Out"));
+    bool d_input_is_tensor_array =
+        d_input_var->IsType<framework::LoDTensorArray>();
+    bool d_out_is_tensor_array = d_out_var->IsType<framework::LoDTensorArray>();
+
+    if (d_input_is_tensor_array) {
+      auto* input_array = context.Input<framework::LoDTensorArray>("Input");
+      auto* d_input_array = context.Output<framework::LoDTensorArray>(
+          framework::GradVarName("Input"));
+
+      int d_in_size = input_array->size();
+      d_input_array->resize(d_in_size);
+      // If the input is LoDTensorArray, the rank of input is 1.
+      // So only use the 0th element of starts.
+      int start = starts[0] < 0 ? (starts[0] + d_in_size) : starts[0];
+      start = std::max(start, 0);
+      // set zero
+      platform::DeviceContextPool& pool =
+          platform::DeviceContextPool::Instance();
+      auto& dev_ctx = *pool.Get(context.GetPlace());
+      T value = 0.0;
+      math::SetConstant<DeviceContext, T> functor;
+      for (int i = 0; i < d_in_size; ++i) {
+        auto dim = input_array->at(i).dims();
+        d_input_array->at(i).Resize(dim);
+        d_input_array->at(i).mutable_data<T>(context.GetPlace());
+        functor(reinterpret_cast<const DeviceContext&>(dev_ctx),
+                &d_input_array->at(i), static_cast<T>(value));
+      }
+
+      if (d_out_is_tensor_array) {
+        auto* d_out_array = context.Input<framework::LoDTensorArray>(
+            framework::GradVarName("Out"));
+        int d_out_size = d_out_array->size();
+        for (int i = 0; i < d_out_size; ++i) {
+          TensorCopy(d_out_array->at(i), context.GetPlace(),
+                     &(d_input_array->at(start + i)));
+        }
+
+      } else {
+        auto* d_out =
+            context.Input<framework::Tensor>(framework::GradVarName("Out"));
+        TensorCopy(*d_out, context.GetPlace(), &(d_input_array->at(start)));
+      }
+      return;
+    }
 
     auto list_new_ends_tensor =
         context.MultiInput<framework::Tensor>("EndsTensorList");
@@ -290,6 +392,17 @@ class SliceGradKernel : public framework::OpKernel<T> {
       auto* ends_tensor = context.Input<framework::Tensor>("EndsTensor");
       ends = get_new_data_from_tensor(ends_tensor);
     }
+
+    auto* d_out =
+        context.Input<framework::Tensor>(framework::GradVarName("Out"));
+
+    auto* d_input =
+        context.Output<framework::Tensor>(framework::GradVarName("Input"));
+
+    d_input->mutable_data<T>(context.GetPlace());
+
+    auto out_dims = d_out->dims();
+    auto in_dims = d_input->dims();
 
     auto decrease_axis = context.Attr<std::vector<int>>("decrease_axis");
     if (decrease_axis.size() > 0) {

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -180,7 +180,7 @@ class TestSliceInForLoop(TestSliceInWhileLoop):
     def run_static_mode(self):
         main_program = fluid.Program()
         with fluid.program_guard(main_program):
-            static_out = dygraph_to_static_graph(self.dygraph_func)(
+            static_out = dygraph_to_static_func(self.dygraph_func)(
                 self.input, self.iter_num)
         exe = fluid.Executor(self.place)
         numpy_res = exe.run(main_program, fetch_list=static_out)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -42,28 +42,29 @@ def test_slice_in_if(x):
                 shape=[1, 2], value=9, dtype="int64"))
     if x.numpy()[0] > 0:
         a[0] = x
-    return a
+    out = a[0:]
+    return out
 
 
 def test_slice_in_while_loop(x, iter_num):
     x = fluid.dygraph.to_variable(x)
-    iter_num = fluid.layers.fill_constant(
+    iter_num_var = fluid.layers.fill_constant(
         shape=[1], value=iter_num, dtype="int32")
     a = []
     i = 0
     # Note: `i < iter_num` can't be supported in dygraph mode now,
     # but PR22892 is fixing it https://github.com/PaddlePaddle/Paddle/pull/22892.
     # If PR22892 merged, change `i < iter_num.numpy()[0]` to `i < iter_num`.
-    while i < iter_num.numpy()[0]:
+    while i < iter_num_var.numpy()[0]:
         a.append(x)
         i += 1
 
     i = 0
-    while i < iter_num.numpy()[0]:
+    while i < iter_num_var.numpy()[0]:
         a[i] = fluid.layers.fill_constant(shape=[2], value=2, dtype="float32")
         i += 1
-
-    return a
+    out = a[0:iter_num]
+    return out
 
 
 def test_slice_in_for_loop(x, iter_num):
@@ -79,7 +80,8 @@ def test_slice_in_for_loop(x, iter_num):
 
     for i in range(iter_num):
         a[i] = x
-    return a
+    out = a[2]
+    return out
 
 
 class TestSliceWithoutControlFlow(unittest.TestCase):
@@ -148,6 +150,8 @@ class TestSliceInWhileLoop(TestSliceWithoutControlFlow):
     def run_dygraph_mode(self):
         with fluid.dygraph.guard():
             var_res = self.dygraph_func(self.input, self.iter_num)
+            if not isinstance(var_res, list):
+                var_res = [var_res]
             numpy_res = [ele.numpy() for ele in var_res]
             return numpy_res
 
@@ -172,6 +176,15 @@ class TestSliceInWhileLoop(TestSliceWithoutControlFlow):
 class TestSliceInForLoop(TestSliceInWhileLoop):
     def init_dygraph_func(self):
         self.dygraph_func = test_slice_in_for_loop
+
+    def run_static_mode(self):
+        main_program = fluid.Program()
+        with fluid.program_guard(main_program):
+            static_out = dygraph_to_static_graph(self.dygraph_func)(
+                self.input, self.iter_num)
+        exe = fluid.Executor(self.place)
+        numpy_res = exe.run(main_program, fetch_list=static_out)
+        return numpy_res
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle.fluid.core as core
 from op_test import OpTest
 import paddle.fluid as fluid
+import paddle.fluid.layers as layers
 
 
 # Situation 1: starts(list, no tensor), ends(list, no tensor)
@@ -526,6 +527,82 @@ class TestSliceAPI(unittest.TestCase):
         assert np.array_equal(res_5, input[-3:3, 0:100, 2:-1, :])
         assert np.array_equal(res_6, input[-3:3, 0:100, :, 2:-1])
         assert np.array_equal(res_7, input[-1, 0:100, :, 2:-1])
+
+
+class TestSliceApiWithLoDTensorArray(unittest.TestCase):
+    def setUp(self):
+        self.shape = [3, 4]
+        self.data = np.random.random(size=self.shape).astype('float32')
+        self.idx = 0
+        self.start = 0
+        self.end = 2
+        self.axis = 1
+
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        self.exe = fluid.Executor(self.place)
+
+    def set_program_and_run(self, main_program, case_num):
+        with fluid.program_guard(main_program):
+            x = [
+                fluid.data(
+                    name='x0', shape=self.shape, dtype="float32"), fluid.data(
+                        name='x1', shape=self.shape, dtype="float32"),
+                fluid.data(
+                    name='x2', shape=self.shape, dtype="float32")
+            ]
+
+            for each_x in x:
+                each_x.stop_gradient = False
+
+            arr = layers.create_array(dtype="float32")
+            for i in range(3):
+                idx = layers.array_length(arr)
+                arr = layers.array_write(x=x[i], i=idx, array=arr)
+
+            if case_num == 1:
+                self.sliced_arr = output = arr[0]
+
+            elif case_num == 2:
+                self.sliced_arr = slice_arr = arr[self.start:self.end]
+                output, _ = fluid.layers.tensor_array_to_tensor(
+                    slice_arr, axis=self.axis, use_stack=True)
+
+            loss = fluid.layers.reduce_sum(output)
+            fluid.backward.append_backward(loss)
+            g_vars = list(
+                map(main_program.global_block().var,
+                    [each_x.name + "@GRAD" for each_x in x]))
+            self.out, self.g_x0, self.g_x1, self.g_x2 = \
+                self.exe.run(main_program,
+                             feed = {'x0': self.data,
+                                     'x1': self.data,
+                                     'x2': self.data},
+                             fetch_list=[output] + g_vars)
+
+    def test_case_1(self):
+        main_program = fluid.Program()
+        self.set_program_and_run(main_program, 1)
+
+        self.assertTrue(self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR)
+        self.assertTrue(np.array_equal(self.out, self.data))
+        self.assertTrue(np.array_equal(self.g_x0, np.ones_like(self.data)))
+        self.assertTrue(np.array_equal(self.g_x1, np.zeros_like(self.data)))
+        self.assertTrue(np.array_equal(self.g_x2, np.zeros_like(self.data)))
+
+    def test_case_2(self):
+        main_program = fluid.Program()
+        self.set_program_and_run(main_program, 2)
+
+        self.assertTrue(
+            self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY)
+        self.assertTrue(
+            np.array_equal(
+                self.out, np.stack(
+                    [self.data, self.data], axis=self.axis)))
+        self.assertTrue(np.array_equal(self.g_x0, np.ones_like(self.data)))
+        self.assertTrue(np.array_equal(self.g_x1, np.ones_like(self.data)))
+        self.assertTrue(np.array_equal(self.g_x2, np.zeros_like(self.data)))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_slice_op.py
@@ -531,7 +531,7 @@ class TestSliceAPI(unittest.TestCase):
 
 class TestSliceApiWithLoDTensorArray(unittest.TestCase):
     def setUp(self):
-        self.shape = [3, 4]
+        self.shape = (3, 4)
         self.data = np.random.random(size=self.shape).astype('float32')
         self.idx = 0
         self.start = 0
@@ -564,7 +564,9 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
                 self.sliced_arr = output = arr[0]
 
             elif case_num == 2:
-                self.sliced_arr = slice_arr = arr[self.start:self.end]
+                end = fluid.layers.array_length(arr) - 1
+                end = fluid.layers.cast(end, "int32")
+                self.sliced_arr = slice_arr = arr[self.start:end]
                 output, _ = fluid.layers.tensor_array_to_tensor(
                     slice_arr, axis=self.axis, use_stack=True)
 
@@ -585,6 +587,7 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
         self.set_program_and_run(main_program, 1)
 
         self.assertTrue(self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR)
+        self.assertEqual(self.sliced_arr.shape, self.shape)
         self.assertTrue(np.array_equal(self.out, self.data))
         self.assertTrue(np.array_equal(self.g_x0, np.ones_like(self.data)))
         self.assertTrue(np.array_equal(self.g_x1, np.zeros_like(self.data)))
@@ -596,6 +599,7 @@ class TestSliceApiWithLoDTensorArray(unittest.TestCase):
 
         self.assertTrue(
             self.sliced_arr.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY)
+        self.assertEqual(self.sliced_arr.shape, self.shape)
         self.assertTrue(
             np.array_equal(
                 self.out, np.stack(


### PR DESCRIPTION
1. Support the input of slice is LoDTensorArray;
2. Support read elements of list in dygraph_to_static. For example:
```Python
arr = fluid.layers.array_write(x, i)
res1 = arr[i]
res2 = arr[0:i]
```

Note: https://github.com/PaddlePaddle/Paddle/pull/24250  (Support list pop in dy2stat) depends on this PR.