### PR TITLE
Refine jit load model by extra_var_info

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 
 import os
+import pickle
 import unittest
 import numpy as np
 
@@ -25,7 +26,7 @@ from paddle.fluid.dygraph import declarative, ProgramTranslator
 from paddle.fluid.dygraph.io import VARIABLE_FILENAME, EXTRA_VAR_INFO_FILENAME
 
 BATCH_SIZE = 32
-BATCH_NUM = 20
+BATCH_NUM = 10
 SEED = 10
 
 
@@ -335,13 +336,13 @@ class LinearNetReturnHidden(fluid.dygraph.Layer):
 class TestJitPruneModelAndLoad(unittest.TestCase):
     def setUp(self):
         self.linear_size = 4
-        self.model_path = "model.jit_multi_load"
+        self.model_path = "model.jit_prune_model_and_load"
         # enable dygraph mode
         fluid.enable_dygraph()
         # config seed
         fluid.default_main_program().random_seed = SEED
 
-    def test_load_pruned_model(self):
+    def train_and_save(self):
         train_layer = LinearNetReturnHidden(8, 8)
         adam = fluid.optimizer.AdamOptimizer(
             learning_rate=0.1, parameter_list=train_layer.parameters())
@@ -353,23 +354,40 @@ class TestJitPruneModelAndLoad(unittest.TestCase):
             adam.minimize(loss)
             train_layer.clear_gradients()
 
-        model_path = "model.save_load_config.output_spec"
         configs = fluid.dygraph.jit.SaveLoadConfig()
         configs.output_spec = [hidden]
         fluid.dygraph.jit.save(
             layer=train_layer,
-            model_path=model_path,
+            model_path=self.model_path,
             input_spec=[x],
             configs=configs)
 
+        return train_layer
+
+    def test_load_pruned_model(self):
+        train_layer = self.train_and_save()
         train_layer.eval()
-        print(train_layer.state_dict())
-        infer_layer = fluid.dygraph.jit.load(model_path, configs=configs)
-        print(infer_layer.state_dict())
+
+        infer_layer = fluid.dygraph.jit.load(self.model_path)
+
         x = fluid.dygraph.to_variable(
             np.random.random((4, 8)).astype('float32'))
         self.assertTrue(
             np.array_equal(train_layer(x)[0].numpy(), infer_layer(x).numpy()))
+
+    def test_load_var_not_in_extra_var_info(self):
+        self.train_and_save()
+
+        # chage extra var info
+        var_info_path = os.path.join(self.model_path, EXTRA_VAR_INFO_FILENAME)
+        with open(var_info_path, 'rb') as f:
+            extra_var_info = pickle.load(f)
+            extra_var_info.clear()
+        with open(var_info_path, 'wb') as f:
+            pickle.dump(extra_var_info, f, protocol=2)
+
+        with self.assertRaises(RuntimeError):
+            fluid.dygraph.jit.load(self.model_path)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->


in some case, users may prune the model and drop some parameters when `save_inference_model`, so we need load persistable vars based the program, because the program may be pruned when `save_inference_model`, some var in `extra_var_info` may have been pruned 

error message of original unittest:
```
======================================================================
ERROR: test_load_pruned_model (__main__.TestJitPruneModelAndLoad)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "../python/paddle/fluid/tests/unittests/test_jit_save_load.py", line 367, in test_load_pruned_model
    infer_layer = fluid.dygraph.jit.load(model_path, configs=configs)
  File "</usr/local/lib/python3.5/dist-packages/decorator.py:decorator-gen-52>", line 2, in load
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 219, in __impl__
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dygraph/jit.py", line 1002, in load
    return TranslatedLayer._construct(model_path, configs)
  File "</usr/local/lib/python3.5/dist-packages/decorator.py:decorator-gen-42>", line 2, in _construct
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/framework.py", line 219, in __impl__
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dygraph/io.py", line 689, in _construct
    model_path, programs, separate_params, params_filename)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dygraph/io.py", line 526, in _construct_params_and_buffers
    params_filename)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dygraph/io.py", line 452, in _load_persistable_vars
    new_name = inv_suffix_varname_dict[name]
KeyError: 'linear_3.b_0'
```

