### PR TITLE
Try to fix random failure of test_buffer_shared_memory_resue_pass by setting fixed numpy seed

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_buffer_shared_memory_reuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_buffer_shared_memory_reuse_pass.py
@@ -23,6 +23,8 @@ import os
 
 batch_size = 32
 
+np.random.seed(10)
+
 feed_dict = {
     'image': np.random.random([batch_size, 784]).astype('float32'),
     'label': np.random.random_integers(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Try to fix random failure of test_buffer_shared_memory_resue_pass by setting fixed numpy seed.