### PR TITLE
fix the segement fault error of profiler in seqseq model test=develop

### DIFF
--- a/paddle/fluid/platform/device_tracer.cc
+++ b/paddle/fluid/platform/device_tracer.cc
@@ -646,7 +646,6 @@ DeviceTracer *GetDeviceTracer() {
 // so when event is not in same thread of PE event, we need add
 // father event(PE::run event) for this event
 void SetCurAnnotation(Event *event) {
-  std::string ret;
   if (!annotation_stack.empty()) {
     event->set_parent(annotation_stack.back());
     event->set_name(annotation_stack.back()->name() + "/" + event->name());

--- a/paddle/fluid/platform/device_tracer.cc
+++ b/paddle/fluid/platform/device_tracer.cc
@@ -670,17 +670,16 @@ void SetCurAnnotation(Event *event) {
 }
 
 void ClearCurAnnotation() {
-  if (!main_thread_annotation_stack.empty() &&
-      main_thread_annotation_stack.back()->name() ==
-          annotation_stack.back()->name()) {
+  if (!main_thread_annotation_stack.empty()) {
     std::string name = annotation_stack.back()->name();
     std::string main_name = main_thread_annotation_stack.back()->name();
     int main_name_len = main_name.length();
     int name_len = name.length();
     int prefix_len = main_name_len - name_len;
 
-    if (prefix_len >= 0 && main_name.at(prefix_len) == '/' &&
-        name == main_name.substr(prefix_len, name_len)) {
+    if ((prefix_len > 0 && main_name.at(prefix_len - 1) == '/' &&
+         name == main_name.substr(prefix_len, name_len)) ||
+        (name == main_name)) {
       main_thread_annotation_stack_name.pop_back();
       main_thread_annotation_stack.pop_back();
     }

--- a/paddle/fluid/platform/profiler.cc
+++ b/paddle/fluid/platform/profiler.cc
@@ -71,8 +71,8 @@ RecordEvent::RecordEvent(const std::string &name, const EventRole role) {
   role_ = role;
   is_enabled_ = true;
   // lock is not needed, the code below is thread-safe
-  Event *e = PushEvent(name, role);
   // Maybe need the same push/pop behavior.
+  Event *e = PushEvent(name, role);
   SetCurAnnotation(e);
   name_ = e->name();
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Describe
<!-- Describe what this PR does --> . 
main_thread_annotation_stack中存放的是类似PE之类的Special的event,当clear的时候遇到相应的event应该pop出去（annotation_stack是thread_local变量，线程之间无法互相访问，main_thread_annotation_stack是为了解决这个问题）
main_thread_annotation_stack 需要pop的前置条件设置错误 应该是main_thread_annotation_stack非空的情况下，当满足680行的任意一个条件就Pop（或逻辑）（导致错误的原因是原来是与逻辑）


修改前seqseq 的profiler结果出错

![image](https://user-images.githubusercontent.com/13411999/83985909-794f7000-a96d-11ea-854d-a7d08b20bbc0.png)


修改后seqseq 的profiler结果正常

![image](https://user-images.githubusercontent.com/13411999/83985914-82404180-a96d-11ea-9880-f3bcf66e7835.png)
