### PR TITLE
【Cherry pick】fix dynamic decode bug

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_rnn_decode_api.py
+++ b/python/paddle/fluid/tests/unittests/test_rnn_decode_api.py
@@ -178,16 +178,14 @@ class Seq2SeqModel(object):
                  beam_size=4):
         self.start_token, self.end_token = start_token, end_token
         self.max_decoding_length, self.beam_size = max_decoding_length, beam_size
-        self.src_embeder = lambda x: fluid.embedding(
-            input=x,
-            size=[src_vocab_size, hidden_size],
-            dtype="float32",
-            param_attr=fluid.ParamAttr(name="source_embedding"))
-        self.trg_embeder = lambda x: fluid.embedding(
-            input=x,
-            size=[trg_vocab_size, hidden_size],
-            dtype="float32",
-            param_attr=fluid.ParamAttr(name="target_embedding"))
+        self.src_embeder = paddle.nn.Embedding(
+            src_vocab_size,
+            hidden_size,
+            weight_attr=fluid.ParamAttr(name="source_embedding"))
+        self.trg_embeder = paddle.nn.Embedding(
+            trg_vocab_size,
+            hidden_size,
+            weight_attr=fluid.ParamAttr(name="target_embedding"))
         self.encoder = Encoder(num_layers, hidden_size, dropout_prob)
         self.decoder = Decoder(num_layers, hidden_size, dropout_prob,
                                decoding_strategy, max_decoding_length)
@@ -195,7 +193,7 @@ class Seq2SeqModel(object):
             x,
             size=trg_vocab_size,
             num_flatten_dims=len(x.shape) - 1,
-            param_attr=fluid.ParamAttr(name="output_w"),
+            param_attr=fluid.ParamAttr(),
             bias_attr=False)
 
     def __call__(self, src, src_length, trg=None, trg_length=None):
@@ -556,6 +554,14 @@ class TestDynamicDecode(unittest.TestCase):
                 },
                 fetch_list=[output])[0]
 
+    def test_dynamic_basic_decoder(self):
+        paddle.disable_static()
+        src = paddle.to_tensor(np.random.randint(8, size=(8, 4)))
+        src_length = paddle.to_tensor(np.random.randint(8, size=(8)))
+        model = Seq2SeqModel(**self.model_hparams)
+        probs, samples, sample_length = model(src, src_length)
+        paddle.enable_static()
+
 
 class ModuleApiTest(unittest.TestCase):
     @classmethod
@@ -672,8 +678,8 @@ class TestBeamSearch(ModuleApiTest):
                    hidden_size,
                    bos_id=0,
                    eos_id=1,
-                   beam_size=2,
-                   max_step_num=2):
+                   beam_size=4,
+                   max_step_num=20):
         embedder = paddle.fluid.dygraph.Embedding(
             size=[vocab_size, embed_dim], dtype="float64")
         output_layer = nn.Linear(hidden_size, vocab_size)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
cherry pick from #29824 
解决了beam search存在的bug
1.修复了当`imputed_finished`为`True`时，动静态图当`finished`的计算错误，解决方法是将`imputed_finished`即`maybe_copy`相关部分移入了`tracks_own_finished`为`False`的分支
2.修复了当`imputed_finished`为`True`时，动静态图`next_sequence_lengths`计算错误，解决方法是将原先`next_sequence_lengths`的计算or赋值部分移入了`tracks_own_finished`为`False`的分支，并重新定义了使用beam search时（`tracks_own_finished`为`True`）的`next_sequence_lengths`的计算（上一时刻的序列长度sequence_lengths+!finished)
