### PR TITLE
[Pass] Fix embedding_eltwise_layernorm_fuse_pass problem.

### DIFF
--- a/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/embedding_eltwise_layernorm_fuse_pass.cc
@@ -36,8 +36,9 @@ static PDNode* create_emb_vars(PDPattern* pattern, const std::string& name,
 static PDNode* create_emb_out_vars(PDPattern* pattern, const std::string& name,
                                    const std::string& arg) {
   PDNode* node = pattern->NewNode(name)
-                     ->assert_is_op_output("lookup_table")
-                     ->assert_is_op_input("elementwise_add", arg);
+                     ->assert_is_only_output_of_op("lookup_table")
+                     ->assert_is_op_input("elementwise_add", arg)
+                     ->AsIntermediate();
   return node;
 }
 void Embedding2Eltwise1Pattern::operator()() {
@@ -94,7 +95,8 @@ void SkipLayerNorm::operator()() {
       pattern->NewNode(eltwise_add_repr())->assert_is_op("elementwise_add");
   auto* eltwise_add_out = pattern->NewNode(eltwise_add_out_repr())
                               ->assert_is_op_output("elementwise_add")
-                              ->assert_is_op_input("layer_norm", "X");
+                              ->assert_is_op_input("layer_norm", "X")
+                              ->AsIntermediate();
   auto* layer_norm =
       pattern->NewNode(layer_norm_repr())->assert_is_op("layer_norm");
   auto* layer_norm_out = pattern->NewNode(layer_norm_out_repr())


### PR DESCRIPTION
【描述】
提高embedding_eltwise_layernorm_fuse_pass的鲁棒性，当不全部满足该pass中patten的定义时，不触发该pass。

该pass支持的标准结构类似于：
![image](https://user-images.githubusercontent.com/26377421/82059857-2cbf9e80-96f9-11ea-9641-c867afb0f2bf.png)


出现错误的结构如下：
![image](https://user-images.githubusercontent.com/26377421/82059677-f3872e80-96f8-11ea-8100-0c796fbe93ab.png)

经过对比发现，是由于加入了fetch lookup_table输出的操作。

解决方法：通过对中间tensor打标记，当不全部满足pattern的条件，不触发该pass，保证程序运行的鲁棒性。