### PR TITLE
add fleet pslib pull and push sparse op and push dense op

### DIFF
--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -66,6 +66,8 @@ class PullDenseWorker {
   void ResetThreadVersion(uint64_t table_id);
   void Wait(std::vector<::std::future<int32_t>>* status_vec);
   void PullDense(bool force_update = false);
+  int GetThreadIdByScope(const Scope* scope);
+  void SetThreadIdByScope(const Scope* scope, int tid);
   static std::shared_ptr<PullDenseWorker> GetInstance() {
     if (NULL == s_instance_) {
       s_instance_.reset(new paddle::framework::PullDenseWorker());
@@ -73,13 +75,14 @@ class PullDenseWorker {
     return s_instance_;
   }
 
+ static std::shared_ptr<PullDenseWorker> s_instance_;
+
  private:
   PullDenseWorker() : root_scope_(NULL) {}
   void Run();
   bool CheckUpdateParam(uint64_t table_id);
 
  private:
-  static std::shared_ptr<PullDenseWorker> s_instance_;
   std::shared_ptr<paddle::framework::FleetWrapper> fleet_ptr_;
   PullDenseWorkerParameter param_;
   DownpourWorkerParameter dwp_param_;
@@ -105,6 +108,7 @@ class PullDenseWorker {
   float squared_sum_epsilon_ = 1e-4;
   std::mutex mutex_for_mean_scale_;
   float total_batch_num_ = 0;
+  std::unordered_map<const Scope*, int> scope_to_thread_id_;
 };
 
 // should incorporate different type of device

--- a/paddle/fluid/framework/dist_multi_trainer.cc
+++ b/paddle/fluid/framework/dist_multi_trainer.cc
@@ -124,6 +124,22 @@ void DistMultiTrainer::FinalizeDumpEnv() {
   queue_.reset();
 }
 
+void DistMultiTrainer::InitTrainerEnv(const ProgramDesc& main_program,
+                                  const platform::Place& place) {
+  for (int i = 0; i < thread_num_; ++i) {
+    workers_[i]->SetPlace(place);
+    workers_[i]->SetReaderPlace(place);
+    workers_[i]->SetRootScope(root_scope_);
+    workers_[i]->CreateDeviceResource(main_program);  // Program
+    workers_[i]->BindingDataFeedMemory();
+  }
+  // Scope* -> thread id, it will be used in push_dense op
+  for (int i = 0; i < thread_num_; ++i) {
+    Scope *thread_scope = workers_[i]->GetThreadScope();
+    pull_dense_worker_->SetThreadIdByScope(thread_scope, i);
+  }
+}
+
 void DistMultiTrainer::InitOtherEnv(const ProgramDesc &main_program) {
   if (need_dump_field_) {
     InitDumpEnv();

--- a/paddle/fluid/framework/pull_dense_worker.cc
+++ b/paddle/fluid/framework/pull_dense_worker.cc
@@ -140,5 +140,16 @@ void PullDenseWorker::ResetThreadVersion(uint64_t table_id) {
   last_versions_[table_id] = current_version_[table_id];
 }
 
+int PullDenseWorker::GetThreadIdByScope(const Scope* scope) {
+  if (scope_to_thread_id_.find(scope) != scope_to_thread_id_.end()) {
+    return scope_to_thread_id_[scope];
+  }
+  return -1;
+}
+
+void PullDenseWorker::SetThreadIdByScope(const Scope* scope, int tid) {
+  scope_to_thread_id_[scope] = tid;
+}
+
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/trainer.h
+++ b/paddle/fluid/framework/trainer.h
@@ -100,6 +100,8 @@ class DistMultiTrainer : public MultiTrainer {
   DistMultiTrainer() {}
   virtual ~DistMultiTrainer() {}
   virtual void Initialize(const TrainerDesc& trainer_desc, Dataset* data_set);
+  virtual void InitTrainerEnv(const ProgramDesc& main_program,
+                              const platform::Place& place);
   virtual void InitOtherEnv(const ProgramDesc& main_program);
   virtual void Run();
   virtual void Finalize();

--- a/paddle/fluid/operators/pull_sparse_op.cc
+++ b/paddle/fluid/operators/pull_sparse_op.cc
@@ -94,7 +94,7 @@ class PushSparseOpMaker : public framework::SingleGradOpMaker<T> {
   using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
 
  protected:
-  std::unique_ptr<T> Apply() const override {
+  std::unique_ptr<T> Apply() const {
     std::unique_ptr<T> op(new T());
     op->SetType("push_sparse");
     op->SetInput("Ids", this->Input("Ids"));

--- a/paddle/fluid/operators/pull_sparse_op.cc
+++ b/paddle/fluid/operators/pull_sparse_op.cc
@@ -73,7 +73,6 @@ class PullSparseOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::string>("CtrLabelName", "(string, ctr label name").SetDefault("");
     AddAttr<int>("PaddingId", "(int, the padding id of this embedding").SetDefault(0);
     AddAttr<bool>("ScaleSparseGrad", "(bool, whether scale sparse gradient with batch size").SetDefault(true);
-    AddAttr<bool>("AsyncPush", "(bool, whether push sparse is async").SetDefault(true);
     AddAttr<std::vector<std::string>>("InputNames", "(vector, slot names").SetDefault(std::vector<std::string>());
     AddAttr<bool>("is_distributed", "(bool, it must be true").SetDefault(true);
     AddComment(R"DOC(

--- a/paddle/fluid/operators/pull_sparse_op.cc
+++ b/paddle/fluid/operators/pull_sparse_op.cc
@@ -1,0 +1,134 @@
+//   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/pull_sparse_op.h"
+
+namespace paddle {
+namespace operators {
+
+class PullSparseOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_GE(ctx->Inputs("Ids").size(), 1UL,
+                      "Input(Ids) of PullSparseOp should not be null.");
+    PADDLE_ENFORCE_GE(ctx->Outputs("Out").size(), 1UL,
+                      "Output(Out) of PullSparseOp should not be null.");
+
+    auto hidden_size = static_cast<uint32_t>(ctx->Attrs().Get<int>("EmbeddingDim"));
+    auto all_ids_dim = ctx->GetInputsDim("Ids");
+    const size_t n_ids = all_ids_dim.size();
+    std::vector<framework::DDim> outs_dims;
+    outs_dims.resize(n_ids);
+    for (size_t i = 0; i < n_ids; ++i) {
+      const auto ids_dims = all_ids_dim[i];
+      int ids_rank = ids_dims.size();
+      PADDLE_ENFORCE_EQ(ids_dims[ids_rank - 1], 1,
+                        "Shape error in %lu id, the last dimension of the "
+                        "'Ids' tensor must be 1.",
+                        i);
+      auto out_dim = framework::vectorize(
+          framework::slice_ddim(ids_dims, 0, ids_rank - 1));
+      out_dim.push_back(hidden_size);
+      outs_dims[i] = framework::make_ddim(out_dim);
+    }
+    ctx->SetOutputsDim("Out", outs_dims);
+    for (size_t i = 0; i < n_ids; ++i) {
+      ctx->ShareLoD("Ids", "Out", i, i);
+    }
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(framework::proto::VarType::FP32,
+                                   ctx.device_context());
+  }
+};
+
+class PullSparseOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("Ids",
+             "Input tensors with type int64 contains "
+             "the ids to be looked up in PSLib. "
+             "The last dimension size must be 1.")
+        .AsDuplicable();
+    AddInput("W", "The lookup table tensors.").AsDuplicable();
+    AddOutput("Out", "The lookup results tensors.").AsDuplicable();
+    AddAttr<int>("EmbeddingDim", "(int, the embedding hidden size").SetDefault(11);
+    AddAttr<int>("TableId", "(int, the table id of this embedding").SetDefault(0);
+    AddAttr<std::string>("AccessorClass", "(string, the class name of accessor").SetDefault("");
+    AddAttr<std::string>("CtrLabelName", "(string, ctr label name").SetDefault("");
+    AddAttr<int>("PaddingId", "(int, the padding id of this embedding").SetDefault(0);
+    AddAttr<bool>("ScaleSparseGrad", "(bool, whether scale sparse gradient with batch size").SetDefault(true);
+    AddAttr<bool>("AsyncPush", "(bool, whether push sparse is async").SetDefault(true);
+    AddAttr<std::vector<std::string>>("InputNames", "(vector, slot names").SetDefault(std::vector<std::string>());
+    AddAttr<bool>("is_distributed", "(bool, it must be true").SetDefault(true);
+    AddComment(R"DOC(
+Pull Sparse Operator.
+
+This operator is used to perform lookups on the PSLib
+then concatenated into a dense tensor.
+
+The input Ids can carry the LoD (Level of Details) information,
+or not. And the output only shares the LoD information with input Ids.
+
+)DOC");
+  }
+};
+
+template <typename T>
+class PushSparseOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  std::unique_ptr<T> Apply() const override {
+    std::unique_ptr<T> op(new T());
+    op->SetType("push_sparse");
+    op->SetInput("Ids", this->Input("Ids"));
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetInput("W", this->Input("W"));
+    op->SetOutput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetAttrMap(this->Attrs());
+    return op;
+  }
+};
+
+class PushSparseOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {}
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.device_context());
+  }
+};
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(pull_sparse, ops::PullSparseOp,
+                  ops::PullSparseOpMaker,
+                  ops::PushSparseOpMaker<paddle::framework::OpDesc>,
+                  ops::PushSparseOpMaker<paddle::imperative::OpBase>);
+REGISTER_OPERATOR(push_sparse, ops::PushSparseOp);
+REGISTER_OP_CPU_KERNEL(pull_sparse, ops::PullSparseCPUKernel<float>)
+REGISTER_OP_CPU_KERNEL(push_sparse, ops::PushSparseCPUKernel<float>)

--- a/paddle/fluid/operators/pull_sparse_op.h
+++ b/paddle/fluid/operators/pull_sparse_op.h
@@ -32,6 +32,7 @@ void PullSparseFunctor(
     uint32_t sleep_seconds_before_fail_exit) {
   const auto& inputs = ctx.MultiInput<framework::LoDTensor>("Ids");
   const auto& outputs = ctx.MultiOutput<framework::LoDTensor>("Out");
+  uint32_t fea_dim = static_cast<uint32_t>(ctx.Attr<int>("EmbeddingDim"));
 #ifdef PADDLE_WITH_PSLIB
   std::vector<uint64_t>* fea_keys =
       const_cast<std::vector<uint64_t>*>(fea_keys_const);
@@ -45,7 +46,6 @@ void PullSparseFunctor(
   fea_keys->reserve(max_feasign_num);
   
   uint64_t padding_id =static_cast<uint64_t>(ctx.Attr<int>("PaddingId"));
-  uint32_t fea_dim = static_cast<uint32_t>(ctx.Attr<int>("EmbeddingDim"));
   std::vector<T> init_value(fea_dim, 0);
   pull_result_ptr->clear();
   framework::LoDTensor* output = nullptr;
@@ -91,14 +91,13 @@ void PullSparseFunctor(
   }
 
 #else
-  for (size_t index = 0; index < input_size; ++index) {
-    auto* tensor = inputs[index];
-    int64_t* ids = tensor->data<int64_t>();
+  for (size_t index = 0; index < inputs.size(); ++index) {
+    const auto* tensor = inputs[index];
     size_t len = tensor->numel();
-    std::vector<T> init_data(fea_value_dim, 0);
+    std::vector<T> init_data(fea_dim, 0);
     for (size_t i = 0; i < len; ++i) {
       memcpy(outputs[index]->mutable_data<T>(ctx.GetPlace()),
-             init_data.data(), fea_value_dim);
+             init_data.data(), fea_dim);
     }
   }
 #endif

--- a/paddle/fluid/operators/pull_sparse_op_v2.cc
+++ b/paddle/fluid/operators/pull_sparse_op_v2.cc
@@ -1,0 +1,127 @@
+//   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/pull_sparse_op_v2.h"
+
+namespace paddle {
+namespace operators {
+
+class PullSparseV2Op : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_GE(ctx->Inputs("Ids").size(), 1UL,
+                      "Input(Ids) of PullSparseV2Op should not be null.");
+    PADDLE_ENFORCE_GE(ctx->Outputs("Out").size(), 1UL,
+                      "Output(Out) of PullSparseV2Op should not be null.");
+
+    auto hidden_size = static_cast<uint32_t>(ctx->Attrs().Get<int>("EmbeddingDim"));
+    auto all_ids_dim = ctx->GetInputsDim("Ids");
+    const size_t n_ids = all_ids_dim.size();
+    std::vector<framework::DDim> outs_dims;
+    outs_dims.resize(n_ids);
+    for (size_t i = 0; i < n_ids; ++i) {
+      const auto ids_dims = all_ids_dim[i];
+      int ids_rank = ids_dims.size();
+      auto out_dim = framework::vectorize(ids_dims);
+      out_dim.push_back(hidden_size);
+      outs_dims[i] = framework::make_ddim(out_dim);
+    }
+    ctx->SetOutputsDim("Out", outs_dims);
+    for (size_t i = 0; i < n_ids; ++i) {
+      ctx->ShareLoD("Ids", "Out", i, i);
+    }
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(framework::proto::VarType::FP32,
+                                   ctx.device_context());
+  }
+};
+
+class PullSparseV2OpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("Ids",
+             "Input tensors with type int64 contains "
+             "the ids to be looked up in PSLib. ")
+        .AsDuplicable();
+    AddInput("W", "The lookup table tensors.").AsDuplicable();
+    AddOutput("Out", "The lookup results tensors.").AsDuplicable();
+    AddAttr<int>("EmbeddingDim", "(int, the embedding hidden size").SetDefault(11);
+    AddAttr<int>("TableId", "(int, the table id of this embedding").SetDefault(0);
+    AddAttr<std::string>("AccessorClass", "(string, the class name of accessor").SetDefault("");
+    AddAttr<std::string>("CtrLabelName", "(string, ctr label name").SetDefault("");
+    AddAttr<int>("PaddingId", "(int, the padding id of this embedding").SetDefault(0);
+    AddAttr<bool>("ScaleSparseGrad", "(bool, whether scale sparse gradient with batch size").SetDefault(true);
+    AddAttr<bool>("AsyncPush", "(bool, whether push sparse is async").SetDefault(true);
+    AddAttr<std::vector<std::string>>("InputNames", "(vector, slot names").SetDefault(std::vector<std::string>());
+    AddComment(R"DOC(
+Pull Sparse V2 Operator.
+
+This operator is used to perform lookups on the PSLib
+then concatenated into a dense tensor.
+
+The input Ids can carry the LoD (Level of Details) information,
+or not. And the output only shares the LoD information with input Ids.
+
+)DOC");
+  }
+};
+
+template <typename T>
+class PushSparseV2OpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  std::unique_ptr<T> Apply() const override {
+    std::unique_ptr<T> op(new T());
+    op->SetType("push_sparse_v2");
+    op->SetInput("Ids", this->Input("Ids"));
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetInput("W", this->Input("W"));
+    op->SetOutput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetAttrMap(this->Attrs());
+    return op;
+  }
+};
+
+class PushSparseV2Op : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {}
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.device_context());
+  }
+};
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(pull_sparse_v2, ops::PullSparseV2Op,
+                  ops::PullSparseV2OpMaker,
+                  ops::PushSparseV2OpMaker<paddle::framework::OpDesc>,
+                  ops::PushSparseV2OpMaker<paddle::imperative::OpBase>);
+REGISTER_OPERATOR(push_sparse_v2, ops::PushSparseV2Op);
+REGISTER_OP_CPU_KERNEL(pull_sparse_v2, ops::PullSparseV2CPUKernel<float>)
+REGISTER_OP_CPU_KERNEL(push_sparse_v2, ops::PushSparseV2CPUKernel<float>)

