### PR TITLE
fix the bug in expand_as op

### DIFF
--- a/paddle/fluid/operators/expand_as_v2_op.cc
+++ b/paddle/fluid/operators/expand_as_v2_op.cc
@@ -45,7 +45,7 @@ class ExpandAsV2Op : public framework::OperatorWithKernel {
             "The rank of Input(target_tensor) must not be less than or equal "
             "to %d. But received: input rank %u, input shape [%s].",
             MAX_RANK_SUPPORTED, x_dims.size(), x_dims));
-    std::vector<int64_t> out_shape(target_tensor_dims.size());
+    std::vector<int> out_shape = framework::vectorize<int>(target_tensor_dims);
     ctx->SetOutputDim("Out", framework::make_ddim(out_shape));
   }
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix the bug in expand_as op.

ExternalError:  Cuda error(77), an illegal memory access was encountered.