### PR TITLE
fix the precision problem of test_distribution

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/test_distribution.py
@@ -396,11 +396,18 @@ class NormalTest(unittest.TestCase):
         np_other_normal = NormalNumpy(self.other_loc_np, self.other_scale_np)
         np_kl = np_normal.kl_divergence(np_other_normal)
 
+        # Because assign op does not support the input of numpy.ndarray whose dtype is FP64.
+        # When loc and scale are FP64 numpy.ndarray, we need to use assign op to convert it
+        #  to FP32 Tensor. And then use cast op to convert it to a FP64 Tensor.
+        # There is a loss of accuracy in this conversion.
+        # So set the tolerance from 1e-6 to 1e-4.
+        log_tolerance = 1e-4
+
         np.testing.assert_equal(sample.shape, np_sample.shape)
         np.testing.assert_allclose(
             entropy, np_entropy, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(
-            log_prob, np_lp, rtol=tolerance, atol=tolerance)
+            log_prob, np_lp, rtol=log_tolerance, atol=log_tolerance)
         np.testing.assert_allclose(probs, np_p, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(kl, np_kl, rtol=tolerance, atol=tolerance)
 

--- a/python/paddle/fluid/tests/unittests/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/test_distribution.py
@@ -408,7 +408,8 @@ class NormalTest(unittest.TestCase):
             entropy, np_entropy, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(
             log_prob, np_lp, rtol=log_tolerance, atol=log_tolerance)
-        np.testing.assert_allclose(probs, np_p, rtol=tolerance, atol=tolerance)
+        np.testing.assert_allclose(
+            probs, np_p, rtol=log_tolerance, atol=log_tolerance)
         np.testing.assert_allclose(kl, np_kl, rtol=tolerance, atol=tolerance)
 
     def test_normal_distribution_dygraph(self, sample_shape=7, tolerance=1e-6):

--- a/python/paddle/fluid/tests/unittests/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/test_distribution.py
@@ -410,7 +410,8 @@ class NormalTest(unittest.TestCase):
             log_prob, np_lp, rtol=log_tolerance, atol=log_tolerance)
         np.testing.assert_allclose(
             probs, np_p, rtol=log_tolerance, atol=log_tolerance)
-        np.testing.assert_allclose(kl, np_kl, rtol=tolerance, atol=tolerance)
+        np.testing.assert_allclose(
+            kl, np_kl, rtol=log_tolerance, atol=log_tolerance)
 
     def test_normal_distribution_dygraph(self, sample_shape=7, tolerance=1e-6):
         paddle.disable_static(self.place)

--- a/python/paddle/fluid/tests/unittests/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/test_distribution.py
@@ -123,7 +123,7 @@ class UniformTest(unittest.TestCase):
     def init_numpy_data(self, batch_size, dims):
         # low ans high are 'float'
         self.low_np = np.random.uniform(-2, 1)
-        self.high_np = np.random.uniform(1, 3)
+        self.high_np = np.random.uniform(2, 4)
         self.values_np = np.array([1.0]).astype('float32')
 
     def init_dynamic_data(self, batch_size, dims):
@@ -138,7 +138,7 @@ class UniformTest(unittest.TestCase):
             self.static_values = layers.data(
                 name='values', shape=[], dtype='float32')
 
-    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-4):
+    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-6):
         sample, entropy, log_prob, probs = fetch_list
 
         np_uniform = UniformNumpy(self.low_np, self.high_np)
@@ -154,7 +154,7 @@ class UniformTest(unittest.TestCase):
             log_prob, np_lp, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(probs, np_p, rtol=tolerance, atol=tolerance)
 
-    def test_uniform_distribution_dygraph(self, sample_shape=7, tolerance=1e-4):
+    def test_uniform_distribution_dygraph(self, sample_shape=7, tolerance=1e-6):
         paddle.disable_static(self.place)
         uniform = Uniform(self.dynamic_low, self.dynamic_high)
         sample = uniform.sample([sample_shape]).numpy()
@@ -165,7 +165,7 @@ class UniformTest(unittest.TestCase):
 
         self.compare_with_numpy(fetch_list)
 
-    def test_uniform_distribution_static(self, sample_shape=7, tolerance=1e-4):
+    def test_uniform_distribution_static(self, sample_shape=7, tolerance=1e-6):
         paddle.enable_static()
         with fluid.program_guard(self.test_program):
             uniform = Uniform(self.static_low, self.static_high)
