### PR TITLE
support fetch the feed var when use_prune=True, test=develop

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -4163,6 +4163,14 @@ class Program(object):
                     raise ValueError(
                         "All targets of Program._prune_with_input() can only be "
                         "Variable or Operator, but received %s." % type(t))
+
+                # NOTEZ(zhiqiu): For variable to be fed in fetch_list, there two cases:
+                # (1) the variable is leaf, it has no op that generates it;
+                # (2) the variable is not leaf, and we need to prune the op that generates it.
+                # In both cases, wo can just skip target_op of that it.
+                if name in feeded_var_names:
+                    continue
+
                 # After transpiler processing, the op that output this
                 # variable maybe has been changed, so t.op is not reliable
                 # and we need to find the current op that generate this
@@ -4179,11 +4187,14 @@ class Program(object):
                         else:
                             target_op = op
                             break
-                t = target_op
-                if t is None:
-                    raise ValueError("The target variable must have an "
-                                     "associated operator that generates it.")
-            targets_idx.append([t.block.idx, t.idx])
+                if target_op is None:
+                    raise ValueError(
+                        "The target variable used for pruning should have an "
+                        "associated operator that generates it.")
+                else:
+                    targets_idx.append([target_op.block.idx, target_op.idx])
+            else:
+                targets_idx.append([t.block.idx, t.idx])
 
         res = Program()
         res.desc, pruned_origin_block_id_map = core.prune(self.desc,


### PR DESCRIPTION
This PR supports the rare case when user adds feed variables in fetch_list, and set `use_prune=True` in `exe.run()` in the model.

Code example,
```
x1 = fluid.data(name="x_1", shape=[None, 3, 4], dtype="float32")
x2 = fluid.data(name="x_2", shape=[None, 3, 4], dtype="float32")
x3 = fluid.data(name="x_3", shape=[None, 3, 4], dtype="float32")
x4 = fluid.data(name="x_4", shape=[None, 3, 4], dtype="float32")

output1 = fluid.layers.elementwise_add(x1, x2)
place = fluid.CPUPlace()
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
input1 = np.random.random(size=(3, 3, 4)).astype("float32")
input2 = np.random.random(size=(3, 3, 4)).astype("float32")

feedData = {"x_1": input1, "x_2": input2}
fetch_list = [x1.name, x2.name, output1.name] # x1 and x2 is the feed variable
x1, x2, res1 = exe.run(feed=feedData, fetch_list=fetch_list)
```

close https://github.com/PaddlePaddle/Paddle/issues/24069

