### PR TITLE
share cudnn rnn weight op

### DIFF
--- a/paddle/fluid/framework/tensor.h
+++ b/paddle/fluid/framework/tensor.h
@@ -150,6 +150,8 @@ class Tensor {
 
   void set_layout(const DataLayout layout) { layout_ = layout; }
 
+  void set_offset(const size_t offset) { offset_ = offset; }
+
   void clear() {
     holder_ = nullptr;
     offset_ = 0;

--- a/paddle/fluid/operators/cudnn_rnn_flatten_weight_op.cc
+++ b/paddle/fluid/operators/cudnn_rnn_flatten_weight_op.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/operators/cudnn_rnn_flatten_weight_op.h"
+
+namespace paddle {
+namespace operators {
+
+class CudnnRnnFlattenWeightOp : public framework::OperatorWithKernel {
+ public:
+  using framework::OperatorWithKernel::OperatorWithKernel;
+
+  void InferShape(framework::InferShapeContext* ctx) const override {
+    OP_INOUT_CHECK(ctx->HasInput("Weight"), "Output", "Weight",
+                   "Cudnn_rnn_flatten_weight");
+    OP_INOUT_CHECK(ctx->HasOutput("WeightHh"), "Input", "WeightHh",
+                   "Cudnn_rnn_flatten_weight");
+    OP_INOUT_CHECK(ctx->HasOutput("WeightIh"), "Input", "WeightIh",
+                   "Cudnn_rnn_flatten_weight");
+    OP_INOUT_CHECK(ctx->HasOutput("BiasHh"), "Input", "BiasHh",
+                   "Cudnn_rnn_flatten_weight");
+    OP_INOUT_CHECK(ctx->HasOutput("BiasIh"), "Input", "BiasIh",
+                   "Cudnn_rnn_flatten_weight");
+  }
+};
+
+class CudnnRnnFlattenWeightOpMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddInput("Weight",
+             "(Tensor), share data with WeightHh, WeightIh, BiasHh, BiasIh.");
+    AddOutput("WeightHh",
+              "(Tensor List), stores weight_hh and share data with W. ")
+        .AsDuplicable();
+    AddOutput("WeightIh",
+              "(Tensor List), stores weight_ih and share data with W.")
+        .AsDuplicable();
+    AddOutput("BiasHh", "(Tensor List), stores bias_hh and share data with W.")
+        .AsDuplicable();
+    AddOutput("BiasIh", "(Tensor List), stores bias_ih and share data with W. ")
+        .AsDuplicable();
+    AddAttr<bool>("is_bidirec",
+                  "If it is bidirectional rnn, this will affect the shape of "
+                  "the Out, LastH, and LastC.")
+        .SetDefault(false);
+    AddAttr<int>("hidden_size", "hidden size of the LSTM").SetDefault(100);
+    AddAttr<int>("input_size", "input size of the LSTM").SetDefault(100);
+    AddAttr<int>("num_layers", "the total layer number of the LSTM")
+        .SetDefault(1);
+    AddComment(R"DOC(
+      Cudnn_rnn_flatten_weight Operator.
+      Designed to share input and output memory.
+)DOC");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+REGISTER_OPERATOR(cudnn_rnn_flatten_weight, ops::CudnnRnnFlattenWeightOp,
+                  ops::CudnnRnnFlattenWeightOpMaker);
+
+REGISTER_OP_CPU_KERNEL(
+    cudnn_rnn_flatten_weight,
+    ops::CudnnRnnFlattenWeightKernel<paddle::platform::CPUDeviceContext, float>,
+    ops::CudnnRnnFlattenWeightKernel<paddle::platform::CPUDeviceContext,
+                                     double>,
+    ops::CudnnRnnFlattenWeightKernel<paddle::platform::CPUDeviceContext, int>,
+    ops::CudnnRnnFlattenWeightKernel<paddle::platform::CPUDeviceContext,
+                                     int64_t>);

--- a/paddle/fluid/operators/cudnn_rnn_flatten_weight_op.h
+++ b/paddle/fluid/operators/cudnn_rnn_flatten_weight_op.h
@@ -1,0 +1,73 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/math/math_function.h"
+
+namespace paddle {
+namespace operators {
+
+template <typename DeviceContext, typename T>
+class CudnnRnnFlattenWeightKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    auto weight = ctx.Input<framework::Tensor>("Weight");
+    auto weight_ih = ctx.MultiOutput<framework::Tensor>("WeightIh");
+    auto weight_hh = ctx.MultiOutput<framework::Tensor>("WeightHh");
+    auto bias_ih = ctx.MultiOutput<framework::Tensor>("BiasIh");
+    auto bias_hh = ctx.MultiOutput<framework::Tensor>("BiasHh");
+
+    bool is_bidirec = ctx.Attr<bool>("is_bidirec");
+    int input_size = ctx.Attr<int>("input_size");
+    int hidden_size = ctx.Attr<int>("hidden_size");
+    int num_layers = ctx.Attr<int>("num_layers");
+    int gate_size = 4 * hidden_size;
+    int n_direct = is_bidirec ? 2 : 1;
+
+    int offset = 0;
+    int size = 0;
+    for (int i = 0; i < num_layers; ++i) {
+      for (int j = 0; j < n_direct; ++j) {
+        int weight_num = i * n_direct + j;
+        size = i == 0 ? gate_size * input_size : gate_size * hidden_size;
+        weight_ih[weight_num]->ShareDataWith(*weight);
+        weight_ih[weight_num]->set_offset(offset);
+        weight_ih[weight_num]->Resize({size});
+        offset += size * sizeof(T);
+
+        size = gate_size * hidden_size;
+        weight_hh[weight_num]->ShareDataWith(*weight);
+        weight_hh[weight_num]->set_offset(offset);
+        weight_hh[weight_num]->Resize({size});
+        offset += size * sizeof(T);
+
+        size = gate_size;
+        bias_ih[weight_num]->ShareDataWith(*weight);
+        bias_ih[weight_num]->set_offset(offset);
+        bias_ih[weight_num]->Resize({size});
+        offset += size * sizeof(T);
+
+        size = gate_size;
+        bias_hh[weight_num]->ShareDataWith(*weight);
+        bias_hh[weight_num]->set_offset(offset);
+        bias_hh[weight_num]->Resize({size});
+        offset += size * sizeof(T);
+      }
+    }
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle


### PR DESCRIPTION
### PR types
New features 

### PR changes
OPs 

### Describe
新增一个cudnn_rnn_flatten_weight_op实现CUDNN与非CUDNN实现参数转换。

内容：CUDNN使用特定的参数格式，若自动切换CUDNN，也需要自动转换参数（CUDNN实现中使用合并的参数，非CUDNN实现参数分开存放）

- 在C++端完成参数转换，并将新参数和原参数的共享存储，新参数对用户隐藏，用户仍使用原参数；并在检测到参数不合要求时（如某个参数指向了其他参数而不再连续）在执行时重新转换并打warning（pytorch的方法），较多内容需要由C++端完成。
