### PR TITLE
[oneDNN] disabling oneDNN inplace pass

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -201,7 +201,7 @@ void CpuPassStrategy::EnableMKLDNN() {
              // Disabled due to topology-dependent speed-up
              // "fc_mkldnn_pass",
              // "mkldnn_inplace_pass",  // This pass should be activated after
-                                     // fuses
+             // fuses
          })) {
       passes_.push_back(pass);
     }

--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -200,7 +200,7 @@ void CpuPassStrategy::EnableMKLDNN() {
              "matmul_transpose_reshape_fuse_pass",         //
              // Disabled due to topology-dependent speed-up
              // "fc_mkldnn_pass",
-             "mkldnn_inplace_pass",  // This pass should be activated after
+             // "mkldnn_inplace_pass",  // This pass should be activated after
                                      // fuses
          })) {
       passes_.push_back(pass);


### PR DESCRIPTION
There was an issue reported #24373 (performance drop). It is caused by oneDNN inplace pass.
It is under investigation. If in-place pass is not fixed very soon than this PR disables , so resotores performance on Transformer.