### PR TITLE
Dygraph amp support cuda pinned place

### DIFF
--- a/paddle/fluid/imperative/amp_auto_cast.cc
+++ b/paddle/fluid/imperative/amp_auto_cast.cc
@@ -49,15 +49,15 @@ inline std::string GetDtypeStr(
 }
 
 inline bool NeedCast(const std::shared_ptr<VarBase>& var) {
-  if (!platform::is_gpu_place(var->Place())) {
-    return false;
+  if (platform::is_gpu_place(var->Place()) ||
+      platform::is_cuda_pinned_place(var->Place())) {
+    // CudaPinndePlace is added for varbase created by dataloader
+    if (var->DataType() == framework::proto::VarType::FP32 ||
+        var->DataType() == framework::proto::VarType::FP16) {
+      return true;
+    }
   }
-  if (var->DataType() == framework::proto::VarType::FP32 ||
-      var->DataType() == framework::proto::VarType::FP16) {
-    return true;
-  } else {
-    return false;
-  }
+  return false;
 }
 
 // NOTE: Trace a cast op, so if a var is casted from fp32 to fp16, then the grad


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Dygraph amp support cuda pinned place, especially for tensors generated by DataLoader.