### PR TITLE
[DO NOT MERGE][ONEDNN] Added prototype of midout for pool

### DIFF
--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -883,11 +883,14 @@ class Pool2D(layers.Layer):
         inputs = {"X": [input]}
 
         pool_out = self._helper.create_variable_for_type_inference(self._dtype)
+        mid_out = helper.create_variable_for_type_inference(
+            dtype=dtype, stop_gradient=True)
 
         self._helper.append_op(
             type=self._l_type,
             inputs={"X": input},
-            outputs={"Out": pool_out},
+            outputs={"Out": pool_out,
+                     "MidOut": mid_out},
             attrs=attrs)
         return pool_out
 

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -2053,11 +2053,13 @@ def pool2d(input,
     helper = LayerHelper(op_type, **locals())
     dtype = helper.input_dtype()
     pool_out = helper.create_variable_for_type_inference(dtype)
-
+    mid_out = helper.create_variable_for_type_inference(
+        dtype=dtype, stop_gradient=True)
     helper.append_op(
         type=op_type,
         inputs={"X": input},
-        outputs={"Out": pool_out},
+        outputs={"Out": pool_out,
+                 "MidOut": mid_out},
         attrs={
             "pooling_type": pool_type,
             "ksize": pool_size,

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_int8_mkldnn_op.py
@@ -41,6 +41,7 @@ class TestPool2dMKLDNNInt8_Op(TestPool2D_Op):
             self.dtype)).astype(self.dtype)
         self.inputs = {'X': OpTest.np_dtype_to_fluid_dtype(input)}
         self.outputs = {'Out': output}
+        self.attrs['is_test'] = True
 
     def test_check_output(self):
         # TODO(wangzhongpu): support mkldnn op in dygraph mode

--- a/python/paddle/fluid/tests/unittests/white_list/no_check_set_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/no_check_set_white_list.py
@@ -19,6 +19,7 @@ no_check_set_white_list = [
     'flatten2',
     'flatten_contiguous_range',
     'lrn',
+    'pool2d',
     'squeeze2',
     'reshape2',
     'transpose2',


### PR DESCRIPTION
This PR is to be discussed. oneDNN kernel of grad pool2d needs "MidOut" data , similar way like it is done for LRN op.
So far instead of MidOut , oneDNN cache was used. But this is very complex especially when multi-threaded training is running. It will also reduce cache operations for dygraph. 

Notes:
- MidOut is added regardless the execution (oneDNN, GPU, native CPU)
- MidOut data depends on oneDNN , so format is opaque, so we do not validate this data in UT.

@luotao1 Please take a look if this idea is acceptable.

### PR types
Breaking changes

### PR changes
Ops

### Describe
oneDNN pool2d kernel of grad op is using data from FWD. This PR is adding MidOut tensor to store that data and make it available during grad execution.

