### PR TITLE
[Paddle TRT Int8] Refactor quant_conv2d_dequant_fuse_pass

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1972,99 +1972,58 @@ PDNode *patterns::TransposeFlattenConcat::operator()(
   return concat_out;
 }
 
-void patterns::QuantDequantOpFuse::operator()(PDNode *quant_op_input,
-                                              const std::string &op_type,
-                                              const std::string &weight_name,
-                                              int times,
-                                              const std::string &quant_type,
-                                              const std::string &dequant_type) {
-  int kNumFields = 5;
-  const int kQuantizedWeightOffset = 0;
-  const int kQuantizedOpOffset = 1;
-  const int kQuantizedOpOutOffset = 2;
-  const int kDequantOpOffset = 3;
-  const int kDequantOpOutOffset = 4;
-  const int kDequantOpWeightScaleOffset = 5;
-
-  // the quant op always be one.
-  auto quant_op_in_scale = pattern->NewNode(GetNodeName("quant_op_in_scale"))
+void patterns::DeleteQuantOpFuse::operator()(PDNode *input_act_node,
+                                             const std::string &quant_type) {
+  auto *input_scale_node = pattern->NewNode(GetNodeName("input_scale_node"))
                                ->assert_is_op_input(quant_type, "InScale")
                                ->AsInput();
-  auto quant_op =
-      pattern->NewNode(GetNodeName("quant_op"))->assert_is_op(quant_type);
+  auto *quant_node =
+      pattern->NewNode(GetNodeName("quant_node"))->assert_is_op(quant_type);
+  auto *output_scale_node = pattern->NewNode(GetNodeName("output_scale_node"))
+                                ->assert_is_op_output(quant_type, "OutScale")
+                                ->AsOutput();
+  auto *output_act_node = pattern->NewNode(GetNodeName("output_act_node"))
+                              ->assert_is_op_output(quant_type, "Out")
+                              ->AsOutput();
+  quant_node->LinksFrom({input_scale_node, input_act_node});
+  output_scale_node->LinksFrom({quant_node});
+  output_act_node->LinksFrom({quant_node});
+}
 
-  PDNode *quant_op_out_scale = nullptr;
+void patterns::DequantOpFuse::operator()(PDNode *quantized_op_input,
+                                         const std::string &quantized_op_type,
+                                         const std::string &dequant_type,
+                                         const std::string &weight_name) {
+  auto *quantized_op_weight =
+      pattern->NewNode(GetNodeName("quantized_op_weight"))
+          ->assert_is_op_input(quantized_op_type, weight_name)
+          ->AsInput();
+  auto *quantized_op = pattern->NewNode(GetNodeName("quantized_op"))
+                           ->assert_is_op(quantized_op_type);
+  auto *quantized_op_out = pattern->NewNode(GetNodeName("quantized_op_out"))
+                               ->assert_is_op_output(quantized_op_type)
+                               ->assert_is_op_input(dequant_type, "X");
+  auto *dequant_op =
+      pattern->NewNode(GetNodeName("dequant_op"))->assert_is_op(dequant_type);
+  auto *dequant_op_out = pattern->NewNode(GetNodeName("dequant_op_out"))
+                             ->assert_is_op_output(dequant_type, "Out")
+                             ->AsOutput();
+  PDNode *dequant_channel_scale = nullptr;
   if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
-    kNumFields += 1;
-    quant_op_out_scale = pattern->NewNode(GetNodeName("quant_op_out_scale"))
-                             ->assert_is_op_output(quant_type, "OutScale")
-                             ->assert_is_op_nth_input(dequant_type, "Scales", 1)
-                             ->AsIntermediate();
+    dequant_channel_scale =
+        pattern->NewNode(GetNodeName("dequant_channel_scale"))
+            ->assert_is_op_nth_input(dequant_type, "Scales", 0)
+            ->AsInput();
+  }
+
+  quantized_op->LinksFrom({quantized_op_input, quantized_op_weight});
+  quantized_op_out->LinksFrom({quantized_op});
+  if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
+    dequant_op->LinksFrom({quantized_op_out, dequant_channel_scale});
   } else {
-    quant_op_out_scale = pattern->NewNode(GetNodeName("quant_op_out_scale"))
-                             ->assert_is_op_output(quant_type, "OutScale")
-                             ->assert_is_op_input(dequant_type, "Scale")
-                             ->AsIntermediate();
+    dequant_op->LinksFrom({quantized_op_out});
   }
