### PR TITLE
fix test_weight_decay_extend unittest error

### DIFF
--- a/python/paddle/fluid/contrib/tests/test_weight_decay_extend.py
+++ b/python/paddle/fluid/contrib/tests/test_weight_decay_extend.py
@@ -149,16 +149,19 @@ class TestWeightDecay(unittest.TestCase):
 
             avg_cost = model(data, label, self.word_dict_len)
 
+            optimizer = fluid.optimizer.Adam(learning_rate=self.learning_rate)
+
+            params_grads = optimizer.backward(avg_cost)
+
             param_list = [(var, var * self.learning_rate)
                           for var in main_prog.block(0).all_parameters()]
 
-            optimizer = fluid.optimizer.Adam(learning_rate=self.learning_rate)
-
-            optimizer.minimize(avg_cost)
             for params in param_list:
                 updated_p = fluid.layers.elementwise_sub(
                     x=params[0], y=params[1])
                 fluid.layers.assign(input=updated_p, output=params[0])
+
+            optimizer.apply_optimize(avg_cost, startup_prog, params_grads)
 
             param_sum = self.run_program(place, [data, label])
         return param_sum


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

fix test_weight_decay_extend unittest error

原因：单测逻辑是错的，两个对比的program结构是不一样的，之前能过，是因为误差较小偶然通过了，这里将逻辑改为等价的、正确的