### PR TITLE
[Dy2Static] Support for iter & enumerate VarBase

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -418,9 +418,9 @@ class LoopTransformer(gast.NodeTransformer):
 
         # 1. check whether need to transform
         # NOTE: Current need transform cases:
-        #   1). for x in range(VarBase.numpy()[0])
-        #   2). for x in VarBase.numpy()
-        #   3). for i, x in enumerate(VarBase.numpy())
+        #   1). for x in range(VarBase[0]|VarBase.numpy()[0])
+        #   2). for x in VarBase|VarBase.numpy()
+        #   3). for i, x in enumerate(VarBase|VarBase.numpy())
         if not self.name_visitor.is_control_flow_loop(node):
             return [node]
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_for_enumerate.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_for_enumerate.py
@@ -24,9 +24,9 @@ from paddle.fluid.dygraph.jit import declarative
 program_translator = ProgramTranslator()
 
 
-# 0. for in range with var case
+# 0. for in range var.numpy()[0]
 @declarative
-def dygraph_for_in_range(x):
+def for_in_range(x):
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x = fluid.dygraph.to_variable(x)
     for i in range(x.numpy()[0]):
@@ -36,7 +36,7 @@ def dygraph_for_in_range(x):
 
 # 1. for iter list 
 @declarative
-def dygraph_for_iter_list(x_array):
+def for_iter_list(x_array):
     z = fluid.layers.fill_constant([1], 'int32', 0)
     for x in x_array:
         z = z + x
@@ -45,7 +45,7 @@ def dygraph_for_iter_list(x_array):
 
 # 2. for enumerate list
 @declarative
-def dygraph_for_enumerate_list(x_array):
+def for_enumerate_list(x_array):
     z = fluid.layers.fill_constant([1], 'int32', 0)
     for i, x in enumerate(x_array):
         z = z + x + i
@@ -54,7 +54,7 @@ def dygraph_for_enumerate_list(x_array):
 
 # 3. for iter var.numpy()
 @declarative
-def dygraph_for_iter_var_numpy(x_array):
+def for_iter_var_numpy(x_array):
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
     for x in x_array.numpy():
@@ -64,7 +64,7 @@ def dygraph_for_iter_var_numpy(x_array):
 
 # 4. for enumerate var.numpy()
 @declarative
-def dygraph_for_enumerate_var_numpy(x_array):
+def for_enumerate_var_numpy(x_array):
     y = fluid.layers.fill_constant([1], 'int32', 0)
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
@@ -76,7 +76,7 @@ def dygraph_for_enumerate_var_numpy(x_array):
 
 # 5. for enumerate var.numpy() with start
 @declarative
-def dygraph_for_enumerate_var_numpy_with_start(x_array):
+def for_enumerate_var_numpy_with_start(x_array):
     y = fluid.layers.fill_constant([1], 'int32', 0)
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
@@ -88,7 +88,7 @@ def dygraph_for_enumerate_var_numpy_with_start(x_array):
 
 # 6. for in range with break
 @declarative
-def dygraph_for_in_range_with_break(x):
+def for_in_range_with_break(x):
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x = fluid.dygraph.to_variable(x)
     for i in range(x.numpy()[0]):
@@ -100,7 +100,7 @@ def dygraph_for_in_range_with_break(x):
 
 # 7. for enumerate var.numpy() with break
 @declarative
-def dygraph_for_enumerate_var_numpy_with_break(x_array):
+def for_enumerate_var_numpy_with_break(x_array):
     y = fluid.layers.fill_constant([1], 'int32', 0)
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
@@ -114,7 +114,7 @@ def dygraph_for_enumerate_var_numpy_with_break(x_array):
 
 # 8. for enumerate var.numpy() with continue
 @declarative
-def dygraph_for_enumerate_var_numpy_with_continue(x_array):
+def for_enumerate_var_numpy_with_continue(x_array):
     y = fluid.layers.fill_constant([1], 'int32', 0)
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
@@ -128,7 +128,7 @@ def dygraph_for_enumerate_var_numpy_with_continue(x_array):
 
 # 9. for enumerate var.numpy() with start & break
 @declarative
-def dygraph_for_enumerate_var_numpy_with_start_break(x_array):
+def for_enumerate_var_numpy_with_start_break(x_array):
     y = fluid.layers.fill_constant([1], 'int32', 0)
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
@@ -142,7 +142,7 @@ def dygraph_for_enumerate_var_numpy_with_start_break(x_array):
 
 # 10. for enumerate var.numpy() with start & continue
 @declarative
