### PR TITLE
QAT: support for new models

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
@@ -151,6 +151,7 @@ class Qat2Int8MkldnnPass(object):
         for op in graph.all_op_nodes():
             if op.op().has_attr("out_threshold"):
                 attr_scale = op.op().attr("out_threshold")
+                if attr_scale == 0.0: continue
                 scale = np.array(1.0 / attr_scale).astype(np.float64)
                 scale_lod_tensor = self._convert_scale2tensor(scale)
                 use_unsigned_int = False

--- a/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
@@ -83,6 +83,7 @@ class Qat2Int8MkldnnPass(object):
         graph = self._propagate_scales(graph)
         graph = self._set_dummy_out_scales(graph)
         graph = self._quantize_fp32_graph(graph)
+        graph = self._optimize_int8_graph(graph)
         graph = self._cleanup(graph)
         return graph
 
@@ -390,11 +391,14 @@ class Qat2Int8MkldnnPass(object):
         self._remove_unused_var_nodes(graph)
         return graph
 
-    def _cleanup(self, graph):
+    def _optimize_int8_graph(self, graph):
         # remove dropout ops
         graph = self._apply_pass(graph, 'simplify_with_basic_ops_pass')
         # make some MKL-DNN ops working inplace
         graph = self._apply_pass(graph, 'mkldnn_inplace_pass')
+        return graph
+
+    def _cleanup(self, graph):
         graph = self._remove_unused_var_nodes(graph)
         graph = self._set_op_role_forward(graph)
         return graph

--- a/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
@@ -37,27 +37,22 @@ class Qat2Int8MkldnnPass(object):
 
     def __init__(self,
                  _quantized_ops,
-                 _scale_from_attr=False,
                  _scope=None,
                  _place=None,
                  _core=None,
                  _debug=False):
-        self._scale_from_attr = _scale_from_attr
         self._scope = _scope
         self._place = _place
         self._core = _core
         self._debug = _debug
-        self._quantize_types = [
-            'fake_quantize_moving_average_abs_max',
-            'fake_quantize_range_abs_max',
-            'fake_quantize_dequantize_moving_average_abs_max'
-        ]
         self._fake_quantize_types = [
             'fake_quantize_moving_average_abs_max',
             'fake_quantize_range_abs_max',
             'fake_quantize_dequantize_moving_average_abs_max'
         ]
-        self._fake_dequantize_types = ['fake_dequantize_max_abs']
+        self._fake_dequantize_types = [
+            'fake_dequantize_max_abs', 'fake_channel_wise_dequantize_max_abs'
+        ]
         self._quantized_ops = _quantized_ops
         self._scale_immutable_ops = [
             'transpose2', 'reshape2', 'pool2d', 'scale'
@@ -78,12 +73,8 @@ class Qat2Int8MkldnnPass(object):
                           IrGraph), 'graph must be the instance of IrGraph.'
 
         graph = self._gather_weight_scales_from_fake(graph)
-        if self._scale_from_attr:
-            graph = self._gather_scales_from_attr(graph)
-            graph = self._gather_scales_from_fake(graph)
-        else:
-            graph = self._gather_scales_from_fake(graph)
-            graph = self._gather_scales_from_attr(graph)
+        graph = self._gather_output_scales_from_attr(graph)
+        graph = self._gather_input_scales_from_fake(graph)
         graph = self._remove_fake_ops(graph)
         graph = self._dequantize_weights(graph)
         graph = self._optimize_fp32_graph(graph)
@@ -114,15 +105,14 @@ class Qat2Int8MkldnnPass(object):
     def _is_fc_quantized(self):
         return 'fc' in self._quantized_ops
 
-    def _gather_scales_from_fake(self, graph):
+    def _gather_input_scales_from_fake(self, graph):
         def _add_scale_for_vars(var_names, use_unsigned_int, lod_tensor):
             scales = self._var_quant_scales
             for var_name in var_names:
-                if (var_name not in scales):
-                    scales[var_name] = (use_unsigned_int, lod_tensor)
+                scales[var_name] = (use_unsigned_int, lod_tensor)
 
         for op in graph.all_op_nodes():
-            if op.name() in self._quantize_types:
+            if op.name() in self._fake_quantize_types:
                 bit_length = op.op().attr("bit_length")
                 assert bit_length == 8, 'Unsupported number quantization bits ({}). Only 8 is supported now.'.format(
                     bit_length)
