### PR TITLE
Show more possible problems with build_and_check in file paddle_build.sh

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1395,6 +1395,26 @@ function example() {
     fi
 }
 
+function summary_check_problems() {
+    set +x
+    local check_style_code=$1
+    local example_code=$2
+    if [ $check_style_code -ne 0 -o $example_code -ne 0 ];then
+      echo "========================================"
+      echo "summary problems:"
+      echo "========================================"
+      if [ $check_style_code -ne 0 ];then
+        echo "- Check code style failed! Please check the log and fix problems."
+      fi
+      if [ $example_code -ne 0 ];then
+        echo "- Check example code failed! Please check the log and fix problems."
+      fi
+      [ $check_style_code -ne 0 ] && exit $check_style_code
+      [ $example_code -ne 0 ] && exit $example_code
+    fi
+    set -x
+}
+
 function main() {
     local CMD=$1 
     local parallel_number=$2
@@ -1415,10 +1435,7 @@ function main() {
         generate_api_spec ${PYTHON_ABI:-""} "PR"
         $(example >&2)
         example_code=$?
-        [ $check_style_code -ne 0 ] && echo "Please check the log and fix code style problems."
-        [ $example_code -ne 0 ] && echo "Please check the log and fix example problems."
-        [ $check_style_code -ne 0 ] && exit $check_style_code
-        [ $example_code -ne 0 ] && exit $example_code
+        summary_check_problems $check_style_code $example_code
         assert_api_spec_approvals
         ;;
       build)

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1407,12 +1407,18 @@ function main() {
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         ;;
       build_and_check)
-        check_style
+        $(check_style >&2)
+        check_style_code=$?
         generate_upstream_develop_api_spec ${PYTHON_ABI:-""} ${parallel_number}
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
         check_sequence_op_unittest
         generate_api_spec ${PYTHON_ABI:-""} "PR"
-        example
+        $(example >&2)
+        example_code=$?
+        [ $check_style_code -ne 0 ] && echo "Please check the log and fix code style problems."
+        [ $example_code -ne 0 ] && echo "Please check the log and fix example problems."
+        [ $check_style_code -ne 0 ] && exit $check_style_code
+        [ $example_code -ne 0 ] && exit $example_code
         assert_api_spec_approvals
         ;;
       build)

--- a/python/paddle/device.py
+++ b/python/paddle/device.py
@@ -68,27 +68,6 @@ def get_cudnn_version():
 
 
 def set_device(device):
-    """
-    Paddle supports running calculations on various types of devices, including CPU and GPU.
-    They are represented by string identifiers. This function can specify the global device
-    which the OP will run.
-
-    Parameters:
-        device(str): This parameter determines the specific running device.
-            It can be ``cpu`` or ``gpu:0``. When ``device`` is ``cpu``, the
-            program is running on the cpu. When ``device`` is ``gpu``, the
-            program is running ont the gpu.
-    Examples:
-
-     .. code-block:: python
-            
-        import paddle
-        paddle.disable_static()
-        paddle.set_device("cpu")
-        x1 = paddle.ones(name='x1', shape=[1, 2], dtype='int32')
-        x2 = paddle.zeros(name='x2', shape=[1, 2], dtype='int32')
-        data = paddle.stack([x1,x2], axis=1)
-    """
     lower_device = device.lower()
     if lower_device == 'cpu':
         place = core.CPUPlace()
@@ -122,15 +101,6 @@ def get_device():
     It's a string which is like 'cpu' and 'gpu:0'. if the global device is not
     set, it will return a string which is 'gpu:0' when cuda is avaliable or it 
     will return a string which is 'cpu' when cuda is not avaliable.
-
-    Examples:
-
-     .. code-block:: python
-            
-        import paddle
-        paddle.disable_static()
-        device = paddle.get_device()
-
     """
     device = ''
     place = framework._current_expected_place()

--- a/python/paddle/device.py
+++ b/python/paddle/device.py
@@ -68,6 +68,27 @@ def get_cudnn_version():
 
 
 def set_device(device):
+    """
+    Paddle supports running calculations on various types of devices, including CPU and GPU.
+    They are represented by string identifiers. This function can specify the global device
+    which the OP will run.
+
+    Parameters:
+        device(str): This parameter determines the specific running device.
+            It can be ``cpu`` or ``gpu:0``. When ``device`` is ``cpu``, the
+            program is running on the cpu. When ``device`` is ``gpu``, the
+            program is running ont the gpu.
+    Examples:
+
+     .. code-block:: python
+
+        import paddle
+        paddle.disable_static()
+        paddle.set_device("cpu")
+        x1 = paddle.ones(name='x1', shape=[1, 2], dtype='int32')
+        x2 = paddle.zeros(name='x2', shape=[1, 2], dtype='int32')
+        data = paddle.stack([x1,x2], axis=1)
+    """
     lower_device = device.lower()
     if lower_device == 'cpu':
         place = core.CPUPlace()
@@ -101,6 +122,15 @@ def get_device():
     It's a string which is like 'cpu' and 'gpu:0'. if the global device is not
     set, it will return a string which is 'gpu:0' when cuda is avaliable or it 
     will return a string which is 'cpu' when cuda is not avaliable.
+
+    Examples:
+
+     .. code-block:: python
+
+        import paddle
+        paddle.disable_static()
+        device = paddle.get_device()
+
     """
     device = ''
     place = framework._current_expected_place()

--- a/python/paddle/device.py
+++ b/python/paddle/device.py
@@ -81,7 +81,7 @@ def set_device(device):
     Examples:
 
      .. code-block:: python
-
+            
         import paddle
         paddle.disable_static()
         paddle.set_device("cpu")
@@ -126,7 +126,7 @@ def get_device():
     Examples:
 
      .. code-block:: python
-
+            
         import paddle
         paddle.disable_static()
         device = paddle.get_device()


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
Since `check_style` and `example` are blocked, `example` would't to run when there are errors in `check_style`. Then whether there are errors in `example`, only display errors in `check_style`. Resulting in multiple commits to fix all problems.

The way is as follows:

1. Function `check_style` and `example` run via `$()`, then `exit` does not take effect in the CI. But `check_style_code` and `example_code` will catch exit status codes for final process.

![image](https://user-images.githubusercontent.com/23427135/91790763-1e63a700-ec44-11ea-890d-6292a4ddc2e5.png)
![image](https://user-images.githubusercontent.com/23427135/91790802-2facb380-ec44-11ea-989a-0ff2d0f4354f.png)
![image](https://user-images.githubusercontent.com/23427135/91790852-4bb05500-ec44-11ea-9a5f-b5489845a855.png)
![image](https://user-images.githubusercontent.com/23427135/91790837-42bf8380-ec44-11ea-98da-f6c3d72ced44.png)

2. Before `assert_api_spec_approvals`, print information and exit in `summary_check_problems` function accroding to `check_style_code` and `example_code`.

![image](https://user-images.githubusercontent.com/23427135/91827924-14589d00-ec72-11ea-83e5-a56788e2630f.png)

