### PR TITLE
Use Sccache(ccache-like compiler tool) to speed up compile on windows

### DIFF
--- a/cmake/ccache.cmake
+++ b/cmake/ccache.cmake
@@ -1,14 +1,33 @@
-# Use ccache if found ccache program
+# On Linux, Use ccache if found ccache program
+# On Windows, Use sccache if found sccache program
+#   sccache(Shared ccache) is a ccache-like compiler caching tool.
+#   please refer to https://github.com/mozilla/sccache
 
-find_program(CCACHE_PATH ccache)
+if(NOT WIN32)
+    find_program(CCACHE_EXECUTABLE ccache)
 
-if(CCACHE_PATH)
-    execute_process(COMMAND ccache -V OUTPUT_VARIABLE ccache_output)
-    execute_process(COMMAND ccache -s cache directory OUTPUT_VARIABLE cache_directory)
-    string(REGEX MATCH "[0-9]+.[0-9]+" ccache_version ${ccache_output})
-    message(STATUS "Ccache is founded, use ccache to speed up compile.")
-    # show statistics summary of ccache
-    message("ccache version\t\t\t    " ${ccache_version} "\n" ${cache_directory})
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_PATH})
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_PATH})
-endif(CCACHE_PATH)
+    if(CCACHE_EXECUTABLE)
+        execute_process(COMMAND ccache -V OUTPUT_VARIABLE ccache_output)
+        execute_process(COMMAND ccache -s cache directory OUTPUT_VARIABLE cache_directory)
+        string(REGEX MATCH "[0-9]+.[0-9]+" ccache_version ${ccache_output})
+        message(STATUS "Ccache is founded on Linux, use ccache to speed up compile.")
+        # show statistics summary of ccache
+        message("ccache version\t\t\t    " ${ccache_version} "\n" ${cache_directory})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE_EXECUTABLE})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE_EXECUTABLE})
+    endif(CCACHE_EXECUTABLE)
+else()
+    find_program(SCCACHE_EXECUTALBE sccache)
+    message("===SCCACHE_EXECUTALBE====${SCCACHE_EXECUTALBE}")
+
+    if(SCCACHE_EXECUTALBE)
+        execute_process(COMMAND sccache --version OUTPUT_VARIABLE sccache_version)
+        execute_process(COMMAND sccache --show-stats OUTPUT_VARIABLE sccache_status)
+        message(STATUS "Sccache is founded on Windows, use ccache to speed up compile.")
+        # show statistics summary of sccache
+        message("sccache version\t\t\t    " ${sccache_version} "\n" ${sccache_status})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${SCCACHE_EXECUTALBE})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${SCCACHE_EXECUTALBE})
+    endif(SCCACHE_EXECUTALBE)
+endif()
+


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Use Sccache(ccache-like compiler tool) to speed up compile on windows.

本地测试：
- GPU: 第1次： 第2次：加速比：
- CPU: 第1次： 第2次： 加速比


CI测试：
