### PR TITLE
Simplify BufferedReader to improve DataLoader performance

### DIFF
--- a/paddle/fluid/framework/data_device_transform.cc
+++ b/paddle/fluid/framework/data_device_transform.cc
@@ -27,8 +27,10 @@ void TransDataDevice(const Tensor &in, const platform::Place &dst_place,
                                     "supported between CPU and CUDA."));
 
   // NOTE(yy): TransDataDevice should wait for computation of input.
-  platform::DeviceContextPool::Instance().Get(in.place())->Wait();
-  platform::DeviceContextPool::Instance().Get(dst_place)->Wait();
+  if (!platform::is_cuda_pinned_place(in.place())) {
+    platform::DeviceContextPool::Instance().Get(in.place())->Wait();
+    platform::DeviceContextPool::Instance().Get(dst_place)->Wait();
+  }
 
   // FIXME(zcd): TransDataDevice is used to transform data from GPU to CPU and
   // the enforced checkings have been done in GetDeviceContext, so the

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -88,9 +88,18 @@ void TensorCopy(const Tensor& src, const platform::Place& dst_place,
         BOOST_GET_CONST(platform::CUDAPinnedPlace, src_place);
     auto dst_gpu_place = BOOST_GET_CONST(platform::CUDAPlace, dst_place);
     auto ctx_place = ctx.GetPlace();
-    PADDLE_ENFORCE_EQ(platform::is_gpu_place(ctx_place), true);
+    PADDLE_ENFORCE_EQ(platform::is_gpu_place(ctx_place), true,
+                      platform::errors::PreconditionNotMet(
+                          "Device context place mismatch. When copying Tensor "
+                          "data from CUDA Pinned memory to GPU memory, current "
+                          "device context place should be GPU."));
     auto ctx_gpu_place = BOOST_GET_CONST(platform::CUDAPlace, ctx_place);
-    PADDLE_ENFORCE_EQ(dst_gpu_place, ctx_gpu_place);
+    PADDLE_ENFORCE_EQ(dst_gpu_place, ctx_gpu_place,
+                      platform::errors::PreconditionNotMet(
+                          "The target GPU device and current device context do "
+                          "not match. The target GPU device number is %d, but "
+                          "device context GPU number is %d.",
+                          dst_gpu_place.device, ctx_gpu_place.device));
     auto stream =
         reinterpret_cast<const platform::CUDADeviceContext&>(ctx).stream();
     memory::Copy(dst_gpu_place, dst_ptr, src_cuda_pinned_place, src_ptr, size,

--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -191,18 +191,13 @@ void* CUDAPinnedAllocator::Alloc(size_t* index, size_t size) {
 
   void* p;
   // PINNED memory is visible to all CUDA contexts.
-  cudaError_t result = cudaHostAlloc(&p, size, cudaHostAllocPortable);
+  PADDLE_ENFORCE_CUDA_SUCCESS(cudaHostAlloc(&p, size, cudaHostAllocPortable));
 
-  if (result == cudaSuccess) {
-    *index = 1;  // PINNED memory
-    cuda_pinnd_alloc_size_ += size;
-    return p;
-  } else {
-    LOG(WARNING) << "cudaHostAlloc failed.";
-    return nullptr;
-  }
+  // Update state
+  *index = 1;
+  cuda_pinnd_alloc_size_ += size;
 
-  return nullptr;
+  return p;
 }
 
 void CUDAPinnedAllocator::Free(void* p, size_t size, size_t index) {

--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -191,13 +191,18 @@ void* CUDAPinnedAllocator::Alloc(size_t* index, size_t size) {
 
   void* p;
   // PINNED memory is visible to all CUDA contexts.
-  PADDLE_ENFORCE_CUDA_SUCCESS(cudaHostAlloc(&p, size, cudaHostAllocPortable));
+  cudaError_t result = cudaHostAlloc(&p, size, cudaHostAllocPortable);
 
-  // Update state
-  *index = 1;
-  cuda_pinnd_alloc_size_ += size;
+  if (result == cudaSuccess) {
+    *index = 1;  // PINNED memory
+    cuda_pinnd_alloc_size_ += size;
+    return p;
+  } else {
+    LOG(WARNING) << "cudaHostAlloc failed.";
+    return nullptr;
+  }
 
-  return p;
+  return nullptr;
 }
 
 void CUDAPinnedAllocator::Free(void* p, size_t size, size_t index) {

--- a/paddle/fluid/operators/cast_op.cc
+++ b/paddle/fluid/operators/cast_op.cc
@@ -64,14 +64,6 @@ class CastOp : public framework::OperatorWithKernel {
     context->SetOutputDim("Out", context->GetInputDim("X"));
     context->ShareLoD("X", "Out");
   }
-
-  framework::OpKernelType GetExpectedKernelType(
-      const framework::ExecutionContext &ctx) const override {
-    framework::OpKernelType kt = OperatorWithKernel::GetExpectedKernelType(ctx);
-    // CastOp kernel's device type is decided by input tensor place
-    kt.place_ = ctx.Input<framework::LoDTensor>("X")->place();
-    return kt;
-  }
 };
 
 }  // namespace operators

--- a/paddle/fluid/operators/reader/buffered_reader.cc
+++ b/paddle/fluid/operators/reader/buffered_reader.cc
@@ -42,22 +42,8 @@ BufferedReader::BufferedReader(
       place_(place),
       buffer_size_(buffer_size) {
   VLOG(1) << "BufferedReader";
-#ifdef PADDLE_WITH_CUDA
-  if (platform::is_gpu_place(place_)) {
-    int dev_idx = BOOST_GET_CONST(platform::CUDAPlace, place_).device;
-    compute_stream_ =
-        ((platform::CUDADeviceContext *)(platform::DeviceContextPool::Instance()
-                                             .Get(place_)))
-            ->stream();
-    events_.resize(buffer_size);
-    for (auto &event : events_) {
-      event = platform::CudaEventResourcePool::Instance().New(dev_idx);
-    }
-    stream_ = platform::CudaStreamResourcePool::Instance().New(dev_idx);
-  }
-#endif
   cpu_buffer_.resize(buffer_size);
-  gpu_buffer_.resize(buffer_size);
+  cuda_pinned_buffer_.resize(buffer_size);
   ReadTillBufferFullAsync();
 }
 
@@ -77,70 +63,40 @@ void BufferedReader::ReadAsync(size_t i) {
     }
 
 #ifdef PADDLE_WITH_CUDA
-    // NOTE(liangdun): using async copy instead of TensorCopySync
-    // TensorCopySync would block other stream, because TensorCopySync
-    // issues the copying command to the default stream, it will make two
-    // commands from different streams cannot run concurrently.
     if (platform::is_gpu_place(place_)) {
-      TensorVec &gpu = gpu_buffer_[i];
-      if (gpu.empty()) {
-        gpu.resize(cpu.size());
+      platform::CUDAPinnedPlace cuda_pinned_place;
+      TensorVec &cuda_pinned = cuda_pinned_buffer_[i];
+      if (cuda_pinned.empty()) {
+        cuda_pinned.resize(cpu.size());
       } else {
         PADDLE_ENFORCE_EQ(
-            gpu.size(), cpu.size(),
+            cuda_pinned.size(), cpu.size(),
             platform::errors::InvalidArgument(
                 "Input tensor number on GPU and CPU devices are not matched."));
       }
 
-      std::vector<void *> gpu_ptrs;
-      gpu_ptrs.reserve(cpu.size());
+      std::vector<void *> cuda_pinned_ptrs;
+      cuda_pinned_ptrs.reserve(cpu.size());
       for (size_t i = 0; i < cpu.size(); ++i) {
-        gpu[i].Resize(cpu[i].dims());
-        gpu[i].set_layout(cpu[i].layout());
-        gpu_ptrs.emplace_back(gpu[i].mutable_data(place_, cpu[i].type()));
+        cuda_pinned[i].Resize(cpu[i].dims());
+        cuda_pinned[i].set_layout(cpu[i].layout());
+        cuda_pinned_ptrs.emplace_back(
+            cuda_pinned[i].mutable_data(cuda_pinned_place, cpu[i].type()));
       }
-
-      // NOTE(zjl): cudaStreamWaitEvent() must be called after all
-      // gpu[i].mutable_data() is called, since some ops release
-      // gpu memory immediately without waiting gpu kernel ends
-      platform::SetDeviceId(
-          BOOST_GET_CONST(platform::CUDAPlace, place_).device);
-      PADDLE_ENFORCE_CUDA_SUCCESS(
-          cudaEventRecord(events_[i].get(), compute_stream_));
-      PADDLE_ENFORCE_CUDA_SUCCESS(
-          cudaStreamWaitEvent(stream_.get(), events_[i].get(), 0));
 
       platform::RecordEvent record_event("BufferedReader:MemoryCopy");
       for (size_t i = 0; i < cpu.size(); ++i) {
         auto cpu_place = cpu[i].place();
         auto cpu_ptr = cpu[i].data<void>();
-        auto gpu_ptr = gpu_ptrs[i];
+        auto cuda_pinned_ptr = cuda_pinned_ptrs[i];
         auto size =
             cpu[i].numel() * paddle::framework::SizeOfType(cpu[i].type());
-        if (platform::is_cuda_pinned_place(cpu_place)) {
-          memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, place_), gpu_ptr,
-                       BOOST_GET_CONST(platform::CUDAPinnedPlace, cpu_place),
-                       cpu_ptr, size, stream_.get());
-        } else if ((platform::is_gpu_place(cpu_place))) {
-          memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, place_), gpu_ptr,
-                       BOOST_GET_CONST(platform::CUDAPlace, cpu_place), cpu_ptr,
-                       size, stream_.get());
-        } else {
-          platform::CUDAPinnedPlace cuda_pinned_place;
-          framework::LoDTensor cuda_pinned_tensor;
-          cuda_pinned_tensor.Resize(cpu[i].dims());
-          auto cuda_pinned_ptr =
-              cuda_pinned_tensor.mutable_data(cuda_pinned_place, cpu[i].type());
-          memory::Copy(cuda_pinned_place, cuda_pinned_ptr,
-                       BOOST_GET_CONST(platform::CPUPlace, cpu_place), cpu_ptr,
-                       size);
-          memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, place_), gpu_ptr,
-                       cuda_pinned_place, cuda_pinned_ptr, size, stream_.get());
-          PADDLE_ENFORCE_CUDA_SUCCESS(cudaStreamSynchronize(stream_.get()));
-        }
-        gpu[i].set_lod(cpu[i].lod());
+
+        memory::Copy(cuda_pinned_place, cuda_pinned_ptr,
+                     BOOST_GET_CONST(platform::CPUPlace, cpu_place), cpu_ptr,
+                     size);
+        cuda_pinned[i].set_lod(cpu[i].lod());
       }
