### PR TITLE
Fix bug of test_var_vase

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -50,7 +50,7 @@ class TestVarBase(unittest.TestCase):
     def test_tensor_to_variable(self):
         with fluid.dygraph.guard():
             t = fluid.Tensor()
-            t.set(np.ndarray([5, 30]), fluid.CPUPlace())
+            t.set(np.random.random((1024, 1024)), fluid.CPUPlace())
             var = fluid.dygraph.to_variable(t)
             self.assertTrue(np.array_equal(t, var.numpy()))
 


### PR DESCRIPTION
This PR fixes a bug of `test_var_vase`.

`np.ndarray([5, 30])` may contains `nan`, which lead to the failure, since `np.equal(np.nan, np.nan)` is `False`.