### PR TITLE
update op_version_registry, test=develop

### DIFF
--- a/paddle/fluid/framework/op_version_registry.h
+++ b/paddle/fluid/framework/op_version_registry.h
@@ -48,11 +48,15 @@ struct ModifyAttr : OpUpdateRecord {
   boost::any default_value_;
 };
 struct NewAttr : OpUpdateRecord {
-  NewAttr(const std::string& name, const std::string& remark)
-      : OpUpdateRecord({Type::kNewAttr, remark}), name_(name) {}
+  NewAttr(const std::string& name, const std::string& remark,
+          boost::any default_value)
+      : OpUpdateRecord({Type::kNewAttr, remark}),
+        name_(name),
+        default_value_(default_value) {}
 
  private:
   std::string name_;
+  boost::any default_value_;
 };
 
 class OpVersionDesc {
@@ -64,9 +68,10 @@ class OpVersionDesc {
     return *this;
   }
 
-  OpVersionDesc& NewAttr(const std::string& name, const std::string& remark) {
-    infos_.push_back(
-        std::shared_ptr<OpUpdateRecord>(new compatible::NewAttr(name, remark)));
+  OpVersionDesc& NewAttr(const std::string& name, const std::string& remark,
+                         boost::any default_value) {
+    infos_.push_back(std::shared_ptr<OpUpdateRecord>(
+        new compatible::NewAttr(name, remark, default_value)));
     return *this;
   }
 

--- a/paddle/fluid/framework/op_version_registry_test.cc
+++ b/paddle/fluid/framework/op_version_registry_test.cc
@@ -32,7 +32,8 @@ TEST(test_operator_version, test_operator_version) {
                           "Increased from the original one method to two.", -1)
               .NewAttr("size",
                        "In order to represent a two-dimensional rectangle, the "
-                       "parameter size is added."))
+                       "parameter size is added.",
+                       0))
       .AddCheckpoint(
           R"ROC(
         Add a new attribute [height]
@@ -40,7 +41,8 @@ TEST(test_operator_version, test_operator_version) {
           framework::compatible::OpVersionDesc().NewAttr(
               "height",
               "In order to represent a two-dimensional rectangle, the "
-              "parameter height is added."));
+              "parameter height is added.",
+              0));
 }
 }  // namespace compatible
 }  // namespace framework


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
为 `NewAttr` 添加默认值参数。

```c++
REGISTER_OP_VERSION(reshape)
    .AddCheckpoint(
        R"ROC(
      Upgrade reshape, modified one attribute [axis] and add a new attribute [size].
    )ROC",
        framework::compatible::OpVersionDesc()
            .ModifyAttr("axis",
                        "Increased from the original one method to two.", -1)
            .NewAttr("size",
                     "In order to represent a two-dimensional rectangle, the "
                     "parameter size is added.", 0))
    .AddCheckpoint(
        R"ROC(
      Add a new attribute [height]
    )ROC",
        framework::compatible::OpVersionDesc().NewAttr(
            "height",
            "In order to represent a two-dimensional rectangle, the "
            "parameter height is added.", 0));
```

核心接口：

`AddCheckpoint(string summary, OpVersionDesc desc)` 此方法会触发 `Op` 的 `version++`
`OpVersionDesc` ，用于注册本次升级对应的修改点 
`NewAttr(name, default_value)` 表示增加了一个 `attribute`，并需要指定其向前兼容的默认值
`ModifyAttr(name, default_value)` 表示修改了 `attribute` 的行为，并需要指定其向前兼容的默认值
其他注册方法可以按需增加
全局的 `op_capatible_info` 会记录每个 `Op` 最新的版本号（`version checkpoint` 的次数），并通过 `save_inference_model` 存储到模型中。

其中记录的版本及描述，会帮助 `Inference` 和 `Lite` 来对应升级策略；也可以自动搜集作为 `Release Notes` 的来源。

设计文档见 Agroup：Op 版本监控及兼容性识别设计（#3366223）