### PR TITLE
API(LayerNorm) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -20,6 +20,7 @@ from ..layers import utils
 from ..layers import nn
 from .. import dygraph_utils
 from . import layers
+from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..framework import Variable, in_dygraph_mode, OpProtoHolder, Parameter, _dygraph_tracer, _varbase_creator
 from ..param_attr import ParamAttr
 from ..initializer import Normal, Constant, NumpyArrayInitializer
@@ -1474,6 +1475,9 @@ class LayerNorm(layers.Layer):
                 'begin_norm_axis', self._begin_norm_axis)
             return dygraph_utils._append_activation_in_dygraph(
                 pre_act, act=self._act)
+
+        check_variable_and_dtype(input, 'input', ['float32', 'float64'],
+                                 'LayerNorm')
 
         inputs = dict()
         inputs['X'] = [input]

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -21,6 +21,7 @@ import paddle.fluid.core as core
 import paddle.fluid as fluid
 from functools import reduce
 from op_test import _set_use_system_allocator
+from paddle.fluid import Program, program_guard
 
 np.random.random(123)
 
@@ -211,6 +212,20 @@ class TestLayerNormAPI(unittest.TestCase):
             epsilon=1e-05,
             param_attr="scale",
             bias_attr="shift")
+
+
+class TestDygraphLayerNormAPIError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            layer_norm = fluid.LayerNorm([32, 32])
+            # the input of LayerNorm must be Variable.
+            x1 = np.random.random((3, 32, 32)).astype('float32')
+            self.assertRaises(TypeError, layer_norm, x1)
+
+            # the input dtype of LayerNorm must be float32 or float64
+            # float16 only can be set on GPU place
+            x2 = fluid.layers.data(name='x2', shape=[3, 32, 32], dtype="int32")
+            self.assertRaises(TypeError, layer_norm, x2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## dygraph.LayerNorm Python API类型检查增强
当此动态图API在静态图下运行时：
- 1. 检查input类型是否为Variable
- 2. 检查数据类型是否为float32, float64

两个异常情况示例如下（可手动执行）:

- type error
```
import paddle.fluid as fluid
import numpy as np
layer_norm = fluid.LayerNorm([32, 32])
x1 = np.random.random((3, 32, 32)).astype('float32')
layer_norm(x1)
# TypeError: The type of 'input' in LayerNorm must be <class 'paddle.fluid.framework.Variable'>, but received <class 'numpy.ndarray'>. 
```

- dtype error
```
import paddle.fluid as fluid
import numpy as np
layer_norm = fluid.LayerNorm([32, 32])
x2 = fluid.layers.data(name='x2', shape=[3, 32, 32], dtype="int32")
layer_norm(x2)
# TypeError: The data type of 'input' in LayerNorm must be ['float32', 'float64'], but received int32. 
```