### PR TITLE
New feature: thread local allocator, test=develop

### DIFF
--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -14,13 +14,15 @@ endif()
 
 if (WITH_GPU)
   nv_library(cuda_allocator SRCS cuda_allocator.cc DEPS allocator cuda_device_guard)
+  nv_library(thread_local_allocator SRCS thread_local_allocator.cc DEPS allocator)
+  cc_test(thread_local_allocator_test SRCS thread_local_allocator_test.cc DEPS thread_local_allocator)
 endif()
 
 cc_library(retry_allocator SRCS retry_allocator.cc DEPS allocator)
 
 nv_library(pinned_allocator SRCS pinned_allocator.cc DEPS allocator)
 if (WITH_GPU)
-    set(AllocatorFacadeDeps gpu_info cuda_allocator pinned_allocator cuda_device_guard)
+    set(AllocatorFacadeDeps gpu_info cuda_allocator pinned_allocator cuda_device_guard thread_local_allocator)
 else ()
     set(AllocatorFacadeDeps)
 endif()
@@ -66,8 +68,6 @@ cc_test(allocator_facade_frac_flags_test SRCS allocator_facade_frac_flags_test.c
 cc_library(auto_growth_best_fit_allocator SRCS auto_growth_best_fit_allocator.cc DEPS allocator aligned_allocator)
 cc_test(auto_growth_best_fit_allocator_facade_test SRCS auto_growth_best_fit_allocator_facade_test.cc DEPS cpu_allocator auto_growth_best_fit_allocator)
 cc_test(auto_growth_best_fit_allocator_test SRCS auto_growth_best_fit_allocator_test.cc DEPS auto_growth_best_fit_allocator)
-
-cc_library(thread_local_allocator SRCS thread_local_allocator.cc DEPS allocator)
 
 if(NOT WIN32)
   cc_library(mmap_allocator SRCS mmap_allocator.cc DEPS allocator)

--- a/paddle/fluid/memory/allocation/CMakeLists.txt
+++ b/paddle/fluid/memory/allocation/CMakeLists.txt
@@ -67,6 +67,8 @@ cc_library(auto_growth_best_fit_allocator SRCS auto_growth_best_fit_allocator.cc
 cc_test(auto_growth_best_fit_allocator_facade_test SRCS auto_growth_best_fit_allocator_facade_test.cc DEPS cpu_allocator auto_growth_best_fit_allocator)
 cc_test(auto_growth_best_fit_allocator_test SRCS auto_growth_best_fit_allocator_test.cc DEPS auto_growth_best_fit_allocator)
 
+cc_library(thread_local_allocator SRCS thread_local_allocator.cc DEPS allocator)
+
 if(NOT WIN32)
   cc_library(mmap_allocator SRCS mmap_allocator.cc DEPS allocator)
   cc_test(mmap_allocator_test SRCS mmap_allocator_test.cc DEPS mmap_allocator allocator)

--- a/paddle/fluid/memory/allocation/allocator_facade.cc
+++ b/paddle/fluid/memory/allocation/allocator_facade.cc
@@ -32,6 +32,7 @@
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/memory/allocation/cuda_allocator.h"
 #include "paddle/fluid/memory/allocation/pinned_allocator.h"
+#include "paddle/fluid/memory/allocation/thread_local_allocator.h"
 #include "paddle/fluid/platform/cuda_device_guard.h"
 #include "paddle/fluid/platform/gpu_info.h"
 #endif
@@ -133,7 +134,11 @@ class AllocatorFacadePrivate {
   }
 
   void InitNaiveBestFitCUDAAllocator(platform::CUDAPlace p) {
+#ifndef PADDLE_ON_INFERENCE
     allocators_[p] = std::make_shared<NaiveBestFitAllocator>(p);
+#else
+    allocators_[p] = std::make_shared<CUDAThreadLocalAllocator>(p);
+#endif
   }
 
   void InitAutoGrowthCUDAAllocator(platform::CUDAPlace p) {

--- a/paddle/fluid/memory/allocation/allocator_strategy.cc
+++ b/paddle/fluid/memory/allocation/allocator_strategy.cc
@@ -32,6 +32,10 @@ static AllocatorStrategy GetStrategyFromFlag() {
     return AllocatorStrategy::kAutoGrowth;
   }
 
+  if (FLAGS_allocator_strategy == "thread_local") {
+    return AllocatorStrategy::kThreadLocal;
+  }
+
   PADDLE_THROW("Unsupported allocator strategy: %s", FLAGS_allocator_strategy);
 }
 

--- a/paddle/fluid/memory/allocation/allocator_strategy.h
+++ b/paddle/fluid/memory/allocation/allocator_strategy.h
@@ -18,7 +18,7 @@ namespace paddle {
 namespace memory {
 namespace allocation {
 
-enum class AllocatorStrategy { kNaiveBestFit, kAutoGrowth };
+enum class AllocatorStrategy { kNaiveBestFit, kAutoGrowth, kThreadLocal };
 
 extern AllocatorStrategy GetAllocatorStrategy();
 

--- a/paddle/fluid/memory/allocation/thread_local_allocator.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/allocation/thread_local_allocator.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class ThreadLocalAllocation : public Allocation {
+ public:
+  ThreadLocalAllocation(void* ptr, size_t size, platform::Place place)
+      : Allocation(ptr, size, place) {}
+
+  void SetThreadLocalAllocator(std::shared_ptr<Allocator> allocator) {
+    allocator_ = allocator;
+  }
+
+ private:
+  std::shared_ptr<Allocator> allocator_;
+};
+
+Allocation* ThreadLocalAllocator::AllocateImpl(size_t size) {
+  void* ptr = buddy_allocator_->Alloc(size);
+  auto* tl_allocation = new ThreadLocalAllocation(ptr, size, place_);
+  tl_allocation->SetThreadLocalAllocator(shared_from_this());
+  return tl_allocation;
+}
+
+void ThreadLocalAllocator::FreeImpl(Allocation* allocation) {
+  auto* tl_allocation = static_cast<ThreadLocalAllocation*>(allocation);
+  buddy_allocator_->Free(tl_allocation->ptr());
+  delete tl_allocation;
+}
+
+const std::shared_ptr<Allocator>& GetThreadLocalAllocator() {
+  static thread_local std::shared_ptr<Allocator> allocator(
+      new ThreadLocalAllocator(platform::CUDAPlace()));
+  return allocator;
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/thread_local_allocator.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.cc
@@ -31,7 +31,7 @@ ThreadLocalAllocatorImpl::ThreadLocalAllocatorImpl(const platform::Place& p)
   }
 }
 
-std::shared_ptr<ThreadLocalAllocatorImpl> CUDAThreadLocalAllocatorPool::Get(
+std::shared_ptr<ThreadLocalAllocatorImpl> ThreadLocalCUDAAllocatorPool::Get(
     int gpu_id) {
   auto pos = std::distance(devices_.begin(),
                            std::find(devices_.begin(), devices_.end(), gpu_id));
@@ -47,7 +47,7 @@ std::shared_ptr<ThreadLocalAllocatorImpl> CUDAThreadLocalAllocatorPool::Get(
   return allocators_[pos];
 }
 
-CUDAThreadLocalAllocatorPool::CUDAThreadLocalAllocatorPool()
+ThreadLocalCUDAAllocatorPool::ThreadLocalCUDAAllocatorPool()
     : devices_(platform::GetSelectedDevices()) {
   auto gpu_num = devices_.size();
   allocators_.resize(gpu_num);

--- a/paddle/fluid/memory/allocation/thread_local_allocator.h
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 #include "paddle/fluid/memory/allocation/allocator.h"
 #include "paddle/fluid/memory/detail/buddy_allocator.h"
 #include "paddle/fluid/memory/detail/system_allocator.h"
@@ -24,32 +25,75 @@ namespace paddle {
 namespace memory {
 namespace allocation {
 
-class ThreadLocalAllocator
-    : public Allocator,
-      public std::enable_shared_from_this<ThreadLocalAllocator> {
+class ThreadLocalAllocatorImpl;
+
+class ThreadLocalAllocation : public Allocation {
  public:
-  explicit ThreadLocalAllocator(const platform::Place& p) : place_(p) {
-    if (platform::is_gpu_place(place_)) {
-      buddy_allocator_.reset(new memory::detail::BuddyAllocator(
-          std::unique_ptr<memory::detail::SystemAllocator>(
-              new memory::detail::GPUAllocator(
-                  boost::get<platform::CUDAPlace>(place_).device)),
-          platform::GpuMinChunkSize(), platform::GpuMaxChunkSize()));
-    } else {
-      LOG(FATAL) << "Thread local allocator only supports CUDAPlace now.";
-    }
+  ThreadLocalAllocation(void* ptr, size_t size, platform::Place place)
+      : Allocation(ptr, size, place) {}
+
+  void SetThreadLocalAllocatorImpl(
+      std::shared_ptr<ThreadLocalAllocatorImpl> allocator) {
+    allocator_ = allocator;
   }
 
- protected:
-  Allocation* AllocateImpl(size_t size) override;
-  void FreeImpl(Allocation* allocation) override;
+  std::shared_ptr<ThreadLocalAllocatorImpl> GetAllocator() {
+    return allocator_;
+  }
+
+ private:
+  std::shared_ptr<ThreadLocalAllocatorImpl> allocator_;
+};
+
+class ThreadLocalAllocatorImpl
+    : public std::enable_shared_from_this<ThreadLocalAllocatorImpl> {
+ public:
+  explicit ThreadLocalAllocatorImpl(const platform::Place& p);
+  ThreadLocalAllocation* AllocateImpl(size_t size);
+  void FreeImpl(ThreadLocalAllocation* allocation);
 
  private:
   std::unique_ptr<memory::detail::BuddyAllocator> buddy_allocator_;
   platform::Place place_;
 };
 
-const std::shared_ptr<Allocator>& GetThreadLocalAllocator();
+class CUDAThreadLocalAllocatorPool {
+ public:
+  static CUDAThreadLocalAllocatorPool& Instance() {
+    static thread_local CUDAThreadLocalAllocatorPool pool;
+    return pool;
+  }
+
+  std::shared_ptr<ThreadLocalAllocatorImpl> Get(int gpu_id);
+
+ private:
+  CUDAThreadLocalAllocatorPool();
+  std::vector<int> devices_;
+  std::vector<std::unique_ptr<std::once_flag>> init_flags_;
+  std::vector<std::shared_ptr<ThreadLocalAllocatorImpl>> allocators_;
+};
+
+class CUDAThreadLocalAllocator : public Allocator {
+ public:
+  explicit CUDAThreadLocalAllocator(const platform::CUDAPlace& p)
+      : gpu_id_(p.device) {}
+
+  bool IsAllocThreadSafe() const override { return true; }
+
+ protected:
+  Allocation* AllocateImpl(size_t size) override {
+    return CUDAThreadLocalAllocatorPool::Instance().Get(gpu_id_)->AllocateImpl(
+        size);
+  }
+  void FreeImpl(Allocation* allocation) override {
+    auto* tl_allocation = static_cast<ThreadLocalAllocation*>(allocation);
+    auto allocator_impl = tl_allocation->GetAllocator();
+    allocator_impl->FreeImpl(tl_allocation);
+  }
+
+ private:
+  int gpu_id_;
+};
 
 }  // namespace allocation
 }  // namespace memory

--- a/paddle/fluid/memory/allocation/thread_local_allocator.h
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include "paddle/fluid/memory/allocation/allocator.h"
+#include "paddle/fluid/memory/detail/buddy_allocator.h"
+#include "paddle/fluid/memory/detail/system_allocator.h"
+#include "paddle/fluid/platform/gpu_info.h"
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+class ThreadLocalAllocator
+    : public Allocator,
+      public std::enable_shared_from_this<ThreadLocalAllocator> {
+ public:
+  explicit ThreadLocalAllocator(const platform::Place& p) : place_(p) {
+    if (platform::is_gpu_place(place_)) {
+      buddy_allocator_.reset(new memory::detail::BuddyAllocator(
+          std::unique_ptr<memory::detail::SystemAllocator>(
+              new memory::detail::GPUAllocator(
+                  boost::get<platform::CUDAPlace>(place_).device)),
+          platform::GpuMinChunkSize(), platform::GpuMaxChunkSize()));
+    } else {
+      LOG(FATAL) << "Thread local allocator only supports CUDAPlace now.";
+    }
+  }
+
+ protected:
+  Allocation* AllocateImpl(size_t size) override;
+  void FreeImpl(Allocation* allocation) override;
+
+ private:
+  std::unique_ptr<memory::detail::BuddyAllocator> buddy_allocator_;
+  platform::Place place_;
+};
+
+const std::shared_ptr<Allocator>& GetThreadLocalAllocator();
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/memory/allocation/thread_local_allocator.h
+++ b/paddle/fluid/memory/allocation/thread_local_allocator.h
@@ -57,32 +57,32 @@ class ThreadLocalAllocatorImpl
   platform::Place place_;
 };
 
-class CUDAThreadLocalAllocatorPool {
+class ThreadLocalCUDAAllocatorPool {
  public:
-  static CUDAThreadLocalAllocatorPool& Instance() {
-    static thread_local CUDAThreadLocalAllocatorPool pool;
+  static ThreadLocalCUDAAllocatorPool& Instance() {
+    static thread_local ThreadLocalCUDAAllocatorPool pool;
     return pool;
   }
 
   std::shared_ptr<ThreadLocalAllocatorImpl> Get(int gpu_id);
 
  private:
-  CUDAThreadLocalAllocatorPool();
+  ThreadLocalCUDAAllocatorPool();
   std::vector<int> devices_;
   std::vector<std::unique_ptr<std::once_flag>> init_flags_;
   std::vector<std::shared_ptr<ThreadLocalAllocatorImpl>> allocators_;
 };
 
-class CUDAThreadLocalAllocator : public Allocator {
+class ThreadLocalCUDAAllocator : public Allocator {
  public:
-  explicit CUDAThreadLocalAllocator(const platform::CUDAPlace& p)
+  explicit ThreadLocalCUDAAllocator(const platform::CUDAPlace& p)
       : gpu_id_(p.device) {}
 
   bool IsAllocThreadSafe() const override { return true; }
 
  protected:
   Allocation* AllocateImpl(size_t size) override {
-    return CUDAThreadLocalAllocatorPool::Instance().Get(gpu_id_)->AllocateImpl(
+    return ThreadLocalCUDAAllocatorPool::Instance().Get(gpu_id_)->AllocateImpl(
         size);
   }
   void FreeImpl(Allocation* allocation) override {

--- a/paddle/fluid/memory/allocation/thread_local_allocator_test.cc
+++ b/paddle/fluid/memory/allocation/thread_local_allocator_test.cc
@@ -1,0 +1,92 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/memory/allocation/thread_local_allocator.h"
+#include <algorithm>
+#include <condition_variable>  // NOLINT
+#include <functional>
+#include <iostream>
+#include <thread>  // NOLINT
+#include <utility>
+#include "gtest/gtest.h"
+#include "paddle/fluid/platform/gpu_info.h"
+
+DECLARE_double(fraction_of_gpu_memory_to_use);
+
+namespace paddle {
+namespace memory {
+namespace allocation {
+
+TEST(ThreadLocalAllocator, cross_scope_release) {
+  FLAGS_fraction_of_gpu_memory_to_use = 0.1;
+
+  const size_t thread_num = 5;
+  const std::vector<int> devices = platform::GetSelectedDevices();
+
+  std::vector<std::vector<void *>> allocator_addresses(devices.size());
+  std::vector<std::vector<AllocationPtr>> thread_allocations(devices.size());
+  static std::vector<std::shared_ptr<Allocator>> allocators(devices.size());
+
+  for (size_t i = 0; i < devices.size(); ++i) {
+    allocator_addresses[i].resize(thread_num);
+    thread_allocations[i].resize(thread_num);
+    allocators[i] = std::make_shared<CUDAThreadLocalAllocator>(
+        platform::CUDAPlace(devices[i]));
+  }
+
+  std::vector<std::thread> threads(thread_num);
+  std::mutex mutex;
+  std::condition_variable cv;
+  bool flag = false;
+
+  for (size_t i = 0; i < threads.size(); ++i) {
+    threads[i] = std::thread([&, i]() {
+      {
+        std::unique_lock<std::mutex> lock(mutex);
+        cv.wait(lock, [&] { return flag; });
+      }
+      for (size_t j = 0; j < devices.size(); ++j) {
+        auto tl_allocator_impl =
+            CUDAThreadLocalAllocatorPool::Instance().Get(devices[j]);
+        allocator_addresses[j][i] = tl_allocator_impl.get();
+        thread_allocations[j][i] = std::move(allocators[j]->Allocate(10));
+      }
+    });
+  }
+
+  {
+    std::lock_guard<std::mutex> lock(mutex);
+    flag = true;
+    cv.notify_all();
+  }
+
+  for (auto &th : threads) {
+    th.join();
+  }
+
+  for (auto &addresses : allocator_addresses) {
+    std::sort(addresses.begin(), addresses.end());
+    ASSERT_EQ(std::adjacent_find(addresses.begin(), addresses.end(),
+                                 std::equal_to<void *>()),
+              addresses.end());
+  }
+
+  ::testing::FLAGS_gtest_death_test_style = "threadsafe";
+  ASSERT_EXIT(([&]() { thread_allocations.clear(); }(), exit(0)),
+              ::testing::ExitedWithCode(0), ".*");
+}
+
+}  // namespace allocation
+}  // namespace memory
+}  // namespace paddle

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -303,7 +303,8 @@ DEFINE_double(memory_fraction_of_eager_deletion, 1.0,
  * Allocator related FLAG
  * Name: FLAGS_allocator_strategy
  * Since Version: 1.2
- * Value Range: string, {naive_best_fit, auto_growth}, default=auto_growth
+ * Value Range: string, {naive_best_fit, auto_growth, thread_local},
+ * default=auto_growth
  * Example:
  * Note: For selecting allocator policy of PaddlePaddle.
  */


### PR DESCRIPTION
本提交是预测多流的一部分，基于 https://github.com/PaddlePaddle/Paddle/pull/23737 。
1、因为目前显存池隐式要求 GPU 单流顺序计算，为便于计算流绑定线程，新增 `ThreadLocalAllocator` 作为策略 `AllocatorStrategy::kThreadLocal` ，线程独占 `CUDAThreadLocalAllocatorPool`。
2、为支持跨线程 / 跨作用域内存块析构，在 `Allocation` 中保存 `Allocator` 智能指针。
3、此修改将仅在 `AnalysisConfig` **使能 GPU 流绑定线程**时生效，此时 `fraction_of_gpu_memory_to_use` 将由单**进程**显存池空间变为单**线程**显存池空间。其它情况沿用已有策略，所以对现存训练和预测显存分配无影响。

--------------------
还考虑过下面两种修改方式：
1、重构 `CUDADeviceContextAllocator`，但显存池绑定上下文会延迟归还，一定概率造成显存占用增大。
2、只将 `NaiveBestFitAllocator` 设为线程本地变量，但因早先 `BuddyAllocator` 未用智能指针，仍有内存不能归还或归还段错误可能。