@@ -148,26 +138,26 @@ class Qat2Int8MkldnnPass(object):
                     _max_range = np.array(op.op().attr("max_range")).astype(
                         np.float64)
                     self._weight_scales[input_name] = _max_range
+                else:
+                    scale_name = op.input("Scales")[0]
+                    scale = np.array(
+                        self._s8_max * self._s8_max / self._load_param(
+                            self._scope, scale_name)).astype(np.float64)
+                    self._weight_scales[input_name] = scale
 
         return graph
 
-    def _gather_scales_from_attr(self, graph):
-        def _get_attr_scale_from_op(op, op_types, op_out_name):
-            if op.name() in op_types and op.op().has_attr("out_threshold"):
-                assert op_out_name in op.op().outputs(
-                ), "Operator {} does not have the output {}.".format(
-                    op.name(), op_out_name)
+    def _gather_output_scales_from_attr(self, graph):
+        for op in graph.all_op_nodes():
+            if op.op().has_attr("out_threshold"):
                 attr_scale = op.op().attr("out_threshold")
                 scale = np.array(1.0 / attr_scale).astype(np.float64)
                 scale_lod_tensor = self._convert_scale2tensor(scale)
                 use_unsigned_int = False
-                out_var_name = op.output(op_out_name)[0]
-                self._var_quant_scales[out_var_name] = (use_unsigned_int,
-                                                        scale_lod_tensor)
-
-        for op in graph.all_op_nodes():
-            _get_attr_scale_from_op(op, ['batch_norm'], 'Y')
-            _get_attr_scale_from_op(op, ['relu'], 'Out')
+                for output_name in op.op().outputs():
+                    for out_var_name in op.op().output(output_name):
+                        self._var_quant_scales[out_var_name] = (
+                            use_unsigned_int, scale_lod_tensor)
 
         return graph
 
@@ -312,29 +302,24 @@ class Qat2Int8MkldnnPass(object):
     def _dequantize_weights(self, graph):
         for op in graph.all_op_nodes():
             if op.name() in self._conv_ops:
-                self._dequantize_conv_weights(graph, op)
+                self._dequantize_op_weights(graph, op, "Filter", "Output")
             elif self._is_fc_quantized() and op.name() in self._mul_ops:
-                self._dequantize_mul_weights(graph, op)
+                self._dequantize_op_weights(graph, op, "Y", "Out")
         return graph
 
-    def _dequantize_conv_weights(self, graph, op_node):
-        weight_name = op_node.input("Filter")[0]
-        output_name = op_node.output("Output")[0]
+    def _dequantize_op_weights(self, graph, op_node, weight_name, output_name):
+        weight_var_name = op_node.input(weight_name)[0]
+        output_var_name = op_node.output(output_name)[0]
         # Convert int8 range weights to fp32 range weights
-        scales = self._weight_scales[output_name]
-        weight = self._load_param(self._scope, weight_name)
-        w_fp32 = np.divide(np.multiply(weight, self._s8_max), scales)
-        w_fp32 = w_fp32.reshape(weight.shape)
-        self._restore_var(weight_name, w_fp32)
-
-    def _dequantize_mul_weights(self, graph, op_node):
-        weight_name = op_node.input("Y")[0]
-        output_name = op_node.output("Out")[0]
-        scales = self._weight_scales[output_name]
-        weight = self._load_param(self._scope, weight_name)
-        w_fp32 = np.divide(np.multiply(weight, self._s8_max), scales)
-        w_fp32 = w_fp32.reshape(weight.shape)
-        self._restore_var(weight_name, w_fp32)
+        scales = self._weight_scales[output_var_name]
+        weight = self._load_param(self._scope, weight_var_name)
+        assert scales.size == 1 or scales.size == len(
+            weight
+        ), "The size of weight scales vector ({}) does not match the number of output channels ({}) in the weights tensor {}.".format(
+            scales.size, len(weight), weight_var_name)
+        w_fp32 = np.divide(np.multiply(weight, self._s8_max).T, scales.T).T
+        w_fp32 = w_fp32.reshape(weight.shape).astype(np.float32)
+        self._restore_var(weight_var_name, w_fp32)
 
     def _restore_var(self, name, array):
         tensor = self._scope.find_var(name).get_tensor()

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -57,10 +57,7 @@ endfunction()
 
 
 # set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 25 
