### PR TITLE
API(fluid.gridents) error message enhancement

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -24,6 +24,7 @@ from .. import compat as cpt
 from . import unique_name
 from . import log_helper
 import paddle.fluid
+from .data_feeder import check_type
 __all__ = [
     'append_backward',
     'gradients',
@@ -1709,5 +1710,14 @@ def gradients(targets, inputs, target_gradients=None, no_grad_set=None):
             z = fluid.gradients([y], x)
             print(z)
     """
+    check_type(targets, 'targets', (framework.Variable, list),
+               'fluid.backward.gradients')
+    check_type(inputs, 'inputs', (framework.Variable, list),
+               'fluid.backward.gradients')
+    check_type(target_gradients, 'target_gradients', (
+        framework.Variable, list, type(None)), 'fluid.backward.gradients')
+    check_type(no_grad_set, 'no_grad_set', (set, type(None)),
+               'fluid.backward.gradients')
+
     outs = calc_gradient(targets, inputs, target_gradients, no_grad_set)
     return _as_list(outs)

--- a/python/paddle/fluid/tests/unittests/test_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_backward.py
@@ -241,6 +241,26 @@ class TestSimpleNet(TestBackward):
         self._check_all(self.net)
 
 
+class TestGradientsError(unittest.TestCase):
+    def test_error(self):
+        x = fluid.data(name='x', shape=[None, 2, 8, 8], dtype='float32')
+        x.stop_gradient = False
+        conv = fluid.layers.conv2d(x, 4, 1, bias_attr=False)
+        y = fluid.layers.relu(conv)
+
+        with self.assertRaises(TypeError):
+            x_grad = fluid.gradients(y.name, x)
+
+        with self.assertRaises(TypeError):
+            x_grad = fluid.gradients(y, x.name)
+
+        with self.assertRaises(TypeError):
+            x_grad = fluid.gradients([y], [x], target_gradients=x.name)
+
+        with self.assertRaises(TypeError):
+            x_grad = fluid.gradients([y], x, no_grad_set=conv)
+
+
 class TestSimpleNetWithErrorParamList(TestBackward):
     def test_parameter_list_type_error(self):
         self.global_block_idx = 0

--- a/python/paddle/fluid/tests/unittests/test_imperative_star_gan_with_gradient_penalty.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_star_gan_with_gradient_penalty.py
@@ -441,7 +441,7 @@ def get_discriminator_loss(image_real, label_org, label_trg, generator,
     d_loss = d_loss_real + d_loss_fake + d_loss_cls
 
     d_loss_gp = gradient_penalty(discriminator, image_real, fake_img,
-                                 discriminator.parameters(), cfg)
+                                 set(discriminator.parameters()), cfg)
     if d_loss_gp is not None:
         d_loss += cfg.lambda_gp * d_loss_gp
 


### PR DESCRIPTION
### gradients API输入类型检查（仅涉及python端）
测试样例：
```python
x = fluid.data(name='x', shape=[None, 2, 8, 8], dtype='float32')
x.stop_gradient = False
conv = fluid.layers.conv2d(x, 4, 1, bias_attr=False)
y = fluid.layers.relu(conv)
```
#### 1. targets参数必须是`list/Variable`
```python
x_grad = fluid.gradients(y.name, x)
```

+ 优化前，错误报在子函数`calc_gradient`具体代码执行处，对用户不明朗
```
File "backward.py", line 1578, in calc_gradient
    block = targets[0].block
AttributeError: 'str' object has no attribute 'block'
```
+ 优化后，在gradients接口处直接报错
```python
TypeError: The type of 'targets' in fluid.backward.gradients must be (<class 'paddle.fluid.framework.Variable'>, <class 'list'>), but received <class 'str'>.
```

#### 2. inputs参数必须是`list/Variable`
```python
x_grad = fluid.gradients(y, x.name)
```

+ 优化前，错误报在子函数`calc_gradient`具体代码执行处，对用户不明朗
```python
File "backward.py", line 1638, in calc_gradient
    if input.block.program != prog:
AttributeError: 'str' object has no attribute 'block'
```
+ 优化后，在gradients接口处直接报错
```python
TypeError: The type of 'inputs' in fluid.backward.gradients must be (<class 'paddle.fluid.framework.Variable'>, <class 'list'>), but received <class 'str'>.
```

#### 3. target_gradients参数必须是`Variable或None`
```python
x_grad = fluid.gradients([y], [x], target_gradients=x.name)
```
+ 优化前，错误报在子函数`calc_gradient`具体代码执行处，对用户不明朗
```python
File "backward.py", line 1625, in calc_gradient
    if target.shape != grad.shape:
AttributeError: 'str' object has no attribute 'shape'
```
+ 优化后，在gradients接口处直接报错
```python
TypeError: The type of 'target_gradients' in fluid.backward.gradients must be (<class 'paddle.fluid.framework.Variable'>, <class 'list'>, <class 'NoneType'>), but received <class 'str'>.
```

#### 4. no_grad_set参数必须是`set或None`
```python
x_grad = fluid.gradients([y], x, no_grad_set=conv)
```

+ 优化前，错误报在子函数`_get_no_grad_set_name`具体代码执行处，对用户不明朗
```python
File "backward.py", line 1141, in _get_no_grad_set_name
    format(type(no_grad_set)))
TypeError: The type of no_grad_set should be set or list or tuple, but received <class 'paddle.fluid.framework.Variable'>
```
+ 优化后，在gradients接口处直接报错
```python
TypeError: The type of 'no_grad_set' in fluid.backward.gradients must be (<class 'set'>, <class 'NoneType'>), but received <class 'paddle.fluid.framework.Variable'>.
```