### PR TITLE
fix ut error of test_recognize_digits, test=develop

### DIFF
--- a/paddle/fluid/train/CMakeLists.txt
+++ b/paddle/fluid/train/CMakeLists.txt
@@ -4,37 +4,26 @@ function(train_test TARGET_NAME)
     set(multiValueArgs ARGS)
     cmake_parse_arguments(train_test "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
-    set(arg_list "")
-    if(train_test_ARGS)
-        foreach(arg ${train_test_ARGS})
-            list(APPEND arg_list "_${arg}")
-        endforeach()
+    if (NOT APPLE AND NOT WIN32)
+        cc_test(test_train_${TARGET_NAME}
+                SRCS test_train_${TARGET_NAME}.cc
+                DEPS paddle_fluid_shared
+                ARGS --dirname=${PYTHON_TESTS_DIR}/book/)
     else()
-        list(APPEND arg_list "_")
+        cc_test(test_train_${TARGET_NAME}${arg}
+                SRCS test_train_${TARGET_NAME}.cc
+                DEPS paddle_fluid_api
+                ARGS --dirname=${PYTHON_TESTS_DIR}/book/)
     endif()
-    foreach(arg ${arg_list})
-        string(REGEX REPLACE "^_$" "" arg "${arg}")
-        if (NOT APPLE AND NOT WIN32)
-            cc_test(test_train_${TARGET_NAME}${arg}
-                    SRCS test_train_${TARGET_NAME}.cc
-                    DEPS paddle_fluid_shared
-                    ARGS --dirname=${PYTHON_TESTS_DIR}/book/${TARGET_NAME}${arg}.train.model/)
-        else()
-            cc_test(test_train_${TARGET_NAME}${arg}
-                    SRCS test_train_${TARGET_NAME}.cc
-                    DEPS paddle_fluid_api
-                    ARGS --dirname=${PYTHON_TESTS_DIR}/book/${TARGET_NAME}${arg}.train.model/)
-        endif()
-        set_tests_properties(test_train_${TARGET_NAME}${arg}
-                PROPERTIES FIXTURES_REQUIRED test_${TARGET_NAME}_infer_model)
-        if(NOT WIN32 AND NOT APPLE)
-            set_tests_properties(test_train_${TARGET_NAME}${arg}
-                    PROPERTIES TIMEOUT 150)
-        endif()
-    endforeach()
+    set_tests_properties(test_train_${TARGET_NAME}
+            PROPERTIES FIXTURES_REQUIRED test_${TARGET_NAME}_infer_model)
+    if(NOT WIN32 AND NOT APPLE)
+        set_tests_properties(test_train_${TARGET_NAME}
+                PROPERTIES TIMEOUT 150)
+    endif()
 endfunction(train_test)
 
 
 if(WITH_TESTING)
-  train_test(recognize_digits ARGS mlp conv)
+  train_test(recognize_digits)
 endif()

--- a/paddle/fluid/train/test_train_recognize_digits.cc
+++ b/paddle/fluid/train/test_train_recognize_digits.cc
@@ -32,16 +32,15 @@ DEFINE_string(dirname, "", "Directory of the train model.");
 
 namespace paddle {
 
-void Train() {
-  CHECK(!FLAGS_dirname.empty());
+void Train(std::string model_dir) {
   framework::InitDevices(false);
   const auto cpu_place = platform::CPUPlace();
   framework::Executor executor(cpu_place);
   framework::Scope scope;
 
   auto train_program = inference::Load(
-      &executor, &scope, FLAGS_dirname + "__model_combined__.main_program",
-      FLAGS_dirname + "__params_combined__");
+      &executor, &scope, model_dir + "__model_combined__.main_program",
+      model_dir + "__params_combined__");
 
   std::string loss_name = "";
   for (auto op_desc : train_program->Block(0).AllOps()) {
@@ -87,6 +86,10 @@ void Train() {
   EXPECT_LT(last_loss, first_loss);
 }
 
-TEST(train, recognize_digits) { Train(); }
+TEST(train, recognize_digits) {
+  CHECK(!FLAGS_dirname.empty());
+  Train(FLAGS_dirname + "recognize_digits_mlp.train.model/");
+  Train(FLAGS_dirname + "recognize_digits_conv.train.model/");
+}
 
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
**问题描述：**
test_recognize_digits单测在infer时会随机抛出模型参数文件的broken错误，错误log如下：

```log
2020-10-05 17:42:19 InvalidArgumentError: The number of variables to be loaded is 0, expect it to be greater than 0.
2020-10-05 17:42:19   [Hint: Expected out_var_names.size() > 0UL, but received out_var_names.size():0 <= 0UL:0.] (at /paddle/paddle/fluid/operators/load_combine_op.h:42)
2020-10-05 17:42:19   [operator < load_combine > error]
```

**错误原因分析：**
由修复test_train_recognize_digits_mlp和test_train_recognize_digits_convd的PR相关https://github.com/PaddlePaddle/Paddle/pull/27475。
在PR27475中修复之后，paddle_build.sh脚本中运行单测的命令如下

```bash
export CTEST_PARALLEL_LEVEL=2
ctest -R test_train_recognize_digits_mlp &
ctest -R test_train_recognize_digits_conv &
```

这两个单测会被并行运行，由于2个都在PR27475中设置依赖test_recognize_digits，test_recognize_digits会同时并行运行2次，log如下：

```log
2020-10-05 17:41:39     ============================================
2020-10-05 17:41:39     Generating TestCases Count ... 
2020-10-05 17:41:39     ============================================
2020-10-05 17:41:39 1 card TestCases count is 425
2020-10-05 17:41:39 Test project /paddle/build
2020-10-05 17:41:39 Test project /paddle/build
2020-10-05 17:41:39         Start 1251: test_recognize_digits
2020-10-05 17:41:39         Start 1251: test_recognize_digits
2020-10-05 17:41:39         Start    2: system_allocator_test
2020-10-05 17:41:39         Start    1: malloc_test
```

并行运行2个test_recognize_digits时，程序对同一个目录下的同一个param文件进行读写，所以会导致test_recognize_digits中的infer func在load param file时得到的param文件时损坏的。

**解决办法：**
将test_train_recognize_digits_mlp和test_train_recognize_digits_conv合并为一个单测case，顺序执行就不会有之前的问题。
也尝试过修改cmake文件中set_tests_properties的依赖关系，但是当paddle_build.sh脚本中并行后台运行2个单测时，即使对2个单测互相直接设置了依赖关系，也会导致test_recognize_digits被一起执行2遍，除非某个单测不设置对test_recognize_digits的依赖，这样又会导致test_train_recognize_digits_mlp或者test_train_recognize_digits_conv的单测失败。