### PR TITLE
Enable GRU infer model running CAPI

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_lexical_analysis_gru_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_lexical_analysis_gru_tester.cc
@@ -189,8 +189,6 @@ std::vector<double> Lexical_Test(
     acc_res = {precision, recall, f1_score};
     // return acc_res;
   } else {
-    EXPECT_GT(outputs->size(), 0UL);
-    EXPECT_EQ(outputs[0].size(), 1UL);
     LOG(INFO) << "No accuracy result. To get accuracy result provide a model "
                  "with accuracy layers in it and use --with_accuracy_layer "
                  "option.";

--- a/paddle/fluid/inference/tests/api/analyzer_lexical_analysis_gru_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_lexical_analysis_gru_tester.cc
@@ -189,6 +189,8 @@ std::vector<double> Lexical_Test(
     acc_res = {precision, recall, f1_score};
     // return acc_res;
   } else {
+    EXPECT_GT(outputs->size(), 0UL);
+    EXPECT_GT(outputs[0].size(), 0UL);
     LOG(INFO) << "No accuracy result. To get accuracy result provide a model "
                  "with accuracy layers in it and use --with_accuracy_layer "
                  "option.";


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Describe
When applying infer model, the output size is not necessary 1. 
After adding this PR, infer_model (without accuracy) could work well too.
