### PR TITLE
[Test] Fix fake_quant error when the dimension of quantized is larger than 1024

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -69,6 +69,10 @@ _out_scale_op_list = [
     "hard_swish",
     "hard_sigmoid",
     "conv2d_transpose",
+    "gru",
+    "bilinear_interp",
+    "nearest_interp",
+    "trilinear_interp",
 ]
 
 # list op real input and output names, to avoid processing input such as AxisTensor.
@@ -114,6 +118,7 @@ _op_real_in_out_name = {
     "scale": [["X"], ["Out"]],
     "hard_swish": [["X"], ["Out"]],
     "hard_sigmoid": [["X"], ["Out"]],
+    "gru": [["Input", "Weight"], ["Hidden"]],
 }
 
 _conv_ops = ['conv2d', 'depthwise_conv2d', 'conv2d_transpose']


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix fake_quant error when the dimension of quantized is larger than 1024