### PR TITLE
fix error when out is not None in std api

### DIFF
--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -151,7 +151,7 @@ def std(input, axis=None, keepdim=False, unbiased=True, out=None, name=None):
 
     tmp = var(input, axis=axis, keepdim=keepdim, unbiased=unbiased, name=name)
     tmp = layers.sqrt(tmp)
-    if out:
+    if out is not None:
         layers.assign(input=tmp, output=out)
         return out
     else:


### PR DESCRIPTION
当out是Variable, if out 判断的不是out是否为None, 触发了动态图中的bool判断，https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/dygraph/varbase_patch_methods.py#L209， 所以改为 if out is not None