### PR TITLE
set opencv-python <=4.2.0.32

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -580,7 +580,8 @@ function generate_api_spec() {
     cd ${PADDLE_ROOT}/build/.check_api_workspace
     virtualenv .${spec_kind}_env
     source .${spec_kind}_env/bin/activate
-    pip install ${PADDLE_ROOT}/build/python/dist/*whl
+    pip install -r ${PADDLE_ROOT}/python/requirements.txt
+    pip --no-cache-dir install ${PADDLE_ROOT}/build/python/dist/*whl
     spec_path=${PADDLE_ROOT}/paddle/fluid/API_${spec_kind}.spec
     python ${PADDLE_ROOT}/tools/print_signatures.py paddle > $spec_path
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
+opencv-python<=4.2.0.32
 requests>=2.20.0
 numpy>=1.12, <=1.16.4 ; python_version<"3.5"
 numpy>=1.12 ; python_version>="3.5"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
![image](https://user-images.githubusercontent.com/6836917/90519637-def47f80-e19a-11ea-9fa5-1a0d226471f0.png)
报个问题：python2环境下安装paddle，在安装opencv-python依赖时会出现上述错误，经排查发现opencv-python目前已升级到4.3.0.38，需要限制安装paddle时opencv-python的版本应小于等于4.2.0.32。