### PR TITLE
modify test_load_op save path from /tmp to ./

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_load_op.py
+++ b/python/paddle/fluid/tests/unittests/test_load_op.py
@@ -41,14 +41,14 @@ class TestLoadOp(unittest.TestCase):
         exe = fluid.Executor(fluid.CPUPlace())
         exe.run(start_prog)
         fluid.io.save_persistables(
-            exe, dirname="/tmp/model", main_program=main_prog)
+            exe, dirname="./model", main_program=main_prog)
 
     def test_load(self):
         main_prog = fluid.Program()
         start_prog = fluid.Program()
         with fluid.program_guard(main_prog, start_prog):
             var = layers.create_tensor(dtype='float32')
-            layers.load(var, file_path='/tmp/model/w')
+            layers.load(var, file_path='./model/w')
 
         exe = fluid.Executor(fluid.CPUPlace())
         exe.run(start_prog)

--- a/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
@@ -44,14 +44,14 @@ class TestLoadOpXpu(unittest.TestCase):
         exe = fluid.Executor(fluid.XPUPlace(0))
         exe.run(start_prog)
         fluid.io.save_persistables(
-            exe, dirname="/tmp/model", main_program=main_prog)
+            exe, dirname="./model", main_program=main_prog)
 
     def test_load_xpu(self):
         main_prog = fluid.Program()
         start_prog = fluid.Program()
         with fluid.program_guard(main_prog, start_prog):
             var = layers.create_tensor(dtype='float32')
-            layers.load(var, file_path='/tmp/model/w')
+            layers.load(var, file_path='./model/w')
 
         exe = fluid.Executor(fluid.XPUPlace(0))
         exe.run(start_prog)

--- a/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License. 
+# limitations under the License.
 
 from __future__ import print_function
 

--- a/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/test_load_op_xpu.py
@@ -10,7 +10,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License. 
 
 from __future__ import print_function
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
PR https://github.com/PaddlePaddle/Paddle/pull/27817
中，红雨给出建议，单测中使用/tmp路径在windows下可能出现异常，不是好的编码习惯。
本PR统一修改test_load_op、test_load_op_xpu