### PR TITLE
[Dy2Stat]Support to transform sequence assignments and multi-target assignments

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -946,7 +946,7 @@ class SplitAssignTransformer(gast.NodeTransformer):
         if len(target_nodes) == 1:
             node = self._parse_sequence_assign(node)
         else:
-            node = self._parse_mul_target_assign(node)
+            node = self._parse_multi_target_assign(node)
         return node
 
     def _parse_sequence_assign(self, node):
@@ -957,7 +957,6 @@ class SplitAssignTransformer(gast.NodeTransformer):
         b = d
         """
         assert isinstance(node, gast.Assign)
-        new_nodes = []
 
         target_nodes = node.targets
         value_node = node.value
@@ -971,13 +970,14 @@ class SplitAssignTransformer(gast.NodeTransformer):
         if len(targets) != len(values):
             return node
 
+        new_nodes = []
         for target, value in zip(targets, values):
             assign_node = gast.Assign(targets=[target], value=value)
             new_nodes.append(assign_node)
 
         return new_nodes
 
-    def _parse_mul_target_assign(self, node):
+    def _parse_multi_target_assign(self, node):
         """
          Example 1:
          a = b = c
@@ -999,6 +999,8 @@ class SplitAssignTransformer(gast.NodeTransformer):
         new_nodes = []
         for target in reversed(target_nodes):
             assign_node = gast.Assign(targets=[target], value=value_node)
+            # NOTE: Because assign_node can be sequence assign statement like `a,b = c,d`,
+            # it's necessary to visit this new assign_node
             parsed_node = self.visit_Assign(assign_node)
             if not isinstance(parsed_node, list):
                 parsed_node = [parsed_node]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_utils.py
@@ -16,7 +16,11 @@ from __future__ import print_function
 
 import unittest
 
+from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
 from paddle.fluid.dygraph.dygraph_to_static.utils import index_in_list
+from paddle.fluid.dygraph.dygraph_to_static.utils import SplitAssignTransformer
+
+from test_program_translator import get_source_code
 
 
 class TestIndexInList(unittest.TestCase):
@@ -27,6 +31,35 @@ class TestIndexInList(unittest.TestCase):
         self.assertEqual(index_in_list(list_to_test, 5), 4)
         self.assertEqual(index_in_list(list_to_test, 0), -1)
         self.assertEqual(index_in_list(list_to_test, 6), -1)
+
+
+def dyfunc_assign(input):
+    a = b = 1
+    c, d = e, f = a, b
+    z = [3, 4]
+    [x, y] = m, n = z
+
+
+class StaticCode():
+    def dyfunc_assign(input):
+        b = 1
+        a = b
+        e = a
+        f = b
+        c = e
+        d = f
+        z = [3, 4]
+        m, n = z
+        x = m
+        y = n
+
+
+class TestSplitAssignTransformer(unittest.TestCase):
+    def test_code(self):
+        answer = get_source_code(StaticCode.dyfunc_assign)
+        program_translator = ProgramTranslator()
+        code = program_translator.get_code(dyfunc_assign)
+        self.assertEqual(answer, code)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
As the title, support to transform sequence assignments and multi-target assignments to normal assignments.

Code transformation is as follows:
- Before:
```Python
a, b = c, d
```
- After:
```
a = c
b = d
```

- Before:
```Python
a, b = c, d = x
```
- After:
```
 c,d = x
 a = c
 b = d
```
