### PR TITLE
Make `reshape` `squeeze` `unsqueeze` inplace in dygraph mode

### DIFF
--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -88,10 +88,19 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
 // with reshape ops being inplace, we can use canonical broadcasting semantics
 // i.e., remove the `axis` argument
 std::map<std::string, std::map<std::string, std::string>>
-op_forward_input_output_map = {
-    {"reshape2", {{"Out", "X"},}},
-    {"unsqueeze2", {{"Out", "X"},}},
-    {"squeeze2", {{"Out", "X"}},},
+    op_forward_input_output_map = {
+        {"reshape2",
+         {
+             {"Out", "X"},
+         }},
+        {"unsqueeze2",
+         {
+             {"Out", "X"},
+         }},
+        {
+            "squeeze2",
+            {{"Out", "X"}},
+        },
 };
 
 // clang-format off
@@ -305,9 +314,8 @@ GenerateOpFunctions(const std::string& module_name) {
 
         if (FindForwardInOutMap(op_type, out_name)) {
           auto in_name = op_forward_input_output_map[op_type][out_name];
-          forward_in_out +=
-            paddle::string::Sprintf(
-              FORWARD_IN_OUT, in_name, out_name, in_name);
+          forward_in_out += paddle::string::Sprintf(FORWARD_IN_OUT, in_name,
+                                                    out_name, in_name);
         }
       }
 
@@ -342,8 +350,8 @@ GenerateOpFunctions(const std::string& module_name) {
     auto op_function_str = paddle::string::Sprintf(
         OP_FUNCTION_TEMPLATE, return_type, func_name, function_args,
         outs_initializer, ins_initializer,
-        ins_initializer_with_null + outs_initializer_with_null,
-        forward_in_out, op_type, return_str);
+        ins_initializer_with_null + outs_initializer_with_null, forward_in_out,
+        op_type, return_str);
 
     // generate pybind item
     auto bind_function_str = paddle::string::Sprintf(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6075,6 +6075,7 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             # the shape of reshaped_3 is [6,8].
     """
     if in_dygraph_mode():
+        #TODO(zhiqiu): enable inplace in dygraph mode.
         if inplace:
             warnings.warn(
                 "Inplace on reshape is not allowed and will be discarded in dygraph mode currently."
@@ -6084,8 +6085,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
                 item.numpy()[0] if isinstance(item, Variable) else item
                 for item in shape
             ]
-        core.ops.reshape2(x, x, 'shape', shape)
-        return dygraph_utils._append_activation_in_dygraph(x, act)
+            out, _ = core.ops.reshape2(x, 'shape', shape)
+            return dygraph_utils._append_activation_in_dygraph(out, act)
 
     check_variable_and_dtype(
         x, 'x', ['float16', 'float32', 'float64', 'int32', 'int64'], 'reshape')
@@ -6203,13 +6204,8 @@ def squeeze(input, axes, name=None):
 
     """
     if in_dygraph_mode():
-        if isinstance(axes, (list, tuple)):
-            axes = [
-                item.numpy()[0] if isinstance(item, Variable) else item
-                for item in axes
-            ]
-        core.ops.squeeze2(input, input, 'axes', axes)
-        return input
+        out, _ = core.ops.squeeze2(input, 'axes', axes)
+        return out
 
     helper = LayerHelper("squeeze", **locals())
     check_variable_and_dtype(
@@ -6258,13 +6254,8 @@ def unsqueeze(input, axes, name=None):
 
     """
     if in_dygraph_mode():
-        if isinstance(axes, (list, tuple)):
-            axes = [
-                item.numpy()[0] if isinstance(item, Variable) else item
-                for item in axes
-            ]
-        core.ops.unsqueeze2(input, input, 'axes', axes)
-        return input
+        out, _ = core.ops.unsqueeze2(input, 'axes', axes)
+        return out
 
     if not isinstance(axes, (int, list, tuple, Variable)):
         raise TypeError(


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
Make `reshape` `squeeze` `unsqueeze` inplace in dygraph mode

this is a short term solution, so that we can use canonical broadcasting semantics, i.e., remove the `axis` argument.

example of generated op implementation
```c++
std::tuple<std::shared_ptr<imperative::VarBase>,std::shared_ptr<imperative::VarBase>> imperative_reshape2(const std::shared_ptr<imperative::VarBase>& X, const py::args* & args)
{
  framework::AttributeMap attrs;
  ConstructAttrMapFromPyArgs(&attrs, args);
  {
    py::gil_scoped_release release;
    auto tracer = imperative::GetCurrentTracer();
    imperative::NameVarBaseMap outs = {{"Out", {std::shared_ptr<imperative::VarBase>(new imperative::VarBase(tracer->GenerateUniqueName()))}},{"XShape", {std::shared_p  tr<imperative::VarBase>(new imperative::VarBase(tracer->GenerateUniqueName()))}}};
    imperative::NameVarBaseMap ins = {{"X", {X}}};


    if (ins["X"][0]->Var().IsType<paddle::framework::LoDTensor>()) {
        outs["Out"][0]->MutableVar()->GetMutable<paddle::framework::LoDTensor>()->ShareBufferWith(ins["X"][0]->Var().Get<paddle::framework::LoDTensor>());
    } else {
        PADDLE_THROW("Variables must be of type LoDTensor");
    }

    tracer->TraceOp("reshape2", ins, outs, attrs);
    return std::make_tuple(outs["Out"][0],outs["XShape"][0]);
  }
}
```
