### PR TITLE
Add api to clear intermediate tensors in AnalysisPredictor

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.h
+++ b/paddle/fluid/inference/api/analysis_predictor.h
@@ -188,6 +188,12 @@ class AnalysisPredictor : public PaddlePredictor {
   void OptimizeInferenceProgram();
 
   ///
+  /// \brief Clear the intermediate tensors of the predictor
+  ///
+  ///
+  void ClearIntermediateTensor();
+
+  ///
   /// \brief Get the argument used by predictor
   ///
   /// \return the argument obtained by config

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -313,6 +313,12 @@ class PD_INFER_DECL PaddlePredictor {
   /// \return Whether the run is successful
   virtual bool ZeroCopyRun() { return false; }
 
+  ///
+  /// \brief Clear the intermediate tensors of the predictor
+  ///
+  ///
+  virtual void ClearIntermediateTensor() {}
+
   /// \brief Clone an existing predictor
   /// When using clone, the same network will be created,
   /// and the parameters between them are shared.

--- a/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
@@ -44,6 +44,7 @@ TEST(AnalysisPredictor, use_gpu) {
   for (auto& input : inputs_all) {
     ASSERT_TRUE(predictor->Run(input, &outputs));
   }
+  predictor->ClearIntermediateTensor();
 }
 
 }  // namespace inference

--- a/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_mobilenet_test.cc
@@ -43,8 +43,8 @@ TEST(AnalysisPredictor, use_gpu) {
   std::vector<PaddleTensor> outputs;
   for (auto& input : inputs_all) {
     ASSERT_TRUE(predictor->Run(input, &outputs));
+    predictor->ClearIntermediateTensor();
   }
-  predictor->ClearIntermediateTensor();
 }
 
 }  // namespace inference

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -501,6 +501,8 @@ void BindAnalysisPredictor(py::module *m) {
       .def("get_output_names", &AnalysisPredictor::GetOutputNames)
       .def("get_input_tensor_shape", &AnalysisPredictor::GetInputTensorShape)
       .def("zero_copy_run", &AnalysisPredictor::ZeroCopyRun)
+      .def("clear_intermediate_tensor",
+           &AnalysisPredictor::ClearIntermediateTensor)
       .def("create_feed_fetch_var", &AnalysisPredictor::CreateFeedFetchVar)
       .def("prepare_feed_fetch", &AnalysisPredictor::PrepareFeedFetch)
       .def("prepare_argument", &AnalysisPredictor::PrepareArgument)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
On some devices, memory/graphic-memory is limited. Instead of running paddle inference parallelly, we have to load, analyze, and run them one after another(with each one's resources released after running) on these devices to avoid OOM. In such situations, loading and analysis phases become bottleneck of latency.
So we add an API to clear intermediate tensors, enabling AnalysisPredictor to load and analyze all models first, and run inference one by one(with each one's intermediate tensors released to graphic memory pool by calling ClearIntermediateTensor()) to cut the overhead mentioned above.