### PR TITLE
fix bug when axis is a tensor with more than 1 element

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6309,7 +6309,7 @@ def unsqueeze(input, axes, name=None):
         if isinstance(axes, int):
             axes = [axes]
         elif isinstance(axes, Variable):
-            axes = [axes.numpy().item(0)]
+            axes = axes.numpy().tolist()
         elif isinstance(axes, (list, tuple)):
             axes = [
                 item.numpy().item(0) if isinstance(item, Variable) else item

--- a/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
+++ b/python/paddle/fluid/tests/unittests/test_unsqueeze_op.py
@@ -167,8 +167,9 @@ class API_TestDyUnsqueezeAxisTensor(unittest.TestCase):
         with fluid.dygraph.guard():
             input1 = np.random.random([5, 10]).astype("int32")
             out1 = np.expand_dims(input1, axis=1)
+            out1 = np.expand_dims(out1, axis=2)
             input = fluid.dygraph.to_variable(input1)
-            output = paddle.unsqueeze(input, axis=paddle.to_tensor([1]))
+            output = paddle.unsqueeze(input, axis=paddle.to_tensor([1, 2]))
             out_np = output.numpy()
             self.assertTrue(np.array_equal(out1, out_np))
             self.assertEqual(out1.shape, out_np.shape)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix a bug of unsqueeze when axis is a tensor with more than 1 element