### PR TITLE
Set static shape for shape tensor with constant [part 1]

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -15100,6 +15100,7 @@ def uniform_random(shape, dtype='float32', min=-1.0, max=1.0, seed=0,
     helper.append_op(
         type="uniform_random", inputs=inputs, attrs=attrs,
         outputs={"Out": out})
+    utils.try_set_static_shape_tensor(out, shape)
     return out
 
 

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -398,8 +398,8 @@ def try_set_static_shape_tensor(tensor, shape):
         if -1 in tensor.shape:
             if isinstance(shape, Variable):
                 shape = try_get_constant_shape_from_tensor(shape)
-                print('shape', shape)
-                tensor.desc.set_shape(shape)
+                if shape:
+                    tensor.desc.set_shape(shape)
 
 
 def try_get_constant_shape_from_tensor(shape_tensor):
@@ -417,16 +417,15 @@ def try_get_constant_shape_from_tensor(shape_tensor):
     
     """
     if in_dygraph_mode():
-        return shape_tensor.shape
+        return shape_tensor.numpy().to_list()
 
     try:
         if shape_tensor.op is not None:
             generate_op = shape_tensor.op
             if generate_op.type == 'shape':
-                print(generate_op.input_names[0])
                 var = shape_tensor.block.vars[generate_op.input_arg_names[0]]
                 return var.shape
     except:
-        return shape_tensor.shape
+        return None
 
-    return shape_tensor.shape
+    return None

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -416,16 +416,15 @@ def try_get_constant_shape_from_tensor(shape_tensor):
     # (-1, 2)
     
     """
-    if in_dygraph_mode():
-        return shape_tensor.numpy().tolist()
+    if not in_dygraph_mode():
+        try:
+            if shape_tensor.op is not None:
+                generate_op = shape_tensor.op
+                if generate_op.type == 'shape':
+                    var = shape_tensor.block.vars[generate_op.input_arg_names[
+                        0]]
+                    return var.shape
+        except:
+            return None
 
-    try:
-        if shape_tensor.op is not None:
-            generate_op = shape_tensor.op
-            if generate_op.type == 'shape':
-                var = shape_tensor.block.vars[generate_op.input_arg_names[0]]
-                return var.shape
-    except:
         return None
-
-    return None

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -387,11 +387,12 @@ def try_set_static_shape_tensor(tensor, shape):
 
     import paddle
     paddle.enable_static()
-    data = paddle.fluid.layers.data(name="x", shape=[-1, 2], dtype='float32')
-    shape = paddle.fluid.layers.shape(data)  # shape should be [-1, 2]
-    x = paddle.fluid.layers.uniform_random(shape) 
+    data = paddle.static.data(name="x", shape=[-1, 2], dtype='float32')
+    shape = paddle.shape(data)  # shape should be [-1, 2] instead of [-1, -1]
+    x = paddle.uniform(shape) 
     print(x.shape) 
     # (-1, 2)
+    
     """
     if not in_dygraph_mode():
         # static mode, and shape is not all inferred (contains -1)
@@ -409,9 +410,9 @@ def try_get_constant_shape_from_tensor(shape_tensor):
     
     import paddle
     paddle.enable_static()
-    data = paddle.fluid.layers.data(name="x", shape=[-1, 2], dtype='float32')
-    shape = paddle.fluid.layers.shape(data)  # shape should be [-1, 2]
-    x = paddle.fluid.layers.uniform_random(shape) 
+    data = paddle.static.data(name="x", shape=[-1, 2], dtype='float32')
+    shape = paddle.shape(data)  # shape should be [-1, 2] instead of [-1, -1]
+    x = paddle.uniform(shape) 
     print(x.shape) 
     # (-1, 2)
     

--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -417,7 +417,7 @@ def try_get_constant_shape_from_tensor(shape_tensor):
     
     """
     if in_dygraph_mode():
-        return shape_tensor.numpy().to_list()
+        return shape_tensor.numpy().tolist()
 
     try:
         if shape_tensor.op is not None:

--- a/python/paddle/fluid/tests/unittests/test_static_shape_inferrence_for_shape_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_static_shape_inferrence_for_shape_tensor.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import paddle
+import unittest
+
+
+class StaticShapeInferrenceTest(unittest.TestCase):
+    def test_check_output(self):
+        paddle.enable_static()
+        data = paddle.fluid.layers.data(
+            name="x", shape=[-1, 2], dtype='float32')
+        shape = paddle.fluid.layers.shape(data)  # shape should be [-1, 2]
+        x = paddle.fluid.layers.uniform_random(shape)
+        self.assertEqual(x.shape, data.shape)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_static_shape_inferrence_for_shape_tensor.py
+++ b/python/paddle/fluid/tests/unittests/test_static_shape_inferrence_for_shape_tensor.py
@@ -17,13 +17,14 @@ import unittest
 
 
 class StaticShapeInferrenceTest(unittest.TestCase):
-    def test_check_output(self):
+    def test_static_graph(self):
         paddle.enable_static()
         data = paddle.fluid.layers.data(
             name="x", shape=[-1, 2], dtype='float32')
         shape = paddle.fluid.layers.shape(data)  # shape should be [-1, 2]
         x = paddle.fluid.layers.uniform_random(shape)
         self.assertEqual(x.shape, data.shape)
+        paddle.disable_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Set static shape for shape tensor with constant

### Why
Sometimes, the shape cannot be fully inferred in the c++ side. 

For example, consider the following code,
```
    import paddle
    paddle.enable_static()
    data = paddle.static.data(name="x", shape=[-1, 2], dtype='float32')
    shape = paddle.shape(data)  # shape should be [-1, 2] instead of [-1, -1]
    x = paddle.uniform(shape) 
    print(x.shape) 
    # (-1, -1)
    out = paddle.static.fc(x, 10)
    # Error, since the shape of weight of fc will be (-1, 10), which is wrong. 
```
Since the given shape of `uniform_random` is got by `layers.shape`, it is a Variable(Tensor) indeed, which is not initialized at compile time. So we cannot infer the right shape for `uniform_random`.

### How
However, in the above case, we know that the shape of `data` is (-1, 2) where `-1` is used for batch size. So the shape of `x` is exactly the same as `data`, which is (-1, 2).

The shape information is actually at the python side, and we can infer it by `looking forward`. 

It means that if the shape tensor of `uniform_random` is  got by `layers.shape`, we can use the shape of input Variable of `layers.shape` as the shape of the output Variable of `uniform_random`.

This may need to be fixed in several operators that involve `shape tensor`, this PR only handles `uniform_random` as a test example.

### Result
```
    import paddle
    paddle.enable_static()
    data = paddle.static.data(name="x", shape=[-1, 2], dtype='float32')
    shape = paddle.shape(data)  # shape should be [-1, 2] instead of [-1, -1]
    x = paddle.uniform(shape) 
    print(x.shape) 
    # (-1, 2)
    out = paddle.static.fc(x, 10)
    # OK, since the shape of weight of fc will be (2, 10), which is ok. 
```