### PR TITLE
【cherry-pick 2.0rc】dygraph nccl init support host domain name

### DIFF
--- a/paddle/fluid/imperative/nccl_context.cc
+++ b/paddle/fluid/imperative/nccl_context.cc
@@ -100,7 +100,19 @@ void NCCLParallelContext::SendNCCLID(const std::string &ep,
   serv_addr.sin_family = AF_INET;
   serv_addr.sin_port = htons(port);
 
-  if (inet_pton(AF_INET, host.c_str(), &serv_addr.sin_addr) <= 0) {
+  char *ip = NULL;
+  struct hostent *hp;
+  if ((hp = gethostbyname(host.c_str())) == NULL) {
+    PADDLE_THROW(platform::errors::InvalidArgument(
+        "Fail to get host by name %s.", host));
+  }
+  int i = 0;
+  while (hp->h_addr_list[i] != NULL) {
+    ip = inet_ntoa(*(struct in_addr *)hp->h_addr_list[i]);
+    VLOG(3) << "gethostbyname  host:" << host << "  ->ip: " << ip;
+    break;
+  }
+  if (inet_pton(AF_INET, ip, &serv_addr.sin_addr) <= 0) {
     PADDLE_THROW(platform::errors::Unavailable("Open address %s failed.", ep));
   }
 

--- a/paddle/fluid/imperative/nccl_context.h
+++ b/paddle/fluid/imperative/nccl_context.h
@@ -16,6 +16,7 @@
 // network header files
 #if defined(PADDLE_WITH_CUDA) && !defined(_WIN32)
 #include <arpa/inet.h>
+#include <netdb.h>
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <sys/socket.h>

--- a/paddle/fluid/imperative/tests/nccl_context_test.cc
+++ b/paddle/fluid/imperative/tests/nccl_context_test.cc
@@ -20,7 +20,7 @@ namespace imperative = paddle::imperative;
 namespace platform = paddle::platform;
 
 imperative::ParallelStrategy GetStrategy(int local_rank) {
-  std::vector<std::string> eps = {"127.0.0.1:9866", "127.0.0.1:9867"};
+  std::vector<std::string> eps = {"127.0.0.1:9866", "localhost:9867"};
   imperative::ParallelStrategy strategy;
   strategy.trainer_endpoints_ = eps;
   strategy.current_endpoint_ = eps[local_rank];


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
cherry pick :   https://github.com/PaddlePaddle/Paddle/pull/28107

目前动态图nccl初始化时由于`inet_pton`函数只支持传入具体的ip地址，不支持传入域名，因此跑多机动态图任务（paddlecloud上）时程序会挂掉
```
if (inet_pton(AF_INET, ip, &serv_addr.sin_addr) <= 0) {
    PADDLE_THROW(platform::errors::Unavailable("Open address %s failed.", ep));
  }
```
解决方法：
在函数`inet_pton`前通过`gethostbyname`函数做解析

在paddlecloud上验证通过：
```
I1019 19:28:28.448112  1570 nccl_context.cc:105] nccl_context host: job-0bb5f8d7770b19f0-trainer-0.a5139f34-68ad-5528-8bb7-a906d3bfbf7b
I1019 19:28:28.453824  1570 nccl_context.cc:114] nccl_context host->ip: 10.127.31.20
...
I1019 19:28:28.453972  1570 nccl_context.cc:105] nccl_context host: job-0bb5f8d7770b19f0-trainer-1.a5139f34-68ad-5528-8bb7-a906d3bfbf7b
I1019 19:28:28.470842  1570 nccl_context.cc:114] nccl_context host->ip: 10.127.19.141
....
```