### PR TITLE
improve performance of cast op

### DIFF
--- a/paddle/fluid/operators/cast_op.cu
+++ b/paddle/fluid/operators/cast_op.cu
@@ -15,11 +15,14 @@ limitations under the License. */
 #include "paddle/fluid/operators/cast_op.h"
 #include "paddle/fluid/platform/float16.h"
 
-template <typename T>
-using CastOpKernel =
-    paddle::operators::CastOpKernel<paddle::platform::CUDADeviceContext, T>;
+namespace ops = paddle::operators;
 
-REGISTER_OP_CUDA_KERNEL(cast, CastOpKernel<float>, CastOpKernel<double>,
-                        CastOpKernel<int>, CastOpKernel<int64_t>,
-                        CastOpKernel<bool>, CastOpKernel<uint8_t>,
-                        CastOpKernel<paddle::platform::float16>);
+REGISTER_OP_CUDA_KERNEL(
+    cast, ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext, double>,
+    ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext, int>,
+    ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext, int64_t>,
+    ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext, bool>,
+    ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext, uint8_t>,
+    ops::CastOpGPUKernel<paddle::platform::CUDADeviceContext,
+                         paddle::platform::float16>);

--- a/paddle/fluid/operators/cast_op.h
+++ b/paddle/fluid/operators/cast_op.h
@@ -62,5 +62,43 @@ class CastOpKernel : public framework::OpKernel<InT> {
   }
 };
 
+template <typename DeviceContext, typename InT, typename OutT>
+static void CastFunction(const framework::ExecutionContext& context) {
+  auto* in = context.Input<framework::Tensor>("X");
+  auto* out = context.Output<framework::Tensor>("Out");
+
+  auto in_t = framework::EigenVector<InT>::Flatten(*in);
+  out->mutable_data<OutT>(context.GetPlace());
+  auto out_t = framework::EigenVector<OutT>::Flatten(*out);
+  auto& place =
+      *context.template device_context<DeviceContext>().eigen_device();
+  out_t.device(place) = in_t.template cast<OutT>();
+}
+
+template <typename DeviceContext, typename InT>
+class CastOpGPUKernel : public framework::OpKernel<InT> {
+ public:
+  void Compute(const framework::ExecutionContext& context) const override {
+    auto out_type = static_cast<framework::proto::VarType::Type>(
+        context.Attr<int>("out_dtype"));
+
+    if (out_type == paddle::framework::proto::VarType::FP64) {
+      CastFunction<DeviceContext, InT, double>(context);
+    } else if (out_type == paddle::framework::proto::VarType::FP32) {
+      CastFunction<DeviceContext, InT, float>(context);
+    } else if (out_type == paddle::framework::proto::VarType::FP16) {
+      CastFunction<DeviceContext, InT, paddle::platform::float16>(context);
+    } else if (out_type == paddle::framework::proto::VarType::INT64) {
+      CastFunction<DeviceContext, InT, int64_t>(context);
+    } else if (out_type == paddle::framework::proto::VarType::INT32) {
+      CastFunction<DeviceContext, InT, int>(context);
+    } else if (out_type == paddle::framework::proto::VarType::UINT8) {
+      CastFunction<DeviceContext, InT, uint8_t>(context);
+    } else if (out_type == paddle::framework::proto::VarType::BOOL) {
+      CastFunction<DeviceContext, InT, bool>(context);
+    }
+  }
+};
+
 }  // namespace operators
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->  OPs 

### Describe
<!-- Describe what this PR does -->
当前的cast基于thrust::transform，每次CPU都会wait GPU Kernel执行完。换成eigen实现，能够避免wait。
