### PR TITLE
fix parallel ssa graph executor test hang

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_fetch_isolated_var.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_fetch_isolated_var.py
@@ -27,7 +27,7 @@ class TestParallelExecutorFetchIsolatedVarBase(unittest.TestCase):
     def build_network(self, is_training):
         x = fluid.data(name='x', shape=[-1, 10], dtype='float32')
         y = fluid.data(name='y', shape=[-1, 10], dtype='float32')
-        fc = fluid.layers.fc(x, size=30)
+        fc = fluid.layers.fc(x, size=30, bias_attr=False)
         loss = fluid.layers.reduce_mean(fc)
         if is_training:
             adam = fluid.optimizer.Adam(learning_rate=1e-3)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
修复 test_parallel_executor_fetch_isolated_var 单测容易hang的问题

hang的具体原因是parallel ssa graph executor执行的时候，参数梯度产生的顺序不固定，多个all reduce 在进行同步的时候shape不一致，nccl失败

这个单测主要目的是为了测试fetch 一个feed的var的正确性得问题， 暂时性修复方式是把参数个数变成是一个，防止nccl失败，由于parallel ssa graph executor 目前没有对用户直接暴露，后续会修复parallel ssa graph executor 产生梯度顺序不一致的问题

