### PR TITLE
Add an operator node in unittest to make the fusing result unique.

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/fusion_group_pass.cc
+++ b/paddle/fluid/framework/ir/fusion_group/fusion_group_pass.cc
@@ -82,7 +82,7 @@ int FusionGroupPass::DetectFusionGroup(Graph* graph, int type) const {
 bool FusionGroupPass::GenerateCode(fusion_group::SubGraph* subgraph) const {
   fusion_group::CodeGenerator code_generator;
   std::string code_str = code_generator.Generate(subgraph);
-  VLOG(3) << code_str;
+  VLOG(4) << code_str;
 
   // TODO(liuyiqun): supported different places
   platform::CUDAPlace place = platform::CUDAPlace(0);

--- a/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/test_ir_fusion_group_pass.py
@@ -122,7 +122,7 @@ class FusionGroupPassTestFP64(FusionGroupPassTest):
         self.fused_op_type = "fusion_group"
 
 
-class FusionGroupPassTestFP16(FusionGroupPassTest):
+class FusionGroupPassTestCastAndFP16(FusionGroupPassTest):
     def build_program(self, dtype):
         with fluid.program_guard(self.main_program, self.startup_program):
             self.feed_vars = self._prepare_feed_vars([32, 128], dtype, 2)
@@ -132,7 +132,7 @@ class FusionGroupPassTestFP16(FusionGroupPassTest):
 
             # subgraph with 2 op nodes
             tmp_0 = self.feed_vars[0] * self.feed_vars[1]
-            tmp_1 = layers.cast(tmp_0, dtype="float16")
+            tmp_1 = layers.softmax(layers.cast(tmp_0, dtype="float16"))
             tmp_2 = layers.mul(tmp_0, self.feed_vars[2])
             # subgraph with 4 op nodes
             tmp_3 = layers.cast(tmp_2, dtype="float16")
@@ -141,7 +141,7 @@ class FusionGroupPassTestFP16(FusionGroupPassTest):
 
         self.append_gradients(tmp_5)
 
-        self.num_fused_ops = 3
+        self.num_fused_ops = 4
         self.fetch_list = [tmp_5, self.grad(tmp_0)]
 
 


### PR DESCRIPTION
<img width="1131" alt="图片" src="https://user-images.githubusercontent.com/12538138/82209977-cdec6600-9940-11ea-9450-6be7960c3a95.png">

test_ir_fusion_group_pass中，有一个单测对应的子图结构如上。因graph中node的顺序，导致了遍历后节点的顺序不同，因而会产生2种可能的融合结果。

- 结果1（如上图所示）：子图1，elementwise_mul+1个红色标记的cast；子图2，elementwise_add+relu+2个绿色标记的cast

- 结果2：子图1，elementwise_mul；子图2，1个红色标记的cast+elementwise_add+relu+2个绿色标记的cast。由于fusion_group_pass中要求子图中的op节点数不小于2，因此两种情况得到的fusion_group op的数量不相同。

这个PR在「红色标记的cast」和elementwise_add直接插入一个softmax，使得子图匹配的结果唯一确定。