### PR TITLE
Support user-defined activation/weight quantize and preprocess.

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/quant_nn.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/quant_nn.py
@@ -333,10 +333,10 @@ class QuantizedConv2D(layers.Layer):
                  moving_rate=0.9,
                  weight_quantize_type='abs_max',
                  activation_quantize_type='abs_max',
-                 weight_preprocess=None,
-                 act_preprocess=None,
-                 weight_quantize=None,
-                 act_quantize=None):
+                 weight_pre_layer=None,
+                 act_pre_layer=None,
+                 weight_quant_layer=None,
+                 act_quant_layer=None):
         super(QuantizedConv2D, self).__init__()
         # For Conv2D
         self._groups = getattr(layer, '_groups')
@@ -352,8 +352,8 @@ class QuantizedConv2D(layers.Layer):
         # For FakeQuant
         self._conv2d_quant_axis = 0
 
-        if weight_quantize is not None:
-            self._fake_quant_weight = weight_quantize()
+        if weight_quant_layer is not None:
+            self._fake_quant_weight = weight_quant_layer()
         else:
             self._fake_quant_weight = _get_fake_quant_type(
                 weight_quantize_type,
@@ -364,8 +364,8 @@ class QuantizedConv2D(layers.Layer):
                 quant_on_weight=True,
                 channel_num=self.weight.shape[self._conv2d_quant_axis],
                 quant_axis=self._conv2d_quant_axis)
-        if act_quantize is not None:
-            self._fake_quant_input = act_quantize()
+        if act_quant_layer is not None:
+            self._fake_quant_input = act_quant_layer()
         else:
             self._fake_quant_input = _get_fake_quant_type(
                 activation_quantize_type,
@@ -375,20 +375,18 @@ class QuantizedConv2D(layers.Layer):
                 dtype=self._dtype,
                 quant_on_weight=False)
 
-        self.do_act_preprocess = True if act_preprocess is not None else False
-        self.do_weight_preprocess = True if weight_preprocess is not None else False
-        if self.do_act_preprocess:
-            self._act_preprocess = act_preprocess()
-        if self.do_weight_preprocess:
-            self._weight_preprocess = weight_preprocess()
+        self._act_preprocess = act_pre_layer(
+        ) if act_pre_layer is not None else None
+        self._weight_preprocess = weight_pre_layer(
+        ) if weight_pre_layer is not None else None
 
     def forward(self, input):
-        if self.do_act_preprocess:
+        if self._act_preprocess is not None:
             input = self._act_preprocess(input)
         quant_input = self._fake_quant_input(input)
 
         weight = self.weight
-        if self.do_weight_preprocess:
+        if self._weight_preprocess is not None:
             weight = self._weight_preprocess(self.weight)
         quant_weight = self._fake_quant_weight(weight)
 
@@ -453,10 +451,10 @@ class QuantizedLinear(layers.Layer):
                  moving_rate=0.9,
                  weight_quantize_type='abs_max',
                  activation_quantize_type='abs_max',
-                 weight_preprocess=None,
-                 act_preprocess=None,
-                 weight_quantize=None,
-                 act_quantize=None):
+                 weight_pre_layer=None,
+                 act_pre_layer=None,
+                 weight_quant_layer=None,
+                 act_quant_layer=None):
         super(QuantizedLinear, self).__init__()
         # For Linear
         self._act = getattr(layer, '_act')
@@ -466,8 +464,8 @@ class QuantizedLinear(layers.Layer):
         # For FakeQuant
         self._linear_quant_axis = 1
 
-        if weight_quantize is not None:
-            self._fake_quant_weight = weight_quantize()
+        if weight_quant_layer is not None:
+            self._fake_quant_weight = weight_quant_layer()
         else:
             self._fake_quant_weight = _get_fake_quant_type(
                 weight_quantize_type,
@@ -479,8 +477,8 @@ class QuantizedLinear(layers.Layer):
                 channel_num=self.weight.shape[self._linear_quant_axis],
                 quant_axis=self._linear_quant_axis)
 
