### PR TITLE
set timeout properity for a unittest

### DIFF
--- a/python/paddle/incubate/hapi/tests/CMakeLists.txt
+++ b/python/paddle/incubate/hapi/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ foreach(src ${TEST_OPS})
     py_test(${src} SRCS ${src}.py)
 endforeach()
 set_tests_properties(test_dataset_imdb PROPERTIES TIMEOUT 150) 
+set_tests_properties(test_vision_models PROPERTIES TIMEOUT 150)
 
 
 function(py_dist_test TARGET_NAME)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
set timeout properity for test_vision_models 