### PR TITLE
Make the place parameter default

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -492,8 +492,14 @@ class Executor(object):
                                fetch_list=[loss.name])
     """
 
-    def __init__(self, place):
-        self.place = place
+    def __init__(self, place=None):
+        if place is None:
+            if core.is_compiled_with_cuda():
+                self.place = core.CUDAPlace(0)
+            else:
+                self.place = core.CPUPlace()
+        else:
+            self.place = place
         self.program_caches = dict()
         self.ctx_caches = dict()
         self.scope_caches = dict()

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -438,8 +438,8 @@ class Executor(object):
         place(fluid.CPUPlace()|fluid.CUDAPlace(n)|None): This parameter represents
             which device the executor runs on. When this parameter is None, PaddlePaddle
             will set the default device according to its installation version. If Paddle
-            is CPU version, the default device would be set to CPUPlace(). If Paddle is GPU
-            version, the default device would be set to CUDAPlace(0). Default is None.
+            is CPU version, the default device would be set to `CPUPlace()` . If Paddle is GPU
+            version, the default device would be set to `CUDAPlace(0)` . Default is None.
 
     Returns:
         Executor
@@ -491,6 +491,9 @@ class Executor(object):
           # Set place explicitly.
           # if not use_cuda:
           #     os.environ['CPU_NUM'] = str(2)
+
+          # If you don't set place and PaddlePaddle is CPU version
+          # os.environ['CPU_NUM'] = str(2)
 
           compiled_prog = compiler.CompiledProgram(
               train_program).with_data_parallel(

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -432,12 +432,12 @@ handler = FetchHandlerExample(var_dict=var_dict)
 class Executor(object):
     """
     An Executor in Python, supports single/multiple-GPU running,
-    and single/multiple-CPU running. When construction the Executor,
-    the device is required.
+    and single/multiple-CPU running.
 
     Args:
-        place(fluid.CPUPlace()|fluid.CUDAPlace(n)): This parameter represents
-            the executor run on which device.
+        place(fluid.CPUPlace()|fluid.CUDAPlace(n)|None): This parameter represents
+            the executor run on which device. When this parameter is None, Paddle
+	    would choose the device independtantly. Default is None.
 
     Returns:
         Executor
@@ -450,9 +450,13 @@ class Executor(object):
           import numpy
           import os
 
-          use_cuda = True
-          place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
-          exe = fluid.Executor(place)
+          # Set place explicitly.
+          # use_cuda = True
+          # place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
+          # exe = fluid.Executor(place)
+
+          # place=None, Paddle chooses the device.
+          exe = fluid.Executor()
 
           train_program = fluid.Program()
           startup_program = fluid.Program()
@@ -475,14 +479,16 @@ class Executor(object):
 
           # Or, compiled the program and run. See `CompiledProgram`
           # for more detail.
-          # NOTE: If you use CPU to run the program, you need
-          # to specify the CPU_NUM, otherwise, fluid will use
-          # all the number of the logic core as the CPU_NUM,
-          # in that case, the batch size of the input should be
-          # greater than CPU_NUM, if not, the process will be
+          # NOTE: If you use CPU to run the program or Paddle is
+          # CPU version, you need to specify the CPU_NUM, otherwise,
+          # fluid will use all the number of the logic core as
+          # the CPU_NUM, in that case, the batch size of the input
+          # should be greater than CPU_NUM, if not, the process will be
           # failed by an exception.
