### PR TITLE
python2 of windows don't need to install netifaces

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -20,4 +20,5 @@ prettytable
 objgraph
 astor
 pathlib
-netifaces
+netifaces ; platform_system != "Windows"
+netifaces ; python_version>="3.5" and platform_system == "Windows"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

python2 for windows not install netifaces, because windows don't have distribution now. 

``netifaces`` must use Visual C++ tools for python2 windows. It can be remove in python2 windows.
https://www.microsoft.com/en-us/download/details.aspx?id=44266