### PR TITLE
fix test_multiprocess_dataloader unittest. test=develop

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -663,30 +663,32 @@ class _DataLoaderIterMultiProcess(_DataLoaderIterBase):
     def _try_put_indices(self):
         assert self._batches_outstanding <= self._outstanding_capacity, \
                     "too many indices have been put to queue"
-        try:
-            # In multi-process mode for IterableDataset, _try_put_indices will
-            # be called both in main process(for our implement has blocking queue,
-            # and blocking queue read is in main process) and thread, which may
-            # cause error: "ValueError: generator already executing", add a lock
-            # for threading save, for _try_put_indices is only a slight function
-            # which is not in data reading pipeline, this lock almost no influence
-            # on performance
-            with self._thread_lock:
+        # In multi-process mode for IterableDataset, _try_put_indices will
+        # be called both in main process(for our implement has blocking queue,
+        # and blocking queue read is in main process) and thread, which may
+        # cause error following error
+        #   1. "ValueError: generator already executing" in next(self._sampler_iter)
+        #   2. re-enter in increase _send_idx
+        # add a lock for threading save, for _try_put_indices is only a slight
+        # function which is not in data reading pipeline, this lock almost no
+        # influence on performance
+        with self._thread_lock:
+            try:
                 indices = next(self._sampler_iter)
-        except StopIteration:
-            return
+            except StopIteration:
+                return
 
-        for i in range(self._num_workers):
-            worker_idx = next(self._workers_idx_cycle)
-            if self._worker_status[worker_idx]:
-                break
-        else:
-            return
+            for i in range(self._num_workers):
+                worker_idx = next(self._workers_idx_cycle)
+                if self._worker_status[worker_idx]:
+                    break
+            else:
+                return
 
-        self._indices_queues[worker_idx].put((self._send_idx, indices))
-        self._task_infos[self._send_idx] = (worker_idx, )
-        self._batches_outstanding += 1
-        self._send_idx += 1
+            self._indices_queues[worker_idx].put((self._send_idx, indices))
+            self._task_infos[self._send_idx] = (worker_idx, )
+            self._batches_outstanding += 1
+            self._send_idx += 1
 
     def __del__(self):
         self._try_shutdown_all()


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
DataLoader implemented with BlockingQueue, which should be `read_next` in main process, and put indices after `read_next`, but the `thread_loop` also need put indices for IterableDataset, which may cause following error or other segment fault or hang
```
Traceback (most recent call last):
File "/paddle/build/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_static.py", line 164, in test_main
   ret = self.run_main(num_workers=num_workers, places=p)
File "/paddle/build/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_iterable_dataset_static.py", line 131, in run_main
   for d in dataloader:
File "/paddle/build/python/paddle/fluid/dataloader/dataloader_iter.py", line 717, in next
  return self.__next__()
File "/paddle/build/python/paddle/fluid/dataloader/dataloader_iter.py", line 708, in __next__
  self._on_output_batch()
File "/paddle/build/python/paddle/fluid/dataloader/dataloader_iter.py", line 722, in _on_output_batch
  self._try_put_indices()
File "/paddle/build/python/paddle/fluid/dataloader/dataloader_iter.py", line 664, in _try_put_indices
  indices = next(self._sampler_iter)
ValueError: generator already executing
```

add `threading.Lock` arround put indices, for `_try_put_indices` is only a slight function beside data reading pipeline, will be OK and almost no influence on performance