### PR TITLE
API(BilinearTensorProduct) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -23,7 +23,6 @@ from . import layers
 from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer, _varbase_creator
 from ..param_attr import ParamAttr
-from ..data_feeder import check_variable_and_dtype, check_type, check_dtype
 from ..initializer import Normal, Constant, NumpyArrayInitializer
 from .. import unique_name
 from .layer_object_helper import LayerObjectHelper

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -23,6 +23,7 @@ from . import layers
 from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer, _varbase_creator
 from ..param_attr import ParamAttr
+from ..data_feeder import check_variable_and_dtype, check_type, check_dtype
 from ..initializer import Normal, Constant, NumpyArrayInitializer
 from .. import unique_name
 from .layer_object_helper import LayerObjectHelper
@@ -2117,6 +2118,10 @@ class BilinearTensorProduct(layers.Layer):
             is_bias=True)
 
     def forward(self, x, y):
+        check_variable_and_dtype(x, 'x', ['float32', 'float64'],
+                                 'BilinearTensorProduct')
+        check_variable_and_dtype(y, 'y', ['float32', 'float64'],
+                                 'BilinearTensorProduct')
         self._inputs = {"X": x, "Y": y, "Weight": self.weight}
         if self.bias is not None:
             self._inputs["Bias"] = self.bias

--- a/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
+++ b/python/paddle/fluid/tests/unittests/test_bilinear_tensor_product_op.py
@@ -16,7 +16,23 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
+import paddle.fluid as fluid
 from op_test import OpTest
+
+
+class TestDygraphBilinearTensorProductAPIError(unittest.TestCase):
+    def test_errors(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            layer = fluid.dygraph.nn.BilinearTensorProduct(
+                input1_dim=5, input2_dim=4, output_dim=1000)
+            # the input must be Variable.
+            x0 = fluid.create_lod_tensor(
+                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, layer, x0)
+            # the input dtype must be float32 or float64
+            x1 = fluid.data(name='x1', shape=[-1, 5], dtype="float16")
+            x2 = fluid.data(name='x2', shape=[-1, 4], dtype="float32")
+            self.assertRaises(TypeError, layer, x1, x2)
 
 
 class TestBilinearTensorProductOp(OpTest):


### PR DESCRIPTION
`dygraph.BilinearTensorProduct` Python API类型检查增强
当此动态图API在静态图下运行时：

检查input类型是否为Variable
检查数据类型是否为float32, float64
异常情况示例如下:

```
import paddle.fluid as fluid
import numpy as np
layer = fluid.dygraph.nn.BilinearTensorProduct(
    input1_dim=5, input2_dim=4, output_dim=1000)
# the input must be Variable.
x0 = fluid.create_lod_tensor(
    np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
layer(x0, x0)
# TypeError: The type of 'x' in BilinearTensorProduct must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>. 

x1 = fluid.data(name='x1', shape=[-1, 5], dtype="float16")
x2 = fluid.data(name='x2', shape=[-1, 4], dtype="float32")
layer(x1, x2)
# TypeError: The data type of 'x' in BilinearTensorProduct must be ['float32', 'float64'], but received float16.
```