### PR TITLE
Fix analysis predictor test

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor_tester.cc
+++ b/paddle/fluid/inference/api/analysis_predictor_tester.cc
@@ -493,7 +493,10 @@ TEST(AnalysisPredictor, bf16_gpu_pass_strategy) {
   config.EnableUseGpu(100, 0);
   config.EnableMkldnnBfloat16();
 #ifdef PADDLE_WITH_MKLDNN
-  ASSERT_EQ(config.mkldnn_bfloat16_enabled(), true);
+  if (platform::MayIUse(platform::cpu_isa_t::avx512_core))
+    ASSERT_EQ(config.mkldnn_bfloat16_enabled(), true);
+  else
+    ASSERT_EQ(config.mkldnn_bfloat16_enabled(), false);
 #else
   ASSERT_EQ(config.mkldnn_bfloat16_enabled(), false);
 #endif

--- a/paddle/fluid/inference/api/analysis_predictor_tester.cc
+++ b/paddle/fluid/inference/api/analysis_predictor_tester.cc
@@ -21,6 +21,7 @@
 #include "paddle/fluid/inference/api/helper.h"
 #include "paddle/fluid/inference/api/paddle_inference_api.h"
 #include "paddle/fluid/inference/tests/api/tester_helper.h"
+#include "paddle/fluid/platform/cpu_info.h"
 #ifdef PADDLE_WITH_MKLDNN
 #include "paddle/fluid/inference/api/mkldnn_quantizer.h"
 #endif

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -37,8 +37,7 @@ fi
 
 # /*==================Fixed Disabled Windows unittests==============================*/
 # TODO: fix these unittest that is bound to fail
-diable_wingpu_test="^test_analysis_predictor$|\
-^test_gradient_clip$|\
+diable_wingpu_test="^test_gradient_clip$|\
 ^test_translated_layer$|\
 ^test_imperative_resnet$|\
 ^test_imperative_resnet_sorted_gradient$|\


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR fixes test that failed on machine 5117 on PR_CI_WINDOWS mentioned in https://github.com/PaddlePaddle/Paddle/issues/30119.
`config.EnableMkldnnBfloat16()`   first checks if BF16 evaluation can be run by condition `platform::MayIUse(platform::cpu_isa_t::avx512_core`. 
So we should check that in analysis predictor as well.