### PR TITLE
Test for passing global env FLAGS_use_mkldnn

### DIFF
--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -49,9 +49,11 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
                      const NameVarBaseMap& outs, framework::AttributeMap attrs,
                      const platform::Place& place, bool trace_backward) {
   VLOG(1) << "Trace Op: " << type;
+  //  if (FLAGS_use_mkldnn && type != "sum") {
   if (FLAGS_use_mkldnn) {
     attrs["use_mkldnn"] = true;
   }
+  VLOG(1) << "FLAGS_use_mkldnn=" << FLAGS_use_mkldnn;
   auto op = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
   const auto& op_info = op->Info();
   auto* attr_checker = op_info.Checker();

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -49,11 +49,9 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
                      const NameVarBaseMap& outs, framework::AttributeMap attrs,
                      const platform::Place& place, bool trace_backward) {
   VLOG(1) << "Trace Op: " << type;
-  //  if (FLAGS_use_mkldnn && type != "sum") {
   if (FLAGS_use_mkldnn) {
     attrs["use_mkldnn"] = true;
   }
-  VLOG(1) << "FLAGS_use_mkldnn=" << FLAGS_use_mkldnn;
   auto op = framework::OpRegistry::CreateOp(type, {}, {}, {}, false);
   const auto& op_info = op->Info();
   auto* attr_checker = op_info.Checker();

--- a/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
@@ -22,6 +22,10 @@ from paddle.fluid.layer_helper import LayerHelper
 
 
 def check():
+    print("check: fluid.core.globals()['FLAGS_use_mkldnn']=",
+          fluid.core.globals()["FLAGS_use_mkldnn"])
+    print("check: fluid.get_flags('FLAGS_use_mkldnn')=",
+          fluid.get_flags(['FLAGS_use_mkldnn']))
     a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
     helper = LayerHelper(fluid.unique_name.generate(str("test")), act="relu")
     func = helper.append_activation

--- a/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import os
+import numpy as np
+import paddle.fluid as fluid
+from paddle.fluid.layer_helper import LayerHelper
+
+np.random.seed(0)
+
+
+def check():
+    a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
+    helper = LayerHelper(fluid.unique_name.generate(str("test")), act="relu")
+    func = helper.append_activation
+    with fluid.dygraph.guard():
+        a = fluid.dygraph.to_variable(a_np)
+        res1 = func(a)
+        res2 = fluid.layers.relu(a)
+    assert (np.array_equal(res1.numpy(), res2.numpy()))
+
+
+if __name__ == '__main__':
+    try:
+        check()
+    except Exception as e:
+        print(e)
+        print(type(e))

--- a/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
@@ -15,12 +15,9 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
-import os
 import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid.layer_helper import LayerHelper
-
-np.random.seed(0)
 
 
 def check():
@@ -30,8 +27,8 @@ def check():
     with fluid.dygraph.guard():
         a = fluid.dygraph.to_variable(a_np)
         res1 = func(a)
-        res2 = fluid.layers.relu(a)
-    assert (np.array_equal(res1.numpy(), res2.numpy()))
+        res2 = np.maximum(a_np, 0)
+    assert (np.array_equal(res1.numpy(), res2))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 
 import numpy as np
 import paddle.fluid as fluid
+import os
 from paddle.fluid.layer_helper import LayerHelper
 
 
@@ -34,6 +35,9 @@ def check():
 if __name__ == '__main__':
     try:
         check()
+        for k, v in sorted(os.environ.items()):
+            print(k + ':', v)
+        print('\n')
     except Exception as e:
         print(e)
         print(type(e))

--- a/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/check_flags_use_mkldnn.py
@@ -26,10 +26,11 @@ def check():
           fluid.core.globals()["FLAGS_use_mkldnn"])
     print("check: fluid.get_flags('FLAGS_use_mkldnn')=",
           fluid.get_flags(['FLAGS_use_mkldnn']))
+    print("check: DNNL_VERBOSE=", os.environ['DNNL_VERBOSE'])
     a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
     helper = LayerHelper(fluid.unique_name.generate(str("test")), act="relu")
     func = helper.append_activation
-    with fluid.dygraph.guard():
+    with fluid.dygraph.guard(fluid.core.CPUPlace()):
         a = fluid.dygraph.to_variable(a_np)
         res1 = func(a)
         res2 = np.maximum(a_np, 0)

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
@@ -43,12 +43,12 @@ class TestFlagsUseMkldnn(unittest.TestCase):
         out, err = proc.communicate()
         returncode = proc.returncode
 
-        print(out)
-        print(err)
+        print('out', out)
+        print('err', err)
 
         assert returncode == 0
         # in python3, type(out) is 'bytes', need use encode
