### PR TITLE
Fix the dropout setting when not initialized in rnn_op

### DIFF
--- a/paddle/fluid/operators/rnn_op.cu.cc
+++ b/paddle/fluid/operators/rnn_op.cu.cc
@@ -89,15 +89,16 @@ class RNNDescriptors {
 
     // ------------------- cudnn dropout descriptors ---------------------
     size_t state_size;
-    if (!is_test_ && !dropout_state->IsInitialized()) {
+    bool is_initialized = dropout_state->IsInitialized();
+    if (!is_test_ && !is_initialized) {
       PADDLE_ENFORCE_CUDA_SUCCESS(
           platform::dynload::cudnnDropoutGetStatesSize(handle, &state_size));
       dropout_state->mutable_data<uint8_t>({static_cast<int64_t>(state_size)},
                                            place);
     }
-    dropout_desc_.descriptor(handle, place, dropout_state->IsInitialized(),
-                             dropout_prob_, is_test_ ? nullptr : dropout_state,
-                             seed_, state_size);
+    dropout_desc_.descriptor(handle, place, is_initialized, dropout_prob_,
+                             is_test_ ? nullptr : dropout_state, seed_,
+                             state_size);
 
 // ------------------- cudnn rnn descriptors ---------------------
 #if CUDNN_VERSION >= 6000


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix the dropout setting when dropout state is not initialized in rnn_op.