### PR TITLE
Optimize compilation time with Unity Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,13 @@ if(WIN32)
         CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
         CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
         string(REGEX REPLACE "/W[1-4]" " /W0 " ${flag_var} "${${flag_var}}")
-        set(${flag_var} "${${flag_var}} /MP")
+        # NOTE(Avin0323): Less parallel count result in faster compilation with
+        # Unity Build.
+        if(WITH_UNITY_BUILD)
+            set(${flag_var} "${${flag_var}} /MP8")
+        else()
+            set(${flag_var} "${${flag_var}} /MP")
+        endif()
     endforeach(flag_var)
     foreach(flag_var CMAKE_CXX_FLAGS CMAKE_C_FLAGS)
         set(${flag_var} "${${flag_var}} /w")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,8 +87,8 @@ if(WIN32)
         CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
         string(REGEX REPLACE "/W[1-4]" " /W0 " ${flag_var} "${${flag_var}}")
         # NOTE(Avin0323): Less parallel count result in faster compilation with
-        # Unity Build.
-        if(WITH_UNITY_BUILD)
+        # Unity Build on GPU.
+        if(WITH_UNITY_BUILD AND WITH_GPU)
             set(${flag_var} "${${flag_var}} /MP8")
         else()
             set(${flag_var} "${${flag_var}} /MP")

--- a/paddle/fluid/operators/controlflow/unity_build_rule.cmake
+++ b/paddle/fluid/operators/controlflow/unity_build_rule.cmake
@@ -14,3 +14,7 @@ register_unity_group(cc
     logical_op.cc
     tensor_array_read_write_op.cc
     while_op.cc)
+register_unity_group(cu
+    logical_op.cu
+    compare_op.cu
+    compare_all_op.cu)

--- a/paddle/fluid/operators/optimizers/proximal_adagrad_op.h
+++ b/paddle/fluid/operators/optimizers/proximal_adagrad_op.h
@@ -20,9 +20,6 @@ namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
 
 template <typename DeviceContext, typename T>
 class ProximalAdagradOpKernel : public framework::OpKernel<T> {
@@ -38,13 +35,13 @@ class ProximalAdagradOpKernel : public framework::OpKernel<T> {
     auto l2 = static_cast<T>(ctx.Attr<float>("l2"));
 
     auto grad = ctx.Input<Tensor>("Grad");
-    auto p = EigenVector<T>::Flatten(*ctx.Input<Tensor>("Param"));
-    auto m = EigenVector<T>::Flatten(*ctx.Input<Tensor>("Moment"));
-    auto g = EigenVector<T>::Flatten(*grad);
-    auto lr = EigenVector<T>::Flatten(*ctx.Input<Tensor>("LearningRate"));
+    auto p = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("Param"));
+    auto m = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("Moment"));
+    auto g = framework::EigenVector<T>::Flatten(*grad);
+    auto lr = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("LearningRate"));
 
-    auto p_out = EigenVector<T>::Flatten(*param_out);
-    auto m_out = EigenVector<T>::Flatten(*moment_out);
+    auto p_out = framework::EigenVector<T>::Flatten(*param_out);
+    auto m_out = framework::EigenVector<T>::Flatten(*moment_out);
     auto* place = ctx.template device_context<DeviceContext>().eigen_device();
 
     Eigen::DSizes<int, 1> grad_dsize(grad->numel());

--- a/paddle/fluid/operators/optimizers/proximal_adagrad_op.h
+++ b/paddle/fluid/operators/optimizers/proximal_adagrad_op.h
@@ -38,7 +38,8 @@ class ProximalAdagradOpKernel : public framework::OpKernel<T> {
     auto p = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("Param"));
     auto m = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("Moment"));
     auto g = framework::EigenVector<T>::Flatten(*grad);
-    auto lr = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("LearningRate"));
+    auto lr =
+        framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("LearningRate"));
 
     auto p_out = framework::EigenVector<T>::Flatten(*param_out);
     auto m_out = framework::EigenVector<T>::Flatten(*moment_out);