-      PADDLE_ENFORCE_CUDA_SUCCESS(cudaStreamSynchronize(stream_.get()));
     }
 #endif
     return i;
@@ -174,7 +130,7 @@ void BufferedReader::ReadNextImpl(std::vector<framework::LoDTensor> *out) {
     return;
   }
 
-  *out = std::move(platform::is_gpu_place(place_) ? gpu_buffer_[i]
+  *out = std::move(platform::is_gpu_place(place_) ? cuda_pinned_buffer_[i]
                                                   : cpu_buffer_[i]);
 
   // Do not push current position into ReadAsync. Push the previous position

--- a/paddle/fluid/operators/reader/buffered_reader.h
+++ b/paddle/fluid/operators/reader/buffered_reader.h
@@ -62,13 +62,8 @@ class BufferedReader : public framework::DecoratedReader {
   // malloc tensors every time is extremely slow. Here we store all data in
   // buffers and prevent alloc every time.
   std::vector<TensorVec> cpu_buffer_;
-  std::vector<TensorVec> gpu_buffer_;
+  std::vector<TensorVec> cuda_pinned_buffer_;
   size_t prev_pos_{-1UL};
-#ifdef PADDLE_WITH_CUDA
-  cudaStream_t compute_stream_;
-  std::shared_ptr<platform::CudaStreamObject> stream_;
-  std::vector<std::shared_ptr<platform::CudaEventObject>> events_;
-#endif
 };
 
 }  // namespace reader

