### PR TITLE
optimizer amp, all use fp16 communication, overlap comm and compute

### DIFF
--- a/paddle/fluid/operators/amp/update_loss_scaling_op.cu
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op.cu
@@ -49,30 +49,6 @@ class UpdateLossScalingFunctor<platform::CUDADeviceContext, T> {
   }
 };
 
-template <typename T>
-class LazyZeroInputs<platform::CUDADeviceContext, T> {
- public:
-  void operator()(const platform::CUDADeviceContext& dev_ctx,
-                  const bool* found_inf_data,
-                  const std::vector<const framework::Tensor*>& xs,
-                  const std::vector<framework::Tensor*>& outs) const {
-    const auto gpu_place =
-        BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace());
-    bool has_inf{false};
-    memory::Copy(platform::CPUPlace(), &has_inf, gpu_place, found_inf_data,
-                 sizeof(bool), dev_ctx.stream());
-    if (has_inf) {
-      VLOG(1) << "-- UpdateLossScaling: Infinite values are found in grads. --";
-      for (size_t i = 0; i < xs.size(); ++i) {
-        auto* out = outs[i];
-        T* out_data = out->mutable_data<T>(dev_ctx.GetPlace());
-        int num = out->numel();
-        cudaMemset(out_data, 0, num * sizeof(T));
-      }
-    }
-  }
-};
-
 }  // namespace operators
 }  // namespace paddle
 

--- a/paddle/fluid/operators/amp/update_loss_scaling_op.h
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op.h
@@ -70,23 +70,13 @@ class UpdateLossScalingFunctor {
 };
 
 template <typename DeviceContext, typename T>
-class LazyZeroInputs {
- public:
-  void operator()(const DeviceContext& dev_ctx, const bool* found_inf_data,
-                  const std::vector<const framework::Tensor*>& xs,
-                  const std::vector<framework::Tensor*>& outs) const;
-};
-
-template <typename DeviceContext, typename T>
 class UpdateLossScalingKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
-    const auto xs = ctx.MultiInput<framework::Tensor>("X");
     const auto* found_inf = ctx.Input<Tensor>("FoundInfinite");
     const auto* pre_loss_scaling = ctx.Input<Tensor>("PrevLossScaling");
     const auto* good_in = ctx.Input<Tensor>("InGoodSteps");
     const auto* bad_in = ctx.Input<Tensor>("InBadSteps");
-    auto outs = ctx.MultiOutput<framework::Tensor>("Out");
     auto* updated_loss_scaling = ctx.Output<Tensor>("LossScaling");
     auto* good_out = ctx.Output<Tensor>("OutGoodSteps");
     auto* bad_out = ctx.Output<Tensor>("OutBadSteps");
@@ -115,7 +105,6 @@ class UpdateLossScalingKernel : public framework::OpKernel<T> {
         dev_ctx, found_inf_data, pre_loss_scaling_data, good_in_data,
         bad_in_data, incr_every_n_steps, decr_every_n_nan_or_inf, incr_ratio,
         decr_ratio, updated_loss_scaling_data, good_out_data, bad_out_data);
-    LazyZeroInputs<DeviceContext, T>{}(dev_ctx, found_inf_data, xs, outs);
   }
 };
 

--- a/python/paddle/fluid/contrib/mixed_precision/amp_nn.py
+++ b/python/paddle/fluid/contrib/mixed_precision/amp_nn.py
@@ -49,8 +49,7 @@ def check_finite_and_unscale(x, scale, name=None):
     return x, found_inf
 
 
