### PR TITLE
add AsDuplicable for sync_comm op

### DIFF
--- a/paddle/fluid/operators/collective/c_sync_comm_stream_op.cc
+++ b/paddle/fluid/operators/collective/c_sync_comm_stream_op.cc
@@ -55,8 +55,10 @@ class CSyncCommStreamOp : public framework::OperatorBase {
 class CSyncCommStreamOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() {
-    AddInput("X", "(Tensor) Dependency of the variable need to sync");
-    AddOutput("Out", "(Tensor) Dependency of the variable need to sync");
+    AddInput("X", "(Tensor) Dependency of the variable need to sync")
+        .AsDuplicable();
+    AddOutput("Out", "(Tensor) Dependency of the variable need to sync")
+        .AsDuplicable();
     AddAttr<int>("ring_id", "(int default 0) ring id.").SetDefault(0);
     AddComment(R"DOC(
 CSyncCommStream Operator


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Ops
### Describe
<!-- Describe what this PR does -->

Sometimes, we need to do `allreduce_sum` for multiple variables at the same time, with only one `sync_comm` op after these `allreduce_sum` ops. These vars should be the input of the sync_comm op. This PR adds the `AsDuplicable` function after the `AddInput` and `AddOutput` calls, thus enable multiple inputs and outputs.

如果有俩reduce var: x, y, 如果不在sync的输入里面加入这俩var，gc就会在reduce完成前就释放x和y，导致nan错误