### PR TITLE
fix curl coverage error

### DIFF
--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -5,7 +5,7 @@ set -xe
 PADDLE_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}")/../../" && pwd )"
 
 # install lcov
-curl -o /lcov-1.14.tar.gz -s https://paddle-ci.gz.bcebos.com/coverage%2Flcov-1.14.tar.gz
+curl -o /lcov-1.14.tar.gz -x "" -s https://paddle-ci.gz.bcebos.com/coverage/lcov-1.14.tar.gz
 tar -xf /lcov-1.14.tar.gz -C /
 cd /lcov-1.14
 make install


### PR DESCRIPTION
解决下载失败问题，不使用代理下载该脚本。
![image](https://user-images.githubusercontent.com/29832297/82109177-92963f80-9766-11ea-9463-d5ba5e3d535c.png)
