### PR TITLE
Optimize Data_feed

### DIFF
--- a/paddle/fluid/framework/data_feed.cc
+++ b/paddle/fluid/framework/data_feed.cc
@@ -798,13 +798,17 @@ void MultiSlotInMemoryDataFeed::Init(
     }
   }
   feed_vec_.resize(use_slots_.size());
+  const int kEstimatedFeasignNumPerSlot = 5;  // Magic Number
   for (size_t i = 0; i < all_slot_num; i++) {
     batch_float_feasigns.push_back(std::vector<float>());
     batch_uint64_feasigns.push_back(std::vector<uint64_t>());
-    batch_float_feasigns[i].reserve(default_batch_size_ * 5);
-    batch_uint64_feasigns[i].reserve(default_batch_size_ * 5);
+    batch_float_feasigns[i].reserve(default_batch_size_ *
+                                    kEstimatedFeasignNumPerSlot);
+    batch_uint64_feasigns[i].reserve(default_batch_size_ *
+                                     kEstimatedFeasignNumPerSlot);
     offset.push_back(std::vector<size_t>());
-    offset[i].reserve(default_batch_size_ + 1);
+    offset[i].reserve(default_batch_size_ +
+                      1);  // Each lod info will prepend a zero
   }
   visit.resize(all_slot_num, false);
   pipe_command_ = data_feed_desc.pipe_command();
@@ -1441,8 +1445,14 @@ void PaddleBoxDataFeed::PutToFeedVec(const std::vector<Record*>& ins_vec) {
     offset[i].clear();
     offset[i].push_back(0);
   }
+  ins_content_vec_.clear();
+  ins_content_vec_.reserve(ins_vec.size());
+  ins_id_vec_.clear();
+  ins_id_vec_.reserve(ins_vec.size());
   for (size_t i = 0; i < ins_vec.size(); ++i) {
     auto r = ins_vec[i];
+    ins_id_vec_.push_back(r->ins_id_);
+    ins_content_vec_.push_back(r->content_);
     for (auto& item : r->float_feasigns_) {
       batch_float_feasigns[item.slot()].push_back(item.sign().float_feasign_);
       visit[item.slot()] = true;

--- a/paddle/fluid/framework/data_feed.h
+++ b/paddle/fluid/framework/data_feed.h
@@ -597,6 +597,10 @@ class MultiSlotInMemoryDataFeed : public InMemoryDataFeed<Record> {
   virtual void PutToFeedVec(const std::vector<Record>& ins_vec);
   virtual void GetMsgFromLogKey(const std::string& log_key, uint64_t* search_id,
                                 uint32_t* cmatch, uint32_t* rank);
+  std::vector<std::vector<float>> batch_float_feasigns;
+  std::vector<std::vector<uint64_t>> batch_uint64_feasigns;
+  std::vector<std::vector<size_t>> offset;
+  std::vector<bool> visit;
 };
 
 class PaddleBoxDataFeed : public MultiSlotInMemoryDataFeed {

--- a/paddle/fluid/framework/data_feed.h
+++ b/paddle/fluid/framework/data_feed.h
@@ -597,10 +597,10 @@ class MultiSlotInMemoryDataFeed : public InMemoryDataFeed<Record> {
   virtual void PutToFeedVec(const std::vector<Record>& ins_vec);
   virtual void GetMsgFromLogKey(const std::string& log_key, uint64_t* search_id,
                                 uint32_t* cmatch, uint32_t* rank);
-  std::vector<std::vector<float>> batch_float_feasigns;
-  std::vector<std::vector<uint64_t>> batch_uint64_feasigns;
-  std::vector<std::vector<size_t>> offset;
-  std::vector<bool> visit;
+  std::vector<std::vector<float>> batch_float_feasigns_;
+  std::vector<std::vector<uint64_t>> batch_uint64_feasigns_;
+  std::vector<std::vector<size_t>> offset_;
+  std::vector<bool> visit_;
 };
 
 class PaddleBoxDataFeed : public MultiSlotInMemoryDataFeed {


### PR DESCRIPTION
Make `batch_float_feasigns` &  `batch_uint64_feasigns`  as member variable to reuse its space , which avoids allocating memory repeatedly in each epoch.
In PaddleBox, this change was proved to accelerate training speed by 11%+.