--- a/paddle/fluid/operators/reader/buffered_reader.h
+++ b/paddle/fluid/operators/reader/buffered_reader.h
@@ -61,6 +61,7 @@ class BufferedReader : public framework::DecoratedReader {
   // buffer, just read async and create futures as buffer size. However, to
   // malloc tensors every time is extremely slow. Here we store all data in
   // buffers and prevent alloc every time.
+  bool is_same_place_;
   std::vector<TensorVec> cpu_buffer_;
   std::vector<TensorVec> cuda_pinned_buffer_;
   size_t prev_pos_{-1UL};

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -166,14 +166,15 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
       LOG(WARNING) << "Invalid devices id.";
       continue;
     }
-
     places.emplace_back(platform::CUDAPlace(devices[i]));
   }
   if (init_p2p) {
     InitP2P(devices);
   }
   places.emplace_back(platform::CPUPlace());
+#ifdef PADDLE_WITH_CUDA
   places.emplace_back(platform::CUDAPinnedPlace());
+#endif
   platform::DeviceContextPool::Init(places);
 
 #ifndef PADDLE_WITH_MKLDNN

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -173,6 +173,7 @@ void InitDevices(bool init_p2p, const std::vector<int> devices) {
     InitP2P(devices);
   }
   places.emplace_back(platform::CPUPlace());
