### PR TITLE
OP(fake_dequantize) error message enhancement

### DIFF
--- a/paddle/fluid/operators/fake_dequantize_op.cc
+++ b/paddle/fluid/operators/fake_dequantize_op.cc
@@ -88,10 +88,9 @@ class FakeDequantizeMaxAbsOp : public framework::OperatorWithKernel {
       : OperatorWithKernel(type, inputs, outputs, attrs) {}
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"),
-                   "Input(X) of FakeDequantizeMaxAbsOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasOutput("Out"),
-                   "Output(Out) of FakeDequantizeMaxAbsOp should not be null.");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "FakeDequantizeMaxAbs");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "FakeDequantizeMaxAbs");
 
     ctx->ShareDim("X", /*->*/ "Out");
     ctx->ShareLoD("X", /*->*/ "Out");
@@ -125,15 +124,12 @@ class FakeChannelWiseDequantizeMaxAbsOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(
-        ctx->HasInput("X"),
-        "Input(X) of FakeChannelWiseDequantizeMaxAbsOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasInputs("Scales"),
-                   "Input(Scales) of FakeChannelWiseDequantizeMaxAbsOp "
-                   "should not be null.");
-    PADDLE_ENFORCE(
-        ctx->HasOutput("Out"),
-        "Output(Out) of FakeChannelWiseDequantizeMaxAbsOp should not be null.");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X",
+                   "FakeChannelWiseDequantizeMaxAbs");
+    OP_INOUT_CHECK(ctx->HasInputs("Scales"), "Input", "Scales",
+                   "FakeChannelWiseDequantizeMaxAbs");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
+                   "FakeChannelWiseDequantizeMaxAbs");
 
     ctx->ShareDim("X", /*->*/ "Out");
     ctx->ShareLoD("X", /*->*/ "Out");

--- a/paddle/fluid/operators/fake_dequantize_op.h
+++ b/paddle/fluid/operators/fake_dequantize_op.h
@@ -71,19 +71,25 @@ class FakeChannelWiseDequantizeMaxAbsKernel : public framework::OpKernel<T> {
     if (scale_num == 1) {
       PADDLE_ENFORCE_EQ(
           scales[0]->numel(), in->dims()[0],
-          "The number of first scale values must be the same with "
-          "first dimension value of Input(X) when the `Scales` has only one "
-          "element.");
+          platform::errors::PreconditionNotMet(
+              "The number of first scale values must be the same with "
+              "first dimension value of Input(X) when the `Scales` has only "
+              "one element, but %ld != %ld here.",
+              scales[0]->numel(), in->dims()[0]));
       max_range *= (std::pow(2, quant_bits[0] - 1) - 1);
     } else if (scale_num == 2) {
       PADDLE_ENFORCE_EQ(
           scales[0]->numel(), in->dims()[1],
-          "The number of first scale values must be the same with "
-          "second dimension value of Input(X) when the `Scales` has two "
-          "elements.");
-      PADDLE_ENFORCE_EQ(
-          scales[1]->numel(), 1,
-          "The second scale tensor should only have one value at now.");
+          platform::errors::PreconditionNotMet(
+              "The number of first scale values must be the same with "
+              "second dimension value of Input(X) when the `Scales` has two "
+              "elements, but %ld != %ld here.",
+              scales[0]->numel(), in->dims()[1]));
+      PADDLE_ENFORCE_EQ(scales[1]->numel(), 1,
+                        platform::errors::PreconditionNotMet(
+                            "The second scale tensor should only have one "
+                            "value at now, but it has %ld values here.",
+                            scales[1]->numel()));
       max_range *= (std::pow(2, quant_bits[0] - 1) - 1) *
                    (std::pow(2, quant_bits[1] - 1) - 1);
     }


### PR DESCRIPTION
## fake_dequantize op报错信息不合规增强：

1. 将fake_dequantize一类Op中的InferShape方法中的输入输出检查从 `PADDLE_ENFORCE `改为`OP_INOUT_CHECK `。

2. 在对OpKernel中的量化scale维度数进行检查时使用`platform::errors::PreconditionNotMet`对error message进行封装，并将错误的维度信息进行详细说明。