### PR TITLE
[DNNL] Added elementwise_add mkl-dnn inplace

### DIFF
--- a/paddle/fluid/framework/ir/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/CMakeLists.txt
@@ -86,7 +86,7 @@ endif()
 
 if(WITH_MKLDNN)
     pass_library(mkldnn_placement_pass base DEPS placement_pass_base DIR mkldnn)
-    pass_library(mkldnn_inplace_pass inference DEPS mkldnn_placement_pass op_registry softmax_op softmax DIR mkldnn)
+    pass_library(mkldnn_inplace_pass inference DEPS mkldnn_placement_pass op_registry elementwise_add_op activation_op softmax_op softmax DIR mkldnn)
     pass_library(depthwise_conv_mkldnn_pass base DIR mkldnn)
     pass_library(conv_bias_mkldnn_fuse_pass inference DIR mkldnn)
     pass_library(conv_activation_mkldnn_fuse_pass inference DIR mkldnn)

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1835,8 +1835,6 @@ PDNode *patterns::MultipleQuantize::operator()() {
 }
 
 PDNode *patterns::MKLDNNInPlace::operator()() {
-  // TODO(jczaja): Enable more mkl-dnn ops e.g. activation, batch_norm....
-  auto prev_op = pattern->NewNode(prev_op_repr())->assert_is_op();
 
   auto possible_inplace_op =
       pattern->NewNode(inplace_to_be_op_repr())
@@ -1858,7 +1856,6 @@ PDNode *patterns::MKLDNNInPlace::operator()() {
   possible_inplace_op->assert_op_attr("use_mkldnn", true);
 
   // linked structure
-  prev_op->LinksTo({input});
   possible_inplace_op->LinksTo({output});
   possible_inplace_op->LinksFrom({input});
   next_op->LinksFrom({output});

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1852,8 +1852,7 @@ PDNode *patterns::MKLDNNInPlace::operator()() {
                     ->AsOutput();
 
   auto next_op = pattern->NewNode(next_op_repr())->assert_is_op();
-  auto next_output = pattern->NewNode(next_op_out_repr())
-                    ->AsOutput();
+  auto next_output = pattern->NewNode(next_op_out_repr())->AsOutput();
 
   // Check if op is MKL-DNN enabled
   possible_inplace_op->assert_op_attr("use_mkldnn", true);

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1835,7 +1835,6 @@ PDNode *patterns::MultipleQuantize::operator()() {
 }
 
 PDNode *patterns::MKLDNNInPlace::operator()() {
-
   auto possible_inplace_op =
       pattern->NewNode(inplace_to_be_op_repr())
           ->assert_is_ops({"elementwise_add", "softmax"});

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -1099,11 +1099,13 @@ struct MKLDNNInPlace : public PatternBase {
       : PatternBase(pattern, name_scope, "mkldnn_inplace") {}
   PDNode* operator()();
 
-  // MKL-DNN's in-place ops: BatchNorm, Softmax, Layer Norm
+  // MKL-DNN's in-place ops: BatchNorm, Softmax, Elementwise_add
+  PATTERN_DECL_NODE(prev_op);
   PATTERN_DECL_NODE(inplace_to_be_op);
   PATTERN_DECL_NODE(inplace_to_be_op_in);
   PATTERN_DECL_NODE(inplace_to_be_op_out);
   PATTERN_DECL_NODE(next_op);
+  PATTERN_DECL_NODE(next_op_out);
 };
 
 struct TransposeFlattenConcat : public PatternBase {

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -1100,7 +1100,6 @@ struct MKLDNNInPlace : public PatternBase {
   PDNode* operator()();
 
   // MKL-DNN's in-place ops: BatchNorm, Softmax, Elementwise_add
-  PATTERN_DECL_NODE(prev_op);
   PATTERN_DECL_NODE(inplace_to_be_op);
   PATTERN_DECL_NODE(inplace_to_be_op_in);
   PATTERN_DECL_NODE(inplace_to_be_op_out);

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -130,11 +130,11 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     current_op->Op()->SetOutput(
         out_name, std::vector<std::string>({current_op_out->Name()}));
 
-    // If next op in a line is doing inplace 
+    // If next op in a line is doing inplace
     // then we need to update its output as well
-    
+
     // Get inferer of next op
-    // If no inferer then we are done 
+    // If no inferer then we are done
     auto& next_op_infer_inplace =
         OpInfoMap::Instance().Get(next_op->Op()->Type()).infer_inplace_;
     if (next_op_infer_inplace) {
@@ -144,13 +144,14 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       auto inputs = op->Inputs();
       auto outputs = op->Outputs();
       // Check if in-place happened
-      if(inputs[in_to_outs.begin()->first] == outputs[in_to_outs.begin()->second] ) {
-        VLOG(3) << "MKL-DNN InPlace: Next Op is in-placed , updating its input and output var!";
+      if (inputs[in_to_outs.begin()->first] ==
+          outputs[in_to_outs.begin()->second]) {
+        VLOG(3) << "MKL-DNN InPlace: Next Op is in-placed , updating its input "
+                   "and output var!";
         next_op->Op()->SetOutput(
             out_name, std::vector<std::string>({current_op_out->Name()}));
         next_op_out->RenameVar(current_op_in->Name());
       }
-
     }
     // Rename input of next op
     next_op->Op()->RenameInput(original_name, current_op_out->Name());

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -143,7 +143,7 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
             out_name, std::vector<std::string>({current_op_out->Name()}));
         next_op_out->RenameVar(current_op_in->Name());
         // Get ops that next_op_out is linked to and update their input
-        auto next_op_out_consumers = next_op_out->outputs; // Has to be ops
+        auto next_op_out_consumers = next_op_out->outputs;  // Has to be ops
         for (auto& c : next_op_out_consumers) {
           c->Op()->RenameInput(original_name, current_op_out->Name());
         }

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -106,20 +106,20 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     } else {
       VLOG(3) << "DNNL Inplace: Current op already inplaced! ";
     }
-   
+
     // It may be that next op is reusing some of vars, we need to
     // make sure that unwanted inplace is not created
     // TODO(jczaja): Make UT for that one
     auto& next_op_infer_inplace =
         OpInfoMap::Instance().Get(next_op->Op()->Type()).infer_inplace_;
-    if((next_op_infer_inplace == nullptr) ) {
-      for(auto& n : next_op->outputs) {
+    if ((next_op_infer_inplace == nullptr)) {
+      for (auto& n : next_op->outputs) {
         if (n->Name() == current_op_out->Name()) {
           VLOG(3) << "DNNL in-place pass FAIL: in-place var cannot "
-                   "be an output to non-inplaced next op";
+                     "be an output to non-inplaced next op";
           return;
         }
-      } 
+      }
     }
 
     auto original_name =

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -114,7 +114,7 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
         OpInfoMap::Instance().Get(next_op->Op()->Type()).infer_inplace_;
     if ((next_op_infer_inplace == nullptr)) {
       for (auto& n : next_op->outputs) {
-        if (n->Name() == current_op_out->Name()) {
+        if (n->Name() == current_op_in->Name()) {
           VLOG(3) << "DNNL in-place pass FAIL: in-place var cannot "
                      "be an output to non-inplaced next op";
           return;

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -106,17 +106,17 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     } else {
       VLOG(3) << "DNNL Inplace: Current op already inplaced! ";
     }
-   
+
     // It may be that next op is reusing some of vars, we need to
     // make sure that unwanted inplace is not created
     auto& next_op_infer_inplace =
         OpInfoMap::Instance().Get(next_op->Op()->Type()).infer_inplace_;
-    if((next_op_infer_inplace == nullptr) &&
+    if ((next_op_infer_inplace == nullptr) &&
         next_op_out->Name() == current_op_out->Name()) {
       VLOG(3) << "DNNL in-place pass FAIL: in-place var cannot "
                  "be an output to non-inplaced next op";
       return;
-    } 
+    }
 
     auto original_name =
         original_output_names[current_op->Name() + current_op_in->Name()];

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -130,16 +130,17 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       auto outputs = op->Outputs();
       // Check if in-place happened
       // for variable we changed (original name)
+      //TODO(jczaja): make recursive propagation of inplace
       auto next_op_inplace_inputs = inputs[in_to_outs.begin()->first];
       if ((next_op_inplace_inputs == outputs[in_to_outs.begin()->second]) &&
           (std::find(next_op_inplace_inputs.begin(),
                      next_op_inplace_inputs.end(),
                      original_name) != next_op_inplace_inputs.end())) {
-        VLOG(3) << "MKL-DNN InPlace: Next Op is in-placed , updating its input "
+        VLOG(3) << "TODO: MKL-DNN InPlace: Next Op is in-placed , updating its input "
                    "and output var!";
-        next_op->Op()->SetOutput(
-            out_name, std::vector<std::string>({current_op_out->Name()}));
-        next_op_out->RenameVar(current_op_in->Name());
+        //next_op->Op()->SetOutput(
+        //    out_name, std::vector<std::string>({current_op_out->Name()}));
+        //next_op_out->RenameVar(current_op_in->Name());
       }
     }
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -88,43 +88,49 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
           for (auto& it : inputs) {
             for (auto& var_name : it.second) {
               if (var_name == in_place_input) {
-                  if (n->id() == next_op->id()) {
-                    // If next op is already having inplace var
-                    // among its inputs then do not perform inplacing
-                    if (count_specific_vars(inputs, var_name) > 0) {
-                      VLOG(3) << "MKL-DNN in-place pass FAIL: in-place var cannot "
-                                 "be an "
-                                 "input to next op in same chain";
-                      return;
-                    }
-                  } else if (n->id() == prev_op->id()) {
-                    // Ok if op that is having current op input as its own
-                    // input is directly before current op, and prev op
-                    // is also in-place then we can in-placed current op
-                    if (count_specific_vars(outputs, var_name) > 0) {
-                      VLOG(3) << "MKL-DNN in-place pass OK: in-place var is "
-                                 "an input of prev op, but also of inplaced op.";
-                    } else {
-                      VLOG(3)
-                          << "MKL-DNN in-place pass FAIL: in-place var cannot be "
-                             "an "
-                             "input to more than one operator of diffrent branches";
-                      return;
-                    }
+                if (n->id() == next_op->id()) {
+                  // If next op is already having inplace var
+                  // among its inputs then do not perform inplacing
+                  if (count_specific_vars(inputs, var_name) > 0) {
+                    VLOG(3)
+                        << "MKL-DNN in-place pass FAIL: in-place var cannot "
+                           "be an "
+                           "input to next op in same chain";
+                    return;
+                  }
+                } else if (n->id() == prev_op->id()) {
+                  // Ok if op that is having current op input as its own
+                  // input is directly before current op, and prev op
+                  // is also in-place then we can in-placed current op
+                  if (count_specific_vars(outputs, var_name) > 0) {
+                    VLOG(3) << "MKL-DNN in-place pass OK: in-place var is "
+                               "an input of prev op, but also of inplaced op.";
                   } else {
-                   // Neither prev_op or next_op
-                   // If some no in pattern node is having our current input var among its 
-                   // inputs,  it is usually cycle, unless current op is already inplaced
-                   if (current_op_in->Name() == current_op_out->Name()) {
-                      VLOG(3) << "MKL-DNN in-place pass OK: op was in-placed already,"
-                                 "but its output is used in multiple ops.";
-                   } else {
-                      VLOG(3)
-                          << "MKL-DNN in-place pass FAIL: in-place var cannot be "
-                             "an "
-                             "input to more than one operator of diffrent branches";
-                      return;
-                   }
+                    VLOG(3)
+                        << "MKL-DNN in-place pass FAIL: in-place var cannot be "
+                           "an "
+                           "input to more than one operator of diffrent "
+                           "branches";
+                    return;
+                  }
+                } else {
+                  // Neither prev_op or next_op
+                  // If some no in pattern node is having our current input var
+                  // among its
+                  // inputs,  it is usually cycle, unless current op is already
+                  // inplaced
+                  if (current_op_in->Name() == current_op_out->Name()) {
+                    VLOG(3)
+                        << "MKL-DNN in-place pass OK: op was in-placed already,"
+                           "but its output is used in multiple ops.";
+                  } else {
+                    VLOG(3)
+                        << "MKL-DNN in-place pass FAIL: in-place var cannot be "
+                           "an "
+                           "input to more than one operator of diffrent "
+                           "branches";
+                    return;
+                  }
                 }
               }
             }
@@ -171,8 +177,9 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     if (current_op_in->Name() != current_op_out->Name()) {
       next_op->Op()->RenameInput(original_name, current_op_out->Name());
     } else {
-      // TODO(jczaja): Improve this for more complex situations 
-      next_op->Op()->SetInput("X",std::vector<std::string>({current_op_out->Name()}));
+      // TODO(jczaja): Improve this for more complex situations
+      next_op->Op()->SetInput(
+          "X", std::vector<std::string>({current_op_out->Name()}));
     }
 
     found_inplace_count++;

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -69,12 +69,14 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     auto outputs = current_op->Op()->Outputs();
     auto in_to_outs = infer_inplace(false);  // strictly no CUDA for MKL-DNN
     VLOG(3) << "MKL-DNN InplaceInferer op(" << current_op->id() << ") "
-     << in_to_outs.begin()->first << ": " << inputs[in_to_outs.begin()->first][0] 
-     << " " << in_to_outs.begin()->second << ": "<< outputs[in_to_outs.begin()->second][0];
+            << in_to_outs.begin()->first << ": "
+            << inputs[in_to_outs.begin()->first][0] << " "
+            << in_to_outs.begin()->second << ": "
+            << outputs[in_to_outs.begin()->second][0];
     // If InferInplace pattern does not contain input node then skip
     auto inplace_input_vec = inputs[in_to_outs.begin()->first];
     if (std::find(inplace_input_vec.begin(), inplace_input_vec.end(),
-          current_op_in->Name()) == inplace_input_vec.end()) {
+                  current_op_in->Name()) == inplace_input_vec.end()) {
       VLOG(3) << "MKL-DNN in-place pass SKIP pattern ";
       return;
     }
@@ -159,11 +161,13 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     // but original name to be changed is gone, so we need to remember it
     // on first time given op is to be inplaced
     if (current_op_in->Name() != current_op_out->Name()) {
-      original_output_names[current_op->Name() + current_op_in->Name()] = current_op_out->Name();
+      original_output_names[current_op->Name() + current_op_in->Name()] =
+          current_op_out->Name();
     } else {
-      VLOG(3) << "MKL-DNN Inplace: Current op already inplaced! "; 
+      VLOG(3) << "MKL-DNN Inplace: Current op already inplaced! ";
     }
-    auto original_name = original_output_names[current_op->Name()+ current_op_in->Name()];
+    auto original_name =
+        original_output_names[current_op->Name() + current_op_in->Name()];
     current_op_out->RenameVar(current_op_in->Name());
 
     // Get mapping of input to output

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -90,7 +90,9 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
               if (var_name == in_place_input) {
 
                 switch(n->id()) {
-                  case next_op->id():
+                  auto nextid =  next_op->id();
+                  auto previd =  prev_op->id();
+                  case nextid:
                     // If next op is already having inplace var
                     // among its inputs then do not perform inplacing
                     if (count_specific_vars(inputs, var_name) > 0) {
@@ -100,7 +102,7 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
                       return;
                     }
                   break;
-                  case prev_op->id():
+                  case previd:
                     // Ok if op that is having current op input as its own
                     // input is directly before current op, and prev op
                     // is also in-place then we can in-placed current op

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -86,16 +86,6 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       VLOG(3) << "MKL-DNN in-place pass SKIP pattern ";
       return;
     }
-    auto count_specific_vars = [](VariableNameMap& mapvar,
-                                  std::string& target_var_name) {
-      unsigned int count = 0;
-      for (auto& it : mapvar) {
-        for (auto& var_name : it.second) {
-          count += (var_name == target_var_name) ? 1 : 0;
-        }
-      }
-      return count;
-    };
 
     // Checking if this particular node (to be inplaced, overwritten)
     // is used anywhere else apart from inplaced op

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -65,6 +65,19 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       return;
     }
 
+    auto inputs = current_op->Op()->Inputs();
+    auto outputs = current_op->Op()->Outputs();
+    auto in_to_outs = infer_inplace(false);  // strictly no CUDA for MKL-DNN
+    VLOG(3) << "MKL-DNN InplaceInferer op(" << current_op->id() << ") "
+     << in_to_outs.begin()->first << ": " << inputs[in_to_outs.begin()->first][0] 
+     << " " << in_to_outs.begin()->second << ": "<< outputs[in_to_outs.begin()->second][0];
+    // If InferInplace pattern does not contain input node then skip
+    auto inplace_input_vec = inputs[in_to_outs.begin()->first];
+    if (std::find(inplace_input_vec.begin(), inplace_input_vec.end(),
+          current_op_in->Name()) == inplace_input_vec.end()) {
+      VLOG(3) << "MKL-DNN in-place pass SKIP pattern ";
+      return;
+    }
     auto count_specific_vars = [](VariableNameMap& mapvar,
                                   std::string& target_var_name) {
       unsigned int count = 0;
@@ -146,13 +159,14 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     // but original name to be changed is gone, so we need to remember it
     // on first time given op is to be inplaced
     if (current_op_in->Name() != current_op_out->Name()) {
-      original_output_names[current_op->Name()] = current_op_out->Name();
+      original_output_names[current_op->Name() + current_op_in->Name()] = current_op_out->Name();
+    } else {
+      VLOG(3) << "MKL-DNN Inplace: Current op already inplaced! "; 
     }
-    auto original_name = original_output_names[current_op->Name()];
+    auto original_name = original_output_names[current_op->Name()+ current_op_in->Name()];
     current_op_out->RenameVar(current_op_in->Name());
 
     // Get mapping of input to output
-    auto in_to_outs = infer_inplace(false);  // strictly no CUDA for MKL-DNN
     auto out_name = in_to_outs.begin()->second;
     current_op->Op()->SetOutput(
         out_name, std::vector<std::string>({current_op_out->Name()}));

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -88,11 +88,7 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
           for (auto& it : inputs) {
             for (auto& var_name : it.second) {
               if (var_name == in_place_input) {
-
-                switch(n->id()) {
-                  int nextid =  next_op->id();
-                  int previd =  prev_op->id();
-                  case nextid:
+                  if (n->id() == next_op->id()) {
                     // If next op is already having inplace var
                     // among its inputs then do not perform inplacing
                     if (count_specific_vars(inputs, var_name) > 0) {
@@ -101,8 +97,7 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
                                  "input to next op in same chain";
                       return;
                     }
-                  break;
-                  case previd:
+                  } else if (n->id() == prev_op->id()) {
                     // Ok if op that is having current op input as its own
                     // input is directly before current op, and prev op
                     // is also in-place then we can in-placed current op
@@ -116,8 +111,8 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
                              "input to more than one operator of diffrent branches";
                       return;
                     }
-                  
-                  default: // Neither prev_op or next_op
+                  } else {
+                   // Neither prev_op or next_op
                    // If some no in pattern node is having our current input var among its 
                    // inputs,  it is usually cycle, unless current op is already inplaced
                    if (current_op_in->Name() == current_op_out->Name()) {
@@ -130,7 +125,6 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
                              "input to more than one operator of diffrent branches";
                       return;
                    }
-                  break;
                 }
               }
             }

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -140,7 +140,6 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       }
     }
 
-
     // If this op was alrady inplaced in previous pass placements
     // then we need to update input of next op
     // but original name to be changed is gone, so we need to remember it

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -90,8 +90,8 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
               if (var_name == in_place_input) {
 
                 switch(n->id()) {
-                  auto nextid =  next_op->id();
-                  auto previd =  prev_op->id();
+                  int nextid =  next_op->id();
+                  int previd =  prev_op->id();
                   case nextid:
                     // If next op is already having inplace var
                     // among its inputs then do not perform inplacing

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -130,17 +130,18 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       auto outputs = op->Outputs();
       // Check if in-place happened
       // for variable we changed (original name)
-      //TODO(jczaja): make recursive propagation of inplace
+      // TODO(jczaja): make recursive propagation of inplace
       auto next_op_inplace_inputs = inputs[in_to_outs.begin()->first];
       if ((next_op_inplace_inputs == outputs[in_to_outs.begin()->second]) &&
           (std::find(next_op_inplace_inputs.begin(),
                      next_op_inplace_inputs.end(),
                      original_name) != next_op_inplace_inputs.end())) {
-        VLOG(3) << "TODO: MKL-DNN InPlace: Next Op is in-placed , updating its input "
+        VLOG(3) << "TODO: MKL-DNN InPlace: Next Op is in-placed , updating its "
+                   "input "
                    "and output var!";
-        //next_op->Op()->SetOutput(
+        // next_op->Op()->SetOutput(
         //    out_name, std::vector<std::string>({current_op_out->Name()}));
-        //next_op_out->RenameVar(current_op_in->Name());
+        // next_op_out->RenameVar(current_op_in->Name());
       }
     }
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/lod_tensor.h"

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -106,16 +106,20 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     } else {
       VLOG(3) << "DNNL Inplace: Current op already inplaced! ";
     }
-
+   
     // It may be that next op is reusing some of vars, we need to
     // make sure that unwanted inplace is not created
+    // TODO(jczaja): Make UT for that one
     auto& next_op_infer_inplace =
         OpInfoMap::Instance().Get(next_op->Op()->Type()).infer_inplace_;
-    if ((next_op_infer_inplace == nullptr) &&
-        next_op_out->Name() == current_op_out->Name()) {
-      VLOG(3) << "DNNL in-place pass FAIL: in-place var cannot "
-                 "be an output to non-inplaced next op";
-      return;
+    if((next_op_infer_inplace == nullptr) ) {
+      for(auto& n : next_op->outputs) {
+        if (n->Name() == current_op_out->Name()) {
+          VLOG(3) << "DNNL in-place pass FAIL: in-place var cannot "
+                   "be an output to non-inplaced next op";
+          return;
+        }
+      } 
     }
 
     auto original_name =

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -64,13 +64,12 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       return;
     }
 
-
     VLOG(3) << "MKL-DNN Inplace op(" << current_op->id() << ") "
-    << "Curr Node In: "<< current_op_in->Name() << " Curr Node out: " 
-    << current_op_out->Name(); 
+            << "Curr Node In: " << current_op_in->Name()
+            << " Curr Node out: " << current_op_out->Name();
 
     VLOG(3) << "MKL-DNN Inplace next op(" << next_op->id() << ") "
-    << " next Node out: " << next_op_out->Name(); 
+            << " next Node out: " << next_op_out->Name();
 
     auto inputs = current_op->Op()->Inputs();
     auto outputs = current_op->Op()->Outputs();
@@ -102,13 +101,10 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
     // is used anywhere else apart from inplaced op
     auto input_consumers = current_op_in->outputs;
     if (input_consumers.size() > 1) {
-      VLOG(3)
-          << "MKL-DNN in-place pass FAIL: in-place var cannot "
-             "be an input to multiple operators";
+      VLOG(3) << "MKL-DNN in-place pass FAIL: in-place var cannot "
+                 "be an input to multiple operators";
       return;
     }
-    
-
 
     // If this op was alrady inplaced in previous pass placements
     // then we need to update input of next op
@@ -144,9 +140,11 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
       auto outputs = op->Outputs();
       // Check if in-place happened
       // for variable we changed (original name)
-      auto next_op_inplace_inputs =  inputs[in_to_outs.begin()->first];
+      auto next_op_inplace_inputs = inputs[in_to_outs.begin()->first];
       if ((next_op_inplace_inputs == outputs[in_to_outs.begin()->second]) &&
-          (std::find(next_op_inplace_inputs.begin(), next_op_inplace_inputs.end(), original_name) != next_op_inplace_inputs.end())) {
+          (std::find(next_op_inplace_inputs.begin(),
+                     next_op_inplace_inputs.end(),
+                     original_name) != next_op_inplace_inputs.end())) {
         VLOG(3) << "MKL-DNN InPlace: Next Op is in-placed , updating its input "
                    "and output var!";
         next_op->Op()->SetOutput(

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass.cc
@@ -139,9 +139,14 @@ void MKLDNNInPlacePass::ApplyImpl(ir::Graph* graph) const {
         VLOG(3) << "TODO: MKL-DNN InPlace: Next Op is in-placed , updating its "
                    "input "
                    "and output var!";
-        // next_op->Op()->SetOutput(
-        //    out_name, std::vector<std::string>({current_op_out->Name()}));
-        // next_op_out->RenameVar(current_op_in->Name());
+        next_op->Op()->SetOutput(
+            out_name, std::vector<std::string>({current_op_out->Name()}));
+        next_op_out->RenameVar(current_op_in->Name());
+        // Get ops that next_op_out is linked to and update their input
+        auto next_op_out_consumers = next_op_out->outputs; // Has to be ops
+        for (auto& c : next_op_out_consumers) {
+          c->Op()->RenameInput(original_name, current_op_out->Name());
+        }
       }
     }
 

--- a/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/mkldnn_inplace_pass_tester.cc
@@ -87,11 +87,8 @@ class MKLDNNInplacePassTest {
     SetOp(&prog, "elementwise_add", "elementwise_add1",
           std::vector<std::string>({"h", "i"}), std::vector<std::string>({"j"}),
           mkldnn_enabled_op.compare("elementwise_add") == 0);
-    SetOp(&prog, "elementwise_add", "elementwise_add2",
-          std::vector<std::string>({"j", "k"}), std::vector<std::string>({"l"}),
-          mkldnn_enabled_op.compare("elementwise_add") == 0);
-    SetOp(&prog, "relu", "relu2", std::vector<std::string>({"l"}),
-          std::vector<std::string>({"m"}),
+    SetOp(&prog, "relu", "relu2", std::vector<std::string>({"j"}),
+          std::vector<std::string>({"k"}),
           mkldnn_enabled_op.compare("softmax") == 0);
     if (branched == true) {
       SetOp(&prog, "softmax", "softmax2", std::vector<std::string>({"g"}),
@@ -154,7 +151,7 @@ TEST(MKLDNNInplacePass, inplace_softmax_branched) {
 
 TEST(MKLDNNInplacePass, inplace_elementwise_add) {
   // Two elementwise_add mkl-dnn enabled op instances to be made inplace
-  MKLDNNInplacePassTest().MainTest("elementwise_add", false, 2);
+  MKLDNNInplacePassTest().MainTest("elementwise_add", false, 1);
 }
 }  // namespace ir
 }  // namespace framework

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -56,39 +56,33 @@ class EltwiseAddMKLDNNKernel : public framework::OpKernel<T> {
         y->format(), MKLDNNMemoryFormat::undef,
         platform::errors::InvalidArgument("Wrong format set for Y tensor"));
 
-    const T* x_data = x->data<T>();
-    const T* y_data = y->data<T>();
-
     auto src_x_tz = framework::vectorize<int64_t>(x->dims());
     auto src_y_tz = framework::vectorize<int64_t>(y->dims());
     auto dst_tz = framework::vectorize<int64_t>(z->dims());
 
-    std::vector<float> scales = {1.0f, 1.0f};
+    // Currently MKL-DNN kernel supports only Z <- X + Y, shape(X) == shape(Y)
+    // TODO(jczaja): Binary primitive support broadcasting, so we can support this in kernel
+    platform::BinaryMKLDNNHandler<T> handler(dnnl::algorithm::binary_add,
+src_x_tz, x->format(), y->format(), dev_ctx, ctx.GetPlace(), ctx.OutputName("Out"));
 
-    const std::string key =
-        platform::CreateKey(src_x_tz, ctx.OutputName("Out"));
+    auto src_x_memory = handler.AcquireSrcMemory(x);
+    auto src_y_memory = handler.AcquireSecondSrcMemory(y);
 
-    platform::SumMKLDNNHandler handler(dev_ctx, mkldnn_engine, key);
+    // For Inplace src and and dst are the same memory object
+    auto dst_memory = x->Holder() == z->Holder() ? src_x_memory : handler.AcquireDstMemory(z);
 
-    auto src_x_memory = handler.AcquireSrcMemory(
-        {{src_x_tz}, platform::MKLDNNGetDataType<T>(), x->format()},
-        paddle::platform::to_void_cast(x_data));
-    auto src_y_memory = handler.AcquireSecondSrcMemory(
-        {{src_y_tz}, platform::MKLDNNGetDataType<T>(), y->format()},
-        paddle::platform::to_void_cast(y_data));
-    auto dst_md = memory::desc({dst_tz}, platform::MKLDNNGetDataType<T>(),
-                               MKLDNNMemoryFormat::any);
-    auto sum_pd = handler.AcquireSumPrimitiveDescriptor(
-        {src_x_memory, src_y_memory}, scales, dst_md);
-    T* z_data =
-        z->mutable_data<T>(ctx.GetPlace(), sum_pd->dst_desc().get_size());
-    auto dst_memory = handler.AcquireDstMemoryFromPrimitive(z_data);
-    auto sum_prim = handler.AcquireSum();
+    auto binary_prim = handler.AcquireForwardPrimitive();
 
     mkldnn::stream astream(mkldnn_engine);
-    sum_prim->execute(astream, {{MKLDNN_ARG_MULTIPLE_SRC, *src_x_memory},
-                                {MKLDNN_ARG_MULTIPLE_SRC + 1, *src_y_memory},
-                                {MKLDNN_ARG_DST, *dst_memory}});
+
+    std::unordered_map<int, dnnl::memory> args =
+    {
+       {DNNL_ARG_SRC_0, *src_x_memory},
+       {DNNL_ARG_SRC_1, *src_y_memory},
+       {DNNL_ARG_DST,  *dst_memory}
+    };
+
+    binary_prim->execute(astream, args);
     astream.wait();
 
     z->set_layout(DataLayout::kMKLDNN);

--- a/paddle/fluid/operators/mkldnn/inplace_op_tests.cmake
+++ b/paddle/fluid/operators/mkldnn/inplace_op_tests.cmake
@@ -1,2 +1,2 @@
-cc_test(test_mkldnn_op_inplace SRCS mkldnn/test_mkldnn_op_inplace.cc DEPS op_registry softmax_op softmax scope device_context enforce executor)
+cc_test(test_mkldnn_op_inplace SRCS mkldnn/test_mkldnn_op_inplace.cc DEPS op_registry elementwise_add_op softmax_op softmax scope device_context enforce executor)
 

--- a/paddle/fluid/operators/mkldnn/test_mkldnn_op_inplace.cc
+++ b/paddle/fluid/operators/mkldnn/test_mkldnn_op_inplace.cc
@@ -33,23 +33,30 @@ USE_OP_DEVICE_KERNEL(elementwise_add, MKLDNN);
 namespace paddle {
 namespace operators {
 
-struct InputVars
-{
+struct InputVars {
   std::string name;
-  framework::LoDTensor* tensor;
+  framework::LoDTensor *tensor;
 };
 
 template <typename T>
-bool TestMain(const platform::Place &place, const std::string& op_type, const framework::DDim &dims, const int num_inputs) {
+bool TestMain(const platform::Place &place, const std::string &op_type,
+              const framework::DDim &dims, const int num_inputs) {
   framework::Scope scope;
 
   std::vector<InputVars> input_names = {
-    {"x", scope.Var("x")->GetMutable<framework::LoDTensor>()},
-    {"x1", num_inputs > 1 ? scope.Var("x1")->GetMutable<framework::LoDTensor>() : nullptr}
-    {"x2", num_inputs > 2 ? scope.Var("x2")->GetMutable<framework::LoDTensor>() : nullptr}
-    {"x3", num_inputs > 3 ? scope.Var("x3")->GetMutable<framework::LoDTensor>() : nullptr}
-    {"x4", num_inputs > 4 ? scope.Var("x4")->GetMutable<framework::LoDTensor>() : nullptr}
-  };
+      {"x", scope.Var("x")->GetMutable<framework::LoDTensor>()},
+      {"x1", num_inputs > 1
+                 ? scope.Var("x1")->GetMutable<framework::LoDTensor>()
+                 : nullptr},
+      {"x2", num_inputs > 2
+                 ? scope.Var("x2")->GetMutable<framework::LoDTensor>()
+                 : nullptr},
+      {"x3", num_inputs > 3
+                 ? scope.Var("x3")->GetMutable<framework::LoDTensor>()
+                 : nullptr},
+      {"x4", num_inputs > 4
+                 ? scope.Var("x4")->GetMutable<framework::LoDTensor>()
+                 : nullptr}};
   auto *y = scope.Var("y")->GetMutable<framework::LoDTensor>();
 
   // Initialize input data
@@ -57,15 +64,15 @@ bool TestMain(const platform::Place &place, const std::string& op_type, const fr
                                          static_cast<T>(20.0));
   std::mt19937 engine;
   size_t numel = static_cast<size_t>(framework::product(dims));
-  for(int i=0; i<num_inputs; ++i) {
-     input_names[i].tensor->Resize(dims);
-     auto data_ptr = input_names[i].tensor->mutable_data<T>(place);
-     for (size_t i = 0; i < numel; ++i) {
-       data_ptr[i] = dist(engine);
-     }
+  for (int i = 0; i < num_inputs; ++i) {
+    input_names[i].tensor->Resize(dims);
+    auto data_ptr = input_names[i].tensor->mutable_data<T>(place);
+    for (size_t i = 0; i < numel; ++i) {
+      data_ptr[i] = dist(engine);
+    }
   }
 
-  // Initialize output 
+  // Initialize output
   y->Resize(dims);
   auto y_ptr = y->mutable_data<T>(place);
   for (size_t i = 0; i < numel; ++i) {
@@ -75,8 +82,12 @@ bool TestMain(const platform::Place &place, const std::string& op_type, const fr
   auto &pool = platform::DeviceContextPool::Instance();
 
   // Out of place (reference) computation
-  auto op_ref = num_inputs > 1 ? 
-framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}, {"Y", {"x1"}}}, {{"Out", {"y"}}}, {{"use_mkldnn", {true}}}) :framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}}, {{"Out", {"y"}}}, {{"use_mkldnn", {true}}});
+  auto op_ref = num_inputs > 1 ? framework::OpRegistry::CreateOp(
+                                     op_type, {{"X", {"x"}}, {"Y", {"x1"}}},
+                                     {{"Out", {"y"}}}, {{"use_mkldnn", {true}}})
+                               : framework::OpRegistry::CreateOp(
+                                     op_type, {{"X", {"x"}}}, {{"Out", {"y"}}},
+                                     {{"use_mkldnn", {true}}});
 
   op_ref->Run(scope, place);
   pool.Get(place)->Wait();
@@ -85,9 +96,12 @@ framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}, {"Y", {"x1"}}}, {{"Out",
   auto &ref_tensor = scope.FindVar("y")->Get<framework::LoDTensor>();
 
   // In-place (to be tested) computation
-  auto op = num_inputs > 1 ? 
-  framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}, {"Y", {"x1"}}}, {{"Out", {"x"}}}, {{"use_mkldnn", {true}}}) :
-  framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}}, {{"Out", {"x"}}}, {{"use_mkldnn", {true}}});
+  auto op = num_inputs > 1 ? framework::OpRegistry::CreateOp(
+                                 op_type, {{"X", {"x"}}, {"Y", {"x1"}}},
+                                 {{"Out", {"x"}}}, {{"use_mkldnn", {true}}})
+                           : framework::OpRegistry::CreateOp(
+                                 op_type, {{"X", {"x"}}}, {{"Out", {"x"}}},
+                                 {{"use_mkldnn", {true}}});
 
   op->Run(scope, place);
   platform::DeviceContextPool::Instance().Get(place)->Wait();
@@ -95,7 +109,7 @@ framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}, {"Y", {"x1"}}}, {{"Out",
   // Get in-place result
   auto &out_tensor = scope.FindVar("x")->Get<framework::LoDTensor>();
   PADDLE_ENFORCE_EQ(
-      &out_tensor, x,
+      &out_tensor, input_names[0].tensor,
       platform::errors::InvalidArgument(
           "Input and output vars should share tensor for In-place test"));
 

--- a/paddle/fluid/operators/mkldnn/test_mkldnn_op_inplace.cc
+++ b/paddle/fluid/operators/mkldnn/test_mkldnn_op_inplace.cc
@@ -27,38 +27,57 @@
 
 USE_OP(softmax);
 USE_OP_DEVICE_KERNEL(softmax, MKLDNN);
+USE_OP(elementwise_add);
+USE_OP_DEVICE_KERNEL(elementwise_add, MKLDNN);
 
 namespace paddle {
 namespace operators {
 
+struct InputVars
+{
+  std::string name;
+  framework::LoDTensor* tensor;
+};
+
 template <typename T>
-bool TestMain(const platform::Place &place, const framework::DDim &dims) {
+bool TestMain(const platform::Place &place, const std::string& op_type, const framework::DDim &dims, const int num_inputs) {
   framework::Scope scope;
-  auto *x = scope.Var("x")->GetMutable<framework::LoDTensor>();
+
+  std::vector<InputVars> input_names = {
+    {"x", scope.Var("x")->GetMutable<framework::LoDTensor>()},
+    {"x1", num_inputs > 1 ? scope.Var("x1")->GetMutable<framework::LoDTensor>() : nullptr}
+    {"x2", num_inputs > 2 ? scope.Var("x2")->GetMutable<framework::LoDTensor>() : nullptr}
+    {"x3", num_inputs > 3 ? scope.Var("x3")->GetMutable<framework::LoDTensor>() : nullptr}
+    {"x4", num_inputs > 4 ? scope.Var("x4")->GetMutable<framework::LoDTensor>() : nullptr}
+  };
   auto *y = scope.Var("y")->GetMutable<framework::LoDTensor>();
 
-  x->Resize(dims);
-  y->Resize(dims);
-
-  size_t numel = static_cast<size_t>(framework::product(dims));
-
-  auto x_ptr = x->mutable_data<T>(place);
-  auto y_ptr = y->mutable_data<T>(place);
-
+  // Initialize input data
   std::uniform_real_distribution<T> dist(static_cast<T>(10.0),
                                          static_cast<T>(20.0));
   std::mt19937 engine;
+  size_t numel = static_cast<size_t>(framework::product(dims));
+  for(int i=0; i<num_inputs; ++i) {
+     input_names[i].tensor->Resize(dims);
+     auto data_ptr = input_names[i].tensor->mutable_data<T>(place);
+     for (size_t i = 0; i < numel; ++i) {
+       data_ptr[i] = dist(engine);
+     }
+  }
 
+  // Initialize output 
+  y->Resize(dims);
+  auto y_ptr = y->mutable_data<T>(place);
   for (size_t i = 0; i < numel; ++i) {
-    x_ptr[i] = dist(engine);
     y_ptr[i] = static_cast<T>(0);
   }
 
   auto &pool = platform::DeviceContextPool::Instance();
 
   // Out of place (reference) computation
-  auto op_ref = framework::OpRegistry::CreateOp(
-      "softmax", {{"X", {"x"}}}, {{"Out", {"y"}}}, {{"use_mkldnn", {true}}});
+  auto op_ref = num_inputs > 1 ? 
+framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}, {"Y", {"x1"}}}, {{"Out", {"y"}}}, {{"use_mkldnn", {true}}}) :framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}}, {{"Out", {"y"}}}, {{"use_mkldnn", {true}}});
+
   op_ref->Run(scope, place);
   pool.Get(place)->Wait();
 
@@ -66,8 +85,10 @@ bool TestMain(const platform::Place &place, const framework::DDim &dims) {
   auto &ref_tensor = scope.FindVar("y")->Get<framework::LoDTensor>();
 
   // In-place (to be tested) computation
-  auto op = framework::OpRegistry::CreateOp(
-      "softmax", {{"X", {"x"}}}, {{"Out", {"x"}}}, {{"use_mkldnn", {true}}});
+  auto op = num_inputs > 1 ? 
+  framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}, {"Y", {"x1"}}}, {{"Out", {"x"}}}, {{"use_mkldnn", {true}}}) :
+  framework::OpRegistry::CreateOp(op_type, {{"X", {"x"}}}, {{"Out", {"x"}}}, {{"use_mkldnn", {true}}});
+
   op->Run(scope, place);
   platform::DeviceContextPool::Instance().Get(place)->Wait();
 
@@ -88,7 +109,13 @@ bool TestMain(const platform::Place &place, const framework::DDim &dims) {
 TEST(test_softmax_inplace, cpu_place) {
   framework::DDim dims({32, 64});
   platform::CPUPlace p;
-  ASSERT_TRUE(TestMain<float>(p, dims));
+  ASSERT_TRUE(TestMain<float>(p, "softmax", dims, 1));
+}
+
+TEST(test_elementwise_add_inplace, cpu_place) {
+  framework::DDim dims({1, 12, 20, 20});
+  platform::CPUPlace p;
+  ASSERT_TRUE(TestMain<float>(p, "elementwise_add", dims, 2));
 }
 
 }  // namespace operators

--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -101,6 +101,11 @@ inline void MatchShapeToLayout(framework::Tensor* tensor_in,
   }
 }
 
+struct mkldnn_dummy_primitive {
+  struct primitive_desc {};
+  struct desc {};
+};
+
 inline mkldnn::memory::desc MKLDNNMemDesc(const std::vector<int64_t>& dims,
                                           mkldnn::memory::data_type data_type,
                                           MKLDNNMemoryFormat format) {

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -30,7 +30,8 @@ namespace platform {
 using user_function = std::function<std::shared_ptr<float>(const float*)>;
 using memory = mkldnn::memory;
 
-template <typename T, typename TForward, typename TBackward>
+template <typename T, typename TForward,
+          typename TBackward = mkldnn_dummy_primitive>
 class MKLDNNHandlerT {
  public:
   MKLDNNHandlerT(const MKLDNNDeviceContext& dev_ctx, mkldnn::engine engine,
@@ -349,6 +350,37 @@ class MKLDNNHandler {
   mkldnn::engine engine_;
   std::string key_;
   std::string key_common_;
+};
+
+template <typename T>
+class BinaryMKLDNNHandler
+    : public platform::MKLDNNHandlerT<T, dnnl::binary> {
+ public:
+  BinaryMKLDNNHandler(const dnnl::algorithm algo,
+                      const std::vector<int64_t>& dims, 
+                      const MKLDNNMemoryFormat src0_fmt,
+                      const MKLDNNMemoryFormat src1_fmt,
+                      const platform::MKLDNNDeviceContext& dev_ctx,
+                       platform::Place cpu_place, const std::string& uniq_name)
+      : platform::MKLDNNHandlerT<T, dnnl::binary>(
+            dev_ctx, dev_ctx.GetEngine(), cpu_place,
+            platform::CreateKey(dims, uniq_name)) {
+    // TODO(jczaja): Add function checking if data already exists
+    auto src0_md = dnnl::memory::desc(dims, MKLDNNGetDataType<T>(), src0_fmt);
+    auto src1_md = dnnl::memory::desc(dims, MKLDNNGetDataType<T>(), src1_fmt);
+    auto dst_md = memory::desc(dims, MKLDNNGetDataType<T>(), MKLDNNMemoryFormat::any);
+
+    this->AcquireForwardPrimitiveDescriptor( algo, src0_md, src1_md, dst_md);
+  }
+
+  std::shared_ptr<mkldnn::memory> AcquireSecondSrcMemory(
+      const framework::Tensor* input) {
+    const T* input_data = input->data<T>();
+    return this->AcquireMemoryFromPrimitive(
+        this->fwd_pd_->src_desc(), to_void_cast<T>(input_data), "@src1_mem_p");
+  }
+
+
 };
 
 class SumMKLDNNHandler : public MKLDNNHandler {

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -449,7 +449,7 @@ class ActivationMKLDNNHandler
       : platform::MKLDNNHandlerT<T, mkldnn::eltwise_forward,
                                  mkldnn::eltwise_backward>(
             dev_ctx, dev_ctx.GetEngine(), cpu_place,
-            platform::CreateKey(dims, unique_name)) {
+            platform::CreateKey(dims, "a", algorithm, unique_name)) {
     auto md = mkldnn::memory::desc(dims, platform::MKLDNNGetDataType<T>(), fmt);
 
     this->AcquireForwardPrimitiveDescriptor(mkldnn::prop_kind::forward_training,
@@ -467,7 +467,7 @@ class ActivationMKLDNNHandler
       : platform::MKLDNNHandlerT<T, mkldnn::eltwise_forward,
                                  mkldnn::eltwise_backward>(
             dev_ctx, dev_ctx.GetEngine(), cpu_place,
-            platform::CreateKey(dims, unique_name)) {
+            platform::CreateKey(dims, "a", algorithm, unique_name)) {
     auto diff_dst_md = platform::MKLDNNMemDesc(
         dims, platform::MKLDNNGetDataType<T>(), diff_fmt);
     auto src_md =

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -353,24 +353,24 @@ class MKLDNNHandler {
 };
 
 template <typename T>
-class BinaryMKLDNNHandler
-    : public platform::MKLDNNHandlerT<T, dnnl::binary> {
+class BinaryMKLDNNHandler : public platform::MKLDNNHandlerT<T, dnnl::binary> {
  public:
   BinaryMKLDNNHandler(const dnnl::algorithm algo,
-                      const std::vector<int64_t>& dims, 
+                      const std::vector<int64_t>& dims,
                       const MKLDNNMemoryFormat src0_fmt,
                       const MKLDNNMemoryFormat src1_fmt,
                       const platform::MKLDNNDeviceContext& dev_ctx,
-                       platform::Place cpu_place, const std::string& uniq_name)
+                      platform::Place cpu_place, const std::string& uniq_name)
       : platform::MKLDNNHandlerT<T, dnnl::binary>(
             dev_ctx, dev_ctx.GetEngine(), cpu_place,
             platform::CreateKey(dims, uniq_name)) {
     // TODO(jczaja): Add function checking if data already exists
     auto src0_md = dnnl::memory::desc(dims, MKLDNNGetDataType<T>(), src0_fmt);
     auto src1_md = dnnl::memory::desc(dims, MKLDNNGetDataType<T>(), src1_fmt);
-    auto dst_md = memory::desc(dims, MKLDNNGetDataType<T>(), MKLDNNMemoryFormat::any);
+    auto dst_md =
+        memory::desc(dims, MKLDNNGetDataType<T>(), MKLDNNMemoryFormat::any);
 
-    this->AcquireForwardPrimitiveDescriptor( algo, src0_md, src1_md, dst_md);
+    this->AcquireForwardPrimitiveDescriptor(algo, src0_md, src1_md, dst_md);
   }
 
   std::shared_ptr<mkldnn::memory> AcquireSecondSrcMemory(
@@ -379,8 +379,6 @@ class BinaryMKLDNNHandler
     return this->AcquireMemoryFromPrimitive(
         this->fwd_pd_->src_desc(), to_void_cast<T>(input_data), "@src1_mem_p");
   }
-
-
 };
 
 class SumMKLDNNHandler : public MKLDNNHandler {


### PR DESCRIPTION
This PR is reimplementing elementwise_add mkldnn kernel so that sum DNNL primitive is replaced with binary primitive as it is a bit more efficient and supports inplace execution. mkldnn inplace pass was updated to support elementwise_add mkl-dnn

Performance improvement : 
~2% on ERNIE (B1 Thread 1 Latency:  252 -> 245 fp32 , 90 -> 87  INT8) : Intel Xeon(R) 6248
~1% on BERT (~162 FPS to ~165 FPS) when tested on Intel(R) Xeon(R) CPU E5-2699 v4 @ 2.20GHz       