+  places.emplace_back(platform::CUDAPinnedPlace());
   platform::DeviceContextPool::Init(places);
 
 #ifndef PADDLE_WITH_MKLDNN

--- a/paddle/fluid/platform/init_test.cc
+++ b/paddle/fluid/platform/init_test.cc
@@ -35,7 +35,7 @@ TEST(InitDevices, CUDA) {
   int count = paddle::platform::GetCUDADeviceCount();
   InitDevices(true);
   DeviceContextPool& pool = DeviceContextPool::Instance();
-  ASSERT_EQ(pool.size(), 1U + static_cast<unsigned>(count));
+  ASSERT_EQ(pool.size(), 2U + static_cast<unsigned>(count));
 #endif
 }
 

--- a/python/paddle/fluid/tests/unittests/test_decoupled_py_reader.py
+++ b/python/paddle/fluid/tests/unittests/test_decoupled_py_reader.py
@@ -122,8 +122,14 @@ class TestBase(unittest.TestCase):
                             label = item['label']
                             assert image.shape() == [BATCH_SIZE, 784]
                             assert label.shape() == [BATCH_SIZE, 1]
-                            assert image._place()._equals(ps[i])
-                            assert label._place()._equals(ps[i])
+                            if ps[i]._equals(fluid.CPUPlace()):
+                                assert image._place()._equals(fluid.CPUPlace())
+                                assert label._place()._equals(fluid.CPUPlace())
+                            else:
+                                assert image._place()._equals(
+                                    fluid.CUDAPinnedPlace())
+                                assert label._place()._equals(
+                                    fluid.CUDAPinnedPlace())
                         L, = exe.run(program=prog,
                                      feed=d,
                                      fetch_list=[loss],

--- a/python/paddle/fluid/tests/unittests/test_generator_dataloader.py
+++ b/python/paddle/fluid/tests/unittests/test_generator_dataloader.py
@@ -117,7 +117,6 @@ class TestBase(unittest.TestCase):
                 for _ in six.moves.range(EPOCH_NUM):
                     step = 0
                     for d in py_reader():
-                        print(d)
                         assert len(d) == len(places), "{} != {}".format(
                             len(d), len(places))
                         for i, item in enumerate(d):
@@ -125,8 +124,14 @@ class TestBase(unittest.TestCase):
                             label = item['label']
                             assert image.shape() == [BATCH_SIZE, 784]
                             assert label.shape() == [BATCH_SIZE, 1]
-                            assert image._place()._equals(ps[i])
-                            assert label._place()._equals(ps[i])
+                            if ps[i]._equals(fluid.CPUPlace()):
+                                assert image._place()._equals(fluid.CPUPlace())
+                                assert label._place()._equals(fluid.CPUPlace())
+                            else:
+                                assert image._place()._equals(
+                                    fluid.CUDAPinnedPlace())
+                                assert label._place()._equals(
+                                    fluid.CUDAPinnedPlace())
                         L, = exe.run(program=prog,
                                      feed=d,
                                      fetch_list=[loss],

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -154,7 +154,7 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
 
     def run_with_worker_done(self, use_shared_memory=True):
         try:
-            place = fluid.CUDAPlace(0)
+            place = fluid.CPUPlace()
             with fluid.dygraph.guard(place):
                 dataset = RandomDataset(800)
 

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_static.py
@@ -137,8 +137,14 @@ class TestStaticDataLoader(unittest.TestCase):
                         label = item['label']
                         assert image.shape() == [BATCH_SIZE, IMAGE_SIZE]
                         assert label.shape() == [BATCH_SIZE, 1]
-                        assert image._place()._equals(places[i])
-                        assert label._place()._equals(places[i])
+                        if places[i]._equals(fluid.CPUPlace()):
+                            assert image._place()._equals(fluid.CPUPlace())
+                            assert label._place()._equals(fluid.CPUPlace())
+                        else:
+                            assert image._place()._equals(fluid.CUDAPinnedPlace(
+                            ))
+                            assert label._place()._equals(fluid.CUDAPinnedPlace(
+                            ))
                     L, = exe.run(program=prog,
                                  feed=d,
                                  fetch_list=[loss],

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_reader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_reader_exception.py
@@ -77,7 +77,7 @@ class TestMultiprocessReaderException(unittest.TestCase):
                     reader.decorate_sample_generator(
                         decorated_reader,
                         batch_size=batch_size,
-                        places=fluid.cuda_places())
+                        places=fluid.cuda_places(0))
                 else:
                     reader.decorate_sample_generator(
                         decorated_reader,
@@ -94,6 +94,7 @@ class TestMultiprocessReaderException(unittest.TestCase):
                     num = 0
                     try:
                         for data in reader():
+                            print(data)
                             exe.run(feed=data, fetch_list=[image_p_1])
                             num += 1
                         self.assertEquals(num, batch_num)

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_reader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_reader_exception.py
@@ -94,7 +94,6 @@ class TestMultiprocessReaderException(unittest.TestCase):
                     num = 0
                     try:
                         for data in reader():
-                            print(data)
                             exe.run(feed=data, fetch_list=[image_p_1])
                             num += 1
                         self.assertEquals(num, batch_num)

--- a/python/paddle/fluid/tests/unittests/test_reader_reset.py
+++ b/python/paddle/fluid/tests/unittests/test_reader_reset.py
@@ -63,7 +63,7 @@ class TestReaderReset(unittest.TestCase):
                 self.prepare_data(), batch_size=self.batch_size))
 
         train_cp = compiler.CompiledProgram(main_prog).with_data_parallel(
-            places=fluid.cuda_places(0))
+            places=[place])
 
         batch_id = 0
         pass_count = 0

