### PR TITLE
[Dy2Stat] Add debugging and logging mechanism for dygraph to static

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/__init__.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/__init__.py
@@ -34,6 +34,9 @@ from .convert_call_func import *
 
 from . import convert_operators
 
+from . import logging_utils
+from .logging_utils import *
+
 __all__ = []
 __all__ += ast_transformer.__all__
 __all__ += loop_transformer.__all__
@@ -41,3 +44,4 @@ __all__ += static_analysis.__all__
 __all__ += variable_trans_func.__all__
 __all__ += program_translator.__all__
 __all__ += convert_call_func.__all__
+__all__ += logging_utils.__all__

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 # as produced by ast.parse from the standard ast module.
 # See details in https://github.com/serge-sans-paille/gast/
 import gast
-
 from paddle.fluid.dygraph.dygraph_to_static.assert_transformer import AssertTransformer
 from paddle.fluid.dygraph.dygraph_to_static.basic_api_transformer import BasicApiTransformer
 from paddle.fluid.dygraph.dygraph_to_static.break_continue_transformer import BreakContinueTransformer
@@ -27,16 +26,15 @@ from paddle.fluid.dygraph.dygraph_to_static.call_transformer import CallTransfor
 from paddle.fluid.dygraph.dygraph_to_static.cast_transformer import CastTransformer
 from paddle.fluid.dygraph.dygraph_to_static.ifelse_transformer import IfElseTransformer
 from paddle.fluid.dygraph.dygraph_to_static.list_transformer import ListTransformer
+from paddle.fluid.dygraph.dygraph_to_static.logging_utils import TranslatorLogger
 from paddle.fluid.dygraph.dygraph_to_static.logical_transformer import LogicalTransformer
 from paddle.fluid.dygraph.dygraph_to_static.loop_transformer import LoopTransformer
 from paddle.fluid.dygraph.dygraph_to_static.print_transformer import PrintTransformer
 from paddle.fluid.dygraph.dygraph_to_static.return_transformer import ReturnTransformer
-from paddle.fluid.dygraph.dygraph_to_static.tensor_shape_transformer import TensorShapeTransformer
-
 from paddle.fluid.dygraph.dygraph_to_static.static_analysis import StaticAnalysisVisitor
+from paddle.fluid.dygraph.dygraph_to_static.tensor_shape_transformer import TensorShapeTransformer
 from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
 from paddle.fluid.dygraph.dygraph_to_static.utils import get_attribute_full_name
-from paddle.fluid.dygraph.dygraph_to_static.logging_utils import TranslatorLogger
 
 __all__ = ['DygraphToStaticAst']
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -26,13 +26,14 @@ from paddle.fluid.dygraph.dygraph_to_static.call_transformer import CallTransfor
 from paddle.fluid.dygraph.dygraph_to_static.cast_transformer import CastTransformer
 from paddle.fluid.dygraph.dygraph_to_static.ifelse_transformer import IfElseTransformer
 from paddle.fluid.dygraph.dygraph_to_static.list_transformer import ListTransformer
-from paddle.fluid.dygraph.dygraph_to_static.logging_utils import TranslatorLogger
 from paddle.fluid.dygraph.dygraph_to_static.logical_transformer import LogicalTransformer
 from paddle.fluid.dygraph.dygraph_to_static.loop_transformer import LoopTransformer
 from paddle.fluid.dygraph.dygraph_to_static.print_transformer import PrintTransformer
 from paddle.fluid.dygraph.dygraph_to_static.return_transformer import ReturnTransformer
 from paddle.fluid.dygraph.dygraph_to_static.static_analysis import StaticAnalysisVisitor
 from paddle.fluid.dygraph.dygraph_to_static.tensor_shape_transformer import TensorShapeTransformer
+
+from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
 from paddle.fluid.dygraph.dygraph_to_static.utils import get_attribute_full_name
 
@@ -57,7 +58,7 @@ class DygraphToStaticAst(gast.NodeTransformer):
         return self.static_analysis_root
 
     def transfer_from_node_type(self, node_wrapper):
-        translator_logger = TranslatorLogger()
+        translator_logger = logging_utils.TranslatorLogger()
         translator_logger.log(
             1, "   Source code: \n{}".format(ast_to_source_code(self.root)))
         # Generic transformation
@@ -65,53 +66,62 @@ class DygraphToStaticAst(gast.NodeTransformer):
 
         # Transform basic api of dygraph to static graph and get feed_name_to_arg_name
         BasicApiTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("BasicApiTransformer", self.root)
+        translator_logger.log_transformed_code(1, self.root,
+                                               "BasicApiTransformer")
 
         # Transform Tensor.shape into fluid.layers.shape(Tensor)
         TensorShapeTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("TensorShapeTransformer",
-                                               self.root)
+        translator_logger.log_transformed_code(2, self.root,
+                                               "TensorShapeTransformer")
 
         # Transform list used in control flow
         ListTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("ListTransformer", self.root)
