### PR TITLE
add the op version check for the elementwise ops, test=op_version

### DIFF
--- a/paddle/fluid/operators/arg_max_op.cc
+++ b/paddle/fluid/operators/arg_max_op.cc
@@ -44,8 +44,8 @@ REGISTER_OP_VERSION(arg_max)
                      false)
             .ModifyAttr(
                 "dtype",
-                "change the default value of dtype, the older version "
-                "is -1, means return the int64 indices."
-                "The new version is 3, return the int64 indices directly."
-                "And supporting the dtype of -1 in new version.",
+                "Change the default value of dtype from -1 to 3"
+                ", means return the int64 indices directly. The rearse why "
+                "changing the default value is that the int64 value in "
+                "VarType is 3 in the frameworke.proto.",
                 3));

--- a/paddle/fluid/operators/arg_min_op.cc
+++ b/paddle/fluid/operators/arg_min_op.cc
@@ -44,8 +44,8 @@ REGISTER_OP_VERSION(arg_min)
                      false)
             .ModifyAttr(
                 "dtype",
-                "change the default value of dtype, the older version "
-                "is -1, means return the int64 indices."
-                "The new version is 3, return the int64 indices directly."
-                "And supporting the dtype of -1 in new version.",
+                "Change the default value of dtype from -1 to 3"
+                ", means return the int64 indices directly. The rearse why "
+                "changing the default value is that the int64 value in "
+                "VarType is 3 in the frameworke.proto.",
                 3));

--- a/paddle/fluid/operators/elementwise/elementwise_add_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.cc
@@ -178,3 +178,12 @@ REGISTER_OP_CPU_KERNEL(
                               paddle::platform::complex64>,
     ops::ElementwiseAddKernel<paddle::platform::CPUDeviceContext,
                               paddle::platform::complex128>);
+
+REGISTER_OP_VERSION(elementwise_add)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_add for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_add.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_div_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/elementwise/elementwise_div_op.h"
 #include <memory>
 #include <string>
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 #include "paddle/fluid/platform/complex128.h"
 #include "paddle/fluid/platform/complex64.h"
@@ -162,3 +163,12 @@ REGISTER_OP_CPU_KERNEL(
                                         paddle::platform::complex64>,
     ops::ElementwiseDivDoubleGradKernel<paddle::platform::CPUDeviceContext,
                                         paddle::platform::complex128>);
