### PR TITLE
fix DataLoader single process mode exit SIGABRT error.

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -350,10 +350,7 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
         # _blocking_queue in keep order mode holds sub-threads
         # need to release thread resources on unexpected exit
         if self._blocking_queue:
-            try:
-                self._blocking_queue.close()
-            except:
-                self._blocking_queue.kill()
+            self._blocking_queue.close()
 
 
 # NOTE(chenweihang): _worker_loop must be top level method to be pickled

--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -346,6 +346,15 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
     def next(self):
         return self.__next__()
 
+    def __del__(self):
+        # _blocking_queue in keep order mode holds sub-threads
+        # need to release thread resources on unexpected exit
+        if self._blocking_queue:
+            try:
+                self._blocking_queue.close()
+            except:
+                self._blocking_queue.kill()
+
 
 # NOTE(chenweihang): _worker_loop must be top level method to be pickled
 def _worker_loop(dataset, dataset_kind, indices_queue, out_queue, done_event,


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
`_DataLoaderSingleProcess` use blocking queue, which holds sub-threads in keep order mode, need to release thread resources on unexpected exit to avoid following error

```
terminate called without an active exception


--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::framework::SignalHandle(char const*, int)
1   paddle::platform::GetCurrentTraceBackString()

----------------------
Error Message Summary:
----------------------
FatalError: A serious error (Process abort signal) is detected by the operating system. (at /paddle/ssd3/git/Paddle/paddle/fluid/platform/init.cc:303)
  [TimeInfo: *** Aborted at 1602475884 (unix time) try "date -d @1602475884" if you are using GNU date ***]
  [SignalInfo: *** SIGABRT (@0x6f3c) received by PID 28476 (TID 0x7f9fbbfff700) from PID 28476 ***]

Segmentation fault
```