### PR TITLE
Fix random failure of test_initializer

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_initializer.py
+++ b/python/paddle/fluid/tests/unittests/test_initializer.py
@@ -599,9 +599,9 @@ class TestUniformInitializerDygraph(unittest.TestCase):
         """
         paddle.disable_static()
 
-        tensor = paddle.zeros([1024, 1024])
+        tensor = paddle.zeros([1024, 1024, 16])
         tensor.stop_gradient = False
-        self.assertTrue(np.allclose(np.zeros((1024, 1024)), tensor.numpy()))
+        self.assertTrue(np.allclose(np.zeros((1024, 1024, 16)), tensor.numpy()))
 
         uniform_ = paddle.nn.initializer.Uniform()
         uniform_(tensor)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->


Fix random failure of test_initializer by increasing the shape of random tensor
