### PR TITLE
[oneDNN] Second fix to 27398

### DIFF
--- a/paddle/fluid/framework/data_transform.cc
+++ b/paddle/fluid/framework/data_transform.cc
@@ -117,6 +117,9 @@ void SetTensorToVariable(const Variable &in_var, const Tensor &tensor,
     auto *tran_lod_tensor = out_var->GetMutable<LoDTensor>();
     tran_lod_tensor->set_lod(in_lod_tensor.lod());
     tran_lod_tensor->set_layout(in_lod_tensor.layout());
+#ifdef PADDLE_WITH_MKLDNN
+    tran_lod_tensor->set_format(in_lod_tensor.format());
+#endif
     tran_lod_tensor->ShareDataWith(tensor);
   } else if (in_var.IsType<SelectedRows>()) {
     auto &in_selected_rows = in_var.Get<SelectedRows>();

--- a/paddle/fluid/framework/tensor_util.cc
+++ b/paddle/fluid/framework/tensor_util.cc
@@ -38,6 +38,9 @@ void TensorCopy(const Tensor& src, const platform::Place& dst_place,
 
   dst->Resize(src.dims());
   dst->set_layout(src.layout());
+#ifdef PADDLE_WITH_MKLDNN
+  dst->set_format(src.format());
+#endif
   auto src_place = src.place();
   auto src_ptr = src.data<void>();
   auto dst_ptr = dst->mutable_data(dst_place, src.type());
@@ -237,6 +240,9 @@ void TensorCopySync(const Tensor& src, const platform::Place& dst_place,
   src.check_memory_size();
   dst->Resize(src.dims());
   dst->set_layout(src.layout());
+#ifdef PADDLE_WITH_MKLDNN
+  dst->set_format(src.format());
+#endif
   auto src_place = src.place();
   auto src_ptr = src.data<void>();
   auto dst_ptr = dst->mutable_data(dst_place, src.type());


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
This is second of two PRs to fix #27398. It adds setting oneDNN format to tensor in some locations where layout is set (layout and format should be set together)
