### PR TITLE
Fix the formate of raising error in randperm op

### DIFF
--- a/paddle/fluid/operators/randperm_op.cc
+++ b/paddle/fluid/operators/randperm_op.cc
@@ -31,7 +31,7 @@ class RandpermOp : public framework::OperatorWithKernel {
     int n = ctx->Attrs().Get<int>("n");
     PADDLE_ENFORCE_GT(
         n, 0, platform::errors::InvalidArgument(
-                  "The input 'n' of randperm op must be greater than 0. "
+                  "The input 'n' of randperm op should be greater than 0. "
                   "But received %d.",
                   n));
 

--- a/paddle/fluid/operators/randperm_op.cc
+++ b/paddle/fluid/operators/randperm_op.cc
@@ -31,7 +31,9 @@ class RandpermOp : public framework::OperatorWithKernel {
     int n = ctx->Attrs().Get<int>("n");
     PADDLE_ENFORCE_GT(
         n, 0, platform::errors::InvalidArgument(
-                  "The input(n) of randperm op must be greater than 0."));
+                  "The input 'n' of randperm op must be greater than 0. "
+                  "But received %d.",
+                  n));
 
     ctx->SetOutputDim("Out", framework::make_ddim({n}));
   }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix the formate of raising error in randperm op