### PR TITLE
fix TransferInplaceBack

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1336,12 +1336,6 @@ Scope* OperatorWithKernel::PrepareData(
         continue;
       }
 
-      auto out_var_names = OutputVars(true);
-      if (std::find(out_var_names.begin(), out_var_names.end(), var_name) !=
-          out_var_names.end()) {
-        transfered_inplace_vars->emplace_back(var_name);
-      }
-
       VLOG(3) << "Transform Variable " << var_name << " from "
               << kernel_type_for_var << " to " << expected_kernel_key;
 
@@ -1383,13 +1377,33 @@ Scope* OperatorWithKernel::PrepareData(
       if (enable_cache_runtime_context_) {
         pre_scope_ = nullptr;
       }
+
+      // Create new var with the same name in transfer scopes
       auto* trans_var = new_scope->Var(var_name);
       input_vars[i] = trans_var;
+
+      // Find if inplace exists between input and output
+      // If inplace exists, set the new created var to inplaced output, and
+      // record its name in transfered_inplace_vars.
+      for (auto& pair : Outputs()) {
+        for (size_t j = 0; j < pair.second.size(); ++j) {
+          if (pair.second[j] == var_name) {
+            VLOG(4) << "Found inplace between input(" << var_name_item.first
+                    << ") and output(" << pair.first
+                    << "), the variable name is " << var_name;
+            ctx->outputs[pair.first][j] = trans_var;
+            transfered_inplace_vars->emplace_back(var_name);
+          }
+        }
+      }
+
+      // Do transfer
       Tensor out;
       TransformData(expected_kernel_key, kernel_type_for_var, *tensor_in, &out);
       SetTensorToVariable(*var, out, trans_var);
     }
   }
+
   // If pre_scope = &scope, it means that scope is cached and the op is not in
   // while block. If new_scope = nullptr, it means that for each input of this
   // Op, there is no need to do PrepareData. So PrepareData could be skipped at

--- a/python/paddle/fluid/tests/unittests/test_increment.py
+++ b/python/paddle/fluid/tests/unittests/test_increment.py
@@ -40,5 +40,19 @@ class TestIncrement(unittest.TestCase):
             self.assertEqual((output.numpy() == expected_result).all(), True)
 
 
+class TestInplaceApiWithDataTransform(unittest.TestCase):
+    def test_increment(self):
+        if fluid.core.is_compiled_with_cuda():
+            paddle.enable_static()
+            with paddle.fluid.device_guard("gpu:0"):
+                x = paddle.fluid.layers.fill_constant([1], "float32", 0)
+            with paddle.fluid.device_guard("cpu"):
+                x = paddle.increment(x)
+            exe = paddle.static.Executor(paddle.CUDAPlace(0))
+            a, = exe.run(paddle.static.default_main_program(), fetch_list=[x])
+            paddle.disable_static()
+            self.assertEqual(a[0], 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
remove TransferInplaceBack

There is a bug in the original `TransferInplaceVarsBack` when data transform happens with inplace.
For example:
```
paddle.enable_static()
with paddle.fluid.device_guard("gpu:0"):
    x = paddle.fluid.layers.fill_constant([1], "float32", 0)
with paddle.fluid.device_guard("cpu"):
    x = paddle.increment(x)
exe = paddle.static.Executor(paddle.CUDAPlace(0))
a, = exe.run(paddle.static.default_main_program(), fetch_list=[x])  # should be 1, but got 0
```

The reason is that, before `data transorm`, variable `x` is in global_scope and its value is 0. The input and output of increment op is x.
- before transform: 
global_scope:   `x(val:0)`
`x = increment(x)`

- after transform (transform only changes the input vars of an operator)
global_scope:   `x(val:0)`
transfer_scope:   `x'(val:0) ` 
`x =  increment(x') ` # x and x' is actually not inplaced.

The `increment` op takes `x'(val:0)`  as input and `x(val:0)` as output. 
After execution, `x(val:0)` will be `x(val:1)`, which means `x(val:1) =  x'(val:0)  + 1` .

There are two problems:

- Since `x` and `x'` may be on different places, the execution may fail.
- In original implementation, `TransferInplaceBack` is called to copy `x'(val:0)` to `x(val:1)` after execution, which overwrite the data of `x` incorrectly.

So, the right way is to change the input and output of an operator if `inplace` and `data transform` happens together, and do `TransferInplaceBack` after execution.
 