### PR TITLE
Correct parameter l2 passed to ftrl op, test=develop

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -2815,7 +2815,7 @@ class FtrlOptimizer(Optimizer):
                 "LinearAccumOut": linear_acc
             },
             attrs={"l1": self._l1,
-                   "l2": self._l1,
+                   "l2": self._l2,
                    "lr_power": self._lr_power},
             stop_gradient=True)
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
Solve #25229
Correct parameter l2 passed to ftrl op