### PR TITLE
[Dy2Stat]Fix bug in convert_call for python3

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_recursive_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_recursive_call.py
@@ -25,6 +25,8 @@ SEED = 2020
 np.random.seed(SEED)
 
 
+# Use a decorator to test exception
+@dygraph_to_static_func
 def dyfunc_with_if(x_v):
     if fluid.layers.mean(x_v).numpy()[0] > 5:
         x_v = x_v - 1
@@ -91,6 +93,7 @@ class MyConvLayer(fluid.dygraph.Layer):
             bias_attr=fluid.ParamAttr(
                 initializer=fluid.initializer.Constant(value=0.5)))
 
+    @dygraph_to_static_func
     def forward(self, inputs):
         y = dyfunc_with_if(inputs)
         y = lambda_fun(y)
@@ -99,6 +102,7 @@ class MyConvLayer(fluid.dygraph.Layer):
 
     @dygraph_to_static_func
     def dymethod(self, x_v):
+        x_v = fluid.layers.assign(x_v)
         return x_v
 
 


### PR DESCRIPTION
Add python3 branch in `convert_call` because when recursively convert a function **without** decorators, there is no difference between PY2 and PY3. Otherwise, difference exists when recursively convert a function **with** decorators.

For example:
```Python
@dygraph_to_static_func # an additional decorator
def dyfunc_with_if(x_v):
    if fluid.layers.mean(x_v).numpy()[0] > 5:
        x_v = x_v - 1
    else:
        x_v = x_v + 1
    return x_v


class MyConvLayer(fluid.dygraph.Layer):
    def __init__(self):
        super(MyConvLayer, self).__init__()
        self._conv = fluid.dygraph.Conv2D(
            num_channels=3,
            num_filters=2,
            filter_size=3,
            param_attr=fluid.ParamAttr(
                initializer=fluid.initializer.Constant(value=0.99)),
            bias_attr=fluid.ParamAttr(
                initializer=fluid.initializer.Constant(value=0.5)))

    @dygraph_to_static_func
    def forward(self, inputs):
        y = dyfunc_with_if(inputs) # dyfunc_with_if is called here and it can be converted recursively.
        y = lambda_fun(y)
        y = self.dymethod(y)
        return y

    @dygraph_to_static_func
    def dymethod(self, x_v):
        x_v = fluid.layers.assign(x_v)
        return x_v
```
