### PR TITLE
Fix test_cond flaky test under Windows

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_cond.py
+++ b/python/paddle/fluid/tests/unittests/test_cond.py
@@ -466,12 +466,6 @@ class TestCondBackward(unittest.TestCase):
                                lambda: batchnorm_fc_with_inputs(img, label, class_num=10))
 
         for use_parallel_exe in [False, True]:
-            if use_parallel_exe and os.name == "nt":
-                print(
-                    "Skip use_parallel_exe=True in Windows because of flaky test when using PE and control flow under Windows"
-                )
-                continue
-
             self.backward_value_helper(cond_func,
                                        core.is_compiled_with_cuda(),
                                        use_parallel_exe)
@@ -493,12 +487,6 @@ class TestCondBackward(unittest.TestCase):
                                lambda: branch(i, img, label))
 
         for use_parallel_exe in [False, True]:
-            if use_parallel_exe and os.name == "nt":
-                print(
-                    "Skip use_parallel_exe=True in Windows because of flaky test when using PE and control flow under Windows"
-                )
-                continue
-
             self.backward_value_helper(cond_func_simple_net_at_true,
                                        core.is_compiled_with_cuda(),
                                        use_parallel_exe)
@@ -526,11 +514,6 @@ class TestCondBackward(unittest.TestCase):
                                lambda: branch(i, img, label, False))
 
         for use_parallel_exe in [False, True]:
-            if use_parallel_exe and os.name == "nt":
-                print(
-                    "Skip use_parallel_exe=True in Windows because of flaky test when using PE and control flow under Windows"
-                )
-                continue
             self.backward_value_helper(cond_func,
                                        core.is_compiled_with_cuda(),
                                        use_parallel_exe)


### PR DESCRIPTION
In the past, the test_cond will fail with 2% probability and easy to re-produce.

Now I re-run 300 times and no failure occurs. The probability of still has the failure is (1 - 2%) ^ 300 ~= 0.00004. We can say the random failure disappears. Maybe someone fixed some bugs in PE.
  