### PR TITLE
remove extra transform from MNIST dataset

### DIFF
--- a/python/paddle/incubate/hapi/datasets/mnist.py
+++ b/python/paddle/incubate/hapi/datasets/mnist.py
@@ -140,10 +140,6 @@ class MNIST(Dataset):
                                                       cols)).astype('float32')
                     offset_img += struct.calcsize(fmt_images)
 
-                    images = images / 255.0
-                    images = images * 2.0
-                    images = images - 1.0
-
                     for i in range(buffer_size):
                         self.images.append(images[i, :])
                         self.labels.append(


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
remove extra transform from MNIST dataset
- not normalize image in MNIST

add VOC 2007-2011 support in next PR