### PR TITLE
add deprecated decorator, remove alias for cumsum op

### DIFF
--- a/python/paddle/fluid/layers/ops.py
+++ b/python/paddle/fluid/layers/ops.py
@@ -18,6 +18,7 @@ from .layer_function_generator import generate_layer_fn, generate_activation_fn,
 from .. import core
 from ..framework import convert_np_dtype_to_dtype_, Variable
 from ..data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
+from paddle.utils import deprecated
 
 __activations_noattr__ = [
     'sigmoid',
@@ -502,6 +503,10 @@ __all__ += ['cumsum']
 _cum_sum_ = generate_layer_fn('cumsum')
 
 
+@deprecated(
+    since="2.0.0",
+    update_to="paddle.cumsum",
+    reason="New APIs for Paddle 2.0 are coming.")
 def cumsum(x, axis=None, exclusive=None, reverse=None):
     check_type(x, 'x', (Variable), 'cumsum')
     locals_var = locals().copy()

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1546,9 +1546,6 @@ ${comment}
 
 def cumsum(x, axis=None, dtype=None, name=None):
     """
-	:alias_main: paddle.cumsum
-	:alias: paddle.cumsum,paddle.tensor.cumsum,paddle.tensor.math.cumsum
-
     The cumulative sum of the elements along a given axis. The first element of the result is the same of the first element of the input. 
 
     Args:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
add deprecated decorator, remove alias for cumsum op
warning展示：
![image](https://user-images.githubusercontent.com/30695251/89857444-aff47180-dbce-11ea-9790-92322cba07fb.png)
