### PR TITLE
upgrade ccache to 3.7.9 to support CUDA

### DIFF
--- a/tools/manylinux1/Dockerfile.GCC8
+++ b/tools/manylinux1/Dockerfile.GCC8
@@ -75,7 +75,7 @@ RUN apt-get update && \
     python-matplotlib \
     automake locales clang-format swig  \
     liblapack-dev liblapacke-dev \
-    net-tools libtool ccache module-init-tools && \
+    net-tools libtool module-init-tools && \
     apt-get clean -y
 
 # Install Python2.7.15 to replace original python
@@ -175,8 +175,6 @@ RUN pip3.6 --no-cache-dir install certifi urllib3[secure]
 RUN pip3.7 --no-cache-dir install certifi urllib3[secure]
 RUN pip --no-cache-dir install certifi urllib3[secure]
 
-RUN echo "export PATH=/usr/lib/ccache:${PATH}" >> ~/.bashrc
-
 # Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
 RUN mkdir /var/run/sshd
 RUN echo 'root:root' | chpasswd
@@ -185,3 +183,9 @@ RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
 CMD source ~/.bashrc
 EXPOSE 22
 
+# ccache 3.7.9
+RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+    tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+    ./configure -prefix=/usr/local/ccache-3.7.9 && \
+    make -j8 && make install && \
+    ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache

--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
@@ -208,7 +208,7 @@ RUN git clone https://github.com/woboq/woboq_codebrowser /woboq && \
 # ar mishandles 4GB files
 # https://sourceware.org/bugzilla/show_bug.cgi?id=14625
 # remove them when apt-get support 2.27 and higher version
-RUN wget -q https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/binutils/2.27-9ubuntu1/binutils_2.27.orig.tar.gz && \
+RUN wget -q https://paddle-ci.gz.bcebos.com/binutils_2.27.orig.tar.gz && \
     tar -xzf binutils_2.27.orig.tar.gz && \
     cd binutils-2.27 && \
     ./configure && make -j && make install && cd .. && rm -rf binutils-2.27 binutils_2.27.orig.tar.gz
@@ -220,12 +220,12 @@ RUN wget --no-check-certificate https://pslib.bj.bcebos.com/openmpi-1.4.5.tar.gz
     apt-get install libprotobuf-dev -y
 RUN pip --no-cache-dir install -U netifaces==0.10.9
 
-# ccache 3.6
-RUN wget https://paddle-ci.cdn.bcebos.com/ccache-3.6.tar.gz && \
-    tar xf ccache-3.6.tar.gz && mkdir /usr/local/ccache-3.6 && cd ccache-3.6 && \
-    ./configure -prefix=/usr/local/ccache-3.6 && \
+# ccache 3.7.9
+RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+    tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+    ./configure -prefix=/usr/local/ccache-3.7.9 && \
     make -j8 && make install && \
-    ln -s /usr/local/ccache-3.6/bin/ccache /usr/local/bin/ccache
+    ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
 
 # Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
 RUN mkdir /var/run/sshd

--- a/tools/manylinux1/Dockerfile.cuda9_cudnn7_gcc48_py35_centos6
+++ b/tools/manylinux1/Dockerfile.cuda9_cudnn7_gcc48_py35_centos6
@@ -34,12 +34,12 @@ RUN cd /opt && wget -q --no-check-certificate https://github.com/google/protobuf
     tar xzf protobuf-cpp-3.6.1.tar.gz && \
     cd protobuf-3.6.1 && ./configure && make -j4 && make install && cd .. && rm -f protobuf-cpp-3.6.1.tar.gz
 
-# ccache 3.6
-RUN wget https://paddle-ci.cdn.bcebos.com/ccache-3.6.tar.gz && \
-    tar xf ccache-3.6.tar.gz && mkdir /usr/local/ccache-3.6 && cd ccache-3.6 && \
-    ./configure -prefix=/usr/local/ccache-3.6 && \
+# ccache 3.7.9
+RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+    tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+    ./configure -prefix=/usr/local/ccache-3.7.9 && \
     make -j8 && make install && \
-    ln -s /usr/local/ccache-3.6/bin/ccache /usr/local/bin/ccache
+    ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
 
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O /root/requirements.txt
 


### PR DESCRIPTION
upgrade ccache to 3.7.9 to support CUDA.

cmake will use `-x cu` to compile .cu files using nvcc compiler explicitly. but ccache less than 3.7.9 can not recognize this option, this bug has been fixed in [ccache 3.7.9](https://ccache.dev/releasenotes.html#_ccache_3_7_9).

Paddle Ci use ccache 3.6 currently, so we need to upgrade ccache to 3.7.9 to ccache CUDA object files.

related #24337