### PR TITLE
fix header file paths of gflags, commit 1, test=develop

### DIFF
--- a/paddle/fluid/distributed/service/communicator.cc
+++ b/paddle/fluid/distributed/service/communicator.cc
@@ -13,10 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/distributed/service/communicator.h"
-#include <google/protobuf/text_format.h>
-#include "paddle/fluid/distributed/table/table.h"
 
-#include <gflags/gflags.h>
+#include <google/protobuf/text_format.h>
 #include <paddle/fluid/framework/program_desc.h>
 
 #include <algorithm>
@@ -25,6 +23,8 @@ limitations under the License. */
 #include <thread>  // NOLINT
 #include <unordered_set>
 
+#include "gflags/gflags.h"
+#include "paddle/fluid/distributed/table/table.h"
 #include "paddle/fluid/framework/eigen.h"
 #include "paddle/fluid/framework/selected_rows.h"
 #include "paddle/fluid/framework/tensor_util.h"
@@ -64,7 +64,7 @@ void Communicator::init_gflag(const std::string &gflags) {
   flags.insert(it, "exe default");
   char *flags_ptr[flags.size()];
   for (size_t i = 0; i < flags.size(); ++i) {
-    flags_ptr[i] = (char *)(flags[i].c_str());
+    flags_ptr[i] = (char *)(flags[i].c_str());  // NOLINT
   }
   int params_cnt = flags.size();
   char **params_ptr = &(flags_ptr[0]);
@@ -225,7 +225,7 @@ void Communicator::RpcSendDense(const CommContext &ctx, const Scope &scope) {
   DownpourBrpcClosure *closure = new DownpourBrpcClosure(
       request_call_num, [this, request_call_num](void *done) {
         int ret = 0;
-        auto *closure = (DownpourBrpcClosure *)done;
+        auto *closure = (DownpourBrpcClosure *)done;  // NOLINT
         for (size_t i = 0; i < request_call_num; ++i) {
           if (closure->check_response(i, PS_PUSH_DENSE_TABLE) != 0) {
             ret = -1;
@@ -262,7 +262,7 @@ void Communicator::RpcSendSparseParam(const std::string &varname, int table_id,
   DownpourBrpcClosure *closure = new DownpourBrpcClosure(
       request_call_num, [this, request_call_num](void *done) {
         int ret = 0;
-        auto *closure = (DownpourBrpcClosure *)done;
+        auto *closure = (DownpourBrpcClosure *)done;  // NOLINT
         for (size_t i = 0; i < request_call_num; ++i) {
           if (closure->check_response(i, PS_PUSH_SPARSE_PARAM) != 0) {
             ret = -1;
@@ -300,7 +300,7 @@ void Communicator::RpcSendSparse(const std::string &var_name, int table_id,
   DownpourBrpcClosure *closure = new DownpourBrpcClosure(
       request_call_num, [this, request_call_num](void *done) {
         int ret = 0;
-        auto *closure = (DownpourBrpcClosure *)done;
+        auto *closure = (DownpourBrpcClosure *)done;  // NOLINT
         for (size_t i = 0; i < request_call_num; ++i) {
           if (closure->check_response(i, PS_PUSH_SPARSE_TABLE) != 0) {
             ret = -1;
@@ -333,9 +333,9 @@ void Communicator::RpcRecvSparse(const std::string &varname, int table_id,
     push_g_vec.push_back(tensor->data<float>() + i * dim);
   }
 
-  auto status = _worker_ptr->pull_sparse((float **)push_g_vec.data(), table_id,
-                                         sparse_push_keys.data(),
-                                         sparse_push_keys.size());
+  auto status = _worker_ptr->pull_sparse(
+      (float **)push_g_vec.data(), table_id,  // NOLINT
+      sparse_push_keys.data(), sparse_push_keys.size());
   status.wait();
   return;
 }
@@ -397,7 +397,7 @@ void Communicator::SendGlobalStep(const CommContext &ctx, int batches,
   DownpourBrpcClosure *closure = new DownpourBrpcClosure(
       request_call_num, [this, request_call_num](void *done) {
         int ret = 0;
-        auto *closure = (DownpourBrpcClosure *)done;
+        auto *closure = (DownpourBrpcClosure *)done;  // NOLINT
         for (size_t i = 0; i < request_call_num; ++i) {
           if (closure->check_response(i, PS_PUSH_GLOBAL_STEP) != 0) {
             ret = -1;
@@ -1106,7 +1106,7 @@ void GeoCommunicator::SendSparse(const std::string &varname,
   ++_async_call_num;
   DownpourBrpcClosure *closure = new DownpourBrpcClosure(1, [this](void *done) {
     int ret = 0;
-    auto *closure = (DownpourBrpcClosure *)done;
+    auto *closure = (DownpourBrpcClosure *)done;  // NOLINT
     if (closure->check_response(0, PS_PUSH_SPARSE_TABLE) != 0) {
       ret = -1;
     }

--- a/paddle/fluid/distributed/service/env.h
+++ b/paddle/fluid/distributed/service/env.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <arpa/inet.h>
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <netinet/in.h>
 #include <stdio.h>
@@ -24,6 +23,7 @@
 #include <string>
 #include <unordered_set>
 #include <vector>
+#include "gflags/gflags.h"
 
 namespace paddle {
 namespace distributed {
@@ -55,7 +55,7 @@ struct PSHost {
     rank = host_label & rank_label_mask;
     port = (host_label >> 12) & port_label_mask;
     uint32_t ip_addr = (host_label >> 32);
-    ip = inet_ntoa(*(in_addr *)&ip_addr);
+    ip = inet_ntoa(*(in_addr *)&ip_addr);  // NOLINT
   }
 
   std::string to_string() {
@@ -108,7 +108,7 @@ struct PSHost {
 
 class PSEnvironment {
  public:
-  explicit PSEnvironment() {}
+  explicit PSEnvironment() {}  // NOLINT
   virtual ~PSEnvironment() {}
 
   virtual int32_t set_ps_servers(uint64_t *host_sign_list, int node_num) {
@@ -162,10 +162,11 @@ class PSEnvironment {
   }
 
  protected:
-  //注册一个host
-  virtual int32_t registe_ps_host(const std::string &ip, uint32_t port,
-                                  int32_t rank, std::vector<PSHost> &host_list,
-                                  std::unordered_set<uint64_t> &sign_set) {
+  //注册一个host //  NOLINT
+  virtual int32_t registe_ps_host(
+      const std::string &ip, uint32_t port, int32_t rank,
+      std::vector<PSHost> &host_list,            // NOLINT
+      std::unordered_set<uint64_t> &sign_set) {  // NOLINT
     PSHost host;
     host.ip = ip;
     host.port = port;
@@ -198,7 +199,7 @@ class PSEnvironment {
 
 class PaddlePSEnvironment : public PSEnvironment {
  public:
-  explicit PaddlePSEnvironment() {}
+  explicit PaddlePSEnvironment() {}  // NOLINT
   virtual ~PaddlePSEnvironment() {}
 
   virtual int32_t set_ps_servers(uint64_t *host_sign_list, int node_num) {

--- a/paddle/fluid/distributed/table/depends/dense.h
+++ b/paddle/fluid/distributed/table/depends/dense.h
@@ -14,13 +14,13 @@
 
 #pragma once
 
-#include <gflags/gflags.h>
 #include <math.h>  // for sqrt in CPU and CUDA
 #include <functional>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+#include "gflags/gflags.h"
 
 #include "paddle/fluid/distributed/common/utils.h"
 

--- a/paddle/fluid/distributed/table/depends/initializers.h
+++ b/paddle/fluid/distributed/table/depends/initializers.h
@@ -14,12 +14,12 @@
 
 #pragma once
 
-#include <gflags/gflags.h>
 #include <functional>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
+#include "gflags/gflags.h"
 
 #include "paddle/fluid/framework/generator.h"
 

--- a/paddle/fluid/distributed/table/depends/large_scale_kv.h
+++ b/paddle/fluid/distributed/table/depends/large_scale_kv.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <ThreadPool.h>
-#include <gflags/gflags.h>
 #include <functional>
 #include <future>  // NOLINT
 #include <memory>
@@ -25,6 +24,7 @@
 #include <unordered_set>
 #include <utility>
 #include <vector>
+#include "gflags/gflags.h"
 
 #include "paddle/fluid/distributed/common/utils.h"
 #include "paddle/fluid/distributed/table/depends/initializers.h"

--- a/paddle/fluid/distributed/table/depends/sparse.h
+++ b/paddle/fluid/distributed/table/depends/sparse.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <gflags/gflags.h>
 #include <math.h>  // for sqrt in CPU and CUDA
 #include <functional>
 #include <memory>
@@ -22,6 +21,7 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
+#include "gflags/gflags.h"
 
 #include "paddle/fluid/distributed/common/utils.h"
 #include "paddle/fluid/distributed/table/depends/large_scale_kv.h"

--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -14,7 +14,6 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/operator.h"
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <algorithm>
@@ -23,6 +22,7 @@ limitations under the License. */
 #include <unordered_set>
 #include <vector>
 
+#include "gflags/gflags.h"
 #include "paddle/fluid/framework/data_transform.h"
 #include "paddle/fluid/framework/data_type_transform.h"
 #include "paddle/fluid/framework/details/nan_inf_utils.h"

--- a/paddle/fluid/framework/unused_var_check.cc
+++ b/paddle/fluid/framework/unused_var_check.cc
@@ -14,10 +14,10 @@ limitations under the License. */
 
 #include "paddle/fluid/framework/unused_var_check.h"
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <string>
 #include <vector>
+#include "gflags/gflags.h"
 
 #include "paddle/fluid/framework/no_need_buffer_vars_inference.h"
 #include "paddle/fluid/framework/op_info.h"

--- a/paddle/fluid/framework/unused_var_check.h
+++ b/paddle/fluid/framework/unused_var_check.h
@@ -14,10 +14,10 @@ limitations under the License. */
 
 #pragma once
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <string>
 #include <unordered_set>
+#include "gflags/gflags.h"
 
 namespace paddle {
 namespace framework {

--- a/paddle/fluid/imperative/profiler.cc
+++ b/paddle/fluid/imperative/profiler.cc
@@ -17,9 +17,9 @@
 #ifdef WITH_GPERFTOOLS
 #include "gperftools/profiler.h"
 #endif
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 #include <mutex>  // NOLINT
+#include "gflags/gflags.h"
 
 DEFINE_string(
     tracer_profile_fname, "xxgperf",

--- a/paddle/fluid/inference/analysis/analyzer.h
+++ b/paddle/fluid/inference/analysis/analyzer.h
@@ -35,9 +35,9 @@ limitations under the License. */
  * phase in the inference service.
  */
 
-#include <gflags/gflags.h>
 #include <string>
 #include <vector>
+#include "gflags/gflags.h"
 #include "paddle/fluid/inference/analysis/analysis_pass.h"
 #include "paddle/fluid/inference/analysis/flags.h"
 

--- a/paddle/fluid/inference/analysis/flags.h
+++ b/paddle/fluid/inference/analysis/flags.h
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gflags/gflags.h>
+#pragma once
+
+#include "gflags/gflags.h"
 
 // TODO(Superjomn) add a definition flag like PADDLE_WITH_TENSORRT and hide this
 // flag if not available.

--- a/paddle/fluid/inference/analysis/ut_helper.h
+++ b/paddle/fluid/inference/analysis/ut_helper.h
@@ -13,10 +13,10 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #pragma once
-#include <gflags/gflags.h>
 #include <gtest/gtest.h>
 #include <fstream>
 #include <string>
+#include "gflags/gflags.h"
 #include "paddle/fluid/framework/executor.h"
 #include "paddle/fluid/inference/analysis/helper.h"
 

--- a/paddle/fluid/inference/api/demo_ci/simple_on_word2vec.cc
+++ b/paddle/fluid/inference/api/demo_ci/simple_on_word2vec.cc
@@ -16,13 +16,13 @@ limitations under the License. */
  * This file contains a simple demo for how to take a model for inference.
  */
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>
 
 #include <algorithm>
 #include <memory>
 #include <thread>  //NOLINT
 
+#include "gflags/gflags.h"
 #include "utils.h"  // NOLINT
 
 DEFINE_string(dirname, "", "Directory of the inference model.");

--- a/paddle/fluid/inference/api/demo_ci/trt_mobilenet_demo.cc
+++ b/paddle/fluid/inference/api/demo_ci/trt_mobilenet_demo.cc
@@ -16,8 +16,8 @@ limitations under the License. */
  * This file contains demo of mobilenet for tensorrt.
  */
 
-#include <gflags/gflags.h>
 #include <glog/logging.h>  // use glog instead of CHECK to avoid importing other paddle header files.
+#include "gflags/gflags.h"
 #include "utils.h"  // NOLINT
 
 DECLARE_double(fraction_of_gpu_memory_to_use);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
为修复预测库无法读入命令行参数的问题，需要首先将 gflags 头文件包含路径修改为非系统路径优先。