### PR TITLE
Use dygraph mode by default

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -277,8 +277,4 @@ from .hapi import summary
 import paddle.text
 import paddle.vision
 
-try:
-    disable_static()
-
-except Exception as e:
-    raise e
+disable_static()

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -276,3 +276,9 @@ from .hapi import callbacks
 from .hapi import summary
 import paddle.text
 import paddle.vision
+
+try:
+    disable_static()
+
+except Exception as e:
+    raise e

--- a/python/paddle/fluid/contrib/slim/tests/convert_model2dot.py
+++ b/python/paddle/fluid/contrib/slim/tests/convert_model2dot.py
@@ -19,6 +19,9 @@ import argparse
 import paddle.fluid as fluid
 from paddle.fluid.framework import IrGraph
 from paddle.fluid import core
+import paddle
+
+paddle.enable_static()
 
 
 def parse_args():

--- a/python/paddle/fluid/contrib/slim/tests/quant2_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/quant2_int8_image_classification_comparison.py
@@ -27,6 +27,8 @@ from paddle.fluid.framework import IrGraph
 from paddle.fluid.contrib.slim.quantization import Quant2Int8MkldnnPass
 from paddle.fluid import core
 
+paddle.enable_static()
+
 logging.basicConfig(format='%(asctime)s-%(levelname)s: %(message)s')
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)

--- a/python/paddle/fluid/contrib/slim/tests/quant2_int8_nlp_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/quant2_int8_nlp_comparison.py
@@ -25,6 +25,8 @@ from paddle.fluid.framework import IrGraph
 from paddle.fluid.contrib.slim.quantization import Quant2Int8MkldnnPass
 from paddle.fluid import core
 
+paddle.enable_static()
+
 logging.basicConfig(format='%(asctime)s-%(levelname)s: %(message)s')
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)

--- a/python/paddle/fluid/contrib/slim/tests/quant_int8_image_classification_comparison.py
+++ b/python/paddle/fluid/contrib/slim/tests/quant_int8_image_classification_comparison.py
@@ -27,6 +27,8 @@ from paddle.fluid.framework import IrGraph
 from paddle.fluid.contrib.slim.quantization import QuantInt8MkldnnPass
 from paddle.fluid import core
 
+paddle.enable_static()
+
 logging.basicConfig(format='%(asctime)s-%(levelname)s: %(message)s')
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)

--- a/python/paddle/fluid/contrib/slim/tests/save_quant_model.py
+++ b/python/paddle/fluid/contrib/slim/tests/save_quant_model.py
@@ -27,6 +27,8 @@ from paddle.fluid.framework import IrGraph
 from paddle.fluid.contrib.slim.quantization import Quant2Int8MkldnnPass
 from paddle.fluid import core
 
+paddle.enable_static()
+
 
 def parse_args():
     parser = argparse.ArgumentParser()

--- a/python/paddle/fluid/contrib/slim/tests/test_graph.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_graph.py
@@ -22,6 +22,8 @@ import paddle.fluid as fluid
 from paddle.fluid.framework import IrGraph
 from paddle.fluid import core
 
+paddle.enable_static()
+
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 os.environ["CPU_NUM"] = "1"
 

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat.py
@@ -32,6 +32,8 @@ from paddle.fluid.dygraph.nn import Pool2D
 from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.log_helper import get_logger
 
+paddle.enable_static()
+
 os.environ["CPU_NUM"] = "1"
 if core.is_compiled_with_cuda():
     fluid.set_flags({"FLAGS_cudnn_deterministic": True})

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_channelwise.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_channelwise.py
@@ -32,6 +32,8 @@ from paddle.fluid.dygraph.nn import Pool2D
 from paddle.fluid.dygraph.nn import Linear
 from paddle.fluid.log_helper import get_logger
 
+paddle.enable_static()
+
 os.environ["CPU_NUM"] = "1"
 if core.is_compiled_with_cuda():
     fluid.set_flags({"FLAGS_cudnn_deterministic": True})

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mnist.py
@@ -25,6 +25,8 @@ import paddle.fluid as fluid
 from paddle.dataset.common import download
 from paddle.fluid.contrib.slim.quantization import PostTrainingQuantization
 
+paddle.enable_static()
+
 random.seed(0)
 np.random.seed(0)
 

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_mobilenetv1.py
@@ -26,6 +26,8 @@ import paddle.fluid as fluid
 from paddle.dataset.common import download
 from paddle.fluid.contrib.slim.quantization import PostTrainingQuantization
 
+paddle.enable_static()
+
 random.seed(0)
 np.random.seed(0)
 

--- a/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_post_training_quantization_resnet50.py
@@ -15,6 +15,9 @@
 import sys
 import unittest
 from test_post_training_quantization_mobilenetv1 import TestPostTrainingQuantization
+import paddle
+
+paddle.enable_static()
 
 
 class TestPostTrainingForResnet50(TestPostTrainingQuantization):

--- a/python/paddle/fluid/contrib/slim/tests/test_quant2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quant2_int8_mkldnn_pass.py
@@ -18,6 +18,9 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.framework import IrGraph
 from paddle.fluid.contrib.slim.quantization import Quant2Int8MkldnnPass
+import paddle
+
+paddle.enable_static()
 
 
 class TestQuant2Int8MkldnnPass(unittest.TestCase):

--- a/python/paddle/fluid/contrib/slim/tests/test_quantization_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quantization_mkldnn_pass.py
@@ -25,6 +25,7 @@ from paddle.fluid.contrib.slim.quantization import QuantizationTransformPass
 from paddle.fluid.contrib.slim.quantization import QuantInt8MkldnnPass
 from paddle.fluid import core
 
+paddle.enable_static()
 os.environ["CPU_NUM"] = "1"
 
 

