### PR TITLE
[Dy2stat] Add Tuple as Assign Target for Tensor Shape

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
@@ -198,10 +198,7 @@ class TensorShapeTransformer(gast.NodeTransformer):
         if isinstance(target_node, gast.Tuple):
             has_updated = False
             for idx, element in enumerate(target_node.elts):
-                try:
-                    target_id = ast_to_source_code(element).strip()
-                except AttributeError:
-                    continue
+                target_id = ast_to_source_code(element).strip()
 
                 if isinstance(value_node, gast.Name):
                     if value_node.id in self.name_to_var_shape:
@@ -227,10 +224,7 @@ class TensorShapeTransformer(gast.NodeTransformer):
 
             return has_updated
         else:
-            try:
-                target_id = ast_to_source_code(target_node).strip()
-            except AttributeError:
-                return False
+            target_id = ast_to_source_code(target_node).strip()
 
             if isinstance(value_node, gast.Name):
                 if value_node.id in self.name_to_var_shape:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
@@ -195,6 +195,11 @@ class TensorShapeTransformer(gast.NodeTransformer):
         target_node = node.targets[0]
         value_node = node.value
 
+        value_str = ast_to_source_code(value_node).strip()
+        while value_str in self.name_to_var_shape:
+            value_node = self.name_to_var_shape[value_str]
+            value_str = ast_to_source_code(value_node).strip()
+
         if isinstance(target_node, gast.Tuple):
             has_updated = False
             for idx, element in enumerate(target_node.elts):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
@@ -195,11 +195,6 @@ class TensorShapeTransformer(gast.NodeTransformer):
         target_node = node.targets[0]
         value_node = node.value
 
-        value_str = ast_to_source_code(value_node).strip()
-        while value_str in self.name_to_var_shape:
-            value_node = self.name_to_var_shape[value_str]
-            value_str = ast_to_source_code(value_node).strip()
-
         if isinstance(target_node, gast.Tuple):
             has_updated = False
             for idx, element in enumerate(target_node.elts):
@@ -210,8 +205,9 @@ class TensorShapeTransformer(gast.NodeTransformer):
 
                 if isinstance(value_node, gast.Name):
                     if value_node.id in self.name_to_var_shape:
+                        var_shape_node = self.name_to_var_shape[value_node.id]
                         sub_node = gast.Subscript(
-                            value=value_node,
+                            value=var_shape_node,
                             slice=gast.Index(value=gast.Constant(
                                 value=idx, kind=None)),
                             ctx=gast.Load())

--- a/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
@@ -205,20 +205,22 @@ class TensorShapeTransformer(gast.NodeTransformer):
 
                 if isinstance(value_node, gast.Name):
                     if value_node.id in self.name_to_var_shape:
+                        index_value_node = gast.Constant(value=idx, kind=None)
+                        slice_index_node = gast.Index(value=index_value_node)
                         var_shape_node = self.name_to_var_shape[value_node.id]
                         sub_node = gast.Subscript(
                             value=var_shape_node,
-                            slice=gast.Index(value=gast.Constant(
-                                value=idx, kind=None)),
+                            slice=slice_index_node,
                             ctx=gast.Load())
                         self.name_to_var_shape[target_id] = sub_node
                         has_updated = True
                 if isinstance(value_node, gast.Attribute):
                     if self.is_var_shape(value_node):  # eg: x.shape
+                        index_value_node = gast.Constant(value=idx, kind=None)
+                        slice_index_node = gast.Index(value=index_value_node)
                         sub_node = gast.Subscript(
                             value=value_node,
-                            slice=gast.Index(value=gast.Constant(
-                                value=idx, kind=None)),
+                            slice=slice_index_node,
                             ctx=gast.Load())
                         self.name_to_var_shape[target_id] = sub_node
                         has_updated = True

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -60,9 +60,17 @@ def dyfunc_tensor_shape_5(x):
     return res
 
 
-def dyfunc_tuple_shape(x):
+def dyfunc_tuple_shape_1(x):
     x = paddle.to_tensor(x)
     a, b = x.shape
+    res = paddle.reshape(x, shape=(b, a))
+    return res
+
+
+def dyfunc_tuple_shape_2(x):
+    x = paddle.to_tensor(x)
+    shape = x.shape
+    a, b = shape
     res = paddle.reshape(x, shape=(b, a))
     return res
 
@@ -232,10 +240,16 @@ class TestTensorShapeBasic5(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_tensor_shape_5
 
 
-class TestTupleShape(TestTensorShapeBasic):
+class TestTupleShape1(TestTensorShapeBasic):
     def init_test_func(self):
         self.input = numpy.ones((5, 7)).astype("int32")
-        self.dygraph_func = dyfunc_tuple_shape
+        self.dygraph_func = dyfunc_tuple_shape_1
+
+
+class TestTupleShape2(TestTensorShapeBasic):
+    def init_test_func(self):
+        self.input = numpy.ones((5, 7)).astype("int32")
+        self.dygraph_func = dyfunc_tuple_shape_2
 
 
 # 2. Tests with control flow if

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import numpy
 
 import unittest
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.jit import declarative
 
@@ -56,6 +57,13 @@ def dyfunc_tensor_shape_5(x):
     x = fluid.dygraph.to_variable(x)
     s = x.shape[0]
     res = fluid.layers.reshape(x, shape=(-1, s))
+    return res
+
+
+def dyfunc_tuple_shape(x):
+    x = paddle.to_tensor(x)
+    a, b = x.shape
+    res = paddle.reshape(x, shape=(b, a))
     return res
 
 
@@ -222,6 +230,12 @@ class TestTensorShapeBasic4(TestTensorShapeBasic):
 class TestTensorShapeBasic5(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_tensor_shape_5
+
+
+class TestTupleShape(TestTensorShapeBasic):
+    def init_test_func(self):
+        self.input = numpy.ones((5, 7)).astype("int32")
+        self.dygraph_func = dyfunc_tuple_shape
 
 
 # 2. Tests with control flow if


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add support for using tuple as tensor.shape (For example: `a, b, c, d = x.shape`)
