### PR TITLE
fill_constant op supports NINF

### DIFF
--- a/paddle/fluid/operators/fill_constant_op.h
+++ b/paddle/fluid/operators/fill_constant_op.h
@@ -50,6 +50,8 @@ class FillConstantKernel : public framework::OpKernel<T> {
       // handle NaN/Inf first, which cannot be read from stream.
       if (str_value == "inf") {
         value = static_cast<T>(std::numeric_limits<double>::infinity());
+      } else if (str_value == "-inf") {
+        value = static_cast<T>(-std::numeric_limits<double>::infinity());
       } else if (str_value == "nan") {
         value = static_cast<T>(std::numeric_limits<double>::quiet_NaN());
       } else {

--- a/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fill_constant_op.py
@@ -340,6 +340,12 @@ class TestFillConstantImperative(unittest.TestCase):
             res = fluid.layers.fill_constant([1], 'float32', np.inf)
             self.assertTrue(np.isinf(res.numpy().item(0)))
 
+    def test_ninf(self):
+        with fluid.dygraph.guard():
+            res = fluid.layers.fill_constant([1], 'float32', np.NINF)
+            self.assertTrue(np.isinf(res.numpy().item(0)))
+            self.assertEqual(np.NINF, res.numpy().item(0))
+
 
 class TestFillConstantOpError(unittest.TestCase):
     def test_errors(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fill_constant op supports NINF, related https://github.com/PaddlePaddle/Paddle/pull/28109