### PR TITLE
Remove NLTK package requirements to avoid dependency security alert 

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -5,11 +5,9 @@ protobuf>=3.1.0
 gast==0.3.3
 matplotlib<=2.2.4 ; python_version<"3.6"
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"
-nltk>=3.2.2, <=3.4 ; python_version<"3.5"
 matplotlib<=3.2.1 ; python_version>="3.6"
 scipy<=1.3.1 ; python_version=="3.5"
 scipy ; python_version>"3.5"
-nltk ; python_version>="3.5"
 rarfile
 Pillow
 six


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
Remove NLTK package requirements to avoid dependency security alert 
