### PR TITLE
remove the dependence of matplotlib  in dataset of uci_housing

### DIFF
--- a/python/paddle/dataset/uci_housing.py
+++ b/python/paddle/dataset/uci_housing.py
@@ -74,7 +74,8 @@ def load_data(filename, feature_num=14, ratio=0.8):
     data = data.reshape(data.shape[0] // feature_num, feature_num)
     maximums, minimums, avgs = data.max(axis=0), data.min(axis=0), data.sum(
         axis=0) / data.shape[0]
-    feature_range(maximums[:-1], minimums[:-1])
+    # if you want to print the distribution of input data, you could use function of feature_range
+    #feature_range(maximums[:-1], minimums[:-1])
     for i in six.moves.range(feature_num - 1):
         data[:, i] = (data[:, i] - avgs[i]) / (maximums[i] - minimums[i])
     offset = int(data.shape[0] * ratio)


### PR DESCRIPTION
### PR types
 Others

### PR changes
Others

### Describe
matplotlib这个依赖包比较大，8.5M左右，且对python版本限制较多，会让部分不符合python版本范围的用户安装paddle时因为这个库遇到一些问题～所以希望将matplotlib这个库删除掉。

uci_housing中打印input的数据分布需要依赖matplotlib，因此注释掉该函数，如果用户打印数据分布的需求，可以打开注释函数，安装matplotlib，即可完成相应的需求。