### PR TITLE
【Dy2stat】Fix is_test switch incorrectly in PartialProgram

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -112,10 +112,10 @@ class PartialProgramLayer(layers.Layer):
         self._outputs = NestSequence(outputs, need_check=True)
         self._params = parameters if parameters is not None else []
 
-        self._infer_program = self._verify_program(main_program)
-        self._train_program = self._append_backward_desc()
-        # Switch infer or train by train() and eval()
-        self._trace_program = None
+        main_program = self._verify_program(main_program)
+        self._infer_program = self._change_is_test_status(main_program, True)
+        self._train_program = self._append_backward_desc(main_program)
+
         self._set_grad_type(self._params)
         self._inner_scope = core.Scope()
         # Set default mode to train
@@ -136,8 +136,8 @@ class PartialProgramLayer(layers.Layer):
         return main_program
 
     @switch_to_static_graph
-    def _append_backward_desc(self):
-        program = self._infer_program.clone()
+    def _append_backward_desc(self, main_program):
+        program = main_program.clone()
         targets = []
         for out in self._outputs.tolist():
             if isinstance(out, framework.Variable):
@@ -168,14 +168,14 @@ class PartialProgramLayer(layers.Layer):
     def train(self):
         # self.training is inherited from layers.Layer
         self.training = True
-        self._trace_program = self._train_program
 
     def eval(self):
         self.training = False
-        self._trace_program = self._infer_program
 
     def forward(self, inputs):
         in_vars, out_vars, tmp_scope_vec = self._prepare(inputs)
+
+        trace_program = self._train_program if self.training else self._infer_program
 
         framework._dygraph_tracer().trace_op(
             type='run_program',
@@ -186,7 +186,7 @@ class PartialProgramLayer(layers.Layer):
             outputs={'Out': valid_vars(out_vars),
                      'OutScope': tmp_scope_vec},
             attrs={
-                'global_block': self._trace_program.desc.block(0),
+                'global_block': trace_program.desc.block(0),
                 'start_op_index': 0,
                 'end_op_index': self._infer_program.desc.block(0).op_size(),
                 'is_test': not self.training
@@ -285,6 +285,19 @@ class PartialProgramLayer(layers.Layer):
             return res
 
         return out_vars
+
+    @switch_to_static_graph
+    def _change_is_test_status(self, main_program, is_test):
+        """
+        Change all `is_test` attributes of given program.
+        """
+        infer_program = main_program.clone()
+        for block in infer_program.blocks:
+            for op in block.ops:
+                if op.has_attr('is_test'):
+                    op._set_attr('is_test', is_test)
+
+        return infer_program
 
     def _set_grad_type(self, params):
         # NOTE: if user set sparse gradient mode, the param's gradient

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -113,7 +113,7 @@ class PartialProgramLayer(layers.Layer):
         self._params = parameters if parameters is not None else []
 
         main_program = self._verify_program(main_program)
-        self._infer_program = main_program.clone(for_test=True)
+        self._infer_program = self._clone_for_test(main_program)
         self._train_program = self._append_backward_desc(main_program)
 
         self._set_grad_type(self._params)
@@ -247,6 +247,10 @@ class PartialProgramLayer(layers.Layer):
             outs = outs[0]
 
         return outs
+
+    @switch_to_static_graph
+    def _clone_for_test(self, main_program):
+        return main_program.clone(for_test=True)
 
     def _is_no_value(self, var):
         if isinstance(var, core.VarBase):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -113,7 +113,7 @@ class PartialProgramLayer(layers.Layer):
         self._params = parameters if parameters is not None else []
 
         main_program = self._verify_program(main_program)
-        self._infer_program = self._clone_for_test(main_program)
+        self._infer_program = main_program.clone(for_test=True)
         self._train_program = self._append_backward_desc(main_program)
 
         self._set_grad_type(self._params)
@@ -280,19 +280,6 @@ class PartialProgramLayer(layers.Layer):
             return res
 
         return out_vars
-
-    @switch_to_static_graph
-    def _clone_for_test(self, main_program):
-        """
-        Clone the main program and change all `is_test` attributes into true.
-        """
-        infer_program = main_program.clone()
-        for block in infer_program.blocks:
-            for op in block.ops:
-                if op.has_attr('is_test'):
-                    op._set_attr('is_test', True)
-
-        return infer_program
 
     def _set_grad_type(self, params):
         # NOTE: if user set sparse gradient mode, the param's gradient

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -487,8 +487,8 @@ class ProgramTranslator(object):
         _, partial_program_layer = self._program_cache[function_spec]
 
         if args and isinstance(args[0], layers.Layer):
-            # Synchronize training attribute.
-            partial_program_layer.training = getattr(args[0], "training", True)
+            # Synchronize self.training attribute.
+            partial_program_layer.training = args[0].training
             args = args[1:]
 
         return partial_program_layer(args)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -487,6 +487,8 @@ class ProgramTranslator(object):
         _, partial_program_layer = self._program_cache[function_spec]
 
         if args and isinstance(args[0], layers.Layer):
+            # Synchronize training attribute.
+            partial_program_layer.training = getattr(args[0], "training", True)
             args = args[1:]
 
         return partial_program_layer(args)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix is_test switch incorrectly in PartialProgram.

While training dygraph using `@declarative`，the `is_test` in some ops like BatchNorm` is not switched correctly. In this case, the mean and variance of BatchNorm will be changed after calling `programTranslator.get_output(mode, *args)`.

The reason is that `model.training` is not passed into PartialProgram correctly. We fix it in this PR.

The Pseudo code is:
```python
model.eval()

fake_data = np.random.random(shape)
inputs = to_variable(fake_data)

# The random data will change mean and variance of BN if is_test is not set True.
prog_trans.get_output(_convert, model, *input_vars)
prog_trans.save_inference_model(dirname, feed, fetch)
```