### PR TITLE
Add approval monitor for unity_build_rule.cmake

### DIFF
--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -318,18 +318,20 @@ if [ "${HASUTFIXED}" != "" ]; then
   check_approval 1 52739577 46314656 12538138
 fi
 
-# NOTE(Avin0323): Files withe the name "unity_build_rule.cmake" are rules used
+# NOTE(Avin0323): Files with the name "unity_build_rule.cmake" are rules used
 # by Unity Build to combine source files. Changes to these rules may cause
-# errors in the compilation. Specific personnel are required to audit the
+# errors in the compilation. Specific personal are required to approve the
 # modification of these files.
 UNITYBUILD_RULE_CHANGED=$(git diff --name-only upstream/$BRANCH |
                           grep "unity_build_rule.cmake" || true)
 if [ -n "${UNITYBUILD_RULE_CHANGED}" -a -n "${GIT_PR_ID}" ]; then
-    echo_line="You must have one RD (Avin0323(Recommend) or luotao1) approval
-               for modifying unity_build_rule.cmake which the rules of Unity
-               Build."
+    echo_line="You must have one RD (Avin0323(Recommend) or zhouwei25 or
+               wanghuancoder or luotao1) approval for modifying
+               unity_build_rule.cmake which the rules of Unity Build."
     echo_line=$(echo ${echo_line})
-    check_approval 1 16167147 6836917
+    # Avin0323(16167147) zhouwei25(52485244)
+    # wanghuancoder(26922892) luotao1(6836917)
+    check_approval 1 16167147 52485244 26922892 6836917
 fi
 
 if [ -n "${echo_list}" ];then

--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -318,6 +318,20 @@ if [ "${HASUTFIXED}" != "" ]; then
   check_approval 1 52739577 46314656 12538138
 fi
 
+# NOTE(Avin0323): Files withe the name "unity_build_rule.cmake" are rules used
+# by Unity Build to combine source files. Changes to these rules may cause
+# errors in the compilation. Specific personnel are required to audit the
+# modification of these files.
+UNITYBUILD_RULE_CHANGED=$(git diff --name-only upstream/$BRANCH |
+                          grep "unity_build_rule.cmake" || true)
+if [ -n "${UNITYBUILD_RULE_CHANGED}" -a -n "${GIT_PR_ID}" ]; then
+    echo_line="You must have one RD (Avin0323(Recommend) or luotao1) approval
+               for modifying unity_build_rule.cmake which the rules of Unity
+               Build."
+    echo_line=$(echo ${echo_line})
+    check_approval 1 16167147 6836917
+fi
+
 if [ -n "${echo_list}" ];then
   echo "****************"
   echo -e "${echo_list[@]}"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
新增对`unity_build_rule.cmake`文件的监控，该文件负责管理Unity Build编译时文件组合规则。