-        if act_quantize is not None:
-            self._fake_quant_input = act_quantize()
+        if act_quant_layer is not None:
+            self._fake_quant_input = act_quant_layer()
         else:
             self._fake_quant_input = _get_fake_quant_type(
                 activation_quantize_type,
@@ -490,20 +488,18 @@ class QuantizedLinear(layers.Layer):
                 dtype=self._dtype,
                 quant_on_weight=False)
 
-        self.do_act_preprocess = True if act_preprocess is not None else False
-        self.do_weight_preprocess = True if weight_preprocess is not None else False
-        if self.do_act_preprocess:
-            self._act_preprocess = act_preprocess()
-        if self.do_weight_preprocess:
-            self._weight_preprocess = weight_preprocess()
+        self._act_preprocess = act_pre_layer(
+        ) if act_pre_layer is not None else None
+        self._weight_preprocess = weight_pre_layer(
+        ) if weight_pre_layer is not None else None
 
     def forward(self, input):
-        if self.do_act_preprocess:
+        if self._act_preprocess is not None:
             input = self._act_preprocess(input)
         quant_input = self._fake_quant_input(input)
 
         weight = self.weight
-        if self.do_weight_preprocess:
+        if self._weight_preprocess is not None:
             weight = self._weight_preprocess(self.weight)
         quant_weight = self._fake_quant_weight(weight)
 

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_user_defined.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_user_defined.py
@@ -1,0 +1,213 @@
+#   copyright (c) 2020 paddlepaddle authors. all rights reserved.
+#
+# licensed under the apache license, version 2.0 (the "license");
+# you may not use this file except in compliance with the license.
+# you may obtain a copy of the license at
+#
+#     http://www.apache.org/licenses/license-2.0
+#
+# unless required by applicable law or agreed to in writing, software
+# distributed under the license is distributed on an "as is" basis,
+# without warranties or conditions of any kind, either express or implied.
+# see the license for the specific language governing permissions and
+# limitations under the license.
+
+from __future__ import print_function
+
+import os
+import numpy as np
+import random
+import unittest
+import logging
+import paddle
+import paddle.nn as nn
+import paddle.fluid as fluid
+from paddle.fluid import core
+from paddle.fluid.optimizer import AdamOptimizer
+from paddle.fluid.framework import IrGraph
+from paddle.fluid.contrib.slim.quantization import ImperativeQuantAware
+from paddle.fluid.contrib.slim.quantization import QuantizationTransformPass
+from paddle.fluid.dygraph.container import Sequential
+from paddle.fluid.dygraph.nn import Conv2D
+from paddle.fluid.dygraph.nn import Pool2D
+from paddle.fluid.dygraph.nn import Linear
+from paddle.fluid.log_helper import get_logger
+from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX
+
+os.environ["CPU_NUM"] = "1"
+
+_logger = get_logger(
+    __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
+
+
+class PACT(nn.Layer):
+    def __init__(self, init_value=20):
+        super(PACT, self).__init__()
+        alpha_attr = paddle.ParamAttr(
+            name=self.full_name() + ".pact",
+            initializer=paddle.nn.initializer.Constant(value=init_value))
+        self.alpha = self.create_parameter(
+            shape=[1], attr=alpha_attr, dtype='float32')
+
+    def forward(self, x):
+        out_left = paddle.nn.functional.relu(x - self.alpha)
+        out_right = paddle.nn.functional.relu(-self.alpha - x)
+        x = x - out_left + out_right
+        return x
+
+
+class ImperativeLenet(fluid.dygraph.Layer):
+    def __init__(self, num_classes=10, classifier_activation='softmax'):
+        super(ImperativeLenet, self).__init__()
+        self.features = Sequential(
+            Conv2D(
+                num_channels=1,
+                num_filters=6,
+                filter_size=3,
+                stride=1,
+                padding=1),
+            Pool2D(
+                pool_size=2, pool_type='max', pool_stride=2),
+            Conv2D(
+                num_channels=6,
+                num_filters=16,
+                filter_size=5,
+                stride=1,
+                padding=0),
+            Pool2D(
+                pool_size=2, pool_type='max', pool_stride=2))
+
+        self.fc = Sequential(
+            Linear(
+                input_dim=400, output_dim=120),
+            Linear(
+                input_dim=120, output_dim=84),
+            Linear(
+                input_dim=84, output_dim=num_classes,
+                act=classifier_activation))
+
+    def forward(self, inputs):
+        x = self.features(inputs)
+
+        x = fluid.layers.flatten(x, 1)
+        x = self.fc(x)
+        return x
+
+
+class TestUserDefinedActPreprocess(unittest.TestCase):
+    def setUp(self):
+        _logger.info("test act_preprocess")
+        self.imperative_qat = ImperativeQuantAware(act_preprocess=PACT)
+
+    def test_quant_aware_training(self):
+        imperative_qat = self.imperative_qat
+        seed = 1
+        np.random.seed(seed)
+        fluid.default_main_program().random_seed = seed
+        fluid.default_startup_program().random_seed = seed
+        lenet = ImperativeLenet()
+        fixed_state = {}
+        param_init_map = {}
+        for name, param in lenet.named_parameters():
+            p_shape = param.numpy().shape
+            p_value = param.numpy()
+            if name.endswith("bias"):
+                value = np.zeros_like(p_value).astype('float32')
+            else:
+                value = np.random.normal(
+                    loc=0.0, scale=0.01,
+                    size=np.product(p_shape)).reshape(p_shape).astype('float32')
+            fixed_state[name] = value
+            param_init_map[param.name] = value
+        lenet.set_dict(fixed_state)
+
+        imperative_qat.quantize(lenet)
+        adam = AdamOptimizer(
+            learning_rate=0.001, parameter_list=lenet.parameters())
+        dynamic_loss_rec = []
+
+        def train(model):
+            adam = AdamOptimizer(
+                learning_rate=0.001, parameter_list=model.parameters())
+            epoch_num = 1
+            for epoch in range(epoch_num):
+                model.train()
+                for batch_id, data in enumerate(train_reader()):
+                    x_data = np.array([x[0].reshape(1, 28, 28)
+                                       for x in data]).astype('float32')
+                    y_data = np.array(
+                        [x[1] for x in data]).astype('int64').reshape(-1, 1)
+
+                    img = fluid.dygraph.to_variable(x_data)
+                    label = fluid.dygraph.to_variable(y_data)
+                    out = model(img)
+                    acc = fluid.layers.accuracy(out, label)
+                    loss = fluid.layers.cross_entropy(out, label)
+                    avg_loss = fluid.layers.mean(loss)
+                    avg_loss.backward()
+                    adam.minimize(avg_loss)
+                    model.clear_gradients()
+                    if batch_id % 100 == 0:
+                        _logger.info(
+                            "Train | At epoch {} step {}: loss = {:}, acc= {:}".
+                            format(epoch, batch_id,
+                                   avg_loss.numpy(), acc.numpy()))
+
+        def test(model):
+            model.eval()
+            avg_acc = [[], []]
+            for batch_id, data in enumerate(test_reader()):
+                x_data = np.array([x[0].reshape(1, 28, 28)
+                                   for x in data]).astype('float32')
+                y_data = np.array(
+                    [x[1] for x in data]).astype('int64').reshape(-1, 1)
+
+                img = fluid.dygraph.to_variable(x_data)
+                label = fluid.dygraph.to_variable(y_data)
+
+                out = model(img)
+                acc_top1 = fluid.layers.accuracy(input=out, label=label, k=1)
+                acc_top5 = fluid.layers.accuracy(input=out, label=label, k=5)
+                avg_acc[0].append(acc_top1.numpy())
+                avg_acc[1].append(acc_top5.numpy())
+                if batch_id % 100 == 0:
+                    _logger.info(
+                        "Test | step {}: acc1 = {:}, acc5 = {:}".format(
+                            batch_id, acc_top1.numpy(), acc_top5.numpy()))
+
+        train_reader = paddle.batch(
+            paddle.dataset.mnist.train(), batch_size=64, drop_last=True)
+        test_reader = paddle.batch(paddle.dataset.mnist.test(), batch_size=64)
+        train(lenet)
+        test(lenet)
+        print(paddle.summary(lenet, (1, 1, 28, 28)))
+
+        paddle.jit.save(
+            layer=lenet,
+            path="./dynamic_quant_user_defined/model",
+            input_spec=[
+                paddle.static.InputSpec(
+                    shape=[None, 1, 28, 28], dtype='float32')
+            ])
+
+
+class TestUserDefinedWeightPreprocess(TestUserDefinedActPreprocess):
+    def setUp(self):
+        _logger.info("test weight_preprocess")
+        self.imperative_qat = ImperativeQuantAware(weight_preprocess=PACT)
+
+
+class TestUserDefinedActQuantize(TestUserDefinedActPreprocess):
+    def setUp(self):
+        _logger.info("test act_quantize")
+        self.imperative_qat = ImperativeQuantAware(act_quantize=PACT)
+
+
+class TestUserDefinedWeightQuantize(TestUserDefinedActPreprocess):
+    def setUp(self):
+        _logger.info("test weight_quantize")
+        self.imperative_qat = ImperativeQuantAware(weight_quantize=PACT)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_user_defined.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_imperative_qat_user_defined.py
@@ -141,11 +141,12 @@ class TestUserDefinedActPreprocess(unittest.TestCase):
                     avg_loss.backward()
                     adam.minimize(avg_loss)
                     model.clear_gradients()
-                    if batch_id % 100 == 0:
+                    if batch_id % 50 == 0:
                         _logger.info(
                             "Train | At epoch {} step {}: loss = {:}, acc= {:}".
                             format(epoch, batch_id,
                                    avg_loss.numpy(), acc.numpy()))
+                        break
 
         def test(model):
             model.eval()
@@ -170,11 +171,10 @@ class TestUserDefinedActPreprocess(unittest.TestCase):
                             batch_id, acc_top1.numpy(), acc_top5.numpy()))
 
         train_reader = paddle.batch(
-            paddle.dataset.mnist.train(), batch_size=64, drop_last=True)
-        test_reader = paddle.batch(paddle.dataset.mnist.test(), batch_size=64)
+            paddle.dataset.mnist.train(), batch_size=512, drop_last=True)
+        test_reader = paddle.batch(paddle.dataset.mnist.test(), batch_size=512)
         train(lenet)
         test(lenet)
