### PR TITLE
[Paddle-TRT] add TensorRT getInferLibVersion

### DIFF
--- a/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
+++ b/paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.cc
@@ -22,6 +22,7 @@
 #include "paddle/fluid/inference/analysis/ir_passes/tensorrt_subgraph_pass.h"
 #include "paddle/fluid/inference/tensorrt/convert/op_converter.h"
 #include "paddle/fluid/inference/tensorrt/engine.h"
+#include "paddle/fluid/inference/tensorrt/helper.h"
 #include "paddle/fluid/inference/tensorrt/op_teller.h"
 #include "paddle/fluid/string/pretty_log.h"
 
@@ -281,11 +282,14 @@ void TensorRtSubgraphPass::CreateTensorRTOp(
     opt_input_shape = {};
   }
 
-  if (min_input_shape.size() > 0 && TRT_VERSION > 6000) {
+  if (min_input_shape.size() > 0 &&
+      TRT_VERSION != tensorrt::GetInferLibVersion()) {
     LOG_FIRST_N(WARNING, 1)
-        << "The Paddle lib links the " << TRT_VERSION << " version TensorRT, "
-        << "make sure the runtime TensorRT you are using is no less than this "
-           "version, otherwise, there might be Segfault!";
+        << "This Paddle lib was built with TensorRT " << TRT_VERSION
+        << ", but this system is using TensorRT "
+        << tensorrt::GetInferLibVersion()
+        << ". It is recommended to use a consistent TensorRT version. "
+           "Otherwise, there might be Segfault!";
   }
 
   // Setting the disable_trt_plugin_fp16 to true means that TRT plugin will not

--- a/paddle/fluid/inference/tensorrt/helper.h
+++ b/paddle/fluid/inference/tensorrt/helper.h
@@ -60,6 +60,9 @@ static nvinfer1::IRuntime* createInferRuntime(nvinfer1::ILogger* logger) {
 static nvinfer1::IPluginRegistry* GetPluginRegistry() {
   return static_cast<nvinfer1::IPluginRegistry*>(dy::getPluginRegistry());
 }
+static int GetInferLibVersion() {
+  return static_cast<int>(dy::getInferLibVersion());
+}
 #endif
 
 // A logger for create TensorRT infer builder.

--- a/paddle/fluid/platform/dynload/tensorrt.h
+++ b/paddle/fluid/platform/dynload/tensorrt.h
@@ -41,7 +41,9 @@ extern void* tensorrt_dso_handle;
       });                                                                     \
       static void* p_##__name = dlsym(tensorrt_dso_handle, #__name);          \
       if (p_##__name == nullptr) {                                            \
-        return nullptr;                                                       \
+        PADDLE_ENFORCE_NOT_NULL(                                              \
+            p_##__name, platform::errors::Unavailable(                        \
+                            "Load tensorrt plugin %s failed", #__name));      \
       }                                                                       \
       using tensorrt_func = decltype(&::__name);                              \
       return reinterpret_cast<tensorrt_func>(p_##__name)(args...);            \
@@ -53,11 +55,13 @@ extern void* tensorrt_dso_handle;
 #define TENSORRT_RAND_ROUTINE_EACH(__macro) \
   __macro(createInferBuilder_INTERNAL);     \
   __macro(createInferRuntime_INTERNAL);     \
-  __macro(getPluginRegistry);
+  __macro(getPluginRegistry);               \
+  __macro(getInferLibVersion);
 #else
 #define TENSORRT_RAND_ROUTINE_EACH(__macro) \
   __macro(createInferBuilder_INTERNAL);     \
-  __macro(createInferRuntime_INTERNAL);
+  __macro(createInferRuntime_INTERNAL);     \
+  __macro(getInferLibVersion);
 #endif
 
 TENSORRT_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_TENSORRT_WRAP)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Because Paddle uses dlopen to load TensorRT at runtime, the TensoRT
version might not be as same as the version that built with Paddle.
In original implementation, Paddle always throws warning message "
The Paddle lib links the XXX version TensorRT, make sure the runtime
TensorRT you are using is no less than this verion, otherwise, there
might be Segfault!" However, it is still unclear to user.

This patch adds `getInferLibVersion` to check which version of TensorRT
is loaded by dlopen at runtime. If versions are not consistent. Paddle
will throw "This Paddle lib was built with TensorRT XXX, but this
system is using TensorRT YYY. It is recommended to use a consistent
TensorRT version. Otherwise, there might be Segfault!"