### PR TITLE
[Kunlun] add unittesets supported kunlun xpu devices based on TestParallelExecutorBase

### DIFF
--- a/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
+++ b/python/paddle/fluid/tests/unittests/parallel_executor_test_base.py
@@ -30,11 +30,17 @@ from feed_data_reader import FeedDataReader
 __all__ = ['TestParallelExecutorBase']
 
 
+class DeviceType:
+    CPU = 1
+    GPU = 2
+    XPU = 3
+
+
 class TestParallelExecutorBase(unittest.TestCase):
     @classmethod
     def check_network_convergence(cls,
                                   method,
-                                  use_cuda=True,
+                                  use_device=DeviceType.GPU,
                                   iter=5,
                                   batch_size=None,
                                   feed_dict=None,
@@ -74,7 +80,9 @@ class TestParallelExecutorBase(unittest.TestCase):
             feed_dict, loss = cls.build_model(feed_dict, get_data_from_feeder,
                                               main, method, optimizer)
 
-        place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
+        place = fluid.CUDAPlace(
+            0) if use_device == DeviceType.GPU else fluid.XPUPlace(
+                0) if use_device == DeviceType.XPU else fluid.CPUPlace()
         exe = fluid.Executor(place)
         exe.run(startup)
 
@@ -82,7 +90,7 @@ class TestParallelExecutorBase(unittest.TestCase):
             enable_inplace, enable_sequential_execution, fuse_all_optimizer_ops,
             fuse_all_reduce_ops, fuse_elewise_add_act_ops,
             fuse_relu_depthwise_conv, use_fast_executor, use_ir_memory_optimize,
-            use_reduce, use_cuda)
+            use_reduce, use_device)
 
         if use_parallel_executor:
             binary = compiler.CompiledProgram(main).with_data_parallel(
@@ -94,7 +102,8 @@ class TestParallelExecutorBase(unittest.TestCase):
 
         if batch_size is not None:
             batch_size *= fluid.core.get_cuda_device_count(
-            ) if use_cuda else int(
+            ) if use_device == DeviceType.GPU else fluid.core.get_xpu_device_count(
+            ) if use_device == DeviceType.XPU else int(
                 os.environ.get('CPU_NUM', multiprocessing.cpu_count()))
 
         begin = time.time()
@@ -123,7 +132,7 @@ class TestParallelExecutorBase(unittest.TestCase):
     @classmethod
     def check_pass_conflict(cls,
                             method,
-                            use_cuda=True,
+                            use_device=DeviceType.GPU,
                             feed_dict=None,
                             get_data_from_feeder=None,
                             use_reduce=False,
@@ -143,7 +152,9 @@ class TestParallelExecutorBase(unittest.TestCase):
             feed_dict, loss = cls.build_model(feed_dict, get_data_from_feeder,
                                               main, method, optimizer)
 
-        place = fluid.CUDAPlace(0) if use_cuda else fluid.CPUPlace()
+        place = fluid.CUDAPlace(
+            0) if use_device == DeviceType.GPU else fluid.XPUPlace(
+                0) if use_device == DeviceType.XPU else fluid.CPUPlace()
         exe = fluid.Executor(place)
         exe.run(startup)
 
@@ -151,7 +162,7 @@ class TestParallelExecutorBase(unittest.TestCase):
             enable_inplace, enable_sequential_execution, fuse_all_optimizer_ops,
             fuse_all_reduce_ops, fuse_elewise_add_act_ops,
             fuse_relu_depthwise_conv, use_fast_executor, use_ir_memory_optimize,
-            use_reduce, use_cuda)
+            use_reduce, use_device)
 
         binary = compiler.CompiledProgram(main).with_data_parallel(
             loss_name=loss.name,
@@ -165,7 +176,7 @@ class TestParallelExecutorBase(unittest.TestCase):
                      fuse_all_optimizer_ops, fuse_all_reduce_ops,
                      fuse_elewise_add_act_ops, fuse_relu_depthwise_conv,
                      use_fast_executor, use_ir_memory_optimize, use_reduce,
-                     use_cuda):
+                     use_device):
         exec_strategy = fluid.ExecutionStrategy()
         if use_fast_executor:
             exec_strategy.use_experimental_executor = True
@@ -180,8 +191,17 @@ class TestParallelExecutorBase(unittest.TestCase):
         build_strategy.enable_inplace = enable_inplace
         build_strategy.enable_sequential_execution = enable_sequential_execution
 
-        if use_cuda and core.is_compiled_with_cuda():
+        if use_device == DeviceType.GPU and core.is_compiled_with_cuda():
             build_strategy.remove_unnecessary_lock = True
+        if use_device == DeviceType.XPU and core.is_compiled_with_xpu():
+            build_strategy.fuse_elewise_add_act_ops = False
+            build_strategy.fuse_relu_depthwise_conv = False
+            build_strategy.fuse_all_optimizer_ops = False
+            build_strategy.fuse_all_reduce_ops = False
+            build_strategy.memory_optimize = False
+            build_strategy.enable_inplace = False
+            build_strategy.enable_sequential_execution = False
+
         return build_strategy, exec_strategy
 
     @classmethod

--- a/python/paddle/fluid/tests/unittests/seresnext_net.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_net.py
@@ -19,6 +19,7 @@ fluid.core._set_eager_deletion_mode(-1, -1, False)
 import paddle.fluid.layers.ops as ops
 from paddle.fluid.layers.learning_rate_scheduler import cosine_decay
 from simple_nets import init_data