+        translator_logger.log_transformed_code(3, self.root, "ListTransformer")
 
         # Transform break/continue in loops
         BreakContinueTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("BreakContinueTransformer",
-                                               self.root)
+        translator_logger.log_transformed_code(4, self.root,
+                                               "BreakContinueTransformer")
 
         # Transform return in functions
         ReturnTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("ReturnTransformer", self.root)
+        translator_logger.log_transformed_code(5, self.root,
+                                               "ReturnTransformer")
 
         # Transform logical and/or/not
         LogicalTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("LogicalTransformer", self.root)
+        translator_logger.log_transformed_code(6, self.root,
+                                               "LogicalTransformer")
 
         # Transform for loop and while loop
         LoopTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("LoopTransformer", self.root)
+        translator_logger.log_transformed_code(7, self.root, "LoopTransformer")
 
         # Transform all if/else statement of Dygraph into Static Graph.
         IfElseTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("IfElseTransformer", self.root)
+        translator_logger.log_transformed_code(8, self.root,
+                                               "IfElseTransformer")
 
         # Transform python assert statement
         AssertTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("AssertTransformer", self.root)
+        translator_logger.log_transformed_code(9, self.root,
+                                               "AssertTransformer")
 
         # Transform all python print statement
         PrintTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("PrintTransformer", self.root)
+        translator_logger.log_transformed_code(10, self.root,
+                                               "PrintTransformer")
 
         # Transform call recursively
         CallTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("CallTransformer", self.root)
+        translator_logger.log_transformed_code(11, self.root, "CallTransformer")
 
         # Transform python type casting statement
         CastTransformer(node_wrapper).transform()
-        translator_logger.log_transformed_code("CastTransformer", self.root)
+        translator_logger.log_transformed_code(12, self.root, "CastTransformer")
+
+        translator_logger.log_transformed_code(logging_utils.LOG_AllTransformer,
+                                               self.root, "All Transformers")
 
     def visit_FunctionDef(self, node):
         if self.decorate_func_name is None:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -19,6 +19,8 @@ from paddle.fluid.dygraph.dygraph_to_static.static_analysis import AstNodeWrappe
 from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
 from paddle.fluid.dygraph.dygraph_to_static.utils import is_paddle_api
 
+PDB_SET = "pdb.set_trace"
+
 
 class CallTransformer(gast.NodeTransformer):
     """
@@ -65,7 +67,7 @@ class CallTransformer(gast.NodeTransformer):
 
         # NOTE(liym27): Don't convert `pad.set_trace` even if the convertion doesn't work finally, because
         # it is clearer to see where it is called from.
-        if "pdb.set_trace" in func_str:
+        if PDB_SET in func_str:
             return node
 
         new_func_str = "fluid.dygraph.dygraph_to_static.convert_call({})".format(

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -62,6 +62,12 @@ class CallTransformer(gast.NodeTransformer):
             return node
 
         func_str = ast_to_source_code(node.func).strip()
+
+        # NOTE(liym27): Don't convert `pad.set_trace` even if the convertion doesn't work finally, because
+        # it is clearer to see where it is called from.git
+        if "pdb.set_trace" in func_str:
+            return node
+
         new_func_str = "fluid.dygraph.dygraph_to_static.convert_call({})".format(
             func_str)
         new_func_ast = gast.parse(new_func_str).body[0].value

--- a/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/call_transformer.py
@@ -64,7 +64,7 @@ class CallTransformer(gast.NodeTransformer):
         func_str = ast_to_source_code(node.func).strip()
 
         # NOTE(liym27): Don't convert `pad.set_trace` even if the convertion doesn't work finally, because
-        # it is clearer to see where it is called from.git
+        # it is clearer to see where it is called from.
         if "pdb.set_trace" in func_str:
             return node
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -33,6 +33,8 @@ from paddle.fluid.dygraph.dygraph_to_static.program_translator import StaticLaye
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import convert_to_static
 from paddle.fluid.dygraph.layers import Layer
 
+# TODO(liym27): A better way to do this.
+BUILTIN_LIKELY_MODULES = [collections, pdb, copy, inspect, re, six, numpy]
 
 translator_logger = TranslatorLogger()
 
@@ -57,9 +59,11 @@ def is_paddle_func(func):
 
 
 def is_unsupported(func):
-    # TODO(liym27): A better way to do this.
-    if any(func in m.__dict__.values()
-           for m in (collections, pdb, copy, inspect, re, six, numpy)):
+    """
+    Checks whether the func is supported by dygraph to static graph.
+    """
+
+    if any(func in m.__dict__.values() for m in BUILTIN_LIKELY_MODULES):
         translator_logger.log(
             2,
             "Whitelist: {} is part of built-in module and does not have to be transformed.".
@@ -108,7 +112,8 @@ def convert_call(func):
           #  [1. 1. 1.]]
 
     """
