### PR TITLE
API(PRelu) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -2019,6 +2019,7 @@ class PRelu(layers.Layer):
             default_initializer=Constant(1.0))
 
     def forward(self, input):
+        check_variable_and_dtype(input, 'input', ['float32'], 'PRelu')
         out = self._helper.create_variable_for_type_inference(self._dtype)
         self._helper.append_op(
             type="prelu",

--- a/python/paddle/fluid/tests/unittests/test_prelu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_prelu_op.py
@@ -16,8 +16,26 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
+import paddle.fluid as fluid
 import six
 from op_test import OpTest, skip_check_grad_ci
+
+
+class TestPReluAPIError(unittest.TestCase):
+    def test_errors(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            layer = fluid.PRelu(
+                mode='all',
+                param_attr=fluid.ParamAttr(
+                    initializer=fluid.initializer.Constant(1.0)))
+            # the input must be Variable.
+            x0 = fluid.create_lod_tensor(
+                np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
+            self.assertRaises(TypeError, layer, x0)
+            # the input dtype must be float32
+            data_t = fluid.data(
+                name="input", shape=[5, 200, 100, 100], dtype="float64")
+            self.assertRaises(TypeError, layer, data_t)
 
 
 class PReluTest(OpTest):


### PR DESCRIPTION
`dygraph.PRelu` Python API类型检查增强
当此动态图API在静态图下运行时：

检查input类型是否为Variable
检查数据类型是否为float32
异常情况示例如下:

```
import paddle.fluid as fluid
import numpy as np
layer = fluid.PRelu(
    mode='all',
    param_attr=fluid.ParamAttr(
        initializer=fluid.initializer.Constant(1.0)))
# the input must be Variable.
x0 = fluid.create_lod_tensor(
    np.array([-1, 3, 5, 5]), [[1, 1, 1, 1]], fluid.CPUPlace())
layer(x0)
# TypeError: The type of 'input' in PRelu must be <class 'paddle.fluid.framework.Variable'>, but received <class 'paddle.fluid.core_avx.LoDTensor'>. 

data_t = fluid.data(name="input", shape=[5, 200, 100, 100], dtype="float64")
layer(data_t)
# TypeError: The data type of 'input' in PRelu must be ['float32'], but received float64.
```