+from seresnext_test_base import DeviceType
 import math
 import os
 os.environ['CPU_NUM'] = str(4)
@@ -169,28 +170,32 @@ def optimizer(learning_rate=0.01):
 model = SE_ResNeXt50Small
 
 
-def batch_size(use_cuda):
-    if use_cuda:
+def batch_size(use_device):
+    if use_device == DeviceType.GPU:
         # Paddle uses 8GB P4 GPU for unittest so we decreased the batch size.
         return 8
     return 12
 
 
-def iter(use_cuda):
-    if use_cuda:
+def iter(use_device):
+    if use_device == DeviceType.GPU:
         return 10
     return 1
 
 
 gpu_img, gpu_label = init_data(
-    batch_size=batch_size(use_cuda=True), img_shape=img_shape, label_range=999)
+    batch_size=batch_size(use_device=DeviceType.GPU),
+    img_shape=img_shape,
+    label_range=999)
 cpu_img, cpu_label = init_data(
-    batch_size=batch_size(use_cuda=False), img_shape=img_shape, label_range=999)
+    batch_size=batch_size(use_device=DeviceType.CPU),
+    img_shape=img_shape,
+    label_range=999)
 feed_dict_gpu = {"image": gpu_img, "label": gpu_label}
 feed_dict_cpu = {"image": cpu_img, "label": cpu_label}
 
 
-def feed_dict(use_cuda):
-    if use_cuda:
+def feed_dict(use_device):
+    if use_device == DeviceType.GPU:
         return feed_dict_gpu
     return feed_dict_cpu

--- a/python/paddle/fluid/tests/unittests/seresnext_test_base.py
+++ b/python/paddle/fluid/tests/unittests/seresnext_test_base.py
@@ -15,34 +15,35 @@
 from __future__ import print_function
 import seresnext_net
 import paddle.fluid.core as core
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
+from parallel_executor_test_base import DeviceType
 import numpy as np
 
 
 class TestResnetBase(TestParallelExecutorBase):
     def _compare_result_with_origin_model(self,
                                           check_func,
-                                          use_cuda,
+                                          use_device,
                                           delta2=1e-5,
                                           compare_seperately=True):
-        if use_cuda and not core.is_compiled_with_cuda():
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         func_1_first_loss, func_1_last_loss = self.check_network_convergence(
             seresnext_net.model,
-            feed_dict=seresnext_net.feed_dict(use_cuda),
-            iter=seresnext_net.iter(use_cuda),
-            batch_size=seresnext_net.batch_size(use_cuda),
-            use_cuda=use_cuda,
+            feed_dict=seresnext_net.feed_dict(use_device),
+            iter=seresnext_net.iter(use_device),
+            batch_size=seresnext_net.batch_size(use_device),
+            use_device=use_device,
             use_reduce=False,
             optimizer=seresnext_net.optimizer)
 
         func_2_first_loss, func_2_last_loss = check_func(
             seresnext_net.model,
-            feed_dict=seresnext_net.feed_dict(use_cuda),
-            iter=seresnext_net.iter(use_cuda),
-            batch_size=seresnext_net.batch_size(use_cuda),
-            use_cuda=use_cuda)
+            feed_dict=seresnext_net.feed_dict(use_device),
+            iter=seresnext_net.iter(use_device),
+            batch_size=seresnext_net.batch_size(use_device),
+            use_device=use_device)
 
         if compare_seperately:
             for loss in zip(func_1_first_loss, func_2_first_loss):

--- a/python/paddle/fluid/tests/unittests/test_fuse_all_reduce_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_all_reduce_pass.py
@@ -14,7 +14,7 @@
 
 from simple_nets import simple_fc_net, fc_with_batchnorm, init_data, bow_net
 from fake_reader import fake_imdb_reader
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 from functools import partial
@@ -30,12 +30,12 @@ class TestFuseAllReduceOpsBase(TestParallelExecutorBase):
 
     def compare_fuse_all_reduce_ops(self,
                                     model,
-                                    use_cuda,
+                                    use_device,
                                     init_feed_dict=None,
                                     get_data_from_feeder=None,
                                     optimizer=None,
                                     fuse_all_optimizer_ops=False):
-        if use_cuda and not core.is_compiled_with_cuda():
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         feed_dict_data = None
@@ -47,7 +47,7 @@ class TestFuseAllReduceOpsBase(TestParallelExecutorBase):
             model,
             feed_dict=feed_dict_data,
             get_data_from_feeder=get_data_from_feeder,
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_all_reduce_ops=False,
             fuse_all_optimizer_ops=fuse_all_optimizer_ops,
             optimizer=optimizer)
@@ -55,7 +55,7 @@ class TestFuseAllReduceOpsBase(TestParallelExecutorBase):
             model,
             feed_dict=feed_dict_data,
             get_data_from_feeder=get_data_from_feeder,
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_all_reduce_ops=True,
             fuse_all_optimizer_ops=fuse_all_optimizer_ops,
             optimizer=optimizer)
@@ -73,28 +73,30 @@ class TestFuseAllReduceOpsBase(TestParallelExecutorBase):
 
 
 class TestFuseAllReduceOps(TestFuseAllReduceOpsBase):
-    def _decorate_compare_fused_all_reduce(self, model, use_cuda):
+    def _decorate_compare_fused_all_reduce(self, model, use_device):
         self.compare_fuse_all_reduce_ops(
             model,
-            use_cuda,
+            use_device,
             init_feed_dict=init_data,
             optimizer=self.optimizer,
             fuse_all_optimizer_ops=True)
 
     def test_simple_fc_with_fuse_all_reduce(self):
