### PR TITLE
Fix the bug that Input(Offsets) and attr(offsets) cannot be set at the same time.

### DIFF
--- a/paddle/fluid/operators/crop_tensor_op.h
+++ b/paddle/fluid/operators/crop_tensor_op.h
@@ -144,6 +144,7 @@ static std::vector<int> GetOffsets(const framework::ExecutionContext& ctx) {
                           "input 'Offsets' must be equal to "
                           "the number of dimensions (%d) of the input tensor.",
                           offsets_tensor->dims()[0], rank));
+
     const int* offsets_data;
     framework::Tensor cpu_tmp_tensor;
     if (platform::is_cpu_place(offsets_tensor->place())) {

--- a/paddle/fluid/operators/crop_tensor_op.h
+++ b/paddle/fluid/operators/crop_tensor_op.h
@@ -132,11 +132,6 @@ static std::vector<int> GetOffsets(const framework::ExecutionContext& ctx) {
   }
 
   if (ctx.HasInput("Offsets")) {
-    PADDLE_ENFORCE_EQ(
-        ctx.Attr<std::vector<int>>("offsets").empty(), true,
-        platform::errors::InvalidArgument(
-            "Input 'Offsets' and attribute 'offsets' for Op(crop_tensor) "
-            "cannot be used at the same time."));
     const auto* offsets_tensor = ctx.Input<Tensor>("Offsets");
     PADDLE_ENFORCE_EQ(offsets_tensor->dims().size(), 1,
                       platform::errors::InvalidArgument(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Fix the bug that Input(Offsets) and attr(offsets) cannot be set at the same time. 
The python side set them both (as the following figure shows), and Input(Offsets) has a high priority， thus we can remove the ENFORCE_XX statement in the source codes.
![image](https://user-images.githubusercontent.com/6737864/88919263-5ec6b280-d29d-11ea-9007-8c5d3358d322.png)

