### PR TITLE
[API2.0]remove image_resize series api in Paddle2.0

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7347,8 +7347,10 @@ def image_resize(input,
         .. code-block:: python
 
 	    #declarative mode
+            import paddle
 	    import paddle.fluid as fluid
 	    import numpy as np
+            paddle.enable_static()
 	    input = fluid.data(name="input", shape=[None,3,6,10])
 
 	    #1
@@ -7797,6 +7799,8 @@ def resize_bilinear(input,
 
 	    #declarative mode
 	    import paddle.fluid as fluid
+            import paddle
+            paddle.enable_static()
 	    import numpy as np
 	    input = fluid.data(name="input", shape=[None,3,6,10])
 
@@ -7961,7 +7965,9 @@ def resize_trilinear(input,
 
 	    #declarative mode
 	    import paddle.fluid as fluid
+            import paddle
 	    import numpy as np
+            paddle.enable_static()
 	    input = fluid.data(name="input", shape=[None,3,6,8,10])
 
 	    #1
@@ -8116,6 +8122,9 @@ def resize_nearest(input,
 	    #declarative mode
 	    import paddle.fluid as fluid
 	    import numpy as np
+            import paddle
+            paddle.enable_static()
+
 	    input = fluid.data(name="input", shape=[None,3,6,10])
 
 	    #1

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7108,9 +7108,6 @@ def image_resize(input,
                  align_mode=1,
                  data_format='NCHW'):
     """
-    :alias_main: paddle.nn.functional.image_resize
-	:alias: paddle.nn.functional.image_resize,paddle.nn.functional.vision.image_resize
-	:old_api: paddle.fluid.layers.image_resize
 
     This op resizes a batch of images.
 
@@ -7708,9 +7705,6 @@ def resize_bilinear(input,
                     align_mode=1,
                     data_format='NCHW'):
     """
-    :alias_main: paddle.nn.functional.resize_bilinear
-	:alias: paddle.nn.functional.resize_bilinear,paddle.nn.functional.vision.resize_bilinear
-	:old_api: paddle.fluid.layers.resize_bilinear
 
     This op resizes the input by performing bilinear interpolation based on given
     output shape which specified by actual_shape, out_shape and scale
@@ -7875,9 +7869,6 @@ def resize_trilinear(input,
                      align_mode=1,
                      data_format='NCDHW'):
     """
-    :alias_main: paddle.nn.functional.resize_trilinear
-	:alias: paddle.nn.functional.resize_trilinear,paddle.nn.functional.vision.resize_trilinear
-	:old_api: paddle.fluid.layers.resize_trilinear
 
     This op resizes the input by performing trilinear interpolation based on given
     output shape which specified by actual_shape, out_shape and scale
@@ -8043,9 +8034,6 @@ def resize_nearest(input,
                    align_corners=True,
                    data_format='NCHW'):
     """
-    :alias_main: paddle.nn.functional.resize_nearest
-	:alias: paddle.nn.functional.resize_nearest,paddle.nn.functional.vision.resize_nearest
-	:old_api: paddle.fluid.layers.resize_nearest
 
     This op resizes the input by performing nearest neighbor interpolation in both the
     height direction and the width direction based on given output shape

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -7347,10 +7347,10 @@ def image_resize(input,
         .. code-block:: python
 
 	    #declarative mode
-            import paddle
+	    import paddle
 	    import paddle.fluid as fluid
 	    import numpy as np
-            paddle.enable_static()
+	    paddle.enable_static()
 	    input = fluid.data(name="input", shape=[None,3,6,10])
 
 	    #1
@@ -7799,8 +7799,8 @@ def resize_bilinear(input,
 
 	    #declarative mode
 	    import paddle.fluid as fluid
-            import paddle
-            paddle.enable_static()
+	    import paddle
+	    paddle.enable_static()
 	    import numpy as np
 	    input = fluid.data(name="input", shape=[None,3,6,10])
 
@@ -7965,9 +7965,9 @@ def resize_trilinear(input,
 
 	    #declarative mode
 	    import paddle.fluid as fluid
-            import paddle
+	    import paddle
 	    import numpy as np
-            paddle.enable_static()
+	    paddle.enable_static()
 	    input = fluid.data(name="input", shape=[None,3,6,8,10])
 
 	    #1
@@ -8122,8 +8122,8 @@ def resize_nearest(input,
 	    #declarative mode
 	    import paddle.fluid as fluid
 	    import numpy as np
-            import paddle
-            paddle.enable_static()
+	    import paddle
+	    paddle.enable_static()
 
 	    input = fluid.data(name="input", shape=[None,3,6,10])
 

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -207,16 +207,12 @@ from .vision import generate_mask_labels  #DEFINE_ALIAS
 from .vision import generate_proposal_labels  #DEFINE_ALIAS
 from .vision import generate_proposals  #DEFINE_ALIAS
 from .vision import grid_sample  #DEFINE_ALIAS
-from .vision import image_resize  #DEFINE_ALIAS
 from .vision import image_resize_short  #DEFINE_ALIAS
 # from .vision import multi_box_head  #DEFINE_ALIAS
 from .vision import pixel_shuffle  #DEFINE_ALIAS
 from .vision import prior_box  #DEFINE_ALIAS
 from .vision import prroi_pool  #DEFINE_ALIAS
 from .vision import psroi_pool  #DEFINE_ALIAS
-from .vision import resize_bilinear  #DEFINE_ALIAS
-from .vision import resize_nearest  #DEFINE_ALIAS
-from .vision import resize_trilinear  #DEFINE_ALIAS
 from .vision import retinanet_detection_output  #DEFINE_ALIAS
 from .vision import retinanet_target_assign  #DEFINE_ALIAS
 from .vision import roi_align  #DEFINE_ALIAS

--- a/python/paddle/nn/functional/vision.py
+++ b/python/paddle/nn/functional/vision.py
@@ -34,13 +34,9 @@ from ...fluid.layers import distribute_fpn_proposals  #DEFINE_ALIAS
 from ...fluid.layers import generate_mask_labels  #DEFINE_ALIAS
 from ...fluid.layers import generate_proposal_labels  #DEFINE_ALIAS
 from ...fluid.layers import generate_proposals  #DEFINE_ALIAS
-from ...fluid.layers import image_resize  #DEFINE_ALIAS
 from ...fluid.layers import prior_box  #DEFINE_ALIAS
 from ...fluid.layers import prroi_pool  #DEFINE_ALIAS
 from ...fluid.layers import psroi_pool  #DEFINE_ALIAS
-from ...fluid.layers import resize_bilinear  #DEFINE_ALIAS
-from ...fluid.layers import resize_nearest  #DEFINE_ALIAS
-from ...fluid.layers import resize_trilinear  #DEFINE_ALIAS
 from ...fluid.layers import roi_align  #DEFINE_ALIAS
 from ...fluid.layers import roi_pool  #DEFINE_ALIAS
 from ...fluid.layers import space_to_depth  #DEFINE_ALIAS
@@ -74,16 +70,12 @@ __all__ = [
     'generate_proposal_labels',
     'generate_proposals',
     'grid_sample',
-    'image_resize',
     'image_resize_short',
     #       'multi_box_head',
     'pixel_shuffle',
     'prior_box',
     'prroi_pool',
     'psroi_pool',
-    'resize_bilinear',
-    'resize_nearest',
-    'resize_trilinear',
     'retinanet_detection_output',
     'retinanet_target_assign',
     'roi_align',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
As the upsample function has already been implemented in ```paddle.nn.functional.interpolate```, ```image_resize``` and ```resize_XXX``` will be removed，and the relied models will be upgraded in the future. 