-        self._decorate_compare_fused_all_reduce(simple_fc_net, True)
-        self._decorate_compare_fused_all_reduce(simple_fc_net, False)
+        self._decorate_compare_fused_all_reduce(simple_fc_net, DeviceType.GPU)
+        self._decorate_compare_fused_all_reduce(simple_fc_net, DeviceType.CPU)
 
     def test_batchnorm_fc_with_fuse_all_reduce(self):
-        self._decorate_compare_fused_all_reduce(fc_with_batchnorm, True)
-        self._decorate_compare_fused_all_reduce(fc_with_batchnorm, False)
+        self._decorate_compare_fused_all_reduce(fc_with_batchnorm,
+                                                DeviceType.GPU)
+        self._decorate_compare_fused_all_reduce(fc_with_batchnorm,
+                                                DeviceType.CPU)
 
 
 class TestFuseAllReduceOpsAndOptiOps(TestFuseAllReduceOps):
-    def _decorate_compare_fused_all_reduce(self, model, use_cuda):
+    def _decorate_compare_fused_all_reduce(self, model, use_device):
         self.compare_fuse_all_reduce_ops(
             model,
-            use_cuda,
+            use_device,
             init_feed_dict=init_data,
             optimizer=self.optimizer,
             fuse_all_optimizer_ops=True)
@@ -115,17 +117,17 @@ class TestFuseAllReduceOpsWithSparseGrad(TestFuseAllReduceOpsBase):
         feeder = fluid.DataFeeder(feed_list=["words", "label"], place=place)
         return feeder.feed(self.train_data)
 
-    def _decorate_compare_fused_all_reduce(self, model, use_cuda):
+    def _decorate_compare_fused_all_reduce(self, model, use_device):
         self.compare_fuse_all_reduce_ops(
             model,
-            use_cuda,
+            use_device,
             get_data_from_feeder=self.get_data_from_feeder,
             optimizer=self.optimizer)
 
     def test_simple_bow_net_with_fuse_all_reduce(self):
         model = partial(bow_net, dict_dim=self.word_dict_len, is_sparse=True)
-        self._decorate_compare_fused_all_reduce(model, True)
-        self._decorate_compare_fused_all_reduce(model, False)
+        self._decorate_compare_fused_all_reduce(model, DeviceType.GPU)
+        self._decorate_compare_fused_all_reduce(model, DeviceType.CPU)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_elewise_add_act_pass.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from simple_nets import simple_fc_net, fc_with_batchnorm, init_data
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import unittest
@@ -25,8 +25,8 @@ class TestMNIST(TestParallelExecutorBase):
     def setUpClass(cls):
         os.environ['CPU_NUM'] = str(4)
 
-    def _compare_fuse_elewise_add_act_ops(self, model, use_cuda):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def _compare_fuse_elewise_add_act_ops(self, model, use_device):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
         img, label = init_data()
 
@@ -45,7 +45,7 @@ class TestMNIST(TestParallelExecutorBase):
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_elewise_add_act_ops=False,
             use_ir_memory_optimize=False,
             enable_inplace=False,
@@ -54,7 +54,7 @@ class TestMNIST(TestParallelExecutorBase):
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_elewise_add_act_ops=True,
             use_ir_memory_optimize=False,
             enable_inplace=False,
@@ -66,12 +66,14 @@ class TestMNIST(TestParallelExecutorBase):
             self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
 
     def test_simple_fc_with_fuse_op(self):
-        self._compare_fuse_elewise_add_act_ops(simple_fc_net, True)
-        self._compare_fuse_elewise_add_act_ops(simple_fc_net, False)
+        self._compare_fuse_elewise_add_act_ops(simple_fc_net, DeviceType.GPU)
+        self._compare_fuse_elewise_add_act_ops(simple_fc_net, DeviceType.CPU)
 
     def test_batchnorm_fc_with_fuse_op(self):
-        self._compare_fuse_elewise_add_act_ops(fc_with_batchnorm, True)
-        self._compare_fuse_elewise_add_act_ops(fc_with_batchnorm, False)
+        self._compare_fuse_elewise_add_act_ops(fc_with_batchnorm,
+                                               DeviceType.GPU)
+        self._compare_fuse_elewise_add_act_ops(fc_with_batchnorm,
+                                               DeviceType.CPU)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_optimizer_pass.py
@@ -14,7 +14,7 @@
 
 from simple_nets import simple_fc_net, fc_with_batchnorm, init_data, bow_net
 from fake_reader import fake_imdb_reader
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 from functools import partial
 import paddle
 import paddle.fluid as fluid
@@ -34,25 +34,25 @@ class TestFuseOptimizationOps(TestParallelExecutorBase):
 
     def _compare_fused_optimizer_ops(self,
                                      model,
-                                     use_cuda,
+                                     use_device,
                                      feed_dict=None,
                                      get_data_from_feeder=None,
                                      optimizer=fluid.optimizer.Adam):
-        if use_cuda and not core.is_compiled_with_cuda():
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         not_fuse_op_first_loss, not_fuse_op_last_loss = self.check_network_convergence(
             model,
             feed_dict=feed_dict,
             get_data_from_feeder=get_data_from_feeder,
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_all_optimizer_ops=False,
             optimizer=optimizer)
         fuse_op_first_loss, fuse_op_last_loss = self.check_network_convergence(
             model,
             feed_dict=feed_dict,
             get_data_from_feeder=get_data_from_feeder,
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_all_optimizer_ops=True,
             optimizer=optimizer)
 
