### PR TITLE
modify generate api.spec

### DIFF
--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -105,6 +105,8 @@ def visit_member(parent_name, member):
             if hasattr(value, '__name__') and (not name.startswith("_") or
                                                name == "__init__"):
                 visit_member(cur_name, value)
+    elif inspect.ismethoddescriptor(member):
+        return
     elif callable(member):
         queue_dict(member, cur_name)
     elif inspect.isgetsetdescriptor(member):


### PR DESCRIPTION
#### Required（必填, multiple choices, two at most）
- **PR type（PR 类型） is (B):**
A. New features（新功能）---------------- D. Performance optimization（性能优化）
B. Bug fixes（问题修复）------------------ E. Breaking changes（向后不兼容的改变）
C. Function optimization（功能优化）-----  F.  Others（其它）

- **PR changes（改动点）is (C ):**
A. OPs（operators）------------------------ C. Docs（文档）
B. APIs（接口）----------------------------- D. Others（其它）

- **Use one sentence to describe what this PR does.（简述本次PR的目的和改动）**
   修改生成API.spec的文件`print_signatures.py`，使API.spec不存在方式标识符（methoddescriptor）

-----------------------
#### Optional（选填, If None, please delete it）

- **Describe what this PR does in detail. If this PR fixes an issue, please give the issue id.**
   
原先`print_signatures.py`中只要检测到函数可以回调就会写入到API.spec，这样存在的问题是有一些API是方法标识符，比如#24457 中出现的 `paddle.incubate.hapi.text.BeamSearchDecoder.OutputWrapper.__init__`，导致PR_CI_CPU_Py2这个CI执行API的示例代码时找不到对应的API。
   本次修改增加`ismethoddescriptor`的判断，如果检测到是methoddescriptor就不写入API.spec，下图为vimdiff 线下测试用新旧`print_signatures.py`的截图：
![image](https://user-images.githubusercontent.com/22937122/81801205-a1061080-9546-11ea-97dc-f7d8db45ce8c.png)
另附上修改后`print_signatures.py`生成的API.spec：https://github.com/lelelelelez/OtherProject/blob/master/API_NEW.spec
以及原`print_signatures.py`生成的API.spec：https://github.com/lelelelelez/OtherProject/blob/master/API_OLD.spec

- **If you modified docs, please make sure that both Chinese and English docs were modified and provide a preview screenshot. （文档必填）**
   <!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

- **Please write down other information you want to tell reviewers.**
