### PR TITLE
add alias for RNN APIs from paddle.nn.layer.rnn explicitly

### DIFF
--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -148,10 +148,17 @@ from .layer.norm import InstanceNorm3d  #DEFINE_ALIAS
 from .layer.norm import BatchNorm1d  #DEFINE_ALIAS
 from .layer.norm import BatchNorm2d  #DEFINE_ALIAS
 from .layer.norm import BatchNorm3d  #DEFINE_ALIAS
-from .layer.rnn import *
-# from .layer.rnn import RNNCell        #DEFINE_ALIAS
-# from .layer.rnn import GRUCell        #DEFINE_ALIAS
-# from .layer.rnn import LSTMCell        #DEFINE_ALIAS
+
+from .layer.rnn import RNNCellBase  #DEFINE_ALIAS
+from .layer.rnn import SimpleRNNCell  #DEFINE_ALIAS
+from .layer.rnn import LSTMCell  #DEFINE_ALIAS
+from .layer.rnn import GRUCell  #DEFINE_ALIAS
+from .layer.rnn import RNN  #DEFINE_ALIAS
+from .layer.rnn import BiRNN  #DEFINE_ALIAS
+from .layer.rnn import SimpleRNN  #DEFINE_ALIAS
+from .layer.rnn import LSTM  #DEFINE_ALIAS
+from .layer.rnn import GRU  #DEFINE_ALIAS
+
 from .layer.transformer import MultiHeadAttention
 from .layer.transformer import TransformerEncoderLayer
 from .layer.transformer import TransformerEncoder


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
add alias for RNN APIs from paddle.nn.layer.rnn explicitly instead of * 
