### PR TITLE
Polish hash function of executor cache key 

### DIFF
--- a/paddle/fluid/framework/executor_cache.cc
+++ b/paddle/fluid/framework/executor_cache.cc
@@ -79,7 +79,7 @@ std::shared_ptr<framework::ExecutorPrepareContext> GetExecutorInfoFromCache(
   auto *program = ctx.Attr<BlockDesc *>("global_block")->Program();
 
   auto &cached_exe_info = framework::ExecutorInfoCache::Instance();
-  auto cache_key = framework::ExecutorInfoCache::KeyType(program, is_grad);
+  auto cache_key = framework::ExecutorInfoCache::KeyInfo(program, is_grad);
 
   if (!cached_exe_info.Has(cache_key)) {
     VLOG(1) << "create exe_info for program: " << program

--- a/paddle/fluid/framework/executor_cache.h
+++ b/paddle/fluid/framework/executor_cache.h
@@ -34,12 +34,13 @@ class ExecutorInfoCache {
    * The ExecutorPrepareContext is different while running forward program and
    * backward program. We add bool value into cached key to distinguish this.
    */
-  using KeyType = std::pair<const framework::ProgramDesc*, /*is_grad*/ bool>;
+  using KeyInfo = std::pair<const framework::ProgramDesc*, /*is_grad*/ bool>;
+  using KeyType = size_t;
 
   struct HashPair {
-    size_t operator()(const KeyType& key) const noexcept {
+    size_t operator()(const KeyInfo& key) const noexcept {
       size_t seed = 10;
-      auto& prog_desc = key.first;
+      auto* prog_desc = key.first;
       /*
        * Note(Aurelius84): DO NOT use only ProgramDesc* to calculate hash value
        * because a new program will hold same pointer address after an older
@@ -52,8 +53,10 @@ class ExecutorInfoCache {
         hash_combine(&seed, prog_desc->Block(i).OpSize());
       }
       hash_combine(&seed, key.second);
+      VLOG(1) << "hash value is : " << seed << " of pointer " << prog_desc;
       return seed;
     }
+
     template <typename T>
     void hash_combine(size_t* seed, const T& val) const {
       std::hash<T> hasher;
@@ -64,35 +67,45 @@ class ExecutorInfoCache {
   static ExecutorInfoCache& Instance();
 
   std::shared_ptr<framework::ExecutorPrepareContext> Get(
-      const KeyType& key) const {
+      const KeyInfo& key) const {
+    KeyType key_value = key_hash_func_(key);
     PADDLE_ENFORCE_EQ(
-        Has(key), true,
+        Has(key_value), true,
         platform::errors::NotFound(
             "(programDesc: %s, is_grad: %s) doesn't exist in ExecutorInfoCache",
             key.first, key.second));
-    return info_map_.at(key);
+    return info_map_.at(key_value);
+  }
+
+  bool Has(const KeyInfo& key) const {
+    KeyType key_value = key_hash_func_(key);
+    return Has(key_value);
   }
 
   bool Has(const KeyType& key) const {
     return info_map_.find(key) != info_map_.end();
   }
 
-  void Insert(const KeyType& key,
+  void Insert(const KeyInfo& key,
               std::shared_ptr<framework::ExecutorPrepareContext> exe_ctx) {
+    KeyType key_value = key_hash_func_(key);
     PADDLE_ENFORCE_NE(
-        Has(key), true,
+        Has(key_value), true,
         platform::errors::NotFound(
             "(programDesc: %s, is_grad: %s) has existed in ExecutorInfoCache",
             key.first, key.second));
-
-    info_map_.insert(std::make_pair(key, exe_ctx));
+    info_map_.insert({key_value, exe_ctx});
   }
 
  private:
   ExecutorInfoCache() = default;
 
-  std::unordered_map<
-      KeyType, std::shared_ptr<framework::ExecutorPrepareContext>, HashPair>
+  HashPair key_hash_func_;
+
+  // Note: we shall avoid using raw pointer as key but use hash code,
+  // beacause pointer doesn't hold resource indeed.
+  std::unordered_map<KeyType,
+                     std::shared_ptr<framework::ExecutorPrepareContext>>
       info_map_;
   DISABLE_COPY_AND_ASSIGN(ExecutorInfoCache);
 };

--- a/paddle/fluid/framework/executor_cache.h
+++ b/paddle/fluid/framework/executor_cache.h
@@ -47,7 +47,7 @@ class ExecutorInfoCache {
        * hashing because program may contains at least one block.
        */
       hash_combine(&seed, prog_desc);
-      for (int i = 0; i < prog_desc->Size(); ++i) {
+      for (size_t i = 0; i < prog_desc->Size(); ++i) {
         hash_combine(&seed, &prog_desc->Block(i));
         hash_combine(&seed, prog_desc->Block(i).OpSize());
       }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Polish hash function of executor cache key 

**BUG描述：**

在CI执行部分动转静单测时，存在一定几率的随机挂，retry之后正常。

**原因：**

之前使用了 `ProgramDesc *`指针作为了 executor_cache内在unordered_map的 **Key**。可能存在两个单测用例中的ProgramDesc指针地址一样的情况，导致执行Program A时，命中了Program B的缓存Context，因此报错。

**修复：**
1. 在hash函数计算中，增加更多的Program字段以避免hash冲突。
    + 由于hash函数经常被调用，考虑性能问题，此处并没有使用program->Proto的序列化string作为字段。频繁序列化的overhead不容忽视
    + 采用了 program_desc + block_desc + op_size (每个block_desc)作为hash计算字段。

2. 移除了指针作为map的key，选择hash_value作为key，保持外层接口 `std::pair<program_desc*, bool>`不变
    + 因为program_desc指针指向物会在单元用例执行完后被析构，若以指针作为key，则存在通过key访问已析构指向物的潜在风险
    +  移除指针作为map的key，禁止通过key访问到program_desc*指针
