### PR TITLE
fix empty op unit test fail sometimes

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_empty_op.py
+++ b/python/paddle/fluid/tests/unittests/test_empty_op.py
@@ -39,7 +39,7 @@ class TestEmptyOp(OpTest):
             min_value = np.nanmin(outs[0])
 
             always_full_zero = max_value == 0.0 and min_value == 0.0
-            always_non_full_zero = max_value > min_value
+            always_non_full_zero = max_value >= min_value
             self.assertTrue(always_full_zero or always_non_full_zero,
                             'always_full_zero or always_non_full_zero.')
         elif data_type in ['bool']:
@@ -124,7 +124,7 @@ class TestEmptyOp_ShapeTensor(OpTest):
             min_value = np.nanmin(outs[0])
 
             always_full_zero = max_value == 0.0 and min_value == 0.0
-            always_non_full_zero = max_value > min_value
+            always_non_full_zero = max_value >= min_value
             self.assertTrue(always_full_zero or always_non_full_zero,
                             'always_full_zero or always_non_full_zero.')
         elif data_type in ['bool']:
@@ -169,7 +169,7 @@ class TestEmptyOp_ShapeTensorList(OpTest):
             min_value = np.nanmin(outs[0])
 
             always_full_zero = max_value == 0.0 and min_value == 0.0
-            always_non_full_zero = max_value > min_value
+            always_non_full_zero = max_value >= min_value
             self.assertTrue(always_full_zero or always_non_full_zero,
                             'always_full_zero or always_non_full_zero.')
         elif data_type in ['bool']:
@@ -186,7 +186,7 @@ class TestEmptyAPI(unittest.TestCase):
     def __check_out__(self, out, dtype='float32'):
         max_value = np.nanmax(np.array(out))
         min_value = np.nanmin(np.array(out))
-        always_non_full_zero = max_value > min_value
+        always_non_full_zero = max_value >= min_value
         always_full_zero = max_value == 0.0 and min_value == 0.0
         self.assertTrue(always_full_zero or always_non_full_zero,
                         'always_full_zero or always_non_full_zero.')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
fix empty op unit test fail sometimes

empty op 用于返回一块未初始化的内存，里面的值可以是任意的，之前的 max_value > min_value 没有考虑到所有值都是相同的情况，现在改成 max_value >= min_value。