### PR TITLE
add default ctor for AnalysisConfig python api

### DIFF
--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -379,7 +379,8 @@ void BindAnalysisConfig(py::module *m) {
       .value("Half", AnalysisConfig::Precision::kHalf)
       .export_values();
 
-  analysis_config.def(py::init<const AnalysisConfig &>())
+  analysis_config.def(py::init<>())
+      .def(py::init<const AnalysisConfig &>())
       .def(py::init<const std::string &>())
       .def(py::init<const std::string &, const std::string &>())
       .def("set_model", (void (AnalysisConfig::*)(const std::string &)) &


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Added default constructor for `AnalysisConfig` in python api for the use of `set_model_buffer`