### PR TITLE
remove beam_search and beam_search_decode api from paddle.nn

### DIFF
--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -45,8 +45,8 @@ from .control_flow import while_loop  #DEFINE_ALIAS
 # from .control_flow import rnn        #DEFINE_ALIAS
 # from .decode import BeamSearchDecoder        #DEFINE_ALIAS
 # from .decode import Decoder        #DEFINE_ALIAS
-from .decode import beam_search  #DEFINE_ALIAS
-from .decode import beam_search_decode  #DEFINE_ALIAS
+# from .decode import beam_search  #DEFINE_ALIAS
+# from .decode import beam_search_decode  #DEFINE_ALIAS
 # from .decode import crf_decoding        #DEFINE_ALIAS
 # from .decode import ctc_greedy_decoder        #DEFINE_ALIAS
 # from .decode import dynamic_decode        #DEFINE_ALIAS

--- a/python/paddle/nn/decode.py
+++ b/python/paddle/nn/decode.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 # TODO: define api to implement decoding algorithm  
-from ..fluid.layers import beam_search  #DEFINE_ALIAS
-from ..fluid.layers import beam_search_decode  #DEFINE_ALIAS
+# from ..fluid.layers import beam_search  #DEFINE_ALIAS
+# from ..fluid.layers import beam_search_decode  #DEFINE_ALIAS
 
 from ..fluid.layers import gather_tree  #DEFINE_ALIAS
 
 __all__ = [
     #       'BeamSearchDecoder',
     #       'Decoder',
-    'beam_search',
-    'beam_search_decode',
+    #       'beam_search',
+    #       'beam_search_decode',
     #       'crf_decoding',
     #       'ctc_greedy_decoder',
     #       'dynamic_decode',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
remove `beam_search` and `beam_search_decode` api from `paddle.nn` since they are both used for `lod-tensor` and for static graph mode for now. 