### PR TITLE
Feature/add amp_checkout_finite_and_scale op

### DIFF
--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -23,6 +23,8 @@ if(WITH_DISTRIBUTE)
     add_subdirectory(collective)
 endif()
 
+add_subdirectory(amp)
+
 add_subdirectory(reader)
 
 if (NOT WIN32)

--- a/paddle/fluid/operators/amp/CMakeLists.txt
+++ b/paddle/fluid/operators/amp/CMakeLists.txt
@@ -1,0 +1,2 @@
+include(operators)
+register_operators()

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cc
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cc
@@ -36,7 +36,9 @@ class AmpCheckFiniteAndScaleOp : public framework::OperatorWithKernel {
         ctx->Inputs("X").size(), ctx->Outputs("Out").size(),
         platform::errors::InvalidArgument(
             "The input(X) and output(Out) should have same size in "
-            "Operator(amp_check_finite_and_unscale)."));
+            "Operator(amp_check_finite_and_unscale), size of input(X) is %d "
+            "and size of output(Out) is %d.",
+            ctx->Inputs("X").size(), ctx->Outputs("Out").size()));
     auto x_dims = ctx->GetInputsDim("X");
     ctx->SetOutputsDim("Out", x_dims);
     ctx->SetOutputDim("FoundInfinite", {1});
@@ -55,13 +57,13 @@ class AmpCheckFiniteAndScaleOpMaker : public framework::OpProtoAndCheckerMaker {
   void Make() override {
     AddInput(
         "X",
-        "(Tensor) The input tensors of amp_check_finite_and_scale operator.")
+        "(Tensors) The input tensors of amp_check_finite_and_scale operator.")
         .AsDuplicable();
     AddInput("Scale",
              "(Tensor) 1-dim tensor, the scale of amp_check_finite_and_scale "
              "operator.");
     AddOutput("Out",
-              "(Tensor) The scaled output tensor of "
+              "(Tensors) The scaled output tensor of "
               "amp_check_finite_and_unscale operator.")
         .AsDuplicable();
     AddOutput("FoundInfinite",
@@ -78,7 +80,6 @@ FoundInfinite will be 1 (True), and Out will not be scaled. In this case, the da
 Out should not be used, and its data may not be deterministic. 
 Otherwise, FoundInfinite will be 0 (False).
 
-%s
 )DOC");
   }
 };

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cc
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cc
@@ -1,0 +1,100 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h"
+#include <string>
+#include <vector>
+
+namespace paddle {
+namespace operators {
+
+class AmpCheckFiniteAndScaleOp : public framework::OperatorWithKernel {
+ public:
+  AmpCheckFiniteAndScaleOp(const std::string &type,
+                           const framework::VariableNameMap &inputs,
+                           const framework::VariableNameMap &outputs,
+                           const framework::AttributeMap &attrs)
+      : OperatorWithKernel(type, inputs, outputs, attrs) {}
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInputs("X"), "Input", "X",
+                   "amp_check_finite_and_unscale");
+    OP_INOUT_CHECK(ctx->HasOutputs("Out"), "Output", "Out",
+                   "amp_check_finite_and_unscale");
+    PADDLE_ENFORCE_EQ(ctx->Inputs("X").size(), ctx->Outputs("Out").size(),
+                      "The input(X) and output(Out) should have same size in "
+                      "Operator(amp_check_finite_and_unscale).");
+    auto x_dims = ctx->GetInputsDim("X");
+    ctx->SetOutputsDim("Out", x_dims);
+    ctx->SetOutputDim("FoundInfinite", {1});
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext &ctx) const override {
+    return framework::OpKernelType(
+        OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace());
+  }
+};
+
+class AmpCheckFiniteAndScaleOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput(
+        "X",
+        "(Tensor) The input tensors of amp_check_finite_and_scale operator.")
+        .AsDuplicable();
+    AddInput("Scale",
+             "(Tensor) 1-dim tensor, the scale of amp_check_finite_and_scale "
+             "operator.");
+    AddOutput("Out",
+              "(Tensor) The scaled output tensor of "
+              "amp_check_finite_and_unscale operator.")
+        .AsDuplicable();
+    AddOutput("FoundInfinite",
+              "(Tensor) 1-dim tensor, contains a int scalar, which indicates "
+              "if there there is infinite or nan item in input X.");
+    AddComment(R"DOC(
+amp_check_finite_and_scale operator.
+Check if input X contains all finite data, if yes, scale it by input Scale.
+
+$$Out = X * scale$$
+
+If any tensor in X contains Inf or Nan, the Out will generate a indicator.
+FoundInfinite will be 1 (True), and Out will not be scaled. In this case, the data of 
+Out should not be used, and its data may not be deterministic. 
+Otherwise, FoundInfinite will be 0 (False).
+
+%s
+)DOC");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(
+    amp_check_finite_and_scale, ops::AmpCheckFiniteAndScaleOp,
+    ops::AmpCheckFiniteAndScaleOpMaker,
+    paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
+    paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OP_CPU_KERNEL(
+    amp_check_finite_and_scale,
+    ops::AmpCheckFiniteAndScaleKernel<paddle::platform::CPUDeviceContext,
+                                      float>,
+    ops::AmpCheckFiniteAndScaleKernel<paddle::platform::CPUDeviceContext,
+                                      double>);

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cc
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cc
@@ -32,9 +32,11 @@ class AmpCheckFiniteAndScaleOp : public framework::OperatorWithKernel {
                    "amp_check_finite_and_unscale");
     OP_INOUT_CHECK(ctx->HasOutputs("Out"), "Output", "Out",
                    "amp_check_finite_and_unscale");
