### PR TITLE
change test_imperative_signal_handler to exclusive

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -632,6 +632,7 @@ set_tests_properties(test_parallel_executor_crf test_sync_batch_norm_op test_inp
         PROPERTIES LABELS "RUN_TYPE=DIST")
 
 if(NOT WIN32 AND NOT APPLE)
+    set_tests_properties(test_imperative_signal_handler PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
     set_tests_properties(test_imperative_data_loader_base PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
     set_tests_properties(test_imperative_data_loader_fds_clear PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
     # set_tests_properties(test_imperative_data_loader_exception PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

change test_imperative_signal_handler to exclusive


近期进出现一次，失败原因是等待10s以上还没有被调度
![image](https://user-images.githubusercontent.com/22561442/100825519-304b2500-3493-11eb-9bb1-ba2ea9a3cd3b.png)

这是一个简单的单测，正常执行仅需要2s左右，改成独占的比较合理
![image](https://user-images.githubusercontent.com/22561442/100825623-73a59380-3493-11eb-9a45-cfda6062d4d5.png)


可以参考之前PR的解释
related PR: https://github.com/PaddlePaddle/Paddle/pull/28640