### PR TITLE
[Cherry-pikc] Use different name_scope for different conv type, test=develop (#29355)

### DIFF
--- a/paddle/fluid/framework/ir/conv_bn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/conv_bn_fuse_pass.cc
@@ -171,7 +171,7 @@ void ConvBNFusePass::ApplyImpl(ir::Graph* graph) const {
 
     // Create eltwise_y (conv bias) variable
     VarDesc eltwise_y_in_desc(
-        patterns::PDNodeName(name_scope_, "eltwise_y_in"));
+        patterns::PDNodeName("fuse_conv_bn", conv_type() + "_eltwise_y_in"));
     eltwise_y_in_desc.SetShape(framework::vectorize(bn_bias_tensor->dims()));
     eltwise_y_in_desc.SetDataType(bn_bias_tensor->type());
     eltwise_y_in_desc.SetLoDLevel(bn_bias->Var()->GetLoDLevel());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Use different name_scope for different conv type, test=develop (#29355)