### PR TITLE
set_default_type only take effect on python floats or complex

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -33,16 +33,28 @@ class TestVarBase(unittest.TestCase):
         def _test_place(place):
             with fluid.dygraph.guard():
                 paddle.set_default_dtype('float32')
+                # set_default_dtype should not take effect on int
                 x = paddle.to_tensor(1, place=place, stop_gradient=False)
                 self.assertTrue(np.array_equal(x.numpy(), [1]))
                 self.assertNotEqual(x.dtype, core.VarDesc.VarType.FP32)
 
+                # set_default_dtype should not take effect on numpy
+                x = paddle.to_tensor(
+                    np.array([1.2]).astype('float16'),
+                    place=place,
+                    stop_gradient=False)
+                self.assertTrue(
+                    np.array_equal(x.numpy(), np.array([1.2], 'float16')))
+                self.assertEqual(x.dtype, core.VarDesc.VarType.FP16)
+
+                # set_default_dtype take effect on float
                 x = paddle.to_tensor(1.2, place=place, stop_gradient=False)
                 self.assertTrue(
                     np.array_equal(x.numpy(), np.array([1.2]).astype(
                         'float32')))
                 self.assertEqual(x.dtype, core.VarDesc.VarType.FP32)
 
+                # set_default_dtype take effect on complex
                 x = paddle.to_tensor(1 + 2j, place=place, stop_gradient=False)
                 self.assertTrue(np.array_equal(x.numpy(), [1 + 2j]))
                 self.assertEqual(x.dtype, 'complex64')

--- a/python/paddle/framework/framework.py
+++ b/python/paddle/framework/framework.py
@@ -22,7 +22,13 @@ __all__ = ['set_default_dtype', 'get_default_dtype']
 
 def set_default_dtype(d):
     """
-    Set default dtype. The default dtype is initially float32
+    Set the default floating point dtype. This dtype is used for python floats or complex 
+    number in ``paddle.to_tensor`` . 
+
+    For python complex number, dtype is ``complex128`` if default floating point dtype
+    is ``float64`` , otherwise it's ``complex64`` .
+    
+    The initial value of default floating point dtype is set to ``float32`` .
 
     Args:
         d(string|np.dtype): the dtype to make the default. It only

--- a/python/paddle/framework/framework.py
+++ b/python/paddle/framework/framework.py
@@ -22,13 +22,7 @@ __all__ = ['set_default_dtype', 'get_default_dtype']
 
 def set_default_dtype(d):
     """
-    Set the default floating point dtype. This dtype is used for python floats or complex 
-    number in ``paddle.to_tensor`` . 
-
-    For python complex number, dtype is ``complex128`` if default floating point dtype
-    is ``float64`` , otherwise it's ``complex64`` .
-    
-    The initial value of default floating point dtype is set to ``float32`` .
+    Set default dtype. The default dtype is initially float32
 
     Args:
         d(string|np.dtype): the dtype to make the default. It only


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
set_default_type only take effect on python floats or complex.