### PR TITLE
improve performance of cast op

### DIFF
--- a/paddle/fluid/operators/cast_op.cu
+++ b/paddle/fluid/operators/cast_op.cu
@@ -15,11 +15,14 @@ limitations under the License. */
 #include "paddle/fluid/operators/cast_op.h"
 #include "paddle/fluid/platform/float16.h"
 
-template <typename T>
-using CastOpKernel =
-    paddle::operators::CastOpKernel<paddle::platform::CUDADeviceContext, T>;
+namespace ops = paddle::operators;
 
-REGISTER_OP_CUDA_KERNEL(cast, CastOpKernel<float>, CastOpKernel<double>,
-                        CastOpKernel<int>, CastOpKernel<int64_t>,
-                        CastOpKernel<bool>, CastOpKernel<uint8_t>,
-                        CastOpKernel<paddle::platform::float16>);
+REGISTER_OP_CUDA_KERNEL(
+    cast, ops::CastOpKernel<paddle::platform::CUDADeviceContext, float>,
+    ops::CastOpKernel<paddle::platform::CUDADeviceContext, double>,
+    ops::CastOpKernel<paddle::platform::CUDADeviceContext, int>,
+    ops::CastOpKernel<paddle::platform::CUDADeviceContext, int64_t>,
+    ops::CastOpKernel<paddle::platform::CUDADeviceContext, bool>,
+    ops::CastOpKernel<paddle::platform::CUDADeviceContext, uint8_t>,
+    ops::CastOpKernel<paddle::platform::CUDADeviceContext,
+                      paddle::platform::float16>);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->  OPs 

### Describe
<!-- Describe what this PR does -->
当前的cast基于thrust::transform，每次CPU都会wait GPU Kernel执行完。换成eigen实现，能够避免wait。
在Bert中测试10个batch，优化后cast的CPU时间从953.436569 ms 降低至156.809596 ms

- before
```
-------------------------       Event Summary       -------------------------

Event                                                       Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
ParallelExecutor::Run                                       10          2842.01     1684.827538 (0.592829)  1157.182943 (0.407171)  269.026     357.902     284.201     0.994883
  cast                                                      5440        1088.28     953.436569 (0.876097)   134.841113 (0.123903)   0.035938    9.77458     0.200051    0.380966
  matmul_grad                                               870         280.762     87.395431 (0.311279)    193.366733 (0.688721)   0.093211    1.67319     0.322715    0.0982845
```
- after
```
-------------------------       Event Summary       -------------------------

Event                                                       Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
BufferedReader:MemoryCopy                                   11          3936.28     3936.004465 (0.999930)  0.276638 (0.000070)     0.383697    3931.31     357.844     0.610139
  GpuMemcpyAsync:CUDAPinned->GPU                            66          3928.84     3928.566093 (0.999930)  0.276638 (0.000070)     0.020847    2783.47     59.5279     0.608986
ParallelExecutor::Run                                       10          2506.17     1331.644783 (0.531346)  1174.529514 (0.468654)  244.423     266.137     250.617     0.388467
  update_loss_scaling                                       10          517.431     517.396812 (0.999935)   0.033856 (0.000065)     33.5507     57.7704     51.7431     0.0802037
    GpuMemcpyAsync:GPU->CPU                                 10          516.128     516.110219 (0.999965)   0.018144 (0.000035)     33.4161     57.6457     51.6128     0.0800019
  cast                                                      5440        302.898     156.809596 (0.517698)   146.088436 (0.482302)   0.024481    1.27884     0.0556798   0.0469504
```