### PR TITLE
use eval() to improve CPU performance

### DIFF
--- a/paddle/fluid/operators/clip_by_norm_op.h
+++ b/paddle/fluid/operators/clip_by_norm_op.h
@@ -82,7 +82,12 @@ class ClipByNormKernel : public framework::OpKernel<T> {
     auto scaling = temp + (static_cast<T>(1) - temp) * max_norm / x_norm;
     Eigen::array<int, 1> one_dim{{1}};
     Eigen::DSizes<int, 1> m_dsize(input->numel());
-    out.device(place) = x * scaling.reshape(one_dim).broadcast(m_dsize);
+    if (context.GetPlace() == platform::CPUPlace()) {
+      out.device(place) =
+          x * scaling.reshape(one_dim).eval().broadcast(m_dsize);
+    } else {
+      out.device(place) = x * scaling.reshape(one_dim).broadcast(m_dsize);
+    }
   }
 };
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> use eval() to improve CPU performance

test code: [benchmark #480](https://github.com/PaddlePaddle/benchmark/pull/480)

**CPU**

| op | before | after | parameters |speed up |
|---|---|---|---|---|
| clip_by_norm | 56091 ms | 0.329109 ms | "x (Variable) - dtype: float32, shape: [1000, 300]\n" | 170432x |

Although it  can also improve GPU performance, we don’t use it here because Eigen eval() would allocate temporary memory to store the immediate result, which causes the memory consumption raise.

**GPU**

| op | before | after | parameters |speed up |
|---|---|---|---|---|
| clip_by_norm | 0.303003 ms | 0.120304 ms | "x (Variable) - dtype: float32, shape: [1000, 300]\n" |2.5x |