### PR TITLE
Relocation of scale op

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -973,6 +973,25 @@ struct MatmulDequant : public PatternBase {
   PATTERN_DECL_NODE(dequant_out);
 };
 
+// Reshape2 + Transpose2 + Scale
+struct ReshapeTransposeScale : public PatternBase {
+  ReshapeTransposeScale(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "reshape_transpose_scale") {}
+
+  PDNode* operator()();
+
+  PATTERN_DECL_NODE(reshape_in);
+  PATTERN_DECL_NODE(reshape_op);
+  PATTERN_DECL_NODE(reshape_out);
+
+  PATTERN_DECL_NODE(transpose_op);
+  PATTERN_DECL_NODE(transpose_out);
+
+  PATTERN_DECL_NODE(scale_op);
+  PATTERN_DECL_NODE(scale_out);
+  PATTERN_DECL_NODE(next_op);
+};
+
 // PriorBox operator
 // operator: prior_box_op
 // inputs: prior_box_input, prior_box_image

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -200,6 +200,50 @@ bool CPUQuantizePass::IsOpQuantized(const Node* node) const {
          node->Op()->GetAttrIfExists<bool>("use_quantizer");
 }
 
+void CPUQuantizePass::RelocateScaleOp(Graph* graph) const {
+  GraphPatternDetector gpd;
+  patterns::ReshapeTransposeScale scale_pattern{gpd.mutable_pattern(),
+                                                "reshape_transpose_scale"};
+  scale_pattern();
+
+  int found_scale_replacement_count = 0;
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    GET_IR_NODE_FROM_SUBGRAPH(reshape_in, reshape_in, scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(reshape_op, reshape_op, scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(transpose_out, transpose_out, scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(scale_op, scale_op, scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(scale_out, scale_out, scale_pattern);
+    GET_IR_NODE_FROM_SUBGRAPH(next_op, next_op, scale_pattern);
+
+    std::string next_op_input_name;
+    for (auto name : next_op->Op()->InputNames())
+      for (auto input_name : next_op->Op()->Input(name))
+        if (input_name == scale_out->Name()) next_op_input_name = name;
+    PADDLE_ENFORCE_NE(
+        next_op_input_name.empty(), true,
+        platform::errors::NotFound("Operator after scale operator "
+                                   "should has scale output as input"));
+
+    UnlinkNodes(transpose_out, scale_op);
+    UnlinkNodes(reshape_in, reshape_op);
+    next_op->Op()->SetInput(next_op_input_name,
+                            std::vector<std::string>({transpose_out->Name()}));
+    IR_NODE_LINK_TO(transpose_out, next_op);
+    scale_op->Op()->SetInput("X",
+                             std::vector<std::string>({reshape_in->Name()}));
+    IR_NODE_LINK_TO(reshape_in, scale_op);
+    reshape_op->Op()->SetInput("X",
+                               std::vector<std::string>({scale_out->Name()}));
+    IR_NODE_LINK_TO(scale_out, reshape_op);
+
+    found_scale_replacement_count++;
+  };
+  gpd(graph, handler);
+  AddStatis(found_scale_replacement_count);
+  PrettyLogDetail("---    relocate %d scale", found_scale_replacement_count);
+}
+
 void CPUQuantizePass::QuantizeConv(Graph* graph,
                                    bool with_residual_data) const {
   GraphPatternDetector gpd;
@@ -593,7 +637,7 @@ void CPUQuantizePass::ApplyImpl(ir::Graph* graph) const {
   FusePassBase::Init(name_scope_, graph);
 
   PADDLE_ENFORCE(param_scope());
-
+  RelocateScaleOp(graph);
   QuantizeConv(graph, false /* with_residual_data */);
   QuantizeConv(graph, true /* with_residual_data */);
   QuantizePool(graph);

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -227,6 +227,7 @@ void CPUQuantizePass::RelocateScaleOp(Graph* graph) const {
 
     UnlinkNodes(transpose_out, scale_op);
     UnlinkNodes(reshape_in, reshape_op);
+    UnlinkNodes(scale_out, next_op);
     next_op->Op()->SetInput(next_op_input_name,
                             std::vector<std::string>({transpose_out->Name()}));
     IR_NODE_LINK_TO(transpose_out, next_op);
@@ -241,7 +242,8 @@ void CPUQuantizePass::RelocateScaleOp(Graph* graph) const {
   };
   gpd(graph, handler);
   AddStatis(found_scale_replacement_count);
-  PrettyLogDetail("---    relocate %d scale", found_scale_replacement_count);
+  PrettyLogDetail("---    relocated %d scale ops",
+                  found_scale_replacement_count);
 }
 
 void CPUQuantizePass::QuantizeConv(Graph* graph,

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.h
@@ -44,6 +44,8 @@ class CPUQuantizePass : public FusePassBase {
  protected:
   void ApplyImpl(ir::Graph* graph) const override;
 
+  void RelocateScaleOp(Graph* graph) const;
+
   void QuantizeConv(Graph* graph, bool with_residual_data = false) const;
 
   void QuantizeFc(Graph* graph) const;

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
@@ -607,7 +607,7 @@ TEST(CpuQuantizePass, matmul_not_quantized) {
 }
 
 static const std::initializer_list<std::string> variable_names_scale = {
-    "a", "b", "c", "d", "e", "f"};
+    "a", "b", "c", "d", "e", "f", "g"};
 
 ProgramDesc BuildProgramDescScaleRelocate() {
   ProgramDesc prog;
@@ -618,7 +618,7 @@ ProgramDesc BuildProgramDescScaleRelocate() {
   SetOp(&prog, "reshape2", "Reshape", {"b"}, {"c"}, false);
   SetOp(&prog, "transpose2", "Transpose", {"c"}, {"d"}, false);
   SetOp(&prog, "scale", "Scale", {"d"}, {"e"}, false);
-  SetOp(&prog, "matmul", "Matmul", {"e"}, {"f"}, false);
+  SetOp(&prog, "matmul", "Matmul", {"e", "f"}, {"g"}, false);
   return prog;
 }
 
@@ -650,7 +650,8 @@ void ScaleRelocateTest(const ProgramDesc& prog,
         EXPECT_EQ(op->Output("Out")[0], transpose_in_out[1]);
       } else if (op->Type() == "matmul") {
         EXPECT_EQ(op->Input("X")[0], matmul_in_out[0]);
-        EXPECT_EQ(op->Output("Out")[0], matmul_in_out[1]);
+        EXPECT_EQ(op->Input("Y")[0], matmul_in_out[1]);
+        EXPECT_EQ(op->Output("Out")[0], matmul_in_out[2]);
       }
     }
   }
@@ -660,7 +661,7 @@ void ScaleRelocateTest(const ProgramDesc& prog,
 TEST(CpuQuantizePass, scale_relocate) {
   int added_nodes_count = 0;
   ScaleRelocateTest(BuildProgramDescScaleRelocate(), {"a", "b"}, {"b", "e"},
-                    {"e", "c"}, {"c", "d"}, {"d", "f"}, added_nodes_count);
+                    {"e", "c"}, {"c", "d"}, {"d", "f", "g"}, added_nodes_count);
 }
 }  // namespace
 

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -367,13 +367,14 @@ void CPUQuantizeSquashPass::ApplyImpl(ir::Graph* graph) const {
   FusePassBase::Init("cpu_quantize_squash_pass", graph);
 
   std::unordered_map<const Node*, int> nodes_keep_counter;
+
+  DequantScaleSquash(graph);
   FindNodesToKeep(graph, &nodes_keep_counter);
   DequantQuantSquash(graph, &nodes_keep_counter);
   ConvRequantSquash(graph);
   ConvDequantSquash(graph);
   FcDequantSquash(graph);
   MultipleQuantizeSquash(graph);
-  DequantScaleSquash(graph);
   MatmulDequantSquash(graph);
 }
 


### PR DESCRIPTION
This PR:
- adds a pass that relocates scale operator before the Reshape-Transpose pattern. Needed for Ernie model. 
- adds tests of that pass
- changes the order of squashes, that DequantScale is the first squash. Thank to that, after squashing Scale op, Dequantize-Quantize pattern can be changed to Requantize op. 