### PR TITLE
fix test_metrics accuracy. test=develop

### DIFF
--- a/python/paddle/incubate/hapi/tests/test_metrics.py
+++ b/python/paddle/incubate/hapi/tests/test_metrics.py
@@ -40,7 +40,8 @@ def accuracy(pred, label, topk=(1, )):
 
 
 def convert_to_one_hot(y, C):
-    oh = np.random.random((y.shape[0], C)).astype('float32') * .5
+    oh = np.random.choice(np.arange(C), C, replace=False).astype('float32') / C
+    oh = np.tile(oh[np.newaxis, :], (y.shape[0], 1))
     for i in range(y.shape[0]):
         oh[i, int(y[i])] = 1.
     return oh


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
- fix `test_metrics` accuracy error
   For multi-topk, accuracy calculation depends on `argsort`, if random prediction values ​​are close together, `argsorts` may be different between C++ and python, cause random fail.
```
2020-08-14 20:47:30 ======================================================================
2020-08-14 20:47:30 FAIL: test_main (test_metrics.TestAccuracyStaticMultiTopk)
2020-08-14 20:47:30 ----------------------------------------------------------------------
2020-08-14 20:47:30 Traceback (most recent call last):
2020-08-14 20:47:30   File "/workspace/Paddle/build/python/paddle/incubate/hapi/tests/test_metrics.py", line 117, in test_main
2020-08-14 20:47:30     "Accuracy precision error: {} != {}".format(res_m, res_f)
2020-08-14 20:47:30 AssertionError: Accuracy precision error: [0.132, 0.54] != [0.132, 0.541]
2020-08-14 20:47:30 
2020-08-14 20:47:30 ----------------------------------------------------------------------
```