### PR TITLE
refine paddle.stack

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -9895,7 +9895,7 @@ def flatten(x, axis=1, name=None):
     return out
 
 
-def stack(x, axis=0):
+def stack(x, axis=0, name=None):
     """
 
     This OP stacks all the inputs :code:`x` along axis.

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -9975,18 +9975,13 @@ def stack(x, axis=0):
             data = layers.stack(x1)  # stack according to axis 0, data.shape=[1, None, 1, 2]
 
     """
-
-    # 动态图和静态图共有的逻辑，保留在if分支前面
     axis = 0 if axis is None else axis
     if not isinstance(x, list) and not isinstance(x, tuple):
         x = [x]
 
-    # 动态图if分支，调用core.ops.stack，执行快速路径
     if in_dygraph_mode():
-        # core.ops.xx()的参数传递依次为输入和attr，详见动态图分支写法文档。
         return core.ops.stack(x, 'axis', axis)
 
-    # 静态图分支，基本保留不变，继续执行append_op的组网逻辑
     helper = LayerHelper('stack', **locals())
     out = helper.create_variable_for_type_inference(x[0].dtype)
     if x[0].desc.type() == core.VarDesc.VarType.LOD_TENSOR_ARRAY:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -198,7 +198,8 @@ def stack(x, axis=0, name=None):
 
     This OP stacks all the input tensors ``x`` along ``axis`` dimemsion. 
     All tensors must be of the same shape and same dtype.
-    For example, given N tensors of shape [A, B], if `axis == 0``, the shape of stacked 
+    
+    For example, given N tensors of shape [A, B], if ``axis == 0``, the shape of stacked 
     tensor is [N, A, B]; if ``axis == 1``, the shape of stacked 
     tensor is [A, N, B], etc.
     
@@ -246,15 +247,16 @@ def stack(x, axis=0, name=None):
                           [5.0, 6.0] ] ]
 
     Args:
-        x (Tensor|list(Tensor)): Input ``x`` can be a single Tensor, or a ``list`` of Tensors.
+        x (Tensor|list[Tensor]): Input ``x`` can be a single tensor, or a ``list`` of tensors.
                                      If ``x`` is a ``list``, the Tensors in ``x``
                                      must be of the same shape and dtype. Support data types: float32, float64, int32, int64.
         axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is ``[-(R+1), R+1)``,
                               where ``R`` is the number of dimensions of the first input tensor ``x[0]``. 
                               If ``axis < 0``, ``axis = axis+R+1``. The default value of axis is 0.
-
+        name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
+        
     Returns:
-        Tensor: The stacked Tensor with same data type as input.
+        Tensor: The stacked tensor with same data type as input.
 
     Example:    
         .. code-block:: python

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -262,21 +262,23 @@ def stack(x, axis=0, name=None):
         .. code-block:: python
 
             import paddle
+            import numpy as np
 
             data1 = np.array([[1.0, 2.0]])
             data2 = np.array([[3.0, 4.0]])
             data3 = np.array([[5.0, 6.0]])
 
             paddle.enable_imperative()
-            x1 = fluid.dygraph.to_variable(data1)
-            x2 = fluid.dygraph.to_variable(data2)
-            x3 = fluid.dygraph.to_variable(data3)
+            x1 = paddle.imperative.to_variable(data1)
+            x2 = paddle.imperative.to_variable(data2)
+            x3 = paddle.imperative.to_variable(data3)
 
-            result = paddle.stack([x1, x2, x3], axis=0)
-            # result shape: [3, 1, 2]
-            # result value: [[[1.0, 2.0]],
-            #                [[3.0, 4.0]],
-            #                [[5.0, 6.0]]]
+            out = paddle.stack([x1, x2, x3], axis=0)
+            print(out.shape)  # [3, 1, 2]
+            print(out.numpy())
+            # [[[1., 2.]],
+            #  [[3., 4.]],
+            #  [[5., 6.]]]
     """
     return layers.stack(x, axis, name)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -196,12 +196,11 @@ def stack(x, axis=0, name=None):
 	:alias_main: paddle.stack
 	:alias: paddle.stack, paddle.tensor.stack, paddle.tensor.manipulation.stack
 
-
     This OP stacks all the input tensors :code:`x` along :code:`axis` dimemsion. 
-    All tensors should to be of the same shape. 
+    All tensors should to be of the same shape and same dtype.
     For example, given N tensors of shape [A, B], if :code:`axis == 0`, the shape of stacked 
     tensor is [N, A, B]; if :code:`axis == 1`, the shape of stacked 
-    tensor is [A, N, B].
+    tensor is [A, N, B]. 
     
 
     .. code-block:: text
@@ -228,7 +227,6 @@ def stack(x, axis=0, name=None):
 
         Case 2:
 
-
           Input:
             x[0].shape = [1, 2]
             x[0].data = [ [1.0 , 2.0 ] ]
@@ -239,7 +237,7 @@ def stack(x, axis=0, name=None):
 
 
           Attrs:
-            axis = 1 or axis = -2
+            axis = 1 or axis = -2  # If axis = -2, axis = axis+ndim(x[0])+1 = -2+2+1 = 1.
 
           Output:
             Out.shape = [1, 3, 2]
@@ -248,21 +246,22 @@ def stack(x, axis=0, name=None):
                           [5.0, 6.0] ] ]
 
     Args:
-        x (Tensor|list(Tensor)): Input :code:`x` can be a single Tensor, a :code:`list` of Tensors.
+        x (Tensor|list(Tensor)): Input :code:`x` can be a single Tensor, or a :code:`list` of Tensors.
                                      If :code:`x` is a :code:`list`, the shapes of all these Tensors
                                      must be the same. Supposing input is N dims
                                      Tensors :math:`[d_0, d_1, ..., d_{n-1}]`, the output is N+1 dims
                                      Tensor :math:`[d_0, d_1, d_{axis-1}, len(x), d_{axis}, ..., d_{n-1}]`.
                                      Support data types: float32, float64, int32, int64.
-        axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is :math:`[-(R+1), R+1)`.
-                              R is the first tensor of inputs. If ``axis`` < 0, :math:`axis = axis+ndim(x[0])+1`.
-                              The default value of axis is 0.
+        axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is :math:`[-(R+1), R+1)`,
+                              where R is the number of dimensions of the first input tensor :code:`x[0]`. 
+                              If ``axis`` < 0, :math:`axis = axis+R+1`. The default value of axis is 0.
 
     Returns:
-        Tensor: The stacked Tensor with same data type as input Tensors.
+        Tensor: The stacked Tensor with same data type as input.
 
     Example:    
         .. code-block:: python
+
             import paddle
 
             data1 = np.array([[1.0, 2.0]])

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -196,11 +196,11 @@ def stack(x, axis=0, name=None):
 	:alias_main: paddle.stack
 	:alias: paddle.stack, paddle.tensor.stack, paddle.tensor.manipulation.stack
 
-    This OP stacks all the input tensors :code:`x` along :code:`axis` dimemsion. 
-    All tensors should to be of the same shape and same dtype.
-    For example, given N tensors of shape [A, B], if :code:`axis == 0`, the shape of stacked 
-    tensor is [N, A, B]; if :code:`axis == 1`, the shape of stacked 
-    tensor is [A, N, B]. 
+    This OP stacks all the input tensors ``x`` along ``axis`` dimemsion. 
+    All tensors must be of the same shape and same dtype.
+    For example, given N tensors of shape [A, B], if `axis == 0``, the shape of stacked 
+    tensor is [N, A, B]; if ``axis == 1``, the shape of stacked 
+    tensor is [A, N, B], etc.
     
 
     .. code-block:: text
