### PR TITLE
Fix uniform op Doc problem

### DIFF
--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -57,7 +57,7 @@ def uniform(shape, dtype='float32', min=-1.0, max=1.0, seed=0, name=None):
             (with the shape [1], and the data type int32 or int64). If ``shape``
             is a Tensor, it should be a 1-D Tensor(with the data type int32 or
             int64).
-        dtype(str|np.dtype|core.VarDesc.VarType, optional): The data type of
+        dtype(str|np.dtype, optional): The data type of
             the output Tensor. Supported data types: float32, float64.
             Default is float32.
         min(float|int, optional): The lower bound on the range of random values
@@ -114,7 +114,6 @@ def uniform(shape, dtype='float32', min=-1.0, max=1.0, seed=0, name=None):
             # [[-0.8517412,  -0.4006908,   0.2551912 ],
             #  [ 0.3364414,   0.36278176, -0.16085452]]
 
-            paddle.enable_static()
 
     """
     if not isinstance(dtype, core.VarDesc.VarType):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
`uniform` op has been implemented in PR #26347. There are some problems in Doc. This PR is used to fix the `uniform` op doc.