### PR TITLE
fix the dtype check for the argmin, argmax

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_arg_min_max_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_arg_min_max_v2_op.py
@@ -322,20 +322,6 @@ class TestArgMinMaxOpError(unittest.TestCase):
 
             self.assertRaises(TypeError, test_argmin_axis_type)
 
-            def test_argmax_dtype_type():
-                data = paddle.static.data(
-                    name="test_argmax", shape=[10], dtype="float32")
-                output = paddle.argmax(x=data, dtype=1)
-
-            self.assertRaises(TypeError, test_argmax_dtype_type)
-
-            def test_argmin_dtype_type():
-                data = paddle.static.data(
-                    name="test_argmin", shape=[10], dtype="float32")
-                output = paddle.argmin(x=data, dtype=1)
-
-            self.assertRaises(TypeError, test_argmin_dtype_type)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -167,11 +167,6 @@ def argmax(x, axis=None, keepdim=False, dtype="int64", name=None):
             "The type of 'axis'  must be int or None in argmax, but received %s."
             % (type(axis)))
 
-    if not (isinstance(dtype, str) or isinstance(dtype, np.dtype)):
-        raise TypeError(
-            "the type of 'dtype' in argmax must be str or np.dtype, but received {}".
-            format(type(dtype)))
-
     var_dtype = convert_np_dtype_to_dtype_(dtype)
     check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmin')
     flatten = False
@@ -244,11 +239,6 @@ def argmin(x, axis=None, keepdim=False, dtype="int64", name=None):
         raise TypeError(
             "The type of 'axis'  must be int or None in argmin, but received %s."
             % (type(axis)))
-
-    if not (isinstance(dtype, str) or isinstance(dtype, np.dtype)):
-        raise TypeError(
-            "the type of 'dtype' in argmin must be str or np.dtype, but received {}".
-            format(dtype(dtype)))
 
     var_dtype = convert_np_dtype_to_dtype_(dtype)
     check_dtype(var_dtype, 'dtype', ['int32', 'int64'], 'argmin')


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
 APIs

### Describe
修复对argmax,argmin中的dtype check