@@ -246,15 +246,12 @@ def stack(x, axis=0, name=None):
                           [5.0, 6.0] ] ]
 
     Args:
-        x (Tensor|list(Tensor)): Input :code:`x` can be a single Tensor, or a :code:`list` of Tensors.
-                                     If :code:`x` is a :code:`list`, the shapes of all these Tensors
-                                     must be the same. Supposing input is N dims
-                                     Tensors :math:`[d_0, d_1, ..., d_{n-1}]`, the output is N+1 dims
-                                     Tensor :math:`[d_0, d_1, d_{axis-1}, len(x), d_{axis}, ..., d_{n-1}]`.
-                                     Support data types: float32, float64, int32, int64.
-        axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is :math:`[-(R+1), R+1)`,
-                              where R is the number of dimensions of the first input tensor :code:`x[0]`. 
-                              If ``axis`` < 0, :math:`axis = axis+R+1`. The default value of axis is 0.
+        x (Tensor|list(Tensor)): Input ``x`` can be a single Tensor, or a ``list`` of Tensors.
+                                     If ``x`` is a ``list``, the Tensors in ``x``
+                                     must be of the same shape and dtype. Support data types: float32, float64, int32, int64.
+        axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is ``[-(R+1), R+1)``,
+                              where ``R`` is the number of dimensions of the first input tensor ``x[0]``. 
+                              If ``axis < 0``, ``axis = axis+R+1``. The default value of axis is 0.
 
     Returns:
         Tensor: The stacked Tensor with same data type as input.

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -191,7 +191,7 @@ def roll(x, shifts, axis=None, name=None):
     return out
 
 
-def stack(x, axis=0, out=None, name=None):
+def stack(x, axis=0, name=None):
     """
 	:alias_main: paddle.stack
 	:alias: paddle.stack,paddle.tensor.stack,paddle.tensor.manipulation.stack
@@ -275,33 +275,7 @@ def stack(x, axis=0, out=None, name=None):
                 #                [[3.0, 4.0]],
                 #                [[5.0, 6.0]]]
     """
