### PR TITLE
Modify prefix "eager_tmp" of UniqueNameGenerator

### DIFF
--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -32,7 +32,7 @@ namespace imperative {
 class UniqueNameGenerator {
  public:
   explicit UniqueNameGenerator(std::string prefix = "") : prefix_(prefix) {}
-  std::string Generate(std::string key = "tmp") {
+  std::string Generate(std::string key = "eager_tmp") {
     return prefix_ + key + "_" + std::to_string(id_++);
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Modify prefix "eager_tmp" in  class `UniqueNameGenerator ` to keep consistent in dygraph