### PR TITLE
optimized transformation form tensor to numpy

### DIFF
--- a/paddle/fluid/framework/details/fetch_op_handle.cc
+++ b/paddle/fluid/framework/details/fetch_op_handle.cc
@@ -117,7 +117,7 @@ static void TransData(const framework::LoDTensor &src_item,
       TensorCopy(src_item, platform::CPUPlace(), dst_item);
 #endif
     } else {
-      dst_item->ShareDataWith(src_item);
+      TensorCopy(src_item, platform::CPUPlace(), dst_item);
     }
   } else {
     dst_item->clear();

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -538,11 +538,8 @@ inline py::array TensorToPyArray(const framework::Tensor &tensor,
   if (!is_gpu_tensor) {
     if (!need_deep_copy) {
       auto base = py::cast(std::move(tensor));
-      auto info = py::buffer_info(
-          const_cast<void *>(tensor_buf_ptr), sizeof_dtype, py_dtype_str,
-          static_cast<size_t>(tensor.dims().size()), py_dims, py_strides);
-      return py::array(pybind11::dtype(info), info.shape, info.strides,
-                       info.ptr, base);
+      return py::array(py::dtype(py_dtype_str.c_str()), py_dims, py_strides,
+                       const_cast<void *>(tensor_buf_ptr), base);
     } else {
       py::array py_arr(py::dtype(py_dtype_str.c_str()), py_dims, py_strides);
       PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -19,6 +19,7 @@ limitations under the License. */
 #include <memory>
 #include <string>
 #include <tuple>
+#include <utility>
 #include <vector>
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/framework/lod_tensor.h"
@@ -540,7 +541,8 @@ inline py::array TensorToPyArray(const framework::Tensor &tensor,
       auto info = py::buffer_info(
           const_cast<void *>(tensor_buf_ptr), sizeof_dtype, py_dtype_str,
           static_cast<size_t>(tensor.dims().size()), py_dims, py_strides);
-      return py::array(pybind11::dtype(info), info.shape, info.strides, info.ptr, base);
+      return py::array(pybind11::dtype(info), info.shape, info.strides,
+                       info.ptr, base);
     } else {
       py::array py_arr(py::dtype(py_dtype_str.c_str()), py_dims, py_strides);
       PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -536,9 +536,11 @@ inline py::array TensorToPyArray(const framework::Tensor &tensor,
 
   if (!is_gpu_tensor) {
     if (!need_deep_copy) {
-      return py::array(py::buffer_info(
+      auto base = py::cast(std::move(tensor));
+      auto info = py::buffer_info(
           const_cast<void *>(tensor_buf_ptr), sizeof_dtype, py_dtype_str,
-          static_cast<size_t>(tensor.dims().size()), py_dims, py_strides));
+          static_cast<size_t>(tensor.dims().size()), py_dims, py_strides);
+      return py::array(pybind11::dtype(info), info.shape, info.strides, info.ptr, base);
     } else {
       py::array py_arr(py::dtype(py_dtype_str.c_str()), py_dims, py_strides);
       PADDLE_ENFORCE_EQ(

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -145,7 +145,7 @@ def as_numpy(tensor):
             Please set the parameter 'return_numpy' as 'False' to \
             return LoDTensor itself directly.")
     if tensor._is_initialized():
-        return np.array(tensor)
+        return np.asarray(tensor)
     else:
         return None
 

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -110,7 +110,7 @@ def scope_guard(scope):
         _switch_scope(ex)
 
 
-def as_numpy(tensor):
+def as_numpy(tensor, copy=False):
     """
     Convert a Tensor to a numpy.ndarray, its only support Tensor without LoD information.
     For higher dimensional sequence data, please use LoDTensor directly.
@@ -129,6 +129,7 @@ def as_numpy(tensor):
 
     Args:
        tensor(Variable): a instance of Tensor
+       copy(bool, optional): Whether to use deep copy.
 
     Returns:
         numpy.ndarray
@@ -145,7 +146,10 @@ def as_numpy(tensor):
             Please set the parameter 'return_numpy' as 'False' to \
             return LoDTensor itself directly.")
     if tensor._is_initialized():
-        return np.asarray(tensor)
+        if copy:
+            return np.array(tensor)
+        else:
+            return np.asarray(tensor)
     else:
         return None
 
@@ -350,7 +354,7 @@ def _fetch_var(name, scope=None, return_numpy=True):
         " program.")
     tensor = var.get_tensor()
     if return_numpy:
-        tensor = as_numpy(tensor)
+        tensor = as_numpy(tensor, copy=True)
     return tensor
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
背景：
Paddle的Fetch性能不好。经分析Fetch过程中涉及多次深拷贝。

深拷贝分析：
**Executor&CPU：** 1）原始数据->FetchVar; 2)TensorToPyArray错误使用pybind带来一次深拷贝；3）as_numpy中使用np.array()带来一次深拷贝；
**Executor&GPU：** 与Executor&CPU相同；
**PE&CPU：** 1）多Place TensorMerge；2)TensorToPyArray错误使用pybind带来一次深拷贝；3）as_numpy中使用np.array()带来一次深拷贝；
**PE&GPU：** 1）原始数据->FetchTensors；2）多Place TensorMerge；3)TensorToPyArray错误使用pybind带来一次深拷贝；4）as_numpy中使用np.array()带来一次深拷贝；
**动态图：** 只有一次深拷贝，是合理的。

期望目标：
原始数据到用户使用的numpy变量只有1次深拷贝，可分两个修改完成：
第一步：去掉两个深拷贝：1）TensorToPyArray错误使用pybind带来一次深拷贝；2）as_numpy中使用np.array()带来一次深拷贝。同时，将PE&CPU模式，增加一次原始数据->FetchTensors的深拷贝。
第二步：优化多Place TensorMerge中的深拷贝。

本PR，完成第一步。

测试：
Fetch数据正确性测试通过。
内存泄露测试，通过检测内存，未发现内存使用量上涨。
性能：
ERNIE DOC模型，fp32性能提升4.7%。amp性能提升7.7%。