### PR TITLE
fix strided_slice_op's GetExpectedKernelType 

### DIFF
--- a/paddle/fluid/operators/strided_slice_op.cc
+++ b/paddle/fluid/operators/strided_slice_op.cc
@@ -154,9 +154,14 @@ class StridedSliceOp : public framework::OperatorWithKernel {
  protected:
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
+    // NOTE: cuda pinned tensor need to copy its data to target place
+    auto in_tensor = ctx.Input<Tensor>("Input");
+    if (platform::is_cuda_pinned_place(in_tensor->place())) {
+      return framework::OpKernelType(in_tensor->type(), ctx.device_context());
+    }
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "Input"),
-        ctx.Input<Tensor>("Input")->place());
+        in_tensor->place());
   }
   framework::OpKernelType GetKernelTypeForVar(
       const std::string &var_name, const Tensor &tensor,

--- a/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
@@ -511,6 +511,15 @@ class TestStridedSliceAPI(unittest.TestCase):
             x, axes=axes, starts=starts, ends=ends, strides=strides_1)
         assert sliced_1.shape == (3, 2, 2, 2)
 
+    def test_cuda_pinned_place(self):
+        with paddle.fluid.dygraph.guard():
+            x = paddle.to_tensor(
+                np.random.randn(2, 10), place=paddle.CUDAPinnedPlace())
+            self.assertTrue(x.place.is_cuda_pinned_place())
+            y = x[:, ::2]
+            self.assertFalse(x.place.is_cuda_pinned_place())
+            self.assertFalse(y.place.is_cuda_pinned_place())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
+++ b/python/paddle/fluid/tests/unittests/test_strided_slice_op.py
@@ -511,6 +511,8 @@ class TestStridedSliceAPI(unittest.TestCase):
             x, axes=axes, starts=starts, ends=ends, strides=strides_1)
         assert sliced_1.shape == (3, 2, 2, 2)
 
+    @unittest.skipIf(not paddle.is_compiled_with_cuda(),
+                     "Cannot use CUDAPinnedPlace in CPU only version")
     def test_cuda_pinned_place(self):
         with paddle.fluid.dygraph.guard():
             x = paddle.to_tensor(


### PR DESCRIPTION

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
fix strided_slice_op's GetExpectedKernelType when input tensor is at CUDAPinnedPlace

A algebric operator generally choose a kernel by the following way:

1. choose dtype from a primary input tensor;
2. choose the execution context's place.

But some operators choose the input tensor's place for some reason. But this behavior could be problematic. When the input tensor's place is CUDAPinnedPlace, the op could not choose a valid kernel, since most ops do not have a kernel for CUDAPinnedPlace. (CUDAPinnedPlace is used for fast copying data from CPU to  GPU, not for computation.)

So for these ops, a proper behavior is to choose the execution context's place when the input tensor is in CUDAPinnedPlace.