--- a/python/paddle/fluid/tests/unittests/test_reader_reset.py
+++ b/python/paddle/fluid/tests/unittests/test_reader_reset.py
@@ -62,7 +62,8 @@ class TestReaderReset(unittest.TestCase):
             paddle.batch(
                 self.prepare_data(), batch_size=self.batch_size))
 
-        train_cp = compiler.CompiledProgram(main_prog).with_data_parallel()
+        train_cp = compiler.CompiledProgram(main_prog).with_data_parallel(
+            places=fluid.cuda_places(0))
 
         batch_id = 0
         pass_count = 0


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

This PR simplifies the operation of creating and copying GPU Tensor by the underlying BufferedReader. 

During GPU training, the original BufferedReader needs to do the following things to buffer a Tensor:

1. Copy Tensor from the BlockingQueue to the CPU buffer
2. Alloc GPU Tensor memory (Independent StreamWait)
3. Copy Tensor from CPU to CUDA Pinned memory
4. Copy Tensor from CUDA Pinned memory to GPU (StreamSync)

These things are time-consuming and require two Syncs. Even if we process these tasks in parallel through threads, the time cannot be compressed to a very short time. When the training time is very short, much less than the above data processing time, the data reading of DataLoader will still become a bottleneck.

Test environments:
- P40 single card, CPU num 25
- dygraph MobileNetV1, batch size 256
- DataLoader num_workers=10

