### PR TITLE
[Cherry-pick] EnableUseGpu has higher priority than flags

### DIFF
--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -72,6 +72,7 @@ void AnalysisConfig::EnableUseGpu(uint64_t memory_pool_init_size_mb,
 #ifdef PADDLE_WITH_CUDA
   use_gpu_ = true;
   memory_pool_init_size_mb_ = memory_pool_init_size_mb;
+  FLAGS_initial_gpu_memory_in_mb = memory_pool_init_size_mb_;
   device_id_ = device_id;
 #else
   LOG(ERROR) << "Please compile with gpu to EnableGpu()";
@@ -492,7 +493,6 @@ float AnalysisConfig::fraction_of_gpu_memory_for_pool() const {
   double total_gpu_memory = gpu_total / 1024. / 1024.;
   float fraction_of_gpu_memory =
       static_cast<double>(memory_pool_init_size_mb()) / total_gpu_memory;
-  FLAGS_initial_gpu_memory_in_mb = memory_pool_init_size_mb();
   VLOG(3) << "total_gpu_memory is " << total_gpu_memory
           << "M, gpu_available is " << gpu_available / 1024. / 1024.
           << "M, memory_pool_init_size is " << memory_pool_init_size_mb()

--- a/paddle/fluid/inference/api/analysis_config.cc
+++ b/paddle/fluid/inference/api/analysis_config.cc
@@ -18,6 +18,10 @@
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/gpu_info.h"
 
+#ifdef PADDLE_WITH_CUDA
+DECLARE_uint64(initial_gpu_memory_in_mb);
+#endif
+
 namespace paddle {
 struct MkldnnQuantizerConfig;
 
@@ -482,12 +486,17 @@ float AnalysisConfig::fraction_of_gpu_memory_for_pool() const {
 #ifdef PADDLE_WITH_CUDA
   // Get the GPU memory details and calculate the fraction of memory for the
   // GPU memory pool.
-  size_t gpu_used, gpu_available;
+  size_t gpu_total, gpu_available;
   platform::SetDeviceId(device_id_);
-  platform::GpuMemoryUsage(&gpu_used, &gpu_available);
-  double total_gpu_memory = (gpu_used + gpu_available) / 1024. / 1024.;
+  platform::GpuMemoryUsage(&gpu_available, &gpu_total);
+  double total_gpu_memory = gpu_total / 1024. / 1024.;
   float fraction_of_gpu_memory =
       static_cast<double>(memory_pool_init_size_mb()) / total_gpu_memory;
+  FLAGS_initial_gpu_memory_in_mb = memory_pool_init_size_mb();
+  VLOG(3) << "total_gpu_memory is " << total_gpu_memory
+          << "M, gpu_available is " << gpu_available / 1024. / 1024.
+          << "M, memory_pool_init_size is " << memory_pool_init_size_mb()
+          << "M.";
   return fraction_of_gpu_memory;
 #else
   return 0.;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherry-pick https://github.com/PaddlePaddle/Paddle/pull/29697

修复C++下，EnableUseGpu(1000, 0) 实际分配显存不准确的问题。
修复python下，enable_use_gpu(1000, 0) 被FLAGS_fraction_of_gpu_memory_to_use覆盖的问题。
