### PR TITLE
Specify numpy>=1.13 

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.20.0
-numpy>=1.12, <=1.16.4 ; python_version<"3.5"
-numpy>=1.12 ; python_version>="3.5"
+numpy>=1.13, <=1.16.4 ; python_version<"3.5"
+numpy>=1.13 ; python_version>="3.5"
 protobuf>=3.1.0
 gast==0.3.3
 matplotlib<=2.2.4 ; python_version<"3.6"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Specify numpy>=1.13 

Paddle use the feature `__array_ufunc__` of numpy, which is released in version in 1.13, see details in doc of [`__array_ufunc__`](https://numpy.org/doc/stable/reference/arrays.classes.html#numpy.class.__array_ufunc__).

https://github.com/PaddlePaddle/Paddle/blob/049ac56c081381c524b3f8cbabb8e2504ca45c49/python/paddle/fluid/dygraph/math_op_patch.py#L251-L259

So this PR is going to specify numpy>=1.13 in requirements.