### PR TITLE
temporary disable unittest on windows

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -86,6 +86,10 @@ if(WIN32)
     list(REMOVE_ITEM TEST_OPS test_merge_ids_op)
     list(REMOVE_ITEM TEST_OPS test_split_ids_op)
     LIST(REMOVE_ITEM TEST_OPS test_ref_by_trainer_id_op)
+
+    # TODO: Fix these unittests failed on Windows due to out of memory
+    LIST(REMOVE_ITEM TEST_OPS test_yolov3)
+    list(REMOVE_ITEM TEST_OPS test_tsm)
 endif()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
temporary disable unittest on windows.