### PR TITLE
OP(fake_quantize) error message enhancement

### DIFF
--- a/paddle/fluid/operators/fake_quantize_op.cc
+++ b/paddle/fluid/operators/fake_quantize_op.cc
@@ -212,7 +212,9 @@ class FakeQuantizeAbsMaxOpMaker : public framework::OpProtoAndCheckerMaker {
         .AddCustomChecker([](const int& bit_length) {
           PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
                             platform::errors::InvalidArgument(
-                                "'bit_length' should be between 1 and 16."));
+                                "'bit_length' should be between 1 and 16, but "
+                                "the received is %d",
+                                bit_length));
         });
     AddComment(R"DOC(
 FakeQuantize operator
@@ -263,7 +265,9 @@ class FakeChannelWiseQuantizeAbsMaxOpMaker
         .AddCustomChecker([](const int& bit_length) {
           PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
                             platform::errors::InvalidArgument(
-                                "'bit_length' should be between 1 and 16."));
+                                "'bit_length' should be between 1 and 16, but "
+                                "the received is %d",
+                                bit_length));
         });
     AddComment(R"DOC(
 The scale of FakeChannelWiseQuantize operator is a vector.
@@ -327,7 +331,9 @@ class FakeQuantizeRangeAbsMaxOpMaker
         .AddCustomChecker([](const int& bit_length) {
           PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
                             platform::errors::InvalidArgument(
-                                "'bit_length' should be between 1 and 16."));
+                                "'bit_length' should be between 1 and 16, but "
+                                "the received is %d",
+                                bit_length));
         });
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
@@ -399,7 +405,9 @@ class FakeQuantOrWithDequantMovingAverageAbsMaxOpMaker
         .AddCustomChecker([](const int& bit_length) {
           PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
                             platform::errors::InvalidArgument(
-                                "'bit_length' should be between 1 and 16."));
+                                "'bit_length' should be between 1 and 16, but "
+                                "the received is %d",
+                                bit_length));
         });
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "

--- a/paddle/fluid/operators/fake_quantize_op.cc
+++ b/paddle/fluid/operators/fake_quantize_op.cc
@@ -180,12 +180,11 @@ class FakeQuantizeAbsMaxOp : public framework::OperatorWithKernel {
       : OperatorWithKernel(type, inputs, outputs, attrs) {}
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"),
-                   "Input(X) of FakeQuantizeOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasOutput("Out"),
-                   "Output(Out) of FakeQuantizeOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasOutput("OutScale"),
-                   "Output(Scale) of FakeQuantizeOp should not be null.");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "FakeQuantizeAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "FakeQuantizeAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("OutScale"), "Output", "OutScale",
+                   "FakeQuantizeAbsMax");
     ctx->SetOutputDim("Out", ctx->GetInputDim("X"));
     ctx->SetOutputDim("OutScale", {1});
     ctx->ShareLoD("X", /*->*/ "Out");
@@ -211,8 +210,9 @@ class FakeQuantizeAbsMaxOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<int>("bit_length", "(int, default 8)")
         .SetDefault(8)
         .AddCustomChecker([](const int& bit_length) {
-          PADDLE_ENFORCE(bit_length >= 1 && bit_length <= 16,
-                         "'bit_length' should be between 1 and 16.");
+          PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
+                            platform::errors::InvalidArgument(
+                                "'bit_length' should be between 1 and 16."));
         });
     AddComment(R"DOC(
 FakeQuantize operator
@@ -230,14 +230,12 @@ class FakeChannelWiseQuantizeAbsMaxOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"),
-                   "Input(X) of FakeChannelWiseQuantizeOp should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("Out"),
-        "Output(Out) of FakeChannelWiseQuantizeOp should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("OutScale"),
-        "Output(Scale) of FakeChannelWiseQuantizeOp should not be null.");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X",
+                   "FakeChannelWiseQuantizeAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "FakeChannelWiseQuantizeAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("OutScale"), "Output", "OutScale",
+                   "FakeChannelWiseQuantizeAbsMax");
     ctx->SetOutputDim("Out", ctx->GetInputDim("X"));
     ctx->SetOutputDim("OutScale", {ctx->GetInputDim("X")[0]});
     ctx->ShareLoD("X", /*->*/ "Out");
