### PR TITLE
add option to exclude ops by id from quantization

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/QAT_mkldnn_int8_readme.md
+++ b/python/paddle/fluid/contrib/slim/tests/QAT_mkldnn_int8_readme.md
@@ -237,11 +237,13 @@ You can use the `qat2_int8_image_classification_comparison.py` script to reprodu
 * `--fp32_model` - a path to an FP32 model whose accuracy will be measured and compared to the accuracy of the INT8 model.
 * `--infer_data` - a path to the validation dataset.
 
-The following option is also accepted:
+The following options are also accepted:
 * `--ops_to_quantize` - a comma-separated list of operator types to quantize. If the option is not used, an attempt to quantize all quantizable operators will be made, and in that case only quantizable operators which have quantization scales provided in the QAT model will be quantized. When deciding which operators to put on the list, the following have to be considered:
   * Only operators which support quantization will be taken into account.
   * All the quantizable operators from the list, which are present in the model, must have quantization scales provided in the model. Otherwise, quantization of the operator will be skipped with a message saying which variable is missing a quantization scale.
   * Sometimes it may be suboptimal to quantize all quantizable operators in the model (cf. *Notes* in the **Gathering scales** section above). To find the optimal configuration for this option, user can run benchmark a few times with different lists of quantized operators present in the model and compare the results. For Image Classification models mentioned above the list usually comprises of `conv2d` and `pool2d` operators.
