### PR TITLE
fix no_grad argspec

### DIFF
--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ..wrapped_decorator import signature_safe_contextmanager, wrap_decorator
+import decorator
 import contextlib
 import functools
 import sys
@@ -196,12 +197,12 @@ def no_grad(func=None):
         return _switch_tracer_mode_guard_(is_train=False)
     else:
 
-        @functools.wraps(func)
-        def __impl__(*args, **kwargs):
+        @decorator.decorator
+        def __impl__(func, *args, **kwargs):
             with _switch_tracer_mode_guard_(is_train=False):
                 return func(*args, **kwargs)
 
-        return __impl__
+        return __impl__(func)
 
 
 @signature_safe_contextmanager

--- a/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
@@ -15,6 +15,7 @@
 import paddle.fluid as fluid
 import paddle.fluid.framework as framework
 import unittest
+import inspect
 
 from test_imperative_base import new_program_scope
 
@@ -50,6 +51,14 @@ class TestTracerMode(unittest.TestCase):
 
             self.assertEqual(self.no_grad_func(1), 1)
             self.assertEqual(self.no_grad_func.__name__, "no_grad_func")
+
+            def need_no_grad_func(a, b=1):
+                return a + b
+
+            decorated_func = fluid.dygraph.no_grad(need_no_grad_func)
+            self.assertTrue(
+                str(inspect.getargspec(decorated_func)) ==
+                str(inspect.getargspec(need_no_grad_func)))
 
             self.assertEqual(self.tracer._train_mode, self.init_mode)
 


### PR DESCRIPTION
修正`no_grad`作为装饰器时`argspec`的丢失。`functools.wraps`只保留了`__name__`和`__doc__`，签名保留的不全，所以改用`decorator`包了