### PR TITLE
fix test_pipeline, test=develop

### DIFF
--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -335,6 +335,9 @@ class SectionWorker : public DeviceWorker {
   void SetSkipVars(const std::vector<std::string>& skip_vars) {
     skip_vars_ = skip_vars;
   }
+  static void ResetBatchId() {
+    batch_id_ = 0;
+  }
 
   static std::atomic<int> cpu_id_;
 

--- a/paddle/fluid/framework/device_worker.h
+++ b/paddle/fluid/framework/device_worker.h
@@ -335,9 +335,7 @@ class SectionWorker : public DeviceWorker {
   void SetSkipVars(const std::vector<std::string>& skip_vars) {
     skip_vars_ = skip_vars;
   }
-  static void ResetBatchId() {
-    batch_id_ = 0;
-  }
+  static void ResetBatchId() { batch_id_ = 0; }
 
   static std::atomic<int> cpu_id_;
 

--- a/paddle/fluid/framework/pipeline_trainer.cc
+++ b/paddle/fluid/framework/pipeline_trainer.cc
@@ -250,6 +250,7 @@ void PipelineTrainer::Finalize() {
     }
   }
   root_scope_->DropKids();
+  SectionWorker::ResetBatchId();
 }
 
 Scope* PipelineTrainer::GetWorkerScope(int thread_id) {

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -234,7 +234,6 @@ list(REMOVE_ITEM TEST_OPS test_fuse_bn_act_pass)
 list(REMOVE_ITEM TEST_OPS test_imperative_static_runner_mnist)
 list(REMOVE_ITEM TEST_OPS test_imperative_static_runner_while)
 list(REMOVE_ITEM TEST_OPS test_conv3d_transpose_op)
-list(REMOVE_ITEM TEST_OPS test_pipeline)
 
 # disable this unittest temporarily
 list(REMOVE_ITEM TEST_OPS test_imperative_data_loader_exception)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Fix the issue of timeout of test_pipeline ut.
单测失败原因分析：
在pipeline模式下，当连续运行两次train_from_dataset时，类成员变量batch_id_会随训练的进行持续增加；而普通的成员变量local_batch_id在每次调用train_from_dataset时都会重置，导致非首个section判断结束条件失败，持续等待。
解决思路：
每次运行train_from_dataset时，对类成员变量batch_id_也进行重置。