### PR TITLE
remove ${CMAKE_VERSION} VERSION_LESS "3.3.0".

### DIFF
--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -52,7 +52,7 @@ ExternalProject_Add(
     UPDATE_COMMAND        ""
     )
 
-if (${CMAKE_VERSION} VERSION_LESS "3.3.0" OR NOT WIN32)
+if (NOT WIN32)
     set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/boost_dummy.c)
     file(WRITE ${dummyfile} "const char *dummy = \"${dummyfile}\";")
     add_library(boost STATIC ${dummyfile})

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -52,13 +52,7 @@ ExternalProject_Add(
     UPDATE_COMMAND        ""
     )
 
-if (NOT WIN32)
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/boost_dummy.c)
-    file(WRITE ${dummyfile} "const char *dummy = \"${dummyfile}\";")
-    add_library(boost STATIC ${dummyfile})
-else()
-    add_library(boost INTERFACE)
-endif()
+add_library(boost INTERFACE)
 
 add_dependencies(boost ${BOOST_PROJECT})
 set(Boost_INCLUDE_DIR ${BOOST_INCLUDE_DIR})

--- a/cmake/external/cub.cmake
+++ b/cmake/external/cub.cmake
@@ -41,12 +41,6 @@ ExternalProject_Add(
   TEST_COMMAND      ""
 )
 
-if(${CMAKE_VERSION} VERSION_LESS "3.3.0")
-  set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/cub_dummy.c)
-  file(WRITE ${dummyfile} "const char *dummy = \"${dummyfile}\";")
-  add_library(cub STATIC ${dummyfile})
-else()
-  add_library(cub INTERFACE)
-endif()
+add_library(cub INTERFACE)
 
 add_dependencies(cub extern_cub)

--- a/cmake/external/dlpack.cmake
+++ b/cmake/external/dlpack.cmake
@@ -42,12 +42,6 @@ ExternalProject_Add(
   TEST_COMMAND      ""
 )
 
-if(${CMAKE_VERSION} VERSION_LESS "3.3.0")
-  set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/dlpack_dummy.c)
-  file(WRITE ${dummyfile} "const char *dummy = \"${dummyfile}\";")
-  add_library(dlpack STATIC ${dummyfile})
-else()
-  add_library(dlpack INTERFACE)
-endif()
+add_library(dlpack INTERFACE)
 
 add_dependencies(dlpack extern_dlpack)

--- a/cmake/external/eigen.cmake
+++ b/cmake/external/eigen.cmake
@@ -89,12 +89,6 @@ else()
     )
 endif()
 
-if (${CMAKE_VERSION} VERSION_LESS "3.3.0")
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/eigen3_dummy.c)
-    file(WRITE ${dummyfile} "const char *dummy_eigen3 = \"${dummyfile}\";")
-    add_library(eigen3 STATIC ${dummyfile})
-else()
-    add_library(eigen3 INTERFACE)
-endif()
+add_library(eigen3 INTERFACE)
 
 add_dependencies(eigen3 extern_eigen3)

--- a/cmake/external/libmct.cmake
+++ b/cmake/external/libmct.cmake
@@ -52,7 +52,7 @@ ExternalProject_Add(
     CMAKE_CACHE_ARGS      -DCMAKE_INSTALL_PREFIX:PATH=${LIBMCT_INSTALL_ROOT}
 )
 
-if (${CMAKE_VERSION} VERSION_LESS "3.3.0" OR NOT WIN32)
+if (NOT WIN32)
     set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/boost_dummy.c)
     file(WRITE ${dummyfile} "const char *dummy = \"${dummyfile}\";")
     add_library(libmct STATIC ${dummyfile})

--- a/cmake/external/libmct.cmake
+++ b/cmake/external/libmct.cmake
@@ -52,12 +52,6 @@ ExternalProject_Add(
     CMAKE_CACHE_ARGS      -DCMAKE_INSTALL_PREFIX:PATH=${LIBMCT_INSTALL_ROOT}
 )
 
-if (NOT WIN32)
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/boost_dummy.c)
-    file(WRITE ${dummyfile} "const char *dummy = \"${dummyfile}\";")
-    add_library(libmct STATIC ${dummyfile})
-else()
-    add_library(libmct INTERFACE)
-endif()
+add_library(libmct INTERFACE)
 
 ADD_DEPENDENCIES(libmct ${LIBMCT_PROJECT})

--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -41,12 +41,6 @@ ExternalProject_Add(
         TEST_COMMAND      ""
 )
 
-if(${CMAKE_VERSION} VERSION_LESS "3.3.0")
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/pybind_dummy.c)
-    file(WRITE ${dummyfile} "const char * dummy_pybind = \"${dummyfile}\";")
-    add_library(pybind STATIC ${dummyfile})
-else()
-    add_library(pybind INTERFACE)
-endif()
+add_library(pybind INTERFACE)
 
 add_dependencies(pybind extern_pybind)

--- a/cmake/external/rocprim.cmake
+++ b/cmake/external/rocprim.cmake
@@ -44,12 +44,6 @@ ExternalProject_Add(
 
 INCLUDE_DIRECTORIES(${ROCPRIM_INCLUDE_DIR})
 
-if (${CMAKE_VERSION} VERSION_LESS "3.3.0")
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/rocprim_dummy.c)
-    file(WRITE ${dummyfile} "const char *dummy_rocprim = \"${dummyfile}\";")
-    add_library(rocprim STATIC ${dummyfile})
-else()
-    add_library(rocprim INTERFACE)
-endif()
+add_library(rocprim INTERFACE)
 
 add_dependencies(rocprim extern_rocprim)

--- a/cmake/external/threadpool.cmake
+++ b/cmake/external/threadpool.cmake
@@ -41,12 +41,6 @@ ExternalProject_Add(
     TEST_COMMAND      ""
 )
 
-if (${CMAKE_VERSION} VERSION_LESS "3.3.0")
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/threadpool_dummy.c)
-    file(WRITE ${dummyfile} "const char *dummy_threadpool = \"${dummyfile}\";")
-    add_library(simple_threadpool STATIC ${dummyfile})
-else()
-    add_library(simple_threadpool INTERFACE)
-endif()
+add_library(simple_threadpool INTERFACE)
 
 add_dependencies(simple_threadpool extern_threadpool)

--- a/cmake/external/xbyak.cmake
+++ b/cmake/external/xbyak.cmake
@@ -49,12 +49,6 @@ ExternalProject_Add(
     CMAKE_CACHE_ARGS    -DCMAKE_INSTALL_PREFIX:PATH=${XBYAK_INSTALL_ROOT}
 )
 
-if (${CMAKE_VERSION} VERSION_LESS "3.3.0")
-    set(dummyfile ${CMAKE_CURRENT_BINARY_DIR}/xbyak_dummy.c)
-    file(WRITE ${dummyfile} "const char *dummy_xbyak = \"${dummyfile}\";")
-    add_library(xbyak STATIC ${dummyfile})
-else()
-    add_library(xbyak INTERFACE)
-endif()
+add_library(xbyak INTERFACE)
 
 add_dependencies(xbyak ${XBYAK_PROJECT})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
cmake最小支持版本为3.10，`${CMAKE_VERSION} VERSION_LESS "3.3.0"` 之类的代码已经不需要了。