### PR TITLE
disable the ut test_dist_mnist_hallreduce temporarily

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -427,6 +427,9 @@ if(WITH_DISTRIBUTE)
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_transformer")
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_transpiler")
 
+    # TODO(sandyhouse): fix and add the ut back
+    list(REMOVE_ITEM DIST_TEST_OPS "test_dist_mnist_hallreduce")
+
     #not need
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_base")
     list(REMOVE_ITEM DIST_TEST_OPS "test_dist_fleet_base")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
临时禁用单测test_dist_mnist_hallreduce
原因是CI系统机器只有2块GPU卡，而该单测创建的nccl rank数为4（4个进程），因此会出现单张GPU卡上存在多个rank的情况。但高版本nccl不支持这一情况： [Using the same CUDA device multiple times as different ranks of the same NCCL communicator is not supported and may lead to hangs.](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/communicators.html)

升级ci docker镜像的pr：#27589