### PR TITLE
[Dy2Stat] Don't convert to paddle.shape if var_x.shape is not negetive

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -274,7 +274,7 @@ def convert_var_shape(x, idx=None, in_control_flow=False):
         num_negetive = sum([1 if i < 0 else 0 for i in list_shape])
         return num_negetive > 0
 
-    # 1. When `x` is Variable, call nn.shape(x) in following cases:
+    # When `x` is Variable, call nn.shape(x) in following cases:
     #  (1) The shape of `x` is used in control flow condition.
     #      ```
     #      if x.shape[0] == 1:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -262,14 +262,28 @@ def convert_len(var):
         return len(var)
 
 
-def convert_var_shape(x):
+def convert_var_shape(x, idx=None):
     """
     A function representation of the shape of variable.
     """
-    if isinstance(x, Variable):
-        return nn.shape(x)
+
+    def has_negetive(list_shape, idx=None):
+        if idx is not None:
+            return list_shape[idx] < 0
+
+        num_negetive = sum([1 if i < 0 else 0 for i in list_shape])
+        return num_negetive > 0
+
+    if idx is None:
+        if has_negetive(x.shape, idx) and isinstance(x, Variable):
+            return nn.shape(x)
+        else:
+            return x.shape
     else:
-        return x.shape
+        if has_negetive(x.shape, idx) and isinstance(x, Variable):
+            return nn.shape(x)[idx]
+        else:
+            return x.shape[idx]
 
 
 def convert_shape_compare(left, *args):

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -192,10 +192,15 @@ class TestTensorShapeBasic(unittest.TestCase):
         self.input = numpy.ones(5).astype("int32")
         self.place = fluid.CUDAPlace(0) if fluid.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
+        self._set_input_spec()
+        self._set_expected_op_num()
         self.init_test_func()
 
     def init_test_func(self):
         self.dygraph_func = dyfunc_tensor_shape_1
+
+    def _set_input_spec(self):
+        self.input_spec = [paddle.static.InputSpec(shape=[5], dtype="int32")]
 
     def _run(self, to_static):
         with fluid.dygraph.guard():
@@ -218,6 +223,30 @@ class TestTensorShapeBasic(unittest.TestCase):
             numpy.allclose(dygraph_res, static_res),
             msg='dygraph res is {}\nstatic_res is {}'.format(dygraph_res,
                                                              static_res))
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 2
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
+
+    def _compute_op_num(self, program):
+        self.op_num = sum([len(block.ops) for block in program.blocks])
+        self.shape_op_num = 0
+        self.slice_op_num = 0
+
+        for block in program.blocks:
+            self.shape_op_num += len(
+                [op for op in block.ops if op.type == "shape"])
+            self.slice_op_num += len(
+                [op for op in block.ops if op.type == "slice"])
+
+    def test_op_num(self):
+        static_layer = paddle.jit.to_static(self.dygraph_func, self.input_spec)
+        program = static_layer.main_program
+        self._compute_op_num(program)
+        self.assertEqual(self.op_num, self.expected_op_num)
+        self.assertEqual(self.shape_op_num, self.expected_shape_op_num)
+        self.assertEqual(self.slice_op_num, self.expected_slice_op_num)
 
 
 class TestTensorShapeBasic2(TestTensorShapeBasic):
@@ -243,12 +272,14 @@ class TestTensorShapeBasic5(TestTensorShapeBasic):
 class TestTupleShape1(TestTensorShapeBasic):
     def init_test_func(self):
         self.input = numpy.ones((5, 7)).astype("int32")
+        self.input_spec = [paddle.static.InputSpec(shape=[5, 7], dtype="int32")]
         self.dygraph_func = dyfunc_tuple_shape_1
 
 
 class TestTupleShape2(TestTensorShapeBasic):
     def init_test_func(self):
         self.input = numpy.ones((5, 7)).astype("int32")
+        self.input_spec = [paddle.static.InputSpec(shape=[5, 7], dtype="int32")]
         self.dygraph_func = dyfunc_tuple_shape_2
 
 