@@ -263,8 +261,9 @@ class FakeChannelWiseQuantizeAbsMaxOpMaker
     AddAttr<int>("bit_length", "(int, default 8)")
         .SetDefault(8)
         .AddCustomChecker([](const int& bit_length) {
-          PADDLE_ENFORCE(bit_length >= 1 && bit_length <= 16,
-                         "'bit_length' should be between 1 and 16.");
+          PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
+                            platform::errors::InvalidArgument(
+                                "'bit_length' should be between 1 and 16."));
         });
     AddComment(R"DOC(
 The scale of FakeChannelWiseQuantize operator is a vector.
@@ -288,14 +287,11 @@ class FakeQuantizeRangeAbsMaxOp : public framework::OperatorWithKernel {
       : OperatorWithKernel(type, inputs, outputs, attrs) {}
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"),
-                   "Input(X) of FakeQuantizeRangeAbsMaxOp should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("Out"),
-        "Output(Out) of FakeQuantizeRangeAbsMaxOp should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("OutScale"),
-        "Output(OutScale) of FakeQuantizeRangeAbsMaxOp should not be null");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "FakeQuantizeRangeAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "FakeQuantizeRangeAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("OutScale"), "Output", "OutScale",
+                   "FakeQuantizeRangeAbsMax");
     if (ctx->HasOutput("OutScales")) {
       int window_size = ctx->Attrs().Get<int>("window_size");
       ctx->SetOutputDim("OutScales", {window_size});
@@ -329,8 +325,9 @@ class FakeQuantizeRangeAbsMaxOpMaker
     AddAttr<int>("bit_length", "(int, default 8), quantization bit number.")
         .SetDefault(8)
         .AddCustomChecker([](const int& bit_length) {
-          PADDLE_ENFORCE(bit_length >= 1 && bit_length <= 16,
-                         "'bit_length' should be between 1 and 16.");
+          PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
+                            platform::errors::InvalidArgument(
+                                "'bit_length' should be between 1 and 16."));
         });
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
@@ -357,16 +354,12 @@ class FakeQuantOrWithDequantMovingAverageAbsMaxOp
       : OperatorWithKernel(type, inputs, outputs, attrs) {}
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"),
-                   "Input(X) of FakeQuantOrWithDequantMovingAverageAbsMaxOp "
-                   "should not be null.");
-    PADDLE_ENFORCE(ctx->HasOutput("Out"),
-                   "Output(Out) of FakeQuantOrWithDequantMovingAverageAbsMaxOp "
-                   "should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("OutScale"),
-        "Output(OutScale) of FakeQuantOrWithDequantMovingAverageAbsMaxOp "
-        "should not be null");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X",
+                   "FakeQuantOrWithDequantMovingAverageAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "FakeQuantOrWithDequantMovingAverageAbsMax");
+    OP_INOUT_CHECK(ctx->HasOutput("OutScale"), "Output", "OutScale",
+                   "FakeQuantOrWithDequantMovingAverageAbsMax");
     if (ctx->HasOutput("OutState")) {
       ctx->SetOutputDim("OutState", {1});
     }
@@ -404,8 +397,9 @@ class FakeQuantOrWithDequantMovingAverageAbsMaxOpMaker
     AddAttr<int>("bit_length", "(int, default 8), quantization bit number.")
         .SetDefault(8)
         .AddCustomChecker([](const int& bit_length) {
-          PADDLE_ENFORCE(bit_length >= 1 && bit_length <= 16,
-                         "'bit_length' should be between 1 and 16.");
+          PADDLE_ENFORCE_EQ(bit_length >= 1 && bit_length <= 16, true,
+                            platform::errors::InvalidArgument(
+                                "'bit_length' should be between 1 and 16."));
         });
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
@@ -434,15 +428,12 @@ class MovingAverageAbsMaxScaleOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(
-        ctx->HasInput("X"),
-        "Input(X) of MovingAverageAbsMaxScaleOp should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("Out"),
-        "Output(Out) of MovingAverageAbsMaxScaleOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasOutput("OutScale"),
-                   "Output(OutScale) of MovingAverageAbsMaxScaleOp"
-                   "should not be null");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X",
+                   "MovingAverageAbsMaxScale");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "MovingAverageAbsMaxScale");
+    OP_INOUT_CHECK(ctx->HasOutput("OutScale"), "Output", "OutScale",
+                   "MovingAverageAbsMaxScale");
     if (ctx->HasOutput("OutState")) {
       ctx->SetOutputDim("OutState", {1});
     }


### PR DESCRIPTION
## fake_quantize op报错信息不合规增强：

1. 将fake_quantize一类Op中的InferShape方法中的输入输出检查从 `PADDLE_ENFORCE `改为`OP_INOUT_CHECK `。

2. 将对属性`bit_length`对检查由`PADDLE_ENFORCE`改为 `PADDLE_ENFORCE_EQ`，并细化说明了设置的不规范值为多少。