### PR TITLE
Change pairwise distance api name eps to epsilon

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_pairwise_distance.py
+++ b/python/paddle/fluid/tests/unittests/test_pairwise_distance.py
@@ -20,11 +20,11 @@ import numpy as np
 import unittest
 
 
-def pairwise_distance(x, y, p=2.0, eps=1e-6, keepdim=False):
+def pairwise_distance(x, y, p=2.0, epsilon=1e-6, keepdim=False):
     return np.linalg.norm(x - y, ord=p, axis=1, keepdims=keepdim)
 
 
-def test_static(x_np, y_np, p=2.0, eps=1e-6, keepdim=False):
+def test_static(x_np, y_np, p=2.0, epsilon=1e-6, keepdim=False):
     prog = paddle.static.Program()
     startup_prog = paddle.static.Program()
 
@@ -35,7 +35,7 @@ def test_static(x_np, y_np, p=2.0, eps=1e-6, keepdim=False):
         x = paddle.data(name='x', shape=x_np.shape, dtype=x_np.dtype)
         y = paddle.data(name='y', shape=y_np.shape, dtype=x_np.dtype)
         dist = paddle.nn.layer.distance.PairwiseDistance(
-            p=p, eps=eps, keepdim=keepdim)
+            p=p, epsilon=epsilon, keepdim=keepdim)
         distance = dist(x, y)
         exe = paddle.static.Executor(place)
         static_ret = exe.run(prog,
@@ -46,12 +46,12 @@ def test_static(x_np, y_np, p=2.0, eps=1e-6, keepdim=False):
     return static_ret
 
 
-def test_dygraph(x_np, y_np, p=2.0, eps=1e-6, keepdim=False):
+def test_dygraph(x_np, y_np, p=2.0, epsilon=1e-6, keepdim=False):
     paddle.disable_static()
     x = paddle.to_variable(x_np)
     y = paddle.to_variable(y_np)
     dist = paddle.nn.layer.distance.PairwiseDistance(
-        p=p, eps=eps, keepdim=keepdim)
+        p=p, epsilon=epsilon, keepdim=keepdim)
     distance = dist(x, y)
     dygraph_ret = distance.numpy()
     paddle.enable_static()

--- a/python/paddle/nn/layer/distance.py
+++ b/python/paddle/nn/layer/distance.py
@@ -34,7 +34,7 @@ class PairwiseDistance(layers.Layer):
 
     Parameters:
         p (float): The order of norm. The default value is 2.
-        eps (float, optional): Add small value to avoid division by zero,
+        epsilon (float, optional): Add small value to avoid division by zero,
             default value is 1e-6.
         keepdim (bool, optional): Whether to reserve the reduced dimension
             in the output Tensor. The result tensor is one dimension less than
@@ -66,21 +66,21 @@ class PairwiseDistance(layers.Layer):
 
     """
 
-    def __init__(self, p=2., eps=1e-6, keepdim=False, name=None):
+    def __init__(self, p=2., epsilon=1e-6, keepdim=False, name=None):
         super(PairwiseDistance, self).__init__()
         self.p = p
-        self.eps = eps
+        self.epsilon = epsilon
         self.keepdim = keepdim
         self.name = name
         check_type(self.p, 'porder', (float, int), 'PairwiseDistance')
-        check_type(self.eps, 'epsilon', (float), 'PairwiseDistance')
+        check_type(self.epsilon, 'epsilon', (float), 'PairwiseDistance')
         check_type(self.keepdim, 'keepdim', (bool), 'PairwiseDistance')
 
     def forward(self, x, y):
         if in_dygraph_mode():
             sub = core.ops.elementwise_sub(x, y)
             return core.ops.p_norm(sub, 'axis', 1, 'porder', self.p, 'keepdim',
-                                   self.keepdim, 'epsilon', self.eps)
+                                   self.keepdim, 'epsilon', self.epsilon)
 
         check_variable_and_dtype(x, 'x', ['float32', 'float64'],
                                  'PairwiseDistance')
@@ -88,15 +88,14 @@ class PairwiseDistance(layers.Layer):
                                  'PairwiseDistance')
         sub = paddle.elementwise_sub(x, y)
 
-        helper = LayerHelper("p_norm", name=self.name)
+        helper = LayerHelper("PairwiseDistance", name=self.name)
         attrs = {
             'axis': 1,
             'porder': self.p,
             'keepdim': self.keepdim,
-            'epsilon': self.eps,
+            'epsilon': self.epsilon,
         }
-        out = helper.create_variable_for_type_inference(
-            dtype=self._helper.input_dtype(x))
+        out = helper.create_variable_for_type_inference(dtype=x.dtype)
         helper.append_op(
             type='p_norm', inputs={'X': sub}, outputs={'Out': out}, attrs=attrs)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
change the pairwise distance api name eps to epsilon