### PR TITLE
Skip convert tensor shape while using Paddle.shape

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -75,6 +75,17 @@ def dyfunc_tuple_shape_2(x):
     return res
 
 
+def dyfunc_paddle_shape_api(x):
+    x = paddle.to_tensor(x)
+    # paddle.shape will not be converted.
+    a = paddle.shape(x)[0]
+    # alias api will also not be converted.
+    alias_old_api = paddle.fluid.layers
+    b = alias_old_api.shape(x)[1]
+    res = paddle.reshape(x, shape=(b, a))
+    return res
+
+
 def dyfunc_with_if_1(x):
     x = fluid.dygraph.to_variable(x)
     res = fluid.layers.reshape(x, [-1, 1])
@@ -250,6 +261,12 @@ class TestTupleShape2(TestTensorShapeBasic):
     def init_test_func(self):
         self.input = numpy.ones((5, 7)).astype("int32")
         self.dygraph_func = dyfunc_tuple_shape_2
+
+
+class TestPaddleShapeApi(TestTensorShapeBasic):
+    def init_test_func(self):
+        self.input = numpy.ones((5, 7)).astype("int32")
+        self.dygraph_func = dyfunc_paddle_shape_api
 
 
 # 2. Tests with control flow if

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -467,4 +467,4 @@ class TestOpNumWithTensorShapeInWhile1(TestOpNumBasicWithTensorShape):
 
 
 if __name__ == '__main__':
-    unittest.main(defaultTest="TestPaddleShapeApi")
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -297,7 +297,13 @@ class TestTupleShape2(TestTensorShapeBasic):
 class TestPaddleShapeApi(TestTensorShapeBasic):
     def init_test_func(self):
         self.input = numpy.ones((5, 7)).astype("int32")
+        self.input_spec = [paddle.static.InputSpec(shape=[5, 7], dtype="int32")]
         self.dygraph_func = dyfunc_paddle_shape_api
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 6
+        self.expected_shape_op_num = 2
+        self.expected_slice_op_num = 2
 
 
 # 2. Tests with control flow if
@@ -461,4 +467,4 @@ class TestOpNumWithTensorShapeInWhile1(TestOpNumBasicWithTensorShape):
 
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main(defaultTest="TestPaddleShapeApi")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Skip convert tensor shape while using Paddle.shape

Bug修复，此PR之前，当用户使用`paddle.shape(x)`时，会错误地将其转换为`paddle.jit.dy2static.convert_var_shape(paddle)(x)`，即将`paddle`识别为了一个变量。

原因：在`_used_by_paddle_api`判断逻辑中，对 gast.Call 类型的parent_node增加条件判断，如果node不是parent_node.func时，才返回True.