### PR TITLE
fix the CI random failure

### DIFF
--- a/paddle/fluid/operators/dist_op.h
+++ b/paddle/fluid/operators/dist_op.h
@@ -19,6 +19,7 @@
 #include <vector>
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/math/math_function.h"
 
 namespace paddle {
 namespace operators {
@@ -169,7 +170,9 @@ static void DistGradFunction(const framework::ExecutionContext& context) {
 
   // 1: Lp-norm(z), z = x-y, compute dz
   if (p == 0) {
-    grad_t.device(place) = grad_t * static_cast<T>(0);
+    math::SetConstant<DeviceContext, T> set_zero;
+    auto& dev_ctx = context.template device_context<DeviceContext>();
+    set_zero(dev_ctx, &grad, static_cast<T>(0));
   } else if (p == INFINITY || p == -INFINITY) {
     // p=inf or -inf, Lp-norm = |z_i|, the j-th element of dz tends to 0 if
     // j!=i, or equals to sign(z_i) * dout if j=i.


### PR DESCRIPTION
As the title. 
```
[2020-04-11 8:22:58]  cat test_dist_op_run.log
[2020-04-11 8:22:58]       1	W0411 00:22:48.892432  2776 device_context.cc:237] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 10.1, Runtime API Version: 10.1
[2020-04-11 8:22:58]     2	W0411 00:22:48.896929  2776 device_context.cc:245] device: 0, cuDNN Version: 7.6.
[2020-04-11 8:22:58]       3	./paddle/build/python/paddle/fluid/tests/unittests/op_test.py:1223: RuntimeWarning: invalid value encountered in greater
[2020-04-11 8:22:58]       4	  offset = np.argmax(diff_mat > max_relative_error)
[2020-04-11 8:22:58]      5	F...........
[2020-04-11 8:22:58]       6	======================================================================
[2020-04-11 8:22:58]       7	FAIL: test_check_grad (__main__.TestDistOp)
[2020-04-11 8:22:58]       8	----------------------------------------------------------------------
[2020-04-11 8:22:58]       9	Traceback (most recent call last):
[2020-04-11 8:22:58]      10	  File "test_dist_op.py", line 105, in test_check_grad
[2020-04-11 8:22:58]      11	    self.check_grad(["X", "Y"], "Out", user_defined_grads=self.gradient)
[2020-04-11 8:22:58]      12	  File "/paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 1253, in check_grad
[2020-04-11 8:22:58]      13	    user_defined_grads, check_dygraph)
[2020-04-11 8:22:58]      14	  File "/paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 1322, in check_grad_with_place
[2020-04-11 8:22:58]      15	    "Gradient Check On %s" % str(place))
[2020-04-11 8:22:58]      16	  File "/paddle/build/python/paddle/fluid/tests/unittests/op_test.py", line 1229, in _assert_is_close
[2020-04-11 8:22:58]      17	    self.assertLessEqual(max_diff, max_relative_error, err_msg())
[2020-04-11 8:22:58]      18	AssertionError: dist error, Gradient Check On CPUPlace variable X max gradient diff nan over limit 0.000000, the first error element is 0, expected 0.000000, but got 0.000000.
```