### PR TITLE
use 32 bit index to improve activation ops

### DIFF
--- a/paddle/fluid/operators/activation_op.h
+++ b/paddle/fluid/operators/activation_op.h
@@ -181,7 +181,8 @@ class ActivationKernel
     }
     // use 32bit index to speed up computation
     bool use_32bit_index = out.size() < Eigen::NumTraits<int>::highest();
-    if (use_32bit_index) {
+    bool is_gpu_place = platform::is_gpu_place(context.GetPlace());
+    if (use_32bit_index && is_gpu_place) {
       functor(*place, To32BitIndex(x), To32BitIndex(out));
     } else {
       functor(*place, x, out);
@@ -218,7 +219,8 @@ class ActivationGradKernel
     }
     // use 32bit index to speed up computation
     bool use_32bit_index = out.size() < Eigen::NumTraits<int>::highest();
-    if (use_32bit_index) {
+    bool is_gpu_place = platform::is_gpu_place(context.GetPlace());
+    if (use_32bit_index && is_gpu_place) {
       functor(*place, To32BitIndex(x), To32BitIndex(out), To32BitIndex(dout),
               To32BitIndex(dx));
     } else {


### PR DESCRIPTION
## Introducion
Use 32bit-index to improve performance of activation ops. The following experiments show that the GPU performance of most operators has improved. However, the CPU performance has been improved slightly or even decreased. So I think 32bit index should be used only in GPU computations of these ops.
- **Test Code:**
  - [abs](https://github.com/PaddlePaddle/benchmark/blob/master/api/tests/abs.py)
  - [sigmoid](https://github.com/PaddlePaddle/benchmark/blob/master/api/tests/sigmoid.py)


## **Performance**
### forward
 **GPU**：CUDA10，v100，use nvprof
  |op| before|after| speed up |
  |---|---|---|---|
  |abs|20.878 us |16.272 us|22.1% | 
  |sigmoid|11.255 us|10.072 us|10.5% | 
  | exp |21.34 us| 16.43 us| 23.0% | 
  | sqrt | 21.17 us| 16.48 us| 22.2% | 
  | ceil | 20.79 us| 20.85 us| -0.3% | 
  | floor | 20.85 us| 16.17 us| 22.4% | 
  | relu | 20.83 us| 16.47 us| 20.9% | 
  | rsqrt | 19.72 us| 16.26 us| 17.5% | 
  | tanh |  21.72 us| 21.74 us| 0% | 
  | square | 2.11 us| 2.06 us| 2.4% | 


  
   **CPU**：6148，use profile
  |op| before|after| speed up |
  |---|---|---|---|
  |abs|697.951 us|694.515 us|0.5 % | 
  |sigmoid|1550.14 us|1523.70 us|1.7 % | 
  | exp | 2413.52 us| 2294.71 us| 4.9% | 
  | sqrt | 928.19 us| 1016.76 us| -9.5% | 
  | ceil | 817.81 us| 778.89 us| 4.8% | 
  | floor | 782.65 us| 753.15 us| 3.8% | 
  | relu | 782.04 us| 767.52 us| 1.9% | 
  | rsqrt |949.49 us| 900.94 us| 5.1% | 
  | tanh | 1518.33 us| 1980.11 us| -30.4% | 
  | square | 44.83 us| 41.86 us| 6.6% | 

### backward
 **GPU**：CUDA10，v100，use nvprof
  |op| before|after| speed up |
  |---|---|---|---|
  |abs_grad| 25.863 us|25.200 us|2.6% | 
  |sigmoid_grad|14.855 us|12.132 us|18.3% | 
  | exp_grad | 24.99 us|  23.11 us| 7.5% | 
  | sqrt_grad | 25.54 us|  23.64 us| 7.4% | 
  | ceil_grad | 17.18 us| 13.89 us| 19.2% | 
  | floor_grad | 17.20 us| 14.06 us| 18.3% | 
  | relu_grad | 25.07 us| 24.99 us| 0.3% | 
  | rsqrt_grad | 25.40 us| 23.45 us| 7.7% | 
  | tanh_grad | 23.31 us| 23.30 us| 0% | 
  | square_grad | 2.48 us| 2.46 us| 0.8% | 

  
   **CPU**：6148，use profile
  |op| before|after| speed up |
  |---|---|---|---|
  |abs_grad|1245.81 us|1082.84 us|13.1 % | 
  |sigmoid_grad|541.53 us|540.75 us|0.1 % | 
  | exp_grad | 999.74 us| 997.21 us| 0.3% | 
  | sqrt_grad | 920.85 us|  904.54 us| 1.8% | 
  | ceil_grad | 692.17 us| 677.09 us| 2.2% | 
  | floor_grad | 708.13 us| 693.58 us| 2.1% | 
  | relu_grad | 2478.60 us| 2640.10 us| -6.5% | 
  | rsqrt_grad | 1023.70 us| 1012.53  us| 1.1% | 
  | tanh_grad | 924.56 us| 968.45 us| -4.7% | 
  | square_grad | 55.87 us| 53.68 us |3.9% | 
