### PR TITLE
Change type of mkldnn_data_type attribute

### DIFF
--- a/paddle/fluid/framework/ir/graph_pattern_detector.cc
+++ b/paddle/fluid/framework/ir/graph_pattern_detector.cc
@@ -2114,22 +2114,22 @@ PDNode *patterns::Bfloat16Placement::operator()(
 PDNode *patterns::OrphanedBfloat16::operator()() {
   auto *prev_op = pattern->NewNode(prev_op_repr())->assert_is_op();
   prev_op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") ==
-           "float32";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") ==
+           proto::VarType::FP32;
   });
   auto *prev_out = pattern->NewNode(prev_out_repr())->AsOutput();
 
   auto *op = pattern->NewNode(op_repr())->assert_is_op();
   op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") ==
-           "bfloat16";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") ==
+           proto::VarType::BF16;
   });
   auto *op_out = pattern->NewNode(op_out_repr())->AsOutput();
 
   auto *next_op = pattern->NewNode(next_op_repr())->assert_is_op();
   next_op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") ==
-           "float32";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") ==
+           proto::VarType::FP32;
   });
 
   prev_op->LinksTo({prev_out});
@@ -2141,15 +2141,15 @@ PDNode *patterns::OrphanedBfloat16::operator()() {
 PDNode *patterns::LastBfloat16Ops::operator()() {
   auto *op = pattern->NewNode(op_repr())->assert_is_op();
   op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") ==
-           "bfloat16";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") ==
+           proto::VarType::BF16;
   });
   auto *op_out = pattern->NewNode(op_out_repr())->AsOutput();
 
   auto *next_op = pattern->NewNode(next_op_repr())->assert_is_op();
   next_op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") !=
-           "bfloat16";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") !=
+           proto::VarType::BF16;
   });
 
   op->LinksTo({op_out});
@@ -2160,15 +2160,15 @@ PDNode *patterns::LastBfloat16Ops::operator()() {
 PDNode *patterns::FirstBfloat16Ops::operator()() {
   auto *prev_op = pattern->NewNode(prev_op_repr())->assert_is_op();
   prev_op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") !=
-           "bfloat16";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") !=
+           proto::VarType::BF16;
   });
   auto *op_in = pattern->NewNode(op_in_repr())->AsOutput();
 
   auto *op = pattern->NewNode(op_repr())->assert_is_op();
   op->assert_more([&](Node *node) {
-    return node->Op()->GetAttrIfExists<std::string>("mkldnn_data_type") ==
-           "bfloat16";
+    return node->Op()->GetAttrIfExists<int>("mkldnn_data_type") ==
+           proto::VarType::BF16;
   });
 
   prev_op->LinksTo({op_in});

--- a/paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_pass_tester.cc
@@ -17,6 +17,7 @@
 #include "paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_pass.h"
 #include "paddle/fluid/framework/naive_executor.h"
 #include "paddle/fluid/imperative/type_defs.h"
