### PR TITLE
Revert "update mklml.cmake to 2019.0.5 (#24022)"

### DIFF
--- a/cmake/external/mklml.cmake
+++ b/cmake/external/mklml.cmake
@@ -32,8 +32,8 @@ IF(WIN32)
     SET(MKLML_SHARED_IOMP_LIB     ${MKLML_LIB_DIR}/libiomp5md.dll)
 ELSE()
     #TODO(intel-huying):
-    #  Now enable csrmm function in mklml library temporarily, it will be updated as offical version later.
-    SET(MKLML_VER "Csrmm_mklml_lnx_2019.0.5.20190502" CACHE STRING "" FORCE)
+    #  Now enable Erf function in mklml library temporarily, it will be updated as offical version later.
+    SET(MKLML_VER "csrmm2_mklml_lnx_2019.0.2" CACHE STRING "" FORCE)
     SET(MKLML_URL "http://paddlepaddledeps.bj.bcebos.com/${MKLML_VER}.tgz" CACHE STRING "" FORCE)
     SET(MKLML_LIB                 ${MKLML_LIB_DIR}/libmklml_intel.so)
     SET(MKLML_IOMP_LIB            ${MKLML_LIB_DIR}/libiomp5.so)


### PR DESCRIPTION
This reverts commit 652e804b411afa4669f1f2c8446cc18e57b07a98.
test=develop

![image](https://user-images.githubusercontent.com/6836917/80230101-05d6f500-8684-11ea-8b41-b10d0737030f.png)
![image](https://user-images.githubusercontent.com/6836917/80299586-2019eb80-87c8-11ea-9788-5d7a7f8736ac.png)

Similar to https://github.com/PaddlePaddle/Paddle/pull/15872#issue-255267471