### PR TITLE
[Dy2Stat] Raise RuntimeError if run the callable object decorated by '@paddle.jit.to_static' not in dynamic mode

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -24,6 +24,7 @@ import warnings
 
 import gast
 from paddle.fluid import framework
+from paddle.fluid import in_dygraph_mode
 from paddle.fluid.dygraph import layers
 from paddle.fluid.data_feeder import check_type
 from paddle.fluid.layers.utils import flatten
@@ -32,6 +33,7 @@ from paddle.fluid.dygraph.base import switch_to_static_graph
 from paddle.fluid.dygraph.dygraph_to_static import DygraphToStaticAst
 from paddle.fluid.dygraph.dygraph_to_static.error import ERROR_DATA
 from paddle.fluid.dygraph.dygraph_to_static.error import attach_error_data
+from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import attach_origin_info
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import create_and_update_origin_info_map
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import update_op_callstack_with_origin_info
@@ -283,12 +285,20 @@ class StaticLayer(object):
         Return:
             Outputs of decorated function.
         """
+
         # 1. call dygraph function directly if not enable `declarative`
         if not self._program_trans.enable_declarative:
-            warnings.warn(
-                "The decorator '@paddle.jit.to_static' doesn't work when setting ProgramTranslator.enable=False. "
+            logging_utils.warn(
+                "The decorator '@paddle.jit.to_static' does NOT work when setting ProgramTranslator.enable=False. "
                 "We will just return dygraph output.")
             return self._call_dygraph_function(*args, **kwargs)
+
+        if not in_dygraph_mode() and self._program_trans.enable_declarative:
+            raise RuntimeError(
+                "Failed to run the callable object {} decorated by '@paddle.jit.to_static', "
+                "because it does NOT in dynamic mode. Please disable the static mode to enter dynamic mode with the "
+                "following API: paddle.disable_static().".format(
+                    self.dygraph_function))
 
         # 2. trace ops from dygraph layers and cache the generated program.
         args, kwargs = self._function_spec.unified_args_and_kwargs(args, kwargs)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
As the title
<!-- ![image](https://user-images.githubusercontent.com/33742067/91454480-94b68100-e8b3-11ea-909e-a8b15e10bc6a.png) -->

<!-- ![image](https://user-images.githubusercontent.com/33742067/91454760-e8c16580-e8b3-11ea-8cda-a287e02f44d8.png) -->

#### Before:
**报错内容无法反映出问题，用户难以定位、解决。**
![image](https://user-images.githubusercontent.com/33742067/91858362-a5903980-ec9b-11ea-8a29-dd1d2df62240.png)

#### After:
**在调用__call__函数时，进行检查，抛出RuntimeError**
**目前仅在：dynamic mode==False 且 ProgramTranslator().enable_declarative==True时，抛出该异常。**
|enable_declarative|动态图|静态图|
|--|--|--|
|True|使用动静转换功能|**RuntimeError**|
|False|动态图模式下，不使用动静转换功能|如果网络中使用了dygraph only的接口，会报错“XX接口在动态图模式下运行”<br>否则，正常运行
 
![image](https://user-images.githubusercontent.com/33742067/91454760-e8c16580-e8b3-11ea-8cda-a287e02f44d8.png)