### PR TITLE
Add batched_gemm op in contrib

### DIFF
--- a/paddle/fluid/operators/batched_gemm_op.cc
+++ b/paddle/fluid/operators/batched_gemm_op.cc
@@ -32,24 +32,6 @@ class BatchedGEMMOp : public framework::OperatorWithKernel {
     auto batch_count = ctx->Attrs().Get<int>("BatchCount");
     auto mat_m = ctx->Attrs().Get<int>("Mat_M");
     auto mat_n = ctx->Attrs().Get<int>("Mat_N");
-    // auto mat_k = ctx->Attrs().Get<int>("Mat_K");
-    // X = batch_count * mat_m * mat_k
-    // Y = batch_count * mat_k * mat_n
-    // Out = batch_count * mat_m * mat_n
-    // auto x_dims = ctx->GetInputDim("X");
-    // auto y_dims = ctx->GetInputDim("Y");
-    // int x_numel = framework::product(x_dims);
-    // int y_numel = framework::product(y_dims);
-
-    // PADDLE_ENFORCE_EQ(
-    //     x_numel, batch_count * mat_m * mat_k,
-    //     platform::errors::OutOfRange(
-    //         "X of BatchedGEMM has error dims."));
-
-    // PADDLE_ENFORCE_EQ(
-    //     y_numel, batch_count * mat_k * mat_n,
-    //     platform::errors::OutOfRange(
-    //         "Y of BatchedGEMM has error dims."));
     ctx->SetOutputDim("Out", {batch_count, mat_m, mat_n});
     ctx->ShareLoD("X", /*->*/ "Out");
   }

