### PR TITLE
Add double grad for paddle.clip

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_nn_grad.py
+++ b/python/paddle/fluid/tests/unittests/test_nn_grad.py
@@ -329,5 +329,26 @@ class TestUnsqueezeDoubleGradCheck(unittest.TestCase):
             self.func(p)
 
 
+class TestClipDoubleGradCheck(unittest.TestCase):
+    @prog_scope()
+    def func(self, place):
+        x_shape = [2, 4, 10]
+        dtype = np.float64
+
+        x = layers.data('x', x_shape, False, dtype)
+        x.persistable = True
+        out = paddle.clip(x, min=-1., max=1.)
+        x_arr = np.random.uniform(-5., 5., x_shape).astype(dtype)
+
+        gradient_checker.double_grad_check([x], out, x_init=x_arr, place=place)
+
+    def test_grad(self):
+        places = [fluid.CPUPlace()]
+        if core.is_compiled_with_cuda():
+            places.append(fluid.CUDAPlace(0))
+        for p in places:
+            self.func(p)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### PR types
New features 

### PR changes
OPs

### Describe

Double grad implementation for `paddle.clip`


test example:

```python
import paddle
import numpy as np

a=np.array([[1.2, 0.5], [2.2, 3.0]])
x=paddle.to_tensor(a)
x.stop_gradient=False

y = x * x
y=paddle.clip(y, 1.0, 2.0)
print(y)
dx = paddle.grad(
        outputs=[y],
        inputs=[x],
        create_graph=True,
        retain_graph=True)[0]

z = y + dx

z.backward()

print(x.gradient())
```
