### PR TITLE
Specific gast==0.3.3

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ requests>=2.20.0
 numpy>=1.12, <=1.16.4 ; python_version<"3.5"
 numpy>=1.12 ; python_version>="3.5"
 protobuf>=3.1.0
-gast>=0.3.3
+gast==0.3.3
 matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
 nltk>=3.2.2, <=3.4 ; python_version<"3.5"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Specific gast==0.3.3

+ AST解析依赖`gast`库，其版本升级存在向下不兼容问题，因此指定依赖`gast`==0.3.3版本，避免三方库版本不同带来的兼容性问题。