-    translator_logger.log(1, "Convert call: convert {}.".format(func))
+    translator_logger.log(1,
+                          "Convert callable object: convert {}.".format(func))
     func_self = None
     converted_call = None
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -57,7 +57,6 @@ def is_paddle_func(func):
 
 
 def is_unsupported(func):
-    # Other built-in modules
     # TODO(liym27): A better way to do this.
     if any(func in m.__dict__.values()
            for m in (collections, pdb, copy, inspect, re, six, numpy)):
@@ -202,7 +201,8 @@ def convert_call(func):
                 # it doesn't need to be transformed
                 func_self = None if func_self else func_self
     else:
-        raise NotImplementedError
+        raise NotImplementedError(
+            "Callable {} can not be transformed at present.".format(func))
 
     if converted_call is None:
         translator_logger.warn(

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -38,6 +38,7 @@ BUILTIN_LIKELY_MODULES = [collections, pdb, copy, inspect, re, six, numpy]
 
 translator_logger = TranslatorLogger()
 
+
 def is_builtin(func):
     if isinstance(func, types.BuiltinFunctionType):
         return True

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -150,7 +150,3 @@ class ErrorData(object):
 
         error_value_str = '\n'.join(error_value_lines)
         self.error_value = self.error_type(error_value_str)
-
-
-class TransformerError(Exception):
-    pass

--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -150,3 +150,7 @@ class ErrorData(object):
 
         error_value_str = '\n'.join(error_value_lines)
         self.error_value = self.error_type(error_value_str)
+
+
+class TransformerError(Exception):
+    pass

--- a/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
@@ -21,7 +21,7 @@ from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
 
 __all__ = ["TranslatorLogger", "set_verbosity", "set_code_level"]
 
-VERBOSITY_ENV_NAME = 'TRANLATOR_VERBOSITY'
+VERBOSITY_ENV_NAME = 'TRANSLATOR_VERBOSITY'
 DEFAULT_VERBOSITY = 0
 
 
@@ -85,7 +85,7 @@ class TranslatorLogger(object):
         self._transformed_code_level = level
 
     def check_level(self, level, name_to_level_dict):
-        if isinstance(level, six.integer_types):
+        if isinstance(level, (six.integer_types, type(None))):
             rv = level
         elif str(level) == level:
             if level not in name_to_level_dict:
@@ -117,39 +117,11 @@ class TranslatorLogger(object):
     def log_transformed_code(self, level, ast_node, *args, **kwargs):
         if self.has_code_level(level):
             msg = ast_to_source_code(ast_node)
-            msg = "Transformed code \n" + msg
+            msg = "Transformed code: \n" + msg
             self.logger.info(msg, *args, **kwargs)
 
 
 _TRANSLATOR_LOGGER = TranslatorLogger()
-
-
-def set_verbosity(level=0):
-    """
-    Sets the verbosity level for dygraph to static graph.
-
-    There are two means to set the logging verbosity:
-     1. Call function `set_verbosity`
-     2. Set environment variable `verbosity_level`
-    NOTE: `set_verbosity` has higher priority than the environment variable
-
-    Args:
-        level(int): The verbosity level. The larger value idicates more verbosity.
-            The default value is 0, which means no logging.
-    Examples:
-        .. code-block:: python
-
-            import os
-            import paddle.fluid as fluid
-
-            fluid.dygraph.dygraph_to_static.set_verbosity(1)
-            # The verbosity level is now 1
-
-            os.environ['verbosity_level'] = 3
-            # The verbosity level is now 3, but it has no effect
-    """
-    _TRANSLATOR_LOGGER.verbosity_level = level
-
 
 BasicApiTransformer = 1
 TensorShapeTransformer = 2
@@ -182,6 +154,37 @@ _transformer_name_to_level = {
 }
 
 
+def set_verbosity(level=0):
+    """
+    Sets the verbosity level for dygraph to static graph.
+
+    There are two means to set the logging verbosity:
+     1. Call function `set_verbosity`
+     2. Set environment variable `TRANSLATOR_VERBOSITY`
+    NOTE: `set_verbosity` has higher priority than the environment variable
+
+    Args:
+        level(int): The verbosity level. The larger value idicates more verbosity.
+            The default value is 0, which means no logging.
+    Examples:
+        .. code-block:: python
+
+            import os
+            import paddle.fluid as fluid
+
+            fluid.dygraph.dygraph_to_static.set_verbosity(1)
+            # The verbosity level is now 1
+
+            os.environ['TRANSLATOR_VERBOSITY'] = '3'
+            # The verbosity level is now 3, but it has no effect
+    """
+    _TRANSLATOR_LOGGER.verbosity_level = level
+
+
+def get_verbosity():
+    return _TRANSLATOR_LOGGER.verbosity_level
+
+
 def set_code_level(level):
     """
     Sets the level to print code from specific Ast Transformer.
@@ -200,3 +203,23 @@ def set_code_level(level):
             # It will print the transformed code after CastTransformer.
         """
     _TRANSLATOR_LOGGER.transformed_code_level = level
+
+
+def get_code_level():
+    return _TRANSLATOR_LOGGER.transformed_code_level
+
+
+def error(msg, *args, **kwargs):
+    _TRANSLATOR_LOGGER.error(msg, *args, **kwargs)
+
+
+def warn(msg, *args, **kwargs):
+    _TRANSLATOR_LOGGER.warn(msg, *args, **kwargs)
+
+
+def log(level, msg, *args, **kwargs):
+    _TRANSLATOR_LOGGER.log(level, msg, *args, **kwargs)
+
+
+def log_transformed_code(level, ast_node, *args, **kwargs):
+    _TRANSLATOR_LOGGER.log_transformed_code(level, ast_node, *args, **kwargs)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import threading
+
+import six
+from paddle.fluid import log_helper
+from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
+
+__all__ = ["TranslatorLogger", "set_verbosity", "set_code_level"]
+
+VERBOSITY_ENV_NAME = 'TRANLATOR_VERBOSITY'
+DEFAULT_VERBOSITY = 0
+
+
+def synchronized(func):
+    def wrapper(*args, **kwargs):
+        with threading.Lock():
+            return func(*args, **kwargs)
+
+    return wrapper
+
+
+class TranslatorLogger(object):
+    """
+    class for Logging and debugging during the tranformation from dygraph to static graph.
+    The object of this class is a singleton.
+    """
+
+    @synchronized
+    def __new__(cls, *args, **kwargs):
+        if not hasattr(cls, '_instance'):
+            cls._instance = object.__new__(cls, *args, **kwargs)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self):
+        if self._initialized:
+            return
+
+        self._initialized = True
+        self._logger = log_helper.get_logger(
+            __name__, 1, fmt='%(asctime)s-%(levelname)s: %(message)s')
+        self._verbosity_level = None
+        self._transformed_code_level = None
+
+    @property
+    def logger(self):
+        return self._logger
+
+    @property
+    def verbosity_level(self):
+        if self._verbosity_level is not None:
+            return self._verbosity_level
+        else:
+            return int(os.getenv(VERBOSITY_ENV_NAME, DEFAULT_VERBOSITY))
+
+    @verbosity_level.setter
+    def verbosity_level(self, level):
+        self.check_level(level, {})
+        self._verbosity_level = level
+
+    @property
+    def transformed_code_level(self):
+        if self._transformed_code_level is not None:
+            return self._transformed_code_level
+        else:
+            return -1
+
+    @transformed_code_level.setter
+    def transformed_code_level(self, level):
+        self.check_level(level, _transformer_name_to_level)
+        self._transformed_code_level = level
+
+    def check_level(self, level, name_to_level_dict):
+        if isinstance(level, six.integer_types):
+            rv = level
+        elif str(level) == level:
+            if level not in name_to_level_dict:
+                raise ValueError("Unknown level: %r" % level)
+            rv = name_to_level_dict[level]
+        else:
+            raise TypeError("Level not an integer or a valid string: %r" %
+                            level)
+        return rv
+
+    def has_code_level(self, level):
+        level = self.check_level(level, _transformer_name_to_level)
+        return level == self.transformed_code_level
+
+    def has_verbosity(self, level):
+        level = self.check_level(level, {})
+        return level >= self.verbosity_level
+
+    def error(self, msg, *args, **kwargs):
+        self.logger.error(msg, *args, **kwargs)
+
+    def warn(self, msg, *args, **kwargs):
+        self.logger.warn(msg, *args, **kwargs)
+
+    def log(self, level, msg, *args, **kwargs):
+        if self.has_verbosity(level):
+            self.logger.log(level, msg, *args, **kwargs)
+
+    def log_transformed_code(self, level, ast_node, *args, **kwargs):
+        if self.has_code_level(level):
+            msg = ast_to_source_code(ast_node)
+            msg = "Transformed code \n" + msg
+            self.logger.info(msg, *args, **kwargs)
+
+
+_TRANSLATOR_LOGGER = TranslatorLogger()
+
+
+def set_verbosity(level=0):
+    """
+    Sets the verbosity level for dygraph to static graph.
+
+    There are two means to set the logging verbosity:
+     1. Call function `set_verbosity`
+     2. Set environment variable `verbosity_level`
+    NOTE: `set_verbosity` has higher priority than the environment variable
+
+    Args:
+        level(int): The verbosity level. The larger value idicates more verbosity.
+            The default value is 0, which means no logging.
+    Examples:
+        .. code-block:: python
+
+            import os
+            import paddle.fluid as fluid
+
+            fluid.dygraph.dygraph_to_static.set_verbosity(1)
+            # The verbosity level is now 1
+
+            os.environ['verbosity_level'] = 3
+            # The verbosity level is now 3, but it has no effect
+    """
+    _TRANSLATOR_LOGGER.verbosity_level = level
+
+
+BasicApiTransformer = 1
+TensorShapeTransformer = 2
+ListTransformer = 3
+BreakContinueTransformer = 4
+ReturnTransformer = 5
+LogicalTransformer = 6
+LoopTransformer = 7
+IfElseTransformer = 8
+AssertTransformer = 9
+PrintTransformer = 10
+CallTransformer = 11
+CastTransformer = 12
+AllTransformer = 12
+
+_transformer_name_to_level = {
+    'BasicApiTransformer': BasicApiTransformer,
+    'TensorShapeTransformer': TensorShapeTransformer,
+    'ListTransformer': ListTransformer,
+    'BreakContinueTransformer': BreakContinueTransformer,
+    'ReturnTransformer': ReturnTransformer,
+    'LogicalTransformer': LogicalTransformer,
+    'LoopTransformer': LoopTransformer,
+    'IfElseTransformer': IfElseTransformer,
+    'AssertTransformer': AssertTransformer,
+    'PrintTransformer': PrintTransformer,
+    'CallTransformer': CallTransformer,
+    'CastTransformer': CastTransformer,
+    'AllTransformer': AllTransformer
+}
+
+
+def set_code_level(level):
+    """
+    Sets the level to print code from specific Ast Transformer.
+
+    Args:
+        level(int): The level to print code.
+
+    Examples:
+        .. code-block:: python
+
+            import os
+            import paddle.fluid as fluid
+            from paddle.fluid.dygraph.dygraph_to_static import logging_utils
+
+            logging_utils.set_code_level(logging_utils.CastTransformer)
+            # It will print the transformed code after CastTransformer.
+        """
+    _TRANSLATOR_LOGGER.transformed_code_level = level

