### PR TITLE
[oneDNN] adaptive pool support

### DIFF
--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -126,21 +126,13 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     UpdatePadding(&paddings, global_pooling, 0, padding_algorithm, data_dims,
                   strides, ksize);
 
-
     const bool adaptive = ctx.Attr<bool>("adaptive");
 
-    const auto src_tz = paddle::framework::vectorize(in_x->dims());
-    if (adaptive) {
-      ksize[0] = static_cast<int>(
-          ceil(static_cast<double>(src_tz[src_tz.size() - 2] / ksize[0])));
-      ksize[1] = static_cast<int>(
-          ceil(static_cast<double>(src_tz[src_tz.size() - 1] / ksize[1])));
-      strides[0] = ksize[0];
-      strides[1] = ksize[1];
-    }
+    PoolingMKLDNNHandler::ComputeAdaptivePoolParameters(
+        ctx, paddle::framework::vectorize(in_x->dims()), ksize, strides)
 
-    auto& dev_ctx =
-        ctx.template device_context<platform::MKLDNNDeviceContext>();
+        auto& dev_ctx =
+            ctx.template device_context<platform::MKLDNNDeviceContext>();
 
     std::vector<mkldnn::primitive> pipeline;
 

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -126,7 +126,7 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     UpdatePadding(&paddings, global_pooling, 0, padding_algorithm, data_dims,
                   strides, ksize);
 
