### PR TITLE
upgrade oneDNN with GRU INT8 optimizations

### DIFF
--- a/cmake/external/mkldnn.cmake
+++ b/cmake/external/mkldnn.cmake
@@ -20,7 +20,7 @@ SET(MKLDNN_SOURCE_DIR     ${THIRD_PARTY_PATH}/mkldnn/src/extern_mkldnn)
 SET(MKLDNN_INSTALL_DIR    ${THIRD_PARTY_PATH}/install/mkldnn)
 SET(MKLDNN_INC_DIR        "${MKLDNN_INSTALL_DIR}/include" CACHE PATH "mkldnn include directory." FORCE)
 SET(MKLDNN_REPOSITORY     ${GIT_URL}/oneapi-src/oneDNN.git)
-SET(MKLDNN_TAG            361725600224f41b7347a1c6bee9b04d1e6c14d7)
+SET(MKLDNN_TAG            b530ba24c7005ec0f72c06cb55cecd5dffdc5e37)
 
 # Introduce variables:
 # * CMAKE_INSTALL_LIBDIR

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_mkldnn_ops_on_off.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_mkldnn_ops_on_off.py
@@ -33,7 +33,7 @@ class TestFlagsUseMkldnn(unittest.TestCase):
 
         self.relu_regex = b"^dnnl_verbose,exec,cpu,eltwise,.+alg:eltwise_relu alpha:0 beta:0,10x20x20"
         self.ew_add_regex = b"^dnnl_verbose,exec,cpu,binary.+alg:binary_add,10x20x30:10x20x30 10x20x30"
-        self.matmul_regex = b"^dnnl_verbose,exec,cpu,matmul,.*b10m20n20k30"
+        self.matmul_regex = b"^dnnl_verbose,exec,cpu,matmul,.*10x20x30:10x30x20:10x20x20"
 
     def flags_use_mkl_dnn_common(self, e):
         cmd = self._python_interp


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
This PR upgrades oneDNN version from v1.6-based to v1.8 which contains additional optimizations for GRU INT8.

Performance benchmark results (in fps) for GRU model on CLX 6271, single thread, oneDNN version 1.6 vs. 1.8):
| batch size | fp32 (1.6&1.8) | int8 (1.6) | int8 (1.8) | int8/fp32 (1.6) ratio | int8/fp32 (1.8) ratio |
|:--:|:--:|:--:|:--:|:--:|:--:|
| 1 | 1082 | 1455 | 1438 | 1.34 | 1.33 |
| 50 | 2209 | 3402 | 3642 | 1.54 | 1.65 |


