### PR TITLE
Disable Windows mult-GPU Unittest test_feed_data_check_shape_type

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -406,7 +406,7 @@ rem TODO: fix these unittest that is bound to fail
 rem /*==================Disabled Windows unite==============================*/
 set diable_wingpu_test=test_analysis_predictor^|test_model^|test_add_reader_dependency^|test_bilateral_slice_op^|^
 test_cholesky_op^|test_dataloader_early_reset^|test_decoupled_py_reader^|test_decoupled_py_reader_data_check^|test_eager_deletion_delete_vars^|^
-test_eager_deletion_while_op^|test_feed_data_check_shape_type^|test_fetch_lod_tensor_array^|test_fleet_base_single^|test_fuse_all_reduce_pass^|test_fuse_elewise_add_act_pass^|^
+test_eager_deletion_while_op^|test_fetch_lod_tensor_array^|test_fleet_base_single^|test_fuse_all_reduce_pass^|test_fuse_elewise_add_act_pass^|^
 test_fuse_optimizer_pass^|test_generator_dataloader^|test_ir_memory_optimize_ifelse_op^|test_lr_scheduler^|^
 test_multiprocess_dataloader_iterable_dataset_dynamic^|test_multiprocess_dataloader_iterable_dataset_static^|test_parallel_dygraph_sync_batch_norm^|test_parallel_executor_drop_scope^|^
 test_parallel_executor_dry_run^|test_partial_eager_deletion_transformer^|test_prune^|test_py_reader_combination^|test_py_reader_pin_memory^|^

--- a/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
+++ b/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
@@ -78,6 +78,13 @@ class TestFeedData(unittest.TestCase):
                     'use_cuda': use_cuda,
                     'use_parallel_executor': use_parallel_executor,
                 })
+
+                if use_parallel_exe and os.name == "nt":
+                    print(
+                        "Skip use_parallel_exe=True in Windows because Windows GPU doesn't support mult-GPU now."
+                    )
+                    continue
+
                 # Test feeding without error
                 self._test_feed_data_match_shape_type(use_cuda,
                                                       use_parallel_executor)

--- a/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
+++ b/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
@@ -79,7 +79,7 @@ class TestFeedData(unittest.TestCase):
                     'use_parallel_executor': use_parallel_executor,
                 })
 
-                if use_parallel_exe and use_cuda and os.name == "nt":
+                if use_parallel_executor and use_cuda and os.name == "nt":
                     print(
                         "Skip use_parallel_exe=True in Windows because Windows GPU doesn't support mult-GPU now."
                     )

--- a/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
+++ b/python/paddle/fluid/tests/unittests/test_feed_data_check_shape_type.py
@@ -79,7 +79,7 @@ class TestFeedData(unittest.TestCase):
                     'use_parallel_executor': use_parallel_executor,
                 })
 
-                if use_parallel_exe and os.name == "nt":
+                if use_parallel_exe and use_cuda and os.name == "nt":
                     print(
                         "Skip use_parallel_exe=True in Windows because Windows GPU doesn't support mult-GPU now."
                     )


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Disable Windows mult-GPU Unittest test_feed_data_check_shape_type because our Windows version only supports 1 card now.