### PR TITLE
fix test_activation_op, test=develop

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_activation_op.py
@@ -799,22 +799,15 @@ class TestLog1p(TestActivation):
                 shape=[11, 17],
                 append_batch_size=False,
                 dtype="float64")
-            res_log1p = fluid.layers.data(
-                name="res_log1p",
-                shape=[11, 17],
-                append_batch_size=False,
-                dtype="float64")
 
             out1 = paddle.log1p(data_x)
-            out2 = paddle.log1p(data_x, out=res_log1p)
             exe = fluid.Executor(place=fluid.CPUPlace())
             exe.run(fluid.default_startup_program())
-            res1, res_in = exe.run(fluid.default_main_program(),
-                                   feed={"data_x": input_x},
-                                   fetch_list=[out1, res_log1p])
+            res1 = exe.run(fluid.default_main_program(),
+                           feed={"data_x": input_x},
+                           fetch_list=[out1])
         expected_res = np.log1p(input_x)
-        np.testing.assert_allclose(res1, expected_res)
-        np.testing.assert_allclose(res_in, expected_res)
+        self.assertTrue(np.allclose(res1, expected_res))
 
         # dygraph
         with fluid.dygraph.guard():
@@ -823,7 +816,7 @@ class TestLog1p(TestActivation):
             z = paddle.log1p(data_x)
             np_z = z.numpy()
             z_expected = np.array(np.log1p(np_x))
-        np.testing.assert_allclose(np_z, z_expected)
+        self.assertTrue(np.allclose(np_z, z_expected))
 
 
 class TestSquare(TestActivation):

--- a/python/paddle/fluid/tests/unittests/test_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_mul_op.py
@@ -175,35 +175,5 @@ class TestFP16MulOp2(TestMulOp2):
                 no_grad_set=set('Y'))
 
 
-class TestMulOpAttr(unittest.TestCase):
-    def test_out(self):
-        with fluid.program_guard(fluid.Program()):
-            x = fluid.data(name="x", shape=[2, 3], dtype="float32")
-            y = fluid.data(name='y', shape=[3, 2], dtype='float32')
-
-            res = fluid.data(name="output", shape=[2, 2], dtype="float32")
-            y_1 = paddle.mul(x, y, out=res)
-
-            place = fluid.CPUPlace()
-            exe = fluid.Executor(place)
-            data1 = np.array([[1, 2, 3], [4, 5, 6]], dtype='float32')
-            data2 = np.array([[1, 2], [1, 2], [1, 2]], dtype='float32')
-            np_res, np_y_1 = exe.run(feed={'x': data1,
-                                           'y': data2},
-                                     fetch_list=[res, y_1])
-
-            self.assertEqual((np_res == np_y_1).all(), True)
-
-    def test_name(self):
-        with fluid.program_guard(fluid.Program()):
-            x = fluid.data(name="x", shape=[2, 3], dtype="float32")
-            y = fluid.data(name='y', shape=[3, 2], dtype='float32')
-
-            res = fluid.data(name="output", shape=[2, 2], dtype="float32")
-            y_1 = paddle.mul(x, y, name='mul_res')
-            y_2 = paddle.mul(x, y, out=res, name='mul_res')
-            self.assertEqual(('mul_res' in y_1.name), True)
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

- PR #25488 changed `paddle.log1p(x, out=None, name=None)` to `paddle.log1p(x, name=None)`, but didn't update the related unit tests.

- PR #25499 changed `paddle.mul()`, but didn't update the related unit tests.

This PR fixes those.
