### PR TITLE
API/OP (Conv2DTranspose) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -2330,8 +2330,9 @@ class Conv2DTranspose(layers.Layer):
             return dygraph_utils._append_activation_in_dygraph(
                 pre_act, act=self._act)
 
-        check_variable_and_dtype(
-            input, 'input', ['float16', 'float32', 'float64'], self._op_type)
+        check_variable_and_dtype(input, 'input',
+                                 ['float16', 'float32', 'float64'],
+                                 "Conv2DTranspose")
 
         inputs = {'Input': [input], 'Filter': [self.weight]}
         attrs = {

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -2330,6 +2330,9 @@ class Conv2DTranspose(layers.Layer):
             return dygraph_utils._append_activation_in_dygraph(
                 pre_act, act=self._act)
 
+        check_variable_and_dtype(
+            input, 'input', ['float16', 'float32', 'float64'], self._op_type)
+
         inputs = {'Input': [input], 'Filter': [self.weight]}
         attrs = {
             'output_size': self._output_size,

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -555,7 +555,7 @@ class TestLayer(LayerTest):
 
             self.assertRaises(TypeError, test_Variable)
 
-            # the input dtype of Conv2DTranspos must be float16 or float32 or float64
+            # the input dtype of Conv2DTranspose must be float16 or float32 or float64
             # float16 only can be set on GPU place
             def test_type():
                 images = layers.data(

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -544,6 +544,28 @@ class TestLayer(LayerTest):
             self.assertTrue(
                 np.array_equal(conv2d1.bias.numpy(), conv2d2.bias.numpy()))
 
+        with self.static_graph():
+
+            # the input of Conv2DTranspose must be Variable.
+            def test_Variable():
+                images = np.ones([2, 3, 5, 5], dtype='float32')
+                conv2d = nn.Conv2DTranspose(
+                    num_channels=3, num_filters=3, filter_size=[2, 2])
+                conv2d_ret1 = conv2d(images)
+
+            self.assertRaises(TypeError, test_Variable)
+
+            # the input dtype of Conv2DTranspos must be float16 or float32 or float64
+            # float16 only can be set on GPU place
+            def test_type():
+                images = layers.data(
+                    name='pixel', shape=[3, 5, 5], dtype='int32')
+                conv2d = nn.Conv2DTranspose(
+                    num_channels=3, num_filters=3, filter_size=[2, 2])
+                conv2d_ret2 = conv2d(images)
+
+            self.assertRaises(TypeError, test_type)
+
     def test_bilinear_tensor_product(self):
         inp_np_x = np.array([[1, 2, 3]]).astype('float32')
         inp_np_y = np.array([[4, 5, 6]]).astype('float32')


### PR DESCRIPTION
error message enhancement for **Conv2DTranspose**.

* check the input's type is Variable

```
import paddle.fluid as fluid
from paddle.fluid.dygraph import nn
import numpy as np

images = np.ones([2, 3, 5, 5], dtype='float32')
conv2d = nn.Conv2DTranspose(
    num_channels=3, num_filters=3, filter_size=[2, 2])
ret = conv2d(images)
TypeError: The type of 'input' in Conv2DTranspose must be <class 'paddle.fluid.framework.Variable'>, but received <type 'numpy.ndarray'>.
```

* check the input's dtype is in ['float16', 'float32', 'float64']

```
import paddle.fluid as fluid
from paddle.fluid.dygraph import nn
import numpy as np

images = fluid.layers.data(name='pixel', shape=[2, 3, 5, 5], dtype='int32')
conv2d = nn.Conv2DTranspose(
    num_channels=3, num_filters=3, filter_size=[2, 2])
ret = conv2d(images)
TypeError: The data type of 'input' in Conv2DTranspose must be ['float16', 'float32', 'float64'], but received int32.
```