### PR TITLE
support fp64 for assign_value op

### DIFF
--- a/paddle/fluid/operators/assign_value_op.cc
+++ b/paddle/fluid/operators/assign_value_op.cc
@@ -60,7 +60,7 @@ class AssignValueOpMaker : public framework::OpProtoAndCheckerMaker {
         .SetDefault({});
     AddAttr<std::vector<float>>("fp32_values", "store the float32 values")
         .SetDefault({});
-    AddAttr<std::vector<double>>("fp64_values", "store the float64 values")
+    AddAttr<std::vector<float>>("fp64_values", "store the float64 values")
         .SetDefault({});
     AddAttr<std::vector<int>>("int32_values", "store the int32 values")
         .SetDefault({});

--- a/paddle/fluid/operators/assign_value_op.cc
+++ b/paddle/fluid/operators/assign_value_op.cc
@@ -52,13 +52,15 @@ class AssignValueOpMaker : public framework::OpProtoAndCheckerMaker {
                               "(vector<int>) "
                               "Shape of values.");
     AddAttr<int>("dtype", "data type of values")
-        .InEnum({framework::proto::VarType::BOOL,
-                 framework::proto::VarType::INT32,
-                 framework::proto::VarType::FP32,
-                 framework::proto::VarType::INT64});
+        .InEnum(
+            {framework::proto::VarType::BOOL, framework::proto::VarType::INT32,
+             framework::proto::VarType::FP32, framework::proto::VarType::FP64,
+             framework::proto::VarType::INT64});
     AddAttr<std::vector<int>>("bool_values", "store the bool values")
         .SetDefault({});
     AddAttr<std::vector<float>>("fp32_values", "store the float32 values")
+        .SetDefault({});
+    AddAttr<std::vector<double>>("fp64_values", "store the float64 values")
         .SetDefault({});
     AddAttr<std::vector<int>>("int32_values", "store the int32 values")
         .SetDefault({});
@@ -84,4 +86,5 @@ REGISTER_OPERATOR(
 REGISTER_OP_CPU_KERNEL(assign_value, ops::AssignValueKernel<bool>,
                        ops::AssignValueKernel<int>,
                        ops::AssignValueKernel<float>,
+                       ops::AssignValueKernel<double>,
                        ops::AssignValueKernel<int64_t>);

--- a/paddle/fluid/operators/assign_value_op.cu.cc
+++ b/paddle/fluid/operators/assign_value_op.cu.cc
@@ -18,4 +18,5 @@ namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(assign_value, ops::AssignValueKernel<bool>,
                         ops::AssignValueKernel<int>,
                         ops::AssignValueKernel<float>,
+                        ops::AssignValueKernel<double>,
                         ops::AssignValueKernel<int64_t>);

--- a/paddle/fluid/operators/assign_value_op.h
+++ b/paddle/fluid/operators/assign_value_op.h
@@ -47,7 +47,25 @@ typename std::enable_if<std::is_same<T, bool>::value>::type CopyVecotorToTensor(
 }
 
 template <typename T>
-typename std::enable_if<!std::is_same<T, bool>::value>::type
+typename std::enable_if<std::is_same<T, double>::value>::type
+CopyVecotorToTensor(const char* value_name, framework::Tensor* out,
+                    const framework::ExecutionContext& ctx) {
+  // If attribute value dtype is vector<double>, it will be converted to
+  // vector<float>.
+  auto values = ctx.Attr<std::vector<float>>(value_name);
+
+  double* array_ptr = new T[values.size()];
+  for (unsigned int i = 0; i < values.size(); i++) {
+    array_ptr[i] = static_cast<T>(values[i]);
+  }
+  framework::TensorFromArray(array_ptr, values.size(), ctx.device_context(),
+                             out);
+  delete[] array_ptr;
+}
+
+template <typename T>
+typename std::enable_if<!std::is_same<T, bool>::value &&
+                        !std::is_same<T, double>::value>::type
 CopyVecotorToTensor(const char* value_name, framework::Tensor* out,
                     const framework::ExecutionContext& ctx) {
   auto values = ctx.Attr<std::vector<T>>(value_name);

--- a/paddle/fluid/operators/assign_value_op.h
+++ b/paddle/fluid/operators/assign_value_op.h
@@ -72,6 +72,9 @@ class AssignValueKernel : public framework::OpKernel<T> {
       case framework::proto::VarType::FP32:
         value_name = "fp32_values";
         break;
+      case framework::proto::VarType::FP64:
+        value_name = "fp64_values";
+        break;
       case framework::proto::VarType::INT64:
         value_name = "int64_values";
         break;

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -600,6 +600,9 @@ def assign(input, output=None):
         elif dtype == VarDesc.VarType.FP32:
             value_name = "fp32_values"
             values = [float(v) for v in input.flat]
+        elif dtype == VarDesc.VarType.FP64:
+            value_name = "fp64_values"
+            values = [float(v) for v in input.flat]
         elif dtype == VarDesc.VarType.INT32:
             value_name = "int32_values"
             values = [int(v) for v in input.flat]
@@ -609,7 +612,7 @@ def assign(input, output=None):
         else:
             raise TypeError(
                 "When the type of 'input' in assign is numpy.ndarray, "
-                "the data type of 'input' must be bool, float32, int32 or int64, but "
+                "the data type of 'input' must be bool, float32, float64, int32 or int64, but "
                 "received %s." % convert_dtype(dtype))
         if input.size > 1024 * 1024:
             raise ValueError("The size of input is too big. Please consider "

--- a/python/paddle/fluid/tests/unittests/test_assign_op.py
+++ b/python/paddle/fluid/tests/unittests/test_assign_op.py
@@ -92,11 +92,9 @@ class TestAssignOpError(unittest.TestCase):
             # When the type of input is Variable, the dtype of input must be float16, float32, float64, int32, int64, bool.
             x3 = fluid.layers.data(name='x3', shape=[4], dtype="uint8")
             self.assertRaises(TypeError, fluid.layers.assign, x3)
-            # When the type of input is numpy.ndarray, the dtype of input must be float32, int32.
-            x4 = np.array([[2.5, 2.5]], dtype='float64')
+            # When the type of input is numpy.ndarray, the dtype of input must be float32, float64, int32, int64, bool.
+            x4 = np.array([[2.5, 2.5]], dtype='uint8')
             self.assertRaises(TypeError, fluid.layers.assign, x4)
-            x5 = np.array([[2.5, 2.5]], dtype='uint8')
-            self.assertRaises(TypeError, fluid.layers.assign, x5)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_assign_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_assign_value_op.py
@@ -61,6 +61,12 @@ class TestAssignValueOp4(TestAssignValueOp):
         self.attrs["bool_values"] = [bool(v) for v in self.value.flat]
 
 
+class TestAssignValueOp5(TestAssignValueOp):
+    def init_data(self):
+        self.value = numpy.random.random(size=(2, 5)).astype(numpy.float64)
+        self.attrs["fp64_values"] = [float(v) for v in self.value.flat]
+
+
 class TestAssignApi(unittest.TestCase):
     def setUp(self):
         self.init_dtype()
@@ -106,6 +112,11 @@ class TestAssignApi4(TestAssignApi):
 
     def init_dtype(self):
         self.dtype = "bool"
+
+
+class TestAssignApi5(TestAssignApi):
+    def init_dtype(self):
+        self.dtype = "float64"
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_assign_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_assign_value_op.py
@@ -86,9 +86,12 @@ class TestAssignApi(unittest.TestCase):
 
         exe = fluid.Executor(self.place)
         [fetched_x] = exe.run(main_program, feed={}, fetch_list=[x])
-        self.assertTrue(
-            numpy.array_equal(fetched_x, self.value),
-            "fetch_x=%s val=%s" % (fetched_x, self.value))
+        if self.dtype == 'float64':
+            numpy.testing.assert_allclose(fetched_x, self.value)
+        else:
+            self.assertTrue(
+                numpy.array_equal(fetched_x, self.value),
+                "fetch_x=%s val=%s" % (fetched_x, self.value))
         self.assertEqual(fetched_x.dtype, self.value.dtype)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
Support that value type of op `assign_value` can be `float64`.
Because of `Attr`（defined in framework.proto） not supporting `double` , so we need to change `double` to `float` in `AddAttr`, and then cast `float` to `double` when doing the `assign` processing . This method will lead to float number precision loss.

```
// in framework.proto
message Attr {
    required string name = 1;
    required AttrType type = 2;
    optional int32 i = 3;
    optional float f = 4;
    optional string s = 5;
    repeated int32 ints = 6;
    repeated float floats = 7;
    repeated string strings = 8;
    optional bool b = 10;
    repeated bool bools = 11;
    optional int32 block_idx = 12;
    optional int64 l = 13;
    repeated int32 blocks_idx = 14;
    repeated int64 longs = 15;
  };
```