### PR TITLE
API(sequence_concat) error message enhancement

### DIFF
--- a/python/paddle/fluid/layers/sequence_lod.py
+++ b/python/paddle/fluid/layers/sequence_lod.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 from .layer_function_generator import templatedoc
 from ..framework import Variable, in_dygraph_mode
 from ..layer_helper import LayerHelper
+from ..data_feeder import check_variable_and_dtype, check_type, check_dtype
 
 __all__ = [
     'sequence_conv',
@@ -405,6 +406,13 @@ def sequence_concat(input, name=None):
     assert not in_dygraph_mode(), (
         "sequence layer is not supported in dygraph mode yet.")
     helper = LayerHelper('sequence_concat', **locals())
+
+    check_type(input, 'input', list, 'fluid.layers.sequence_concat')
+    if isinstance(input, list):
+        for i, input_x in enumerate(input):
+            check_type(input_x, 'input[' + str(i) + ']', Variable, 'fluid.layers.sequence_concat')
+            check_dtype(input_x.dtype, 'input[' + str(i) + ']', ['int64', 'float32', 'float64'], 'fluid.layers.sequence_concat')
+
     out = helper.create_variable_for_type_inference(dtype=helper.input_dtype())
     helper.append_op(
         type='sequence_concat', inputs={'X': input}, outputs={'Out': [out]})

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -2990,6 +2990,41 @@ class TestBook(LayerTest):
                 input=seqs, offset=offset, length=length)
             return (out)
 
+    def test_sequence_concat(self): 
+        with self.static_graph(): 
+            seqs_x = layers.data(name='x', shape=[10, 5], dtype='float32', lod_level=1)
+            seqs_y = layers.data(name='y', shape=[10, 5], dtype='float32', lod_level=1)
+            out = layers.sequence_concat(input=[seqs_x, seqs_y], name="sequence_concat")
+            return (out)
+
+    def test_sequence_concat_op_error(self): 
+        with self.static_graph(): 
+
+            def test_type_list(): 
+                # the input type must be list
+                x_data = fluid.layers.data(
+                  name='x', shape=[4], dtype='float32')
+                fluid.layers.sequence_concat(x=x_data)
+            self.assertRaises(TypeError, test_type_list)
+
+            def test_variable(): 
+                # the input element type must be Variable              
+                x1_data = fluid.layers.data(
+                  name='x1', shape=[3, 5], dtype='float32')
+                import numpy as np
+                y1_data = np.array([[3, 5]]).astype('float32')
+                fluid.layers.sequence_concat(x=[x1_data, y1_data])
+            self.assertRaises(TypeError, test_variable)
+
+            def test_dtype(): 
+                # dtype must be 'float32', 'float64', 'int64'
+                x2_data = fluid.layers.data(
+                  name='x2', shape=[3, 5], dtype='int32')
+                y2_data = fluid.layers.data(
+                  name='y2', shape=[3, 5], dtype='int32')
+                fluid.layers.sequence_concat(x=[x2_data, y2_data])
+            self.assertRaises(TypeError, test_dtype)
+
     def test_filter_by_instag(self):
         # TODO(minqiyang): dygraph do not support lod now
         with self.static_graph():


### PR DESCRIPTION
sequence_concat API input error message enhancement
1) check type and dtype
2) add unittest for equence_concat and equence_concat_op_error