### PR TITLE
remove std::move

### DIFF
--- a/paddle/fluid/string/string_helper.h
+++ b/paddle/fluid/string/string_helper.h
@@ -52,7 +52,7 @@ template <class... ARGS>
 std::string format_string(const char* fmt, ARGS&&... args) {
   std::string str;
   format_string_append(str, fmt, args...);
-  return std::move(str);
+  return str;
 }
 
 template <class... ARGS>


### PR DESCRIPTION
 error: moving a local object in a return statement prevents copy elision [-Werror=pessimizing-move]
   55 |   return std::move(str);