### PR TITLE
Add more version info to version.txt

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -276,11 +276,12 @@ function(version version_file)
     if(WITH_GPU)
         file(APPEND ${version_file}
                 "CUDA version: ${CUDA_VERSION}\n"
-                "CUDNN version: v${CUDNN_MAJOR_VERSION}\n")
+                "CUDNN version: v${CUDNN_MAJOR_VERSION}.${CUDNN_MINOR_VERSION}\n")
     endif()
+    file(APPEND ${version_file} "CXX compiler version: ${CMAKE_CXX_COMPILER_VERSION}\n")
     if(TENSORRT_FOUND)
         file(APPEND ${version_file}
-                "WITH_TENSORRT: ${TENSORRT_FOUND}\n")
+                "WITH_TENSORRT: ${TENSORRT_FOUND}\n" "TensorRT version: v${TENSORRT_MAJOR_VERSION}\n")
     endif()
     
 endfunction()


### PR DESCRIPTION
When using Paddle Inference libs, it's vital to keep the local versions of dependency libs(CUDA, CUDNN,  GCC, etc.) the same as the inference lib. For users to do this check more easily, we added more version information to version.txt:
- CUDNN minor version(if using GPU)
- CXX compiler version
- TensorRT version (if using TensorRT)

because inconsistency of the above versions might cause serious compiling or runtime problems.
Now the version.txt looks like:
![image](https://user-images.githubusercontent.com/12407750/81910825-09b0c400-95ff-11ea-8751-4a5884d27a32.png)
