### PR TITLE
[Dy2Stat] Fix bug and optimizer dy2stat error. 

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/error.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/error.py
@@ -21,11 +21,13 @@ from paddle.fluid.dygraph.dygraph_to_static.origin_info import Location, OriginI
 
 ERROR_DATA = "Error data about original source code information and traceback."
 
-SIMPLIFY_EOOR_ENV_NAME = "TRANSLATOR_SIMPLIFY_NEW_EOOR"
-DEFAULT_SIMPLIFY_NEW_EOOR = 1
+# A flag to set whether to open the dygraph2static error reporting module
+SIMPLIFY_ERROR_ENV_NAME = "TRANSLATOR_SIMPLIFY_NEW_ERROR"
+DEFAULT_SIMPLIFY_NEW_ERROR = 1
 
-DISABLE_EOOR_ENV_NAME = "TRANSLATOR_DISABLE_NEW_EOOR"
-DEFAULT_DISABLE_NEW_EOOR = 0
+# A flag to set whether to display the simplified error stack
+DISABLE_ERROR_ENV_NAME = "TRANSLATOR_DISABLE_NEW_ERROR"
+DEFAULT_DISABLE_NEW_ERROR = 0
 
 
 def attach_error_data(error, in_runtime=False):
@@ -111,8 +113,8 @@ class ErrorData(object):
         # Simplify error value to improve readability if error is raised in runtime
         if self.in_runtime:
             if int(
-                    os.getenv(SIMPLIFY_EOOR_ENV_NAME,
-                              DEFAULT_SIMPLIFY_NEW_EOOR)):
+                    os.getenv(SIMPLIFY_ERROR_ENV_NAME,
+                              DEFAULT_SIMPLIFY_NEW_ERROR)):
                 self._simplify_error_value()
             message_lines.append(str(self.error_value))
             return '\n'.join(message_lines)
@@ -162,7 +164,9 @@ class ErrorData(object):
         self.error_value = self.error_type(error_value_str)
 
     def raise_new_exception(self):
-        if int(os.getenv(DISABLE_EOOR_ENV_NAME, DEFAULT_DISABLE_NEW_EOOR)):
+
+        # Raises the origin error if disable dygraph2static error module,
+        if int(os.getenv(DISABLE_ERROR_ENV_NAME, DEFAULT_DISABLE_NEW_ERROR)):
             raise
 
         new_exception = self.create_exception()

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -32,8 +32,7 @@ from paddle.fluid.layers.utils import flatten
 from paddle.fluid.dygraph.base import param_guard
 from paddle.fluid.dygraph.base import switch_to_static_graph
 from paddle.fluid.dygraph.dygraph_to_static import DygraphToStaticAst
-from paddle.fluid.dygraph.dygraph_to_static.error import ERROR_DATA
-from paddle.fluid.dygraph.dygraph_to_static.error import attach_error_data
+from paddle.fluid.dygraph.dygraph_to_static import error
 from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import attach_origin_info
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import create_and_update_origin_info_map
@@ -315,6 +314,7 @@ class StaticLayer(object):
 
         # 2. trace ops from dygraph layers and cache the generated program.
         args, kwargs = self._function_spec.unified_args_and_kwargs(args, kwargs)
+
         try:
             concrete_program, partial_program_layer = self.get_concrete_program(
                 *args, **kwargs)
@@ -324,25 +324,17 @@ class StaticLayer(object):
                 partial_program_layer.training = self._class_instance.training
 
             # 4. return outputs.
-            return partial_program_layer(args)
+            try:
+                return partial_program_layer(args)
+            except Exception as e:
+                if not hasattr(e, error.ERROR_DATA):
+                    # runtime error
+                    error.attach_error_data(e, in_runtime=True)
+                    raise
         except Exception as e:
-            if not hasattr(e, ERROR_DATA):
-                # runtime error
-                attach_error_data(e, in_runtime=True)
-            error_data = getattr(e, ERROR_DATA, None)
+            error_data = getattr(e, error.ERROR_DATA, None)
             if error_data:
-                new_exception = error_data.create_exception()
-                if six.PY3:
-                    # NOTE(liym27):
-                    # 1. Why `raise new_exception from None`?
-                    #   In Python 3, by default, an new exception is raised with trace information of the caught exception.
-                    #   This only raises new_exception and hides unwanted implementation details from tracebacks of the
-                    #   caught exception.
-                    # 2. Use exec to bypass syntax error checking in Python 2.
-
-                    six.exec_("raise new_exception from None")
-                else:
-                    raise new_exception
+                error_data.raise_new_exception()
             else:
                 raise
 
@@ -593,7 +585,7 @@ class ConcreteProgram(object):
                         outputs = static_func(*inputs)
                     except BaseException as e:
                         # NOTE: If e is raised in compile time, e should be attached to ERROR_DATA here.
-                        attach_error_data(e)
+                        error.attach_error_data(e)
                         raise
 
                 if not isinstance(outputs,
@@ -813,28 +805,33 @@ class ProgramTranslator(object):
                 "The ProgramTranslator.get_output doesn't work when setting ProgramTranslator.enable = False. "
                 "We will just return dygraph output.")
             return dygraph_func(*args, **kwargs)
