### PR TITLE
fix test failure of test_recognize_digits, test=develop

### DIFF
--- a/paddle/fluid/train/test_train_recognize_digits.cc
+++ b/paddle/fluid/train/test_train_recognize_digits.cc
@@ -19,6 +19,7 @@ limitations under the License. */
 #include "gtest/gtest.h"
 
 #include "paddle/fluid/framework/executor.h"
+#include "paddle/fluid/framework/io/fs.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/program_desc.h"
 #include "paddle/fluid/framework/tensor_util.h"

--- a/python/paddle/fluid/tests/book/test_recognize_digits.py
+++ b/python/paddle/fluid/tests/book/test_recognize_digits.py
@@ -123,8 +123,8 @@ def train(nn_type,
                     # get test acc and loss
                     acc_val = numpy.array(acc_set).mean()
                     avg_loss_val = numpy.array(avg_loss_set).mean()
-                    if float(acc_val
-                             ) > 0.2:  # Smaller value to increase CI speed
+                    if float(acc_val) > 0.2 or pass_id == (PASS_NUM - 1):
+                        # Smaller value to increase CI speed
                         if save_dirname is not None:
                             fluid.io.save_inference_model(
                                 save_dirname, ["img"], [prediction],


### PR DESCRIPTION
PR types: Bug fixes

PR changes: Others - test case

Describe: fix the random test cases failure:
- test_train_recognize_digits_mlp
- test_train_recognize_digits_conv

Python test case of "test_recognize_digits" will not save model `if accuracy < 0.2`, please refer to the code in `Paddle/python/paddle/fluid/tests/book/test_recognize_digits.py`. Then the above two C++ tests will failure with error:

Error: Cannot open file /paddle/build/python/paddle/fluid/tests/book/recognize_digits_mlp.train.model/__model_combined__.main_program at (/paddle/paddle/fluid/inference/io.cc:50)

Still save model even if accuracy < 0.2.
