### PR TITLE
fix reciprocal op doc. test=develop,test=document_fix

### DIFF
--- a/python/paddle/fluid/layers/layer_function_generator.py
+++ b/python/paddle/fluid/layers/layer_function_generator.py
@@ -288,7 +288,6 @@ Examples:
         import paddle
         import numpy as np
 
-        # use dygraph
         paddle.enable_imperative()
         x_data = np.array([1, 2, 3, 4]).astype(np.float32)
         x = paddle.imperative.to_variable(x_data)

--- a/python/paddle/fluid/layers/layer_function_generator.py
+++ b/python/paddle/fluid/layers/layer_function_generator.py
@@ -286,27 +286,15 @@ Examples:
     .. code-block:: python
 
         import paddle
-        import paddle.fluid as fluid
         import numpy as np
 
-        inputs = fluid.data(name="x", shape = [None, 4], dtype='float32')
-        output = paddle.%s(inputs)
-
-        exe = fluid.Executor(fluid.CPUPlace())
-        exe.run(fluid.default_startup_program())
-
-        #input.shape=1X4, batch_size=1
-        img = np.array([[1.0, 2.0, 3.0, 4.0]]).astype(np.float32)
-        res = exe.run(fluid.default_main_program(), feed={'x':img}, fetch_list=[output])
-        print(res)
-
-        # using dygraph
-        with paddle.imperative.guard():
-            dygraph_input = paddle.imperative.to_variable(img)
-            dygraph_output = paddle.%s(dygraph_input)
-            print(dygraph_output.numpy())
-""" % (op_type, op_type)
-
+        # use dygraph
+        paddle.enable_imperative()
+        x_data = np.array([1, 2, 3, 4]).astype(np.float32)
+        x = paddle.imperative.to_variable(x_data)
+        res = paddle.%s(x)
+        print(res.numpy())
+""" % op_type
     return func
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
激活函数的示例代码使用 `paddle.enable_imperative()`,  并删除静态图示例代码。包括如下函数：
```
    'sigmoid',
    'logsigmoid',
    'exp',
    'tanh',
    'atan',
    'tanh_shrink',
    'sqrt',
    'rsqrt',
    'abs',
    'ceil',
    'floor',
    'cos',
    'acos',
    'asin',
    'sin',
    'round',
    'reciprocal',
    'square',
    'softplus',
    'softsign',
```
