### PR TITLE
don't clear mkldnn cache in block_op executor dtor

### DIFF
--- a/paddle/fluid/framework/executor.cc
+++ b/paddle/fluid/framework/executor.cc
@@ -77,14 +77,13 @@ ExecutorPrepareContext::~ExecutorPrepareContext() {
   VLOG(5) << "destroy ExecutorPrepareContext";
 }
 
-Executor::Executor(const platform::Place& place, bool is_block_op)
-    : place_(place), is_block_op_(is_block_op) {}
+Executor::Executor(const platform::Place& place) : place_(place) {}
 
 Executor::~Executor() {
 #ifdef PADDLE_WITH_MKLDNN
   // Clear mkl-dnn cache,
   // this is needed to have mkl-dnn unit tests working
-  if (!is_block_op_) {
+  if (clear_mkldnn_cache_) {
     if (platform::is_cpu_place(place_)) {
       platform::DeviceContextPool& pool =
           platform::DeviceContextPool::Instance();

--- a/paddle/fluid/framework/executor.h
+++ b/paddle/fluid/framework/executor.h
@@ -56,7 +56,7 @@ class Executor {
   explicit Executor(const platform::DeviceContext& device)
       : Executor(device.GetPlace()) {}
 
-  explicit Executor(const platform::Place& place, bool is_block_op = false);
+  explicit Executor(const platform::Place& place);
 
   ~Executor();
   /*
@@ -136,9 +136,17 @@ class Executor {
 
   const platform::Place GetPlace() const { return place_; }
 
+#ifdef PADDLE_WITH_MKLDNN
+  void KeepMKLDNNCache(bool keep_mkldnn_cache) {
+    clear_mkldnn_cache_ = !keep_mkldnn_cache;
+  }
+#endif
+
  private:
   const platform::Place place_;
-  bool is_block_op_;
+#ifdef PADDLE_WITH_MKLDNN
+  bool clear_mkldnn_cache_ = true;
+#endif
 };
 
 }  // namespace framework

--- a/paddle/fluid/framework/executor.h
+++ b/paddle/fluid/framework/executor.h
@@ -56,7 +56,7 @@ class Executor {
   explicit Executor(const platform::DeviceContext& device)
       : Executor(device.GetPlace()) {}
 
-  explicit Executor(const platform::Place& place);
+  explicit Executor(const platform::Place& place, bool is_block_op = false);
 
   ~Executor();
   /*
@@ -138,6 +138,7 @@ class Executor {
 
  private:
   const platform::Place place_;
+  bool is_block_op_;
 };
 
 }  // namespace framework

--- a/paddle/fluid/operators/collective/c_gen_nccl_id_op.cc
+++ b/paddle/fluid/operators/collective/c_gen_nccl_id_op.cc
@@ -100,7 +100,7 @@ class CGenNCCLIdOp : public framework::OperatorBase {
     framework::ProgramDesc empty_program;
     framework::Executor executor(dev_ctx.GetPlace());
 #ifdef PADDLE_WITH_MKLDNN
-    exec.KeepMKLDNNCache(true);
+    executor.KeepMKLDNNCache(true);
 #endif
     rpc_h.SetScope(scope);
     rpc_h.SetDevCtx(&dev_ctx);

--- a/paddle/fluid/operators/collective/c_gen_nccl_id_op.cc
+++ b/paddle/fluid/operators/collective/c_gen_nccl_id_op.cc
@@ -99,6 +99,9 @@ class CGenNCCLIdOp : public framework::OperatorBase {
 
     framework::ProgramDesc empty_program;
     framework::Executor executor(dev_ctx.GetPlace());
+#ifdef PADDLE_WITH_MKLDNN
+    exec.KeepMKLDNNCache(true);
+#endif
     rpc_h.SetScope(scope);
     rpc_h.SetDevCtx(&dev_ctx);
     rpc_h.SetProgram(&empty_program);

--- a/paddle/fluid/operators/controlflow/conditional_block_infer_op.cc
+++ b/paddle/fluid/operators/controlflow/conditional_block_infer_op.cc
@@ -60,6 +60,9 @@ class ConditionalBlockInferOp : public ConditionalOp {
       auto &cur_scope = *scopes->front();
 
       framework::Executor exec(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+      exec.KeepMKLDNNCache(true);
+#endif
       auto *block = Attr<framework::BlockDesc *>("sub_block");
       exec.Run(*block->Program(), &cur_scope, block->ID(), false);
       scope.DeleteScope(scopes->front());

--- a/paddle/fluid/operators/controlflow/conditional_block_op.cc
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.cc
@@ -63,7 +63,10 @@ class ConditionalBlockOp : public ConditionalOp {
       scopes->resize(1);
       scopes->front() = &scope.NewScope();
       auto &cur_scope = *scopes->front();
-      framework::Executor exec(dev_place, true);
+      framework::Executor exec(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+      exec.KeepMKLDNNCache(true);
+#endif
       auto *block = Attr<framework::BlockDesc *>("sub_block");
       VLOG(3) << "Conditional block.idx = " << block->ID()
               << ", scope = " << &cur_scope;
@@ -128,6 +131,9 @@ class ConditionalBlockGradOp : public ConditionalOp {
       framework::Scope &cur_scope = *scopes[0];
 
       framework::Executor exec(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+      exec.KeepMKLDNNCache(true);
+#endif
       auto *block = Attr<framework::BlockDesc *>("sub_block");
 
       VLOG(3) << "Conditional Grad block.idx = " << block->ID()

--- a/paddle/fluid/operators/controlflow/conditional_block_op.cc
+++ b/paddle/fluid/operators/controlflow/conditional_block_op.cc
@@ -63,7 +63,7 @@ class ConditionalBlockOp : public ConditionalOp {
       scopes->resize(1);
       scopes->front() = &scope.NewScope();
       auto &cur_scope = *scopes->front();
-      framework::Executor exec(dev_place);
+      framework::Executor exec(dev_place, true);
       auto *block = Attr<framework::BlockDesc *>("sub_block");
       VLOG(3) << "Conditional block.idx = " << block->ID()
               << ", scope = " << &cur_scope;

--- a/paddle/fluid/operators/controlflow/while_op.cc
+++ b/paddle/fluid/operators/controlflow/while_op.cc
@@ -62,6 +62,9 @@ class WhileOp : public framework::OperatorBase {
             cond.dims().to_str(), ".\n"));
 
     framework::Executor executor(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+    executor.KeepMKLDNNCache(true);
+#endif
     auto *block = Attr<framework::BlockDesc *>(kStepBlock);
 
     auto *program = block->Program();
@@ -177,6 +180,9 @@ class WhileGradOp : public framework::OperatorBase {
     platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
     auto &dev_ctx = *pool.Get(dev_place);
     framework::Executor executor(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+    executor.KeepMKLDNNCache(true);
+#endif
     auto *block = Attr<framework::BlockDesc *>(kStepBlock);
     auto *program = block->Program();
 

--- a/paddle/fluid/operators/distributed_ops/fl_listen_and_serv_op.cc
+++ b/paddle/fluid/operators/distributed_ops/fl_listen_and_serv_op.cc
@@ -219,7 +219,7 @@ void FlListenAndServOp::RunImpl(const framework::Scope &scope,
   auto *program = optimize_blocks[0]->Program();
   framework::Executor executor(dev_place);
 #ifdef PADDLE_WITH_MKLDNN
-  exec.KeepMKLDNNCache(true);
+  executor.KeepMKLDNNCache(true);
 #endif
 
   auto f = std::bind(FillRequestCtx, std::placeholders::_1, &recv_scope,

--- a/paddle/fluid/operators/distributed_ops/fl_listen_and_serv_op.cc
+++ b/paddle/fluid/operators/distributed_ops/fl_listen_and_serv_op.cc
@@ -218,6 +218,9 @@ void FlListenAndServOp::RunImpl(const framework::Scope &scope,
       "optimize blocks should be 1 at least on the pserver side.");
   auto *program = optimize_blocks[0]->Program();
   framework::Executor executor(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+  exec.KeepMKLDNNCache(true);
+#endif
 
   auto f = std::bind(FillRequestCtx, std::placeholders::_1, &recv_scope,
                      &dev_ctx, &executor, program, rpc_service_.get());

--- a/paddle/fluid/operators/distributed_ops/gen_nccl_id_op.cc
+++ b/paddle/fluid/operators/distributed_ops/gen_nccl_id_op.cc
@@ -215,7 +215,7 @@ class GenNCCLIdOp : public framework::OperatorBase {
     framework::ProgramDesc empty_program;
     framework::Executor executor(dev_ctx.GetPlace());
 #ifdef PADDLE_WITH_MKLDNN
-    exec.KeepMKLDNNCache(true);
+    executor.KeepMKLDNNCache(true);
 #endif
     rpc_h.SetScope(scope);
     rpc_h.SetDevCtx(&dev_ctx);

--- a/paddle/fluid/operators/distributed_ops/gen_nccl_id_op.cc
+++ b/paddle/fluid/operators/distributed_ops/gen_nccl_id_op.cc
@@ -214,6 +214,9 @@ class GenNCCLIdOp : public framework::OperatorBase {
 
     framework::ProgramDesc empty_program;
     framework::Executor executor(dev_ctx.GetPlace());
+#ifdef PADDLE_WITH_MKLDNN
+    exec.KeepMKLDNNCache(true);
+#endif
     rpc_h.SetScope(scope);
     rpc_h.SetDevCtx(&dev_ctx);
     rpc_h.SetProgram(&empty_program);

--- a/paddle/fluid/operators/distributed_ops/listen_and_serv_op.cc
+++ b/paddle/fluid/operators/distributed_ops/listen_and_serv_op.cc
@@ -402,7 +402,7 @@ void ListenAndServOp::RunImpl(const framework::Scope &scope,
   auto *program = optimize_blocks[0]->Program();
   framework::Executor executor(dev_place);
 #ifdef PADDLE_WITH_MKLDNN
-  exec.KeepMKLDNNCache(true);
+  executor.KeepMKLDNNCache(true);
 #endif
 
   std::shared_ptr<framework::ExecutorPrepareContext> ckpt_pre_context = nullptr;

--- a/paddle/fluid/operators/distributed_ops/listen_and_serv_op.cc
+++ b/paddle/fluid/operators/distributed_ops/listen_and_serv_op.cc
@@ -401,6 +401,9 @@ void ListenAndServOp::RunImpl(const framework::Scope &scope,
                         "should be 1 at least on the pserver side."));
   auto *program = optimize_blocks[0]->Program();
   framework::Executor executor(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+  exec.KeepMKLDNNCache(true);
+#endif
 
   std::shared_ptr<framework::ExecutorPrepareContext> ckpt_pre_context = nullptr;
   if (checkpoint_block_id != -1) {

--- a/paddle/fluid/operators/recurrent_op.cc
+++ b/paddle/fluid/operators/recurrent_op.cc
@@ -200,6 +200,9 @@ void RecurrentOp::RunImpl(const framework::Scope &scope,
   auto reverse = Attr<bool>(kReverse);
 
   framework::Executor executor(place);
+#ifdef PADDLE_WITH_MKLDNN
+  executor.KeepMKLDNNCache(true);
+#endif
   auto *block = Attr<framework::BlockDesc *>(kStepBlock);
 
   auto *program = block->Program();
@@ -312,6 +315,9 @@ void RecurrentGradOp::RunImpl(const framework::Scope &scope,
   auto reverse = Attr<bool>(kReverse);
 
   framework::Executor executor(place);
+#ifdef PADDLE_WITH_MKLDNN
+  executor.KeepMKLDNNCache(true);
+#endif
   auto *block = Attr<framework::BlockDesc *>(kStepBlock);
   auto *program = block->Program();
   auto ctx = executor.Prepare(

--- a/paddle/fluid/operators/run_program_op.h
+++ b/paddle/fluid/operators/run_program_op.h
@@ -223,6 +223,9 @@ class RunProgramOpKernel : public framework::OpKernel<T> {
 
     // Step 2. prepare executor and init persistable variables
     framework::Executor exe(ctx.GetPlace());
+#ifdef PADDLE_WITH_MKLDNN
+    exe.KeepMKLDNNCache(true);
+#endif
 
     // skip delete vars
     std::vector<std::string> skip_vars;
@@ -319,6 +322,9 @@ class RunProgramGradOpKernel : public framework::OpKernel<T> {
 
     // Step 2. prepare executor and scope
     framework::Executor exe(ctx.GetPlace());
+#ifdef PADDLE_WITH_MKLDNN
+    exe.KeepMKLDNNCache(true);
+#endif
 
     // skip delete vars
     std::vector<std::string> skip_vars;

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -135,7 +135,7 @@ class TensorRTEngineOp : public framework::OperatorBase {
                      const platform::Place &dev_place) const {
     framework::Executor executor(dev_place);
 #ifdef PADDLE_WITH_MKLDNN
-    exec.KeepMKLDNNCache(true);
+    executor.KeepMKLDNNCache(true);
 #endif
     auto *block = Attr<framework::BlockDesc *>("sub_block");
     auto *program = block->Program();

--- a/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
+++ b/paddle/fluid/operators/tensorrt/tensorrt_engine_op.h
@@ -134,6 +134,9 @@ class TensorRTEngineOp : public framework::OperatorBase {
   void RunNativeImpl(const framework::Scope &scope,
                      const platform::Place &dev_place) const {
     framework::Executor executor(dev_place);
+#ifdef PADDLE_WITH_MKLDNN
+    exec.KeepMKLDNNCache(true);
+#endif
     auto *block = Attr<framework::BlockDesc *>("sub_block");
     auto *program = block->Program();
     auto &current_scope = scope.NewScope();


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
MKLDNN cache is removed in Executor's destructor. This should not happen at the end of RunImpl of conditional_block_op, where locally created Executor is destroyed. When working on dygraph resnet enablement of MKLDNN, I found that `test_resnet.py` with MKLDNN enabled will crash because it cannot find **forward MKLDNN primitive** in cache.