### PR TITLE
Add cross_norm_hadamard_op in Contrib

### DIFF
--- a/paddle/fluid/operators/cross_norm_hadamard.cu.h
+++ b/paddle/fluid/operators/cross_norm_hadamard.cu.h
@@ -1,0 +1,229 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include <memory.h>
+#include "cub/cub.cuh"
+#include "paddle/fluid/operators/math/math_function.h"
+
+#define NORM_POS(idx, row, col) (((idx)*block_cols + (col)) * ins_num + (row))
+#define SCALE_MEAN_POS(idx, col) ((idx)*block_cols + (col))
+#define INPUT_POS(idx, row, col) \
+  (((embed_dim * (idx)) + (col)) * ins_num + (row))
+
+#define CUDA_KERNEL_LOOP(i, n)                                 \
+  for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < (n); \
+       i += blockDim.x * gridDim.x)
+
+const int CUDA_NUM_THREADS = 1024;
+static inline int GET_BLOCKS(const int N) {
+  return (N + CUDA_NUM_THREADS - 1) / CUDA_NUM_THREADS;
+}
+namespace paddle {
+namespace operators {
+
+template <typename T>
+__global__ void nncross_normforward_multi(int len, int n, int embed_dim,
+                                          int ins_num, const T* inputs,
+                                          T* norm_output, const T* mean,
+                                          const T* scale) {
+  CUDA_KERNEL_LOOP(i, len) {
+    int block_cols = embed_dim * 3 + 1;
+    int row = i % ins_num;
+    int col_global = i / ins_num;
+    int block_idx = col_global / block_cols;
+    int col = col_global % block_cols;
+
+    if (col < embed_dim) {
+      norm_output[i] =
+          (inputs[INPUT_POS(block_idx * 2, row, col)] - mean[col_global]) *
+          scale[col_global];
+    } else if (col < embed_dim * 2) {
+      col -= embed_dim;
+      norm_output[i] =
+          (inputs[INPUT_POS(block_idx * 2 + 1, row, col)] - mean[col_global]) *
+          scale[col_global];
+    } else if (col < embed_dim * 3) {
+      col -= 2 * embed_dim;
+      norm_output[i] = (inputs[INPUT_POS(block_idx * 2, row, col)] *
+                            inputs[INPUT_POS(block_idx * 2 + 1, row, col)] -
+                        mean[col_global]) *
+                       scale[col_global];
+    }
+  }
+}
+
+template <typename T>
+__global__ void nncross_normforward_multi_sim(int len, int N, int embed_dim,
+                                              int ins_num, const T* inputs,
+                                              T* norm_output, const T* mean,
+                                              const T* scale) {
+  CUDA_KERNEL_LOOP(i, len) {
+    int block_cols = embed_dim * 3 + 1;
+    int row = i % ins_num;
+    int col_global = (i / ins_num + 1) * block_cols - 1;
+    int block_idx = col_global / block_cols;
+
+    T sum = 0;
+    for (int j = 0; j < embed_dim; ++j) {
+      sum += inputs[INPUT_POS(block_idx * 2, row, j)] *
+             inputs[INPUT_POS(block_idx * 2 + 1, row, j)];
+    }
+    norm_output[NORM_POS(block_idx, row, embed_dim * 3)] =
+        (sum - mean[col_global]) * scale[col_global];
+  }
+}
+
+template <typename T>
+__global__ void nncross_normbackpropagate_multi(int len, int N, int embed_dim,
+                                                int ins_num, const T* inputs,
+                                                const T* norm_grad, T* grads,
+                                                const T* mean, const T* scale) {
+  CUDA_KERNEL_LOOP(i, len) {
+    int row = i % ins_num;
+    int col_global = i / ins_num;
+    int a_idx = col_global / embed_dim;
+    int col = col_global % embed_dim;
+    int block_cols = embed_dim * 3 + 1;
+
+    // grad 0
+    grads[i] += norm_grad[NORM_POS(a_idx / 2, row, col)] *
+                scale[SCALE_MEAN_POS(a_idx / 2, col)];
+    // grad 1
+    grads[i] += norm_grad[NORM_POS(a_idx / 2, row, (embed_dim * 2 + col))] *
+                scale[SCALE_MEAN_POS(a_idx / 2, (embed_dim * 2 + col))] *
+                inputs[INPUT_POS((1 + (a_idx / 2) * 4 - a_idx), row, col)];
+    // grad 2
+    grads[i] += norm_grad[NORM_POS(a_idx / 2, row, (embed_dim * 3))] *
+                scale[SCALE_MEAN_POS(a_idx / 2, (embed_dim * 3))] *
+                inputs[INPUT_POS((1 + (a_idx / 2) * 4 - a_idx), row, col)];
+  }
+}
+
+template <typename T>
+__global__ void kernel_mean_scale(int N, const T* summary, T* mean, T* scale) {
+  CUDA_KERNEL_LOOP(i, N) {
+    mean[i] = summary[3 * i + 1] / summary[3 * i];
+    scale[i] = sqrt(summary[3 * i] / summary[3 * i + 2]);
+  }
+}
+
+template <typename T>
+__global__ void kernel_normbackwardsummary_x0(int len, int row, T* in_val,
+                                              T* sum_grad, const T* means,
+                                              const T* scale,
+                                              const T squared_sum_epsilon) {
+  CUDA_KERNEL_LOOP(i, len) {
+    in_val[i] = in_val[i] / scale[i / row] + means[i / row];
+  }
+}
+
+template <typename T>
+__global__ void kernel_normbackwardsummary_plus_mean(
+    int len, int row, T* in_val, T* sum_grad, const T* means, const T* scale,
+    const T squared_sum_epsilon) {
+  CUDA_KERNEL_LOOP(i, len) {
+    in_val[i] = (in_val[i] - means[i / row]) * (in_val[i] - means[i / row]);
+  }
+}
+
+template <typename T>
+__global__ void kernel_normbackwardsummary_place_sum(int len, T* buf1, T* buf2,
+                                                     T* out_val, int row,
+                                                     T squared_sum_epsilon) {
+  CUDA_KERNEL_LOOP(i, len) {
+    out_val[3 * i] = row;
+    out_val[3 * i + 1] = buf1[i];
+    out_val[3 * i + 2] = buf2[i] + row * squared_sum_epsilon;
+  }
+}
+
+template <typename T>
+void nncross_norm_ff(int N, int embed_dim, int ins_num, const T* inputs,
+                     T* norm_output, const T* summary, T* mean, T* scale,
+                     cudaStream_t stream) {
+  int norm_cols = N * (embed_dim * 3 + 1);
+  kernel_mean_scale<<<GET_BLOCKS(norm_cols), CUDA_NUM_THREADS, 0, stream>>>(
+      norm_cols, summary, mean, scale);
+  nncross_normforward_multi<<<GET_BLOCKS(norm_cols * ins_num), CUDA_NUM_THREADS,
+                              0, stream>>>(norm_cols * ins_num, N, embed_dim,
+                                           ins_num, inputs, norm_output, mean,
+                                           scale);
+  nncross_normforward_multi_sim<<<GET_BLOCKS(N * ins_num), CUDA_NUM_THREADS, 0,
+                                  stream>>>(N * ins_num, N, embed_dim, ins_num,
+                                            inputs, norm_output, mean, scale);
+}
+
+template <typename T>
+void nncross_norm_bp(int N, int embed_dim, int ins_num, const T* inputs,
+                     T* norm_output, const T* norm_grad, T* grads, T* sum_grad,
+                     T* summary, const T* mean, const T* scale,
+                     const T squared_sum_epsilon, cudaStream_t stream,
+                     T* sum_grad_buf, int* sum_offset, T* sum_grad_buf2,
+                     const framework::ExecutionContext& ctx) {
+  auto& dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+  int norm_cols = N * (embed_dim * 3 + 1);
+  int intput_cols = N * embed_dim;
+
+  kernel_normbackwardsummary_x0<<<GET_BLOCKS(norm_cols * ins_num),
+                                  CUDA_NUM_THREADS, 0, stream>>>(
+      norm_cols * ins_num, ins_num, norm_output, sum_grad, mean, scale,
+      squared_sum_epsilon);
+
+  size_t temp_storage_bytes;
+  cub::DeviceSegmentedReduce::Sum(NULL, temp_storage_bytes, norm_output,
+                                  sum_grad_buf, norm_cols, sum_offset,
+                                  sum_offset + 1);
+  auto temp_cub_buf = memory::Alloc(dev_ctx, temp_storage_bytes);
+  T* cub_buf = reinterpret_cast<T*>(temp_cub_buf->ptr());
+
+  cub::DeviceSegmentedReduce::Sum(cub_buf, temp_storage_bytes, norm_output,
+                                  sum_grad_buf, norm_cols, sum_offset,
+                                  sum_offset + 1, stream);
+
+  kernel_normbackwardsummary_plus_mean<<<GET_BLOCKS(norm_cols * ins_num),
+                                         CUDA_NUM_THREADS, 0, stream>>>(
+      norm_cols * ins_num, ins_num, norm_output, sum_grad, mean, scale,
+      squared_sum_epsilon);
+  cub::DeviceSegmentedReduce::Sum(cub_buf, temp_storage_bytes, norm_output,
+                                  sum_grad_buf2, norm_cols, sum_offset,
+                                  sum_offset + 1, stream);
+  kernel_normbackwardsummary_place_sum<<<GET_BLOCKS(norm_cols),
+                                         CUDA_NUM_THREADS, 0, stream>>>(
+      norm_cols, sum_grad_buf, sum_grad_buf2, sum_grad, ins_num,
+      squared_sum_epsilon);
+
+  nncross_normbackpropagate_multi<<<GET_BLOCKS(intput_cols * ins_num * 2),
+                                    CUDA_NUM_THREADS, 0, stream>>>(
+      intput_cols * ins_num * 2, N, embed_dim, ins_num, inputs, norm_grad,
+      grads, mean, scale);
+}
+
+template <typename T>
+__global__ void KernelUpdateParam(int C, const T* d_summary, T* summary,
+                                  const float decay_rate) {
+  CUDA_KERNEL_LOOP(i, C) {
+    summary[i] = summary[i] * decay_rate + d_summary[i];
+  }
+}
+
+template <typename T>
+void update_norm_param(cudaStream_t stream, int C, const T* d_summary,
+                       T* summary, const float decay_rate) {
+  KernelUpdateParam<<<GET_BLOCKS(C), CUDA_NUM_THREADS, 0, stream>>>(
+      C, d_summary, summary, decay_rate);
+}
+
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/cross_norm_hadamard_op.cc
+++ b/paddle/fluid/operators/cross_norm_hadamard_op.cc
@@ -1,0 +1,168 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/cross_norm_hadamard_op.h"
+#include <string>
+
+namespace paddle {
+namespace operators {
+
+class CrossNormHadamardOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Input"), "Input", "X", "CrossNormHadamard");
+    OP_INOUT_CHECK(ctx->HasInput("SummaryInput"), "Input", "SummaryInput",
+                   "CrossNormHadamard");
+
+    OP_INOUT_CHECK(ctx->HasOutput("CudaMeans"), "Output", "CudaMeans",
+                   "CrossNormHadamard");
+    OP_INOUT_CHECK(ctx->HasOutput("CudaScales"), "Output", "CudaScales",
+                   "CrossNormHadamard");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "CrossNormHadamard");
+
+    auto fields_num = ctx->Attrs().Get<int64_t>("fields_num");
+    auto embed_dim = ctx->Attrs().Get<int64_t>("embed_dim");
+
+    auto cols = (embed_dim * 3 + 1) * fields_num;
+    auto input_dims = ctx->GetInputDim("Input");
+    auto summary_dims = ctx->GetInputDim("SummaryInput");
+
+    PADDLE_ENFORCE_EQ(
+        cols, summary_dims[1],
+        platform::errors::InvalidArgument("Input(SummaryInput) should be [%d],"
+                                          "but now it is [%d]",
+                                          cols, summary_dims[0]));
+
+    PADDLE_ENFORCE_EQ(embed_dim * 2 * fields_num, input_dims[1],
+                      platform::errors::InvalidArgument(
+                          "Input(Input) should be [%d],"
+                          "but now it is [%d]",
+                          embed_dim * 2 * fields_num, input_dims[1]));
+    ctx->SetOutputDim("Out", {input_dims[0], cols});
+    ctx->SetOutputDim("CudaMeans", {1, cols});
+    ctx->SetOutputDim("CudaScales", {1, cols});
+
+    ctx->ShareLoD("Input", /*->*/ "Out");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(
+        OperatorWithKernel::IndicateVarDataType(ctx, "Input"),
+        ctx.device_context());
+  }
+};
+
+class CrossNormHadamardGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput("Input"), true,
+        platform::errors::InvalidArgument("Input should not be null"));
+    PADDLE_ENFORCE_EQ(ctx->HasInput("SummaryInput"), true,
+                      platform::errors::InvalidArgument(
+                          "Input(SummaryInput) should not be null"));
+
+    ctx->SetOutputDim(framework::GradVarName("Input"),
+                      ctx->GetInputDim("Input"));
+    ctx->SetOutputDim(framework::GradVarName("SummaryInput"),
+                      ctx->GetInputDim("SummaryInput"));
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext& ctx) const override {
+    return framework::OpKernelType(OperatorWithKernel::IndicateVarDataType(
+                                       ctx, framework::GradVarName("Out")),
+                                   ctx.device_context());
+  }
+};
+
+class CrossNormHadamardOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("Input",
+             "(Tensor) Input tensor of cross_norm_hadamard_op operator.");
+    AddInput("SummaryInput",
+             "(Tensor) Input tensor of cross_norm_hadamard_op operator.");
+    AddAttr<int64_t>("fields_num", "(int64_t) the fields_num").SetDefault(2);
+    AddAttr<int64_t>("embed_dim", "(int64_t) the embed_dim").SetDefault(1);
+    AddAttr<float>(
+        "summary_decay_rate",
+        "(float, default 0.9999999) The decay rate when update the summary")
+        .SetDefault(0.9999999);
+    AddAttr<float>("epsilon", "")
+        .SetDefault(1e-4)
+        .AddCustomChecker([](const float& epsilon) {
+          PADDLE_ENFORCE(epsilon >= 0.0f && epsilon <= 0.001f,
+                         "'epsilon' should be between 0.0 and 0.001.");
+        });
+    AddOutput("Out", "Output tensor of cross_norm_hadamard_op operator.");
+    AddOutput("CudaMeans", "Output tensor of cross_norm_hadamard_op operator.");
+    AddOutput("CudaScales",
+              "Output tensor of cross_norm_hadamard_op operator.");
+
+    AddComment(R"DOC(
+CrossNormHadamard Operator.
+Notice: It currently supports GPU device.
+This Op exists in contrib, which means that it is not shown to the public.
+)DOC");
+  }
+};
+
+template <typename T>
+class CrossNormHadamardGradOpMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> op) const override {
+    op->SetType("cross_norm_hadamard_grad");
+
+    op->SetInput("Input", this->Input("Input"));
+    op->SetInput("SummaryInput", this->Input("SummaryInput"));
+    op->SetInput("Out", this->Output("Out"));
+    op->SetInput("CudaMeans", this->Output("CudaMeans"));
+    op->SetInput("CudaScales", this->Output("CudaScales"));
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+
+    op->SetOutput("SummaryInput", this->Input("SummaryInput"));
+    op->SetOutput(framework::GradVarName("Input"), this->InputGrad("Input"));
+    op->SetOutput(framework::GradVarName("SummaryInput"),
+                  this->InputGrad("SummaryInput"));
+    op->SetAttrMap(this->Attrs());
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(
+    cross_norm_hadamard, ops::CrossNormHadamardOp,
+    ops::CrossNormHadamardOpMaker,
+    ops::CrossNormHadamardGradOpMaker<paddle::framework::OpDesc>,
+    ops::CrossNormHadamardGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OPERATOR(cross_norm_hadamard_grad, ops::CrossNormHadamardGradOp);
+
+REGISTER_OP_CPU_KERNEL(
+    cross_norm_hadamard,
+    ops::CrossNormHadamardKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CrossNormHadamardKernel<paddle::platform::CPUDeviceContext, double>);

--- a/paddle/fluid/operators/cross_norm_hadamard_op.cu
+++ b/paddle/fluid/operators/cross_norm_hadamard_op.cu
@@ -1,0 +1,211 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include <cublas.h>
+#include <string>
+#include <vector>
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/operators/cross_norm_hadamard.cu.h"
+#include "paddle/fluid/operators/cross_norm_hadamard_op.h"
+#include "paddle/fluid/operators/math/blas.h"
+#include "paddle/fluid/operators/math/math_function.h"
+#include "paddle/fluid/platform/cuda_primitives.h"
+#include "paddle/fluid/platform/gpu_info.h"
+
+namespace paddle {
+namespace operators {
+using framework::Tensor;
+using platform::PADDLE_CUDA_NUM_THREADS;
+
+template <typename DeviceContext, typename T>
+class CrossNormHadamardCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* input = ctx.Input<framework::LoDTensor>("Input");
+    auto* summary_input = ctx.Input<framework::Tensor>("SummaryInput");
+    auto* Out = ctx.Output<Tensor>("Out");
+    auto* cuda_means = ctx.Output<Tensor>("CudaMeans");
+    auto* cuda_scales = ctx.Output<Tensor>("CudaScales");
+
+    auto fields_num = ctx.Attr<int64_t>("fields_num");
+    auto embed_dim = ctx.Attr<int64_t>("embed_dim");
+
+    auto cols = (embed_dim * 3 + 1) * fields_num;
+    auto input_dims = input->dims();
+    auto rows = input_dims[0];
+
+    auto& place = *ctx.template device_context<platform::CUDADeviceContext>()
+                       .eigen_device();
+    auto& dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    auto stream = ctx.cuda_device_context().stream();
+
+    Out->Resize({rows, cols});
+    T* out_data = Out->mutable_data<T>(ctx.GetPlace());
+    auto out_eigen = framework::EigenVector<T>::Flatten(*Out);
+    out_eigen.device(place) = out_eigen.constant(static_cast<T>(0));
+
+    cuda_means->Resize({1, cols});
+    cuda_scales->Resize({1, cols});
+    cuda_means->mutable_data<T>(ctx.GetPlace());
+    cuda_scales->mutable_data<T>(ctx.GetPlace());
+
+    // temperary tensor
+    Tensor input_help;
+    input_help = ctx.AllocateTmpTensor<T, DeviceContext>(
+        {fields_num * 2 * embed_dim, rows}, dev_ctx);
+    input_help.mutable_data<T>(ctx.GetPlace());
+
+    Tensor summary_help;
+    summary_help = ctx.AllocateTmpTensor<T, DeviceContext>({cols, 3}, dev_ctx);
+    summary_help.mutable_data<T>(ctx.GetPlace());
+
+    Tensor out_help;
+    out_help = ctx.AllocateTmpTensor<T, DeviceContext>({cols, rows}, dev_ctx);
+    out_help.mutable_data<T>(ctx.GetPlace());
+
+    math::Transpose<DeviceContext, T, 2> trans;
+    trans(dev_ctx, *input, &input_help, {1, 0});
+
+    trans(dev_ctx, *summary_input, &summary_help, {1, 0});
+    trans(dev_ctx, *Out, &out_help, {1, 0});
+
+    auto input_help_data = input_help.data<T>();
+    auto summary_help_data = summary_help.data<T>();
+    auto out_help_data = out_help.data<T>();
+
+    nncross_norm_ff<T>(fields_num, embed_dim, rows, input_help_data,
+                       out_help_data, summary_help_data, cuda_means->data<T>(),
+                       cuda_scales->data<T>(), stream);
+    trans(dev_ctx, out_help, Out, {1, 0});
+  }
+};
+
+template <typename DeviceContext, typename T>
+class CrossNormHadamardOpCUDAKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* input = ctx.Input<Tensor>("Input");
+    auto* summary_input = ctx.Input<Tensor>("SummaryInput");
+    auto* out = ctx.Input<Tensor>("Out");
+    auto* means = ctx.Input<Tensor>("CudaMeans");
+    auto* scales = ctx.Input<Tensor>("CudaScales");
+    auto* out_grad = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto fields_num = ctx.Attr<int64_t>("fields_num");
+    auto embed_dim = ctx.Attr<int64_t>("embed_dim");
+    const float epsilon = ctx.Attr<float>("epsilon");
+    const float dr = ctx.Attr<float>("summary_decay_rate");
+
+    auto* input_grad = ctx.Output<Tensor>(framework::GradVarName("Input"));
+    auto* summary_grad =
+        ctx.Output<Tensor>(framework::GradVarName("SummaryInput"));
+
+    auto& dev_ctx = ctx.template device_context<platform::CUDADeviceContext>();
+    auto& place = *ctx.template device_context<platform::CUDADeviceContext>()
+                       .eigen_device();
+    auto stream = ctx.cuda_device_context().stream();
+
+    // initialize
+    input_grad->mutable_data<T>(ctx.GetPlace());
+    auto input_grad_eigen = framework::EigenVector<T>::Flatten(*input_grad);
+    input_grad_eigen.device(place) =
+        input_grad_eigen.constant(static_cast<T>(0));
+
+    summary_grad->mutable_data<T>(ctx.GetPlace());
+    auto summary_grad_eigen = framework::EigenVector<T>::Flatten(*summary_grad);
+    summary_grad_eigen.device(place) =
+        summary_grad_eigen.constant(static_cast<T>(0));
+
+    auto cols = (embed_dim * 3 + 1) * fields_num;
+    auto input_dims = input->dims();
+    auto rows = input_dims[0];
+
+    // temperary tensor
+    math::Transpose<DeviceContext, T, 2> trans;
+
+    Tensor input_help;
+    input_help = ctx.AllocateTmpTensor<T, DeviceContext>(
+        {fields_num * 2 * embed_dim, rows}, dev_ctx);
+    trans(dev_ctx, *input, &input_help, {1, 0});
+
+    Tensor summary_help;
+    summary_help = ctx.AllocateTmpTensor<T, DeviceContext>({cols, 3}, dev_ctx);
+    trans(dev_ctx, *summary_input, &summary_help, {1, 0});
+
+    Tensor out_help;
+    out_help = ctx.AllocateTmpTensor<T, DeviceContext>({cols, rows}, dev_ctx);
+    trans(dev_ctx, *out, &out_help, {1, 0});
+
+    Tensor out_grad_help;
+    out_grad_help =
+        ctx.AllocateTmpTensor<T, DeviceContext>({cols, rows}, dev_ctx);
+    trans(dev_ctx, *out_grad, &out_grad_help, {1, 0});
+
+    Tensor input_grad_help;
+    input_grad_help = ctx.AllocateTmpTensor<T, DeviceContext>(
+        {fields_num * 2 * embed_dim, rows}, dev_ctx);
+    trans(dev_ctx, *input_grad, &input_grad_help, {1, 0});
+
+    Tensor summary_grad_help;
+    summary_grad_help =
+        ctx.AllocateTmpTensor<T, DeviceContext>({cols, 3}, dev_ctx);
+    trans(dev_ctx, *summary_grad, &summary_grad_help, {1, 0});
+
+    std::vector<int> sum_offset(cols + 1, rows);
+    for (int i = 2; i < sum_offset.size(); ++i) {
+      sum_offset[i] += sum_offset[i - 1];
+    }
+    sum_offset[0] = 0;
+
+    auto tmp_array = memory::Alloc(dev_ctx, sum_offset.size() * sizeof(int));
+    memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
+                 tmp_array->ptr(), platform::CPUPlace(),
+                 reinterpret_cast<void*>(sum_offset.data()),
+                 sum_offset.size() * sizeof(int), dev_ctx.stream());
+    int* g_sum_offset = reinterpret_cast<int*>(tmp_array->ptr());
+
+    auto temp_grad_buf1 = memory::Alloc(dev_ctx, sizeof(T) * cols);
+    T* g_grad_buf1 = reinterpret_cast<T*>(temp_grad_buf1->ptr());
+    auto temp_grad_buf2 = memory::Alloc(dev_ctx, sizeof(T) * cols);
+    T* g_grad_buf2 = reinterpret_cast<T*>(temp_grad_buf2->ptr());
+
+    nncross_norm_bp<T>(fields_num, embed_dim, rows, input_help.data<T>(),
+                       out_help.data<T>(), out_grad_help.data<T>(),
+                       input_grad_help.data<T>(), summary_grad_help.data<T>(),
+                       summary_help.data<T>(), means->data<T>(),
+                       scales->data<T>(), epsilon, stream, g_grad_buf1,
+                       g_sum_offset, g_grad_buf2, ctx);
+
+    trans(dev_ctx, input_grad_help, input_grad, {1, 0});
+    trans(dev_ctx, summary_grad_help, summary_grad, {1, 0});
+
+    int C = 3 * input_dims[1];
+    T* summary_input_data =
+        ctx.Output<Tensor>("SummaryInput")->mutable_data<T>(ctx.GetPlace());
+    update_norm_param<T>(stream, C, summary_grad->data<T>(), summary_input_data,
+                         dr);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+using GPUCtx = paddle::platform::CUDADeviceContext;
+REGISTER_OP_CUDA_KERNEL(cross_norm_hadamard,
+                        ops::CrossNormHadamardCUDAKernel<GPUCtx, float>,
+                        ops::CrossNormHadamardCUDAKernel<GPUCtx, double>);
+
+REGISTER_OP_CUDA_KERNEL(cross_norm_hadamard_grad,
+                        ops::CrossNormHadamardOpCUDAKernel<GPUCtx, float>,
+                        ops::CrossNormHadamardOpCUDAKernel<GPUCtx, double>);

--- a/paddle/fluid/operators/cross_norm_hadamard_op.h
+++ b/paddle/fluid/operators/cross_norm_hadamard_op.h
@@ -1,0 +1,32 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+class CrossNormHadamardKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        platform::is_gpu_place(ctx.GetPlace()), true,
+        platform::errors::Unimplemented("BatchFC only supports GPU now."));
+  }
+};
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/fluid/tests/unittests/test_cross_norm_hadamard_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_norm_hadamard_op.py
@@ -1,0 +1,142 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle.fluid.core as core
+from op_test import OpTest
+
+
+class TestCrossNormHadamardOp(OpTest):
+    """
+    test forward and backward
+    """
+
+    def setUp(self):
+        self.op_type = 'cross_norm_hadamard'
+
+        ins_num = 100
+        embed_dim = 2
+        fields_num = 5
+        tp = np.float64
+
+        input_a = np.random.random([ins_num, embed_dim]).astype(tp)
+        input_b = np.random.random([ins_num, embed_dim]).astype(tp)
+        input = np.concatenate((input_a, input_b), axis=1)
+        input_multi = input_a * input_b
+        input_sim = np.sum(input_multi, axis=1, keepdims=True)
+
+        np_res = np.concatenate(
+            (input_a, input_b, input_multi, input_sim), axis=1)
+
+        for _ in range(fields_num - 1):
+            input_a = np.random.random([ins_num, embed_dim]).astype(tp)
+            input_b = np.random.random([ins_num, embed_dim]).astype(tp)
+            input = np.concatenate((input, input_a, input_b), axis=1)
+            input_multi = input_a * input_b
+            input_sim = np.sum(input_multi, axis=1, keepdims=True)
+
+            np_res = np.concatenate(
+                (np_res, input_a, input_b, input_multi, input_sim), axis=1)
+
+        summary_input = np.zeros(
+            [3, (embed_dim * 3 + 1) * fields_num]).astype(tp)
+        summary_input[0, :] = 1e4
+        summary_input[1, :] = 0.0
+        summary_input[2, :] = 1e4
+
+        np_mean = summary_input[1, :] / summary_input[0, :]
+        np_scale = np.sqrt(summary_input[0, :] / summary_input[2, :])
+
+        self.inputs = {"Input": input, "SummaryInput": summary_input}
+        self.outputs = {
+            "Out": np_res,
+            "CudaMeans": np_mean,
+            "CudaScales": np_scale
+        }
+        self.attrs = {"fields_num": fields_num, "embed_dim": embed_dim}
+
+    def test_check_output_gpu(self):
+        if core.is_compiled_with_cuda():
+            self.check_output_with_place(core.CUDAPlace(0))
+
+    def test_check_grad_gpu(self):
+        if core.is_compiled_with_cuda():
+            self.check_grad_with_place(core.CUDAPlace(0), ["Input"], "Out")
+
+
+class TestRankAttentionOpCpu(OpTest):
+    def setUp(self):
+        """
+        """
+        self.op_type = 'cross_norm_hadamard'
+
+        ins_num = 100
+        embed_dim = 2
+        fields_num = 5
+        tp = np.float64
+
+        input_a = np.random.random([ins_num, embed_dim]).astype(tp)
+        input_b = np.random.random([ins_num, embed_dim]).astype(tp)
+        input = np.concatenate((input_a, input_b), axis=1)
+        input_multi = input_a * input_b
+        input_sim = np.sum(input_multi, axis=1, keepdims=True)
+
+        np_res = np.concatenate(
+            (input_a, input_b, input_multi, input_sim), axis=1)
+
+        for _ in range(fields_num - 1):
+            input_a = np.random.random([ins_num, embed_dim]).astype(tp)
+            input_b = np.random.random([ins_num, embed_dim]).astype(tp)
+            input = np.concatenate((input, input_a, input_b), axis=1)
+            input_multi = input_a * input_b
+            input_sim = np.sum(input_multi, axis=1, keepdims=True)
+
+            np_res = np.concatenate(
+                (np_res, input_a, input_b, input_multi, input_sim), axis=1)
+
+        summary_input = np.zeros(
+            [3, (embed_dim * 3 + 1) * fields_num]).astype(tp)
+        summary_input[0, :] = 1e4
+        summary_input[1, :] = 0.0
+        summary_input[2, :] = 1e4
+
+        np_mean = summary_input[1, :] / summary_input[0, :]
+        np_scale = np.sqrt(summary_input[0, :] / summary_input[2, :])
+
+        self.inputs = {"Input": input, "SummaryInput": summary_input}
+        self.outputs = {
+            "Out": np_res,
+            "CudaMeans": np_mean,
+            "CudaScales": np_scale
+        }
+        self.attrs = {"fields_num": fields_num, "embed_dim": embed_dim}
+
+    def test_check_output_cpu(self):
+        try:
+            self.check_output_with_place(place=core.CPUPlace())
+        except:
+            print("do not support cpu test, skip")
+
+    def test_check_grad_cpu(self):
+        try:
+            self.check_grad_with_place(core.CPUPlace(), ["Input"], "Out")
+        except:
+            print("do not support cpu test, skip")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -3237,6 +3237,22 @@ class TestBook(LayerTest):
                 max_rank=3)
             return (out)
 
+    def test_cross_norm_layer_hadamard(self):
+        with self.static_graph():
+            input = fluid.data(name="input", shape=[None, 2], dtype="float32")
+            param_attr = {
+                "batch_size": 1e4,
+                "batch_sum": 0.0,
+                "batch_square": 1e4
+            }
+            out = fluid.contrib.layers.cross_norm_layer_hadamard(
+                input=input,
+                param_dict=param_attr,
+                fields_num=1,
+                embed_dim=1,
+                name="cross")
+            return (out)
+
     def test_roi_pool(self):
         # TODO(minqiyang): dygraph do not support lod now
         with self.static_graph():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
This Op can calculate multiply and sim between input_a and input_b. Notice: It currently supports GPU device. This Op exists in contrib, which means that it is not shown to the public.