### PR TITLE
Append scale for static runner outputs

### DIFF
--- a/python/paddle/fluid/dygraph/static_runner.py
+++ b/python/paddle/fluid/dygraph/static_runner.py
@@ -19,13 +19,14 @@ import numpy as np
 import os
 import six
 
-from . import layers
-from .. import core
-from .. import framework
-from .. import backward
+from paddle import fluid
+from paddle.fluid.dygraph import layers
+from paddle.fluid import core
+from paddle.fluid import framework
+from paddle.fluid import backward
 
-from .base import switch_to_static_graph
-from ... import compat as cpt
+from paddle.fluid.dygraph.base import switch_to_static_graph
+from paddle import compat as cpt
 
 # DESIGN IDEA: Add an special operator, execute static program inside operator.
 #
@@ -359,7 +360,27 @@ class StaticModelRunner(layers.Layer):
         # NOTE: reverse feed vars
         self._input_names.reverse()
 
+        # Step 4. add scale for multiple outputs case
+        if len(self._output_names) > 1:
+            tmp_program = self._build_program_by_desc(program_desc)
+            self._append_scale_to_output(tmp_program)
+
         return program_desc
+
+    @switch_to_static_graph
+    def _append_scale_to_output(self, program):
+        # 1. append scale & save var
+        scale_output_vars = []
+        with fluid.program_guard(program):
+            for i, out in enumerate(self._output_descs):
+                var = program.global_block().var(out.name())
+                var = fluid.layers.scale(
+                    var, 1., name="static_model_runner/scale_{}".format(i))
+                scale_output_vars.append(var)
+        # 2. update output names & descs
+        for i, var in enumerate(scale_output_vars):
+            self._output_names[i] = var.name
+            self._output_descs[i] = var.desc
 
     @switch_to_static_graph
     def _append_backward_desc(self):

--- a/python/paddle/fluid/dygraph/static_runner.py
+++ b/python/paddle/fluid/dygraph/static_runner.py
@@ -19,14 +19,14 @@ import numpy as np
 import os
 import six
 
-from paddle import fluid
-from paddle.fluid.dygraph import layers
-from paddle.fluid import core
-from paddle.fluid import framework
-from paddle.fluid import backward
+from . import layers
+from .. import core
+from .. import framework
+from .. import backward
 
-from paddle.fluid.dygraph.base import switch_to_static_graph
-from paddle import compat as cpt
+from ..layers import nn
+from .base import switch_to_static_graph
+from ... import compat as cpt
 
 # DESIGN IDEA: Add an special operator, execute static program inside operator.
 #
@@ -371,10 +371,10 @@ class StaticModelRunner(layers.Layer):
     def _append_scale_to_output(self, program):
         # 1. append scale & save var
         scale_output_vars = []
-        with fluid.program_guard(program):
+        with framework.program_guard(program):
             for i, out in enumerate(self._output_descs):
                 var = program.global_block().var(out.name())
-                var = fluid.layers.scale(
+                var = nn.scale(
                     var, 1., name="static_model_runner/scale_{}".format(i))
                 scale_output_vars.append(var)
         # 2. update output names & descs

--- a/python/paddle/fluid/dygraph/static_runner.py
+++ b/python/paddle/fluid/dygraph/static_runner.py
@@ -360,10 +360,9 @@ class StaticModelRunner(layers.Layer):
         # NOTE: reverse feed vars
         self._input_names.reverse()
 
-        # Step 4. add scale for multiple outputs case
-        if len(self._output_names) > 1:
-            tmp_program = self._build_program_by_desc(program_desc)
-            self._append_scale_to_output(tmp_program)
+        # Step 4. add scale for outputs
+        tmp_program = self._build_program_by_desc(program_desc)
+        self._append_scale_to_output(tmp_program)
 
         return program_desc
 


### PR DESCRIPTION
当StaticModelRunner处理一些较为复杂的静态图预训练模型时，会存在预训练模型有多个fetch输出的情况。在多个fetch输出的场景中，有一种特殊的case，模型的多个输出可能在同一个分支上，如下图所示，示例取自PaddleHub [`ernie`](https://github.com/PaddlePaddle/PaddleHub/blob/5aa513e33c1641690f59d6444ba2ca779948c9d1/hub_module/modules/text/semantic_model/ernie_tiny/model/ernie.py#L175)

![image](https://user-images.githubusercontent.com/22561442/82292247-23765080-99dd-11ea-8707-24f20cb2184c.png)


将这多个输出作为StaticModuleRunner的输出进行处理时，会通过`fluid.gradients`为载入的预训练预测program添加反向，写法类似

`fluid.gradients(targets=[sequqnce_out, pooled_out])`

注意此时的网络，由于这两个输出在同一分支上，`gradients`生成反向的时候，并不知道后续这两个输出后续使用的状况，中间的输出节点仅仅是一个正常的中间节点而已

但是之后用户可能仅使用其中一个输出，并仅为这个输出添加后续的损失计算逻辑，如果用户只为中间的变量添加了后续op，网络将变成如下状态

![image](https://user-images.githubusercontent.com/22561442/82293235-d85d3d00-99de-11ea-993b-f132089620ac.png)


这里网络的性质发生改变，两个输出其实关联了两个分支，这些后续添加的操作在StaticModelRunner初始化时是不可知的，这导致后续在`sequence_out`节点上需要的梯度累加操作，在StaticModelRunner里面添加反向时并未被添加

后续计算时，`pooled_out`没有使用，梯度为0，且不会在`sequence_out`节点累加，导致后续一些利梯度都为0，参数无法正确更新

所以这里提前为这种情况增加scale操作，提前让StaticModelRunner将这里识别为两个分支，确保反向添加时，梯度累加操作不会遗漏，修改后的初始网络为

![image](https://user-images.githubusercontent.com/22561442/82292628-d0e96400-99dd-11ea-82fc-e0f5618b20fb.png)

- 补充1：这种处理方法可以解决当前问题，但是在执行上和静态图是有差别的，这里保留了无用梯度反向传播的op，理论上性能不如直接使用原静态图训练。在静态图中，由于网络在最后一次性添加反向，这种需要可以被正确识别，并进行合理的裁剪

- 补充2：这里为什么不在forward执行的时候根据用户需求，动态调整网络结构呢？
  - 这需要用户添加额外声明，比如一定要写明`pooled_out.stop_gradient=True`，否则动态图没有全局网络，StaticModelRunner无法感知到外部需求
  - forward是每个step都需要被执行的操作，在这里动态修改网络，会在循环中引入额外开销，同样导致性能下降，复杂度提高
  - 后续可以详细考虑下如何设计此处的实现





