### PR TITLE
Fix program constructed by programdesc incomplete bug

### DIFF
--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -139,6 +139,7 @@ def _append_loaded_suffix_to_var(program_desc):
         var_desc.set_name(new_name)
         for block_idx in six.moves.range(program_desc.num_blocks()):
             block = program_desc.block(block_idx)
+            block._rename_var(cpt.to_bytes(old_name), cpt.to_bytes(new_name))
             for op_idx in six.moves.range(block.op_size()):
                 op = block.op(op_idx)
                 op._rename_input(old_name, new_name)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix program constructed by programdesc incomplete bug

only update var name is not enough, need use `BlockDesc._rename_var` update var info.

#### original:

the var `linear_0.w_0.load_0` and `linear_0.b_0.load_0`
```
{ // block 0
    var linear_1.tmp_0 : fluid.VarType.LOD_TENSOR.shape(16, 10).astype(VarType.FP32)
    var linear_1.tmp_1 : fluid.VarType.LOD_TENSOR.shape(16, 10).astype(VarType.FP32)
    var linear_0.w_0.load_0 : fluid.VarType.LOD_TENSOR.shape().astype(VarType.BOOL)
    var translated_layer/scale_0.tmp_0 : fluid.VarType.LOD_TENSOR.shape(16, 10).astype(VarType.FP32)
    var linear_0.b_0.load_0 : fluid.VarType.LOD_TENSOR.shape().astype(VarType.BOOL)
    var generated_var_0 : fluid.VarType.LOD_TENSOR.shape(16, 784).astype(VarType.FP32)

    {Out=['linear_1.tmp_0']} = matmul(inputs={X=['generated_var_0'], Y=['linear_0.w_0.load_0']}, Scale_out = 1.0, Scale_x = 1.0, Scale_y = 1.0, alpha = 1.0, force_fp32_output = False, fused_reshape_Out = [], fused_reshape_X = [], fused_reshape_Y = [], fused_transpose_Out = [], fused_transpose_X = [], fused_transpose_Y = [], mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], transpose_X = False, transpose_Y = False, use_mkldnn = False, use_quantizer = False)
    {Out=['linear_1.tmp_1']} = elementwise_add(inputs={X=['linear_1.tmp_0'], Y=['linear_0.b_0.load_0']}, Scale_out = 1.0, Scale_x = 1.0, Scale_y = 1.0, axis = 1, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], use_mkldnn = False, use_quantizer = False, x_data_format = , y_data_format = )
    {Out=['translated_layer/scale_0.tmp_0']} = scale(inputs={ScaleTensor=[], X=['linear_1.tmp_1']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], scale = 1.0)
}
```

- fixed:
```
{ // block 0
    persist var linear_0.b_0.load_0 : fluid.VarType.LOD_TENSOR.shape(10,).astype(VarType.FP32)
    var linear_1.tmp_0 : fluid.VarType.LOD_TENSOR.shape(16, 10).astype(VarType.FP32)
    var linear_1.tmp_1 : fluid.VarType.LOD_TENSOR.shape(16, 10).astype(VarType.FP32)
    persist var linear_0.w_0.load_0 : fluid.VarType.LOD_TENSOR.shape(784, 10).astype(VarType.FP32)
    var translated_layer/scale_0.tmp_0 : fluid.VarType.LOD_TENSOR.shape(16, 10).astype(VarType.FP32)
    var generated_var_0 : fluid.VarType.LOD_TENSOR.shape(16, 784).astype(VarType.FP32)

    {Out=['linear_1.tmp_0']} = matmul(inputs={X=['generated_var_0'], Y=['linear_0.w_0.load_0']}, Scale_out = 1.0, Scale_x = 1.0, Scale_y = 1.0, alpha = 1.0, force_fp32_output = False, fused_reshape_Out = [], fused_reshape_X = [], fused_reshape_Y = [], fused_transpose_Out = [], fused_transpose_X = [], fused_transpose_Y = [], mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], transpose_X = False, transpose_Y = False, use_mkldnn = False, use_quantizer = False)
    {Out=['linear_1.tmp_1']} = elementwise_add(inputs={X=['linear_1.tmp_0'], Y=['linear_0.b_0.load_0']}, Scale_out = 1.0, Scale_x = 1.0, Scale_y = 1.0, axis = 1, mkldnn_data_type = float32, op_device = , op_namescope = /, op_role = 0, op_role_var = [], use_mkldnn = False, use_quantizer = False, x_data_format = , y_data_format = )
    {Out=['translated_layer/scale_0.tmp_0']} = scale(inputs={ScaleTensor=[], X=['linear_1.tmp_1']}, bias = 0.0, bias_after_scale = True, op_device = , op_namescope = /, op_role = 0, op_role_var = [], scale = 1.0)
}
```