### PR TITLE
fix unused var with zero gradient bug in fluid.gradient

### DIFF
--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1751,6 +1751,11 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
         if input.block.program != prog:
             raise "input must be in the same program as targets"
 
+    # find no grad var by op_path
+    no_grad_vars = _find_no_grad_vars(block, op_path, targets,
+                                      block_no_grad_set)
+    block_no_grad_set.update(no_grad_vars)
+
     block_no_grad_set = set(map(_strip_grad_suffix_, no_grad_dict[0]))
 
     op_path_dict = dict()

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1751,16 +1751,17 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
         if input.block.program != prog:
             raise "input must be in the same program as targets"
 
-    # find no grad var by op_path
-    no_grad_vars = _find_no_grad_vars(block, op_path, targets,
-                                      block_no_grad_set)
-    block_no_grad_set.update(no_grad_vars)
-
     block_no_grad_set = set(map(_strip_grad_suffix_, no_grad_dict[0]))
 
     op_path_dict = dict()
     op_path = _find_op_path_(block, targets, inputs, block_no_grad_set,
                              op_path_dict)
+
+    # find no grad var by op_path
+    no_grad_vars = _find_no_grad_vars(block, op_path, targets,
+                                      block_no_grad_set)
+    block_no_grad_set.update(no_grad_vars)
+
     no_grad_dict[0].update(list(map(_append_grad_suffix_, block_no_grad_set)))
     grad_to_var = dict()
     grad_info_map = dict()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 import numpy as np
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.layers.utils import flatten
 from paddle.fluid.dygraph import declarative, ProgramTranslator
@@ -149,6 +150,34 @@ class TestWithTrainAndEval(unittest.TestCase):
             linear_net(x)
             self.assertEqual(partial_layer.program,
                              partial_layer._train_program)
+
+
+class GPT2LMHeadModel(fluid.dygraph.Layer):
+    def __init__(self):
+        super(GPT2LMHeadModel, self).__init__()
+        self.embedding0 = paddle.nn.Embedding((20, 16))
+        self.embedding1 = paddle.nn.Embedding((20, 32))
+        self.lm_head_weight = paddle.to_tensor(
+            np.random.rand(2, 3).astype('float32'))
+
+    @declarative
+    def forward(self, x):
+        x = fluid.layers.reshape(x, shape=[-1, 6])
+        x1, x2, x3 = fluid.layers.split(input=x, dim=1, num_or_sections=3)
+        return x1
+
+
+class TestPruneUnusedParamInProgram(unittest.TestCase):
+    def test_prune(self):
+        input_ids = np.array([[15, 11, 6, 3, 18, 13]]).astype("float32")
+
+        place = fluid.CPUPlace()
+        with fluid.dygraph.guard(place):
+            model = GPT2LMHeadModel()
+            model.eval()
+            input_ids = paddle.to_tensor(input_ids)
+            out = model(input_ids)
+            self.assertTrue(np.array_equal(out.numpy(), [[15, 11]]))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
@@ -155,8 +155,8 @@ class TestWithTrainAndEval(unittest.TestCase):
 class GPT2LMHeadModel(fluid.dygraph.Layer):
     def __init__(self):
         super(GPT2LMHeadModel, self).__init__()
-        self.embedding0 = paddle.nn.Embedding((20, 16))
-        self.embedding1 = paddle.nn.Embedding((20, 32))
+        self.embedding0 = paddle.nn.Embedding(20, 16)
+        self.embedding1 = paddle.nn.Embedding(20, 32)
         self.lm_head_weight = paddle.to_tensor(
             np.random.rand(2, 3).astype('float32'))
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
fix unused var with zero gradient

Example code:
`x1`, `x2`, `x3` are output vars from same op, but only `x1` is used to calculate gradient, so `x2@GRAD`、`x3@GRAD` should be zero but not before in this PR. They are not initialized as expected.

```python
class TestGradientWithPrune(unittest.TestCase):
    def test_prune(self):
        x = fluid.data(name='x', shape=[3], dtype='float32')
        x.stop_gradient = False
        x1, x2, x3 = fluid.layers.split(x, dim=0, num_or_sections=3)
        y = x1 * 2
        x1_grad = fluid.gradients(y, x)

        exe = fluid.Executor(fluid.CPUPlace())
        main = fluid.default_main_program()
        exe.run(fluid.default_startup_program())
        out = exe.run(main,
                      feed={'x': np.ones([3]).astype('float32')},
                      fetch_list=[x1_grad])
        self.assertTrue(np.array_equal(out[0], [2., 0., 0.]))
```