### PR TITLE
[Dy2stat] Support that do not convert a function when use Dynamic-to-Stat

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -33,7 +33,7 @@ from paddle.fluid.dygraph.dygraph_to_static.program_translator import convert_to
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import unwrap_decorators
 from paddle.fluid.dygraph.layers import Layer
 
-__all__ = ["convert_call", "not_to_convert"]
+__all__ = ["convert_call", "not_to_static"]
 
 # TODO(liym27): A better way to do this.
 BUILTIN_LIKELY_MODULES = [
@@ -46,7 +46,7 @@ DISABLE_CONVERTION = "An attribute for a function that indicates that" \
                   "the user does not want it to be converted in dynamic-to-static."
 
 
-def not_to_convert(func=None):
+def not_to_static(func=None):
     """
     A Decorator to suppresses the convertion of a function.
 
@@ -61,15 +61,15 @@ def not_to_convert(func=None):
 
             import paddle
 
-            @paddle.jit.not_to_convert
-            def func_not_to_convert(x):
+            @paddle.jit.not_to_static
+            def func_not_to_static(x):
                 res = x - 1
                 return res
 
             @paddle.jit.to_static
             def func(x):
                 if paddle.mean(x) < 0:
-                    x_v = func_not_to_convert(x)
+                    x_v = func_not_to_static(x)
                 else:
                     x_v = x + 1
                 return x_v
@@ -79,7 +79,7 @@ def not_to_convert(func=None):
             print(x_v) # [[2. 2.]]
     """
     if func is None:
-        return not_to_convert
+        return not_to_static
 
     setattr(func, DISABLE_CONVERTION, True)
     return func
@@ -178,7 +178,7 @@ def convert_call(func):
     if getattr(func, DISABLE_CONVERTION, False):
         translator_logger.log(
             2,
-            "{} is not converted it is decorated by 'paddle.jit.not_to_convert'.".
+            "{} is not converted it is decorated by 'paddle.jit.not_to_static'.".
             format(func))
         return func
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -42,8 +42,21 @@ BUILTIN_LIKELY_MODULES = [
 
 translator_logger = TranslatorLogger()
 
-DISABLE_CONVERTION = "An attribute for a function that indicates that" \
-                  "the user does not want it to be converted in dynamic-to-static."
+CONVERSION_OPTIONS = "An attribute for a function that indicates conversion flags of the function in dynamic-to-static."
+
+
+class ConversionOptions(object):
+    """
+    A container for conversion flags of a function in dynamic-to-static.
+
+    Attributes:
+        not_convert(bool): An attribute indicates that the function won't be converted in dynamic-to-static.
+
+    NOTE(liym27): More attributes and methods can be added in this class.
+    """
+
+    def __init__(self, not_convert=False):
+        self.not_convert = not_convert
 
 
 def not_to_static(func=None):
@@ -81,7 +94,8 @@ def not_to_static(func=None):
     if func is None:
         return not_to_static
 
-    setattr(func, DISABLE_CONVERTION, True)
+    options = ConversionOptions(not_convert=True)
+    setattr(func, CONVERSION_OPTIONS, options)
     return func
 
 
@@ -175,7 +189,8 @@ def convert_call(func):
     # in this case, unwraps it into a raw method or function.
     _, func = unwrap_decorators(func)
 
-    if getattr(func, DISABLE_CONVERTION, False):
+    options = getattr(func, CONVERSION_OPTIONS, None)
+    if options is not None and options.not_convert:
         translator_logger.log(
             2,
             "{} is not converted when it is decorated by 'paddle.jit.not_to_static'.".

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -178,7 +178,7 @@ def convert_call(func):
     if getattr(func, DISABLE_CONVERTION, False):
         translator_logger.log(
             2,
-            "{} is not converted it is decorated by 'paddle.jit.not_to_static'.".
+            "{} is not converted when it is decorated by 'paddle.jit.not_to_static'.".
             format(func))
         return func
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_call_func.py
@@ -33,7 +33,7 @@ from paddle.fluid.dygraph.dygraph_to_static.program_translator import convert_to
 from paddle.fluid.dygraph.dygraph_to_static.program_translator import unwrap_decorators
 from paddle.fluid.dygraph.layers import Layer
 
-__all__ = ["convert_call", "not_to_static"]
+__all__ = ["convert_call"]
 
 # TODO(liym27): A better way to do this.
 BUILTIN_LIKELY_MODULES = [
@@ -57,46 +57,6 @@ class ConversionOptions(object):
 
     def __init__(self, not_convert=False):
         self.not_convert = not_convert
-
-
-def not_to_static(func=None):
-    """
-    A Decorator to suppresses the convertion of a function.
-
-    Args:
-        func(callable): The function to decorate.
-
-    Returns:
-        callable: A function which won't be converted in Dynamic-to-Static.
-
-    Examples:
-        .. code-block:: python
-
-            import paddle
-
-            @paddle.jit.not_to_static
-            def func_not_to_static(x):
-                res = x - 1
-                return res
-
-            @paddle.jit.to_static
-            def func(x):
-                if paddle.mean(x) < 0:
-                    x_v = func_not_to_static(x)
-                else:
-                    x_v = x + 1
-                return x_v
-
-            x = paddle.ones([1, 2], dtype='float32')
-            x_v = func(x)
-            print(x_v) # [[2. 2.]]
-    """
-    if func is None:
-        return not_to_static
-
-    options = ConversionOptions(not_convert=True)
-    setattr(func, CONVERSION_OPTIONS, options)
-    return func
 
 
 def is_builtin(func):

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -37,11 +37,11 @@ from paddle.fluid.framework import Block, ParamBase, Program, Variable
 from paddle.fluid.framework import _current_expected_place, _dygraph_guard, _dygraph_tracer
 from paddle.fluid.framework import dygraph_only, in_dygraph_mode
 from paddle.fluid.wrapped_decorator import wrap_decorator
-from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import not_to_convert
+from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import not_to_static
 
 __all__ = [
     'TracedLayer', 'declarative', 'dygraph_to_static_func', 'set_code_level',
-    'set_verbosity', 'save', 'load', 'not_to_convert'
+    'set_verbosity', 'save', 'load', 'not_to_static'
 ]
 
 

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -37,10 +37,11 @@ from paddle.fluid.framework import Block, ParamBase, Program, Variable
 from paddle.fluid.framework import _current_expected_place, _dygraph_guard, _dygraph_tracer
 from paddle.fluid.framework import dygraph_only, in_dygraph_mode
 from paddle.fluid.wrapped_decorator import wrap_decorator
+from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import not_to_convert
 
 __all__ = [
     'TracedLayer', 'declarative', 'dygraph_to_static_func', 'set_code_level',
-    'set_verbosity', 'save', 'load'
+    'set_verbosity', 'save', 'load', 'not_to_convert'
 ]
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -22,8 +22,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from paddle.fluid.dygraph import ProgramTranslator
-from paddle.fluid.dygraph import declarative
-from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import DISABLE_CONVERTION
+from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import CONVERSION_OPTIONS
 from test_program_translator import get_source_code
 
 program_translator = ProgramTranslator()
@@ -219,8 +218,10 @@ class TestNotToConvert(TestRecursiveCall2):
     def set_func(self):
         self.dygraph_func = func_not_to_static
 
-    def test_disable_convertion(self):
-        self.assertTrue(getattr(self.dygraph_func, DISABLE_CONVERTION))
+    def test_CONVERSION_OPTIONS(self):
+        options = getattr(self.dygraph_func, CONVERSION_OPTIONS, None)
+        self.assertIsNotNone(options)
+        self.assertTrue(options.not_convert)
 
 
 class TestNotToConvert2(TestRecursiveCall2):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -35,7 +35,7 @@ np.random.seed(SEED)
 
 
 # Use a decorator to test exception
-@declarative
+@paddle.jit.to_static
 def dyfunc_with_if(x_v):
     if fluid.layers.mean(x_v).numpy()[0] > 5:
         x_v = x_v - 1
@@ -44,7 +44,7 @@ def dyfunc_with_if(x_v):
     return x_v
 
 
-@declarative
+@paddle.jit.to_static
 def nested_func(x_v):
     x_v = fluid.dygraph.to_variable(x_v)
 
@@ -55,7 +55,7 @@ def nested_func(x_v):
     return res
 
 
-@declarative
+@paddle.jit.to_static
 def dyfunc_with_third_library_logging(x_v):
     logging.info('test dyfunc_with_third_library_logging')
     if fluid.layers.mean(x_v).numpy()[0] > 5:
@@ -111,14 +111,14 @@ class MyConvLayer(fluid.dygraph.Layer):
             bias_attr=fluid.ParamAttr(
                 initializer=fluid.initializer.Constant(value=0.5)))
 
-    @declarative
+    @paddle.jit.to_static
     def forward(self, inputs):
         y = dyfunc_with_if(inputs)
         y = lambda_fun(y)
         y = self.dymethod(y)
         return y
 
-    @declarative
+    @paddle.jit.to_static
     def dymethod(self, x_v):
         x_v = fluid.layers.assign(x_v)
         return x_v
@@ -138,7 +138,7 @@ class MyLayer(fluid.dygraph.Layer):
             bias_attr=fluid.ParamAttr(
                 initializer=fluid.initializer.Constant(value=0.5)))
 
-    @declarative
+    @paddle.jit.to_static
     def forward(self, inputs):
         h = self.conv(inputs)
         out = self.fc(h)
@@ -198,7 +198,7 @@ def func_not_to_static(x):
     return res
 
 
-@declarative
+@paddle.jit.to_static
 def func_convert_then_not_to_static(x):
     y = func_not_to_static(x)
     return y
@@ -209,7 +209,7 @@ class TestClass(paddle.nn.Layer):
     def called_member(self, x):
         return paddle.sum(x)
 
-    @declarative
+    @paddle.jit.to_static
     def forward(self, x):
         y = self.called_member(x)
         return y

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -34,6 +34,8 @@ np.random.seed(SEED)
 # Situation 1 : test recursive call
 
 
+# Use a decorator to test exception
+@declarative
 def dyfunc_with_if(x_v):
     if fluid.layers.mean(x_v).numpy()[0] > 5:
         x_v = x_v - 1

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -218,7 +218,7 @@ class TestNotToConvert(TestRecursiveCall2):
     def set_func(self):
         self.dygraph_func = func_not_to_static
 
-    def test_CONVERSION_OPTIONS(self):
+    def test_conversion_options(self):
         options = getattr(self.dygraph_func, CONVERSION_OPTIONS, None)
         self.assertIsNotNone(options)
         self.assertTrue(options.not_convert)

--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -20,7 +20,7 @@ from ..fluid.dygraph.jit import TracedLayer  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import set_code_level  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import set_verbosity  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import declarative as to_static  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import not_to_convert  #DEFINE_ALIAS
+from ..fluid.dygraph.jit import not_to_static  #DEFINE_ALIAS
 from ..fluid.dygraph import ProgramTranslator  #DEFINE_ALIAS
 from ..fluid.dygraph.io import TranslatedLayer  #DEFINE_ALIAS
 
@@ -28,5 +28,5 @@ from . import dy2static
 
 __all__ = [
     'save', 'load', 'TracedLayer', 'to_static', 'ProgramTranslator',
-    'TranslatedLayer', 'set_code_level', 'set_verbosity', 'not_to_convert'
+    'TranslatedLayer', 'set_code_level', 'set_verbosity', 'not_to_static'
 ]

--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -20,6 +20,7 @@ from ..fluid.dygraph.jit import TracedLayer  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import set_code_level  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import set_verbosity  #DEFINE_ALIAS
 from ..fluid.dygraph.jit import declarative as to_static  #DEFINE_ALIAS
+from ..fluid.dygraph.jit import not_to_convert  #DEFINE_ALIAS
 from ..fluid.dygraph import ProgramTranslator  #DEFINE_ALIAS
 from ..fluid.dygraph.io import TranslatedLayer  #DEFINE_ALIAS
 
@@ -27,5 +28,5 @@ from . import dy2static
 
 __all__ = [
     'save', 'load', 'TracedLayer', 'to_static', 'ProgramTranslator',
-    'TranslatedLayer', 'set_code_level', 'set_verbosity'
+    'TranslatedLayer', 'set_code_level', 'set_verbosity', 'not_to_convert'
 ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- ### 功能
新增 `paddle.jit.not_to_static` 装饰器，可在动静转换场景中装饰函数，被装饰的函数将不会被转化。

- ### 背景需求：
1. 从动静转换功能的完整性和易用性层面考虑，需要支持 `not_to_static` 接口，以使得动转静过程中，特定的函数不被转化。
2. 尤其是当函数本身可以在静态图模型下使用，例如，函数内部本身就写了动态图和静态图2个分支，这类函数是无需再被转化成静态图函数的。[目前，这种情况在 PaddleDetection 模型中尤为常见]

- ### 使用场景：
前提：一个函数本就可以在静态图模式下成功运行，在以下场景中可以使用 `not_to_static` 装饰该函数。
1.  该函数在转化过程中出现未知错误；
2. 该函数内部实现中，本身具有动态图分支和静态图2种分支；
3. 用户不想在动转静过程中转化该函数；
--- 
Add a decorator  `paddle.jit.not_to_static` to support that do not convert a function in Dynamic-to-Static.

- ### Background
1. For the integrity of Dynamic-to-Static function, add a decorator to suppresses the convertion of a spectial function. 
2. Especially when the function itself can be used in static mode, for example, there are two branches of static mode and static mode in the function.

- ### Usage scenarios：
1. An unknown error occurs in the dynamic-to-static conversion process of the function;
2. In the internal implementation of the function, it has two branches: dynamic branch and static branch;
3. Users don't want to convert the function in the process of dynamic to static;


For example, when you don't want to convert a function when use Dynamic-to-Static, you can use `@paddle.jit.not_to_static` to decorate the function. 

Here, `func_not_to_static` will not be converted. Note: `func_not_to_static` can be executed in dynamic mode or static mode.
```python
import paddle

@paddle.jit.not_to_static
def func_not_to_static(x):
    res = x - 1
    return res

@paddle.jit.to_static
def func(x):
    if paddle.mean(x) < 0:
        x_v = func_not_to_static(x)
    else:
        x_v = x + 1
    return x_v

x = paddle.ones([1, 2], dtype='float32')
x_v = func(x)
print(x_v) # [[2. 2.]]
```

---
Document of `not_to_static`
http://gzhxy-inf-bce36a39de.gzhxy.baidu.com:8121/documentation/docs/zh/api/index_cn.html?reviewVersion=jenkins-doc_review-180
![image](https://user-images.githubusercontent.com/33742067/100886476-d9733900-34ee-11eb-8fe1-8581be3ed4f5.png)

---

- [ ] TODO: Update document of **[Dygraph to Static Graph](https://www.paddlepaddle.org.cn/documentation/docs/en/develop/guides/04_dygraph_to_static/basic_usage_en.html#programtranslator)** 