--- a/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
@@ -127,16 +127,18 @@ _TRANSLATOR_LOGGER = TranslatorLogger()
 
 def set_verbosity(level=0):
     """
-    Sets the verbosity level for dygraph to static graph.
-
+    Sets the verbosity level of log for dygraph to static graph.
     There are two means to set the logging verbosity:
      1. Call function `set_verbosity`
      2. Set environment variable `TRANSLATOR_VERBOSITY`
-    NOTE: `set_verbosity` has a higher priority than the environment variable
+
+    **Note**:
+    `set_verbosity` has a higher priority than the environment variable.
 
     Args:
         level(int): The verbosity level. The larger value idicates more verbosity.
             The default value is 0, which means no logging.
+
     Examples:
         .. code-block:: python
 
@@ -162,27 +164,29 @@ LOG_AllTransformer = 100
 def set_code_level(level=LOG_AllTransformer):
     """
     Sets the level to print code from specific level of Ast Transformer.
-
     There are two means to set the code level:
      1. Call function `set_code_level`
      2. Set environment variable `TRANSLATOR_CODE_LEVEL`
 
-    NOTE: `set_code_level` has a higher priority than the environment variable
+    **Note**:
+    `set_code_level` has a higher priority than the environment variable.
 
     Args:
-        level(int): The level to print code. Default is 100, which means to print the code after all AST Transformers
+        level(int): The level to print code. Default is 100, which means to print the code after all AST Transformers.
 
     Examples:
         .. code-block:: python
