### PR TITLE
fs_wrapper add __all__

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -30,9 +30,9 @@ except ImportError:
 import paddle.reader
 import paddle.dataset
 import paddle.batch
+batch = batch.batch
 import paddle.compat
 import paddle.distributed
-batch = batch.batch
 import paddle.sysconfig
 import paddle.tensor
 import paddle.nn

--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -1,4 +1,4 @@
-#Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/python/paddle/distributed/__init__.py
+++ b/python/paddle/distributed/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,3 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from . import fs_wrapper
+
+__all__ = fs_wrapper.__all__

--- a/python/paddle/distributed/fs_wrapper.py
+++ b/python/paddle/distributed/fs_wrapper.py
@@ -19,6 +19,8 @@ import os
 from pathlib import PurePosixPath
 import shutil
 
+__all__ = ['FS', 'LocalFS', 'BDFS']
+
 
 class FS(object):
     @abc.abstractmethod


### PR DESCRIPTION
```
[09:40:38][Step 1/1] ----------------End of the Check--------------------
[09:40:38][Step 1/1] ['paddle.incubate.hapi.metrics.Metric.__init__', 'paddle.distributed.fs_wrapper.PurePosixPath.__init__', 'paddle.distributed.fs_wrapper.LocalFS.__init__', 'paddle.distributed.fs_wrapper.FS.__init__'] is not in whl.
[09:40:38][Step 1/1] 
[09:40:38][Step 1/1] Please check the whl package and API_PR.spec!
[09:40:38][Step 1/1] You can follow these steps in order to generate API.spec:
[09:40:38][Step 1/1] 1. cd ${paddle_path}, compile paddle;
[09:40:38][Step 1/1] 2. pip install build/python/dist/(build whl package);
[09:40:38][Step 1/1] 3. run 'python tools/print_signatures.py paddle > paddle/fluid/API.spec'.
```
解决[#24293](https://github.com/PaddlePaddle/Paddle/pull/24293) log中['paddle.distributed.fs_wrapper.PurePosixPath.__init__', 'paddle.distributed.fs_wrapper.LocalFS.__init__', 'paddle.distributed.fs_wrapper.FS.__init__'] is not in whl.的问题：为fs_wrapper增加__all__