### PR TITLE
[CHERRY-PICK2.0]Add note about the time cost and change HTTPS to HTTP to avoid download failed

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -210,7 +210,7 @@ list(APPEND third_party_deps extern_eigen3 extern_gflags extern_glog extern_boos
 list(APPEND third_party_deps extern_zlib extern_dlpack extern_warpctc extern_threadpool)
 
 # download file
-set(CUDAERROR_URL  "https://paddlepaddledeps.bj.bcebos.com/cudaErrorMessage.tar.gz" CACHE STRING "" FORCE)
+set(CUDAERROR_URL  "http://paddlepaddledeps.bj.bcebos.com/cudaErrorMessage.tar.gz" CACHE STRING "" FORCE)
 file_download_and_uncompress(${CUDAERROR_URL} "cudaerror")
 
 if(WITH_AMD_GPU)

--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -843,6 +843,8 @@ def append_gradient_clip_ops(param_grads):
 
 
 # change wrong mapping relation between param & grad in clip op
+# Note: This function is sensitive to the time cost of the network with gradient clipping 
+# and should not be changed easily. If you must change, please test the time cost.
 def _correct_clip_op_role_var(params_grads, param_new_grad_name_dict):
     block_id_list = []
     if len(param_new_grad_name_dict) == 0:


### PR DESCRIPTION
1. 修复问题：将https->http，避免了没有配置curl支持https协议的机器无法下载的问题。

2. 另外添加注释说明：某段函数对静态组网的梯度裁剪耗时较为敏感，勿轻易改动，需要测量时间才能改动。之前忘记添加的注释。