### PR TITLE
[Dy2Static]Convert while stmt and convert logical_XX

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/__init__.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/__init__.py
@@ -32,6 +32,8 @@ from .program_translator import *
 from . import convert_call_func
 from .convert_call_func import *
 
+from . import convert_operators
+
 __all__ = []
 __all__ += ast_transformer.__all__
 __all__ += loop_transformer.__all__

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -22,11 +22,9 @@ def convert_while_loop(cond, body, loop_vars):
     A function representation of a Python ``while`` statement.
 
     Args:
-        cond(Callable): A callable returning a boolean variable controlling whether to continue looping. And ``cond`` takes
-        as many arguments as ``loop_vars`` .
-        body(Callable): A callable returning a tuple or list of variables of the same arity
-            (length and structure) and types as ``loops_vars`` . And ``body`` takes as many arguments as ``loop_vars`` .
-        loop_vars(list|tuple): A list or tuple of variables that is passed to both ``cond`` and ``body`` .
+        cond(Callable): A callable object that returns a boolean variable to control whether to  execute the loop body.  It takes  ``loop_vars`` as arguments.
+        body(Callable): A callable object that returns a tuple or list of variables with the same arguments ``loops_vars`` as ``cond`` .
+        loop_vars(list|tuple): A list or tuple of variables passed to ``cond`` and ``body`` .
 
     Returns:
         A list or tuple of variables which returned by ``body`` .
@@ -79,6 +77,8 @@ def _run_paddle_logical_and(x, y):
 
 
 def _run_py_logical_and(x, y):
+    assert not isinstance(x, Variable)
+    # NOTE: Returns y if x is True
     return x and y
 
 
@@ -108,6 +108,8 @@ def _run_paddle_logical_or(x, y):
 
 
 def _run_py_logical_or(x, y):
+    assert not isinstance(x, Variable)
+    # NOTE: Returns y if x is False
     return x or y
 
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from paddle.fluid.framework import Variable
-from paddle.fluid.layers import fill_constant, control_flow, logical_and, logical_or, logical_not
+from paddle.fluid.layers import control_flow, logical_and, logical_or, logical_not
 from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable
 
 
@@ -65,15 +65,16 @@ def convert_logical_and(x, y):
         A python bool variable or a bool Tensor.
     """
 
-    if isinstance(x, Variable):
+    if isinstance(x, Variable) and isinstance(y, Variable):
         return _run_paddle_logical_and(x, y)
-    else:
+
+    if not isinstance(x, Variable):
         return _run_py_logical_and(x, y)
+
+    return _run_py_logical_and(y, x)
 
 
 def _run_paddle_logical_and(x, y):
-    if not isinstance(y, Variable):
-        y = fill_constant(shape=[1], value=bool(y), dtype="bool")
     return logical_and(x, y)
 
 
@@ -93,15 +94,16 @@ def convert_logical_or(x, y):
         A python bool variable or a bool Tensor.
     """
 
-    if isinstance(x, Variable):
+    if isinstance(x, Variable) and isinstance(y, Variable):
         return _run_paddle_logical_or(x, y)
-    else:
+
+    if not isinstance(x, Variable):
         return _run_py_logical_or(x, y)
+
+    return _run_py_logical_or(y, x)
 
 
 def _run_paddle_logical_or(x, y):
