### PR TITLE
Update pybind version to adopt CINN

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -17,7 +17,7 @@ include(ExternalProject)
 set(PYBIND_PREFIX_DIR     ${THIRD_PARTY_PATH}/pybind)
 set(PYBIND_SOURCE_DIR     ${THIRD_PARTY_PATH}/pybind/src/extern_pybind)
 SET(PYBIND_REPOSITORY     ${GIT_URL}/pybind/pybind11.git)
-SET(PYBIND_TAG            v2.2.4)
+SET(PYBIND_TAG            v2.4.0)
 
 cache_third_party(extern_pybind
     REPOSITORY    ${PYBIND_REPOSITORY}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Update pybind version to 2.4.0 in order to adopt CINN
fix bugs in CINN paddle co-development:
```
72: Traceback (most recent call last):
72:   File "/cinn_paddle_v2/CINN/python/tests/test_efficientnet.py", line 4, in <module>
72:     from cinn.frontend import *
72:   File "/cinn_paddle_v2/CINN/build/python/cinn/__init__.py", line 1, in <module>
72:     from .core_api.common import Type
72: ImportError: /cinn_paddle_v2/CINN/build/python/cinn/core_api.so: undefined symbol: PyThread_tss_alloc
```