### PR TITLE
Layer norm fp16 3

### DIFF
--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -247,6 +247,14 @@ class LayerNormGradOp : public framework::OperatorWithKernel {
     framework::LibraryType library = framework::LibraryType::kPlain;
     framework::DataLayout layout = framework::DataLayout::kAnyLayout;
 
+#ifdef PADDLE_WITH_MKLDNN
+    if (library == framework::LibraryType::kPlain &&
+        this->CanMKLDNNBeUsed(ctx)) {
+      library = framework::LibraryType::kMKLDNN;
+      layout = framework::DataLayout::kMKLDNN;
+    }
+#endif
+
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),
         layout, library);

--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -233,20 +233,16 @@ class LayerNormGradOp : public framework::OperatorWithKernel {
   framework::OpKernelType GetExpectedKernelType(
       const framework::ExecutionContext &ctx) const override {
     const auto *var = ctx.InputVar(framework::GradVarName("Y"));
-    if (var == nullptr) {
-      PADDLE_THROW(platform::errors::InvalidArgument(
-          "can't find gradient variable of Y"));
-    }
+    PADDLE_ENFORCE_NOT_NULL(var, platform::errors::NotFound(
+                                     "Y@GRAD of LayerNorm Op is not found."));
     const Tensor *t = nullptr;
     if (var->IsType<Tensor>()) {
       t = &var->Get<Tensor>();
     } else if (var->IsType<LoDTensor>()) {
       t = &var->Get<LoDTensor>();
     }
-    if (t == nullptr) {
-      PADDLE_THROW(
-          platform::errors::InvalidArgument("gradient variable of Y is empty"));
-    }
+    PADDLE_ENFORCE_NOT_NULL(
+        t, platform::errors::NotFound("Y@GRAD of LayerNorm Op is not found."));
 
     framework::LibraryType library = framework::LibraryType::kPlain;
     framework::DataLayout layout = framework::DataLayout::kAnyLayout;

--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -247,13 +247,13 @@ class LayerNormGradOp : public framework::OperatorWithKernel {
     framework::LibraryType library = framework::LibraryType::kPlain;
     framework::DataLayout layout = framework::DataLayout::kAnyLayout;
 
-    // #ifdef PADDLE_WITH_MKLDNN
-    //     if (library == framework::LibraryType::kPlain &&
-    //         platform::CanMKLDNNBeUsed(ctx)) {
-    //       library = framework::LibraryType::kMKLDNN;
-    //       layout = framework::DataLayout::kMKLDNN;
-    //     }
-    // #endif
+#ifdef PADDLE_WITH_MKLDNN
+    if (library == framework::LibraryType::kPlain &&
+        platform::CanMKLDNNBeUsed(ctx)) {
+      library = framework::LibraryType::kMKLDNN;
+      layout = framework::DataLayout::kMKLDNN;
+    }
+#endif
 
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),

--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #include "paddle/fluid/operators/layer_norm_op.h"
 #include <memory>
+#include <string>
 
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
@@ -98,7 +99,26 @@ class LayerNormOp : public framework::OperatorWithKernel {
 
  protected:
   framework::OpKernelType GetExpectedKernelType(
-      const framework::ExecutionContext &ctx) const {
+      const framework::ExecutionContext &ctx) const override {
+    auto input_data_type = OperatorWithKernel::IndicateVarDataType(ctx, "X");
+    // By default, the type of the scale, bias, mean,
+    // and var tensors should both be float. (For float or float16 input tensor)
+    // or double (For double input tensor).
+    auto ln_param_type = framework::proto::VarType::FP32;
+    if (input_data_type == framework::proto::VarType::FP64) {
+      ln_param_type = framework::proto::VarType::FP64;
+    }
+    if (ctx.HasInput("Scale")) {
+      PADDLE_ENFORCE_EQ(ln_param_type, ctx.Input<Tensor>("Scale")->type(),
+                        platform::errors::InvalidArgument(
+                            "Scale input should be of float type"));
+    }
+    if (ctx.HasInput("Bias")) {
+      PADDLE_ENFORCE_EQ(ln_param_type, ctx.Input<Tensor>("Bias")->type(),
+                        platform::errors::InvalidArgument(
+                            "Bias input should be of float type"));
+    }
+
     framework::LibraryType library = framework::LibraryType::kPlain;
     framework::DataLayout layout = framework::DataLayout::kAnyLayout;
 
@@ -110,9 +130,8 @@ class LayerNormOp : public framework::OperatorWithKernel {
     }
 #endif
 
-    return framework::OpKernelType(
-        OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),
-        layout, library);
+    return framework::OpKernelType(input_data_type, ctx.GetPlace(), layout,
+                                   library);
   }
 };
 

--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -247,14 +247,6 @@ class LayerNormGradOp : public framework::OperatorWithKernel {
     framework::LibraryType library = framework::LibraryType::kPlain;
     framework::DataLayout layout = framework::DataLayout::kAnyLayout;
 
-#ifdef PADDLE_WITH_MKLDNN
-    if (library == framework::LibraryType::kPlain &&
-        platform::CanMKLDNNBeUsed(ctx)) {
-      library = framework::LibraryType::kMKLDNN;
-      layout = framework::DataLayout::kMKLDNN;
-    }
-#endif
-
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),
         layout, library);

