### PR TITLE
API (switch_case) error message enhancement.

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -26,7 +26,7 @@ import numpy
 import warnings
 import six
 from functools import reduce, partial
-from ..data_feeder import convert_dtype, check_variable_and_dtype
+from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type
 from ... import compat as cpt
 from ..backward import _infer_var_data_type_shape_
 
@@ -3364,24 +3364,14 @@ def switch_case(branch_index, branch_fns, default=None, name=None):
     helper = LayerHelper('switch_case', **locals())
 
     def _check_args(branch_index, branch_fns, default):
-        if not isinstance(branch_index, Variable):
-            raise TypeError(
-                _error_message("The type", "branch_index", "switch_case",
-                               "Variable", type(branch_index)))
 
-        if convert_dtype(branch_index.dtype) not in ["uint8", "int32", "int64"]:
-            raise TypeError(
-                _error_message("The data type", "branch_index", "switch_case",
-                               "uint8, int32 or int64",
-                               convert_dtype(branch_index.dtype)))
+        check_variable_and_dtype(branch_index, 'branch_index',
+                                 ['uint8', 'int32', 'int64'], 'switch_case')
 
         if convert_dtype(branch_index.dtype) != "int64":
             branch_index = cast(branch_index, "int64")
 
-        if not isinstance(branch_fns, (list, tuple, dict)):
-            raise TypeError(
-                _error_message("The type", "branch_fns", "switch_case",
-                               "dict, tuple or list", type(branch_fns)))
+        check_type(branch_fns, 'branch_fns', (list, tuple, dict), 'switch_case')
 
         branch_fns = branch_fns.items() if isinstance(branch_fns,
                                                       dict) else branch_fns
@@ -3394,7 +3384,7 @@ def switch_case(branch_index, branch_fns, default=None, name=None):
             if not isinstance(index_fn_pair, tuple):
                 raise TypeError(
                     _error_message("The elements' type", "branch_fns",
-                                   "switch_case", "tuple", type(branch_fns)))
+                                   "switch_case", tuple, type(branch_fns)))
 
             if len(index_fn_pair) != 2:
                 raise TypeError(
@@ -3407,7 +3397,7 @@ def switch_case(branch_index, branch_fns, default=None, name=None):
             if not isinstance(key, int):
                 raise TypeError(
                     _error_message("The key's type", "branch_fns",
-                                   "switch_case", "int", type(key)))
+                                   "switch_case", int, type(key)))
 
             if key in keys_of_fns:
                 raise ValueError(


### PR DESCRIPTION
## switch api 增强输入类型检查
```python
switch_case(branch_index, branch_fns, default=None, name=None)
```
1. 检查`branch_index`:
   - 检查类型是否为Variable
   - 检查数据类型是否为"uint8", "int32", "int64"

2. 检查`branch_fns`:
   - 检查类型是否为 list, tuple, dict
```
TypeError: The type of 'branch_fns' in switch_case must be (<type 'list'>, <type 'tuple'>, <type 'dict'>), but received <type 'int'>.
```

**注：该api原本的报错信息已很完善，本PR尽可能将类型检查统一用`check_variable_and_dtype`和`check_type`接口。无法统一到上述2个接口的，不做修改。**


