### PR TITLE
Use vector instead of pointer to init gflags

### DIFF
--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -50,7 +50,7 @@ std::once_flag glog_init_flag;
 std::once_flag p2p_init_flag;
 std::once_flag glog_warning_once_flag;
 
-bool InitGflags(std::vector<std::string> argv) {
+bool InitGflags(std::vector<std::string> args) {
   bool successed = false;
   std::call_once(gflags_init_flag, [&]() {
     FLAGS_logtostderr = true;
@@ -59,20 +59,23 @@ bool InitGflags(std::vector<std::string> argv) {
     // commandline strings from idx 1.
     // The reason is, it assumes that the first one (idx 0) is
     // the filename of executable file.
-    argv.insert(argv.begin(), "dummy");
-    int argc = argv.size();
-    char **arr = new char *[argv.size()];
+    args.insert(args.begin(), "dummy");
+    std::vector<char *> argv;
     std::string line;
-    for (size_t i = 0; i < argv.size(); i++) {
-      arr[i] = &argv[i][0];
-      line += argv[i];
+    int argc = args.size();
+    for (auto &arg : args) {
+      argv.push_back(const_cast<char *>(arg.data()));
+      line += arg;
       line += ' ';
     }
     VLOG(1) << "Before Parse: argc is " << argc
             << ", Init commandline: " << line;
+
+    char **arr = argv.data();
     google::ParseCommandLineFlags(&argc, &arr, true);
-    VLOG(1) << "After Parse: argc is " << argc;
     successed = true;
+
+    VLOG(1) << "After Parse: argc is " << argc;
   });
   return successed;
 }


### PR DESCRIPTION
As the title.
The args of `InitGflags` passed from python to c++ is a vector of string, like `['--tryfromenv=check_nan_inf,fast_check_nan_inf,xxx']`. 

In function `InitGflags`, since `ParseCommandLineFlags` takes `char***` as the second input arg, the original implementation `new` a `char**` by:
    `char **arr = new char *[argv.size()];` 

It did not delete `arr`, and may result in a smalle size `memory leak` detected by some code analysis tools, such as valgrind.  For example, the result of `valgrind`:
![image](https://user-images.githubusercontent.com/6888866/82213436-b6b07700-9946-11ea-839a-84fb78d348da.png)

It should be ponited out that the lambda function inside `InitGflags` uses `call_once`, so it is will not cause much memory leak indeed. The newed memory will be re-collected by os when the process exit. 

But, it is still not a good code practice, since `delete` is not paired with `new` explictly.

When I try to add delete in the lamdda function, I got `Error in python3: free(): invalid pointer:xx`. Debugging found that `arr` is assigned to a new memory address instread of the original newed one.

To avoid errors, I use vector instead of newed pointer to do it safely. 

