### PR TITLE
modify inference and py35 docker of branch 1.8

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.20.0
-numpy>=1.12, <=1.16.4 ; python_version<"3.5"
+numpy>=1.12, <=1.16.4 ; python_version<="3.6"
 numpy>=1.12 ; python_version>="3.5"
 protobuf>=3.1.0
 gast>=0.3.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.20.0
-numpy>=1.12, <=1.16.4 ; python_version<="3.6"
+numpy==1.16.4 ; python_version<="3.6"
 numpy>=1.12 ; python_version>="3.5"
 protobuf>=3.1.0
 gast>=0.3.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.20.0
-numpy==1.12 ; python_version<="3.6"
+numpy>=1.12, <=1.16.4 ; python_version<"3.5"
 numpy>=1.12 ; python_version>="3.5"
 protobuf>=3.1.0
 gast>=0.3.3

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.20.0
-numpy==1.16.4 ; python_version<="3.6"
+numpy==1.12 ; python_version<="3.6"
 numpy>=1.12 ; python_version>="3.5"
 protobuf>=3.1.0
 gast>=0.3.3

--- a/tools/manylinux1/Dockerfile.CI35-GCC4.8
+++ b/tools/manylinux1/Dockerfile.CI35-GCC4.8
@@ -35,11 +35,11 @@ RUN cd /opt && wget -q --no-check-certificate https://github.com/google/protobuf
     cd protobuf-3.6.1 && ./configure && make -j4 && make install && cd .. && rm -f protobuf-cpp-3.6.1.tar.gz
 
 # ccache 3.7.9
- RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
-     tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
-     ./configure -prefix=/usr/local/ccache-3.7.9 && \
-     make -j8 && make install && \
-     ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
+RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+    tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+    ./configure -prefix=/usr/local/ccache-3.7.9 && \
+    make -j8 && make install && \
+    ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
 
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O /root/requirements.txt
 

--- a/tools/manylinux1/Dockerfile.CI35-GCC4.8
+++ b/tools/manylinux1/Dockerfile.CI35-GCC4.8
@@ -65,4 +65,8 @@ RUN LD_LIBRARY_PATH=/opt/_internal/cpython-2.7.11-ucs4/lib:${LD_LIBRARY_PATH} /o
 RUN wget -O /opt/swig-2.0.12.tar.gz https://sourceforge.net/projects/swig/files/swig/swig-2.0.12/swig-2.0.12.tar.gz/download && \
     cd /opt && tar xzf swig-2.0.12.tar.gz && cd /opt/swig-2.0.12 && ./configure && make && make install && cd /opt && rm swig-2.0.12.tar.gz
 
+# Install hadoop
+RUN wget --no-check-certificate  -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz && \
+     tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/
+
 CMD ["bash", "/paddle/paddle/scripts/docker/build.sh"]

--- a/tools/manylinux1/Dockerfile.CI35-GCC4.8
+++ b/tools/manylinux1/Dockerfile.CI35-GCC4.8
@@ -34,12 +34,12 @@ RUN cd /opt && wget -q --no-check-certificate https://github.com/google/protobuf
     tar xzf protobuf-cpp-3.6.1.tar.gz && \
     cd protobuf-3.6.1 && ./configure && make -j4 && make install && cd .. && rm -f protobuf-cpp-3.6.1.tar.gz
 
-# ccache 3.6
-RUN wget https://paddle-ci.cdn.bcebos.com/ccache-3.6.tar.gz && \
-    tar xf ccache-3.6.tar.gz && mkdir /usr/local/ccache-3.6 && cd ccache-3.6 && \
-    ./configure -prefix=/usr/local/ccache-3.6 && \
-    make -j8 && make install && \
-    ln -s /usr/local/ccache-3.6/bin/ccache /usr/local/bin/ccache
+# ccache 3.7.9
+ RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+     tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+     ./configure -prefix=/usr/local/ccache-3.7.9 && \
+     make -j8 && make install && \
+     ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
 
 RUN wget https://raw.githubusercontent.com/PaddlePaddle/Paddle/develop/python/requirements.txt -O /root/requirements.txt
 

--- a/tools/manylinux1/Dockerfile.CI35-GCC4.8
+++ b/tools/manylinux1/Dockerfile.CI35-GCC4.8
@@ -65,7 +65,6 @@ RUN LD_LIBRARY_PATH=/opt/_internal/cpython-2.7.11-ucs4/lib:${LD_LIBRARY_PATH} /o
 RUN wget -O /opt/swig-2.0.12.tar.gz https://sourceforge.net/projects/swig/files/swig/swig-2.0.12/swig-2.0.12.tar.gz/download && \
     cd /opt && tar xzf swig-2.0.12.tar.gz && cd /opt/swig-2.0.12 && ./configure && make && make install && cd /opt && rm swig-2.0.12.tar.gz
 
