### PR TITLE
Verify the correctness of jit.save/jit.load on multiple models - part 1

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lac.py
@@ -535,9 +535,14 @@ class TestLACModel(unittest.TestCase):
             batch = [np.vstack(var) for var in zip(*batch)]
             dy_pre = self.predict_dygraph(batch)
             st_pre = self.predict_static(batch)
+            dy_jit_pre = self.predict_dygraph_jit(batch)
             self.assertTrue(
                 np.allclose(dy_pre, st_pre),
                 msg="dy_pre:\n {}\n, st_pre: \n{}.".format(dy_pre, st_pre))
+            self.assertTrue(
+                np.allclose(dy_jit_pre, st_pre),
+                msg="dy_jit_pre:\n {}\n, st_pre: \n{}.".format(dy_jit_pre,
+                                                               st_pre))
 
     def predict_dygraph(self, batch):
         words, targets, length = batch
@@ -575,6 +580,16 @@ class TestLACModel(unittest.TestCase):
                   feed_target_names[1]: length},
             fetch_list=fetch_targets)
         return pred_res[0]
+
+    def predict_dygraph_jit(self, batch):
+        words, targets, length = batch
+        with fluid.dygraph.guard(self.place):
+            model = fluid.dygraph.jit.load(self.args.model_save_dir)
+            model.eval()
+
+            pred_res = model(to_variable(words), to_variable(length))
+
+            return pred_res.numpy()
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_resnet.py
@@ -22,39 +22,33 @@ import numpy as np
 
 import paddle
 import paddle.fluid as fluid
-from paddle.fluid.dygraph.jit import dygraph_to_static_func
+from paddle.fluid.dygraph import declarative, ProgramTranslator
 from paddle.fluid.dygraph.nn import BatchNorm, Conv2D, Linear, Pool2D
+from paddle.fluid.dygraph.io import VARIABLE_FILENAME
 
+SEED = 2020
 IMAGENET1000 = 1281167
-base_lr = 0.1
+base_lr = 0.001
 momentum_rate = 0.9
 l2_decay = 1e-4
 batch_size = 8
 epoch_num = 1
 place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() \
     else fluid.CPUPlace()
+MODEL_SAVE_PATH = "./resnet.inference.model"
+DY_STATE_DICT_SAVE_PATH = "./resnet.dygraph"
+program_translator = ProgramTranslator()
+
+if fluid.is_compiled_with_cuda():
+    fluid.set_flags({'FLAGS_cudnn_deterministic': True})
 
 
 def optimizer_setting(parameter_list=None):
-    total_images = IMAGENET1000
-    step = int(math.ceil(float(total_images) / batch_size))
-    epochs = [30, 60, 90]
-    bd = [step * e for e in epochs]
-
-    lr = [base_lr * (0.1**i) for i in range(len(bd) + 1)]
-    if fluid.in_dygraph_mode():
-        optimizer = fluid.optimizer.Momentum(
-            learning_rate=fluid.layers.piecewise_decay(
-                boundaries=bd, values=lr),
-            momentum=momentum_rate,
-            regularization=fluid.regularizer.L2Decay(l2_decay),
-            parameter_list=parameter_list)
-    else:
-        optimizer = fluid.optimizer.Momentum(
-            learning_rate=fluid.layers.piecewise_decay(
-                boundaries=bd, values=lr),
-            momentum=momentum_rate,
-            regularization=fluid.regularizer.L2Decay(l2_decay))
+    optimizer = fluid.optimizer.Momentum(
+        learning_rate=base_lr,
+        momentum=momentum_rate,
+        regularization=fluid.regularizer.L2Decay(l2_decay),
+        parameter_list=parameter_list)
 
     return optimizer
 
@@ -189,8 +183,8 @@ class ResNet(fluid.dygraph.Layer):
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.Uniform(-stdv, stdv)))
 
-    @dygraph_to_static_func
-    def forward(self, inputs, label):
+    @declarative
+    def forward(self, inputs):
         y = self.conv(inputs)
         y = self.pool2d_max(y)
         for bottleneck_block in self.bottleneck_block_list:
