### PR TITLE
Fix output dtype inconsistent with input

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_gather_op.py
+++ b/python/paddle/fluid/tests/unittests/test_gather_op.py
@@ -19,6 +19,7 @@ import numpy as np
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+from paddle.framework import core
 
 
 def gather_numpy(x, index, axis):
@@ -296,6 +297,14 @@ class TestGathertError(unittest.TestCase):
                 paddle.fluid.layers.gather(x, index_float)
 
             self.assertRaises(TypeError, test_index_type)
+
+
+class TestCheckOutType(unittest.TestCase):
+    def test_out_type(self):
+        data = paddle.static.data(shape=[16, 10], dtype='int64', name='x')
+        index = paddle.static.data(shape=[4], dtype='int64', name='index')
+        out = paddle.gather(data, index)
+        self.assertTrue(out.dtype == core.VarDesc.VarType.INT64)
 
 
 if __name__ == "__main__":

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -153,7 +153,7 @@ def flip(x, axis, name=None):
     """
     helper = LayerHelper("flip", **locals())
     check_type(x, 'X', (Variable), 'flip')
-    dtype = helper.input_dtype(input_param_name='x')
+    dtype = helper.input_dtype('x')
     check_dtype(dtype, 'X',
                 ['float16', 'float32', 'float64', 'int32', 'int64', 'bool'],
                 'flip')

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -153,7 +153,7 @@ def flip(x, axis, name=None):
     """
     helper = LayerHelper("flip", **locals())
     check_type(x, 'X', (Variable), 'flip')
-    dtype = helper.input_dtype('x')
+    dtype = helper.input_dtype(input_param_name='x')
     check_dtype(dtype, 'X',
                 ['float16', 'float32', 'float64', 'int32', 'int64', 'bool'],
                 'flip')
@@ -808,7 +808,7 @@ def gather(x, index, axis=None, name=None):
         check_type(axis, 'axis', (int), 'gather')
 
     helper = LayerHelper('gather', **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype('x')
     out = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type="gather",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix output dtype inconsistent with input