### PR TITLE
[Paddle-TRT] fix memory leak and unsafe emb_norm plugin

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
@@ -73,6 +73,16 @@ int EmbEltwiseLayernormPluginDynamic<T>::initialize() {
 }
 
 template <typename T>
+void EmbEltwiseLayernormPluginDynamic<T>::terminate() {
+  for (auto ptr : embs_gpu_) {
+    if (ptr) cudaFree(ptr);
+  }
+
+  if (bias_gpu_) cudaFree(bias_gpu_);
+  if (scale_gpu_) cudaFree(scale_gpu_);
+}
+
+template <typename T>
 size_t EmbEltwiseLayernormPluginDynamic<T>::getSerializationSize() const {
   return 0;
 }

--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
@@ -47,9 +47,13 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
   EmbEltwiseLayernormPluginDynamic(void const* serialData,
                                    size_t serialLength) {}
   nvinfer1::IPluginV2DynamicExt* clone() const override {
-    return new EmbEltwiseLayernormPluginDynamic(
+    auto ptr = new EmbEltwiseLayernormPluginDynamic(
         embs_, bias_, scale_, emb_sizes_, bias_size_, scale_size_, hidden_size_,
         eps_);
+    ptr->embs_gpu_ = embs_gpu_;
+    ptr->bias_gpu_ = bias_gpu_;
+    ptr->scale_gpu_ = scale_gpu_;
+    return ptr;
   }
 
   const char* getPluginType() const override {
@@ -57,6 +61,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
   }
   int getNbOutputs() const override { return 1; }
   int initialize() override;
+  void terminate() override;
 
   size_t getSerializationSize() const override;
   void serialize(void* buffer) const override;


### PR DESCRIPTION
`IPlugin*::initialize` and `IPlugin*::terminate` should be always implemented as a pair. Also, resources acquired in `IPlugin*::initialize` should be released in `IPlugin*::terminate`.  Otherwise, it causes memory leak.

The all data members of cloned plugin must be set in `PluginV2::clone`. The plugin only calls `IPlugin*::initialize` once when creating ICudaEngine. The cloned plugin won't call `IPlugin*::initialize` after IExecutionContext is created, but TensorRT may clone the plugin during the creation of IExecutionContext and use the cloned plugin to infer the model.

Read https://docs.nvidia.com/deeplearning/sdk/tensorrt-developer-guide/index.html#ipluginext to know more.