### PR TITLE
use IndexList to improve performance of dot op

### DIFF
--- a/paddle/fluid/operators/dot_op.h
+++ b/paddle/fluid/operators/dot_op.h
@@ -49,7 +49,14 @@ class DotKernel : public framework::OpKernel<T> {
       auto y = EigenMatrix<T>::From(*tensor_y);
 
       auto& dev = *ctx.template device_context<DeviceContext>().eigen_device();
-      out.device(dev) = (x * y).sum(Eigen::DSizes<int, 1>(1));
+// The IndexList requires a c++11 compliant compiler. If the compiler
+// is older we need to use arrays of indices instead.
+#ifndef EIGEN_HAS_INDEX_LIST
+      Eigen::DSizes<int, 2> axis(1);
+#else
+      Eigen::IndexList<Eigen::type2index<1>> axis;
+#endif
+      out.device(dev) = (x * y).sum(axis);
     }
 #else
     const auto* data_x = tensor_x->data<T>();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> 
 Using IndexList instead of arrays of indices can speed up CPU and GPU performance. This PR use it to improve performance of dot op. For more information, please refer to #25132

### performace
   **GPU**: v100, cuda10
  |op|input shape|before|after| speed up |
  |---|---|---|---|---|
  |dot|[1000, 1000]|0.210704 ms|0.125058 ms|1.7x| 

**由于修改错误，以上数据存在问题，实际没有提升，此PR暂时关闭**