### PR TITLE
Disable test_code_generator and test_post_training_quantization_mobilenetv1

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/fusion_group/CMakeLists.txt
@@ -2,7 +2,7 @@ cc_library(code_generator
     SRCS operation.cc code_generator.cc code_generator_helper.cc
     DEPS graph subgraph_detector)
 if(WITH_GPU)
-    cc_test(test_code_generator SRCS code_generator_tester.cc DEPS code_generator device_code lod_tensor graph_viz_pass)
+#    cc_test(test_code_generator SRCS code_generator_tester.cc DEPS code_generator device_code lod_tensor graph_viz_pass)
 endif()
 
 cc_library(fusion_group_pass

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -107,9 +107,10 @@ function(save_qat_model_test target qat_model_dir fp32_model_save_path int8_mode
 		 --quantized_ops ${quantized_ops})
 endfunction()
 
+# Disable the unittest temporary
+list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mobilenetv1)
 if(WIN32)
     list(REMOVE_ITEM TEST_OPS test_light_nas)
-    list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mobilenetv1)
     list(REMOVE_ITEM TEST_OPS test_post_training_quantization_resnet50)
     list(REMOVE_ITEM TEST_OPS test_weight_quantization_mobilenetv1)
 endif()


### PR DESCRIPTION
- 单测覆盖率的CI切换环境后，`test_code_generator`出现如下错误：
![image](https://user-images.githubusercontent.com/12538138/78316357-03f0a900-7592-11ea-9b46-217ee55e8acd.png)

为了不影响大家的op开发工作，故先disable这个单测，已经记录在[Temporarily disabled Unit Test](https://github.com/PaddlePaddle/Paddle/wiki/Temporarily-disabled-Unit-Test)。
 
- https://github.com/PaddlePaddle/Paddle/pull/22719 已经尝试彻底解决此类问题，但还需要在多个环境下进行充分的验证。

- 顺便关了另一个CI文档挂的单测`test_post_training_quantization_mobilenetv1`，从log看应该是精度问题，后续由@wzzju @juncaipeng 来修复。
![image](https://user-images.githubusercontent.com/12538138/78317315-8b3f1c00-7594-11ea-8b97-4a2e66ef1af4.png)
