### PR TITLE
fix the bug in gloo

### DIFF
--- a/python/paddle/distributed/fleet/base/role_maker.py
+++ b/python/paddle/distributed/fleet/base/role_maker.py
@@ -176,7 +176,7 @@ class Gloo(object):
             http_server.start()
             wait_seconds = 5
             while http_server_d.get("running",
-                                    False) and http_server.should_stop():
+                                    False) or not http_server.should_stop():
                 time.sleep(wait_seconds)
             http_server.stop()
 

--- a/python/paddle/distributed/fleet/base/role_maker.py
+++ b/python/paddle/distributed/fleet/base/role_maker.py
@@ -175,7 +175,8 @@ class Gloo(object):
             http_server = KVServer(port, size_d)
             http_server.start()
             wait_seconds = 5
-            while http_server_d.get("running", False):
+            while http_server_d.get("running",
+                                    False) and http_server.should_stop():
                 time.sleep(wait_seconds)
             http_server.stop()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The http server started by gloo may exit before gloo initialization of all trainers. The should_stop function returns True when all trainers finished the gloo initialization.