### PR TITLE
Op (reorder_lod_tensor_by_rank) error message enhancement

### DIFF
--- a/paddle/fluid/operators/reorder_lod_tensor_by_rank_op.cc
+++ b/paddle/fluid/operators/reorder_lod_tensor_by_rank_op.cc
@@ -188,7 +188,9 @@ class ReorderLoDTensorByRankTableOp : public ReorderLoDTensorByRankTableBase {
     size_t out_offset = 0;
     out->mutable_lod()->clear();
     for (auto &item : rank_table.items()) {
-      PADDLE_ENFORCE_LT(item.index, absolute_table.size());
+      PADDLE_ENFORCE_LT(item.index, absolute_table.size(),
+                        platform::errors::OutOfRange(
+                            "The value of rank_table is out of range."));
       out_offset = CopyTensorAndLod(place, absolute_table[item.index], x, out,
                                     out_offset);
     }

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -3456,9 +3456,14 @@ def reorder_lod_tensor_by_rank(x, rank_table):
                            x=data, rank_table=table)
 
     """
+
+    check_type(x, 'x', (Variable), 'reorder_lod_tensor_by_rank')
+    check_type(rank_table, 'rank_table', (Variable),
+               'reorder_lod_tensor_by_rank')
+    if rank_table.type != core.VarDesc.VarType.LOD_RANK_TABLE:
+        raise TypeError("The type of rank_table should be LOD_RANK_TABLE.")
+
     helper = LayerHelper('reorder_lod_tensor_by_rank', **locals())
-    helper.is_instance('x', Variable)
-    helper.is_instance('rank_table', Variable)
 
     out = helper.create_variable_for_type_inference(dtype=x.dtype)
     helper.append_op(

--- a/python/paddle/fluid/tests/unittests/test_reorder_lod_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_reorder_lod_tensor.py
@@ -18,6 +18,7 @@ import unittest
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.layers.control_flow import lod_rank_table
+from paddle.fluid import Program, program_guard
 import numpy
 import functools
 
@@ -207,6 +208,30 @@ class TestReorderLoDTensor(unittest.TestCase):
             self.assertTrue(
                 numpy.allclose(
                     numpy.array(actual_output), expect_output, atol=0.001))
+
+
+class TestReorderLoDTensorError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program()):
+
+            def test_Variable():
+                # The input must be Variable.
+                x1 = numpy.array([0.9383, 0.1983, 3.2, 1.2]).astype("float64")
+                table1 = numpy.array(
+                    [0.9383, 0.1983, 3.2, 1.2]).astype("float64")
+                new_dat = fluid.layers.reorder_lod_tensor_by_rank(
+                    x=x1, rank_table=table1)
+
+            self.assertRaises(TypeError, test_Variable)
+
+            def test_type():
+                x2 = fluid.layers.data(name='x1', shape=[4], dtype='float32')
+                table2 = fluid.layers.data(
+                    name='table2', shape=[4], dtype='int32')
+                new_dat2 = fluid.layers.reorder_lod_tensor_by_rank(
+                    x=x2, rank_table=table2)
+
+            self.assertRaises(TypeError, test_type)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### reorder_lod_tensor_by_rank 增强输入类型检查 
```
reorder_lod_tensor_by_rank(x, rank_table)
```
**Python接口Input类型检查**

1. 检查```x```
- 检查类型是否为Variable

2. 检查```rank_table```
- 检查类型是否为Variable
- 检查数据类型是否为 "LOD_RANK_TABLE"

**c++不合规报错检查增强：**
1. 增加报错信息
修改前报错：
```
Error: An error occurred here. There is no accurate error hint for this error yet. 
```
修改后报错：
```
OutOfRange：The value of rank_table is out of range.
```