### PR TITLE
TracedLayer Error Message Enhancement

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -44,10 +44,13 @@ def create_program_from_desc(program_desc):
 def _extract_vars(inputs, result_list):
     if isinstance(inputs, Variable):
         result_list.append(inputs)
-
-    if isinstance(inputs, (list, tuple)):
+    elif isinstance(inputs, (list, tuple)):
         for var in inputs:
             _extract_vars(var, result_list)
+    else:
+        raise TypeError(
+            "The type of 'each element of inputs' in fluid.dygraph.jit.TracedLayer.trace must be fluid.Variable, but received {}.".
+            format(type(inputs)))
 
 
 def extract_vars(inputs):
@@ -1064,7 +1067,8 @@ class TracedLayer(object):
 
         Args:
             layer (dygraph.Layer): the layer object to be traced.
-            inputs (list(Variable)): the input variables of the layer object.
+            inputs (list(Variable)|tuple(Variable)|Variable): the input
+                variables of the layer object.
 
         Returns:
             tuple: A tuple of 2 items, whose the first item is the output of
@@ -1105,15 +1109,6 @@ class TracedLayer(object):
             layer, Layer
         ), "The type of 'layer' in fluid.dygraph.jit.TracedLayer.trace must be fluid.dygraph.Layer, but received {}.".format(
             type(layer))
-        assert isinstance(
-            inputs, list
-        ), "The type of 'inputs' in fluid.dygraph.jit.TracedLayer.trace must be {}, but received {}.".format(
-            list, type(inputs))
-        for inp in inputs:
-            assert isinstance(
-                inp, (Variable, core.VarBase)
-            ), "The type of 'each element of inputs' in fluid.dygraph.jit.TracedLayer.trace must be fluid.Variable, but received {}.".format(
-                type(inp))
         outs, prog, feed, fetch, parameters = _trace(layer, inputs)
         traced = TracedLayer(prog, parameters, feed, fetch)
         return outs, traced

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -1067,13 +1067,13 @@ class TracedLayer(object):
 
         Args:
             layer (dygraph.Layer): the layer object to be traced.
-            inputs (list(Variable)|tuple(Variable)|Variable): the input
-                variables of the layer object.
+            inputs (list(Tensor)|tuple(Tensor)|Tensor): the input tensors of
+                the layer object.
 
         Returns:
             tuple: A tuple of 2 items, whose the first item is the output of
-            :code:`layer(*inputs)` , and the second item is the created
-            TracedLayer object.
+                :code:`layer(*inputs)` , and the second item is the created
+                TracedLayer object.
 
         Examples:
             .. code-block:: python:

--- a/python/paddle/fluid/tests/unittests/test_imperative_ptb_rnn.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_ptb_rnn.py
@@ -272,7 +272,7 @@ class TestDygraphPtbRnn(unittest.TestCase):
                     program = traced_layer.program
 
                     traced_layer.save_inference_model(
-                        './infe_imperative_ptb_rnn', feed=range(4))
+                        './infe_imperative_ptb_rnn', feed=list(range(4)))
                 else:
                     outs = ptb_model(x, y, init_hidden, init_cell)
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -269,7 +269,7 @@ class TestDygraphResnet(unittest.TestCase):
 
                 out = None
                 if batch_id % 5 == 0:
-                    out, traced_layer = TracedLayer.trace(resnet, img)
+                    out, traced_layer = TracedLayer.trace(resnet, [img])
                     if program is not None:
                         self.assertTrue(
                             is_equal_program(program, traced_layer.program))

--- a/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_resnet.py
@@ -269,7 +269,7 @@ class TestDygraphResnet(unittest.TestCase):
 
                 out = None
                 if batch_id % 5 == 0:
-                    out, traced_layer = TracedLayer.trace(resnet, [img])
+                    out, traced_layer = TracedLayer.trace(resnet, img)
                     if program is not None:
                         self.assertTrue(
                             is_equal_program(program, traced_layer.program))

