### PR TITLE
【paddle.fleet】remove async py37 configuration from distributed_strategy.py

### DIFF
--- a/python/paddle/fleet/base/distributed_strategy.py
+++ b/python/paddle/fleet/base/distributed_strategy.py
@@ -375,17 +375,6 @@ class DistributedStrategy(object):
             print("WARNING: sync should have value of bool type")
 
     @property
-    def async(self):
-        return self.strategy.async
-
-    @async.setter
-    def async(self, flag):
-        if isinstance(flag, bool):
-            self.strategy.async = flag
-        else:
-            print("WARNING: async should have value of bool type")
-
-    @property
     def async_k_step(self):
         return self.strategy.async_k_step
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_distributed_strategy.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_distributed_strategy.py
@@ -247,15 +247,6 @@ class TestStrategyConfig(unittest.TestCase):
         strategy.sync = "True"
         self.assertEqual(strategy.sync, False)
 
-    def test_async(self):
-        strategy = paddle.fleet.DistributedStrategy()
-        strategy.async = True
-        self.assertEqual(strategy.async, True)
-        strategy.async = False
-        self.assertEqual(strategy.async, False)
-        strategy.async = "True"
-        self.assertEqual(strategy.async, False)
-
     def test_async_k_step(self):
         strategy = paddle.fleet.DistributedStrategy()
         strategy.async_k_step = 10000


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types

<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
remove async configuration for compatibility of py37