--- a/paddle/fluid/operators/pull_sparse_op_v2.cc
+++ b/paddle/fluid/operators/pull_sparse_op_v2.cc
@@ -67,7 +67,6 @@ class PullSparseV2OpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::string>("CtrLabelName", "(string, ctr label name").SetDefault("");
     AddAttr<int>("PaddingId", "(int, the padding id of this embedding").SetDefault(0);
     AddAttr<bool>("ScaleSparseGrad", "(bool, whether scale sparse gradient with batch size").SetDefault(true);
-    AddAttr<bool>("AsyncPush", "(bool, whether push sparse is async").SetDefault(true);
     AddAttr<std::vector<std::string>>("InputNames", "(vector, slot names").SetDefault(std::vector<std::string>());
     AddComment(R"DOC(
 Pull Sparse V2 Operator.

--- a/paddle/fluid/operators/pull_sparse_op_v2.h
+++ b/paddle/fluid/operators/pull_sparse_op_v2.h
@@ -1,0 +1,57 @@
+//   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+#include <vector>
+#include "paddle/fluid/framework/fleet/fleet_wrapper.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/tensor.h"
+#include "paddle/fluid/operators/pull_sparse_op.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+class PullSparseV2CPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    PullSparseFunctor<T>(ctx, &fea_keys_, &pull_result_ptr_,
+                         &pull_sparse_status_, max_feasign_num_,
+                         sleep_seconds_before_fail_exit_);
+  }
+ protected:
+   std::vector<uint64_t> fea_keys_;
+   std::vector<T*> pull_result_ptr_;
+   std::vector<::std::future<int32_t>> pull_sparse_status_;
+   uint32_t max_feasign_num_ = 10240000;
+   uint32_t sleep_seconds_before_fail_exit_ = 300;
+};
+
+template <typename T>
+class PushSparseV2CPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    PushSparseFunctor<T>(ctx, &push_keys_, &push_values_,
+                        &fea_labels_, max_feasign_num_);
+  }
+
+ protected:
+  std::vector<uint64_t> push_keys_;
+  std::vector<std::vector<T>> push_values_;
+  std::vector<T> fea_labels_;
+  uint32_t max_feasign_num_ = 10240000;
+};
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/push_dense_op.cc
+++ b/paddle/fluid/operators/push_dense_op.cc
@@ -1,0 +1,66 @@
+//   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/push_dense_op.h"
+
+namespace paddle {
+namespace operators {
+
+class PushDenseOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_GE(ctx->Inputs("DenseGrads").size(), 1UL,
+                      "Input(DenseGrads) of PushDenseOp should not be null.");
+    PADDLE_ENFORCE_GE(ctx->Inputs("Ids").size(), 1UL,
+                      "Input(Ids) of PushDenseOp should not be null.");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(framework::proto::VarType::FP32,
+                                   ctx.device_context());
+  }
+};
+
+class PushDenseOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("DenseGrads", "The dense gradient tensors").AsDuplicable();
+    AddInput("Ids", "the tensor to get batch size").AsDuplicable();
+    AddAttr<int>("TableId", "(int, the table id of this embedding").SetDefault(-1);;
+    AddAttr<float>("ScaleDataNorm", "(float, scale data norm gradient").SetDefault(-1.0f);
+    AddAttr<std::vector<std::string>>("InputNames", "(vector, slot names").SetDefault(std::vector<std::string>());
+    AddComment(R"DOC(
+Push Dense Operator.
+
+push dense gradients to PSLib's Parameter Server.
+
+The input gradients can carry the LoD (Level of Details) information,
+or not. And the output only shares the LoD information with input Ids.
+
+)DOC");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(push_dense, ops::PushDenseOp,
+                  ops::PushDenseOpMaker,
+                  paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
+                 paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
+REGISTER_OP_CPU_KERNEL(push_dense, ops::PushDenseCPUKernel<float>)

