### PR TITLE
[Dy2stat] Make loop_transformer supports class variable

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -233,3 +233,20 @@ def if_with_and_or_4(x, y=None):
                                                  mean_res.numpy()[0] > 0):
         x = x - 1
     return x
+
+
+def if_with_class_var(x, y=None):
+    class Foo(object):
+        def __init__(self):
+            self.a = 1
+            self.b = 2
+
+    foo = Foo()
+    batch_size = fluid.layers.shape(x)
+    mean_res = fluid.layers.mean(x)
+
+    if batch_size[0] > foo.a:
+        x = x + foo.b
+    else:
+        x = x - foo.b
+    return x

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
@@ -124,6 +124,26 @@ def test_for_in_else(x):
     return x
 
 
+def while_loop_class_var(x):
+    class Foo(object):
+        def __init__(self):
+            self.a = 3
+            self.b = 4
+            self.c = 5
+
+    foo = Foo()
+    i = fluid.dygraph.to_variable(x)
+    while i < 10:
+        foo.b = fluid.layers.zeros(shape=[1], dtype='float32')
+        foo.c = foo.b + foo.a
+        i += 1
+        if foo.c < 0:
+            continue
+        if foo.c > 6:
+            break
+    return foo.c
+
+
 class TestContinueInFor(unittest.TestCase):
     def setUp(self):
         self.input = np.zeros((1)).astype('int32')
@@ -186,24 +206,15 @@ class TestContinueInWhile(TestContinueInFor):
     def init_dygraph_func(self):
         self.dygraph_func = test_continue_in_while
 
-    def test_transformed_static_result(self):
-        # TODO: while i < 10 in dygraph will be supported after PR22892
-        # so currently we just assert static result.
-        # remove this overrided function after PR22892 is merged
-        static_res = self.run_static_mode()
-        self.assertEqual(15, static_res[0])
-
 
 class TestBreakInWhile(TestContinueInWhile):
     def init_dygraph_func(self):
         self.dygraph_func = test_break_in_while
 
-    def test_transformed_static_result(self):
-        # TODO: while i < 10 in dygraph will be supported after PR22892
-        # so currently we just assert static result.
-        # remove this overrided function after PR22892 is merged
-        static_res = self.run_static_mode()
-        self.assertEqual(15, static_res[0])
+
+class TestWhileLoopClassVar(TestContinueInWhile):
+    def init_dygraph_func(self):
+        self.dygraph_func = while_loop_class_var
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -146,6 +146,12 @@ class TestDygraphIfElseWithAndOr4(TestDygraphIfElse):
         self.dyfunc = if_with_and_or_4
 
 
+class TestDygraphIfElseWithClassVar(TestDygraphIfElse):
+    def setUp(self):
+        self.x = np.random.random([10, 16]).astype('float32')
+        self.dyfunc = if_with_class_var
+
+
 class TestDygraphIfElseNet(unittest.TestCase):
     """
     TestCase for the transformation from control flow `if/else`

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -116,7 +116,7 @@ class TestDygraphIfElse6(TestDygraphIfElse):
         self.dyfunc = dyfunc_ifExp_with_while
 
 
-def dyfunc_ifExp_with_while2(x):
+def dyfunc_ifExp(x):
     y = [x]
 
     def add_fn(x):
@@ -128,16 +128,16 @@ def dyfunc_ifExp_with_while2(x):
 
     i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
     # It will be converted into `layers.cond` as followed.
-    # map_func(lambda x: fluid.layers.cond(i==0, lambda: x, lambda: add_fn(x), y)
-    # `i (Tensor) == 0` is supported in dygraph.
-    y = map_func(lambda x: x if i == 0 else add_fn(x), y)
+    # map_func(lambda x: fluid.layers.cond(i==1, lambda: x, lambda: add_fn(x), y)
+    # `if (Tensor) == 1` is supported in dygraph.
+    y = map_func(lambda x: x if i == 1 else add_fn(x), y)
     return y[0]
 
 
 class TestDygraphIfElse7(TestDygraphIfElse):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')
-        self.dyfunc = dyfunc_ifExp_with_while2
+        self.dyfunc = dyfunc_ifExp
 
 
 class TestDygraphIfElseWithAndOr(TestDygraphIfElse):


### PR DESCRIPTION
This CR makes two changes:

1. In old loop_transformer, if a class variable, such as "self.a, foo.bar" is a loop var, the Dy2stat will fail because `def func(self.foo)` is not legal syntax. We support class variable by renaming.

2. After https://github.com/PaddlePaddle/Paddle/pull/22892 is merged, we can support `while x < 10` in dygraph. I enable those tests in corresponding Dy2stat