### PR TITLE
add shell of GPU version,test=document_fix

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1535,7 +1535,7 @@ function main() {
         exit 1
         ;;
       esac
-      python summary_env.py
+      python ${PADDLE_ROOT}/tools/summary_env.py
       echo "paddle_build script finished as expected"
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1535,7 +1535,7 @@ function main() {
         exit 1
         ;;
       esac
-      /opt/compiler/gcc-4.8.2/bin/pwd
+      pwd
       python ../../tools/summary_env.py
       echo "paddle_build script finished as expected"
 }

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1535,8 +1535,7 @@ function main() {
         exit 1
         ;;
       esac
-      pwd
-      python ../../tools/summary_env.py
+      python summary_env.py
       echo "paddle_build script finished as expected"
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1403,6 +1403,7 @@ function main() {
     local CMD=$1 
     local parallel_number=$2
     init
+    python ${PADDLE_ROOT}/tools/summary_env.py
     case $CMD in
       build_only)
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
@@ -1535,7 +1536,6 @@ function main() {
         exit 1
         ;;
       esac
-      python ${PADDLE_ROOT}/tools/summary_env.py
       echo "paddle_build script finished as expected"
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1535,6 +1535,7 @@ function main() {
         exit 1
         ;;
       esac
+      python ../../tools/summary_env.py
       echo "paddle_build script finished as expected"
 }
 

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1535,6 +1535,7 @@ function main() {
         exit 1
         ;;
       esac
+      /opt/compiler/gcc-4.8.2/bin/pwd
       python ../../tools/summary_env.py
       echo "paddle_build script finished as expected"
 }

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1403,7 +1403,9 @@ function main() {
     local CMD=$1 
     local parallel_number=$2
     init
-    python ${PADDLE_ROOT}/tools/summary_env.py
+    if [ "$CMD" != "assert_file_approvals" ];then
+      python ${PADDLE_ROOT}/tools/summary_env.py
+    fi
     case $CMD in
       build_only)
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}

--- a/tools/summary_env.py
+++ b/tools/summary_env.py
@@ -93,7 +93,7 @@ def get_cudnn_info():
         if cudnn_dll_path:
             cudnn_header_path = cudnn_dll_path.split('bin')[
                 0] + 'include\cudnn.h'
-            cmd = 'type "{}" | findstr "{}" | findstr /v "CUDNN_VERSION"'
+            cmd = 'type "{0}" | findstr "{1}" | findstr /v "CUDNN_VERSION"'
         else:
             envs['cudnn_version'] = None
             return
@@ -102,7 +102,7 @@ def get_cudnn_info():
             'whereis "cudnn.h" | awk \'{print $2}\'')
         if cudnn_header_path:
             cudnn_header_path = cudnn_header_path.strip()
-            cmd = 'cat "{}" | grep "{}" | grep -v "CUDNN_VERSION"'
+            cmd = 'cat "{0}" | grep "{1}" | grep -v "CUDNN_VERSION"'
         else:
             envs['cudnn_version'] = None
             return

--- a/tools/summary_env.py
+++ b/tools/summary_env.py
@@ -55,7 +55,7 @@ def get_os_info():
     else:
         plat = None
         ver = None
-    envs['os_info'] = "{} {}".format(plat, ver)
+    envs['os_info'] = "{0} {1}".format(plat, ver)
 
 
 def get_python_info():
@@ -112,7 +112,7 @@ def get_cudnn_info():
     patch_level = _get_cudnn_ver(
         cmd.format(cudnn_header_path, 'CUDNN_PATCHLEVEL'))
 
-    envs['cudnn_version'] = "{}.{}.{}".format(major, minor, patch_level)
+    envs['cudnn_version'] = "{0}.{1}.{2}".format(major, minor, patch_level)
 
 
 def get_driver_info():
@@ -132,7 +132,7 @@ def main():
     get_cuda_info()
     get_cudnn_info()
     get_driver_info()
-    print(envs_template.format(**envs))
+    print('*' * 40 + envs_template.format(**envs) + '*' * 40)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
每次跑流水线都不太清楚机型，所以需要在paddle_build.sh中加入查看GPU型号的命令
tools/summary.py 工具加到paddle_build.sh里
![image](https://user-images.githubusercontent.com/45056973/91545942-53c27900-e954-11ea-9b82-cdad091207cb.png)

解决了下以下报错
![image](https://user-images.githubusercontent.com/45056973/91545997-6341c200-e954-11ea-9f52-7accfdde657c.png)
该报错原因是因为py版本不一致，语法不兼容导致的，把报错涉及的语法修改成每个版本都兼容的写法
