### PR TITLE
fix cmake error when execute build_inference_lib

### DIFF
--- a/paddle/fluid/framework/ir/fusion_group/CMakeLists.txt
+++ b/paddle/fluid/framework/ir/fusion_group/CMakeLists.txt
@@ -9,6 +9,6 @@ cc_library(fusion_group_pass
     SRCS fusion_group_pass.cc elementwise_group_detector.cc
     DEPS subgraph_detector fuse_pass_base code_generator device_code)
 cc_test(test_fusion_group_pass SRCS fusion_group_pass_tester.cc DEPS fusion_group_pass graph_viz_pass)
-if(WITH_GPU AND NOT ON_INFER)
+if(WITH_TESTING)
     set_tests_properties(test_code_generator PROPERTIES TIMEOUT 120)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix cmake error when execute build_inference_lib