### PR TITLE
API(BatchNorm) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -20,6 +20,7 @@ from ..layers import utils
 from ..layers import nn
 from .. import dygraph_utils
 from . import layers
+from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer, _varbase_creator
 from ..param_attr import ParamAttr
 from ..initializer import Normal, Constant, NumpyArrayInitializer
@@ -1146,6 +1147,9 @@ class BatchNorm(layers.Layer):
                 mean_out, variance_out, *attrs)
             return dygraph_utils._append_activation_in_dygraph(
                 batch_norm_out, act=self._act)
+
+        check_variable_and_dtype(input, 'input',
+                                 ['float16', 'float32', 'float64'], 'BatchNorm')
 
         attrs = {
             "momentum": self._momentum,

--- a/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batch_norm_op.py
@@ -608,5 +608,20 @@ class TestBatchNormOpError(unittest.TestCase):
             self.assertRaises(TypeError, fluid.layers.batch_norm, x2)
 
 
+class TestDygraphBatchNormAPIError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            batch_norm = fluid.dygraph.BatchNorm(10)
+            # the input of BatchNorm must be Variable.
+            x1 = fluid.create_lod_tensor(
+                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, batch_norm, x1)
+
+            # the input dtype of BatchNorm must be float16 or float32 or float64
+            # float16 only can be set on GPU place
+            x2 = fluid.layers.data(name='x2', shape=[3, 4, 5, 6], dtype="int32")
+            self.assertRaises(TypeError, batch_norm, x2)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## dygraph.BatchNorm Python API类型检查增强
当此动态图API在静态图下运行时：
- 1. 检查input类型是否为Variable
- 2. 检查数据类型是否为float16, float32, float64

两个异常情况示例如下（可手动执行）:

- type error
```
import paddle.fluid as fluid
import numpy as np
batch_norm = fluid.dygraph.BatchNorm(10)
x1 = fluid.create_lod_tensor(
    np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
batch_norm(x1)
# TypeError: The type of 'input' in BatchNorm must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>.
```

- dtype error
```
import paddle.fluid as fluid
import numpy as np
batch_norm = fluid.dygraph.BatchNorm(10)
x2 = fluid.layers.data(name='x2', shape=[3, 4, 5, 6], dtype="int32")
batch_norm(x2)
# TypeError: The data type of 'input' in BatchNorm must be ['float16', 'float32', 'float64'], but received int32. 
```