### PR TITLE
修复windows环境下保存模型时会报文件夹不存在的错误

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1543,6 +1543,10 @@ def save(program, model_path):
 
     parameter_list = list(filter(is_parameter, program.list_vars()))
     param_dict = {p.name: get_tensor(p) for p in parameter_list}
+
+    if not os.path.exists(model_path):
+        os.makedirs(model_path)
+
     with open(model_path + ".pdparams", 'wb') as f:
         pickle.dump(param_dict, f, protocol=2)
 


### PR DESCRIPTION
在windows环境下运行的时候不会自动生成文件夹，需要加这一段代码生成文件夹