### PR TITLE
[Dy2Stat] Remove op call stack in PartialProgram

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -308,7 +308,7 @@ class PartialProgramLayer(layers.Layer):
         transforamtions to avoid confusing users.
         """
         assert isinstance(main_program, framework.Program)
-        for block in main_program.blocks():
+        for block in main_program.blocks:
             for op in block.ops:
                 if op.has_attr("op_callstack"):
                     op._remove_attr("op_callstack")

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -112,14 +112,7 @@ class PartialProgramLayer(layers.Layer):
         self._outputs = NestSequence(outputs, need_check=True)
         self._params = parameters if parameters is not None else []
 
-        # Check all params from main program can be found in self._params:
-        # 1. parameter in self._params should be type `framework.ParamBase` which are created in dygraph.
-        # 2. parameter from transformed program shall be found in self._params.
-        #    Because they share same data with ParamBase of original dygraph.
-        self._check_params_all_inited(main_program)
-        self._prune_unused_params(main_program)
-
-        self._infer_program = main_program
+        self._infer_program = self._verify_program(main_program)
         self._train_program = self._append_backward_desc()
         # Switch infer or train by train() and eval()
         self._trace_program = None
@@ -127,6 +120,20 @@ class PartialProgramLayer(layers.Layer):
         self._inner_scope = core.Scope()
         # Set default mode to train
         self.train()
+
+    def _verify_program(self, main_program):
+        """
+        Verify that the program parameter is initialized, prune some unused params,
+        and remove redundant op callstack.
+        """
+        # 1. Check all params from main program can be found in self._params
+        self._check_params_all_inited(main_program)
+        # 2. Prune the parameters not used anywhere in the program.
+        self._prune_unused_params(main_program)
+        # 3. Remove op's python call stack with redundant low-level error messages.
+        main_program = self._remove_op_call_stack(main_program)
+
+        return main_program
 
     @switch_to_static_graph
     def _append_backward_desc(self):
@@ -294,6 +301,19 @@ class PartialProgramLayer(layers.Layer):
             if grad_var is None:
                 continue
             param._set_grad_type(grad_var.type())
+
+    def _remove_op_call_stack(self, main_program):
+        """
+        Remove op's python call stack with redundant low-level error messages related to
+        transforamtions to avoid confusing users.
+        """
+        assert isinstance(main_program, framework.Program)
+        for block in main_program.blocks():
+            for op in block.ops:
+                if op.has_attr("op_callstack"):
+                    op._remove_attr("op_callstack")
+
+        return main_program
 
     def _check_params_all_inited(self, main_program):
         """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
+ Remove op call stack in PartialProgram which is redundant low-level error message. It will confusing users.
+ Refine logic code of checking `main_program` by putting them into `_verify_program`

