### PR TITLE
optimize cast op

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -250,6 +250,8 @@ def cast(x, dtype):
         'uint8'
     ], 'cast')
 
+    if convert_dtype(x.dtype) == convert_dtype(dtype):
+        return x
     helper = LayerHelper('cast', **locals())
     out = helper.create_variable_for_type_inference(dtype=dtype)
     helper.append_op(

--- a/python/paddle/fluid/tests/unittests/test_cast_op.py
+++ b/python/paddle/fluid/tests/unittests/test_cast_op.py
@@ -88,5 +88,24 @@ class TestCastOpError(unittest.TestCase):
             self.assertRaises(TypeError, test_dtype_type)
 
 
+class TestCastSameDtype(unittest.TestCase):
+    def test_same_dtype(self):
+        with program_guard(Program(), Program()):
+            x = fluid.layers.data(name='x', shape=[4, 8], dtype='float32')
+            output = fluid.layers.cast(x=x, dtype='float32')
+            x_data = np.random.random((4, 8)).astype('float32')
+            if core.is_compiled_with_cuda():
+                place = core.CUDAPlace(0)
+            else:
+                place = core.CPUPlace()
+            exe = fluid.Executor(place)
+            exe.run(fluid.default_startup_program())
+            results = exe.run(fluid.default_main_program(),
+                              feed={"x": x_data, },
+                              fetch_list=[output],
+                              return_numpy=True)
+        self.assertTrue(np.allclose(results[0], x_data))
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> APIs 

### Describe
<!-- Describe what this PR does --> return the input(x) when x.dtype is the same as attr(dtype)

### GPU Performance
V100, cuda10
|op | shape | input dtype|dtype | before |after| speed up|
|---|---|---|---|---|---|---|
|cast | [16, 1785] |bool| bool|0.00150 ms|0.000026 ms  | 57x|