--- a/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_transformer_sorted_gradient.py
@@ -1010,8 +1010,8 @@ class TestDygraphTransformerSortGradient(unittest.TestCase):
                     program = traced_layer.program
                     traced_layer.save_inference_model(
                         './infer_imperative_transformer',
-                        feed=range(len(ins_static)),
-                        fetch=range(len(outs_static)))
+                        feed=list(range(len(ins_static))),
+                        fetch=list(range(len(outs_static))))
                 else:
                     outs = transformer(enc_inputs, dec_inputs, label, weights)
 

--- a/python/paddle/fluid/tests/unittests/test_traced_layer_err_msg.py
+++ b/python/paddle/fluid/tests/unittests/test_traced_layer_err_msg.py
@@ -53,13 +53,13 @@ class TestTracedLayerErrMsg(unittest.TestCase):
             self.assertEqual(
                 "The type of 'layer' in fluid.dygraph.jit.TracedLayer.trace must be fluid.dygraph.Layer, but received <{} 'NoneType'>.".
                 format(self.type_str), str(e.exception))
-            with self.assertRaises(AssertionError) as e:
+            with self.assertRaises(TypeError) as e:
                 dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
                     self.layer, 3)
             self.assertEqual(
-                "The type of 'inputs' in fluid.dygraph.jit.TracedLayer.trace must be <{} 'list'>, but received <{} 'int'>.".
+                "The type of 'each element of inputs' in fluid.dygraph.jit.TracedLayer.trace must be fluid.Variable, but received <{} 'int'>.".
                 format(self.type_str, self.type_str), str(e.exception))
