### PR TITLE
add stop_gradient property and remove reduce redundant information

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1309,10 +1309,10 @@ class Variable(object):
                                                     dtype='float32')
                 print(new_variable._to_readable_code())
         """
-        type_str = str(self.type).split('.')[
-            1]  # VarType.LOD_TENSOR -> LOD_TENSOR
-        dtype_str = str(self.dtype).split('.')[1]
+        # VarType.LOD_TENSOR -> LOD_TENSOR
+        type_str = str(self.type).split('.')[1]
         if self.type == core.VarDesc.VarType.SELECTED_ROWS or self.type == core.VarDesc.VarType.LOD_TENSOR:
+            dtype_str = str(self.dtype).split('.')[1]
             var_str = "{name} : {type}.shape{shape}.dtype({dtype}).stop_gradient({stop_gradient})".\
                 format(name=self.name, type=type_str, shape=self.shape, dtype=dtype_str, stop_gradient=self.stop_gradient)
         else:

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1309,12 +1309,15 @@ class Variable(object):
                                                     dtype='float32')
                 print(new_variable._to_readable_code())
         """
+        type_str = str(self.type).split('.')[
+            1]  # VarType.LOD_TENSOR -> LOD_TENSOR
+        dtype_str = str(self.dtype).split('.')[1]
         if self.type == core.VarDesc.VarType.SELECTED_ROWS or self.type == core.VarDesc.VarType.LOD_TENSOR:
-            var_str = "{name} : paddle.{type}.shape{shape}.astype({dtype})".\
-                format(i="{", e="}", name=self.name, type=self.type, shape=self.shape, dtype=self.dtype)
+            var_str = "{name} : {type}.shape{shape}.dtype({dtype}).stop_gradient({stop_gradient})".\
+                format(name=self.name, type=type_str, shape=self.shape, dtype=dtype_str, stop_gradient=self.stop_gradient)
         else:
-            var_str = "{name} : paddle.{type})".\
-                format(i="{", e="}", name=self.name, type=self.type)
+            var_str = "{name} : {type})".\
+                format(name=self.name, type=type_str)
 
         if type(self) == Parameter:
             if self.trainable:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Polish format of printing static variable, add stop_gradient property which is useful for debugging and remove reduce redundant information

- example
```
import paddle
paddle.enable_static()
print(paddle.static.data(name='a', shape=[1]))
```

- before
`var a : paddle.VarType.LOD_TENSOR.shape(1,).astype(VarType.FP32)`



- after
`var a : LOD_TENSOR.shape(1,).dtype(FP32).stop_gradient(True)`
