### PR TITLE
refine unsqueeze, test=develop

### DIFF
--- a/paddle/fluid/operators/squeeze_op.cc
+++ b/paddle/fluid/operators/squeeze_op.cc
@@ -304,6 +304,7 @@ REGISTER_OPERATOR(squeeze2_grad, ops::Squeeze2GradOp,
 REGISTER_OP_CPU_KERNEL(
     squeeze, ops::SqueezeKernel<paddle::platform::CPUDeviceContext, float>,
     ops::SqueezeKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::SqueezeKernel<paddle::platform::CPUDeviceContext, bool>,
     ops::SqueezeKernel<paddle::platform::CPUDeviceContext, int>,
     ops::SqueezeKernel<paddle::platform::CPUDeviceContext, int8_t>,
     ops::SqueezeKernel<paddle::platform::CPUDeviceContext, int64_t>);
@@ -311,12 +312,14 @@ REGISTER_OP_CPU_KERNEL(
     squeeze_grad,
     ops::SqueezeGradKernel<paddle::platform::CPUDeviceContext, float>,
     ops::SqueezeGradKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::SqueezeGradKernel<paddle::platform::CPUDeviceContext, bool>,
     ops::SqueezeGradKernel<paddle::platform::CPUDeviceContext, int>,
     ops::SqueezeGradKernel<paddle::platform::CPUDeviceContext, int8_t>,
     ops::SqueezeGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
 REGISTER_OP_CPU_KERNEL(
     squeeze2, ops::Squeeze2Kernel<paddle::platform::CPUDeviceContext, float>,
     ops::Squeeze2Kernel<paddle::platform::CPUDeviceContext, double>,
+    ops::Squeeze2Kernel<paddle::platform::CPUDeviceContext, bool>,
     ops::Squeeze2Kernel<paddle::platform::CPUDeviceContext, int>,
     ops::Squeeze2Kernel<paddle::platform::CPUDeviceContext, int8_t>,
     ops::Squeeze2Kernel<paddle::platform::CPUDeviceContext, int64_t>);
@@ -324,6 +327,7 @@ REGISTER_OP_CPU_KERNEL(
     squeeze2_grad,
     ops::Squeeze2GradKernel<paddle::platform::CPUDeviceContext, float>,
     ops::Squeeze2GradKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::Squeeze2GradKernel<paddle::platform::CPUDeviceContext, bool>,
     ops::Squeeze2GradKernel<paddle::platform::CPUDeviceContext, int>,
     ops::Squeeze2GradKernel<paddle::platform::CPUDeviceContext, int8_t>,
     ops::Squeeze2GradKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/squeeze_op.cu.cc
+++ b/paddle/fluid/operators/squeeze_op.cu.cc
@@ -21,6 +21,7 @@ REGISTER_OP_CUDA_KERNEL(
     squeeze, ops::SqueezeKernel<paddle::platform::CUDADeviceContext, float>,
     ops::SqueezeKernel<paddle::platform::CUDADeviceContext, double>,
     ops::SqueezeKernel<paddle::platform::CUDADeviceContext, plat::float16>,
+    ops::SqueezeKernel<paddle::platform::CUDADeviceContext, bool>,
     ops::SqueezeKernel<paddle::platform::CUDADeviceContext, int>,
     ops::SqueezeKernel<paddle::platform::CUDADeviceContext, int8_t>,
     ops::SqueezeKernel<paddle::platform::CUDADeviceContext, int64_t>);
@@ -29,6 +30,7 @@ REGISTER_OP_CUDA_KERNEL(
     ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, double>,
     ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, plat::float16>,
+    ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, bool>,
     ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, int>,
     ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, int8_t>,
     ops::SqueezeGradKernel<paddle::platform::CUDADeviceContext, int64_t>);
@@ -36,6 +38,7 @@ REGISTER_OP_CUDA_KERNEL(
     squeeze2, ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, float>,
     ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, double>,
     ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, plat::float16>,
+    ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, bool>,
     ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, int>,
     ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, int8_t>,
     ops::Squeeze2Kernel<paddle::platform::CUDADeviceContext, int64_t>);
@@ -44,6 +47,7 @@ REGISTER_OP_CUDA_KERNEL(
     ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, double>,
     ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, plat::float16>,
+    ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, bool>,
     ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, int>,
     ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, int8_t>,
     ops::Squeeze2GradKernel<paddle::platform::CUDADeviceContext, int64_t>);

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6200,7 +6200,7 @@ def squeeze(input, axes, name=None):
             Out.shape = [1,3,5]
 
     Args:
-        input (Variable): The input Tensor. Support data type: float32, float64, bool, int8, int32, int64.
+        input (Variable): The input Tensor. Supported data type: float32, float64, bool, int8, int32, int64.
                           axes (list): One integer or List of integers, indicating the dimensions to be squeezed.
                           Axes range is :math:`[-rank(input), rank(input))`.
                           If axes is negative, :math:`axes=axes+rank(input)`.
@@ -6255,7 +6255,7 @@ def unsqueeze(input, axes, name=None):
       then Unsqueezed tensor with axes=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
-        input (Variable): The input Tensor to be unsqueezed. Support data type: float32, float64, bool, int8, int32, int64.
+        input (Variable): The input Tensor to be unsqueezed. Supported data type: float32, float64, bool, int8, int32, int64.
         axes (int|list|tuple|Variable): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
         name (str|None): Name for this layer.
 
@@ -9972,7 +9972,7 @@ def stack(x, axis=0, name=None):
                                      must be the same. Supposing input is N dims
                                      Tensors :math:`[d_0, d_1, ..., d_{n-1}]`, the output is N+1 dims
                                      Tensor :math:`[d_0, d_1, d_{axis-1}, len(x), d_{axis}, ..., d_{n-1}]`.
-                                     Support data types: float32, float64, int32, int64.
+                                     Supported data types: float32, float64, int32, int64.
         axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is :math:`[-(R+1), R+1)`.
                               R is the first tensor of inputs. If ``axis`` < 0, :math:`axis=axis+rank(x[0])+1`.
                               The default value of axis is 0.

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6269,6 +6269,10 @@ def unsqueeze(input, axes, name=None):
             y = fluid.layers.unsqueeze(input=x, axes=[1])
 
     """
+    if in_dygraph_mode():
+        out, _ = core.ops.unsqueeze2(x, 'axis', axis)
+        return out
+
     if not isinstance(axes, (int, list, tuple, Variable)):
         raise TypeError(
             "The type of 'axes' in unsqueeze must be int, list, tuple or Variable, but "

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6270,7 +6270,7 @@ def unsqueeze(input, axes, name=None):
 
     """
     if in_dygraph_mode():
-        out, _ = core.ops.unsqueeze2(x, 'axis', axis)
+        out, _ = core.ops.unsqueeze2(input, 'axes', axes)
         return out
 
     if not isinstance(axes, (int, list, tuple, Variable)):

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6200,7 +6200,7 @@ def squeeze(input, axes, name=None):
             Out.shape = [1,3,5]
 
     Args:
-        input (Variable): The input Tensor. Support data type: float16, float32, float64, int8, int32, int64.
+        input (Variable): The input Tensor. Support data type: float32, float64, bool, int8, int32, int64.
                           axes (list): One integer or List of integers, indicating the dimensions to be squeezed.
                           Axes range is :math:`[-rank(input), rank(input))`.
                           If axes is negative, :math:`axes=axes+rank(input)`.
@@ -6226,7 +6226,8 @@ def squeeze(input, axes, name=None):
     helper = LayerHelper("squeeze", **locals())
     check_variable_and_dtype(
         input, 'input',
-        ['float16', 'float32', 'float64', 'int8', 'int32', 'int64'], 'squeeze')
+        ['float16', 'float32', 'float64', 'bool', 'int8', 'int32', 'int64'],
+        'squeeze')
     check_type(axes, 'axis/axes', (list, tuple), 'squeeze')
     out = helper.create_variable_for_type_inference(dtype=input.dtype)
     x_shape = helper.create_variable_for_type_inference(dtype=input.dtype)
@@ -6254,7 +6255,7 @@ def unsqueeze(input, axes, name=None):
       then Unsqueezed tensor with axes=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
-        input (Variable): The input Tensor to be unsqueezed. Support data type: float16, float32, float64, int8, int32, int64.
+        input (Variable): The input Tensor to be unsqueezed. Support data type: float32, float64, bool, int8, int32, int64.
         axes (int|list|tuple|Variable): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
         name (str|None): Name for this layer.
 
@@ -6274,6 +6275,10 @@ def unsqueeze(input, axes, name=None):
         return out
 
     check_type(axes, 'axis/axes', (int, list, tuple, Variable), 'unsqueeze')
+    check_variable_and_dtype(
+        input, 'input',
+        ['float16', 'float32', 'float64', 'bool', 'int8', 'int32', 'int64'],
+        'unsqueeze')
     helper = LayerHelper("unsqueeze2", **locals())
     inputs = {"X": input}
     attrs = {}

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6227,7 +6227,7 @@ def squeeze(input, axes, name=None):
     check_variable_and_dtype(
         input, 'input',
         ['float16', 'float32', 'float64', 'int8', 'int32', 'int64'], 'squeeze')
-    check_type(axes, 'axes', (list, tuple), 'squeeze')
+    check_type(axes, 'axis/axes', (list, tuple), 'squeeze')
     out = helper.create_variable_for_type_inference(dtype=input.dtype)
     x_shape = helper.create_variable_for_type_inference(dtype=input.dtype)
     helper.append_op(
@@ -6254,12 +6254,12 @@ def unsqueeze(input, axes, name=None):
       then Unsqueezed tensor with axes=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
-        input (Variable): The input Tensor to be unsqueezed. It is a N-D Tensor of data types float32, float64, int32.
+        input (Variable): The input Tensor to be unsqueezed. Support data type: float16, float32, float64, int8, int32, int64.
         axes (int|list|tuple|Variable): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
         name (str|None): Name for this layer.
 
     Returns:
-        Variable: Output unsqueezed Tensor, with data type being float32, float64, int32, int64.
+        Variable: Unsqueezed Tensor, with the same data type as input.
 
     Examples:
         .. code-block:: python
@@ -6273,10 +6273,7 @@ def unsqueeze(input, axes, name=None):
         out, _ = core.ops.unsqueeze2(input, 'axes', axes)
         return out
 
-    if not isinstance(axes, (int, list, tuple, Variable)):
-        raise TypeError(
-            "The type of 'axes' in unsqueeze must be int, list, tuple or Variable, but "
-            "received %s." % (type(axes)))
+    check_type(axes, 'axis/axes', (int, list, tuple, Variable), 'unsqueeze')
     helper = LayerHelper("unsqueeze2", **locals())
     inputs = {"X": input}
     attrs = {}

--- a/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
@@ -81,7 +81,7 @@ class API_TestUnsqueeze(unittest.TestCase):
     def test_out(self):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
             data1 = fluid.layers.data('data1', shape=[-1, 10], dtype='float64')
-            result_squeeze = paddle.unsqueeze(data1, axes=[1])
+            result_squeeze = paddle.unsqueeze(data1, axis=[1])
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             input1 = np.random.random([5, 1, 10]).astype('float64')
@@ -98,7 +98,7 @@ class TestUnsqueezeOpError(unittest.TestCase):
             def test_axes_type():
                 x6 = fluid.layers.data(
                     shape=[-1, 10], dtype='float16', name='x3')
-                paddle.unsqueeze(x6, axes=3.2)
+                paddle.unsqueeze(x6, axis=3.2)
 
             self.assertRaises(TypeError, test_axes_type)
 
@@ -125,7 +125,7 @@ class API_TestUnsqueeze3(unittest.TestCase):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
             data1 = fluid.data('data1', shape=[-1, 10], dtype='float64')
             data2 = fluid.data('data2', shape=[1], dtype='int32')
-            result_squeeze = paddle.unsqueeze(data1, axes=[data2, 3])
+            result_squeeze = paddle.unsqueeze(data1, axis=[data2, 3])
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             input1 = np.random.random([5, 1, 10, 1]).astype('float64')
@@ -143,7 +143,7 @@ class API_TestDyUnsqueeze(unittest.TestCase):
             input_1 = np.random.random([5, 1, 10]).astype("int32")
             input1 = np.squeeze(input_1, axis=1)
             input = fluid.dygraph.to_variable(input_1)
-            output = paddle.unsqueeze(input, axes=[1])
+            output = paddle.unsqueeze(input, axis=[1])
             out_np = output.numpy()
             self.assertTrue(np.allclose(input1, out_np))
 
@@ -154,7 +154,7 @@ class API_TestDyUnsqueeze2(unittest.TestCase):
             input_1 = np.random.random([5, 1, 10]).astype("int32")
             input1 = np.squeeze(input_1, axis=1)
             input = fluid.dygraph.to_variable(input_1)
-            output = paddle.unsqueeze(input, axes=1)
+            output = paddle.unsqueeze(input, axis=1)
             out_np = output.numpy()
             self.assertTrue(np.allclose(input1, out_np))
 

--- a/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
@@ -108,7 +108,7 @@ class API_TestUnsqueeze2(unittest.TestCase):
         with fluid.program_guard(fluid.Program(), fluid.Program()):
             data1 = fluid.data('data1', shape=[-1, 10], dtype='float64')
             data2 = fluid.data('data2', shape=[1], dtype='int32')
-            result_squeeze = paddle.unsqueeze(data1, axes=data2)
+            result_squeeze = paddle.unsqueeze(data1, axis=data2)
             place = fluid.CPUPlace()
             exe = fluid.Executor(place)
             input1 = np.random.random([5, 1, 10]).astype('float64')

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -438,7 +438,7 @@ def stack(x, axis=0, name=None):
     Args:
         x (Tensor|list[Tensor]): Input ``x`` can be a single tensor, or a ``list`` of tensors.
                                      If ``x`` is a ``list``, the Tensors in ``x``
-                                     must be of the same shape and dtype. Support data types: float32, float64, int32, int64.
+                                     must be of the same shape and dtype. Supported data types: float32, float64, int32, int64.
         axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is ``[-(R+1), R+1)``,
                               where ``R`` is the number of dimensions of the first input tensor ``x[0]``. 
                               If ``axis < 0``, ``axis = axis+R+1``. The default value of axis is 0.

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -593,40 +593,41 @@ def squeeze(x, axis=None, name=None):
 def unsqueeze(x, axis, name=None):
     """
 	:alias_main: paddle.unsqueeze
-	:alias: paddle.unsqueeze,paddle.tensor.unsqueeze,paddle.tensor.manipulation.unsqueeze
+	:alias: paddle.unsqueeze, paddle.tensor.unsqueeze, paddle.tensor.manipulation.unsqueeze
 
-    Insert single-dimensional entries to the shape of a Tensor. Takes one
-    required argument axes, a list of dimensions that will be inserted.
-    Dimension indices in axes are as seen in the output tensor.
+    Insert single-dimensional entries to the shape of input Tensor ``x``. Takes one
+    required argument axis, a dimension or list of dimensions that will be inserted.
+    Dimension indices in axis are as seen in the output tensor.
 
     For example:
 
     .. code-block:: text
 
       Given a tensor such that tensor with shape [3, 4, 5],
-      then Unsqueezed tensor with axes=[0, 4] has shape [1, 3, 4, 5, 1].
+      then unsqueezed tensor with axes=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
-        input (Variable): The input Tensor to be unsqueezed. It is a N-D Tensor of data types float32, float64, int32.
-        axis (int|list|tuple|Variable): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
+        x (Tensor): The input Tensor to be unsqueezed. It is a N-D Tensor of data types float32, float64, int32.
+        axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
         name (str|None): Name for this layer. Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Variable: Output unsqueezed Tensor. Data type is same as input Tensor.
+        Variable: Output unsqueezed Tensor with the same data type as input Tensor.
 
     Examples:
         .. code-block:: python
             import numpy as np
             import paddle
-            import paddle.fluid as fluid
 
-            with fluid.dygraph.guard():
-                input_1 = np.random.random([5, 10]).astype("int32")
-                # input is a variable which shape is [5, 10]
-                input = fluid.dygraph.to_variable(input_1)
-
-                output = paddle.unsqueeze(input, axes=[1])
-                # output.shape [5, 1, 10]
+            paddle.enable_imperative()
+            x = paddle.rand([5, 10])
+            
+            out1 = paddle.unsqueeze(x, axis=0)
+            print(out1.shape)  # [1, 5, 10]
+            
+            out2 = paddle.unsqueeze(x, axis=[0, 2]) 
+            print(out2.shape)  # [1, 5, 1, 10]
+            
     """
     if axis == None:
         axis = []

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -580,7 +580,7 @@ def squeeze(x, axis=None, name=None):
             out.shape = [1, 3, 5]
 
     Args:
-        x (Tensor): The input Tensor. Support data type: float32, float64, bool, int8, int32, int64.
+        x (Tensor): The input Tensor. Supported data type: float32, float64, bool, int8, int32, int64.
         axis (int|list|tuple, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
                           The range of axis is :math:`[-ndim(x), ndim(x))`.
                           If axis is negative, :math:`axis = axis + ndim(x)`.
@@ -622,7 +622,7 @@ def unsqueeze(x, axis, name=None):
     Dimension indices in axis are as seen in the output tensor.
 
     Args:
-        x (Tensor): The input Tensor to be unsqueezed. Support data type: float32, float64, bool, int8, int32, int64.
+        x (Tensor): The input Tensor to be unsqueezed. Supported data type: float32, float64, bool, int8, int32, int64.
         axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . 
                                     If ``axis`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. 
                                     If ``axis`` is a Tensor, it should be an 1-D Tensor .

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -633,53 +633,7 @@ def unsqueeze(x, axis, name=None):
     elif isinstance(axis):
         axis = [axis]
 
-    if in_dygraph_mode():
-        out, _ = core.ops.unsqueeze2(x, 'axis', axis)
-        return out
-
-    if not isinstance(axes, (int, list, tuple, Variable)):
-        raise TypeError(
-            "The type of 'axis' in unsqueeze must be int, list, tuple or Variable, but "
-            "received %s." % (type(axis)))
-    helper = LayerHelper("unsqueeze2", **locals())
-    inputs = {"X": input}
-    attrs = {}
-
-    def _to_Variable_list(one_list):
-        Variable_list = []
-        for ele in one_list:
-            if isinstance(ele, Variable):
-                ele.stop_gradient = True
-                Variable_list.append(ele)
-            else:
-                assert (isinstance(ele, int))
-                temp_out = helper.create_variable_for_type_inference('int32')
-                fill_constant([1], 'int32', ele, force_cpu=True, out=temp_out)
-                Variable_list.append(temp_out)
-        return Variable_list
-
-    if isinstance(axes, int):
-        axes = [axes]
-    if isinstance(axes, Variable):
-        axes.stop_gradient = True
-        inputs["AxesTensor"] = axes
-    elif isinstance(axes, (list, tuple)):
-        contain_var = not all(not isinstance(ele, Variable) for ele in axes)
-        if contain_var:
-            inputs["AxesTensorList"] = _to_Variable_list(axes)
-        else:
-            attrs["axes"] = axes
-
-    out = helper.create_variable_for_type_inference(dtype=input.dtype)
-    x_shape = helper.create_variable_for_type_inference(dtype=input.dtype)
-    helper.append_op(
-        type="unsqueeze2",
-        inputs=inputs,
-        attrs=attrs,
-        outputs={"Out": out,
-                 "XShape": x_shape})
-
-    return out
+    return layers.unsqueeze(x, axis, name)
 
 
 def gather(input, index, overwrite=True):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -580,7 +580,7 @@ def squeeze(x, axis=None, name=None):
             out.shape = [1, 3, 5]
 
     Args:
-        input (Tensor): The input Tensor. Support data type: float32, float64, int8, int32, int64.
+        input (Tensor): The input Tensor. Support data type: float16, float32, float64, int8, int32, int64.
         axis (int|list|tuple, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
                           The range of axis is :math:`[-ndim(input), ndim(input))`.
                           If axis is negative, :math:`axis = axis + ndim(input)`.
@@ -588,7 +588,7 @@ def squeeze(x, axis=None, name=None):
         name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Tensor: Output squeezed Tensor with the same data type as input Tensor.
+        Tensor: Squeezed Tensor with the same data type as input Tensor.
 
     Examples:
         .. code-block:: python
@@ -628,14 +628,14 @@ def unsqueeze(x, axis, name=None):
       then unsqueezed tensor with axis=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
-        x (Tensor): The input Tensor to be unsqueezed. It is a N-D Tensor of data types float32, float64, int32.
+        x (Tensor): The input Tensor to be unsqueezed. Support data type: float16, float32, float64, int8, int32, int64.
         axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . 
                                     If ``axis`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. 
                                     If ``axis`` is a Tensor, it should be an 1-D Tensor .
         name (str|None): Name for this layer. Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Tensor: Output unsqueezed Tensor with the same data type as input Tensor.
+        Tensor: Unsqueezed Tensor with the same data type as input Tensor.
 
     Examples:
         .. code-block:: python
@@ -650,6 +650,10 @@ def unsqueeze(x, axis, name=None):
             
             out2 = paddle.unsqueeze(x, axis=[0, 2]) 
             print(out2.shape)  # [1, 5, 1, 10]
+
+            axis = paddle.fluid.dygraph.to_variable([0, 1, 2])
+            out3 = paddle.unsqueeze(x, axis=axis) 
+            print(out3.shape)  # [1, 1, 1, 5, 10]
             
     """
     if isinstance(axis, int):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -42,11 +42,32 @@ from ..fluid import layers
 import paddle
 
 __all__ = [
-    'cast', 'concat', 'expand', 'expand_as', 'flatten', 'gather', 'gather_nd',
-    'reshape', 'reverse', 'scatter', 'scatter_nd_add', 'scatter_nd',
-    'shard_index', 'slice', 'split', 'squeeze', 'stack', 'strided_slice',
-    'transpose', 'unique', 'unique_with_counts', 'unsqueeze', 'unstack', 'flip',
-    'unbind', 'roll'
+    'cast',
+    'concat',
+    'expand',
+    'expand_as',
+    'flatten',
+    'gather',
+    'gather_nd',
+    'reshape',
+    'reverse',
+    'scatter',
+    'scatter_nd_add',
+    'scatter_nd',
+    'shard_index',
+    'slice',
+    'split',
+    'squeeze',
+    'stack',
+    'strided_slice',
+    'transpose',
+    'unique',
+    'unique_with_counts',
+    'unsqueeze',
+    'unstack',
+    'flip',
+    'unbind',
+    'roll',
 ]
 
 
@@ -612,7 +633,7 @@ def unsqueeze(x, axis, name=None):
         name (str|None): Name for this layer. Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Variable: Output unsqueezed Tensor with the same data type as input Tensor.
+        Tensor: Output unsqueezed Tensor with the same data type as input Tensor.
 
     Examples:
         .. code-block:: python
@@ -629,7 +650,7 @@ def unsqueeze(x, axis, name=None):
             print(out2.shape)  # [1, 5, 1, 10]
             
     """
-    if axis == None:
+    if axis is None:
         axis = []
     elif isinstance(axis, int):
         axis = [axis]

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -590,7 +590,7 @@ def squeeze(x, axis=None, name=None):
     return layers.squeeze(x, axis, name)
 
 
-def unsqueeze(input, axes, out=None, name=None):
+def unsqueeze(x, axis, name=None):
     """
 	:alias_main: paddle.unsqueeze
 	:alias: paddle.unsqueeze,paddle.tensor.unsqueeze,paddle.tensor.manipulation.unsqueeze
@@ -608,11 +608,11 @@ def unsqueeze(input, axes, out=None, name=None):
 
     Args:
         input (Variable): The input Tensor to be unsqueezed. It is a N-D Tensor of data types float32, float64, int32.
-        axes (int|list|tuple|Variable): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
-        name (str|None): Name for this layer.
+        axis (int|list|tuple|Variable): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
+        name (str|None): Name for this layer. Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Variable: Output unsqueezed Tensor, with data type being float32, float64, int32, int64.
+        Variable: Output unsqueezed Tensor. Data type is same as input Tensor.
 
     Examples:
         .. code-block:: python
@@ -628,10 +628,19 @@ def unsqueeze(input, axes, out=None, name=None):
                 output = paddle.unsqueeze(input, axes=[1])
                 # output.shape [5, 1, 10]
     """
+    if axis == None:
+        axis = []
+    elif isinstance(axis):
+        axis = [axis]
+
+    if in_dygraph_mode():
+        out, _ = core.ops.unsqueeze2(x, 'axis', axis)
+        return out
+
     if not isinstance(axes, (int, list, tuple, Variable)):
         raise TypeError(
-            "The type of 'axes' in unsqueeze must be int, list, tuple or Variable, but "
-            "received %s." % (type(axes)))
+            "The type of 'axis' in unsqueeze must be int, list, tuple or Variable, but "
+            "received %s." % (type(axis)))
     helper = LayerHelper("unsqueeze2", **locals())
     inputs = {"X": input}
     attrs = {}

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -631,7 +631,7 @@ def unsqueeze(x, axis, name=None):
     """
     if axis == None:
         axis = []
-    elif isinstance(axis):
+    elif isinstance(axis, int):
         axis = [axis]
 
     return layers.unsqueeze(x, axis, name)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -580,7 +580,7 @@ def squeeze(x, axis=None, name=None):
             out.shape = [1, 3, 5]
 
     Args:
-        input (Tensor): The input Tensor. Support data type: float16, float32, float64, int8, int32, int64.
+        input (Tensor): The input Tensor. Support data type: float32, float64, bool, int8, int32, int64.
         axis (int|list|tuple, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
                           The range of axis is :math:`[-ndim(input), ndim(input))`.
                           If axis is negative, :math:`axis = axis + ndim(input)`.
@@ -592,6 +592,7 @@ def squeeze(x, axis=None, name=None):
 
     Examples:
         .. code-block:: python
+
             import paddle
 
             paddle.enable_imperative()
@@ -628,7 +629,7 @@ def unsqueeze(x, axis, name=None):
       then unsqueezed tensor with axis=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
-        x (Tensor): The input Tensor to be unsqueezed. Support data type: float16, float32, float64, int8, int32, int64.
+        x (Tensor): The input Tensor to be unsqueezed. Support data type: float32, float64, bool, int8, int32, int64.
         axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . 
                                     If ``axis`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. 
                                     If ``axis`` is a Tensor, it should be an 1-D Tensor .
@@ -639,7 +640,7 @@ def unsqueeze(x, axis, name=None):
 
     Examples:
         .. code-block:: python
-            import numpy as np
+
             import paddle
 
             paddle.enable_imperative()

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -588,7 +588,7 @@ def squeeze(x, axis=None, name=None):
         name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
-        Tensor: Output squeezed Tensor. Data type is same as input Tensor.
+        Tensor: Output squeezed Tensor with the same data type as input Tensor.
 
     Examples:
         .. code-block:: python
@@ -625,11 +625,13 @@ def unsqueeze(x, axis, name=None):
     .. code-block:: text
 
       Given a tensor such that tensor with shape [3, 4, 5],
-      then unsqueezed tensor with axes=[0, 4] has shape [1, 3, 4, 5, 1].
+      then unsqueezed tensor with axis=[0, 4] has shape [1, 3, 4, 5, 1].
 
     Args:
         x (Tensor): The input Tensor to be unsqueezed. It is a N-D Tensor of data types float32, float64, int32.
-        axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . If ``axes`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. If ``axes`` is an Variable, it should be an 1-D Tensor .
+        axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . 
+                                    If ``axis`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. 
+                                    If ``axis`` is a Tensor, it should be an 1-D Tensor .
         name (str|None): Name for this layer. Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
@@ -650,9 +652,7 @@ def unsqueeze(x, axis, name=None):
             print(out2.shape)  # [1, 5, 1, 10]
             
     """
-    if axis is None:
-        axis = []
-    elif isinstance(axis, int):
+    if isinstance(axis, int):
         axis = [axis]
 
     return layers.unsqueeze(x, axis, name)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -580,11 +580,11 @@ def squeeze(x, axis=None, name=None):
             out.shape = [1, 3, 5]
 
     Args:
-        input (Tensor): The input Tensor. Support data type: float32, float64, bool, int8, int32, int64.
+        x (Tensor): The input Tensor. Support data type: float32, float64, bool, int8, int32, int64.
         axis (int|list|tuple, optional): An integer or list of integers, indicating the dimensions to be squeezed. Default is None.
-                          The range of axis is :math:`[-ndim(input), ndim(input))`.
-                          If axis is negative, :math:`axis = axis + ndim(input)`.
-                          If axis is None, all the dimensions of input of size 1 will be removed.
+                          The range of axis is :math:`[-ndim(x), ndim(x))`.
+                          If axis is negative, :math:`axis = axis + ndim(x)`.
+                          If axis is None, all the dimensions of x of size 1 will be removed.
         name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
@@ -621,18 +621,12 @@ def unsqueeze(x, axis, name=None):
     required argument axis, a dimension or list of dimensions that will be inserted.
     Dimension indices in axis are as seen in the output tensor.
 
-    For example:
-
-    .. code-block:: text
-
-      Given a tensor such that tensor with shape [3, 4, 5],
-      then unsqueezed tensor with axis=[0, 4] has shape [1, 3, 4, 5, 1].
-
     Args:
         x (Tensor): The input Tensor to be unsqueezed. Support data type: float32, float64, bool, int8, int32, int64.
         axis (int|list|tuple|Tensor): Indicates the dimensions to be inserted. The data type is ``int32`` . 
                                     If ``axis`` is a list or tuple, the elements of it should be integers or Tensors with shape [1]. 
                                     If ``axis`` is a Tensor, it should be an 1-D Tensor .
+                                    If ``axis`` is negative, ``axis = axis + ndim(x) + 1``.
         name (str|None): Name for this layer. Please refer to :ref:`api_guide_Name`, Default None.
 
     Returns:
@@ -645,6 +639,7 @@ def unsqueeze(x, axis, name=None):
 
             paddle.enable_imperative()
             x = paddle.rand([5, 10])
+            print(x.shape)  # [5, 10]
             
             out1 = paddle.unsqueeze(x, axis=0)
             print(out1.shape)  # [1, 5, 10]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Refine paddle.unsqueeze

1. paddle.unsqueeze(input, axes, name=None) -> paddle.unsqueeze(x, axis, name=None)
2. `axis` supports `int, list, tuple`
3.  `dtype` supports  float32, float64, bool, int8, int32, int64, (and float16 on CUDAPlace).
4. refine document 


