### PR TITLE
OP (tensor_array_read_write) error message enhancement. 

### DIFF
--- a/paddle/fluid/operators/array_operator.h
+++ b/paddle/fluid/operators/array_operator.h
@@ -31,9 +31,14 @@ class ArrayOp : public framework::OperatorBase {
   size_t GetOffset(const framework::Scope &scope,
                    const platform::Place &place) const {
     auto *i = scope.FindVar(Input("I"));
-    PADDLE_ENFORCE(i != nullptr, "I must be set");
+    PADDLE_ENFORCE_NOT_NULL(
+        i, platform::errors::NotFound("Input(I) is not found."));
     auto &i_tensor = i->Get<framework::LoDTensor>();
-    PADDLE_ENFORCE_EQ(i_tensor.numel(), 1);
+    PADDLE_ENFORCE_EQ(i_tensor.numel(), 1,
+                      platform::errors::InvalidArgument(
+                          "Input(I) must have numel 1. "
+                          "But received %d, and it's shape is [%s].",
+                          i_tensor.numel(), i_tensor.dims()));
 
     // get device context from pool
     platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();

--- a/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
+++ b/paddle/fluid/operators/controlflow/tensor_array_read_write_op.cc
@@ -84,8 +84,7 @@ class WriteToArrayInferShape : public framework::InferShapeBase {
   void operator()(framework::InferShapeContext *context) const override {
     PADDLE_ENFORCE_EQ(
         context->HasInput("I"), true,
-        platform::errors::InvalidArgument(
-            "Read/Write array operation must set the subscript index."));
+        platform::errors::NotFound("Input(I) of WriteToArrayOp is not found."));
 
     // TODO(wangchaochaohu) control flow Op do not support runtime infer shape
     // Later we add [ontext->GetInputDim("I")) == 1] check when it's supported
@@ -94,11 +93,9 @@ class WriteToArrayInferShape : public framework::InferShapeBase {
       return;
     }
 
-    PADDLE_ENFORCE_EQ(
-        context->HasOutput("Out"), true,
-        platform::errors::InvalidArgument(
-            "Read/Write array operation must set the output Tensor "
-            "to get the result."));
+    PADDLE_ENFORCE_EQ(context->HasOutput("Out"), true,
+                      platform::errors::NotFound(
+                          "Output(Out) of WriteToArrayOp is not found."));
     context->SetOutputDim("Out", context->GetInputDim("X"));
 
     // When compile time, we need to:
@@ -140,15 +137,14 @@ class ReadFromArrayOp : public ArrayOp {
   void RunImpl(const framework::Scope &scope,
                const platform::Place &place) const override {
     auto *x = scope.FindVar(Input("X"));
-    PADDLE_ENFORCE_NOT_NULL(
-        x,
-        platform::errors::InvalidArgument(
-            "X(Input Variable) must be set when we call read array operation"));
+    PADDLE_ENFORCE_NOT_NULL(x,
+                            platform::errors::NotFound(
+                                "Input(X) of ReadFromArrayOp is not found."));
     auto &x_array = x->Get<framework::LoDTensorArray>();
     auto *out = scope.FindVar(Output("Out"));
-    PADDLE_ENFORCE_NOT_NULL(out, platform::errors::InvalidArgument(
-                                     "Out(Output Varibale) must be set when we "
-                                     "call read array operation"));
+    PADDLE_ENFORCE_NOT_NULL(
+        out, platform::errors::NotFound(
+                 "Output(Out) of ReadFromArrayOp is not found."));
     size_t offset = GetOffset(scope, place);
     if (offset < x_array.size()) {
       auto *out_tensor = out->GetMutable<framework::LoDTensor>();


### PR DESCRIPTION
## tensor_array_read_write op 报错信息增强 [仅C++端]
### c++不合规报错检查增强
#### 1. 错误类型有误，报错内容需改
- 修改前报错：
```
InvalidArgumentError: Read/Write array operation must set the subscript index.
```

- 修改后报错：
```
NotFoundError: Input(I) of WriteToArrayOp is not found.
```

#### 2. 错误类型有误，报错内容需改
- 修改前报错：
```
InvalidArgumentError: Read/Write array operation must set the output Tensor to get the result.
```

- 修改后报错：
```
NotFoundError: Output(Out) of WriteToArrayOp is not found.
```

#### 3. 错误类型有误，报错内容需改
- 修改前报错：
```
InvalidArgumentError: X(Input Variable) must be set when we call read array operation。
```

- 修改后报错：
```
NotFoundError: Input(X) of ReadFromArrayOp is not found.
```

#### 4. 错误类型有误，报错内容需改
- 修改前报错：
```
InvalidArgumentError: Out(Output Varibale) must be set when we call read array operation.
```

- 修改后报错：
```
NotFoundError: Output(Out) of ReadFromArrayOp is not found.
```

#### 5. 报错不规范
- 修改前报错：
```
I must be set
```

- 修改后报错：
```
NotFoundError: Input(I) is not found.
```

#### 6. 报错不规范
- 修改前报错：无

- 修改后报错：
```
InvalidArgumentError: Input(I) must have numel 1. But received 2, and it's shape is [1,2]
```


