### PR TITLE
fix bug when compile CPU inference library,test=develop

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -213,7 +213,11 @@ copy(fluid_lib_dist
         )
 
 set(module "platform")
-set(platform_lib_deps profiler_proto error_codes_proto cuda_error_proto)
+set(platform_lib_deps profiler_proto error_codes_proto)
+if(WITH_GPU)
+  set(platform_lib_deps ${platform_lib_deps} cuda_error_proto)
+endif(WITH_GPU)
+
 add_dependencies(fluid_lib_dist ${platform_lib_deps})
 copy(fluid_lib_dist
         SRCS ${src_dir}/${module}/*.h ${src_dir}/${module}/dynload/*.h ${src_dir}/${module}/details/*.h ${PADDLE_BINARY_DIR}/paddle/fluid/platform/*.pb.h


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: 预测库编译相关
<!--  Describe what this PR does  -->
Describe: CPU情况下，不编译cuda_error_proto，此为误依赖。fix  https://github.com/PaddlePaddle/Paddle/commit/d1047d0a699689724e037f944f205fbeca7ab1fb#commitcomment-39502737
