### PR TITLE
clean __str__ of VarBase and ParamBase, test=develop

### DIFF
--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -212,46 +212,35 @@ def monkey_patch_varbase():
             return np.array(new_ivar.value().get_tensor())
 
     def __str__(self):
-        return self.to_string(True)
-
-    @property
-    def block(self):
-        return framework.default_main_program().global_block()
-
-    def to_string(self, throw_on_error, with_details=False):
         """
-        Get debug string.
+        Convert a VarBase object to a readable string.
 
-        Args:
-
-            throw_on_error (bool): True if raise an exception when self is not initialized.
-
-            with_details (bool): more details about variables and parameters (e.g. trainable, optimize_attr, ...) will be printed when with_details is True. Default value is False;
-
-        Returns:
-            str: The debug string.
+        Returns(str): A readable string.
 
         Examples:
             .. code-block:: python
 
-                import paddle.fluid as fluid
-
-                cur_program = fluid.Program()
-                cur_block = cur_program.current_block()
-                new_variable = cur_block.create_var(name="X",
-                                                    shape=[-1, 23, 48],
-                                                    dtype='float32')
-                print(new_variable.to_string(True))
-                print("=============with detail===============")
-                print(new_variable.to_string(True, True))
+                import paddle
+                paddle.enable_imperative()
+                x = paddle.rand([1, 5])
+                print(x)
+                # Variable: eager_tmp_0
+                #   - place: CUDAPlace(0)
+                #   - shape: [1, 5]
+                #   - layout: NCHW
+                #   - dtype: float
+                #   - data: [0.645307 0.597973 0.732793 0.646921 0.540328]
+                paddle.disable_imperative()
         """
-        if framework.in_dygraph_mode():
-            # TODO(panyx0718): add more dygraph debug info.
-            tensor = self.value().get_tensor()
-            if tensor._is_initialized():
-                return 'Variable: %s\n%s' % (self.name, str(tensor))
-            else:
-                return 'Variable: %s, not initialized' % (self.name)
+        tensor = self.value().get_tensor()
+        if tensor._is_initialized():
+            return 'Variable: %s\n%s' % (self.name, str(tensor))
+        else:
+            return 'Variable: %s, not initialized' % (self.name)
+
+    @property
+    def block(self):
+        return framework.default_main_program().global_block()
 
     def __nonzero__(self):
         numel = np.prod(self.shape)

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -256,7 +256,7 @@ def monkey_patch_varbase():
         ("__bool__", __bool__), ("__nonzero__", __nonzero__),
         ("_to_static_var", _to_static_var), ("set_value", set_value),
         ("block", block), ("backward", backward), ("gradient", gradient),
-        ("__str__", __str__), ("to_string", to_string)):
+        ("__str__", __str__)):
         setattr(core.VarBase, method_name, method)
 
     # patch math methods for varbase

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5121,11 +5121,7 @@ class ParamBase(core.VarBase):
         self.do_model_average = kwargs.get('do_model_average', None)
 
         self.is_distributed = False
-
         # self.block = default_main_program().global_block()
-
-    def __str__(self):
-        return self.to_string(True)
 
     @property
     def trainable(self):
@@ -5140,30 +5136,27 @@ class ParamBase(core.VarBase):
                 "The type of trainable MUST be bool, but the type is ",
                 type(trainable))
 
-    def to_string(self, throw_on_error, with_details=False):
+    def __str__(self):
         """
-        To debug string.
+        Convert a ParamBase object to a readable string.
 
-        Args:
-            throw_on_error(bool): raise exception when self is not initialized
-                when throw_on_error is True
-            with_details(bool): more details about variables and parameters
-                (e.g. trainable, optimize_attr, ...) will be printed when with_details is True
-
-        Returns(str): The debug string.
+        Returns(str): A readable string.
 
         Examples:
             .. code-block:: python
 
-                import paddle.fluid as fluid
-
-                prog = fluid.default_main_program()
-                rlt = fluid.layers.data("fake_data", shape=[1,1], dtype='float32')
-                debug_str = prog.to_string(throw_on_error=True, with_details=False)
-                print(debug_str)
+                import paddle
+                paddle.enable_imperative()
+                conv = paddle.nn.Conv2D(3, 3, 5)
+                print(conv.weight)
+                # Parameter: conv2d_0.w_0
+                #   - place: CUDAPlace(0)
+                #   - shape: [3, 3, 5, 5]
+                #   - layout: NCHW
+                #   - dtype: float
+                #   - data: [...] 
+                paddle.disable_imperative()
         """
-        assert isinstance(throw_on_error, bool) and isinstance(with_details,
-                                                               bool)
         tensor = self.value().get_tensor()
         if tensor._is_initialized():
             return 'Parameter: %s\n%s' % (self.name, str(tensor))

--- a/python/paddle/fluid/tests/unittests/test_imperative_framework.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_framework.py
@@ -62,5 +62,5 @@ class TestDygraphFramework(unittest.TestCase):
     def test_dygraph_to_string(self):
         np_inp = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
         with fluid.dygraph.guard():
-            var_inp = fluid.dygraph.base.to_variable(np_inp)
-            var_inp.to_string(throw_on_error=True)
+            var_inp = fluid.dygraph.to_variable(np_inp)
+            print(str(var_inp))

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -102,7 +102,7 @@ class TestVarBase(unittest.TestCase):
     def test_to_string(self):
         with fluid.dygraph.guard():
             var = fluid.dygraph.to_variable(self.array)
-            self.assertTrue(isinstance(str(var.to_string(True)), str))
+            self.assertTrue(isinstance(str(var), str))
 
     def test_backward(self):
         with fluid.dygraph.guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

Clean unused code in `__str__` of VarBase and ParamBase

The parameter `throw_on_error ` and `with_details` seems directly copied from Variable.to_string(), which is useless.