### PR TITLE
add new method of gradient_clip, better to use and avoid mistake of set_gradient_clip

### DIFF
--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -75,8 +75,8 @@ from .transpiler import DistributeTranspiler, \
     memory_optimize, release_memory, DistributeTranspilerConfig
 from .lod_tensor import create_lod_tensor, create_random_int_lodtensor
 from . import clip
-from . import dygraph_grad_clip
 from . import profiler
+from .dygraph_grad_clip import *
 from . import unique_name
 from . import parallel_executor
 from .parallel_executor import *

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2409,7 +2409,6 @@ class Block(object):
             trainable = v.trainable
             optimize_attr = v.optimize_attr
             regularizer = v.regularizer
-            gradient_clip_attr = v.gradient_clip_attr
             error_clip = v.error_clip
         elif type(v) == Variable:
             var_type = "Variable"
@@ -2432,7 +2431,6 @@ class Block(object):
                     trainable=trainable,
                     optimize_attr=optimize_attr,
                     regularizer=regularizer,
-                    gradient_clip_attr=gradient_clip_attr,
                     error_clip=error_clip)
             else:
                 var = Parameter(
@@ -2445,7 +2443,6 @@ class Block(object):
                     trainable=trainable,
                     optimize_attr=optimize_attr,
                     regularizer=regularizer,
-                    gradient_clip_attr=gradient_clip_attr,
                     error_clip=error_clip)
         elif var_type == "Variable":
             var = Variable(
@@ -2723,7 +2720,6 @@ class Block(object):
                     trainable=p.trainable,
                     optimize_attr=p.optimize_attr,
                     regularizer=p.regularizer,
-                    gradient_clip_attr=p.gradient_clip_attr,
                     error_clip=p.error_clip,
                     name=v.name)
             else:
@@ -2737,7 +2733,6 @@ class Block(object):
                     trainable=p.trainable,
                     optimize_attr=p.optimize_attr,
                     regularizer=p.regularizer,
-                    gradient_clip_attr=p.gradient_clip_attr,
                     error_clip=p.error_clip,
                     name=v.name)
             self.vars[new_p.name] = new_p
@@ -4646,8 +4641,6 @@ class Parameter(Variable):
             Default: {'learning_rate': 1.0}
         regularizer(WeightDecayRegularizer): The Regularizer which will
             be applied on the parameter. Default: None
-        gradient_clip_attr(BaseGradientClipAttr): The gradient clip strategy
-            which will be applied on the parameter. Default: None
         do_model_average(bool): True if the model average strategy will
             be applied on this parameter.
     """
@@ -4687,8 +4680,6 @@ class Parameter(Variable):
 
         self.regularizer = kwargs.get('regularizer', None)
 
-        self.gradient_clip_attr = kwargs.get('gradient_clip_attr', None)
-
         self.do_model_average = kwargs.get('do_model_average', None)
 
         self.is_distributed = False
@@ -4723,7 +4714,7 @@ class Parameter(Variable):
         if with_details:
             res_str = Variable.to_string(self, throw_on_error, True)
             additional_attr = ("trainable", "optimize_attr", "regularizer",
-                               "gradient_clip_attr", "do_model_average")
+                               "do_model_average")
             for attr_name in additional_attr:
                 res_str += "%s: %s\n" % (attr_name,
                                          cpt.to_text(getattr(self, attr_name)))
@@ -4752,8 +4743,6 @@ class ParamBase(core.VarBase):
             Default: {'learning_rate': 1.0}
         regularizer(WeightDecayRegularizer): The Regularizer which will
             be applied on the ParamBase. Default: None
-        gradient_clip_attr(BaseGradientClipAttr): The gradient clip strategy
-            which will be applied on the ParamBase. Default: None
         do_model_average(bool): True if the model average strategy will
             be applied on this ParamBase.
     """
@@ -4791,8 +4780,6 @@ class ParamBase(core.VarBase):
         self.optimize_attr = kwargs.get('optimize_attr', {'learning_rate': 1.0})
 
         self.regularizer = kwargs.get('regularizer', None)
-
-        self.gradient_clip_attr = kwargs.get('gradient_clip_attr', None)
 
         self.do_model_average = kwargs.get('do_model_average', None)
 

--- a/python/paddle/fluid/param_attr.py
+++ b/python/paddle/fluid/param_attr.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import six
+import warnings
 
 from .initializer import Initializer, Xavier, Constant
 from .regularizer import WeightDecayRegularizer
