### PR TITLE
API (case) error message enhancement.

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -26,7 +26,7 @@ import numpy
 import warnings
 import six
 from functools import reduce, partial
-from ..data_feeder import convert_dtype, check_variable_and_dtype
+from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type
 from ... import compat as cpt
 from ..backward import _infer_var_data_type_shape_
 
@@ -2251,16 +2251,13 @@ def case(pred_fn_pairs, default=None, name=None):
         '''
         Check arguments pred_fn_pairs and default. Return canonical pre_fn_pairs and default.
         '''
-        if not isinstance(pred_fn_pairs, (list, tuple)):
-            raise TypeError(
-                _error_message("The type", "pred_fn_pairs", "case",
-                               "list or tuple", type(pred_fn_pairs)))
+        check_type(pred_fn_pairs, 'pred_fn_pairs', (list, tuple), 'case')
 
         for pred_fn in pred_fn_pairs:
             if not isinstance(pred_fn, tuple):
                 raise TypeError(
                     _error_message("The elements' type", "pred_fn_pairs",
-                                   "case", "tuple", type(pred_fn)))
+                                   "case", tuple, type(pred_fn)))
             if len(pred_fn) != 2:
                 raise TypeError(
                     _error_message("The tuple's size", "pred_fn_pairs", "case",

--- a/python/paddle/fluid/tests/unittests/test_case.py
+++ b/python/paddle/fluid/tests/unittests/test_case.py
@@ -187,7 +187,7 @@ class TestAPICase_Error(unittest.TestCase):
             z = layers.fill_constant(shape=[1], dtype='float32', value=0.2)
             pred_1 = layers.less_than(z, x)  # true
 
-            # The type of 'pred_fn_pairs' in case must be list or  tuple
+            # The type of 'pred_fn_pairs' in case must be list or tuple
             def type_error_pred_fn_pairs():
                 layers.case(pred_fn_pairs=1, default=fn_1)
 


### PR DESCRIPTION
## case api 增强输入类型检查
```python
case(pred_fn_pairs, default=None, name=None)
```
本PR：检查`pred_fn_pairs` 类型是否为 list, tuple

注：该api原本的报错信息已很完善，本PR尽可能将类型检查统一用`check_variable_and_dtype`和`check_type`接口。无法统一到上述2个接口的，不做修改。