### PR TITLE
[Dy2stat] Fix windows dy2stat test_yolov3 random failure

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_yolov3.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_yolov3.py
@@ -53,13 +53,9 @@ class FakeDataReader(object):
             for j in range(cfg.batch_size):
                 img = np.random.normal(0.485, 0.229,
                                        [3, cfg.input_size, cfg.input_size])
-                gt_boxes_node1 = np.random.randint(
-                    low=cfg.input_size / 4,
-                    high=cfg.input_size / 2,
-                    size=[1, 2])
-                gt_boxes_node2 = gt_boxes_node1 + cfg.input_size / 4
-                gt_boxes = np.concatenate(
-                    (gt_boxes_node1, gt_boxes_node2), axis=1)
+                point1 = cfg.input_size / 4
+                point2 = cfg.input_size / 2
+                gt_boxes = np.array([[point1, point1, point2, point2]])
                 gt_labels = np.random.randint(
                     low=0, high=cfg.class_num, size=[1])
                 gt_scores = np.zeros([1])


### PR DESCRIPTION
### PR types
Fix Unit Test

### PR changes
Fix Unit Test

### Describe
The random failure at Windows may due to some random gt_boxes can cause some numbers in YoloV3 to be negative thus access the invalid memory. This PR tries to solve it.
