### PR TITLE
fix adamw apply gradient

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_adamw_op.py
+++ b/python/paddle/fluid/tests/unittests/test_adamw_op.py
@@ -29,10 +29,12 @@ class TestAdamWOp(unittest.TestCase):
             parameters=linear.parameters(),
             apply_decay_param_fun=lambda name: True,
             weight_decay=0.01)
-        out = linear(a)
-        out.backward()
-        adam.step()
-        adam.clear_gradients()
+
+        for _ in range(2):
+            out = linear(a)
+            out.backward()
+            adam.step()
+            adam.clear_gradients()
 
     def test_adamw_op_coverage(self):
         paddle.disable_static()

--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -16,6 +16,7 @@ from .optimizer import Optimizer
 from ..fluid import core
 from ..fluid import framework
 from ..fluid.framework import Variable
+from ..fluid.dygraph import base as imperative_base
 
 import paddle
 
@@ -247,6 +248,7 @@ class Adam(Optimizer):
 
         return adam_op
 
+    @imperative_base.no_grad
     @framework.dygraph_only
     def step(self):
         """

--- a/python/paddle/optimizer/adamw.py
+++ b/python/paddle/optimizer/adamw.py
@@ -158,13 +158,6 @@ class AdamW(Adam):
                 and not self._apply_decay_param_fun(param.name):
             return
 
-        if isinstance(self._coeff, float):
-            assert param.dtype == paddle.fluid.core.VarDesc.VarType.FP32, \
-                "the type of coeff(float) and parameter(%s) is not consistent."%(param.dtype)
-        else:
-            assert self._coeff.dtype == param.dtype, \
-                "the type of coeff(%s) and parameter(%s) is not consistent."%(self._coeff.dtype, param.dtype)
-
         if isinstance(self._learning_rate, float):
             learning_rate = self._learning_rate
         else:
@@ -180,7 +173,7 @@ class AdamW(Adam):
             # If it has been calculated, the result will be reused
             decay_coeff = self._lr_to_coeff.get(learning_rate, None)
             if decay_coeff is None:
-                decay_coeff = 1.0 - self._coeff * learning_rate
+                decay_coeff = 1.0 - learning_rate * self._coeff
                 self._lr_to_coeff[learning_rate] = decay_coeff
 
             scaled_param = param * decay_coeff


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. Fix Adamw weight_decay not applied when open AMP. see https://github.com/PaddlePaddle/Paddle/issues/29794
2. Fix Adamw weight_decay LR is fixed when using LRSchedule.
3. Fix Adam step() not add imperative_base.no_grad, which gradients may be generated in the optimizer.
4. Optimization calculation, the calculation formula of `param = param - param * lr * coeff` is optimized as follows
     `param = param * (1.0 - lr * coeff)`