### PR TITLE
copy api from paddle to paddle.fluid

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -35,7 +35,8 @@ __all__ = [
     'Conv2D', 'Conv3D', 'Pool2D', 'Linear', 'BatchNorm', 'Dropout', 'Embedding',
     'GRUUnit', 'InstanceNorm', 'LayerNorm', 'NCE', 'PRelu',
     'BilinearTensorProduct', 'Conv2DTranspose', 'Conv3DTranspose', 'GroupNorm',
-    'SpectralNorm', 'TreeConv'
+    'SpectralNorm', 'TreeConv', 'CrossEntropyLoss', 'MSELoss', 'L1Loss',
+    'NLLLoss', 'BCELoss'
 ]
 
 
@@ -3122,3 +3123,560 @@ class TreeConv(layers.Layer):
         else:
             pre_activation = out
         return self._helper.append_activation(pre_activation, act=self._act)
+
+
+class CrossEntropyLoss(layers.Layer):
+    """
+    This operator implements the cross entropy loss function. This OP combines `softmax`,
+    `cross_entropy`, and `reduce_sum`/`reduce_mean` together.
+
+    It is useful when training a classification problem with `C` classes.
+    If provided, the optional argument `weight` should be a 1D Variable assigning
+    weight to each of the classes.
+
+    For predictions label, and target label, the loss is calculated as follows.
+    .. math::
+
+        loss_j =  -\\text{input[class]} +
+        \\log\\left(\\sum_{i=0}^{K}\\exp(\\text{input}_i)\\right), j = 1,..., K
+
+    If weight is not `None`:
+    .. math::
+
+        loss_j =  \\text{weight[class]}(-\\text{input[class]} +
+        \\log\\left(\\sum_{i=0}^{K}\\exp(\\text{input}_i)\\right)), j = 1,..., K
+
+    Parameters:
+        input (Variable): Input tensor, the data type is float32,
+            float64, int32, int64.
+        label (Variable): Label tensor, the data type is float32,
+            float64, int32, int64.
+        weight (Variable, optional): Weight tensor, a manual rescaling weight given
+            to each class. It has the same dimensions as class number and the data type
+            is float32, float64, int32, int64. Default is ``'None'``.
+        reduction (str, optional): Indicate how to average the loss by batch_size,
+            the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned;
+            If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned.
+            If :attr:`reduction` is ``'none'``, the unreduced loss is returned.
+            Default is ``'mean'``.
+    Returns:
+        The tensor variable storing the cross_entropy_loss of input and label.
+    Return type: Variable.
+    Examples:
+        .. code-block:: python
+
+            # declarative mode
+            import paddle.fluid as fluid
+            import numpy as np
+
+            input = fluid.layers.data(name='input', shape=[5, 100], dtype='float32')
+            label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
+            weight = fluid.layers.data(name='weight', shape=[100], dtype='float32')
+            ce_loss = fluid.dygraph.CrossEntropyLoss(weight=weight, reduction='mean')
+            output = ce_loss(input,label)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+            input_data = np.random.random([5, 100]).astype("float32")
+            label_data = np.array([[1], [9], [40], [50], [90]]).astype("int64")
+            weight_data = np.random.random([100]).astype("float32")
+            output = exe.run(fluid.default_main_program(),
+                        feed={"input": input_data, "label": label_data,"weight": weight_data},
+                        fetch_list=[output],
+                        return_numpy=True)
+            print(output)
+
+            # imperative mode
+            import paddle.fluid.dygraph as dg
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_data)
+                label = dg.to_variable(label_data)
+                weight = dg.to_variable(weight_data)
+                ce_loss = fluid.dygraph.CrossEntropyLoss(weight=weight, reduction='mean')
+                output = ce_loss(input, label)
+                print(output.numpy())
+    """
+
+    def __init__(self, weight=None, reduction='mean'):
+        super(CrossEntropyLoss, self).__init__()
+        self.weight = weight
+        self.reduction = reduction
+
+    def forward(self, input, label):
+        check_variable_and_dtype(input, 'input',
+                                 ['float32', 'float64', 'int32', 'int64'],
+                                 'cross_entropy_loss')
+        check_variable_and_dtype(label, 'label',
+                                 ['float32', 'float64', 'int32', 'int64'],
+                                 'cross_entropy_loss')
+
+        if self.reduction not in ['sum', 'mean', 'none']:
+            raise ValueError(
+                "The value of 'reduction' in cross_entropy_loss should be 'sum', 'mean' or 'none',"
+                " but received %s, which is not allowed." % self.reduction)
+
+        softmax_out = layers.softmax(input)
+        if self.weight is not None:
+            if isinstance(self.weight, Variable):
+                softmax_out = layers.elementwise_pow(
+                    softmax_out, self.weight, axis=-1)
+            else:
+                raise ValueError(
+                    "The weight' is not a Variable, please convert to Variable.")
+
+        out = layers.cross_entropy(softmax_out, label)
+
+        if self.reduction == 'sum':
+            return layers.reduce_sum(out)
+        elif self.reduction == 'mean':
+            return layers.reduce_mean(out)
+        else:
+            return out
+
+
+class MSELoss(layers.Layer):
+    """
+    **Mean Square Error Loss**
+    Computes the mean square error (squared L2 norm) of given input and label.
+
+    If :attr:`reduction` is set to ``'none'``, loss is calculated as:
+
+    .. math::
+        Out = (input - label)^2
+
+    If :attr:`reduction` is set to ``'mean'``, loss is calculated as:
+
+    .. math::
+        Out = \operatorname{mean}((input - label)^2)
+
+    If :attr:`reduction` is set to ``'sum'``, loss is calculated as:
+
+    .. math::
+        Out = \operatorname{sum}((input - label)^2)
+
+    where `input` and `label` are `float32` tensors of same shape.
+
+    Parameters:
+        input (Variable): Input tensor, the data type is float32,
+        label (Variable): Label tensor, the data type is float32,
+        reduction (string, optional): The reduction method for the output,
+            could be 'none' | 'mean' | 'sum'.
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned. 
+            If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned. 
+            If :attr:`reduction` is ``'none'``, the unreduced loss is returned. 
+            Default is ``'mean'``.
+
+    Returns:
+        The tensor variable storing the MSE loss of input and label.
+
+    Return type:
+        Variable.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from paddle import fluid
+            import paddle.fluid.dygraph as dg
+
+            mse_loss = paddle.dygraph.MSELoss()
+            input = fluid.data(name="input", shape=[1])
+            label = fluid.data(name="label", shape=[1])
+            place = fluid.CPUPlace()
+            input_data = np.array([1.5]).astype("float32")
+            label_data = np.array([1.7]).astype("float32")
+
+            # declarative mode
+            output = mse_loss(input,label)
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+            output_data = exe.run(
+                fluid.default_main_program(),
+                feed={"input":input_data, "label":label_data},
+                fetch_list=[output],
+                return_numpy=True)
+            print(output_data)
+            # [array([0.04000002], dtype=float32)]
+
+            # imperative mode
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_data)
+                label = dg.to_variable(label_data)
+                output = mse_loss(input, label)
+                print(output.numpy())
+                # [0.04000002]
+    """
+
+    def __init__(self, reduction='mean'):
+        super(MSELoss, self).__init__()
+        if reduction not in ['sum', 'mean', 'none']:
+            raise ValueError(
+                "'reduction' in 'MSELoss' should be 'sum', 'mean' or 'none', "
+                "but received {}.".format(reduction))
+        self.reduction = reduction
+
+    def forward(self, input, label):
+        if not in_dygraph_mode():
+            check_variable_and_dtype(input, 'input', ['float32'], 'MSELoss')
+            check_variable_and_dtype(label, 'label', ['float32'], 'MSELoss')
+
+        square_out = layers.square(layers.elementwise_sub(input, label))
+        if self.reduction == 'none':
+            return square_out
+
+        reduce_op = 'reduce_mean'
+        if self.reduction == 'sum':
+            reduce_op = 'reduce_sum'
+
+        return getattr(layers, reduce_op)(square_out)
+
+
+class L1Loss(layers.Layer):
+    """
+    This interface is used to construct a callable object of the ``L1Loss`` class.
+    The L1Loss layer calculates the L1 Loss of input predictions and target 
+    labels as follows.
+
+    If :attr:`reduction` set to ``'none'``, the unreduced loss is:
+    .. math::
+        Out = |input - label|
+    If :attr:`reduction` set to ``'mean'``, the reduced mean loss is:
+    .. math::
+        Out = MEAN(|input - label|)
+    If :attr:`reduction` set to ``'sum'``, the reduced sum loss is:
+    .. math::
+        Out = SUM(|input - label|)
+
+    The shape of input predictions and target labels are [N, *], where N is batch_size and `*` 
+    means any number of additional dimensions.
+    If :attr:`reduction` is ``'none'``, the shape of output loss is [N, *], the same as input.
+    If :attr:`reduction` is ``'mean'`` or ``'sum'``, the shape of output loss is [1], which means the output is a scalar.
+    
+    Parameters:
+        reduction (str, optional): Indicate the reduction to apply to the loss, 
+            the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'none'``, the unreduced loss is returned; 
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned. 
+            If :attr:`reduction` is ``'sum'``, the reduced sum loss is returned. 
+            Default is ``'mean'``.
+    Returns:
+        A callable object of L1Loss.
+    Examples:
+        .. code-block:: python
+            # declarative mode
+            import paddle.fluid as fluid
+            import numpy as np
+            input = fluid.data(name="input", shape=[1])
+            label = fluid.data(name="label", shape=[1])
+            l1_loss = paddle.dygraph.L1Loss(reduction='mean')
+            output = l1_loss(input,label)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+    
+            input_data = np.array([1.5]).astype("float32")
+            label_data = np.array([1.7]).astype("float32")
+            output_data = exe.run(fluid.default_main_program(),
+                    feed={"input":input_data, "label":label_data},
+                    fetch_list=[output],
+                    return_numpy=True)
+    
+            print(output_data)  # [array([0.2], dtype=float32)]
+            
+            # imperative mode
+            import paddle.fluid.dygraph as dg
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_data)
+                label = dg.to_variable(label_data)
+                l1_loss = paddle.nn.loss.L1Loss(reduction='mean')
+                output = l1_loss(input,label)
+                print(output.numpy())  # [0.2]
+    """
+
+    def __init__(self, reduction='mean'):
+        if reduction not in ['sum', 'mean', 'none']:
+            raise ValueError(
+                "The value of 'reduction' in L1Loss should be 'sum', 'mean' or 'none', but "
+                "received %s, which is not allowed." % reduction)
+        super(L1Loss, self).__init__()
+        self.reduction = reduction
+
+    def forward(self, input, label):
+        check_variable_and_dtype(
+            input, 'input', ['float32', 'float64', 'int32', 'int64'], 'l1_loss')
+        check_variable_and_dtype(
+            label, 'label', ['float32', 'float64', 'int32', 'int64'], 'l1_loss')
+
+        unreduced = layers.elementwise_sub(input, label, act='abs')
+
+        if self.reduction == 'sum':
+            return layers.reduce_sum(unreduced)
+        elif self.reduction == 'mean':
+            return layers.reduce_mean(unreduced)
+        else:
+            return unreduced
+
+
+class BCELoss(layers.Layer):
+    """
+    This interface is used to construct a callable object of the ``BCELoss`` class.
+    The BCELoss layer measures the binary_cross_entropy loss between input predictions 
+    and target labels. The binary_cross_entropy loss can be described as:
+
+    If :attr:`weight` is set, the loss is:
+
+    .. math::
+        Out = -1 * weight * (label * log(input) + (1 - label) * log(1 - input))
+    If :attr:`weight` is None, the loss is:
+
+    .. math::
+        Out = -1 * (label * log(input) + (1 - label) * log(1 - input))
+
+    If :attr:`reduction` set to ``'none'``, the unreduced loss is:
+
+    .. math::
+        Out = Out
+    If :attr:`reduction` set to ``'mean'``, the reduced mean loss is:
+
+    .. math::
+        Out = MEAN(Out)
+    If :attr:`reduction` set to ``'sum'``, the reduced sum loss is:
+
+    .. math::
+        Out = SUM(Out)
+
+    Note that the input predictions always be the output of sigmoid, and the target labels 
+    should be numbers between 0 and 1.
+
+    The shape of input predictions and target labels are [N, *], where N is batch_size and `*` 
+    means any number of additional dimensions. If ``reduction`` is ``'none'``, the shape of 
+    output is scalar, else the shape of output is same as input.
+
+    Parameters:
+        weight (Variable, optional): A manual rescaling weight given to the loss of each 
+            batch element. If given, has to be a Variable of size nbatch and the data type
+            is float32, float64. Default is ``'None'``.
+        reduction (str, optional): Indicate how to average the loss by batch_size, 
+            the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'none'``, the unreduced loss is returned;
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; 
+            If :attr:`reduction` is ``'sum'``, the summed loss is returned.
+            Default is ``'mean'``.
+
+    Returns: 
+        A callable object of BCELoss.
+
+    Examples:
+        .. code-block:: python
+
+            # declarative mode
+            import paddle.fluid as fluid
+            import numpy as np
+            input = fluid.data(name="input", shape=[3, 1], dtype='float32')
+            label = fluid.data(name="label", shape=[3, 1], dtype='float32')
+            bce_loss = paddle.dygraph.BCELoss()
+            output = bce_loss(input, label)
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+    
+            input_data = np.array([0.5, 0.6, 0.7]).astype("float32")
+            label_data = np.array([1.0, 0.0, 1.0]).astype("float32")
+            output_data = exe.run(fluid.default_main_program(),
+                    feed={"input":input_data, "label":label_data},
+                    fetch_list=[output],
+                    return_numpy=True)
+    
+            print(output_data)  # [array([0.65537095], dtype=float32)]
+            
+            # imperative mode
+            import paddle.fluid.dygraph as dg
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_data)
+                label = dg.to_variable(label_data)
+                output = bce_loss(input, label)
+                print(output.numpy())  # [0.65537095]
+    """
+
+    def __init__(self, weight=None, reduction='mean'):
+        if reduction not in ['sum', 'mean', 'none']:
+            raise ValueError(
+                "The value of 'reduction' in bce_loss should be 'sum', 'mean' or 'none', but "
+                "received %s, which is not allowed." % reduction)
+
+        super(BCELoss, self).__init__()
+        self.weight = weight
+        self.reduction = reduction
+
+    def forward(self, input, label):
+        dtype = self._helper.input_dtype(input)
+
+        check_variable_and_dtype(input, 'input', ['float32', 'float64'],
+                                 'bce_loss')
+        check_variable_and_dtype(label, 'label', ['float32', 'float64'],
+                                 'bce_loss')
+
+        out = self._helper.create_variable_for_type_inference(dtype=input.dtype)
+        self._helper.append_op(
+            type='bce_loss',
+            inputs={
+                'X': [input],
+                'Label': [label],
+            },
+            outputs={'Out': [out]})
+
+        if self.weight is not None:
+            if isinstance(self.weight, Variable):
+                w = self.weight
+                out = layers.elementwise_mul(out, w, axis=-1)
+            else:
+                raise ValueError(
+                    "The weight is not a Variable, please convert to Variable.")
+
+        if self.reduction == 'sum':
+            return layers.reduce_sum(out)
+        elif self.reduction == 'mean':
+            return layers.reduce_mean(out)
+        else:
+            return out
+
+
+class NLLLoss(layers.Layer):
+    """
+    This op accepts input and target label and returns negative log likelihood 
+    cross error. It is useful to train a classification problem with C classes.
+     
+    The input for the loss is epected to contain log-probabilities of
+    each classes. It hs to be a Tensor of size either (batch_size, C) or 
+    (batch_size, C, d1, d2, ..., dK) with K >= 1 for the K-dimensional case.
+    The label for the loss should be a class index in the range [0, C-1]
+    where C is the number of classes. If ignore_index is specified, the
+    specified target value does not contribute to the input gradient.
+    
+    If the optional argument `weight` is provided, it should be a 1D Tensor
+    assigning weight to each of the classed. This is particularly useful
+    when you have an unbalanced training set.
+ 
+    The loss is calculated as follows.
+    The unreduced (i.e. with :attr:`reduction` set to ``'none'``) loss can be described as:
+
+    .. math::
+        \ell(x, y) = L = \{l_1,\dots,l_N\}^\\top, \quad
+        l_n = - w_{y_n} x_{n,y_n}, \quad
+        w_{c} = \\text{weight}[c] \cdot \mathbb{1}\{c \\not= \\text{ignore\\_index}\},
+
+    where :math:`N` is the batch size. If :attr:`reduction` is not ``'none'``
+    (default ``'mean'``), then
+
+    .. math::
+        \ell(x, y) = \\begin{cases}
+            \\sum_{n=1}^N \\frac{1}{\\sum_{n=1}^N w_{y_n}} l_n, &
+            \\text{if reduction} = \\text{'mean';}\\\\
+            \\sum_{n=1}^N l_n,  &
+            \\text{if reduction} = \\text{'sum'.}
+        \\end{cases}
+
+    Parameters:
+        input (Variable): Input tensor, the data type is float32, float64. 
+        label (Variable): Label tensor, the data type is int64_t.
+        weight (Variable, optional): Weight tensor, a manual rescaling weight given
+            to each class. If given, it has to be a Tensor of size `C`. Otherwise,
+            it treated as if having all ones. the data type is 
+            float32, float64, Default is ``'None'``.
+        reduction (str, optional): Indicate how to average the loss, 
+            the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
+            If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned; 
+            Default is ``'mean'``.
+        ignore_index (int64, optional): Specifies a target value that is ignored
+            and does not contribute to the input gradient.
+
+    Returns:
+        The tensor variable storing the nll_loss.
+
+    Return type: Variable.
+    
+    Examples:
+
+        .. code-block:: python
+
+            # declarative mode
+            import paddle.fluid as fluid
+            import numpy as np
+
+            input_np = np.random.random(size=(10, 10)).astype(np.float32)
+            label_np = np.random.randint(0, 10, size=(10,)).astype(np.int64)
+            prog = fluid.Program()
+            startup_prog = fluid.Program()
+            place = fluid.CPUPlace()
+            with fluid.program_guard(prog, startup_prog):
+                input = fluid.data(name='input', shape=[10, 10], dtype='float32')
+                label = fluid.data(name='label', shape=[10], dtype='int64')
+                nll_loss = paddle.dygraph.NLLLoss()
+                res = nll_loss(input, label)
+
+                exe = fluid.Executor(place)
+                static_result = exe.run(
+                    prog,
+                    feed={"input": input_np,
+                          "label": label_np},
+                    fetch_list=[res])
+            print(static_result)
+            
+            # imperative mode
+            import paddle.fluid.dygraph as dg
+            with dg.guard(place) as g:
+                input = dg.to_variable(input_np)
+                label = dg.to_variable(label_np)
+                output = nll_loss(input, label)
+                print(output.numpy())
+    """
+
+    def __init__(self, weight=None, reduction='mean', ignore_index=-100):
+        super(NLLLoss, self).__init__()
+        self.weight = weight
+        self.reduction = reduction
+        self.ignore_index = ignore_index
+
+    def forward(self, input, label):
+        dtype = self._helper.input_dtype(input)
+
+        check_variable_and_dtype(input, 'input', ['float32', 'float64'],
+                                 'nll_loss')
+        check_variable_and_dtype(label, 'label', ['int64'], 'nll_loss')
+
+        if self.reduction not in ['sum', 'mean', 'none']:
+            raise ValueError(
+                "The value of 'reduction' in nll_loss should be 'sum', 'mean' or 'none', but "
+                "received %s, which is not allowed." % self.reduction)
+
+        x_shape = list(input.shape)
+        n = x_shape[0]
+        c = x_shape[1]
+        x_dims = len(x_shape)
+        if x_dims < 2:
+            raise ValueError('Expected 2 or more dimensions (got {})'.format(
+                x_dims))
+        if x_dims != 2 and x_dims != 4:
+            input = layers.reshape(input, shape=[n, c, 1, -1])
+            label = layers.reshape(label, shape=[n, 1, -1])
+            out_shape = [n] + x_shape[2:]
+
+        inputs = {'X': input, 'Label': label}
+        attrs = {'reduction': self.reduction, 'ignore_index': self.ignore_index}
+
+        if self.weight is not None:
+            if isinstance(self.weight, Variable):
+                inputs['Weight'] = self.weight
+
+        out = self._helper.create_variable_for_type_inference(dtype=input.dtype)
+        total_weight = self._helper.create_variable_for_type_inference(
+            dtype=input.dtype)
+        outputs = {'Out': out, 'Total_weight': total_weight}
+
+        self._helper.append_op(
+            type='nll_loss', inputs=inputs, outputs=outputs, attrs=attrs)
+        if x_dims != 2 and x_dims != 4 and self.reduction == 'none':
+            out = layers.reshape(out, shape=out_shape)
+
+        return out

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -26,7 +26,7 @@ import six
 import paddle
 from ..layer_helper import LayerHelper
 from ..initializer import Normal, Constant, NumpyArrayInitializer