@@ -61,10 +61,11 @@ class TestFuseOptimizationOps(TestParallelExecutorBase):
         for loss in zip(not_fuse_op_last_loss, fuse_op_last_loss):
             self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
 
-    def _decorate_compare_fused_optimizer_ops(self, model, use_cuda, optimizer):
+    def _decorate_compare_fused_optimizer_ops(self, model, use_device,
+                                              optimizer):
         self._compare_fused_optimizer_ops(
             model,
-            use_cuda,
+            use_device,
             feed_dict=self._get_feed_dict(),
             optimizer=optimizer)
 
@@ -75,9 +76,9 @@ class TestFuseAdamOps(TestFuseOptimizationOps):
 
     def test_batchnorm_fc_with_fuse_op(self):
         self._decorate_compare_fused_optimizer_ops(
-            fc_with_batchnorm, True, optimizer=self.optimizer)
+            fc_with_batchnorm, DeviceType.GPU, optimizer=self.optimizer)
         self._decorate_compare_fused_optimizer_ops(
-            fc_with_batchnorm, False, optimizer=self.optimizer)
+            fc_with_batchnorm, DeviceType.CPU, optimizer=self.optimizer)
 
 
 class TestFuseSGDOps(TestFuseAdamOps):
@@ -106,10 +107,11 @@ class TestSpareFuseAdamOps(TestFuseOptimizationOps):
         feeder = fluid.DataFeeder(feed_list=["words", "label"], place=place)
         return feeder.feed(self.train_data)
 
-    def _decorate_compare_fused_optimizer_ops(self, model, use_cuda, optimizer):
+    def _decorate_compare_fused_optimizer_ops(self, model, use_device,
+                                              optimizer):
         self._compare_fused_optimizer_ops(
             model,
-            use_cuda,
+            use_device,
             get_data_from_feeder=self._get_data_from_feeder,
             optimizer=optimizer)
 
@@ -119,9 +121,9 @@ class TestSpareFuseAdamOps(TestFuseOptimizationOps):
     def test_simple_bow_net_with_fuse_op(self):
         model = partial(bow_net, dict_dim=self.word_dict_len, is_sparse=True)
         self._decorate_compare_fused_optimizer_ops(
-            model, True, optimizer=self.optimizer)
+            model, DeviceType.GPU, optimizer=self.optimizer)
         self._decorate_compare_fused_optimizer_ops(
-            model, False, optimizer=self.optimizer)
+            model, DeviceType.CPU, optimizer=self.optimizer)
 
 
 class TestSpareFuseSGDOps(TestSpareFuseAdamOps):
@@ -138,18 +140,18 @@ class TestSpareFuseMomentumOps(TestSpareFuseAdamOps):
 class TestPassConflictBase(TestFuseAdamOps):
     def _compare_fused_optimizer_ops(self,
                                      model,
-                                     use_cuda,
+                                     use_device,
                                      feed_dict=None,
                                      get_data_from_feeder=None,
                                      optimizer=fluid.optimizer.Adam):
-        if use_cuda and not core.is_compiled_with_cuda():
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         self.check_pass_conflict(
             model,
             feed_dict=feed_dict,
             get_data_from_feeder=get_data_from_feeder,
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_all_optimizer_ops=True,
             optimizer=optimizer,
             enable_sequential_execution=True)
@@ -161,9 +163,9 @@ class TestFuseAdamOpsPassConflict(TestPassConflictBase):
 
     def test_batchnorm_fc_with_fuse_op(self):
         self._decorate_compare_fused_optimizer_ops(
-            fc_with_batchnorm, True, optimizer=self.optimizer)
+            fc_with_batchnorm, DeviceType.CPU, optimizer=self.optimizer)
         self._decorate_compare_fused_optimizer_ops(
-            fc_with_batchnorm, False, optimizer=self.optimizer)
+            fc_with_batchnorm, DeviceType.GPU, optimizer=self.optimizer)
 
 
 class TestFuseSGDOpsPassConflict(TestFuseAdamOpsPassConflict):

--- a/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_fuse_relu_depthwise_conv_pass.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import numpy as np
@@ -72,8 +72,8 @@ class TestMNIST(TestParallelExecutorBase):
         label = np.ones(shape=[32, 1], dtype='int64')
         return img, label
 
-    def _compare(self, model, use_cuda, random_data=True, only_forward=False):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def _compare(self, model, use_device, random_data=True, only_forward=False):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
         img, label = self._init_data(random_data)
 
@@ -90,7 +90,7 @@ class TestMNIST(TestParallelExecutorBase):
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_relu_depthwise_conv=True,
             use_ir_memory_optimize=True,
             optimizer=_optimizer)
@@ -98,7 +98,7 @@ class TestMNIST(TestParallelExecutorBase):
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_relu_depthwise_conv=False,
             optimizer=_optimizer)
 
@@ -108,12 +108,12 @@ class TestMNIST(TestParallelExecutorBase):
             self.assertAlmostEquals(loss[0], loss[1], delta=1e-6)
 
     def test_simple_depthwise_with_fuse_op(self):
-        self._compare(simple_depthwise_net, True)
-        self._compare(simple_depthwise_net, False)
+        self._compare(simple_depthwise_net, DeviceType.GPU)
+        self._compare(simple_depthwise_net, DeviceType.CPU)
 
     def test_simple_depthwise_with_fuse_op_only_forward(self):
