### PR TITLE
[Dy2Stat] Fix bug: the return statement should be transformed to an equivalent Paddle/Python if statement, which depends on if conditions of the return stmt.

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/variable_trans_func.py
@@ -18,12 +18,14 @@ import six
 import gast
 
 from paddle.fluid import core
+from paddle.fluid.framework import Variable
 from paddle.fluid.layers import fill_constant
 from paddle.fluid.layer_helper import LayerHelper
 
 __all__ = [
-    'create_fill_constant_node', 'create_static_variable_gast_node',
-    'data_layer_not_check', 'to_static_variable', 'to_static_variable_gast_node'
+    'create_bool_as_type', 'create_fill_constant_node',
+    'create_static_variable_gast_node', 'data_layer_not_check',
+    'to_static_variable', 'to_static_variable_gast_node'
 ]
 
 
@@ -122,3 +124,13 @@ def to_static_variable(x):
         return fill_constant(shape=[1], dtype='int64', value=x)
 
     return x
+
+
+def create_bool_as_type(x, value=True):
+    '''
+    Create a bool variable, which type is the same as x.
+    '''
+    if isinstance(x, Variable):
+        return fill_constant(shape=[1], value=value, dtype="bool")
+    else:
+        return value

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
@@ -62,10 +62,7 @@ def get_source_code(func):
 
 
 class StaticCode1():
-    # TODO: Transform return statement
     def dyfunc_with_if_else(x_v, label=None):
-        __return_1 = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=False)
-        __return_0 = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=False)
         __return_value_init_0 = paddle.fluid.layers.fill_constant(
             shape=[1], dtype='float64', value=0.0)
         __return_value_0 = __return_value_init_0
@@ -81,11 +78,13 @@ class StaticCode1():
         x_v = paddle.jit.dy2static.convert_ifelse(
             fluid.layers.mean(x_v)[0] > 5, true_fn_0, false_fn_0, (x_v, ),
             (x_v, ), (x_v, ))
+        __return_0 = paddle.jit.dy2static.create_bool_as_type(label is not None,
+                                                              False)
 
         def true_fn_1(__return_0, __return_value_0, label, x_v):
             loss = fluid.layers.cross_entropy(x_v, label)
-            __return_0 = paddle.fluid.layers.fill_constant(
-                shape=[1], dtype='bool', value=True)
+            __return_0 = paddle.jit.dy2static.create_bool_as_type(
+                label is not None, True)
             __return_value_0 = loss
             return __return_0, __return_value_0
 
@@ -97,27 +96,25 @@ class StaticCode1():
             (__return_0, __return_value_0, label, x_v),
             (__return_0, __return_value_0), (__return_0, __return_value_0)))
 
-        def true_fn_2(__return_1, __return_value_0, x_v):
-            __return_1 = paddle.fluid.layers.fill_constant(
-                shape=[1], dtype='bool', value=True)
+        def true_fn_2(__return_0, __return_value_0, x_v):
+            __return_1 = paddle.jit.dy2static.create_bool_as_type(
+                paddle.jit.dy2static.convert_logical_not(__return_0), True)
             __return_value_0 = x_v
-            return __return_1, __return_value_0
+            return __return_value_0
 
-        def false_fn_2(__return_1, __return_value_0):
-            return __return_1, __return_value_0
+        def false_fn_2(__return_value_0):
+            return __return_value_0
 
-        __return_1, __return_value_0 = (paddle.jit.dy2static.convert_ifelse(
+        __return_value_0 = paddle.jit.dy2static.convert_ifelse(
             paddle.jit.dy2static.convert_logical_not(__return_0), true_fn_2,
-            false_fn_2, (__return_1, __return_value_0, x_v),
-            (__return_1, __return_value_0), (__return_1, __return_value_0)))
+            false_fn_2, (__return_0, __return_value_0,
+                         x_v), (__return_value_0, ), (__return_value_0, ))
         return __return_value_0
 
 
 class StaticCode2():
     # TODO: Transform return statement
     def dyfunc_with_if_else(x_v, label=None):
-        __return_3 = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=False)
-        __return_2 = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool', value=False)
         __return_value_init_1 = paddle.fluid.layers.fill_constant(
             shape=[1], dtype='float64', value=0.0)
         __return_value_1 = __return_value_init_1
@@ -133,35 +130,37 @@ class StaticCode2():
         x_v = paddle.jit.dy2static.convert_ifelse(
             fluid.layers.mean(x_v)[0] > 5, true_fn_3, false_fn_3, (x_v, ),
             (x_v, ), (x_v, ))
+        __return_2 = paddle.jit.dy2static.create_bool_as_type(label is not None,
+                                                              False)
 
         def true_fn_4(__return_2, __return_value_1, label, x_v):
             loss = fluid.layers.cross_entropy(x_v, label)
-            __return_2 = paddle.fluid.layers.fill_constant(
-                shape=[1], dtype='bool', value=True)
+            __return_2 = paddle.jit.dy2static.create_bool_as_type(
+                label is not None, True)
             __return_value_1 = loss
             return __return_2, __return_value_1
 
         def false_fn_4(__return_2, __return_value_1):
             return __return_2, __return_value_1
 
