### PR TITLE
fix logger propagate

### DIFF
--- a/python/paddle/fluid/log_helper.py
+++ b/python/paddle/fluid/log_helper.py
@@ -49,4 +49,8 @@ def get_logger(name, level, fmt=None):
         handler.setFormatter(formatter)
 
     logger.addHandler(handler)
+
+    # stop propagate for propagating may print
+    # log multiple times
+    logger.propagate = False
     return logger


### PR DESCRIPTION
**fix logger propagate**
`logger.propagate` is True by default, log message will propagate from `logger.handler` to default root handler and print twice, set `logger.propagate` as False to prevent this