### PR TITLE
Skip paddle.fluid.core in API.spec compare

### DIFF
--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -124,6 +124,9 @@ def visit_all_module(mod):
     if mod_name != 'paddle' and not mod_name.startswith('paddle.'):
         return
 
+    if mod_name.startswith('paddle.fluid.core'):
+        return
+
     if mod in visited_modules:
         return
 


### PR DESCRIPTION
as title.

skip paddle.fluid.core in API.spec to skip comparing `paddle.fluid.core.***`
```
[09:16:19]	[Step 1/1] + python sampcd_processor.py cpu
[09:16:21]	[Step 1/1] API check -- Example Code
[09:16:21]	[Step 1/1] ('sample_test running under python', '2.7.15')
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] ----Exception in get api methods----
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] paddle.fluid.core_avx.ops.dist
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] paddle.fluid.core_avx.ops.dist method is None!!!
[09:16:21]	[Step 1/1] 
[09:16:21]	[Step 1/1] API_PR is diff from API_DEV: ['../python/paddle/tensor/linalg.py', '../python/paddle/fluid/core_avx/ops.py']
```