### PR TITLE
Feature/add L1Loss

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -29,6 +29,7 @@ except ImportError:
 import paddle.reader
 import paddle.dataset
 import paddle.batch
+import paddle.nn
 import paddle.compat
 import paddle.distributed
 batch = batch.batch

--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -379,9 +379,12 @@ def l1_loss(input, label, reduction='mean'):
             float64, int32, int64.
         label (Variable): Label tensor, the data type is float32,
             float64, int32, int64.
-        reduction (str, optional): Indicate how to average the loss by batch_size.
-            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; If :attr:`size_average` is ``'sum'``,
-            the reduced sum loss is returned. Default is ``'None'``, the unreduced loss is returned.
+        reduction (str, optional): Indicate how to average the loss by batch_size, 
+            the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; 
+            If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned. 
+            If :attr:`reduction` is ``'none'``, the unreduced loss is returned. 
+            Default is ``'sum'``.
     Returns:
         The tensor variable storing the l1_loss of input and label.
 
@@ -419,6 +422,11 @@ def l1_loss(input, label, reduction='mean'):
                 output = fluid.layers.l1_loss(input, label)
                 print(output.numpy())  # [0.2]
     """
+    if not in_dygraph_mode():
+        check_variable_and_dtype(
+            input, 'input', ['float32', 'float64', 'int32', 'int64'], 'l1_loss')
+        check_variable_and_dtype(
+            label, 'label', ['float32', 'float64', 'int32', 'int64'], 'l1_loss')
 
     if reduction not in ['sum', 'mean', 'none']:
         raise ValueError(

--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -349,7 +349,7 @@ def square_error_cost(input, label):
     return square_out
 
 
-def l1_loss(input, label, size_average=None, reruce=None, reduction='mean'):
+def l1_loss(input, label, reduction='mean'):
     """
     This op accepts input predictions and target label and returns the
     mean absolute error.
@@ -375,8 +375,10 @@ def l1_loss(input, label, size_average=None, reruce=None, reduction='mean'):
         Out = SUM(|input - label|)
 
     Parameters:
-        input (Variable): Input tensor, the data type should be float32.
-        label (Variable): Label tensor, the data type should be float32.
+        input (Variable): Input tensor, the data type is float32,
+            float64, int32, int64.
+        label (Variable): Label tensor, the data type is float32,
+            float64, int32, int64.
         reduction (str, optional): Indicate how to average the loss by batch_size.
             If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; If :attr:`size_average` is ``'sum'``,
             the reduced sum loss is returned. Default is ``'None'``, the unreduced loss is returned.
@@ -389,36 +391,33 @@ def l1_loss(input, label, size_average=None, reruce=None, reduction='mean'):
 
         .. code-block:: python
 
-	    # declarative mode
-	    import paddle.fluid as fluid
-	    import numpy as np
-	    input = fluid.data(name="input", shape=[1])
-	    label = fluid.data(name="label", shape=[1])
-	    output = fluid.layers.l1_loss(input,label)
-	    place = fluid.CPUPlace()
-	    exe = fluid.Executor(place)
-	    exe.run(fluid.default_startup_program())
- 
-	    input_data = np.array([1.5]).astype("float32")
-	    label_data = np.array([1.7]).astype("float32")
-	    output_data = exe.run(fluid.default_main_program(),
-                feed={"input":input_data, "label":label_data},
-                fetch_list=[output],
-                return_numpy=True)
- 
-	    print(output_data)
-	    # [array([0.2], dtype=float32)]
-	    
-	    # imperative mode
-	    import paddle.fluid.dygraph as dg
+            # declarative mode
+            import paddle.fluid as fluid
+            import numpy as np
+            input = fluid.data(name="input", shape=[1])
+            label = fluid.data(name="label", shape=[1])
+            output = fluid.layers.l1_loss(input,label)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+    
+            input_data = np.array([1.5]).astype("float32")
+            label_data = np.array([1.7]).astype("float32")
+            output_data = exe.run(fluid.default_main_program(),
+                    feed={"input":input_data, "label":label_data},
+                    fetch_list=[output],
+                    return_numpy=True)
+    
+            print(output_data)  # [array([0.2], dtype=float32)]
+            
+            # imperative mode
+            import paddle.fluid.dygraph as dg
 
