### PR TITLE
fix VLOG

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -177,7 +177,7 @@ void OperatorBase::Run(const Scope& scope, const platform::Place& place) {
       RunImpl(scope, place);
     }
 
-    VLOG(3) << place << " " << DebugStringEx(&scope);
+    VLOG(3) << GetExecutionPlace(place) << " " << DebugStringEx(&scope);
   } catch (platform::EnforceNotMet& exception) {
     framework::InsertCallStackInfo(Type(), Attrs(), &exception);
     throw std::move(exception);

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -190,6 +190,11 @@ class OperatorBase {
                                  const platform::Place& place,
                                  const RuntimeContext& ctx) const {}
 
+  virtual platform::Place GetExecutionPlace(
+      const platform::Place& place) const {
+    return place;
+  }
+
  protected:
   std::string type_;
   // NOTE: in case of OpGrad, inputs_ contains:
@@ -506,6 +511,11 @@ class OperatorWithKernel : public OperatorBase {
   virtual OpKernelType GetKernelTypeForVar(
       const std::string& var_name, const Tensor& tensor,
       const OpKernelType& expected_kernel_type) const;
+
+  virtual platform::Place GetExecutionPlace(
+      const platform::Place& platform) const {
+    return kernel_type_->place_;
+  }
 
  private:
   void ParseInputDataType(const ExecutionContext& ctx, const std::string& name,


### PR DESCRIPTION
fix VLOG.
- test code
```python
import paddle.fluid as fluid

data1 = fluid.layers.fill_constant(shape=[1, 3, 8, 8], value=0.5, dtype='float32')
data2 = fluid.layers.fill_constant(shape=[1, 3, 5, 5], value=0.5, dtype='float32')
shape = fluid.layers.shape(data2)
with fluid.device_guard("cpu"):
    shape = fluid.layers.slice(shape, axes=[0], starts=[0], ends=[4])
out = fluid.layers.crop_tensor(data1, shape=shape)

place = fluid.CUDAPlace(0)
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
result = exe.run(fetch_list=[out])
```

- before：place of `expected_kernel_key`  for `slice` op is CPUPlace，but VLOG gives CUDAPlace(0) 
```
8 11:21:30.365912 20538 operator.cc:1066] expected_kernel_key:data_type[int]:data_layout[ANY_LAYOUT]:place[CPUPlace]:library_type[PLAIN]
I0408 11:21:30.366003 20538 operator.cc:180] CUDAPlace(0) Op(slice), inputs:{EndsTensor[], EndsTensorList[], Input[shape_0.tmp_0:int[4]({})], StartsTensor[], StartsTensorList[]}, outputs:{Out[slice_0.tmp_0:int[4]({})]}.
I0408 11:21:30.366035 20538 executor_gc_helper.cc:166] Erase variable shape_0.tmp_0
I0408 11:21:30.366080 20538 operator.cc:1066] expected_kernel_key:data_type[float]:data_layout[ANY_LAYOUT]:place[CUDAPlace(0)]:library_type[PLAIN]
I0408 11:21:30.366216 20538 operator.cc:180] CUDAPlace(0) Op(crop_tensor), inputs:{Offsets[], OffsetsTensor[], Shape[slice_0.tmp_0:int[4]({})], ShapeTensor[], X[fill_constant_0.tmp_0:float[1, 3, 8, 8]({})]}, outputs:{Out[crop_tensor_0.tmp_0:float[1, 3, 5, 5]({})]}.
```
- after：place of `expected_kernel_key`  for `slice` op is CPUPlace，and VLOG gives CPUPlace 
```
8 11:21:30.365912 20538 operator.cc:1066] expected_kernel_key:data_type[int]:data_layout[ANY_LAYOUT]:place[CPUPlace]:library_type[PLAIN]
I0408 11:21:30.366003 20538 operator.cc:180] CPUPlace Op(slice), inputs:{EndsTensor[], EndsTensorList[], Input[shape_0.tmp_0:int[4]({})], StartsTensor[], StartsTensorList[]}, outputs:{Out[slice_0.tmp_0:int[4]({})]}.
I0408 11:21:30.366035 20538 executor_gc_helper.cc:166] Erase variable shape_0.tmp_0
I0408 11:21:30.366080 20538 operator.cc:1066] expected_kernel_key:data_type[float]:data_layout[ANY_LAYOUT]:place[CUDAPlace(0)]:library_type[PLAIN]
I0408 11:21:30.366216 20538 operator.cc:180] CUDAPlace(0) Op(crop_tensor), inputs:{Offsets[], OffsetsTensor[], Shape[slice_0.tmp_0:int[4]({})], ShapeTensor[], X[fill_constant_0.tmp_0:float[1, 3, 8, 8]({})]}, outputs:{Out[crop_tensor_0.tmp_0:float[1, 3, 5, 5]({})]}.
```
