### PR TITLE
Support gradient accumulation of fp16 in imperative mode

### DIFF
--- a/paddle/fluid/imperative/CMakeLists.txt
+++ b/paddle/fluid/imperative/CMakeLists.txt
@@ -2,7 +2,7 @@ cc_library(imperative_flag SRCS flags.cc DEPS gflags)
 
 cc_library(prepared_operator SRCS prepared_operator.cc DEPS proto_desc operator device_context lod_tensor selected_rows var_type_traits op_kernel_type data_transform)
 cc_library(layer SRCS layer.cc DEPS prepared_operator math_function imperative_flag variable_helper op_registry)
-cc_library(gradient_accumulator SRCS gradient_accumulator.cc DEPS blas operator lod_tensor selected_rows selected_rows_functor var_type_traits layer)
+cc_library(gradient_accumulator SRCS gradient_accumulator.cc DEPS blas operator lod_tensor selected_rows selected_rows_functor var_type_traits layer math_function) 
 add_subdirectory(jit)
 
 cc_library(tracer SRCS tracer.cc DEPS layer engine program_desc_tracer)

--- a/paddle/fluid/imperative/tests/test_gradient_accmulator.cc
+++ b/paddle/fluid/imperative/tests/test_gradient_accmulator.cc
@@ -107,12 +107,18 @@ TEST(test_add_functor, add_functor) {
   cpu_res = TensorCPUAddTest(cpu_place, static_cast<double>(1.0),
                              static_cast<double>(2.0));
   EXPECT_EQ(cpu_res, 0);
+  cpu_res = TensorCPUAddTest(cpu_place, static_cast<platform::float16>(1.0),
+                             static_cast<platform::float16>(2.0));
+  EXPECT_EQ(cpu_res, 0);
 #if defined(PADDLE_WITH_CUDA)
   int gpu_res = 1;
   gpu_res = TensorGPUAddTest(gpu_place, 1.0, 0.0);
   EXPECT_EQ(gpu_res, 0);
   gpu_res = TensorGPUAddTest(gpu_place, static_cast<double>(1.0),
                              static_cast<double>(2.0));
+  EXPECT_EQ(gpu_res, 0);
+  gpu_res = TensorGPUAddTest(gpu_place, static_cast<platform::float16>(1.0),
+                             static_cast<platform::float16>(2.0));
   EXPECT_EQ(gpu_res, 0);
 #endif
 }

--- a/paddle/fluid/imperative/tests/test_gradient_accmulator.cc
+++ b/paddle/fluid/imperative/tests/test_gradient_accmulator.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <memory>
+#include <type_traits>
 #include <vector>
 #include "gtest/gtest.h"
 #include "paddle/fluid/framework/variable.h"