-def update_loss_scaling(x,
-                        found_inf,
+def update_loss_scaling(found_inf,
                         prev_loss_scaling,
                         num_good_steps,
                         num_bad_steps,
@@ -66,8 +65,7 @@ def update_loss_scaling(x,
     decr_every_n_nan_or_inf steps and each step some gradients are infinite.
 
     Args:
-        x(list|tuple): The input tensors of update_loss_scaling operator.
-        found_inf (Variable): A boolean variable indicates whether 
+        found_inf (Variable): A boolean variable indicates whether
                                      there is any infinite gradient.
         prev_loss_scaling (Variable): Previous loss scaling.
         num_good_steps (Variable): A variable accumulates good steps in which 
@@ -88,16 +86,10 @@ def update_loss_scaling(x,
 
     check_variable_and_dtype(prev_loss_scaling, "prev_loss_scaling",
                              ['float32', 'float64'], "update_loss_scaling")
-    check_type(x, 'x', (tuple, list), 'update_loss_scaling')
-    for e in x:
-        check_variable_and_dtype(e, "x", ['float32', 'float64'],
-                                 'update_loss_scaling')
-        assert prev_loss_scaling.dtype == e.dtype, "The dtype of prev_loss_scaling should be equal to the dtype of x."
 
     helper = LayerHelper("update_loss_scaling", **locals())
 
     inputs = {
-        'X': x,
         'FoundInfinite': found_inf,
         'PrevLossScaling': prev_loss_scaling,
         'InGoodSteps': num_good_steps,
@@ -105,7 +97,6 @@ def update_loss_scaling(x,
     }
 
     outputs = {
-        'Out': x,
         'LossScaling': prev_loss_scaling,
         'OutGoodSteps': num_good_steps,
         'OutBadSteps': num_bad_steps
@@ -121,4 +112,4 @@ def update_loss_scaling(x,
     helper.append_op(
         type='update_loss_scaling', inputs=inputs, outputs=outputs, attrs=attrs)
 
-    return x
+    return prev_loss_scaling


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#### 本PR前
分析bert amp的timeline图.
![image](https://user-images.githubusercontent.com/10208305/99530514-5aeda600-29dc-11eb-86a7-efd8b26d4801.png)
1. 在进行通信时，梯度并非都转成了fp16，有一部分梯度还是fp32的梯度。fp32梯度就形成了图中的那一小块部分。
![image](https://user-images.githubusercontent.com/10208305/99530573-7658b100-29dc-11eb-80c9-63f3ea677b80.png)
2. 图中的gap，绿色部分为`check_finite_and_unscale`，会将所有梯度都组成大op调用，和所有通信都会有拓扑依赖，等着最后一个allreduce完成。使最后一个通信无法和optimizer overlap起来。另外最后一个allreduce使用的fp32，通信时间较长。
![image](https://user-images.githubusercontent.com/10208305/99530726-a4d68c00-29dc-11eb-9d75-0bade7158a16.png)
#### 本PR
查看timeline图
![image](https://user-images.githubusercontent.com/10208305/99530957-fd0d8e00-29dc-11eb-8407-6a07212f8a82.png)
`修改点`
1、fp32梯度都先转成fp16，梯度都可以fuse使用fp16_allreduce，原timeline中小块部分被fuse。
2、将check_finite_and_unscale粒度分成一个个grad，修改了部分算法逻辑，每个grad中若存在inf，只将自己的grad设为0。最后一个通信也可以overlap了。同时由于算法逻辑的更改，adam和前面其它grad的check_finite_and_unscale的拓扑依赖也消失了，计算op间的gap也可以降到最小。

`bert测试`
bert下性能测试, v100 32G, 多机100Gbps rdma，
max_seq_len=512，
| 节点*卡数 | batch_size | develop分支速度 | 这个PR速度 | 速度提升 | 
| --- | --- | --- | --- | --- |
| 1*8 | 2048 | 149100.8 | 151166.9 | 1.38% |
| 1*8 | 4096 | 171482.4 | 173417.0 | 1.12% |
| 1*8 | 8192 | 184871.7 | 185726.7 | 0.46% |
| 4*4 | 2048 | 225724.2 | 245541.3 | 8.77% |
| 4*4 | 4096 | 293673.2 | 309961.4 | 5.54% |
| 4*4 | 8192 | 338435.1 | 348395.8 | 2.94% |

可以看出有明显性能提升。不过在单机下性能提升没那么明显，因为单机8卡的带宽较高，develop分支未overlap较小，提升没那么明显；同时可看出在batch_size增大时，性能提升也会降低，这是由于batch_size增大时，计算量提升，而通信量保持不变，最后未overlap的瓶颈占比变小。

`resnet测试`
单机8卡resnet50， imagenet数据集，bs=128.
速度从966.6->991.1，提升2.5%。
精度 acc1 0.7608, acc5 0.9295。精度对齐