### PR TITLE
fix example bug for tensor eye,t,min 

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -404,7 +404,8 @@ def eye(num_rows,
         name=None):
     """
     **eye**
-    This function constructs an identity tensor, or a batch of tensor.
+    This function constructs an identity tensor.
+
     Args:
         num_rows(int): the number of rows in each batch tensor.
         num_columns(int, optional): the number of columns in each batch tensor.
@@ -417,8 +418,10 @@ def eye(num_rows,
         stop_gradient(bool, optional): Whether stop calculating gradients. Default:True.
         name(str, optional): The default value is None.  Normally there is no need for 
             user to set this property.  For more information, please refer to :ref:`api_guide_Name`
+
     Returns:
         Variable: An identity Tensor or LoDTensor of shape [num_rows, num_columns].
+
     Examples:
         .. code-block:: python
           import paddle

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -467,11 +467,11 @@ def t(input, name=None):
     the fluid.layers.transpose function which perm dimensions set 0 and 1.
     
     Args:
-        input (Variable): The input Tensor. It is a N-D (N<=2) Tensor of data types float32, float64, int32.
+        input (Variable): The input Tensor. It is a N-D (N<=2) Tensor of data types float16, float32, float64, int32.
         name(str, optional): The default value is None.  Normally there is no need for 
             user to set this property.  For more information, please refer to :ref:`api_guide_Name`
     Returns:
-        Variable: A transposed n-D Tensor, with data type being float32, float64, int32, int64.
+        Variable: A transposed n-D Tensor, with data type being float16, float32, float64, int32, int64.
     
     For Example:
         .. code-block:: text

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1094,7 +1094,7 @@ def max(input, dim=None, keep_dim=False, out=None, name=None):
         .. code-block:: python
             import paddle
             import paddle.fluid as fluid
-            
+
             # x is a Tensor variable with following elements:
             #    [[0.2, 0.3, 0.5, 0.9]
             #     [0.1, 0.2, 0.6, 0.7]]
@@ -1144,6 +1144,7 @@ def max(input, dim=None, keep_dim=False, out=None, name=None):
 def min(input, dim=None, keep_dim=False, out=None, name=None):
     """
     Computes the minimum of tensor elements over the given dimension.
+
     Args:
         input (Variable): The input variable which is a Tensor, the data type is float32,
             float64, int32, int64.
@@ -1161,9 +1162,11 @@ def min(input, dim=None, keep_dim=False, out=None, name=None):
             if out is None, a new Varibale will be create to store the result.
         name(str, optional): The default value is None.  Normally there is no need for 
             user to set this property.  For more information, please refer to :ref:`api_guide_Name`
+
     Returns:
         Variable: Tensor, result of minimum on the specified dim of input tensor,
         it's data type is the same as input's Tensor.
+
     Examples:
         .. code-block:: python
             import paddle
@@ -1228,6 +1231,7 @@ def log1p(x, out=None, name=None):
             user to set this property.  For more information, please refer to :ref:`api_guide_Name`
     Returns:
         Variable: The natural log of the input LoDTensor or Tensor computed element-wise.
+
     Examples:
         .. code-block:: python
             import paddle


### PR DESCRIPTION
1. add blank line for min tensor api
2. correct explanation for eye tensor api
3. fix type example for t tensor api