### PR TITLE
Fix boost get ci rule

### DIFF
--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -415,10 +415,3 @@ TEST(BOOST_GET_SAFELY, FAIL) {
   }
   EXPECT_TRUE(caught_exception);
 }
-
-TEST(BOOST_GET, SUCCESS) {
-  paddle::framework::Attribute attr;
-  attr = true;
-  bool rlt = boost::get<bool>(attr);
-  EXPECT_EQ(rlt, true);
-}

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -415,3 +415,10 @@ TEST(BOOST_GET_SAFELY, FAIL) {
   }
   EXPECT_TRUE(caught_exception);
 }
+
+TEST(BOOST_GET, SUCCESS) {
+  paddle::framework::Attribute attr;
+  attr = true;
+  bool rlt = boost_get<bool>(attr);
+  EXPECT_EQ(rlt, true);
+}

--- a/paddle/fluid/platform/enforce_test.cc
+++ b/paddle/fluid/platform/enforce_test.cc
@@ -419,6 +419,6 @@ TEST(BOOST_GET_SAFELY, FAIL) {
 TEST(BOOST_GET, SUCCESS) {
   paddle::framework::Attribute attr;
   attr = true;
-  bool rlt = boost_get<bool>(attr);
+  bool rlt = boost::get<bool>(attr);
   EXPECT_EQ(rlt, true);
 }

--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -157,7 +157,7 @@ if [ ${HAS_CONST_CAST} ] && [ "${GIT_PR_ID}" != "" ]; then
 fi
 
 HAS_BOOST_GET=`git diff -U0 upstream/$BRANCH |grep "^+" |grep -o -m 1 "boost::get" || true`
-if [ ${HAS_CONST_CAST} ] && [ "${GIT_PR_ID}" != "" ]; then
+if [ ${HAS_BOOST_GET} ] && [ "${GIT_PR_ID}" != "" ]; then
     echo_line="boost::get is not recommended, because it may throw an bad_get exception without any stack information, so please use BOOST_GET(_**)(dtype, value) series macros here. If these macros cannot meet your needs, please use try-catch to handle boost::get and specify chenwhql (Recommend), luotao1 or lanxianghit review and approve.\n"
     check_approval 1 6836917 47554610 22561442
 fi


### PR DESCRIPTION
fix boost get ci rule error.

added test code:

```c++
TEST(BOOST_GET, SUCCESS) {
  paddle::framework::Attribute attr;
  attr = true;
  bool rlt = boost::get<bool>(attr);
  EXPECT_EQ(rlt, true);
}
```

test log: http://10.87.145.41:8111/viewLog.html?buildId=348211&buildTypeId=YYTest_PrCiCpuPy2&tab=buildLog&branch_YYTest=pull%2F23816
![image](https://user-images.githubusercontent.com/22561442/82421528-bb466e00-9ab3-11ea-9c13-3a24dd052126.png)

