### PR TITLE
fix windows bug that compile .cu files use MSVC dynamic C runtime

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -205,9 +205,9 @@ set(CUDA_PROPAGATE_HOST_FLAGS OFF)
 # Release/Debug flags set by cmake. Such as -O3 -g -DNDEBUG etc.
 # So, don't set these flags here.
 if (NOT WIN32) # windows msvc2015 support c++11 natively. 
-# -std=c++11 -fPIC not recoginize by msvc, -Xcompiler will be added by cmake.
-list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
-list(APPEND CUDA_NVCC_FLAGS "-Xcompiler -fPIC")
+  # -std=c++11 -fPIC not recoginize by msvc, -Xcompiler will be added by cmake.
+  list(APPEND CUDA_NVCC_FLAGS "-std=c++11")
+  list(APPEND CUDA_NVCC_FLAGS "-Xcompiler -fPIC")
 endif(NOT WIN32)
 
 # in cuda9, suppress cuda warning on eigen 
@@ -229,6 +229,11 @@ if (NOT WIN32)
 else(NOT WIN32)
   list(APPEND CUDA_NVCC_FLAGS  "-Xcompiler \"/wd 4244 /wd 4267 /wd 4819\"")
   list(APPEND CUDA_NVCC_FLAGS  "--compiler-options;/bigobj")
+  if(MSVC_STATIC_CRT)
+    list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-MT$<$<CONFIG:Debug>:d>")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-Xcompiler" "-MD$<$<CONFIG:Debug>:d>")
+  endif()
   if(CMAKE_BUILD_TYPE  STREQUAL "Debug")
     list(APPEND CUDA_NVCC_FLAGS  "-g -G")
     # match the cl's _ITERATOR_DEBUG_LEVEL

--- a/cmake/flags.cmake
+++ b/cmake/flags.cmake
@@ -217,8 +217,8 @@ foreach(flag ${GPU_COMMON_FLAGS})
 endforeach()
 
 if(WIN32 AND MSVC_STATIC_CRT)
-# windows build turn off warnings.
-safe_set_static_flag()
+    # windows build turn off warnings.
+    safe_set_static_flag()
     foreach(flag_var
         CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
         CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO


### PR DESCRIPTION
PR types: Bug fixes（问题修复）

PR changes: Others（其它）

Describe:  fix #24677 ，改动地方为CUDA_NVCC_FLAGS，编译GPU下的MD预测库时，当设置-DWITH_GPU=ON, -DMSVC_STATIC_CRT=OFF时，会出现以下编译报错：
![image](https://user-images.githubusercontent.com/52485244/82814443-c93c2a80-9ec9-11ea-8d6d-c9f45d26c55f.png)
由于框架中设置了 set(CUDA_PROPAGATE_HOST_FLAGS OFF)，因此CMAKE_CXX_FLAGS/CMAKE_C_FLAGS虽然正确设置，但没有传递到CUDA_NVCC_FLAGS，这里给CUDA_NVCC_FLAGS设置了-Xcompiler MD/MT的相应选项。
