### PR TITLE
[Cherry-pick] add the paddle.distributed.split api #29970

### DIFF
--- a/python/paddle/fluid/dygraph/parallel_helper.py
+++ b/python/paddle/fluid/dygraph/parallel_helper.py
@@ -44,5 +44,9 @@ def _init_parallel_ctx():
 
 def _broadcast_parameters(parameters):
     for param in parameters:
+        # In model parallel, some parameters are split into multiple devices,
+        # so we could not broadcast these parameters.
+        if param.is_distributed: continue
+
         if isinstance(param, Parameter) and param.trainable:
             collective._broadcast(param, 0, sync_mode=True)

--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -73,6 +73,10 @@ if(NOT WITH_GPU OR WIN32)
     LIST(REMOVE_ITEM TEST_OPS test_collective_sendrecv)
     LIST(REMOVE_ITEM TEST_OPS test_reducescatter)
     LIST(REMOVE_ITEM TEST_OPS test_reducescatter_api)
+    LIST(REMOVE_ITEM TEST_OPS test_collective_split_embedding)
+    LIST(REMOVE_ITEM TEST_OPS test_collective_split_embedding_none_divisible)
+    LIST(REMOVE_ITEM TEST_OPS test_collective_split_row_linear)
+    LIST(REMOVE_ITEM TEST_OPS test_collective_split_col_linear)
     LIST(REMOVE_ITEM TEST_OPS test_collective_reduce_api)
     LIST(REMOVE_ITEM TEST_OPS test_collective_scatter_api)
     LIST(REMOVE_ITEM TEST_OPS test_collective_barrier_api)
@@ -824,6 +828,17 @@ if(WITH_GPU AND NOT WIN32)
     set_tests_properties(test_collective_barrier_api PROPERTIES TIMEOUT 120)
     set_tests_properties(test_collective_scatter PROPERTIES TIMEOUT 120)
     set_tests_properties(test_collective_sendrecv PROPERTIES TIMEOUT 120)
+    set_tests_properties(test_collective_split_embedding
+        test_collective_split_embedding_none_divisible
+        test_collective_split_row_linear
+        test_collective_split_col_linear
+        test_collective_scatter_api
+        test_collective_barrier_api
+        test_collective_reduce_api
+        test_collective_allreduce_api
+        test_collective_broadcast_api
+        test_collective_allgather_api
+        PROPERTIES LABELS "RUN_TYPE=DIST")
 endif()
 if(WITH_GPU)
     set_tests_properties(test_imperative_auto_mixed_precision PROPERTIES TIMEOUT 120)

--- a/python/paddle/fluid/tests/unittests/column_parallel_linear_api.py
+++ b/python/paddle/fluid/tests/unittests/column_parallel_linear_api.py
@@ -29,6 +29,8 @@ import paddle.fluid as fluid
 import paddle.fluid.profiler as profiler
 import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
+import paddle.distributed.fleet as fleet
+from paddle.fluid.incubate.fleet.base import role_maker
 import unittest
 from multiprocessing import Process
 import paddle.fluid.layers as layers
@@ -38,25 +40,39 @@ from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 paddle.enable_static()
 
 
-class TestCollectiveScatterAPI(TestCollectiveAPIRunnerBase):
+class TestColumnParallelLinearAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):
         self.global_ring_id = 0
 
     def get_model(self, main_prog, startup_program, rank):
         with fluid.program_guard(main_prog, startup_program):
