### PR TITLE
saving inference model when user define activation or weight preprocess function

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -298,7 +298,6 @@ list(REMOVE_ITEM TEST_OPS
 #TODO(wanghaoshuang): Fix this unitest failed on GCC8.
 LIST(REMOVE_ITEM TEST_OPS test_auto_pruning)
 LIST(REMOVE_ITEM TEST_OPS test_filter_pruning)
-LIST(REMOVE_ITEM TEST_OPS test_user_defined_quantization)
 foreach(src ${TEST_OPS})
     py_test(${src} SRCS ${src}.py)
 endforeach()

--- a/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
@@ -206,8 +206,8 @@ class TestUserDefinedQuantization(unittest.TestCase):
 
         mapping_table = load_dict()
         test_graph.out_node_mapping_table = mapping_table
-
-        freeze_pass.apply(test_graph)
+        if act_quantize_func == None and weight_quantize_func == None:
+            freeze_pass.apply(test_graph)
 
     def test_act_preprocess_cuda(self):
         if fluid.core.is_compiled_with_cuda():
@@ -250,6 +250,48 @@ class TestUserDefinedQuantization(unittest.TestCase):
                 weight_quant_type='channel_wise_abs_max',
                 for_ci=True,
                 weight_preprocess_func=pact)
+
+    def test_act_quantize_cuda(self):
+        if fluid.core.is_compiled_with_cuda():
+            with fluid.unique_name.guard():
+                self.quantization_scale(
+                    True,
+                    seed=1,
+                    activation_quant_type='moving_average_abs_max',
+                    weight_quant_type='channel_wise_abs_max',
+                    for_ci=True,
+                    act_quantize_func=pact)
+
+    def test_act_quantize_cpu(self):
+        with fluid.unique_name.guard():
+            self.quantization_scale(
+                False,
+                seed=2,
+                activation_quant_type='moving_average_abs_max',
+                weight_quant_type='channel_wise_abs_max',
+                for_ci=True,
+                act_quantize_func=pact)
+
+    def test_weight_quantize_cuda(self):
+        if fluid.core.is_compiled_with_cuda():
+            with fluid.unique_name.guard():
+                self.quantization_scale(
+                    True,
+                    seed=1,
+                    activation_quant_type='moving_average_abs_max',
+                    weight_quant_type='channel_wise_abs_max',
+                    for_ci=True,
+                    weight_quantize_func=pact)
+
+    def test_weight_quantize_cpu(self):
+        with fluid.unique_name.guard():
+            self.quantization_scale(
+                False,
+                seed=2,
+                activation_quant_type='moving_average_abs_max',
+                weight_quant_type='channel_wise_abs_max',
+                for_ci=True,
+                weight_quantize_func=pact)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
@@ -14,6 +14,7 @@
 
 import os
 import unittest
+import json
 import random
 import numpy as np
 import six
@@ -109,6 +110,16 @@ class TestUserDefinedQuantization(unittest.TestCase):
         def get_optimizer():
             return fluid.optimizer.MomentumOptimizer(0.0001, 0.9)
 
+        def load_dict():
+            with open('mapping_table_for_saving_inference_model', 'r') as file:
+                data = file.read()
+                data = json.loads(data)
+                return data
+
+        def save_dict(Dict):
+            with open('mapping_table_for_saving_inference_model', 'w') as file:
+                file.write(json.dumps(Dict))
+
         random.seed(0)
         np.random.seed(0)
 
@@ -151,6 +162,7 @@ class TestUserDefinedQuantization(unittest.TestCase):
             executor=exe)
 
         test_transform_pass.apply(test_graph)
+        save_dict(test_graph.out_node_mapping_table)
 
         add_quant_dequant_pass = AddQuantDequantPass(scope=scope, place=place)
         add_quant_dequant_pass.apply(main_graph)
@@ -181,6 +193,21 @@ class TestUserDefinedQuantization(unittest.TestCase):
                 loss_v = exe.run(binary,
                                  feed=feeder.feed(data),
                                  fetch_list=[loss])
+
+        out_scale_infer_pass = OutScaleForInferencePass(scope=scope)
+        out_scale_infer_pass.apply(test_graph)
+
+        freeze_pass = QuantizationFreezePass(
+            scope=scope,
+            place=place,
+            weight_bits=8,
+            activation_bits=8,
+            weight_quantize_type=weight_quant_type)
+
+        mapping_table = load_dict()
+        test_graph.out_node_mapping_table = mapping_table
+
+        freeze_pass.apply(test_graph)
 
     def test_act_preprocess_cuda(self):
         if fluid.core.is_compiled_with_cuda():
@@ -223,48 +250,6 @@ class TestUserDefinedQuantization(unittest.TestCase):
                 weight_quant_type='channel_wise_abs_max',
                 for_ci=True,
                 weight_preprocess_func=pact)
-
-    def test_act_quantize_cuda(self):
-        if fluid.core.is_compiled_with_cuda():
-            with fluid.unique_name.guard():
-                self.quantization_scale(
-                    True,
-                    seed=1,
-                    activation_quant_type='moving_average_abs_max',
-                    weight_quant_type='channel_wise_abs_max',
-                    for_ci=True,
-                    act_quantize_func=pact)
-
-    def test_act_quantize_cpu(self):
-        with fluid.unique_name.guard():
-            self.quantization_scale(
-                False,
-                seed=2,
-                activation_quant_type='moving_average_abs_max',
-                weight_quant_type='channel_wise_abs_max',
-                for_ci=True,
-                act_quantize_func=pact)
-
-    def test_weight_quantize_cuda(self):
-        if fluid.core.is_compiled_with_cuda():
-            with fluid.unique_name.guard():
-                self.quantization_scale(
-                    True,
-                    seed=1,
-                    activation_quant_type='moving_average_abs_max',
-                    weight_quant_type='channel_wise_abs_max',
-                    for_ci=True,
-                    weight_quantize_func=pact)
-
-    def test_weight_quantize_cpu(self):
-        with fluid.unique_name.guard():
-            self.quantization_scale(
-                False,
-                seed=2,
-                activation_quant_type='moving_average_abs_max',
-                weight_quant_type='channel_wise_abs_max',
-                for_ci=True,
-                weight_quantize_func=pact)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
saving inference model when user define activation or weight preprocess function