### PR TITLE
[cherry-pick] Fix analysis_config trt pase bug

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -182,6 +182,10 @@ AnalysisConfig::AnalysisConfig(const AnalysisConfig &other) {
     // deleted_pass.
     auto all_passes = kTRTSubgraphPasses;
     auto other_passes = other.pass_builder()->AllPasses();
+    // We should sort them, because the user may call the SwitchIrDebug
+    // interface, which will change the pass.
+    std::sort(all_passes.begin(), all_passes.end());
+    std::sort(other_passes.begin(), other_passes.end());
     std::vector<std::string> deleted_passes;
     std::set_difference(all_passes.begin(), all_passes.end(),
                         other_passes.begin(), other_passes.end(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick https://github.com/PaddlePaddle/Paddle/pull/29304

Opening the ir_debug interface will cause the wrong trt pass to run.
config->SwitchIrDebug();
