### PR TITLE
Alias from  paddle.fluid.layers.auc to paddle.static.auc

### DIFF
--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -63,4 +63,4 @@ from ..fluid.io import load_program_state  #DEFINE_ALIAS
 from ..fluid.io import set_program_state  #DEFINE_ALIAS
 from ..fluid.layers import create_parameter  #DEFINE_ALIAS
 from ..fluid.layers import create_global_var  #DEFINE_ALIAS
-from ..fluid.layers.metric_op.auc import auc  #DEFINE_ALIAS
+from ..fluid.layers.metric_op import auc  #DEFINE_ALIAS

--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -63,3 +63,4 @@ from ..fluid.io import load_program_state  #DEFINE_ALIAS
 from ..fluid.io import set_program_state  #DEFINE_ALIAS
 from ..fluid.layers import create_parameter  #DEFINE_ALIAS
 from ..fluid.layers import create_global_var  #DEFINE_ALIAS
+from ..fluid.layers.metric_op.auc import auc  #DEFINE_ALIAS


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add alias from  `paddle.fluid.layers.auc` to `paddle.static.auc`
根据@frankwhzhang 同学内部反馈，需要使用 `paddle.fluid.layers.auc` 在静态图组网时计算auc，现有的`paddle.metric`不支持组网时计算，希望把已有的`paddle.fluid.layers.auc` alias到`paddle.static.layers.auc`。

