### PR TITLE
[Dy2Stat-log] Add feature also_to_stdout and optimize log messages

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ast_transformer.py
@@ -60,7 +60,7 @@ class DygraphToStaticAst(gast.NodeTransformer):
     def transfer_from_node_type(self, node_wrapper):
         translator_logger = logging_utils.TranslatorLogger()
         translator_logger.log(
-            1, "   Source code: \n{}".format(ast_to_source_code(self.root)))
+            1, "Source code: \n{}".format(ast_to_source_code(self.root)))
         # Generic transformation
         self.visit(node_wrapper.node)
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 import six
 import inspect
 import numpy as np
 import collections
+
 import paddle
 from paddle.fluid import core
 from paddle.fluid.dygraph import layers
 from paddle.fluid.layers.utils import flatten
 from paddle.fluid.layers.utils import pack_sequence_as
 from paddle.fluid.dygraph.base import switch_to_static_graph
+from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.utils import parse_arg_and_kwargs
 from paddle.fluid.dygraph.dygraph_to_static.utils import type_name
 from paddle.fluid.dygraph.dygraph_to_static.utils import func_to_source_code
@@ -291,7 +292,7 @@ def convert_to_input_spec(inputs, input_spec):
         if len(inputs) > len(input_spec):
             for rest_input in inputs[len(input_spec):]:
                 if isinstance(rest_input, (core.VarBase, np.ndarray)):
