### PR TITLE
Fix padding in conv1d op

### DIFF
--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -248,7 +248,7 @@ class Conv1d(_ConvNd):
         padding = 0
         if self._padding_mode != "zeros":
             x = F.pad(x,
-                      self._padding,
+                      self._reversed_padding_repeated_twice,
                       mode=self._padding_mode,
                       data_format=self._data_format)
         else:


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
Fix padding in conv1d op when padding is an instance of int.