-
-    helper = LayerHelper('stack', **locals())
-    axis = 0 if axis is None else axis
-
-    if not isinstance(x, list) and not isinstance(x, tuple):
-        x = [x]
-    out = helper.create_variable_for_type_inference(x[0].dtype)
-    if not in_dygraph_mode() and \
-            x[0].desc.type() == core.VarDesc.VarType.LOD_TENSOR_ARRAY:
-        assert len(x) == 1, "If the elements of 'x' in stack are Variable(LoDTensorArray), " \
-                            "number of the elements must be 1, but received %s." % len(x)
-        out_index = helper.create_variable_for_type_inference(dtype="int32")
-        helper.append_op(
-            type='tensor_array_to_tensor',
-            inputs={'X': x[0]},
-            outputs={'Out': [out],
-                     'OutIndex': [out_index]},
-            attrs={'axis': axis,
-                   'use_stack': True})
-    else:
-        helper.append_op(
-            type='stack',
-            inputs={'X': x},
-            outputs={'Y': out},
-            attrs={'axis': axis})
-
-    return out
+    return layers.stack(x, axis, name)
 
 
 def split(input, num_or_sections, dim=-1, name=None):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -194,10 +194,15 @@ def roll(x, shifts, axis=None, name=None):
 def stack(x, axis=0, name=None):
     """
 	:alias_main: paddle.stack
-	:alias: paddle.stack,paddle.tensor.stack,paddle.tensor.manipulation.stack
+	:alias: paddle.stack, paddle.tensor.stack, paddle.tensor.manipulation.stack
 
 
-    This OP stacks all the inputs :code:`x` along axis.
+    This OP stacks all the input tensors :code:`x` along :code:`axis` dimemsion. 
+    All tensors should to be of the same shape. 
+    For example, given N tensors of shape [A, B], if :code:`axis == 0`, the shape of stacked 
+    tensor is [N, A, B]; if :code:`axis == 1`, the shape of stacked 
+    tensor is [A, N, B].
+    
 
     .. code-block:: text
 
@@ -243,37 +248,37 @@ def stack(x, axis=0, name=None):
                           [5.0, 6.0] ] ]
 
     Args:
-        x (Variable|list(Variable)): Input :code:`x` can be a single Tensor, a :code:`list` of Tensors.
+        x (Tensor|list(Tensor)): Input :code:`x` can be a single Tensor, a :code:`list` of Tensors.
                                      If :code:`x` is a :code:`list`, the shapes of all these Tensors
                                      must be the same. Supposing input is N dims
                                      Tensors :math:`[d_0, d_1, ..., d_{n-1}]`, the output is N+1 dims
                                      Tensor :math:`[d_0, d_1, d_{axis-1}, len(x), d_{axis}, ..., d_{n-1}]`.
                                      Support data types: float32, float64, int32, int64.
         axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is :math:`[-(R+1), R+1)`.
-                              R is the first tensor of inputs. If ``axis`` < 0, :math:`axis=axis+rank(x[0])+1`.
+                              R is the first tensor of inputs. If ``axis`` < 0, :math:`axis = axis+ndim(x[0])+1`.
                               The default value of axis is 0.
 
     Returns:
-        Variable: The stacked Tensor, has same data type with input Tensors. Output dim is :math:`rank(x[0])+1`.
+        Tensor: The stacked Tensor with same data type as input Tensors.
 
     Example:    
         .. code-block:: python
-            import numpy as np
             import paddle
-            import paddle.fluid as fluid
 
             data1 = np.array([[1.0, 2.0]])
             data2 = np.array([[3.0, 4.0]])
             data3 = np.array([[5.0, 6.0]])
-            with fluid.dygraph.guard():
-                x1 = fluid.dygraph.to_variable(data1)
-                x2 = fluid.dygraph.to_variable(data2)
-                x3 = fluid.dygraph.to_variable(data3)
-                result = paddle.stack([x1, x2, x3], axis=0)
-                # result shape: [3, 1, 2]
-                # result value: [[[1.0, 2.0]],
-                #                [[3.0, 4.0]],
-                #                [[5.0, 6.0]]]
+
+            paddle.enable_imperative()
+            x1 = fluid.dygraph.to_variable(data1)
+            x2 = fluid.dygraph.to_variable(data2)
+            x3 = fluid.dygraph.to_variable(data3)
+
+            result = paddle.stack([x1, x2, x3], axis=0)
+            # result shape: [3, 1, 2]
+            # result value: [[[1.0, 2.0]],
+            #                [[3.0, 4.0]],
+            #                [[5.0, 6.0]]]
     """
     return layers.stack(x, axis, name)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Refine paddle.stack API

- Variable -> Tensor
- use `core.ops.stack` in dygraph mode
- refine document
- `fluid.layers.stack(x, axis=0)` -> `fluid.layers.stack(x, axis=0, name=None)`, which is compatible upgrade.
- reuse code of `fluid.layers.stack`