### PR TITLE
generate ci index

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -887,12 +887,12 @@ set -ex
 }
 
 function parallel_test() {
-    ut_startTime_s=`date +%s`
+    ut_total_startTime_s=`date +%s`
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
     parallel_test_base
-    ut_endTime_s=`date +%s`
-    echo "TestCases Total Time: $[ $ut_endTime_s - $ut_startTime_s ]s"
+    ut_total_endTime_s=`date +%s`
+    echo "TestCases Total Time: $[ $ut_total_endTime_s - $ut_total_startTime_s ]s"
 }
 
 function enable_unused_var_check() {

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -315,6 +315,32 @@ function build_base() {
     make install -j ${parallel_number}
 }
 
+function build_size() {
+    cat <<EOF
+    ============================================
+    Calculate /paddle/build size and PR whl size
+    ============================================
+EOF
+    if [ "$1" == "fluid_inference"]; then
+        cd ${PADDLE_ROOT}/build
+        cp -r fluid_inference_install_dir fluid_inference
+        tar -czf fluid_inference.tgz fluid_inference
+        buildSize=$(du -h --max-depth=0 ${PADDLE_ROOT}/build/fluid_inference.tgz |awk '{print $1}')
+        echo "FLuid_Inference Size: $buildSize"
+    else
+        SYSTEM=`uname -s`
+        if [ "$SYSTEM" == "Darwin" ]; then
+            com='du -h -d 0'
+        else
+            com='du -h --max-depth=0'
+        fi
+        buildSize=$($com ${PADDLE_ROOT}/build |awk '{print $1}')
+        echo "Build Size: $buildSize"
+        PR_whlSize=$($com ${PADDLE_ROOT}/build/python/dist |awk '{print $1}')
+        echo "PR whl Size: $PR_whlSize"
+    fi
+}
+
 function build() {
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
@@ -324,6 +350,18 @@ function build() {
     ============================================
 EOF
     build_base $@
+    current_branch=`git branch | grep \* | cut -d ' ' -f2`
+    if [ "$current_branch" != "develop_base_pr" ];then
+        build_size
+    fi
+}
+
+function cmake_gen_and_build() {
+    startTime_s=`date +%s`
+    cmake_gen $1
+    build $2
+    endTime_s=`date +%s`
+    echo "Build Time: $[ $endTime_s - $startTime_s ]s"
 }
 
 function build_mac() {
@@ -338,6 +376,14 @@ EOF
         make clean
     fi
     make install -j 8
+}
+
+function cmake_gen_and_build_mac() {
+    startTime_s=`date +%s`
+    cmake_gen $1
+    build_mac
+    endTime_s=`date +%s`
+    echo "Build Time: $[ $endTime_s - $startTime_s ]s"
 }
 
 function run_test() {
@@ -455,8 +501,10 @@ EOF
         elif [ "$1" == "cp37-cp37m" ]; then
             pip3.7 install --user ${INSTALL_PREFIX:-/paddle/build}/opt/paddle/share/wheels/*.whl
         fi
-
+        ut_startTime_s=`date +%s`
         ctest --output-on-failure -j $2
+        ut_endTime_s=`date +%s`
+        echo "Mac testCase Time: $[ $ut_endTime_s - $ut_startTime_s ]s"
         paddle version
         # Recovery proxy to avoid failure in later steps
         export http_proxy=$my_proxy
@@ -681,9 +729,25 @@ function caught_error() {
     done
 }
 
+function case_count(){
+    cat <<EOF
+    ============================================
+    Generating TestCases Count ... 
+    ============================================
+EOF
+    testcases=$1
+    num=$(echo $testcases|grep -o '\^'|wc -l)
+    if [ "$2" == "" ]; then
+        echo "exclusive TestCases count is $num"
+    else
+        echo "$2 card TestCases count is $num"
+    fi
+}
+
 function card_test() {
     set -m
-
+    case_count $1 $2
+    ut_startTime_s=`date +%s` 
     # get the CUDA device count
     CUDA_DEVICE_COUNT=$(nvidia-smi -L | wc -l)
 
@@ -731,6 +795,12 @@ function card_test() {
     done
 
     wait; # wait for all subshells to finish
+    ut_endTime_s=`date +%s`
+    if [ "$2" == "" ]; then
+        echo "exclusive TestCases Total Time: $[ $ut_endTime_s - $ut_startTime_s ]s"
+    else
+        echo "$2 card TestCases Total Time: $[ $ut_endTime_s - $ut_startTime_s ]s"
+    fi
     set +m
 }
 
@@ -816,9 +886,12 @@ set -ex
 }
 
 function parallel_test() {
+    ut_startTime_s=`date +%s`
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
     parallel_test_base
+    ut_endTime_s=`date +%s`
+    echo "TestCases Total Time: $[ $ut_endTime_s - $ut_startTime_s ]s"
 }
 
 function enable_unused_var_check() {
@@ -1076,10 +1149,14 @@ EOF
     if [[ "$1" != "" ]]; then
       parallel_number=$1
     fi
+    startTime_s=`date +%s` 
     cmake .. -DWITH_DISTRIBUTE=OFF -DON_INFER=ON -DCUDA_ARCH_NAME=${CUDA_ARCH_NAME:-Auto}
 
     make -j ${parallel_number} fluid_lib_dist
     make -j ${parallel_number} inference_lib_dist
+    endTime_s=`date +%s`
+    echo "Build Time: $[ $endTime_s - $startTime_s ]s"
+    build_size "fluid_inference"
 }
 
 function tar_fluid_lib() {
@@ -1101,10 +1178,13 @@ function test_fluid_lib() {
     Testing fluid library for inference ...
     ========================================
 EOF
+    fluid_startTime_s=`date +%s`
     cd ${PADDLE_ROOT}/paddle/fluid/inference/api/demo_ci
     ./run.sh ${PADDLE_ROOT} ${WITH_MKL:-ON} ${WITH_GPU:-OFF} ${INFERENCE_DEMO_INSTALL_DIR} \
              ${TENSORRT_INCLUDE_DIR:-/usr/local/TensorRT/include} \
              ${TENSORRT_LIB_DIR:-/usr/local/TensorRT/lib}
+    fluid_endTime_s=`date +%s`
+    echo "test_fluid_lib Total Time: $[ $fluid_endTime_s - $fluid_startTime_s ]s"          
     ./clean.sh
 }
 
@@ -1114,8 +1194,11 @@ function test_fluid_lib_train() {
     Testing fluid library for training ...
     ========================================
 EOF
+    fluid_train_startTime_s=`date +%s`
     cd ${PADDLE_ROOT}/paddle/fluid/train/demo
     ./run.sh ${PADDLE_ROOT} ${WITH_MKL:-ON}
+    fluid_train_endTime_s=`date +%s`
+    echo "test_fluid_lib_train Total Time: $[ $fluid_train_endTime_s - $fluid_train_startTime_s ]s"
     ./clean.sh
 }
 
@@ -1135,21 +1218,18 @@ function example() {
     fi
 }
 
-
 function main() {
     local CMD=$1 
     local parallel_number=$2
     init
     case $CMD in
       build_only)
-        cmake_gen ${PYTHON_ABI:-""}
-        build ${parallel_number}
+        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         ;;
       build_and_check)
         check_style
         generate_upstream_develop_api_spec ${PYTHON_ABI:-""} ${parallel_number}
-        cmake_gen ${PYTHON_ABI:-""}
-        build ${parallel_number} 
+        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         check_sequence_op_unittest
         generate_api_spec ${PYTHON_ABI:-""} "PR"
         example
@@ -1205,8 +1285,7 @@ function main() {
         ;;
       cicheck_coverage)
         check_approvals_of_unittest 1
-        cmake_gen ${PYTHON_ABI:-""}
-        build ${parallel_number}
+        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         enable_unused_var_check
         parallel_test
         check_coverage
@@ -1234,13 +1313,11 @@ function main() {
         assert_api_spec_approvals
         ;;
       maccheck)
-        cmake_gen ${PYTHON_ABI:-""}
-        build_mac
+        cmake_gen_and_build_mac ${PYTHON_ABI:-""}
         run_mac_test ${PYTHON_ABI:-""} ${PROC_RUN:-1}
         ;;
       maccheck_py35)
-        cmake_gen ${PYTHON_ABI:-""}
-        build_mac
+        cmake_gen_and_build_mac ${PYTHON_ABI:-""}
         run_mac_test ${PYTHON_ABI:-""} ${PROC_RUN:-1}
         check_change_of_unittest ${PYTHON_ABI:-""}
         ;;
@@ -1249,8 +1326,7 @@ function main() {
         build_mac
         ;;
       cicheck_py35)
-        cmake_gen ${PYTHON_ABI:-""}
-        build ${parallel_number}
+        cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         parallel_test
         ;;
       cmake_gen)

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -321,7 +321,7 @@ function build_size() {
     Calculate /paddle/build size and PR whl size
     ============================================
 EOF
-    if [ "$1" == "fluid_inference"]; then
+    if [ "$1" == "fluid_inference" ]; then
         cd ${PADDLE_ROOT}/build
         cp -r fluid_inference_install_dir fluid_inference
         tar -czf fluid_inference.tgz fluid_inference
@@ -376,6 +376,7 @@ EOF
         make clean
     fi
     make install -j 8
+    build_size
 }
 
 function cmake_gen_and_build_mac() {


### PR DESCRIPTION
### PR types
Function optimization
### PR changes
Others
### Describe
增加Linux与Mac端的CI buildlog中的CI评价指标的输出；
1. PR_CI_CPU_Py2 ：编译时间、Build目录大小、PRwhl包大小
2. PR_CI_GPU_Py2_GCC8：编译时间、Build目录大小、PRwhl包大小
3. PR_CI_Py35：编译时间、Build目录大小、PRwhl包大小、单测总时间、独占case时间、单卡case时间、2卡case时间 以及各个case的数量
4. PR_CI_Inference：编译时间、预测库大小、预测库测试case 耗时、训练库测试case 耗时
5. PR_CI_Coverage：编译时间、Build目录大小、PRwhl包大小、单测总时间、独占case时间、单卡case时间、2卡case时间 以及各个case的数量
6. MAC_PR_CI：编译时间、Build目录大小、PRwhl包大小、单测总时间
7. MAC_PR_CI_python35：编译时间、Build目录大小、PRwhl包大小、单测总时间

**测试如下：**
1. PR_CI_CPU_Py2 ：Build Time: 197s；Build Size: 5.8G；PR whl Size: 88M
2. PR_CI_GPU_Py2_GCC8：Build Time: 1294s；Build Size: 16G；PR whl Size: 114M
3. PR_CI_Py35：Build Time: 1247s；Build Size: 16G；PR whl Size: 76M；TestCases Total Time: 2176s；1 card TestCases Total Time: 28s；1 card TestCases count is 134；1 card TestCases Total Time: 1088s；1 card TestCases count is 759；(此处有两个1card原因是单卡case被分成了两部分)；2 card TestCases count is 29；2 card TestCases Total Time: 220s；exclusive TestCases count is 41；exclusive TestCases Total Time: 832s；
4. PR_CI_Inference：Build Time: 991s；FLuid_Inference Size: 187M ；test_fluid_lib Total Time: 84s；test_fluid_lib_train Total Time: 13s；
5. PR_CI_Coverage：Build Time: 2933s；Build Size: 144G；PR whl Size: 713M；TestCases Total Time: 4918s；1 card TestCases count is 129；1 card TestCases Total Time: 44s；1 card TestCases count is 849； 1 card TestCases Total Time: 2532s；2 card TestCases count is 30；2 card TestCases Total Time: 675s；exclusive TestCases count is 41；exclusive TestCases Total Time: 991s；
6. MAC_PR_CI：Build Time: 234s；Build Size: 10G；PR whl Size: 25M
 ；Mac testCase Time: 1115s
7. MAC_PR_CI_python35：Build Time: 249s；Build Size: 13G；PR whl Size: 25M；Mac testCase Time: 1263s