### PR TITLE
fix port conflict in parallel dygraph mode

### DIFF
--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -138,7 +138,6 @@ def init_parallel_env():
         http_server.daemon = True
         http_server_d["running"] = True
         http_server.start()
-    wait_server_ready([ParallelEnv().trainer_endpoints[0]])
 
     # 4. init NCCL ParallelStrategy
     strategy = ParallelStrategy()
@@ -166,6 +165,8 @@ def init_parallel_env():
     # dividing init_gloo into two part beacause nccl and gloo
     # are separately looking for free ports which sometimes
     # leads to port-conflict.
+    wait_server_ready([ParallelEnv().trainer_endpoints[0]])
+
     gloo_strategy = core.GlooParallelStrategy()
     gloo_strategy.rank = ParallelEnv().rank
     gloo_strategy.rank_num = ParallelEnv().world_size

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -125,7 +125,7 @@ def init_parallel_env():
     if ParallelEnv().world_size < 2:
         return
 
-    # 3: init gloo context
+    # 3: init gloo context (step 1: httpsever start)
     ep_rank_0 = ParallelEnv().trainer_endpoints[0].split(":")
     ep_rank = ParallelEnv().trainer_endpoints[ParallelEnv().rank].split(":")
     manager = Manager()
@@ -140,6 +140,32 @@ def init_parallel_env():
         http_server.start()
     wait_server_ready([ParallelEnv().trainer_endpoints[0]])
 
+    # 4. init NCCL ParallelStrategy
+    strategy = ParallelStrategy()
+    if parallel_helper._is_parallel_ctx_initialized():
+        warnings.warn("The parallel environment has been initialized.")
+    strategy.nranks = ParallelEnv().world_size
+    strategy.local_rank = ParallelEnv().rank
+    strategy.trainer_endpoints = ParallelEnv().trainer_endpoints
+    strategy.current_endpoint = ParallelEnv().current_endpoint
+
+    # NOTE(chenweihang): [ why config global place here? ]
+    # the dygraph mode will be set to default mode,
+    # users will not call `dygraph.guard` or `enable_dygraph`
+    # directly, if they want to switch default place,
+    # they need to call a function to change default place,
+    # here just set correctly place to users
+    place = core.CUDAPlace(ParallelEnv().device_id)
+    _set_expected_place(place)
+
+    # init nccl context
+    parallel_helper._set_parallel_ctx(core.NCCLParallelContext(strategy, place))
+    parallel_helper._init_parallel_ctx()
+
+    # 5: init gloo context (step 2: gloo init)
+    # dividing init_gloo into two part beacause nccl and gloo
+    # are separately looking for free ports which sometimes
+    # leads to port-conflict.
     gloo_strategy = core.GlooParallelStrategy()
     gloo_strategy.rank = ParallelEnv().rank
     gloo_strategy.rank_num = ParallelEnv().world_size
@@ -154,28 +180,6 @@ def init_parallel_env():
     if ParallelEnv().rank == 0:
         http_server_d["running"] = False
         http_server.join()
-
-    # 4. init NCCL ParallelStrategy
-    strategy = ParallelStrategy()
-    if parallel_helper._is_parallel_ctx_initialized():
-        warnings.warn("The parallel environment has been initialized.")
-    strategy.nranks = ParallelEnv().world_size
-    strategy.local_rank = ParallelEnv().rank
-    strategy.trainer_endpoints = ParallelEnv().trainer_endpoints
-    strategy.current_endpoint = ParallelEnv().current_endpoint
-
-    # NOTE(chenweihang): [ why config global place here? ]
-    # the dygraph mode will be set to default mode, 
-    # users will not call `dygraph.guard` or `enable_dygraph`
-    # directly, if they want to switch default place,
-    # they need to call a function to change default place,
-    # here just set correctly place to users
-    place = core.CUDAPlace(ParallelEnv().device_id)
-    _set_expected_place(place)
-
-    # init nccl context
-    parallel_helper._set_parallel_ctx(core.NCCLParallelContext(strategy, place))
-    parallel_helper._init_parallel_ctx()
 
 
 def get_rank():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
when running dygraph parallel code in local machine,  random failure will occur.  It may be caused by the port conflict when gloo and nccl initialized at the same time. 
rank0 log (send id, connect failed):
![image](https://user-images.githubusercontent.com/52735331/98541248-1e2dfa80-22ca-11eb-88a2-ad92558a5dab.png)
rank3 log (receive id, bind failed):
![image](https://user-images.githubusercontent.com/52735331/98541382-51708980-22ca-11eb-863d-2ae659c55414.png)

In this PR, we change the order of the gloo and nccl init like below:
HttpServer start -> NCCL init -> GLOO init

HttpServer is used for gloo initial, which will use rank0 port. After changing order, port conflict will be resolved.