-	    with dg.guard(place) as g:
-    		input = dg.to_variable(input_data)
-    		label = dg.to_variable(label_data)
-    		output = fluid.layers.l1_loss(input, label)
-        print(output.numpy())
-	        
-	        # [0.2]
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_data)
+                label = dg.to_variable(label_data)
+                output = fluid.layers.l1_loss(input, label)
+                print(output.numpy())  # [0.2]
     """
 
     if reduction not in ['sum', 'mean', 'none']:

--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -377,13 +377,6 @@ def l1_loss(input, label, size_average=None, reruce=None, reduction='mean'):
     Parameters:
         input (Variable): Input tensor, the data type should be float32.
         label (Variable): Label tensor, the data type should be float32.
-        size_average (bool, optional): Indicate how to average the loss by batch_size.
-            If :attr:`size_average` is ``'True'``, the reduced mean loss is returned; If :attr:`size_average` is ``'False'``,
-            the reduced sum loss is returned. Default is ``'None'``, the unreduced loss is returned.
-            :attr:`size_average` is deprecated, please use :attr:`reduction` instead.
-        reduce (bool, optional): Indicate whether to reduce the loss or not.
-            If :attr:`reduce` is ``'True'``, the loss is reduced (by sum or mean accroding to :attr:`size_average`); 
-            Default is ``'None'``, the unreduced loss is returned.  :attr:`reduce` is deprecated, please use :attr:`reduction` instead.
         reduction (str, optional): Indicate how to average the loss by batch_size.
             If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; If :attr:`size_average` is ``'sum'``,
             the reduced sum loss is returned. Default is ``'None'``, the unreduced loss is returned.
@@ -423,27 +416,15 @@ def l1_loss(input, label, size_average=None, reruce=None, reduction='mean'):
     		input = dg.to_variable(input_data)
     		label = dg.to_variable(label_data)
     		output = fluid.layers.l1_loss(input, label)
-    		print(output.numpy())
+        print(output.numpy())
 	        
 	        # [0.2]
     """
 
-    def determine_reduction():
-        if reduction in ['sum', 'mean', 'none']:
-            return reduction
-        if size_average is None:
-            size_average = True
-        if reduce is None:
-            reduce = True
-        if size_average and reduce:
-            reduction = 'mean'
-        elif reduce:
-            reduction = 'sum'
-        else:
-            reduction = 'none'
-        return reduction
-
-    redution = determine_reduction()
+    if reduction not in ['sum', 'mean', 'none']:
+        raise ValueError(
+            "The value of 'reduction' in l1_loss should be 'sum', 'mean' or 'none', but "
+            "received %s, which is not allowed." % reduction)
 
     unreduced = nn.elementwise_sub(input, label, act='abs')
 

