### PR TITLE
[cherry-pick]Skip convert tensor shape while using Paddle.shape (#30223)

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -75,6 +75,17 @@ def dyfunc_tuple_shape_2(x):
     return res
 
 
+def dyfunc_paddle_shape_api(x):
+    x = paddle.to_tensor(x)
+    # paddle.shape will not be converted.
+    a = paddle.shape(x)[0]
+    # alias api will also not be converted.
+    alias_old_api = paddle.fluid.layers
+    b = alias_old_api.shape(x)[1]
+    res = paddle.reshape(x, shape=(b, a))
+    return res
+
+
 def dyfunc_with_if_1(x):
     x = fluid.dygraph.to_variable(x)
     res = fluid.layers.reshape(x, [-1, 1])
@@ -250,6 +261,18 @@ class TestTupleShape2(TestTensorShapeBasic):
     def init_test_func(self):
         self.input = numpy.ones((5, 7)).astype("int32")
         self.dygraph_func = dyfunc_tuple_shape_2
+
+
+class TestPaddleShapeApi(TestTensorShapeBasic):
+    def init_test_func(self):
+        self.input = numpy.ones((5, 7)).astype("int32")
+        self.input_spec = [paddle.static.InputSpec(shape=[5, 7], dtype="int32")]
+        self.dygraph_func = dyfunc_paddle_shape_api
+
+    def _set_expected_op_num(self):
+        self.expected_op_num = 6
+        self.expected_shape_op_num = 2
+        self.expected_slice_op_num = 2
 
 
 # 2. Tests with control flow if


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[cherry-pick]Skip convert tensor shape while using Paddle.shape (#30223)