### PR TITLE
Remove target vars of gast.For from before_loop_vars or after_loop_vars

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -328,9 +328,7 @@ class NameVisitor(gast.NodeVisitor):
             return parent_node
         return None
 
-    def _remove_target_vars_of_for(self,
-                                   before_or_after_loop_vars,
-                                   loop_node=None):
+    def _remove_target_vars_of_for(self, before_or_after_loop_vars, loop_node):
         """
         Remove target vars of gast.For from before_loop_vars or after_loop_vars.
         :param before_or_after_loop_vars: before_loop_vars or after_loop_vars of loop_node.
@@ -343,6 +341,9 @@ class NameVisitor(gast.NodeVisitor):
                 continue
 
             parent_node = self._get_parent_node(name_node)
+
+            # NOTE: gast.For.target can be gast.Tuple.
+            #  For example: `for i, j in enumerate(x)` has two target vars: i and j
             if isinstance(parent_node, gast.Tuple):
                 parent_node = self._get_parent_node(parent_node)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -132,6 +132,19 @@ def var_create_in_for_loop(max_len):
     return ret
 
 
+def nested_for_loop_dyfunc():
+    two = fluid.layers.fill_constant(shape=[1], value=2, dtype="int32")
+    three = fluid.layers.fill_constant(shape=[1], value=3, dtype="int32")
+    for j in range(two):
+        for i in range(10):
+            a = 2
+
+    for i in range(three):
+        b = fluid.layers.zeros(shape=[1], dtype='float32')
+
+    return b
+
+
 class TestNameVisitor(unittest.TestCase):
     def setUp(self):
         self.loop_funcs = [
@@ -141,6 +154,8 @@ class TestNameVisitor(unittest.TestCase):
             set(["i", "x"]), set(["i", "ret", "max_len"]), set(["i", "x"])
         ]
         self.create_var_names = [set(), set(["ret"]), set()]
+
+        self.nested_for_loop_func = nested_for_loop_dyfunc
 
     def test_loop_vars(self):
         for i in range(len(self.loop_funcs)):
@@ -154,6 +169,28 @@ class TestNameVisitor(unittest.TestCase):
                         node)
                     self.assertEqual(loop_var_names, self.loop_var_names[i])
                     self.assertEqual(create_var_names, self.create_var_names[i])
+
+    def test_nested_loop_vars(self):
+        func = self.nested_for_loop_func
+        test_func = inspect.getsource(func)
+        gast_root = gast.parse(test_func)
+        name_visitor = NameVisitor(gast_root)
+
+        self.loop_var_names = [
+            set(["j", "two"]),
+            set(["i", "three", "b"]),
+            set(["i"]),
+        ]
+        self.create_var_names = [set(), set(["b"]), set()]
+        i = 0
+        for node in gast.walk(gast_root):
+            if isinstance(node, (gast.While, gast.For)):
+                loop_var_names, create_var_names = name_visitor.get_loop_var_names(
+                    node)
+                # print(loop_var_names)
+                self.assertEqual(loop_var_names, self.loop_var_names[i])
+                self.assertEqual(create_var_names, self.create_var_names[i])
+                i += 1
 
 
 class TestTransformWhileLoop(unittest.TestCase):


### PR DESCRIPTION
#### Required（必填, multiple choices, two at most）
- **PR type（PR 类型） is ( B ):**
A. New features（新功能）---------------- D. Performance optimization（性能优化）
**B. Bug fixes**（问题修复）------------------ E. Breaking changes（向后不兼容的改变）
C. Function optimization（功能优化）------F.  Others（其它）

- **PR changes（改动点）is ( D ):**
A. OPs（operators）---------------------- C. Docs（文档）
B. APIs（接口）--------------------------- **D. Others（其它）**

- **Use one sentence to describe what this PR does.（简述本次PR的目的和改动）**
1. Remove target vars of gast.For from before_loop_vars or after_loop_vars
2. fix bug of condition_vars: condition_vars should only contain vars in current  loop node, should not contain the target vars of child loop node or parent loop node.
-----------------------
#### Optional（选填, If None, please delete it）

- **Describe what this PR does in detail. If this PR fixes an issue, please give the issue id.**
  <!-- DESCRIBE THE BUG OR REQUIREMENT HERE. eg. #2020（格式为 #Issue编号）-->
For example:
```Python
for i in range(tensor_a): # condition_vars of this for loop is `i`, not `i and j`
   # for this for loop, variable j should not in after_loop_vars. This PR fix it.      
   for j in range(int_b):   # condition_vars of this for loop is `j`, not `i and j`
       # do something

# for this for loop, variable i should not in before_loop_body_vars. This PR fix it.      
for j in range(tensor_c): 
    # do something
```

- **If you modified docs, please make sure that both Chinese and English docs were modified and provide a preview screenshot. （文档必填）**
   <!-- ADD SCREENSHOT HERE IF APPLICABLE. -->

- **Please write down other information you want to tell reviewers.**
