### PR TITLE
Decrease the Batch Size of SE-Resnext in Unittest.

### DIFF
--- a/python/paddle/fluid/tests/unittests/seresnext_net.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_net.py
@@ -173,7 +173,7 @@ model = SE_ResNeXt50Small
 
 
 def batch_size():
-    return 12
+    return 8
 
 
 def iter(use_cuda):


### PR DESCRIPTION
As discussed with QA, we will use p4 machine for unit test and the GPU on those machine may not have enough GPU, which can cause "test_parallel_executor_seresnext_base_gpu" failed. So I decrease the batch size.