-# Install hadoop
 RUN wget --no-check-certificate  -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz && \
      tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/
 

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -23,7 +23,7 @@ COPY ./paddle/scripts/docker/root/ /root/
 RUN apt-get update && \
     apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
     libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev \
-    xz-utils tk-dev libffi-dev liblzma-dev
+    xz-utils tk-dev libffi-dev liblzma-dev openmpi-bin openmpi-doc libopenmpi-dev
 
 # Downgrade gcc&&g++
 RUN apt-get update
@@ -108,6 +108,7 @@ RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
 RUN python setup.py install && \
   python3.7 setup.py install && \
+  python3.6 setup.py install && \
   python3 setup.py install
 
 WORKDIR /home

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -160,17 +160,17 @@ RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
     pip --no-cache-dir install -U docopt PyYAML sphinx==1.5.6 && \
     pip --no-cache-dir install sphinx-rtd-theme==0.1.9 recommonmark
 
-RUN pip3 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip3 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
+RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
     pip3 --no-cache-dir install opencv-python && \
-    pip3.6 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip3.6 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
+    pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
     pip3.6 --no-cache-dir install opencv-python && \
-    pip3.7 --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip3.7 --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
+    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.7 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
     pip3.7 --no-cache-dir install opencv-python && \
-    pip --no-cache-dir install 'pre-commit==1.10.4' 'ipython==5.3.0' && \
-    pip --no-cache-dir install 'ipykernel==4.6.0' 'jupyter==1.0.0' && \
+    pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
     pip --no-cache-dir install opencv-python
 
 #For docstring checker

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -106,7 +106,10 @@ WORKDIR /home
 RUN wget https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-18.0.tar.gz
 RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
-RUN python setup.py install
+RUN python setup.py install && \
+  python3.7 setup.py install && \
+  python3.6 setup.py install && \
+  python3 setup.py install
 
 WORKDIR /home
 RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-18.0.tar.gz && \

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -162,16 +162,16 @@ RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
 
 RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3 --no-cache-dir install opencv-python==4.2.0 && \
+    pip3 --no-cache-dir install opencv-python==4.2.0.32 && \
     pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3.6 --no-cache-dir install opencv-python==4.2.0 && \
+    pip3.6 --no-cache-dir install opencv-python==4.2.0.32 && \
     pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.7 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3.7 --no-cache-dir install opencv-python==4.2.0 && \
+    pip3.7 --no-cache-dir install opencv-python==4.2.0.32 && \
     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip --no-cache-dir install opencv-python==4.2.0
+    pip --no-cache-dir install opencv-python
 
 #For docstring checker
 RUN pip3 --no-cache-dir install pylint pytest astroid isort

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -107,6 +107,13 @@ RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
 RUN python setup.py install
 
+RUN wget https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-18.0.tar.gz && tar -zxvf pip-18.0.tar.gz
+WORKDIR pip-18.0
+RUN python setup.py install && \
+  python3.7 setup.py install && \
+  python3.6 setup.py install && \
+  python3 setup.py install
+
 WORKDIR /home
 RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-18.0.tar.gz && \
     rm -r Python-$version setuptools-40.6.2 pip-18.0

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -162,16 +162,16 @@ RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
 
 RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3 --no-cache-dir install opencv-python && \
+    pip3 --no-cache-dir install opencv-python==4.2.0 && \
     pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3.6 --no-cache-dir install opencv-python && \
+    pip3.6 --no-cache-dir install opencv-python==4.2.0 && \
     pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.7 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3.7 --no-cache-dir install opencv-python && \
+    pip3.7 --no-cache-dir install opencv-python==4.2.0 && \
     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip --no-cache-dir install opencv-python
+    pip --no-cache-dir install opencv-python==4.2.0
 
 #For docstring checker
 RUN pip3 --no-cache-dir install pylint pytest astroid isort

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -102,17 +102,11 @@ WORKDIR /home/setuptools-40.6.2
 RUN python setup.py build
 RUN python setup.py install
 WORKDIR /home
+
 RUN wget https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-18.0.tar.gz
 RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
 RUN python setup.py install
-
-RUN wget https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-18.0.tar.gz && tar -zxvf pip-18.0.tar.gz
-WORKDIR pip-18.0
-RUN python setup.py install && \
-  python3.7 setup.py install && \
-  python3.6 setup.py install && \
-  python3 setup.py install
 
 WORKDIR /home
 RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-18.0.tar.gz && \

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -106,10 +106,7 @@ WORKDIR /home
 RUN wget https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-18.0.tar.gz
 RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
