### PR TITLE
move container from imperative to nn

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -37,7 +37,7 @@ class TestImperativeContainer(unittest.TestCase):
             [fluid.dygraph.Linear(2**i, 2**(i + 1)) for i in range(6)])
 
     def paddle_imperative_list(self):
-        return paddle.imperative.LayerList(
+        return paddle.nn.LayerList(
             [fluid.dygraph.Linear(2**i, 2**(i + 1)) for i in range(6)])
 
     def layer_list(self, use_fluid_api):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_parameterlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_parameterlist.py
@@ -35,7 +35,7 @@ class MyLayer(fluid.Layer):
                 shape=[2, 2], dtype='float32')] * num_stacked_param)
 
     def paddle_imperative_ParameterList(self, num_stacked_param):
-        return paddle.imperative.ParameterList(
+        return paddle.nn.ParameterList(
             [fluid.layers.create_parameter(
                 shape=[2, 2], dtype='float32')] * num_stacked_param)
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
@@ -67,7 +67,7 @@ class TestImperativeNamedParameters(unittest.TestCase):
             fc1 = fluid.Linear(10, 3)
             fc2 = fluid.Linear(3, 10, bias_attr=False)
             custom = MyLayer(3, 10)
-            model = paddle.imperative.Sequential(fc1, fc2, custom)
+            model = paddle.nn.Sequential(fc1, fc2, custom)
 
             named_parameters = list(model.named_parameters())
             expected_named_parameters = list()

--- a/python/paddle/imperative/__init__.py
+++ b/python/paddle/imperative/__init__.py
@@ -21,7 +21,6 @@ __all__ = [
 
 from paddle.fluid import core
 from ..fluid.dygraph.base import enabled, guard, no_grad, to_variable, grad
-from ..fluid.dygraph.container import LayerList, ParameterList, Sequential
 from ..fluid.dygraph.checkpoint import load_dygraph as load
 from ..fluid.dygraph.checkpoint import save_dygraph as save
 from ..fluid.dygraph.parallel import prepare_context

--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -98,3 +98,4 @@ from .layer.norm import InstanceNorm  #DEFINE_ALIAS
 from .layer import loss  #DEFINE_ALIAS
 from .layer import conv  #DEFINE_ALIAS
 from ..fluid.dygraph.layers import Layer  #DEFINE_ALIAS
+from ..fluid.dygraph.container import LayerList, ParameterList, Sequential  #DEFINE_ALIAS


### PR DESCRIPTION
把一些基础的容器 从imperative 目录移到 nn中，这些容器是动态图和静态图都可以使用的，放在imperative中不太合适

三个容器主要是 LayerList, ParameterList, Sequential
