### PR TITLE
[Dynamic-to-Static] Fix bug of convert_logical_and/convert_logical_or:  the operands are executed sequentially

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logical.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_logical.py
@@ -1,0 +1,228 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for logical operators of Dynamic-to-Static.
+Only test simple cases here. The complex test samples like nested ifelse
+or nested loop have been covered in file test_ifelse.py and test_loop.py"""
+from __future__ import print_function
+
+import unittest
+
+import numpy as np
+
+import paddle
+import paddle.fluid as fluid
+from paddle.fluid.dygraph import ProgramTranslator
+
+program_translator = ProgramTranslator()
+
+SEED = 2020
+np.random.seed(22)
+
+
+@paddle.jit.to_static
+def test_logical_not(x):
+    x = paddle.to_tensor(x)
+    if not x:
+        x = x - 1
+    else:
+        x = x + 1
+
+    if x != 10:
+        x = x - 1
+    else:
+        x = x + 1
+
+    y = 0
+    if not y:
+        x = x + 4
+
+    if y != 3:
+        x = x + 2
+    return x
+
+
+@paddle.jit.to_static
+def test_logical_not_2(x):
+    x = paddle.to_tensor(x)
+
+    y = None
+    if y is not None and not y:
+        x = x + 4
+
+    if y != 3:
+        x = x + 2
+    return x
+
+
+@paddle.jit.to_static
+def test_logical_and(x):
+    x = paddle.to_tensor(x)
+
+    if x < 10 and x > 1:
+        x = x - 1
+    else:
+        x = x + 1
+
+    y = 3
+    if y < 10 and y > 1:
+        x = x - 2
+    else:
+        x = x + 2
+
+    return x
+
+
+@paddle.jit.to_static
+def test_logical_and_2(x):
+    x = paddle.to_tensor(x)
+
+    a = None
+    # NOTE(liym27):
+    # because `a is not None` is False, then `a > 1` won't be run,
+    # which means `convert_logical_and(a is not None, a > 1)` should not
+    # run a>1.
+    if a is not None and a > 1:
+        x = x - 1
+    else:
+        x = x + 1
+
+    b = 3
+
+    if b is not None and b > 1:
+        x = x - 1
+    else:
+        x = x + 1
+
+    return x
+
+
+@paddle.jit.to_static
+def test_logical_or(x):
+    x = paddle.to_tensor(x)
+
+    if x < 10 or x > 1:
+        x = x - 1
+    else:
+        x = x + 1
+
+    a = 10
+    if a > 3 or a < 1:
+        x = x - 1
+    else:
+        x = x + 1
+
+    return x
+
+
+@paddle.jit.to_static
+def test_logical_or_2(x):
+    x = paddle.to_tensor(x)
+
+    a = None
+    if x > 1 or a is None or a > 1:
+        x = x - 1
+    else:
+        x = x + 1
+    return x
+
+
+@paddle.jit.to_static
+def test_logical_not_and_or(x):
+    x = paddle.to_tensor(x)
+
+    a = 1
+    if x < 10 and (a < 4 or a > 0) or a < -1 or not x > -1:
+        x = x - 1
+    else:
+        x = x + 1
+    return x
+
+
+class TestLogicalBase(unittest.TestCase):
+    def setUp(self):
+        self.input = np.array([3]).astype('int32')
+        self.place = paddle.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else paddle.CPUPlace()
+        self._set_test_func()
+
+    def _set_test_func(self):
+        raise NotImplementedError(
+            "Method 'set_test_func' should be implemented.")
+
+    def _run(self, to_static):
+        program_translator.enable(to_static)
+        with fluid.dygraph.guard(self.place):
+            result = self.dygraph_func(self.input)
+            return result.numpy()
+
+    def _run_dygraph(self):
+        return self._run(to_static=False)
+
+    def _run_static(self):
+        return self._run(to_static=True)
+
+
+class TestLogicalNot(TestLogicalBase):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_not
+
+    def test_transformed_result(self):
+        dygraph_res = self._run_dygraph()
+        static_res = self._run_static()
+        self.assertTrue(
+            np.allclose(dygraph_res, static_res),
+            msg='dygraph result is {}\nstatic_result is {}'.format(dygraph_res,
+                                                                   static_res))
+
+
+class TestLogicalNot2(TestLogicalBase):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_not_2
+
+    def test_transformed_result(self):
+        dygraph_res = self._run_dygraph()
+        static_res = self._run_static()
+        self.assertTrue(
+            np.allclose(dygraph_res, static_res),
+            msg='dygraph result is {}\nstatic_result is {}'.format(dygraph_res,
+                                                                   static_res))
+
+
+class TestLogicalAnd(TestLogicalNot):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_and
+
+
+class TestLogicalAnd2(TestLogicalNot):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_and_2
+
+
+class TestLogicalOr(TestLogicalNot):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_or
+
+
+class TestLogicalOr2(TestLogicalNot):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_or_2
+
+
+class TestLogicalNotAndOr(TestLogicalNot):
+    def _set_test_func(self):
+        self.dygraph_func = test_logical_not_and_or
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

#### 1. The operands are executed sequentially according to the running logic of Python. So here the arguments
should be callable.
#### 2. If the left hand operand is True, the right hand operand should be executed.
 For example:
    `a = x > 1 or y < 1`
Transformed code:
   ` a = paddle.jit.dy2static.convert_logical_or(lambda:x>1, lambda:y<1)`

 In `convert_logical_or(lambda:x>1, lambda:y<1)`, `lambda:y<1` must be run after `lambda:x>1`. And
if `x>1` is True, `y<1` should NOT be run.

---

### Before this PR:

#### Case 1:
```python
@paddle.jit.to_static
def test1():
    a = None
    if a is not None and a > 1:
        x = x - 1
    else:
        x = x + 1

test1()
```

Error:
```python
TypeError: unorderable types: NoneType() > int()
```
Because `a > 1` is run,   but `a` is None and `a > 1`  should not have been run.


#### Case 2:
```python
@paddle.jit.to_static
def test():
    x = paddle.zeros([1])

    a = None

    if a is not None:
        z = x+1

    if a is not None and z < -1:
        x = x - 1
    return x

test2()
```

Error:
```python
InvalidArgumentError: The Tensor in the less_than Op's Input Variable X(z) is not initialized.
  [Hint: Expected t->IsInitialized() == true, but received t->IsInitialized():0 != true:1.] (at /home/teamcity/work/ef54dc8a5b211854/paddle/fluid/framework/operator.cc:1419)
  [operator < less_than > error]  [operator < run_program > error]

```
Because `z < -1` is run,  the OP `less_than`  is added in the program, but `z` is not initialized. Actually, `z < -1` should not have been run.