@@ -27,70 +28,62 @@ namespace imperative {
 
 void TensorAdd(const framework::Variable& src, framework::Variable* dst);
 
+template <typename Place, typename T>
+int TensorddTest(Place place, T t1, T t2) {
+  framework::Variable var1;
+  framework::Variable var2;
+  std::vector<T> src_data(10, t1);
+  std::vector<T> dst_data(10, t2);
+  std::vector<T> result;
+  platform::CPUPlace src_place;
+  for (unsigned int i = 0; i < 10; i++) {
+    result.emplace_back(src_data[i] + dst_data[i]);
+  }
+
+  for (int i = 1; i <= 6; ++i) {
+    std::vector<int64_t> dims = {10};
+    if (i == 1) {
+      dims = {10};
+    } else if (i == 2) {
+      dims = {2, 5};
+    } else if (i == 3) {
+      dims = {1, 2, 5};
+    } else if (i == 4) {
+      dims = {1, 1, 2, 5};
+    } else if (i == 5) {
+      dims = {1, 1, 1, 2, 5};
+    } else if (i == 6) {
+      dims = {1, 1, 1, 2, 5, 1};
+    }
+
+    auto* src = var1.GetMutable<framework::LoDTensor>();
+    auto* dst = var2.GetMutable<framework::LoDTensor>();
+    src->Resize(framework::make_ddim(dims));
+    dst->Resize(framework::make_ddim(dims));
+    auto* src_mutable = src->mutable_data<T>(place);
+    auto* dst_mutable = dst->mutable_data<T>(place);
+    if (!std::is_same<Place, platform::CUDAPlace>::value) {
+      paddle::memory::Copy(place, src_mutable, src_place, src_data.data(),
+                           sizeof(T) * src_data.size());
+      paddle::memory::Copy(place, dst_mutable, src_place, dst_data.data(),
+                           sizeof(T) * dst_data.size());
 #if defined(PADDLE_WITH_CUDA)
-template <typename T>
-int TensorGPUAddTest(platform::CUDAPlace place, T t1, T t2) {
-  framework::Variable var1;
-  framework::Variable var2;
-  std::vector<T> src_data(10, t1);
-  std::vector<T> dst_data(10, t2);
-  std::vector<T> result;
-  platform::CPUPlace src_place;
-  for (unsigned int i = 0; i < 10; i++) {
-    result.emplace_back(src_data[i] + dst_data[i]);
-  }
-  std::vector<int64_t> dims = {2, 5};
-  auto* src = var1.GetMutable<framework::LoDTensor>();
-  auto* dst = var2.GetMutable<framework::LoDTensor>();
-  src->Resize(framework::make_ddim(dims));
-  dst->Resize(framework::make_ddim(dims));
-  auto* src_mutable = src->mutable_data<T>(place);
-  auto* dst_mutable = dst->mutable_data<T>(place);
-  paddle::memory::Copy(place, src_mutable, src_place, src_data.data(),
-                       sizeof(T) * src_data.size(), 0);
-  paddle::memory::Copy(place, dst_mutable, src_place, dst_data.data(),
-                       sizeof(T) * dst_data.size(), 0);
-  imperative::TensorAdd(var1, &var2);
-  framework::LoDTensor rlt;
-  platform::CPUPlace rlt_place;
-  framework::TensorCopySync(*dst, rlt_place, &rlt);
-
-  for (unsigned int i = 0; i < rlt.numel(); i++) {
-    if (rlt.data<T>()[i] != result[i]) return 1;
-  }
-  return 0;
-}
+    } else {
+      paddle::memory::Copy(place, src_mutable, src_place, src_data.data(),
+                           sizeof(T) * src_data.size(), 0);
+      paddle::memory::Copy(place, dst_mutable, src_place, dst_data.data(),
+                           sizeof(T) * dst_data.size(), 0);
 #endif
+    }
 
-template <typename T>
-int TensorCPUAddTest(platform::CPUPlace place, T t1, T t2) {
-  framework::Variable var1;
-  framework::Variable var2;
-  std::vector<T> src_data(10, t1);
-  std::vector<T> dst_data(10, t2);
-  std::vector<T> result;
-  platform::CPUPlace src_place;
-  for (unsigned int i = 0; i < 10; i++) {
-    result.emplace_back(src_data[i] + dst_data[i]);
-  }
-  std::vector<int64_t> dims = {2, 5};
-  auto* src = var1.GetMutable<framework::LoDTensor>();
-  auto* dst = var2.GetMutable<framework::LoDTensor>();
-  src->Resize(framework::make_ddim(dims));
-  dst->Resize(framework::make_ddim(dims));
-  auto* src_mutable = src->mutable_data<T>(place);
-  auto* dst_mutable = dst->mutable_data<T>(place);
-  paddle::memory::Copy(place, src_mutable, src_place, src_data.data(),
-                       sizeof(T) * src_data.size());
-  paddle::memory::Copy(place, dst_mutable, src_place, dst_data.data(),
-                       sizeof(T) * dst_data.size());
-  imperative::TensorAdd(var1, &var2);
-  framework::LoDTensor rlt;
-  platform::CPUPlace rlt_place;
-  framework::TensorCopySync(*dst, rlt_place, &rlt);
+    imperative::TensorAdd(var1, &var2);
+    framework::LoDTensor rlt;
+    platform::CPUPlace rlt_place;
+    framework::TensorCopySync(*dst, rlt_place, &rlt);
 
-  for (unsigned int i = 0; i < rlt.numel(); i++) {
-    if (rlt.data<T>()[i] != result[i]) return 1;
+    for (unsigned int i = 0; i < rlt.numel(); i++) {
+      if (rlt.data<T>()[i] != result[i]) return 1;
+    }
   }
   return 0;
 }
@@ -102,24 +95,38 @@ TEST(test_add_functor, add_functor) {
   platform::CPUPlace cpu_place;
 
   int cpu_res = 1;
-  cpu_res = TensorCPUAddTest(cpu_place, 1.0, 0.0);
+  cpu_res = TensorddTest(cpu_place, 1.0, 0.0);
   EXPECT_EQ(cpu_res, 0);
-  cpu_res = TensorCPUAddTest(cpu_place, static_cast<double>(1.0),
-                             static_cast<double>(2.0));
+  cpu_res = TensorddTest(cpu_place, static_cast<double>(1.0),
+                         static_cast<double>(2.0));
   EXPECT_EQ(cpu_res, 0);
-  cpu_res = TensorCPUAddTest(cpu_place, static_cast<platform::float16>(1.0),
-                             static_cast<platform::float16>(2.0));
+  cpu_res = TensorddTest(cpu_place, static_cast<platform::float16>(1.0),
+                         static_cast<platform::float16>(2.0));
   EXPECT_EQ(cpu_res, 0);
 #if defined(PADDLE_WITH_CUDA)
   int gpu_res = 1;
-  gpu_res = TensorGPUAddTest(gpu_place, 1.0, 0.0);
+  gpu_res = TensorddTest(gpu_place, 1.0, 0.0);
   EXPECT_EQ(gpu_res, 0);
-  gpu_res = TensorGPUAddTest(gpu_place, static_cast<double>(1.0),
-                             static_cast<double>(2.0));
+  gpu_res = TensorddTest(gpu_place, static_cast<double>(1.0),
+                         static_cast<double>(2.0));
   EXPECT_EQ(gpu_res, 0);
-  gpu_res = TensorGPUAddTest(gpu_place, static_cast<platform::float16>(1.0),
-                             static_cast<platform::float16>(2.0));
+  gpu_res = TensorddTest(gpu_place, static_cast<platform::float16>(1.0),
+                         static_cast<platform::float16>(2.0));
   EXPECT_EQ(gpu_res, 0);
+#endif
+}
+
+TEST(test_add_functor, execption) {
+  platform::CUDAPinnedPlace cuda_pinned_place;
+  platform::CUDAPlace cuda_place(0);
+  platform::CPUPlace cpu_place;
+
+  ASSERT_ANY_THROW(TensorddTest(cpu_place, 1, 0));
+#if defined(PADDLE_WITH_CUDA)
+  ASSERT_ANY_THROW(TensorddTest(cuda_pinned_place, 1.0, 0.0));
+  ASSERT_ANY_THROW(TensorddTest(cuda_pinned_place,
+                                static_cast<platform::float16>(1.0),
+                                static_cast<platform::float16>(2.0)));
 #endif
 }
 

--- a/paddle/fluid/operators/math/math_function.cc
+++ b/paddle/fluid/operators/math/math_function.cc
@@ -146,6 +146,24 @@ template struct RowwiseSum<platform::CPUDeviceContext, double>;
 template struct RowwiseMean<platform::CPUDeviceContext, float>;
 template struct RowwiseMean<platform::CPUDeviceContext, double>;
 
+template <typename T, int D>
+struct AddTensor<platform::CPUDeviceContext, T, D> {
+  void operator()(platform::CPUDeviceContext* ctx, const framework::Tensor& src,
+                  framework::Tensor* dst) {
+    auto in = framework::EigenTensor<T, D>::From(src);
+    auto out = framework::EigenTensor<T, D>::From(*dst);
+    auto& place = *(ctx->eigen_device());
+    out.device(place) = out + in;
+  }
+};
+
+template struct AddTensor<platform::CPUDeviceContext, platform::float16, 1>;
+template struct AddTensor<platform::CPUDeviceContext, platform::float16, 2>;
+template struct AddTensor<platform::CPUDeviceContext, platform::float16, 3>;
+template struct AddTensor<platform::CPUDeviceContext, platform::float16, 4>;
+template struct AddTensor<platform::CPUDeviceContext, platform::float16, 5>;
+template struct AddTensor<platform::CPUDeviceContext, platform::float16, 6>;
+
 }  // namespace math
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/math/math_function.cc
+++ b/paddle/fluid/operators/math/math_function.cc
@@ -146,23 +146,18 @@ template struct RowwiseSum<platform::CPUDeviceContext, double>;
 template struct RowwiseMean<platform::CPUDeviceContext, float>;
 template struct RowwiseMean<platform::CPUDeviceContext, double>;
 
-template <typename T, int D>
-struct AddTensor<platform::CPUDeviceContext, T, D> {
+template <typename T>
+struct ElementwiseAddTo<platform::CPUDeviceContext, T> {
   void operator()(platform::CPUDeviceContext* ctx, const framework::Tensor& src,
                   framework::Tensor* dst) {
-    auto in = framework::EigenTensor<T, D>::From(src);
-    auto out = framework::EigenTensor<T, D>::From(*dst);
+    auto in = framework::EigenVector<T>::Flatten(src);
+    auto out = framework::EigenVector<T>::Flatten(*dst);
     auto& place = *(ctx->eigen_device());
     out.device(place) = out + in;
   }
 };
 
-template struct AddTensor<platform::CPUDeviceContext, platform::float16, 1>;
-template struct AddTensor<platform::CPUDeviceContext, platform::float16, 2>;
-template struct AddTensor<platform::CPUDeviceContext, platform::float16, 3>;
-template struct AddTensor<platform::CPUDeviceContext, platform::float16, 4>;
-template struct AddTensor<platform::CPUDeviceContext, platform::float16, 5>;
-template struct AddTensor<platform::CPUDeviceContext, platform::float16, 6>;
+template struct ElementwiseAddTo<platform::CPUDeviceContext, platform::float16>;
 
 }  // namespace math
 }  // namespace operators

--- a/paddle/fluid/operators/math/math_function.cu
+++ b/paddle/fluid/operators/math/math_function.cu
@@ -148,6 +148,23 @@ void RowwiseSum<platform::CUDADeviceContext, double>::operator()(
 template struct RowwiseMean<platform::CUDADeviceContext, float>;
 template struct RowwiseMean<platform::CUDADeviceContext, double>;
 
+template <typename T, int D>
+struct AddTensor<platform::CUDADeviceContext, T, D> {
+  void operator()(platform::CUDADeviceContext* ctx,
+                  const framework::Tensor& src, framework::Tensor* dst) {
+    auto in = framework::EigenTensor<T, D>::From(src);
+    auto out = framework::EigenTensor<T, D>::From(*dst);
+    auto& place = *(ctx->eigen_device());
+    out.device(place) = out + in;
+  }
+};
+
+template struct AddTensor<platform::CUDADeviceContext, platform::float16, 1>;
+template struct AddTensor<platform::CUDADeviceContext, platform::float16, 2>;
+template struct AddTensor<platform::CUDADeviceContext, platform::float16, 3>;
+template struct AddTensor<platform::CUDADeviceContext, platform::float16, 4>;
+template struct AddTensor<platform::CUDADeviceContext, platform::float16, 5>;
+template struct AddTensor<platform::CUDADeviceContext, platform::float16, 6>;
 }  // namespace math
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/math/math_function.cu
+++ b/paddle/fluid/operators/math/math_function.cu
@@ -148,23 +148,19 @@ void RowwiseSum<platform::CUDADeviceContext, double>::operator()(
 template struct RowwiseMean<platform::CUDADeviceContext, float>;
 template struct RowwiseMean<platform::CUDADeviceContext, double>;
 
-template <typename T, int D>
-struct AddTensor<platform::CUDADeviceContext, T, D> {
+template <typename T>
+struct ElementwiseAddTo<platform::CUDADeviceContext, T> {
   void operator()(platform::CUDADeviceContext* ctx,
                   const framework::Tensor& src, framework::Tensor* dst) {
-    auto in = framework::EigenTensor<T, D>::From(src);
-    auto out = framework::EigenTensor<T, D>::From(*dst);
+    auto in = framework::EigenVector<T>::Flatten(src);
+    auto out = framework::EigenVector<T>::Flatten(*dst);
     auto& place = *(ctx->eigen_device());
     out.device(place) = out + in;
   }
 };
 
-template struct AddTensor<platform::CUDADeviceContext, platform::float16, 1>;
-template struct AddTensor<platform::CUDADeviceContext, platform::float16, 2>;
-template struct AddTensor<platform::CUDADeviceContext, platform::float16, 3>;
-template struct AddTensor<platform::CUDADeviceContext, platform::float16, 4>;
-template struct AddTensor<platform::CUDADeviceContext, platform::float16, 5>;
-template struct AddTensor<platform::CUDADeviceContext, platform::float16, 6>;
+template struct ElementwiseAddTo<platform::CUDADeviceContext,
+                                 platform::float16>;
 }  // namespace math
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/math/math_function.h
+++ b/paddle/fluid/operators/math/math_function.h
@@ -51,6 +51,12 @@ struct RowwiseAdd {
                   const framework::Tensor& vec, framework::Tensor* output);
 };
 
+template <typename DeviceContext, typename T, int D>
+struct AddTensor {
+  void operator()(DeviceContext* ctx, const framework::Tensor& src,
+                  framework::Tensor* dst);
+};
+
 template <typename DeviceContext, typename T>
 struct ColwiseSum {
   void operator()(const DeviceContext& context, const framework::Tensor& input,

--- a/paddle/fluid/operators/math/math_function.h
+++ b/paddle/fluid/operators/math/math_function.h
@@ -51,8 +51,9 @@ struct RowwiseAdd {
                   const framework::Tensor& vec, framework::Tensor* output);
 };
 
-template <typename DeviceContext, typename T, int D>
-struct AddTensor {
+template <typename DeviceContext, typename T>
+struct ElementwiseAddTo {
+  // dst = dst + src
   void operator()(DeviceContext* ctx, const framework::Tensor& src,
                   framework::Tensor* dst);
 };


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: New features
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: Others
<!--  Describe what this PR does  -->
Describe: Support gradient accumulation of fp16 in imperative mode

Note, original gradient accumulation of `float` and `double` uses `AXPY` of blas library, which does not support `float16`. So `float16` calculation uses `eigen` library.
