### PR TITLE
update initializer.Normal API

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/bert_dygraph_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/bert_dygraph_model.py
@@ -181,7 +181,7 @@ class BertModelLayer(Layer):
         self._dtype = "float16" if use_fp16 else "float32"
 
         self._param_initializer = fluid.initializer.TruncatedNormal(
-            scale=config['initializer_range'])
+            std=config['initializer_range'])
 
         self._src_emb = Embedding(
             size=[self._voc_size, self._emb_size],
@@ -276,7 +276,7 @@ class PretrainModelLayer(Layer):
 
         self._word_emb_name = "word_embedding"
         self._param_initializer = fluid.initializer.TruncatedNormal(
-            scale=config['initializer_range'])
+            std=config['initializer_range'])
         self._weight_sharing = weight_sharing
         self.use_fp16 = use_fp16
         self._dtype = "float16" if use_fp16 else "float32"

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cycle_gan.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_cycle_gan.py
@@ -329,7 +329,7 @@ class conv2d(fluid.dygraph.Layer):
             use_cudnn=use_cudnn,
             param_attr=fluid.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=stddev)),
+                    mean=0.0, std=stddev)),
             bias_attr=con_bias_attr)
         # Note(Aurelius84): The calculation of GPU kernel in BN is non-deterministic, 
         # failure rate is 1/100 in Dev but seems incremental in CE platform.
@@ -390,7 +390,7 @@ class DeConv2D(fluid.dygraph.Layer):
             use_cudnn=use_cudnn,
             param_attr=fluid.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=stddev)),
+                    mean=0.0, std=stddev)),
             bias_attr=de_bias_attr)
         if fluid.is_compiled_with_cuda():
             norm = False

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_mnist.py
@@ -98,7 +98,7 @@ class MNIST(fluid.dygraph.Layer):
             10,
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=scale)),
+                    mean=0.0, std=scale)),
             act="softmax")
 
     @paddle.jit.to_static

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_mnist.py
@@ -96,7 +96,7 @@ class MNIST(fluid.dygraph.Layer):
             10,
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=scale)),
+                    mean=0.0, std=scale)),
             act="softmax")
 
     def forward(self, inputs, label):

--- a/python/paddle/fluid/tests/unittests/test_cuda_random_seed.py
+++ b/python/paddle/fluid/tests/unittests/test_cuda_random_seed.py
@@ -127,12 +127,12 @@ class TestGeneratorSeed(unittest.TestCase):
                 input=x,
                 size=10,
                 param_attr=fluid.initializer.TruncatedNormal(
-                    loc=0.0, scale=2.0))
+                    mean=0.0, std=2.0))
             result_2 = fluid.layers.fc(
                 input=x,
                 size=10,
                 param_attr=fluid.initializer.TruncatedNormal(
-                    loc=0.0, scale=2.0))
+                    mean=0.0, std=2.0))
 
             exe = fluid.Executor(fluid.CPUPlace())
             exe.run(startup_program)

--- a/python/paddle/fluid/tests/unittests/test_desc_clone.py
+++ b/python/paddle/fluid/tests/unittests/test_desc_clone.py
@@ -67,7 +67,7 @@ def cnn_model(data):
         act="softmax",
         param_attr=fluid.param_attr.ParamAttr(
             initializer=fluid.initializer.NormalInitializer(
-                loc=0.0, scale=scale)))
+                mean=0.0, std=scale)))
     return predict
 
 

--- a/python/paddle/fluid/tests/unittests/test_dist_fleet_heter_program.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_fleet_heter_program.py
@@ -87,7 +87,7 @@ class TestDistFleetHeterProgram(unittest.TestCase):
                 size=400,
                 act="relu",
                 param_attr=fluid.ParamAttr(initializer=fluid.initializer.Normal(
-                    scale=1 / math.sqrt(concated.shape[1]))),
+                    std=1 / math.sqrt(concated.shape[1]))),
                 name="fc1")
 
         with fluid.device_guard("cpu"):
@@ -96,7 +96,7 @@ class TestDistFleetHeterProgram(unittest.TestCase):
                                   act="relu",
                                   param_attr=fluid.ParamAttr(
                                       initializer=fluid.initializer.Normal(
-                                          scale=1 / math.sqrt(fc1.shape[1]))),
+                                          std=1 / math.sqrt(fc1.shape[1]))),
                                   name="fc2")
 
         with fluid.device_guard("gpu"):
@@ -105,7 +105,7 @@ class TestDistFleetHeterProgram(unittest.TestCase):
                                   act="relu",
                                   param_attr=fluid.ParamAttr(
                                       initializer=fluid.initializer.Normal(
-                                          scale=1 / math.sqrt(fc2.shape[1]))),
+                                          std=1 / math.sqrt(fc2.shape[1]))),
                                   name="fc3")
 
         with fluid.device_guard("cpu"):
@@ -114,7 +114,7 @@ class TestDistFleetHeterProgram(unittest.TestCase):
                 size=2,
                 act="softmax",
                 param_attr=fluid.ParamAttr(initializer=fluid.initializer.Normal(
-                    scale=1 / math.sqrt(fc3.shape[1]))), )
+                    std=1 / math.sqrt(fc3.shape[1]))), )
 
         with fluid.device_guard("gpu"):
             labels = fluid.layers.cast(inputs[-1], dtype="int64")

