### PR TITLE
Fix double-grad bug in static-graph

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_calc_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_calc_gradient.py
@@ -23,16 +23,62 @@ from paddle.fluid.backward import calc_gradient
 
 class TestCalcGradient(unittest.TestCase):
     def test_calc_gradient(self):
-        x = layers.create_parameter(dtype="float32", shape=[5, 10])
-        y = layers.create_parameter(dtype="float32", shape=[10, 8])
-        mul_out = layers.mul(x=x, y=y)
-        mean_out = layers.mean(mul_out)
-        a = calc_gradient(mean_out, mul_out)
-        b = calc_gradient(mean_out, x)
+        main = fluid.Program()
+        startup = fluid.Program()
+        with fluid.program_guard(main, startup):
+            x = layers.create_parameter(dtype="float32", shape=[5, 10])
+            y = layers.create_parameter(dtype="float32", shape=[10, 8])
+            mul_out = layers.mul(x=x, y=y)
+            mean_out = layers.mean(mul_out)
+            a = calc_gradient(mean_out, mul_out)
+            b = calc_gradient(mean_out, x)
         place = fluid.CPUPlace()
         exe = fluid.Executor(place)
-        exe.run(fluid.default_startup_program())
-        exe.run(fluid.default_main_program(), feed={}, fetch_list=[a, b])
+        exe.run(startup)
+        exe.run(main, feed={}, fetch_list=[a, b])
+
+
+class TestDoubleGrad(unittest.TestCase):
+    def test1(self):
+        main = fluid.Program()
+        startup = fluid.Program()
+        with fluid.program_guard(main, startup):
+            net = lambda x: x * x
+            x = fluid.layers.create_parameter(
+                name='x',
+                shape=[1],
+                dtype='float32',
+                default_initializer=fluid.initializer.Constant(3))
+            grad1, = fluid.gradients(net(x), x)  # 2x = 6
+            z = net(x - grad1)
+            grad2, = fluid.gradients(z, x)  # gradients( (x - 2x)^2) = 2x = 6
+
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        exe.run(startup)
+        out = exe.run(main, fetch_list=[grad1.name, grad2.name])
+        self.assertEqual(6, out[0][0])
+        self.assertEqual(6, out[1][0])
+
+    def test2(self):
+        main = fluid.Program()
+        startup = fluid.Program()
+        with fluid.program_guard(main, startup):
+            x = fluid.layers.create_parameter(
+                name='x',
+                shape=[1],
+                dtype='float32',
+                default_initializer=fluid.initializer.Constant(1))
+            y = x * x
+            dx1, = fluid.gradients(y, x)
+            z = dx1 * dx1 + y * y
+            dx2, = fluid.gradients(z, x)
+
+        place = fluid.CPUPlace()
+        exe = fluid.Executor(place)
+        exe.run(startup)
+        out, = exe.run(main, fetch_list=[dx2])
+        self.assertEqual(12, out[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fix https://github.com/PaddlePaddle/Paddle/issues/23998

- 问题:

  ```
   y = x * x
   grad1 = fluid.gradients(y, x)
   z = grad1  + y * y
   grad2 = fluid.gradients(z, x)
   ```
  第二次反向时，产生了和第一次反向同名的variable，覆盖了内容，导致第二次反向的一些输入有误。


- 修复方法1：

  在`fluid.gradients`中，把新生成的反向var重新命名，命名关联反向的次数，使得每次反向生成的var名字不同。

  但`append_backward` and `minimize`没有修改，不影响使用minimize和append_backward的模型。 本质上，这两个修改也没问题。

- 修复方法2:
  参考  https://github.com/PaddlePaddle/Paddle/pulls