### PR TITLE
[Cherry-pick] Add some error messages for the op without double grads. (#25951)

### DIFF
--- a/paddle/fluid/imperative/partial_grad_engine.cc
+++ b/paddle/fluid/imperative/partial_grad_engine.cc
@@ -870,12 +870,14 @@ void PartialGradTask::RunEachOp(OpBase *op) {
   if (create_graph_) {
     auto double_grad_node = CreateGradOpNode(op->InnerOp(), tmp_ins, tmp_outs,
                                              op->Attrs(), op->place());
-    if (double_grad_node) {
-      VLOG(10) << "Create " << double_grad_node->size()
-               << " double grad op(s) for " << op->Type()
-               << ", pending ops: " << GradPendingOpTypes(*double_grad_node);
-      double_grad_nodes_.emplace_back(std::move(double_grad_node));
-    }
+    PADDLE_ENFORCE_NOT_NULL(
+        double_grad_node,
+        platform::errors::NotFound("The Op %s doesn't have any grad op.",
+                                   op->Type()));
+    VLOG(10) << "Create " << double_grad_node->size()
+             << " double grad op(s) for " << op->Type()
+             << ", pending ops: " << GradPendingOpTypes(*double_grad_node);
+    double_grad_nodes_.emplace_back(std::move(double_grad_node));
   }
 
   VLOG(10) << "There are " << grads_to_accumulate_.size() << " to sum gradient";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
```python
import paddle
from paddle import fluid
import numpy as np

paddle.enable_imperative()
x = fluid.layers.ones(shape=[2, 3, 2, 2], dtype='float32') 
x.stop_gradient = False
y = paddle.fluid.layers.batch_norm(x)

dx = fluid.dygraph.grad(
        outputs=[y],
        inputs=[x], 
        create_graph=True, 
        retain_graph=True)[0]

loss = fluid.layers.reduce_mean(dx)
loss.backward()

print(x.gradient())
```
As the code described above, when an op doesn't own double grad op, the value of `x.gradient()` is `None`. After this pr, this program will throw some error messages, which is shown as below.

![image](https://user-images.githubusercontent.com/17102274/89306727-d7b17a00-d6a2-11ea-866f-731f4323f71c.png)
