### PR TITLE
Polish error Info in while_loop

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1032,7 +1032,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
         if not isinstance(output_vars, (list, tuple)):
             output_vars = [output_vars]
         try:
-            assert_same_structure(output_vars, loop_vars, check_types=True)
+            assert_same_structure(output_vars, loop_vars, check_types=False)
         except ValueError as e:
             raise ValueError(
                 "body in while_loop should return the same arity "

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1034,9 +1034,9 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
         try:
             assert_same_structure(output_vars, loop_vars, check_types=False)
         except ValueError as e:
-            raise ValueError(
-                "body in while_loop should return the same arity "
-                "(length and structure) and types as loop_vars: {0}".format(e))
+            raise ValueError("body in while_loop should return the same arity "
+                             "(length and structure) as loop_vars: {0}".format(
+                                 e))
         now_cond = cond(*output_vars)
         map_structure(assign, output_vars, loop_vars)
         assign(now_cond, pre_cond)

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1031,9 +1031,12 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
             output_vars = body(*loop_vars)
         if not isinstance(output_vars, (list, tuple)):
             output_vars = [output_vars]
-        if len(output_vars) != len(loop_vars):
-            raise ValueError("body in while_loop should return the same arity "
-                             "(length and structure) and types as loop_vars")
+        try:
+            assert_same_structure(output_vars, loop_vars, check_types=True)
+        except ValueError as e:
+            raise ValueError(
+                "body in while_loop should return the same arity "
+                "(length and structure) and types as loop_vars: {0}".format(e))
         now_cond = cond(*output_vars)
         map_structure(assign, output_vars, loop_vars)
         assign(now_cond, pre_cond)


### PR DESCRIPTION
while using`while_loop` in static graph, if  python mutable object like `dict/list/set` is involved in `loop_vars`, the object (or var) shall not add or delete element in `body function`.

In this PR, we add `assert_same_structure` to `check output_vars.`

If a list var add a element in `body function`,  it will raise ValueError as follows:
```python
ValueError: body in while_loop should return the same arity (length and structure) and types as loop_vars: The two structures don't have the same number of elements.

First structure (3 elements): (name: "fill_constant_0.tmp_0"
type {
  type: LOD_TENSOR
  lod_tensor {
    tensor {
      data_type: INT64
      dims: 1
      ......

Second structure (2 elements): [name: "fill_constant_0.tmp_0"
type {
  type: LOD_TENSOR
  lod_tensor {
    tensor {
      data_type: INT64
      dims: 1
      ......

Assertion failed

Process finished with exit code 1
```

