### PR TITLE
[Dynamic-to-Static] Fix bug: support pop from a dict and polish code of convert_pop

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -361,21 +361,12 @@ def _slice_tensor_array(array, start, end):
 
 
 def _run_python_pop(target, *args):
-    # Parse args
-    if len(args) == 0:
-        idx = -1
-    elif len(args) == 1:
-        idx = args[0]
-    elif len(args) == 2:
-        idx = args[0]
-        default = args[1]
-
     # 1. pop for a dict
     if len(args) == 2:
-        result = target.pop(idx, default)
+        idx, default = args
+        return target.pop(idx, default)
 
     # 2. pop for a list or dict
     else:
-        result = target.pop(idx)
-
-    return result
+        idx = args[0] if args else -1
+        return target.pop(idx)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -16,7 +16,10 @@ from paddle.fluid.data_feeder import convert_dtype
 from paddle.fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable
 from paddle.fluid.framework import core, Variable
 from paddle.fluid.layers import Assert, Print
+from paddle.fluid.layers import array_length, array_read, array_write, create_array
+from paddle.fluid.layers import assign, fill_constant, slice
 from paddle.fluid.layers import cast, control_flow, logical_and, logical_not, logical_or, nn
+from paddle.fluid.layers.control_flow import cond, while_loop, less_than, increment
 
 
 def convert_while_loop(cond, body, loop_vars):
@@ -24,12 +27,12 @@ def convert_while_loop(cond, body, loop_vars):
     A function representation of a Python ``while`` statement.
 
     Args:
-        cond(Callable): A callable object that returns a boolean variable to control whether to execute the loop body.  It takes  ``loop_vars`` as arguments.
+        cond(Callable): A callable object that returns a boolean variable to control whether to execute the loop body. It takes ``loop_vars`` as arguments.
         body(Callable): A callable object that returns a tuple or list of variables with the same arguments ``loops_vars`` as ``cond`` .
         loop_vars(list|tuple): A list or tuple of variables passed to ``cond`` and ``body`` .
 
     Returns:
