### PR TITLE
[Dy2Static]fix bug in LogicalOpTransformer: Create logic node recursively. 

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -109,8 +109,10 @@ class LogicalOpTransformer(gast.NodeTransformer):
             len(nodes))
         if len(nodes) > 2:
             # Creates logic_and/logic_or node recursively.
-            pre_assign_node = self._create_bool_op_node(nodes[:2], api_type)
-            nodes = [pre_assign_node] + nodes[2:]
+            pre_logic_node = self._create_bool_op_node(nodes[:2], api_type)
+            post_logic_node = self._create_bool_op_node(nodes[2:], api_type)
+            nodes = [pre_logic_node] + [post_logic_node]
+
         args = [ast_to_source_code(child) for child in nodes]
         new_node_str = "fluid.layers.logical_{}(x={}, y={})".format(
             api_type, args[0], args[1])

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -85,7 +85,7 @@ def while_loop_bool_op(x):
     # Use `to_variable` so that static analysis can analyze the type of X is Tensor
     x = fluid.dygraph.to_variable(
         x)  # TODO(liym27): Delete it if the type of parameter x can be resolved
-    while (x >= 0 and x < 10) or x <= -1 or x < -3 or (x < -7 or x < -5):
+    while x <= -1 or x < -3 or (x < -7 or x < -5) or (x >= 0 and x < 10):
         i = i + x
         x = x + 1
     return i


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
**PR types**: Bug fixes 
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
**PR changes**: Others
<!--  Describe what this PR does  -->
**Describe**:
1.
- **Before**: Don't create logical node **recursively**
```Python
(x >= 0 and x < 10) or x <= -1 or x < -3 or (x < -7 or x < -5) 
```

The logical node: missing `or (x < -7 or x < -5)`
```
fluid.layers.logical_or(x=fluid.layers.logical_or(x=fluid.
            layers.logical_and(x=x >= 0, y=x < 10), y=x <= -1), y=x < -3)
```
- **This PR**: fix this bug
```Python
# The logical node now
fluid.layers.logical_or(x=fluid.layers.logical_or(x=fluid.
            layers.logical_and(x=x >= 0, y=x < 10), y=x <= -1), y=fluid.
            layers.logical_or(x=x < -3, y=fluid.layers.logical_or(x=x < -7,
            y=x < -5)))
```
2.
- **Before**: The unittest doesn't expose this bug.
- **This PR**: Modify the unittest to check whether the recursive conversion is successful.