### PR TITLE
Op(feed) error message enhancement.

### DIFF
--- a/paddle/fluid/operators/controlflow/feed_op.cc
+++ b/paddle/fluid/operators/controlflow/feed_op.cc
@@ -28,35 +28,52 @@ class FeedOp : public framework::OperatorBase {
  private:
   void RunImpl(const framework::Scope &scope,
                const platform::Place &place) const override {
-    // get device context from pool
-    auto *dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+    OP_INOUT_CHECK(HasInputs("X"), "Input", "X", "Feed");
+    OP_INOUT_CHECK(HasOutputs("Out"), "Output", "Out", "Feed");
 
     auto feed_var_name = Input("X");
     auto *feed_var = scope.FindVar(feed_var_name);
-
-    PADDLE_ENFORCE(feed_var != nullptr,
-                   "Cannot find feed_var in scope, feed_var_name is %s",
-                   feed_var_name);
+    PADDLE_ENFORCE_NOT_NULL(
+        feed_var,
+        platform::errors::NotFound(
+            "Input varibale(%s) cannot be found in scope for operator 'Feed'.",
+            feed_var_name));
 
     auto out_name = this->Output("Out");
     auto *out_var = scope.FindVar(out_name);
-    PADDLE_ENFORCE(out_var != nullptr,
-                   "Cannot find out_var in scope, out_var_name is %s",
-                   out_name);
+    PADDLE_ENFORCE_NOT_NULL(
+        out_var,
+        platform::errors::NotFound(
+            "Output variable(%s) cannot be found in scope for operator 'Feed'",
+            out_name));
 
     auto col = Attr<int>("col");
+    PADDLE_ENFORCE_GE(col, 0,
+                      platform::errors::InvalidArgument(
+                          "Expected the column index (the attribute 'col' of "
+                          "operator 'Feed') of current feeding variable to be "
+                          "no less than 0. But received column index = %d.",
+                          col));
 
-    VLOG(3) << "Feed Var " << feed_var_name << "'s " << col << " column to var "
-            << out_name;
+    VLOG(3) << "Feed variable " << feed_var_name << "'s " << col
+            << " column to variable " << out_name;
 
     auto &feed_list = feed_var->Get<framework::FeedFetchList>();
-    PADDLE_ENFORCE_LT(static_cast<size_t>(col), feed_list.size());
+    PADDLE_ENFORCE_LT(
+        static_cast<size_t>(col), feed_list.size(),
+        platform::errors::InvalidArgument(
+            "The column index of current feeding variable is expected to be "
+            "less than the length of feeding list. But received column index = "
+            "%d, the length of feeding list = %d",
+            col, feed_list.size()));
+
     auto &feed_item = feed_list.at(static_cast<size_t>(col));
     auto *out_item = out_var->GetMutable<framework::FeedFetchType>();
 
     if (platform::is_same_place(feed_item.place(), place)) {
       out_item->ShareDataWith(feed_item);
     } else {
+      auto *dev_ctx = platform::DeviceContextPool::Instance().Get(place);
       framework::TensorCopy(feed_item, place, *dev_ctx, out_item);
     }
     out_item->set_lod(feed_item.lod());
@@ -66,9 +83,13 @@ class FeedOp : public framework::OperatorBase {
 class FeedOpInfoMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
-    AddInput("X", "The input of feed op");
-    AddOutput("Out", "The output of feed op");
-    AddAttr<int>("col", "(int) The column of feed");
+    AddInput("X",
+             "(vector<LoDTensor>) A feeding list of LoDTensor, which may have "
+             "different dimension and data type.");
+    AddOutput("Out",
+              "(LoDTensor) The LoDTensor which is a copy of the col-th feeding "
+              "object.");
+    AddAttr<int>("col", "(int) The column index of current feeding object.");
     AddComment(R"DOC(
 Feed Operator.
 


### PR DESCRIPTION
### feed_op报错信息增强 [仅C++端]
#### 1. 使用`OP_INOUT_CHECK`，增加输入、输出是否设置的检查。
由于feed_op继承的是`OperatorBase`，当输入或者输出没有设置时，在进入`RunImpl`函数之前就会报错，因此修改前后报错信息一样，具体如下：
    
- 没有设置输入
    ```
    Error: Operator feed's input, X, is not set at (/paddle/paddle/fluid/framework/operator.cc:382)
    ```
    
- 没有设置输出
    ```
    Error: Operator feed's output, Out, is not set at (/paddle/paddle/fluid/framework/operator.cc:390)
    ```

#### 2. 增强scope中，输入、输出变量是否存在的检查
    
- 检查scope中输入变量是否存在
    - 修改前
    ```
    Error: Cannot find feed_var in scope, feed_var_name is feed at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:39)
      [operator < feed > error]
    ```
    - 修改后
    ```
    NotFoundError: Input varibale(feed) cannot be found in scope for operator 'Feed'.
      [Hint: feed_var should not be null.] at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:40)
      [operator < feed > error]
    ```
    
- 检查scope中输出变量是否存在
    - 修改前
    ```
    Error: Cannot find out_var in scope, out_var_name is out_0 at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:45)
      [operator < feed > error]
    ```
    - 修改后
    ```
    NotFoundError: Output variable(out_0) cannot be found in scope for operator 'Feed'
      [Hint: out_var should not be null.] at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:48)
      [operator < feed > error]
    ```

#### 3. 增强属性值是否合法的检查
    
- 增加`col >= 0`的检查
    - 设置`col = -1`，修改前
    ```
    Error: An error occurred here. There is no accurate error hint for this error yet. We are continuously in the process of increasing hint for this kind of error check. It would be helpful if you could inform us of how this conversion went by opening a github issue. And we will resolve it with high priority.
      - New issue link: https://github.com/PaddlePaddle/Paddle/issues/new
      - Recommended issue content: all error stack information
      [Hint: Expected static_cast<size_t>(col) < feed_list.size(), but received static_cast<size_t>(col):18446744073709551615 >= feed_list.size():0.] at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:53)
        [operator < feed > error]
    ```
    - 设置`col = -1`，修改后
    ```
    InvalidArgumentError: Expected the column index (the attribute 'col' of operator 'Feed') of current feeding variable to be no less than 0. But received column index = -1.
      [Hint: Expected col >= 0, but received col:-1 < 0:0.] at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:56)
      [operator < feed > error]
    ```
    
- 增强col < feed列表长度的报错信息
    - 修改前    
    ```
    Error: An error occurred here. There is no accurate error hint for this error yet. We are continuously in the process of increasing hint for this kind of error check. It would be helpful if you could inform us of how this conversion went by opening a github issue. And we will resolve it with high priority.
      - New issue link: https://github.com/PaddlePaddle/Paddle/issues/new
      - Recommended issue content: all error stack information
      [Hint: Expected static_cast<size_t>(col) < feed_list.size(), but received static_cast<size_t>(col):1 >= feed_list.size():0.] at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:53)
         [operator < feed > error]
    ```
    - 修改后
    ```
    InvalidArgumentError: The column index of current feeding variable is expected to be less than the length of feeding list. But received column index = 1, the length of feeding list = 1
  [Hint: Expected static_cast<size_t>(col) < feed_list.size(), but received static_cast<size_t>(col):1 >= feed_list.size():1.] at (/paddle/paddle/fluid/operators/controlflow/feed_op.cc:68)
  [operator < feed > error]
    ```

#### 说明
feed op不是普通op，使用executor执行时，由executor根据用户的feed需求自动插入feed_op来填充用户数据。没有Python API，错误示例难以构造，因此不提供错误示例。