### PR TITLE
Add scalar_mul OP, test=develop

### DIFF
--- a/paddle/fluid/operators/scalar_mul_op.cc
+++ b/paddle/fluid/operators/scalar_mul_op.cc
@@ -1,0 +1,91 @@
+// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/scalar_mul_op.h"
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+class ScalarMulOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
+                      platform::errors::NotFound(
+                          "Input(X) of ScalarMulOp should not be null."));
+
+    auto in_dims = ctx->GetInputDim("X");
+    ctx->SetOutputDim("Out", in_dims);
+  }
+};
+
+class ScalarMulOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "(Tensor), The input tensor.");
+    AddOutput("Out", "(Tensor), The output tensor of scalar mul op");
+    AddAttr<float>("a", "(Scalar), The scaled factor of the input tensor")
+        AddAttr<float>("b", "(Scalar), The bias of the scalr mul op")
+            AddComment(R"DOC(
+Scalar Mul Operator.
+This operator is used to perform scalar multiply for input tensor X,
+Out = a * X + b
+)DOC");
+  }
+};
+
+class ScalarMulGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    PADDLE_ENFORCE_EQ(
+        ctx->HasInput(framework::GradVarName("Out")), true,
+        platform::errors::NotFound(
+            "Input(Out@Grad) of ScalarMulOp should not be null."));
+
+    auto in_dims = ctx->GetInputDim(framework::GradVarName("Out"));
+    ctx->SetOutputDim(framework::GradVarName("X"), in_dims);
+  }
+};
+
+template <typename T>
+class ScalarMulOpGradMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+  void Apply(GradOpPtr<T> op) const override {
+    op->SetType("scalar_mul_grad");
+    // op->SetInput("X", this->Input("X"));
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    op->SetAttrMap(this->Attrs());
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+using CPU = paddle::platform::CPUDeviceContext;
+REGISTER_OPERATOR(scalar_mul, ops::ScalarMulOp, ops::ScalarMulOpMaker,
+                  ops::ScalarMulOpGradMaker<paddle::framework::OpDesc>,
+                  ops::ScalarMulOpGradMaker<paddle::imperative::OpBase>);
+REGISTER_OPERATOR(scalar_mul_grad, ops::ScalarMulGradOp);
+REGISTER_OP_CPU_KERNEL(scalar_mul, ops::ScalarMulKernel<CPU, float>,
+                       ops::ScalarMulKernel<CPU, double>);
+REGISTER_OP_CPU_KERNEL(scalar_mul_grad, ops::ScalarMulGradKernel<CPU, float>,
+                       ops::ScalarMulGradKernel<CPU, double>);

--- a/paddle/fluid/operators/scalar_mul_op.cc
+++ b/paddle/fluid/operators/scalar_mul_op.cc
@@ -40,10 +40,10 @@ class ScalarMulOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<float>("a", "(Scalar), The scaled factor of the input tensor");
     AddAttr<float>("b", "(Scalar), The bias of the scalr mul op");
     AddComment(R"DOC(
-Scalar Mul Operator.
-This operator is used to perform scalar multiply for input tensor X,
-Out = a * X + b
-)DOC");
+              Scalar Mul Operator.
+              This operator is used to perform scalar multiply for input tensor X,
+              Out = a * X + b
+              )DOC");
   }
 };
 

--- a/paddle/fluid/operators/scalar_mul_op.cc
+++ b/paddle/fluid/operators/scalar_mul_op.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,9 +23,8 @@ class ScalarMulOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE_EQ(ctx->HasInput("X"), true,
-                      platform::errors::NotFound(
-                          "Input(X) of ScalarMulOp should not be null."));
+    OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "X", "ScalarMul");
+    OP_INOUT_CHECK(ctx->HasOutput("Out"), "Output", "Out", "ScalarMul");
 
     auto in_dims = ctx->GetInputDim("X");
     ctx->SetOutputDim("Out", in_dims);
