### PR TITLE
slice and share data with cudnn weight

### DIFF
--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -150,6 +150,8 @@ class Tensor {
 
   void set_layout(const DataLayout layout) { layout_ = layout; }
 
+  void set_offset(const size_t offset) { offset_ = offset; }
+
   void clear() {
     holder_ = nullptr;
     offset_ = 0;

--- a/paddle/fluid/operators/cudnn_lstm_op.cc
+++ b/paddle/fluid/operators/cudnn_lstm_op.cc
@@ -137,6 +137,16 @@ class CudnnLSTMOpMaker : public framework::OpProtoAndCheckerMaker {
               "is_bidirec is False"
               "and When is_bidirect is True, the shape will be (num_layers*2 x "
               "batch_size x hidden_size*2)");
+    AddOutput("WeightHh",
+              "(Tensor List), stores weight_hh and share data with W. ")
+        .AsDuplicable();
+    AddOutput("WeightIh",
+              "(Tensor List), stores weight_ih and share data with W.")
+        .AsDuplicable();
+    AddOutput("BiasHh", "(Tensor List), stores bias_hh and share data with W.")
+        .AsDuplicable();
+    AddOutput("BiasIh", "(Tensor List), stores bias_ih and share data with W. ")
+        .AsDuplicable();
     AddAttr<float>(
         "dropout_prob",
         "dropout prob of the dropout op"

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -2281,23 +2281,19 @@ def lstm(input,
     input_shape = list(input.shape)
     input_size = input_shape[-1]
     weight_size = 0
+    n_direction = 2 if is_bidirec else 1
+    gate_size = hidden_size * 4
+
     for i in range(num_layers):
         if i == 0:
-            input_weight_size = (input_size * hidden_size) * 4
+            input_weight_size = gate_size * input_size
         else:
-            if is_bidirec:
-                input_weight_size = (hidden_size * 2 * hidden_size) * 4
-            else:
-                input_weight_size = (hidden_size * hidden_size) * 4
+            input_weight_size = gate_size * hidden_size * n_direction
 
-        hidden_weight_size = (hidden_size * hidden_size) * 4
+        hidden_weight_size = gate_size * hidden_size
 
-        if is_bidirec:
-            weight_size += (input_weight_size + hidden_weight_size) * 2
-            weight_size += hidden_size * 8 * 2
-        else:
-            weight_size += input_weight_size + hidden_weight_size
-            weight_size += hidden_size * 8
+        weight_size += (input_weight_size + hidden_weight_size)
+        weight_size += gate_size * 2
 
     weight = helper.create_parameter(
         attr=helper.param_attr,
@@ -2308,6 +2304,22 @@ def lstm(input,
     out = helper.create_variable_for_type_inference(dtype)
     last_h = helper.create_variable_for_type_inference(dtype)
     last_c = helper.create_variable_for_type_inference(dtype)
+    weight_ih = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
+    weight_hh = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
+    bias_ih = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
+    bias_hh = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
     reserve = helper.create_variable_for_type_inference(
         dtype=core.VarDesc.VarType.UINT8, stop_gradient=True)
     state_out = helper.create_variable_for_type_inference(
@@ -2326,6 +2338,10 @@ def lstm(input,
             'Out': out,
             'LastH': last_h,
             'LastC': last_c,
+            'WeightIh': weight_ih,
+            'WeightHh': weight_hh,
+            'BiasIh': bias_ih,
+            'BiasHh': bias_hh,
             'Reserve': reserve,
             'StateOut': state_out,
         },

--- a/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
@@ -161,14 +161,22 @@ class TestCUDNNLstmOp(OpTest):
             "LastH": last_hidden,
             'LastC': last_cell,
             'Reserve': np.ndarray((400)).astype("uint8"),
-            'StateOut': state_out
+            'StateOut': state_out,
+            'WeightIh': [('WeightIh%d' % i, state_out) for i in range(1)],
+            'WeightHh': [('WeightHh%d' % i, state_out) for i in range(1)],
+            'BiasIh': [('BiasIh%d' % i, state_out) for i in range(1)],
+            'BiasHh': [('BiasHh%d' % i, state_out) for i in range(1)],
         }
 
     def test_output_with_place(self):
         # depend on the scope structure
         place = core.CUDAPlace(0)
         self.check_output_with_place(
-            place, no_check_set=['Reserve', 'StateOut'])
+            place,
+            no_check_set=[
+                'Reserve', 'StateOut', 'WeightIh', 'WeightHh', 'BiasIh',
+                'BiasHh'
+            ])
 
     def test_grad_with_place(self):
         # depend on the scope structure


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs 

### Describe
CUDNN与非CUDNN实现参数转换

内容：CUDNN使用特定的参数格式，若自动切换CUDNN，也需要自动转换参数（CUDNN实现中使用合并的参数，非CUDNN实现参数分开存放）

- 在C++端完成参数转换，并将新参数和原参数的共享存储，新参数对用户隐藏，用户仍使用原参数；并在检测到参数不合要求时（如某个参数指向了其他参数而不再连续）在执行时重新转换并打warning（pytorch的方法），较多内容需要由C++端完成。