@@ -43,8 +44,6 @@ class ParamAttr(object):
         regularizer (WeightDecayRegularizer, optional): Regularization factor. Default None, meaning
                 there is no regularization.
         trainable (bool): Whether this parameter is trainable. Default True.
-        gradient_clip (BaseGradientClipAttr, optional): The method to clip this parameter's
-                gradient. Default None, meaning that there is no gradient clip.
         do_model_average (bool): Whether this parameter should do model average
                 when model average is enabled. Default False.
 
@@ -78,8 +77,16 @@ class ParamAttr(object):
         self.learning_rate = learning_rate
         self.regularizer = regularizer
         self.trainable = trainable
-        self.gradient_clip = gradient_clip
         self.do_model_average = do_model_average
+
+        if gradient_clip is not None:
+            warnings.warn(
+                "Caution! 'gradient_clip' of paddle.fluid.ParamAttr() is "
+                "deprecated since 2.0 and not maintained any more, because "
+                "it is easily to be misused.\n"
+                "After that, We recommend a new strategy: clip gradient by "
+                "'optimizer.minimize(loss, grad_clip=clip)'. This method can "
+                "reduce the mistakes, please see documention of 'minimize'.")
 
     def _set_default_initializer(self, initializer):
         """
@@ -176,7 +183,6 @@ class ParamAttr(object):
             },
             'regularizer': self.regularizer,
             'trainable': self.trainable,
-            'gradient_clip_attr': self.gradient_clip,
             'do_model_average': self.do_model_average
         }
         if with_initializer:

--- a/python/paddle/fluid/tests/unittests/test_grad_clip_minimize.py
+++ b/python/paddle/fluid/tests/unittests/test_grad_clip_minimize.py
@@ -200,7 +200,6 @@ class TestGradClipByValue(unittest.TestCase):
 
     def get_dygrap_clip_result(self):
         with fluid.dygraph.guard():
-
             value_clip = GradClipByValue(self.min_value, self.max_value)
             p_g_var = []
             for p, g in self.para_and_grad:

--- a/python/paddle/fluid/tests/unittests/test_gradient_clip.py
+++ b/python/paddle/fluid/tests/unittests/test_gradient_clip.py
@@ -1,10 +1,10 @@
-#  Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ import six
 from fake_reader import fake_imdb_reader
 
 
-def bow_net(data,
+def bow_net(words,
             label,
             dict_dim,
             emb_dim=128,
@@ -36,7 +36,7 @@ def bow_net(data,
     fluid/PaddleNLP/text_classification/nets.py
     """
     emb = fluid.layers.embedding(
-        input=data, is_sparse=True, size=[dict_dim, emb_dim])
+        input=words, is_sparse=True, size=[dict_dim, emb_dim])
     bow = fluid.layers.sequence_pool(input=emb, pool_type='sum')
     bow_tanh = fluid.layers.tanh(bow)
     fc_1 = fluid.layers.fc(input=bow_tanh, size=hid_dim, act="tanh")
@@ -54,26 +54,32 @@ class TestGradientClip(unittest.TestCase):
         self.BATCH_SIZE = 2
         reader = fake_imdb_reader(self.word_dict_len, self.BATCH_SIZE * 100)
         self.train_data = paddle.batch(reader, batch_size=self.BATCH_SIZE)
+        self.init()
+
+    def init(self):
+        pass
 
     def get_places(self):
-        places = [core.CPUPlace()]
+        places = [fluid.CPUPlace()]
         if core.is_compiled_with_cuda():
-            places.append(core.CUDAPlace(0))
+            places.append(fluid.CUDAPlace(0))
         return places
 
-    def check_operators(self, place):
-        CLIP = 1
+    def gradient_clip(self, params_grads):
+        pass
 
-        prog = fluid.framework.Program()
-        startup_program = fluid.framework.Program()
+    def check_output(self, out, out_clip):
+        pass
+
+    def check_gradient_clip(self, place):
+        prog = fluid.Program()
+        startup_program = fluid.Program()
         with fluid.program_guard(
                 main_program=prog, startup_program=startup_program):
