### PR TITLE
Add unittest to check whether GPU whl package can run with CPU.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_install_check_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_install_check_cpu.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import os
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+import unittest
+import paddle.fluid as fluid
+
+
+class TestInstallCheckCPU(unittest.TestCase):
+    def test_install_check(self):
+        fluid.install_check.run_check()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
#### 问题介绍
开启GPU编的python包无法在CPU机器上运行，错误由@MrChengmo 报出。具体错误如下：
![image](https://user-images.githubusercontent.com/12538138/95545956-e8c79000-0a31-11eb-9a7a-a5edc93bc46a.png)

1.8.4版本没有问题：
![image](https://user-images.githubusercontent.com/12538138/95545989-ff6de700-0a31-11eb-9b44-67b8e8818561.png)

经 @wzzju 定位，该问题由https://github.com/PaddlePaddle/Paddle/pull/27443 引起，`import paddle`时某个文件调用了如下函数，会定义`CUDAPlace`，从而引起上述错误。
![image](https://user-images.githubusercontent.com/12538138/95546062-2d532b80-0a32-11eb-94d3-d7447dd507fe.png)

#### 解决方法
1. 添加单测test_install_check_cpu，develop执行情况如下：
```

```
2. 使用`if core.is_compiled_with_cuda() and core.get_cuda_device_count() > 0`判断CUDA是否可用。