### PR TITLE
use has_grad instead of train_mode

### DIFF
--- a/paddle/fluid/imperative/variable_wrapper.h
+++ b/paddle/fluid/imperative/variable_wrapper.h
@@ -35,6 +35,8 @@ class VariableWrapper {
 
   explicit VariableWrapper(const std::string& name) : name_(name) {}
 
+  ~VariableWrapper() { VLOG(10) << "Destruct VariableWrapper: " << Name(); }
+
   const framework::Variable& Var() const { return var_; }
 
   framework::Variable* MutableVar() { return &var_; }

--- a/python/paddle/fluid/dygraph/base.py
+++ b/python/paddle/fluid/dygraph/base.py
@@ -326,13 +326,13 @@ class no_grad_:
     def __enter__(self):
         tracer = framework._dygraph_tracer()
         if tracer:
-            self.orig = tracer._train_mode
-            tracer._train_mode = False
+            self.orig = tracer._has_grad
+            tracer._has_grad = False
 
     def __exit__(self, *args):
         tracer = framework._dygraph_tracer()
         if tracer:
-            tracer._train_mode = self.orig
+            tracer._has_grad = self.orig
 
 
 @signature_safe_contextmanager

--- a/python/paddle/fluid/tests/unittests/test_imperative_basic.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_basic.py
@@ -288,13 +288,13 @@ class TestImperative(unittest.TestCase):
                 self.assertTrue(l1.weight.stop_gradient is False)
                 tmp = l1.weight * 2
                 print(tmp)
-                self.assertFalse(tmp.stop_gradient)
+                self.assertTrue(tmp.stop_gradient)
             x = fluid.dygraph.to_variable(data)
             y = l0(x) + tmp
             o = l1(y)
             o.backward()
 
-            self.assertTrue(tmp._grad_ivar() is not None)
+            self.assertTrue(tmp._grad_ivar() is None)
             self.assertTrue(l0.weight._grad_ivar() is not None)
 
     def test_sum_op(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_decorator.py
@@ -79,7 +79,8 @@ class TestTracerMode2(TestTracerMode):
 class TestNoGradClass(unittest.TestCase):
     @paddle.no_grad()
     def no_grad_func(self, a):
-        self.assertEqual(self.tracer._train_mode, False)
+        self.assertEqual(self.tracer._train_mode, True)
+        self.assertEqual(self.tracer._has_grad, False)
         return a
 
     def test_main(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Use has_grad instead of train_mode in `class no_grad_`
related #29064