### PR TITLE
Remove __all__ in fluid.input to avoid exposing interfaces

### DIFF
--- a/python/paddle/fluid/input.py
+++ b/python/paddle/fluid/input.py
@@ -18,8 +18,6 @@ from .framework import Variable, in_dygraph_mode
 from .layer_helper import LayerHelper
 from .data_feeder import check_variable_and_dtype, check_dtype
 
-__all__ = ['one_hot', 'embedding']
-
 
 def one_hot(input, depth, allow_out_of_range=False):
     """


### PR DESCRIPTION
移除`__all__`避免以`fluid.input.embedding`的形式暴露到官网