### PR TITLE
[cherry-pick 2.0]enable MakeCiper api for inference;test=develop (#29692)

### DIFF
--- a/paddle/fluid/framework/io/crypto/cipher.cc
+++ b/paddle/fluid/framework/io/crypto/cipher.cc
@@ -56,9 +56,16 @@ std::shared_ptr<Cipher> CipherFactory::CreateCipher(
 }
 
 }  // namespace framework
-#ifdef PADDLE_ON_INFERENCE
+
 std::shared_ptr<framework::Cipher> MakeCipher(const std::string& config_file) {
+#ifdef PADDLE_ON_INFERENCE
   return framework::CipherFactory::CreateCipher(config_file);
-}
+#else
+  PADDLE_THROW(platform::errors::Unavailable(
+      "Cipher API is not available, should not reach here. Please re-compile "
+      "with ON_INFER=ON."));
+  return nullptr;
 #endif
+}
+
 }  // namespace paddle

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SHARED_INFERENCE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/api/analysis_predictor.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/details/zero_copy_tensor.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/io_utils.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../framework/io/crypto/cipher.cc
     ${mkldnn_quantizer_src_file})
 
 # Create shared inference library defaultly

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -450,4 +450,9 @@ PD_INFER_DECL std::string get_version();
 
 PD_INFER_DECL std::string UpdateDllFlag(const char* name, const char* value);
 
+#ifdef PADDLE_ON_INFERENCE
+PD_INFER_DECL std::shared_ptr<framework::Cipher> MakeCipher(
+    const std::string& config_file);
+#endif
+
 }  // namespace paddle

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -450,9 +450,7 @@ PD_INFER_DECL std::string get_version();
 
 PD_INFER_DECL std::string UpdateDllFlag(const char* name, const char* value);
 
-#ifdef PADDLE_ON_INFERENCE
 PD_INFER_DECL std::shared_ptr<framework::Cipher> MakeCipher(
     const std::string& config_file);
-#endif
 
 }  // namespace paddle


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
#29692 
支持模型加密的MakeCipher接口暴露到inference lib api