### PR TITLE
reduce the execution time of affine_channel op unittests

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
@@ -22,6 +22,7 @@ import numpy as np
 from op_test import OpTest
 import paddle.fluid.core as core
 import paddle.fluid as fluid
+import time
 
 
 def affine_channel(x, scale, bias, layout):
@@ -63,7 +64,7 @@ class TestAffineChannelOp(OpTest):
         self.check_grad(['X'], 'Out', no_grad_set=set(['Scale', 'Bias']))
 
     def init_test_case(self):
-        self.shape = [2, 100, 12, 12]
+        self.shape = [2, 100, 3, 3]
         self.C = 100
         self.layout = 'NCHW'
 
@@ -102,7 +103,7 @@ class TestAffineChannelOpError(unittest.TestCase):
 
 class TestAffineChannelNHWC(TestAffineChannelOp):
     def init_test_case(self):
-        self.shape = [2, 12, 12, 100]
+        self.shape = [2, 3, 3, 100]
         self.C = 100
         self.layout = 'NHWC'
 
@@ -115,7 +116,7 @@ class TestAffineChannelNHWC(TestAffineChannelOp):
 
 class TestAffineChannel2D(TestAffineChannelOp):
     def init_test_case(self):
-        self.shape = [8, 100]
+        self.shape = [2, 100]
         self.C = 100
         self.layout = 'NCHW'
 
@@ -150,4 +151,7 @@ class TestAffineChannel2D(TestAffineChannelOp):
 #        self.layout = 'NHWC'
 
 if __name__ == '__main__':
+    start = time.time()
     unittest.main()
+    end = time.time()
+    print('time cost: ', end - start)

--- a/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
+++ b/python/paddle/fluid/tests/unittests/test_affine_channel_op.py
@@ -22,7 +22,6 @@ import numpy as np
 from op_test import OpTest
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-import time
 
 
 def affine_channel(x, scale, bias, layout):
@@ -151,7 +150,4 @@ class TestAffineChannel2D(TestAffineChannelOp):
 #        self.layout = 'NHWC'
 
 if __name__ == '__main__':
-    start = time.time()
     unittest.main()
-    end = time.time()
-    print('time cost: ', end - start)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
reduce affine_channel op unittest execution time
* test_affine_channel_op: 196.34s -> 15.374s

original test data:
![image](https://user-images.githubusercontent.com/48898730/90479571-76d57780-e161-11ea-9149-4cb132ef6a75.png)

new test data:

![image](https://user-images.githubusercontent.com/48898730/90479655-98366380-e161-11ea-965d-47e044bd050e.png)
