### PR TITLE
Fix the error misjudgment when there are control nodes in graph.

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
+++ b/paddle/fluid/framework/ir/fusion_group/elementwise_group_detector.cc
@@ -88,38 +88,52 @@ bool GroupDetector::CheckPrecondition(const Node* n) {
     return true;
   };
 
-  return n && n->IsOp() && n->Op() && check_data_type(n->inputs) &&
-         check_data_type(n->outputs);
+  auto check_running_on_cpu = [&](const Node* n) -> bool {
+    if (n && n->IsOp() && n->Op()) {
+      auto* op = n->Op();
+      bool is_run_on_cpu = false;
+      if (op->HasAttr("force_cpu") &&
+          op->GetAttrType("force_cpu") == proto::AttrType::BOOLEAN) {
+        is_run_on_cpu = op->GetAttrIfExists<bool>("force_cpu");
+      }
+      if (op->HasAttr("op_device")) {
+        is_run_on_cpu = op->GetAttrIfExists<std::string>("op_device") == "cpu";
+      }
+      return is_run_on_cpu;
+    }
+    return false;
+  };
+
+  return n && n->IsOp() && n->Op() && !check_running_on_cpu(n) &&
+         check_data_type(n->inputs) && check_data_type(n->outputs);
 }
 
 bool ElementwiseGroupDetector::IsElementwiseOp(const Node* n) {
   if (IsSpecifiedOp(GetElementwiseOpTypes(), n)) {
     // Check whether all inputs have the same shape.
+    bool is_first = true;
     std::vector<int64_t> shape_0;
-    for (size_t i = 0; i < n->inputs.size(); ++i) {
-      auto* in_i = n->inputs[i];
-      if (!(in_i && in_i->IsVar() && in_i->Var())) {
-        return false;
-      }
-
-      std::vector<int64_t> shape_i = in_i->Var()->GetShape();
-      if (i == 0U) {
-        shape_0 = shape_i;
-      } else {
-        if (!IsEqualAndNotEmpty(shape_0, shape_i)) {
-          return false;
+    for (auto* in_i : n->inputs) {
+      if (in_i && in_i->IsVar() && in_i->Var()) {
+        std::vector<int64_t> shape_i = in_i->Var()->GetShape();
+        if (is_first) {
+          shape_0 = shape_i;
+          is_first = false;
+        } else {
+          if (!IsEqualAndNotEmpty(shape_0, shape_i)) {
+            return false;
+          }
         }
       }
     }
-
     auto op = n->Op();
     std::vector<std::string> output_names =
         OperationMap::Instance().Get(op->Type()).output_names;
-
     for (auto& name : output_names) {
-      if (op->Output(name).size() != 1) return false;
+      if (op->Output(name).size() < 1U) {
+        return false;
+      }
     }
-
     return true;
   }
   return false;

--- a/paddle/fluid/framework/ir/fusion_group/subgraph.h
+++ b/paddle/fluid/framework/ir/fusion_group/subgraph.h
@@ -170,7 +170,7 @@ class SubGraph {
       }
 
       for (auto* n : nodes_set_) {
-        if (n && n->IsVar() && n->Var()) {
+        if (n && ((n->IsVar() && n->Var()) || n->IsCtrlVar())) {
           // Set the input of subgraph's input var node to null.
           std::vector<Node*> inputs;
           for (auto* in : n->inputs) {

--- a/paddle/fluid/framework/ir/pass_tester_helper.h
+++ b/paddle/fluid/framework/ir/pass_tester_helper.h
@@ -484,7 +484,7 @@ static std::string DebugString(OpDesc* op) {
   return os.str();
 }
 
-static std::string DebugString(Node* node) {
+static std::string DebugString(const Node* node) {
   std::ostringstream os;
   if (node->IsOp() && node->Op()) {
     OpDesc* op = node->Op();
@@ -553,7 +553,7 @@ static std::string DebugString(const std::vector<Node*>& nodes) {
   for (auto* node : nodes) {
     if (node->IsOp() && node->Op()) {
       os << "  ";
-    } else if (node->IsVar() && node->Var()) {
+    } else if ((node->IsVar() && node->Var()) || node->IsCtrlVar()) {
       os << "    ";
     }
     os << DebugString(node) << "\n";


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/12538138/79534719-e8b38c80-80ad-11ea-85f9-6fb7a0f815b0.png)

当前fusion_group的实现，不能正确地匹配和处理上述子图结构（红色表示子图外部的节点），主要原因有2：
- sum的输入中存在一个control节点，当前实现会判断sum的所有输入节点的shape是否相同。实现中，遇到control节点就直接返回false了，因此不能匹配到sum节点。
- 子图在sort的时候，由于没有对control节点进行正确的处理，导致排序后将sum节点丢了。

这个PR对上述两点进行修正，应用于ResNet50 fp16训练中，能够匹配到161个`scale+sum`的子图，ResNet50 fp16总共能匹配到193个子图，子图结构如下：
```
{
    Node(res5c_branch2c_weights{2048x512x1x1}), inputs:{}, outputs:{cast, scale, momentum}
    Node(tmp_160{2048x512x1x1}), inputs:{conditional_block}, outputs:{sum}
    Node(__control_var@4629), inputs:{conditional_block}, outputs:{sum}
  Node(Op(scale), inputs:{ScaleTensor[], X[res5c_branch2c_weights]}, outputs:{Out[_generated_var_176]}), inputs:{res5c_branch2c_weights}, outputs:{_generated_var_176, __control_var@4427}.
    Node(_generated_var_176{2048x512x1x1}), inputs:{scale}, outputs:{sum}
    Node(__control_var@4427), inputs:{scale}, outputs:{momentum}
  Node(Op(sum), inputs:{X[tmp_160, _generated_var_176]}, outputs:{Out[tmp_160]}), inputs:{tmp_160, _generated_var_176, __control_var@4629}, outputs:{tmp_160}.
    Node(tmp_160{2048x512x1x1}), inputs:{sum}, outputs:{momentum}
}
```

生成的代码如下：
```cpp
__device__ inline float Max(float x, float y) { return fmaxf(x, y); }
__device__ inline float Exp(float x) { return expf(x); }
__device__ inline float Log(float x) { return logf(x); }
__device__ inline float Sqrt(float x) { return sqrtf(x); }


extern "C" __global__ void FusedElementwise14(int N, float* arg0, float* arg1, float* arg2) {
  for(int idx = blockIdx.x * blockDim.x + threadIdx.x;
      idx < N;
      idx += gridDim.x * blockDim.x) {
    float tmp0 = arg0[idx];
    float tmp2 = true ? (0.0001 * tmp0 + 0) : (0.0001 * (tmp0 + 0));
    float tmp1 = tmp1 + tmp2;
    arg1[idx] = tmp1;
    arg2[idx] = tmp2;
  }
}
```