### PR TITLE
disable test_rnn_decode_api and test_complex_matmul on windows

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -135,6 +135,11 @@ if(WITH_MUSL)
     LIST(REMOVE_ITEM TEST_OPS test_sigmoid_focal_loss_op)
 endif()
 
+if(WIN32)
+    LIST(REMOVE_ITEM TEST_OPS test_rnn_decode_api)
+    LIST(REMOVE_ITEM TEST_OPS test_complex_matmul)
+endif()
+
 LIST(REMOVE_ITEM TEST_OPS test_auto_checkpoint)
 LIST(REMOVE_ITEM TEST_OPS test_auto_checkpoint1)
 LIST(REMOVE_ITEM TEST_OPS test_auto_checkpoint2)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
disable test_rnn_decode_api and test_complex_matmul on windows