### PR TITLE
update matrix nms op to api 2.0

### DIFF
--- a/paddle/fluid/operators/detection/matrix_nms_op.cc
+++ b/paddle/fluid/operators/detection/matrix_nms_op.cc
@@ -385,7 +385,7 @@ independently for each class. The outputs is a 2-D LoDTenosr, for each
 image, the offsets in first dimension of LoDTensor are called LoD, the number
 of offset is N + 1, where N is the batch size. If LoD[i + 1] - LoD[i] == 0,
 means there is no detected bbox for this image. Now this operator has one more
-ouput, which is RoisNum. The size if RoisNum is N, RoisNum[i] means the number of 
+ouput, which is RoisNum. The size of RoisNum is N, RoisNum[i] means the number of 
 detected bbox for this image.
 
 For more information on Matrix NMS, please refer to:

--- a/paddle/fluid/operators/detection/matrix_nms_op.cc
+++ b/paddle/fluid/operators/detection/matrix_nms_op.cc
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/detection/nms_util.h"
 
 namespace paddle {
@@ -59,6 +60,9 @@ class MatrixNMSOp : public framework::OperatorWithKernel {
     }
     ctx->SetOutputDim("Out", {box_dims[1], box_dims[2] + 2});
     ctx->SetOutputDim("Index", {box_dims[1], 1});
+    if (ctx->HasOutput("RoisNum")) {
+      ctx->SetOutputDim("RoisNum", {-1});
+    }
     if (!ctx->IsRuntime()) {
       ctx->SetLoDLevel("Out", std::max(ctx->GetLoDLevel("BBoxes"), 1));
       ctx->SetLoDLevel("Index", std::max(ctx->GetLoDLevel("BBoxes"), 1));
@@ -259,8 +263,10 @@ class MatrixNMSKernel : public framework::OpKernel<T> {
     std::vector<size_t> offsets = {0};
     std::vector<T> detections;
     std::vector<int> indices;
+    std::vector<int> num_per_batch;
     detections.reserve(out_dim * num_boxes * batch_size);
     indices.reserve(num_boxes * batch_size);
+    num_per_batch.reserve(batch_size);
     for (int i = 0; i < batch_size; ++i) {
       scores_slice = scores->Slice(i, i + 1);
       scores_slice.Resize({score_dims[1], score_dims[2]});
@@ -272,6 +278,7 @@ class MatrixNMSKernel : public framework::OpKernel<T> {
           background_label, nms_top_k, keep_top_k, normalized, score_threshold,
           post_threshold, use_gaussian, gaussian_sigma);
       offsets.push_back(offsets.back() + num_out);
+      num_per_batch.emplace_back(num_out);
     }
 
     int64_t num_kept = offsets.back();
@@ -285,6 +292,12 @@ class MatrixNMSKernel : public framework::OpKernel<T> {
       std::copy(indices.begin(), indices.end(), index->data<int>());
     }
 
+    if (ctx.HasOutput("RoisNum")) {
+      auto* rois_num = ctx.Output<Tensor>("RoisNum");
+      rois_num->mutable_data<int>({batch_size}, ctx.GetPlace());
+      std::copy(num_per_batch.begin(), num_per_batch.end(),
+                rois_num->data<int>());
+    }
     framework::LoD lod;
     lod.emplace_back(offsets);
     outs->set_lod(lod);
@@ -355,6 +368,8 @@ class MatrixNMSOpMaker : public framework::OpProtoAndCheckerMaker {
               "(LoDTensor) A 2-D LoDTensor with shape [No, 1] represents the "
               "index of selected bbox. The index is the absolute index cross "
               "batches.");
+    AddOutput("RoisNum", "(Tensor), Number of RoIs in each images.")
+        .AsDispensable();
     AddComment(R"DOC(
 This operator does multi-class matrix non maximum suppression (NMS) on batched
 boxes and scores.
@@ -369,7 +384,9 @@ This operator support multi-class and batched inputs. It applying NMS
 independently for each class. The outputs is a 2-D LoDTenosr, for each
 image, the offsets in first dimension of LoDTensor are called LoD, the number
 of offset is N + 1, where N is the batch size. If LoD[i + 1] - LoD[i] == 0,
-means there is no detected bbox for this image.
+means there is no detected bbox for this image. Now this operator has one more
+ouput, which is RoisNum. The size if RoisNum is N, RoisNum[i] means the number of 
+detected bbox for this image.
 
 For more information on Matrix NMS, please refer to:
 https://arxiv.org/abs/2003.10152
@@ -387,3 +404,8 @@ REGISTER_OPERATOR(
     paddle::framework::EmptyGradOpMaker<paddle::imperative::OpBase>);
 REGISTER_OP_CPU_KERNEL(matrix_nms, ops::MatrixNMSKernel<float>,
                        ops::MatrixNMSKernel<double>);
+REGISTER_OP_VERSION(matrix_nms)
+    .AddCheckpoint(
+        R"ROC(Upgrade matrix_nms: add a new output [RoisNum].)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewOutput(
+            "RoisNum", "The number of RoIs in each image."));

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -74,6 +74,7 @@ std::map<std::string, std::set<std::string>> op_outs_map = {
     {"unique", {"Out", "Index", "Indices", "Counts"}},
     {"generate_proposals", {"RpnRois", "RpnRoiProbs", "RpnRoisNum"}},
     {"collect_fpn_proposals", {"FpnRois", "RoisNum"}},
+    {"matrix_nms", {"Out", "Index", "RoisNum"}},
     {"distribute_fpn_proposals",
      {"MultiFpnRois", "RestoreIndex", "MultiLevelRoIsNum"}},
     {"moving_average_abs_max_scale", {"OutScale", "OutAccum", "OutState"}},

--- a/python/paddle/fluid/tests/unittests/test_matrix_nms_op.py
+++ b/python/paddle/fluid/tests/unittests/test_matrix_nms_op.py
@@ -201,7 +201,8 @@ class TestMatrixNMSOp(OpTest):
         self.inputs = {'BBoxes': boxes, 'Scores': scores}
         self.outputs = {
             'Out': (nmsed_outs, [lod]),
-            'Index': (index_outs[:, None], [lod])
+            'Index': (index_outs[:, None], [lod]),
+            'RoisNum': np.array(lod).astype('int32')
         }
         self.attrs = {
             'background_label': 0,


### PR DESCRIPTION
### PR types 
Function optimization

### PR changes
OPs

### Describe
Update matrix nms to be suitable for dygraph. Add RoisNum for output  which is dispensable and compatible with inference of previous Paddle version. The new output is only used in dygraph detection models. 
The test result on ppyolo shows that the latest paddle version could use the inference model from previous paddle version correctly.

预测兼容性测试：

测试方法：
在PaddleDetection中使用 [export_model.py](https://github.com/PaddlePaddle/PaddleDetection/blob/release/0.4/tools/export_model.py)  导出模型，使用[deploy/python/infer.py](https://github.com/PaddlePaddle/PaddleDetection/blob/release/0.4/deploy/python/infer.py)进行预测，对比检测结果。测试模型为[ppyolo](https://github.com/PaddlePaddle/PaddleDetection/blob/release/0.4/configs/ppyolo/ppyolo.yml) ，其中包含了改动的OP。

case1：
使用paddle1.8.4版本保存模型，在1.8.4版本和develop版本分别预测
1.8.4版本预测结果：
![image](https://user-images.githubusercontent.com/69842442/97267554-4d258480-1865-11eb-9abf-1dbce0458eb1.png)
develop版本预测结果：
![image](https://user-images.githubusercontent.com/69842442/97267179-b1941400-1864-11eb-9887-d240041f325c.png)

case2:
使用develop版本保存模型，在1.8.4版本和develop版本分别预测
1.8.4版本预测结果：
![image](https://user-images.githubusercontent.com/69842442/97267486-33843d00-1865-11eb-85e2-2c1c8c00ae0d.png)
develop版本预测结果：
![image](https://user-images.githubusercontent.com/69842442/97266881-33d00880-1864-11eb-82af-198ac172976c.png)
测试结论：
新增输出是兼容老版本的