-                    logging.warning(
+                    logging_utils.warn(
                         "The inputs constain `{}` without specificing InputSpec, its shape and dtype will be treated immutable. "
                         "Please specific InputSpec information in `@declarative` if you expect them as mutable inputs.".
                         format(type_name(rest_input)))

--- a/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
@@ -26,9 +26,6 @@ CODE_LEVEL_ENV_NAME = 'TRANSLATOR_CODE_LEVEL'
 DEFAULT_VERBOSITY = -1
 DEFAULT_CODE_LEVEL = -1
 
-LOG_TO_STDOUT_ENV_NAME = 'TRANSLATOR_LOG_TO_STDOUT'
-DEFAULT_LOG_TO_STDOUT = False
-
 LOG_AllTransformer = 100
 
 
@@ -99,12 +96,7 @@ class TranslatorLogger(object):
     @property
     def need_to_echo_log_to_stdout(self):
         if self._need_to_echo_log_to_stdout is not None:
-            if self._need_to_echo_log_to_stdout:
-                return True
-        else:
-            if str(os.getenv(LOG_TO_STDOUT_ENV_NAME,
-                             DEFAULT_LOG_TO_STDOUT)).upper() == "TRUE":
-                return True
+            return self._need_to_echo_log_to_stdout
         return False
 
     @need_to_echo_log_to_stdout.setter
@@ -187,16 +179,12 @@ class TranslatorLogger(object):
 _TRANSLATOR_LOGGER = TranslatorLogger()
 
 
-def set_verbosity(level=0, log_to_stdout=False):
+def set_verbosity(level=0, also_to_stdout=False):
     """
-    Sets the verbosity level of log for dygraph to static graph. Logs can be output to stdout by setting `log_to_stdout`.
+    Sets the verbosity level of log for dygraph to static graph. Logs can be output to stdout by setting `also_to_stdout`.
     There are two means to set the logging verbosity:
      1. Call function `set_verbosity`
      2. Set environment variable `TRANSLATOR_VERBOSITY`
-
-    There are two means to set whether to output log to `sys.stdout`:
-     1. Set `log_to_stdout` in function `set_verbosity`
-     2. Set environment variable `TRANSLATOR_LOG_TO_STDOUT`
 
     **Note**:
     `set_verbosity` has a higher priority than the environment variable.
@@ -204,7 +192,7 @@ def set_verbosity(level=0, log_to_stdout=False):
     Args:
         level(int): The verbosity level. The larger value idicates more verbosity.
             The default value is 0, which means no logging.
-        log_to_stdout(bool): Whether to output log messages to `sys.stdout`.
+        also_to_stdout(bool): Whether to also output log messages to `sys.stdout`.
 
     Examples:
         .. code-block:: python
@@ -219,30 +207,27 @@ def set_verbosity(level=0, log_to_stdout=False):
             # The verbosity level is now 3, but it has no effect because it has a lower priority than `set_verbosity`
     """
     _TRANSLATOR_LOGGER.verbosity_level = level
-    _TRANSLATOR_LOGGER.need_to_echo_log_to_stdout = log_to_stdout
+    _TRANSLATOR_LOGGER.need_to_echo_log_to_stdout = also_to_stdout
 
 
 def get_verbosity():
     return _TRANSLATOR_LOGGER.verbosity_level
 
 
-def set_code_level(level=LOG_AllTransformer, log_to_stdout=False):
+def set_code_level(level=LOG_AllTransformer, also_to_stdout=False):
     """
-    Sets the level to print code from specific level Ast Transformer.
+    Sets the level to print code from specific level Ast Transformer. Code can be output to stdout by setting `also_to_stdout`.
     There are two means to set the code level:
      1. Call function `set_code_level`
      2. Set environment variable `TRANSLATOR_CODE_LEVEL`
 
-    There are two means to set whether to output code to `sys.stdout`:
-     1. Set `log_to_stdout` in function `set_code_level`
-     2. Set environment variable `TRANSLATOR_LOG_TO_STDOUT`
 
     **Note**:
     `set_code_level` has a higher priority than the environment variable.
 
     Args:
         level(int): The level to print code. Default is 100, which means to print the code after all AST Transformers.
-        log_to_stdout(bool): Whether to output code to `sys.stdout`.
+        also_to_stdout(bool): Whether to also output code to `sys.stdout`.
 
     Examples:
         .. code-block:: python
@@ -258,7 +243,7 @@ def set_code_level(level=LOG_AllTransformer, log_to_stdout=False):
 
     """
     _TRANSLATOR_LOGGER.transformed_code_level = level
-    _TRANSLATOR_LOGGER.need_to_echo_code_to_stdout = log_to_stdout
+    _TRANSLATOR_LOGGER.need_to_echo_code_to_stdout = also_to_stdout
 
 
 def get_code_level():

--- a/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
@@ -182,9 +182,13 @@ _TRANSLATOR_LOGGER = TranslatorLogger()
 def set_verbosity(level=0, also_to_stdout=False):
     """
     Sets the verbosity level of log for dygraph to static graph. Logs can be output to stdout by setting `also_to_stdout`.
+
     There are two means to set the logging verbosity:
-     1. Call function `set_verbosity`
-     2. Set environment variable `TRANSLATOR_VERBOSITY`
+
+    1. Call function `set_verbosity`
+
+    2. Set environment variable `TRANSLATOR_VERBOSITY`
+
 
     **Note**:
     `set_verbosity` has a higher priority than the environment variable.
@@ -217,9 +221,12 @@ def get_verbosity():
 def set_code_level(level=LOG_AllTransformer, also_to_stdout=False):
     """
     Sets the level to print code from specific level Ast Transformer. Code can be output to stdout by setting `also_to_stdout`.
+
     There are two means to set the code level:
-     1. Call function `set_code_level`
-     2. Set environment variable `TRANSLATOR_CODE_LEVEL`
+
+    1. Call function `set_code_level`
+
+    2. Set environment variable `TRANSLATOR_CODE_LEVEL`
 
 
     **Note**:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/logging_utils.py
@@ -140,19 +140,19 @@ class TranslatorLogger(object):
     def error(self, msg, *args, **kwargs):
         self.logger.error(msg, *args, **kwargs)
         if self.need_to_echo_log_to_stdout:
-            self._output_to_stdout_if_need('ERROR: ' + msg, *args)
+            self._output_to_stdout('ERROR: ' + msg, *args)
 
     def warn(self, msg, *args, **kwargs):
         self.logger.warning(msg, *args, **kwargs)
         if self.need_to_echo_log_to_stdout:
-            self._output_to_stdout_if_need('WARNING: ' + msg, *args)
+            self._output_to_stdout('WARNING: ' + msg, *args)
 
     def log(self, level, msg, *args, **kwargs):
         if self.has_verbosity(level):
             msg_with_level = '(Level {}) {}'.format(level, msg)
             self.logger.info(msg_with_level, *args, **kwargs)
             if self.need_to_echo_log_to_stdout:
-                self._output_to_stdout_if_need('INFO: ' + msg_with_level, *args)
+                self._output_to_stdout('INFO: ' + msg_with_level, *args)
 
     def log_transformed_code(self, level, ast_node, transformer_name, *args,
                              **kwargs):
@@ -169,9 +169,9 @@ class TranslatorLogger(object):
             self.logger.info(msg, *args, **kwargs)
 
             if self.need_to_echo_code_to_stdout:
-                self._output_to_stdout_if_need('INFO: ' + msg, *args)
+                self._output_to_stdout('INFO: ' + msg, *args)
 
-    def _output_to_stdout_if_need(self, msg, *args):
+    def _output_to_stdout(self, msg, *args):
         msg = self.logger_name + ' ' + msg
         print(msg % args)
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -14,20 +14,16 @@
 
 from __future__ import print_function
 import numpy as np
-import logging
 import six
 
-from paddle.fluid import log_helper
 from paddle.fluid import framework, backward, core
 from paddle.fluid.dygraph import layers
 from paddle.fluid.dygraph.base import switch_to_static_graph
+from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.return_transformer import RETURN_NO_VALUE_MAGIC_NUM
 from paddle.fluid.layers.utils import flatten
 from paddle.fluid.layers.utils import pack_sequence_as
 import paddle.compat as cpt
-
-_logger = log_helper.get_logger(
-    __name__, logging.WARNING, fmt='%(asctime)s-%(levelname)s: %(message)s')
 
 
 class NestSequence(object):
@@ -72,7 +68,7 @@ class NestSequence(object):
                 if not isinstance(var, (framework.Variable, core.VarBase)):
                     warning_types.add(type(var))
             if warning_types:
-                _logger.warning(
+                logging_utils.warn(
                     "Output of traced function contains non-tensor type values: {}. "
                     "Currently, We don't support to update them while training and will return "
                     "what we first saw. Please try to return them as tensor.".

--- a/python/paddle/fluid/dygraph/dygraph_to_static/print_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/print_transformer.py
@@ -15,14 +15,8 @@
 from __future__ import print_function
 
 import gast
-import logging
 
-from paddle.fluid import log_helper
-from paddle.fluid.dygraph.dygraph_to_static.static_analysis import AstNodeWrapper, NodeVarType, StaticAnalysisVisitor
-from paddle.fluid.dygraph.dygraph_to_static.utils import ast_to_source_code
-
-_logger = log_helper.get_logger(
-    __name__, logging.WARNING, fmt='%(asctime)s-%(levelname)s: %(message)s')
+from paddle.fluid.dygraph.dygraph_to_static.static_analysis import AstNodeWrapper, StaticAnalysisVisitor
 
 
 class PrintTransformer(gast.NodeTransformer):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -13,17 +13,15 @@
 # limitations under the License.
 
 from __future__ import print_function
-import gast
+
 import collections
-import logging
+import gast
 import inspect
 import six
 import textwrap
 import threading
-import warnings
 import weakref
 
-import gast
 from paddle.fluid import framework
 from paddle.fluid import in_dygraph_mode
 from paddle.fluid.dygraph import layers
@@ -451,7 +449,7 @@ class StaticLayer(object):
                     format(self._function_spec))
         # If more than one programs have been cached, return the recent converted program by default.
         elif cached_program_len > 1:
-            logging.warning(
+            logging_utils.warn(
                 "Current {} has more than one cached programs: {}, the last traced progam will be return by default.".
                 format(self._function_spec, cached_program_len))
 
@@ -632,7 +630,7 @@ class ProgramCache(object):
             # Note: raise warnings if number of traced program is more than `max_tracing_count`
             current_tracing_count = len(self._caches)
             if current_tracing_count > MAX_TRACED_PROGRAM_COUNT:
-                logging.warning(
+                logging_utils.warn(
                     "Current traced program number: {} > `max_tracing_count`:{}. Too much cached programs will bring expensive overhead. "
                     "The reason may be: (1) passing tensors with different shapes, (2) passing python objects instead of tensors.".
                     format(current_tracing_count, MAX_TRACED_PROGRAM_COUNT))
@@ -804,8 +802,9 @@ class ProgramTranslator(object):
         assert callable(
             dygraph_func
         ), "Input dygraph_func is not a callable in ProgramTranslator.get_output"
+
         if not self.enable_to_static:
-            warnings.warn(
+            logging_utils.warn(
                 "The ProgramTranslator.get_output doesn't work when setting ProgramTranslator.enable to False. "
                 "We will just return dygraph output. "
                 "Please call ProgramTranslator.enable(True) if you would like to get static output."
@@ -879,8 +878,9 @@ class ProgramTranslator(object):
         assert callable(
             dygraph_func
         ), "Input dygraph_func is not a callable in ProgramTranslator.get_func"
+
         if not self.enable_to_static:
-            warnings.warn(
+            logging_utils.warn(
                 "The ProgramTranslator.get_func doesn't work when setting ProgramTranslator.enable to False. We will "
                 "just return dygraph output. Please call ProgramTranslator.enable(True) if you would like to get static output."
             )
@@ -933,8 +933,9 @@ class ProgramTranslator(object):
         assert callable(
             dygraph_func
         ), "Input dygraph_func is not a callable in ProgramTranslator.get_program"
+
         if not self.enable_to_static:
-            warnings.warn(
+            logging_utils.warn(
                 "The ProgramTranslator.get_program doesn't work when setting ProgramTranslator.enable to False."
                 "We will just return dygraph output. "
                 "Please call ProgramTranslator.enable(True) if you would like to get static output."

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -26,6 +26,7 @@ from paddle.fluid import core
 from paddle.fluid.compiler import BuildStrategy, CompiledProgram, ExecutionStrategy
 from paddle.fluid.data_feeder import check_type
 from paddle.fluid.dygraph.base import program_desc_tracing_guard, switch_to_static_graph
+from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.logging_utils import set_code_level, set_verbosity
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator, StaticLayer, unwrap_decorators
 from paddle.fluid.dygraph.io import EXTRA_VAR_INFO_FILENAME, VARIABLE_FILENAME, TranslatedLayer
@@ -120,7 +121,7 @@ def _dygraph_to_static_func_(dygraph_func):
     def __impl__(*args, **kwargs):
         program_translator = ProgramTranslator()
         if in_dygraph_mode() or not program_translator.enable_to_static:
-            warnings.warn(
+            logging_utils.warn(
                 "The decorator 'dygraph_to_static_func' doesn't work in "
                 "dygraph mode or set ProgramTranslator.enable to False. "
                 "We will just return dygraph output.")
@@ -215,7 +216,7 @@ def declarative(function=None, input_spec=None):
         if isinstance(function, Layer):
             if isinstance(function.forward, StaticLayer):
                 class_name = function.__class__.__name__
-                warnings.warn(
+                logging_utils.warn(
                     "`{}.forward` has already been decorated somewhere. It will be redecorated to replace previous one.".
                     format(class_name))
             function.forward = decorated(function.forward)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -56,12 +56,11 @@ class TestLoggingUtils(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.jit.set_verbosity(3.3)
 
-    def test_verbosity_with_stdout(self):
-        paddle.jit.set_verbosity(log_to_stdout=None)
+    def test_log_to_stdout(self):
+        logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout = None
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
 
-        paddle.jit.set_verbosity(log_to_stdout=None)
         os.environ[logging_utils.LOG_TO_STDOUT_ENV_NAME] = 'True'
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, True)
@@ -70,12 +69,21 @@ class TestLoggingUtils(unittest.TestCase):
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
 
-        # String is not supported
+        os.environ[logging_utils.LOG_TO_STDOUT_ENV_NAME] = 'True'
+        self.assertEqual(
+            logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
+
+        paddle.jit.set_code_level(log_to_stdout=True)
+        self.assertEqual(
+            logging_utils._TRANSLATOR_LOGGER.need_to_echo_code_to_stdout, True)
+
         with self.assertRaises(AssertionError):
             paddle.jit.set_verbosity(log_to_stdout=1)
 
-    def test_code_level(self):
+        with self.assertRaises(AssertionError):
+            paddle.jit.set_code_level(log_to_stdout=1)
 
+    def test_set_code_level(self):
         paddle.jit.set_code_level(None)
         os.environ[logging_utils.CODE_LEVEL_ENV_NAME] = '2'
         self.assertEqual(logging_utils.get_code_level(), 2)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -31,8 +31,8 @@ from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 #  After discuss with Tian Shuo, now use mock only in PY3, and use it in PY2 after CI installs it.
 if six.PY3:
     from unittest import mock
-else:
-    import mock
+# else:
+#     import mock
 
 
 class TestLoggingUtils(unittest.TestCase):
@@ -100,16 +100,17 @@ class TestLoggingUtils(unittest.TestCase):
         log_msg_1 = "test_log_1"
         log_msg_2 = "test_log_2"
 
-        with mock.patch.object(sys, 'stdout', stream):
-            logging_utils.warn(warn_msg)
-            logging_utils.error(error_msg)
-            self.translator_logger.verbosity_level = 1
-            logging_utils.log(1, log_msg_1)
-            logging_utils.log(2, log_msg_2)
+        if six.PY3:
+            with mock.patch.object(sys, 'stdout', stream):
+                logging_utils.warn(warn_msg)
+                logging_utils.error(error_msg)
+                self.translator_logger.verbosity_level = 1
+                logging_utils.log(1, log_msg_1)
+                logging_utils.log(2, log_msg_2)
 
-        result_msg = '\n'.join(
-            [warn_msg, error_msg, "(Level 1) " + log_msg_1, ""])
-        self.assertEqual(result_msg, stream.getvalue())
+            result_msg = '\n'.join(
+                [warn_msg, error_msg, "(Level 1) " + log_msg_1, ""])
+            self.assertEqual(result_msg, stream.getvalue())
 
     def test_log_transformed_code(self):
         source_code = "x = 3"
@@ -120,16 +121,18 @@ class TestLoggingUtils(unittest.TestCase):
         stdout_handler = logging.StreamHandler(stream)
         log.addHandler(stdout_handler)
 
-        with mock.patch.object(sys, 'stdout', stream):
-            paddle.jit.set_code_level(1)
-            logging_utils.log_transformed_code(1, ast_code,
-                                               "BasicApiTransformer")
+        if six.PY3:
+            with mock.patch.object(sys, 'stdout', stream):
+                paddle.jit.set_code_level(1)
+                logging_utils.log_transformed_code(1, ast_code,
+                                                   "BasicApiTransformer")
 
-            paddle.jit.set_code_level()
-            logging_utils.log_transformed_code(logging_utils.LOG_AllTransformer,
-                                               ast_code, "All Transformers")
+                paddle.jit.set_code_level()
+                logging_utils.log_transformed_code(
+                    logging_utils.LOG_AllTransformer, ast_code,
+                    "All Transformers")
 
-        self.assertIn(source_code, stream.getvalue())
+            self.assertIn(source_code, stream.getvalue())
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -56,32 +56,24 @@ class TestLoggingUtils(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.jit.set_verbosity(3.3)
 
-    def test_log_to_stdout(self):
+    def test_also_to_stdout(self):
         logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout = None
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
 
-        os.environ[logging_utils.LOG_TO_STDOUT_ENV_NAME] = 'True'
-        self.assertEqual(
-            logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, True)
-
-        paddle.jit.set_verbosity(log_to_stdout=False)
+        paddle.jit.set_verbosity(also_to_stdout=False)
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
 
-        os.environ[logging_utils.LOG_TO_STDOUT_ENV_NAME] = 'True'
-        self.assertEqual(
-            logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
-
-        paddle.jit.set_code_level(log_to_stdout=True)
+        paddle.jit.set_code_level(also_to_stdout=True)
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_code_to_stdout, True)
 
         with self.assertRaises(AssertionError):
-            paddle.jit.set_verbosity(log_to_stdout=1)
+            paddle.jit.set_verbosity(also_to_stdout=1)
 
         with self.assertRaises(AssertionError):
-            paddle.jit.set_code_level(log_to_stdout=1)
+            paddle.jit.set_code_level(also_to_stdout=1)
 
     def test_set_code_level(self):
         paddle.jit.set_code_level(None)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -31,8 +31,8 @@ from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 #  After discuss with Tian Shuo, now use mock only in PY3, and use it in PY2 after CI installs it.
 if six.PY3:
     from unittest import mock
-# else:
-#     import mock
+else:
+    import mock
 
 
 class TestLoggingUtils(unittest.TestCase):
@@ -100,16 +100,16 @@ class TestLoggingUtils(unittest.TestCase):
         log_msg_1 = "test_log_1"
         log_msg_2 = "test_log_2"
 
-        if six.PY3:
-            with mock.patch.object(sys, 'stdout', stream):
-                logging_utils.warn(warn_msg)
-                logging_utils.error(error_msg)
-                self.translator_logger.verbosity_level = 1
-                logging_utils.log(1, log_msg_1)
-                logging_utils.log(2, log_msg_2)
+        with mock.patch.object(sys, 'stdout', stream):
+            logging_utils.warn(warn_msg)
+            logging_utils.error(error_msg)
+            self.translator_logger.verbosity_level = 1
+            logging_utils.log(1, log_msg_1)
+            logging_utils.log(2, log_msg_2)
 
-            result_msg = '\n'.join([warn_msg, error_msg, log_msg_1, ""])
-            self.assertEqual(result_msg, stream.getvalue())
+        result_msg = '\n'.join(
+            [warn_msg, error_msg, "(Level 1) " + log_msg_1, ""])
+        self.assertEqual(result_msg, stream.getvalue())
 
     def test_log_transformed_code(self):
         source_code = "x = 3"
@@ -120,18 +120,16 @@ class TestLoggingUtils(unittest.TestCase):
         stdout_handler = logging.StreamHandler(stream)
         log.addHandler(stdout_handler)
 
-        if six.PY3:
-            with mock.patch.object(sys, 'stdout', stream):
-                paddle.jit.set_code_level(1)
-                logging_utils.log_transformed_code(1, ast_code,
-                                                   "BasicApiTransformer")
+        with mock.patch.object(sys, 'stdout', stream):
+            paddle.jit.set_code_level(1)
+            logging_utils.log_transformed_code(1, ast_code,
+                                               "BasicApiTransformer")
 
-                paddle.jit.set_code_level()
-                logging_utils.log_transformed_code(
-                    logging_utils.LOG_AllTransformer, ast_code,
-                    "All Transformers")
+            paddle.jit.set_code_level()
+            logging_utils.log_transformed_code(logging_utils.LOG_AllTransformer,
+                                               ast_code, "All Transformers")
 
-            self.assertIn(source_code, stream.getvalue())
+        self.assertIn(source_code, stream.getvalue())
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -65,6 +65,10 @@ class TestLoggingUtils(unittest.TestCase):
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
 
+        logging_utils._TRANSLATOR_LOGGER.need_to_echo_node_to_stdout = None
+        self.assertEqual(
+            logging_utils._TRANSLATOR_LOGGER.need_to_echo_code_to_stdout, False)
+
         paddle.jit.set_code_level(also_to_stdout=True)
         self.assertEqual(
             logging_utils._TRANSLATOR_LOGGER.need_to_echo_code_to_stdout, True)
@@ -89,7 +93,25 @@ class TestLoggingUtils(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.jit.set_code_level(3.3)
 
-    def test_log(self):
+    def test_log_api(self):
+        # test api for CI Converage
+        logging_utils.set_verbosity(1, True)
+
+        logging_utils.warn("warn")
+        logging_utils.error("error")
+
+        logging_utils.log(1, "log level 1")
+        logging_utils.log(2, "log level 2")
+
+        source_code = "x = 3"
+        ast_code = gast.parse(source_code)
+        logging_utils.set_code_level(1, True)
+        logging_utils.log_transformed_code(1, ast_code, "TestTransformer")
+        logging_utils.set_code_level(logging_utils.LOG_AllTransformer, True)
+        logging_utils.log_transformed_code(logging_utils.LOG_AllTransformer,
+                                           ast_code, "TestTransformer")
+
+    def test_log_message(self):
         stream = io.BytesIO() if six.PY2 else io.StringIO()
         log = self.translator_logger.logger
         stdout_handler = logging.StreamHandler(stream)
@@ -102,9 +124,9 @@ class TestLoggingUtils(unittest.TestCase):
 
         if six.PY3:
             with mock.patch.object(sys, 'stdout', stream):
+                logging_utils.set_verbosity(1, False)
                 logging_utils.warn(warn_msg)
                 logging_utils.error(error_msg)
-                self.translator_logger.verbosity_level = 1
                 logging_utils.log(1, log_msg_1)
                 logging_utils.log(2, log_msg_2)
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logging_utils.py
@@ -56,6 +56,24 @@ class TestLoggingUtils(unittest.TestCase):
         with self.assertRaises(TypeError):
             paddle.jit.set_verbosity(3.3)
 
+    def test_verbosity_with_stdout(self):
+        paddle.jit.set_verbosity(log_to_stdout=None)
+        self.assertEqual(
+            logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
+
+        paddle.jit.set_verbosity(log_to_stdout=None)
+        os.environ[logging_utils.LOG_TO_STDOUT_ENV_NAME] = 'True'
+        self.assertEqual(
+            logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, True)
+
+        paddle.jit.set_verbosity(log_to_stdout=False)
+        self.assertEqual(
+            logging_utils._TRANSLATOR_LOGGER.need_to_echo_log_to_stdout, False)
+
+        # String is not supported
+        with self.assertRaises(AssertionError):
+            paddle.jit.set_verbosity(log_to_stdout=1)
+
     def test_code_level(self):
 
         paddle.jit.set_code_level(None)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#### 1. New features: also output log or code to `sys.stdout`
  - Add parameter **`also_to_stdout`**  for API **`paddle.jit.set_verbosity`** to control whether to also output log messages to `sys.stdout`.
  - Add parameter **`also_to_stdout`**  for API **`paddle.jit.set_code_level`** to control whether to also output code to `sys.stdout`.

#### 2. Optimize log messages in dygraph-to-static
- Add logger_name `Dynamic-to-Static` in logger format so that logs about Dynamic-to-Static can be distinguished from other logs
   - Before:
   ```
   2020-09-15 11:13:18,909 WARNING: warn message ...
   ```
   After:
   ```
   2020-09-15 11:13:18,909 Dynamic-to-Static WARNING: warn message ...
   ```
- Optimization on other details

#### 3. In dygraph-to-static, use log function from `logging_utils` to make the log more standardized
Use `logging_utils.warn` to replace other warn function like `logging.warning`, ` _logger.warning` and `warnings.warn` in dygraph_to_static

---
### 优化 log 展示效果，方便区分动转静和框架其他log
#### 1. 新特性：也可以输出 log 或 code 到 `sys.stdout`
  - API  **`paddle.jit.set_verbosity`**  增加参数 **`also_to_stdout`** 控制是否也将日志信息输出到 `sys.stdout`
  - API   **`paddle.jit.set_code_level`**  增加参数 **`also_to_stdout`** 控制是否也将code信息输出到 `sys.stdout`

#### 2. 优化动转静中的 log 信息
- log 格式中，增加 logger 名称 `Dynamic-to-Static`，使得动转静 log 与框架其他 log 区分开
   - Before:
   ```
   2020-09-15 11:13:18,909 WARNING: warn message ...
   ```
   After:
   ```
   2020-09-15 11:13:18,909 Dynamic-to-Static WARNING: warn message ...
   ```
- 优化了 log 信息的一些其他细节

#### 3. 动转静的 log/warning等 统一使用 `logging_utils` 中的接口，以规范化动转静 log （动转静log 会统一 `Dynamic-to-Static` 标识，统一控制是否输出到 stdout）
本PR修改：使用`logging_utils.warn` 替代了动转静相关文件中的 warn 函数 如 `logging.warning`, ` _logger.warning` 和 `warnings.warn`

---
## 文档预览图

### set_code_level

![image](https://user-images.githubusercontent.com/33742067/93439534-4409d500-f901-11ea-8acb-2c83ed6a5795.png)

![image](https://user-images.githubusercontent.com/33742067/93435565-356cef00-f8fc-11ea-8685-893bab097600.png)

### set_verbosity

![image](https://user-images.githubusercontent.com/33742067/93439588-53891e00-f901-11ea-8d41-ab59b215a640.png)

![image](https://user-images.githubusercontent.com/33742067/93435181-a19b2300-f8fb-11ea-8ab0-64b716d1404f.png)