@@ -199,77 +193,144 @@ class ResNet(fluid.dygraph.Layer):
         y = fluid.layers.reshape(y, shape=[-1, self.pool2d_avg_output])
         pred = self.out(y)
 
-        loss = fluid.layers.cross_entropy(input=pred, label=label)
-        avg_loss_ = fluid.layers.mean(x=loss)
-        acc_top1_ = fluid.layers.accuracy(input=pred, label=label, k=1)
-        acc_top5_ = fluid.layers.accuracy(input=pred, label=label, k=5)
-
-        return pred, avg_loss_, acc_top1_, acc_top5_
+        return pred
 
 
-def train_resnet_in_static_mode():
+def reader_decorator(reader):
+    def __reader__():
+        for item in reader():
+            img = np.array(item[0]).astype('float32').reshape(3, 224, 224)
+            label = np.array(item[1]).astype('int64').reshape(1)
+            yield img, label
+
+    return __reader__
+
+
+def train(to_static):
     """
     Tests model decorated by `dygraph_to_static_output` in static mode. For users, the model is defined in dygraph mode and trained in static mode.
     """
+    with fluid.dygraph.guard(place):
+        np.random.seed(SEED)
+        fluid.default_startup_program().random_seed = SEED
+        fluid.default_main_program().random_seed = SEED
 
-    exe = fluid.Executor(place)
-    startup_prog = fluid.Program()
-    main_prog = fluid.Program()
+        train_reader = paddle.batch(
+            reader_decorator(paddle.dataset.flowers.train(use_xmap=False)),
+            batch_size=batch_size,
+            drop_last=True)
+        data_loader = fluid.io.DataLoader.from_generator(
+            capacity=5, iterable=True)
+        data_loader.set_sample_list_generator(train_reader)
 
-    with fluid.program_guard(main_prog, startup_prog):
-
-        img = fluid.data(name="img", shape=[None, 3, 224, 224], dtype="float32")
-        label = fluid.data(name="label", shape=[None, 1], dtype="int64")
-        label.stop_gradient = True
         resnet = ResNet()
-        pred, avg_loss_, acc_top1_, acc_top5_ = resnet(img, label)
         optimizer = optimizer_setting(parameter_list=resnet.parameters())
-        optimizer.minimize(avg_loss_)
 
-    exe.run(startup_prog)
+        for epoch in range(epoch_num):
+            total_loss = 0.0
+            total_acc1 = 0.0
+            total_acc5 = 0.0
+            total_sample = 0
 
-    train_reader = paddle.batch(
-        paddle.dataset.flowers.train(use_xmap=False), batch_size=batch_size)
+            for batch_id, data in enumerate(data_loader()):
+                start_time = time.time()
+                img, label = data
 
-    for epoch in range(epoch_num):
-        total_loss = 0.0
-        total_acc1 = 0.0
-        total_acc5 = 0.0
-        total_sample = 0
+                pred = resnet(img)
+                loss = fluid.layers.cross_entropy(input=pred, label=label)
+                avg_loss = fluid.layers.mean(x=loss)
+                acc_top1 = fluid.layers.accuracy(input=pred, label=label, k=1)
+                acc_top5 = fluid.layers.accuracy(input=pred, label=label, k=5)
 
-        for batch_id, data in enumerate(train_reader()):
-            start_time = time.time()
-            dy_x_data = np.array(
-                [x[0].reshape(3, 224, 224) for x in data]).astype('float32')
-            if len(np.array([x[1]
-                             for x in data]).astype('int64')) != batch_size:
-                continue
-            y_data = np.array([x[1] for x in data]).astype('int64').reshape(-1,
-                                                                            1)
+                avg_loss.backward()
+                optimizer.minimize(avg_loss)
+                resnet.clear_gradients()
 
-            avg_loss, acc_top1, acc_top5 = exe.run(
-                main_prog,
-                feed={"img": dy_x_data,
-                      "label": y_data},
-                fetch_list=[avg_loss_, acc_top1_, acc_top5_])
+                total_loss += avg_loss
+                total_acc1 += acc_top1
+                total_acc5 += acc_top5
+                total_sample += 1
 
