### PR TITLE
Optimize the performance of piecewise_decay.

### DIFF
--- a/python/paddle/fluid/layers/learning_rate_scheduler.py
+++ b/python/paddle/fluid/layers/learning_rate_scheduler.py
@@ -425,16 +425,18 @@ Applies piecewise decay to the initial learning rate.
                         dtype='float32',
                         value=float(boundaries[i]),
                         force_cpu=True)
-                    value_var = tensor.fill_constant(
-                        shape=[1], dtype='float32', value=float(values[i]))
                     with switch.case(global_step < boundary_val):
-                        tensor.assign(value_var, lr)
-                last_value_var = tensor.fill_constant(
-                    shape=[1],
-                    dtype='float32',
-                    value=float(values[len(values) - 1]))
+                        tensor.fill_constant(
+                            shape=[1],
+                            dtype="float32",
+                            value=float(values[i]),
+                            out=lr)
                 with switch.default():
-                    tensor.assign(last_value_var, lr)
+                    tensor.fill_constant(
+                        shape=[1],
+                        dtype="float32",
+                        value=float(values[len(values) - 1]),
+                        out=lr)
 
             return lr
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
- develop的profile结果
```
conditional_block                                         40          1578.19     1578.172142 (0.999988)  0.019296 (0.000012)     0.005383    178.836     39.4548     0.247162
  assign                                                  10          0.610976    0.591680 (0.968418)     0.019296 (0.031582)     0.055614    0.066238    0.0610976   9.56853e-05
    GpuMemcpyAsync(same_gpu):GPU->GPU                     10          0.331618    0.312322 (0.941813)     0.019296 (0.058187)     0.030635    0.037316    0.0331618   5.19349e-05
fill_constant                                             70          2.27661     2.215617 (0.973209)     0.060992 (0.026791)     0.017972    0.064743    0.032523    0.000356541
less_than                                                 30          0.579018    0.579018 (1.000000)     0.000000 (0.000000)     0.012872    0.040594    0.0193006   9.06804e-05
cast                                                      10          0.165345    0.165345 (1.000000)     0.000000 (0.000000)     0.014338    0.022326    0.0165345   2.58948e-05
```

- 优化方法：原来的实现：先使用`fill_constant`将`values[i]`设置给一个新的变量`value_var`，再使用`assign`将`value_var`复制给`lr`。实际上可以直接使用`fill_constant`将`values[i]`设置给已有的变量`lr`。
- 优化后的profile效果：主要是少了一个assign。
```
conditional_block                                         40          1417.74     1417.731893 (0.999992)  0.011904 (0.000008)     0.004762    185.262     35.4436     0.239721
  fill_constant                                           10          0.423595    0.411691 (0.971898)     0.011904 (0.028102)     0.038722    0.049693    0.0423595   7.16242e-05
fill_constant                                             30          1.34635     1.346350 (1.000000)     0.000000 (0.000000)     0.015271    0.211983    0.0448783   0.000217799
less_than                                                 30          0.587124    0.587124 (1.000000)     0.000000 (0.000000)     0.012245    0.032833    0.0195708   9.4979e-05
cast                                                      10          0.159345    0.159345 (1.000000)     0.000000 (0.000000)     0.01256     0.020458    0.0159345   2.57772e-05
```