### PR TITLE
Try to remove test_fuse_elewise_add_act_pass from the black list of running unittest on windows.

### DIFF
--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -64,7 +64,6 @@ diable_wingpu_test="^test_gradient_clip$|\
 ^test_dataloader_early_reset$|\
 ^test_decoupled_py_reader_data_check$|\
 ^test_fleet_base_single$|\
-^test_fuse_elewise_add_act_pass$|\
 ^test_fuse_optimizer_pass$|\
 ^test_multiprocess_dataloader_iterable_dataset_dynamic$|\
 ^test_parallel_dygraph_sync_batch_norm$|\


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Try to remove test_fuse_elewise_add_act_pass from the black list of running unittest on windows.