### PR TITLE
The new unit test cannot have the same name as the existing unit test

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1061,6 +1061,16 @@ set -x
                 set -x
             fi
         fi
+        if [ -a "$PADDLE_ROOT/duplicate_ut" ];then
+            duplicate_uts=$(cat $PADDLE_ROOT/duplicate_ut|sed -e 's/\r//g')
+            if [[ "$duplicate_uts" != "" ]];then
+                echo "========================================"
+                echo "The new unit test has the same name as the existing unit test"
+                cat "$PADDLE_ROOT/duplicate_ut"
+                echo "========================================"
+                exit 8;
+            fi
+        fi
         if [ -a "$PADDLE_ROOT/added_ut" ];then
             added_uts=^$(awk BEGIN{RS=EOF}'{gsub(/\n/,"$|^");print}' $PADDLE_ROOT/added_ut)$
             ctest -R "(${added_uts})" --output-on-failure --repeat-until-fail 3 --timeout 15;added_ut_error=$?

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1069,7 +1069,7 @@ set -x
                 echo "The new unit test has the same name as the existing unit test"
                 cat "$PADDLE_ROOT/duplicate_ut"
                 echo "========================================"
-                exit 8;
+                exit 102;
                 set -x
             fi
         fi

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -1064,11 +1064,13 @@ set -x
         if [ -a "$PADDLE_ROOT/duplicate_ut" ];then
             duplicate_uts=$(cat $PADDLE_ROOT/duplicate_ut|sed -e 's/\r//g')
             if [[ "$duplicate_uts" != "" ]];then
+                set +x
                 echo "========================================"
                 echo "The new unit test has the same name as the existing unit test"
                 cat "$PADDLE_ROOT/duplicate_ut"
                 echo "========================================"
                 exit 8;
+                set -x
             fi
         fi
         if [ -a "$PADDLE_ROOT/added_ut" ];then

--- a/tools/check_added_ut.sh
+++ b/tools/check_added_ut.sh
@@ -36,7 +36,7 @@ cd $PADDLE_ROOT/build
 ctest -N | awk -F ':' '{print $2}' | sed '/^$/d' | sed '$d' | sed 's/ //g' > /$PADDLE_ROOT/pr-ut
 cd $PADDLE_ROOT
 grep -F -x -v -f br-ut pr-ut > $PADDLE_ROOT/added_ut
-sort pr-ut |uniq -d > > $PADDLE_ROOT/duplicate_ut
+sort pr-ut |uniq -d > $PADDLE_ROOT/duplicate_ut
 echo "New-UT:"
 cat $PADDLE_ROOT/added_ut
 rm -rf prec_build

--- a/tools/check_added_ut.sh
+++ b/tools/check_added_ut.sh
@@ -36,6 +36,7 @@ cd $PADDLE_ROOT/build
 ctest -N | awk -F ':' '{print $2}' | sed '/^$/d' | sed '$d' | sed 's/ //g' > /$PADDLE_ROOT/pr-ut
 cd $PADDLE_ROOT
 grep -F -x -v -f br-ut pr-ut > $PADDLE_ROOT/added_ut
+sort pr-ut |uniq -d > > $PADDLE_ROOT/duplicate_ut
 echo "New-UT:"
 cat $PADDLE_ROOT/added_ut
 rm -rf prec_build


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The new unit test cannot have the same name as the existing unit test