-    platform::PoolingMKLDNNHandler::ComputeAdaptivePoolParameters(
+    platform::PoolingMKLDNNHandler<T>::ComputeAdaptivePoolParameters(
         ctx, paddle::framework::vectorize(in_x->dims()), ksize, strides);
 
     auto& dev_ctx =

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -126,11 +126,11 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     UpdatePadding(&paddings, global_pooling, 0, padding_algorithm, data_dims,
                   strides, ksize);
 
-    PoolingMKLDNNHandler::ComputeAdaptivePoolParameters(
+    platform::PoolingMKLDNNHandler::ComputeAdaptivePoolParameters(
         ctx, paddle::framework::vectorize(in_x->dims()), ksize, strides);
 
-        auto& dev_ctx =
-            ctx.template device_context<platform::MKLDNNDeviceContext>();
+    auto& dev_ctx =
+        ctx.template device_context<platform::MKLDNNDeviceContext>();
 
     std::vector<mkldnn::primitive> pipeline;
 

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -126,6 +126,19 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     UpdatePadding(&paddings, global_pooling, 0, padding_algorithm, data_dims,
                   strides, ksize);
 
+
+    const bool adaptive = ctx.Attr<bool>("adaptive");
+
+    const auto src_tz = paddle::framework::vectorize(in_x->dims());
+    if (adaptive) {
+      ksize[0] = static_cast<int>(
+          ceil(static_cast<double>(src_tz[src_tz.size() - 2] / ksize[0])));
+      ksize[1] = static_cast<int>(
+          ceil(static_cast<double>(src_tz[src_tz.size() - 1] / ksize[1])));
+      strides[0] = ksize[0];
+      strides[1] = ksize[1];
+    }
+
     auto& dev_ctx =
         ctx.template device_context<platform::MKLDNNDeviceContext>();
 

--- a/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/pool_mkldnn_op.cc
@@ -126,10 +126,8 @@ class PoolMKLDNNGradOpKernel : public paddle::framework::OpKernel<T> {
     UpdatePadding(&paddings, global_pooling, 0, padding_algorithm, data_dims,
                   strides, ksize);
 
-    const bool adaptive = ctx.Attr<bool>("adaptive");
-
     PoolingMKLDNNHandler::ComputeAdaptivePoolParameters(
-        ctx, paddle::framework::vectorize(in_x->dims()), ksize, strides)
+        ctx, paddle::framework::vectorize(in_x->dims()), ksize, strides);
 
         auto& dev_ctx =
             ctx.template device_context<platform::MKLDNNDeviceContext>();

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -898,15 +898,6 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
 
     auto mkldnn_paddings = ToMkldnnPadding(paddings);
 
-    const bool adaptive = ctx.Attr<bool>("adaptive");
-    if (adaptive) {
-      ksize[0] = static_cast<int>(
-          ceil(static_cast<double>(src_tz[src_tz.size() - 2] / ksize[0])));
-      ksize[1] = static_cast<int>(
-          ceil(static_cast<double>(src_tz[src_tz.size() - 1] / ksize[1])));
-      strides[0] = ksize[0];
-      strides[1] = ksize[1];
-    }
 
     this->AcquireBackwardPrimitiveDescriptor(
         pooling_type == "max"

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -927,10 +927,17 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
       const std::vector<int64_t>& src_tz, std::vector<int64_t>& ksize,
       std::vector<int64_t>& strides) {
     if (ctx.Attr<bool>("adaptive")) {
-      ksize[0] = static_cast<int>(
-          ceil(static_cast<double>(src_tz[src_tz.size() - 2] / ksize[0])));
-      ksize[1] = static_cast<int>(
-          ceil(static_cast<double>(src_tz[src_tz.size() - 1] / ksize[1])));
+      // (jczaja): oneDNN is supporting only unchangable in size pool window
+      PADDLE_ENFORCE_EQ(
+          src_tz[src_tz.size() - 1] % ksize[1], 0,
+          platform::errors::Unimplemented(
+              "Input dim must be divisible by corressponding ksize dim."));
+      PADDLE_ENFORCE_EQ(
+          src_tz[src_tz.size() - 2] % ksize[0], 0,
+          platform::errors::Unimplemented(
+              "Input dim must be divisible by corressponding ksize dim."));
+      ksize[0] = src_tz[src_tz.size() - 2] / ksize[0];
+      ksize[1] = src_tz[src_tz.size() - 1] / ksize[1];
       strides[0] = ksize[0];
       strides[1] = ksize[1];
     }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -856,8 +856,8 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
       }
 
       if (adaptive) {
-        ksize[0] = static_cast<int>(ceil(static_cast<double>((src_tz[src_tz.size()-2]/ksize[0])));  
-        ksize[1] = static_cast<int>(ceil(static_cast<double>((src_tz[src_tz.size()-1]/ksize[1])));
+        ksize[0] = static_cast<int>(ceil(static_cast<double>(src_tz[src_tz.size()-2]/ksize[0])));  
+        ksize[1] = static_cast<int>(ceil(static_cast<double>(src_tz[src_tz.size()-1]/ksize[1])));
         strides[0] = ksize[0];
         strides[1] = ksize[1];
       }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -859,8 +859,8 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
 	PADDLE_ENFORCE_EQ(ksize , std::vector<int64_t>(2,1), 
 	  platform::errors::InvalidArgument(
           "Not supported ksize for adaptive mode"));
-	ksize[0] = dst_tz[dst_tz.size()-2];  
-	ksize[1] = dst_tz[dst_tz.size()-1];
+	ksize[0] = src_tz[src_tz.size()-2];  
+	ksize[1] = src_tz[src_tz.size()-1];
       }
 
       this->AcquireForwardPrimitiveDescriptor(

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -856,8 +856,10 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
       }
 
       if (adaptive) {
-        ksize[0] = static_cast<int>(ceil(static_cast<double>(src_tz[src_tz.size()-2]/ksize[0])));  
-        ksize[1] = static_cast<int>(ceil(static_cast<double>(src_tz[src_tz.size()-1]/ksize[1])));
+        ksize[0] = static_cast<int>(
+            ceil(static_cast<double>(src_tz[src_tz.size() - 2] / ksize[0])));
+        ksize[1] = static_cast<int>(
+            ceil(static_cast<double>(src_tz[src_tz.size() - 1] / ksize[1])));
         strides[0] = ksize[0];
         strides[1] = ksize[1];
       }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -856,11 +856,10 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
       }
 
       if (adaptive) {
-	PADDLE_ENFORCE_EQ(ksize , std::vector<int64_t>(2,1), 
-	  platform::errors::InvalidArgument(
-          "Not supported ksize for adaptive mode"));
-	ksize[0] = src_tz[src_tz.size()-2];  
-	ksize[1] = src_tz[src_tz.size()-1];
+        ksize[0] = static_cast<int>(ceil(static_cast<double>((src_tz[src_tz.size()-2]/ksize[0])));  
+        ksize[1] = static_cast<int>(ceil(static_cast<double>((src_tz[src_tz.size()-1]/ksize[1])));
+        strides[0] = ksize[0];
+        strides[1] = ksize[1];
       }
 
       this->AcquireForwardPrimitiveDescriptor(

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -898,6 +898,16 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
 
     auto mkldnn_paddings = ToMkldnnPadding(paddings);
 
+    const bool adaptive = ctx.Attr<bool>("adaptive");
+    if (adaptive) {
+      ksize[0] = static_cast<int>(
+          ceil(static_cast<double>(src_tz[src_tz.size() - 2] / ksize[0])));
+      ksize[1] = static_cast<int>(
+          ceil(static_cast<double>(src_tz[src_tz.size() - 1] / ksize[1])));
+      strides[0] = ksize[0];
+      strides[1] = ksize[1];
+    }
+
     this->AcquireBackwardPrimitiveDescriptor(
         pooling_type == "max"
             ? mkldnn::algorithm::pooling_max

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -835,7 +835,7 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
       const auto fmt = input->format();
 
       const auto exclude_padding = ctx.Attr<bool>("exclusive");
-      const bool adaptive = context.Attr<bool>("adaptive");
+      const bool adaptive = ctx.Attr<bool>("adaptive");
 
       const auto src_md = mkldnn::memory::desc(src_tz, dt, fmt);
       /* create memory descriptor for pooling without specified format

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -60,6 +60,7 @@ create_test_mkldnn_class(TestCase3)
 create_test_mkldnn_class(TestCase4)
 create_test_mkldnn_class(TestCase5)
 
+
 class TestAvgPoolAdaptive(TestPool2D_Op):
     def init_adaptive(self):
         self.adaptive = True
@@ -73,6 +74,8 @@ class TestAvgPoolAdaptive(TestPool2D_Op):
 
     def init_test_case(self):
         self.ksize = [1, 1]
+        self.strides = [1, 1]
+
 
 class TestAsymPad(TestPool2D_Op):
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -60,6 +60,19 @@ create_test_mkldnn_class(TestCase3)
 create_test_mkldnn_class(TestCase4)
 create_test_mkldnn_class(TestCase5)
 
+class TestAvgPoolAdaptive(TestPool2D_Op):
+    def init_adaptive(self):
+        self.adaptive = True
+
+    def init_pool_type(self):
+        self.pool_type = "avg"
+        self.pool2D_forward_naive = avg_pool2D_forward_naive
+
+    def init_kernel_type(self):
+        self.use_mkldnn = True
+
+    def init_test_case(self):
+        self.ksize = [1, 1]
 
 class TestAsymPad(TestPool2D_Op):
     def init_test_case(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -79,6 +79,7 @@ class TestAvgPoolAdaptive(TestPool2D_Op):
     def init_data_type(self):
         self.dtype = np.float32
 
+
 class TestAvgPoolAdaptive2(TestAvgPoolAdaptive):
     def init_test_case(self):
         self.ksize = [2, 2]

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -76,6 +76,14 @@ class TestAvgPoolAdaptive(TestPool2D_Op):
         self.ksize = [1, 1]
         self.strides = [1, 1]
 
+    def init_data_type(self):
+        self.dtype = np.float32
+
+class TestAvgPoolAdaptive2(TestAvgPoolAdaptive):
+    def init_test_case(self):
+        self.ksize = [2, 2]
+        self.strides = [1, 1]
+
 
 class TestAsymPad(TestPool2D_Op):
     def init_test_case(self):
@@ -176,4 +184,6 @@ class TestAsymPadValidNHWC(TestAsymPadValid):
 
 
 if __name__ == '__main__':
+    from paddle import enable_static
+    enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_pool2d_mkldnn_op.py
@@ -79,11 +79,17 @@ class TestAvgPoolAdaptive(TestPool2D_Op):
     def init_data_type(self):
         self.dtype = np.float32
 
+    def init_global_pool(self):
+        self.global_pool = False
+
 
 class TestAvgPoolAdaptive2(TestAvgPoolAdaptive):
     def init_test_case(self):
-        self.ksize = [2, 2]
+        self.ksize = [2, 3]
         self.strides = [1, 1]
+
+    def init_shape(self):
+        self.shape = [2, 3, 6, 6]
 
 
 class TestAsymPad(TestPool2D_Op):


### PR DESCRIPTION
### PR types
New features

### PR changes
OPs

### Describe
Added support for adaptive pooling (It was missing in oneDNN kernel) e.g. handling attribute "adaptive" and act accordingly. This is first of two fixes needed to fix #27398 
