### PR TITLE
Enhance debugging

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -33,6 +33,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/transfer_scope_cache.h"
 #include "paddle/fluid/framework/unused_var_check.h"
 #include "paddle/fluid/framework/var_type.h"
+#include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/profiler.h"
 #ifdef PADDLE_WITH_XPU
 #include "paddle/fluid/platform/xpu_info.h"
@@ -1121,7 +1122,10 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
 
   /*For profiling/benchmark only*/
   if (FLAGS_benchmark) {
+    VLOG(4) << "Operator(" << Type() << "): context wait and get last error";
+    usleep(1000);
     dev_ctx->Wait();
+    PADDLE_ENFORCE_CUDA_SUCCESS(cudaGetLastError());
   }
 
   if (FLAGS_fast_check_nan_inf) {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -358,6 +358,7 @@ std::string OperatorBase::DebugStringEx(const Scope* scope) const {
           ss << ":" << dtype;
           ss << "[" << GetDimsDebug(*scope, var_name, true) << "]";
           ss << "(" << GetLoDDebug(*scope, var_name) << ")";
+          ss << "(" << GetPlace(*scope, var_name) << ")";
         }
       }
       if (i != output.second.size() - 1) {

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1153,8 +1153,10 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
   /*For profiling/benchmark only*/
   if (FLAGS_benchmark) {
     dev_ctx->Wait();
+#if defined(PADDLE_WITH_CUDA)
     PADDLE_ENFORCE_CUDA_SUCCESS(cudaGetLastError());
     VLOG(4) << "Operator(" << Type() << "): context wait and get last error";
+#endif
   }
 
   if (FLAGS_fast_check_nan_inf) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Enhance debugging

- Add place information when in op debug string, which is useful for finding some bugs related with place. 
For example, 
![image](https://user-images.githubusercontent.com/6888866/103280131-91223a80-4a0a-11eb-842f-275ee8922afd.png)

After debugging, I found the problem is that the `input x` is generated on `GPU 0` by dataloader, and `input y` is created on `GPU 1` by other operator. So, the kernel of `not_equal op` use (data) pointer from two cards, which is wrong.

If the logs contain place information, we can find the bug easier. As the following log message shows,
![image](https://user-images.githubusercontent.com/6888866/103283101-9daa9100-4a12-11eb-8bad-85fcd4041f44.png)


- Because of the Asynchronous Execution of cuda kernel, the error message cannot point to the correct operator in which the error first happens. 

To relieve the problem, I add `cudaGetLastError` after each operator running if `FLAGS_benchmark==True`. Since `dev_ctx->Wait();` is performed if `FLAGS_benchmark==True`, it will wait for the cuda kernel to finish and check if any error happens during the cuda kernel execution, which may help to locate the operator of the first error.