-        self._compare(simple_depthwise_net, True, only_forward=True)
-        self._compare(simple_depthwise_net, False, only_forward=True)
+        self._compare(simple_depthwise_net, DeviceType.GPU, only_forward=True)
+        self._compare(simple_depthwise_net, DeviceType.CPU, only_forward=True)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_ir_inplace_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_inplace_pass.py
@@ -19,7 +19,7 @@ import unittest
 import numpy as np
 import paddle.fluid.core as core
 import paddle.fluid as fluid
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 
 
 def fc_with_batchnorm(use_feed):
@@ -58,7 +58,7 @@ class TestIrInplace(TestParallelExecutorBase):
             fc_with_batchnorm,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=True,
+            use_device=DeviceType.GPU,
             use_ir_memory_optimize=ir_memory_optimize,
             enable_inplace=enable_inplace)
 

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_pass.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_pass.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 import paddle.fluid as fluid
 import paddle.fluid.core as core
 import numpy as np
@@ -60,8 +60,8 @@ class TestMNIST(TestParallelExecutorBase):
         label = np.ones(shape=[32, 1], dtype='int64')
         return img, label
 
-    def _compare_ir_memory_optimize(self, model, use_cuda):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def _compare_ir_memory_optimize(self, model, use_device):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         img, label = self._dummy_data()
@@ -69,13 +69,13 @@ class TestMNIST(TestParallelExecutorBase):
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_ir_memory_optimize=False)
         first_loss1, last_loss1 = self.check_network_convergence(
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_ir_memory_optimize=True)
         for loss in zip(first_loss0, first_loss1):
             self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
@@ -83,12 +83,12 @@ class TestMNIST(TestParallelExecutorBase):
             self.assertAlmostEqual(loss[0], loss[1], delta=1e-6)
 
     def test_simple_fc_net(self):
-        self._compare_ir_memory_optimize(simple_fc_net, False)
-        self._compare_ir_memory_optimize(simple_fc_net, True)
+        self._compare_ir_memory_optimize(simple_fc_net, DeviceType.CPU)
+        self._compare_ir_memory_optimize(simple_fc_net, DeviceType.GPU)
 
     def test_fc_with_reshape_net(self):
-        self._compare_ir_memory_optimize(fc_with_inplace_net, False)
-        self._compare_ir_memory_optimize(fc_with_inplace_net, True)
+        self._compare_ir_memory_optimize(fc_with_inplace_net, DeviceType.CPU)
+        self._compare_ir_memory_optimize(fc_with_inplace_net, DeviceType.GPU)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_transformer.py
+++ b/python/paddle/fluid/tests/unittests/test_ir_memory_optimize_transformer.py
@@ -23,7 +23,7 @@ import paddle.dataset.wmt16 as wmt16
 
 os.environ['FLAGS_eager_delete_tensor_gb'] = "0.0"
 
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 from test_parallel_executor_transformer import get_feed_data_reader, transformer
 
 
@@ -35,14 +35,14 @@ class TestTransformerWithIR(TestParallelExecutorBase):
             # check python transpiler
             self.check_network_convergence(
                 transformer,
-                use_cuda=True,
+                use_device=DeviceType.GPU,
                 feed_data_reader=get_feed_data_reader(),
                 use_ir_memory_optimize=False,
                 iter=2)
             # check IR memory optimize
             self.check_network_convergence(
                 transformer,
-                use_cuda=True,
+                use_device=DeviceType.GPU,
                 feed_data_reader=get_feed_data_reader(),
                 use_ir_memory_optimize=True,
                 iter=2)

--- a/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
+++ b/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
@@ -24,7 +24,7 @@ import numpy as np
 import paddle
 import paddle.fluid as fluid
 from simple_nets import init_data
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 
 batch_size = 12
 img_shape = [1, 28, 28]
@@ -68,7 +68,7 @@ def _optimizer(learning_rate=1e-6):
 
 
 class TestResnet(TestParallelExecutorBase):
-    def check_model(self, use_cuda):
+    def check_model(self, use_device):
         img, label = init_data(
             batch_size=batch_size, img_shape=img_shape, label_range=9)
         img = np.float16(img)
@@ -78,7 +78,7 @@ class TestResnet(TestParallelExecutorBase):
             conv_net,
             feed_dict=feed_dict,
             iter=10,
-            use_cuda=use_cuda,
+            use_device=use_device,
             fuse_all_reduce_ops=True,
             optimizer=_optimizer)
 

--- a/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
+++ b/python/paddle/fluid/tests/unittests/test_mix_precision_all_reduce_fuse.py
@@ -84,7 +84,7 @@ class TestResnet(TestParallelExecutorBase):
 
     def test_model(self):
         if core.is_compiled_with_cuda():
-            self.check_model(True)
+            self.check_model(DeviceType.GPU)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_mnist.py
@@ -21,7 +21,7 @@ import paddle.fluid.core as core
 import paddle
 import os
 import paddle.fluid as fluid
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 from parallel_executor_test_base import DeviceType
 
 

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_mnist.py
@@ -21,6 +21,7 @@ import paddle.fluid.core as core
 import os
 import paddle.fluid as fluid
 from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import DeviceType
 
 
 def simple_fc_net(use_feed):
@@ -76,10 +77,13 @@ class TestMNIST(TestParallelExecutorBase):
 
     def _compare_reduce_and_allreduce(self,
                                       model,
-                                      use_cuda,
+                                      use_device,
                                       delta1=1e-6,
                                       delta2=1e-4):
