### PR TITLE
Add macro check for using TRT api dynamicRangeIsSet()

### DIFF
--- a/paddle/fluid/inference/tensorrt/engine.cc
+++ b/paddle/fluid/inference/tensorrt/engine.cc
@@ -124,6 +124,7 @@ void TensorRTEngine::FreezeNetwork() {
                   << ", this might be ok when trt does not need this range";
         }
       }
+#if IS_TRT_VERSION_GE(5122)
       auto is_layer_int8 = [&](nvinfer1::ILayer *layer) -> bool {
         for (int j = 0; j < layer->getNbInputs(); j++) {
           auto *temp_in = layer->getInput(j);
@@ -161,6 +162,11 @@ void TensorRTEngine::FreezeNetwork() {
           layer->setPrecision(nvinfer1::DataType::kFLOAT);
         }
       }
+#else
+      LOG(WARNING) << "If your TensorRT version is lower than 5.1.2.2, you "
+                      "must provide quantization scales for all tensors using "
+                      "TRT to run.";
+#endif
 #endif
     }
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add macro check for using TRT api dynamicRangeIsSet(),  because it is only available in TRT version equal or  higher than 5.1.2.2