### PR TITLE
[Dy2stat]Add naming rule if not specific InputSpec.name

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -136,7 +136,7 @@ class FunctionSpec(object):
             input_with_spec = pack_sequence_as(args, input_with_spec)
 
         # If without specificing name in input_spec, add default name
-        # according by argument name from decorated function.
+        # according to argument name from decorated function.
         input_with_spec = replace_spec_empty_name(self._arg_names,
                                                   input_with_spec)
 
@@ -319,7 +319,7 @@ def convert_to_input_spec(inputs, input_spec):
 def replace_spec_empty_name(args_name, input_with_spec):
     """
     Adds default name according to argument name from decorated function
-    if without specificing inputSpec.name
+    if without specificing InputSpec.name
 
     The naming rule are as followed:
         1. If InputSpec.name is not None, do nothing.

--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -363,12 +363,12 @@ def _replace_spec_name(name, input_spec):
         processed_specs = []
         for i, spec in enumerate(input_spec):
             new_name = "{}_{}".format(name, i)
-            processed_specs.append(fill_name(new_name, spec))
+            processed_specs.append(_replace_spec_name(new_name, spec))
         return processed_specs
     elif isinstance(input_spec, dict):
         processed_specs = {}
         for key, spec in six.iteritems(input_spec):
-            processed_specs[key] = fill_name(key, spec)
+            processed_specs[key] = _replace_spec_name(key, spec)
         return processed_specs
     else:
         return input_spec

--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -135,6 +135,11 @@ class FunctionSpec(object):
 
             input_with_spec = pack_sequence_as(args, input_with_spec)
 
+        # If without specificing name in input_spec, add default name
+        # according by argument name from decorated function.
+        input_with_spec = replace_spec_empty_name(self._arg_names,
+                                                  input_with_spec)
+
         return input_with_spec
 
     @switch_to_static_graph
@@ -309,3 +314,61 @@ def convert_to_input_spec(inputs, input_spec):
         raise TypeError(
             "The type(input_spec) should be a `InputSpec` or dict/list/tuple of it, but received {}.".
             type_name(input_spec))
+
+
+def replace_spec_empty_name(args_name, input_with_spec):
+    """
+    Adds default name according to argument name from decorated function
+    if without specificing inputSpec.name
+
+    The naming rule are as followed:
+        1. If InputSpec.name is not None, do nothing.
+        2. If each argument `x` corresponds to an InputSpec, using the argument name like `x`
+        3. If the arguments `inputs` corresponds to a list(InputSpec), using name like `inputs_0`, `inputs_1`
+        4. If the arguments `input_dic` corresponds to a dict(InputSpec), using key as name.
+
+    For example:
+        
+        # case 1: foo(x, y)
+        foo = to_static(foo, input_spec=[InputSpec([None, 10]), InputSpec([None])])
+        print([in_var.name for in_var in foo.inputs])  # [x, y]
+
+        # case 2: foo(inputs) where inputs is a list
+        foo = to_static(foo, input_spec=[[InputSpec([None, 10]), InputSpec([None])]])
+        print([in_var.name for in_var in foo.inputs])  # [inputs_0, inputs_1]
+
+        # case 3: foo(inputs) where inputs is a dict
+        foo = to_static(foo, input_spec=[{'x': InputSpec([None, 10]), 'y': InputSpec([None])}])
+        print([in_var.name for in_var in foo.inputs])  # [x, y]
+    """
+    input_with_spec = list(input_with_spec)
+    candidate_arg_names = args_name[:len(input_with_spec)]
+
+    for i, arg_name in enumerate(candidate_arg_names):
+        input_spec = input_with_spec[i]
+        input_with_spec[i] = _replace_spec_name(arg_name, input_spec)
+
+    return input_with_spec
+
+
+def _replace_spec_name(name, input_spec):
+    """
+    Replaces InputSpec.name with given `name` while not specificing it.
+    """
+    if isinstance(input_spec, paddle.static.InputSpec):
+        if input_spec.name is None:
+            input_spec.name = name
+        return input_spec
+    elif isinstance(input_spec, (list, tuple)):
+        processed_specs = []
+        for i, spec in enumerate(input_spec):
+            new_name = "{}_{}".format(name, i)
+            processed_specs.append(fill_name(new_name, spec))
+        return processed_specs
+    elif isinstance(input_spec, dict):
+        processed_specs = {}
+        for key, spec in six.iteritems(input_spec):
+            processed_specs[key] = fill_name(key, spec)
+        return processed_specs
+    else:
+        return input_spec

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_declarative.py
@@ -283,7 +283,6 @@ class TestInputDefaultName(unittest.TestCase):
         decorated_func = getattr(self.net, func_name)
 
         spec_names = [x.name for x in decorated_func.inputs]
-        print(spec_names)
         self.assertListEqual(spec_names, input_names)
 
     def test_common_input(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add naming rule if not specific InputSpec.name.

### Naming rule

#### 1. Already specific name
If InputSpec.name is not `None`, do nothing.

#### 2. Single argument single InputSpec
If each argument `x` corresponds to an InputSpec, using the argument name like `x`
```python
def foo(x, y):
    return x + y

foo = to_static(foo, input_spec=[InputSpec([None, 10]), InputSpec([None])])
print([in_var.name for in_var in foo.inputs])  # [x, y]
```

#### 3. Argument with list
 If the arguments `inputs` corresponds to a list(InputSpec), using name like `inputs_0`, `inputs_1`
```python
def foo(inputs):
    return inputs[0] + inputs[1]

foo = to_static(foo, input_spec=[[InputSpec([None, 10]), InputSpec([None])]])
print([in_var.name for in_var in foo.inputs])  # [inputs_0, inputs_1]
```
#### 4. Argument with dict
If the arguments `input_dic` corresponds to a dict(InputSpec), using key as name.
```python
def foo(inputs):
    return inputs['x'] + inputs['y']

 foo = to_static(foo, input_spec=[{'x': InputSpec([None, 10]), 'y': InputSpec([None])}])
print([in_var.name for in_var in foo.inputs])  # [x, y]
```