### PR TITLE
Fusion group optimizer

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/code_generator.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.cc
@@ -269,7 +269,6 @@ std::string CodeGenerator::EmitParameters(
     }
     index++;
   }
-
   return ret.str();
 }
 
@@ -288,7 +287,6 @@ std::string CodeGenerator::EmitComputeBody(
   // Load input to temporal variables.
   std::ostringstream load;
   for (auto id : input_ids) {
-    VLOG(0) << id;
     if (output_ids.find(id) == output_ids.end() &&
         used.find(id) != used.end()) {
       load << dtypes.at(id) << " " << TmpName(id) << " = "

--- a/paddle/fluid/framework/ir/fusion_group/code_generator.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.cc
@@ -226,7 +226,8 @@ std::string CodeGenerator::EmitParameters(
   // from the input list.
   for (auto id : input_ids) {
     if (output_ids.find(id) == output_ids.end()) {
-      ret << dtypes.at(id) << "* " << ArgName(id) << ", ";
+      ret << "const " << dtypes.at(id) << "* __restrict__ " << ArgName(id)
+          << ", ";
     }
   }
 
@@ -258,7 +259,8 @@ std::string CodeGenerator::EmitComputeBody(
   for (auto id : input_ids) {
     if (output_ids.find(id) == output_ids.end() &&
         used.find(id) != used.end()) {
-      load << dtypes.at(id) << " " << TmpName(id) << " = " << VarName(id)
+      load << dtypes.at(id) << " " << TmpName(id) << " = "
+           << "__ldg(&" << VarName(id) << ")"
            << ";";
     }
   }

--- a/paddle/fluid/framework/ir/fusion_group/code_generator.h
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.h
@@ -43,6 +43,8 @@ class CodeGenerator {
       const std::vector<OperationExpression>& expressions);
   std::set<int> DistilOutputIds(
       const std::vector<OperationExpression>& expressions);
+  std::set<int> DistilIntermediateIds(
+      const std::vector<OperationExpression>& expressions);
   std::unordered_map<int, std::string> DistilDtypes(
       const std::vector<OperationExpression>& expressions);
 
@@ -54,6 +56,7 @@ class CodeGenerator {
   std::string EmitComputeBody(
       const std::vector<OperationExpression>& expressions,
       const std::set<int>& input_ids, const std::set<int>& output_ids,
+      const std::set<int>& intermediate_ids,
       const std::unordered_map<int, std::string>& dtypes) const;
 
   // Encode all var nodes in the subgraph with an unique number.

--- a/paddle/fluid/framework/ir/fusion_group/code_generator.h
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.h
@@ -51,6 +51,7 @@ class CodeGenerator {
   // we get the parameter list code for the expression information
   std::string EmitParameters(
       const std::set<int>& input_ids, const std::set<int>& output_ids,
+      const std::set<int>& intermediate_ids,
       const std::unordered_map<int, std::string>& dtypes) const;
 
   std::string EmitComputeBody(

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.cc
@@ -149,8 +149,6 @@ std::string OperationExpression::GetRHS(std::unordered_set<int>* used,
                               "Expected %d-th input id > 0 for operation < %s "
                               ">. Received %d.",
                               index, op_type_, input_ids_[index]));
-        // TODO(wangchaochaohu): Here fp16 convert to float to do comupte, we
-        // need to add general fp16 compute later.
         var_name = TmpName(input_ids_[index]);
         rhs.replace(pos, length + 3, var_name);
         used->insert(input_ids_[index]);

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
@@ -46,14 +46,17 @@ class OperationExpression {
  public:
   explicit OperationExpression(std::string op_type, std::vector<int> input_ids,
                                std::vector<int> output_ids,
-                               std::string rhs_type, std::string lhs_type)
+                               std::string rhs_type, std::string lhs_type,
+                               bool intermediate_state)
       : op_type_(op_type),
         input_ids_(input_ids),
         output_ids_(output_ids),
         rhs_type_(rhs_type),
-        lhs_type_(lhs_type) {}
+        lhs_type_(lhs_type),
+        intermediate_state_(intermediate_state) {}
 
   std::string GetOpType() const { return op_type_; }
+  bool GetIntermediateState() const { return intermediate_state_; }
   std::vector<int> GetInputIds() const { return input_ids_; }
   std::vector<int> GetOutputIds() const { return output_ids_; }
   std::string GetRHSType() const { return rhs_type_; }
@@ -78,6 +81,7 @@ class OperationExpression {
   AttributeMap attr_;
   std::string rhs_type_;
   std::string lhs_type_;
+  bool intermediate_state_;
 };
 
 class TemplateVariable {

--- a/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator_helper.h
@@ -47,7 +47,7 @@ class OperationExpression {
   explicit OperationExpression(std::string op_type, std::vector<int> input_ids,
                                std::vector<int> output_ids,
                                std::string rhs_type, std::string lhs_type,
-                               bool intermediate_state)
+                               std::unordered_map<int, bool> intermediate_state)
       : op_type_(op_type),
         input_ids_(input_ids),
         output_ids_(output_ids),
@@ -56,7 +56,9 @@ class OperationExpression {
         intermediate_state_(intermediate_state) {}
 
   std::string GetOpType() const { return op_type_; }
-  bool GetIntermediateState() const { return intermediate_state_; }
+  std::unordered_map<int, bool> GetIntermediateState() const {
+    return intermediate_state_;
+  }
   std::vector<int> GetInputIds() const { return input_ids_; }
   std::vector<int> GetOutputIds() const { return output_ids_; }
   std::string GetRHSType() const { return rhs_type_; }
@@ -81,7 +83,7 @@ class OperationExpression {
   AttributeMap attr_;
   std::string rhs_type_;
   std::string lhs_type_;
-  bool intermediate_state_;
+  std::unordered_map<int, bool> intermediate_state_;
 };
 
 class TemplateVariable {

--- a/paddle/fluid/framework/ir/fusion_group/cuda_resources.h
+++ b/paddle/fluid/framework/ir/fusion_group/cuda_resources.h
@@ -269,6 +269,22 @@ __CUDA_FP16_DECL__ __half hsqrt(const __half a) {
     __APPROX_FCAST(sqrt);
 }
 
+#if defined(__cplusplus) && (__CUDA_ARCH__ >= 320 || !defined(__CUDA_ARCH__))
+#if (defined(_MSC_VER) && defined(_WIN64)) || defined(__LP64__) || defined(__CUDACC_RTC__)
+#define __LDG_PTR   "l"
+#else
+#define __LDG_PTR   "r"
+#endif /*(defined(_MSC_VER) && defined(_WIN64)) || defined(__LP64__) || defined(__CUDACC_RTC__)*/
+__CUDA_FP16_DECL__ __half __ldg(const __half *ptr)
+{
+    __half ret;
+    asm ("ld.global.nc.b16 %0, [%1];"  : "=h"(__HALF_TO_US(ret)) : __LDG_PTR(ptr));
+    return ret;
+}
+
+#undef __LDG_PTR
+#endif /*defined(__cplusplus) && (__CUDA_ARCH__ >= 320 || !defined(__CUDA_ARCH__))*/
+
 __device__ inline __half Exp(const __half x) { return hexp(x); }
 __device__ inline __half Log(const __half x) { return hlog(x); }
 __device__ inline __half Sqrt(const __half x) { return hsqrt(x); }

--- a/paddle/fluid/framework/ir/fusion_group/fusion_group_pass.cc
+++ b/paddle/fluid/framework/ir/fusion_group/fusion_group_pass.cc
@@ -131,9 +131,12 @@ void FusionGroupPass::InsertFusionGroupOp(
   std::vector<std::string> outs_data_types;
   std::vector<Node*> output_var_without_intermediate;
   for (auto* n : output_vars_of_subgraph) {
-    auto it = find(intermediate_vars_of_subgraph.begin(),
-                   intermediate_vars_of_subgraph.end(), n);
-    if (it == intermediate_vars_of_subgraph.end()) {
+    auto it_input =
+        find(input_vars_of_subgraph.begin(), input_vars_of_subgraph.end(), n);
+    auto it_intermediate = find(intermediate_vars_of_subgraph.begin(),
+                                intermediate_vars_of_subgraph.end(), n);
+    if (it_intermediate == intermediate_vars_of_subgraph.end() &&
+        it_input == input_vars_of_subgraph.end()) {
       output_names.push_back(n->Name());
       outs_data_types.push_back(DataTypeToString(n->Var()->GetDataType()));
       output_var_without_intermediate.push_back(n);

--- a/paddle/fluid/framework/ir/fusion_group/operation.cc
+++ b/paddle/fluid/framework/ir/fusion_group/operation.cc
@@ -54,6 +54,7 @@ void OperationMap::Insert(int type, int num_operands, std::string op_type,
     std::string grad_op_type = op_type + "_grad";
     // grad_inputs = inputs + outputs + grad of outputs
     std::vector<std::string> grad_input_names = input_names;
+
     for (auto name : output_names) {
       grad_input_names.push_back(name);
     }

--- a/paddle/fluid/framework/ir/fusion_group/subgraph.h
+++ b/paddle/fluid/framework/ir/fusion_group/subgraph.h
@@ -149,12 +149,14 @@ class SubGraph {
       bool enable_remove = true;
 
       if (n && n->IsVar() && n->Var()) {
+        bool leaf_graph = true;
         for (auto* node : graph_nodes) {
-          if (node->IsOp() && !Has(node)) {
+          if (node->IsOp()) {
             auto inputs = node->inputs;
             for (auto* in : inputs) {
               if (in == n) {
-                enable_remove = false;
+                if (!Has(node)) enable_remove = false;
+                leaf_graph = false;
               }
             }
           }
@@ -162,6 +164,8 @@ class SubGraph {
             break;
           }
         }
+        if (leaf_graph) enable_remove = false;
+
       } else {
         enable_remove = false;
       }

--- a/paddle/fluid/framework/ir/fusion_group/subgraph.h
+++ b/paddle/fluid/framework/ir/fusion_group/subgraph.h
@@ -142,6 +142,7 @@ class SubGraph {
   std::vector<Node*> GetIntermediateOutVarNodes() {
     return intermediate_out_nodes_;
   }
+
   void DetectIntermediateOutWithGraph(Graph* graph) {
     auto graph_nodes = graph->Nodes();
 


### PR DESCRIPTION
code generator:
graph
```
I0420 10:18:34.893874 66342 fusion_group_pass.cc:56] subgraph: {
    Node(sigmoid_1.tmp_0{32x128}), inputs:{sigmoid}, outputs:{elementwise_mul, elementwise_mul_grad}
    Node(tanh_0.tmp_0{32x128}), inputs:{tanh}, outputs:{elementwise_mul, elementwise_mul_grad}
    Node(tmp_3{32x128}), inputs:{elementwise_mul}, outputs:{elementwise_add, elementwise_add_grad}
    Node(tanh_1.tmp_0{32x128}), inputs:{tanh}, outputs:{elementwise_add, elementwise_add_grad, tanh_grad}
    Node(sigmoid_2.tmp_0{32x128}), inputs:{sigmoid}, outputs:{elementwise_add, elementwise_add_grad}
    Node(assign_0.tmp_0{32x128}), inputs:{assign}, outputs:{elementwise_mul, elementwise_mul_grad}
    Node(sigmoid_0.tmp_0{32x128}), inputs:{sigmoid}, outputs:{elementwise_mul, elementwise_mul_grad}
    Node(tmp_2{32x128}), inputs:{elementwise_mul}, outputs:{elementwise_add, elementwise_add_grad}
    Node(tmp_5@GRAD{32x128}), inputs:{mean_grad}, outputs:{elementwise_add_grad}
  Node(Op(elementwise_add_grad), inputs:{Out@GRAD[tmp_5@GRAD], X[tanh_1.tmp_0], Y[sigmoid_2.tmp_0]}, outputs:{X@GRAD[tanh_1.tmp_0@GRAD], Y@GRAD[sigmoid_2.tmp_0@GRAD]}), inputs:{tmp_5@GRAD, tanh_1.tmp_0, sigmoid_2.tmp_0}, outputs:{tanh_1.tmp_0@GRAD, sigmoid_2.tmp_0@GRAD}.
    Node(tanh_1.tmp_0@GRAD{32x128}), inputs:{elementwise_add_grad}, outputs:{tanh_grad}
    Node(sigmoid_2.tmp_0@GRAD{32x128}), inputs:{elementwise_add_grad}, outputs:{}
  Node(Op(tanh_grad), inputs:{Out[tanh_1.tmp_0], Out@GRAD[tanh_1.tmp_0@GRAD]}, outputs:{X@GRAD[tmp_4@GRAD]}), inputs:{tanh_1.tmp_0, tanh_1.tmp_0@GRAD}, outputs:{tmp_4@GRAD}.
    Node(tmp_4@GRAD{32x128}), inputs:{tanh_grad}, outputs:{elementwise_add_grad}
  Node(Op(elementwise_add_grad), inputs:{Out@GRAD[tmp_4@GRAD], X[tmp_2], Y[tmp_3]}, outputs:{X@GRAD[tmp_2@GRAD], Y@GRAD[tmp_3@GRAD]}), inputs:{tmp_4@GRAD, tmp_2, tmp_3}, outputs:{tmp_2@GRAD, tmp_3@GRAD}.
    Node(tmp_2@GRAD{32x128}), inputs:{elementwise_add_grad}, outputs:{elementwise_mul_grad}
    Node(tmp_3@GRAD{32x128}), inputs:{elementwise_add_grad}, outputs:{elementwise_mul_grad}
  Node(Op(elementwise_mul_grad), inputs:{Out@GRAD[tmp_3@GRAD], X[sigmoid_1.tmp_0], Y[tanh_0.tmp_0]}, outputs:{X@GRAD[sigmoid_1.tmp_0@GRAD], Y@GRAD[tanh_0.tmp_0@GRAD]}), inputs:{tmp_3@GRAD, sigmoid_1.tmp_0, tanh_0.tmp_0}, outputs:{sigmoid_1.tmp_0@GRAD, tanh_0.tmp_0@GRAD}.
  Node(Op(elementwise_mul_grad), inputs:{Out@GRAD[tmp_2@GRAD], X[assign_0.tmp_0], Y[sigmoid_0.tmp_0]}, outputs:{X@GRAD[assign_0.tmp_0@GRAD], Y@GRAD[sigmoid_0.tmp_0@GRAD]}), inputs:{tmp_2@GRAD, assign_0.tmp_0, sigmoid_0.tmp_0}, outputs:{assign_0.tmp_0@GRAD, sigmoid_0.tmp_0@GRAD}.
    Node(sigmoid_1.tmp_0@GRAD{32x128}), inputs:{elementwise_mul_grad}, outputs:{}
    Node(tanh_0.tmp_0@GRAD{32x128}), inputs:{elementwise_mul_grad}, outputs:{}
    Node(assign_0.tmp_0@GRAD{32x128}), inputs:{elementwise_mul_grad}, outputs:{}
    Node(sigmoid_0.tmp_0@GRAD{32x128}), inputs:{elementwise_mul_grad}, outputs:{}
}
```
code
```
extern "C" __global__ void FusedElementwise9(int N, const float* __restrict__ arg0, const float* __restrict__ arg1, const float* __restrict__ arg2, const float* __restrict__ arg3, const float* __restrict__ arg4, const float* __restrict__ arg5, const float* __restrict__ arg6, const float* __restrict__ arg7, const float* __restrict__ arg8, float* arg10, float* arg14, float* arg15, float* arg16, float* arg17) {
  for(int idx = blockIdx.x * blockDim.x + threadIdx.x;
      idx < N;
      idx += gridDim.x * blockDim.x) {
    float tmp0 = __ldg(&arg0[idx]);
    float tmp1 = __ldg(&arg1[idx]);
    float tmp3 = __ldg(&arg3[idx]);
    float tmp5 = __ldg(&arg5[idx]);
    float tmp6 = __ldg(&arg6[idx]);
    float tmp8 = __ldg(&arg8[idx]);
    float tmp9 = tmp8;
    float tmp10 = tmp8;
    float tmp11 = tmp9 * (1.0 - tmp3 * tmp3);
    float tmp12 = tmp11;
    float tmp13 = tmp11;
    float tmp14 = tmp13 * tmp1;
    float tmp15 = tmp13 * tmp0;
    float tmp16 = tmp12 * tmp6;
    float tmp17 = tmp12 * tmp5;
    arg10[idx] = tmp10;
    arg14[idx] = tmp14;
    arg15[idx] = tmp15;
    arg16[idx] = tmp16;
    arg17[idx] = tmp17;
  }
}
```
develop
```

extern "C" __global__ void FusedElementwise2(int N, float* arg0, float* arg1, float* arg2, float* arg3, float* arg4, float* arg5, float* arg6, float* arg7, float* arg8, float* arg9, float* arg10, float* arg11, float* arg12, float* arg13, float* arg14, float* arg15, float* arg16, float* arg17) {
  for(int idx = blockIdx.x * blockDim.x + threadIdx.x;
      idx < N;
      idx += gridDim.x * blockDim.x) {
    float tmp1 = arg1[idx];
    float tmp3 = arg3[idx];
    float tmp4 = arg4[idx];
    float tmp5 = arg5[idx];
    float tmp6 = arg6[idx];
    float tmp8 = arg8[idx];
    float tmp9 = tmp4;
    float tmp10 = tmp4;
    float tmp11 = tmp9 * (1.0 - tmp1 * tmp1);
    float tmp12 = tmp11;
    float tmp13 = tmp11;
    float tmp16 = tmp13 * tmp5;
    float tmp17 = tmp13 * tmp8;
    float tmp14 = tmp12 * tmp6;
    float tmp15 = tmp12 * tmp3;
    arg9[idx] = tmp9;
    arg10[idx] = tmp10;
    arg11[idx] = tmp11;
    arg12[idx] = tmp12;
    arg13[idx] = tmp13;
    arg14[idx] = tmp14;
    arg15[idx] = tmp15;
    arg16[idx] = tmp16;
    arg17[idx] = tmp17;
  }
}
```



ResNet50 
Memory:(BS=128)
without fusion_group
```
I0403 11:39:16.828281 76940 parallel_executor.cc:481] The Program will be executed on CUDA using ParallelExecutor, 1 cards are used, so 1 programs are executed in parallel.
I0403 11:39:16.888053 76940 graph_pattern_detector.cc:101] ---  detected 33 subgraphs
I0403 11:39:17.092631 76940 graph_pattern_detector.cc:101] ---  detected 33 subgraphs
I0403 11:39:17.181783 76940 graph_pattern_detector.cc:101] ---  detected 16 subgraphs
I0403 11:39:17.198555 76940 graph_pattern_detector.cc:101] ---  detected 16 subgraphs
I0403 11:39:17.279995 76940 build_strategy.cc:376] SeqOnlyAllReduceOps:0, num_trainers:1
I0403 11:39:17.407210 76940 parallel_executor.cc:333] Inplace strategy is enabled, when build_strategy.enable_inplace = True
I0403 11:39:17.442723 76940 parallel_executor.cc:401] Garbage collection strategy is enabled, when FLAGS_eager_delete_tensor_gb = 1
2020-04-03 11:39:17,695-INFO: [Pass 0, train batch 0] 	loss 58.28773, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.9014 sec
2020-04-03 11:39:19,361-INFO: [Pass 0, train batch 10] 	loss 37.40405, acc1 0.00781, acc5 0.01562, lr 0.10000, elapse 0.1647 sec
2020-04-03 11:39:21,045-INFO: [Pass 0, train batch 20] 	loss 35.53636, acc1 0.00000, acc5 0.02344, lr 0.10000, elapse 0.1616 sec
2020-04-03 11:39:22,662-INFO: [Pass 0, train batch 30] 	loss 30.75803, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1630 sec
2020-04-03 11:39:24,269-INFO: [Pass 0, train batch 40] 	loss 22.00988, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1612 sec
2020-04-03 11:39:25,881-INFO: [Pass 0, train batch 50] 	loss 12.28711, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1619 sec
2020-04-03 11:39:27,615-INFO: [Pass 0, train batch 60] 	loss 8.07491, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1659 sec
2020-04-03 11:39:29,239-INFO: [Pass 0, train batch 70] 	loss 7.84996, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1597 sec
2020-04-03 11:39:30,850-INFO: [Pass 0, train batch 80] 	loss 7.88690, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1618 sec
2020-04-03 11:39:32,464-INFO: [Pass 0, train batch 90] 	loss 7.37603, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1610 sec
2020-04-03 11:39:34,081-INFO: [Pass 0, train batch 100] 	loss 7.40630, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1616 sec
2020-04-03 11:39:35,704-INFO: [Pass 0, train batch 110] 	loss 8.60868, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1616 sec
2020-04-03 11:39:37,321-INFO: [Pass 0, train batch 120] 	loss 7.49577, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1630 sec
2020-04-03 11:39:38,957-INFO: [Pass 0, train batch 130] 	loss 7.61791, acc1 0.00000, acc5 0.01562, lr 0.10000, elapse 0.1648 sec
2020-04-03 11:39:40,568-INFO: [Pass 0, train batch 140] 	loss 7.55739, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1604 sec
2020-04-03 11:39:42,205-INFO: [Pass 0, train batch 150] 	loss 7.34031, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1631 sec
2020-04-03 11:39:43,821-INFO: [Pass 0, train batch 160] 	loss 7.34924, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1611 sec
2020-04-03 11:39:45,435-INFO: [Pass 0, train batch 170] 	loss 7.53807, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1627 sec
2020-04-03 11:39:47,072-INFO: [Pass 0, train batch 180] 	loss 7.39394, acc1 0.00781, acc5 0.02344, lr 0.10000, elapse 0.1611 sec
2020-04-03 11:39:48,696-INFO: [Pass 0, train batch 190] 	loss 7.38567, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1639 sec
2020-04-03 11:39:50,317-INFO: [Pass 0, train batch 200] 	loss 8.64147, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1607 sec
2020-04-03 11:39:51,938-INFO: [Pass 0, train batch 210] 	loss 7.43214, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1617 sec
2020-04-03 11:39:53,554-INFO: [Pass 0, train batch 220] 	loss 7.34309, acc1 0.00000, acc5 0.01562, lr 0.10000, elapse 0.1619 sec
2020-04-03 11:39:55,174-INFO: [Pass 0, train batch 230] 	loss 7.40224, acc1 0.00781, acc5 0.01562, lr 0.10000, elapse 0.1711 sec
2020-04-03 11:39:56,786-INFO: [Pass 0, train batch 240] 	loss 7.90558, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1612 sec
2020-04-03 11:39:58,426-INFO: [Pass 0, train batch 250] 	loss 7.40587, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1619 sec
2020-04-03 11:40:00,059-INFO: [Pass 0, train batch 260] 	loss 7.36620, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1616 sec
2020-04-03 11:40:01,684-INFO: [Pass 0, train batch 270] 	loss 7.76474, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1630 sec
2020-04-03 11:40:03,296-INFO: [Pass 0, train batch 280] 	loss 7.36287, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1602 sec
2020-04-03 11:40:04,904-INFO: [Pass 0, train batch 290] 	loss 7.39509, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1609 sec
2020-04-03 11:40:06,510-INFO: [Pass 0, train batch 300] 	loss 8.02802, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1605 sec
2020-04-03 11:40:08,196-INFO: [Pass 0, train batch 310] 	loss 7.82140, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1630 sec
2020-04-03 11:40:09,819-INFO: [Pass 0, train batch 320] 	loss 7.41313, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1612 sec
2020-04-03 11:40:11,461-INFO: [Pass 0, train batch 330] 	loss 7.74391, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1667 sec
2020-04-03 11:40:13,089-INFO: [Pass 0, train batch 340] 	loss 7.72739, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1634 sec
2020-04-03 11:40:14,711-INFO: [Pass 0, train batch 350] 	loss 7.33674, acc1 0.01562, acc5 0.01562, lr 0.10000, elapse 0.1613 sec
```
develop with fusion group:

speed
```
I0420 07:50:40.972506 108885 fusion_group_pass.cc:36] Detect 32 elementwise fusion groups.
2020-04-20 07:50:41,567-INFO: [Pass 0, train batch 0] 	loss 58.35946, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 8.1403 sec
2020-04-20 07:50:43,376-INFO: [Pass 0, train batch 10] 	loss 41.27401, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1948 sec
2020-04-20 07:50:45,259-INFO: [Pass 0, train batch 20] 	loss 45.37650, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1811 sec
2020-04-20 07:50:47,071-INFO: [Pass 0, train batch 30] 	loss 42.26008, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1727 sec
2020-04-20 07:50:48,845-INFO: [Pass 0, train batch 40] 	loss 27.94326, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1724 sec
2020-04-20 07:50:50,590-INFO: [Pass 0, train batch 50] 	loss 16.90263, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1726 sec
2020-04-20 07:50:52,349-INFO: [Pass 0, train batch 60] 	loss 9.08802, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1772 sec
2020-04-20 07:50:54,191-INFO: [Pass 0, train batch 70] 	loss 7.46220, acc1 0.00781, acc5 0.01562, lr 0.10000, elapse 0.1848 sec
2020-04-20 07:50:56,104-INFO: [Pass 0, train batch 80] 	loss 7.42559, acc1 0.00000, acc5 0.01562, lr 0.10000, elapse 0.1744 sec
2020-04-20 07:50:57,995-INFO: [Pass 0, train batch 90] 	loss 7.34507, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1734 sec
2020-04-20 07:50:59,815-INFO: [Pass 0, train batch 100] 	loss 7.41156, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1815 sec
2020-04-20 07:51:01,643-INFO: [Pass 0, train batch 110] 	loss 7.40986, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1735 sec
2020-04-20 07:51:03,443-INFO: [Pass 0, train batch 120] 	loss 7.85518, acc1 0.00000, acc5 0.02344, lr 0.10000, elapse 0.1727 sec
2020-04-20 07:51:05,287-INFO: [Pass 0, train batch 130] 	loss 7.41322, acc1 0.01562, acc5 0.01562, lr 0.10000, elapse 0.1751 sec
2020-04-20 07:51:07,112-INFO: [Pass 0, train batch 140] 	loss 7.39413, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.2064 sec
2020-04-20 07:51:08,908-INFO: [Pass 0, train batch 150] 	loss 7.34854, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1745 sec
2020-04-20 07:51:10,649-INFO: [Pass 0, train batch 160] 	loss 7.37619, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1737 sec
2020-04-20 07:51:12,389-INFO: [Pass 0, train batch 170] 	loss 7.36869, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1736 sec
2020-04-20 07:51:14,230-INFO: [Pass 0, train batch 180] 	loss 7.66026, acc1 0.01562, acc5 0.02344, lr 0.10000, elapse 0.1809 sec
2020-04-20 07:51:16,205-INFO: [Pass 0, train batch 190] 	loss 7.76989, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.2118 sec
2020-04-20 07:51:18,048-INFO: [Pass 0, train batch 200] 	loss 7.63018, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1853 sec
2020-04-20 07:51:19,829-INFO: [Pass 0, train batch 210] 	loss 7.36925, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1708 sec
2020-04-20 07:51:21,713-INFO: [Pass 0, train batch 220] 	loss 7.35503, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1850 sec
2020-04-20 07:51:23,582-INFO: [Pass 0, train batch 230] 	loss 7.47642, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.2238 sec
2020-04-20 07:51:25,521-INFO: [Pass 0, train batch 240] 	loss 7.36822, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1909 sec
2020-04-20 07:51:27,313-INFO: [Pass 0, train batch 250] 	loss 7.36916, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1748 sec
2020-04-20 07:51:29,134-INFO: [Pass 0, train batch 260] 	loss 7.66580, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1734 sec
2020-04-20 07:51:30,877-INFO: [Pass 0, train batch 270] 	loss 7.35389, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1744 sec

```

this pr with fusion group


speed:
```
I0420 07:37:51.626042 102071 graph_pattern_detector.cc:101] ---  detected 33 subgraphs
I0420 07:37:51.824518 102071 graph_pattern_detector.cc:101] ---  detected 33 subgraphs
I0420 07:37:59.413408 102071 fusion_group_pass.cc:36] Detect 32 elementwise fusion groups.
2020-04-20 07:38:00,071-INFO: [Pass 0, train batch 0] 	loss 57.01205, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 8.5414 sec
2020-04-20 07:38:01,711-INFO: [Pass 0, train batch 10] 	loss 22.20854, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1618 sec
2020-04-20 07:38:03,335-INFO: [Pass 0, train batch 20] 	loss 19.15162, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1574 sec
2020-04-20 07:38:05,019-INFO: [Pass 0, train batch 30] 	loss 13.94458, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1713 sec
2020-04-20 07:38:06,685-INFO: [Pass 0, train batch 40] 	loss 10.60628, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1652 sec
2020-04-20 07:38:08,333-INFO: [Pass 0, train batch 50] 	loss 9.11628, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1645 sec
2020-04-20 07:38:09,945-INFO: [Pass 0, train batch 60] 	loss 7.43096, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1627 sec
2020-04-20 07:38:11,536-INFO: [Pass 0, train batch 70] 	loss 7.36789, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1575 sec
2020-04-20 07:38:13,124-INFO: [Pass 0, train batch 80] 	loss 7.35075, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1582 sec
2020-04-20 07:38:14,728-INFO: [Pass 0, train batch 90] 	loss 7.36890, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1604 sec
2020-04-20 07:38:16,361-INFO: [Pass 0, train batch 100] 	loss 7.79940, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1691 sec
2020-04-20 07:38:17,966-INFO: [Pass 0, train batch 110] 	loss 7.52226, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1568 sec
2020-04-20 07:38:19,578-INFO: [Pass 0, train batch 120] 	loss 7.58882, acc1 0.00000, acc5 0.01562, lr 0.10000, elapse 0.1596 sec
2020-04-20 07:38:21,168-INFO: [Pass 0, train batch 130] 	loss 7.56549, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1570 sec
2020-04-20 07:38:22,782-INFO: [Pass 0, train batch 140] 	loss 7.39170, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1597 sec
2020-04-20 07:38:24,377-INFO: [Pass 0, train batch 150] 	loss 7.35504, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1580 sec
2020-04-20 07:38:25,978-INFO: [Pass 0, train batch 160] 	loss 7.35626, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1593 sec
2020-04-20 07:38:27,590-INFO: [Pass 0, train batch 170] 	loss 7.35559, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1613 sec
2020-04-20 07:38:29,176-INFO: [Pass 0, train batch 180] 	loss 7.35849, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1579 sec
2020-04-20 07:38:30,805-INFO: [Pass 0, train batch 190] 	loss 7.45062, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1638 sec
2020-04-20 07:38:32,392-INFO: [Pass 0, train batch 200] 	loss 7.45199, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1574 sec
2020-04-20 07:38:33,985-INFO: [Pass 0, train batch 210] 	loss 7.35009, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1587 sec
2020-04-20 07:38:35,579-INFO: [Pass 0, train batch 220] 	loss 7.35454, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1589 sec
2020-04-20 07:38:37,160-INFO: [Pass 0, train batch 230] 	loss 7.35036, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1579 sec
2020-04-20 07:38:38,813-INFO: [Pass 0, train batch 240] 	loss 7.66524, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1589 sec
2020-04-20 07:38:40,396-INFO: [Pass 0, train batch 250] 	loss 7.47834, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1583 sec
2020-04-20 07:38:41,992-INFO: [Pass 0, train batch 260] 	loss 7.36098, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1587 sec
2020-04-20 07:38:43,582-INFO: [Pass 0, train batch 270] 	loss 7.46548, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1582 sec
2020-04-20 07:38:45,166-INFO: [Pass 0, train batch 280]
```
