### PR TITLE
Fix scipy

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
 nltk>=3.2.2, <=3.4 ; python_version<"3.5"
 matplotlib ; python_version>="3.6"
-scipy<=1.3.1 ; python_version<="3.5.2"
+scipy<=1.3.1 ; python_version<"3.5.3"
 scipy ; python_version>="3.5.3"
 nltk ; python_version>="3.5"
 rarfile

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,8 @@ matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
 nltk>=3.2.2, <=3.4 ; python_version<"3.5"
 matplotlib ; python_version>="3.6"
-scipy ; python_version>="3.5"
+scipy<=1.3.1 ; python_version<="3.5.2"
+scipy ; python_version>="3.5.3"
 nltk ; python_version>="3.5"
 rarfile
 Pillow

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
 nltk>=3.2.2, <=3.4 ; python_version<"3.5"
 matplotlib ; python_version>="3.6"
-scipy<=1.3.1 ; python_versions="3.5"
+scipy<=1.3.1 ; python_versions=="3.5"
 scipy ; python_version>"3.5"
 nltk ; python_version>="3.5"
 rarfile

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,7 +7,7 @@ matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
 nltk>=3.2.2, <=3.4 ; python_version<"3.5"
 matplotlib ; python_version>="3.6"
-scipy<=1.3.1 ; python_versions=="3.5"
+scipy<=1.3.1 ; python_version=="3.5"
 scipy ; python_version>"3.5"
 nltk ; python_version>="3.5"
 rarfile

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,8 +7,8 @@ matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
 nltk>=3.2.2, <=3.4 ; python_version<"3.5"
 matplotlib ; python_version>="3.6"
-scipy<=1.3.1 ; python_version<"3.5.3"
-scipy ; python_version>="3.5.3"
+scipy<=1.3.1 ; python_versions="3.5"
+scipy ; python_version>"3.5"
 nltk ; python_version>="3.5"
 rarfile
 Pillow

--- a/tools/manylinux1/Dockerfile.cuda9_cudnn7_gcc48_py35_centos6
+++ b/tools/manylinux1/Dockerfile.cuda9_cudnn7_gcc48_py35_centos6
@@ -65,4 +65,7 @@ RUN LD_LIBRARY_PATH=/opt/_internal/cpython-2.7.11-ucs4/lib:${LD_LIBRARY_PATH} /o
 RUN wget -O /opt/swig-2.0.12.tar.gz https://sourceforge.net/projects/swig/files/swig/swig-2.0.12/swig-2.0.12.tar.gz/download && \
     cd /opt && tar xzf swig-2.0.12.tar.gz && cd /opt/swig-2.0.12 && ./configure && make && make install && cd /opt && rm swig-2.0.12.tar.gz
 
+RUN wget --no-check-certificate  -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz && \
+     tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/
+
 CMD ["bash", "/paddle/paddle/scripts/docker/build.sh"]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix scipy in python3.5
python3.5.2之前的python存在一个bug，scipy 1.4.1版本会用到这个问题，导致报错：ImportError: cannot import name 'Type'，scipy 降级1.3.1 可以解决这个问题
![image](https://user-images.githubusercontent.com/29832297/86587516-563fcc80-bfbc-11ea-9a7f-16efe3318c46.png)
