### PR TITLE
Register op version for print, test=op_version

### DIFF
--- a/paddle/fluid/operators/print_op.cc
+++ b/paddle/fluid/operators/print_op.cc
@@ -13,6 +13,7 @@
    limitations under the License. */
 
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/tensor_formatter.h"
 
 namespace paddle {
@@ -173,3 +174,11 @@ REGISTER_OPERATOR(print, ops::PrintOp, ops::PrintOpProtoAndCheckMaker,
                   ops::PrintOpGradientMaker<paddle::framework::OpDesc>,
                   ops::PrintOpGradientMaker<paddle::imperative::OpBase>,
                   ops::PrintOpInferShape, ops::PrintOpVarTypeInference);
+
+REGISTER_OP_VERSION(print)
+    .AddCheckpoint(
+        R"ROC(Upgrade print add a new attribute [print_tensor_layout] to "
+             "contorl whether to print tensor's layout.)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "print_tensor_layout", "Whether to print the tensor's layout.",
+            true));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Register op version for print, test=op_version

- The added attribute 'print_tensor_layout' is not yet registered.  (由PR#24068添加)
- The change of attribute 'print_tensor_type' is not yet registered. (根据PR#24068，只是修改了打印结果中重复的dtype，这个attr本身并没有修改)