-            tindata = layers.data(
-                name="tindata",
-                shape=[10, 1000],
-                dtype='float32',
-                append_batch_size=False)
-            toutdata = layers.fill_constant(
-                shape=[5, 1000], dtype='float32', value=1.0)
-            tensor_list = None
-            if rank == 1:
-                tensor_list = paddle.split(tindata, 2, axis=0)
-            paddle.distributed.scatter(toutdata, tensor_list, src=1)
-            return [toutdata]
+            fleet.init(is_collective=True)
+            np.random.seed(2020)
+            np_array = np.random.rand(1000, 16)
+
+            data = paddle.static.data(
+                name='tindata', shape=[10, 1000], dtype="float32")
+            paddle.distributed.broadcast(data, src=0)
+            if rank == 0:
+                param_attr = paddle.fluid.ParamAttr(
+                    initializer=paddle.fluid.initializer.NumpyArrayInitializer(
+                        np_array[:, 0:8]), )
+            else:
+                param_attr = paddle.fluid.ParamAttr(
+                    initializer=paddle.fluid.initializer.NumpyArrayInitializer(
+                        np_array[:, 8:16]), )
+
+            linear_out = paddle.distributed.split(
+                data,
+                size=(1000, 16),
+                operation='linear',
+                axis=1,
+                num_partitions=2,
+                weight_attr=param_attr,
+                bias_attr=False, )
+
+            return [linear_out]
 
 
 if __name__ == "__main__":
-    runtime_main(TestCollectiveScatterAPI, "scatter")
+    runtime_main(TestColumnParallelLinearAPI, "column_parallel_linear")

--- a/python/paddle/fluid/tests/unittests/parallel_embedding_api_none_divisible.py
+++ b/python/paddle/fluid/tests/unittests/parallel_embedding_api_none_divisible.py
@@ -29,6 +29,8 @@ import paddle.fluid as fluid
 import paddle.fluid.profiler as profiler
 import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
+import paddle.distributed.fleet as fleet
+from paddle.fluid.incubate.fleet.base import role_maker
 import unittest
 from multiprocessing import Process
 import paddle.fluid.layers as layers
@@ -38,25 +40,37 @@ from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 paddle.enable_static()
 
 
-class TestCollectiveScatterAPI(TestCollectiveAPIRunnerBase):
+class TestParallelEmbeddingAPINoneDivisible(TestCollectiveAPIRunnerBase):
     def __init__(self):
         self.global_ring_id = 0
 
     def get_model(self, main_prog, startup_program, rank):
         with fluid.program_guard(main_prog, startup_program):
-            tindata = layers.data(
-                name="tindata",
-                shape=[10, 1000],
-                dtype='float32',
-                append_batch_size=False)
-            toutdata = layers.fill_constant(
-                shape=[5, 1000], dtype='float32', value=1.0)
-            tensor_list = None
-            if rank == 1:
-                tensor_list = paddle.split(tindata, 2, axis=0)
-            paddle.distributed.scatter(toutdata, tensor_list, src=1)
-            return [toutdata]
+            fleet.init(is_collective=True)
+            np.random.seed(2020)
+            np_array = np.random.rand(9, 8)
+            paddle.seed(2020)
+            data_in = paddle.randint(0, 7, shape=(10, 4))
+
+            data = paddle.static.data(
+                name='tindata', shape=[10, 1000], dtype="float32")
+            if rank == 0:
+                param_attr = paddle.fluid.ParamAttr(
+                    initializer=paddle.fluid.initializer.NumpyArrayInitializer(
+                        np_array[0:5, :]), )
+            else:
+                param_attr = paddle.fluid.ParamAttr(
+                    initializer=paddle.fluid.initializer.NumpyArrayInitializer(
+                        np_array[5:9, :]), )
+
+            emb_out = paddle.distributed.split(
+                data_in, (7, 8),
+                operation="embedding",
+                num_partitions=2,
+                weight_attr=param_attr)
+
+            return [data_in, emb_out]
 
 
 if __name__ == "__main__":
-    runtime_main(TestCollectiveScatterAPI, "scatter")
+    runtime_main(TestParallelEmbeddingAPINoneDivisible, "parallel_embedding")

--- a/python/paddle/fluid/tests/unittests/row_parallel_linear_api.py
+++ b/python/paddle/fluid/tests/unittests/row_parallel_linear_api.py
@@ -29,6 +29,8 @@ import paddle.fluid as fluid
 import paddle.fluid.profiler as profiler
 import paddle.fluid.unique_name as nameGen
 from paddle.fluid import core
+import paddle.distributed.fleet as fleet
+from paddle.fluid.incubate.fleet.base import role_maker
 import unittest
 from multiprocessing import Process
 import paddle.fluid.layers as layers