-            image = fluid.layers.data(name='x', shape=[784], dtype='float32')
-            label = fluid.layers.data(name='y', shape=[1], dtype='int64')
-
-            hidden1 = fluid.layers.fc(input=image, size=128, act='relu')
-            hidden2 = fluid.layers.fc(input=hidden1, size=64, act='relu')
-            predict = fluid.layers.fc(input=hidden2, size=10, act='softmax')
+            image = fluid.data(name='x', shape=[-1, 784], dtype='float32')
+            label = fluid.data(name='y', shape=[-1, 1], dtype='int64')
+            hidden = fluid.layers.fc(input=image, size=64, act='relu')
+            predict = fluid.layers.fc(input=hidden, size=10, act='softmax')
 
             cost = fluid.layers.cross_entropy(input=predict, label=label)
             avg_cost = fluid.layers.mean(cost)
@@ -84,78 +90,395 @@ class TestGradientClip(unittest.TestCase):
         p_g = fluid.backward.append_backward(loss=avg_cost)
         p_g_clip = fluid.backward.append_backward(loss=avg_cost_clip)
 
+        p_g = sorted(p_g, key=lambda x: x[0].name)
+        p_g_clip = sorted(p_g_clip, key=lambda x: x[0].name)
         with fluid.program_guard(
                 main_program=prog_clip, startup_program=startup_program):
-            fluid.clip.set_gradient_clip(
-                fluid.clip.GradientClipByGlobalNorm(clip_norm=CLIP))
-            p_g_clip = fluid.clip.append_gradient_clip_ops(p_g_clip)
+            p_g_clip = self.gradient_clip(p_g_clip)
 
         grad_list = [elem[1] for elem in p_g]
         grad_clip_list = [elem[1] for elem in p_g_clip]
 
-        train_reader = paddle.batch(
-            paddle.reader.shuffle(
-                paddle.dataset.mnist.train(), buf_size=8192),
-            batch_size=128)
-
+        train_reader = paddle.batch(paddle.dataset.mnist.train(), batch_size=5)
         exe = fluid.Executor(place)
         feeder = fluid.DataFeeder(feed_list=[image, label], place=place)
         exe.run(startup_program)
 
-        count = 0
-        for data in train_reader():
-            count += 1
-            if count > 5:
-                break
-            out = exe.run(prog, feed=feeder.feed(data), fetch_list=grad_list)
-            out_clip = exe.run(prog_clip,
-                               feed=feeder.feed(data),
-                               fetch_list=grad_clip_list)
-            global_norm = 0
-            for v in out:
-                global_norm += np.sum(np.power(v, 2))
-            global_norm = np.sqrt(global_norm)
+        data = next(train_reader())
+        out = exe.run(prog, feed=feeder.feed(data), fetch_list=grad_list)
+        out_clip = exe.run(prog_clip,
+                           feed=feeder.feed(data),
+                           fetch_list=grad_clip_list)
+        self.check_output(out, out_clip)
 
-            global_norm_clip = 0
-            for v in out_clip:
-                global_norm_clip += np.sum(np.power(v, 2))
-            global_norm_clip = np.sqrt(global_norm_clip)
+    def backward_and_optimize(cost):
+        pass
 
-            assert np.isclose(
-                a=global_norm_clip, b=np.minimum(global_norm, CLIP), rtol=5e-3)
-
-    def check_sparse_gradient_clip(self, place):
-        prog = fluid.framework.Program()
-        startup_program = fluid.framework.Program()
+    def check_with_optimize(self, place):
+        prog = fluid.Program()
+        startup_program = fluid.Program()
         with fluid.program_guard(
                 main_program=prog, startup_program=startup_program):
-            data = fluid.layers.data(
-                name="words", shape=[1], dtype="int64", lod_level=1)
-            label = fluid.layers.data(name="label", shape=[1], dtype="int64")
-            cost = bow_net(data, label, self.word_dict_len)
-
-            fluid.clip.set_gradient_clip(
-                clip=fluid.clip.GradientClipByGlobalNorm(clip_norm=5.0))
-
-            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.01)
-            sgd_optimizer.minimize(cost)
+            words = fluid.data(
+                name="words", shape=[-1, 1], dtype="int64", lod_level=1)
+            label = fluid.data(name="label", shape=[-1, 1], dtype="int64")
+            cost = bow_net(words, label, self.word_dict_len)
+            self.backward_and_optimize(cost)
 
         exe = fluid.Executor(place)
-        feeder = fluid.DataFeeder(feed_list=[data, label], place=place)
+        feeder = fluid.DataFeeder(feed_list=[words, label], place=place)
         exe.run(startup_program)
 
         data = next(self.train_data())
         val = exe.run(prog, feed=feeder.feed(data), fetch_list=[cost])[0]
