### PR TITLE
avoid warnings in MAC compile

### DIFF
--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -484,8 +484,8 @@ class OperatorWithKernel : public OperatorBase {
       const std::string& var_name, const Tensor& tensor,
       const OpKernelType& expected_kernel_type) const;
 
-  virtual platform::Place GetExecutionPlace(
-      const platform::Place& platform) const {
+  platform::Place GetExecutionPlace(
+      const platform::Place& platform) const override {
     return kernel_type_->place_;
   }
 


### PR DESCRIPTION
avoid warnings in MAC compile, [details](https://github.com/PaddlePaddle/Paddle/pull/23327#issuecomment-617802786)
```
[11:37:24]	[Step 1/1] /home/teamcity/work/46c9546acda8e8c6/paddle/fluid/framework/operator.h:487:27: warning: 'GetExecutionPlace' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
[11:37:24]	[Step 1/1]   virtual platform::Place GetExecutionPlace(
[11:37:24]	[Step 1/1]                           ^
[11:37:24]	[Step 1/1] /home/teamcity/work/46c9546acda8e8c6/paddle/fluid/framework/operator.h:195:27: note: overridden virtual function is here
[11:37:24]	[Step 1/1]   virtual platform::Place GetExecutionPlace(
[11:37:24]	[Step 1/1]                           ^
[11:37:24]	[Step 1/1] 1 warning generated.
```