### PR TITLE
API(create_tensor) error message enhancement

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -51,9 +51,6 @@ def create_tensor(dtype, name=None, persistable=False):
     Returns:
         Variable: The tensor to be created according to dtype.
 
-    Raise:
-        TypeError: The dtype must be one of bool, float16, float32, float64, int8, int16, int32 and int64.
-    
     Examples:
         .. code-block:: python
 

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -57,6 +57,8 @@ def create_tensor(dtype, name=None, persistable=False):
           import paddle.fluid as fluid
           tensor = fluid.layers.create_tensor(dtype='float32')
     """
+    check_dtype(dtype, 'dtype', ['float32', 'float64', 'int32', 'int64'],
+                'create_tensor')
     helper = LayerHelper("create_tensor", **locals())
     return helper.create_variable(
         name=helper.name, dtype=dtype, persistable=persistable)

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -51,13 +51,17 @@ def create_tensor(dtype, name=None, persistable=False):
     Returns:
         Variable: The tensor to be created according to dtype.
 
+    Raise:
+        TypeError: The dtype must be one of bool, float16, float32, float64, int32 and int64.
+    
     Examples:
         .. code-block:: python
 
           import paddle.fluid as fluid
           tensor = fluid.layers.create_tensor(dtype='float32')
     """
-    check_dtype(dtype, 'dtype', ['float32', 'float64', 'int32', 'int64'],
+    check_dtype(dtype, 'dtype',
+                ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'],
                 'create_tensor')
     helper = LayerHelper("create_tensor", **locals())
     return helper.create_variable(

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -52,7 +52,7 @@ def create_tensor(dtype, name=None, persistable=False):
         Variable: The tensor to be created according to dtype.
 
     Raise:
-        TypeError: The dtype must be one of bool, float16, float32, float64, int32 and int64.
+        TypeError: The dtype must be one of bool, float16, float32, float64, int8, int16, int32 and int64.
     
     Examples:
         .. code-block:: python
@@ -60,9 +60,10 @@ def create_tensor(dtype, name=None, persistable=False):
           import paddle.fluid as fluid
           tensor = fluid.layers.create_tensor(dtype='float32')
     """
-    check_dtype(dtype, 'dtype',
-                ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'],
-                'create_tensor')
+    check_dtype(dtype, 'dtype', [
+        'bool', 'float16', 'float32', 'float64', 'int8', 'int32', 'int32',
+        'int64'
+    ], 'create_tensor')
     helper = LayerHelper("create_tensor", **locals())
     return helper.create_variable(
         name=helper.name, dtype=dtype, persistable=persistable)


### PR DESCRIPTION
### API fluid.layers.create_tensor 报错信息增强 [仅涉及Python端]
- API接口
```python
def create_tensor(dtype, name=None, persistable=False):
```
对dtype类型进行检查


![image](https://user-images.githubusercontent.com/13411999/78746368-2ec76c80-7999-11ea-9710-e3fe06860777.png)
