### PR TITLE
fix bug that diag API can't use on Windows,test=develop

### DIFF
--- a/paddle/fluid/operators/trace_op.h
+++ b/paddle/fluid/operators/trace_op.h
@@ -24,10 +24,10 @@ namespace paddle {
 namespace operators {
 
 template <typename T>
-struct DiagFunctor {
-  DiagFunctor(const T* input, const int64_t* diag_stride,
-              const int64_t* ret_strides, int64_t pos, int64_t dim_size,
-              T* diag)
+struct DiagonalFunctor {
+  DiagonalFunctor(const T* input, const int64_t* diag_stride,
+                  const int64_t* ret_strides, int64_t pos, int64_t dim_size,
+                  T* diag)
       : input_(input),
         diag_stride_(diag_stride),
         ret_strides_(ret_strides),
@@ -157,8 +157,8 @@ framework::Tensor Diagonal(const framework::ExecutionContext& context,
 
     auto& dev_ctx = context.template device_context<DeviceContext>();
     platform::ForRange<DeviceContext> for_range(dev_ctx, diag.numel());
-    DiagFunctor<T> functor(input_data, diag_arr, ret_arr, pos, dim_size,
-                           diag_data);
+    DiagonalFunctor<T> functor(input_data, diag_arr, ret_arr, pos, dim_size,
+                               diag_data);
     for_range(functor);
     return diag;
   } else {


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes on windows
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: OPs
<!--  Describe what this PR does  -->
Describe:

在https://github.com/PaddlePaddle/Paddle/pull/23873 中新增的trace_op定义了struct DiagFunctor，与diag_op中的[struct DiagFunctor](https://github.com/PaddlePaddle/Paddle/blob/1bfff02047c6b9db9e864864aba827fdcdc09bae/paddle/fluid/operators/diag_op.h#L25-L36)同名，会导致Windows上运行diag API出错，错误截图为：
![image](https://user-images.githubusercontent.com/52485244/82978301-d0248380-a016-11ea-8b1a-4b3a5ad377fa.png)
但gcc编译不会使得diag出错，仅Windows上MSVC编译时会导致diag运行错误，推测是不同平台上编译器对.cu文件的同名结构体的处理机制不同。该PR将struct更名之后，Windows上不再出现该问题。