### PR TITLE
remove stream wait after cudaMemcpyAsync with pageable host memory

### DIFF
--- a/paddle/fluid/operators/amp/update_loss_scaling_op.cu
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op.cu
@@ -59,9 +59,10 @@ class LazyZeroInputs<platform::CUDADeviceContext, T> {
     const auto gpu_place =
         BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace());
     bool has_inf{false};
+    // NOTE. Async copy to pageable host memory will be sync. More details see
+    // https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior
     memory::Copy(platform::CPUPlace(), &has_inf, gpu_place, found_inf_data,
                  sizeof(bool), dev_ctx.stream());
-    dev_ctx.Wait();  // wait async copy
     if (has_inf) {
       VLOG(1) << "-- UpdateLossScaling: Infinite values are found in grads. --";
       for (size_t i = 0; i < xs.size(); ++i) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#### 背景
https://github.com/PaddlePaddle/Paddle/pull/28957 这个PR测试说可能降低了性能，不过自测没有降低性能。

#### 分析
如果性能可能降低，那应该是在D2H的memcpy后加了wait导致的。
由于可分页内存的cudaMemcpy实际上是同步的，**所以本PR去掉wait**。详见 https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior 。`For transfers from device memory to pageable host memory, the function will return only once the copy has completed`。
不过感觉最好不要依赖这样的机制，很容易出错O_o

#### kernel性能测试
贴出PR https://github.com/PaddlePaddle/Paddle/pull/28957 中关于kernel部分的改动并不会降低性能的测试。
测试代码见，https://gist.github.com/wangxicoding/e9207332b23a0daf01b3829e9b2201af
得出如下数据，测试1000次耗时。其中原实现为Memset + GpuInverse + ScaleV0，PR中实现为InverseAndMemset + ScaleV1，可以看出PR中各大小数据量下，总耗时以及ScaleV1的耗时都比原PR低。
  | Memset(ms) | GpuInverse(ms) | ScaleV0(ms) | 原实现耗时 | InverseMemset(ms_ | ScaleV1(ms) | PR耗时
-- | -- | -- | -- | -- | -- | -- | --
1KB | 1.8032 | 1.4923 | 1.7314 | 5.0269 | 1.4956 | **1.3042** | **2.7998**
128KB | 1.8037 | 1.484 | 1.7846 | 5.0723 | 1.4875 | **1.4241** | **2.9116**
1MB | 1.7874 | 1.4555 | 3.0414 | 6.2843 | 1.4601 | **2.6801** | **4.1402**
64MB | 1.731 | 1.827 | 173.62 | 177.178 | 1.9776 | **172.3** | **174.2776**
256MB | 1.7129 | 1.7992 | 687.79 | 691.3021 | 1.9574 | **684.19** | **686.1474**
1GB | 1.7135 | 1.7929 | 2744.68 | 2748.1864 | 1.9471 | **2731.98** | **2733.9271**

#### PR性能测试
下面给出**1. 当前develop(合入了#28957)**，**2. 该PR**，**3. revert#28957** 的速度。可以看到合入了#28957的develop速度略高于revert的速度，而当前PR对性能基本无影响

resnet50 fp16
节点*卡数 | batch_size | develop速度 | PR速度 | 速度提升 | revert_ampv1 | 速度提升
-- | -- | -- | -- | -- | -- | --
1*1 | 256 | 1053.952 | 1052.443 | -0.14% | 1048.238 | `-0.54%`
1*1 | 128 | 1066.561 | 1065.079 | -0.14% | 1060.028 | `-0.61%`
1*1 | 64 | 964.9 | 965.753 | 0.09% | 956.86 | `-0.83%`

bert base seq_len=128
节点*卡数 | batch_size | develop速度 | PR速度 | 速度提升 | revert_ampv1 | 速度提升
-- | -- | -- | -- | -- | -- | --
1*1 | 160 | 330.49 | 331.836 | 0.41% | 330.357 | `-0.04%`
1*1 | 96 | 317.975 | 319.188 | 0.38% | 317.432 | `-0.17%`
1*1 | 64 | 303.954 | 303.756 | -0.07% | 302.095 | `-0.61%`
