### PR TITLE
fix python35 ci cuda flag not found ;test=develop

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -27,6 +27,8 @@ function(detect_installed_gpus out_variable)
 
     file(WRITE ${cufile} ""
       "#include <cstdio>\n"
+      "#include \"cuda.h\"\n"
+      "#include \"cuda_runtime.h\"\n"
       "int main() {\n"
       "  int count = 0;\n"
       "  if (cudaSuccess != cudaGetDeviceCount(&count)) return -1;\n"


### PR DESCRIPTION
修复这个Python35-CI 找不到cuda flag问题。
![image](https://user-images.githubusercontent.com/29832297/79733632-00964500-8328-11ea-9695-b41107087a9a.png)
