### PR TITLE
[cherry-pick 2.0] Fix bug: In dynamic mode, if start or end is negetive, __getitem__  return wrong result(#30003)

### DIFF
--- a/paddle/fluid/operators/slice_op.cc
+++ b/paddle/fluid/operators/slice_op.cc
@@ -121,8 +121,11 @@ class SliceOp : public framework::OperatorWithKernel {
           start = std::max(start, 0);
           end = std::max(end, 0);
           end = std::min(end, dim_value);
-          PADDLE_ENFORCE_GT(end, start, platform::errors::InvalidArgument(
-                                            "end should greater than start"));
+          PADDLE_ENFORCE_GT(end, start,
+                            platform::errors::InvalidArgument(
+                                "end should greater than start, but received "
+                                "end = %d, start = %d.",
+                                ends[i], starts[i]));
           out_dims[axes[i]] = end - start;
         }
       }

--- a/paddle/fluid/operators/slice_op.h
+++ b/paddle/fluid/operators/slice_op.h
@@ -122,8 +122,8 @@ class SliceKernel : public framework::OpKernel<T> {
       PADDLE_ENFORCE_GT(end, start,
                         platform::errors::InvalidArgument(
                             "Attr(ends) should be greater than attr(starts) in "
-                            "slice op. But received ends = %d, starts = %d.",
-                            end, start));
+                            "slice op. But received end = %d, start = %d.",
+                            ends[0], starts[0]));
       int64_t out_size = end - start;
 
       if (out_is_tensor_array) {
@@ -181,8 +181,8 @@ class SliceKernel : public framework::OpKernel<T> {
               end, start,
               platform::errors::InvalidArgument(
                   "Attr(ends) should be greater than attr(starts) in "
-                  "slice op. But received ends = %d, starts = %d.",
-                  end, start));
+                  "slice op. But received end = %d, start = %d.",
+                  ends[i], starts[i]));
           out_dims[axes[i]] = end - start;
         }
       }

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -413,10 +413,11 @@ class TestVarBase(unittest.TestCase):
         var13 = var[2:10, 2:, -2:-1]
         var14 = var[1:-1, 0:2, ::-1]
         var15 = var[::-1, ::-1, ::-1]
+        var16 = var[-4:4]
 
         vars = [
             var, var1, var2, var3, var4, var5, var6, var7, var8, var9, var10,
-            var11, var12, var13, var14, var15
+            var11, var12, var13, var14, var15, var16
         ]
         local_out = [var.numpy() for var in vars]
 
@@ -444,6 +445,7 @@ class TestVarBase(unittest.TestCase):
             np.array_equal(local_out[14], tensor_array[1:-1, 0:2, ::-1]))
         self.assertTrue(
             np.array_equal(local_out[15], tensor_array[::-1, ::-1, ::-1]))
+        self.assertTrue(np.array_equal(local_out[16], tensor_array[-4:4]))
 
     def _test_for_var(self):
         np_value = np.random.random((30, 100, 100)).astype('float32')
@@ -463,6 +465,9 @@ class TestVarBase(unittest.TestCase):
 
             with self.assertRaises(IndexError):
                 y = var[self.shape[0]]
+
+            with self.assertRaises(IndexError):
+                y = var[0 - self.shape[0] - 1]
 
     def test_var_base_to_np(self):
         with fluid.dygraph.guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
cherry-pick #30003 