### PR TITLE
API(append_backward) error message enhancement

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1243,7 +1243,7 @@ def append_backward(loss,
             p_g_list6 = fluid.backward.append_backward(loss=avg_loss, parameter_list=all_weights, no_grad_set=set(all_weights))
 
     """
-    check_type(loss, 'loss', (framework.Variable),
+    check_type(loss, 'loss', framework.Variable,
                'fluid.backward.append_backward')
 
     if loss.op is None:
@@ -1255,7 +1255,7 @@ def append_backward(loss,
                       int(core.op_proto_and_checker_maker.OpRole.Loss))
 
     if callbacks is not None:
-        check_type(callbacks, 'callbacks', (list),
+        check_type(callbacks, 'callbacks', list,
                    'fluid.backward.append_backward')
 
     program = loss.block.program

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1715,8 +1715,6 @@ def gradients(targets, inputs, target_gradients=None, no_grad_set=None):
                'fluid.backward.gradients')
     check_type(target_gradients, 'target_gradients', (
         framework.Variable, list, type(None)), 'fluid.backward.gradients')
-    check_type(no_grad_set, 'no_grad_set', (set, type(None)),
-               'fluid.backward.gradients')
 
     outs = calc_gradient(targets, inputs, target_gradients, no_grad_set)
     return _as_list(outs)

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1243,7 +1243,8 @@ def append_backward(loss,
             p_g_list6 = fluid.backward.append_backward(loss=avg_loss, parameter_list=all_weights, no_grad_set=set(all_weights))
 
     """
-    assert isinstance(loss, framework.Variable)
+    check_type(loss, 'loss', (framework.Variable),
+               'fluid.backward.append_backward')
 
     if loss.op is None:
         # the loss is from a cloned program. Find loss op manually.
@@ -1254,7 +1255,8 @@ def append_backward(loss,
                       int(core.op_proto_and_checker_maker.OpRole.Loss))
 
     if callbacks is not None:
-        isinstance(callbacks, list)
+        check_type(callbacks, 'callbacks', (list),
+                   'fluid.backward.append_backward')
 
     program = loss.block.program
     root_block = program.block(0)
@@ -1370,20 +1372,17 @@ def append_backward(loss,
     program._sync_with_cpp()
 
     if parameter_list is not None:
-        if not isinstance(parameter_list, (list, tuple, set)):
-            raise TypeError(
-                "The type of parameter_list argument must be list or tuple or set, but received %s."
-                % (type(parameter_list)))
+        check_type(parameter_list, 'parameter_list', (list, tuple, set),
+                   'fluid.backward.append_backward')
         parameters = []
         for i, param in enumerate(parameter_list):
+            check_type(param, 'parameter_list[%s]' % i, (framework.Variable,
+                                                         six.string_types),
+                       'fluid.backward.append_backward')
             if isinstance(param, framework.Variable):
                 parameters.append(param.name)
             elif isinstance(param, six.string_types):
                 parameters.append(param)
-            else:
-                raise TypeError(
-                    "The type of parameter_list's member must be paddle.fluid.Variable or str, but received %s."
-                    % (type(param)))
     else:
         params = program.global_block().all_parameters()
         parameters = [param.name for param in params if param.trainable]

--- a/python/paddle/fluid/tests/unittests/test_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_backward.py
@@ -303,7 +303,9 @@ class TestAppendBackwardWithError(unittest.TestCase):
         return avg_loss, param_names
 
     def setUp(self):
-        self.avg_loss, self.param_names = self.build_net()
+        main_program = fluid.Program()
+        with fluid.program_guard(main_program):
+            self.avg_loss, self.param_names = self.build_net()
 
     def test_loss_type_error(self):
         with self.assertRaises(TypeError):


### PR DESCRIPTION
### append_backward API输入类型检查（仅涉及python端）

#### 1. loss参数必须为`Variable`
```python
fluid.backward.append_backward(loss=avg_loss.name)  # 若传入string类型
```
+ 优化前只有一个assert语句相关报错
```python
  File "backward.py", line 1245, in append_backward
    assert isinstance(loss, framework.Variable)
AssertionError
```
+ 优化后，会提示当前转入的类型
```python
TypeError: The type of 'loss' in fluid.backward.append_backward must be <class 'paddle.fluid.framework.Variable'>, but received <class 'str'>.
```

#### 2. parameter_list参数为`list[Variable|str]`
```python
param_names = [
    param.name
    for param in fluid.default_main_program().block(0).all_parameters()
]
param_names[0] = np.random.random([10])
fluid.backward.append_backward(loss=avg_loss, parameter_list=self.param_names)
```
+ 优化前，若parameter_list的元素不是Varibale或str，报如下错：
```python
TypeError: The type of parameter_list's member must be paddle.fluid.Variable or str, but received <class 'numpy.ndarray'>.
```
+ 优化后，增加了具体元素的位置信息
```python
TypeError: The type of 'parameter_list[0]' in fluid.backward.append_backward must be (<class 'paddle.fluid.framework.Variable'>, (<class 'str'>,)), but received <class 'numpy.ndarray'>.
```

#### 3. callbacks参数必须为list
```python
def callback(block, context):
    return

fluid.backward.append_backward(loss=avg_loss, callbacks=callback)
```
+ 优化前，仅会输出assert信息
```python
_append_backward_ops_
    assert (isinstance(callbacks, list))
AssertionError
```
+ 优化后，按照规范输出报错信息
```python
TypeError: The type of 'callbacks' in fluid.backward.append_backward must be <class 'list'>, but received <class 'function'>.
```

+  移除了对`fluid.gradients`的no_grad_set的强制set类型检查

> 之前存在no_grad_set传入list、tuple的情况，已在内部进行兼容处理，并已经给出了完备的报错信息提示，故此处移除对`fluid.gradients`的no_grad_set的强制set类型检查

