### PR TITLE
move DataLoader._worker_loop to top level

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -85,6 +85,30 @@ def _convert_places(places):
     return ret
 
 
+# NOTE(chenweihang): _reader_process_loop must be top level method to be pickled
+def _reader_process_loop(batch_reader, data_queue):
+    try:
+        # set signal handler
+        core._set_process_signal_handler()
+
+        # NOTE: [ mmap files clear ] When the child process exits unexpectedly,
+        # some shared memory objects may have been applied for but have not yet
+        # been put into the inter-process Queue. This part of the object needs
+        # to be cleaned up when the process ends.
+        CleanupFuncRegistrar.register(_cleanup_mmap)
+
+        for batch in batch_reader():
+            tensor_list = core._convert_to_tensor_list(batch)
+            data_queue.put(tensor_list)
+            core._remove_tensor_list_mmap_fds(tensor_list)
+        data_queue.put(None)
+    except KeyboardInterrupt:
+        # NOTE: Main process will raise KeyboardInterrupt anyways, ignore it in child process
+        pass
+    except:
+        six.reraise(*sys.exc_info())
+
+
 class DataLoaderBase(object):
     def __init__(self):
         self._places = None
@@ -811,7 +835,8 @@ class DygraphGeneratorLoader(DataLoaderBase):
             global multiprocess_queue_set
             multiprocess_queue_set.add(self._data_queue)
             self._process = multiprocessing.Process(
-                target=self._reader_process_loop)
+                target=_reader_process_loop,
+                args=(self._batch_reader, self._data_queue))
             self._process.daemon = True
             self._process.start()
 
@@ -866,28 +891,6 @@ class DygraphGeneratorLoader(DataLoaderBase):
         self._thread_done_event.set()
         self._blocking_queue.kill()
         logging.error("DataLoader reader thread raised an exception!")
-
-    def _reader_process_loop(self):
-        try:
-            # set signal handler
-            core._set_process_signal_handler()
-
-            # NOTE: [ mmap files clear ] When the child process exits unexpectedly,
-            # some shared memory objects may have been applied for but have not yet
-            # been put into the inter-process Queue. This part of the object needs
-            # to be cleaned up when the process ends.
-            CleanupFuncRegistrar.register(_cleanup_mmap)
-
-            for batch in self._batch_reader():
-                tensor_list = core._convert_to_tensor_list(batch)
-                self._data_queue.put(tensor_list)
-                core._remove_tensor_list_mmap_fds(tensor_list)
-            self._data_queue.put(None)
-        except KeyboardInterrupt:
-            # NOTE: Main process will raise KeyboardInterrupt anyways, ignore it in child process
-            pass
-        except:
-            six.reraise(*sys.exc_info())
 
     def _reader_thread_loop_for_multiprocess(self):
         while not self._thread_done_event.is_set():

--- a/python/paddle/fluid/tests/unittests/test_imperative_data_loader_process.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_data_loader_process.py
@@ -18,6 +18,7 @@ import multiprocessing
 import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid import core
+from paddle.fluid.reader import _reader_process_loop
 
 if sys.version_info[0] == 2:
     import Queue as queue
@@ -66,7 +67,7 @@ class TestDygraphDataLoaderProcess(unittest.TestCase):
                 batch_generator_creator(self.batch_size, self.batch_num),
                 places=fluid.CPUPlace())
             loader._data_queue = queue.Queue(self.batch_num + 1)
-            loader._reader_process_loop()
+            _reader_process_loop(loader._batch_reader, loader._data_queue)
             # For clean memory mapped files
             util_queue = multiprocessing.Queue(self.batch_num + 1)
             for _ in range(self.batch_num):
@@ -94,7 +95,7 @@ class TestDygraphDataLoaderProcess(unittest.TestCase):
             loader._data_queue = queue.Queue(self.batch_num + 1)
             exception = None
             try:
-                loader._reader_process_loop()
+                _reader_process_loop(loader._batch_reader, loader._data_queue)
             except core.EnforceNotMet as ex:
                 exception = ex
             self.assertIsNotNone(exception)

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -27,6 +27,7 @@ import paddle.fluid.core as core
 from paddle.io import Dataset, IterableDataset, BatchSampler, DataLoader
 from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.dygraph.base import to_variable
+from paddle.fluid.dataloader.dataloader_iter import _worker_loop
 
 
 class RandomDataset(Dataset):
@@ -185,9 +186,10 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
                 for i in range(10):
                     indices_queue.put([i, i + 10])
                 indices_queue.put(None)
-                loader._worker_loop(
-                    loader._dataset, 0, indices_queue, loader._data_queue,
-                    loader._workers_done_event, _collate_fn, _init_fn, 0, 1)
+                _worker_loop(loader._dataset, 0, indices_queue,
+                             loader._data_queue, loader._workers_done_event,
+                             _collate_fn, _init_fn, 0, 1,
+                             loader._use_shared_memory)
                 self.assertTrue(False)
         except AssertionError:
             pass
