### PR TITLE
Fix wrong out dtype inferred from helper.input_dtype

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6685,8 +6685,8 @@ def pad(x, paddings, pad_value=0., name=None):
     check_variable_and_dtype(
         x, 'x', ['float16', 'float32', 'float64', 'int32', 'int64'], "pad")
 
-    helper = LayerHelper('pad', input=x, **locals())
-    dtype = helper.input_dtype()
+    helper = LayerHelper('pad', **locals())
+    dtype = helper.input_dtype(input_param_name='x')
     out = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type='pad',
@@ -6780,8 +6780,8 @@ def pad_constant_like(x, y, pad_value=0., name=None):
     check_variable_and_dtype(y, 'y', ['float32', 'float64', 'int32', 'int64'],
                              "pad_constant_like")
 
-    helper = LayerHelper('pad_constant_like', input=x, **locals())
-    dtype = helper.input_dtype()
+    helper = LayerHelper('pad_constant_like', **locals())
+    dtype = helper.input_dtype(input_param_name='y')
     out = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type='pad_constant_like',
@@ -8892,7 +8892,6 @@ def mean_iou(input, label, num_classes):
     check_variable_and_dtype(input, 'Predictions', ['int32', 'int64'],
                              'mean_iou')
     check_variable_and_dtype(label, 'Labels', ['int32', 'int64'], 'mean_iou')
-    dtype = helper.input_dtype()
     out_mean_iou = helper.create_variable_for_type_inference(dtype='float32')
     out_wrong = helper.create_variable_for_type_inference(dtype='int32')
     out_correct = helper.create_variable_for_type_inference(dtype='int32')

--- a/python/paddle/fluid/layers/sequence_lod.py
+++ b/python/paddle/fluid/layers/sequence_lod.py
@@ -759,8 +759,8 @@ def sequence_expand(x, y, ref_level=-1, name=None):
         "sequence layer is not supported in dygraph mode yet.")
     check_variable_and_dtype(x, 'x', ['float32', 'float64', 'int32', 'int64'],
                              'sequence_expand')
-    helper = LayerHelper('sequence_expand', input=x, **locals())
-    dtype = helper.input_dtype()
+    helper = LayerHelper('sequence_expand', **locals())
+    dtype = helper.input_dtype(input_param_name='x')
     tmp = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type='sequence_expand',
@@ -880,8 +880,8 @@ def sequence_expand_as(x, y, name=None):
     check_variable_and_dtype(x, 'x', ['float32', 'float64', 'int32', 'int64'],
                              'sequence_expand_as')
     check_type(y, 'y', Variable, 'sequence_expand_as')
