### PR TITLE
update patchelf to fix bug when coverage in ON

### DIFF
--- a/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
+++ b/tools/manylinux1/Dockerfile.cuda10_cudnn7_gcc8_ubuntu16
@@ -143,6 +143,11 @@ RUN wget -q https://paddlepaddledeps.bj.bcebos.com/TensorRT-6.0.1.5.Ubuntu-16.04
     tar -zxf TensorRT-6.0.1.5.Ubuntu-16.04.x86_64-gnu.cuda-10.1.cudnn7.tar.gz -C /usr/local && \
     cp -rf /usr/local/TensorRT-6.0.1.5/include/* /usr/include/ && cp -rf /usr/local/TensorRT-6.0.1.5/lib/* /usr/lib/ 
 
+# Install patchelf-0.10 
+RUN wget https://paddle-ci.gz.bcebos.com/patchelf-0.10.tar.gz && \
+    tar -zxvf patchelf-0.10.tar.gz && cd patchelf-0.10 && \
+    ./configure && make -j8 && make install
+
 # git credential to skip password typing
 RUN git config --global credential.helper store
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复`WITH_COVERAGE=ON`时，`make -j`时出现的patchelf的错误
```
Traceback (most recent call last):
  File "setup.py", line 316, in <module>
    raise Exception("patch core_avx.%s failed, command: %s" % (ext_name, command))
Exception: patch core_avx..so failed, command: patchelf --set-rpath '$ORIGIN/../libs/' /Paddle/build_coverage/python/paddle/fluid/core_avx.so
python/CMakeFiles/paddle_python.dir/build.make:1165: recipe for target 'python/build/.timestamp' failed
make[2]: *** [python/build/.timestamp] Error 1
CMakeFiles/Makefile2:111111: recipe for target 'python/CMakeFiles/paddle_python.dir/all' failed
make[1]: *** [python/CMakeFiles/paddle_python.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2

```