### PR TITLE
add minimum learning rate of API:CosineDecay,test=develop

### DIFF
--- a/python/paddle/fluid/dygraph/learning_rate_scheduler.py
+++ b/python/paddle/fluid/dygraph/learning_rate_scheduler.py
@@ -487,6 +487,7 @@ class CosineDecay(LearningRateDecay):
         begin(int, optional): The begin step. The initial value of global_step described above. The default value is 0.
         step(int, optional): The step size used to calculate the new global_step in the description above.
             The default value is 1.
+        min_lr(float, optional): The minimum learning rate. Default: 0.
         dtype(str, optional): The data type used to create the learning rate variable. The data type can be set as
             'float32', 'float64'. The default value is 'float32'.
 
@@ -509,17 +510,19 @@ class CosineDecay(LearningRateDecay):
                  epochs,
                  begin=0,
                  step=1,
+                 min_lr=0,
                  dtype='float32'):
         super(CosineDecay, self).__init__(begin, step, dtype)
         self.learning_rate = learning_rate
         self.step_each_epoch = step_each_epoch
         self.epochs = epochs
+        self.min_lr = min_lr
 
     def step(self):
         from .. import layers
         cur_epoch = layers.floor(
             self.create_lr_var(self.step_num / self.step_each_epoch))
-        decayed_lr = self.learning_rate * 0.5 * (
+        decayed_lr = self.min_lr + (self.learning_rate - self.min_lr) * 0.5 * (
             layers.cos(cur_epoch * math.pi / self.epochs) + 1)
         return decayed_lr
 

--- a/python/paddle/fluid/layers/learning_rate_scheduler.py
+++ b/python/paddle/fluid/layers/learning_rate_scheduler.py
@@ -448,7 +448,7 @@ Applies piecewise decay to the initial learning rate.
             return lr
 
 
-def cosine_decay(learning_rate, step_each_epoch, epochs):
+def cosine_decay(learning_rate, step_each_epoch, epochs, min_lr=0):
     """
 	:alias_main: paddle.nn.functional.cosine_decay
 	:alias: paddle.nn.functional.cosine_decay,paddle.nn.functional.learning_rate.cosine_decay
@@ -468,6 +468,7 @@ def cosine_decay(learning_rate, step_each_epoch, epochs):
         learning_rate(Variable|float): The initial learning rate.
         step_each_epoch(int): the number of steps in an epoch.
         epochs(int): the number of epochs.
+        min_lr(float, optional): The minimum learning rate. Default: 0.
 
     Returns:
         Variable: The decayed learning rate.
@@ -492,8 +493,8 @@ def cosine_decay(learning_rate, step_each_epoch, epochs):
             global_step = _decay_step_counter()
 
             cur_epoch = ops.floor(global_step / step_each_epoch)
-            decayed_lr = learning_rate * 0.5 * (
-                ops.cos(cur_epoch * math.pi / epochs) + 1)
+            decayed_lr = min_lr + (learning_rate - min_lr) * 0.5 * (ops.cos(
+                cur_epoch * math.pi / epochs) + 1)
             return decayed_lr
 
 

--- a/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
+++ b/python/paddle/fluid/tests/unittests/test_learning_rate_scheduler.py
@@ -83,10 +83,10 @@ def piecewise_decay(global_step, boundaries, values):
     return values[len(values) - 1]
 
 
-def cosine_decay(global_step, learning_rate, step_each_epoch, epochs):
+def cosine_decay(global_step, learning_rate, step_each_epoch, epochs, min_lr):
     cur_epoch = math.floor(global_step / step_each_epoch)
-    decayed_lr = learning_rate * 0.5 * (
-        math.cos(cur_epoch * math.pi / epochs) + 1)
+    decayed_lr = min_lr + (learning_rate - min_lr) * 0.5 * (math.cos(
+        cur_epoch * math.pi / epochs) + 1)
     return decayed_lr
 
 
@@ -187,9 +187,10 @@ class TestLearningRateDecay(unittest.TestCase):
                 "values": [0.1, 0.2, 0.3, 0.4]
             }),
             (cosine_decay, layers.cosine_decay, {
-                "learning_rate": 0.1,
+                "learning_rate": 0.5,
                 "step_each_epoch": 100,
-                "epochs": 120
+                "epochs": 120,
+                "min_lr": 0.1
             }),
             (noam_decay, layers.noam_decay, {
                 "d_model": 0.01,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
make API:CosineDecay support minimum learning rate.