### PR TITLE
Hide the C++ stack by default and add hints

### DIFF
--- a/paddle/fluid/framework/op_call_stack.cc
+++ b/paddle/fluid/framework/op_call_stack.cc
@@ -25,11 +25,11 @@ std::string InsertIndentationIntoEachLine(const std::string &str) {
   std::ostringstream sout;
   size_t start_pos = 0;
   size_t end_pos = 0;
-  while ((end_pos = str.find("\n", start_pos)) != std::string::npos) {
-    sout << "    " << str.substr(start_pos, end_pos + 1);
+  while ((end_pos = str.find_first_of("\n", start_pos)) != std::string::npos) {
+    sout << "    " << str.substr(start_pos, end_pos - start_pos + 1);
     start_pos = end_pos + 1;
   }
-  sout << "    " << str.substr(start_pos, end_pos);
+  sout << "    " << str.substr(start_pos, end_pos - start_pos + 1);
   return sout.str();
 }
 
@@ -58,6 +58,7 @@ void InsertCallStackInfo(const std::string &type, const AttributeMap &attrs,
       sout << "\n  " << line;
     }
   }
+  VLOG(1) << exception->error_str();
   // Step 2. Construct final call stack & append error op name
   if (FLAGS_call_stack_level > 1) {
     sout << exception->what();

--- a/paddle/fluid/framework/op_registry_test.cc
+++ b/paddle/fluid/framework/op_registry_test.cc
@@ -118,7 +118,7 @@ TEST(OpRegistry, IllegalAttr) {
     paddle::framework::OpRegistry::CreateOp(op_desc);
   } catch (paddle::platform::EnforceNotMet& err) {
     caught = true;
-    std::string msg = "OutOfRangeError";
+    std::string msg = "OutOfRange";
     std::string err_msg = err.what();
     ASSERT_TRUE(err_msg.find(msg) != std::string::npos);
   }
@@ -152,7 +152,7 @@ TEST(OpRegistry, CustomChecker) {
     paddle::framework::OpRegistry::CreateOp(op_desc);
   } catch (paddle::platform::EnforceNotMet& err) {
     caught = true;
-    std::string msg = "InvalidArgumentError";
+    std::string msg = "InvalidArgument";
     std::string err_msg = err.what();
     ASSERT_TRUE(err_msg.find(msg) != std::string::npos);
   }

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -279,8 +279,15 @@ inline std::string GetErrorSumaryString(StrType&& what, const char* file,
             "Summary:\n----------------------\n";
   }
   sout << string::Sprintf("%s (at %s:%d)", std::forward<StrType>(what), file,
-                          line)
-       << std::endl;
+                          line);
+  if (FLAGS_call_stack_level < 2) {
+    // NOTE(chenweihang): if no C++ backtrace, give a hint to tell users
+    // how to show C++ backtrace, this hint only show in 2.0-rc verison,
+    // and will be removed in 2.0 official version
+    sout << "\n  [Hint: If need to show C++ stacktraces, please set "
+            "`FlAGS_call_stack_level=2`.]";
+  }
+  sout << std::endl;
   return sout.str();
 }
 

--- a/paddle/fluid/platform/errors_test.cc
+++ b/paddle/fluid/platform/errors_test.cc
@@ -20,61 +20,59 @@ limitations under the License. */
 
 using namespace paddle::platform::errors;  // NOLINT
 
