### PR TITLE
fix PE in test_profiler.py

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler.py
@@ -94,17 +94,13 @@ class TestProfiler(unittest.TestCase):
                         event.name.startswith("Runtime API")):
                     print("Warning: unregister", event.name)
 
-    def run_iter(self, exe, main_program, fetch_list, pass_acc_calculator):
+    def run_iter(self, exe, main_program, fetch_list):
         x = np.random.random((32, 784)).astype("float32")
         y = np.random.randint(0, 10, (32, 1)).astype("int64")
         outs = exe.run(main_program,
                        feed={'x': x,
                              'y': y},
                        fetch_list=fetch_list)
-        acc = np.array(outs[1])
-        b_size = np.array(outs[2])
-        pass_acc_calculator.add(value=acc, weight=b_size)
-        pass_acc = pass_acc_calculator.eval()
 
     def net_profiler(self,
                      exe,
@@ -120,13 +116,11 @@ class TestProfiler(unittest.TestCase):
         profile_path = self.get_profile_path()
         if not use_new_api:
             with profiler.profiler(state, 'total', profile_path, tracer_option):
-                pass_acc_calculator = fluid.average.WeightedAverage()
                 for iter in range(10):
                     if iter == 2:
                         profiler.reset_profiler()
                     self.run_iter(exe, main_program,
-                                  [avg_cost, batch_acc, batch_size],
-                                  pass_acc_calculator)
+                                  [avg_cost, batch_acc, batch_size])
         else:
             options = utils.ProfilerOptions(options={
                 'state': state,
@@ -136,11 +130,9 @@ class TestProfiler(unittest.TestCase):
                 'profile_path': profile_path
             })
             with utils.Profiler(enabled=True, options=options) as prof:
-                pass_acc_calculator = fluid.average.WeightedAverage()
                 for iter in range(10):
                     self.run_iter(exe, main_program,
-                                  [avg_cost, batch_acc, batch_size],
-                                  pass_acc_calculator)
+                                  [avg_cost, batch_acc, batch_size])
                     utils.get_profiler().record_step()
                     if batch_range is None and iter == 2:
                         utils.get_profiler().reset()
@@ -156,7 +148,7 @@ class TestProfiler(unittest.TestCase):
                 "Default",
                 batch_range=[5, 10],
                 use_new_api=use_new_api)
-            #self.net_profiler('CPU', "Default", use_parallel_executor=True)
+            self.net_profiler(exe, 'CPU', "Default", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
@@ -167,9 +159,10 @@ class TestProfiler(unittest.TestCase):
                 exe,
                 'GPU',
                 "OpDetail",
-                batch_range=[0, 100],
+                batch_range=[0, 10],
                 use_new_api=use_new_api)
-            #self.net_profiler('GPU', "OpDetail", use_parallel_executor=True)
+            self.net_profiler(
+                exe, 'GPU', "OpDetail", use_parallel_executor=True)
 
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
@@ -182,7 +175,8 @@ class TestProfiler(unittest.TestCase):
                 "AllOpDetail",
                 batch_range=None,
                 use_new_api=use_new_api)
-            #self.net_profiler('All', "AllOpDetail", use_parallel_executor=True)
+            self.net_profiler(
+                exe, 'All', "AllOpDetail", use_parallel_executor=True)
 
 
 class TestProfilerAPIError(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. #23701 在4月7日把`test_profiler.py`中PE相关单测给注释了，由于过了2个半月，且目前在本地无法复现，先打开PE单测。
2. 单测网络中去掉`pass_acc_calculator`，原因是有如下错误：(去掉此处，不影响profiler功能测试)
```
======================================================================
642: ERROR: test_cpu_profiler (test_profiler.TestProfiler)
642: ----------------------------------------------------------------------
642: Traceback (most recent call last):
642:   File "/home/luotao/Paddle/cpu_build/python/paddle/fluid/tests/unittests/test_profiler.py", line 159, in test_cpu_profiler
642:     self.net_profiler(exe, 'CPU', "Default", use_parallel_executor=True)
642:   File "/home/luotao/Paddle/cpu_build/python/paddle/fluid/tests/unittests/test_profiler.py", line 129, in net_profiler
642:     pass_acc_calculator)
642:   File "/home/luotao/Paddle/cpu_build/python/paddle/fluid/tests/unittests/test_profiler.py", line 106, in run_iter
642:     pass_acc_calculator.add(value=acc, weight=b_size)
642:   File "/home/luotao/Paddle/cpu_build/python/paddle/fluid/average.py", line 77, in add
642:     raise ValueError("The 'weight' must be a number(int, float).")
642: ValueError: The 'weight' must be a number(int, float).
642:
642: ----------------------------------------------------------------------
642: Ran 4 tests in 0.662s
```
3. 将`batch_range=[0, 100],`改短为`batch_range=[0, 10],`，来加速单测