### PR TITLE
Version recording APIs for compatible Op upgrades,  test=develop

### DIFF
--- a/paddle/fluid/framework/op_version_registry.h
+++ b/paddle/fluid/framework/op_version_registry.h
@@ -29,14 +29,20 @@ namespace framework {
 namespace compatible {
 
 struct OpUpdateRecord {
-  enum class Type { kInvalid = 0, kModifyAttr, kNewAttr };
+  enum class Type {
+    kInvalid = 0,
+    kModifyAttr,
+    kNewAttr,
+    kNewInput,
+    kNewOutput
+  };
   Type type_;
   std::string remark_;
 };
 
 struct ModifyAttr : OpUpdateRecord {
   ModifyAttr(const std::string& name, const std::string& remark,
-             boost::any default_value)
+             const boost::any& default_value)
       : OpUpdateRecord({Type::kModifyAttr, remark}),
         name_(name),
         default_value_(default_value) {
@@ -47,9 +53,10 @@ struct ModifyAttr : OpUpdateRecord {
   std::string name_;
   boost::any default_value_;
 };
+
 struct NewAttr : OpUpdateRecord {
   NewAttr(const std::string& name, const std::string& remark,
-          boost::any default_value)
+          const boost::any& default_value)
       : OpUpdateRecord({Type::kNewAttr, remark}),
         name_(name),
         default_value_(default_value) {}
@@ -57,6 +64,22 @@ struct NewAttr : OpUpdateRecord {
  private:
   std::string name_;
   boost::any default_value_;
+};
+
+struct NewInput : OpUpdateRecord {
+  NewInput(const std::string& name, const std::string& remark)
+      : OpUpdateRecord({Type::kNewInput, remark}), name_(name) {}
+
+ private:
+  std::string name_;
+};
+
+struct NewOutput : OpUpdateRecord {
+  NewOutput(const std::string& name, const std::string& remark)
+      : OpUpdateRecord({Type::kNewOutput, remark}), name_(name) {}
+
+ private:
+  std::string name_;
 };
 
 class OpVersionDesc {
@@ -72,6 +95,18 @@ class OpVersionDesc {
                          boost::any default_value) {
     infos_.push_back(std::shared_ptr<OpUpdateRecord>(
         new compatible::NewAttr(name, remark, default_value)));
+    return *this;
+  }
+
+  OpVersionDesc& NewInput(const std::string& name, const std::string& remark) {
+    infos_.push_back(std::shared_ptr<OpUpdateRecord>(
+        new compatible::NewInput(name, remark)));
+    return *this;
+  }
+
+  OpVersionDesc& NewOutput(const std::string& name, const std::string& remark) {
+    infos_.push_back(std::shared_ptr<OpUpdateRecord>(
+        new compatible::NewOutput(name, remark)));
     return *this;
   }
 

--- a/paddle/fluid/framework/op_version_registry_test.cc
+++ b/paddle/fluid/framework/op_version_registry_test.cc
@@ -42,7 +42,14 @@ TEST(test_operator_version, test_operator_version) {
               "height",
               "In order to represent a two-dimensional rectangle, the "
               "parameter height is added.",
-              0));
+              0))
+      .AddCheckpoint(
+          R"ROC(
+        Add a input [X2] and a output [Y2]
+      )ROC",
+          framework::compatible::OpVersionDesc()
+              .NewInput("X2", "The second input.")
+              .NewOutput("Y2", "The second output."));
 }
 }  // namespace compatible
 }  // namespace framework


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others

### PR changes
Others

### Describe
添加 `NewInput` 和 `NewOutput`。

```c++
REGISTER_OP_VERSION(test__)
  .AddCheckpoint(
      R"ROC(
    Upgrade reshape, modified one attribute [axis] and add a new attribute [size].
  )ROC",
      framework::compatible::OpVersionDesc()
          .ModifyAttr("axis",
                      "Increased from the original one method to two.", -1)
          .NewAttr("size",
                   "In order to represent a two-dimensional rectangle, the "
                   "parameter size is added.",
                   0))
  .AddCheckpoint(
      R"ROC(
    Add a new attribute [height]
  )ROC",
      framework::compatible::OpVersionDesc().NewAttr(
          "height",
          "In order to represent a two-dimensional rectangle, the "
          "parameter height is added.",
          0))
  .AddCheckpoint(
      R"ROC(
    Add a input [X2] and a output [Y2]
  )ROC",
      framework::compatible::OpVersionDesc()
          .NewInput("X2", "The second input.")
          .NewOutput("Y2", "The second output."));
```

核心接口：

- `AddCheckpoint(string summary, OpVersionDesc desc)` 此方法会触发 `Op` 的 `version++`
- `OpVersionDesc` ，用于注册本次升级对应的修改点 
- `NewAttr(name, default_value)` 表示增加了一个 `attribute`，并需要指定其向前兼容的默认值
- `ModifyAttr(name, default_value)` 表示修改了 `attribute` 的行为，并需要指定其向前兼容的默认值
- `NewInput` 增加了新的输入
- `NewOutput` 增加了新的输出

其他注册方法可以按需增加
全局的 `op_capatible_info` 会记录每个 `Op` 最新的版本号（`version checkpoint` 的次数），并通过 `save_inference_model` 存储到模型中。

其中记录的版本及描述，会帮助 `Inference` 和 `Lite` 来对应升级策略；也可以自动搜集作为 `Release Notes` 的来源。

设计文档见 Agroup：Op 版本监控及兼容性识别设计（#3366223）