--- a/paddle/fluid/operators/push_dense_op.h
+++ b/paddle/fluid/operators/push_dense_op.h
@@ -1,0 +1,85 @@
+//   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <memory>
+#include <vector>
+#include "paddle/fluid/framework/device_worker.h"
+#include "paddle/fluid/framework/fleet/fleet_wrapper.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/tensor.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+void PushDenseFunctor(const framework::ExecutionContext& ctx) {
+#ifdef PADDLE_WITH_PSLIB
+  const auto& inputs = ctx.MultiInput<framework::LoDTensor>("DenseGrads");
+  const auto& input_names = ctx.Attr<std::vector<std::string>>("InputNames");
+  auto table_id = static_cast<uint32_t>(ctx.Attr<int>("TableId"));
+  float scale_datanorm = ctx.Attr<float>("ScaleDataNorm");
+  std::vector<paddle::ps::Region> regions;
+  CHECK(inputs.size() == input_names.size());
+
+  const auto& ids = ctx.MultiInput<framework::LoDTensor>("Ids");
+  int batch_size =
+      ids[0]->lod().size() ? ids[0]->lod()[0].size() - 1 : ids[0]->dims()[0];
+  CHECK_GT(batch_size, 0);  
+  
+  for (size_t index = 0; index < inputs.size(); ++index) {
+    framework::LoDTensor* tensor = const_cast<framework::LoDTensor*>(inputs[index]);
+    T* g = tensor->data<T>();
+    size_t count = tensor->numel();
+    const std::string& name = input_names[index];
+    if (scale_datanorm >= 0.0f) {
+      if (name.find(".batch_size@GRAD") != std::string::npos ||
+          name.find(".batch_sum@GRAD") != std::string::npos) {
+        Eigen::Map<Eigen::MatrixXf> mat(g, 1, count);
+        float scale = 1.0 / batch_size;
+        mat *= scale;
+      }
+    } else if (name.find(".batch_square_sum@GRAD") != std::string::npos) {
+      for (int i = 0; i < count; ++i) {
+        g[i] = (g[i] - batch_size * scale_datanorm) / batch_size +
+               batch_size * scale_datanorm;
+      }
+    }
+    paddle::ps::Region reg(g, count);
+    regions.emplace_back(std::move(reg));
+  }
+
+  CHECK(framework::FleetWrapper::pslib_ptr_ != nullptr);
+  auto status = framework::FleetWrapper::pslib_ptr_->_worker_ptr->push_dense(
+      regions.data(), regions.size(), table_id);
+
+  // not use GetInstance() here, because it's not thread-safe,
+  // s_instance_ should be already initialized in DistMultiTrainer
+  auto pull_dense_worker = framework::PullDenseWorker::s_instance_;
+  CHECK(pull_dense_worker != nullptr);
+  int thread_id = pull_dense_worker->GetThreadIdByScope(&ctx.scope());
+  pull_dense_worker->IncreaseThreadVersion(thread_id, table_id);
+#endif
+}
+
+template <typename T>
+class PushDenseCPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    PushDenseFunctor<T>(ctx);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/device_worker.py
+++ b/python/paddle/fluid/device_worker.py
@@ -91,6 +91,83 @@ class Hogwild(DeviceWorker):
             # just ignore feed op for inference model
             trainer_desc.hogwild_param.skip_ops.extend(["feed"])
 
