### PR TITLE
Enable GLOO when compiled with WITH_DISTRIBUTE=ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,9 @@ if(WITH_AMD_GPU)
 endif(WITH_AMD_GPU)
 
 if(WITH_DISTRIBUTE)
-    set(WITH_GLOO ON CACHE STRING "Enable GLOO when compiling WITH_DISTRIBUTE=ON." FORCE)
+    if(LINUX)
+        set(WITH_GLOO ON CACHE STRING "Enable GLOO when compiling WITH_DISTRIBUTE=ON." FORCE)
+    endif()
 endif()
 
 if(WITH_ARM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,6 +239,10 @@ if(WITH_AMD_GPU)
     include(hip)
 endif(WITH_AMD_GPU)
 
+if(WITH_DISTRIBUTE)
+    set(WITH_GLOO ON CACHE STRING "Enable GLOO when compiling WITH_DISTRIBUTE=ON." FORCE)
+endif()
+
 if(WITH_ARM)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Enable GLOO when compiled with WITH_DISTRIBUTE=ON
For distributed training, we will initialize GLOO by default. To avoid use -DWITH_GLOO=ON option, we set WITH_GLOO=ON by default when WITH_DISTRIBUTE=ON is set.