+
             import paddle
 
             paddle.jit.set_code_level(2)
-            # It will print the transformed code at level 2, which means to print the code after CastTransformer.
+            # It will print the transformed code at level 2, which means to print the code after second transformer,
+            # as the date of August 28, 2020, it is CastTransformer.
 
             os.environ['TRANSLATOR_CODE_LEVEL'] = '3'
             # The code level is now 3, but it has no effect because it has a lower priority than `set_code_level`
 
-        """
+    """
     _TRANSLATOR_LOGGER.transformed_code_level = level
 
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -30,8 +30,8 @@ from paddle.fluid.layers.utils import flatten
 from paddle.fluid.dygraph.base import param_guard
 from paddle.fluid.dygraph.base import switch_to_static_graph
 from paddle.fluid.dygraph.dygraph_to_static import DygraphToStaticAst
-from paddle.fluid.dygraph.dygraph_to_static.error import attach_error_data
 from paddle.fluid.dygraph.dygraph_to_static.error import ERROR_DATA
+from paddle.fluid.dygraph.dygraph_to_static.error import attach_error_data
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import attach_origin_info
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import create_and_update_origin_info_map
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import update_op_callstack_with_origin_info

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -32,8 +32,6 @@ from paddle.fluid.dygraph.base import switch_to_static_graph
 from paddle.fluid.dygraph.dygraph_to_static import DygraphToStaticAst
 from paddle.fluid.dygraph.dygraph_to_static.error import attach_error_data
 from paddle.fluid.dygraph.dygraph_to_static.error import ERROR_DATA
