### PR TITLE
Op (concat) error message enhancement

### DIFF
--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -31,17 +31,21 @@ class ConcatOp : public framework::OperatorWithKernel {
 
   void InferShape(framework::InferShapeContext *ctx) const override {
     PADDLE_ENFORCE_GE(ctx->Inputs("X").size(), 1UL,
-                      "Inputs(X) of ConcatOp should not be empty.");
+                      platform::errors::InvalidArgument(
+                          "Inputs(X) of ConcatOp should not be empty."));
 
     PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
-                      "Output(Out) of ConcatOp should not be null.");
+                      platform::errors::InvalidArgument(
+                          "Output(Out) of ConcatOp should not be null."));
 
     auto inputs_dims = ctx->GetInputsDim("X");
 
     const size_t inputs_num = inputs_dims.size();
-    PADDLE_ENFORCE_GT(inputs_num, 0,
-                      "ShapeError: Input tensors count should > 0. But "
-                      "recevied inputs' length is 0.");
+    PADDLE_ENFORCE_GT(
+        inputs_num, 0,
+        platform::errors::InvalidArgument(
+            "The number of input tensors in concat op should > 0. But "
+            "recevied inputs' length is 0."));
     if (inputs_num == 1) {
       VLOG(3) << "Warning: concat op have only one input, may waste memory";
     }

--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -30,22 +30,17 @@ class ConcatOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext *ctx) const override {
-    PADDLE_ENFORCE_GE(ctx->Inputs("X").size(), 1UL,
-                      platform::errors::InvalidArgument(
-                          "Inputs(X) of ConcatOp should not be empty."));
-
-    PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
-                      platform::errors::InvalidArgument(
-                          "Output(Out) of ConcatOp should not be null."));
+    OP_INOUT_CHECK(ctx->HasInputs("X"), "Input", "X", "Concat");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "Concat");
 
     auto inputs_dims = ctx->GetInputsDim("X");
 
     const size_t inputs_num = inputs_dims.size();
     PADDLE_ENFORCE_GT(
-        inputs_num, 0,
+        inputs_num, static_cast<size_t>(0),
         platform::errors::InvalidArgument(
             "The number of input tensors in concat op should > 0. But "
-            "recevied inputs' length is 0."));
+            "received inputs' length is 0."));
     if (inputs_num == 1) {
       VLOG(3) << "Warning: concat op have only one input, may waste memory";
     }

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -49,10 +49,11 @@ static inline framework::DDim ComputeAndCheckShape(
           // check all shape in run time
           PADDLE_ENFORCE_EQ(
               inputs_dims[0][j], inputs_dims[i][j],
-              "ShapeError: Dimension %d in inputs' shapes must be equal. "
-              "But recevied input[0]'s shape = "
-              "[%s], input[%d]'s shape = [%s].",
-              j, inputs_dims[0], i, inputs_dims[i]);
+              platform::errors::InvalidArgument(
+                  "ShapeError: Dimension %d in inputs' shapes must be equal. "
+                  "But recevied input[0]'s shape = "
+                  "[%s], input[%d]'s shape = [%s].",
+                  j, inputs_dims[0], i, inputs_dims[i]));
         }
       }
     }
@@ -78,7 +79,9 @@ class ConcatKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto ins = ctx.MultiInput<framework::LoDTensor>("X");
     framework::LoDTensor* out = ctx.Output<framework::LoDTensor>("Out");
-    PADDLE_ENFORCE_EQ(ins[0] != nullptr, true, "The input should not be null.");
+    PADDLE_ENFORCE_EQ(ins[0] != nullptr, true,
+                      platform::errors::InvalidArgument(
+                          " The first input of concat should not be null."));
     auto axis = ctx.Attr<int>("axis");
     bool need_resize_out_dims = false;
     if (ctx.HasInput("AxisTensor")) {
@@ -178,7 +181,9 @@ class ConcatGradKernel : public framework::OpKernel<T> {
         }
       }
     }
-    PADDLE_ENFORCE_EQ(ins[0] != nullptr, true, "The input should not be null.");
+    PADDLE_ENFORCE_EQ(ins[0] != nullptr, true,
+                      platform::errors::InvalidArgument(
+                          "The first input of concat should not be null."));
 
     auto axis = ctx.Attr<int>("axis");
     if (ctx.HasInput("AxisTensor")) {

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -50,10 +50,10 @@ static inline framework::DDim ComputeAndCheckShape(
           PADDLE_ENFORCE_EQ(
               inputs_dims[0][j], inputs_dims[i][j],
               platform::errors::InvalidArgument(
-                  "ShapeError: Dimension %d in inputs' shapes must be equal. "
-                  "But recevied input[0]'s shape = "
+                  "The shape of input[%d] must be equal to input[0]. "
+                  "But received input[0]'s shape = "
                   "[%s], input[%d]'s shape = [%s].",
-                  j, inputs_dims[0], i, inputs_dims[i]));
+                  i, inputs_dims[0], i, inputs_dims[i]));
         }
       }
     }
@@ -79,9 +79,9 @@ class ConcatKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto ins = ctx.MultiInput<framework::LoDTensor>("X");
     framework::LoDTensor* out = ctx.Output<framework::LoDTensor>("Out");
-    PADDLE_ENFORCE_EQ(ins[0] != nullptr, true,
-                      platform::errors::InvalidArgument(
-                          " The first input of concat should not be null."));
+    PADDLE_ENFORCE_NOT_NULL(
+        ins[0], platform::errors::NotFound(
+                    " The first input of concat should not be null."));
     auto axis = ctx.Attr<int>("axis");
     bool need_resize_out_dims = false;
     if (ctx.HasInput("AxisTensor")) {
@@ -181,9 +181,9 @@ class ConcatGradKernel : public framework::OpKernel<T> {
         }
       }
     }
-    PADDLE_ENFORCE_EQ(ins[0] != nullptr, true,
-                      platform::errors::InvalidArgument(
-                          "The first input of concat should not be null."));
+    PADDLE_ENFORCE_NOT_NULL(
+        ins[0], platform::errors::NotFound(
+                    "The first input of concat should not be null."));
 
     auto axis = ctx.Attr<int>("axis");
     if (ctx.HasInput("AxisTensor")) {


### PR DESCRIPTION
### concat 增强输入类型检查 【仅C++端】
注：concat python端检查已经很完整，本次仅修复C++端

```
concat(input, axis=0, name=None)
```

**c++不合规报错检查增强：**

1. 使用OP_INOUT_CHECK，增加输入、输出是否设置的检查。
```
NotFoundError: No Input(X) found for Concat operator.
```
```
NotFoundError: No Output(Out) found for Concat operator.
```
2. 错误类型有误
修改前报错：
```
Error: ShapeError: Input tensors count should > 0. But recevied inputs' length is 0.
```
修改后报错：
```
InvalidArgumentError: The number of input tensors in concat op should > 0. But received inputs' length is 0.
```
3. 错误类型有误，报错内容需改
修改前报错：
```
Error: ShapeError: Dimension 1 in inputs' shapes must be equal. But recevied input[0]'s shape = [2, 3], input[1]'s shape = [2, 2].
```
修改后报错：
```
InvalidArgumentError: The shape of input[1] must be equal to input[0]. But received input[0]'s shape = [2, 3], input[1]'s shape = [2, 2].
```
4. 错误类型有误，报错内容需改
修改前报错：
```
Error: The input should not be null.
```
修改后报错：
```
NotFoundError:  The first input of concat should not be null.
```