### PR TITLE
[WIP] Set fp32_model optional in QAT test 

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/qat2_int8_mkldnn_pass.py
@@ -90,7 +90,9 @@ class Qat2Int8MkldnnPass(object):
     def apply_fp32(self, graph):
         assert isinstance(graph,
                           IrGraph), 'graph must be the instance of IrGraph.'
-
+        graph = self._gather_weight_scales_from_fake(graph)
+        graph = self._remove_fake_ops(graph)
+        graph = self._dequantize_weights(graph)
         graph = self._optimize_fp32_graph(graph)
         graph = self._cleanup(graph)
         return graph

--- a/python/paddle/fluid/contrib/slim/tests/qat2_int8_nlp_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat2_int8_nlp_comparison.py
@@ -153,14 +153,16 @@ class QatInt8NLPComparisonTest(unittest.TestCase):
             graph = IrGraph(core.Graph(inference_program.desc), for_test=True)
             if (self._debug):
                 graph.draw('.', 'qat_orig', graph.all_op_nodes())
+            transform_to_mkldnn_int8_pass = Qat2Int8MkldnnPass(
+                self._quantized_ops,
+                _scope=inference_scope,
+                _place=place,
+                _core=core,
+                _debug=self._debug)
             if (transform_to_int8):
-                transform_to_mkldnn_int8_pass = Qat2Int8MkldnnPass(
-                    self._quantized_ops,
-                    _scope=inference_scope,
-                    _place=place,
-                    _core=core,
-                    _debug=self._debug)
                 graph = transform_to_mkldnn_int8_pass.apply(graph)
+            else:
+                graph = transform_to_mkldnn_int8_pass.apply_fp32(graph)
 
             inference_program = graph.to_program()
 


### PR DESCRIPTION
Modify `apply_fp32` function so that it could optimize fp32 and qat model by DNNL passes

There was a discussion that in qat test we should only test fp32 and int8 model. But now it turns out that it is not considerable enough. Because the qat model generated by user may have accuracy difference with original fp32 model (Not trained properly). So comparing original fp32 model and int8 model is not enough.