### PR TITLE
adjust group and grid size

### DIFF
--- a/paddle/fluid/operators/lookup_table_op.cu
+++ b/paddle/fluid/operators/lookup_table_op.cu
@@ -105,17 +105,17 @@ class LookupTableCUDAKernel : public framework::OpKernel<T> {
     auto *table = table_t->data<T>();
     auto *output = output_t->mutable_data<T>(context.GetPlace());
 
-    dim3 threads(128, 8);
-    dim3 grids(8, 1);
+    dim3 threads(256, 4);
+    dim3 grids(160, 1);
 
     if (padding_idx == -1)
       LookupTable<
-          T, 128, 8, 8,
+          T, 256, 4, 160,
           false><<<grids, threads, 0, context.cuda_device_context().stream()>>>(
           output, table, ids, N, K, D, padding_idx);
     else
       LookupTable<
-          T, 128, 8, 8,
+          T, 256, 4, 160,
           true><<<grids, threads, 0, context.cuda_device_context().stream()>>>(
           output, table, ids, N, K, D, padding_idx);
   }

--- a/paddle/fluid/operators/lookup_table_v2_op.cu
+++ b/paddle/fluid/operators/lookup_table_v2_op.cu
@@ -110,7 +110,7 @@ class LookupTableV2CUDAKernel : public framework::OpKernel<T> {
     size_t K = ids_t->numel();
 
     dim3 threads(256, 4);
-    dim3 grids(80, 1);
+    dim3 grids(160, 1);
 
     // copy GPU memory to CPU pinned memory
     framework::Vector<int64_t> ids;
@@ -132,12 +132,12 @@ class LookupTableV2CUDAKernel : public framework::OpKernel<T> {
 
     if (padding_idx == -1)
       LookupTableV2<
-          T, 256, 4, 80,
+          T, 256, 4, 160,
           false><<<grids, threads, 0, context.cuda_device_context().stream()>>>(
           output, table, ids_p, N, K, D, padding_idx);
     else
       LookupTableV2<
-          T, 256, 4, 80,
+          T, 256, 4, 160,
           true><<<grids, threads, 0, context.cuda_device_context().stream()>>>(
           output, table, ids_p, N, K, D, padding_idx);
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Adjust Grid and Group size of LookupTableV2/LookupTable

Profiled in Docker with nsys
Tesla V100-SXM2, CUDA 10.1, NVIDIA-SMI 440.33.01, Driver Version: 440.33.01

|configuration|inputshape|type|size|is_sparse|timing|
|:---:|:---:|:---:|:---:|:---:|:---:|
|80, 128x8|[16,16]|fp16|[2,768]|false|4288ns|
|160, 256x4|[512, 512]|fp32|[4000000, 128]|false| 485933 ns|
|160, 256x4|[512, 512]|fp32|[2000000, 256]|false| 762171 ns|
|160, 256x4|[512, 512]|fp32|[1000000, 512]|false| 1489623.5 ns|

for input(512, 512) and size(4000000, 128), LookupTable

|configuration|speedup|
|:---:|:---:|
|160,256x4|6.9x|
|8,128x8(current)|1x|
