### PR TITLE
mac build exitcode;test=develop

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -370,6 +370,7 @@ function cmake_gen_and_build() {
 }
 
 function build_mac() {
+    set +e
     mkdir -p ${PADDLE_ROOT}/build
     cd ${PADDLE_ROOT}/build
     cat <<EOF
@@ -380,7 +381,11 @@ EOF
     if [[ "$ENABLE_MAKE_CLEAN" != "OFF" ]]; then
         make clean
     fi
-    make install -j 8
+    make install -j 8;build_error=$?
+    if [ "$build_error" != 0 ];then
+        exit 7;
+    fi
+    set -e
     build_size
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
增加mac编译失败的退出码
测试结果如下：
MAC_PR_CI_python35：http://10.87.145.41:8111/viewLog.html?buildId=374261&buildTypeId=PaddleMac_MacPrCiPython35&tab=buildLog
MAC_PR_CI：http://10.87.145.41:8111/viewLog.html?buildId=374263&buildTypeId=PaddleMac_MacPrCi&tab=buildLog
![image](https://user-images.githubusercontent.com/22937122/87519302-fcbe5880-c6b3-11ea-9c93-dd156a975a6f.png)
