### PR TITLE
Add use of global flag 'use_mkldnn' to layer_helper

### DIFF
--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -50,8 +50,7 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
                      const platform::Place& place, bool trace_backward) {
   VLOG(1) << "Trace Op: " << type;
   if (FLAGS_use_mkldnn) {
-    auto& mutable_op_attrs = const_cast<framework::AttributeMap&>(attrs);
-    mutable_op_attrs["use_mkldnn"] = true;
+    attrs["use_mkldnn"] = true;
   }
   auto op = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
   const auto& op_info = op->Info();

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -21,6 +21,8 @@
 #include "paddle/fluid/platform/profiler.h"
 #include "paddle/fluid/string/string_helper.h"
 
+DECLARE_bool(use_mkldnn);
+
 namespace paddle {
 namespace imperative {
 
@@ -47,6 +49,10 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
                      const NameVarBaseMap& outs, framework::AttributeMap attrs,
                      const platform::Place& place, bool trace_backward) {
   VLOG(1) << "Trace Op: " << type;
+  if (FLAGS_use_mkldnn) {
+    auto& mutable_op_attrs = const_cast<framework::AttributeMap&>(attrs);
+    mutable_op_attrs["use_mkldnn"] = true;
+  }
   auto op = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
   const auto& op_info = op->Info();
   auto* attr_checker = op_info.Checker();

--- a/paddle/fluid/pybind/global_value_getter_setter.cc
+++ b/paddle/fluid/pybind/global_value_getter_setter.cc
@@ -333,8 +333,7 @@ void BindGlobalValueGetterSetter(pybind11::module *module) {
   } while (0)
 
 static void RegisterGlobalVarGetterSetter() {
-  REGISTER_PRIVATE_GLOBAL_VAR(/*is_writable=*/false, FLAGS_use_mkldnn,
-                              FLAGS_free_idle_chunk,
+  REGISTER_PRIVATE_GLOBAL_VAR(/*is_writable=*/false, FLAGS_free_idle_chunk,
                               FLAGS_free_when_no_cache_hit);
 
   REGISTER_PUBLIC_GLOBAL_VAR(
@@ -348,7 +347,7 @@ static void RegisterGlobalVarGetterSetter() {
       FLAGS_init_allocated_mem, FLAGS_initial_cpu_memory_in_mb,
       FLAGS_memory_fraction_of_eager_deletion, FLAGS_use_pinned_memory,
       FLAGS_benchmark, FLAGS_inner_op_parallelism, FLAGS_tracer_profile_fname,
-      FLAGS_paddle_num_threads);
+      FLAGS_paddle_num_threads, FLAGS_use_mkldnn);
 
 #ifdef PADDLE_WITH_CUDA
   REGISTER_PUBLIC_GLOBAL_VAR(

--- a/python/paddle/fluid/layer_helper.py
+++ b/python/paddle/fluid/layer_helper.py
@@ -29,6 +29,8 @@ from .layer_helper_base import LayerHelperBase
 class LayerHelper(LayerHelperBase):
     def __init__(self, layer_type, **kwargs):
         self.kwargs = kwargs
+        self.debug_ = self.kwargs.get('debug', False)
+        self.appended_op = None
         name = self.kwargs.get('name', None)
         # TODO(panyx0718, minqiyang): dygraph mode
         # can not use both `layer_type` and `name`. Deprecate LayerHelper
@@ -40,7 +42,10 @@ class LayerHelper(LayerHelperBase):
             self.kwargs['name'], layer_type=layer_type)
 
     def append_op(self, *args, **kwargs):
-        return self.main_program.current_block().append_op(*args, **kwargs)
+        op = self.main_program.current_block().append_op(*args, **kwargs)
+        if self.debug_:
+            self.appended_op = op
+        return op
 
     def multiple_input(self, input_param_name='input'):
         inputs = self.kwargs.get(input_param_name, [])
@@ -151,7 +156,7 @@ class LayerHelper(LayerHelperBase):
         # priority order: use_mkldnn in kwargs then global
         use_mkldnn = self.kwargs.get(
             'use_mkldnn', core.globals().get("FLAGS_use_mkldnn", False))
-        if (use_mkldnn is not None) and use_mkldnn:
+        if use_mkldnn:
             act['use_mkldnn'] = use_mkldnn
 
         act_type = act.pop('type')

--- a/python/paddle/fluid/layer_helper.py
+++ b/python/paddle/fluid/layer_helper.py
@@ -148,9 +148,9 @@ class LayerHelper(LayerHelperBase):
         if 'use_cudnn' in self.kwargs and self.kwargs.get('use_cudnn'):
             act['use_cudnn'] = self.kwargs.get('use_cudnn')
 
-        use_mkldnn = core.globals()["FLAGS_use_mkldnn"]
-        if 'use_mkldnn' in self.kwargs:
-            use_mkldnn = self.kwargs.get('use_mkldnn')
+        # priority use_mkldnn in kwargs then global
+        use_mkldnn = self.kwargs.get(
+            'use_mkldnn', core.globals().get("FLAGS_use_mkldnn", False))
         if (use_mkldnn is not None) and use_mkldnn:
             act['use_mkldnn'] = use_mkldnn
 

--- a/python/paddle/fluid/layer_helper.py
+++ b/python/paddle/fluid/layer_helper.py
@@ -147,8 +147,13 @@ class LayerHelper(LayerHelperBase):
 
         if 'use_cudnn' in self.kwargs and self.kwargs.get('use_cudnn'):
             act['use_cudnn'] = self.kwargs.get('use_cudnn')
+
+        use_mkldnn = core.globals()["FLAGS_use_mkldnn"]
         if 'use_mkldnn' in self.kwargs:
-            act['use_mkldnn'] = self.kwargs.get('use_mkldnn')
+            use_mkldnn = self.kwargs.get('use_mkldnn')
+        if (use_mkldnn is not None) and use_mkldnn:
+            act['use_mkldnn'] = use_mkldnn
+
         act_type = act.pop('type')
 
         tmp = self.create_variable_for_type_inference(dtype=input_var.dtype)

--- a/python/paddle/fluid/layer_helper.py
+++ b/python/paddle/fluid/layer_helper.py
@@ -148,7 +148,7 @@ class LayerHelper(LayerHelperBase):
         if 'use_cudnn' in self.kwargs and self.kwargs.get('use_cudnn'):
             act['use_cudnn'] = self.kwargs.get('use_cudnn')
 
-        # priority use_mkldnn in kwargs then global
+        # priority order: use_mkldnn in kwargs then global
         use_mkldnn = self.kwargs.get(
             'use_mkldnn', core.globals().get("FLAGS_use_mkldnn", False))
         if (use_mkldnn is not None) and use_mkldnn:

--- a/python/paddle/fluid/layer_helper.py
+++ b/python/paddle/fluid/layer_helper.py
@@ -29,8 +29,6 @@ from .layer_helper_base import LayerHelperBase
 class LayerHelper(LayerHelperBase):
     def __init__(self, layer_type, **kwargs):
         self.kwargs = kwargs
-        self.debug_ = self.kwargs.get('debug', False)
-        self.appended_op = None
         name = self.kwargs.get('name', None)
         # TODO(panyx0718, minqiyang): dygraph mode
         # can not use both `layer_type` and `name`. Deprecate LayerHelper
@@ -42,10 +40,7 @@ class LayerHelper(LayerHelperBase):
             self.kwargs['name'], layer_type=layer_type)
 
     def append_op(self, *args, **kwargs):
-        op = self.main_program.current_block().append_op(*args, **kwargs)
-        if self.debug_:
-            self.appended_op = op
-        return op
+        return self.main_program.current_block().append_op(*args, **kwargs)
 
     def multiple_input(self, input_param_name='input'):
         inputs = self.kwargs.get(input_param_name, [])
@@ -152,13 +147,8 @@ class LayerHelper(LayerHelperBase):
 
         if 'use_cudnn' in self.kwargs and self.kwargs.get('use_cudnn'):
             act['use_cudnn'] = self.kwargs.get('use_cudnn')
-
-        # priority order: use_mkldnn in kwargs then global
-        use_mkldnn = self.kwargs.get(
-            'use_mkldnn', core.globals().get("FLAGS_use_mkldnn", False))
-        if use_mkldnn:
-            act['use_mkldnn'] = use_mkldnn
-
+        if 'use_mkldnn' in self.kwargs:
+            act['use_mkldnn'] = self.kwargs.get('use_mkldnn')
         act_type = act.pop('type')
 
         tmp = self.create_variable_for_type_inference(dtype=input_var.dtype)

--- a/python/paddle/fluid/tests/unittests/test_get_set_flags.py
+++ b/python/paddle/fluid/tests/unittests/test_get_set_flags.py
@@ -40,7 +40,7 @@ class TestGetAndSetFlagsErrors(unittest.TestCase):
     def test_errors(self):
         flags_list = ['FLAGS_eager_delete_tensor_gb', 'FLAGS_check_nan_inf']
         flag = 1
-        flag_private = {'FLAGS_use_mkldnn': True}
+        flag_private = {'FLAGS_free_idle_chunk': True}
 
         # flags type of set_flags should be dict.
         def test_set_flags_input_type():
@@ -51,7 +51,7 @@ class TestGetAndSetFlagsErrors(unittest.TestCase):
         # flags in set_flags should be public flags.
         def test_set_private_flag():
 
-            fluid.get_flags('FLAGS_use_mkldnn')
+            fluid.set_flags(flag_private)
 
         self.assertRaises(ValueError, test_set_private_flag)
 
@@ -63,7 +63,7 @@ class TestGetAndSetFlagsErrors(unittest.TestCase):
 
         # flags in get_flags should be public flags.
         def test_get_private_flag():
-            fluid.get_flags('FLAGS_use_mkldnn')
+            fluid.get_flags('FLAGS_free_idle_chunk')
 
         self.assertRaises(ValueError, test_get_private_flag)
 

--- a/python/paddle/fluid/tests/unittests/test_global_var_getter_setter.py
+++ b/python/paddle/fluid/tests/unittests/test_global_var_getter_setter.py
@@ -26,7 +26,7 @@ class VarInfo(object):
 class TestGlobalVarGetterSetter(unittest.TestCase):
     def test_main(self):
         var_infos = [
-            VarInfo("FLAGS_use_mkldnn", bool, False),
+            VarInfo("FLAGS_free_idle_chunk", bool, False),
             VarInfo("FLAGS_eager_delete_tensor_gb", float, True),
         ]
 

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -644,19 +644,24 @@ class TestDygraphUtils(unittest.TestCase):
     def test_append_activation_in_dygraph_use_mkldnn(self):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
         helper = LayerHelper(
-            fluid.unique_name.generate("test"), act="relu", use_mkldnn=True)
+            fluid.unique_name.generate("test"),
+            act="relu",
+            use_mkldnn=True,
+            debug=True)
         func = helper.append_activation
         with fluid.dygraph.guard():
             a = fluid.dygraph.to_variable(a_np)
             res1 = func(a)
             res2 = fluid.layers.relu(a)
+            self.assertTrue(helper.appended_op.attrs.get('use_mkldnn', False))
             self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_activation_in_dygraph_global_use_mkldnn(self):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
         fluid.set_flags({'FLAGS_use_mkldnn': True})
         try:
-            helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
+            helper = LayerHelper(
+                fluid.unique_name.generate("test"), act="relu", debug=True)
             func = helper.append_activation
             with fluid.dygraph.guard():
                 a = fluid.dygraph.to_variable(a_np)
@@ -664,6 +669,7 @@ class TestDygraphUtils(unittest.TestCase):
                 res2 = fluid.layers.relu(a)
         finally:
             fluid.set_flags({'FLAGS_use_mkldnn': False})
+        self.assertTrue(helper.appended_op.attrs.get('use_mkldnn', False))
         self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_bias_in_dygraph_exception(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -641,7 +641,7 @@ class TestDygraphUtils(unittest.TestCase):
             res2 = fluid.layers.sigmoid(a)
             self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
-    def test_append_activation_in_dygraph4(self):
+    def test_append_activation_in_dygraph_use_mkldnn(self):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
         helper = LayerHelper(
             fluid.unique_name.generate("test"), act="relu", use_mkldnn=True)
@@ -651,6 +651,20 @@ class TestDygraphUtils(unittest.TestCase):
             res1 = func(a)
             res2 = fluid.layers.relu(a)
             self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
+
+    def test_append_activation_in_dygraph_global_use_mkldnn(self):
+        a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
+        fluid.set_flags({'FLAGS_use_mkldnn': True})
+        try:
+            helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
+            func = helper.append_activation
+            with fluid.dygraph.guard():
+                a = fluid.dygraph.to_variable(a_np)
+                res1 = func(a)
+                res2 = fluid.layers.relu(a)
+        finally:
+            fluid.set_flags({'FLAGS_use_mkldnn': False})
+        self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_bias_in_dygraph_exception(self):
         with new_program_scope():

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -19,6 +19,7 @@ import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid import Linear
+from paddle.fluid.layer_helper import LayerHelper
 from test_imperative_base import new_program_scope
 import paddle.fluid.dygraph_utils as dygraph_utils
 from paddle.fluid.dygraph.layer_object_helper import LayerObjectHelper
@@ -638,6 +639,17 @@ class TestDygraphUtils(unittest.TestCase):
             a = fluid.dygraph.to_variable(a_np)
             res1 = func(a, act="sigmoid", use_cudnn=True)
             res2 = fluid.layers.sigmoid(a)
+            self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
+
+    def test_append_activation_in_dygraph4(self):
+        a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
+        helper = LayerHelper(
+            fluid.unique_name.generate("test"), act="relu", use_mkldnn=True)
+        func = helper.append_activation
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            res1 = func(a)
+            res2 = fluid.layers.relu(a)
             self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_bias_in_dygraph_exception(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -644,32 +644,26 @@ class TestDygraphUtils(unittest.TestCase):
     def test_append_activation_in_dygraph_use_mkldnn(self):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
         helper = LayerHelper(
-            fluid.unique_name.generate("test"),
-            act="relu",
-            use_mkldnn=True,
-            debug=True)
+            fluid.unique_name.generate("test"), act="relu", use_mkldnn=True)
         func = helper.append_activation
         with fluid.dygraph.guard():
             a = fluid.dygraph.to_variable(a_np)
             res1 = func(a)
             res2 = fluid.layers.relu(a)
-            self.assertTrue(helper.appended_op.attrs.get('use_mkldnn', False))
             self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_activation_in_dygraph_global_use_mkldnn(self):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
-        fluid.set_flags({'FLAGS_use_mkldnn': True})
-        try:
-            helper = LayerHelper(
-                fluid.unique_name.generate("test"), act="relu", debug=True)
-            func = helper.append_activation
-            with fluid.dygraph.guard():
-                a = fluid.dygraph.to_variable(a_np)
+        helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
+        func = helper.append_activation
+        with fluid.dygraph.guard():
+            a = fluid.dygraph.to_variable(a_np)
+            fluid.set_flags({'FLAGS_use_mkldnn': True})
+            try:
                 res1 = func(a)
-                res2 = fluid.layers.relu(a)
-        finally:
-            fluid.set_flags({'FLAGS_use_mkldnn': False})
-        self.assertTrue(helper.appended_op.attrs.get('use_mkldnn', False))
+            finally:
+                fluid.set_flags({'FLAGS_use_mkldnn': False})
+            res2 = fluid.layers.relu(a)
         self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_bias_in_dygraph_exception(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Get use of global  FLAGS_use_mkldnn to append_activation in layer_helper