+
+REGISTER_OP_VERSION(elementwise_div)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_div for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_div.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_floordiv_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_floordiv_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <string>
 
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 
 namespace paddle {
@@ -69,3 +70,12 @@ REGISTER_OP_CPU_KERNEL(
     ops::ElementwiseFloorDivKernel<paddle::platform::CPUDeviceContext, int>,
     ops::ElementwiseFloorDivKernel<paddle::platform::CPUDeviceContext,
                                    int64_t>);
+
+REGISTER_OP_VERSION(elementwise_floordiv)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_floordiv for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_floordiv.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_max_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_max_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <string>
 
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 
 namespace paddle {
@@ -94,3 +95,12 @@ REGISTER_OP_CPU_KERNEL(
     ops::ElementwiseMaxGradKernel<paddle::platform::CPUDeviceContext, double>,
     ops::ElementwiseMaxGradKernel<paddle::platform::CPUDeviceContext, int>,
     ops::ElementwiseMaxGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
+
+REGISTER_OP_VERSION(elementwise_max)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_max for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_max.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_min_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_min_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <string>
 
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 
 namespace paddle {
@@ -94,3 +95,12 @@ REGISTER_OP_CPU_KERNEL(
     ops::ElementwiseMinGradKernel<paddle::platform::CPUDeviceContext, double>,
     ops::ElementwiseMinGradKernel<paddle::platform::CPUDeviceContext, int>,
     ops::ElementwiseMinGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
+
+REGISTER_OP_VERSION(elementwise_min)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_min for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_min.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_mod_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_mod_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <string>
 
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 
 namespace paddle {
@@ -69,3 +70,12 @@ REGISTER_OP_CPU_KERNEL(
     ops::ElementwiseModKernel<paddle::platform::CPUDeviceContext, int64_t>,
     ops::ElementwiseModFPKernel<paddle::platform::CPUDeviceContext, float>,
     ops::ElementwiseModFPKernel<paddle::platform::CPUDeviceContext, double>);
+
+REGISTER_OP_VERSION(elementwise_mod)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_mod for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_mod.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_mul_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_mul_op.cc
@@ -15,6 +15,8 @@ limitations under the License. */
 #include "paddle/fluid/operators/elementwise/elementwise_mul_op.h"
 #include <memory>
 #include <string>
+
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 #include "paddle/fluid/platform/complex128.h"
 #include "paddle/fluid/platform/complex64.h"
@@ -161,3 +163,12 @@ REGISTER_OP_CPU_KERNEL(
                                         paddle::platform::complex64>,
     ops::ElementwiseMulDoubleGradKernel<paddle::platform::CPUDeviceContext,
                                         paddle::platform::complex128>);
+
+REGISTER_OP_VERSION(elementwise_mul)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_mul for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_mul.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_pow_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_pow_op.cc
@@ -13,6 +13,7 @@ limitations under the License. */
 
 #include <string>
 
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 
 namespace paddle {
@@ -83,3 +84,12 @@ REGISTER_OP_CPU_KERNEL(
     ops::ElementwisePowGradKernel<paddle::platform::CPUDeviceContext, double>,
     ops::ElementwisePowGradKernel<paddle::platform::CPUDeviceContext, int>,
     ops::ElementwisePowGradKernel<paddle::platform::CPUDeviceContext, int64_t>);
+
+REGISTER_OP_VERSION(elementwise_pow)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_pow for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_pow.",
+            1.0f));

--- a/paddle/fluid/operators/elementwise/elementwise_sub_op.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_sub_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #include <string>
 
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/elementwise/elementwise_op.h"
 #include "paddle/fluid/platform/complex128.h"
 #include "paddle/fluid/platform/complex64.h"
@@ -156,3 +157,12 @@ REGISTER_OP_CPU_KERNEL(
                                         paddle::platform::complex64>,
     ops::ElementwiseSubDoubleGradKernel<paddle::platform::CPUDeviceContext,
                                         paddle::platform::complex128>);
+
+REGISTER_OP_VERSION(elementwise_sub)
+    .AddCheckpoint(
+        R"ROC(Register elementwise_sub for adding the attribute of Scale_y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "Scale_y",
+            "In order to support the function of scaling the input Y when "
+            "using the operator of elementwise_sub.",
+            1.0f));

--- a/paddle/fluid/operators/matmul_op.cc
+++ b/paddle/fluid/operators/matmul_op.cc
@@ -16,6 +16,7 @@ limitations under the License. */
 #include <utility>
 #include <vector>
 #include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/operators/math/blas.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/platform/mkldnn_helper.h"
@@ -932,3 +933,13 @@ REGISTER_OP_CUDA_KERNEL(
     ops::MatMulDoubleGradKernel<paddle::platform::CUDADeviceContext, float>,
     ops::MatMulDoubleGradKernel<paddle::platform::CUDADeviceContext, double>);
 #endif
+
+REGISTER_OP_VERSION(matmul)
+    .AddCheckpoint(
+        R"ROC(Register matmul for adding the attribute of fused_reshape_Y)ROC",
+        paddle::framework::compatible::OpVersionDesc().NewAttr(
+            "fused_reshape_Y",
+            "In order to support the function of fused the input Y "
+            " and input X into the input X when "
+            "using the operator of matmul, and get raw shape of input Y.",
+            {}));


### PR DESCRIPTION
### PR types
Others

### PR changes
OPs

### Describe
add the op version check for the elementwise ops, matmul, argmax, argmin for inference compatibility