### PR TITLE
API(Embedding) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1329,6 +1329,7 @@ class Embedding(layers.Layer):
                 'is_distributed', self._is_distributed, 'remote_prefetch',
                 self._remote_prefetch, 'padding_idx', self._padding_idx)
 
+        check_variable_and_dtype(input, 'input', ['int64'], 'Embedding')
         attrs = {
             'is_sparse': self._is_sparse,
             'is_distributed': self._is_distributed,

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_op.py
@@ -25,6 +25,21 @@ import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 
 
+class TestDygraphEmbeddingAPIError(unittest.TestCase):
+    def test_errors(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            dict_size = 20
+            layer = fluid.dygraph.nn.Embedding(
+                size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
+            # the input must be Variable.
+            x0 = fluid.create_lod_tensor(
+                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, layer, x0)
+            # the input dtype must be int64
+            data_t = fluid.data(name='word', shape=[1], dtype='int32')
+            self.assertRaises(TypeError, layer, data_t)
+
+
 class TestLookupTableOp(OpTest):
     def setUp(self):
         self.op_type = "lookup_table_v2"


### PR DESCRIPTION
`dygraph.Embedding` Python API类型检查增强
当此动态图API在静态图下运行时：

检查input类型是否为Variable
检查数据类型是否为int64
异常情况示例如下:

```
import paddle.fluid as fluid
import numpy as np
dict_size = 20
layer = fluid.dygraph.nn.Embedding(
    size=[dict_size, 32], param_attr='emb.w', is_sparse=False)
x0 = fluid.create_lod_tensor(
    np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
layer(x0)
# TypeError: The type of 'input' in Embedding must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>. 

data_t = fluid.data(name='word', shape=[1], dtype='int32')
layer(data_t)
# TypeError: The data type of 'input' in Embedding must be ['int64'], but received int32.
```