### PR TITLE
Fix dtype of ungenerated grad var

### DIFF
--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -100,7 +100,11 @@ void BasicEngine::CheckBackwardInputs(const OpBase& op) {
 
       if (tensor && !tensor->IsInitialized()) {
         auto* dev_ctx = platform::DeviceContextPool::Instance().Get(op.place());
-        // NOTE(zhiqiu): since grad var is ungenerated, so
+        // NOTE(zhiqiu): since grad variable is ungenerated, so the dtype is not
+        // correct. var->DataType() returns the default dtype, which is float32.
+        // Here, we use the type of the corresponding forward variable (if
+        // exists) as the true dtype of grad variable.
+
         auto forward_var = var->GetForwardVar();
         auto dtype = forward_var ? forward_var->DataType() : var->DataType();
         VLOG(6) << "Set ungenerated Grad: " << var->Name()

--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -102,14 +102,12 @@ void BasicEngine::CheckBackwardInputs(const OpBase& op) {
         auto* dev_ctx = platform::DeviceContextPool::Instance().Get(op.place());
         // NOTE(zhiqiu): since grad variable is ungenerated, so the dtype is not
         // correct. var->DataType() returns the default dtype, which is float32.
-        // Here, we use the type of the corresponding forward variable (if
-        // exists) as the true dtype of grad variable.
+        // Here, we use the type of the corresponding forward datatype.
 
-        auto forward_var = var->GetForwardVar();
-        auto dtype = forward_var ? forward_var->DataType() : var->DataType();
+        tensor->mutable_data(op.place(), var->ForwardDataType());
         VLOG(6) << "Set ungenerated Grad: " << var->Name()
-                << " as zero with dtype " << framework::DataTypeToString(dtype);
-        tensor->mutable_data(op.place(), dtype);
+                << " as zero with dtype "
+                << framework::DataTypeToString(var->ForwardDataType());
         operators::math::set_constant(*dev_ctx, tensor, 0.0);
       }
     }

--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -99,9 +99,13 @@ void BasicEngine::CheckBackwardInputs(const OpBase& op) {
       }
 
       if (tensor && !tensor->IsInitialized()) {
-        VLOG(6) << "Set ungenerated Grad: " << var->Name() << " as zero";
         auto* dev_ctx = platform::DeviceContextPool::Instance().Get(op.place());
-        tensor->mutable_data(op.place(), var->DataType());
+        // NOTE(zhiqiu): since grad var is ungenerated, so
+        auto forward_var = var->GetForwardVar();
+        auto dtype = forward_var ? forward_var->DataType() : var->DataType();
+        VLOG(6) << "Set ungenerated Grad: " << var->Name()
+                << " as zero with dtype " << framework::DataTypeToString(dtype);
+        tensor->mutable_data(op.place(), dtype);
         operators::math::set_constant(*dev_ctx, tensor, 0.0);
       }
     }

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -384,6 +384,13 @@ static void OpBaseRunImpl(const framework::OperatorBase& op,
   prepared_op.Run(tmp_ins, outs, attrs);
 
   VLOG(4) << LayerDebugString(op.Type(), ins, outs);
+
+  // set the output var
+  for (auto& var_pair : outs) {
+    for (auto& var : var_pair.second) {
+      SetForwardDataTypeOfGradVar(var);
+    }
+  }
 }
 
 void OpBase::Run(const framework::OperatorBase& op,

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -388,7 +388,10 @@ static void OpBaseRunImpl(const framework::OperatorBase& op,
   // set the output var
   for (auto& var_pair : outs) {
     for (auto& var : var_pair.second) {
-      SetForwardDataTypeOfGradVar(var);
+      // NOTE(zhiqu): The ouput may be NULL because of pruning.
+      if (var) {
+        SetForwardDataTypeOfGradVar(var);
+      }
     }
   }
 }

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -73,6 +73,7 @@ class VarBase {
       : var_(std::make_shared<VariableWrapper>(name)),
         grad_var_(has_grad ? new VarBase(false, GradVarName()) : nullptr) {
     if (has_grad) {
+      grad_var_->var_->SetForwardVar(var_);
       var_->SetGradVar(grad_var_->var_);
     }
 
@@ -229,6 +230,7 @@ class VarBase {
   const std::shared_ptr<VariableWrapper> var_;
 
   std::shared_ptr<VarBase> grad_var_;
+  std::weak_ptr<VarBase> forward_var_;
 
   /**
    * NOTE(zengjinle): should consider whether to implement an inlined vector

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -230,7 +230,6 @@ class VarBase {
   const std::shared_ptr<VariableWrapper> var_;
 
   std::shared_ptr<VarBase> grad_var_;
-  std::weak_ptr<VarBase> forward_var_;
 
   /**
    * NOTE(zengjinle): should consider whether to implement an inlined vector

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -73,7 +73,6 @@ class VarBase {
       : var_(std::make_shared<VariableWrapper>(name)),
         grad_var_(has_grad ? new VarBase(false, GradVarName()) : nullptr) {
     if (has_grad) {
-      grad_var_->var_->SetForwardVar(var_);
       var_->SetGradVar(grad_var_->var_);
     }
 

--- a/paddle/fluid/imperative/prepared_operator.h
+++ b/paddle/fluid/imperative/prepared_operator.h
@@ -50,7 +50,7 @@ void SetForwardDataTypeOfGradVar<VariableWrapper>(
     const std::shared_ptr<VariableWrapper>& var) {
   if (var->HasGradVar()) {
     auto grad_var = var->GetGradVar();
-    VLOG(6) << "Set grad var (" << grad_var->Name() << ") dtype to ("
+    VLOG(6) << "Set grad var (" << grad_var->Name() << ")'s forward dtype to ("
             << framework::DataTypeToString(var->DataType()) << ").";
     grad_var->SetForwardDataType(var->DataType());
   }

--- a/paddle/fluid/imperative/variable_wrapper.h
+++ b/paddle/fluid/imperative/variable_wrapper.h
@@ -126,10 +126,6 @@ class VariableWrapper {
     return grad_var_.lock();
   }
 
-  std::shared_ptr<VariableWrapper> GetForwardVar() const {
-    return forward_var_.lock();
-  }
-
   const std::weak_ptr<VariableWrapper>& GetWeakGradVar() const {
     return grad_var_;
   }
@@ -253,17 +249,6 @@ class VariableWrapper {
     }
   }
 
-  void SetForwardVar(const std::shared_ptr<VariableWrapper>& var) {
-    auto shared_var = forward_var_.lock();
-    if (shared_var != var) {
-      PADDLE_ENFORCE_EQ(
-          shared_var, nullptr,
-          platform::errors::PermissionDenied(
-              "Cannot set forward variable wrapper twice for %s", name_));
-      forward_var_ = var;
-    }
-  }
-
   void SetGradNode(const std::shared_ptr<GradOpNode>& grad_node) {
     if (!grad_node) {
       grad_node_.reset();
@@ -338,7 +323,6 @@ class VariableWrapper {
       static_cast<framework::proto::VarType::Type>(-1)};
 
   std::weak_ptr<VariableWrapper> grad_var_;
-  std::weak_ptr<VariableWrapper> forward_var_;
   std::weak_ptr<GradOpNode> grad_node_;
 
   // TODO(zhouwei): fix bug of Tensor.clear_gradient(), function SetIsEmpty()

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -55,6 +55,7 @@ std::map<std::string, std::set<std::string>> op_ins_map = {
     {"multiclass_nms3", {"BBoxes", "Scores", "RoisNum"}},
     {"box_coder", {"PriorBox", "PriorBoxVar", "TargetBox"}},
     {"momentum", {"Param", "Grad", "Velocity", "LearningRate"}},
+    {"rnn", {"Input", "PreState", "WeightList", "SequenceLength"}},
 };
 
 // NOTE(zhiqiu): Like op_ins_map.
@@ -84,6 +85,7 @@ std::map<std::string, std::set<std::string>> op_outs_map = {
     {"multiclass_nms3", {"Out", "NmsRoisNum"}},
     {"generate_proposals_v2", {"RpnRois", "RpnRoiProbs", "RpnRoisNum"}},
     {"momentum", {"ParamOut", "VelocityOut"}},
+    {"rnn", {"DropoutState", "Reserve", "Out", "State"}},
 };
 
 // NOTE(zhiqiu): Commonly, the outputs in auto-generated OP function are
@@ -128,6 +130,7 @@ std::map<std::string, std::set<std::string>> op_passing_outs_map = {
     {"update_loss_scaling",
      {"Out", "LossScaling", "OutGoodSteps", "OutBadSteps"}},
     {"moving_average_abs_max_scale", {"OutScale", "OutAccum", "OutState"}},
+    {"rnn", {"DropoutState"}},
 };
 
 // clang-format off

--- a/python/paddle/fluid/tests/unittests/rnn/test_rnn_nets.py
+++ b/python/paddle/fluid/tests/unittests/rnn/test_rnn_nets.py
@@ -272,8 +272,7 @@ class TestLSTM(unittest.TestCase):
 
     def test_predict(self):
         predict_test_util(self.place, "LSTM")
-        predict_test_util(self.place, "LSTM", "float64", stop_gradient=False)
-        predict_test_util(self.place, "LSTM", "float32", stop_gradient=False)
+        predict_test_util(self.place, "LSTM", False)
 
     def runTest(self):
         self.test_with_initial_state()
@@ -282,9 +281,8 @@ class TestLSTM(unittest.TestCase):
         self.test_predict()
 
 
-def predict_test_util(place, mode, dtype="float32", stop_gradient=True):
+def predict_test_util(place, mode, stop_gradient=True):
     place = paddle.set_device(place)
-    paddle.set_default_dtype(dtype)
     paddle.seed(123)
     np.random.seed(123)
 

--- a/python/paddle/fluid/tests/unittests/rnn/test_rnn_nets.py
+++ b/python/paddle/fluid/tests/unittests/rnn/test_rnn_nets.py
@@ -272,6 +272,8 @@ class TestLSTM(unittest.TestCase):
 
     def test_predict(self):
         predict_test_util(self.place, "LSTM")
+        predict_test_util(self.place, "LSTM", "float64", stop_gradient=False)
+        predict_test_util(self.place, "LSTM", "float32", stop_gradient=False)
 
     def runTest(self):
         self.test_with_initial_state()
@@ -280,7 +282,7 @@ class TestLSTM(unittest.TestCase):
         self.test_predict()
 
 
-def predict_test_util(place, mode):
+def predict_test_util(place, mode, dtype="float32", stop_gradient=True):
     place = paddle.set_device(place)
     paddle.seed(123)
     np.random.seed(123)
@@ -297,8 +299,8 @@ def predict_test_util(place, mode):
         def forward(self, input):
             return self.rnn(input)
 
-    x = paddle.randn((4, 10, 16))
-    x.stop_gradient = False
+    x = paddle.randn((4, 10, 16), dtype=dtype)
+    x.stop_gradient = stop_gradient
     seq_len = paddle.to_tensor(np.array([10, 6, 8, 5]))
     mask = sequence_mask(seq_len, maxlen=10, dtype=x.dtype)
     mask = paddle.unsqueeze(mask, [2])

--- a/python/paddle/fluid/tests/unittests/rnn/test_rnn_nets.py
+++ b/python/paddle/fluid/tests/unittests/rnn/test_rnn_nets.py
@@ -284,6 +284,7 @@ class TestLSTM(unittest.TestCase):
 
 def predict_test_util(place, mode, dtype="float32", stop_gradient=True):
     place = paddle.set_device(place)
+    paddle.set_default_dtype(dtype)
     paddle.seed(123)
     np.random.seed(123)
 
@@ -299,7 +300,7 @@ def predict_test_util(place, mode, dtype="float32", stop_gradient=True):
         def forward(self, input):
             return self.rnn(input)
 
-    x = paddle.randn((4, 10, 16), dtype=dtype)
+    x = paddle.randn((4, 10, 16))
     x.stop_gradient = stop_gradient
     seq_len = paddle.to_tensor(np.array([10, 6, 8, 5]))
     mask = sequence_mask(seq_len, maxlen=10, dtype=x.dtype)

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -906,6 +906,7 @@ class RNNBase(LayerList):
         self.could_use_cudnn = True
         self.could_use_cudnn &= len(self.parameters()) == num_layers * 4 * (
             2 if direction in bidirectional_list else 1)
+            
 
         # Expose params as RNN's attribute, which can make it compatible when
         # replacing small ops composed rnn with cpp rnn kernel.

--- a/python/paddle/nn/layer/rnn.py
+++ b/python/paddle/nn/layer/rnn.py
@@ -906,7 +906,6 @@ class RNNBase(LayerList):
         self.could_use_cudnn = True
         self.could_use_cudnn &= len(self.parameters()) == num_layers * 4 * (
             2 if direction in bidirectional_list else 1)
-            
 
         # Expose params as RNN's attribute, which can make it compatible when
         # replacing small ops composed rnn with cpp rnn kernel.
@@ -978,39 +977,50 @@ class RNNBase(LayerList):
     def _cudnn_impl(self, inputs, initial_states, sequence_length):
         if not self.time_major:
             inputs = paddle.tensor.transpose(inputs, [1, 0, 2])
-        out = self._helper.create_variable_for_type_inference(inputs.dtype)
-        state = [
-            self._helper.create_variable_for_type_inference(inputs.dtype)
-            for i in range(self.state_components)
-        ]
-        reserve = self._helper.create_variable_for_type_inference(
-            dtype=fluid.core.VarDesc.VarType.UINT8, stop_gradient=True)
 
-        inputs = {
-            'Input': inputs,
-            'WeightList': self._all_weights,
-            'PreState': initial_states,
-            'SequenceLength': sequence_length
-        }
-        attrs = {
-            'dropout_prob': self.dropout,
-            'is_bidirec': self.num_directions == 2,
-            'input_size': self.input_size,
-            'hidden_size': self.hidden_size,
-            'num_layers': self.num_layers,
-            'mode': self.mode,
-            'is_test': not self.training
-        }
+        if fluid.framework.in_dygraph_mode():
+            _, _, out, state = framework.core.ops.rnn(
+                inputs, initial_states, self._all_weights, sequence_length,
+                self._dropout_state, self.state_components, 'dropout_prob',
+                self.dropout, 'is_bidirec', self.num_directions == 2,
+                'input_size', self.input_size, 'hidden_size', self.hidden_size,
+                'num_layers', self.num_layers, 'mode', self.mode, 'is_test',
+                not self.training)
+        else:
+            out = self._helper.create_variable_for_type_inference(inputs.dtype)
+            state = [
+                self._helper.create_variable_for_type_inference(inputs.dtype)
+                for i in range(self.state_components)
+            ]
+            reserve = self._helper.create_variable_for_type_inference(
+                dtype=fluid.core.VarDesc.VarType.UINT8, stop_gradient=True)
 
-        outputs = {
-            'Out': out,
-            'State': state,
-            'Reserve': reserve,
-            'DropoutState': self._dropout_state,
-        }
+            inputs = {
+                'Input': inputs,
+                'WeightList': self._all_weights,
+                'PreState': initial_states,
+                'SequenceLength': sequence_length
+            }
+            attrs = {
+                'dropout_prob': self.dropout,
+                'is_bidirec': self.num_directions == 2,
+                'input_size': self.input_size,
+                'hidden_size': self.hidden_size,
+                'num_layers': self.num_layers,
+                'mode': self.mode,
+                'is_test': not self.training
+            }
 
-        self._helper.append_op(
-            type="rnn", inputs=inputs, outputs=outputs, attrs=attrs)
+            outputs = {
+                'Out': out,
+                'State': state,
+                'Reserve': reserve,
+                'DropoutState': self._dropout_state,
+            }
+
+            self._helper.append_op(
+                type="rnn", inputs=inputs, outputs=outputs, attrs=attrs)
+
         out = paddle.tensor.transpose(out,
                                       [1, 0, 2]) if not self.time_major else out
         return out, tuple(state) if len(state) > 1 else state[0]
@@ -1021,15 +1031,15 @@ class RNNBase(LayerList):
         if initial_states is None:
             state_shape = (self.num_layers * self.num_directions, -1,
                            self.hidden_size)
-            if self.state_components == 1:
-                initial_states = paddle.fluid.layers.fill_constant_batch_size_like(
+            initial_states = tuple([
+                paddle.fluid.layers.fill_constant_batch_size_like(
                     inputs, state_shape, dtype, 0, batch_index, 1)
-            else:
-                initial_states = tuple([
-                    paddle.fluid.layers.fill_constant_batch_size_like(
-                        inputs, state_shape, dtype, 0, batch_index, 1)
-                    for _ in range(self.state_components)
-                ])
+                for _ in range(self.state_components)
+            ])
+        else:
+            initial_states = [initial_states] if isinstance(
+                initial_states,
+                paddle.fluid.framework.Variable) else initial_states
 
         if self.could_use_cudnn:
             # Add CPU kernel and dispatch in backend later


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix dtype of ungenerated grad var

### Why
In the following situation, there are more than one outputs generated by an operator, and only one of them is involved in the loss calculation. (eg, rnn op)

In backward execution, `out1@grad` is generated from loss@grad by BP, while `out0@grad` is not. However, the grad_op may need  `out0@grad`, `out1@grad`, and other forward input vars (x, y, maybe) as inputs. Since `out0@grad` is not generated, it will be set as 0. The problem is that we need to know the real `dtype` of `out0@grad`, otherwise it may result in dtype error.

```
out0, out1 = op(x, y)
loss = loss_fn(out1)
loss.backward()
```
### How
In the above situation, `out0@grad` will use the `dtype` of the related forward variable `out0` as real `dtype`.