-def dygraph_for_enumerate_var_numpy_with_start_continue(x_array):
+def for_enumerate_var_numpy_with_start_continue(x_array):
     y = fluid.layers.fill_constant([1], 'int32', 0)
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
@@ -150,6 +150,28 @@ def dygraph_for_enumerate_var_numpy_with_start_continue(x_array):
         y = y + i
         if i > 2:
             continue
+        z = z + x
+    return y, z
+
+
+# 11. for iter var
+@declarative
+def for_iter_var(x_array):
+    z = fluid.layers.fill_constant([1], 'int32', 0)
+    x_array = fluid.dygraph.to_variable(x_array)
+    for x in x_array:
+        z = z + x
+    return z
+
+
+# 12. for enumerate var
+@declarative
+def for_enumerate_var(x_array):
+    y = fluid.layers.fill_constant([1], 'int32', 0)
+    z = fluid.layers.fill_constant([1], 'int32', 0)
+    x_array = fluid.dygraph.to_variable(x_array)
+    for i, x in enumerate(x_array):
+        y = y + i
         z = z + x
     return y, z
 
@@ -206,7 +228,7 @@ class TestForInRange(TestTransform):
         self.input = np.array([5])
 
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_in_range
+        self.dygraph_func = for_in_range
 
     def test_transformed_result_compare(self):
         self.transformed_result_compare()
@@ -214,7 +236,7 @@ class TestForInRange(TestTransform):
 
 class TestForIterList(TestTransform):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_iter_list
+        self.dygraph_func = for_iter_list
 
     def test_transformed_result_compare(self):
         self.transformed_result_compare()
@@ -222,12 +244,12 @@ class TestForIterList(TestTransform):
 
 class TestForEnumerateSimple(TestForIterList):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_list
+        self.dygraph_func = for_enumerate_list
 
 
 class TestForInRangeWithBreak(TestForInRange):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_in_range_with_break
+        self.dygraph_func = for_in_range_with_break
 
 
 class TestForIterVarNumpy(TestTransform):
@@ -235,7 +257,7 @@ class TestForIterVarNumpy(TestTransform):
         self.input = np.array([1, 2, 3, 4, 5])
 
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_iter_var_numpy
+        self.dygraph_func = for_iter_var_numpy
 
     def test_transformed_result_compare(self):
         self.transformed_result_compare()
@@ -243,32 +265,42 @@ class TestForIterVarNumpy(TestTransform):
 
 class TestForEnumerateVarNumpy(TestForIterVarNumpy):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_var_numpy
+        self.dygraph_func = for_enumerate_var_numpy
 
 
 class TestForEnumerateVarNumpyWithStart(TestForIterVarNumpy):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_var_numpy_with_start
+        self.dygraph_func = for_enumerate_var_numpy_with_start
 
 
 class TestForEnumerateVarNumpyWithBreak(TestForIterVarNumpy):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_var_numpy_with_break
+        self.dygraph_func = for_enumerate_var_numpy_with_break
 
 
 class TestForEnumerateVarNumpyWithBreak(TestForIterVarNumpy):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_var_numpy_with_continue
+        self.dygraph_func = for_enumerate_var_numpy_with_continue
 
 
 class TestForEnumerateVarNumpyWithStartAndBreak(TestForIterVarNumpy):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_var_numpy_with_start_break
+        self.dygraph_func = for_enumerate_var_numpy_with_start_break
 
 
 class TestForEnumerateVarNumpyWithStartAndBreak(TestForIterVarNumpy):
     def set_test_func(self):
-        self.dygraph_func = dygraph_for_enumerate_var_numpy_with_start_continue
+        self.dygraph_func = for_enumerate_var_numpy_with_start_continue
+
+
+class TestForIterVar(TestForIterVarNumpy):
+    def set_test_func(self):
+        self.dygraph_func = for_iter_var
+
+
+class TestForEnumerateVar(TestForIterVarNumpy):
+    def set_test_func(self):
+        self.dygraph_func = for_enumerate_var
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: New features
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: Others
<!--  Describe what this PR does  -->
Describe:

动转静支持for直接遍历`VarBase`，而不是通过`VarBase.numpy()`进行遍历：

- for遍历VarBase示例
```python
@declarative
def for_iter_var(x_array):
    z = fluid.layers.fill_constant([1], 'int32', 0)
    x_array = fluid.dygraph.to_variable(x_array)
    for x in x_array:
        z = z + x
    return z
```
- for enumerate VarBase示例
```python
@declarative
def for_enumerate_var(x_array):
    y = fluid.layers.fill_constant([1], 'int32', 0)
    z = fluid.layers.fill_constant([1], 'int32', 0)
    x_array = fluid.dygraph.to_variable(x_array)
    for i, x in enumerate(x_array):
        y = y + i
        z = z + x
    return y, z
```

#### TODO

该PR合入后接着要完成：for遍历LoDTensorArray支持
