### PR TITLE
Do not use program seed in random-related API

### DIFF
--- a/python/paddle/fluid/contrib/layers/nn.py
+++ b/python/paddle/fluid/contrib/layers/nn.py
@@ -824,8 +824,7 @@ def shuffle_batch(x, seed=None):
 
     out = helper.create_variable_for_type_inference(dtype=x.dtype)
     shuffle_idx = helper.create_variable_for_type_inference(dtype=np.int64)
-    if seed is None and helper.main_program.random_seed != 0:
-        seed = helper.main_program.random_seed
+
     if seed is None:
         seed = np.random.randint(-65536, 65535)
     op_attrs = {}

--- a/python/paddle/fluid/dygraph/nn.py
+++ b/python/paddle/fluid/dygraph/nn.py
@@ -1461,9 +1461,6 @@ class Dropout(layers.Layer):
         self._is_test = is_test
 
     def forward(self, input):
-        prog = default_main_program()
-        if (self._seed is None or self._seed == 0) and prog.random_seed != 0:
-            self._seed = prog.random_seed
         attrs = {
             'dropout_prob': self._dropout_prob,
             'is_test': not self.training

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -1002,8 +1002,6 @@ def dropout(x,
     """
 
     def get_attrs(prog, dropout_prob, is_test, seed):
-        if (seed is None or seed == 0) and prog.random_seed != 0:
-            seed = prog.random_seed
         attrs = {
             'dropout_prob': dropout_prob,
             'is_test': is_test,
@@ -1014,9 +1012,6 @@ def dropout(x,
         return attrs
 
     if in_dygraph_mode():
-        if (seed is None or
-                seed == 0) and default_main_program().random_seed != 0:
-            seed = default_main_program().random_seed
         _is_test = not _dygraph_tracer()._train_mode
         out, mask = core.ops.dropout(
             x, 'dropout_prob', dropout_prob, 'is_test', _is_test, 'fix_seed',

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -887,8 +887,6 @@ def dropout(x,
         mode = 'downgrade_in_infer' if mode == 'downscale_in_infer' else mode  #semantic transfer
 
         def get_attrs(prog, dropout_prob, is_test, seed):
-            if (seed is None or seed == 0) and prog.random_seed != 0:
-                seed = prog.random_seed
             attrs = {
                 'dropout_prob': dropout_prob,
                 'is_test': is_test,
@@ -899,8 +897,6 @@ def dropout(x,
             return attrs
 
         if in_dygraph_mode():
-            if default_main_program().random_seed != 0:
-                seed = default_main_program().random_seed
             out, mask = core.ops.dropout(
                 x, 'dropout_prob', p, 'is_test', not training, 'fix_seed',
                 seed is not None, 'seed', seed


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

By design, `program.random_seed`  is used for initializer, while not APIs like `dropout`. 
What's more, in paddle-2.0, `Generator` is added to control the random number generation. 

So,

-  there is no need for users to set `program.random_seed`,

- `program.random_seed` should only affect initializer if it is set,

This PR removes some usage of `program.random_seed`  in random-related APIs, inlude `paddle.fluid.layers.dropout`, `paddle.nn.dropout`, `paddle.fluid.dygraph.Dropout`, `paddle.fluid.contrib.shuffle_batch`.