--- a/paddle/fluid/operators/layer_norm_op.cc
+++ b/paddle/fluid/operators/layer_norm_op.cc
@@ -251,13 +251,13 @@ class LayerNormGradOp : public framework::OperatorWithKernel {
     framework::LibraryType library = framework::LibraryType::kPlain;
     framework::DataLayout layout = framework::DataLayout::kAnyLayout;
 
-#ifdef PADDLE_WITH_MKLDNN
-    if (library == framework::LibraryType::kPlain &&
-        platform::CanMKLDNNBeUsed(ctx)) {
-      library = framework::LibraryType::kMKLDNN;
-      layout = framework::DataLayout::kMKLDNN;
-    }
-#endif
+    // #ifdef PADDLE_WITH_MKLDNN
+    //     if (library == framework::LibraryType::kPlain &&
+    //         platform::CanMKLDNNBeUsed(ctx)) {
+    //       library = framework::LibraryType::kMKLDNN;
+    //       layout = framework::DataLayout::kMKLDNN;
+    //     }
+    // #endif
 
     return framework::OpKernelType(
         OperatorWithKernel::IndicateVarDataType(ctx, "X"), ctx.GetPlace(),

--- a/paddle/fluid/operators/layer_norm_op.cu
+++ b/paddle/fluid/operators/layer_norm_op.cu
@@ -599,9 +599,9 @@ class LayerNormGradKernel<platform::CUDADeviceContext, T>
 
     auto stream = ctx.cuda_device_context().stream();
 
-    LayerNormBackward<T, U>(x_data, d_y_data, scale_data, mean_data, var_data,
-                            d_x_data, d_scale_data, d_bias_data, epsilon,
-                            batch_size, feature_size, stream);
+    LayerNormBackward<T>(x_data, d_y_data, scale_data, mean_data, var_data,
+                         d_x_data, d_scale_data, d_bias_data, epsilon,
+                         batch_size, feature_size, stream);
   }
 };
 

