### PR TITLE
fix the formula of floor OP and ceil OP

### DIFF
--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -225,7 +225,7 @@ $$out = |x|$$
 UNUSED constexpr char CeilDoc[] = R"DOC(
 Ceil Operator. Computes ceil of x element-wise.
 
-$$out = \left \lceil x \right \rceil$$
+$$out = \\left \\lceil x \\right \\rceil$$
 
 )DOC";
 

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -230,7 +230,7 @@ $$out = \left \lceil x \right \rceil$$
 )DOC";
 
 UNUSED constexpr char FloorDoc[] = R"DOC(
-Floor Activation Operator.
+Floor Activation Operator. Computes floor of x element-wise.
 
 $$out = \\left \\lfloor x \\right \\rfloor$$
 

--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -232,7 +232,7 @@ $$out = \left \lceil x \right \rceil$$
 UNUSED constexpr char FloorDoc[] = R"DOC(
 Floor Activation Operator.
 
-$$out = \left \lfloor x \right \rfloor$$
+$$out = \\left \\lfloor x \\right \\rfloor$$
 
 )DOC";
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Docs 

### Describe
<!-- Describe what this PR does -->
1. fix the formula of the [floor OP](https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-alpha/api/layers/floor.html)
![image](https://user-images.githubusercontent.com/14162525/86197719-92bc9400-bb88-11ea-8756-b2ba9317224e.png)
Now is :
![image](https://user-images.githubusercontent.com/14162525/86197704-89332c00-bb88-11ea-9dd5-9c76d6773bd7.png)

2. fix the formula of the [ceil OP](https://www.paddlepaddle.org.cn/documentation/docs/en/2.0-alpha/api/layers/ceil.html)
![image](https://user-images.githubusercontent.com/14162525/86237547-88bd8400-bbce-11ea-9976-a1a053bf38a6.png)
Now is:
![image](https://user-images.githubusercontent.com/14162525/86237524-7f341c00-bbce-11ea-94a4-2fd95d837620.png)