-        print(paddle.summary(lenet, (1, 1, 28, 28)))
 
         paddle.jit.save(
             layer=lenet,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Support user-defined quantification and preprocessing methods, such as PACT.
QAT model without using PACT
```bash

-----------------------------------------------------------------------------------------------
           Layer (type)                 Input Shape          Output Shape         Param #
===============================================================================================
     FakeQuantMovingAverage-1         [[1, 1, 28, 28]]      [1, 1, 28, 28]           3
FakeChannelWiseQuantDequantAbsMax-1    [[6, 1, 3, 3]]        [6, 1, 3, 3]            6
         QuantizedConv2D-1            [[1, 1, 28, 28]]      [1, 6, 28, 28]          60
             Pool2D-1                 [[1, 6, 28, 28]]      [1, 6, 14, 14]           0
     FakeQuantMovingAverage-2         [[1, 6, 14, 14]]      [1, 6, 14, 14]           3
FakeChannelWiseQuantDequantAbsMax-2   [[16, 6, 5, 5]]       [16, 6, 5, 5]           16
         QuantizedConv2D-2            [[1, 6, 14, 14]]     [1, 16, 10, 10]         2,416
             Pool2D-2                [[1, 16, 10, 10]]      [1, 16, 5, 5]            0
     FakeQuantMovingAverage-3            [[1, 400]]            [1, 400]              3
FakeChannelWiseQuantDequantAbsMax-3     [[400, 120]]          [400, 120]            120
         QuantizedLinear-1               [[1, 400]]            [1, 120]           48,120
     FakeQuantMovingAverage-4            [[1, 120]]            [1, 120]              3
FakeChannelWiseQuantDequantAbsMax-4     [[120, 84]]           [120, 84]             84
         QuantizedLinear-2               [[1, 120]]            [1, 84]            10,164
     FakeQuantMovingAverage-5            [[1, 84]]             [1, 84]               3
FakeChannelWiseQuantDequantAbsMax-5      [[84, 10]]            [84, 10]             10
         QuantizedLinear-3               [[1, 84]]             [1, 10]              850
===============================================================================================
Total params: 61,861
Trainable params: 61,610
Non-trainable params: 251
-----------------------------------------------------------------------------------------------
Input size (MB): 0.00
Forward/backward pass size (MB): 0.55
Params size (MB): 0.24
Estimated Total Size (MB): 0.79
-----------------------------------------------------------------------------------------------
```

PACT QAT model:
```bash
-----------------------------------------------------------------------------------------------
           Layer (type)                 Input Shape          Output Shape         Param #
===============================================================================================
              PACT-1                  [[1, 1, 28, 28]]      [1, 1, 28, 28]           1
     FakeQuantMovingAverage-1         [[1, 1, 28, 28]]      [1, 1, 28, 28]           3
FakeChannelWiseQuantDequantAbsMax-1    [[6, 1, 3, 3]]        [6, 1, 3, 3]            6
         QuantizedConv2D-1            [[1, 1, 28, 28]]      [1, 6, 28, 28]          60
             Pool2D-1                 [[1, 6, 28, 28]]      [1, 6, 14, 14]           0
              PACT-2                  [[1, 6, 14, 14]]      [1, 6, 14, 14]           1
     FakeQuantMovingAverage-2         [[1, 6, 14, 14]]      [1, 6, 14, 14]           3
FakeChannelWiseQuantDequantAbsMax-2   [[16, 6, 5, 5]]       [16, 6, 5, 5]           16
         QuantizedConv2D-2            [[1, 6, 14, 14]]     [1, 16, 10, 10]         2,416
             Pool2D-2                [[1, 16, 10, 10]]      [1, 16, 5, 5]            0
              PACT-3                     [[1, 400]]            [1, 400]              1
     FakeQuantMovingAverage-3            [[1, 400]]            [1, 400]              3
FakeChannelWiseQuantDequantAbsMax-3     [[400, 120]]          [400, 120]            120
         QuantizedLinear-1               [[1, 400]]            [1, 120]           48,120
              PACT-4                     [[1, 120]]            [1, 120]              1
     FakeQuantMovingAverage-4            [[1, 120]]            [1, 120]              3
FakeChannelWiseQuantDequantAbsMax-4     [[120, 84]]           [120, 84]             84
         QuantizedLinear-2               [[1, 120]]            [1, 84]            10,164
              PACT-5                     [[1, 84]]             [1, 84]               1
     FakeQuantMovingAverage-5            [[1, 84]]             [1, 84]               3
FakeChannelWiseQuantDequantAbsMax-5      [[84, 10]]            [84, 10]             10
         QuantizedLinear-3               [[1, 84]]             [1, 10]              850
===============================================================================================
Total params: 61,866
Trainable params: 61,615
Non-trainable params: 251
-----------------------------------------------------------------------------------------------
Input size (MB): 0.00
Forward/backward pass size (MB): 0.57
Params size (MB): 0.24
Estimated Total Size (MB): 0.81
-----------------------------------------------------------------------------------------------
```