### PR TITLE
[Dy2Stat] 1. Fix error in _build_cond_stmt of for-range stmts. 2. Support that step value is negative in for-range stmts

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -1033,7 +1033,8 @@ class ForNodeVisitor(object):
                 "Dynamic-to-Static only supports the step value is a constant or negative constant in 'for-range' statements, "
                 "such as '2', '-3'. But received: '{}'. Please fix code to be compatible with Dynamic-to-Static."
                 .format(ast_to_source_code(step_node).strip()))
-        if isinstance(step_node, gast.UnaryOp):
+
+        if isinstance(step_node, gast.UnaryOp) or step_node.value < 0:
             # eg:
             # range(max, min, -2)
             # ->

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_loop.py
@@ -94,6 +94,28 @@ def for_loop_dyfunc2(max_len):
     return ret
 
 
+def for_loop_dyfunc3(max_len):
+    ret = fluid.layers.zeros(shape=[1], dtype='float32')
+    for i in range(1, 10, 2):
+        fluid.layers.increment(ret, value=2.0, in_place=True)
+    return ret
+
+
+def for_loop_dyfunc4(max_len):
+    ret = fluid.layers.zeros(shape=[1], dtype='float32')
+    for i in range(10, 1, -2):
+        fluid.layers.increment(ret, value=2.0, in_place=True)
+    return ret
+
+
+def for_loop_dyfunc_not_support(max_len):
+    ret = fluid.layers.zeros(shape=[1], dtype='float32')
+    a = -2
+    for i in range(10, 1, a):
+        fluid.layers.increment(ret, value=2.0, in_place=True)
+    return ret
+
+
 def while_loop_bool_op(x):
     i = fluid.dygraph.to_variable(x)
 
@@ -333,6 +355,16 @@ class TestTransformForLoop2(TestTransformForLoop):
         self.dyfunc = for_loop_dyfunc2
 
 
+class TestTransformForLoop3(TestTransformForLoop):
+    def _init_dyfunc(self):
+        self.dyfunc = for_loop_dyfunc3
+
+
+class TestTransformForLoop4(TestTransformForLoop):
+    def _init_dyfunc(self):
+        self.dyfunc = for_loop_dyfunc4
+
+
 class TestClassVarInForLoop(TestTransformForLoop):
     def _init_dyfunc(self):
         self.dyfunc = for_loop_class_var
@@ -341,6 +373,18 @@ class TestClassVarInForLoop(TestTransformForLoop):
 class TestVarCreateInForLoop(TestTransformForLoop):
     def _init_dyfunc(self):
         self.dyfunc = var_create_in_for_loop
+
+
+class TestErrorInForLoop(TestTransformForLoop):
+    def _init_dyfunc(self):
+        self.dyfunc = for_loop_dyfunc_not_support
+
+    def test_ast_to_func(self):
+        with self.assertRaisesRegexp(
+                NotImplementedError,
+                "Dynamic-to-Static only supports the step value is a constant or negative constant "
+        ):
+            self._run_static()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

1. Fix error in _build_cond_stmt of for-range stmts. 
2. Support that step value is negative in for-range stmts

---

#### 1. Fix error in _build_cond_stmt of for-range stmts. 
```python
def test():
    ret = paddle.zeros(shape=[1], dtype='float32')
    for i in range(1, 10, 2):
        ret = ret+2
    return ret
```

- Before this PR, the transformed code:
```python
def test():
    ret = paddle.zeros(shape=[1], dtype='float32')
    i = 1

    def for_loop_condition_0(ret, i):
        return i + 2 <= 10      # Here, it should be `i < 10` but not `i+2 <= 10`

    def for_loop_body_0(ret, i):
        ret = ret + 2
        i += 2
        return ret, i

    [ret, i] = paddle.jit.dy2static.convert_while_loop(for_loop_condition_0,
        for_loop_body_0, [ret, i])
    return ret

```

- After:
```python
def test():
    ret = paddle.zeros(shape=[1], dtype='float32')
    i = 1

    def for_loop_condition_0(ret, i):
        return i < 10

    def for_loop_body_0(ret, i):
        ret = ret + 2
        i += 2
        return ret, i
    [ret, i] = paddle.jit.dy2static.convert_while_loop(for_loop_condition_0,
        for_loop_body_0, [ret, i])
    return ret
```


####  2. Support that step value is negative in for-range stmts
```python
def test():
    ret = paddle.zeros(shape=[1], dtype='float32')
    for i in range(10, 1, -2):
        ret = ret+2
    return ret
```

- Before this PR, the transformed code: 
```python
def test():
    ret = paddle.zeros(shape=[1], dtype='float32')
    i = 10

    def for_loop_condition_0(ret, i):
        return i + -2 <= 1  # Here, it should be `i > 1` but not `i-2 <= 1`

    def for_loop_body_0(ret, i):
        ret = ret + 2
        i += -2
        return ret, i

    [ret, i] = paddle.jit.dy2static.convert_while_loop(for_loop_condition_0,
        for_loop_body_0, [ret, i])
    return ret


```

- After:
```python
def test():
    ret = paddle.zeros(shape=[1], dtype='float32')
    i = 10

    def for_loop_condition_0(ret, i):
        return i > 1

    def for_loop_body_0(ret, i):
        ret = ret + 2
        i += -2
        return ret, i
    [ret, i] = paddle.jit.dy2static.convert_while_loop(for_loop_condition_0,
        for_loop_body_0, [ret, i])
    return ret

```