### PR TITLE
fix test_graph_wrapper failure on cudnnv7, test=develop

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/test_graph_wrapper.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_graph_wrapper.py
@@ -37,6 +37,7 @@ def residual_block(num):
             num_filters=ch_out,
             stride=stride,
             padding=padding,
+            use_cudnn=False,
             act=None,
             bias_attr=bias_attr)
         return fluid.layers.batch_norm(input=tmp, act=act)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/28884066/78347291-d5df8900-75d2-11ea-8194-e33a45683c64.png)
Because CI failed on cudnnv7 conv2d, disable cudnn flag in test_graph_wrapper.