### PR TITLE
Fix beam_search InferShape

### DIFF
--- a/paddle/fluid/operators/beam_search_op.cc
+++ b/paddle/fluid/operators/beam_search_op.cc
@@ -95,6 +95,10 @@ class BeamSearchOp : public framework::OperatorWithKernel {
          std::vector<std::string>({"selected_ids", "selected_scores"})) {
       OP_INOUT_CHECK(ctx->HasOutput(arg), "Output", arg, "BeamSeach");
     }
+    auto id_dims = ctx->GetInputDim("pre_ids");
+    ctx->SetOutputDim("selected_scores", ctx->GetInputDim("pre_scores"));
+    ctx->SetOutputDim("selected_ids", id_dims);
+    ctx->SetOutputDim("parent_idx", {id_dims[0]});
   }
 
  protected:

--- a/python/paddle/fluid/tests/unittests/test_beam_search_op.py
+++ b/python/paddle/fluid/tests/unittests/test_beam_search_op.py
@@ -38,9 +38,9 @@ class BeamSearchOpTester(unittest.TestCase):
         self._create_pre_scores()
         self._create_scores()
         self._create_pre_ids()
-        self.scope.var('selected_ids')
-        self.scope.var('selected_scores')
-        self.scope.var('parent_idx')
+        self.scope.var('selected_ids').get_tensor()
+        self.scope.var('selected_scores').get_tensor()
+        self.scope.var('parent_idx').get_tensor()
 
     def test_run(self):
         op = Operator(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Before this fix, the `InferShape` of `beam_search` doesn't set the shape of output, which leads to saved transformer \_\_model\_\_ maintains `[0]` shape information for `init_score`, `trg_word` and `init_idx`. 
It is just fine for C++ inference but will fail when using `load_inference_model`. 
![image](https://user-images.githubusercontent.com/7160927/85367951-d9910500-b55c-11ea-986f-826709b13aee.png)