-function(inference_qat2_int8_image_classification_test target qat_model_dir fp32_model_dir dataset_path quantized_ops scale_from_attr)
-    if (scale_from_attr)
-            set(scale_from_attr_option "--scale_from_attr")
-    endif()
+function(inference_qat2_int8_image_classification_test target qat_model_dir fp32_model_dir dataset_path quantized_ops)
     py_test(${target} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/qat2_int8_image_classification_comparison.py"
             ENVS FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
                  OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
@@ -71,8 +68,7 @@ function(inference_qat2_int8_image_classification_test target qat_model_dir fp32
                  --batch_size 10
                  --batch_num 2
                  --acc_diff_threshold 0.1
-                 --quantized_ops ${quantized_ops}
-                 ${scale_from_attr_option})
+                 --quantized_ops ${quantized_ops})
 endfunction()
 
 # set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 20 
@@ -219,25 +215,34 @@ if(LINUX AND WITH_MKLDNN)
 
 	set(QAT2_IC_QUANTIZED_OPS "conv2d,pool2d")
 
-	# QAT2 ResNet50 with input/output scales taken from moving-average-based fake quantize/dequantize operators only
+	# QAT2 ResNet50 with input/output scales in `fake_quantize_moving_average_abs_max` operators,
+	# with weight scales in `fake_dequantize_max_abs` operators
         set(QAT2_RESNET50_MODEL_DIR "${QAT_INSTALL_DIR}/ResNet50_qat_perf")
 	set(FP32_RESNET50_MODEL_DIR "${INT8_INSTALL_DIR}/resnet50")
 	set(QAT2_RESNET50_MODEL_ARCHIVE "ResNet50_qat_perf.tar.gz")
 	download_qat_model(${QAT2_RESNET50_MODEL_DIR} ${QAT2_RESNET50_MODEL_ARCHIVE})