-        assert (out + err).find(
+        assert out.find(
             "dnnl_verbose,exec,cpu,eltwise,jit:avx512_common,forward_training,"
             "data_f32::blocked:abc:f0 diff_undef::undef::f0,,alg:eltwise_relu".
             encode()) != -1

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import unittest
+import os
+import sys
+import subprocess
+
+
+class TestFlagsUseMkldnn(unittest.TestCase):
+    def setUp(self):
+        self._python_interp = sys.executable
+        self._python_interp += " check_flags_use_mkldnn.py"
+
+        self.env = os.environ.copy()
+        self.env[str("DNNL_VERBOSE")] = str("1")
+        self.env[str("FLAGS_use_mkldnn")] = str("True")
+
+    def test_flags_use_mkl_dnn(self):
+        cmd = self._python_interp
+
+        proc = subprocess.Popen(
+            cmd.split(" "),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=self.env)
+
+        out, err = proc.communicate()
+        returncode = proc.returncode
+
+        # print(out)
+
+        assert returncode == 0
+        # in python3, type(out) is 'bytes', need use encode
+        assert out.find(
+            "dnnl_verbose,exec,cpu,eltwise,jit:avx512_common,forward_training,"
+            "data_f32::blocked:abc:f0 diff_undef::undef::f0,,alg:eltwise_relu".
+            encode()) != -1
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
@@ -28,7 +28,7 @@ class TestFlagsUseMkldnn(unittest.TestCase):
 
         self.env = os.environ.copy()
         self.env[str("DNNL_VERBOSE")] = str("1")
-        self.env[str("FLAGS_use_mkldnn")] = str("True")
+        self.env[str("FLAGS_use_mkldnn")] = str("1")
 
     def test_flags_use_mkl_dnn(self):
         cmd = self._python_interp

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
@@ -27,6 +27,7 @@ class TestFlagsUseMkldnn(unittest.TestCase):
         self._python_interp += " check_flags_use_mkldnn.py"
 
         self.env = os.environ.copy()
+        self.env[str("GLOG_v")] = str("3")
         self.env[str("DNNL_VERBOSE")] = str("1")
         self.env[str("FLAGS_use_mkldnn")] = str("1")
 
@@ -47,7 +48,7 @@ class TestFlagsUseMkldnn(unittest.TestCase):
 
         assert returncode == 0
         # in python3, type(out) is 'bytes', need use encode
-        assert out.find(
+        assert (out + err).find(
             "dnnl_verbose,exec,cpu,eltwise,jit:avx512_common,forward_training,"
             "data_f32::blocked:abc:f0 diff_undef::undef::f0,,alg:eltwise_relu".
             encode()) != -1

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_use_mkldnn.py
@@ -42,7 +42,8 @@ class TestFlagsUseMkldnn(unittest.TestCase):
         out, err = proc.communicate()
         returncode = proc.returncode
 
-        # print(out)
+        print(out)
+        print(err)
 
         assert returncode == 0
         # in python3, type(out) is 'bytes', need use encode

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -663,7 +663,7 @@ class TestDygraphUtils(unittest.TestCase):
         self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
     def test_append_activation_in_dygraph_global_use_mkldnn_throw(self):
-        a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.double)
+        a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.bool)
         helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
         func = helper.append_activation
         msg = "NotFoundError: Operator relu does not have kernel for " \

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -662,7 +662,7 @@ class TestDygraphUtils(unittest.TestCase):
             res2 = fluid.layers.relu(a)
         self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
 
-    def test_append_activation_in_dygraph_global_use_mkldnn(self):
+    def test_append_activation_in_dygraph_global_use_mkldnn_throw(self):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.double)
         helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
         func = helper.append_activation
@@ -673,6 +673,7 @@ class TestDygraphUtils(unittest.TestCase):
                 res1 = func(a)
             except Exception as e:
                 exc_out = e.message
+                print(exc_out)
             finally:
                 fluid.set_flags({'FLAGS_use_mkldnn': False})
         self.assertNotEqual(

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -652,7 +652,7 @@ class TestDygraphUtils(unittest.TestCase):
         a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.float32)
         helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
         func = helper.append_activation
-        with fluid.dygraph.guard():
+        with fluid.dygraph.guard(fluid.core.CPUPlace()):
             a = fluid.dygraph.to_variable(a_np)
             fluid.set_flags({'FLAGS_use_mkldnn': True})
             try:
@@ -661,30 +661,6 @@ class TestDygraphUtils(unittest.TestCase):
                 fluid.set_flags({'FLAGS_use_mkldnn': False})
             res2 = fluid.layers.relu(a)
         self.assertTrue(np.array_equal(res1.numpy(), res2.numpy()))
-
-    def test_append_activation_in_dygraph_global_use_mkldnn_throw(self):
-        a_np = np.random.uniform(-2, 2, (10, 20, 30)).astype(np.bool)
-        helper = LayerHelper(fluid.unique_name.generate("test"), act="relu")
-        func = helper.append_activation
-        msg = "NotFoundError: Operator relu does not have kernel for " \
-              "data_type[double]:data_layout[MKLDNNLAYOUT]:place[CPUPlace]:library_type[MKLDNN]"
-
-        def check(msg_):
-
-            with fluid.dygraph.guard(fluid.core.CPUPlace()):
-                a = fluid.dygraph.to_variable(a_np)
-                fluid.set_flags({'FLAGS_use_mkldnn': True})
-                try:
-                    func(a)
-                except Exception as e:
-                    if msg_ in str(e):
-                        raise AttributeError
-                    else:
-                        print(e)
-                finally:
-                    fluid.set_flags({'FLAGS_use_mkldnn': False})
-
-        self.assertRaises(AttributeError, check, msg)
 
     def test_append_bias_in_dygraph_exception(self):
         with new_program_scope():

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -670,6 +670,7 @@ class TestDygraphUtils(unittest.TestCase):
               "data_type[double]:data_layout[MKLDNNLAYOUT]:place[CPUPlace]:library_type[MKLDNN]"
 
         def check(msg_):
+
             with fluid.dygraph.guard(fluid.core.CPUPlace()):
                 a = fluid.dygraph.to_variable(a_np)
                 fluid.set_flags({'FLAGS_use_mkldnn': True})


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Test for passing env FLAGS_use_mkldnn and parsing result of DNNL_VERBOSE