### PR TITLE
fix judge cache file of inference api

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -9,6 +9,7 @@ if(WITH_GPU AND TENSORRT_FOUND)
 endif()
 
 function(download_data install_dir data_file)
+    string(REGEX MATCH "[^/\\]+$" data_file ${data_file})
     if (NOT EXISTS ${install_dir}/${data_file})
         inference_download_and_uncompress(${install_dir} ${INFERENCE_URL} ${data_file})
     endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix judge cache file of inference API. such as ``temp/transformer_model.tar.gz`` , because cannot be hit now because ''/'' between ``temp`` and ``transformer_model.tar.gz``. 

![image](https://user-images.githubusercontent.com/52485244/93305804-9c71a180-f831-11ea-8159-0cd2320ce2f0.png)
