### PR TITLE
add deprecated decorator for old apis expand and expand_as 

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10205,6 +10205,7 @@ def unstack(x, axis=0, num=None):
     return outs
 
 
+@deprecated(since='2.0.0', update_to="paddle.expand")
 def expand(x, expand_times, name=None):
     """
     :alias_main: paddle.expand
@@ -10312,6 +10313,7 @@ def expand(x, expand_times, name=None):
     return out
 
 
+@deprecated(since='2.0.0', update_to="paddle.expand_as")
 def expand_as(x, target_tensor, name=None):
     """
     :alias_main: paddle.expand_as

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10379,6 +10379,9 @@ def expand_as(x, target_tensor, name=None):
         #(3,20)
 
     """
+    if in_dygraph_mode():
+        return core.ops.expand_as(x, target_tensor)
+
     check_variable_and_dtype(
         x, 'x', ['float32', 'float64', 'int32', 'int64', 'bool'], 'expand_as')
     check_variable_and_dtype(target_tensor, 'target_tensor',

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -108,12 +108,12 @@ class TestExpandAsDygraphAPI(unittest.TestCase):
     def test_api(self):
         paddle.disable_static()
         np_data_x = np.array([1, 2, 3]).astype('int32')
-        np_data_y = np.array([[1, 2, 3], [1, 2, 3]]).astype('int32')
+        np_data_y = np.array([1, 2, 3, 1, 2, 3]).astype('int32')
         data_x = paddle.to_tensor(np_data_x)
         data_y = paddle.to_tensor(np_data_y)
         out = fluid.layers.expand_as(data_x, data_y)
         np_out = out.numpy()
-        assert np.array_equal(np_out, np.tile(input1, (2, 1)))
+        assert np.array_equal(np_out, np.tile(input1, (2)))
 
 
 # Test python API

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -17,7 +17,6 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle
 import paddle.fluid as fluid
 
 
@@ -106,6 +105,7 @@ class TestExpandAsOpRank4(OpTest):
 # Test dygraph API
 class TestExpandAsDygraphAPI(unittest.TestCase):
     def test_api(self):
+        import paddle
         paddle.disable_static()
         np_data_x = np.array([1, 2, 3]).astype('int32')
         np_data_y = np.array([1, 2, 3, 1, 2, 3]).astype('int32')
@@ -114,6 +114,7 @@ class TestExpandAsDygraphAPI(unittest.TestCase):
         out = fluid.layers.expand_as(data_x, data_y)
         np_out = out.numpy()
         assert np.array_equal(np_out, np.tile(input1, (2)))
+        paddle.enable_static()
 
 
 # Test python API

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle
 import paddle.fluid as fluid
 
 

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -102,8 +102,21 @@ class TestExpandAsOpRank4(OpTest):
         self.check_grad(['X'], 'Out')
 
 
+# Test dygraph API
+class TestExpandAsDygraphAPI(unittest.TestCase):
+    def test_api(self):
+        paddle.disable_static()
+        np_data_x = np.array([1, 2, 3]).astype('int32')
+        np_data_y = np.array([[1, 2, 3], [1, 2, 3]]).astype('int32')
+        data_x = paddle.to_tensor(np_data_x)
+        data_y = paddle.to_tensor(np_data_y)
+        out = fluid.layers.expand_as(data_x, data_y)
+        np_out = out.numpy()
+        assert np.array_equal(np_out, np.tile(input1, (2, 1)))
+
+
 # Test python API
-class TestExpandAPI(unittest.TestCase):
+class TestExpandAsAPI(unittest.TestCase):
     def test_api(self):
         input1 = np.random.random([12, 14]).astype("float32")
         input2 = np.random.random([48, 14]).astype("float32")

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -113,7 +113,7 @@ class TestExpandAsDygraphAPI(unittest.TestCase):
         data_y = paddle.to_tensor(np_data_y)
         out = fluid.layers.expand_as(data_x, data_y)
         np_out = out.numpy()
-        assert np.array_equal(np_out, np.tile(input1, (2)))
+        assert np.array_equal(np_out, np.tile(np_data_x, (2)))
         paddle.enable_static()
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add deprecated decorator for old apis expand and expand_as 