### PR TITLE
fix op_register_version for compare ops, test=op_version

### DIFF
--- a/paddle/fluid/operators/controlflow/compare_op.cc
+++ b/paddle/fluid/operators/controlflow/compare_op.cc
@@ -133,9 +133,9 @@ class CompareOp : public framework::OperatorWithKernel {
   REGISTER_OP_VERSION(op_type)                                             \
       .AddCheckpoint(                                                      \
           R"ROC(Upgrade compare ops, add a new attribute [force_cpu])ROC", \
-          paddle::framework::compatible::OpVersionDesc().NewAttr(          \
+          paddle::framework::compatible::OpVersionDesc().ModifyAttr(       \
               "force_cpu",                                                 \
-              "In order to force fill output variable to cpu memory.",     \
+              "In order to force fill output variable to gpu memory.",     \
               false));
 
 #define REGISTER_COMPARE_OP(op_type, _equation)                           \


### PR DESCRIPTION
### PR types

Others 

### PR changes

OPs 

### Describe

fix compare ops op_register_version to modify attribute 'force_cpu' from 'true' to 'false' 
