### PR TITLE
Simplify Op input and output check in InferShape

### DIFF
--- a/paddle/fluid/framework/shape_inference.h
+++ b/paddle/fluid/framework/shape_inference.h
@@ -79,6 +79,8 @@ class InferShapeContext {
   virtual std::vector<InferShapeVarPtr> GetOutputVarPtrs(
       const std::string &name) = 0;
 
+  void CheckInputsAndOutputs(const std::string &type) const;
+
  protected:
   virtual std::vector<DDim> GetRepeatedDims(const std::string &name) const = 0;
   virtual void SetRepeatedDims(const std::string &name,

--- a/paddle/fluid/operators/mul_op.cc
+++ b/paddle/fluid/operators/mul_op.cc
@@ -32,9 +32,7 @@ class MulOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "Mul");
-    OP_INOUT_CHECK(ctx->HasInput("Y"), "Input", "Y", "Mul");
-    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "Mul");
+    ctx->CheckInputsAndOutputs("mul");
 
     auto x_dims = ctx->GetInputDim("X");
     auto y_dims = ctx->GetInputDim("Y");


### PR DESCRIPTION
Simplify Op input and output check in op's inferShape.

original:
```
OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "Mul");
OP_INOUT_CHECK(ctx->HasInput("Y"), "Input", "Y", "Mul");	
OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "Mul");
```

new:
```
ctx->CheckInputsAndOutputs("mul");
```