-
-  auto quant_op_out = pattern->NewNode(GetNodeName("quant_op_out"))
-                          ->assert_is_op_output(quant_type, "Out")
-                          ->assert_is_op_input(op_type)
-                          ->AsIntermediate();
-
-  // there are 'times' quantized and dequant op
-  std::vector<PDNode *> nodes;
-  for (int i = 0; i < times; i++) {
-    nodes.push_back(
-        pattern->NewNode(GetNodeName("quantized_op_weight") + std::to_string(i))
-            ->assert_is_op_input(op_type, weight_name)
-            ->AsInput());
-    nodes.push_back(
-        pattern->NewNode(GetNodeName("quantized_op") + std::to_string(i))
-            ->assert_is_op(op_type));
-
-    nodes.push_back(
-        pattern->NewNode(GetNodeName("quantized_op_out") + std::to_string(i))
-            ->assert_is_op_output(op_type)
-            ->assert_is_op_input(dequant_type, "X")
-            ->AsIntermediate());
-
-    nodes.push_back(
-        pattern->NewNode(GetNodeName("dequant_op") + std::to_string(i))
-            ->assert_is_op(dequant_type));
-
-    nodes.push_back(
-        pattern->NewNode(GetNodeName("dequant_op_out") + std::to_string(i))
-            ->assert_is_op_output(dequant_type, "Out")
-            ->AsOutput());
-
-    if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
-      nodes.push_back(pattern
-                          ->NewNode(GetNodeName("dequant_channel_scale") +
-                                    std::to_string(i))
-                          ->assert_is_op_nth_input(dequant_type, "Scales", 0)
-                          ->AsInput());
-    }
-  }
-
-  quant_op->LinksFrom({quant_op_input, quant_op_in_scale});
-  quant_op_out->LinksFrom({quant_op});
-  for (int i = 0; i < times; i++) {
-    nodes[i * kNumFields + kQuantizedOpOffset]->LinksFrom(
-        {quant_op_out, nodes[i * kNumFields + kQuantizedWeightOffset]});
-    nodes[i * kNumFields + kQuantizedOpOutOffset]->LinksFrom(
-        {nodes[i * kNumFields + kQuantizedOpOffset]});
-    if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
-      nodes[i * kNumFields + kDequantOpOffset]->LinksFrom(
-          {nodes[i * kNumFields + kQuantizedOpOutOffset], quant_op_out_scale,
-           nodes[i * kNumFields + kDequantOpWeightScaleOffset]});
-    } else {
-      nodes[i * kNumFields + kDequantOpOffset]->LinksFrom(
-          {nodes[i * kNumFields + kQuantizedOpOutOffset], quant_op_out_scale});
-    }
-    nodes[i * kNumFields + kDequantOpOutOffset]->LinksFrom(
-        {nodes[i * kNumFields + kDequantOpOffset]});
-  }
+  dequant_op_out->LinksFrom({dequant_op});
 }
 
 void patterns::ShuffleChannelPattern::operator()(PDNode *reshape1_in) {

--- a/paddle/fluid/framework/ir/graph_pattern_detector.h
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.h
@@ -1150,14 +1150,28 @@ struct TransposeFlattenConcat : public PatternBase {
   }
 };
 
