### PR TITLE
update the version of pybind, test=develop

### DIFF
--- a/cmake/external/pybind11.cmake
+++ b/cmake/external/pybind11.cmake
@@ -17,7 +17,7 @@ include(ExternalProject)
 set(PYBIND_PREFIX_DIR     ${THIRD_PARTY_PATH}/pybind)
 set(PYBIND_SOURCE_DIR     ${THIRD_PARTY_PATH}/pybind/src/extern_pybind)
 SET(PYBIND_REPOSITORY     ${GIT_URL}/pybind/pybind11.git)
-SET(PYBIND_TAG            v2.2.4)
+SET(PYBIND_TAG            v2.4.3)
 
 cache_third_party(extern_pybind
     REPOSITORY    ${PYBIND_REPOSITORY}
@@ -34,7 +34,6 @@ ExternalProject_Add(
         "${PYBIND_DOWNLOAD_CMD}"
         PREFIX            ${PYBIND_PREFIX_DIR}
         SOURCE_DIR        ${PYBIND_SOURCE_DIR}
-        UPDATE_COMMAND    ""
         CONFIGURE_COMMAND ""
         BUILD_COMMAND     ""
         INSTALL_COMMAND   ""

--- a/paddle/fluid/pybind/tensor_py.h
+++ b/paddle/fluid/pybind/tensor_py.h
@@ -58,7 +58,7 @@ struct npy_format_descriptor<paddle::platform::float16> {
     // https://docs.python.org/3/library/struct.html#format-characters.
     return "e";
   }
-  static PYBIND11_DESCR name() { return _("float16"); }
+  static constexpr auto name = _("float16");
 };
 
 // Note: Since bfloat16 is not a builtin type in C++ and in numpy,
@@ -75,7 +75,7 @@ struct npy_format_descriptor<paddle::platform::bfloat16> {
     // https://docs.python.org/3/library/struct.html#format-characters.
     return "H";
   }
-  static PYBIND11_DESCR name() { return _("bfloat16"); }
+  static constexpr auto name = _("bfloat16");
 };
 
 }  // namespace detail

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1310,8 +1310,12 @@ class Executor(object):
             tensor.set(data, self.place)
 
         if not use_program_cache:
+            if type(fetch_var_name) == str:
+                fetch_var_names = [fetch_var_name]
+            else:
+                fetch_var_names = fetch_var_name
             self._default_executor.run(program.desc, scope, 0, True, True,
-                                       fetch_var_name)
+                                       fetch_var_names)
         else:
             self._default_executor.run_prepared_ctx(ctx, scope, False, False,
                                                     False)

--- a/python/paddle/fluid/executor.py
+++ b/python/paddle/fluid/executor.py
@@ -1261,6 +1261,11 @@ class Executor(object):
                 "Executor requires Program as its Parameter. But you passed in %s"
                 % (type(program)))
 
+        if not isinstance(fetch_var_name, str):
+            raise TypeError(
+                "The name of fetch variable requires string as its Parameter. But you passed in %s"
+                % (type(fetch_var_name)))
+
         if use_program_cache:
             cache_key = _get_strong_program_cache_key(program, feed, fetch_list)
             cached_program = self._get_program_cache(cache_key)
@@ -1310,12 +1315,8 @@ class Executor(object):
             tensor.set(data, self.place)
 
         if not use_program_cache:
-            if type(fetch_var_name) == str:
-                fetch_var_names = [fetch_var_name]
-            else:
-                fetch_var_names = fetch_var_name
             self._default_executor.run(program.desc, scope, 0, True, True,
-                                       fetch_var_names)
+                                       [fetch_var_name])
         else:
             self._default_executor.run_prepared_ctx(ctx, scope, False, False,
                                                     False)

--- a/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
+++ b/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
@@ -86,14 +86,8 @@ class TestFeedData(unittest.TestCase):
                 self._test_feed_lod_tensor(use_cuda, use_parallel_executor)
 
                 # Test exception message when feeding with error 
