### PR TITLE
[API 2.0]Fix adaptive pooling bug

### DIFF
--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -1125,7 +1125,7 @@ def adaptive_max_pool1d(x, output_size, return_indices=False, name=None):
                               with shape [N, C, L].  The format of input tensor is NCL,
                               where N is batch size, C is the number of channels, L is the
                               length of the feature. The data type is float32 or float64.
-        output_size (int|list|tuple): The pool kernel size. The value should be an integer.
+        output_size (int): The pool kernel size. The value should be an integer.
         return_indices (bool): If true, the index of max pooling point will be returned along
                 with outputs. It cannot be set in average pooling type. Default False.
         name(str, optional): For detailed information, please refer
@@ -1138,6 +1138,7 @@ def adaptive_max_pool1d(x, output_size, return_indices=False, name=None):
             ValueError: 'output_size' should be an integer.
     Examples:
         .. code-block:: python
+
               # max adaptive pool1d
               # suppose input data in shape of [N, C, L], `output_size` is m or [m],
               # output shape is [N, C, m], adaptive pool divide L dimension
@@ -1202,15 +1203,19 @@ def adaptive_max_pool2d(x, output_size, return_indices=False, name=None):
     """
         This operation applies a 2D adaptive max pooling on input tensor.
         See more details in :ref:`api_nn_pooling_AdaptiveMaxPool2d` .
+
         Args:
             x (Tensor): The input tensor of adaptive max pool2d operator, which is a 4-D tensor. The data type can be float16, float32, float64, int32 or int64.
             output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list, it must contain two elements, (H, W). H and W can be either a int, or None which means the size will be the same as that of the input.
             return_indices (bool): If true, the index of max pooling point will be returned along with outputs. Default False.
             name(str, optional): For detailed information, please refer to :ref:`api_guide_Name`. Usually name is no need to set and None by default.
+
         Returns:
             Tensor: The output tensor of adaptive max pool2d result. The data type is same as input tensor.
+
         Examples:
             .. code-block:: python
+
               # max adaptive pool2d
               # suppose input data in the shape of [N, C, H, W], `output_size` is [m, n]
               # output shape is [N, C, m, n], adaptive pool divide H and W dimensions
@@ -1285,15 +1290,19 @@ def adaptive_max_pool3d(x, output_size, return_indices=False, name=None):
     """
         This operation applies a 3D adaptive max pooling on input tensor.
         See more details in :ref:`api_nn_pooling_AdaptiveMaxPool3d` .
+
         Args:
             x (Tensor): The input tensor of adaptive max pool3d operator, which is a 5-D tensor. The data type can be float32, float64.
             output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list, it must contain three elements, (D, H, W). D, H and W can be either a int, or None which means the size will be the same as that of the input.
             return_indices (bool): If true, the index of max pooling point will be returned along with outputs. Default False.
             name(str, optional): For detailed information, please refer to :ref:`api_guide_Name`. Usually name is no need to set and None by default.
+
         Returns:
             Tensor: The output tensor of adaptive max pool3d result. The data type is same as input tensor.
+
         Examples:
             .. code-block:: python
+
               # adaptive max pool3d
               # suppose input data in the shape of [N, C, D, H, W], `output_size` is [l, m, n]
               # output shape is [N, C, l, m, n], adaptive pool divide D, H and W dimensions

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -976,6 +976,7 @@ def adaptive_avg_pool2d(x, output_size, data_format='NCHW', name=None):
     if isinstance(output_size, int):
         output_size = utils.convert_to_list(output_size, 2, 'output_size')
     else:
+        output_size = list(output_size)
         if output_size[0] == None:
             output_size[0] = in_h
         if output_size[1] == None:
@@ -1079,6 +1080,7 @@ def adaptive_avg_pool3d(x, output_size, data_format='NCDHW', name=None):
     if isinstance(output_size, int):
         output_size = utils.convert_to_list(output_size, 3, 'output_size')
     else:
+        output_size = list(output_size)
         if output_size[0] == None:
             output_size[0] = in_l
         if output_size[1] == None:
@@ -1123,8 +1125,7 @@ def adaptive_max_pool1d(x, output_size, return_indices=False, name=None):
                               with shape [N, C, L].  The format of input tensor is NCL,
                               where N is batch size, C is the number of channels, L is the
                               length of the feature. The data type is float32 or float64.
-        output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
-                it must contain one int.
+        output_size (int|list|tuple): The pool kernel size. The value should be an integer.
         return_indices (bool): If true, the index of max pooling point will be returned along
                 with outputs. It cannot be set in average pooling type. Default False.
         name(str, optional): For detailed information, please refer
@@ -1134,7 +1135,7 @@ def adaptive_max_pool1d(x, output_size, return_indices=False, name=None):
             Tensor: The output tensor of adaptive pooling result. The data type is same
                       as input tensor.
     Raises:
-            ValueError: 'output_size' should be a integer or list or tuple with length as 1.
+            ValueError: 'output_size' should be an integer.
     Examples:
         .. code-block:: python
               # max adaptive pool1d
@@ -1162,7 +1163,7 @@ def adaptive_max_pool1d(x, output_size, return_indices=False, name=None):
     check_variable_and_dtype(x, 'x', ['float32', 'float64'],
                              'adaptive_max_pool1d')
     _check_input(x, 3)
-    check_type(output_size, 'pool_size', (int), 'adaptive_max_pool1d')
+    check_type(output_size, 'pool_size', int, 'adaptive_max_pool1d')
     check_type(return_indices, 'return_indices', bool, 'adaptive_max_pool1d')
 
     pool_size = [1] + utils.convert_to_list(output_size, 1, 'pool_size')
