### PR TITLE
Adjust signal trigger wait time to fix unittest random failed

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
@@ -49,7 +49,7 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             test_process.start()
 
             set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(5)
+            time.sleep(10)
         except SystemError as ex:
             self.assertIn("Fatal", cpt.get_exception_message(ex))
             exception = ex
@@ -67,7 +67,7 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             test_process.start()
 
             set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(3)
+            time.sleep(10)
         except SystemError as ex:
             self.assertIn("Segmentation fault", cpt.get_exception_message(ex))
             exception = ex
@@ -85,7 +85,7 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             test_process.start()
 
             set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(3)
+            time.sleep(10)
         except SystemError as ex:
             self.assertIn("Bus error", cpt.get_exception_message(ex))
             exception = ex


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

adjust signal trigger wait time to fix unittest random failed

单测并行执行时候调度存在不确定性，test_imperative_signal_handler中的单测都是让子进程主动抛出一个signal错误，然后主进程捕获这个错误从而通过验证，但由于进程调度的原因，子进程的执行可能不是马上进行的，这导致，主进程在等待几秒之后结束还没有等到子进程执行抛出错误，所以这个单测偶尔会失败，要进一步减小失败的可能，有两种方法：
1. 延长主进程等待时间
2. 设置为独占执行的单测

这里采取第一种方法修复