### PR TITLE
Refine deprecated decorator

### DIFF
--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -18,7 +18,6 @@ decorator to deprecate a function or class
 import warnings
 import functools
 import paddle
-import sys
 
 # NOTE(zhiqiu): Since python 3.2, DeprecationWarning is ignored by default,
 # and since python 3.7, it is once again shown by default when triggered directly by code in __main__.

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -19,6 +19,8 @@ import warnings
 import functools
 import paddle
 
+warnings.simplefilter('default', DeprecationWarning)
+
 
 def deprecated(update_to="", since="", reason=""):
     """Decorate a function to signify its deprecation.
@@ -54,7 +56,7 @@ def deprecated(update_to="", since="", reason=""):
                 "paddle."
             ), 'Argument update_to must start with "paddle.", your value is "{}"'.format(
                 update_to)
-            msg += ' Use "{}" instead.'.format(_update_to)
+            msg += ' Please use "{}" instead.'.format(_update_to)
         if len(_reason) > 0:
             msg += "\n reason: {}".format(_reason)
 
@@ -70,11 +72,8 @@ def deprecated(update_to="", since="", reason=""):
             v_since = [int(i) for i in _since.split(".")]
             v_since += [0] * (4 - len(v_since))
             if paddle.__version__ == "0.0.0" or _since == "" or v_current >= v_since:
-                warnings.simplefilter('always',
-                                      DeprecationWarning)  # turn off filter
                 warnings.warn(msg, category=DeprecationWarning, stacklevel=2)
-                warnings.simplefilter('default',
-                                      DeprecationWarning)  # reset filter
+
             return func(*args, **kwargs)
 
         return wrapper

--- a/python/paddle/utils/deprecated.py
+++ b/python/paddle/utils/deprecated.py
@@ -18,7 +18,14 @@ decorator to deprecate a function or class
 import warnings
 import functools
 import paddle
+import sys
 
+# NOTE(zhiqiu): Since python 3.2, DeprecationWarning is ignored by default,
+# and since python 3.7, it is once again shown by default when triggered directly by code in __main__.
+# See details: https://docs.python.org/3/library/warnings.html#default-warning-filter
+# The following line set DeprecationWarning to show once, which is expected to work in python 3.2 -> 3.6
+# However, doing this could introduce one samll side effect, i.e., the DeprecationWarning which is not issued by @deprecated.
+# The side effect is acceptable, and we will find better way to do this if we could.
 warnings.simplefilter('default', DeprecationWarning)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Refine deprecated decorator, show deprecation warning once.

For the following case, the original  `deprecated` on `reduce_mean` will print too many warnings, this PR fixes that.
```
import paddle

def model(x):
    return paddle.fluid.layers.reduce_mean(x)   # reduce_mean is decorated with @deprecated

paddle.disable_static()
for epoch in range(5):
    for batch in range(100):
        x = paddle.rand([2, 10])
        loss = model(x)
        if batch % 100 == 0:
            print(loss)
```

- before
![image](https://user-images.githubusercontent.com/6888866/90103298-da802f00-dd74-11ea-801f-c2f62292ec7f.png)

- after
![image](https://user-images.githubusercontent.com/6888866/90103311-e0761000-dd74-11ea-884c-76a5884e69a4.png)