-    PADDLE_ENFORCE_EQ(ctx->Inputs("X").size(), ctx->Outputs("Out").size(),
-                      "The input(X) and output(Out) should have same size in "
-                      "Operator(amp_check_finite_and_unscale).");
+    PADDLE_ENFORCE_EQ(
+        ctx->Inputs("X").size(), ctx->Outputs("Out").size(),
+        platform::errors::InvalidArgument(
+            "The input(X) and output(Out) should have same size in "
+            "Operator(amp_check_finite_and_unscale)."));
     auto x_dims = ctx->GetInputsDim("X");
     ctx->SetOutputsDim("Out", x_dims);
     ctx->SetOutputDim("FoundInfinite", {1});

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
@@ -56,7 +56,7 @@ class AmpCheckFiniteAndScaleKernel<platform::CUDADeviceContext, T>
       int num = x->numel();
       int block = 512;
       int grid = (num + block - 1) / block;
-      VLOG(3) << "lanuch kernel";
+      VLOG(3) << "launch kernel";
       AmpCheckFiniteAndScale<T><<<grid, block, 0, dev_ctx.stream()>>>(
           x_data, scale_data, num, found_inf_data, out_data);
       VLOG(3) << "finish kernel";

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
@@ -45,7 +45,7 @@ class AmpCheckFiniteAndScaleKernel<platform::CUDADeviceContext, T>
 
     const T* scale_data = scale->data<T>();
     int* found_inf_data = found_inf->mutable_data<int>(dev_ctx.GetPlace());
