### PR TITLE
fix cmake dependencies of test_recognize_digits, test=develop

### DIFF
--- a/paddle/fluid/train/CMakeLists.txt
+++ b/paddle/fluid/train/CMakeLists.txt
@@ -26,7 +26,7 @@ function(train_test TARGET_NAME)
                     ARGS --dirname=${PYTHON_TESTS_DIR}/book/${TARGET_NAME}${arg}.train.model/)
         endif()
         set_tests_properties(test_train_${TARGET_NAME}${arg}
-                PROPERTIES DEPENDS test_${TARGET_NAME})
+                PROPERTIES FIXTURES_REQUIRED test_${TARGET_NAME}_infer_model)
         if(NOT WIN32 AND NOT APPLE)
             set_tests_properties(test_train_${TARGET_NAME}${arg}
                     PROPERTIES TIMEOUT 150)

--- a/python/paddle/fluid/tests/book/CMakeLists.txt
+++ b/python/paddle/fluid/tests/book/CMakeLists.txt
@@ -4,4 +4,5 @@ string(REPLACE ".py" "" TEST_OPS "${TEST_OPS}")
 # default test
 foreach(src ${TEST_OPS})
     py_test(${src} SRCS ${src}.py)
+    set_tests_properties(${src} PROPERTIES FIXTURES_SETUP ${src}_infer_model)
 endforeach()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
解决单测test_train_recognize_digits_mlp和test_train_recognize_digits_conv，第一次失败，进行retry之后才成功。

**错误原因分析：**
test_train_recognize_digits_mlp 依赖于 test_recognize_digits需要先运行从而才会有inference model文件，否则会提示模型文件无法找到的错误。当前Paddle的CI脚本parallel_test_base_gpu都是调用ctest -R test_name命令，该命令即使识别到依赖关系，也无法自动在跑test_train_recognize_digits_mlp之前就先跑test_recognize_digits，所以导致先跑所有单卡测试时Fail。之后第二次retry的时候因为已经运行过test_recognize_digits，所以可以retry成功。

**解决办法：**
将依赖关系修改为FIXTURES_REQUIRED，在运行ctest -R test_train_recognize_digits_mlp前会先运行test_recognize_digits，从而保证单测运行成功。
- 使用方法可以查看这个cmake文档 https://cmake.org/cmake/help/latest/prop_test/FIXTURES_REQUIRED.html
- 关于fixtures功能详细说明文章 https://crascit.com/2016/10/18/test-fixtures-with-cmake-ctest/

