### PR TITLE
[Dy2Stat] Fix test_lac unittest timeout

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
@@ -513,13 +513,8 @@ class TestLACModel(unittest.TestCase):
         return out
 
     def test_train(self):
-        # TODO(Aurelius84): The unittest will hang sometimes under command "ctest" 
-        # on Windows platform, which means it failed to start up this unittest. 
-        # So the unittest raised timeout.
-        if os.name == 'nt':
-            return
-        dy_out = self.train(to_static=False)
         st_out = self.train(to_static=True)
+        dy_out = self.train(to_static=False)
         self.assertTrue(
             np.allclose(dy_out, st_out),
             msg="dygraph output:\n{},\nstatic output:\n {}.".format(dy_out,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix test_lac unittest timeout. I fixed it but the exact reason is uncertain.
#### What

##### 1. Step One:
The unittest `test_lac`  randomly timeout on Windows CI, but it's ok on Linux CI. This is strange intuitively. 
I debug this for details by logging info in `paddle/tools/test_runner.py`, because it was launched by cmd:
```bash
cmake.exe -E env PYTHONPATH=D:/zhangliujie/Paddle/build/python C:/Python27/python.exe D:/zhangliujie/Paddle/tools/test_runner.py test_lac
```
In `test_runner.py`, I add followed code:
```python
def main():
    print("enter main()")  # <-----------  here
    sys.path.append(os.getcwd())
    some_test_failed = False
    for module_name in sys.argv[1:]:
        print("module_name: ", module_name)  # <-----------  here
        buffer = cStringIO()
        main = fluid.Program()
        startup = fluid.Program()
        scope = fluid.core.Scope()
        with fluid.program_guard(main, startup):
            with fluid.scope_guard(scope):
                with fluid.unique_name.guard():
                    print("init test_loader")   # <-----------  here
                    test_loader = unittest.TestLoader()
                    module = importlib.import_module(module_name)
                    tests = test_loader.loadTestsFromModule(module)
                    res = unittest.TextTestRunner(stream=buffer).run(tests)
                    if not res.wasSuccessful():
                        some_test_failed = True
                        print(
                            module_name,
                            'failed\n',
                            buffer.getvalue(),
                            file=sys.stderr)
```
When I ran `ctest.exe --output-on-failure -C Release -R test_lac -V --repeat-until-fail 30`, it will output something like this when randomly failed.
```bash

768: Test command: "C:\Program Files\CMake\bin\cmake.exe" "-E" "env" "PYTHONPATH=D:/zhangliujie/Paddle/build/python" "C:/Python27/python.exe" "D:/zhangliujie/Paddle/tools/test_runner.py" "test_lac"
768: Test timeout computed to be: 350
```
**We can see that the `information` didn't appear here, which means `ctest` didn't launch the `test_runner.py` sucessfully.**

#####  2. step two
I executed the unittest by `python test_lac.py`, it's ok even I ran it more than 500 times.

I removed the codes related with training to make it only yield data from `DataLoader`.  **Everything is OK using CTest**

I removed the codes related with `Dy2stat`, the problem still existed that means it was not from `Dy2stat`.

If I put `st_out = self._train(to_static=True)` on the front， it can fix this timeout problem.

#### Why

The exact reason is uncertain. This problem only come out on windows with CTest. It seems to have something to do with windows compliing or CTest. I'll figure that out later.

#### reference
+ [A CTest never ends](https://yyangtech.wordpress.com/category/python/)
+ [Test Fixtures With CMake/CTest](https://crascit.com/2016/10/18/test-fixtures-with-cmake-ctest/)
