### PR TITLE
update expand as op to use the shape of the target tensor instead of the target tensor itself.

### DIFF
--- a/paddle/fluid/operators/expand_as_v2_op.cc
+++ b/paddle/fluid/operators/expand_as_v2_op.cc
@@ -57,7 +57,8 @@ class ExpandAsV2OpMaker : public framework::OpProtoAndCheckerMaker {
               "to size of the corresponding dimension of Input(X) multiplying "
               "the corresponding value given by Attr(expand_times).");
     AddAttr<std::vector<int>>("target_shape",
-                              "Expand shape for each dimension.");
+                              "Expand shape for each dimension.")
+        .SetDefault({});
     AddComment(R"DOC(
 Expand the input to the given shape.
 )DOC");

--- a/paddle/fluid/operators/expand_as_v2_op.cc
+++ b/paddle/fluid/operators/expand_as_v2_op.cc
@@ -98,6 +98,7 @@ class ExpandAsV2GradOpMaker : public framework::SingleGradOpMaker<T> {
  protected:
   void Apply(GradOpPtr<T> op) const override {
     op->SetType("expand_as_v2_grad");
+    op->SetInput("X", this->Input("X"));
     op->SetInput(framework::GradVarName("Out"), this->OutputGrad("Out"));
     op->SetOutput(framework::GradVarName("X"), this->InputGrad("X"));
     op->SetAttrMap(this->Attrs());

--- a/paddle/fluid/operators/expand_as_v2_op.cc
+++ b/paddle/fluid/operators/expand_as_v2_op.cc
@@ -33,15 +33,13 @@ class ExpandAsV2Op : public framework::OperatorWithKernel {
         platform::errors::InvalidArgument(
             "The rank of target_shape must be greater than or equal "
             "to the rank of Input(X). But received Input(X): input "
-            "rank %u, input shape [%s]; received target_shape: "
-            "input rank %u, input shape [%s].",
-            x_dims.size(), x_dims, target_shape.size(), target_shape));
-    PADDLE_ENFORCE_LE(
-        target_shape.size(), MAX_RANK_SUPPORTED,
-        platform::errors::InvalidArgument(
-            "The rank of target_shape must be less than or equal "
-            "to %d. But received: rank %u, shape [%s].",
-            MAX_RANK_SUPPORTED, target_shape.size(), target_shape));
+            "rank %u; received target_shape: rank %u.",
+            x_dims.size(), target_shape.size()));
+    PADDLE_ENFORCE_LE(target_shape.size(), MAX_RANK_SUPPORTED,
+                      platform::errors::InvalidArgument(
+                          "The rank of target_shape must be less than or equal "
+                          "to %d. But received: rank %u.",
+                          MAX_RANK_SUPPORTED, target_shape.size()));
     ctx->SetOutputDim("Out", framework::make_ddim(target_shape));
   }
 };

--- a/paddle/fluid/operators/expand_as_v2_op.h
+++ b/paddle/fluid/operators/expand_as_v2_op.h
@@ -59,8 +59,8 @@ class ExpandAsV2Kernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
     auto rank = context.Input<Tensor>("X")->dims().size();
