### PR TITLE
Disable mkldnn inplace pass on windows

### DIFF
--- a/paddle/fluid/inference/api/paddle_pass_builder.cc
+++ b/paddle/fluid/inference/api/paddle_pass_builder.cc
@@ -220,8 +220,12 @@ void CpuPassStrategy::EnableMKLDNN() {
              // "fc_mkldnn_pass",
              // "fc_act_mkldnn_fuse_pass",
              "batch_norm_act_fuse_pass",
+#ifndef _WIN32
+             // TODO(intel): Please fix the bug on windows.
+             // https://github.com/PaddlePaddle/Paddle/issues/29710
              "mkldnn_inplace_pass",  // This pass should be activated after
                                      // fuses
+#endif
          })) {
       passes_.push_back(pass);
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
mkldnn_inplace_pass在windows下存在问题，临时关闭该pass，待intel修复后再打开
related #29710