### PR TITLE
[OpDevOptimize] add common unary op

### DIFF
--- a/paddle/fluid/framework/grad_op_desc_maker.h
+++ b/paddle/fluid/framework/grad_op_desc_maker.h
@@ -20,6 +20,7 @@ limitations under the License. */
 #include <unordered_set>
 #include <utility>
 #include <vector>
+
 #include "paddle/fluid/framework/op_call_stack.h"
 #include "paddle/fluid/framework/op_desc.h"
 #include "paddle/fluid/framework/operator.h"
@@ -225,6 +226,8 @@ class SingleGradOpMaker<imperative::OpBase>
       imperative::TracedGradOp traced_grad_op(node);
       try {
         this->Apply(&traced_grad_op);
+        traced_grad_op.SetOrderedInputNames();
+        traced_grad_op.SetOrderedOutputNames();
       } catch (platform::EnforceNotMet& exception) {
         framework::AppendErrorOpHint(traced_grad_op.Type(), &exception);
         throw std::move(exception);

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -54,24 +54,11 @@ class CompileTimeInferShapeContext : public InferShapeContext {
   std::vector<std::string> Outputs(const std::string &name) const override;
 
   std::string GetInputNameByIdx(size_t idx) const override {
-    auto input_names = op_.OrderedInputNames();
-    PADDLE_ENFORCE_LT(idx, input_names.size(),
-                      platform::errors::OutOfRange(
-                          "The index should be less than the size of inputs of "
-                          "operator %s, but got index is %d and size is %d",
-                          op_.Type(), idx, input_names.size()));
-    return input_names[idx];
+    return op_.GetInputNameByIdx(idx);
   }
 
   std::string GetOutputNameByIdx(size_t idx) const override {
-    auto output_names = op_.OrderedOutputNames();
-    PADDLE_ENFORCE_LT(
-        idx, output_names.size(),
-        platform::errors::OutOfRange(
-            "The index should be less than the size of outputs of "
-            "operator %s, but got index is %d and size is %d",
-            op_.Type(), idx, output_names.size()));
-    return output_names[idx];
+    return op_.GetOutputNameByIdx(idx);
   }
 
   void ShareDim(const std::string &in, const std::string &out, size_t i = 0,

--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -303,6 +303,7 @@ OpDesc::OpDesc(const std::string &type, const VariableNameMap &inputs,
   outputs_ = outputs;
   attrs_ = attrs;
   need_update_ = true;
+  // TODO(zhiqiu): set input_names_ and output_names_ properly here
   block_ = nullptr;
 }
 
@@ -317,6 +318,8 @@ void OpDesc::CopyFrom(const OpDesc &op_desc) {
   inputs_ = op_desc.inputs_;
   outputs_ = op_desc.outputs_;
   attrs_ = op_desc.attrs_;
+  input_names_ = op_desc.input_names_;
+  output_names_ = op_desc.output_names_;
   need_update_ = true;
 }
 
@@ -381,6 +384,7 @@ void OpDesc::SetInput(const std::string &param_name,
                       const std::vector<std::string> &args) {
   need_update_ = true;
   inputs_[param_name] = args;
+  input_names_.emplace_back(param_name);
 }
 
 const std::vector<std::string> &OpDesc::Output(const std::string &name) const {
@@ -406,6 +410,7 @@ void OpDesc::SetOutput(const std::string &param_name,
                        const std::vector<std::string> &args) {
   need_update_ = true;
   this->outputs_[param_name] = args;
+  output_names_.emplace_back(param_name);
 }
 
 bool OpDesc::HasProtoAttr(const std::string &name) const {

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -175,6 +175,25 @@ class OpDesc {
     }
   }
 
+  std::string GetInputNameByIdx(size_t idx) const {
+    PADDLE_ENFORCE_LT(idx, input_names_.size(),
+                      platform::errors::OutOfRange(
+                          "The index should be less than the size of inputs of "
+                          "operator %s, but got index is %d and size is %d",
+                          Type(), idx, input_names_.size()));
+    return input_names_[idx];
+  }
+
+  std::string GetOutputNameByIdx(size_t idx) const {
+    PADDLE_ENFORCE_LT(
+        idx, output_names_.size(),
+        platform::errors::OutOfRange(
+            "The index should be less than the size of outputs of "
+            "operator %s, but got index is %d and size is %d",
+            Type(), idx, output_names_.size()));
+    return output_names_[idx];
+  }
+
  private:
   template <typename MapType>
   static std::vector<typename MapType::key_type> MapKeys(const MapType &map) {

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -20,6 +20,7 @@ limitations under the License. */
 #include <vector>
 
 #include "paddle/fluid/framework/attribute.h"
+#include "paddle/fluid/framework/op_info.h"
 #include "paddle/fluid/framework/type_defs.h"
 #include "paddle/fluid/framework/var_desc.h"
 
@@ -28,6 +29,13 @@ namespace framework {
 
 class BlockDesc;
 class ProgramDesc;
+
+// If an op's OpInfo has proto, it is a forward op; otherwise, it is a grad op
+static inline bool IsOpInfoHasProto(std::string type) {
+  auto &op_proto = paddle::framework::OpInfoMap::Instance().Get(type).proto_;
+  return op_proto != nullptr;
+}
+
 class OpDesc {
  public:
   OpDesc() {}
@@ -47,7 +55,10 @@ class OpDesc {
 
   std::string Type() const { return desc_.type(); }
 
-  void SetType(const std::string &type) { desc_.set_type(type); }
+  void SetType(const std::string &type) {
+    desc_.set_type(type);
+    InitOrderedInputOutputNamesForForwardOp();
+  }
 
   const std::vector<std::string> &Input(const std::string &name) const;
 
@@ -138,22 +149,30 @@ class OpDesc {
   BlockDesc *Block() { return this->block_; }
 
   const BlockDesc *Block() const { return this->block_; }
-  std::string GetInputNameByIdx(size_t idx) {
-    PADDLE_ENFORCE_LT(idx, input_names_.size(),
-                      platform::errors::OutOfRange(
-                          "The index should be less than the size of inputs of "
-                          "operator %s, but got index is %d and size is %d",
-                          Type(), idx, output_names_.size()));
-    return input_names_[idx];
+
+  const std::vector<std::string> &OrderedInputNames() const {
+    return input_names_;
   }
-  std::string GetOutputNameByIdx(size_t idx) {
-    PADDLE_ENFORCE_LT(
-        idx, output_names_.size(),
-        platform::errors::OutOfRange(
-            "The index should be less than the size of outputs of "
-            "operator %s, but got index is %d and size is %d",
-            Type(), idx, output_names_.size()));
-    return output_names_[idx];
+
+  const std::vector<std::string> &OrderedOutputNames() const {
+    return output_names_;
+  }
+
+  void InitOrderedInputOutputNamesForForwardOp() {
+    if (IsOpInfoHasProto(Type())) {
+      auto &op_proto =
+          paddle::framework::OpInfoMap::Instance().Get(Type()).proto_;
+      if (input_names_.empty()) {
+        for (auto &in : op_proto->inputs()) {
+          input_names_.emplace_back(in.name());
+        }
+      }
+      if (output_names_.empty()) {
+        for (auto &out : op_proto->outputs()) {
+          output_names_.emplace_back(out.name());
+        }
+      }
+    }
   }
 
  private:

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -18,6 +18,7 @@ limitations under the License. */
 #include <unordered_map>
 #include <utility>
 #include <vector>
+
 #include "paddle/fluid/framework/attribute.h"
 #include "paddle/fluid/framework/type_defs.h"
 #include "paddle/fluid/framework/var_desc.h"
@@ -137,6 +138,23 @@ class OpDesc {
   BlockDesc *Block() { return this->block_; }
 
   const BlockDesc *Block() const { return this->block_; }
+  std::string GetInputNameByIdx(size_t idx) {
+    PADDLE_ENFORCE_LT(idx, input_names_.size(),
+                      platform::errors::OutOfRange(
+                          "The index should be less than the size of inputs of "
+                          "operator %s, but got index is %d and size is %d",
+                          Type(), idx, output_names_.size()));
+    return input_names_[idx];
+  }
+  std::string GetOutputNameByIdx(size_t idx) {
+    PADDLE_ENFORCE_LT(
+        idx, output_names_.size(),
+        platform::errors::OutOfRange(
+            "The index should be less than the size of outputs of "
+            "operator %s, but got index is %d and size is %d",
+            Type(), idx, output_names_.size()));
+    return output_names_[idx];
+  }
 
  private:
   template <typename MapType>
@@ -155,6 +173,9 @@ class OpDesc {
   VariableNameMap inputs_;
   // output arg name => output variable names
   VariableNameMap outputs_;
+  // keep input/output order, so we can get name by idx
+  std::vector<std::string> input_names_;
+  std::vector<std::string> output_names_;
   AttributeMap attrs_;
 
   // need_update_ indicate there some local changes not be synchronized. If

--- a/paddle/fluid/framework/op_registry.h
+++ b/paddle/fluid/framework/op_registry.h
@@ -23,6 +23,7 @@ limitations under the License. */
 #include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #define GLOG_NO_ABBREVIATED_SEVERITIES  // msvc conflict logging with windows.h
 #include "glog/logging.h"               // For VLOG()
@@ -90,15 +91,20 @@ class OpRegistry {
    *            attr_check is set to false, otherwise it will be failed
    *            when check function called.
    */
-  static std::unique_ptr<OperatorBase> CreateOp(const std::string& type,
-                                                const VariableNameMap& inputs,
-                                                const VariableNameMap& outputs,
-                                                AttributeMap attrs,
-                                                bool attr_check = true);
+  static std::unique_ptr<OperatorBase> CreateOp(
+      const std::string& type, const VariableNameMap& inputs,
+      const VariableNameMap& outputs, AttributeMap attrs,
+      const std::vector<std::string>& input_names = {},
+      const std::vector<std::string>& output_names = {},
+      bool attr_check = true);
 
-  static std::unique_ptr<OperatorBase> CreateOp(const proto::OpDesc& op_desc);
+  static std::unique_ptr<OperatorBase> CreateOp(
+      const proto::OpDesc& op_desc,
+      const std::vector<std::string>& input_names = {},
+      const std::vector<std::string>& output_names = {});
 
   static std::unique_ptr<OperatorBase> CreateOp(const OpDesc& op_desc);
+  static std::unique_ptr<OperatorBase> CreateOp(const std::string& type);
 };
 
 template <typename PlaceType, bool at_end, size_t I, typename... KernelType>

--- a/paddle/fluid/framework/operator.h
+++ b/paddle/fluid/framework/operator.h
@@ -298,6 +298,29 @@ class ExecutionContext {
     return it->second;
   }
 
+  virtual std::string GetInputNameByIdx(size_t idx) const {
+    auto& op_proto =
+        paddle::framework::OpInfoMap::Instance().Get(op_.Type()).proto_;
+    PADDLE_ENFORCE_LT(idx, op_proto->inputs().size(),
+                      platform::errors::OutOfRange(
+                          "The index should be less than the size of inputs of "
+                          "operator %s, but got index is %d and size is %d",
+                          op_.Type(), idx, op_proto->inputs().size()));
+    return op_proto->inputs()[idx].name();
+  }
+
+  virtual std::string GetOutputNameByIdx(size_t idx) const {
+    auto& op_proto =
+        paddle::framework::OpInfoMap::Instance().Get(op_.Type()).proto_;
+    PADDLE_ENFORCE_LT(
+        idx, op_proto->outputs().size(),
+        platform::errors::OutOfRange(
+            "The index should be less than the size of outputs of "
+            "operator %s, but got index is %d and size is %d",
+            op_.Type(), idx, op_proto->outputs().size()));
+    return op_proto->outputs()[idx].name();
+  }
+
   virtual std::vector<std::string> InNameList() const {
     std::vector<std::string> vec_temp;
     vec_temp.reserve(ctx_.inputs.size());

--- a/paddle/fluid/imperative/dygraph_grad_maker.h
+++ b/paddle/fluid/imperative/dygraph_grad_maker.h
@@ -281,6 +281,10 @@ class TracedGradOp {
     return op_->Attr<T>(name);
   }
 
+  void SetOrderedInputNames() { op_->SetInnerOpInputNames(); }
+
+  void SetOrderedOutputNames() { op_->SetInnerOpOutputNames(); }
+
  private:
   template <TracedVarRole kRole>
   static std::vector<std::shared_ptr<VariableWrapper>> ToVarWrapperList(

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -13,9 +13,11 @@
 // limitations under the License.
 
 #include "paddle/fluid/imperative/layer.h"
+
 #include <algorithm>
 #include <queue>
 #include <utility>
+
 #include "paddle/fluid/framework/framework.pb.h"
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/framework/variable_helper.h"
@@ -279,7 +281,8 @@ std::shared_ptr<VarBase> VarBase::NewVarBase(const platform::Place& dst_place,
 }
 
 void OpBase::SetType(const std::string& type) {
-  op_ = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
+  op_ = framework::OpRegistry::CreateOp(type);
+  InitOrderedInputOutputNamesForForwardOp();
 }
 
 void OpBase::ClearBackwardTrace() {
@@ -298,6 +301,7 @@ static void OpBaseRunImpl(const framework::OperatorBase& op,
       op_kernel, platform::errors::PermissionDenied(
                      "Only support operator with kernel in Dygraph mode."));
   auto& info = op.Info();
+
   if (info.infer_var_type_) {
     RuntimeInferVarTypeContext<VarType> infer_var_type_ctx(ins, outs, attrs);
     info.infer_var_type_(&infer_var_type_ctx);

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 #include "paddle/fluid/imperative/tracer.h"
+
 #include <set>
 #include <unordered_set>
 #include <utility>
+
 #include "paddle/fluid/framework/op_registry.h"
 #include "paddle/fluid/imperative/amp_auto_cast.h"
 #include "paddle/fluid/imperative/op_base.h"
@@ -47,7 +49,7 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
                      const NameVarBaseMap& outs, framework::AttributeMap attrs,
                      const platform::Place& place, bool trace_backward) {
   VLOG(1) << "Trace Op: " << type;
-  auto op = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
+  auto op = framework::OpRegistry::CreateOp(type);
   const auto& op_info = op->Info();
   auto* attr_checker = op_info.Checker();
   if (attr_checker) {

--- a/paddle/fluid/operators/CMakeLists.txt
+++ b/paddle/fluid/operators/CMakeLists.txt
@@ -114,6 +114,8 @@ set(OPERATOR_DEPS ${OPERATOR_DEPS} ${COMMON_OP_DEPS})
 set(GLOB_OPERATOR_DEPS ${OPERATOR_DEPS} CACHE INTERNAL "Global Op dependencies")
 
 cc_test(test_common_infer_shape_functions SRCS test_common_infer_shape_functions.cc DEPS common_infer_shape_functions ${COMMON_OP_DEPS} activation_op elementwise_add_op softmax_op softmax)
+cc_test(test_common_cwise_ops SRCS test_common_cwise_ops.cc DEPS common_infer_shape_functions operator op_registry device_context layer)
+
 cc_test(assign_op_test SRCS assign_op_test.cc DEPS assign_op)
 cc_test(gather_test SRCS gather_test.cc DEPS tensor)
 cc_test(scatter_test SRCS scatter_test.cc DEPS tensor math_function)

--- a/paddle/fluid/operators/common_cwise_functors.h
+++ b/paddle/fluid/operators/common_cwise_functors.h
@@ -1,8 +1,11 @@
 /* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/paddle/fluid/operators/common_cwise_functors.h
+++ b/paddle/fluid/operators/common_cwise_functors.h
@@ -1,0 +1,74 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+
+// This file almostly contains all the coefficient-wise Operator class and
+// OpKernel class
+
+namespace paddle {
+namespace operators {
+namespace functors {
+
+// binary functor
+template <typename T>
+struct Pow {
+  inline HOSTDEVICE T operator()(T a, T b) const {
+#ifdef __CUDA_ARCH__
+    // On CUDAPlace, std::pow(3, 1) calls pow(float, float), and
+    // it will return a float number like 2.99... , which floor to 2
+    // when cast to int by default and it is wrong.
+    // Use llrint to cast it to the nearest integer, which is 3.
+    if (std::is_integral<T>::value) {
+      return std::llrint(std::pow(a, b));
+    }
+#endif
+    return std::pow(a, b);
+  }
+};
+
+template <typename T>
+struct Add {
+  inline HOSTDEVICE T operator()(T a, T b) const { return a + b; }
+};
+
+template <typename T>
+struct Sub {
+  inline HOSTDEVICE T operator()(T a, T b) const { return a - b; }
+};
+
+template <typename T>
+struct Mul {
+  inline HOSTDEVICE T operator()(T a, T b) const { return a * b; }
+};
+
+template <typename T>
+struct Div {
+  inline HOSTDEVICE T operator()(T a, T b) const { return a / b; }
+};
+
+// unary functor
+template <typename T>
+struct IsNan {
+  inline HOSTDEVICE T operator()(T a) const { return std::isnan(a); }
+};
+
+template <typename T>
+struct Neg {
+  inline HOSTDEVICE T operator()(T a) const { return -a; }
+};
+
+}  // namespace functors
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/common_cwise_ops.h
+++ b/paddle/fluid/operators/common_cwise_ops.h
@@ -1,8 +1,11 @@
 /* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/paddle/fluid/operators/common_cwise_ops.h
+++ b/paddle/fluid/operators/common_cwise_ops.h
@@ -72,8 +72,6 @@ class UnaryGradOpKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
     // NOTE(zhiqiu): only supports Tensor now
-    std::cout << ctx.GetInputNameByIdx(0) << std::endl;
-    std::cout << ctx.GetOutputNameByIdx(0) << std::endl;
     auto *dout = ctx.Input<Tensor>(ctx.GetInputNameByIdx(0));
     auto *dx = ctx.Output<Tensor>(ctx.GetOutputNameByIdx(0));
     dx->mutable_data<T>(ctx.GetPlace());

--- a/paddle/fluid/operators/common_cwise_ops.h
+++ b/paddle/fluid/operators/common_cwise_ops.h
@@ -40,6 +40,16 @@ class UnaryOp : public framework::OperatorWithKernel {
   // Use default GetExpectedKernelType
 };
 
+class UnaryGradOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    return UnaryOpUnchangedInferShape(ctx);
+  }
+  // Use default GetExpectedKernelType
+};
+
 template <typename DeviceContext, typename Functor, typename T>
 class UnaryOpKernel : public framework::OpKernel<T> {
  public:
@@ -58,10 +68,12 @@ class UnaryOpKernel : public framework::OpKernel<T> {
 };
 
 template <typename DeviceContext, typename Functor, typename T>
-class UnaryOpGradKernel : public framework::OpKernel<T> {
+class UnaryGradOpKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
     // NOTE(zhiqiu): only supports Tensor now
+    std::cout << ctx.GetInputNameByIdx(0) << std::endl;
+    std::cout << ctx.GetOutputNameByIdx(0) << std::endl;
     auto *dout = ctx.Input<Tensor>(ctx.GetInputNameByIdx(0));
     auto *dx = ctx.Output<Tensor>(ctx.GetOutputNameByIdx(0));
     dx->mutable_data<T>(ctx.GetPlace());

--- a/paddle/fluid/operators/common_cwise_ops.h
+++ b/paddle/fluid/operators/common_cwise_ops.h
@@ -1,0 +1,99 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#pragma once
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/operators/common_infer_shape_functions.h"
+#include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
+
+#ifdef PADDLE_WITH_MKLDNN
+#include "paddle/fluid/platform/mkldnn_helper.h"
+#endif
+
+// This file almostly contains all the coefficient-wise Operator class and
+// OpKernel class
+
+namespace paddle {
+namespace operators {
+using Tensor = framework::LoDTensor;
+
+class UnaryOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *ctx) const override {
+    return UnaryOpUnchangedInferShape(ctx);
+  }
+  // Use default GetExpectedKernelType
+};
+
+template <typename DeviceContext, typename Functor, typename T>
+class UnaryOpKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    // NOTE(zhiqiu): only supports Tensor now
+    auto *x = ctx.Input<Tensor>(ctx.GetInputNameByIdx(0));
+    auto *out = ctx.Output<Tensor>(ctx.GetOutputNameByIdx(0));
+    out->mutable_data<T>(ctx.GetPlace());
+
+    auto eigen_in = framework::EigenVector<T>::Flatten(*x);
+    auto eigen_out = framework::EigenVector<T>::Flatten(*out);
+    auto &dev = *ctx.template device_context<DeviceContext>().eigen_device();
+
+    eigen_out.device(dev) = eigen_in.unaryExpr(Functor());
+  }
+};
+
+template <typename DeviceContext, typename Functor, typename T>
+class UnaryOpGradKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext &ctx) const override {
+    // NOTE(zhiqiu): only supports Tensor now
+    auto *dout = ctx.Input<Tensor>(ctx.GetInputNameByIdx(0));
+    auto *dx = ctx.Output<Tensor>(ctx.GetOutputNameByIdx(0));
+    dx->mutable_data<T>(ctx.GetPlace());
+
+    auto eigen_in = framework::EigenVector<T>::Flatten(*dout);
+    auto eigen_out = framework::EigenVector<T>::Flatten(*dx);
+    auto &dev = *ctx.template device_context<DeviceContext>().eigen_device();
+    eigen_out.device(dev) = eigen_in.unaryExpr(Functor());
+  }
+};
+
+#define REGISTER_OP_KERNEL_1(N, K, D, F, T0) \
+  REGISTER_OP_CPU_KERNEL(N, K<paddle::platform::D##DeviceContext, F<T0>, T0>)
+
+#define REGISTER_OP_KERNEL_2(N, K, D, F, T0, T1)                              \
+  REGISTER_OP_CPU_KERNEL(N, K<paddle::platform::D##DeviceContext, F<T0>, T0>, \
+                         K<paddle::platform::D##DeviceContext, F<T1>, T1>)
+
+#define REGISTER_OP_KERNEL_3(N, K, D, F, T0, T1, T2)                          \
+  REGISTER_OP_CPU_KERNEL(N, K<paddle::platform::D##DeviceContext, F<T0>, T0>, \
+                         K<paddle::platform::D##DeviceContext, F<T1>, T1>, \
+                         K<paddle::platform::D##DeviceContext, F<T1>, T1>))
+
+#define REGISTER_OP_KERNEL_4(N, K, D, F, T0, T1, T2, T3)                      \
+  REGISTER_OP_CPU_KERNEL(N, K<paddle::platform::D##DeviceContext, F<T0>, T0>, \
+                         K<paddle::platform::D##DeviceContext, F<T1>, T1>,    \
+                         K<paddle::platform::D##DeviceContext, F<T2>, T2>,    \
+                         K<paddle::platform::D##DeviceContext, F<T3>, T3>)
+
+#define REGISTER_OP_KERNEL_5(N, K, D, F, T0, T1, T2, T3, T4)                  \
+  REGISTER_OP_CPU_KERNEL(N, K<paddle::platform::D##DeviceContext, F<T0>, T0>, \
+                         K<paddle::platform::D##DeviceContext, F<T1>, T1>,    \
+                         K<paddle::platform::D##DeviceContext, F<T2>, T2>,    \
+                         K<paddle::platform::D##DeviceContext, F<T3>, T3>,    \
+                         K<paddle::platform::D##DeviceContext, F<T4>, T4>)
+
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/common_infer_shape_functions.cc
+++ b/paddle/fluid/operators/common_infer_shape_functions.cc
@@ -77,7 +77,6 @@ inline void GetBroadcastDimsArrays(const framework::DDim &x_dims,
 void UnaryOpUnchangedInferShape(framework::InferShapeContext *ctx) {
   auto x_name = ctx->GetInputNameByIdx(0);
   auto out_name = ctx->GetOutputNameByIdx(0);
-  std::cout << x_name << " " << out_name << std::endl;
   ctx->ShareDim(x_name, /*->*/ out_name);
   ctx->ShareLoD(x_name, /*->*/ out_name);
 }

--- a/paddle/fluid/operators/common_infer_shape_functions.cc
+++ b/paddle/fluid/operators/common_infer_shape_functions.cc
@@ -77,6 +77,7 @@ inline void GetBroadcastDimsArrays(const framework::DDim &x_dims,
 void UnaryOpUnchangedInferShape(framework::InferShapeContext *ctx) {
   auto x_name = ctx->GetInputNameByIdx(0);
   auto out_name = ctx->GetOutputNameByIdx(0);
+  std::cout << x_name << " " << out_name << std::endl;
   ctx->ShareDim(x_name, /*->*/ out_name);
   ctx->ShareLoD(x_name, /*->*/ out_name);
 }

--- a/paddle/fluid/operators/test_common_cwise_ops.cc
+++ b/paddle/fluid/operators/test_common_cwise_ops.cc
@@ -1,0 +1,94 @@
+/* Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/ddim.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/framework/var_type.h"
+#include "paddle/fluid/imperative/infer_shape_context.h"
+#include "paddle/fluid/imperative/layer.h"
+#include "paddle/fluid/operators/common_cwise_functors.h"
+#include "paddle/fluid/operators/common_cwise_ops.h"
+#include "paddle/fluid/operators/common_infer_shape_functions.h"
+
+namespace paddle {
+namespace operators {
+
+class TestNegOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("X", "input of test op");
+    AddOutput("Out", "output of test op");
+    AddComment("Out = -X");
+  }
+};
+
+template <typename T>
+class TestNegOpGradMaker : public framework::SingleGradOpMaker<T> {
+ public:
+  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;
+
+ protected:
+  void Apply(GradOpPtr<T> op) const override {
+    op->SetType(this->ForwardOpType() + "_grad");
+    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
+    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
+    op->SetAttrMap(this->Attrs());
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace functors = paddle::operators::functors;
+
+REGISTER_OPERATOR(test_neg, ops::UnaryOp, ops::TestNegOpMaker,
+                  ops::TestNegOpGradMaker<paddle::framework::OpDesc>,
+                  ops::TestNegOpGradMaker<paddle::imperative::OpBase>);
+REGISTER_OP_KERNEL_4(test_neg, ops::UnaryOpKernel, CPU, functors::Neg, int,
+                     int64_t, float, double);
+REGISTER_OP_KERNEL_4(test_neg_grad, ops::UnaryOpGradKernel, CPU, functors::Neg,
+                     int, int64_t, float, double);
+namespace paddle {
+namespace operators {
+
+TEST(test_neg, test_run) {
+  paddle::platform::CPUPlace cpu_place;
+  paddle::framework::Scope scope;
+
+  auto op = framework::OpRegistry::CreateOp("test_neg", {{"X", {"X"}}},
+                                            {{"Out", {"Out"}}}, {});
+
+  auto in_tensor = scope.Var("X")->GetMutable<framework::LoDTensor>();
+  in_tensor->Resize({2, 10});
+  size_t numel = 2 * 10;
+  auto in_data = in_tensor->mutable_data<float>(cpu_place);
+  std::uniform_real_distribution<float> dist(static_cast<float>(10.0),
+                                             static_cast<float>(20.0));
+  std::mt19937 engine;
+  std::vector<float> expected_out;
+  expected_out.reserve(numel);
+  for (size_t i = 0; i < numel; ++i) {
+    in_data[i] = dist(engine);
+    expected_out[i] = -in_data[i];
+  }
+  auto out_tensor = scope.Var("Out")->GetMutable<framework::LoDTensor>();
+  op->Run(scope, cpu_place);
+  auto out_data = out_tensor->data<float>();
+  auto is_equal = std::equal(out_data, out_data + numel, expected_out.data());
+  ASSERT_TRUE(is_equal);
+}
+}  // namespace operators
+}  // namespace paddle

--- a/paddle/fluid/operators/test_common_cwise_ops.cc
+++ b/paddle/fluid/operators/test_common_cwise_ops.cc
@@ -62,6 +62,9 @@ REGISTER_OP_KERNEL_4(test_neg, ops::UnaryOpKernel, CPU, functors::Neg, int,
                      int64_t, float, double);
 REGISTER_OP_KERNEL_4(test_neg_grad, ops::UnaryGradOpKernel, CPU, functors::Neg,
                      int, int64_t, float, double);
+
+USE_OP(test_neg);
+
 namespace paddle {
 namespace operators {
 
@@ -69,8 +72,8 @@ TEST(test_neg, test_run) {
   paddle::platform::CPUPlace cpu_place;
   paddle::framework::Scope scope;
 
-  auto op = framework::OpRegistry::CreateOp("test_neg", {{"X", {"X"}}},
-                                            {{"Out", {"Out"}}}, {});
+  auto op = framework::OpRegistry::CreateOp(
+      "test_neg", {{"X", {"X"}}}, {{"Out", {"Out"}}}, {}, {"X"}, {"Out"});
 
   auto in_tensor = scope.Var("X")->GetMutable<framework::LoDTensor>();
   in_tensor->Resize({2, 10});
@@ -96,8 +99,9 @@ TEST(test_neg_grad, test_run) {
   paddle::platform::CPUPlace cpu_place;
   paddle::framework::Scope scope;
 
-  auto op = framework::OpRegistry::CreateOp(
-      "test_neg_grad", {{"DOut", {"DOut"}}}, {{"DX", {"DX"}}}, {});
+  auto op =
+      framework::OpRegistry::CreateOp("test_neg_grad", {{"DOut", {"DOut"}}},
+                                      {{"DX", {"DX"}}}, {}, {"DOut"}, {"DX"});
 
   auto in_tensor = scope.Var("DOut")->GetMutable<framework::LoDTensor>();
   in_tensor->Resize({2, 10});
@@ -112,10 +116,8 @@ TEST(test_neg_grad, test_run) {
     in_data[i] = dist(engine);
     expected_out[i] = -in_data[i];
   }
-  std::cout << "here" << std::endl;
   auto out_tensor = scope.Var("DX")->GetMutable<framework::LoDTensor>();
   op->Run(scope, cpu_place);
-  std::cout << "here2" << std::endl;
   auto out_data = out_tensor->data<float>();
   auto is_equal = std::equal(out_data, out_data + numel, expected_out.data());
   ASSERT_TRUE(is_equal);

--- a/tools/print_op_desc.py
+++ b/tools/print_op_desc.py
@@ -103,5 +103,9 @@ def get_all_ops_desc():
 
 
 all_op_protos_dict = get_all_ops_desc()
-result = json.dumps(all_op_protos_dict)
+result = json.dumps(
+    all_op_protos_dict,
+    sort_keys=True,
+    indent=2,
+    separators=(', ', ': '), )
 print(result)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

Add common unary op

#### Usage

For example, if we want to write a new operator, `y = -(x)`.
We can simply write like this, 
```
class TestNegOpMaker : public framework::OpProtoAndCheckerMaker {
 public:
  void Make() override {
    AddInput("X", "input of test op");
    AddOutput("Out", "output of test op");
    AddComment("Out = -X");
  }
};

template <typename T>
class TestNegOpGradMaker : public framework::SingleGradOpMaker<T> {
 public:
  using framework::SingleGradOpMaker<T>::SingleGradOpMaker;

 protected:
  void Apply(GradOpPtr<T> op) const override {
    op->SetType(this->ForwardOpType() + "_grad");
    op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
    op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
    op->SetAttrMap(this->Attrs());
  }
};

}  // namespace operators
}  // namespace paddle

namespace ops = paddle::operators;
namespace functors = paddle::operators::functors;

REGISTER_OPERATOR(test_neg, ops::UnaryOp, ops::TestNegOpMaker,
                  ops::TestNegOpGradMaker<paddle::framework::OpDesc>,
                  ops::TestNegOpGradMaker<paddle::imperative::OpBase>);
REGISTER_OPERATOR(test_neg_grad, ops::UnaryGradOp);
REGISTER_OP_KERNEL_4(test_neg, ops::UnaryOpKernel, CPU, functors::Neg, int,
                     int64_t, float, double);
REGISTER_OP_KERNEL_4(test_neg_grad, ops::UnaryGradOpKernel, CPU, functors::Neg,
                     int, int64_t, float, double);
```
As the example shown, the implementation of `neg` op can be easy and simple enough.

Plus, if we want to implement another unary op, we only need to change the `OpMaker`, `op_name`, and `functor`.