@@ -268,10 +299,20 @@ class TestTensorShapeInFor1(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_for_1
 
+    def _set_expected_op_num(self):
+        self.expected_op_num = 7
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
+
 
 class TestTensorShapeInFor2(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_for_2
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 7
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
 
 
 # 4. Tests with control flow while loop
@@ -279,20 +320,132 @@ class TestTensorShapeInWhile1(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_while_1
 
+    def _set_expected_op_num(self):
+        self.expected_op_num = 4
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
+
 
 class TestTensorShapeInWhile2(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_while_2
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 4
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
 
 
 class TestTensorShapeInWhile3(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_while_3
 
+    def _set_expected_op_num(self):
+        self.expected_op_num = 2
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
+
 
 class TestTensorShapeInWhile4(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_while_4
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 5
+        self.expected_shape_op_num = 0
+        self.expected_slice_op_num = 0
+
+
+# 5. Test op num for negetive dim
+class TestOpNumBasicWithTensorShape(unittest.TestCase):
+    def setUp(self):
+        self._set_input_spec()
+        self._set_test_func()
+        self._set_expected_op_num()
+
+    def _set_input_spec(self):
+        self.input_spec = [
+            paddle.static.InputSpec(
+                shape=[-1, 5], dtype="int32")
+        ]
+
+    def _set_test_func(self):
+        self.dygraph_func = dyfunc_tensor_shape_1
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 3
+        self.expected_shape_op_num = 1
+        self.expected_slice_op_num = 0
+
+    def _compute_op_num(self, program):
+        self.op_num = sum([len(block.ops) for block in program.blocks])
+        self.shape_op_num = 0
+        self.slice_op_num = 0
+
+        for block in program.blocks:
+            self.shape_op_num += len(
+                [op for op in block.ops if op.type == "shape"])
+            self.slice_op_num += len(
+                [op for op in block.ops if op.type == "slice"])
+
+    def test_op_num(self):
+        static_layer = paddle.jit.to_static(self.dygraph_func, self.input_spec)
+        program = static_layer.main_program
+
+        self._compute_op_num(program)
+        self.assertEqual(self.op_num, self.expected_op_num)
+        self.assertEqual(self.shape_op_num, self.expected_shape_op_num)
+        self.assertEqual(self.slice_op_num, self.expected_slice_op_num)
+
+
+class TestOpNumBasicWithTensorShape4(TestOpNumBasicWithTensorShape):
+    def _set_test_func(self):
+        self.dygraph_func = dyfunc_tensor_shape_4
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 6
+        self.expected_shape_op_num = 1
+        self.expected_slice_op_num = 1
+
+
+class TestOpNumWithTensorShapeTuple1(TestOpNumBasicWithTensorShape):
+    def _set_test_func(self):
+        self.dygraph_func = dyfunc_tuple_shape_1
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 5
+        self.expected_shape_op_num = 1
+        self.expected_slice_op_num = 1
+
+
+class TestOpNumWithTensorShapeInIf1(TestOpNumBasicWithTensorShape):
+    def _set_test_func(self):
+        self.dygraph_func = dyfunc_with_if_1
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 28
+        self.expected_shape_op_num = 4
+        self.expected_slice_op_num = 2
+
+
+class TestOpNumWithTensorShapeInFor1(TestOpNumBasicWithTensorShape):
+    def _set_test_func(self):
+        self.dygraph_func = dyfunc_with_for_1
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 22
+        self.expected_shape_op_num = 3
+        self.expected_slice_op_num = 3
+
+
+class TestOpNumWithTensorShapeInWhile1(TestOpNumBasicWithTensorShape):
+    def _set_test_func(self):
+        self.dygraph_func = dyfunc_with_while_1
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 22
+        self.expected_shape_op_num = 3
+        self.expected_slice_op_num = 3
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -288,10 +288,20 @@ class TestTensorShapeInIf1(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_if_1
 
+    def _set_expected_op_num(self):
+        self.expected_op_num = 26
+        self.expected_shape_op_num = 2
+        self.expected_slice_op_num = 2
+
 
 class TestTensorShapeInIf2(TestTensorShapeBasic):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_if_2
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 14
+        self.expected_shape_op_num = 2
+        self.expected_slice_op_num = 1
 
 
 # 3. Tests with control flow for loop
@@ -300,40 +310,25 @@ class TestTensorShapeInFor1(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_with_for_1
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 7
-        self.expected_shape_op_num = 0
-        self.expected_slice_op_num = 0
+        self.expected_op_num = 22
+        self.expected_shape_op_num = 3
+        self.expected_slice_op_num = 3
 
 
-class TestTensorShapeInFor2(TestTensorShapeBasic):
+class TestTensorShapeInFor2(TestTensorShapeInFor1):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_for_2
 
-    def _set_expected_op_num(self):
-        self.expected_op_num = 7
-        self.expected_shape_op_num = 0
-        self.expected_slice_op_num = 0
-
 
 # 4. Tests with control flow while loop
-class TestTensorShapeInWhile1(TestTensorShapeBasic):
+class TestTensorShapeInWhile1(TestTensorShapeInFor1):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_while_1
 
-    def _set_expected_op_num(self):
-        self.expected_op_num = 4
-        self.expected_shape_op_num = 0
-        self.expected_slice_op_num = 0
 
-
-class TestTensorShapeInWhile2(TestTensorShapeBasic):
+class TestTensorShapeInWhile2(TestTensorShapeInFor1):
     def init_test_func(self):
         self.dygraph_func = dyfunc_with_while_2
-
-    def _set_expected_op_num(self):
-        self.expected_op_num = 4
-        self.expected_shape_op_num = 0
-        self.expected_slice_op_num = 0
 
 
 class TestTensorShapeInWhile3(TestTensorShapeBasic):
@@ -341,9 +336,9 @@ class TestTensorShapeInWhile3(TestTensorShapeBasic):
         self.dygraph_func = dyfunc_with_while_3
 
     def _set_expected_op_num(self):
-        self.expected_op_num = 2
-        self.expected_shape_op_num = 0
-        self.expected_slice_op_num = 0
+        self.expected_op_num = 25
+        self.expected_shape_op_num = 6
+        self.expected_slice_op_num = 3
 
 
 class TestTensorShapeInWhile4(TestTensorShapeBasic):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
1. When `x` is Variable, call nn.shape(x) only in following cases:
- The shape of `x` is used in control flow condition.
     ```python
     if x.shape[0] == 1:
         y = XX
     ```python
- The dim to be used is negetive
     ```python
     # Assume x.shape=[3, -1] in static mode
     y = paddle.reshape(x, shape=[1, x.shape[1]])
     ```
2.  When `x` is Variable, but x.shape or x.shape[idx] doesn't contain negetive value, don't convert to paddle.shape()