### PR TITLE
[Dy2Stat-log]Call warnings.warn() to display the warn-message only once

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -20,6 +20,7 @@ import inspect
 import six
 import textwrap
 import threading
+import warnings
 import weakref
 
 from paddle.fluid import framework
@@ -298,7 +299,11 @@ class StaticFunction(object):
 
         # 1. call dygraph function directly if not enable `declarative`
         if not self._program_trans.enable_to_static:
-            logging_utils.warn(
+            # NOTE(liym27):
+            # Here calls `warnings.warn` but not `logging_utils.warn` because by default warnings.warn(message)
+            # will show up **only once**. StaticFunction.__call__ will run many times, it is appropriate to
+            # display this warning message only once.
+            warnings.warn(
                 "The decorator '@paddle.jit.to_static' does NOT work when setting ProgramTranslator.enable to False. "
                 "We will just return dygraph output. If you would like to get static graph output, please call API "
                 "ProgramTranslator.enable(True)")
@@ -831,7 +836,9 @@ class ProgramTranslator(object):
         ), "Input dygraph_func is not a callable in ProgramTranslator.get_output"
 
         if not self.enable_to_static:
-            logging_utils.warn(
+            # Here calls `warnings.warn` but not `logging_utils.warn` because by default warnings.warn(message)
+            # will show up **only once**.
+            warnings.warn(
                 "The ProgramTranslator.get_output doesn't work when setting ProgramTranslator.enable to False. "
                 "We will just return dygraph output. "
                 "Please call ProgramTranslator.enable(True) if you would like to get static output."


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Call `warnings.warn` but not `logging_utils.warn` because by default warnings.warn(message) will show up **only once**. `StaticFunction.__call__` will run many times, it is appropriate to display the warning  message in `StaticFunction.__call__` only once.

Reference: https://docs.python.org/3.7/library/warnings.html#warnings.warn