### PR TITLE
Fix slice bug in while loop

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -647,6 +647,7 @@ def _getitem_impl_(var, item):
     slice_step = []
     use_strided_slice = False
     reverse_axis = []
+    target_block = default_main_program().current_block()
 
     def fill_constant(shape, value, force_cpu=False, out=None):
         var.block.append_op(
@@ -701,8 +702,8 @@ def _getitem_impl_(var, item):
             if isinstance(slice_item, Variable):
                 temp_1 = var.block.create_var(dtype='int32')
                 fill_constant([1], 1, force_cpu=True, out=temp_1)
-                temp_end = var.block.create_var(dtype='int32')
-                var.block.append_op(
+                temp_end = target_block.create_var(dtype='int32')
+                target_block.append_op(
                     type='elementwise_add',
                     inputs={'X': slice_item,
                             'Y': temp_1},
@@ -785,11 +786,11 @@ def _getitem_impl_(var, item):
     out = var
     if use_strided_slice == False and len(slice_axis) > 0:
         # append slice_op here
-        slice_out_var = var.block.create_var(
+        slice_out_var = target_block.create_var(
             name=unique_name.generate_with_ignorable_key(var.name + "_slice"),
             dtype=var.dtype)
 
-        var.block.append_op(
+        target_block.append_op(
             type="slice",
             inputs=inputs,
             outputs={'Out': [slice_out_var]},
@@ -797,11 +798,11 @@ def _getitem_impl_(var, item):
 
         out = slice_out_var
     elif use_strided_slice == True and len(slice_axis) > 0:
-        strided_slice_out_var = var.block.create_var(
+        strided_slice_out_var = target_block.create_var(
             name=unique_name.generate_with_ignorable_key(var.name +
                                                          "_strided_slice"),
             dtype=var.dtype)
-        var.block.append_op(
+        target_block.append_op(
             type="strided_slice",
             inputs=inputs,
             outputs={'Out': [strided_slice_out_var]},
@@ -810,11 +811,11 @@ def _getitem_impl_(var, item):
         out = strided_slice_out_var
 
     if len(reverse_axis) > 0:
-        reverse_out_var = var.block.create_var(
+        reverse_out_var = target_block.create_var(
             name=unique_name.generate_with_ignorable_key(var.name +
                                                          "_slice_reverse"),
             dtype=var.dtype)
-        var.block.append_op(
+        target_block.append_op(
             type="reverse",
             inputs={'X': out},
             outputs={'Out': [reverse_out_var]},


### PR DESCRIPTION
This PR fix a bug, when while_loop body contains tensor slice operation, the slice op won't be add into sub block, which will cause calculate result error.

The reason for this error is that when `x[i]` adds slice-related ops, add ops according to the block where the var is located. Since x, i, etc. are variables of the global block, all ops are not correctly added to the sub-block, but the op should be added into the block it is executed, so this PR modified the block added for slice related ops.

### error case
- except result is `15`, but print result is `5`
```
def static_func(x):
    z = fluid.layers.fill_constant([1], 'int32', 0)
    x = fluid.layers.assign(x)
    x_shape = fluid.layers.shape(x)
    i = fluid.layers.fill_constant([1], 'int32', 0)

    def for_loop_condition_0(z, i):
        return i + 1 <= x_shape[0]

    def for_loop_body_0(z, i):
        z = z + x[i]
        i += 1
        return z, i

    z, i = fluid.layers.while_loop(for_loop_condition_0, for_loop_body_0, [z, i])
    return z

def execute():
    startup_program = fluid.Program()
    main_program = fluid.Program()
    with fluid.program_guard(main_program, startup_program):
        # prepare input
        np_x = np.array([1, 2, 3, 4, 5], dtype='int32')
        
        # add feed var
        x = data_layer_not_check(name='x', shape=list(np_x.shape), dtype=str(np_x.dtype))

        # build net
        result = static_func(x)

        # prepare exe
        place = fluid.CPUPlace()
        exe = fluid.Executor(place)

        # run
        # exe.run(startup_program)
        out, = exe.run(main_program,
            feed={'x': np_x},
            fetch_list=[result])
        print(out[0])

if __name__== '__main__':
    execute()
```

