### PR TITLE
Dev/fix init flags

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -53,7 +53,6 @@ std::once_flag glog_warning_once_flag;
 void InitGflags(std::vector<std::string> argv) {
   std::call_once(gflags_init_flag, [&]() {
     FLAGS_logtostderr = true;
-    argv.insert(argv.begin(), "dummy");
     int argc = argv.size();
     char **arr = new char *[argv.size()];
     std::string line;

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -53,6 +53,12 @@ std::once_flag glog_warning_once_flag;
 void InitGflags(std::vector<std::string> argv) {
   std::call_once(gflags_init_flag, [&]() {
     FLAGS_logtostderr = true;
+    // NOTE(zhiqiu): dummy is needed, since the function
+    // ParseNewCommandLineFlags in gflags.cc starts processing
+    // commandline strings from idx 1.
+    // The reason is, it assumes that the first one (idx 0) is
+    // the filename of executable file.
+    argv.insert(argv.begin(), "dummy");
     int argc = argv.size();
     char **arr = new char *[argv.size()];
     std::string line;
@@ -61,8 +67,10 @@ void InitGflags(std::vector<std::string> argv) {
       line += argv[i];
       line += ' ';
     }
+    VLOG(1) << "Before Parse: argc is " << argc
+            << ", Init commandline: " << line;
     google::ParseCommandLineFlags(&argc, &arr, true);
-    VLOG(1) << "Init commandline: " << line;
+    VLOG(1) << "After Parse: argc is " << argc;
   });
 }
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -216,8 +216,7 @@ def __bootstrap__():
             'cudnn_batchnorm_spatial_persistent', 'gpu_allocator_retry_time',
             'local_exe_sub_scope_limit', 'gpu_memory_limit_mb'
         ]
-    core.init_gflags([sys.argv[0]] +
-                     ["--tryfromenv=" + ",".join(read_env_flags)])
+    core.init_gflags(["--tryfromenv=" + ",".join(read_env_flags)])
     core.init_glog(sys.argv[0])
     # don't init_p2p when in unittest to save time.
     core.init_devices(not in_test)

--- a/python/paddle/fluid/tests/unittests/test_run_fluid_by_module_or_command_line.py
+++ b/python/paddle/fluid/tests/unittests/test_run_fluid_by_module_or_command_line.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import os
+
+
+class TestRunFluidByModule(unittest.TestCase):
+    def test_module(self):
+        res = os.system('python -m "paddle.fluid"')
+        self.assertEqual(res, 0)  # 0 means status OK
+
+
+class TestRunFluidByCommand(unittest.TestCase):
+    def test_command(self):
+        res = os.system('python -c "import paddle.fluid"')
+        self.assertEqual(res, 0)  # 0 means status OK
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_run_fluid_by_module_or_command_line.py
+++ b/python/paddle/fluid/tests/unittests/test_run_fluid_by_module_or_command_line.py
@@ -14,17 +14,19 @@
 
 import unittest
 import os
+import sys
 
 
 class TestRunFluidByModule(unittest.TestCase):
     def test_module(self):
-        res = os.system('python -m "paddle.fluid"')
+        print(sys.executable)
+        res = os.system(sys.executable + ' -m "paddle.fluid.reader"')
         self.assertEqual(res, 0)  # 0 means status OK
 
 
 class TestRunFluidByCommand(unittest.TestCase):
     def test_command(self):
-        res = os.system('python -c "import paddle.fluid"')
+        res = os.system(sys.executable + ' -c "import paddle.fluid"')
         self.assertEqual(res, 0)  # 0 means status OK
 
 


### PR DESCRIPTION
This PR fixes a bug that existed for a long time.

The `__init__.py` in `paddle.fluid ` pass `sys.argv[0]` to `core.init_flags`.
Commonly, if we run `python xx.py`, then `sys.argv[0]`  is `xx.py`, and it makes no error, since it does not start with `-`.
But, in the following 2 cases, it may cause `ERROR`

1. run `python -m paddle.fluid`,
2. run `python -c "import paddle.fluid"`,

Examples in paddle-1.6,
![image](https://user-images.githubusercontent.com/6888866/78370518-54e7b800-75f9-11ea-9566-21b6633645f1.png)

The reason is that, in these 2 cases, `sys.argv[0]` is `-c` and `-m`.
And, starting with `-` is treated as `key` of args in `gflags`, see more details in [gflags](https://gflags.github.io/gflags/). So it cannot be properly interpreted as `gflags` defined in paddle. 

Plus, I found that `sys.argv[0]` is useless even if it is `xx.py`, since not start with `-` or `--`, so I remove them.

Related #23265