+* `--op_ids_to_skip` - a comma-separated list of operator ids to skip in quantization. To get an id of a particular operator run the script with the `--debug` option first (see below for the description of the option), and having opened the generated file `qat_int8_cpu_quantize_placement_pass.dot` find the id number written in parentheses next to the name of the operator.
+* `--debug` - add this option to generate a series of `*.dot` files containing the model graphs after each step of the transformation. For a description of the DOT format see [DOT]( https://graphviz.gitlab.io/_pages/doc/info/lang.html). The files will be saved in the current location. To open the `*.dot` files use any of the Graphviz tools available on your system (e.g. `xdot` tool on Linux or `dot` tool on Windows, for documentation see [Graphviz](http://www.graphviz.org/documentation/)).
 
 ```bash
 cd /PATH/TO/PADDLE

--- a/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
@@ -42,10 +42,6 @@ def parse_args():
         help='Number of the first minibatches to skip in performance statistics.'
     )
     parser.add_argument(
-        '--debug',
-        action='store_true',
-        help='If used, the graph of QAT model is drawn.')
-    parser.add_argument(
         '--qat_model', type=str, default='', help='A path to a QAT model.')
     parser.add_argument(
         '--fp32_model', type=str, default='', help='A path to an FP32 model.')
@@ -67,6 +63,15 @@ def parse_args():
         default='',
         help='A comma separated list of operators to quantize. Only quantizable operators are taken into account. If the option is not used, an attempt to quantize all quantizable operators will be made.'
     )
+    parser.add_argument(
+        '--op_ids_to_skip',
+        type=str,
+        default='',
+        help='A comma separated list of operator ids to skip in quantization.')
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='If used, the graph of QAT model is drawn.')
 
     test_args, args = parser.parse_known_args(namespace=unittest)
     return test_args, sys.argv[:1] + args
@@ -181,6 +186,7 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
             if (transform_to_int8):
                 transform_to_mkldnn_int8_pass = Qat2Int8MkldnnPass(
                     self._quantized_ops,
+                    _op_ids_to_skip=self._op_ids_to_skip,
                     _scope=inference_scope,
                     _place=place,
                     _core=core,
@@ -306,9 +312,15 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
         skip_batch_num = test_case_args.skip_batch_num
         acc_diff_threshold = test_case_args.acc_diff_threshold
         self._debug = test_case_args.debug
+
         self._quantized_ops = set()
         if len(test_case_args.ops_to_quantize) > 0:
             self._quantized_ops = set(test_case_args.ops_to_quantize.split(','))
+
+        self._op_ids_to_skip = set([-1])
+        if len(test_case_args.op_ids_to_skip) > 0:
+            self._op_ids_to_skip = set(
+                map(int, test_case_args.op_ids_to_skip.split(',')))
 
         _logger.info('FP32 & QAT INT8 prediction run.')
         _logger.info('QAT model: {0}'.format(qat_model_path))
@@ -318,6 +330,8 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
         _logger.info('Batch number: {0}'.format(batch_num))
         _logger.info('Accuracy drop threshold: {0}.'.format(acc_diff_threshold))
         _logger.info('Quantized ops: {0}.'.format(self._quantized_ops))
+        _logger.info('Op ids to skip quantization: {0}.'.format(
+            self._op_ids_to_skip))
 
         _logger.info('--- FP32 prediction start ---')
         val_reader = paddle.batch(

--- a/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat2_int8_image_classification_comparison.py
@@ -315,7 +315,8 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
 
         self._quantized_ops = set()
         if len(test_case_args.ops_to_quantize) > 0:
-            self._quantized_ops = set(test_case_args.ops_to_quantize.split(','))
+            self._quantized_ops = set(
+                op.strip() for op in test_case_args.ops_to_quantize.split(','))
 
         self._op_ids_to_skip = set([-1])
         if len(test_case_args.op_ids_to_skip) > 0:
@@ -323,15 +324,17 @@ class Qat2Int8ImageClassificationComparisonTest(unittest.TestCase):
                 map(int, test_case_args.op_ids_to_skip.split(',')))
 
         _logger.info('FP32 & QAT INT8 prediction run.')
-        _logger.info('QAT model: {0}'.format(qat_model_path))
-        _logger.info('FP32 model: {0}'.format(fp32_model_path))
-        _logger.info('Dataset: {0}'.format(data_path))
-        _logger.info('Batch size: {0}'.format(batch_size))
-        _logger.info('Batch number: {0}'.format(batch_num))
-        _logger.info('Accuracy drop threshold: {0}.'.format(acc_diff_threshold))
-        _logger.info('Quantized ops: {0}.'.format(self._quantized_ops))
-        _logger.info('Op ids to skip quantization: {0}.'.format(
-            self._op_ids_to_skip))
+        _logger.info('QAT model: {}'.format(qat_model_path))
+        _logger.info('FP32 model: {}'.format(fp32_model_path))
+        _logger.info('Dataset: {}'.format(data_path))
+        _logger.info('Batch size: {}'.format(batch_size))
+        _logger.info('Batch number: {}'.format(batch_num))
+        _logger.info('Accuracy drop threshold: {}.'.format(acc_diff_threshold))
+        _logger.info('Quantized ops: {}.'.format(','.join(
+            self._quantized_ops) if self._quantized_ops else 'all quantizable'))
+        _logger.info('Op ids to skip quantization: {}.'.format(','.join(
+            map(str, self._op_ids_to_skip)) if test_case_args.op_ids_to_skip
+                                                               else 'none'))
 
         _logger.info('--- FP32 prediction start ---')
         val_reader = paddle.batch(

--- a/python/paddle/fluid/contrib/slim/tests/qat2_int8_nlp_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/qat2_int8_nlp_comparison.py
@@ -261,25 +261,28 @@ class QatInt8NLPComparisonTest(unittest.TestCase):
         self._debug = test_case_args.debug
 
         self._quantized_ops = set()
-        if len(test_case_args.ops_to_quantize) > 0:
-            self._quantized_ops = set(test_case_args.ops_to_quantize.split(','))
+        if test_case_args.ops_to_quantize:
+            self._quantized_ops = set(
+                op.strip() for op in test_case_args.ops_to_quantize.split(','))
 
         self._op_ids_to_skip = set([-1])
-        if len(test_case_args.op_ids_to_skip) > 0:
+        if test_case_args.op_ids_to_skip:
             self._op_ids_to_skip = set(
                 map(int, test_case_args.op_ids_to_skip.split(',')))
 
         _logger.info('FP32 & QAT INT8 prediction run.')
-        _logger.info('QAT model: {0}'.format(qat_model_path))
-        _logger.info('FP32 model: {0}'.format(fp32_model_path))
-        _logger.info('Dataset: {0}'.format(data_path))
-        _logger.info('Labels: {0}'.format(labels_path))
-        _logger.info('Batch size: {0}'.format(batch_size))
-        _logger.info('Batch number: {0}'.format(batch_num))
-        _logger.info('Accuracy drop threshold: {0}.'.format(acc_diff_threshold))
-        _logger.info('Quantized ops: {0}.'.format(self._quantized_ops))
-        _logger.info('Op ids to skip quantization: {0}.'.format(
-            self._op_ids_to_skip))
+        _logger.info('QAT model: {}'.format(qat_model_path))
+        _logger.info('FP32 model: {}'.format(fp32_model_path))
+        _logger.info('Dataset: {}'.format(data_path))
+        _logger.info('Labels: {}'.format(labels_path))
+        _logger.info('Batch size: {}'.format(batch_size))
+        _logger.info('Batch number: {}'.format(batch_num))
+        _logger.info('Accuracy drop threshold: {}.'.format(acc_diff_threshold))
+        _logger.info('Quantized ops: {}.'.format(','.join(
+            self._quantized_ops) if self._quantized_ops else 'all quantizable'))
+        _logger.info('Op ids to skip quantization: {}.'.format(','.join(
+            map(str, self._op_ids_to_skip)) if test_case_args.op_ids_to_skip
+                                                               else 'none'))
 
         _logger.info('--- FP32 prediction start ---')
         val_reader = paddle.batch(

--- a/python/paddle/fluid/contrib/slim/tests/save_qat_model.py
+++ b/python/paddle/fluid/contrib/slim/tests/save_qat_model.py
@@ -48,6 +48,15 @@ def parse_args():
         default='',
         help='A comma separated list of operators to quantize. Only quantizable operators are taken into account. If the option is not used, an attempt to quantize all quantizable operators will be made.'
     )
+    parser.add_argument(
+        '--op_ids_to_skip',
+        type=str,
+        default='',
+        help='A comma separated list of operator ids to skip in quantization.')
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='If used, the graph of QAT model is drawn.')
 
     test_args, args = parser.parse_known_args(namespace=unittest)
     return test_args, sys.argv[:1] + args
@@ -70,8 +79,20 @@ def transform_and_save_model(original_path, save_path, save_type):
         if len(test_args.ops_to_quantize) > 0:
             ops_to_quantize = set(test_args.ops_to_quantize.split(','))
 
+        op_ids_to_skip = set([-1])
+        if len(test_args.op_ids_to_skip) > 0:
+            op_ids_to_skip = set(map(int, test_args.op_ids_to_skip.split(',')))
+
+        graph = IrGraph(core.Graph(inference_program.desc), for_test=True)
+        if (test_args.debug):
+            graph.draw('.', 'qat_orig', graph.all_op_nodes())
         transform_to_mkldnn_int8_pass = Qat2Int8MkldnnPass(
-            ops_to_quantize, _scope=inference_scope, _place=place, _core=core)
+            ops_to_quantize,
+            _op_ids_to_skip=op_ids_to_skip,
+            _scope=inference_scope,
+            _place=place,
+            _core=core,
+            _debug=test_args.debug)
 
         graph = IrGraph(core.Graph(inference_program.desc), for_test=True)
         if save_type == 'FP32':


### PR DESCRIPTION
#### Required（必填, multiple choices, two at most）
- **PR type（PR 类型） is (C, F ):**
A. New features（新功能）---------------- D. Performance optimization（性能优化）
B. Bug fixes（问题修复）------------------ E. Breaking changes（向后不兼容的改变）
C. Function optimization（功能优化）------F.  Others（其它）

- **PR changes（改动点）is (C, D ):**
A. OPs（operators）---------------------- C. Docs（文档）
B. APIs（接口）--------------------------- D. Others（其它）

- **Use one sentence to describe what this PR does.（简述本次PR的目的和改动）**
Improves QAT INT8 quantization process.

-----------------------
#### Optional（选填, If None, please delete it）

- **Describe what this PR does in detail. If this PR fixes an issue, please give the issue id.**
  
With this patch, the following updates are made to QAT:
* added the `--op_ids_to_skip` option to exclude operators from quantization by their id numbers,
* added the `--debug` option to enable the generation of graphviz `*.dot` files after each step of the graph transformation,
* improved quantization of operators with missing output quantization scale,
* improved logging during quantization,
* enabled optimization of the FP32 model,
* fixed quantizing unsigned output data after `relu` op or postop,
* updated the QAT documentation.

With the help of the `--op_ids_to_skip` and `--debug` options the accuracy of the `pvnet_ocr` model after quantization was improved greatly. See the issue https://github.com/PaddlePaddle/Paddle/issues/24461 for details.

- **If you modified docs, please make sure that both Chinese and English docs were modified and provide a preview screenshot. （文档必填）**

- **Please write down other information you want to tell reviewers.**