-    if not isinstance(y, Variable):
-        y = fill_constant(shape=[1], value=bool(y), dtype="bool")
     return logical_or(x, y)
 
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from paddle.fluid.framework import Variable
+from paddle.fluid.layers import fill_constant, control_flow, logical_and, logical_or, logical_not
+from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable
+
+
+def convert_while_loop(cond, body, loop_vars):
+    """
+    A function representation of a Python ``while`` statement.
+
+    Args:
+        cond(Callable): A callable returning a boolean variable controlling whether to continue looping. And ``cond`` takes
+        as many arguments as ``loop_vars`` .
+        body(Callable): A callable returning a tuple or list of variables of the same arity
+            (length and structure) and types as ``loops_vars`` . And ``body`` takes as many arguments as ``loop_vars`` .
+        loop_vars(list|tuple): A list or tuple of variables that is passed to both ``cond`` and ``body`` .
+
+    Returns:
+        A list or tuple of variables which returned by ``body`` .
+    """
+
+    pred = cond(*loop_vars)
+    if isinstance(pred, Variable):
+        loop_vars = _run_paddle_while_loop(cond, body, loop_vars)
+    else:
+        loop_vars = _run_py_while(cond, body, loop_vars)
+
+    return loop_vars
+
+
+def _run_paddle_while_loop(cond, body, loop_vars):
+    loop_vars = [to_static_variable(var) for var in loop_vars]
+    loop_vars = control_flow.while_loop(cond, body, loop_vars)
+    return loop_vars
+
+
+def _run_py_while(cond, body, loop_vars):
+    while cond(*loop_vars):
+        loop_vars = body(*loop_vars)
+    return loop_vars
+
+
+def convert_logical_and(x, y):
+    """
+    A function representation of a Python ``and`` statement.
+
+    Args:
+        x(bool|Variable): Left hand operand of ``and`` operator.
+        y(bool|Variable): Right hand operand of ``and`` operator.
+
+    Returns:
+        A python bool variable or a bool Tensor.
+    """
+
+    if isinstance(x, Variable):
+        return _run_paddle_logical_and(x, y)
+    else:
+        return _run_py_logical_and(x, y)
+
+
+def _run_paddle_logical_and(x, y):
+    if not isinstance(y, Variable):
+        y = fill_constant(shape=[1], value=bool(y), dtype="bool")
+    return logical_and(x, y)
+
+
+def _run_py_logical_and(x, y):
+    return x and y
+
+
+def convert_logical_or(x, y):
+    """
+    A function representation of a Python ``or`` statement.
+
+    Args:
+        x(bool|Variable): Left hand operand of ``or`` operator.
+        y(bool|Variable): Right hand operand of ``or`` operator.
+
+    Returns:
+        A python bool variable or a bool Tensor.
+    """
+
+    if isinstance(x, Variable):
+        return _run_paddle_logical_or(x, y)
+    else:
+        return _run_py_logical_or(x, y)
+
+
+def _run_paddle_logical_or(x, y):
+    if not isinstance(y, Variable):
+        y = fill_constant(shape=[1], value=bool(y), dtype="bool")
+    return logical_or(x, y)
+
+
+def _run_py_logical_or(x, y):
+    return x or y
+
+
+def convert_logical_not(x):
+    """
+    A function representation of a Python ``not`` statement.
+
+    Args:
+        x(bool|Variable): Operand of of ``not`` operator.
+
+    Returns:
+        A python bool variable or a bool Tensor.
+    """
+
+    if isinstance(x, Variable):
+        return _run_paddle_logical_not(x)
+    else:
+        return _run_py_logical_not(x)
+
+
+def _run_paddle_logical_not(x):
+    return logical_not(x)
+
+
+def _run_py_logical_not(x):
+    return not x

--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -29,7 +29,7 @@ from paddle.fluid.dygraph.dygraph_to_static.utils import is_control_flow_to_tran
 from paddle.fluid.dygraph.dygraph_to_static.utils import ForNodeVisitor
 from paddle.fluid.dygraph.dygraph_to_static.utils import RenameTransformer
 from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import create_static_variable_gast_node
-from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable_gast_node, to_static_variable
+from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable_gast_node
 
 __all__ = ['LoopTransformer', 'NameVisitor']
 
@@ -541,10 +541,6 @@ class LoopTransformer(gast.NodeTransformer):
         return new_stmts
 
     def get_while_stmt_nodes(self, node):
-        # TODO: consider while - else in python
-        # if not self.name_visitor.is_control_flow_loop(node):
-        #     return [node]
-
         loop_var_names, create_var_names = self.name_visitor.get_loop_var_names(
             node)
         new_stmts = []
@@ -560,10 +556,6 @@ class LoopTransformer(gast.NodeTransformer):
         for name in create_var_names:
             if "." not in name:
                 new_stmts.append(create_static_variable_gast_node(name))
-
-        # while x < 10 in dygraph should be convert into static tensor < 10
-        # for name in loop_var_names:
-        #     new_stmts.append(to_static_variable_gast_node(name))
 
         logical_op_transformer = LogicalOpTransformer(node.test)
         cond_value_node = logical_op_transformer.transform()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -111,7 +111,10 @@ class LogicalOpTransformer(gast.NodeTransformer):
         if len(nodes) > 2:
             # Creates logic_and/logic_or node recursively.
             pre_logic_node = self._create_bool_op_node(nodes[:2], api_type)
