### PR TITLE
increase eps in unittest to avoid precision problem due to float32

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_nn_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_grad.py
@@ -156,7 +156,7 @@ class TestMulDoubleGradCheck(unittest.TestCase):
 class TestMatmulDoubleGradCheck(unittest.TestCase):
     @prog_scope()
     def func(self, place):
-        eps = 0.005
+        eps = 0.05
         x_shapes = [[2], [2, 3], [2, 4, 3], [2, 3, 4, 5], [2, 3, 4]]
         y_shapes = [[2], [3, 2], [2, 4, 5], [2, 3, 3, 5], [4, 3]]
         transpose_xs = [False, True, True, False, False]


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
increase eps in unittest to avoid precision problem due to float32, as a patch for https://github.com/PaddlePaddle/Paddle/pull/27776
