### PR TITLE
Remove original name for alias APIs

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -210,8 +210,6 @@ from .framework import BackwardStrategy  #DEFINE_ALIAS
 from .framework import to_variable  #DEFINE_ALIAS
 from .framework import grad  #DEFINE_ALIAS
 from .framework import no_grad  #DEFINE_ALIAS
-from .framework import save_dygraph  #DEFINE_ALIAS
-from .framework import load_dygraph  #DEFINE_ALIAS
 from .framework import save  #DEFINE_ALIAS
 from .framework import load  #DEFINE_ALIAS
 from .framework import prepare_context  #DEFINE_ALIAS
@@ -238,8 +236,6 @@ from .fluid.data import data
 
 from . import incubate
 from .incubate import hapi
-from .fluid.dygraph.base import enable_dygraph  #DEFINE_ALIAS
-from .fluid.dygraph.base import disable_dygraph  #DEFINE_ALIAS
 from .fluid.dygraph.base import enable_dygraph as disable_static  #DEFINE_ALIAS
 from .fluid.dygraph.base import disable_dygraph as enable_static  #DEFINE_ALIAS
 from .fluid.framework import in_dygraph_mode as in_dynamic_mode  #DEFINE_ALIAS

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -234,19 +234,10 @@ class TestNnFunctionalSoftmaxApi(unittest.TestCase):
     def test_api_static(self):
         with program_guard(Program()):
             x = paddle.data('X', self.x_np.shape, 'float32')
-<<<<<<< 4443e1d785e18f6e7c880a7a7ae1edb6bea19e57
             out = F.softmax(x)
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'X': self.x_np}, fetch_list=[out])
         self.assertEqual(np.allclose(self.out_ref, res[0]), True)
-=======
-            out = paddle.nn.functional.softmax(x)
-
-        exe = paddle.static.Executor(self.place)
-        res = exe.run(train_program, feed={'X': self.x_np}, fetch_list=[out])
-
-        assert np.allclose(self.out_ref, res[0])
->>>>>>> fixed static module
 
     def test_api_imperative(self):
         paddle.disable_static(self.place)

--- a/python/paddle/fluid/tests/unittests/test_softmax_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_op.py
@@ -234,10 +234,19 @@ class TestNnFunctionalSoftmaxApi(unittest.TestCase):
     def test_api_static(self):
         with program_guard(Program()):
             x = paddle.data('X', self.x_np.shape, 'float32')
+<<<<<<< 4443e1d785e18f6e7c880a7a7ae1edb6bea19e57
             out = F.softmax(x)
             exe = paddle.static.Executor(self.place)
             res = exe.run(feed={'X': self.x_np}, fetch_list=[out])
         self.assertEqual(np.allclose(self.out_ref, res[0]), True)
+=======
+            out = paddle.nn.functional.softmax(x)
+
+        exe = paddle.static.Executor(self.place)
+        res = exe.run(train_program, feed={'X': self.x_np}, fetch_list=[out])
+
+        assert np.allclose(self.out_ref, res[0])
+>>>>>>> fixed static module
 
     def test_api_imperative(self):
         paddle.disable_static(self.place)

--- a/python/paddle/framework/__init__.py
+++ b/python/paddle/framework/__init__.py
@@ -43,8 +43,6 @@ from paddle.fluid import core  #DEFINE_ALIAS
 from ..fluid.dygraph.base import no_grad  #DEFINE_ALIAS
 from ..fluid.dygraph.base import to_variable  #DEFINE_ALIAS
 from ..fluid.dygraph.base import grad  #DEFINE_ALIAS
-from ..fluid.dygraph.checkpoint import load_dygraph  #DEFINE_ALIAS
-from ..fluid.dygraph.checkpoint import save_dygraph  #DEFINE_ALIAS
 from ..fluid.dygraph.checkpoint import load_dygraph as load  #DEFINE_ALIAS
 from ..fluid.dygraph.checkpoint import save_dygraph as save  #DEFINE_ALIAS
 from ..fluid.dygraph.parallel import prepare_context  #DEFINE_ALIAS

--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -16,7 +16,6 @@ from ..fluid.dygraph.jit import save  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import load  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import SaveLoadConfig  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import TracedLayer  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import declarative as __impl__  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import declarative as to_static  #DEFINE_ALIAS
 from ..fluid.dygraph import ProgramTranslator  #DEFINE_ALIAS
 from ..fluid.dygraph.io import TranslatedLayer  #DEFINE_ALIAS


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
In the implementation of Paddle 2.0 directory migration（PR #25898）, we both import the alias name and original name for alias APIs. For example, in paddle/\__init__.py
```
from .fluid.dygraph.base import enable_dygraph  #DEFINE_ALIAS
from .fluid.dygraph.base import disable_dygraph  #DEFINE_ALIAS
from .fluid.dygraph.base import enable_dygraph as disable_static  #DEFINE_ALIAS
from .fluid.dygraph.base import disable_dygraph as enable_static  #DEFINE_ALIAS
```
Importing original name is unnecessary, however, the algorithm used to print all the specifications of APIs in `print_signatures.py` use the original name. If we don't import original name, CI can't pass.
After solving the problem of `print_signatures.py` in  PR #26143, we can remove the unnecessary original name. This PR is used to remove the original name for alias APIs.
