### PR TITLE
[Dy2static] Fix random bug in bert unittest

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_bert.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_bert.py
@@ -17,17 +17,14 @@ import unittest
 
 import numpy as np
 import paddle.fluid as fluid
-from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.dygraph.dygraph_to_static import ProgramTranslator
 
 from bert_dygraph_model import PretrainModelLayer
 from bert_utils import get_bert_config, get_feed_data_reader
 
 program_translator = ProgramTranslator()
-
 place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() else fluid.CPUPlace(
 )
-
 SEED = 2020
 STEP_NUM = 10
 PRINT_STEP = 2
@@ -38,16 +35,19 @@ def train(bert_config, data_reader):
         fluid.default_main_program().random_seed = SEED
         fluid.default_startup_program().random_seed = SEED
 
+        data_loader = fluid.io.DataLoader.from_generator(
+            capacity=50, iterable=True)
+        data_loader.set_batch_generator(
+            data_reader.data_generator(), places=place)
+
         bert = PretrainModelLayer(
             config=bert_config, weight_sharing=False, use_fp16=False)
 
         optimizer = fluid.optimizer.Adam(parameter_list=bert.parameters())
         step_idx = 0
         speed_list = []
-        for input_data in data_reader.data_generator():
-            input_data = [to_variable(ele) for ele in input_data]
+        for input_data in data_loader():
             src_ids, pos_ids, sent_ids, input_mask, mask_label, mask_pos, labels = input_data
-
             next_sent_acc, mask_lm_loss, total_loss = bert(
                 src_ids=src_ids,
                 position_ids=pos_ids,


### PR DESCRIPTION
#### Required（必填, multiple choices, two at most）
- **PR type（PR 类型） is ( B ):**
A. New features（新功能）---------------- D. Performance optimization（性能优化）
B. Bug fixes（问题修复）------------------ E. Breaking changes（向后不兼容的改变）
C. Function optimization（功能优化）------F.  Others（其它）

- **PR changes（改动点）is ( D ):**
A. OPs（operators）---------------------- C. Docs（文档）
B. APIs（接口）--------------------------- D. Others（其它）

- **Use one sentence to describe what this PR does.（简述本次PR的目的和改动）**

This PR fix random using problem in dy2static unittest `test_bert`, fix the problem in https://github.com/PaddlePaddle/Paddle/pull/24692.

-----------------------
#### Optional（选填, If None, please delete it）

- **Describe what this PR does in detail. If this PR fixes an issue, please give the issue id.**
  <!-- DESCRIBE THE BUG OR REQUIREMENT HERE. eg. #2020（格式为 #Issue编号）-->

`test_bert` data reader shows different generate result with the same seed, this is very strange, so we suspect that the DataLoader made changes to the input data.

But after testing, I found that these are the problems of `numpy.random` and `python random`, not the problem of `DataLoader`

1. `numpy.random.seed` is not thread-safe, but `fluid.DataLoader` use child thread to speed up data reading, the seed may be different in different thread even if you set the seed by `np.random.seed`. related doc:
- [Numpy: random seed and multithreading causes differing results](https://stackoverflow.com/questions/58875076/numpy-random-seed-and-multithreading-causes-differing-results)
- [Differences between numpy.random and random.random in Python](https://stackoverflow.com/questions/7029993/differences-between-numpy-random-and-random-random-in-python)

2. python `random` has bug in python2, we should avoid using it in unittest. related doc:
- [random.randint shows different output in Python 2.x and Python 3.x with same seed](https://stackoverflow.com/questions/55647936/random-randint-shows-different-output-in-python-2-x-and-python-3-x-with-same-see)

3. for this case, we can use [`numpy.random.RandomState`](https://het.as.utexas.edu/HET/Software/Numpy/reference/generated/numpy.random.RandomState.html)

- **If you modified docs, please make sure that both Chinese and English docs were modified and provide a preview screenshot. （文档必填）**
   <!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

- **Please write down other information you want to tell reviewers.**
