### PR TITLE
[cherry-pick-1.8]. Fix compile problem when WITH_NCCL=OFF. Fix compile with Paddle-Lite

### DIFF
--- a/cmake/external/lite.cmake
+++ b/cmake/external/lite.cmake
@@ -91,3 +91,4 @@ endfunction()
 external_lite_static_libs(lite_full_static ${LITE_BINARY_DIR}/inference_lite_lib/cxx/lib/libpaddle_full_api_shared.so)
 
 add_definitions(-DPADDLE_WITH_LITE)
+add_definitions(-DLITE_WITH_LOG)

--- a/paddle/fluid/operators/sync_batch_norm_op.cu.h
+++ b/paddle/fluid/operators/sync_batch_norm_op.cu.h
@@ -186,7 +186,7 @@ void SyncBatchNormFunctor(const framework::ExecutionContext &ctx,
     auto gplace = boost::get<platform::CUDAPlace>(ctx.GetPlace());
     memory::Copy(platform::CPUPlace(), c_g_st_d, gplace, stats, bytes, 0);
 
-#ifndef WIN32
+#ifdef PADDLE_WITH_NCCL
     auto *comm = dev_ctx.nccl_comm();
     if (comm) {
       int dtype = platform::ToNCCLDataType(mean_out->type());
@@ -460,7 +460,7 @@ void SyncBatchNormGradFunctor(
         dy_d, x_d, saved_mean, N, fsize, C, stats);
   }
 
-#ifndef WIN32
+#ifdef PADDLE_WITH_NCCL
   auto *comm = dev_ctx.nccl_comm();
   if (comm) {
     int dtype = platform::ToNCCLDataType(scale->type());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick https://github.com/PaddlePaddle/Paddle/pull/24444.
【问题描述】
由于ci中没有覆盖WITH_NCCL=OFF的情况，导致合入了用到nccl，但没有使用WITH_NCCL宏来控制的op，导致去掉NCCL编译不过。

【问题解决】
在.cu.h中将需要NCCL包装起来

【子图编译问题】
lite的近期改动导致fluid-lite子图编译不过，原因在于fluid中没有定义LITE_WITH_LOG宏，使得lite和fluid的log不一致，加上该宏后解决