Test data of the above data processing (Batch Image Input):
```
1. [BlockingQueue -> CPU Buffer] PyReader: ReadNext: copy time: 0.040572 s
2. [GPU Memory Alloc] BufferedReader: ReadAsync: gpu prepare time: 0.562235 s
3. [CPU -> CUDA Pinned] BufferedReader: ReadAsync: gpu copy cpu -> cuda pinned time: 0.105902 s
4. [CUDA Pinned -> GPU] BufferedReader: ReadAsync: gpu copy cuda pinned -> cuda time: 0.022287 s
```

But in fact, copying Tensor to cuda memory does not necessarily need to be done by DataLoader. The necessary DataTransform will be performed during Op calculation. If it is GPU training, we can only return Tensor on CUDA Pinned memory.

Doing so can save the time of two Stream synchronizations and greatly improve training efficiency.
Why must synchronize two times in the original DataLoader? because the calculation process here and training is asynchronous, not waiting for the data may be wrong, but if it is done by Op, because the data read by the DataLoader is the beginning of the entire topological sequence network , There is no need to Sync specifically, and there will be no errors. This is more efficient.

From the following test data, a single training step, the data reading efficiency is increased by about **400 times**, and the training speed is increased by about 16%

#### Local P40 Compare (Batchsize 256): + 16.8%

- Test Data of origin:

```
average latency of 50 steps, skip 0 step:
	Avg: 0.738 s/step
	FPS: 346.757 samples/s
average latency of 50 steps, skip 5 steps:
	Avg: 0.738 s/step
	Min: 0.631 s/step
	Max: 0.751 s/step
	FPS: 346.878 samples/s
```

```
[Epoch 0, batch 10], avg_loss 4.93304, acc_top1 0.01953, acc_top5 0.07812, batch_cost: 0.62935 s, net_t: 0.01716 s, backward_t: 0.00481 s, reader_t: 0.02031 s
[Epoch 0, batch 20], avg_loss 4.73635, acc_top1 0.00781, acc_top5 0.05469, batch_cost: 0.62887 s, net_t: 0.01724 s, backward_t: 0.00499 s, reader_t: 0.02020 s
[Epoch 0, batch 30], avg_loss 4.65680, acc_top1 0.01953, acc_top5 0.07812, batch_cost: 0.62766 s, net_t: 0.01711 s, backward_t: 0.00487 s, reader_t: 0.01990 s
[Epoch 0, batch 40], avg_loss 4.67236, acc_top1 0.01172, acc_top5 0.06641, batch_cost: 0.62676 s, net_t: 0.01545 s, backward_t: 0.00415 s, reader_t: 0.01972 s
[Epoch 0, batch 50], avg_loss 4.54960, acc_top1 0.01953, acc_top5 0.09766, batch_cost: 0.73081 s, net_t: 0.01584 s, backward_t: 0.00419 s, reader_t: 0.12186 s
[Epoch 0, batch 60], avg_loss 4.50596, acc_top1 0.01562, acc_top5 0.11719, batch_cost: 0.73087 s, net_t: 0.01571 s, backward_t: 0.00399 s, reader_t: 0.12242 s
[Epoch 0, batch 70], avg_loss 4.40637, acc_top1 0.03906, acc_top5 0.13672, batch_cost: 0.72815 s, net_t: 0.01587 s, backward_t: 0.00388 s, reader_t: 0.12172 s
[Epoch 0, batch 80], avg_loss 4.39635, acc_top1 0.05469, acc_top5 0.17188, batch_cost: 0.73179 s, net_t: 0.01555 s, backward_t: 0.00410 s, reader_t: 0.12241 s
[Epoch 0, batch 90], avg_loss 4.49055, acc_top1 0.03906, acc_top5 0.13281, batch_cost: 0.73156 s, net_t: 0.01590 s, backward_t: 0.00437 s, reader_t: 0.12434 s
[Epoch 0, batch 100], avg_loss 4.22573, acc_top1 0.05469, acc_top5 0.17188, batch_cost: 0.73142 s, net_t: 0.01592 s, backward_t: 0.00423 s, reader_t: 0.12429 s
```

