### PR TITLE
Add parameter(learning_rate) in NoamDecay

### DIFF
--- a/python/paddle/fluid/dygraph/learning_rate_scheduler.py
+++ b/python/paddle/fluid/dygraph/learning_rate_scheduler.py
@@ -526,14 +526,14 @@ class NoamDecay(LearningRateDecay):
             it's a tensor with shape [1] and the data type can be int32 or int64. The type can also be python int.
         warmup_steps(Variable|int): The number of warmup steps. A super parameter. If type is Variable, 
             it's a tensor with shape [1] and the data type can be int32 or int64. The type can also be python int.
-        learning_rate(Variable|float): The initial learning rate. If the type
-            is Variable, it's a tensor with shape [1], the data type can be
-            float32 or float64. It also can be set to python int number. Default 1.0
         begin(int, optional): The begin step. The initial value of global_step described above. The default value is 0.
         step(int, optional): The step size used to calculate the new global_step in the description above.
             The default value is 1.
         dtype(str, optional): The data type used to create the learning rate variable. The data type can be set as
             'float32', 'float64'. The default value is 'float32'.
+        learning_rate(Variable|float|int): The initial learning rate. If the type
+            is Variable, it's a tensor with shape [1], the data type can be
+            float32 or float64. It also can be set to python int number. Default 1.0
 
     Returns:
         None.
@@ -556,10 +556,10 @@ class NoamDecay(LearningRateDecay):
     def __init__(self,
                  d_model,
                  warmup_steps,
-                 learning_rate=1.0,
                  begin=1,
                  step=1,
-                 dtype='float32'):
+                 dtype='float32',
+                 learning_rate=1.0):
         super(NoamDecay, self).__init__(begin, step, dtype)
         self.learning_rate = learning_rate
         self.d_model = d_model

--- a/python/paddle/fluid/layers/learning_rate_scheduler.py
+++ b/python/paddle/fluid/layers/learning_rate_scheduler.py
@@ -49,7 +49,7 @@ def _decay_step_counter(begin=0):
     return global_step
 
 
-def noam_decay(d_model, warmup_steps):
+def noam_decay(d_model, warmup_steps, learning_rate=1.0):
     """
     Noam decay method. The numpy implementation of noam decay as follows.
 
@@ -58,11 +58,12 @@ def noam_decay(d_model, warmup_steps):
       import paddle.fluid as fluid
       import numpy as np
       # set hyper parameters
+      base_lr = 0.01
       d_model = 2
       current_steps = 20
       warmup_steps = 200
       # compute
-      lr_value = np.power(d_model, -0.5) * np.min([
+      lr_value = base_lr * np.power(d_model, -0.5) * np.min([
                               np.power(current_steps, -0.5),
                               np.power(warmup_steps, -1.5) * current_steps])
 
@@ -74,6 +75,9 @@ def noam_decay(d_model, warmup_steps):
 
         warmup_steps(Variable): A super parameter.
 
+        learning_rate(Variable|float): The initial learning rate. It should be a Variable
+                                       or a float, default 1.0
+
     Returns:
         The decayed learning rate.
     Examples:
@@ -84,18 +88,20 @@ def noam_decay(d_model, warmup_steps):
           learning_rate = 0.01
           lr = fluid.layers.learning_rate_scheduler.noam_decay(
                          1/(warmup_steps *(learning_rate ** 2)),
-                         warmup_steps)
+                         warmup_steps,
+                         learning_rate)
     """
     with default_main_program()._lr_schedule_guard():
         if in_dygraph_mode():
-            decay = imperate_lr.NoamDecay(d_model, warmup_steps)
+            decay = imperate_lr.NoamDecay(d_model, warmup_steps, learning_rate)
             return decay
         else:
             global_step = _decay_step_counter(1)
 
             a = global_step**-0.5
             b = (warmup_steps**-1.5) * global_step
-            lr_value = (d_model**-0.5) * nn.elementwise_min(a, b)
+            lr_value = learning_rate * (d_model**-0.5) * nn.elementwise_min(a,
+                                                                            b)
 
             return lr_value
 

--- a/python/paddle/fluid/layers/learning_rate_scheduler.py
+++ b/python/paddle/fluid/layers/learning_rate_scheduler.py
@@ -75,8 +75,9 @@ def noam_decay(d_model, warmup_steps, learning_rate=1.0):
 
         warmup_steps(Variable): A super parameter.
 
-        learning_rate(Variable|float): The initial learning rate. It should be a Variable
-                                       or a float, default 1.0
+        learning_rate(Variable|float|int): The initial learning rate. If the type
+            is Variable, it's a tensor with shape [1], the data type can be
+            float32 or float64. It also can be set to python int number. Default 1.0
 
     Returns:
         The decayed learning rate.
