### PR TITLE
refine the gpu config for temporal_shift_op

### DIFF
--- a/paddle/fluid/operators/temporal_shift_op.cu
+++ b/paddle/fluid/operators/temporal_shift_op.cu
@@ -11,6 +11,7 @@
 
 #include "paddle/fluid/operators/temporal_shift_op.h"
 #include "paddle/fluid/platform/cuda_primitives.h"
+#include "paddle/fluid/platform/gpu_launch_config.h"
 
 namespace paddle {
 namespace operators {
@@ -112,11 +113,11 @@ class TemporalShiftOpCUDAKernel : public framework::OpKernel<T> {
     T* output_data = output->mutable_data<T>({nt, c, h, w}, ctx.GetPlace());
 
     int pixelNum = nt * chw;
-    int grid_dim = (pixelNum + 512 - 1) / 512;
-    grid_dim = grid_dim > 8 ? 8 : grid_dim;
+    platform::GpuLaunchConfig config =
+        platform::GetGpuLaunchConfig1D(ctx.cuda_device_context(), pixelNum);
 
-    KeTemporalShiftFw<
-        T><<<grid_dim, 512, 0, ctx.cuda_device_context().stream()>>>(
+    KeTemporalShiftFw<T><<<config.block_per_grid, config.thread_per_block, 0,
+                           ctx.cuda_device_context().stream()>>>(
         input_data, output_data, ntchw, tchw, chw, hw, w, t, c, shift_ratio);
   }
 };
@@ -148,11 +149,11 @@ class TemporalShiftGradOpCUDAKernel : public framework::OpKernel<T> {
         static_cast<T>(0));
 
     int pixelNum = nt * chw;
-    int grid_dim = (pixelNum + 512 - 1) / 512;
-    grid_dim = grid_dim > 8 ? 8 : grid_dim;
+    platform::GpuLaunchConfig config =
+        platform::GetGpuLaunchConfig1D(ctx.cuda_device_context(), pixelNum);
 
-    KeTemporalShiftBw<
-        T><<<grid_dim, 512, 0, ctx.cuda_device_context().stream()>>>(
+    KeTemporalShiftBw<T><<<config.block_per_grid, config.thread_per_block, 0,
+                           ctx.cuda_device_context().stream()>>>(
         output_grad_data, input_grad_data, ntchw, tchw, chw, hw, w, t, c,
         shift_ratio);
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
主要修改： 修改了grid size最大值的设置，原本develop中的grid size最大值为8，并行block数目太少.


V100 testing data using nvprof to get gpu kernel time
[benchmark script](https://github.com/PaddlePaddle/benchmark/blob/master/api/tests_v2/temporal_shift.py)

develop
| 输入(x_shape) | FW Kernel average |BW Kernel average| 
|---|---|---|
| [32, 64, 24, 42] | 398.74us | 338.85us|
| [128, 64, 24, 24] | 905.79us |778.21us| 


this PR
| 输入(x_shape) | FW Kernel average |BW Kernel average| 
|---|---|---|
| [32, 64, 24, 42] | 33.294us | 30.625us|
| [128, 64, 24, 24] | 70.578us |66.002us| 


tsm model:
```
python -u train.py --use_data_parallel=False --epoch 1 --batch_size=16 --config=./tsm_ucf101_sing.yaml --pretrain=./ResNet50_pretrained --weights=k400_wei/TSM.pdparams
```
develop batch_cost: 0.419
this pr batch_cost: 0.296
performance improvement: 29%

