### PR TITLE
randperm run error in multi-gpus

### DIFF
--- a/paddle/fluid/operators/randperm_op.h
+++ b/paddle/fluid/operators/randperm_op.h
@@ -57,7 +57,7 @@ class RandpermKernel : public framework::OpKernel<T> {
       tmp_tensor.Resize(framework::make_ddim({n}));
       T* tmp_data = tmp_tensor.mutable_data<T>(platform::CPUPlace());
       random_permate<T>(tmp_data, n, seed);
-      framework::TensorCopy(tmp_tensor, platform::CUDAPlace(), out_tensor);
+      framework::TensorCopy(tmp_tensor, ctx.GetPlace(), out_tensor);
     }
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
- 修复多卡运行时，randperm只能指定0卡的bug