### PR TITLE
set NCCL_SHM_DISABLE=1 for test_parallel_executor_profilery.py

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_profiler.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_profiler.py
@@ -19,6 +19,14 @@ import numpy as np
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from paddle.fluid.tests.unittests.test_profiler import TestProfiler
+import os
+
+# NCCL 2.7 decides to use shared memory while NCCL 2.6 didn't, hence causing the error.
+# include/shm.h:28 NCCL WARN Call to posix_fallocate failed: No space left on device
+#
+# Set environment variables NCCL_SHM_DISABLE=1 to disables the Shared Memory (SHM) transports 
+# and force to use P2P which is the default transports way of NCCL2.6.
+os.environ['NCCL_SHM_DISABLE'] = str(1)
 
 
 class TestPEProfiler(TestProfiler):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#### 错误说明
- `test_parallel_executor_profilery.py`从10月28日起开始随机挂，每天大约有1-2次挂在PR_CI_Coverage任务上。
```
2020-11-06 15:08:33 18/21 Test #1116: test_parallel_executor_profiler ......................................***Failed   13.99 sec
2020-11-06 15:08:33 W1106 07:08:21.050976  9038 device_context.cc:338] Please NOTE: device: 0, CUDA Capability: 70, Driver API Version: 11.0, Runtime API Version: 10.1
2020-11-06 15:08:33 W1106 07:08:21.051435  9038 device_context.cc:346] device: 0, cuDNN Version: 7.6.
2020-11-06 15:08:33 W1106 07:08:32.807945  9038 fuse_all_reduce_op_pass.cc:75] Find all_reduce operators: 8. To make the speed faster, some all_reduce ops are fused during training, after fusion, the number of all_reduce ops is 4.
2020-11-06 15:08:33 
2020-11-06 15:08:33 
2020-11-06 15:08:33 --------------------------------------
2020-11-06 15:08:33 C++ Traceback (most recent call last):
2020-11-06 15:08:33 --------------------------------------
2020-11-06 15:08:33 0   paddle::framework::SignalHandle(char const*, int)
2020-11-06 15:08:33 1   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()
2020-11-06 15:08:33 
2020-11-06 15:08:33 ----------------------
2020-11-06 15:08:33 Error Message Summary:
2020-11-06 15:08:33 ----------------------
2020-11-06 15:08:33 FatalError: `Segmentation fault` is detected by the operating system.
2020-11-06 15:08:33   [TimeInfo: *** Aborted at 1604646512 (unix time) try "date -d @1604646512" if you are using GNU date ***]
2020-11-06 15:08:33   [SignalInfo: *** SIGSEGV (@0x0) received by PID 9038 (TID 0x7fb788cee700) from PID 0 ***]
2020-11-06 15:08:33 
2020-11-06 15:08:33 Segmentation fault
```
https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2055160/job/2951859

#### 复现过程
- 在`paddlepaddle/paddle:latest-dev-cuda10.1-cudnn7-gcc82`镜像中无法复现
- 在CI机器的镜像中直接复现，错误如下
```

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::framework::ParallelExecutor::ParallelExecutor(std::vector<paddle::platform::Place, std::allocator<paddle::platform::Place> > const&, std::vector<std::string, std::allocator<std::string > > const&, std::string const&, paddle::framework::Scope*, std::vector<paddle::framework::Scope*, std::allocator<paddle::framework::Scope*> > const&, paddle::framework::details::ExecutionStrategy const&, paddle::framework::details::BuildStrategy const&, paddle::framework::ir::Graph*)
1   paddle::platform::NCCLCommunicator::GetSyncBatchNormCtx(paddle::framework::Scope*, std::vector<paddle::platform::Place, std::allocator<paddle::platform::Place> > const&)
2   paddle::platform::NCCLContextMap::NCCLContextMap(std::vector<paddle::platform::Place, std::allocator<paddle::platform::Place> > const&, ncclUniqueId*, unsigned long, unsigned long)
3   paddle::platform::EnforceNotMet::EnforceNotMet(paddle::platform::ErrorSummary const&, char const*, int)
4   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
ExternalError:  Nccl error, unhandled system error  (at /Paddle/paddle/fluid/platform/nccl_helper.h:118)
----------------------------------------------------------------------
```
两个镜像的差别在于，CI使用NCCL2.7（升级是在10月23日前几天完成），而latest-dev镜像是NCCL2.4

#### 分析过程
因此，猜测是否是NCCL升级导致的问题，做了如下实验。
- 使用`NCCL_DEBUG=INFO`来打印具体的错误，完整命令为：`NCCL_DEBUG=INFO ctest -R test_parallel_executor_profiler -V`。错误日志中含有
```
1053: paddle-testing-ningzhefeng:15929:16016 [1] include/shm.h:28 NCCL WARN Call to posix_fallocate failed : No space left on device
```
- 该错误在NCCl官方多个Issue和Pytorch的Issue中有 https://github.com/NVIDIA/nccl/issues/290 ，https://github.com/NVIDIA/nccl/issues/342#issuecomment-693770236 ，https://github.com/pytorch/pytorch/pull/40622

> it could be that NCCL 2.7 decides to use shared memory while NCCL 2.6 didn't, hence causing the error.
Set environment variables NCCL_SHM_DISABLE=1 to disables the Shared Memory (SHM) transports and force to use P2P which is the default transports way of NCCL2.6.

因此，按照Issue中的说明，将`NCCL_SHM_DISABLE=1`来看是否还会复现该错误。

