### PR TITLE
fix Bilinear bias shape, from [1, x] to [x]

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -672,7 +672,7 @@ def bilinear(x1, x2, weight, bias=None, name=None):
        x1 (Tensor): the first input tensor, it's data type should be float32, float64.
        x2 (Tensor): the second input tensor, it's data type should be float32, float64.
        weight (Parameter): The learnable weights of this layer, shape is [out_features, in1_features, in2_features].
-       bias (Parameter, optional): The learnable bias(Bias) of this layer, shape is [1, out_features]. If it is set to None, no bias will be added to the output units. The default value is None.
+       bias (Parameter, optional): The learnable bias(Bias) of this layer, shape is [out_features]. If it is set to None, no bias will be added to the output units. The default value is None.
        name (str, optional): The default value is None. Normally there is no need for user
            to set this property. For more information, please refer to :ref:`api_guide_Name`. Default: None.
 
@@ -690,7 +690,7 @@ def bilinear(x1, x2, weight, bias=None, name=None):
         x1 = numpy.random.random((5, 5)).astype('float32')
         x2 = numpy.random.random((5, 4)).astype('float32')
         w = numpy.random.random((1000, 5, 4)).astype('float32')
-        b = numpy.random.random((1, 1000)).astype('float32')
+        b = numpy.random.random((1000)).astype('float32')
 
         result = F.bilinear(paddle.to_tensor(x1), paddle.to_tensor(x2), paddle.to_tensor(w), paddle.to_tensor(b))           # result shape [5, 1000]
 

--- a/python/paddle/nn/layer/common.py
+++ b/python/paddle/nn/layer/common.py
@@ -624,7 +624,7 @@ class Bilinear(layers.Layer):
      - :math:`x2`: the second input contains in2_features elements, shape is [batch_size, in2_features].
      - :math:`W_{i}`: the i-th learned weight, shape is [in1_features, in2_features], and learned weight's shape is [out_features, in1_features, in2_features].
      - :math:`out_{i}`: the i-th element of out, shape is [batch_size, out_features].
-     - :math:`b`: the learned bias, shape is [1, out_features].
+     - :math:`b`: the learned bias, shape is [out_features].
      - :math:`x2^\mathrm{T}`: the transpose of :math:`x2`.
 
     Parameters:
@@ -687,7 +687,7 @@ class Bilinear(layers.Layer):
             shape=weight_shape,
             dtype=self._dtype,
             is_bias=False)
-        bias_shape = [1, self._out_features]
+        bias_shape = [self._out_features]
         self.bias = self.create_parameter(
             attr=self._bias_attr,
             shape=bias_shape,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
修改Bilinear中bias的Shape，从[1, out_features]改为[out_features]，进而与Torch保持一致。