### PR TITLE
fix prune for save_inference_model. test=develop

### DIFF
--- a/paddle/fluid/framework/prune.cc
+++ b/paddle/fluid/framework/prune.cc
@@ -190,16 +190,20 @@ void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
       // For example, in the transformer structure, the third parameter returned
       // by beam_search op is generally assigned to a feed var. Cutting the
       // assign op will cause an error.
-      bool flag = false;
-      for (auto& var : op_desc.outputs()) {
-        for (auto& argu : var.arguments()) {
-          if (feed_var_names.count(argu)) {
-            flag = true;
+      if (parent_block_id != -1) {
+        bool flag = false;
+        for (auto& var : op_desc.outputs()) {
+          for (auto& argu : var.arguments()) {
+            if (feed_var_names.count(argu)) {
+              flag = true;
+            }
           }
         }
-      }
-      if (flag) {
-        should_run.push_back(true);
+        if (flag) {
+          should_run.push_back(true);
+        } else {
+          should_run.push_back(false);
+        }
       } else {
         should_run.push_back(false);
       }

--- a/paddle/fluid/framework/prune.cc
+++ b/paddle/fluid/framework/prune.cc
@@ -186,7 +186,23 @@ void prune_impl(const proto::ProgramDesc& input, proto::ProgramDesc* output,
       }
       should_run.push_back(true);
     } else {
-      should_run.push_back(false);
+      // If the output of an op modifies feed vars, the op should not clip.
+      // For example, in the transformer structure, the third parameter returned
+      // by beam_search op is generally assigned to a feed var. Cutting the
+      // assign op will cause an error.
+      bool flag = false;
+      for (auto& var : op_desc.outputs()) {
+        for (auto& argu : var.arguments()) {
+          if (feed_var_names.count(argu)) {
+            flag = true;
+          }
+        }
+      }
+      if (flag) {
+        should_run.push_back(true);
+      } else {
+        should_run.push_back(false);
+      }
     }
   }
 

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -2902,7 +2902,8 @@ def beam_search_decode(ids, scores, beam_size, end_id, name=None):
     """
     helper = LayerHelper('beam_search_decode', **locals())
     sentence_ids = helper.create_variable_for_type_inference(dtype=ids.dtype)
-    sentence_scores = helper.create_variable_for_type_inference(dtype=ids.dtype)
+    sentence_scores = helper.create_variable_for_type_inference(
+        dtype=scores.dtype)
 
     helper.append_op(
         type="beam_search_decode",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

典型transformer模型中，while内部的beam_serarch op返回的第三个参数 通过layers.assign的方式传给输入int_idx，while的下一次循环中会用到int_idx，原有逻辑会错误的裁掉assign op导致模型出错。


由于无法触发效率云ci，因此关闭此pr，重开新pr  https://github.com/PaddlePaddle/Paddle/pull/25347