### PR TITLE
fix the bug of gloo hang in dygraph mode

### DIFF
--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -49,7 +49,7 @@ def _start_kv_server(port, http_server_d):
     http_server = KVServer(int(port))
     http_server.start()
     wait_seconds = 5
-    while http_server_d.get("running", False):
+    while http_server_d.get("running", False) or not http_server.should_stop():
         time.sleep(wait_seconds)
     http_server.stop()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
A http server will be started which is used by gloo initialization, but it may exit before gloo initialization. This pr ensures the http server will not exit before gloo initialization.