### PR TITLE
Remove optimizer which exposed in fleet

### DIFF
--- a/python/paddle/optimizer/__init__.py
+++ b/python/paddle/optimizer/__init__.py
@@ -14,24 +14,20 @@
 
 __all__ = [
     'Adadelta', 'AdadeltaOptimizer', 'Adagrad', 'AdagradOptimizer', 'Adam',
-    'Adamax', 'AdamW', 'DecayedAdagrad', 'DecayedAdagradOptimizer',
-    'DGCMomentumOptimizer', 'Dpsgd', 'DpsgdOptimizer',
-    'ExponentialMovingAverage', 'Ftrl', 'FtrlOptimizer', 'LambOptimizer',
-    'LarsMomentum', 'LarsMomentumOptimizer', 'LookaheadOptimizer',
-    'ModelAverage', 'Momentum', 'MomentumOptimizer', 'PipelineOptimizer',
-    'RecomputeOptimizer', 'RMSProp', 'SGD', 'SGDOptimizer', 'Optimizer',
-    '_LRScheduler', 'NoamLR', 'PiecewiseLR', 'NaturalExpLR', 'InverseTimeLR',
-    'PolynomialLR', 'LinearLrWarmup', 'ExponentialLR', 'MultiStepLR', 'StepLR',
-    'LambdaLR', 'ReduceLROnPlateau', 'CosineAnnealingLR'
+    'Adamax', 'AdamW', 'DecayedAdagrad', 'DecayedAdagradOptimizer', 'Dpsgd',
+    'DpsgdOptimizer', 'ExponentialMovingAverage', 'Ftrl', 'FtrlOptimizer',
+    'LookaheadOptimizer', 'ModelAverage', 'Momentum', 'MomentumOptimizer',
+    'RMSProp', 'SGD', 'SGDOptimizer', 'Optimizer', '_LRScheduler', 'NoamLR',
+    'PiecewiseLR', 'NaturalExpLR', 'InverseTimeLR', 'PolynomialLR',
+    'LinearLrWarmup', 'ExponentialLR', 'MultiStepLR', 'StepLR', 'LambdaLR',
+    'ReduceLROnPlateau', 'CosineAnnealingLR'
 ]
 
 
 from ..fluid.optimizer import Momentum, Adagrad, Dpsgd, DecayedAdagrad, Ftrl,\
-            AdagradOptimizer,DpsgdOptimizer,\
-            DecayedAdagradOptimizer,FtrlOptimizer,AdadeltaOptimizer, \
-            ModelAverage, LarsMomentum, DGCMomentumOptimizer, LambOptimizer,\
-            ExponentialMovingAverage, PipelineOptimizer, LookaheadOptimizer, \
-            RecomputeOptimizer, LarsMomentumOptimizer
+            AdagradOptimizer, DpsgdOptimizer, DecayedAdagradOptimizer, \
+            FtrlOptimizer, AdadeltaOptimizer, ModelAverage, \
+            ExponentialMovingAverage, LookaheadOptimizer
 
 from .optimizer import Optimizer
 from .adam import Adam


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
Remove `DGCMomentumOptimizer, LarsMomentum, LambOptimizer, PipelineOptimizer, RecomputeOptimizer` which has exposed in fleet.
Users can apply these interfaces in the following ways:
``` python
import paddle.distributed.fleet as fleet
strategy = fleet.DistributedStrategy()
strategy.dgc = True  # DGCMomentumOptimizer
strategy.lars = True  # LarsMomentum
strategy.lamb = True  # LambOptimizer
strategy.pipeline = True  # PipelineOptimizer
strategy.recompute = True  # RecomputeOptimizer
```
More details can see https://www.paddlepaddle.org.cn/documentation/docs/zh/develop/api/paddle/distributed/fleet/DistributedStrategy_cn.html