--- a/python/paddle/fluid/contrib/slim/tests/test_quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quantization_pass.py
@@ -27,6 +27,8 @@ from paddle.fluid.contrib.slim.quantization import TransformForMobilePass
 from paddle.fluid.contrib.slim.quantization import AddQuantDequantPass
 from paddle.fluid import core
 
+paddle.enable_static()
+
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 os.environ["CPU_NUM"] = "1"
 

--- a/python/paddle/fluid/contrib/slim/tests/test_quantization_scale_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quantization_scale_pass.py
@@ -27,6 +27,8 @@ from paddle.fluid.contrib.slim.quantization import OutScaleForInferencePass
 from paddle.fluid.contrib.slim.quantization import AddQuantDequantPass
 from paddle.fluid import core
 
+paddle.enable_static()
+
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 os.environ["CPU_NUM"] = "1"
 

--- a/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_user_defined_quantization.py
@@ -29,6 +29,8 @@ from paddle.fluid.contrib.slim.quantization import AddQuantDequantPass
 from paddle.fluid import core
 from paddle.fluid.layer_helper import LayerHelper
 
+paddle.enable_static()
+
 os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 os.environ["CPU_NUM"] = "1"
 

--- a/python/paddle/fluid/contrib/slim/tests/test_weight_quantization_mobilenetv1.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_weight_quantization_mobilenetv1.py
@@ -17,6 +17,9 @@ import os
 import time
 from paddle.dataset.common import download, DATA_HOME
 from paddle.fluid.contrib.slim.quantization import WeightQuantization
+import paddle
+
+paddle.enable_static()
 
 
 class TestWeightQuantization(unittest.TestCase):

--- a/python/paddle/fluid/contrib/tests/test_correlation.py
+++ b/python/paddle/fluid/contrib/tests/test_correlation.py
@@ -16,6 +16,9 @@ import unittest
 import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.base import to_variable
