### PR TITLE
modify doc for unique_name

### DIFF
--- a/python/paddle/fluid/unique_name.py
+++ b/python/paddle/fluid/unique_name.py
@@ -97,9 +97,9 @@ def generate(key):
 
         .. code-block:: python
 
-            import paddle.fluid as fluid
-            name1 = fluid.unique_name.generate('fc')
-            name2 = fluid.unique_name.generate('fc')
+            import paddle
+            name1 = paddle.utils.unique_name.generate('fc')
+            name2 = paddle.utils.unique_name.generate('fc')
             print(name1, name2) # fc_0, fc_1
     """
     return generator(key)
@@ -154,19 +154,18 @@ def switch(new_generator=None, new_para_name_checker=None):
 
         .. code-block:: python
 
-            import paddle.fluid as fluid
-            name1 = fluid.unique_name.generate('fc')
-            name2 = fluid.unique_name.generate('fc')
+            import paddle
+            name1 = paddle.utils.unique_name.generate('fc')
+            name2 = paddle.utils.unique_name.generate('fc')
             print(name1, name2) # fc_0, fc_1
 
-            pre_generator, pre_dygraph_name_checker = fluid.unique_name.switch() # switch to a new anonymous namespace.
-            name2 = fluid.unique_name.generate('fc')
+            pre_generator, pre_dygraph_name_checker = paddle.utils.unique_name.switch() # switch to a new anonymous namespace.
+            name2 = paddle.utils.unique_name.generate('fc')
             print(name2) # fc_0
 
-            fluid.unique_name.switch(pre_generator, pre_dygraph_name_checker) # switch back to pre_generator.
-            name3 = fluid.unique_name.generate('fc')
+            paddle.utils.unique_name.switch(pre_generator, pre_dygraph_name_checker) # switch back to pre_generator.
+            name3 = paddle.utils.unique_name.generate('fc')
             print(name3) # fc_2, since pre_generator has generated fc_0, fc_1.
-
     """
     global generator
     old_generator = generator
@@ -204,17 +203,17 @@ def guard(new_generator=None):
 
         .. code-block:: python
 
-            import paddle.fluid as fluid
-            with fluid.unique_name.guard():
-              name_1 = fluid.unique_name.generate('fc')
-            with fluid.unique_name.guard():
-              name_2 = fluid.unique_name.generate('fc')
+            import paddle
+            with paddle.utils.unique_name.guard():
+                name_1 = paddle.utils.unique_name.generate('fc')
+            with paddle.utils.unique_name.guard():
+                name_2 = paddle.utils.unique_name.generate('fc')
             print(name_1, name_2) # fc_0, fc_0
 
-            with fluid.unique_name.guard('A'):
-              name_1 = fluid.unique_name.generate('fc')
-            with fluid.unique_name.guard('B'):
-              name_2 = fluid.unique_name.generate('fc') 
+            with paddle.utils.unique_name.guard('A'):
+                name_1 = paddle.utils.unique_name.generate('fc')
+            with paddle.utils.unique_name.guard('B'):
+                name_2 = paddle.utils.unique_name.generate('fc')
             print(name_1, name_2) # Afc_0, Bfc_0
     """
     if isinstance(new_generator, six.string_types):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
【Fluid API迁移至2.0 Paddle】paddle.fluid.unique_name.guard API迁移
卡片要求：
(1)1.8API list：paddle.fluid.unique_name.guard 
(2)2.0_main_alias：paddle.util.unique_name.guard 
(3) 组长建议：新API名称：暂无,暂无 

经确认，paddle.utils.unique_name.guard alias已经完成建立。
因此，修改了unique_name.guard unique_name.generate unique_name.switch三个函数的代码示例。
预览图如下：
![guard jgp](https://user-images.githubusercontent.com/26922892/94381553-5b9c5580-016c-11eb-83f8-02f2c7b72998.JPG)
![switch](https://user-images.githubusercontent.com/26922892/94381556-5d661900-016c-11eb-958b-688e49bdead8.jpg)
![generate](https://user-images.githubusercontent.com/26922892/94381557-5dfeaf80-016c-11eb-8463-b9a5c91e65d8.jpg)