### PR TITLE
simplify the cmake log of ir/CMakeLists.txt

### DIFF
--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -27,7 +27,9 @@ function(pass_library TARGET DEST)
 
     # add more DEST here, such as train, dist and collect USE_PASS into a file automatically.
     if (${DEST} STREQUAL "base" OR ${DEST} STREQUAL "inference")
-        message(STATUS "add pass ${TARGET} ${DEST}")
+        if(NOT CMAKE_BUILD_TYPE STREQUAL "Release")
+            message(STATUS "add pass ${TARGET} ${DEST}")
+        endif()
         file(APPEND ${pass_file} "USE_PASS(${TARGET});\n")
         set(INFER_IR_PASSES ${INFER_IR_PASSES} ${TARGET} CACHE INTERNAL "")
     endif()


### PR DESCRIPTION
As the number of pass becomes bigger, the cmake log has redundancy.
http://10.87.145.41:8081/viewLog.html?tab=buildLog&buildTypeId=Paddle_PrCiCoverage&buildId=306553&_focus=845
```
[14:06:52]	[Step 1/1] -- add pass graph_to_program_pass base
[14:06:52]	[Step 1/1] -- add pass graph_viz_pass base
[14:06:52]	[Step 1/1] -- add pass lock_free_optimize_pass base
[14:06:52]	[Step 1/1] -- add pass fc_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass attention_lstm_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass fc_lstm_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass embedding_fc_lstm_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass fc_gru_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass seq_concat_fc_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass multi_batch_merge_pass base
[14:06:52]	[Step 1/1] -- add pass conv_bn_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass seqconv_eltadd_relu_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass seqpool_concat_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass seqpool_cvm_concat_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass repeated_fc_relu_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass squared_mat_sub_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass is_test_pass base
[14:06:52]	[Step 1/1] -- add pass conv_elementwise_add_act_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass conv_elementwise_add2_act_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass conv_elementwise_add_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass conv_affine_channel_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass transpose_flatten_concat_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass identity_scale_op_clean_pass base
[14:06:52]	[Step 1/1] -- add pass sync_batch_norm_pass base
[14:06:52]	[Step 1/1] -- add pass runtime_context_cache_pass base
[14:06:52]	[Step 1/1] -- add pass quant_conv2d_dequant_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass shuffle_channel_detect_pass inference
[14:06:52]	[Step 1/1] -- add pass delete_quant_dequant_op_pass inference
[14:06:52]	[Step 1/1] -- add pass simplify_with_basic_ops_pass base
[14:06:52]	[Step 1/1] -- add pass fc_elementwise_layernorm_fuse_pass base
[14:06:52]	[Step 1/1] -- add pass skip_layernorm_fuse_pass base
[14:06:52]	[Step 1/1] -- add pass multihead_matmul_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass cudnn_placement_pass base
[14:06:52]	[Step 1/1] -- add pass embedding_eltwise_layernorm_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass mkldnn_placement_pass base
[14:06:52]	[Step 1/1] -- add pass depthwise_conv_mkldnn_pass base
[14:06:52]	[Step 1/1] -- add pass conv_bias_mkldnn_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass conv_activation_mkldnn_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass conv_concat_relu_mkldnn_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass conv_elementwise_add_mkldnn_fuse_pass inference
[14:06:52]	[Step 1/1] -- add pass fc_mkldnn_pass inference
[14:06:52]	[Step 1/1] -- add pass cpu_quantize_placement_pass base
[14:06:52]	[Step 1/1] -- add pass cpu_quantize_pass inference
[14:06:52]	[Step 1/1] -- add pass cpu_quantize_squash_pass inference
```
To simplify the cmake log, this PR doesn't print above log in `Release` mode.