### PR TITLE
[Dy2stat] Support len syntax

### DIFF
--- a/paddle/fluid/operators/shape_op.h
+++ b/paddle/fluid/operators/shape_op.h
@@ -20,15 +20,23 @@ namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
+using LoDTensor = framework::LoDTensor;
+using SelectedRows = framework::SelectedRows;
 
 template <typename T>
 class ShapeKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    auto* in_t = ctx.Input<Tensor>("Input");
+    auto* in_var = ctx.InputVar("Input");
+    framework::DDim in_dims;
+    if (in_var->IsType<SelectedRows>()) {
+      in_dims = in_var->Get<SelectedRows>().value().dims();
+    } else {
+      in_dims = in_var->Get<LoDTensor>().dims();
+    }
     auto* out_t = ctx.Output<Tensor>("Out");
+    out_t->Resize({in_dims.size()});
     auto out_data = out_t->mutable_data<int32_t>(platform::CPUPlace());
-    auto in_dims = in_t->dims();
     for (int i = 0; i < in_dims.size(); ++i) {
       out_data[i] = in_dims[i];
     }

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -36,10 +36,8 @@ class CallTransformer(gast.NodeTransformer):
         assert isinstance(node, gast.Call)
         func_str = ast_to_source_code(node.func).strip()
         try:
-            from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin, is_builtin_len
-            is_builtin_func = eval("is_builtin({})".format(func_str))
-            is_len_func = eval("is_builtin_len({})".format(func_str))
-            return not is_len_func and is_builtin_func
+            from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin_call
+            return eval("is_builtin_call({})".format(func_str))
         except Exception:
             return False
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -32,13 +32,20 @@ class CallTransformer(gast.NodeTransformer):
         self.wrapper_root = wrapper_root
         self.root = wrapper_root.node
 
-    def _is_builtin_call(self, node):
+    def _in_convert_call_whitelist(self, node):
+        """
+        Determines whether a function needs to be transformed by `convert_call`.
+        It doesn't need to be transformed when a function satisfies the following conditions:
+          1. It's a api of paddle
+          2. It's a python builtin function not include `len`
+        """
         assert isinstance(node, gast.Call)
         func_str = ast_to_source_code(node.func).strip()
         try:
             from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin_len, is_builtin
-            return not eval("is_builtin_len({})".format(func_str)) and eval(
-                "is_builtin({})".format(func_str))
+            is_builtin = eval("is_builtin({})".format(func_str))
+            is_builtin_len = eval("is_builtin_len({})".format(func_str))
+            return is_paddle_api(node) or (is_builtin and not is_builtin_len)
         except Exception:
             return False
 
@@ -47,10 +54,8 @@ class CallTransformer(gast.NodeTransformer):
 
     def visit_Call(self, node):
         self.generic_visit(node)
-        if is_paddle_api(node):
-            return node
 
-        if self._is_builtin_call(node):
+        if self._in_convert_call_whitelist(node):
             return node
 
         func_str = ast_to_source_code(node.func).strip()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -36,7 +36,7 @@ class CallTransformer(gast.NodeTransformer):
         assert isinstance(node, gast.Call)
         func_str = ast_to_source_code(node.func).strip()
         try:
-            from convert_call_func import is_builtin, is_builtin_len
+            from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin, is_builtin_len
             is_builtin_func = eval("is_builtin({})".format(func_str))
             is_len_func = eval("is_builtin_len({})".format(func_str))
             return not is_len_func and is_builtin_func

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -36,8 +36,9 @@ class CallTransformer(gast.NodeTransformer):
         assert isinstance(node, gast.Call)
         func_str = ast_to_source_code(node.func).strip()
         try:
-            from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin_call
-            return eval("is_builtin_call({})".format(func_str))
+            from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin_len, is_builtin
+            return not eval("is_builtin_len({})".format(func_str)) and eval(
+                "is_builtin({})".format(func_str))
         except Exception:
             return False
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -40,12 +40,15 @@ class CallTransformer(gast.NodeTransformer):
           2. It's a python builtin function not include `len`
         """
         assert isinstance(node, gast.Call)
+        if is_paddle_api(node):
+            return True
+
         func_str = ast_to_source_code(node.func).strip()
         try:
             from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin_len, is_builtin
             is_builtin = eval("is_builtin({})".format(func_str))
             is_builtin_len = eval("is_builtin_len({})".format(func_str))
-            return is_paddle_api(node) or (is_builtin and not is_builtin_len)
+            return is_builtin and not is_builtin_len
         except Exception:
             return False
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -32,7 +32,7 @@ class CallTransformer(gast.NodeTransformer):
         self.wrapper_root = wrapper_root
         self.root = wrapper_root.node
 
-    def _in_convert_call_whitelist(self, node):
+    def _no_need_convert_call(self, node):
         """
         Determines whether a function needs to be transformed by `convert_call`.
         It doesn't need to be transformed when a function satisfies the following conditions:
