### PR TITLE
use IndexList to improve performance of instance_norm op

### DIFF
--- a/paddle/fluid/operators/instance_norm_op.cc
+++ b/paddle/fluid/operators/instance_norm_op.cc
@@ -180,12 +180,22 @@ class InstanceNormKernel<platform::CPUDeviceContext, T>
 
     auto &dev_ctx = ctx.template device_context<platform::CPUDeviceContext>();
     auto *place = dev_ctx.eigen_device();
-
+// The IndexList requires a c++11 compliant compiler. If the compiler
+// is older we need to use arrays of indices instead.
+#ifndef EIGEN_HAS_INDEX_LIST
     Eigen::DSizes<int, 2> bcast(1, sample_size);
     Eigen::DSizes<int, 2> C_shape(C, 1);
     Eigen::DSizes<int, 2> NxC_shape(NxC, 1);
-    Eigen::DSizes<int, 2> shape(NxC, sample_size);
-
+    Eigen::DSizes<int, 1> rdims(1);
+#else
+    Eigen::IndexList<Eigen::type2index<1>, int> bcast;
+    bcast.set(1, sample_size);
+    Eigen::IndexList<int, Eigen::type2index<1>> C_shape;
+    C_shape.set(0, C);
+    Eigen::IndexList<int, Eigen::type2index<1>> NxC_shape;
+    NxC_shape.set(0, NxC);
+    Eigen::IndexList<Eigen::type2index<1>> rdims;
+#endif
     math::SetConstant<platform::CPUDeviceContext, T> set_constant;
 
     saved_mean->mutable_data<T>(ctx.GetPlace());
@@ -198,10 +208,9 @@ class InstanceNormKernel<platform::CPUDeviceContext, T>
     auto saved_variance_a = framework::EigenVector<T>::Flatten(*saved_variance);
     auto saved_variance_e = saved_variance_a.reshape(NxC_shape);
 
+    Eigen::DSizes<int, 2> shape(NxC, sample_size);
     auto x_e = framework::EigenVector<T>::Flatten(*x);
     auto x_arr = x_e.reshape(shape);
-
-    Eigen::DSizes<int, 1> rdims(1);
 
     saved_mean_e.device(*place) = x_arr.mean(rdims);
     auto saved_variance_arr =
@@ -316,14 +325,25 @@ class InstanceNormGradKernel<platform::CPUDeviceContext, T>
     auto &dev_ctx = ctx.template device_context<platform::CPUDeviceContext>();
     auto *place = dev_ctx.eigen_device();
 
+    Eigen::DSizes<int, 2> rshape(NxC, sample_size);
+    Eigen::DSizes<int, 2> param_shape(N, C);
+    Eigen::DSizes<int, 2> shape(NxC, sample_size);
+#ifndef EIGEN_HAS_INDEX_LIST
     Eigen::DSizes<int, 1> rdims(0);
     Eigen::DSizes<int, 1> mean_rdims(1);
-    Eigen::DSizes<int, 2> rshape(NxC, sample_size);
     Eigen::DSizes<int, 2> bcast(1, sample_size);
     Eigen::DSizes<int, 2> C_shape(C, 1);
     Eigen::DSizes<int, 2> NxC_shape(NxC, 1);
-    Eigen::DSizes<int, 2> param_shape(N, C);
-    Eigen::DSizes<int, 2> shape(NxC, sample_size);
+#else
+    Eigen::IndexList<Eigen::type2index<0>, int> rdims;
+    Eigen::IndexList<Eigen::type2index<1>, int> mean_rdims;
+    Eigen::IndexList<Eigen::type2index<1>, int> bcast;
+    bcast.set(1, sample_size);
+    Eigen::IndexList<int, Eigen::type2index<1>> C_shape;
+    C_shape.set(0, C);
+    Eigen::IndexList<int, Eigen::type2index<1>> NxC_shape;
+    NxC_shape.set(0, NxC);
+#endif
 
     math::SetConstant<platform::CPUDeviceContext, T> set_constant;
 

