### PR TITLE
add alias for fluid.contrib.mixed_precision

### DIFF
--- a/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
+++ b/python/paddle/fluid/contrib/mixed_precision/fp16_utils.py
@@ -20,6 +20,9 @@ from ... import global_scope
 from ...log_helper import get_logger
 import logging
 import numpy as np
+
+__all__ = ["cast_model_to_fp16", "cast_parameters_to_fp16"]
+
 _logger = get_logger(
     __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
 

--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -24,7 +24,6 @@ __all__ = [
 ]
 
 from . import nn
-from . import amp
 from .io import save_inference_model  #DEFINE_ALIAS
 from .io import load_inference_model  #DEFINE_ALIAS
 from ..fluid import Scope  #DEFINE_ALIAS

--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
 ]
 
 from . import nn
+from . import amp
 from .io import save_inference_model  #DEFINE_ALIAS
 from .io import load_inference_model  #DEFINE_ALIAS
 from ..fluid import Scope  #DEFINE_ALIAS

--- a/python/paddle/static/amp/__init__.py
+++ b/python/paddle/static/amp/__init__.py
@@ -1,4 +1,4 @@
-#   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserve.
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
+from ...fluid.contrib import mixed_precision
+from ...fluid.contrib.mixed_precision import *
 
-from . import decorator
-from .decorator import *
-from . import fp16_lists
-from .fp16_lists import *
-from . import fp16_utils
-from .fp16_utils import *
-
-__all__ = decorator.__all__
-__all__ += fp16_lists.__all__
-__all__ += fp16_utils.__all__
+__all__ = mixed_precision.__all__


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
This PR adds alias for fluid.contrib.mixed_precision.

you can import amp related functions as follows:

```python
from paddle.static.amp import decorate
from paddle.static.amp import cast_model_to_fp16

def decorate(optimizer,
             amp_lists=None,
             init_loss_scaling=2**15,
             incr_every_n_steps=1000,
             decr_every_n_nan_or_inf=2,
             incr_ratio=2.0,
             decr_ratio=0.8,
             use_dynamic_loss_scaling=True):


"""
    Decorate the given optimizer to adapt to the mixed-precision training.

    Args:
        optimizer(Optimizer): A common Optimizer.
        amp_lists (AutoMixedPrecisionLists): An AutoMixedPrecisionLists object.
        init_loss_scaling(float): The initial loss scaling factor.
        incr_every_n_steps(int): Increases loss scaling every n consecutive 
                                 steps with finite gradients.
        decr_every_n_nan_or_inf(int): Decreases loss scaling every n 
                                      accumulated steps with nan or 
                                      inf gradients.
        incr_ratio(float): The multiplier to use when increasing the loss 
                           scaling.
        decr_ratio(float): The less-than-one-multiplier to use when decreasing 
                           the loss scaling.
        use_dynamic_loss_scaling(bool): Whether to use dynamic loss scaling.

    Returns:
        An optimizer acting like a normal one but with mixed-precision training 
        enabled.

    Examples:
	.. code-block:: python

	    loss = network()
            optimizer = fluid.optimizer.Adam(learning_rate=0.001)
	
            mp_optimizer = fluid.contrib.mixed_precision.decorate(
	              optimizer=optimizer, init_loss_scaling=8.0)
	
            ops, param_grads = mp_optimizer.minimize(loss)
            scaled_loss = mp_optimizer.get_scaled_loss()
"""
```
