### PR TITLE
optimize for long width for elementwise

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_add_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.h
@@ -19,6 +19,11 @@ limitations under the License. */
 #include "paddle/fluid/operators/elementwise/elementwise_op_function.cu.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op_function.h"
 #include "paddle/fluid/operators/math/blas.h"
+#ifdef PADDLE_WITH_CUDA
+#ifdef __NVCC__
+#include "cub/cub.cuh"
+#endif
+#endif
 
 namespace paddle {
 namespace operators {
@@ -121,6 +126,20 @@ elementwise_add_grad(const framework::ExecutionContext &ctx,
 #ifdef PADDLE_WITH_CUDA
 #ifdef __NVCC__
 
+template <typename T, int Size>
+struct alignas(sizeof(T) * Size) AlignedVector {
+  T val[Size];
+};
+
+template <typename T>
+inline int VectorizedSize(const T *pointer) {
+  uint64_t address = reinterpret_cast<uint64_t>(pointer);
+  constexpr int vec4 = std::alignment_of<AlignedVector<T, 4>>::value;  // NOLINT
+  if (address % vec4 == 0) {
+    return 4;
+  }
+  return 1;
+}
 template <typename T, int BLOCK_W, int BLOCK_H>
 __global__ void MatrixColReduce(const T *__restrict__ in, T *__restrict__ out,
                                 size_t width, size_t height) {
@@ -216,6 +235,29 @@ __global__ void MatrixReduceLongWidth(const T *__restrict__ in, T *out,
   }
 }
 
+template <typename T, int VEC_SIZE>
+__global__ void VecMatrixReduceLongWidth(const T *__restrict__ in, T *out,
+                                         size_t width, size_t height) {
+  using LoadT = AlignedVector<T, VEC_SIZE>;
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int w = idx * VEC_SIZE;
+  int width_stride = blockDim.x * gridDim.x * VEC_SIZE;
+  for (; w < width; w += width) {
+    T zero = static_cast<T>(0);
+    T sum[VEC_SIZE] = {zero};
+    T tmp_vec[VEC_SIZE] = {zero};
+    LoadT *tmp_ptr = reinterpret_cast<LoadT *>(&tmp_vec);
+    for (int row = 0; row < height; row++) {
+      int offset = width * row + w;
+      *tmp_ptr = *reinterpret_cast<const LoadT *>(&in[offset]);
+      for (int v = 0; v < VEC_SIZE; v++) {
+        sum[v] += tmp_vec[v];
+      }
+    }
+
+    for (int v = 0; v < VEC_SIZE; v++) out[w + v] = sum[v];
+  }
+}
 #endif
 #endif
 bool static RunSpecialDims(const framework::DDim &dx_dims,
@@ -319,17 +361,17 @@ class ElementwiseAddGradKernel : public ElemwiseGradKernel<T> {
       }
       // special optimization using cub
       if (width == 1) {
+        int nums = height;
         size_t temp_storage_bytes = 0;
-
-        auto err = cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, out_data,
-                                          size_prob, stream);
+        auto err = cub::DeviceReduce::Sum(nullptr, temp_storage_bytes,
+                                          dout_data, out_data, nums, stream);
         PADDLE_ENFORCE_CUDA_SUCCESS(err);
         framework::Tensor tmp;
         auto *temp_storage = tmp.mutable_data<uint8_t>(
             framework::make_ddim({static_cast<int64_t>(temp_storage_bytes)}),
-            context.GetPlace());
-        err = cub::DeviceReduce::Sum(temp_storage, temp_storage_bytes, out_data,
-                                     size_prob, stream);
+            ctx.GetPlace());
+        err = cub::DeviceReduce::Sum(temp_storage, temp_storage_bytes,
+                                     dout_data, out_data, nums, stream);
         PADDLE_ENFORCE_CUDA_SUCCESS(err);
       }
 
@@ -362,10 +404,18 @@ class ElementwiseAddGradKernel : public ElemwiseGradKernel<T> {
         MatrixColReduce<T, block_x, block_y><<<grids, blocks, 0, stream>>>(
             dout_data, out_data, width, height);
       } else {
-        size_t thread_nums = 128;
+        size_t thread_nums = 1024;
         size_t block_nums = (width + thread_nums - 1) / thread_nums;
-        MatrixReduceLongWidth<T><<<block_nums, thread_nums, 0, stream>>>(
-            dout_data, out_data, width, height);
+        int vec_size = VectorizedSize<T>(dx_data);
+        if (vec_size == 4 && width % 4 == 0) {
+          block_nums = (width / vec_size + thread_nums - 1) / thread_nums;
+          VecMatrixReduceLongWidth<T,
+                                   4><<<block_nums, thread_nums, 0, stream>>>(
+              dout_data, out_data, width, height);
+        } else {
+          MatrixReduceLongWidth<T><<<block_nums, thread_nums, 0, stream>>>(
+              dout_data, out_data, width, height);
+        }
       }
       return;
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
| 输入(x_shape)/y_shape | data type | develop|this PR|
|---|---|---|---|
| [32, 128, 728]/ [128, 728] | float16 |54.75us |14.78us|


精度对齐测试
```

===========================================================================
-- paddle version             : 0.0.0
-- paddle commit              : 443eb5a955dd518457c6d97edf62701d3a3d69a7
-- tensorflow version         : 2.3.0
-- benchmark commit           : 7e8b491f5911241f07ad0a3b796eacbdd57a53a5
-- benchmark last update time : Mon Dec 14 20:33:56 2020 +0800
===========================================================================
run command: /workspace/tmp/anaconda2/envs/py37/bin/python /workspace/work/benchmark/api/dynamic_tests_v2/elementwise.py --task accuracy --framework pytorch --testing_mode dynamic --json_file /workspace/work/benchmark/api/tests_v2/configs/elementwise.json --config_id 0 --check_output False --profiler none --backward True --use_gpu True --repeat 2 --allow_adaptive_repeat False --log_level 0
grep: warning: GREP_OPTIONS is deprecated; please use an alias or script
2020-12-15 11:25:18.876369: I tensorflow/stream_executor/platform/default/dso_loader.cc:48] Successfully opened dynamic library libcudart.so.10.1
W1215 11:25:26.151871 16750 device_context.cc:320] Please NOTE: device: 0, GPU Compute Capability: 7.0, Driver API Version: 11.0, Runtime API Version: 10.1
W1215 11:25:26.156766 16750 device_context.cc:330] device: 0, cuDNN Version: 7.6.
/workspace/tmp/anaconda2/envs/py37/lib/python3.7/site-packages/tensorflow/python/data/ops/iterator_ops.py:546: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
  class IteratorBase(collections.Iterator, trackable.Trackable,
/workspace/tmp/anaconda2/envs/py37/lib/python3.7/site-packages/tensorflow/python/autograph/utils/testing.py:21: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
---- Initialize APIConfig from /workspace/work/benchmark/api/tests_v2/configs/elementwise.json, config_id = 0.

[pytorch][elementwise] add {
  atol: 1e-05
  run_tf: True
  run_torch: True
  repeat: 5000
  axis: -1
  x_shape: [32, 128, 768]
  x_dtype: float16
  y_shape: [128, 768]
  y_dtype: float16
}
Successly import torch.add
[paddle][elementwise] add {
  atol: 1e-05
  run_tf: True
  run_torch: True
  repeat: 5000
  axis: -1
  x_shape: [32, 128, 768]
  x_dtype: float16
  y_shape: [128, 768]
  y_dtype: float16
}
Successly import paddle.add
{"name": "add", "device": "GPU", "backward": true, "consistent": true, "num_outputs": 3, "diff": 0.0, "parameters": "x (Variable) - dtype: float16, shape: [32, 128, 768]\ny (Variable) - dtype: float16, shape: [128, 768]\naxis (int): -1\n"}

```