### PR TITLE
support feeding scalar when runing program , test=develop

### DIFF
--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -393,11 +393,13 @@ def _as_lodtensor(data, place, dtype):
                 ndarray to LoDTensor. Please convert data to LoDTensor \
                 directly before feeding the data.\
                 ")
+
     #NOTE(zhiqiu): convert python builtin ,like float and int, to numpy array
     if not isinstance(data, np.ndarray):
-        dtype = convert_dtype(dtype) if isinstance(
-            dtype, core.VarDesc.VarType) else dtype
-        data = np.array(data).astype(dtype)
+        if np.isscalar(data):
+            dtype = convert_dtype(dtype) if isinstance(
+                dtype, core.VarDesc.VarType) else dtype
+            data = np.array([data]).astype(dtype)
 
     # single tensor case
     tensor = core.LoDTensor()
@@ -579,7 +581,6 @@ class Executor(object):
                 var = global_block.var(feed_target_name)
                 if not isinstance(cur_feed, core.LoDTensor):
                     cur_feed = _as_lodtensor(cur_feed, self.place, var.dtype)
-
                 check_feed_shape_type(var, cur_feed)
                 idx = op.desc.attr('col')
                 core.set_feed_variable(scope, cur_feed, feed_var_name, idx)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -634,16 +634,13 @@ class Executor(object):
             feed_tensor_dict = dict()
             for feed_name in feed:
                 feed_tensor = feed[feed_name]
+                var = global_block.var(feed_name)
                 if not isinstance(feed_tensor, core.LoDTensor):
-                    feed_tensor = core.LoDTensor()
                     # always set to CPU place, since the tensor need to be split
                     # it is fast in CPU
-                    assert isinstance( feed[feed_name], np.ndarray ), \
-                        "The input({}) should be numpy.array or Tensor, but not {}.".format(
-                        feed_name, type(feed[feed_name]))
-                    feed_tensor.set(feed[feed_name], core.CPUPlace())
+                    feed_tensor = _as_lodtensor(feed[feed_name],
+                                                core.CPUPlace(), var.dtype)
                 if need_check_feed:
-                    var = global_block.var(feed_name)
                     check_feed_shape_type(var, feed_tensor, exe.device_count())
                 feed_tensor_dict[feed_name] = feed_tensor
 
@@ -657,15 +654,11 @@ class Executor(object):
                 res_dict = dict()
                 for feed_name in each:
                     tensor = each[feed_name]
+                    var = global_block.var(feed_name)
                     if not isinstance(tensor, core.LoDTensor):
-                        tmp = core.LoDTensor()
-                        assert isinstance(each[feed_name], np.ndarray), \
-                            "The input({}) should be numpy.array or Tensor, but not {}.".format(
-                            feed_name, type(each[feed_name]))
-                        tmp.set(tensor, program._places[i])
-                        tensor = tmp
+                        tensor = _as_lodtensor(each[feed_name],
+                                               program._places[i], var.dtype)
                     if need_check_feed:
-                        var = global_block.var(feed_name)
                         check_feed_shape_type(var, tensor)
                     res_dict[feed_name] = tensor
                 res.append(res_dict)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -396,7 +396,8 @@ def _as_lodtensor(data, place, dtype=None):
 
     #NOTE(zhiqiu): convert python builtin ,like float and int, to numpy array
     if not isinstance(data, np.ndarray):
-        if np.isscalar(data) and dtype:
+        if np.isscalar(data):
+            assert dtype is not None, 'dtype should be given when casting python scalar to tensor'
             dtype = convert_dtype(dtype) if isinstance(
                 dtype, core.VarDesc.VarType) else dtype
             data = np.array([data]).astype(dtype)

--- a/python/paddle/fluid/tests/unittests/test_executor_feed_scalar.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_feed_scalar.py
@@ -112,5 +112,23 @@ class TestExecutor(unittest.TestCase):
                 self.assertEqual(type(a), float)
 
 