-          if not use_cuda:
-              os.environ['CPU_NUM'] = str(2)
+
+          # Set place explicitly.
+          # if not use_cuda:
+          #     os.environ['CPU_NUM'] = str(2)
 
           compiled_prog = compiler.CompiledProgram(
               train_program).with_data_parallel(

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -436,8 +436,10 @@ class Executor(object):
 
     Args:
         place(fluid.CPUPlace()|fluid.CUDAPlace(n)|None): This parameter represents
-            the executor run on which device. When this parameter is None, Paddle
-	    would choose the device independtantly. Default is None.
+            which device the executor run on. When this parameter is None, PaddlePaddle
+            will set the default device according to its installation version. If Paddle
+            is CPU version, the default device would set to CPUPlace(). If Paddle is GPU
+            version, the default device would set to CUDAPlace(0). Default is None.
 
     Returns:
         Executor
@@ -455,7 +457,7 @@ class Executor(object):
           # place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
           # exe = fluid.Executor(place)
 
-          # place=None, Paddle chooses the device.
+          # If you don't set place, PaddlePaddle set the default device.
           exe = fluid.Executor()
 
           train_program = fluid.Program()

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -436,10 +436,10 @@ class Executor(object):
 
     Args:
         place(fluid.CPUPlace()|fluid.CUDAPlace(n)|None): This parameter represents
-            which device the executor run on. When this parameter is None, PaddlePaddle
+            which device the executor runs on. When this parameter is None, PaddlePaddle
             will set the default device according to its installation version. If Paddle
-            is CPU version, the default device would set to CPUPlace(). If Paddle is GPU
-            version, the default device would set to CUDAPlace(0). Default is None.
+            is CPU version, the default device would be set to CPUPlace(). If Paddle is GPU
+            version, the default device would be set to CUDAPlace(0). Default is None.
 
     Returns:
         Executor

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -438,8 +438,8 @@ class Executor(object):
         place(fluid.CPUPlace()|fluid.CUDAPlace(n)|None): This parameter represents
             which device the executor runs on. When this parameter is None, PaddlePaddle
             will set the default device according to its installation version. If Paddle
-            is CPU version, the default device would be set to `CPUPlace()` . If Paddle is GPU
-            version, the default device would be set to `CUDAPlace(0)` . Default is None.
+            is CPU version, the default device would be set to `CPUPlace()` . If Paddle is
+            GPU version, the default device would be set to `CUDAPlace(0)` . Default is None.
 
     Returns:
         Executor

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -457,7 +457,7 @@ class Executor(object):
           # place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
           # exe = fluid.Executor(place)
 
-          # If you don't set place, PaddlePaddle set the default device.
+          # If you don't set place, PaddlePaddle sets the default device.
           exe = fluid.Executor()
 
           train_program = fluid.Program()

--- a/python/paddle/fluid/tests/unittests/test_executor_and_mul.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_and_mul.py
@@ -31,10 +31,9 @@ class TestExecutor(unittest.TestCase):
             dtype='float32',
             append_batch_size=False)
         out = mul(x=a, y=b)
-        place = core.CPUPlace()
         a_np = numpy.random.random((100, 784)).astype('float32')
         b_np = numpy.random.random((784, 100)).astype('float32')
-        exe = Executor(place)
+        exe = Executor()
         outs = exe.run(feed={'a': a_np, 'b': b_np}, fetch_list=[out])
         out = outs[0]
         self.assertEqual((100, 100), out.shape)

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -41,7 +41,9 @@ class TestApiWhileLoop(unittest.TestCase):
             ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
             out = layers.while_loop(cond, body, (i, ))
 
-        exe = fluid.Executor()
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        exe = fluid.Executor(place)
         res = exe.run(main_program, fetch_list=out)
         self.assertTrue(
             np.allclose(np.asarray(res[0]), np.full((1), 10, np.int64)))
@@ -67,7 +69,9 @@ class TestApiWhileLoop(unittest.TestCase):
             data = np.random.rand(10).astype('float32')
             data_one = np.ones(10).astype('float32')
 
-        exe = fluid.Executor()
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        exe = fluid.Executor(place)
         res = exe.run(main_program, feed={'mem': data}, fetch_list=out)
         for i in range(10):
             data = np.add(data, data_one)
@@ -109,7 +113,9 @@ class TestApiWhileLoop(unittest.TestCase):
 
             i, ten, test_dict, test_list, test_list_dict = layers.while_loop(
                 cond, body, [i, ten, test_dict, test_list, test_list_dict])
