### PR TITLE
Fix Unit Test: Add Sleep Time for CUDA Retry

### DIFF
--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -19,12 +19,13 @@ limitations under the License. */
 #endif               // __GNUC__
 
 #if !defined(_WIN32)
-#include <dlfcn.h>  // dladdr
-#else               // _WIN32
+#include <dlfcn.h>   // dladdr
+#include <unistd.h>  // sleep
+#else                // _WIN32
 #ifndef NOMINMAX
 #define NOMINMAX  // msvc max/min macro conflict with std::min/max
 #endif
-#include <windows.h>  // GetModuleFileName
+#include <windows.h>  // GetModuleFileName, sleep
 #endif
 
 #ifdef PADDLE_WITH_CUDA
@@ -80,6 +81,9 @@ class ErrorSummary;
 }  // namespace platform
 }  // namespace paddle
 
+#ifdef PADDLE_WITH_CUDA
+DECLARE_int64(gpu_allocator_retry_time);
+#endif
 DECLARE_int32(call_stack_level);
 
 namespace paddle {
@@ -933,6 +937,7 @@ DEFINE_CUDA_STATUS_TYPE(ncclResult_t, ncclSuccess);
         ::paddle::platform::details::CudaStatusType<                    \
             __CUDA_STATUS_TYPE__>::kSuccess;                            \
     while (UNLIKELY(__cond__ != __success_type__) && retry_count < 5) { \
+      sleep(FLAGS_gpu_allocator_retry_time);                            \
       __cond__ = (COND);                                                \
       ++retry_count;                                                    \
     }                                                                   \

--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -114,6 +114,10 @@ namespace platform {
 #define LIKELY(condition) (condition)
 #endif
 
+#ifdef _WIN32
+#define sleep(millisecond) Sleep(millisecond)
+#endif
+
 #if defined _WIN32 && defined PADDLE_ON_INFERENCE && defined PADDLE_NO_PYTHON
 #define HANDLE_THE_ERROR try {
 #define END_HANDLE_THE_ERROR            \


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add Sleep Time for CUDA Retry, which is similar to our GPU retry logic. This is a try to avoid init GPU allocation random failure in unit test.