### PR TITLE
Inference Feature: Thread local allocator

### DIFF
--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -14,13 +14,15 @@ endif()
 
 if (WITH_GPU)
   nv_library(cuda_allocator SRCS cuda_allocator.cc DEPS allocator cuda_device_guard)
+  nv_library(thread_local_allocator SRCS thread_local_allocator.cc DEPS allocator)
+  cc_test(thread_local_allocator_test SRCS thread_local_allocator_test.cc DEPS thread_local_allocator)
 endif()
 
 cc_library(retry_allocator SRCS retry_allocator.cc DEPS allocator)
 
 nv_library(pinned_allocator SRCS pinned_allocator.cc DEPS allocator)
 if (WITH_GPU)
-    set(AllocatorFacadeDeps gpu_info cuda_allocator pinned_allocator cuda_device_guard)
+    set(AllocatorFacadeDeps gpu_info cuda_allocator pinned_allocator cuda_device_guard thread_local_allocator)
 else ()
     set(AllocatorFacadeDeps)
 endif()
@@ -66,8 +68,6 @@ cc_test(allocator_facade_frac_flags_test SRCS allocator_facade_frac_flags_test.c
 cc_library(auto_growth_best_fit_allocator SRCS auto_growth_best_fit_allocator.cc DEPS allocator aligned_allocator)
 cc_test(auto_growth_best_fit_allocator_facade_test SRCS auto_growth_best_fit_allocator_facade_test.cc DEPS cpu_allocator auto_growth_best_fit_allocator)
 cc_test(auto_growth_best_fit_allocator_test SRCS auto_growth_best_fit_allocator_test.cc DEPS auto_growth_best_fit_allocator)
-
-cc_library(thread_local_allocator SRCS thread_local_allocator.cc DEPS allocator)
 
 if(NOT WIN32)
   cc_library(mmap_allocator SRCS mmap_allocator.cc DEPS allocator)

--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -67,6 +67,8 @@ cc_library(auto_growth_best_fit_allocator SRCS auto_growth_best_fit_allocator.cc
 cc_test(auto_growth_best_fit_allocator_facade_test SRCS auto_growth_best_fit_allocator_facade_test.cc DEPS cpu_allocator auto_growth_best_fit_allocator)
 cc_test(auto_growth_best_fit_allocator_test SRCS auto_growth_best_fit_allocator_test.cc DEPS auto_growth_best_fit_allocator)
 
+cc_library(thread_local_allocator SRCS thread_local_allocator.cc DEPS allocator)
+
 if(NOT WIN32)
   cc_library(mmap_allocator SRCS mmap_allocator.cc DEPS allocator)
   cc_test(mmap_allocator_test SRCS mmap_allocator_test.cc DEPS mmap_allocator allocator)

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -32,6 +32,7 @@
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/memory/allocation/cuda_allocator.h"
 #include "paddle/fluid/memory/allocation/pinned_allocator.h"
+#include "paddle/fluid/memory/allocation/thread_local_allocator.h"
 #include "paddle/fluid/platform/cuda_device_guard.h"
 #include "paddle/fluid/platform/gpu_info.h"
 #endif
@@ -133,7 +134,11 @@ class AllocatorFacadePrivate {
   }
 
   void InitNaiveBestFitCUDAAllocator(platform::CUDAPlace p) {
+#ifndef PADDLE_ON_INFERENCE
     allocators_[p] = std::make_shared<NaiveBestFitAllocator>(p);
+#else
+    allocators_[p] = std::make_shared<CUDAThreadLocalAllocator>(p);
+#endif
   }
 
   void InitAutoGrowthCUDAAllocator(platform::CUDAPlace p) {

--- a/paddle/fluid/memory/allocation/thread_local_allocator.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/allocation/thread_local_allocator.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class ThreadLocalAllocation : public Allocation {
+ public:
+  ThreadLocalAllocation(void* ptr, size_t size, platform::Place place)
+      : Allocation(ptr, size, place) {}
+
+  void SetThreadLocalAllocator(std::shared_ptr<Allocator> allocator) {
+    allocator_ = allocator;
+  }
+
+ private:
+  std::shared_ptr<Allocator> allocator_;
+};
+
+Allocation* ThreadLocalAllocator::AllocateImpl(size_t size) {
+  void* ptr = buddy_allocator_->Alloc(size);
+  auto* tl_allocation = new ThreadLocalAllocation(ptr, size, place_);
+  tl_allocation->SetThreadLocalAllocator(shared_from_this());
+  return tl_allocation;
+}
+
+void ThreadLocalAllocator::FreeImpl(Allocation* allocation) {
+  auto* tl_allocation = static_cast<ThreadLocalAllocation*>(allocation);
+  buddy_allocator_->Free(tl_allocation->ptr());
+  delete tl_allocation;
+}
+
+const std::shared_ptr<Allocator>& GetThreadLocalAllocator() {
+  static thread_local std::shared_ptr<Allocator> allocator(
+      new ThreadLocalAllocator(platform::CUDAPlace()));
+  return allocator;
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/thread_local_allocator.h
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 #include "paddle/fluid/memory/allocation/allocator.h"
 #include "paddle/fluid/memory/detail/buddy_allocator.h"
 #include "paddle/fluid/memory/detail/system_allocator.h"
@@ -24,32 +25,75 @@ namespace paddle {
 namespace memory {
 namespace allocation {
 
-class ThreadLocalAllocator
-    : public Allocator,
-      public std::enable_shared_from_this<ThreadLocalAllocator> {
+class ThreadLocalAllocatorImpl;
+
+class ThreadLocalAllocation : public Allocation {
  public:
-  explicit ThreadLocalAllocator(const platform::Place& p) : place_(p) {
-    if (platform::is_gpu_place(place_)) {
-      buddy_allocator_.reset(new memory::detail::BuddyAllocator(
-          std::unique_ptr<memory::detail::SystemAllocator>(
-              new memory::detail::GPUAllocator(
-                  boost::get<platform::CUDAPlace>(place_).device)),
-          platform::GpuMinChunkSize(), platform::GpuMaxChunkSize()));
-    } else {
-      LOG(FATAL) << "Thread local allocator only supports CUDAPlace now.";
-    }
+  ThreadLocalAllocation(void* ptr, size_t size, platform::Place place)
+      : Allocation(ptr, size, place) {}
+
+  void SetThreadLocalAllocatorImpl(
+      std::shared_ptr<ThreadLocalAllocatorImpl> allocator) {
+    allocator_ = allocator;
   }
 
- protected:
-  Allocation* AllocateImpl(size_t size) override;
-  void FreeImpl(Allocation* allocation) override;
+  std::shared_ptr<ThreadLocalAllocatorImpl> GetAllocator() {
+    return allocator_;
+  }
+
+ private:
+  std::shared_ptr<ThreadLocalAllocatorImpl> allocator_;
+};
+
+class ThreadLocalAllocatorImpl
+    : public std::enable_shared_from_this<ThreadLocalAllocatorImpl> {
+ public:
+  explicit ThreadLocalAllocatorImpl(const platform::Place& p);
+  ThreadLocalAllocation* AllocateImpl(size_t size);
+  void FreeImpl(ThreadLocalAllocation* allocation);
 
  private:
   std::unique_ptr<memory::detail::BuddyAllocator> buddy_allocator_;
   platform::Place place_;
 };
 
-const std::shared_ptr<Allocator>& GetThreadLocalAllocator();
+class CUDAThreadLocalAllocatorPool {
+ public:
+  static CUDAThreadLocalAllocatorPool& Instance() {
+    static thread_local CUDAThreadLocalAllocatorPool pool;
+    return pool;
+  }
+
+  std::shared_ptr<ThreadLocalAllocatorImpl> Get(int gpu_id);
+
+ private:
+  CUDAThreadLocalAllocatorPool();
+  std::vector<int> devices_;
+  std::vector<std::unique_ptr<std::once_flag>> init_flags_;
+  std::vector<std::shared_ptr<ThreadLocalAllocatorImpl>> allocators_;
+};
+
+class CUDAThreadLocalAllocator : public Allocator {
+ public:
+  explicit CUDAThreadLocalAllocator(const platform::CUDAPlace& p)
+      : gpu_id_(p.device) {}
+
+  bool IsAllocThreadSafe() const override { return true; }
+
+ protected:
+  Allocation* AllocateImpl(size_t size) override {
+    return CUDAThreadLocalAllocatorPool::Instance().Get(gpu_id_)->AllocateImpl(
+        size);
+  }
+  void FreeImpl(Allocation* allocation) override {
+    auto* tl_allocation = static_cast<ThreadLocalAllocation*>(allocation);
+    auto allocator_impl = tl_allocation->GetAllocator();
+    allocator_impl->FreeImpl(tl_allocation);
+  }
+
+ private:
+  int gpu_id_;
+};
 
 }  // namespace allocation
 }  // namespace memory

--- a/paddle/fluid/memory/allocation/thread_local_allocator.h
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/fluid/memory/allocation/allocator.h"
+#include "paddle/fluid/memory/detail/buddy_allocator.h"
+#include "paddle/fluid/memory/detail/system_allocator.h"
+#include "paddle/fluid/platform/gpu_info.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class ThreadLocalAllocator
+    : public Allocator,
+      public std::enable_shared_from_this<ThreadLocalAllocator> {
+ public:
+  explicit ThreadLocalAllocator(const platform::Place& p) : place_(p) {
+    if (platform::is_gpu_place(place_)) {
+      buddy_allocator_.reset(new memory::detail::BuddyAllocator(
+          std::unique_ptr<memory::detail::SystemAllocator>(
+              new memory::detail::GPUAllocator(
+                  boost::get<platform::CUDAPlace>(place_).device)),
+          platform::GpuMinChunkSize(), platform::GpuMaxChunkSize()));
+    } else {
+      LOG(FATAL) << "Thread local allocator only supports CUDAPlace now.";
+    }
+  }
+
+ protected:
+  Allocation* AllocateImpl(size_t size) override;
+  void FreeImpl(Allocation* allocation) override;
+
+ private:
+  std::unique_ptr<memory::detail::BuddyAllocator> buddy_allocator_;
+  platform::Place place_;
+};
+
+const std::shared_ptr<Allocator>& GetThreadLocalAllocator();
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/thread_local_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator_test.cc
@@ -1,0 +1,92 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/allocation/thread_local_allocator.h"
+#include <algorithm>
+#include <condition_variable>  // NOLINT
+#include <functional>
+#include <iostream>
+#include <thread>  // NOLINT
+#include <utility>
+#include "gtest/gtest.h"
+#include "paddle/fluid/platform/gpu_info.h"
+
+DECLARE_double(fraction_of_gpu_memory_to_use);
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+TEST(ThreadLocalAllocator, cross_scope_release) {
+  FLAGS_fraction_of_gpu_memory_to_use = 0.1;
+
+  const size_t thread_num = 5;
+  const std::vector<int> devices = platform::GetSelectedDevices();
+
+  std::vector<std::vector<void *>> allocator_addresses(devices.size());
+  std::vector<std::vector<AllocationPtr>> thread_allocations(devices.size());
+  static std::vector<std::shared_ptr<Allocator>> allocators(devices.size());
+
+  for (size_t i = 0; i < devices.size(); ++i) {
+    allocator_addresses[i].resize(thread_num);
+    thread_allocations[i].resize(thread_num);
+    allocators[i] = std::make_shared<CUDAThreadLocalAllocator>(
+        platform::CUDAPlace(devices[i]));
+  }
+
+  std::vector<std::thread> threads(thread_num);
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool flag = false;
+
+  for (size_t i = 0; i < threads.size(); ++i) {
+    threads[i] = std::thread([&, i]() {
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [&] { return flag; });
+      }
+      for (size_t j = 0; j < devices.size(); ++j) {
+        auto tl_allocator_impl =
+            CUDAThreadLocalAllocatorPool::Instance().Get(devices[j]);
+        allocator_addresses[j][i] = tl_allocator_impl.get();
+        thread_allocations[j][i] = std::move(allocators[j]->Allocate(10));
+      }
+    });
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    flag = true;
+    cv.notify_all();
+  }
+
+  for (auto &th : threads) {
+    th.join();
+  }
+
+  for (auto &addresses : allocator_addresses) {
+    std::sort(addresses.begin(), addresses.end());
+    ASSERT_EQ(std::adjacent_find(addresses.begin(), addresses.end(),
+                                 std::equal_to<void *>()),
+              addresses.end());
+  }
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_EXIT(([&]() { thread_allocations.clear(); }(), exit(0)),
+              ::testing::ExitedWithCode(0), ".*");
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle


### PR DESCRIPTION
本提交是预测多流的一部分。
1、因为目前显存池隐式要求单流顺序计算，所以在编译指定 ON_INFER 时，每个线程独占一个 CUDAThreadLocalAllocatorPool，以便于计算流绑定线程。
2、为支持跨线程 / 跨作用域内存块析构，在 Allocation 中保存相关的 Allocator 智能指针。

注意：在此修改后线程将独占显存池，所以在预测时 `fraction_of_gpu_memory_to_use` 的意义将由每个**进程**拥有的显存池空间变为每个**线程**的显存池空间。

--------------------
还考虑过下面两种修改方式：
1、重构 CUDADeviceContextAllocator 解决问题，但显存池绑定上下文会延迟归还，一定概率造成显存占用增大。
2、只将 NaiveBestFitAllocator 设为线程本地变量，但因为 BuddyAllocator 未用智能指针，仍有内存不能释放或释放时段错误的可能。