### PR TITLE
Fix gradients with ignore_idx in softmax_with_cross_entropy

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.h
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.h
@@ -82,6 +82,7 @@ class SoftmaxWithCrossEntropyGradKernel : public framework::OpKernel<T> {
     }
 
     const bool soft_label = context.Attr<bool>("soft_label");
+    auto ignore_index = context.Attr<int>("ignore_index");
 
     const int rank = logit_grad->dims().size();
     const int axis = CanonicalAxis(context.Attr<int>("axis"), rank);
@@ -117,6 +118,11 @@ class SoftmaxWithCrossEntropyGradKernel : public framework::OpKernel<T> {
           int idx = i * remain + j;
           logit_grad_data[i * d + label_data[idx] * remain + j] -=
               out_grad_data[idx];
+          if (label_data[idx] == ignore_index) {
+            for (int k = 0; k < axis_dim; ++k) {
+              logit_grad_data[i * d + k * remain + j] = 0;
+            }
+          }
         }
       }
     }

--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.h
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.h
@@ -116,12 +116,13 @@ class SoftmaxWithCrossEntropyGradKernel : public framework::OpKernel<T> {
       for (int i = 0; i < n; ++i) {
         for (int j = 0; j < remain; j++) {
           int idx = i * remain + j;
-          logit_grad_data[i * d + label_data[idx] * remain + j] -=
-              out_grad_data[idx];
           if (label_data[idx] == ignore_index) {
             for (int k = 0; k < axis_dim; ++k) {
               logit_grad_data[i * d + k * remain + j] = 0;
             }
+          } else {
+            logit_grad_data[i * d + label_data[idx] * remain + j] -=
+                out_grad_data[idx];
           }
         }
       }

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -83,9 +83,9 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         self.attrs = {
             "numeric_stable_mode": self.numeric_stable_mode,
             "soft_label": self.soft_label,
+            "ignore_index": self.ignore_index,
         }
-        if self.ignore_index >= 0:
-            self.attrs['ignore_index'] = self.ignore_index
+
         if self.axis != -1:
             self.attrs['axis'] = self.axis
 
@@ -93,7 +93,7 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(["Logits"], "Loss", max_relative_error=0.05)
+        self.check_grad(["Logits"], "Loss")
 
 
 class TestSoftmaxWithCrossEntropyOpNoCudnn(TestSoftmaxWithCrossEntropyOp):

--- a/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
+++ b/python/paddle/fluid/tests/unittests/test_softmax_with_cross_entropy_op.py
@@ -93,7 +93,7 @@ class TestSoftmaxWithCrossEntropyOp(OpTest):
         self.check_output()
 
     def test_check_grad(self):
-        self.check_grad(["Logits"], "Loss")
+        self.check_grad(["Logits"], "Loss", max_relative_error=5e-5)
 
 
 class TestSoftmaxWithCrossEntropyOpNoCudnn(TestSoftmaxWithCrossEntropyOp):

--- a/python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py
@@ -36,7 +36,6 @@ NEED_FIX_FP64_CHECK_GRAD_THRESHOLD_OP_LIST = [
     'selu', \
     'sigmoid_cross_entropy_with_logits', \
     'soft_relu', \
-    'softmax_with_cross_entropy', \
     'spp', \
     'teacher_student_sigmoid_loss', \
     'unpool', \

--- a/python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py
+++ b/python/paddle/fluid/tests/unittests/white_list/op_threshold_white_list.py
@@ -36,6 +36,7 @@ NEED_FIX_FP64_CHECK_GRAD_THRESHOLD_OP_LIST = [
     'selu', \
     'sigmoid_cross_entropy_with_logits', \
     'soft_relu', \
+    'softmax_with_cross_entropy', \
     'spp', \
     'teacher_student_sigmoid_loss', \
     'unpool', \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix gradient calculation with ignore_idx in softmax_with_cross_entropy.

Example code for reproducing error gradients on elements with `ignore_idx`:
```python
import paddle
import numpy as np

paddle.seed(123)
np.random.seed(123)

class Net(paddle.nn.Layer):
    def __init__(self):
        super(Net, self).__init__()
        self.embedder = paddle.nn.Embedding(100, 64)
        self.linear = paddle.nn.Linear(64, 5)

    def forward(self, x, y):
        x = self.embedder(x)
        self.logits = logits = self.linear(x)
        print(y)
        loss = paddle.nn.functional.softmax_with_cross_entropy(logits, y, ignore_index=1)
        loss = paddle.mean(loss)
        return loss

x_data = np.random.randint(0, 5, (4,)).astype("int64")
x = paddle.to_tensor(x_data)
y_data = np.random.randint(0, 5, (4, 1))
y_data[0, 0] = 1  # ignore_idx
y = paddle.to_tensor(y_data)

net = Net()
loss = net(x, y)
loss.backward()
print(net.logits.grad)
```
