### PR TITLE
make numpy version is below 1.19.3 for windows bug

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,7 @@
 requests>=2.20.0
 numpy>=1.13, <=1.16.4 ; python_version<"3.5"
-numpy>=1.13 ; python_version>="3.5"
+numpy>=1.13 ; python_version>="3.5" and platform_system != "Windows"
+numpy>=1.13, <=1.19.3 ; python_version>="3.5" and platform_system == "Windows"
 protobuf>=3.1.0
 gast==0.3.3
 scipy>=0.19.0, <=1.2.1 ; python_version<"3.5"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Make Numpy version is below 1.19.3. Because numpy 1.19.4 have a bug and will fail on windows when ``import numpy`` .

![image](https://user-images.githubusercontent.com/52485244/98641439-ba0d4400-2366-11eb-830f-47b4a24cec1c.png)

Refer to: 

https://stackoverflow.com/questions/64654805/how-do-you-fix-runtimeerror-package-fails-to-pass-a-sanity-check-for-numpy-an/64658254

Microsoft will focus on this problem.
https://developercommunity.visualstudio.com/content/problem/1207405/fmod-after-an-update-to-windows-2004-is-causing-a.html