### PR TITLE
[Dy2Stat] Support grammar: for ele in var[idx]

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -882,6 +882,8 @@ class ForNodeVisitor(object):
                 self.node.iter.func,
                 gast.Attribute) and self.node.iter.func.attr == 'numpy':
             return True
+        elif isinstance(self.node.iter, gast.Subscript):
+            return True
         else:
             return False
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_for_enumerate.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_for_enumerate.py
@@ -159,6 +159,7 @@ def for_enumerate_var_numpy_with_start_continue(x_array):
 def for_iter_var(x_array):
     z = fluid.layers.fill_constant([1], 'int32', 0)
     x_array = fluid.dygraph.to_variable(x_array)
+
     for x in x_array:
         z = z + x
     return z
@@ -219,6 +220,17 @@ def for_enumerate_var_with_nested_range(x_array):
         for idx in range(num):
             x = x + num
     return x
+
+
+# 16. for iter var[idx]
+@paddle.jit.to_static
+def for_iter_var_idx(x_array):
+    z = fluid.layers.fill_constant([1], 'int32', 0)
+    x_array = fluid.dygraph.to_variable(x_array)
+
+    for x in x_array[0:]:
+        z = z + x
+    return z
 
 
 class TestTransformBase(unittest.TestCase):
@@ -341,6 +353,11 @@ class TestForEnumerateVarNumpyWithStartAndBreak(TestForIterVarNumpy):
 class TestForIterVar(TestForIterVarNumpy):
     def set_test_func(self):
         self.dygraph_func = for_iter_var
+
+
+class TestForIterVarIdx(TestForIterVarNumpy):
+    def set_test_func(self):
+        self.dygraph_func = for_iter_var_idx
 
 
 class TestForEnumerateVar(TestForIterVarNumpy):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#### Support to transform`for ele in var` stms in which var is a slice of Tensor.

For example：
```python
def for_iter_var_idx(x_array):
    z = fluid.layers.fill_constant([1], 'int32', 0)
    x_array = fluid.dygraph.to_variable(x_array)

    for x in x_array[0:]:
        z = z + x
    return z
```

- Before this PR, `for_iter_var_idx` can't be transformed successfully. 
```
AttributeError: 'Subscript' object has no attribute 'args'
```