### PR TITLE
Add convert_function_with_cache in dygraph_to_static_func

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -286,7 +286,7 @@ class ProgramTranslator(object):
                 "The decorator 'dygraph_to_static_graph' doesn't work in dygraph mode."
                 " Please use it in static mode.")
             return dygraph_func
-        static_func, ast_transformer = convert_to_static(dygraph_func)
+        static_func = convert_function_with_cache(dygraph_func)
         return static_func
 
     def get_code(self, dygraph_func):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -29,7 +29,7 @@ from paddle.fluid.dygraph.dygraph_to_static.ast_transformer import DygraphToStat
 from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
 from paddle.fluid.framework import in_dygraph_mode
 
-__all__ = ['ProgramTranslator']
+__all__ = ['ProgramTranslator', 'convert_function_with_cache']
 
 
 class FunctionCache(object):
@@ -64,6 +64,19 @@ class FunctionCache(object):
     def exist(self, func):
         return self._dycode_to_static_func.get(
             self._get_dedent_code_string(func), None) is not None
+
+
+_CACHE_LOCK = threading.Lock()
+_FUNCTION_CACHE = FunctionCache()
+
+
+def convert_function_with_cache(dygraph_func):
+    """
+    Transform function of dygraph into static function using the cache mechanism.
+    """
+    with _CACHE_LOCK:
+        static_func = _FUNCTION_CACHE.get_or_cache_func(dygraph_func)
+        return static_func
 
 
 def synchronized(func):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cache_program.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cache_program.py
@@ -21,7 +21,7 @@ from collections import Counter
 import paddle.fluid as fluid
 
 from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
-from paddle.fluid.dygraph.jit import dygraph_to_static_output
+from paddle.fluid.dygraph.dygraph_to_static import convert_function_with_cache
 
 from test_fetch_feed import Pool2D, Linear
 
@@ -109,6 +109,20 @@ class TestCacheProgramWithOptimizer(unittest.TestCase):
             np.allclose(dygraph_loss, static_loss),
             msg='dygraph is {}\n static_res is \n{}'.format(dygraph_loss,
                                                             static_loss))
+
+
+def simple_func(x):
+    inputs = fluid.dygraph.to_variable(x)
+    mean = fluid.layers.mean(inputs)
+    return mean
+
+
+class TestConvertWithCache(unittest.TestCase):
+    def test_cache(self):
+        static_func = convert_function_with_cache(simple_func)
+        # Get transformed function from cache.
+        cached_func = convert_function_with_cache(simple_func)
+        self.assertTrue(id(static_func), id(cached_func))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As the title.

**Example code:**
```python
Class SubNet(fluid.dygraph.Layer):

    @dygraph_to_static_graph
    def forward(self, x)
        return self.fc(x)

Class SubNet(fluid.dygraph.Layer):
    def __init__(self):
        self.fc_net = SubNet()

    @dygraph_to_static_graph
    def forward(self, x)
        # Convert into static_func at first time
        fc_1 = self.fc_net(x)
        
        # Convert into static_func repeatly before this PR.
        # In this PR, here cached static_func will be used.
        fc_2 = self.fc_net(x)
```