-from ..framework import Variable, OpProtoHolder, in_dygraph_mode, dygraph_only, _dygraph_tracer, default_main_program
+from ..framework import Variable, OpProtoHolder, in_dygraph_mode, dygraph_only, _dygraph_tracer, default_main_program, device_guard, _varbase_creator
 from .. import dygraph_utils
 from ..param_attr import ParamAttr
 from .layer_function_generator import autodoc, templatedoc, _generate_doc_string_
@@ -39,153 +39,38 @@ from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, c
 import paddle
 
 __all__ = [
-    'fc',
-    'embedding',
-    'linear_chain_crf',
-    'crf_decoding',
-    'cos_sim',
-    'chunk_eval',
-    'conv2d',
-    'conv3d',
-    'softmax',
-    'pool2d',
-    'pool3d',
-    'adaptive_pool2d',
-    'adaptive_pool3d',
-    'batch_norm',
-    'inplace_abn',
-    'instance_norm',
-    'data_norm',
-    'conv2d_transpose',
-    'conv3d_transpose',
-    'reduce_sum',
-    'reduce_mean',
-    'reduce_max',
-    'reduce_min',
-    'reduce_prod',
-    'reduce_all',
-    'reduce_any',
-    'dropout',
-    'split',
-    'ctc_greedy_decoder',
-    'l2_normalize',
-    'matmul',
-    'topk',
-    'transpose',
-    'im2sequence',
-    'row_conv',
-    'multiplex',
-    'layer_norm',
-    'group_norm',
-    'spectral_norm',
-    'smooth_l1',
-    'one_hot',
-    'autoincreased_step_counter',
-    'reshape',
-    'squeeze',
-    'unsqueeze',
-    'lod_reset',
-    'lod_append',
-    'lrn',
-    'pad',
-    'pad_constant_like',
-    'label_smooth',
-    'roi_pool',
-    'roi_align',
-    'dice_loss',
-    'image_resize',
-    'image_resize_short',
-    'resize_bilinear',
-    'resize_trilinear',
-    'resize_nearest',
-    'gather',
-    'gather_nd',
-    'scatter',
-    'scatter_nd_add',
-    'scatter_nd',
-    'random_crop',
-    'mean_iou',
-    'relu',
-    'selu',
-    'log',
-    'crop',
-    'crop_tensor',
-    'elu',
-    'relu6',
-    'pow',
-    'stanh',
-    'hard_sigmoid',
-    'swish',
-    'prelu',
-    'brelu',
-    'leaky_relu',
-    'soft_relu',
-    'flatten',
-    'stack',
-    'pad2d',
-    'unstack',
-    'unique',
-    'unique_with_counts',
-    'expand',
-    'expand_as',
-    'scale',
-    'elementwise_add',
-    'elementwise_div',
-    'elementwise_sub',
-    'elementwise_mul',
-    'elementwise_max',
-    'elementwise_min',
-    'elementwise_pow',
-    'elementwise_mod',
-    'elementwise_floordiv',
-    'uniform_random_batch_size_like',
-    'gaussian_random',
-    'sampling_id',
-    'gaussian_random_batch_size_like',
-    'sum',
-    'slice',
-    'strided_slice',
-    'shape',
-    'rank',
-    'size',
-    'logical_and',
-    'logical_or',
-    'logical_xor',
-    'logical_not',
-    'clip',
-    'clip_by_norm',
-    'mean',
-    'mul',
-    'maxout',
-    'space_to_depth',
-    'affine_grid',
-    'affine_channel',
-    'similarity_focus',
-    'hash',
-    'grid_sampler',
-    'log_loss',
-    'add_position_encoding',
-    'bilinear_tensor_product',
-    'merge_selected_rows',
-    'get_tensor_from_selected_rows',
-    'shuffle_channel',
-    'temporal_shift',
-    'py_func',
-    'psroi_pool',
-    'prroi_pool',
-    'pixel_shuffle',
-    'fsp_matrix',
-    'continuous_value_model',
-    'where',
-    'sign',
-    'deformable_conv',
-    'unfold',
-    'deformable_roi_pooling',
-    'filter_by_instag',
-    'shard_index',
-    'hard_swish',
-    'gather_tree',
-    'uniform_random',
+    'fc', 'embedding', 'linear_chain_crf', 'crf_decoding', 'cos_sim',
+    'chunk_eval', 'conv2d', 'conv3d', 'softmax', 'pool2d', 'pool3d',
+    'adaptive_pool2d', 'adaptive_pool3d', 'batch_norm', 'inplace_abn',
+    'instance_norm', 'data_norm', 'conv2d_transpose', 'conv3d_transpose',
+    'reduce_sum', 'reduce_mean', 'reduce_max', 'reduce_min', 'reduce_prod',
+    'reduce_all', 'reduce_any', 'dropout', 'split', 'ctc_greedy_decoder',
+    'l2_normalize', 'matmul', 'topk', 'transpose', 'im2sequence', 'row_conv',
+    'multiplex', 'layer_norm', 'group_norm', 'spectral_norm', 'smooth_l1',
+    'one_hot', 'autoincreased_step_counter', 'reshape', 'squeeze', 'unsqueeze',
+    'lod_reset', 'lod_append', 'lrn', 'pad', 'pad_constant_like',
+    'label_smooth', 'roi_pool', 'roi_align', 'dice_loss', 'image_resize',
+    'image_resize_short', 'resize_bilinear', 'resize_trilinear',
+    'resize_nearest', 'gather', 'gather_nd', 'scatter', 'scatter_nd_add',
+    'scatter_nd', 'random_crop', 'mean_iou', 'relu', 'selu', 'log', 'crop',
+    'crop_tensor', 'elu', 'relu6', 'pow', 'stanh', 'hard_sigmoid', 'swish',
+    'prelu', 'brelu', 'leaky_relu', 'soft_relu', 'flatten', 'stack', 'pad2d',
+    'unstack', 'unique', 'unique_with_counts', 'expand', 'expand_as', 'scale',
+    'elementwise_add', 'elementwise_div', 'elementwise_sub', 'elementwise_mul',
+    'elementwise_max', 'elementwise_min', 'elementwise_pow', 'elementwise_mod',
+    'elementwise_floordiv', 'uniform_random_batch_size_like', 'gaussian_random',
+    'sampling_id', 'gaussian_random_batch_size_like', 'sum', 'slice',
+    'strided_slice', 'shape', 'rank', 'size', 'logical_and', 'logical_or',
+    'logical_xor', 'logical_not', 'clip', 'clip_by_norm', 'mean', 'mul',
+    'maxout', 'space_to_depth', 'affine_grid', 'affine_channel',
+    'similarity_focus', 'hash', 'grid_sampler', 'log_loss',
+    'add_position_encoding', 'bilinear_tensor_product', 'merge_selected_rows',
+    'get_tensor_from_selected_rows', 'shuffle_channel', 'temporal_shift',
+    'py_func', 'psroi_pool', 'prroi_pool', 'pixel_shuffle', 'fsp_matrix',
+    'continuous_value_model', 'where', 'sign', 'deformable_conv', 'unfold',
+    'deformable_roi_pooling', 'filter_by_instag', 'shard_index', 'hard_swish',
+    'gather_tree', 'uniform_random', 'randint', 'randn', 'randperm', 'equal',
+    'allclose', 'elementwise_equal'
 ]
 
 
