### PR TITLE
Fix CUDAHandleHolder destruction problem

### DIFF
--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -110,8 +110,6 @@ class NCCLCommContext {
   // ring id to dev-NCCLComm
   std::map<int, std::map<int, std::unique_ptr<NCCLComm>>> comm_map_;
 
-  std::vector<ncclComm_t> comm_vec_;
-
   void ReleaseNCCLComms();
 
   NCCLCommContext() = default;


### PR DESCRIPTION
CUDADeviceContext has several CUDA resources such as CublasHandleHolder, ncclComm_t, cudaStream_t, cudnnHandle_t, etc. We have to eagerly release them all before CUDA enviroment destroying. So we explicitly reset NCCLCommImpl, which contains CUDADeviceContext, in std::atexit.