### PR TITLE
refine the performance of gather Op

### DIFF
--- a/paddle/fluid/operators/gather.cu.h
+++ b/paddle/fluid/operators/gather.cu.h
@@ -20,8 +20,8 @@ limitations under the License. */
 #include "paddle/fluid/memory/malloc.h"
 #include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/platform/cuda_primitives.h"
+#include "paddle/fluid/platform/gpu_launch_config.h"
 #include "paddle/fluid/platform/place.h"
-
 namespace paddle {
 namespace operators {
 
@@ -165,14 +165,16 @@ __global__ void GatherGPUKernel(const T* input, const U* index, T* out,
                                 int out_index_dim_size,
                                 int input_index_dim_size, int size) {
   int idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int outer_size = outer_dim_size * out_index_dim_size;
   for (; idx < size; idx += blockDim.x * gridDim.x) {
-    int inner_dim_index = idx / (outer_dim_size * out_index_dim_size);
-    int next_idx = idx % (outer_dim_size * out_index_dim_size);
-    int index_dim_index = next_idx / (outer_dim_size);
-    int out_dim_index = next_idx % outer_dim_size;
+    int inner_dim_index = idx / outer_size;
+    int next_idx = idx - outer_size * inner_dim_index;
+    int index_dim_index = next_idx / outer_dim_size;
+    int index_val = index[index_dim_index];
+    int out_dim_index = next_idx - outer_dim_size * index_dim_index;
     int input_index =
         inner_dim_index * (outer_dim_size * input_index_dim_size) +
-        index[index_dim_index] * outer_dim_size + out_dim_index;
+        index_val * outer_dim_size + out_dim_index;
     out[idx] = input[input_index];
   }
 }
@@ -234,10 +236,11 @@ void GatherV2CUDAFunction(const Tensor* input, const Tensor* index,
   auto* out_data = out->mutable_data<T>(place);
   int out_size = out->numel();
 
-  int threads = 512;
-  int grid = (out_size + threads - 1) / threads;
+  platform::GpuLaunchConfig config =
+      platform::GetGpuLaunchConfig1D(ctx.cuda_device_context(), out_size);
   auto stream = ctx.cuda_device_context().stream();
-  GatherGPUKernel<T, U><<<grid, threads, 0, stream>>>(
+  GatherGPUKernel<
+      T, U><<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
       input_data, index_data, out_data, outer_dim_size, inner_dim_size,
       index_size, index_dim_size, out_size);
 }
@@ -280,10 +283,11 @@ void GatherV2GradCUDAFunction(const Tensor* input, const Tensor* index,
   int out_index_dim_size = out_dim[axis_index];
   operators::math::set_constant(*dev_ctx, out, 0.0);
 
-  int threads = 512;
-  int grid = (input_size + threads - 1) / threads;
+  platform::GpuLaunchConfig config =
+      platform::GetGpuLaunchConfig1D(ctx.cuda_device_context(), input_size);
   auto stream = ctx.cuda_device_context().stream();
-  GatherGradGPUKernel<T, U><<<grid, threads, 0, stream>>>(
+  GatherGradGPUKernel<
+      T, U><<<config.block_per_grid, config.thread_per_block, 0, stream>>>(
       input_data, index_data, out_data, outer_dim_size, inner_dim_size,
       input_index_dim_size, out_index_dim_size, input_size);
 }

--- a/paddle/fluid/operators/gather_op.cc
+++ b/paddle/fluid/operators/gather_op.cc
@@ -66,6 +66,11 @@ class GatherOp : public framework::OperatorWithKernel {
         OperatorWithKernel::IndicateVarDataType(ctx, "X"),
         ctx.device_context());
   }
+  framework::OpKernelType GetKernelTypeForVar(
+      const std::string& var_name, const framework::Tensor& tensor,
+      const framework::OpKernelType& expected_kernel_type) const override {
+    return expected_kernel_type;
+  }
 };
 
 class GatherGradOp : public framework::OperatorWithKernel {

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 from ..fluid.layers import core
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.framework import Variable, OpProtoHolder, in_dygraph_mode, convert_np_dtype_to_dtype_
+from ..fluid.framework import Variable, OpProtoHolder, in_dygraph_mode, convert_np_dtype_to_dtype_, device_guard
 from ..fluid.data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 from ..fluid.layers.tensor import fill_constant
 from ..fluid.layers import utils
@@ -794,7 +794,8 @@ def gather(x, index, axis=None, name=None):
         axis = 0
     axis_tensor = axis
     if not isinstance(axis, Variable):
-        axis_tensor = fill_constant(shape=[1], dtype='int64', value=axis)
+        with device_guard("cpu"):
+            axis_tensor = fill_constant(shape=[1], dtype='int64', value=axis)
     if in_dygraph_mode():
         return core.ops.gather(x, index, axis_tensor)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
This PR
paddle.gather
```

run command: nvprof /workspace/tmp/anaconda2/envs/py37/bin/python /workspace/work/benchmark/api/tests_v2/gather.py --task speed --framework paddle --json_file /workspace/work/benchmark/api/tests_v2/configs/gather.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 5000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   99.71%  7.8124ms      5001  1.5620us  1.5350us  7.2320us  void paddle::operators::GatherGPUKernel<float, int>(float const *, int const *, paddle::operators::GatherGPUKernel<float, int>*, int, int, int, int, int)
                    0.21%  16.160us         9  1.7950us  1.7280us  2.0480us  [CUDA memcpy HtoD]

percent: 1.00; gpu_time: 7.8124 ms; calls: 5001; function: void paddle::operators::GatherGPUKernel<float, int>(float const *, int const *, paddle::operators::GatherGPUKernel<float, int>*, int, int, int, int, int)
total gpu_time: 7.8351 ms

```
develop
paddle.gather

```
run command: nvprof /workspace/tmp/anaconda2/envs/py37/bin/python /workspace/work/benchmark/api/tests_v2/gather.py --task speed --framework paddle --json_file /workspace/work/benchmark/api/tests_v2/configs/gather.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 5000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   39.96%  9.4163ms      5001  1.8820us  1.8240us  10.656us  [CUDA memcpy DtoH]
                   33.01%  7.7776ms      5001  1.5550us  1.5350us  7.2640us  void paddle::operators::GatherGPUKernel<float, int>(float const *, int const *, paddle::operators::GatherGPUKernel<float, int>*, int, int, int, int, int)
                   26.93%  6.3463ms      5001  1.2680us  1.1840us  7.1040us  void Eigen::internal::EigenMetaKernel<Eigen::TensorEvaluator<Eigen::TensorAssignOp<Eigen::TensorMap<Eigen::Tensor<long, int=1, int=1, long>, int=0, Eigen::MakePointer>, Eigen::TensorCwiseNullaryOp<Eigen::internal::scalar_constant_op<long>, Eigen::TensorMap<Eigen::Tensor<long, int=1, int=1, long>, int=0, Eigen::MakePointer> const > const > const , Eigen::GpuDevice>, long>(long, int=1)
                    0.07%  16.128us         9  1.7920us  1.6960us  2.0800us  [CUDA memcpy HtoD]

```

paddle.fluid.layers.gather
```
run command: nvprof /workspace/tmp/anaconda2/envs/py37/bin/python /workspace/work/benchmark/api/tests/gather.py --task speed --framework paddle --json_file /workspace/work/benchmark/api/tests/configs/gather.json --config_id 0 --check_output False --profiler none --backward False --use_gpu True --repeat 5000 --allow_adaptive_repeat False --log_level 0
            Type  Time(%)      Time     Calls       Avg       Min       Max  Name
 GPU activities:   99.69%  7.5451ms      5001  1.5080us  1.4710us  7.3590us  void paddle::operators::GatherCUDAKernel<float, int>(float const *, int const *, paddle::operators::GatherCUDAKernel<float, int>*, unsigned long, unsigned long)
                    0.22%  16.896us         9  1.8770us  1.6960us  2.4000us  [CUDA memcpy HtoD]

percent: 1.00; gpu_time: 7.5451 ms; calls: 5001; function: void paddle::operators::GatherCUDAKernel<float, int>(float const *, int const *, paddle::operators::GatherCUDAKernel<float, int>*, unsigned long, unsigned long)
total gpu_time: 7.5686 ms
```