-    auto* target_tensor = context.Input<Tensor>("target_tensor");
-    auto target_rank = target_tensor->dims().size();
+    auto target_shape = context.Attr<std::vector<int>>("target_shape");
+    auto target_rank = target_shape.size();
     PADDLE_ENFORCE_GE(target_rank, rank,
                       platform::errors::InvalidArgument(
                           "The rank (%d) of the input 'target_tensor' for "
@@ -85,9 +85,8 @@ class ExpandAsV2Kernel : public framework::OpKernel<T> {
   void ExpandAs(const framework::ExecutionContext& context) const {
     auto* in0 = context.Input<Tensor>("X");
     auto in_dims = in0->dims();
-    auto* target_tensor = context.Input<Tensor>("target_tensor");
+    auto target_shape = context.Attr<std::vector<int>>("target_shape");
     auto vec_in_dims = framework::vectorize<int>(in_dims);
-    auto target_shape = framework::vectorize<int>(target_tensor->dims());
     auto diff = target_shape.size() - vec_in_dims.size();
     vec_in_dims.insert(vec_in_dims.begin(), diff, 1);
     std::vector<int> repeat_times(vec_in_dims.size());
@@ -132,9 +131,8 @@ class ExpandAsV2GradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
     auto* in0 = context.Input<Tensor>("X");
-    auto* target_tensor = context.Input<Tensor>("target_tensor");
+    auto target_shape = framework::vectorize<int>(target_tensor->dims());
     auto x_dims = in0->dims();
-    auto target_shape = target_tensor->dims();
     auto vec_in_dims = framework::vectorize<int>(x_dims);
     auto diff = target_shape.size() - vec_in_dims.size();
     vec_in_dims.insert(vec_in_dims.begin(), diff, 1);

--- a/paddle/fluid/operators/expand_as_v2_op.h
+++ b/paddle/fluid/operators/expand_as_v2_op.h
@@ -131,7 +131,7 @@ class ExpandAsV2GradKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& context) const override {
     auto* in0 = context.Input<Tensor>("X");
-    auto target_shape = framework::vectorize<int>(target_tensor->dims());
+    auto target_shape = context.Attr<std::vector<int>>("target_shape");
     auto x_dims = in0->dims();
     auto vec_in_dims = framework::vectorize<int>(x_dims);
     auto diff = target_shape.size() - vec_in_dims.size();

--- a/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
@@ -26,8 +26,8 @@ class TestExpandAsOpRank1(OpTest):
         self.op_type = "expand_as_v2"
         x = np.random.rand(100).astype("float64")
         target_tensor = np.random.rand(2, 100).astype("float64")
-        self.inputs = {'X': x, 'target_tensor': target_tensor}
-        self.attrs = {}
+        self.inputs = {'X': x}
+        self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [2, 1]
         output = np.tile(self.inputs['X'], bcast_dims)
         self.outputs = {'Out': output}
@@ -44,8 +44,8 @@ class TestExpandAsOpRank2(OpTest):
         self.op_type = "expand_as_v2"
         x = np.random.rand(10, 12).astype("float64")
         target_tensor = np.random.rand(10, 12).astype("float64")
-        self.inputs = {'X': x, 'target_tensor': target_tensor}
-        self.attrs = {}
+        self.inputs = {'X': x}
+        self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [1, 1]
         output = np.tile(self.inputs['X'], bcast_dims)
         self.outputs = {'Out': output}
@@ -62,8 +62,8 @@ class TestExpandAsOpRank3(OpTest):
         self.op_type = "expand_as_v2"
         x = np.random.rand(2, 3, 20).astype("float64")
         target_tensor = np.random.rand(2, 3, 20).astype("float64")
-        self.inputs = {'X': x, 'target_tensor': target_tensor}
-        self.attrs = {}
+        self.inputs = {'X': x}
+        self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [1, 1, 1]
         output = np.tile(self.inputs['X'], bcast_dims)
         self.outputs = {'Out': output}
@@ -80,8 +80,8 @@ class TestExpandAsOpRank4(OpTest):
         self.op_type = "expand_as_v2"
         x = np.random.rand(1, 1, 7, 16).astype("float64")
         target_tensor = np.random.rand(4, 6, 7, 16).astype("float64")
-        self.inputs = {'X': x, 'target_tensor': target_tensor}
-        self.attrs = {}
+        self.inputs = {'X': x}
+        self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [4, 6, 1, 1]
         output = np.tile(self.inputs['X'], bcast_dims)
         self.outputs = {'Out': output}

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1183,7 +1183,7 @@ def expand_as(x, y, name=None):
             # [[1, 2, 3], [1, 2, 3]]
     """
     if in_dygraph_mode():
-        return core.ops.expand_as_v2(x, y.shape)
+        return core.ops.expand_as_v2(x, 'target_shape', y.shape)
 
     check_variable_and_dtype(
         x, 'x', ['bool', 'float32', 'float64', 'int32', 'int64'], 'expand_as')

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1183,7 +1183,7 @@ def expand_as(x, y, name=None):
             # [[1, 2, 3], [1, 2, 3]]
     """
     if in_dygraph_mode():
-        return core.ops.expand_as_v2(x, y)
+        return core.ops.expand_as_v2(x, y.shape)
 
     check_variable_and_dtype(
         x, 'x', ['bool', 'float32', 'float64', 'int32', 'int64'], 'expand_as')
@@ -1195,12 +1195,16 @@ def expand_as(x, y, name=None):
             "you must set its stop_gradient to be False by "
             "some_var.stop_gradient = True, supporting "
             "some_var as the input 'x'.")
-    inputs = {"X": [x], "target_tensor": [y]}
+    inputs = {"X": [x]}
 
     helper = LayerHelper('expand_as', **locals())
     dtype = helper.input_dtype(input_param_name='x')
     out = helper.create_variable_for_type_inference(dtype)
-    helper.append_op(type='expand_as_v2', inputs=inputs, outputs={'Out': out})
+    helper.append_op(
+        type='expand_as_v2',
+        inputs=inputs,
+        attrs={'target_shape': y.shape},
+        outputs={'Out': out})
     return out
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
由于当前paddle op的kernel实现需要所有输入具有相同的类型，因此expand_as_v2 op的两个输入x、y必须具备相同的数据类型，这一点和竞品不同。该pr直接使用输入y的shape作为expand_as_v2 op的属性，而不再把y作为其输入，已解除这个条件限制。

备注：expand_as_v2 op为2.0beta版本添加。