+        dense_table_set = set()
+        program_id = str(id(self._program))
+        if self._program == None:
+            print("program of current device worker is not configured")
+            exit(-1)
+        opt_info = self._program._fleet_opt
+        if opt_info is None:
+            return
+
+        program_configs = opt_info["program_configs"]
+        downpour = trainer_desc.downpour_param
+
+        for pid in program_configs:
+            if pid == program_id:
+                pc = downpour.program_config.add()
+                pc.program_id = program_id
+                for i in program_configs[program_id]["push_sparse"]:
+                    pc.push_sparse_table_id.extend([i])
+                for i in program_configs[program_id]["push_dense"]:
+                    pc.push_dense_table_id.extend([i])
+                    dense_table_set.add(i)
+                for i in program_configs[program_id]["pull_sparse"]:
+                    pc.pull_sparse_table_id.extend([i])
+                for i in program_configs[program_id]["pull_dense"]:
+                    pc.pull_dense_table_id.extend([i])
+                    dense_table_set.add(i)
+                break
+
+        trainer_desc.device_worker_name = "HogwildWorker"
+        pull_thread = trainer_desc.pull_dense_param
+        pull_thread.device_num = trainer_desc.thread_num
+        if opt_info.get("program_id_to_worker") is None:
+            raise ValueError("opt_info must have program_id_to_worker")
+        prog_id_to_worker = opt_info["program_id_to_worker"]
+        if prog_id_to_worker.get(program_id) is None:
+            raise ValueError("%s not found in program_id_to_worker" %
+                             program_id)
+        worker = opt_info["program_id_to_worker"][program_id]
+        for i in worker.get_desc().dense_table:
+            if i.table_id in dense_table_set:
+                dense_table = pull_thread.dense_table.add()
+                dense_table.dense_value_name.extend(i.dense_variable_name)
+                dense_table.table_id = \
+                    i.table_id
+        sparse_len = len(worker.get_desc().sparse_table)
+        for i in range(sparse_len):
+            sparse_table = downpour.sparse_table.add()
+            sparse_table.table_id = worker.get_desc().sparse_table[i].table_id
+            sparse_table.sparse_key_name.extend(worker.get_desc().sparse_table[
+                i].slot_key)
+            sparse_table.sparse_value_name.extend(worker.get_desc()
+                                                  .sparse_table[i].slot_value)
+            sparse_table.sparse_grad_name.extend(worker.get_desc().sparse_table[
+                i].slot_gradient)
+            sparse_table.fea_dim = \
+                self._fleet_desc.server_param.downpour_server_param.downpour_table_param[
+                i].accessor.fea_dim
+            # not use emb_dim
+            sparse_table.emb_dim = -1
+            # not use hard code click
+            sparse_table.label_var_name = ""
+        if opt_info["stat_var_names"]:
+            for i in opt_info["stat_var_names"]:
+                downpour.stat_var_names.extend([i])
+
+        for i in worker.get_desc().dense_table:
+            if i.table_id in dense_table_set:
+                dense_table = downpour.dense_table.add()
+                dense_table.table_id = i.table_id
+                dense_table.dense_value_name.extend(i.dense_variable_name)
+                dense_table.dense_grad_name.extend(
+                    i.dense_gradient_variable_name)
+        downpour.skip_ops.extend(worker.get_desc().skip_op)
+        if self._infer:
+            downpour.push_dense = False
+            downpour.push_sparse = False
+
 
 class DownpourSGD(DeviceWorker):
     """

--- a/python/paddle/fluid/incubate/fleet/parameter_server/pslib/__init__.py
+++ b/python/paddle/fluid/incubate/fleet/parameter_server/pslib/__init__.py
@@ -687,7 +687,7 @@ class fleet_ctr_embedding(object):
     def __init__(self, click_name=None, dump_slot=True, scale_sparse_grad=True):
         self.origin_emb = fluid.layers.embedding
         self.origin_emb_v2 = fluid.embedding
-        self.click_name = click_name
+        self.click_name = "" if click_name is None else click_name
         self.scale_sparse_grad = scale_sparse_grad
         if dump_slot:
             self.accessor = "DownpourCtrAccessor"

--- a/python/paddle/fluid/incubate/fleet/parameter_server/pslib/optimizer_factory.py
+++ b/python/paddle/fluid/incubate/fleet/parameter_server/pslib/optimizer_factory.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Optimizer Factory."""
 
