### PR TITLE
[cherry-pick]Fix cache pip take a long time on windows CI

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -113,10 +113,9 @@ rem call paddle_winci\Scripts\activate.bat
 rem ------pre install python requirement----------
 where python
 where pip
-pip install --upgrade pip --user
 pip install wheel --user
-pip install -U -r %work_dir%\python\requirements.txt --user
-pip install -U -r %work_dir%\python\unittest_py\requirements.txt --user
+pip install -r %work_dir%\python\requirements.txt --user
+pip install -r %work_dir%\python\unittest_py\requirements.txt --user
 if %ERRORLEVEL% NEQ 0 (
     echo pip install requirements.txt failed!
     exit /b 7


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick https://github.com/PaddlePaddle/Paddle/pull/29618

Fix pip take a long time and failed on windows CI.

![image](https://user-images.githubusercontent.com/52485244/102180526-fdb61900-3ee3-11eb-8e4c-17608d50c3d7.png)
