### PR TITLE
Collecting concat output threshold for quantization

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -43,7 +43,7 @@ _fake_quant_dequant_op_list = [
 _out_scale_op_list = [
     "conv2d", "depthwise_conv2d", "mul", "matmul", "relu", "leaky_relu",
     "relu6", "sigmoid", "tanh", "prelu", "swish", "softmax", "batch_norm",
-    "elementwise_add", "pool2d", "reshape2", "transpose2"
+    "elementwise_add", "pool2d", "reshape2", "transpose2", "concat"
 ]
 
 # list op real input and output names, to avoid processing input such as AxisTensor.


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types:Function optimization
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: Collecting concat output threshold for quantization
<!--  Describe what this PR does  -->
Describe: Add concat to _out_scale_op_list