@@ -38,25 +40,40 @@ from test_collective_api_base import TestCollectiveAPIRunnerBase, runtime_main
 paddle.enable_static()
 
 
-class TestCollectiveScatterAPI(TestCollectiveAPIRunnerBase):
+class TestRowParallelLinearAPI(TestCollectiveAPIRunnerBase):
     def __init__(self):
         self.global_ring_id = 0
 
     def get_model(self, main_prog, startup_program, rank):
         with fluid.program_guard(main_prog, startup_program):
-            tindata = layers.data(
-                name="tindata",
-                shape=[10, 1000],
-                dtype='float32',
-                append_batch_size=False)
-            toutdata = layers.fill_constant(
-                shape=[5, 1000], dtype='float32', value=1.0)
-            tensor_list = None
-            if rank == 1:
-                tensor_list = paddle.split(tindata, 2, axis=0)
-            paddle.distributed.scatter(toutdata, tensor_list, src=1)
-            return [toutdata]
+            fleet.init(is_collective=True)
+            np.random.seed(2020)
+            np_array = np.random.rand(1000, 16)
+
+            data = paddle.static.data(
+                name='tindata', shape=[10, 1000], dtype="float32")
+            paddle.distributed.broadcast(data, src=0)
+            data = paddle.split(data, 2, axis=1)[rank]
+            if rank == 0:
+                param_attr = paddle.fluid.ParamAttr(
+                    initializer=paddle.fluid.initializer.NumpyArrayInitializer(
+                        np_array[0:500, :]), )
+            else:
+                param_attr = paddle.fluid.ParamAttr(
+                    initializer=paddle.fluid.initializer.NumpyArrayInitializer(
+                        np_array[500:1000, :]), )
+
+            linear_out = paddle.distributed.split(
+                data,
+                size=(1000, 8),
+                operation='linear',
+                axis=0,
+                num_partitions=2,
+                weight_attr=param_attr,
+                bias_attr=False, )
+
+            return [linear_out]
 
 
 if __name__ == "__main__":
-    runtime_main(TestCollectiveScatterAPI, "scatter")
+    runtime_main(TestRowParallelLinearAPI, "row_parallel_linear")

--- a/python/paddle/fluid/tests/unittests/test_collective_api_base.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_api_base.py
@@ -55,7 +55,7 @@ class TestCollectiveAPIRunnerBase(object):
         exe = fluid.Executor(place)
         exe.run(startup_prog)
         np.random.seed(os.getpid())
-        indata = np.random.random((10, 1000))
+        indata = np.random.random((10, 1000)).astype("float32")
         fetch_list = []
         for elem in result:
             fetch_list.append(elem.name)
@@ -219,5 +219,31 @@ class TestDistBase(unittest.TestCase):
             self.assertTrue(
                 np.allclose(
                     tr1_out, need_result, rtol=1e-05, atol=1e-05))
+        elif col_type == "parallel_embedding":
+            result_data = tr0_out[0]
+            np.random.seed(2020)
+            need_result = np.random.rand(10, 8)
+            for i in range(result_data.shape[0]):
+                for j in range(result_data.shape[1]):
+                    data = result_data[i][j]
+                    if data >= 4: data += 1
+                    assert np.allclose(
+                        tr0_out[1][i][j], need_result[data], atol=1e-08)
+        elif col_type == "row_parallel_linear":
+            result_data = tr0_out[0]
+            np.random.seed(2020)
+            weight = np.random.rand(1000, 16)
+            need_result = np.matmul(input1, weight)
+            self.assertTrue(
+                np.allclose(
+                    result_data, need_result, rtol=1e-05, atol=1e-05))
+        elif col_type == "column_parallel_linear":
+            result_data = tr0_out[0]
+            np.random.seed(2020)
+            weight = np.random.rand(1000, 16)
+            need_result = np.matmul(input1, weight)
+            self.assertTrue(
+                np.allclose(
+                    result_data, need_result, rtol=1e-05, atol=1e-05))
         else:
             pass

