### PR TITLE
Remove c++ stacktrace open hint

### DIFF
--- a/paddle/fluid/platform/enforce.h
+++ b/paddle/fluid/platform/enforce.h
@@ -284,15 +284,8 @@ inline std::string GetErrorSumaryString(StrType&& what, const char* file,
             "Summary:\n----------------------\n";
   }
   sout << string::Sprintf("%s (at %s:%d)", std::forward<StrType>(what), file,
-                          line);
-  if (FLAGS_call_stack_level < 2) {
-    // NOTE(chenweihang): if no C++ backtrace, give a hint to tell users
-    // how to show C++ backtrace, this hint only show in 2.0-rc verison,
-    // and will be removed in 2.0 official version
-    sout << "\n  [Hint: If you need C++ stacktraces for debugging, please set "
-            "`FLAGS_call_stack_level=2`.]";
-  }
-  sout << std::endl;
+                          line)
+       << std::endl;
   return sout.str();
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Remove c++ stacktrace open hint from 2.0