### PR TITLE
test=develop, bug fix for ~ListenAndServOP()

### DIFF
--- a/paddle/fluid/operators/distributed_ops/listen_and_serv_op.cc
+++ b/paddle/fluid/operators/distributed_ops/listen_and_serv_op.cc
@@ -87,7 +87,11 @@ ListenAndServOp::ListenAndServOp(const std::string &type,
                                  const framework::AttributeMap &attrs)
     : OperatorBase(type, inputs, outputs, attrs) {}
 
-ListenAndServOp::~ListenAndServOp() { Stop(); }
+ListenAndServOp::~ListenAndServOp() {
+  if (rpc_service_ != nullptr) {
+    Stop();
+  }
+}
 
 void ListenAndServOp::Stop() {
   rpc_service_->ShutDown();

--- a/paddle/fluid/operators/distributed_ops/send_recv_op_test.cc
+++ b/paddle/fluid/operators/distributed_ops/send_recv_op_test.cc
@@ -198,7 +198,6 @@ TEST(SendRecvOp, CPUDense) {
   for (int64_t i = 0; i < target->numel(); ++i) {
     EXPECT_EQ(expected[i] * 2, actual[i]);
   }
-  listen_and_serv_op->Stop();
   server_thread.join();
   listen_and_serv_op.reset(nullptr);
   paddle::operators::ListenAndServOp::ResetPort();
@@ -250,8 +249,7 @@ TEST(SendRecvOp, CPUSparse) {
     EXPECT_EQ(expect_value->mutable_data<float>(place)[i],
               actual->mutable_data<float>(place)[i]);
   }
-  listen_and_serv_op->Stop();
   server_thread.join();
-  listen_and_serv_op.reset();
+  listen_and_serv_op.reset(nullptr);
   paddle::operators::ListenAndServOp::ResetPort();
 }


### PR DESCRIPTION
修复ListenAndServ Op析构函数中rpc_service_指针可能为空的情况，增加条件判断。