### PR TITLE
Move nccl.h find code to avoid cmake error

### DIFF
--- a/cmake/nccl.cmake
+++ b/cmake/nccl.cmake
@@ -7,14 +7,14 @@ if(WIN32)
     return()
 endif()
 
-set(NCCL_ROOT "/usr" CACHE PATH "NCCL ROOT")
-find_path(NCCL_INCLUDE_DIR nccl.h
-    PATHS ${NCCL_ROOT} ${NCCL_ROOT}/include ${NCCL_ROOT}/local/include
-    $ENV{NCCL_ROOT} $ENV{NCCL_ROOT}/include $ENV{NCCL_ROOT}/local/include
-    NO_DEFAULT_PATH
-)
-
 if(WITH_NCCL)
+    set(NCCL_ROOT "/usr" CACHE PATH "NCCL ROOT")
+    find_path(NCCL_INCLUDE_DIR nccl.h
+        PATHS ${NCCL_ROOT} ${NCCL_ROOT}/include ${NCCL_ROOT}/local/include
+        $ENV{NCCL_ROOT} $ENV{NCCL_ROOT}/include $ENV{NCCL_ROOT}/local/include
+        NO_DEFAULT_PATH
+    )
+
     file(READ ${NCCL_INCLUDE_DIR}/nccl.h NCCL_VERSION_FILE_CONTENTS)
 
     string(REGEX MATCH "define NCCL_VERSION_CODE +([0-9]+)"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Move nccl.h find code to avoid cmake error, if not compiled with WITH_NCCL=ON, no need to find nccl.h.