@@ -52,10 +51,10 @@ class ScalarMulGradOp : public framework::OperatorWithKernel {
   using framework::OperatorWithKernel::OperatorWithKernel;
 
   void InferShape(framework::InferShapeContext* ctx) const override {
-    PADDLE_ENFORCE_EQ(
-        ctx->HasInput(framework::GradVarName("Out")), true,
-        platform::errors::NotFound(
-            "Input(Out@Grad) of ScalarMulOp should not be null."));
+    OP_INOUT_CHECK(ctx->HasInput(framework::GradVarName("Out")), "Input",
+                   framework::GradVarName("Out"), "ScalarMulGrad");
+    OP_INOUT_CHECK(ctx->HasOutput(framework::GradVarName("X")), "Output",
+                   framework::GradVarName("X"), "ScalarMulGrad");
 
     auto in_dims = ctx->GetInputDim(framework::GradVarName("Out"));
     ctx->SetOutputDim(framework::GradVarName("X"), in_dims);

--- a/paddle/fluid/operators/scalar_mul_op.cc
+++ b/paddle/fluid/operators/scalar_mul_op.cc
@@ -37,9 +37,9 @@ class ScalarMulOpMaker : public framework::OpProtoAndCheckerMaker {
   void Make() override {
     AddInput("X", "(Tensor), The input tensor.");
     AddOutput("Out", "(Tensor), The output tensor of scalar mul op");
-    AddAttr<float>("a", "(Scalar), The scaled factor of the input tensor")
-        AddAttr<float>("b", "(Scalar), The bias of the scalr mul op")
-            AddComment(R"DOC(
+    AddAttr<float>("a", "(Scalar), The scaled factor of the input tensor");
+    AddAttr<float>("b", "(Scalar), The bias of the scalr mul op");
+    AddComment(R"DOC(
 Scalar Mul Operator.
 This operator is used to perform scalar multiply for input tensor X,
 Out = a * X + b

--- a/paddle/fluid/operators/scalar_mul_op.cu
+++ b/paddle/fluid/operators/scalar_mul_op.cu
@@ -12,14 +12,89 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "paddle/fluid/framework/eigen.h"
+#include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/operators/scalar_mul_op.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+
+template <typename DeviceContext, typename T>
+class CUDAScalarMulKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* in_t = ctx.Input<Tensor>("X");
+    auto* out_t = ctx.Output<Tensor>("Out");
+    auto a = static_cast<T>(ctx.Attr<float>("a"));
+    auto b = static_cast<T>(ctx.Attr<float>("b"));
+    auto x = in_t->data<T>();
+
+    /*
+    auto dim = in_t->dims();
+    Tensor out_tmp;
+    T* out;
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
+    out_tmp = ctx.AllocateTmpTensor<T, DeviceContext>(dim, dev_ctx);
+    out = out_tmp.mutable_data<T>(ctx.GetPlace());
+
+    for (int i = 0; i < in_t->numel(); ++i) {
+      out[i] = a * x[i] + b;
+    }
+    */
+
+    out_t->mutable_data<T>(ctx.GetPlace());
+
+    auto eigen_out = framework::EigenVector<T>::Flatten(*out_t);
+    auto eigen_in = framework::EigenVector<T>::Flatten(*in_t);
+    auto& dev = *ctx.template device_context<DeviceContext>().eigen_device();
+    eigen_out.device(dev) = a * eigen_in + b;
+  }
+};
+
+template <typename DeviceContext, typename T>
+class CUDAScalarMulGradKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* dout_t = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto* dx_t = ctx.Output<Tensor>(framework::GradVarName("X"));
+    auto a = static_cast<T>(ctx.Attr<float>("a"));
+
+    /*
+    auto dout = dout_t->data<T>();
+
+    auto dim = dout_t->dims();
+    Tensor dx_tmp;
+    T* dx;
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
+    dx_tmp = ctx.AllocateTmpTensor<T, DeviceContext>(dim, dev_ctx);
+    dx = dx_tmp.mutable_data<T>(ctx.GetPlace());
+
+    for (int i = 0; i < dout_t->numel(); ++i) {
+      dx[i] = dout[i] * a;
+    }
+    */
+
+    dx_t->mutable_data<T>(ctx.GetPlace());
+
+    auto eigen_out = framework::EigenVector<T>::Flatten(*dx_t);
+    auto eigen_in = framework::EigenVector<T>::Flatten(*dout_t);
+    auto& dev = *ctx.template device_context<DeviceContext>().eigen_device();
+    eigen_out.device(dev) = a * eigen_in;
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
 
-REGISTER_OP_CUDA_KERNEL(scalar_mul,
-                        ops::ScalarMulKernel<plat::CUDADeviceContext, float>,
-                        ops::ScalarMulKernel<plat::CUDADeviceContext, double>);
 REGISTER_OP_CUDA_KERNEL(
-    scalar_mul_grad, ops::ScalarMulGradKernel<plat::CUDADeviceContext, float>,
-    ops::ScalarMulGradKernel<plat::CUDADeviceContext, double>);
+    scalar_mul, ops::CUDAScalarMulKernel<plat::CUDADeviceContext, float>,
+    ops::CUDAScalarMulKernel<plat::CUDADeviceContext, double>);
+REGISTER_OP_CUDA_KERNEL(
+    scalar_mul_grad,
+    ops::CUDAScalarMulGradKernel<plat::CUDADeviceContext, float>,
+    ops::CUDAScalarMulGradKernel<plat::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/scalar_mul_op.cu
+++ b/paddle/fluid/operators/scalar_mul_op.cu
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/scalar_mul_op.h"
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_CUDA_KERNEL(scalar_mul,
+                        ops::ScalarMulKernel<plat::CUDADeviceContext, float>,
+                        ops::ScalarMulKernel<plat::CUDADeviceContext, double>);
+REGISTER_OP_CUDA_KERNEL(
+    scalar_mul_grad, ops::ScalarMulGradKernel<plat::CUDADeviceContext, float>,
+    ops::ScalarMulGradKernel<plat::CUDADeviceContext, double>);

--- a/paddle/fluid/operators/scalar_mul_op.h
+++ b/paddle/fluid/operators/scalar_mul_op.h
@@ -1,4 +1,4 @@
-/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/paddle/fluid/operators/scalar_mul_op.h
+++ b/paddle/fluid/operators/scalar_mul_op.h
@@ -16,6 +16,9 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
 
+namespace paddle {
+namespace operators {
+
 using Tensor = framework::Tensor;
 
 template <typename DeviceContext, typename T>
@@ -24,8 +27,8 @@ class ScalarMulKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto* in_t = ctx.Input<Tensor>("X");
     auto* out_t = ctx.Output<Tensor>("Out");
-    auto a = static_cast<T>(context.Attr<float>("a"));
-    auto b = static_cast<T>(context.Attr<float>("b"));
+    auto a = static_cast<T>(ctx.Attr<float>("a"));
+    auto b = static_cast<T>(ctx.Attr<float>("b"));
     auto x = in_t->data<T>();
     auto out = out_t->mutable_data<T>(ctx.GetPlace());
 
@@ -42,13 +45,16 @@ class ScalarMulGradKernel : public framework::OpKernel<T> {
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto* dout_t = ctx.Input<Tensor>(framework::GradVarName("Out"));
     auto* dx_t = ctx.Output<Tensor>(framework::GradVarName("X"));
-    auto a = static_cast<T>(context.Attr<float>("a"));
+    auto a = static_cast<T>(ctx.Attr<float>("a"));
 
     auto dout = dout_t->data<T>();
     auto dx = dx_t->mutable_data<T>(ctx.GetPlace());
 
-    for (int i = 0; i < dout->numel(); ++i) {
+    for (int i = 0; i < dout_t->numel(); ++i) {
       dx[i] = dout[i] / a;
     }
   }
 };
+
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/scalar_mul_op.h
+++ b/paddle/fluid/operators/scalar_mul_op.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/op_registry.h"
 
 namespace paddle {
@@ -32,7 +33,6 @@ class ScalarMulKernel : public framework::OpKernel<T> {
     auto x = in_t->data<T>();
     auto out = out_t->mutable_data<T>(ctx.GetPlace());
 
-    // may have error
     for (int i = 0; i < in_t->numel(); ++i) {
       out[i] = a * x[i] + b;
     }

--- a/paddle/fluid/operators/scalar_mul_op.h
+++ b/paddle/fluid/operators/scalar_mul_op.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/fluid/framework/op_registry.h"
+
+using Tensor = framework::Tensor;
+
+template <typename DeviceContext, typename T>
+class ScalarMulKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* in_t = ctx.Input<Tensor>("X");
+    auto* out_t = ctx.Output<Tensor>("Out");
+    auto a = static_cast<T>(context.Attr<float>("a"));
+    auto b = static_cast<T>(context.Attr<float>("b"));
+    auto x = in_t->data<T>();
+    auto out = out_t->mutable_data<T>(ctx.GetPlace());
+
+    // may have error
+    for (int i = 0; i < in_t->numel(); ++i) {
+      out[i] = a * x[i] + b;
+    }
+  }
+};
+
+template <typename DeviceContext, typename T>
+class ScalarMulGradKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto* dout_t = ctx.Input<Tensor>(framework::GradVarName("Out"));
+    auto* dx_t = ctx.Output<Tensor>(framework::GradVarName("X"));
+    auto a = static_cast<T>(context.Attr<float>("a"));
+
+    auto dout = dout_t->data<T>();
+    auto dx = dx_t->mutable_data<T>(ctx.GetPlace());
+
+    for (int i = 0; i < dout->numel(); ++i) {
+      dx[i] = dout[i] / a;
+    }
+  }
+};

--- a/paddle/fluid/operators/scalar_mul_op.h
+++ b/paddle/fluid/operators/scalar_mul_op.h
@@ -51,7 +51,7 @@ class ScalarMulGradKernel : public framework::OpKernel<T> {
     auto dx = dx_t->mutable_data<T>(ctx.GetPlace());
 
     for (int i = 0; i < dout_t->numel(); ++i) {
-      dx[i] = dout[i] / a;
+      dx[i] = dout[i] * a;
     }
   }
 };

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11237,6 +11237,22 @@ def scalar_mul(x, a=1.0, b=0.0):
         
     Returns:
         Variable(Tensor|LoDTensor): Output tensor of scalar mul operator, with shape and data type same as input.
+    
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            import paddle.fluid as fluid
+            import numpy as np
+
+            inputs = fluid.layers.data(name="x", shape=[2, 3], dtype='float32')
+            output = fluid.layers.scalar_mul(inputs, a = 2.0, b = 1.0)
+
+            exe = fluid.Executor(fluid.CPUPlace())
+            exe.run(fluid.default_startup_program())
+            img = np.array([[1, 2, 3], [4, 5, 6]]).astype(np.float32)
+            res = exe.run(fluid.default_main_program(), feed={'x':img}, fetch_list=[output])
+            print(res) # [array([[ 3.,  5.,  7.], [ 9., 11., 13.]], dtype=float32)]
     """
 
     check_variable_and_dtype(x, "x", ['float32', 'float64'], "scalar_mul")

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -130,6 +130,7 @@ __all__ = [
     'unique_with_counts',
     'expand',
     'expand_as',
+    'scalar_mul',
     'scale',
     'elementwise_add',
     'elementwise_div',
@@ -10423,58 +10424,47 @@ def gaussian_random(shape,
                     dtype='float32',
                     name=None):
     """
-    This OP returns a Tensor filled with random values sampled from a Gaussian
-    distribution, with ``shape`` and ``dtype``.
+    Generate a random tensor whose data is drawn from a Gaussian distribution.
 
     Args:
-        shape(list|tuple|Tensor): The shape of the output Tensor. If ``shape``
-            is a list or tuple, the elements of it should be integers or Tensors
-            (with the shape [1], and the data type int32 or int64). If ``shape``
-            is a Tensor, it should be a 1-D Tensor(with the data type int32 or
-            int64).
-        mean(float|int, optional): Mean of the output tensor, default is 0.0.
-        std(float|int, optional): Standard deviation of the output tensor, default
-            is 1.0.
-        seed(int, optional): ${seed_comment}
-        dtype(str|np.dtype|core.VarDesc.VarType, optional): The data type of
-            the output Tensor. Supported data types: float32, float64.
-            Default is float32.
-        name(str, optional): The default value is None. Normally there is no
-            need for user to set this property. For more information, please
-            refer to :ref:`api_guide_Name`.
+        shape(list|tuple|Variable): Shape of the Tensor to be created. The data
+            type is ``int32`` or ``int64`` . If ``shape`` is a list or tuple,
+            the elements of it should be integers or Tensors with shape [1]. If
+            ``shape`` is a Variable, it should be an 1-D Tensor .
+        mean(float): Mean of the random tensor, defaults to 0.0.
+        std(float): Standard deviation of the random tensor, defaults to 1.0.
+        seed(int): ${seed_comment}
+        dtype(np.dtype|core.VarDesc.VarType|str, optional): Data type of the output
+            tensor, which can be float32, float64. Default is float32.
+        name(str, optional): Normally there is no need for user to set this property.
+            For more information, please refer to :ref:`api_guide_Name` .
+            Default is None.
 
     Returns:
-        Tensor: A Tensor filled with random values sampled from a Gaussian
-        distribution, with ``shape`` and ``dtype``.
+        Variable: Random tensor whose data is drawn from a Gaussian distribution, dtype: flaot32 or float64 as specified.
 
     Examples:
+
        .. code-block:: python
 
             import paddle.fluid as fluid
 
             # example 1:
-            # attr shape is a list which doesn't contain Tensor.
+            # attr shape is a list which doesn't contain tensor Variable.
             result_1 = fluid.layers.gaussian_random(shape=[3, 4])
-            # [[-0.31261674,  1.8736548,  -0.6274357,   0.96988016],
-            #  [-0.12294637,  0.9554768,   1.5690808,  -1.2894802 ],
-            #  [-0.60082096, -0.61138713,  1.5345167,  -0.21834975]]
 
             # example 2:
-            # attr shape is a list which contains Tensor.
-            dim_1 = fluid.layers.fill_constant([1], "int64", 2)
-            dim_2 = fluid.layers.fill_constant([1], "int32", 3)
+            # attr shape is a list which contains tensor Variable.
+            dim_1 = fluid.layers.fill_constant([1],"int64",3)
+            dim_2 = fluid.layers.fill_constant([1],"int32",5)
             result_2 = fluid.layers.gaussian_random(shape=[dim_1, dim_2])
-            # [[ 0.51398206, -0.3389769,   0.23597084],
-            #  [ 1.0388143,  -1.2015356,  -1.0499583 ]]
 
             # example 3:
-            # attr shape is a Tensor, the data type must be int64 or int32.
+            # attr shape is a Variable, the data type must be int64 or int32.
             var_shape = fluid.data(name='var_shape', shape=[2], dtype="int64")
             result_3 = fluid.layers.gaussian_random(var_shape)
-            # if var_shape's value is [2, 3]
-            # result_3 is:
-            # [[-0.12310527,  0.8187662,   1.923219  ]
-            #  [ 0.70721835,  0.5210541,  -0.03214082]]
+            var_shape_int32 = fluid.data(name='var_shape_int32', shape=[2], dtype="int32")
+            result_4 = fluid.layers.gaussian_random(var_shape_int32)
        
        .. code-block:: python
        
@@ -10516,10 +10506,8 @@ def gaussian_random(shape,
 
     if in_dygraph_mode():
         shape = utils._convert_shape_to_list(shape)
-        return core.ops.gaussian_random('shape', shape, 'mean',
-                                        float(mean), 'std',
-                                        float(std), 'seed', seed, 'dtype',
-                                        dtype)
+        return core.ops.gaussian_random('shape', shape, 'mean', mean, 'std',
+                                        std, 'seed', seed, 'dtype', dtype)
 
     check_type(shape, 'shape', (list, tuple, Variable), 'gaussian_random/randn')
     check_dtype(dtype, 'dtype', ['float32', 'float64'], 'gaussian_random/randn')
@@ -11231,6 +11219,35 @@ def _elementwise_op(helper):
         attrs={'axis': axis,
                'use_mkldnn': use_mkldnn})
     return helper.append_activation(out)
+
+
+def scalar_mul(x, a=1.0, b=0.0):
+    """
+    Scalar Mul Operator. A simple version of Scale operator.
+
+    Putting scale and bias to the input Tensor as following:
+
+    .. math::
+                            Out=a*X+b
+
+    Args:
+        x(Tensor): Input N-D Tensor of scale operator. Data type can be float32, float64.
+        a(float): The scale factor of the input, it should be a float number.
+        b(float): The bias to be put on the input, it should be a float number.
+        
+    Returns:
+        Variable(Tensor|LoDTensor): Output tensor of scalar mul operator, with shape and data type same as input.
+    """
+
+    check_variable_and_dtype(x, "x", ['float32', 'float64'], "scalar_mul")
+    inputs = {'X': [x]}
+    attrs = {'a': float(a), 'b': float(b)}
+    helper = LayerHelper('scalar_mul', **locals())
+    out = helper.create_variable_for_type_inference(dtype=x.dtype)
+
+    helper.append_op(
+        type='scalar_mul', inputs=inputs, outputs={'Out': out}, attrs=attrs)
+    return out
 
 
 def scale(x, scale=1.0, bias=0.0, bias_after_scale=True, act=None, name=None):
@@ -14928,8 +14945,8 @@ def gather_tree(ids, parents):
 def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0,
                    name=None):
     """
-    This OP returns a Tensor filled with random values sampled from a uniform
-    distribution in the range [``min``, ``max``), with ``shape`` and ``dtype``.
+    This OP initializes a variable with random values sampled from a
+    uniform distribution in the range [min, max).
 
     Examples:
     ::
@@ -14941,33 +14958,30 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0,
           result=[[0.8505902, 0.8397286]]
 
     Args:
-        shape(list|tuple|Tensor): The shape of the output Tensor. If ``shape``
-            is a list or tuple, the elements of it should be integers or Tensors
-            (with the shape [1], and the data type int32 or int64). If ``shape``
-            is a Tensor, it should be a 1-D Tensor(with the data type int32 or
-            int64).
-        dtype(str|np.dtype|core.VarDesc.VarType, optional): The data type of
-            the output Tensor. Supported data types: float32, float64.
-            Default is float32.
-        min(float|int, optional): The lower bound on the range of random values
-            to generate, ``min`` is included in the range. Default is -1.0.
-        max(float|int, optional): The upper bound on the range of random values
-            to generate, ``max`` is excluded in the range. Default is 1.0.
-        seed(int, optional): Random seed used for generating samples. 0 means
+        shape (list|tuple|Variable): The shape of the output Tensor,  if the
+            shape is a list or tuple, its elements can be an integer or a
+            Tensor with the shape [1], and the type of the Tensor must be
+            int32 or int64. If the shape is a Variable, it is a 1-D Tensor, and
+            the type of the Tensor must be int32 or int64.
+        dtype(np.dtype|core.VarDesc.VarType|str, optional): The type of the
+            output Tensor. Supported data types: float32, float64. Default: float32.
+        min (float, optional): The lower bound on the range of random values
+            to generate, the min is included in the range. Default -1.0.
+        max (float, optional): The upper bound on the range of random values
+            to generate, the max is excluded in the range. Default 1.0.
+        seed (int, optional): Random seed used for generating samples. 0 means
             use a seed generated by the system. Note that if seed is not 0,
             this operator will always generate the same random numbers every
-            time. Default is 0.
+            time. Default 0.
         name(str, optional): The default value is None. Normally there is no
             need for user to set this property. For more information, please
             refer to :ref:`api_guide_Name`.
 
     Returns:
-        Tensor: A Tensor filled with random values sampled from a uniform
-        distribution in the range [``min``, ``max``), with ``shape`` and ``dtype``.
+        Variable: A Tensor of the specified shape filled with uniform_random values.
 
     Raises:
-        TypeError: If ``shape`` is not list, tuple, Tensor.
-        TypeError: If ``dtype`` is not float32, float64.
+        TypeError: The shape type should be list or tuple or variable.
 
     Examples:
         .. code-block:: python
@@ -14975,28 +14989,21 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0,
             import paddle.fluid as fluid
 
             # example 1:
-            # attr shape is a list which doesn't contain Tensor.
+            # attr shape is a list which doesn't contain tensor Variable.
             result_1 = fluid.layers.uniform_random(shape=[3, 4])
-            # [[ 0.84524226,  0.6921872,   0.56528175,  0.71690357],
-            #  [-0.34646994, -0.45116323, -0.09902662, -0.11397249],
-            #  [ 0.433519,    0.39483607, -0.8660099,   0.83664286]]
 
             # example 2:
-            # attr shape is a list which contains Tensor.
-            dim_1 = fluid.layers.fill_constant([1], "int64", 2)
-            dim_2 = fluid.layers.fill_constant([1], "int32", 3)
+            # attr shape is a list which contains tensor Variable.
+            dim_1 = fluid.layers.fill_constant([1],"int64",3)
+            dim_2 = fluid.layers.fill_constant([1],"int32",5)
             result_2 = fluid.layers.uniform_random(shape=[dim_1, dim_2])
-            # [[-0.9951253,   0.30757582, 0.9899647 ],
-            #  [ 0.5864527,   0.6607096,  -0.8886161 ]]
 
             # example 3:
-            # attr shape is a Tensor, the data type must be int64 or int32.
+            # attr shape is a Variable, the data type must be int64 or int32.
             var_shape = fluid.data(name='var_shape', shape=[2], dtype="int64")
             result_3 = fluid.layers.uniform_random(var_shape)
-            # if var_shape's value is [2, 3]
-            # result_3 is:
-            # [[-0.8517412,  -0.4006908,   0.2551912 ],
-            #  [ 0.3364414,   0.36278176, -0.16085452]]
+            var_shape_int32 = fluid.data(name='var_shape_int32', shape=[2], dtype="int32")
+            result_4 = fluid.layers.uniform_random(var_shape_int32)
 
     """
     if not isinstance(dtype, core.VarDesc.VarType):

--- a/python/paddle/fluid/tests/unittests/test_scalar_mul_op.py
+++ b/python/paddle/fluid/tests/unittests/test_scalar_mul_op.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import numpy as np
+from op_test import OpTest
+
+
+class TestScalarMulOp(OpTest):
+    def setUp(self):
+        self.op_type = "scalar_mul"
+        self.inputs = {
+            # "X": np.random.random((5, 5)).astype("float32")
+            "X": np.random.random((10, 10)).astype(np.float64)
+        }
+        self.attrs = {"a": -1.5, "b": 0.1}
+        self.outputs = {
+            "Out": self.inputs["X"] * self.attrs["a"] + self.attrs["b"]
+        }
+
+    def test_check_output(self):
+        self.check_output()
+
+    def test_check_grad_normal(self):
+        self.check_grad(["X"], "Out", max_relative_error=0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Add a new OP named scalar_mul. It realizes the function of multiply between scalar and tensor. The formula is Out = aX + b, where a and b are scalar attributes, and X is the input tensor.