--- a/python/paddle/fluid/tests/unittests/test_dist_transpiler.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_transpiler.py
@@ -1055,7 +1055,7 @@ class TestRemoteHsigmoid(TestDistLookupTableBase):
             is_sparse=is_sparse,
             size=[3, 3],
             param_attr=fluid.ParamAttr(initializer=fluid.initializer.Normal(
-                scale=1 / math.sqrt(num_total_classes))))
+                std=1 / math.sqrt(num_total_classes))))
 
         cost = fluid.layers.hsigmoid(
             input=emb,

--- a/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_mnist_fp16.py
@@ -102,7 +102,7 @@ class MNIST(fluid.dygraph.Layer):
             10,
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=scale)),
+                    mean=0.0, std=scale)),
             act="softmax",
             dtype=dtype)
 

--- a/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
+++ b/python/paddle/fluid/tests/unittests/test_dygraph_multi_forward.py
@@ -94,7 +94,7 @@ class MNIST(fluid.dygraph.Layer):
             SIZE,
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=scale)),
+                    mean=0.0, std=scale)),
             act="softmax")
 
     def forward(self, inputs):

--- a/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
+++ b/python/paddle/fluid/tests/unittests/test_hsigmoid_op.py
@@ -249,7 +249,7 @@ class TestHSigmoidOpWithSparseGrad(unittest.TestCase):
             is_sparse=is_sparse,
             size=[3, 3],
             param_attr=fluid.ParamAttr(initializer=fluid.initializer.Normal(
-                scale=1 / math.sqrt(3))))
+                std=1 / math.sqrt(3))))
 
         cost = fluid.layers.hsigmoid(
             input=emb,

--- a/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_mnist.py
@@ -93,7 +93,7 @@ class MNIST(fluid.dygraph.Layer):
             10,
             param_attr=fluid.param_attr.ParamAttr(
                 initializer=fluid.initializer.NormalInitializer(
-                    loc=0.0, scale=scale)),
+                    mean=0.0, std=scale)),
             act="softmax")
 
     def forward(self, inputs):

--- a/python/paddle/fluid/tests/unittests/test_random_seed.py
+++ b/python/paddle/fluid/tests/unittests/test_random_seed.py
@@ -458,12 +458,12 @@ class TestGeneratorSeed(unittest.TestCase):
                 input=x,
                 size=10,
                 param_attr=fluid.initializer.TruncatedNormal(
-                    loc=0.0, scale=2.0))
+                    mean=0.0, std=2.0))
             result_2 = fluid.layers.fc(
                 input=x,
                 size=10,
                 param_attr=fluid.initializer.TruncatedNormal(
-                    loc=0.0, scale=2.0))
+                    mean=0.0, std=2.0))
 
             exe = fluid.Executor(fluid.CPUPlace())
             exe.run(startup_program)

--- a/python/paddle/nn/initializer/__init__.py
+++ b/python/paddle/nn/initializer/__init__.py
@@ -20,7 +20,9 @@ from ...fluid.initializer import MSRA  #DEFINE_ALIAS
 from ...fluid.initializer import Normal  #DEFINE_ALIAS
 from ...fluid.initializer import TruncatedNormal  #DEFINE_ALIAS
 from ...fluid.initializer import Uniform  #DEFINE_ALIAS
-from ...fluid.initializer import Xavier  #DEFINE_ALIAS
+from ...fluid.initializer import XavierNormal  #DEFINE_ALIAS
+from ...fluid.initializer import XavierUniform  #DEFINE_ALIAS
+from ...fluid.initializer import NumpyArrayInitializer  #DEFINE_ALIAS
 
 __all__ = [
     'Bilinear',
@@ -29,5 +31,7 @@ __all__ = [
     'Normal',
     'TruncatedNormal',
     'Uniform',
-    'Xavier',
+    'XavierNormal',
+    'XavierUniform'
+    'NumpyArrayInitializer',
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
update initializer API, including: NormalInitializer, TruncatedNormalInitializer, UniformInitializer, XavierNormalInitializer, XavierUniformInitializer, NumpyArrayInitializer.

这次修改涉及的场景比较麻烦，好像在迁移之前就已经存在别名问题导致的文档问题 http://newicafe.baidu.com/v5/issue/DLTP-13276/show。 如果 XXX、XXXInitializer 接口都需要暴露，则必须都定义，不能再使用 XXX = XXXInitializer 的写法。前面的链接里面有讨论结论。比如，对于 Normal 和 NormalInitializer API，之前使用 Normal = NormalInitializer 别名方式，现在是重新定义了一个 类 Normal，继承自 NormalInitializer。

另外：
1. XavierNormalInitializer 和 XavierUniformInitializer 由于是新增 API，应该是放在 paddle.nn 目录实现的，但是鉴于整体代码结构，我这里还是放在 paddle.fluid 实现，采用别名方式映射到 paddle.nn 目录中。
2. XavierNormalInitializer 和 XavierUniformInitializer 不使用参数 gain，而继续使用参数 seed。这是之前调研时对于参数 gain 的意思有误解，它不是 seed 的意思，是系数（factor）的意思，所以这里还是保持和原来的实现一致，不改变 API 的具体实现。tensorflow 也是参数 seed，不是 gain，pytorch 是 gain。

我这里先提供一个初步的版本，麻烦看看哪里需要修改，请指出。


迁移到另一个 [PR#27744](https://github.com/PaddlePaddle/Paddle/pull/27744) 了，关闭此 PR。