-        if use_cuda and not core.is_compiled_with_cuda():
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
+            return
+
+        if use_device == DeviceType.XPU and not core.is_compiled_with_xpu():
             return
 
         img, label = self._init_data()
@@ -88,14 +92,14 @@ class TestMNIST(TestParallelExecutorBase):
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=DeviceType.GPU,
             use_reduce=False)
 
         reduce_first_loss, reduce_last_loss = self.check_network_convergence(
             model,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=DeviceType.GPU,
             use_reduce=True)
 
         for loss in zip(all_reduce_first_loss, reduce_first_loss):
@@ -104,8 +108,11 @@ class TestMNIST(TestParallelExecutorBase):
             self.assertAlmostEqual(loss[0], loss[1], delta=delta2)
 
     # simple_fc
-    def check_simple_fc_convergence(self, use_cuda, use_reduce=False):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def check_simple_fc_convergence(self, use_device, use_reduce=False):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
+            return
+
+        if use_device == DeviceType.XPU and not core.is_compiled_with_xpu():
             return
 
         img, label = self._init_data()
@@ -114,23 +121,24 @@ class TestMNIST(TestParallelExecutorBase):
             simple_fc_net,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=DeviceType.GPU,
             use_reduce=use_reduce)
 
     def test_simple_fc(self):
-        # use_cuda
-        self.check_simple_fc_convergence(True)
-        self.check_simple_fc_convergence(False)
+        # use_device
+        self.check_simple_fc_convergence(DeviceType.GPU)
+        self.check_simple_fc_convergence(DeviceType.CPU)
+        self.check_simple_fc_convergence(DeviceType.XPU)
 
     def test_simple_fc_with_new_strategy(self):
-        # use_cuda, use_reduce
+        # use_device, use_reduce
         # NOTE: the computation result of nccl_reduce is non-deterministic,
         # related issue: https://github.com/NVIDIA/nccl/issues/157
         self._compare_reduce_and_allreduce(simple_fc_net, True, 1e-5, 1e-2)
         self._compare_reduce_and_allreduce(simple_fc_net, False, 1e-5, 1e-2)
 
-    def check_simple_fc_parallel_accuracy(self, use_cuda):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def check_simple_fc_parallel_accuracy(self, use_device):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         img, label = self._init_data()
@@ -139,13 +147,13 @@ class TestMNIST(TestParallelExecutorBase):
             method=simple_fc_net,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_parallel_executor=False)
         parallel_first_loss, parallel_last_loss = self.check_network_convergence(
             method=simple_fc_net,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_parallel_executor=True)
 
         self.assertAlmostEquals(
@@ -159,23 +167,25 @@ class TestMNIST(TestParallelExecutorBase):
         self.check_simple_fc_parallel_accuracy(True)
         self.check_simple_fc_parallel_accuracy(False)
 
-    def check_batchnorm_fc_convergence(self, use_cuda, use_fast_executor):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def check_batchnorm_fc_convergence(self, use_device, use_fast_executor):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
-
+        if use_device == DeviceType.XPU and not core.is_compiled_with_xpu():
+            return
         img, label = self._init_data()
 
         self.check_network_convergence(
             fc_with_batchnorm,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_fast_executor=use_fast_executor)
 
     def test_batchnorm_fc(self):
-        for use_cuda in (False, True):
+        for use_device in (DeviceType.CPU, DeviceType.GPU, DeviceType.XPU):
             for use_fast_executor in (False, True):
-                self.check_batchnorm_fc_convergence(use_cuda, use_fast_executor)
+                self.check_batchnorm_fc_convergence(use_device,
+                                                    use_fast_executor)
 
     def test_batchnorm_fc_with_new_strategy(self):
         # NOTE: the computation result of nccl_reduce is non-deterministic,

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_pg.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_pg.py
@@ -21,7 +21,7 @@ import os
 os.environ['FLAGS_enable_parallel_graph'] = str(1)
 import paddle.fluid.core as core
 import os
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 from simple_nets import simple_fc_net, init_data
 
 
@@ -31,8 +31,8 @@ class TestMNIST(TestParallelExecutorBase):
         os.environ['CPU_NUM'] = str(4)
 
     # simple_fc
-    def check_simple_fc_convergence(self, use_cuda, use_reduce=False):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def check_simple_fc_convergence(self, use_device, use_reduce=False):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         img, label = init_data()
@@ -40,15 +40,15 @@ class TestMNIST(TestParallelExecutorBase):
             simple_fc_net,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_reduce=use_reduce)
 
     def test_simple_fc(self):
-        # use_cuda
+        # use_device
         self.check_simple_fc_convergence(True)
 
-    def check_simple_fc_parallel_accuracy(self, use_cuda):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def check_simple_fc_parallel_accuracy(self, use_device):
+        if use_device and not core.is_compiled_with_cuda():
             return
 
         img, label = init_data()
@@ -56,13 +56,13 @@ class TestMNIST(TestParallelExecutorBase):
             method=simple_fc_net,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_parallel_executor=False)
         parallel_first_loss, parallel_last_loss = self.check_network_convergence(
             method=simple_fc_net,
             feed_dict={"image": img,
                        "label": label},
-            use_cuda=use_cuda,
+            use_device=use_device,
             use_parallel_executor=True)
 
         self.assertAlmostEquals(
@@ -73,7 +73,7 @@ class TestMNIST(TestParallelExecutorBase):
             np.mean(parallel_last_loss), single_last_loss, delta=1e-6)
 
     def test_simple_fc_parallel_accuracy(self):
