### PR TITLE
Move temporal_shift to paddle.nn.functional

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -13332,7 +13332,7 @@ def temporal_shift(x, seg_num, shift_ratio=0.25, name=None):
             import paddle.nn.functional as F
 
             input = paddle.randn([6, 4, 2, 2])
-            out = paddle.fluid.layers.temporal_shift(x=input, seg_num=2, shift_ratio=0.2)
+            out = F.temporal_shift(x=input, seg_num=2, shift_ratio=0.2)
     """
     helper = LayerHelper("temporal_shift", **locals())
     check_variable_and_dtype(x, 'x', ['float32', 'float64'], 'temporal_shift')

--- a/python/paddle/fluid/tests/unittests/test_temporal_shift_op.py
+++ b/python/paddle/fluid/tests/unittests/test_temporal_shift_op.py
@@ -87,7 +87,11 @@ class TestTemporalShiftAPI(unittest.TestCase):
         out_from_function = paddle.nn.functional.temporal_shift(
             x=input, seg_num=2, shift_ratio=0.2)
 
-        np.testing.assert_allclose(out_from_function, out)
+        # dygraph
+        with paddle.fluid.dygraph.guard():
+            input = paddle.randn([6, 4, 2, 2])
+            out = paddle.nn.functional.temporal_shift(
+                x=input, seg_num=2, shift_ratio=0.2)
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_temporal_shift_op.py
+++ b/python/paddle/fluid/tests/unittests/test_temporal_shift_op.py
@@ -84,6 +84,11 @@ class TestTemporalShiftAPI(unittest.TestCase):
         out = paddle.fluid.layers.temporal_shift(
             x=input, seg_num=2, shift_ratio=0.2)
 
+        out_from_function = paddle.nn.functional.temporal_shift(
+            x=input, seg_num=2, shift_ratio=0.2)
+
+        np.testing.assert_allclose(out_from_function, out)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -216,3 +216,4 @@ from .vision import pixel_shuffle  #DEFINE_ALIAS
 from .input import one_hot  #DEFINE_ALIAS
 from .input import embedding  #DEFINE_ALIAS
 from ...fluid.layers import gather_tree
+from ...fluid.layers import temporal_shift


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Move temporal_shift to paddle.nn.functional.
