### PR TITLE
Fix test_slice: avoid unnecessary copying of TensorArray from subblock to parent block

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -2278,9 +2278,13 @@ def copy_var_to_parent_block(var, layer_helper):
     assert parent_idx >= 0, "Got wrong parent block index when assigning var to parent scope in control_flow"
     parent_block = prog.block(parent_idx)
 
-    parent_block_var = parent_block.create_var(
-        dtype=var.dtype, shape=var.shape, type=var.type)
-    assign(var, parent_block_var)
+    if var.type == core.VarDesc.VarType.LOD_TENSOR_ARRAY \
+            and parent_block._find_var_recursive(var.name):
+        parent_block_var = var
+    else:
+        parent_block_var = parent_block.create_var(
+            dtype=var.dtype, shape=var.shape, type=var.type)
+        assign(var, parent_block_var)
     return parent_block_var
 
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -40,9 +40,12 @@ def test_slice_in_if(x):
     if x.numpy()[0] > 0:
         a.append(x)
     else:
-        a.append(paddle.full(shape=[1, 2], fill_value=9, dtype="int64"))
+        a.append(paddle.full(shape=[1, 2], fill_value=9, dtype="int32"))
+
     if x.numpy()[0] > 0:
         a[0] = x
+
+    a[0] = x + 1
     out = a[0]
     return out
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix unitest `test_slice` to avoid runing failed.
![image](https://user-images.githubusercontent.com/33742067/103968039-2b6a4700-519e-11eb-8b16-f30ed5cba75c.png)

In this PR, in control flow, **don't** copy TensorArray from subblock to parent block when TensorArray is created in parent block.
