### PR TITLE
Fix `paddle.abs` docstring

### DIFF
--- a/paddle/fluid/operators/activation_op.cc
+++ b/paddle/fluid/operators/activation_op.cc
@@ -216,7 +216,7 @@ $$out = \\frac{1}{\\sqrt{x}}$$
 )DOC";
 
 UNUSED constexpr char AbsDoc[] = R"DOC(
-Abs Activation Operator.
+Abs Operator.
 
 $$out = |x|$$
 


### PR DESCRIPTION
### PR types
Others

### PR changes
Docs

### Describe

remove activation wording
use negative input in example
