### PR TITLE
records the offset of log when creating by paddle.distributed.launch

### DIFF
--- a/python/paddle/distributed/utils.py
+++ b/python/paddle/distributed/utils.py
@@ -381,7 +381,7 @@ def start_local_trainers(cluster,
         tp.rank = t.rank
         tp.local_rank = idx
         tp.log_fn = fn
-        tp.log_offset = 0 if fn else None
+        tp.log_offset = fn.tell() if fn else None
         tp.cmd = cmd
 
         procs.append(tp)


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
Others

### Describe
when a distributed training invoked by paddle.distributed.launch with `--log_dir` set, the log is appended to the log file instead of overridden, so we should record the offset of log file to distinguish the new log from the old one.
the preceding related PR: https://github.com/PaddlePaddle/Paddle/pull/25304/files