### PR TITLE
Fix compile error(cpuid.h not found) on nvidia jetson platforms. 

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -4,6 +4,7 @@ endif()
 
 
 if (WITH_NV_JETSON)
+  add_definitions(-DWITH_NV_JETSON)
   set(paddle_known_gpu_archs "53 62 72")
   set(paddle_known_gpu_archs7 "53")
   set(paddle_known_gpu_archs8 "53 62")

--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -139,6 +139,7 @@ bool MayIUse(const cpu_isa_t cpu_isa) {
   if (cpu_isa == isa_any) {
     return true;
   } else {
+#ifndef WITH_NV_JETSON
     int reg[4];
     cpuid(reg, 0);
     int nIds = reg[0];
@@ -164,6 +165,7 @@ bool MayIUse(const cpu_isa_t cpu_isa) {
         return (reg[1] & avx512f_mask) != 0;
       }
     }
+#endif
     return false;
   }
 }

--- a/paddle/fluid/platform/cpu_info.h
+++ b/paddle/fluid/platform/cpu_info.h
@@ -40,10 +40,12 @@ limitations under the License. */
 #ifdef _WIN32
 #define cpuid(reg, x) __cpuidex(reg, x, 0)
 #else
+#ifndef WITH_NV_JETSON
 #include <cpuid.h>
 inline void cpuid(int reg[4], int x) {
   __cpuid_count(x, 0, reg[0], reg[1], reg[2], reg[3]);
 }
+#endif
 #endif
 #endif
 


### PR DESCRIPTION
**Bug**: Compiling Paddle inference lib fails on NV Jetson platforms:
![image](https://user-images.githubusercontent.com/12407750/81278315-16299f80-9088-11ea-80f9-c1c795dc61cb.png)
**Fix**: According to [PR#22716](https://github.com/PaddlePaddle/Paddle/pull/22716), if XBYAK is OFF, get avx info by calling __cpuid() function from cpuid.h, which is included in most gcc libs. However, on Jetson platforms, XBYAK is OFF, and the gcc of the origin linux distribution doesn't contain cpuid.h, causing the compile error above. So we use macros to skip the part [PR#22716](https://github.com/PaddlePaddle/Paddle/pull/22716) added. 
The bug[#22636](https://github.com/PaddlePaddle/Paddle/issues/22636) that PR#22716 fixed is tested on Jetson TX2. It is not triggerd when executing `import paddle.fluid as fluid`.

intel在2月合入的一个[PR#22716](https://github.com/PaddlePaddle/Paddle/pull/22716)里设置了在关掉xbyak时，调用gcc中的cpuid.h获得avx信息。这个改动目前会导致在英伟达jetson硬件上编译不过，因为jetson自带的gcc没有这个头文件。
由于要求所有jetson用户重装gcc的成本太高，所以加了个宏控制在jetson上编译时把pr22716的内容跳过。
[PR#22716](https://github.com/PaddlePaddle/Paddle/pull/22716)fix了一个在关掉xbyak时由于检测avx指令集返回false导致import paddle报错的bug，jetson是arm64 cpu，在jetson tx2上也验证了可以正常编译和import。