### PR TITLE
fix is_controw_flow bug with `if Tensor.numpy()`

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -148,7 +148,7 @@ def is_candidate_node(node):
     is_compare_node = isinstance(node,
                                  (gast.Compare, gast.BoolOp, gast.UnaryOp))
     # TODO(Aurelius84): `.numpy()` may be an customized function,
-    # and should consider a more elegant way to solve this problem。
+    # and should consider a more elegant way to solve this problem.
     has_numpy_attr = ".numpy()" in ast_to_source_code(node)
     return is_compare_node or has_numpy_attr
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -62,8 +62,6 @@ class IfElseTransformer(gast.NodeTransformer):
         self.after_visit(self.root)
 
     def visit_If(self, node):
-        if 'numpy' not in ast_to_source_code(node):
-            return node
         if_condition_visitor = IfConditionVisitor(node.test,
                                                   self.static_analysis_visitor)
         need_transform = if_condition_visitor.is_control_flow()
@@ -97,15 +95,6 @@ class IfElseTransformer(gast.NodeTransformer):
             return new_node
         else:
             return node
-
-    # def visit_Call(self, node):
-    #     # self.generic_visit(node)
-    #     # Remove `numpy()` statement, like `Tensor.numpy()[i]` -> `Tensor[i]`
-    #     if isinstance(node.func, gast.Attribute):
-    #         attribute = node.func
-    #         if attribute.attr == 'numpy':
-    #             node = attribute.value
-    #     return node
 
     def after_visit(self, node):
         """

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -79,6 +79,14 @@ class IfElseTransformer(gast.NodeTransformer):
         else:
             return node
 
+    def visit_Call(self, node):
+        # Remove `numpy()` statement, like `Tensor.numpy()[i]` -> `Tensor[i]`
+        if isinstance(node.func, gast.Attribute):
+            attribute = node.func
+            if attribute.attr == 'numpy':
+                node = attribute.value
+        return node
+
     def visit_IfExp(self, node):
         """
         Transformation with `true_fn(x) if Tensor > 0 else false_fn(x)`

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -259,8 +259,7 @@ class IsControlFlowVisitor(gast.NodeVisitor):
         return node
 
     def _is_node_with_tensor(self, node, name_id):
-        tensor_types = set(
-            [NodeVarType.TENSOR, NodeVarType.PADDLE_RETURN_TYPES])
+        tensor_types = {NodeVarType.TENSOR, NodeVarType.PADDLE_RETURN_TYPES}
         # Look up the node_var_type_map by name_id.
         if self.node_var_type_map:
             if name_id and isinstance(name_id, six.string_types):
@@ -282,7 +281,9 @@ class IsControlFlowVisitor(gast.NodeVisitor):
 
 
 class NodeTestTransformer(gast.NodeTransformer):
-    def __init__(self, ast_node, compare_nodes_with_tensor=set()):
+    def __init__(self, ast_node, compare_nodes_with_tensor=None):
+        if compare_nodes_with_tensor is None:
+            compare_nodes_with_tensor = set()
         self.ast_root = ast_node
         self._compare_nodes_with_tensor = compare_nodes_with_tensor
         self._new_assign_nodes = []

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -695,16 +695,16 @@ def create_cond_node(return_name_ids,
     original `python if/else` statement.
     """
 
-    def create_lambda_node(func_node, is_if_expr=False):
-        body = func_node
+    def create_lambda_node(func_or_expr_node, is_if_expr=False):
+        body = func_or_expr_node
         if not is_if_expr:
             body = gast.Call(
                 func=gast.Name(
-                    id=func_node.name,
+                    id=func_or_expr_node.name,
                     ctx=gast.Load(),
                     annotation=None,
                     type_comment=None),
-                args=[func_node.args],
+                args=[func_or_expr_node.args],
                 keywords=[])
 
         lambda_node = gast.Lambda(

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -83,7 +83,6 @@ class IfElseTransformer(gast.NodeTransformer):
         """
         Transformation with `true_fn(x) if Tensor > 0 else false_fn(x)`
         """
-        return node
         if_condition_visitor = IfConditionVisitor(node.test,
                                                   self.static_analysis_visitor)
         need_transform = if_condition_visitor.is_control_flow()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -147,6 +147,8 @@ def is_candidate_node(node):
     """
     is_compare_node = isinstance(node,
                                  (gast.Compare, gast.BoolOp, gast.UnaryOp))
+    # TODO(Aurelius84): `.numpy()` may be an customized function,
+    # and should consider a more elegant way to solve this problem。
     has_numpy_attr = ".numpy()" in ast_to_source_code(node)
     return is_compare_node or has_numpy_attr
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -28,28 +28,6 @@ def loss_fn(x, lable):
     return loss
 
 
-def dyfunc_ifExp_with_while(x):
-    y = [x]
-
-    def cond(i, ten, y):
-        return i < ten
-
-    def map_func(func, tensor_list):
-        return [func(x) for x in tensor_list]
-
-    def body(i, ten, y):
-        # It will be converted into `layers.cond` as followed.
-        # map_func(lambda x: fluid.layers.cond(i==0, lambda: x, lambda: add_fn(x), y)
-        y = map_func(lambda x: x if i == 0 else add_fn(x), y)
-        i += 1
-        return [i, ten, y]
-
-    i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
-    ten = fluid.layers.fill_constant(shape=[1], dtype='int64', value=10)
-    i, ten, y = fluid.layers.while_loop(cond, body, [i, ten, y])
-    return y[0]
-
-
 def dyfunc_with_if_else(x_v, label=None):
     if fluid.layers.mean(x_v).numpy()[0] > 5:
         x_v = x_v - 1

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -28,6 +28,28 @@ def loss_fn(x, lable):
     return loss
 
 
+def dyfunc_ifExp_with_while(x):
+    y = [x]
+
+    def cond(i, ten, y):
+        return i < ten
+
+    def map_func(func, tensor_list):
+        return [func(x) for x in tensor_list]
+
+    def body(i, ten, y):
+        # It will be converted into `layers.cond` as followed.
+        # map_func(lambda x: fluid.layers.cond(i==0, lambda: x, lambda: add_fn(x), y)
+        y = map_func(lambda x: x if i == 0 else add_fn(x), y)
+        i += 1
+        return [i, ten, y]
+
+    i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
+    ten = fluid.layers.fill_constant(shape=[1], dtype='int64', value=10)
+    i, ten, y = fluid.layers.while_loop(cond, body, [i, ten, y])
+    return y[0]
+
+
 def dyfunc_with_if_else(x_v, label=None):
     if fluid.layers.mean(x_v).numpy()[0] > 5:
         x_v = x_v - 1
@@ -58,7 +80,8 @@ def nested_if_else(x_v):
     bias = fluid.layers.fill_constant([feat_size], dtype='float32', value=1)
     if x_v.shape[0] != batch_size:
         batch_size = x_v.shape[0]
-    if fluid.layers.mean(x_v).numpy()[0] < 0:
+    # if tensor.shape is [1], now support to compare with numpy.
+    if fluid.layers.mean(x_v).numpy() < 0:
         y = x_v + bias
         w = fluid.layers.fill_constant([feat_size], dtype='float32', value=10)
         if y.numpy()[0] < 10:

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_dict.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_dict.py
@@ -89,7 +89,13 @@ class MainNetWithDict(fluid.dygraph.Layer):
                 dtype='float32',
                 value=0),
         }
