### PR TITLE
Restore file changes caused by pre-commit

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -562,7 +562,7 @@ function fetch_upstream_develop_if_not_exist() {
 function generate_upstream_develop_api_spec() {
     fetch_upstream_develop_if_not_exist
     cur_branch=`git branch | grep \* | cut -d ' ' -f2`
-    git checkout -- *
+    git checkout .
     git checkout -b develop_base_pr upstream/$BRANCH
     cmake_gen $1
     build $2

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -562,6 +562,7 @@ function fetch_upstream_develop_if_not_exist() {
 function generate_upstream_develop_api_spec() {
     fetch_upstream_develop_if_not_exist
     cur_branch=`git branch | grep \* | cut -d ' ' -f2`
+    git checkout -- *
     git checkout -b develop_base_pr upstream/$BRANCH
     cmake_gen $1
     build $2

--- a/python/paddle/fluid/tests/unittests/test_linspace.py
+++ b/python/paddle/fluid/tests/unittests/test_linspace.py
@@ -156,7 +156,7 @@ class TestLinspaceOpError(unittest.TestCase):
             def test_start_dtype():
                 start = fluid.data(shape=[1], dtype="float64", name="start")
                 fluid.layers.linspace(start, 10, 1, dtype="float32")
-
+            
             self.assertRaises(ValueError, test_start_dtype)
 
             def test_end_dtype():

--- a/python/paddle/fluid/tests/unittests/test_linspace.py
+++ b/python/paddle/fluid/tests/unittests/test_linspace.py
@@ -156,7 +156,7 @@ class TestLinspaceOpError(unittest.TestCase):
             def test_start_dtype():
                 start = fluid.data(shape=[1], dtype="float64", name="start")
                 fluid.layers.linspace(start, 10, 1, dtype="float32")
-            
+
             self.assertRaises(ValueError, test_start_dtype)
 
             def test_end_dtype():


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe

`generate_upstream_develop_api_spec` can't run successful when `check_style` failed, the example can find in [PR-CI-CPU-Py2](https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/1666964/job/2382033). The reason is that file changes by `per-commit` in `check_style` stage.
![image](https://user-images.githubusercontent.com/23427135/92356463-bd8f0f80-f118-11ea-9ecd-f938315c55f4.png)

Restore file changes before create new branch via `git checkout .`. There is a test log in [PR-CI-CPU-Py2](https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/1680405/job/2401954).
![image](https://user-images.githubusercontent.com/23427135/92356489-cb449500-f118-11ea-9302-c7640c7c1e23.png)

