### PR TITLE
[Dy2stat] Add descriptor cache for StaticLayer

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -31,6 +31,7 @@ from paddle.fluid.dygraph.dygraph_to_static.convert_operators import convert_len
 from paddle.fluid.dygraph.dygraph_to_static.logging_utils import TranslatorLogger
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import StaticLayer
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import convert_to_static
+from paddle.fluid.dygraph.dygraph_to_static.program_translator import unwrap_decorators
 from paddle.fluid.dygraph.layers import Layer
 
 # TODO(liym27): A better way to do this.
@@ -118,14 +119,9 @@ def convert_call(func):
     func_self = None
     converted_call = None
 
-    # Function in convert_call may be decorated by another `@declarative`,
+    # Function in convert_call may be decorated by another `@to_static`,
     # in this case, unwraps it into a raw method or function.
-    if isinstance(func, StaticLayer):
-        instance = func._class_instance
-        if instance is not None:
-            func = func.dygraph_function.__get__(instance)
-        else:
-            func = func.dygraph_function
+    _, func = unwrap_decorators(func)
 
     if is_builtin_len(func):
         return convert_len
@@ -155,7 +151,8 @@ def convert_call(func):
                 if inspect.isfunction(fn):
                     global_functions.add(fn)
                 elif isinstance(fn, StaticLayer):
-                    global_functions.add(fn.dygraph_function)
+                    _, fn = unwrap_decorators(fn)
+                    global_functions.add(fn)
 
             if func in global_functions:
                 converted_call = convert_to_static(func)
@@ -189,7 +186,8 @@ def convert_call(func):
     elif hasattr(func, '__class__') and hasattr(func.__class__, '__call__'):
         if hasattr(func, 'forward') and isinstance(func, Layer):
             try:
-                forward_func = convert_to_static(func.forward)
+                _, forward_func = unwrap_decorators(func.forward)
+                forward_func = convert_to_static(forward_func)
                 setattr(func, 'forward', forward_func)
                 func_self = func
             except Exception:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -21,6 +21,7 @@ import six
 import textwrap
 import threading
 import warnings
+import weakref
 
 import gast
 from paddle.fluid import framework
@@ -245,6 +246,7 @@ class StaticLayer(object):
         self._input_spec = input_spec
         self._function_spec = FunctionSpec(function, input_spec)
         self._program_cache = ProgramCache()
+        self._descriptor_cache = weakref.WeakKeyDictionary()
         # Note: Hold a reference to ProgramTranslator for switching `enable_declarative`.
         self._program_trans = ProgramTranslator()
 
@@ -271,8 +273,17 @@ class StaticLayer(object):
         of `Net` instance. After decorated by `@paddle.jit.to_static`, it will firstly to call `__get__`
         to parse the class instance correctly instead of the `StaticLayer` instance.
         """
-        self._class_instance = instance
-        return self
+        if instance not in self._descriptor_cache:
+            # Note(Aurelius84): To construct new instance of StaticLayer when we
+            # first encouter the bound function of layer and cache it.
+            new_static_layer = self._clone()
+            new_static_layer._class_instance = instance
+            self._descriptor_cache[instance] = new_static_layer
+
+        return self._descriptor_cache[instance]
+
+    def _clone():
+        return self.__class__(self._dygraph_function, self._input_spec)
 
     def __call__(self, *args, **kwargs):
         """

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -274,6 +274,8 @@ class StaticLayer(object):
         to parse the class instance correctly instead of the `StaticLayer` instance.
         """
         if instance not in self._descriptor_cache:
+            if instance is None:
+                return self
             # Note(Aurelius84): To construct new instance of StaticLayer when we
             # first encouter the bound function of layer and cache it.
             new_static_layer = self._clone()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -282,7 +282,7 @@ class StaticLayer(object):
 
         return self._descriptor_cache[instance]
 
-    def _clone():
+    def _clone(self):
         return self.__class__(self._dygraph_function, self._input_spec)
 
     def __call__(self, *args, **kwargs):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_inference_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_save_inference_model.py
@@ -133,7 +133,7 @@ class TestPartialProgramRaiseError(unittest.TestCase):
             x = fluid.dygraph.to_variable(x_data)
             out = net(x)
 
-            program_cache = SimpleFcLayer.forward.program_cache
+            program_cache = net.forward.program_cache
             _, (concrete_program, _) = program_cache.last()
 
             params = concrete_program.parameters


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Add descriptor cache for StaticLayer.

### Why need this
In StaticLayer, we implement `__get__` method to make it into `descriptor`(see [this](https://docs.python.org/3/howto/descriptor.html)).

This allows us to easily parse the instance from decorated bound method, such as `self.forward`.
```python
class A:
    @decorator
    def foo(self, x):
        return x

a = A()
a.foo(10)
```

if `decorated` is a decorator,  `a.foo` will firstly call `__get__` in `decorator`. The common implementation is:
```python
def __get__(self, instance, owner):
   # instance is `a` as above
   # owner is `A` as above
    do_somethind_useful()
```

**However why we need `self._descriptor_cache` here?**

Before this PR, consider the following example code:
```python
class Net(Layer):
    ....
    @to_static
    def forward(self, x):
         return x*2

net_1 = Net()
net_2 = Net()

isinstance(net_1.forward, StaticLayer)  # True
isinstance(net_2.forward, StaticLayer)  # True

id(net_1.forward) == id(net_2.forward)  # True !!
id(net_1.forward) == id(Net.forward)  # True !!
```
That's the problem. For different instance from same Class, they share the same StaticLayer instance, which has risk in some  operations.

### Solution
We introduce a `wreakref.WeakKeyDictionary()` as descriptor_cache to hold different StaticLayer instance.

```python
def __get__(self, instance, owner):
    if instance is not in self._descriptor_cache:
        self._descriptor_cache[instance] = self._clone()  # create a new staticLayer

    return self._descriptor_cache[instance]
```

The benefits to choose `wreakref.WeakKeyDictionary()` instead of `Dict` is if `net` is garbage collected, it will be removed from `self._descriptor_cache` to save memory.

After this PR: 
```python
id(net_1.forward) == id(net_2.forward)  # False
id(net_1.forward) == id(Net.forward)  # False
```
