### PR TITLE
Skip the process of copying LoDTensorArray in loop_vars in while_loop

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -980,17 +980,8 @@ def assign_skip_lod_tensor_array(inputs, outputs):
     """
     Skip the process of copying LoDTensorArray.
     """
-    if isinstance(inputs, (list, tuple)):
-        for i in range(len(inputs)):
-            assign_skip_lod_tensor_array(inputs[i], outputs[i])
-    elif isinstance(inputs, dict):
-        for key in _sorted(inputs):
-            assign(inputs[key], outputs[key])
-    else:
-        if inputs.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY:
-            pass
-        else:
-            assign(inputs, outputs)
+    if inputs.type != core.VarDesc.VarType.LOD_TENSOR_ARRAY:
+        assign(inputs, outputs)
 
 
 def while_loop(cond, body, loop_vars, is_test=False, name=None):
@@ -1080,7 +1071,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
                     "body in while_loop should return the same arity "
                     "(length and structure) and types as loop_vars")
             now_cond = cond(*output_vars).numpy()[0]
-            assign_skip_lod_tensor_array(output_vars, loop_vars)
+            map_structure(assign_skip_lod_tensor_array, output_vars, loop_vars)
         return loop_vars
 
     while_loop_block = While(pre_cond, is_test, name)
@@ -1104,7 +1095,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
                              "(length and structure) as loop_vars: {0}".format(
                                  e))
         now_cond = cond(*output_vars)
-        assign_skip_lod_tensor_array(output_vars, loop_vars)
+        map_structure(assign_skip_lod_tensor_array, output_vars, loop_vars)
         assign(now_cond, pre_cond)
     return loop_vars
 

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -21,7 +21,7 @@ from .. import core
 from ..framework import Program, Variable, Operator, in_dygraph_mode
 from ..layer_helper import LayerHelper, unique_name
 from .nn import logical_and, logical_not, logical_or
-from .utils import assert_same_structure, map_structure, hold_mutable_vars, copy_mutable_vars, _sorted
+from .utils import assert_same_structure, map_structure, hold_mutable_vars, copy_mutable_vars
 import numpy
 import warnings
 import six

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -21,7 +21,7 @@ from .. import core
 from ..framework import Program, Variable, Operator, in_dygraph_mode
 from ..layer_helper import LayerHelper, unique_name
 from .nn import logical_and, logical_not, logical_or
-from .utils import assert_same_structure, map_structure, hold_mutable_vars, copy_mutable_vars
+from .utils import assert_same_structure, map_structure, hold_mutable_vars, copy_mutable_vars, assign_skip_lod_tensor_array
 import numpy
 import warnings
 import six
@@ -1063,7 +1063,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
                     "body in while_loop should return the same arity "
                     "(length and structure) and types as loop_vars")
             now_cond = cond(*output_vars).numpy()[0]
-            loop_vars = output_vars
+            assign_skip_lod_tensor_array(output_vars, loop_vars)
         return loop_vars
 
     while_loop_block = While(pre_cond, is_test, name)
@@ -1087,7 +1087,7 @@ def while_loop(cond, body, loop_vars, is_test=False, name=None):
                              "(length and structure) as loop_vars: {0}".format(
                                  e))
         now_cond = cond(*output_vars)
-        map_structure(assign, output_vars, loop_vars)
+        assign_skip_lod_tensor_array(output_vars, loop_vars)
         assign(now_cond, pre_cond)
     return loop_vars
 

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -17,8 +17,6 @@ import collections
 import copy
 import six
 import numpy as np
-from .tensor import assign
-from .. import core
 from ..framework import Variable
 from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..layer_helper import LayerHelper
@@ -325,17 +323,3 @@ def _get_shape_tensor_inputs(inputs, helper, attrs, shape, op_type):
             inputs['ShapeTensorList'] = _get_shape_tensor(shape)
 
     return inputs
-
-
-def assign_skip_lod_tensor_array(inputs, outputs):
-    if isinstance(inputs, (list, tuple)):
-        for i in range(len(inputs)):
-            assign_skip_lod_tensor_array(inputs[i], outputs[i])
-    elif isinstance(inputs, dict):
-        for key in _sorted(inputs):
-            assign(inputs[key], outputs[key])
-    else:
-        if inputs.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY:
-            pass
-        else:
-            assign(inputs, outputs)

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -17,6 +17,8 @@ import collections
 import copy
 import six
 import numpy as np
+from .tensor import assign
+from .. import core
 from ..framework import Variable
 from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..layer_helper import LayerHelper
@@ -323,3 +325,17 @@ def _get_shape_tensor_inputs(inputs, helper, attrs, shape, op_type):
             inputs['ShapeTensorList'] = _get_shape_tensor(shape)
 
     return inputs
+
+
+def assign_skip_lod_tensor_array(inputs, outputs):
+    if isinstance(inputs, (list, tuple)):
+        for i in range(len(inputs)):
+            assign_skip_lod_tensor_array(inputs[i], outputs[i])
+    elif isinstance(inputs, dict):
+        for key in _sorted(inputs):
+            assign(inputs[key], outputs[key])
+    else:
+        if inputs.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY:
+            pass
+        else:
+            assign(inputs, outputs)


### PR DESCRIPTION
目前在while_loop的执行过程中，loop_vars中的变量在每次的循环中都会进行拷贝，但是LoDTensorArray类型的变量在while循环体中已经完成了读/写的操作，即完成了更新，此时在进行拷贝属于冗余的操作，故该PR跳过每次循环中loop_vars中LoDTensorArray类型的变量的复制过程。

在PaddleCV/ocr_recognition/atention模型的预测过程中进行性能测试：
|性能|with this PR|without this PR|提升|
|---|---|---|---|
|速度|4957.4ms|4978.47ms|0.4%|
