### PR TITLE
fix yolov3_loss gt_score check in dygraph

### DIFF
--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -993,7 +993,7 @@ def yolov3_loss(x,
         "GTBox": gt_box,
         "GTLabel": gt_label,
     }
-    if gt_score:
+    if gt_score is not None:
         inputs["GTScore"] = gt_score
 
     attrs = {


### PR DESCRIPTION
**fix yolov3_loss gt_score check in dygraph**
fix following error:
```
Traceback (most recent call last):
  File "main.py", line 209, in <module>
    main()
  File "main.py", line 165, in main
    save_freq=10)
  File "/paddle/dengkaipeng/git/hapi/model.py", line 987, in fit
    loader, cbks, 'train', metrics_name, epoch=epoch)
  File "/paddle/dengkaipeng/git/hapi/model.py", line 1198, in _run_one_epoch
    data[len(self._inputs):])
  File "/paddle/dengkaipeng/git/hapi/model.py", line 705, in train
    return self._adapter.train(*args, **kwargs)
  File "/paddle/dengkaipeng/git/hapi/model.py", line 548, in train
    losses = self.model._loss_function(outputs, labels)
  File "/paddle/dengkaipeng/git/hapi/model.py", line 121, in __call__
    losses = to_list(self.forward(to_list(outputs), labels))
  File "/paddle/dengkaipeng/git/hapi/models/yolov3.py", line 228, in forward
    use_label_smooth=True)
  File "/usr/local/lib/python3.7/site-packages/paddle/fluid/layers/detection.py", line 996, in yolov3_loss
    if gt_score:
  File "/usr/local/lib/python3.7/site-packages/paddle/fluid/dygraph/varbase_patch_methods.py", line 215, in __bool__
    return self.__nonzero__()
  File "/usr/local/lib/python3.7/site-packages/paddle/fluid/dygraph/varbase_patch_methods.py", line 209, in __nonzero__
    assert numel == 1, "When Variable is used as the condition of if/while , Variable can only contain one element."
AssertionError: When Variable is used as the condition of if/while , Variable can only contain one element.
```
