### PR TITLE
[Dy2stat] Add GPU unittest of test_se_resnet

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
@@ -40,7 +40,7 @@ place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() \
 #     1. For one operation, cuDNN has several algorithms,
 #        some algorithm results are non-deterministic, like convolution algorithms.
 if fluid.is_compiled_with_cuda():
-    fluid.core.globals()['FLAGS_cudnn_deterministic'] = True
+    fluid.set_flags({'FLAGS_cudnn_deterministic': True})
 
 train_parameters = {
     "learning_strategy": {

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
@@ -14,10 +14,16 @@
 
 import logging
 import math
+import os
 import time
 import unittest
-
 import numpy as np
+# Note: Set True to eliminate randomness.
+#     1. For one operation, cuDNN has several algorithms,
+#        some algorithm results are non-deterministic, like convolution algorithms.
+#     2. It must be declared before the `import paddle` statement.
+#        Otherwise, it will not take effect.
+os.environ['FLAGS_cudnn_deterministic'] = 'True'
 
 import paddle
 import paddle.fluid as fluid
@@ -34,9 +40,8 @@ EPOCH_NUM = 1
 PRINT_STEP = 2
 STEP_NUM = 10
 
-place = fluid.CPUPlace()
-# TODO(liym27): Diff exists between dygraph and static graph on CUDA place.
-# place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() else fluid.CPUPlace()
+place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() \
+    else fluid.CPUPlace()
 
 train_parameters = {
     "learning_strategy": {

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
@@ -14,16 +14,9 @@
 
 import logging
 import math
-import os
 import time
 import unittest
 import numpy as np
-# Note: Set True to eliminate randomness.
-#     1. For one operation, cuDNN has several algorithms,
-#        some algorithm results are non-deterministic, like convolution algorithms.
-#     2. It must be declared before the `import paddle` statement.
-#        Otherwise, it will not take effect.
-os.environ['FLAGS_cudnn_deterministic'] = 'True'
 
 import paddle
 import paddle.fluid as fluid
@@ -42,6 +35,12 @@ STEP_NUM = 10
 
 place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() \
     else fluid.CPUPlace()
+
+# Note: Set True to eliminate randomness.
+#     1. For one operation, cuDNN has several algorithms,
+#        some algorithm results are non-deterministic, like convolution algorithms.
+if fluid.is_compiled_with_cuda():
+    fluid.core.globals()['FLAGS_cudnn_deterministic'] = True
 
 train_parameters = {
     "learning_strategy": {


### PR DESCRIPTION
### 1.内容

+ 动转静`test_se_resnet`添加GPU正确性测试。
+ `export FLAGS_cudnn_deterministic=True`消除计算随机性，详见[文档](https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/advanced_guide/flags/cudnn_cn.html#flags-cudnn-deterministic)

Note:
> 1. cuDNN对于同一操作有几种算法，一些算法结果是非确定性的，如卷积算法。
> 2. `os.environ`的设置变量的方式，在效率云上无法生效，且此方式需放在导入paddle包之前，易用性较差。改为`fluid.set_flags`方式

类似issue https://github.com/PaddlePaddle/Paddle/issues/21963