-struct QuantDequantOpFuse : public PatternBase {
-  QuantDequantOpFuse(PDPattern* pattern, const std::string& name_scope)
-      : PatternBase(pattern, name_scope, "quant_dequant_fuse") {}
+struct DeleteQuantOpFuse : public PatternBase {
+  DeleteQuantOpFuse(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "delete_quant_fuse") {}
 
-  void operator()(PDNode* quant_op_input, const std::string& op_name,
-                  const std::string& weight_name, int times,
-                  const std::string& quant_type,
-                  const std::string& dequant_type);
+  void operator()(PDNode* input_act_node, const std::string& quant_type);
+
+  std::string GetNodeName(const std::string& op_type) {
+    return PDNodeName(name_scope_, repr_, id_, op_type);
+  }
+
+  PDNode* GetPDNode(const std::string& op_type) {
+    return pattern->RetrieveNode(GetNodeName(op_type));
+  }
+};
+
+struct DequantOpFuse : public PatternBase {
+  DequantOpFuse(PDPattern* pattern, const std::string& name_scope)
+      : PatternBase(pattern, name_scope, "dequant_fuse") {}
+
+  void operator()(PDNode* quant_op_input, const std::string& quantized_op_type,
+                  const std::string& dequant_type,
+                  const std::string& weight_name);
 
   std::string GetNodeName(const std::string& op_type) {
     return PDNodeName(name_scope_, repr_, id_, op_type);

--- a/paddle/fluid/framework/ir/quant_conv2d_dequant_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/quant_conv2d_dequant_fuse_pass.cc
@@ -24,159 +24,221 @@ namespace paddle {
 namespace framework {
 namespace ir {
 
-void RunQuantDequant(ir::Graph* graph, Scope* scope, int times,
-                     const std::string& op_type, const std::string& quant_type,
-                     const std::string& dequant_type) {
-  const std::string pattern_name = "quant_dequant_fuse";
-  int kNumFields = 5;
-  const int kQuantizedWeightOffset = 0;
-  const int kQuantizedOpOffset = 1;
-  const int kQuantizedOpOutOffset = 2;
-  const int kDequantOpOffset = 3;
-  const int kDequantOpOutOffset = 4;
-  const int kDequantOpWeightScaleOffset = 5;
-
-  if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
-    kNumFields += 1;
-  }
-
+void DeleteQuant(ir::Graph* graph, Scope* scope,
+                 const std::string& quant_type) {
+  const std::string pattern_name = "delete_quant_fuse";
   GraphPatternDetector gpd;
-  auto* x = gpd.mutable_pattern()
-                ->NewNode("x")
-                ->assert_is_op_input(quant_type, "X")
-                ->AsInput();
+  auto* input_act_node = gpd.mutable_pattern()
+                             ->NewNode("input_act_node")
+                             ->assert_is_op_input(quant_type, "X")
+                             ->AsInput();
 
-  std::string quantized_op_type = op_type;
-  std::string weight_name = "";
-  if (op_type == "conv2d" || op_type == "depthwise_conv2d" ||
-      op_type == "conv2d_fusion") {
-    weight_name = "Filter";
-  } else if (op_type == "mul") {
-    weight_name = "Y";
-  } else if (op_type == "fc") {
-    weight_name = "W";
-  } else {
-    PADDLE_ENFORCE(
-        "QuantDequantFuse: We only support conv2d, conv2d_fusion, fc, mul for "
-        "now.");
-  }
-
-  patterns::QuantDequantOpFuse pattern(gpd.mutable_pattern(), pattern_name);
-  pattern(x, quantized_op_type, weight_name, times, quant_type, dequant_type);
+  patterns::DeleteQuantOpFuse pattern(gpd.mutable_pattern(), pattern_name);
+  pattern(input_act_node, quant_type);
 
   auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
                      Graph* g) {
-    PADDLE_ENFORCE(subgraph.count(x));
-    auto* input_node = subgraph.at(x);
-    Node* quant_op_in_scale =
-        subgraph.at(pattern.GetPDNode("quant_op_in_scale"));
-    Node* quant_op = subgraph.at(pattern.GetPDNode("quant_op"));
-    Node* quant_op_out_scale =
-        subgraph.at(pattern.GetPDNode("quant_op_out_scale"));
-    Node* quant_op_out = subgraph.at(pattern.GetPDNode("quant_op_out"));
+    PADDLE_ENFORCE_EQ(subgraph.count(input_act_node), true,
+                      platform::errors::NotFound(
+                          "Input act node not found in Delete Quant fusion."));
+    Node* input_act = subgraph.at(input_act_node);
+    Node* input_scale = subgraph.at(pattern.GetPDNode("input_scale_node"));
+    Node* quant = subgraph.at(pattern.GetPDNode("quant_node"));
+    Node* output_scale = subgraph.at(pattern.GetPDNode("output_scale_node"));
+    Node* output_act = subgraph.at(pattern.GetPDNode("output_act_node"));
 
-    std::vector<Node*> nodes;
-    for (int i = 0; i < times; i++) {
-      nodes.push_back(subgraph.at(
-          pattern.GetPDNode("quantized_op_weight" + std::to_string(i))));
-      nodes.push_back(
-          subgraph.at(pattern.GetPDNode("quantized_op" + std::to_string(i))));
-      nodes.push_back(subgraph.at(
-          pattern.GetPDNode("quantized_op_out" + std::to_string(i))));
-      nodes.push_back(
-          subgraph.at(pattern.GetPDNode("dequant_op" + std::to_string(i))));
-      nodes.push_back(
-          subgraph.at(pattern.GetPDNode("dequant_op_out" + std::to_string(i))));
-      if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
-        nodes.push_back(subgraph.at(
-            pattern.GetPDNode("dequant_channel_scale" + std::to_string(i))));
-      }
-    }
+    int bit_length = BOOST_GET_CONST(int, quant->Op()->GetAttr("bit_length"));
 
-    int bit_length =
-        BOOST_GET_CONST(int, quant_op->Op()->GetAttr("bit_length"));
-    int range = ((1 << (bit_length - 1)) - 1);
     // Prepare input scale
-    std::string input_scale_var_name = quant_op->Op()->Input("InScale").front();
-    PADDLE_ENFORCE(scope);
+    std::string input_scale_var_name = quant->Op()->Input("InScale").front();
+    PADDLE_ENFORCE_NOT_NULL(scope,
+                            platform::errors::NotFound(
+                                "Scope in Delete Quant fusion is not found."));
     const LoDTensor& input_scale_tensor =
         scope->FindVar(input_scale_var_name)->Get<LoDTensor>();
 
-    PADDLE_ENFORCE(paddle::platform::is_cpu_place(input_scale_tensor.place()));
+    PADDLE_ENFORCE_EQ(
+        paddle::platform::is_cpu_place(input_scale_tensor.place()), true,
+        platform::errors::InvalidArgument(
+            "Input scale tensor's place should be CPU."));
+
     const float* input_scale_data = input_scale_tensor.data<float>();
-    float input_scale = input_scale_data[0];
-    std::unordered_set<const Node*> delete_nodes;
+    float scale_value = input_scale_data[0];
 
-    for (int i = 0; i < times; i++) {
-      std::vector<float> weight_scale;
+    std::string input_act_name = input_act->Var()->Name();
+    std::string output_act_name = output_act->Var()->Name();
+    auto outlinks = output_act->outputs;
+    for (auto* quantized_node : outlinks) {
+      auto* op_desc = quantized_node->Op();
 
-      // Get weight scale from dequant op.
-      if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
-        auto scales_name =
-            nodes[i * kNumFields + kDequantOpOffset]->Op()->Input("Scales");
-        PADDLE_ENFORCE(scales_name.size() == 2);
-        const LoDTensor& channel_scale_tensor =
-            scope->FindVar(scales_name[0])->Get<LoDTensor>();
-        PADDLE_ENFORCE(
-            paddle::platform::is_cpu_place(channel_scale_tensor.place()));
-        const float* channel_scale_data = channel_scale_tensor.data<float>();
-        for (int i = 0; i < channel_scale_tensor.numel(); i++) {
-          weight_scale.push_back(channel_scale_data[i]);
-        }
-        delete_nodes.insert(
-            nodes[i * kNumFields + kDequantOpWeightScaleOffset]);
-      } else {
-        float max_range = BOOST_GET_CONST(
-            float, nodes[i * kNumFields + kDequantOpOffset]->Op()->GetAttr(
-                       "max_range"));
-        weight_scale.push_back((range * range) / max_range);
-      }
-
-      // create new op_desc
-      auto base_op_desc =
-          *nodes[i * kNumFields + kQuantizedOpOffset]->Op()->Proto();
-      std::string new_input = input_node->Name();
-      std::string new_output =
-          nodes[i * kNumFields + kDequantOpOutOffset]->Name();
-
-      framework::OpDesc new_op_desc(base_op_desc, nullptr);
-      new_op_desc.SetType(quantized_op_type);
-      new_op_desc.SetAttr("enable_int8", true);
-
+      std::string quantized_op_type = op_desc->Type();
       if (quantized_op_type == "conv2d" ||
           quantized_op_type == "conv2d_fusion" ||
-          quantized_op_type == "depthwise_conv2d") {
-        new_op_desc.SetInput("Input", {new_input});
-        new_op_desc.SetAttr("Input_scale", input_scale);
-        new_op_desc.SetOutput("Output", {new_output});
-      } else if (quantized_op_type == "fc") {
-        new_op_desc.SetInput("Input", {new_input});
-        new_op_desc.SetAttr("Input_scale", input_scale);
-        new_op_desc.SetOutput("Out", {new_output});
+          quantized_op_type == "depthwise_conv2d" ||
+          quantized_op_type == "fc") {
+        op_desc->SetAttr("Input_scale", scale_value);
       } else if (quantized_op_type == "mul") {
-        new_op_desc.SetInput("X", {new_input});
-        new_op_desc.SetAttr("X_scale", input_scale);
-        new_op_desc.SetOutput("Out", {new_output});
+        op_desc->SetAttr("X_scale", scale_value);
+      } else {
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "Unsupported quantized op type %s", quantized_op_type));
       }
+      op_desc->SetAttr("bit_length", bit_length);
+      op_desc->ResetInputs(output_act_name, input_act_name);
+      op_desc->Flush();
+      IR_NODE_LINK_TO(input_act, quantized_node);
+    }
+    // delete nodes and edges
+    std::unordered_set<const Node*> nodes2rm = {input_scale, quant,
+                                                output_scale, output_act};
+    GraphSafeRemoveNodes(graph, nodes2rm);
+  };
+  gpd(graph, handler);
+}
 
-      new_op_desc.SetAttr("weight_scale", weight_scale);
-      new_op_desc.Flush();
-      auto* new_op = graph->CreateOpNode(&new_op_desc);
-      IR_NODE_LINK_TO(input_node, new_op);
-      IR_NODE_LINK_TO(nodes[i * kNumFields + kQuantizedWeightOffset], new_op);
-      IR_NODE_LINK_TO(new_op, nodes[i * kNumFields + kDequantOpOutOffset]);
+void FuseDequant(ir::Graph* graph, Scope* scope,
+                 const std::string& quantized_op_type,
+                 const std::string& dequant_type) {
+  std::string input_name = "";
+  std::string weight_name = "";
+  if (quantized_op_type == "conv2d" ||
+      quantized_op_type == "depthwise_conv2d" ||
+      quantized_op_type == "conv2d_fusion") {
+    input_name = "Input";
+    weight_name = "Filter";
+  } else if (quantized_op_type == "mul") {
+    input_name = "X";
+    weight_name = "Y";
+  } else if (quantized_op_type == "fc") {
+    input_name = "Input";
+    weight_name = "W";
+  } else {
+    PADDLE_THROW(
+        platform::errors::InvalidArgument("QuantDequantFuse: We only support "
+                                          "conv2d, conv2d_fusion, fc, mul "
+                                          "for "
+                                          "now, but got %s.",
+                                          quantized_op_type));
+  }
+  const std::string pattern_name = "dequant_fuse";
+  GraphPatternDetector gpd;
 
-      delete_nodes.insert(nodes[i * kNumFields + kQuantizedOpOffset]);
-      delete_nodes.insert(nodes[i * kNumFields + kQuantizedOpOutOffset]);
-      delete_nodes.insert(nodes[i * kNumFields + kDequantOpOffset]);
+  auto* quantized_op_input =
+      gpd.mutable_pattern()
+          ->NewNode("quantized_op_input")
+          ->assert_is_op_input(quantized_op_type, input_name)
+          ->AsInput();
+
+  patterns::DequantOpFuse pattern(gpd.mutable_pattern(), pattern_name);
+  pattern(quantized_op_input, quantized_op_type, dequant_type, weight_name);
+
+  auto handler = [&](const GraphPatternDetector::subgraph_t& subgraph,
+                     Graph* g) {
+    PADDLE_ENFORCE_EQ(
+        subgraph.count(quantized_op_input), true,
+        platform::errors::NotFound(
+            "Quantized op input node not found in Dequant fusion."));
+    PADDLE_ENFORCE_NOT_NULL(
+        scope,
+        platform::errors::NotFound("Scope in Dequant fusion is not found."));
+    Node* quantized_op_input_node = subgraph.at(quantized_op_input);
+    Node* quantized_op_weight_node =
+        subgraph.at(pattern.GetPDNode("quantized_op_weight"));
+    Node* quantized_op_node = subgraph.at(pattern.GetPDNode("quantized_op"));
+    Node* dequant_op_node = subgraph.at(pattern.GetPDNode("dequant_op"));
+    Node* dequant_op_out_node =
+        subgraph.at(pattern.GetPDNode("dequant_op_out"));
+
+    std::unordered_set<const Node*> nodes2rm = {};
+
+    int bit_length =
+        BOOST_GET_CONST(int, quantized_op_node->Op()->GetAttr("bit_length"));
+    int range = ((1 << (bit_length - 1)) - 1);
+    std::vector<float> weight_scale;
+
+    if (dequant_type == "fake_channel_wise_dequantize_max_abs") {
+      Node* dequant_channel_scale_node =
+          subgraph.at(pattern.GetPDNode("dequant_channel_scale"));
+      auto scales_name = dequant_op_node->Op()->Input("Scales");
+      PADDLE_ENFORCE_EQ(
+          scales_name.size(), 2,
+          platform::errors::InvalidArgument(
+              "Scales size in channel-wise dequantize op should be 2, got %d",
+              scales_name.size()));
+      const LoDTensor& channel_scale_tensor =
+          scope->FindVar(scales_name[0])->Get<LoDTensor>();
+      PADDLE_ENFORCE_EQ(
+          paddle::platform::is_cpu_place(channel_scale_tensor.place()), true,
+          platform::errors::InvalidArgument(
+              "Channel scale tensor's place should be CPU."));
+      const float* channel_scale_data = channel_scale_tensor.data<float>();
+      for (int i = 0; i < channel_scale_tensor.numel(); i++) {
+        weight_scale.push_back(channel_scale_data[i] / range);
+      }
+      nodes2rm.insert(dequant_channel_scale_node);
+    } else {
+      float max_range =
+          BOOST_GET_CONST(float, dequant_op_node->Op()->GetAttr("max_range"));
+      weight_scale.push_back((range * range) / max_range / range);
     }
 
-    delete_nodes.insert(quant_op_in_scale);
-    delete_nodes.insert(quant_op);
-    delete_nodes.insert(quant_op_out);
-    delete_nodes.insert(quant_op_out_scale);
-    // Delete the unneeded nodes.
-    GraphSafeRemoveNodes(graph, delete_nodes);
+    auto* weight_tensor =
+        scope->Var(quantized_op_weight_node->Name())->GetMutable<LoDTensor>();
+    auto w_dims = weight_tensor->dims();
+    // when the op is fc, scale's size should be 1
+    // when the op is conv, scale's size should be w_dims[0]
+    bool valid_scale_size =
+        (weight_scale.size() == 1 ||
+         weight_scale.size() == static_cast<size_t>(w_dims[0]));
+    PADDLE_ENFORCE_EQ(
+        valid_scale_size, true,
+        platform::errors::InvalidArgument(
+            "TRT int8 quant: invalid weight scale size. TRT int8 requires "
+            "weight scale size to be equal to either 1(when quantized op is "
+            "fc) or weight dims[0](when quantized op is conv)."));
+    float* quantized_weight_data =
+        weight_tensor->mutable_data<float>(platform::CPUPlace());
+    for (int j = 0; j < weight_tensor->numel(); j++) {
+      if (weight_scale.size() == 1) {
+        quantized_weight_data[j] *= weight_scale[0];
+      } else {
+        int inner_size = w_dims[1] * w_dims[2] * w_dims[3];
+        quantized_weight_data[j] *= weight_scale[j / inner_size];
+      }
+    }
+
+    // create new op_desc
+    auto base_op_desc = *quantized_op_node->Op()->Proto();
+    std::string new_input = quantized_op_input_node->Name();
+    std::string new_output = dequant_op_out_node->Name();
+
+    framework::OpDesc new_op_desc(base_op_desc, nullptr);
+    new_op_desc.SetType(quantized_op_type);
+    new_op_desc.SetAttr("enable_int8", true);
+
+    if (quantized_op_type == "conv2d" || quantized_op_type == "conv2d_fusion" ||
+        quantized_op_type == "depthwise_conv2d") {
+      new_op_desc.SetInput("Input", {new_input});
+      new_op_desc.SetOutput("Output", {new_output});
+    } else if (quantized_op_type == "fc") {
+      new_op_desc.SetInput("Input", {new_input});
+      new_op_desc.SetOutput("Out", {new_output});
+    } else if (quantized_op_type == "mul") {
+      new_op_desc.SetInput("X", {new_input});
+      new_op_desc.SetOutput("Out", {new_output});
+    }
+
+    new_op_desc.SetAttr("weight_scale", weight_scale);
+    new_op_desc.Flush();
+    auto* new_op = graph->CreateOpNode(&new_op_desc);
+    IR_NODE_LINK_TO(quantized_op_input_node, new_op);
+    IR_NODE_LINK_TO(quantized_op_weight_node, new_op);
+    IR_NODE_LINK_TO(new_op, dequant_op_out_node);
+
+    // delete nodes and edges
+    nodes2rm.insert(quantized_op_node);
+    nodes2rm.insert(dequant_op_node);
+    GraphSafeRemoveNodes(graph, nodes2rm);
   };
   gpd(graph, handler);
 }
@@ -189,16 +251,16 @@ void QuantDequantFusePass::ApplyImpl(ir::Graph* graph) const {
       "fake_dequantize_max_abs", "fake_channel_wise_dequantize_max_abs"};
   std::unordered_set<std::string> quant_types = {
       "fake_quantize_range_abs_max", "fake_quantize_moving_average_abs_max"};
-  std::unordered_set<std::string> quantized_op_types = {"conv2d", "mul",
-                                                        "depthwise_conv2d"};
+  std::unordered_set<std::string> quantized_op_types = {
+      "conv2d", "mul", "depthwise_conv2d", "fc"};
   auto* scope = param_scope();
+
+  for (auto& quant_type : quant_types) {
+    DeleteQuant(graph, scope, quant_type);
+  }
   for (auto& dequant_type : dequant_types) {
-    for (auto& quant_type : quant_types) {
-      for (auto& op_type : quantized_op_types) {
-        for (int i = 6; i >= 1; i--) {
-          RunQuantDequant(graph, scope, i, op_type, quant_type, dequant_type);
-        }
-      }
+    for (auto& quantized_op_type : quantized_op_types) {
+      FuseDequant(graph, scope, quantized_op_type, dequant_type);
     }
   }
 }

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -358,6 +358,15 @@ void OpDesc::SetInput(const std::string &param_name,
   inputs_[param_name] = args;
 }
 
+void OpDesc::ResetInputs(const std::string &from, const std::string &to) {
+  need_update_ = true;
+  for (auto &item : this->inputs_) {
+    for (auto &var : item.second) {
+      if (var == from) var = to;
+    }
+  }
+}
+
 const std::vector<std::string> &OpDesc::Output(const std::string &name) const {
   auto it = outputs_.find(name);
   PADDLE_ENFORCE(it != outputs_.end(), "Output %s cannot be found in Op %s",

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -55,6 +55,8 @@ class OpDesc {
   void SetInput(const std::string &param_name,
                 const std::vector<std::string> &args);
 
+  void ResetInputs(const std::string &from, const std::string &to);
+
   const std::vector<std::string> &Output(const std::string &name) const;
 
   std::vector<std::string> OutputArgumentNames() const;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The former quant_conv2d_dequant_fuse_pass has problems as following:
1. Using a matrix-like structure to store IR nodes requires a threshold of the max number of quantized nodes preceded by the same quant node, which leads to serious problems when model structure is like:
![image](https://user-images.githubusercontent.com/12407750/83528710-0339ac00-a51c-11ea-974d-98b069e3104f.png)

2. Converting weights from int8 range to fp32 range happens in tensorrt_subgraph_pass, which means if some quantized op is outside trt subgraph, it's weight will not be converted. This might cause wrong results when trt subgraph can't cover all quantized nodes.

We refactored this pass by splitting the fusion into 2 phases, DeleteQuant Fuse and Dequant fuse, so that the threshold of branch nodes is not needed. Moreover, the range of quantized weights in conv/mul/fc is converted to fp32 in this pass instead of tensorrt_subgraph_pass, to produce the right result when trt subgraph can't cover all quantized nodes.