### PR TITLE
API(fluid.layers.array_length) error message enhancement

### DIFF
--- a/paddle/fluid/operators/lod_array_length_op.cc
+++ b/paddle/fluid/operators/lod_array_length_op.cc
@@ -60,8 +60,8 @@ CPU and the length of LoDTensorArray should be used as control variables.
 class LoDArrayLengthInferShape : public framework::InferShapeBase {
  public:
   void operator()(framework::InferShapeContext *context) const override {
-    PADDLE_ENFORCE(context->HasInput("X"));
-    PADDLE_ENFORCE(context->HasOutput("Out"));
+    OP_INOUT_CHECK(context->HasInput("X"), "Input", "X", "ArrayLength");
+    OP_INOUT_CHECK(context->HasOutput("Out"), "Output", "Out", "ArrayLegth");
     context->SetOutputDim("Out", {1});
   }
 };

--- a/paddle/fluid/operators/lod_array_length_op.cc
+++ b/paddle/fluid/operators/lod_array_length_op.cc
@@ -60,8 +60,9 @@ CPU and the length of LoDTensorArray should be used as control variables.
 class LoDArrayLengthInferShape : public framework::InferShapeBase {
  public:
   void operator()(framework::InferShapeContext *context) const override {
-    OP_INOUT_CHECK(context->HasInput("X"), "Input", "X", "ArrayLength");
-    OP_INOUT_CHECK(context->HasOutput("Out"), "Output", "Out", "ArrayLegth");
+    OP_INOUT_CHECK(context->HasInput("X"), "Input", "X", "LDArrayLength");
+    OP_INOUT_CHECK(context->HasOutput("Out"), "Output", "Out",
+                   "LoDArrayLength");
     context->SetOutputDim("Out", {1});
   }
 };

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1747,6 +1747,9 @@ def array_length(array):
     Returns:
         Variable: 1-D Tensor with shape [1], which is the length of array. Datatype: int64.
 
+    Raises:
+        TypeError: array(input) is not a Variable
+    
     Examples:
         .. code-block:: python
 
@@ -1780,6 +1783,9 @@ def array_length(array):
             #       so the dtype value is typeid(int64_t).Name(), which is 'x' on MacOS, 'l' on Linux, 
             #       and '__int64' on Windows. They both represent 64-bit integer variables.
     """
+
+    check_type(array, 'array', (Variable), 'array_length')
+
     if in_dygraph_mode():
         assert isinstance(
             array,

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1747,9 +1747,6 @@ def array_length(array):
     Returns:
         Variable: 1-D Tensor with shape [1], which is the length of array. Datatype: int64.
 
-    Raises:
-        TypeError: array(input) is not a Variable
-    
     Examples:
         .. code-block:: python
 
@@ -1784,13 +1781,17 @@ def array_length(array):
             #       and '__int64' on Windows. They both represent 64-bit integer variables.
     """
 
-    check_type(array, 'array', (Variable), 'array_length')
-
     if in_dygraph_mode():
         assert isinstance(
             array,
             list), "The 'array' in array_write must be a list in dygraph mode"
         return len(array)
+
+    if not isinstance(
+            array,
+            Variable) or array.type != core.VarDesc.VarType.LOD_TENSOR_ARRAY:
+        raise TypeError(
+            "array should be tensor array vairable in array_length Op")
 
     helper = LayerHelper('array_length', **locals())
     tmp = helper.create_variable_for_type_inference(dtype='int64')

--- a/python/paddle/fluid/tests/unittests/test_lod_array_length_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lod_array_length_op.py
@@ -18,6 +18,8 @@ import unittest
 import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard
 import numpy
 
 
@@ -31,6 +33,15 @@ class TestLoDArrayLength(unittest.TestCase):
         exe = Executor(cpu)
         result = exe.run(fetch_list=[arr_len])[0]
         self.assertEqual(11, result[0])
+
+
+class TestLoDArrayLengthOpError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            #for ci coverage
+            x1 = numpy.random.randn(2, 4).astype('int32')
+
+            self.assertRaises(TypeError, fluid.layers.array_length, array=x1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### API fluid.layers.array_length报错信息增强 [C++端 + Python端]

#### python 端
array length 类型检查

```
def array_length(array):
```
对输入是否是Variable 进行检查
#### C++端
判断时候有输入X和输出Out
Input X 
```
NotFoundError: No Input(X) found for LDArrayLength operator.
  [Hint: Expected false == true, but received false:0 != true:1.] at (/workspace/card_requrement/Paddle/paddle/fluid/operators/lod_array_length_op.cc:63)
  [operator < lod_array_length > error]

```
Output Out
```
NotFoundError: No Output(Out) found for LoDArrayLength operator.
  [Hint: Expected false == true, but received false:0 != true:1.] at (/workspace/card_requrement/Paddle/paddle/fluid/operators/lod_array_length_op.cc:65)
  [operator < lod_array_length > error]
```
![image](https://user-images.githubusercontent.com/13411999/78745256-2883c100-7996-11ea-815e-f732f85c2089.png)
