### PR TITLE
[cherrypick 2.0]Fix Conv2DTanspose bug when padding='same' (#29915)

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_conv2d_transpose_layer.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_transpose_layer.py
@@ -219,6 +219,7 @@ def add_cases(suite):
     suite.addTest(
         Conv2DTransposeTestCase(
             methodName='runTest', padding="valid"))
+    suite.addTest(Conv2DTransposeTestCase(methodName='runTest', padding="same"))
     suite.addTest(
         Conv2DTransposeTestCase(
             methodName='runTest', filter_size=1, padding=(2, 3)))

--- a/python/paddle/nn/layer/conv.py
+++ b/python/paddle/nn/layer/conv.py
@@ -100,14 +100,12 @@ class _ConvNd(layers.Layer):
         self._padding_mode = padding_mode
         self.output_padding = output_padding
         if dims != 1:
-            self._padding, self._padding_algorithm = _update_padding_nd(
+            self._updated_padding, self._padding_algorithm = _update_padding_nd(
                 padding, channel_last, dims)
 
         if transposed:
             filter_shape = [self._in_channels, out_channels // groups
                             ] + self._kernel_size
-            self._padding, self._padding_algorithm = _update_padding_nd(
-                padding, channel_last, dims)
         else:
             if in_channels % groups != 0:
                 raise ValueError("in_channels must be divisible by groups.")
@@ -118,7 +116,8 @@ class _ConvNd(layers.Layer):
                 self._reversed_padding_repeated_twice = _reverse_repeat_list(
                     _paired_padding, 2)
 
-                self._padding, _ = _update_padding_nd(0, channel_last, dims)
+                self._updated_padding, self._padding_algorithm = _update_padding_nd(
+                    0, channel_last, dims)
 
             filter_shape = [out_channels, in_channels // groups
                             ] + self._kernel_size
@@ -634,7 +633,7 @@ class Conv2D(_ConvNd):
             self.weight,
             bias=self.bias,
             stride=self._stride,
-            padding=self._padding,
+            padding=self._updated_padding,
             padding_algorithm=self._padding_algorithm,
             dilation=self._dilation,
             groups=self._groups,
@@ -951,7 +950,7 @@ class Conv3D(_ConvNd):
             self.weight,
             bias=self.bias,
             stride=self._stride,
-            padding=self._padding,
+            padding=self._updated_padding,
             padding_algorithm=self._padding_algorithm,
             dilation=self._dilation,
             groups=self._groups,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
cherrypick from #29915 