### PR TITLE
[cherry-pick] OP(pad, pad2d, pad_constant_like) error message enhancement

### DIFF
--- a/paddle/fluid/operators/pad_op.cc
+++ b/paddle/fluid/operators/pad_op.cc
@@ -25,17 +25,24 @@ class PadOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE(ctx->HasInput("X"), "Input(X) of PadOp should not be null.");
-    PADDLE_ENFORCE(ctx->HasOutput("Out"),
-                   "Output(Out) of PadOp should not be null.");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "Pad");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "Pad");
 
     auto x_dim = ctx->GetInputDim("X");
     auto& paddings = ctx->Attrs().Get<std::vector<int>>("paddings");
-    PADDLE_ENFORCE_EQ(x_dim.size() * 2, int64_t(paddings.size()),
-                      "Size of paddings should be equal to 2 * dimension size "
-                      "of input tensor.");
+    PADDLE_ENFORCE_EQ(
+        static_cast<int>(paddings.size()), x_dim.size() * 2,
+        platform::errors::InvalidArgument(
+            "Size of 'paddings' dimension should be equal to 2 * size of "
+            "Input(X)'s dimension, but received (size of 'paddings' dimension "
+            "is) %d vs (2 * size of Input(X)'s dimension is) %d.",
+            static_cast<int>(paddings.size()), x_dim.size() * 2));
     for (size_t i = 0; i < paddings.size(); ++i) {
-      PADDLE_ENFORCE_GE(paddings[i], 0, "paddings should >= 0.");
+      PADDLE_ENFORCE_GE(paddings[i], 0,
+                        platform::errors::InvalidArgument(
+                            "The element of 'paddings' should >= 0, but "
+                            "received %d for index %d.",
+                            paddings[i], static_cast<int>(i)));
     }
     std::vector<int64_t> out_dims(x_dim.size());
     for (int i = 0; i < x_dim.size(); ++i) {

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6432,6 +6432,9 @@ def pad(x, paddings, pad_value=0., name=None):
             x = fluid.data(name='data', shape=[300, 300], dtype='float32')
             out = fluid.layers.pad(x=x, paddings=[0, 1, 1, 2], pad_value=0.)
     """
+    check_variable_and_dtype(
+        x, 'x', ['float16', 'float32', 'float64', 'int32', 'int64'], "pad")
+
     helper = LayerHelper('pad', input=x, **locals())
     dtype = helper.input_dtype()
     out = helper.create_variable_for_type_inference(dtype)
@@ -6523,6 +6526,10 @@ def pad_constant_like(x, y, pad_value=0., name=None):
             out = fluid.layers.pad_constant_like(x=x, y=y, pad_value=0.)
             # out is a rank 4 tensor variable, and out.shape = [2, 3 ,2 , 3]
     """
+    check_type(x, 'x', (Variable), 'pad_constant_like')
+    check_variable_and_dtype(y, 'y', ['float32', 'float64', 'int32', 'int64'],
+                             "pad_constant_like")
+
     helper = LayerHelper('pad_constant_like', input=x, **locals())
     dtype = helper.input_dtype()
     out = helper.create_variable_for_type_inference(dtype)
@@ -8802,6 +8809,9 @@ def pad2d(input,
             data = fluid.data(name='data', shape=[None, 3, 32, 32], dtype='float32')
             result = fluid.layers.pad2d(input=data, paddings=[0, 1, 2, 3], mode='reflect')
     """
+    check_variable_and_dtype(
+        input, 'input', ['float16', 'float32', 'float64', 'int32', 'int64'],
+        "pad2d")
 
     if in_dygraph_mode():
         _paddings = paddings.numpy().tolist() if isinstance(

--- a/python/paddle/fluid/tests/unittests/test_pad2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad2d_op.py
@@ -15,6 +15,8 @@
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 class TestPad2dOp(OpTest):
@@ -122,6 +124,21 @@ class TestCase7(TestPad2dOp):
         self.mode = "reflect"
         self.data_format = "NCHW"
         self.variable_paddings = True
+
+
+class TestPad2dOpError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            input_data = np.random.random((2, 2, 2, 2)).astype("float32")
+
+            def test_Variable():
+                fluid.layers.pad2d(input=input_data, paddings=[1, 1, 1, 1])
+
+            self.assertRaises(TypeError, test_Variable)
+
+            data = fluid.data(
+                name='data', shape=[None, 3, 20, 20], dtype='float16')
+            fluid.layers.pad2d(input=data, paddings=[1, 1, 1, 1])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
@@ -17,9 +17,11 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
-class TestPadOp(OpTest):
+class TestPadConstantLikeOp(OpTest):
     def setUp(self):
         self.initTestCase()
         self.op_type = "pad_constant_like"
@@ -49,7 +51,7 @@ class TestPadOp(OpTest):
         self.paddings = [(0, 13), (0, 0)]
 
 
-class TestCase1(TestPadOp):
+class TestCase1(TestPadConstantLikeOp):
     def initTestCase(self):
         self.x_shape = (4, 3, 4, 5)
         self.y_shape = (2, 3, 4, 5)
@@ -57,12 +59,33 @@ class TestCase1(TestPadOp):
         self.pad_value = 0.5
 
 
-class TestCase2(TestPadOp):
+class TestCase2(TestPadConstantLikeOp):
     def initTestCase(self):
         self.x_shape = (4, 3, 4, 10)
         self.y_shape = (2, 3, 2, 10)
         self.paddings = [(0, 2), (0, 0), (0, 2), (0, 0)]
         self.pad_value = 0.5
+
+
+class TestPadConstantLikeOpError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            x_data = np.random.random((2, 2, 2, 2)).astype("float32")
+            y_data = np.random.random((2, 2, 2, 2)).astype("float32")
+
+            def test_Variable_x():
+                var_y = fluid.data(
+                    name="data_y", shape=[2, 2, 2, 2], dtype="float32")
+                fluid.layers.pad_constant_like(x=x_data, y=var_y)
+
+            self.assertRaises(TypeError, test_Variable_x)
+
+            def test_Variable_y():
+                var_x = fluid.data(
+                    name="data_x", shape=[2, 2, 2, 2], dtype="float32")
+                fluid.layers.pad_constant_like(x=var_x, y=y_data)
+
+            self.assertRaises(TypeError, test_Variable_y)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_pad_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_op.py
@@ -18,6 +18,8 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid.core as core
+import paddle.fluid as fluid
+from paddle.fluid import Program, program_guard
 
 
 class TestPadOp(OpTest):
@@ -94,6 +96,21 @@ create_test_fp16(TestPadOp)
 create_test_fp16(TestCase1)
 create_test_fp16(TestCase2)
 create_test_fp16(TestCase3)
+
+
+class TestPadOpError(unittest.TestCase):
+    def test_errors(self):
+        with program_guard(Program(), Program()):
+            input_data = np.random.random((2, 2)).astype("float32")
+
+            def test_Variable():
+                fluid.layers.pad(x=input_data, paddings=[1, 1, 1, 1])
+
+            self.assertRaises(TypeError, test_Variable)
+
+            data = fluid.data(name='data', shape=[4], dtype='float16')
+            fluid.layers.pad(x=data, paddings=[0, 1])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
cherry-pick #23882 
OP(pad) error message enhancement for both C++ and python, and provide unittest.
OP(pad2d) error message enhancement for both C++ and python, and provide unittest.
OP(pad_constant_like) error message enhancement for both C++ and python, and provide unittest.