### PR TITLE
fix Layer.__dir__  to show the parameters/sublayers/buffers/attr/method of the Layer

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -762,7 +762,7 @@ class Layer(core.Layer):
 
             fluid.dygraph.enable_dygraph()
 
-            class Mylayer1(fluid.dygraph.Layer):
+            class Mylayer(fluid.dygraph.Layer):
                 def __init__(self):
                     super(Mylayer1, self).__init__()
                     self.linear1 = fluid.dygraph.Linear(10, 10)
@@ -771,29 +771,18 @@ class Layer(core.Layer):
                     self.embedding = fluid.dygraph.Embedding(size=[128, 16])
                     self.h_0 = fluid.dygraph.to_variable(np.zeros([10, 10]).astype('float32'))
 
-            class Mylayer2(fluid.dygraph.Layer):
-                def __init__(self):
-                    super(Mylayer2, self).__init__()
-                    self.linear1 = fluid.dygraph.Linear(10, 10)
-                    self.linear2 = fluid.dygraph.Linear(5, 5)
-                    self.conv2d = fluid.dygraph.Conv2D(3, 2, 3)
-                    self.embedding = fluid.dygraph.Embedding(size=[128, 16])
-                    self.mylayer1 =  Mylayer1()
-
-            mylayer = Mylayer2()
+            mylayer = Mylayer()
             print(dir(mylayer))
+            #
 
         """
         method = dir(self.__class__)
         attrs = list(self.__dict__.keys())
-        parameters_name = [
-            param_name for param_name, _ in self.named_parameters()
-        ]
-        sublayers_name = [
-            sublayer_name for sublayer_name, _ in self.named_sublayers()
-        ]
-        buffers_name = [buf_name for buf_name, _ in self.named_buffers()]
-        keys = parameters_name + sublayers_name + buffers_name + attrs + method
+        parameters = list(self._parameters.keys())
+        sublayers = list(self._sub_layers.keys())
+        buffers = list(self._buffers.keys())
+
+        keys = method + attrs + parameters + sublayers + buffers
 
         return keys
 

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -754,7 +754,34 @@ class Layer(core.Layer):
 
     def __dir__(self):
         """
-        Get all parameters， sublayers, method and attr of Layer.
+        Get all parameters, buffers(non-parameter variables), sublayers, method and attr of Layer.
+
+        Examples:
+            import paddle.fluid as fluid
+            import numpy as np
+
+            fluid.dygraph.enable_dygraph()
+
+            class Mylayer1(fluid.dygraph.Layer):
+                def __init__(self):
+                    super(Mylayer1, self).__init__()
+                    self.linear1 = fluid.dygraph.Linear(10, 10)
+                    self.linear2 = fluid.dygraph.Linear(5, 5)
+                    self.conv2d = fluid.dygraph.Conv2D(3, 2, 3)
+                    self.embedding = fluid.dygraph.Embedding(size=[128, 16])
+                    self.h_0 = fluid.dygraph.to_variable(np.zeros([10, 10]).astype('float32'))
+
+            class Mylayer2(fluid.dygraph.Layer):
+                def __init__(self):
+                    super(Mylayer2, self).__init__()
+                    self.linear1 = fluid.dygraph.Linear(10, 10)
+                    self.linear2 = fluid.dygraph.Linear(5, 5)
+                    self.conv2d = fluid.dygraph.Conv2D(3, 2, 3)
+                    self.embedding = fluid.dygraph.Embedding(size=[128, 16])
+                    self.mylayer1 =  Mylayer1()
+
+            mylayer = Mylayer2()
+            print(dir(mylayer))
 
         """
         method = dir(self.__class__)
@@ -765,7 +792,8 @@ class Layer(core.Layer):
         sublayers_name = [
             sublayer_name for sublayer_name, _ in self.named_sublayers()
         ]
-        keys = parameters_name + sublayers_name + attrs + method
+        buffers_name = [buf_name for buf_name, _ in self.named_buffers()]
+        keys = parameters_name + sublayers_name + buffers_name + attrs + method
 
         return keys
 

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -754,7 +754,7 @@ class Layer(core.Layer):
 
     def __dir__(self):
         """
