### PR TITLE
Remove inplace argument when calling nn.reshape()

### DIFF
--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -416,7 +416,7 @@ class DataParallel(layers.Layer):
                 g_var_shapes.append(g_var.shape)
                 flattened_vars.append(
                     nn.reshape(
-                        x=g_var, shape=[np.prod(g_var.shape)], inplace=True))
+                        x=g_var, shape=[np.prod(g_var.shape)]))
             coalesced_grad = nn.concat(flattened_vars)
             coalesced_grads_and_grad_vars.append(
                 [coalesced_grad, grad_vars, g_var_shapes])

--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -1736,7 +1736,7 @@ def npair_loss(anchor, positive, labels, l2_reg=0.002):
     Beta = 0.25
     batch_size = labels.shape[0]
 
-    labels = nn.reshape(labels, shape=[batch_size, 1], inplace=True)
+    labels = nn.reshape(labels, shape=[batch_size, 1])
     labels = nn.expand(labels, expand_times=[1, batch_size])
 
     labels = equal(labels, nn.transpose(labels, perm=[1, 0])).astype('float32')

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6103,7 +6103,7 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
         .. code-block:: python
 
             import paddle.fluid as fluid
-
+            paddle.enable_static()
             # example 1:
             # attr shape is a list which doesn't contain Tensors.
             data_1 = fluid.data(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6101,9 +6101,11 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
 
     Examples:
         .. code-block:: python
-
+            
+            import paddle
             import paddle.fluid as fluid
             paddle.enable_static()
+            
             # example 1:
             # attr shape is a list which doesn't contain Tensors.
             data_1 = fluid.data(

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6109,7 +6109,7 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             data_1 = fluid.data(
               name='data_1', shape=[2, 4, 6], dtype='float32')
             reshaped_1 = fluid.layers.reshape(
-              x=data_1, shape=[-1, 0, 3, 2], inplace=True)
+              x=data_1, shape=[-1, 0, 3, 2])
             # the shape of reshaped_1 is [2,4,3,2].
 
             # example 2:

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -363,7 +363,7 @@ def roll(x, shifts, axis=None, name=None):
         outputs={'Out': out},
         attrs={'axis': axis,
                'shifts': shifts})
-    out = layers.reshape(out, shape=origin_shape, inplace=True)
+    out = layers.reshape(out, shape=origin_shape)
     return out
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Remove inplace argument when calling `fluid.layers.reshape()`

There are 2 reasons,

1. `fluid.layers.reshape()` do not support inplace in dygraph mode, while dygraph will be default in Paddle-2.0. So we need to avoid annoying warnings in Paddle-2.0 as follows.

![image](https://user-images.githubusercontent.com/6888866/93426136-064f8100-f8ee-11ea-9638-c71815e182f9.png)

2. `fluid.layers.reshape(inplace=True)` will be replace by  `BufferSharedIdentityInplaceOpPass`, see details in #25900