### PR TITLE
Remove conv_bn_fuse_pass and fc_fuse_pass in trt int8 calibration

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -279,7 +279,14 @@ void AnalysisConfig::Update() {
 
   if (use_tensorrt_) {
     pass_builder()->ClearPasses();
+    bool use_calib_int8 =
+        (tensorrt_precision_mode_ == AnalysisConfig::Precision::kInt8) &&
+        trt_use_calib_mode_;
     for (const auto &pass : kTRTSubgraphPasses) {
+      if (use_calib_int8 &&
+          (pass == "conv_bn_fuse_pass" || pass == "fc_fuse_pass")) {
+        continue;
+      }
       pass_builder()->AppendPass(pass);
     }
   }

--- a/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
@@ -29,7 +29,7 @@ TEST(TensorRT, split_converter) {
   config.SetModel(model_dir);
   config.SwitchUseFeedFetchOps(false);
   config.EnableTensorRtEngine(1 << 20, batch_size, 1,
-                              AnalysisConfig::Precision::kFloat32, false);
+                              AnalysisConfig::Precision::kInt8, false, true);
 
   auto predictor = CreatePaddlePredictor(config);
 


### PR DESCRIPTION
Remove conv_bn_fuse_pass and fc_fuse_pass in trt int8 calibration mode to avoid possible inconsistence between local and server calibration tables caused by the unstableness in these 2 passes.