### PR TITLE
API/OP (Linear) error message enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -936,6 +936,10 @@ class Linear(layers.Layer):
 
             return dygraph_utils._append_activation_in_dygraph(pre_act,
                                                                self._act)
+
+        check_variable_and_dtype(input, 'input',
+                                 ['float16', 'float32', 'float64'], "Linear")
+
         attrs = {
             "x_num_col_dims": len(input.shape) - 1,
             "y_num_col_dims": 1,

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -128,6 +128,31 @@ class TestLayer(LayerTest):
 
         self.assertTrue(np.array_equal(static_ret, dy_ret_value))
 
+        with self.static_graph():
+
+            # the input of Linear must be Variable.
+            def test_Variable():
+                inp = np.ones([3, 32, 32], dtype='float32')
+                linear = nn.Linear(
+                    32,
+                    4,
+                    bias_attr=fluid.initializer.ConstantInitializer(value=1))
+                linear_ret1 = linear(inp)
+
+            self.assertRaises(TypeError, test_Variable)
+
+            # the input dtype of Linear must be float16 or float32 or float64
+            # float16 only can be set on GPU place
+            def test_type():
+                inp = np.ones([3, 32, 32], dtype='int32')
+                linear = nn.Linear(
+                    32,
+                    4,
+                    bias_attr=fluid.initializer.ConstantInitializer(value=1))
+                linear_ret2 = linear(inp)
+
+            self.assertRaises(TypeError, test_type)
+
     def test_layer_norm(self):
         inp = np.ones([3, 32, 32], dtype='float32')
         with self.static_graph():


### PR DESCRIPTION
error message enhancement for **Linear**.

* check the input's type is Variable

```
import paddle.fluid as fluid
from paddle.fluid.dygraph import nn
import numpy as np

inp = np.ones([3, 32, 32], dtype='float32')
linear = nn.Linear(32, 4, bias_attr=fluid.initializer.ConstantInitializer(value=1))
linear_ret1 = linear(inp)
TypeError: The type of 'input' in Linear must be <class 'paddle.fluid.framework.Variable'>, but received <type 'numpy.ndarray'>.
```

* check the input's dtype is in ['float16', 'float32', 'float64']

```
import paddle.fluid as fluid
from paddle.fluid.dygraph import nn
import numpy as np

inp = fluid.layers.data(name='pixel', shape=[3, 32, 32], dtype='int32')
linear = nn.Linear(32, 4, bias_attr=fluid.initializer.ConstantInitializer(value=1))
linear_ret2 = linear(inp)
TypeError: The data type of 'input' in Linear must be ['float16', 'float32', 'float64'], but received int32.
```