### PR TITLE
[cherry-pick] clean redundant API alias in 2.0 - part 2

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/basic_api_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/basic_api_transformer.py
@@ -116,14 +116,14 @@ def is_to_variable(node):
 
 
 def to_assign_node(node):
-    # Transform dygraph api `fluid.dygraph.to_variable` alias `paddle.to_tensor` to static api `paddle.nn.functional.assign`.
+    # Transform dygraph api `fluid.dygraph.to_variable` alias `paddle.to_tensor` to static api `paddle.assign`.
     # NOTE:
     #   1. Api `to_variable` supports data type {float16, float32, float64, int16, int32, int64, uint8, uint16},
     #   but api `assign` only supports {float32, float64, int32, int64, bool};
     #   2. If the input of api `assign` is numpy.ndarray, its size cannot be greater than 1024 * 1024.
 
     assert isinstance(node, gast.Call)
-    assign_api = gast.parse('paddle.nn.functional.assign').body[0].value
+    assign_api = gast.parse('paddle.assign').body[0].value
     node.func = assign_api
 
     if node.args:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/basic_api_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/basic_api_transformer.py
@@ -132,7 +132,7 @@ def to_assign_node(node):
     else:
         for idx, kw in enumerate(node.keywords):
             if kw.arg == 'value' or kw.arg == 'data':
-                node.keywords[idx].arg = 'input'
+                node.keywords[idx].arg = 'x'
                 node.keywords = [node.keywords[idx]]
                 node.args = []
                 break

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -563,9 +563,9 @@ def assign(input, output=None):
                             [3, 4],
                             [1, 3]]).astype(np.int64)
           result1 = paddle.zeros(shape=[3, 3], dtype='float32')
-          paddle.nn.functional.assign(array, result1) # result1 = [[1, 1], [3 4], [1, 3]]
-          result2 = paddle.nn.functional.assign(data)  # result2 = [[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]]
-          result3 = paddle.nn.functional.assign(np.array([[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]], dtype='float32')) # result3 = [[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]]
+          paddle.assign(array, result1) # result1 = [[1, 1], [3 4], [1, 3]]
+          result2 = paddle.assign(data)  # result2 = [[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]]
+          result3 = paddle.assign(np.array([[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]], dtype='float32')) # result3 = [[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]]
     """
     helper = LayerHelper('assign', **locals())
     check_type(input, 'input', (Variable, numpy.ndarray), 'assign')

--- a/python/paddle/fluid/tests/unittests/test_inplace.py
+++ b/python/paddle/fluid/tests/unittests/test_inplace.py
@@ -30,7 +30,7 @@ class TestInplace(unittest.TestCase):
             var[0] = 1.1
             self.assertEqual(var.inplace_version, 1)
 
-            paddle.nn.functional.assign(paddle.ones(shape=[3]), var)
+            paddle.assign(paddle.ones(shape=[3]), var)
 
             # NOTE(liym27): assign(input, output) is an inplace operation for output.
             # There is inplace-related processing for api assign, var.inplace_version should be 2 not 1.

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -68,7 +68,6 @@ from .common import pad  #DEFINE_ALIAS
 from .common import cosine_similarity  #DEFINE_ALIAS
 from .common import unfold  #DEFINE_ALIAS
 # from .common import bilinear_tensor_product        #DEFINE_ALIAS
-from .common import assign  #DEFINE_ALIAS
 from .common import interpolate  #DEFINE_ALIAS
 from .common import upsample  #DEFINE_ALIAS
 from .common import bilinear  #DEFINE_ALIAS

--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -23,7 +23,6 @@ from ...fluid import dygraph_utils
 # from ...fluid import one_hot  #DEFINE_ALIAS
 # from ...fluid.layers import pad2d  #DEFINE_ALIAS
 from ...fluid.layers import unfold  #DEFINE_ALIAS
-from ...fluid.layers import assign  #DEFINE_ALIAS
 from ...fluid.layers import squeeze  #DEFINE_ALIAS
 from ...fluid.layers import unsqueeze  #DEFINE_ALIAS
 from ...tensor import clip
@@ -53,7 +52,6 @@ __all__ = [
     'pad',
     'unfold',
     #       'bilinear_tensor_product',
-    'assign',
     'interpolate',
     'upsample',
     'bilinear',


### PR DESCRIPTION
### PR types
Others

### PR changes
APIs

### Describe
to clean the redundant API alias for 2.0

[Part1](https://github.com/PaddlePaddle/Paddle/pull/29928) has deleted APIs as follows:
paddle.metric.mean_iou | delete | 没发现使用
paddle.metric.chunk_eval | delete | 在paddlenlp里提供api
paddle.nn.clip | delete | 跟paddle.clip重复，加删除paddle.nn.clip_by_norm
paddle.nn.functional.activation.brelu | modify | 加入到__all__列表
paddle.nn.functional.activation.hard_sigmoid | delete | 跟paddle.functional.activation.hardsigmoid重复
paddle.nn.functional.activation.hard_swish | delete | 跟paddle.functional.activation.hardswish重复
paddle.nn.functional.extension.row_conv | delete | 推荐用conv1d
paddle.nn.layer.BilinearTensorProduct | delete | 推荐用paddle.nn.Bilinear
paddle.nn.layer.Pool2D | delete | 推荐用paddle.nn.MaxPool2D, paddle.nn.AvgPool2D
paddle.nn.RowConv

Part2 delete APIs as follows:
paddle.check_import_scipy | delete | 没发现使用
paddle.nn.functional.assign | delete | 跟paddle.assign, paddle.tensor.assign重复，加删除paddle.nn.functional.assign，paddle.nn.functional.common.assign

https://github.com/PaddlePaddle/Paddle/pull/30013