### PR TITLE
fix concat shape error

### DIFF
--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -50,9 +50,6 @@ static inline framework::DDim ComputeAndCheckShape(
           }
         }
       } else {
-        if (!is_runtime && inputs_dims[i][j] == -1) {
-          out_dims[axis] = -1;
-        }
         bool check_shape =
             is_runtime || (out_dims[j] > 0 && inputs_dims[i][j] > 0);
         if (check_shape) {
@@ -64,6 +61,9 @@ static inline framework::DDim ComputeAndCheckShape(
                                 "But received input[0]'s shape = "
                                 "[%s], input[%d]'s shape = [%s].",
                                 j, i, inputs_dims[0], i, inputs_dims[i]));
+        }
+        if (!is_runtime && out_dims[j] == -1 && inputs_dims[i][j] > 0) {
+          out_dims[j] = inputs_dims[i][j];
         }
       }
     }

--- a/paddle/fluid/operators/concat_op.h
+++ b/paddle/fluid/operators/concat_op.h
@@ -31,18 +31,28 @@ static inline framework::DDim ComputeAndCheckShape(
   auto out_dims = inputs_dims[0];
   size_t in_zero_dims_size = out_dims.size();
   for (size_t i = 1; i < n; i++) {
+    PADDLE_ENFORCE_EQ(inputs_dims[i].size(), out_dims.size(),
+                      platform::errors::InvalidArgument(
+                          "The shape of input[0] and input[%d] "
+                          "is expected to be equal."
+                          "But received input[0]'s shape = "
+                          "[%s], input[%d]'s shape = [%s].",
+                          i, inputs_dims[0], i, inputs_dims[i]));
     for (size_t j = 0; j < in_zero_dims_size; j++) {
       if (j == axis) {
         if (is_runtime) {
           out_dims[axis] += inputs_dims[i][j];
         } else {
-          if (inputs_dims[i][j] == -1) {
+          if (inputs_dims[i][j] == -1 || out_dims[j] == -1) {
             out_dims[axis] = -1;
           } else {
             out_dims[axis] += inputs_dims[i][j];
           }
         }
       } else {
+        if (!is_runtime && inputs_dims[i][j] == -1) {
+          out_dims[axis] = -1;
+        }
         bool check_shape =
             is_runtime || (out_dims[j] > 0 && inputs_dims[i][j] > 0);
         if (check_shape) {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
修复两个case：
1.  #25318 在组网阶段，针对其中一个输入的维度不确定[-1, -1, -1, -1]，一个输入维度确定[1, 32, 64, 64]的情况 (axis=1)。
    修复前：得到的tensor维度为[-1, 31, -1, -1]，即直接进行了加减处理，且不是axis的轴，默认取第一个输入的维度。
    修复后：得到的tensor维度为[-1,-1, 64, 64]。axis的轴，需要运行时确认。不是axis的轴，不同输入变量的维度应该相等，所以采用确定的维度数据。在运行时，还会再一次进行维度相等判断。

2. #25102 增加concat输入的形状不同的报错。两个输入维度分别为[-1, 20]和[-1, 4, 20]。
```
----------------------
Error Message Summary:
----------------------
InvalidArgumentError: The shape of input[0] and input[1] is expected to be equal.But received input[0]'s shape = [-1, 20], input[1]'s shape = [-1, 4, 20].
  [Hint: Expected inputs_dims[i].size() == out_dims.size(), but received inputs_dims[i].size():3 != out_dims.size():2.] at (/home/gaowei/padding/Paddle/paddle/fluid/operators/concat_op.h:40)
  [operator < concat > error]
```