- Test Data of this PR:

```
average latency of 50 steps, skip 0 step:
	Avg: 0.632 s/step
	FPS: 405.302 samples/s
average latency of 50 steps, skip 5 steps:
	Avg: 0.632 s/step
	Min: 0.628 s/step
	Max: 0.647 s/step
	FPS: 405.379 samples/s
```

```
[Epoch 0, batch 10], avg_loss 4.88844, acc_top1 0.01953, acc_top5 0.08594, batch_cost: 0.62908 s, net_t: 0.20680 s, backward_t: 0.00415 s, reader_t: 0.00031 s
[Epoch 0, batch 20], avg_loss 4.67345, acc_top1 0.02344, acc_top5 0.07031, batch_cost: 0.64242 s, net_t: 0.20697 s, backward_t: 0.00421 s, reader_t: 0.01385 s
[Epoch 0, batch 30], avg_loss 4.70440, acc_top1 0.00781, acc_top5 0.09375, batch_cost: 0.62896 s, net_t: 0.20702 s, backward_t: 0.00421 s, reader_t: 0.00036 s
[Epoch 0, batch 40], avg_loss 4.63014, acc_top1 0.02734, acc_top5 0.08203, batch_cost: 0.62771 s, net_t: 0.20672 s, backward_t: 0.00412 s, reader_t: 0.00035 s
[Epoch 0, batch 50], avg_loss 4.57004, acc_top1 0.01953, acc_top5 0.10938, batch_cost: 0.62895 s, net_t: 0.20712 s, backward_t: 0.00414 s, reader_t: 0.00032 s
[Epoch 0, batch 60], avg_loss 4.52250, acc_top1 0.03125, acc_top5 0.11719, batch_cost: 0.63154 s, net_t: 0.20688 s, backward_t: 0.00448 s, reader_t: 0.00035 s
[Epoch 0, batch 70], avg_loss 4.45112, acc_top1 0.01172, acc_top5 0.15625, batch_cost: 0.63901 s, net_t: 0.20697 s, backward_t: 0.00413 s, reader_t: 0.01154 s
[Epoch 0, batch 80], avg_loss 4.41960, acc_top1 0.04688, acc_top5 0.16797, batch_cost: 0.62847 s, net_t: 0.20702 s, backward_t: 0.00430 s, reader_t: 0.00034 s
[Epoch 0, batch 90], avg_loss 4.48008, acc_top1 0.03906, acc_top5 0.16016, batch_cost: 0.64134 s, net_t: 0.20712 s, backward_t: 0.00442 s, reader_t: 0.01047 s
[Epoch 0, batch 100], avg_loss 4.22524, acc_top1 0.04688, acc_top5 0.14062, batch_cost: 0.62963 s, net_t: 0.20731 s, backward_t: 0.00520 s, reader_t: 0.00043 s
```


#### V100 Benchmark Compare (Batchsize 128): + 34%

- Test Data of origin:

![image](https://user-images.githubusercontent.com/22561442/88184913-e2611d80-cc65-11ea-857c-17ba80538b5d.png)

- Test Data of this PR:

```
average latency of 100 steps, skip 0 step:
	Avg: 0.128 s/step
	FPS: 997.512 samples/s
average latency of 100 steps, skip 5 steps:
	Avg: 0.128 s/step
	Min: 0.122 s/step
	Max: 0.136 s/step
	FPS: 998.054 samples/s
```