-#define CHECK_PADDLE_THROW(EFUNC)                                   \
-  do {                                                              \
-    bool caught_exception = false;                                  \
-    try {                                                           \
-      PADDLE_THROW((EFUNC)("paddle throw test."));                  \
-    } catch (paddle::platform::EnforceNotMet & error) {             \
-      caught_exception = true;                                      \
-      std::string ex_msg = error.what();                            \
-      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle throw test.") != \
-                  std::string::npos);                               \
-    }                                                               \
-    EXPECT_TRUE(caught_exception);                                  \
+#define CHECK_PADDLE_THROW(EFUNC)                                          \
+  do {                                                                     \
+    bool caught_exception = false;                                         \
+    try {                                                                  \
+      PADDLE_THROW((EFUNC)("paddle throw test."));                         \
+    } catch (paddle::platform::EnforceNotMet & error) {                    \
+      caught_exception = true;                                             \
+      std::string ex_msg = error.what();                                   \
+      EXPECT_TRUE(ex_msg.find("paddle throw test.") != std::string::npos); \
+    }                                                                      \
+    EXPECT_TRUE(caught_exception);                                         \
   } while (0)
 
-#define CHECK_PADDLE_ENFORCE(EFUNC)                                   \
+#define CHECK_PADDLE_ENFORCE(EFUNC)                                          \
+  do {                                                                       \
+    bool caught_exception = false;                                           \
+    try {                                                                    \
+      PADDLE_ENFORCE(false, (EFUNC)("paddle enforce test."));                \
+    } catch (paddle::platform::EnforceNotMet & error) {                      \
+      caught_exception = true;                                               \
+      std::string ex_msg = error.what();                                     \
+      EXPECT_TRUE(ex_msg.find("paddle enforce test.") != std::string::npos); \
+    }                                                                        \
+    EXPECT_TRUE(caught_exception);                                           \
+  } while (0)
+
+#define CHECK_PADDLE_ENFORCE_NOT_NULL(EFUNC)                             \
+  do {                                                                   \
+    bool caught_exception = false;                                       \
+    try {                                                                \
+      PADDLE_ENFORCE_NOT_NULL(nullptr,                                   \
+                              (EFUNC)("paddle enforce not null test.")); \
+    } catch (paddle::platform::EnforceNotMet & error) {                  \
+      caught_exception = true;                                           \
+      std::string ex_msg = error.what();                                 \
+      EXPECT_TRUE(ex_msg.find("paddle enforce not null test.") !=        \
+                  std::string::npos);                                    \
+    }                                                                    \
+    EXPECT_TRUE(caught_exception);                                       \
+  } while (0)
+
+#define CHECK_PADDLE_ENFORCE_EQ(EFUNC)                                \
   do {                                                                \
     bool caught_exception = false;                                    \
     try {                                                             \
-      PADDLE_ENFORCE(false, (EFUNC)("paddle enforce test."));         \
+      PADDLE_ENFORCE_EQ(1, 2, (EFUNC)("paddle enforce equal test.")); \
     } catch (paddle::platform::EnforceNotMet & error) {               \
       caught_exception = true;                                        \
       std::string ex_msg = error.what();                              \
-      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle enforce test.") != \
+      EXPECT_TRUE(ex_msg.find("paddle enforce equal test.") !=        \
                   std::string::npos);                                 \
     }                                                                 \
     EXPECT_TRUE(caught_exception);                                    \
-  } while (0)
-
-#define CHECK_PADDLE_ENFORCE_NOT_NULL(EFUNC)                                   \
-  do {                                                                         \
-    bool caught_exception = false;                                             \
-    try {                                                                      \
-      PADDLE_ENFORCE_NOT_NULL(nullptr,                                         \
-                              (EFUNC)("paddle enforce not null test."));       \
-    } catch (paddle::platform::EnforceNotMet & error) {                        \
-      caught_exception = true;                                                 \
-      std::string ex_msg = error.what();                                       \
-      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle enforce not null test.") != \
-                  std::string::npos);                                          \
-    }                                                                          \
-    EXPECT_TRUE(caught_exception);                                             \
-  } while (0)
-
-#define CHECK_PADDLE_ENFORCE_EQ(EFUNC)                                      \
-  do {                                                                      \
-    bool caught_exception = false;                                          \
-    try {                                                                   \
-      PADDLE_ENFORCE_EQ(1, 2, (EFUNC)("paddle enforce equal test."));       \
-    } catch (paddle::platform::EnforceNotMet & error) {                     \
-      caught_exception = true;                                              \
-      std::string ex_msg = error.what();                                    \
-      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle enforce equal test.") != \
-                  std::string::npos);                                       \
-    }                                                                       \
-    EXPECT_TRUE(caught_exception);                                          \
   } while (0)
 
 #define CHECK_ALL_PADDLE_EXCEPTION_MACRO(EFUNC) \

--- a/paddle/fluid/platform/errors_test.cc
+++ b/paddle/fluid/platform/errors_test.cc
@@ -20,62 +20,61 @@ limitations under the License. */
 
 using namespace paddle::platform::errors;  // NOLINT
 
-#define CHECK_PADDLE_THROW(EFUNC)                                    \
-  do {                                                               \
-    bool caught_exception = false;                                   \
-    try {                                                            \
-      PADDLE_THROW((EFUNC)("paddle throw test."));                   \
-    } catch (paddle::platform::EnforceNotMet & error) {              \
-      caught_exception = true;                                       \
-      std::string ex_msg = error.what();                             \
-      EXPECT_TRUE(ex_msg.find(#EFUNC "Error: paddle throw test.") != \
-                  std::string::npos);                                \
-    }                                                                \
-    EXPECT_TRUE(caught_exception);                                   \
+#define CHECK_PADDLE_THROW(EFUNC)                                   \
+  do {                                                              \
+    bool caught_exception = false;                                  \
+    try {                                                           \
+      PADDLE_THROW((EFUNC)("paddle throw test."));                  \
+    } catch (paddle::platform::EnforceNotMet & error) {             \
+      caught_exception = true;                                      \
+      std::string ex_msg = error.what();                            \
+      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle throw test.") != \
+                  std::string::npos);                               \
+    }                                                               \
+    EXPECT_TRUE(caught_exception);                                  \
   } while (0)
 
-#define CHECK_PADDLE_ENFORCE(EFUNC)                                    \
-  do {                                                                 \
-    bool caught_exception = false;                                     \
-    try {                                                              \
-      PADDLE_ENFORCE(false, (EFUNC)("paddle enforce test."));          \
-    } catch (paddle::platform::EnforceNotMet & error) {                \
-      caught_exception = true;                                         \
-      std::string ex_msg = error.what();                               \
-      EXPECT_TRUE(ex_msg.find(#EFUNC "Error: paddle enforce test.") != \
-                  std::string::npos);                                  \
-    }                                                                  \
-    EXPECT_TRUE(caught_exception);                                     \
+#define CHECK_PADDLE_ENFORCE(EFUNC)                                   \
+  do {                                                                \
+    bool caught_exception = false;                                    \
+    try {                                                             \
+      PADDLE_ENFORCE(false, (EFUNC)("paddle enforce test."));         \
+    } catch (paddle::platform::EnforceNotMet & error) {               \
+      caught_exception = true;                                        \
+      std::string ex_msg = error.what();                              \
+      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle enforce test.") != \
+                  std::string::npos);                                 \
+    }                                                                 \
+    EXPECT_TRUE(caught_exception);                                    \
   } while (0)
 
-#define CHECK_PADDLE_ENFORCE_NOT_NULL(EFUNC)                             \
-  do {                                                                   \
-    bool caught_exception = false;                                       \
-    try {                                                                \
-      PADDLE_ENFORCE_NOT_NULL(nullptr,                                   \
-                              (EFUNC)("paddle enforce not null test.")); \
-    } catch (paddle::platform::EnforceNotMet & error) {                  \
-      caught_exception = true;                                           \
-      std::string ex_msg = error.what();                                 \
-      EXPECT_TRUE(                                                       \
-          ex_msg.find(#EFUNC "Error: paddle enforce not null test.") !=  \
-          std::string::npos);                                            \
-    }                                                                    \
-    EXPECT_TRUE(caught_exception);                                       \
+#define CHECK_PADDLE_ENFORCE_NOT_NULL(EFUNC)                                   \
+  do {                                                                         \
+    bool caught_exception = false;                                             \
+    try {                                                                      \
+      PADDLE_ENFORCE_NOT_NULL(nullptr,                                         \
+                              (EFUNC)("paddle enforce not null test."));       \
+    } catch (paddle::platform::EnforceNotMet & error) {                        \
+      caught_exception = true;                                                 \
+      std::string ex_msg = error.what();                                       \
+      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle enforce not null test.") != \
+                  std::string::npos);                                          \
+    }                                                                          \
+    EXPECT_TRUE(caught_exception);                                             \
   } while (0)
 
-#define CHECK_PADDLE_ENFORCE_EQ(EFUNC)                                       \
-  do {                                                                       \
-    bool caught_exception = false;                                           \
-    try {                                                                    \
-      PADDLE_ENFORCE_EQ(1, 2, (EFUNC)("paddle enforce equal test."));        \
-    } catch (paddle::platform::EnforceNotMet & error) {                      \
-      caught_exception = true;                                               \
-      std::string ex_msg = error.what();                                     \
-      EXPECT_TRUE(ex_msg.find(#EFUNC "Error: paddle enforce equal test.") != \
-                  std::string::npos);                                        \
-    }                                                                        \
-    EXPECT_TRUE(caught_exception);                                           \
+#define CHECK_PADDLE_ENFORCE_EQ(EFUNC)                                      \
+  do {                                                                      \
+    bool caught_exception = false;                                          \
+    try {                                                                   \
+      PADDLE_ENFORCE_EQ(1, 2, (EFUNC)("paddle enforce equal test."));       \
+    } catch (paddle::platform::EnforceNotMet & error) {                     \
+      caught_exception = true;                                              \
+      std::string ex_msg = error.what();                                    \
+      EXPECT_TRUE(ex_msg.find("(" #EFUNC ") paddle enforce equal test.") != \
+                  std::string::npos);                                       \
+    }                                                                       \
+    EXPECT_TRUE(caught_exception);                                          \
   } while (0)
 
 #define CHECK_ALL_PADDLE_EXCEPTION_MACRO(EFUNC) \

--- a/paddle/fluid/platform/flags.cc
+++ b/paddle/fluid/platform/flags.cc
@@ -499,7 +499,7 @@ DEFINE_bool(use_mkldnn, false, "Use MKLDNN to run");
  * message summary will be shown.
  */
 DEFINE_int32(
-    call_stack_level, 2,
+    call_stack_level, 1,
     "Determine the call stack to print when error or exeception happens."
     // TODO(zhiqiu): implement logic of FLAGS_call_stack_level==0
     // "If FLAGS_call_stack_level == 0, only the error message summary will be "

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_matmul_mkldnn_op.py
@@ -437,7 +437,7 @@ class TestMatMulOpTransposeReshapeTransposeAxisNotSupportedException(
 
     def test_check_output(self):
         self.assertRaises(AttributeError, self.check_raise_error,
-                          'InvalidArgumentError: supported transpose axis '
+                          'supported transpose axis '
                           'for the fuse are {0, 2, 1, 3}')
 
 
@@ -449,9 +449,8 @@ class TestMatMulOpTransposeReshapeTransposeRankNotSupportedException(
         self.out = np.matmul(self.x, self.y)
 
     def test_check_output(self):
-        self.assertRaises(
-            AttributeError, self.check_raise_error,
-            'InvalidArgumentError: transpose_out supported rank is 4')
+        self.assertRaises(AttributeError, self.check_raise_error,
+                          'transpose_out supported rank is 4')
 
 
 class TestMatMulOpTransposeReshapeRankOfReshapeNotSupportedException(
@@ -462,9 +461,8 @@ class TestMatMulOpTransposeReshapeRankOfReshapeNotSupportedException(
         self.out = np.matmul(self.x, self.y)
 
     def test_check_output(self):
-        self.assertRaises(
-            AttributeError, self.check_raise_error,
-            'InvalidArgumentError: reshape_out supported rank is 3')
+        self.assertRaises(AttributeError, self.check_raise_error,
+                          'reshape_out supported rank is 3')
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_prelu_op.py
+++ b/python/paddle/fluid/tests/unittests/test_prelu_op.py
@@ -83,10 +83,12 @@ class TestFunctionalPReluAPI(unittest.TestCase):
             # The input type must be Variable.
             self.assertRaises(TypeError, F.prelu, x=1, weight=weight_fp32)
             # The input dtype must be float16, float32, float64.
-            x_int32 = paddle.fluid.data(name='x_int32', shape=[2, 3], dtype='int32')
+            x_int32 = paddle.fluid.data(
+                name='x_int32', shape=[2, 3], dtype='int32')
             self.assertRaises(TypeError, F.prelu, x=x_int32, weight=weight_fp32)
             # support the input dtype is float16
-            x_fp16 = paddle.fluid.data(name='x_fp16', shape=[2, 3], dtype='float16')
+            x_fp16 = paddle.fluid.data(
+                name='x_fp16', shape=[2, 3], dtype='float16')
             F.prelu(x=x_fp16, weight=weight_fp32)
 
 
@@ -100,7 +102,8 @@ class TestNNPReluAPI(unittest.TestCase):
         startup_program = paddle.static.Program()
         train_program = paddle.static.Program()
         with paddle.static.program_guard(train_program, startup_program):
-            x = paddle.fluid.data(name='X', shape=self.x_np.shape, dtype='float32')
+            x = paddle.fluid.data(
+                name='X', shape=self.x_np.shape, dtype='float32')
             m = paddle.nn.PReLU()
             out = m(x)
             exe = paddle.static.Executor(self.place)
@@ -296,7 +299,7 @@ class TestModeError(unittest.TestCase):
             try:
                 y = prelu_t(x, 'any')
             except Exception as e:
-                assert (e.args[0].find('InvalidArgumentError') != -1)
+                assert (e.args[0].find('InvalidArgument') != -1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Hide the C++ stack by default and add hints


original static:
```
λ yq01-gpu-255-137-12-00 /work/scripts/errors {master} python2.7 base_error_case1.py 
Traceback (most recent call last):
  File "base_error_case1.py", line 27, in <module>
    loss_data, = exe.run(fluid.default_main_program(), feed={'X': x, 'Y': y}, fetch_list=[avg_loss.name])
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1107, in run
    six.reraise(*sys.exc_info())
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1105, in run
    return_merged=return_merged)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1229, in _run_impl
    use_program_cache=use_program_cache)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1319, in _run_program
    [fetch_var_name])
ValueError: 

  Compile Traceback (most recent call last):
    File "base_error_case1.py", line 12, in <module>
      predict = fluid.layers.fc(input=x, size=1, act=None)
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/layers/nn.py", line 354, in fc
      "y_num_col_dims": 1})
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/layer_helper.py", line 43, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2926, in append_op
      attrs=kwargs.get("attrs", None))
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2016, in __init__
      for frame in traceback.extract_stack():

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::framework::Executor::Run(paddle::framework::ProgramDesc const&, paddle::framework::Scope*, int, bool, bool, std::vector<std::string, std::allocator<std::string> > const&, bool, bool)
1   paddle::framework::Executor::RunPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, bool, bool, bool)
2   paddle::framework::Executor::RunPartialPreparedContext(paddle::framework::ExecutorPrepareContext*, paddle::framework::Scope*, long, long, bool, bool, bool)
3   paddle::framework::OperatorBase::Run(paddle::framework::Scope const&, paddle::platform::Place const&)
4   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&) const
5   paddle::framework::OperatorWithKernel::RunImpl(paddle::framework::Scope const&, paddle::platform::Place const&, paddle::framework::RuntimeContext*) const
6   paddle::operators::MulOp::InferShape(paddle::framework::InferShapeContext*) const
7   paddle::platform::EnforceNotMet::EnforceNotMet(paddle::platform::ErrorSummary const&, char const*, int)
8   paddle::platform::GetCurrentTraceBackString()

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: After flatten the input tensor X and Y to 2-D dimensions matrix X1 and Y1, the matrix X1's width must be equal with matrix Y1's height. But received X's shape = [8, 12], X1's shape = [8, 12], X1's width = 12; Y's shape = [13, 1], Y1's shape = [13, 1], Y1's height = 13.
  [Hint: Expected x_mat_dims[1] == y_mat_dims[0], but received x_mat_dims[1]:12 != y_mat_dims[0]:13.] (at /work/paddle_py2/paddle/fluid/operators/mul_op.cc:83)
  [operator < mul > error]
```

new static:
```
λ yq01-gpu-255-137-12-00 /work/scripts/errors {master} python2.7 base_error_case1.py 
Traceback (most recent call last):
  File "base_error_case1.py", line 27, in <module>
    loss_data, = exe.run(fluid.default_main_program(), feed={'X': x, 'Y': y}, fetch_list=[avg_loss.name])
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1108, in run
    six.reraise(*sys.exc_info())
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1106, in run
    return_merged=return_merged)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1236, in _run_impl
    use_program_cache=use_program_cache)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/executor.py", line 1326, in _run_program
    [fetch_var_name])
ValueError: In user code:

    File "base_error_case1.py", line 12, in <module>
      predict = fluid.layers.fc(input=x, size=1, act=None)
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/layers/nn.py", line 354, in fc
      "y_num_col_dims": 1})
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/layer_helper.py", line 43, in append_op
      return self.main_program.current_block().append_op(*args, **kwargs)
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2934, in append_op
      attrs=kwargs.get("attrs", None))
    File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/framework.py", line 2019, in __init__
      for frame in traceback.extract_stack():

    InvalidArgumentError: After flatten the input tensor X and Y to 2-D dimensions matrix X1 and Y1, the matrix X1's width must be equal with matrix Y1's height. But received X's shape = [8, 12], X1's shape = [8, 12], X1's width = 12; Y's shape = [13, 1], Y1's shape = [13, 1], Y1's height = 13.
      [Hint: Expected x_mat_dims[1] == y_mat_dims[0], but received x_mat_dims[1]:12 != y_mat_dims[0]:13.] (at /work/paddle_py2/paddle/fluid/operators/mul_op.cc:83)
      [Hint: If need to show C++ stacktraces, please set `FlAGS_call_stack_level=2`.]
      [operator < mul > error]
```

original dynamic:
```
λ yq01-gpu-255-137-12-00 /work/scripts/errors {master} python2.7 base_error_case2.py 
Traceback (most recent call last):
  File "base_error_case2.py", line 9, in <module>
    res = linear(data)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/layers.py", line 829, in __call__
    outputs = self.forward(*inputs, **kwargs)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/nn.py", line 970, in forward
    self._use_mkldnn)
ValueError: 

--------------------------------------
C++ Traceback (most recent call last):
--------------------------------------
0   paddle::imperative::Tracer::TraceOp(std::string const&, paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::AttributeMap)
1   paddle::imperative::Tracer::TraceOp(std::string const&, paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::AttributeMap, paddle::platform::Place const&, bool)
2   paddle::imperative::OpBase::Run(paddle::framework::OperatorBase const&, paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::AttributeMap const&, paddle::platform::Place const&)
3   paddle::imperative::PreparedOp::Run(paddle::imperative::NameVarBaseMap const&, paddle::imperative::NameVarBaseMap const&, paddle::framework::AttributeMap const&)
4   paddle::operators::MatMulOp::InferShape(paddle::framework::InferShapeContext*) const
5   paddle::platform::EnforceNotMet::EnforceNotMet(paddle::platform::ErrorSummary const&, char const*, int)
6   paddle::platform::GetCurrentTraceBackString()

----------------------
Error Message Summary:
----------------------
InvalidArgumentError: Input X's width should be equal to the Y's height, but received X's shape: [10, 2],Y's shape: [1, 10].
  [Hint: Expected mat_dim_x.width_ == mat_dim_y.height_, but received mat_dim_x.width_:2 != mat_dim_y.height_:1.] (at /work/paddle_py2/paddle/fluid/operators/matmul_op.cc:586)
  [operator < matmul > error]
```

new dynamic:
```
Traceback (most recent call last):
  File "base_error_case2.py", line 9, in <module>
    res = linear(data)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/layers.py", line 829, in __call__
    outputs = self.forward(*inputs, **kwargs)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/nn.py", line 970, in forward
    self._use_mkldnn)
ValueError: (InvalidArgument) Input X's width should be equal to the Y's height, but received X's shape: [10, 2],Y's shape: [1, 10].
  [Hint: Expected mat_dim_x.width_ == mat_dim_y.height_, but received mat_dim_x.width_:2 != mat_dim_y.height_:1.] (at /work/paddle_py2/paddle/fluid/operators/matmul_op.cc:586)
  [Hint: If need to show C++ stacktraces, please set `FlAGS_call_stack_level=2`.]
  [operator < matmul > error]
```
