### PR TITLE
API (layers.data/fluid.data) error message enhancement

### DIFF
--- a/python/paddle/fluid/data.py
+++ b/python/paddle/fluid/data.py
@@ -15,8 +15,9 @@
 import numpy as np
 import six
 
-from . import core
-from .layer_helper import LayerHelper
+from paddle.fluid import core
+from paddle.fluid.layer_helper import LayerHelper
+from paddle.fluid.data_feeder import check_dtype, check_type
 
 __all__ = ['data']
 
@@ -99,6 +100,14 @@ def data(name, shape, dtype='float32', lod_level=0):
 
     """
     helper = LayerHelper('data', **locals())
+
+    check_type(name, 'name', (six.binary_type, six.text_type), 'data')
+    check_type(shape, 'shape', (list, tuple), 'data')
+    check_dtype(dtype, 'dtype', [
+        'bool', 'float16', 'float32', 'float64', 'int8', 'int16', 'int32',
+        'int64', 'uint8'
+    ], 'data')
+
     shape = list(shape)
     for i in six.moves.range(len(shape)):
         if shape[i] is None:

--- a/python/paddle/fluid/data.py
+++ b/python/paddle/fluid/data.py
@@ -103,10 +103,6 @@ def data(name, shape, dtype='float32', lod_level=0):
 
     check_type(name, 'name', (six.binary_type, six.text_type), 'data')
     check_type(shape, 'shape', (list, tuple), 'data')
-    check_dtype(dtype, 'dtype', [
-        'bool', 'float16', 'float32', 'float64', 'int8', 'int16', 'int32',
-        'int64', 'uint8'
-    ], 'data')
 
     shape = list(shape)
     for i in six.moves.range(len(shape)):

--- a/python/paddle/fluid/layers/io.py
+++ b/python/paddle/fluid/layers/io.py
@@ -31,6 +31,7 @@ from ..layer_helper import LayerHelper
 from ..unique_name import generate as unique_name
 from ..transpiler.distribute_transpiler import DistributedMode
 import logging
+from ..data_feeder import check_dtype, check_type
 
 __all__ = [
     'data', 'read_file', 'double_buffer', 'py_reader',
@@ -73,7 +74,7 @@ def data(name,
     Args:
        name(str): The name/alias of the variable, see :ref:`api_guide_Name`
             for more details.
-       shape(list): Tuple declaring the shape. If :code:`append_batch_size` is 
+       shape(list|tuple): Tuple declaring the shape. If :code:`append_batch_size` is
             True and there is no -1 inside :code:`shape`, it should be 
             considered as the shape of the each sample. Otherwise, it should
             be considered as the shape of the batched data.  
@@ -107,6 +108,14 @@ def data(name,
           data = fluid.layers.data(name='x', shape=[784], dtype='float32')
     """
     helper = LayerHelper('data', **locals())
+
+    check_type(name, 'name', (six.binary_type, six.text_type), 'data')
+    check_type(shape, 'shape', (list, tuple), 'data')
+    check_dtype(dtype, 'dtype', [
+        'bool', 'float16', 'float32', 'float64', 'int8', 'int16', 'int32',
+        'int64', 'uint8'
+    ], 'data')
+
     shape = list(shape)
     for i in six.moves.range(len(shape)):
         if shape[i] is None:

--- a/python/paddle/fluid/layers/io.py
+++ b/python/paddle/fluid/layers/io.py
@@ -111,10 +111,6 @@ def data(name,
 
     check_type(name, 'name', (six.binary_type, six.text_type), 'data')
     check_type(shape, 'shape', (list, tuple), 'data')
-    check_dtype(dtype, 'dtype', [
-        'bool', 'float16', 'float32', 'float64', 'int8', 'int16', 'int32',
-        'int64', 'uint8'
-    ], 'data')
 
     shape = list(shape)
     for i in six.moves.range(len(shape)):

--- a/python/paddle/fluid/tests/unittests/test_data.py
+++ b/python/paddle/fluid/tests/unittests/test_data.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
+from paddle.fluid import Program, program_guard
+
+
+class TestApiDataError(unittest.TestCase):
+    def test_fluid_data(self):
+        with program_guard(Program(), Program()):
+
+            # 1. The type of 'name' in fluid.data must be str.
+            def test_name_type():
+                fluid.data(name=1, shape=[2, 25], dtype="bool")
+
+            self.assertRaises(TypeError, test_name_type)
+
+            # 2. The type of 'shape' in fluid.data must be list or tuple.
+            def test_shape_type():
+                fluid.data(name='data1', shape=2, dtype="bool")
+
+            self.assertRaises(TypeError, test_shape_type)
+
+            # 3. The 'dtype' in fluid.data must be
+            # [bool, float16, float32, float64, int8, int16, int32, int64, uint8].
+            def test_dtype():
+                fluid.data(name='data2', shape=[1], dtype="int")
+
+            self.assertRaises(ValueError, test_dtype)
+
+    def test_layers_data(self):
+        with program_guard(Program(), Program()):
+
+            # 1. The type of 'name' in layers.data must be str.
+            def test_name_type():
+                layers.data(name=1, shape=[2, 25], dtype="bool")
+
+            self.assertRaises(TypeError, test_name_type)
+
+            # 2. The type of 'shape' in layers.data must be list or tuple.
+            def test_shape_type():
+                layers.data(name='data1', shape=2, dtype="bool")
+
+            self.assertRaises(TypeError, test_shape_type)
+
+            # 3. The 'dtype' in layers.data must be
+            # [bool, float16, float32, float64, int8, int16, int32, int64, uint8].
+            def test_dtype():
+                layers.data(name='data2', shape=[1], dtype="int")
+
+            self.assertRaises(ValueError, test_dtype)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_data.py
+++ b/python/paddle/fluid/tests/unittests/test_data.py
@@ -37,13 +37,6 @@ class TestApiDataError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_shape_type)
 
-            # 3. The 'dtype' in fluid.data must be
-            # [bool, float16, float32, float64, int8, int16, int32, int64, uint8].
-            def test_dtype():
-                fluid.data(name='data2', shape=[1], dtype="int")
-
-            self.assertRaises(ValueError, test_dtype)
-
     def test_layers_data(self):
         with program_guard(Program(), Program()):
 
@@ -58,13 +51,6 @@ class TestApiDataError(unittest.TestCase):
                 layers.data(name='data1', shape=2, dtype="bool")
 
             self.assertRaises(TypeError, test_shape_type)
-
-            # 3. The 'dtype' in layers.data must be
-            # [bool, float16, float32, float64, int8, int16, int32, int64, uint8].
-            def test_dtype():
-                layers.data(name='data2', shape=[1], dtype="int")
-
-            self.assertRaises(ValueError, test_dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## API fluid.data/fluid.layers.data 报错信息增强 [仅涉及Python端]
```Python
paddle.fluid.data(name, shape, dtype='float32', lod_level=0)

paddle.fluid.layers.data(name, shape, append_batch_size=True, dtype='float32', lod_level=0, type=VarType.LOD_TENSOR, stop_gradient=True)
```
> 因为这2个接口的单测在同一文件，且通用之处较多，所以在同一个PR中修改。


#### 1. 参数`name`的类型是`str/unicode`
- 报错样例：
```
TypeError: The type of 'name' in data must be (<type 'str'>, <type 'unicode'>), but received <type 'int'>.
```

#### 2. 参数`shape`的类型是`list/tuple`
- 报错样例：
```
TypeError: The type of 'shape' in data must be (<type 'list'>, <type 'tuple'>), but received <type 'int'>. 
```