--- a/paddle/fluid/operators/optimizers/proximal_gd_op.h
+++ b/paddle/fluid/operators/optimizers/proximal_gd_op.h
@@ -20,9 +20,6 @@ namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
 
 template <typename DeviceContext, typename T>
 class ProximalGDOpKernel : public framework::OpKernel<T> {
@@ -37,11 +34,12 @@ class ProximalGDOpKernel : public framework::OpKernel<T> {
     auto l1 = static_cast<T>(ctx.Attr<float>("l1"));
     auto l2 = static_cast<T>(ctx.Attr<float>("l2"));
 
-    auto p = EigenVector<T>::Flatten(*ctx.Input<Tensor>("Param"));
-    auto g = EigenVector<T>::Flatten(*grad);
-    auto lr = EigenVector<T>::Flatten(*ctx.Input<Tensor>("LearningRate"));
+    auto p = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("Param"));
+    auto g = framework::EigenVector<T>::Flatten(*grad);
+    auto lr = framework::EigenVector<T>::Flatten(
+            *ctx.Input<Tensor>("LearningRate"));
 
-    auto p_out = EigenVector<T>::Flatten(*param_out);
+    auto p_out = framework::EigenVector<T>::Flatten(*param_out);
     auto& place = *ctx.template device_context<DeviceContext>().eigen_device();
 
     Eigen::DSizes<int, 1> grad_dsize(grad->numel());
@@ -52,10 +50,10 @@ class ProximalGDOpKernel : public framework::OpKernel<T> {
           prox_param.sign() *
           (((prox_param.abs() - (lr * l1).broadcast(grad_dsize))
                 .cwiseMax(T(0.0))) /
-           (1.0 + (lr * l2).broadcast(grad_dsize)));
+           (1.0f + (lr * l2).broadcast(grad_dsize)));
     } else {
       p_out.device(place) =
-          prox_param / (1.0 + (lr * l2).broadcast(grad_dsize));
+          prox_param / (1.0f + (lr * l2).broadcast(grad_dsize));
     }
   }
 };

--- a/paddle/fluid/operators/optimizers/proximal_gd_op.h
+++ b/paddle/fluid/operators/optimizers/proximal_gd_op.h
@@ -36,8 +36,8 @@ class ProximalGDOpKernel : public framework::OpKernel<T> {
 
     auto p = framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("Param"));
     auto g = framework::EigenVector<T>::Flatten(*grad);
-    auto lr = framework::EigenVector<T>::Flatten(
-            *ctx.Input<Tensor>("LearningRate"));
+    auto lr =
+        framework::EigenVector<T>::Flatten(*ctx.Input<Tensor>("LearningRate"));
 
     auto p_out = framework::EigenVector<T>::Flatten(*param_out);
     auto& place = *ctx.template device_context<DeviceContext>().eigen_device();