-        self.check_simple_fc_parallel_accuracy(True)
+        self.check_simple_fc_parallel_accuracy(DeviceType.GPU)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_base_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_base_cpu.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 import unittest
 import seresnext_net
-from seresnext_test_base import TestResnetBase
+from seresnext_test_base import TestResnetBase, DeviceType
 from functools import partial
 
 
@@ -30,7 +30,10 @@ class TestResnetCPU(TestResnetBase):
             optimizer=seresnext_net.optimizer,
             use_parallel_executor=False)
         self._compare_result_with_origin_model(
-            check_func, use_cuda=False, compare_seperately=False, delta2=1e-3)
+            check_func,
+            use_device=DeviceType.CPU,
+            compare_seperately=False,
+            delta2=1e-3)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_base_gpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_base_gpu.py
@@ -15,7 +15,7 @@
 from __future__ import print_function
 import unittest
 import seresnext_net
-from seresnext_test_base import TestResnetBase
+from seresnext_test_base import TestResnetBase, DeviceType
 from functools import partial
 
 
@@ -30,7 +30,7 @@ class TestResnetGPU(TestResnetBase):
             optimizer=seresnext_net.optimizer,
             use_parallel_executor=False)
         self._compare_result_with_origin_model(
-            check_func, use_cuda=True, compare_seperately=False)
+            check_func, use_device=DeviceType.GPU, compare_seperately=False)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_fuse_all_reduce_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_fuse_all_reduce_cpu.py
@@ -19,7 +19,7 @@ fluid.core._set_fuse_parameter_memory_size(131072)
 
 import unittest
 import seresnext_net
-from seresnext_test_base import TestResnetBase
+from seresnext_test_base import TestResnetBase, DeviceType
 from functools import partial
 
 
@@ -31,7 +31,8 @@ class TestResnetWithFuseAllReduceCPU(TestResnetBase):
             self.check_network_convergence,
             optimizer=seresnext_net.optimizer,
             fuse_all_reduce_ops=True)
-        self._compare_result_with_origin_model(check_func, use_cuda=False)
+        self._compare_result_with_origin_model(
+            check_func, use_device=DeviceType.CPU)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_fuse_all_reduce_gpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_fuse_all_reduce_gpu.py
@@ -19,7 +19,7 @@ fluid.core._set_fuse_parameter_memory_size(131072)
 
 import unittest
 import seresnext_net
-from seresnext_test_base import TestResnetBase
+from seresnext_test_base import TestResnetBase, DeviceType
 from functools import partial
 
 
@@ -32,7 +32,7 @@ class TestResnetWithFuseAllReduceGPU(TestResnetBase):
             optimizer=seresnext_net.optimizer,
             fuse_all_reduce_ops=True)
         self._compare_result_with_origin_model(
-            check_func, use_cuda=True, delta2=1e-2)
+            check_func, use_device=DeviceType.GPU, delta2=1e-2)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_cpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_cpu.py
@@ -14,30 +14,30 @@
 
 from __future__ import print_function
 import unittest
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 import seresnext_net
 import paddle.fluid.core as core
 
 
 class TestResnetWithReduceBase(TestParallelExecutorBase):
-    def _compare_reduce_and_allreduce(self, use_cuda, delta2=1e-5):
-        if use_cuda and not core.is_compiled_with_cuda():
+    def _compare_reduce_and_allreduce(self, use_device, delta2=1e-5):
+        if use_device == DeviceType.GPU and not core.is_compiled_with_cuda():
             return
 
         all_reduce_first_loss, all_reduce_last_loss = self.check_network_convergence(
             seresnext_net.model,
-            feed_dict=seresnext_net.feed_dict(use_cuda),
-            iter=seresnext_net.iter(use_cuda),
-            batch_size=seresnext_net.batch_size(use_cuda),
-            use_cuda=use_cuda,
+            feed_dict=seresnext_net.feed_dict(use_device),
+            iter=seresnext_net.iter(use_device),
+            batch_size=seresnext_net.batch_size(use_device),
+            use_device=use_device,
             use_reduce=False,
             optimizer=seresnext_net.optimizer)
         reduce_first_loss, reduce_last_loss = self.check_network_convergence(
             seresnext_net.model,
-            feed_dict=seresnext_net.feed_dict(use_cuda),
-            iter=seresnext_net.iter(use_cuda),
-            batch_size=seresnext_net.batch_size(use_cuda),
-            use_cuda=use_cuda,
+            feed_dict=seresnext_net.feed_dict(use_device),
+            iter=seresnext_net.iter(use_device),
+            batch_size=seresnext_net.batch_size(use_device),
+            use_device=use_device,
             use_reduce=True,
             optimizer=seresnext_net.optimizer)
 
@@ -46,25 +46,25 @@ class TestResnetWithReduceBase(TestParallelExecutorBase):
         for loss in zip(all_reduce_last_loss, reduce_last_loss):
             self.assertAlmostEquals(loss[0], loss[1], delta=loss[0] * delta2)
 
