### PR TITLE
update the operator registration, test=release/2.0

### DIFF
--- a/paddle/fluid/framework/op_version_registry.cc
+++ b/paddle/fluid/framework/op_version_registry.cc
@@ -62,6 +62,37 @@ OpVersionDesc&& OpVersionDesc::BugfixWithBehaviorChanged(
   return std::move(*this);
 }
 
+OpVersionDesc&& OpVersionDesc::DeleteAttr(const std::string& name,
+                                          const std::string& remark) {
+  infos_.emplace_back(
+      new_update<OpUpdateType::kDeleteAttr>(OpAttrInfo(name, remark)));
+  return std::move(*this);
+}
+OpVersionDesc&& OpVersionDesc::ModifyInput(const std::string& name,
+                                           const std::string& remark) {
+  infos_.emplace_back(
+      new_update<OpUpdateType::kModifyInput>(OpInputOutputInfo(name, remark)));
+  return std::move(*this);
+}
+OpVersionDesc&& OpVersionDesc::ModifyOutput(const std::string& name,
+                                            const std::string& remark) {
+  infos_.emplace_back(
+      new_update<OpUpdateType::kModifyOutput>(OpInputOutputInfo(name, remark)));
+  return std::move(*this);
+}
+OpVersionDesc&& OpVersionDesc::DeleteInput(const std::string& name,
+                                           const std::string& remark) {
+  infos_.emplace_back(
+      new_update<OpUpdateType::kDeleteInput>(OpInputOutputInfo(name, remark)));
+  return std::move(*this);
+}
+OpVersionDesc&& OpVersionDesc::DeleteOutput(const std::string& name,
+                                            const std::string& remark) {
+  infos_.emplace_back(
+      new_update<OpUpdateType::kDeleteOutput>(OpInputOutputInfo(name, remark)));
+  return std::move(*this);
+}
+
 OpVersion& OpVersionRegistrar::Register(const std::string& op_type) {
   PADDLE_ENFORCE_EQ(
       op_version_map_.find(op_type), op_version_map_.end(),

--- a/paddle/fluid/framework/op_version_registry_test.cc
+++ b/paddle/fluid/framework/op_version_registry_test.cc
@@ -53,6 +53,19 @@ TEST(test_operator_version, test_operator_version) {
           framework::compatible::OpVersionDesc()
               .NewInput("X2", "The second input.")
               .NewOutput("Y2", "The second output."));
+
+  REGISTER_OP_VERSION(op_name_0__)
+      .AddCheckpoint(
+          R"ROC(
+        Incompatible upgrade of attribute [height], input [X2] and output [Y2]
+      )ROC",
+          framework::compatible::OpVersionDesc()
+              .DeleteAttr("height",
+                          "Parameters deleted due to interface alignment.")
+              .ModifyInput("X2", "Modify input due to interface alignment.")
+              .ModifyOutput("Y2", "Modify output due to interface alignment.")
+              .DeleteInput("X2", "Delete input due to interface alignment.")
+              .DeleteOutput("Y2", "Delete output due to interface alignment."));
 }
 
 TEST(test_pass_op_version_checker, test_pass_op_version_checker) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
 cherry-pick of #29720 
为了标注哪些算子进行过不兼容升级，在注册机制中加入了这些类别。不兼容升级类型仅限于存量不兼容版本记录，不用于引入不兼容情况的版本新增：任何新增的不兼容算子升级都会被 CI 禁止，即使进行了注册也不可以。