### PR TITLE
Speedup reader check_input_array when item is array

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -809,7 +809,7 @@ class DygraphGeneratorLoader(DataLoaderBase):
 
     @classmethod
     def _check_input_array(cls, item):
-        arr = np.array(item)
+        arr = np.asarray(item)
         if arr.dtype == np.object:
             raise TypeError(
                 "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
@@ -817,6 +817,7 @@ class DygraphGeneratorLoader(DataLoaderBase):
                 "\n\t* Check the reader function passed to 'decorate_batch_generator'"
                 " to locate the data causes this issue.\n\t* Please consider using "
                 "'fluid.create_lod_tensor' to convert it to a LoD-Tensor.")
+        return arr
 
     def _exit_thread_expectedly(self):
         self._thread_done_event.set()
@@ -894,7 +895,7 @@ class DygraphGeneratorLoader(DataLoaderBase):
                 array = core.LoDTensorArray()
                 for item in sample:
                     if not isinstance(item, core.LoDTensor):
-                        self._check_input_array(item)
+                        item = self._check_input_array(item)
                         tmp = core.LoDTensor()
                         tmp.set(item, core.CPUPlace())
                         item = tmp
@@ -1117,7 +1118,7 @@ class GeneratorLoader(DataLoaderBase):
 
     @classmethod
     def _check_input_array(cls, item):
-        arr = np.array(item)
+        arr = np.asarray(item)
         if arr.dtype == np.object:
             raise TypeError((
                 "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "

--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -97,6 +97,18 @@ class DataLoaderBase(object):
     def __next__(self):
         raise NotImplementedError()
 
+    @classmethod
+    def _check_input_array(cls, item):
+        arr = np.asarray(item)
+        if arr.dtype == np.object:
+            raise TypeError(
+                "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
+                "this means the input data contains nested lists with different lengths. "
+                "\n\t* Check the reader function passed to 'decorate_batch_generator'"
+                " to locate the data causes this issue.\n\t* Please consider using "
+                "'fluid.create_lod_tensor' to convert it to a LoD-Tensor.")
+        return arr
+
 
 class DataLoader(object):
     """
@@ -807,18 +819,6 @@ class DygraphGeneratorLoader(DataLoaderBase):
             self._reset()
             six.reraise(*sys.exc_info())
 
-    @classmethod
-    def _check_input_array(cls, item):
-        arr = np.asarray(item)
-        if arr.dtype == np.object:
-            raise TypeError(
-                "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
-                "this means the input data contains nested lists with different lengths. "
-                "\n\t* Check the reader function passed to 'decorate_batch_generator'"
-                " to locate the data causes this issue.\n\t* Please consider using "
-                "'fluid.create_lod_tensor' to convert it to a LoD-Tensor.")
-        return arr
-
     def _exit_thread_expectedly(self):
         self._thread_done_event.set()
         self._blocking_queue.close()
@@ -1115,19 +1115,6 @@ class GeneratorLoader(DataLoaderBase):
     def reset(self):
         assert not self._iterable, "reset() cannot be called when DataLoader is iterable"
         self._reset()
-
-    @classmethod
-    def _check_input_array(cls, item):
-        arr = np.asarray(item)
-        if arr.dtype == np.object:
-            raise TypeError((
-                "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
-                "this means the input data contains nested lists with different lengths. "
-                "\n\t* Check the reader function passed to 'decorate_batch_generator'"
-                " to locate the data causes this issue.\n\t* Please consider using "
-                "'fluid.create_lod_tensor' to convert it to a LoD-Tensor."))
-
-        return arr
 
     def _start(self):
         def __thread_main__():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
When the item is ndarry, _check_input_array will copy it as a new array, this copy is unnecessary. Now use `asarray` to optimize this scene.


![image](https://user-images.githubusercontent.com/10208305/86570719-f4269d80-bfa2-11ea-974d-93857492f3b4.png)
As shown in the figure, when the amount of data is 100 * 300 * 768 * 4 = 87.89MB, it takes 77.7ms to copy. While `asarray` uses zerocopy in this scenario, which takes only 326ns.