### PR TITLE
Replace some logging.warn() with warings.warn(), test=develop

### DIFF
--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 
-import logging
+import warnings
 import inspect
 
 from .. import core
@@ -268,7 +268,7 @@ def monkey_patch_variable():
                 stack = inspect.stack()[1]
                 file_name = stack[1]
                 line_num = stack[2]
-                logging.warning(
+                warnings.warn(
                     "%s:%s\nThe behavior of expression %s has been unified with %s(X, Y, axis=-1) from Paddle 2.0. "
                     "If your code works well in the older versions but crashes in this version, try to use "
                     "%s(X, Y, axis=0) instead of %s. This transitional warning will be dropped in the future."

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -27,6 +27,7 @@ from .dataloader.dataloader_iter import _DataLoaderIterSingleProcess, _DataLoade
 from .layers.io import monkey_patch_reader_methods, _copy_reader_var_, double_buffer
 from .unique_name import UniqueNameGenerator
 import logging
+import warnings
 from .dataset import DatasetBase, InMemoryDataset
 
 ### Dygraph DataLoader configs ###
@@ -313,9 +314,9 @@ class DataLoader(object):
         assert num_workers >= 0, "num_workers should be a non-negative value"
         if num_workers > 0 and (sys.platform == 'darwin' or
                                 sys.platform == 'win32'):
-            logging.warning(
-                "multi-process mode not support MacOs and Windows currently." \
-                " use signle-process with num_workers = 0 instead")
+            warnings.warn(
+                "DataLoader with multi-process mode is not supported on MacOs and Windows currently." \
+                " Please use signle-process mode with num_workers = 0 instead")
             num_workers = 0
         self.num_workers = num_workers
 
@@ -670,13 +671,13 @@ class DygraphGeneratorLoader(DataLoaderBase):
         self._use_double_buffer = use_double_buffer
 
         if not iterable:
-            logging.warning(
-                "Please NOTE: imperative mode can support iterable mode only. Change to iterable mode."
+            warnings.warn(
+                "Please NOTE: DygraphGeneratorLoader supports iterable mode only. Change to iterable mode."
             )
         self._iterable = True
         if not return_list:
-            logging.warning(
-                "Please NOTE: imperative mode can support return as list only. Change to return as list."
+            warnings.warn(
+                "Please NOTE: DygraphGeneratorLoader supports returning as list only. Change to return as list."
             )
         self._return_list = True
 
@@ -684,8 +685,8 @@ class DygraphGeneratorLoader(DataLoaderBase):
         self._use_multiprocess = use_multiprocess
         if self._use_multiprocess and (sys.platform == 'darwin' or
                                        sys.platform == 'win32'):
-            logging.warning(
-                "NOTE: The multiprocess mode does not currently support MacOs and Windows."
+            warnings.warn(
+                "NOTE: DygraphGeneratorLoader with multiprocess mode is not currently supported on MacOs and Windows."
             )
             self._use_multiprocess = False
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Replace some `logging.warn()` with `warings.warn()`

As stated in [official doc ](https://docs.python.org/2/howto/logging.html#when-to-use-logging)

> `warnings.warn()` in library code if the issue is avoidable and the client application should be modified to eliminate the warning
> `logging.warning()` if there is nothing the client application can do about the situation, but the event should still be noted

Plus, repetitions of a particular warning for the same source location are typically suppressed when using `warnings.warn()`.

To avoid the following logs,
![image](https://user-images.githubusercontent.com/6888866/84402533-1d1f7100-ac37-11ea-8868-62ba5f79dc8a.png)

