### PR TITLE
Fix random fail of test_mobile_net

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mobile_net.py
@@ -517,10 +517,10 @@ class TestMobileNet(unittest.TestCase):
             np.allclose(dy_out, st_out),
             msg="dy_out: {}, st_out: {}".format(dy_out, st_out))
 
-    def test_mobileNetV1(self):
+    def test_mobileNet(self):
+        # MobileNet-V1
         self.assert_same_loss("MobileNetV1")
-
-    def test_mobileNetV2(self):
+        # MobileNet-V2
         self.assert_same_loss("MobileNetV2")
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR typeshttps://github.com/PaddlePaddle/Paddle/pull/25184/files
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix random fail of test_mobile_net。

I ran the unittest on local machine but can not reproduce the problem. I supposed it's because the two `test_func` Interact with each other and attempted to fix this.