### PR TITLE
Fix bug for 'save mutiple method'

### DIFF
--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -636,8 +636,8 @@ def _construct_params_and_buffers(model_path,
         model_name = params_filename[:-len(INFER_PARAMS_SUFFIX)]
         #Load every file that meets the requirements in the directory model_path.
         for file_name in os.listdir(model_path):
-            if file_name.endswith(INFER_PARAMS_SUFFIX) and file_name.startswith(
-                    model_name):
+            if file_name.startswith(model_name) and file_name.endswith(
+                    INFER_PARAMS_SUFFIX):
                 part_name = file_name[len(model_name):-len(INFER_PARAMS_SUFFIX)
                                       + 1]
                 parsing_names = part_name.split('.')

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -638,10 +638,11 @@ def _construct_params_and_buffers(model_path,
         for file_name in os.listdir(model_path):
             if file_name.endswith(INFER_PARAMS_SUFFIX) and file_name.startswith(
                     model_name):
-                parsing_name = file_name[len(model_name):-len(
-                    INFER_PARAMS_SUFFIX) + 1].split('.')
-                if len(parsing_name) == 3 and len(parsing_name[1]) > 0:
-                    func_name = parsing_name[1]
+                part_name = file_name[len(model_name):-len(INFER_PARAMS_SUFFIX)
+                                      + 1]
+                parsing_names = part_name.split('.')
+                if len(parsing_names) == 3 and len(parsing_names[1]) > 0:
+                    func_name = parsing_names[1]
                 else:
                     continue
             else:

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -606,7 +606,6 @@ def _construct_program_holders(model_path, model_filename=None):
                     func_name = parsing_names[1]
                     model_file_path = os.path.join(model_path, filename)
                 else:
-                    func_name = ''
                     continue
             else:
                 continue
@@ -648,7 +647,6 @@ def _construct_params_and_buffers(model_path,
                 if len(parsing_names) == 3 and len(parsing_names[1]) > 0:
                     func_name = parsing_names[1]
                 else:
-                    func_name = ''
                     continue
             else:
                 continue

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -637,9 +637,13 @@ def _construct_params_and_buffers(model_path,
         #Load every file that meets the requirements in the directory model_path.
         for file_name in os.listdir(model_path):
             if file_name.endswith(INFER_PARAMS_SUFFIX) and file_name.startswith(
-                    model_name) and file_name != params_filename:
-                func_name = file_name[len(model_name) + 1:-len(
-                    INFER_PARAMS_SUFFIX)]
+                    model_name):
+                parsing_name = file_name[len(model_name):-len(
+                    INFER_PARAMS_SUFFIX) + 1].split('.')
+                if len(parsing_name) == 3 and len(parsing_name[1]) > 0:
+                    func_name = parsing_name[1]
+                else:
+                    continue
             else:
                 continue
             var_info_path = os.path.join(model_path, var_info_filename)

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -600,9 +600,13 @@ def _construct_program_holders(model_path, model_filename=None):
                 model_file_path = os.path.join(model_path, model_filename)
             elif filename.endswith(INFER_MODEL_SUFFIX) and filename.startswith(
                     model_name):
-                func_name = filename[len(model_name) + 1:-len(
-                    INFER_MODEL_SUFFIX)]
-                model_file_path = os.path.join(model_path, filename)
+                parsing_names = filename[len(model_name):-len(
+                    INFER_MODEL_SUFFIX) + 1].split('.')
+                if len(parsing_names) == 3 and len(parsing_names[1]) > 0:
+                    func_name = parsing_names[1]
+                    model_file_path = os.path.join(model_path, filename)
+                else:
+                    continue
             else:
                 continue
             program_holder_dict[func_name] = _ProgramHolder(
@@ -638,10 +642,8 @@ def _construct_params_and_buffers(model_path,
         for file_name in os.listdir(model_path):
             if file_name.startswith(model_name) and file_name.endswith(
                     INFER_PARAMS_SUFFIX):
-                part_name = file_name[len(model_name):-len(INFER_PARAMS_SUFFIX)
-                                      + 1]
-                parsing_names = part_name.split('.')
-
+                parsing_names = file_name[len(model_name):-len(
+                    INFER_PARAMS_SUFFIX) + 1].split('.')
                 if len(parsing_names) == 3 and len(parsing_names[1]) > 0:
                     func_name = parsing_names[1]
                 else:

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -641,6 +641,7 @@ def _construct_params_and_buffers(model_path,
                 part_name = file_name[len(model_name):-len(INFER_PARAMS_SUFFIX)
                                       + 1]
                 parsing_names = part_name.split('.')
+
                 if len(parsing_names) == 3 and len(parsing_names[1]) > 0:
                     func_name = parsing_names[1]
                 else:

--- a/python/paddle/fluid/dygraph/io.py
+++ b/python/paddle/fluid/dygraph/io.py
@@ -606,6 +606,7 @@ def _construct_program_holders(model_path, model_filename=None):
                     func_name = parsing_names[1]
                     model_file_path = os.path.join(model_path, filename)
                 else:
+                    func_name = ''
                     continue
             else:
                 continue
@@ -647,6 +648,7 @@ def _construct_params_and_buffers(model_path,
                 if len(parsing_names) == 3 and len(parsing_names[1]) > 0:
                     func_name = parsing_names[1]
                 else:
+                    func_name = ''
                     continue
             else:
                 continue

--- a/python/paddle/fluid/tests/unittests/test_jit_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_jit_save_load.py
@@ -864,6 +864,18 @@ class TestJitSaveLoadMultiMethods(unittest.TestCase):
             paddle.jit.save(
                 layer, model_path, input_spec=[InputSpec(shape=[None, 784])])
 
+    def test_parse_name(self):
+        model_path_inference = "jit_save_load_parse_name/model"
+        IMAGE_SIZE = 224
+        layer = LinearNet(IMAGE_SIZE, 1)
+        inps = paddle.randn([1, IMAGE_SIZE])
+        layer(inps)
+        paddle.jit.save(layer, model_path_inference)
+        paddle.jit.save(layer, model_path_inference + '_v2')
+        load_net = paddle.jit.load(model_path_inference)
+
+        self.assertFalse(hasattr(load_net, 'v2'))
+
 
 class LayerSaved(paddle.nn.Layer):
     def __init__(self, in_size, out_size):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
resnet和resnet_v2存储在同一个目录时，`resnet_v2.pdiparams`误识别成了`resnet.v2.pdiparams`,导致加载resnet模型时加载resnent_v2的文件，触发错误。
<!-- Describe what this PR does -->

![image](https://user-images.githubusercontent.com/22128369/103972128-4ab9a200-51a7-11eb-9f82-b0cbdf1ddfec.png)
