### PR TITLE
fix case name error when op benchmark ci auto-retry

### DIFF
--- a/tools/check_op_benchmark_result.py
+++ b/tools/check_op_benchmark_result.py
@@ -127,7 +127,7 @@ def update_api_info_file(fail_case_list, api_info_file):
     check_path_exists(api_info_file)
 
     # set of case names for performance check failures
-    fail_case_set = set(map(lambda x: x.split('_')[0], fail_case_list))
+    fail_case_set = set(map(lambda x: x.rsplit('_', 1)[0], fail_case_list))
 
     # list of api infos for performance check failures
     api_info_list = list()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复如`floor_divide_0(forward)`等case名称解析错误问题。

使用`split('_')[0]`形式只能取得第一个下划线前的内容，对于含有下划线的API，这种方式获取不到正确的case。

需要改为使用`rsplit('_', 1)[0]`的方式来获取最后一个下划线前的所有内容。
