### PR TITLE
[Dy2stat] Fix Incorrect After Node Vars in IfElseTransformer

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import numpy as np
 import unittest
 
+import paddle
 from paddle.fluid.dygraph.jit import declarative
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator
 
@@ -269,6 +270,76 @@ class TestNetWithExternalFunc(TestDygraphIfElseNet):
     def setUp(self):
         self.x = np.random.random([10, 16]).astype('float32')
         self.Net = NetWithExternalFunc
+
+
+class DiffModeNet1(paddle.nn.Layer):
+    def __init__(self, mode):
+        super(DiffModeNet1, self).__init__()
+        self.mode = mode
+
+    @paddle.jit.to_static
+    def forward(self, x, y):
+        if self.mode == 'train':
+            out = x + y
+        elif self.mode == 'infer':
+            out = x - y
+        else:
+            raise ValueError('Illegal mode')
+        return out
+
+
+class DiffModeNet2(paddle.nn.Layer):
+    def __init__(self, mode):
+        super(DiffModeNet2, self).__init__()
+        self.mode = mode
+
+    @paddle.jit.to_static
+    def forward(self, x, y):
+        if self.mode == 'train':
+            out = x + y
+            return out
+        elif self.mode == 'infer':
+            out = x - y
+            return out
+        else:
+            raise ValueError('Illegal mode')
+
+
+class TestDiffModeNet(unittest.TestCase):
+    """
+    TestCase for the net with different modes
+    """
+
+    def setUp(self):
+        self.x = paddle.randn([10, 16], 'float32')
+        self.y = paddle.randn([10, 16], 'float32')
+        self.init_net()
+
+    def init_net(self):
+        self.Net = DiffModeNet1
+
+    def _run(self, mode, to_static):
+        prog_trans = ProgramTranslator()
+        prog_trans.enable(to_static)
+
+        net = self.Net(mode)
+        ret = net(self.x, self.y)
+        return ret.numpy()
+
+    def test_train_mode(self):
+        self.assertTrue((self._run(
+            mode='train', to_static=True) == self._run(
+                mode='train', to_static=False)).all())
+
+    def test_infer_mode(self):
+        self.assertTrue((self._run(
+            mode='infer', to_static=True) == self._run(
+                mode='infer', to_static=False)).all())
+
+
+class TestDiffModeNet2(TestDiffModeNet):
+    def init_net(self):
+        self.Net = DiffModeNet2
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
**Problem**: our current Dy2stat will fail on a simple case:

```
    @paddle.jit.to_static
    def forward(self, x, y):
        if self.mode == 'train':
            out = x + y
        elif self.mode == 'infer':
            out = x - y
        else:
            raise ValueError('Illegal mode')
        return out
```

**Reason**: the if-elif-else will be transferred into two `ast.If` in `ast`. In our old code, we calculate the vars before/after if-else expression. While we got `after_var_name_ids` by

```
after_var_names_ids = [	
            ctx for ctx in all_name_ids[name] if ctx not in before_var_names_ids	
        ]
```
We are using all vars minus vars before the if-else expression. However, that's incorrect because: 

```
before_var_names_ids = parent_name_ids.get(name, []) + \	
                               body_name_ids.get(name, []) + orelse_name_ids.get(name, [])
```
From the code you could see `before_var_names_ids` doesn't include the `body_name_ids` of the previous `ast.If`.

**Solution**: the key fix of this PR is:
```
after_ifelse_name_ids = get_name_ids([root], after_node=node)
```
Where we get `after_ifelse_name_id` by visiting instead of set minus. To support it, we enable `NameVisitor` to search after the `after_node`.

