### PR TITLE
Add avx512 core instructions check

### DIFF
--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -164,6 +164,13 @@ bool MayIUse(const cpu_isa_t cpu_isa) {
         // AVX512F: EBX Bit 16
         int avx512f_mask = (1 << 16);
         return (reg[1] & avx512f_mask) != 0;
+      } else if (cpu_isa == avx512_core) {
+        uint avx512f_mask = (1 << 16);
+        uint avx512dq_mask = (1 << 17);
+        uint avx512bw_mask = (1 << 30);
+        uint avx512vl_mask = (1 << 31);
+        return ((reg[1] & avx512f_mask) && (reg[1] & avx512dq_mask) &&
++                (reg[1] & avx512bw_mask) && (reg[1] & avx512vl_mask));
       }
     }
 #endif

--- a/paddle/fluid/platform/cpu_info.cc
+++ b/paddle/fluid/platform/cpu_info.cc
@@ -165,12 +165,12 @@ bool MayIUse(const cpu_isa_t cpu_isa) {
         int avx512f_mask = (1 << 16);
         return (reg[1] & avx512f_mask) != 0;
       } else if (cpu_isa == avx512_core) {
-        uint avx512f_mask = (1 << 16);
-        uint avx512dq_mask = (1 << 17);
-        uint avx512bw_mask = (1 << 30);
-        uint avx512vl_mask = (1 << 31);
+        unsigned int avx512f_mask = (1 << 16);
+        unsigned int avx512dq_mask = (1 << 17);
+        unsigned int avx512bw_mask = (1 << 30);
+        unsigned int avx512vl_mask = (1 << 31);
         return ((reg[1] & avx512f_mask) && (reg[1] & avx512dq_mask) &&
-+                (reg[1] & avx512bw_mask) && (reg[1] & avx512vl_mask));
+                (reg[1] & avx512bw_mask) && (reg[1] & avx512vl_mask));
       }
     }
 #endif

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -142,6 +142,17 @@ bool IsCompiledWithMKLDNN() {
 #endif
 }
 
+bool IsBfloat16() {
+#ifndef PADDLE_WITH_MKLDNN
+  return false;
+#else
+  if (platform::MayIUse(platform::cpu_isa_t::avx512_core))
+    return true;
+  else
+    return false;
+#endif
+}
+
 bool IsCompiledWithBrpc() {
 #ifndef PADDLE_WITH_DISTRIBUTE
   return false;
@@ -1661,6 +1672,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("is_compiled_with_cuda", IsCompiledWithCUDA);
   m.def("is_compiled_with_xpu", IsCompiledWithXPU);
   m.def("is_compiled_with_mkldnn", IsCompiledWithMKLDNN);
+  m.def("is_bfloat16", IsBfloat16);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);
   m.def("_cuda_synchronize", [](const platform::CUDAPlace &place) {

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -142,7 +142,7 @@ bool IsCompiledWithMKLDNN() {
 #endif
 }
 
-bool IsBfloat16() {
+bool SupportsBfloat16() {
 #ifndef PADDLE_WITH_MKLDNN
   return false;
 #else
@@ -1672,7 +1672,7 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("is_compiled_with_cuda", IsCompiledWithCUDA);
   m.def("is_compiled_with_xpu", IsCompiledWithXPU);
   m.def("is_compiled_with_mkldnn", IsCompiledWithMKLDNN);
-  m.def("is_bfloat16", IsBfloat16);
+  m.def("supports_bfloat16", SupportsBfloat16);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);
   m.def("_cuda_synchronize", [](const platform::CUDAPlace &place) {

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -205,5 +205,5 @@ class TestWithInput1x1Filter1x1(TestConv2dBf16Op):
 
 
 if __name__ == '__main__':
-    if core.is_bfloat16():
+    if core.supports_bfloat16():
         unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -203,6 +203,7 @@ class TestWithInput1x1Filter1x1(TestConv2dBf16Op):
     def init_group(self):
         self.groups = 3
 
-    if __name__ == '__main__':
-        if core.is_bfloat16():
-            unittest.main()
+
+if __name__ == '__main__':
+    if core.is_bfloat16():
+        unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -19,7 +19,7 @@ import numpy as np
 import struct
 
 import paddle.fluid.core as core
-from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci, convert_float_to_uint16
+from paddle.fluid.tests.unittests.op_test import OpTest, convert_float_to_uint16
 from paddle.fluid.tests.unittests.test_conv2d_op import conv2d_forward_naive, TestConv2dOp
 
 
@@ -203,6 +203,6 @@ class TestWithInput1x1Filter1x1(TestConv2dBf16Op):
     def init_group(self):
         self.groups = 3
 
-
-if __name__ == '__main__':
-    unittest.main()
+    if __name__ == '__main__':
+        if core.is_bfloat16():
+            unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
This PR adds avx512 core instruction check in bfloat16 convolution test. Bfloat16 evaluation is possible only if the CPU has ` AVX512BW, AVX512VL, and AVX512DQ` flags. Without them, all tests with bfloat16 will fail.
It is related to https://github.com/PaddlePaddle/Paddle/issues/27588