### PR TITLE
Dev/add fake_interface_only decorator for some function of Variable

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -3879,7 +3879,6 @@ class Program(object):
     def _version(self):
         return self.desc._version()
 
-    @dygraph_not_support
     def clone(self, for_test=False):
         """
         **Notes**:
@@ -4555,7 +4554,6 @@ class Program(object):
                 if other_var.stop_gradient:
                     var.stop_gradient = True
 
-    @dygraph_not_support
     def list_vars(self):
         """
         Get all :ref:`api_guide_Variable_en` from this Program. A iterable object is returned.
@@ -4578,7 +4576,6 @@ class Program(object):
             for each_var in list(each_block.vars.values()):
                 yield each_var
 
-    @dygraph_not_support
     def all_parameters(self):
         """
         Get all :ref:`api_guide_parameter_en` from this Program. A list object is returned.

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -217,6 +217,24 @@ def _dygraph_only_(func):
     return __impl__
 
 
+# NOTE(zhiqiu): This decorator is used for the APIs of Variable which is only
+# used to make Variable and VarBase has same interfaces, like numpy. Since VarBase is not exposed in our
+# official docments, logically, we want to keep VarBase and logically consistent. While, actually,
+# in our implementation, there some APIs not supported, like numpy, because Variable contains the desc.
+# So, those APIs are listed under class Variable to generate docs only.
+# TODO(zhiqiu): We should make VarBase consistent with Variable, for example, by inheritting
+# same base class. 
+def _fake_interface_only_(func):
+    def __impl__(*args, **kwargs):
+        #   if in_dygraph_mode():
+        #       raise AssertionError("We Only support %s in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode" % func.__name__
+        #   else:
+        #       raise AssertionError("We Only support %s in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode" % func.__name__
+        return func(*args, **kwargs)
+
+    return __impl__
+
+
 dygraph_not_support = wrap_decorator(_dygraph_not_support_)
 dygraph_only = wrap_decorator(_dygraph_only_)
 
@@ -1199,9 +1217,6 @@ class Variable(object):
                 print("=============with detail===============")
                 print(new_variable.to_string(True, True))
         """
-        if in_dygraph_mode():
-            return
-
         assert isinstance(throw_on_error, bool) and isinstance(with_details,
                                                                bool)
         protostr = self.desc.serialize_to_string()

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -202,7 +202,7 @@ def in_dygraph_mode():
 def _dygraph_not_support_(func):
     def __impl__(*args, **kwargs):
         assert not in_dygraph_mode(
-        ), "We don't support %s in Dygraph mode" % func.__name__
+        ), "We don't support %s in imperative mode" % func.__name__
         return func(*args, **kwargs)
 
     return __impl__
@@ -211,7 +211,7 @@ def _dygraph_not_support_(func):
 def _dygraph_only_(func):
     def __impl__(*args, **kwargs):
         assert in_dygraph_mode(
-        ), "We Only support %s in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode" % func.__name__
+        ), "We Only support %s in imperative mode, please use fluid.dygraph.guard() as context to run it in imperative Mode" % func.__name__
         return func(*args, **kwargs)
 
     return __impl__
@@ -227,7 +227,7 @@ def _dygraph_only_(func):
 def _fake_interface_only_(func):
     def __impl__(*args, **kwargs):
         raise AssertionError(
-            "'%s' should be called by Dygraph Varible in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode"
+            "'%s' should be called by imperative Varible in imperative mode, please use fluid.dygraph.guard() as context to run it in imperative mode"
             % func.__name__)
 
     return __impl__

--- a/python/paddle/fluid/tests/unittests/test_detach.py
+++ b/python/paddle/fluid/tests/unittests/test_detach.py
@@ -158,7 +158,7 @@ class Test_Detach(unittest.TestCase):
             assert type(e) == AssertionError
             assert str(
                 e
-            ) == 'We Only support detach in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode'
+            ) == "'detach' should be called by Dygraph Varible in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode"
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_detach.py
+++ b/python/paddle/fluid/tests/unittests/test_detach.py
@@ -158,7 +158,7 @@ class Test_Detach(unittest.TestCase):
             assert type(e) == AssertionError
             assert str(
                 e
-            ) == "'detach' should be called by Dygraph Varible in Dygraph mode, please use fluid.dygraph.guard() as context to run it in Dygraph Mode"
+            ) == "'detach' should be called by imperative Varible in imperative mode, please use fluid.dygraph.guard() as context to run it in imperative mode"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In PR #21359, we split VarBase from Variable. Currently, Variable (for static graph) and VarBase (for dygraph) are logically same type for developers. However, some of the internal APIs has small differences. This PR handles those APIs.

1.  Some functions of Variable is not supported, such as `detach()`. Historically, these APIs are decorated by `dygraph_only` when VarBase have not been split from Variable. Basically, we should remove them.  While, actually, now we keep these functions under class Variable for generating API docs only, since VarBase is not exposed and not mentioned in our official website. 
So, I add a `fake_interface_only` decorator for those APIs.

2. Some functions of Variable is not supported for dygraph Variable when VarBase have not been split from Variable, like `lod_level`. Historically, these APIs are decorated by `dygraph_not_support`. Since we have split VarBase, users cannot access these APIs by  VarBase.
So, I remove the `dygraph_not_support` decorators for those APIs.