-        A list or tuple of variables which returned by ``body`` .
+        A list or tuple of variables which returned by ``body``.
     """
 
     # NOTE: It may be slower if cond is very expensive, but usually cond is just O(1).
@@ -285,3 +288,94 @@ def convert_print(*args):
             var = Print(var)
         else:
             print(var)
+
+
+def convert_pop(target, *args):
+    """
+    A function representation of a Python pop statement for a list or dict.
+
+    Args:
+        target(list|dict|Tensor): A variable to pop item from.
+        *args(tuple): index or default value to parse.
+
+    Returns:
+        A item poped from target.
+    """
+
+    is_variable = isinstance(target, Variable)
+    if is_variable:
+        is_tensor_array = target.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY
+
+    if is_variable and is_tensor_array:
+        return _run_paddle_pop(target, *args)
+    else:
+        return _run_python_pop(target, *args)
+
+
+def _run_paddle_pop(array, *args):
+    if len(args) == 0:
+        idx = -1
+    else:
+        idx = args[0]
+
+    assert isinstance(idx, int)
+
+    def cond(i, new_array):
+        return less_than(i, arr_len)
+
+    def body(i, new_array):
+        item = array_read(array=array, i=i)
+        array_write(item, array_length(new_array), new_array)
+        i = increment(i)
+        return i, new_array
+
+    arr_len = array_length(array)
+    if idx < 0:
+        idx = idx + arr_len
+    else:
+        idx = fill_constant(shape=[1], dtype="int64", value=idx)
+
+    pop_item = array_read(array, idx)
+
+    new_array = _slice_tensor_array(array, 0, idx)
+    i = idx + 1
+    _, new_array = while_loop(cond, body, [i, new_array])
+    assign(input=new_array, output=array)
+
+    return pop_item
+
+
+# TODO(liym27): A better way to slice tensor array.
+#  Maybe support start == end for slice op.
+def _slice_tensor_array(array, start, end):
+    def true_fn():
+        null_array = create_array("float32")
+        return null_array
+
+    def false_fn(array, start, end):
+        new_array = slice(array, starts=[start], ends=[end], axes=[0])
+        return new_array
+
+    new_array = cond(start == end, true_fn, lambda: false_fn(array, start, end))
+    return new_array
+
+
+def _run_python_pop(target, *args):
+    # Parse args
+    if len(args) == 0:
+        idx = -1
+    elif len(args) == 1:
+        idx = args[0]
+    elif len(args) == 2:
+        idx = args[0]
+        default = args[1]
+
+    # 1. pop for a dict
+    if len(args) == 2:
+        result = target.pop(idx, default)
+
+    # 2. pop for a list or dict
+    else:
+        result = target.pop(idx)
+
+    return result

--- a/python/paddle/fluid/dygraph/dygraph_to_static/list_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/list_transformer.py
@@ -240,22 +240,14 @@ class ListTransformer(gast.NodeTransformer):
 
         args_str = [ast_to_source_code(arg).strip() for arg in node.args]
 
-        # 1. pop stmt for a list
-        if len(args_str) == 0:
-            new_call_str = "paddle.jit.dy2static.convert_pop({})".format(
-                target_str, args_str)
-
-        # 2. pop stmt for a list or dict
-        elif len(args_str) == 1:
-            new_call_str = "paddle.jit.dy2static.convert_pop({}, {})".format(
-                target_str, args_str[0])
-
-        # 3. pop stmt for a dict
-        elif len(args_str) == 2:
-            new_call_str = "paddle.jit.dy2static.convert_pop({}, {}, {})".format(
-                target_str, args_str[0], args_str[1])
+        # NOTE(liym27):
+        # 1. pop stmt for a list if len(args_str) == 0
+        # 2. pop stmt for a list or dict if len(args_str) == 1
+        # 3. pop stmt for a dict if len(args_str) == 2
+        if len(args_str) <= 2:
+            new_pop_str = "paddle.jit.dy2static.convert_pop({}, {})"\
+                .format(target_str, ",".join(args_str))
+            new_pop_node = gast.parse(new_pop_str).body[0].value
+            return new_pop_node
         else:
-            raise node
-
-        new_call_node = gast.parse(new_call_str).body[0].value
-        return new_call_node
+            return node

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_dict.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_dict.py
@@ -18,6 +18,7 @@ import six
 import numpy as np
 import unittest
 
+import paddle
 import paddle.fluid as fluid
 from paddle.jit import to_static
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import ProgramTranslator
@@ -137,6 +138,68 @@ class TestNetWithDict(unittest.TestCase):
 
     def test_ast_to_func(self):
         self.assertTrue((self._run_dygraph() == self._run_static()).all())
+
+
+# Tests for dict pop
+@paddle.jit.to_static
+def test_dic_pop(x):
+    x = paddle.to_tensor(x)
+    dict_a = {"red": 0, "green": 1, "blue": 2}
+
+    m = dict_a.pop("red")
+    n = dict_a.pop("black", 3)
+
+    out = x + m + n
+    return out
+
+
+@paddle.jit.to_static
+def test_dic_pop_2(x):
+    x = paddle.to_tensor(x)
+    dict_a = {"red": x, "green": x + 1, "blue": x + 3}
+
+    m = dict_a.pop("red")
+    n = dict_a.pop("black", 3)
+
+    out = x + m + n
+    return out
+
+
+class TestDicPop(unittest.TestCase):
+    def setUp(self):
+        self.input = np.random.random((3)).astype('int32')
+        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        self._set_test_func()
+
+    def _set_test_func(self):
+        self.dygraph_func = test_dic_pop
+
+    def _run_static(self):
+        return self._run(to_static=True)
+
+    def _run_dygraph(self):
+        return self._run(to_static=False)
+
+    def _run(self, to_static):
+        prog_trans = ProgramTranslator()
+        prog_trans.enable(to_static)
+        with fluid.dygraph.guard(self.place):
+            result = self.dygraph_func(self.input)
+            return result.numpy()
+
+    def test_transformed_result(self):
+        dygraph_res = self._run_dygraph()
+        static_res = self._run_static()
+        self.assertTrue(
+            np.allclose(dygraph_res, static_res),
+            msg='dygraph result is {}\nstatic result is {}'.format(dygraph_res,
+                                                                   static_res))
+
+
+class TestDictPop2(TestDicPop):
+    def _set_test_func(self):
+        self.dygraph_func = test_dic_pop_2
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_dict.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_dict.py
@@ -165,11 +165,11 @@ def test_dic_pop_2(x):
     return out
 
 
-class TestDicPop(unittest.TestCase):
+class TestDictPop(unittest.TestCase):
     def setUp(self):
         self.input = np.random.random((3)).astype('int32')
-        self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
-        ) else fluid.CPUPlace()
+        self.place = paddle.CUDAPlace(0) if paddle.is_compiled_with_cuda(
+        ) else paddle.CPUPlace()
         self._set_test_func()
 
     def _set_test_func(self):
@@ -184,9 +184,10 @@ class TestDicPop(unittest.TestCase):
     def _run(self, to_static):
         prog_trans = ProgramTranslator()
         prog_trans.enable(to_static)
-        with fluid.dygraph.guard(self.place):
-            result = self.dygraph_func(self.input)
-            return result.numpy()
+
+        result = self.dygraph_func(self.input)
+
+        return result.numpy()
 
     def test_transformed_result(self):
         dygraph_res = self._run_dygraph()
@@ -197,7 +198,7 @@ class TestDicPop(unittest.TestCase):
                                                                    static_res))
 
 
-class TestDictPop2(TestDicPop):
+class TestDictPop2(TestDictPop):
     def _set_test_func(self):
         self.dygraph_func = test_dic_pop_2
 

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -20,6 +20,7 @@ from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_len  #D
 from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_and  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_not  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_or  #DEFINE_ALIAS
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_pop  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_print  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_dtype  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_shape  #DEFINE_ALIAS
@@ -28,6 +29,6 @@ from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_while_l
 __all__ = [
     'cast_bool_if_necessary', 'convert_assert', 'convert_ifelse', 'convert_len',
     'convert_logical_and', 'convert_logical_not', 'convert_logical_or',
-    'convert_print', 'convert_var_dtype', 'convert_var_shape',
+    'convert_pop', 'convert_print', 'convert_var_dtype', 'convert_var_shape',
     'convert_while_loop'
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### 1. support pop from a dict 
```python
@paddle.jit.to_static
def test():
  dict_a = {"x": 1, "y":2}
  dict_a.pop("z", 3)
```
Before this PR, there is no specific support for dict pop. For `dict.pop(key, default)`, `default` is ignored.
```python
def test():
  dict_a = {"x": 1, "y":2}
  fluid.dygraph.dygraph_to_static.list_transformer.convert_list_pop(dict_a, "z")  # There is no default value 3. 

test()
```

```python
KeyError: 'z'
```

This PR fix it.
```python
def test():
   dict_a = {"x": 1, "y":2}
   paddle.jit.dy2static.convert_pop(dict_a, "z", 3)  # There is default value 3. 
```

### 2. polish code of `convert_pop`
1. Rename the function `convert_list_pop` to `convert_pop` and it support pop stmt for list and dict.
2. Move the function `convert_pop` to file `convert_operators.py` fit **Paddle 2.0**
3. Polish code of it.