### PR TITLE
fix rnn import core error

### DIFF
--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -18,6 +18,7 @@ import sys
 from functools import partial, reduce
 
 from . import nn
+from . import core
 from . import tensor
 from . import control_flow
 from . import utils

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -2090,8 +2090,8 @@ def lstm(input,
 
                         Three tensors, rnn_out, last_h, last_c:
 
-                        - rnn_out is result of LSTM hidden, shape is :math:`[seq\_len, batch\_size, hidden\_size]` \
-                          if is_bidirec set to True, shape will be :math:`[seq\_len, batch\_size, hidden\_size*2]`
+                        - rnn_out is result of LSTM hidden, shape is :math:`[batch\_size, seq\_len, hidden\_size]` \
+                          if is_bidirec set to True, shape will be :math:`[batch\_size, seq\_len, hidden\_size*2]`
                         - last_h is the hidden state of the last step of LSTM \
                           shape is :math:`[num\_layers, batch\_size, hidden\_size]` \
                           if is_bidirec set to True, shape will be :math:`[num\_layers*2, batch\_size, hidden\_size]`

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -2124,6 +2124,7 @@ def lstm(input,
             rnn_out.shape  # (-1, 100, 150)
             last_h.shape  # (1, 20, 150)
             last_c.shape  # (1, 20, 150)
+
     """
 
     helper = LayerHelper('cudnn_lstm', **locals())


### PR DESCRIPTION
1. in version 1.7, if not add "import core", error will occur. fix it.

2. the shape of rnn_out in function lstm's description is wrong, fix it