### PR TITLE
Add pil backend for vision transforms

### DIFF
--- a/python/paddle/tests/test_callbacks.py
+++ b/python/paddle/tests/test_callbacks.py
@@ -105,7 +105,7 @@ class TestCallbacks(unittest.TestCase):
         self.run_callback()
 
     def test_visualdl_callback(self):
-        # visualdl not support python3
+        # visualdl not support python2
         if sys.version_info < (3, ):
             return
 

--- a/python/paddle/tests/test_transforms.py
+++ b/python/paddle/tests/test_transforms.py
@@ -299,6 +299,39 @@ class TestFunctional(unittest.TestCase):
                 'uint8'))
             F.resize(fake_img, '1')
 
+        with self.assertRaises(TypeError):
+            F.resize(1, 1)
+
+        with self.assertRaises(TypeError):
+            F.pad(1, 1)
+
+        with self.assertRaises(TypeError):
+            F.crop(1, 1, 1, 1, 1)
+
+        with self.assertRaises(TypeError):
+            F.hflip(1)
+
+        with self.assertRaises(TypeError):
+            F.vflip(1)
+
+        with self.assertRaises(TypeError):
+            F.adjust_brightness(1, 0.1)
+
+        with self.assertRaises(TypeError):
+            F.adjust_contrast(1, 0.1)
+
+        with self.assertRaises(TypeError):
+            F.adjust_hue(1, 0.1)
+
+        with self.assertRaises(TypeError):
+            F.adjust_saturation(1, 0.1)
+
+        with self.assertRaises(TypeError):
+            F.rotate(1, 0.1)
+
+        with self.assertRaises(TypeError):
+            F.to_grayscale(1)
+
     def test_normalize(self):
         np_img = (np.random.rand(28, 24, 3)).astype('uint8')
         pil_img = Image.fromarray(np_img)

--- a/python/paddle/tests/test_transforms.py
+++ b/python/paddle/tests/test_transforms.py
@@ -297,6 +297,22 @@ class TestTransformsCV2(unittest.TestCase):
             fake_img = self.create_image((100, 120, 3))
             trans_gray(fake_img)
 
