### PR TITLE
Api/Op (select_input/select_ouput) error message enhancement.

### DIFF
--- a/paddle/fluid/operators/select_input_op.cc
+++ b/paddle/fluid/operators/select_input_op.cc
@@ -40,9 +40,13 @@ class SelectInputOp : public framework::OperatorBase {
     size_t output_branch = static_cast<size_t>(GetBranchNumber(mask));
 
     const std::vector<std::string> &x_names = Inputs("X");
-    PADDLE_ENFORCE_LT(output_branch, x_names.size(),
-                      "Selected branch number is greater than actual branch "
-                      "num in SelectInputOp");
+    PADDLE_ENFORCE_LT(
+        output_branch, x_names.size(),
+        platform::errors::InvalidArgument(
+            "Input 'Mask' in SelectInputOp is invalid. "
+            "'Mask' must be less than the size of input vector 'X'. "
+            "But received Mask = %d, X's size = %d.",
+            output_branch, x_names.size()));
 
     const framework::Variable *selected_x =
         scope.FindVar(x_names[output_branch]);

--- a/paddle/fluid/operators/select_op_helper.h
+++ b/paddle/fluid/operators/select_op_helper.h
@@ -40,10 +40,10 @@ inline int GetBranchNumber(const framework::LoDTensor &mask) {
 #ifdef PADDLE_WITH_CUDA
   framework::TensorCopySync(mask, platform::CPUPlace(), cpu_mask.get());
 #else
-  PADDLE_THROW(
-      "This version of PaddlePaddle does NOT support GPU but got GPU tensor "
-      "Mask in SelectInputOp or SelectOutputOp. Please compile WITH_GPU "
-      "option");
+  PADDLE_THROW(platform::errors::PreconditionNotMet(
+      "This version of PaddlePaddle does NOT support GPU, "
+      "but got GPU tensor 'Mask' in SelectInputOp or SelectOutputOp. "
+      "Please compile PaddlePaddle WITH_GPU first."));
 #endif
   return cpu_mask->data<int>()[0];
 }

--- a/paddle/fluid/operators/select_op_helper.h
+++ b/paddle/fluid/operators/select_op_helper.h
@@ -26,8 +26,12 @@ namespace operators {
 // Returns the integer in mask whose numel must be 1. The integer means the
 // selected branch number.
 inline int GetBranchNumber(const framework::LoDTensor &mask) {
-  PADDLE_ENFORCE_EQ(mask.numel(), 1,
-                    "Mask in SelectOutputOp must have numel 1.");
+  PADDLE_ENFORCE_EQ(
+      mask.numel(), 1,
+      platform::errors::InvalidArgument(
+          "Mask in SelectInputOp or SelectOutputOp must have numel 1. "
+          "But received %d, and it's shape is [%s].",
+          mask.numel(), mask.dims()));
   if (platform::is_cpu_place(mask.place())) {
     return mask.data<int>()[0];
   }
@@ -37,8 +41,9 @@ inline int GetBranchNumber(const framework::LoDTensor &mask) {
   framework::TensorCopySync(mask, platform::CPUPlace(), cpu_mask.get());
 #else
   PADDLE_THROW(
-      "This version of PaddlePaddle doen NOT support GPU but got GPU tensor "
-      "Mask in SelectOutputOp. Please compile WITH_GPU option");
+      "This version of PaddlePaddle does NOT support GPU but got GPU tensor "
+      "Mask in SelectInputOp or SelectOutputOp. Please compile WITH_GPU "
+      "option");
 #endif
   return cpu_mask->data<int>()[0];
 }

--- a/paddle/fluid/operators/select_op_helper.h
+++ b/paddle/fluid/operators/select_op_helper.h
@@ -26,12 +26,12 @@ namespace operators {
 // Returns the integer in mask whose numel must be 1. The integer means the
 // selected branch number.
 inline int GetBranchNumber(const framework::LoDTensor &mask) {
-  PADDLE_ENFORCE_EQ(
-      mask.numel(), 1,
-      platform::errors::InvalidArgument(
-          "Mask in SelectInputOp or SelectOutputOp must have numel 1. "
-          "But received %d, and it's shape is [%s].",
-          mask.numel(), mask.dims()));
+  PADDLE_ENFORCE_EQ(mask.numel(), 1,
+                    platform::errors::InvalidArgument(
+                        "The numel of Input(Mask) in SelectInputOp or "
+                        "SelectOutputOp must be 1. "
+                        "But received %d, and it's shape is [%s].",
+                        mask.numel(), mask.dims()));
   if (platform::is_cpu_place(mask.place())) {
     return mask.data<int>()[0];
   }

--- a/paddle/fluid/operators/select_output_op.cc
+++ b/paddle/fluid/operators/select_output_op.cc
@@ -41,9 +41,13 @@ class SelectOutputOp : public framework::OperatorBase {
     size_t output_branch = static_cast<size_t>(GetBranchNumber(mask));
 
     const std::vector<std::string> &out_names = Outputs("Out");
-    PADDLE_ENFORCE_LT(output_branch, out_names.size(),
-                      "Selected branch number is greater than actual branch "
-                      "num in SelectOutputOp");
+    PADDLE_ENFORCE_LT(
+        output_branch, out_names.size(),
+        platform::errors::InvalidArgument(
+            "Input 'Mask' in SelectOutputOp is invalid. "
+            "'Mask' must be less than the size of output vector 'Out'. "
+            "But received Mask = %d, Out's size = %d.",
+            output_branch, out_names.size()));
 
     const framework::Variable *x = scope.FindVar(Input("X"));
     framework::Variable *selected_out = scope.FindVar(out_names[output_branch]);

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -56,6 +56,10 @@ def select_output(input, outputs, mask):
         Variable: The outputs variables
     """
     helper = LayerHelper('select_output', **locals())
+    check_type(input, 'input', (Variable), 'select_output')
+    check_variable_and_dtype(mask, 'mask', ['int32'], 'select_output')
+    check_type(outputs, 'outputs', (list, tuple), 'select_output')
+
     helper.append_op(
         type='select_output',
         inputs={'X': input,
@@ -80,14 +84,12 @@ def select_input(inputs, mask):
         Variable: The selected input variable
     """
     helper = LayerHelper('select_input', **locals())
-    if isinstance(inputs, list) or isinstance(inputs, tuple):
-        input_dtype = inputs[0].dtype
-        input_shape = inputs[0].shape
-        input_type = inputs[0].type
-    else:
-        input_dtype = inputs.dtype
-        input_shape = inputs.shape
-        input_type = inputs.type
+    check_type(inputs, 'inputs', (list, tuple), 'select_input')
+    check_variable_and_dtype(mask, 'mask', ['int32'], 'select_input')
+
+    input_dtype = inputs[0].dtype
+    input_shape = inputs[0].shape
+    input_type = inputs[0].type
 
     out = helper.create_variable(
         dtype=input_dtype, shape=input_shape, type=input_type)


### PR DESCRIPTION
## select_input/select_output op报错信息增强
```Python
def select_input(inputs, mask)
def select_output(input, outputs, mask)
```
> 因为这2个接口的单测在同一文件，且通用之处较多，所以在同一个PR中修改。

~~Op shape报错检查增强~~

### 一、 Python API的input类型检查
#### 1. 「select_input」的输入「inputs」的类型是tuple/list
- 修改后报错：
```
TypeError: The type of 'inputs' in select_input must be (<type 'list'>, <type 'tuple'>), but received <type 'int'>. 
```

#### 2. 「select_input」的输入「mask」的类型是Variable，dtype是int32/int64
- 修改后报错：
```
TypeError: The type of 'mask' in select_input must be <class 'paddle.fluid.framework.Variable'>, but received <type 'int'>. 

TypeError: The data type of 'mask' in select_input must be ['int32'], but received float32. 
```

#### 3. 「select_output」的输入「input」的类型是Variable
- 修改后报错：
```
TypeError: The type of 'input' in select_output must be <class 'paddle.fluid.framework.Variable'>, but received <type 'int'>. 
```

#### 4. 「select_output」的输入「mask」的类型是Variable，dtype是int32/int64
- 修改后报错：
```
TypeError: The type of 'mask' in select_output must be <class 'paddle.fluid.framework.Variable'>, but received <type 'int'>. 

TypeError: The data type of 'mask' in select_output must be ['int32'], but received float32. 
```

#### 5. 「select_output」的输入「outputs」的类型是list/tuple
- 修改后报错：
```
TypeError: The type of 'outputs' in select_output must be (<type 'list'>, <type 'tuple'>), but received <class 'paddle.fluid.framework.Variable'>. 
```

----

### 二、 c++不合规报错检查增强
#### 1.Mask数据比Inputs的size大时：
- 修改前报错：报错内容没有打印数据信息
```
Selected branch number is greater than actual branch num in SelectInputOp
```

- 修改后报错
```
InvalidArgumentError: Input 'Mask' in SelectInputOp is invalid. 'Mask' must be less than the size of input vector 'X'. But received Mask = 10, X's size = 2.
```

#### 2. Mask的数据元素个数不等于1时：
- 修改前报错：报错内容没有打印数据信息
```
Mask in SelectOutputOp must have numel 1.
```

- 修改后报错：
```
InvalidArgumentError: Mask in SelectInputOp or SelectOutputOp must have numel 1. But received 2, and it's shape is [2].
```

#### 3.Mask数据比Out的size大时：
- 修改前报错：报错内容没有打印数据信息
```
Selected branch number is greater than actual branch num in num in SelectOutputOp
```

- 修改后报错
```
InvalidArgumentError: Input 'Mask' in SelectOutputOp is invalid. 'Mask' must be less than the size of output vector 'Out'. But received Mask = 10, Out's size = 2.
```
