### PR TITLE
Cudnn lstm weight share

### DIFF
--- a/paddle/fluid/operators/cudnn_lstm_op.cc
+++ b/paddle/fluid/operators/cudnn_lstm_op.cc
@@ -137,6 +137,16 @@ class CudnnLSTMOpMaker : public framework::OpProtoAndCheckerMaker {
               "is_bidirec is False"
               "and When is_bidirect is True, the shape will be (num_layers*2 x "
               "batch_size x hidden_size*2)");
+    AddOutput("WeightHh",
+              "(Tensor List), stores weight_hh and share data with W. ")
+        .AsDuplicable();
+    AddOutput("WeightIh",
+              "(Tensor List), stores weight_ih and share data with W.")
+        .AsDuplicable();
+    AddOutput("BiasHh", "(Tensor List), stores bias_hh and share data with W.")
+        .AsDuplicable();
+    AddOutput("BiasIh", "(Tensor List), stores bias_ih and share data with W. ")
+        .AsDuplicable();
     AddAttr<float>(
         "dropout_prob",
         "dropout prob of the dropout op"

--- a/paddle/fluid/operators/cudnn_lstm_op.cu.cc
+++ b/paddle/fluid/operators/cudnn_lstm_op.cu.cc
@@ -52,6 +52,7 @@ class CudnnLSTMGPUKernel : public framework::OpKernel<T> {
     float dropout_prob = ctx.Attr<float>("dropout_prob");
     bool is_bidirec = ctx.Attr<bool>("is_bidirec");
     int hidden_size = ctx.Attr<int>("hidden_size");
+    int input_size = ctx.Attr<int>("input_size");
     int num_layers = ctx.Attr<int>("num_layers");
     bool is_test = ctx.Attr<bool>("is_test");
     int seed = ctx.Attr<int>("seed");
@@ -69,23 +70,31 @@ class CudnnLSTMGPUKernel : public framework::OpKernel<T> {
     int n_direct = is_bidirec ? 2 : 1;
     for (int i = 0; i < num_layers; ++i) {
       for (int j = 0; j < n_direct; ++j) {
-        int weight_num = i * 4 + j;
+        int num = i * n_direct + j;
         int size = 0;
         size = gate_size * input_size;
-        weight_ih[weight_num]=w->Slice(offset,size);
+        LOG(INFO) << "offset 1" << offset << "size" << size;
+        weight_ih[num]->ShareDataWith(w->Slice(offset, offset + size));
         offset += size;
+        LOG(INFO) << "offset 2" << offset << "size" << size;
 
         size = gate_size * hidden_size * n_direct;
-        weight_hh[weight_num]=w->Slice(offset,size);
+        LOG(INFO) << "offset 3" << offset << "size" << size;
+        weight_hh[num]->ShareDataWith(w->Slice(offset, offset + size));
         offset += size;
+        LOG(INFO) << "offset 4" << offset << "size" << size;
 
         size = gate_size * hidden_size;
-        bias_ih[weight_num]=w->Slice(offset,size);
+        LOG(INFO) << "offset 5" << offset << "size" << size;
+        bias_ih[num]->ShareDataWith(w->Slice(offset, offset + size));
         offset += size;
+        LOG(INFO) << "offset 6" << offset << "size" << size;
 
         size = gate_size;
-        bias_hh[weight_num]=w->Slice(offset,size);
+        LOG(INFO) << "offset 7" << offset << "size" << size;
+        bias_hh[num]->ShareDataWith(w->Slice(offset, offset + size));
         offset += size;
+        LOG(INFO) << "offset 8" << offset << "size" << size;
       }
     }
 

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -2285,7 +2285,7 @@ def lstm(input,
     weight_size = 0
     for i in range(num_layers):
         if i == 0:
-            input_weight_size =gate_size * input_size
+            input_weight_size = gate_size * input_size
         else:
             input_weight_size = gate_size * hidden_size * n_direction
 
@@ -2308,6 +2308,22 @@ def lstm(input,
     state_out = helper.create_variable_for_type_inference(
         dtype=core.VarDesc.VarType.UINT8, stop_gradient=True)
     state_out.persistable = True
+    weight_ih = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
+    weight_hh = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
+    bias_ih = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
+    bias_hh = [
+        helper.create_variable_for_type_inference(dtype)
+        for i in range(num_layers * n_direction)
+    ]
 
     helper.append_op(
         type='cudnn_lstm',
@@ -2321,6 +2337,10 @@ def lstm(input,
             'Out': out,
             'LastH': last_h,
             'LastC': last_c,
+            'WeightIh': weight_ih,
+            'WeightHh': weight_hh,
+            'BiasIh': bias_ih,
+            'BiasHh': bias_hh,
             'Reserve': reserve,
             'StateOut': state_out,
         },

--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -2279,25 +2279,20 @@ def lstm(input,
     check_type(num_layers, 'num_layers', (int), 'lstm')
     dtype = input.dtype
     input_shape = list(input.shape)
+    n_direction = 2 if is_bidirec else 1
+    gate_size = hidden_size * 4
     input_size = input_shape[-1]
     weight_size = 0
     for i in range(num_layers):
         if i == 0:
-            input_weight_size = (input_size * hidden_size) * 4
+            input_weight_size =gate_size * input_size
         else:
-            if is_bidirec:
-                input_weight_size = (hidden_size * 2 * hidden_size) * 4
-            else:
-                input_weight_size = (hidden_size * hidden_size) * 4
+            input_weight_size = gate_size * hidden_size * n_direction
 
-        hidden_weight_size = (hidden_size * hidden_size) * 4
+        hidden_weight_size = gate_size * hidden_size
 
-        if is_bidirec:
-            weight_size += (input_weight_size + hidden_weight_size) * 2
-            weight_size += hidden_size * 8 * 2
-        else:
-            weight_size += input_weight_size + hidden_weight_size
-            weight_size += hidden_size * 8
+        weight_size += (input_weight_size + hidden_weight_size)
+        weight_size += gate_size * 2
 
     weight = helper.create_parameter(
         attr=helper.param_attr,

--- a/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lstm_cudnn_op.py
@@ -150,7 +150,7 @@ class TestCUDNNLstmOp(OpTest):
             'InitC': init_c
         }
         self.attrs = {
-            'dropout_prob': 0.0,
+            'dropout_prob': 0.1,
             'is_bidirec': False,
             'input_size': hidden_size,
             'hidden_size': hidden_size,
@@ -161,14 +161,22 @@ class TestCUDNNLstmOp(OpTest):
             "LastH": last_hidden,
             'LastC': last_cell,
             'Reserve': np.ndarray((400)).astype("uint8"),
-            'StateOut': state_out
+            'StateOut': state_out,
+            'WeightIh': [('WeightIh%d' % i, state_out) for i in range(1)],
+            'WeightHh': [('WeightHh%d' % i, state_out) for i in range(1)],
+            'BiasIh': [('BiasIh%d' % i, state_out) for i in range(1)],
+            'BiasHh': [('BiasHh%d' % i, state_out) for i in range(1)]
         }
 
     def test_output_with_place(self):
         # depend on the scope structure
         place = core.CUDAPlace(0)
         self.check_output_with_place(
-            place, no_check_set=['Reserve', 'StateOut'])
+            place,
+            no_check_set=[
+                'Reserve', 'StateOut', 'WeightIh', 'WeightHh', 'BiasIh',
+                'BiasHh'
+            ])
 
     def test_grad_with_place(self):
         # depend on the scope structure


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs 

### Describe
CUDNN与非CUDNN实现参数转换

内容：CUDNN使用特定的参数格式，若自动切换CUDNN，也需要自动转换参数（CUDNN实现中使用合并的参数，非CUDNN实现参数分开存放）

- 在C++端完成参数转换，并将新参数和原参数的共享存储，新参数对用户隐藏，用户仍使用原参数；并在检测到参数不合要求时（如某个参数指向了其他参数而不再连续）在执行时重新转换并打warning（pytorch的方法），较多内容需要由C++端完成。
