### PR TITLE
Add avx512 core instructions check 2 

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -102,7 +102,6 @@ class TestConv2dBf16Op(TestConv2dOp):
             'force_fp32_output': self.force_fp32_output,
             'fuse_residual_connection': self.fuse_residual
         }
-        print("working.........")
 
     def test_check_output(self):
         self.check_output_with_place(core.CPUPlace())

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -35,6 +35,8 @@ def conv2d_residual_naive(out, residual):
     return out
 
 
+@unittest.skipIf(not core.supports_bfloat16(),
+                 "place does not support BF16 evaluation")
 class TestConv2dBf16Op(TestConv2dOp):
     def setUp(self):
         self.op_type = "conv2d"
@@ -42,9 +44,9 @@ class TestConv2dBf16Op(TestConv2dOp):
         self.exhaustive_search = False
         self.use_cuda = False
         self.use_mkldnn = True
+        self._cpu_only = True
         self.weight_type = np.float32
         self.input_type = np.float32
-        self.use_mkldnn = True
         self.mkldnn_data_type = "bfloat16"
         self.force_fp32_output = False
         self.init_group()
@@ -100,6 +102,7 @@ class TestConv2dBf16Op(TestConv2dOp):
             'force_fp32_output': self.force_fp32_output,
             'fuse_residual_connection': self.fuse_residual
         }
+        print("working.........")
 
     def test_check_output(self):
         self.check_output_with_place(core.CPUPlace())
@@ -205,5 +208,4 @@ class TestWithInput1x1Filter1x1(TestConv2dBf16Op):
 
 
 if __name__ == '__main__':
-    if core.supports_bfloat16():
-        unittest.main()
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
In previous PR https://github.com/PaddlePaddle/Paddle/pull/27732 I added an instruction check but it only works while running from python, but it did not work if the test was run from cmake. 
This PR adds `unittest.SkipIf` what skip the test if the place does not support bfloat16 evaluation and it works for both cases. 

It also removes duplicated `self.use_mkldnn = True`

