### PR TITLE
improve efficiency of dot op in dygraph mode

### DIFF
--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -440,6 +440,10 @@ def dot(x, y, name=None):
 
     """
     op_type = 'dot'
+    if in_dygraph_mode():
+        op = getattr(core.ops, op_type)
+        return op(x, y)
+
     assert x is not None, 'x cannot be None in {}'.format(op_type)
     assert y is not None, 'y cannot be None in {}'.format(op_type)
 

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -440,6 +440,7 @@ def dot(x, y, name=None):
 
     """
     op_type = 'dot'
+    # skip var type check in dygraph mode to improve efficiency
     if in_dygraph_mode():
         op = getattr(core.ops, op_type)
         return op(x, y)


### PR DESCRIPTION
Type check consumes too much time in dygraph mode: about 8~10 times to other framework.
Change the code to call API directly in dygraph mode.