### PR TITLE
[error message enhancement] fused_elemwise_activation_op and  fusion_conv_inception_op

### DIFF
--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -79,8 +79,8 @@ static bool IsSupportedCompound(const std::vector<std::string> &functors) {
   } else if (binary_fun.count(functors[1])) {
     unary_fun_str = functors[0];
   } else {
-    PADDLE_THROW("%s and %s are not included in fused_list.", functors[0],
-                 functors[1]);
+    PADDLE_THROW(platform::errors::InvalidArgument(
+        "%s and %s are not included in fused_list.", functors[0], functors[1]));
   }
   PADDLE_ENFORCE_EQ(unary_fun.count(unary_fun_str), 1,
                     platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -104,7 +104,7 @@ class FusedElemwiseActivationOp : public framework::OperatorWithKernel {
     PADDLE_ENFORCE(
         ctx->HasOutput("Out"),
         platform::errors::InvalidArgument(
-            "Output(Out) of FusedElemwiseActivationOp op should not be null.");
+            "Output(Out) of FusedElemwiseActivationOp op should not be null."));
 
     auto x_dim = ctx->GetInputDim("X");
     auto y_dim = ctx->GetInputDim("Y");

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -195,9 +195,10 @@ class FusedElemwiseActivationMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<std::string>>("functor_list",
                                       "The functors that should be fused.")
         .AddCustomChecker([&](const std::vector<std::string> &functor_list) {
-          PADDLE_ENFORCE(IsSupportedCompound(functor_list),
-                         platform::errors::InvalidArgument(
-                             "the input functors should support compounding."));
+          PADDLE_ENFORCE_EQ(
+              IsSupportedCompound(functor_list), true,
+              platform::errors::InvalidArgument(
+                  "the input functors should support compounding."));
         });
 
     AddComment(R"DOC(

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -93,16 +93,16 @@ class FusedElemwiseActivationOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext *ctx) const override {
-    PADDLE_ENFORCE(
-        ctx->HasInput("X"),
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput("X"), true,
         platform::errors::InvalidArgument(
             "Input(X) of FusedElemwiseActivationOp op should not be null."));
-    PADDLE_ENFORCE(
-        ctx->HasInput("Y"),
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput("Y"), true,
         platform::errors::InvalidArgument(
             "Input(Y) of FusedElemwiseActivationOp op should not be null."));
-    PADDLE_ENFORCE(
-        ctx->HasOutput("Out"),
+    PADDLE_ENFORCE_EQ(
+        ctx->HasOutput("Out"), true,
         platform::errors::InvalidArgument(
             "Output(Out) of FusedElemwiseActivationOp op should not be null."));
 
@@ -117,10 +117,11 @@ class FusedElemwiseActivationOp : public framework::OperatorWithKernel {
     std::string out_lod = bcast_y ? "X" : "Y";
 
     if (ctx->Attrs().Get<bool>("save_intermediate_out")) {
-      PADDLE_ENFORCE(ctx->HasOutput("IntermediateOut"),
-                     platform::errors::InvalidArgument(
-                         "Output(IntermediateOut) of FusedElemwiseActivationOp "
-                         "should not be null."));
+      PADDLE_ENFORCE_EQ(
+          ctx->HasOutput("IntermediateOut"), true,
+          platform::errors::InvalidArgument(
+              "Output(IntermediateOut) of FusedElemwiseActivationOp "
+              "should not be null."));
 
       if (IsUnaryCompound(
               ctx->Attrs().Get<std::vector<std::string>>("functor_list"))) {
@@ -291,21 +292,22 @@ class FusedElemwiseActivationOpGrad : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext *ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput(framework::GradVarName("Out")),
-                   platform::errors::InvalidArgument(
-                       "Input(Out@Grad) should not be null."));
+    PADDLE_ENFORCE_EQ(ctx->HasInput(framework::GradVarName("Out")), true,
+                      platform::errors::InvalidArgument(
+                          "Input(Out@Grad) should not be null."));
 
     auto functor_list =
         ctx->Attrs().Get<std::vector<std::string>>("functor_list");
 
     if (ctx->Attrs().Get<bool>("save_intermediate_out")) {
-      PADDLE_ENFORCE(ctx->HasInput("IntermediateOut"),
-                     platform::errors::InvalidArgument(
-                         "Input(IntermediateOut) should not be null."));
+      PADDLE_ENFORCE_EQ(ctx->HasInput("IntermediateOut"), true,
+                        platform::errors::InvalidArgument(
+                            "Input(IntermediateOut) should not be null."));
     } else {
       if (!InputXCanBeAbsent(functor_list)) {
-        PADDLE_ENFORCE(ctx->HasInput("X"), platform::errors::InvalidArgument(
-                                               "Input(X) should not be null."));
+        PADDLE_ENFORCE_EQ(
+            ctx->HasInput("X"), true,
+            platform::errors::InvalidArgument("Input(X) should not be null."));
       }
     }
 
@@ -320,8 +322,8 @@ class FusedElemwiseActivationOpGrad : public framework::OperatorWithKernel {
       } else {
         // Currently, only when Binary is elementwise_add or elementwise_sub,
         // the "X" could be absent.
-        PADDLE_ENFORCE(
-            InputXCanBeAbsent(functor_list),
+        PADDLE_ENFORCE_EQ(
+            InputXCanBeAbsent(functor_list), true,
             platform::errors::InvalidArgument(
                 "Only when BinaryFunctor is elementwise_add, the 'X' "
                 "could be absent."));
@@ -336,8 +338,9 @@ class FusedElemwiseActivationOpGrad : public framework::OperatorWithKernel {
     }
 
     if (ctx->HasOutput(y_grad_name)) {
-      PADDLE_ENFORCE(ctx->HasInput("Y"), platform::errors::InvalidArgument(
-                                             "Input(Y) should not be null."));
+      PADDLE_ENFORCE_EQ(
+          ctx->HasInput("Y"), true,
+          platform::errors::InvalidArgument("Input(Y) should not be null."));
       ctx->SetOutputDim(y_grad_name, ctx->GetInputDim("Y"));
       ctx->ShareLoD("Y", y_grad_name);
     }

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -66,7 +66,7 @@ static bool IsSupportedCompound(const std::vector<std::string> &functors) {
       functors.size(), 2UL,
       platform::errors::InvalidArgument(
           "Invalid functor list size %d, which should be equal to %d.",
-          functor_list.size(), 2));
+          functors.size(), 2));
 
   static std::unordered_set<std::string> unary_fun = {"scale", "relu", "tanh",
                                                       "sigmoid"};

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -195,10 +195,9 @@ class FusedElemwiseActivationMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<std::string>>("functor_list",
                                       "The functors that should be fused.")
         .AddCustomChecker([&](const std::vector<std::string> &functor_list) {
-          PADDLE_ENFORCE(
-              IsSupportedCompound(functor_list)
-                  platform::errors::InvalidArgument(
-                      "the input functors should support compounding."));
+          PADDLE_ENFORCE(IsSupportedCompound(functor_list),
+                         platform::errors::InvalidArgument(
+                             "the input functors should support compounding."));
         });
 
     AddComment(R"DOC(

--- a/paddle/fluid/operators/fused/fusion_conv_inception_op.cc
+++ b/paddle/fluid/operators/fused/fusion_conv_inception_op.cc
@@ -32,10 +32,20 @@ class ConvInceptionFusionOp : public framework::OperatorWithKernel {
     // 4 filters
     auto w_dims = ctx->GetInputsDim("Filter");
 
-    PADDLE_ENFORCE(in_dims.size(), 4, "Conv intput should be 4-D tensor.");
-    PADDLE_ENFORCE_EQ(w_dims.size(), 4, "There should be 4 filters");
-    PADDLE_ENFORCE_EQ(w_dims[0][1], in_dims[1]);
-    PADDLE_ENFORCE_EQ(w_dims[1][1], in_dims[1]);
+    PADDLE_ENFORCE(in_dims.size(), 4, platform::errors::InvalidArgument(
+                                          "Conv intput should be 4-D tensor."));
+    PADDLE_ENFORCE_EQ(w_dims.size(), 4, platform::errors::InvalidArgument(
+                                            "There should be 4 filters."));
+    PADDLE_ENFORCE_EQ(w_dims[0][1], in_dims[1],
+                      platform::errors::InvalidArgument(
+                          "Invalid fileter channel number %d, which should be "
+                          "equal to input channel number %d.",
+                          w_dims[0][1], in_dims[1]));
+    PADDLE_ENFORCE_EQ(w_dims[1][1], in_dims[1],
+                      platform::errors::InvalidArgument(
+                          "Invalid fileter channel number %d, which should be "
+                          "equal to input channel number %d.",
+                          w_dims[1][1], in_dims[1]));
 
     int n = in_dims[0];
     // compute output channel

--- a/paddle/fluid/operators/fused/fusion_conv_inception_op.cc
+++ b/paddle/fluid/operators/fused/fusion_conv_inception_op.cc
@@ -32,8 +32,9 @@ class ConvInceptionFusionOp : public framework::OperatorWithKernel {
     // 4 filters
     auto w_dims = ctx->GetInputsDim("Filter");
 
-    PADDLE_ENFORCE(in_dims.size(), 4, platform::errors::InvalidArgument(
-                                          "Conv intput should be 4-D tensor."));
+    PADDLE_ENFORCE_EQ(
+        in_dims.size(), 4,
+        platform::errors::InvalidArgument("Conv intput should be 4-D tensor."));
     PADDLE_ENFORCE_EQ(w_dims.size(), 4, platform::errors::InvalidArgument(
                                             "There should be 4 filters."));
     PADDLE_ENFORCE_EQ(w_dims[0][1], in_dims[1],


### PR DESCRIPTION
【背景】 PaddlePaddle API 报错信息优化、对代码实现中 `PADDLE_ENFORCE_**` 检查规范报错信息
【本PR工作】修复 `fused_elemwise_activation_op` 和 `fusion_conv_inception_op` 两个 API C++ 实现中报错信息不规范的代码片段