--- a/paddle/fluid/operators/layer_norm_op.cu
+++ b/paddle/fluid/operators/layer_norm_op.cu
@@ -188,8 +188,7 @@ __global__ void LayerNormBackwardGradientAll(const T *x, const T *d_y,
 
   for (int i = beg_idx; i < end_idx; i += stride) {
     int row_idx = i / feature_size;
-    auto var_val =
-        static_cast<U>(real_sqrt(static_cast<float>(var[row_idx]) + epsilon));
+    auto var_val = real_sqrt(static_cast<U>(var[row_idx]) + epsilon);
     d_scale_partial += static_cast<U>(d_y[i]) *
                        (static_cast<U>(x[i]) - mean[row_idx]) / var_val;
     d_bias_partial += static_cast<U>(d_y[i]);

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
@@ -74,7 +74,6 @@ class AutoMixedPrecisionLists(object):
 white_list = {
     'conv2d',
     'matmul',
-    'matmul_v2',
     'mul',
 }
 
@@ -109,9 +108,11 @@ gray_list = {
     'elementwise_mod',
     'elementwise_floordiv',
     'batch_norm',
+    'layer_norm',
     'tanh',
     'sigmoid',
     'lookup_table',
+    'lookup_table_v2',
     'top_k',
     'pool2d',
     'pool3d',
@@ -123,6 +124,7 @@ gray_list = {
     'flatten2',
     'stack',
     'unstack',
+    'uniform_random',
     'uniform_random_batch_size_like',
     'gaussian_random',
     'gaussian_random_batch_size_like',
@@ -192,7 +194,6 @@ unsupported_fp16_list = {
     'sequence_concat',
     'sequence_slice',
     'data_norm',
-    'layer_norm',
     'group_norm',
     'spectral_norm',
     'depthwise_conv2d_transpose',

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_lists.py
@@ -74,6 +74,7 @@ class AutoMixedPrecisionLists(object):
 white_list = {
     'conv2d',
     'matmul',
+    'matmul_v2',
     'mul',
 }
 

--- a/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
@@ -70,7 +70,7 @@ def _insert_cast_op(block, op, idx, src_dtype, dest_dtype):
 
     for in_name in op.input_names:
         if src_dtype == core.VarDesc.VarType.FP32 and op.type in [
-                'batch_norm', 'fused_bn_add_activation'
+                'batch_norm', 'fused_bn_add_activation', 'layer_norm'
         ]:
             if in_name not in {'X', 'Z'}:
                 continue
@@ -104,8 +104,9 @@ def _insert_cast_op(block, op, idx, src_dtype, dest_dtype):
                     op._set_attr('in_dtype', dest_dtype)
     if src_dtype == core.VarDesc.VarType.FP32 and dest_dtype == core.VarDesc.VarType.FP16:
         for out_name in op.output_names:
-            if op.type in ['batch_norm', 'fused_bn_add_activation'
-                           ] and out_name != 'Y':
+            if op.type in [
+                    'batch_norm', 'fused_bn_add_activation', 'layer_norm'
+            ] and out_name != 'Y':
                 continue
             for out_var_name in op.output(out_name):
                 out_var = block.var(out_var_name)

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 import unittest
 import numpy as np
+import paddle
 
 from operator import mul
 import paddle.fluid.core as core
@@ -310,6 +311,8 @@ class TestLayerNormAPI(unittest.TestCase):
 class TestDygraphLayerNormAPIError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):
+            paddle.enable_static()
+
             layer_norm = fluid.LayerNorm([32, 32])
             # the input of LayerNorm must be Variable.
             x1 = np.random.random((3, 32, 32)).astype('float32')

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -211,6 +211,7 @@ class TestLayerNormOp(unittest.TestCase):
                                   for name in ['x', 'scale', 'bias', 'y@GRAD']
                               },
                               fetch_list=fetch_list)
+                # TODO: why need set atol = 1e-3
                 self.__assert_close(y, out[0], "y", 1e-3)
                 self.__assert_close(mean, out[1], "mean")
                 self.__assert_close(variance, out[2], "variance", 1e-3)

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -211,7 +211,7 @@ class TestLayerNormOp(unittest.TestCase):
                                   for name in ['x', 'scale', 'bias', 'y@GRAD']
                               },
                               fetch_list=fetch_list)
-                self.__assert_close(y, out[0], "y")
+                self.__assert_close(y, out[0], "y", 1e-3)
                 self.__assert_close(mean, out[1], "mean")
                 self.__assert_close(variance, out[2], "variance", 1e-3)
                 self.__assert_close(x_grad, out[3], "x_grad")

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -293,10 +293,11 @@ def layer_norm(x,
                                             'begin_norm_axis', begin_norm_axis)
         return dygraph_utils._append_activation_in_dygraph(pre_act, act=None)
 
