### PR TITLE
[cherry-pick] Support deepcopy for Layer/Tensor/Paramerbase

### DIFF
--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -282,6 +282,37 @@ std::shared_ptr<VarBase> VarBase::NewVarBase(const platform::Place& dst_place,
   }
 }
 
+void VarBase::CopyFrom(const VarBase& src, const bool blocking) {
+  if (SharedVar()->IsEmpty()) {
+    SetName(src.Name() + "_copy");
+    VLOG(3) << "deep copy Variable from " << src.Name() << " to " << Name();
+    SetPersistable(src.Persistable());
+    SetDataType(src.DataType());
+    SetType(src.Type());
+    SetOverridedStopGradient(src.OverridedStopGradient());
+    if (!src.SharedVar()->IsEmpty()) {
+      const platform::Place& place = src.Place();
+      if (src.Var().IsType<framework::LoDTensor>()) {
+        auto& src_tensor = src.Var().Get<framework::LoDTensor>();
+        auto* dst_tensor = MutableVar()->GetMutable<framework::LoDTensor>();
+        dst_tensor->set_lod(src_tensor.lod());
+        framework::TensorCopy(src_tensor, place, dst_tensor);
+      } else if (src.Var().IsType<framework::SelectedRows>()) {
+        auto& src_selected_rows = src.Var().Get<framework::SelectedRows>();
+        auto* dst_selected_rows =
+            MutableVar()->GetMutable<framework::SelectedRows>();
+        dst_selected_rows->set_height(src_selected_rows.height());
+        dst_selected_rows->set_rows(src_selected_rows.rows());
+        framework::TensorCopy(src_selected_rows.value(), place,
+                              dst_selected_rows->mutable_value());
+      }
+      if (blocking) {
+        platform::DeviceContextPool::Instance().Get(place)->Wait();
+      }
+    }
+  }
+}
+
 void VarBase::BumpInplaceVersion() {
   PADDLE_ENFORCE_EQ(
       Var().IsInitialized(), true,

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -284,7 +284,6 @@ std::shared_ptr<VarBase> VarBase::NewVarBase(const platform::Place& dst_place,
 
 void VarBase::CopyFrom(const VarBase& src, const bool blocking) {
   if (SharedVar()->IsEmpty()) {
-    SetName(src.Name() + "_copy");
     VLOG(3) << "deep copy Variable from " << src.Name() << " to " << Name();
     SetPersistable(src.Persistable());
     SetDataType(src.DataType());

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -208,6 +208,8 @@ class VarBase {
   std::shared_ptr<VarBase> NewVarBase(const platform::Place& dst_place,
                                       const bool blocking) const;
 
+  void CopyFrom(const imperative::VarBase& src, bool blocking);
+
   void BumpInplaceVersion();
 
  private:

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -527,6 +527,13 @@ void BindImperative(py::module *m_ptr) {
       m, "VarBase", R"DOC()DOC")
       .def_static("_alive_vars", &imperative::VarBase::AliveVarNames)
       .def("__init__",
+           [](imperative::VarBase &self) {
+             std::string name =
+                 imperative::GetCurrentTracer()->GenerateUniqueName(
+                     "generated_tensor");
+             new (&self) imperative::VarBase(name);
+           })
+      .def("__init__",
            [](imperative::VarBase &self, framework::proto::VarType::Type dtype,
               const std::vector<int> &dims, const py::handle &name,
               framework::proto::VarType::Type type, bool persistable) {
@@ -1023,6 +1030,7 @@ void BindImperative(py::module *m_ptr) {
               y = x.cuda(1)
               print(y.place)        # CUDAPlace(1)
        )DOC")
+      .def("copy_", &imperative::VarBase::CopyFrom)
       .def("_copy_to",
            [](const imperative::VarBase &self, const platform::CPUPlace &place,
               bool blocking) { return self.NewVarBase(place, blocking); },

--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -21,6 +21,7 @@ import re
 import copy
 import weakref
 import warnings
+from copy import deepcopy
 
 from . import parallel_helper
 from .. import unique_name
@@ -1010,15 +1011,26 @@ class Layer(core.Layer):
             self._parameters[name] = parameter
         return parameter
 
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+
     def __getattr__(self, name):
-        if name in self._parameters:
-            return self._parameters[name]
-        elif name in self._sub_layers:
-            return self._sub_layers[name]
-        elif name in self._buffers:
-            return self._buffers[name]
-        else:
-            return object.__getattribute__(self, name)
+        if '_parameters' in self.__dict__:
+            _parameters = self.__dict__['_parameters']
+            if name in self._parameters:
+                return self._parameters[name]
+        if '_sub_layers' in self.__dict__:
+            _sub_layers = self.__dict__['_sub_layers']
+            if name in self._sub_layers:
+                return self._sub_layers[name]
+        if '_buffers' in self.__dict__:
+            _buffers = self.__dict__['_buffers']
+            if name in _buffers:
+                return _buffers[name]
+        return object.__getattribute__(self, name)
 
     def __setattr__(self, name, value):
         def _remove_if_exist(*dicts):

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -17,6 +17,7 @@ import numpy as np
 
 import paddle
 from .. import framework
+from .. import unique_name
 from .. import core
 from ..framework import Variable, Parameter, ParamBase
 from .base import switch_to_static_graph
@@ -286,9 +287,10 @@ def monkey_patch_varbase():
         """
         if not self.is_leaf:
             raise RuntimeError(
-                "Only Leaf Tensors support the deepcopy protocol at the moment, non-Leaf Tensors contains graph information that does't support deepcopy"
+                "Only Leaf Tensor support the deepcopy at the moment, non-Leaf Tensors contains graph information that does't support deepcopy"
             )
         new_varbase = core.VarBase()
+        new_varbase.name = self.name + unique_name.generate("_deepcopy")
         memo[id(self)] = new_varbase
         new_varbase.copy_(self, True)
         return new_varbase

--- a/python/paddle/fluid/dygraph/varbase_patch_methods.py
+++ b/python/paddle/fluid/dygraph/varbase_patch_methods.py
@@ -263,6 +263,36 @@ def monkey_patch_varbase():
         from paddle.tensor.to_string import to_string
         return to_string(self)
 
+    def __deepcopy__(self, memo):
+        """
+        Deep copy Tensor, it will always performs Tensor copy.
+
+        Examples:
+            .. code-block:: python
+
+                import paddle
+                import copy
+                x = paddle.to_tensor(2.)
+                y = copy.deepcopy(x)
+                
+                print(x)
+                # Tensor(shape=[1], dtype=float32, place=CPUPlace, stop_gradient=True,
+                #        [2.])
+
+                print(y)
+                # Tensor(shape=[1], dtype=float32, place=CPUPlace, stop_gradient=True,
+                #        [2.])
+
+        """
+        if not self.is_leaf:
+            raise RuntimeError(
+                "Only Leaf Tensors support the deepcopy protocol at the moment, non-Leaf Tensors contains graph information that does't support deepcopy"
+            )
+        new_varbase = core.VarBase()
+        memo[id(self)] = new_varbase
+        new_varbase.copy_(self, True)
+        return new_varbase
+
     @property
     def block(self):
         return framework.default_main_program().global_block()
@@ -283,7 +313,8 @@ def monkey_patch_varbase():
         ("block", block), ("backward", backward), ("clear_grad", clear_grad),
         ("inplace_version", inplace_version), ("grad", grad),
         ("gradient", gradient), ("__str__", __str__), ("__repr__", __str__),
-        ("__module__", "paddle"), ("__name__", "Tensor")):
+        ("__deepcopy__", __deepcopy__), ("__module__", "paddle"),
+        ("__name__", "Tensor")):
         setattr(core.VarBase, method_name, method)
 
     # patch math methods for varbase

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -23,6 +23,7 @@ import os
 import re
 import traceback
 import six
+import copy
 
 import numpy as np
 import subprocess
@@ -5270,6 +5271,36 @@ class ParamBase(core.VarBase):
         """
         return "Parameter containing:\n{tensor}".format(
             tensor=super(ParamBase, self).__str__())
+
+    def __deepcopy__(self, memo):
+        """
+        Deep copy parameter, it will always performs Tensor copy.
+
+        Examples:
+            .. code-block:: python
+
+                import paddle
+                import copy
+                linear = paddle.nn.Linear(1, 3)
+                linear_copy = copy.deepcopy(linear)
+                
+                print(linear.weight)
+                # Parameter containing:
+                # Tensor(shape=[1, 3], dtype=float32, place=CPUPlace, stop_gradient=False,
+                #     [[-0.30929261, -0.90929240, -1.07851017]])
+
+                print(linear_copy.weight)
+                # Parameter containing:
+                # Tensor(shape=[1, 3], dtype=float32, place=CPUPlace, stop_gradient=False,
+                #     [[-0.30929261, -0.90929240, -1.07851017]])
+
+        """
+        state = copy.deepcopy(self.__dict__, memo)
+        state["name"] = self.name + "_copy"
+        new_param = ParamBase(self.shape, self.dtype, **state)
+        memo[id(self)] = new_param
+        new_param.copy_(self, True)
+        return new_param
 
     __repr__ = __str__
 

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5296,7 +5296,7 @@ class ParamBase(core.VarBase):
 
         """
         state = copy.deepcopy(self.__dict__, memo)
-        state["name"] = self.name + "_copy"
+        state["name"] = self.name + unique_name.generate("_deepcopy")
         new_param = ParamBase(self.shape, self.dtype, **state)
         memo[id(self)] = new_param
         new_param.copy_(self, True)

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -56,7 +56,6 @@ class ParameterChecks(unittest.TestCase):
 
             memo = {}
             param_copy = copy.deepcopy(param, memo)
-            self.assertEqual(param_copy.name, "linear_0.w_0_copy")
             self.assertEqual(param_copy.shape, param.shape)
             self.assertEqual(param_copy.type, param.type)
             self.assertEqual(param_copy.dtype, param.dtype)

--- a/python/paddle/fluid/tests/unittests/test_parameter.py
+++ b/python/paddle/fluid/tests/unittests/test_parameter.py
@@ -15,6 +15,9 @@
 from __future__ import print_function
 
 import unittest
+import copy
+import paddle
+from paddle.fluid.dygraph import guard
 from paddle.fluid.framework import default_main_program
 import paddle.fluid.core as core
 from paddle.fluid.executor import Executor
@@ -26,7 +29,7 @@ main_program = default_main_program()
 
 
 class ParameterChecks(unittest.TestCase):
-    def check_param(self):
+    def check_parameter(self):
         shape = [784, 100]
         val = 1.0625
         b = main_program.global_block()
@@ -46,6 +49,29 @@ class ParameterChecks(unittest.TestCase):
         p = io.get_parameter_value_by_name('fc.w', exe, main_program)
         self.assertTrue(np.allclose(np.array(p), np.ones(shape) * val))
 
+    def check_parambase(self):
+        with guard():
+            linear = paddle.nn.Linear(10, 10)
+            param = linear.weight
+
+            memo = {}
+            param_copy = copy.deepcopy(param, memo)
+            self.assertEqual(param_copy.name, "linear_0.w_0_copy")
+            self.assertEqual(param_copy.shape, param.shape)
+            self.assertEqual(param_copy.type, param.type)
+            self.assertEqual(param_copy.dtype, param.dtype)
+            self.assertEqual(str(param_copy.place), str(param.place))
+            self.assertTrue(np.array_equal(param_copy.numpy(), param.numpy()))
+            self.assertEqual(param_copy.optimize_attr, param.optimize_attr)
+            self.assertEqual(param_copy.regularizer, param.regularizer)
+            self.assertEqual(param_copy.do_model_average,
+                             param.do_model_average)
+            self.assertEqual(param_copy.need_clip, param.need_clip)
+            self.assertEqual(param_copy.is_distributed, param.is_distributed)
+
+            pram_copy2 = copy.deepcopy(param, memo)
+            self.assertEqual(id(param_copy), id(pram_copy2))
+
     def check_exceptions(self):
         b = main_program.global_block()
         with self.assertRaises(ValueError):
@@ -63,8 +89,11 @@ class ParameterChecks(unittest.TestCase):
 
 
 class TestParameter(ParameterChecks):
-    def test_param(self):
-        self.check_param()
+    def _test_parameter(self):
+        self.check_parameter()
+
+    def test_parambase(self):
+        self.check_parambase()
 
     def test_exceptions(self):
         self.check_exceptions()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

Cherry-pick https://github.com/PaddlePaddle/Paddle/pull/29387
Support deepcopy for Layer/Tensor/Paramerbase.
===

deep copy Layer
---
```
class MLP(paddle.nn.Layer):
    def __init__(self, param_attr=None, bias_attr=None):
        super(MLP, self).__init__()

        self._fc1 = paddle.nn.Linear(784, 10)
        self._fc2 = paddle.nn.Linear(10, 10)

    def forward(self, inputs):
        y = self._fc1(inputs)
        y = self._fc2(y)
        return y

mlp = MLP()
mlp_copy = copy.deepcopy(mlp)

print(mlp.sublayers())
print(mlp_copy.sublayers())

[<paddle.nn.layer.common.Linear object at 0x7f44bdc09bf8>, <paddle.nn.layer.common.Linear object at 0x7f44bdc09d00>]
[<paddle.nn.layer.common.Linear object at 0x7f44bdc09eb8>, <paddle.nn.layer.common.Linear object at 0x7f44bdc09f10>]

```
``mlp_copy`` is completely independent from the original ``mlp`` , has same ``parameters, buffers, sublayers`` value, different address.


deep copy Tensor
---
```
x = paddle.to_tensor([2.], stop_gradient=False)
x_copy = copy.deepcopy(x)

print(x)  # 2.
print(x_copy) #2.

x[:]  =5.

print(x)  # 5.
print(x_copy) #2.
```

deep copy Parameter
---
```
linear = paddle.nn.Linear(10, 10)
param = linear.weight

param_copy = copy.deepcopy(param)

print(param)
print(param_copy)
```

``param_copy`` is completely independent from ``param`` , and can be trained independently.