### PR TITLE
fix test directory migration

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_directory_migration.py
+++ b/python/paddle/fluid/tests/unittests/test_directory_migration.py
@@ -88,8 +88,8 @@ class TestDirectory(unittest.TestCase):
             stderr=subprocess.PIPE)
         stdout, stderr = ps_proc.communicate()
 
-        assert "Error" not in str(stderr), "Error: Can't" \
-            " import Module {}".format(module)
+        assert "Error" not in str(stderr), "ErrorMessage:\n{}".format(
+            bytes.decode(stderr))
 
     def test_old_directory(self):
         old_directory = [

--- a/python/paddle/fluid/tests/unittests/test_directory_migration.py
+++ b/python/paddle/fluid/tests/unittests/test_directory_migration.py
@@ -88,8 +88,8 @@ class TestDirectory(unittest.TestCase):
             stderr=subprocess.PIPE)
         stdout, stderr = ps_proc.communicate()
 
-        assert "Error" not in str(stderr), "ErrorMessage:\n{}".format(
-            bytes.decode(stderr))
+        self.assertFalse("Error" in str(stderr),
+                         "ErrorMessage:\n{}".format(bytes.decode(stderr)))
 
     def test_old_directory(self):
         old_directory = [
@@ -173,7 +173,7 @@ if count != {len_old_directory}:
             stderr=subprocess.PIPE)
         stdout, stderr = ps_proc.communicate()
 
-        assert "Error" not in str(stdout), str(stdout)
+        self.assertFalse("Error" in str(stdout), bytes.decode(stdout))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Unittest file `test_directory_migration.py` is used to test the correction of module path in PR #25898 .
To test the new path of modules, it will write all the new modules into a file and then run it.
Because all the modules are tested at the same time, it can't find which module occurs error.
This PR is used to position the specific module that occurs error.

The following list is the modules that needs to be checked, they will be writed into a file and be checked in order.

<img width="523" alt="屏幕快照 2020-10-15 下午3 15 15" src="https://user-images.githubusercontent.com/26408901/96089472-7820e780-0ef9-11eb-9de6-61b64689b1df.png">

For example, if module `paddle.to_tensor` is deleted.
Before this PR, the error message is

![image](https://user-images.githubusercontent.com/26408901/96090685-2b3e1080-0efb-11eb-919b-3cbc61eebc80.png)

It gives the wrong error message that `Can't import Module paddle.static.nn.embedding`. 
Because all the modules are tested at the same time. No matter which module occurs error, only the last module `paddle.static.nn.embedding` will be reported as a problem.



After we position the specific module in this PR, the error message is

![image](https://user-images.githubusercontent.com/26408901/96090362-ae129b80-0efa-11eb-8aeb-39823a56a7c5.png)

It can clearly tell users that `cannot import name 'to_tensor'`.

