### PR TITLE
Add conv2d bfloat16 support

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1895,7 +1895,7 @@ PDNode *patterns::QuantizePlacement::operator()(
 PDNode *patterns::Bfloat16Placement::operator()(
     const std::unordered_set<std::string> &bfloat16_enabled_op_types) {
   std::unordered_set<std::string> supported_op_types =
-      std::unordered_set<std::string>();
+      std::unordered_set<std::string>({"conv2d"});
   if (!bfloat16_enabled_op_types.empty()) {
     supported_op_types = bfloat16_enabled_op_types;
   }

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1894,7 +1894,7 @@ PDNode *patterns::QuantizePlacement::operator()(
 
 PDNode *patterns::Bfloat16Placement::operator()(
     const std::unordered_set<std::string> &bfloat16_enabled_op_types) {
-  std::unordered_set<std::string> supported_op_types {"conv2d"};
+  std::unordered_set<std::string> supported_op_types{"conv2d"};
   if (!bfloat16_enabled_op_types.empty()) {
     supported_op_types = bfloat16_enabled_op_types;
   }

--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -1894,8 +1894,7 @@ PDNode *patterns::QuantizePlacement::operator()(
 
 PDNode *patterns::Bfloat16Placement::operator()(
     const std::unordered_set<std::string> &bfloat16_enabled_op_types) {
-  std::unordered_set<std::string> supported_op_types =
-      std::unordered_set<std::string>({"conv2d"});
+  std::unordered_set<std::string> supported_op_types {"conv2d"};
   if (!bfloat16_enabled_op_types.empty()) {
     supported_op_types = bfloat16_enabled_op_types;
   }

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -166,7 +166,8 @@ framework::OpKernelType ConvOp::GetExpectedKernelType(
 #endif
 
   if (input_data_type != framework::proto::VarType::INT8 &&
-      input_data_type != framework::proto::VarType::UINT8) {
+      input_data_type != framework::proto::VarType::UINT8 &&
+      input_data_type != framework::proto::VarType::BF16) {
     auto filter_data_type = ctx.Input<Tensor>("Filter")->type();
     PADDLE_ENFORCE_EQ(input_data_type, filter_data_type,
                       platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -451,6 +451,11 @@ void Conv3DOpMaker::Make() {
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
+  AddAttr<std::string>(
+      "mkldnn_data_type",
+      "(string, default \"float32\"). Data type of mkldnn kernel")
+      .SetDefault("float32")
+      .InEnum({"float32", "int8", "bfloat16"});
   AddAttr<bool>("fuse_relu", "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
   AddAttr<std::string>("fuse_activation",

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -51,14 +51,14 @@ inline MKLDNNMemoryFormat GetWeightsFormat(const MKLDNNMemoryFormat format,
   }
 }
 
-static mkldnn::memory::data_type GetDstType(std::string mkldnn_data_type,
+static mkldnn::memory::data_type GetDstType(bool is_int8, bool is_bfloat16,
                                             bool force_fp32_output,
                                             std::string fuse_activation,
                                             bool fuse_residual_conn,
                                             const Tensor* residual_param) {
   auto dst_dt =
       mkldnn::memory::data_type::f32;  // uint8_t, int8_t, float, bfloat16
-  if (mkldnn_data_type == "int8") {
+  if (is_int8) {
     dst_dt = (fuse_activation == "relu" || fuse_activation == "relu6")
                  ? mkldnn::memory::data_type::u8
                  : mkldnn::memory::data_type::s8;
@@ -70,7 +70,7 @@ static mkldnn::memory::data_type GetDstType(std::string mkldnn_data_type,
       if (dst_dt != residual_dt) dst_dt = residual_dt;
     }
   } else {
-    if (!force_fp32_output && mkldnn_data_type == "bfloat16") {
+    if (!force_fp32_output && is_bfloat16) {
       dst_dt = mkldnn::memory::data_type::bf16;
       if (fuse_residual_conn && residual_param) {
         dst_dt = framework::ToMKLDNNDataType(residual_param->type());
@@ -389,16 +389,17 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     PADDLE_ENFORCE_EQ(platform::is_cpu_place(ctx.GetPlace()), true,
                       paddle::platform::errors::PreconditionNotMet(
                           "Operator DNNL Conv must use CPUPlace"));
-
-    std::string mkldnn_data_type = ctx.Attr<std::string>("mkldnn_data_type");
+    bool is_INT8 =
+        std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value;
+    bool is_BFLOAT16 = ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16";
     auto residual_param = ctx.Input<Tensor>("ResidualData");
     bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
     std::string fuse_activation = ctx.Attr<std::string>("fuse_activation");
     bool force_fp32_output = ctx.Attr<bool>("force_fp32_output");
 
-    if (mkldnn_data_type != "int8") {
+    if (!is_INT8) {
       auto dst_dt =
-          GetDstType(mkldnn_data_type, force_fp32_output, fuse_activation,
+          GetDstType(false, is_BFLOAT16, force_fp32_output, fuse_activation,
                      fuse_residual_conn, residual_param);
       if (dst_dt == mkldnn::memory::data_type::f32) {
         ComputeFP32<float>(ctx);
@@ -407,7 +408,7 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
       }
     } else {
       auto dst_dt =
-          GetDstType(mkldnn_data_type, force_fp32_output, fuse_activation,
+          GetDstType(true, false, force_fp32_output, fuse_activation,
                      fuse_residual_conn, residual_param);
       if (dst_dt == mkldnn::memory::data_type::f32) {
         ComputeINT8<float>(ctx);

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -396,8 +396,8 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
     std::string fuse_activation = ctx.Attr<std::string>("fuse_activation");
     bool force_fp32_output = ctx.Attr<bool>("force_fp32_output");
     auto dst_dt =
-          GetDstType(is_INT8, is_BFLOAT16, force_fp32_output, fuse_activation,
-                     fuse_residual_conn, residual_param);
+        GetDstType(is_INT8, is_BFLOAT16, force_fp32_output, fuse_activation,
+                   fuse_residual_conn, residual_param);
     if (!is_INT8) {
       if (dst_dt == mkldnn::memory::data_type::f32) {
         ComputeFP32<float>(ctx);

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -407,9 +407,8 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
         ComputeFP32<platform::bfloat16>(ctx);
       }
     } else {
-      auto dst_dt =
-          GetDstType(true, false, force_fp32_output, fuse_activation,
-                     fuse_residual_conn, residual_param);
+      auto dst_dt = GetDstType(true, false, force_fp32_output, fuse_activation,
+                               fuse_residual_conn, residual_param);
       if (dst_dt == mkldnn::memory::data_type::f32) {
         ComputeINT8<float>(ctx);
       } else if (dst_dt == mkldnn::memory::data_type::u8) {

--- a/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
@@ -110,4 +110,6 @@ class DeQuantOpKernel : public framework::OpKernel<T> {
 namespace ops = paddle::operators;
 
 REGISTER_OP_KERNEL(dequantize, MKLDNN, ::paddle::platform::CPUPlace,
-                   ops::DeQuantOpKernel<uint8_t>, ops::DeQuantOpKernel<int8_t>);
+                   ops::DeQuantOpKernel<uint8_t>, ops::DeQuantOpKernel<int8_t>,
+                   ops::DeQuantOpKernel<paddle::platform::bfloat16>,
+                   ops::DeQuantOpKernel<float>);

--- a/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/dequantize_mkldnn_op.cc
@@ -111,5 +111,4 @@ namespace ops = paddle::operators;
 
 REGISTER_OP_KERNEL(dequantize, MKLDNN, ::paddle::platform::CPUPlace,
                    ops::DeQuantOpKernel<uint8_t>, ops::DeQuantOpKernel<int8_t>,
-                   ops::DeQuantOpKernel<paddle::platform::bfloat16>,
-                   ops::DeQuantOpKernel<float>);
+                   ops::DeQuantOpKernel<paddle::platform::bfloat16>);

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -41,6 +41,7 @@ namespace detail {
 // import numpy as np
 // print np.dtype(np.float16).num  # 23
 constexpr int NPY_FLOAT16_ = 23;
+constexpr int NPY_UINT16_ = 4;
 
 // Note: Since float16 is not a builtin type in C++, we register
 // paddle::platform::float16 as numpy.float16.
@@ -58,6 +59,23 @@ struct npy_format_descriptor<paddle::platform::float16> {
     return "e";
   }
   static PYBIND11_DESCR name() { return _("float16"); }
+};
+
+// Note: Since bfloat16 is not a builtin type in C++ and in numpy,
+// we register paddle::platform::bfloat16 as numpy.uint16.
+template <>
+struct npy_format_descriptor<paddle::platform::bfloat16> {
+  static py::dtype dtype() {
+    handle ptr = npy_api::get().PyArray_DescrFromType_(NPY_UINT16_);
+    return reinterpret_borrow<py::dtype>(ptr);
+  }
+  static std::string format() {
+    // Note: "H" represents UINT16.
+    // Details at:
+    // https://docs.python.org/3/library/struct.html#format-characters.
+    return "H";
+  }
+  static PYBIND11_DESCR name() { return _("bfloat16"); }
 };
 
 }  // namespace detail

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -603,7 +603,7 @@ def convert_np_dtype_to_dtype_(np_dtype):
     elif dtype == np.bool:
         return core.VarDesc.VarType.BOOL
     elif dtype == np.uint16:
-        return core.VarDesc.VarType.INT16
+        return core.VarDesc.VarType.BF16
     elif dtype == np.uint8:
         return core.VarDesc.VarType.UINT8
     elif dtype == np.int8:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -603,6 +603,8 @@ def convert_np_dtype_to_dtype_(np_dtype):
     elif dtype == np.bool:
         return core.VarDesc.VarType.BOOL
     elif dtype == np.uint16:
+        # since there is still no support for bfloat16 in NumPy,
+        # uint16 is used for casting bfloat16
         return core.VarDesc.VarType.BF16
     elif dtype == np.uint8:
         return core.VarDesc.VarType.UINT8

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -1,0 +1,211 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import struct
+
+import paddle.fluid.core as core
+from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci, convert_float_to_uint16
+from paddle.fluid.tests.unittests.test_conv2d_op import conv2d_forward_naive, TestConv2dOp
+
+
+@skip_check_grad_ci(
+    reason="The function 'check_grad' for large inputs is too slow.")
+def conv2d_forward_refer(input, filter, group, conv_param):
+    out, in_n, out_h, out_w, out_c = conv2d_forward_naive(input, filter, group,
+                                                          conv_param)
+    return out
+
+
+def conv2d_residual_naive(out, residual):
+    assert out.shape == residual.shape
+    out = np.add(out, residual)
+    return out
+
+
+class TestConv2dBf16Op(TestConv2dOp):
+    def setUp(self):
+        self.op_type = "conv2d"
+        self.use_cudnn = False
+        self.exhaustive_search = False
+        self.use_cuda = False
+        self.use_mkldnn = True
+        self.weight_type = np.float32
+        self.input_type = np.float32
+        self.use_mkldnn = True
+        self.mkldnn_data_type = "bfloat16"
+        self.force_fp32_output = False
+        self.init_group()
+        self.init_dilation()
+        self.init_test_case()
+        self.init_fuse_relu()
+        self.init_fuse_residual()
+        self.init_data_type()
+        self.init_force_fp32_output()
+
+        conv2d_param = {
+            'stride': self.stride,
+            'pad': self.pad,
+            'dilation': self.dilations
+        }
+        self.input = np.random.random(self.input_size).astype(np.float32)
+        self.filter = np.random.random(self.filter_size).astype(np.float32)
+        conv_out, _, _, _, _ = conv2d_forward_naive(self.input, self.filter,
+                                                    self.groups, conv2d_param)
+        self.conv_output_float = conv_out
+
+        if self.fuse_residual:
+            self.input_residual = np.random.random(
+                self.input_residual_size).astype(np.float32)
+            self.conv_output_float = conv2d_residual_naive(
+                self.conv_output_float, self.input_residual)
+            self.conv_output = convert_float_to_uint16(self.conv_output_float)
+            self.outputs = {'Output': self.conv_output}
+        elif self.force_fp32_output:
+            self.outputs = {'Output': self.conv_output_float.astype(np.float32)}
+
+        if self.input_type is not np.float32:
+            self.input = convert_float_to_uint16(self.input)
+
+        self.inputs = {
+            'Input': self.input.view(self.input_type),
+            'Filter': OpTest.np_dtype_to_fluid_dtype(
+                self.filter.astype(self.weight_type))
+        }
+
+        if self.fuse_residual:
+            self.inputs['ResidualData'] = OpTest.np_dtype_to_fluid_dtype(
+                convert_float_to_uint16(self.input_residual))
+
+        self.attrs = {
+            'strides': self.stride,
+            'paddings': self.pad,
+            'groups': self.groups,
+            'dilations': self.dilations,
+            'use_cudnn': self.use_cudnn,
+            'use_mkldnn': self.use_mkldnn,
+            'mkldnn_data_type': self.mkldnn_data_type,
+            'force_fp32_output': self.force_fp32_output,
+            'fuse_residual_connection': self.fuse_residual
+        }
+
+    def test_check_output(self):
+        self.check_output_with_place(
+            core.CPUPlace(), atol=2, check_dygraph=False)
+
+    def test_check_grad(self):
+        pass
+
+    def test_check_grad_no_filter(self):
+        pass
+
+    def test_check_grad_no_input(self):
+        pass
+
+    def init_test_case(self):
+        TestConv2dOp.init_test_case(self)
+        self.input_size = [1, 1, 5, 5]  # NCHW
+        f_c = self.input_size[1] // self.groups
+        self.input_residual_size = [1, 2, 3, 3]
+        self.filter_size = [2, f_c, 3, 3]
+
+    def init_data_type(self):
+        self.weight_type = np.float32
+        self.input_type = np.float32
+
+    def init_force_fp32_output(self):
+        self.force_fp32_output = False
+
+    def init_fuse_relu(self):
+        self.fuse_activation = "relu"
+
+    def init_fuse_residual(self):
+        self.fuse_residual = True
+
+
+class TestConv2d(TestConv2dBf16Op):
+    def init_test_case(self):
+        self.pad = [0, 0]
+        self.stride = [1, 1]
+        self.input_size = [2, 3, 5, 5]  # NCHW
+        self.input_residual_size = [2, 6, 3, 3]
+        assert np.mod(self.input_size[1], self.groups) == 0
+        f_c = self.input_size[1] // self.groups
+        self.filter_size = [6, f_c, 3, 3]
+
+    def init_data_type(self):
+        self.input_type = np.uint16
+
+
+class TestWithPad(TestConv2d):
+    def init_test_case(self):
+        TestConv2d.init_test_case(self)
+        self.pad = [1, 1]
+        self.input_residual_size = [2, 6, 5, 5]
+
+
+class TestWithGroup(TestConv2d):
+    def init_group(self):
+        self.groups = 3
+
+
+class TestWithStride(TestConv2dBf16Op):
+    def init_test_case(self):
+        self.pad = [1, 1]
+        self.stride = [2, 2]
+        self.input_size = [2, 3, 6, 6]
+        self.input_residual_size = [2, 6, 3, 3]
+        assert np.mod(self.input_size[1], self.groups) == 0
+        f_c = self.input_size[1] // self.groups
+        self.filter_size = [6, f_c, 3, 3]
+
+    def init_data_type(self):
+        self.input_type = np.uint16
+
+
+class TestWith1x1ForceFP32Output(TestConv2dBf16Op):
+    def init_test_case(self):
+        self.pad = [0, 0]
+        self.stride = [1, 1]
+        self.input_size = [1, 3, 5, 5]
+        assert np.mod(self.input_size[1], self.groups) == 0
+        f_c = self.input_size[1] // self.groups
+        self.filter_size = [6, f_c, 1, 1]
+
+    def init_force_fp32_output(self):
+        self.force_fp32_output = True
+
+    def init_fuse_residual(self):
+        self.fuse_residual = False
+
+
+class TestWithInput1x1Filter1x1(TestConv2dBf16Op):
+    def init_test_case(self):
+        self.pad = [0, 0]
+        self.stride = [1, 1]
+        self.input_size = [2, 3, 1, 1]
+        self.input_residual_size = [2, 6, 1, 1]
+        assert np.mod(self.input_size[1], self.groups) == 0
+        f_c = self.input_size[1] // self.groups
+        self.filter_size = [6, f_c, 1, 1]
+
+    def init_group(self):
+        self.groups = 3
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -35,8 +35,6 @@ def conv2d_residual_naive(out, residual):
     return out
 
 
-@skip_check_grad_ci(
-    reason="Grad check is meaningless because Grad Op BF16 is not registered")
 class TestConv2dBf16Op(TestConv2dOp):
     def setUp(self):
         self.op_type = "conv2d"
@@ -104,10 +102,7 @@ class TestConv2dBf16Op(TestConv2dOp):
         }
 
     def test_check_output(self):
-        self.check_output_with_place(
-            core.CPUPlace(),
-            atol=1e-2 if self.force_fp32_output else 2,
-            check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace())
 
     def test_check_grad(self):
         pass

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -23,8 +23,6 @@ from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci, con
 from paddle.fluid.tests.unittests.test_conv2d_op import conv2d_forward_naive, TestConv2dOp
 
 
-@skip_check_grad_ci(
-    reason="The function 'check_grad' for large inputs is too slow.")
 def conv2d_forward_refer(input, filter, group, conv_param):
     out, in_n, out_h, out_w, out_c = conv2d_forward_naive(input, filter, group,
                                                           conv_param)
@@ -37,6 +35,8 @@ def conv2d_residual_naive(out, residual):
     return out
 
 
+@skip_check_grad_ci(
+    reason="Grad check is meaningless because Grad Op BF16 is not registered")
 class TestConv2dBf16Op(TestConv2dOp):
     def setUp(self):
         self.op_type = "conv2d"

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -105,7 +105,9 @@ class TestConv2dBf16Op(TestConv2dOp):
 
     def test_check_output(self):
         self.check_output_with_place(
-            core.CPUPlace(), atol=2, check_dygraph=False)
+            core.CPUPlace(),
+            atol=1e-2 if self.force_fp32_output else 2,
+            check_dygraph=False)
 
     def test_check_grad(self):
         pass

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
@@ -36,6 +36,7 @@ class TestConv2dInt8Op(TestConv2dOp):
         self.use_cuda = False
         self.use_mkldnn = False
         self.data_format = "NCHW"
+        self.mkldnn_data_type = "int8"
         self.weighttype = np.float32
         self.use_mkldnn = True
         self.init_group()
@@ -141,7 +142,8 @@ class TestConv2dInt8Op(TestConv2dOp):
             'Scale_weights': self.scale_weights,
             'Scale_in_eltwise': self.scale_in_eltwise,
             'fuse_activation': self.fuse_activation,
-            'fuse_residual_connection': self.fuse_residual
+            'fuse_residual_connection': self.fuse_residual,
+            'mkldnn_data_type': self.mkldnn_data_type
         }
         self.outputs = {'Output': output}
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from paddle.fluid.tests.unittests.op_test import OpTest
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 
 
 class TestDeQuantizeOp(OpTest):
@@ -32,6 +32,9 @@ class TestDeQuantizeOp(OpTest):
             input = (np.random.randint(0, 100, self.input_size) - 50
                      ).astype(self.data_type)
             output = (input * (1 / self.scale)).astype('float')
+        elif self.data_type == 'uint16':
+            output = np.random.random(self.input_size).astype(np.float32)
+            input = convert_float_to_uint16(output)
         else:
             input = (np.random.randint(0, 100,
                                        self.input_size)).astype(self.data_type)
@@ -68,6 +71,17 @@ class TestDeQuantizeOp2(TestDeQuantizeOp):
 
     def set_data_type(self):
         self.data_type = 'uint8'
+
+
+class TestDeQuantizeOpBf16(TestDeQuantizeOp):
+    def test_check_output(self):
+        self.check_output(atol=1e-2, check_dygraph=False)
+
+    def set_scale(self):
+        self.scale = 1.0
+
+    def set_data_type(self):
+        self.data_type = 'uint16'
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
@@ -74,9 +74,6 @@ class TestDeQuantizeOp2(TestDeQuantizeOp):
 
 
 class TestDeQuantizeOpBf16(TestDeQuantizeOp):
-    def test_check_output(self):
-        self.check_output(atol=1e-2, check_dygraph=False)
-
     def set_scale(self):
         self.scale = 1.0
 

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -20,6 +20,7 @@ import warnings
 import numpy as np
 import random
 import six
+import struct
 import time
 import itertools
 import collections
@@ -167,6 +168,22 @@ def skip_check_grad_ci(reason=None):
     return wrapper
 
 
+def copy_bits_from_float_to_uint16(f):
+    return struct.unpack('<I', struct.pack('<f', f))[0] >> 16
+
+
+def convert_float_to_uint16(float_list):
+    new_output = []
+    for first in float_list:
+        for second in first:
+            for third in second:
+                for fourth in third:
+                    new_output.append(
+                        np.uint16(copy_bits_from_float_to_uint16(fourth)))
+
+    return np.reshape(new_output, float_list.shape).view(np.uint16)
+
+
 class OpTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -276,8 +293,9 @@ class OpTest(unittest.TestCase):
         infer_dtype(inputs, dtype_set)
         dtype_list = [
             np.dtype(np.float64), np.dtype(np.float32), np.dtype(np.float16),
-            np.dtype(np.int64), np.dtype(np.int32), np.dtype(np.int16),
-            np.dtype(np.int8), np.dtype(np.uint8), np.dtype(np.bool)
+            np.dtype(np.int64), np.dtype(np.int32), np.dtype(np.uint16),
+            np.dtype(np.int16), np.dtype(np.int8), np.dtype(np.uint8),
+            np.dtype(np.bool)
         ]
         # check the dtype in dtype_list in order, select the first dtype that in dtype_set
         for dtype in dtype_list:

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -260,8 +260,9 @@ class OpTest(unittest.TestCase):
             self.dtype = data_type
 
     def is_bfloat16_op(self):
-        return (hasattr(self, 'mkldnn_data_type') and
-                getattr(self, 'mkldnn_data_type') is "bfloat16")
+        return self.dtype == np.uint16 or (
+            hasattr(self, 'mkldnn_data_type') and
+            getattr(self, 'mkldnn_data_type') is "bfloat16")
 
     def infer_dtype_from_inputs_outputs(self, inputs, outputs):
         def is_np_data(input):

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -174,12 +174,8 @@ def copy_bits_from_float_to_uint16(f):
 
 def convert_float_to_uint16(float_list):
     new_output = []
-    for first in float_list:
-        for second in first:
-            for third in second:
-                for fourth in third:
-                    new_output.append(
-                        np.uint16(copy_bits_from_float_to_uint16(fourth)))
+    for x in np.nditer(float_list):
+        new_output.append(np.uint16(copy_bits_from_float_to_uint16(x)))
 
     return np.reshape(new_output, float_list.shape).view(np.uint16)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
This PR presents:
- fix pybind conversion from uint16 to bfloat16. Numpy doesn't support bfloat16 data type, so in python bfloat16 is represented by uint16. In UT all operations can be done on float32 and then using `convert_float32_to_uint16`  from `OpTest` converted to uint16.
- conv2d and dequantize bfloat16 support with unit tests. In both unit tests `atol` in check output is changed, because we compare native convolution that was calculated on float32 with conv2d bf16 kernel that was calculated on bfloat16. 

>  When the output from the convolution is:
> - bfloat16, in Python we get uint16 data type, so `atol = 2`
> - float32, so `atol = 1e-2` 
> 