### PR TITLE
Print user-friendly error message in core.ops [part 2]

### DIFF
--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -90,15 +90,36 @@ CastPyHandleToVarBaseList(const std::string& op_type,
   return result;
 }  // namespace pybind
 
-static inline void ConstructAttrMapFromPyArgs(framework::AttributeMap* attrs,
+static inline void ConstructAttrMapFromPyArgs(const std::string& op_type,
+                                              int start_idx,
+                                              framework::AttributeMap* attrs,
                                               const py::args& args) {
   PADDLE_ENFORCE_EQ(
       args.size() % 2, 0,
       platform::errors::InvalidArgument(
           "The number of arguments for arributes should be even."));
   for (size_t i = 0; i < args.size(); i += 2) {
-    auto name = args[i].cast<std::string>();
-    auto value = args[i + 1].cast<framework::Attribute>();
+    std::string name;
+    framework::Attribute value;
+    try {
+      name = args[i].cast<std::string>();
+    } catch (std::exception& e) {
+      PyObject* py_obj = args[i].ptr();  // get underlying PyObject
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "%s(): argument (position %d) must be str, but got "
+          "%s",
+          op_type, start_idx + i, Py_TYPE(py_obj)->tp_name));
+    }
+    try {
+      value = args[i + 1].cast<framework::Attribute>();
+    } catch (std::exception& e) {
+      PyObject* py_obj = args[i + 1].ptr();  // get underlying PyObject
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "%s(): argument (position %d) must be "
+          "Attribute type (one of str, bool, int, int64, float, or list of "
+          "them), but got %s",
+          op_type, start_idx + i + 1, Py_TYPE(py_obj)->tp_name));
+    }
     (*attrs)[name] = value;
   }
 }

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -146,7 +146,7 @@ R"(
 {
   %s
   framework::AttributeMap attrs;
-  ConstructAttrMapFromPyArgs(&attrs, args);
+  ConstructAttrMapFromPyArgs("%s", %d, &attrs, args);
   {
     py::gil_scoped_release release;
     auto tracer = imperative::GetCurrentTracer();
@@ -204,6 +204,7 @@ GenerateOpFunctions(const std::string& module_name) {
     std::string ins_initializer_with_null = "";
     std::string py_arg = "";
     int arg_idx = 0;
+    int input_args_num = 0;
     std::string ins_cast_str = "";
     for (auto& input : op_proto->inputs()) {
       auto& in_name = input.name();
@@ -216,6 +217,7 @@ GenerateOpFunctions(const std::string& module_name) {
           paddle::string::Sprintf(ARG_TEMPLATE, in_type, TempName(in_name));
       input_args += input_arg;
       input_args += ",";
+      input_args_num++;
       const auto in_cast_type =
           input.duplicable() ? CAST_VAR_LIST_TEMPLATE : CAST_VAR_TEMPLATE;
       ins_cast_str +=
@@ -269,6 +271,7 @@ GenerateOpFunctions(const std::string& module_name) {
         }
         input_args += out_type;
         input_args += out_name;
+        input_args_num++;
 
         if (output.dispensable()) {
           const auto out_template =
@@ -295,6 +298,7 @@ GenerateOpFunctions(const std::string& module_name) {
           auto out_num_str = paddle::string::Sprintf(ARG_OUT_NUM, out_name);
           input_args += ARG_OUT_NUM_TYPE;
           input_args += out_num_str;
+          input_args_num++;
           outs_initializer += paddle::string::Sprintf(
               OUT_DUPLICABLE_INITIALIZER_TEMPLATE, out_name, out_num_str);
         } else {
@@ -334,9 +338,9 @@ GenerateOpFunctions(const std::string& module_name) {
     // generate op funtcion body
     auto op_function_str = paddle::string::Sprintf(
         OP_FUNCTION_TEMPLATE, return_type, func_name, function_args,
-        ins_cast_str, outs_initializer, ins_initializer,
-        ins_initializer_with_null + outs_initializer_with_null, op_type,
-        return_str);
+        ins_cast_str, op_type, input_args_num, outs_initializer,
+        ins_initializer, ins_initializer_with_null + outs_initializer_with_null,
+        op_type, return_str);
 
     // generate pybind item
     auto bind_function_str = paddle::string::Sprintf(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Related #26261

This PR enhances the error message when the OP got an attribute of the wrong type.
For example, 

`paddle.mean(x=tensor, axis=np.random.uniform(0, 1, [2,10]))  `

In this API, `axis` should be `int` but got `numpy.ndarray`.



- before (dynamic graph)
```
Traceback (most recent call last):
  File "aa.py", line 13, in <module>
    loss = model(x, np.random.uniform(0,1,[2,10]))
  File "aa.py", line 5, in model
    return paddle.mean(x, axis)
  File "/usr/local/lib/python3.5/dist-packages/paddle/tensor/stat.py", line 97, in mean
    'reduce_all', reduce_all)
RuntimeError: Unable to cast Python instance to C++ type (compile in debug mode for details)
```

- after (dynamic graph)
```
Traceback (most recent call last):
  File "aa.py", line 13, in <module>
    loss = model(x, np.random.uniform(0,1,[2,100]))
  File "aa.py", line 5, in model
    return paddle.mean(x, axis)
  File "/usr/local/lib/python3.5/dist-packages/paddle/tensor/stat.py", line 97, in mean
    'reduce_all', reduce_all)
paddle.fluid.core_avx.EnforceNotMet: 

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::platform::EnforceNotMet::EnforceNotMet(paddle::platform::ErrorSummary const&, char const*, int)
1   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: reduce_mean(): argument (position 2) must be Attribute type (one of str, bool, int, int64, float, or list of them), but got numpy.ndarray (at /Paddle/Paddle/paddle/fluid/pybind/op_function.h:121)
```
- static graph
```
Traceback (most recent call last):
  File "aa.py", line 13, in <module>
    loss = model(x, np.random.uniform(0,1,[2,10]))
  File "aa.py", line 5, in model
    return paddle.mean(x, axis)
  File "/usr/local/lib/python3.5/dist-packages/paddle/tensor/stat.py", line 107, in mean
    type='reduce_mean', inputs={'X': x}, outputs={'Out': out}, attrs=attrs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layer_helper.py", line 43, in append_op
    return self.main_program.current_block().append_op(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 2847, in append_op
    attrs=kwargs.get("attrs", None))
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 2048, in __init__
    self._update_desc_attr(attr_name, attr_val)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 2313, in _update_desc_attr
    self.desc._set_attr(name, val)
TypeError: _set_attr(): incompatible function arguments. The following argument types are supported:
    1. (self: paddle.fluid.core_avx.OpDesc, arg0: str, arg1: Variant) -> None

Invoked with: <paddle.fluid.core_avx.OpDesc object at 0x7f93cbab5880>, 'dim', array([[0.73971283, 0.75059874, 0.75798314, 0.90461967, 0.22399589,
        0.61482389, 0.02209774, 0.10888649, 0.31326088, 0.06176087],
       [0.22037032, 0.36700745, 0.96432121, 0.33347811, 0.22299534,
        0.44126188, 0.21502262, 0.55826981, 0.53548203, 0.85884811]])
```
The error message in static graph could be refined in the future.