### PR TITLE
float16 for fc op in GPU device

### DIFF
--- a/paddle/fluid/operators/fc_op.cu.cc
+++ b/paddle/fluid/operators/fc_op.cu.cc
@@ -17,4 +17,5 @@ limitations under the License. */
 namespace ops = paddle::operators;
 REGISTER_OP_CUDA_KERNEL(
     fc, ops::FCOpKernel<paddle::platform::CUDADeviceContext, float>,
-    ops::FCOpKernel<paddle::platform::CUDADeviceContext, double>);
+    ops::FCOpKernel<paddle::platform::CUDADeviceContext, double>,
+    ops::FCOpKernel<paddle::platform::CUDADeviceContext, paddle::platform::float16>);

--- a/paddle/fluid/operators/math/fc.cu
+++ b/paddle/fluid/operators/math/fc.cu
@@ -15,6 +15,7 @@ limitations under the License. */
 #include <algorithm>
 #include "paddle/fluid/operators/math/blas.h"
 #include "paddle/fluid/operators/math/fc.h"
+#include <cuda_fp16.h>
 
 namespace paddle {
 namespace operators {
@@ -31,6 +32,11 @@ struct FcTypeTraits<float> {
 template <>
 struct FcTypeTraits<double> {
   typedef double4 Type;
+};
+
+template <>
+struct FcTypeTraits<platform::float16> {
+  typedef half4 Type;
 };
 
 template <typename T, bool DoRelu>
@@ -127,6 +133,7 @@ class FCFunctor<platform::CUDADeviceContext, T> {
 
 template class FCFunctor<platform::CUDADeviceContext, float>;
 template class FCFunctor<platform::CUDADeviceContext, double>;
+template class FCFunctor<platform::CUDADeviceContext, platform::float16>;
 
 }  // namespace math
 }  // namespace operators


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
OPs
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
Add float16 data type for fc op in GPU device
<!-- Describe what this PR does -->