@@ -228,9 +230,10 @@ class TestDataLoaderWorkerLoop(unittest.TestCase):
                     indices_queue.put([i, i + 10])
                 indices_queue.put(None)
                 loader._workers_done_event.set()
-                loader._worker_loop(
-                    loader._dataset, 0, indices_queue, loader._data_queue,
-                    loader._workers_done_event, _collate_fn, _init_fn, 0, 1)
+                _worker_loop(loader._dataset, 0, indices_queue,
+                             loader._data_queue, loader._workers_done_event,
+                             _collate_fn, _init_fn, 0, 1,
+                             loader._use_shared_memory)
                 self.assertTrue(True)
         except AssertionError:
             pass


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

move `DataLoader._worker_loop` to top level

Otherwise, it will cause errors when using `paddle.distributed.spawn` method to start multi-process DataLoader because the `_worker_loop` cannot be pickled.

error example:

```
I0910 12:49:50.989151  8382 nccl_context.cc:127] init nccl context nranks: 2 local rank: 0 gpu id: 0
I0910 12:49:50.989272  8383 nccl_context.cc:127] init nccl context nranks: 2 local rank: 1 gpu id: 1
W0910 12:49:51.561908  8382 device_context.cc:320] Please NOTE: device: 0, CUDA Capability: 61, Driver API Version: 10.1, Runtime API Version: 10.0
W0910 12:49:51.562680  8383 device_context.cc:320] Please NOTE: device: 1, CUDA Capability: 61, Driver API Version: 10.1, Runtime API Version: 10.0
W0910 12:49:51.568655  8382 device_context.cc:328] device: 0, cuDNN Version: 7.5.
W0910 12:49:51.569162  8383 device_context.cc:328] device: 1, cuDNN Version: 7.5.
Exception ignored in: <bound method _DataLoaderIterMultiProcess.__del__ of <paddle.fluid.dataloader.dataloader_iter._DataLoaderIterMultiProcess object at 0x7f71cbeb5898>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 719, in __del__
    self._try_shutdown_all()
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 456, in _try_shutdown_all
    if not self._shutdown:
AttributeError: '_DataLoaderIterMultiProcess' object has no attribute '_shutdown'
Exception ignored in: <bound method _DataLoaderIterMultiProcess.__del__ of <paddle.fluid.dataloader.dataloader_iter._DataLoaderIterMultiProcess object at 0x7fcf918958d0>>
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 719, in __del__
    self._try_shutdown_all()
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 456, in _try_shutdown_all
    if not self._shutdown:
AttributeError: '_DataLoaderIterMultiProcess' object has no attribute '_shutdown'
Traceback (most recent call last):
  File "spawn_dataloader.py", line 72, in <module>
    dist.spawn(train, nprocs=2)
  File "/usr/local/lib/python3.5/dist-packages/paddle/distributed/spawn.py", line 409, in spawn
    while not context.join():
  File "/usr/local/lib/python3.5/dist-packages/paddle/distributed/spawn.py", line 210, in join
    self._throw_exception(error_index)
  File "/usr/local/lib/python3.5/dist-packages/paddle/distributed/spawn.py", line 228, in _throw_exception
    raise Exception(msg)
Exception: 

----------------------------------------------
Process 0 terminated with the following error:
----------------------------------------------

Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/paddle/distributed/spawn.py", line 159, in _func_wrapper
    result = func(*args)
  File "/work/scripts/spawn/spawn_dataloader.py", line 58, in train
    for batch_id, (image, label) in enumerate(loader()):
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/reader.py", line 406, in __call__
    return self.__iter__()
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/reader.py", line 403, in __iter__
    return _DataLoaderIterMultiProcess(self)
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 381, in __init__
    self._init_workers()
  File "/usr/local/lib/python3.5/dist-packages/paddle/fluid/dataloader/dataloader_iter.py", line 413, in _init_workers
    worker.start()
  File "/usr/lib/python3.5/multiprocessing/process.py", line 105, in start
    self._popen = self._Popen(self)
  File "/usr/lib/python3.5/multiprocessing/context.py", line 212, in _Popen
    return _default_context.get_context().Process._Popen(process_obj)
  File "/usr/lib/python3.5/multiprocessing/context.py", line 274, in _Popen
    return Popen(process_obj)
  File "/usr/lib/python3.5/multiprocessing/popen_spawn_posix.py", line 33, in __init__
    super().__init__(process_obj)
  File "/usr/lib/python3.5/multiprocessing/popen_fork.py", line 20, in __init__
    self._launch(process_obj)
  File "/usr/lib/python3.5/multiprocessing/popen_spawn_posix.py", line 48, in _launch
    reduction.dump(process_obj, fp)
  File "/usr/lib/python3.5/multiprocessing/reduction.py", line 59, in dump
    ForkingPickler(file, protocol).dump(obj)
TypeError: can't pickle _thread.lock objects
```
