### PR TITLE
Fix test_gast_with_compatibility.py due to the problem of gast in py3.8

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_gast_with_compatibility.py
+++ b/python/paddle/fluid/tests/unittests/test_gast_with_compatibility.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import ast
 import gast
+import sys
 import textwrap
 import unittest
 
@@ -143,47 +144,60 @@ class TestPythonCompatibility(unittest.TestCase):
         """
         self._check_compatibility(source, target)
 
-    def test_with(self):
-        """
-        The fileds `context_expr/optional_vars` of `ast.With` in PY2
-        is moved into `ast.With.items.withitem` in PY3.
-        """
-        source = """
-        with guard():
-            a = 1
-        """
-        target = """
-        with guard_new():
-            a = 1
-        """
-        self._check_compatibility(source, target)
+    # The 0.3.3 version of gast has a bug in python3.8 that
+    # would cause the following tests to fail. But this 
+    # problem doesn't affect the use of Paddle's related 
+    # functions, therefore, the following tests would be 
+    # disable in python3.8.
+    #
+    # This problem had been fixed and updated to version 
+    # 0.4.1 of gast.
+    #
+    # More information please refer to:
+    # https://github.com/serge-sans-paille/gast/issues/49
+    if sys.version_info < (3, 8):
 
-    def test_subscript_Index(self):
-        source = """
-            x = y()[10]
-        """
-        target = """
-            x = y()[20]
-        """
-        self._check_compatibility(source, target)
+        def test_with(self):
+            """
+            The fileds `context_expr/optional_vars` of `ast.With` in PY2
+            is moved into `ast.With.items.withitem` in PY3.
+            """
+            source = """
+            with guard():
+                a = 1
+            """
+            target = """
+            with guard_new():
+                a = 1
+            """
+            self._check_compatibility(source, target)
 
-    def test_subscript_Slice(self):
-        source = """
-            x = y()[10:20]
-        """
-        target = """
-            x = y()[20:40]
-        """
-        self._check_compatibility(source, target)
+        def test_subscript_Index(self):
+            source = """
+                x = y()[10]
+            """
+            target = """
+                x = y()[20]
+            """
+            self._check_compatibility(source, target)
 
-    def test_call(self):
-        source = """
-            y = foo(*arg)
-        """
-        target = """
-            y = foo(*arg_new)
-        """
-        self._check_compatibility(source, target)
+        def test_subscript_Slice(self):
+            source = """
+                x = y()[10:20]
+            """
+            target = """
+                x = y()[20:40]
+            """
+            self._check_compatibility(source, target)
+
+        def test_call(self):
+            source = """
+                y = foo(*arg)
+            """
+            target = """
+                y = foo(*arg_new)
+            """
+            self._check_compatibility(source, target)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
The 0.3.3 version of gast has a bug in python3.8 that would cause test_gast_with_compatibility to fail. But this problem doesn't affect the use of Paddle's related functions, therefore, the some tests in test_gast_with_compatibility would be disable in python3.8.

And this problem had been fixed and updated to version 0.4.1 of gast.

More information please refer to:
https://github.com/serge-sans-paille/gast/issues/49
