### PR TITLE
Update container.py

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -269,7 +269,7 @@ class LayerList(Layer):
                     print(linears[3] is another)  # True
         """
         assert isinstance(index, int) and \
-               0 <= index < len(self._sub_layers), \
+               ((0 <= index < len(self._sub_layers)) or (len(self._sub_layers) == 0)), \
             "index should be an integer in range [0, len(self))"
         for i in range(len(self._sub_layers), index, -1):
             self._sub_layers[str(i)] = self._sub_layers[str(i - 1)]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
如果建立一个空的 `fluid.dygraph.LayerList` 则无法直接 `insert`
`(0 <= index < len(self._sub_layers)` 会为`false`，所以应考虑 `fluid.dygraph.LayerList` 为空的情况