the print parameters after fixed:
```
# train time
.OrderedDict([('_linear_1.weight', Parameter containing:
  Tensor: linear_2.w_0
  - place: CUDAPlace(0)
  - shape: [8, 8]
  - layout: NCHW
  - dtype: float
  - data: [-1.58772 -0.255275 -1.52371 1.49306 -0.275414 -0.168475 0.230902 1.20642 -0.817552 -0.763787 -0.443542 1.11068 -0.100593 -1.14978 1.17326 0.149519 -0.649422 -0.132161 -1.21925 1.18688 0.0815581 -0.947889 1.26608 0.655169 -1.5692 -0.543081 -0.747706 1.08126 -1.02387 -0.115365 0.491379 0.185428 -1.48442 -1.1143 -0.371503 1.47069 -0.0159431 -0.724717 1.17924 1.1528 -1.47183 -0.901608 -0.32105 0.921306 0.023746 -0.374763 0.925162 1.13111 -1.29885 -0.312415 -0.511889 1.3673 -0.903202 -0.297663 0.528955 0.179144 -1.11226 -1.14992 -1.4314 1.50156 -0.163933 -0.484057 1.25413 0.432871]
  - stop_gradient: False), 
('_linear_1.bias', Parameter containing:
  Tensor: linear_2.b_0
  - place: CUDAPlace(0)
  - shape: [8]
  - layout: NCHW
  - dtype: float
  - data: [-0.975621 -0.684333 -0.927903 0.983432 -0.495326 -0.654574 0.659859 0.618442]
  - stop_gradient: False),
 ('_linear_2.weight', Parameter containing:
  Tensor: linear_3.w_0
  - place: CUDAPlace(0)
  - shape: [8, 8]
  - layout: NCHW
  - dtype: float
  - data: [0.397251 1.43841 0.413542 1.51898 1.22926 1.49545 0.580392 1.59733 0.723868 0.486345 1.05016 0.693051 0.960532 0.0705953 1.0792 0.0968771 0.762217 0.98819 0.144674 0.639466 1.0129 0.142703 1.04224 0.472746 -1.59827 -0.863434 -0.82449 -0.906861 -1.53323 -0.465478 -1.17317 -1.4377 -0.393223 -0.314396 0.671974 0.602835 0.594958 0.0454323 0.634957 0.649931 -0.230145 0.0487894 0.872918 0.203939 0.785137 0.545876 0.531368 0.77873 -1.24725 -0.552098 -0.508001 -0.540139 -1.33189 -0.567104 -1.05492 -1.36331 -0.919708 -1.24866 -1.28657 -0.264934 -0.451678 -0.612554 -0.188803 -0.96864]
  - stop_gradient: False),
 ('_linear_2.bias', Parameter containing:
  Tensor: linear_3.b_0
  - place: CUDAPlace(0)
  - shape: [8]
  - layout: NCHW
  - dtype: float
  - data: [-0.999996 -0.999996 -0.999996 -0.999996 -0.999996 -0.999996 -0.999996 -0.999996]
  - stop_gradient: False)])

# load infer time
OrderedDict([('param_0', Parameter containing:
  Tensor: linear_2.w_0.load_0
  - place: CUDAPlace(0)
  - shape: [8, 8]
  - layout: NCHW
  - dtype: float
  - data: [-1.58772 -0.255275 -1.52371 1.49306 -0.275414 -0.168475 0.230902 1.20642 -0.817552 -0.763787 -0.443542 1.11068 -0.100593 -1.14978 1.17326 0.149519 -0.649422 -0.132161 -1.21925 1.18688 0.0815581 -0.947889 1.26608 0.655169 -1.5692 -0.543081 -0.747706 1.08126 -1.02387 -0.115365 0.491379 0.185428 -1.48442 -1.1143 -0.371503 1.47069 -0.0159431 -0.724717 1.17924 1.1528 -1.47183 -0.901608 -0.32105 0.921306 0.023746 -0.374763 0.925162 1.13111 -1.29885 -0.312415 -0.511889 1.3673 -0.903202 -0.297663 0.528955 0.179144 -1.11226 -1.14992 -1.4314 1.50156 -0.163933 -0.484057 1.25413 0.432871]
  - stop_gradient: False), 
('param_1', Parameter containing:
  Tensor: linear_2.b_0.load_0
  - place: CUDAPlace(0)
  - shape: [8]
  - layout: NCHW
  - dtype: float
  - data: [-0.975621 -0.684333 -0.927903 0.983432 -0.495326 -0.654574 0.659859 0.618442]
  - stop_gradient: False)])
``` 