-        __return_2, __return_value_1 = (paddle.jit.dy2static.convert_ifelse(
-            label is not None, true_fn_4, false_fn_4,
-            (__return_2, __return_value_1, label, x_v),
-            (__return_2, __return_value_1), (__return_2, __return_value_1)))
+        __return_2, __return_value_1 = paddle.jit.dy2static.convert_ifelse(
+            label is not None, true_fn_4, false_fn_4, (
+                __return_2, __return_value_1, label, x_v),
+            (__return_2, __return_value_1), (__return_2, __return_value_1))
 
-        def true_fn_5(__return_3, __return_value_1, x_v):
-            __return_3 = paddle.fluid.layers.fill_constant(
-                shape=[1], dtype='bool', value=True)
+        def true_fn_5(__return_2, __return_value_1, x_v):
+            __return_3 = paddle.jit.dy2static.create_bool_as_type(
+                paddle.jit.dy2static.convert_logical_not(__return_2), True)
             __return_value_1 = x_v
-            return __return_3, __return_value_1
+            return __return_value_1
 
-        def false_fn_5(__return_3, __return_value_1):
-            return __return_3, __return_value_1
+        def false_fn_5(__return_value_1):
+            return __return_value_1
 
-        __return_3, __return_value_1 = (paddle.jit.dy2static.convert_ifelse(
+        __return_value_1 = paddle.jit.dy2static.convert_ifelse(
             paddle.jit.dy2static.convert_logical_not(__return_2), true_fn_5,
-            false_fn_5, (__return_3, __return_value_1, x_v),
-            (__return_3, __return_value_1), (__return_3, __return_value_1)))
+            false_fn_5, (__return_2, __return_value_1,
+                         x_v), (__return_value_1, ), (__return_value_1, ))
         return __return_value_1
 
 

--- a/python/paddle/jit/dy2static/variable_trans_func.py
+++ b/python/paddle/jit/dy2static/variable_trans_func.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_bool_as_type  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_fill_constant_node  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_static_variable_gast_node  #DEFINE_ALIAS
 from ...fluid.dygraph.dygraph_to_static.variable_trans_func import data_layer_not_check  #DEFINE_ALIAS
@@ -21,6 +22,7 @@ from ...fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_var
 from ...fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable_gast_node  #DEFINE_ALIAS
 
 __all__ = [
-    'create_fill_constant_node', 'create_static_variable_gast_node',
-    'data_layer_not_check', 'to_static_variable', 'to_static_variable_gast_node'
+    'create_bool_as_type', 'create_fill_constant_node',
+    'create_static_variable_gast_node', 'data_layer_not_check',
+    'to_static_variable', 'to_static_variable_gast_node'
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
转写 return 语句时，需转成等价的 Paddle/Python if，之前均转写成 Paddle cond，导致某些case 下组网出错（因为return 转写中创建的 Tensor变量的 shape和dtype 不满足组网要求） 。本PR 根据情况创建变量类型。

Before this PR, the `return` statement is transformed to an equivalent `paddle if` statement. But sometimes it should be transformed to `Python if`, which depends on the  `if` conditions of the `return` stmt.
For example:

- original dygraph code:
```python
def inner_func(x):
    a = 2
    if a < 0:
        y = x + 1
        return y
    y = x * 2
    return y

@to_static
def test():
    y = paddle.ones([10])

    # the shape of inner_func(y) should be [10], not [1]
    y = inner_func(y)
    y = paddle.reshape(y, [2, 5])
    return y

test()
``` 

- Return Transformed code before this PR, the type of `__return_0` is always `Paddle Tensor`
```python
def inner_func(x):
    __return_1 = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool',
        value=False)
    __return_0 = paddle.fluid.layers.fill_constant(shape=[1], dtype='bool',
        value=False) 
    __return_value_init_0 = paddle.fluid.layers.fill_constant(shape=[1],
        dtype='float64', value=0.0)
    __return_value_0 = __return_value_init_0
    a = 2
    if a < 0:
        y = x + 1
        __return_0 = paddle.fluid.layers.fill_constant(shape=[1], dtype=
            'bool', value=True)
        __return_value_0 = y

   # here __return_0 is Paddle Tensor, this if stmt will be transformed to Paddle cond
    if not __return_0: 
        y = x * 2
        __return_1 = paddle.fluid.layers.fill_constant(shape=[1], dtype=
            'bool', value=True)
        __return_value_0 = y
    return __return_value_0
```
```
InvalidArgumentError: The 'shape' in ReshapeOp is invalid. The input tensor X'size must be equal to the capacity of 'shape'. But received X's shape = [1], X's size = 1, 'shape' is [2, 5], the capacity of 'shape' is 10.
  [Hint: Expected capacity == in_size, but received capacity:10 != in_size:1.] (at /home/teamcity/work/ef54dc8a5b211854/paddle/fluid/operators/reshape_op.cc:222)
  [operator < reshape2 > error]
```

- After fixed by this PR, the  type of `__return_0` is the same as ` a < 0`.
```python
def inner_func(x):
    __return_value_init_0 = paddle.fluid.layers.fill_constant(shape=[1],
        dtype='float64', value=0.0)
    __return_value_0 = __return_value_init_0
    a = 2
    __return_0 = paddle.jit.dy2static.create_bool_as_type(a < 0, False)
    if a < 0:
        y = x + 1
        __return_0 = paddle.jit.dy2static.create_bool_as_type(a < 0, True)
        __return_value_0 = y
   
    # here __return_0 is Python bool, this if stmt will still be a python if
    if not __return_0:
        y = x * 2
        __return_1 = paddle.jit.dy2static.create_bool_as_type(not
            __return_0, True)
        __return_value_0 = y
    return __return_value_0
```