### PR TITLE
refine paddle.stack

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10018,15 +10018,16 @@ def stack(x, axis=0, name=None):
 
 
     Args:
-        x (Variable|list(Variable)): Input :code:`x` can be a single Tensor, a :code:`list` of Tensors.
-                                     If :code:`x` is a :code:`list`, the shapes of all these Tensors
+        x (list(Variable)|tuple(Variable)): Input :code:`x` can be a :code:`list` or :code:`tuple` of Tensors, the shapes of all these Tensors
                                      must be the same. Supposing input is N dims
                                      Tensors :math:`[d_0, d_1, ..., d_{n-1}]`, the output is N+1 dims
                                      Tensor :math:`[d_0, d_1, d_{axis-1}, len(x), d_{axis}, ..., d_{n-1}]`.
                                      Supported data types: float32, float64, int32, int64.
-        axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is :math:`[-(R+1), R+1)`.
-                              R is the first tensor of inputs. If ``axis`` < 0, :math:`axis=axis+rank(x[0])+1`.
-                              The default value of axis is 0.
+        axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is ``[-(R+1), R+1)``,
+                              where ``R`` is the number of dimensions of the first input tensor ``x[0]``. 
+                              If ``axis < 0``, ``axis = axis+R+1``. The default value of axis is 0.
+        name (str, optional): Please refer to :ref:`api_guide_Name`, Default None.
+    
 
     Returns:
         Variable: The stacked Tensor, has same data type with input Tensors. Output dim is :math:`rank(x[0])+1`.