@@ -1247,6 +1248,7 @@ def adaptive_max_pool2d(x, output_size, return_indices=False, name=None):
     if isinstance(output_size, int):
         output_size = utils.convert_to_list(output_size, 2, 'output_size')
     else:
+        output_size = list(output_size)
         if output_size[0] == None:
             output_size[0] = in_h
         if output_size[1] == None:
@@ -1333,6 +1335,7 @@ def adaptive_max_pool3d(x, output_size, return_indices=False, name=None):
     if isinstance(output_size, int):
         output_size = utils.convert_to_list(output_size, 3, 'output_size')
     else:
+        output_size = list(output_size)
         if output_size[0] == None:
             output_size[0] = in_l
         if output_size[1] == None:

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -87,6 +87,7 @@ class AvgPool1d(layers.Layer):
     Examples:
 
         .. code-block:: python
+
           import paddle
           import paddle.nn as nn
           paddle.disable_static()
@@ -176,6 +177,7 @@ class AvgPool2d(layers.Layer):
         ShapeError: If the output's shape calculated is not greater than 0.
     Examples:
         .. code-block:: python
+
           import paddle
           import paddle.nn as nn
           import numpy as np
@@ -267,6 +269,7 @@ class AvgPool3d(layers.Layer):
 
     Examples:
         .. code-block:: python
+
           import paddle
           import paddle.nn as nn
           import numpy as np
@@ -457,6 +460,7 @@ class MaxPool2d(layers.Layer):
 
     Examples:
         .. code-block:: python
+
           import paddle
           import paddle.nn as nn
           import numpy as np
@@ -547,6 +551,7 @@ class MaxPool3d(layers.Layer):
 
     Examples:
         .. code-block:: python
+
           import paddle
           import paddle.nn as nn
           import numpy as np
@@ -915,8 +920,11 @@ class AdaptiveMaxPool2d(layers.Layer):
     """
     This operation applies 2D adaptive max pooling on input tensor. The h and w dimensions
     of the output tensor are determined by the parameter output_size. The difference between adaptive pooling and pooling is adaptive one focus on the output size.
+
     For adaptive max pool2d:
+
     ..  math::
+
        hstart &= floor(i * H_{in} / H_{out})
        hend &= ceil((i + 1) * H_{in} / H_{out})
        wstart &= floor(j * W_{in} / W_{out})
@@ -936,6 +944,7 @@ class AdaptiveMaxPool2d(layers.Layer):
         A callable object of AdaptiveMaxPool2d.
     Examples:
         .. code-block:: python
+
             # adaptive max pool2d
             # suppose input data in shape of [N, C, H, W], `output_size` is [m, n],
             # output shape is [N, C, m, n], adaptive pool divide H and W dimensions
@@ -976,10 +985,13 @@ class AdaptiveMaxPool2d(layers.Layer):
 
 class AdaptiveMaxPool3d(layers.Layer):
     """
-   This operation applies 3D adaptive max pooling on input tensor. The h and w dimensions
+    This operation applies 3D adaptive max pooling on input tensor. The h and w dimensions
     of the output tensor are determined by the parameter output_size. The difference between adaptive pooling and pooling is adaptive one focus on the output size.
+
     For adaptive max pool3d:
+
     ..  math::
+
       dstart &= floor(i * D_{in} / D_{out})
       dend &= ceil((i + 1) * D_{in} / D_{out})
       hstart &= floor(j * H_{in} / H_{out})
@@ -987,10 +999,9 @@ class AdaptiveMaxPool3d(layers.Layer):
       wstart &= floor(k * W_{in} / W_{out})
       wend &= ceil((k + 1) * W_{in} / W_{out})
       Output(i ,j, k) &= max(Input[dstart:dend, hstart:hend, wstart:wend])
+
     Parameters:
-        output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list,
-            it must contain three elements, (D, H, W). D, H and W can be either a int, or None which means
-            the size will be the same as that of the input.
+        output_size (int|list|tuple): The pool kernel size. If pool kernel size is a tuple or list, it must contain three elements, (D, H, W). D, H and W can be either a int, or None which means the size will be the same as that of the input.
         return_indices (bool): If true, the index of max pooling point will be returned along with outputs. Default False.
         name(str, optional): For detailed information, please refer
                              to :ref:`api_guide_Name`. Usually name is no need to set and
@@ -1002,6 +1013,7 @@ class AdaptiveMaxPool3d(layers.Layer):
         A callable object of AdaptiveMaxPool3d.
     Examples:
         .. code-block:: python
+
             # adaptive max pool3d
             # suppose input data in shape of [N, C, D, H, W], `output_size` is [l, m, n],
             # output shape is [N, C, l, m, n], adaptive pool divide D, H and W dimensions

--- a/python/paddle/nn/layer/pooling.py
+++ b/python/paddle/nn/layer/pooling.py
@@ -1028,8 +1028,8 @@ class AdaptiveMaxPool3d(layers.Layer):
             pool = paddle.nn.AdaptiveMaxPool3d(output_size=4)
             out = pool(x)
             # out shape: [2, 3, 4, 4, 4]
-            pool, indices = paddle.nn.AdaptiveMaxPool3d(output_size=3, return_indices=True)
-            out = pool(x)
+            pool = paddle.nn.AdaptiveMaxPool3d(output_size=3, return_indices=True)
+            out, indices = pool(x)
             # out shape: [2, 3, 4, 4, 4], indices shape: [2, 3, 4, 4, 4]
             
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix bug when passing tuple, like:
```python
adaptive_max_pool2d = paddle.nn.AdaptiveMaxPool2d(output_size=(None,5), return_indices=True)
```