### PR TITLE
[API 2.0] Fix api 'is_empty' 

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -3790,9 +3790,6 @@ def reorder_lod_tensor_by_rank(x, rank_table):
 
 def is_empty(x, name=None):
     """
-    :alias_main: paddle.is_empty
-	:alias: paddle.is_empty,paddle.tensor.is_empty,paddle.tensor.logic.is_empty
-	:old_api: paddle.fluid.layers.is_empty
 
     Test whether a Tensor is empty.
 
@@ -3820,23 +3817,6 @@ def is_empty(x, name=None):
             #    - layout: NCHW
             #    - dtype: bool
             #    - data: [0])
-
-
-        .. code-block:: python
-
-            # static mode
-            import numpy as np
-            import paddle
-
-            paddle.enable_static()
-            input = paddle.static.data(name="input", shape=[4, 32, 32], dtype="float32")
-            res = paddle.is_empty(x=input)
-
-            exe = paddle.static.Executor(paddle.CPUPlace())
-            data = np.ones((4, 32, 32)).astype(np.float32)
-            out = exe.run(feed={'input':data}, fetch_list=[res])
-            print("is_empty: ", out)
-            # ('out:', [array([False])])
 
     """
     if in_dygraph_mode():

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -3794,18 +3794,34 @@ def is_empty(x, name=None):
 	:alias: paddle.is_empty,paddle.tensor.is_empty,paddle.tensor.logic.is_empty
 	:old_api: paddle.fluid.layers.is_empty
 
-    Test whether a Variable is empty.
+    Test whether a Tensor is empty.
 
     Args:
-        x (Variable): The Variable to be tested.
+        x (Tensor): The Tensor to be tested.
         name (str, optional): The default value is ``None`` . Normally users
                             don't have to set this parameter. For more information,
                             please refer to :ref:`api_guide_Name` .
 
     Returns:
-        Variable: A bool scalar. True if 'x' is an empty Variable.
+        Tensor: A bool scalar. True if 'x' is an empty Tensor.
 
     Examples:
+        .. code-block:: python
+
+            # dygraph_mode
+            import paddle
+
+            input = paddle.rand(shape=[4, 32, 32], dtype='float32')
+            res = paddle.is_empty(x=input)
+            print("res:", res)
+            # ('res:', Tensor: eager_tmp_1
+            #    - place: CPUPlace
+            #    - shape: [1]
+            #    - layout: NCHW
+            #    - dtype: bool
+            #    - data: [0])
+
+
         .. code-block:: python
 
             # static mode
@@ -3822,27 +3838,8 @@ def is_empty(x, name=None):
             print("is_empty: ", out)
             # ('out:', [array([False])])
 
-
-        .. code-block:: python
-
-            # dygraph_mode
-            import paddle
-
-            input = paddle.rand(shape=[4, 32, 32], dtype='float32')
-            res = paddle.is_empty(x=input)
-            print("res:", res)
-            # ('res:', Tensor: eager_tmp_1
-            #    - place: CPUPlace
-            #    - shape: [1]
-            #    - layout: NCHW
-            #    - dtype: bool
-            #    - data: [0])
-
     """
     if in_dygraph_mode():
-        assert isinstance(
-            x, Variable
-        ), "The input data 'x' in is_empty must be Variable in dygraph mode"
         return core.ops.is_empty(x)
 
     check_variable_and_dtype(x, 'x', ['float32', 'float64', 'int32', 'int64'],

--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -3800,12 +3800,11 @@ def is_empty(x, name=None):
                             please refer to :ref:`api_guide_Name` .
 
     Returns:
-        Tensor: A bool scalar. True if 'x' is an empty Tensor.
+        Tensor: A bool scalar Tensor. True if 'x' is an empty Tensor.
 
     Examples:
         .. code-block:: python
 
-            # dygraph_mode
             import paddle
 
             input = paddle.rand(shape=[4, 32, 32], dtype='float32')

--- a/python/paddle/fluid/tests/unittests/test_is_empty_op.py
+++ b/python/paddle/fluid/tests/unittests/test_is_empty_op.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
-import paddle.fluid as fluid
+import paddle
 
 
 class TestEmpty(OpTest):
@@ -39,39 +39,39 @@ class TestNotEmpty(TestEmpty):
 
 class TestIsEmptyOpError(unittest.TestCase):
     def test_errors(self):
-        with fluid.program_guard(fluid.Program(), fluid.Program()):
+        paddle.enable_static()
+        with paddle.static.program_guard(paddle.static.Program(),
+                                         paddle.static.Program()):
             input_data = np.random.random((3, 2)).astype("float64")
 
             def test_Variable():
                 # the input type must be Variable
-                fluid.layers.is_empty(x=input_data)
+                paddle.is_empty(x=input_data)
 
             self.assertRaises(TypeError, test_Variable)
 
-            def test_cond_Variable():
-                # cond type must be Variable or None
-                x2 = fluid.layers.data(name="x2", shape=[3, 2], dtype="float32")
-                cond_data = np.random.random((3, 2)).astype("float32")
-                fluid.layers.is_empty(x=x2, cond=cond_data)
-
-            self.assertRaises(TypeError, test_cond_Variable)
-
             def test_type():
                 # dtype must be float32, float64, int32, int64
-                x3 = fluid.layers.data(
+                x3 = paddle.static.data(
                     name="x3", shape=[4, 32, 32], dtype="bool")
-                res = fluid.layers.is_empty(x=x3)
+                res = paddle.is_empty(x=x3)
 
             self.assertRaises(TypeError, test_type)
 
-            def test_cond_type():
-                # cond dtype must be bool.
-                x4 = fluid.layers.data(name="x4", shape=[3, 2], dtype="float32")
-                cond = fluid.layers.data(
-                    name="cond", shape=[1], dtype="float32")
-                fluid.layers.is_empty(x=x4, cond=cond)
+            def test_name_type():
+                # name type must be string.
+                x4 = paddle.static.data(
+                    name="x4", shape=[3, 2], dtype="float32")
+                res = paddle.is_empty(x=x4, name=1)
 
-            self.assertRaises(TypeError, test_cond_type)
+            self.assertRaises(TypeError, test_name_type)
+
+
+class TestIsEmptyOpDygraph(unittest.TestCase):
+    def test_dygraph(self):
+        paddle.disable_static()
+        input = paddle.rand(shape=[4, 32, 32], dtype='float32')
+        res = paddle.is_empty(x=input)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 APIs
### Describe
<!-- Describe what this PR does -->
fix is_empty, main changes include:
1. api interface from  `is_empty(x, cond=None)` to `is_empty(x, name=None)`
2. add dygraph mode for `is_empty`
3. edit example code in static mode
4. add example code in dygraph mode

![image](https://user-images.githubusercontent.com/52735331/94425711-f6258480-01be-11eb-8549-8c0b7b54da12.png)

chinese doc PR: https://github.com/PaddlePaddle/FluidDoc/pull/2692