### PR TITLE
resolve inference_pass_test input lodtensor case, test=develop

### DIFF
--- a/python/paddle/fluid/tests/unittests/ir/inference/inference_pass_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/inference_pass_test.py
@@ -79,11 +79,9 @@ class InferencePassTest(unittest.TestCase):
             shape[0] = 1
             tensor = predictor.get_input_tensor(name)
             feed_data = list(self.feeds.values())[i]
+            tensor.copy_from_cpu(np.array(feed_data))
             if type(feed_data) == fluid.LoDTensor:
-                tensor.copy_from_cpu(np.array(feed_data))
                 tensor.set_lod(feed_data.lod())
-            else:
-                tensor.copy_from_cpu(feed_data)
 
         predictor.zero_copy_run()
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/inference_pass_test.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/inference_pass_test.py
@@ -78,7 +78,12 @@ class InferencePassTest(unittest.TestCase):
             shape = tensor_shapes[name]
             shape[0] = 1
             tensor = predictor.get_input_tensor(name)
-            tensor.copy_from_cpu(list(self.feeds.values())[i])
+            feed_data = list(self.feeds.values())[i]
+            if type(feed_data) == fluid.LoDTensor:
+                tensor.copy_from_cpu(np.array(feed_data))
+                tensor.set_lod(feed_data.lod())
+            else:
+                tensor.copy_from_cpu(feed_data)
 
         predictor.zero_copy_run()
 

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add2_act_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add2_act_fuse_pass.py
@@ -44,7 +44,8 @@ class ConvElementwiseAdd2ActFusePassTest(InferencePassTest):
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
-            self.check_output_with_option([True])
+            use_gpu = True
+            self.check_output_with_option(use_gpu)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_act_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_act_fuse_pass.py
@@ -46,7 +46,8 @@ class ConvElementwiseAddActFusePassTest(InferencePassTest):
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
-            self.check_output_with_option([True])
+            use_gpu = True
+            self.check_output_with_option(use_gpu)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_conv_elementwise_add_fuse_pass.py
@@ -42,7 +42,8 @@ class ConvElementwiseAddFusePassTest(InferencePassTest):
 
     def test_check_output(self):
         if core.is_compiled_with_cuda():
-            self.check_output_with_option([True])
+            use_gpu = True
+            self.check_output_with_option(use_gpu)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_transpose_flatten_concat_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_transpose_flatten_concat_fuse_pass.py
@@ -42,7 +42,8 @@ class TransposeFlattenConcatFusePassTest(InferencePassTest):
     def test_check_output(self):
         # There is no cpu pass for transpose_flatten_concat_fuse
         if core.is_compiled_with_cuda():
-            self.check_output_with_option([True])
+            use_gpu = True
+            self.check_output_with_option(use_gpu)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_transpose_flatten_concat_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_transpose_flatten_concat_fuse_pass.py
@@ -48,7 +48,8 @@ class TransposeFlattenConcatFusePassTRTTest(InferencePassTest):
     def test_check_output(self):
         # There is no cpu pass for transpose_flatten_concat_fuse
         if core.is_compiled_with_cuda():
-            self.check_output_with_option([True])
+            use_gpu = True
+            self.check_output_with_option(use_gpu)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
1. If feed data type is LoDtensor, the analysis predictor will fail to copy data.
2. function check_output_with_option need bool input, but receive list.
