### PR TITLE
Fix Unix Sleep for Wrong Time

### DIFF
--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -932,7 +932,7 @@ inline void retry_sleep(unsigned millisecond) {
 #ifdef _WIN32
   Sleep(millisecond);
 #else
-  sleep(millisecond);
+  usleep(millisecond * 1000);
 #endif
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
PADDLE_RETRY_CUDA_SUCCESS used wrong sleep time so it can cause timeout in unittest. This PR fixed it.

After we searched the doc in https://pubs.opengroup.org/onlinepubs/7908799/xsh/unistd.h.html, the time unit of `sleep` in `unistd.h` takes "seconds", `usleep` takes "microseconds", `Sleep` in `windows.h` takes "milliseconds".
 