### PR TITLE
improve dropout

### DIFF
--- a/paddle/fluid/operators/dropout_op.cu
+++ b/paddle/fluid/operators/dropout_op.cu
@@ -45,76 +45,6 @@ inline int VectorizedSize(char* pointer) {
 }
 
 template <typename T, typename MaskType>
-__global__ void RandomGenerator(const size_t n, const int seed,
-                                const float dropout_prob, const T* src,
-                                MaskType* mask_data, T* dst,
-                                bool is_upscale_in_train) {
-  curandStatePhilox4_32_10_t state;
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
-  int step_size = 0;
-
-  MaskType mask;
-  T dest;
-  for (; idx < n; idx += blockDim.x * gridDim.x) {
-    T s = src[idx];
-    if (step_size == 0) {
-      curand_init(seed, idx, idx, &state);
-      step_size = blockDim.x * gridDim.x;
-    } else {
-      curand_init(seed, idx, step_size, &state);
-    }
-    if (curand_uniform(&state) < dropout_prob) {
-      mask = 0;
-      dest = 0;
-    } else {
-      mask = 1;
-      if (is_upscale_in_train) {
-        dest = s / static_cast<T>(1.0f - dropout_prob);
-      } else {
-        dest = s;
-      }
-    }
-    mask_data[idx] = mask;
-    dst[idx] = dest;
-  }
-}
-
-template <typename T, typename MaskType>
-__global__ void RandomGeneratorWithSeed(const size_t n, const int* seed,
-                                        const float dropout_prob, const T* src,
-                                        MaskType* mask_data, T* dst,
-                                        bool is_upscale_in_train) {
-  curandStatePhilox4_32_10_t state;
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
-  int step_size = 0;
-
-  MaskType mask;
-  T dest;
-  for (; idx < n; idx += blockDim.x * gridDim.x) {
-    T s = src[idx];
-    if (step_size == 0) {
-      curand_init(seed[0], idx, idx, &state);
-      step_size = blockDim.x * gridDim.x;
-    } else {
-      curand_init(seed[0], idx, step_size, &state);
-    }
-    if (curand_uniform(&state) < dropout_prob) {
-      mask = 0;
-      dest = 0;
-    } else {
-      mask = 1;
-      if (is_upscale_in_train) {
-        dest = s / static_cast<T>(1.0f - dropout_prob);
-      } else {
-        dest = s;
-      }
-    }
-    mask_data[idx] = mask;
-    dst[idx] = dest;
-  }
-}
-
-template <typename T, typename MaskType>
 __global__ void RandomGeneratorWithGenerator(const size_t n, uint64_t seed,
                                              const float dropout_prob,
                                              const T* src, MaskType* mask_data,
@@ -122,18 +52,12 @@ __global__ void RandomGeneratorWithGenerator(const size_t n, uint64_t seed,
                                              uint64_t increment) {
   curandStatePhilox4_32_10_t state;
   int idx = blockDim.x * blockIdx.x + threadIdx.x;
-  int step_size = 0;
+  curand_init(seed, idx, increment, &state);
 
   MaskType mask;
   T dest;
   for (; idx < n; idx += blockDim.x * gridDim.x) {
     T s = src[idx];
-    if (step_size == 0) {
-      curand_init(seed, idx, increment, &state);
-      step_size = blockDim.x * gridDim.x;
-    } else {
-      curand_init(seed, idx, increment, &state);
-    }
     if (curand_uniform(&state) < dropout_prob) {
       mask = 0;
       dest = 0;
@@ -154,7 +78,7 @@ template <typename T, typename MaskType, int VecSize>
 __global__ void VectorizedRandomGeneratorWithGenerator(
     const size_t n, uint64_t seed, const float dropout_prob, const T* src,
     MaskType* mask_data, T* dst, bool is_upscale_in_train, uint64_t increment) {
-  int idx = blockDim.x * blockIdx.x + threadIdx.x;
+  int64_t idx = blockDim.x * blockIdx.x + threadIdx.x;
   curandStatePhilox4_32_10_t state;
   curand_init(seed, idx, increment, &state);
 
@@ -167,10 +91,6 @@ __global__ void VectorizedRandomGeneratorWithGenerator(
     T src_vec[VecSize];
     LoadT* value = reinterpret_cast<LoadT*>(&src_vec);
     float4 rand = curand_uniform4(&state);
-    rand.x = rand.x < dropout_prob;
-    rand.y = rand.y < dropout_prob;
-    rand.z = rand.z < dropout_prob;
-    rand.w = rand.w < dropout_prob;
     *value = *reinterpret_cast<LoadT*>(const_cast<T*>(&src[i]));
 
     T dest_vec[VecSize];
@@ -178,12 +98,17 @@ __global__ void VectorizedRandomGeneratorWithGenerator(
 
 #pragma unroll
     for (int ii = 0; ii < VecSize; ii++) {
-      if (is_upscale_in_train) {
-        dest_vec[ii] = src_vec[ii] * static_cast<T>((&rand.x)[ii]) * factor;
+      if ((&rand.x)[ii] < dropout_prob) {
+        dest_vec[ii] = 0;
+        mask_vec[ii] = 0;
       } else {
-        dest_vec[ii] = src_vec[ii] * static_cast<T>((&rand.x)[ii]);
+        if (is_upscale_in_train) {
+          dest_vec[ii] = src_vec[ii] * factor;
+        } else {
+          dest_vec[ii] = src_vec[ii];
+        }
+        mask_vec[ii] = 1;
       }
-      mask_vec[ii] = (uint8_t)(&rand.x)[ii];
     }
 
     *(reinterpret_cast<LoadT*>(&dst[i])) =
@@ -238,46 +163,47 @@ class GPUDropoutKernel : public framework::OpKernel<T> {
           dev_ctx.GetMaxPhysicalThreadCount() / dev_ctx.GetSMCount() / threads;
       grid = std::min(dev_ctx.GetSMCount() * blocks_per_sm, grid);
 
-      if (seed && platform::is_gpu_place(seed->place())) {
-        auto seed_gpu_data = seed->data<int>();
-        RandomGeneratorWithSeed<T, uint8_t><<<grid, threads, 0, stream>>>(
-            size, seed_gpu_data, dropout_prob, x_data, mask_data, y_data,
-            upscale_in_train);
-        return;
-      }
-
+      uint64_t seed_data;
+      uint64_t increment;
+      int vec_size =
+          VectorizedSize<T>(reinterpret_cast<char*>(const_cast<T*>(x_data)));
+      auto offset =
+          ((x_numel - 1) / (threads * grid * vec_size) + 1) * vec_size;
       int device_id = BOOST_GET_CONST(platform::CUDAPlace, context.GetPlace())
                           .GetDeviceId();
       auto gen_cuda = framework::GetDefaultCUDAGenerator(device_id);
-      if (gen_cuda->GetIsInitPy() && (!context.Attr<bool>("fix_seed"))) {
-        int vec_size =
-            VectorizedSize<T>(reinterpret_cast<char*>(const_cast<T*>(x_data)));
-        auto seed_offset = gen_cuda->IncrementOffset(1);
-        if (vec_size == 4) {
-          VectorizedRandomGeneratorWithGenerator<
-              T, uint8_t, 4><<<grid, threads, 0, stream>>>(
-              size, seed_offset.first, dropout_prob, x_data, mask_data, y_data,
-              upscale_in_train, seed_offset.second);
+
+      if (seed && platform::is_gpu_place(seed->place())) {
+        framework::Tensor seed_cpu_tensor;
+        TensorCopySync(*seed, platform::CPUPlace(), &seed_cpu_tensor);
+        seed_data = static_cast<uint64_t>(seed_cpu_tensor.data<int>()[0]);
+        increment = offset;
+      } else if (gen_cuda->GetIsInitPy() && (!context.Attr<bool>("fix_seed"))) {
+        auto seed_offset = gen_cuda->IncrementOffset(offset);
+        seed_data = seed_offset.first;
+        increment = seed_offset.second;
+      } else {
+        if (seed) {
+          seed_data = *(seed->data<int>());
         } else {
-          RandomGeneratorWithGenerator<T,
-                                       uint8_t><<<grid, threads, 0, stream>>>(
-              size, seed_offset.first, dropout_prob, x_data, mask_data, y_data,
-              upscale_in_train, seed_offset.second);
+          std::random_device rnd;
+          seed_data = context.Attr<bool>("fix_seed") ? context.Attr<int>("seed")
+                                                     : rnd();
         }
-        return;
+        increment = offset;
       }
 
-      int seed_data;
-      if (seed) {
-        seed_data = *(seed->data<int>());
+      if (vec_size == 4) {
+        VectorizedRandomGeneratorWithGenerator<T, uint8_t,
+                                               4><<<grid, threads, 0, stream>>>(
+            size, seed_data, dropout_prob, x_data, mask_data, y_data,
+            upscale_in_train, increment);
       } else {
-        std::random_device rnd;
-        seed_data =
-            context.Attr<bool>("fix_seed") ? context.Attr<int>("seed") : rnd();
+        RandomGeneratorWithGenerator<T, uint8_t><<<grid, threads, 0, stream>>>(
+            size, seed_data, dropout_prob, x_data, mask_data, y_data,
+            upscale_in_train, increment);
       }
-      RandomGenerator<T, uint8_t><<<grid, threads, 0, stream>>>(
-          size, seed_data, dropout_prob, x_data, mask_data, y_data,
-          upscale_in_train);
+
     } else {
       auto X = EigenMatrix<T>::Reshape(*x, 1);
       auto Y = EigenMatrix<T>::Reshape(*y, 1);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> improve dropout
- 将原来OP里的3个kernel统一为了一个，因为原来的3个kernel没有太大差异：
  - 原来的RandomGenerator和RandomGeneratorWithSeed逻辑上无差异，只是函数的seed参数类型不同，前者是const int seed，后者是const int* seed。RandomGeneratorWithSeed用到的是Input(seed)。这两个函数完全可以统一为一个。
  - RandomGeneratorWithGenerator的逻辑和前两个也相同，只是该函数使用了CUDAGenerator产生的seed和offset去设置curand_init。函数多了一个increment参数，用来设置kernel中curand_init的offset参数。
  - 以上3个函数接口和逻辑上是可以进行统一的。
- 代码逻辑修改：
  - curand_init用来生成state，但是原始的逻辑中将curand_init放在了for循环里，并没有起到实质性的意义，因为只是在多次迭代时，修改了curand_init的offset参数而已，在PR 的comments里有更详细的描述解释这个接口的原理。放在for循环内或者外，只是在产生随机数时从序列的哪个位置取数上有差异，但是这不影响op的功能。

#### Op-Benchmark Forward Results
![image](https://user-images.githubusercontent.com/26615455/101570659-d954cb00-3a11-11eb-86ef-f68d7116d7cd.png)

#### Bert Forward Results
![image](https://user-images.githubusercontent.com/26615455/101570718-f2f61280-3a11-11eb-9216-7412f3d756f7.png)

