### PR TITLE
Skip ci check of core.ops for sequence-related API

### DIFF
--- a/tools/check_api_source_without_core_ops.py
+++ b/tools/check_api_source_without_core_ops.py
@@ -40,7 +40,7 @@ diffs = []
 for each_diff in result:
     if each_diff[0] == '+':
         api_name = each_diff.split(' ')[1].strip()
-        if api_name in api_without_ops:
+        if api_name in api_without_ops and api_name.find('sequence') == -1:
             error = True
             diffs += [api_name]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Related #25596，since sequence-related API like `sequence_pool` is not supported in dygraph mode yet, this PR skips the PR check added in #25596.