+class TestAsLodTensor(unittest.TestCase):
+    def test_as_lodtensor_int32(self):
+        cpu = fluid.CPUPlace()
+        tensor = fluid.executor._as_lodtensor(1.0, cpu,
+                                              fluid.core.VarDesc.VarType.INT32)
+        self.assertEqual(tensor._dtype(), fluid.core.VarDesc.VarType.INT32)
+
+    def test_as_lodtensor_fp64(self):
+        cpu = fluid.CPUPlace()
+        tensor = fluid.executor._as_lodtensor(1, cpu,
+                                              fluid.core.VarDesc.VarType.FP64)
+        self.assertEqual(tensor._dtype(), fluid.core.VarDesc.VarType.FP64)
+
+    def test_as_lodtensor_error(self):
+        cpu = fluid.CPUPlace()
+        self.assertRaises(AssertionError, fluid.executor._as_lodtensor, 1, cpu)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_executor_feed_scalar.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_feed_scalar.py
@@ -23,8 +23,7 @@ import paddle.fluid as fluid
 
 class TestExecutor(unittest.TestCase):
     def net(self):
-        lr = fluid.layers.data(
-            name="lr", shape=[1], dtype='float32', append_batch_size=False)
+        lr = fluid.data(name="lr", shape=[1], dtype='float32')
         x = fluid.data(name="x", shape=[None, 1], dtype='float32')
         y = fluid.data(name="y", shape=[None, 1], dtype='float32')
         y_predict = fluid.layers.fc(input=x, size=1, act=None)

--- a/python/paddle/fluid/tests/unittests/test_executor_feed_scalar.py
+++ b/python/paddle/fluid/tests/unittests/test_executor_feed_scalar.py
@@ -1,0 +1,95 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import numpy
+import paddle.fluid.core as core
+import paddle.fluid as fluid
+from test_eager_deletion_padding_rnn import RNNConfig, PaddingRNNTestBase
+
+
+class TestExecutor(unittest.TestCase):
+    def net(self):
+        lr = fluid.layers.data(
+            name="lr", shape=[1], dtype='float32', append_batch_size=False)
+        x = fluid.data(name="x", shape=[None, 1], dtype='float32')
+        y = fluid.data(name="y", shape=[None, 1], dtype='float32')
+        y_predict = fluid.layers.fc(input=x, size=1, act=None)
+
+        cost = fluid.layers.square_error_cost(input=y_predict, label=y)
+        avg_cost = fluid.layers.mean(cost)
+
+        opt = fluid.optimizer.Adam(learning_rate=lr)
+        opt.minimize(avg_cost)
+
+        return lr, avg_cost
+
+    #NOTE(zhiqiu): Historically, Program supports feeding scalar.
+    def test_program_feed_scalar(self):
+        main_program = fluid.Program()
+        startup_program = fluid.Program()
+        scope = fluid.Scope()
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        with fluid.program_guard(main_program, startup_program):
+            with fluid.scope_guard(scope):
+                cpu = fluid.CPUPlace()
+                exe = fluid.Executor(cpu)
+                lr, cost = self.net()
+                exe.run(startup_program)
+                train_data = numpy.array(
+                    [[1.0], [2.0], [3.0], [4.0]]).astype('float32')
+                y_true = numpy.array(
+                    [[2.0], [4.0], [6.0], [8.0]]).astype('float32')
+                _lr, _, _ = exe.run(
+                    feed={'x': train_data,
+                          'y': y_true,
+                          'lr': 0.01},
+                    fetch_list=[lr, cost])
+            self.assertEqual(_lr._dtype(), lr.dtype)
+
+    #NOTE(zhiqiu): CompiledProgram does not support feeding scalar.
+    def test_program_feed_scalar(self):
+        main_program = fluid.Program()
+        startup_program = fluid.Program()
+        scope = fluid.Scope()
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        with fluid.program_guard(main_program, startup_program):
+            with fluid.scope_guard(scope):
+                cpu = fluid.CPUPlace()
+                exe = fluid.Executor(cpu)
+                lr, cost = self.net()
+                compiled_prog = fluid.CompiledProgram(
+                    main_program).with_data_parallel(loss_name=cost.name)
+                exe.run(startup_program)
+                train_data = numpy.array(
+                    [[1.0], [2.0], [3.0], [4.0]]).astype('float32')
+                y_true = numpy.array(
+                    [[2.0], [4.0], [6.0], [8.0]]).astype('float32')
+            self.assertRaises(
+                AssertionError,
+                exe.run,
+                compiled_prog,
+                feed={'x': train_data,
+                      'y': y_true,
+                      'lr': 0.01},
+                fetch_list=[lr, cost])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As the title,
- support feeding python scalar in exe.run,
- set the dtype of tensor fed tensor to the dtype of corresponding variable when feeding scalar.