--- a/python/paddle/fluid/tests/unittests/test_collective_split_col_linear.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_split_col_linear.py
@@ -1,0 +1,35 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import numpy as np
+import paddle
+
+from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
+
+
+class TestColParallelLinearAPI(TestDistBase):
+    def _setup_config(self):
+        pass
+
+    def test_col_parallel_linear(self):
+        self.check_with_place("column_parallel_linear_api.py",
+                              "column_parallel_linear", "nccl")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_collective_split_embedding.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_split_embedding.py
@@ -1,0 +1,35 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import numpy as np
+import paddle
+
+from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
+
+
+class TestParallelEmbeddingAPI(TestDistBase):
+    def _setup_config(self):
+        pass
+
+    def test_parallel_embedding(self):
+        self.check_with_place("parallel_embedding_api.py", "parallel_embedding",
+                              "nccl")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_collective_split_embedding_none_divisible.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_split_embedding_none_divisible.py
@@ -1,0 +1,35 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import numpy as np
+import paddle
+
+from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
+
+
+class TestParallelEmbeddingNoneDivisibleAPI(TestDistBase):
+    def _setup_config(self):
+        pass
+
+    def test_parallel_embedding_none_divisible(self):
+        self.check_with_place("parallel_embedding_api_none_divisible.py",
+                              "parallel_embedding", "nccl")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_collective_split_row_linear.py
+++ b/python/paddle/fluid/tests/unittests/test_collective_split_row_linear.py
@@ -1,0 +1,35 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+import unittest
+import numpy as np
+import paddle
+
+from test_collective_api_base import TestDistBase
+
+paddle.enable_static()
+
+
+class TestRowParallelLinearAPI(TestDistBase):
+    def _setup_config(self):
+        pass
+
+    def test_row_parallel_linear(self):
+        self.check_with_place("row_parallel_linear_api.py",
+                              "row_parallel_linear", "nccl")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add the paddle.distributed.split api, which implements the parallel embedding and parallel linear.
It splits the weight of the specified operation into multiple devices and do the computation in parallel.

Now the following three cases are supported.

- Case 1: Parallel Embedding
   The weight of the embedding operation is a NxM matrix with N rows and M columns. With parallel embedding, the weight is split into num_partitions partitions, each of which is a matrix with N/num_partitions rows and M column.
   Usage：
```python
import numpy
import paddle
from paddle.distributed import init_parallel_env
init_parallel_env()
np_data = numpy.random.randint(0, 8, (10,4))
data = paddle.to_tensor(np_data)
emb_out = padle.distributed.split(
    data,
    (8, 128)
    operation="embedding",
    num_partitions=2)
```

- Case 2: Row Parallel Linear
   The weight of the linear operation is a NxM matrix with N rows and M columns. With row parallel linear, the weight is split into num_partitions partitions, each of which is a matrix with N/num_partitions rows and M column.
   Usage：
```python
import numpy
import paddle
from paddle.distributed import init_parallel_env
init_parallel_env()
np_data = numpy.random.rand(10, 1000)
data = paddle.to_tensor(np_data)
data = paddle.distributed.broadcast(data, src=0)
rank = paddle.distributed.ParallelEnv().local_rank
data = paddle.split(data, 2, axis=1)[rank]
linear_out = padle.distributed.split(
    data,
    (1000, 16)
    axis=0,
    operation="linear",
    num_partitions=2)
```

- Case 3: Column Parallel Linear
   The weight of the linear operation is a NxM matrix with N rows and M columns. With column parallel linear, the weight is split into num_paratitions partitions, each of which is a matrix with N rows and M/num_partitions column.
   Usage：
```python
import numpy
import paddle
from paddle.distributed import init_parallel_env
init_parallel_env()
np_data = numpy.random.rand(10, 1000)
data = paddle.to_tensor(np_data)
data = paddle.distributed.broadcast(data, src=0)
linear_out = padle.distributed.split(
    data,
    (1000, 16)
    axis=1,
    operation="linear",
    num_partitions=2)
```
