### PR TITLE
operator missing data_feed_proto deps, which cause build failed

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -124,7 +124,7 @@ cc_library(shape_inference SRCS shape_inference.cc DEPS ddim attribute device_co
 
 cc_library(transfer_scope_cache SRCS transfer_scope_cache.cc DEPS scope framework_proto device_context)
 cc_library(op_kernel_type SRCS op_kernel_type.cc DEPS device_context place)
-cc_library(operator SRCS operator.cc DEPS op_info device_context tensor scope glog
+cc_library(operator SRCS operator.cc DEPS op_info device_context tensor scope glog data_feed_proto
     shape_inference data_transform lod_tensor profiler transfer_scope_cache op_kernel_type op_call_stack)
 
 cc_test(operator_test SRCS operator_test.cc DEPS operator op_registry device_context)


### PR DESCRIPTION
Scanning dependencies of target operator
[ 21%] Building CXX object paddle/fluid/framework/CMakeFiles/operator.dir/operator.cc.o
In file included from /Users/user/Paddle/paddle/fluid/framework/operator.cc:24:
In file included from /Users/user/Paddle/paddle/fluid/framework/executor.h:22:
In file included from /Users/user/Paddle/paddle/fluid/framework/data_set.h:25:
/Users/user/Paddle/paddle/fluid/framework/data_feed.h:28:10: fatal error: 'paddle/fluid/framework/data_feed.pb.h' file not found
#include "paddle/fluid/framework/data_feed.pb.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [paddle/fluid/framework/CMakeFiles/operator.dir/operator.cc.o] Error 1
make[1]: *** [paddle/fluid/framework/CMakeFiles/operator.dir/all] Error 2

operator lib build procedure needs above dependence