@@ -14295,3 +14180,541 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0):
         outputs={"Out": out})
 
     return helper.append_activation(out)
+
+
+def randint(low,
+            high=None,
+            shape=None,
+            out=None,
+            dtype=None,
+            device=None,
+            stop_gradient=False,
+            seed=0,
+            name=None):
+    """
+    This function returns a Tensor filled with random integers from the "discrete uniform" distribution of the
+    specified data type in the interval [low, high). If high is None (the default), then results are from [0, low).
+
+    Args:
+        low (int): The lower bound on the range of random values to generate, the low is included in the range.
+            (unless high=None, in which case this parameter is one above the highest such integer).
+        high (int, optional): The upper bound on the range of random values to generate, the high is excluded 
+            in the range. Default None(see above for behavior if high=None).
+        shape (list|tuple|Variable, optional): The shape of the output Tensor,  if the shape is a list or tuple, 
+                                     its elements can be an integer
+                                     or a Tensor with the shape [1], and the type of the Tensor must be int32 or int64. 
+                                     If the shape is a Variable, it is a 1-D Tensor, and the type of the Tensor must be 
+                                     int32 or int64. Default is None, in which case the shape is [1].
+        out(Variable, optional): Optional output which can be any created 
+            Variable that meets the requirements to store the result of operation.
+            if out is None, a new Varibale will be create to store the result.
+        dtype(np.dtype|core.VarDesc.VarType|str, optional): Data type of the output Tensor
+            which can be int32, int64, if dytpe is `None`, the data
+            type of created Tensor is `int64`
+        device(str, optional): This parameter specifies that the Tensor is created 
+            on the GPU or CPU.
+        stop_gradient(bool, optional): Indicating if we stop gradient from current(out) Variable,
+            default value is False.
+        seed (int, optional): Random seed used for permute samples. If seed is 
+            equal to 0, it means use a seed generated by the system. Note that 
+            if seed is not 0, this operator will always generate the same random 
+            permutation every time. Default: 0.
+        name(str, optional): The default value is None.  Normally there is no need for user to set this
+            property.  For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns: 
+        Variable: A Tensor of the specified shape filled with random integers.
+
+    Raises:
+        TypeError: Randint's low must less then high.
+
+    Examples:
+        .. code-block:: python
+            import paddle.fluid as fluid
+
+            # example 1:
+            # attr shape is a list which doesn't contain tensor Variable.
+            result_1 = fluid.layers.randint(low=-5, high=5, shape=[3, 4], dtype="int64")
+
+            # example 2:
+            # attr shape is a list which contains tensor Variable.
+            dim_1 = fluid.layers.fill_constant([1],"int64",3)
+            dim_2 = fluid.layers.fill_constant([1],"int32",5)
+            result_2 = fluid.layers.randint(low=-5, high=5, shape=[dim_1, dim_2], dtype="int32")
+
+            # example 3:
+            # attr shape is a Variable, the data type must be int64 or int32.
+            var_shape = fluid.data(name='var_shape', shape=[2], dtype="int64")
+            result_3 = padddle.randint(low=-5, high=5, shape=var_shape, dtype="int32")
+            var_shape_int32 = fluid.data(name='var_shape_int32', shape=[2], dtype="int32")
+            result_4 = fluid.layers.randint(low=-5, high=5, shape=var_shape_int32, dtype="int64")
+
+            # example 4:
+            # Input only one parameter
+            # low=0, high=10, shape=[1], dtype='int64'
+            result_4 = fluid.layers.randint(10)
+     """
+
+    def get_new_shape_tensor(list_shape):
+        new_shape_tensor = []
+        for dim in list_shape:
+            if isinstance(dim, Variable):
+                dim.stop_gradient = True
+                new_shape_tensor.append(dim)
+            else:
+                assert isinstance(dim, int) or isinstance(dim, long)
+                temp_out = helper.create_variable_for_type_inference('int64')
+                fill_constant([1], 'int64', dim, force_cpu=True, out=temp_out)
+                new_shape_tensor.append(temp_out)
+        return new_shape_tensor
+
+    def get_attr_shape(list_shape):
+        unk_dim_idx = -1
+        attrs_shape = []
+        for dim_idx, dim_size in enumerate(list_shape):
+            if isinstance(dim_size, Variable):
+                attrs_shape.append(-1)
+            else:
+                attrs_shape.append(dim_size)
+                assert dim_size > 0, (
+                    "Each dimension size given in shape must not be negative "
+                    "except one unknown dimension.")
+        return attrs_shape
+
+    if dtype is None:
+        dtype = 'int64'
+    check_dtype(dtype, 'dtype', ['int32', 'int64'], 'randint')
+
+    inputs = dict()
+    attrs = dict()
+
+    if shape is None:
+        shape = [1]
+        assert len(shape) > 0, ("The size of argument(shape) can't be zero.")
+
+    helper = LayerHelper("randint", **locals())
+
+    if in_dygraph_mode():
+        attrs['shape'] = shape
+    else:
+        if isinstance(shape, Variable):
+            shape.stop_gradient = True
+            inputs["ShapeTensor"] = shape
+        elif isinstance(shape, (list, tuple)):
+            assert len(shape) > 0, (
+                "The size of argument(shape) can't be zero.")
+            if utils._contain_var(shape):
+                inputs['ShapeTensorList'] = get_new_shape_tensor(shape)
+            else:
+                attrs["shape"] = get_attr_shape(shape)
+    check_type(shape, 'shape', (list, tuple, Variable), 'randint')
+
+    if high is None:
+        high = low
+        low = 0
+    attrs['low'] = low
+    attrs['high'] = high
+    attrs['seed'] = seed
+    if (low >= high):
+        raise ValueError(
+            "randint's low must less then high, but received low = {0}, "
+            "high = {1}".format(low, high))
+
+    if out is None:
+        if name is None:
+            out = helper.create_variable_for_type_inference(dtype=dtype)
+        else:
+            out = helper.create_variable(
+                name=name, dtype=dtype, persistable=False)
+    else:
+        check_dtype(dtype, 'dtype',
+                    convert_dtype(out.dtype), 'randint',
+                    "(The dtype in randint must be the same with out's dtype.)")
+    attrs['dtype'] = out.dtype
+    out.stop_gradient = stop_gradient
+
+    if device is None:
+        helper.append_op(
+            type='randint', inputs=inputs, outputs={'Out': out}, attrs=attrs)
+    else:
+        with device_guard(device):
+            helper.append_op(
+                type='randint',
+                inputs=inputs,
+                outputs={'Out': out},
+                attrs=attrs)
+    return out
+
+
+def randn(shape,
+          out=None,
+          dtype=None,
+          device=None,
+          stop_gradient=True,
+          name=None):
+    """
+    This function returns a tensor filled with random numbers from a normal 
+    distribution with mean 0 and variance 1 (also called the standard normal
+    distribution).
+
+    Args:
+        shape(list|tuple): Shape of the generated random tensor.
+        out(Variable, optional): Optional output which can be any created Variable 
+            that meets the requirements to store the result of operation. If the 
+            out is `None`, a new Variable wiil be returned to store the result.
+            Default is None.
+        dtype(np.dtype|core.VarDesc.VarType|str, optional): Data type of the output 
+            tensor, which can be float32, float64. if dtype is `None` , the data 
+            type of output tensor is `float32` .
+            Default is None.
+        device(str, optional): Specific the output variable to be saved in cpu
+            or gpu memory. Supported None, 'cpu', 'gpu'. If it is None, the output
+            variable will be automatically assigned devices. 
+            Default: None.
+        stop_gradient(bool, optional): Indicating if we stop gradient from current(out) 
+            Variable. Default is True.
+        name(str, optional): Normally there is no need for user to set this property.
+            For more information, please refer to :ref:`api_guide_Name` .
+            Default is None.
+
+    Returns:
+        Random tensor whose data is drawn from a Gaussian distribution, 
+        dtype: flaot32 or float64 as specified.
+
+    Return type:
+        Variable
+
+    Raises:
+        TypeError: If the type of `shape` is not list or tuple.
+        TypeError: If the data type of `dtype` is not float32 or float64.
+        ValueError: If the length of `shape` is not bigger than 0.
+
+    Examples:
+        .. code-block:: python
+
+            # declarative mode
+            import paddle.fluid as fluid
+
+            data = fluid.layers.randn([2, 4])
+            place = fluid.CPUPlace()
+            exe = fluid.Executor(place)
+            res, = exe.run(fluid.default_main_program(), feed={}, fetch_list=[data])
+            print(res)
+            # [[-1.4187592   0.7368311  -0.53748125 -0.0146909 ]
+            #  [-0.66294265 -1.3090698   0.1898754  -0.14065823]]
+
+        .. code-block:: python
+
+            # imperative mode
+            import paddle.fluid as fluid
+            import paddle.fluid.dygraph as dg
+
+            place = fluid.CPUPlace()
+            with dg.guard(place) as g:
+                x = fluid.layers.randn([2, 4])
+                x_np = x.numpy()
+                print(x_np)
+                # [[ 1.5149173  -0.26234224 -0.592486    1.4523455 ]
+                #  [ 0.04581212 -0.85345626  1.1687907  -0.02512913]]
+    """
+    helper = LayerHelper("randn", **locals())
+    check_type(shape, 'shape', (list, tuple), 'randn')
+    assert len(shape) > 0, ("The size of argument(shape) can't be zero.")
+
+    if dtype is None:
+        dtype = 'float32'
+
+    check_dtype(dtype, 'create data type', ['float32', 'float64'], 'randn')
+
+    if out is None:
+        out = helper.create_variable_for_type_inference(dtype=dtype)
+    else:
+        check_variable_and_dtype(out, 'out', [dtype], 'randn')
+
+    out.stop_gradient = stop_gradient
+
+    dtype = convert_np_dtype_to_dtype_(dtype)
+    seed = np.random.randint(0, 100)
+
+    with device_guard(device):
+        helper.append_op(
+            type='gaussian_random',
+            outputs={'Out': out},
+            attrs={
+                'shape': shape,
+                'mean': 0.0,
+                'std': 1.0,
+                'seed': seed,
+                'dtype': dtype,
+                'use_mkldnn': False
+            })
+    return out
+
+
+@templatedoc()
+def randperm(n,
+             out=None,
+             dtype="int64",
+             device=None,
+             stop_gradient=True,
+             seed=0):
+    """
+    ${comment}
+
+    Args:
+        n (int): The upper bound (exclusive), and it should be greater than 0.
+        out (Variable, optional): Optional output which can be any created 
+            Variable that meets the requirements to store the result of operation.
+            If out is None, a new Varibale will be create to store the result. 
+            Default: None.
+        dtype (np.dtype|core.VarDesc.VarType|str, optional): The type of the 
+            output Tensor. Supported data types: int64, int32. Default: int32.
+        device (str, optional): Specific the output variable to be saved in cpu
+            or gpu memory. Supported None, 'cpu', 'gpu'. If it is None, the output
+            variable will be automatically assigned devices.
+            Default: None.
+        stop_gradient (bool, optional): Whether grad should record operations 
+            on the returned tensor. Default: True.
+        seed (int, optional): Random seed used for permute samples. If seed is 
+            equal to 0, it means use a seed generated by the system. Note that 
+            if seed is not 0, this operator will always generate the same random 
+            permutation every time. Default: 0.
+
+    Returns:
+        ${out_comment}.
+
+    Return Type:
+        ${out_type}
+
+    Examples:
+        .. code-block:: python
+
+	    import paddle.fluid as fluid
+
+	    num = 6
+	    is_use_gpu = False
+
+	    data_1 = fluid.layers.randperm(num)
+	    fluid.layers.Print(data_1)
+
+	    data_2 = fluid.layers.randperm(num, dtype="int32", seed=1)
+	    fluid.layers.Print(data_2)
+
+	    data_3 = fluid.layers.randperm(num, stop_gradient=False, device="cpu")
+	    fluid.layers.Print(data_3)
+
+	    fluid.layers.randperm(num, out=data_3)
+	    fluid.layers.Print(data_3)
+
+	    place = fluid.CUDAPlace(0) if is_use_gpu else fluid.CPUPlace()
+	    exe = fluid.Executor(place)
+	    exe.run(fluid.default_startup_program())
+	    exe.run()
+ 
+    """
+
+    if n < 1:
+        raise ValueError("The input n should be greater than 0 in randperm op.")
+    check_dtype(dtype, 'dtype', ['int64', 'int32'], 'randperm')
+    dtype = convert_dtype(dtype)
+    if device not in [None, 'cpu', 'gpu']:
+        raise ValueError("The input device should in [None, 'cpu', 'gpu'].")
+    check_type(stop_gradient, 'stop_gradient', bool, 'randperm')
+
+    helper = LayerHelper("randperm", **locals())
+    if out is None:
+        out = helper.create_variable_for_type_inference(dtype=dtype)
+    else:
+        check_variable_and_dtype(out, 'out', [dtype], 'randperm')
+    if stop_gradient:
+        out.stop_gradient = True
+    inputs = dict()
+    outputs = {'Out': [out]}
+    attrs = {'n': n, 'dtype': out.dtype, 'seed': seed}
+    with device_guard(device):
+        helper.append_op(
+            type='randperm', inputs=inputs, outputs=outputs, attrs=attrs)
+    return out
+
+
+def equal(x, y, axis=-1, name=None):
+    """
+    This OP returns the truth value of :math:`x == y`. True if two inputs have the same elements, False otherwise.
+
+    **NOTICE**: The output of this OP has no gradient, and this OP supports broadcasting by :attr:`axis`.
+
+    Args:
+        x(Variable): Tensor, data type is float32, float64, int32, int64.
+        y(Variable): Tensor, data type is float32, float64, int32, int64.
+        axis(int32, optional): If X.dimension != Y.dimension, Y.dimension
+            must be a subsequence of x.dimension. And axis is the start 
+            dimension index for broadcasting Y onto X. For more detail, 
+            please refer to OP:`elementwise_add`.
+        name(str, optional): Normally there is no need for user to set this property. 
+            For more information, please refer to :ref:`api_guide_Name`.Default: None.
+
+    Returns:
+        Variable: output Tensor, data type is bool, value is [False] or [True].
+
+    Examples:
+        .. code-block:: python
+
+          import paddle.fluid as fluid
+          import numpy as np
+
+          label = fluid.layers.assign(np.array([3, 4], dtype="int32"))
+          label_1 = fluid.layers.assign(np.array([1, 2], dtype="int32"))
+          limit = fluid.layers.assign(np.array([3, 4], dtype="int32"))
+          out1 = fluid.layers.equal(x=label, y=limit) #out1=[True]
+          out2 = fluid.layers.equal(x=label_1, y=limit) #out2=[False]
+
+        .. code-block:: python
+
+          import paddle.fluid as fluid
+          import numpy as np
+
+          def gen_data():
+              return {
+                    "x": np.ones((2, 3, 4, 5)).astype('float32'),
+                    "y": np.zeros((3, 4)).astype('float32')
+                }
+
+          x = fluid.data(name="x", shape=[2,3,4,5], dtype='float32')
+          y = fluid.data(name="y", shape=[3,4], dtype='float32')
+          out = fluid.layers.equal(x, y, axis=1)
+          place = fluid.CPUPlace()
+          exe = fluid.Executor(place)
+
+          res = exe.run(feed=gen_data(),
+                            fetch_list=[out])
+          print(res[0]) #[False]
+    """
+    helper = LayerHelper("equal_reduce", **locals())
+    out = helper.create_variable_for_type_inference(dtype='bool')
+    attrs = {}
+    attrs['axis'] = axis
+    helper.append_op(
+        type='equal_reduce',
+        inputs={'X': [x],
+                'Y': [y]},
+        attrs=attrs,
+        outputs={'Out': [out]})
+    return out
+
+
+@templatedoc()
+def allclose(input, other, rtol=1e-05, atol=1e-08, equal_nan=False, name=None):
+    """
+    ${comment}
+
+    Args:
+        input(inputtype):{input_comment}.
+        other(othertype):{other_comment}.
+        rtol(rtoltype,optional):{rtol_comment}.
+        atol(atoltype,optional):{atol_comment}.
+        equal_nan(equalnantype,optional):{equal_nan_comment}.
+        name(STR, optional): The default value is None.
+                        Normally there is no need for user to set this property.
+                        For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        ${out_comment}.
+
+    Return Type:
+        ${out_type}
+        
+    Examples:
+        .. code-block:: python
+
+          import paddle.fluid as fluid
+          import numpy as np
+
+          use_cuda = fluid.core.is_compiled_with_cuda()
+
+          a = fluid.data(name="a", shape=[2], dtype='float32')
+          b = fluid.data(name="b", shape=[2], dtype='float32')
+
+          result = fluid.layers.allclose(a, b, rtol=1e-05, atol=1e-08,
+                                  equal_nan=False, name="ignore_nan")
+          result_nan = fluid.layers.allclose(a, b, rtol=1e-05, atol=1e-08,
+                                      equal_nan=True, name="equal_nan")
+
+          place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
+          exe = fluid.Executor(place)
+          exe.run(fluid.default_startup_program())
+
+          x = np.array([10000., 1e-07]).astype("float32")
+          y = np.array([10000.1, 1e-08]).astype("float32")
+          result_v, result_nan_v = exe.run(
+              feed={'a': x, 'b': y},
+              fetch_list=[result, result_nan])
+          print(result_v, result_nan_v)
+          # Output: (array([False]), array([False]))
+
+          x = np.array([10000., 1e-08]).astype("float32")
+          y = np.array([10000.1, 1e-09]).astype("float32")
+          result_v, result_nan_v = exe.run(
+              feed={'a': x, 'b': y},
+              fetch_list=[result, result_nan])
+          print(result_v, result_nan_v)
+          # Output: (array([ True]), array([ True]))
+
+          x = np.array([1.0, float('nan')]).astype("float32")
+          y = np.array([1.0, float('nan')]).astype("float32")
+          result_v, result_nan_v = exe.run(
+              feed={'a': x, 'b': y},
+              fetch_list=[result, result_nan])
+          print(result_v, result_nan_v)
+          # Output: (array([False]), array([ True]))
+    """
+
+    check_type(rtol, 'rtol', float, 'allclose')
+    check_type(atol, 'atol', float, 'allclose')
+    check_type(equal_nan, 'equal_nan', bool, 'allclose')
+
+    helper = LayerHelper("allclose", **locals())
+    out = helper.create_variable_for_type_inference(dtype='bool')
+
+    inputs = {'Input': input, 'Other': other}
+    outputs = {'Out': out}
+    attrs = {'rtol': rtol, 'atol': atol, 'equal_nan': equal_nan}
+    helper.append_op(
+        type='allclose', inputs=inputs, outputs=outputs, attrs=attrs)
+
+    return out
+
+
+def elementwise_equal(x, y, name=None):
+    """
+    This layer returns the truth value of :math:`x == y` elementwise.
+
+    Args:
+        x(Variable): Tensor, data type is float32, float64, int32, int64.
+        y(Variable): Tensor, data type is float32, float64, int32, int64.
+        name(str, optional): The default value is None.  Normally there is no need for
+            user to set this property.  For more information, please refer to :ref:`api_guide_Name`.
+
+    Returns:
+        Variable: output Tensor, it's shape is the same as the input's Tensor,
+        and the data type is bool. The result of this op is stop_gradient. 
+
+    Examples:
+        .. code-block:: python
+
+          import paddle.fluid as fluid
+          import numpy as np
+          label = fluid.layers.assign(np.array([3, 3], dtype="int32"))
+          limit = fluid.layers.assign(np.array([3, 2], dtype="int32"))
+          out1 = fluid.layers.elementwise_equal(x=label, y=limit) #out1=[True, False]
+    """
+    helper = LayerHelper("elementwise_equal", **locals())
+    out = helper.create_variable_for_type_inference(dtype='bool')
+    out.stop_gradient = True
+
+    helper.append_op(
+        type='equal',
+        inputs={'X': [x],
+                'Y': [y]},
+        outputs={'Out': [out]},
+        attrs={'force_cpu': False})
+    return out

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -35,7 +35,7 @@ __all__ = [
     'fill_constant_batch_size_like', 'fill_constant', 'argmin', 'argmax',
     'argsort', 'ones', 'zeros', 'reverse', 'has_inf', 'has_nan', 'isfinite',
     'range', 'linspace', 'zeros_like', 'ones_like', 'diag', 'eye', 'kron',
-    'full_like', 'arange', 'full', 'tril', 'triu', 'meshgrid'
+    'full_like', 'arange', 'full', 'tril', 'triu'
 ]
 
 
