### PR TITLE
Rebuild group automatically in dynamic graph distributed

### DIFF
--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -198,7 +198,6 @@ void Reducer::AddDistHook(VariableWrapper *var_warpper, size_t var_index) {
   auto &group = groups_[group_index];
 
   if (!has_rebuilt_group_) {
-    rebuild_vars_.push_back(vars_[var_index]);
     rebuild_var_indices_.push_back(var_index);
   }
 
@@ -264,12 +263,12 @@ void Reducer::MarkGroupReady(size_t group_index) {
 }
 
 std::vector<std::vector<size_t>> Reducer::RebuildGruops() {
-  auto rebuild_group_index =
-      AssignGroupBySize(rebuild_vars_, is_sparse_gradient_, group_size_limits_,
-                        rebuild_var_indices_);
+  std::reverse(rebuild_var_indices_.begin(), rebuild_var_indices_.end());
+  auto rebuild_group_index = AssignGroupBySize(
+      vars_, is_sparse_gradient_, group_size_limits_, rebuild_var_indices_);
   has_rebuilt_group_ = true;
-  rebuild_vars_.clear();
   rebuild_var_indices_.clear();
+  std::reverse(rebuild_group_index.begin(), rebuild_group_index.end());
   return rebuild_group_index;
 }
 

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -199,7 +199,7 @@ void Reducer::AddDistHook(VariableWrapper *var_warpper, size_t var_index) {
 
   if (!has_rebuilt_group_) {
     rebuild_vars_.push_back(vars_[var_index]);
-    rebuild_group_indices_.push_back(var_index);
+    rebuild_var_indices_.push_back(var_index);
   }
 
   if (!group.is_sparse_) {
@@ -264,12 +264,13 @@ void Reducer::MarkGroupReady(size_t group_index) {
 }
 
 std::vector<std::vector<size_t>> Reducer::RebuildGruops() {
-  auto rebuild_index =
-      AssignGroupBySize(rebuild_vars_, is_sparse_gradient_, group_size_limits_);
+  auto rebuild_group_index =
+      AssignGroupBySize(rebuild_vars_, is_sparse_gradient_, group_size_limits_,
+                        rebuild_var_indices_);
   has_rebuilt_group_ = true;
   rebuild_vars_.clear();
-  rebuild_group_indices_.clear();
-  return rebuild_index;
+  rebuild_var_indices_.clear();
+  return rebuild_group_index;
 }
 
 void Reducer::FinalizeBackward() {
@@ -277,8 +278,8 @@ void Reducer::FinalizeBackward() {
   PADDLE_ENFORCE_CUDA_SUCCESS(
       cudaStreamWaitEvent(compute_stream_, comm_enent_.get(), 0));
   if (!has_rebuilt_group_) {
-    auto rebuild_index = RebuildGruops();
-    InitializeGroups(rebuild_index);
+    auto rebuild_group_index = RebuildGruops();
+    InitializeGroups(rebuild_group_index);
   }
   VLOG(3) << "In the batch, Reducer is finished...";
 }

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -358,8 +358,6 @@ void Reducer::FinalizeBackward() {
     VLOG(3) << "Start rebuilding the groups";
     auto rebuild_group_indices = RebuildGruops();
     auto rebuild_group_number = rebuild_group_indices.size();
-    VLOG(3) << "The number of groups changed from [" << group_indices_.size()
-            << "] to [" << rebuild_group_number << "]";
     group_indices_ = std::move(rebuild_group_indices);
     CreateGroupEvents(rebuild_group_number);
     InitializeGroups(group_indices_);

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -31,14 +31,6 @@ Reducer::Reducer(const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
       parallel_ctx_(parallel_ctx),
       group_size_limits_(group_size_limits) {
   VLOG(3) << "Start construct the Reducer ...";
-
-  VLOG(0) << "group_indices: ";
-  for (size_t i = 0; i < group_indices.size(); ++i) {
-    auto indices = group_indices[i];
-    VLOG(0) << "group_indices[" << i << "] ";
-    for (auto index : indices) VLOG(0) << index;
-  }
-
   // initialize groups
   InitializeGroups(group_indices);
   for (size_t global_var_index = 0; global_var_index < vars_.size();
@@ -302,12 +294,9 @@ void Reducer::FinalizeBackward() {
       cudaStreamWaitEvent(compute_stream_, comm_enent_.get(), 0));
   if (!has_rebuilt_group_) {
     auto rebuild_group_index = RebuildGruops();
-    VLOG(0) << "rebuild_group_index: ";
-    for (size_t i = 0; i < rebuild_group_index.size(); ++i) {
-      auto indices = rebuild_group_index[i];
-      VLOG(0) << "rebuild_group_index[" << i << "] ";
-      for (auto index : indices) VLOG(0) << index;
-    }
+    VLOG(3) << "The number of groups changed from [" << group_indices_.size()
+            << "] to [" << rebuild_group_index.size() << "]";
+    group_indices_ = rebuild_group_index;
     CreateGroupEvents(rebuild_group_index.size());
     InitializeGroups(rebuild_group_index);
   }

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -198,6 +198,7 @@ void Reducer::AddDistHook(VariableWrapper *var_warpper, size_t var_index) {
   auto &group = groups_[group_index];
 
   if (!has_rebuilt_group_) {
+    rebuild_vars_.push_back(vars_[var_index]);
     rebuild_var_indices_.push_back(var_index);
   }
 
@@ -263,10 +264,13 @@ void Reducer::MarkGroupReady(size_t group_index) {
 }
 
 std::vector<std::vector<size_t>> Reducer::RebuildGruops() {
+  std::reverse(rebuild_vars_.begin(), rebuild_vars_.end());
   std::reverse(rebuild_var_indices_.begin(), rebuild_var_indices_.end());
-  auto rebuild_group_index = AssignGroupBySize(
-      vars_, is_sparse_gradient_, group_size_limits_, rebuild_var_indices_);
+  auto rebuild_group_index =
+      AssignGroupBySize(rebuild_vars_, is_sparse_gradient_, group_size_limits_,
+                        rebuild_var_indices_);
   has_rebuilt_group_ = true;
+  rebuild_vars_.clear();
   rebuild_var_indices_.clear();
   std::reverse(rebuild_group_index.begin(), rebuild_group_index.end());
   return rebuild_group_index;

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -222,7 +222,7 @@ class Reducer {
   // Following variables are to help rebuild group
   bool has_rebuilt_group_{false};
   std::vector<std::shared_ptr<imperative::VarBase>> rebuild_vars_;
-  std::vector<size_t> rebuild_group_indices_;
+  std::vector<int64_t> rebuild_var_indices_;
   const std::vector<size_t> group_size_limits_;
 };
 

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -221,7 +221,6 @@ class Reducer {
 
   // Following variables are to help rebuild group
   bool has_rebuilt_group_{false};
-  std::vector<std::shared_ptr<imperative::VarBase>> rebuild_vars_;
   std::vector<int64_t> rebuild_var_indices_;
   const std::vector<size_t> group_size_limits_;
 };

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -218,7 +218,8 @@ class Reducer {
 std::vector<std::vector<size_t>> AssignGroupBySize(
     const std::vector<std::shared_ptr<imperative::VarBase>>& tensors,
     const std::vector<bool>& is_sparse_gradient,
-    const std::vector<size_t>& group_size_limits);
+    const std::vector<size_t>& group_size_limits,
+    const std::vector<int64_t>& tensor_indices);
 #endif
 
 }  // namespace imperative

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -229,7 +229,7 @@ std::vector<std::vector<size_t>> AssignGroupBySize(
     const std::vector<std::shared_ptr<imperative::VarBase>>& tensors,
     const std::vector<bool>& is_sparse_gradient,
     const std::vector<size_t>& group_size_limits,
-    const std::vector<int64_t>& tensor_indices);
+    const std::vector<int64_t>& tensor_indices = {});
 #endif
 
 }  // namespace imperative

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -221,6 +221,7 @@ class Reducer {
 
   // Following variables are to help rebuild group
   bool has_rebuilt_group_{false};
+  std::vector<std::shared_ptr<imperative::VarBase>> rebuild_vars_;
   std::vector<int64_t> rebuild_var_indices_;
   const std::vector<size_t> group_size_limits_;
 };

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -179,6 +179,8 @@ class Reducer {
 
   std::vector<std::vector<size_t>> RebuildGruops();
 
+  void CreateGroupEvents(int group_num);
+
   // Reducer Singleton
   static std::shared_ptr<Reducer> SetInstance(
       const std::vector<std::shared_ptr<imperative::VarBase>>& vars,

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -86,6 +86,8 @@ class Group {
   std::vector<framework::Tensor> dense_tensors_;
 
   std::vector<size_t> length_;
+
+  int64_t all_length_{0};
   // Global indices of participating variables in the group
   std::vector<size_t> variable_indices_;
 
@@ -97,50 +99,12 @@ class Group {
   framework::proto::VarType::Type dtype_;
 
   // context is used to select the stream for concat
-  void ConcatTensors(const platform::CUDADeviceContext& context) {
-    switch (dtype_) {
-      case framework::proto::VarType::FP16:
-        ConcatTensorsForAllReduce<platform::float16>(context, dense_tensors_,
-                                                     &dense_contents_);
-        break;
-      case framework::proto::VarType::FP32:
-        ConcatTensorsForAllReduce<float>(context, dense_tensors_,
-                                         &dense_contents_);
-        break;
-      case framework::proto::VarType::FP64:
-        ConcatTensorsForAllReduce<double>(context, dense_tensors_,
-                                          &dense_contents_);
-        break;
-      default:
-        PADDLE_THROW(platform::errors::Unimplemented(
-            "Data type (%s) is not supported when it concats tensors for "
-            "allreduce.",
-            framework::DataTypeToString(dtype_)));
-    }
-  }
+  void ConcatTensors(const platform::CUDADeviceContext& context);
 
   // context is used to select the stream for split
-  void SplitTensors(const platform::CUDADeviceContext& context) {
-    switch (dtype_) {
-      case framework::proto::VarType::FP16:
-        SplitTensorsForAllReduce<platform::float16>(context, &dense_contents_,
-                                                    &dense_tensors_);
-        break;
-      case framework::proto::VarType::FP32:
-        SplitTensorsForAllReduce<float>(context, &dense_contents_,
-                                        &dense_tensors_);
-        break;
-      case framework::proto::VarType::FP64:
-        SplitTensorsForAllReduce<double>(context, &dense_contents_,
-                                         &dense_tensors_);
-        break;
-      default:
-        PADDLE_THROW(platform::errors::Unimplemented(
-            "Data type (%s) is not supported when it splits tensors for "
-            "allreduce.",
-            framework::DataTypeToString(dtype_)));
-    }
-  }
+  void SplitTensors(const platform::CUDADeviceContext& context);
+
+  friend std::ostream& operator<<(std::ostream&, const Group&);
 };
 
 struct VariableLocator {
@@ -162,8 +126,8 @@ class Reducer {
 
   void InitializeGroups(const std::vector<std::vector<size_t>>& group_indices);
 
-  int64_t InitializeDenseGroups(const std::vector<size_t>& variable_indices_,
-                                Group* p_group);
+  void InitializeDenseGroups(const std::vector<size_t>& variable_indices_,
+                             Group* p_group);
 
   void PrepareForBackward();
 
@@ -226,6 +190,19 @@ class Reducer {
   std::vector<std::shared_ptr<imperative::VarBase>> rebuild_vars_;
   std::vector<int64_t> rebuild_var_indices_;
   const std::vector<size_t> group_size_limits_;
+
+  // //just for debug
+  // inline void PrintSequence(std::ostream& out, Iter begin, Iter end) {
+  //   // Output at most 100 elements -- appropriate if used for logging.
+  //   for (int i = 0; begin != end && i < 100; ++i, ++begin) {
+  //     if (i > 0)
+  //       out << ' ';
+  //     out << *begin;
+  //   }
+  //   if (begin != end) {
+  //     out << " ...";
+  //   }
+  // }
 };
 
 std::vector<std::vector<size_t>> AssignGroupBySize(

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -190,19 +190,6 @@ class Reducer {
   std::vector<std::shared_ptr<imperative::VarBase>> rebuild_vars_;
   std::vector<int64_t> rebuild_var_indices_;
   const std::vector<size_t> group_size_limits_;
-
-  // //just for debug
-  // inline void PrintSequence(std::ostream& out, Iter begin, Iter end) {
-  //   // Output at most 100 elements -- appropriate if used for logging.
-  //   for (int i = 0; begin != end && i < 100; ++i, ++begin) {
-  //     if (i > 0)
-  //       out << ' ';
-  //     out << *begin;
-  //   }
-  //   if (begin != end) {
-  //     out << " ...";
-  //   }
-  // }
 };
 
 std::vector<std::vector<size_t>> AssignGroupBySize(

--- a/paddle/fluid/imperative/tests/CMakeLists.txt
+++ b/paddle/fluid/imperative/tests/CMakeLists.txt
@@ -12,3 +12,7 @@ cc_test(test_layer SRCS test_layer.cc DEPS layer proto_desc operator op_registry
 cc_test(test_prepare_op SRCS test_prepare_op.cc DEPS prepared_operator op_info split_op layer concat_and_split activation_op place)
 cc_test(test_tracer SRCS test_tracer.cc DEPS tracer layer proto_desc operator op_registry variable_helper mul_op reduce_sum_op elementwise_add_op memcpy)
 cc_test(test_hooks SRCS test_hooks.cc DEPS tracer basic_engine layer proto_desc operator op_registry variable_helper mul_op elementwise_add_op memcpy)
+
+if (WITH_NCCL)
+cc_test(test_group SRCS test_group.cc DEPS reducer concat_and_split memcpy)
+endif()

--- a/paddle/fluid/imperative/tests/test_group.cc
+++ b/paddle/fluid/imperative/tests/test_group.cc
@@ -1,0 +1,66 @@
+// Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+
+#if defined(PADDLE_WITH_NCCL)
+#include "paddle/fluid/imperative/reducer.h"
+#endif
+
+namespace paddle {
+namespace imperative {
+
+#if defined(PADDLE_WITH_NCCL)
+TEST(TestGroup, TestPrintGroupMessage) {
+  Group group;
+  std::stringstream stream1, stream2;
+  stream1 << group;
+  ASSERT_STREQ(stream1.str().c_str(),
+               "numul: 0 ;is_sparse: 0 ;var number: 0\n[]\n");
+
+  std::vector<size_t> vars;
+  size_t vars_num = 102;
+  for (size_t i = 0; i < vars_num; ++i) {
+    vars.push_back(i);
+  }
+  group.variable_indices_ = vars;
+  group.all_length_ = 102;
+  group.is_sparse_ = false;
+
+  std::string head = "numul: 102 ;is_sparse: 0 ;var number: 102\n";
+  head = head + "[";
+  auto begin = vars.begin();
+  auto end = vars.end();
+  for (int i = 0; begin != end && i < 100; ++i, ++begin) {
+    if (i > 0) head += ' ';
+    head += std::to_string(*begin);
+  }
+  if (begin != end) {
+    head += " ...";
+  }
+  head += "]\n";
+  stream2 << group;
+  ASSERT_STREQ(stream2.str().c_str(), head.c_str());
+}
+
+#endif
+
+}  // namespace imperative
+}  // namespace paddle

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1299,6 +1299,7 @@ void BindImperative(py::module *m_ptr) {
   m.def("assign_group_by_size", &imperative::AssignGroupBySize, py::arg("vars"),
         py::arg("is_sparse_gradient"),
         py::arg("group_size_limits") = std::vector<size_t>{25 * 1024 * 1024},
+        py::arg("tensor_indices") = std::vector<int64_t>{},
         py::call_guard<py::gil_scoped_release>());
 #endif
 }

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1289,9 +1289,11 @@ void BindImperative(py::module *m_ptr) {
           [](const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
              const std::vector<std::vector<size_t>> &group_indices,
              const std::vector<bool> &is_sparse_gradient,
-             std::shared_ptr<imperative::ParallelContext> parallel_ctx) {
+             std::shared_ptr<imperative::ParallelContext> parallel_ctx,
+             const std::vector<size_t> &group_size_limits) {
             return imperative::Reducer::SetInstance(
-                vars, group_indices, is_sparse_gradient, parallel_ctx);
+                vars, group_indices, is_sparse_gradient, parallel_ctx,
+                group_size_limits);
           }))
       .def("prepare_for_backward", &imperative::Reducer::PrepareForBackward,
            py::call_guard<py::gil_scoped_release>());

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -18,7 +18,6 @@ from paddle.fluid.framework import Variable, set_flags, core
 from paddle.fluid.wrapped_decorator import wrap_decorator
 import google.protobuf.text_format
 import google.protobuf
-from paddle.fluid.framework import dygraph_only
 
 __all__ = ["DistributedStrategy"]
 

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -437,10 +437,11 @@ class DataParallel(layers.Layer):
             "ParallelContext must be initialized before. You should use init_parallel_env() before" \
             "constructing the DataParallel."
 
-        self._reducer = core.Reducer(trainable_parameters,
-                                     list(reversed(self.group_indices)),
-                                     is_sparse_gradient,
-                                     parallel_helper.__parallel_ctx__clz__)
+        self._reducer = core.Reducer(
+            trainable_parameters,
+            list(reversed(self.group_indices)), is_sparse_gradient,
+            parallel_helper.__parallel_ctx__clz__,
+            [self.small_group_size, self.group_size_limits])
 
     def forward(self, *inputs, **kwargs):
         if self._strategy.nranks > 1:

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -441,7 +441,7 @@ class DataParallel(layers.Layer):
             trainable_parameters,
             list(reversed(self.group_indices)), is_sparse_gradient,
             parallel_helper.__parallel_ctx__clz__,
-            [self.small_group_size, self.group_size_limits])
+            [self.last_comm_buffer_size, self.comm_buffer_size])
 
     def forward(self, *inputs, **kwargs):
         if self._strategy.nranks > 1:

--- a/python/paddle/fluid/tests/unittests/test_imperative_group.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_group.py
@@ -167,6 +167,18 @@ class TestDataParallelGroup(unittest.TestCase):
                                         [400], [3, 0, 1, 2])
         self.assertEqual([[3, 0], [1], [2]], res)
 
+    def test_construct_group9(self):
+        # one dtype & one limit capability & have tensor_indices
+        var_list = []
+        var_list.append(self.create_varbase(core.VarDesc.VarType.FP32, [2, 25]))
+        var_list.append(self.create_varbase(core.VarDesc.VarType.FP32, [2, 25]))
+        var_list.append(self.create_varbase(core.VarDesc.VarType.FP32, [2, 25]))
+        var_list.append(
+            self.create_varbase(core.VarDesc.VarType.FP32, [2, 1000]))
+        res = core.assign_group_by_size(var_list, [False, False, False, True],
+                                        [300], [1, 0, 2, 3])
+        self.assertEqual([[1, 0], [3], [2]], res)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_imperative_group.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_group.py
@@ -155,6 +155,18 @@ class TestDataParallelGroup(unittest.TestCase):
             var_list, [True, False, False, False, False, True], [200, 400])
         self.assertEqual([[0], [1], [2], [3], [4], [5]], res)
 
+    def test_construct_group8(self):
+        # one dtype & one limit capability & have tensor_indices
+        var_list = []
+        var_list.append(self.create_varbase(core.VarDesc.VarType.FP32, [2, 25]))
+        var_list.append(
+            self.create_varbase(core.VarDesc.VarType.FP32, [2, 100]))
+        var_list.append(self.create_varbase(core.VarDesc.VarType.FP32, [2, 50]))
+        var_list.append(self.create_varbase(core.VarDesc.VarType.FP32, [2, 25]))
+        res = core.assign_group_by_size(var_list, [False, False, False, False],
+                                        [400], [3, 0, 1, 2])
+        self.assertEqual([[3, 0], [1], [2]], res)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add rebuild group feature in reducer.
In dynamic graph networking, if the parameter order is not declared in the forward order, performance may be affected. As shown in the figure: in the Bert model, putting the declaration of the embedding parameter of the first layer at the end will result in slower performance. The timeline is as follows:
![image](https://user-images.githubusercontent.com/19485646/101589865-41aca800-3a24-11eb-93dd-a58f529b9b08.png)
Here add the automatic rebuild group strategy, in the second batch, the group ready order can be adjusted automatically, which makes the computation and communication stream overlap fully. From the experiment of 4 machines and 32 cards, the speed can be improved  about **10.6%**.