--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+nn package.
+"""
+
+from .loss import *
+
+__all__ = []
+__all__ += loss.__all__

--- a/python/paddle/nn/loss.py
+++ b/python/paddle/nn/loss.py
@@ -44,9 +44,12 @@ class L1Loss(layers.Layer):
         Out = SUM(|input - label|)
 
     Parameters:
-        reduction (str, optional): Indicate how to average the loss by batch_size, the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
-            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; If :attr:`size_average` is ``'sum'``,
-            the reduced sum loss is returned. If :attr:`reduction` is ``'none'``, the unreduced loss is returned. Default is ``'sum'``.
+        reduction (str, optional): Indicate how to average the loss by batch_size, 
+            the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; 
+            If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned. 
+            If :attr:`reduction` is ``'none'``, the unreduced loss is returned. 
+            Default is ``'sum'``.
 
     Returns:
         None

--- a/python/paddle/nn/loss.py
+++ b/python/paddle/nn/loss.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle.fluid.dygraph.layers as layers
+import paddle.fluid.layers.loss as loss
+
+__all__ = ['L1Loss', ]
+
+
+class L1Loss(layers.Layer):
+    """
+    This interface is used to construct a callable object of the ``L1Loss`` class.
+    The L1Loss layer calculates the mean absolute error of input predictions and target label.
+
+    For input predictions label, and target label, the loss is calculated as follows.
+
+    If :attr:`reduction` set to ``'none'``, the unreduced loss is:
+
+    .. math::
+
+        Out = |input - label|
+
+    If :attr:`reduction` set to ``'mean'``, the reduced mean loss is:
+
+    .. math::
+
+        Out = MEAN(|input - label|)
+
+    If :attr:`reduction` set to ``'sum'``, the reduced sum loss is:
+
+    .. math::
+
+        Out = SUM(|input - label|)
+
+    Parameters:
+        reduction (str, optional): Indicate how to average the loss by batch_size, the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; If :attr:`size_average` is ``'sum'``,
+            the reduced sum loss is returned. If :attr:`reduction` is ``'none'``, the unreduced loss is returned. Default is ``'sum'``.
+
+    Returns:
+        None
+
+    Examples:
+        .. code-block:: python
+
+	    # declarative mode
+	    import paddle.fluid as fluid
+        import paddle
+	    import numpy as np
+        l1_loss = paddle.loss.L1Loss()
+	    input = fluid.data(name="input", shape=[1])
+	    label = fluid.data(name="label", shape=[1])
+	    output = l1_loss(input, label)
+	    place = fluid.CPUPlace()
+	    exe = fluid.Executor(place)
+	    exe.run(fluid.default_startup_program())
+    
+	    input_data = np.array([1.5]).astype("float32")
+	    label_data = np.array([1.7]).astype("float32")
+	    output_data = exe.run(fluid.default_main_program(),
+                feed={"input":input_data, "label":label_data},
+                fetch_list=[output],
+                return_numpy=True)
+ 
+	    print(output_data)
+	    # [array([0.2], dtype=float32)]
+	    
+	    # imperative mode
+	    import paddle.fluid.dygraph as dg
+        import paddle
+
+        l1_loss = paddle.loss.L1Loss()
+	    with dg.guard(place) as g:
+    		input = dg.to_variable(input_data)
+    		label = dg.to_variable(label_data)
+    		output = l1_loss(input, label)
+        print(output.numpy())
+	        
+	        # [0.2]
+    """
+
+    def __init__(self, reduction='mean'):
+        super(L1Loss, self).__init__()
+        self.reduction = reduction
+
+    def forward(self, input, label):
+        return loss.l1_loss(input, label, self.reduction)

--- a/python/paddle/nn/loss.py
+++ b/python/paddle/nn/loss.py
@@ -54,40 +54,36 @@ class L1Loss(layers.Layer):
     Examples:
         .. code-block:: python
 
-	    # declarative mode
-	    import paddle.fluid as fluid
-        import paddle
-	    import numpy as np
-        l1_loss = paddle.loss.L1Loss()
-	    input = fluid.data(name="input", shape=[1])
-	    label = fluid.data(name="label", shape=[1])
-	    output = l1_loss(input, label)
-	    place = fluid.CPUPlace()
-	    exe = fluid.Executor(place)
-	    exe.run(fluid.default_startup_program())
+            # declarative mode
+            import paddle.fluid as fluid
+            import numpy as np
+            import paddle
+            input = fluid.data(name="input", shape=[1])
+            label = fluid.data(name="label", shape=[1])
+            l1_loss = paddle.nn.loss.L1Loss(reduction='mean')
+            output = l1_loss(input,label)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
     
-	    input_data = np.array([1.5]).astype("float32")
-	    label_data = np.array([1.7]).astype("float32")
-	    output_data = exe.run(fluid.default_main_program(),
-                feed={"input":input_data, "label":label_data},
-                fetch_list=[output],
-                return_numpy=True)
- 
-	    print(output_data)
-	    # [array([0.2], dtype=float32)]
-	    
-	    # imperative mode
-	    import paddle.fluid.dygraph as dg
-        import paddle
+            input_data = np.array([1.5]).astype("float32")
+            label_data = np.array([1.7]).astype("float32")
+            output_data = exe.run(fluid.default_main_program(),
+                    feed={"input":input_data, "label":label_data},
+                    fetch_list=[output],
+                    return_numpy=True)
+    
+            print(output_data)  # [array([0.2], dtype=float32)]
+            
+            # imperative mode
+            import paddle.fluid.dygraph as dg
 
-        l1_loss = paddle.loss.L1Loss()
-	    with dg.guard(place) as g:
-    		input = dg.to_variable(input_data)
-    		label = dg.to_variable(label_data)
-    		output = l1_loss(input, label)
-        print(output.numpy())
-	        
-	        # [0.2]
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_data)
+                label = dg.to_variable(label_data)
+                l1_loss = paddle.nn.loss.L1Loss(reduction='mean')
+                output = l1_loss(input,label)
+                print(output.numpy())  # [0.2]
     """
 
     def __init__(self, reduction='mean'):

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -106,6 +106,7 @@ write_version_py(filename='@PADDLE_BINARY_DIR@/python/paddle/version.py')
 
 packages=['paddle',
           'paddle.libs',
+          'paddle.nn',
           'paddle.utils',
           'paddle.dataset',
           'paddle.reader',


### PR DESCRIPTION
Add a new public nn API, `paddle.nn.loss.L1Loss(reduction='mean')`.

1. As the form of class.
2. Under module `paddle`directly, instead of `fluid`.
3. The functionality of `L1Loss` is to calculate the L1 loss.

usage:
```
import paddle.fluid as fluid
import paddle
import numpy as np
l1_loss = paddle.nn.loss.L1Loss()
input = fluid.data(name="input", shape=[1])
label = fluid.data(name="label", shape=[1])
output = l1_loss(input, label)
place = fluid.CPUPlace()
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())

input_data = np.array([1.5]).astype("float32")
label_data = np.array([1.7]).astype("float32")
output_data = exe.run(fluid.default_main_program(),
        feed={"input":input_data, "label":label_data},
        fetch_list=[output],
        return_numpy=True)

print(output_data)  # [array([0.2], dtype=float32)]
```