### PR TITLE
Add some command to display the context of `dist_test` when it meets error!

### DIFF
--- a/python/paddle/fluid/tests/unittests/dist_test.sh
+++ b/python/paddle/fluid/tests/unittests/dist_test.sh
@@ -61,7 +61,14 @@ for i in {1..2}; do
     fi
 done
 
+echo "dist space:"
+df -h
+
 #display /tmp/files
+echo "ls /tmp/paddle.*"
 ls -l /tmp/paddle.*
+
+echo "ls -l ./"
+ls -l ./
 
 exit 1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
 Others

### Describe
`test_auto_checkpoint_multiple.py` meets timeout occasionally and this pr print more context details.
