### PR TITLE
fix the intermediate of graph node for fusion group 

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/code_generator.cc
+++ b/paddle/fluid/framework/ir/fusion_group/code_generator.cc
@@ -263,12 +263,17 @@ std::string CodeGenerator::EmitParameters(
   }
 
   size_t index = 0;
+  std::vector<std::string> output_args;
   for (auto id : output_ids) {
     if (intermediate_ids.find(id) == intermediate_ids.end()) {
-      ret << dtypes.at(id) << "* " << ArgName(id);
-      if (index != output_ids.size() - 1) {
-        ret << ", ";
-      }
+      std::string args_str = dtypes.at(id) + "* " + ArgName(id);
+      output_args.push_back(args_str);
+    }
+  }
+  for (auto args : output_args) {
+    ret << args;
+    if (index != output_args.size() - 1) {
+      ret << ", ";
     }
     index++;
   }

--- a/paddle/fluid/framework/ir/fusion_group/subgraph.h
+++ b/paddle/fluid/framework/ir/fusion_group/subgraph.h
@@ -155,7 +155,7 @@ class SubGraph {
           if (node->IsOp()) {
             auto inputs = node->inputs;
             for (auto* in : inputs) {
-              if (in == n) {
+              if (in && in->Name() == n->Name()) {
                 if (!Has(node)) enable_remove = false;
                 leaf_graph = false;
               }


### PR DESCRIPTION
修复Resnet-50 在fusion group情况下生成代码出错的情况
```
2020-04-26 18:11:14,577-INFO: [Pass 0, train batch 10]  loss 59.52795, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1612 sec
2020-04-26 18:11:16,148-INFO: [Pass 0, train batch 20]  loss 59.34349, acc1 0.00000, acc5 0.01562, lr 0.10000, elapse 0.1568 sec
2020-04-26 18:11:17,718-INFO: [Pass 0, train batch 30]  loss 59.80452, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1583 sec
2020-04-26 18:11:19,377-INFO: [Pass 0, train batch 40]  loss 58.73994, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1559 sec
2020-04-26 18:11:20,972-INFO: [Pass 0, train batch 50]  loss 58.84933, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1579 sec
2020-04-26 18:11:22,563-INFO: [Pass 0, train batch 60]  loss 59.51080, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1606 sec
2020-04-26 18:11:24,180-INFO: [Pass 0, train batch 70]  loss 58.23547, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1730 sec
2020-04-26 18:11:25,777-INFO: [Pass 0, train batch 80]  loss 58.20548, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1594 sec
2020-04-26 18:11:27,380-INFO: [Pass 0, train batch 90]  loss 56.78304, acc1 0.00781, acc5 0.02344, lr 0.10000, elapse 0.1571 sec
2020-04-26 18:11:28,964-INFO: [Pass 0, train batch 100]         loss 59.06978, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1641 sec
2020-04-26 18:11:30,530-INFO: [Pass 0, train batch 110]         loss 60.42583, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1549 sec
2020-04-26 18:11:32,137-INFO: [Pass 0, train batch 120]         loss 58.88316, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1600 sec
2020-04-26 18:11:33,760-INFO: [Pass 0, train batch 130]         loss 57.93267, acc1 0.00000, acc5 0.01562, lr 0.10000, elapse 0.1601 sec
2020-04-26 18:11:35,325-INFO: [Pass 0, train batch 140]         loss 56.81481, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1558 sec
2020-04-26 18:11:36,881-INFO: [Pass 0, train batch 150]         loss 58.62671, acc1 0.00781, acc5 0.01562, lr 0.10000, elapse 0.1555 sec
2020-04-26 18:11:38,487-INFO: [Pass 0, train batch 160]         loss 59.64296, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1742 sec
2020-04-26 18:11:40,284-INFO: [Pass 0, train batch 170]         loss 59.67616, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1622 sec
2020-04-26 18:11:41,925-INFO: [Pass 0, train batch 180]         loss 58.02383, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1737 sec
2020-04-26 18:11:43,527-INFO: [Pass 0, train batch 190]         loss 57.89303, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1573 sec
2020-04-26 18:11:45,153-INFO: [Pass 0, train batch 200]         loss 57.62944, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1594 sec
2020-04-26 18:11:46,756-INFO: [Pass 0, train batch 210]         loss 57.49866, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1597 sec
2020-04-26 18:11:48,356-INFO: [Pass 0, train batch 220]         loss 56.91420, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1578 sec
2020-04-26 18:11:49,944-INFO: [Pass 0, train batch 230]         loss 57.74237, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1568 sec
2020-04-26 18:11:51,626-INFO: [Pass 0, train batch 240]         loss 58.66930, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1636 sec
2020-04-26 18:11:53,241-INFO: [Pass 0, train batch 250]         loss 56.69247, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1557 sec
2020-04-26 18:11:54,844-INFO: [Pass 0, train batch 260]         loss 58.00697, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1568 sec
2020-04-26 18:11:56,438-INFO: [Pass 0, train batch 270]         loss 60.29344, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1586 sec
2020-04-26 18:11:58,011-INFO: [Pass 0, train batch 280]         loss 57.91217, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1558 sec
2020-04-26 18:11:59,648-INFO: [Pass 0, train batch 290]         loss 59.53586, acc1 0.00781, acc5 0.00781, lr 0.10000, elapse 0.1862 sec
2020-04-26 18:12:01,261-INFO: [Pass 0, train batch 300]         loss 60.49903, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1575 sec
2020-04-26 18:12:02,870-INFO: [Pass 0, train batch 310]         loss 58.25085, acc1 0.00000, acc5 0.00000, lr 0.10000, elapse 0.1584 sec
2020-04-26 18:12:04,548-INFO: [Pass 0, train batch 320]         loss 57.46001, acc1 0.00000, acc5 0.00781, lr 0.10000, elapse 0.1550 sec

```