### PR TITLE
[Dy2Stat] Fix Error when generating train_program in eval mode

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -138,14 +138,14 @@ class PartialProgramLayer(layers.Layer):
         self.training = True
 
     @LazyInitialized
-    def infer_program(self):
+    def _infer_program(self):
         """
         Lazy initialized property of infer_program.
         """
         return self._clone_for_test(self._origin_main_program)
 
     @LazyInitialized
-    def train_program(self):
+    def _train_program(self):
         """
         Lazy initialized property of train_program.
         """
@@ -213,7 +213,7 @@ class PartialProgramLayer(layers.Layer):
             attrs={
                 'global_block': self.program.desc.block(0),
                 'start_op_index': 0,
-                'end_op_index': self.infer_program.desc.block(0).op_size(),
+                'end_op_index': self._infer_program.desc.block(0).op_size(),
                 'is_test': not self.training
             })
 
@@ -222,7 +222,7 @@ class PartialProgramLayer(layers.Layer):
 
     @property
     def program(self):
-        return self.train_program if self.training else self.infer_program
+        return self._train_program if self.training else self._infer_program
 
     def _prepare(self, inputs):
         """

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -82,6 +82,21 @@ class NestSequence(object):
         return self.tolist()[item]
 
 
+class LazyInitialized(object):
+    """
+    Descriptor to implement lazy initialization of property.
+    """
+
+    def __init__(self, function):
+        self.function = function
+
+    def __get__(self, instance, cls):
+        assert instance is not None
+        val = self.function(instance)
+        setattr(instance, self.function.__name__, val)
+        return val
+
+
 class PartialProgramLayer(layers.Layer):
     """
     PartialProgramLayer wraps all the ops from layers decorated by `@declarative`
@@ -109,14 +124,29 @@ class PartialProgramLayer(layers.Layer):
         self._outputs = NestSequence(outputs, need_check=True)
         self._params = parameters if parameters is not None else []
 
-        main_program = self._verify_program(main_program)
-        self._infer_program = self._clone_for_test(main_program)
-        self._train_program = self._append_backward_desc(main_program)
-
-        self._set_grad_type(self._params)
+        self._origin_main_program = self._verify_program(main_program)
         self._inner_scope = core.Scope()
         # Set default mode to train
         self.training = True
+
+    @LazyInitialized
+    def infer_program(self):
+        """
+        Lazy initialized property of infer_program.
+        """
+        return self._clone_for_test(self._origin_main_program)
+
+    @LazyInitialized
+    def train_program(self):
+        """
+        Lazy initialized property of train_program.
+        """
+        train_program = self._append_backward_desc(self._origin_main_program)
+        # Note: Only set grad type once after initializing train program. So we
+        # put it here.
+        self._set_grad_type(self._params, train_program)
+
+        return train_program
 
     def _verify_program(self, main_program):
         """
@@ -174,7 +204,7 @@ class PartialProgramLayer(layers.Layer):
             attrs={
                 'global_block': self.program.desc.block(0),
                 'start_op_index': 0,
-                'end_op_index': self._infer_program.desc.block(0).op_size(),
+                'end_op_index': self.infer_program.desc.block(0).op_size(),
                 'is_test': not self.training
             })
 
@@ -183,7 +213,7 @@ class PartialProgramLayer(layers.Layer):
 
     @property
     def program(self):
-        return self._train_program if self.training else self._infer_program
+        return self.train_program if self.training else self.infer_program
 
     def _prepare(self, inputs):
         """
@@ -280,7 +310,7 @@ class PartialProgramLayer(layers.Layer):
 
         return out_vars
 
-    def _set_grad_type(self, params):
+    def _set_grad_type(self, params, train_program):
         # NOTE: if user set sparse gradient mode, the param's gradient
         # will be SelectedRows, not LoDTensor. But tracer will just
         # set param grad VarBase by forward VarBase(LoDTensor)
@@ -289,7 +319,7 @@ class PartialProgramLayer(layers.Layer):
         # be user wanted result.
         for param in params:
             grad_name = param.name + core.grad_var_suffix()
