### PR TITLE
Support jit.save on DataParallel

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -581,6 +581,16 @@ def save(layer, path, input_spec=None, **configs):
             "The input layer of paddle.jit.save should be 'Layer', but received layer type is %s."
             % type(layer))
 
+    # NOTE(chenweihang): If the input layer be wrapped by DataParallel,
+    # the args and kwargs of forward method will can't be parsed by
+    # function_spec, so here we save DataParallel._layers instead 
+    # DataParallel it self
+    # NOTE(chenweihang): using inner_layer, do not change input layer
+    if isinstance(layer, paddle.DataParallel):
+        inner_layer = layer._layers
+    else:
+        inner_layer = layer
+
     # path check
     file_prefix = os.path.basename(path)
     if file_prefix == "":
@@ -596,8 +606,8 @@ def save(layer, path, input_spec=None, **configs):
     # avoid change user given input_spec
     inner_input_spec = None
     if input_spec is not None:
-        for attr_func in dir(layer):
-            static_func = getattr(layer, attr_func, None)
+        for attr_func in dir(inner_layer):
+            static_func = getattr(inner_layer, attr_func, None)
             if isinstance(static_func,
                           StaticFunction) and 'forward' != attr_func:
                 raise ValueError(
@@ -623,14 +633,14 @@ def save(layer, path, input_spec=None, **configs):
     configs = _parse_save_configs(configs)
     scope = core.Scope()
     extra_var_info = dict()
-    for attr_func in dir(layer):
-        static_func = getattr(layer, attr_func, None)
+    for attr_func in dir(inner_layer):
+        static_func = getattr(inner_layer, attr_func, None)
         if isinstance(static_func, StaticFunction):
             concrete_program = static_func.concrete_program
         elif 'forward' == attr_func:
             # transform in jit.save, if input_spec is incomplete, declarative will throw error
             static_forward = declarative(
-                layer.forward, input_spec=inner_input_spec)
+                inner_layer.forward, input_spec=inner_input_spec)
             concrete_program = static_forward.concrete_program
             # the input_spec has been used in declarative, which is equal to 
             # @declarative with input_spec and jit.save without input_spec,
@@ -663,7 +673,7 @@ def save(layer, path, input_spec=None, **configs):
         # saved to inference program may not need by dygraph Layer, 
         # we only record the state_dict variable's structured name
         state_names_dict = dict()
-        for structured_name, var in six.iteritems(layer.state_dict()):
+        for structured_name, var in six.iteritems(inner_layer.state_dict()):
             state_names_dict[var.name] = structured_name
 
         # 4. share parameters from Layer to scope & record var info        


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

Support jit.save on DataParallel

If the input layer be wrapped by DataParallel, the args and kwargs of forward method will can't be parsed by function_spec, so here we save DataParallel._layers instead DataParallel it self

error like:
```
Traceback (most recent call last):
  File "../python/paddle/fluid/tests/unittests/test_jit_save_load.py", line 886, in test_jit_save_data_parallel_with_inputspec
    layer=layer, path=path, input_spec=[InputSpec(shape=[None, 784])])
  File "<decorator-gen-54>", line 2, in save
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/wrapped_decorator.py", line 25, in __impl__
    return wrapped_func(*args, **kwargs)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/base.py", line 38, in __impl__
    return func(*args, **kwargs)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/jit.py", line 634, in save
    concrete_program = static_forward.concrete_program
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/program_translator.py", line 450, in concrete_program
    concrete_program, _ = self.get_concrete_program(*input_spec)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/program_translator.py", line 382, in get_concrete_program
    kwargs)
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/dygraph_to_static/function_spec.py", line 75, in unified_args_and_kwargs
    raise ValueError(error_msg)
ValueError: The decorated function `forward` requires 0 arguments: [], but received 1 with (InputSpec(shape=(-1, 784), dtype=VarType.FP32, name=None),).
```