### PR TITLE
fix negative framework overhead in Profiling Report

### DIFF
--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -84,10 +84,11 @@ struct EventItem {
 };
 
 struct OverHead {
-  bool print = false;
+  bool print_overhead = false;
+  bool print_explanation = false;
   double total_time = 0.;
-  float compute_ratio = 0.0f;
-  float framework_ratio = 0.0f;
+  double compute_time = 0.0;
+  double framework_time = 0.0;
   EventItem memcpy_item;
   std::vector<EventItem> sub_memcpy_items;
 };

--- a/paddle/fluid/platform/profiler.h
+++ b/paddle/fluid/platform/profiler.h
@@ -86,7 +86,8 @@ struct EventItem {
 struct OverHead {
   bool print_overhead = false;
   bool print_explanation = false;
-  double total_time = 0.;
+  double elapsed_time = 0.;      // the elapsed time of all events
+  double accumulated_time = 0.;  // the accumulated time of all events
   double compute_time = 0.0;
   double framework_time = 0.0;
   EventItem memcpy_item;

--- a/paddle/fluid/platform/profiler_helper.h
+++ b/paddle/fluid/platform/profiler_helper.h
@@ -410,17 +410,23 @@ void ComputeOverhead(const std::vector<EventItem> &main_event_items,
                            EventRole::kOrdinary};
   // GpuMemcpy may be in main_event_items
   for (auto &item : main_event_items) {
+    if (item.role != EventRole::kSpecial) {
+      overhead->total_time += item.total_time;
+    }
     UpdateGpuMemcpy(item, &memcpy_async, &memcpy_sync);
   }
 
   for (auto it = sub_child_map.begin(); it != sub_child_map.end(); it++) {
+    if (it->first == "ParallelExecutor::Run") {
+      overhead->total_time += it->second.total_time;
+    }
     if (it->second.name.find("compute") != std::string::npos &&
         it->second.name.find("compute/") == std::string::npos) {
-      overhead->compute_ratio += it->second.ratio;
+      overhead->compute_time += it->second.total_time;
     }
     UpdateGpuMemcpy(it->second, &memcpy_async, &memcpy_sync);
   }
-  overhead->framework_ratio = 1.0f - overhead->compute_ratio;
+  overhead->framework_time = overhead->total_time - overhead->compute_time;
   overhead->memcpy_item.calls = memcpy_async.calls + memcpy_sync.calls;
   overhead->memcpy_item.total_time =
       memcpy_async.total_time + memcpy_sync.total_time;
@@ -486,16 +492,33 @@ void GetChildMap(const std::multimap<std::string, EventItem> &sub_child_map,
 }
 
 void PrintOverHead(const OverHead &overhead, const size_t data_width) {
-  double compute_time = overhead.total_time * overhead.compute_ratio;
-  double framework_time = overhead.total_time * overhead.framework_ratio;
+  float compute_ratio = overhead.compute_time / overhead.total_time;
+  float framework_ratio = 1 - compute_ratio;
+  if (overhead.print_explanation) {
+    std::cout
+        << "The total time in OpRun Summary may be higher than that of "
+           "ParallelExecutor::Run."
+        << "\nBecause the OP is executed asynchronously. The details are as "
+           "follows: "
+        << "\nEvent                   Timeline"
+        << "\nParallelExecutor::Run   "
+           "---------------------------------------------------------"
+        << "\n  thread1::OP1                 -----------------------------"
+        << "\n  thread2::OP2                      "
+           "---------------------------------------------"
+        << "\nOP1.time + OP2.time > ParallelExecutor::Run.time\n\n";
+  }
+  std::cout << "-------------------------"
+            << "       OpRun Summary       "
+            << "-------------------------\n\n";
   std::cout.setf(std::ios::left);
   std::cout << "Total time: " << overhead.total_time << std::endl;
   std::cout << std::setw(25) << "  Computation time"
-            << "Total: " << std::setw(data_width) << compute_time
-            << "Ratio: " << overhead.compute_ratio * 100 << "%" << std::endl;
+            << "Total: " << std::setw(data_width) << overhead.compute_time
+            << "Ratio: " << compute_ratio * 100 << "%" << std::endl;
   std::cout << std::setw(25) << "  Framework overhead"
-            << "Total: " << std::setw(data_width) << framework_time
-            << "Ratio: " << overhead.framework_ratio * 100 << "%" << std::endl;
+            << "Total: " << std::setw(data_width) << overhead.framework_time
+            << "Ratio: " << framework_ratio * 100 << "%" << std::endl;
 
   std::cout << "\n-------------------------"
             << "     GpuMemCpy Summary     "
@@ -552,7 +575,7 @@ void PrintProfiler(
     std::cout << "Sorted by " << sorted_domain
               << " in descending order in the same thread\n\n";
 
-    if (overhead.print) {
+    if (overhead.print_overhead) {
       PrintOverHead(overhead, data_width);
     }
     std::cout << "\n-------------------------"
@@ -681,7 +704,6 @@ void AnalyzeEvent(
         }
       }
     }
-
     for (size_t j = 0; j < table_size; ++j) {
       if (child_index[j] == 0) {
         main_event_items.push_back(event_items[j]);
@@ -699,8 +721,10 @@ void AnalyzeEvent(
     }
     // When multi-threaded, overhead are printed only if merge_thread is true
     if ((*analyze_events).size() == 1) {
-      overhead->total_time = total;
-      overhead->print = true;
+      if (!main_thread_event_name.empty()) {
+        overhead->print_explanation = true;
+      }
+      overhead->print_overhead = true;
       ComputeOverhead(main_event_items, sub_child_map, overhead);
     }
     // sort


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: Others 
<!--  Describe what this PR does  -->
Describe: fix negative framework overhead in Profiling Report


**问题描述**：在多线程异步情况下，所有OP的时间加起来会超过PE::Run的总时间。原来的计算方式中，OP的计算时间累加可能会超出PE::Run的总时间，导致计算开销会超过100%，框架开销则出现了负值。
![image](https://user-images.githubusercontent.com/26615455/83488161-f6e32e00-a4de-11ea-9113-a3d968096218.png)
错误的结果如下：
```
------------------------->     Profiling Report     <-------------------------

Note! This Report merge all thread info into one.
Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

Total time: 283.36
  Computation time       Total: 308.212     Ratio: 108.77%
  Framework overhead     Total: -24.8519    Ratio: -8.77043%

-------------------------     GpuMemCpy Summary     -------------------------

GpuMemcpy                Calls: 1010        Total: 48.4536     Ratio: 17.0996%
  GpuMemcpyAsync         Calls: 1010        Total: 48.4536     Ratio: 17.0996%

-------------------------       Event Summary       -------------------------

Event                                                       Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
ParallelExecutor::Run                                       101         252.018     213.998650 (0.849140)   38.019367 (0.150860)    1.92219     18.9717     2.49523     0.889391    
  sgd                                                       808         69.489      67.924036 (0.977479)    1.564934 (0.022521)     0.052489    0.609431    0.0860012   0.245232    
    sgd/compute                                             808         50.1686     48.603663 (0.968807)    1.564934 (0.031193)     0.036338    0.586896    0.0620898   0.177049    
    sgd/infer_shape                                         808         5.33121     5.331206 (1.000000)     0.000000 (0.000000)     0.003979    0.077721    0.00659803  0.0188142   
    sgd/prepare_data                                        808         2.20663     2.206631 (1.000000)     0.000000 (0.000000)     0.00156     0.028646    0.00273098  0.00778737  
  eager_deletion                                            2525        64.8066     64.806632 (1.000000)    0.000000 (0.000000)     0.002863    0.840161    0.025666    0.228708    
  mean                                                      404         61.8447     60.512483 (0.978459)    1.332169 (0.021541)     0.062434    1.26818     0.153081    0.218255    
    mean/compute                                            404         52.1264     50.794270 (0.974444)    1.332169 (0.025556)     0.051081    1.2281      0.129026    0.183958    
    mean/infer_shape                                        404         2.16366     2.163659 (1.000000)     0.000000 (0.000000)     0.002144    0.400586    0.00535559  0.00763572  
    mean/prepare_data                                       404         1.43627     1.436273 (1.000000)     0.000000 (0.000000)     0.001338    0.190212    0.00355513  0.00506872  
  fused_all_reduce                                          101         51.5964     28.214688 (0.546834)    23.381719 (0.453166)    0.393805    1.43119     0.510856    0.182088    
  Fetch                                                     101         38.8271     37.956839 (0.977587)    0.870243 (0.022413)     0.288826    1.13474     0.384427    0.137024    
    GpuMemcpyAsync:GPU->CPU                                 404         20.9701     20.099873 (0.958501)    0.870243 (0.041499)     0.033541    0.841356    0.0519062   0.0740052   
  mul                                                       404         37.1503     35.294986 (0.950060)    1.855304 (0.049940)     0.070873    0.47856     0.0919562   0.131106    
    mul/compute                                             404         26.8528     24.997533 (0.930908)    1.855304 (0.069092)     0.051788    0.429212    0.0664674   0.0947658   
    mul/infer_shape                                         404         3.40059     3.400591 (1.000000)     0.000000 (0.000000)     0.006506    0.059252    0.0084173   0.012001    
    mul/prepare_data                                        404         1.09492     1.094916 (1.000000)     0.000000 (0.000000)     0.001505    0.021974    0.00271019  0.00386404  
  mean_grad                                                 404         36.0132     35.004058 (0.971978)    1.009159 (0.028022)     0.052266    0.769423    0.0891416   0.127093    
    mean_grad/compute                                       404         24.3422     23.333037 (0.958543)    1.009159 (0.041457)     0.037928    0.727382    0.060253    0.0859055   
    mean_grad/infer_shape                                   404         3.1129      3.112896 (1.000000)     0.000000 (0.000000)     0.003569    0.256055    0.00770519  0.0109857   
    mean_grad/prepare_data                                  404         2.31923     2.319225 (1.000000)     0.000000 (0.000000)     0.001354    0.231534    0.00574066  0.00818473  
  elementwise_add                                           404         33.8471     32.839607 (0.970234)    1.007493 (0.029766)     0.067468    0.225151    0.08378     0.119449    
    elementwise_add/compute                                 404         25.2547     24.247168 (0.960107)    1.007493 (0.039893)     0.049591    0.205667    0.0625115   0.0891257   
    elementwise_add/infer_shape                             404         3.32483     3.324835 (1.000000)     0.000000 (0.000000)     0.006987    0.022292    0.00822979  0.0117336   
    elementwise_add/prepare_data                            404         0.789441    0.789441 (1.000000)     0.000000 (0.000000)     0.001334    0.067954    0.00195406  0.002786    
  elementwise_add_grad                                      404         33.7536     32.105894 (0.951185)    1.647687 (0.048815)     0.05726     0.486006    0.0835485   0.119119    
    elementwise_add_grad/compute                            404         24.3042     22.656513 (0.932206)    1.647687 (0.067794)     0.04267     0.469235    0.0601589   0.0857714   
    elementwise_add_grad/infer_shape                        404         2.20565     2.205648 (1.000000)     0.000000 (0.000000)     0.003497    0.217639    0.00545952  0.00778391  
    elementwise_add_grad/prepare_data                       404         1.67869     1.678690 (1.000000)     0.000000 (0.000000)     0.001333    0.27289     0.00415517  0.00592423  
  Scale LossGrad                                            404         33.6812     33.316892 (0.989184)    0.364293 (0.010816)     0.037688    1.43339     0.0833693   0.118864    
    GpuMemcpyAsync:CPU->GPU                                 404         18.8977     18.533368 (0.980723)    0.364293 (0.019277)     0.022363    1.40327     0.0467764   0.0666913   
  square_grad                                               404         33.6594     32.634097 (0.969539)    1.025288 (0.030461)     0.050742    0.635562    0.0833153   0.118787    
    square_grad/compute                                     404         26.9496     25.924294 (0.961955)    1.025288 (0.038045)     0.038351    0.615405    0.0667069   0.0951072   
    square_grad/infer_shape                                 404         1.62465     1.624648 (1.000000)     0.000000 (0.000000)     0.003098    0.06289     0.00402141  0.00573351  
    square_grad/prepare_data                                404         0.707922    0.707922 (1.000000)     0.000000 (0.000000)     0.001285    0.058798    0.00175228  0.00249831  
  mul_grad                                                  404         30.0936     28.808749 (0.957305)    1.284835 (0.042695)     0.059035    0.319572    0.0744891   0.106203    
    mul_grad/compute                                        404         22.335      21.050129 (0.942474)    1.284835 (0.057526)     0.044072    0.116937    0.0552846   0.0788218   
    mul_grad/infer_shape                                    404         2.16482     2.164815 (1.000000)     0.000000 (0.000000)     0.003977    0.096564    0.00535845  0.0076398   
    mul_grad/prepare_data                                   404         1.28536     1.285362 (1.000000)     0.000000 (0.000000)     0.001266    0.229127    0.00318159  0.00453614  
  elementwise_sub_grad                                      404         28.5152     27.695528 (0.971257)    0.819622 (0.028743)     0.049448    0.311572    0.0705821   0.100632    
    elementwise_sub_grad/compute                            404         20.4459     19.626288 (0.959913)    0.819622 (0.040087)     0.035297    0.196554    0.0506087   0.0721552   
    elementwise_sub_grad/infer_shape                        404         2.0822      2.082200 (1.000000)     0.000000 (0.000000)     0.003657    0.102627    0.00515396  0.00734825  
    elementwise_sub_grad/prepare_data                       404         0.836329    0.836329 (1.000000)     0.000000 (0.000000)     0.00141     0.058499    0.00207012  0.00295147  
  elementwise_sub                                           404         25.297      24.501416 (0.968550)    0.795588 (0.031450)     0.045065    0.29609     0.0626163   0.0892751   
    elementwise_sub/compute                                 404         16.5399     15.744307 (0.951899)    0.795588 (0.048101)     0.031126    0.245642    0.0409403   0.0583706   
    elementwise_sub/infer_shape                             404         2.59911     2.599115 (1.000000)     0.000000 (0.000000)     0.004148    0.122978    0.00643345  0.00917248  
    elementwise_sub/prepare_data                            404         2.03608     2.036077 (1.000000)     0.000000 (0.000000)     0.001314    0.226062    0.00503979  0.00718548  
  square                                                    404         24.585      23.586649 (0.959392)    0.998345 (0.040608)     0.049034    0.594126    0.0608539   0.0867624   
    square/compute                                          404         18.3591     17.360708 (0.945621)    0.998345 (0.054379)     0.037321    0.145106    0.0454432   0.0647905   
    square/infer_shape                                      404         1.3298      1.329801 (1.000000)     0.000000 (0.000000)     0.002608    0.019914    0.00329159  0.00469297  
    square/prepare_data                                     404         0.731172    0.731172 (1.000000)     0.000000 (0.000000)     0.001309    0.03101     0.00180983  0.00258036  
  FastThreadedSSAGraphExecutorPrepare                       101         16.2028     16.140133 (0.996131)    0.062688 (0.003869)     0.030768    11.8768     0.160424    0.057181    
  InitLocalVars                                             2           1.00266     1.002662 (1.000000)     0.000000 (0.000000)     0.318218    0.684444    0.501331    0.00353847  
    coalesce_tensor                                         8           0.734838    0.734838 (1.000000)     0.000000 (0.000000)     0.031506    0.188881    0.0918547   0.0025933   
      coalesce_tensor/compute                               8           0.533647    0.533647 (1.000000)     0.000000 (0.000000)     0.016358    0.140149    0.0667059   0.00188328  
      coalesce_tensor/prepare_data                          8           0.031694    0.031694 (1.000000)     0.000000 (0.000000)     0.002509    0.008106    0.00396175  0.000111851 
      coalesce_tensor/infer_shape                           8           0.025378    0.025378 (1.000000)     0.000000 (0.000000)     0.001057    0.00843     0.00317225  8.9561e-05  
  ScopeBufferedMonitor::post_local_exec_scopes_process      101         0.661377    0.661377 (1.000000)     0.000000 (0.000000)     0.005516    0.014467    0.00654829  0.00233405  
  ScopeBufferedMonitor::pre_local_exec_scopes_process       101         0.377346    0.377346 (1.000000)     0.000000 (0.000000)     0.002414    0.019412    0.0037361   0.00133168  
  DropLocalExeScopes                                        1           0.075909    0.075909 (1.000000)     0.000000 (0.000000)     0.075909    0.075909    0.075909    0.000267889 
GpuMemcpyPeerAsync:GPU->GPU                                 606         22.7563     22.756298 (1.000000)    0.000000 (0.000000)     0.028132    1.00743     0.0375516   0.0803088   
GpuMemcpyAsync(same_gpu):GPU->GPU                           202         8.58577     8.219407 (0.957328)     0.366368 (0.042672)     0.033658    0.105725    0.0425038   0.0302999   
```
**解决方法**：因此在这种情况下，修改统计方式如下：
- Elapsed time of events = PE::Run的时间 + 与PE::Run同级的其他event时间。这是真实的运行时间
- Accumulated time of events = PE::Run下面所有第一层event的时间 + 与PE::Run同级的其他event时间
- 计算开销 = PE::Run下面所有OP的计算时间之和
- 框架开销 =  Accumulated time of events -  计算开销 

**测试结果**
- 使用PE时，由于累加所有event的时间，则`Accumulated time of events`可能会超出`Elapsed time of events`的总时间，因此会对这种情况打出说明。
```
------------------------->     Profiling Report     <-------------------------

Note! This Report merge all thread info into one.
Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

-------------------------       Overhead Summary       -------------------------

The Overhead Summary divides the cost of each event into framework overhead or computation time.
The `Accumulated time of events` is higher than the `Elapsed time of events`.
Because the OP is executed asynchronously. For example,
Event                   Timeline
ParallelExecutor::Run   ---------------------------------------------------------
  thread1::OP1                 -----------------------------
  thread2::OP2                      ---------------------------------------------
OP1.time + OP2.time > ParallelExecutor::Run.time

Elapsed time of events: 318.515
Accumulated time of events: 700.157
  Computation time       Total: 325.922     Ratio: 46.5499%
  Framework overhead     Total: 374.235     Ratio: 53.4501%

-------------------------     GpuMemCpy Summary     -------------------------

GpuMemcpy                Calls: 1010        Total: 51.7275     Ratio: 16.2402%
  GpuMemcpyAsync         Calls: 1010        Total: 51.7275     Ratio: 16.2402%

-------------------------       Event Summary       -------------------------

Event                                                       Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
ParallelExecutor::Run                                       101         287.239     246.964806 (0.859790)   40.273860 (0.140210)    1.91504     25.7137     2.84395     0.901805    
  sgd                                                       808         71.1351     69.572274 (0.978031)    1.562790 (0.021969)     0.05137     0.971534    0.0880384   0.223333    
    sgd/compute                                             808         50.2732     48.710380 (0.968914)    1.562790 (0.031086)     0.035033    0.926918    0.0622193   0.157836    
    sgd/infer_shape                                         808         5.30956     5.309556 (1.000000)     0.000000 (0.000000)     0.003665    0.048278    0.00657123  0.0166697   
    sgd/prepare_data                                        808         2.80657     2.806575 (1.000000)     0.000000 (0.000000)     0.001469    0.213608    0.00347348  0.00881143  
  eager_deletion                                            2525        65.6136     65.613633 (1.000000)    0.000000 (0.000000)     0.003102    1.0336      0.0259856   0.205998    
  mean                                                      404         63.9552     62.579759 (0.978494)    1.375399 (0.021506)     0.064581    1.3907      0.158305    0.200792    
    mean/compute                                            404         53.5413     52.165896 (0.974311)    1.375399 (0.025689)     0.05155     1.37257     0.132528    0.168096    
    mean/infer_shape                                        404         2.11314     2.113139 (1.000000)     0.000000 (0.000000)     0.001968    0.132298    0.00523054  0.00663434  
    mean/prepare_data                                       404         1.52617     1.526170 (1.000000)     0.000000 (0.000000)     0.001355    0.213159    0.00377765  0.00479151  
  fused_all_reduce                                          101         56.1997     30.653997 (0.545447)    25.545731 (0.454553)    0.404376    1.07337     0.556433    0.176443    
  Fetch                                                     101         44.7079     43.820028 (0.980140)    0.887882 (0.019860)     0.277265    6.35805     0.442653    0.140363    
    GpuMemcpyAsync:GPU->CPU                                 404         21.0924     20.204505 (0.957905)    0.887882 (0.042095)     0.034091    0.182868    0.0522089   0.066221    
  mul                                                       404         44.5065     42.629058 (0.957817)    1.877416 (0.042183)     0.068884    1.94009     0.110165    0.139731    
    mul/compute                                             404         31.0676     29.190174 (0.939570)    1.877416 (0.060430)     0.051018    1.00242     0.0769      0.0975388   
    mul/infer_shape                                         404         4.7345      4.734504 (1.000000)     0.000000 (0.000000)     0.00583     0.745505    0.0117191   0.0148643   
    mul/prepare_data                                        404         1.40533     1.405327 (1.000000)     0.000000 (0.000000)     0.001463    0.289287    0.00347853  0.00441212  
  mean_grad                                                 404         38.7339     37.730771 (0.974102)    1.003145 (0.025898)     0.05294     1.94291     0.095876    0.121608    
    mean_grad/compute                                       404         26.3596     25.356429 (0.961944)    1.003145 (0.038056)     0.037558    0.969785    0.0652465   0.0827577   
    mean_grad/infer_shape                                   404         3.96678     3.966783 (1.000000)     0.000000 (0.000000)     0.003735    1.31657     0.00981877  0.012454    
    mean_grad/prepare_data                                  404         1.85732     1.857319 (1.000000)     0.000000 (0.000000)     0.001447    0.212299    0.00459732  0.00583118  
  elementwise_add                                           404         37.5807     36.603619 (0.974000)    0.977094 (0.026000)     0.066413    0.747173    0.0930216   0.117987    
    elementwise_add/compute                                 404         28.2786     27.301554 (0.965448)    0.977094 (0.034552)     0.048407    0.710529    0.0699967   0.0887827   
    elementwise_add/infer_shape                             404         3.70431     3.704314 (1.000000)     0.000000 (0.000000)     0.006953    0.049728    0.00916909  0.0116299   
    elementwise_add/prepare_data                            404         0.867949    0.867949 (1.000000)     0.000000 (0.000000)     0.001368    0.015853    0.00214839  0.00272498  
  elementwise_add_grad                                      404         37.4647     35.816582 (0.956010)    1.648071 (0.043990)     0.057458    0.617826    0.0927343   0.117623    
    elementwise_add_grad/compute                            404         25.7121     24.063995 (0.935903)    1.648071 (0.064097)     0.04255     0.592051    0.0636437   0.0807248   
    elementwise_add_grad/infer_shape                        404         3.57705     3.577046 (1.000000)     0.000000 (0.000000)     0.00369     0.52115     0.00885407  0.0112304   
    elementwise_add_grad/prepare_data                       404         2.3837      2.383698 (1.000000)     0.000000 (0.000000)     0.00137     0.280906    0.00590024  0.00748378  
  Scale LossGrad                                            404         36.8363     36.467547 (0.989991)    0.368710 (0.010009)     0.038554    0.927321    0.0911789   0.11565     
    GpuMemcpyAsync:CPU->GPU                                 404         21.9031     21.534426 (0.983166)    0.368710 (0.016834)     0.022411    0.640125    0.0542157   0.0687664   
  square_grad                                               404         34.834      33.824006 (0.971005)    1.010023 (0.028995)     0.048772    0.454574    0.0862228   0.109364    
    square_grad/compute                                     404         27.5282     26.518171 (0.963310)    1.010023 (0.036690)     0.035902    0.441383    0.0681391   0.0864266   
    square_grad/infer_shape                                 404         1.96123     1.961230 (1.000000)     0.000000 (0.000000)     0.003163    0.256155    0.00485453  0.00615741  
    square_grad/prepare_data                                404         0.773251    0.773251 (1.000000)     0.000000 (0.000000)     0.001348    0.021702    0.00191399  0.00242767  
  mul_grad                                                  404         33.5663     32.252644 (0.960863)    1.313671 (0.039137)     0.059304    0.846595    0.0830849   0.105384    
    mul_grad/compute                                        404         24.4014     23.087747 (0.946164)    1.313671 (0.053836)     0.044676    0.828259    0.0603995   0.0766099   
    mul_grad/infer_shape                                    404         2.46039     2.460388 (1.000000)     0.000000 (0.000000)     0.004121    0.187394    0.00609007  0.00772455  
    mul_grad/prepare_data                                   404         1.02246     1.022462 (1.000000)     0.000000 (0.000000)     0.001345    0.076278    0.00253085  0.00321009  
  elementwise_sub_grad                                      404         31.039      30.212049 (0.973357)    0.826987 (0.026643)     0.048809    1.71555     0.0768293   0.0974491   
    elementwise_sub_grad/compute                            404         22.2551     21.428097 (0.962841)    0.826987 (0.037159)     0.034412    1.69659     0.0550868   0.0698713   
    elementwise_sub_grad/infer_shape                        404         2.29374     2.293739 (1.000000)     0.000000 (0.000000)     0.003682    0.249344    0.00567757  0.00720135  
    elementwise_sub_grad/prepare_data                       404         0.944735    0.944735 (1.000000)     0.000000 (0.000000)     0.00144     0.098499    0.00233845  0.00296606  
  elementwise_sub                                           404         27.0167     26.197502 (0.969677)    0.819239 (0.030323)     0.046129    0.697821    0.0668731   0.0848209   
    elementwise_sub/compute                                 404         16.9297     16.110505 (0.951609)    0.819239 (0.048391)     0.030826    0.454733    0.0419053   0.0531521   
    elementwise_sub/infer_shape                             404         2.94159     2.941587 (1.000000)     0.000000 (0.000000)     0.004497    0.218608    0.00728116  0.00923531  
    elementwise_sub/prepare_data                            404         1.58997     1.589971 (1.000000)     0.000000 (0.000000)     0.00131     0.267379    0.00393557  0.00499182  
  square                                                    404         25.7254     24.731882 (0.961379)    0.993542 (0.038621)     0.048383    0.33466     0.0636768   0.0807667   
    square/compute                                          404         19.0487     18.055188 (0.947842)    0.993542 (0.052158)     0.036716    0.219042    0.0471503   0.0598048   
    square/infer_shape                                      404         1.54825     1.548248 (1.000000)     0.000000 (0.000000)     0.002573    0.126951    0.0038323   0.00486083  
    square/prepare_data                                     404         1.14926     1.149261 (1.000000)     0.000000 (0.000000)     0.001335    0.265066    0.00284471  0.00360818  
  FastThreadedSSAGraphExecutorPrepare                       101         17.6515     17.587369 (0.996365)    0.064160 (0.003635)     0.033855    12.7612     0.174768    0.0554182   
  InitLocalVars                                             2           1.03343     1.033434 (1.000000)     0.000000 (0.000000)     0.31439     0.719044    0.516717    0.00324454  
    coalesce_tensor                                         8           0.744229    0.744229 (1.000000)     0.000000 (0.000000)     0.032939    0.183407    0.0930286   0.00233656  
      coalesce_tensor/compute                               8           0.526845    0.526845 (1.000000)     0.000000 (0.000000)     0.017261    0.142144    0.0658556   0.00165407  
      coalesce_tensor/prepare_data                          8           0.027531    0.027531 (1.000000)     0.000000 (0.000000)     0.002406    0.005255    0.00344138  8.64354e-05 
      coalesce_tensor/infer_shape                           8           0.020868    0.020868 (1.000000)     0.000000 (0.000000)     0.001286    0.010603    0.0026085   6.55165e-05 
  ScopeBufferedMonitor::post_local_exec_scopes_process      101         0.801446    0.801446 (1.000000)     0.000000 (0.000000)     0.00573     0.025676    0.00793511  0.00251619  
  ScopeBufferedMonitor::pre_local_exec_scopes_process       101         0.383996    0.383996 (1.000000)     0.000000 (0.000000)     0.002612    0.012577    0.00380194  0.00120558  
  DropLocalExeScopes                                        1           0.095075    0.095075 (1.000000)     0.000000 (0.000000)     0.095075    0.095075    0.095075    0.000298494 
GpuMemcpyPeerAsync:GPU->GPU                                 606         22.5446     22.544607 (1.000000)    0.000000 (0.000000)     0.027808    0.089058    0.0372023   0.0707803   
GpuMemcpyAsync(same_gpu):GPU->GPU                           202         8.73195     8.366481 (0.958145)     0.365474 (0.041855)     0.033028    0.162869    0.0432275   0.0274146   

```
- 不使用PE时，依然使用`Total time`，并且不会打印Overhead Summary中的说明文字。
```
------------------------->     Profiling Report     <-------------------------

Place: All
Time unit: ms
Sorted by total time in descending order in the same thread

-------------------------     Overhead Summary      -------------------------

Total time: 113.014
  Computation time       Total: 70.4321     Ratio: 62.3217%
  Framework overhead     Total: 42.5817     Ratio: 37.6783%

-------------------------     GpuMemCpy Summary     -------------------------

GpuMemcpy                Calls: 101         Total: 6.19812     Ratio: 5.48439%
  GpuMemcpySync          Calls: 101         Total: 6.19812     Ratio: 5.48439%

-------------------------       Event Summary       -------------------------

Event                                             Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
thread0::sgd                                      202         13.2494     12.863907 (0.970909)    0.385443 (0.029091)     0.054122    0.223713    0.0655908   0.117237    
  thread0::sgd/compute                            202         8.38116     7.995721 (0.954011)     0.385443 (0.045989)     0.034825    0.068528    0.0414909   0.0741606   
  thread0::sgd/prepare_data                       202         0.965246    0.965246 (1.000000)     0.000000 (0.000000)     0.003063    0.145243    0.00477845  0.00854096  
  thread0::sgd/infer_shape                        202         0.951762    0.951762 (1.000000)     0.000000 (0.000000)     0.003592    0.02222     0.00471169  0.00842165  
thread0::mul                                      101         12.1206     11.095870 (0.915457)    1.024711 (0.084543)     0.093702    0.617461    0.120006    0.107249    
  thread0::mul/compute                            101         8.56022     7.535508 (0.880294)     1.024711 (0.119706)     0.069519    0.210997    0.0847546   0.0757449   
  thread0::mul/infer_shape                        101         0.81799     0.817990 (1.000000)     0.000000 (0.000000)     0.006153    0.027186    0.00809891  0.00723797  
  thread0::mul/prepare_data                       101         0.46656     0.466560 (1.000000)     0.000000 (0.000000)     0.003442    0.02067     0.00461941  0.00412835  
thread0::elementwise_add                          101         10.0003     9.758456 (0.975812)     0.241890 (0.024188)     0.081819    0.322989    0.0990133   0.0884879   
  thread0::elementwise_add/compute                101         7.04423     6.802338 (0.965661)     0.241890 (0.034339)     0.056004    0.283644    0.0697448   0.0623307   
  thread0::elementwise_add/infer_shape            101         0.848194    0.848194 (1.000000)     0.000000 (0.000000)     0.007172    0.016275    0.00839796  0.00750523  
  thread0::elementwise_add/prepare_data           101         0.404719    0.404719 (1.000000)     0.000000 (0.000000)     0.002954    0.014897    0.00400712  0.00358115  
thread0::fetch                                    101         9.45005     9.234689 (0.977211)     0.215361 (0.022789)     0.067727    0.990343    0.0935649   0.0836186   
  GpuMemcpySync:GPU->CPU                          101         6.19812     5.982755 (0.965254)     0.215361 (0.034746)     0.049004    0.107011    0.0613675   0.0548439   
thread0::mul_grad                                 101         9.3886      8.367696 (0.891261)     1.020905 (0.108739)     0.084127    0.120381    0.0929564   0.0830748   
  thread0::mul_grad/compute                       101         6.99518     5.974275 (0.854056)     1.020905 (0.145944)     0.062831    0.095201    0.0692592   0.0618967   
  thread0::mul_grad/infer_shape                   101         0.508196    0.508196 (1.000000)     0.000000 (0.000000)     0.00426     0.022526    0.00503164  0.00449676  
  thread0::mul_grad/prepare_data                  101         0.320011    0.320011 (1.000000)     0.000000 (0.000000)     0.002873    0.003911    0.00316843  0.00283161  
thread0::mean                                     101         8.44128     8.137379 (0.963998)     0.303905 (0.036002)     0.071231    0.167118    0.0835771   0.0746925   
  thread0::mean/compute                           101         6.37641     6.072501 (0.952339)     0.303905 (0.047661)     0.054102    0.144761    0.0631327   0.0564215   
  thread0::mean/infer_shape                       101         0.329867    0.329867 (1.000000)     0.000000 (0.000000)     0.002677    0.00442     0.00326601  0.00291882  
  thread0::mean/prepare_data                      101         0.281569    0.281569 (1.000000)     0.000000 (0.000000)     0.002273    0.003419    0.00278781  0.00249146  
thread0::elementwise_add_grad                     101         8.04027     7.658538 (0.952522)     0.381732 (0.047478)     0.069253    0.207925    0.0796066   0.0711442   
  thread0::elementwise_add_grad/compute           101         5.51815     5.136418 (0.930822)     0.381732 (0.069178)     0.048527    0.090672    0.0546351   0.0488272   
  thread0::elementwise_add_grad/prepare_data      101         0.538485    0.538485 (1.000000)     0.000000 (0.000000)     0.003212    0.119121    0.00533153  0.00476477  
  thread0::elementwise_add_grad/infer_shape       101         0.438175    0.438175 (1.000000)     0.000000 (0.000000)     0.00353     0.021711    0.00433837  0.00387718  
thread0::fill_constant                            101         7.17655     6.975200 (0.971944)     0.201345 (0.028056)     0.060367    0.097833    0.0710549   0.0635015   
  thread0::fill_constant/compute                  101         5.10615     4.904804 (0.960568)     0.201345 (0.039432)     0.043084    0.076745    0.0505559   0.0451817   
  thread0::fill_constant/infer_shape              101         0.484222    0.484222 (1.000000)     0.000000 (0.000000)     0.0041      0.006107    0.00479428  0.00428463  
  thread0::fill_constant/prepare_data             101         0.34172     0.341720 (1.000000)     0.000000 (0.000000)     0.002363    0.020399    0.00338337  0.0030237   
thread0::elementwise_sub_grad                     101         6.87401     6.655898 (0.968270)     0.218112 (0.031730)     0.059441    0.09097     0.0680595   0.0608245   
  thread0::elementwise_sub_grad/compute           101         4.498       4.279891 (0.951509)     0.218112 (0.048491)     0.038606    0.065344    0.0445347   0.0398005   
  thread0::elementwise_sub_grad/prepare_data      101         0.432625    0.432625 (1.000000)     0.000000 (0.000000)     0.003686    0.016085    0.00428342  0.00382807  
  thread0::elementwise_sub_grad/infer_shape       101         0.42706     0.427060 (1.000000)     0.000000 (0.000000)     0.003695    0.015945    0.00422832  0.00377883  
thread0::square_grad                              101         6.83659     6.590478 (0.964000)     0.246114 (0.036000)     0.058088    0.14232     0.067689    0.0604934   
  thread0::square_grad/compute                    101         4.68703     4.440913 (0.947490)     0.246114 (0.052510)     0.040266    0.085618    0.0464062   0.0414731   
  thread0::square_grad/prepare_data               101         0.375348    0.375348 (1.000000)     0.000000 (0.000000)     0.002578    0.019118    0.00371632  0.00332126  
  thread0::square_grad/infer_shape                101         0.344221    0.344221 (1.000000)     0.000000 (0.000000)     0.002903    0.020857    0.00340813  0.00304583  
thread0::square                                   101         6.70329     6.459606 (0.963648)     0.243680 (0.036352)     0.055751    0.107108    0.0663692   0.0593139   
  thread0::square/compute                         101         4.58683     4.343153 (0.946874)     0.243680 (0.053126)     0.038609    0.074574    0.0454142   0.0405865   
  thread0::square/prepare_data                    101         0.366302    0.366302 (1.000000)     0.000000 (0.000000)     0.002643    0.024842    0.00362675  0.00324122  
  thread0::square/infer_shape                     101         0.300453    0.300453 (1.000000)     0.000000 (0.000000)     0.002629    0.004087    0.00297478  0.00265855  
thread0::elementwise_sub                          101         6.67508     6.459531 (0.967708)     0.215553 (0.032292)     0.05651     0.101731    0.0660899   0.0590643   
  thread0::elementwise_sub/compute                101         4.31841     4.102857 (0.950085)     0.215553 (0.049915)     0.036866    0.064492    0.0427565   0.0382114   
  thread0::elementwise_sub/infer_shape            101         0.539652    0.539652 (1.000000)     0.000000 (0.000000)     0.004682    0.01572     0.00534309  0.0047751   
  thread0::elementwise_sub/prepare_data           101         0.374585    0.374585 (1.000000)     0.000000 (0.000000)     0.002706    0.034722    0.00370876  0.00331451  
thread0::mean_grad                                101         6.62688     6.380638 (0.962842)     0.246241 (0.037158)     0.057557    0.089747    0.0656127   0.0586378   
  thread0::mean_grad/compute                      101         4.36032     4.114076 (0.943527)     0.246241 (0.056473)     0.037697    0.068337    0.0431715   0.0385822   
  thread0::mean_grad/infer_shape                  101         0.402563    0.402563 (1.000000)     0.000000 (0.000000)     0.003564    0.004913    0.00398577  0.00356207  
  thread0::mean_grad/prepare_data                 101         0.381873    0.381873 (1.000000)     0.000000 (0.000000)     0.003195    0.004491    0.00378092  0.003379    
thread0::feed                                     202         1.43089     1.430893 (1.000000)     0.000000 (0.000000)     0.002635    0.032524    0.00708363  0.0126612   
```
