### PR TITLE
Update rnn.py

### DIFF
--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -23,6 +23,7 @@ from . import control_flow
 from . import utils
 from . import sequence_lod
 from .utils import *
+from paddle.fluid import core
 from ..framework import default_main_program
 from ..data_feeder import convert_dtype
 from ..layer_helper import LayerHelper


### PR DESCRIPTION
在rnn.py添加引用core，否则使用lstm模块时报错 NameError: name 'core' is not defined