### PR TITLE
Simplify the timeline, to remove the prefix of each event.

### DIFF
--- a/tools/timeline.py
+++ b/tools/timeline.py
@@ -58,7 +58,7 @@ class _ChromeTraceFormatter(object):
         event = {}
         event['ph'] = ph
         event['cat'] = category
-        event['name'] = name
+        event['name'] = name.replace("ParallelExecutor::Run/", "")
         event['pid'] = pid
         event['tid'] = tid
         event['ts'] = timestamp


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
简化timeline每个event的名字。自从加入`ParallelExecutor::Run`计时后，timeline的每个event名字也会出现`ParallelExecutor::Run/`前缀，当timeline缩放的较小时，缩略图无法看到是哪个op。因此在timeline.py里面处理下，生成timeline文件时删除每个event名字的`ParallelExecutor::Run/`前缀。
- 修改之前，timeline图如下：
![image](https://user-images.githubusercontent.com/12538138/99529984-a784b180-29db-11eb-99a4-0596c6109115.png)


- 修改之后，timeline图如下：
![image](https://user-images.githubusercontent.com/12538138/99529840-72785f00-29db-11eb-8089-cc3d8a4544aa.png)


