### PR TITLE
[cherry-pick] fix dynamic decode imperative

### DIFF
--- a/python/paddle/fluid/layers/rnn.py
+++ b/python/paddle/fluid/layers/rnn.py
@@ -1395,7 +1395,7 @@ def _dynamic_decode_imperative(decoder,
         control_flow.increment(x=step_idx_tensor, value=1.0, in_place=True)
         step_idx += 1
 
-        control_flow.logical_not(nn.reduce_all(finished), cond)
+        cond = control_flow.logical_not(nn.reduce_all(finished))
         if max_step_num is not None and step_idx > max_step_num:
             break
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
cherry-pick #28160 
The parameter out for `logical_not` won't used in imperative mode, which leads to dynamic_decode cannot stop expectedly. This PR fix this by directly returning the cond.