### PR TITLE
Avoid crash when calling ctx->HasInputs and add the check of shape in fill_copnstant op.

### DIFF
--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -721,6 +721,9 @@ CompileTimeInferShapeContext::CompileTimeInferShapeContext(
     : op_(op), block_(block) {}
 
 bool CompileTimeInferShapeContext::HasInput(const std::string &name) const {
+  if (op_.Inputs().find(name) == op_.Inputs().end()) {
+    return false;
+  }
   const std::vector<std::string> &input_names = op_.Input(name);
   auto length = input_names.size();
   if (length == 0) {
@@ -734,6 +737,9 @@ bool CompileTimeInferShapeContext::HasInput(const std::string &name) const {
 }
 
 bool CompileTimeInferShapeContext::HasOutput(const std::string &name) const {
+  if (op_.Outputs().find(name) == op_.Outputs().end()) {
+    return false;
+  }
   const std::vector<std::string> &output_names = op_.Output(name);
   auto length = output_names.size();
   if (length == 0) {
@@ -747,6 +753,9 @@ bool CompileTimeInferShapeContext::HasOutput(const std::string &name) const {
 }
 
 bool CompileTimeInferShapeContext::HasInputs(const std::string &name) const {
+  if (op_.Inputs().find(name) == op_.Inputs().end()) {
+    return false;
+  }
   const std::vector<std::string> &input_names = op_.Input(name);
   if (input_names.empty()) {
     return false;
@@ -758,6 +767,9 @@ bool CompileTimeInferShapeContext::HasInputs(const std::string &name) const {
 }
 
 bool CompileTimeInferShapeContext::HasOutputs(const std::string &name) const {
+  if (op_.Outputs().find(name) == op_.Outputs().end()) {
+    return false;
+  }
   const std::vector<std::string> &output_names = op_.Output(name);
   if (output_names.empty()) {
     return false;

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -26,6 +26,16 @@ class FillConstantOp : public framework::OperatorWithKernel {
                       "Output(Out) of FillConstantOp should not be null.");
 
     auto& shape = ctx->Attrs().Get<std::vector<int64_t>>("shape");
+    if (!ctx->HasInput("ShapeTensor") && !ctx->HasInputs("ShapeTensorList")) {
+      for (size_t i = 0; i < shape.size(); ++i) {
+        PADDLE_ENFORCE_GT(
+            shape[i], 0,
+            platform::errors::InvalidArgument(
+                "Each value of attribute 'shape' is expected to be greater "
+                "than 0. But recieved: shape[%u] = %d; shape = [%s].",
+                i, shape[i], framework::make_ddim(shape)));
+      }
+    }
 
     if (shape.empty() && ctx->HasInput("ShapeTensor")) {
       auto shape_dims = ctx->GetInputDim("ShapeTensor");

--- a/paddle/fluid/operators/fill_constant_op.cc
+++ b/paddle/fluid/operators/fill_constant_op.cc
@@ -28,7 +28,7 @@ class FillConstantOp : public framework::OperatorWithKernel {
     auto& shape = ctx->Attrs().Get<std::vector<int64_t>>("shape");
     if (!ctx->HasInput("ShapeTensor") && !ctx->HasInputs("ShapeTensorList")) {
       for (size_t i = 0; i < shape.size(); ++i) {
-        PADDLE_ENFORCE_GT(
+        PADDLE_ENFORCE_GE(
             shape[i], 0,
             platform::errors::InvalidArgument(
                 "Each value of attribute 'shape' is expected to be greater "

--- a/python/paddle/fluid/tests/unittests/test_rnn_decode_api.py
+++ b/python/paddle/fluid/tests/unittests/test_rnn_decode_api.py
@@ -369,11 +369,11 @@ class SeqPGAgent(object):
             self.probs, self.samples, self.sample_length = self.model(
                 source, source_length, target, target_length)
             self.samples.stop_gradient = True
-            self.reward = fluid.layers.create_global_var(
+            self.reward = fluid.data(
                 name="reward",
-                shape=[-1, -1],  # batch_size, seq_len
-                value="1",
+                shape=[None, None],  # batch_size, seq_len
                 dtype=self.probs.dtype)
+            self.samples.stop_gradient = False
             self.cost = self.alg.learn(self.probs, self.samples, self.reward,
                                        self.sample_length)
 


### PR DESCRIPTION
1. `ctx->HasInput`等函数检查输入、输出是否存在时，可能会因为输入、输出不存在而直接挂掉，原因是`ctx->HasInput`在判断之前，会直接访问`op_.Input(name)`，该函数在name指定的输入、输出不存在时，会直接挂掉。这个PR对此进行了修复，增加了输入、输出是否存在的判断。

https://github.com/PaddlePaddle/Paddle/blob/6f7077db256e5f3291091d8dfc5b96075dd81152/paddle/fluid/framework/op_desc.cc#L723-L724

2. 当fill_constant的输出形状由属性shape指定时，shape中的值应该是非负的整数。这个PR对此增加了检查。

3. `test_rnn_decode_api.py`单测中，将指定shape=[-1, -1]，导致运行时Tensor的dims被设置成[-1, -1]，这是个bug，这个PR对这个单测进行了修正。