### PR TITLE
Upgrade minimum numpy version from v1.13 to v1.14

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 requests>=2.20.0
-numpy>=1.13, <=1.16.4 ; python_version<"3.5"
-numpy>=1.13 ; python_version>="3.5"
+numpy>=1.14, <=1.16.4 ; python_version<"3.5"
+numpy>=1.14 ; python_version>="3.5"
 protobuf>=3.1.0
 gast==0.3.3
 matplotlib<=2.2.4 ; python_version<"3.6"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Upgrade minimum numpy version from v1.13 to v1.14

- WHY

