### PR TITLE
fix _check_values_dtype_in_probs method in Distribution class

### DIFF
--- a/python/paddle/distribution.py
+++ b/python/paddle/distribution.py
@@ -138,7 +138,7 @@ class Distribution(object):
         convert value's dtype to be consistent with param's dtype.
 
         Args:
-            param (int|float|list|numpy.ndarray|Tensor): low and high in Uniform class, loc and scale in Normal class.
+            param (Tensor): low and high in Uniform class, loc and scale in Normal class.
             value (Tensor): The input tensor.
 
         Returns:
@@ -152,6 +152,7 @@ class Distribution(object):
                 )
                 return core.ops.cast(value, 'in_dtype', value.dtype,
                                      'out_dtype', param.dtype)
+            return value
 
         check_variable_and_dtype(value, 'value', ['float32', 'float64'],
                                  'log_prob')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
`_check_values_dtypes_in_probs(param, value)` method in `Distribution` class is used to ensure dtype of `param` and `value` are consistent. (refer to PR #26767)
If in_dygraph_mode and value.dtype == param.dtype, it doesn't have return value in dygraph mode. And it has to run static mode again. This PR adds return value in dygraph mode.