### PR TITLE
fix no_grad signature

### DIFF
--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from ..wrapped_decorator import signature_safe_contextmanager, wrap_decorator
 import contextlib
+import functools
 import sys
 import numpy as np
 from paddle.fluid import core
@@ -195,6 +196,7 @@ def no_grad(func=None):
         return _switch_tracer_mode_guard_(is_train=False)
     else:
 
+        @functools.wraps(func)
         def __impl__(*args, **kwargs):
             with _switch_tracer_mode_guard_(is_train=False):
                 return func(*args, **kwargs)

--- a/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
@@ -28,7 +28,6 @@ class TestTracerMode(unittest.TestCase):
 
     @fluid.dygraph.no_grad
     def no_grad_func(self, a):
-        """doc for no_grad_func"""
         self.assertEqual(self.tracer._train_mode, False)
         return a
 
@@ -50,7 +49,7 @@ class TestTracerMode(unittest.TestCase):
             self.tracer._train_mode = self.init_mode
 
             self.assertEqual(self.no_grad_func(1), 1)
-            self.assertEqual(self.no_grad_func.__doc__, "doc for no_grad_func")
+            self.assertEqual(self.no_grad_func.__name__, "no_grad_func")
 
             self.assertEqual(self.tracer._train_mode, self.init_mode)
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
@@ -28,6 +28,7 @@ class TestTracerMode(unittest.TestCase):
 
     @fluid.dygraph.no_grad
     def no_grad_func(self, a):
+        """doc for no_grad_func"""
         self.assertEqual(self.tracer._train_mode, False)
         return a
 
@@ -49,6 +50,7 @@ class TestTracerMode(unittest.TestCase):
             self.tracer._train_mode = self.init_mode
 
             self.assertEqual(self.no_grad_func(1), 1)
+            self.assertEqual(self.no_grad_func.__doc__, "doc for no_grad_func")
 
             self.assertEqual(self.tracer._train_mode, self.init_mode)
 


### PR DESCRIPTION
use `functools.wraps` to preserve decorated function signature (fix function signature missing bug in PR #22522)