### PR TITLE
[CHERRY-PICK2.0]fix cudaerror download project name conflicts,which result inference …

### DIFF
--- a/cmake/external/cudaerror.cmake
+++ b/cmake/external/cudaerror.cmake
@@ -1,0 +1,41 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Funciton to Download the dependencies during compilation
+# This function has 2 parameters, URL / DIRNAME:
+# 1. URL:           The download url of 3rd dependencies
+# 2. NAME:          The name of file, that determin the dirname
+#
+FUNCTION(file_download_and_uncompress URL NAME)
+  MESSAGE(STATUS "Download dependence[${NAME}] from ${URL}")
+  SET(${NAME}_INCLUDE_DIR ${THIRD_PARTY_PATH}/${NAME}/data PARENT_SCOPE)
+  ExternalProject_Add(
+      extern_download_${NAME}
+      ${EXTERNAL_PROJECT_LOG_ARGS}
+      PREFIX                ${THIRD_PARTY_PATH}/${NAME}
+      URL                   ${URL}
+      DOWNLOAD_DIR          ${THIRD_PARTY_PATH}/${NAME}/data/
+      SOURCE_DIR            ${THIRD_PARTY_PATH}/${NAME}/data/
+      DOWNLOAD_NO_PROGRESS  1
+      CONFIGURE_COMMAND     ""
+      BUILD_COMMAND         ""
+      UPDATE_COMMAND        ""
+      INSTALL_COMMAND       ""
+    )
+ENDFUNCTION()
+
+# download file
+set(CUDAERROR_URL  "http://paddlepaddledeps.bj.bcebos.com/cudaErrorMessage.tar.gz" CACHE STRING "" FORCE)
+file_download_and_uncompress(${CUDAERROR_URL} "cudaerror")
+list(APPEND third_party_deps extern_download_cudaerror)

--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -135,10 +135,14 @@ copy(inference_lib_dist
         SRCS ${THREADPOOL_INCLUDE_DIR}/ThreadPool.h
         DSTS ${dst_dir})
 
