### PR TITLE
Fix/isfinite on windows

### DIFF
--- a/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
+++ b/paddle/fluid/operators/amp/amp_check_finite_and_scale_op.cu
@@ -13,21 +13,11 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include <cuda.h>
-#include <limits>
 #include "paddle/fluid/operators/amp/amp_check_finite_and_scale_op.h"
 #include "paddle/fluid/platform/float16.h"
 
 namespace paddle {
 namespace operators {
-
-// std::isfinite has some problem on windows msvc.
-// NOTE: x == x checks NAN, std::numeric_limits::infinity checks INF.
-// Use bitwise & instead of logical && for better performance.
-// Ref: https://stackoverflow.com/questions/14580168/stdisfinite-on-msvc
-template <typename T>
-inline bool __device__ isfinite(T x) {
-  return (x == x) & (std::fabs(x) != std::numeric_limits<T>::infinity());
-}
 
 template <typename T>
 __global__ void AmpCheckFiniteAndScale(const T* in, const T* scale, int num,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

Fix compile problem on windows. The error message is:

> error : calling a `__host__` function("isfinite<float> ") from a `__global__` function("paddle::operators::AmpCheckFiniteAndScale<float> ") is not allowed

This PR changes `std::isfinite` to `finite`, so the function uses the [isfinite in cuda math functions](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__SINGLE.html#group__CUDA__MATH__SINGLE_1g57a3c8313f570282a1a7bcc78743b08e), instead of `isfinite` in c++.
In linux platform, the nvcc compiler should automatically redirect to cuda math functions, not sure why it fails on windows platform.