-RUN python setup.py install && \
-  python3.7 setup.py install && \
-  python3.6 setup.py install && \
-  python3 setup.py install
+RUN python setup.py install
 
 WORKDIR /home
 RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-18.0.tar.gz && \

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -171,7 +171,7 @@ RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.7 --no-cache-dir install opencv-python==4.2.0.32 && \
     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip --no-cache-dir install opencv-python
+    pip --no-cache-dir install opencv-python==4.2.0.32
 
 #For docstring checker
 RUN pip3 --no-cache-dir install pylint pytest astroid isort

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -205,6 +205,10 @@ RUN git clone https://github.com/woboq/woboq_codebrowser /woboq && \
            -DCMAKE_BUILD_TYPE=Release . \
      make)
 
+# Install hadoop
+RUN wget --no-check-certificate  -q https://paddle-edl.bj.bcebos.com/hadoop-2.7.7.tar.gz && \
+     tar -xzf  hadoop-2.7.7.tar.gz && mv hadoop-2.7.7 /usr/local/
+
 # ar mishandles 4GB files
 # https://sourceware.org/bugzilla/show_bug.cgi?id=14625
 # remove them when apt-get support 2.27 and higher version

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -162,7 +162,7 @@ RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
 
 RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3 --no-cache-dir install opencv-python && \
+    pip3 --no-cache-dir install opencv-python==3.1.0.0 && \
     pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
     pip3.6 --no-cache-dir install opencv-python==4.2.0.32 && \
@@ -171,7 +171,7 @@ RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.7 --no-cache-dir install opencv-python==4.2.0.32 && \
     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip --no-cache-dir install opencv-python
+    pip --no-cache-dir install opencv-python==3.1.0.0
 
 #For docstring checker
 RUN pip3 --no-cache-dir install pylint pytest astroid isort

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -219,11 +219,6 @@ RUN wget -q https://launchpad.net/ubuntu/+archive/primary/+sourcefiles/binutils/
     cd binutils-2.27 && \
     ./configure && make -j && make install && cd .. && rm -rf binutils-2.27 binutils_2.27.orig.tar.gz
 
-RUN wget --no-check-certificate https://pslib.bj.bcebos.com/openmpi-1.4.5.tar.gz && tar -xzf openmpi-1.4.5.tar.gz && \
-    cd openmpi-1.4.5 && ./configure --prefix=/usr/local && make all -j8 && make install -j8 && \
-    export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH && export PATH=/usr/local/bin:$PATH && cd .. && \
-    rm -rf openmpi-1.4.5.tar.gz && pip --no-cache-dir install mpi4py && ln -fs /bin/bash /bin/sh && \
-    apt-get install libprotobuf-dev -y
 RUN pip --no-cache-dir install -U netifaces==0.10.9
 
 # Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -106,7 +106,8 @@ WORKDIR /home
 RUN wget https://files.pythonhosted.org/packages/69/81/52b68d0a4de760a2f1979b0931ba7889202f302072cc7a0d614211bc7579/pip-18.0.tar.gz
 RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
-RUN python setup.py install
+RUN python setup.py install && \
+    python3 setup.py install
 
 WORKDIR /home
 RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-18.0.tar.gz && \

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -162,7 +162,7 @@ RUN pip3 --no-cache-dir install -U wheel py-cpuinfo==5.0.0 && \
 
 RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip3 --no-cache-dir install opencv-python==4.2.0.32 && \
+    pip3 --no-cache-dir install opencv-python && \
     pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.6 --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
     pip3.6 --no-cache-dir install opencv-python==4.2.0.32 && \
@@ -171,7 +171,7 @@ RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip3.7 --no-cache-dir install opencv-python==4.2.0.32 && \
     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
     pip --no-cache-dir install ipykernel==4.6.0 jupyter==1.0.0 && \
-    pip --no-cache-dir install opencv-python==4.2.0.32
+    pip --no-cache-dir install opencv-python
 
 #For docstring checker
 RUN pip3 --no-cache-dir install pylint pytest astroid isort

--- a/tools/manylinux1/Dockerfile.Inference
+++ b/tools/manylinux1/Dockerfile.Inference
@@ -108,7 +108,6 @@ RUN tar -zxvf pip-18.0.tar.gz
 WORKDIR pip-18.0
 RUN python setup.py install && \
   python3.7 setup.py install && \
-  python3.6 setup.py install && \
   python3 setup.py install
 
 WORKDIR /home


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
有RD反馈，1.8镜像缺少hadoop
所以1.8inference和py35的dockerfile，与develop做下同步

py35镜像
- 增加hadoop
- 升级下ccache

coverage镜像
- 增加hadoop
- 升级py35的pip版本
- 低于python36的版本需要指定安装版本低于等于3.1.0.0的opencv-python版本，py36和py37则指定安装4.2.0.32版本
   取消wget安装openmpi，改为apt-get安装
  
