### PR TITLE
[Dynamic-to-Static] Remove unnecessary variables of the arguments in true_func/false_func

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/ifelse_simple_func.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import paddle
 import paddle.fluid as fluid
 
 
@@ -97,6 +98,16 @@ def dyfunc_with_if_else3(x):
     n = q + 2
     x = n
     return x
+
+
+def dyfunc_with_if_else_with_list_geneator(x):
+    if 10 > 5:
+        y = paddle.add_n(
+            [paddle.full(
+                shape=[2], fill_value=v) for v in range(5)])
+    else:
+        y = x
+    return y
 
 
 def nested_if_else(x_v):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -69,6 +69,12 @@ class TestDygraphIfElse3(TestDygraphIfElse):
         self.dyfunc = dyfunc_with_if_else3
 
 
+class TestDygraphIfElseWithListGenerator(TestDygraphIfElse):
+    def setUp(self):
+        self.x = np.random.random([10, 16]).astype('float32')
+        self.dyfunc = dyfunc_with_if_else_with_list_geneator
+
+
 class TestDygraphNestedIfElse(TestDygraphIfElse):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

#### Remove unnecessary variables of the arguments in `true_func`/`false_func`

Fox example:
- dygraph code
```python
def dyfunc_with_if_else_with_list_geneator(x):
    if 10 > 5:
        y = paddle.add_n([paddle.full(shape=[2], fill_value=v) for v in range(5)])
    else:
        y = x
    return y
```

- Before converted code:

In converted code, useless arguments in function `true_func`/`false_func`.  
In `true_fn_0`, 
   - (1) `v` is not a var from parent scope,  v should not in the arguments;
   - (2) `y` is created in `true_fn_0`, it doesn't have to be in the arguments.

In `false_fn_0`, 
   - (2) `y` is created in `false_fn_0`, it doesn't have to be in the arguments.
```python
def dyfunc_with_if_else_with_list_geneator(x):
    y = paddle.jit.dy2static.data_layer_not_check(name='y', shape=[-1], dtype='float32')

    def true_fn_0(v, y):    # v and y should not in the arguments of  true_fn_0
        y = paddle.add_n([paddle.full(shape=[2], fill_value=v) for v in range(5)])
        return y

    def false_fn_0(x, y):  # y should not in the arguments of  false_fn_0
        y = x
        return y

    #  NameError: name 'v' is not defined
    y = paddle.jit.dy2static.convert_ifelse(10 > 5, true_fn_0, false_fn_0, (v, y), (x, y), (y,))  
    return y

```


- Fixed convterd code:
```python
def dyfunc_with_if_else_with_list_geneator(x):
    y = paddle.jit.dy2static.data_layer_not_check(name='y', shape=[-1], dtype='float32')

    def true_fn_0():
        y = paddle.add_n([paddle.full(shape=[2], fill_value=v) for v in range(5)])
        return y

    def false_fn_0(x):
        y = x
        return y
    y = paddle.jit.dy2static.convert_ifelse(10 > 5, true_fn_0, false_fn_0, (), (x,), (y,))
    return y
```