### PR TITLE
fix p_norm with empty shape

### DIFF
--- a/paddle/fluid/operators/p_norm_op.cc
+++ b/paddle/fluid/operators/p_norm_op.cc
@@ -116,6 +116,9 @@ class PnormOp : public framework::OperatorWithKernel {
       for (int i = 0; i < x_dim.size(); ++i) {
         if (i != axis) reduce_dims.emplace_back(x_dim[i]);
       }
+      if (reduce_dims.size() == 0) {
+        reduce_dims.emplace_back(1);
+      }
     }
     x_dim[axis] = 1;
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix p_norm with empty shape
