### PR TITLE
add paddle.static.data

### DIFF
--- a/python/paddle/fluid/data.py
+++ b/python/paddle/fluid/data.py
@@ -18,10 +18,12 @@ import six
 from paddle.fluid import core
 from paddle.fluid.layer_helper import LayerHelper
 from paddle.fluid.data_feeder import check_dtype, check_type
+from ..utils import deprecated
 
 __all__ = ['data']
 
 
+@deprecated(since="2.0.0", update_to="paddle.static.data")
 def data(name, shape, dtype='float32', lod_level=0):
     """
     **Data Layer**

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -8353,6 +8353,7 @@ def gather_nd(input, index, name=None):
     return output
 
 
+@deprecated(since="2.0.0", update_to="paddle.scatter")
 def scatter(input, index, updates, name=None, overwrite=True):
     """
     :alias_main: paddle.scatter

--- a/python/paddle/fluid/tests/unittests/test_data.py
+++ b/python/paddle/fluid/tests/unittests/test_data.py
@@ -56,7 +56,7 @@ class TestApiDataError(unittest.TestCase):
 
 
 class TestApiStaticDataError(unittest.TestCase):
-    def test_fluid_data(self):
+    def test_fluid_dtype(self):
         with program_guard(Program(), Program()):
             x1 = paddle.static.data(name="x1", shape=[2, 25])
             self.assertEqual(x1.dtype, core.VarDesc.VarType.FP32)
@@ -67,6 +67,36 @@ class TestApiStaticDataError(unittest.TestCase):
             paddle.set_default_dtype("float64")
             x3 = paddle.static.data(name="x3", shape=[2, 25])
             self.assertEqual(x3.dtype, core.VarDesc.VarType.FP64)
+
+    def test_fluid_data(self):
+        with program_guard(Program(), Program()):
+
+            # 1. The type of 'name' in fluid.data must be str.
+            def test_name_type():
+                paddle.static.data(name=1, shape=[2, 25], dtype="bool")
+
+            self.assertRaises(TypeError, test_name_type)
+
+            # 2. The type of 'shape' in fluid.data must be list or tuple.
+            def test_shape_type():
+                paddle.static.data(name='data1', shape=2, dtype="bool")
+
+            self.assertRaises(TypeError, test_shape_type)
+
+    def test_layers_data(self):
+        with program_guard(Program(), Program()):
+
+            # 1. The type of 'name' in layers.data must be str.
+            def test_name_type():
+                paddle.static.data(name=1, shape=[2, 25], dtype="bool")
+
+            self.assertRaises(TypeError, test_name_type)
+
+            # 2. The type of 'shape' in layers.data must be list or tuple.
+            def test_shape_type():
+                paddle.static.data(name='data1', shape=2, dtype="bool")
+
+            self.assertRaises(TypeError, test_shape_type)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_data.py
+++ b/python/paddle/fluid/tests/unittests/test_data.py
@@ -16,9 +16,11 @@ from __future__ import print_function
 
 import unittest
 
+import paddle
 import paddle.fluid as fluid
 import paddle.fluid.layers as layers
 from paddle.fluid import Program, program_guard
+import paddle.fluid.core as core
 
 
 class TestApiDataError(unittest.TestCase):
@@ -51,6 +53,20 @@ class TestApiDataError(unittest.TestCase):
                 layers.data(name='data1', shape=2, dtype="bool")
 
             self.assertRaises(TypeError, test_shape_type)
+
+
+class TestApiStaticDataError(unittest.TestCase):
+    def test_fluid_data(self):
+        with program_guard(Program(), Program()):
+            x1 = paddle.static.data(name="x1", shape=[2, 25])
+            self.assertEqual(x1.dtype, core.VarDesc.VarType.FP32)
+
+            x2 = paddle.static.data(name="x2", shape=[2, 25], dtype="bool")
+            self.assertEqual(x2.dtype, core.VarDesc.VarType.BOOL)
+
+            paddle.set_default_dtype("float64")
+            x3 = paddle.static.data(name="x3", shape=[2, 25])
+            self.assertEqual(x3.dtype, core.VarDesc.VarType.FP64)
 
 
 if __name__ == "__main__":

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -12,47 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..fluid.data import data as fluid_data
 import paddle
+import numpy as np
+import six
+
+from paddle.fluid import core
+from paddle.fluid.layer_helper import LayerHelper
+from paddle.fluid.data_feeder import check_dtype, check_type
 
 __all__ = ['data', 'InputSpec']
-
-
-class InputSpec(object):
-    """
-    Define input specification of the model.
-
-    Args:
-        name (str): The name/alias of the variable, see :ref:`api_guide_Name`
-            for more details.
-        shape (tuple(integers)|list[integers]): List|Tuple of integers
-            declaring the shape. You can set "None" or -1 at a dimension
-            to indicate the dimension can be of any size. For example,
-            it is useful to set changeable batch size as "None" or -1.
-        dtype (np.dtype|VarType|str, optional): The type of the data. Supported
-            dtype: bool, float16, float32, float64, int8, int16, int32, int64,
-            uint8. Default: float32.
-
-    Examples:
-        .. code-block:: python
-
-        from paddle.static import InputSpec
-
-        input = InputSpec([None, 784], 'float32', 'x')
-        label = InputSpec([None, 1], 'int64', 'label')
-    """
-
-    def __init__(self, shape=None, dtype='float32', name=None):
-        self.shape = shape
-        self.dtype = dtype
-        self.name = name
-
-    def _create_feed_layer(self):
-        return fluid_data(self.name, shape=self.shape, dtype=self.dtype)
-
-    def __repr__(self):
-        return '{}(shape={}, dtype={}, name={})'.format(
-            type(self).__name__, self.shape, self.dtype, self.name)
 
 
 def data(name, shape, dtype=None, lod_level=0):