-            post_logic_node = self._create_bool_op_node(nodes[2:], api_type)
+            if len(nodes[2:]) == 1:
+                post_logic_node = nodes[2]
+            else:
+                post_logic_node = self._create_bool_op_node(nodes[2:], api_type)
             nodes = [pre_logic_node] + [post_logic_node]
 
         args = [ast_to_source_code(child) for child in nodes]

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import six
 import paddle.fluid as fluid
 
 
@@ -257,6 +258,14 @@ def if_tensor_case(x):
     # It is equivalent to `if mean != 0`
     if mean:
         for i in range(0, 10):
+            # TODO(liym27): Delete it if the type of parameter `i` can be resolved in "if" stmt
+            if six.PY2:
+                i = fluid.layers.fill_constant(
+                    shape=[1], value=i, dtype="int32")
+            else:
+                i = fluid.layers.fill_constant(
+                    shape=[1], value=i, dtype="int64")
+
             if i > 5:
                 x += 1
                 break

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_break_continue.py
@@ -89,29 +89,44 @@ def test_break_in_while(x):
 
 def test_break_continue_in_for(x):
     x = fluid.dygraph.to_variable(x)
+
+    # TODO(liym27): Uncomment code after "if" statement can be transformed correctly.
+    # for i in range(1, 10, 1):
+    #     if i <= 4:
+    #         x += 1
+    #         continue
+    #     else:
+    #         x += 10010
+    #         break
+    #     x += 10086
+
+    a = fluid.layers.fill_constant(shape=[1], dtype='int32', value=0)
     for i in range(1, 10, 1):
-        if i <= 4:
+        if a <= 4:
             x += 1
+            a += 1
             continue
         else:
             x += 10010
             break
         x += 10086
+
     return x
 
 
 def test_for_in_else(x):
     x = fluid.dygraph.to_variable(x)
 
-    # Case 1:
-    if False:
-        pass
-    else:
-        for i in range(0, 10):
-            if i > 5:
-                x += 1
-                break
-            x += i
+    # TODO(liym27): Uncomment code after "if" statement can be transformed correctly.
+    # # Case 1:
+    # if False:
+    #     pass
+    # else:
+    #     for i in range(0, 10):
+    #         if i > 5:
+    #             x += 1
+    #             break
+    #         x += i
 
     # Case 2:
     if False:

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -156,6 +156,9 @@ def test_list_pop_in_while_loop(x, iter_num):
         shape=[1], value=iter_num, dtype="int32")
     a = []
     i = 0
+
+    # TODO(liym27): Delete it if the type of parameter `i` can be resolved in "if" stmt
+    i = fluid.layers.fill_constant(shape=[1], value=i, dtype="int32")
     while i < iter_num:
         a.append(x + i)
         i += 1

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -29,9 +29,6 @@ np.random.seed(SEED)
 
 def while_loop_dyfunc(x):
     i = fluid.dygraph.to_variable(x)
-    # Use `to_variable` so that static analysis can analyze the type of X is Tensor
-    x = fluid.dygraph.to_variable(
-        x)  # TODO(liym27): Delete it if the type of parameter x can be resolved
     while x < 10:
         i = i + x
         x = x + 1
@@ -40,9 +37,6 @@ def while_loop_dyfunc(x):
 
 def while_loop_dyfun_with_conflict_var(x):
     i = fluid.dygraph.to_variable(x)
-    # Use `to_variable` so that static analysis can analyze the type of X is Tensor
-    x = fluid.dygraph.to_variable(
-        x)  # TODO(liym27): Delete it if the type of parameter x can be resolved
 
     def relu(y):
         # 'y' is not visible outside the scope.
@@ -82,9 +76,6 @@ def for_loop_dyfunc(max_len):
 def while_loop_bool_op(x):
     i = fluid.dygraph.to_variable(x)
 
-    # Use `to_variable` so that static analysis can analyze the type of X is Tensor
-    x = fluid.dygraph.to_variable(
-        x)  # TODO(liym27): Delete it if the type of parameter x can be resolved
     while x <= -1 or x < -3 or (x < -7 or x < -5) or (x >= 0 and x < 10):
         i = i + x
         x = x + 1
@@ -120,6 +111,7 @@ def for_loop_class_var(max_len):
     # TODO(liym27): Delete it if the type of parameter x can be resolved
     max_len = fluid.layers.fill_constant(
         shape=[1], value=max_len, dtype="int32")