@@ -1843,6 +1843,13 @@ def tril(input, diagonal=0, name=None):
         .. code-block:: python
 
             # example 2, positive diagonal value
+            import paddle.fluid as fluid
+            import numpy as np
+
+            data = np.arange(1, 13, dtype="int64").reshape(3,-1)
+            x = fluid.data(shape=(-1, 4), dtype='int64', name='x')
+            exe = fluid.Executor(fluid.CPUPlace())
+
             tril = fluid.layers.tril(x, diagonal=2)
             tril_out, = exe.run(fluid.default_main_program(), feed={"x": data},
                 fetch_list=[tril], return_numpy=True)
@@ -1853,6 +1860,13 @@ def tril(input, diagonal=0, name=None):
         .. code-block:: python
 
             # example 3, negative diagonal value
+            import paddle.fluid as fluid
+            import numpy as np
+
+            data = np.arange(1, 13, dtype="int64").reshape(3,-1)
+            x = fluid.data(shape=(-1, 4), dtype='int64', name='x')
+            exe = fluid.Executor(fluid.CPUPlace())
+
             tril = fluid.layers.tril(x, diagonal=-1)
             tril_out, = exe.run(fluid.default_main_program(), feed={"x": data},
                 fetch_list=[tril], return_numpy=True)
@@ -1907,6 +1921,7 @@ def triu(input, diagonal=0, name=None):
             exe = fluid.Executor(fluid.CPUPlace())
 
             # example 1, default diagonal
+            import paddle.fluid as fluid
             triu = fluid.layers.triu(x)
             triu_out, = exe.run(fluid.default_main_program(), feed={"x": data},
                 fetch_list=[triu], return_numpy=True)
@@ -1917,6 +1932,13 @@ def triu(input, diagonal=0, name=None):
         .. code-block:: python
 
             # example 2, positive diagonal value
+            import paddle.fluid as fluid
+            import numpy as np
+
+            data = np.arange(1, 13, dtype="int64").reshape(3,-1)
+            x = fluid.data(shape=(-1, 4), dtype='int64', name='x')
+            exe = fluid.Executor(fluid.CPUPlace())
+
             triu = fluid.layers.triu(x, diagonal=2)
             triu_out, = exe.run(fluid.default_main_program(), feed={"x": data},
                 fetch_list=[triu], return_numpy=True)
@@ -1927,6 +1949,13 @@ def triu(input, diagonal=0, name=None):
         .. code-block:: python
 
             # example 3, negative diagonal value
+            import paddle.fluid as fluid
+            import numpy as np
+
+            data = np.arange(1, 13, dtype="int64").reshape(3,-1)
+            x = fluid.data(shape=(-1, 4), dtype='int64', name='x')
+            exe = fluid.Executor(fluid.CPUPlace())
+
             triu = fluid.layers.triu(x, diagonal=-1)
             triu_out, = exe.run(fluid.default_main_program(), feed={"x": data},
                 fetch_list=[triu], return_numpy=True)
