### PR TITLE
Replace exit method in test_imperative_signal_handler

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
@@ -41,7 +41,7 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
     def test_child_process_exit_with_error(self):
         def __test_process__():
             core._set_process_signal_handler()
-            sys.exit(1)
+            os._exit(os.EX_DATAERR)
 
         exception = None
         try:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Replace exit method in test_imperative_signal_handler

sys.exit换用os._exit