### PR TITLE
conda install cuda10 cudnn7.6

### DIFF
--- a/paddle/scripts/conda_build.py
+++ b/paddle/scripts/conda_build.py
@@ -116,7 +116,7 @@ python setup.py install
     """
         self.cuda100 = r"""
     - cudatoolkit>=10.0, <10.1
-    - cudnn>=7.3, <7.4
+    - cudnn>=7.6, <7.7
     """
         self.cuda_info = [(self.cuda90, "cuda9.0", ".post97"),
                           (self.cuda100, "cuda10.0", ".post107")]


### PR DESCRIPTION
默认使用conda安装cuda10版本的paddle会安装cudnn7.3，在跑install_check.run_check()命令时会报warning,whl包编译环境都是使用cudnn7.6版本，conda编包脚本需要升级。
![image](https://user-images.githubusercontent.com/29832297/82528620-c78e0200-9b6b-11ea-93aa-5ec44941eae8.png)


