### PR TITLE
when WITH_TENSORRT=ON but TensorRT is not found, cmake report error

### DIFF
--- a/cmake/tensorrt.cmake
+++ b/cmake/tensorrt.cmake
@@ -39,8 +39,7 @@ find_library(TENSORRT_LIBRARY NAMES ${TR_INFER_LIB} ${TR_INFER_RT}
 if(TENSORRT_INCLUDE_DIR AND TENSORRT_LIBRARY)
     set(TENSORRT_FOUND ON)
 else()
-    set(TENSORRT_FOUND OFF)
-    message(WARNING "TensorRT is disabled. You are compiling PaddlePaddle with option -DWITH_TENSORRT=ON, but TensorRT is not found, please configure path to TensorRT with option -DTENSORRT_ROOT or install it.")
+    message(SEND_ERROR "TensorRT is disabled. You are compiling PaddlePaddle with option -DWITH_TENSORRT=ON, but TensorRT is not found, please configure path to TensorRT with option -DTENSORRT_ROOT or install it.")
 endif()
 
 if(TENSORRT_FOUND)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
当WIHT_TENSORRT=ON，但是tensorRT未找到时，cmake报错。
<!-- Describe what this PR does -->
