### PR TITLE
fix example code of api data/switch_case to keep cn-doc and en-doc consistent

### DIFF
--- a/python/paddle/fluid/data.py
+++ b/python/paddle/fluid/data.py
@@ -40,7 +40,7 @@ def data(name, shape, dtype='float32', lod_level=0):
         `paddle.fluid.data` checks the shape and the dtype of data fed by
         Executor or ParallelExecutor during run time.
 
-        To feed variable size inputs, users can set -1 on the variable
+        To feed variable size inputs, users can set None or -1 on the variable
         dimension when using :code:`paddle.fluid.data`, or feed variable size
         inputs directly to :code:`paddle.fluid.layers.data` and PaddlePaddle
         will fit the size accordingly.
@@ -54,14 +54,14 @@ def data(name, shape, dtype='float32', lod_level=0):
        name (str): The name/alias of the variable, see :ref:`api_guide_Name`
            for more details.
        shape (list|tuple): List|Tuple of integers declaring the shape. You can
-           set "None" at a dimension to indicate the dimension can be of any
-           size. For example, it is useful to set changeable batch size as "None" 
+           set "None" or -1 at a dimension to indicate the dimension can be of any
+           size. For example, it is useful to set changeable batch size as "None" or -1.
        dtype (np.dtype|VarType|str, optional): The type of the data. Supported
            dtype: bool, float16, float32, float64, int8, int16, int32, int64,
-           uint8. Default: float32
+           uint8. Default: float32.
        lod_level (int, optional): The LoD level of the LoDTensor. Usually users
            don't have to set this value. For more details about when and how to
-           use LoD level, see :ref:`user_guide_lod_tensor` . Default: 0
+           use LoD level, see :ref:`user_guide_lod_tensor` . Default: 0.
 
     Returns:
         Variable: The global variable that gives access to the data.
@@ -76,10 +76,10 @@ def data(name, shape, dtype='float32', lod_level=0):
           # User can only feed data of the same shape to x
           x = fluid.data(name='x', shape=[3, 2, 1], dtype='float32')
 
-          # Creates a variable with changeable batch size.
+          # Creates a variable with changeable batch size -1.
           # Users can feed data of any batch size into y,
           # but size of each data sample has to be [2, 1]
-          y = fluid.data(name='y', shape=[None, 2, 1], dtype='float32')
+          y = fluid.data(name='y', shape=[-1, 2, 1], dtype='float32')
 
           z = x + y
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -2324,6 +2324,7 @@ class Switch(object):
 
     .. code-block:: python
 
+        '''
         with fluid.layers.Switch() as switch:
             with switch.case(cond1):
                 i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=1)
@@ -2331,6 +2332,7 @@ class Switch(object):
                 i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=2)
             with switch.default():
                 i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
+        '''
 
     Args:
         name(str, optional): The default value is None.  Normally there is no need for user to set this property.  For more information, please refer to :ref:`api_guide_Name` .

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -2323,8 +2323,7 @@ class Switch(object):
     Case and default functions can only be used inside the scope of Switch, as shown below:
 
     .. code-block:: python
-        
-        '''
+
         with fluid.layers.Switch() as switch:
             with switch.case(cond1):
                 i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=1)
@@ -2332,7 +2331,6 @@ class Switch(object):
                 i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=2)
             with switch.default():
                 i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
-        '''
 
     Args:
         name(str, optional): The default value is None.  Normally there is no need for user to set this property.  For more information, please refer to :ref:`api_guide_Name` .
@@ -3363,8 +3361,7 @@ def switch_case(branch_index, branch_fns, default=None, name=None):
                     branch_fns=[(0, fn_1), (4, fn_2), (7, fn_3)])
 
                 exe = fluid.Executor(fluid.CPUPlace())
-                res_1, res_2, res_3 = exe.run(main_program,
-                                              fetch_list=[out_1, out_2, out_3])
+                res_1, res_2, res_3 = exe.run(main_program, fetch_list=[out_1, out_2, out_3])
                 print(res_1)  # [[1. 1.]]
                 print(res_2)  # [[2 2] [2 2]]
                 print(res_3)  # [3 3 3]


### PR DESCRIPTION
## data
![image](https://user-images.githubusercontent.com/33742067/78974345-5e66a800-7b44-11ea-80c7-d4ff64c4e3f8.png)

## switch_case
![image](https://user-images.githubusercontent.com/33742067/78974496-b3a2b980-7b44-11ea-88b0-de1fd1d021e3.png)
