### PR TITLE
fix test_multiprocess_dataloader_exception failed on CPU-only version

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -109,6 +109,8 @@ class TestDataLoaderAssert(unittest.TestCase):
 
 # CI Converage cannot record stub in subprocess,
 # HACK a _worker_loop in main process call here
+@unittest.skipIf(not core.is_compiled_with_cuda(),
+                 "core is not compiled with CUDA")
 class TestDataLoaderWorkerLoop(unittest.TestCase):
     def run_without_worker_done(self, use_shared_memory=True):
         try:

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -23,6 +23,7 @@ import multiprocessing
 import numpy as np
 
 import paddle.fluid as fluid
+import paddle.fluid.core as core
 from paddle.io import Dataset, BatchSampler, DataLoader
 from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.dygraph.base import to_variable


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others 

### Describe
test_multiprocess_dataloader_exception use CUDAPlace may failed on CPU-only version
skip test if CPU-only version installed