-    cudaMemset(found_inf_data, 0, found_inf->numel() * sizeof(int));
+    cudaMemset(found_inf_data, false, found_inf->numel() * sizeof(bool));
 
     for (size_t i = 0; i < xs.size(); ++i) {
       const auto* x = xs[i];

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
@@ -1,0 +1,75 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cuda.h>
+#include "paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h"
+#include "paddle/fluid/platform/float16.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+__global__ void AmpCheckFiniteAndScale(const T* in, const T* scale, int num,
+                                       int* found_inf, T* out) {
+  const int idx = threadIdx.x + blockIdx.x * blockDim.x;
+
+  if (idx < num) {
+    if (!std::isfinite(in[idx])) {
+      *found_inf = 1;
+    }
+    out[idx] = *found_inf ? in[idx] : in[idx] * scale[0];
+  }
+}
+
+template <typename T>
+class AmpCheckFiniteAndScaleKernel<platform::CUDADeviceContext, T>
+    : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const {
+    auto& dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    const auto xs = ctx.MultiInput<framework::Tensor>("X");
+    const auto* scale = ctx.Input<framework::Tensor>("Scale");
+    auto outs = ctx.MultiOutput<framework::Tensor>("Out");
+    auto* found_inf = ctx.Output<framework::Tensor>("FoundInfinite");
+
+    const T* scale_data = scale->data<T>();
+    int* found_inf_data = found_inf->mutable_data<int>(dev_ctx.GetPlace());
+    cudaMemset(found_inf_data, 0, found_inf->numel() * sizeof(int));
+
+    for (size_t i = 0; i < xs.size(); ++i) {
+      const auto* x = xs[i];
+      auto* out = outs[i];
+      const T* x_data = x->data<T>();
+      T* out_data = out->mutable_data<T>(dev_ctx.GetPlace());
+
+      int num = x->numel();
+      int block = 512;
+      int grid = (num + block - 1) / block;
+      VLOG(3) << "lanuch kernel";
+      AmpCheckFiniteAndScale<T><<<grid, block, 0, dev_ctx.stream()>>>(
+          x_data, scale_data, num, found_inf_data, out_data);
+      VLOG(3) << "finish kernel";
+    }
+  }
+};
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OP_CUDA_KERNEL(
+    amp_check_finite_and_scale,
+    ops::AmpCheckFiniteAndScaleKernel<paddle::platform::CUDADeviceContext,
+                                      float>,
+    ops::AmpCheckFiniteAndScaleKernel<paddle::platform::CUDADeviceContext,
+                                      double>);

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h
@@ -1,0 +1,66 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include <string>
+#include <vector>
+#include "paddle/fluid/framework/tensor_util.h"
+#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
+#include "paddle/fluid/operators/isfinite_op.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+class AmpCheckFiniteAndScaleKernel<platform::CPUDeviceContext, T>
+    : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const {
+    auto& dev_ctx = ctx.template device_context<platform::CPUDeviceContext>();
+    const auto xs = ctx.MultiInput<framework::Tensor>("X");
+    const auto* scale = ctx.Input<framework::Tensor>("Scale");
+    auto outs = ctx.MultiOutput<framework::Tensor>("Out");
+    auto* found_inf = ctx.Output<framework::Tensor>("FoundInfinite");
+
+    const T* scale_data = scale->data<T>();
+    int* found_inf_data = found_inf->mutable_data<int>(dev_ctx.GetPlace());
+    *found_inf_data = 0;
+    auto isfinite =
+        ctx.AllocateTmpTensor<bool, platform::CPUDeviceContext>({1}, dev_ctx);
+    const bool* isfinite_data = x->data<bool>();
+
+    auto& dev = *ctx.template device_context<DeviceContext>().eigen_device();
+    for (size_t i = 0; i < xs.size(); ++i) {
+      const auto* x = xs[i];
+      auto* out = outs[i];
+      out->mutable_data<T>(dev_ctx.GetPlace());
+      if (!(*found_inf)) {
+        framework::TensorIsfinite(*x, &isfinite);
+        if (*isfinite_data) {
+          auto eigen_out = framework::EigenVector<T>::Flatten(*out);
+          auto eigen_in = framework::EigenVector<T>::Flatten(*x);
+          eigen_out.device(dev) = (*scale_data) * eigen_in;
+        } else {
+          *found_inf = 1;
+          break;
+        }
+      }
+    }
+    return;
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h
@@ -34,8 +34,9 @@ class AmpCheckFiniteAndScaleKernel : public framework::OpKernel<T> {
     auto* found_inf = ctx.Output<framework::Tensor>("FoundInfinite");
 
     const T* scale_data = scale->data<T>();
-    int* found_inf_data = found_inf->mutable_data<int>(dev_ctx.GetPlace());
-    *found_inf_data = 0;
+    bool* found_inf_data = found_inf->mutable_data<bool>(dev_ctx.GetPlace());
+
+    *found_inf_data = false;
     framework::Tensor is_finite =
         ctx.AllocateTmpTensor<bool, DeviceContext>({1}, dev_ctx);
     bool* is_finite_data = is_finite.template data<bool>();
@@ -52,7 +53,7 @@ class AmpCheckFiniteAndScaleKernel : public framework::OpKernel<T> {
           auto eigen_in = framework::EigenVector<T>::Flatten(*x);
           eigen_out.device(dev) = (*scale_data) * eigen_in;
         } else {
-          *found_inf_data = 1;
+          *found_inf_data = true;
           break;
         }
       }

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -76,6 +76,7 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
     {"matmul", {"Out"}},
     {"fake_quantize_dequantize_moving_average_abs_max",
      {"Out", "OutScale", "OutAccum", "OutState"}},
+    {"amp_check_finite_and_scale", {"Out", "FoundInfinite"}},
 };
 
 // clang-format off

