### PR TITLE
[cherry pick] Add trt int8 support for elementwise_mul and scale

### DIFF
--- a/paddle/fluid/inference/tensorrt/op_teller.cc
+++ b/paddle/fluid/inference/tensorrt/op_teller.cc
@@ -54,7 +54,10 @@ struct SimpleOpTypeSetTeller : public Teller {
                                                   "leaky_relu",
                                                   "fc",
                                                   "relu6",
-                                                  "concat"};
+                                                  "concat",
+                                                  "scale",
+                                                  "elementwise_mul",
+                                                  "conv2d_transpose"};
   std::unordered_set<std::string> teller_set{
       "mul",
       "conv2d",

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -46,9 +46,26 @@ _fake_quant_dequant_op_list = [
 ]
 
 _out_scale_op_list = [
-    "conv2d", "depthwise_conv2d", "mul", "matmul", "relu", "leaky_relu",
-    "relu6", "sigmoid", "tanh", "prelu", "swish", "softmax", "batch_norm",
-    "elementwise_add", "pool2d", "reshape2", "transpose2", "concat"
+    "conv2d",
+    "depthwise_conv2d",
+    "mul",
+    "matmul",
+    "relu",
+    "leaky_relu",
+    "relu6",
+    "sigmoid",
+    "tanh",
+    "prelu",
+    "swish",
+    "softmax",
+    "batch_norm",
+    "elementwise_add",
+    "pool2d",
+    "reshape2",
+    "transpose2",
+    "concat",
+    "elementwise_mul",
+    "scale",
 ]
 
 # list op real input and output names, to avoid processing input such as AxisTensor.
@@ -89,6 +106,8 @@ _op_real_in_out_name = {
     "dropout": [["X"], ["Out"]],
     "batch_norm": [["X"], ["Y"]],
     "sigmoid": [["X"], ["Out"]],
+    "elementwise_mul": [["X", "Y"], ["Out"]],
+    "scale": [["X"], ["Out"]],
 }
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick [PR#25676](https://github.com/PaddlePaddle/Paddle/pull/25676)