### PR TITLE
API(fluid.layers.array_read/array_write) error message enhancement

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1256,11 +1256,6 @@ def array_write(x, i, array=None):
     Returns:
         Variable: The input ``array`` after ``x`` is written into.
 
-    Raises:
-        TypeError: If `array` is not None or a variable.
-        TypeError: If `i` is not a variable.
-        TypeError: If `x` is not a variable.
-    
     Examples:
         .. code-block:: python
 
@@ -1292,10 +1287,6 @@ def array_write(x, i, array=None):
             #       and '__int64' on Windows. They both represent 64-bit integer variables.
 
     """
-    if array is not None:
-        check_type(array, 'array', (Variable), 'array_write')
-    check_type(i, 'i', (Variable), 'array_write')
-    check_type(x, 'x', (Variable), 'array_write')
     if in_dygraph_mode():
         assert isinstance(
             x, Variable
@@ -1321,7 +1312,15 @@ def array_write(x, i, array=None):
             array.append(x)
         return array
 
+    check_variable_and_dtype(i, 'i', ['int32', 'int64'], 'array_write')
+    check_type(x, 'x', (Variable), 'array_write')
     helper = LayerHelper('array_write', **locals())
+    if array is not None:
+        if not isinstance(
+                array,
+                Variable) or array.type != core.VarDesc.VarType.LOD_TENSOR_ARRAY:
+            raise TypeError(
+                "array should be tensor array vairable in array_write Op")
     if array is None:
         array = helper.create_variable(
             name="{0}.out".format(helper.name),
@@ -1645,10 +1644,6 @@ def array_read(array, i):
     Returns:
         Variable: The LoDTensor or Tensor that is read at the specified position of ``array``.
     
-    Raises:
-        TypeError: If `array` is not a variable.
-        TypeError: If `i` is not a variable.
-
     Examples:
         .. code-block:: python
 
@@ -1684,8 +1679,6 @@ def array_read(array, i):
             #       so the dtype value is typeid(int64_t).Name(), which is 'x' on MacOS, 'l' on Linux, 
             #       and '__int64' on Windows. They both represent 64-bit integer variables.
     """
