### PR TITLE
Add check for non-dispensable input

### DIFF
--- a/paddle/fluid/pybind/op_function.h
+++ b/paddle/fluid/pybind/op_function.h
@@ -36,9 +36,15 @@ namespace pybind {
 
 static inline std::shared_ptr<imperative::VarBase> CastPyHandleToVarBase(
     const std::string& op_type, const std::string& arg_name, int arg_idx,
-    const py::handle& handle) {
+    const py::handle& handle, bool dispensable = false) {
   PyObject* py_obj = handle.ptr();  // get underlying PyObject
   if (!py_obj || py_obj == Py_None) {
+    if (!dispensable) {
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "%s(): argument '%s' (position %d) must be Tensor, but got "
+          "%s",
+          op_type, arg_name, arg_idx, Py_TYPE(py_obj)->tp_name));
+    }
     return nullptr;
   }
   try {
@@ -54,9 +60,15 @@ static inline std::shared_ptr<imperative::VarBase> CastPyHandleToVarBase(
 static inline std::vector<std::shared_ptr<imperative::VarBase>>
 CastPyHandleToVarBaseList(const std::string& op_type,
                           const std::string& arg_name, int arg_idx,
-                          const py::handle& handle) {
+                          const py::handle& handle, bool dispensable = false) {
   PyObject* py_obj = handle.ptr();  // get underlying PyObject
   if (!py_obj || py_obj == Py_None) {
+    if (!dispensable) {
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "%s(): argument '%s' (position %d) must be Tensor, but got "
+          "%s",
+          op_type, arg_name, arg_idx, Py_TYPE(py_obj)->tp_name));
+    }
     return {};
   }
   std::vector<std::shared_ptr<imperative::VarBase>> result;

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -263,7 +263,7 @@ GenerateOpFunctions(const std::string& module_name) {
       input_args_num++;
       const auto in_cast_type =
           input.duplicable() ? CAST_VAR_LIST_TEMPLATE : CAST_VAR_TEMPLATE;
-      auto dispensable = input.duplicable() ? "true" : "false";
+      auto dispensable = input.dispensable() ? "true" : "false";
       ins_cast_str +=
           paddle::string::Sprintf(in_cast_type, in_name, op_type, in_name,
                                   arg_idx++, TempName(in_name), dispensable);

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -166,10 +166,10 @@ const char* OUT_VAR_TYPE = R"(std::shared_ptr<imperative::VarBase>)";
 const char* OUT_VAR_LIST_TYPE = R"(std::vector<std::shared_ptr<imperative::VarBase>>)";
 
 const char* CAST_VAR_TEMPLATE = R"(
-  auto %s = CastPyHandleToVarBase("%s", "%s", %d, %s);)";
+  auto %s = CastPyHandleToVarBase("%s", "%s", %d, %s, %s);)";
 
 const char* CAST_VAR_LIST_TEMPLATE = R"(
-  auto %s = CastPyHandleToVarBaseList("%s", "%s", %d, %s);)";
+  auto %s = CastPyHandleToVarBaseList("%s", "%s", %d, %s, %s);)";
 
 
 const char* ARG_TEMPLATE = R"(const %s& %s)";
@@ -263,9 +263,10 @@ GenerateOpFunctions(const std::string& module_name) {
       input_args_num++;
       const auto in_cast_type =
           input.duplicable() ? CAST_VAR_LIST_TEMPLATE : CAST_VAR_TEMPLATE;
+      auto dispensable = input.duplicable() ? "true" : "false";
       ins_cast_str +=
           paddle::string::Sprintf(in_cast_type, in_name, op_type, in_name,
-                                  arg_idx++, TempName(in_name));
+                                  arg_idx++, TempName(in_name), dispensable);
 
       if (input.dispensable()) {
         const auto in_template = input.duplicable()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Add check and throw an exception when non-dispensable input is None

- example
```
import paddle
x1 = paddle.to_tensor([1.2])
paddle.mv(x=x1, vec=None)
```

- before
```
--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::imperative::Tracer::TraceOp(std::string const&, paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::AttributeMap)
1   paddle::imperative::Tracer::TraceOp(std::string const&, paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::AttributeMap, paddle::platform::Place const&, bool)
2   paddle::imperative::PreparedOp::Prepare(paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::OperatorWithKernel const&, paddle::platform::Place const&, paddle::framework::AttributeMap const&)
3   paddle::imperative::PreparedOp paddle::imperative::PrepareOpImpl<paddle::imperative::VarBase>(paddle::imperative::details::NameVarMapTrait<paddle::imperative::VarBase>::Type const&, paddle::imperative::details::NameVarMapTrait<paddle::imperative::VarBase>::Type const&, paddle::framework::OperatorWithKernel const&, paddle::platform::Place, paddle::framework::AttributeMap const&)
4   paddle::framework::SignalHandle(char const*, int)
5   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
FatalError: `Segmentation fault` is detected by the operating system.
  [TimeInfo: *** Aborted at 1605541982 (unix time) try "date -d @1605541982" if you are using GNU date ***]
  [SignalInfo: *** SIGSEGV (@0x0) received by PID 5692 (TID 0x7f6c2add3700) from PID 0 ***]

Segmentation fault
```

- after
```
Traceback (most recent call last):
  File "a.py", line 3, in <module>
    paddle.mv(x=x1, vec=None)
  File "/usr/local/lib/python3.8/dist-packages/paddle/tensor/linalg.py", line 931, in mv
    out = core.ops.mv(x, vec)
ValueError: 

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::platform::EnforceNotMet::EnforceNotMet(paddle::platform::ErrorSummary const&, char const*, int)
1   paddle::platform::GetCurrentTraceBackString[abi:cxx11]()

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: mv(): argument 'Vec' (position 1) must be Tensor, but got NoneType (at /Paddle/Paddle/paddle/fluid/pybind/op_function.h:46)
```