@@ -10048,12 +10049,15 @@ def stack(x, axis=0, name=None):
             data = layers.stack(x1)  # stack according to axis 0, data.shape=[1, None, 1, 2]
 
     """
-    axis = 0 if axis is None else axis
-    if not isinstance(x, list) and not isinstance(x, tuple):
-        x = [x]
+    if axis is None:
+        axis = 0
 
     if in_dygraph_mode():
         return core.ops.stack(x, 'axis', axis)
+
+    if not isinstance(x, list) and not isinstance(x, tuple):
+        raise TypeError("The type of '%s' in %s must be %s, but received %s" % (
+            'x', 'stack', 'list[Tensor] or tuple[Tensor]', type(x)))
 
     helper = LayerHelper('stack', **locals())
     out = helper.create_variable_for_type_inference(x[0].dtype)

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10045,8 +10045,6 @@ def stack(x, axis=0, name=None):
 
             data = layers.stack([x1,x2], axis=1) # stack according to axis 1, data.shape=[None, 2, 1, 2]
 
-            # stack single Tensor
-            data = layers.stack(x1)  # stack according to axis 0, data.shape=[1, None, 1, 2]
 
     """
     axis = 0 if axis is None else axis

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -10049,8 +10049,7 @@ def stack(x, axis=0, name=None):
             data = layers.stack(x1)  # stack according to axis 0, data.shape=[1, None, 1, 2]
 
     """
-    if axis is None:
-        axis = 0
+    axis = 0 if axis is None else axis
 
     if in_dygraph_mode():
         return core.ops.stack(x, 'axis', axis)

--- a/python/paddle/fluid/tests/unittests/test_stack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_stack_op.py
@@ -199,10 +199,15 @@ class API_DygraphTest(unittest.TestCase):
 
         with fluid.dygraph.guard():
             y1 = fluid.dygraph.to_variable(data1)
-            result = paddle.stack(y1, axis=0)
+            result = paddle.stack([y1], axis=0)
             result_np_2 = result.numpy()
-        expected_result_2 = np.stack(data1, axis=0)
+        expected_result_2 = np.stack([data1], axis=0)
         self.assertTrue(np.allclose(expected_result_2, result_np_2))
+
+    def test_single_tensor_error(self):
+        with fluid.dygraph.guard():
+            x = paddle.to_tensor([1, 2, 3])
+            self.assertRaises(Exception, paddle.stack, x)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_stack_op.py
+++ b/python/paddle/fluid/tests/unittests/test_stack_op.py
@@ -182,6 +182,11 @@ class API_test(unittest.TestCase):
             expected_result = np.stack([input1, input2, input3], axis=0)
             self.assertTrue(np.allclose(expected_result, result))
 
+    def test_single_tensor_error(self):
+        with fluid.program_guard(fluid.Program(), fluid.Program()):
+            x = paddle.rand([2, 3])
+            self.assertRaises(TypeError, paddle.stack, x)
+
 
 class API_DygraphTest(unittest.TestCase):
     def test_out(self):
@@ -192,9 +197,9 @@ class API_DygraphTest(unittest.TestCase):
             x1 = fluid.dygraph.to_variable(data1)
             x2 = fluid.dygraph.to_variable(data2)
             x3 = fluid.dygraph.to_variable(data3)
-            result = paddle.stack([x1, x2, x3], axis=0)
+            result = paddle.stack([x1, x2, x3])
             result_np = result.numpy()
-        expected_result = np.stack([data1, data2, data3], axis=0)
+        expected_result = np.stack([data1, data2, data3])
         self.assertTrue(np.allclose(expected_result, result_np))
 
         with fluid.dygraph.guard():

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -449,15 +449,10 @@ def stack(x, axis=0, name=None):
             import paddle
             import numpy as np
 
-            data1 = np.array([[1.0, 2.0]])
-            data2 = np.array([[3.0, 4.0]])
-            data3 = np.array([[5.0, 6.0]])
-
             paddle.disable_static()
-            x1 = paddle.to_variable(data1)
-            x2 = paddle.to_variable(data2)
-            x3 = paddle.to_variable(data3)
-
+            x1 = paddle.to_tensor([[1.0, 2.0]])
+            x2 = paddle.to_tensor([[3.0, 4.0]])
+            x3 = paddle.to_tensor([[5.0, 6.0]])
             out = paddle.stack([x1, x2, x3], axis=0)
             print(out.shape)  # [3, 1, 2]
             print(out.numpy())

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -433,8 +433,7 @@ def stack(x, axis=0, name=None):
                           [5.0, 6.0] ] ]
 
     Args:
-        x (Tensor|list[Tensor]|tuple[Tensor]): Input ``x`` can be a single tensor, or a ``list`` or ``tuple`` of tensors.
-                                     If ``x`` is a ``list`` or ``tuple`` , the Tensors in ``x``
+        x (list[Tensor]|tuple[Tensor]): Input ``x`` can be a ``list`` or ``tuple`` of tensors, the Tensors in ``x``
                                      must be of the same shape and dtype. Supported data types: float32, float64, int32, int64.
         axis (int, optional): The axis along which all inputs are stacked. ``axis`` range is ``[-(R+1), R+1)``,
                               where ``R`` is the number of dimensions of the first input tensor ``x[0]``. 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
paddle.stack does not support a single Tensor as input anymore.

Before this PR, `paddle.stack` accepts a single Tensor `x` as input, and implicitly convert it to a list of Tensor `[x]`.

This is not a good design since it violates the single responsibility. The responsibility of stack is to stack several Tensors, so this PR prohibits that usage.

**An Exception,** input as Variable of `LOD_Tensor_Array` type in static graph is still ok, since it means `array of tensors`.

For example, the following code will result in an error.
```
import paddle

paddle.disable_static()
x1 = paddle.rand([2,2])
result = paddle.stack(x1, axis=0)
```
- dygraph 
```
Traceback (most recent call last):
  File "test_stack.py", line 8, in <module>
    result = paddle.stack(x1, axis=0)
  File "/usr/local/lib/python3.5/dist-packages/paddle/tensor/manipulation.py", line 468, in stack
    return layers.stack(x, axis, name)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layers/nn.py", line 10055, in stack
    return core.ops.stack(x, 'axis', axis)
paddle.fluid.core_avx.EnforceNotMet: 

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::platform::EnforceNotMet::EnforceNotMet(paddle::platform::ErrorSummary const&, char const*, int)
1   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: stack(): argument 'X' (position 0) must be list of Tensors, but got Tensor (at /Paddle/Paddle/paddle/fluid/pybind/op_function.h:88)
```

- static graph
```
Traceback (most recent call last):
  File "test_stack.py", line 8, in <module>
    result = paddle.stack(x1, axis=0)
  File "/usr/local/lib/python3.5/dist-packages/paddle/tensor/manipulation.py", line 468, in stack
    return layers.stack(x, axis, name)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/layers/nn.py", line 10058, in stack
    raise TypeError("The type of '%s' in %s must be %s, but received %s" % ( 'x', 'stack', 'list[Tensor] or tuple[Tensor]', type(x)))
TypeError: The type of 'x' in stack must be list[Tensor] or tuple[Tensor], but received <class 'paddle.fluid.framework.Variable'>
```


