### PR TITLE
Fix `paddle.nn.loss.CrossEntropyLoss` op English doc

### DIFF
--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -26,20 +26,22 @@ __all__ = [
 
 class CrossEntropyLoss(fluid.dygraph.Layer):
     """
-    This operator implements the cross entropy loss function. This OP combines `softmax`,
-    `cross_entropy`, and `reduce_sum`/`reduce_mean` together.
+    This operator implements the cross entropy loss function. This OP combines ``softmax``,
+    ``cross_entropy``, and ``reduce_sum``/``reduce_mean`` together.
 
-    It is useful when training a classification problem with `C` classes.
-    If provided, the optional argument `weight` should be a 1D Variable assigning
+    It is useful when training a classification problem with ``C`` classes.
+    If provided, the optional argument ``weight`` should be a 1D Variable assigning
     weight to each of the classes.
 
     For predictions label, and target label, the loss is calculated as follows.
+
     .. math::
 
         loss_j =  -\\text{input[class]} +
         \\log\\left(\\sum_{i=0}^{K}\\exp(\\text{input}_i)\\right), j = 1,..., K
 
-    If weight is not `None`:
+    If weight is not ``None``:
+
     .. math::
 
         loss_j =  \\text{weight[class]}(-\\text{input[class]} +
@@ -59,9 +61,12 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned.
             If :attr:`reduction` is ``'none'``, the unreduced loss is returned.
             Default is ``'mean'``.
+
     Returns:
         The tensor variable storing the cross_entropy_loss of input and label.
+
     Return type: Variable.
+
     Examples:
         .. code-block:: python
 


### PR DESCRIPTION
After fix，Preview：
![image](https://user-images.githubusercontent.com/15628872/80073044-b3111680-8579-11ea-8020-661f63695cf8.png)
![image](https://user-images.githubusercontent.com/15628872/80073075-c328f600-8579-11ea-956d-fffebd8a134c.png)
![image](https://user-images.githubusercontent.com/15628872/80073107-d045e500-8579-11ea-95e5-6f535aae5c1a.png)