+        with self.assertRaises(TypeError):
+            transform = transforms.RandomResizedCrop(64)
+            transform(1)
+
+        with self.assertRaises(ValueError):
+            transform = transforms.BrightnessTransform([-0.1, -0.2])
+
+        with self.assertRaises(TypeError):
+            transform = transforms.BrightnessTransform('0.1')
+
+        with self.assertRaises(ValueError):
+            transform = transforms.BrightnessTransform('0.1', keys=1)
+
+        with self.assertRaises(NotImplementedError):
+            transform = transforms.BrightnessTransform('0.1', keys='a')
+
     def test_info(self):
         str(
             transforms.Compose(
@@ -311,6 +327,229 @@ class TestTransformsCV2(unittest.TestCase):
 class TestTransformsPIL(TestTransformsCV2):
     def set_backend(self):
         return 'pil'
+
+
+class TestFunctional(unittest.TestCase):
+    def test_errors(self):
+        with self.assertRaises(TypeError):
+            F.to_tensor(1)
+
+        with self.assertRaises(ValueError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.to_tensor(fake_img, data_format=1)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.resize(fake_img, '1')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.resize(fake_img, 24)
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.crop(fake_img, 1, 1, 1, 1)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.crop(fake_img, 1, 1, 1, 1, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.hflip(fake_img)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.hflip(fake_img, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.vflip(fake_img)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.vflip(fake_img, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.adjust_brightness(fake_img, 0.1)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.adjust_brightness(fake_img, 0.1, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.adjust_contrast(fake_img, 0.1)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.adjust_contrast(fake_img, 0.1, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.adjust_hue(fake_img, 0.1)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.adjust_hue(fake_img, 0.1, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.adjust_saturation(fake_img, 0.1)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.adjust_saturation(fake_img, 0.1, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.rotate(fake_img, 90)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.rotate(fake_img, 90, backend='cv2')
+
+        with self.assertRaises(TypeError):
+            fake_img = (np.random.rand(28, 28, 3) * 255).astype('uint8')
+            F.to_grayscale(fake_img)
+
+        with self.assertRaises(TypeError):
+            fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+                'uint8'))
+            F.to_grayscale(fake_img, backend='cv2')
+
+        fake_img = Image.fromarray((np.random.rand(28, 28, 3) * 255).astype(
+            'uint8'))
+        with self.assertRaises(ValueError):
+            F.pad(fake_img, 1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.crop(fake_img, 1, 1, 1, 1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.center_crop(fake_img, 1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.hflip(fake_img, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.vflip(fake_img, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.adjust_brightness(fake_img, 0.1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.adjust_contrast(fake_img, 0.1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.adjust_hue(fake_img, 0.1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.adjust_saturation(fake_img, 0.1, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.rotate(fake_img, 90, backend=1)
+
+        with self.assertRaises(ValueError):
+            F.to_grayscale(fake_img, backend=1)
+
+    def test_normalize(self):
+        np_img = (np.random.rand(28, 24, 3)).astype('uint8')
+        pil_img = Image.fromarray(np_img)
+        tensor_img = F.to_tensor(pil_img)
+        tensor_img_hwc = F.to_tensor(pil_img, data_format='HWC')
+
+        mean = [0.5, 0.5, 0.5]
+        std = [0.5, 0.5, 0.5]
+
+        normalized_img = F.normalize(tensor_img, mean, std)
+        normalized_img = F.normalize(
+            tensor_img_hwc, mean, std, data_format='HWC')
+
+        normalized_img = F.normalize(pil_img, mean, std, data_format='HWC')
+        normalized_img = F.normalize(
+            np_img, mean, std, data_format='HWC', to_rgb=True)
+
+    def test_center_crop(self):
+        np_img = (np.random.rand(28, 24, 3)).astype('uint8')
+        pil_img = Image.fromarray(np_img)
+
+        np_cropped_img = F.center_crop(np_img, 4, backend='cv2')
+        pil_cropped_img = F.center_crop(pil_img, 4, backend='pil')
+
+        np.testing.assert_almost_equal(np_cropped_img,
+                                       np.array(pil_cropped_img))
+
+    def test_pad(self):
+        np_img = (np.random.rand(28, 24, 3)).astype('uint8')
+        pil_img = Image.fromarray(np_img)
+
+        np_padded_img = F.pad(np_img, [1, 2],
+                              padding_mode='reflect',
+                              backend='cv2')
+        pil_padded_img = F.pad(pil_img, [1, 2],
+                               padding_mode='reflect',
+                               backend='pil')
+
+        np.testing.assert_almost_equal(np_padded_img, np.array(pil_padded_img))
+
+        pil_p_img = pil_img.convert('P')
+        pil_padded_img = F.pad(pil_p_img, [1, 2], backend='pil')
+        pil_padded_img = F.pad(pil_p_img, [1, 2],
+                               padding_mode='reflect',
+                               backend='pil')
+
+    def test_resize(self):
+        np_img = (np.zeros([28, 24, 3])).astype('uint8')
+        pil_img = Image.fromarray(np_img)
+
+        np_reseized_img = F.resize(np_img, 40, backend='cv2')
+        pil_reseized_img = F.resize(pil_img, 40, backend='pil')
+
+        np.testing.assert_almost_equal(np_reseized_img,
+                                       np.array(pil_reseized_img))
+
+        gray_img = (np.zeros([28, 32])).astype('uint8')
+        gray_resize_img = F.resize(gray_img, 40, backend='cv2')
+
+    def test_to_tensor(self):
+        np_img = (np.random.rand(28, 28) * 255).astype('uint8')
+        pil_img = Image.fromarray(np_img)
+
+        np_tensor = F.to_tensor(np_img, data_format='HWC')
+        pil_tensor = F.to_tensor(pil_img, data_format='HWC')
+
+        np.testing.assert_allclose(np_tensor.numpy(), pil_tensor.numpy())
+
+        # test float dtype 
+        float_img = np.random.rand(28, 28)
+        float_tensor = F.to_tensor(float_img)
+
+        pil_img = Image.fromarray(np_img).convert('I')
+        pil_tensor = F.to_tensor(pil_img)
+
+        pil_img = Image.fromarray(np_img).convert('I;16')
+        pil_tensor = F.to_tensor(pil_img)
+
+        pil_img = Image.fromarray(np_img).convert('F')
+        pil_tensor = F.to_tensor(pil_img)
+
+        pil_img = Image.fromarray(np_img).convert('1')
+        pil_tensor = F.to_tensor(pil_img)
+
+        pil_img = Image.fromarray(np_img).convert('YCbCr')
+        pil_tensor = F.to_tensor(pil_img)
 
 
 if __name__ == '__main__':

--- a/python/paddle/tests/test_transforms.py
+++ b/python/paddle/tests/test_transforms.py
@@ -332,6 +332,9 @@ class TestFunctional(unittest.TestCase):
         with self.assertRaises(TypeError):
             F.to_grayscale(1)
 
+        with self.assertRaises(TypeError):
+            set_image_backend(1)
+
     def test_normalize(self):
         np_img = (np.random.rand(28, 24, 3)).astype('uint8')
         pil_img = Image.fromarray(np_img)

--- a/python/paddle/tests/test_transforms.py
+++ b/python/paddle/tests/test_transforms.py
@@ -332,7 +332,7 @@ class TestFunctional(unittest.TestCase):
         with self.assertRaises(TypeError):
             F.to_grayscale(1)
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             set_image_backend(1)
 
     def test_normalize(self):

--- a/python/paddle/tests/test_transforms.py
+++ b/python/paddle/tests/test_transforms.py
@@ -21,7 +21,7 @@ import numpy as np
 from PIL import Image
 
 import paddle
-from paddle.vision import get_image_backend, set_image_backend
+from paddle.vision import get_image_backend, set_image_backend, image_load
 from paddle.vision.datasets import DatasetFolder
 from paddle.vision.transforms import transforms
 import paddle.vision.transforms.functional as F
@@ -335,6 +335,9 @@ class TestFunctional(unittest.TestCase):
         with self.assertRaises(ValueError):
             set_image_backend(1)
 
+        with self.assertRaises(ValueError):
+            image_load('tmp.jpg', backend=1)
+
     def test_normalize(self):
         np_img = (np.random.rand(28, 24, 3)).astype('uint8')
         pil_img = Image.fromarray(np_img)
@@ -415,6 +418,25 @@ class TestFunctional(unittest.TestCase):
 
         pil_img = Image.fromarray(np_img).convert('YCbCr')
         pil_tensor = F.to_tensor(pil_img)
+
+    def test_image_load(self):
+        fake_img = Image.fromarray((np.random.random((32, 32, 3)) * 255).astype(
+            'uint8'))
+
+        path = 'temp.jpg'
+        fake_img.save(path)
+
+        set_image_backend('pil')
+
+        pil_img = image_load(path).convert('RGB')
+
+        print(type(pil_img))
+
+        set_image_backend('cv2')
+
+        np_img = image_load(path)
+
+        os.remove(path)
 
 
 if __name__ == '__main__':

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -21,7 +21,9 @@ from .transforms import *
 from . import datasets
 from .datasets import *
 
-__all__ = models.__all__ \
+__all__ = ['set_image_backend', 'get_image_backend']
+
+__all__ += models.__all__ \
         + transforms.__all__ \
         + datasets.__all__
 
@@ -30,20 +32,85 @@ _image_backend = 'pil'
 
 def set_image_backend(backend):
     """
-    Specifies the package used to load images.
+    Specifies the backend used to load images in class ``paddle.vision.datasets.ImageFolder`` 
+    and ``paddle.vision.datasets.DatasetFolder`` . Now support backends are pillow and opencv. 
+    If backend not set, will use 'pil' as default. 
 
     Args:
-        backend (str): Name of the image backend. one of {'pil', 'cv2'}.
+        backend (str): Name of the image load backend, should be one of {'pil', 'cv2'}.
+
+    Examples:
+    
+        .. code-block:: python
+
+            import os
+            import cv2
+            import shutil
+            import tempfile
+            import numpy as np
+
+            from paddle.vision import DatasetFolder
+            from paddle.vision import set_image_backend
+
+            set_image_backend('cv2')
+
+            def make_fake_dir():
+                data_dir = tempfile.mkdtemp()
+
+                for i in range(2):
+                    sub_dir = os.path.join(data_dir, 'class_' + str(i))
+                    if not os.path.exists(sub_dir):
+                        os.makedirs(sub_dir)
+                    for j in range(2):
+                        fake_img = (np.random.random((32, 32, 3)) * 255).astype('uint8')
+                        cv2.imwrite(os.path.join(sub_dir, str(j) + '.jpg'), fake_img)
+                return data_dir
+
+            temp_dir = make_fake_dir()
+
+            cv2_data_folder = DatasetFolder(temp_dir)
+
+            for items in cv2_data_folder:
+                break
+
+            # should get numpy.ndarray
+            print(type(items[0]))
+
+            set_image_backend('pil')
+
+            pil_data_folder = DatasetFolder(temp_dir)
+
+            for items in pil_data_folder:
+                break
+
+            # should get PIL.Image.Image
+            print(type(items[0]))
+
+            shutil.rmtree(temp_dir)
     """
     global _image_backend
     if backend not in ['pil', 'cv2']:
-        raise ValueError("Invalid backend '{}'. Options are 'pil' and 'cv2'"
-                         .format(backend))
+        raise ValueError(
+            "Expected backend are one of {'pil', 'cv2'}, but got {}"
+            .format(backend))
     _image_backend = backend
 
 
 def get_image_backend():
     """
     Gets the name of the package used to load images
+
+    Returns:
+        str: backend of image load.
+
+    Examples:
+    
+        .. code-block:: python
+
+            from paddle.vision import get_image_backend
+
+            backend = get_image_backend()
+            print(backend)
+
     """
     return _image_backend

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -24,3 +24,26 @@ from .datasets import *
 __all__ = models.__all__ \
         + transforms.__all__ \
         + datasets.__all__
+
+_image_backend = 'pil'
+
+
+def set_image_backend(backend):
+    """
+    Specifies the package used to load images.
+
+    Args:
+        backend (str): Name of the image backend. one of {'pil', 'cv2'}.
+    """
+    global _image_backend
+    if backend not in ['pil', 'cv2']:
+        raise ValueError("Invalid backend '{}'. Options are 'pil' and 'cv2'"
+                         .format(backend))
+    _image_backend = backend
+
+
+def get_image_backend():
+    """
+    Gets the name of the package used to load images
+    """
+    return _image_backend

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -23,7 +23,6 @@ from .datasets import *
 
 from . import utils
 from .utils import *
-from .utils import _image_backend
 
 __all__ = models.__all__ \
         + transforms.__all__ \

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -21,96 +21,11 @@ from .transforms import *
 from . import datasets
 from .datasets import *
 
-__all__ = ['set_image_backend', 'get_image_backend']
+from . import utils
+from .utils import *
+from .utils import _image_backend
 
-__all__ += models.__all__ \
+__all__ = models.__all__ \
         + transforms.__all__ \
-        + datasets.__all__
-
-_image_backend = 'pil'
-
-
-def set_image_backend(backend):
-    """
-    Specifies the backend used to load images in class ``paddle.vision.datasets.ImageFolder`` 
-    and ``paddle.vision.datasets.DatasetFolder`` . Now support backends are pillow and opencv. 
-    If backend not set, will use 'pil' as default. 
-
-    Args:
-        backend (str): Name of the image load backend, should be one of {'pil', 'cv2'}.
-
-    Examples:
-    
-        .. code-block:: python
-
-            import os
-            import cv2
-            import shutil
-            import tempfile
-            import numpy as np
-
-            from paddle.vision import DatasetFolder
-            from paddle.vision import set_image_backend
-
-            set_image_backend('cv2')
-
-            def make_fake_dir():
-                data_dir = tempfile.mkdtemp()
-
-                for i in range(2):
-                    sub_dir = os.path.join(data_dir, 'class_' + str(i))
-                    if not os.path.exists(sub_dir):
-                        os.makedirs(sub_dir)
-                    for j in range(2):
-                        fake_img = (np.random.random((32, 32, 3)) * 255).astype('uint8')
-                        cv2.imwrite(os.path.join(sub_dir, str(j) + '.jpg'), fake_img)
-                return data_dir
-
-            temp_dir = make_fake_dir()
-
-            cv2_data_folder = DatasetFolder(temp_dir)
-
-            for items in cv2_data_folder:
-                break
-
-            # should get numpy.ndarray
-            print(type(items[0]))
-
-            set_image_backend('pil')
-
-            pil_data_folder = DatasetFolder(temp_dir)
-
-            for items in pil_data_folder:
-                break
-
-            # should get PIL.Image.Image
-            print(type(items[0]))
-
-            shutil.rmtree(temp_dir)
-    """
-    global _image_backend
-    if backend not in ['pil', 'cv2']:
-        raise ValueError(
-            "Expected backend are one of {'pil', 'cv2'}, but got {}"
-            .format(backend))
-    _image_backend = backend
-
-
-def get_image_backend():
-    """
-    Gets the name of the package used to load images
-
-    Returns:
-        str: backend of image load.
-
-    Examples:
-    
-        .. code-block:: python
-
-            from paddle.vision import get_image_backend
-
-            backend = get_image_backend()
-            print(backend)
-
-    """
-    return _image_backend
+        + datasets.__all__ \
+        + utils.__all__

--- a/python/paddle/vision/__init__.py
+++ b/python/paddle/vision/__init__.py
@@ -21,10 +21,10 @@ from .transforms import *
 from . import datasets
 from .datasets import *
 
-from . import utils
-from .utils import *
+from . import image
+from .image import *
 
 __all__ = models.__all__ \
         + transforms.__all__ \
         + datasets.__all__ \
-        + utils.__all__
+        + image.__all__

--- a/python/paddle/vision/datasets/folder.py
+++ b/python/paddle/vision/datasets/folder.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+from PIL import Image
 
 import paddle
 from paddle.io import Dataset
@@ -136,7 +137,7 @@ class DatasetFolder(Dataset):
                 "Found 0 files in subfolders of: " + self.root + "\n"
                 "Supported extensions are: " + ",".join(extensions)))
 
-        self.loader = cv2_loader if loader is None else loader
+        self.loader = pil_loader if loader is None else loader
         self.extensions = extensions
 
         self.classes = classes
@@ -193,9 +194,8 @@ IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif',
                   '.tiff', '.webp')
 
 
-def cv2_loader(path):
-    cv2 = try_import('cv2')
-    return cv2.imread(path)
+def pil_loader(path):
+    return Image.open(path).convert('RGB')
 
 
 class ImageFolder(Dataset):
@@ -280,7 +280,7 @@ class ImageFolder(Dataset):
                 "Found 0 files in subfolders of: " + self.root + "\n"
                 "Supported extensions are: " + ",".join(extensions)))
 
-        self.loader = cv2_loader if loader is None else loader
+        self.loader = pil_loader if loader is None else loader
         self.extensions = extensions
         self.samples = samples
         self.transform = transform

--- a/python/paddle/vision/datasets/folder.py
+++ b/python/paddle/vision/datasets/folder.py
@@ -137,7 +137,7 @@ class DatasetFolder(Dataset):
                 "Found 0 files in subfolders of: " + self.root + "\n"
                 "Supported extensions are: " + ",".join(extensions)))
 
-        self.loader = pil_loader if loader is None else loader
+        self.loader = default_loader if loader is None else loader
         self.extensions = extensions
 
         self.classes = classes
@@ -195,7 +195,22 @@ IMG_EXTENSIONS = ('.jpg', '.jpeg', '.png', '.ppm', '.bmp', '.pgm', '.tif',
 
 
 def pil_loader(path):
-    return Image.open(path).convert('RGB')
+    with open(path, 'rb') as f:
+        img = Image.open(f)
+        return img.convert('RGB')
+
+
+def cv2_loader(path):
+    cv2 = try_import('cv2')
+    return cv2.cvtColor(cv2.imread(path), cv2.COLOR_BGR2RGB)
+
+
+def default_loader(path):
+    from paddle.vision import get_image_backend
+    if get_image_backend() == 'cv2':
+        return cv2_loader(path)
+    else:
+        return pil_loader(path)
 
 
 class ImageFolder(Dataset):
@@ -280,7 +295,7 @@ class ImageFolder(Dataset):
                 "Found 0 files in subfolders of: " + self.root + "\n"
                 "Supported extensions are: " + ",".join(extensions)))
 
-        self.loader = pil_loader if loader is None else loader
+        self.loader = default_loader if loader is None else loader
         self.extensions = extensions
         self.samples = samples
         self.transform = transform

--- a/python/paddle/vision/image.py
+++ b/python/paddle/vision/image.py
@@ -123,6 +123,7 @@ def image_load(path, backend=None):
     
         .. code-block:: python
 
+            import numpy as np
             from PIL import Image
             from paddle.vision import image_load, set_image_backend
 

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -185,7 +185,7 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
             - "area": cv2.INTER_AREA, 
             - "bicubic": cv2.INTER_CUBIC, 
             - "lanczos": cv2.INTER_LANCZOS4
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Returns:
@@ -302,7 +302,7 @@ def pad(img, padding, fill=0, padding_mode='constant', backend='pil'):
 
                          padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
                          will result in [2, 1, 1, 2, 3, 4, 4, 3]
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array: Padded image.
@@ -420,7 +420,7 @@ def crop(img, top, left, height, width, backend='pil'):
         left (int): Horizontal component of the top left corner of the crop box.
         height (int): Height of the crop box.
         width (int): Width of the crop box.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Returns:
@@ -468,7 +468,7 @@ def center_crop(img, output_size, backend='pil'):
             img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
             output_size (sequence or int): (height, width) of the crop box. If int,
                 it is used for both directions
-            backend (str, optional): The image resize backend type. Options are `pil`, `cv2`. Default: 'pil'. 
+            backend (str, optional): The image proccess backend type. Options are `pil`, `cv2`. Default: 'pil'. 
         
         Returns:
             PIL.Image or np.array: Cropped image.
@@ -514,7 +514,7 @@ def hflip(img, backend='pil'):
 
     Args:
         img (PIL.Image|np.array): Image to be flipped.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Returns:
@@ -557,7 +557,7 @@ def vflip(img, backend='pil'):
 
     Args:
         img (PIL.Image|np.array): Image to be flipped.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Returns:
@@ -605,7 +605,7 @@ def adjust_brightness(img, brightness_factor, backend='pil'):
         brightness_factor (float):  How much to adjust the brightness. Can be
             any non negative number. 0 gives a black image, 1 gives the
             original image while 2 increases the brightness by a factor of 2.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array: Brightness adjusted image.
@@ -656,7 +656,7 @@ def adjust_contrast(img, contrast_factor, backend='pil'):
         contrast_factor (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives a solid gray image, 1 gives the
             original image while 2 increases the contrast by a factor of 2.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array: Contrast adjusted image.
@@ -706,7 +706,7 @@ def adjust_saturation(img, saturation_factor, backend='pil'):
         saturation_factor (float):  How much to adjust the saturation. 0 will
             give a black and white image, 1 will give the original image while
             2 will enhance the saturation by a factor of 2.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Returns:
@@ -770,7 +770,7 @@ def adjust_hue(img, hue_factor, backend='pil'):
             HSV space in positive and negative direction respectively.
             0 means no shift. Therefore, both -0.5 and 0.5 will give an image
             with complementary colors while 0 gives the original image.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Returns:
@@ -867,7 +867,7 @@ def rotate(img,
             Default is the center of the image.
         fill (3-tuple or int): RGB pixel fill value for area outside the rotated image.
             If int, it is used for all channels respectively.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
                     `cv2`. Default: 'pil'. 
 
     Returns:
@@ -920,7 +920,7 @@ def to_grayscale(img, num_output_channels=1, backend='pil'):
 
     Args:
         img (PIL.Image|np.array): Image to be converted to grayscale.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
                     `cv2`. Default: 'pil'. 
 
     Returns:
@@ -991,7 +991,7 @@ def normalize(img, mean, std, data_format='CHW', to_rgb=False):
         data_format (str, optional): Data format of img, should be 'HWC' or 
             'CHW'. Default: 'CHW'.
         to_rgb (bool, optional): Whether to convert to rgb. Default: False.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
                     `cv2`. Default: 'pil'. 
 
     Returns:

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -173,19 +173,19 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
         size (int|list|tuple): Target size of input data, with (height, width) shape.
         interpolation (int|str, optional): Interpolation method. 
             when use pil backend, support method are as following: 
-                'nearest': Image.NEAREST, 
-                'bilinear': Image.BILINEAR, 
-                'bicubic': Image.BICUBIC, 
-                'box': Image.BOX, 
-                'lanczos': Image.LANCZOS, 
-                'hamming': Image.HAMMING
-                
+                - 'nearest': Image.NEAREST, 
+                - 'bilinear': Image.BILINEAR, 
+                - 'bicubic': Image.BICUBIC, 
+                - 'box': Image.BOX, 
+                - 'lanczos': Image.LANCZOS, 
+                - 'hamming': Image.HAMMING
+
             when use cv2 backend, support method are as following: 
-                'nearest': cv2.INTER_NEAREST, 
-                'bilinear': cv2.INTER_LINEAR, 
-                'area': cv2.INTER_AREA, 
-                'bicubic': cv2.INTER_CUBIC, 
-                'lanczos': cv2.INTER_LANCZOS4
+                - 'nearest': cv2.INTER_NEAREST, 
+                - 'bilinear': cv2.INTER_LINEAR, 
+                - 'area': cv2.INTER_AREA, 
+                - 'bicubic': cv2.INTER_CUBIC, 
+                - 'lanczos': cv2.INTER_LANCZOS4
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
@@ -853,14 +853,14 @@ def rotate(img,
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend. 
             when use pil backend, support method are as following: 
-                'nearest': Image.NEAREST, 
-                'bilinear': Image.BILINEAR, 
-                'bicubic': Image.BICUBIC
+                - 'nearest': Image.NEAREST, 
+                - 'bilinear': Image.BILINEAR, 
+                - 'bicubic': Image.BICUBIC
 
             when use cv2 backend, support method are as following: 
-                'nearest': cv2.INTER_NEAREST, 
-                'bilinear': cv2.INTER_LINEAR, 
-                'bicubic': cv2.INTER_CUBIC
+                - 'nearest': cv2.INTER_NEAREST, 
+                - 'bilinear': cv2.INTER_LINEAR, 
+                - 'bicubic': cv2.INTER_CUBIC
         expand (bool, optional): Optional expansion flag.
             If true, expands the output image to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -16,18 +16,13 @@ from __future__ import division
 
 import sys
 import math
-from PIL import Image, ImageOps, ImageEnhance
-
-try:
-    import cv2
-except ImportError:
-    cv2 = None
+import numbers
+import warnings
+import collections
 
 import numpy as np
+from PIL import Image
 from numpy import sin, cos, tan
-import numbers
-import collections
-import warnings
 import paddle
 
 if sys.version_info < (3, 3):
@@ -46,31 +41,6 @@ __all__ = [
     'crop', 'center_crop', 'adjust_brightness', 'adjust_contrast', 'adjust_hue',
     'to_grayscale', 'normalize'
 ]
-
-_pil_interp_from_str = {
-    'nearest': Image.NEAREST,
-    'bilinear': Image.BILINEAR,
-    'bicubic': Image.BICUBIC,
-    'box': Image.BOX,
-    'lanczos': Image.LANCZOS,
-    'hamming': Image.HAMMING
-}
-
-if cv2 is not None:
-    _cv2_interp_from_str = {
-        'nearest': cv2.INTER_NEAREST,
-        'bilinear': cv2.INTER_LINEAR,
-        'area': cv2.INTER_AREA,
-        'bicubic': cv2.INTER_CUBIC,
-        'lanczos': cv2.INTER_LANCZOS4
-    }
-
-    _cv2_pad_from_str = {
-        'constant': cv2.BORDER_CONSTANT,
-        'edge': cv2.BORDER_REPLICATE,
-        'reflect': cv2.BORDER_REFLECT_101,
-        'symmetric': cv2.BORDER_REFLECT
-    }
 
 
 def _is_pil_image(img):
@@ -96,7 +66,7 @@ def to_tensor(pic, data_format='CHW'):
             'CHW'. Default: 'CHW'.
 
     Returns:
-        Tensor: Converted image.
+        Tensor: Converted image. Data format is same as input img.
 
     Examples:
         .. code-block:: python
@@ -238,7 +208,7 @@ def pad(img, padding, fill=0, padding_mode='constant'):
 
 
 def crop(img, top, left, height, width):
-    """Crops the given PIL Image.
+    """Crops the given Image.
 
     Args:
         img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left 
@@ -278,7 +248,7 @@ def crop(img, top, left, height, width):
 
 
 def center_crop(img, output_size):
-    """Crops the given PIL Image and resize it to desired size.
+    """Crops the given Image and resize it to desired size.
 
         Args:
             img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
@@ -314,7 +284,7 @@ def center_crop(img, output_size):
 
 
 def hflip(img, backend='pil'):
-    """Horizontally flips the given PIL Image or np.array.
+    """Horizontally flips the given Image or np.array.
 
     Args:
         img (PIL.Image|np.array): Image to be flipped.
@@ -351,7 +321,7 @@ def hflip(img, backend='pil'):
 
 
 def vflip(img):
-    """Vertically flips the given PIL Image or np.array.
+    """Vertically flips the given Image or np.array.
 
     Args:
         img (PIL.Image|np.array): Image to be flipped.
@@ -389,8 +359,8 @@ def adjust_brightness(img, brightness_factor):
     """Adjusts brightness of an Image.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
-        brightness_factor (float):  How much to adjust the brightness. Can be
+        img (PIL.Image|np.array): Image to be adjusted.
+        brightness_factor (float): How much to adjust the brightness. Can be
             any non negative number. 0 gives a black image, 1 gives the
             original image while 2 increases the brightness by a factor of 2.
 
@@ -426,7 +396,7 @@ def adjust_contrast(img, contrast_factor):
     """Adjusts contrast of an Image.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image|np.array): Image to be adjusted.
         contrast_factor (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives a solid gray image, 1 gives the
             original image while 2 increases the contrast by a factor of 2.
@@ -463,7 +433,7 @@ def adjust_saturation(img, saturation_factor):
     """Adjusts color saturation of an image.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image|np.array): Image to be adjusted.
         saturation_factor (float):  How much to adjust the saturation. 0 will
             give a black and white image, 1 will give the original image while
             2 will enhance the saturation by a factor of 2.
@@ -508,7 +478,7 @@ def adjust_hue(img, hue_factor):
     interval `[-0.5, 0.5]`.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image|np.array): Image to be adjusted.
         hue_factor (float):  How much to shift the hue channel. Should be in
             [-0.5, 0.5]. 0.5 and -0.5 give complete reversal of hue channel in
             HSV space in positive and negative direction respectively.
@@ -648,13 +618,13 @@ def normalize(img, mean, std, data_format='CHW', to_rgb=False):
         img (PIL.Image|np.array|paddle.Tensor): input data to be normalized.
         mean (list|tuple): Sequence of means for each channel.
         std (list|tuple): Sequence of standard deviations for each channel.
-        data_format (str, optional): Data format of img, should be 'HWC' or 
+        data_format (str, optional): Data format of input img, should be 'HWC' or 
             'CHW'. Default: 'CHW'.
         to_rgb (bool, optional): Whether to convert to rgb. If input is tensor, 
             this option will be igored. Default: False.
 
     Returns:
-        Tensor: Normalized mage.
+        Tensor: Normalized mage. Data format is same as input img.
     
     Examples:
         .. code-block:: python

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -173,18 +173,18 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
         size (int|list|tuple): Target size of input data, with (height, width) shape.
         interpolation (int|str, optional): Interpolation method. when use pil backend, 
             support method are as following: 
-                - 'nearest': Image.NEAREST, 
-                - 'bilinear': Image.BILINEAR, 
-                - 'bicubic': Image.BICUBIC, 
-                - 'box': Image.BOX, 
-                - 'lanczos': Image.LANCZOS, 
-                - 'hamming': Image.HAMMING
+            - 'nearest': Image.NEAREST, 
+            - 'bilinear': Image.BILINEAR, 
+            - 'bicubic': Image.BICUBIC, 
+            - 'box': Image.BOX, 
+            - 'lanczos': Image.LANCZOS, 
+            - 'hamming': Image.HAMMING
             when use cv2 backend, support method are as following: 
-                - 'nearest': cv2.INTER_NEAREST, 
-                - 'bilinear': cv2.INTER_LINEAR, 
-                - 'area': cv2.INTER_AREA, 
-                - 'bicubic': cv2.INTER_CUBIC, 
-                - 'lanczos': cv2.INTER_LANCZOS4
+            - 'nearest': cv2.INTER_NEAREST, 
+            - 'bilinear': cv2.INTER_LINEAR, 
+            - 'area': cv2.INTER_AREA, 
+            - 'bicubic': cv2.INTER_CUBIC, 
+            - 'lanczos': cv2.INTER_LANCZOS4
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
@@ -851,13 +851,13 @@ def rotate(img,
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend. when use pil backend, support method are as following: 
-                - 'nearest': Image.NEAREST, 
-                - 'bilinear': Image.BILINEAR, 
-                - 'bicubic': Image.BICUBIC
+            - 'nearest': Image.NEAREST, 
+            - 'bilinear': Image.BILINEAR, 
+            - 'bicubic': Image.BICUBIC
             when use cv2 backend, support method are as following: 
-                - 'nearest': cv2.INTER_NEAREST, 
-                - 'bilinear': cv2.INTER_LINEAR, 
-                - 'bicubic': cv2.INTER_CUBIC
+            - 'nearest': cv2.INTER_NEAREST, 
+            - 'bilinear': cv2.INTER_LINEAR, 
+            - 'bicubic': cv2.INTER_CUBIC
         expand (bool, optional): Optional expansion flag.
             If true, expands the output image to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -684,9 +684,17 @@ def rotate(img,
     Args:
         img (PIL.Image|np.array): Image to be rotated.
         angle (float or int): In degrees degrees counter clockwise order.
-        resample (``PIL.Image.NEAREST`` or ``PIL.Image.BILINEAR`` or ``PIL.Image.BICUBIC``, optional):
-            An optional resampling filter. See `filters`_ for more information.
-            If omitted, or if the image has mode "1" or "P", it is set to ``PIL.Image.NEAREST``.
+        resample (int|str, optional): An optional resampling filter. If omitted, or if the 
+            image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
+            according the backend.
+            when use pil backend, support method are as following:
+                'nearest': Image.NEAREST,
+                'bilinear': Image.BILINEAR,
+                'bicubic': Image.BICUBIC
+            when use cv2 backend, support method are as following:
+                'nearest': cv2.INTER_NEAREST,
+                'bilinear': cv2.INTER_LINEAR,
+                'bicubic': cv2.INTER_CUBIC
         expand (bool, optional): Optional expansion flag.
             If true, expands the output image to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.
@@ -785,15 +793,15 @@ def normalize(img, mean, std, data_format='CHW', to_rgb=False):
     """Normalizes a tensor or image with mean and standard deviation.
 
     Args:
-        tensor (Tensor): Tensor image of size (C, H, W) to be normalized.
-        mean (sequence): Sequence of means for each channel.
-        std (sequence): Sequence of standard deviations for each channel.
+        img (PIL.Image|np.array|paddle.Tensor): input data to be normalized.
+        mean (list|tuple): Sequence of means for each channel.
+        std (list|tuple): Sequence of standard deviations for each channel.
         to_rgb (bool, optional): Whether to convert to rgb. Default: False.
         backend (str, optional): The image resize backend type. Options are `pil`, 
                     `cv2`. Default: 'pil'. 
 
     Returns:
-        Tensor: Normalized Tensor image.
+        Tensor: Normalized mage.
     """
 
     if _is_tensor_image(img):

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -171,15 +171,14 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
     Args:
         input (PIL.Image|np.ndarray): Image to be resized.
         size (int|list|tuple): Target size of input data, with (height, width) shape.
-        interpolation (int|str, optional): Interpolation method. 
-            when use pil backend, support method are as following: 
+        interpolation (int|str, optional): Interpolation method. when use pil backend, 
+            support method are as following: 
                 - 'nearest': Image.NEAREST, 
                 - 'bilinear': Image.BILINEAR, 
                 - 'bicubic': Image.BICUBIC, 
                 - 'box': Image.BOX, 
                 - 'lanczos': Image.LANCZOS, 
                 - 'hamming': Image.HAMMING
-
             when use cv2 backend, support method are as following: 
                 - 'nearest': cv2.INTER_NEAREST, 
                 - 'bilinear': cv2.INTER_LINEAR, 
@@ -851,12 +850,10 @@ def rotate(img,
         angle (float or int): In degrees degrees counter clockwise order.
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
-            according the backend. 
-            when use pil backend, support method are as following: 
+            according the backend. when use pil backend, support method are as following: 
                 - 'nearest': Image.NEAREST, 
                 - 'bilinear': Image.BILINEAR, 
                 - 'bicubic': Image.BICUBIC
-
             when use cv2 backend, support method are as following: 
                 - 'nearest': cv2.INTER_NEAREST, 
                 - 'bilinear': cv2.INTER_LINEAR, 

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -88,6 +88,8 @@ def to_tensor(pic, data_format='CHW'):
 
     Args:
         pic (PIL.Image|np.ndarray): Image to be converted to tensor.
+        data_format (str, optional): Data format of img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
 
     Returns:
         Tensor: Converted image.
@@ -169,19 +171,20 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
     Args:
         input (PIL.Image|np.ndarray): Image to be resized.
         size (int|list|tuple): Target size of input data, with (height, width) shape.
-        interpolation (int|str, optional): Interpolation method.
-            when use pil backend, support method are as following:
-                'nearest': Image.NEAREST,
-                'bilinear': Image.BILINEAR,
-                'bicubic': Image.BICUBIC,
-                'box': Image.BOX,
-                'lanczos': Image.LANCZOS,
+        interpolation (int|str, optional): Interpolation method. 
+            when use pil backend, support method are as following: 
+                'nearest': Image.NEAREST, 
+                'bilinear': Image.BILINEAR, 
+                'bicubic': Image.BICUBIC, 
+                'box': Image.BOX, 
+                'lanczos': Image.LANCZOS, 
                 'hamming': Image.HAMMING
-            when use cv2 backend, support method are as following:
-                'nearest': cv2.INTER_NEAREST,
-                'bilinear': cv2.INTER_LINEAR,
-                'area': cv2.INTER_AREA,
-                'bicubic': cv2.INTER_CUBIC,
+                
+            when use cv2 backend, support method are as following: 
+                'nearest': cv2.INTER_NEAREST, 
+                'bilinear': cv2.INTER_LINEAR, 
+                'area': cv2.INTER_AREA, 
+                'bicubic': cv2.INTER_CUBIC, 
                 'lanczos': cv2.INTER_LANCZOS4
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -410,6 +413,7 @@ def pad(img, padding, fill=0, padding_mode='constant', backend='pil'):
 
 def crop(img, top, left, height, width, backend='pil'):
     """Crops the given PIL Image.
+
     Args:
         img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left 
             corner of the image.
@@ -419,6 +423,7 @@ def crop(img, top, left, height, width, backend='pil'):
         width (int): Width of the crop box.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
+
     Returns:
         PIL.Image or np.array: Cropped image.
 
@@ -464,8 +469,8 @@ def center_crop(img, output_size, backend='pil'):
             img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
             output_size (sequence or int): (height, width) of the crop box. If int,
                 it is used for both directions
-            backend (str, optional): The image resize backend type. Options are `pil`, 
-            `cv2`. Default: 'pil'. 
+            backend (str, optional): The image resize backend type. Options are `pil`, `cv2`. Default: 'pil'. 
+        
         Returns:
             PIL.Image or np.array: Cropped image.
 
@@ -510,6 +515,8 @@ def hflip(img, backend='pil'):
 
     Args:
         img (PIL.Image|np.array): Image to be flipped.
+        backend (str, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
 
     Returns:
         PIL.Image or np.array:  Horizontall flipped image.
@@ -527,6 +534,7 @@ def hflip(img, backend='pil'):
 
             flpped_img = F.hflip(fake_img)
             print(flpped_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -552,6 +560,7 @@ def vflip(img, backend='pil'):
         img (PIL.Image|np.array): Image to be flipped.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
+
     Returns:
         PIL.Image or np.array:  Vertically flipped image.
 
@@ -568,6 +577,7 @@ def vflip(img, backend='pil'):
 
             flpped_img = F.vflip(fake_img)
             print(flpped_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -841,14 +851,15 @@ def rotate(img,
         angle (float or int): In degrees degrees counter clockwise order.
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
-            according the backend.
-            when use pil backend, support method are as following:
-                'nearest': Image.NEAREST,
-                'bilinear': Image.BILINEAR,
+            according the backend. 
+            when use pil backend, support method are as following: 
+                'nearest': Image.NEAREST, 
+                'bilinear': Image.BILINEAR, 
                 'bicubic': Image.BICUBIC
-            when use cv2 backend, support method are as following:
-                'nearest': cv2.INTER_NEAREST,
-                'bilinear': cv2.INTER_LINEAR,
+
+            when use cv2 backend, support method are as following: 
+                'nearest': cv2.INTER_NEAREST, 
+                'bilinear': cv2.INTER_LINEAR, 
                 'bicubic': cv2.INTER_CUBIC
         expand (bool, optional): Optional expansion flag.
             If true, expands the output image to make it large enough to hold the entire rotated image.
@@ -980,6 +991,8 @@ def normalize(img, mean, std, data_format='CHW', to_rgb=False):
         img (PIL.Image|np.array|paddle.Tensor): input data to be normalized.
         mean (list|tuple): Sequence of means for each channel.
         std (list|tuple): Sequence of standard deviations for each channel.
+        data_format (str, optional): Data format of img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
         to_rgb (bool, optional): Whether to convert to rgb. Default: False.
         backend (str, optional): The image resize backend type. Options are `pil`, 
                     `cv2`. Default: 'pil'. 

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -91,6 +91,21 @@ def to_tensor(pic, data_format='CHW'):
 
     Returns:
         Tensor: Converted image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            tensor = F.to_tensor(fake_img)
+            print(tensor.shape)
+
     """
     if not (_is_pil_image(pic) or _is_numpy_image(pic)):
         raise TypeError('pic should be PIL Image or ndarray. Got {}'.format(
@@ -169,6 +184,9 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
+    Returns:
+        PIL.Image or np.array: Resized image.
+
     Examples:
         .. code-block:: python
 
@@ -176,13 +194,15 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
             from PIL import Image
             from paddle.vision.transforms import functional as F
 
-            fake_img = np.random.rand(256, 256, 3)
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
 
             fake_img = Image.fromarray(fake_img)
-            
-            F.resize(fake_img, 224)
 
-            F.resize(fake_img, (200, 150))
+            converted_img = F.resize(fake_img, 224)
+            print(converted_img.size)
+
+            converted_img = F.resize(fake_img, (200, 150))
+            print(converted_img.size)
     """
 
     if backend not in ['cv2', 'pil']:
@@ -283,6 +303,22 @@ def pad(img, padding, fill=0, padding_mode='constant', backend='pil'):
     Returns:
         PIL.Image or np.array: Padded image.
 
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            padded_img = F.pad(fake_img, padding=1)
+            print(padded_img.size)
+
+            padded_img = F.pad(fake_img, padding=(2, 1))
+            print(padded_img.size)
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -303,6 +339,8 @@ def pad(img, padding, fill=0, padding_mode='constant', backend='pil'):
     assert padding_mode in ['constant', 'edge', 'reflect', 'symmetric'], \
         'Padding mode should be either constant, edge, reflect or symmetric'
 
+    if isinstance(padding, list):
+        padding = tuple(padding)
     if isinstance(padding, int):
         pad_left = pad_right = pad_top = pad_bottom = padding
     if isinstance(padding, Sequence) and len(padding) == 2:
@@ -381,6 +419,21 @@ def crop(img, top, left, height, width, backend='pil'):
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array: Cropped image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            cropped_img = F.crop(fake_img, 56, 150, 200, 100)
+            print(cropped_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -413,6 +466,20 @@ def center_crop(img, output_size, backend='pil'):
             `cv2`. Default: 'pil'. 
         Returns:
             PIL.Image or np.array: Cropped image.
+
+        Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            cropped_img = F.center_crop(fake_img, (150, 100))
+            print(cropped_img.size)
         """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -444,6 +511,20 @@ def hflip(img, backend='pil'):
 
     Returns:
         PIL.Image or np.array:  Horizontall flipped image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            flpped_img = F.hflip(fake_img)
+            print(flpped_img.size)
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -471,6 +552,20 @@ def vflip(img, backend=None):
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array:  Vertically flipped image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            flpped_img = F.vflip(fake_img)
+            print(flpped_img.size)
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -503,6 +598,20 @@ def adjust_brightness(img, brightness_factor, backend='pil'):
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array: Brightness adjusted image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            converted_img = F.adjust_brightness(fake_img, 0.4)
+            print(converted_img.size)
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -540,6 +649,20 @@ def adjust_contrast(img, contrast_factor, backend='pil'):
             `cv2`. Default: 'pil'. 
     Returns:
         PIL.Image or np.array: Contrast adjusted image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            converted_img = F.adjust_contrast(fake_img, 0.4)
+            print(converted_img.size)
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -577,6 +700,21 @@ def adjust_saturation(img, saturation_factor, backend='pil'):
 
     Returns:
         PIL.Image or np.array: Saturation adjusted image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            converted_img = F.adjust_saturation(fake_img, 0.4)
+            print(converted_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -626,6 +764,21 @@ def adjust_hue(img, hue_factor, backend='pil'):
 
     Returns:
         PIL.Image or np.array: Hue adjusted image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            converted_img = F.adjust_hue(fake_img, 0.4)
+            print(converted_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -709,6 +862,21 @@ def rotate(img,
 
     Returns:
         PIL.Image or np.array: Rotated image.
+
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            rotated_img = F.rotate(fake_img, 90)
+            print(rotated_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -750,7 +918,21 @@ def to_grayscale(img, num_output_channels=1, backend='pil'):
             if num_output_channels = 1 : returned image is single channel
 
             if num_output_channels = 3 : returned image is 3 channel with r = g = b
-        
+    
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            gray_img = F.to_grayscale(fake_img)
+            print(gray_img.size)
+
     """
     if backend not in ['cv2', 'pil']:
         raise ValueError("Expected backend is 'cv2' or 'pil', \
@@ -802,6 +984,24 @@ def normalize(img, mean, std, data_format='CHW', to_rgb=False):
 
     Returns:
         Tensor: Normalized mage.
+    
+    Examples:
+        .. code-block:: python
+
+            import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import functional as F
+
+            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
+
+            fake_img = Image.fromarray(fake_img)
+
+            mean = [127.5, 127.5, 127.5]
+            std = [127.5, 127.5, 127.5]
+
+            normalized_img = F.normalize(fake_img, mean, std, data_format='HWC')
+            print(normalized_img.max(), normalized_img.min())
+
     """
 
     if _is_tensor_image(img):

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -173,18 +173,18 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
         size (int|list|tuple): Target size of input data, with (height, width) shape.
         interpolation (int|str, optional): Interpolation method. when use pil backend, 
             support method are as following: 
-            - 'nearest': Image.NEAREST, 
-            - 'bilinear': Image.BILINEAR, 
-            - 'bicubic': Image.BICUBIC, 
-            - 'box': Image.BOX, 
-            - 'lanczos': Image.LANCZOS, 
-            - 'hamming': Image.HAMMING
+            - "nearest": Image.NEAREST, 
+            - "bilinear": Image.BILINEAR, 
+            - "bicubic": Image.BICUBIC, 
+            - "box": Image.BOX, 
+            - "lanczos": Image.LANCZOS, 
+            - "hamming": Image.HAMMING
             when use cv2 backend, support method are as following: 
-            - 'nearest': cv2.INTER_NEAREST, 
-            - 'bilinear': cv2.INTER_LINEAR, 
-            - 'area': cv2.INTER_AREA, 
-            - 'bicubic': cv2.INTER_CUBIC, 
-            - 'lanczos': cv2.INTER_LANCZOS4
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "area": cv2.INTER_AREA, 
+            - "bicubic": cv2.INTER_CUBIC, 
+            - "lanczos": cv2.INTER_LANCZOS4
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
@@ -851,13 +851,13 @@ def rotate(img,
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend. when use pil backend, support method are as following: 
-            - 'nearest': Image.NEAREST, 
-            - 'bilinear': Image.BILINEAR, 
-            - 'bicubic': Image.BICUBIC
+            - "nearest": Image.NEAREST, 
+            - "bilinear": Image.BILINEAR, 
+            - "bicubic": Image.BICUBIC
             when use cv2 backend, support method are as following: 
-            - 'nearest': cv2.INTER_NEAREST, 
-            - 'bilinear': cv2.INTER_LINEAR, 
-            - 'bicubic': cv2.INTER_CUBIC
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "bicubic": cv2.INTER_CUBIC
         expand (bool, optional): Optional expansion flag.
             If true, expands the output image to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.

--- a/python/paddle/vision/transforms/functional.py
+++ b/python/paddle/vision/transforms/functional.py
@@ -186,8 +186,8 @@ def resize(img, size, interpolation='bilinear', backend='pil'):
     """
 
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if not (isinstance(size, int) or
             (isinstance(size, Iterable) and len(size) == 2)):
@@ -285,8 +285,8 @@ def pad(img, padding, fill=0, padding_mode='constant', backend='pil'):
 
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if not isinstance(padding, (numbers.Number, list, tuple)):
         raise TypeError('Got inappropriate padding arg')
@@ -383,8 +383,8 @@ def crop(img, top, left, height, width, backend='pil'):
         PIL.Image or np.array: Cropped image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -415,8 +415,8 @@ def center_crop(img, output_size, backend='pil'):
             PIL.Image or np.array: Cropped image.
         """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if isinstance(output_size, numbers.Number):
         output_size = (int(output_size), int(output_size))
@@ -446,8 +446,8 @@ def hflip(img, backend='pil'):
         PIL.Image or np.array:  Horizontall flipped image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -473,8 +473,8 @@ def vflip(img, backend=None):
         PIL.Image or np.array:  Vertically flipped image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -505,8 +505,8 @@ def adjust_brightness(img, brightness_factor, backend='pil'):
         PIL.Image or np.array: Brightness adjusted image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -542,8 +542,8 @@ def adjust_contrast(img, contrast_factor, backend='pil'):
         PIL.Image or np.array: Contrast adjusted image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -579,8 +579,8 @@ def adjust_saturation(img, saturation_factor, backend='pil'):
         PIL.Image or np.array: Saturation adjusted image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -628,8 +628,8 @@ def adjust_hue(img, hue_factor, backend='pil'):
         PIL.Image or np.array: Hue adjusted image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if not (-0.5 <= hue_factor <= 0.5):
         raise ValueError('hue_factor is not in [-0.5, 0.5].'.format(hue_factor))
@@ -711,8 +711,8 @@ def rotate(img,
         PIL.Image or np.array: Rotated image.
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):
@@ -753,8 +753,8 @@ def to_grayscale(img, num_output_channels=1, backend='pil'):
         
     """
     if backend not in ['cv2', 'pil']:
-        raise ValueError(f'backend: {backend} is not supported.'
-                         f"Supported backends are 'cv2', 'pil'")
+        raise ValueError("Expected backend is 'cv2' or 'pil', \
+                          but got {}".format(backend))
 
     if backend == 'pil':
         if not _is_pil_image(img):

--- a/python/paddle/vision/transforms/functional_cv2.py
+++ b/python/paddle/vision/transforms/functional_cv2.py
@@ -1,0 +1,504 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import sys
+import math
+from PIL import Image, ImageOps, ImageEnhance
+
+import numpy as np
+from numpy import sin, cos, tan
+import numbers
+import collections
+import warnings
+import paddle
+from paddle.utils import try_import
+
+if sys.version_info < (3, 3):
+    Sequence = collections.Sequence
+    Iterable = collections.Iterable
+else:
+    Sequence = collections.abc.Sequence
+    Iterable = collections.abc.Iterable
+
+
+def to_tensor(pic, data_format='CHW'):
+    """Converts a ``numpy.ndarray`` to paddle.Tensor.
+
+    See ``ToTensor`` for more details.
+
+    Args:
+        pic (np.ndarray): Image to be converted to tensor.
+        data_format (str, optional): Data format of img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
+
+    Returns:
+        Tensor: Converted image.
+
+    """
+
+    if not data_format in ['CHW', 'HWC']:
+        raise ValueError('data_format should be CHW or HWC. Got {}'.format(
+            data_format))
+
+    if pic.ndim == 2:
+        pic = pic[:, :, None]
+
+    if data_format == 'CHW':
+        img = paddle.to_tensor(pic.transpose((2, 0, 1)))
+    else:
+        img = paddle.to_tensor(pic)
+
+    if paddle.fluid.data_feeder.convert_dtype(img.dtype) == 'uint8':
+        return paddle.cast(img, np.float32) / 255.
+    else:
+        return img
+
+
+def resize(img, size, interpolation='bilinear'):
+    """
+    Resizes the image to given size
+
+    Args:
+        input (np.ndarray): Image to be resized.
+        size (int|list|tuple): Target size of input data, with (height, width) shape.
+        interpolation (int|str, optional): Interpolation method. when use cv2 backend, 
+            support method are as following: 
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "area": cv2.INTER_AREA, 
+            - "bicubic": cv2.INTER_CUBIC, 
+            - "lanczos": cv2.INTER_LANCZOS4
+
+    Returns:
+        np.array: Resized image.
+
+    """
+    cv2 = try_import('cv2')
+    _cv2_interp_from_str = {
+        'nearest': cv2.INTER_NEAREST,
+        'bilinear': cv2.INTER_LINEAR,
+        'area': cv2.INTER_AREA,
+        'bicubic': cv2.INTER_CUBIC,
+        'lanczos': cv2.INTER_LANCZOS4
+    }
+
+    if not (isinstance(size, int) or
+            (isinstance(size, Iterable) and len(size) == 2)):
+        raise TypeError('Got inappropriate size arg: {}'.format(size))
+
+    h, w = img.shape[:2]
+
+    if isinstance(size, int):
+        if (w <= h and w == size) or (h <= w and h == size):
+            return img
+        if w < h:
+            ow = size
+            oh = int(size * h / w)
+            output = cv2.resize(
+                img,
+                dsize=(ow, oh),
+                interpolation=_cv2_interp_from_str[interpolation])
+        else:
+            oh = size
+            ow = int(size * w / h)
+            output = cv2.resize(
+                img,
+                dsize=(ow, oh),
+                interpolation=_cv2_interp_from_str[interpolation])
+    else:
+        output = cv2.resize(
+            img,
+            dsize=(size[1], size[0]),
+            interpolation=_cv2_interp_from_str[interpolation])
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        return output[:, :, np.newaxis]
+    else:
+        return output
+
+
+def pad(img, padding, fill=0, padding_mode='constant'):
+    """
+    Pads the given numpy.array on all sides with specified padding mode and fill value.
+
+    Args:
+        img (np.array): Image to be padded.
+        padding (int|list|tuple): Padding on each border. If a single int is provided this
+            is used to pad all borders. If tuple of length 2 is provided this is the padding
+            on left/right and top/bottom respectively. If a tuple of length 4 is provided
+            this is the padding for the left, top, right and bottom borders
+            respectively.
+        fill (float, optional): Pixel fill value for constant fill. If a tuple of
+            length 3, it is used to fill R, G, B channels respectively.
+            This value is only used when the padding_mode is constant. Default: 0. 
+        padding_mode: Type of padding. Should be: constant, edge, reflect or symmetric. Default: 'constant'.
+
+            - constant: pads with a constant value, this value is specified with fill
+
+            - edge: pads with the last value on the edge of the image
+
+            - reflect: pads with reflection of image (without repeating the last value on the edge)
+
+                       padding [1, 2, 3, 4] with 2 elements on both sides in reflect mode
+                       will result in [3, 2, 1, 2, 3, 4, 3, 2]
+
+            - symmetric: pads with reflection of image (repeating the last value on the edge)
+
+                         padding [1, 2, 3, 4] with 2 elements on both sides in symmetric mode
+                         will result in [2, 1, 1, 2, 3, 4, 4, 3]
+
+    Returns:
+        np.array: Padded image.
+
+    """
+    cv2 = try_import('cv2')
+    _cv2_pad_from_str = {
+        'constant': cv2.BORDER_CONSTANT,
+        'edge': cv2.BORDER_REPLICATE,
+        'reflect': cv2.BORDER_REFLECT_101,
+        'symmetric': cv2.BORDER_REFLECT
+    }
+
+    if not isinstance(padding, (numbers.Number, list, tuple)):
+        raise TypeError('Got inappropriate padding arg')
+    if not isinstance(fill, (numbers.Number, str, list, tuple)):
+        raise TypeError('Got inappropriate fill arg')
+    if not isinstance(padding_mode, str):
+        raise TypeError('Got inappropriate padding_mode arg')
+
+    if isinstance(padding, Sequence) and len(padding) not in [2, 4]:
+        raise ValueError(
+            "Padding must be an int or a 2, or 4 element tuple, not a " +
+            "{} element tuple".format(len(padding)))
+
+    assert padding_mode in ['constant', 'edge', 'reflect', 'symmetric'], \
+        'Padding mode should be either constant, edge, reflect or symmetric'
+
+    if isinstance(padding, list):
+        padding = tuple(padding)
+    if isinstance(padding, int):
+        pad_left = pad_right = pad_top = pad_bottom = padding
+    if isinstance(padding, Sequence) and len(padding) == 2:
+        pad_left = pad_right = padding[0]
+        pad_top = pad_bottom = padding[1]
+    if isinstance(padding, Sequence) and len(padding) == 4:
+        pad_left = padding[0]
+        pad_top = padding[1]
+        pad_right = padding[2]
+        pad_bottom = padding[3]
+
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        return cv2.copyMakeBorder(
+            img,
+            top=pad_top,
+            bottom=pad_bottom,
+            left=pad_left,
+            right=pad_right,
+            borderType=_cv2_pad_from_str[padding_mode],
+            value=fill)[:, :, np.newaxis]
+    else:
+        return cv2.copyMakeBorder(
+            img,
+            top=pad_top,
+            bottom=pad_bottom,
+            left=pad_left,
+            right=pad_right,
+            borderType=_cv2_pad_from_str[padding_mode],
+            value=fill)
+
+
+def crop(img, top, left, height, width):
+    """Crops the given image.
+
+    Args:
+        img (np.array): Image to be cropped. (0,0) denotes the top left 
+            corner of the image.
+        top (int): Vertical component of the top left corner of the crop box.
+        left (int): Horizontal component of the top left corner of the crop box.
+        height (int): Height of the crop box.
+        width (int): Width of the crop box.
+
+    Returns:
+        np.array: Cropped image.
+
+    """
+
+    return img[top:top + height, left:left + width, :]
+
+
+def center_crop(img, output_size):
+    """Crops the given image and resize it to desired size.
+
+        Args:
+            img (np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
+            output_size (sequence or int): (height, width) of the crop box. If int,
+                it is used for both directions
+            backend (str, optional): The image proccess backend type. Options are `pil`, `cv2`. Default: 'pil'. 
+        
+        Returns:
+            np.array: Cropped image.
+
+        """
+
+    if isinstance(output_size, numbers.Number):
+        output_size = (int(output_size), int(output_size))
+
+    h, w = img.shape[0:2]
+    th, tw = output_size
+    i = int(round((h - th) / 2.))
+    j = int(round((w - tw) / 2.))
+    return crop(img, i, j, th, tw)
+
+
+def hflip(img):
+    """Horizontally flips the given image.
+
+    Args:
+        img (np.array): Image to be flipped.
+
+    Returns:
+        np.array:  Horizontall flipped image.
+
+    """
+    cv2 = try_import('cv2')
+
+    return cv2.flip(img, 1)
+
+
+def vflip(img):
+    """Vertically flips the given PIL Image or np.array.
+
+    Args:
+        img (PIL.Image|np.array): Image to be flipped.
+
+    Returns:
+        np.array:  Vertically flipped image.
+
+    """
+    cv2 = try_import('cv2')
+
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        return cv2.flip(img, 0)[:, :, np.newaxis]
+    else:
+        return cv2.flip(img, 0)
+
+
+def adjust_brightness(img, brightness_factor):
+    """Adjusts brightness of an image.
+
+    Args:
+        img (np.array): PIL Image to be adjusted.
+        brightness_factor (float):  How much to adjust the brightness. Can be
+            any non negative number. 0 gives a black image, 1 gives the
+            original image while 2 increases the brightness by a factor of 2.
+
+    Returns:
+        np.array: Brightness adjusted image.
+
+    """
+    cv2 = try_import('cv2')
+
+    table = np.array([i * brightness_factor
+                      for i in range(0, 256)]).clip(0, 255).astype('uint8')
+
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        return cv2.LUT(img, table)[:, :, np.newaxis]
+    else:
+        return cv2.LUT(img, table)
+
+
+def adjust_contrast(img, contrast_factor):
+    """Adjusts contrast of an image.
+
+    Args:
+        img (np.array): PIL Image to be adjusted.
+        contrast_factor (float): How much to adjust the contrast. Can be any
+            non negative number. 0 gives a solid gray image, 1 gives the
+            original image while 2 increases the contrast by a factor of 2.
+
+    Returns:
+        np.array: Contrast adjusted image.
+
+    """
+    cv2 = try_import('cv2')
+
+    table = np.array([(i - 74) * contrast_factor + 74
+                      for i in range(0, 256)]).clip(0, 255).astype('uint8')
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        return cv2.LUT(img, table)[:, :, np.newaxis]
+    else:
+        return cv2.LUT(img, table)
+
+
+def adjust_saturation(img, saturation_factor):
+    """Adjusts color saturation of an image.
+
+    Args:
+        img (np.array): PIL Image to be adjusted.
+        saturation_factor (float):  How much to adjust the saturation. 0 will
+            give a black and white image, 1 will give the original image while
+            2 will enhance the saturation by a factor of 2.
+
+    Returns:
+        np.array: Saturation adjusted image.
+
+    """
+    cv2 = try_import('cv2')
+
+    dtype = img.dtype
+    img = img.astype(np.float32)
+    alpha = np.random.uniform(
+        max(0, 1 - saturation_factor), 1 + saturation_factor)
+    gray_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    gray_img = gray_img[..., np.newaxis]
+    img = img * alpha + gray_img * (1 - alpha)
+    return img.clip(0, 255).astype(dtype)
+
+
+def adjust_hue(img, hue_factor):
+    """Adjusts hue of an image.
+
+    The image hue is adjusted by converting the image to HSV and
+    cyclically shifting the intensities in the hue channel (H).
+    The image is then converted back to original image mode.
+
+    `hue_factor` is the amount of shift in H channel and must be in the
+    interval `[-0.5, 0.5]`.
+
+    Args:
+        img (np.array): PIL Image to be adjusted.
+        hue_factor (float):  How much to shift the hue channel. Should be in
+            [-0.5, 0.5]. 0.5 and -0.5 give complete reversal of hue channel in
+            HSV space in positive and negative direction respectively.
+            0 means no shift. Therefore, both -0.5 and 0.5 will give an image
+            with complementary colors while 0 gives the original image.
+
+    Returns:
+        np.array: Hue adjusted image.
+
+    """
+    cv2 = try_import('cv2')
+
+    if not (-0.5 <= hue_factor <= 0.5):
+        raise ValueError('hue_factor is not in [-0.5, 0.5].'.format(hue_factor))
+
+    dtype = img.dtype
+    img = img.astype(np.uint8)
+    hsv_img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV_FULL)
+    h, s, v = cv2.split(hsv_img)
+
+    alpha = np.random.uniform(hue_factor, hue_factor)
+    h = h.astype(np.uint8)
+    # uint8 addition take cares of rotation across boundaries
+    with np.errstate(over="ignore"):
+        h += np.uint8(alpha * 255)
+    hsv_img = cv2.merge([h, s, v])
+    return cv2.cvtColor(hsv_img, cv2.COLOR_HSV2BGR_FULL).astype(dtype)
+
+
+def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
+    """Rotates the image by angle.
+
+    Args:
+        img (np.array): Image to be rotated.
+        angle (float or int): In degrees degrees counter clockwise order.
+        resample (int|str, optional): An optional resampling filter. If omitted, or if the 
+            image has only one channel, it is set to cv2.INTER_NEAREST.
+            when use cv2 backend, support method are as following: 
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "bicubic": cv2.INTER_CUBIC
+        expand (bool, optional): Optional expansion flag.
+            If true, expands the output image to make it large enough to hold the entire rotated image.
+            If false or omitted, make the output image the same size as the input image.
+            Note that the expand flag assumes rotation around the center and no translation.
+        center (2-tuple, optional): Optional center of rotation.
+            Origin is the upper left corner.
+            Default is the center of the image.
+        fill (3-tuple or int): RGB pixel fill value for area outside the rotated image.
+            If int, it is used for all channels respectively.
+
+    Returns:
+        np.array: Rotated image.
+
+    """
+    cv2 = try_import('cv2')
+
+    rows, cols = img.shape[0:2]
+    if center is None:
+        center = (cols / 2, rows / 2)
+    M = cv2.getRotationMatrix2D(center, angle, 1)
+    if len(img.shape) == 3 and img.shape[2] == 1:
+        return cv2.warpAffine(img, M, (cols, rows))[:, :, np.newaxis]
+    else:
+        return cv2.warpAffine(img, M, (cols, rows))
+
+
+def to_grayscale(img, num_output_channels=1):
+    """Converts image to grayscale version of image.
+
+    Args:
+        img (np.array): Image to be converted to grayscale.
+
+    Returns:
+        np.array: Grayscale version of the image.
+            if num_output_channels = 1 : returned image is single channel
+
+            if num_output_channels = 3 : returned image is 3 channel with r = g = b
+
+    """
+    cv2 = try_import('cv2')
+
+    if num_output_channels == 1:
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)[:, :, np.newaxis]
+    elif num_output_channels == 3:
+        # much faster than doing cvtColor to go back to gray
+        img = np.broadcast_to(
+            cv2.cvtColor(img, cv2.COLOR_RGB2GRAY)[:, :, np.newaxis], img.shape)
+    else:
+        raise ValueError('num_output_channels should be either 1 or 3')
+
+    return img
+
+
+def normalize(img, mean, std, data_format='CHW', to_rgb=False):
+    """Normalizes a ndarray imge or image with mean and standard deviation.
+
+    Args:
+        img (np.array): input data to be normalized.
+        mean (list|tuple): Sequence of means for each channel.
+        std (list|tuple): Sequence of standard deviations for each channel.
+        data_format (str, optional): Data format of img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
+        to_rgb (bool, optional): Whether to convert to rgb. Default: False.
+
+    Returns:
+        np.array: Normalized mage.
+
+    """
+
+    if data_format == 'CHW':
+        mean = np.float32(np.array(mean).reshape(-1, 1, 1))
+        std = np.float32(np.array(std).reshape(-1, 1, 1))
+    else:
+        mean = np.float32(np.array(mean).reshape(1, 1, -1))
+        std = np.float32(np.array(std).reshape(1, 1, -1))
+    if to_rgb:
+        cv2 = try_import('cv2')
+        # inplace
+        cv2.cvtColor(img, cv2.COLOR_BGR2RGB, img)
+
+    img = (img - mean) / std
+    return img

--- a/python/paddle/vision/transforms/functional_cv2.py
+++ b/python/paddle/vision/transforms/functional_cv2.py
@@ -15,14 +15,13 @@
 from __future__ import division
 
 import sys
-import math
-from PIL import Image, ImageOps, ImageEnhance
+import numbers
+import warnings
+import collections
 
 import numpy as np
 from numpy import sin, cos, tan
-import numbers
-import collections
-import warnings
+
 import paddle
 from paddle.utils import try_import
 
@@ -278,10 +277,10 @@ def hflip(img):
 
 
 def vflip(img):
-    """Vertically flips the given PIL Image or np.array.
+    """Vertically flips the given np.array.
 
     Args:
-        img (PIL.Image|np.array): Image to be flipped.
+        img (np.array): Image to be flipped.
 
     Returns:
         np.array:  Vertically flipped image.
@@ -299,7 +298,7 @@ def adjust_brightness(img, brightness_factor):
     """Adjusts brightness of an image.
 
     Args:
-        img (np.array): PIL Image to be adjusted.
+        img (np.array): Image to be adjusted.
         brightness_factor (float):  How much to adjust the brightness. Can be
             any non negative number. 0 gives a black image, 1 gives the
             original image while 2 increases the brightness by a factor of 2.
@@ -323,7 +322,7 @@ def adjust_contrast(img, contrast_factor):
     """Adjusts contrast of an image.
 
     Args:
-        img (np.array): PIL Image to be adjusted.
+        img (np.array): Image to be adjusted.
         contrast_factor (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives a solid gray image, 1 gives the
             original image while 2 increases the contrast by a factor of 2.
@@ -346,7 +345,7 @@ def adjust_saturation(img, saturation_factor):
     """Adjusts color saturation of an image.
 
     Args:
-        img (np.array): PIL Image to be adjusted.
+        img (np.array): Image to be adjusted.
         saturation_factor (float):  How much to adjust the saturation. 0 will
             give a black and white image, 1 will give the original image while
             2 will enhance the saturation by a factor of 2.
@@ -378,7 +377,7 @@ def adjust_hue(img, hue_factor):
     interval `[-0.5, 0.5]`.
 
     Args:
-        img (np.array): PIL Image to be adjusted.
+        img (np.array): Image to be adjusted.
         hue_factor (float):  How much to shift the hue channel. Should be in
             [-0.5, 0.5]. 0.5 and -0.5 give complete reversal of hue channel in
             HSV space in positive and negative direction respectively.

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -18,11 +18,6 @@ import sys
 import math
 from PIL import Image, ImageOps, ImageEnhance
 
-try:
-    import cv2
-except ImportError:
-    cv2 = None
-
 import numpy as np
 from numpy import sin, cos, tan
 import numbers
@@ -37,16 +32,6 @@ else:
     Sequence = collections.abc.Sequence
     Iterable = collections.abc.Iterable
 
-from . import functional_pil as F_pil
-from . import functional_cv2 as F_cv2
-from . import functional_tensor as F_t
-
-__all__ = [
-    'to_tensor', 'hflip', 'vflip', 'resize', 'pad', 'rotate', 'to_grayscale',
-    'crop', 'center_crop', 'adjust_brightness', 'adjust_contrast', 'adjust_hue',
-    'to_grayscale', 'normalize'
-]
-
 _pil_interp_from_str = {
     'nearest': Image.NEAREST,
     'bilinear': Image.BILINEAR,
@@ -56,43 +41,15 @@ _pil_interp_from_str = {
     'hamming': Image.HAMMING
 }
 
-if cv2 is not None:
-    _cv2_interp_from_str = {
-        'nearest': cv2.INTER_NEAREST,
-        'bilinear': cv2.INTER_LINEAR,
-        'area': cv2.INTER_AREA,
-        'bicubic': cv2.INTER_CUBIC,
-        'lanczos': cv2.INTER_LANCZOS4
-    }
-
-    _cv2_pad_from_str = {
-        'constant': cv2.BORDER_CONSTANT,
-        'edge': cv2.BORDER_REPLICATE,
-        'reflect': cv2.BORDER_REFLECT_101,
-        'symmetric': cv2.BORDER_REFLECT
-    }
-
-
-def _is_pil_image(img):
-    return isinstance(img, Image.Image)
-
-
-def _is_tensor_image(img):
-    return isinstance(img, paddle.Tensor)
-
-
-def _is_numpy_image(img):
-    return isinstance(img, np.ndarray) and (img.ndim in {2, 3})
-
 
 def to_tensor(pic, data_format='CHW'):
-    """Converts a ``PIL.Image`` or ``numpy.ndarray`` to paddle.Tensor.
+    """Converts a ``PIL.Image`` to paddle.Tensor.
 
     See ``ToTensor`` for more details.
 
     Args:
         pic (PIL.Image|np.ndarray): Image to be converted to tensor.
-        data_format (str, optional): Data format of input img, should be 'HWC' or 
+        data_format (str, optional): Data format of img, should be 'HWC' or 
             'CHW'. Default: 'CHW'.
 
     Returns:
@@ -113,14 +70,41 @@ def to_tensor(pic, data_format='CHW'):
             print(tensor.shape)
 
     """
-    if not (_is_pil_image(pic) or _is_numpy_image(pic)):
-        raise TypeError('pic should be PIL Image or ndarray. Got {}'.format(
-            type(pic)))
 
-    if _is_pil_image(pic):
-        return F_pil.to_tensor(pic, data_format)
+    if not data_format in ['CHW', 'HWC']:
+        raise ValueError('data_format should be CHW or HWC. Got {}'.format(
+            data_format))
+
+    # PIL Image
+    if pic.mode == 'I':
+        img = paddle.to_tensor(np.array(pic, np.int32, copy=False))
+    elif pic.mode == 'I;16':
+        # cast and reshape not support int16
+        img = paddle.to_tensor(np.array(pic, np.int32, copy=False))
+    elif pic.mode == 'F':
+        img = paddle.to_tensor(np.array(pic, np.float32, copy=False))
+    elif pic.mode == '1':
+        img = 255 * paddle.to_tensor(np.array(pic, np.uint8, copy=False))
     else:
-        return F_cv2.to_tensor(pic, data_format)
+        img = paddle.to_tensor(np.array(pic, copy=False))
+
+    if pic.mode == 'YCbCr':
+        nchannel = 3
+    elif pic.mode == 'I;16':
+        nchannel = 1
+    else:
+        nchannel = len(pic.mode)
+
+    dtype = paddle.fluid.data_feeder.convert_dtype(img.dtype)
+    if dtype == 'uint8':
+        img = paddle.cast(img, np.float32) / 255.
+
+    img = img.reshape([pic.size[1], pic.size[0], nchannel])
+
+    if data_format == 'CHW':
+        img = img.transpose([2, 0, 1])
+
+    return img
 
 
 def resize(img, size, interpolation='bilinear'):
@@ -138,15 +122,9 @@ def resize(img, size, interpolation='bilinear'):
             - "box": Image.BOX, 
             - "lanczos": Image.LANCZOS, 
             - "hamming": Image.HAMMING
-            when use cv2 backend, support method are as following: 
-            - "nearest": cv2.INTER_NEAREST, 
-            - "bilinear": cv2.INTER_LINEAR, 
-            - "area": cv2.INTER_AREA, 
-            - "bicubic": cv2.INTER_CUBIC, 
-            - "lanczos": cv2.INTER_LANCZOS4
 
     Returns:
-        PIL.Image or np.array: Resized image.
+        PIL.Image: Resized image.
 
     Examples:
         .. code-block:: python
@@ -165,20 +143,30 @@ def resize(img, size, interpolation='bilinear'):
             converted_img = F.resize(fake_img, (200, 150))
             print(converted_img.size)
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.resize(img, size, interpolation)
+    if not (isinstance(size, int) or
+            (isinstance(size, Iterable) and len(size) == 2)):
+        raise TypeError('Got inappropriate size arg: {}'.format(size))
+
+    if isinstance(size, int):
+        w, h = img.size
+        if (w <= h and w == size) or (h <= w and h == size):
+            return img
+        if w < h:
+            ow = size
+            oh = int(size * h / w)
+            return img.resize((ow, oh), _pil_interp_from_str[interpolation])
+        else:
+            oh = size
+            ow = int(size * w / h)
+            return img.resize((ow, oh), _pil_interp_from_str[interpolation])
     else:
-        return F_cv2.resize(img, size, interpolation)
+        return img.resize(size[::-1], _pil_interp_from_str[interpolation])
 
 
 def pad(img, padding, fill=0, padding_mode='constant'):
     """
-    Pads the given PIL.Image or numpy.array on all sides with specified padding mode and fill value.
+    Pads the given PIL.Image on all sides with specified padding mode and fill value.
 
     Args:
         img (PIL.Image|np.array): Image to be padded.
@@ -207,7 +195,7 @@ def pad(img, padding, fill=0, padding_mode='constant'):
                          will result in [2, 1, 1, 2, 3, 4, 4, 3]
 
     Returns:
-        PIL.Image or np.array: Padded image.
+        PIL.Image: Padded image.
 
     Examples:
         .. code-block:: python
@@ -226,22 +214,71 @@ def pad(img, padding, fill=0, padding_mode='constant'):
             padded_img = F.pad(fake_img, padding=(2, 1))
             print(padded_img.size)
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.pad(img, padding, fill, padding_mode)
+    if not isinstance(padding, (numbers.Number, list, tuple)):
+        raise TypeError('Got inappropriate padding arg')
+    if not isinstance(fill, (numbers.Number, str, list, tuple)):
+        raise TypeError('Got inappropriate fill arg')
+    if not isinstance(padding_mode, str):
+        raise TypeError('Got inappropriate padding_mode arg')
+
+    if isinstance(padding, Sequence) and len(padding) not in [2, 4]:
+        raise ValueError(
+            "Padding must be an int or a 2, or 4 element tuple, not a " +
+            "{} element tuple".format(len(padding)))
+
+    assert padding_mode in ['constant', 'edge', 'reflect', 'symmetric'], \
+        'Padding mode should be either constant, edge, reflect or symmetric'
+
+    if isinstance(padding, list):
+        padding = tuple(padding)
+    if isinstance(padding, int):
+        pad_left = pad_right = pad_top = pad_bottom = padding
+    if isinstance(padding, Sequence) and len(padding) == 2:
+        pad_left = pad_right = padding[0]
+        pad_top = pad_bottom = padding[1]
+    if isinstance(padding, Sequence) and len(padding) == 4:
+        pad_left = padding[0]
+        pad_top = padding[1]
+        pad_right = padding[2]
+        pad_bottom = padding[3]
+
+    if padding_mode == 'constant':
+        if img.mode == 'P':
+            palette = img.getpalette()
+            image = ImageOps.expand(img, border=padding, fill=fill)
+            image.putpalette(palette)
+            return image
+
+        return ImageOps.expand(img, border=padding, fill=fill)
     else:
-        return F_cv2.pad(img, padding, fill, padding_mode)
+        if img.mode == 'P':
+            palette = img.getpalette()
+            img = np.asarray(img)
+            img = np.pad(img, ((pad_top, pad_bottom), (pad_left, pad_right)),
+                         padding_mode)
+            img = Image.fromarray(img)
+            img.putpalette(palette)
+            return img
+
+        img = np.asarray(img)
+        # RGB image
+        if len(img.shape) == 3:
+            img = np.pad(img, ((pad_top, pad_bottom), (pad_left, pad_right),
+                               (0, 0)), padding_mode)
+        # Grayscale image
+        if len(img.shape) == 2:
+            img = np.pad(img, ((pad_top, pad_bottom), (pad_left, pad_right)),
+                         padding_mode)
+
+        return Image.fromarray(img)
 
 
 def crop(img, top, left, height, width):
     """Crops the given PIL Image.
 
     Args:
-        img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left 
+        img (PIL.Image): Image to be cropped. (0,0) denotes the top left 
             corner of the image.
         top (int): Vertical component of the top left corner of the crop box.
         left (int): Horizontal component of the top left corner of the crop box.
@@ -249,7 +286,7 @@ def crop(img, top, left, height, width):
         width (int): Width of the crop box.
 
     Returns:
-        PIL.Image or np.array: Cropped image.
+        PIL.Image: Cropped image.
 
     Examples:
         .. code-block:: python
@@ -266,27 +303,20 @@ def crop(img, top, left, height, width):
             print(cropped_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
-
-    if _is_pil_image(img):
-        return F_pil.crop(img, top, left, height, width)
-    else:
-        return F_cv2.crop(img, top, left, height, width)
+    return img.crop((left, top, left + width, top + height))
 
 
 def center_crop(img, output_size):
     """Crops the given PIL Image and resize it to desired size.
 
         Args:
-            img (PIL.Image|np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
+            img (np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
             output_size (sequence or int): (height, width) of the crop box. If int,
                 it is used for both directions
+            backend (str, optional): The image proccess backend type. Options are `pil`, `cv2`. Default: 'pil'. 
         
         Returns:
-            PIL.Image or np.array: Cropped image.
+            PIL.Image: Cropped image.
 
         Examples:
         .. code-block:: python
@@ -301,28 +331,27 @@ def center_crop(img, output_size):
 
             cropped_img = F.center_crop(fake_img, (150, 100))
             print(cropped_img.size)
+
         """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.center_crop(img, output_size)
-    else:
-        return F_cv2.center_crop(img, output_size)
+    if isinstance(output_size, numbers.Number):
+        output_size = (int(output_size), int(output_size))
+
+    image_width, image_height = img.size
+    crop_height, crop_width = output_size
+    crop_top = int(round((image_height - crop_height) / 2.))
+    crop_left = int(round((image_width - crop_width) / 2.))
+    return crop(img, crop_top, crop_left, crop_height, crop_width)
 
 
-def hflip(img, backend='pil'):
-    """Horizontally flips the given PIL Image or np.array.
+def hflip(img):
+    """Horizontally flips the given PIL Image.
 
     Args:
-        img (PIL.Image|np.array): Image to be flipped.
-        backend (str, optional): The image proccess backend type. Options are `pil`, 
-            `cv2`. Default: 'pil'. 
+        img (PIL.Image): Image to be flipped.
 
     Returns:
-        PIL.Image or np.array:  Horizontall flipped image.
+        PIL.Image:  Horizontall flipped image.
 
     Examples:
         .. code-block:: python
@@ -339,15 +368,8 @@ def hflip(img, backend='pil'):
             print(flpped_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.hflip(img)
-    else:
-        return F_cv2.hflip(img)
+    return img.transpose(Image.FLIP_LEFT_RIGHT)
 
 
 def vflip(img):
@@ -357,7 +379,7 @@ def vflip(img):
         img (PIL.Image|np.array): Image to be flipped.
 
     Returns:
-        PIL.Image or np.array:  Vertically flipped image.
+        PIL.Image:  Vertically flipped image.
 
     Examples:
         .. code-block:: python
@@ -374,22 +396,15 @@ def vflip(img):
             print(flpped_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.vflip(img)
-    else:
-        return F_cv2.vflip(img)
+    return img.transpose(Image.FLIP_TOP_BOTTOM)
 
 
 def adjust_brightness(img, brightness_factor):
     """Adjusts brightness of an Image.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image): PIL Image to be adjusted.
         brightness_factor (float):  How much to adjust the brightness. Can be
             any non negative number. 0 gives a black image, 1 gives the
             original image while 2 increases the brightness by a factor of 2.
@@ -410,16 +425,12 @@ def adjust_brightness(img, brightness_factor):
 
             converted_img = F.adjust_brightness(fake_img, 0.4)
             print(converted_img.size)
-    """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.adjust_brightness(img, brightness_factor)
-    else:
-        return F_cv2.adjust_brightness(img, brightness_factor)
+    """
+
+    enhancer = ImageEnhance.Brightness(img)
+    img = enhancer.enhance(brightness_factor)
+    return img
 
 
 def adjust_contrast(img, contrast_factor):
@@ -432,7 +443,7 @@ def adjust_contrast(img, contrast_factor):
             original image while 2 increases the contrast by a factor of 2.
 
     Returns:
-        PIL.Image or np.array: Contrast adjusted image.
+        PIL.Image: Contrast adjusted image.
 
     Examples:
         .. code-block:: python
@@ -447,16 +458,12 @@ def adjust_contrast(img, contrast_factor):
 
             converted_img = F.adjust_contrast(fake_img, 0.4)
             print(converted_img.size)
-    """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.adjust_contrast(img, contrast_factor)
-    else:
-        return F_cv2.adjust_contrast(img, contrast_factor)
+    """
+
+    enhancer = ImageEnhance.Contrast(img)
+    img = enhancer.enhance(contrast_factor)
+    return img
 
 
 def adjust_saturation(img, saturation_factor):
@@ -469,7 +476,7 @@ def adjust_saturation(img, saturation_factor):
             2 will enhance the saturation by a factor of 2.
 
     Returns:
-        PIL.Image or np.array: Saturation adjusted image.
+        PIL.Image: Saturation adjusted image.
 
     Examples:
         .. code-block:: python
@@ -486,15 +493,10 @@ def adjust_saturation(img, saturation_factor):
             print(converted_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.adjust_saturation(img, saturation_factor)
-    else:
-        return F_cv2.adjust_saturation(img, saturation_factor)
+    enhancer = ImageEnhance.Color(img)
+    img = enhancer.enhance(saturation_factor)
+    return img
 
 
 def adjust_hue(img, hue_factor):
@@ -516,7 +518,7 @@ def adjust_hue(img, hue_factor):
             with complementary colors while 0 gives the original image.
 
     Returns:
-        PIL.Image or np.array: Hue adjusted image.
+        PIL.Image: Hue adjusted image.
 
     Examples:
         .. code-block:: python
@@ -533,15 +535,23 @@ def adjust_hue(img, hue_factor):
             print(converted_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
+    if not (-0.5 <= hue_factor <= 0.5):
+        raise ValueError('hue_factor is not in [-0.5, 0.5].'.format(hue_factor))
 
-    if _is_pil_image(img):
-        return F_pil.adjust_hue(img, hue_factor)
-    else:
-        return F_cv2.adjust_hue(img, hue_factor)
+    input_mode = img.mode
+    if input_mode in {'L', '1', 'I', 'F'}:
+        return img
+
+    h, s, v = img.convert('HSV').split()
+
+    np_h = np.array(h, dtype=np.uint8)
+    # uint8 addition take cares of rotation across boundaries
+    with np.errstate(over='ignore'):
+        np_h += np.uint8(hue_factor * 255)
+    h = Image.fromarray(np_h, 'L')
+
+    img = Image.merge('HSV', (h, s, v)).convert(input_mode)
+    return img
 
 
 def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
@@ -549,18 +559,14 @@ def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
 
 
     Args:
-        img (PIL.Image|np.array): Image to be rotated.
+        img (PIL.Image): Image to be rotated.
         angle (float or int): In degrees degrees counter clockwise order.
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
-            image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
-            according the backend. when use pil backend, support method are as following: 
+            image has only one channel, it is set to PIL.Image.NEAREST . when use pil backend, 
+            support method are as following: 
             - "nearest": Image.NEAREST, 
             - "bilinear": Image.BILINEAR, 
             - "bicubic": Image.BICUBIC
-            when use cv2 backend, support method are as following: 
-            - "nearest": cv2.INTER_NEAREST, 
-            - "bilinear": cv2.INTER_LINEAR, 
-            - "bicubic": cv2.INTER_CUBIC
         expand (bool, optional): Optional expansion flag.
             If true, expands the output image to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.
@@ -571,9 +577,8 @@ def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
         fill (3-tuple or int): RGB pixel fill value for area outside the rotated image.
             If int, it is used for all channels respectively.
 
-
     Returns:
-        PIL.Image or np.array: Rotated image.
+        PIL.Image: Rotated image.
 
     Examples:
         .. code-block:: python
@@ -590,27 +595,23 @@ def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
             print(rotated_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.rotate(img, angle, resample, expand, center, fill)
-    else:
-        return F_cv2.rotate(img, angle, resample, expand, center, fill)
+    if isinstance(fill, int):
+        fill = tuple([fill] * 3)
+
+    return img.rotate(angle, resample, expand, center, fillcolor=fill)
 
 
 def to_grayscale(img, num_output_channels=1):
     """Converts image to grayscale version of image.
 
     Args:
-        img (PIL.Image|np.array): Image to be converted to grayscale.
+        img (PIL.Image): Image to be converted to grayscale.
         backend (str, optional): The image proccess backend type. Options are `pil`, 
                     `cv2`. Default: 'pil'. 
 
     Returns:
-        PIL.Image or np.array: Grayscale version of the image.
+        PIL.Image: Grayscale version of the image.
             if num_output_channels = 1 : returned image is single channel
 
             if num_output_channels = 3 : returned image is 3 channel with r = g = b
@@ -630,55 +631,15 @@ def to_grayscale(img, num_output_channels=1):
             print(gray_img.size)
 
     """
-    if not (_is_pil_image(img) or _is_numpy_image(img)):
-        raise TypeError(
-            'img should be PIL Image or ndarray with dim=[2 or 3]. Got {}'.
-            format(type(img)))
 
-    if _is_pil_image(img):
-        return F_pil.to_grayscale(img, num_output_channels)
+    if num_output_channels == 1:
+        img = img.convert('L')
+    elif num_output_channels == 3:
+        img = img.convert('L')
+        np_img = np.array(img, dtype=np.uint8)
+        np_img = np.dstack([np_img, np_img, np_img])
+        img = Image.fromarray(np_img, 'RGB')
     else:
-        return F_cv2.to_grayscale(img, num_output_channels)
+        raise ValueError('num_output_channels should be either 1 or 3')
 
-
-def normalize(img, mean, std, data_format='CHW', to_rgb=False):
-    """Normalizes a tensor or image with mean and standard deviation.
-
-    Args:
-        img (PIL.Image|np.array|paddle.Tensor): input data to be normalized.
-        mean (list|tuple): Sequence of means for each channel.
-        std (list|tuple): Sequence of standard deviations for each channel.
-        data_format (str, optional): Data format of img, should be 'HWC' or 
-            'CHW'. Default: 'CHW'.
-        to_rgb (bool, optional): Whether to convert to rgb. If input is tensor, 
-            this option will be igored. Default: False.
-
-    Returns:
-        Tensor: Normalized mage.
-    
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            mean = [127.5, 127.5, 127.5]
-            std = [127.5, 127.5, 127.5]
-
-            normalized_img = F.normalize(fake_img, mean, std, data_format='HWC')
-            print(normalized_img.max(), normalized_img.min())
-
-    """
-
-    if _is_tensor_image(img):
-        return F_t.normalize(img, mean, std, data_format)
-    else:
-        if _is_pil_image(img):
-            img = np.array(img).astype(np.float32)
-
-        return F_cv2.normalize(img, mean, std, data_format, to_rgb)
+    return img

--- a/python/paddle/vision/transforms/functional_pil.py
+++ b/python/paddle/vision/transforms/functional_pil.py
@@ -16,13 +16,13 @@ from __future__ import division
 
 import sys
 import math
+import numbers
+import warnings
+import collections
 from PIL import Image, ImageOps, ImageEnhance
 
 import numpy as np
 from numpy import sin, cos, tan
-import numbers
-import collections
-import warnings
 import paddle
 
 if sys.version_info < (3, 3):
@@ -48,26 +48,12 @@ def to_tensor(pic, data_format='CHW'):
     See ``ToTensor`` for more details.
 
     Args:
-        pic (PIL.Image|np.ndarray): Image to be converted to tensor.
+        pic (PIL.Image): Image to be converted to tensor.
         data_format (str, optional): Data format of img, should be 'HWC' or 
             'CHW'. Default: 'CHW'.
 
     Returns:
         Tensor: Converted image.
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            tensor = F.to_tensor(fake_img)
-            print(tensor.shape)
 
     """
 
@@ -112,7 +98,7 @@ def resize(img, size, interpolation='bilinear'):
     Resizes the image to given size
 
     Args:
-        input (PIL.Image|np.ndarray): Image to be resized.
+        input (PIL.Image): Image to be resized.
         size (int|list|tuple): Target size of input data, with (height, width) shape.
         interpolation (int|str, optional): Interpolation method. when use pil backend, 
             support method are as following: 
@@ -126,22 +112,6 @@ def resize(img, size, interpolation='bilinear'):
     Returns:
         PIL.Image: Resized image.
 
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            converted_img = F.resize(fake_img, 224)
-            print(converted_img.size)
-
-            converted_img = F.resize(fake_img, (200, 150))
-            print(converted_img.size)
     """
 
     if not (isinstance(size, int) or
@@ -169,7 +139,7 @@ def pad(img, padding, fill=0, padding_mode='constant'):
     Pads the given PIL.Image on all sides with specified padding mode and fill value.
 
     Args:
-        img (PIL.Image|np.array): Image to be padded.
+        img (PIL.Image): Image to be padded.
         padding (int|list|tuple): Padding on each border. If a single int is provided this
             is used to pad all borders. If tuple of length 2 is provided this is the padding
             on left/right and top/bottom respectively. If a tuple of length 4 is provided
@@ -197,22 +167,6 @@ def pad(img, padding, fill=0, padding_mode='constant'):
     Returns:
         PIL.Image: Padded image.
 
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            padded_img = F.pad(fake_img, padding=1)
-            print(padded_img.size)
-
-            padded_img = F.pad(fake_img, padding=(2, 1))
-            print(padded_img.size)
     """
 
     if not isinstance(padding, (numbers.Number, list, tuple)):
@@ -288,20 +242,6 @@ def crop(img, top, left, height, width):
     Returns:
         PIL.Image: Cropped image.
 
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            cropped_img = F.crop(fake_img, 56, 150, 200, 100)
-            print(cropped_img.size)
-
     """
     return img.crop((left, top, left + width, top + height))
 
@@ -310,27 +250,13 @@ def center_crop(img, output_size):
     """Crops the given PIL Image and resize it to desired size.
 
         Args:
-            img (np.array): Image to be cropped. (0,0) denotes the top left corner of the image.
+            img (PIL.Image): Image to be cropped. (0,0) denotes the top left corner of the image.
             output_size (sequence or int): (height, width) of the crop box. If int,
                 it is used for both directions
             backend (str, optional): The image proccess backend type. Options are `pil`, `cv2`. Default: 'pil'. 
         
         Returns:
             PIL.Image: Cropped image.
-
-        Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            cropped_img = F.center_crop(fake_img, (150, 100))
-            print(cropped_img.size)
 
         """
 
@@ -353,47 +279,19 @@ def hflip(img):
     Returns:
         PIL.Image:  Horizontall flipped image.
 
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            flpped_img = F.hflip(fake_img)
-            print(flpped_img.size)
-
     """
 
     return img.transpose(Image.FLIP_LEFT_RIGHT)
 
 
 def vflip(img):
-    """Vertically flips the given PIL Image or np.array.
+    """Vertically flips the given PIL Image.
 
     Args:
-        img (PIL.Image|np.array): Image to be flipped.
+        img (PIL.Image): Image to be flipped.
 
     Returns:
         PIL.Image:  Vertically flipped image.
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            flpped_img = F.vflip(fake_img)
-            print(flpped_img.size)
 
     """
 
@@ -410,21 +308,7 @@ def adjust_brightness(img, brightness_factor):
             original image while 2 increases the brightness by a factor of 2.
 
     Returns:
-        PIL.Image or np.array: Brightness adjusted image.
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            converted_img = F.adjust_brightness(fake_img, 0.4)
-            print(converted_img.size)
+        PIL.Image: Brightness adjusted image.
 
     """
 
@@ -437,27 +321,13 @@ def adjust_contrast(img, contrast_factor):
     """Adjusts contrast of an Image.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image): PIL Image to be adjusted.
         contrast_factor (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives a solid gray image, 1 gives the
             original image while 2 increases the contrast by a factor of 2.
 
     Returns:
         PIL.Image: Contrast adjusted image.
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            converted_img = F.adjust_contrast(fake_img, 0.4)
-            print(converted_img.size)
 
     """
 
@@ -470,27 +340,13 @@ def adjust_saturation(img, saturation_factor):
     """Adjusts color saturation of an image.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image): PIL Image to be adjusted.
         saturation_factor (float):  How much to adjust the saturation. 0 will
             give a black and white image, 1 will give the original image while
             2 will enhance the saturation by a factor of 2.
 
     Returns:
         PIL.Image: Saturation adjusted image.
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            converted_img = F.adjust_saturation(fake_img, 0.4)
-            print(converted_img.size)
 
     """
 
@@ -510,7 +366,7 @@ def adjust_hue(img, hue_factor):
     interval `[-0.5, 0.5]`.
 
     Args:
-        img (PIL.Image|np.array): PIL Image to be adjusted.
+        img (PIL.Image): PIL Image to be adjusted.
         hue_factor (float):  How much to shift the hue channel. Should be in
             [-0.5, 0.5]. 0.5 and -0.5 give complete reversal of hue channel in
             HSV space in positive and negative direction respectively.
@@ -519,20 +375,6 @@ def adjust_hue(img, hue_factor):
 
     Returns:
         PIL.Image: Hue adjusted image.
-
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            converted_img = F.adjust_hue(fake_img, 0.4)
-            print(converted_img.size)
 
     """
     if not (-0.5 <= hue_factor <= 0.5):
@@ -557,7 +399,6 @@ def adjust_hue(img, hue_factor):
 def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
     """Rotates the image by angle.
 
-
     Args:
         img (PIL.Image): Image to be rotated.
         angle (float or int): In degrees degrees counter clockwise order.
@@ -580,20 +421,6 @@ def rotate(img, angle, resample=False, expand=False, center=None, fill=0):
     Returns:
         PIL.Image: Rotated image.
 
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            rotated_img = F.rotate(fake_img, 90)
-            print(rotated_img.size)
-
     """
 
     if isinstance(fill, int):
@@ -615,20 +442,6 @@ def to_grayscale(img, num_output_channels=1):
             if num_output_channels = 1 : returned image is single channel
 
             if num_output_channels = 3 : returned image is 3 channel with r = g = b
-    
-    Examples:
-        .. code-block:: python
-
-            import numpy as np
-            from PIL import Image
-            from paddle.vision.transforms import functional as F
-
-            fake_img = (np.random.rand(256, 300, 3) * 255.).astype('uint8')
-
-            fake_img = Image.fromarray(fake_img)
-
-            gray_img = F.to_grayscale(fake_img)
-            print(gray_img.size)
 
     """
 

--- a/python/paddle/vision/transforms/functional_tensor.py
+++ b/python/paddle/vision/transforms/functional_tensor.py
@@ -18,7 +18,7 @@ import paddle
 
 
 def normalize(img, mean, std, data_format='CHW'):
-    """Normalizes a tensor or image with mean and standard deviation.
+    """Normalizes a tensor image with mean and standard deviation.
 
     Args:
         img (paddle.Tensor): input data to be normalized.

--- a/python/paddle/vision/transforms/functional_tensor.py
+++ b/python/paddle/vision/transforms/functional_tensor.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import paddle
+
+
+def normalize(img, mean, std, data_format='CHW'):
+    """Normalizes a tensor or image with mean and standard deviation.
+
+    Args:
+        img (paddle.Tensor): input data to be normalized.
+        mean (list|tuple): Sequence of means for each channel.
+        std (list|tuple): Sequence of standard deviations for each channel.
+        data_format (str, optional): Data format of img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
+
+    Returns:
+        Tensor: Normalized mage.
+
+    """
+    if data_format == 'CHW':
+        mean = paddle.to_tensor(mean).reshape([-1, 1, 1])
+        std = paddle.to_tensor(std).reshape([-1, 1, 1])
+    else:
+        mean = paddle.to_tensor(mean)
+        std = paddle.to_tensor(std)
+    return (img - mean) / std

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -165,7 +165,7 @@ class BaseTransform(object):
             
             You can also customize your data types only if you implement the corresponding
             _apply_*() methods, otherwise ``NotImplementedError`` will be raised.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     
     Examples:
@@ -370,7 +370,7 @@ class Resize(BaseTransform):
             - "bicubic": cv2.INTER_CUBIC, 
             - "lanczos": cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Examples:
@@ -426,7 +426,7 @@ class RandomResizedCrop(BaseTransform):
             - "bicubic": cv2.INTER_CUBIC, 
             - "lanczos": cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Examples:
@@ -511,7 +511,7 @@ class CenterCrop(BaseTransform):
     Args:
         size (int|list|tuple): Target size of output image, with (height, width) shape.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -546,7 +546,7 @@ class RandomHorizontalFlip(BaseTransform):
     Args:
         prob (float, optional): Probability of the input data being flipped. Default: 0.5
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -580,7 +580,7 @@ class RandomVerticalFlip(BaseTransform):
     Args:
         prob (float, optional): Probability of the input data being flipped. Default: 0.5
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Examples:
@@ -623,7 +623,7 @@ class Normalize(BaseTransform):
             'CHW'. Default: 'CHW'.
         to_rgb (bool, optional): Whether to convert to rgb. Default: False.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
         
     Examples:
@@ -715,7 +715,7 @@ class BrightnessTransform(BaseTransform):
         value (float): How much to adjust the brightness. Can be any
             non negative number. 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -752,7 +752,7 @@ class ContrastTransform(BaseTransform):
         value (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -791,7 +791,7 @@ class SaturationTransform(BaseTransform):
         value (float): How much to adjust the saturation. Can be any
             non negative number. 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -828,7 +828,7 @@ class HueTransform(BaseTransform):
         value (float): How much to adjust the hue. Can be any number
             between 0 and 0.5, 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -872,7 +872,7 @@ class ColorJitter(BaseTransform):
         hue: How much to jitter hue.
             Chosen uniformly from [-hue, hue]. Should have 0<= hue <= 0.5.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -960,7 +960,7 @@ class RandomCrop(BaseTransform):
         pad_if_needed (boolean|optional): It will pad the image if smaller than the
             desired size to avoid raising an exception. Default: False.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -1065,7 +1065,7 @@ class Pad(BaseTransform):
             padding ``[1, 2, 3, 4]`` with 2 elements on both sides in symmetric mode 
             will result in ``[2, 1, 1, 2, 3, 4, 4, 3]``.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -1146,7 +1146,7 @@ class RandomRotation(BaseTransform):
             Origin is the upper left corner.
             Default is the center of the image.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -1215,7 +1215,7 @@ class Grayscale(BaseTransform):
     Args:
         num_output_channels (int): (1 or 3) number of channels desired for output image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (str, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image proccess backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Returns:
         CV Image: Grayscale version of the input.

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -113,15 +113,13 @@ class Compose(object):
 
     def __call__(self, data):
         for f in self.transforms:
-            # try:
-            data = f(data)
-            if data is None:
-                print('deubgggggggg:', f)
-            # except Exception as e:
-            #     stack_info = traceback.format_exc()
-            #     print("fail to perform transform [{}] with error: "
-            #           "{} and stack:\n{}".format(f, e, str(stack_info)))
-            #     raise e
+            try:
+                data = f(data)
+            except Exception as e:
+                stack_info = traceback.format_exc()
+                print("fail to perform transform [{}] with error: "
+                      "{} and stack:\n{}".format(f, e, str(stack_info)))
+                raise e
         return data
 
     def __repr__(self):

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -202,14 +202,14 @@ class BaseTransform(object):
                         return F.hflip(image, self.backend)
                     return image
 
-                # if you only want transform image, do not need to rewrite this function
+                # if you only want to transform image, do not need to rewrite this function
                 def _apply_coords(self, coords):
                     if self.params['flip']:
                         w = self.params['size'][0]
                         coords[:, 0] = w - coords[:, 0]
                     return coords
 
-                # if you only want transform image, do not need to rewrite this function
+                # if you only want to transform image, do not need to rewrite this function
                 def _apply_boxes(self, boxes):
                     idxs = np.array([(0, 1), (2, 1), (0, 3), (2, 3)]).flatten()
                     coords = np.asarray(boxes).reshape(-1, 4)[:, idxs].reshape(-1, 2)
@@ -219,7 +219,7 @@ class BaseTransform(object):
                     trans_boxes = np.concatenate((minxy, maxxy), axis=1)
                     return trans_boxes
                     
-                # if you only want transform image, do not need to rewrite this function
+                # if you only want to transform image, do not need to rewrite this function
                 def _apply_mask(self, mask):
                     if self.params['flip']:
                         return F.hflip(mask, self.backend)
@@ -357,18 +357,18 @@ class Resize(BaseTransform):
             (size * height / width, size)
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. 
             when use pil backend, support method are as following: 
-            - 'nearest': Image.NEAREST, 
-            - 'bilinear': Image.BILINEAR, 
-            - 'bicubic': Image.BICUBIC, 
-            - 'box': Image.BOX, 
-            - 'lanczos': Image.LANCZOS, 
-            - 'hamming': Image.HAMMING
+            - "nearest": Image.NEAREST, 
+            - "bilinear": Image.BILINEAR, 
+            - "bicubic": Image.BICUBIC, 
+            - "box": Image.BOX, 
+            - "lanczos": Image.LANCZOS, 
+            - "hamming": Image.HAMMING
             when use cv2 backend, support method are as following: 
-            - 'nearest': cv2.INTER_NEAREST, 
-            - 'bilinear': cv2.INTER_LINEAR, 
-            - 'area': cv2.INTER_AREA, 
-            - 'bicubic': cv2.INTER_CUBIC, 
-            - 'lanczos': cv2.INTER_LANCZOS4
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "area": cv2.INTER_AREA, 
+            - "bicubic": cv2.INTER_CUBIC, 
+            - "lanczos": cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -413,18 +413,18 @@ class RandomResizedCrop(BaseTransform):
         ratio (list|tuple): Range of aspect ratio of the origin aspect ratio cropped. Default: (0.75, 1.33)
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. when use pil backend, 
             support method are as following: 
-            - 'nearest': Image.NEAREST, 
-            - 'bilinear': Image.BILINEAR, 
-            - 'bicubic': Image.BICUBIC, 
-            - 'box': Image.BOX, 
-            - 'lanczos': Image.LANCZOS, 
-            - 'hamming': Image.HAMMING
+            - "nearest": Image.NEAREST, 
+            - "bilinear": Image.BILINEAR, 
+            - "bicubic": Image.BICUBIC, 
+            - "box": Image.BOX, 
+            - "lanczos": Image.LANCZOS, 
+            - "hamming": Image.HAMMING
             when use cv2 backend, support method are as following: 
-            - 'nearest': cv2.INTER_NEAREST, 
-            - 'bilinear': cv2.INTER_LINEAR, 
-            - 'area': cv2.INTER_AREA, 
-            - 'bicubic': cv2.INTER_CUBIC, 
-            - 'lanczos': cv2.INTER_LANCZOS4
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "area": cv2.INTER_AREA, 
+            - "bicubic": cv2.INTER_CUBIC, 
+            - "lanczos": cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -1131,13 +1131,13 @@ class RandomRotation(BaseTransform):
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend. when use pil backend, support method are as following: 
-            - 'nearest': Image.NEAREST, 
-            - 'bilinear': Image.BILINEAR, 
-            - 'bicubic': Image.BICUBIC
+            - "nearest": Image.NEAREST, 
+            - "bilinear": Image.BILINEAR, 
+            - "bicubic": Image.BICUBIC
             when use cv2 backend, support method are as following: 
-            - 'nearest': cv2.INTER_NEAREST, 
-            - 'bilinear': cv2.INTER_LINEAR, 
-            - 'bicubic': cv2.INTER_CUBIC
+            - "nearest": cv2.INTER_NEAREST, 
+            - "bilinear": cv2.INTER_LINEAR, 
+            - "bicubic": cv2.INTER_CUBIC
         expand (bool|optional): Optional expansion flag. Default: False.
             If true, expands the output to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -154,12 +154,14 @@ class BaseTransform(object):
 
             Current available strings & data type are describe below:
 
-            * "image": input image, with shape of (H, W, C)
-            * "coords": coordinates, with shape of (N, 2)
-            * "boxes": bounding boxes, with shape of (N, 4), "xyxy" format, 
-                the 1st "xy" represents top left point of a box, 
-                the 2nd "xy" represents right bottom point.
-            * "mask": map used for segmentation, with shape of (H, W, 1)
+            - "image": input image, with shape of (H, W, C) 
+            - "coords": coordinates, with shape of (N, 2) 
+            - "boxes": bounding boxes, with shape of (N, 4), "xyxy" format, 
+            
+                       the 1st "xy" represents top left point of a box, 
+                       the 2nd "xy" represents right bottom point.
+
+            - "mask": map used for segmentation, with shape of (H, W, 1)
             
             You can also customize your data types only if you implement the corresponding
             _apply_*() methods, otherwise ``NotImplementedError`` will be raised.
@@ -355,19 +357,19 @@ class Resize(BaseTransform):
             (size * height / width, size)
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. 
             when use pil backend, support method are as following: 
-                'nearest': Image.NEAREST, 
-                'bilinear': Image.BILINEAR, 
-                'bicubic': Image.BICUBIC, 
-                'box': Image.BOX, 
-                'lanczos': Image.LANCZOS, 
-                'hamming': Image.HAMMING 
-                
+                - 'nearest': Image.NEAREST, 
+                - 'bilinear': Image.BILINEAR, 
+                - 'bicubic': Image.BICUBIC, 
+                - 'box': Image.BOX, 
+                - 'lanczos': Image.LANCZOS, 
+                - 'hamming': Image.HAMMING
+
             when use cv2 backend, support method are as following: 
-                'nearest': cv2.INTER_NEAREST, 
-                'bilinear': cv2.INTER_LINEAR, 
-                'area': cv2.INTER_AREA, 
-                'bicubic': cv2.INTER_CUBIC, 
-                'lanczos': cv2.INTER_LANCZOS4
+                - 'nearest': cv2.INTER_NEAREST, 
+                - 'bilinear': cv2.INTER_LINEAR, 
+                - 'area': cv2.INTER_AREA, 
+                - 'bicubic': cv2.INTER_CUBIC, 
+                - 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -411,19 +413,20 @@ class RandomResizedCrop(BaseTransform):
         scale (list|tuple): Range of size of the origin size cropped. Default: (0.08, 1.0)
         ratio (list|tuple): Range of aspect ratio of the origin aspect ratio cropped. Default: (0.75, 1.33)
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
-            when use pil backend, support method are as following:
-                'nearest': Image.NEAREST,
-                'bilinear': Image.BILINEAR,
-                'bicubic': Image.BICUBIC,
-                'box': Image.BOX,
-                'lanczos': Image.LANCZOS,
-                'hamming': Image.HAMMING
-            when use cv2 backend, support method are as following:
-                'nearest': cv2.INTER_NEAREST,
-                'bilinear': cv2.INTER_LINEAR,
-                'area': cv2.INTER_AREA,
-                'bicubic': cv2.INTER_CUBIC,
-                'lanczos': cv2.INTER_LANCZOS4
+            when use pil backend, support method are as following: 
+                - 'nearest': Image.NEAREST, 
+                - 'bilinear': Image.BILINEAR, 
+                - 'bicubic': Image.BICUBIC, 
+                - 'box': Image.BOX, 
+                - 'lanczos': Image.LANCZOS, 
+                - 'hamming': Image.HAMMING
+
+            when use cv2 backend, support method are as following: 
+                - 'nearest': cv2.INTER_NEAREST, 
+                - 'bilinear': cv2.INTER_LINEAR, 
+                - 'area': cv2.INTER_AREA, 
+                - 'bicubic': cv2.INTER_CUBIC, 
+                - 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -1131,14 +1134,14 @@ class RandomRotation(BaseTransform):
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend.
             when use pil backend, support method are as following: 
-                'nearest': Image.NEAREST, 
-                'bilinear': Image.BILINEAR, 
-                'bicubic': Image.BICUBIC
+                - 'nearest': Image.NEAREST, 
+                - 'bilinear': Image.BILINEAR, 
+                - 'bicubic': Image.BICUBIC
 
             when use cv2 backend, support method are as following: 
-                'nearest': cv2.INTER_NEAREST, 
-                'bilinear': cv2.INTER_LINEAR, 
-                'bicubic': cv2.INTER_CUBIC
+                - 'nearest': cv2.INTER_NEAREST, 
+                - 'bilinear': cv2.INTER_LINEAR, 
+                - 'bicubic': cv2.INTER_CUBIC
         expand (bool|optional): Optional expansion flag. Default: False.
             If true, expands the output to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -321,7 +321,7 @@ class ToTensor(BaseTransform):
     """
 
     def __init__(self, data_format='CHW', keys=None):
-        super().__init__(keys)
+        super(ToTensor, self).__init__(keys)
         self.data_format = data_format
 
     def _apply_image(self, img):
@@ -380,7 +380,7 @@ class Resize(BaseTransform):
 
     def __init__(self, size, interpolation='bilinear', keys=None,
                  backend='pil'):
-        super().__init__(keys, backend)
+        super(Resize, self).__init__(keys, backend)
         assert isinstance(size, int) or (isinstance(size, Iterable) and
                                          len(size) == 2)
         self.size = size
@@ -442,7 +442,7 @@ class RandomResizedCrop(BaseTransform):
                  interpolation='bilinear',
                  keys=None,
                  backend='pil'):
-        super().__init__(keys, backend)
+        super(RandomResizedCrop, self).__init__(keys, backend)
         if isinstance(size, int):
             self.size = (size, size)
         else:
@@ -519,7 +519,7 @@ class CenterCrop(BaseTransform):
     """
 
     def __init__(self, size, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(CenterCrop, self).__init__(keys, backend)
         if isinstance(size, numbers.Number):
             self.size = (int(size), int(size))
         else:
@@ -554,7 +554,7 @@ class RandomHorizontalFlip(BaseTransform):
     """
 
     def __init__(self, prob=0.5, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(RandomHorizontalFlip, self).__init__(keys, backend)
         self.prob = prob
 
     def _apply_image(self, img):
@@ -589,7 +589,7 @@ class RandomVerticalFlip(BaseTransform):
     """
 
     def __init__(self, prob=0.5, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(RandomVerticalFlip, self).__init__(keys, backend)
         self.prob = prob
 
     def _apply_image(self, img):
@@ -637,7 +637,7 @@ class Normalize(BaseTransform):
                  to_rgb=False,
                  keys=None,
                  backend='pil'):
-        super().__init__(keys, backend)
+        super(Normalize, self).__init__(keys, backend)
         if isinstance(mean, numbers.Number):
             mean = [mean, mean, mean]
 
@@ -682,7 +682,7 @@ class Transpose(BaseTransform):
     """
 
     def __init__(self, order=(2, 0, 1), keys=None):
-        super().__init__(keys)
+        super(Transpose, self).__init__(keys)
         self.order = order
 
     def _apply_image(self, img):
@@ -718,7 +718,7 @@ class BrightnessTransform(BaseTransform):
     """
 
     def __init__(self, value, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(BrightnessTransform, self).__init__(keys, backend)
         self.value = _check_input(value, 'brightness')
 
     def _apply_image(self, img):
@@ -755,7 +755,7 @@ class ContrastTransform(BaseTransform):
     """
 
     def __init__(self, value, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(ContrastTransform, self).__init__(keys, backend)
         if value < 0:
             raise ValueError("contrast value should be non-negative")
         self.value = _check_input(value, 'contrast')
@@ -794,7 +794,7 @@ class SaturationTransform(BaseTransform):
     """
 
     def __init__(self, value, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(SaturationTransform, self).__init__(keys, backend)
         self.value = _check_input(value, 'saturation')
 
     def _apply_image(self, img):
@@ -831,7 +831,7 @@ class HueTransform(BaseTransform):
     """
 
     def __init__(self, value, keys=None, backend='pil'):
-        super().__init__(keys, backend)
+        super(HueTransform, self).__init__(keys, backend)
         self.value = _check_input(
             value, 'hue', center=0, bound=(-0.5, 0.5), clip_first_on_zero=False)
 
@@ -881,7 +881,7 @@ class ColorJitter(BaseTransform):
                  hue=0,
                  keys=None,
                  backend='pil'):
-        super().__init__(keys, backend)
+        super(ColorJitter, self).__init__(keys, backend)
         self.brightness = brightness
         self.contrast = contrast
         self.saturation = saturation
@@ -970,7 +970,7 @@ class RandomCrop(BaseTransform):
                  padding_mode='constant',
                  keys=None,
                  backend='pil'):
-        super().__init__(keys, backend)
+        super(RandomCrop, self).__init__(keys, backend)
         if isinstance(size, numbers.Number):
             self.size = (int(size), int(size))
         else:
@@ -1087,7 +1087,7 @@ class Pad(BaseTransform):
                 "Padding must be an int or a 2, or 4 element tuple, not a " +
                 "{} element tuple".format(len(padding)))
 
-        super().__init__(keys, backend)
+        super(Pad, self).__init__(keys, backend)
         self.padding = padding
         self.fill = fill
         self.padding_mode = padding_mode
@@ -1139,9 +1139,9 @@ class RandomRotation(BaseTransform):
 
             import numpy as np
             from PIL import Image
-            from paddle.vision.transforms import RandomRotate
+            from paddle.vision.transforms import RandomRotation
 
-            transform = RandomRotate(90)
+            transform = RandomRotation(90)
 
             fake_img = Image.fromarray((np.random.rand(200, 150, 3) * 255.).astype(np.uint8))
 
@@ -1168,7 +1168,7 @@ class RandomRotation(BaseTransform):
                     "If degrees is a sequence, it must be of len 2.")
             self.degrees = degrees
 
-        super().__init__(keys, backend)
+        super(RandomRotation, self).__init__(keys, backend)
         self.resample = resample
         self.expand = expand
         self.center = center
@@ -1224,7 +1224,7 @@ class Grayscale(BaseTransform):
     """
 
     def __init__(self, num_output_channels=1, keys=None, backend=None):
-        super().__init__(keys, backend)
+        super(Grayscale, self).__init__(keys, backend)
         self.num_output_channels = num_output_channels
 
     def _apply_image(self, img):

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -36,28 +36,48 @@ else:
     Iterable = collections.abc.Iterable
 
 __all__ = [
-    "Compose",
-    "BatchCompose",
-    "Resize",
-    "RandomResizedCrop",
-    "CenterCropResize",
-    "CenterCrop",
-    "RandomHorizontalFlip",
-    "RandomVerticalFlip",
-    "Permute",
-    "Normalize",
-    "GaussianNoise",
-    "BrightnessTransform",
-    "SaturationTransform",
-    "ContrastTransform",
-    "HueTransform",
-    "ColorJitter",
-    "RandomCrop",
-    "RandomErasing",
-    "Pad",
-    "RandomRotate",
-    "Grayscale",
+    "BaseTransform", "Compose", "Resize", "RandomResizedCrop", "CenterCrop",
+    "RandomHorizontalFlip", "RandomVerticalFlip", "Transpose", "Normalize",
+    "BrightnessTransform", "SaturationTransform", "ContrastTransform",
+    "HueTransform", "ColorJitter", "RandomCrop", "Pad", "RandomRotation",
+    "Grayscale", "ToTensor"
 ]
+
+
+def _get_image_size(img):
+    if F._is_pil_image(img):
+        return img.size
+    elif F._is_numpy_image(img):
+        return img.shape[:2][::-1]
+    else:
+        raise TypeError("Unexpected type {}".format(type(img)))
+
+
+def _check_input(value,
+                 name,
+                 center=1,
+                 bound=(0, float('inf')),
+                 clip_first_on_zero=True):
+    if isinstance(value, numbers.Number):
+        if value < 0:
+            raise ValueError(
+                "If {} is a single number, it must be non negative.".format(
+                    name))
+        value = [center - value, center + value]
+        if clip_first_on_zero:
+            value[0] = max(value[0], 0)
+    elif isinstance(value, (tuple, list)) and len(value) == 2:
+        if not bound[0] <= value[0] <= value[1] <= bound[1]:
+            raise ValueError("{} values should be between {}".format(name,
+                                                                     bound))
+    else:
+        raise TypeError(
+            "{} should be a single number or a list/tuple with lenght 2.".
+            format(name))
+
+    if value[0] == value[1] == center:
+        value = None
+    return value
 
 
 class Compose(object):
@@ -91,15 +111,10 @@ class Compose(object):
     def __init__(self, transforms):
         self.transforms = transforms
 
-    def __call__(self, *data):
+    def __call__(self, data):
         for f in self.transforms:
             try:
-                # multi-fileds in a sample
-                if isinstance(data, Sequence):
-                    data = f(*data)
-                # single field in a sample, call transform directly
-                else:
-                    data = f(data)
+                data = f(data)
             except Exception as e:
                 stack_info = traceback.format_exc()
                 print("fail to perform transform [{}] with error: "
@@ -116,96 +131,207 @@ class Compose(object):
         return format_string
 
 
-class BatchCompose(object):
-    """Composes several batch transforms together
+class BaseTransform():
+    """
+    Base class of all transforms used in computer vision.
+    calling logic: 
+        if keys is None:
+            get_params -> _apply_image()
+        else:
+            get_params -> _apply_*() for * in keys 
+
+    If you want to implement a self-defined transform method for image,
+    rewrite _apply_* method in subclass.
 
     Args:
-        transforms (list): List of transforms to compose.
-                           these transforms perform on batch data.
+        keys (list[str]|tuple[str], optional): Input type. Input is a tuple contains different structures,
+            key is used to specify the type of input. For example, if your input
+            is image type, then the key can be None or ("image"). if your input
+            is (image, image) type, then the keys should be ("image", "image"). 
+            if your input is (image, boxes), then the keys should be ("image", "boxes").
 
+            Current available strings & data type are describe below:
+
+            * "image": input image, with shape of (H, W, C)
+            * "coords": coordinates, with shape of (N, 2)
+            * "boxes": bounding boxes, with shape of (N, 4), "xyxy" format,
+            the 1st "xy" represents top left point of a box,
+            the 2nd "xy" represents right bottom point.
+            * "mask": map used for segmentation, with shape of (H, W, 1)
+            
+            You can also customize your data types only if you implement the corresponding
+            _apply_*() methods, otherwise ``NotImplementedError`` will be raised.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
+    
+    Examples:
+    
+        .. code-block:: python
+
+            from PIL import image
+            import paddle.vision.functional as F
+            from paddle.vision.transforms import BaseTransform
+
+            def _get_image_size(img):
+                if F._is_pil_image(img):
+                    return img.size
+                elif F._is_numpy_image(img):
+                    return img.shape[:2][::-1]
+                else:
+                    raise TypeError("Unexpected type {}".format(type(img)))
+            
+            class CustomRandomFlip(BaseTransform):
+                def __init__(prob=0.5, backend='pil', keys=None):
+                    super().__init(keys, backend)
+
+                def get_params(self, inputs):
+                    image = self.keys.index('image')
+                    params = {}
+                    params['flip'] = np.random.random() < self.prob
+                    params['size'] = _get_image_size(image)
+                    return params
+
+                def _apply_image(image):
+                    if self.params['flip']:
+                        return F.hflip(image)
+                    return image
+
+                # if you only want transform image, do not need to rewrite this function
+                def _apply_coords(coords):
+                    if self.params['flip']:
+                        coords[:, 0] = self._w - coords[:, 0]
+                    return coords
+
+                # if you only want transform image, do not need to rewrite this function
+                def _apply_mask(mask):
+                    if self.params['flip']:
+                        return F.hflip(mask)
+                    return mask
+                    
+            # create fake inputs
+            fake_img = Image.from(np.random().rand() * 255.)
+            fake_boxes = np.array([[2, 3, 200, 300], [50, 60, 80, 100]])
+            fake_mask = Image.from()
+
+            # only transform for image:
+            flip_transform = CustomRandomFlip(1.0)
+            converted_img = flip_transform(fake_img)
+
+            # transform for image, boxes and mask
+            flip_transform = CustomRandomFlip(1.0, keys=('image', 'boxes', 'mask'))
+            (converted_img, converted_boxes, converted_mask) = transform((fake_img, fake_boxes, fake_mask))
+
+    """
+
+    def __init__(self, keys=None, backend='pil'):
+        if keys is None:
+            keys = ("image", )
+        elif not isinstance(keys, collections.abc.Sequence):
+            raise ValueError(
+                "keys should be a sequence, but got keys={}".format(keys))
+        for k in keys:
+            if self._get_apply(k) is None:
+                raise NotImplementedError(
+                    "{} is unsupported data structure".format(k))
+        self.keys = keys
+        self.backend = backend
+        # storage some params get from function get_params()
+        self.params = None
+
+    def _get_params(self, inputs):
+        pass
+
+    def __call__(self, inputs):
+        """Apply transform on single input data"""
+        if not isinstance(inputs, tuple):
+            inputs = (inputs, )
+
+        self.params = self._get_params(inputs)
+
+        outputs = []
+        for i in range(min(len(inputs), len(self.keys))):
+            apply_func = self._get_apply(self.keys[i])
+            if apply_func is None:
+                outputs.append(inputs[i])
+            else:
+                outputs.append(apply_func(inputs[i]))
+        if len(inputs) > len(self.keys):
+            outputs.extend(input[len(self.keys):])
+
+        if len(outputs) == 1:
+            outputs = outputs[0]
+        else:
+            outputs = tuple(outputs)
+        return outputs
+
+    def _get_apply(self, key):
+        return getattr(self, "_apply_{}".format(key), None)
+
+    def _apply_image(self, image):
+        raise NotImplementedError
+
+    def _apply_boxes(self, boxes):
+        idxs = np.array([(0, 1), (2, 1), (0, 3), (2, 3)]).flatten()
+        coords = np.asarray(boxes).reshape(-1, 4)[:, idxs].reshape(-1, 2)
+        coords = self._apply_coords(coords).reshape((-1, 4, 2))
+        minxy = coords.min(axis=1)
+        maxxy = coords.max(axis=1)
+        trans_boxes = np.concatenate((minxy, maxxy), axis=1)
+        return trans_boxes
+
+    def _apply_mask(self, mask):
+        raise NotImplementedError
+
+
+class ToTensor(BaseTransform):
+    """Convert a ``PIL.Image`` or ``numpy.ndarray`` to ``paddle.Tensor``.
+
+    Converts a PIL.Image or numpy.ndarray (H x W x C) in the range
+    [0, 255] to a paddle.Tensor of shape (C x H x W) in the range [0.0, 1.0]
+    if the PIL Image belongs to one of the modes (L, LA, P, I, F, RGB, YCbCr, RGBA, CMYK, 1)
+    or if the numpy.ndarray has dtype = np.uint8
+
+    In the other cases, tensors are returned without scaling.
+    Args:
+        size (int|list|tuple): Desired output size. If size is a sequence like
+            (h, w), output size will be matched to this. If size is an int,
+            smaller edge of the image will be matched to this number.
+            i.e, if height > width, then image will be rescaled to
+            (size * height / width, size)
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-            from paddle.io import DataLoader
+            from PIL import Image
+            import paddle.vision.functional as F
+            from paddle.vision.transforms import T
 
-            from paddle import set_device
-            from paddle.vision.datasets import Flowers
-            from paddle.vision.transforms import Compose, BatchCompose, Resize
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
-            class NormalizeBatch(object):
-                def __init__(self,
-                            mean=[0.485, 0.456, 0.406],
-                            std=[0.229, 0.224, 0.225],
-                            scale=True,
-                            channel_first=True):
+            transform = T.ToTensor()
 
-                    self.mean = mean
-                    self.std = std
-                    self.scale = scale
-                    self.channel_first = channel_first
-                    if not (isinstance(self.mean, list) and isinstance(self.std, list) and
-                            isinstance(self.scale, bool)):
-                        raise TypeError("{}: input type is invalid.".format(self))
-                    from functools import reduce
-                    if reduce(lambda x, y: x * y, self.std) == 0:
-                        raise ValueError('{}: std is invalid!'.format(self))
-
-                def __call__(self, samples):
-                    for i in range(len(samples)):
-                        samples[i] = list(samples[i])
-                        im = samples[i][0]
-                        im = im.astype(np.float32, copy=False)
-                        mean = np.array(self.mean)[np.newaxis, np.newaxis, :]
-                        std = np.array(self.std)[np.newaxis, np.newaxis, :]
-                        if self.scale:
-                            im = im / 255.0
-                        im -= mean
-                        im /= std
-                        if self.channel_first:
-                            im = im.transpose((2, 0, 1))
-                        samples[i][0] = im
-                    return samples
-
-            transform = Compose([Resize((500, 500))])
-            flowers_dataset = Flowers(mode='test', transform=transform)
-
-            device = set_device('cpu')
-
-            collate_fn = BatchCompose([NormalizeBatch()])
-            loader = DataLoader(
-                        flowers_dataset,
-                        batch_size=4,
-                        places=device,
-                        return_list=True,
-                        collate_fn=collate_fn)
-
-            for data in loader:
-                # do something
-                break
+            tensor = transform(fake_img)
     """
 
-    def __init__(self, transforms=[]):
-        self.transforms = transforms
+    def __init__(self, data_format='CHW', keys=None):
+        super().__init__(keys)
+        self.data_format = data_format
 
-    def __call__(self, data):
-        for f in self.transforms:
-            try:
-                data = f(data)
-            except Exception as e:
-                stack_info = traceback.format_exc()
-                print("fail to perform batch transform [{}] with error: "
-                      "{} and stack:\n{}".format(f, e, str(stack_info)))
-                raise e
+    def _apply_image(self, img):
+        """
+        Args:
+            img (PIL.Image|np.ndarray): Image to be converted to tensor.
 
-        # sample list to batch data
-        batch = list(zip(*data))
-
-        return batch
+        Returns:
+            Tensor: Converted image.
+        """
+        return F.to_tensor(img, self.data_format)
 
 
-class Resize(object):
+class Resize(BaseTransform):
     """Resize the input Image to the given size.
 
     Args:
@@ -214,97 +340,117 @@ class Resize(object):
             smaller edge of the image will be matched to this number.
             i.e, if height > width, then image will be rescaled to
             (size * height / width, size)
-        interpolation (int, optional): Interpolation mode of resize. Default: 1.
-            0 : cv2.INTER_NEAREST 
-            1 : cv2.INTER_LINEAR 
-            2 : cv2.INTER_CUBIC 
-            3 : cv2.INTER_AREA 
-            4 : cv2.INTER_LANCZOS4 
-            5 : cv2.INTER_LINEAR_EXACT
-            7 : cv2.INTER_MAX 
-            8 : cv2.WARP_FILL_OUTLIERS 
-            16: cv2.WARP_INVERSE_MAP 
+        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
+            when use pil backend, support method are as following:
+                'nearest': Image.NEAREST,
+                'bilinear': Image.BILINEAR,
+                'bicubic': Image.BICUBIC,
+                'box': Image.BOX,
+                'lanczos': Image.LANCZOS,
+                'hamming': Image.HAMMING
+            when use cv2 backend, support method are as following:
+                'nearest': cv2.INTER_NEAREST,
+                'bilinear': cv2.INTER_LINEAR,
+                'area': cv2.INTER_AREA,
+                'bicubic': cv2.INTER_CUBIC,
+                'lanczos': cv2.INTER_LANCZOS4
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import Resize
 
             transform = Resize(size=224)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(100, 120, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, size, interpolation=1):
+    def __init__(self, size, interpolation='bilinear', keys=None,
+                 backend='pil'):
+        super().__init__(keys, backend)
         assert isinstance(size, int) or (isinstance(size, Iterable) and
                                          len(size) == 2)
         self.size = size
         self.interpolation = interpolation
 
-    def __call__(self, img):
-        return F.resize(img, self.size, self.interpolation)
+    def _apply_image(self, img):
+        return F.resize(img, self.size, self.interpolation, self.backend)
 
 
-class RandomResizedCrop(object):
+class RandomResizedCrop(BaseTransform):
     """Crop the input data to random size and aspect ratio.
     A crop of random size (default: of 0.08 to 1.0) of the original size and a random
     aspect ratio (default: of 3/4 to 1.33) of the original aspect ratio is made.
     After applying crop transfrom, the input data will be resized to given size.
 
     Args:
-        output_size (int|list|tuple): Target size of output image, with (height, width) shape.
+        size (int|list|tuple): Target size of output image, with (height, width) shape.
         scale (list|tuple): Range of size of the origin size cropped. Default: (0.08, 1.0)
         ratio (list|tuple): Range of aspect ratio of the origin aspect ratio cropped. Default: (0.75, 1.33)
-        interpolation (int, optional): Interpolation mode of resize. Default: 1.
-            0 : cv2.INTER_NEAREST 
-            1 : cv2.INTER_LINEAR 
-            2 : cv2.INTER_CUBIC 
-            3 : cv2.INTER_AREA 
-            4 : cv2.INTER_LANCZOS4 
-            5 : cv2.INTER_LINEAR_EXACT
-            7 : cv2.INTER_MAX 
-            8 : cv2.WARP_FILL_OUTLIERS 
-            16: cv2.WARP_INVERSE_MAP 
+        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
+            when use pil backend, support method are as following:
+                'nearest': Image.NEAREST,
+                'bilinear': Image.BILINEAR,
+                'bicubic': Image.BICUBIC,
+                'box': Image.BOX,
+                'lanczos': Image.LANCZOS,
+                'hamming': Image.HAMMING
+            when use cv2 backend, support method are as following:
+                'nearest': cv2.INTER_NEAREST,
+                'bilinear': cv2.INTER_LINEAR,
+                'area': cv2.INTER_AREA,
+                'bicubic': cv2.INTER_CUBIC,
+                'lanczos': cv2.INTER_LANCZOS4
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import RandomResizedCrop
 
             transform = RandomResizedCrop(224)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(300, 320, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
+
     """
 
     def __init__(self,
-                 output_size,
+                 size,
                  scale=(0.08, 1.0),
                  ratio=(3. / 4, 4. / 3),
-                 interpolation=1):
-        if isinstance(output_size, int):
-            self.output_size = (output_size, output_size)
+                 interpolation='bilinear',
+                 keys=None,
+                 backend='pil'):
+        super().__init__(keys, backend)
+        if isinstance(size, int):
+            self.size = (size, size)
         else:
-            self.output_size = output_size
+            self.size = size
         assert (scale[0] <= scale[1]), "scale should be of kind (min, max)"
         assert (ratio[0] <= ratio[1]), "ratio should be of kind (min, max)"
         self.scale = scale
         self.ratio = ratio
         self.interpolation = interpolation
 
-    def _get_params(self, image, attempts=10):
-        height, width, _ = image.shape
+    def get_params(self, image, attempts=10):
+        width, height = _get_image_size(image)
         area = height * width
 
         for _ in range(attempts):
@@ -316,9 +462,9 @@ class RandomResizedCrop(object):
             h = int(round(math.sqrt(target_area / aspect_ratio)))
 
             if 0 < w <= width and 0 < h <= height:
-                x = np.random.randint(0, width - w + 1)
-                y = np.random.randint(0, height - h + 1)
-                return x, y, w, h
+                i = random.randint(0, height - h)
+                j = random.randint(0, width - w)
+                return i, j, h, w
 
         # Fallback to central crop
         in_ratio = float(width) / float(height)
@@ -328,179 +474,127 @@ class RandomResizedCrop(object):
         elif in_ratio > max(self.ratio):
             h = height
             w = int(round(h * max(self.ratio)))
-        else:  # whole image
+        else:
+            # return whole image
             w = width
             h = height
-        x = (width - w) // 2
-        y = (height - h) // 2
-        return x, y, w, h
+        i = (height - h) // 2
+        j = (width - w) // 2
+        return i, j, h, w
 
-    def __call__(self, img):
-        x, y, w, h = self._get_params(img)
-        cropped_img = img[y:y + h, x:x + w]
-        return F.resize(cropped_img, self.output_size, self.interpolation)
+    def _apply_image(self, img):
+        i, j, h, w = self.get_params(img)
 
-
-class CenterCropResize(object):
-    """Crops to center of image with padding then scales size.
-
-    Args:
-        size (int|list|tuple): Target size of output image, with (height, width) shape.
-        crop_padding (int): Center crop with the padding. Default: 32.
-        interpolation (int, optional): Interpolation mode of resize. Default: 1.
-            0 : cv2.INTER_NEAREST 
-            1 : cv2.INTER_LINEAR 
-            2 : cv2.INTER_CUBIC 
-            3 : cv2.INTER_AREA 
-            4 : cv2.INTER_LANCZOS4 
-            5 : cv2.INTER_LINEAR_EXACT
-            7 : cv2.INTER_MAX 
-            8 : cv2.WARP_FILL_OUTLIERS 
-            16: cv2.WARP_INVERSE_MAP 
-
-    Examples:
-    
-        .. code-block:: python
-
-            import numpy as np
-
-            from paddle.vision.transforms import CenterCropResize
-
-            transform = CenterCropResize(224)
-
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
-
-            fake_img = transform(fake_img)
-            print(fake_img.shape)
-    """
-
-    def __init__(self, size, crop_padding=32, interpolation=1):
-        if isinstance(size, int):
-            self.size = (size, size)
-        else:
-            self.size = size
-        self.crop_padding = crop_padding
-        self.interpolation = interpolation
-
-    def _get_params(self, img):
-        h, w = img.shape[:2]
-        size = min(self.size)
-        c = int(size / (size + self.crop_padding) * min((h, w)))
-        x = (h + 1 - c) // 2
-        y = (w + 1 - c) // 2
-        return c, x, y
-
-    def __call__(self, img):
-        c, x, y = self._get_params(img)
-        cropped_img = img[x:x + c, y:y + c, :]
-        return F.resize(cropped_img, self.size, self.interpolation)
+        cropped_img = F.crop(img, i, j, h, w, self.backend)
+        return F.resize(cropped_img, self.size, self.interpolation,
+                        self.backend)
 
 
-class CenterCrop(object):
+class CenterCrop(BaseTransform):
     """Crops the given the input data at the center.
 
     Args:
-        output_size: Target size of output image, with (height, width) shape.
-    
+        size (int|list|tuple): Target size of output image, with (height, width) shape.
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import CenterCrop
 
             transform = CenterCrop(224)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(300, 320, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, output_size):
-        if isinstance(output_size, int):
-            self.output_size = (output_size, output_size)
+    def __init__(self, size, keys=None, backend='pil'):
+        super().__init__(keys, backend)
+        if isinstance(size, numbers.Number):
+            self.size = (int(size), int(size))
         else:
-            self.output_size = output_size
+            self.size = size
 
-    def _get_params(self, img):
-        th, tw = self.output_size
-        h, w, _ = img.shape
-        assert th <= h and tw <= w, "output size is bigger than image size"
-        x = int(round((w - tw) / 2.0))
-        y = int(round((h - th) / 2.0))
-        return x, y
-
-    def __call__(self, img):
-        x, y = self._get_params(img)
-        th, tw = self.output_size
-        return img[y:y + th, x:x + tw]
+    def _apply_image(self, img):
+        return F.center_crop(img, self.size, self.backend)
 
 
-class RandomHorizontalFlip(object):
+class RandomHorizontalFlip(BaseTransform):
     """Horizontally flip the input data randomly with a given probability.
 
     Args:
-        prob (float): Probability of the input data being flipped. Default: 0.5
-
+        prob (float, optional): Probability of the input data being flipped. Default: 0.5
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import RandomHorizontalFlip
 
             transform = RandomHorizontalFlip(224)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(300, 320, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, prob=0.5):
+    def __init__(self, prob=0.5, keys=None, backend='pil'):
+        super().__init__(keys, backend)
         self.prob = prob
 
-    def __call__(self, img):
-        if np.random.random() < self.prob:
-            return F.flip(img, code=1)
+    def _apply_image(self, img):
+        if random.random() < self.prob:
+            return F.hflip(img, self.backend)
         return img
 
 
-class RandomVerticalFlip(object):
+class RandomVerticalFlip(BaseTransform):
     """Vertically flip the input data randomly with a given probability.
 
     Args:
-        prob (float): Probability of the input data being flipped. Default: 0.5
+        prob (float, optional): Probability of the input data being flipped. Default: 0.5
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
-            from paddle.vision.transforms import RandomVerticalFlip
+            from PIL import Image
+            from paddle.vision.transforms import RandomHorizontalFlip
 
             transform = RandomVerticalFlip(224)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(300, 320, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, prob=0.5):
+    def __init__(self, prob=0.5, keys=None, backend='pil'):
+        super().__init__(keys, backend)
         self.prob = prob
 
-    def __call__(self, img):
-        if np.random.random() < self.prob:
-            return F.flip(img, code=0)
+    def _apply_image(self, img):
+        if random.random() < self.prob:
+            return F.vflip(img, self.backend)
         return img
 
 
-class Normalize(object):
+class Normalize(BaseTransform):
     """Normalize the input data with mean and standard deviation.
     Given mean: ``(M1,...,Mn)`` and std: ``(S1,..,Sn)`` for ``n`` channels,
     this transform will normalize each channel of the input data.
@@ -509,286 +603,243 @@ class Normalize(object):
     Args:
         mean (int|float|list): Sequence of means for each channel.
         std (int|float|list): Sequence of standard deviations for each channel.
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
+        
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import Normalize
 
             normalize = Normalize(mean=[0.5, 0.5, 0.5], 
                                 std=[0.5, 0.5, 0.5])
 
-            fake_img = np.random.rand(3, 500, 500).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(300, 320, 3) * 255.).astype(np.uint8))
 
             fake_img = normalize(fake_img)
             print(fake_img.shape)
+            print(fake_img.max, fake_img.max)
     
     """
 
-    def __init__(self, mean=0.0, std=1.0):
+    def __init__(self,
+                 mean=0.0,
+                 std=1.0,
+                 data_format='CHW',
+                 to_rgb=False,
+                 keys=None,
+                 backend='pil'):
+        super().__init__(keys, backend)
         if isinstance(mean, numbers.Number):
             mean = [mean, mean, mean]
 
         if isinstance(std, numbers.Number):
             std = [std, std, std]
 
-        self.mean = np.array(mean, dtype=np.float32).reshape(len(mean), 1, 1)
-        self.std = np.array(std, dtype=np.float32).reshape(len(std), 1, 1)
-
-    def __call__(self, img):
-        return (img - self.mean) / self.std
-
-
-class Permute(object):
-    """Change input data to a target mode.
-    For example, most transforms use HWC mode image,
-    while the Neural Network might use CHW mode input tensor.
-    Input image should be HWC mode and an instance of numpy.ndarray. 
-
-    Args:
-        mode (str): Output mode of input. Default: "CHW".
-        to_rgb (bool): Convert 'bgr' image to 'rgb'. Default: True.
-
-    Examples:
-    
-        .. code-block:: python
-
-            import numpy as np
-
-            from paddle.vision.transforms import Permute
-
-            transform = Permute()
-
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
-
-            fake_img = transform(fake_img)
-            print(fake_img.shape)
-    """
-
-    def __init__(self, mode="CHW", to_rgb=True):
-        assert mode in [
-            "CHW"
-        ], "Only support 'CHW' mode, but received mode: {}".format(mode)
-        self.mode = mode
+        self.mean = mean
+        self.std = std
+        self.data_format = 'CHW'
         self.to_rgb = to_rgb
 
-    def __call__(self, img):
-        if self.to_rgb:
-            img = img[..., ::-1]
-        if self.mode == "CHW":
-            return img.transpose((2, 0, 1))
-        return img
+    def _apply_image(self, img):
+        return F.normalize(img, self.mean, self.std, self.data_format,
+                           self.to_rgb)
 
 
-class GaussianNoise(object):
-    """Add random gaussian noise to the input data.
-    Gaussian noise is generated with given mean and std.
+class Transpose(BaseTransform):
+    """Transpose input data to a target format.
+    For example, most transforms use HWC mode image,
+    while the Neural Network might use CHW mode input tensor.
+    output image will be an instance of numpy.ndarray. 
 
     Args:
-        mean (float): Gaussian mean used to generate noise.
-        std (float): Gaussian standard deviation used to generate noise.
-    
+        order (list|tuple, optional): Target order of input data. Default: (2, 0, 1).
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        
     Examples:
     
         .. code-block:: python
 
             import numpy as np
+            from PIL import Image
+            from paddle.vision.transforms import Transpose
 
-            from paddle.vision.transforms import GaussianNoise
+            transform = Transpose()
 
-            transform = GaussianNoise()
-
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(300, 320, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
             print(fake_img.shape)
+    
     """
 
-    def __init__(self, mean=0.0, std=1.0):
-        self.mean = np.array(mean, dtype=np.float32)
-        self.std = np.array(std, dtype=np.float32)
+    def __init__(self, order=(2, 0, 1), keys=None):
+        super().__init__(keys)
+        self.order = order
 
-    def __call__(self, img):
-        dtype = img.dtype
-        noise = np.random.normal(self.mean, self.std, img.shape) * 255
-        img = img + noise.astype(np.float32)
-        return np.clip(img, 0, 255).astype(dtype)
+    def _apply_image(self, img):
+        if F._is_pil_image(img):
+            img = np.asarray(img)
+
+        return img.transpose(self.order)
 
 
-class BrightnessTransform(object):
+class BrightnessTransform(BaseTransform):
     """Adjust brightness of the image.
 
     Args:
         value (float): How much to adjust the brightness. Can be any
             non negative number. 0 gives the original image
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import BrightnessTransform
 
             transform = BrightnessTransform(0.4)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            
     """
 
-    def __init__(self, value):
-        if value < 0:
-            raise ValueError("brightness value should be non-negative")
-        self.value = value
+    def __init__(self, value, keys=None, backend='pil'):
+        super().__init__(keys, backend)
+        self.value = _check_input(value, 'brightness')
 
-    def __call__(self, img):
-        if self.value == 0:
+    def _apply_image(self, img):
+        if self.value is None:
             return img
 
-        dtype = img.dtype
-        img = img.astype(np.float32)
-        alpha = np.random.uniform(max(0, 1 - self.value), 1 + self.value)
-        img = img * alpha
-        return img.clip(0, 255).astype(dtype)
+        brightness_factor = random.uniform(self.value[0], self.value[1])
+        return F.adjust_brightness(img, brightness_factor, self.backend)
 
 
-class ContrastTransform(object):
+class ContrastTransform(BaseTransform):
     """Adjust contrast of the image.
 
     Args:
         value (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives the original image
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import ContrastTransform
 
             transform = ContrastTransform(0.4)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+
     """
 
-    def __init__(self, value):
+    def __init__(self, value, keys=None, backend='pil'):
+        super().__init__(keys, backend)
         if value < 0:
             raise ValueError("contrast value should be non-negative")
-        self.value = value
+        self.value = _check_input(value, 'contrast')
 
-    def __call__(self, img):
-        if self.value == 0:
+    def _apply_image(self, img):
+        if self.value is None:
             return img
 
-        cv2 = try_import('cv2')
-        dtype = img.dtype
-        img = img.astype(np.float32)
-        alpha = np.random.uniform(max(0, 1 - self.value), 1 + self.value)
-        img = img * alpha + cv2.cvtColor(img, cv2.COLOR_BGR2GRAY).mean() * (
-            1 - alpha)
-        return img.clip(0, 255).astype(dtype)
+        contrast_factor = random.uniform(self.value[0], self.value[1])
+        return F.adjust_contrast(img, contrast_factor, self.backend)
 
 
-class SaturationTransform(object):
+class SaturationTransform(BaseTransform):
     """Adjust saturation of the image.
 
     Args:
         value (float): How much to adjust the saturation. Can be any
             non negative number. 0 gives the original image
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import SaturationTransform
 
             transform = SaturationTransform(0.4)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
         
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+
     """
 
-    def __init__(self, value):
-        if value < 0:
-            raise ValueError("saturation value should be non-negative")
-        self.value = value
+    def __init__(self, value, keys=None, backend='pil'):
+        super().__init__(keys, backend)
+        self.value = _check_input(value, 'saturation')
 
-    def __call__(self, img):
-        if self.value == 0:
+    def _apply_image(self, img):
+        if self.value is None:
             return img
 
-        cv2 = try_import('cv2')
-
-        dtype = img.dtype
-        img = img.astype(np.float32)
-        alpha = np.random.uniform(max(0, 1 - self.value), 1 + self.value)
-        gray_img = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
-        gray_img = gray_img[..., np.newaxis]
-        img = img * alpha + gray_img * (1 - alpha)
-        return img.clip(0, 255).astype(dtype)
+        saturation_factor = random.uniform(self.value[0], self.value[1])
+        return F.adjust_saturation(img, saturation_factor, self.backend)
 
 
-class HueTransform(object):
+class HueTransform(BaseTransform):
     """Adjust hue of the image.
 
     Args:
         value (float): How much to adjust the hue. Can be any number
             between 0 and 0.5, 0 gives the original image
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import HueTransform
 
             transform = HueTransform(0.4)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+
     """
 
-    def __init__(self, value):
-        if value < 0 or value > 0.5:
-            raise ValueError("hue value should be in [0.0, 0.5]")
-        self.value = value
+    def __init__(self, value, keys=None, backend='pil'):
+        super().__init__(keys, backend)
+        self.value = _check_input(
+            value, 'hue', center=0, bound=(-0.5, 0.5), clip_first_on_zero=False)
 
-    def __call__(self, img):
-        if self.value == 0:
+    def _apply_image(self, img):
+        if self.value is None:
             return img
 
-        cv2 = try_import('cv2')
-        dtype = img.dtype
-        img = img.astype(np.uint8)
-        hsv_img = cv2.cvtColor(img, cv2.COLOR_BGR2HSV_FULL)
-        h, s, v = cv2.split(hsv_img)
-
-        alpha = np.random.uniform(-self.value, self.value)
-        h = h.astype(np.uint8)
-        # uint8 addition take cares of rotation across boundaries
-        with np.errstate(over="ignore"):
-            h += np.uint8(alpha * 255)
-        hsv_img = cv2.merge([h, s, v])
-        return cv2.cvtColor(hsv_img, cv2.COLOR_HSV2BGR_FULL).astype(dtype)
+        hue_factor = random.uniform(self.value[0], self.value[1])
+        return F.adjust_hue(img, hue_factor, self.backend)
 
 
-class ColorJitter(object):
+class ColorJitter(BaseTransform):
     """Randomly change the brightness, contrast, saturation and hue of an image.
 
     Args:
@@ -800,42 +851,83 @@ class ColorJitter(object):
             Chosen uniformly from [max(0, 1 - saturation), 1 + saturation]. Should be non negative numbers.
         hue: How much to jitter hue.
             Chosen uniformly from [-hue, hue]. Should have 0<= hue <= 0.5.
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import ColorJitter
 
-            transform = ColorJitter(0.4)
+            transform = ColorJitter(0.4, 0.4, 0.4, 0.4)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+
     """
 
-    def __init__(self, brightness=0, contrast=0, saturation=0, hue=0):
+    def __init__(self,
+                 brightness=0,
+                 contrast=0,
+                 saturation=0,
+                 hue=0,
+                 keys=None,
+                 backend='pil'):
+        super().__init__(keys, backend)
+        self.brightness = brightness
+        self.contrast = contrast
+        self.saturation = saturation
+        self.hue = hue
+
+    def get_params(self, brightness, contrast, saturation, hue):
+        """Get a randomized transform to be applied on image.
+
+        Arguments are same as that of __init__.
+
+        Returns:
+            Transform which randomly adjusts brightness, contrast and
+            saturation in a random order.
+        """
         transforms = []
-        if brightness != 0:
-            transforms.append(BrightnessTransform(brightness))
-        if contrast != 0:
-            transforms.append(ContrastTransform(contrast))
-        if saturation != 0:
-            transforms.append(SaturationTransform(saturation))
-        if hue != 0:
-            transforms.append(HueTransform(hue))
+
+        if brightness is not None:
+            transforms.append(
+                BrightnessTransform(brightness, self.keys, self.backend))
+
+        if contrast is not None:
+            transforms.append(
+                ContrastTransform(contrast, self.keys, self.backend))
+
+        if saturation is not None:
+            transforms.append(
+                SaturationTransform(saturation, self.keys, self.backend))
+
+        if hue is not None:
+            transforms.append(HueTransform(hue, self.keys, self.backend))
 
         random.shuffle(transforms)
-        self.transforms = Compose(transforms)
+        transform = Compose(transforms)
 
-    def __call__(self, img):
-        return self.transforms(img)
+        return transform
+
+    def _apply_image(self, img):
+        """
+        Args:
+            img (PIL Image): Input image.
+
+        Returns:
+            PIL Image: Color jittered image.
+        """
+        transform = self.get_params(self.brightness, self.contrast,
+                                    self.saturation, self.hue)
+        return transform(img)
 
 
-class RandomCrop(object):
+class RandomCrop(BaseTransform):
     """Crops the given CV Image at a random location.
 
     Args:
@@ -847,159 +939,91 @@ class RandomCrop(object):
             top, right, bottom borders respectively. Default: 0.
         pad_if_needed (boolean|optional): It will pad the image if smaller than the
             desired size to avoid raising an exception. Default: False.
-    
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import RandomCrop
 
             transform = RandomCrop(224)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(324, 300, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, size, padding=0, pad_if_needed=False):
+    def __init__(self,
+                 size,
+                 padding=None,
+                 pad_if_needed=False,
+                 fill=0,
+                 padding_mode='constant',
+                 keys=None,
+                 backend='pil'):
+        super().__init__(keys, backend)
         if isinstance(size, numbers.Number):
             self.size = (int(size), int(size))
         else:
             self.size = size
         self.padding = padding
         self.pad_if_needed = pad_if_needed
+        self.fill = fill
+        self.padding_mode = padding_mode
 
-    def _get_params(self, img, output_size):
+    def get_params(self, img, output_size):
         """Get parameters for ``crop`` for a random crop.
 
         Args:
-            img (numpy.ndarray): Image to be cropped.
+            img (PIL Image): Image to be cropped.
             output_size (tuple): Expected output size of the crop.
 
         Returns:
             tuple: params (i, j, h, w) to be passed to ``crop`` for random crop.
-
         """
-        h, w, _ = img.shape
+        w, h = _get_image_size(img)
         th, tw = output_size
         if w == tw and h == th:
             return 0, 0, h, w
 
-        try:
-            i = random.randint(0, h - th)
-        except ValueError:
-            i = random.randint(h - th, 0)
-        try:
-            j = random.randint(0, w - tw)
-        except ValueError:
-            j = random.randint(w - tw, 0)
+        i = random.randint(0, h - th)
+        j = random.randint(0, w - tw)
         return i, j, th, tw
 
-    def __call__(self, img):
+    def _apply_image(self, img):
         """
-
         Args:
-            img (numpy.ndarray): Image to be cropped.
-        Returns:
-            numpy.ndarray: Cropped image.
+            img (PIL Image): Image to be cropped.
 
+        Returns:
+            PIL Image: Cropped image.
         """
-        if self.padding > 0:
-            img = F.pad(img, self.padding)
+        if self.padding is not None:
+            img = F.pad(img, self.padding, self.fill, self.padding_mode,
+                        self.backend)
+
+        w, h = _get_image_size(img)
 
         # pad the width if needed
-        if self.pad_if_needed and img.shape[1] < self.size[1]:
-            img = F.pad(img, (int((1 + self.size[1] - img.shape[1]) / 2), 0))
+        if self.pad_if_needed and w < self.size[1]:
+            img = F.pad(img, (self.size[1] - w, 0), self.fill,
+                        self.padding_mode, self.backend)
         # pad the height if needed
-        if self.pad_if_needed and img.shape[0] < self.size[0]:
-            img = F.pad(img, (0, int((1 + self.size[0] - img.shape[0]) / 2)))
+        if self.pad_if_needed and h < self.size[0]:
+            img = F.pad(img, (0, self.size[0] - h), self.fill,
+                        self.padding_mode, self.backend)
 
-        i, j, h, w = self._get_params(img, self.size)
+        i, j, h, w = self.get_params(img, self.size)
 
-        return img[i:i + h, j:j + w]
-
-
-class RandomErasing(object):
-    """Randomly selects a rectangle region in an image and erases its pixels.
-    ``Random Erasing Data Augmentation`` by Zhong et al.
-    See https://arxiv.org/pdf/1708.04896.pdf
-
-    Args:
-         prob (float): probability that the random erasing operation will be performed.
-         scale (tuple): range of proportion of erased area against input image. Should be (min, max).
-         ratio (float): range of aspect ratio of erased area.
-         value (float|list|tuple): erasing value. If a single int, it is used to
-            erase all pixels. If a tuple of length 3, it is used to erase
-            R, G, B channels respectively. Default: 0. 
-
-    Examples:
-    
-        .. code-block:: python
-
-            import numpy as np
-
-            from paddle.vision.transforms import RandomCrop
-
-            transform = RandomCrop(224)
-
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
-
-            fake_img = transform(fake_img)
-            print(fake_img.shape)
-    """
-
-    def __init__(self,
-                 prob=0.5,
-                 scale=(0.02, 0.4),
-                 ratio=0.3,
-                 value=[0., 0., 0.]):
-        assert isinstance(value, (
-            float, Sequence
-        )), "Expected type of value in [float, list, tupue], but got {}".format(
-            type(value))
-        assert scale[0] <= scale[1], "scale range should be of kind (min, max)!"
-
-        if isinstance(value, float):
-            self.value = [value, value, value]
-        else:
-            self.value = value
-
-        self.p = prob
-        self.scale = scale
-        self.ratio = ratio
-
-    def __call__(self, img):
-        if random.uniform(0, 1) > self.p:
-            return img
-
-        for _ in range(100):
-            area = img.shape[0] * img.shape[1]
-
-            target_area = random.uniform(self.scale[0], self.scale[1]) * area
-            aspect_ratio = random.uniform(self.ratio, 1 / self.ratio)
-
-            h = int(round(math.sqrt(target_area * aspect_ratio)))
-            w = int(round(math.sqrt(target_area / aspect_ratio)))
-
-            if w < img.shape[1] and h < img.shape[0]:
-                x1 = random.randint(0, img.shape[0] - h)
-                y1 = random.randint(0, img.shape[1] - w)
-
-                if len(img.shape) == 3 and img.shape[2] == 3:
-                    img[x1:x1 + h, y1:y1 + w, 0] = self.value[0]
-                    img[x1:x1 + h, y1:y1 + w, 1] = self.value[1]
-                    img[x1:x1 + h, y1:y1 + w, 2] = self.value[2]
-                else:
-                    img[x1:x1 + h, y1:y1 + w] = self.value[1]
-                return img
-
-        return img
+        return F.crop(img, i, j, h, w, self.backend)
 
 
-class Pad(object):
+class Pad(BaseTransform):
     """Pads the given CV Image on all sides with the given "pad" value.
 
     Args:
@@ -1020,64 +1044,81 @@ class Pad(object):
             ``symmetric`` menas pads with reflection of image (repeating the last value on the edge)
             padding ``[1, 2, 3, 4]`` with 2 elements on both sides in symmetric mode 
             will result in ``[2, 1, 1, 2, 3, 4, 4, 3]``.
-
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import Pad
 
             transform = Pad(2)
 
-            fake_img = np.random.rand(500, 500, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, padding, fill=0, padding_mode='constant'):
+    def __init__(self,
+                 padding,
+                 fill=0,
+                 padding_mode='constant',
+                 keys=None,
+                 backend='pil'):
         assert isinstance(padding, (numbers.Number, list, tuple))
         assert isinstance(fill, (numbers.Number, str, list, tuple))
         assert padding_mode in ['constant', 'edge', 'reflect', 'symmetric']
-        if isinstance(padding,
-                      collections.Sequence) and len(padding) not in [2, 4]:
+
+        if isinstance(padding, list):
+            padding = tuple(padding)
+        if isinstance(fill, list):
+            fill = tuple(fill)
+
+        if isinstance(padding, Sequence) and len(padding) not in [2, 4]:
             raise ValueError(
                 "Padding must be an int or a 2, or 4 element tuple, not a " +
                 "{} element tuple".format(len(padding)))
 
+        super().__init__(keys, backend)
         self.padding = padding
         self.fill = fill
         self.padding_mode = padding_mode
 
-    def __call__(self, img):
+    def _apply_image(self, img):
         """
         Args:
-            img (numpy.ndarray): Image to be padded.
+            img (PIL Image): Image to be padded.
+
         Returns:
-            numpy.ndarray: Padded image.
+            PIL Image: Padded image.
         """
-        return F.pad(img, self.padding, self.fill, self.padding_mode)
+        return F.pad(img, self.padding, self.fill, self.padding_mode,
+                     self.backend)
 
 
-class RandomRotate(object):
+class RandomRotation(BaseTransform):
     """Rotates the image by angle.
 
     Args:
         degrees (sequence or float or int): Range of degrees to select from.
             If degrees is a number instead of sequence like (min, max), the range of degrees
             will be (-degrees, +degrees) clockwise order.
-        interpolation (int, optional): Interpolation mode of resize. Default: 1.
-            0 : cv2.INTER_NEAREST 
-            1 : cv2.INTER_LINEAR 
-            2 : cv2.INTER_CUBIC 
-            3 : cv2.INTER_AREA 
-            4 : cv2.INTER_LANCZOS4 
-            5 : cv2.INTER_LINEAR_EXACT
-            7 : cv2.INTER_MAX 
-            8 : cv2.WARP_FILL_OUTLIERS 
-            16: cv2.WARP_INVERSE_MAP 
+        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
+        resample (int|str, optional): An optional resampling filter. If omitted, or if the 
+            image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
+            according the backend.
+            when use pil backend, support method are as following:
+                'nearest': Image.NEAREST,
+                'bilinear': Image.BILINEAR,
+                'bicubic': Image.BICUBIC,
+            when use cv2 backend, support method are as following:
+                'nearest': cv2.INTER_NEAREST,
+                'bilinear': cv2.INTER_LINEAR,
+                'bicubic': cv2.INTER_CUBIC,
         expand (bool|optional): Optional expansion flag. Default: False.
             If true, expands the output to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.
@@ -1085,24 +1126,33 @@ class RandomRotate(object):
         center (2-tuple|optional): Optional center of rotation.
             Origin is the upper left corner.
             Default is the center of the image.
-    
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Examples:
     
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import RandomRotate
 
             transform = RandomRotate(90)
 
-            fake_img = np.random.rand(500, 400, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(200, 150, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(fake_img.size)
     """
 
-    def __init__(self, degrees, interpolation=1, expand=False, center=None):
+    def __init__(self,
+                 degrees,
+                 resample=False,
+                 expand=False,
+                 center=None,
+                 fill=0,
+                 keys=None,
+                 backend='pil'):
         if isinstance(degrees, numbers.Number):
             if degrees < 0:
                 raise ValueError(
@@ -1114,37 +1164,40 @@ class RandomRotate(object):
                     "If degrees is a sequence, it must be of len 2.")
             self.degrees = degrees
 
-        self.interpolation = interpolation
+        super().__init__(keys, backend)
+        self.resample = resample
         self.expand = expand
         self.center = center
+        self.fill = fill
 
-    def _get_params(self, degrees):
-        """Get parameters for ``rotate`` for a random rotation.
-        Returns:
-            sequence: params to be passed to ``rotate`` for random rotation.
-        """
+    def get_params(self, degrees):
         angle = random.uniform(degrees[0], degrees[1])
 
         return angle
 
-    def __call__(self, img):
+    def _apply_image(self, img):
         """
-            img (np.ndarray): Image to be rotated.
+        Args:
+            img (PIL.Image|np.array): Image to be rotated.
+
         Returns:
-            np.ndarray: Rotated image.
+            PIL.Image or np.array: Rotated image.
         """
 
-        angle = self._get_params(self.degrees)
+        angle = self.get_params(self.degrees)
 
-        return F.rotate(img, angle, self.interpolation, self.expand,
-                        self.center)
+        return F.rotate(img, angle, self.resample, self.expand, self.center,
+                        self.fill, self.backend)
 
 
-class Grayscale(object):
+class Grayscale(BaseTransform):
     """Converts image to grayscale.
 
     Args:
-        output_channels (int): (1 or 3) number of channels desired for output image
+        num_output_channels (int): (1 or 3) number of channels desired for output image
+        keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
+        backend (std, optional): The image resize backend type. Options are `pil`, 
+            `cv2`. Default: 'pil'. 
     Returns:
         CV Image: Grayscale version of the input.
         - If output_channels == 1 : returned image is single channel
@@ -1155,25 +1208,27 @@ class Grayscale(object):
         .. code-block:: python
 
             import numpy as np
-
+            from PIL import Image
             from paddle.vision.transforms import Grayscale
 
             transform = Grayscale()
 
-            fake_img = np.random.rand(500, 400, 3).astype('float32')
+            fake_img = Image.fromarray((np.random.rand(224, 224, 3) * 255.).astype(np.uint8))
 
             fake_img = transform(fake_img)
-            print(fake_img.shape)
+            print(np.array(fake_img).shape)
     """
 
-    def __init__(self, output_channels=1):
-        self.output_channels = output_channels
+    def __init__(self, num_output_channels=1, keys=None, backend=None):
+        super().__init__(keys, backend)
+        self.num_output_channels = num_output_channels
 
-    def __call__(self, img):
+    def _apply_image(self, img):
         """
         Args:
-            img (numpy.ndarray): Image to be converted to grayscale.
+            img (PIL Image): Image to be converted to grayscale.
+
         Returns:
-            numpy.ndarray: Randomly grayscaled image.
+            PIL Image: Randomly grayscaled image.
         """
-        return F.to_grayscale(img, num_output_channels=self.output_channels)
+        return F.to_grayscale(img, self.num_output_channels, self.backend)

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -161,7 +161,7 @@ class BaseTransform(object):
             
             You can also customize your data types only if you implement the corresponding
             _apply_*() methods, otherwise ``NotImplementedError`` will be raised.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     
     Examples:
@@ -365,7 +365,7 @@ class Resize(BaseTransform):
                 'bicubic': cv2.INTER_CUBIC,
                 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Examples:
@@ -421,7 +421,7 @@ class RandomResizedCrop(BaseTransform):
                 'bicubic': cv2.INTER_CUBIC,
                 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Examples:
@@ -506,7 +506,7 @@ class CenterCrop(BaseTransform):
     Args:
         size (int|list|tuple): Target size of output image, with (height, width) shape.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -541,7 +541,7 @@ class RandomHorizontalFlip(BaseTransform):
     Args:
         prob (float, optional): Probability of the input data being flipped. Default: 0.5
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -575,7 +575,7 @@ class RandomVerticalFlip(BaseTransform):
     Args:
         prob (float, optional): Probability of the input data being flipped. Default: 0.5
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
 
     Examples:
@@ -615,7 +615,7 @@ class Normalize(BaseTransform):
         mean (int|float|list): Sequence of means for each channel.
         std (int|float|list): Sequence of standard deviations for each channel.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
         
     Examples:
@@ -707,7 +707,7 @@ class BrightnessTransform(BaseTransform):
         value (float): How much to adjust the brightness. Can be any
             non negative number. 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -744,7 +744,7 @@ class ContrastTransform(BaseTransform):
         value (float): How much to adjust the contrast. Can be any
             non negative number. 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -783,7 +783,7 @@ class SaturationTransform(BaseTransform):
         value (float): How much to adjust the saturation. Can be any
             non negative number. 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -820,7 +820,7 @@ class HueTransform(BaseTransform):
         value (float): How much to adjust the hue. Can be any number
             between 0 and 0.5, 0 gives the original image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -864,7 +864,7 @@ class ColorJitter(BaseTransform):
         hue: How much to jitter hue.
             Chosen uniformly from [-hue, hue]. Should have 0<= hue <= 0.5.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -952,7 +952,7 @@ class RandomCrop(BaseTransform):
         pad_if_needed (boolean|optional): It will pad the image if smaller than the
             desired size to avoid raising an exception. Default: False.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -1057,7 +1057,7 @@ class Pad(BaseTransform):
             padding ``[1, 2, 3, 4]`` with 2 elements on both sides in symmetric mode 
             will result in ``[2, 1, 1, 2, 3, 4, 4, 3]``.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -1139,7 +1139,7 @@ class RandomRotation(BaseTransform):
             Origin is the upper left corner.
             Default is the center of the image.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Examples:
     
@@ -1208,7 +1208,7 @@ class Grayscale(BaseTransform):
     Args:
         num_output_channels (int): (1 or 3) number of channels desired for output image
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
-        backend (std, optional): The image resize backend type. Options are `pil`, 
+        backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
     Returns:
         CV Image: Grayscale version of the input.

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -134,7 +134,9 @@ class Compose(object):
 class BaseTransform(object):
     """
     Base class of all transforms used in computer vision.
+
     calling logic: 
+
         if keys is None:
             _get_params -> _apply_image()
         else:
@@ -154,9 +156,9 @@ class BaseTransform(object):
 
             * "image": input image, with shape of (H, W, C)
             * "coords": coordinates, with shape of (N, 2)
-            * "boxes": bounding boxes, with shape of (N, 4), "xyxy" format,
-            the 1st "xy" represents top left point of a box,
-            the 2nd "xy" represents right bottom point.
+            * "boxes": bounding boxes, with shape of (N, 4), "xyxy" format, 
+                the 1st "xy" represents top left point of a box, 
+                the 2nd "xy" represents right bottom point.
             * "mask": map used for segmentation, with shape of (H, W, 1)
             
             You can also customize your data types only if you implement the corresponding
@@ -300,6 +302,7 @@ class ToTensor(BaseTransform):
     or if the numpy.ndarray has dtype = np.uint8
 
     In the other cases, tensors are returned without scaling.
+
     Args:
         size (int|list|tuple): Desired output size. If size is a sequence like
             (h, w), output size will be matched to this. If size is an int,
@@ -350,19 +353,20 @@ class Resize(BaseTransform):
             smaller edge of the image will be matched to this number.
             i.e, if height > width, then image will be rescaled to
             (size * height / width, size)
-        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
-            when use pil backend, support method are as following:
-                'nearest': Image.NEAREST,
-                'bilinear': Image.BILINEAR,
-                'bicubic': Image.BICUBIC,
-                'box': Image.BOX,
-                'lanczos': Image.LANCZOS,
-                'hamming': Image.HAMMING
-            when use cv2 backend, support method are as following:
-                'nearest': cv2.INTER_NEAREST,
-                'bilinear': cv2.INTER_LINEAR,
-                'area': cv2.INTER_AREA,
-                'bicubic': cv2.INTER_CUBIC,
+        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. 
+            when use pil backend, support method are as following: 
+                'nearest': Image.NEAREST, 
+                'bilinear': Image.BILINEAR, 
+                'bicubic': Image.BICUBIC, 
+                'box': Image.BOX, 
+                'lanczos': Image.LANCZOS, 
+                'hamming': Image.HAMMING 
+                
+            when use cv2 backend, support method are as following: 
+                'nearest': cv2.INTER_NEAREST, 
+                'bilinear': cv2.INTER_LINEAR, 
+                'area': cv2.INTER_AREA, 
+                'bicubic': cv2.INTER_CUBIC, 
                 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
@@ -614,6 +618,9 @@ class Normalize(BaseTransform):
     Args:
         mean (int|float|list): Sequence of means for each channel.
         std (int|float|list): Sequence of standard deviations for each channel.
+        data_format (str, optional): Data format of img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
+        to_rgb (bool, optional): Whether to convert to rgb. Default: False.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -1123,13 +1130,14 @@ class RandomRotation(BaseTransform):
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend.
-            when use pil backend, support method are as following:
-                'nearest': Image.NEAREST,
-                'bilinear': Image.BILINEAR,
+            when use pil backend, support method are as following: 
+                'nearest': Image.NEAREST, 
+                'bilinear': Image.BILINEAR, 
                 'bicubic': Image.BICUBIC
-            when use cv2 backend, support method are as following:
-                'nearest': cv2.INTER_NEAREST,
-                'bilinear': cv2.INTER_LINEAR,
+
+            when use cv2 backend, support method are as following: 
+                'nearest': cv2.INTER_NEAREST, 
+                'bilinear': cv2.INTER_LINEAR, 
                 'bicubic': cv2.INTER_CUBIC
         expand (bool|optional): Optional expansion flag. Default: False.
             If true, expands the output to make it large enough to hold the entire rotated image.

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -304,11 +304,8 @@ class ToTensor(BaseTransform):
     In the other cases, tensors are returned without scaling.
 
     Args:
-        size (int|list|tuple): Desired output size. If size is a sequence like
-            (h, w), output size will be matched to this. If size is an int,
-            smaller edge of the image will be matched to this number.
-            i.e, if height > width, then image will be rescaled to
-            (size * height / width, size)
+        data_format (str, optional): Data format of input img, should be 'HWC' or 
+            'CHW'. Default: 'CHW'.
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         
     Examples:

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -363,7 +363,6 @@ class Resize(BaseTransform):
                 - 'box': Image.BOX, 
                 - 'lanczos': Image.LANCZOS, 
                 - 'hamming': Image.HAMMING
-
             when use cv2 backend, support method are as following: 
                 - 'nearest': cv2.INTER_NEAREST, 
                 - 'bilinear': cv2.INTER_LINEAR, 
@@ -412,15 +411,14 @@ class RandomResizedCrop(BaseTransform):
         size (int|list|tuple): Target size of output image, with (height, width) shape.
         scale (list|tuple): Range of size of the origin size cropped. Default: (0.08, 1.0)
         ratio (list|tuple): Range of aspect ratio of the origin aspect ratio cropped. Default: (0.75, 1.33)
-        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
-            when use pil backend, support method are as following: 
+        interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. when use pil backend, 
+            support method are as following: 
                 - 'nearest': Image.NEAREST, 
                 - 'bilinear': Image.BILINEAR, 
                 - 'bicubic': Image.BICUBIC, 
                 - 'box': Image.BOX, 
                 - 'lanczos': Image.LANCZOS, 
                 - 'hamming': Image.HAMMING
-
             when use cv2 backend, support method are as following: 
                 - 'nearest': cv2.INTER_NEAREST, 
                 - 'bilinear': cv2.INTER_LINEAR, 
@@ -1132,12 +1130,10 @@ class RandomRotation(BaseTransform):
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'.
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
-            according the backend.
-            when use pil backend, support method are as following: 
+            according the backend. when use pil backend, support method are as following: 
                 - 'nearest': Image.NEAREST, 
                 - 'bilinear': Image.BILINEAR, 
                 - 'bicubic': Image.BICUBIC
-
             when use cv2 backend, support method are as following: 
                 - 'nearest': cv2.INTER_NEAREST, 
                 - 'bilinear': cv2.INTER_LINEAR, 

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -131,7 +131,7 @@ class Compose(object):
         return format_string
 
 
-class BaseTransform():
+class BaseTransform(object):
     """
     Base class of all transforms used in computer vision.
     calling logic: 
@@ -230,7 +230,7 @@ class BaseTransform():
     def __init__(self, keys=None, backend='pil'):
         if keys is None:
             keys = ("image", )
-        elif not isinstance(keys, collections.abc.Sequence):
+        elif not isinstance(keys, Sequence):
             raise ValueError(
                 "keys should be a sequence, but got keys={}".format(keys))
         for k in keys:

--- a/python/paddle/vision/transforms/transforms.py
+++ b/python/paddle/vision/transforms/transforms.py
@@ -357,18 +357,18 @@ class Resize(BaseTransform):
             (size * height / width, size)
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. 
             when use pil backend, support method are as following: 
-                - 'nearest': Image.NEAREST, 
-                - 'bilinear': Image.BILINEAR, 
-                - 'bicubic': Image.BICUBIC, 
-                - 'box': Image.BOX, 
-                - 'lanczos': Image.LANCZOS, 
-                - 'hamming': Image.HAMMING
+            - 'nearest': Image.NEAREST, 
+            - 'bilinear': Image.BILINEAR, 
+            - 'bicubic': Image.BICUBIC, 
+            - 'box': Image.BOX, 
+            - 'lanczos': Image.LANCZOS, 
+            - 'hamming': Image.HAMMING
             when use cv2 backend, support method are as following: 
-                - 'nearest': cv2.INTER_NEAREST, 
-                - 'bilinear': cv2.INTER_LINEAR, 
-                - 'area': cv2.INTER_AREA, 
-                - 'bicubic': cv2.INTER_CUBIC, 
-                - 'lanczos': cv2.INTER_LANCZOS4
+            - 'nearest': cv2.INTER_NEAREST, 
+            - 'bilinear': cv2.INTER_LINEAR, 
+            - 'area': cv2.INTER_AREA, 
+            - 'bicubic': cv2.INTER_CUBIC, 
+            - 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -413,18 +413,18 @@ class RandomResizedCrop(BaseTransform):
         ratio (list|tuple): Range of aspect ratio of the origin aspect ratio cropped. Default: (0.75, 1.33)
         interpolation (int|str, optional): Interpolation method. Default: 'bilinear'. when use pil backend, 
             support method are as following: 
-                - 'nearest': Image.NEAREST, 
-                - 'bilinear': Image.BILINEAR, 
-                - 'bicubic': Image.BICUBIC, 
-                - 'box': Image.BOX, 
-                - 'lanczos': Image.LANCZOS, 
-                - 'hamming': Image.HAMMING
+            - 'nearest': Image.NEAREST, 
+            - 'bilinear': Image.BILINEAR, 
+            - 'bicubic': Image.BICUBIC, 
+            - 'box': Image.BOX, 
+            - 'lanczos': Image.LANCZOS, 
+            - 'hamming': Image.HAMMING
             when use cv2 backend, support method are as following: 
-                - 'nearest': cv2.INTER_NEAREST, 
-                - 'bilinear': cv2.INTER_LINEAR, 
-                - 'area': cv2.INTER_AREA, 
-                - 'bicubic': cv2.INTER_CUBIC, 
-                - 'lanczos': cv2.INTER_LANCZOS4
+            - 'nearest': cv2.INTER_NEAREST, 
+            - 'bilinear': cv2.INTER_LINEAR, 
+            - 'area': cv2.INTER_AREA, 
+            - 'bicubic': cv2.INTER_CUBIC, 
+            - 'lanczos': cv2.INTER_LANCZOS4
         keys (list[str]|tuple[str], optional): Same as ``BaseTransform``. Default: None.
         backend (str, optional): The image resize backend type. Options are `pil`, 
             `cv2`. Default: 'pil'. 
@@ -1131,13 +1131,13 @@ class RandomRotation(BaseTransform):
         resample (int|str, optional): An optional resampling filter. If omitted, or if the 
             image has only one channel, it is set to PIL.Image.NEAREST or cv2.INTER_NEAREST 
             according the backend. when use pil backend, support method are as following: 
-                - 'nearest': Image.NEAREST, 
-                - 'bilinear': Image.BILINEAR, 
-                - 'bicubic': Image.BICUBIC
+            - 'nearest': Image.NEAREST, 
+            - 'bilinear': Image.BILINEAR, 
+            - 'bicubic': Image.BICUBIC
             when use cv2 backend, support method are as following: 
-                - 'nearest': cv2.INTER_NEAREST, 
-                - 'bilinear': cv2.INTER_LINEAR, 
-                - 'bicubic': cv2.INTER_CUBIC
+            - 'nearest': cv2.INTER_NEAREST, 
+            - 'bilinear': cv2.INTER_LINEAR, 
+            - 'bicubic': cv2.INTER_CUBIC
         expand (bool|optional): Optional expansion flag. Default: False.
             If true, expands the output to make it large enough to hold the entire rotated image.
             If false or omitted, make the output image the same size as the input image.

--- a/python/paddle/vision/utils.py
+++ b/python/paddle/vision/utils.py
@@ -34,6 +34,7 @@ def set_image_backend(backend):
             import shutil
             import tempfile
             import numpy as np
+            from PIL import Image
 
             from paddle.vision import DatasetFolder
             from paddle.vision import set_image_backend
@@ -48,8 +49,8 @@ def set_image_backend(backend):
                     if not os.path.exists(sub_dir):
                         os.makedirs(sub_dir)
                     for j in range(2):
-                        fake_img = (np.random.random((32, 32, 3)) * 255).astype('uint8')
-                        cv2.imwrite(os.path.join(sub_dir, str(j) + '.jpg'), fake_img)
+                        fake_img = Image.fromarray((np.random.random((32, 32, 3)) * 255).astype('uint8'))
+                        fake_img.save(os.path.join(sub_dir, str(j) + '.png'))
                 return data_dir
 
             temp_dir = make_fake_dir()
@@ -64,7 +65,7 @@ def set_image_backend(backend):
 
             # use opencv as backend
             # set_image_backend('cv2')
-    
+
             # cv2_data_folder = DatasetFolder(temp_dir)
 
             # for items in cv2_data_folder:
@@ -78,7 +79,7 @@ def set_image_backend(backend):
     global _image_backend
     if backend not in ['pil', 'cv2']:
         raise ValueError(
-            "Expected backend are one of {'pil', 'cv2'}, but got {}"
+            "Expected backend are one of ['pil', 'cv2'], but got {}"
             .format(backend))
     _image_backend = backend
 

--- a/python/paddle/vision/utils.py
+++ b/python/paddle/vision/utils.py
@@ -1,0 +1,103 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+__all__ = ['set_image_backend', 'get_image_backend']
+
+_image_backend = 'pil'
+
+
+def set_image_backend(backend):
+    """
+    Specifies the backend used to load images in class ``paddle.vision.datasets.ImageFolder`` 
+    and ``paddle.vision.datasets.DatasetFolder`` . Now support backends are pillow and opencv. 
+    If backend not set, will use 'pil' as default. 
+
+    Args:
+        backend (str): Name of the image load backend, should be one of {'pil', 'cv2'}.
+
+    Examples:
+    
+        .. code-block:: python
+
+            import os
+            import cv2
+            import shutil
+            import tempfile
+            import numpy as np
+
+            from paddle.vision import DatasetFolder
+            from paddle.vision import set_image_backend
+
+            set_image_backend('cv2')
+
+            def make_fake_dir():
+                data_dir = tempfile.mkdtemp()
+
+                for i in range(2):
+                    sub_dir = os.path.join(data_dir, 'class_' + str(i))
+                    if not os.path.exists(sub_dir):
+                        os.makedirs(sub_dir)
+                    for j in range(2):
+                        fake_img = (np.random.random((32, 32, 3)) * 255).astype('uint8')
+                        cv2.imwrite(os.path.join(sub_dir, str(j) + '.jpg'), fake_img)
+                return data_dir
+
+            temp_dir = make_fake_dir()
+
+            cv2_data_folder = DatasetFolder(temp_dir)
+
+            for items in cv2_data_folder:
+                break
+
+            # should get numpy.ndarray
+            print(type(items[0]))
+
+            set_image_backend('pil')
+
+            pil_data_folder = DatasetFolder(temp_dir)
+
+            for items in pil_data_folder:
+                break
+
+            # should get PIL.Image.Image
+            print(type(items[0]))
+
+            shutil.rmtree(temp_dir)
+    """
+    global _image_backend
+    if backend not in ['pil', 'cv2']:
+        raise ValueError(
+            "Expected backend are one of {'pil', 'cv2'}, but got {}"
+            .format(backend))
+    _image_backend = backend
+
+
+def get_image_backend():
+    """
+    Gets the name of the package used to load images
+
+    Returns:
+        str: backend of image load.
+
+    Examples:
+    
+        .. code-block:: python
+
+            from paddle.vision import get_image_backend
+
+            backend = get_image_backend()
+            print(backend)
+
+    """
+    return _image_backend

--- a/python/paddle/vision/utils.py
+++ b/python/paddle/vision/utils.py
@@ -12,7 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ['set_image_backend', 'get_image_backend']
+from PIL import Image
+from paddle.utils import try_import
+
+__all__ = ['set_image_backend', 'get_image_backend', 'image_load']
 
 _image_backend = 'pil'
 
@@ -102,3 +105,57 @@ def get_image_backend():
 
     """
     return _image_backend
+
+
+def image_load(path, backend=None):
+    """Load an image.
+
+    Args:
+        path (str): Path of the image.
+        backend (str, optional): The image decoding backend type. Options are
+            `cv2`, `pil`, `None`. If backend is None, the global _imread_backend 
+            specified by ``paddle.vision.set_image_backend`` will be used. Default: None.
+
+    Returns:
+        PIL.Image or np.array: Loaded image.
+
+    Examples:
+    
+        .. code-block:: python
+
+            from PIL import Image
+            from paddle.vision import image_load, set_image_backend
+
+            fake_img = Image.fromarray((np.random.random((32, 32, 3)) * 255).astype('uint8'))
+
+            path = 'temp.png'
+            fake_img.save(path)
+
+            set_image_backend('pil')
+            
+            pil_img = image_load(path).convert('RGB')
+
+            # should be PIL.Image.Image
+            print(type(pil_img))
+
+            # use opencv as backend
+            # set_image_backend('cv2')
+
+            # np_img = image_load(path)
+            # # should get numpy.ndarray
+            # print(type(np_img))
+    
+    """
+
+    if backend is None:
+        backend = _image_backend
+    if backend not in ['pil', 'cv2']:
+        raise ValueError(
+            "Expected backend are one of ['pil', 'cv2'], but got {}"
+            .format(backend))
+
+    if backend == 'pil':
+        return Image.open(path)
+    else:
+        cv2 = try_import('cv2')
+        return cv2.imread(path)

--- a/python/paddle/vision/utils.py
+++ b/python/paddle/vision/utils.py
@@ -31,7 +31,6 @@ def set_image_backend(backend):
         .. code-block:: python
 
             import os
-            import cv2
             import shutil
             import tempfile
             import numpy as np
@@ -39,7 +38,7 @@ def set_image_backend(backend):
             from paddle.vision import DatasetFolder
             from paddle.vision import set_image_backend
 
-            set_image_backend('cv2')
+            set_image_backend('pil')
 
             def make_fake_dir():
                 data_dir = tempfile.mkdtemp()
@@ -55,16 +54,6 @@ def set_image_backend(backend):
 
             temp_dir = make_fake_dir()
 
-            cv2_data_folder = DatasetFolder(temp_dir)
-
-            for items in cv2_data_folder:
-                break
-
-            # should get numpy.ndarray
-            print(type(items[0]))
-
-            set_image_backend('pil')
-
             pil_data_folder = DatasetFolder(temp_dir)
 
             for items in pil_data_folder:
@@ -72,6 +61,17 @@ def set_image_backend(backend):
 
             # should get PIL.Image.Image
             print(type(items[0]))
+
+            # use opencv as backend
+            # set_image_backend('cv2')
+    
+            # cv2_data_folder = DatasetFolder(temp_dir)
+
+            # for items in cv2_data_folder:
+            #     break
+
+            # should get numpy.ndarray
+            # print(type(items[0]))
 
             shutil.rmtree(temp_dir)
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. 添加了pil处理图片的后端
2. 添加了参数keys，便于后续将这些算子扩展到其余组件

文档地址：http://gzhxy-inf-bce36a39de.gzhxy.baidu.com:8121/documentation/docs/en/api/paddle/vision/BaseTransform_en.html

![image](https://user-images.githubusercontent.com/50691816/96461076-87d06100-1256-11eb-9974-04441592c9bb.png)
