### PR TITLE
set opencv<=4.2.0.32

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -580,7 +580,10 @@ function generate_api_spec() {
     cd ${PADDLE_ROOT}/build/.check_api_workspace
     virtualenv .${spec_kind}_env
     source .${spec_kind}_env/bin/activate
-    pip install ${PADDLE_ROOT}/build/python/dist/*whl
+    pip install ${PADDLE_ROOT}/build/python/dist/*whl;pip_excode=$?
+    if [[ "$pip_excode" != "0" ]]; then
+        exit 4;
+    fi
     spec_path=${PADDLE_ROOT}/paddle/fluid/API_${spec_kind}.spec
     python ${PADDLE_ROOT}/tools/print_signatures.py paddle > $spec_path
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -580,7 +580,7 @@ function generate_api_spec() {
     cd ${PADDLE_ROOT}/build/.check_api_workspace
     virtualenv .${spec_kind}_env
     source .${spec_kind}_env/bin/activate
-    pip install ${PADDLE_ROOT}/build/python/dist/*whl;pip_excode=$?
+    pip install --no-cache-dir ${PADDLE_ROOT}/build/python/dist/*whl;pip_excode=$?
     if [[ "$pip_excode" != "0" ]]; then
         exit 4;
     fi

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
+opencv-python<=4.2.0.32
 requests>=2.20.0
 numpy>=1.12, <=1.16.4 ; python_version<"3.5"
 numpy>=1.12 ; python_version>="3.5"

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -234,6 +234,9 @@ if sys.version_info >= (3,7):
         setup_requires_tmp+=[setup_requires_i]
     setup_requires = setup_requires_tmp
 
+if '${CMAKE_SYSTEM_PROCESSOR}' not in ['arm', 'armv7-a', 'aarch64']:
+    setup_requires+=['opencv-python<=4.2.0.32']
+
 # the prefix is sys.prefix which should always be usr
 paddle_bins = ''
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -234,9 +234,6 @@ if sys.version_info >= (3,7):
         setup_requires_tmp+=[setup_requires_i]
     setup_requires = setup_requires_tmp
 
-if '${CMAKE_SYSTEM_PROCESSOR}' not in ['arm', 'armv7-a', 'aarch64']:
-    setup_requires+=['opencv-python']
-
 # the prefix is sys.prefix which should always be usr
 paddle_bins = ''
 

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -234,9 +234,6 @@ if sys.version_info >= (3,7):
         setup_requires_tmp+=[setup_requires_i]
     setup_requires = setup_requires_tmp
 
-if '${CMAKE_SYSTEM_PROCESSOR}' not in ['arm', 'armv7-a', 'aarch64']:
-    setup_requires+=['opencv-python<=4.2.0.32']
-
 # the prefix is sys.prefix which should always be usr
 paddle_bins = ''
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
![image](https://user-images.githubusercontent.com/6836917/90519637-def47f80-e19a-11ea-9fa5-1a0d226471f0.png)
报个问题：python2环境下安装paddle，在安装opencv-python依赖时会出现上述错误，经排查发现opencv-python目前已升级到4.3.0.38，需要限制安装paddle时opencv-python的版本应小于等于4.2.0.32。