### PR TITLE
Disable test imperative data loader exception

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -200,11 +200,13 @@ list(REMOVE_ITEM TEST_OPS test_fuse_bn_act_pass)
 list(REMOVE_ITEM TEST_OPS test_imperative_static_runner_mnist)
 list(REMOVE_ITEM TEST_OPS test_imperative_static_runner_while)
 
+# disable this unittest temporarily
+list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_exception)
 if (APPLE OR WIN32)
   list(REMOVE_ITEM TEST_OPS test_dataset)
   list(REMOVE_ITEM TEST_OPS test_dataset_dataloader)
   list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_base)
-  list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_exception)
+  # list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_exception)
   list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_process)
   list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_fds_clear)
   list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_exit_func)
@@ -377,6 +379,6 @@ set_tests_properties(test_parallel_executor_crf test_sync_batch_norm_op test_inp
 
 if(NOT WIN32 AND NOT APPLE)
     set_tests_properties(test_imperative_data_loader_base PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" RUN_SERIAL TRUE)
-    set_tests_properties(test_imperative_data_loader_exception PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" RUN_SERIAL TRUE)
     set_tests_properties(test_imperative_data_loader_fds_clear PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" RUN_SERIAL TRUE)
+    # set_tests_properties(test_imperative_data_loader_exception PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE" RUN_SERIAL TRUE)
 endif()


### PR DESCRIPTION
4月14日开始，效率云CI中`test_imperative_data_loader_exception`突然开始超时，经本地开发环境调试无法复现该问题，为不影响大家工作，暂时disable掉这个单测，已经记录在[Temporarily-disabled-Unit-Test](https://github.com/PaddlePaddle/Paddle/wiki/Temporarily-disabled-Unit-Test)

![image](https://user-images.githubusercontent.com/22561442/79479231-0b5a8c80-803f-11ea-8479-c2653778484d.png)


这个单测是多进程测试case，为了覆盖一些多进程DataLoader中异常分支而添加的，所以该文件中的单测均为在子线程或者子进程中主动制造错误，让主进程捕获然后报出，本身比较复杂，主要是为了覆盖率添加的；且由于python multiprocessing模块也并非完全稳定，因此这种单测在复杂的并行执行环境中偶尔会出现一些不可解释的现象

https://github.com/PaddlePaddle/Paddle/pull/23898 已经在尝试解决此问题，但鉴于目前排队时间较长，验证成本较高，先关闭单测更为高效，之后需要在效率云机器上调试和复现确认问题