@@ -58,7 +58,7 @@ class CallTransformer(gast.NodeTransformer):
     def visit_Call(self, node):
         self.generic_visit(node)
 
-        if self._in_convert_call_whitelist(node):
+        if self._no_need_convert_call(node):
             return node
 
         func_str = ast_to_source_code(node.func).strip()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -36,8 +36,10 @@ class CallTransformer(gast.NodeTransformer):
         assert isinstance(node, gast.Call)
         func_str = ast_to_source_code(node.func).strip()
         try:
-            from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import is_builtin
-            return eval("is_builtin({})".format(func_str))
+            from convert_call_func import is_builtin, is_builtin_len
+            is_builtin_func = eval("is_builtin({})".format(func_str))
+            is_len_func = eval("is_builtin_len({})".format(func_str))
+            return not is_len_func and is_builtin_func
         except Exception:
             return False
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_builtins_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_builtins_func.py
@@ -16,7 +16,8 @@ from __future__ import print_function
 
 from paddle.fluid import framework
 from paddle.fluid import core
-from paddle.fluid import layers
+from paddle.fluid.layers import nn
+from paddle.fluid.layers import control_flow
 
 
 def convert_len(var):
@@ -35,9 +36,9 @@ def convert_len(var):
             # Note: Length of var may be known ahead of time in dygraph,
             # but it probably represents batch size which can be variant.
             # so we return a variable dynamically inferred from var.shape.
-            return layers.shape(var)[0]
+            return nn.shape(var)[0]
         elif var.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY:
