### PR TITLE
revert join to terminate in distributed/utils.py

### DIFF
--- a/python/paddle/distributed/utils.py
+++ b/python/paddle/distributed/utils.py
@@ -252,9 +252,7 @@ def get_cluster(node_ips, node_ip, paddle_ports, selected_gpus):
 def terminate_local_procs(procs):
     for p in procs:
         if p.proc.poll() is None:
-            # subprocess need to release resource(e.g. shared memory)
-            # use join to wait subprocess releasing
-            p.proc.join(timeout=1)
+            p.proc.terminate()
             p.log_fn.close()
             logger.debug("terminate process id:{}".format(p.proc.pid))
 


### PR DESCRIPTION
**revert join to terminate in distributed/utils.py**
revert for following error
