### PR TITLE
fix that parameters'grad has grad var

### DIFF
--- a/paddle/fluid/imperative/variable_wrapper.h
+++ b/paddle/fluid/imperative/variable_wrapper.h
@@ -81,7 +81,7 @@ class VariableWrapper {
   }
 
   bool IsLeafGrad() const {
-    if (!HasGradVar() && !HasGradNode() && !OverridedStopGradient()) {
+    if (!HasGradNode() && !OverridedStopGradient()) {
       return true;
     }
     return false;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix that parameters'grad has grad var.  It should not have grad var.

But,  Leaf Tensor `grad var` has been add `grad var` , which lead to mis-judgment.

![image](https://user-images.githubusercontent.com/52485244/101305912-9d3d3100-387e-11eb-985c-40d164d28fdc.png)
