### PR TITLE
remove eigen threadpool and release the cost time for DeviceContext

### DIFF
--- a/paddle/fluid/operators/math/math_function.cc
+++ b/paddle/fluid/operators/math/math_function.cc
@@ -99,13 +99,7 @@ struct TransposeNormal<platform::CPUDeviceContext, T> {
         out_ptr[out_idx] = in_ptr[in_idx];
       }
     };
-    double cost_per_iteration =
-        rank * (Eigen::TensorOpCost::DivCost<int64_t>() +
-                2 * Eigen::TensorOpCost::MulCost<int64_t>() +
-                2 * Eigen::TensorOpCost::AddCost<int64_t>());
-    Eigen::TensorOpCost cost(sizeof(T), sizeof(T), cost_per_iteration);
-    auto* cpu_device = context.eigen_pool_device();
-    cpu_device->parallelFor(out->numel(), cost, std::move(transpose_helper));
+    transpose_helper(0, out->numel());
   }
 };
 

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -12,7 +12,6 @@ limitations under the License. */
 #include "paddle/fluid/platform/device_context.h"
 #include <set>
 #include <string>
-#include <thread>  //NOLINT
 #include <unordered_set>
 #include <vector>
 
@@ -24,7 +23,6 @@ limitations under the License. */
 #endif
 
 #include "glog/logging.h"
-#include "unsupported/Eigen/CXX11/ThreadPool"
 
 namespace paddle {
 namespace memory {
@@ -133,30 +131,14 @@ DeviceContextPool::DeviceContextPool(
 
 CPUDeviceContext::CPUDeviceContext() {
   eigen_device_.reset(new Eigen::DefaultDevice());
-  InitPoolDevice();
 }
 
 CPUDeviceContext::CPUDeviceContext(CPUPlace place) : place_(place) {
   eigen_device_.reset(new Eigen::DefaultDevice());
-  InitPoolDevice();
-}
-
-void CPUDeviceContext::InitPoolDevice() {
-  using EigenEnv = Eigen::StlThreadEnvironment;
-  using EigenThreadPool = Eigen::ThreadPoolTempl<EigenEnv>;
-  // int num_threads = std::thread::hardware_concurrency();
-  int num_threads = 1;
-  eigen_threadpool_.reset(new EigenThreadPool(num_threads));
-  eigen_pool_device_.reset(
-      new Eigen::ThreadPoolDevice(eigen_threadpool_.get(), num_threads));
 }
 
 Eigen::DefaultDevice* CPUDeviceContext::eigen_device() const {
   return eigen_device_.get();
-}
-
-Eigen::ThreadPoolDevice* CPUDeviceContext::eigen_pool_device() const {
-  return eigen_pool_device_.get();
 }
 
 Place CPUDeviceContext::GetPlace() const { return place_; }

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -43,7 +43,6 @@ limitations under the License. */
 #ifdef PADDLE_WITH_CUDA
 #include "paddle/fluid/platform/stream/cuda_stream.h"
 #endif
-#define EIGEN_USE_THREADS
 #include "unsupported/Eigen/CXX11/Tensor"
 
 namespace Eigen {
@@ -73,17 +72,11 @@ class CPUDeviceContext : public DeviceContext {
 
   Eigen::DefaultDevice* eigen_device() const;
 
-  Eigen::ThreadPoolDevice* eigen_pool_device() const;
-
   Place GetPlace() const override;
-
-  inline void InitPoolDevice();
 
  private:
   CPUPlace place_;
   std::unique_ptr<Eigen::DefaultDevice> eigen_device_;
-  std::unique_ptr<Eigen::ThreadPoolDevice> eigen_pool_device_;
-  std::unique_ptr<Eigen::ThreadPool> eigen_threadpool_;
 };
 
 template <typename Place>


### PR DESCRIPTION
### PR types
 Bug fixes

### PR changes
OPs

### Describe
remove eigen threadpool and release the cost time for DeviceContext

在性能diff排查过程中，发现在https://github.com/PaddlePaddle/Paddle/pull/27163 PR中发现了修改了DeviceContext中的初始化过程，在初始化过程中加了一些EigenThreadPool的初始化，这块的线程池开销增加了10%的性能diff，因此进行修复。删除DeviceContext中的ThreadPool的的创建，在8维度的Tranpose那块使用单线程。