### PR TITLE
Fix out of range error for outs map.

### DIFF
--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -75,7 +75,7 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
     {"fill_constant", {"Out"}},
     {"matmul", {"Out"}},
     {"fake_quantize_dequantize_moving_average_abs_max",
-     {"OutScale", "OutAccum", "OutState"}},
+     {"Out", "OutScale", "OutAccum", "OutState"}},
 };
 
 // clang-format off
@@ -98,16 +98,12 @@ const char* INPUT_INITIALIZER_TEMPLATE_WITH_NULL_LIST = R"(
     }	
 )";
 
-const char* OUTPUT_INITIALIZER_TEMPLATE_WITH_NULL = R"(	
-    if (%s != nullptr) {	
-      outs["%s"] = {%s};	
-    }	
+const char* OUTPUT_INITIALIZER_TEMPLATE_WITH_NULL = R"(
+    outs["%s"] = {%s};
 )";
 
-const char* OUTPUT_INITIALIZER_TEMPLATE_WITH_NULL_LIST = R"(	
-    if (%s.size() != 0) {
-      outs["%s"] = %s;	
-    }	
+const char* OUTPUT_INITIALIZER_TEMPLATE_WITH_NULL_LIST = R"(
+    outs["%s"] = %s;
 )";
 // if inputs is list, no need {}
 const char* ARG_OUT_NUM = R"(%sNum)";
@@ -246,8 +242,8 @@ GenerateOpFunctions(const std::string& module_name) {
           const auto out_template =
               output.duplicable() ? OUTPUT_INITIALIZER_TEMPLATE_WITH_NULL_LIST
                                   : OUTPUT_INITIALIZER_TEMPLATE_WITH_NULL;
-          outs_initializer_with_null += paddle::string::Sprintf(
-              out_template, out_name, out_name, out_name);
+          outs_initializer_with_null +=
+              paddle::string::Sprintf(out_template, out_name, out_name);
         } else {
           const auto out_template = output.duplicable()
                                         ? INPUT_LIST_INITIALIZER_TEMPLATE


### PR DESCRIPTION
PR types: Bug fixes
PR changes: Others
Describe:
![image](https://user-images.githubusercontent.com/17102274/82998612-89e11b80-a03a-11ea-8c9a-7db76407ff3e.png)

As shown above, when `OutState` is `nullptr`, `outs["OutState"][0]` will cause the out of range error.