### PR TITLE
Add default cudnn lib path

### DIFF
--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -58,7 +58,7 @@ struct PathNode {
 };
 
 static constexpr char cupti_lib_path[] = CUPTI_LIB_PATH;
-static constexpr char cudnn_lib_path[] = "/usr/local/cuda/lib64";
+static constexpr char linux_cudnn_lib_path[] = "/usr/local/cuda/lib64";
 
 static PathNode s_py_site_pkg_path;
 
@@ -196,15 +196,15 @@ void* GetCublasDsoHandle() {
 }
 
 void* GetCUDNNDsoHandle() {
-  std::string cudnn_path = cudnn_lib_path;
-  if (!FLAGS_cudnn_dir.empty()) {
-    cudnn_path = FLAGS_cudnn_dir;
-  }
 #if defined(__APPLE__) || defined(__OSX__)
   return GetDsoHandleFromSearchPath(cudnn_path, "libcudnn.dylib", false);
 #elif defined(_WIN32) && defined(PADDLE_WITH_CUDA)
   return GetDsoHandleFromSearchPath(cudnn_path, win_cudnn_lib);
 #else
+  std::string cudnn_path = linux_cudnn_lib_path;
+  if (!FLAGS_cudnn_dir.empty()) {
+    cudnn_path = FLAGS_cudnn_dir;
+  }
   return GetDsoHandleFromSearchPath(cudnn_path, "libcudnn.so", false);
 #endif
 }

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -58,6 +58,7 @@ struct PathNode {
 };
 
 static constexpr char cupti_lib_path[] = CUPTI_LIB_PATH;
+static constexpr char cudnn_lib_path[] = "/usr/local/cuda/lib64";
 
 static PathNode s_py_site_pkg_path;
 
@@ -195,6 +196,10 @@ void* GetCublasDsoHandle() {
 }
 
 void* GetCUDNNDsoHandle() {
+  std::string cudnn_path = cudnn_lib_path;
+  if (!FLAGS_cudnn_dir.empty()) {
+    cudnn_path = FLAGS_cudnn_dir;
+  }
 #if defined(__APPLE__) || defined(__OSX__)
   return GetDsoHandleFromSearchPath(FLAGS_cudnn_dir, "libcudnn.dylib", false);
 #elif defined(_WIN32) && defined(PADDLE_WITH_CUDA)

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -197,15 +197,15 @@ void* GetCublasDsoHandle() {
 
 void* GetCUDNNDsoHandle() {
 #if defined(__APPLE__) || defined(__OSX__)
-  return GetDsoHandleFromSearchPath(cudnn_path, "libcudnn.dylib", false);
+  return GetDsoHandleFromSearchPath(FLAGS_cudnn_dir, "libcudnn.dylib", false);
 #elif defined(_WIN32) && defined(PADDLE_WITH_CUDA)
-  return GetDsoHandleFromSearchPath(cudnn_path, win_cudnn_lib);
+  return GetDsoHandleFromSearchPath(FLAGS_cudnn_dir, win_cudnn_lib);
 #else
-  std::string cudnn_path = linux_cudnn_lib_path;
+  std::string linux_cudnn_path = linux_cudnn_lib_path;
   if (!FLAGS_cudnn_dir.empty()) {
-    cudnn_path = FLAGS_cudnn_dir;
+    linux_cudnn_path = FLAGS_cudnn_dir;
   }
-  return GetDsoHandleFromSearchPath(cudnn_path, "libcudnn.so", false);
+  return GetDsoHandleFromSearchPath(linux_cudnn_path, "libcudnn.so", false);
 #endif
 }
 

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -201,11 +201,11 @@ void* GetCUDNNDsoHandle() {
     cudnn_path = FLAGS_cudnn_dir;
   }
 #if defined(__APPLE__) || defined(__OSX__)
-  return GetDsoHandleFromSearchPath(FLAGS_cudnn_dir, "libcudnn.dylib", false);
+  return GetDsoHandleFromSearchPath(cudnn_path, "libcudnn.dylib", false);
 #elif defined(_WIN32) && defined(PADDLE_WITH_CUDA)
-  return GetDsoHandleFromSearchPath(FLAGS_cudnn_dir, win_cudnn_lib);
+  return GetDsoHandleFromSearchPath(cudnn_path, win_cudnn_lib);
 #else
-  return GetDsoHandleFromSearchPath(FLAGS_cudnn_dir, "libcudnn.so", false);
+  return GetDsoHandleFromSearchPath(cudnn_path, "libcudnn.so", false);
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Add default cudnn lib path, to solve the problem that the cudnn library cannot be found after installing paddle.

fix issue: https://github.com/PaddlePaddle/Paddle/issues/21917