--- a/paddle/fluid/operators/batched_gemm_op.cc
+++ b/paddle/fluid/operators/batched_gemm_op.cc
@@ -1,0 +1,148 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/batched_gemm_op.h"
+
+namespace paddle {
+namespace operators {
+
+class BatchedGEMMOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
+                      platform::errors::InvalidArgument(
+                          "Input(X) of BatchedGEMM should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("Y"), true,
+                      platform::errors::InvalidArgument(
+                          "Input(Y) of BatchedGEMM should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
+                      platform::errors::InvalidArgument(
+                          "Output(Out) of BatchedGEMM should not be null."));
+
+    auto batch_count = ctx->Attrs().Get<int>("BatchCount");
+    auto mat_m = ctx->Attrs().Get<int>("Mat_M");
+    auto mat_n = ctx->Attrs().Get<int>("Mat_N");
+    // auto mat_k = ctx->Attrs().Get<int>("Mat_K");
+    // X = batch_count * mat_m * mat_k
+    // Y = batch_count * mat_k * mat_n
+    // Out = batch_count * mat_m * mat_n
+    // auto x_dims = ctx->GetInputDim("X");
+    // auto y_dims = ctx->GetInputDim("Y");
+    // int x_numel = framework::product(x_dims);
+    // int y_numel = framework::product(y_dims);
+
+    // PADDLE_ENFORCE_EQ(
+    //     x_numel, batch_count * mat_m * mat_k,
+    //     platform::errors::OutOfRange(
+    //         "X of BatchedGEMM has error dims."));
+
+    // PADDLE_ENFORCE_EQ(
+    //     y_numel, batch_count * mat_k * mat_n,
+    //     platform::errors::OutOfRange(
+    //         "Y of BatchedGEMM has error dims."));
+    ctx->SetOutputDim("Out", {batch_count, mat_m, mat_n});
+    ctx->ShareLoD("X", /*->*/ "Out");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(
+        OperatorWithKernel::IndicateVarDataType(ctx, "X"),
+        ctx.device_context());
+  }
+};
+
+class BatchedGEMMGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput("X"), true,
+        platform::errors::InvalidArgument("Input(X) should not be null"));
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput("Y"), true,
+        platform::errors::InvalidArgument("Input(Y) should not be null"));
+
+    ctx->SetOutputDim(framework::GradVarName("X"), ctx->GetInputDim("X"));
+    ctx->SetOutputDim(framework::GradVarName("Y"), ctx->GetInputDim("Y"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.device_context());
+  }
+};
+
+class BatchedGEMMOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor) Input tensor of batched_gemm_op operator.");
+    AddInput("Y", "(Tensor) Input tensor of batched_gemm_op operator.");
+    AddOutput("Out", "Output tensor of batched_gemm_op operator.");
+    AddAttr<int>("Mat_M", "(int, default 1) rows of X in batched_gemm_op")
+        .SetDefault(1);
+    AddAttr<int>("Mat_N", "(int, default 1) columns of Y in batched_gemm_op")
+        .SetDefault(1);
+    AddAttr<int>(
+        "Mat_K",
+        "(int, default 1) columns of X or rows of Y in batched_gemm_op")
+        .SetDefault(1);
+    AddAttr<int>("BatchCount", "(int, default 1) batch_cout of batched_gemm_op")
+        .SetDefault(1);
+    AddComment(R"DOC(
+BatchedGEMM Operator.
+This Op can calculate rank attention between input and rank_param, 
+and rank_param gives the organization of data. Notice: It currently supports GPU device.
+This Op exists in contrib, which means that it is not shown to the public.
+)DOC");
+  }
+};
+
+template <typename T>
+class BatchedGEMMGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> op) const override {
+    op->SetType("batched_gemm_grad");
+
+    op->SetInput("X", this->Input("X"));
+    op->SetInput("Y", this->Input("Y"));
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+
+    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    op->SetOutput(framework::GradVarName("Y"), this->InputGrad("Y"));
+    op->SetAttrMap(this->Attrs());
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(batched_gemm, ops::BatchedGEMMOp, ops::BatchedGEMMOpMaker,
+                  ops::BatchedGEMMGradOpMaker<paddle::framework::OpDesc>,
+                  ops::BatchedGEMMGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OPERATOR(batched_gemm_grad, ops::BatchedGEMMGradOp);
+
+REGISTER_OP_CPU_KERNEL(
+    batched_gemm,
+    ops::BatchedGEMMKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::BatchedGEMMKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/batched_gemm_op.cu
+++ b/paddle/fluid/operators/batched_gemm_op.cu
@@ -1,0 +1,139 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cublas.h>
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/operators/batched_gemm_op.h"
+#include "paddle/fluid/operators/math/blas.h"
+#include "paddle/fluid/platform/cuda_primitives.h"
+#include "paddle/fluid/platform/gpu_info.h"
+
+namespace paddle {
+namespace operators {
+
+using framework::Tensor;
+
+template <typename DeviceContext, typename T>
+class BatchedGEMMCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    auto *X = ctx.Input<Tensor>("X");
+    auto *Y = ctx.Input<Tensor>("Y");
+    int batch_count = ctx.Attr<int>("BatchCount");
+    int mat_m = ctx.Attr<int>("Mat_M");
+    int mat_n = ctx.Attr<int>("Mat_N");
+    int mat_k = ctx.Attr<int>("Mat_K");
+    auto *Out = ctx.Output<Tensor>("Out");
+
+    auto x_dims = X->dims();
+    auto y_dims = Y->dims();
+    int x_numel = framework::product(x_dims);
+    int y_numel = framework::product(y_dims);
+
+    PADDLE_ENFORCE_EQ(
+        x_numel, batch_count * mat_m * mat_k,
+        platform::errors::OutOfRange("X of BatchedGEMM has error dims."));
+    PADDLE_ENFORCE_EQ(
+        y_numel, batch_count * mat_k * mat_n,
+        platform::errors::OutOfRange("Y of BatchedGEMM has error dims."));
+
+    // get data ptr
+    const T *x_data = X->data<T>();
+    const T *y_data = Y->data<T>();
+
+    Out->mutable_data<T>(ctx.GetPlace());
+    // initialize
+    auto out_eigen = framework::EigenVector<T>::Flatten(*Out);
+    auto &dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    auto &place = *ctx.template device_context<platform::CUDADeviceContext>()
+                       .eigen_device();
+    out_eigen.device(place) = out_eigen.constant(static_cast<T>(0));
+
+    // get data ptr
+    T *out_data = Out->data<T>();
+
+    CBLAS_TRANSPOSE transA = CblasNoTrans;
+    CBLAS_TRANSPOSE transB = CblasNoTrans;
+
+    T alpha = 1;
+    T beta = 0;
+    int64_t strideA = mat_m * mat_k;
+    int64_t strideB = mat_k * mat_n;
+
+    auto blas = math::GetBlas<platform::CUDADeviceContext, T>(dev_ctx);
+    blas.BatchedGEMM(transA, transB, mat_m, mat_n, mat_k, alpha, x_data, y_data,
+                     beta, out_data, batch_count, strideA, strideB);
+  }
+};
+
+template <typename DeviceContext, typename T>
+class BatchedGEMMGradOpCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    auto *X = ctx.Input<Tensor>("X");
+    auto *Y = ctx.Input<Tensor>("Y");
+    auto *dout = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    int batch_count = ctx.Attr<int>("BatchCount");
+    int mat_m = ctx.Attr<int>("Mat_M");
+    int mat_n = ctx.Attr<int>("Mat_N");
+    int mat_k = ctx.Attr<int>("Mat_K");
+
+    auto *dx = ctx.Output<Tensor>(framework::GradVarName("X"));
+    auto *dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
+
+    auto &dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    auto &place = *ctx.template device_context<platform::CUDADeviceContext>()
+                       .eigen_device();
+
+    // initialize
+    dx->mutable_data<T>(ctx.GetPlace());
+    auto dx_eigen = framework::EigenVector<T>::Flatten(*dx);
+    dx_eigen.device(place) = dx_eigen.constant(static_cast<T>(0));
+    dy->mutable_data<T>(ctx.GetPlace());
+    auto dy_eigen = framework::EigenVector<T>::Flatten(*dy);
+    dy_eigen.device(place) = dy_eigen.constant(static_cast<T>(0));
+
+    // get data ptr
+    T *dx_data = dx->data<T>();
+    T *dy_data = dy->data<T>();
+    const T *x_data = X->data<T>();
+    const T *y_data = Y->data<T>();
+    const T *dout_data = dout->data<T>();
+
+    auto blas = math::GetBlas<platform::CUDADeviceContext, T>(dev_ctx);
+    T alpha = 1;
+    T beta = 0;
+
+    // dx = dout_data * y^T
+    blas.BatchedGEMM(CblasNoTrans, CblasTrans, mat_m, mat_k, mat_n, alpha,
+                     dout_data, y_data, beta, dx_data, batch_count,
+                     mat_m * mat_n, mat_k * mat_n);
+    // dy = x^T * dout_data
+    blas.BatchedGEMM(CblasTrans, CblasNoTrans, mat_k, mat_n, mat_m, alpha,
+                     x_data, dout_data, beta, dy_data, batch_count,
+                     mat_k * mat_m, mat_m * mat_n);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+using GPUCtx = paddle::platform::CUDADeviceContext;
+REGISTER_OP_CUDA_KERNEL(batched_gemm, ops::BatchedGEMMCUDAKernel<GPUCtx, float>,
+                        ops::BatchedGEMMCUDAKernel<GPUCtx, double>);
+
+REGISTER_OP_CUDA_KERNEL(batched_gemm_grad,
+                        ops::BatchedGEMMGradOpCUDAKernel<GPUCtx, float>,
+                        ops::BatchedGEMMGradOpCUDAKernel<GPUCtx, double>);

--- a/paddle/fluid/operators/batched_gemm_op.cu
+++ b/paddle/fluid/operators/batched_gemm_op.cu
@@ -114,7 +114,6 @@ class BatchedGEMMGradOpCUDAKernel : public framework::OpKernel<T> {
     auto blas = math::GetBlas<platform::CUDADeviceContext, T>(dev_ctx);
     T alpha = 1;
     T beta = 0;
-
     // dx = dout_data * y^T
     blas.BatchedGEMM(CblasNoTrans, CblasTrans, mat_m, mat_k, mat_n, alpha,
                      dout_data, y_data, beta, dx_data, batch_count,

--- a/paddle/fluid/operators/batched_gemm_op.h
+++ b/paddle/fluid/operators/batched_gemm_op.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+class BatchedGEMMKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        platform::is_gpu_place(ctx.GetPlace()), true,
+        platform::errors::Unimplemented("BatchedGEMM only supports GPU now."));
+  }
+};
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/contrib/layers/nn.py
+++ b/python/paddle/fluid/contrib/layers/nn.py
@@ -1298,3 +1298,53 @@ def rank_attention(input,
         attrs={"MaxRank": max_rank,
                "MaxSize": max_size})
     return output
+
+
+def batched_gemm(x, y, batch_count, mat_m, mat_n, mat_k):
+    """
+    **Batched GEMM layer**
+    This Op can calculate BatchedGEMM between x and y.
+    Notice: It currently supports GPU device.
+    This Op exists in contrib, which means that it is not shown to the public.
+    Args:
+        x: Tensor with data type float32, float64.
+        y: Tensor with data type float32, float64.
+        batch_count: The batch size of x or y.
+        mat_m: rows of x.
+        mat_n: columns of y.
+        mat_k: columns of x or rows of y.
+    Returns:
+        Variable: A Tensor with the same data type as x's.
+    Examples:
+        .. code-block:: python
+           import paddle.fluid as fluid
+           
+           x = fluid.data(name="x", shape=[16, 2, 3], dtype="float32")
+           y = fluid.data(name="y", shape=[16, 3, 5], dtype="float32")
+           out = fluid.contrib.layers.batched_gemm(x=x,
+                                                   y=y,
+                                                   batch_count=16,
+                                                   mat_m=2,
+                                                   mat_n=5,
+                                                   mat_k=3)
+    """
+    helper = LayerHelper('batched_gemm', **locals())
+    dtype = helper.input_dtype(input_param_name='x')
+
+    output = helper.create_variable_for_type_inference(dtype)
+
+    helper.append_op(
+        type="batched_gemm",
+        inputs={
+            "X": x,
+            "Y": y,
+        },
+        outputs={"Out": output},
+        attrs={
+            "BatchCount": batch_count,
+            "Mat_M": mat_m,
+            "Mat_N": mat_n,
+            "Mat_K": mat_k
+        })
+
+    return output

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 if (NOT ${WITH_GPU})
     LIST(REMOVE_ITEM TEST_OPS test_conv2d_fusion_op)
     LIST(REMOVE_ITEM TEST_OPS test_rank_attention_op) # TODO(shenliang03): rank_attention_op support CPU device in future
+    LIST(REMOVE_ITEM TEST_OPS test_batched_gemm_op) # TODO(shenliang03): batched_gemm_op support CPU device in future
     LIST(REMOVE_ITEM TEST_OPS test_parallel_dygraph_mnist) # TODO(Yancey1989): parallel dygraph support CPU device in future
 elseif(${CUDNN_VERSION} VERSION_LESS 7100)
     LIST(REMOVE_ITEM TEST_OPS test_conv2d_fusion_op)

--- a/python/paddle/fluid/tests/unittests/test_batched_gemm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batched_gemm_op.py
@@ -105,7 +105,7 @@ class TestBatchedGemmOp2(OpTest):
 
     def test_check_grad_cpu(self):
         try:
-            self.check_grad_with_place(core.CPUPlace(), ["RankParam"], "Out")
+            self.check_grad_with_place(core.CPUPlace(), ["X", "Y"], "Out")
         except:
             print("do not support cpu test, skip")
 

--- a/python/paddle/fluid/tests/unittests/test_batched_gemm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_batched_gemm_op.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+import random
+from op_test import OpTest
+import paddle.fluid as fluid
+from op_test import OpTest, skip_check_grad_ci
+import paddle.fluid.core as core
+
+
+def np_batched_gemm(x, y, batch_count, mat_m, mat_n, mat_k):
+    res = np.zeros((batch_count, mat_m, mat_n))
+    for ins in range(batch_count):
+        res[ins, :] = np.dot(x[ins, :], y[ins, :])
+    return res
+
+
+class TestBatchedGemmOp1(OpTest):
+    def config(self):
+        self.batch_count = 100
+        self.mat_m = 8
+        self.mat_n = 12
+        self.mat_k = 5
+        self.dtype = "float64"
+
+    def setUp(self):
+        self.op_type = "batched_gemm"
+        self.config()
+        x = np.random.random(
+            (self.batch_count, self.mat_m, self.mat_k)).astype(self.dtype)
+        y = np.random.random(
+            (self.batch_count, self.mat_k, self.mat_n)).astype(self.dtype)
+        np_res = np_batched_gemm(x, y, self.batch_count, self.mat_m, self.mat_n,
+                                 self.mat_k)
+
+        self.inputs = {
+            "X": x,
+            "Y": y,
+        }
+        self.attrs = {
+            "BatchCount": self.batch_count,
+            "Mat_M": self.mat_m,
+            "Mat_N": self.mat_n,
+            "Mat_K": self.mat_k
+        }
+        self.outputs = {"Out": np_res}
+
+    def test_check_output_gpu(self):
+        if core.is_compiled_with_cuda():
+            self.check_output_with_place(core.CUDAPlace(0))
+
+    def test_check_grad_gpu(self):
+        if core.is_compiled_with_cuda():
+            self.check_grad_with_place(core.CUDAPlace(0), ["X", "Y"], "Out")
+
+
+class TestBatchedGemmOp2(OpTest):
+    def config(self):
+        self.batch_count = 100
+        self.mat_m = 8
+        self.mat_n = 12
+        self.mat_k = 5
+        self.dtype = "float64"
+
+    def setUp(self):
+        self.op_type = "batched_gemm"
+        self.config()
+        x = np.random.random(
+            (self.batch_count, self.mat_m, self.mat_k)).astype(self.dtype)
+        y = np.random.random(
+            (self.batch_count, self.mat_k, self.mat_n)).astype(self.dtype)
+        np_res = np_batched_gemm(x, y, self.batch_count, self.mat_m, self.mat_n,
+                                 self.mat_k)
+
+        self.inputs = {
+            "X": x,
+            "Y": y,
+        }
+        self.attrs = {
+            "BatchCount": self.batch_count,
+            "Mat_M": self.mat_m,
+            "Mat_N": self.mat_n,
+            "Mat_K": self.mat_k
+        }
+        self.outputs = {"Out": np_res}
+
+    def test_check_output_cpu(self):
+        try:
+            self.check_output_with_place(place=core.CPUPlace())
+        except:
+            print("do not support cpu test, skip")
+
+    def test_check_grad_cpu(self):
+        try:
+            self.check_grad_with_place(core.CPUPlace(), ["RankParam"], "Out")
+        except:
+            print("do not support cpu test, skip")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -3195,6 +3195,14 @@ class TestBook(LayerTest):
                 [x, y], start_index=0, length=2)
             return (sum)
 
+    def test_batched_gemm(self):
+        with self.static_graph():
+            x = fluid.data(name="x", shape=[16, 2, 3], dtype="float32")
+            y = fluid.data(name="y", shape=[16, 3, 5], dtype="float32")
+            out = fluid.contrib.layers.batched_gemm(
+                x=x, y=y, batch_count=16, mat_m=2, mat_n=5, mat_k=3)
+            return (out)
+
     def test_rank_attention(self):
         with self.static_graph():
             input = fluid.data(name="input", shape=[None, 2], dtype="float32")


### PR DESCRIPTION
This Op can calculate batched gemm between x and y. Notice: It currently supports GPU device. This Op exists in contrib, which means that it is not shown to the public.
Reference: https://devblogs.nvidia.com/cublas-strided-batched-matrix-multiply/