### PR TITLE
add empty_like op (c++, python, unit test)

### DIFF
--- a/paddle/fluid/operators/empty_like_op.cc
+++ b/paddle/fluid/operators/empty_like_op.cc
@@ -1,0 +1,101 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/empty_like_op.h"
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+class EmptyLikeOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddComment(R"DOC(empty_like operator
+Returns a tensor filled with uninitialized data. The shape of the tensor is
+defined by the variable argument `input.shape`.
+
+The type of the tensor is specify by `input.dtype`.
+)DOC");
+    AddInput("X", "The input of empty_like op.");
+    AddOutput("Out", "(Tensor) The output tensor.");
+    AddAttr<int>("dtype",
+                 "Output tensor data type. defalut value is -1,"
+                 "according to the input dtype.")
+        .SetDefault(-1);
+  }
+};
+
+class EmptyLikeOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext *context) const override {
+    OP_INOUT_CHECK(context->HasInput("X"), "Input", "X", "empty_like");
+    OP_INOUT_CHECK(context->HasOutput("Out"), "Output", "Out", "empty_like");
+    context->SetOutputDim("Out", context->GetInputDim("X"));
+    context->ShareLoD("X", /*->*/ "Out");
+  }
+
+ protected:
+  framework::OpKernelType GetExpectedKernelType(
+      const framework::ExecutionContext &context) const override {
+    framework::OpKernelType kt =
+        OperatorWithKernel::GetExpectedKernelType(context);
+    const auto &data_type = context.Attr<int>("dtype");
+    if (data_type >= 0) {
+      kt.data_type_ = static_cast<framework::proto::VarType::Type>(data_type);
+    }
+    return kt;
+  }
+
+  framework::OpKernelType GetKernelTypeForVar(
+      const std::string &var_name, const framework::Tensor &tensor,
+      const framework::OpKernelType &expected_kernel_type) const override {
+    return framework::OpKernelType(expected_kernel_type.data_type_,
+                                   expected_kernel_type.place_,
+                                   tensor.layout());
+  }
+};
+
+class EmptyLikeOpVarTypeInference : public framework::VarTypeInference {
+ public:
+  void operator()(framework::InferVarTypeContext *context) const override {
+    auto var_data_type = static_cast<framework::proto::VarType::Type>(
+        BOOST_GET_CONST(int, context->GetAttr("dtype")));
+    if (var_data_type < 0) {
+      context->SetOutputDataType("Out", context->GetInputDataType("X"));
+    } else {
+      context->SetOutputDataType("Out", var_data_type);
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OPERATOR(
+    empty_like, ops::EmptyLikeOp, ops::EmptyLikeOpMaker,
+    ops::EmptyLikeOpVarTypeInference,
+    paddle::framework::EmptyGradOpMaker<paddle::framework::OpDesc>,
+    paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
+
+REGISTER_OP_CPU_KERNEL(
+    empty_like, ops::EmptyLikeKernel<plat::CPUDeviceContext, float>,
+    ops::EmptyLikeKernel<plat::CPUDeviceContext, double>,
+    ops::EmptyLikeKernel<plat::CPUDeviceContext, int64_t>,
+    ops::EmptyLikeKernel<plat::CPUDeviceContext, int>,
+    ops::EmptyLikeKernel<plat::CPUDeviceContext, plat::float16>);

--- a/paddle/fluid/operators/empty_like_op.cu
+++ b/paddle/fluid/operators/empty_like_op.cu
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/empty_like_op.h"
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_CUDA_KERNEL(
+    empty_like, ops::EmptyLikeKernel<plat::CUDADeviceContext, float>,
+    ops::EmptyLikeKernel<plat::CUDADeviceContext, double>,
+    ops::EmptyLikeKernel<plat::CUDADeviceContext, int64_t>,
+    ops::EmptyLikeKernel<plat::CUDADeviceContext, int>,
+    ops::EmptyLikeKernel<plat::CUDADeviceContext, plat::float16>);

--- a/paddle/fluid/operators/empty_like_op.h
+++ b/paddle/fluid/operators/empty_like_op.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paddle/fluid/framework/op_registry.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+class EmptyLikeKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    // auto& out = GET_DATA_SAFELY(context.Output<framework::Tensor>("Out"),
+    //                             "Output", "Out", "empty_like");
+    auto* out = context.Output<framework::Tensor>("Out");
+
+    // @NOTE
+    // only use cpu device for uninitialized memory
+    auto place = platform::CPUPlace();
+    // auto place = context.GetPlace();
+    out->mutable_data<T>(place);
+    // out.mutable_data(context.GetPlace());
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -75,6 +75,7 @@ from .tensor.creation import full_like  #DEFINE_ALIAS
 from .tensor.creation import triu  #DEFINE_ALIAS
 from .tensor.creation import tril  #DEFINE_ALIAS
 from .tensor.creation import meshgrid  #DEFINE_ALIAS
+from .tensor.creation import empty_like  #DEFINE_ALIAS
 from .tensor.linalg import matmul  #DEFINE_ALIAS
 from .tensor.linalg import dot  #DEFINE_ALIAS
 # from .tensor.linalg import einsum        #DEFINE_ALIAS

--- a/python/paddle/fluid/tests/unittests/test_empty_like_op.py
+++ b/python/paddle/fluid/tests/unittests/test_empty_like_op.py
@@ -1,0 +1,115 @@
+#Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.layers as layers
+import paddle.fluid.core as core
+from op_test import OpTest
+from paddle.fluid import compiler, Program, program_guard
+from paddle.fluid.framework import convert_np_dtype_to_dtype_
+from paddle.fluid.op import Operator
+
+
+class TestEmptyLikeOp(OpTest):
+    def setUp(self):
+        self.op_type = "empty_like"
+        self.init_config()
+
+    def test_check_output(self):
+        # self.check_output()
+        self.check_output_customized(self.verify_output)
+
+    def verify_output(self, outs):
+        # print('----- outs -----: ', outs)
+        total_value = np.sum(np.array(outs[0]))
+        mean_value = np.mean(np.array(outs[0]))
+        # print('total_value: ', total_value)
+        # print('mean_value: ', mean_value)
+        always_non_zero = total_value != 0.0 and mean_value != 0.0
+        self.assertTrue(always_non_zero, 'always non zeros.')
+        # self.assertTrue(always_non_zero, 'always non zeros.')
+        # self.assertTrue(always_zero or always_non_zero,
+        #                 'always_zero or always_non_zero.')
+
+    def init_config(self):
+        shape = [500, 3]
+        dtype = 'float32'
+        # dtype = core.VarDesc.VarType.FP32
+        # dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        # print('----- dtype_inner -----: ', dtype_inner)
+        # self.attrs = {'shape': shape, 'dtype': dtype_inner}
+        self.x = np.random.uniform(-5, 5, shape).astype(dtype)
+        self.inputs = {'X': self.x}
+        self.outputs = {'Out': np.zeros(shape).astype(dtype)}
+
+
+class TestEmptyOp2(TestEmptyLikeOp):
+    def init_config(self):
+        shape = [500, 3]
+        dtype = 'float64'
+        # dtype = core.VarDesc.VarType.FP64
+        # dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        # print('----- dtype_inner -----: ', dtype_inner)
+        # self.attrs = {'shape': shape, 'dtype': dtype_inner}
+        self.x = np.random.uniform(-5, 5, shape).astype(dtype)
+        self.inputs = {'X': self.x}
+        self.outputs = {'Out': np.zeros(shape).astype(dtype)}
+
+
+class TestEmptyOp3(TestEmptyLikeOp):
+    def init_config(self):
+        shape = [500, 3]
+        dtype = 'int32'
+        # dtype = core.VarDesc.VarType.INT32
+        # dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        # print('----- dtype_inner -----: ', dtype_inner)
+        # self.attrs = {'shape': shape, 'dtype': dtype_inner}
+        self.x = np.random.uniform(-5, 5, shape).astype(dtype)
+        self.inputs = {'X': self.x}
+        self.outputs = {'Out': np.zeros(shape).astype(dtype)}
+
+
+class TestEmptyOp4(TestEmptyLikeOp):
+    def init_config(self):
+        shape = [500, 3]
+        dtype = 'int64'
+        # dtype = core.VarDesc.VarType.INT64
+        # dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        # print('----- dtype_inner -----: ', dtype_inner)
+        # self.attrs = {'shape': shape, 'dtype': dtype_inner}
+        self.x = np.random.uniform(-5, 5, shape).astype(dtype)
+        self.inputs = {'X': self.x}
+        self.outputs = {'Out': np.zeros(shape).astype(dtype)}
+
+
+class TestEmptyOp5(TestEmptyLikeOp):
+    def init_config(self):
+        shape = [500, 3]
+        dtype = 'float32'
+        # dtype = core.VarDesc.VarType.FP32
+        dtype_inner = convert_np_dtype_to_dtype_(dtype)
+        # print('----- dtype_inner -----: ', dtype_inner)
+        self.attrs = {'shape': shape, 'dtype': dtype_inner}
+        self.x = np.random.uniform(-5, 5, shape).astype(dtype)
+        self.inputs = {'X': self.x}
+        self.outputs = {'Out': np.zeros(shape).astype(dtype)}
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -40,6 +40,7 @@ from .creation import full_like  #DEFINE_ALIAS
 from .creation import triu  #DEFINE_ALIAS
 from .creation import tril  #DEFINE_ALIAS
 from .creation import meshgrid  #DEFINE_ALIAS
+from .creation import empty_like  #DEFINE_ALIAS
 from .io import save  #DEFINE_ALIAS
 from .io import load  #DEFINE_ALIAS
 from .linalg import matmul  #DEFINE_ALIAS


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
add empty_like op.

Returns an uninitialized tensor with the same size as input.