### PR TITLE
【paddle.fleet】add gradient Merge Optimizer

### DIFF
--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -4945,9 +4945,11 @@ class GradientMergeOptimizer(object):
     to the parameters.
 
     Args:
-        inner_optimizer (Optimizer): The specific optimization (such as SGD, Adam) which update the parameters
+        inner_optimizer (Optimizer): The specific optimization (such as SGD, Adam)
+            which update the parameters
         k_steps (int): the update period of the parameters
-        avg (bool): whether to average the gradients of each mini-batch, the default value is `True`
+        avg (bool): whether to average the gradients of each mini-batch,
+            the default value is `True`
 
     Examples:
         .. code-block:: python

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -1006,16 +1006,17 @@ class TestGradientMergeOptimizer(unittest.TestCase):
         ])
 
         # merge block
-        self.assertEqual(len(main_program.block(1).ops), 4)
+        self.assertEqual(len(main_program.block(1).ops), 2)
         self.assertEqual([op.type for op in main_program.block(1).ops], [
-            'elementwise_add', 'assign', 'elementwise_add', 'assign'
+            'elementwise_add',
+            'elementwise_add',
         ])
 
         # reset block
-        self.assertEqual(len(main_program.block(2).ops), 8)
+        self.assertEqual(len(main_program.block(2).ops), 6)
         self.assertEqual([op.type for op in main_program.block(2).ops], [
-            'elementwise_add', 'scale', 'assign', 'elementwise_add', 'scale',
-            'assign', 'fill_constant', 'fill_constant'
+            'elementwise_add', 'scale', 'elementwise_add', 'scale',
+            'fill_constant', 'fill_constant'
         ])
 
         # optimize block

--- a/python/paddle/fluid/tests/unittests/test_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer.py
@@ -948,5 +948,81 @@ class TestRecomputeOptimizerCUDA(unittest.TestCase):
                 self.assertEqual(drop_vec[0].tolist(), drop_vec[1].tolist())
 
 
+class TestGradientMergeOptimizer(unittest.TestCase):
+    def net(self):
+        program = framework.Program()
+        block = program.global_block()
+        mul_x = block.create_parameter(
+            dtype="float32", shape=[5, 10], lod_level=0, name="mul.x")
+        mul_y = block.create_var(
+            dtype="float32", shape=[10, 8], lod_level=0, name="mul.y")
+        mul_out = block.create_var(
+            dtype="float32", shape=[5, 8], lod_level=0, name="mul.out")
+        b1 = block.create_parameter(
+            dtype="float32", shape=[5, 8], lod_level=0, name="b1")
+        b1_out = block.create_var(
+            dtype="float32", shape=[5, 8], lod_level=0, name="b1_out")
+        mean_out = block.create_var(
+            dtype="float32", shape=[1], lod_level=0, name="mean.out")
+        block.append_op(
+            type="mul",
+            inputs={"X": mul_x,
+                    "Y": mul_y},
+            outputs={"Out": mul_out},
+            attrs={"x_num_col_dims": 1})
+        block.append_op(
+            type="elementwise_add",
+            inputs={"X": mul_out,
+                    "Y": b1},
+            outputs={"Out": b1_out})
+        block.append_op(
+            type="mean", inputs={"X": b1_out}, outputs={"Out": mean_out})
+        return mean_out
+
+    def test_program_desc(self, ):
+        cost = self.net()
+        main_program = cost.block.program
+        init_program = framework.Program()
+        self.assertEqual(main_program.num_blocks, 1)
+        self.assertEqual(len(cost.block.ops), 3)
+        self.assertEqual([op.type for op in cost.block.ops],
+                         ["mul", "elementwise_add", "mean"])
+
+        opt = optimizer.SGD(learning_rate=1.0)
+        opt = optimizer.GradientMergeOptimizer(opt, k_steps=4)
+        with framework.program_guard(main_program, init_program):
+            ops, params_grads = opt.minimize(cost)
+
+        self.assertEqual(main_program.num_blocks, 4)
+
+        # main block
+        self.assertEqual(len(cost.block.ops), 17)
+        self.assertEqual([op.type for op in cost.block.ops], [
+            'mul', 'elementwise_add', 'mean', 'fill_constant', 'mean_grad',
+            'elementwise_add_grad', 'mul_grad', 'increment', 'fill_constant',
+            'fill_constant', 'elementwise_mod', 'cast', 'not_equal',
+            'logical_not', 'conditional_block', 'conditional_block',
+            'conditional_block_grad'
+        ])
+
+        # merge block
+        self.assertEqual(len(main_program.block(1).ops), 4)
+        self.assertEqual([op.type for op in main_program.block(1).ops], [
+            'elementwise_add', 'assign', 'elementwise_add', 'assign'
+        ])
+
+        # reset block
+        self.assertEqual(len(main_program.block(2).ops), 8)
+        self.assertEqual([op.type for op in main_program.block(2).ops], [
+            'elementwise_add', 'scale', 'assign', 'elementwise_add', 'scale',
+            'assign', 'fill_constant', 'fill_constant'
+        ])
+
+        # optimize block
+        self.assertEqual(len(main_program.block(3).ops), 2)
+        self.assertEqual([op.type for op in main_program.block(3).ops],
+                         ['sgd', 'sgd'])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

APIs

### Describe
<!-- Describe what this PR does -->

在分布式训练中，经常遇到显存或者内存不足的情况，这通常有三种原因：

- 中间层输出占据的显存超出了内存/显存大小
- 参数过大（比如CPU的embedding）
- 输入Var过大（比如视频输入）

GradientMerge(梯度累加) 策略的做法，是将大Batch的输入改成小Batch，分别进行“前向+反向”网络计算梯度；最后将梯度做累加。

In the distributed training, we often encounter insufficient memory problem. There are usually 3 reasons:

- The memory occupied by the middle layer output exceeds the memory size
- The parameter is too large (such as CPU embedding)
- Input Var is too large (such as input)

The GradientMerge (gradient accumulation) strategy is to split the input of a large batch to a small batch, it performs a "forward + backward" network to calculate the gradient for each small batch; finally, the gradient is accumulated and the parameter is updated by specific optimize algorithm
