### PR TITLE
Add friendly Error message in save_inference_model

### DIFF
--- a/python/paddle/fluid/io.py
+++ b/python/paddle/fluid/io.py
@@ -1064,6 +1064,13 @@ def prepend_feed_ops(inference_program,
         persistable=True)
 
     for i, name in enumerate(feed_target_names):
+        if not global_block.has_var(name):
+            raise ValueError(
+                "The feeded_var_names[{i}]: '{name}' doesn't exist in pruned inference program. "
+                "Please check whether '{name}' is a valid feed_var name, or remove it from feeded_var_names "
+                "if '{name}' is not involved in the target_vars calculation.".
+                format(
+                    i=i, name=name))
         out = global_block.var(name)
         global_block._prepend_op(
             type='feed',

--- a/python/paddle/fluid/tests/unittests/test_io_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_io_save_load.py
@@ -48,5 +48,26 @@ class TestSaveLoadAPIError(unittest.TestCase):
                 vars="vars")
 
 
+class TestSaveInferenceModelAPIError(unittest.TestCase):
+    def test_useless_feeded_var_names(self):
+        start_prog = fluid.Program()
+        main_prog = fluid.Program()
+        with fluid.program_guard(main_prog, start_prog):
+            x = fluid.data(name='x', shape=[10, 16], dtype='float32')
+            y = fluid.data(name='y', shape=[10, 16], dtype='float32')
+            z = fluid.layers.fc(x, 4)
+
+        exe = fluid.Executor(fluid.CPUPlace())
+        exe.run(start_prog)
+        with self.assertRaisesRegexp(
+                ValueError, "not involved in the target_vars calculation"):
+            fluid.io.save_inference_model(
+                dirname='./model',
+                feeded_var_names=['x', 'y'],
+                target_vars=[z],
+                executor=exe,
+                main_program=main_prog)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add friendly Error message in save_inference_model.

When `feeded_var_names` constains the var that will be prune in inference model, it will raise error in `framework.py`. This error message may confuse user that don't understand what happends？

This PR polishes the error message in above case.

**Sample code:**
```python
class TestSaveInferenceModelAPIError(unittest.TestCase):
    def test_useless_feeded_var_names(self):
        start_prog = fluid.Program()
        main_prog = fluid.Program()
        with fluid.program_guard(main_prog, start_prog):
            x = fluid.data(name='x', shape=[10, 16], dtype='float32')
            y = fluid.data(name='y', shape=[10, 16], dtype='float32')
            z = fluid.layers.fc(x, 4)

        exe = fluid.Executor(fluid.CPUPlace())
        exe.run(start_prog)
        with self.assertRaisesRegexp(
                ValueError, "not involved in the target_vars calculation"):
        fluid.io.save_inference_model(
            dirname='./model',
            feeded_var_names=['x', 'y'],
            target_vars=[z],
            executor=exe,
            main_program=main_prog)
```

**before:**
```
======================================================================
ERROR: test_useless_feeded_var_names (__main__.TestSaveInferenceModelAPIError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/test_io_save_load.py", line 69, in test_useless_feeded_var_names
    main_program=main_prog)
  File "<decorator-gen-60>", line 2, in save_inference_model
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/framework.py", line 211, in __impl__
    return func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/io.py", line 1280, in save_inference_model
    prepend_feed_ops(main_program, feeded_var_names)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/io.py", line 1073, in prepend_feed_ops
    out = global_block.var(name)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2566, in var
    raise ValueError("var %s not in this block" % name)
ValueError: var y not in this block

----------------------------------------------------------------------
```

**After:**
```
======================================================================
ERROR: test_useless_feeded_var_names (__main__.TestSaveInferenceModelAPIError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/code_dev/paddle-fork/python/paddle/fluid/tests/unittests/test_io_save_load.py", line 69, in test_useless_feeded_var_names
    main_program=main_prog)
  File "<decorator-gen-60>", line 2, in save_inference_model
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/framework.py", line 211, in __impl__
    return func(*args, **kwargs)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/io.py", line 1280, in save_inference_model
    prepend_feed_ops(main_program, feeded_var_names)
  File "/workspace/code_dev/paddle-fork/build_gpu/env2.7_gpu/local/lib/python2.7/site-packages/paddle/fluid/io.py", line 1072, in prepend_feed_ops
    format(i=i, name=name))
ValueError: The feeded_var_names[1]: 'y' doesn't exist in pruned inference program. Please check whether 'y' is a valid feed_var name, or remove it from feeded_var_names if 'y' is not involved in the target_vars calculation.
```