### PR TITLE
Add retry for dygraph parallel socket bind

### DIFF
--- a/paddle/fluid/imperative/nccl_context.cc
+++ b/paddle/fluid/imperative/nccl_context.cc
@@ -51,15 +51,11 @@ void NCCLParallelContext::RecvNCCLID(const std::string &ep,
   int try_times = 0;
   while (true) {
     if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
-      if (try_times < 10) {
-        LOG(WARNING) << "Socket bind worker " << ep
-                     << " failed, try again after 3 seconds.";
-      } else {
-        PADDLE_THROW(platform::errors::Unavailable(
-            "Bind on endpoint %s failed. Please confirm whether the "
-            "communication port (%d) or GPU card is occupied.",
-            ep, port));
-      }
+      LOG(WARNING) << "Socket bind worker " << ep << (try_times < 5)
+          ? " failed, try again after 3 seconds."
+          : " failed, try again after 3 seconds. Bind on endpoint %s failed. "
+            "Please confirm whether the communication port or GPU card is "
+            "occupied.";
       std::this_thread::sleep_for(std::chrono::seconds(3));
       ++try_times;
       continue;
@@ -133,16 +129,11 @@ void NCCLParallelContext::SendNCCLID(const std::string &ep,
   int try_times = 0;
   while (true) {
     if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
-      if (try_times < 10) {
-        LOG(WARNING) << "Socket connect worker " << ep
-                     << " failed, try again after 3 seconds.";
-      } else {
-        PADDLE_THROW(platform::errors::Unavailable(
-            "Worker %s is not ready. Maybe that some process "
+      LOG(WARNING) << "Socket connect worker " << ep << (try_times < 5)
+          ? " failed, try again after 3 seconds."
+          : " failed, try again after 3 seconds. Maybe that some process "
             "is occupied the GPUs of this node now, "
-            "and you should kill those process manually.",
-            ep));
-      }
+            "and you should kill those process manually.";
       std::this_thread::sleep_for(std::chrono::seconds(3));
       ++try_times;
       continue;

--- a/paddle/fluid/imperative/nccl_context.cc
+++ b/paddle/fluid/imperative/nccl_context.cc
@@ -51,11 +51,13 @@ void NCCLParallelContext::RecvNCCLID(const std::string &ep,
   int try_times = 0;
   while (true) {
     if (bind(server_fd, (struct sockaddr *)&address, sizeof(address)) < 0) {
-      LOG(WARNING) << "Socket bind worker " << ep << (try_times < 5)
-          ? " failed, try again after 3 seconds."
-          : " failed, try again after 3 seconds. Bind on endpoint %s failed. "
-            "Please confirm whether the communication port or GPU card is "
-            "occupied.";
+      LOG(WARNING) << "Socket bind worker " << ep
+                   << (try_times < 5 ? " failed, try again after 3 seconds."
+                                     : " failed, try again after 3 seconds. "
+                                       "Bind on endpoint %s failed. "
+                                       "Please confirm whether the "
+                                       "communication port or GPU card is "
+                                       "occupied.");
       std::this_thread::sleep_for(std::chrono::seconds(3));
       ++try_times;
       continue;
@@ -129,11 +131,13 @@ void NCCLParallelContext::SendNCCLID(const std::string &ep,
   int try_times = 0;
   while (true) {
     if (connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
-      LOG(WARNING) << "Socket connect worker " << ep << (try_times < 5)
-          ? " failed, try again after 3 seconds."
-          : " failed, try again after 3 seconds. Maybe that some process "
-            "is occupied the GPUs of this node now, "
-            "and you should kill those process manually.";
+      LOG(WARNING)
+          << "Socket connect worker " << ep
+          << (try_times < 5
+                  ? " failed, try again after 3 seconds."
+                  : " failed, try again after 3 seconds. Maybe that "
+                    "some process is occupied the GPUs of this node "
+                    "now, and you should kill those process manually.");
       std::this_thread::sleep_for(std::chrono::seconds(3));
       ++try_times;
       continue;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

When run dygraph parallel by `paddle.distributed.launch` or `padddle.distributed.spawn`, the launch module will find freee ports for this training default, but after getting free port set, the ports will not be used immediately, they are unbound in a short time before they are used. In this short time, these free ports may be occupied by other tasks, which will cause binding or connecting error when nccl eenvironment is initialized. The error like:

![image](https://user-images.githubusercontent.com/22561442/98077316-f5150080-1eaa-11eb-942b-38a5f9247f8d.png)

Strictly speaking, after we obtain free ports, we should lock these ports until they are used by epected tasks, but the current logic is flawed, and the locking behavior is also complicated.

Here, I add retry mechanism to alleviate this problem.
