### PR TITLE
[Quant] Remove the output for moving_average_abs_max_scale op

### DIFF
--- a/paddle/fluid/operators/fake_quantize_op.cc
+++ b/paddle/fluid/operators/fake_quantize_op.cc
@@ -447,8 +447,6 @@ class MovingAverageAbsMaxScaleOp : public framework::OperatorWithKernel {
   void InferShape(framework::InferShapeContext* ctx) const override {
     OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X",
                    "MovingAverageAbsMaxScale");
-    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out",
-                   "MovingAverageAbsMaxScale");
     OP_INOUT_CHECK(ctx->HasOutput("OutScale"), "Output", "OutScale",
                    "MovingAverageAbsMaxScale");
     if (ctx->HasOutput("OutState")) {
@@ -457,9 +455,7 @@ class MovingAverageAbsMaxScaleOp : public framework::OperatorWithKernel {
     if (ctx->HasOutput("OutAccum")) {
       ctx->SetOutputDim("OutAccum", {1});
     }
-    ctx->SetOutputDim("Out", ctx->GetInputDim("X"));
     ctx->SetOutputDim("OutScale", {1});
-    ctx->ShareLoD("X", /*->*/ "Out");
   }
 
  protected:
@@ -477,8 +473,6 @@ class MovingAverageAbsMaxScaleOpMaker
     AddInput("X", "(Tensor) Input is float data type.");
     AddInput("InAccum", "Last accum.").AsDispensable();
     AddInput("InState", "Last state.").AsDispensable();
-    AddOutput("Out",
-              "(Tensor) Output tensor is just equivalent to the input tensor.");
     AddOutput("OutScale", " Current scale");
     AddOutput("OutState", "(Tensor) state buffer.").AsDispensable();
     AddOutput("OutAccum", "(Tensor) accum buffer.").AsDispensable();

--- a/paddle/fluid/operators/fake_quantize_op.h
+++ b/paddle/fluid/operators/fake_quantize_op.h
@@ -277,10 +277,7 @@ class MovingAverageAbsMaxScaleKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
     auto* in = context.Input<framework::Tensor>("X");
-    auto* out = context.Output<framework::Tensor>("Out");
-    out->mutable_data<T>(context.GetPlace());
     auto& dev_ctx = context.template device_context<DeviceContext>();
-    framework::TensorCopy(*in, context.GetPlace(), dev_ctx, out);
 
     bool is_test = context.Attr<bool>("is_test");
     // testing

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -1442,7 +1442,6 @@ class OutScaleForTrainingPass(object):
         for op in target_ops:
             for output_var_name in _get_op_output_var_names(op):
                 in_node = graph._find_node_by_name(op.outputs, output_var_name)
-                out_node = graph.create_var_node_from_desc(in_node.var())
                 scale_node = graph.create_persistable_node(
                     name=self._scale_name(in_node.name()),
                     var_type=core.VarDesc.VarType.LOD_TENSOR,
@@ -1457,7 +1456,7 @@ class OutScaleForTrainingPass(object):
                     self._scope,
                     self._place)
                 ins = {'X': in_node}
-                outs = {'Out': out_node, 'OutScale': scale_node}
+                outs = {'OutScale': scale_node}
                 if not self._is_test:
                     state_in_node = graph.create_persistable_node(
                         name=unique_name.generate('scale_state@'),
@@ -1502,7 +1501,6 @@ class OutScaleForTrainingPass(object):
                     inputs=ins,
                     outputs=outs)
                 graph.link_to(in_node, scale_op_node)
-                graph.link_to(scale_op_node, out_node)
                 graph.link_to(scale_op_node, scale_node)
                 if not self._is_test:
                     graph.link_to(state_in_node, scale_op_node)

--- a/python/paddle/fluid/tests/unittests/test_fake_quantize_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fake_quantize_op.py
@@ -146,7 +146,6 @@ class TestMovingAverageAbsMaxScaleOp(OpTest):
         out_state[0] = self.attrs['moving_rate'] * state[0] + 1
         out_scale = out_accum / out_state
         self.outputs = {
-            'Out': self.inputs['X'],
             'OutAccum': out_accum,
             'OutState': out_state,
             'OutScale': out_scale,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
* Remove the output for moving_average_abs_max_scale op, test=develop

修复产出量化模型中，预测模型会存在moving_average_abs_max_scale op的问题。

moving_average_abs_max_scale的作用是统计一个Tensor的绝对值最大值，在产出量化模型中用到。
理论上该OP只需要输入Tensor和输出Scale，不需要输出Tensor。但是，该OP原先的实现是输入Tensor直接给到输出Tensor，会导致产出的量化模型中会保存该OP，引入错误。

因此，删除改OP的Out Tensor，这样在保存预测模型的时候，会自动裁剪掉改OP。
修复原先量化中的bug，该OP内部使用，修复后对用户不影响。