-        exe = fluid.Executor()
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        exe = fluid.Executor(place)
         res = exe.run(main_program,
                       fetch_list=[
                           test_dict["test_key"], test_list[0],
@@ -173,7 +179,9 @@ class TestApiWhileLoop_Nested(unittest.TestCase):
             data = np.random.rand(3, 3).astype('float32')
             data_sums = np.zeros([3, 3]).astype('float32')
 
-        exe = fluid.Executor()
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        exe = fluid.Executor(place)
         res = exe.run(main_program,
                       feed={'init': data,
                             'sums': data_sums},
@@ -210,7 +218,9 @@ class TestApiWhileLoop_Backward(unittest.TestCase):
             mean = layers.mean(out[1])
             append_backward(mean)
 
-        exe = fluid.Executor()
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        exe = fluid.Executor(place)
 
         feed_i = np.ones(1).astype('float32')
         feed_x = np.ones(1).astype('float32')
@@ -284,7 +294,9 @@ class TestApiWhileLoop_NestedWithBackwardAndLoDTensorArray(unittest.TestCase):
             mean = layers.mean(sum_result)
             append_backward(mean)
 
-            exe = fluid.Executor()
+            place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+            ) else fluid.CPUPlace()
+            exe = fluid.Executor(place)
 
             d = []
             for i in range(3):
@@ -336,7 +348,9 @@ class TestApiWhileLoopWithSwitchCase(unittest.TestCase):
             one = layers.fill_constant(shape=[1], dtype='int64', value=1)
             out = layers.while_loop(cond, body, [i])
 
-        exe = fluid.Executor()
+        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        exe = fluid.Executor(place)
         res = exe.run(main_program, fetch_list=out)
 
         data = np.asarray([25]).astype('int64')

--- a/python/paddle/fluid/tests/unittests/test_while_loop_op.py
+++ b/python/paddle/fluid/tests/unittests/test_while_loop_op.py
@@ -41,9 +41,7 @@ class TestApiWhileLoop(unittest.TestCase):
             ten = layers.fill_constant(shape=[1], dtype='int64', value=10)
             out = layers.while_loop(cond, body, (i, ))
 
-        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
-        exe = fluid.Executor(place)
+        exe = fluid.Executor()
         res = exe.run(main_program, fetch_list=out)
         self.assertTrue(
             np.allclose(np.asarray(res[0]), np.full((1), 10, np.int64)))
@@ -69,9 +67,7 @@ class TestApiWhileLoop(unittest.TestCase):
             data = np.random.rand(10).astype('float32')
             data_one = np.ones(10).astype('float32')
 
-        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
-        exe = fluid.Executor(place)
+        exe = fluid.Executor()
         res = exe.run(main_program, feed={'mem': data}, fetch_list=out)
         for i in range(10):
             data = np.add(data, data_one)
@@ -113,9 +109,7 @@ class TestApiWhileLoop(unittest.TestCase):
 
             i, ten, test_dict, test_list, test_list_dict = layers.while_loop(
                 cond, body, [i, ten, test_dict, test_list, test_list_dict])
-        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
-        exe = fluid.Executor(place)
+        exe = fluid.Executor()
         res = exe.run(main_program,
                       fetch_list=[
                           test_dict["test_key"], test_list[0],
@@ -179,9 +173,7 @@ class TestApiWhileLoop_Nested(unittest.TestCase):
             data = np.random.rand(3, 3).astype('float32')
             data_sums = np.zeros([3, 3]).astype('float32')
 
-        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
-        exe = fluid.Executor(place)
+        exe = fluid.Executor()
         res = exe.run(main_program,
                       feed={'init': data,
                             'sums': data_sums},
@@ -218,9 +210,7 @@ class TestApiWhileLoop_Backward(unittest.TestCase):
             mean = layers.mean(out[1])
             append_backward(mean)
 
-        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
-        exe = fluid.Executor(place)
+        exe = fluid.Executor()
 
         feed_i = np.ones(1).astype('float32')
         feed_x = np.ones(1).astype('float32')
@@ -294,9 +284,7 @@ class TestApiWhileLoop_NestedWithBackwardAndLoDTensorArray(unittest.TestCase):
             mean = layers.mean(sum_result)
             append_backward(mean)
 
-            place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-            ) else fluid.CPUPlace()
-            exe = fluid.Executor(place)
+            exe = fluid.Executor()
 
             d = []
             for i in range(3):
@@ -348,9 +336,7 @@ class TestApiWhileLoopWithSwitchCase(unittest.TestCase):
             one = layers.fill_constant(shape=[1], dtype='int64', value=1)
             out = layers.while_loop(cond, body, [i])
 
-        place = fluid.CUDAPlace(0) if core.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
-        exe = fluid.Executor(place)
+        exe = fluid.Executor()
         res = exe.run(main_program, fetch_list=out)
 
         data = np.asarray([25]).astype('int64')


### PR DESCRIPTION
目前框架在创建`Executor`时需用户手动设置运行的`place`，略显繁琐，现将`Executor`中`place`参数默认，用户可以不设置`place`参数，而有框架自动判断运行的`place`。

目前的使用方法：
```
exe = fluid.Executor()                # 框架自动判断运行place
# exe = fluid.Executor(CUDAPlace(0))  # 显式指定为CUDAPlace：0
# exe = fluid.Executor(CPUPlace())    # 显式指定为CPUPlace
```

[Executor中文文档修改PR](https://github.com/PaddlePaddle/FluidDoc/pull/1946)

![172 18 25 111_8088_documentation_docs_en_api_fluid_Executor html](https://user-images.githubusercontent.com/52460041/78002142-513e0200-7369-11ea-9f06-f010c8ab2004.png)


