### PR TITLE
Op(fetch) error message enhancement.

### DIFF
--- a/paddle/fluid/operators/controlflow/fetch_op.cc
+++ b/paddle/fluid/operators/controlflow/fetch_op.cc
@@ -49,7 +49,7 @@ class FetchOp : public framework::OperatorBase {
                                          "in scope for operator 'Fetch'.",
                                          out_name));
 
-    auto col = static_cast<size_t>(Attr<int>("col"));
+    int col = Attr<int>("col");
     PADDLE_ENFORCE_GE(
         col, 0, platform::errors::InvalidArgument(
                     "Expected the column index (the attribute 'col' of "
@@ -63,7 +63,7 @@ class FetchOp : public framework::OperatorBase {
     auto *fetch_list = out_var->GetMutable<framework::FeedFetchList>();
     auto &src_item = fetch_var->Get<framework::FeedFetchType>();
 
-    if (col >= fetch_list->size()) {
+    if (static_cast<size_t>(col) >= fetch_list->size()) {
       fetch_list->resize(col + 1);
     }
     auto &dst_item = fetch_list->at(col);

--- a/paddle/fluid/operators/controlflow/fetch_op.cc
+++ b/paddle/fluid/operators/controlflow/fetch_op.cc
@@ -31,19 +31,34 @@ class FetchOp : public framework::OperatorBase {
  private:
   void RunImpl(const framework::Scope &scope,
                const platform::Place &place) const override {
+    OP_INOUT_CHECK(HasInputs("X"), "Input", "X", "Fetch");
+    OP_INOUT_CHECK(HasOutputs("Out"), "Output", "Out", "Fetch");
+
     auto fetch_var_name = Input("X");
     auto *fetch_var = scope.FindVar(fetch_var_name);
-    PADDLE_ENFORCE(fetch_var != nullptr,
-                   "Cannot find fetch variable in scope, fetch_var_name is %s",
-                   fetch_var_name);
+    PADDLE_ENFORCE_NOT_NULL(
+        fetch_var,
+        platform::errors::NotFound(
+            "Input variable(%s) cannot be found in scope for operator 'Fetch'.",
+            fetch_var_name));
 
-    auto out_name = this->Output("Out");
+    auto out_name = Output("Out");
     auto *out_var = scope.FindVar(out_name);
-    PADDLE_ENFORCE(out_var != nullptr,
-                   "Cannot find out_var in scope, out_var_name is %s",
-                   out_name);
+    PADDLE_ENFORCE_NOT_NULL(out_var, platform::errors::NotFound(
+                                         "Output variable(%s) cannot be found "
+                                         "in scope for operator 'Fetch'.",
+                                         out_name));
 
     auto col = static_cast<size_t>(Attr<int>("col"));
+    PADDLE_ENFORCE_GE(
+        col, 0, platform::errors::InvalidArgument(
+                    "Expected the column index (the attribute 'col' of "
+                    "operator 'Fetch') of current fetching variable to be "
+                    "no less than 0. But received column index = %d.",
+                    col));
+
+    VLOG(3) << "Fetch variable " << fetch_var_name << " to variable "
+            << out_name << "'s " << col << " column.";
 
     auto *fetch_list = out_var->GetMutable<framework::FeedFetchList>();
     auto &src_item = fetch_var->Get<framework::FeedFetchType>();
@@ -81,17 +96,19 @@ class FetchOp : public framework::OperatorBase {
       dst_item.Resize({0});
     }
     dst_item.set_lod(src_item.lod());
-
-    VLOG(3) << "Fetch variable " << fetch_var_name << " to " << out_name;
   }
 };
 
 class FetchOpInfoMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
-    AddInput("X", "The input of fetch op");
-    AddOutput("Out", "The output of fetch op");
-    AddAttr<int>("col", "(int) The column of fetch");
+    AddInput("X",
+             "(LoDTensor) The resulted LoDTensor which is expected to return "
+             "to users.");
+    AddOutput("Out",
+              "(vector<LoDTensor>) A fetching list of LoDTensor which may have "
+              "different dimension, shape and data type.");
+    AddAttr<int>("col", "(int) The column index of fetching object.");
     AddComment(R"DOC(
 Fetch Operator.
 


### PR DESCRIPTION
### fetch_op报错信息增强 [仅C++端]
#### 1. 使用OP_INOUT_CHECK，增加输入、输出是否设置的检查
由于fetch_op继承的是OperatorBase，当输入或者输出没有设置时，在进入RunImpl函数之前就会报错，因此修改前后报错信息一样，具体如下：

- 没有设置输入
    ```
    Error: Operator fetch's input, X, is not set at (/paddle/paddle/fluid/framework/operator.cc:382)
    ```

- 没有设置输出
    ```
    Error: Operator fetch's output, Out, is not set at (/paddle/paddle/fluid/framework/operator.cc:390)
    ```

#### 2. 增强scope中，输入、输出变量是否存在的检查
- 检查scope中输入变量是否存在
    - 修改前
    ```
    Error: Cannot find fetch variable in scope, fetch_var_name is in_0 at (/paddle/paddle/fluid/operators/controlflow/fetch_op.cc:38)
      [operator < fetch > error]
    ```
    - 修改后
    ```
    NotFoundError: Input variable(in_0) cannot be found in scope for operator 'Fetch'.
      [Hint: fetch_var should not be null.] at (/paddle/paddle/fluid/operators/controlflow/fetch_op.cc:43)
      [operator < fetch > error]
    ```
- 检查scope中输出变量是否存在
    - 修改前
    ```
    Error: Cannot find out_var in scope, out_var_name is fetch at (/paddle/paddle/fluid/operators/controlflow/fetch_op.cc:44)
  [operator < fetch > error]
    ```
    - 修改后
    ```
    NotFoundError: Output variable(fetch) cannot be found in scope for operator 'Fetch'.
      [Hint: out_var should not be null.] at (/paddle/paddle/fluid/operators/controlflow/fetch_op.cc:50)
      [operator < fetch > error]
    ```
3. 增加属性`col >= 0`的检查
    - 修改前
    ```
    W0408 05:43:54.087884 59585 operator.cc:187] fetch raises an exception std::out_of_range, vector::_M_range_check
    ```
    - 修改后
    ```
    InvalidArgumentError: Expected the column index (the attribute 'col' of operator 'Fetch') of current fetching variable to be no less than 0. But received column index = -1.
      [Hint: Expected col >= 0, but received col:-1 < 0:0.] at (/paddle/paddle/fluid/operators/controlflow/fetch_op.cc:59)
      [operator < fetch > error]
    ```

#### 说明
fetch op不是普通op，使用executor执行时，由executor根据用户的fetch需求自动插入fetch_op来取回计算的结果数据。没有Python API，错误示例难以构造，因此不提供错误示例。