### PR TITLE
fix dtype error in retinanet_target_assgin example codes

### DIFF
--- a/python/paddle/fluid/layers/detection.py
+++ b/python/paddle/fluid/layers/detection.py
@@ -230,9 +230,9 @@ def retinanet_target_assign(bbox_pred,
           gt_boxes = fluid.data(name='gt_boxes', shape=[10, 4],
                             dtype='float32')
           gt_labels = fluid.data(name='gt_labels', shape=[10, 1],
-                            dtype='float32')
+                            dtype='int32')
           is_crowd = fluid.data(name='is_crowd', shape=[1],
-                            dtype='float32')
+                            dtype='int32')
           im_info = fluid.data(name='im_info', shape=[1, 3],
                             dtype='float32')
           score_pred, loc_pred, score_target, loc_target, bbox_inside_weight, fg_num = \\


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Describe
Example code of retinanet_target_assgin op raises dtype errors, input `gt_label` and `is_crowd` must be int32 variables but they are float32 variables before，so this bug need to be been fixed.

**Before**
![image](https://user-images.githubusercontent.com/22235422/84869329-7876b680-b0b0-11ea-903f-6909076e2999.png)
![image](https://user-images.githubusercontent.com/22235422/84869365-83c9e200-b0b0-11ea-904c-9edda361a8d7.png)
![image](https://user-images.githubusercontent.com/22235422/84869400-8f1d0d80-b0b0-11ea-858f-6cd3d3bf27ac.png)
![image](https://user-images.githubusercontent.com/22235422/84869424-96441b80-b0b0-11ea-85be-faaf635682c2.png)

**After**
![image](https://user-images.githubusercontent.com/22235422/84869185-4b2a0880-b0b0-11ea-95c4-cdac996d90ad.png)
![image](https://user-images.githubusercontent.com/22235422/84869232-57ae6100-b0b0-11ea-93ad-37f36132a4c8.png)
![image](https://user-images.githubusercontent.com/22235422/84869252-5f6e0580-b0b0-11ea-9228-591b94ee4f18.png)
![image](https://user-images.githubusercontent.com/22235422/84869275-6563e680-b0b0-11ea-8561-d604aef5f301.png)
