### PR TITLE
[oneDNN] Added UT for testing elementwise_mul caching

### DIFF
--- a/paddle/fluid/operators/mkldnn/caching_tests.cmake
+++ b/paddle/fluid/operators/mkldnn/caching_tests.cmake
@@ -1,1 +1,1 @@
-cc_test(test_mkldnn_caching SRCS mkldnn/test_mkldnn_caching.cc DEPS op_registry elementwise_add_op activation_op softmax_op softmax scope device_context enforce)
+cc_test(test_mkldnn_caching SRCS mkldnn/test_mkldnn_caching.cc DEPS op_registry elementwise_mul_op elementwise_add_op activation_op softmax_op softmax scope device_context enforce)

--- a/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
+++ b/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
@@ -68,8 +68,10 @@ void RunOperator(const platform::Place &place, const std::string &op_type,
                  bool inplace = false) {
   framework::Scope scope;
 
-  std::map<const std::string, int> num_inputs = {
-      {"softmax", 1}, {"relu", 1}, {"elementwise_add", 2}, {"elementwise_mul", 2}};
+  std::map<const std::string, int> num_inputs = {{"softmax", 1},
+                                                 {"relu", 1},
+                                                 {"elementwise_add", 2},
+                                                 {"elementwise_mul", 2}};
 
   std::string first_input = inplace == true ? output_name : "x";
 

--- a/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
+++ b/paddle/fluid/operators/mkldnn/test_mkldnn_caching.cc
@@ -27,6 +27,8 @@
 
 USE_OP(elementwise_add);
 USE_OP_DEVICE_KERNEL(elementwise_add, MKLDNN);
+USE_OP(elementwise_mul);
+USE_OP_DEVICE_KERNEL(elementwise_mul, MKLDNN);
 USE_OP(relu);
 USE_OP_DEVICE_KERNEL(relu, MKLDNN);
 USE_OP(softmax);
@@ -67,7 +69,7 @@ void RunOperator(const platform::Place &place, const std::string &op_type,
   framework::Scope scope;
 
   std::map<const std::string, int> num_inputs = {
-      {"softmax", 1}, {"relu", 1}, {"elementwise_add", 2}};
+      {"softmax", 1}, {"relu", 1}, {"elementwise_add", 2}, {"elementwise_mul", 2}};
 
   std::string first_input = inplace == true ? output_name : "x";
 
@@ -161,6 +163,18 @@ TEST(test_elementwise_add_reuse_cache, cpu_place) {
   RunOperator<float>(p, "elementwise_add", dims, "elementwise_add_out");
   RunOperator<float>(p, "relu", dims, "elementwise_add_out", true);
   PADDLE_ENFORCE_EQ(ct.Analyze(8), true,
+                    platform::errors::InvalidArgument(
+                        "Wrong number of cached oneDNN objects"));
+}
+
+TEST(test_elementwises_sequence_reuse_cache, cpu_place) {
+  framework::DDim dims({32, 64});
+  platform::CPUPlace p;
+  CacheTester ct;
+  RunOperator<float>(p, "elementwise_add", dims, "elementwise_add_out", true);
+  RunOperator<float>(p, "elementwise_mul", dims, "elementwise_add_out", true);
+  RunOperator<float>(p, "relu", dims, "elementwise_add_out", true);
+  PADDLE_ENFORCE_EQ(ct.Analyze(11), true,
                     platform::errors::InvalidArgument(
                         "Wrong number of cached oneDNN objects"));
 }

--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -516,8 +516,8 @@ class BinaryMKLDNNHandler : public platform::MKLDNNHandlerT<T, dnnl::binary> {
       : platform::MKLDNNHandlerT<T, dnnl::binary>(
             dev_ctx, engine, cpu_place,
             platform::CreateKey(
-                dev_ctx, framework::vectorize(x->dims()),
-                uniq_name + (algo == dnnl::algorithm::binary_mul ? "M" : ""))) {
+                dev_ctx, framework::vectorize(x->dims()), uniq_name,
+                (algo == dnnl::algorithm::binary_mul ? "M" : ""))) {
     // bradcasting combined with in-place may require
     auto rankdiff = x->dims().size() - y->dims().size();
     if (rankdiff > 0) {


### PR DESCRIPTION
### PR types
Performance optimization 

### PR changes
OPs

### Describe
Reduce some memory allocation that could happened when elementwise_mul oneDNN is used , also unit test of oneDNN caching was extended with scenario: inplace execution of elementwise_mul, elementwise_add, relu 
