### PR TITLE
add dtype for unique 

### DIFF
--- a/paddle/fluid/operators/unique_op.cc
+++ b/paddle/fluid/operators/unique_op.cc
@@ -13,6 +13,7 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/unique_op.h"
+#include "paddle/fluid/framework/op_version_registry.h"
 
 namespace paddle {
 namespace operators {
@@ -149,3 +150,34 @@ REGISTER_OP_CPU_KERNEL(
     ops::UniqueKernel<paddle::platform::CPUDeviceContext, double>,
     ops::UniqueKernel<paddle::platform::CPUDeviceContext, int32_t>,
     ops::UniqueKernel<paddle::platform::CPUDeviceContext, int64_t>);
+REGISTER_OP_VERSION(unique)
+    .AddCheckpoint(
+        R"ROC(
+        Upgrade unique, add 2 outputs [Indices, Counts] and 5 attribute
+        [return_index, return_inverse, return_counts, axis, is_sorted].
+      )ROC",
+        paddle::framework::compatible::OpVersionDesc()
+            .NewOutput("Indices",
+                       "The indices of the input tensor that result in the "
+                       "unique tensor.")
+            .NewOutput("Counts", "The counts for each unique element.")
+            .NewAttr("return_index",
+                     "If True, also return the indices of the input"
+                     " tensor that result in the unique Tensor.",
+                     false)
+            .NewAttr("return_inverse",
+                     "If True, also return the indices for where elements"
+                     " in the original input ended up in the returned unique "
+                     "tensor.",
+                     false)
+            .NewAttr("return_counts",
+                     "If True, also return the counts for each unique element.",
+                     false)
+            .NewAttr("axis",
+                     "The axis to apply unique. If None, the input will be "
+                     "flattened.",
+                     {})
+            .NewAttr("is_sorted",
+                     "If True, the unique elements of X are in ascending order."
+                     "Otherwise, the unique elements are not sorted.",
+                     false));

--- a/paddle/fluid/operators/unique_op.h
+++ b/paddle/fluid/operators/unique_op.h
@@ -131,91 +131,65 @@ static bool Equal(const framework::Tensor& a, const framework::Tensor& b) {
   return true;
 }
 
-template <typename DeviceContext, typename InT>
-struct UniqueFlattendTensorFunctor {
-  const DeviceContext& ctx_;
-  framework::Tensor* out_;
-  framework::Tensor* indices_;
-  framework::Tensor* inverse_;
-  framework::Tensor* counts_;
-  const framework::Tensor* in_;
-  const bool return_index_;
-  const bool return_inverse_;
-  const bool return_counts_;
+template <typename InT, typename IndexT>
+static void UniqueFlattendTensor(const framework::ExecutionContext& context,
+                                 const framework::Tensor& in,
+                                 framework::Tensor* out, bool return_index,
+                                 bool return_inverse, bool return_counts) {
+  const InT* in_data = in.data<InT>();
+  std::set<InT> unique(in_data, in_data + in.numel());
+  out->Resize(framework::make_ddim({static_cast<int64_t>(unique.size())}));
+  auto out_data = out->mutable_data<InT>(context.GetPlace());
+  std::copy(unique.begin(), unique.end(), out_data);
 
-  UniqueFlattendTensorFunctor(const framework::ExecutionContext& context,
-                              const framework::Tensor& in,
-                              framework::Tensor* out,
-                              framework::Tensor* indices,
-                              framework::Tensor* inverse,
-                              framework::Tensor* counts, bool return_index,
-                              bool return_inverse, bool return_counts)
-      : ctx_(context),
-        in_(in),
-        out_(out),
-        indices_(indices),
-        inverse_(inverse),
-        counts_(counts),
-        return_index_(return_index),
-        return_inverse_(return_inverse),
-        return_counts_(return_counts) {}
-
-  template <typename IndexT>
-  void apply() const {
-    auto data_type = static_cast<framework::proto::VarType::Type>(
-        context.Attr<int>("dtype"));
-    const T* in_data = in_.data<InT>();
-    std::set<T> unique(in_data, in_data + in.numel());
-    out->Resize(framework::make_ddim({static_cast<int64_t>(unique.size())}));
-    auto out_data = out_->mutable_data<IndexT>(context.GetPlace());
-    std::copy(unique.begin(), unique.end(), out_data);
-
-    if (return_index) {
-      indices_->Resize(framework::make_ddim({out->numel()}));
-      auto indices_data = indices_->mutable_data<IndexT>(context.GetPlace());
-      std::unordered_map<InT, IndexT> indices_map;
-      indices_map.reserve(out->numel());
-      for (int64_t i = 0; i < in.numel(); ++i) {
-        if (indices_map.find(in_data[i]) != indices_map.end()) continue;
-        indices_map[in_data[i]] = i;
-      }
-      for (int64_t i = 0; i < out->numel(); ++i) {
-        indices_data[i] = indices_map[out_data[i]];
-      }
+  if (return_index) {
+    auto* indices = context.Output<framework::Tensor>("Indices");
+    indices->Resize(framework::make_ddim({out->numel()}));
+    auto indices_data = indices->mutable_data<IndexT>(context.GetPlace());
+    std::unordered_map<InT, IndexT> indices_map;
+    indices_map.reserve(out->numel());
+    for (int64_t i = 0; i < in.numel(); ++i) {
+      if (indices_map.find(in_data[i]) != indices_map.end()) continue;
+      indices_map[in_data[i]] = i;
     }
-
-    if (return_inverse) {
-      inverse_->Resize(framework::make_ddim({in.numel()}));
-      auto inverse_data = inverse_->mutable_data<IndexT>(context.GetPlace());
-      std::unordered_map<InT, IndexT> inverse_map;
-      inverse_map.reserve(out->numel());
-      for (int64_t i = 0; i < out->numel(); ++i) {
-        inverse_map[out_data[i]] = i;
-      }
-      for (int64_t i = 0; i < in.numel(); ++i) {
-        inverse_data[i] = inverse_map[in_data[i]];
-      }
-    }
-
-    if (return_counts) {
-      counts_->Resize(framework::make_ddim({out->numel()}));
-      auto count_data = counts_->mutable_data<IndexT>(context.GetPlace());
-      std::unordered_map<InT, IndexT> counts_map;
-      counts_map.reserve(out->numel());
-      for (int64_t i = 0; i < out->numel(); ++i) {
-        counts_map[out_data[i]] = 0;
-      }
-      for (int64_t i = 0; i < in.numel(); i++) {
-        counts_map[in_data[i]] += 1;
-      }
-      for (int64_t i = 0; i < out->numel(); i++) {
-        count_data[i] = counts_map[out_data[i]];
-      }
+    for (int64_t i = 0; i < out->numel(); ++i) {
+      indices_data[i] = indices_map[out_data[i]];
     }
   }
-};
 
-template <class ForwardIt, typename T, typename IndexT>
+  if (return_inverse) {
+    auto* inverse = context.Output<framework::Tensor>("Index");
+    inverse->Resize(framework::make_ddim({in.numel()}));
+    auto inverse_data = inverse->mutable_data<IndexT>(context.GetPlace());
+    std::unordered_map<InT, IndexT> inverse_map;
+    inverse_map.reserve(out->numel());
+    for (int64_t i = 0; i < out->numel(); ++i) {
+      inverse_map[out_data[i]] = i;
+    }
+    for (int64_t i = 0; i < in.numel(); ++i) {
+      inverse_data[i] = inverse_map[in_data[i]];
+    }
+  }
+
+  if (return_counts) {
+    auto* count = context.Output<framework::Tensor>("Counts");
+    count->Resize(framework::make_ddim({out->numel()}));
+    auto count_data = count->mutable_data<IndexT>(context.GetPlace());
+    std::unordered_map<InT, IndexT> counts_map;
+    counts_map.reserve(out->numel());
+    for (int64_t i = 0; i < out->numel(); ++i) {
+      counts_map[out_data[i]] = 0;
+    }
+    for (int64_t i = 0; i < in.numel(); i++) {
+      counts_map[in_data[i]] += 1;
+    }
+    for (int64_t i = 0; i < out->numel(); i++) {
+      count_data[i] = counts_map[out_data[i]];
+    }
+  }
+}
+
+template <class ForwardIt, typename InT, typename IndexT>
 static ForwardIt UniqueDimImpl(const framework::ExecutionContext& context,
                                ForwardIt first, ForwardIt last,
                                const std::vector<IndexT>& sorted_indices_vec,
@@ -236,7 +210,7 @@ static ForwardIt UniqueDimImpl(const framework::ExecutionContext& context,
   while (++first != last) {
     int64_t idx_first = std::distance(begin, first);
     int64_t idx_result = std::distance(begin, result);
-    if (!Equal<T>(*result, *first)) {
+    if (!Equal<InT>(*result, *first)) {
       if (++result != first) {
         *result = std::move(*first);
       }
@@ -265,7 +239,7 @@ static void UniqueDim(const framework::ExecutionContext& context,
   framework::Tensor in_trans;
   framework::DDim in_trans_dims = framework::make_ddim(in_trans_dims_vec);
   in_trans.Resize(in_trans_dims);
-  in_trans.mutable_data<T>(context.GetPlace());
+  in_trans.mutable_data<InT>(context.GetPlace());
   auto& dev_ctx = context.template device_context<DeviceContext>();
   TransCompute<DeviceContext, InT>(in.dims().size(), dev_ctx, in, &in_trans,
                                    permute);
@@ -278,12 +252,12 @@ static void UniqueDim(const framework::ExecutionContext& context,
   std::vector<IndexT> sorted_indices_vec(in_trans.dims()[0]);
   std::iota(sorted_indices_vec.begin(), sorted_indices_vec.end(), 0);
   int64_t col = in_trans.dims()[1];
-  const T* in_trans_data = in_trans.data<T>();
+  const InT* in_trans_data = in_trans.data<InT>();
   std::sort(sorted_indices_vec.begin(), sorted_indices_vec.end(),
-            [&](IndexT a, IndexT b) -> bool {
+            [&](int64_t a, int64_t b) -> bool {
               for (int64_t i = 0; i < col; ++i) {
-                T lhs = in_trans_data[i + a * col];
-                T rhs = in_trans_data[i + b * col];
+                InT lhs = in_trans_data[i + a * col];
+                InT rhs = in_trans_data[i + b * col];
                 if (lhs < rhs) {
                   return true;
                 } else if (lhs > rhs) {
@@ -297,10 +271,11 @@ static void UniqueDim(const framework::ExecutionContext& context,
   framework::Tensor input_sorted;
   input_sorted.Resize(in_trans_dims);
   input_sorted.mutable_data<InT>(context.GetPlace());
-  T* input_sorted_data = input_sorted.data<InT>();
+  InT* input_sorted_data = input_sorted.data<InT>();
   for (size_t i = 0; i < sorted_indices_vec.size(); ++i) {
     memcpy(input_sorted_data + i * col,
-           in_trans_data + sorted_indices_vec[i] * col, col * sizeof(InT));
+           in_trans_data + static_cast<int64_t>(sorted_indices_vec[i]) * col,
+           col * sizeof(InT));
   }
 
   std::vector<framework::Tensor> input_unbind = Unbind(input_sorted);
@@ -320,7 +295,7 @@ static void UniqueDim(const framework::ExecutionContext& context,
   std::vector<int64_t> out_trans_dims_vec = in_trans_dims_vec;
   out_trans_dims_vec[0] = input_unbind.size();
   out_trans.Resize(framework::make_ddim(out_trans_dims_vec));
-  out_trans.mutable_data<T>(context.GetPlace());
+  out_trans.mutable_data<InT>(context.GetPlace());
   std::swap(out_trans_dims_vec[0], out_trans_dims_vec[axis]);
   out->Resize(framework::make_ddim(out_trans_dims_vec));
   out->mutable_data<InT>(context.GetPlace());
@@ -345,13 +320,37 @@ static void UniqueDim(const framework::ExecutionContext& context,
 }
 
 template <typename DeviceContext, typename InT>
-struct UniqueDimFunctor {
-  const DeviceContext& ctx_;
+struct UniqueFlattendTensorFunctor {
+  const framework::ExecutionContext& ctx_;
+  const framework::Tensor& in_;
   framework::Tensor* out_;
-  framework::Tensor* indices_;
-  framework::Tensor* inverse_;
-  framework::Tensor* counts_;
-  const framework::Tensor* in_;
+  const bool return_index_;
+  const bool return_inverse_;
+  const bool return_counts_;
+
+  UniqueFlattendTensorFunctor(const framework::ExecutionContext& context,
+                              const framework::Tensor& in,
+                              framework::Tensor* out, bool return_index,
+                              bool return_inverse, bool return_counts)
+      : ctx_(context),
+        in_(in),
+        out_(out),
+        return_index_(return_index),
+        return_inverse_(return_inverse),
+        return_counts_(return_counts) {}
+
+  template <typename IndexT>
+  void apply() const {
+    UniqueFlattendTensor<InT, IndexT>(ctx_, in_, out_, return_index_,
+                                      return_inverse_, return_counts_);
+  }
+};
+
+template <typename DeviceContext, typename InT>
+struct UniqueDimFunctor {
+  const framework::ExecutionContext& ctx_;
+  const framework::Tensor& in_;
+  framework::Tensor* out_;
   const int axis_;
   const bool return_index_;
   const bool return_inverse_;
@@ -359,15 +358,11 @@ struct UniqueDimFunctor {
 
   UniqueDimFunctor(const framework::ExecutionContext& context,
                    const framework::Tensor& in, framework::Tensor* out,
-                   framework::Tensor* indices, framework::Tensor* inverse,
-                   framework::Tensor* counts, const int axis, bool return_index,
-                   bool return_inverse, bool return_counts)
+                   const int axis, bool return_index, bool return_inverse,
+                   bool return_counts)
       : ctx_(context),
         in_(in),
         out_(out),
-        indices_(indices),
-        inverse_(inverse),
-        counts_(counts),
         axis_(axis),
         return_index_(return_index),
         return_inverse_(return_inverse),
@@ -375,8 +370,8 @@ struct UniqueDimFunctor {
 
   template <typename IndexT>
   void apply() const {
-    UniqueDim<DeviceContext, InT, IndexT>(context, *x, out, return_index,
-                                          return_inverse, return_counts, axis);
+    UniqueDim<DeviceContext, InT, IndexT>(
+        ctx_, in_, out_, return_index_, return_inverse_, return_counts_, axis_);
   }
 };
 
@@ -388,6 +383,15 @@ class UniqueKernel : public framework::OpKernel<T> {
     auto* out = context.Output<framework::Tensor>("Out");
     auto data_type = static_cast<framework::proto::VarType::Type>(
         context.Attr<int>("dtype"));
+    if (data_type == framework::proto::VarType::INT32) {
+      PADDLE_ENFORCE_LE(
+          x->numel(), INT_MAX,
+          platform::errors::InvalidArgument(
+              "The number of elements in Input(X) should be less than or "
+              "equal to INT_MAX, but received num is %d. Please set `dtype` to "
+              "int64.",
+              x->numel()));
+    }
     if (!context.Attr<bool>("is_sorted")) {
       auto* index = context.Output<framework::Tensor>("Index");
 
@@ -395,25 +399,22 @@ class UniqueKernel : public framework::OpKernel<T> {
       return;
     }
 
-    auto* indices = context.Output<framework::Tensor>("Indices");
-    auto* inverse = context.Output<framework::Tensor>("Index");
-    auto* counts = context.Output<framework::Tensor>("Counts");
     std::vector<int> axis_vec = context.Attr<std::vector<int>>("axis");
     bool return_index = context.Attr<bool>("return_index");
     bool return_inverse = context.Attr<bool>("return_inverse");
     bool return_counts = context.Attr<bool>("return_counts");
 
     if (axis_vec.empty()) {
-      framework::VisitDataType(
+      framework::VisitDataTypeSmall(
           data_type,
-          UniqueFlattendTensor<T>(context, *x, out, indices, inverse, counts,
-                                  return_index, return_inverse, return_counts));
+          UniqueFlattendTensorFunctor<DeviceContext, T>(
+              context, *x, out, return_index, return_inverse, return_counts));
     } else {
       int axis = axis_vec[0];
-      framework::VisitDataType(
-          data_type,
-          UniqueDimFunctor<T>(context, *x, out, indices, inverse, counts, axis,
-                              return_index, return_inverse, return_counts));
+      framework::VisitDataTypeSmall(
+          data_type, UniqueDimFunctor<DeviceContext, T>(
+                         context, *x, out, axis, return_index, return_inverse,
+                         return_counts));
     }
   }
 };

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14102,7 +14102,7 @@ def unique(x, dtype='int32'):
 
     Args:
         x(Tensor): A 1-D input tensor, it's data type should be float32, float64, int32, int64.
-        dtype(np.dtype|str): The type of index tensor: int32, int64.
+        dtype(np.dtype|str, optional): The type of index tensor: int32, int64. Default: int32.
 
     Returns:
         tuple: (out, index). `out` is the unique tensor for `x`, with identical dtype to `x`, and \

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -14098,17 +14098,11 @@ def sign(x):
 
 def unique(x, dtype='int32'):
     """
-    :alias_main: paddle.unique
-	:alias: paddle.unique,paddle.tensor.unique,paddle.tensor.manipulation.unique
-	:old_api: paddle.fluid.layers.unique
-
-    **unique**
-
     Return a unique tensor for `x` and an index tensor pointing to this unique tensor.
 
     Args:
-        x(Variable): A 1-D input tensor.
-        dtype(np.dtype|core.VarDesc.VarType|str): The type of index tensor: int32, int64.
+        x(Tensor): A 1-D input tensor, it's data type should be float32, float64, int32, int64.
+        dtype(np.dtype|str): The type of index tensor: int32, int64.
 
     Returns:
         tuple: (out, index). `out` is the unique tensor for `x`, with identical dtype to `x`, and \

--- a/python/paddle/fluid/tests/unittests/test_unique.py
+++ b/python/paddle/fluid/tests/unittests/test_unique.py
@@ -233,6 +233,24 @@ class TestUniqueAPI(unittest.TestCase):
         self.assertTrue((counts.numpy() == np_counts).all(), True)
         paddle.enable_static()
 
+    def test_dygraph_attr_dtype(self):
+        paddle.disable_static()
+        x_data = x_data = np.random.randint(0, 10, (120))
+        x = paddle.to_tensor(x_data)
+        out, indices, inverse, counts = paddle.unique(
+            x,
+            return_index=True,
+            return_inverse=True,
+            return_counts=True,
+            dtype="int32")
+        expected_out, np_indices, np_inverse, np_counts = np.unique(
+            x_data, return_index=True, return_inverse=True, return_counts=True)
+        self.assertTrue((out.numpy() == expected_out).all(), True)
+        self.assertTrue((indices.numpy() == np_indices).all(), True)
+        self.assertTrue((inverse.numpy() == np_inverse).all(), True)
+        self.assertTrue((counts.numpy() == np_counts).all(), True)
+        paddle.enable_static()
+
     def test_static_graph(self):
         with paddle.static.program_guard(paddle.static.Program(),
                                          paddle.static.Program()):
@@ -281,6 +299,9 @@ class TestUniqueError(unittest.TestCase):
 
         def test_axis():
             result = paddle.unique(x, axis='12')
+
+        def test_dtype():
+            result = paddle.unique(x, dtype='float64')
 
         self.assertRaises(TypeError, test_axis)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -626,7 +626,7 @@ def unique(x,
         return_counts(bool, optional): If True, also return the counts for each unique element.
         axis(int, optional): The axis to apply unique. If None, the input will be flattened.
             Default: None.
-        dtype(np.dtype|str): The date type of `indices` or `inverse` tensor: int32 or int64.
+        dtype(np.dtype|str, optional): The date type of `indices` or `inverse` tensor: int32 or int64.
             Default: int64.
         name(str, optional): Name for the operation. For more information, please refer to
             :ref:`api_guide_Name`. Default: None.
@@ -666,11 +666,10 @@ def unique(x,
         axis = []
     else:
         axis = [axis]
-
+    attr_dtype = convert_np_dtype_to_dtype_(dtype)
     if in_dygraph_mode():
         out, inverse, indices, counts = core.ops.unique(
-            x, 'dtype',
-            convert_np_dtype_to_dtype_('int32'), 'return_index', return_index,
+            x, 'dtype', attr_dtype, 'return_index', return_index,
             'return_inverse', return_inverse, 'return_counts', return_counts,
             'axis', axis, "is_sorted", True)
         outs = [out]
@@ -697,30 +696,29 @@ def unique(x,
 
     helper = LayerHelper('unique', **locals())
     attrs = {
-        'dtype': int(core.VarDesc.VarType.INT32),
+        'dtype': attr_dtype,
         "return_index": return_index,
         "return_inverse": return_inverse,
         "return_counts": return_counts,
         "axis": axis,
         "is_sorted": True
     }
-    dtype = convert_dtype(dtype)
     out = helper.create_variable_for_type_inference(
         dtype=x.dtype, stop_gradient=True)
     inverse = helper.create_variable_for_type_inference(
-        dtype=dtype, stop_gradient=True)
+        dtype=attr_dtype, stop_gradient=True)
     outputs = {"Out": out, "Index": inverse}
     outs = [out]
     if return_index:
         indices = helper.create_variable_for_type_inference(
-            dtype=dtype, stop_gradient=True)
+            dtype=attr_dtype, stop_gradient=True)
         outputs["Indices"] = indices
         outs.append(indices)
     if return_inverse:
         outs.append(inverse)
     if return_counts:
         counts = helper.create_variable_for_type_inference(
-            dtype=core.VarDesc.VarType.INT64, stop_gradient=True)
+            dtype=attr_dtype, stop_gradient=True)
         outputs["Counts"] = counts
         outs.append(counts)
 

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -612,6 +612,7 @@ def unique(x,
            return_inverse=False,
            return_counts=False,
            axis=None,
+           dtype="int64",
            name=None):
     """
     Returns the unique elements of `x` in ascending order.
@@ -625,6 +626,8 @@ def unique(x,
         return_counts(bool, optional): If True, also return the counts for each unique element.
         axis(int, optional): The axis to apply unique. If None, the input will be flattened.
             Default: None.
+        dtype(np.dtype|str): The date type of `indices` or `inverse` tensor: int32 or int64.
+            Default: int64.
         name(str, optional): Name for the operation. For more information, please refer to
             :ref:`api_guide_Name`. Default: None.
 
@@ -688,6 +691,7 @@ def unique(x,
     check_type(return_index, 'return_index', bool, 'unique')
     check_type(return_inverse, 'return_inverse', bool, 'unique')
     check_type(return_counts, 'return_counts', bool, 'unique')
+    check_dtype(dtype, 'dtype', ['int32', 'int64'], 'unique')
     if len(axis) != 0:
         check_type(axis[0], 'axis', int, 'unique')
 
@@ -700,15 +704,16 @@ def unique(x,
         "axis": axis,
         "is_sorted": True
     }
+    dtype = convert_dtype(dtype)
     out = helper.create_variable_for_type_inference(
         dtype=x.dtype, stop_gradient=True)
     inverse = helper.create_variable_for_type_inference(
-        dtype=core.VarDesc.VarType.INT64, stop_gradient=True)
+        dtype=dtype, stop_gradient=True)
     outputs = {"Out": out, "Index": inverse}
     outs = [out]
     if return_index:
         indices = helper.create_variable_for_type_inference(
-            dtype=core.VarDesc.VarType.INT64, stop_gradient=True)
+            dtype=dtype, stop_gradient=True)
         outputs["Indices"] = indices
         outs.append(indices)
     if return_inverse:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -650,6 +650,7 @@ def unique(x,
             np_counts = counts.numpy() # [1 1 3 1]
 
             x_data = np.array([[2, 1, 3], [3, 0, 1], [2, 1, 3]])
+            x = paddle.to_tensor(x_data)
             unique = paddle.unique(x)
             np_unique = unique.numpy() # [0 1 2 3]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> add dtype for unique 

**PR改动**
- 对新的unique接口，允许通过dtype参数设置输出的indices、inverse和counts的dtype
- manipulation下的unique为新版接口，暴露dtype参数，同时默认值为int64，同时修正了示例代码
- fluid下的unique为旧版接口，原本已暴露了dtype参数，默认值为int32，未做改动。
- 同时注册了unique op的兼容性信息，该OP新增了2个输出（indice和counts），5个属性（return_index，return_inverse，return_counts，axis，is_sorted）

**文档**
- 新接口：
![image](https://user-images.githubusercontent.com/26615455/91387043-ec7acb00-e866-11ea-840d-c3f8267fc58f.png)
![image](https://user-images.githubusercontent.com/26615455/91387051-f1d81580-e866-11ea-9257-bf1752268573.png)


- 旧接口
![image](https://user-images.githubusercontent.com/26615455/91387097-05837c00-e867-11ea-84bc-9d2c061f75fb.png)


 
