### PR TITLE
Move unittest test_optimizer_in_control_flow from CI multi_cards.

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -558,7 +558,7 @@ set_tests_properties(test_parallel_executor_test_while_train test_parallel_execu
         test_parallel_executor_feed_persistable_var
         test_buffer_shared_memory_reuse_pass_and_fuse_optimization_op_pass
         test_data_norm_op test_imperative_using_non_zero_gpu test_fuse_bn_act_pass
-        test_optimizer_in_control_flow test_dataloader_keep_order
+        test_dataloader_keep_order
         test_dataloader_unkeep_order
         test_parallel_executor_fetch_isolated_var
         test_parallel_executor_inference_feed_partial_data

--- a/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
@@ -261,7 +261,14 @@ class TestMultiOptimizersMultiCardsError(unittest.TestCase):
             exe.run(startup_program)
 
             np.random.seed(SEED)
+
+            # NOTE(liym27):
+            # This test needs to run in multi cards to test NotImplementedError, but it don't need actual multi cards.
+            # Here to set environment variables CPU_NUM and FLAGS_selected_gpus to simulate multiple cards,
+            # and it actually runs on a single card to reduce CI time.
             os.environ['CPU_NUM'] = str(2)
+            os.environ['FLAGS_selected_gpus'] = "2,3"
+
             pe_exe = fluid.ParallelExecutor(
                 use_cuda=use_cuda,
                 main_program=main_program,
@@ -274,10 +281,8 @@ class TestMultiOptimizersMultiCardsError(unittest.TestCase):
                 },
                            fetch_list=[avg_loss.name])
 
-            if num_devices > 1:
-                self.assertRaises(NotImplementedError, not_implemented_error)
-            else:
-                not_implemented_error()
+            self.assertGreater(num_devices, 1)
+            self.assertRaises(NotImplementedError, not_implemented_error)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_optimizer_in_control_flow.py
@@ -263,11 +263,10 @@ class TestMultiOptimizersMultiCardsError(unittest.TestCase):
             np.random.seed(SEED)
 
             # NOTE(liym27):
-            # This test needs to run in multi cards to test NotImplementedError, but it don't need actual multi cards.
-            # Here to set environment variables CPU_NUM and FLAGS_selected_gpus to simulate multiple cards,
-            # and it actually runs on a single card to reduce CI time.
+            # This test needs to run in multi cards to test NotImplementedError.
+            # Here, move this test from RUN_TYPE=DIST in tests/unittests/CMakeList.txt,
+            # to use multi cards ** only on CPU ** not GPU to reduce CI time.
             os.environ['CPU_NUM'] = str(2)
-            os.environ['FLAGS_selected_gpus'] = "2,3"
 
             pe_exe = fluid.ParallelExecutor(
                 use_cuda=use_cuda,
@@ -281,8 +280,10 @@ class TestMultiOptimizersMultiCardsError(unittest.TestCase):
                 },
                            fetch_list=[avg_loss.name])
 
-            self.assertGreater(num_devices, 1)
-            self.assertRaises(NotImplementedError, not_implemented_error)
+            if num_devices > 1:
+                self.assertRaises(NotImplementedError, not_implemented_error)
+            else:
+                not_implemented_error()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Move unittest test_optimizer_in_control_flow from CI multi_cards.

- Why do this? 
`test_optimizer_in_control_flow.py` needs to run in multi cards to **test `NotImplementedError`**. Here, move this test from RUN_TYPE=DIST in tests/unittests/CMakeList.txt, to use multi cards **only on CPU** not GPU to reduce CI time.