### PR TITLE
modify doc for in_dygraph_mode

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -180,14 +180,12 @@ def require_version(min_version, max_version=None):
 
 def in_dygraph_mode():
     """
-    :alias_main: paddle.in_dygraph_mode
-	:alias: paddle.in_dygraph_mode
-	:old_api: paddle.fluid.framework.in_dygraph_mode
-
     This function checks whether the program runs in dynamic graph mode or not.
-    You can enter dynamic graph mode with :ref:`api_fluid_dygraph_guard` api,
-    or enable and disable dynamic graph mode with :ref:`api_fluid_dygraph_enable`
-    and :ref:`api_fluid_dygraph_disable` api .
+    Starting with paddle2.0, the dynamic graph mode the default mode.
+
+    **Note**:
+        ``paddle.in_dynamic_mode`` is the alias of ``fluid.in_dygraph_mode``, and
+        ``paddle.in_dynamic_mode`` is recommended to use.
 
     Returns:
         bool: Whether the program is running in dynamic graph mode.
@@ -195,12 +193,11 @@ def in_dygraph_mode():
     Examples:
         .. code-block:: python
 
-            import paddle.fluid as fluid
+            import paddle
 
-            fluid.enable_dygraph()  # Now we are in dygragh mode
-            print(fluid.in_dygraph_mode())  # True
-            fluid.disable_dygraph()
-            print(fluid.in_dygraph_mode())  # False
+            print(paddle.in_dynamic_mode())  # True
+            paddle.enable_static()
+            print(paddle.in_dynamic_mode())  # False
     """
     return _dygraph_tracer_ is not None
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs 
### Describe
<!-- Describe what this PR does -->
根据2.0API要求，修改paddle.in_dynamic_mode代码示例

icafe描述如下：
(1)1.8API list：paddle.fluid.dygraph.enabled 
(2)2.0_main_alias：paddle.in_dynamic_mode 
(3) 组长建议：新API名称：暂无,文档和示例待更新 

经与胡晓光沟通：
本次文档修复，不修复enabled文档。而是修复fluid.in_dygraph_mode文档，并建议用户使用paddle.in_dynamic_mode

文档预览图：
![dmode](https://user-images.githubusercontent.com/26922892/94384602-8939cc80-0175-11eb-810e-560844f43900.jpg)
