### PR TITLE
fix bert bug using trt6 when compile with CUDA_ARCH_NAME=All

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc
+++ b/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc
@@ -91,9 +91,9 @@ class EmbEltwiseLayerNormOpConverter : public OpConverter {
             input_embs, bias, scale, emb_sizes, bias_size, scale_size, hidden,
             eps);
 #else
-        PADDLE_THROW(
-            platform::errors::Fatal("use EmbEltwiseLayernormPluginDynamic "
-                                    "FP16, but GPU doesn't have FP16."));
+        plugin = new plugin::EmbEltwiseLayernormPluginDynamic<float>(
+            input_embs, bias, scale, emb_sizes, bias_size, scale_size, hidden,
+            eps);
 #endif
       } else {
         plugin = new plugin::EmbEltwiseLayernormPluginDynamic<float>(

--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -29,7 +29,6 @@ struct SimpleOpTypeSetTeller : public Teller {
     teller_set.insert("fused_embedding_eltwise_layernorm");
     teller_set.insert("multihead_matmul");
     teller_set.insert("skip_layernorm");
-    teller_set.insert("slice");
 #endif
   }
 

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_test.cc
@@ -120,7 +120,7 @@ void trt_ernie(bool with_fp16, std::vector<float> result) {
   if (with_fp16) {
     precision = AnalysisConfig::Precision::kHalf;
   }
-  config.EnableTensorRtEngine(1 << 30, 1, 1, precision, false, true);
+  config.EnableTensorRtEngine(1 << 30, 1, 5, precision, false, true);
   config.SetTRTDynamicShapeInfo(min_input_shape, max_input_shape,
                                 opt_input_shape);
   std::vector<float> out_data;


### PR DESCRIPTION
If we set CUDA_ARCH_NAME to All and run the bert using paddle-trt fp16. 
There will be a bug of 

```
FatalError: use EmbEltwiseLayernormPluginDynamic FP16, but GPU doesn't have FP16. at (/workspace/paddle/fluid/inference/tensorrt/convert/emb_eltwise_layernorm.cc:96)
```