-        if not use_cuda:
+        if not use_device:
             return
 
         all_reduce_first_loss_seq, all_reduce_last_loss_seq = self.check_network_convergence(
             seresnext_net.model,
-            feed_dict=seresnext_net.feed_dict(use_cuda),
-            iter=seresnext_net.iter(use_cuda),
-            batch_size=seresnext_net.batch_size(use_cuda),
-            use_cuda=use_cuda,
+            feed_dict=seresnext_net.feed_dict(use_device),
+            iter=seresnext_net.iter(use_device),
+            batch_size=seresnext_net.batch_size(use_device),
+            use_device=use_device,
             use_reduce=False,
             optimizer=seresnext_net.optimizer,
             enable_sequential_execution=True)
 
         reduce_first_loss_seq, reduce_last_loss_seq = self.check_network_convergence(
             seresnext_net.model,
-            feed_dict=seresnext_net.feed_dict(use_cuda),
-            iter=seresnext_net.iter(use_cuda),
-            batch_size=seresnext_net.batch_size(use_cuda),
-            use_cuda=use_cuda,
+            feed_dict=seresnext_net.feed_dict(use_device),
+            iter=seresnext_net.iter(use_device),
+            batch_size=seresnext_net.batch_size(use_device),
+            use_device=use_device,
             use_reduce=True,
             optimizer=seresnext_net.optimizer,
             enable_sequential_execution=True)
@@ -87,7 +87,8 @@ class TestResnetWithReduceBase(TestParallelExecutorBase):
 
 class TestResnetWithReduceCPU(TestResnetWithReduceBase):
     def test_seresnext_with_reduce(self):
-        self._compare_reduce_and_allreduce(use_cuda=False, delta2=1e-3)
+        self._compare_reduce_and_allreduce(
+            use_device=DeviceType.CPU, delta2=1e-3)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_gpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_gpu.py
@@ -19,7 +19,8 @@ from test_parallel_executor_seresnext_with_reduce_cpu import TestResnetWithReduc
 
 class TestResnetWithReduceGPU(TestResnetWithReduceBase):
     def test_seresnext_with_reduce(self):
-        self._compare_reduce_and_allreduce(use_cuda=True, delta2=1e-2)
+        self._compare_reduce_and_allreduce(
+            use_device=DeviceType.GPU, delta2=1e-2)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_gpu.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_seresnext_with_reduce_gpu.py
@@ -14,7 +14,7 @@
 
 from __future__ import print_function
 import unittest
-from test_parallel_executor_seresnext_with_reduce_cpu import TestResnetWithReduceBase
+from test_parallel_executor_seresnext_with_reduce_cpu import TestResnetWithReduceBase, DeviceType
 
 
 class TestResnetWithReduceGPU(TestResnetWithReduceBase):

--- a/python/paddle/fluid/tests/unittests/test_parallel_executor_transformer.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_executor_transformer.py
@@ -17,7 +17,7 @@ from __future__ import print_function
 import paddle.fluid as fluid
 import transformer_model
 import numpy as np
-from parallel_executor_test_base import TestParallelExecutorBase
+from parallel_executor_test_base import TestParallelExecutorBase, DeviceType
 import unittest
 import paddle
 import paddle.fluid.core as core
@@ -191,16 +191,16 @@ class TestTransformer(TestParallelExecutorBase):
         if core.is_compiled_with_cuda():
             self.check_network_convergence(
                 transformer,
-                use_cuda=True,
+                use_device=DeviceType.GPU,
                 feed_data_reader=get_feed_data_reader())
             self.check_network_convergence(
                 transformer,
-                use_cuda=True,
+                use_device=DeviceType.GPU,
                 enable_sequential_execution=True,
                 feed_data_reader=get_feed_data_reader())
         self.check_network_convergence(
             transformer,
-            use_cuda=False,
+            use_device=DeviceType.CPU,
             iter=2,
             feed_data_reader=get_feed_data_reader())
 

--- a/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_program_prune_backward.py
@@ -22,7 +22,7 @@ import paddle.fluid as fluid
 import paddle.fluid.core as core
 from simple_nets import init_data, simple_fc_net, fc_with_batchnorm
 import seresnext_net
-from test_parallel_executor_transformer import transformer, get_feed_data_reader
+from test_parallel_executor_transformer import transformer, get_feed_data_reader, DeviceType
 from fake_reader import fake_imdb_reader
 
 
@@ -219,7 +219,7 @@ class TestProgramPruneBackward(unittest.TestCase):
         with self.program_scope_guard():
             self.check_prune_correctness(
                 method=seresnext_net.model,
-                feed_dict=seresnext_net.feed_dict(use_cuda=False),
+                feed_dict=seresnext_net.feed_dict(use_device=DeviceType.CPU),
                 optimizer=seresnext_net.optimizer)
 
     def test_transformer(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add unittesets supported kunlun xpu devices based on TestParallelExecutorBase:
- test_fuse_all_reduce_pass.py
- test_fuse_elewise_add_act_pass.py
- test_fuse_optimizer_pass.py
- test_fuse_relu_depthwise_conv_pass.py
- test_ir_inplace_pass.py
- test_ir_memory_optimize_pass.py
- test_ir_memory_optimize_transformer.py
- test_mix_precision_all_reduce_fuse.py
- test_parallel_executor_mnist.py
- test_parallel_executor_transformer.py 
- test_parallel_executor_pg.py
- test_parallel_executor_seresnext_with_reduce_cpu.py/TestResnetWithReduceBase
   - test_parallel_executor_seresnext_with_reduce_cpu.py
   - test_parallel_executor_seresnext_with_reduce_gpu.py
-  seresnext_test_base.py/TestResnetBase
   - test_parallel_executor_seresnext_with_fuse_all_reduce_cpu.py
   - test_parallel_executor_seresnext_with_fuse_all_reduce_gpu.py 
   - test_parallel_executor_seresnext_base_cpu.py
   - test_parallel_executor_seresnext_base_gpu.py