@@ -1937,85 +1966,6 @@ def triu(input, diagonal=0, name=None):
     """
 
     return _tril_triu_op(LayerHelper('triu', **locals()))
-
-
-def meshgrid(input, name=None):
-    """
-    This op takes a list of N tensors as input, each of which is 1-dimensional 
-    vector, and creates N-dimensional grids.
-    
-    Args:
-        input(Variable) : tensors (list of tensor): the shapes of input k tensors are (N1,), 
-            (N2,),..., (Nk,). Support data types: ``float64``, ``float32``, ``int32``, ``int64``.
-        name (str, optional): The default value is None. Normally there is no need for
-            user to set this property. For more information, please refer to :ref:`api_guide_Name`.
- 
-    Returns:
-         Variable: k tensors. The shape of each tensor is (N1, N2, ..., Nk)
-
-    Examples:
-      .. code-block:: python
-
-          import paddle.fluid as fluid
-          import numpy as np
-
-          x = fluid.data(name='x', shape=[100], dtype='int32')
-          y = fluid.data(name='y', shape=[200], dtype='int32')
-
-          input_1 = np.random.randint(0, 100, [100, ]).astype('int32')
-          input_2 = np.random.randint(0, 100, [200, ]).astype('int32')
-
-          exe = fluid.Executor(place=fluid.CPUPlace())
-          grid_x, grid_y = fluid.layers.meshgrid([x, y])
-          res_1, res_2 = exe.run(fluid.default_main_program(),
-                                 feed={'x': input_1,
-                                       'y': input_2},
-                                 fetch_list=[grid_x, grid_y])
-     
-          #the shape of res_1 is (100, 200)
-          #the shape of res_2 is (100, 200)
-
-      .. code-block:: python
-
-          #example 2: in dygraph mode
-
-          import paddle.fluid as fluid
-          import numpy as np
-
-          input_3 = np.random.randint(0, 100, [100, ]).astype('int32')
-          input_4 = np.random.randint(0, 100, [200, ]).astype('int32')
-          with fluid.dygraph.guard():
-              tensor_3 = fluid.dygraph.to_variable(input_3)
-              tensor_4 = fluid.dygraph.to_variable(input_4)
-              grid_x, grid_y = fluid.layers.meshgrid([tensor_3, tensor_4])
-
-          #the shape of grid_x is (100, 200)
-          #the shape of grid_y is (100, 200)
-
-    """
-
-    if in_dygraph_mode():
-        num = len(input)
-        out = core.ops.meshgrid(input, num)
-        return out
-
-    helper = LayerHelper('meshgrid', **locals())
-
-    if not isinstance(input, list):
-        raise TypeError("The type of input in meshgrid should be list.")
-
-    for id, input_ in enumerate(input):
-        check_dtype(input_.dtype, 'create data type',
-                    ['float16', 'float32', 'float64', 'int32', 'int64'],
-                    'meshgrid')
-
-    num = len(input)
-    out = [
-        helper.create_variable_for_type_inference(dtype=input[i].dtype)
-        for i in range(num)
-    ]
-    helper.append_op(type='meshgrid', inputs={'X': input}, outputs={'Out': out})
-    return out
 
 
 @templatedoc(op_type="kron")

--- a/python/paddle/fluid/tests/unittests/test_allclose_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_allclose_layer.py
@@ -23,9 +23,9 @@ class TestAllcloseLayer(unittest.TestCase):
         a = fluid.data(name="a", shape=[2], dtype='float32')
         b = fluid.data(name="b", shape=[2], dtype='float32')
 
-        result = paddle.allclose(
+        result = fluid.layers.allclose(
             a, b, rtol=1e-05, atol=1e-08, equal_nan=False, name="ignore_nan")
-        result_nan = paddle.allclose(
+        result_nan = fluid.layers.allclose(
             a, b, rtol=1e-05, atol=1e-08, equal_nan=True, name="equal_nan")
 
         place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
@@ -82,7 +82,7 @@ class TestAllcloseLayer(unittest.TestCase):
         with fluid.dygraph.guard():
             x_v_1 = fluid.dygraph.to_variable(x_1)
             y_v_1 = fluid.dygraph.to_variable(y_1)
-            ret_1 = paddle.allclose(
+            ret_1 = fluid.layers.allclose(
                 x_v_1,
                 y_v_1,
                 rtol=1e-05,
@@ -90,7 +90,7 @@ class TestAllcloseLayer(unittest.TestCase):
                 equal_nan=False,
                 name='test_1')
             self.assertEqual(ret_1.numpy()[0], False)
-            ret_1 = paddle.allclose(
+            ret_1 = fluid.layers.allclose(
                 x_v_1,
                 y_v_1,
                 rtol=1e-05,
@@ -100,7 +100,7 @@ class TestAllcloseLayer(unittest.TestCase):
             self.assertEqual(ret_1.numpy()[0], False)
             x_v_2 = fluid.dygraph.to_variable(x_2)
             y_v_2 = fluid.dygraph.to_variable(y_2)
-            ret_2 = paddle.allclose(
+            ret_2 = fluid.layers.allclose(
                 x_v_2,
                 y_v_2,
                 rtol=1e-05,
@@ -108,7 +108,7 @@ class TestAllcloseLayer(unittest.TestCase):
                 equal_nan=False,
                 name='test_3')
             self.assertEqual(ret_2.numpy()[0], True)
-            ret_2 = paddle.allclose(
+            ret_2 = fluid.layers.allclose(
                 x_v_2,
                 y_v_2,
                 rtol=1e-05,
@@ -118,7 +118,7 @@ class TestAllcloseLayer(unittest.TestCase):
             self.assertEqual(ret_2.numpy()[0], True)
             x_v_3 = fluid.dygraph.to_variable(x_3)
             y_v_3 = fluid.dygraph.to_variable(y_3)
-            ret_3 = paddle.allclose(
+            ret_3 = fluid.layers.allclose(
                 x_v_3,
                 y_v_3,
                 rtol=1e-05,
@@ -126,7 +126,7 @@ class TestAllcloseLayer(unittest.TestCase):
                 equal_nan=False,
                 name='test_5')
             self.assertEqual(ret_3.numpy()[0], False)
-            ret_3 = paddle.allclose(
+            ret_3 = fluid.layers.allclose(
                 x_v_3,
                 y_v_3,
                 rtol=1e-05,

--- a/python/paddle/fluid/tests/unittests/test_arange.py
+++ b/python/paddle/fluid/tests/unittests/test_arange.py
@@ -14,7 +14,6 @@
 
 from __future__ import print_function
 
-import paddle
 import paddle.fluid as fluid
 import unittest
 import numpy as np
@@ -71,7 +70,7 @@ class TestInt32ArangeOpCase2(TestArangeOp):
 class TestArangeAPI(unittest.TestCase):
     def test_out(self):
         with fluid.program_guard(fluid.Program()):
-            data = paddle.arange(0, 5, 1)
+            data = fluid.layers.arange(0, 5, 1)
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             result, = exe.run(fetch_list=[data])
@@ -79,7 +78,7 @@ class TestArangeAPI(unittest.TestCase):
         self.assertEqual((result == expected_data).all(), True)
 
         with fluid.program_guard(fluid.Program()):
-            data = paddle.arange(0.0, 5.0, 1.0, 'int32')
+            data = fluid.layers.arange(0.0, 5.0, 1.0, 'int32')
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             result, = exe.run(fetch_list=[data])

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -36,7 +36,7 @@ class TestBCELoss(unittest.TestCase):
                         name='input', shape=[None, 30], dtype='float64')
                     label = fluid.data(
                         name='label', shape=[None, 30], dtype='float64')
-                    bce_loss = paddle.nn.loss.BCELoss(reduction=red)
+                    bce_loss = paddle.dygraph.BCELoss(reduction=red)
                     res = bce_loss(input, label)
 
                     exe = fluid.Executor(place)
@@ -47,7 +47,7 @@ class TestBCELoss(unittest.TestCase):
                         fetch_list=[res])
 
                 with fluid.dygraph.guard():
-                    bce_loss = paddle.nn.loss.BCELoss(reduction=red)
+                    bce_loss = paddle.dygraph.BCELoss(reduction=red)
                     dy_res = bce_loss(
                         fluid.dygraph.to_variable(input_np),
                         fluid.dygraph.to_variable(label_np))
@@ -80,7 +80,7 @@ class TestBCELoss(unittest.TestCase):
                 name='label', shape=[None, 3, 4, 10], dtype='float64')
             weight = fluid.data(
                 name='weight', shape=[3, 4, 10], dtype='float64')
-            bce_loss = paddle.nn.loss.BCELoss(weight=weight)
+            bce_loss = paddle.dygraph.BCELoss(weight=weight)
             res = bce_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -93,7 +93,7 @@ class TestBCELoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            bce_loss = paddle.nn.loss.BCELoss(
+            bce_loss = paddle.dygraph.BCELoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = bce_loss(
                 fluid.dygraph.to_variable(input_np),

--- a/python/paddle/fluid/tests/unittests/test_bce_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_bce_loss.py
@@ -36,7 +36,7 @@ class TestBCELoss(unittest.TestCase):
                         name='input', shape=[None, 30], dtype='float64')
                     label = fluid.data(
                         name='label', shape=[None, 30], dtype='float64')
-                    bce_loss = paddle.dygraph.BCELoss(reduction=red)
+                    bce_loss = fluid.dygraph.BCELoss(reduction=red)
                     res = bce_loss(input, label)
 
                     exe = fluid.Executor(place)
@@ -47,7 +47,7 @@ class TestBCELoss(unittest.TestCase):
                         fetch_list=[res])
 
                 with fluid.dygraph.guard():
-                    bce_loss = paddle.dygraph.BCELoss(reduction=red)
+                    bce_loss = fluid.dygraph.BCELoss(reduction=red)
                     dy_res = bce_loss(
                         fluid.dygraph.to_variable(input_np),
                         fluid.dygraph.to_variable(label_np))
@@ -80,7 +80,7 @@ class TestBCELoss(unittest.TestCase):
                 name='label', shape=[None, 3, 4, 10], dtype='float64')
             weight = fluid.data(
                 name='weight', shape=[3, 4, 10], dtype='float64')
-            bce_loss = paddle.dygraph.BCELoss(weight=weight)
+            bce_loss = fluid.dygraph.BCELoss(weight=weight)
             res = bce_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -93,7 +93,7 @@ class TestBCELoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            bce_loss = paddle.dygraph.BCELoss(
+            bce_loss = fluid.dygraph.BCELoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = bce_loss(
                 fluid.dygraph.to_variable(input_np),

--- a/python/paddle/fluid/tests/unittests/test_compare_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_op.py
@@ -82,7 +82,7 @@ class API_TestElementwise_Equal(unittest.TestCase):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
             label = fluid.layers.assign(np.array([3, 3], dtype="int32"))
             limit = fluid.layers.assign(np.array([3, 2], dtype="int32"))
-            out = paddle.elementwise_equal(x=label, y=limit)
+            out = fluid.layers.elementwise_equal(x=label, y=limit)
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             res, = exe.run(fetch_list=[out])
@@ -91,7 +91,7 @@ class API_TestElementwise_Equal(unittest.TestCase):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
             label = fluid.layers.assign(np.array([3, 3], dtype="int32"))
             limit = fluid.layers.assign(np.array([3, 3], dtype="int32"))
-            out = paddle.elementwise_equal(x=label, y=limit)
+            out = fluid.layers.elementwise_equal(x=label, y=limit)
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             res, = exe.run(fetch_list=[out])

--- a/python/paddle/fluid/tests/unittests/test_compare_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_reduce_op.py
@@ -148,7 +148,7 @@ class TestEqualReduceAPI(unittest.TestCase):
     def test_name(self):
         x = fluid.layers.assign(np.array([3, 4], dtype="int32"))
         y = fluid.layers.assign(np.array([3, 4], dtype="int32"))
-        out = paddle.equal(x, y, name='equal_res')
+        out = fluid.layers.equal(x, y, name='equal_res')
         assert 'equal_res' in out.name
 
 

--- a/python/paddle/fluid/tests/unittests/test_compare_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_compare_reduce_op.py
@@ -148,7 +148,7 @@ class TestEqualReduceAPI(unittest.TestCase):
     def test_name(self):
         x = fluid.layers.assign(np.array([3, 4], dtype="int32"))
         y = fluid.layers.assign(np.array([3, 4], dtype="int32"))
-        out = fluid.layers.equal(x, y, name='equal_res')
+        out = paddle.equal(x, y, name='equal_res')
         assert 'equal_res' in out.name
 
 

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
@@ -35,7 +35,7 @@ class CrossEntropyLoss(unittest.TestCase):
             label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
             weight = fluid.layers.data(
                 name='weight', shape=[100], dtype='float32')
-            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(weight=weight)
+            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(weight=weight)
             ret = cross_entropy_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -48,7 +48,7 @@ class CrossEntropyLoss(unittest.TestCase):
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         with fluid.dygraph.guard():
-            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_ret = cross_entropy_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -71,7 +71,7 @@ class CrossEntropyLoss(unittest.TestCase):
             label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
             weight = fluid.layers.data(
                 name='weight', shape=[100], dtype='float32')
-            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
                 weight=weight, reduction='sum')
             ret = cross_entropy_loss(input, label)
 
@@ -85,7 +85,7 @@ class CrossEntropyLoss(unittest.TestCase):
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         with fluid.dygraph.guard():
-            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_ret = cross_entropy_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -108,7 +108,7 @@ class CrossEntropyLoss(unittest.TestCase):
             label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
             weight = fluid.layers.data(
                 name='weight', shape=[100], dtype='float32')
-            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
                 weight=weight, reduction='none')
             ret = cross_entropy_loss(input, label)
 
@@ -122,7 +122,7 @@ class CrossEntropyLoss(unittest.TestCase):
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         with fluid.dygraph.guard():
-            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_ret = cross_entropy_loss(
                 fluid.dygraph.to_variable(input_np),

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
@@ -35,7 +35,7 @@ class CrossEntropyLoss(unittest.TestCase):
             label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
             weight = fluid.layers.data(
                 name='weight', shape=[100], dtype='float32')
-            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(weight=weight)
+            cross_entropy_loss = fluid.dygraph.CrossEntropyLoss(weight=weight)
             ret = cross_entropy_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -48,7 +48,7 @@ class CrossEntropyLoss(unittest.TestCase):
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         with fluid.dygraph.guard():
-            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
+            cross_entropy_loss = fluid.dygraph.CrossEntropyLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_ret = cross_entropy_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -71,7 +71,7 @@ class CrossEntropyLoss(unittest.TestCase):
             label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
             weight = fluid.layers.data(
                 name='weight', shape=[100], dtype='float32')
-            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
+            cross_entropy_loss = fluid.dygraph.CrossEntropyLoss(
                 weight=weight, reduction='sum')
             ret = cross_entropy_loss(input, label)
 
@@ -85,7 +85,7 @@ class CrossEntropyLoss(unittest.TestCase):
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         with fluid.dygraph.guard():
-            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
+            cross_entropy_loss = fluid.dygraph.CrossEntropyLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_ret = cross_entropy_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -108,7 +108,7 @@ class CrossEntropyLoss(unittest.TestCase):
             label = fluid.layers.data(name='label', shape=[5, 1], dtype='int64')
             weight = fluid.layers.data(
                 name='weight', shape=[100], dtype='float32')
-            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
+            cross_entropy_loss = fluid.dygraph.CrossEntropyLoss(
                 weight=weight, reduction='none')
             ret = cross_entropy_loss(input, label)
 
@@ -122,7 +122,7 @@ class CrossEntropyLoss(unittest.TestCase):
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         with fluid.dygraph.guard():
-            cross_entropy_loss = paddle.dygraph.CrossEntropyLoss(
+            cross_entropy_loss = fluid.dygraph.CrossEntropyLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_ret = cross_entropy_loss(
                 fluid.dygraph.to_variable(input_np),

--- a/python/paddle/fluid/tests/unittests/test_fill_any_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_any_like_op.py
@@ -106,7 +106,7 @@ class TestFillAnyLikeOp_attr_out(unittest.TestCase):
         with fluid.program_guard(train_program, startup_program):
             fill_value = 2.0
             input = fluid.data(name='input', dtype='float32', shape=[2, 3])
-            output = paddle.full_like(input, fill_value)
+            output = fluid.layers.full_like(input, fill_value)
 
             place = fluid.CPUPlace()
             if fluid.core.is_compiled_with_cuda():
@@ -132,20 +132,20 @@ class TestFillAnyLikeOpError(unittest.TestCase):
             #for ci coverage
 
             input_data = fluid.data(name='input', dtype='float32', shape=[2, 3])
-            output = paddle.full_like(input_data, 2.0)
+            output = fluid.layers.full_like(input_data, 2.0)
 
             def test_input_dtype():
-                paddle.full_like
+                fluid.layers.full_like
 
             self.assertRaises(
                 ValueError,
-                paddle.full_like,
+                fluid.layers.full_like,
                 input=input_data,
                 fill_value=2,
                 dtype='uint4')
             self.assertRaises(
                 TypeError,
-                paddle.full_like,
+                fluid.layers.full_like,
                 input=input_data,
                 fill_value=2,
                 dtype='int16')

--- a/python/paddle/fluid/tests/unittests/test_flip.py
+++ b/python/paddle/fluid/tests/unittests/test_flip.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
@@ -32,7 +31,7 @@ class TestFlipOp_API(unittest.TestCase):
         with fluid.program_guard(train_program, startup_program):
             dims = [0]
             input = fluid.data(name='input', dtype='float32', shape=[2, 3])
-            output = paddle.flip(input, dims)
+            output = fluid.layers.flip(input, dims)
             place = fluid.CPUPlace()
             if fluid.core.is_compiled_with_cuda():
                 place = fluid.CUDAPlace(0)
@@ -52,7 +51,7 @@ class TestFlipOp_API(unittest.TestCase):
         img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
         with fluid.dygraph.guard():
             inputs = fluid.dygraph.to_variable(img)
-            ret = paddle.flip(inputs, [0])
+            ret = fluid.layers.flip(inputs, [0])
             out_ref = np.array([[4, 5, 6], [1, 2, 3]]).astype(np.float32)
             self.assertTrue(
                 (ret.numpy() == out_ref).all(),

--- a/python/paddle/fluid/tests/unittests/test_full_op.py
+++ b/python/paddle/fluid/tests/unittests/test_full_op.py
@@ -21,7 +21,6 @@ from op_test import OpTest
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
-import paddle
 from paddle.fluid import compiler, Program, program_guard
 
 
@@ -37,39 +36,39 @@ class TestFullAPI(unittest.TestCase):
         shape_tensor_int64 = fluid.data(
             name="shape_tensor_int64", shape=[2], dtype="int64")
 
-        out_1 = paddle.full(
+        out_1 = fluid.layers.full(
             shape=[1, 2], dtype="float32", fill_value=1.1, device='gpu')
 
-        out_2 = paddle.full(
+        out_2 = fluid.layers.full(
             shape=[1, positive_2_int32],
             dtype="float32",
             fill_value=1.1,
             device='cpu')
 
-        out_3 = paddle.full(
+        out_3 = fluid.layers.full(
             shape=[1, positive_2_int64],
             dtype="float32",
             fill_value=1.1,
             device='gpu')
 
-        out_4 = paddle.full(
+        out_4 = fluid.layers.full(
             shape=shape_tensor_int32,
             dtype="float32",
             fill_value=1.2,
             out=out_3)
 
-        out_5 = paddle.full(
+        out_5 = fluid.layers.full(
             shape=shape_tensor_int64,
             dtype="float32",
             fill_value=1.1,
             device='gpu',
             stop_gradient=False)
 
-        out_6 = paddle.full(
+        out_6 = fluid.layers.full(
             shape=shape_tensor_int64, dtype=np.float32, fill_value=1.1)
 
         val = fluid.layers.fill_constant(shape=[1], dtype=np.float32, value=1.1)
-        out_7 = paddle.full(
+        out_7 = fluid.layers.full(
             shape=shape_tensor_int64, dtype=np.float32, fill_value=val)
 
         exe = fluid.Executor(place=fluid.CPUPlace())
@@ -97,17 +96,21 @@ class TestFullOpError(unittest.TestCase):
             x1 = fluid.layers.data(name='x1', shape=[1], dtype="int16")
             x2 = np.random.randn(1, 2).astype('int32')
             self.assertRaises(
-                ValueError, paddle.full, shape=[1], fill_value=5, dtype='uint4')
+                ValueError,
+                fluid.layers.full,
+                shape=[1],
+                fill_value=5,
+                dtype='uint4')
             self.assertRaises(
                 TypeError,
-                paddle.full,
+                fluid.layers.full,
                 shape=[1],
                 fill_value=5,
                 dtype='int32',
                 out=x2)
             self.assertRaises(
                 TypeError,
-                paddle.full,
+                fluid.layers.full,
                 shape=[1],
                 fill_value=5,
                 dtype='int16',
@@ -118,17 +121,21 @@ class TestFullOpError(unittest.TestCase):
             x2 = fluid.layers.data(name='x2', shape=[1], dtype="int32")
 
             self.assertRaises(
-                TypeError, paddle.full, shape=[1], fill_value=5, dtype='uint8')
+                TypeError,
+                fluid.layers.full,
+                shape=[1],
+                fill_value=5,
+                dtype='uint8')
 
             # The argument shape's type of full_op  must be list, tuple or Variable.
             def test_shape_type():
-                paddle.full(shape=1, dtype="float32", fill_value=1)
+                fluid.layers.full(shape=1, dtype="float32", fill_value=1)
 
             self.assertRaises(TypeError, test_shape_type)
 
             # The argument shape's size of full_op must not be 0.
             def test_shape_size():
-                paddle.full(shape=[], dtype="float32", fill_value=1)
+                fluid.layers.full(shape=[], dtype="float32", fill_value=1)
 
             self.assertRaises(AssertionError, test_shape_size)
 
@@ -136,14 +143,15 @@ class TestFullOpError(unittest.TestCase):
             def test_shape_tensor_dtype():
                 shape = fluid.data(
                     name="shape_tensor", shape=[2], dtype="float32")
-                paddle.full(shape=shape, dtype="float32", fill_value=1)
+                fluid.layers.full(shape=shape, dtype="float32", fill_value=1)
 
             self.assertRaises(TypeError, test_shape_tensor_dtype)
 
             def test_shape_tensor_list_dtype():
                 shape = fluid.data(
                     name="shape_tensor_list", shape=[1], dtype="bool")
-                paddle.full(shape=[shape, 2], dtype="float32", fill_value=1)
+                fluid.layers.full(
+                    shape=[shape, 2], dtype="float32", fill_value=1)
 
             self.assertRaises(TypeError, test_shape_tensor_list_dtype)
 

--- a/python/paddle/fluid/tests/unittests/test_l1_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_l1_loss.py
@@ -33,7 +33,7 @@ class TestL1Loss(unittest.TestCase):
                 name='input', shape=[10, 1], dtype='float32')
             label = fluid.layers.data(
                 name='label', shape=[10, 1], dtype='float32')
-            l1_loss = paddle.dygraph.L1Loss()
+            l1_loss = fluid.dygraph.L1Loss()
             ret = l1_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -44,7 +44,7 @@ class TestL1Loss(unittest.TestCase):
                 fetch_list=[ret])
 
         with fluid.dygraph.guard():
-            l1_loss = paddle.dygraph.L1Loss()
+            l1_loss = fluid.dygraph.L1Loss()
             dy_ret = l1_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -68,7 +68,7 @@ class TestL1Loss(unittest.TestCase):
                 name='input', shape=[10, 10, 5], dtype='float32')
             label = fluid.layers.data(
                 name='label', shape=[10, 10, 5], dtype='float32')
-            l1_loss = paddle.dygraph.L1Loss(reduction='sum')
+            l1_loss = fluid.dygraph.L1Loss(reduction='sum')
             ret = l1_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -79,7 +79,7 @@ class TestL1Loss(unittest.TestCase):
                 fetch_list=[ret])
 
         with fluid.dygraph.guard():
-            l1_loss = paddle.dygraph.L1Loss(reduction='sum')
+            l1_loss = fluid.dygraph.L1Loss(reduction='sum')
             dy_ret = l1_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -103,7 +103,7 @@ class TestL1Loss(unittest.TestCase):
                 name='input', shape=[10, 5], dtype='float32')
             label = fluid.layers.data(
                 name='label', shape=[10, 5], dtype='float32')
-            l1_loss = paddle.dygraph.L1Loss(reduction='none')
+            l1_loss = fluid.dygraph.L1Loss(reduction='none')
             ret = l1_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -114,7 +114,7 @@ class TestL1Loss(unittest.TestCase):
                 fetch_list=[ret])
 
         with fluid.dygraph.guard():
-            l1_loss = paddle.dygraph.L1Loss(reduction='none')
+            l1_loss = fluid.dygraph.L1Loss(reduction='none')
             dy_ret = l1_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))

--- a/python/paddle/fluid/tests/unittests/test_l1_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_l1_loss.py
@@ -33,7 +33,7 @@ class TestL1Loss(unittest.TestCase):
                 name='input', shape=[10, 1], dtype='float32')
             label = fluid.layers.data(
                 name='label', shape=[10, 1], dtype='float32')
-            l1_loss = paddle.nn.loss.L1Loss()
+            l1_loss = paddle.dygraph.L1Loss()
             ret = l1_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -44,7 +44,7 @@ class TestL1Loss(unittest.TestCase):
                 fetch_list=[ret])
 
         with fluid.dygraph.guard():
-            l1_loss = paddle.nn.loss.L1Loss()
+            l1_loss = paddle.dygraph.L1Loss()
             dy_ret = l1_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -68,7 +68,7 @@ class TestL1Loss(unittest.TestCase):
                 name='input', shape=[10, 10, 5], dtype='float32')
             label = fluid.layers.data(
                 name='label', shape=[10, 10, 5], dtype='float32')
-            l1_loss = paddle.nn.loss.L1Loss(reduction='sum')
+            l1_loss = paddle.dygraph.L1Loss(reduction='sum')
             ret = l1_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -79,7 +79,7 @@ class TestL1Loss(unittest.TestCase):
                 fetch_list=[ret])
 
         with fluid.dygraph.guard():
-            l1_loss = paddle.nn.loss.L1Loss(reduction='sum')
+            l1_loss = paddle.dygraph.L1Loss(reduction='sum')
             dy_ret = l1_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -103,7 +103,7 @@ class TestL1Loss(unittest.TestCase):
                 name='input', shape=[10, 5], dtype='float32')
             label = fluid.layers.data(
                 name='label', shape=[10, 5], dtype='float32')
-            l1_loss = paddle.nn.loss.L1Loss(reduction='none')
+            l1_loss = paddle.dygraph.L1Loss(reduction='none')
             ret = l1_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -114,7 +114,7 @@ class TestL1Loss(unittest.TestCase):
                 fetch_list=[ret])
 
         with fluid.dygraph.guard():
-            l1_loss = paddle.nn.loss.L1Loss(reduction='none')
+            l1_loss = paddle.dygraph.L1Loss(reduction='none')
             dy_ret = l1_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))

--- a/python/paddle/fluid/tests/unittests/test_log_softmax.py
+++ b/python/paddle/fluid/tests/unittests/test_log_softmax.py
@@ -17,7 +17,6 @@ import numpy as np
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import paddle.nn as nn
-import paddle.nn.functional as functional
 
 
 def stable_softmax(x):
@@ -84,14 +83,14 @@ class TestNNFunctionalLogSoftmaxAPI(unittest.TestCase):
         mylogsoftmax = nn.LogSoftmax(axis)
         with fluid.program_guard(main_program):
             x = fluid.data(name='x', shape=self.x_shape)
-            y = functional.log_softmax(x, axis, dtype)
+            y = fluid.layers.log_softmax(x, axis, dtype)
         exe = fluid.Executor(place)
         out = exe.run(main_program, feed={'x': self.x}, fetch_list=[y])
         self.assertTrue(np.allclose(out[0], ref_out))
 
         with fluid.dygraph.guard(place):
             x = fluid.dygraph.to_variable(self.x)
-            y = functional.log_softmax(x, axis, dtype)
+            y = fluid.layers.log_softmax(x, axis, dtype)
         self.assertTrue(np.allclose(y.numpy(), ref_out))
 
     def test_check_api(self):

--- a/python/paddle/fluid/tests/unittests/test_meshgrid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_meshgrid_op.py
@@ -18,7 +18,6 @@ import unittest
 import numpy as np
 from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
-import paddle
 from paddle.fluid import compiler, Program, program_guard, core
 
 
@@ -79,7 +78,7 @@ class TestMeshgridOp3(unittest.TestCase):
         out_2 = np.broadcast_to(out_2, [100, 200])
 
         exe = fluid.Executor(place=fluid.CPUPlace())
-        grid_x, grid_y = paddle.tensor.meshgrid([x, y])
+        grid_x, grid_y = fluid.layers.meshgrid([x, y])
         res_1, res_2 = exe.run(fluid.default_main_program(),
                                feed={'x': input_1,
                                      'y': input_2},
@@ -95,7 +94,7 @@ class TestMeshgridOp4(unittest.TestCase):
 
             def test_input_type():
                 x = fluid.data(shape=[200], dtype='float32', name='x2')
-                paddle.tensor.meshgrid(x)
+                fluid.layers.meshgrid(x)
 
         self.assertRaises(TypeError, test_input_type)
 
@@ -108,7 +107,7 @@ class TestMeshgridOp5(unittest.TestCase):
         with fluid.dygraph.guard():
             tensor_3 = fluid.dygraph.to_variable(input_3)
             tensor_4 = fluid.dygraph.to_variable(input_4)
-            res_3, res_4 = paddle.tensor.meshgrid([tensor_3, tensor_4])
+            res_3, res_4 = fluid.layers.meshgrid([tensor_3, tensor_4])
 
             assert np.array_equal(res_3.shape, [100, 200])
             assert np.array_equal(res_4.shape, [100, 200])

--- a/python/paddle/fluid/tests/unittests/test_meshgrid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_meshgrid_op.py
@@ -19,6 +19,7 @@ import numpy as np
 from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
 from paddle.fluid import compiler, Program, program_guard, core
+import paddle
 
 
 class TestMeshgridOp(OpTest):
@@ -78,7 +79,7 @@ class TestMeshgridOp3(unittest.TestCase):
         out_2 = np.broadcast_to(out_2, [100, 200])
 
         exe = fluid.Executor(place=fluid.CPUPlace())
-        grid_x, grid_y = fluid.layers.meshgrid([x, y])
+        grid_x, grid_y = paddle.meshgrid([x, y])
         res_1, res_2 = exe.run(fluid.default_main_program(),
                                feed={'x': input_1,
                                      'y': input_2},
@@ -94,7 +95,7 @@ class TestMeshgridOp4(unittest.TestCase):
 
             def test_input_type():
                 x = fluid.data(shape=[200], dtype='float32', name='x2')
-                fluid.layers.meshgrid(x)
+                paddle.meshgrid(x)
 
         self.assertRaises(TypeError, test_input_type)
 
@@ -107,7 +108,7 @@ class TestMeshgridOp5(unittest.TestCase):
         with fluid.dygraph.guard():
             tensor_3 = fluid.dygraph.to_variable(input_3)
             tensor_4 = fluid.dygraph.to_variable(input_4)
-            res_3, res_4 = fluid.layers.meshgrid([tensor_3, tensor_4])
+            res_3, res_4 = paddle.meshgrid([tensor_3, tensor_4])
 
             assert np.array_equal(res_3.shape, [100, 200])
             assert np.array_equal(res_4.shape, [100, 200])

--- a/python/paddle/fluid/tests/unittests/test_mse_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_mse_loss.py
@@ -78,7 +78,7 @@ class TestNNMseLoss(unittest.TestCase):
                     name='input', shape=dim, dtype='float32')
                 label = fluid.layers.data(
                     name='label', shape=dim, dtype='float32')
-                mse_loss = paddle.dygraph.MSELoss()
+                mse_loss = fluid.dygraph.MSELoss()
                 ret = mse_loss(input, label)
 
                 exe = fluid.Executor(place)
@@ -89,7 +89,7 @@ class TestNNMseLoss(unittest.TestCase):
                     fetch_list=[ret])
 
             with fluid.dygraph.guard():
-                mse_loss = paddle.dygraph.MSELoss()
+                mse_loss = fluid.dygraph.MSELoss()
                 dy_ret = mse_loss(
                     fluid.dygraph.to_variable(input_np),
                     fluid.dygraph.to_variable(label_np))
@@ -115,7 +115,7 @@ class TestNNMseLoss(unittest.TestCase):
                     name='input', shape=dim, dtype='float32')
                 label = fluid.layers.data(
                     name='label', shape=dim, dtype='float32')
-                mse_loss = paddle.dygraph.MSELoss(reduction='sum')
+                mse_loss = fluid.dygraph.MSELoss(reduction='sum')
                 ret = mse_loss(input, label)
 
                 exe = fluid.Executor(place)
@@ -126,7 +126,7 @@ class TestNNMseLoss(unittest.TestCase):
                     fetch_list=[ret])
 
             with fluid.dygraph.guard():
-                mse_loss = paddle.dygraph.MSELoss(reduction='sum')
+                mse_loss = fluid.dygraph.MSELoss(reduction='sum')
                 dy_ret = mse_loss(
                     fluid.dygraph.to_variable(input_np),
                     fluid.dygraph.to_variable(label_np))
@@ -152,7 +152,7 @@ class TestNNMseLoss(unittest.TestCase):
                     name='input', shape=dim, dtype='float32')
                 label = fluid.layers.data(
                     name='label', shape=dim, dtype='float32')
-                mse_loss = paddle.dygraph.MSELoss(reduction='none')
+                mse_loss = fluid.dygraph.MSELoss(reduction='none')
                 ret = mse_loss(input, label)
 
                 exe = fluid.Executor(place)
@@ -163,7 +163,7 @@ class TestNNMseLoss(unittest.TestCase):
                     fetch_list=[ret])
 
             with fluid.dygraph.guard():
-                mse_loss = paddle.dygraph.MSELoss(reduction='none')
+                mse_loss = fluid.dygraph.MSELoss(reduction='none')
                 dy_ret = mse_loss(
                     fluid.dygraph.to_variable(input_np),
                     fluid.dygraph.to_variable(label_np))

--- a/python/paddle/fluid/tests/unittests/test_mse_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_mse_loss.py
@@ -78,7 +78,7 @@ class TestNNMseLoss(unittest.TestCase):
                     name='input', shape=dim, dtype='float32')
                 label = fluid.layers.data(
                     name='label', shape=dim, dtype='float32')
-                mse_loss = paddle.nn.loss.MSELoss()
+                mse_loss = paddle.dygraph.MSELoss()
                 ret = mse_loss(input, label)
 
                 exe = fluid.Executor(place)
@@ -89,7 +89,7 @@ class TestNNMseLoss(unittest.TestCase):
                     fetch_list=[ret])
 
             with fluid.dygraph.guard():
-                mse_loss = paddle.nn.loss.MSELoss()
+                mse_loss = paddle.dygraph.MSELoss()
                 dy_ret = mse_loss(
                     fluid.dygraph.to_variable(input_np),
                     fluid.dygraph.to_variable(label_np))
@@ -115,7 +115,7 @@ class TestNNMseLoss(unittest.TestCase):
                     name='input', shape=dim, dtype='float32')
                 label = fluid.layers.data(
                     name='label', shape=dim, dtype='float32')
-                mse_loss = paddle.nn.loss.MSELoss(reduction='sum')
+                mse_loss = paddle.dygraph.MSELoss(reduction='sum')
                 ret = mse_loss(input, label)
 
                 exe = fluid.Executor(place)
@@ -126,7 +126,7 @@ class TestNNMseLoss(unittest.TestCase):
                     fetch_list=[ret])
 
             with fluid.dygraph.guard():
-                mse_loss = paddle.nn.loss.MSELoss(reduction='sum')
+                mse_loss = paddle.dygraph.MSELoss(reduction='sum')
                 dy_ret = mse_loss(
                     fluid.dygraph.to_variable(input_np),
                     fluid.dygraph.to_variable(label_np))
@@ -152,7 +152,7 @@ class TestNNMseLoss(unittest.TestCase):
                     name='input', shape=dim, dtype='float32')
                 label = fluid.layers.data(
                     name='label', shape=dim, dtype='float32')
-                mse_loss = paddle.nn.loss.MSELoss(reduction='none')
+                mse_loss = paddle.dygraph.MSELoss(reduction='none')
                 ret = mse_loss(input, label)
 
                 exe = fluid.Executor(place)
@@ -163,7 +163,7 @@ class TestNNMseLoss(unittest.TestCase):
                     fetch_list=[ret])
 
             with fluid.dygraph.guard():
-                mse_loss = paddle.nn.loss.MSELoss(reduction='none')
+                mse_loss = paddle.dygraph.MSELoss(reduction='none')
                 dy_ret = mse_loss(
                     fluid.dygraph.to_variable(input_np),
                     fluid.dygraph.to_variable(label_np))

--- a/python/paddle/fluid/tests/unittests/test_nll_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_nll_loss.py
@@ -82,7 +82,7 @@ class TestNLLLoss(unittest.TestCase):
         with fluid.program_guard(prog, startup_prog):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
-            nll_loss = paddle.dygraph.NLLLoss()
+            nll_loss = fluid.dygraph.NLLLoss()
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -93,7 +93,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss()
+            nll_loss = fluid.dygraph.NLLLoss()
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -115,7 +115,7 @@ class TestNLLLoss(unittest.TestCase):
         with fluid.program_guard(prog, startup_prog):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
-            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -126,7 +126,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -150,7 +150,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -163,7 +163,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -188,7 +188,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight, reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -201,7 +201,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -225,7 +225,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -238,7 +238,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -261,7 +261,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='none')
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight, reduction='none')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -274,7 +274,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -299,7 +299,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(
                 name='input', shape=[5, 3, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
-            nll_loss = paddle.dygraph.NLLLoss()
+            nll_loss = fluid.dygraph.NLLLoss()
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -310,7 +310,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss()
+            nll_loss = fluid.dygraph.NLLLoss()
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -334,7 +334,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(
                 name='input', shape=[5, 3, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
-            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -345,7 +345,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -372,7 +372,7 @@ class TestNLLLoss(unittest.TestCase):
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
 
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -385,7 +385,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -411,7 +411,7 @@ class TestNLLLoss(unittest.TestCase):
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
 
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -424,7 +424,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -452,7 +452,7 @@ class TestNLLLoss(unittest.TestCase):
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
 
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight, reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -465,7 +465,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -491,7 +491,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
-            nll_loss = paddle.dygraph.NLLLoss()
+            nll_loss = fluid.dygraph.NLLLoss()
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -502,7 +502,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss()
+            nll_loss = fluid.dygraph.NLLLoss()
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -533,7 +533,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -546,7 +546,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -579,7 +579,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='sum')
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight, reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -592,7 +592,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -628,7 +628,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='none')
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight, reduction='none')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -641,7 +641,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -676,7 +676,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='none')
+            nll_loss = fluid.dygraph.NLLLoss(weight=weight, reduction='none')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -689,7 +689,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.dygraph.NLLLoss(
+            nll_loss = fluid.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),

--- a/python/paddle/fluid/tests/unittests/test_nll_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_nll_loss.py
@@ -82,7 +82,7 @@ class TestNLLLoss(unittest.TestCase):
         with fluid.program_guard(prog, startup_prog):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
-            nll_loss = paddle.nn.loss.NLLLoss()
+            nll_loss = paddle.dygraph.NLLLoss()
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -93,7 +93,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss()
+            nll_loss = paddle.dygraph.NLLLoss()
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -115,7 +115,7 @@ class TestNLLLoss(unittest.TestCase):
         with fluid.program_guard(prog, startup_prog):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
-            nll_loss = paddle.nn.loss.NLLLoss(reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -126,7 +126,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -150,7 +150,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight)
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -163,7 +163,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -188,7 +188,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight, reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -201,7 +201,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -225,7 +225,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight)
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -238,7 +238,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -261,7 +261,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[10, 10], dtype='float64')
             label = fluid.data(name='label', shape=[10], dtype='int64')
             weight = fluid.data(name='weight', shape=[10], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight, reduction='none')
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='none')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -274,7 +274,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -299,7 +299,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(
                 name='input', shape=[5, 3, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
-            nll_loss = paddle.nn.loss.NLLLoss()
+            nll_loss = paddle.dygraph.NLLLoss()
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -310,7 +310,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss()
+            nll_loss = paddle.dygraph.NLLLoss()
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -334,7 +334,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(
                 name='input', shape=[5, 3, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
-            nll_loss = paddle.nn.loss.NLLLoss(reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -345,7 +345,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -372,7 +372,7 @@ class TestNLLLoss(unittest.TestCase):
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
 
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight)
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -385,7 +385,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -411,7 +411,7 @@ class TestNLLLoss(unittest.TestCase):
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
 
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight)
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -424,7 +424,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -452,7 +452,7 @@ class TestNLLLoss(unittest.TestCase):
             label = fluid.data(name='label', shape=[5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
 
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight, reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -465,7 +465,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -491,7 +491,7 @@ class TestNLLLoss(unittest.TestCase):
             input = fluid.data(
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
-            nll_loss = paddle.nn.loss.NLLLoss()
+            nll_loss = paddle.dygraph.NLLLoss()
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -502,7 +502,7 @@ class TestNLLLoss(unittest.TestCase):
                 fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss()
+            nll_loss = paddle.dygraph.NLLLoss()
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
                 fluid.dygraph.to_variable(label_np))
@@ -533,7 +533,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight)
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight)
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -546,7 +546,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np))
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -579,7 +579,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight, reduction='sum')
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='sum')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -592,7 +592,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='sum')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -628,7 +628,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight, reduction='none')
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='none')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -641,7 +641,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),
@@ -676,7 +676,7 @@ class TestNLLLoss(unittest.TestCase):
                 name='input', shape=[5, 3, 5, 5, 5], dtype='float64')
             label = fluid.data(name='label', shape=[5, 5, 5, 5], dtype='int64')
             weight = fluid.data(name='weight', shape=[3], dtype='float64')
-            nll_loss = paddle.nn.loss.NLLLoss(weight=weight, reduction='none')
+            nll_loss = paddle.dygraph.NLLLoss(weight=weight, reduction='none')
             res = nll_loss(input, label)
 
             exe = fluid.Executor(place)
@@ -689,7 +689,7 @@ class TestNLLLoss(unittest.TestCase):
                                     fetch_list=[res])
 
         with fluid.dygraph.guard():
-            nll_loss = paddle.nn.loss.NLLLoss(
+            nll_loss = paddle.dygraph.NLLLoss(
                 weight=fluid.dygraph.to_variable(weight_np), reduction='none')
             dy_res = nll_loss(
                 fluid.dygraph.to_variable(input_np),

--- a/python/paddle/fluid/tests/unittests/test_randint_op.py
+++ b/python/paddle/fluid/tests/unittests/test_randint_op.py
@@ -22,7 +22,6 @@ import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
-import paddle
 
 
 def output_hist(out):
@@ -62,17 +61,18 @@ class TestRandintOpError(unittest.TestCase):
 
             def test_shape():
                 shape = np.array([2, 3])
-                paddle.randint(5, shape=shape, dtype='int32')
+                fluid.layers.randint(5, shape=shape, dtype='int32')
 
             self.assertRaises(TypeError, test_shape)
 
             def test_dtype():
-                paddle.randint(5, shape=[32, 32], dtype='float32')
+                fluid.layers.randint(5, shape=[32, 32], dtype='float32')
 
             self.assertRaises(TypeError, test_dtype)
 
             def test_low_high():
-                paddle.randint(low=5, high=5, shape=[32, 32], dtype='int32')
+                fluid.layers.randint(
+                    low=5, high=5, shape=[32, 32], dtype='int32')
 
             self.assertRaises(ValueError, test_low_high)
 
@@ -131,21 +131,21 @@ class TestRandintAPI(unittest.TestCase):
         train_program = fluid.Program()
         with fluid.program_guard(train_program, startup_program):
             # results are from [0, 5).
-            output1 = paddle.randint(5)
+            output1 = fluid.layers.randint(5)
             # shape is a list and dtype is 'int32'
-            output2 = paddle.randint(
+            output2 = fluid.layers.randint(
                 low=-100, high=100, shape=[64, 64], dtype='int32')
             # shape is a tuple and dtype is 'int64'
-            output3 = paddle.randint(
+            output3 = fluid.layers.randint(
                 low=-100, high=100, shape=(32, 32, 3), dtype='int64')
             # shape is a tensorlist and dtype is 'float32'
             dim_1 = fluid.layers.fill_constant([1], "int64", 32)
             dim_2 = fluid.layers.fill_constant([1], "int32", 50)
-            output4 = paddle.randint(
+            output4 = fluid.layers.randint(
                 low=-100, high=100, shape=[dim_1, 5], dtype='int32')
             # shape is a tensor and dtype is 'float64'
             var_shape = fluid.data(name='var_shape', shape=[2], dtype="int64")
-            output5 = paddle.randint(
+            output5 = fluid.layers.randint(
                 low=1, high=1000, shape=var_shape, dtype='int64')
 
             place = fluid.CPUPlace()
@@ -163,7 +163,7 @@ class TestRandintAPI(unittest.TestCase):
 class TestRandintDygraphMode(unittest.TestCase):
     def test_check_output(self):
         with fluid.dygraph.guard():
-            x = paddle.randint(10, shape=[10], dtype="int32")
+            x = fluid.layers.randint(10, shape=[10], dtype="int32")
             x_np = x.numpy()
             for i in range(10):
                 self.assertTrue((x_np[i] >= 0 and x_np[i] < 10))

--- a/python/paddle/fluid/tests/unittests/test_randn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_randn_op.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid import Program, program_guard
@@ -24,14 +23,16 @@ from paddle.fluid import Program, program_guard
 
 class TestRandnOp(unittest.TestCase):
     def test_api(self):
-        x1 = paddle.randn(shape=[1000, 784], dtype='float32')
-        x2 = paddle.randn(shape=[1000, 784], dtype='float64')
+        x1 = fluid.layers.randn(shape=[1000, 784], dtype='float32')
+        x2 = fluid.layers.randn(shape=[1000, 784], dtype='float64')
         x3 = fluid.layers.fill_constant(
             shape=[1000, 784], dtype='float32', value=0)
-        paddle.randn(shape=[1000, 784], out=x3, dtype='float32')
-        x4 = paddle.randn(shape=[1000, 784], dtype='float32', device='cpu')
-        x5 = paddle.randn(shape=[1000, 784], dtype='float32', device='gpu')
-        x6 = paddle.randn(
+        fluid.layers.randn(shape=[1000, 784], out=x3, dtype='float32')
+        x4 = fluid.layers.randn(
+            shape=[1000, 784], dtype='float32', device='cpu')
+        x5 = fluid.layers.randn(
+            shape=[1000, 784], dtype='float32', device='gpu')
+        x6 = fluid.layers.randn(
             shape=[1000, 784],
             dtype='float32',
             device='gpu',
@@ -64,43 +65,43 @@ class TestRandnOpError(unittest.TestCase):
 
             # The argument shape's size of randn_op should not be 0.
             def test_shape_size():
-                out = paddle.randn(shape=[])
+                out = fluid.layers.randn(shape=[])
 
             self.assertRaises(AssertionError, test_shape_size)
 
             # The argument shape's type of randn_op should be list or tuple.
             def test_shape_type():
-                out = paddle.randn(shape=1)
+                out = fluid.layers.randn(shape=1)
 
             self.assertRaises(TypeError, test_shape_type)
 
             # The argument dtype of randn_op should be float32 or float64.
             def test_dtype_float16():
-                out = paddle.randn(shape=[1, 2], dtype='float16')
+                out = fluid.layers.randn(shape=[1, 2], dtype='float16')
 
             self.assertRaises(TypeError, test_dtype_float16)
 
             # The argument dtype of randn_op should be float32 or float64.
             def test_dtype_int32():
-                out = paddle.randn(shape=[1, 2], dtype='int32')
+                out = fluid.layers.randn(shape=[1, 2], dtype='int32')
 
             self.assertRaises(TypeError, test_dtype_int32)
 
             # The argument dtype of randn_op should be float32 or float64.
             def test_dtype_int64():
-                out = paddle.randn(shape=[1, 2], dtype='int64')
+                out = fluid.layers.randn(shape=[1, 2], dtype='int64')
 
             self.assertRaises(TypeError, test_dtype_int64)
 
             # The argument dtype of randn_op should be float32 or float64.
             def test_dtype_uint8():
-                out = paddle.randn(shape=[1, 2], dtype='uint8')
+                out = fluid.layers.randn(shape=[1, 2], dtype='uint8')
 
             self.assertRaises(TypeError, test_dtype_uint8)
 
             # The argument dtype of randn_op should be float32 or float64.
             def test_dtype_bool():
-                out = paddle.randn(shape=[1, 2], dtype='bool')
+                out = fluid.layers.randn(shape=[1, 2], dtype='bool')
 
             self.assertRaises(TypeError, test_dtype_bool)
 

--- a/python/paddle/fluid/tests/unittests/test_randperm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_randperm_op.py
@@ -15,7 +15,6 @@
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
@@ -120,12 +119,12 @@ class TestRandpermOpError(unittest.TestCase):
 
             def test_Variable():
                 out = np.arange(10)
-                paddle.randperm(n=10, out=out)
+                fluid.layers.randperm(n=10, out=out)
 
             self.assertRaises(TypeError, test_Variable)
 
             def test_value():
-                paddle.randperm(n=-3)
+                fluid.layers.randperm(n=-3)
 
             self.assertRaises(ValueError, test_value)
 
@@ -139,9 +138,9 @@ class TestRandpermOp_attr_out(unittest.TestCase):
         with fluid.program_guard(train_program, startup_program):
             n = 10
             data_1 = fluid.layers.fill_constant([n], "int64", 3)
-            paddle.randperm(n=n, out=data_1)
+            fluid.layers.randperm(n=n, out=data_1)
 
-            data_2 = paddle.randperm(n=n, dtype="int32", device="cpu")
+            data_2 = fluid.layers.randperm(n=n, dtype="int32", device="cpu")
 
             place = fluid.CPUPlace()
             if fluid.core.is_compiled_with_cuda():
@@ -160,12 +159,12 @@ class TestRandpermDygraphMode(unittest.TestCase):
     def test_check_output(self):
         with fluid.dygraph.guard():
             n = 10
-            data_1 = paddle.randperm(n, dtype="int64")
+            data_1 = fluid.layers.randperm(n, dtype="int64")
             data_1_np = data_1.numpy()
             self.assertTrue(
                 check_randperm_out(n, data_1_np), msg=error_msg(data_1_np))
 
-            data_2 = paddle.randperm(n, dtype="int32", device="cpu")
+            data_2 = fluid.layers.randperm(n, dtype="int32", device="cpu")
             data_2_np = data_2.numpy()
             self.assertTrue(
                 check_randperm_out(n, data_2_np), msg=error_msg(data_2_np))

--- a/python/paddle/fluid/tests/unittests/test_roll_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roll_op.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 
 import unittest
-import paddle
 import numpy as np
 import paddle.fluid.core as core
 from op_test import OpTest
@@ -66,7 +65,7 @@ class TestRollAPI(unittest.TestCase):
         # case 1:
         with program_guard(Program(), Program()):
             x = fluid.layers.data(name='x', shape=[-1, 3])
-            z = paddle.roll(x, shifts=1)
+            z = fluid.layers.roll(x, shifts=1)
             exe = fluid.Executor(fluid.CPUPlace())
             res, = exe.run(feed={'x': self.data_x},
                            fetch_list=[z.name],
@@ -78,7 +77,7 @@ class TestRollAPI(unittest.TestCase):
         # case 2:
         with program_guard(Program(), Program()):
             x = fluid.layers.data(name='x', shape=[-1, 3])
-            z = paddle.roll(x, shifts=1, dims=0)
+            z = fluid.layers.roll(x, shifts=1, dims=0)
             exe = fluid.Executor(fluid.CPUPlace())
             res, = exe.run(feed={'x': self.data_x},
                            fetch_list=[z.name],
@@ -92,7 +91,7 @@ class TestRollAPI(unittest.TestCase):
         # case 1:
         with fluid.dygraph.guard():
             x = fluid.dygraph.to_variable(self.data_x)
-            z = paddle.roll(x, shifts=1)
+            z = fluid.layers.roll(x, shifts=1)
             np_z = z.numpy()
         expect_out = np.array([[9.0, 1.0, 2.0], [3.0, 4.0, 5.0],
                                [6.0, 7.0, 8.0]])
@@ -101,7 +100,7 @@ class TestRollAPI(unittest.TestCase):
         # case 2:
         with fluid.dygraph.guard():
             x = fluid.dygraph.to_variable(self.data_x)
-            z = paddle.roll(x, shifts=1, dims=0)
+            z = fluid.layers.roll(x, shifts=1, dims=0)
             np_z = z.numpy()
         expect_out = np.array([[7.0, 8.0, 9.0], [1.0, 2.0, 3.0],
                                [4.0, 5.0, 6.0]])

--- a/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_tril_triu_op.py
@@ -17,7 +17,6 @@ import unittest
 import numpy as np
 from op_test import OpTest
 import paddle.fluid as fluid
-import paddle.tensor as tensor
 
 
 class TrilTriuOpDefaultTest(OpTest):
@@ -71,7 +70,7 @@ def case_generator(op_type, Xshape, diagonal, expected):
             data = fluid.data(shape=Xshape, dtype='float64', name=cls_name)
             with self.assertRaisesRegexp(
                     eval(expected.split(':')[-1]), errmsg[expected]):
-                getattr(tensor, op_type)(input=data, diagonal=diagonal)
+                getattr(fluid.layers, op_type)(input=data, diagonal=diagonal)
 
     class SuccessCase(TrilTriuOpDefaultTest):
         def initTestCase(self):
@@ -122,7 +121,7 @@ class TestTrilTriuOpAPI(unittest.TestCase):
     def test_api(self):
         data = np.random.random([1, 9, 9, 4]).astype('float32')
         x = fluid.data(shape=[1, 9, -1, 4], dtype='float32', name='x')
-        tril_out, triu_out = tensor.tril(x), tensor.triu(x)
+        tril_out, triu_out = fluid.layers.tril(x), fluid.layers.triu(x)
 
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()


### PR DESCRIPTION
copy api from paddle to paddle.fluid.

* paddle.tensor -> paddle.fluid.layers
* paddle.nn -> paddle.fluid.layers or paddle.fluid.dygraph

| paddle | paddle.fluid |
| ---------- | ---------- |
| paddle.nn.CrossEntropyLoss | paddle.fluid.dygraph.CrossEntropyLoss |
| paddle.nn.MSELoss | paddle.fluid.dygraph.MSELoss |
| paddle.nn.L1Loss | paddle.fluid.dygraph.L1Loss |
| paddle.nn.NLLLoss | paddle.fluid.dygraph.NLLLoss |
| paddle.nn.BCELoss | paddle.fluid.dygraph.BCELoss |
| paddle.tensor.randint | paddle.fluid.layers.randint |
| paddle.tensor.randn | paddle.fluid.layers.randn |
| paddle.tensor.randperm | paddle.fluid.layers.randperm |
| paddle.tensor.allclose | paddle.fluid.layers.allclose |
| paddle.tensor.elementwise_equal | paddle.fluid.layers.elementwise_equal |
| paddle.tensor.flip | paddle.fluid.layers.flip |
| paddle.tensor.roll | paddle.fluid.layers.roll |
| paddle.tensor.log_softmax | paddle.fluid.layers.log_softmax |
| paddle.tensor.full_like | paddle.fluid.layers.full_like |
| paddle.tensor.arange | paddle.fluid.layers.arange |
| paddle.tensor.full | paddle.fluid.layers.full |
| paddle.tensor.tril | paddle.fluid.layers.tril |
| paddle.tensor.triu | paddle.fluid.layers.triu |
