### PR TITLE
support tensor to varbase, test=develop

### DIFF
--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -538,8 +538,8 @@ def to_variable(value, name=None, zero_copy=None):
     numpy\.ndarray, Variable or ComplexVariable object.
 
     Parameters:
-        value(ndarray|Variable|ComplexVariable): The numpy\.ndarray, Variable 
-            or ComplexVariable object that needs to be converted, it can be 
+        value(ndarray|Variable|Tensor|ComplexVariable): The numpy\.ndarray, Variable 
+            Tensor or ComplexVariable object that needs to be converted, it can be 
             multi-dimension, and the data type is one of numpy\.{float16, 
             float32, float64, int16, int32, int64, uint8, uint16, complex64, 
             complex128}.
@@ -611,6 +611,8 @@ def to_variable(value, name=None, zero_copy=None):
     elif isinstance(value, (core.VarBase, framework.Variable,
                             framework.ComplexVariable)):
         return value
+    elif isinstance(value, (core.Tensor, core.LoDTensor)):
+        return core.VarBase(value)
     else:
         raise TypeError(
             "The type of input value is invalid, expected type is 'ndarray', "

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -240,18 +240,22 @@ class TestImperative(unittest.TestCase):
     def test_create_VarBase(self):
         x = np.ones([2, 2], np.float32)
         y = np.zeros([3, 3], np.float32)
+        t = fluid.Tensor()
+        t.set(x, fluid.CPUPlace())
         with fluid.dygraph.guard():
             tmp = fluid.core.VarBase(value=x, place=fluid.core.CPUPlace())
             tmp2 = fluid.core.VarBase(y, fluid.core.CPUPlace())
             tmp3 = fluid.dygraph.base.to_variable(x)
             tmp4 = fluid.core.VarBase(y)
             tmp5 = fluid.core.VarBase(value=x)
+            tmp6 = fluid.core.VarBase(t)
 
             self.assertTrue(np.array_equal(x, tmp.numpy()))
             self.assertTrue(np.array_equal(y, tmp2.numpy()))
             self.assertTrue(np.array_equal(x, tmp3.numpy()))
             self.assertTrue(np.array_equal(y, tmp4.numpy()))
             self.assertTrue(np.array_equal(x, tmp5.numpy()))
+            self.assertTrue(np.array_equal(x, tmp6.numpy()))
 
     def test_no_grad_guard(self):
         data = np.array([[2, 3], [4, 5]]).astype('float32')
@@ -384,7 +388,6 @@ class TestImperative(unittest.TestCase):
             var_inp = fluid.dygraph.base.to_variable(np_inp)
             var_inp.stop_gradient = False
             l = MyLayer()
-            print(var_inp)
             x = l(var_inp)[0]
             self.assertIsNotNone(x)
             dy_out = x.numpy()

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -47,6 +47,13 @@ class TestVarBase(unittest.TestCase):
                 linear = fluid.dygraph.Linear(32, 64)
                 var = linear._helper.to_variable("test", name="abc")
 
+    def test_tensor_to_variable(self):
+        with fluid.dygraph.guard():
+            t = fluid.Tensor()
+            t.set(np.ndarray([5, 30]), fluid.CPUPlace())
+            var = fluid.dygraph.to_variable(t)
+            self.assertTrue(np.array_equal(t, var.numpy()))
+
     def test_write_property(self):
         with fluid.dygraph.guard():
             var = fluid.dygraph.to_variable(self.array)


### PR DESCRIPTION
As the title.

In some scenarios, we need the ability to covert tensor to VarBase in imperative mode.

```
t = fluid.Tensor()
t.set(np.ndarray([5, 30]), fluid.CUDAPlace(0))
var = fluid.dygraph.to_variable(t)
np.array_equal(t, var.numpy())
```