### PR TITLE
API(GRUUnit) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1671,10 +1671,6 @@ class GRUUnit(layers.Layer):
         }
         if self.bias is not None:
             inputs['Bias'] = [self.bias]
-        attrs = {
-            'activation': self.activation,
-            'gate_activation': self.gate_activation,
-        }
         gate = self._helper.create_variable_for_type_inference(self._dtype)
         reset_hidden_pre = self._helper.create_variable_for_type_inference(
             self._dtype)

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1660,6 +1660,10 @@ class GRUUnit(layers.Layer):
                 self.activation, 'gate_activation', self.gate_activation)
             return updated_hidden, reset_hidden_pre, gate
 
+        check_variable_and_dtype(input, 'input', ['float32', 'float64'],
+                                 'GRUUnit')
+        check_variable_and_dtype(hidden, 'hidden', ['float32', 'float64'],
+                                 'GRUUnit')
         inputs = {
             'Input': [input],
             'HiddenPrev': [hidden],

--- a/python/paddle/fluid/tests/unittests/test_gru_unit_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gru_unit_op.py
@@ -17,7 +17,23 @@ from __future__ import print_function
 import math
 import unittest
 import numpy as np
+import paddle.fluid as fluid
 from op_test import OpTest
+
+
+class TestGRUUnitAPIError(unittest.TestCase):
+    def test_errors(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            D = 5
+            layer = fluid.dygraph.nn.GRUUnit(size=D * 3)
+            # the input must be Variable.
+            x0 = fluid.create_lod_tensor(
+                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, layer, x0)
+            # the input dtype must be float32 or float64
+            x = fluid.data(name='x', shape=[-1, D * 3], dtype='float16')
+            hidden = fluid.data(name='hidden', shape=[-1, D], dtype='float32')
+            self.assertRaises(TypeError, layer, x, hidden)
 
 
 class GRUActivationType(OpTest):


### PR DESCRIPTION
`dygraph.GRUUnit` Python API类型检查增强
当此动态图API在静态图下运行时：

检查input类型是否为Variable
检查数据类型是否为float32/float64
异常情况示例如下:

```
import paddle.fluid as fluid
import numpy as np
D = 5
layer = fluid.dygraph.nn.GRUUnit(size=D * 3)
# the input must be Variable.
x0 = fluid.create_lod_tensor(
    np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
layer(x0, x0)
# TypeError: The type of 'input' in GRUUnit must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>. 

x = fluid.data(name='x', shape=[-1, D * 3], dtype='float16')
hidden = fluid.data(name='hidden', shape=[-1, D], dtype='float32')
layer(x, hidden)
# TypeError: The data type of 'input' in GRUUnit must be ['float32', 'float64'], but received float16.
```