### PR TITLE
Fix bug of handling blank characters in operators.cmake

### DIFF
--- a/cmake/operators.cmake
+++ b/cmake/operators.cmake
@@ -138,12 +138,17 @@ function(op_library TARGET)
     # And for detail pybind information, please see generated paddle/pybind/pybind.h.
     file(READ ${TARGET}.cc TARGET_CONTENT)
     string(REGEX MATCH "REGISTER_OPERATOR\\(.*REGISTER_OPERATOR\\(" multi_register "${TARGET_CONTENT}")
-    string(REGEX MATCH "REGISTER_OPERATOR\\([a-z0-9_]*," one_register "${multi_register}")
+    # [ \t\r\n]* is used for blank characters
+    string(REGEX MATCH "REGISTER_OPERATOR\\([ \t\r\n]*[a-z0-9_]*," one_register "${multi_register}")
+
     if (one_register STREQUAL "")
         string(REPLACE "_op" "" TARGET "${TARGET}")
     else ()
         string(REPLACE "REGISTER_OPERATOR(" "" TARGET "${one_register}")
         string(REPLACE "," "" TARGET "${TARGET}")
+        # [ \t\r\n]+ is used for blank characters.
+        # Here we use '+' instead of '*' since it is a REPLACE operation.
+        string(REGEX REPLACE "[ \t\r\n]+" "" TARGET "${TARGET}")
     endif()
 
     # pybind USE_NO_KERNEL_OP


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix bug of handling blank characters in operators.cmake

Paddle automatically add `USE_OP`(or `USE_OP_DEVICE_KERNEL`) for each operator target to `pybind.h` during `running cmake` (to avoid the operator registrar being removed from the generated binary file by the linker).

The approach is to extract `REGISTER_OPERAOR(` using regex for the source file of each operator, like `xx_op.cc`, and find the first registered operator.

However, the original implementation did not handle `blank characters`, which may result in errors, link https://github.com/PaddlePaddle/Paddle/pull/27112#issuecomment-691941000.

The problem is, due to `code formatting`, the `REGISTER_OPERATOR(xxx` may be separated into two lines. 
For example, `elementwise_add_grad` and `elementwise_add_grad_grad` in `elementwise_add_op.cc`.
```
REGISTER_OPERATOR(
    elementwise_add_grad, ops::ElementwiseOpGrad,
    ops::ElementwiseGradOpInplaceInferer, ops::ElementwiseGradNoBufVarsInferer,
    ops::ElementwiseAddDoubleGradMaker<paddle::framework::OpDesc>,
    ops::ElementwiseAddDoubleGradMaker<paddle::imperative::OpBase>);

REGISTER_OPERATOR(elementwise_add_grad_grad,
                  ops::ElementwiseOpDoubleGradWithoutDXDY,
                  ops::ElementwiseDoubleGradOpInplaceInferer,
                  ops::ElementwiseDoubleGradNoBufVarsInferer);
```
Since the `REGISTER_OPERATOR(elementwise_add_grad, ...)` is separated into two lines, the regex will match `elementwise_add_grad_grad`.
 And, since `elementwise_add_mkldnn_op.cc` is present, a line `USE_OP_DEVICE_KERNEL(elementwise_add_grad_grad, MKLDNN)` will be added to `pybind.h`, which results in https://github.com/PaddlePaddle/Paddle/pull/27112#issuecomment-691941000.

This PR fixes that.