### PR TITLE
Fix ut by serial run

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -351,8 +351,6 @@ if (WITH_TESTING)
 endif()
 
 set_tests_properties(test_parallel_executor_test_while_train test_parallel_executor_mnist
-        test_parallel_executor_seresnext_base_gpu test_parallel_executor_seresnext_with_reduce_gpu
-        test_parallel_executor_seresnext_with_fuse_all_reduce_gpu
         test_parallel_executor_feed_persistable_var
         test_buffer_shared_memory_reuse_pass_and_fuse_optimization_op_pass
         test_data_norm_op test_imperative_using_non_zero_gpu test_fuse_bn_act_pass
@@ -362,7 +360,11 @@ set_tests_properties(test_parallel_executor_test_while_train test_parallel_execu
         test_fetch_unmerged
         test_buffer_shared_memory_reuse_pass PROPERTIES LABELS "RUN_TYPE=DIST")
 
-set_tests_properties(test_parallel_executor_crf test_sync_batch_norm_op PROPERTIES LABELS "RUN_TYPE=DIST" RUN_SERIAL TRUE)
+set_tests_properties(test_parallel_executor_crf test_sync_batch_norm_op
+        test_parallel_executor_seresnext_base_gpu
+        test_parallel_executor_seresnext_with_reduce_gpu
+        test_parallel_executor_seresnext_with_fuse_all_reduce_gpu
+        PROPERTIES LABELS "RUN_TYPE=DIST" RUN_SERIAL TRUE)
 
 if(NOT WIN32 AND NOT APPLE)
     set_tests_properties(test_imperative_data_loader_base PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" RUN_SERIAL TRUE)


### PR DESCRIPTION
The following uts consume lots of gpu memory, and may cause other uts fail randomly in Py35 CI. This PR fixes them by serial running:

- test_parallel_executor_seresnext_base_gpu: about 8G gpu memory
- test_parallel_executor_seresnext_with_reduce_gpu: about 4G gpu memory
- test_parallel_executor_seresnext_with_fuse_all_reduce_gpu: about 7G gpu memory