### PR TITLE
[Dy2stat] Support to modify value of buffer tensor

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -1023,13 +1023,20 @@ class Layer(core.Layer):
                         self._non_persistable_buffer_names_set.add(name)
                     _buffers[name] = value
                 elif _buffers is not None and name in _buffers:
-                    if value is not None:
+                    # Note(Aurelius84): In Dy2stat, the value of the Buffer may be modified in 
+                    # decorated function, such as `self.buffer = new_tensor`. So we update its
+                    # value via `assign`.
+                    if type(value) == framework.Variable:
+                        from paddle import assign
+                        assign(value, _buffers[name])
+                    elif value is not None:
                         raise TypeError(
                             "assignment to buffers '{}' should be of type core.VarBase or None, but got '{}'"
                             .format(name, type(value).__name__))
-                    # Assigning None will remove the buffer, but if re-assign a new varBase to it,
-                    # it will be remarked as a buffer with same `persistable` attribute.
-                    _buffers[name] = None
+                    else:
+                        # Assigning None will remove the buffer, but if re-assign a new varBase to it,
+                        # it will be remarked as a buffer with same `persistable` attribute.
+                        _buffers[name] = None
                 else:
                     object.__setattr__(self, name, value)
 

--- a/python/paddle/fluid/tests/unittests/test_base_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_base_layer.py
@@ -290,9 +290,9 @@ class TestBuffer(unittest.TestCase):
         self.assertTrue(np.array_equal(var1.numpy(), var2.numpy()))
 
 
-class BufferNet(paddle.nn.Layer):
+class BufferNetWithModification(paddle.nn.Layer):
     def __init__(self, shape):
-        super(BufferNet, self).__init__()
+        super(BufferNetWithModification, self).__init__()
 
         self.buffer1 = paddle.zeros(shape, 'int32')
         self.buffer2 = paddle.zeros(shape, 'int32')
@@ -317,7 +317,7 @@ class TestModifiedBuffer(unittest.TestCase):
         self.prog_trans.enable(to_static)
 
         x = paddle.ones([1], 'int32')
-        net = BufferNet(self.shape)
+        net = BufferNetWithModification(self.shape)
         out = net(x)
 
         return out, net.buffer1, net.buffer2

--- a/python/paddle/fluid/tests/unittests/test_base_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_base_layer.py
@@ -297,6 +297,7 @@ class BufferNet(paddle.nn.Layer):
         self.buffer1 = paddle.zeros(shape, 'int32')
         self.buffer2 = paddle.zeros(shape, 'int32')
 
+    @paddle.jit.to_static
     def forward(self, x):
         self.buffer1 += x
         self.buffer2 = self.buffer1 + x
@@ -331,4 +332,4 @@ class TestModifiedBuffer(unittest.TestCase):
 
 
 if __name__ == '__main__':
-    unittest.main(defaultTest='TestModifiedBuffer')
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[Dy2stat] Support to modify value of buffer tensor

### What's New?

Before this PR, the value of registered buffer tensor is not supported to modified. Now we implement it.

A simple example:

```python
class BufferNet(paddle.nn.Layer):
    def __init__(self, shape):
        super(BufferNet, self).__init__()

        self.buffer1 = paddle.zeros(shape, 'int32')
        self.buffer2 = paddle.zeros(shape, 'int32')

    @paddle.jit.to_static
    def forward(self, x):
        self.buffer1 += x
        self.buffer2 = self.buffer1 + x

        out = self.buffer1 + self.buffer2

        return out
``` 