### PR TITLE
refine ccache statistics show

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -3,7 +3,12 @@
 find_program(CCACHE_PATH ccache)
 
 if(CCACHE_PATH)
+    execute_process(COMMAND ccache -V OUTPUT_VARIABLE ccache_output)
+    execute_process(COMMAND ccache -s cache directory OUTPUT_VARIABLE cache_directory)
+    string(REGEX MATCH "[0-9]+.[0-9]+" ccache_version ${ccache_output})
     message(STATUS "Ccache is founded, use ccache to speed up compile.")
+    # show statistics summary of ccache
+    message("ccache version\t\t\t    " ${ccache_version} "\n" ${cache_directory})
     set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PATH})
     set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PATH})
 endif(CCACHE_PATH)

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -253,8 +253,6 @@ EOF
 function cmake_gen() {
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
-    # show statistics summary of ccache
-    ccache -s cache directory
     cmake_base $1
 }
 


### PR DESCRIPTION
1. fix bug when ccache is not installed
![image](https://user-images.githubusercontent.com/6836917/80300891-f3b79c80-87d2-11ea-875d-1f12f8943f61.png)
2. add ccache version, result likes:
```
-- GLOO_NAME: gloo, GLOO_URL: https://pslib.bj.bcebos.com/gloo.tar.gz
-- Ccache is founded, use ccache to speed up compile.
ccache version			    3.2
cache directory                     /home/luotao/.ccache
primary config                      /home/luotao/.ccache/ccache.conf
secondary config      (readonly)    /home/luotao/.jumbo/etc/ccache.conf
cache hit (direct)                 81626
cache hit (preprocessed)           17221
cache miss                        138478
called for link                   458722
compile failed                       740
preprocessor error                   216
unsupported compiler option         1304
files in cache                     14261
cache size                           4.4 GB
max cache size                       5.0 GB

-- Paddle version is 0.0.0
-- Enable Intel OpenMP with /home/luotao/Paddle/cpu_build/third_party/install/mklml/lib/libiomp5.so
```

related #24125 