### PR TITLE
Split train_mode and has_grad for tracer

### DIFF
--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -38,11 +38,20 @@ void SetCurrentTracer(const std::shared_ptr<Tracer>& tracer) {
 }
 
 static void PassStopGradient(const NameVarBaseMap& outs, bool generate_grad) {
-  for (const auto& name_pair : outs) {
-    for (const auto& vb : name_pair.second) {
-      VLOG(6) << "Set output: " << vb->Name() << "'s OverridedStopGradient as "
+  for (const auto& pair : outs) {
+    for (const auto& var : pair.second) {
+      // NOTE(zhiqiu): this happends when None output are passed from python
+      // side. For example, fake_quantize_dequantize_moving_average_abs_max may
+      // pass None OutAccum in eval mode.
+      // It can be refined by generate several different pybind interface for
+      // one operator with different function signature.
+      if (var == nullptr) {
+        VLOG(4) << pair.first << " is NULL";
+        continue;
+      }
+      VLOG(6) << "Set output: " << var->Name() << "'s OverridedStopGradient as "
               << generate_grad;
-      vb->InnerSetOverridedStopGradient(generate_grad);
+      var->InnerSetOverridedStopGradient(generate_grad);
     }
   }
 }

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -631,18 +631,18 @@ void BindImperative(py::module *m_ptr) {
                return out;
              }
            })
