### PR TITLE
fix the set dtype bug of uniform_random op

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14310,7 +14310,7 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0):
 
     helper = LayerHelper("uniform_random", **locals())
     inputs = dict()
-    attrs = {'seed': seed, 'min': min, 'max': max}
+    attrs = {'seed': seed, 'min': min, 'max': max, 'dtype': dtype}
     if in_dygraph_mode():
         attrs['shape'] = shape
     else:

--- a/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
+++ b/python/paddle/fluid/tests/unittests/test_uniform_random_op.py
@@ -190,6 +190,12 @@ class TestUniformRandomOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_dtype)
 
+            def test_out_dtype():
+                out = fluid.layers.uniform_random(shape=[3, 4], dtype='float64')
+                self.assertEqual(out.dtype, fluid.core.VarDesc.VarType.FP64)
+
+            test_out_dtype()
+
 
 class TestUniformRandomOpWithDiagInit(TestUniformRandomOp):
     def init_attrs(self):


### PR DESCRIPTION
Fix the set dtype bug of uniform_random op. 
The attrs of  uniform_random is missing, and the dtype of out variable will always be the default FP32. 
