### PR TITLE
refine the usage of numpy element fetch for Ops test=develop

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1511,7 +1511,7 @@ def array_write(x, i, array=None):
         assert i.shape == [
             1
         ], "The shape of index 'i' should be [1] in dygraph mode"
-        i = i.numpy()[0]
+        i = i.numpy().item(0)
         if array is None:
             array = create_array(x.dtype)
         assert isinstance(
@@ -1976,7 +1976,7 @@ def array_read(array, i):
         assert i.shape == [
             1
         ], "The shape of index 'i' should be [1] in dygraph mode"
-        i = i.numpy()[0].item()
+        i = i.numpy().item(0)
         return array[i]
 
     check_variable_and_dtype(i, 'i', ['int64'], 'array_read')

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1976,7 +1976,7 @@ def array_read(array, i):
         assert i.shape == [
             1
         ], "The shape of index 'i' should be [1] in dygraph mode"
-        i = i.numpy()[0]
+        i = i.numpy()[0].item()
         return array[i]
 
     check_variable_and_dtype(i, 'i', ['int64'], 'array_read')

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -4868,7 +4868,7 @@ def split(input, num_or_sections, dim=-1, name=None):
 
         if isinstance(dim, Variable):
             dim = dim.numpy()
-            dim = dim[0]
+            dim = dim.item(0)
         dim = (len(input.shape) + dim) if dim < 0 else dim
         attrs += ('axis', dim)
 
@@ -5912,7 +5912,7 @@ def one_hot(input, depth, allow_out_of_range=False):
             depth = depth.numpy()
             assert depth.shape == (
                 1, ), "depth of type Variable should have shape [1]"
-            depth = depth[0]
+            depth = depth.item(0)
         out = core.ops.one_hot(input, 'depth', depth, 'allow_out_of_range',
                                allow_out_of_range)
         out.stop_gradient = True
@@ -6094,7 +6094,7 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             )
         if isinstance(shape, (list, tuple)):
             shape = [
-                item.numpy()[0] if isinstance(item, Variable) else item
+                item.numpy().item(0) if isinstance(item, Variable) else item
                 for item in shape
             ]
             out, _ = core.ops.reshape2(x, 'shape', shape)
@@ -10222,7 +10222,7 @@ def expand(x, expand_times, name=None):
     if in_dygraph_mode():
         if isinstance(expand_times, (list, tuple)):
             expand_times = [
-                item.numpy()[0] if isinstance(item, Variable) else item
+                item.numpy().item(0) if isinstance(item, Variable) else item
                 for item in expand_times
             ]
 
@@ -10833,11 +10833,11 @@ def slice(input, axes, starts, ends):
         if isinstance(starts, (list, tuple)) and isinstance(ends,
                                                             (list, tuple)):
             starts = [
-                item.numpy()[0] if isinstance(item, Variable) else item
+                item.numpy().item(0) if isinstance(item, Variable) else item
                 for item in starts
             ]
             ends = [
-                item.numpy()[0] if isinstance(item, Variable) else item
+                item.numpy().item(0) if isinstance(item, Variable) else item
                 for item in ends
             ]
 

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -317,7 +317,7 @@ def concat(input, axis=0, name=None):
     if in_dygraph_mode():
         if isinstance(axis, Variable):
             axis = axis.numpy()
-            axis = axis[0]
+            axis = axis.item(0)
         return core.ops.concat(input, 'axis', axis)
 
     check_type(input, 'input', (list, tuple, Variable), 'concat')
@@ -699,9 +699,9 @@ def fill_constant(shape, dtype, value, force_cpu=False, out=None, name=None):
 
         if isinstance(value, Variable):
             if dtype in ['int64', 'int32']:
-                attrs['str_value'] = str(int(value.numpy()))
+                attrs['str_value'] = str(int(value.numpy().item(0)))
             else:
-                attrs['str_value'] = str(float(value.numpy()))
+                attrs['str_value'] = str(float(value.numpy().item(0)))
 
         core.ops.fill_constant(out, 'value',
                                float(value), 'force_cpu', force_cpu, 'dtype',

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -313,6 +313,8 @@ class TestFillConstantImperative(unittest.TestCase):
                 shape=shape, dtype='float32', value=1.1)
             res3 = fluid.layers.fill_constant(
                 shape=shape, dtype='float32', value=val)
+            res3 = fluid.layers.fill_constant(
+                shape=shape, dtype='int32', value=88)
             assert np.array_equal(
                 res1.numpy(), np.full(
                     [1, 2], 1.1, dtype="float32"))
@@ -322,6 +324,9 @@ class TestFillConstantImperative(unittest.TestCase):
             assert np.array_equal(
                 res3.numpy(), np.full(
                     [1, 2], 1.1, dtype="float32"))
+            assert np.array_equal(
+                res3.numpy(), np.full(
+                    [1, 2], 88, dtype="int32"))
 
 
 class TestFillConstantOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -305,8 +305,10 @@ class TestFillConstantImperative(unittest.TestCase):
         with fluid.dygraph.guard():
             data1 = np.array([1, 2]).astype('int32')
             data2 = np.array([1.1]).astype('float32')
+            data3 = np.array([88]).astype('int32')
             shape = fluid.dygraph.to_variable(data1)
             val = fluid.dygraph.to_variable(data2)
+            value = fluid.dygraph.to_variable(data3)
             res1 = fluid.layers.fill_constant(
                 shape=[1, 2], dtype='float32', value=1.1)
             res2 = fluid.layers.fill_constant(
@@ -314,7 +316,7 @@ class TestFillConstantImperative(unittest.TestCase):
             res3 = fluid.layers.fill_constant(
                 shape=shape, dtype='float32', value=val)
             res4 = fluid.layers.fill_constant(
-                shape=shape, dtype='int32', value=88)
+                shape=shape, dtype='int32', value=value)
             assert np.array_equal(
                 res1.numpy(), np.full(
                     [1, 2], 1.1, dtype="float32"))

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -313,7 +313,7 @@ class TestFillConstantImperative(unittest.TestCase):
                 shape=shape, dtype='float32', value=1.1)
             res3 = fluid.layers.fill_constant(
                 shape=shape, dtype='float32', value=val)
-            res3 = fluid.layers.fill_constant(
+            res4 = fluid.layers.fill_constant(
                 shape=shape, dtype='int32', value=88)
             assert np.array_equal(
                 res1.numpy(), np.full(
@@ -325,7 +325,7 @@ class TestFillConstantImperative(unittest.TestCase):
                 res3.numpy(), np.full(
                     [1, 2], 1.1, dtype="float32"))
             assert np.array_equal(
-                res3.numpy(), np.full(
+                res4.numpy(), np.full(
                     [1, 2], 88, dtype="int32"))
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
numpy的数据fetch 应该使用item,直接使用下标取值返回的并不是存储的数据类型，而是类似numpy.float64这种类型 可能导致C++报错异常(比如在axis 为tensor 的时候 传入float类型但是C++端不报错 不符合预期 这种就是数据类型异常导致的 )