### PR TITLE
[Inference] lod operator should not be reused in memory_optimize pass.

### DIFF
--- a/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
+++ b/paddle/fluid/inference/analysis/passes/memory_optimize_pass.cc
@@ -96,6 +96,7 @@ void MemoryOptimizePass::CollectVarMemorySize(
   const int fake_batch_size = 1;
 
   auto valid_var = [&](framework::ir::Node* node) -> bool {
+    // lod operator reuse may cause unknown errors.
     std::set<std::string> invalid_op = {"while",
                                         "conditional_block",
                                         "tensorrt_engine",
@@ -103,6 +104,7 @@ void MemoryOptimizePass::CollectVarMemorySize(
                                         "merge_lod_tensor_infer",
                                         "merge_lod_tensor",
                                         "equal",
+                                        "sequence_pool",
                                         "lod_reset"};
     for (auto* tmp : node->inputs) {
       CHECK(tmp->IsOp());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
内/显存复用pass中，不应该复用lod operator。

lod operator的输出tensor一般都具有lod信息，默认算子的行为会保留lod信息，即输出的lod默认等于输入的lod。在此情况下进行复用会导致未知的行为，该pr修复由于sequence_pool的复用，输入lod处于随机状态，导致rec_r34_vd_tps_bilstm_attn模型出错。