### PR TITLE
fix random compile fail on windows

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -81,19 +81,19 @@ if(WITH_PYTHON)
 
     if(${CBLAS_PROVIDER} STREQUAL MKLML)
       add_custom_command(TARGET op_function_generator
-            PRE_BUILD
+            PRE_LINK
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
           )
     else(${CBLAS_PROVIDER} STREQUAL EXTERN_OPENBLAS)
       add_custom_command(TARGET op_function_generator
-            PRE_BUILD
+            PRE_LINK
             COMMAND ${CMAKE_COMMAND} -E copy ${OPENBLAS_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
           )
     endif()
     if(WITH_MKLDNN)
       add_custom_command(TARGET op_function_generator
-          PRE_BUILD
+          PRE_LINK
           COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_BUILD_TYPE}
           )
     endif()
@@ -113,14 +113,14 @@ if(WITH_PYTHON)
     )
     if(WITH_MKL)
       add_custom_command(TARGET op_function_generator
-            PRE_BUILD
+            PRE_LINK
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
             COMMAND ${CMAKE_COMMAND} -E copy ${MKLML_SHARED_IOMP_LIB} ${CMAKE_CURRENT_BINARY_DIR}
             )
     endif(WITH_MKL)
     if(WITH_MKLDNN)
       add_custom_command(TARGET op_function_generator
-          PRE_BUILD
+          PRE_LINK
           COMMAND ${CMAKE_COMMAND} -E copy ${MKLDNN_SHARED_LIB} ${CMAKE_CURRENT_BINARY_DIR}
           )
     endif(WITH_MKLDNN)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix compile random failure at op_function_cmd.

![image](https://user-images.githubusercontent.com/52485244/88517005-c15f4a80-d020-11ea-8b3a-3416b875670b.png)

随机挂原因：PRE_BUILD可能导致发生随机失败，且只在Windows上高频出现。

![image](https://user-images.githubusercontent.com/52485244/88677117-7bd57700-d11f-11ea-8f6f-10a77f4ca1aa.png)

且只有Windows的VS支持PRE_BUILD，该问题只在Windows出现。