--- a/paddle/fluid/operators/instance_norm_op.cc
+++ b/paddle/fluid/operators/instance_norm_op.cc
@@ -180,14 +180,7 @@ class InstanceNormKernel<platform::CPUDeviceContext, T>
 
     auto &dev_ctx = ctx.template device_context<platform::CPUDeviceContext>();
     auto *place = dev_ctx.eigen_device();
-// The IndexList requires a c++11 compliant compiler. If the compiler
-// is older we need to use arrays of indices instead.
-#ifndef EIGEN_HAS_INDEX_LIST
-    Eigen::DSizes<int, 2> bcast(1, sample_size);
-    Eigen::DSizes<int, 2> C_shape(C, 1);
-    Eigen::DSizes<int, 2> NxC_shape(NxC, 1);
-    Eigen::DSizes<int, 1> rdims(1);
-#else
+
     Eigen::IndexList<Eigen::type2index<1>, int> bcast;
     bcast.set(1, sample_size);
     Eigen::IndexList<int, Eigen::type2index<1>> C_shape;
@@ -195,7 +188,7 @@ class InstanceNormKernel<platform::CPUDeviceContext, T>
     Eigen::IndexList<int, Eigen::type2index<1>> NxC_shape;
     NxC_shape.set(0, NxC);
     Eigen::IndexList<Eigen::type2index<1>> rdims;
-#endif
+
     math::SetConstant<platform::CPUDeviceContext, T> set_constant;
 
     saved_mean->mutable_data<T>(ctx.GetPlace());
@@ -328,22 +321,14 @@ class InstanceNormGradKernel<platform::CPUDeviceContext, T>
     Eigen::DSizes<int, 2> rshape(NxC, sample_size);
     Eigen::DSizes<int, 2> param_shape(N, C);
     Eigen::DSizes<int, 2> shape(NxC, sample_size);
-#ifndef EIGEN_HAS_INDEX_LIST
-    Eigen::DSizes<int, 1> rdims(0);
-    Eigen::DSizes<int, 1> mean_rdims(1);
-    Eigen::DSizes<int, 2> bcast(1, sample_size);
-    Eigen::DSizes<int, 2> C_shape(C, 1);
-    Eigen::DSizes<int, 2> NxC_shape(NxC, 1);
-#else
-    Eigen::IndexList<Eigen::type2index<0>, int> rdims;
-    Eigen::IndexList<Eigen::type2index<1>, int> mean_rdims;
+    Eigen::IndexList<Eigen::type2index<0>> rdims;
+    Eigen::IndexList<Eigen::type2index<1>> mean_rdims;
     Eigen::IndexList<Eigen::type2index<1>, int> bcast;
     bcast.set(1, sample_size);
     Eigen::IndexList<int, Eigen::type2index<1>> C_shape;
     C_shape.set(0, C);
     Eigen::IndexList<int, Eigen::type2index<1>> NxC_shape;
     NxC_shape.set(0, NxC);
-#endif
 
     math::SetConstant<platform::CPUDeviceContext, T> set_constant;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does -->
IndexList in Eigen is used to encode a set of Tensor dimensions/indices. The indices in the list can be known at compile time or at runtime. A mix of static and dynamic indices can also be provided if needed. The tensor code will attempt to take advantage of the indices that are known at compile time to optimize the code it generates. Using IndexList instead of  arrays of indices can speed up CPU and GPU performance.

**Note:** 
- Eigen on windows is not updated, so there is no IndexList.  We need to use arrays of indices instead.  That's why the `EIGEN_HAS_INDEX_LIST` is used in the code. 

### Performance
   **CPU**：
  |op|input shape|before|after| speed up |
  |---|---|---|---|---|
  |instance_norm|[1, 64, 128, 128]|41.2712 ms|3.21222 ms|13x| 
  |instance_norm_grad|[1, 64, 128, 128]|149.14 ms|11.949 ms|12x| 
  |instance_norm|[1, 128, 64, 64]|20.6193 ms|1.61026 ms|13x| 
  |instance_norm_grad|[1, 128, 64, 64]|74.4767 ms|5.19748 ms|14x| 
  |instance_norm|[1, 256, 32, 32]|10.308 ms| 0.821658 ms|13x|
  |instance_norm_grad|[1, 256, 32, 32]|37.1751 ms|2.60926 ms|14x|