-set(dst_dir "${FLUID_INFERENCE_INSTALL_DIR}/third_party/cudaerror/data")
-copy(inference_lib_dist
-        SRCS ${cudaerror_INCLUDE_DIR}
-        DSTS ${dst_dir})
+# Only GPU need cudaErrorMessage.pb
+IF(WITH_GPU)
+        set(dst_dir "${FLUID_INFERENCE_INSTALL_DIR}/third_party/cudaerror/data")
+        copy(inference_lib_dist
+                SRCS ${cudaerror_INCLUDE_DIR}
+                DSTS ${dst_dir})
+ENDIF()
+
 
 # CMakeCache Info
 copy(inference_lib_dist

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -102,31 +102,6 @@ MACRO(UNSET_VAR VAR_NAME)
     UNSET(${VAR_NAME})
 ENDMACRO()
 
-# Funciton to Download the dependencies during compilation
-# This function has 2 parameters, URL / DIRNAME:
-# 1. URL:           The download url of 3rd dependencies
-# 2. NAME:          The name of file, that determin the dirname
-#
-MACRO(file_download_and_uncompress URL NAME)
-  MESSAGE(STATUS "Download dependence[${NAME}] from ${URL}")
-  SET(EXTERNAL_PROJECT_NAME "extern_download_${NAME}")
-  SET(${NAME}_INCLUDE_DIR ${THIRD_PARTY_PATH}/${NAME}/data)
-  ExternalProject_Add(
-      ${EXTERNAL_PROJECT_NAME}
-      ${EXTERNAL_PROJECT_LOG_ARGS}
-      PREFIX                ${THIRD_PARTY_PATH}/${NAME}
-      URL                   ${URL}
-      DOWNLOAD_DIR          ${THIRD_PARTY_PATH}/${NAME}/data/
-      SOURCE_DIR            ${THIRD_PARTY_PATH}/${NAME}/data/
-      DOWNLOAD_NO_PROGRESS  1
-      CONFIGURE_COMMAND     ""
-      BUILD_COMMAND         ""
-      UPDATE_COMMAND        ""
-      INSTALL_COMMAND       ""
-    )
-  list(APPEND third_party_deps ${EXTERNAL_PROJECT_NAME})
-ENDMACRO()
-
 
 # Correction of flags on different Platform(WIN/MAC) and Print Warning Message
 if (APPLE)
@@ -209,10 +184,6 @@ include(external/warpctc)   # download, build, install warpctc
 list(APPEND third_party_deps extern_eigen3 extern_gflags extern_glog extern_boost extern_xxhash)
 list(APPEND third_party_deps extern_zlib extern_dlpack extern_warpctc extern_threadpool)
 
-# download file
-set(CUDAERROR_URL  "https://paddlepaddledeps.bj.bcebos.com/cudaErrorMessage.tar.gz" CACHE STRING "" FORCE)
-file_download_and_uncompress(${CUDAERROR_URL} "cudaerror")
-
 if(WITH_AMD_GPU)
     include(external/rocprim)   # download, build, install rocprim
     list(APPEND third_party_deps extern_rocprim)
@@ -248,6 +219,7 @@ IF(WITH_TESTING OR (WITH_DISTRIBUTE AND NOT WITH_GRPC))
 ENDIF()
 
 if(WITH_GPU)
+    include(external/cudaerror)  # download cudaErrorMessage.pb
     include(external/cub)       # download cub
     list(APPEND third_party_deps extern_cub)
 endif(WITH_GPU)

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -1,6 +1,8 @@
 proto_library(profiler_proto SRCS profiler.proto DEPS framework_proto simple_threadpool)
 proto_library(error_codes_proto SRCS error_codes.proto)
-proto_library(cuda_error_proto SRCS cuda_error.proto)
+if(WITH_GPU)
+  proto_library(cuda_error_proto SRCS cuda_error.proto)
+endif(WITH_GPU)
 
 if (WITH_PYTHON)
   py_proto_compile(profiler_py_proto SRCS profiler.proto)
@@ -28,7 +30,11 @@ cc_library(flags SRCS flags.cc DEPS gflags)
 cc_library(errors SRCS errors.cc DEPS error_codes_proto)
 cc_test(errors_test SRCS errors_test.cc DEPS errors enforce)
 
-cc_library(enforce INTERFACE SRCS enforce.cc DEPS flags errors cuda_error_proto)
+set(enforce_deps flags errors)
+if(WITH_GPU)
+  set(enforce_deps ${enforce_deps} cuda_error_proto)
+endif()
+cc_library(enforce INTERFACE SRCS enforce.cc DEPS ${enforce_deps})
 cc_test(enforce_test SRCS enforce_test.cc DEPS stringpiece enforce)
 
 set(CPU_INFO_DEPS gflags glog enforce)

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -31,6 +31,7 @@ limitations under the License. */
 #include <curand.h>
 #include <thrust/system/cuda/error.h>
 #include <thrust/system_error.h>
+#include "paddle/fluid/platform/cuda_error.pb.h"
 #endif  // PADDLE_WITH_CUDA
 
 #include <fstream>
@@ -45,7 +46,6 @@ limitations under the License. */
 
 #define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
 #include "glog/logging.h"
-#include "paddle/fluid/platform/cuda_error.pb.h"
 #include "paddle/fluid/platform/errors.h"
 #include "paddle/fluid/platform/macros.h"
 #include "paddle/fluid/platform/port.h"

--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -843,6 +843,8 @@ def append_gradient_clip_ops(param_grads):
 
 
 # change wrong mapping relation between param & grad in clip op
+# Note: This function is sensitive to the time cost of the network with gradient clipping 
+# and should not be changed easily. If you must change, please test the time cost.
 def _correct_clip_op_role_var(params_grads, param_new_grad_name_dict):
     block_id_list = []
     if len(param_new_grad_name_dict) == 0:

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -331,7 +331,6 @@ headers = (
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/string')) +
     list(find_files('*.pb.h', '${PADDLE_BINARY_DIR}/paddle/fluid/platform')) +
     list(find_files('*.pb.h', '${PADDLE_BINARY_DIR}/paddle/fluid/framework')) +
-    list(find_files('*.pb', '${cudaerror_INCLUDE_DIR}')) + # errorMessage.pb for errormessage
     ['${EIGEN_INCLUDE_DIR}/Eigen/Core'] + # eigen
     list(find_files('*', '${EIGEN_INCLUDE_DIR}/Eigen/src')) + # eigen
     list(find_files('*', '${EIGEN_INCLUDE_DIR}/unsupported/Eigen')) + # eigen
@@ -346,6 +345,8 @@ headers = (
 if '${WITH_MKLDNN}' == 'ON':
     headers += list(find_files('*', '${MKLDNN_INSTALL_DIR}/include')) # mkldnn
 
+if '${WITH_GPU}' == 'ON':
+    headers += list(find_files('*.pb', '${cudaerror_INCLUDE_DIR}')) + # errorMessage.pb for errormessage
 
 class InstallCommand(InstallCommandBase):
     def finalize_options(self):
@@ -405,7 +406,8 @@ class InstallHeaders(Command):
     def run(self):
         # only copy third_party/cudaErrorMessage.pb for cudaErrorMessage on mac or windows
         if os.name == 'nt' or sys.platform == 'darwin':
-            self.mkdir_and_copy_file('${cudaerror_INCLUDE_DIR}/cudaErrorMessage.pb')
+            if '${WITH_GPU}' == 'ON':
+                self.mkdir_and_copy_file('${cudaerror_INCLUDE_DIR}/cudaErrorMessage.pb')
             return
         hdrs = self.distribution.headers
         if not hdrs:


### PR DESCRIPTION
CHERRY-PICK #24051 
===

1. 修复cmake下载函数里命名冲突的问题，可能会导致预测缓存无法命中，重复下载。

2. 修复问题：将https->http，避免了没有配置curl支持https协议和openssl的机器，无法下载的问题。

3. 另外添加注释说明：某段函数对静态组网的梯度裁剪耗时较为敏感，之前未添加的注释。