### PR TITLE
[Dy2Stat] Fix bug in convert_call

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -193,11 +193,14 @@ def convert_call(func):
             try:
                 _, forward_func = unwrap_decorators(func.forward)
                 forward_func = convert_to_static(forward_func)
-                func_self = func
+                # Bound mothod will be convert into plain function after `convert_to_static`.
+                # So descriptor mechanism is used to bound `self` instance on function to
+                # keep it as bound method.
+                setattr(func, 'forward', forward_func.__get__(func))
             except Exception:
                 # NOTE: func.forward may have been decorated.
                 func_self = None if func_self else func_self
-            converted_call = forward_func
+            converted_call = func
         else:
             try:
                 call_func = func.__class__.__call__

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -219,5 +219,6 @@ def convert_call(func):
         return func
 
     if func_self:
+
         converted_call = functools.partial(converted_call, func_self)
     return converted_call

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -142,7 +142,7 @@ def convert_call(func):
             # Note(Aurelius84): Because `@declarative` returns a class instance instead of
             # a function. This will modify the value referring to itself in `__globals__`.
 
-            # For example: 
+            # For example:
             #
             #      @declarative
             #      def foo(x):
@@ -150,7 +150,7 @@ def convert_call(func):
             #
             # `foo` will be converted into a wrapper class, suppose as `StaticFunction`.
             # And `foo.__globals__['foo']` will still return this `StaticFunction` instead of
-            # `foo` function. So `isinstance(fn, StaticFunction)` is added here. 
+            # `foo` function. So `isinstance(fn, StaticFunction)` is added here.
             global_functions = set()
             for fn in func.__globals__.values():
                 if inspect.isfunction(fn):
@@ -193,12 +193,11 @@ def convert_call(func):
             try:
                 _, forward_func = unwrap_decorators(func.forward)
                 forward_func = convert_to_static(forward_func)
-                setattr(func, 'forward', forward_func)
                 func_self = func
             except Exception:
                 # NOTE: func.forward may have been decorated.
                 func_self = None if func_self else func_self
-            converted_call = func
+            converted_call = forward_func
         else:
             try:
                 call_func = func.__class__.__call__

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -219,6 +219,5 @@ def convert_call(func):
         return func
 
     if func_self:
-
         converted_call = functools.partial(converted_call, func_self)
     return converted_call

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -17,6 +17,7 @@ import paddle
 import unittest
 from paddle import nn
 
+
 class LSTMLayer(nn.Layer):
     def __init__(self, in_channels, hidden_size):
         super(LSTMLayer, self).__init__()
@@ -26,6 +27,7 @@ class LSTMLayer(nn.Layer):
     def forward(self, x):
         x, _ = self.cell(x)
         return x
+
 
 class Net(nn.Layer):
     def __init__(self, in_channels, hidden_size):
@@ -137,8 +139,9 @@ class TestEvalAfterSave(unittest.TestCase):
         print(after_func)
         out = net(x)
         # No changes applied on function after jit.save
-        print('xxx'*50)
+        print('xxx' * 50)
         self.assertEqual(origin_func, after_func)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -132,7 +132,10 @@ class TestEvalAfterSave(unittest.TestCase):
         dy_out = net(x)
         # save model
         paddle.jit.save(net, 'jit.save/lstm', input_spec=[x])
-
+        load_net = paddle.jit.load('jit.save/lstm')
+        load_out = load_net(x)
+        self.assertTrue(np.allclose(dy_out.numpy(), load_out.numpy()))
+        # eval
         net.eval()
         out = net(x)
         self.assertTrue(np.allclose(dy_out.numpy(), out.numpy()))

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -129,18 +129,13 @@ class TestEvalAfterSave(unittest.TestCase):
     def test_eval_after_save(self):
         x = paddle.randn((2, 10, 12)).astype('float32')
         net = Net(12, 2)
-
-        origin_func = net.lstm.forward
-        print(origin_func)
+        dy_out = net(x)
+        # save model
         paddle.jit.save(net, 'jit.save/lstm', input_spec=[x])
 
         net.eval()
-        after_func = net.lstm.forward
-        print(after_func)
         out = net(x)
-        # No changes applied on function after jit.save
-        print('xxx' * 50)
-        self.assertEqual(origin_func, after_func)
+        self.assertTrue(np.allclose(dy_out.numpy(), out.numpy()))
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -115,5 +115,19 @@ class TestSaveInEvalMode(unittest.TestCase):
                                                             infer_out))
 
 
+class TestEvalAfterSave(unittest.TestCase):
+    def test_eval_after_save(self):
+        x = paddle.randn((2, 10, 12)).astype('float32')
+        net = Net(12, 2)
+
+        origin_func = net.lstm.forward
+        paddle.jit.save(net, 'jit.save/lstm', input_spec=[x])
+
+        net.eval()
+        after_func = net.lstm.forward
+        out = net(x)
+        # No changes applied on function after jit.save
+        self.assertEqual(origin_func, after_func)
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_lstm.py
@@ -17,15 +17,23 @@ import paddle
 import unittest
 from paddle import nn
 
+class LSTMLayer(nn.Layer):
+    def __init__(self, in_channels, hidden_size):
+        super(LSTMLayer, self).__init__()
+        self.cell = nn.LSTM(
+            in_channels, hidden_size, direction='bidirectional', num_layers=2)
+
+    def forward(self, x):
+        x, _ = self.cell(x)
+        return x
 
 class Net(nn.Layer):
     def __init__(self, in_channels, hidden_size):
         super(Net, self).__init__()
-        self.lstm = nn.LSTM(
-            in_channels, hidden_size, direction='bidirectional', num_layers=2)
+        self.lstm = LSTMLayer(in_channels, hidden_size)
 
     def forward(self, x):
-        x, _ = self.lstm(x)
+        x = self.lstm(x)
         return x
 
 
@@ -121,12 +129,15 @@ class TestEvalAfterSave(unittest.TestCase):
         net = Net(12, 2)
 
         origin_func = net.lstm.forward
+        print(origin_func)
         paddle.jit.save(net, 'jit.save/lstm', input_spec=[x])
 
         net.eval()
         after_func = net.lstm.forward
+        print(after_func)
         out = net(x)
         # No changes applied on function after jit.save
+        print('xxx'*50)
         self.assertEqual(origin_func, after_func)
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix bug in convert_call

**The repetition code：**
```python
class LSTMLayer(nn.Layer):
    def __init__(self, in_channels, hidden_size):
        super(LSTMLayer, self).__init__()
        self.cell = nn.LSTM(
            in_channels, hidden_size, direction='bidirectional', num_layers=2)


    def forward(self, x):
        x, _ = self.cell(x)
        return x


class Net(nn.Layer):
    def __init__(self, in_channels, hidden_size):
        super(Net, self).__init__()
        self.lstm = LSTMLayer(in_channels, hidden_size)
    
    def forward(self, x):
        x = convert_call(self.lstm)(x)
        return x


class TestEvalAfterSave(unittest.TestCase):
    def test_eval_after_save(self):
        x = paddle.randn((2, 10, 12)).astype('float32')
        net = Net(12, 2)

        dy_out = net(x)
        # save model
        paddle.jit.save(net, 'jit.save/lstm', input_spec=[x])

        net.eval()
        out = net(x)
        self.assertTrue(np.allclose(dy_out.numpy(), out.numpy()))

```