### PR TITLE
Complex op test

### DIFF
--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -1544,6 +1544,10 @@ class OpTest(unittest.TestCase):
                 grad_outputs = []
                 for grad_out_value in user_defined_grad_outputs:
                     grad_outputs.append(paddle.to_tensor(grad_out_value))
+                # delete the inputs which no need to calculate grad
+                for no_grad_val in no_grad_set:
+                    del(inputs[no_grad_val])
+
                 grad_inputs = paddle.grad(
                     outputs=fluid.layers.utils.flatten(outputs),
                     inputs=fluid.layers.utils.flatten(inputs),

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -1546,7 +1546,7 @@ class OpTest(unittest.TestCase):
                     grad_outputs.append(paddle.to_tensor(grad_out_value))
                 # delete the inputs which no need to calculate grad
                 for no_grad_val in no_grad_set:
-                    del(inputs[no_grad_val])
+                    del (inputs[no_grad_val])
 
                 grad_inputs = paddle.grad(
                     outputs=fluid.layers.utils.flatten(outputs),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
In dygraph mode of op_test, the inputs arg of paddle.grad API's args is all the input vars. The no_grad_set arg is useless.  This PR fix this bug.