--- a/paddle/fluid/operators/optimizers/rmsprop_op.h
+++ b/paddle/fluid/operators/optimizers/rmsprop_op.h
@@ -23,10 +23,6 @@ limitations under the License. */
 namespace paddle {
 namespace operators {
 
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
-
 template <typename T>
 struct DenseRmspropGradFunctor {
   inline explicit DenseRmspropGradFunctor(const T *grad) : grad_(grad) {}
@@ -169,25 +165,25 @@ class RmspropOpKernel : public framework::OpKernel<T> {
             *ctx.template device_context<DeviceContext>().eigen_device();
         auto lr_value = lr_tensor.data<T>()[0];
 
-        auto p = EigenVector<T>::Flatten(p_tensor);
-        auto ms = EigenVector<T>::Flatten(ms_tensor);
-        auto g = EigenVector<T>::Flatten(grad_tensor);
-        auto mom = EigenVector<T>::Flatten(mom_tensor);
+        auto p = framework::EigenVector<T>::Flatten(p_tensor);
+        auto ms = framework::EigenVector<T>::Flatten(ms_tensor);
+        auto g = framework::EigenVector<T>::Flatten(grad_tensor);
+        auto mom = framework::EigenVector<T>::Flatten(mom_tensor);
 
-        auto p_out = EigenVector<T>::Flatten(*param_out);
-        auto mom_out = EigenVector<T>::Flatten(*moment_out);
-        auto ms_out = EigenVector<T>::Flatten(*mean_square_out);
+        auto p_out = framework::EigenVector<T>::Flatten(*param_out);
+        auto mom_out = framework::EigenVector<T>::Flatten(*moment_out);
+        auto ms_out = framework::EigenVector<T>::Flatten(*mean_square_out);
 
         ms_out.device(place) = rho * ms + (1 - rho) * g * g;
         if (centered) {
           auto &mg_tensor = *ctx.Input<LoDTensor>("MeanGrad");
-          auto mg = EigenVector<T>::Flatten(mg_tensor);
+          auto mg = framework::EigenVector<T>::Flatten(mg_tensor);
           auto *mean_grad_out = ctx.Output<LoDTensor>("MeanGradOut");
           PADDLE_ENFORCE_EQ(
               &mg_tensor, mean_grad_out,
               platform::errors::InvalidArgument(
                   "MeanGrad and MeanGradOut must be the same Tensor"));
-          auto mg_out = EigenVector<T>::Flatten(*mean_grad_out);
+          auto mg_out = framework::EigenVector<T>::Flatten(*mean_grad_out);
 
           mg_out.device(place) = rho * mg + (1 - rho) * g;
           mom_out.device(place) =

--- a/paddle/fluid/operators/optimizers/unity_build_rule.cmake
+++ b/paddle/fluid/operators/optimizers/unity_build_rule.cmake
@@ -8,14 +8,13 @@ register_unity_group(cc
     ftrl_op.cc
     lars_momentum_op.cc
     momentum_op.cc
-    sgd_op.cc)
-register_unity_group(cc
+    sgd_op.cc
+    proximal_adagrad_op.cc
     adagrad_op.cc
     adam_op.cc
     adamax_op.cc
     dgc_momentum_op.cc
-    proximal_gd_op.cc)
-register_unity_group(cc
+    proximal_gd_op.cc
     decayed_adagrad_op.cc
     adadelta_op.cc
     lamb_op.cc
@@ -25,16 +24,12 @@ register_unity_group(cu
     ftrl_op.cu
     lars_momentum_op.cu
     momentum_op.cu
-    sgd_op.cu)
-register_unity_group(cu
+    sgd_op.cu
+    proximal_adagrad_op.cu
     adagrad_op.cu
     adam_op.cu
-    adamax_op.cu)
-register_unity_group(cu
+    adamax_op.cu
     decayed_adagrad_op.cu
     adadelta_op.cu
     lamb_op.cu
     rmsprop_op.cu)
-# The following groups are to make better use of `/MP` which MSVC's parallel
-# compilation instruction when compiling in Unity Build.
-register_unity_group(cu proximal_adagrad_op.cu)

--- a/paddle/fluid/operators/sequence_ops/sequence_concat_op.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_concat_op.cc
@@ -133,16 +133,18 @@ namespace op = paddle::operators;
 REGISTER_OPERATOR(sequence_concat, op::SequenceConcatOp, op::SeqConcatOpMaker,
                   op::SeqConcatGradOpMaker<paddle::framework::OpDesc>,
                   op::SeqConcatGradOpMaker<paddle::imperative::OpBase>);
-template <typename T>
-using Kernel = op::SeqConcatKernel<paddle::platform::CPUDeviceContext, T>;
-REGISTER_OP_CPU_KERNEL(sequence_concat, Kernel<float>, Kernel<double>,
-                       Kernel<int>, Kernel<int64_t>);
+REGISTER_OP_CPU_KERNEL(
+    sequence_concat,
+    op::SeqConcatKernel<paddle::platform::CPUDeviceContext, float>,
+    op::SeqConcatKernel<paddle::platform::CPUDeviceContext, double>,
+    op::SeqConcatKernel<paddle::platform::CPUDeviceContext, int>,
+    op::SeqConcatKernel<paddle::platform::CPUDeviceContext, int64_t>);
 
 REGISTER_OPERATOR(sequence_concat_grad, op::SeqConcatGradOp,
                   op::SeqConcatGradNoNeedBufferVarsInferer);
-template <typename T>
-using GradKernel =
-    op::SeqConcatGradKernel<paddle::platform::CPUDeviceContext, T>;
-REGISTER_OP_CPU_KERNEL(sequence_concat_grad, GradKernel<float>,
-                       GradKernel<double>, GradKernel<int>,
-                       GradKernel<int64_t>);
+REGISTER_OP_CPU_KERNEL(
+    sequence_concat_grad,
+    op::SeqConcatGradKernel<paddle::platform::CPUDeviceContext, float>,
+    op::SeqConcatGradKernel<paddle::platform::CPUDeviceContext, double>,
+    op::SeqConcatGradKernel<paddle::platform::CPUDeviceContext, int>,
+    op::SeqConcatGradKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/sequence_ops/sequence_concat_op.cu.cc
+++ b/paddle/fluid/operators/sequence_ops/sequence_concat_op.cu.cc
@@ -21,15 +21,23 @@ class CUDADeviceContext;
 }  // namespace platform
 }  // namespace paddle
 
-template <typename T>
-using Kernel =
-    paddle::operators::SeqConcatKernel<paddle::platform::CUDADeviceContext, T>;
-REGISTER_OP_CUDA_KERNEL(sequence_concat, Kernel<float>, Kernel<double>,
-                        Kernel<int>, Kernel<int64_t>);
-template <typename T>
-using GradKernel =
+REGISTER_OP_CUDA_KERNEL(
+    sequence_concat,
+    paddle::operators::SeqConcatKernel<paddle::platform::CUDADeviceContext,
+                                       float>,
+    paddle::operators::SeqConcatKernel<paddle::platform::CUDADeviceContext,
+                                       double>,
+    paddle::operators::SeqConcatKernel<paddle::platform::CUDADeviceContext,
+                                       int>,
+    paddle::operators::SeqConcatKernel<paddle::platform::CUDADeviceContext,
+                                       int64_t>);
+REGISTER_OP_CUDA_KERNEL(
+    sequence_concat_grad,
     paddle::operators::SeqConcatGradKernel<paddle::platform::CUDADeviceContext,
-                                           T>;
-REGISTER_OP_CUDA_KERNEL(sequence_concat_grad, GradKernel<float>,
-                        GradKernel<double>, GradKernel<int>,
-                        GradKernel<int64_t>);
+                                           float>,
+    paddle::operators::SeqConcatGradKernel<paddle::platform::CUDADeviceContext,
+                                           double>,
+    paddle::operators::SeqConcatGradKernel<paddle::platform::CUDADeviceContext,
+                                           int>,
+    paddle::operators::SeqConcatGradKernel<paddle::platform::CUDADeviceContext,
+                                           int64_t>);

--- a/paddle/fluid/operators/sequence_ops/sequence_expand_as_op.cu
+++ b/paddle/fluid/operators/sequence_ops/sequence_expand_as_op.cu
@@ -62,7 +62,7 @@ static __global__ void sequence_expand_as_grad_kernel(
 }
 
 template <typename T>
-struct SequenceExpandFunctor<platform::CUDADeviceContext, T> {
+struct SequenceExpandAsFunctor<platform::CUDADeviceContext, T> {
   void operator()(
       const platform::CUDADeviceContext &context, const LoDTensor &x,
       const framework::Vector<size_t> &ref_lod, /*expand referenced lod*/

--- a/paddle/fluid/operators/sequence_ops/sequence_expand_as_op.h
+++ b/paddle/fluid/operators/sequence_ops/sequence_expand_as_op.h
@@ -24,7 +24,7 @@ namespace paddle {
 namespace operators {
 
 template <typename DeviceContext, typename T>
-struct SequenceExpandFunctor {
+struct SequenceExpandAsFunctor {
   void operator()(
       const DeviceContext &ctx, const framework::LoDTensor &x,
       const framework::Vector<size_t> &ref_lod, /*expand referenced lod*/
@@ -40,7 +40,7 @@ struct SequenceExpandAsGradFunctor {
 };
 
 template <typename T>
-struct SequenceExpandFunctor<platform::CPUDeviceContext, T> {
+struct SequenceExpandAsFunctor<platform::CPUDeviceContext, T> {
   void operator()(
       const platform::CPUDeviceContext &context, const framework::LoDTensor &x,
       const framework::Vector<size_t> &ref_lod, /*expand referenced lod*/
@@ -97,7 +97,7 @@ class SequenceExpandAsKernel : public framework::OpKernel<T> {
     out->mutable_data<T>(context.GetPlace());
 
     auto &dev_ctx = context.template device_context<DeviceContext>();
-    SequenceExpandFunctor<DeviceContext, T> seq_espand_functor;
+    SequenceExpandAsFunctor<DeviceContext, T> seq_espand_functor;
     seq_espand_functor(dev_ctx, *x, y_lod[0], out);
   }
 };

--- a/paddle/fluid/operators/sequence_ops/unity_build_rule.cmake
+++ b/paddle/fluid/operators/sequence_ops/unity_build_rule.cmake
@@ -12,8 +12,7 @@ register_unity_group(cc
     sequence_expand_op.cc
     sequence_mask_op.cc
     sequence_pad_op.cc
-    sequence_pool_op.cc)
-register_unity_group(cc
+    sequence_pool_op.cc
     sequence_expand_as_op.cc
     sequence_reshape_op.cc
     sequence_reverse_op.cc
@@ -21,8 +20,7 @@ register_unity_group(cc
     sequence_slice_op.cc
     sequence_softmax_op.cc
     sequence_topk_avg_pooling_op.cc
-    sequence_unpad_op.cc)
-register_unity_group(cc
+    sequence_unpad_op.cc
     sequence_concat_op.cu.cc
     sequence_conv_op.cu.cc)
 register_unity_group(cu
@@ -31,8 +29,7 @@ register_unity_group(cu
     sequence_expand_op.cu
     sequence_mask_op.cu
     sequence_pad_op.cu
-    sequence_pool_op.cu)
-register_unity_group(cu
+    sequence_pool_op.cu
     sequence_expand_as_op.cu
     sequence_reshape_op.cu
     sequence_reverse_op.cu

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -253,6 +253,11 @@ echo    Step 2. Buile Paddle ...
 echo    ========================================
 
 for /F %%# in ('wmic cpu get NumberOfLogicalProcessors^|findstr [0-9]') do set /a PARALLEL_PROJECT_COUNT=%%#*9/10
+:: NOTE(Avin0323): Less `PARALLEL_PROJECT_COUNT` result in faster compilation
+:: with Unity Build.
+if "%WITH_UNITY_BUILD%" EQU "ON" (
+    if %PARALLEL_PROJECT_COUNT% GTR 6 set PARALLEL_PROJECT_COUNT=6
+)
 set build_times=1
 :build_tp
 echo Build third_party the %build_times% time:

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -256,7 +256,7 @@ for /F %%# in ('wmic cpu get NumberOfLogicalProcessors^|findstr [0-9]') do set /
 :: NOTE(Avin0323): Less `PARALLEL_PROJECT_COUNT` result in faster compilation
 :: with Unity Build.
 if "%WITH_UNITY_BUILD%" EQU "ON" (
-    if %PARALLEL_PROJECT_COUNT% GTR 6 set PARALLEL_PROJECT_COUNT=6
+    if %PARALLEL_PROJECT_COUNT% GTR 8 set PARALLEL_PROJECT_COUNT=8
 )
 set build_times=1
 :build_tp

--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -253,11 +253,6 @@ echo    Step 2. Buile Paddle ...
 echo    ========================================
 
 for /F %%# in ('wmic cpu get NumberOfLogicalProcessors^|findstr [0-9]') do set /a PARALLEL_PROJECT_COUNT=%%#*9/10
-:: NOTE(Avin0323): Less `PARALLEL_PROJECT_COUNT` result in faster compilation
-:: with Unity Build.
-if "%WITH_UNITY_BUILD%" EQU "ON" (
-    if %PARALLEL_PROJECT_COUNT% GTR 8 set PARALLEL_PROJECT_COUNT=8
-)
 set build_times=1
 :build_tp
 echo Build third_party the %build_times% time:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
1. 通过修改代码中重复声明、定义等方式使更多源文件支持Unity Build编译，优化Unity Build的编译时间。

- 本次主要涉及`optimizers`、`sequence_ops`、`controlflow`三个目录下的文件；

2. 在windows GPU编译时，限制`/MP`的参数，可以达到较稳定的编译时间；

MSVC构建系统在并行编译时，

首先会并行n个target进行编译（n的取值会根据指定参数设置`msbuild /m:n`，或者自动取机器核数），

然后每个target再并行m个编译单元进行编译（m的取值可以指定参数设置`cl /MP8`，或者自动取机器核数与源文件数量的最小值），

如果target下源文件数量较多，则会导致编译单元过多造成编译任务在CPU等资源的抢占，导致编译时间的增加。在UB场景下需要限制target并行编译源文件的数量来保证编译效率。