### PR TITLE
Remove redundant visit_FunctionDef

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -142,15 +142,6 @@ class BasicApiTransformer(gast.NodeTransformer):
         self.visit(self.root)
         return self.wrapper_root
 
-    def visit_FunctionDef(self, node):
-        self.generic_visit(node)
-        if hasattr(node, 'decorator_list'):
-            decorator_list = [
-                d for d in node.decorator_list if d.id not in DECORATOR_NAMES
-            ]
-            node.decorator_list = decorator_list
-        return node
-
     def visit_Assign(self, node):
         if self._update_class_node_dict(node):
             return None


### PR DESCRIPTION
The `visit_FunctionDef` to remove dygraph_to_static decorator has been implemented in `DygraphToStaticAst`, I think the same code in `BasicApiTransformer` is redundant.