### PR TITLE
Fix some problems in StaticModelRunner

### DIFF
--- a/python/paddle/fluid/dygraph/static_runner.py
+++ b/python/paddle/fluid/dygraph/static_runner.py
@@ -334,11 +334,15 @@ class StaticModelRunner(layers.Layer):
                 self._output_names.append(cpt.to_bytes(op.input('X')[0]))
                 self._output_descs.append(
                     root_block.find_var(cpt.to_bytes(op.input('X')[0])))
-            elif op.type() == 'fetch' and op.input('X')[0].startswith(
-                    'save_infer_model/scale_'):
+            elif op.type() == 'fetch':
                 ops_to_remove.append(i)
                 fetch_var_name = cpt.to_bytes(op.output('Out')[0])
                 root_block._remove_var(fetch_var_name)
+                # NOTE: some old pre-train models have no extra scale_op
+                if not op.input('X')[0].startswith('save_infer_model/scale_'):
+                    self._output_names.append(cpt.to_bytes(op.input('X')[0]))
+                    self._output_descs.append(
+                        root_block.find_var(cpt.to_bytes(op.input('X')[0])))
             else:
                 if op.has_attr("op_callstack"):
                     op.remove_attr("op_callstack")

--- a/python/paddle/fluid/tests/unittests/test_imperative_static_runner_while.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_static_runner_while.py
@@ -136,7 +136,7 @@ class TestImperativeStaticModelRunnerWhile(unittest.TestCase):
                 label = data[1]
                 label.stop_gradient = True
 
-                cost = while_net(inputs=img)
+                cost = while_net(img)
 
                 loss = fluid.layers.cross_entropy(cost, label)
                 avg_loss = fluid.layers.mean(loss)


### PR DESCRIPTION
 fix some problems in StaticModelRunner:

1. save model no extra `scale`

Now in paddle, the model saved by `save_inference_model` will add extra `scale` layer before `fetch`, but this feture is added before a year, the model was trained before one year may not hold this `scale` layer, this PR adapt this case.

2. inference result error

inferencing use changed program desc by StaticModelRunner, only change `is_test` is not equal to using original program desc, so changing using original loaded program desc.

3. multiple inputs order error

reverse input variables order

4. change forward `inputs` to `*args`

support multiple inputs instead of list[var]

5. polish doc