### PR TITLE
Polish tensor set error messag

### DIFF
--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -246,12 +246,13 @@ void SetTensorFromPyArray(framework::Tensor *self, const py::object &obj,
   } else if (py::isinstance<py::array_t<bool>>(array)) {
     SetTensorFromPyArrayT<bool, P>(self, array, place, zero_copy);
   } else {
+    // obj may be any type, obj.cast<py::array>() may be failed,
+    // then the array.dtype will be string of unknown meaning,
     PADDLE_THROW(platform::errors::InvalidArgument(
-        "Incompatible data type: tensor.set() supports bool, float16, "
-        "float32, "
-        "float64, "
-        "int8, int16, int32, int64 and uint8, uint16, but got %s!",
-        array.dtype()));
+        "Input object type error or incompatible array data type. "
+        "tensor.set() supports array with bool, float16, float32, "
+        "float64, int8, int16, int32, int64, uint8 or uint16, "
+        "please check your input or input array data type."));
   }
 }
 

--- a/python/paddle/fluid/tests/unittests/test_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor.py
@@ -345,6 +345,22 @@ class TestTensor(unittest.TestCase):
             self.assertEqual([2, 200, 300], tensor.shape())
             self.assertTrue(numpy.array_equal(numpy.array(tensor), list_array))
 
+    def test_tensor_set_error(self):
+        scope = core.Scope()
+        var = scope.var("test_tensor")
+        place = core.CPUPlace()
+
+        tensor = var.get_tensor()
+
+        exception = None
+        try:
+            error_array = ["1", "2"]
+            tensor.set(error_array, place)
+        except core.EnforceNotMet as ex:
+            exception = ex
+
+        self.assertIsNotNone(exception)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

poliish tensor.set() error message.

code example:
```
error_array = ['1', '2']
tensor.set(error_array, place)
```

original:

```
----------------------
Error Message Summary:
----------------------
InvalidArgumentError: Incompatible data type: tensor.set() supports bool, float16, float32, float64, int8, int16, int32, int64 and uint8, uint16, but got <U1! at (/work/paddle/paddle/fluid/pybind/tensor_py.h:254)
```

new:

```
----------------------
Error Message Summary:
----------------------
InvalidArgumentError: Input object type error or incompatible array data type. tensor.set() supports array with bool, float16, float32, float64, int8, int16, int32, int64, uint8 or uint16, please check your input or input array data type. at (/work/paddle/paddle/fluid/pybind/tensor_py.h:255)
```