### PR TITLE
set fetch async op to highest

### DIFF
--- a/paddle/fluid/framework/details/fetch_async_op_handle.h
+++ b/paddle/fluid/framework/details/fetch_async_op_handle.h
@@ -53,6 +53,8 @@ struct FetchAsyncOpHandle : public OpHandleBase {
 
   bool IsMultiDeviceTransfer() override;
 
+  Priority GetPriority() const override { return kHighest; }
+
  protected:
   void RunImpl() override;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
# 背景
PE，在Fetch完成后，exe.run是可以提前返回的。
这有利于下一轮“准备”工作的提前展开，使得GPU能够更充分利用。
如果等本轮所有GPU Kernel计算结束，exe.run才返回。那么在两次exe.run之间，因为数据加载、拉起Kernel等问题，会是GPU出现少量空闲时间。如下图所示：
![微信图片_20200929194732](https://user-images.githubusercontent.com/26922892/94554425-a4e3c680-028c-11eb-982d-78323f27611f.png)

# 本次修改点
近期，在分析Resnet模型性能时，发现一个问题：
在多线程调度时，FetchOP，会重新切换一个线程，负责OP的Context准备工作。而这个线程调度，存在随机性。有时候，会在整轮OP中的最后一个被拉起。因此阻塞了exe.run的日前结束。这在一些场景下会影响PE性能。
本PR，通过设置FetchOP的优先级，让FetchOP保留在当前线程高优处理，优化该问题。

值得注意的是：TF中将OP“丢”到其它线程上运行，与Paddle的策略是不同的：
Paddle策略：除了Highest的，其余全都丢掉新线成上；
TF策略：只有运行缓慢的OP，才丢掉新线程独立运行，其余保留在当前线程下。
而本人在入职初期，曾分析发现，OP Context的准备时间是非常短的，而切换线程是有开销的，有时候多线程无法达到OP Context准备加速的效果。
因此，Paddle的多线程策略有可能需要考虑调整。