### PR TITLE
"Enhance container 'Sequential' class. Supporting: int (including minus), slice, and str" 

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -79,8 +79,9 @@ class Sequential(Layer):
         idx %= size
         return next(itertools.islice(iterator, idx, None))
 
-    def __getitem__(self, idx: Union[slice, int, str]):
-        r'''get
+    def __getitem__(self, idx):
+        r'''get 
+        idx: Union[slice, int, str]
         Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
         '''
         if isinstance(idx, str):
@@ -90,8 +91,9 @@ class Sequential(Layer):
         else:
             return self._get_item_by_idx(self._sub_layers.values(), idx)
 
-    def __setitem__(self, idx: Union[int, str], layer: Layer) -> None:
+    def __setitem__(self, idx, layer: Layer):
         r'''set
+        idx: Union[int, str]
         Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
         '''
         if isinstance(idx, str):
@@ -100,8 +102,9 @@ class Sequential(Layer):
             key = self._get_item_by_idx(self._sub_layers.keys(), idx)
             return setattr(self, key, layer)
 
-    def __delitem__(self, idx: Union[slice, int, str]) -> None:
+    def __delitem__(self, idx):
         r'''del 
+        idx: Union[slice, int, str]
         Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
         '''
         if isinstance(idx, slice):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

- https://github.com/lyuwenyu/Paddle/commit/f3a68bff4d3d24c8c45e80813f694c64dcce4c2c
- get: Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
- set: Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
- def: Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
- example:

```python
mm = Sequential(paddle.nn.Linear(3, 3), 
                  paddle.nn.ReLU(), 
                  paddle.nn.Sequential(paddle.nn.Linear(3, 3), paddle.nn.ReLU()), 
                  paddle.nn.Conv2D(2, 2, 2, 2, 2),
                  paddle.nn.Linear(3, 3))

print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "Linear(input_dim=3, output_dim=3)"
    }
    

### get
```python
print(repr_string(mm[-1]))
```

    "Linear(input_dim=3, output_dim=3)"
    


```python
mm[-1] = paddle.nn.ReLU()
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "ReLU()"
    }
    


```python
print(repr_string(mm[:-2]))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       }
    }
    

### set
```python
print(repr_string(mm))
mm['3'] = paddle.nn.Linear(100, 300)
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "ReLU()"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Linear(input_dim=100, output_dim=300)",
       "4": "ReLU()"
    }
    

### del
```python
del mm[-1]
print(repr_string(mm))

del mm['2']
print(repr_string(mm))

del mm[1:]
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Linear(input_dim=100, output_dim=300)"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "3": "Linear(input_dim=100, output_dim=300)"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)"
    }
    


```python

```