@@ -93,7 +94,8 @@ def noam_decay(d_model, warmup_steps, learning_rate=1.0):
     """
     with default_main_program()._lr_schedule_guard():
         if in_dygraph_mode():
-            decay = imperate_lr.NoamDecay(d_model, warmup_steps, learning_rate)
+            decay = imperate_lr.NoamDecay(
+                d_model, warmup_steps, learning_rate=learning_rate)
             return decay
         else:
             global_step = _decay_step_counter(1)

--- a/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
@@ -140,6 +140,7 @@ class TestLearningRateDecay(unittest.TestCase):
         exe.run(startup_prog)
 
         for step in range(10):
+            # Step of NoamDecay starts from 1.
             if python_decay_fn.__name__ == 'noam_decay':
                 step += 1
             lr_val, = exe.run(main_prog, feed={}, fetch_list=[decayed_lr])
@@ -230,6 +231,9 @@ class TestLinearWamrupLearningRateDecay(TestLearningRateDecay):
         exe.run(startup_prog)
 
         for step in range(20):
+            # Step of NoamDecay starts from 1.
+            if fluid_decay_fn.__name__ == 'noam_decay':
+                step += 1
             lr_val, = exe.run(main_prog, feed={}, fetch_list=[decayed_lr])
             if step < warmup_steps:
                 python_decayed_lr = linear_lr_warmup(

--- a/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
@@ -89,6 +89,34 @@ def cosine_decay(global_step, learning_rate, step_each_epoch, epochs):
     return decayed_lr
 
 
+def noam_decay(global_step, d_model, warmup_steps, learning_rate=1.0):
+    a = math.pow(global_step, -0.5)
+    b = math.pow(warmup_steps, -1.5) * global_step
+    decayed_lr = learning_rate * math.pow(d_model, -0.5) * min(a, b)
+
+    return decayed_lr
+
+
+class TestNoamLearningRateDecayDygraphMode(unittest.TestCase):
+    def test_dygraph_mode(self):
+        with fluid.dygraph.guard():
+            d_model = 0.01
+            warmup_steps = 200
+            learning_rate = 2.0
+            lr = fluid.layers.noam_decay(d_model, warmup_steps, learning_rate)
+            for step in range(5):
+                step += 1
+                right_result = noam_decay(step, d_model, warmup_steps,
+                                          learning_rate)
+                fluid_result = lr()
+
+                self.assertAlmostEqual(
+                    right_result,
+                    fluid_result[0],
+                    msg='Failed lr scheduler in step {0}, Python result is {1}, Fluid result is {2}'.
+                    format(step, right_result, fluid_result[0]))
+
+
 class TestLearningRateDecay(unittest.TestCase):
     def check_decay(self, python_decay_fn, fluid_decay_fn, kwargs):
         places = [fluid.CPUPlace()]
@@ -112,6 +140,8 @@ class TestLearningRateDecay(unittest.TestCase):
         exe.run(startup_prog)
 
         for step in range(10):
+            if python_decay_fn.__name__ == 'noam_decay':
+                step += 1
             lr_val, = exe.run(main_prog, feed={}, fetch_list=[decayed_lr])
             python_decayed_lr = python_decay_fn(
                 global_step=float(step), **kwargs)
@@ -158,6 +188,11 @@ class TestLearningRateDecay(unittest.TestCase):
                 "learning_rate": 0.1,
                 "step_each_epoch": 100,
                 "epochs": 120
+            }),
+            (noam_decay, layers.noam_decay, {
+                "d_model": 0.01,
+                "warmup_steps": 200,
+                "learning_rate": 2.0
             }),
         ]
 


### PR DESCRIPTION
+ Add parameter(learning_rate) in NoamDecay, default 1.0

`NoamDecay` is a strategy for learning rate attenuation which is used in Transformer(See《Attension is all you need》). The calculation of decayed learning rate as follows, and it doesn't dependent on origin `learning_rate` and is only relates with `current_step` and `warmup_steps`.

![image](https://user-images.githubusercontent.com/9301846/77383087-f29ee400-6dbc-11ea-93c0-5e8c9014cf03.png)
![image](https://user-images.githubusercontent.com/9301846/77383199-41e51480-6dbd-11ea-8b89-c699d489d929.png)

But, in some cases, `base_lr` may be applied to multiple the returned valued of `NoamDecay`, just like [`CosineDecay`](https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/dygraph_cn/CosineDecay_cn.html#cosinedecay), [ExponentialDecay](https://www.paddlepaddle.org.cn/documentation/docs/zh/api_cn/dygraph_cn/ExponentialDecay_cn.html#exponentialdecay) and so on.

Unlike `CosineDecay`, the `learning_rate` is not a required parameter because `NoamDecay` doesn't dependent on it. So we set it 1.0 by default which is compatible with the previous usage.

![image](https://user-images.githubusercontent.com/9301846/77396923-98fbe100-6ddf-11ea-9b5b-6d7139da64eb.png)
![image](https://user-images.githubusercontent.com/9301846/77396980-b9c43680-6ddf-11ea-8adb-34c8bb48497b.png)


Zh-CN doc: https://github.com/PaddlePaddle/FluidDoc/pull/1940