**after:**
```
======================================================================
ERROR: test_train (__main__.TestDeclarative)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 211, in test_train
    st_out = train(self.args, self.place, to_static=True)
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 189, in train
    returns = finish_episode()
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 155, in finish_episode
    policy_loss.backward()
  File "<decorator-gen-94>", line 2, in backward
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/framework.py", line 220, in __impl__
    return func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/varbase_patch_methods.py", line 167, in backward
    self._run_backward(backward_strategy, framework._dygraph_tracer())
EnforceNotMet: 

--------------------------------------------
C++ Call Stacks (More useful to developers):
--------------------------------------------
0   std::string paddle::platform::GetTraceBackString<std::string >(std::string&&, char const*, int)
1   paddle::framework::Tensor::check_memory_size() const
2   paddle::framework::Tensor::ShareDataWith(paddle::framework::Tensor const&)
3   paddle::operators::SoftmaxGradKernel<paddle::platform::CPUDeviceContext, float>::Compute(paddle::framework::ExecutionContext const&) const
4   std::_Function_handler<void (paddle::framework::ExecutionContext const&), paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 0ul, paddle::operators::SoftmaxGradKernel<paddle::platform::CPUDeviceContext, float>, paddle::operators::SoftmaxGradKernel<paddle::platform::CPUDeviceContext, double> >::operator()(char const*, char const*, int) const::{lambda(paddle::framework::ExecutionContext const&)#1}>::_M_invoke(std::_Any_data const&, paddle::framework::ExecutionContext const&)
5   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&, paddle::framework::RuntimeContext*) const
6   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&) const
7   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, paddle::platform::Place const&)
8   paddle::framework::Executor::RunPartialPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, long, long, bool, bool, bool)
9   paddle::operators::RunProgramGradOpKernel<paddle::platform::CPUDeviceContext, float>::Compute(paddle::framework::ExecutionContext const&) const
10  std::_Function_handler<void (paddle::framework::ExecutionContext const&), paddle::framework::OpKernelRegistrarFunctor<paddle::platform::CPUPlace, false, 0ul, paddle::operators::RunProgramGradOpKernel<paddle::platform::CPUDeviceContext, float> >::operator()(char const*, char const*, int) const::{lambda(paddle::framework::ExecutionContext const&)#1}>::_M_invoke(std::_Any_data const&, paddle::framework::ExecutionContext const&)
11  paddle::imperative::PreparedOp::Run(paddle::imperative::NameVariableWrapperMap const&, paddle::imperative::NameVariableWrapperMap const&, paddle::framework::AttributeMap const&)
12  paddle::imperative::BasicEngine::Execute()

----------------------
Error Message Summary:
----------------------
Error: Tensor holds no memory. Call Tensor::mutable_data first.
  [Hint: holder_ should not be null.] at (/workspace/code_dev/paddle-fork/paddle/fluid/framework/tensor.cc:23)
  [operator < softmax_grad > error]
```

**before:**
```
======================================================================
ERROR: test_train (__main__.TestDeclarative)
----------------------------------------------------------------------
<同上>

--------------------------------------------
C++ Call Stacks (More useful to developers):     
--------------------------------------------
<同上>

------------------------------------------
Python Call Stacks (More useful to users):       <------- 删除了此部分无用的报错栈信息
------------------------------------------
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2799, in append_op
    attrs=kwargs.get("attrs", None))
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/layer_helper.py", line 43, in append_op
    return self.main_program.current_block().append_op(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/layers/nn.py", line 1311, in softmax
    attrs=attrs)
  File "/workspace/tmp/tmpOA_sVt.py", line 8, in forward
    log_prob = fluid.layers.softmax(action_scores, axis=1)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/program_translator.py", line 280, in from_func_spec
    outputs = static_func(*inputs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/base.py", line 41, in __impl__
    return func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "<decorator-gen-40>", line 2, in from_func_spec
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/program_translator.py", line 302, in _build_once
    concrete_program = ConcreteProgram.from_func_spec(func_spec)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/program_translator.py", line 311, in __getitem__
    self._caches[item] = self._build_once(item)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/program_translator.py", line 469, in get_output
    _, partial_program_layer = self._program_cache[function_spec]
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/jit.py", line 161, in __impl__
    return program_translator.get_output(dygraph_func, *args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "<decorator-gen-99>", line 2, in forward
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/dygraph/layers.py", line 600, in __call__
    outputs = self.forward(*inputs, **kwargs)
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 114, in select_action
    loss_probs = policy(state)
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 173, in train
    action = select_action(state)
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 211, in test_train
    st_out = train(self.args, self.place, to_static=True)
  File "/usr/lib/python2.7/unittest/case.py", line 329, in run
    testMethod()
  File "/usr/lib/python2.7/unittest/case.py", line 393, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python2.7/unittest/suite.py", line 108, in run
    test(result)
  File "/usr/lib/python2.7/unittest/suite.py", line 70, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python2.7/unittest/suite.py", line 108, in run
    test(result)
  File "/usr/lib/python2.7/unittest/suite.py", line 70, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python2.7/unittest/runner.py", line 151, in run
    test(result)
  File "/usr/lib/python2.7/unittest/main.py", line 232, in runTests
    self.result = testRunner.run(self.test)
  File "/usr/lib/python2.7/unittest/main.py", line 95, in __init__
    self.runTests()
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/dygraph_to_static/test_reinforcement_learning.py", line 217, in <module>
    unittest.main()

----------------------
Error Message Summary:
----------------------
<同上>
```

