### PR TITLE
fix Tanh remainder en doc

### DIFF
--- a/python/paddle/nn/layer/activation.py
+++ b/python/paddle/nn/layer/activation.py
@@ -252,12 +252,10 @@ class Tanh(layers.Layer):
             import paddle
             import numpy as np
 
-            paddle.disable_static()
-
             x = paddle.to_tensor(np.array([-0.4, -0.2, 0.1, 0.3]))
             m = paddle.nn.Tanh()
             out = m(x)
-            print(out.numpy())
+            print(out)
             # [-0.37994896 -0.19737532  0.09966799  0.29131261]
     """
 

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -384,7 +384,7 @@ def remainder(x, y, name=None):
     Mod two tensors element-wise. The equation is:
 
     .. math::
-        out = x \% y
+        out = x / y
 
     **Note**:
     ``paddle.remainder`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting` .
@@ -407,6 +407,7 @@ def remainder(x, y, name=None):
             y = paddle.to_tensor([1, 5, 3, 3])
             z = paddle.remainder(x, y)
             print(z)  # [0, 3, 2, 1]
+
     """
     op_type = 'elementwise_mod'
     axis = -1

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -384,10 +384,10 @@ def remainder(x, y, name=None):
     Mod two tensors element-wise. The equation is:
 
     .. math::
-        out = x / y
+        out = x \% y
 
     **Note**:
-    ``paddle.remainder`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting` .
+    ``paddle.mod`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting` .
 
     Args:
         x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
@@ -405,7 +405,7 @@ def remainder(x, y, name=None):
 
             x = paddle.to_tensor([2, 3, 8, 7])
             y = paddle.to_tensor([1, 5, 3, 3])
-            z = paddle.remainder(x, y)
+            z = paddle.mod(x, y)
             print(z)  # [0, 3, 2, 1]
 
     """

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -390,8 +390,8 @@ def remainder(x, y, name=None):
     ``paddle.remainder`` supports broadcasting. If you want know more about broadcasting, please refer to :ref:`user_guide_broadcasting` .
 
     Args:
-        x (Tensor): the input tensor, it's data type should be int32, int64.
-        y (Tensor): the input tensor, it's data type should be int32, int64.
+        x (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
+        y (Tensor): the input tensor, it's data type should be float32, float64, int32, int64.
         name (str, optional): Name for the operation (optional, default is None). For more information, please refer to :ref:`api_guide_Name`.
 
     Returns:
@@ -403,13 +403,10 @@ def remainder(x, y, name=None):
 
             import paddle
 
-            paddle.disable_static()
-
             x = paddle.to_tensor([2, 3, 8, 7])
             y = paddle.to_tensor([1, 5, 3, 3])
             z = paddle.remainder(x, y)
-            print(z.numpy())  # [0, 3, 2, 1]
-
+            print(z)  # [0, 3, 2, 1]
     """
     op_type = 'elementwise_mod'
     axis = -1


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
Fix `Tanh` & `remainder` en docs, rm `enable_static` and change `print(out.numpy())` --> `print(out)`.
`remainder` en doc use alias `paddle.mod`.

CN docs see https://github.com/PaddlePaddle/FluidDoc/pull/2851

`Tanh` preview:
![image](https://user-images.githubusercontent.com/10208305/98245258-9e432000-1fab-11eb-849e-e72b9bf5e14b.png)

`remainder(paddle.mod)` preview:
![image](https://user-images.githubusercontent.com/10208305/98336902-ba45d080-2042-11eb-8303-db677a4d3945.png)