### PR TITLE
Make buddy_allocator_test Exclusive

### DIFF
--- a/paddle/fluid/memory/detail/CMakeLists.txt
+++ b/paddle/fluid/memory/detail/CMakeLists.txt
@@ -13,6 +13,7 @@ cc_library(buddy_allocator SRCS buddy_allocator.cc DEPS memory_block system_allo
 cc_test(buddy_allocator_test SRCS buddy_allocator_test.cc DEPS buddy_allocator)
 
 if(WITH_TESTING)
+  set_tests_properties(buddy_allocator_test PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
   add_custom_command(TARGET buddy_allocator_test POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/../../testdata/buddy_allocator_test_data ${CMAKE_CURRENT_BINARY_DIR}/buddy_allocator_test_data
   )


### PR DESCRIPTION
The background is that buddy_allocator_test depends on some big GPU allocations and current machine may not have it. It can cause random failure on cloud machine. After discussion with Shuo Tian, we decided to make buddy_allocator_test exclusive.