-	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_mkldnn ${QAT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS} False)
+	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_mkldnn ${QAT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
 
-	# QAT2 ResNet50 with input/output scales taken from range-based fake quantize/dequantize operators and the `out_threshold` attribute
+	# QAT2 ResNet50 with input/output scales in `fake_quantize_range_abs_max` operators and the `out_threshold` attributes,
+	# with weight scales in `fake_dequantize_max_abs` operators
 	set(QAT2_RESNET50_RANGE_MODEL_DIR "${QAT_INSTALL_DIR}/ResNet50_qat_range")
 	set(QAT2_RESNET50_RANGE_MODEL_ARCHIVE "ResNet50_qat_range.tar.gz")
 	download_qat_model(${QAT2_RESNET50_RANGE_MODEL_DIR} ${QAT2_RESNET50_RANGE_MODEL_ARCHIVE})
-	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_range_mkldnn ${QAT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS} True)
+	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_range_mkldnn ${QAT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
+
+	# QAT2 ResNet50 with input/output scales in `fake_quantize_range_abs_max` operators and the `out_threshold` attributes,
+	# with weight scales in `fake_channel_wise_dequantize_max_abs` operators
+	set(QAT2_RESNET50_CHANNELWISE_MODEL_DIR "${QAT_INSTALL_DIR}/ResNet50_qat_channelwise")
+	set(QAT2_RESNET50_CHANNELWISE_MODEL_ARCHIVE "ResNet50_qat_channelwise.tar.gz")
+	download_qat_model(${QAT2_RESNET50_CHANNELWISE_MODEL_DIR} ${QAT2_RESNET50_CHANNELWISE_MODEL_ARCHIVE})
+	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_channelwise_mkldnn ${QAT2_RESNET50_CHANNELWISE_MODEL_DIR}/ResNet50_qat_channelwise ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
 
 	# QAT2 MobileNetV1
         set(QAT2_MOBILENETV1_MODEL_DIR "${QAT_INSTALL_DIR}/MobileNet_qat_perf")
 	set(FP32_MOBILENETV1_MODEL_DIR "${INT8_INSTALL_DIR}/mobilenetv1")
 	set(QAT2_MOBILENETV1_MODEL_ARCHIVE "MobileNet_qat_perf.tar.gz")
 	download_qat_model(${QAT2_MOBILENETV1_MODEL_DIR} ${QAT2_MOBILENETV1_MODEL_ARCHIVE})
-	inference_qat2_int8_image_classification_test(test_qat2_int8_mobilenetv1_mkldnn ${QAT2_MOBILENETV1_MODEL_DIR}/MobileNet_qat_perf/float ${FP32_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS} False)
+	inference_qat2_int8_image_classification_test(test_qat2_int8_mobilenetv1_mkldnn ${QAT2_MOBILENETV1_MODEL_DIR}/MobileNet_qat_perf/float ${FP32_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
 	
 	### QATv2 for NLP
 

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -215,12 +215,18 @@ if(LINUX AND WITH_MKLDNN)
 
 	set(QAT2_IC_QUANTIZED_OPS "conv2d,pool2d")
 
-	# QAT2 ResNet50
+	# QAT2 ResNet50 with input/output scales taken from moving-average-based fake quantize/dequantize operators only
         set(QAT2_RESNET50_MODEL_DIR "${QAT_INSTALL_DIR}/ResNet50_qat_perf")
 	set(FP32_RESNET50_MODEL_DIR "${INT8_INSTALL_DIR}/resnet50")
 	set(QAT2_RESNET50_MODEL_ARCHIVE "ResNet50_qat_perf.tar.gz")
 	download_qat_model(${QAT2_RESNET50_MODEL_DIR} ${QAT2_RESNET50_MODEL_ARCHIVE})
 	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_mkldnn ${QAT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
+
+	# QAT2 ResNet50 with input/output scales taken from range-based fake quantize/dequantize operators and the `out_threshold` attribute
+	set(QAT2_RESNET50_RANGE_MODEL_DIR "${QAT_INSTALL_DIR}/ResNet50_qat_range")
+	set(QAT2_RESNET50_RANGE_MODEL_ARCHIVE "ResNet50_qat_range.tar.gz")
+	download_qat_model(${QAT2_RESNET50_RANGE_MODEL_DIR} ${QAT2_RESNET50_RANGE_MODEL_ARCHIVE})
+	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_range_mkldnn ${QAT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
 
 	# QAT2 MobileNetV1
         set(QAT2_MOBILENETV1_MODEL_DIR "${QAT_INSTALL_DIR}/MobileNet_qat_perf")

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -57,7 +57,10 @@ endfunction()
 
 
 # set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 25 
-function(inference_qat2_int8_image_classification_test target qat_model_dir fp32_model_dir dataset_path quantized_ops)
+function(inference_qat2_int8_image_classification_test target qat_model_dir fp32_model_dir dataset_path quantized_ops scale_from_attr)
+    if (scale_from_attr)
+            set(scale_from_attr_option "--scale_from_attr")
+    endif()
     py_test(${target} SRCS "${CMAKE_CURRENT_SOURCE_DIR}/qat2_int8_image_classification_comparison.py"
             ENVS FLAGS_OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
                  OMP_NUM_THREADS=${CPU_NUM_THREADS_ON_CI}
@@ -68,7 +71,8 @@ function(inference_qat2_int8_image_classification_test target qat_model_dir fp32
                  --batch_size 10
                  --batch_num 2
                  --acc_diff_threshold 0.1
-		 --quantized_ops ${quantized_ops})
+                 --quantized_ops ${quantized_ops}
+                 ${scale_from_attr_option})
 endfunction()
 
 # set batch_size 10 for UT only (avoid OOM). For whole dataset, use batch_size 20 
@@ -220,20 +224,20 @@ if(LINUX AND WITH_MKLDNN)
 	set(FP32_RESNET50_MODEL_DIR "${INT8_INSTALL_DIR}/resnet50")
 	set(QAT2_RESNET50_MODEL_ARCHIVE "ResNet50_qat_perf.tar.gz")
 	download_qat_model(${QAT2_RESNET50_MODEL_DIR} ${QAT2_RESNET50_MODEL_ARCHIVE})
-	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_mkldnn ${QAT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
+	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_mkldnn ${QAT2_RESNET50_MODEL_DIR}/ResNet50_qat_perf/float ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS} False)
 
 	# QAT2 ResNet50 with input/output scales taken from range-based fake quantize/dequantize operators and the `out_threshold` attribute
 	set(QAT2_RESNET50_RANGE_MODEL_DIR "${QAT_INSTALL_DIR}/ResNet50_qat_range")
 	set(QAT2_RESNET50_RANGE_MODEL_ARCHIVE "ResNet50_qat_range.tar.gz")
 	download_qat_model(${QAT2_RESNET50_RANGE_MODEL_DIR} ${QAT2_RESNET50_RANGE_MODEL_ARCHIVE})
-	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_range_mkldnn ${QAT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
+	inference_qat2_int8_image_classification_test(test_qat2_int8_resnet50_range_mkldnn ${QAT2_RESNET50_RANGE_MODEL_DIR}/ResNet50_qat_range ${FP32_RESNET50_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS} True)
 
 	# QAT2 MobileNetV1
         set(QAT2_MOBILENETV1_MODEL_DIR "${QAT_INSTALL_DIR}/MobileNet_qat_perf")
 	set(FP32_MOBILENETV1_MODEL_DIR "${INT8_INSTALL_DIR}/mobilenetv1")
 	set(QAT2_MOBILENETV1_MODEL_ARCHIVE "MobileNet_qat_perf.tar.gz")
 	download_qat_model(${QAT2_MOBILENETV1_MODEL_DIR} ${QAT2_MOBILENETV1_MODEL_ARCHIVE})
-	inference_qat2_int8_image_classification_test(test_qat2_int8_mobilenetv1_mkldnn ${QAT2_MOBILENETV1_MODEL_DIR}/MobileNet_qat_perf/float ${FP32_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS})
+	inference_qat2_int8_image_classification_test(test_qat2_int8_mobilenetv1_mkldnn ${QAT2_MOBILENETV1_MODEL_DIR}/MobileNet_qat_perf/float ${FP32_MOBILENETV1_MODEL_DIR}/model ${IMAGENET_DATA_PATH} ${QAT2_IC_QUANTIZED_OPS} False)
 	
 	### QATv2 for NLP
 

--- a/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
@@ -46,11 +46,6 @@ def parse_args():
         action='store_true',
         help='If used, the graph of QAT model is drawn.')
     parser.add_argument(
-        '--scale_from_attr',
-        action='store_true',
-        help='If used, quantization scales from the `out_threshold` attribute are preffered over the scales from `fake_quantize/dequantize` ops.'
-    )
-    parser.add_argument(
         '--qat_model', type=str, default='', help='A path to a QAT model.')
     parser.add_argument(
         '--fp32_model', type=str, default='', help='A path to an FP32 model.')
@@ -185,7 +180,6 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
             if (transform_to_int8):
                 transform_to_mkldnn_int8_pass = Qat2Int8MkldnnPass(
                     self._quantized_ops,
-                    _scale_from_attr=self._scale_from_attr,
                     _scope=inference_scope,
                     _place=place,
                     _core=core,
@@ -311,7 +305,6 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
         skip_batch_num = test_case_args.skip_batch_num
         acc_diff_threshold = test_case_args.acc_diff_threshold
         self._debug = test_case_args.debug
-        self._scale_from_attr = test_case_args.scale_from_attr
         self._quantized_ops = set(test_case_args.quantized_ops.split(','))
 
         _logger.info('FP32 & QAT INT8 prediction run.')

--- a/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
@@ -46,6 +46,11 @@ def parse_args():
         action='store_true',
         help='If used, the graph of QAT model is drawn.')
     parser.add_argument(
+        '--scale_from_attr',
+        action='store_true',
+        help='If used, quantization scales from the `out_threshold` attribute are preffered over the scales from `fake_quantize/dequantize` ops.'
+    )
+    parser.add_argument(
         '--qat_model', type=str, default='', help='A path to a QAT model.')
     parser.add_argument(
         '--fp32_model', type=str, default='', help='A path to an FP32 model.')
@@ -180,6 +185,7 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
             if (transform_to_int8):
                 transform_to_mkldnn_int8_pass = Qat2Int8MkldnnPass(
                     self._quantized_ops,
+                    _scale_from_attr=self._scale_from_attr,
                     _scope=inference_scope,
                     _place=place,
                     _core=core,
@@ -305,6 +311,7 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
         skip_batch_num = test_case_args.skip_batch_num
         acc_diff_threshold = test_case_args.acc_diff_threshold
         self._debug = test_case_args.debug
+        self._scale_from_attr = test_case_args.scale_from_attr
         self._quantized_ops = set(test_case_args.quantized_ops.split(','))
 
         _logger.info('FP32 & QAT INT8 prediction run.')


### PR DESCRIPTION
With this patch QAT2 procedure supports:
* range-based fake quantize operators,
* channelwise-based fake dequantize operators,
* quantization scales stored in the `out_threshold` operator attributes.

Also two tests are added for ResNet50 QAT models:
* with range-based input quantization and
* with channel-wise weights quantization.

It is related to https://github.com/PaddlePaddle/Paddle/issues/23346.