### PR TITLE
fix compile error about cub

### DIFF
--- a/cmake/external/cub.cmake
+++ b/cmake/external/cub.cmake
@@ -17,7 +17,7 @@ include(ExternalProject)
 set(CUB_PREFIX_DIR ${THIRD_PARTY_PATH}/cub)
 set(CUB_SOURCE_DIR ${THIRD_PARTY_PATH}/cub/src/extern_cub)
 set(CUB_REPOSITORY https://github.com/NVlabs/cub.git)
-set(CUB_TAG        v1.8.0)
+set(CUB_TAG        1.8.0)
 
 cache_third_party(extern_cub
     REPOSITORY    ${CUB_REPOSITORY}


### PR DESCRIPTION
+ fix cub error while compiling
![image](https://user-images.githubusercontent.com/33303691/82398694-09dd1380-9a86-11ea-9fcd-49316adccd2c.png)
The reason is: https://github.com/NVlabs/cub/releases update yesterday (May 19th), and we don't know what's happen.