-            return layers.array_length(var)
+            return control_flow.array_length(var)
         else:
             raise TypeError(
                 'len(var) only supports LoDTensor/LoDTensorArray/SelectedRows, but received %s.'

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_builtins_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_builtins_func.py
@@ -23,9 +23,9 @@ def convert_len(var):
     """
     return variable(length) from shape ops based on var.type
 
-    Note: In addition to some ast transformations,
-          there are also some block-related operations in `len`
-          transformation, such as append `shape_op` in var.block.
+    Note: In addition to some ast transformations, some block-related
+          operations are added in `len` transformation, such as appending
+          `shape_op` in var.block.
     """
     if isinstance(var, framework.Variable):
         if var.type in [

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_builtins_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_builtins_func.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+from paddle.fluid import framework
+from paddle.fluid import core
+from paddle.fluid import unique_name
+
+
+def converted_len(var):
+    print("invoke variable.__len__ in math_op_path:")
+    # return variable from length ops based on var.type
+    if isinstance(var, framework.Variable):
+        block = current_block(var)
+        out = create_new_var(block, 'int32', name='shape')
+        if var.type == core.VarDesc.VarType.LOD_TENSOR:
+            # Note: Length of var may be known ahead of time in dygraph,
+            # but it probably represents batch size which is variant.
+            # so we return a variable dynamically inferred from var.shape.
+            block.append_op(
+                type='shape', inputs={'Input': var}, outputs={'Out': out})
+        elif var.type == core.VarDesc.VarType.SELECTED_ROWS:
+            block.append_op(
+                type='shape', inputs={'Input': var}, outputs={'Out': out})
+        elif var.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY:
+            block.append_op(
+                type='lod_array_length',
+                inputs={'X': [var]},
+                outputs={'Out': [out]})
+            return out
+        else:
+            raise TypeError(
+                'len(var) only supports LoDTensor/LoDTensorArray/SelectedRows, but received %s.'
+                % type(var))
+        # return shape[0] as length.
+        len_var = out[0]
+        return len_var
+    else:
+        return builtin_len(var)
+
+
+def builtin_len(x):
+    return len(x)
+
+
+def current_block(var):
+    return var.block.program.current_block()
+
+
+def create_new_var(block, dtype, name):
+    tmp_name = unique_name.generate(name)
+    return block.create_var(name=tmp_name, dtype=dtype)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -29,6 +29,7 @@ import six
 
 from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
 from paddle.fluid.dygraph.layers import Layer
+from convert_builtins_func import converted_len
 
 DECORATOR_NAMES = ['declarative', 'dygraph_to_static_func']
 program_translator = ProgramTranslator()
@@ -47,6 +48,12 @@ def is_builtin(func):
         return True
     else:
         return False
+
+
+def is_builtin_len(func):
+    if isinstance(func, types.BuiltinFunctionType) and func.__name__ == 'len':
+        return True
+    return False
 
 
 def is_paddle_func(func):
@@ -91,10 +98,10 @@ def convert_call(func):
     func_self = None
     converted_call = None
 
-    if is_builtin(func):
-        return func
+    if is_builtin_len(func):
+        return converted_len
 
-    if is_paddle_func(func):
+    if is_builtin(func) or is_paddle_func(func):
         return func
 
     if inspect.isfunction(func):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -29,7 +29,7 @@ import six
 
 from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
 from paddle.fluid.dygraph.layers import Layer
-from convert_builtins_func import converted_len
+from paddle.fluid.dygraph.dygraph_to_static.convert_builtins_func import converted_len
 
 DECORATOR_NAMES = ['declarative', 'dygraph_to_static_func']
 program_translator = ProgramTranslator()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -36,6 +36,14 @@ program_translator = ProgramTranslator()
 to_static_func = program_translator.get_func
 
 
+def is_builtin_call(func):
+    """
+    Determines whether a function needs to be transformed by `convert_call`.
+    Wrappers the complex logic to avoid repeated calls by python `eval`.
+    """
+    return not is_builtin_len(func) and is_builtin(func)
+
+
 def is_builtin(func):
     if isinstance(func, types.BuiltinFunctionType):
         return True

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -29,19 +29,11 @@ import six
 
 from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
 from paddle.fluid.dygraph.layers import Layer
-from paddle.fluid.dygraph.dygraph_to_static.convert_builtins_func import converted_len
+from paddle.fluid.dygraph.dygraph_to_static.convert_builtins_func import convert_len
 
 DECORATOR_NAMES = ['declarative', 'dygraph_to_static_func']
 program_translator = ProgramTranslator()
 to_static_func = program_translator.get_func
-
-
-def is_builtin_call(func):
-    """
-    Determines whether a function needs to be transformed by `convert_call`.
-    Wrappers the complex logic to avoid repeated calls by python `eval`.
-    """
-    return not is_builtin_len(func) and is_builtin(func)
 
 
 def is_builtin(func):
@@ -107,7 +99,7 @@ def convert_call(func):
     converted_call = None
 
     if is_builtin_len(func):
-        return converted_len
+        return convert_len
 
     if is_builtin(func) or is_paddle_func(func):
         return func

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11018,8 +11018,26 @@ def shape(input):
 
     Get the shape of the input.
 
+    .. code-block:: text
+
+        Case1:
+            Given N-D Tensor:
+                input = [ [1, 2, 3, 4], [5, 6, 7, 8] ]
+
+            Then:
+                input.shape = [2, 4]
+
+        Case2:
+            Given SelectedRows:
+                input.rows = [0, 4, 19]
+                input.height = 20
+                input.value = [ [1, 2], [3, 4], [5, 6] ]  # inner tensor
+            Then:
+                input.shape = [3, 2]
+
     Args:
-        input (Variable): The input N-D Tensor. Datatype can be float32, float64, int32, int64.
+        input (Variable): The input can be N-D Tensor or SelectedRows with data type float32, float64, int32, int64.
+                          If input variable is type of SelectedRows, returns the shape of it's inner tensor.
 
     Returns:
         Variable (Tensor): The shape of the input variable.

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11048,7 +11048,7 @@ def shape(input):
             import paddle.fluid as fluid
             import numpy as np
 
-            inputs = fluid.layers.data(name="x", shape=[3, 100, 100], dtype="float32")
+            inputs = fluid.data(name="x", shape=[3, 100, 100], dtype="float32")
             output = fluid.layers.shape(inputs)
 
             exe = fluid.Executor(fluid.CPUPlace())

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
@@ -64,9 +64,7 @@ class TestLen(unittest.TestCase):
 
     def test_len(self):
         dygraph_res = self._run(to_static=False)
-        print(dygraph_res)
         static_res = self._run(to_static=True)
-        print(static_res)
         self.assertTrue(np.allclose(dygraph_res, static_res))
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
@@ -18,8 +18,8 @@ import unittest
 
 import numpy as np
 import paddle.fluid as fluid
-from jit import declarative
-from dygraph_to_static import convert_call
+from paddle.fluid.dygraph import declarative
+from paddle.fluid.dygraph.dygraph_to_static import convert_call
 
 SEED = 2020
 np.random.seed(SEED)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_len.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+import paddle.fluid as fluid
+from jit import declarative
+from dygraph_to_static import convert_call
+
+SEED = 2020
+np.random.seed(SEED)
+
+
+def len_with_tensor(x):
+    x = fluid.dygraph.to_variable(x)
+    x_len = len(x)
+    return x_len
+
+
+def len_with_lod_tensor_array(x):
+    x = fluid.dygraph.to_variable(x)
+
+    i = fluid.layers.fill_constant(shape=[1], dtype='int64', value=0)
+    arr = fluid.layers.array_write(x, i=i)
+    arr_len = len(arr)
+
+    return arr_len
+
+
+class TestLen(unittest.TestCase):
+    def setUp(self):
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        self.x_data = np.random.random([10, 16]).astype('float32')
+        self.init_func()
+
+    def init_func(self):
+        self.func = len_with_tensor
+
+    def _run(self, to_static):
+        with fluid.dygraph.guard(self.place):
+            if to_static:
+                out = declarative(self.func)(self.x_data)
+            else:
+                out = self.func(self.x_data)
+
+            if isinstance(out, fluid.core.VarBase):
+                out = out.numpy()
+            return out
+
+    def test_len(self):
+        dygraph_res = self._run(to_static=False)
+        print(dygraph_res)
+        static_res = self._run(to_static=True)
+        print(static_res)
+        self.assertTrue(np.allclose(dygraph_res, static_res))
+
+
+class TestLenWithTensorArray(TestLen):
+    def init_func(self):
+        self.func = len_with_lod_tensor_array
+
+
+def len_with_selected_rows(place):
+    block = fluid.default_main_program().global_block()
+    # create selected_rows variable
+    var = block.create_var(
+        name="X",
+        dtype="float32",
+        persistable=True,
+        type=fluid.core.VarDesc.VarType.SELECTED_ROWS)
+    y = fluid.layers.merge_selected_rows(var)
+    y_len = convert_call(len)(y)
+
+    z = fluid.layers.get_tensor_from_selected_rows(y)
+    z_len = convert_call(len)(z)
+
+    # set data for selected_rows
+    x_rows = [0, 2, 2, 4, 19]
+    row_numel = 2
+    np_array = np.ones((len(x_rows), row_numel)).astype("float32")
+
+    x_var = fluid.global_scope().var("X").get_selected_rows()
+    x_var.set_rows(x_rows)
+    x_var.set_height(20)
+    x_tensor = x_var.get_tensor()
+    x_tensor.set(np_array, place)
+
+    exe = fluid.Executor(place=place)
+    result = exe.run(fluid.default_main_program(),
+                     fetch_list=[y, y_len, z, z_len])
+    return result
+
+
+class TestLenWithSelectedRows(unittest.TestCase):
+    def setUp(self):
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+
+    def test_len(self):
+        selected_rows_var, selected_rows_var_len, var_tensor, var_tensor_len = len_with_selected_rows(
+            self.place)
+        print(selected_rows_var)
+        print(selected_rows_var_len)
+        print(var_tensor)
+        print(var_tensor_len)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
#### Required（必填, multiple choices, two at most）
- **PR type（PR 类型） is (A):**
A. New features（新功能）---------------- D. Performance optimization（性能优化）
B. Bug fixes（问题修复）------------------ E. Breaking changes（向后不兼容的改变）
C. Function optimization（功能优化）------F.  Others（其它）

- **PR changes（改动点）is ( D):**
A. OPs（operators）---------------------- C. Docs（文档）
B. APIs（接口）--------------------------- D. Others（其它）

- **Use one sentence to describe what this PR does.（简述本次PR的目的和改动）**

  This PR supports python `len` transformation in dy2stat.

-----------------------
#### Optional（选填, If None, please delete it）

- **If you modified docs, please make sure that both Chinese and English docs were modified and provide a preview screenshot. （文档必填）**
 
![image](https://user-images.githubusercontent.com/9301846/82856796-9e8db880-9f41-11ea-9859-41856a93057e.png)


###  PR功能
#### 1. shape_op支持`selected_rows`(前置功能)
`len`语法依赖`shape_op`，之前此op不支持`selected_rows`类型的variable，此PR对此进行了兼容性支持。

对于`selected_rows`类型的variable，`shape_op`返回其内部持有Tensor的shape。
```python
# SelectedRows X的基本信息：
x_rows = [0, 1, 5, 4, 19]
height = 20
row_numel = 2

shape(X)=[5,2]
```

#### 2. 动转静支持len语法
+ **LoDTensor**类型

  动态图下为VarBase，动态执行时是通过var.numpy()[0]返回的len信息（底层重写了__len__）。静态图下考虑到`shape[0]`在较多场景下表示`batch_size`，因此借助`shape_op`动态从Variable获取，取shape[0]作为length

+ **LoDTensorArray**类型

  动态图下LoDTensorArray实际就是python的list类型。静态图下LoDTensorArray有单独的array_length方法，借助此api返回length

+ **SelectedRows**类型

   动态图下没有直接暴露出来给用户，如上所述，升级了`shape_op`也支持对此类型调用`len`

+ python内建类型

   返回和动态图一致的结果

> Note: 动态图中len返回的均为int类型，转为静态图后，对于variable类型返回的是shape=[1]的Variable


shape中文文档PR：https://github.com/PaddlePaddle/FluidDoc/pull/2176