### PR TITLE
fix WITH_GLOO CMake Flag,support pslib. test=develop

### DIFF
--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -270,7 +270,7 @@ endif(WITH_PSLIB)
 
 if(WITH_GLOO)
     if(NOT WIN32 AND NOT APPLE)
-	include(external/gloo)
+        include(external/gloo)
         list(APPEND third_party_deps extern_gloo)
     endif()
 endif()

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -268,6 +268,13 @@ if(WITH_PSLIB)
     endif()
 endif(WITH_PSLIB)
 
+if(WITH_GLOO)
+    if(NOT WIN32 AND NOT APPLE)
+	include(external/gloo)
+        list(APPEND third_party_deps extern_gloo)
+    endif()
+endif()
+
 
 if(WITH_BOX_PS)
     include(external/box_ps)
@@ -275,11 +282,6 @@ if(WITH_BOX_PS)
 endif(WITH_BOX_PS)
 
 if(WITH_DISTRIBUTE)
-    if(WITH_GLOO)
-        include(external/gloo)
-        list(APPEND third_party_deps extern_gloo)
-    endif()
-
     if(WITH_GRPC)
         list(APPEND third_party_deps extern_grpc)
     else()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
support WITH_GLOO CMake Flag of PSlib, using as "Cmake ..  WITH_GLOO=ON,..."