### PR TITLE
[Dy2Stat] Removes temporary files created during the transformation of dygraph to static graph

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 import traceback
 
@@ -38,7 +39,25 @@ def attach_error_data(error, in_runtime=False):
 
     setattr(error, ERROR_DATA, error_data)
 
+    remove_static_file()
     return error
+
+
+def remove_static_file():
+    """
+    Removes temporary files created during the transformation of dygraph to static graph.
+    """
+    del_files = set()
+    for loc in global_origin_info_map:
+        static_filepath = loc[0]
+        del_files.add(static_filepath)
+
+        filename, extension = os.path.splitext(static_filepath)
+        del_files.add(filename + ".pyc")
+
+    for filepath in del_files:
+        if os.path.exists(filepath):
+            os.remove(filepath)
 
 
 class TraceBackFrame(OriginInfo):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -368,6 +368,11 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
     TODO: If only decorate one of inner function instead of decorating the main
     function, the other inner functions are invisible for the decorated function.
     """
+
+    def remove_file(filepath):
+        if os.path.exists(filepath):
+            os.remove(filepath)
+
     source = ast_to_source_code(ast_root)
     import_fluid = "import paddle.fluid as fluid\n"
     source = import_fluid + source
@@ -382,7 +387,9 @@ def ast_to_func(ast_root, dyfunc, delete_on_exit=True):
         f.write(source)
 
     if delete_on_exit:
-        atexit.register(lambda: os.remove(f.name))
+        atexit.register(lambda: remove_file(f.name))
+        atexit.register(lambda: remove_file(f.name[:-3] + ".pyc"))
+
     module = imp.load_source(module_name, f.name)
     func_name = dyfunc.__name__
     if not hasattr(module, func_name):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1.Bug fixes: Removes temporary files `*.pyc` created during the transformation of dygraph to static graph.
2.New features: Removes  temporary files`*.py` and  `*.pyc` when an exception is raised