### PR TITLE
Fix Layer train eval setting failed in static mode

### DIFF
--- a/python/paddle/fluid/dygraph/layers.py
+++ b/python/paddle/fluid/dygraph/layers.py
@@ -132,8 +132,11 @@ class Layer(core.Layer):
                 out = mylayer(x)
 
         """
-        # global setting
-        framework._dygraph_tracer().train_mode()
+        # global setting in dygraph
+        # NOTE(chenweihang): nn.Layer also can be used in static mode,
+        # but _dygraph_tracer() can not be called in static mode
+        if in_dygraph_mode():
+            framework._dygraph_tracer().train_mode()
         # Layer-level setting
         self.training = True
         for layer in self.sublayers():
@@ -170,8 +173,11 @@ class Layer(core.Layer):
                 print(out)
 
         """
-        # global setting
-        framework._dygraph_tracer().eval_mode()
+        # global setting in dygraph
+        # NOTE(chenweihang): nn.Layer also can be used in static mode,
+        # but _dygraph_tracer() can not be called in static mode
+        if in_dygraph_mode():
+            framework._dygraph_tracer().eval_mode()
         # Layer-level setting
         self.training = False
         for layer in self.sublayers():

--- a/python/paddle/fluid/tests/unittests/test_layers.py
+++ b/python/paddle/fluid/tests/unittests/test_layers.py
@@ -3701,6 +3701,23 @@ class TestLayerParameterTrainableSet(unittest.TestCase):
             self.assertFalse(net.weight.trainable)
 
 
+class TestLayerTrainingAttribute(unittest.TestCase):
+    def test_set_train_eval_in_dynamic_mode(self):
+        with fluid.dygraph.guard():
+            net = paddle.nn.Dropout()
+            net.train()
+            self.assertTrue(net.training)
+            net.eval()
+            self.assertFalse(net.training)
+
+    def test_set_train_eval_in_static_mode(self):
+        net = paddle.nn.Dropout()
+        net.train()
+        self.assertTrue(net.training)
+        net.eval()
+        self.assertFalse(net.training)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

Fix Layer train eval setting failed in static mode

By our design, `paddlle.nn.Layer` also can be used in static graph mode, but `Layer.train()` and `Layer.eval()` can only be set in dygraph mode, if set in static mode, it willl throw like:
```
Traceback (most recent call last):
  File "train_mode.py", line 5, in <module>
    l.train()
  File "/usr/local/python2.7.15/lib/python2.7/site-packages/paddle/fluid/dygraph/layers.py", line 135, in train
    framework._dygraph_tracer().train_mode()
AttributeError: 'NoneType' object has no attribute 'train_mode'
```

related issue: https://github.com/PaddlePaddle/Paddle/issues/29534

This may cause some problem. For example, the behavior of `paddle.nn.Dropout`in `Layer.train()` and `Layer.eval()` are diffferent, the 2.0 `paddle.nn.Dropout` implement as:

```
def forward(self, input):
        out = F.dropout(
            input,
            p=self.p,
            axis=self.axis,
            training=self.training,
            mode=self.mode,
            name=self.name)
        return out
```

It need `self.training` as argument of original `dropout`, if user want use `paddle.nn.Dropout` for test in static mode, it need to set `Layer.eval()` firstly.

So this PR fix this problem, only set `framework._dygraph_tracer().train_mode()` in dygraph mode.