### PR TITLE
optimize elementwise_sub_grad SimpleElemwiseSubGradCUDAKernel on half…

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_sub_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_sub_op.h
@@ -88,7 +88,19 @@ elementwise_sub_grad(const framework::ExecutionContext& ctx,
 
 #ifdef PADDLE_WITH_CUDA
 // cuda definition
-template <typename DeviceContext, typename T>
+template <typename DeviceContext, typename T,
+          typename std::enable_if<!std::is_same<
+              T, paddle::platform::float16>::value>::type* = nullptr>
+typename std::enable_if<
+    std::is_same<DeviceContext, platform::CUDADeviceContext>::value>::type
+elementwise_sub_grad(const framework::ExecutionContext& ctx,
+                     const framework::Tensor* x, const framework::Tensor* y,
+                     const framework::Tensor* out,
+                     const framework::Tensor* dout, framework::Tensor* dx,
+                     framework::Tensor* dy);
+template <typename DeviceContext, typename T,
+          typename std::enable_if<std::is_same<
+              T, paddle::platform::float16>::value>::type* = nullptr>
 typename std::enable_if<
     std::is_same<DeviceContext, platform::CUDADeviceContext>::value>::type
 elementwise_sub_grad(const framework::ExecutionContext& ctx,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Optimize SimpleElemwiseSubGradCUDAKernel on half
Profiled in Docker with nsys
Tesla V100-SXM2, CUDA 10.1, NVIDIA-SMI 440.33.01, Driver Version: 440.33.01

|size|before|after|speedup|
|:---:|:---:|:---:|:---:|
|16,2048,16,16|69312|64624|1.07x|