### PR TITLE
Refine example code in en doc

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6372,7 +6372,6 @@ def pad(x, paddings, pad_value=0., name=None):
             pad_value = 0
 
         Return:
-
             out = [[0, 1, 2, 0, 0]
                    [0, 3, 4, 0, 0]
                    [0, 0, 0, 0, 0]]
@@ -6397,12 +6396,10 @@ def pad(x, paddings, pad_value=0., name=None):
     Examples:
         .. code-block:: python
 
-            # x is a rank 2 tensor variable with shape [100, 224].
-            # out will be a tensor of shape [101, 227] 
+            # x is a rank 2 tensor variable
             import paddle.fluid as fluid
-            x = fluid.data(name='data', shape=[100, 224], dtype='float32')
-            out = fluid.layers.pad(
-                x=x, paddings=[0, 1, 1, 2], pad_value=0.)
+            x = fluid.data(name='data', shape=[2, 2], dtype='float32')
+            out = fluid.layers.pad(x=x, paddings=[0, 1, 1, 2], pad_value=0.)
     """
     helper = LayerHelper('pad', input=x, **locals())
     dtype = helper.input_dtype()
@@ -6440,29 +6437,34 @@ def pad_constant_like(x, y, pad_value=0., name=None):
                    [27, 28, 29]],
                   [[30, 31, 32],
                    [33, 34, 35]]]]
+
             X.shape = (2, 3, 2, 3)
 
             Y = [[[[35, 36, 37]],
                   [[38, 39, 40]],
                   [[41, 42, 43]]]]
+
             Y.shape = (1, 3, 1, 3)
-		And
-            pad_value = -1,
+
+        And
+            pad_value = 0.
 
         Return:
             Out = [[[[35, 36, 37],
-                     [-1, -1, -1]],
+                     [ 0,  0,  0]],
                     [[38, 39, 40],
-                     [-1, -1, -1]],
+                     [ 0,  0,  0]],
                     [[41, 42, 43],
-                     [-1, -1, -1]]],
-                  [[[-1, -1, -1],
-                    [-1, -1, -1]],
-                   [[-1, -1, -1],
-                    [-1, -1, -1]],
-                   [[-1, -1, -1],
-                    [-1, -1, -1]]]]
-            Out.shape = (2, 3, 2, 3)
+                     [ 0,  0,  0]]],
+                   [[[ 0,  0,  0], 
+                     [ 0,  0,  0]],
+                    [[ 0,  0,  0], 
+                     [ 0,  0,  0]],
+                    [[ 0,  0,  0], 
+                     [ 0,  0,  0]]]]
+
+            Out.shape = [2, 3, 2, 3]
+
 
     Args:
         x (Variable): Tensor, its shape specifies the shape of output.
@@ -8722,47 +8724,38 @@ def pad2d(input,
     Examples:
         .. code-block:: text
 
-	      Given that X is a channel of image from input:
+            Input = [[[[1., 2., 3.],
+                       [4., 5., 6.]]]]
 
-	      X = [[1, 2, 3],
-		   [4, 5, 6]]
+            Case 0:
+                paddings = [0, 1, 2, 3],
+                mode = 'constant'
+                pad_value = 0
+                Out = [[[[0., 0., 1., 2., 3., 0., 0., 0.],
+                         [0., 0., 4., 5., 6., 0., 0., 0.],
+                         [0., 0., 0., 0., 0., 0., 0., 0.]]]]
 
-	      Case 0:
+            Case 1:
+                paddings = [0, 1, 2, 1],
+                mode = 'reflect'
+                Out = [[[[3., 2., 1., 2., 3., 2.],
+                         [6., 5., 4., 5., 6., 5.],
+                         [3., 2., 1., 2., 3., 2.]]]]
 
-		paddings = [0, 1, 2, 3],
-		mode = 'constant'
-		pad_value = 0
-
-		Out = [[0, 0, 1, 2, 3, 0, 0, 0]
-		       [0, 0, 4, 5, 6, 0, 0, 0]
-		       [0, 0, 0, 0, 0, 0, 0, 0]]
-
-	      Case 1:
-
-		paddings = [0, 1, 2, 1],
-		mode = 'reflect'
-
-		Out = [[3, 2, 1, 2, 3, 2]
-		       [6, 5, 4, 5, 6, 5]
-		       [3, 2, 1, 2, 3, 2]]
-
-	      Case 2:
-
-		paddings = [0, 1, 2, 1],
-		mode = 'edge'
-
-		Out = [[1, 1, 1, 2, 3, 3]
-		       [4, 4, 4, 5, 6, 6]
-		       [4, 4, 4, 5, 6, 6]]
+            Case 2:
+                paddings = [0, 1, 2, 1],
+                mode = 'edge'
+                Out = [[[[1., 1., 1., 2., 3., 3.],
+                         [4., 4., 4., 5., 6., 6.],
+                         [4., 4., 4., 5., 6., 6.]]]]
 
     Code Examples:
+
         .. code-block:: python
 
-          import paddle.fluid as fluid
-          data = fluid.data(name='data', shape=[None, 3, 32, 32],
-                                   dtype='float32')
-          result = fluid.layers.pad2d(input=data, paddings=[1, 2, 3, 4],
-                                      mode='reflect')
+            import paddle.fluid as fluid
+            data = fluid.data(name='data', shape=[1, 1, 2, 3], dtype='float32')
+            result = fluid.layers.pad2d(input=data, paddings=[0, 1, 2, 3], mode='reflect')
     """
 
     if in_dygraph_mode():

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -8750,7 +8750,6 @@ def pad2d(input,
                          [4., 4., 4., 5., 6., 6.]]]]
 
     Code Examples:
-
         .. code-block:: python
 
             import paddle.fluid as fluid

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6398,7 +6398,7 @@ def pad(x, paddings, pad_value=0., name=None):
 
             # x is a rank 2 tensor variable
             import paddle.fluid as fluid
-            x = fluid.data(name='data', shape=[2, 2], dtype='float32')
+            x = fluid.data(name='data', shape=[300, 300], dtype='float32')
             out = fluid.layers.pad(x=x, paddings=[0, 1, 1, 2], pad_value=0.)
     """
     helper = LayerHelper('pad', input=x, **locals())
@@ -8753,7 +8753,7 @@ def pad2d(input,
         .. code-block:: python
 
             import paddle.fluid as fluid
-            data = fluid.data(name='data', shape=[1, 1, 2, 3], dtype='float32')
+            data = fluid.data(name='data', shape=[None, 3, 32, 32], dtype='float32')
             result = fluid.layers.pad2d(input=data, paddings=[0, 1, 2, 3], mode='reflect')
     """
 

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -134,7 +134,7 @@ def create_global_var(shape,
             import paddle.fluid as fluid
             import paddle.fluid.layers as layers
             var = layers.create_global_var(shape=[2,3], value=1.0, dtype='float32',
-                                          persistable=True, force_cpu=True, name='new_var')
+                                           persistable=True, force_cpu=True, name='new_var')
     """
     helper = LayerHelper("global_var", **locals())
     var = helper.create_global_variable(


### PR DESCRIPTION
Refine the doc of create_global_var, pad, pad_constant_like and pad2d to make it consistent with cn doc. 
Related to [FluidDoc #1964](https://github.com/PaddlePaddle/FluidDoc/pull/1964)
Related to [FluidDoc #1957](https://github.com/PaddlePaddle/FluidDoc/pull/1957)