### PR TITLE
[suguan-ROCm] fix var_type_traits related file 

### DIFF
--- a/paddle/fluid/framework/var_type_traits.cc
+++ b/paddle/fluid/framework/var_type_traits.cc
@@ -29,6 +29,15 @@
 #include "paddle/fluid/operators/conv_cudnn_op_cache.h"
 #include "paddle/fluid/operators/cudnn_rnn_cache.h"
 #endif
+#ifdef PADDLE_WITH_HIP
+#include <miopen/miopen.h>
+#include "paddle/fluid/operators/conv_miopen_op_cache.h"
+#include "paddle/fluid/operators/miopen_rnn_cache.h"
+#if defined(PADDLE_WITH_RCCL)
+#include "paddle/fluid/operators/rccl/rccl_gpu_common.h"
+#include "paddle/fluid/platform/rccl_helper.h"
+#endif
+#endif
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/framework/var_type_traits.h
+++ b/paddle/fluid/framework/var_type_traits.h
@@ -30,13 +30,21 @@
 #include <nccl.h>
 #endif
 #endif
-
+#ifdef PADDLE_WITH_HIP
+#include <miopen/miopen.h>
+#ifdef PADDLE_WITH_RCCL
+#include <rccl.h>
+#endif
+#endif
 // Users should add forward declarations here
 namespace paddle {
 
 namespace platform {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
 #ifdef PADDLE_WITH_CUDA
 #if defined(PADDLE_WITH_NCCL)
+
 class Communicator;
 class NCCLCommunicator;
 #endif
@@ -145,6 +153,12 @@ using VarTypeRegistry = detail::VarTypeRegistryImpl<
     operators::reader::OrderedMultiDeviceLoDTensorBlockingQueueHolder,
 #ifdef PADDLE_WITH_CUDA
 #if defined(PADDLE_WITH_NCCL)
+    ncclUniqueId, platform::Communicator, platform::NCCLCommunicator,
+#endif
+    operators::CudnnRNNCache,
+#endif
+#ifdef PADDLE_WITH_HIP
+#if defined(PADDLE_WITH_RCCL)
     ncclUniqueId, platform::Communicator, platform::NCCLCommunicator,
 #endif
     operators::CudnnRNNCache,

--- a/paddle/fluid/framework/var_type_traits_test.cc
+++ b/paddle/fluid/framework/var_type_traits_test.cc
@@ -31,6 +31,14 @@
 #include "paddle/fluid/operators/conv_cudnn_op_cache.h"
 #include "paddle/fluid/operators/cudnn_rnn_cache.h"
 #endif
+#ifdef PADDLE_WITH_HIP
+#if defined(PADDLE_WITH_RCCL)
+#include "paddle/fluid/operators/rccl/rccl_gpu_common.h"
+#include "paddle/fluid/platform/rccl_helper.h"
+#endif
+#include "paddle/fluid/operators/conv_miopen_op_cache.h"
+#include "paddle/fluid/operators/miopen_rnn_cache.h"
+#endif
 
 namespace paddle {
 namespace framework {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
In order to support suguan-ROCm we have to transfer some file which had been developed with v1.8 to paddle 2.0 or dev branch.
TODO:
FRAMEWORK/
- var_type_traits (yes)
