### PR TITLE
fix logical related api; test=develop

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -12146,7 +12146,10 @@ def logical_and(x, y, out=None, name=None):
             res = paddle.logical_and(x, y)
             print(res.numpy()) # [True False False False]
     """
-
+    if x.shape != y.shape:
+        raise TypeError(
+            'Input tensors must be same shape, but received x \'s shape: %s, y \'s shape: %s '
+            % (x.shape, y.shape))
     return _logical_op(
         op_name="logical_and", x=x, y=y, name=name, out=out, binary_op=True)
 
@@ -12188,7 +12191,10 @@ def logical_or(x, y, out=None, name=None):
             res = paddle.logical_or(x, y)
             print(res.numpy()) # [True  True  True False]
     """
-
+    if x.shape != y.shape:
+        raise TypeError(
+            'Input tensors must be same shape, but received x \'s shape: %s, y \'s shape: %s '
+            % (x.shape, y.shape))
     return _logical_op(
         op_name="logical_or", x=x, y=y, name=name, out=out, binary_op=True)
 
@@ -12230,7 +12236,10 @@ def logical_xor(x, y, out=None, name=None):
             res = paddle.logical_xor(x, y)
             print(res.numpy()) # [False  True  True False]
     """
-
+    if x.shape != y.shape:
+        raise TypeError(
+            'Input tensors must be same shape, but received x \'s shape: %s, y \'s shape: %s '
+            % (x.shape, y.shape))
     return _logical_op(
         op_name="logical_xor", x=x, y=y, name=name, out=out, binary_op=True)
 

--- a/python/paddle/fluid/tests/unittests/test_logical_op.py
+++ b/python/paddle/fluid/tests/unittests/test_logical_op.py
@@ -17,8 +17,9 @@ from __future__ import print_function
 import op_test
 import unittest
 import numpy as np
+import paddle
 import paddle.fluid as fluid
-from paddle.fluid import Program, program_guard
+from paddle.static import Program, program_guard
 
 
 def create_test_class(op_type, callback, binary_op=True):
@@ -42,6 +43,8 @@ def create_test_class(op_type, callback, binary_op=True):
 
         def test_error(self):
             with program_guard(Program(), Program()):
+
+                # test 1 type error, x, y must be bool type
                 x = fluid.layers.data(name='x', shape=[2], dtype='bool')
                 y = fluid.layers.data(name='y', shape=[2], dtype='bool')
                 a = fluid.layers.data(name='a', shape=[2], dtype='int32')
@@ -54,7 +57,16 @@ def create_test_class(op_type, callback, binary_op=True):
                     self.assertRaises(TypeError, op, x=x, out=1)
                     self.assertRaises(TypeError, op, x=a)
 
-    Cls.__name__ = op_type
+                # test 2 type error, x, y must be same shape
+                x_data = fluid.layers.data(
+                    name='x_data', shape=[2], dtype='bool')
+                y_data = fluid.layers.data(
+                    name='y_data', shape=[2, 2], dtype='bool')
+
+                if self.op_type != "logical_not":
+                    self.assertRaises(TypeError, op, x=x_data, y=y_data, out=1)
+                    self.assertRaises(TypeError, op, x=y_data, y=x_data)
+
     globals()[op_type] = Cls
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 APIs
### Describe
<!-- Describe what this PR does -->

Logic运算包括以下算子：logical_and、logical_or、logical_xor

- 不支持broadcast
- 按目前paddle不支持braodcast进行验证，当两个输入tensor维度不相等时应该报错。

测试代码：
```
from __future__ import print_function

import op_test
import unittest
import numpy as np
import paddle
import paddle.fluid as fluid
from paddle.static import Program, program_guard


def create_test_class(op_type, callback, binary_op=True):
    class Cls(op_test.OpTest):
        def setUp(self):
            a = np.random.choice(a=[True, False], size=(10, 7)).astype(bool)
            if binary_op:
                b = np.random.choice(a=[True, False], size=(10, 7)).astype(bool)
                c = callback(a, b)
            else:
                c = callback(a)
            self.outputs = {'Out': c}
            self.op_type = op_type
            if binary_op:
                self.inputs = {'X': a, 'Y': b}
            else:
                self.inputs = {'X': a}

        def test_output(self):
            self.check_output()

        def test_error(self):
            with program_guard(Program(), Program()):
                
                # test 1 type error, x, y must be bool type
                x = fluid.layers.data(name='x', shape=[2], dtype='bool')
                y = fluid.layers.data(name='y', shape=[2], dtype='bool')
                a = fluid.layers.data(name='a', shape=[2], dtype='int32')
                op = eval("fluid.layers.%s" % self.op_type)
                if self.op_type != "logical_not":
                    self.assertRaises(TypeError, op, x=x, y=y, out=1)
                    self.assertRaises(TypeError, op, x=x, y=a)
                    self.assertRaises(TypeError, op, x=a, y=y)
                else:
                    self.assertRaises(TypeError, op, x=x, out=1)
                    self.assertRaises(TypeError, op, x=a)
                
                # test 2 type error, x, y must be bool type
                x_data = fluid.layers.data(name='x_data', shape=[2], dtype='bool')
                y_data = fluid.layers.data(name='y_data', shape=[2,2], dtype='bool')
                
                if self.op_type != "logical_not":
                    self.assertRaises(TypeError, op, x=x_data, y=y_data, out=1)
                    self.assertRaises(TypeError, op, x=y_data, y=x_data)


    globals()[op_type] = Cls


create_test_class('logical_and', lambda _a, _b: np.logical_and(_a, _b))
create_test_class('logical_or', lambda _a, _b: np.logical_or(_a, _b))
create_test_class('logical_not', lambda _a: np.logical_not(_a), False)
create_test_class('logical_xor', lambda _a, _b: np.logical_xor(_a, _b))

if __name__ == '__main__':
    unittest.main()

```
