### PR TITLE
Support setting xpu place in dygraph mode

### DIFF
--- a/paddle/fluid/operators/metrics/accuracy_op_xpu.cc
+++ b/paddle/fluid/operators/metrics/accuracy_op_xpu.cc
@@ -81,9 +81,9 @@ class AccuracyXPUKernel : public framework::OpKernel<T> {
     memory::Copy(platform::CPUPlace(), label_int64_host,
                  BOOST_GET_CONST(platform::XPUPlace, ctx.GetPlace()),
                  label_data, label_int64_size);
-    for (int i = 0; i < num_samples; ++i) {
+    for (size_t i = 0; i < num_samples; ++i) {
       label_int32_host[i] = label_int64_host[i];
-      for (int j = 0; j < class_dim; ++j) {
+      for (size_t j = 0; j < class_dim; ++j) {
         indices_int32_host[i * class_dim + j] =
             indices_int64_host[i * class_dim + j];
       }

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -1439,6 +1439,7 @@ All parameter, weight, gradient are variables in Paddle.
              std::exit(-1);
 #endif
            })
+#ifdef PADDLE_WITH_XPU
       .def("_type", &PlaceIndex<platform::XPUPlace>)
       .def("_equals", &IsSamePlace<platform::XPUPlace, platform::Place>)
       .def("_equals", &IsSamePlace<platform::XPUPlace, platform::CUDAPlace>)
@@ -1446,6 +1447,9 @@ All parameter, weight, gradient are variables in Paddle.
       .def("_equals", &IsSamePlace<platform::XPUPlace, platform::XPUPlace>)
       .def("_equals",
            &IsSamePlace<platform::XPUPlace, platform::CUDAPinnedPlace>)
+      .def("get_device_id",
+           [](const platform::XPUPlace &self) { return self.GetDeviceId(); })
+#endif
       .def("__str__", string::to_string<const platform::XPUPlace &>);
 
   py::class_<paddle::platform::CPUPlace>(m, "CPUPlace", R"DOC(

--- a/python/paddle/device.py
+++ b/python/paddle/device.py
@@ -109,7 +109,7 @@ def set_device(device):
 
     Parameters:
         device(str): This parameter determines the specific running device.
-            It can be ``cpu``, ``gpu:X`` and ``xpu:X``, where ``X`` is the 
+            It can be ``cpu``, ``gpu:x`` and ``xpu:x``, where ``x`` is the 
             index of the GPUs or XPUs. 
 
     Examples:
@@ -141,7 +141,7 @@ def set_device(device):
     else:
         avaliable_gpu_device = re.match(r'gpu:\d+', lower_device)
         avaliable_xpu_device = re.match(r'xpu:\d+', lower_device)
-        if not avaliable_device and not avaliable_xpu_device:
+        if not avaliable_gpu_device and not avaliable_xpu_device:
             raise ValueError(
                 "The device must be a string which is like 'cpu', 'gpu', 'gpu:x', 'xpu' or 'xpu:x'"
             )
@@ -149,7 +149,7 @@ def set_device(device):
             if not core.is_compiled_with_cuda():
                 raise ValueError(
                     "The device should not be {}, since PaddlePaddle is " \
-                    "not compiled with CUDA".format(avaliable_device))
+                    "not compiled with CUDA".format(avaliable_gpu_device))
             device_info_list = device.split(':', 1)
             device_id = device_info_list[1]
             device_id = int(device_id)
@@ -158,7 +158,7 @@ def set_device(device):
             if not core.is_compiled_with_xpu():
                 raise ValueError(
                     "The device should not be {}, since PaddlePaddle is " \
-                    "not compiled with XPU".format(avaliable_device))
+                    "not compiled with XPU".format(avaliable_xpu_device))
             device_info_list = device.split(':', 1)
             device_id = device_info_list[1]
             device_id = int(device_id)
@@ -170,8 +170,8 @@ def set_device(device):
 def get_device():
     """
     This funciton can get the current global device of the program is running.
-    It's a string which is like 'cpu' and 'gpu:0'. if the global device is not
-    set, it will return a string which is 'gpu:0' when cuda is avaliable or it 
+    It's a string which is like 'cpu', 'gpu:x' and 'xpu:x'. if the global device is not
+    set, it will return a string which is 'gpu:x' when cuda is avaliable or it 
     will return a string which is 'cpu' when cuda is not avaliable.
 
     Examples:
@@ -190,5 +190,8 @@ def get_device():
     elif isinstance(place, core.CUDAPlace):
         device_id = place.get_device_id()
         device = 'gpu:' + str(device_id)
+    elif isinstance(place, core.XPUPlace):
+        device_id = place.get_device_id()
+        device = 'xpu:' + str(device_id)
 
     return device

--- a/python/paddle/fluid/tests/unittests/test_device.py
+++ b/python/paddle/fluid/tests/unittests/test_device.py
@@ -51,6 +51,19 @@ class TestStaticDeviceManage(unittest.TestCase):
             self.assertEqual(isinstance(exe.place, core.CUDAPlace), True)
             self.assertEqual(device, "gpu:0")
 
+    def test_xpu_device(self):
+        if core.is_compiled_with_xpu():
+            out1 = paddle.zeros(shape=[1, 3], dtype='float32')
+            out2 = paddle.ones(shape=[1, 3], dtype='float32')
+            out3 = paddle.concat(x=[out1, out2], axis=0)
+            paddle.set_device('xpu:0')
+            exe = paddle.fluid.Executor()
+            exe.run(paddle.fluid.default_startup_program())
+            res = exe.run(fetch_list=[out3])
+            device = paddle.get_device()
+            self.assertEqual(isinstance(exe.place, core.XPUPlace), True)
+            self.assertEqual(device, "xpu:0")
+
 
 class TestImperativeDeviceManage(unittest.TestCase):
     def test_cpu(self):
@@ -77,6 +90,20 @@ class TestImperativeDeviceManage(unittest.TestCase):
                     isinstance(framework._current_expected_place(),
                                core.CUDAPlace), True)
                 self.assertEqual(device, "gpu:0")
+
+    def test_xpu(self):
+        if core.is_compiled_with_xpu():
+            with fluid.dygraph.guard():
+                paddle.set_device('xpu:0')
+                out1 = paddle.zeros(shape=[1, 3], dtype='float32')
+                out2 = paddle.ones(shape=[1, 3], dtype='float32')
+                out3 = paddle.concat(x=[out1, out2], axis=0)
+                device = paddle.get_device()
+                self.assertEqual(
+                    isinstance(framework._current_expected_place(),
+                               core.XPUPlace), True)
+                self.assertTrue(out3.place.is_xpu_place())
+                self.assertEqual(device, "xpu:0")
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_device.py
+++ b/python/paddle/fluid/tests/unittests/test_device.py
@@ -94,15 +94,12 @@ class TestImperativeDeviceManage(unittest.TestCase):
     def test_xpu(self):
         if core.is_compiled_with_xpu():
             with fluid.dygraph.guard():
-                paddle.set_device('xpu:0')
-                out1 = paddle.zeros(shape=[1, 3], dtype='float32')
-                out2 = paddle.ones(shape=[1, 3], dtype='float32')
-                out3 = paddle.concat(x=[out1, out2], axis=0)
+                out = paddle.to_tensor([1, 2])
                 device = paddle.get_device()
                 self.assertEqual(
                     isinstance(framework._current_expected_place(),
                                core.XPUPlace), True)
-                self.assertTrue(out3.place.is_xpu_place())
+                self.assertTrue(out.place.is_xpu_place())
                 self.assertEqual(device, "xpu:0")
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Support setting xpu place in dygraph mode

`paddle.set_device()` and `paddle.get_device()` support xpu, like `xpu:0`.