-    check_type(array, 'array', (Variable), 'array_read')
-    check_type(array, 'i', (Variable), 'array_read')
     if in_dygraph_mode():
         assert isinstance(
             array,
@@ -1699,6 +1692,7 @@ def array_read(array, i):
         i = i.numpy()[0]
         return array[i]
 
+    check_variable_and_dtype(i, 'i', ['int32', 'int64'], 'array_read')
     helper = LayerHelper('array_read', **locals())
     if not isinstance(
             array,

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1256,6 +1256,11 @@ def array_write(x, i, array=None):
     Returns:
         Variable: The input ``array`` after ``x`` is written into.
 
+    Raises:
+        TypeError: If `array` is not a variable.
+        TypeError: If `i` is not a variable.
+        TypeError: If `x` is not a variable.
+    
     Examples:
         .. code-block:: python
 
@@ -1287,6 +1292,10 @@ def array_write(x, i, array=None):
             #       and '__int64' on Windows. They both represent 64-bit integer variables.
 
     """
+    if array is not None:
+        check_type(array, 'array', (Variable), 'array_write')
+    check_type(i, 'i', (Variable), 'array_write')
+    check_type(x, 'x', (Variable), 'array_write')
     if in_dygraph_mode():
         assert isinstance(
             x, Variable
@@ -1635,6 +1644,10 @@ def array_read(array, i):
 
     Returns:
         Variable: The LoDTensor or Tensor that is read at the specified position of ``array``.
+    
+    Raises:
+        TypeError: If `array` is not a variable.
+        TypeError: If `i` is not a variable.
 
     Examples:
         .. code-block:: python
@@ -1671,6 +1684,8 @@ def array_read(array, i):
             #       so the dtype value is typeid(int64_t).Name(), which is 'x' on MacOS, 'l' on Linux, 
             #       and '__int64' on Windows. They both represent 64-bit integer variables.
     """
+    check_type(array, 'array', (Variable), 'array_read')
+    check_type(array, 'i', (Variable), 'array_read')
     if in_dygraph_mode():
         assert isinstance(
             array,

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1257,7 +1257,7 @@ def array_write(x, i, array=None):
         Variable: The input ``array`` after ``x`` is written into.
 
     Raises:
-        TypeError: If `array` is not a variable.
+        TypeError: If `array` is not None or a variable.
         TypeError: If `i` is not a variable.
         TypeError: If `x` is not a variable.
     

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1312,7 +1312,7 @@ def array_write(x, i, array=None):
             array.append(x)
         return array
 
-    check_variable_and_dtype(i, 'i', ['int32', 'int64'], 'array_write')
+    check_variable_and_dtype(i, 'i', ['int64'], 'array_write')
     check_type(x, 'x', (Variable), 'array_write')
     helper = LayerHelper('array_write', **locals())
     if array is not None:
@@ -1692,7 +1692,7 @@ def array_read(array, i):
         i = i.numpy()[0]
         return array[i]
 
-    check_variable_and_dtype(i, 'i', ['int32', 'int64'], 'array_read')
+    check_variable_and_dtype(i, 'i', ['int64'], 'array_read')
     helper = LayerHelper('array_read', **locals())
     if not isinstance(
             array,

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1643,7 +1643,7 @@ def array_read(array, i):
 
     Returns:
         Variable: The LoDTensor or Tensor that is read at the specified position of ``array``.
-    
+
     Examples:
         .. code-block:: python
 

--- a/python/paddle/fluid/tests/unittests/test_array_read_write_op.py
+++ b/python/paddle/fluid/tests/unittests/test_array_read_write_op.py
@@ -21,6 +21,7 @@ import paddle.fluid.layers as layers
 from paddle.fluid.executor import Executor
 from paddle.fluid.backward import append_backward
 from paddle.fluid.framework import default_main_program
+from paddle.fluid import compiler, Program, program_guard
 import numpy
 
 
@@ -123,6 +124,20 @@ class TestArrayReadWrite(unittest.TestCase):
             g_out_sum_dygraph = numpy.array(g_out_dygraph).sum()
 
             self.assertAlmostEqual(1.0, g_out_sum_dygraph, delta=0.1)
+
+
+class TestArrayReadWriteOpError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            #for ci coverage
+            x1 = numpy.random.randn(2, 4).astype('int32')
+            x2 = fluid.layers.fill_constant(shape=[1], dtype='int32', value=1)
+            x3 = numpy.random.randn(2, 4).astype('int32')
+
+            self.assertRaises(
+                TypeError, fluid.layers.array_read, array=x1, i=x2)
+            self.assertRaises(
+                TypeError, fluid.layers.array_write, array=x1, i=x2, out=x3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### API fluid.layers.array_read/array_write报错信息增强 [仅涉及Python端]
- C++端已在https://github.com/PaddlePaddle/Paddle/pull/23468 进行修改。
- API接口
```python
def array_write(x, i , array=None):
def array_read(array, i):
```
对输入（x  i  arrary等输入变量）是否是Variable 进行检查

![image](https://user-images.githubusercontent.com/13411999/78747054-122c3400-799b-11ea-8a17-ce47559a648f.png)


![image](https://user-images.githubusercontent.com/13411999/78747825-f3c73800-799c-11ea-8846-1bf40d9bf344.png)


###Pytho 端测试代码
```

            import paddle.fluid as fluid
            import numpy as np
            arr = fluid.layers.create_array(dtype='float32')
            tmp = np.random.randn(2, 1).astype('float32')
            i = fluid.layers.fill_constant(shape=[1], dtype='float32', value=10)
            arr = fluid.layers.array_write(tmp, i, array=arr)
            item = fluid.layers.array_read(arr, i)
            input = fluid.layers.Print(item, message="The LoDTensor of the i-th position:")
            main_program = fluid.default_main_program()
            exe = fluid.Executor(fluid.CPUPlace())
            exe.run(main_program)


```
报错信息
```
TypeError: The data type of 'i' in array_write must be ['int32', 'int64'], but received float32.
```