### PR TITLE
Add callback after TensorCopy 

### DIFF
--- a/paddle/fluid/framework/garbage_collector.cc
+++ b/paddle/fluid/framework/garbage_collector.cc
@@ -107,6 +107,15 @@ void StreamGarbageCollector::ClearCallback(
     const std::function<void()> &callback) {
   callback_manager_->AddCallback(callback);
 }
+
+CUDAPinnedGarbageCollector::CUDAPinnedGarbageCollector(
+    const platform::CUDAPinnedPlace &place, size_t max_memory_size)
+    : GarbageCollector(place, max_memory_size) {}
+
+void CUDAPinnedGarbageCollector::ClearCallback(
+    const std::function<void()> &callback) {
+  callback();
+}
 #endif
 
 int64_t GetEagerDeletionThreshold() {

--- a/paddle/fluid/framework/garbage_collector.h
+++ b/paddle/fluid/framework/garbage_collector.h
@@ -119,6 +119,15 @@ class StreamGarbageCollector : public GarbageCollector {
   cudaStream_t stream_;
   std::unique_ptr<platform::StreamCallbackManager> callback_manager_;
 };
+
+class CUDAPinnedGarbageCollector : public GarbageCollector {
+ public:
+  CUDAPinnedGarbageCollector(const platform::CUDAPinnedPlace &place,
+                             size_t max_memory_size);
+
+ protected:
+  void ClearCallback(const std::function<void()> &callback) override;
+};
 #endif
 
 template <typename Container>

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -265,8 +265,8 @@ std::shared_ptr<VarBase> VarBase::NewVarBase(const platform::Place& dst_place,
     auto* dst_selected_rows =
         new_var->MutableVar()->GetMutable<framework::SelectedRows>();
 
-    framework::TensorCopy(src_selected_rows.value(), dst_place,
-                          dst_selected_rows->mutable_value());
+    framework::TensorCopySync(src_selected_rows.value(), dst_place,
+                              dst_selected_rows->mutable_value());
     if (blocking) {
       platform::DeviceContextPool::Instance().Get(dst_place)->Wait();
       auto src_place = src_selected_rows.place();

--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -244,7 +244,7 @@ std::shared_ptr<VarBase> VarBase::NewVarBase(const platform::Place& dst_place,
     new_var->SetPersistable(Persistable());
     new_var->SetDataType(DataType());
     new_var->SetType(Type());
-    framework::TensorCopy(src_tensor, dst_place, dst_tensor);
+    framework::TensorCopySync(src_tensor, dst_place, dst_tensor);
     if (blocking) {
       platform::DeviceContextPool::Instance().Get(dst_place)->Wait();
       auto src_place = src_tensor.place();

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -92,6 +92,18 @@ paddle::framework::GarbageCollector* Tracer::MutableGarbageCollectorIfNotExists(
           "Paddle can't use CUDA device since it's not compiled with CUDA,"
           "Please recompile or reinstall Paddle with GPU support."));
 #endif
+    } else if (platform::is_cuda_pinned_place(place)) {
+#ifdef PADDLE_WITH_CUDA
+      gc.reset(new framework::CUDAPinnedGarbageCollector(
+          BOOST_GET_CONST(platform::CUDAPinnedPlace, place), 0));
+
+      VLOG(10) << "Created GarbageCollector at " << place;
+#else
+      PADDLE_THROW(platform::errors::PermissionDenied(
+          "Paddle can't use CUDAPinned device since it's not compiled with "
+          "CUDA,"
+          "Please recompile or reinstall Paddle with GPU support."));
+#endif
     } else if (platform::is_xpu_place(place)) {
 #if defined(PADDLE_WITH_XPU)
       gc.reset(new framework::XPUGarbageCollector(

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -125,6 +125,9 @@ class Tracer {
 // To access static variable current_tracer
 const std::shared_ptr<Tracer>& GetCurrentTracer();
 void SetCurrentTracer(const std::shared_ptr<Tracer>& tracer_);
+void IncreaseVarbaseReferenceCountUntilCopyComplete(
+    const std::shared_ptr<imperative::VarBase>& var,
+    const platform::Place& place);
 
 }  // namespace imperative
 }  // namespace paddle

--- a/paddle/fluid/imperative/tracer.h
+++ b/paddle/fluid/imperative/tracer.h
@@ -16,12 +16,14 @@
 
 #include <atomic>
 #include <future>  // NOLINT
+#include <map>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
 #include "ThreadPool.h"
+#include "paddle/fluid/framework/garbage_collector.h"
 #include "paddle/fluid/imperative/basic_engine.h"
 #include "paddle/fluid/imperative/jit/program_desc_tracer.h"
 #include "paddle/fluid/imperative/layer.h"
@@ -29,6 +31,10 @@
 
 namespace paddle {
 namespace imperative {
+
+using GarbageCollectorMap =
+    std::map<platform::Place,
+             std::unique_ptr<paddle::framework::GarbageCollector>>;
 
 class UniqueNameGenerator {
  public:
@@ -102,6 +108,9 @@ class Tracer {
 
   bool IsAutoCastEnabled() const { return enable_autocast_; }
 
+  paddle::framework::GarbageCollector* MutableGarbageCollectorIfNotExists(
+      const platform::Place& place);
+
  private:
   std::unique_ptr<BasicEngine> basic_engine_;
   std::unique_ptr<jit::ProgramDescTracer> program_desc_tracer_;
@@ -110,6 +119,7 @@ class Tracer {
   platform::Place expected_place_;
   bool has_grad_{true};
   bool enable_autocast_{false};
+  GarbageCollectorMap gcs_;
 };
 
 // To access static variable current_tracer

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1059,7 +1059,7 @@ void BindImperative(py::module *m_ptr) {
       .def("_copy_to",
            [](const std::shared_ptr<imperative::VarBase> &self,
               const platform::CPUPlace &place, bool blocking) {
-             auto new_var = self.NewVarBase(place, blocking);
+             auto new_var = self->NewVarBase(place, blocking);
              // Note(zhiqiu): Since NewVarBase may use GpuCopyAsync to
              // copy data from the tensor of self to the tensor of new varbase,
              // we need to ensure that the varbase self is not destructed until
@@ -1077,7 +1077,7 @@ void BindImperative(py::module *m_ptr) {
       .def("_copy_to",
            [](const std::shared_ptr<imperative::VarBase> &self,
               const platform::CUDAPinnedPlace &place, bool blocking) {
-             auto new_var = self.NewVarBase(place, blocking);
+             auto new_var = self->NewVarBase(place, blocking);
              if (!blocking) {
                IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
              }
@@ -1087,7 +1087,7 @@ void BindImperative(py::module *m_ptr) {
       .def("_copy_to",
            [](const std::shared_ptr<imperative::VarBase> &self,
               const platform::XPUPlace &place, bool blocking) {
-             auto new_var = self.NewVarBase(place, blocking);
+             auto new_var = self->NewVarBase(place, blocking);
              if (!blocking) {
                IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
              }
@@ -1097,7 +1097,7 @@ void BindImperative(py::module *m_ptr) {
       .def("_copy_to",
            [](const std::shared_ptr<imperative::VarBase> &self,
               const platform::CUDAPlace &place, bool blocking) {
-             auto new_var = self.NewVarBase(place, blocking);
+             auto new_var = self->NewVarBase(place, blocking);
              if (!blocking) {
                IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
              }

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1057,21 +1057,52 @@ void BindImperative(py::module *m_ptr) {
        )DOC")
       .def("copy_", &imperative::VarBase::CopyFrom)
       .def("_copy_to",
-           [](const imperative::VarBase &self, const platform::CPUPlace &place,
-              bool blocking) { return self.NewVarBase(place, blocking); },
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::CPUPlace &place, bool blocking) {
+             auto new_var = self.NewVarBase(place, blocking);
+             // Note(zhiqiu): Since NewVarBase may use GpuCopyAsync to
+             // copy data from the tensor of self to the tensor of new varbase,
+             // we need to ensure that the varbase self is not destructed until
+             // the GpuCopyAsync is completed. Otherwise, the memory may be
+             // freed
+             // when varbase self is destructed.
+             // To do that, we increase the reference count of self by 1 and
+             // add a cuda event to wait the GpuCopyAsync's completion.
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return new_var;
+           },
            py::return_value_policy::copy)
       .def("_copy_to",
-           [](const imperative::VarBase &self,
-              const platform::CUDAPinnedPlace &place,
-              bool blocking) { return self.NewVarBase(place, blocking); },
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::CUDAPinnedPlace &place, bool blocking) {
+             auto new_var = self.NewVarBase(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return new_var;
+           },
            py::return_value_policy::copy)
       .def("_copy_to",
-           [](const imperative::VarBase &self, const platform::XPUPlace &place,
-              bool blocking) { return self.NewVarBase(place, blocking); },
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::XPUPlace &place, bool blocking) {
+             auto new_var = self.NewVarBase(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return new_var;
+           },
            py::return_value_policy::copy)
       .def("_copy_to",
-           [](const imperative::VarBase &self, const platform::CUDAPlace &place,
-              bool blocking) { return self.NewVarBase(place, blocking); },
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::CUDAPlace &place, bool blocking) {
+             auto new_var = self.NewVarBase(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return new_var;
+           },
            py::return_value_policy::copy)
       .def("value", [](imperative::VarBase &self) { return self.MutableVar(); },
            py::return_value_policy::reference)

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -148,20 +148,23 @@ class TestVarBase(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     paddle.to_tensor([[1], [2, 3]], place=1)
 
-            if core.is_compiled_with_cuda():
-                a_np = np.random.rand(1024, 1024)
-                a = paddle.to_tensor(a_np, place=paddle.CUDAPinnedPlace())
-                with paddle.fluid.device_guard(core.CPUPlace()):
-                    a1 = paddle.to_tensor(a)
-                    self.assertEqual(a1.place.__repr__(), "CPUPlace")
-                with paddle.fluid.device_guard(core.CUDAPlace(0)):
-                    a2 = paddle.to_tensor(a)
-                    self.assertEqual(a2.place.__repr__(), "CUDAPlace(0)")
-
         _test_place(core.CPUPlace())
         if core.is_compiled_with_cuda():
             _test_place(core.CUDAPinnedPlace())
             _test_place(core.CUDAPlace(0))
+
+    def test_to_tensor_change_place(self):
+        if core.is_compiled_with_cuda():
+            a_np = np.random.rand(1024, 1024)
+            with paddle.fluid.dygraph.guard(core.CPUPlace()):
+                a = paddle.to_tensor(a_np, place=paddle.CUDAPinnedPlace())
+                a = paddle.to_tensor(a)
+                self.assertEqual(a.place.__repr__(), "CPUPlace")
+
+            with paddle.fluid.dygraph.guard(core.CUDAPlace(0)):
+                a = paddle.to_tensor(a_np, place=paddle.CUDAPinnedPlace())
+                a = paddle.to_tensor(a)
+                self.assertEqual(a.place.__repr__(), "CUDAPlace(0)")
 
     def test_to_variable(self):
         with fluid.dygraph.guard():

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -166,6 +166,11 @@ class TestVarBase(unittest.TestCase):
                 a = paddle.to_tensor(a)
                 self.assertEqual(a.place.__repr__(), "CUDAPlace(0)")
 
+            with paddle.fluid.dygraph.guard(core.CUDAPlace(0)):
+                a = paddle.to_tensor(a_np, place=paddle.CPUPlace())
+                a = paddle.to_tensor(a, place=paddle.CUDAPinnedPlace())
+                self.assertEqual(a.place.__repr__(), "CUDAPinnedPlace")
+
     def test_to_variable(self):
         with fluid.dygraph.guard():
             var = fluid.dygraph.to_variable(self.array, name="abc")

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -148,6 +148,16 @@ class TestVarBase(unittest.TestCase):
                 with self.assertRaises(ValueError):
                     paddle.to_tensor([[1], [2, 3]], place=1)
 
+            if core.is_compiled_with_cuda():
+                a_np = np.random.rand(1024, 1024)
+                a = paddle.to_tensor(a_np, place=paddle.CUDAPinnedPlace())
+                with paddle.fluid.device_guard(core.CPUPlace()):
+                    a1 = paddle.to_tensor(a)
+                    self.assertEqual(a1.place.__repr__(), "CPUPlace")
+                with paddle.fluid.device_guard(core.CUDAPlace(0)):
+                    a2 = paddle.to_tensor(a)
+                    self.assertEqual(a2.place.__repr__(), "CUDAPlace(0)")
+
         _test_place(core.CPUPlace())
         if core.is_compiled_with_cuda():
             _test_place(core.CUDAPinnedPlace())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Add callback after TensorCopy to make sure that the src tensor is not destructed until the copy is completed.

### Why
In dygraph mode, the `life cycle` or `duration` of a Tensor is maintained by the `reference count` in both c++ and python.

When doing async operation on cuda, the Tensor may be destructed (and thus the corresponding memory is freed) before the operation is completed.

Since paddle is single-stream-desgin, 
- If all the async operations are on cuda device, it is safe since the freed memory will not be used again before its operation is completed.
- If the operations are between different place, it may introduce data inconsistent. For example, `cudaMemcpyAsync` is async when copying from `cuda pinned place` to `cuda place`, if the memory of `cuda pinned place` (host memory, actually) is freed, it may be reused by others and the data may change before the copy is completed. 

An example code,
```
import paddle
import numpy as np
import time

start = time.time()

x = paddle.rand([4096, 4096])
for i in range(500):
    x = paddle.matmul(x, x)

a_np = np.random.rand(1024, 1024)
a = paddle.to_tensor(a_np, place=paddle.CUDAPinnedPlace())
print(a.name)
print(a)
a = paddle.to_tensor(a)   # it will copy a from CUDAPinnedPlace to CUDAPlace(0), which is async
print('cpu end', time.time()-start)
x.numpy()
print('gpu end', time.time()-start)
```
- Before
![image](https://user-images.githubusercontent.com/6888866/103651634-df03e900-4f9c-11eb-99ae-3a24e044ebaf.png)
As shown in the figure, the tensor `generated_tensor_501` is destructed immediately after the copy(cudaMemcpyAsync) is launched.

- After
![image](https://user-images.githubusercontent.com/6888866/103655960-f80f9880-4fa2-11eb-80dc-a6318b9f664f.png)
As shown in the figure, the tensor `generated_tensor_501` is destructed 3 seconds later after the copy(cudaMemcpyAsync) is launched.