-                if six.PY2:
-                    in_shape_tuple = (long(-1), long(3), long(4), long(8))
-                    error_shape_list = [
-                        long(self.data_batch_size), long(3), long(4), long(5)
-                    ]
-                else:
-                    in_shape_tuple = (-1, 3, 4, 8)
-                    error_shape_list = [self.data_batch_size, 3, 4, 5]
+                in_shape_tuple = (-1, 3, 4, 8)
+                error_shape_list = [self.data_batch_size, 3, 4, 5]
 
                 with self.assertRaises(ValueError) as shape_mismatch_err:
                     self._test_feed_data_shape_mismatch(use_cuda,

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -430,18 +430,7 @@ class TestVarBase(unittest.TestCase):
         paddle.set_printoptions(4, 100, 3)
         a_str = str(a)
 
-        if six.PY2:
-            expected = '''Tensor(shape=[10L, 20L], dtype=float32, place=CPUPlace, stop_gradient=True,
-       [[0.2727, 0.5489, 0.8655, ..., 0.2916, 0.8525, 0.9000],
-        [0.3806, 0.8996, 0.0928, ..., 0.9535, 0.8378, 0.6409],
-        [0.1484, 0.4038, 0.8294, ..., 0.0148, 0.6520, 0.4250],
-        ...,
-        [0.3426, 0.1909, 0.7240, ..., 0.4218, 0.2676, 0.5679],
-        [0.5561, 0.2081, 0.0676, ..., 0.9778, 0.3302, 0.9559],
-        [0.2665, 0.8483, 0.5389, ..., 0.4956, 0.6862, 0.9178]])'''
-
-        else:
-            expected = '''Tensor(shape=[10, 20], dtype=float32, place=CPUPlace, stop_gradient=True,
+        expected = '''Tensor(shape=[10, 20], dtype=float32, place=CPUPlace, stop_gradient=True,
        [[0.2727, 0.5489, 0.8655, ..., 0.2916, 0.8525, 0.9000],
         [0.3806, 0.8996, 0.0928, ..., 0.9535, 0.8378, 0.6409],
         [0.1484, 0.4038, 0.8294, ..., 0.0148, 0.6520, 0.4250],
@@ -458,12 +447,7 @@ class TestVarBase(unittest.TestCase):
         a = paddle.to_tensor([[1.5111111, 1.0], [0, 0]])
         a_str = str(a)
 
-        if six.PY2:
-            expected = '''Tensor(shape=[2L, 2L], dtype=float32, place=CPUPlace, stop_gradient=True,
-       [[1.5111, 1.    ],
-        [0.    , 0.    ]])'''
-        else:
-            expected = '''Tensor(shape=[2, 2], dtype=float32, place=CPUPlace, stop_gradient=True,
+        expected = '''Tensor(shape=[2, 2], dtype=float32, place=CPUPlace, stop_gradient=True,
        [[1.5111, 1.    ],
         [0.    , 0.    ]])'''
 
@@ -475,12 +459,7 @@ class TestVarBase(unittest.TestCase):
         a = paddle.to_tensor([[-1.5111111, 1.0], [0, -0.5]])
         a_str = str(a)
 
-        if six.PY2:
-            expected = '''Tensor(shape=[2L, 2L], dtype=float32, place=CPUPlace, stop_gradient=True,
-       [[-1.5111,  1.    ],
-        [ 0.    , -0.5000]])'''
-        else:
-            expected = '''Tensor(shape=[2, 2], dtype=float32, place=CPUPlace, stop_gradient=True,
+        expected = '''Tensor(shape=[2, 2], dtype=float32, place=CPUPlace, stop_gradient=True,
        [[-1.5111,  1.    ],
         [ 0.    , -0.5000]])'''
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Pybind v2.2 为 2017 年发布的旧版本，其遗留 bug 需要替换新版本解决，所以升级 Paddle 的依赖。
考虑到兼容性，此次升级选择 `branch/v2.4` 的最后稳定发布（v2.4.3）。

涉及到本修改的提交：
1、https://github.com/pybind/pybind11/pull/1603 是一个重要修复：解决了 Python 侧错误修改 C++ `const STL` 引用容器内容，导致无法直接封装 `std::vector` / `std::map` 等 STL 容器的关键问题。
2、https://github.com/pybind/pybind11/pull/1186 修复 Python 2.7 上 `int` 基本类型的兼容性问题：在拷贝 C++ 整型到 Python 时，根据数值范围挑选数值类型，从而将 Python 2/3 的绑定行为统一。
3、https://github.com/pybind/pybind11/pull/1198 修复了 pybind11 函数签名不符合 Python 编码规范的问题：在等号 `=` 前后添加空格。

由于上述 2、3 修复，导致接口签名文本内容发生变化，触发强制检查：
![image](https://user-images.githubusercontent.com/39303645/97676339-75aeb800-1acb-11eb-8cb8-db2b9a9ea374.png)