-            total_loss += avg_loss
-            total_acc1 += acc_top1
-            total_acc5 += acc_top5
-            total_sample += 1
+                end_time = time.time()
+                if batch_id % 2 == 0:
+                    print( "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f" % \
+                        ( epoch, batch_id, total_loss.numpy() / total_sample, \
+                            total_acc1.numpy() / total_sample, total_acc5.numpy() / total_sample, end_time-start_time))
+                if batch_id == 10:
+                    if to_static:
+                        fluid.dygraph.jit.save(resnet, MODEL_SAVE_PATH)
+                    else:
+                        fluid.dygraph.save_dygraph(resnet.state_dict(),
+                                                   DY_STATE_DICT_SAVE_PATH)
+                    # avoid dataloader throw abort signaal
+                    data_loader._reset()
+                    break
 
-            end_time = time.time()
-            if batch_id % 2 == 0:
-                print( "epoch %d | batch step %d, loss %0.3f, acc1 %0.3f, acc5 %0.3f, time %f" % \
-                       ( epoch, batch_id, total_loss / total_sample, \
-                         total_acc1 / total_sample, total_acc5 / total_sample, end_time-start_time))
-            if batch_id == 10:
-                break
+    return total_loss.numpy()
+
+
+def predict_dygraph(data):
+    program_translator.enable(False)
+    with fluid.dygraph.guard(place):
+        resnet = ResNet()
+
+        model_dict, _ = fluid.dygraph.load_dygraph(DY_STATE_DICT_SAVE_PATH)
+        resnet.set_dict(model_dict)
+        resnet.eval()
+
+        pred_res = resnet(fluid.dygraph.to_variable(data))
+
+        return pred_res.numpy()
+
+
+def predict_static(data):
+    exe = fluid.Executor(place)
+    [inference_program, feed_target_names,
+     fetch_targets] = fluid.io.load_inference_model(
+         MODEL_SAVE_PATH, executor=exe, params_filename=VARIABLE_FILENAME)
+
+    pred_res = exe.run(inference_program,
+                       feed={feed_target_names[0]: data},
+                       fetch_list=fetch_targets)
+
+    return pred_res[0]
+
+
+def predict_dygraph_jit(data):
+    with fluid.dygraph.guard(place):
+        resnet = fluid.dygraph.jit.load(MODEL_SAVE_PATH)
+        resnet.eval()
+
+        pred_res = resnet(data)
+
+        return pred_res.numpy()
 
 
 class TestResnet(unittest.TestCase):
-    def test_in_static_mode(self):
-        train_resnet_in_static_mode()
+    def train(self, to_static):
+        program_translator.enable(to_static)
+        return train(to_static)
+
+    def verify_predict(self):
+        image = np.random.random([1, 3, 224, 224]).astype('float32')
+        dy_pre = predict_dygraph(image)
+        st_pre = predict_static(image)
+        dy_jit_pre = predict_dygraph_jit(image)
+        self.assertTrue(
+            np.allclose(dy_pre, st_pre),
+            msg="dy_pre:\n {}\n, st_pre: \n{}.".format(dy_pre, st_pre))
+        self.assertTrue(
+            np.allclose(dy_jit_pre, st_pre),
+            msg="dy_jit_pre:\n {}\n, st_pre: \n{}.".format(dy_jit_pre, st_pre))
+
+    def test_resnet(self):
+        static_loss = self.train(to_static=True)
+        dygraph_loss = self.train(to_static=False)
+        self.assertTrue(
+            np.allclose(static_loss, dygraph_loss),
+            msg="static_loss: {} \n dygraph_loss: {}".format(static_loss,
+                                                             dygraph_loss))
+        self.verify_predict()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_se_resnet.py
@@ -24,6 +24,7 @@ from paddle.fluid.dygraph.base import to_variable
 from paddle.fluid.dygraph.nn import BatchNorm, Conv2D, Linear, Pool2D
 from paddle.fluid.dygraph import declarative
 from paddle.fluid.dygraph import ProgramTranslator
+from paddle.fluid.dygraph.io import VARIABLE_FILENAME
 
 SEED = 2020
 np.random.seed(SEED)
