### PR TITLE
revert python file coverage, delete coverage run --include

### DIFF
--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -790,23 +790,13 @@ function(py_test TARGET_NAME)
     cmake_parse_arguments(py_test "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(WITH_COVERAGE)
-      if ("$ENV{PADDLE_GIT_DIFF_PY_FILE}" STREQUAL "")
-        add_test(NAME ${TARGET_NAME}
-                COMMAND ${CMAKE_COMMAND} -E env FLAGS_init_allocated_mem=true FLAGS_cudnn_deterministic=true
-                FLAGS_cpu_deterministic=true
-                PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_ENVS}
-                ${PYTHON_EXECUTABLE} -u ${py_test_SRCS} ${py_test_ARGS}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-
-      else()
-        add_test(NAME ${TARGET_NAME}
-                COMMAND ${CMAKE_COMMAND} -E env FLAGS_init_allocated_mem=true FLAGS_cudnn_deterministic=true
-                FLAGS_cpu_deterministic=true
-                PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_ENVS}
-                COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-                ${PYTHON_EXECUTABLE} -m coverage run --branch -p --include=$ENV{PADDLE_GIT_DIFF_PY_FILE} ${py_test_SRCS} ${py_test_ARGS}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-      endif()
+      add_test(NAME ${TARGET_NAME}
+        COMMAND ${CMAKE_COMMAND} -E env FLAGS_init_allocated_mem=true FLAGS_cudnn_deterministic=true
+        FLAGS_cpu_deterministic=true
+        PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_ENVS}
+        COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
+        ${PYTHON_EXECUTABLE} -m coverage run --branch -p ${py_test_SRCS} ${py_test_ARGS}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     else()
       add_test(NAME ${TARGET_NAME}
                COMMAND ${CMAKE_COMMAND} -E env FLAGS_init_allocated_mem=true FLAGS_cudnn_deterministic=true

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -235,18 +235,11 @@ function(py_test_modules TARGET_NAME)
     cmake_parse_arguments(py_test_modules "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
     if(WITH_COVERAGE)
-        if ("$ENV{PADDLE_GIT_DIFF_PY_FILE}" STREQUAL "")
-            add_test(NAME ${TARGET_NAME}
-                    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_modules_ENVS}
-                    ${PYTHON_EXECUTABLE} ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-        else()
-            add_test(NAME ${TARGET_NAME}
-                    COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_modules_ENVS}
-                    COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
-                    ${PYTHON_EXECUTABLE} -m coverage run --branch -p --include=$ENV{PADDLE_GIT_DIFF_PY_FILE} ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
-                    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-        endif()
+        add_test(NAME ${TARGET_NAME}
+            COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_modules_ENVS}
+            COVERAGE_FILE=${PADDLE_BINARY_DIR}/python-coverage.data
+            ${PYTHON_EXECUTABLE} -m coverage run --branch -p ${PADDLE_SOURCE_DIR}/tools/test_runner.py ${py_test_modules_MODULES}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
     else()
         add_test(NAME ${TARGET_NAME}
                 COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${PADDLE_BINARY_DIR}/python ${py_test_modules_ENVS}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
回滚PR https://github.com/PaddlePaddle/Paddle/pull/28508 中python增量代码覆盖率生成逻辑。
即：删除coverage run后的 --include参数。