### PR TITLE
Fix hang  in seq_topk_avg_pooling op

### DIFF
--- a/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.cc
@@ -24,16 +24,15 @@ class SequenceTopkAvgPoolingOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
-                      "Input(X) of SequencePoolOp should not be null.");
-    PADDLE_ENFORCE_EQ(ctx->HasInput("ROW"), true,
-                      "Input(ROW) of SequencePoolOp should not be null.");
-    PADDLE_ENFORCE_EQ(ctx->HasInput("COLUMN"), true,
-                      "Input(COLUMN) of SequencePoolOp should not be null.");
-    PADDLE_ENFORCE_EQ(ctx->HasOutput("Out"), true,
-                      "Output(Out) of SequencePoolOp should not be null.");
-    PADDLE_ENFORCE_EQ(ctx->HasOutput("pos"), true,
-                      "pos(out) should not be null");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "SequenceTopkAvgPooling");
+    OP_INOUT_CHECK(ctx->HasInput("ROW"), "Input", "ROW",
+                   "SequenceTopkAvgPooling");
+    OP_INOUT_CHECK(ctx->HasInput("COLUMN"), "Input", "COLUMN",
+                   "SequenceTopkAvgPooling");
+    OP_INOUT_CHECK(ctx->HasInput("Out"), "Output", "Out",
+                   "SequenceTopkAvgPooling");
+    OP_INOUT_CHECK(ctx->HasInput("pos"), "Output", "pos",
+                   "SequenceTopkAvgPooling");
 
     auto attr = ctx->Attrs();
     auto channel_num = attr.Get<int>("channel_num");
@@ -49,7 +48,7 @@ class SequenceTopkAvgPoolingOp : public framework::OperatorWithKernel {
     vec_out_shape.push_back(channel_num * num_k);
 
     ctx->SetOutputDim("Out", framework::make_ddim(vec_out_shape));
-    ctx->ShareLoD("X", "Out");
+    ctx->ShareLoD("ROW", "Out");
   }
 };
 
@@ -78,10 +77,10 @@ class SequenceTopkAvgPoolingGradOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE_EQ(ctx->HasInput(framework::GradVarName("Out")), true,
-                      "Gradient of Out should not be null.");
-    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
-                      "The input X should not be null.");
+    OP_INOUT_CHECK(ctx->HasInput(framework::GradVarName("Out")), "Input",
+                   framework::GradVarName("Out"), "SequenceTopkAvgPoolingGrad");
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X",
+                   "SequenceTopkAvgPoolingGrad");
 
     ctx->ShareDim("X", /*->*/ framework::GradVarName("X"));
     ctx->ShareLoD("X", /*->*/ framework::GradVarName("X"));

--- a/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.cc
@@ -29,9 +29,9 @@ class SequenceTopkAvgPoolingOp : public framework::OperatorWithKernel {
                    "SequenceTopkAvgPooling");
     OP_INOUT_CHECK(ctx->HasInput("COLUMN"), "Input", "COLUMN",
                    "SequenceTopkAvgPooling");
-    OP_INOUT_CHECK(ctx->HasInput("Out"), "Output", "Out",
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
                    "SequenceTopkAvgPooling");
-    OP_INOUT_CHECK(ctx->HasInput("pos"), "Output", "pos",
+    OP_INOUT_CHECK(ctx->HasOutput("pos"), "Output", "pos",
                    "SequenceTopkAvgPooling");
 
     auto attr = ctx->Attrs();

--- a/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.cc
@@ -36,11 +36,18 @@ class SequenceTopkAvgPoolingOp : public framework::OperatorWithKernel {
 
     auto attr = ctx->Attrs();
     auto channel_num = attr.Get<int>("channel_num");
+    PADDLE_ENFORCE_GT(
+        channel_num, 0,
+        platform::errors::InvalidArgument(
+            "Expected channel_num > 0, but received %d.", channel_num));
+
     auto topks = attr.Get<std::vector<int>>("topks");
+    auto num_k = topks.size();
+    PADDLE_ENFORCE_GT(
+        num_k, 0, platform::errors::InvalidArgument(
+                      "Expected topks.size() > 0, but received %zu.", num_k));
 
     auto row_dim = ctx->GetInputDim("ROW");
-
-    auto num_k = topks.size();
     auto row_shape_0 = row_dim[0];
 
     std::vector<int> vec_out_shape;

--- a/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_topk_avg_pooling_op.h
@@ -50,7 +50,7 @@ static void get_topk_pos(const T* data, int length, int k, int* pos) {
     }
     VLOG(3) << "top" << id_k + 1 << " index is : " << max_pos;
     PADDLE_ENFORCE_GE(max_pos, 0,
-                      framework::platform::errors::PreconditionNotMet(
+                      platform::errors::PreconditionNotMet(
                           "Expected max_pos >= 0, but received -1. Probably "
                           "because the input data contains `Nan`."));
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Related issue： https://github.com/PaddlePaddle/Paddle/issues/24304

#### 1. Problem Description
While using `circle_loss` in user's defined model, the training thread will hang up and never exit. The log shows thread hang in function `get_topk_pos` from `sequence_topk_avg_pooing_op`.

**The indeed reason is as followed:**
```cpp
{
std::vector<T> v(data, data+length);

T min_val = std::numeric_limits<T>::lowest();
T max_val = min_val;
// if v[i] is NAN, `v[i] > max_val` will return false.
if (v[i] > max_val) {
        max_pos = i;
        max_val = v[i];
      }
// so here max_pos = -1 which leads to illegal visit for vector[-1]
v[max_pos] = min_val;   // illegal visit
}
```

In the end of function, C++ will deconstruct vector `v` but found it has illegal visit. However, it will not throw exception while deconstruction process.

So ,the outer `thread` will not exit and `threads.join()` will wait the child thread finish but no way. So the main program hangs.

#### 2. Solution
The direct reason is `NAN` comes out in training model. We refactor the implementation of the `get_top_pos` to avoid illegal visit in vector. If encounter `NAN`, this op will execute normally and will not hang.