### PR TITLE
set isfinite op on cpu for amp

### DIFF
--- a/python/paddle/fluid/contrib/mixed_precision/decorator.py
+++ b/python/paddle/fluid/contrib/mixed_precision/decorator.py
@@ -14,6 +14,7 @@
 
 from ... import default_main_program
 from ... import default_startup_program
+from ... import device_guard
 from ... import layers
 from ... import unique_name
 from . import fp16_utils
@@ -164,7 +165,8 @@ class OptimizerWithMixedPrecision(object):
             grads = [layers.reduce_sum(g) for [_, g] in scaled_params_grads]
             all_grads = layers.concat(grads)
             all_grads_sum = layers.reduce_sum(all_grads)
-            is_overall_finite = layers.isfinite(all_grads_sum)
+            with device_guard("cpu"):
+                is_overall_finite = layers.isfinite(all_grads_sum)
 
             update_loss_scaling(is_overall_finite, self._loss_scaling,
                                 self._num_good_steps, self._num_bad_steps,


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> Others

### Describe
<!-- Describe what this PR does --> set isfinite op on cpu for amp


AMP训练中，isfinite的输出会作为conditionnal_block的cond，cond会被拷贝到CPU上，存在wait，导致耗时较多。但在profiling report中，conditional_block中的wait会干扰分析，实际上conditional_block中计算量可忽略不计。

因此将isfinite设置在CPU上，则wait会体现在isfinite中，这样设置并不会影响原始性能。
