### PR TITLE
fix cascade rcnn branch unit test

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
+++ b/python/paddle/fluid/tests/unittests/test_generate_proposal_labels_op.py
@@ -94,6 +94,7 @@ def _sample_rois(rpn_rois, gt_classes, is_crowd, gt_boxes, im_info,
         hs = boxes[:, 3] - boxes[:, 1] + 1
         keep = np.where((ws > 0) & (hs > 0))[0]
         boxes = boxes[keep]
+        max_overlaps = max_overlaps[keep]
         fg_inds = np.where(max_overlaps >= fg_thresh)[0]
         bg_inds = np.where((max_overlaps < bg_thresh_hi) & (max_overlaps >=
                                                             bg_thresh_lo))[0]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48318485/77295322-af8f3300-6d20-11ea-9b1f-8955081fae23.png)
有个bug，在generate_proposal_labels的单测里 =，is_cascade_rcnn这个分支boxes的个数因为keep变少了，但是fg_inds和bg_inds对应的还是原来box的个数中的index，这样可能会导致下标溢出