### PR TITLE
[Dy2stat] Fix convert_call May be Called Multiple Times

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -260,9 +260,9 @@ class NameVisitor(gast.NodeVisitor):
             type_node = node.args[1]
             if isinstance(type_node, gast.Tuple):
                 for element in type_node.elts:
-                    self.type_vars.add(ast_to_source_code(element))
+                    self.type_vars.add(ast_to_source_code(element).strip())
             else:
-                self.type_vars.add(ast_to_source_code(type_node))
+                self.type_vars.add(ast_to_source_code(type_node).strip())
         self.generic_visit(node)
 
     def _var_nodes_to_names(self, node_set, ctx_filter_set=None):
@@ -381,7 +381,7 @@ class NameVisitor(gast.NodeVisitor):
 
         # 3. Remove var type names which are stored in self.type_vars
         for var in loop_vars:
-            if ast_to_source_code(var) in self.type_vars:
+            if ast_to_source_code(var).strip() in self.type_vars:
                 removed_vars.add(var)
 
         return loop_vars - removed_vars

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -149,7 +149,14 @@ def _is_api_in_module_helper(obj, module_prefix):
 
 def is_api_in_module(node, module_prefix):
     assert isinstance(node, gast.Call), "Input non-Call node for is_dygraph_api"
-    func_str = astor.to_source(gast.gast_to_ast(node.func))
+
+    # Python can have gast.Call as function, for example: covert_call(func)(x)
+    # We only check the most outside function
+    func_node = node.func
+    while isinstance(func_node, gast.Call):
+        func_node = func_node.func
+
+    func_str = astor.to_source(gast.gast_to_ast(func_node)).strip()
     try:
         # TODO(liym27):
         #  Consider a better to import modules like:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix convert_callmMay be called multiple times in Dy2stat. Also strip some strings to make sure no influence from blank spaces.