### PR TITLE
-1 -> KeyError

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -208,6 +208,8 @@ class LayerList(Layer):
         if isinstance(idx, slice):
             return self.__class__(list(self._sub_layers.values())[idx])
         else:
+            if idx < 0:
+                idx = len(self) + idx
             return self._sub_layers[str(idx)]
 
     def __setitem__(self, idx, sublayer):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

When running:
```python
import paddle.nn as nn
net = nn.LayerList([nn.Linear(784, 256), nn.ReLU()])
print(net[-1]) 
```
```shell
Traceback:

  File "/xxx/miniconda3/envs/paddle/lib/python3.7/site-packages/paddle/fluid/dygraph/container.py", line 213, in __getitem__
    return self._sub_layers[str(idx)]

KeyError: '-1'
```
So, add:
```python
if idx < 0:
    idx = len(self) + idx
```
