### PR TITLE
reduce ernie_large test time

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_ernie_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_ernie_tester.cc
@@ -143,7 +143,7 @@ void SetConfig(AnalysisConfig *cfg, bool use_mkldnn = false,
   }
   cfg->SwitchSpecifyInputNames();
   cfg->SwitchIrOptim();
-  cfg->SetCpuMathLibraryNumThreads(FLAGS_cpu_num_threads);
+  cfg->SetCpuMathLibraryNumThreads(FLAGS_ernie_cpu_num_threads);
 }
 
 void profile(bool use_mkldnn = false, bool use_gpu = false) {

--- a/paddle/fluid/inference/tests/api/tester_helper.h
+++ b/paddle/fluid/inference/tests/api/tester_helper.h
@@ -68,6 +68,8 @@ DEFINE_bool(warmup, false,
 
 DEFINE_bool(enable_profile, false, "Turn on profiler for fluid");
 DEFINE_int32(cpu_num_threads, 1, "Number of threads for each paddle instance.");
+DEFINE_int32(ernie_cpu_num_threads, 4,
+             "Number of threads for each paddle instance.");
 
 namespace paddle {
 namespace inference {


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
更改统一的线程数量，会造成部分模型的耗时增加，因此只修改ernie模型的线程数。CI机器上测试下性能加速比。

test_analyzer_ernie_large耗时，本地 37.89 sec -> 33.19sec
test_analyzer_ernie耗时，本地 7.54 sec->6.64 sec

### CI 机器上耗时

- 修改前
Test  #190: test_analyzer_ernie ................................   Passed   21.24 sec
Test  #191: test_analyzer_ernie_large ...................................   Passed  126.68 sec

- 修改后
Test  #190: test_analyzer_ernie .........................................   Passed   17.62 sec
Test  #191: test_analyzer_ernie_large ..........................   Passed  101.09 sec