-        self.assertEqual((1, ), val.shape)
-        print(val)
-        self.assertFalse(np.isnan(val))
+        self.assertEqual((1, ), val.shape, "the shape of loss is not [1]")
+        self.assertFalse(np.isnan(val), "the loss of network is nan")
 
-    def test_operators(self):
-        self.check_operators(core.CPUPlace())
 
-    def test_sparse_gradient_clip(self):
+class TestGradientClipByGlobalNorm(TestGradientClip):
+    def init(self):
+        self.clip_norm = 1.0
+
+    def check_output(self, out, out_clip):
+        global_norm = 0
+        for v in out:
+            global_norm += np.sum(np.power(v, 2))
+        global_norm = np.sqrt(global_norm)
+
+        global_norm_clip = 0
+        for v in out_clip:
+            global_norm_clip += np.sum(np.power(v, 2))
+        global_norm_clip = np.sqrt(global_norm_clip)
+
+        a = np.minimum(global_norm, self.clip_norm)
+        b = global_norm_clip
+        self.assertTrue(
+            np.isclose(
+                a=a, b=b, rtol=1e-5, atol=1e-8),
+            "gradient clip by global norm has wrong results, expetcd:%f, but recieved:%f"
+            % (a, b))
+
+    # test whether the ouput is right when use set_gradient_clip
+    def test_old_gradient_clip(self):
+        def func(params_grads):
+            clip = fluid.clip.GradientClipByGlobalNorm(clip_norm=self.clip_norm)
+            fluid.clip.set_gradient_clip(clip)
+            return fluid.clip.append_gradient_clip_ops(params_grads)
+
+        self.gradient_clip = func
+        self.check_gradient_clip(fluid.CPUPlace())
+
+    # test whether the ouput is right when use minimize(grad_clip)
+    def test_new_gradient_clip(self):
+        def func(params_grads):
+            clip = fluid.GradClipByGlobalNorm(clip_norm=self.clip_norm)
+            print(clip)
+            return clip(params_grads)
+
+        self.gradient_clip = func
+        self.check_gradient_clip(fluid.CPUPlace())
+
+    # test minimize and only clip a part of parameter
+    def test_gradient_clip_with_optimize(self):
+        def backward_func(cost):
+            # only clip gradient of fc_0.w_0 (Parameter)
+            def fileter_func(param):
+                return param.name == "fc_0.w_0"
+
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            clip = fluid.GradClipByGlobalNorm(
+                clip_norm=self.clip_norm, need_clip=fileter_func)
+            sgd_optimizer.minimize(cost, grad_clip=clip)
+
+        self.backward_and_optimize = backward_func
         for place in self.get_places():
