### PR TITLE
remove duplicated mac_test build

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -425,12 +425,11 @@ function run_mac_test() {
     Running unit tests ...
     ========================================
 EOF
-        #remove proxy here to fix dist error on mac
+        #remove proxy here to fix dist ut 'test_fl_listen_and_serv_op' error on mac. 
+        #see details: https://github.com/PaddlePaddle/Paddle/issues/24738
         my_proxy=$http_proxy
         export http_proxy=
         export https_proxy=
-        # make install should also be test when unittest
-        make install -j 8
 
         set +ex
         if [ "$1" == "cp27-cp27m" ]; then


### PR DESCRIPTION
#### PR types
Others
#### PR changes
Others
#### Describe
删除Mac中跑单测时还需要在执行一次make install 的操作。节约CI时间