@@ -62,8 +30,7 @@ def data(name, shape, dtype=None, lod_level=0):
     This function creates a variable on the global block. The global variable
     can be accessed by all the following operators in the graph. The variable
     is a placeholder that could be fed with input, such as Executor can feed
-    input into the variable. Except the `dtype` is different in default parameter 
-    settings, It is similar as `fluid.data` api. When `dtype` is not set, the dtype
+    input into the variable. When `dtype` is None, the dtype
     will get from the global dtype by `paddle.get_default_dtype()`.
 
     Args:
@@ -74,7 +41,7 @@ def data(name, shape, dtype=None, lod_level=0):
            size. For example, it is useful to set changeable batch size as "None" or -1.
        dtype (np.dtype|VarType|str, optional): The type of the data. Supported
            dtype: bool, float16, float32, float64, int8, int16, int32, int64,
-           uint8. Default: float32. When `dtype` is not set, the dtype will get 
+           uint8. Default: None. When `dtype` is not set, the dtype will get 
            from the global dtype by `paddle.get_default_dtype()`.
        lod_level (int, optional): The LoD level of the LoDTensor. Usually users
            don't have to set this value. For more details about when and how to
@@ -120,7 +87,69 @@ def data(name, shape, dtype=None, lod_level=0):
           print(out)
 
     """
+    helper = LayerHelper('data', **locals())
+    check_type(name, 'name', (six.binary_type, six.text_type), 'data')
+    check_type(shape, 'shape', (list, tuple), 'data')
+
+    shape = list(shape)
+    for i in six.moves.range(len(shape)):
+        if shape[i] is None:
+            shape[i] = -1
+
     if dtype:
-        return fluid_data(name, shape, dtype, lod_level)
+        return helper.create_global_variable(
+            name=name,
+            shape=shape,
+            dtype=dtype,
+            type=core.VarDesc.VarType.LOD_TENSOR,
+            stop_gradient=True,
+            lod_level=lod_level,
+            is_data=True,
+            need_check_feed=True)
     else:
-        return fluid_data(name, shape, paddle.get_default_dtype(), lod_level)
+        return helper.create_global_variable(
+            name=name,
+            shape=shape,
+            dtype=paddle.get_default_dtype(),
+            type=core.VarDesc.VarType.LOD_TENSOR,
+            stop_gradient=True,
+            lod_level=lod_level,
+            is_data=True,
+            need_check_feed=True)
+
+
+class InputSpec(object):
+    """
+    Define input specification of the model.
+
+    Args:
+        name (str): The name/alias of the variable, see :ref:`api_guide_Name`
+            for more details.
+        shape (tuple(integers)|list[integers]): List|Tuple of integers
+            declaring the shape. You can set "None" or -1 at a dimension
+            to indicate the dimension can be of any size. For example,
+            it is useful to set changeable batch size as "None" or -1.
+        dtype (np.dtype|str, optional): The type of the data. Supported
+            dtype: bool, float16, float32, float64, int8, int16, int32, int64,
+            uint8. Default: float32.
+
+    Examples:
+        .. code-block:: python
+
+        from paddle.static import InputSpec
+
+        input = InputSpec([None, 784], 'float32', 'x')
+        label = InputSpec([None, 1], 'int64', 'label')
+    """
+
+    def __init__(self, shape=None, dtype='float32', name=None):
+        self.shape = shape
+        self.dtype = dtype
+        self.name = name
+
+    def _create_feed_layer(self):
+        return data(self.name, shape=self.shape, dtype=self.dtype)
+
+    def __repr__(self):
+        return '{}(shape={}, dtype={}, name={})'.format(
+            type(self).__name__, self.shape, self.dtype, self.name)

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -87,6 +87,7 @@ def data(name, shape, dtype=None, lod_level=0):
         .. code-block:: python
 
           import numpy as np
+          import paddle.fluid as fluid
           import paddle
 
           # Creates a variable with fixed size [3, 2, 1]

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -39,7 +39,7 @@ def data(name, shape, dtype=None, lod_level=0):
        shape (list|tuple): List|Tuple of integers declaring the shape. You can
            set "None" or -1 at a dimension to indicate the dimension can be of any
            size. For example, it is useful to set changeable batch size as "None" or -1.
-       dtype (np.dtype|VarType|str, optional): The type of the data. Supported
+       dtype (np.dtype|str, optional): The type of the data. Supported
            dtype: bool, float16, float32, float64, int8, int16, int32, int64,
            uint8. Default: None. When `dtype` is not set, the dtype will get 
            from the global dtype by `paddle.get_default_dtype()`.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Except the `dtype` is different in default parameter settings, It is similar as `fluid.data` api. When `dtype` is not set, the dtype will get from the global dtype by `paddle.get_default_dtype()`.