### PR TITLE
fix a bug in op_version_registry, test=develop, test=op_version

### DIFF
--- a/paddle/fluid/framework/op_version_registry.cc
+++ b/paddle/fluid/framework/op_version_registry.cc
@@ -18,29 +18,6 @@ namespace paddle {
 namespace framework {
 namespace compatible {
 
-namespace {
-template <OpUpdateType type__, typename InfoType>
-OpUpdate<InfoType, type__>* new_update(InfoType&& info) {
-  return new OpUpdate<InfoType, type__>(info);
-}
-}
-
-OpVersionDesc&& OpVersionDesc::ModifyAttr(const std::string& name,
-                                          const std::string& remark,
-                                          const OpAttrVariantT& default_value) {
-  infos_.emplace_back(new_update<OpUpdateType::kModifyAttr>(
-      OpAttrInfo(name, remark, default_value)));
-  return std::move(*this);
-}
-
-OpVersionDesc&& OpVersionDesc::NewAttr(const std::string& name,
-                                       const std::string& remark,
-                                       const OpAttrVariantT& default_value) {
-  infos_.emplace_back(new_update<OpUpdateType::kNewAttr>(
-      OpAttrInfo(name, remark, default_value)));
-  return std::move(*this);
-}
-
 OpVersionDesc&& OpVersionDesc::NewInput(const std::string& name,
                                         const std::string& remark) {
   infos_.emplace_back(

--- a/paddle/fluid/operators/conv_transpose_op.cc
+++ b/paddle/fluid/operators/conv_transpose_op.cc
@@ -661,7 +661,7 @@ REGISTER_OP_VERSION(conv_transpose)
             "output_padding",
             "In order to add additional size to one side of each dimension "
             "in the output",
-            {}));
+            std::vector<int>{}));
 
 REGISTER_OP_VERSION(conv2d_transpose)
     .AddCheckpoint(
@@ -672,7 +672,7 @@ REGISTER_OP_VERSION(conv2d_transpose)
             "output_padding",
             "In order to add additional size to one side of each dimension "
             "in the output",
-            {}));
+            std::vector<int>{}));
 
 REGISTER_OP_VERSION(conv3d_transpose)
     .AddCheckpoint(
@@ -683,7 +683,7 @@ REGISTER_OP_VERSION(conv3d_transpose)
             "output_padding",
             "In order to add additional size to one side of each dimension "
             "in the output",
-            {}));
+            std::vector<int>{}));
 
 REGISTER_OP_VERSION(depthwise_conv2d_transpose)
     .AddCheckpoint(
@@ -694,4 +694,4 @@ REGISTER_OP_VERSION(depthwise_conv2d_transpose)
             "output_padding",
             "In order to add additional size to one side of each dimension "
             "in the output",
-            {}));
+            std::vector<int>{}));

--- a/paddle/fluid/operators/fused/fusion_gru_op.cc
+++ b/paddle/fluid/operators/fused/fusion_gru_op.cc
@@ -489,4 +489,4 @@ REGISTER_OP_VERSION(fusion_gru)
             "Scale_weights",
             "The added attribute 'Scale_weights' is not yet "
             "registered.",
-            {1.0f}));
+            std::vector<float>{1.0f}));

--- a/paddle/fluid/operators/unique_op.cc
+++ b/paddle/fluid/operators/unique_op.cc
@@ -184,7 +184,7 @@ REGISTER_OP_VERSION(unique)
             .NewAttr("axis",
                      "The axis to apply unique. If None, the input will be "
                      "flattened.",
-                     {})
+                     std::vector<int>{})
             .NewAttr("is_sorted",
                      "If True, the unique elements of X are in ascending order."
                      "Otherwise, the unique elements are not sorted.",


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
解决 `REGISTER_OP_VERSION` 注册过程中有类型歧义的参数能生效，无歧义的参数可能报错的问题。