-    helper = LayerHelper('sequence_expand_as', input=x, **locals())
-    dtype = helper.input_dtype()
+    helper = LayerHelper('sequence_expand_as', **locals())
+    dtype = helper.input_dtype(input_param_name='x')
     tmp = helper.create_variable_for_type_inference(dtype)
     helper.append_op(
         type='sequence_expand_as',
@@ -980,13 +980,13 @@ def sequence_pad(x, pad_value, maxlen=None, name=None):
 
     assert not in_dygraph_mode(), (
         "sequence layer is not supported in dygraph mode yet.")
-    helper = LayerHelper('sequence_pad', input=x, **locals())
+    helper = LayerHelper('sequence_pad', **locals())
     check_variable_and_dtype(x, 'x', ['float32', 'float64', 'int32', 'int64'],
                              'fluid.layers.sequence_pad')
     check_variable_and_dtype(pad_value, 'pad_value',
                              ['float32', 'float64', 'int32', 'int64'],
                              'fluid.layers.sequence_pad')
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     out = helper.create_variable_for_type_inference(dtype)
     length = helper.create_variable_for_type_inference(VarDesc.VarType.INT64)
 
@@ -1062,12 +1062,12 @@ def sequence_unpad(x, length, name=None):
 
     assert not in_dygraph_mode(), (
         "sequence layer is not supported in dygraph mode yet.")
-    helper = LayerHelper('sequence_unpad', input=x, **locals())
+    helper = LayerHelper('sequence_unpad', **locals())
     check_variable_and_dtype(x, 'x', ['float32', 'float64', 'int32', 'int64'],
                              'fluid.layers.sequence_unpad')
     check_variable_and_dtype(length, 'length', ['int64'],
                              'fluid.layers.sequence_unpad')
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     out = helper.create_variable_for_type_inference(dtype)
 
     length.stop_gradient = True

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -76,12 +76,9 @@ def check_out_dtype(api_fn, in_specs, expect_dtypes, target_index=0, **configs):
             out_dtype = fluid.data_feeder.convert_dtype(out.dtype)
 
             if out_dtype != expect_dtype:
-                paddle.disable_static()
                 raise ValueError(
                     "Expected out.dtype is {}, but got {} from {}.".format(
                         expect_dtype, out_dtype, api_fn.__name__))
-
-    paddle.disable_static()
 
 
 def _set_use_system_allocator(value=None):

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -39,6 +39,51 @@ from white_list import op_accuracy_white_list, check_shape_white_list, compile_v
 from white_list import op_threshold_white_list, no_grad_set_white_list
 
 
+def check_out_dtype(api_fn, in_specs, expect_dtypes, target_index=0, **configs):
+    """
+    Determines whether dtype of output tensor is as expected.
+
+    Args:
+        api_fn(callable):  paddle api function
+        in_specs(list[tuple]): list of shape and dtype information for constructing input tensor of api_fn, such as [(shape, dtype), (shape, dtype)].
+        expected_dtype(list[str]): expected dtype of output tensor.
+        target_index(int): indicate which one from in_specs to infer the dtype of output.
+        config(dict): other arguments of paddle api function
+
+    Example:
+        check_out_dtype(fluid.layers.pad_constant_like, [([2,3,2,3], 'float64'), ([1, 3, 1,3], )], ['float32', 'float64', 'int64'], target_index=1, pad_value=0.)
+
+    """
+    paddle.enable_static()
+    for i, expect_dtype in enumerate(expect_dtypes):
+        with paddle.static.program_guard(paddle.static.Program()):
+            input_t = []
+            for index, spec in enumerate(in_specs):
+                if len(spec) == 1:
+                    shape = spec[0]
+                    dtype = expect_dtype if target_index == index else 'float32'
+                elif len(spec) == 2:
+                    shape, dtype = spec
+                else:
+                    raise ValueError(
+                        "Value of in_specs[{}] should contains two elements: [shape, dtype]".
+                        format(index))
+                input_t.append(
+                    paddle.static.data(
+                        name='data_%s' % index, shape=shape, dtype=dtype))
+
+            out = api_fn(*input_t, **configs)
+            out_dtype = fluid.data_feeder.convert_dtype(out.dtype)
+
+            if out_dtype != expect_dtype:
+                paddle.disable_static()
+                raise ValueError(
+                    "Expected out.dtype is {}, but got {} from {}.".format(
+                        expect_dtype, out_dtype, api_fn.__name__))
+
+    paddle.disable_static()
+
+
 def _set_use_system_allocator(value=None):
     USE_SYSTEM_ALLOCATOR_FLAG = "FLAGS_use_system_allocator"
     old_value = core.globals()[USE_SYSTEM_ALLOCATOR_FLAG]

--- a/python/paddle/fluid/tests/unittests/test_adaptive_max_pool1d.py
+++ b/python/paddle/fluid/tests/unittests/test_adaptive_max_pool1d.py
@@ -14,7 +14,7 @@
 
 import numpy as np
 import unittest
-from op_test import OpTest
+from op_test import OpTest, check_out_dtype
 import paddle.fluid.core as core
 from paddle.fluid import compiler, Program, program_guard
 import paddle
@@ -104,6 +104,17 @@ class TestPool1D_API(unittest.TestCase):
         for place in self.places:
             self.check_adaptive_max_dygraph_results(place)
             self.check_adaptive_max_static_results(place)
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_max_pool(self):
+        api_fn = F.adaptive_max_pool1d
+        shape = [1, 3, 32]
+        check_out_dtype(
+            api_fn,
+            in_specs=[(shape, )],
+            expect_dtypes=['float32', 'float64'],
+            output_size=16)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_adaptive_max_pool2d.py
+++ b/python/paddle/fluid/tests/unittests/test_adaptive_max_pool2d.py
@@ -19,10 +19,11 @@ import unittest
 import numpy as np
 
 import paddle.fluid.core as core
-from op_test import OpTest
+from op_test import OpTest, check_out_dtype
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
+import paddle.nn.functional as F
 
 
 def adaptive_start_index(index, input_size, output_size):
@@ -268,6 +269,17 @@ class TestAdaptiveMaxPool2DClassAPI(unittest.TestCase):
             #assert np.allclose(out_4.numpy(), self.res_4_np)
 
             assert np.allclose(out_5.numpy(), self.res_5_np)
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_max_pool(self):
+        api_fn = F.adaptive_max_pool2d
+        shape = [1, 3, 32, 32]
+        check_out_dtype(
+            api_fn,
+            in_specs=[(shape, )],
+            expect_dtypes=['float32', 'float64'],
+            output_size=16)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_adaptive_max_pool3d.py
+++ b/python/paddle/fluid/tests/unittests/test_adaptive_max_pool3d.py
@@ -19,10 +19,11 @@ import unittest
 import numpy as np
 
 import paddle.fluid.core as core
-from op_test import OpTest
+from op_test import OpTest, check_out_dtype
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
+import paddle.nn.functional as F
 
 
 def adaptive_start_index(index, input_size, output_size):
@@ -289,6 +290,17 @@ class TestAdaptiveMaxPool3DClassAPI(unittest.TestCase):
             #     assert np.allclose(out_4.numpy(), self.res_4_np)
 
             assert np.allclose(out_5.numpy(), self.res_5_np)
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_max_pool(self):
+        api_fn = F.adaptive_max_pool3d
+        shape = [1, 3, 32, 32, 32]
+        check_out_dtype(
+            api_fn,
+            in_specs=[(shape, )],
+            expect_dtypes=['float32', 'float64'],
+            output_size=16)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_op.py
@@ -16,12 +16,13 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest, skip_check_grad_ci, check_out_dtype
 import paddle.fluid.core as core
 from paddle.fluid.op import Operator
 import paddle.compat as cpt
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
+import paddle.nn.functional as F
 
 
 class TestLookupTableOp(OpTest):
@@ -313,6 +314,16 @@ class TestLookupTableWithTensorIdsWIsSelectedRowsInt8(
     def check_result(self, ids_array, result_array):
         for idx, row in np.ndenumerate(ids_array):
             assert (row == result_array[idx]).all()
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_dtype(self):
+        api_fn = F.embedding
+        check_out_dtype(
+            api_fn,
+            in_specs=[([10, 16], 'int64'), ([100, 64], )],
+            expect_dtypes=['float32', 'float64'],
+            target_index=1)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_max_op.py
+++ b/python/paddle/fluid/tests/unittests/test_max_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest, skip_check_grad_ci, check_out_dtype
 import paddle
 import paddle.fluid.core as core
 
@@ -85,3 +85,17 @@ class ApiMaxTest(unittest.TestCase):
         np_z = z.numpy()
         z_expected = np.array(np.max(np_x, axis=0))
         self.assertEqual((np_z == z_expected).all(), True)
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_max(self):
+        api_fn = paddle.max
+        shape = [10, 16]
+        check_out_dtype(
+            api_fn,
+            in_specs=[(shape, )],
+            expect_dtypes=['float32', 'float64', 'int32', 'int64'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_min_op.py
+++ b/python/paddle/fluid/tests/unittests/test_min_op.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest, skip_check_grad_ci
+from op_test import OpTest, skip_check_grad_ci, check_out_dtype
 import paddle
 import paddle.fluid.core as core
 
@@ -85,3 +85,17 @@ class ApiMinTest(unittest.TestCase):
         np_z = z.numpy()
         z_expected = np.array(np.min(np_x, axis=0))
         self.assertEqual((np_z == z_expected).all(), True)
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_min(self):
+        api_fn = paddle.min
+        shape = [10, 16]
+        check_out_dtype(
+            api_fn,
+            in_specs=[(shape, )],
+            expect_dtypes=['float32', 'float64', 'int32', 'int64'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
+++ b/python/paddle/fluid/tests/unittests/test_pad_constant_like.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
-from op_test import OpTest
+from op_test import OpTest, check_out_dtype
 import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 
@@ -86,6 +86,17 @@ class TestPadConstantLikeOpError(unittest.TestCase):
                 fluid.layers.pad_constant_like(x=var_x, y=y_data)
 
             self.assertRaises(TypeError, test_Variable_y)
+
+
+class TestOutDtype(unittest.TestCase):
+    def test_dtype(self):
+        api_fn = fluid.layers.pad_constant_like
+        check_out_dtype(
+            api_fn,
+            in_specs=[([2, 3, 2, 3], 'float64'), ([1, 3, 1, 3], )],
+            expect_dtypes=['float32', 'float64', 'int32', 'int64'],
+            target_index=1,
+            pad_value=0.)
 
 
 if __name__ == '__main__':

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -310,7 +310,7 @@ def conv1d(x,
         check_variable_and_dtype(x, 'input', ['float16', 'float32', 'float64'],
                                  'conv2d')
         helper = LayerHelper(l_type, **locals())
-        dtype = helper.input_dtype()
+        dtype = helper.input_dtype(input_param_name='x')
         out = helper.create_variable_for_type_inference(dtype)
         outputs = {"Output": [out]}
         helper.append_op(
@@ -528,7 +528,7 @@ def conv2d(x,
         check_variable_and_dtype(x, 'x', ['float16', 'float32', 'float64'],
                                  'conv2d')
         helper = LayerHelper(l_type, **locals())
-        dtype = helper.input_dtype()
+        dtype = helper.input_dtype(input_param_name='x')
         pre_bias = helper.create_variable_for_type_inference(dtype)
         outputs = {"Output": [pre_bias]}
         helper.append_op(
@@ -790,7 +790,7 @@ def conv1d_transpose(x,
         check_variable_and_dtype(x, 'input', ['float16', 'float32', 'float64'],
                                  'conv2d_transpose')
         helper = LayerHelper(op_type, **locals())
-        dtype = helper.input_dtype()
+        dtype = helper.input_dtype(input_param_name='x')
         out = helper.create_variable_for_type_inference(dtype)
         outputs = {"Output": [out]}
         helper.append_op(
@@ -1225,7 +1225,7 @@ def conv3d(x,
             "data_format": data_format
         }
         helper = LayerHelper(op_type, **locals())
-        dtype = helper.input_dtype()
+        dtype = helper.input_dtype(input_param_name='x')
         check_variable_and_dtype(x, 'x', ['float16', 'float32', 'float64'],
                                  'conv3d')
 

--- a/python/paddle/nn/functional/input.py
+++ b/python/paddle/nn/functional/input.py
@@ -199,7 +199,7 @@ def embedding(x, weight, padding_idx=None, sparse=False, name=None):
             'remote_prefetch', False, 'padding_idx', padding_idx)
     else:
         helper = LayerHelper('embedding', **locals())
-        dtype = helper.input_dtype()
+        dtype = helper.input_dtype(input_param_name='weight')
 
         check_variable_and_dtype(x, 'input', ['int32', 'int64'], 'embedding')
 

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -236,7 +236,7 @@ def avg_pool1d(x,
 
     op_type = 'pool2d'
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     helper.append_op(
@@ -348,7 +348,7 @@ def avg_pool2d(x,
 
     op_type = 'pool2d'
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     helper.append_op(
@@ -463,7 +463,7 @@ def avg_pool3d(x,
 
     op_type = "pool3d"
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
     outputs = {"Out": pool_out}
 
@@ -584,7 +584,7 @@ def max_pool1d(x,
 
     op_type = 'max_pool2d_with_index' if return_mask else "pool2d"
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
     mask = helper.create_variable_for_type_inference(dtype)
     outputs = {"Out": pool_out, "Mask": mask}
@@ -718,7 +718,7 @@ def max_pool2d(x,
 
     op_type = 'max_pool2d_with_index' if return_mask else "pool2d"
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
     mask = helper.create_variable_for_type_inference(dtype)
     outputs = {"Out": pool_out, "Mask": mask}
@@ -844,7 +844,7 @@ def max_pool3d(x,
 
     op_type = "max_pool3d_with_index" if return_mask else "pool3d"
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_type='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
     mask = helper.create_variable_for_type_inference(dtype)
     outputs = {"Out": pool_out, "Mask": mask}
@@ -925,7 +925,7 @@ def adaptive_avg_pool1d(x, output_size, name=None):
         return squeeze(pool_out, [2])
 
     helper = LayerHelper(l_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     outputs = {"Out": pool_out}
@@ -1024,7 +1024,7 @@ def adaptive_avg_pool2d(x, output_size, data_format='NCHW', name=None):
     l_type = 'pool2d'
 
     helper = LayerHelper(l_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     outputs = {"Out": pool_out}
@@ -1130,7 +1130,7 @@ def adaptive_avg_pool3d(x, output_size, data_format='NCDHW', name=None):
     l_type = 'pool3d'
 
     helper = LayerHelper(l_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
     outputs = {"Out": pool_out}
 
@@ -1212,7 +1212,7 @@ def adaptive_max_pool1d(x, output_size, return_mask=False, name=None):
             pool_out[1], [2])) if return_mask else squeeze(pool_out[0], [2])
 
     helper = LayerHelper(l_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     mask = helper.create_variable_for_type_inference(dtype)
@@ -1300,7 +1300,7 @@ def adaptive_max_pool2d(x, output_size, return_mask=False, name=None):
     l_type = 'max_pool2d_with_index'
 
     helper = LayerHelper(l_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     mask = helper.create_variable_for_type_inference(dtype)
@@ -1393,7 +1393,7 @@ def adaptive_max_pool3d(x, output_size, return_mask=False, name=None):
     l_type = 'max_pool3d_with_index'
 
     helper = LayerHelper(l_type, **locals())
-    dtype = helper.input_dtype()
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
 
     mask = helper.create_variable_for_type_inference(dtype)

--- a/python/paddle/nn/functional/pooling.py
+++ b/python/paddle/nn/functional/pooling.py
@@ -844,7 +844,7 @@ def max_pool3d(x,
 
     op_type = "max_pool3d_with_index" if return_mask else "pool3d"
     helper = LayerHelper(op_type, **locals())
-    dtype = helper.input_dtype(input_param_type='x')
+    dtype = helper.input_dtype(input_param_name='x')
     pool_out = helper.create_variable_for_type_inference(dtype)
     mask = helper.create_variable_for_type_inference(dtype)
     outputs = {"Out": pool_out, "Mask": mask}

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -1176,7 +1176,7 @@ def max(x, axis=None, keepdim=False, name=None):
         x, 'x', ['float32', 'float64', 'int32', 'int64'], 'max')
 
     out = helper.create_variable_for_type_inference(
-            dtype=helper.input_dtype())
+            dtype=x.dtype)
     helper.append_op(
         type='reduce_max',
         inputs={'X': x},
@@ -1267,7 +1267,7 @@ def min(x, axis=None, keepdim=False, name=None):
         x, 'x', ['float32', 'float64', 'int32', 'int64'], 'min')
 
     out = helper.create_variable_for_type_inference(
-            dtype=helper.input_dtype())
+            dtype=x.dtype)
     helper.append_op(
         type='reduce_min',
         inputs={'X': x},


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
## 一、问题背景
### 1. helper.input_dtype 接口用途
在 Paddle 框架的 Python 端API实现中，常需要根据接口的输入Tensor（如 x）的类型推导出输出Tensor（如 out）的类型。

如 `paddle.max`的接口，此处调用`helper.input_dtype()`获取接口输入`input`张量的数据类型，并以此类型创建输出Out.
```python
def max(x, axis=None, keepdim=False, name=None):
   ......
   helper = LayerHelper('max', **locals())

   out = helper.create_variable_for_type_inference(
            dtype=helper.input_dtype())
            
   helper.append_op(
        type='reduce_max',
        inputs={'X': x},
        outputs={'Out': out},
        attrs={
            'dim': axis,
            'keep_dim': keepdim,
            'reduce_all': reduce_all
        })
    return out
```

### 2. helper.input_dtype 存在的问题
上述`input_type()`方法的实现内含一个支持缺省的默认参数`input_param_name`。

若未指定此参数，则会从接口中解析名称为`input`的输入Tensor，返回其数据类型。

`input_type`方法实现：
```python
def input_dtype(self, input_param_name='input'):
        inputs = self.multiple_input(input_param_name)
        dtype = None
        for each in inputs:
            if dtype is None:
                dtype = each.dtype
            elif dtype != each.dtype:
                raise ValueError("Data Type mismatch: %d to %d" %
                                 (dtype, each.dtype))
        return dtype
```

**存在问题：**
 
 + 若接口输入为`x`，则此接口返回`dtype`的值为None
 + `dtype`为None时，框架会默认创建一个`float32`类型的Tensor作为out
 + 在静态图组网时，默认的`float32`类型会导致组网失败（类型不一致）


### 3. 类型推导失败接口样例
如下是在静态图下推导类型与动态图不一致的两个 2.0 接口样例：

+ `paddle.max`接口
```python
import paddle
import paddle.nn.functional as F

paddle.set_device('cpu')

def test_max():
    data = paddle.randint(low=0, high=100, shape=[4, 10])
    max_data = paddle.max(data)
    print(max_data.dtype)  # int64

    paddle.enable_static()
    data = paddle.static.data(shape=[16, 10], dtype='int64', name='x')
    max_data = paddle.max(data)
    print(max_data.dtype)  # float32
```
当输入为`int64`类型时：
> 动态图下，输出为`int64`，正常
> 静态图下，输出为`float32`，错误

+ `F.adaptive_max_pool1d`接口

```python
def test_ adaptive_max_pool1d():
    data = paddle.randn([1, 3, 32], 'float64')
    pool_out = F.adaptive_max_pool1d(data, output_size=16)
    print(pool_out.dtype) # float64

    paddle.enable_static()
    data = paddle.static.data(shape=[1, 3, 32], dtype='float64', name='x')
    max_data = F.adaptive_max_pool1d(data, output_size=16)
    print(max_data.dtype)  # float32
```
当输入为`float64`类型时：
> 动态图下，输出为`float64`，正常
> 静态图下，输出为`float32`，错误


## 二、解决方案

### 1. 存量接口
目前，对框架内涉及使用`input_dtype`的接口进行了逐一排查，目前筛选出了具有类型推导风险的接口（见附表）。

针对存量的接口，需要各个API接口负责人确认`input_dtype()`返回的类型是否符合预期：

+ 若`input_dtype()`返回None值，则需要明确指定`input_dtype(input_param_name=XXX)`以获取正确的数据类型，不允许返回None值
+ 若`input_dtype()`返回不为None，则需要指定`input_param_name`参数值，以明确输出的类型是从哪个输入推导出来的


### 2. 新增接口
在存量接口解决完之后，会升级`helper.input_dtype()`方法：

+ 移除参数的缺省行为，减少默认行为带来的dtype不一致风险
+ 新增dtype返回为None的报错，禁止此接口返回None值


## 涉及接口

接口名称 | 接口路径 | 问题级别 |
|---|---|---|
| max| paddle/tensor/math.py |   动静行为不一致 |  
|min | paddle/tensor/math.py |   动静行为不一致 | 
| pad_constant_like|  paddle/fluid/layers/nn.py | 动静行为不一致 |
|embedding | paddle/nn/functional/input.py |  动静行为不一致 |
| pad| paddle/fluid/layers/nn.py |  动静行为不一致 |
|adaptive_max_pool1d | paddle/nn/functional/pooling.py | 动静行为不一致 |
|adaptive_max_pool2d |paddle/nn/functional/pooling.py  |动静行为不一致 |
|adaptive_max_pool3d | paddle/nn/functional/pooling.py | 动静行为不一致 |


以下接口python端产生out类型不一致，在C++端的inferVarType更新为正常dtype。但仍存在潜在风险，在本PR里也一并修复

接口名称 | 接口名称 | 接口名称 |
|---|---|---|
| mean_iou | sequence_expand | sequence_expand_as |
|sequence_pad |sequence_unpad | conv1d | 
| conv2d| conv1d_transpose | conv3d |
|avg_pool1d | avg_pool2d| avg_pool3d | 
| max_pool1d| max_pool2d| max_pool3d |
|adaptive_avg_pool1d |adaptive_avg_pool2d|  adaptive_avg_pool3d|

### TODO:
+ 针对后续新增接口，会单独提PR禁止`helper.input_dtype()`返回 None