### PR TITLE
Del cuda8 nccl2

### DIFF
--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
@@ -57,7 +57,6 @@ RUN apt-get update && \
     apt-get install -y --allow-downgrades --allow-change-held-packages \
     patchelf python3 python3-dev python3-pip \
     git python-pip python-dev python-opencv openssh-server bison \
-    libnccl2=2.1.2-1+cuda8.0 libnccl-dev=2.1.2-1+cuda8.0 \
     wget unzip unrar tar xz-utils bzip2 gzip coreutils ntp \
     curl sed grep graphviz libjpeg-dev zlib1g-dev  \
     python-matplotlib gcc-4.8 g++-4.8 \

--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
@@ -50,7 +50,6 @@ RUN wget -q https://www.python.org/ftp/python/3.7.0/Python-3.7.0.tgz && \
     tar -xzf Python-3.7.0.tgz && cd Python-3.7.0 && \
     CFLAGS="-Wformat" ./configure --prefix=/usr/local/ --enable-shared > /dev/null && \
     make -j8 > /dev/null && make altinstall > /dev/null
-
 RUN rm -r /root/python_build
 
 RUN apt-get update && \


### PR DESCRIPTION
删除安装的cuda8 nccl2，使用默认的cuda10 nccl2。
使用过低的nccl版本容易造成nccl多链接初始化的错误。