### PR TITLE
Fix OpTester from incorrectly converting uint8 data to utf-8 string

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -308,7 +308,6 @@ class OpTest(unittest.TestCase):
                 else:
                     tensor.set(self.inputs[var_name], place)
                 feed_map[var_name] = tensor
-
         return feed_map
 
     def _append_ops(self, block):
@@ -630,24 +629,23 @@ class OpTest(unittest.TestCase):
             # computational consistency.
             # When inplace_atol is not None, the inplace check uses numpy.allclose
             # to check inplace result instead of numpy.array_equal.
+            expect_out = np.array(expect_outs[i])
+            actual_out = np.array(actual_outs[i])
             if inplace_atol is not None:
                 self.assertTrue(
                     np.allclose(
-                        np.array(expect_outs[i]),
-                        np.array(actual_outs[i]),
-                        atol=inplace_atol),
+                        expect_out, actual_out, atol=inplace_atol),
                     "Output (" + name + ") has diff at " + str(place) +
                     " when using and not using inplace" + "\nExpect " +
-                    str(expect_outs[i]) + "\n" + "But Got" + str(actual_outs[i])
-                    + " in class " + self.__class__.__name__)
+                    str(expect_out) + "\n" + "But Got" + str(actual_out) +
+                    " in class " + self.__class__.__name__)
             else:
                 self.assertTrue(
-                    np.array_equal(
-                        np.array(expect_outs[i]), np.array(actual_outs[i])),
+                    np.array_equal(expect_out, actual_out),
                     "Output (" + name + ") has diff at " + str(place) +
                     " when using and not using inplace" + "\nExpect " +
-                    str(expect_outs[i]) + "\n" + "But Got" + str(actual_outs[i])
-                    + " in class " + self.__class__.__name__ + '\n')
+                    str(expect_out) + "\n" + "But Got" + str(actual_out) +
+                    " in class " + self.__class__.__name__ + '\n')
 
     def _construct_grad_program_from_forward(self, fwd_program, grad_op_desc,
                                              op_grad_to_var):


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: Bug fixes
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: APIs
<!--  Describe what this PR does  -->
Describe: When uint8 datatype is to be outputted in the message by `_compare_expect_and_actual_outputs`, direct cast using str(), causes to throw an error related to encoding (data is incorrectly treated as array of characters instead of array of numbers). To mitigate this, the data is cast to np.array which then can be safely cast to string.
