### PR TITLE
fill_constant op supports NaN and Inf

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -330,6 +330,16 @@ class TestFillConstantImperative(unittest.TestCase):
                 res4.numpy(), np.full(
                     [1, 2], 88, dtype="int32"))
 
+    def test_nan(self):
+        with fluid.dygraph.guard():
+            res = fluid.layers.fill_constant([1], 'float32', np.nan)
+            self.assertTrue(np.isnan(res.numpy().item(0)))
+
+    def test_inf(self):
+        with fluid.dygraph.guard():
+            res = fluid.layers.fill_constant([1], 'float32', np.inf)
+            self.assertTrue(np.isinf(res.numpy().item(0)))
+
 
 class TestFillConstantOpError(unittest.TestCase):
     def test_errors(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fill_constant op supports NaN and Inf

For example,
```
import paddle
import numpy as np
print(paddle.fluid.layers.fill_constant([1], 'float32', np.nan))
print(paddle.fluid.layers.fill_constant([1], 'float32', np.inf))
```

- before
```
Tensor(shape=[1], dtype=float32, place=CPUPlace, stop_gradient=True,
       [0.])
Tensor(shape=[1], dtype=float32, place=CPUPlace, stop_gradient=True,
       [0.])
```
- after
```
Tensor(shape=[1], dtype=float32, place=CPUPlace, stop_gradient=True,
       [nan.])
Tensor(shape=[1], dtype=float32, place=CPUPlace, stop_gradient=True,
       [inf.])
```
