### PR TITLE
communication stream use high priority

### DIFF
--- a/paddle/fluid/platform/nccl_helper.h
+++ b/paddle/fluid/platform/nccl_helper.h
@@ -79,7 +79,10 @@ struct NCCLContext {
   ncclComm_t comm_;
 
   explicit NCCLContext(int dev_id)
-      : ctx_(new CUDADeviceContext(CUDAPlace(dev_id))), comm_{nullptr} {}
+      : ctx_(new CUDADeviceContext(CUDAPlace(dev_id))), comm_{nullptr} {
+    // communication stream use high priority
+    ctx_->ResetDefaultContext(platform::stream::Priority::kHigh);
+  }
 
   cudaStream_t stream() const { return ctx_->stream(); }
   ncclComm_t comm() const { return comm_; }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
At present, the priority of communication stream is the same as the calculation stream. If the priority of the communication stream is raised, the communication may be executed ahead of time, which may improve the performance.
![image](https://user-images.githubusercontent.com/10208305/99403408-65993400-2925-11eb-89a0-5e5dee70d69c.png)

性能测试：
v100 32G机器，由于测试集群中存在不同cpu配置的机器。所以在相同任务下测试不同分支的速度，排除机器配置的影响。

#### resnet50测试
fp16测试
节点*卡数 | batch_size | develop速度 | PR速度 | 速度提升
-- | -- | -- | -- | --
1*1 | 256 | 1158.079 | 1153.842 | -0.37%
1*1 | 128 | 1074.966 | 1071.897 | -0.29%
1*1 | 64 | 972.601 | 965.277 | -0.75%
1*8 | 256 | 8948.252 | 8954.939 | 0.07%
1*8 | 128 | 8104.042 | 8050.583 | -0.66%
1*8 | 64 | 7134.114 | 7091.422 | -0.60%
2*8 | 256 | 16225.948 | 16094.808 | -0.81%
2*8 | 128 | 14269.97 | 14240.891 | -0.20%
2*8 | 64 | 11632.285 | 11685.657 | 0.46%
4*8 | 256 | 31673.684 | 31478.329 | -0.62%
4*8 | 128 | 29020.726 | 29176.776 | 0.54%
4*8 | 64 | 22803.938 | 22947.152 | 0.63%

fp32测试
节点*卡数 | batch_size | develop速度 | PR速度 | 速度提升
-- | -- | -- | -- | --
1*1 | 128 | 368.93 | 368.655 | -0.07%
1*1 | 64 | 353.52 | 354.036 | 0.15%
1*1 | 32 | 325.102 | 325.811 | 0.22%
1*8 | 128 | 2764.938 | 2782.944 | 0.65%
1*8 | 64 | 2608.006 | 2603.62 | -0.17%
1*8 | 32 | 2467.9 | 2470.463 | 0.10%
2*8 | 128 | 5674.31 | 5664.382 | -0.17%
2*8 | 64 | 5273.955 | 5259.953 | -0.27%
2*8 | 32 | 4510.088 | 4491.356 | -0.42%
4*8 | 128 | 11199.232 | 11185.599 | -0.12%
4*8 | 64 | 10333.509 | 10330.098 | -0.03%
4*8 | 32 | 8620.307 | 8613.178 | -0.08%

#### Bert base seq_len=128
fp16测试
节点*卡数 | batch_size | develop速度 | PR速度 | 速度提升
-- | -- | -- | -- | --
1*1 | 160 | 333.145 | 333.657 | 0.15%
1*1 | 96 | 321.448 | 319.645 | -0.56%
1*1 | 64 | 305.729 | 304.959 | -0.25%
1*8 | 160 | 2589.636 | 2580.183 | -0.37%
1*8 | 96 | 2457.885 | 2455.727 | -0.09%
1*8 | 64 | 2308.992 | 2309.034 | 0.00%
2*8 | 160 | 4802.248 | 4727.645 | -1.55%
2*8 | 96 | 4349.065 | 4380.348 | 0.72%
2*8 | 64 | 3924.497 | 3921.626 | -0.07%
4*8 | 160 | 9548.709 | 9576.389 | 0.29%
4*8 | 96 | 8516.147 | 8556.374 | 0.47%
4*8 | 64 | 7728.587 | 7709.398 | -0.25%

fp32测试
节点*卡数 | batch_size | develop速度 | PR速度 | 速度提升
-- | -- | -- | -- | --
1*1 | 96 | 142.827 | 142.522 | -0.21%
1*1 | 64 | 139.675 | 139.731 | 0.04%
1*8 | 96 | 1077.706 | 1074.861 | -0.26%
1*8 | 64 | 1043.632 | 1038.578 | -0.48%
2*8 | 96 | 2124.069 | 2113.197 | -0.51%
2*8 | 64 | 2014.465 | 2019.604 | 0.26%
4*8 | 96 | 4177.11 | 4141.855 | -0.84%
4*8 | 64 | 3918.5 | 3916.539 | -0.05%

性能基本属于波动范围，看起来没有性能提升。。