### PR TITLE
Avoid the scale to be infinity in quant2_int8_mkldnn_pass

### DIFF
--- a/python/paddle/fluid/contrib/slim/tests/test_quant2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/tests/test_quant2_int8_mkldnn_pass.py
@@ -187,9 +187,9 @@ class TestQuant2Int8MkldnnPass(unittest.TestCase):
 
             assert np.allclose(
                 self.scope.find_var("mul_weights").get_tensor(),
-                [[127, 63.5, 42.3333, 31.75, 25.4],
-                 [127, 63.5, 42.3333, 31.75, 25.4],
-                 [127, 63.5, 42.3333, 31.75, 25.4]])
+                [[1. / 127., 2. / 127., 3. / 127., 4. / 127., 5. / 127.],
+                 [1. / 127., 2. / 127., 3. / 127., 4. / 127., 5. / 127.],
+                 [1. / 127., 2. / 127., 3. / 127., 4. / 127., 5. / 127.]])
 
             param = self.scope.var("mul_weights").get_tensor()
             param.set(self.variables_mul["mul_weights_bad"], self.place)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Avoid the scale to be infinity in quant2_int8_mkldnn_pass.

When the weight is per-channel quantized, gather the threshold instead of `s8_max * s8_max / threshold`.