### PR TITLE
Fix the elementwise_add axis bug, add the warning log

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -14,6 +14,9 @@
 
 from __future__ import print_function
 
+import logging
+import inspect
+
 from .. import core
 from ..framework import Variable, unique_name
 from .layer_function_generator import OpProtoHolder
@@ -27,6 +30,29 @@ _supported_int_dtype_ = [
 ]
 
 compare_ops = ['__eq__', '__ne__', '__lt__', '__le__', '__gt__', '__ge__']
+
+EXPRESSION_MAP = {
+    "__add__": "A + B",
+    "__radd__": "A += B",
+    "__sub__": "A - B",
+    "__rsub__": "A -= B",
+    "__mul__": "A * B",
+    "__rmul__": "A *= B",
+    "__div__": "A / B",
+    "__truediv__": "A / B",
+    "__rdiv__": "A /= B",
+    "__rtruediv__": "A /= B",
+    "__pow__": "A ** B",
+    "__rpow__": "A **= B",
+    "__floordiv__": "A //B",
+    "__mod__": "A % B",
+    "__eq__": "A == B",
+    "__ne__": "A != B",
+    "__lt__": "A < B",
+    "__le__": "A <= B",
+    "__gt__": "A > B",
+    "__ge__": "A >= B"
+}
 
 
 def monkey_patch_variable():
@@ -233,7 +259,15 @@ def monkey_patch_variable():
 
             axis = -1
             if other_var.shape[0] == -1:
-                axis = 0
+                stack = inspect.stack()[1]
+                file_name = stack[1]
+                line_num = stack[2]
+                logging.warning(
+                    "%s:%s\nThe behavior of expression %s has been unified with %s(X, Y, axis=-1) from Paddle 2.0. "
+                    "If your code works well in the older versions but crashes in this version, try to use "
+                    "%s(X, Y, axis=0) instead of %s. This transitional warning will be dropped in the future."
+                    % (file_name, line_num, EXPRESSION_MAP[method_name],
+                       op_type, op_type, EXPRESSION_MAP[method_name]))
             current_block(self).append_op(
                 type=op_type,
                 inputs={'X': [self],


### PR DESCRIPTION
import paddle.fluid as fluid
import numpy as np
x = fluid.data(name="x", shape=[20, 10, 10], dtype='float32')
y = fluid.data(name="y", shape=[-1, 10], dtype='float32')
c = fluid.layers.elementwise_add( x, y )
d = x + y
place = fluid.CPUPlace()
exe = fluid.Executor(place)
x_np = np.random.uniform( -1, 1, [20, 10, 10]).astype("float32")
y_np = np.random.uniform( -1, 1, [1, 10]).astype("float32")
out = exe.run(feed={ "x" : x_np , "y" : y_np }, fetch_list=[ c, d] )
print( np.array_equal( out[0], out[1])) ## result is False

![image](https://user-images.githubusercontent.com/16698950/79422871-379aec80-7ff0-11ea-8038-68aa3edfa652.png)