+#include "paddle/fluid/platform/mkldnn_helper.h"
 #include "paddle/fluid/platform/place.h"
 
 namespace paddle {
@@ -26,7 +27,7 @@ namespace ir {
 void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs, bool use_mkldnn,
-           const std::string& mkldnn_data_type = "float32",
+           const int mkldnn_data_type = FP32,
            const bool force_fp32_output = false) {
   auto* op = prog->MutableBlock(0)->AppendOp();
   op->SetType(type);
@@ -79,16 +80,15 @@ ProgramDesc BuildProgramDesc(bool use_mkldnn) {
   for (auto& v : variable_names) {
     prog.MutableBlock(0)->Var(v);
   }
-  SetOp(&prog, "dropout", "Dropout1", {"z"}, {"a"}, use_mkldnn, "float32");
-  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_mkldnn, "bfloat16");
-  SetOp(&prog, "pool2d", "Pool1", {"b"}, {"c"}, use_mkldnn, "bfloat16");
-  SetOp(&prog, "conv2d", "Conv1", {"c"}, {"d"}, use_mkldnn, "bfloat16");
-  SetOp(&prog, "dropout", "Dropout2", {"d"}, {"e"}, use_mkldnn, "float32");
-  SetOp(&prog, "transpose2", "Transpose1", {"e"}, {"f"}, use_mkldnn,
-        "bfloat16");
-  SetOp(&prog, "reshape2", "Reshape1", {"f"}, {"g"}, use_mkldnn, "bfloat16");
-  SetOp(&prog, "concat", "Concat1", {"g"}, {"h"}, use_mkldnn, "bfloat16");
-  SetOp(&prog, "dropout", "Dropout3", {"h"}, {"i"}, use_mkldnn, "float32");
+  SetOp(&prog, "dropout", "Dropout1", {"z"}, {"a"}, use_mkldnn, FP32);
+  SetOp(&prog, "conv2d", "Conv1", {"a"}, {"b"}, use_mkldnn, BF16);
+  SetOp(&prog, "pool2d", "Pool1", {"b"}, {"c"}, use_mkldnn, BF16);
+  SetOp(&prog, "conv2d", "Conv1", {"c"}, {"d"}, use_mkldnn, BF16);
+  SetOp(&prog, "dropout", "Dropout2", {"d"}, {"e"}, use_mkldnn, FP32);
+  SetOp(&prog, "transpose2", "Transpose1", {"e"}, {"f"}, use_mkldnn, BF16);
+  SetOp(&prog, "reshape2", "Reshape1", {"f"}, {"g"}, use_mkldnn, BF16);
+  SetOp(&prog, "concat", "Concat1", {"g"}, {"h"}, use_mkldnn, BF16);
+  SetOp(&prog, "dropout", "Dropout3", {"h"}, {"i"}, use_mkldnn, FP32);
 
   return prog;
 }

--- a/paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_placement_pass.cc
@@ -46,7 +46,7 @@ void CPUBfloat16PlacementPass::SetMkldnnDataType(
     if ((op->Op()->HasAttr("mkldnn_data_type") ||
          op->Op()->HasProtoAttr("mkldnn_data_type")) &&
         !platform::HasOpINT8DataType(op->Op())) {
-      op->Op()->SetAttr("mkldnn_data_type", std::string("bfloat16"));
+      op->Op()->SetAttr("mkldnn_data_type", BF16);
       (*bfloat16_operators)++;
     }
   };
@@ -65,7 +65,7 @@ void CPUBfloat16PlacementPass::RemoveOrhanedOperators(
                      Graph* g) {
     GET_IR_NODE_FROM_SUBGRAPH(op, op, orphaned_bfloat16_pattern);
 
-    op->Op()->SetAttr("mkldnn_data_type", std::string("float32"));
+    op->Op()->SetAttr("mkldnn_data_type", FP32);
     bfloat16_operators--;
   };
   gpd(graph, handler);

--- a/paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_bfloat16_placement_pass_tester.cc
@@ -24,7 +24,7 @@ namespace ir {
 void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs,
-           const std::string& mkldnn_data_type = "float32") {
+           const int mkldnn_data_type = FP32) {
   auto* op = prog->MutableBlock(0)->AppendOp();
 
   op->SetType(type);

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass.cc
@@ -54,7 +54,7 @@ void LogQuantizationDisabled(Node* op) {
   std::stringstream msg_ss;
   VLOG(4) << "Qantization skipped for operator " << op->Name()
           << " (type: " << op->Op()->Type() << ", id: " << op->id()
-          << "). Attribute mkldnn_data_type != \"int8\".";
+          << "). Attribute mkldnn_data_type != INT8 .";
 }
 
 }  // namespace

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_pass_tester.cc
@@ -671,7 +671,8 @@ ProgramDesc BuildProgramDescElementwiseAdd() {
   }
   SetOp(&prog, "dequantize", "Dequantize1", {"a"}, {"b"}, true);
   SetOp(&prog, "dequantize", "Dequantize2", {"c"}, {"d"}, true);
-  SetOp(&prog, "elementwise_add", "ElementwiseAdd", {"b", "d"}, {"e"}, true, INT8);
+  SetOp(&prog, "elementwise_add", "ElementwiseAdd", {"b", "d"}, {"e"}, true,
+        INT8);
   SetOp(&prog, "dropout", "Dropout", {"e"}, {"f"}, true, FP32);
 
   return prog;

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.h"
 #include <unordered_set>
+#include "paddle/fluid/platform/mkldnn_helper.h"
 
 namespace paddle {
 namespace framework {
@@ -44,13 +45,12 @@ void CPUQuantizePlacementPass::ApplyImpl(ir::Graph* graph) const {
 
     if (op->Op()->HasAttr("mkldnn_data_type") ||
         op->Op()->HasProtoAttr("mkldnn_data_type")) {
-      // use_quantizer is no longer used
+      // The attribute `use_quantizer` is no longer used
       // assign value for compatibility
       if (op->Op()->GetAttrIfExists<bool>("use_quantizer")) {
-        op->Op()->SetAttr("mkldnn_data_type", std::string("int8"));
+        op->Op()->SetAttr("use_quantizer", true);
       }
-      op->Op()->SetAttr("mkldnn_data_type", std::string("int8"));
-      op->Op()->SetAttr("use_quantizer", true);
+      op->Op()->SetAttr("mkldnn_data_type", INT8);
     }
   };
   gpd(graph, handler);

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass.cc
@@ -45,11 +45,6 @@ void CPUQuantizePlacementPass::ApplyImpl(ir::Graph* graph) const {
 
     if (op->Op()->HasAttr("mkldnn_data_type") ||
         op->Op()->HasProtoAttr("mkldnn_data_type")) {
-      // The attribute `use_quantizer` is no longer used
-      // assign value for compatibility
-      if (op->Op()->GetAttrIfExists<bool>("use_quantizer")) {
-        op->Op()->SetAttr("use_quantizer", true);
-      }
       op->Op()->SetAttr("mkldnn_data_type", INT8);
     }
   };

--- a/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
+++ b/paddle/fluid/framework/ir/mkldnn/cpu_quantize_placement_pass_tester.cc
@@ -24,7 +24,7 @@ namespace ir {
 void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
            const std::vector<std::string>& inputs,
            const std::vector<std::string>& outputs,
-           const std::string& mkldnn_data_type = "float32") {
+           const int mkldnn_data_type = FP32) {
   auto* op = prog->MutableBlock(0)->AppendOp();
 
   op->SetType(type);
@@ -50,12 +50,12 @@ void SetOp(ProgramDesc* prog, const std::string& type, const std::string& name,
 
 // operator                      mkldnn_data_type
 // ---------------------------------------
-// (a,b)->concat->c              none
-// (c,weights,bias)->conv->f     false
-// f->relu->g                    none
-// g->pool->h                    false
-// (h,weights2,bias2)->conv->k   false
-// k->pool->l                    false
+// (a,b)->concat->c              FP32
+// (c,weights,bias)->conv->f     FP32
+// f->relu->g                    FP32
+// g->pool->h                    FP32
+// (h,weights2,bias2)->conv->k   FP32
+// k->pool->l                    FP32
 ProgramDesc BuildProgramDesc() {
   ProgramDesc prog;
 
@@ -69,12 +69,12 @@ ProgramDesc BuildProgramDesc() {
     }
   }
 
-  SetOp(&prog, "concat", "concat1", {"a", "b"}, {"c"}, "float32");
-  SetOp(&prog, "conv2d", "conv1", {"c", "weights", "bias"}, {"f"}, "float32");
-  SetOp(&prog, "relu", "relu1", {"f"}, {"g"}, "float32");
-  SetOp(&prog, "pool2d", "pool1", {"g"}, {"h"}, "float32");
-  SetOp(&prog, "conv2d", "conv2", {"h", "weights2", "bias2"}, {"k"}, "float32");
-  SetOp(&prog, "pool2d", "pool2", {"k"}, {"l"}, "float32");
+  SetOp(&prog, "concat", "concat1", {"a", "b"}, {"c"});
+  SetOp(&prog, "conv2d", "conv1", {"c", "weights", "bias"}, {"f"});
+  SetOp(&prog, "relu", "relu1", {"f"}, {"g"});
+  SetOp(&prog, "pool2d", "pool1", {"g"}, {"h"});
+  SetOp(&prog, "conv2d", "conv2", {"h", "weights2", "bias2"}, {"k"});
+  SetOp(&prog, "pool2d", "pool2", {"k"}, {"l"});
 
   return prog;
 }

--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -396,9 +396,9 @@ if(WITH_MKLDNN)
   ### Lexcial analysis GRU model
   set(GRU_PATH "${INFERENCE_DEMO_INSTALL_DIR}/gru")
   download_GRU_data("${GRU_PATH}" "GRU_eval_data.tar.gz")
-  download_GRU_data("${GRU_PATH}" "GRU_eval_model_v2.tar.gz")
+  download_GRU_data("${GRU_PATH}" "GRU_eval_model_v3.tar.gz")
   set(GRU_DATA_PATH "${GRU_PATH}/GRU_eval_data.bin")
-  set(GRU_MODEL_PATH "${GRU_PATH}/GRU_eval_model_v2")
+  set(GRU_MODEL_PATH "${GRU_PATH}/GRU_eval_model_v3")
   set(LEXICAL_TEST_APP "test_analyzer_lexical_analysis")
   set(LEXICAL_TEST_APP_SRC "analyzer_lexical_analysis_gru_tester.cc")
 

--- a/paddle/fluid/operators/concat_op.cc
+++ b/paddle/fluid/operators/concat_op.cc
@@ -129,11 +129,12 @@ class ConcatOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
     AddComment(R"DOC(
 Concat Operator.
 

--- a/paddle/fluid/operators/conv_op.cc
+++ b/paddle/fluid/operators/conv_op.cc
@@ -285,11 +285,11 @@ void Conv2DOpMaker::Make() {
       "(bool, default false) "
       "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
       .SetDefault(false);
-  AddAttr<std::string>(
-      "mkldnn_data_type",
-      "(string, default \"float32\"). Data type of mkldnn kernel")
-      .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
+  AddAttr<int>("mkldnn_data_type",
+               "(int, default: FP32). Data type of mkldnn kernel")
+      .SetDefault(framework::proto::VarType::FP32)
+      .InEnum({framework::proto::VarType::FP32, framework::proto::VarType::BF16,
+               framework::proto::VarType::INT8});
   AddAttr<bool>("fuse_relu", "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
   AddAttr<bool>("fuse_brelu",
@@ -456,11 +456,11 @@ void Conv3DOpMaker::Make() {
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
-  AddAttr<std::string>(
-      "mkldnn_data_type",
-      "(string, default \"float32\"). Data type of mkldnn kernel")
-      .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
+  AddAttr<int>("mkldnn_data_type",
+               "(int, default: FP32). Data type of mkldnn kernel")
+      .SetDefault(framework::proto::VarType::FP32)
+      .InEnum({framework::proto::VarType::FP32, framework::proto::VarType::BF16,
+               framework::proto::VarType::INT8});
   AddAttr<bool>("fuse_relu", "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
   AddAttr<std::string>("fuse_activation",

--- a/paddle/fluid/operators/detection/prior_box_op.cc
+++ b/paddle/fluid/operators/detection/prior_box_op.cc
@@ -225,11 +225,12 @@ class PriorBoxOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
     AddComment(R"DOC(
 Prior box operator
 Generate prior boxes for SSD(Single Shot MultiBox Detector) algorithm.

--- a/paddle/fluid/operators/elementwise/elementwise_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op.h
@@ -152,11 +152,12 @@ class ElementwiseOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
     /* int8 parameters */
     AddAttr<float>("Scale_x",
                    "(float, default 1.0f), The quantize scale of X tensor")

--- a/paddle/fluid/operators/fc_op.cc
+++ b/paddle/fluid/operators/fc_op.cc
@@ -163,11 +163,12 @@ class FCOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
     /* int8 parameters */
     AddAttr<float>("Scale_in",
                    "(float, default 1.0f), The quantize scale of input data")

--- a/paddle/fluid/operators/fused/fusion_gru_op.cc
+++ b/paddle/fluid/operators/fused/fusion_gru_op.cc
@@ -207,11 +207,11 @@ void FusionGRUOpMaker::Make() {
   AddAttr<bool>("use_mkldnn",
                 "(bool, default false) Only used in mkldnn kernel")
       .SetDefault(false);
-  AddAttr<std::string>(
-      "mkldnn_data_type",
-      "(string, default \"float32\"). Data type of mkldnn kernel")
-      .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
+  AddAttr<int>("mkldnn_data_type",
+               "(int, default: FP32). Data type of mkldnn kernel")
+      .SetDefault(framework::proto::VarType::FP32)
+      .InEnum({framework::proto::VarType::FP32, framework::proto::VarType::BF16,
+               framework::proto::VarType::INT8});
   AddAttr<float>("Scale_data",
                  "Scale to be used for int8 input/output data."
                  "Only used with MKL-DNN INT8.")

--- a/paddle/fluid/operators/gelu_op.cc
+++ b/paddle/fluid/operators/gelu_op.cc
@@ -111,11 +111,11 @@ class GeluOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("use_mkldnn",
                   "(bool, default false) Only used in mkldnn kernel")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum(
+            {framework::proto::VarType::FP32, framework::proto::VarType::BF16});
     AddAttr<bool>("use_cudnn",
                   "(bool, default false) Only used in cudnn kernel, need "
                   "install cudnn")

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -715,11 +715,12 @@ class MatMulOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
     /* int8 parameters */
     AddAttr<float>("Scale_x",
                    "(float, default 1.0f), The quantize scale of X tensor")

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -213,7 +213,7 @@ class ConvMKLDNNHandlerT
       auto chosen_memory_format = MKLDNNMemoryFormat::any;
 
       auto data_type = mkldnn::memory::data_type::f32;
-      if (ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16" ||
+      if (ctx.Attr<int>("mkldnn_data_type") == BF16 ||
           std::is_same<T_out, platform::bfloat16>::value)
         data_type = mkldnn::memory::data_type::bf16;
 
@@ -377,7 +377,8 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
                           "Operator DNNL Conv must use CPUPlace"));
     bool is_INT8 =
         std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value;
-    bool is_BFLOAT16 = ctx.Attr<std::string>("mkldnn_data_type") == "bfloat16";
+    bool is_BFLOAT16 =
+        ctx.Attr<int>("mkldnn_data_type") == BF16;
     auto residual_param = ctx.Input<Tensor>("ResidualData");
     bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
     std::string fuse_activation = ctx.Attr<std::string>("fuse_activation");

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -377,8 +377,7 @@ class ConvMKLDNNOpKernel : public paddle::framework::OpKernel<T> {
                           "Operator DNNL Conv must use CPUPlace"));
     bool is_INT8 =
         std::is_same<T, int8_t>::value || std::is_same<T, uint8_t>::value;
-    bool is_BFLOAT16 =
-        ctx.Attr<int>("mkldnn_data_type") == BF16;
+    bool is_BFLOAT16 = ctx.Attr<int>("mkldnn_data_type") == BF16;
     auto residual_param = ctx.Input<Tensor>("ResidualData");
     bool fuse_residual_conn = ctx.Attr<bool>("fuse_residual_connection");
     std::string fuse_activation = ctx.Attr<std::string>("fuse_activation");

--- a/paddle/fluid/operators/pool_op.cc
+++ b/paddle/fluid/operators/pool_op.cc
@@ -320,11 +320,11 @@ void Pool2dOpMaker::Make() {
       "(bool, default false) "
       "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
       .SetDefault(false);
-  AddAttr<std::string>(
-      "mkldnn_data_type",
-      "(string, default \"float32\"). Data type of mkldnn kernel")
-      .SetDefault("float32")
-      .InEnum({"float32", "int8", "bfloat16"});
+  AddAttr<int>("mkldnn_data_type",
+               "(int, default: FP32). Data type of mkldnn kernel")
+      .SetDefault(framework::proto::VarType::FP32)
+      .InEnum({framework::proto::VarType::FP32, framework::proto::VarType::BF16,
+               framework::proto::VarType::INT8});
   AddAttr<std::string>(
       "data_format",
       "(string, default NCHW) Only used in "

--- a/paddle/fluid/operators/reshape_op.cc
+++ b/paddle/fluid/operators/reshape_op.cc
@@ -466,11 +466,12 @@ class Reshape2OpMaker : public ReshapeOpMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
   }
 };
 

--- a/paddle/fluid/operators/softmax_op.cc
+++ b/paddle/fluid/operators/softmax_op.cc
@@ -115,11 +115,11 @@ class SoftmaxOpMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<bool>("use_mkldnn",
                   "(bool, default false) Only used in mkldnn kernel")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum(
+            {framework::proto::VarType::FP32, framework::proto::VarType::BF16});
     AddAttr<bool>("is_test",
                   "(bool, default false) Set to true for inference only, false "
                   "for training. Some layers may run faster when this is true.")

--- a/paddle/fluid/operators/transpose_op.cc
+++ b/paddle/fluid/operators/transpose_op.cc
@@ -126,11 +126,12 @@ class TransposeOpMaker : public framework::OpProtoAndCheckerMaker {
         "(bool, default false) "
         "This parameter is no longer used. Use 'mkldnn_data_type' instead.")
         .SetDefault(false);
-    AddAttr<std::string>(
-        "mkldnn_data_type",
-        "(string, default \"float32\"). Data type of mkldnn kernel")
-        .SetDefault("float32")
-        .InEnum({"float32", "int8", "bfloat16"});
+    AddAttr<int>("mkldnn_data_type",
+                 "(int, default: FP32). Data type of mkldnn kernel")
+        .SetDefault(framework::proto::VarType::FP32)
+        .InEnum({framework::proto::VarType::FP32,
+                 framework::proto::VarType::BF16,
+                 framework::proto::VarType::INT8});
     /* int8 parameters */
     AddComment(R"DOC(
 Transpose Operator.

--- a/paddle/fluid/platform/mkldnn_helper.h
+++ b/paddle/fluid/platform/mkldnn_helper.h
@@ -27,6 +27,10 @@ namespace paddle {
 #ifdef PADDLE_WITH_MKLDNN
 using MKLDNNMemoryFormat = mkldnn::memory::format_tag;
 #endif
+
+constexpr int FP32 = framework::proto::VarType::FP32;
+constexpr int BF16 = framework::proto::VarType::BF16;
+constexpr int INT8 = framework::proto::VarType::INT8;
 namespace platform {
 
 using MKLDNNStream = mkldnn::stream;
@@ -465,16 +469,16 @@ inline std::vector<std::vector<int64_t>> ToMkldnnPadding(
 }
 
 inline bool HasOpINT8DataType(const paddle::framework::OpDesc* op) {
-  return (op->GetAttrIfExists<std::string>("mkldnn_data_type") == "int8" ||
+  return (op->GetAttrIfExists<int>("mkldnn_data_type") == INT8 ||
           op->GetAttrIfExists<bool>("use_quantizer"));
 }
 
 inline bool HasOpBFLOAT16DataType(const paddle::framework::OpDesc* op) {
-  return op->GetAttrIfExists<std::string>("mkldnn_data_type") == "bfloat16";
+  return op->GetAttrIfExists<int>("mkldnn_data_type") == BF16;
 }
 
 inline bool HasOpFLOAT32DataType(const paddle::framework::OpDesc* op) {
-  return op->GetAttrIfExists<std::string>("mkldnn_data_type") == "float32";
+  return op->GetAttrIfExists<int>("mkldnn_data_type") == FP32;
 }
 enum class RNNReorderType { PP_NTC, PP_TNC, NTC_PP, TNC_PP };
 

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -282,7 +282,8 @@ endforeach()
 if(NOT WIN32)
     set_tests_properties(test_post_training_quantization_mobilenetv1 PROPERTIES TIMEOUT 250 LABELS "RUN_TYPE=NIGHTLY")
 	set_tests_properties(test_post_training_quantization_resnet50 PROPERTIES TIMEOUT 200 LABELS "RUN_TYPE=NIGHTLY")
-    set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT 120)
+    # TODO(wozna) remove after generating new mnist model after merge #27777
+	# set_tests_properties(test_post_training_quantization_mnist PROPERTIES TIMEOUT 120)
     set_tests_properties(test_weight_quantization_mobilenetv1 PROPERTIES TIMEOUT 120)
 endif()
 

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -128,6 +128,8 @@ if(WIN32)
 endif()
 
 if(LINUX AND WITH_MKLDNN)
+    # TODO(wozna) remove after generating new mnist model after merge #27777
+    list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mnist)
 
 	#### Image classification dataset: ImageNet (small)
 	# The dataset should already be downloaded for INT8v2 unit tests

--- a/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
+++ b/python/paddle/fluid/contrib/slim/tests/CMakeLists.txt
@@ -267,6 +267,9 @@ list(REMOVE_ITEM TEST_OPS
 	quant_int8_image_classification_comparison
 	quant_int8_nlp_comparison)
 
+# TODO(wozna) remove after generating new mnist model after merge #27777
+list(REMOVE_ITEM TEST_OPS test_post_training_quantization_mnist)
+
 #TODO(wanghaoshuang): Fix this unitest failed on GCC8.
 LIST(REMOVE_ITEM TEST_OPS test_auto_pruning)
 LIST(REMOVE_ITEM TEST_OPS test_filter_pruning)

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_concat_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_concat_bf16_mkldnn_op.py
@@ -30,7 +30,7 @@ class TestConcatBf16Op(OpTest):
         enable_static()
         self.op_type = "concat"
         self.use_mkldnn = True
-        self.mkldnn_data_type = "bfloat16"
+        self.mkldnn_data_type = core.VarDesc.VarType.BF16
         self.init_axis()
         self.init_shape()
         self.init_test_data()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_bf16_mkldnn_op.py
@@ -41,7 +41,7 @@ class TestConv2DBf16Op(TestConv2DOp):
         self._cpu_only = True
         self.weight_type = np.float32
         self.input_type = np.float32
-        self.mkldnn_data_type = "bfloat16"
+        self.mkldnn_data_type = core.VarDesc.VarType.BF16
         self.force_fp32_output = False
         self.init_group()
         self.init_dilation()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_int8_mkldnn_op.py
@@ -36,7 +36,7 @@ class TestConv2DInt8Op(TestConv2DOp):
         self.use_cuda = False
         self.use_mkldnn = False
         self.data_format = "NCHW"
-        self.mkldnn_data_type = "int8"
+        self.mkldnn_data_type = core.VarDesc.VarType.INT8
         self.weighttype = np.float32
         self.use_mkldnn = True
         self.init_group()

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_reshape_bf16_op.py
@@ -30,7 +30,7 @@ class TestReshapeBf16Op(OpTest):
         enable_static()
         self.op_type = "reshape2"
         self.use_mkldnn = True
-        self.mkldnn_data_type = "bfloat16"
+        self.mkldnn_data_type = core.VarDesc.VarType.BF16
         self.init_data()
         self.init_input_data()
 

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_transpose_bf16_mkldnn_op.py
@@ -28,7 +28,7 @@ class TestTransposeOp(OpTest):
         enable_static()
         self.op_type = "transpose2"
         self.use_mkldnn = True
-        self.mkldnn_data_type = "bfloat16"
+        self.mkldnn_data_type = core.VarDesc.VarType.BF16
         self.init_test_case()
         self.init_test_data()
         self.axis = (0, 2, 3, 1)

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -263,7 +263,7 @@ class OpTest(unittest.TestCase):
     def is_bfloat16_op(self):
         return self.dtype == np.uint16 or (
             hasattr(self, 'mkldnn_data_type') and
-            getattr(self, 'mkldnn_data_type') is "bfloat16")
+            getattr(self, 'mkldnn_data_type') is core.VarDesc.VarType.BF16)
 
     def infer_dtype_from_inputs_outputs(self, inputs, outputs):
         def is_np_data(input):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
This PR change type of `mkldnn_data_type` attribute from string to int. It is more elegant and less prone to errors solution. 
Unfortunately, I couldn't find a way to split this PR with fewer files.

This PR remove temporarily `test_post_training_quantization_mnist` because this test was generated with `mkldnn_data_type` as std::string. This model should be generated after this PR merge and the test should be restored.   