-    check_variable_and_dtype(x, 'input', ['float32', 'float64'], 'LayerNorm')
+    check_variable_and_dtype(x, 'input', ['float16', 'float32', 'float64'],
+                             'LayerNorm')
 
     inputs = dict()
-    inputs['X'] = [x]
+    # inputs['X'] = [x]
     if weight:
         inputs['Scale'] = [weight]
     if bias:
@@ -305,11 +306,35 @@ def layer_norm(x,
 
     # create output
     helper = LayerHelper('layer_norm', **locals())
+
+    dtype = x.dtype if x.dtype is not 'float16' else 'float32'
     mean_out = helper.create_variable_for_type_inference(
-        dtype=x.dtype, stop_gradient=True)
+        dtype=dtype, stop_gradient=True)
     variance_out = helper.create_variable_for_type_inference(
-        dtype=x.dtype, stop_gradient=True)
-    layer_norm_out = helper.create_variable_for_type_inference(x.dtype)
+        dtype=dtype, stop_gradient=True)
+    # layer_norm_out = helper.create_variable_for_type_inference(dtype)
+
+    if x.dtype == fluid.core.VarDesc.VarType.FP32:
+        x_fp16 = helper.create_variable_for_type_inference(
+            dtype=fluid.core.VarDesc.VarType.FP16)
+
+        helper.append_op(
+            type="cast",
+            inputs={"X": x},
+            outputs={"Out": x_fp16},
+            attrs={
+                "in_dtype": fluid.core.VarDesc.VarType.FP32,
+                "out_dtype": fluid.core.VarDesc.VarType.FP16
+            })
+
+        inputs['X'] = [x_fp16]
+
+        layer_norm_out = helper.create_variable_for_type_inference(
+            fluid.core.VarDesc.VarType.FP16)
+    else:
+        inputs['X'] = [x]
+
+        layer_norm_out = helper.create_variable_for_type_inference(x.dtype)
 
     helper.append_op(
         type="layer_norm",

--- a/python/paddle/nn/functional/norm.py
+++ b/python/paddle/nn/functional/norm.py
@@ -297,7 +297,7 @@ def layer_norm(x,
                              'LayerNorm')
 
     inputs = dict()
-    # inputs['X'] = [x]
+    inputs['X'] = [x]
     if weight:
         inputs['Scale'] = [weight]
     if bias:
@@ -307,34 +307,12 @@ def layer_norm(x,
     # create output
     helper = LayerHelper('layer_norm', **locals())
 
-    dtype = x.dtype if x.dtype is not 'float16' else 'float32'
+    dtype = x.dtype
     mean_out = helper.create_variable_for_type_inference(
         dtype=dtype, stop_gradient=True)
     variance_out = helper.create_variable_for_type_inference(
         dtype=dtype, stop_gradient=True)
-    # layer_norm_out = helper.create_variable_for_type_inference(dtype)
-
-    if x.dtype == fluid.core.VarDesc.VarType.FP32:
-        x_fp16 = helper.create_variable_for_type_inference(
-            dtype=fluid.core.VarDesc.VarType.FP16)
-
-        helper.append_op(
-            type="cast",
-            inputs={"X": x},
-            outputs={"Out": x_fp16},
-            attrs={
-                "in_dtype": fluid.core.VarDesc.VarType.FP32,
-                "out_dtype": fluid.core.VarDesc.VarType.FP16
-            })
-
-        inputs['X'] = [x_fp16]
-
-        layer_norm_out = helper.create_variable_for_type_inference(
-            fluid.core.VarDesc.VarType.FP16)
-    else:
-        inputs['X'] = [x]
-
-        layer_norm_out = helper.create_variable_for_type_inference(x.dtype)
+    layer_norm_out = helper.create_variable_for_type_inference(dtype)
 
     helper.append_op(
         type="layer_norm",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Add FP16 support for layer_norm.

Now, for FP16, the params are: inputs = {X: FP16, Scale: FP32, Bias: FP32}, outputs = {Y: FP16}. But, the computation is based on FP32.