-      .def(
-          "numpy",
-          [](imperative::VarBase &self) -> py::array {
-            const auto &tensor = self.MutableVar()->Get<framework::LoDTensor>();
-            PADDLE_ENFORCE_EQ(
-                tensor.IsInitialized(), true,
-                platform::errors::InvalidArgument(
-                    "Tensor of %s is Empty, please check if it has no data.",
-                    self.Name()));
-            return TensorToPyArray(tensor, true);
-          },
-          R"DOC(
+      .def("numpy",
+           [](imperative::VarBase &self) -> py::array {
+             const auto &tensor =
+                 self.MutableVar()->Get<framework::LoDTensor>();
+             PADDLE_ENFORCE_EQ(
+                 tensor.IsInitialized(), true,
+                 platform::errors::InvalidArgument(
+                     "Tensor of %s is Empty, please check if it has no data.",
+                     self.Name()));
+             return TensorToPyArray(tensor, true);
+           },
+           R"DOC(
         **Notes**:
             **This API is ONLY available in Dygraph mode**
 
@@ -670,16 +670,15 @@ void BindImperative(py::module *m_ptr) {
                     print(x.numpy())
 
        )DOC")
-      .def(
-          "detach",
-          [](const imperative::VarBase &self) {
-            const auto &tensor = self.Var().Get<framework::LoDTensor>();
-            PADDLE_ENFORCE_EQ(tensor.IsInitialized(), true,
-                              platform::errors::InvalidArgument(
-                                  "%s has not been initialized", self.Name()));
-            return self.NewVarBase(tensor.place(), false);
-          },
-          py::return_value_policy::copy, R"DOC(
+      .def("detach",
+           [](const imperative::VarBase &self) {
+             const auto &tensor = self.Var().Get<framework::LoDTensor>();
+             PADDLE_ENFORCE_EQ(tensor.IsInitialized(), true,
+                               platform::errors::InvalidArgument(
+                                   "%s has not been initialized", self.Name()));
+             return self.NewVarBase(tensor.place(), false);
+           },
+           py::return_value_policy::copy, R"DOC(
 
         Returns a new Tensor, detached from the current graph.
 
@@ -714,23 +713,23 @@ void BindImperative(py::module *m_ptr) {
                 linear.weight.clear_gradient()
                 print("After clear_gradient, linear.weight.grad: {}".format(linear.weight.grad))
       )DOC")
-      .def(
-          "clone",
-          [](std::shared_ptr<imperative::VarBase> &self) {
-            const auto &tensor = self->Var().Get<framework::LoDTensor>();
-            PADDLE_ENFORCE_EQ(tensor.IsInitialized(), true,
-                              platform::errors::InvalidArgument(
-                                  "%s has not been initialized", self->Name()));
-            auto tracer = imperative::GetCurrentTracer();
-            auto new_var = std::make_shared<imperative::VarBase>(
-                true, tracer->GenerateUniqueName(self->Name() + "_clone"));
-            framework::AttributeMap attrs;
-            imperative::NameVarBaseMap ins = {{"X", {self}}};
-            imperative::NameVarBaseMap outs = {{"Out", {new_var}}};
-            tracer->TraceOp("assign", ins, outs, attrs);
-            return new_var;
-          },
-          py::return_value_policy::copy, R"DOC(
+      .def("clone",
+           [](std::shared_ptr<imperative::VarBase> &self) {
+             const auto &tensor = self->Var().Get<framework::LoDTensor>();
+             PADDLE_ENFORCE_EQ(
+                 tensor.IsInitialized(), true,
+                 platform::errors::InvalidArgument(
+                     "%s has not been initialized", self->Name()));
+             auto tracer = imperative::GetCurrentTracer();
+             auto new_var = std::make_shared<imperative::VarBase>(
+                 true, tracer->GenerateUniqueName(self->Name() + "_clone"));
+             framework::AttributeMap attrs;
+             imperative::NameVarBaseMap ins = {{"X", {self}}};
+             imperative::NameVarBaseMap outs = {{"Out", {new_var}}};
+             tracer->TraceOp("assign", ins, outs, attrs);
+             return new_var;
+           },
+           py::return_value_policy::copy, R"DOC(
 
         Returns a new Tensor, which is clone of origin Tensor, and it remains in the current graph.
         It will always have a Tensor copy.
@@ -762,61 +761,57 @@ void BindImperative(py::module *m_ptr) {
               print(x.stop_gradient) # True
               print(x.grad)          # None
        )DOC")
-      .def(
-          "_run_backward",
-          [](imperative::VarBase &self, const imperative::Tracer &tracer,
-             bool retain_graph) {
-            // TODO(jiabin): when we impl more backward execution we can
-            // select them
-            auto *engine = tracer.GetEngine();
-            engine->Init(&self, retain_graph);
-            VLOG(3) << "Start backward";
-            engine->Execute();
-            VLOG(3) << "Finish backward";
-          },
-          py::call_guard<py::gil_scoped_release>())
+      .def("_run_backward",
+           [](imperative::VarBase &self, const imperative::Tracer &tracer,
+              bool retain_graph) {
+             // TODO(jiabin): when we impl more backward execution we can
+             // select them
+             auto *engine = tracer.GetEngine();
+             engine->Init(&self, retain_graph);
+             VLOG(3) << "Start backward";
+             engine->Execute();
+             VLOG(3) << "Finish backward";
+           },
+           py::call_guard<py::gil_scoped_release>())
       .def("_grad_name", &imperative::VarBase::GradVarName)
-      .def(
-          "_grad_value",
-          [](imperative::VarBase &self) {
-            return self.MutableGradVar()->Get<framework::LoDTensor>();
-          },
-          py::return_value_policy::reference)
+      .def("_grad_value",
+           [](imperative::VarBase &self) {
+             return self.MutableGradVar()->Get<framework::LoDTensor>();
+           },
+           py::return_value_policy::reference)
       .def("_set_grad_type",
            [](imperative::VarBase &self, framework::proto::VarType::Type type) {
              self.MutableGradVarBase()->SetType(type);
            })
-      .def(
-          "_grad_ivar",
-          [](const imperative::VarBase &self) {
-            auto &grad_var = self.GradVarBase();
-            if (grad_var && grad_var->Var().IsInitialized()) {
-              auto *tensor =
-                  grad_var->MutableVar()->IsType<framework::LoDTensor>()
-                      ? grad_var->MutableVar()
-                            ->GetMutable<framework::LoDTensor>()
-                      : grad_var->MutableVar()
-                            ->GetMutable<framework::SelectedRows>()
-                            ->mutable_value();
-              if (tensor->IsInitialized()) {
-                return grad_var;
-              }
-            }
-            return std::shared_ptr<imperative::VarBase>(nullptr);
-          },
-          py::return_value_policy::copy)
+      .def("_grad_ivar",
+           [](const imperative::VarBase &self) {
+             auto &grad_var = self.GradVarBase();
+             if (grad_var && grad_var->Var().IsInitialized()) {
+               auto *tensor =
+                   grad_var->MutableVar()->IsType<framework::LoDTensor>()
+                       ? grad_var->MutableVar()
+                             ->GetMutable<framework::LoDTensor>()
+                       : grad_var->MutableVar()
+                             ->GetMutable<framework::SelectedRows>()
+                             ->mutable_value();
+               if (tensor->IsInitialized()) {
+                 return grad_var;
+               }
+             }
+             return std::shared_ptr<imperative::VarBase>(nullptr);
+           },
+           py::return_value_policy::copy)
       .def("_is_sparse",
            [](imperative::VarBase &self) {
              return self.Var().IsType<framework::SelectedRows>();
            })
-      .def(
-          "_allreduce",
-          [](imperative::VarBase &self,
-             const imperative::ParallelStrategy &strategy) {
-            if (strategy.nranks_ > 1) {
+      .def("_allreduce",
+           [](imperative::VarBase &self,
+              const imperative::ParallelStrategy &strategy) {
+             if (strategy.nranks_ > 1) {
 #ifdef PADDLE_WITH_NCCL
 #if NCCL_VERSION_CODE >= 2212
-              imperative::AllReduce(self.Var(), self.MutableVar(), strategy);
+               imperative::AllReduce(self.Var(), self.MutableVar(), strategy);
 #else
                if (!self.Var().IsType<framework::SelectedRows>()) {
                  imperative::AllReduce(self.Var(), self.MutableVar(), strategy);
@@ -833,21 +828,20 @@ void BindImperative(py::module *m_ptr) {
                    "Imperative allreduce is not supported when paddle is "
                    "not compiled with NCCL."));
 #endif  // PADDLE_WITH_NCCL
-            }
-          },
-          py::call_guard<py::gil_scoped_release>())
-      .def(
-          "cpu",
-          [](const std::shared_ptr<imperative::VarBase> &self) {
-            if (platform::is_cpu_place(self->Place())) {
-              return self;
-            } else {
-              auto new_var = self->NewVarBase(platform::CPUPlace(), true);
-              new_var->SetOverridedStopGradient(self->OverridedStopGradient());
-              return new_var;
-            }
-          },
-          R"DOC(
+             }
+           },
+           py::call_guard<py::gil_scoped_release>())
+      .def("cpu",
+           [](const std::shared_ptr<imperative::VarBase> &self) {
+             if (platform::is_cpu_place(self->Place())) {
+               return self;
+             } else {
+               auto new_var = self->NewVarBase(platform::CPUPlace(), true);
+               new_var->SetOverridedStopGradient(self->OverridedStopGradient());
+               return new_var;
+             }
+           },
+           R"DOC(
         Returns a copy of this Tensor in CPU memory.
 
         If this Tensor is already in CPU memory, then no copy is performed and the original Tensor is returned.
@@ -863,25 +857,24 @@ void BindImperative(py::module *m_ptr) {
               print(y.place)    # CPUPlace
 
               )DOC")
-      .def(
-          "pin_memory",
-          [](const std::shared_ptr<imperative::VarBase> &self) {
+      .def("pin_memory",
+           [](const std::shared_ptr<imperative::VarBase> &self) {
 #ifndef PADDLE_WITH_CUDA
-            PADDLE_THROW(platform::errors::PermissionDenied(
-                "Cannot copy this Tensor to pinned memory in CPU version "
-                "Paddle, "
-                "Please recompile or reinstall Paddle with CUDA support."));
+             PADDLE_THROW(platform::errors::PermissionDenied(
+                 "Cannot copy this Tensor to pinned memory in CPU version "
+                 "Paddle, "
+                 "Please recompile or reinstall Paddle with CUDA support."));
 #endif
-            if (platform::is_cuda_pinned_place(self->Place())) {
-              return self;
-            } else {
-              auto new_var =
-                  self->NewVarBase(platform::CUDAPinnedPlace(), true);
-              new_var->SetOverridedStopGradient(self->OverridedStopGradient());
-              return new_var;
-            }
-          },
-          R"DOC(
+             if (platform::is_cuda_pinned_place(self->Place())) {
+               return self;
+             } else {
+               auto new_var =
+                   self->NewVarBase(platform::CUDAPinnedPlace(), true);
+               new_var->SetOverridedStopGradient(self->OverridedStopGradient());
+               return new_var;
+             }
+           },
+           R"DOC(
         Returns a copy of this Tensor in pin memory.
 
         If this Tensor is already in pin memory, then no copy is performed and the original Tensor is returned.
@@ -897,14 +890,13 @@ void BindImperative(py::module *m_ptr) {
               print(y.place)      # CUDAPinnedPlace
 
       )DOC")
-      .def(
-          "cuda",
-          [](const std::shared_ptr<imperative::VarBase> &self, int device_id,
-             bool blocking) {
+      .def("cuda",
+           [](const std::shared_ptr<imperative::VarBase> &self, int device_id,
+              bool blocking) {
 #ifndef PADDLE_WITH_CUDA
-            PADDLE_THROW(platform::errors::PermissionDenied(
-                "Cannot copy this Tensor to GPU in CPU version Paddle, "
-                "Please recompile or reinstall Paddle with CUDA support."));
+             PADDLE_THROW(platform::errors::PermissionDenied(
+                 "Cannot copy this Tensor to GPU in CPU version Paddle, "
+                 "Please recompile or reinstall Paddle with CUDA support."));
 #else
              int device_count = platform::GetCUDADeviceCount();
              if (device_id == -1) {
@@ -935,8 +927,8 @@ void BindImperative(py::module *m_ptr) {
                return new_var;
              }
 #endif
-          },
-          py::arg("device_id") = -1, py::arg("blocking") = true, R"DOC(
+           },
+           py::arg("device_id") = -1, py::arg("blocking") = true, R"DOC(
         Returns a copy of this Tensor in GPU memory.
 
         If this Tensor is already in GPU memory and device_id is default, 
@@ -960,30 +952,25 @@ void BindImperative(py::module *m_ptr) {
               y = x.cuda(1)
               print(y.place)        # CUDAPlace(1)
        )DOC")
-      .def(
-          "_copy_to",
-          [](const imperative::VarBase &self, const platform::CPUPlace &place,
-             bool blocking) { return self.NewVarBase(place, blocking); },
-          py::return_value_policy::copy)
-      .def(
-          "_copy_to",
-          [](const imperative::VarBase &self,
-             const platform::CUDAPinnedPlace &place,
-             bool blocking) { return self.NewVarBase(place, blocking); },
-          py::return_value_policy::copy)
-      .def(
-          "_copy_to",
-          [](const imperative::VarBase &self, const platform::XPUPlace &place,
-             bool blocking) { return self.NewVarBase(place, blocking); },
-          py::return_value_policy::copy)
-      .def(
-          "_copy_to",
-          [](const imperative::VarBase &self, const platform::CUDAPlace &place,
-             bool blocking) { return self.NewVarBase(place, blocking); },
-          py::return_value_policy::copy)
-      .def(
-          "value", [](imperative::VarBase &self) { return self.MutableVar(); },
-          py::return_value_policy::reference)
+      .def("_copy_to",
+           [](const imperative::VarBase &self, const platform::CPUPlace &place,
+              bool blocking) { return self.NewVarBase(place, blocking); },
+           py::return_value_policy::copy)
+      .def("_copy_to",
+           [](const imperative::VarBase &self,
+              const platform::CUDAPinnedPlace &place,
+              bool blocking) { return self.NewVarBase(place, blocking); },
+           py::return_value_policy::copy)
+      .def("_copy_to",
+           [](const imperative::VarBase &self, const platform::XPUPlace &place,
+              bool blocking) { return self.NewVarBase(place, blocking); },
+           py::return_value_policy::copy)
+      .def("_copy_to",
+           [](const imperative::VarBase &self, const platform::CUDAPlace &place,
+              bool blocking) { return self.NewVarBase(place, blocking); },
+           py::return_value_policy::copy)
+      .def("value", [](imperative::VarBase &self) { return self.MutableVar(); },
+           py::return_value_policy::reference)
       .def_property("name", &imperative::VarBase::Name,
                     &imperative::VarBase::SetName)
       .def_property("stop_gradient",
@@ -1146,14 +1133,13 @@ void BindImperative(py::module *m_ptr) {
           [](imperative::ParallelStrategy &self, int nranks) {
             self.nranks_ = nranks;
           })
-      .def_property(
-          "local_rank",
-          [](const imperative::ParallelStrategy &self) {
-            return self.local_rank_;
-          },
-          [](imperative::ParallelStrategy &self, int local_rank) {
-            self.local_rank_ = local_rank;
-          })
+      .def_property("local_rank",
+                    [](const imperative::ParallelStrategy &self) {
+                      return self.local_rank_;
+                    },
+                    [](imperative::ParallelStrategy &self, int local_rank) {
+                      self.local_rank_ = local_rank;
+                    })
       .def_property(
           "trainer_endpoints",
           [](const imperative::ParallelStrategy &self) {
@@ -1162,14 +1148,12 @@ void BindImperative(py::module *m_ptr) {
           [](imperative::ParallelStrategy &self, std::vector<std::string> eps) {
             self.trainer_endpoints_ = eps;
           })
-      .def_property(
-          "current_endpoint",
-          [](const imperative::ParallelStrategy &self) {
-            return self.current_endpoint_;
-          },
-          [](imperative::ParallelStrategy &self, const std::string &ep) {
-            self.current_endpoint_ = ep;
-          });
+      .def_property("current_endpoint",
+                    [](const imperative::ParallelStrategy &self) {
+                      return self.current_endpoint_;
+                    },
+                    [](imperative::ParallelStrategy &self,
+                       const std::string &ep) { self.current_endpoint_ = ep; });
 
   m.def(
       "dygraph_partial_grad",

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -190,12 +190,12 @@ def disable_dygraph():
 def _switch_tracer_mode_guard_(is_train=True):
     tracer = framework._dygraph_tracer()
     if tracer:
-        mode = tracer._train_mode
-        tracer._train_mode = is_train
+        has_grad = tracer._has_grad
+        tracer._has_grad = is_train
         try:
             yield
         finally:
-            tracer._train_mode = mode
+            tracer._has_grad = has_grad
     else:
         yield
 

--- a/python/paddle/fluid/dygraph/tracer.py
+++ b/python/paddle/fluid/dygraph/tracer.py
@@ -41,7 +41,7 @@ class Tracer(core.Tracer):
 
     def trace_op(self, type, inputs, outputs, attrs, stop_gradient=False):
         self.trace(type, inputs, outputs, attrs,
-                   framework._current_expected_place(), self._train_mode and
+                   framework._current_expected_place(), self._has_grad and
                    not stop_gradient)
 
     def train_mode(self):

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -997,7 +997,10 @@ def dropout(x,
 
         .. code-block:: python
 
+            import paddle
             import paddle.fluid as fluid
+            
+            paddle.enable_static()
             x = fluid.data(name="data", shape=[None, 32, 32], dtype="float32")
             dropped = fluid.layers.dropout(x, dropout_prob=0.5)
     """

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -945,7 +945,7 @@ def cos_sim(X, Y):
 @deprecated(since="2.0.0", update_to="paddle.nn.functional.dropout")
 def dropout(x,
             dropout_prob,
-            is_test=False,
+            is_test=None,
             seed=None,
             name=None,
             dropout_implementation="downgrade_in_infer"):
@@ -964,7 +964,8 @@ def dropout(x,
     Args:
         x (Variable): The input tensor variable. The data type is float16 or float32 or float64.
         dropout_prob (float): Probability of setting units to zero.
-        is_test (bool): A flag indicating whether it is in test phrase or not.
+        is_test (bool): A flag indicating whether it is in test phrase or not. 
+                        Default None, in dynamic graph, it use global tracer mode; in static graph, it means False.
         seed (int): A Python integer used to create random seeds. If this
                     parameter is set to None, a random seed is used.
                     NOTE: If an integer seed is given, always the same output
@@ -1017,9 +1018,10 @@ def dropout(x,
         if (seed is None or
                 seed == 0) and default_main_program().random_seed != 0:
             seed = default_main_program().random_seed
-        _is_test = not _dygraph_tracer()._train_mode
+        if is_test is None:
+            is_test = not _dygraph_tracer()._train_mode
         out, mask = core.ops.dropout(
-            x, 'dropout_prob', dropout_prob, 'is_test', _is_test, 'fix_seed',
+            x, 'dropout_prob', dropout_prob, 'is_test', is_test, 'fix_seed',
             seed is not None, 'seed', seed if seed is not None else 0,
             'dropout_implementation', dropout_implementation)
         return out

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/transformer_dygraph_model.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/transformer_dygraph_model.py
@@ -64,7 +64,7 @@ class PrePostProcessLayer(Layer):
             elif cmd == "d":  # add dropout
                 if dropout_rate:
                     self.functors.append(lambda x: layers.dropout(
-                        x, dropout_prob=dropout_rate, is_test=False))
+                        x, dropout_prob=dropout_rate))
 
     def forward(self, x, residual=None):
         for i, cmd in enumerate(self.process_cmd):
@@ -137,8 +137,7 @@ class MultiHeadAttention(Layer):
             product += attn_bias
         weights = layers.softmax(product)
         if self.dropout_rate:
-            weights = layers.dropout(
-                weights, dropout_prob=self.dropout_rate, is_test=False)
+            weights = layers.dropout(weights, dropout_prob=self.dropout_rate)
             out = layers.matmul(weights, v)
         out = layers.transpose(out, perm=[0, 2, 1, 3])
         out = layers.reshape(x=out, shape=[0, 0, out.shape[2] * out.shape[3]])
@@ -156,8 +155,7 @@ class FFN(Layer):
     def forward(self, x):
         hidden = self.fc1(x)
         if self.dropout_rate:
-            hidden = layers.dropout(
-                hidden, dropout_prob=self.dropout_rate, is_test=False)
+            hidden = layers.dropout(hidden, dropout_prob=self.dropout_rate)
         out = self.fc2(hidden)
         return out
 
@@ -276,8 +274,8 @@ class WrapEncoder(Layer):
         pos_enc.stop_gradient = True
         emb = word_emb + pos_enc
         enc_input = layers.dropout(
-            emb, dropout_prob=self.emb_dropout,
-            is_test=False) if self.emb_dropout else emb
+            emb,
+            dropout_prob=self.emb_dropout, ) if self.emb_dropout else emb
         enc_output = self.encoder(enc_input, src_slf_attn_bias)
         return enc_output
 
@@ -407,8 +405,8 @@ class WrapDecoder(Layer):
         pos_enc.stop_gradient = True
         emb = word_emb + pos_enc
         dec_input = layers.dropout(
-            emb, dropout_prob=self.emb_dropout,
-            is_test=False) if self.emb_dropout else emb
+            emb,
+            dropout_prob=self.emb_dropout, ) if self.emb_dropout else emb
         dec_output = self.decoder(dec_input, enc_output, trg_slf_attn_bias,
                                   trg_src_attn_bias, caches)
         dec_output = layers.reshape(

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -287,13 +287,14 @@ class TestImperative(unittest.TestCase):
             with paddle.no_grad():
                 self.assertTrue(l1.weight.stop_gradient is False)
                 tmp = l1.weight * 2
-                self.assertTrue(tmp.stop_gradient)
+                print(tmp)
+                self.assertFalse(tmp.stop_gradient)
             x = fluid.dygraph.to_variable(data)
             y = l0(x) + tmp
             o = l1(y)
             o.backward()
 
-            self.assertTrue(tmp._grad_ivar() is None)
+            self.assertTrue(tmp._grad_ivar() is not None)
             self.assertTrue(l0.weight._grad_ivar() is not None)
 
     def test_sum_op(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
@@ -30,7 +30,7 @@ class TestTracerMode(unittest.TestCase):
 
     @fluid.dygraph.no_grad
     def no_grad_func(self, a):
-        self.assertEqual(self.tracer._train_mode, False)
+        self.assertEqual(self.tracer._has_grad, False)
         return a
 
     @framework.dygraph_not_support


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Split train_mode and has_grad for tracer, close https://github.com/PaddlePaddle/Paddle/issues/28089

### Why
Before this PR, the behavior `train/eval mode` and `trcing grad or not` are coupled. 

When setting `layer.eval()`, it also means `do not trace grad`, which is not a good design.

### How
This PR couples `train/eval mode` and `trcing grad or not`. 

- Setting `train/eval mode` of a Layer only affects the internal logic of the specific operators (dropout and batchnorm), since they have different algorithms in train mode and eval mode.
- If really want  "do not trace grad", use `paddle.no_grad` instead.

Also, see details in https://github.com/PaddlePaddle/Paddle/pull/25024