### PR TITLE
add paddle.fluid._cuda_synchronize

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1663,6 +1663,15 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("is_compiled_with_mkldnn", IsCompiledWithMKLDNN);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);
+  m.def("_cuda_synchronize", [](const platform::XPUPlace &place) {
+    platform::DeviceContextPool::Instance().Get(place)->Wait();
+  });
+  m.def("_cuda_synchronize", [](const platform::CUDAPlace &place) {
+    platform::DeviceContextPool::Instance().Get(place)->Wait();
+  });
+  m.def("_cuda_synchronize", [](const platform::CPUPlace &place) {
+    platform::DeviceContextPool::Instance().Get(place)->Wait();
+  });
 
   m.def("get_float_stats", []() {
     std::vector<paddle::platform::ExportedStatValue<float>> float_stats;

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1663,13 +1663,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("is_compiled_with_mkldnn", IsCompiledWithMKLDNN);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);
-  m.def("_cuda_synchronize", [](const platform::XPUPlace &place) {
-    platform::DeviceContextPool::Instance().Get(place)->Wait();
-  });
   m.def("_cuda_synchronize", [](const platform::CUDAPlace &place) {
-    platform::DeviceContextPool::Instance().Get(place)->Wait();
-  });
-  m.def("_cuda_synchronize", [](const platform::CPUPlace &place) {
     platform::DeviceContextPool::Instance().Get(place)->Wait();
   });
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -90,6 +90,7 @@ from .io import save, load, load_program_state, set_program_state
 from .dygraph.checkpoint import save_dygraph, load_dygraph
 from .dygraph.varbase_patch_methods import monkey_patch_varbase
 from . import generator
+from .core_avx import _cuda_synchronize
 Tensor = LoDTensor
 enable_imperative = enable_dygraph
 disable_imperative = disable_dygraph
@@ -133,7 +134,8 @@ __all__ = framework.__all__ + executor.__all__ + \
         'install_check',
         'save',
         'load',
-        'VarBase'
+        'VarBase',
+        '_cuda_synchronize'
     ]
 
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -90,7 +90,8 @@ from .io import save, load, load_program_state, set_program_state
 from .dygraph.checkpoint import save_dygraph, load_dygraph
 from .dygraph.varbase_patch_methods import monkey_patch_varbase
 from . import generator
-from .core_avx import _cuda_synchronize
+from .core import _cuda_synchronize
+
 Tensor = LoDTensor
 enable_imperative = enable_dygraph
 disable_imperative = disable_dygraph

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -263,6 +263,7 @@ if avx_supported():
         from .core_avx import _save_dygraph_dict
         from .core_avx import _load_dygraph_dict
         from .core_avx import _create_loaded_parameter
+        from .core_avx import _cuda_synchronize
         if sys.platform != 'win32':
             from .core_avx import _set_process_pids
             from .core_avx import _erase_process_pids
@@ -307,6 +308,7 @@ if load_noavx:
         from .core_noavx import _save_dygraph_dict
         from .core_noavx import _load_dygraph_dict
         from .core_noavx import _create_loaded_parameter
+        from .core_noavx import _cuda_synchronize
         if sys.platform != 'win32':
             from .core_noavx import _set_process_pids
             from .core_noavx import _erase_process_pids


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->
向python暴露paddle.fluid._cuda_synchronize接口。
其本质为DeviceContext::Wait()。