### PR TITLE
remove BatchSampler type check

### DIFF
--- a/python/paddle/fluid/reader.py
+++ b/python/paddle/fluid/reader.py
@@ -366,9 +366,6 @@ class DataLoader(object):
             self.dataset_kind = _DatasetKind.MAP
 
         if batch_sampler is not None:
-            assert isinstance(batch_sampler, BatchSampler), \
-                "batch_sampler should be None or subclass instance " \
-                "of paddle.io.BatchSampler"
             assert batch_size == 1 and not shuffle and not drop_last, \
                 "batch_size/shuffle/drop_last should not be set when " \
                 "batch_sampler is given"

--- a/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
+++ b/python/paddle/fluid/tests/unittests/test_multiprocess_dataloader_exception.py
@@ -80,14 +80,6 @@ class TestDataLoaderAssert(unittest.TestCase):
             except AssertionError:
                 pass
 
-            # batch_sampler is not instance of BatchSampler
-            try:
-                loader = DataLoader(
-                    dataset=dataset, places=place, batch_sampler=dataset)
-                self.assertTrue(False)
-            except AssertionError:
-                pass
-
             # set batch_sampler and shuffle/batch_size/drop_last
             try:
                 loader = DataLoader(


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs

### Describe
- remove `BatchSampler` type check in DataLoader
