### PR TITLE
Fix clip output var dtype

### DIFF
--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1656,7 +1656,7 @@ def clip(x, min=None, max=None, name=None):
 
     helper = LayerHelper('clip', **locals())
     output = helper.create_variable_for_type_inference(
-        dtype=helper.input_dtype())
+        dtype=helper.input_dtype('x'))
     helper.append_op(
         type='clip', inputs=inputs, outputs={'Out': [output]}, attrs=attrs)
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs
 
### Describe
`input_dtype()` defaults to `input`