-from paddle.fluid.dygraph.dygraph_to_static.error import TransformerError
-from paddle.fluid.dygraph.dygraph_to_static.logging_utils import TranslatorLogger
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import attach_origin_info
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import create_and_update_origin_info_map
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import update_op_callstack_with_origin_info
@@ -138,14 +136,8 @@ def convert_to_static(function):
         function(callable): The function with dygraph layers that will be converted into static layers.
     """
     with _CACHE_LOCK:
-        try:
-            static_func = _FUNCTION_CACHE.convert_with_cache(function)
-            return static_func
-        except Exception as e:
-            translator_logger = TranslatorLogger()
-            translator_logger.error('Transform {} failed.'.format(function))
-            raise TransformerError("Transforming {}: {}".format(function,
-                                                                str(e)))
+        static_func = _FUNCTION_CACHE.convert_with_cache(function)
+        return static_func
 
 
 class CacheKey(object):

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -24,6 +24,7 @@ from paddle.fluid import core
 from paddle.fluid.compiler import BuildStrategy, CompiledProgram, ExecutionStrategy
 from paddle.fluid.data_feeder import check_type
 from paddle.fluid.dygraph.base import program_desc_tracing_guard, switch_to_static_graph
+from paddle.fluid.dygraph.dygraph_to_static.logging_utils import set_code_level, set_verbosity
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator, StaticLayer, unwrap_decorators
 from paddle.fluid.dygraph.io import EXTRA_VAR_INFO_FILENAME, VARIABLE_FILENAME, TranslatedLayer
 from paddle.fluid.dygraph.layers import Layer
@@ -33,7 +34,10 @@ from paddle.fluid.framework import _current_expected_place, _dygraph_guard, _dyg
 from paddle.fluid.framework import dygraph_only, in_dygraph_mode
 from paddle.fluid.wrapped_decorator import wrap_decorator
 
-__all__ = ['TracedLayer', 'declarative', 'dygraph_to_static_func']
+__all__ = [
+    'TracedLayer', 'declarative', 'dygraph_to_static_func', 'set_code_level',
+    'set_verbosity'
+]
 
 
 def create_program_from_desc(program_desc):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -1,0 +1,171 @@
+#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import paddle.fluid as fluid
+from paddle.fluid.dygraph import ProgramTranslator
+from paddle.fluid.dygraph import declarative
+from paddle.fluid.dygraph.dygraph_to_static import logging_utils
+
+program_translator = ProgramTranslator()
+
+SEED = 2020
+np.random.seed(SEED)
+
+logging_utils.set_verbosity(1)
+logging_utils.set_code_level(logging_utils.AllTransformer)
+
+
+# Use a decorator to test exception
+@declarative
+def dyfunc_with_if(x_v):
+    if fluid.layers.mean(x_v).numpy()[0] > 5:
+        x_v = x_v - 1
+    else:
+        x_v = x_v + 1
+    return x_v
+
+
+@declarative
+def nested_func(x_v):
+    x_v = fluid.dygraph.to_variable(x_v)
+
+    def fn1():
+        return x_v
+
+    res = fn1()
+    return res
+
+
+class TestRecursiveCall1(unittest.TestCase):
+    def setUp(self):
+        self.input = np.random.random([10, 16]).astype('float32')
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        self.init_test_func()
+
+    def init_test_func(self):
+        self.dyfunc = nested_func
+
+    def get_dygraph_output(self):
+        program_translator.enable(False)
+        with fluid.dygraph.guard():
+            res = self.dyfunc(self.input).numpy()
+            return res
+
+    def get_static_output(self):
+        program_translator.enable(True)
+        with fluid.dygraph.guard():
+            res = self.dyfunc(self.input).numpy()
+            return res
+
+    def test_transformed_static_result(self):
+        static_res = self.get_static_output()
+        dygraph_res = self.get_dygraph_output()
+        self.assertTrue(
+            np.allclose(dygraph_res, static_res),
+            msg='dygraph res is {}\nstatic_res is {}'.format(dygraph_res,
+                                                             static_res))
+
+
+lambda_fun = lambda x: x
+
+
+class MyConvLayer(fluid.dygraph.Layer):
+    def __init__(self):
+        super(MyConvLayer, self).__init__()
+        self._conv = fluid.dygraph.Conv2D(
+            num_channels=3,
+            num_filters=2,
+            filter_size=3,
+            param_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.99)),
+            bias_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.5)))
+
+    @declarative
+    def forward(self, inputs):
+        y = dyfunc_with_if(inputs)
+        y = lambda_fun(y)
+        y = self.dymethod(y)
+        return y
+
+    @declarative
+    def dymethod(self, x_v):
+        x_v = fluid.layers.assign(x_v)
+        return x_v
+
+
+class MyLayer(fluid.dygraph.Layer):
+    def __init__(self):
+        super(MyLayer, self).__init__()
+
+        self.conv = MyConvLayer()
+        self.fc = fluid.dygraph.Linear(
+            input_dim=5,
+            output_dim=1,
+            act='relu',
+            param_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.99)),
+            bias_attr=fluid.ParamAttr(
+                initializer=fluid.initializer.Constant(value=0.5)))
+
+    @declarative
+    def forward(self, inputs):
+        h = self.conv(inputs)
+        out = self.fc(h)
+        return out
+
+
+class TestRecursiveCall2(unittest.TestCase):
+    def setUp(self):
+        self.input = np.random.random((1, 3, 3, 5)).astype('float32')
+        self.Layer = MyLayer
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+
+    def _run(self):
+        with fluid.dygraph.guard():
+            self.dygraph_func = self.Layer()
+            fluid.default_startup_program.random_seed = SEED
+            fluid.default_main_program.random_seed = SEED
+            data = fluid.dygraph.to_variable(self.input)
+            res = self.dygraph_func(data)
+
+            return res.numpy()
+
+    def get_dygraph_output(self):
+        program_translator.enable(False)
+        return self._run()
+
+    def get_static_output(self):
+        program_translator.enable(True)
+        return self._run()
+
+    def test_transformed_static_result(self):
+        dygraph_res = self.get_dygraph_output()
+        static_res = self.get_static_output()
+        self.assertTrue(
+            np.allclose(dygraph_res, static_res),
+            msg='dygraph is {}\n static_res is \n{}'.format(dygraph_res,
+                                                            static_res))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -21,9 +21,13 @@ import sys
 import unittest
 
 import gast
-import mock
 import six
 from paddle.fluid.dygraph.dygraph_to_static import logging_utils
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
 
 
 class TestLoggingUtils(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -22,6 +22,8 @@ import unittest
 
 import gast
 import six
+
+import paddle
 from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 
 # TODO(liym27): library mock needs to be installed separately in PY2,
@@ -40,30 +42,34 @@ class TestLoggingUtils(unittest.TestCase):
         self.translator_logger = logging_utils._TRANSLATOR_LOGGER
 
     def test_verbosity(self):
-        logging_utils.set_verbosity(None)
+        paddle.jit.set_verbosity(None)
         os.environ[logging_utils.VERBOSITY_ENV_NAME] = '3'
         self.assertEqual(logging_utils.get_verbosity(), 3)
 
-        logging_utils.set_verbosity(self.verbosity_level)
+        paddle.jit.set_verbosity(self.verbosity_level)
         self.assertEqual(self.verbosity_level, logging_utils.get_verbosity())
 
         # String is not supported
         with self.assertRaises(TypeError):
-            logging_utils.set_verbosity("3")
+            paddle.jit.set_verbosity("3")
 
         with self.assertRaises(TypeError):
-            logging_utils.set_verbosity(3.3)
+            paddle.jit.set_verbosity(3.3)
 
     def test_code_level(self):
 
-        logging_utils.set_code_level(self.code_level)
+        paddle.jit.set_code_level(None)
+        os.environ[logging_utils.CODE_LEVEL_ENV_NAME] = '2'
+        self.assertEqual(logging_utils.get_code_level(), 2)
+
+        paddle.jit.set_code_level(self.code_level)
         self.assertEqual(logging_utils.get_code_level(), self.code_level)
 
-        logging_utils.set_code_level(9)
+        paddle.jit.set_code_level(9)
         self.assertEqual(logging_utils.get_code_level(), 9)
 
         with self.assertRaises(TypeError):
-            logging_utils.set_code_level(3.3)
+            paddle.jit.set_code_level(3.3)
 
     def test_log(self):
         stream = io.BytesIO() if six.PY2 else io.StringIO()
@@ -98,11 +104,11 @@ class TestLoggingUtils(unittest.TestCase):
 
         if six.PY3:
             with mock.patch.object(sys, 'stdout', stream):
-                logging_utils.set_code_level(1)
+                paddle.jit.set_code_level(1)
                 logging_utils.log_transformed_code(1, ast_code,
                                                    "BasicApiTransformer")
 
-                logging_utils.set_code_level()
+                paddle.jit.set_code_level()
                 logging_utils.log_transformed_code(
                     logging_utils.LOG_AllTransformer, ast_code,
                     "All Transformers")

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -24,10 +24,13 @@ import gast
 import six
 from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 
-if six.PY2:
-    import mock
-else:
+# TODO(liym27): library mock needs to be installed separately in PY2,
+#  but CI environment has not installed mock yet.
+#  After discuss with Tian Shuo, now use mock only in PY3, and use it in PY2 after CI installs it.
+if six.PY3:
     from unittest import mock
+# else:
+#     import mock
 
 
 class TestLoggingUtils(unittest.TestCase):
@@ -45,7 +48,7 @@ class TestLoggingUtils(unittest.TestCase):
         self.assertEqual(self.verbosity_level, logging_utils.get_verbosity())
 
         # String is not supported
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             logging_utils.set_verbosity("3")
 
         with self.assertRaises(TypeError):
@@ -56,7 +59,7 @@ class TestLoggingUtils(unittest.TestCase):
         logging_utils.set_code_level(self.code_level)
         self.assertEqual(logging_utils.get_code_level(), self.code_level)
 
-        logging_utils.set_code_level(logging_utils.AssertTransformer)
+        logging_utils.set_code_level(9)
         self.assertEqual(logging_utils.get_code_level(), 9)
 
         with self.assertRaises(TypeError):
@@ -72,15 +75,17 @@ class TestLoggingUtils(unittest.TestCase):
         error_msg = "test_error"
         log_msg_1 = "test_log_1"
         log_msg_2 = "test_log_2"
-        with mock.patch.object(sys, 'stdout', stream):
-            logging_utils.warn(warn_msg)
-            logging_utils.error(error_msg)
-            self.translator_logger.verbosity_level = 2
-            logging_utils.log(1, log_msg_1)
-            logging_utils.log(2, log_msg_2)
 
-        result_msg = '\n'.join([warn_msg, error_msg, log_msg_2, ""])
-        self.assertEqual(result_msg, stream.getvalue())
+        if six.PY3:
+            with mock.patch.object(sys, 'stdout', stream):
+                logging_utils.warn(warn_msg)
+                logging_utils.error(error_msg)
+                self.translator_logger.verbosity_level = 2
+                logging_utils.log(1, log_msg_1)
+                logging_utils.log(2, log_msg_2)
+
+            result_msg = '\n'.join([warn_msg, error_msg, log_msg_2, ""])
+            self.assertEqual(result_msg, stream.getvalue())
 
     def test_log_transformed_code(self):
         source_code = "x = 3"
@@ -91,11 +96,18 @@ class TestLoggingUtils(unittest.TestCase):
         stdout_handler = logging.StreamHandler(stream)
         log.addHandler(stdout_handler)
 
-        with mock.patch.object(sys, 'stdout', stream):
-            logging_utils.set_code_level(1)
-            logging_utils.log_transformed_code(1, ast_code)
+        if six.PY3:
+            with mock.patch.object(sys, 'stdout', stream):
+                logging_utils.set_code_level(1)
+                logging_utils.log_transformed_code(1, ast_code,
+                                                   "BasicApiTransformer")
 
-        self.assertIn(source_code, stream.getvalue())
+                logging_utils.set_code_level()
+                logging_utils.log_transformed_code(
+                    logging_utils.LOG_AllTransformer, ast_code,
+                    "All Transformers")
+
+            self.assertIn(source_code, stream.getvalue())
 
 
 if __name__ == '__main__':

--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -16,11 +16,13 @@ from ..fluid.dygraph.jit import save  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import load  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import SaveLoadConfig  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import TracedLayer  #DEFINE_ALIAS
+from ..fluid.dygraph.jit import set_code_level  #DEFINE_ALIAS
+from ..fluid.dygraph.jit import set_verbosity  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import declarative as to_static  #DEFINE_ALIAS
 from ..fluid.dygraph import ProgramTranslator  #DEFINE_ALIAS
 from ..fluid.dygraph.io import TranslatedLayer  #DEFINE_ALIAS
 
 __all__ = [
     'save', 'load', 'SaveLoadConfig', 'TracedLayer', 'to_static',
-    'ProgramTranslator', 'TranslatedLayer'
+    'ProgramTranslator', 'TranslatedLayer', 'set_code_level', 'set_verbosity'
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add debugging and logging mechanism for dygraph to static graph
1. Add logs in the conversion of function, and unified log information, clear and easy to understand.
 For example:
```
2020-08-26 11:09:42,088-Level 2: Whitelist: <paddle.fluid.dygraph.nn.Linear object at 0x13306dd70> is part of Paddle module and does not have to be transformed.
```

2. Add function `set_verbosity(level=0)` for user to set the verbosity level for dygraph to static graph.
    There are two means to set the logging verbosity:
     1. Call function `set_verbosity`
     2. Set environment variable `TRANSLATOR_VERBOSITY`
 
3. Add function `set_code_level(level)` for user to set the level to print code from specific Ast Transformer.