-            grad_var = self._train_program.desc.block(0).find_var(
+            grad_var = train_program.desc.block(0).find_var(
                 cpt.to_bytes(grad_name))
             # NOTE: cannot find var desc maybe no problem, such as in batch_norm
             if grad_var is None:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -91,7 +91,6 @@ class LazyInitialized(object):
         self.function = function
 
     def __get__(self, instance, cls):
-        assert instance is not None
         val = self.function(instance)
         setattr(instance, self.function.__name__, val)
         return val

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -54,10 +54,28 @@ class TestLstm(unittest.TestCase):
     def test_save_in_eval(self):
         paddle.jit.ProgramTranslator().enable(True)
         net = Net(12, 2)
+        # switch eval mode firstly
         net.eval()
         net = paddle.jit.to_static(
             net, input_spec=[paddle.static.InputSpec(shape=[-1, 10, 12])])
         paddle.jit.save(net, 'simple_lstm')
+        # load saved model
+        load_net = paddle.jit.load('simple_lstm')
+
+        x = paddle.randn((2, 10, 12))
+        dygraph_out = net(x)
+        static_out = load_net(x)
+        self.assertTrue(
+            np.allclose(dygraph_out.numpy(), static_out.numpy()),
+            msg='dygraph_out is {}\n static_out is \n{}'.format(dygraph_out,
+                                                                static_out))
+        # switch back into train mode.
+        net.train()
+        train_out = net(x)
+        self.assertTrue(
+            np.allclose(dygraph_out.numpy(), train_out.numpy()),
+            msg='dygraph_out is {}\n static_out is \n{}'.format(dygraph_out,
+                                                                train_out))
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -51,6 +51,14 @@ class TestLstm(unittest.TestCase):
             msg='dygraph_out is {}\n static_out is \n{}'.format(dygraph_out,
                                                                 static_out))
 
+    def test_save_in_eval(self):
+        paddle.jit.ProgramTranslator().enable(True)
+        net = Net(12, 2)
+        net.eval()
+        net = paddle.jit.to_static(
+            net, input_spec=[paddle.static.InputSpec(shape=[-1, 10, 12])])
+        paddle.jit.save(net, 'simple_lstm')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
@@ -136,17 +136,20 @@ class TestWithTrainAndEval(unittest.TestCase):
 
             _, partial_layer = linear_net.forward.program_cache.last()[-1]
             # check default mode is for training
-            self.assertEqual(partial_layer.program, partial_layer.train_program)
+            self.assertEqual(partial_layer.program,
+                             partial_layer._train_program)
 
             # switch to run test program after `eval()`
             linear_net.eval()
             linear_net(x)
-            self.assertEqual(partial_layer.program, partial_layer.infer_program)
+            self.assertEqual(partial_layer.program,
+                             partial_layer._infer_program)
 
             # switch back into training
             linear_net.train()
             linear_net(x)
-            self.assertEqual(partial_layer.program, partial_layer.train_program)
+            self.assertEqual(partial_layer.program,
+                             partial_layer._train_program)
 
 
 class GPT2LMHeadModel(fluid.dygraph.Layer):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_partial_program.py
@@ -136,20 +136,17 @@ class TestWithTrainAndEval(unittest.TestCase):
 
             _, partial_layer = linear_net.forward.program_cache.last()[-1]
             # check default mode is for training
-            self.assertEqual(partial_layer.program,
-                             partial_layer._train_program)
+            self.assertEqual(partial_layer.program, partial_layer.train_program)
 
             # switch to run test program after `eval()`
             linear_net.eval()
             linear_net(x)
-            self.assertEqual(partial_layer.program,
-                             partial_layer._infer_program)
+            self.assertEqual(partial_layer.program, partial_layer.infer_program)
 
             # switch back into training
             linear_net.train()
             linear_net(x)
-            self.assertEqual(partial_layer.program,
-                             partial_layer._train_program)
+            self.assertEqual(partial_layer.program, partial_layer.train_program)
 
 
 class GPT2LMHeadModel(fluid.dygraph.Layer):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix Error when generating train_program in eval mode. See following example code:

```python
class Net(nn.Layer):
    def __init__(self, in_channels, hidden_size):
        super(Net, self).__init__()
        self.lstm = nn.LSTM(
            in_channels, hidden_size, direction='bidirectional', num_layers=2)

    @paddle.jit.to_static
    def forward(self, x):
        x, _ = self.lstm(x)
        return x

net = Net(12, 2)
net.eval() # switch into eval mode firstly
# Here, we will get infer_program defaultly after converting dygraph layers into static.
# When initializing ParitalLayer, a train_program will be generated by `append_backward`
# from converted program(here is infer_program) with `is_test=True`, which will raise a error.
net = paddle.jit.to_static(
    net, input_spec=[paddle.static.InputSpec(shape=[-1, 10, 12])])
paddle.jit.save(net, 'simple_lstm')
```

**Solution:**
1. Add `change_is_test_status` to make sure all is_test=True  before `append_backward`
2. Introduce lazy initialization mechanism to create program while only we need it. 
