### PR TITLE
Set exit code in op benchmark ci

### DIFF
--- a/tools/test_op_benchmark.sh
+++ b/tools/test_op_benchmark.sh
@@ -161,17 +161,20 @@ function run_op_benchmark_test {
 
 # diff benchmakr result and miss op
 function summary_problems {
-  local op_name
+  local op_name exit_code
   python ${PADDLE_ROOT}/tools/check_op_benchmark_result.py \
       --develop_logs_dir $(pwd)/logs-develop \
       --pr_logs_dir $(pwd)/logs-test_pr
+  exit_code=$?
   for op_name in ${!CHANGE_OP_MAP[@]}
   do
     if [ -z "${BENCHMARK_OP_MAP[$op_name]}" ]
     then
+      exit_code=8
       LOG "[WARNING] Missing test script of \"${op_name}\" in benchmark."
     fi
   done
+  [ $exit_code -ne 0 ] && exit $exit_code
 }
 
 function main {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
在op性能测试中，添加退出状态码设置规则：
- 测试结果中GPU time增长，且增长比例大于5%，则ci失败；
- 测试中发现benchmark repo中缺少测试脚本，则ci失败；
- 其余情况ci成功；
