### PR TITLE
add boost dependency to cuda_stream, test=develop

### DIFF
--- a/paddle/fluid/platform/stream/CMakeLists.txt
+++ b/paddle/fluid/platform/stream/CMakeLists.txt
@@ -1,3 +1,3 @@
 IF(WITH_GPU)
-cc_library(cuda_stream SRCS cuda_stream.cc DEPS enforce)
+cc_library(cuda_stream SRCS cuda_stream.cc DEPS enforce boost)
 ENDIF()


### PR DESCRIPTION
添加缺失的依赖。
fix #24030 