### PR TITLE
Refine paddle error stack format

### DIFF
--- a/paddle/fluid/framework/op_call_stack.cc
+++ b/paddle/fluid/framework/op_call_stack.cc
@@ -39,7 +39,7 @@ void InsertCallStackInfo(const std::string &type, const AttributeMap &attrs,
   if (callstack) {
     sout << "\n\n  Compile Traceback (most recent call last):\n";
     for (auto &line : *callstack) {
-      sout << "    " << line;
+      sout << "  " << line;
     }
   }
   // Step 2. Construct final call stack & append error op name

--- a/paddle/fluid/framework/op_call_stack.cc
+++ b/paddle/fluid/framework/op_call_stack.cc
@@ -35,26 +35,14 @@ void InsertCallStackInfo(const std::string &type, const AttributeMap &attrs,
   }
 
   std::ostringstream sout;
-  std::ostringstream sout_py_trace;
   // Step 1. Construct python call stack string
   if (callstack) {
-    sout_py_trace << "\n------------------------------------------\n";
-    sout_py_trace << "Python Call Stacks (More useful to users):";
-    sout_py_trace << "\n------------------------------------------\n";
+    sout << "\n\n  Compile Traceback (most recent call last):\n";
     for (auto &line : *callstack) {
-      sout_py_trace << line;
+      sout << "    " << line;
     }
   }
-  // Step 2. Insert python traceback into err_str_
-  std::size_t found = exception->err_str_.rfind(
-      "\n----------------------\nError Message "
-      "Summary:\n----------------------\n");
-  if (found != std::string::npos) {
-    exception->err_str_.insert(found, sout_py_trace.str());
-  } else {
-    exception->err_str_.append(sout_py_trace.str());
-  }
-  // Step 3. Construct final call stack & append error op name
+  // Step 2. Construct final call stack & append error op name
   sout << exception->err_str_;
   sout << "  [operator < " << type << " > error]";
   exception->err_str_ = sout.str();

--- a/paddle/fluid/framework/op_call_stack.cc
+++ b/paddle/fluid/framework/op_call_stack.cc
@@ -37,9 +37,9 @@ void InsertCallStackInfo(const std::string &type, const AttributeMap &attrs,
   std::ostringstream sout;
   // Step 1. Construct python call stack string
   if (callstack) {
-    sout << "\n\n  Compile Traceback (most recent call last):\n";
+    sout << "\n\n  Compile Traceback (most recent call last):";
     for (auto &line : *callstack) {
-      sout << "  " << line;
+      sout << "\n  " << line;
     }
   }
   // Step 2. Construct final call stack & append error op name

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -700,7 +700,7 @@ void OpDesc::InferShape(const BlockDesc &block) const {
     }
     infer_shape(&ctx);
   } catch (platform::EnforceNotMet &exception) {
-    framework::InsertCallStackInfo(Type(), attrs_, &exception);
+    framework::AppendErrorOpHint(Type(), &exception);
     throw std::move(exception);
   } catch (...) {
     std::rethrow_exception(std::current_exception());

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -230,16 +230,16 @@ inline std::string GetTraceBackString(StrType&& what, const char* file,
   static constexpr int TRACE_STACK_LIMIT = 100;
   std::ostringstream sout;
 
-  sout << "\n\n--------------------------------------------\n";
-  sout << "C++ Call Stacks (More useful to developers):";
-  sout << "\n--------------------------------------------\n";
+  sout << "\n--------------------------------------\n";
+  sout << "C++ Traceback (most recent call last):";
+  sout << "\n--------------------------------------\n";
 #if !defined(_WIN32)
   void* call_stack[TRACE_STACK_LIMIT];
   auto size = backtrace(call_stack, TRACE_STACK_LIMIT);
   auto symbols = backtrace_symbols(call_stack, size);
   Dl_info info;
   int idx = 0;
-  for (int i = 0; i < size; ++i) {
+  for (int i = size - 1; i >= 0; --i) {
     if (dladdr(call_stack[i], &info) && info.dli_sname) {
       auto demangled = demangle(info.dli_sname);
       std::string path(info.dli_fname);

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -230,7 +230,7 @@ inline std::string GetTraceBackString(StrType&& what, const char* file,
   static constexpr int TRACE_STACK_LIMIT = 100;
   std::ostringstream sout;
 
-  sout << "\n--------------------------------------\n";
+  sout << "\n\n--------------------------------------\n";
   sout << "C++ Traceback (most recent call last):";
   sout << "\n--------------------------------------\n";
 #if !defined(_WIN32)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1914,8 +1914,13 @@ class Operator(object):
                     "`type` to initialized an Operator can not be None.")
             else:
                 callstack_var_name = op_maker.kOpCreationCallstackAttrName()
-                op_attrs[callstack_var_name] = list(traceback.format_stack(
-                ))[:-1]
+                op_attrs[callstack_var_name] = []
+                for frame in traceback.extract_stack():
+                    op_attrs[callstack_var_name].append(
+                        '  File "{}", line {}, in {}\n'.format(frame[0], frame[
+                            1], frame[2]))
+                    op_attrs[callstack_var_name].append('    {}\n'.format(frame[
+                        3]))
 
             self.desc.set_type(type)
             proto = OpProtoHolder.instance().get_op_proto(type)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1914,8 +1914,8 @@ class Operator(object):
                     "`type` to initialized an Operator can not be None.")
             else:
                 callstack_var_name = op_maker.kOpCreationCallstackAttrName()
-                op_attrs[callstack_var_name] = list(
-                    reversed(traceback.format_stack()))[1:]
+                op_attrs[callstack_var_name] = list(traceback.format_stack(
+                ))[:-1]
 
             self.desc.set_type(type)
             proto = OpProtoHolder.instance().get_op_proto(type)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1917,9 +1917,9 @@ class Operator(object):
                 op_attrs[callstack_var_name] = []
                 for frame in traceback.extract_stack():
                     op_attrs[callstack_var_name].append(
-                        '  File "{}", line {}, in {}\n'.format(frame[0], frame[
-                            1], frame[2]))
-                    op_attrs[callstack_var_name].append('    {}\n'.format(frame[
+                        '  File "{}", line {}, in {}'.format(frame[0], frame[1],
+                                                             frame[2]))
+                    op_attrs[callstack_var_name].append('    {}'.format(frame[
                         3]))
 
             self.desc.set_type(type)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->


1. Move the `op compile python stack` follow the `native python stack`, two split python stacks not easy to read
2. Make the order of entries in all stacks consistent with the python native stack order
3. remove op python compile traceback when compile time infershape error, which is duplicated with the native python stack.

#### Stack format compare

- original：

![image](https://user-images.githubusercontent.com/22561442/88762281-7457b180-d1a3-11ea-9bac-cbd26ce7edb9.png)

- new:

```
λ yq01-gpu-255-137-12-00 /work/scripts {master} python paddle_error_case1.py
Traceback (most recent call last):
  File "paddle_error_case1.py", line 24, in <module>
    loss_data, = exe.run(fluid.default_main_program(), feed={'X': x, 'Y': y}, fetch_list=[avg_loss.name])
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/executor.py", line 1085, in run
    six.reraise(*sys.exc_info())
  File "/usr/local/lib/python3.5/dist-packages/six.py", line 693, in reraise
    raise value
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/executor.py", line 1080, in run
    return_merged=return_merged)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/executor.py", line 1168, in _run_impl
    use_program_cache=use_program_cache)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/executor.py", line 1243, in _run_program
    fetch_var_name)
paddle.fluid.core_avx.EnforceNotMet:

  Compile Traceback (most recent call last):
    File "paddle_error_case1.py", line 9, in <module>
      predict = fluid.layers.fc(input=x, size=1, act=None)
    File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layers/nn.py", line 350, in fc
      "y_num_col_dims": 1})
    File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layer_helper.py", line 43, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 2804, in append_op
      attrs=kwargs.get("attrs", None))
    File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 1918, in __init__
      for frame in traceback.extract_stack():

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::framework::Executor::Run(paddle::framework::ProgramDesc const&, paddle::framework::Scope*, int, bool, bool, std::vector<std::string, std::allocator<std::string > > const&, bool, bool)
1   paddle::framework::Executor::RunPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, bool, bool, bool)
2   paddle::framework::Executor::RunPartialPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, long, long, bool, bool, bool)
3   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, paddle::platform::Place const&)
4   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&) const
5   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&, paddle::framework::RuntimeContext*) const
6   paddle::operators::MulOp::InferShape(paddle::framework::InferShapeContext*) const
7   paddle::platform::EnforceNotMet::EnforceNotMet(std::string const&, char const*, int)
8   std::string paddle::platform::GetTraceBackString<std::string >(std::string&&, char const*, int)

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: After flatten the input tensor X and Y to 2-D dimensions matrix X1 and Y1, the matrix X1's width must be equal with matrix Y1's height. But received X's shape = [8, 12], X1's shape = [8, 12], X1's width = 12; Y's shape = [13, 1], Y1's shape = [13, 1], Y1's height = 13.
  [Hint: Expected x_mat_dims[1] == y_mat_dims[0], but received x_mat_dims[1]:12 != y_mat_dims[0]:13.] at (/work/paddle/paddle/fluid/operators/mul_op.cc:83)
  [operator < mul > error]
```

#### Remove compile nferShape op callstack

- original:

![image](https://user-images.githubusercontent.com/22561442/88762489-e203dd80-d1a3-11ea-99d4-d92232941f10.png)

- new:
```
λ yq01-gpu-255-137-12-00 /work/scripts {master} python paddle_error_case1.py 
Traceback (most recent call last):
  File "paddle_error_case1.py", line 9, in <module>
    predict = fluid.layers.fc(input=x, size=1, act=None)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layers/nn.py", line 350, in fc
    "y_num_col_dims": 2})
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layer_helper.py", line 43, in append_op
    return self.main_program.current_block().append_op(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 2799, in append_op
    attrs=kwargs.get("attrs", None))
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 2022, in __init__
    self.desc.infer_shape(self.block.desc)
paddle.fluid.core_avx.EnforceNotMet: 

--------------------------------------------
C++ Call Stacks (More useful to developers):
--------------------------------------------
0   std::string paddle::platform::GetTraceBackString<std::string >(std::string&&, char const*, int)
1   paddle::platform::EnforceNotMet::EnforceNotMet(std::string const&, char const*, int)
2   paddle::operators::MulOp::InferShape(paddle::framework::InferShapeContext*) const
3   paddle::framework::OpDesc::InferShape(paddle::framework::BlockDesc const&) const

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: The input tensor Y's dimensions of MulOp should be larger than y_num_col_dims. But received Y's dimensions = 2, Y's shape = [13, 1], y_num_col_dims = 2.
  [Hint: Expected y_dims.size() > y_num_col_dims, but received y_dims.size():2 <= y_num_col_dims:2.] at (/work/paddle/paddle/fluid/operators/mul_op.cc:69)
  [operator < mul > error]
```

