### PR TITLE
Fix param base trainable set failed

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2858,6 +2858,12 @@ class Block(object):
             param = ParamBase(*args, **kwargs)
         else:
             param = Parameter(global_block, *args, **kwargs)
+            # NOTE: Why only set stop_gradient=False in static mode
+            # Because in dygraph mode, the `stop_gradient` and 
+            # `trainable` are related, if we set `stop_gradient` 
+            # here, the user given `trainable` argument will not 
+            # take effect
+            param.stop_gradient = False
         if 'initializer' in kwargs:
 
             def _is_inited_by(block, var):
@@ -2884,7 +2890,6 @@ class Block(object):
                 pass
             else:
                 initializer(param, self)
-        param.stop_gradient = False
         return param
 
     def append_op(self, *args, **kwargs):

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -2859,10 +2859,10 @@ class Block(object):
         else:
             param = Parameter(global_block, *args, **kwargs)
             # NOTE: Why only set stop_gradient=False in static mode
-            # Because in dygraph mode, the `stop_gradient` and 
-            # `trainable` are related, if we set `stop_gradient` 
-            # here, the user given `trainable` argument will not 
-            # take effect
+            # Because in dygraph mode, the `stop_gradient` and `trainable`
+            # are related, and `trainable` default vallue is `True` or
+            # it is specified by users, there is no need to set
+            # `stop_gradient` for ParamBase here.
             param.stop_gradient = False
         if 'initializer' in kwargs:
 

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -3683,5 +3683,24 @@ class TestMetricsDetectionMap(unittest.TestCase):
         print(str(program))
 
 
+class ExampleNet(paddle.nn.Layer):
+    def __init__(self):
+        super(ExampleNet, self).__init__()
+        self.weight = self.create_parameter(
+            shape=[1, 1], attr=paddle.ParamAttr(trainable=False))
+
+    def forward(self):
+        # only for test parameter trainable sttr
+        pass
+
+
+class TestLayerParameterTrainableSet(unittest.TestCase):
+    def test_layer_parameter_set(self):
+        with fluid.dygraph.guard():
+            net = ExampleNet()
+            self.assertFalse(net.weight.trainable)
+
+
 if __name__ == '__main__':
+    paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -3690,7 +3690,7 @@ class ExampleNet(paddle.nn.Layer):
             shape=[1, 1], attr=paddle.ParamAttr(trainable=False))
 
     def forward(self):
-        # only for test parameter trainable sttr
+        # only for test parameter trainable attr
         pass
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix param base trainable set failed

in dygraph mode, the `stop_gradient` and `trainable` are related, if we set `stop_gradient` here, the user given `trainable` argument will not take effect 