### PR TITLE
[Dy2static] fix some print transformer problems

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/print_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/print_transformer.py
@@ -15,8 +15,14 @@
 from __future__ import print_function
 
 import gast
+import logging
 
+from paddle.fluid import log_helper
 from paddle.fluid.dygraph.dygraph_to_static.static_analysis import AstNodeWrapper, NodeVarType, StaticAnalysisVisitor
+from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
+
+_logger = log_helper.get_logger(
+    __name__, logging.WARNING, fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 
 class PrintTransformer(gast.NodeTransformer):
@@ -39,20 +45,66 @@ class PrintTransformer(gast.NodeTransformer):
         self.visit(self.root)
 
     # NOTE: deal with print in PY3
-    def visit_Call(self, node):
-        assert isinstance(node, gast.Call)
-        if isinstance(node.func, gast.Name) and node.func.id == 'print':
-            var = self._get_print_var(node)
-            return self._construct_print_node(var)
+    def visit_Assign(self, node):
+        if isinstance(node.value, gast.Call):
+            if isinstance(node.value.func,
+                          gast.Name) and node.value.func.id == 'print':
+                node.value = self._transform_call_node(node.value)
+        return node
+
+    def visit_Expr(self, node):
+        if isinstance(node.value, gast.Call):
+            if isinstance(node.value.func,
+                          gast.Name) and node.value.func.id == 'print':
+                print_assign_node = self._create_assign_node(node.value)
+                if print_assign_node is not None:
+                    return print_assign_node
         return node
 
     # NOTE: deal with print in PY2
     def visit_Print(self, node):
-        var = self._get_print_var(node)
-        print_call_node = self._construct_print_node(var)
-        return gast.Expr(value=print_call_node)
+        print_assign_node = self._create_assign_node(node)
+        if print_assign_node is not None:
+            return print_assign_node
+        return node
 
-    def _get_print_var(self, node):
+    def _transform_call_node(self, node):
+        assert isinstance(node, gast.Call), "visit Node is not gast.Call node."
+        var_node = self._get_print_var_node(node)
+        if var_node is None:
+            return node
+        if self._need_transform(var_node, node):
+            return self._build_print_call_node(var_node)
+        return node
+
+    def _create_assign_node(self, node):
+        var_node = self._get_print_var_node(node)
+        if var_node is None:
+            return None
+        if self._need_transform(var_node, node):
+            # NOTE: why need transform to gast.Assign node
+            # only fluid.layers.Print(x) will be pruned when exe.run(use_prune=True)
+            return gast.Assign(
+                targets=[var_node], value=self._build_print_call_node(var_node))
+        return None
+
+    def _build_print_call_node(self, node):
+        return gast.Call(
+            func=gast.parse('fluid.layers.Print').body[0].value,
+            args=[node],
+            keywords=[
+                gast.keyword(
+                    arg='summarize',
+                    value=gast.UnaryOp(
+                        op=gast.USub(),
+                        operand=gast.Constant(
+                            value=1, kind=None))), gast.keyword(
+                                arg='print_phase',
+                                value=gast.Constant(
+                                    value='forward', kind=None))
+            ])
+
+    def _get_print_var_node(self, node):
         if isinstance(node, gast.Call):
             var_list = node.args
         elif isinstance(node, gast.Print):
@@ -60,24 +112,27 @@ class PrintTransformer(gast.NodeTransformer):
             if isinstance(var_list[0], gast.Tuple):
                 var_list = var_list[0].elts
         # TODO: support print multiple Var
-        assert len(var_list) == 1, "Now only support print one Variable."
-        return var_list[0]
-
-    def _construct_print_node(self, node):
-        if isinstance(node, gast.Name):
-            if self._is_tensor_node(node):
-                print_node = gast.Call(
-                    func=gast.parse('fluid.layers.Print').body[0].value,
-                    args=[node],
-                    keywords=[])
-                return print_node
-            else:
-                raise TypeError(
-                    "print object type error, only support print Variable now.")
+        if len(var_list) == 1:
+            return var_list[0]
         else:
-            # TODO: may not only print with format
-            raise NotImplementedError(
-                "cannot transform print with format temporarily.")
+            _logger.warning(
+                "ProgramTranslator could not transform printing multiple values like < %s > now and will run it as-is."
+                % ast_to_source_code(node).strip())
+        return None
+
+    def _need_transform(self, var_node, print_node):
+        if isinstance(var_node, gast.Name):
+            if self._is_tensor_node(var_node):
+                return True
+            else:
+                _logger.warning(
+                    "ProgramTranslator could not transform printing value that are not Tensor like < %s > now and will run it as-is."
+                    % ast_to_source_code(print_node).strip())
+        else:
+            _logger.warning(
+                "ProgramTranslator could not transform < %s > now and will run it as-is."
+                % ast_to_source_code(print_node).strip())
+        return False
 
     def _is_tensor_node(self, node):
         tensor_types = {NodeVarType.TENSOR, NodeVarType.PADDLE_RETURN_TYPES}

--- a/python/paddle/fluid/dygraph/dygraph_to_static/print_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/print_transformer.py
@@ -55,7 +55,7 @@ class PrintTransformer(gast.NodeTransformer):
                 if print_assign_node is not None:
                     return print_assign_node
             else:
-                node.value = self._transform_call_node(node)
+                return self._transform_call_node(node)
         return node
 
     # NOTE: deal with print in PY2

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_print.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_print.py
@@ -185,34 +185,19 @@ class TestPrintVariable(TestPrintBase):
         self.get_static_output()
 
 
-class TestPrintNdArray(TestPrintBase):
+class TestPrintNdArray(TestPrintVariable):
     def set_test_func(self):
         self.dygraph_func = dyfunc_print_ndarray
 
-    def test_transform_static_error(self):
-        with self.assertRaises(TypeError):
-            self.get_dygraph_output()
-            self.get_static_output()
 
-
-class TestPrintWithFormat(TestPrintBase):
+class TestPrintWithFormat(TestPrintVariable):
     def set_test_func(self):
         self.dygraph_func = dyfunc_print_with_format
 
-    def test_transform_static_error(self):
-        with self.assertRaises(NotImplementedError):
-            self.get_dygraph_output()
-            self.get_static_output()
 
-
-class TestPrintWithFormat2(TestPrintBase):
+class TestPrintWithFormat2(TestPrintVariable):
     def set_test_func(self):
         self.dygraph_func = dyfunc_print_with_format2
-
-    def test_transform_static_error(self):
-        with self.assertRaises(NotImplementedError):
-            self.get_dygraph_output()
-            self.get_static_output()
 
 
 class TestPrintWithIfElse(TestPrintVariable):
@@ -225,14 +210,9 @@ class TestPrintMultipleVar(TestPrintVariable):
         self.dygraph_func = dyfunc_print_multi_vars
 
 
-class TestPrintContinueVar(TestPrintBase):
+class TestPrintContinueVar(TestPrintVariable):
     def set_test_func(self):
         self.dygraph_func = dyfunc_print_continue_vars
-
-    def test_transform_static_error(self):
-        with self.assertRaises(AssertionError):
-            self.get_dygraph_output()
-            self.get_static_output()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
该PR修复三个Print Transformer的问题：

1. 动转静`print`替换为`fluid.layers.Print`之后，如果是gast.Expr而不是gast.Assign，print将会成为叶子节点，这导致的在exe.run(use_prune=True)时，Print节点会被剪掉

- 因此改为，将`print(x)`要处理为`x = fluid.layers.Print(x)`
  - 对于py3：两种情况
    - Expr(Call) - > Assign()
    - Assign() - > Assign()
  - 对于py2：
    - Print() -> Assign()

2. 改为`layers.Print`之后，一些参数不能仅使用默认的，否则和原动态图写法语义存在差别

- `print_phase`应该只包含前向：在动态图的语义中，`print(x)`是只打印当前变量的，所以转换之后，也应该保持语义相同，带参数`print_phase='forward'`

- `summarize`应该改为-1，打印全部tensor数据

3. 一些报错信息应该去掉，换成WARNING，无法转换的并不应该报错

related PR：https://github.com/PaddlePaddle/Paddle/pull/24068