### PR TITLE
test=develop, fix the gpu inference library can't compile on windows

### DIFF
--- a/cmake/inference_lib.cmake
+++ b/cmake/inference_lib.cmake
@@ -21,7 +21,7 @@ set(FLUID_INFERENCE_INSTALL_DIR "${CMAKE_BINARY_DIR}/fluid_inference_install_dir
   
 if(WIN32)
     #todo: remove the option 
-    option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   ON)
+    option(WITH_STATIC_LIB "Compile demo with static/shared library, default use static."   OFF)
     if(NOT PYTHON_EXECUTABLE)
         FIND_PACKAGE(PythonInterp REQUIRED)
     endif()
@@ -128,7 +128,11 @@ function(copy_part_of_thrid_party TARGET DST)
 endfunction()
 
 # inference library for only inference
-set(inference_lib_deps third_party paddle_fluid paddle_fluid_c paddle_fluid_shared paddle_fluid_c_shared)
+if(WIN32)
+  set(inference_lib_deps third_party  paddle_fluid_c paddle_fluid_shared paddle_fluid_c_shared)
+else()
+  set(inference_lib_deps third_party paddle_fluid paddle_fluid_c paddle_fluid_shared paddle_fluid_c_shared)
+endif()
 add_custom_target(inference_lib_dist DEPENDS ${inference_lib_deps})
 
 
@@ -194,6 +198,12 @@ endif(WIN32)
 copy(inference_lib_dist
         SRCS  ${src_dir}/inference/capi/paddle_c_api.h  ${paddle_fluid_c_lib}
         DSTS  ${FLUID_INFERENCE_C_INSTALL_DIR}/paddle/include ${FLUID_INFERENCE_C_INSTALL_DIR}/paddle/lib)
+
+if(WIN32)
+  copy(inference_lib_dist
+          SRCS  ${PADDLE_BINARY_DIR}/paddle/fluid/inference/${CMAKE_BUILD_TYPE}/paddle_fluid.dll
+          DSTS  ${FLUID_INFERENCE_C_INSTALL_DIR}/paddle/lib)
+endif()
 
 # fluid library for both train and inference
 set(fluid_lib_deps inference_lib_dist)

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -44,9 +44,10 @@ add_subdirectory(api)
 # All static libs in inference/api
 set(STATIC_INFERENCE_API paddle_inference_api analysis_predictor zero_copy_tensor reset_tensor_array
               analysis_config paddle_pass_builder activation_functions ${mkldnn_quantizer_cfg})
-create_static_lib(paddle_fluid ${fluid_modules} ${STATIC_INFERENCE_API})
-
-if(NOT APPLE)
+if(NOT WIN32)
+  create_static_lib(paddle_fluid ${fluid_modules} ${STATIC_INFERENCE_API})
+endif()
+if(NOT APPLE AND NOT WIN32)
   # TODO(liuyiqu: Temporarily disable the link flag because it is not support on Mac.
   set(LINK_FLAGS "-Wl,--retain-symbols-file ${CMAKE_CURRENT_SOURCE_DIR}/paddle_fluid.sym")
   set_target_properties(paddle_fluid PROPERTIES LINK_FLAGS "${LINK_FLAGS}")

--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -117,7 +117,12 @@ else()
 endif()
 
 if(WITH_STATIC_LIB)
-  set(DEPS ${PADDLE_LIB}/paddle/lib/libpaddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
+  if(WIN32)
+     message(WARNING "The option of \"WITH_STATIC_LIB\" is invaild on winodws.")
+     set(DEPS ${PADDLE_LIB}/paddle/lib/paddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
+  else()
+    set(DEPS ${PADDLE_LIB}/paddle/lib/libpaddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
+  endif()
 else()
   if(WIN32)
     set(DEPS ${PADDLE_LIB}/paddle/lib/paddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
@@ -179,9 +184,9 @@ if(WIN32)
           COMMAND ${CMAKE_COMMAND} -E copy ${OPENBLAS_LIB_PATH}/lib/openblas.dll ${CMAKE_BINARY_DIR}/Release
     )
   endif()
-  if(NOT WITH_STATIC_LIB)
+  
       add_custom_command(TARGET ${DEMO_NAME} POST_BUILD 
         COMMAND ${CMAKE_COMMAND} -E copy "${PADDLE_LIB}/paddle/lib/paddle_fluid.dll" ${CMAKE_BINARY_DIR}/${CMAKE_BUILD_TYPE}
       )
-  endif()
+  
 endif()

--- a/paddle/fluid/inference/capi/CMakeLists.txt
+++ b/paddle/fluid/inference/capi/CMakeLists.txt
@@ -15,14 +15,23 @@
 
 set(C_API_SRCS pd_config.cc pd_predictor.cc pd_tensor.cc c_api.cc)
 
-cc_library(paddle_fluid_c SRCS ${C_API_SRCS} DEPS paddle_fluid)
+if(WIN32)
+  cc_library(paddle_fluid_c SRCS ${C_API_SRCS} DEPS paddle_fluid_shared)
+else()
+  cc_library(paddle_fluid_c SRCS ${C_API_SRCS} DEPS paddle_fluid)
+endif()
 
 if(NOT ON_INFER)
     return()
 endif()
 
 # Create inference capi shared library
-cc_library(paddle_fluid_c_shared SHARED SRCS ${C_API_SRCS} DEPS paddle_fluid)
+if(WIN32)
+  cc_library(paddle_fluid_c_shared SHARED SRCS ${C_API_SRCS} DEPS paddle_fluid_shared)
+else()
+  cc_library(paddle_fluid_c_shared SHARED SRCS ${C_API_SRCS} DEPS paddle_fluid)
+endif()
+
 set_target_properties(paddle_fluid_c_shared PROPERTIES OUTPUT_NAME paddle_fluid_c)
 if(WIN32)
     target_link_libraries(paddle_fluid_c_shared shlwapi.lib)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes 

### PR changes
Others

### Describe
Fix the bug  of GPU inference library can't compile on windows.

The reason for this problem is that the inference static library is too large (4GB) and exceeds the limit.

