### PR TITLE
fleetrun: add endpoints log for details

### DIFF
--- a/python/paddle/distributed/fleet/launch.py
+++ b/python/paddle/distributed/fleet/launch.py
@@ -463,9 +463,8 @@ def launch():
         cuda_device_num = 0
 
     if len(has_ps_args) > 0 or cuda_device_num == 0:
-        logger.info(
-            "Run parameter-sever cpu mode. pserver arguments:{}, cuda count:{}".
-            format(has_ps_args, cuda_device_num))
+        logger.info("Run parameter-sever cpu mode. pserver arguments:{}".format(
+            has_ps_args))
         launch_ps(args)
     elif len(has_collective_args) > 0:
         logger.info("Run collective gpu mode. gpu arguments:{}, cuda count:{}".

--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -435,9 +435,17 @@ def start_local_trainers(cluster,
                             len(pod.trainers),
                             pretty_print_envs(proc_env, ("Distributed Envs",
                                                          "Value"))))
+            logger.info(
+                "details abouts PADDLE_TRAINER_ENDPOINTS can be found in {}/endpoints.log.".
+                format(log_dir))
         fn = None
         if log_dir is not None:
             os.system("mkdir -p {}".format(log_dir))
+            if os.path.exists("%s/endpoints.log" % log_dir):
+                os.system("rm -f {}/endpoints.log".format(log_dir))
+            with open("%s/endpoints.log" % log_dir, "w") as f:
+                f.write("PADDLE_TRAINER_ENDPOINTS: \n")
+                f.write("\n".join(cluster.trainers_endpoints()))
             fn = open("%s/workerlog.%d" % (log_dir, idx), "a")
             proc = subprocess.Popen(cmd, env=current_env, stdout=fn, stderr=fn)
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fleetrun: add endpoints log for details

after fixed:
```
-----------  Configuration Arguments -----------
gpus: None
ips: 127.0.0.1
log_dir: log
server_num: None
servers:
training_script: fleetrun_demo.py
training_script_args: []
worker_num: None
workers:
------------------------------------------------
WARNING 2020-09-21 11:42:33,790 launch.py:476] Not found distinct arguments. Default use gpu collective mode
INFO 2020-09-21 11:42:33,792 launch_utils.py:437] Local start 4 processes. First process distributed environment info (Only For Debug):
    +=======================================================================================+
    |                        Distributed Envs                      Value                    |
    +---------------------------------------------------------------------------------------+
    |                 PADDLE_CURRENT_ENDPOINT                 127.0.0.1:23008               |
    |                     PADDLE_TRAINERS_NUM                        4                      |
    |                     FLAGS_selected_gpus                        0                      |
    |                PADDLE_TRAINER_ENDPOINTS  ... 0.1:26420,127.0.0.1:27405,127.0.0.1:10590|
    |                       PADDLE_TRAINER_ID                        0                      |
    +=======================================================================================+

INFO 2020-09-21 11:42:33,793 launch_utils.py:438] details abouts PADDLE_TRAINER_ENDPOINTS can be found in log/endpoints.log.
```

log/endpoints.log:
```
PADDLE_TRAINER_ENDPOINTS:
127.0.0.1:23008
127.0.0.1:26420
127.0.0.1:27405
127.0.0.1:10590
```