### PR TITLE
Fix test_weight_decay_extend random failed

### DIFF
--- a/python/paddle/fluid/contrib/tests/test_weight_decay_extend.py
+++ b/python/paddle/fluid/contrib/tests/test_weight_decay_extend.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import six
 import unittest
 from functools import partial
 import numpy as np
@@ -22,6 +23,24 @@ import paddle.fluid as fluid
 import contextlib
 
 paddle.enable_static()
+
+
+def fake_imdb_reader(word_dict_size,
+                     sample_num,
+                     lower_seq_len=100,
+                     upper_seq_len=200,
+                     class_dim=2):
+    def __reader__():
+        for _ in six.moves.range(sample_num):
+            length = np.random.random_integers(
+                low=lower_seq_len, high=upper_seq_len, size=[1])[0]
+            ids = np.random.random_integers(
+                low=0, high=word_dict_size - 1, size=[length]).astype('int64')
+            label = np.random.random_integers(
+                low=0, high=class_dim - 1, size=[1]).astype('int64')[0]
+            yield ids, label
+
+    return __reader__
 
 
 def get_places():
@@ -68,10 +87,11 @@ def bow_net(data,
 
 class TestWeightDecay(unittest.TestCase):
     def setUp(self):
-        self.word_dict = paddle.dataset.imdb.word_dict()
-        reader = paddle.batch(
-            paddle.dataset.imdb.train(self.word_dict), batch_size=2)()
-        self.train_data = [next(reader) for _ in range(5)]
+        self.word_dict_len = 5147
+        batch_size = 2
+        reader = fake_imdb_reader(self.word_dict_len, batch_size * 100)
+        reader = paddle.batch(reader, batch_size=batch_size)()
+        self.train_data = [next(reader) for _ in range(3)]
         self.learning_rate = .5
 
     def run_program(self, place, feed_list):
@@ -103,7 +123,7 @@ class TestWeightDecay(unittest.TestCase):
             data = fluid.layers.data(
                 name="words", shape=[1], dtype="int64", lod_level=1)
             label = fluid.layers.data(name="label", shape=[1], dtype="int64")
-            avg_cost = model(data, label, len(self.word_dict))
+            avg_cost = model(data, label, self.word_dict_len)
             AdamW = fluid.contrib.extend_with_decoupled_weight_decay(
                 fluid.optimizer.Adam)
 
@@ -127,7 +147,7 @@ class TestWeightDecay(unittest.TestCase):
                 name="words", shape=[1], dtype="int64", lod_level=1)
             label = fluid.layers.data(name="label", shape=[1], dtype="int64")
 
-            avg_cost = model(data, label, len(self.word_dict))
+            avg_cost = model(data, label, self.word_dict_len)
 
             param_list = [(var, var * self.learning_rate)
                           for var in main_prog.block(0).all_parameters()]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix test_weight_decay_extend random failed

问题原因分析及改进措施：这个单测是超时了，超时应该是极低频率的偶发，但这个单测的执行时间确实比较长，单测中使用了paddle.dataset.imdb，使用这个标准数据集速度慢且会引入不确定因素，比如可能要先下载数据。单测中应该使用fake数据进行测试更加高效，所以这里将测试数据集改为fake数据，也减少了迭代的轮次，单测执行时间从46s减少到6s