+
     for i in range(max_len):
         foo.b = fluid.layers.zeros(shape=[1], dtype='float32')
         foo.c = foo.b + foo.a
@@ -211,10 +203,12 @@ class TestTransformWhileLoop(unittest.TestCase):
 
     def _run(self, to_static):
         with fluid.dygraph.guard(self.place):
+            # Set the input of dyfunc to VarBase
+            tensor_x = fluid.dygraph.to_variable(self.x, zero_copy=False)
             if to_static:
-                ret = declarative(self.dyfunc)(self.x)
+                ret = declarative(self.dyfunc)(tensor_x)
             else:
-                ret = self.dyfunc(self.x)
+                ret = self.dyfunc(tensor_x)
             return ret.numpy()
 
     def test_ast_to_func(self):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -82,6 +82,16 @@ def while_loop_bool_op(x):
     return i
 
 
+def while_loop_bool_op2(x):
+    i = fluid.dygraph.to_variable(x)
+    a = 1
+    while x < 10 and (a < 4 or a > 0) or a < -1:
+        i = i + x
+        x = x + 1
+        a = a + 1
+    return i
+
+
 def while_loop_class_var(x):
     class Foo(object):
         def __init__(self):
@@ -230,6 +240,11 @@ class TestTransformWhileLoopWithNone(TestTransformWhileLoop):
 class TestWhileLoopBoolOp(TestTransformWhileLoop):
     def _init_dyfunc(self):
         self.dyfunc = while_loop_bool_op
+
+
+class TestWhileLoopBoolOp2(TestTransformWhileLoop):
+    def _init_dyfunc(self):
+        self.dyfunc = while_loop_bool_op2
 
 
 class TestWhileLoopClassVar(TestTransformWhileLoop):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -35,6 +35,17 @@ def while_loop_dyfunc(x):
     return i
 
 
+def while_loop_dyfunc_without_tensor(x):
+    a = 1
+    # There are no tensors in the while condition, which means it's a plain while in python,
+    # so it wont't be transformed to `while_loop` op.
+    while not a > 4 and a > 0:
+        x = x + 1
+        a = a + 1
+
+    return x
+
+
 def while_loop_dyfun_with_conflict_var(x):
     i = fluid.dygraph.to_variable(x)
 
@@ -85,7 +96,9 @@ def while_loop_bool_op(x):
 def while_loop_bool_op2(x):
     i = fluid.dygraph.to_variable(x)
     a = 1
-    while x < 10 and (a < 4 or a > 0) or a < -1:
+
+    # In the while condition, there are both Paddle Variable and non-Variable.
+    while x < 10 and (a < 4 or a > 0) or a < -1 or not x > -1:
         i = i + x
         x = x + 1
         a = a + 1
@@ -225,6 +238,11 @@ class TestTransformWhileLoop(unittest.TestCase):
         static_numpy = self._run_static()
         dygraph_numpy = self._run_dygraph()
         self.assertTrue(np.allclose(dygraph_numpy, static_numpy))
+
+
+class TestTransformWhileLoopWithoutTensor(TestTransformWhileLoop):
+    def _init_dyfunc(self):
+        self.dyfunc = while_loop_dyfunc_without_tensor
 
 
 class TestTransformWhileLoopWithConflicVar(TestTransformWhileLoop):


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: New features
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: dygraph to static graph
<!--  Describe what this PR does  -->
Describe:
#### 1. Fix bug:  Create logic node recursively in LogicalOpTransformer.
#### 2. Add functions `convert_XX` to run the transformed code dynamically. Which means, 
- All while stmts and logical stmts are transformed whether it depends on `Tensor` or not;
- But in run-time, the code will be run in different ways (1) run paddle op like `while_loop`; (2) run python while. How it runs depends on whether it depends on `Tensor`. 
> This method will not use static variable types while transforming ast node, because the variable types got from static analysis are often inaccurate.

---

`convert_while_loop `: A function representation of a Python ``while`` statement.
`convert_logical_and `:  A function representation of a Python ``and`` statement.
`convert_logical_or `: A function representation of a Python ``or`` statement.
`convert_logical_not `: A function representation of a Python ``not`` statement.

---
Related PR :
convert_ifelse: https://github.com/PaddlePaddle/Paddle/pull/24866