### PR TITLE
API/OP (Pool2D) error message enhancement 

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -834,6 +834,10 @@ class Pool2D(layers.Layer):
                      'use_mkldnn', False, 'exclusive', self._exclusive)
             return core.ops.pool2d(input, *attrs)
 
+        check_variable_and_dtype(
+            input, 'input', ['int8', 'uint8', 'float16', 'float32', 'float64'],
+            'Pool2D')
+
         attrs = {
             "pooling_type": self._pool_type,
             "ksize": self._pool_size,


### PR DESCRIPTION
error message enhancement for **Pool2D**.

* check the input's type is Variable

```
import paddle.fluid as fluid
from paddle.fluid.dygraph import nn
import numpy as np

data = np.random.random((3, 32, 32, 5)).astype('float32')
pool2d = fluid.dygraph.Pool2D(
    pool_size=2,
    pool_type='max',
    pool_stride=1,
    global_pooling=False)
ret = pool2d(data)
TypeError: The type of 'input' in Pool2D must be <class 'paddle.fluid.framework.Variable'>, but received <type 'numpy.ndarray'>.
```

* check the input's dtype is in ['int8', 'uint8', 'float16', 'float32', 'float64']

```
import paddle.fluid as fluid
from paddle.fluid.dygraph import nn
import numpy as np

data = fluid.layers.data(name='x1', shape=[3, 32, 32, 5], dtype="int32")
pool2d = fluid.dygraph.Pool2D(
    pool_size=2,
    pool_type='max',
    pool_stride=1,
    global_pooling=False)
ret = pool2d(data)
TypeError: The data type of 'input' in Pool2D must be ['int8', 'uint8', 'float16', 'float32', 'float64'], but received int32.
```