-__all__ = ["DistributedAdam"]
+__all__ = ["DistributedAdam", "FLEET_GLOBAL_DICT"]
 import paddle.fluid as fluid
 from paddle.fluid.distribute_lookup_table import find_distributed_lookup_table
 from paddle.fluid.distribute_lookup_table import find_distributed_lookup_table_inputs
@@ -22,6 +22,19 @@ from google.protobuf import text_format
 from collections import OrderedDict
 from .node import DownpourWorker, DownpourServer
 from . import ps_pb2 as pslib
+
+FLEET_GLOBAL_DICT = {
+    # global settings
+    "enable": False,
+    "emb_to_table": {},
+    "emb_to_accessor": {},
+    "emb_to_size": {},
+    # current embedding settings
+    "cur_sparse_id": 0,
+    "cur_accessor": "",
+    "click_name": "",
+    "scale_sparse_grad": None,
+}
 
 
 class DistributedOptimizerImplBase(object):
@@ -274,6 +287,67 @@ class DistributedAdam(DistributedOptimizerImplBase):
                         ps_param.trainer_param[idx])
                     idx += 1
 
+        # check config in op defination and fleet config
+        if FLEET_GLOBAL_DICT["enable"]:
+            one_slot = None
+            strategy["device_worker"] = "Hogwild"
+            emb_to_table = FLEET_GLOBAL_DICT["emb_to_table"]
+            emb_to_accessor = FLEET_GLOBAL_DICT["emb_to_accessor"]
+            emb_to_size = FLEET_GLOBAL_DICT["emb_to_size"]
+            if len(sparse_table_to_index) != len(emb_to_table):
+                raise ValueError(
+                    "sparse tables from  program != sparse tables from op: %s "
+                    "vs %s" %(len(sparse_table_to_index), len(emb_to_table)))
+            for key in sparse_table_to_index:
+                if key not in emb_to_table or \
+                        sparse_table_to_index[key] != emb_to_table[key]:
+                    print("sparse_table_to_index ", sparse_table_to_index)
+                    print("emb_to_table ", emb_to_table)
+                    raise ValueError("key error: %s" % key)
+                if strategy.get(key) is None:
+                    strategy[key] = dict()
+                st = strategy[key]
+
+                accessor = None
+                if st.get("sparse_accessor_class") is not None:
+                    accessor = st["sparse_accessor_class"]
+                tables = \
+                    server.get_desc().downpour_server_param.downpour_table_param
+                for table in tables:
+                    if table.table_id == sparse_table_to_index[key]:
+                        accessor = table.accessor.accessor_class
+
+                for loss in losses:
+                    for op in loss.block.program.global_block().ops:
+                        if op.type in self.supported_embedding_types:
+                            if accessor is not None \
+                                    and op.has_attr("AccessorClass"):
+                                op._set_attr("AccessorClass", accessor)
+                            if one_slot is None:
+                                one_slot = loss.block.program.\
+                                    global_block().var(op.input("Ids")[0])
+
+                # set sparse_embedx_dim in strategy,
+                # user do not have to set it in config_fleet
+                if accessor == "DownpourFeatureValueAccessor" \
+                        or accessor == "DownpourCtrAccessor" \
+                        or accessor == "DownpourUnitAccessor":
+                    if st.get("sparse_embedx_dim") is not None \
+                            and st["sparse_embedx_dim"] != emb_to_size[key] - 3:
+                        raise ValueError("fleet config sparse_embedx_dim=%s not"
+                                         " equal to embedding size - 3 = %s"
+                                         % (st["sparse_embedx_dim"],
+                                            emb_to_size[key] - 3))
+                    st["sparse_embedx_dim"] = emb_to_size[key] - 3
+                elif accessor == "DownpourSparseValueAccessor":
+                    if st.get("sparse_embedx_dim") is not None \
+                            and st["sparse_embedx_dim"] != emb_to_size[key]:
+                        raise ValueError("fleet config sparse_embedx_dim=%s not"
+                                         " equal to embedding size = %s"
+                                         % (st["sparse_embedx_dim"],
+                                            emb_to_size[key]))
+                    st["sparse_embedx_dim"] = emb_to_size[key]
+
         # ServerParameter add all sparse tables
         for tn in sparse_table_to_index:
             sparse_table_index = sparse_table_to_index[tn]
