### PR TITLE
[INT8] Add requant-op squash

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -913,6 +913,22 @@ struct OpRequant : public PatternBase {
   PATTERN_DECL_NODE(requant_out);
 };
 
+// Requant + Op
+// named nodes:
+// requant_in, requant_op,
+// requant_out, any_op
+struct RequantOp : public PatternBase {
+  RequantOp(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "requant_op") {}
+
+  PDNode* operator()();
+
+  PATTERN_DECL_NODE(any_op);
+  PATTERN_DECL_NODE(requant_in);
+  PATTERN_DECL_NODE(requant_op);
+  PATTERN_DECL_NODE(requant_out);
+};
+
 // Conv + Dequant
 // named nodes:
 // conv_op, conv_out

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.cc
@@ -170,8 +170,8 @@ void CPUQuantizeSquashPass::OpRequantSquash(Graph* graph) const {
                   found_requant_squash_count);
 }
 
-// op+requant squash if op has Scale_in, Scale_x, Scale_y attr
-// conv2d and fc
+// requant-op squash if op has Scale_in, Scale_x, Scale_y attr
+// conv2d, fc, matmul
 void CPUQuantizeSquashPass::RequantOpSquash(Graph* graph) const {
   GraphPatternDetector gpd;
   patterns::RequantOp requant_op_pattern{gpd.mutable_pattern(), "requant_op"};

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.h
@@ -56,6 +56,11 @@ class CPUQuantizeSquashPass : public FusePassBase {
   void OpRequantSquash(Graph* graph) const;
 
   /*
+   * Squash requantize op into conv with scale_out like requantize scale_out
+   */
+  void RequantOpSquash(Graph* graph) const;
+
+  /*
   *  Squash conv2d with dequant when dequant is the only op after conv2d
   */
   void ConvDequantSquash(Graph* graph) const;

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.h
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_squash_pass.h
@@ -56,7 +56,7 @@ class CPUQuantizeSquashPass : public FusePassBase {
   void OpRequantSquash(Graph* graph) const;
 
   /*
-   * Squash requantize op into conv with scale_out like requantize scale_out
+   * Squash requantize op if the next operator's input scale can be updated
    */
   void RequantOpSquash(Graph* graph) const;
 


### PR DESCRIPTION
This PR presents:
- `requantize-op squash` , which removes requantize operator if it occurs before the operator in which we can skip input scaling.

The image below shows this squash on the matmula operator.
<img width="566" alt="diag" src="https://user-images.githubusercontent.com/33838455/80208452-8b30ba00-8630-11ea-98d4-e96240701291.png">


For now it is enabled `matmul`, `fc` and `conv`.