### PR TITLE
Hot fix complle failed in gcc4.8 caused by complex impl

### DIFF
--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -152,14 +152,11 @@ static void PrintNanInf(const T* value, const size_t numel, int print_num,
              static_cast<uint64_t>(i), static_cast<float>(value[i]));
     }
   }
-  bool has_nan_inf = true;
   printf("In cpu, there has %lu,%lu,%lu nan,inf,num\n",
          static_cast<uint64_t>(nan_count), static_cast<uint64_t>(inf_count),
          static_cast<uint64_t>(num_count));
-  PADDLE_ENFORCE_EQ(has_nan_inf, false,
-                    platform::errors::PreconditionNotMet(
-                        "===ERROR: in [op=%s] [tensor=%s] find nan or inf===",
-                        op_type, var_name));
+  PADDLE_THROW(platform::errors::PreconditionNotMet(
+      "Found nan or inf in tensor `%s` of operator `%s`.", op_type, var_name));
 }
 
 // openmp 4.0, reduction with fp16
@@ -231,14 +228,25 @@ template <>
 void CheckNanInf<paddle::platform::complex64>(
     const paddle::platform::complex64* value, const size_t numel, int print_num,
     const std::string& op_type, const std::string& var_name) {
-  paddle::platform::complex64 sum(0.0, 0.0);
-#pragma omp parallel for reduction(+ : sum)
+  float real_sum = 0.0f;
+#pragma omp parallel for reduction(+ : real_sum)
   for (size_t i = 0; i < numel; ++i) {
-    sum += (value[i] - value[i]);
+    real_sum += (value[i].real - value[i].real);
   }
 
-  if (std::isnan(sum) || std::isinf(sum)) {
-    PrintNanInf(value, numel, print_num, op_type, var_name);
+  float imag_sum = 0.0f;
+#pragma omp parallel for reduction(+ : imag_sum)
+  for (size_t i = 0; i < numel; ++i) {
+    imag_sum += (value[i].imag - value[i].imag);
+  }
+
+  if (std::isnan(real_sum) || std::isinf(real_sum) || std::isnan(imag_sum) ||
+      std::isinf(imag_sum)) {
+    // hot fix for compile failed in gcc4.8
+    // here also need print detail info of nan or inf later
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "Found nan or inf in tensor `%s` of operator `%s`.", op_type,
+        var_name));
   }
 }
 
@@ -246,17 +254,27 @@ template <>
 void CheckNanInf<paddle::platform::complex128>(
     const paddle::platform::complex128* value, const size_t numel,
     int print_num, const std::string& op_type, const std::string& var_name) {
-  paddle::platform::complex128 sum(0.0, 0.0);
-#pragma omp parallel for reduction(+ : sum)
+  double real_sum = 0.0;
+#pragma omp parallel for reduction(+ : real_sum)
   for (size_t i = 0; i < numel; ++i) {
-    sum += (value[i] - value[i]);
+    real_sum += (value[i].real - value[i].real);
   }
 
-  if (std::isnan(sum) || std::isinf(sum)) {
-    PrintNanInf(value, numel, print_num, op_type, var_name);
+  double imag_sum = 0.0;
+#pragma omp parallel for reduction(+ : imag_sum)
+  for (size_t i = 0; i < numel; ++i) {
+    imag_sum += (value[i].imag - value[i].imag);
+  }
+
+  if (std::isnan(real_sum) || std::isinf(real_sum) || std::isnan(imag_sum) ||
+      std::isinf(imag_sum)) {
+    // hot fix for compile failed in gcc4.8
+    // here also need print detail info of nan or inf later
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "Found nan or inf in tensor `%s` of operator `%s`.", op_type,
+        var_name));
   }
 }
-
 #endif
 
 template <>

--- a/paddle/fluid/framework/details/nan_inf_utils_detail.cc
+++ b/paddle/fluid/framework/details/nan_inf_utils_detail.cc
@@ -156,7 +156,8 @@ static void PrintNanInf(const T* value, const size_t numel, int print_num,
          static_cast<uint64_t>(nan_count), static_cast<uint64_t>(inf_count),
          static_cast<uint64_t>(num_count));
   PADDLE_THROW(platform::errors::PreconditionNotMet(
-      "Found nan or inf in tensor `%s` of operator `%s`.", op_type, var_name));
+      "There are `nan` or `inf` in tensor (%s) of operator (%s).", var_name,
+      op_type));
 }
 
 // openmp 4.0, reduction with fp16
@@ -245,8 +246,8 @@ void CheckNanInf<paddle::platform::complex64>(
     // hot fix for compile failed in gcc4.8
     // here also need print detail info of nan or inf later
     PADDLE_THROW(platform::errors::PreconditionNotMet(
-        "Found nan or inf in tensor `%s` of operator `%s`.", op_type,
-        var_name));
+        "There are `nan` or `inf` in tensor (%s) of operator (%s).", var_name,
+        op_type));
   }
 }
 
@@ -271,8 +272,8 @@ void CheckNanInf<paddle::platform::complex128>(
     // hot fix for compile failed in gcc4.8
     // here also need print detail info of nan or inf later
     PADDLE_THROW(platform::errors::PreconditionNotMet(
-        "Found nan or inf in tensor `%s` of operator `%s`.", op_type,
-        var_name));
+        "There are `nan` or `inf` in tensor (%s) of operator (%s).", var_name,
+        op_type));
   }
 }
 #endif

--- a/python/paddle/fluid/tests/unittests/test_nan_inf.py
+++ b/python/paddle/fluid/tests/unittests/test_nan_inf.py
@@ -50,7 +50,8 @@ class TestNanInf(unittest.TestCase):
 
         assert returncode == 0
         # in python3, type(out+err) is 'bytes', need use encode
-        assert (out + err).find('find nan or inf'.encode()) != -1
+        assert (out + err
+                ).find('There are `nan` or `inf` in tensor'.encode()) != -1
 
 
 class TestNanInfEnv(TestNanInf):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Hot fix complle failed in gcc4.8 caused by complex import

problems:
1. openmp reduction doesn't support `paddle::platform::complex*` dtype out defined
2. `std::isnan` and `std::isinf` only support basic floating type
![image](https://user-images.githubusercontent.com/22561442/100719576-c598db80-33f7-11eb-888a-79dc82f81b4d.png)

others:
- polish error message format: `===ERROR: in [op=%s] [tensor=%s] find nan or inf===` is not a English sentence and its format is strange