### PR TITLE
Refine squeeze, test=develop

### DIFF
--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -13,14 +13,61 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/squeeze_op.h"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+
 #include "paddle/fluid/framework/op_registry.h"
 
 namespace paddle {
 namespace operators {
+
+framework::DDim GetOutputShape(const std::vector<int> squeeze_dims,
+                               const framework::DDim &in_dims) {
+  size_t num_squeeze_dims = squeeze_dims.size();
+  std::vector<bool> should_squeeze(in_dims.size(), false);
+
+  // Mark dimensions need to be squeezed.
+  if (num_squeeze_dims == 0) {
+    for (int i = 0; i < in_dims.size(); ++i) {
+      if (in_dims[i] == 1) {
+        should_squeeze[i] = true;
+      }
+    }
+  } else {
+    for (size_t i = 0; i < num_squeeze_dims; ++i) {
+      int current = squeeze_dims[i] < 0 ? squeeze_dims[i] + in_dims.size()
+                                        : squeeze_dims[i];
+
+      PADDLE_ENFORCE_GE(
+          current, 0,
+          platform::errors::InvalidArgument(
+              "Each axis in Attr(axes) should be in the range of [%d, %d]"
+              "But current axis is:%d, input tensor's shape = [%s].",
+              -in_dims.size(), in_dims.size() - 1, current, in_dims));
+      PADDLE_ENFORCE_LT(
+          current, in_dims.size(),
+          platform::errors::InvalidArgument(
+              "Each axis in Attr(axes) should be in the range of [%d, %d]"
+              "But current axis is:%d, input tensor's shape = [%s].",
+              -in_dims.size(), in_dims.size() - 1, current, in_dims));
+
+      if (in_dims[current] == 1 && !should_squeeze[current]) {
+        should_squeeze[current] = true;
+      }
+    }
+  }
+  // Make output dimensions
+  std::vector<int64_t> output_shape;
+  for (int i = 0; i < in_dims.size(); ++i) {
+    if (!should_squeeze[i]) {
+      output_shape.push_back(in_dims[i]);
+    }
+  }
+  return framework::make_ddim(output_shape);
+}
 
 class SqueezeOp : public framework::OperatorWithKernel {
  public:
@@ -47,56 +94,6 @@ class SqueezeOp : public framework::OperatorWithKernel {
       // are the same.
       ctx->ShareLoD("X", "Out");
     }
-  }
-
-  static framework::DDim GetOutputShape(const std::vector<int> squeeze_dims,
-                                        const framework::DDim &in_dims) {
-    size_t num_squeeze_dims = squeeze_dims.size();
-    int cnt_squeezed_dims = 0;
-    bool should_squeeze[9] = {false};
-
-    // Determines number of dimensions of output tensor after squeeze.
-    // Mark and count the dimensions need to be squeezed
-    if (num_squeeze_dims == 0) {
-      for (int idx = 0; idx < in_dims.size(); ++idx) {
-        if (in_dims[idx] == 1) {
-          should_squeeze[idx] = true;
-          ++cnt_squeezed_dims;
-        }
-      }
-    } else {
-      for (size_t idx = 0; idx < num_squeeze_dims; ++idx) {
-        int current = squeeze_dims[idx] < 0 ? squeeze_dims[idx] + in_dims.size()
-                                            : squeeze_dims[idx];
-        PADDLE_ENFORCE_GE(
-            current, 0,
-            platform::errors::InvalidArgument(
-                "Each axis in Attr(axes) should be in the range of [%d, %d]"
-                "But current axis is:%d, input tensor's shape = [%s].",
-                -in_dims.size(), in_dims.size() - 1, current, in_dims));
-        PADDLE_ENFORCE_LT(
-            current, in_dims.size(),
-            platform::errors::InvalidArgument(
-                "Each axis in Attr(axes) should be in the range of [%d, %d]"
-                "But current axis is:%d, input tensor's shape = [%s].",
-                -in_dims.size(), in_dims.size() - 1, current, in_dims));
-
-        if (!(should_squeeze[current])) {
-          ++cnt_squeezed_dims;
-        }
-        should_squeeze[current] = true;
-      }
-    }
-
-    // Make output dimensions
-    std::vector<int64_t> output_shape(in_dims.size() - cnt_squeezed_dims, 0);
-    for (int in_idx = 0, out_idx = 0; in_idx < in_dims.size(); ++in_idx) {
-      if (!should_squeeze[in_idx]) {
-        output_shape[out_idx++] = in_dims[in_idx];
-      }
-    }
-
-    return framework::make_ddim(output_shape);
   }
 
  protected:
@@ -183,7 +180,7 @@ class Squeeze2Op : public framework::OperatorWithKernel {
 
     const auto &axes = ctx->Attrs().Get<std::vector<int>>("axes");
 
-    auto out_dims = SqueezeOp::GetOutputShape(axes, x_dims);
+    auto out_dims = GetOutputShape(axes, x_dims);
     ctx->SetOutputDim("Out", out_dims);
     if (x_dims[0] == out_dims[0]) {
       // Only pass LoD when the first dimension of output and Input(X)

--- a/paddle/fluid/operators/squeeze_op.h
+++ b/paddle/fluid/operators/squeeze_op.h
@@ -26,7 +26,7 @@ namespace paddle {
 namespace operators {
 
 framework::DDim GetOutputShape(const std::vector<int> squeeze_dims,
-                               const framework::DDim &in_dims);
+                               const framework::DDim &in_dims, bool is_runtime);
 
 template <typename DeviceContext, typename T>
 class SqueezeKernel : public framework::OpKernel<T> {
@@ -37,7 +37,7 @@ class SqueezeKernel : public framework::OpKernel<T> {
 
     auto &axes = context.Attr<std::vector<int>>("axes");
     auto x_dims = in->dims();
-    auto out_dims = GetOutputShape(axes, x_dims);
+    auto out_dims = GetOutputShape(axes, x_dims, true);
 
     out->mutable_data(context.GetPlace(), in->type());
     framework::TensorCopy(
@@ -72,7 +72,7 @@ class Squeeze2Kernel : public framework::OpKernel<T> {
     auto &axes = context.Attr<std::vector<int>>("axes");
 
     auto x_dims = in->dims();
-    auto out_dims = GetOutputShape(axes, x_dims);
+    auto out_dims = GetOutputShape(axes, x_dims, true);
 
     out->mutable_data(context.GetPlace(), in->type());
     framework::TensorCopy(

--- a/paddle/fluid/operators/squeeze_op.h
+++ b/paddle/fluid/operators/squeeze_op.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 
 #include <vector>
+
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/math/blas.h"
 #include "paddle/fluid/operators/math/math_function.h"
@@ -23,6 +24,9 @@ limitations under the License. */
 
 namespace paddle {
 namespace operators {
+
+framework::DDim GetOutputShape(const std::vector<int> squeeze_dims,
+                               const framework::DDim &in_dims);
 
 template <typename DeviceContext, typename T>
 class SqueezeKernel : public framework::OpKernel<T> {
@@ -40,64 +44,6 @@ class SqueezeKernel : public framework::OpKernel<T> {
         *in, context.GetPlace(),
         context.template device_context<platform::DeviceContext>(), out);
     out->Resize(out_dims);
-  }
-
-  static framework::DDim GetOutputShape(const std::vector<int> squeeze_dims,
-                                        const framework::DDim &in_dims) {
-    size_t num_squeeze_dims = squeeze_dims.size();
-    int cnt_squeezed_dims = 0;
-    bool should_squeeze[9] = {false};
-
-    // Determines number of dimensions of output tensor after squeeze.
-    // Mark and count the dimensions need to be squeezed
-    if (num_squeeze_dims == 0) {
-      for (int idx = 0; idx < in_dims.size(); ++idx) {
-        if (in_dims[idx] == 1) {
-          should_squeeze[idx] = true;
-          ++cnt_squeezed_dims;
-        }
-      }
-    } else {
-      for (size_t idx = 0; idx < num_squeeze_dims; ++idx) {
-        int current = squeeze_dims[idx] < 0 ? squeeze_dims[idx] + in_dims.size()
-                                            : squeeze_dims[idx];
-
-        PADDLE_ENFORCE_GE(
-            current, 0,
-            platform::errors::InvalidArgument(
-                "Each axis in Attr(axes) should be in the range of [%d, %d]"
-                "But current axis is:%d, input tensor's shape = [%s].",
-                -in_dims.size(), in_dims.size() - 1, current, in_dims));
-        PADDLE_ENFORCE_LT(
-            current, in_dims.size(),
-            platform::errors::InvalidArgument(
-                "Each axis in Attr(axes) should be in the range of [%d, %d]"
-                "But current axis is:%d, input tensor's shape = [%s].",
-                -in_dims.size(), in_dims.size() - 1, current, in_dims));
-
-        PADDLE_ENFORCE_EQ(in_dims[current], 1,
-                          platform::errors::InvalidArgument(
-                              "The size of axis that will be squeezed "
-                              "should be equal to 1. But current axis = %d,"
-                              "input tensor's shape = [%s].",
-                              in_dims[current], in_dims));
-
-        if (!(should_squeeze[current])) {
-          ++cnt_squeezed_dims;
-        }
-        should_squeeze[current] = true;
-      }
-    }
-
-    // Make output dimensions
-    std::vector<int64_t> output_shape(in_dims.size() - cnt_squeezed_dims, 0);
-    for (int in_idx = 0, out_idx = 0; in_idx < in_dims.size(); ++in_idx) {
-      if (!should_squeeze[in_idx]) {
-        output_shape[out_idx++] = in_dims[in_idx];
-      }
-    }
-
-    return framework::make_ddim(output_shape);
   }
 };
 
@@ -126,8 +72,7 @@ class Squeeze2Kernel : public framework::OpKernel<T> {
     auto &axes = context.Attr<std::vector<int>>("axes");
 
     auto x_dims = in->dims();
-    auto out_dims =
-        SqueezeKernel<DeviceContext, T>::GetOutputShape(axes, x_dims);
+    auto out_dims = GetOutputShape(axes, x_dims);
 
     out->mutable_data(context.GetPlace(), in->type());
     framework::TensorCopy(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6143,74 +6143,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
     return helper.append_activation(out)
 
 
-def squeeze(input, axes, name=None):
-    """
-    This OP will squeeze single-dimensional entries of input tensor's shape. If axes is provided, will
-    remove the dims by axes, the dims selected by axes should be one. If not provide axes, all dims equal
-    to one will be deleted.
-
-
-    .. code-block:: text
-
-        Case1:
-
-          Input:
-            X.shape = (1, 3, 1, 5)
-            axes = [0]
-          Output:
-            Out.shape = (3, 1, 5)
-
-        Case2:
-
-          Input:
-            X.shape = (1, 3, 1, 5)
-            axes = []
-          Output:
-            Out.shape = (3, 5)
-
-        Case3:
-
-          Input:
-            X.shape = [1,3,1,5]
-            axes = [-2]
-          Output:
-            Out.shape = [1,3,5]
-
-    Args:
-        input (Variable): The input Tensor. Support data type: float16, float32, float64, int8, int32, int64.
-                          axes (list): One integer or List of integers, indicating the dimensions to be squeezed.
-                          Axes range is :math:`[-rank(input), rank(input))`.
-                          If axes is negative, :math:`axes=axes+rank(input)`.
-        name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
-
-    Returns:
-        Variable: Output squeezed Tensor. Data type is same as input Tensor.
-
-    Examples:
-        .. code-block:: python
-
-            import paddle.fluid as fluid
-            import paddle.fluid.layers as layers
-            # set batch size=None
-            x = fluid.data(name='x', shape=[None, 5, 1, 10])
-            y = layers.squeeze(input=x, axes=[2]) # y.shape=[None, 5, 10]
-
-    """
-    helper = LayerHelper("squeeze", **locals())
-    check_variable_and_dtype(
-        input, 'input',
-        ['float16', 'float32', 'float64', 'int8', 'int32', 'int64'], 'squeeze')
-    check_type(axes, 'axes', list, 'squeeze')
-    out = helper.create_variable_for_type_inference(dtype=input.dtype)
-    x_shape = helper.create_variable_for_type_inference(dtype=input.dtype)
-    helper.append_op(
-        type="squeeze2",
-        inputs={"X": input},
-        attrs={"axes": axes},
-        outputs={"Out": out,
-                 "XShape": x_shape})
-
-    return out
+def squeeze(x, axis=None, name=None):
+    return paddle.tensor.manipulation.squeeze(x, axis, name)
 
 
 def unsqueeze(input, axes, name=None):

--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -70,6 +70,14 @@ class TestSqueezeOp3(TestSqueezeOp):
         self.new_shape = (6, 5, 1, 4)
 
 
+# Correct: The demension of axis is not of size 1 remains unchanged.
+class TestSqueezeOp4(TestSqueezeOp):
+    def init_test_case(self):
+        self.ori_shape = (6, 1, 5, 1, 4, 1)
+        self.axes = (1, 2)
+        self.new_shape = (6, 5, 1, 4, 1)
+
+
 class TestSqueezeOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
@@ -106,6 +114,24 @@ class API_TestDygraphSqueeze(unittest.TestCase):
             input_1 = np.random.random([5, 1, 10]).astype("int32")
             input = fluid.dygraph.to_variable(input_1)
             output = paddle.squeeze(input, axis=[1])
+            out_np = output.numpy()
+            expected_out = np.squeeze(input_1, axis=1)
+            self.assertTrue(np.allclose(expected_out, out_np))
+
+    def test_axis_not_list(self):
+        with fluid.dygraph.guard():
+            input_1 = np.random.random([5, 1, 10]).astype("int32")
+            input = fluid.dygraph.to_variable(input_1)
+            output = paddle.squeeze(input, axis=1)
+            out_np = output.numpy()
+            expected_out = np.squeeze(input_1, axis=1)
+            self.assertTrue(np.allclose(expected_out, out_np))
+
+    def test_dimension_not_1(self):
+        with fluid.dygraph.guard():
+            input_1 = np.random.random([5, 1, 10]).astype("int32")
+            input = fluid.dygraph.to_variable(input_1)
+            output = paddle.squeeze(input, axis=(1, 2))
             out_np = output.numpy()
             expected_out = np.squeeze(input_1, axis=1)
             self.assertTrue(np.allclose(expected_out, out_np))

--- a/python/paddle/fluid/tests/unittests/test_squeeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_squeeze_op.py
@@ -90,7 +90,7 @@ class API_TestSqueeze(unittest.TestCase):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
             data1 = fluid.layers.data(
                 'data1', shape=[-1, 1, 10], dtype='float64')
-            result_squeeze = paddle.squeeze(data1, axes=[1])
+            result_squeeze = paddle.squeeze(data1, axis=[1])
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             input1 = np.random.random([5, 1, 10]).astype('float64')
@@ -105,7 +105,7 @@ class API_TestDygraphSqueeze(unittest.TestCase):
         with fluid.dygraph.guard():
             input_1 = np.random.random([5, 1, 10]).astype("int32")
             input = fluid.dygraph.to_variable(input_1)
-            output = paddle.squeeze(input, axes=[1])
+            output = paddle.squeeze(input, axis=[1])
             out_np = output.numpy()
             expected_out = np.squeeze(input_1, axis=1)
             self.assertTrue(np.allclose(expected_out, out_np))

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -447,7 +447,7 @@ def squeeze(x, axis=None, name=None):
         Case1:
 
           Input:
-            x.shape = [1, 3, 1, 5]
+            x.shape = [1, 3, 1, 5]  # If axis is not provided, all dims equal of size 1 will be removed.
             axis = None
           Output:
             out.shape = [3, 5]
@@ -455,32 +455,32 @@ def squeeze(x, axis=None, name=None):
         Case2:
 
           Input:
-            x.shape = [1, 3, 1, 5]
+            x.shape = [1, 3, 1, 5]  # If axis is provided, it will remove the dimension(s) by given axis that of size 1.
             axis = 0
           Output:
             out.shape = [3, 1, 5]
         
-        Case3:
+        Case4:
 
           Input:
-            x.shape = [1, 3, 1, 5]
-            axis = [-1, -2]
+            x.shape = [1, 3, 1, 5]  # If the dimension of one given axis (3) is not of size 1, the dimension remain unchanged. 
+            axis = [0, 2, 3]
           Output:
-            out.shape = [1, 3, 5]
+            out.shape = [3, 5]
 
         Case4:
 
           Input:
-            x.shape = [1, 3, 1, 5]
-            axis = [0, 2]
+            x.shape = [1, 3, 1, 5]  # If axis is negative, axis = axis + rank(input)
+            axis = [-2]
           Output:
-            out.shape = [3, 5]
+            out.shape = [1, 3, 5]
 
     Args:
         input (Variable): The input Tensor. Support data type: float32, float64, int8, int32, int64.
-        axis (int|list, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
+        axis (int|list|tuple, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
                           The range of axis is :math:`[-rank(input), rank(input))`.
-                          If axis is negative, :math:`axes=axes+rank(input)`.
+                          If axis is negative, :math:`axis = axis + rank(input)`.
                           If axis is None, all the dimensions of input of size 1 will be removed.
         name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
 
@@ -502,6 +502,8 @@ def squeeze(x, axis=None, name=None):
         axis = []
     elif isinstance(axis, int):
         axis = [axis]
+    elif isinstance(axis, tuple):
+        axis = list(axis)
 
     return layers.squeeze(x, axis, name)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -436,9 +436,11 @@ def squeeze(x, axis=None, name=None):
 	:alias_main: paddle.squeeze
 	:alias: paddle.squeeze,paddle.tensor.squeeze,paddle.tensor.manipulation.squeeze
 
-    This OP will squeeze entries of size 1 of input tensor's shape. If axis is provided, will
-    remove the dim(s) by axis that of size 1. If axis is not provided, all dims equal of size 1
-    will be removed.
+    This OP will squeeze the dimension(s) of size 1 of input tensor's shape. 
+
+    If axis is provided, it will remove the dimension(s) by given axis that of size 1. 
+    If the dimension of given axis is not of size 1, the dimension remain unchanged. 
+    If axis is not provided, all dims equal of size 1 will be removed.
 
     .. code-block:: text
 
@@ -462,7 +464,7 @@ def squeeze(x, axis=None, name=None):
 
           Input:
             x.shape = [1, 3, 1, 5]
-            axis = [-2]
+            axis = [-1, -2]
           Output:
             out.shape = [1, 3, 5]
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -435,6 +435,7 @@ def squeeze(x, axis=None, name=None):
     """
 	:alias_main: paddle.squeeze
 	:alias: paddle.squeeze,paddle.tensor.squeeze,paddle.tensor.manipulation.squeeze
+    :update_api: paddle.fluid.layers.squeeze
 
     This OP will squeeze the dimension(s) of size 1 of input tensor's shape. 
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -434,10 +434,9 @@ def split(input, num_or_sections, dim=-1, name=None):
 def squeeze(x, axis=None, name=None):
     """
 	:alias_main: paddle.squeeze
-	:alias: paddle.squeeze,paddle.tensor.squeeze,paddle.tensor.manipulation.squeeze
-    :update_api: paddle.fluid.layers.squeeze
+	:alias: paddle.squeeze, paddle.tensor.squeeze, paddle.tensor.manipulation.squeeze
 
-    This OP will squeeze the dimension(s) of size 1 of input tensor's shape. 
+    This OP will squeeze the dimension(s) of size 1 of input tensor x's shape. 
 
     If axis is provided, it will remove the dimension(s) by given axis that of size 1. 
     If the dimension of given axis is not of size 1, the dimension remain unchanged. 
@@ -472,21 +471,21 @@ def squeeze(x, axis=None, name=None):
         Case4:
 
           Input:
-            x.shape = [1, 3, 1, 5]  # If axis is negative, axis = axis + rank(input)
+            x.shape = [1, 3, 1, 5]  # If axis is negative, axis = axis + ndim (number of dimensions in x). 
             axis = [-2]
           Output:
             out.shape = [1, 3, 5]
 
     Args:
-        input (Variable): The input Tensor. Support data type: float32, float64, int8, int32, int64.
+        input (Tensor): The input Tensor. Support data type: float32, float64, int8, int32, int64.
         axis (int|list|tuple, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
-                          The range of axis is :math:`[-rank(input), rank(input))`.
-                          If axis is negative, :math:`axis = axis + rank(input)`.
+                          The range of axis is :math:`[-ndim(input), ndim(input))`.
+                          If axis is negative, :math:`axis = axis + ndim(input)`.
                           If axis is None, all the dimensions of input of size 1 will be removed.
         name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Variable: Output squeezed Tensor. Data type is same as input Tensor.
+        Tensor: Output squeezed Tensor. Data type is same as input Tensor.
 
     Examples:
         .. code-block:: python

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -41,6 +41,7 @@ from ..fluid.layers import scatter_nd_add  #DEFINE_ALIAS
 from ..fluid.layers import scatter_nd  #DEFINE_ALIAS
 from ..fluid.layers import shard_index  #DEFINE_ALIAS
 from ..fluid.layers import unique_with_counts  #DEFINE_ALIAS
+from ..fluid import layers
 
 __all__ = [
     'cast', 'concat', 'expand', 'expand_as', 'flatten', 'gather', 'gather_nd',
@@ -486,17 +487,13 @@ def squeeze(x, axis=None, name=None):
 
     Examples:
         .. code-block:: python
-            import numpy as np
             import paddle
-            import paddle.fluid as fluid
 
-            with fluid.dygraph.guard():
-                x_np = np.random.random([5, 1, 10]).astype("int32")
-                # x is a variable of shape [5, 1, 10]
-                x = fluid.dygraph.to_variable(input_1)
-
-                output = paddle.squeeze(x, axes=1)
-                # output.shape [5, 10]
+            paddle.enable_imperative()
+            
+            x = paddle.rand([5, 1, 10])
+            output = paddle.squeeze(x, axis=1)
+            # output.shape [5, 10]
 
     """
     if axis is None:
@@ -504,24 +501,7 @@ def squeeze(x, axis=None, name=None):
     elif isinstance(axis, int):
         axis = [axis]
 
-    if in_dygraph_mode():
-        out, _ = core.ops.squeeze2(x, 'axes', axis)
-        return out
-
-    helper = LayerHelper("squeeze", **locals())
-    check_variable_and_dtype(
-        x, 'x', ['float32', 'float64', 'int8', 'int32', 'int64'], 'squeeze')
-    check_type(axis, 'axis', (int, list, type(None)), 'squeeze')
-    out = helper.create_variable_for_type_inference(dtype=x.dtype)
-    x_shape = helper.create_variable_for_type_inference(dtype=x.dtype)
-    helper.append_op(
-        type="squeeze2",
-        inputs={"X": x},
-        attrs={"axes": axis},
-        outputs={"Out": out,
-                 "XShape": x_shape})
-
-    return out
+    return layers.squeeze(x, axis, name)
 
 
 def unsqueeze(input, axes, out=None, name=None):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Enhance `paddle.squeeze`

- Update signature  
    `paddle.squeeze(input, axes, out=None, name=None)` -> `paddle.squeeze(x, axis=None, name=None)`
- Support `None, int, and list` for `axis`
- Return `x` unchanged if its shape is `[A, 1, B, 1]` and `axis` is `0` instead of raising exception
- Code clean