### PR TITLE
seperate test_parallel_executor_pe cpu/gpu test

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_profiler.py
@@ -22,10 +22,6 @@ from paddle.fluid.tests.unittests.test_profiler import TestProfiler
 
 
 class TestPEProfiler(TestProfiler):
-    def test_cpu_profiler(self):
-        exe = fluid.Executor(fluid.CPUPlace())
-        self.net_profiler(exe, 'CPU', "Default", use_parallel_executor=True)
-
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_cuda_profiler(self):

--- a/python/paddle/fluid/tests/unittests/test_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_profiler.py
@@ -155,6 +155,10 @@ class TestProfiler(unittest.TestCase):
                 batch_range=[5, 10],
                 use_new_api=use_new_api)
 
+    def test_cpu_profiler_pe(self):
+        exe = fluid.Executor(fluid.CPUPlace())
+        self.net_profiler(exe, 'CPU', "Default", use_parallel_executor=True)
+
     @unittest.skipIf(not core.is_compiled_with_cuda(),
                      "profiler is enabled only with GPU")
     def test_cuda_profiler(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
`test_cpu_profiler`虽然是`use_parallel_executor=True`，但CPU测试并不需要独占GPU卡，因此将其拆分出来。

拆分后，在py35上效果不明显。优化前37.69sec，优化后33.17 sec