@@ -32,6 +33,8 @@ BATCH_SIZE = 8
 EPOCH_NUM = 1
 PRINT_STEP = 2
 STEP_NUM = 10
+MODEL_SAVE_PATH = "./se_resnet.inference.model"
+DY_STATE_DICT_SAVE_PATH = "./se_resnet.dygraph"
 
 place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda() \
     else fluid.CPUPlace()
@@ -377,9 +380,58 @@ def train(train_reader, to_static):
 
                 step_idx += 1
                 if step_idx == STEP_NUM:
+                    if to_static:
+                        configs = fluid.dygraph.jit.SaveLoadConfig()
+                        configs.output_spec = [pred]
+                        fluid.dygraph.jit.save(se_resnext, MODEL_SAVE_PATH,
+                                               [img], configs)
+                    else:
+                        fluid.dygraph.save_dygraph(se_resnext.state_dict(),
+                                                   DY_STATE_DICT_SAVE_PATH)
                     break
         return pred.numpy(), avg_loss.numpy(), acc_top1.numpy(), acc_top5.numpy(
         )
+
+
+def predict_dygraph(data):
+    program_translator = ProgramTranslator()
+    program_translator.enable(False)
+    with fluid.dygraph.guard(place):
+        se_resnext = SeResNeXt()
+
+        model_dict, _ = fluid.dygraph.load_dygraph(DY_STATE_DICT_SAVE_PATH)
+        se_resnext.set_dict(model_dict)
+        se_resnext.eval()
+
+        label = np.random.random([1, 1]).astype("int64")
+        img = fluid.dygraph.to_variable(data)
+        label = fluid.dygraph.to_variable(label)
+        pred_res, _, _, _ = se_resnext(img, label)
+
+        return pred_res.numpy()
+
+
+def predict_static(data):
+    exe = fluid.Executor(place)
+    [inference_program, feed_target_names,
+     fetch_targets] = fluid.io.load_inference_model(
+         MODEL_SAVE_PATH, executor=exe, params_filename=VARIABLE_FILENAME)
+
+    pred_res = exe.run(inference_program,
+                       feed={feed_target_names[0]: data},
+                       fetch_list=fetch_targets)
+
+    return pred_res[0]
+
+
+def predict_dygraph_jit(data):
+    with fluid.dygraph.guard(place):
+        se_resnext = fluid.dygraph.jit.load(MODEL_SAVE_PATH)
+        se_resnext.eval()
+
+        pred_res = se_resnext(data)
+
+        return pred_res.numpy()
 
 
 class TestSeResnet(unittest.TestCase):
@@ -389,6 +441,18 @@ class TestSeResnet(unittest.TestCase):
                 use_xmap=False, cycle=True),
             batch_size=BATCH_SIZE,
             drop_last=True)
+
+    def verify_predict(self):
+        image = np.random.random([1, 3, 224, 224]).astype('float32')
+        dy_pre = predict_dygraph(image)
+        st_pre = predict_static(image)
+        dy_jit_pre = predict_dygraph_jit(image)
+        self.assertTrue(
+            np.allclose(dy_pre, st_pre),
+            msg="dy_pre:\n {}\n, st_pre: \n{}.".format(dy_pre, st_pre))
+        self.assertTrue(
+            np.allclose(dy_jit_pre, st_pre),
+            msg="dy_jit_pre:\n {}\n, st_pre: \n{}.".format(dy_jit_pre, st_pre))
 
     def test_check_result(self):
         pred_1, loss_1, acc1_1, acc5_1 = train(
@@ -408,6 +472,8 @@ class TestSeResnet(unittest.TestCase):
         self.assertTrue(
             np.allclose(acc5_1, acc5_2),
             msg="static acc5: {} \ndygraph acc5: {}".format(acc5_1, acc5_2))
+
+        self.verify_predict()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Verify the correctness of jit.save/jit.load on multiple models

Test points include:
1. The model saved by `jit.save` can be used coorrectly after being loaded through `io.load_inference_model` and `jit.load`
2. The prediction result of model loaded by `jit.load` is consistent with the prediction result of `io.load_inference_model`

The PR test model includes:
- BERT
- BMN
- LAC
- MobileNet V1/V2
- ResNet
- SeResNet