-        max_len = input.shape[0] if input.shape[0] != max_len else max_len
+        # TODO(Aurelius84): The following code will be converted into:
+        # max_len = layers.cond(layers.shape(input)[0] != max_len,
+        #                       lambda: layers.shape(input)[0], lambda: max_len)
+        # But max_len should be wrapped into tensor, which is not supported.
+
+        # Comment out this line of code for now.
+        # max_len = input.shape[0] if input.shape[0] != max_len else max_len
         out = input
         for i in range(max_len):
             out = self.sub_net(out, cache)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -84,6 +84,32 @@ class TestDygraphIfElse5(TestDygraphIfElse):
         self.dyfunc = nested_if_else_3
 
 
+def dyfunc_ifExp_with_while(x):
+    y = [x]
+
+    def add_fn(x):
+        x = x + 1
+        return x
+
+    def cond(i, ten, y):
+        return i < ten
+
+    def map_func(func, tensor_list):
+        return [func(x) for x in tensor_list]
+
+    def body(i, ten, y):
+        # It will be converted into `layers.cond` as followed.
+        # map_func(lambda x: fluid.layers.cond(i==0, lambda: x, lambda: add_fn(x), y)
+        y = map_func(lambda x: x if i == 0 else add_fn(x), y)
+        i += 1
+        return [i, ten, y]
+
+    i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
+    ten = fluid.layers.fill_constant(shape=[1], dtype='int64', value=10)
+    i, ten, y = fluid.layers.while_loop(cond, body, [i, ten, y])
+    return y[0]
+
+
 class TestDygraphIfElse6(TestDygraphIfElse):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -84,6 +84,12 @@ class TestDygraphIfElse5(TestDygraphIfElse):
         self.dyfunc = nested_if_else_3
 
 
+class TestDygraphIfElse6(TestDygraphIfElse):
+    def setUp(self):
+        self.x = np.random.random([10, 16]).astype('float32')
+        self.dyfunc = dyfunc_ifExp_with_while
+
+
 class TestDygraphIfElseWithAndOr(TestDygraphIfElse):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse_basic.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse_basic.py
@@ -135,7 +135,15 @@ class TestIsControlFlowIf(unittest.TestCase):
         self.check_false_case("a+b")
 
     def test_expr2(self):
-        self.check_false_case("a + x.numpy()[1]")
+        # x is a Tensor.
+        node = gast.parse("a + x.numpy()")
+        node_test = node.body[0].value
+
+        if_visitor = IfConditionVisitor(node_test)
+        self.assertTrue(if_visitor.is_control_flow())
+        # No transformation will be applied.
+        new_node, assign_nodes = if_visitor.transform()
+        self.assertTrue(len(assign_nodes) == 0)
 
     def test_is_None(self):
         self.check_false_case("x is None")


### PR DESCRIPTION
+ Fix bug with `if tensor.numpy() > 0` that cannot be identified as `isControlFlowIF`
+ Add transformation with `ast.IfExpr`, see example codes as followed.

**Example code:**
```python
# It will be converted into `layers.cond` as followed.
# map_func(lambda x: fluid.layers.cond(i==0, lambda: x, lambda: add_fn(x), y)

y = map_func(lambda x: x if i == 0 else add_fn(x), y)
```