@@ -193,7 +193,7 @@ class UniformTest2(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # low ans high are 'int'
         self.low_np = int(np.random.uniform(-2, 1))
-        self.high_np = int(np.random.uniform(1, 3))
+        self.high_np = int(np.random.uniform(2, 4))
         self.values_np = np.array([1.0]).astype('float32')
 
 
@@ -201,7 +201,7 @@ class UniformTest3(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # test broadcast: low is float, high is numpy.ndarray with dtype 'float32'.
         self.low_np = np.random.uniform(-2, 1)
-        self.high_np = np.random.uniform(-5.0, 5.0,
+        self.high_np = np.random.uniform(5.0, 15.0,
                                          (batch_size, dims)).astype('float32')
         self.values_np = np.random.randn(batch_size, dims).astype('float32')
 
@@ -217,7 +217,7 @@ class UniformTest4(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # low and high are numpy.ndarray with dtype 'float32'.
         self.low_np = np.random.randn(batch_size, dims).astype('float32')
-        self.high_np = np.random.uniform(-5.0, 5.0,
+        self.high_np = np.random.uniform(5.0, 15.0,
                                          (batch_size, dims)).astype('float32')
         self.values_np = np.random.randn(batch_size, dims).astype('float32')
 
@@ -233,7 +233,7 @@ class UniformTest5(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # low and high are numpy.ndarray with dtype 'float64'.
         self.low_np = np.random.randn(batch_size, dims).astype('float64')
-        self.high_np = np.random.uniform(-5.0, 5.0,
+        self.high_np = np.random.uniform(5.0, 15.0,
                                          (batch_size, dims)).astype('float64')
         self.values_np = np.random.randn(batch_size, dims).astype('float64')
 
@@ -254,7 +254,7 @@ class UniformTest6(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # low and high are Tensor with dtype 'VarType.FP32'.
         self.low_np = np.random.randn(batch_size, dims).astype('float32')
-        self.high_np = np.random.uniform(-5.0, 5.0,
+        self.high_np = np.random.uniform(5.0, 15.0,
                                          (batch_size, dims)).astype('float32')
         self.values_np = np.random.randn(batch_size, dims).astype('float32')
 
@@ -277,7 +277,7 @@ class UniformTest7(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # low and high are Tensor with dtype 'VarType.FP64'.
         self.low_np = np.random.randn(batch_size, dims).astype('float64')
-        self.high_np = np.random.uniform(-5.0, 5.0,
+        self.high_np = np.random.uniform(5.0, 15.0,
                                          (batch_size, dims)).astype('float64')
         self.values_np = np.random.randn(batch_size, dims).astype('float64')
 
@@ -300,7 +300,7 @@ class UniformTest8(UniformTest):
     def init_numpy_data(self, batch_size, dims):
         # low and high are Tensor with dtype 'VarType.FP64'. value's dtype is 'VarType.FP32'.
         self.low_np = np.random.randn(batch_size, dims).astype('float64')
-        self.high_np = np.random.uniform(-5.0, 5.0,
+        self.high_np = np.random.uniform(5.0, 15.0,
                                          (batch_size, dims)).astype('float64')
         self.values_np = np.random.randn(batch_size, dims).astype('float32')
 
@@ -315,6 +315,23 @@ class UniformTest8(UniformTest):
                 name='low', shape=[dims], dtype='float64')
             self.static_high = layers.data(
                 name='high', shape=[dims], dtype='float64')
+            self.static_values = layers.data(
+                name='values', shape=[dims], dtype='float32')
+
+
+class UniformTest9(UniformTest):
+    def init_numpy_data(self, batch_size, dims):
+        # low and high are numpy.ndarray with dtype 'float32'.
+        # high < low.
+        self.low_np = np.random.randn(batch_size, dims).astype('float32')
+        self.high_np = np.random.uniform(-10.0, -5.0,
+                                         (batch_size, dims)).astype('float32')
+        self.values_np = np.random.randn(batch_size, dims).astype('float32')
+
+    def init_static_data(self, batch_size, dims):
+        self.static_low = self.low_np
+        self.static_high = self.high_np
+        with fluid.program_guard(self.test_program):
             self.static_values = layers.data(
                 name='values', shape=[dims], dtype='float32')
 
@@ -368,7 +385,7 @@ class NormalTest(unittest.TestCase):
             self.static_values = layers.data(
                 name='values', shape=[], dtype='float32')
 
-    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-4):
+    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-6):
         sample, entropy, log_prob, probs, kl = fetch_list
 
         np_normal = NormalNumpy(self.loc_np, self.scale_np)
@@ -387,7 +404,7 @@ class NormalTest(unittest.TestCase):
         np.testing.assert_allclose(probs, np_p, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(kl, np_kl, rtol=tolerance, atol=tolerance)
 
-    def test_normal_distribution_dygraph(self, sample_shape=7, tolerance=1e-4):
+    def test_normal_distribution_dygraph(self, sample_shape=7, tolerance=1e-6):
         paddle.disable_static(self.place)
         normal = Normal(self.dynamic_loc, self.dynamic_scale)
 
@@ -401,7 +418,7 @@ class NormalTest(unittest.TestCase):
         fetch_list = [sample, entropy, log_prob, probs, kl]
         self.compare_with_numpy(fetch_list)
 
-    def test_normal_distribution_static(self, sample_shape=7, tolerance=1e-4):
+    def test_normal_distribution_static(self, sample_shape=7, tolerance=1e-6):
         paddle.enable_static()
         with fluid.program_guard(self.test_program):
             normal = Normal(self.static_loc, self.static_scale)

--- a/python/paddle/fluid/tests/unittests/test_distribution.py
+++ b/python/paddle/fluid/tests/unittests/test_distribution.py
@@ -138,7 +138,7 @@ class UniformTest(unittest.TestCase):
             self.static_values = layers.data(
                 name='values', shape=[], dtype='float32')
 
-    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-6):
+    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-4):
         sample, entropy, log_prob, probs = fetch_list
 
         np_uniform = UniformNumpy(self.low_np, self.high_np)
@@ -154,7 +154,7 @@ class UniformTest(unittest.TestCase):
             log_prob, np_lp, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(probs, np_p, rtol=tolerance, atol=tolerance)
 
-    def test_uniform_distribution_dygraph(self, sample_shape=7, tolerance=1e-6):
+    def test_uniform_distribution_dygraph(self, sample_shape=7, tolerance=1e-4):
         paddle.disable_static(self.place)
         uniform = Uniform(self.dynamic_low, self.dynamic_high)
         sample = uniform.sample([sample_shape]).numpy()
@@ -165,7 +165,7 @@ class UniformTest(unittest.TestCase):
 
         self.compare_with_numpy(fetch_list)
 
-    def test_uniform_distribution_static(self, sample_shape=7, tolerance=1e-6):
+    def test_uniform_distribution_static(self, sample_shape=7, tolerance=1e-4):
         paddle.enable_static()
         with fluid.program_guard(self.test_program):
             uniform = Uniform(self.static_low, self.static_high)
@@ -368,7 +368,7 @@ class NormalTest(unittest.TestCase):
             self.static_values = layers.data(
                 name='values', shape=[], dtype='float32')
 
-    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-6):
+    def compare_with_numpy(self, fetch_list, sample_shape=7, tolerance=1e-4):
         sample, entropy, log_prob, probs, kl = fetch_list
 
         np_normal = NormalNumpy(self.loc_np, self.scale_np)
@@ -387,7 +387,7 @@ class NormalTest(unittest.TestCase):
         np.testing.assert_allclose(probs, np_p, rtol=tolerance, atol=tolerance)
         np.testing.assert_allclose(kl, np_kl, rtol=tolerance, atol=tolerance)
 
-    def test_normal_distribution_dygraph(self, sample_shape=7, tolerance=1e-6):
+    def test_normal_distribution_dygraph(self, sample_shape=7, tolerance=1e-4):
         paddle.disable_static(self.place)
         normal = Normal(self.dynamic_loc, self.dynamic_scale)
 
@@ -401,7 +401,7 @@ class NormalTest(unittest.TestCase):
         fetch_list = [sample, entropy, log_prob, probs, kl]
         self.compare_with_numpy(fetch_list)
 
-    def test_normal_distribution_static(self, sample_shape=7, tolerance=1e-6):
+    def test_normal_distribution_static(self, sample_shape=7, tolerance=1e-4):
         paddle.enable_static()
         with fluid.program_guard(self.test_program):
             normal = Normal(self.static_loc, self.static_scale)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

#### reason for test_distribution failure
- Because `assign` op does not support the input of numpy.ndarray whose dtype is `FP64`. 
When users set `FP64 numpy.ndarray` as the parameters of `Uniform` and `Normal` classes. We need to use `assign` op to convert it to `FP32 Tensor`. And then use `cast` op to convert it to a `FP64 Tensor`.
There is a loss of accuracy in this conversion.
Refer to PR https://github.com/PaddlePaddle/Paddle/pull/26767 .

- In test_distribution, compare the output of paddle and output of numpy to verify the correction.
In `Uniform(low, high)`, the formula to calculate the entropy is `entropy(low, high) = log (high - low)`.
if `low` and `high` are very close, `high - low` will be close to `0`, and small precision loss will become large error because of using `log`.


#### solution

In the realization of the original `Uniform` unittest, the range of `low` is [-1, 1), the range of `high` is [-5, 5).
To avoid `low` and `high` being too close, set `low` in the range of [-1, 1), and set `high` in range of [5, 15).
What's more, add a unittest to discuss the situation that `high < low`.

`log_prob` unittest of `Normal` class also fails, change the tolerance from 1e-6 to 1e-4.
tolerance: 1e-6 -> 1e-4

