### PR TITLE
Fix bug: Don't check dims if contain_unknown_dim in compile time. 

### DIFF
--- a/paddle/fluid/operators/cross_entropy_op.cc
+++ b/paddle/fluid/operators/cross_entropy_op.cc
@@ -145,11 +145,10 @@ class CrossEntropyGradientOpBase : public framework::OperatorWithKernel {
             "But received: Y@Grad's rank is [%d], Y's rank is [%d]",
             dy_dims.size(), label_dims.size()));
 
-    bool check = true;
-    if ((!ctx->IsRuntime()) &&
-        (framework::product(x_dims) <= 0 || framework::product(dy_dims) <= 0)) {
-      check = false;
-    }
+    bool contain_unknown_dim = framework::contain_unknown_dim(x_dims) ||
+                               framework::contain_unknown_dim(dy_dims);
+
+    bool check = ctx->IsRuntime() || !contain_unknown_dim;
 
     if (check) {
       PADDLE_ENFORCE_EQ(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
As the title