### PR TITLE
Using input.place() in GetExpectedKernel in slice_op

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -148,9 +148,14 @@ class SliceOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
+    auto *in_var = ctx.InputVar("Input");
+    bool is_tensor = in_var->IsType<framework::LoDTensor>();
+    platform::Place place = ctx.device_context().GetPlace();
+    if (is_tensor) {
+      place = in_var->Get<framework::LoDTensor>().place();
+    }
     return framework::OpKernelType(
-        OperatorWithKernel::IndicateVarDataType(ctx, "Input"),
-        ctx.Input<Tensor>("Input")->place());
+        OperatorWithKernel::IndicateVarDataType(ctx, "Input"), place);
   }
   framework::OpKernelType GetKernelTypeForVar(
       const std::string &var_name, const Tensor &tensor,

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -150,7 +150,7 @@ class SliceOp : public framework::OperatorWithKernel {
       const framework::ExecutionContext &ctx) const override {
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "Input"),
-        ctx.device_context());
+        ctx.Input<Tensor>("Input")->place());
   }
   framework::OpKernelType GetKernelTypeForVar(
       const std::string &var_name, const Tensor &tensor,

--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -149,13 +149,16 @@ class SliceOp : public framework::OperatorWithKernel {
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
     auto *in_var = ctx.InputVar("Input");
-    bool is_tensor = in_var->IsType<framework::LoDTensor>();
-    platform::Place place = ctx.device_context().GetPlace();
-    if (is_tensor) {
-      place = in_var->Get<framework::LoDTensor>().place();
+    if (in_var->IsType<framework::LoDTensor>()) {
+      auto &in_tensor = in_var->Get<framework::LoDTensor>();
+      PADDLE_ENFORCE_EQ(
+          in_tensor.IsInitialized(), true,
+          platform::errors::InvalidArgument(
+              "The tensor Input (Input) of Slice op is not initialized."));
+      return framework::OpKernelType(in_tensor.type(), in_tensor.place());
     }
     return framework::OpKernelType(
-        OperatorWithKernel::IndicateVarDataType(ctx, "Input"), place);
+        OperatorWithKernel::IndicateVarDataType(ctx, "Input"), ctx.GetPlace());
   }
   framework::OpKernelType GetKernelTypeForVar(
       const std::string &var_name, const Tensor &tensor,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

Slice_op causes two extra data-copy between CPU and GPU, such as `shape_op` -> `slice_op` -> `cond/while`.
Because output of `shape_op` is on CPU, it will be copied into GPU while calling `slice_op` (first copy). And the conditional Tensor of `cond/while` is always CPU (second copy).

In this PR, `slice_op` will choose kernel according by `input.place` instead of `ctx.device_context`. 
+ if input is a GPU Tensor, slice will run on GPU normally.
+ if input is a CPU Tensor, slice will run on CPU without copy, if the next op runs on GPU, copy the output into GPU. (before, it will firstly copy input into GPU.)

| op | device | before| after| speed up|
| --- | --- | --- | --- | --- |
|slice| GPU | 0.12116 ms | 0.0329354 ms |  3.6x|
### Profiler
**sample code:**
```python
import paddle.fluid as fluid
import paddle.fluid.compiler as compiler
import paddle.fluid.profiler as profiler

data1 = fluid.layers.fill_constant(shape=[1, 3, 8, 8], value=0.5, dtype='float32')
data2 = fluid.layers.fill_constant(shape=[1, 3, 5, 5], value=0.5, dtype='float32')

shape = fluid.layers.shape(data2)

shape = fluid.layers.slice(shape, axes=[0], starts=[0], ends=[4])
out = fluid.layers.crop_tensor(data1, shape=shape)

place = fluid.CUDAPlace(0)
exe = fluid.Executor(place)

exe.run(fluid.default_startup_program())
compiled_prog = compiler.CompiledProgram(fluid.default_main_program())

with profiler.profiler('All', 'total') as prof:
    for i in range(10):
        result = exe.run(program=compiled_prog, fetch_list=[out])
```

**Before this PR:**
```
Elapsed time of events: 17.1752
Accumulated time of events: 16.2003
  Computation time       Total: 3.00644     Ratio: 18.558%
  Framework overhead     Total: 13.1938     Ratio: 81.442%

-------------------------     GpuMemCpy Summary     -------------------------

GpuMemcpy                Calls: 30          Total: 1.10892     Ratio: 6.45655%
  GpuMemcpyAsync         Calls: 10          Total: 0.318288    Ratio: 1.85319%
  GpuMemcpySync          Calls: 20          Total: 0.790636    Ratio: 4.60337%

-------------------------       Event Summary       -------------------------

Event                                                       Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
ParallelExecutor::Run                                       10          17.1752     17.039264 (0.992087)    0.135908 (0.007913)     0.433268    11.9763     1.71752     1           
  FastThreadedSSAGraphExecutorPrepare                       10          10.5408     10.524060 (0.998415)    0.016704 (0.001585)     0.019449    10.3304     1.05408     0.613721    
  fill_constant                                             20          1.9313      1.902629 (0.985154)     0.028673 (0.014846)     0.040439    0.497802    0.0965651   0.112447    
  slice                                                     10          1.21159     1.177707 (0.972030)     0.033888 (0.027970)     0.095464    0.202203    0.12116     0.0705434   
    GpuMemcpySync:CPU->GPU                                  10          0.393691    0.375707 (0.954320)     0.017984 (0.045680)     0.02878     0.054542    0.0393691   0.0229221   
  crop_tensor                                               10          0.981318    0.941572 (0.959497)     0.039746 (0.040503)     0.082106    0.148866    0.0981318   0.0571358   
    GpuMemcpySync:GPU->CPU                                  10          0.396945    0.380433 (0.958402)     0.016512 (0.041598)     0.034933    0.047378    0.0396945   0.0231116   
  Fetch                                                     10          0.589248    0.572351 (0.971324)     0.016897 (0.028676)     0.04751     0.108541    0.0589248   0.0343081   
    GpuMemcpyAsync:GPU->CPU                                 10          0.318288    0.301391 (0.946913)     0.016897 (0.053087)     0.028327    0.043384    0.0318288   0.0185319   
  shape                                                     10          0.444145    0.444145 (1.000000)     0.000000 (0.000000)     0.016104    0.221937    0.0444145   0.0258597   
  eager_deletion                                            30          0.265539    0.265539 (1.000000)     0.000000 (0.000000)     0.003649    0.020933    0.0088513   0.0154606   
  ScopeBufferedMonitor::post_local_exec_scopes_process      10          0.201678    0.201678 (1.000000)     0.000000 (0.000000)     0.015185    0.037       0.0201678   0.0117424   
  ScopeBufferedMonitor::pre_local_exec_scopes_process       10          0.027369    0.027369 (1.000000)     0.000000 (0.000000)     0.00227     0.004678    0.0027369   0.00159352  
  InitLocalVars                                             1           0.007322    0.007322 (1.000000)     0.000000 (0.000000)     0.007322    0.007322    0.007322    0.000426313 
```

**In this PR:**
```
Elapsed time of events: 15.6836
Accumulated time of events: 14.9056
  Computation time       Total: 2.3706      Ratio: 15.9041%
  Framework overhead     Total: 12.535      Ratio: 84.0959%

-------------------------     GpuMemCpy Summary     -------------------------

GpuMemcpy                Calls: 10          Total: 0.424664    Ratio: 2.7077%
  GpuMemcpyAsync         Calls: 10          Total: 0.424664    Ratio: 2.7077%

-------------------------       Event Summary       -------------------------

Event                                                       Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.      
ParallelExecutor::Run                                       10          15.6836     15.599329 (0.994629)    0.084231 (0.005371)     0.351126    11.6683     1.56836     1           
  FastThreadedSSAGraphExecutorPrepare                       10          10.3378     10.320995 (0.998372)    0.016834 (0.001628)     0.018803    10.1083     1.03378     0.659151    
  fill_constant                                             20          2.05201     2.022341 (0.985542)     0.029667 (0.014458)     0.039567    0.440852    0.1026      0.130838    
  Fetch                                                     10          0.813746    0.797009 (0.979432)     0.016737 (0.020568)     0.052813    0.140455    0.0813746   0.0518853   
    GpuMemcpyAsync:GPU->CPU                                 10          0.424664    0.407927 (0.960588)     0.016737 (0.039412)     0.032235    0.070573    0.0424664   0.027077    
  crop_tensor                                               10          0.531672    0.510679 (0.960515)     0.020993 (0.039485)     0.038242    0.110476    0.0531672   0.0339      
  shape                                                     10          0.488133    0.488133 (1.000000)     0.000000 (0.000000)     0.015376    0.259864    0.0488133   0.0311239   
  slice                                                     10          0.329354    0.329354 (1.000000)     0.000000 (0.000000)     0.01955     0.074567    0.0329354   0.021       
  eager_deletion                                            30          0.260191    0.260191 (1.000000)     0.000000 (0.000000)     0.003209    0.021799    0.00867303  0.01659     
  ScopeBufferedMonitor::post_local_exec_scopes_process      10          0.048583    0.048583 (1.000000)     0.000000 (0.000000)     0.003078    0.014849    0.0048583   0.0030977   
  ScopeBufferedMonitor::pre_local_exec_scopes_process       10          0.035136    0.035136 (1.000000)     0.000000 (0.000000)     0.002035    0.011479    0.0035136   0.00224031  
```