### PR TITLE
fix bug of ListTransformer in dygraph_to_static

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/list_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/list_transformer.py
@@ -196,6 +196,7 @@ class ListTransformer(gast.NodeTransformer):
             self.list_name_to_updated[target_id] = False
             self.list_nodes.add(node)
             return True
-        elif target_id in self.list_name_to_updated:
+        elif target_id in self.list_name_to_updated and \
+                self.list_name_to_updated[target_id] == False:
             del self.list_name_to_updated[target_id]
         return False

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -56,8 +56,8 @@ def test_list_in_for_loop_with_concat(x, iter_num):
     a = []
     for i in range(iter_num):
         a.append(x)
-    out = fluid.layers.concat(a, axis=0)
-    return out
+    a = fluid.layers.concat(a, axis=0)
+    return a
 
 
 def test_list_in_while_loop(x, iter_num):


### PR DESCRIPTION
Before this PR,  list `a` won't be transformed to LoDTensorArray because `a` is reassigned with a Tensor `fluid.layers.concat(a, axis=0)`. However, `a=[]` should be transformed into `a=fluid.layers.create_array(dtype="float32")`.
```Python
def test_list_in_for_loop_with_concat(x, iter_num):
    x = fluid.dygraph.to_variable(x)
    a = []  # Before this PR, `a=[]` is not transformed
    for i in range(iter_num):
        a.append(x)
    a = fluid.layers.concat(a, axis=0)
    return a
```