-        Get all parameters, buffers(non-parameter variables), sublayers, method and attr of Layer.
+        Return a list. Get all parameters, buffers(non-parameter variables), sublayers, method and attr of Layer.
 
         Examples:
             import paddle.fluid as fluid
@@ -764,7 +764,7 @@ class Layer(core.Layer):
 
             class Mylayer(fluid.dygraph.Layer):
                 def __init__(self):
-                    super(Mylayer1, self).__init__()
+                    super(Mylayer, self).__init__()
                     self.linear1 = fluid.dygraph.Linear(10, 10)
                     self.linear2 = fluid.dygraph.Linear(5, 5)
                     self.conv2d = fluid.dygraph.Conv2D(3, 2, 3)
@@ -773,7 +773,8 @@ class Layer(core.Layer):
 
             mylayer = Mylayer()
             print(dir(mylayer))
-            #
+            # only parts are shown, because of list have too much content
+            # ['__call__', '__class__',  ... , 'conv2d', 'embedding', 'h_0', 'linear1', 'linear2', ... , 'sublayers', 'train']
 
         """
         method = dir(self.__class__)

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -591,6 +591,23 @@ class Layer(core.Layer):
         else:
             object.__delattr__(self, name)
 
+    def __dir__(self):
+        """
+        Get all parameters， sublayers, method and attr of Layer.
+
+        """
+        method = dir(self.__class__)
+        attrs = list(self.__dict__.keys())
+        parameters_name = [
+            param_name for param_name, _ in self.named_parameters()
+        ]
+        sublayers_name = [
+            sublayer_name for sublayer_name, _ in self.named_sublayers()
+        ]
+        keys = parameters_name + sublayers_name + attrs + method
+
+        return keys
+
     def state_dict(self,
                    destination=None,
                    include_sublayers=True,

--- a/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
@@ -81,42 +81,38 @@ class TestImperativeNamedParameters(unittest.TestCase):
 
     def test_dir_layer(self):
         with fluid.dygraph.guard():
-            fc1 = fluid.Linear(10, 3)
-            fc2 = fluid.Linear(3, 10)
-            mylayer = MyLayer(3, 10)
-            model = paddle.nn.Sequential(("fc1", fc1), ("fc2", fc2),
-                                         ("mylayer", mylayer))
+
+            class Mymodel(fluid.dygraph.Layer):
+                def __init__(self):
+                    super(Mymodel, self).__init__()
+                    self.linear1 = fluid.dygraph.Linear(10, 10)
+                    self.linear2 = fluid.dygraph.Linear(5, 5)
+                    self.conv2d = fluid.dygraph.Conv2D(3, 2, 3)
+                    self.embedding = fluid.dygraph.Embedding(size=[128, 16])
+                    self.h_0 = fluid.dygraph.to_variable(
+                        np.zeros([10, 10]).astype('float32'))
+                    self.weight = self.create_parameter(
+                        shape=[2, 3],
+                        attr=fluid.ParamAttr(),
+                        dtype="float32",
+                        is_bias=False)
+
+            model = Mymodel()
 
             expected_members = dir(model)
 
-            self.assertTrue("fc1" in expected_members,
-                            "model should contain Layer: fc1")
-            self.assertTrue("fc1.weight" in expected_members,
-                            "model should contain Parameter: fc1.weight")
-            self.assertTrue("fc1.bias" in expected_members,
-                            "model should contain Parameter: fc1.bias")
-
-            self.assertTrue("fc2" in expected_members,
-                            "model should contain Layer: fc2")
-            self.assertTrue("fc2.weight" in expected_members,
-                            "model should contain Parameter: fc2.weight")
-            self.assertTrue("fc2.bias" in expected_members,
-                            "model should contain Parameter: fc2.bias")
-
-            self.assertTrue("mylayer.fc" in expected_members,
-                            "model should contain Layer: mylayer.fc")
-            self.assertTrue("mylayer.fc.weight" in expected_members,
-                            "model should contain Parameter: mylayer.fc.weight")
-            self.assertTrue("mylayer.fc.bias" in expected_members,
-                            "model should contain Parameter: mylayer.fc.bias")
-
-            self.assertTrue("mylayer.conv" in expected_members,
-                            "model should contain Layer: mylayer.conv")
-            self.assertTrue(
-                "mylayer.conv.weight" in expected_members,
-                "model should contain Parameter: mylayer.conv.weight")
-            self.assertTrue("mylayer.conv.bias" in expected_members,
-                            "model should contain Parameter: mylayer.conv.bias")
+            self.assertTrue("linear1" in expected_members,
+                            "model should contain Layer: linear1")
+            self.assertTrue("linear2" in expected_members,
+                            "model should contain Layer: linear2")
+            self.assertTrue("conv2d" in expected_members,
+                            "model should contain Layer: conv2d")
+            self.assertTrue("embedding" in expected_members,
+                            "model should contain Layer: embedding")
+            self.assertTrue("h_0" in expected_members,
+                            "model should contain buffer: h_0")
+            self.assertTrue("weight" in expected_members,
+                            "model should contain parameter: weight")
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_named_members.py
@@ -79,6 +79,45 @@ class TestImperativeNamedParameters(unittest.TestCase):
 
             self.assertListEqual(expected_named_parameters, named_parameters)
 
+    def test_dir_layer(self):
+        with fluid.dygraph.guard():
+            fc1 = fluid.Linear(10, 3)
+            fc2 = fluid.Linear(3, 10)
+            mylayer = MyLayer(3, 10)
+            model = paddle.nn.Sequential(("fc1", fc1), ("fc2", fc2),
+                                         ("mylayer", mylayer))
+
+            expected_members = dir(model)
+
+            self.assertTrue("fc1" in expected_members,
+                            "model should contain Layer: fc1")
+            self.assertTrue("fc1.weight" in expected_members,
+                            "model should contain Parameter: fc1.weight")
+            self.assertTrue("fc1.bias" in expected_members,
+                            "model should contain Parameter: fc1.bias")
+
+            self.assertTrue("fc2" in expected_members,
+                            "model should contain Layer: fc2")
+            self.assertTrue("fc2.weight" in expected_members,
+                            "model should contain Parameter: fc2.weight")
+            self.assertTrue("fc2.bias" in expected_members,
+                            "model should contain Parameter: fc2.bias")
+
+            self.assertTrue("mylayer.fc" in expected_members,
+                            "model should contain Layer: mylayer.fc")
+            self.assertTrue("mylayer.fc.weight" in expected_members,
+                            "model should contain Parameter: mylayer.fc.weight")
+            self.assertTrue("mylayer.fc.bias" in expected_members,
+                            "model should contain Parameter: mylayer.fc.bias")
+
+            self.assertTrue("mylayer.conv" in expected_members,
+                            "model should contain Layer: mylayer.conv")
+            self.assertTrue(
+                "mylayer.conv.weight" in expected_members,
+                "model should contain Parameter: mylayer.conv.weight")
+            self.assertTrue("mylayer.conv.bias" in expected_members,
+                            "model should contain Parameter: mylayer.conv.bias")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
New API: 
```
Layer.__dir__
```
modify dir() to make it easy for users to view the attr/parameters/sublayers/function of the Layer.


For example:

```
import paddle.fluid as fluid
import numpy as np

fluid.dygraph.enable_dygraph()

class Mylayer(fluid.dygraph.Layer):
    def __init__(self):
        super(Mylayer, self).__init__()
        self.linear1 = fluid.dygraph.Linear(10, 10)
        self.linear2 = fluid.dygraph.Linear(5, 5)
        self.conv2d = fluid.dygraph.Conv2D(3, 2, 3)
        self.embedding = fluid.dygraph.Embedding(size=[128, 16])
        self.h_0 = fluid.dygraph.to_variable(np.zeros([10, 10]).astype('float32'))

mylayer = Mylayer()
print(dir(mylayer))
```

![image](https://user-images.githubusercontent.com/52485244/86350641-968a0c80-bc95-11ea-8c57-844e2cdfc679.png)
