### PR TITLE
improve performance of instance_norm

### DIFF
--- a/paddle/fluid/operators/instance_norm_op.cc
+++ b/paddle/fluid/operators/instance_norm_op.cc
@@ -311,8 +311,8 @@ class InstanceNormGradKernel<platform::CPUDeviceContext, T>
     auto dy_arr = dy_e.reshape(shape);
     auto x_arr = x_e.reshape(shape);
 
-    auto tmp =
-        (x_arr - mean_arr.broadcast(bcast)) * inv_var_arr.broadcast(bcast);
+    auto tmp = (x_arr - mean_arr.eval().broadcast(bcast)) *
+               inv_var_arr.eval().broadcast(bcast);
 
     math::SetConstant<platform::CPUDeviceContext, T> set_constant;
     // math: d_bias = np.sum(d_y, axis=(n,h,w))
@@ -333,7 +333,8 @@ class InstanceNormGradKernel<platform::CPUDeviceContext, T>
           (tmp * dy_arr).sum(mean_rdims).reshape(param_shape).sum(rdims);
     }
 
-    auto dy_mean = dy_arr.mean(mean_rdims).reshape(NxC_shape).broadcast(bcast);
+    auto dy_mean =
+        dy_arr.mean(mean_rdims).reshape(NxC_shape).eval().broadcast(bcast);
 
     Eigen::DSizes<int, 2> bcast_param(N, sample_size);
     set_constant(dev_ctx, d_x, static_cast<T>(0));
@@ -351,6 +352,7 @@ class InstanceNormGradKernel<platform::CPUDeviceContext, T>
                                  (dy_arr * tmp)
                                      .mean(mean_rdims)
                                      .reshape(NxC_shape)
+                                     .eval()
                                      .broadcast(bcast));
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->  OPs

### Describe
<!-- Describe what this PR does --> improve performance of instance_norm by calling eval()

**说明**：Eigen的官方文档中提到，在一些表达式中插入`eval()`可以避免重复计算，从而提升性能。参考[链接](https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/CXX11/src/Tensor/README.md#calling-eval)。在实验中发现，当计算表达式中存在broadcast，并且在broadcast之前有较多其他运算时，可能会造成重复计算。因此本PR尝试在instance_norm 反向OP的计算表达式中插入`eval()`，去提升该OP的性能。

以下是instance_norm的CPU性能，实验表明修改后性能得到大幅度提升。该OP在GPU下调用cub库，因此使用eval也不会增加GPU下的显存

**性能提升**
  |op|input shape|before|after| speed up |
  |---|---|---|---|---|
  |instance_norm_grad|[1, 64, 128, 128]|166419 ms|149.262 ms|1115倍| 
  |instance_norm_grad|[1, 128, 64, 64]|20719.6 ms|74.9551 ms|276倍| 
  |instance_norm_grad|[1, 256, 32, 32]|2606.85 ms|37.3511 ms|70倍|
