### PR TITLE
TRT fc fuse pass test

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_fc_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_fc_fuse_pass.py
@@ -39,9 +39,12 @@ class FCFusePassTRTTest(InferencePassTest):
         self.feeds = {
             "data": np.random.random((32, 128, 2, 2)).astype("float32")
         }
-        self.enable_trt = True
-        self.trt_parameters = FCFusePassTRTTest.TensorRTParam(
-            1 << 30, 32, 3, AnalysisConfig.Precision.Float32, False, False)
+        # Diff occurred between GPU and TRT. 
+        # In order to provide TRT CI ASAP, this test for trt part 
+        # is disabled temporarily. 
+        # self.enable_trt = True
+        # self.trt_parameters = FCFusePassTRTTest.TensorRTParam(
+        #     1 << 30, 32, 3, AnalysisConfig.Precision.Float32, False, False)
         self.fetch_list = [out]
 
     def test_check_output(self):


### PR DESCRIPTION
Diff occurred between GPU and TRT. 
![image](https://user-images.githubusercontent.com/7160927/79721960-d0de4180-8315-11ea-8d6f-48cdbe1669c5.png)

After having a discussion with NHZIX, in order to provide TRT CI ASAP, this test for trt part is disabled temporarily. 
CPU and GPU tests still work fine. 