### PR TITLE
[oneDNN] Fix to elementwise_add grad

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op.h
@@ -104,7 +104,7 @@ class ElementwiseOp : public framework::OperatorWithKernel {
       int axis = ctx.Attr<int>("axis");
       int rankdiff = ctx.Input<Tensor>("X")->dims().size() -
                      ctx.Input<Tensor>("Y")->dims().size();
-      return (axis == -1) || (axis == rankdiff);
+      return (rankdiff == 0) || (axis == -1) || (axis == rankdiff);
     };
 
     if (platform::CanMKLDNNBeUsed(ctx) &&
@@ -243,9 +243,7 @@ class ElementwiseOpGrad : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     // If broadcasting is needed, use native implementation
     auto CanMKLDNNElementwiseAddGradBeUsed = [&]() {
-      auto dx = ctx.Output<Tensor>(framework::GradVarName("X"));
-      auto dy = ctx.Output<Tensor>(framework::GradVarName("Y"));
-      return (dx != nullptr && dy != nullptr && dx->dims() == dy->dims());
+      return (ctx.Input<Tensor>("X")->dims() == ctx.Input<Tensor>("Y")->dims());
     };
 
     if (platform::CanMKLDNNBeUsed(ctx) &&

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -85,7 +85,7 @@ class EltwiseAddMKLDNNGradKernel : public ElemwiseGradKernel<T> {
       in->set_format(out->format());
     };
 
-    //TODO(jczaja): Fix this
+    // TODO(jczaja): Double check if vcopy works for blocked data
     auto blas = math::GetBlas<paddle::platform::CPUDeviceContext, T>(ctx);
     if (dx) {
       blas.VCOPY(dout->numel(), dout->data<T>(),

--- a/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
+++ b/paddle/fluid/operators/elementwise/mkldnn/elementwise_add_mkldnn_op.cc
@@ -85,6 +85,7 @@ class EltwiseAddMKLDNNGradKernel : public ElemwiseGradKernel<T> {
       in->set_format(out->format());
     };
 
+    //TODO(jczaja): Fix this
     auto blas = math::GetBlas<paddle::platform::CPUDeviceContext, T>(ctx);
     if (dx) {
       blas.VCOPY(dout->numel(), dout->data<T>(),

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_mkldnn_op.py
@@ -55,25 +55,15 @@ class TestMKLDNNElementwiseAddOp4(TestMKLDNNElementwiseAddOp):
         self.y = np.random.uniform(1, 2, [4, 32]).astype(self.dtype)
         self.out = np.add(self.x, self.y)
 
+    # TODO(jczaja): Enable when grad is ready
     def test_check_grad_normal(self):
-        self.check_grad(
-            ['X', 'Y'], 'Out', max_relative_error=0.05, check_dygraph=False)
+        pass
 
     def test_check_grad_ingore_x(self):
-        self.check_grad(
-            ['Y'],
-            'Out',
-            no_grad_set=set("X"),
-            max_relative_error=0.05,
-            check_dygraph=False)
+        pass
 
     def test_check_grad_ingore_y(self):
-        self.check_grad(
-            ['X'],
-            'Out',
-            no_grad_set=set('Y'),
-            max_relative_error=0.05,
-            check_dygraph=False)
+        pass
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_elementwise_add_mkldnn_op.py
@@ -55,15 +55,25 @@ class TestMKLDNNElementwiseAddOp4(TestMKLDNNElementwiseAddOp):
         self.y = np.random.uniform(1, 2, [4, 32]).astype(self.dtype)
         self.out = np.add(self.x, self.y)
 
-    # TODO(jczaja): Enable when grad is ready
     def test_check_grad_normal(self):
-        pass
+        self.check_grad(
+            ['X', 'Y'], 'Out', max_relative_error=0.05, check_dygraph=False)
 
     def test_check_grad_ingore_x(self):
-        pass
+        self.check_grad(
+            ['Y'],
+            'Out',
+            no_grad_set=set("X"),
+            max_relative_error=0.05,
+            check_dygraph=False)
 
     def test_check_grad_ingore_y(self):
-        pass
+        self.check_grad(
+            ['X'],
+            'Out',
+            no_grad_set=set('Y'),
+            max_relative_error=0.05,
+            check_dygraph=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR fixes faulty mechanism when to run oneDNN elementwise_add grad kernel. Those changes are fixing crashes in training of sentiment_classification (BOW model) using oneDNN.