### PR TITLE
Clear hold scope before execute run_program_op

### DIFF
--- a/paddle/fluid/operators/run_program_op.h
+++ b/paddle/fluid/operators/run_program_op.h
@@ -198,7 +198,11 @@ class RunProgramOpKernel : public framework::OpKernel<T> {
 
     auto exe_ctx = exe.Prepare(*program, 0, skip_vars);
 
+    // get scope and clear old vars
     framework::Scope &scope = *(out_scope_vec->front());
+    auto local_vars = scope.LocalVarNames();
+    scope.EraseVars(local_vars);
+
     // share input_vars & parameters into scope
     details::ShareVarsIntoScope(input_vars, input_var_names, &scope);
     details::ShareVarsIntoScope(param_vars, param_names, &scope);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

the scope used in run_program_op is holded by python class, which is to avoid repeated creation and destruction of temp scopes. But if we only hold one scope, we should claer it before using it next time, because some variable's state may need to be updated.
