### PR TITLE
fix layer_norm accuracy

### DIFF
--- a/paddle/fluid/operators/layer_norm_op.cu
+++ b/paddle/fluid/operators/layer_norm_op.cu
@@ -133,7 +133,7 @@ template <typename T, typename U, int BlockDim>
 __global__ void LayerNormForward(const T *x, const U *scale, const U *bias,
                                  T *y, U *mean, U *var, float epsilon,
                                  int feature_size) {
-  using BlockReduce = cub::BlockReduce<PairForLayerNorm<U>, BlockDim>;
+  using BlockReduce = cub::BlockReduce<PairForLayerNorm<double>, BlockDim>;
   __shared__ typename BlockReduce::TempStorage temp_storage;
   __shared__ U mean_share;
   __shared__ U var_share;
@@ -142,16 +142,16 @@ __global__ void LayerNormForward(const T *x, const U *scale, const U *bias,
   int end_idx = (blockIdx.x + 1) * feature_size;
 
   // Step 1: Reduce to calculate mean and var
-  U mean_val = 0;
-  U var_val = 0;
+  double mean_val = 0;
+  double var_val = 0;
   for (int i = beg_idx; i < end_idx; i += BlockDim) {
     U tmp = static_cast<U>(x[i]);
     mean_val += tmp;
     var_val += (tmp * tmp);
   }
   auto pair = BlockReduce(temp_storage)
-                  .Reduce(PairForLayerNorm<U>(mean_val, var_val),
-                          PairForLayerNormAddFunctor<U>());
+                  .Reduce(PairForLayerNorm<double>(mean_val, var_val),
+                          PairForLayerNormAddFunctor<double>());
   if (threadIdx.x == 0) {
     auto tmp = pair.first_ / feature_size;
     mean[blockIdx.x] = mean_share = static_cast<U>(tmp);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
layer_norm 性能优化的 PR #29522 导致了一定的精度下降。

```
x_data = np.array([[[[0.6964692, 0.28613934, 0.22685145],
                       [0.5513148, 0.71946895, 0.42310646]],
                      [[0.9807642, 0.6848297, 0.4809319],
                       [0.39211753, 0.343178, 0.7290497]]],
                     [[[0.43857226, 0.0596779, 0.39804426],
                       [0.7379954, 0.18249173, 0.17545176]],
                      [[0.53155136, 0.53182757, 0.63440096],
                       [0.8494318, 0.7244553, 0.6110235]]]])
x_data = x_data.astype('float32')
res = [[[[0.7187893, -1.2011795, -1.4785926],
       [0.03959922, 0.82640713, -0.5602985]],
      [[2.0490303, 0.66432714, -0.28972825],
       [-0.7052984, -0.93429065, 0.8712362]]],
     [[[-0.21512909, -1.8132395, -0.38606915],
       [1.0477855, -1.2952322, -1.3249255]],
      [[0.17704056, 0.17820556, 0.6108423],
       [1.5178049, 0.99067575, 0.5122401]]]]
```

导致计算出的 y = layer_norm(x) 如下：
```
[[[[ 0.7187892  -1.2011794  -1.4785925 ]
   [ 0.03959922  0.8264071  -0.5602985 ]]

  [[ 2.04903     0.6643271  -0.28972825]
   [-0.70529836 -0.9342906   0.87123615]]]


 [[[-0.21512899 -1.8132395  -0.38606903]
   [ 1.0477856  -1.295232   -1.3249255 ]]

  [[ 0.1770407   0.1782057   0.6108424 ]
   [ 1.5178051   0.9906759   0.5122403 ]]]]
```

与期望的 res 有 diff，比如最后的值从  0.5122401 -> 0.5122403，np.allclose(y, res, rtol=1e-7, atol=1e-6) 会出现问题，问题是出现在 rtol=1e-7。rtol = 1e-6 都不会。

本 PR 修改之后，计算出的 y = layer_norm(x) 如下：
```
[[[[ 0.7187893  -1.2011795  -1.4785926 ]
   [ 0.03959922  0.82640713 -0.5602985 ]]

  [[ 2.04903     0.66432714 -0.28972825]
   [-0.70529836 -0.93429065  0.8712362 ]]]


 [[[-0.2151291  -1.8132396  -0.38606915]
   [ 1.0477855  -1.2952322  -1.3249255 ]]

  [[ 0.17704056  0.17820556  0.6108423 ]
   [ 1.517805    0.9906758   0.5122402 ]]]]
```

能通过 np.allclose(y, res, rtol=1e-7, atol=1e-6)  测试，但是最后一个值还是有 diff，0.5122401 -> 0.5122402。