+import paddle
+
+paddle.enable_static()
 
 
 def corr(x_1,

--- a/python/paddle/fluid/contrib/tests/test_fp16_utils.py
+++ b/python/paddle/fluid/contrib/tests/test_fp16_utils.py
@@ -16,6 +16,9 @@ import unittest
 import paddle.fluid as fluid
 from paddle.fluid import core
 from paddle.fluid.contrib.mixed_precision import fp16_utils
+import paddle
+
+paddle.enable_static()
 
 
 class AMPTest(unittest.TestCase):

--- a/python/paddle/fluid/contrib/tests/test_image_classification_fp16.py
+++ b/python/paddle/fluid/contrib/tests/test_image_classification_fp16.py
@@ -25,6 +25,8 @@ import os
 import copy
 import numpy as np
 
+paddle.enable_static()
+
 
 def resnet_cifar10(input, depth=32):
     def conv_bn_layer(input,

--- a/python/paddle/fluid/contrib/tests/test_quantize_transpiler.py
+++ b/python/paddle/fluid/contrib/tests/test_quantize_transpiler.py
@@ -20,6 +20,9 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid.contrib.quantize.quantize_transpiler import _original_var_name
 from paddle.fluid.contrib.quantize.quantize_transpiler import QuantizeTranspiler
+import paddle
+
+paddle.enable_static()
 
 
 def linear_fc(num):

--- a/python/paddle/fluid/contrib/tests/test_weight_decay_extend.py
+++ b/python/paddle/fluid/contrib/tests/test_weight_decay_extend.py
@@ -21,6 +21,8 @@ import paddle
 import paddle.fluid as fluid
 import contextlib
 
+paddle.enable_static()
+
 
 def get_places():
     places = [fluid.CPUPlace()]

--- a/python/paddle/fluid/install_check.py
+++ b/python/paddle/fluid/install_check.py
@@ -62,6 +62,8 @@ def run_check():
             # Your Paddle Fluid works well on MUTIPLE GPU or CPU.
             # Your Paddle Fluid is installed successfully! Let's start deep Learning with Paddle Fluid now
     """
+    paddle.enable_static()
+
     print("Running Verify Fluid Program ... ")
 
     device_list = []
@@ -157,3 +159,5 @@ def run_check():
         print(
             "Your Paddle Fluid is installed successfully ONLY for SINGLE GPU or CPU! "
             "\n Let's start deep Learning with Paddle Fluid now")
+
+    paddle.disable_static()

--- a/python/paddle/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/fluid/tests/book/test_fit_a_line.py
@@ -23,6 +23,8 @@ import math
 import sys
 import os
 
+paddle.enable_static()
+
 
 def train(use_cuda, save_dirname, is_local):
     x = fluid.layers.data(name='x', shape=[13], dtype='float32')

--- a/python/paddle/fluid/tests/book/test_image_classification.py
+++ b/python/paddle/fluid/tests/book/test_image_classification.py
@@ -24,6 +24,8 @@ import unittest
 import os
 import numpy as np
 
+paddle.enable_static()
+
 
 def resnet_cifar10(input, depth=32):
     def conv_bn_layer(input,

--- a/python/paddle/fluid/tests/book/test_label_semantic_roles.py
+++ b/python/paddle/fluid/tests/book/test_label_semantic_roles.py
@@ -25,6 +25,8 @@ import paddle
 import paddle.dataset.conll05 as conll05
 import paddle.fluid as fluid
 
+paddle.enable_static()
+
 word_dict, verb_dict, label_dict = conll05.get_dict()
 word_dict_len = len(word_dict)
 label_dict_len = len(label_dict)

--- a/python/paddle/fluid/tests/book/test_machine_translation.py
+++ b/python/paddle/fluid/tests/book/test_machine_translation.py
@@ -24,6 +24,8 @@ from paddle.fluid.executor import Executor
 import unittest
 import os
 
+paddle.enable_static()
+
 dict_size = 30000
 source_dict_dim = target_dict_dim = dict_size
 hidden_dim = 32

--- a/python/paddle/fluid/tests/book/test_recognize_digits.py
+++ b/python/paddle/fluid/tests/book/test_recognize_digits.py
@@ -26,6 +26,8 @@ import paddle
 import paddle.fluid as fluid
 from paddle.fluid.layers.device import get_places
 
+paddle.enable_static()
+
 BATCH_SIZE = 64
 
 

--- a/python/paddle/fluid/tests/book/test_recommender_system.py
+++ b/python/paddle/fluid/tests/book/test_recommender_system.py
@@ -26,6 +26,8 @@ import paddle.fluid.nets as nets
 from paddle.fluid.executor import Executor
 from paddle.fluid.optimizer import SGDOptimizer
 
+paddle.enable_static()
+
 IS_SPARSE = True
 USE_GPU = False
 BATCH_SIZE = 256

--- a/python/paddle/fluid/tests/book/test_rnn_encoder_decoder.py
+++ b/python/paddle/fluid/tests/book/test_rnn_encoder_decoder.py
@@ -25,6 +25,9 @@ import math
 import sys
 import unittest
 from paddle.fluid.executor import Executor
+import paddle
+
+paddle.enable_static()
 
 dict_size = 30000
 source_dict_dim = target_dict_dim = dict_size

--- a/python/paddle/fluid/tests/book/test_word2vec.py
+++ b/python/paddle/fluid/tests/book/test_word2vec.py
@@ -23,6 +23,8 @@ import numpy as np
 import math
 import sys
 
+paddle.enable_static()
+
 
 def train(use_cuda, is_sparse, is_parallel, save_dirname, is_local=True):
     PASS_NUM = 100

--- a/python/paddle/fluid/tests/custom_op/test_custom_op.py
+++ b/python/paddle/fluid/tests/custom_op/test_custom_op.py
@@ -21,6 +21,8 @@ import contextlib
 import paddle
 import paddle.fluid as fluid
 
+paddle.enable_static()
+
 file_dir = os.path.dirname(os.path.abspath(__file__))
 fluid.load_op_library(os.path.join(file_dir, 'librelu2_op.so'))
 

--- a/python/paddle/fluid/tests/test_beam_search_decoder.py
+++ b/python/paddle/fluid/tests/test_beam_search_decoder.py
@@ -29,6 +29,8 @@ from paddle.fluid.contrib.decoder.beam_search_decoder import *
 import unittest
 import os
 
+paddle.enable_static()
+
 dict_size = 30000
 source_dict_dim = target_dict_dim = dict_size
 src_dict, trg_dict = paddle.dataset.wmt14.get_dict(dict_size)

--- a/python/paddle/fluid/tests/test_data_feeder.py
+++ b/python/paddle/fluid/tests/test_data_feeder.py
@@ -16,6 +16,9 @@ from __future__ import print_function
 
 import paddle.fluid as fluid
 import unittest
+import paddle
+
+paddle.enable_static()
 
 
 class TestDataFeeder(unittest.TestCase):

--- a/python/paddle/fluid/tests/test_detection.py
+++ b/python/paddle/fluid/tests/test_detection.py
@@ -24,6 +24,9 @@ import numpy as np
 from unittests.test_imperative_base import new_program_scope
 from paddle.fluid.dygraph import base
 from paddle.fluid import core
+import paddle
+
+paddle.enable_static()
 
 
 class LayerTest(unittest.TestCase):

--- a/python/paddle/fluid/tests/test_error_clip.py
+++ b/python/paddle/fluid/tests/test_error_clip.py
@@ -22,6 +22,7 @@ BATCH_SIZE = 128
 CLIP_MAX = 2e-6
 CLIP_MIN = -1e-6
 
+paddle.enable_static()
 prog = fluid.framework.Program()
 
 with fluid.program_guard(main_program=prog):

--- a/python/paddle/fluid/tests/test_if_else_op.py
+++ b/python/paddle/fluid/tests/test_if_else_op.py
@@ -28,6 +28,8 @@ from paddle.fluid.layers.control_flow import ConditionalBlock
 import unittest
 import numpy as np
 
+paddle.enable_static()
+
 
 class TestMNISTIfElseOp(unittest.TestCase):
     # FIXME: https://github.com/PaddlePaddle/Paddle/issues/12245#issuecomment-406462379

--- a/python/paddle/fluid/tests/test_python_operator_overriding.py
+++ b/python/paddle/fluid/tests/test_python_operator_overriding.py
@@ -21,6 +21,9 @@ import numpy as np
 import paddle.fluid.layers as layers
 import paddle.fluid.framework as framework
 import paddle.fluid as fluid
+import paddle
+
+paddle.enable_static()
 
 
 class TestPythonOperatorOverride(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/c_comm_init_op.py
+++ b/python/paddle/fluid/tests/unittests/c_comm_init_op.py
@@ -19,6 +19,9 @@ import os
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from paddle.distributed.fleet.base.private_helper_function import wait_server_ready
+import paddle
+
+paddle.enable_static()
 
 
 class TestCCommInitOp(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/check_nan_inf_base.py
+++ b/python/paddle/fluid/tests/unittests/check_nan_inf_base.py
@@ -28,6 +28,8 @@ import paddle
 import paddle.fluid as fluid
 import paddle.compat as cpt
 
+paddle.enable_static()
+
 np.random.seed(0)
 
 

--- a/python/paddle/fluid/tests/unittests/collective_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_allgather_api.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveAllgatherAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_allgather_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_allgather_op.py
@@ -34,6 +34,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveAllGather(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_allreduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_allreduce_api.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveAllreduceAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_allreduce_op.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveAllreduce(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_barrier_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_barrier_api.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveBarrierAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_broadcast_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_broadcast_api.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveBroadcastAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_broadcast_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_broadcast_op.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveBroadcast(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_reduce_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_reduce_api.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveReduceAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_reduce_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_reduce_op.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveReduce(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_reduce_op_calc_stream.py
+++ b/python/paddle/fluid/tests/unittests/collective_reduce_op_calc_stream.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveReduce(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_reducescatter.py
+++ b/python/paddle/fluid/tests/unittests/collective_reducescatter.py
@@ -34,6 +34,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveReduceScatter(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_reducescatter_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_reducescatter_op.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveReduceScatter(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_scatter_api.py
+++ b/python/paddle/fluid/tests/unittests/collective_scatter_api.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveScatterAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/collective_scatter_op.py
+++ b/python/paddle/fluid/tests/unittests/collective_scatter_op.py
@@ -35,6 +35,8 @@ import paddle.fluid.layers as layers
 from functools import reduce
 from test_collective_base import TestCollectiveRunnerBase, runtime_main
 
+paddle.enable_static()
+
 
 class TestCollectiveScatter(TestCollectiveRunnerBase):
     def __init__(self):

--- a/python/paddle/fluid/tests/unittests/dist_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/dist_allreduce_op.py
@@ -30,6 +30,8 @@ import signal
 from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 
+paddle.enable_static()
+
 DTYPE = "float32"
 paddle.dataset.mnist.fetch()
 

--- a/python/paddle/fluid/tests/unittests/dist_fleet_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_ctr.py
@@ -30,6 +30,8 @@ import ctr_dataset_reader
 from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
 from paddle.distributed.fleet.base.util_factory import fleet_util
 
+paddle.enable_static()
+
 # Fix seed for test
 fluid.default_startup_program().random_seed = 1
 fluid.default_main_program().random_seed = 1

--- a/python/paddle/fluid/tests/unittests/dist_fleet_heter_ctr.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_heter_ctr.py
@@ -31,6 +31,8 @@ from test_dist_fleet_heter_base import runtime_main, FleetDistHeterRunnerBase
 from dist_fleet_ctr import TestDistCTR2x2, fake_ctr_reader
 from paddle.distributed.fleet.base.util_factory import fleet_util
 
+paddle.enable_static()
+
 # Fix seed for test
 fluid.default_startup_program().random_seed = 1
 fluid.default_main_program().random_seed = 1

--- a/python/paddle/fluid/tests/unittests/dist_fleet_simnet_bow.py
+++ b/python/paddle/fluid/tests/unittests/dist_fleet_simnet_bow.py
@@ -34,6 +34,8 @@ from functools import reduce
 from test_dist_fleet_base import runtime_main, FleetDistRunnerBase
 from paddle.distributed.fleet.base.util_factory import fleet_util
 
+paddle.enable_static()
+
 DTYPE = "int64"
 DATA_URL = 'http://paddle-dist-ce-data.bj.bcebos.com/simnet.train.1000'
 DATA_MD5 = '24e49366eb0611c552667989de2f57d5'

--- a/python/paddle/fluid/tests/unittests/dist_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dist_mnist.py
@@ -31,6 +31,8 @@ from functools import reduce
 from test_dist_base import TestDistRunnerBase, runtime_main
 from paddle.fluid.incubate.fleet.collective import fleet, DistributedStrategy
 
+paddle.enable_static()
+
 DTYPE = "float32"
 paddle.dataset.mnist.fetch()
 

--- a/python/paddle/fluid/tests/unittests/dist_se_resnext.py
+++ b/python/paddle/fluid/tests/unittests/dist_se_resnext.py
@@ -30,6 +30,8 @@ import sys
 import signal
 from test_dist_base import TestDistRunnerBase, runtime_main
 
+paddle.enable_static()
+
 # Fix seed for test
 fluid.default_startup_program().random_seed = 1
 fluid.default_main_program().random_seed = 1

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_yolov3.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_yolov3.py
@@ -17,12 +17,14 @@ import random
 import time
 import unittest
 
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph import ProgramTranslator
 from paddle.fluid.dygraph import to_variable
 
 from yolov3 import cfg, YOLOv3
 
+paddle.enable_static()
 random.seed(0)
 np.random.seed(0)
 

--- a/python/paddle/fluid/tests/unittests/test_allgather.py
+++ b/python/paddle/fluid/tests/unittests/test_allgather.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestAllGatherOp(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_allreduce.py
+++ b/python/paddle/fluid/tests/unittests/test_allreduce.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestAllReduceOp(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_auto_checkpoint.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_checkpoint.py
@@ -31,6 +31,7 @@ from paddle.io import Dataset, BatchSampler, DataLoader
 
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 
+paddle.enable_static()
 logger = get_logger()
 
 

--- a/python/paddle/fluid/tests/unittests/test_auto_checkpoint1.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_checkpoint1.py
@@ -32,6 +32,7 @@ from paddle.io import Dataset, BatchSampler, DataLoader
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 from paddle.fluid.tests.unittests.test_auto_checkpoint import AutoCheckPointACLBase
 
+paddle.enable_static()
 logger = get_logger()
 
 

--- a/python/paddle/fluid/tests/unittests/test_auto_checkpoint2.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_checkpoint2.py
@@ -32,6 +32,7 @@ from paddle.io import Dataset, BatchSampler, DataLoader
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 from paddle.fluid.tests.unittests.test_auto_checkpoint import AutoCheckPointACLBase
 
+paddle.enable_static()
 logger = get_logger()
 
 

--- a/python/paddle/fluid/tests/unittests/test_auto_checkpoint3.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_checkpoint3.py
@@ -32,6 +32,7 @@ from paddle.io import Dataset, BatchSampler, DataLoader
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 from paddle.fluid.tests.unittests.test_auto_checkpoint import AutoCheckPointACLBase
 
+paddle.enable_static()
 logger = get_logger()
 
 

--- a/python/paddle/fluid/tests/unittests/test_auto_checkpoint_dist_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_checkpoint_dist_basic.py
@@ -32,6 +32,7 @@ from paddle.io import Dataset, BatchSampler, DataLoader
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 from paddle.fluid.tests.unittests.test_auto_checkpoint import AutoCheckPointACLBase
 
+paddle.enable_static()
 logger = get_logger()
 
 

--- a/python/paddle/fluid/tests/unittests/test_auto_checkpoint_multiple.py
+++ b/python/paddle/fluid/tests/unittests/test_auto_checkpoint_multiple.py
@@ -32,6 +32,7 @@ from paddle.io import Dataset, BatchSampler, DataLoader
 from paddle.fluid.tests.unittests.auto_checkpoint_utils import AutoCheckpointBase, get_logger
 from paddle.fluid.tests.unittests.test_auto_checkpoint import AutoCheckPointACLBase
 
+paddle.enable_static()
 logger = get_logger()
 
 

--- a/python/paddle/fluid/tests/unittests/test_broadcast.py
+++ b/python/paddle/fluid/tests/unittests/test_broadcast.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCBroadcastOp(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_buffer_shared_memory_reuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_buffer_shared_memory_reuse_pass.py
@@ -36,6 +36,7 @@ class InplaceTestBase(unittest.TestCase):
         self.fuse_all_optimizer_ops = False
 
     def setUp(self):
+        paddle.enable_static()
         self.initParameter()
         if self.use_cuda and fluid.core.is_compiled_with_cuda():
             self.device_count = fluid.core.get_cuda_device_count()

--- a/python/paddle/fluid/tests/unittests/test_collective_allgather_api.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_allgather_api.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCollectiveAllgatherAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_allreduce_api.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_allreduce_api.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCollectiveAllreduceAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_barrier_api.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_barrier_api.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCollectiveBarrierAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_broadcast_api.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_broadcast_api.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCollectiveBroadcastAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_reduce.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_reduce.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCReduceOp(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_reduce_api.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_reduce_api.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCollectiveReduceAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_scatter.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_scatter.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCScatterOp(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_collective_scatter_api.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_scatter_api.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestCollectiveScatterAPI(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_communicator_geo.py
+++ b/python/paddle/fluid/tests/unittests/test_communicator_geo.py
@@ -28,6 +28,8 @@ import paddle.fluid as fluid
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet as fleet
 
+paddle.enable_static()
+
 
 class TestCommunicatorGeoEnd2End(unittest.TestCase):
     def net(self):
@@ -140,6 +142,7 @@ import paddle.distributed.fleet as fleet
 
 from test_communicator_geo import TestCommunicatorGeoEnd2End
 
+paddle.enable_static()
 
 class RunServer(TestCommunicatorGeoEnd2End):
     def runTest(self):

--- a/python/paddle/fluid/tests/unittests/test_communicator_half_async.py
+++ b/python/paddle/fluid/tests/unittests/test_communicator_half_async.py
@@ -29,6 +29,8 @@ import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
 
+paddle.enable_static()
+
 
 class TestCommunicatorHalfAsyncEnd2End(unittest.TestCase):
     def net(self):
@@ -120,6 +122,7 @@ from test_communicator_half_async import TestCommunicatorHalfAsyncEnd2End
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
 
+paddle.enable_static()
 
 class RunServer(TestCommunicatorHalfAsyncEnd2End):
     def runTest(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_allreduce_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_allreduce_op.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistNCCL2(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_async.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_async.py
@@ -19,6 +19,8 @@ import unittest
 import paddle
 import paddle.distributed.fleet.base.role_maker as role_maker
 
+paddle.enable_static()
+
 
 class TestFleetGradientMergeMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_auto.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_auto.py
@@ -18,6 +18,8 @@ import os
 import paddle.distributed.fleet.base.role_maker as role_maker
 import time
 
+paddle.enable_static()
+
 
 class TestFleetGradientMergeMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_auto_async.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_auto_async.py
@@ -18,6 +18,8 @@ import os
 import paddle.distributed.fleet.base.role_maker as role_maker
 import time
 
+paddle.enable_static()
+
 
 class TestFleetGradientMergeMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_auto_geo.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_auto_geo.py
@@ -18,6 +18,8 @@ import os
 import paddle.distributed.fleet.base.role_maker as role_maker
 import time
 
+paddle.enable_static()
+
 
 class TestFleetGradientMergeMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_geo.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_geo.py
@@ -18,6 +18,8 @@ import os
 import paddle.distributed.fleet.base.role_maker as role_maker
 import time
 
+paddle.enable_static()
+
 
 class TestFleetGradientMergeMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_sync.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_a_sync_optimizer_sync.py
@@ -19,6 +19,8 @@ import paddle.distributed.fleet as fleet
 import paddle.distributed.fleet.base.role_maker as role_maker
 import time
 
+paddle.enable_static()
+
 
 class TestFleetGradientMergeMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_geo.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_geo.py
@@ -22,6 +22,9 @@ from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import f
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
 from test_dist_fleet_base import TestFleetBase
 from dist_fleet_simnet_bow import train_network
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistGeoCtr_2x2(TestFleetBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_heter_ctr.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_heter_ctr.py
@@ -18,6 +18,9 @@ import os
 import unittest
 import tempfile
 from test_dist_fleet_heter_base import TestFleetHeterBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistHeterDatasetAsync2x2(TestFleetHeterBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_heter_program.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_heter_program.py
@@ -21,6 +21,9 @@ import paddle.fluid as fluid
 import paddle.distributed.fleet.base.role_maker as role_maker
 from paddle.distributed.fleet.base.util_factory import fleet_util
 from paddle.distributed.fleet import fleet
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistFleetHeterProgram(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_ps.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_ps.py
@@ -19,6 +19,9 @@ import paddle.fluid as fluid
 import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
+import paddle
+
+paddle.enable_static()
 
 # For Net
 base_lr = 0.2

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_ps2.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_ps2.py
@@ -24,6 +24,8 @@ import paddle.fluid as fluid
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet as fleet
 
+paddle.enable_static()
+
 # For Net
 base_lr = 0.2
 emb_lr = base_lr * 3

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_ps3.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_ps3.py
@@ -19,6 +19,9 @@ import paddle.fluid as fluid
 import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
+import paddle
+
+paddle.enable_static()
 
 # For Net
 base_lr = 0.2

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_ps4.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_ps4.py
@@ -19,6 +19,9 @@ import paddle.fluid as fluid
 import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
+import paddle
+
+paddle.enable_static()
 
 # For Net
 base_lr = 0.2

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_ps5.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_ps5.py
@@ -19,6 +19,9 @@ import paddle.fluid as fluid
 import paddle.fluid.incubate.fleet.base.role_maker as role_maker
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler import fleet
 from paddle.fluid.incubate.fleet.parameter_server.distribute_transpiler.distributed_strategy import StrategyFactory
+import paddle
+
+paddle.enable_static()
 
 # For Net
 base_lr = 0.2

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_simnet.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_simnet.py
@@ -18,6 +18,9 @@ import os
 import unittest
 import tempfile
 from test_dist_fleet_base import TestFleetBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistSimnetASync2x2(TestFleetBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_backward_deps.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_backward_deps.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistNCCL2BackWardDeps(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_batch_merge.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_batch_merge.py
@@ -16,6 +16,9 @@ from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
 import os
+import paddle
+
+paddle.enable_static()
 
 flag_name = os.path.splitext(__file__)[0]
 

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_dgc_nccl.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_dgc_nccl.py
@@ -18,6 +18,9 @@ from test_dist_base import TestDistBase
 
 import os
 import subprocess
+import paddle
+
+paddle.enable_static()
 flag_name = os.path.splitext(__file__)[0]
 
 

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_fleet_save.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_fleet_save.py
@@ -17,6 +17,9 @@ import shutil
 import os
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistFleetSave(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_fleetapi.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_fleetapi.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistNCCL2FleetApi(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_hallreduce.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_hallreduce.py
@@ -17,6 +17,9 @@ import unittest
 from test_dist_base import TestDistBase
 
 import os
+import paddle
+
+paddle.enable_static()
 flag_name = os.path.splitext(__file__)[0]
 
 

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_multi_comm.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_multi_comm.py
@@ -17,6 +17,9 @@ import unittest
 from test_dist_base import TestDistBase
 
 import os
+import paddle
+
+paddle.enable_static()
 flag_name = os.path.splitext(__file__)[0]
 
 

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_pg.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_pg.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistNCCL2(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_ring_allreduce.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_ring_allreduce.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistNCCL2(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_with_program.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_with_program.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 import unittest
 from test_dist_base import TestDistBase
+import paddle
+
+paddle.enable_static()
 
 
 class TestDistMnistLocalSGDFleetApi(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_dist_op.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_op.py
@@ -19,6 +19,8 @@ import paddle
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 
+paddle.enable_static()
+
 
 def dist(x, y, p):
     if p == 0.:

--- a/python/paddle/fluid/tests/unittests/test_dist_se_resnext_nccl.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_se_resnext_nccl.py
@@ -18,6 +18,9 @@ from test_dist_base import TestDistBase
 import os
 
 import os
+import paddle
+
+paddle.enable_static()
 flag_name = os.path.splitext(__file__)[0]
 
 

--- a/python/paddle/fluid/tests/unittests/test_dist_transpiler_async_decay.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_transpiler_async_decay.py
@@ -17,6 +17,9 @@ from __future__ import print_function
 import unittest
 import gc
 import paddle.fluid as fluid
+import paddle
+
+paddle.enable_static()
 
 
 class TranspilerAsyncLRDecayTest(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_dist_transpiler_config.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_transpiler_config.py
@@ -15,6 +15,9 @@
 import unittest
 import paddle.fluid as fluid
 import gc
+import paddle
+
+paddle.enable_static()
 
 gc.set_debug(gc.DEBUG_COLLECTABLE)
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_graph_execution_meta_optimizer.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_graph_execution_meta_optimizer.py
@@ -17,6 +17,8 @@ import paddle
 import os
 from launch_function_helper import launch_func, wait, _find_free_port
 
+paddle.enable_static()
+
 
 class TestFleetGraphExecutionMetaOptimizer(unittest.TestCase):
     def setUp(self):

--- a/python/paddle/fluid/tests/unittests/test_listen_and_serv_op.py
+++ b/python/paddle/fluid/tests/unittests/test_listen_and_serv_op.py
@@ -28,6 +28,8 @@ import unittest
 from multiprocessing import Process
 from op_test import OpTest
 
+paddle.enable_static()
+
 
 def run_pserver(use_cuda, sync_mode, ip, port, trainers, trainer_id):
     remove_ps_flag(os.getpid())

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -19,6 +19,9 @@ import unittest
 import os
 import sys
 import subprocess
+import paddle
+
+paddle.enable_static()
 
 
 class TestNanInf(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_reducescatter.py
+++ b/python/paddle/fluid/tests/unittests/test_reducescatter.py
@@ -15,8 +15,11 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestReduceScatterOp(TestDistBase):

--- a/python/paddle/fluid/tests/unittests/test_reducescatter_api.py
+++ b/python/paddle/fluid/tests/unittests/test_reducescatter_api.py
@@ -16,8 +16,11 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle.fluid as fluid
+import paddle
 
 from test_collective_base import TestDistBase
+
+paddle.enable_static()
 
 
 class TestReduceScatterAPI(TestDistBase):

--- a/python/paddle/tests/test_text.py
+++ b/python/paddle/tests/test_text.py
@@ -28,6 +28,8 @@ from paddle import Model, set_device
 from paddle.static import InputSpec as Input
 from paddle.text import *
 
+paddle.enable_static()
+
 
 class ModuleApiTest(unittest.TestCase):
     @classmethod

--- a/tools/test_runner.py
+++ b/tools/test_runner.py
@@ -17,12 +17,14 @@ from __future__ import print_function
 import unittest
 import os
 import sys
+import paddle
 import paddle.fluid as fluid
 import importlib
 from six.moves import cStringIO
 
 
 def main():
+    paddle.enable_static()
     sys.path.append(os.getcwd())
     some_test_failed = False
     for module_name in sys.argv[1:]:
@@ -44,6 +46,7 @@ def main():
                             'failed\n',
                             buffer.getvalue(),
                             file=sys.stderr)
+    paddle.disable_static()
 
     if some_test_failed:
         exit(1)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Breaking changes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

Paddle 2.0 uses `dygraph mode` by default. This PR change the default mode from `static mode` to `dygraph mode`.

#### 1. use dygraph mode by default
In `paddle/__init__.py`, add `disable_static()` to change the default mode to `dygraph mode`.

#### 2. manually change unittest's mode to static mode
Unittest is realized based on static mode. It will cause conflicts when dygraph mode is opened by default.
In order to pass CI, before the unittest runs, switch the mode to static mode.

- modify `test_runner.py`
When using `ctest` to execute unittest files, `test_runner.py` is the entry point for many unittest files. `test_runner.py` will call the module in unittest files to execute.
Thus, we can add `enable_static` in `test_runner.py`. Before running unittest, `test_runner.py` will provide static mode.

- modify unittest file
Some unittests are not executed based on `test_runner.py`, so their running environment is still dygraph mode, and CI wil fail.
To solve this problem, we modify all unittests in the CI error report manually.
The following files will be added `enable_static` manually.



CI-Mac
```
2020-09-17 21:17:20 	132 - test_train_recognize_digits_mlp (Failed)
2020-09-17 21:17:20 	133 - test_train_recognize_digits_conv (Failed)
2020-09-17 21:17:20 	156 - test_beam_search_decoder (Failed)
2020-09-17 21:17:20 	157 - test_data_feeder (Failed)
2020-09-17 21:17:20 	158 - test_detection (Failed)
2020-09-17 21:17:20 	159 - test_error_clip (Failed) # add enable_static
2020-09-17 21:17:20 	160 - test_if_else_op (Failed)
2020-09-17 21:17:20 	162 - test_python_operator_overriding (Failed)
2020-09-17 21:17:20 	615 - test_nan_inf (Failed) # add enable_static
2020-09-17 21:17:20 	954 - test_fit_a_line (Failed)
2020-09-17 21:17:20 	955 - test_image_classification (Failed)
2020-09-17 21:17:20 	956 - test_label_semantic_roles (Failed)
2020-09-17 21:17:20 	957 - test_machine_translation (Failed)
2020-09-17 21:17:20 	958 - test_recognize_digits (Failed)
2020-09-17 21:17:20 	959 - test_recommender_system (Failed) # add enable_static
2020-09-17 21:17:20 	960 - test_rnn_encoder_decoder (Failed)
2020-09-17 21:17:20 	961 - test_word2vec (Failed)
2020-09-17 21:17:20 	964 - test_fp16_utils (Failed)
2020-09-17 21:17:20 	966 - test_quantize_transpiler (Failed)
2020-09-17 21:17:20 	967 - test_weight_decay_extend (Failed)
2020-09-17 21:17:20 	968 - test_graph (Failed)
2020-09-17 21:17:20 	969 - test_imperative_qat (Failed)
2020-09-17 21:17:20 	970 - test_post_training_quantization_mnist (Failed)
2020-09-17 21:17:20 	971 - test_post_training_quantization_mobilenetv1 (Failed)
2020-09-17 21:17:20 	972 - test_post_training_quantization_resnet50 (Failed)
2020-09-17 21:17:20 	973 - test_quant2_int8_mkldnn_pass (Failed)
2020-09-17 21:17:20 	974 - test_quantization_mkldnn_pass (Failed)
2020-09-17 21:17:20 	975 - test_quantization_pass (Failed)
2020-09-17 21:17:20 	976 - test_quantization_scale_pass (Failed)
2020-09-17 21:17:20 	977 - test_user_defined_quantization (Failed)
2020-09-17 21:17:20 	978 - test_weight_quantization_mobilenetv1 (Failed)
test_communicator_geo
```

CI-Py3
```
2020-09-20 21:01:30 	268 - test_allreduce (Timeout)
2020-09-20 21:01:30 	327 - test_collective_allgather_api (Failed)
2020-09-20 21:01:30 	330 - test_collective_barrier_api (Failed)
2020-09-20 21:01:30 	333 - test_collective_reduce (Timeout)
2020-09-20 21:01:30 	335 - test_collective_scatter (Timeout)
2020-09-20 21:01:30 	813 - test_reducescatter (Timeout)
2020-09-20 21:01:30 	952 - test_communicator_half_async (Timeout)
2020-09-20 21:01:30 	1031 - test_auto_checkpoint (Failed)
2020-09-20 21:01:30 	1033 - test_auto_checkpoint2 (Failed)
2020-09-20 21:01:30 	1035 - test_auto_checkpoint_multiple (Failed)
2020-09-20 21:01:30 	1134 - test_correlation (Failed)
2020-09-20 21:01:30 	267 - test_allgather (Timeout)
2020-09-20 21:01:30 	309 - test_broadcast (Timeout)
2020-09-20 21:01:30 	328 - test_collective_allreduce_api (Failed)
2020-09-20 21:01:30 	332 - test_collective_broadcast_api (Failed)
2020-09-20 21:01:30 	334 - test_collective_reduce_api (Failed)
2020-09-20 21:01:30 	336 - test_collective_scatter_api (Failed)
2020-09-20 21:01:30 	814 - test_reducescatter_api (Timeout)
2020-09-20 21:01:30 	974 - test_c_comm_init_op (Failed)
2020-09-20 21:01:30 	1032 - test_auto_checkpoint1 (Failed)
2020-09-20 21:01:30 	1034 - test_auto_checkpoint3 (Failed)
2020-09-20 21:01:30 	1036 - test_auto_checkpoint_dist_basic (Failed)
2020-09-20 21:01:30 	978 - test_dist_allreduce_op (Failed)
2020-09-20 21:01:30 	979 - test_dist_fleet_a_sync_optimizer_async (Failed)
2020-09-20 21:01:30 	980 - test_dist_fleet_a_sync_optimizer_auto (Failed)
2020-09-20 21:01:30 	981 - test_dist_fleet_a_sync_optimizer_auto_async (Failed)
2020-09-20 21:01:30 	982 - test_dist_fleet_a_sync_optimizer_auto_geo (Failed)
2020-09-20 21:01:30 	983 - test_dist_fleet_a_sync_optimizer_geo (Failed)
2020-09-20 21:01:30 	984 - test_dist_fleet_a_sync_optimizer_sync (Failed)
2020-09-20 21:01:30 	985 - test_dist_fleet_ctr (Failed)
2020-09-20 21:01:30 	986 - test_dist_fleet_geo (Failed)
2020-09-20 21:01:30 	989 - test_dist_fleet_heter_ctr (Failed)
2020-09-20 21:01:30 	990 - test_dist_fleet_heter_program (Failed)
2020-09-20 21:01:30 	996 - test_dist_fleet_simnet (Failed)
2020-09-20 21:01:30 	997 - test_dist_mnist_backward_deps (Failed)
2020-09-20 21:01:30 	998 - test_dist_mnist_batch_merge (Failed)
2020-09-20 21:01:30 	999 - test_dist_mnist_dgc_nccl (Failed)
2020-09-20 21:01:30 	1000 - test_dist_mnist_fleet_save (Failed)
2020-09-20 21:01:30 	1001 - test_dist_mnist_fleetapi (Failed)
2020-09-20 21:01:30 	1002 - test_dist_mnist_hallreduce (Failed)
2020-09-20 21:01:30 	1003 - test_dist_mnist_multi_comm (Failed)
2020-09-20 21:01:30 	1004 - test_dist_mnist_pg (Failed)
2020-09-20 21:01:30 	1005 - test_dist_mnist_ring_allreduce (Failed)
2020-09-20 21:01:30 	1006 - test_dist_mnist_with_program (Failed)
2020-09-20 21:01:30 	1009 - test_dist_se_resnext_nccl (Failed)
test_buffer_shared_memory_reuse_pass
```

CI-coverage

```
2020-09-22 07:44:41 The following tests FAILED: 
2020-09-22 07:44:41 	385 - test_collective_reduce (Timeout)
2020-09-22 07:44:41 	1231 - test_image_classification_fp16 (Failed)
2020-09-22 07:44:41 	1235 - test_quant_int8_googlenet_mkldnn (Failed)   # quant_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1237 - test_quant_int8_mobilenetv2_mkldnn (Failed)  # quant_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1239 - test_quant2_int8_resnet50_range_mkldnn (Failed)  # quant2_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1241 - test_quant2_int8_mobilenetv1_mkldnn (Failed)  # quant2_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1243 - save_quant2_model_resnet50 (Failed)  # save_quant_model.py
2020-09-22 07:44:41 	1245 - convert_model2dot_ernie (Failed)  # convert_model2dot.py
2020-09-22 07:44:41 	259 - test_text (Failed)
2020-09-22 07:44:41 	1226 - test_custom_op (Failed)
2020-09-22 07:44:41 	1234 - test_quant_int8_resnet50_mkldnn (Failed)  # quant_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1236 - test_quant_int8_mobilenetv1_mkldnn (Failed)  # quant_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1238 - test_quant2_int8_resnet50_mkldnn (Failed)  # quant2_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1240 - test_quant2_int8_resnet50_channelwise_mkldnn (Failed)  # quant2_int8_image_classification_comparison.py
2020-09-22 07:44:41 	1242 - test_quant2_int8_ernie_mkldnn (Failed)  # quant2_int8_nlp_comparison.py
2020-09-22 07:44:41 	1244 - save_quant2_model_ernie (Failed)  # save_quant_model.py
2020-09-22 07:44:41 	1046 - test_dist_fleet_ps (Failed)
2020-09-22 07:44:41 	1047 - test_dist_fleet_ps2 (Failed)
2020-09-22 07:44:41 	1048 - test_dist_fleet_ps3 (Failed)
2020-09-22 07:44:41 	1049 - test_dist_fleet_ps4 (Failed)
2020-09-22 07:44:41 	1050 - test_dist_fleet_ps5 (Failed)
2020-09-22 07:44:41 	1062 - test_dist_op (Failed)
2020-09-22 07:44:41 	1066 - test_dist_transpiler_async_decay (Failed)
2020-09-22 07:44:41 	1067 - test_dist_transpiler_config (Failed)
2020-09-22 07:44:41 	1072 - test_listen_and_serv_op (Failed)
2020-09-22 07:44:41 	1073 - test_fleet_graph_execution_meta_optimizer (Failed)
```