-            with self.assertRaises(AssertionError) as e:
+            with self.assertRaises(TypeError) as e:
                 dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
                     self.layer, [True, 1])
             self.assertEqual(

--- a/python/paddle/fluid/tests/unittests/test_traced_layer_err_msg.py
+++ b/python/paddle/fluid/tests/unittests/test_traced_layer_err_msg.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import paddle.fluid as fluid
+import six
+import unittest
+
+
+class SimpleFCLayer(fluid.dygraph.Layer):
+    def __init__(self, feature_size, batch_size, fc_size):
+        super(SimpleFCLayer, self).__init__()
+        self._linear = fluid.dygraph.Linear(feature_size, fc_size)
+        self._offset = fluid.dygraph.to_variable(
+            np.random.random((batch_size, fc_size)).astype('float32'))
+
+    def forward(self, x):
+        fc = self._linear(x)
+        return fc + self._offset
+
+
+class TestTracedLayerErrMsg(unittest.TestCase):
+    def setUp(self):
+        self.batch_size = 4
+        self.feature_size = 3
+        self.fc_size = 2
+        self.layer = self._train_simple_net()
+        if six.PY2:
+            self.type_str = 'type'
+        else:
+            self.type_str = 'class'
+
+    def test_trace_err(self):
+        with fluid.dygraph.guard():
+            in_x = fluid.dygraph.to_variable(
+                np.random.random((self.batch_size, self.feature_size)).astype(
+                    'float32'))
+
+            with self.assertRaises(AssertionError) as e:
+                dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                    None, [in_x])
+            self.assertEqual(
+                "The type of 'layer' in fluid.dygraph.jit.TracedLayer.trace must be fluid.dygraph.Layer, but received <{} 'NoneType'>.".
+                format(self.type_str), str(e.exception))
+            with self.assertRaises(AssertionError) as e:
+                dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                    self.layer, 3)
+            self.assertEqual(
+                "The type of 'inputs' in fluid.dygraph.jit.TracedLayer.trace must be <{} 'list'>, but received <{} 'int'>.".
+                format(self.type_str, self.type_str), str(e.exception))
+            with self.assertRaises(AssertionError) as e:
+                dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                    self.layer, [True, 1])
+            self.assertEqual(
+                "The type of 'each element of inputs' in fluid.dygraph.jit.TracedLayer.trace must be fluid.Variable, but received <{} 'bool'>.".
+                format(self.type_str), str(e.exception))
+
+            dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                self.layer, [in_x])
+
+    def test_set_strategy_err(self):
+        with fluid.dygraph.guard():
+            in_x = fluid.dygraph.to_variable(
+                np.random.random((self.batch_size, self.feature_size)).astype(
+                    'float32'))
+            dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                self.layer, [in_x])
+
+            with self.assertRaises(AssertionError) as e:
+                traced_layer.set_strategy(1, fluid.ExecutionStrategy())
+            self.assertEqual(
+                "The type of 'build_strategy' in fluid.dygraph.jit.TracedLayer.set_strategy must be fluid.BuildStrategy, but received <{} 'int'>.".
+                format(self.type_str), str(e.exception))
+
+            with self.assertRaises(AssertionError) as e:
+                traced_layer.set_strategy(fluid.BuildStrategy(), False)
+            self.assertEqual(
+                "The type of 'exec_strategy' in fluid.dygraph.jit.TracedLayer.set_strategy must be fluid.ExecutionStrategy, but received <{} 'bool'>.".
+                format(self.type_str), str(e.exception))
+
+            traced_layer.set_strategy(build_strategy=fluid.BuildStrategy())
+            traced_layer.set_strategy(exec_strategy=fluid.ExecutionStrategy())
+            traced_layer.set_strategy(fluid.BuildStrategy(),
+                                      fluid.ExecutionStrategy())
+
+    def test_save_inference_model_err(self):
+        with fluid.dygraph.guard():
+            in_x = fluid.dygraph.to_variable(
+                np.random.random((self.batch_size, self.feature_size)).astype(
+                    'float32'))
+            dygraph_out, traced_layer = fluid.dygraph.TracedLayer.trace(
+                self.layer, [in_x])
+
+            dirname = './traced_layer_err_msg'
+            with self.assertRaises(TypeError) as e:
+                traced_layer.save_inference_model([0])
+            self.assertEqual(
+                "The type of 'dirname' in fluid.dygraph.jit.TracedLayer.save_inference_model must be <{} 'str'>, but received <{} 'list'>. ".
+                format(self.type_str, self.type_str), str(e.exception))
+            with self.assertRaises(TypeError) as e:
+                traced_layer.save_inference_model(dirname, [0], [None])
+            self.assertEqual(
+                "The type of 'each element of fetch' in fluid.dygraph.jit.TracedLayer.save_inference_model must be <{} 'int'>, but received <{} 'NoneType'>. ".
+                format(self.type_str, self.type_str), str(e.exception))
+            with self.assertRaises(TypeError) as e:
+                traced_layer.save_inference_model(dirname, [0], False)
+            self.assertEqual(
+                "The type of 'fetch' in fluid.dygraph.jit.TracedLayer.save_inference_model must be (<{} 'NoneType'>, <{} 'list'>), but received <{} 'bool'>. ".
+                format(self.type_str, self.type_str, self.type_str),
+                str(e.exception))
+            with self.assertRaises(TypeError) as e:
+                traced_layer.save_inference_model(dirname, [None], [0])
+            self.assertEqual(
+                "The type of 'each element of feed' in fluid.dygraph.jit.TracedLayer.save_inference_model must be <{} 'int'>, but received <{} 'NoneType'>. ".
+                format(self.type_str, self.type_str), str(e.exception))
+            with self.assertRaises(TypeError) as e:
+                traced_layer.save_inference_model(dirname, True, [0])
+            self.assertEqual(
+                "The type of 'feed' in fluid.dygraph.jit.TracedLayer.save_inference_model must be (<{} 'NoneType'>, <{} 'list'>), but received <{} 'bool'>. ".
+                format(self.type_str, self.type_str, self.type_str),
+                str(e.exception))
+
+            traced_layer.save_inference_model(dirname)
+
+    def _train_simple_net(self):
+        layer = None
+        with fluid.dygraph.guard():
+            layer = SimpleFCLayer(self.feature_size, self.batch_size,
+                                  self.fc_size)
+            optimizer = fluid.optimizer.SGD(learning_rate=1e-3,
+                                            parameter_list=layer.parameters())
+
+            for i in range(5):
+                in_x = fluid.dygraph.to_variable(
+                    np.random.random((self.batch_size, self.feature_size))
+                    .astype('float32'))
+                dygraph_out = layer(in_x)
+                loss = fluid.layers.reduce_mean(dygraph_out)
+                loss.backward()
+                optimizer.minimize(loss)
+        return layer
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Enhance TracedLayer Error Message

Note: this PR uses `assert` to check type somewhere and `check_type` somewhere, the reason is that the `check_type` skips checking when it is under dygraph mode.