-            self.check_sparse_gradient_clip(place)
+            self.check_with_optimize(place)
+
+    # use 'set_gradient_clip' after 'minimize', and 'set_gradient_clip' will be ineffective
+    def test_wrong_gradient_clip_1(self):
+        def backward_func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            clip = fluid.clip.GradientClipByGlobalNorm(clip_norm=self.clip_norm)
+            # ParamAttr will not support gradient_clip
+            param_attr = fluid.ParamAttr(gradient_clip=clip)
+            sgd_optimizer.minimize(cost)
+            fluid.clip.set_gradient_clip(clip)
+
+        self.backward_and_optimize = backward_func
+        self.check_with_optimize(fluid.CPUPlace())
+
+    # use 'set_gradient_clip' and 'minimize(grad_clip)' together, and 'set_gradient_clip' will be ineffective
+    def test_wrong_gradient_clip_2(self):
+        def backward_func(cost):
+            sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+            clip1 = fluid.clip.GradientClipByGlobalNorm(
+                clip_norm=self.clip_norm)
+            fluid.clip.set_gradient_clip(clip1)
+            clip2 = fluid.GradClipByNorm(clip_norm=self.clip_norm)
+            sgd_optimizer.minimize(cost, grad_clip=clip2)
+
+        self.backward_and_optimize = backward_func
+        self.check_with_optimize(fluid.CPUPlace())
+
+    # if grad is None
+    def test_wrong_gradient_clip_3(self):
+        clip = fluid.GradClipByGlobalNorm(clip_norm=self.clip_norm)
+        x = fluid.default_main_program().global_block().create_parameter(
+            shape=[2, 3], dtype="float32")
+        clip([(x, None), (x, x)])
+        clip([(x, None)])
+
+    # if minimize(grad_clip) is not an instance of GradientClipBase's derived class
+    def test_wrong_gradient_clip_4(self):
+        sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+        recompute_optimizer = fluid.optimizer.RecomputeOptimizer(sgd_optimizer)
+        x = fluid.default_main_program().global_block().create_parameter(
+            name="x", shape=[2, 3], dtype="float32")
+        loss = fluid.layers.reduce_mean(x)
+        try:
+            sgd_optimizer.minimize(loss, grad_clip=loss)
+        except AssertionError:
+            print(
+                "AssertionError: 'grad_clip' should be an instance of GradientClipBase's derived class"
+            )
+        recompute_optimizer._set_checkpoints([x])
+        recompute_optimizer.minimize(loss, grad_clip=fluid.GradClipByNorm(1.0))
+        try:
+            clip = fluid.GradClipByGlobalNorm(
+                clip_norm=self.clip_norm, need_clip=loss)
+        except TypeError:
+            print(
+                "TypeError: The type of need_clip must be funciton, and it can filter "
+                "out parameter that does't need gradient clip, please refer to "
+                "API documention of GradClipByGlobalNorm/GradClipByValue/"
+                "GradClipByNorm!")
+
+
+class TestGradientClipByNorm(TestGradientClip):
+    def init(self):
+        self.clip_norm = 1.0
+
+    def check_output(self, out, out_clip):
+        self.assertTrue(
+            len(out) == len(out_clip),
+            "Number of gradient changed after clipping, before clip:%d, after clip:%d"
+            % (len(out), len(out_clip)))
+        for u, v in zip(out, out_clip):
+            a = np.sqrt(np.sum(np.power(u, 2)))
+            a = np.minimum(a, self.clip_norm)
+            b = np.sqrt(np.sum(np.power(v, 2)))
+            self.assertTrue(
+                np.isclose(
+                    a=a, b=b, rtol=1e-5, atol=1e-8),
+                "gradient clip by norm has wrong results, expetcd:%f, but recieved:%f"
+                % (a, b))
+
+    def gradient_clip(self, params_grads):
+        clip = fluid.GradClipByNorm(clip_norm=self.clip_norm)
+        print(clip)
+        return clip(params_grads)
+
+    # test whether the ouput is right when use minimize(grad_clip)
+    def test_new_gradient_clip(self):
+        self.check_gradient_clip(fluid.CPUPlace())
+
+    def backward_and_optimize(self, cost):
+        # not clip gradient of fc_18.w_0 (Parameter)
+        def fileter_func(param):
+            return param.name != "fc_18.w_0"
+
+        sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+        clip = fluid.GradClipByNorm(
+            clip_norm=self.clip_norm, need_clip=fileter_func)
+        sgd_optimizer.minimize(cost, grad_clip=clip)
+
+    # test minimize and only clip a part of parameter
+    def test_gradient_clip_with_optimize(self):
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+    # if grad is None
+    def test_wrong_gradient_clip(self):
+        clip = fluid.GradClipByNorm(clip_norm=self.clip_norm)
+        x = fluid.default_main_program().global_block().create_var(
+            shape=[2, 3], dtype="float32")
+        clip([(x, None)])
+
+
+class TestGradientClipByValue(TestGradientClip):
+    def init(self):
+        self.max = 1.0
+        self.min = 0.1
+
+    def check_output(self, out, out_clip):
+        for i, v in enumerate(out):
+            out[i] = np.clip(v, self.min, self.max)
+
+        self.assertTrue(
+            len(out) == len(out_clip),
+            "Number of gradient changed after clipping, before clip:%d, after clip:%d"
+            % (len(out), len(out_clip)))
+        for u, v in zip(out, out_clip):
+            self.assertTrue(
+                np.allclose(
+                    a=u, b=v, rtol=1e-6, atol=1e-8),
+                "gradient clip by value has wrong results")
+
+    def gradient_clip(self, params_grads):
+        clip = fluid.GradClipByValue(min_value=self.min, max_value=self.max)
+        print(clip)
+        return clip(params_grads)
+
+    # test whether the ouput is right when use minimize(grad_clip)
+    def test_new_gradient_clip(self):
+        self.check_gradient_clip(fluid.CPUPlace())
+
+    def backward_and_optimize(self, cost):
+        # not clip gradient of fc_24.w_0 (Parameter)
+        def fileter_func(param):
+            return param.name != "fc_24.w_0"
+
+        sgd_optimizer = fluid.optimizer.SGD(learning_rate=0.1)
+        clip = fluid.GradClipByValue(
+            min_value=self.min, max_value=self.max, need_clip=fileter_func)
+        sgd_optimizer.minimize(cost, grad_clip=clip)
+
+    # test minimize and only clip a part of parameter
+    def test_gradient_clip_with_optimize(self):
+        for place in self.get_places():
+            self.check_with_optimize(place)
+
+    # if grad is None
+    def test_wrong_gradient_clip(self):
+        clip = fluid.GradClipByValue(-1, 1)
+        x = fluid.default_main_program().global_block().create_var(
+            shape=[2, 3], dtype="float32")
+        clip([(x, None)])
+
+
+class TestDygraphGradientClip(unittest.TestCase):
+    def setUp(self):
+        # only clip gradient of linear_1.w_0 (ParamBase)
+        def fileter_func(param):
+            return param.name == "linear_1.w_0"
+
+        self.clip_norm = 1.0
+        self.clip = fluid.GradClipByGlobalNorm(
+            clip_norm=self.clip_norm, need_clip=fileter_func)
+
+    def test_gradient_clip(self):
+        with fluid.dygraph.guard():
+            linear = fluid.dygraph.Linear(10, 10)
+            inputs = fluid.layers.uniform_random([32, 10]).astype('float32')
+            out = linear(fluid.dygraph.to_variable(inputs))
+            loss = fluid.layers.reduce_mean(out)
+            loss.backward()
+            sgd_optimizer = fluid.optimizer.SGD(
+                learning_rate=0.1, parameter_list=linear.parameters())
+            self.check_output(loss, sgd_optimizer)
+
+    def check_output(self, loss, optimizer):
+        optimizer.minimize(loss, grad_clip=self.clip)
+        self.assertEqual((1, ),
+                         loss.numpy().shape, "the shape of loss is not [1]")
+        self.assertFalse(
+            np.isnan(loss.numpy()), "the loss of dygraph network is nan")
+
+
+class TestDygraphGradientClipByGlobalNorm(TestDygraphGradientClip):
+    def setUp(self):
+        self.clip_norm = 1.0
+        self.clip = fluid.GradClipByGlobalNorm(clip_norm=self.clip_norm)
+
+    def check_output(self, loss, optimizer):
+        # if grad is None
+        self.clip([(fluid.dygraph.to_variable(np.array([2, 3])), None)])
+
+        params_grads = optimizer.backward(loss)
+        _, grads = zip(*params_grads)
+        params_grads = self.clip(params_grads)
+        _, grads_clip = zip(*params_grads)
+
+        global_norm = 0
+        for v in grads:
+            v = v.numpy()
+            global_norm += np.sum(np.power(v, 2))
+        global_norm = np.sqrt(global_norm)
+
+        global_norm_clip = 0
+        for v in grads_clip:
+            v = v.numpy()
+            global_norm_clip += np.sum(np.power(v, 2))
+        global_norm_clip = np.sqrt(global_norm_clip)
+
+        a = np.minimum(global_norm, self.clip_norm)
+        b = global_norm_clip
+        self.assertTrue(
+            np.isclose(
+                a=a, b=b, rtol=1e-6, atol=1e-8),
+            "gradient clip by global norm has wrong results, expetcd:%f, but recieved:%f"
+            % (a, b))
+
+
+class TestDygraphGradientClipByNorm(TestDygraphGradientClip):
+    def setUp(self):
+        # only clip gradient of linear_0.w_0 (ParamBase)
+        def fileter_func(param):
+            return param.name == "linear_0.w_0"
+
+        self.clip_norm = 1.0
+        self.clip = fluid.GradClipByNorm(
+            clip_norm=self.clip_norm, need_clip=fileter_func)
+
+    def check_output(self, loss, optimizer):
+        # if grad is None
+        self.clip([(fluid.dygraph.to_variable(np.array([2, 3])), None)])
+
+        params_grads = optimizer.backward(loss)
+        _, grads = zip(*params_grads)
+        params_grads = self.clip(params_grads)
+        _, grads_clip = zip(*params_grads)
+
+        for u, v in zip(grads, grads_clip):
+            u = u.numpy()
+            v = v.numpy()
+            a = np.sqrt(np.sum(np.power(u, 2)))
+            a = np.minimum(a, self.clip_norm)
+            b = np.sqrt(np.sum(np.power(v, 2)))
+            self.assertTrue(
+                np.isclose(
+                    a=a, b=b, rtol=1e-6, atol=1e-8),
+                "gradient clip by norm has wrong results, expetcd:%f, but recieved:%f"
+                % (a, b))
+
+
+class TestDygraphGradientClipByValue(TestDygraphGradientClip):
+    def setUp(self):
+        # only clip gradient of linear_0.w_0 (ParamBase)
+        def fileter_func(param):
+            return param.name == "linear_0.w_0"
+
+        self.max = 1.0
+        self.min = 0.1
+        self.clip = fluid.GradClipByValue(
+            min_value=self.min, max_value=self.max, need_clip=fileter_func)
+
+    def check_output(self, loss, optimizer):
+        # if grad is None
+        self.clip([(fluid.dygraph.to_variable(np.array([2, 3])), None)])
+
+        params_grads = optimizer.backward(loss)
+        _, grads = zip(*params_grads)
+        params_grads = self.clip(params_grads)
+        _, grads_clip = zip(*params_grads)
+
+        for u, v in zip(grads, grads_clip):
+            a = np.clip(u.numpy(), self.min, self.max)
+            b = v.numpy()
+            self.assertTrue(
+                np.allclose(
+                    a=a, b=b, rtol=1e-6, atol=1e-8),
+                "gradient clip by value has wrong results!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
当前问题
-------------
当前的梯度裁剪API `set_gradient_clip` 存在一些问题，因为 `set_gradient_clip` 是一个隐式地API，其本质是设置一个参数的属性，然后在`minimize中`操作该属性来生效，因而对位置的要求很高。

- **问题1**：set_gradient_clip必须位于minimize之前，否则不会生效。
- **问题2**：set_gradient_clip必须位于组网之后，否则此时参数未更新，也不会生效。
- **问题3**：set_gradient_clip会重置掉ParamAttr所设的值，导致ParamAttr的grad_clip_attr失效。
而且这些问题对用户不会有提醒。

新方案的要点为：
----------

1. 动态图与静态图统一成一套接口，均在`minimize`中传入`grad_clip`参数进行裁剪；
2. 部分参数裁剪的功能：给`GradClipByGlobalNorm`实例对象初始化时，给`need_clip`参数传入一个有过滤功能的函数，其返回True或False；
3. 兼容设计：兼容老接口`set_gradient_clip`，新接口优先级高于旧接口，同时添加了`set_gradient_clip`错误使用时的报错信息；

全部参数的裁剪
-------------
提供三个class，分别对应三种梯度裁剪：
```
fluid.GradClipByGlobalNorm(clip_norm,need_clip=None)
fluid.GradClipByNorm(clip_norm,need_clip=None)
fluid.GradClipByValue(min_value,max_value,need_clip=None)
```

在minimize中传入一个clip对象，会根据clip的class类型来裁剪全部的参数
```
loss.backward()  # 动态图需要这一行，静态图不需要
clip = fluid.GradClipByGlobalNorm(clip_norm=1.0)
sgd_optimize.minimize(loss, grad_clip=clip)
```

部分参数的裁剪
------------
只裁剪一部分参数的需求。该需求一般用的较少，如果需要时，可在定义clip对象时，传入一个function给need_clip参数，该function返回True或False
```
 # 过滤函数，返回True or False
def func(param)
    return param.name == "linear_0.w_0"（True表示需要裁剪，False表示不需要裁剪）
	
loss.backward()  # 动态图需要这一行，静态图不需要
clip = fluid.GradClipByGlobalNorm(clip_norm=1.0, need_clip=func)
sgd_optimize.minimize(loss, grad_clip=clip)
```

新旧兼容
-------------
- 老接口`set_gradient_clip`继续保留，但新接口`minimize(grad_clip=clip)`优先级高于老接口(`set_gradient_clip`)，一旦发现两套接口重复使用，则会屏蔽`set_gradient_clip`的所有操作并打出warning
- 老接口`set_gradient_clip`单独使用时，须位于`minimize`之前，如果顺序错误，也会打出warning

接口删除
------------

仅删除：fluid.ParamAttr(仅gradient_clip属性)，不再对用户暴露