@@ -351,6 +425,21 @@ class DistributedAdam(DistributedOptimizerImplBase):
                     worker.add_dense_table(
                         dense_table_index, self._learning_rate, params, grads,
                         dense_start_table_id, sparse_table_names)
+
+                    if FLEET_GLOBAL_DICT["enable"]:
+                        cur_prog = losses[loss_index].block.program
+                        cur_prog.global_block().append_op(
+                            type="push_dense",
+                            inputs={
+                                "DenseGrads": grads,
+                                "Ids": one_slot
+                            },
+                            attrs={
+                                "InputNames": [i.name for i in params],
+                                "TableId": dense_table_index,
+                                "ScaleDataNorm": strategy.get("scale_datanorm", -1)
+                            })
+
                     if "pull_dense" in program_configs[
                             program_id] and "push_dense" in program_configs[
                                 program_id] and len(program_configs[program_id][
@@ -381,6 +470,21 @@ class DistributedAdam(DistributedOptimizerImplBase):
                             dense_table_index, self._learning_rate,
                             data_norm_params, data_norm_grads,
                             dense_start_table_id, sparse_table_names)
+
+                        if FLEET_GLOBAL_DICT["enable"]:
+                            cur_prog = losses[loss_index].block.program
+                            cur_prog.global_block().append_op(
+                                type="push_dense",
+                                inputs={
+                                    "DenseGrads": data_norm_grads,
+                                    "Ids": one_slot
+                                },
+                                attrs={
+                                    "InputNames": [i.name for i in data_norm_params],
+                                    "TableId": dense_table_index,
+                                    "ScaleDataNorm": strategy.get("scale_datanorm", -1)
+                                })
+
                     program_configs[program_id]["pull_dense"].extend(
                         [dense_table_index])
                     program_configs[program_id]["push_dense"].extend(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -507,8 +507,7 @@ def _pull_sparse(input,
                  ctr_label_name="",
                  padding_id = 0,
                  dtype='float32',
-                 scale_sparse_grad=True,
-                 async_push=True):
+                 scale_sparse_grad=True):
     helper = LayerHelper(name, **locals())
     inputs = helper.multiple_input()
     outs = [
@@ -522,7 +521,6 @@ def _pull_sparse(input,
         'CtrLabelName': ctr_label_name,
         'PaddingId': padding_id,
         'ScaleSparseGrad': scale_sparse_grad,
-        'AsyncPush': async_push,
         'InputNames': input_names,
         # this is only for compatible with embedding op
         'is_distributed': True
@@ -548,8 +546,7 @@ def _pull_sparse_v2(input,
                    ctr_label_name="",
                    padding_id = 0,
                    dtype='float32',
-                   scale_sparse_grad=True,
-                   async_push=True):
+                   scale_sparse_grad=True):
     helper = LayerHelper(name, **locals())
     inputs = helper.multiple_input()
     outs = [
@@ -563,7 +560,6 @@ def _pull_sparse_v2(input,
         'CtrLabelName': ctr_label_name,
         'PaddingId': padding_id,
         'ScaleSparseGrad': scale_sparse_grad,
-        'AsyncPush': async_push,
         'InputNames': input_names,
         # this is only for compatible with embedding op
         'is_distributed': True

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -499,6 +499,87 @@ def embedding(input,
         })
     return tmp
 
+def _pull_sparse(input,
+                 size,
+                 table_id,
+                 accessor_class,
+                 name="embedding",
+                 ctr_label_name="",
+                 padding_id = 0,
+                 dtype='float32',
+                 scale_sparse_grad=True,
+                 async_push=True):
+    helper = LayerHelper(name, **locals())
+    inputs = helper.multiple_input()
+    outs = [
+        helper.create_variable_for_type_inference(dtype)
+    ]
+    input_names = [i.name for i in inputs]
+    attrs={
+        'EmbeddingDim': size,
+        'TableId': table_id,
+        'AccessorClass': accessor_class,
+        'CtrLabelName': ctr_label_name,
+        'PaddingId': padding_id,
+        'ScaleSparseGrad': scale_sparse_grad,
+        'AsyncPush': async_push,
+        'InputNames': input_names,
+        # this is only for compatible with embedding op
+        'is_distributed': True
+    }
+    # this is only for compatible with embedding op
+    w, _ = helper.create_or_get_global_variable(
+        name=name, shape=[size], dtype=dtype, is_bias=False, persistable=True)
+    helper.append_op(
+        type='pull_sparse',
+        inputs={'Ids': inputs, 'W': w},
+        outputs={'Out': outs},
+        attrs=attrs
+    )
+    if len(outs) == 1:
+        return outs[0]
+    return outs
+
+def _pull_sparse_v2(input,
+                   size,
+                   table_id,
+                   accessor_class,
+                   name="embedding",
+                   ctr_label_name="",
+                   padding_id = 0,
+                   dtype='float32',
+                   scale_sparse_grad=True,
+                   async_push=True):
+    helper = LayerHelper(name, **locals())
+    inputs = helper.multiple_input()
+    outs = [
+        helper.create_variable_for_type_inference(dtype)
+    ]
+    input_names = [i.name for i in inputs]
+    attrs={
+        'EmbeddingDim': size,
+        'TableId': table_id,
+        'AccessorClass': accessor_class,
+        'CtrLabelName': ctr_label_name,
+        'PaddingId': padding_id,
+        'ScaleSparseGrad': scale_sparse_grad,
+        'AsyncPush': async_push,
+        'InputNames': input_names,
+        # this is only for compatible with embedding op
+        'is_distributed': True
+    }
+    # this is only for compatible with embedding op
+    w, _ = helper.create_or_get_global_variable(
+        name=name, shape=[size], dtype=dtype, is_bias=False, persistable=True)
+    helper.append_op(
+        type='pull_sparse_v2',
+        inputs={'Ids': inputs, 'W': w},
+        outputs={'Out': outs},
+        attrs=attrs
+    )
+    if len(outs) == 1:
+        return outs[0]
+    return outs
 
 def _pull_box_sparse(input, size, dtype='float32'):
     """


### PR DESCRIPTION
* add fleet pslib pull and push sparse op and push dense op
* test=develop

**why adding these ops**: current embedding in pslib mode must be next to fluid.layers.data,  nothing can be done between data and embedding, such as reshape or sampling, etc. And not to mention some complex operation on the calculation graph.

**advantages**: fleet_ctr_embedding  and fleet_embedding is just a wrapper, the interface of fluid.layers.embedding does not change a bit.

**usage**:

for push dense op, it  is added by fleet automatically.
for sparse op, user only need to add a wrapper as following:

```python
from paddle.fluid.incubate.fleet.parameter_server.pslib import fleet_ctr_embedding, fleet_embedding

# when using fleet_ctr_embedding, default accessor is DownpourCtrAccessor, 
# you can use config_fleet or fleet_desc_file to specify.

# user does not have to set fea_dim and embedx_dim in config_fleet

# ctr accessor, no click is specified, so user must use cvm layer
with fleet_ctr_embedding():
    emb = fluid.layers.embedding(
        input=var,
        size=[-1, 11], 
        is_sparse=True,
        is_distributed=True, 
        param_attr=fluid.ParamAttr(name="embedding"))

#  ctr accessor, it's click name is label.name
with fleet_ctr_embedding(click=label.name):
    emb = fluid.layers.embedding(
        input=var,
        size=[-1, 11], 
        is_sparse=True,
        is_distributed=True, 
        param_attr=fluid.ParamAttr(name="embedding"))

# sparse value accessor 
with fleet_embedding():
    emb = fluid.layers.embedding(
        input=var,
        size=[-1, 11], 
        is_sparse=True,
        is_distributed=True, 
        param_attr=fluid.ParamAttr(name="embedding"))

```