### PR TITLE
fix softmax with cross entropy out of bound

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -27,9 +27,11 @@ __global__ void CrossEntropyGrad(T* logit_grad, const int64_t* labels,
   CUDA_KERNEL_LOOP(index, n * remain) {
     int idx_n = index / remain;
     int idx_remain = index % remain;
-    int idx = idx_n * d + labels[index] * remain + idx_remain;
-    logit_grad[idx] -=
-        ignore_index == labels[index] ? static_cast<T>(0.) : static_cast<T>(1.);
+    int tmp = labels[index];
+    if (ignore_index != tmp) {
+      int idx = idx_n * d + tmp * remain + idx_remain;
+      logit_grad[idx] -= static_cast<T>(1.);
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
### PR changes
OPs

### Describe
修复 softmax with cross entropy 显存访问越界的问题，如果label中有一个id 大于待处理的维度， 会发生访问越界的情况

例如logits.shape = [ 3, 5], labels= [ 1, 2, 10], ignore_index = 10, 当处理lables中的10是，是大于5的，会发生写越界
