### PR TITLE
fix the pe profiler run error test=develop

### DIFF
--- a/paddle/fluid/platform/device_tracer.cc
+++ b/paddle/fluid/platform/device_tracer.cc
@@ -641,22 +641,24 @@ DeviceTracer *GetDeviceTracer() {
   return tracer;
 }
 
-std::string SetCurAnnotation(Event *event) {
+// In order to record PE time, we add main_thread_annotation_stack
+// for all event between PE run, we treat it as PE's child Event,
+// so when event is not in same thread of PE event, we need add
+// father event(PE::run event) for this event
+void SetCurAnnotation(Event *event) {
   std::string ret;
-  if (!annotation_stack.empty() && event->role() != EventRole::kSpecial) {
+  if (!annotation_stack.empty()) {
     event->set_parent(annotation_stack.back());
     event->set_name(annotation_stack.back()->name() + "/" + event->name());
   }
-
+  if (annotation_stack.empty() && !main_thread_annotation_stack.empty() &&
+      main_thread_annotation_stack.back()->thread_id() != event->thread_id()) {
+    event->set_parent(main_thread_annotation_stack.back());
+    event->set_name(main_thread_annotation_stack.back()->name() + "/" +
+                    event->name());
+  }
   annotation_stack.push_back(event);
 
-  if (!main_thread_annotation_stack_name.empty() && !annotation_stack.empty() &&
-      main_thread_annotation_stack.back()->thread_id() !=
-          annotation_stack.back()->thread_id()) {
-    ret = main_thread_annotation_stack_name.back() + "/" + event->name();
-  } else {
-    ret = event->name();
-  }
   if (event->role() == EventRole::kSpecial) {
     std::string name = event->name();
     if (!main_thread_annotation_stack_name.empty()) {
@@ -665,22 +667,23 @@ std::string SetCurAnnotation(Event *event) {
     main_thread_annotation_stack_name.push_back(name);
     main_thread_annotation_stack.push_back(event);
   }
-
-  return ret;
 }
 
 void ClearCurAnnotation() {
-  if (!main_thread_annotation_stack_name.empty() && !annotation_stack.empty() &&
-      main_thread_annotation_stack.back()->thread_id() !=
-          annotation_stack.back()->thread_id()) {
-    annotation_stack.back()->set_name(main_thread_annotation_stack_name.back() +
-                                      "/" + annotation_stack.back()->name());
-  }
   if (!main_thread_annotation_stack.empty() &&
       main_thread_annotation_stack.back()->name() ==
           annotation_stack.back()->name()) {
-    main_thread_annotation_stack_name.pop_back();
-    main_thread_annotation_stack.pop_back();
+    std::string name = annotation_stack.back()->name();
+    std::string main_name = main_thread_annotation_stack.back()->name();
+    int main_name_len = main_name.length();
+    int name_len = name.length();
+    int prefix_len = main_name_len - name_len;
+
+    if (prefix_len >= 0 && main_name.at(prefix_len) == '/' &&
+        name == main_name.substr(prefix_len, name_len)) {
+      main_thread_annotation_stack_name.pop_back();
+      main_thread_annotation_stack.pop_back();
+    }
   }
   annotation_stack.pop_back();
 }

--- a/paddle/fluid/platform/device_tracer.h
+++ b/paddle/fluid/platform/device_tracer.h
@@ -137,7 +137,7 @@ class DeviceTracer {
 DeviceTracer* GetDeviceTracer();
 
 // Set a name for the cuda kernel operation being launched by the thread.
-std::string SetCurAnnotation(Event* event);
+void SetCurAnnotation(Event* event);
 // Clear the name after the operation is done.
 void ClearCurAnnotation();
 // Current name of the operation being run in the thread.

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -73,7 +73,8 @@ RecordEvent::RecordEvent(const std::string &name, const EventRole role) {
   // lock is not needed, the code below is thread-safe
   Event *e = PushEvent(name, role);
   // Maybe need the same push/pop behavior.
-  name_ = SetCurAnnotation(e);
+  SetCurAnnotation(e);
+  name_ = e->name();
 }
 
 RecordEvent::~RecordEvent() {


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: Others 
<!--  Describe what this PR does  -->
Describe:修复添加PE profiler导致的Profiler异常的问题（FrameWork OverHead的比例错误问题（结果为负数））,主要是因为子EventGPU时间未向上传递导致的）
错误截图如下：
![image](https://user-images.githubusercontent.com/13411999/82987986-0b30b200-a02b-11ea-81ea-2882f633328b.png)


正确结果
ResetNet50
![image](https://user-images.githubusercontent.com/13411999/82878410-0659f880-9f6e-11ea-8c52-176b3c8ea010.png)
![image](https://user-images.githubusercontent.com/13411999/82878462-18d43200-9f6e-11ea-9724-a172e1a44a1f.png)

Transformer
![image](https://user-images.githubusercontent.com/13411999/82884376-386f5880-9f76-11ea-8a16-90c9be9f5ecc.png)



