### PR TITLE
Change PADDLE_ENFORCE dimension size

### DIFF
--- a/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/activation_mkldnn_op.cc
@@ -94,8 +94,10 @@ void eltwise_forward(const framework::ExecutionContext &ctx,
   }
 
   PADDLE_ENFORCE(
-      x->dims().size() == 2 || x->dims().size() == 3 || x->dims().size() == 4,
-      platform::errors::Unimplemented("Input dim must be with 2, 3 or 4"));
+      x->dims().size() >= 1 || x->dims().size() <= 6,
+      platform::errors::Unimplemented("Input dimension size can be 1, 2, 3, 4, "
+                                      "5, or 6, but now the dimension size is",
+                                      x->dims().size()));
 
   auto src_tz = framework::vectorize<int64_t>(x->dims());
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others 

### PR changes
Others 

### Describe
Fix issue #30089. Remove wrong PADDLE_ENFORCE. After merging this, the 30089 may have [0.95209444, nan, nan ..etc] that is because #30089 model is with only one batch
