### PR TITLE
solve mklml memory leak

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -37,7 +37,9 @@
 #include "paddle/fluid/inference/utils/singleton.h"
 #include "paddle/fluid/memory/memcpy.h"
 #include "paddle/fluid/platform/cpu_helper.h"
+#ifdef PADDLE_WITH_MKLML
 #include "paddle/fluid/platform/dynload/mklml.h"
+#endif
 #include "paddle/fluid/platform/gpu_info.h"
 #include "paddle/fluid/platform/place.h"
 #include "paddle/fluid/platform/profiler.h"
@@ -310,11 +312,13 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
 #ifdef PADDLE_WITH_MKLDNN
   if (config_.use_mkldnn_) MkldnnPostReset();
 #endif
-#if PADDLE_WITH_MKLML
+#if defined(PADDLE_WITH_MKLML) && defined(_LINUX)
   // Frees unused memory allocated by the Intel® MKL Memory Allocator to
   // avoid memory leak. See:
   // https://software.intel.com/en-us/mkl-developer-reference-c-mkl-free-buffers
   platform::dynload::MKL_Free_Buffers();
+// We don't support windows since MKL_Free_Buffers is not in
+// mklml_win_2019.0.1.20181227.zip. We will upgrade mklml_win version later.
 #endif
   return true;
 }
@@ -655,11 +659,13 @@ bool AnalysisPredictor::ZeroCopyRun() {
   // recover the cpu_math_library_num_threads to 1, in order to avoid thread
   // conflict when integrating it into deployment service.
   paddle::platform::SetNumThreads(1);
-#if PADDLE_WITH_MKLML
+#if defined(PADDLE_WITH_MKLML) && defined(_LINUX)
   // Frees unused memory allocated by the Intel® MKL Memory Allocator to
   // avoid memory leak. See:
   // https://software.intel.com/en-us/mkl-developer-reference-c-mkl-free-buffers
   platform::dynload::MKL_Free_Buffers();
+// We don't support windows since MKL_Free_Buffers is not in
+// mklml_win_2019.0.1.20181227.zip. We will upgrade mklml_win version later.
 #endif
   return true;
 }

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -314,7 +314,7 @@ bool AnalysisPredictor::Run(const std::vector<PaddleTensor> &inputs,
   // Frees unused memory allocated by the Intel® MKL Memory Allocator to
   // avoid memory leak. See:
   // https://software.intel.com/en-us/mkl-developer-reference-c-mkl-free-buffers
-  mkl_free_buffers();
+  platform::dynload::MKL_Free_Buffers();
 #endif
   return true;
 }
@@ -659,7 +659,7 @@ bool AnalysisPredictor::ZeroCopyRun() {
   // Frees unused memory allocated by the Intel® MKL Memory Allocator to
   // avoid memory leak. See:
   // https://software.intel.com/en-us/mkl-developer-reference-c-mkl-free-buffers
-  mkl_free_buffers();
+  platform::dynload::MKL_Free_Buffers();
 #endif
   return true;
 }

--- a/paddle/fluid/platform/dynload/mklml.h
+++ b/paddle/fluid/platform/dynload/mklml.h
@@ -89,6 +89,7 @@ extern void* mklml_dso_handle;
   __macro(vdInv);                   \
   __macro(vmsErf);                  \
   __macro(vmdErf);                  \
+  __macro(MKL_Free_Buffers);        \
   __macro(MKL_Set_Num_Threads)
 
 MKLML_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_MKLML_WRAP);


### PR DESCRIPTION
fix #22827 
- related https://github.com/PaddlePaddle/Paddle/pull/23314#issuecomment-607583628
- use [mkl_free_buffers()](https://software.intel.com/en-us/mkl-developer-reference-c-mkl-free-buffers) to solve memory leak
- Inspired by [Avoiding Memory Leaks in Intel® MKL](https://software.intel.com/en-us/mkl-linux-developer-guide-avoiding-memory-leaks-in-intel-mkl). In our application, call the `mkl_disable_fast_mm()` function or `mkl_thread_free_buffers` function could not fix the memory leak.
