### PR TITLE
Adjust minimum TRT version for hard_sigmoid converter to 5130.

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/hard_sigmoid_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/hard_sigmoid_op.cc
@@ -25,7 +25,7 @@ class HardSigmoidOpConverter : public OpConverter {
  public:
   void operator()(const framework::proto::OpDesc& op,
                   const framework::Scope& scope, bool test_mode) override {
-#if IS_TRT_VERSION_GE(5000)
+#if IS_TRT_VERSION_GE(5130)
     VLOG(3) << "convert a fluid HardSigmoid op to tensorrt IActivationLayer "
                "layer without bias";
     framework::OpDesc op_desc(op, nullptr);


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: Adjust minimum TRT version for hard_sigmoid converter to 5130
<!--  Describe what this PR does  -->
Describe: Activation type kHardSigmoid is introduced after TRT version 5.1.3.0, so adjust the version to 5.1.3.0 for hard_sigmoid converter.
