### PR TITLE
 fix NameError: name 'core' is not defined

### DIFF
--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -23,6 +23,7 @@ from . import control_flow
 from . import utils
 from . import sequence_lod
 from .utils import *
+from .. import core
 from ..framework import default_main_program
 from ..data_feeder import convert_dtype
 from ..layer_helper import LayerHelper


### PR DESCRIPTION
paddle.fluid.layers.rnn didn't import core.py