### PR TITLE
[oneDNN] Fix flags use test for #29080, assert condition more general

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -418,7 +418,7 @@ test_fuse_optimizer_pass^|test_generator_dataloader^|test_ir_memory_optimize_ife
 test_multiprocess_dataloader_iterable_dataset_dynamic^|test_multiprocess_dataloader_iterable_dataset_static^|test_parallel_dygraph_sync_batch_norm^|test_parallel_executor_drop_scope^|^
 test_parallel_executor_dry_run^|test_partial_eager_deletion_transformer^|test_prune^|test_py_reader_combination^|test_py_reader_pin_memory^|^
 test_py_reader_push_pop^|test_py_reader_using_executor^|test_reader_reset^|test_update_loss_scaling_op^|test_imperative_static_runner_while^|^
-test_flags_use_mkldnn^|test_optimizer_in_control_flow^|test_fuse_bn_act_pass^|^
+test_optimizer_in_control_flow^|test_fuse_bn_act_pass^|^
 test_fuse_bn_add_act_pass^|test_activation_mkldnn_op^|test_tsm^|test_gru_rnn_op^|test_rnn_op^|test_simple_rnn_op^|test_pass_builder^|test_lstm_cudnn_op^|test_inplace_addto_strategy^|^
 test_ir_inplace_pass^|test_ir_memory_optimize_pass^|test_memory_reuse_exclude_feed_var^|test_mix_precision_all_reduce_fuse^|test_parallel_executor_pg^|test_print_op^|test_py_func_op^|^
 test_weight_decay^|^

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_flags_mkldnn_ops_on_off.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_flags_mkldnn_ops_on_off.py
@@ -48,54 +48,65 @@ class TestFlagsUseMkldnn(unittest.TestCase):
         returncode = proc.returncode
 
         assert returncode == 0
-        return out
+        return out, err
 
-    def found(self, regex, out):
-        return re.search(regex, out, re.MULTILINE)
+    def _print_when_false(self, cond, out, err):
+        if not cond:
+            print('out', out)
+            print('err', err)
+        return cond
+
+    def found(self, regex, out, err):
+        _found = re.search(regex, out, re.MULTILINE)
+        return self._print_when_false(_found, out, err)
+
+    def not_found(self, regex, out, err):
+        _not_found = not re.search(regex, out, re.MULTILINE)
+        return self._print_when_false(_not_found, out, err)
 
     def test_flags_use_mkl_dnn_on_empty_off_empty(self):
-        out = self.flags_use_mkl_dnn_common({})
-        assert self.found(self.relu_regex, out)
-        assert self.found(self.ew_add_regex, out)
-        assert self.found(self.matmul_regex, out)
+        out, err = self.flags_use_mkl_dnn_common({})
+        assert self.found(self.relu_regex, out, err)
+        assert self.found(self.ew_add_regex, out, err)
+        assert self.found(self.matmul_regex, out, err)
 
     def test_flags_use_mkl_dnn_on(self):
         env = {str("FLAGS_tracer_mkldnn_ops_on"): str("relu")}
-        out = self.flags_use_mkl_dnn_common(env)
-        assert self.found(self.relu_regex, out)
-        assert not self.found(self.ew_add_regex, out)
-        assert not self.found(self.matmul_regex, out)
+        out, err = self.flags_use_mkl_dnn_common(env)
+        assert self.found(self.relu_regex, out, err)
+        assert self.not_found(self.ew_add_regex, out, err)
+        assert self.not_found(self.matmul_regex, out, err)
 
     def test_flags_use_mkl_dnn_on_multiple(self):
         env = {str("FLAGS_tracer_mkldnn_ops_on"): str("relu,elementwise_add")}
-        out = self.flags_use_mkl_dnn_common(env)
-        assert self.found(self.relu_regex, out)
-        assert self.found(self.ew_add_regex, out)
-        assert not self.found(self.matmul_regex, out)
+        out, err = self.flags_use_mkl_dnn_common(env)
+        assert self.found(self.relu_regex, out, err)
+        assert self.found(self.ew_add_regex, out, err)
+        assert self.not_found(self.matmul_regex, out, err)
 
     def test_flags_use_mkl_dnn_off(self):
         env = {str("FLAGS_tracer_mkldnn_ops_off"): str("matmul")}
-        out = self.flags_use_mkl_dnn_common(env)
-        assert self.found(self.relu_regex, out)
-        assert self.found(self.ew_add_regex, out)
-        assert not self.found(self.matmul_regex, out)
+        out, err = self.flags_use_mkl_dnn_common(env)
+        assert self.found(self.relu_regex, out, err)
+        assert self.found(self.ew_add_regex, out, err)
+        assert self.not_found(self.matmul_regex, out, err)
 
     def test_flags_use_mkl_dnn_off_multiple(self):
         env = {str("FLAGS_tracer_mkldnn_ops_off"): str("matmul,relu")}
-        out = self.flags_use_mkl_dnn_common(env)
-        assert not self.found(self.relu_regex, out)
-        assert self.found(self.ew_add_regex, out)
-        assert not self.found(self.matmul_regex, out)
+        out, err = self.flags_use_mkl_dnn_common(env)
+        assert self.not_found(self.relu_regex, out, err)
+        assert self.found(self.ew_add_regex, out, err)
+        assert self.not_found(self.matmul_regex, out, err)
 
     def test_flags_use_mkl_dnn_on_off(self):
         env = {
             str("FLAGS_tracer_mkldnn_ops_on"): str("elementwise_add"),
             str("FLAGS_tracer_mkldnn_ops_off"): str("matmul")
         }
-        out = self.flags_use_mkl_dnn_common(env)
-        assert not self.found(self.relu_regex, out)
-        assert self.found(self.ew_add_regex, out)
-        assert not self.found(self.matmul_regex, out)
+        out, err = self.flags_use_mkl_dnn_common(env)
+        assert self.not_found(self.relu_regex, out, err)
+        assert self.found(self.ew_add_regex, out, err)
+        assert self.not_found(self.matmul_regex, out, err)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Flags assert condition more general fixes the failing **test_flags_use_mkldnn** issue as described in #29080. 
Print output if pattern not found in test stdout for better debugging.