### PR TITLE
fix nccl comm double free bug

### DIFF
--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -287,11 +287,6 @@ CUDADeviceContext::~CUDADeviceContext() {
   SetDeviceId(place_.device);
   Wait();
   WaitStreamCallback();
-#if defined(PADDLE_WITH_NCCL)
-  if (nccl_comm_) {
-    PADDLE_ENFORCE_CUDA_SUCCESS(dynload::ncclCommDestroy(nccl_comm_));
-  }
-#endif
 }
 
 Place CUDADeviceContext::GetPlace() const { return place_; }


### PR DESCRIPTION
As nccl comm is not created by CUDADeviceContext, it should be destroyed by the creator as the best practice of RAII.