### PR TITLE
optimize embedding forward cuda kernel lookup_table_v2,test=develop

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op.cu
+++ b/paddle/fluid/operators/lookup_table_v2_op.cu
@@ -105,17 +105,17 @@ class LookupTableV2CUDAKernel : public framework::OpKernel<T> {
     auto *table = table_t->data<T>();
     auto *output = output_t->mutable_data<T>(context.GetPlace());
 
-    dim3 threads(128, 8);
-    dim3 grids(8, 1);
+    dim3 threads(256, 4);
+    dim3 grids(80, 1);
 
     if (padding_idx == -1)
       LookupTableV2<
-          T, 128, 8, 8,
+          T, 256, 4, 80,
           false><<<grids, threads, 0, context.cuda_device_context().stream()>>>(
           output, table, ids, N, K, D, padding_idx);
     else
       LookupTableV2<
-          T, 128, 8, 8,
+          T, 256, 4, 80,
           true><<<grids, threads, 0, context.cuda_device_context().stream()>>>(
           output, table, ids, N, K, D, padding_idx);
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Adjust Grid and Group size of LookupTableV2
 - Profiled in Docker with nsys
 - Tesla V100-SXM2,    CUDA 10.1,    NVIDIA-SMI 440.33.01,    Driver Version: 440.33.01

| op/kernel  | inputshape  |type| size |is_sparse|  before|after|
|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
|LookupTableV2|[16,16]| fp16|[2,768]  |false|6980ns | 3232ns |
|LookupTableV2|[16,35,1]|fp32|[10000,1500]|false|56110ns|14880ns|
|LookupTableV2|[16,16]|fp32|[2,768]|false| 7140ns |3696ns|

- Impacts of different Grid and Group size

|configuration|inputshape|type|size|is_sparse|timing|
|:---:|:---:|:---:|:---:|:---:|:---:|
|80, 128x8|[16,16]|fp16|[2,768]|false|4288ns|
|80, 1024x1|[16,16]|fp16|[2,768]|false|3888ns|
|40, 256x4|[16,16]|fp16|[2,768]|false|4160ns|