### PR TITLE
Reduce the execution time of several unittests

### DIFF
--- a/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
+++ b/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
@@ -34,7 +34,7 @@ class TestParallelExecutorBase(unittest.TestCase):
     def check_network_convergence(cls,
                                   method,
                                   use_cuda=True,
-                                  iter=50,
+                                  iter=5,
                                   batch_size=None,
                                   feed_dict=None,
                                   feed_data_reader=None,

--- a/python/paddle/fluid/tests/unittests/seresnext_net.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_net.py
@@ -179,7 +179,7 @@ def batch_size(use_cuda):
 def iter(use_cuda):
     if use_cuda:
         return 10
-    return 2
+    return 1
 
 
 gpu_img, gpu_label = init_data(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

reduce unittest execution time:
- test_parallel_executor_seresnext_base_cpu: `336.05s -> 103.17s`
- test_parallel_executor_seresnext_with_reduce_cpu: `352.63s -> 89.82s`
- test_parallel_executor_seresnext_with_fuse_all_reduce_cpu: `416.39s -> 65.33s`
- test_fuse_optimizer_pass: `131.54s -> 37.15s`

original test data:
![image](https://user-images.githubusercontent.com/22561442/90470615-84cdcd00-e14e-11ea-9057-95c1237aac40.png)


new test data:
![image](https://user-images.githubusercontent.com/22561442/90470672-a4fd8c00-e14e-11ea-92c0-39a9874b1026.png)
![image](https://user-images.githubusercontent.com/22561442/90470633-90b98f00-e14e-11ea-866c-cc62c69f3fd7.png)
