### PR TITLE
Temporally disable zero_copy

### DIFF
--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -610,10 +610,10 @@ def to_variable(value, name=None, zero_copy=None, dtype=None):
             uint8, uint16, complex64, complex128}.
         name(str, optional): The default value is None. Normally there is no 
             need for user to set this property. For more information, please 
-            refer to :ref:`api_guide_Name` .
+            refer to :ref:`api_guide_Name` . 
         zero_copy(bool, optional): Whether to share memory with the input numpy 
             array. This parameter only works with CPUPlace and will be set to 
-            True when it is None. Default: None.
+            True when it is None. Default: None. (Note: zero_copy is discarded temporally for some reason.)
         dtype(str, optional): The desired data type of returned ``Variable`` .
             Can be 'bool' , 'float16' , 'float32' , 'float64' , 'int8' , 'int16' , 
             'int32' , 'int64' , 'uint8' . Default: None.

--- a/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
@@ -21,12 +21,14 @@ class TestImperativeNumpyBridge(unittest.TestCase):
     def test_tensor_from_numpy(self):
         data_np = np.array([[2, 3, 1]]).astype('float32')
         with fluid.dygraph.guard(fluid.CPUPlace()):
-            var = fluid.dygraph.to_variable(data_np, zero_copy=True)
-            self.assertTrue(np.array_equal(var.numpy(), data_np))
-            data_np[0][0] = 4
-            self.assertEqual(data_np[0][0], 4)
-            self.assertEqual(var[0][0].numpy()[0], 4)
-            self.assertTrue(np.array_equal(var.numpy(), data_np))
+            # Temporally diable zero_copy
+            # var = fluid.dygraph.to_variable(data_np, zero_copy=True)
+            # self.assertTrue(np.array_equal(var.numpy(), data_np))
+            # data_np[0][0] = 4
+            # self.assertEqual(data_np[0][0], 4)
+            # self.assertEqual(var[0][0].numpy()[0], 4)
+            # self.assertTrue(np.array_equal(var.numpy(), data_np))
+
             var2 = fluid.dygraph.to_variable(data_np, zero_copy=False)
             self.assertTrue(np.array_equal(var2.numpy(), data_np))
             data_np[0][0] = -1

--- a/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_numpy_bridge.py
@@ -15,12 +15,18 @@
 import unittest
 import numpy as np
 import paddle.fluid as fluid
+import warnings
 
 
 class TestImperativeNumpyBridge(unittest.TestCase):
     def test_tensor_from_numpy(self):
         data_np = np.array([[2, 3, 1]]).astype('float32')
         with fluid.dygraph.guard(fluid.CPUPlace()):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                var = fluid.dygraph.to_variable(data_np, zero_copy=True)
+                assert "Currently, zero_copy is not supported, and it will be discarded." in str(
+                    w[-1].message)
             # Temporally diable zero_copy
             # var = fluid.dygraph.to_variable(data_np, zero_copy=True)
             # self.assertTrue(np.array_equal(var.numpy(), data_np))

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -208,20 +208,20 @@ def to_tensor(data, dtype=None, place=None, stop_gradient=True):
             value=data,
             place=place,
             persistable=False,
-            zero_copy=True,
+            zero_copy=False,
             stop_gradient=stop_gradient)
     else:
         name = unique_name.generate('generated_tensor')
         real_tensor = paddle.Tensor(
             value=data.real,
             place=place,
-            zero_copy=True,
+            zero_copy=False,
             name=name + ".real",
             stop_gradient=stop_gradient)
         imag_tensor = paddle.Tensor(
             value=data.imag,
             place=place,
-            zero_copy=True,
+            zero_copy=False,
             name=name + ".imag",
             stop_gradient=stop_gradient)
         return paddle.ComplexTensor(real_tensor, imag_tensor)

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -62,8 +62,7 @@ def to_tensor(data, dtype=None, place=None, stop_gradient=True):
 
     If the ``data`` is already a tensor, and ``dtype`` or ``place`` does't change, no copy 
     will be performed and return origin tensor, otherwise a new tensor will be constructed
-    and returned. Similarly, if the data is an numpy\.ndarray of with the same ``dtype`` 
-    and the current place is cpu, no copy will be performed.
+    and returned. 
 
     The ``ComplexTensor`` is a unique type of paddle. If x is ``ComplexTensor``, then 
     ``x.real`` is the real part, and ``x.imag`` is the imaginary part.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Temporally disable zero_copy of `to_variable` and `to_tensor`
### Why?
we found two problems when enable zero_copy on CPUPlace.
- Eigen requires 16-bytes alignments, but the data of numpy array may not always satisfy the condition. 
Details: https://eigen.tuxfamily.org/dox/group__TopicUnalignedArrayAssert.html
- When used in flask framework, it may result in hang.
Details: https://github.com/PaddlePaddle/Paddle/issues/26635
- zero_copy is only used in CPUPlace. For training on CPU, the computation is not as fast as on GPU, so the time consumption of doing copy may not be the major issue of performance.

So, we temporally diable the zero_copy strategy.
 