### PR TITLE
add paddle1to2 dependency

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -21,3 +21,4 @@ objgraph
 astor
 pathlib
 netifaces
+paddle1to2 ; python_version>="3.5"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
add paddle1to2 dependency. [paddle1to2](https://pypi.org/project/paddle1to2/) will be installed automatically when install [paddlepaddle](https://pypi.org/project/paddlepaddle/)