### PR TITLE
fix tensorrt 6 build error. test=develop

### DIFF
--- a/paddle/fluid/platform/dynload/tensorrt.h
+++ b/paddle/fluid/platform/dynload/tensorrt.h
@@ -41,10 +41,11 @@ extern void* tensorrt_dso_handle;
       });                                                                     \
       static void* p_##__name = dlsym(tensorrt_dso_handle, #__name);          \
       if (p_##__name == nullptr) {                                            \
-        return nullptr;                                                       \
+        return p_##__name;                                                    \
       }                                                                       \
       using tensorrt_func = decltype(&::__name);                              \
-      return reinterpret_cast<tensorrt_func>(p_##__name)(args...);            \
+      auto ret = reinterpret_cast<tensorrt_func>(p_##__name)(args...);        \
+      return static_cast<void*>(ret);                                         \
     }                                                                         \
   };                                                                          \
   extern DynLoad__##__name __name

--- a/paddle/fluid/platform/dynload/tensorrt.h
+++ b/paddle/fluid/platform/dynload/tensorrt.h
@@ -35,7 +35,7 @@ extern void* tensorrt_dso_handle;
 #define DECLARE_DYNAMIC_LOAD_TENSORRT_WRAP(__name)                            \
   struct DynLoad__##__name {                                                  \
     template <typename... Args>                                               \
-    auto operator()(Args... args) -> DECLARE_TYPE(__name, args...) {          \
+    void* operator()(Args... args) {                                          \
       std::call_once(tensorrt_dso_flag, []() {                                \
         tensorrt_dso_handle = paddle::platform::dynload::GetTensorRtHandle(); \
       });                                                                     \

--- a/paddle/fluid/platform/dynload/tensorrt.h
+++ b/paddle/fluid/platform/dynload/tensorrt.h
@@ -41,7 +41,7 @@ extern void* tensorrt_dso_handle;
       });                                                                     \
       static void* p_##__name = dlsym(tensorrt_dso_handle, #__name);          \
       if (p_##__name == nullptr) {                                            \
-        return p_##__name;                                                    \
+        return nullptr;                                                       \
       }                                                                       \
       using tensorrt_func = decltype(&::__name);                              \
       auto ret = reinterpret_cast<tensorrt_func>(p_##__name)(args...);        \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
resolve #26335

The return type of template function [DynLoad__##__name()](https://github.com/PaddlePaddle/Paddle/blob/8e1712a71057e3ca06a2927ceec51c18cb171fdc/paddle/fluid/platform/dynload/tensorrt.h#L38) is `auto`, and `DECLARE_TYPE(__name, args...)` indicates that this function should return `void*`,  which suits `nullptr`. [createInferBuilder_INTERNAL in tensorrt](https://github.com/NVIDIA/TensorRT/blob/9a9cae75e7155b2114454f37ccc49eca9d3352dc/include/NvInfer.h#L7250) and [createInferRuntime_INTERNAL in tensorrt](https://github.com/NVIDIA/TensorRT/blob/9a9cae75e7155b2114454f37ccc49eca9d3352dc/include/NvInferRuntime.h#L1854) return `void*`. But [getPluginRegistry in tensorrt 6](https://github.com/NVIDIA/TensorRT/blob/9a9cae75e7155b2114454f37ccc49eca9d3352dc/include/NvInferRuntimeCommon.h#L1294) returns `nvinfer1::IPluginRegistry*`, Visual Studio don't convert `nvinfer1::IPluginRegistry*` to `void*` implicitly like what `g++` do, it throws the convert error instead.