-
-        function_spec = FunctionSpec(dygraph_func)
-        cache_key = CacheKey.from_func_and_args(function_spec, args, kwargs,
-                                                getattr(dygraph_func,
-                                                        '__self__', None))
-        _, partial_program_layer = self._program_cache[cache_key]
-
-        if args and isinstance(args[0], layers.Layer):
-            # Synchronize self.training attribute.
-            partial_program_layer.training = args[0].training
-            args = args[1:]
         try:
-            return partial_program_layer(args)
+            function_spec = FunctionSpec(dygraph_func)
+            cache_key = CacheKey.from_func_and_args(function_spec, args, kwargs,
+                                                    getattr(dygraph_func,
+                                                            '__self__', None))
+            _, partial_program_layer = self._program_cache[cache_key]
 
+            if args and isinstance(args[0], layers.Layer):
+                # Synchronize self.training attribute.
+                partial_program_layer.training = args[0].training
+                args = args[1:]
+            try:
+                return partial_program_layer(args)
+            except BaseException as e:
+                # NOTE:
+                # 1. If e is raised in compile time, e should have been attached to ERROR_DATA before;
+                # 2. If e raised in runtime, e should be attached to ERROR_DATA here.
+                if not hasattr(e, error.ERROR_DATA):
+                    # runtime error
+                    error.attach_error_data(e, in_runtime=True)
+                raise
         except BaseException as e:
-            # NOTE:
-            # 1. If e is raised in compile time, e should have been attached to ERROR_DATA before;
-            # 2. If e raised in runtime, e should be attached to ERROR_DATA here.
-            if not hasattr(e, ERROR_DATA):
-                # runtime error
-                attach_error_data(e, in_runtime=True)
-            raise
+            error_data = getattr(e, error.ERROR_DATA, None)
+            if error_data:
+                error_data.raise_new_exception()
+            else:
+                raise e
 
     def get_func(self, dygraph_func):
         """

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -336,7 +336,10 @@ class StaticLayer(object):
             if error_data:
                 error_data.raise_new_exception()
             else:
-                raise
+                logging_utils.warn(
+                    "Please file an issue at 'https://github.com/PaddlePaddle/Paddle/issues'"
+                    " if you can't handle this {} yourself.".format(type(e)))
+                raise e
 
     def _call_dygraph_function(self, *args, **kwargs):
         """
@@ -831,6 +834,9 @@ class ProgramTranslator(object):
             if error_data:
                 error_data.raise_new_exception()
             else:
+                logging_utils.warn(
+                    "Please file an issue at 'https://github.com/PaddlePaddle/Paddle/issues'"
+                    " if you can't handle this {} yourself.".format(type(e)))
                 raise e
 
     def get_func(self, dygraph_func):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -14,15 +14,15 @@
 
 from __future__ import print_function
 
+import os
 import inspect
 import unittest
-
 import numpy as np
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.core import EnforceNotMet
-from paddle.fluid.dygraph.dygraph_to_static.error import ERROR_DATA, ErrorData
+from paddle.fluid.dygraph.dygraph_to_static import error
 from paddle.fluid.dygraph.dygraph_to_static.origin_info import unwrap
-from paddle.fluid.dygraph.jit import declarative
 
 
 def inner_func():
@@ -30,7 +30,7 @@ def inner_func():
     return
 
 
-@declarative
+@paddle.jit.to_static
 def func_error_in_compile_time(x):
     x = fluid.dygraph.to_variable(x)
     inner_func()
@@ -41,14 +41,14 @@ def func_error_in_compile_time(x):
     return x_v
 
 
-@declarative
+@paddle.jit.to_static
 def func_error_in_compile_time_2(x):
     x = fluid.dygraph.to_variable(x)
     x = fluid.layers.reshape(x, shape=[1, 2])
     return x
 
 
-@declarative
+@paddle.jit.to_static
 def func_error_in_runtime(x, iter_num=3):
     x = fluid.dygraph.to_variable(x)
     two = fluid.layers.fill_constant(shape=[1], value=2, dtype="int32")
@@ -61,6 +61,9 @@ class TestErrorInCompileTime(unittest.TestCase):
         self.set_func()
         self.set_input()
         self.set_exception_type()
+        self.prog_trans = paddle.jit.ProgramTranslator()
+        self.simplify_error = 1
+        self.disable_error = 0
 
     def set_func(self):
         self.func = func_error_in_compile_time
@@ -88,14 +91,38 @@ class TestErrorInCompileTime(unittest.TestCase):
         for m in self.expected_message:
             self.assertIn(m, error_message)
 
