### PR TITLE
[Dy2stat] Write Simnet Correctly and Enable Multiple Return Test

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/simnet_dygraph_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/simnet_dygraph_model.py
@@ -492,25 +492,16 @@ class BOW(Layer):
         left_soft = softsign_layer.ops(bow_left)
         right_soft = softsign_layer.ops(bow_right)
 
-        left_bow = self.bow_layer(left_soft)
-        right_bow = self.bow_layer(right_soft)
-        cos_sim_layer = CosSimLayer()
-        pred = cos_sim_layer.ops(left_bow, right_bow)
-        return left_bow, pred
-
-        # TODO(huihuangzheng): uncomment the following return statements after
-        # we fix it.
-        #
         # matching layer
-        #if self.task_mode == "pairwise":
-        #    left_bow = self.bow_layer(left_soft)
-        #    right_bow = self.bow_layer(right_soft)
-        #    cos_sim_layer = CosSimLayer()
-        #    pred = cos_sim_layer.ops(left_bow, right_bow)
-        #    return left_bow, pred
-        #else:
-        #    concat_layer = ConcatLayer(1)
-        #    concat = concat_layer.ops([left_soft, right_soft])
-        #    concat_fc = self.bow_layer_po(concat)
-        #    pred = self.softmax_layer(concat_fc)
-        #    return left_soft, pred
+        if self.task_mode == "pairwise":
+            left_bow = self.bow_layer(left_soft)
+            right_bow = self.bow_layer(right_soft)
+            cos_sim_layer = CosSimLayer()
+            pred = cos_sim_layer.ops(left_bow, right_bow)
+            return left_bow, pred
+        else:
+            concat_layer = ConcatLayer(1)
+            concat = concat_layer.ops([left_soft, right_soft])
+            concat_fc = self.bow_layer_po(concat)
+            pred = self.softmax_layer(concat_fc)
+            return left_soft, pred

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_simnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_simnet.py
@@ -28,7 +28,7 @@ random.seed(SEED)
 
 def create_conf_dict():
     conf_dict = {}
-    conf_dict["task_mode"] = "train"
+    conf_dict["task_mode"] = "pairwise"
     conf_dict["net"] = {"emb_dim": 128, "bow_dim": 128, "hidden_dim": 128}
     conf_dict["loss"] = {"margin": 0.1}
     return conf_dict


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
We found that the reason of multiple return error in SimNet is that I wrote wrong task_mode. If we set task_mode as "pairwise" correctly, which is a format of the model input data, the multiple return won't have problem in the unit test. In this PR we corrected the task_mode and enable multiple return in SimNet unit test.
