### PR TITLE
Enable BF16 models test for googlenet, mobiletnetv1 and mobilenetv2 

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -375,6 +375,15 @@ if(WITH_MKLDNN)
 
   # resnet50 bfloat16
   inference_analysis_api_bfloat16_test_run(test_analyzer_bfloat16_resnet50 ${BF16_IMG_CLASS_TEST_APP} ${INT8_RESNET50_MODEL_DIR} ${IMAGENET_DATA_PATH})
+  
+  # googlenet bfloat16
+  inference_analysis_api_bfloat16_test_run(test_analyzer_bfloat16_googlenet ${BF16_IMG_CLASS_TEST_APP} ${INT8_GOOGLENET_MODEL_DIR} ${IMAGENET_DATA_PATH})
+
+  # mobilenetv1 bfloat16
+  inference_analysis_api_bfloat16_test_run(test_analyzer_bfloat16_mobilenetv1 ${BF16_IMG_CLASS_TEST_APP} ${INT8_MOBILENETV1_MODEL_DIR} ${IMAGENET_DATA_PATH})
+
+  # mobilenetv2 bfloat16
+  inference_analysis_api_bfloat16_test_run(test_analyzer_bfloat16_mobilenetv2 ${BF16_IMG_CLASS_TEST_APP} ${INT8_MOBILENETV2_MODEL_DIR} ${IMAGENET_DATA_PATH})
 
   ### Object detection models
   set(PASCALVOC_DATA_PATH "${INT8_DATA_DIR}/pascalvoc_val_head_300.bin")

--- a/paddle/fluid/inference/tests/api/analyzer_bfloat16_image_classification_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_bfloat16_image_classification_tester.cc
@@ -28,20 +28,18 @@ void SetConfig(AnalysisConfig *cfg) {
   cfg->EnableMKLDNN();
 }
 
-TEST(Analyzer_int8_image_classification, bfloat16) {
+TEST(Analyzer_bfloat16_image_classification, bfloat16) {
   AnalysisConfig cfg;
   SetConfig(&cfg);
 
-  AnalysisConfig q_cfg;
-  SetConfig(&q_cfg);
+  AnalysisConfig b_cfg;
+  SetConfig(&b_cfg);
 
   // read data from file and prepare batches with test data
   std::vector<std::vector<PaddleTensor>> input_slots_all;
   SetInputs(&input_slots_all);
-  q_cfg.SwitchIrDebug();
-  q_cfg.EnableMkldnnBfloat16();
-  q_cfg.SetBfloat16Op({"conv2d"});
-  CompareBFloat16AndAnalysis(&cfg, &q_cfg, input_slots_all);
+  b_cfg.EnableMkldnnBfloat16();
+  CompareBFloat16AndAnalysis(&cfg, &b_cfg, input_slots_all);
 }
 
 }  // namespace analysis


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
This PR:
- removes `SetBfloat16Op` config option, thanks to that all operators that support BF16 will use mkldnn BF16 kernels
- adds bfloat16 analyzer test for googlenet, mobiletnetv1 and mobilenetv2 


Those tests were tested on CooperLake 
```
batch_size=1
nr_threads=1
full dataset
Intel(R) Xeon(R)   Platinum 8371HC CPU @ 3.30GHz - 2 socket machine
```

| Full   dataset | BF16 fps improvement compared to MKLDNN FP32  | TOP1 acc MKLDNN   FP32 | TOP1 acc MKLDNN   BF16 | TOP1 acc drop |
|----------------|:----------------------------------------------:|:----------------------:|:----------------------:|:-------------:|
|    resnet50    |                      1.85x                     |         0.7663         |         0.7656         |    0.00091    |
|    googlenet   |                      1.61x                     |          0.705         |         0.7049         |    0.00014    |
|   mobilenetV1  |                      1.71x                     |         0.7078         |         0.7071         |    0.00099    |
|   mobilenetV2  |                      1.52x                     |          0.719         |         0.7171         |    0.00264    |