--- a/python/paddle/fluid/tests/unittests/test_amp_check_finite_and_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_amp_check_finite_and_scale_op.py
@@ -39,7 +39,7 @@ class TestAmpCheckFiniteAndScaleOp(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(place=self.place)
+        self.check_output()
 
 
 @skip_check_grad_ci(
@@ -58,13 +58,12 @@ class TestAmpCheckFiniteAndScaleOpWithNan(OpTest):
             'FoundInfinite': np.array([1]),
             'Out': [('out0', x)],
         }
-        self.place = fluid.CUDAPlace(0)
 
     def init_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(place=self.place, no_check_set=['Out'])
+        self.check_output(no_check_set=['Out'])
 
 
 @skip_check_grad_ci(
@@ -83,13 +82,12 @@ class TestAmpCheckFiniteAndScaleOpWithInf(OpTest):
             'FoundInfinite': np.array([1]),
             'Out': [('out0', x)],
         }
-        self.place = fluid.CUDAPlace(0)
 
     def init_dtype(self):
         self.dtype = np.float32
 
     def test_check_output(self):
-        self.check_output_with_place(place=self.place, no_check_set=['Out'])
+        self.check_output(no_check_set=['Out'])
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_amp_check_finite_and_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_amp_check_finite_and_scale_op.py
@@ -18,9 +18,6 @@ from op_test import OpTest, skip_check_grad_ci
 import paddle.fluid as fluid
 
 
-@skip_check_grad_ci(
-    reason="Operator amp_check_finite_and_scale is used for dygraph auto-mixed_precision training only. It has no grad op."
-)
 class TestAmpCheckFiniteAndScaleOp(OpTest):
     def setUp(self):
         self.op_type = "amp_check_finite_and_scale"
@@ -33,7 +30,6 @@ class TestAmpCheckFiniteAndScaleOp(OpTest):
             'FoundInfinite': np.array([0]),
             'Out': [('out0', x * scale)],
         }
-        self.place = fluid.CUDAPlace(0)
 
     def init_dtype(self):
         self.dtype = np.float32
@@ -42,9 +38,6 @@ class TestAmpCheckFiniteAndScaleOp(OpTest):
         self.check_output()
 
 
-@skip_check_grad_ci(
-    reason="Operator amp_check_finite_and_scale is used for dygraph auto-mixed_precision training only. It has no grad op."
-)
 class TestAmpCheckFiniteAndScaleOpWithNan(OpTest):
     def setUp(self):
         self.op_type = "amp_check_finite_and_scale"
