### PR TITLE
cherry-pick _cuda_synchronize to 1.8

### DIFF
--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1497,6 +1497,10 @@ All parameter, weight, gradient are variables in Paddle.
   m.def("is_compiled_with_mkldnn", IsCompiledWithMKLDNN);
   m.def("is_compiled_with_brpc", IsCompiledWithBrpc);
   m.def("is_compiled_with_dist", IsCompiledWithDIST);
+  m.def("_cuda_synchronize", [](const platform::CUDAPlace &place) {
+    platform::DeviceContextPool::Instance().Get(place)->Wait();
+  });
+
   m.def("run_cmd",
         [](const std::string &cmd, int time_out = -1,
            int sleep_inter = -1) -> const std::string {

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -88,6 +88,7 @@ from .dygraph.base import enable_dygraph, disable_dygraph, enable_imperative, di
 from .io import save, load, load_program_state, set_program_state
 from .dygraph.checkpoint import save_dygraph, load_dygraph
 from .dygraph.varbase_patch_methods import monkey_patch_varbase
+from .core import _cuda_synchronize
 Tensor = LoDTensor
 
 __all__ = framework.__all__ + executor.__all__ + \
@@ -128,7 +129,8 @@ __all__ = framework.__all__ + executor.__all__ + \
         'install_check',
         'save',
         'load',
-        'VarBase'
+        'VarBase',
+        '_cuda_synchronize'
     ]
 
 

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -260,6 +260,7 @@ if avx_supported():
         from .core_avx import _save_dygraph_dict
         from .core_avx import _load_dygraph_dict
         from .core_avx import _create_loaded_parameter
+        from .core_avx import _cuda_synchronize
         if sys.platform != 'win32':
             from .core_avx import _set_process_pids
             from .core_avx import _erase_process_pids
@@ -304,6 +305,7 @@ if load_noavx:
         from .core_noavx import _save_dygraph_dict
         from .core_noavx import _load_dygraph_dict
         from .core_noavx import _create_loaded_parameter
+        from .core_noavx import _cuda_synchronize
         if sys.platform != 'win32':
             from .core_noavx import _set_process_pids
             from .core_noavx import _erase_process_pids


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
目前Paddle正在进行1.8-2.0 API的性能对比工作，需要统计模型，在GPU运行结束后的整体耗时。
_cuda_synchronize 用于等待GPU运行结束。
代码已在2.0中merge，本PR将代码cherry-pick到1.8分支。
