### PR TITLE
fix initalization and regularization docs

### DIFF
--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -130,7 +130,7 @@ class Initializer(object):
 
 class ConstantInitializer(Initializer):
     """Implements the constant initializer
-    
+
     Args:
         value (float32): constant value to initialize the variable 
         force_cpu (bool): place for initialization, if set true, initialization will

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -156,9 +156,9 @@ class ConstantInitializer(Initializer):
         """Add constant initialization ops for a variable
 
         Args:
-            var: Variable that needs to be initialized.
+            var: Variable that needs to be initialized
             block: The block in which initialization ops
-                   should be added.
+                   should be added
 
         Returns:
             the initialization op

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -156,9 +156,9 @@ class ConstantInitializer(Initializer):
         """Add constant initialization ops for a variable
 
         Args:
-            var: Variable that needs to be initialized
+            var: Variable that needs to be initialized.
             block: The block in which initialization ops
-                   should be added
+                   should be added.
 
         Returns:
             the initialization op

--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -130,17 +130,19 @@ class Initializer(object):
 
 class ConstantInitializer(Initializer):
     """Implements the constant initializer
-
+    
     Args:
         value (float32): constant value to initialize the variable 
+        force_cpu (bool): place for initialization, if set true, initialization will
+            be forced on CPU even if executor is set on CUDA. default false.
 
     Examples:
         .. code-block:: python
 
     	    import paddle.fluid as fluid
-            x = fluid.data(name="data", shape=[8, 32, 32], dtype="float32")
+            x = fluid.data(name="data", shape=[32, 32], dtype="float32")
 	    fc = fluid.layers.fc(input=x, size=10,
-    		param_attr=fluid.initializer.Constant(value=2.0))
+    		param_attr=fluid.initializer.ConstantInitializer(value=2.0))
 
     """
 
@@ -744,15 +746,16 @@ class BilinearInitializer(Initializer):
         .. code-block:: python
 
             import paddle.fluid as fluid
+            import math
             factor = 2
             C = 2
             B = 8
             H = W = 32
             w_attr = fluid.param_attr.ParamAttr(
-                learning_rate=0., 
+                learning_rate=0.,
                 regularizer=fluid.regularizer.L2Decay(0.),
                 initializer=fluid.initializer.Bilinear())
-            x = fluid.data(name="data", shape=[B, 3, H, W], 
+            x = fluid.data(name="data", shape=[B, 3, H, W],
                                   dtype="float32")
             conv_up = fluid.layers.conv2d_transpose(
                 input=x,

--- a/python/paddle/fluid/regularizer.py
+++ b/python/paddle/fluid/regularizer.py
@@ -134,8 +134,8 @@ class L2DecayRegularizer(WeightDecayRegularizer):
             main_prog = fluid.Program()
             startup_prog = fluid.Program()
             with fluid.program_guard(main_prog, startup_prog):
-                data = fluid.layers.data(name='image', shape=[3, 28, 28], dtype='float32')
-                label = fluid.layers.data(name='label', shape=[1], dtype='int64')
+                data = fluid.data(name='image', shape=[256, 3, 28, 28], dtype='float32')
+                label = fluid.data(name='label', shape=[256, 1], dtype='int64')
                 hidden = fluid.layers.fc(input=data, size=128, act='relu')
                 prediction = fluid.layers.fc(input=hidden, size=10, act='softmax')
                 loss = fluid.layers.cross_entropy(input=prediction, label=label)
@@ -213,8 +213,8 @@ class L1DecayRegularizer(WeightDecayRegularizer):
             main_prog = fluid.Program()
             startup_prog = fluid.Program()
             with fluid.program_guard(main_prog, startup_prog):
-                data = fluid.layers.data(name='image', shape=[3, 28, 28], dtype='float32')
-                label = fluid.layers.data(name='label', shape=[1], dtype='int64')
+                data = fluid.data(name='image', shape=[256, 3, 28, 28], dtype='float32')
+                label = fluid.data(name='label', shape=[256, 1], dtype='int64')
                 hidden = fluid.layers.fc(input=data, size=128, act='relu')
                 prediction = fluid.layers.fc(input=hidden, size=10, act='softmax')
                 loss = fluid.layers.cross_entropy(input=prediction, label=label)


### PR DESCRIPTION
1. change sample code of ConstantInitializer, TruncatedNormalInitializer and BilinearInitializer to  unify with Chinese docs.
![image](https://user-images.githubusercontent.com/14270174/78460241-c440d300-76f1-11ea-9b05-8ce9249b9b10.png)
![image](https://user-images.githubusercontent.com/14270174/78460246-ce62d180-76f1-11ea-8a77-f107d7c31cd0.png)
![image](https://user-images.githubusercontent.com/14270174/78460325-6f518c80-76f2-11ea-81ab-77d40bc6f7d4.png)

2. Change sample code of l1_decay and l2_decay to adapt to paddle1.7.

![image](https://user-images.githubusercontent.com/14270174/78460227-9cea0600-76f1-11ea-988f-6966d611ffb7.png)
![image](https://user-images.githubusercontent.com/14270174/78460214-880d7280-76f1-11ea-9073-9056510a8f87.png)