@@ -63,12 +56,11 @@ class TestAmpCheckFiniteAndScaleOpWithNan(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
+        # When input contains nan, do not check the output, 
+        # since the output may be nondeterministic and will be discarded.
         self.check_output(no_check_set=['Out'])
 
 
-@skip_check_grad_ci(
-    reason="Operator amp_check_finite_and_scale is used for dygraph auto-mixed_precision training only. It has no grad op."
-)
 class TestAmpCheckFiniteAndScaleOpWithInf(OpTest):
     def setUp(self):
         self.op_type = "amp_check_finite_and_scale"
@@ -87,6 +79,8 @@ class TestAmpCheckFiniteAndScaleOpWithInf(OpTest):
         self.dtype = np.float32
 
     def test_check_output(self):
+        # When input contains inf, do not check the output, 
+        # since the output may be nondeterministic and will be discarded.
         self.check_output(no_check_set=['Out'])
 
 

--- a/python/paddle/fluid/tests/unittests/test_amp_check_finite_and_scale_op.py
+++ b/python/paddle/fluid/tests/unittests/test_amp_check_finite_and_scale_op.py
@@ -1,0 +1,96 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest, skip_check_grad_ci
+import paddle.fluid as fluid
+
+
+@skip_check_grad_ci(
+    reason="Operator amp_check_finite_and_scale is used for dygraph auto-mixed_precision training only. It has no grad op."
+)
+class TestAmpCheckFiniteAndScaleOp(OpTest):
+    def setUp(self):
+        self.op_type = "amp_check_finite_and_scale"
+        self.init_dtype()
+        x = np.random.random((1024, 1024)).astype(self.dtype)
+        scale = np.random.random((1)).astype(self.dtype)
+
+        self.inputs = {'X': [('x0', x)], 'Scale': scale}
+        self.outputs = {
+            'FoundInfinite': np.array([0]),
+            'Out': [('out0', x * scale)],
+        }
+        self.place = fluid.CUDAPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(place=self.place)
+
+
+@skip_check_grad_ci(
+    reason="Operator amp_check_finite_and_scale is used for dygraph auto-mixed_precision training only. It has no grad op."
+)
+class TestAmpCheckFiniteAndScaleOpWithNan(OpTest):
+    def setUp(self):
+        self.op_type = "amp_check_finite_and_scale"
+        self.init_dtype()
+        x = np.random.random((1024, 1024)).astype(self.dtype)
+        x[128][128] = np.nan
+        scale = np.random.random((1)).astype(self.dtype)
+
+        self.inputs = {'X': [('x0', x)], 'Scale': scale}
+        self.outputs = {
+            'FoundInfinite': np.array([1]),
+            'Out': [('out0', x)],
+        }
+        self.place = fluid.CUDAPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(place=self.place, no_check_set=['Out'])
+
+
+@skip_check_grad_ci(
+    reason="Operator amp_check_finite_and_scale is used for dygraph auto-mixed_precision training only. It has no grad op."
+)
+class TestAmpCheckFiniteAndScaleOpWithInf(OpTest):
+    def setUp(self):
+        self.op_type = "amp_check_finite_and_scale"
+        self.init_dtype()
+        x = np.random.random((1024, 1024)).astype(self.dtype)
+        x[128][128] = np.inf
+        scale = np.random.random((1)).astype(self.dtype)
+
+        self.inputs = {'X': [('x0', x)], 'Scale': scale}
+        self.outputs = {
+            'FoundInfinite': np.array([1]),
+            'Out': [('out0', x)],
+        }
+        self.place = fluid.CUDAPlace(0)
+
+    def init_dtype(self):
+        self.dtype = np.float32
+
+    def test_check_output(self):
+        self.check_output_with_place(place=self.place, no_check_set=['Out'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/white_list/no_check_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_check_set_white_list.py
@@ -23,4 +23,5 @@ no_check_set_white_list = [
     'unsqueeze2',
     'cross_entropy2',
     'seed',
+    'amp_check_finite_and_scale',
 ]


### PR DESCRIPTION
<!--  Demo: PR types: Bug fixes, Function optimization  -->
<!--  One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ]  -->
PR types: New features
<!--  Demo: PR changes: OPs  -->
<!--  One of [ OPs | APIs | Docs | Others ]  -->
PR changes: OPs
<!--  Describe what this PR does  -->
Describe: Add amp_checkout_finite_and_scale op

When doing mixed-precision training / inferring in imperative mode, we will first scale the loss to `scale * loss` and perform `backward`. After that, we need to check if the gradients of each parameter contains NAN or INF. If not, the gradients are unscaled to `loss * (1 / scale)` and the parameters are updated by gradients. If yes, the gradients are discarded and the parameters will not updated in this step.

In order to achieve high performance, reduce CUDA synchronization and Python/C++ interaction, Operator `amp_checkout_finite_and_scale` is added to check if a list of gradients (tensors) contain NAN or INF, and scale them if not contain.
