### PR TITLE
Fix bug in ShareBufferWith causing non-fp32 inplace uts to fail

### DIFF
--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -158,6 +158,7 @@ class Tensor {
   void ShareBufferWith(const Tensor& tensor) {
     holder_ = tensor.holder_;
     offset_ = tensor.offset_;
+    type_ = tensor.type_;
   }
 
   bool IsSharedBufferWith(const Tensor& src) const {


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: APIs
<!--  Describe what this PR does  -->
Describe: During call to ShareBufferWith, the type wasn't assigned when holders were assigned. This causes inplace UTs that use non-fp32 tensors (for example int8, uint8) to fail on FetchOp.
