### PR TITLE
modify coverage gcc48 and gcc8 dockerfile trt's url, add gcc8 dockerfile

### DIFF
--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc48_ubuntu16
@@ -128,9 +128,9 @@ RUN curl -s -q https://glide.sh/get | sh
 # 2. Manually add ~IPluginFactory() in IPluginFactory class of NvInfer.h, otherwise, it couldn't work in paddle.
 #    See https://github.com/PaddlePaddle/Paddle/issues/10129 for details.
 
-RUN wget -q https://paddlepaddledeps.cdn.bcebos.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz --no-check-certificate && \
-    tar -zxf TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz -C /usr/local && \
-    cp -rf /usr/local/TensorRT-6.0.1.5/include/* /usr/include/ && cp -rf /usr/local/TensorRT-6.0.1.5/lib/* /usr/lib/ 
+RUN wget -q https://paddlepaddledeps.bj.bcebos.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.tar.gz --no-check-certificate && \
+    tar -zxf TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.tar.gz -C /usr/local && \
+    cp -rf /usr/local/TensorRT-6.0.1.5/include/* /usr/include/ && cp -rf /usr/local/TensorRT-6.0.1.5/lib/* /usr/lib/
 
 # git credential to skip password typing
 RUN git config --global credential.helper store

--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
@@ -150,56 +150,56 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 # specify sphinx version as 1.5.6 and remove -U option for [pip install -U
 # sphinx-rtd-theme] since -U option will cause sphinx being updated to newest
 # version(1.7.1 for now), which causes building documentation failed.
-RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.6 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.6 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.6 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.7 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.7 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.7 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
+    pip3 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6  && \
+    pip3 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark  && \
+    pip3.6 --no-cache-dir install -U wheel py-cpuinfo==5.0.0  && \
+    pip3.6 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6  && \
+    pip3.6 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark  && \
+    pip3.7 --no-cache-dir install -U wheel py-cpuinfo==5.0.0  && \
+    pip3.7 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6  && \
+    pip3.7 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark  && \
+    pip --no-cache-dir install -U wheel py-cpuinfo==5.0.0  && \
+    pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6  && \
+    pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark 
 
-RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3 --no-cache-dir install opencv-python -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.6 --no-cache-dir install opencv-python -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.7 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip3.7 --no-cache-dir install opencv-python -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
-    pip --no-cache-dir install -i https://pypi.tuna.tsinghua.edu.cn/simple opencv-python
+RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0  && \
+    pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0  && \
+    pip3 --no-cache-dir install opencv-python  && \
+    pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0  && \
+    pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0  && \
+    pip3.6 --no-cache-dir install opencv-python  && \
+    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0  && \
+    pip3.7 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0  && \
+    pip3.7 --no-cache-dir install opencv-python  && \
+    pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0  && \
+    pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0  && \
+    pip --no-cache-dir install  opencv-python
 
 #For docstring checker
-RUN pip3 --no-cache-dir install pylint pytest astroid isort -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.6 --no-cache-dir install pylint pytest astroid isort -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.7 --no-cache-dir install pylint pytest astroid isort -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip --no-cache-dir install pylint pytest astroid isort LinkChecker -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3 --no-cache-dir install pylint pytest astroid isort 
+RUN pip3.6 --no-cache-dir install pylint pytest astroid isort 
+RUN pip3.7 --no-cache-dir install pylint pytest astroid isort 
+RUN pip --no-cache-dir install pylint pytest astroid isort LinkChecker 
 
-RUN pip3 --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.6 --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.7 --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3 --no-cache-dir install coverage 
+RUN pip3.6 --no-cache-dir install coverage 
+RUN pip3.7 --no-cache-dir install coverage 
+RUN pip --no-cache-dir install coverage 
 
 COPY ./python/requirements.txt /root/
-RUN pip3 --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.6 --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.7 --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3 --no-cache-dir install -r /root/requirements.txt 
+RUN pip3.6 --no-cache-dir install -r /root/requirements.txt 
+RUN pip3.7 --no-cache-dir install -r /root/requirements.txt 
+RUN pip --no-cache-dir install -r /root/requirements.txt 
 
 # To fix https://github.com/PaddlePaddle/Paddle/issues/1954, we use
 # the solution in https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
 RUN apt-get install -y libssl-dev libffi-dev && apt-get clean -y
-RUN pip3 --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.6 --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip3.7 --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
-RUN pip --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3 --no-cache-dir install certifi urllib3[secure] 
+RUN pip3.6 --no-cache-dir install certifi urllib3[secure] 
+RUN pip3.7 --no-cache-dir install certifi urllib3[secure] 
+RUN pip --no-cache-dir install certifi urllib3[secure] 
 
 
 # Install woboq_codebrowser to /woboq
@@ -222,7 +222,7 @@ RUN wget -q https://paddle-ci.gz.bcebos.com/binutils_2.27.orig.tar.gz && \
 #    export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH && export PATH=/usr/local/bin:$PATH && cd .. && \
 #    rm -rf openmpi-1.4.5.tar.gz && pip --no-cache-dir install mpi4py && ln -fs /bin/bash /bin/sh && \
 RUN apt-get install libprotobuf-dev -y
-RUN pip --no-cache-dir install -U netifaces==0.10.9 -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip --no-cache-dir install -U netifaces==0.10.9 
 
 # ccache 3.7.9
 RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \

--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
@@ -23,6 +23,7 @@ ENV PATH=/usr/local/gcc-8.2/bin:$PATH
 RUN rm -rf /temp_gcc82 && rm -rf /gcc-8.2.0.tar.xz && rm -rf /gcc-8.2.0
 
 # Prepare packages for Python
+# apt install openmpi: In order to run a single test of pslib coverage
 RUN apt-get update && \
     apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
@@ -217,10 +218,6 @@ RUN wget -q https://paddle-ci.gz.bcebos.com/binutils_2.27.orig.tar.gz && \
     cd binutils-2.27 && \
     ./configure && make -j && make install && cd .. && rm -rf binutils-2.27 binutils_2.27.orig.tar.gz
 
-#RUN wget --no-check-certificate https://pslib.bj.bcebos.com/openmpi-1.4.5.tar.gz && tar -xzf openmpi-1.4.5.tar.gz && \
-#    cd openmpi-1.4.5 && ./configure --prefix=/usr/local && make all -j8 && make install -j8 && \
-#    export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH && export PATH=/usr/local/bin:$PATH && cd .. && \
-#    rm -rf openmpi-1.4.5.tar.gz && pip --no-cache-dir install mpi4py && ln -fs /bin/bash /bin/sh && \
 RUN apt-get install libprotobuf-dev -y
 RUN pip --no-cache-dir install -U netifaces==0.10.9 
 

--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
@@ -26,7 +26,7 @@ RUN rm -rf /temp_gcc82 && rm -rf /gcc-8.2.0.tar.xz && rm -rf /gcc-8.2.0
 RUN apt-get update && \
     apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev
+    xz-utils tk-dev libffi-dev liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev
 
 # gcc8.2
 RUN wget -q https://paddle-docker-tar.bj.bcebos.com/home/users/tianshuo/bce-python-sdk-0.8.27/gcc-8.2.0.tar.xz && \
@@ -134,8 +134,8 @@ RUN curl -s -q https://glide.sh/get | sh
 # 2. Manually add ~IPluginFactory() in IPluginFactory class of NvInfer.h, otherwise, it couldn't work in paddle.
 #    See https://github.com/PaddlePaddle/Paddle/issues/10129 for details.
 
-RUN wget -q https://paddlepaddledeps.cdn.bcebos.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz --no-check-certificate && \
-    tar -zxf TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.6.tar.gz -C /usr/local && \
+RUN wget -q https://paddlepaddledeps.bj.bcebos.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.tar.gz --no-check-certificate && \
+    tar -zxf TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.tar.gz -C /usr/local && \
     cp -rf /usr/local/TensorRT-6.0.1.5/include/* /usr/include/ && cp -rf /usr/local/TensorRT-6.0.1.5/lib/* /usr/lib/ 
 
 # git credential to skip password typing
@@ -150,56 +150,56 @@ RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 # specify sphinx version as 1.5.6 and remove -U option for [pip install -U
 # sphinx-rtd-theme] since -U option will cause sphinx being updated to newest
 # version(1.7.1 for now), which causes building documentation failed.
-RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
-    pip3 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
-    pip3 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark && \
-    pip3.6 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
-    pip3.6 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
-    pip3.6 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark && \
-    pip3.7 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
-    pip3.7 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
-    pip3.7 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark && \
-    pip --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
-    pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
-    pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark
+RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.6 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.6 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.6 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.7 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.7 --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.7 --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip --no-cache-dir install -U wheel py-cpuinfo==5.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark -i https://pypi.tuna.tsinghua.edu.cn/simple
 
-RUN pip3 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip3 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip3 --no-cache-dir install opencv-python && \
-    pip3.6 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip3.6 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip3.6 --no-cache-dir install opencv-python && \
-    pip3.7 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip3.7 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip3.7 --no-cache-dir install opencv-python && \
-    pip --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
-    pip --no-cache-dir install opencv-python
+RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3 --no-cache-dir install opencv-python -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.6 --no-cache-dir install opencv-python -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.7 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip3.7 --no-cache-dir install opencv-python -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 -i https://pypi.tuna.tsinghua.edu.cn/simple && \
+    pip --no-cache-dir install -i https://pypi.tuna.tsinghua.edu.cn/simple opencv-python
 
 #For docstring checker
-RUN pip3 --no-cache-dir install pylint pytest astroid isort
-RUN pip3.6 --no-cache-dir install pylint pytest astroid isort
-RUN pip3.7 --no-cache-dir install pylint pytest astroid isort
-RUN pip --no-cache-dir install pylint pytest astroid isort LinkChecker
+RUN pip3 --no-cache-dir install pylint pytest astroid isort -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.6 --no-cache-dir install pylint pytest astroid isort -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.7 --no-cache-dir install pylint pytest astroid isort -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip --no-cache-dir install pylint pytest astroid isort LinkChecker -i https://pypi.tuna.tsinghua.edu.cn/simple
 
-RUN pip3 --no-cache-dir install coverage                
-RUN pip3.6 --no-cache-dir install coverage             
-RUN pip3.7 --no-cache-dir install coverage            
-RUN pip --no-cache-dir install coverage
+RUN pip3 --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.6 --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.7 --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip --no-cache-dir install coverage -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 COPY ./python/requirements.txt /root/
-RUN pip3 --no-cache-dir install -r /root/requirements.txt
-RUN pip3.6 --no-cache-dir install -r /root/requirements.txt
-RUN pip3.7 --no-cache-dir install -r /root/requirements.txt
-RUN pip --no-cache-dir install -r /root/requirements.txt
+RUN pip3 --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.6 --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.7 --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip --no-cache-dir install -r /root/requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # To fix https://github.com/PaddlePaddle/Paddle/issues/1954, we use
 # the solution in https://urllib3.readthedocs.io/en/latest/user-guide.html#ssl-py2
 RUN apt-get install -y libssl-dev libffi-dev && apt-get clean -y
-RUN pip3 --no-cache-dir install certifi urllib3[secure]
-RUN pip3.6 --no-cache-dir install certifi urllib3[secure]
-RUN pip3.7 --no-cache-dir install certifi urllib3[secure]
-RUN pip --no-cache-dir install certifi urllib3[secure]
+RUN pip3 --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.6 --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip3.7 --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
+RUN pip --no-cache-dir install certifi urllib3[secure] -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 
 # Install woboq_codebrowser to /woboq
@@ -217,12 +217,12 @@ RUN wget -q https://paddle-ci.gz.bcebos.com/binutils_2.27.orig.tar.gz && \
     cd binutils-2.27 && \
     ./configure && make -j && make install && cd .. && rm -rf binutils-2.27 binutils_2.27.orig.tar.gz
 
-RUN wget --no-check-certificate https://pslib.bj.bcebos.com/openmpi-1.4.5.tar.gz && tar -xzf openmpi-1.4.5.tar.gz && \
-    cd openmpi-1.4.5 && ./configure --prefix=/usr/local && make all -j8 && make install -j8 && \
-    export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH && export PATH=/usr/local/bin:$PATH && cd .. && \
-    rm -rf openmpi-1.4.5.tar.gz && pip --no-cache-dir install mpi4py && ln -fs /bin/bash /bin/sh && \
-    apt-get install libprotobuf-dev -y
-RUN pip --no-cache-dir install -U netifaces==0.10.9
+#RUN wget --no-check-certificate https://pslib.bj.bcebos.com/openmpi-1.4.5.tar.gz && tar -xzf openmpi-1.4.5.tar.gz && \
+#    cd openmpi-1.4.5 && ./configure --prefix=/usr/local && make all -j8 && make install -j8 && \
+#    export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH && export PATH=/usr/local/bin:$PATH && cd .. && \
+#    rm -rf openmpi-1.4.5.tar.gz && pip --no-cache-dir install mpi4py && ln -fs /bin/bash /bin/sh && \
+RUN apt-get install libprotobuf-dev -y
+RUN pip --no-cache-dir install -U netifaces==0.10.9 -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # ccache 3.7.9
 RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
修改coverage的dockerfile中trt下载地址(包含gcc48和gcc8)
新地址: https://paddlepaddledeps.bj.bcebos.com/TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.tar.gz
因镜像构建时，一直不会出现安装超时情况，故我在coverage_gcc8dockerfile里给pip加上了清华源
pip安装添加参数: -i https://pypi.tuna.tsinghua.edu.cn/simple
coverage_gcc8的dockerfile中，openmpi的安装方式改为用apt-get安装