### PR TITLE
refine error message of randint

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_randint_op.py
+++ b/python/paddle/fluid/tests/unittests/test_randint_op.py
@@ -57,6 +57,7 @@ class TestRandintOpError(unittest.TestCase):
             self.assertRaises(TypeError, paddle.randint, 5, shape=np.array([2]))
             self.assertRaises(TypeError, paddle.randint, 5, dtype='float32')
             self.assertRaises(ValueError, paddle.randint, 5, 5)
+            self.assertRaises(ValueError, paddle.randint, -5)
 
 
 class TestRandintOp_attr_tensorlist(OpTest):

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -114,6 +114,10 @@ def randint(low=0, high=None, shape=[1], dtype=None, name=None):
 
     """
     if high is None:
+        if low <= 0:
+            raise ValueError(
+                "If high is None, low must be greater than 0, but received low = {0}.".
+                format(low))
         high = low
         low = 0
     if dtype is None:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
- raise ValueError if low is not greater than 0 and high is None.