### PR TITLE
update gcc/g++ version from 5.4 to 4.8 for docker

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -974,6 +974,8 @@ EOF
     FROM ${BASE_IMAGE}
     MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
     ENV HOME /root
+    WORKDIR /usr/bin
+    RUN apt-get update && apt install -y gcc-4.8 g++-4.8 && cp gcc gcc.bak && cp g++ g++.bak && rm gcc && rm g++ && ln -s gcc-4.8 gcc && ln -s g++-4.8 g++
 EOF
 
     if [[ ${WITH_GPU} == "ON"  ]]; then

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -974,8 +974,7 @@ EOF
     FROM ${BASE_IMAGE}
     MAINTAINER PaddlePaddle Authors <paddle-dev@baidu.com>
     ENV HOME /root
-    WORKDIR /usr/bin
-    RUN apt-get update && apt install -y gcc-4.8 g++-4.8 && cp gcc gcc.bak && cp g++ g++.bak && rm gcc && rm g++ && ln -s gcc-4.8 gcc && ln -s g++-4.8 g++
+    RUN apt-get update && apt install -y gcc-4.8 g++-4.8 && ln -sf /usr/bin/gcc-4.8 /usr/bin/gcc && ln -sf /usr/bin/g++-4.8 /usr/bin/g++
 EOF
 
     if [[ ${WITH_GPU} == "ON"  ]]; then


### PR DESCRIPTION
Paddle ci's gcc/g++ version is 4.8, so update gcc/g++ version from 5.4 to 4.8 for docker.