### PR TITLE
update name generator, test=develop

### DIFF
--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -76,7 +76,7 @@ class Tracer {
     return program_desc_tracer_.get();
   }
 
-  std::string GenerateUniqueName(std::string key = "_tmp") {
+  std::string GenerateUniqueName(std::string key = "tmp") {
     return generator_->Generate(key);
   }
 

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -76,7 +76,7 @@ class Tracer {
     return program_desc_tracer_.get();
   }
 
-  std::string GenerateUniqueName(std::string key = "tmp") {
+  std::string GenerateUniqueName(std::string key = "_tmp") {
     return generator_->Generate(key);
   }
 

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -741,6 +741,8 @@ void BindImperative(py::module *m_ptr) {
       .def("_get_program_desc_tracer",
            &imperative::Tracer::GetProgramDescTracer,
            py::return_value_policy::reference)
+      .def("_generate_unique_name", &imperative::Tracer::GenerateUniqueName,
+           py::arg("key") = "tmp")
       .def("trace",
            [](imperative::Tracer &self, const std::string &type,
               const PyNameVarBaseMap &ins, const PyNameVarBaseMap &outs,

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -232,8 +232,7 @@ GenerateOpFunctions(const std::string& module_name) {
     }
     std::string function_args = "";
     if (input_args == "") {
-      function_args =
-          paddle::string::Sprintf(FUNCTION_ARGS_NO_INPUT, input_args);
+      function_args = FUNCTION_ARGS_NO_INPUT;
     } else {
       function_args = paddle::string::Sprintf(FUNCTION_ARGS, input_args);
     }

--- a/python/paddle/fluid/unique_name.py
+++ b/python/paddle/fluid/unique_name.py
@@ -119,11 +119,14 @@ def generate(key):
 # would save model in static graph mode, and load it in dygraph
 # mode. Therefore, we keep the variable name of Parameter currently.
 # 
-# Please fix me if a better method is found.        
+# Please fix me if a better method is found.    
+# 
+# NOTE(zhiqiu): use c++ unique_name_generator in dygraph mode, 
+# in order to keep name consistency.
 def generate_with_ignorable_key(key):
-    from .framework import in_dygraph_mode
+    from .framework import in_dygraph_mode, _dygraph_tracer
     if in_dygraph_mode():
-        key = "tmp"
+        return _dygraph_tracer()._generate_unique_name()
 
     return generator(key)
 


### PR DESCRIPTION
use c++ unique_name_generator for non-parameter variable in dygraph mode, keep consistent.
close #24038 