-    def test(self):
-        with fluid.dygraph.guard():
-            with self.assertRaises(self.exception_type) as cm:
-                self.func(self.input)
-            exception = cm.exception
-            error_data = getattr(exception, ERROR_DATA)
-            self.assertIsInstance(error_data, ErrorData)
-            self._test_create_message(error_data)
+    def _test_attach_and_raise_new_exception(self, func_call):
+        paddle.disable_static()
+        with self.assertRaises(self.exception_type) as cm:
+            func_call()
+        exception = cm.exception
+
+        error_data = getattr(exception, error.ERROR_DATA, None)
+
+        self.assertIsInstance(error_data, error.ErrorData)
+        self._test_create_message(error_data)
+
+    def test_static_layer_call(self):
+        # NOTE: self.func(self.input) is the StaticLayer().__call__(self.input)
+        call_dy2static = lambda: self.func(self.input)
+
+        self.set_flags(0)
+        self._test_attach_and_raise_new_exception(call_dy2static)
+
+    def test_program_translator_get_output(self):
+        call_dy2static = lambda : self.prog_trans.get_output(unwrap(self.func), self.input)
+
+        self.set_flags(0)
+        self._test_attach_and_raise_new_exception(call_dy2static)
+
+    def set_flags(self, disable_error=0, simplify_error=1):
+        os.environ[error.DISABLE_EOOR_ENV_NAME] = str(disable_error)
+        self.disable_error = int(os.getenv(error.DISABLE_EOOR_ENV_NAME, 0))
+        self.assertEqual(self.disable_error, disable_error)
+
+        os.environ[error.SIMPLIFY_EOOR_ENV_NAME] = str(simplify_error)
+        self.simplify_error = int(os.getenv(error.SIMPLIFY_EOOR_ENV_NAME, 1))
+        self.assertEqual(self.simplify_error, simplify_error)
 
 
 class TestErrorInCompileTime2(TestErrorInCompileTime):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -170,5 +170,28 @@ class TestErrorInRuntime(TestErrorInCompileTime):
             self.assertIn(m, error_message)
 
 
+@unwrap
+@paddle.jit.to_static()
+def func_decorated_by_other_1():
+    return 1
+
+
+@paddle.jit.to_static()
+@unwrap
+def func_decorated_by_other_2():
+    return 1
+
+
+class TestErrorInOther(unittest.TestCase):
+    def test(self):
+        paddle.disable_static()
+        prog_trans = paddle.jit.ProgramTranslator()
+        with self.assertRaises(NotImplementedError):
+            prog_trans.get_output(func_decorated_by_other_1)
+
+        with self.assertRaises(NotImplementedError):
+            func_decorated_by_other_2()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_error.py
@@ -116,12 +116,12 @@ class TestErrorInCompileTime(unittest.TestCase):
         self._test_attach_and_raise_new_exception(call_dy2static)
 
     def set_flags(self, disable_error=0, simplify_error=1):
-        os.environ[error.DISABLE_EOOR_ENV_NAME] = str(disable_error)
-        self.disable_error = int(os.getenv(error.DISABLE_EOOR_ENV_NAME, 0))
+        os.environ[error.DISABLE_ERROR_ENV_NAME] = str(disable_error)
+        self.disable_error = int(os.getenv(error.DISABLE_ERROR_ENV_NAME, 0))
         self.assertEqual(self.disable_error, disable_error)
 
-        os.environ[error.SIMPLIFY_EOOR_ENV_NAME] = str(simplify_error)
-        self.simplify_error = int(os.getenv(error.SIMPLIFY_EOOR_ENV_NAME, 1))
+        os.environ[error.SIMPLIFY_ERROR_ENV_NAME] = str(simplify_error)
+        self.simplify_error = int(os.getenv(error.SIMPLIFY_ERROR_ENV_NAME, 1))
         self.assertEqual(self.simplify_error, simplify_error)
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
### 之前的问题：

动转静部分场景下报错异常；
   - 因为之前动转静接口更新的一些改动，接口ProgramTranslator().get_output() 未使用动转静报错模块（仍用了Paddle框架报错）
   - 当动转静过程中（反向添加、AST转化）报错时，有bug，无法正常报错。
      - 这部分报错应该用Paddle框架报错，不应该走动转静报错模块。
      - 这部分内容可能是动转静流程中有bug，需要提示用户将异常信息反馈给Paddle

---

### 本PR修改后：  
修复了现存bug，整合了动转静报错场景，修改后：

1. 仅2个接口使用时需要用到动转静报错模块：ProgramTranslator().get_output，StaticLayer.__call_
2. 动转静流程中的报错来自4个阶段：静态图编译期前向、反向组网、运行期，其他环节（如AST转化、添加反向等）

|阶段|可以用动转静报错模块|仅用Python原生报错|
|--|--|--|
|静态图编译期前向|是|需要设置环境变量<br>TRANSLATOR_DISABLE_NEW_ERROR=1|
|反向组网|是|需要设置环境变量<br>TRANSLATOR_DISABLE_NEW_ERROR=1|
|运行期|否|是，同时报warn提醒用户反馈给Paddle|
|其他环节|否|是，同时报warn提醒用户反馈给Paddle|

3. 增加2个Flag，控制报错信息栈，方便debug
    - TRANSLATOR_DISABLE_NEW_ERROR: 默认为0。为1时可关闭动转静报错模块，仅使用Python原生报错
    - TRANSLATOR_SIMPLIFY_NEW_ERROR: 默认为1。为0时，可看到未被简化的报错。

---

TODO:   
- [ ] 2个flag的使用信息，更新到官网文档。