### PR TITLE
Enhance container 'Sequential' class. Supporting: int (including minus), slice, and str

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -79,8 +79,9 @@ class Sequential(Layer):
         idx %= size
         return next(itertools.islice(iterator, idx, None))
 
-    def __getitem__(self, idx: Union[slice, int, str]):
-        r'''get
+    def __getitem__(self, idx):
+        r'''get 
+        idx: Union[slice, int, str]
         Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
         '''
         if isinstance(idx, str):
@@ -90,8 +91,9 @@ class Sequential(Layer):
         else:
             return self._get_item_by_idx(self._sub_layers.values(), idx)
 
-    def __setitem__(self, idx: Union[int, str], layer: Layer) -> None:
+    def __setitem__(self, idx, layer: Layer):
         r'''set
+        idx: Union[int, str]
         Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
         '''
         if isinstance(idx, str):
@@ -100,8 +102,9 @@ class Sequential(Layer):
             key = self._get_item_by_idx(self._sub_layers.keys(), idx)
             return setattr(self, key, layer)
 
-    def __delitem__(self, idx: Union[slice, int, str]) -> None:
+    def __delitem__(self, idx):
         r'''del 
+        idx: Union[slice, int, str]
         Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
         '''
         if isinstance(idx, slice):

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -69,14 +69,13 @@ class Sequential(Layer):
             for idx, layer in enumerate(layers):
                 self.add_sublayer(str(idx), layer)
 
-    def _get_item_by_idx(self, iterator, idx):
-        """Get the idx-th item of the iterator"""
-        size = len(self)
-        idx = operator.index(idx)
-        if not -size <= idx < size:
+    def _get_abs_index(self, idx):
+        '''Get the absolute index '''
+        if not (-len(self) <= idx < len(self)):
             raise IndexError('index {} is out of range'.format(idx))
-        idx %= size
-        return next(itertools.islice(iterator, idx, None))
+        if idx < 0:
+            idx += len(self)
+        return idx
 
     def __getitem__(self, idx):
         r'''get 
@@ -88,7 +87,7 @@ class Sequential(Layer):
         elif isinstance(idx, slice):
             return self.__class__(*list(self._sub_layers.items())[idx])
         else:
-            return self._get_item_by_idx(self._sub_layers.values(), idx)
+            return self._sub_layers[str(self._get_abs_index(idx))]
 
     def __setitem__(self, idx, layer):
         r'''set
@@ -98,7 +97,7 @@ class Sequential(Layer):
         if isinstance(idx, str):
             return setattr(self, str(idx), layer)
         else:
-            key = self._get_item_by_idx(self._sub_layers.keys(), idx)
+            key = list(self._sub_layers.keys())[self._get_abs_index(idx)]
             return setattr(self, key, layer)
 
     def __delitem__(self, idx):
@@ -110,7 +109,7 @@ class Sequential(Layer):
             for key in list(self._sub_layers.keys())[idx]:
                 delattr(self, key)
         elif isinstance(idx, int):
-            key = self._get_item_by_idx(self._sub_layers.keys(), idx)
+            key = list(self._sub_layers.keys())[self._get_abs_index(idx)]
             delattr(self, key)
         else:
             delattr(self, idx)

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -67,7 +67,6 @@ class Sequential(Layer):
                 self.add_sublayer(str(idx), layer)
 
     def _get_abs_index(self, idx):
-        """Get the absolute index"""
         assert -len(self) <= idx < len(self)
         if idx < 0:
             idx += len(self)
@@ -75,8 +74,14 @@ class Sequential(Layer):
 
     def __getitem__(self, idx):
         r"""get 
-        idx: Union[slice, int, str]
         Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
+        
+        Parameters: idx: Union[slice, int, str]
+        
+        Examples:
+            .. code-block:: python
+             pass
+             
         """
         if isinstance(idx, str):
             return self._sub_layers[idx]
@@ -86,9 +91,15 @@ class Sequential(Layer):
             return self._sub_layers[str(self._get_abs_index(idx))]
 
     def __setitem__(self, idx, layer):
-        r"""set
-        idx: Union[int, str]
+        """set
         Support Operations: mm[1] = 'Layer Instance', mm['L1'] = 'Layer Instance'. Where mm is sequential instance
+        
+        Parameters: idx: Union[int, str]
+
+        Examples:
+            .. code-block:: python
+             pass
+             
         """      
         if isinstance(idx, str):
             return setattr(self, str(idx), layer)
@@ -97,9 +108,15 @@ class Sequential(Layer):
             return setattr(self, key, layer)
 
     def __delitem__(self, idx):
-        r"""del 
-        idx: Union[slice, int, str]
+        """del 
         Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
+        
+        Parameters: idx: Union[slice, int, str]
+        
+        Examples:
+            .. code-block:: python
+             pass
+             
         """
         if isinstance(idx, slice):
             for key in list(self._sub_layers.keys())[idx]:

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import OrderedDict
-from typing import Union
 import operator
 import itertools
 

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -67,17 +67,17 @@ class Sequential(Layer):
                 self.add_sublayer(str(idx), layer)
 
     def _get_abs_index(self, idx):
-        '''Get the absolute index '''
+        """Get the absolute index"""
         assert -len(self) <= idx < len(self)
         if idx < 0:
             idx += len(self)
         return idx
 
     def __getitem__(self, idx):
-        r'''get 
+        r"""get 
         idx: Union[slice, int, str]
         Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
-        '''
+        """
         if isinstance(idx, str):
             return self._sub_layers[idx]
         elif isinstance(idx, slice):
@@ -86,10 +86,10 @@ class Sequential(Layer):
             return self._sub_layers[str(self._get_abs_index(idx))]
 
     def __setitem__(self, idx, layer):
-        r'''set
+        r"""set
         idx: Union[int, str]
-        Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
-        '''        
+        Support Operations: mm[1] = 'Layer Instance', mm['L1'] = 'Layer Instance'. Where mm is sequential instance
+        """      
         if isinstance(idx, str):
             return setattr(self, str(idx), layer)
         else:
@@ -97,10 +97,10 @@ class Sequential(Layer):
             return setattr(self, key, layer)
 
     def __delitem__(self, idx):
-        r'''del 
+        r"""del 
         idx: Union[slice, int, str]
         Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
-        '''
+        """
         if isinstance(idx, slice):
             for key in list(self._sub_layers.keys())[idx]:
                 delattr(self, key)

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 
 from collections import OrderedDict
-import operator
-import itertools
-
 from ..framework import Parameter
 from .layers import Layer
 
@@ -71,8 +68,7 @@ class Sequential(Layer):
 
     def _get_abs_index(self, idx):
         '''Get the absolute index '''
-        if not (-len(self) <= idx < len(self)):
-            raise IndexError('index {} is out of range'.format(idx))
+        assert -len(self) <= idx < len(self)
         if idx < 0:
             idx += len(self)
         return idx

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -91,11 +91,13 @@ class Sequential(Layer):
         else:
             return self._get_item_by_idx(self._sub_layers.values(), idx)
 
-    def __setitem__(self, idx, layer: Layer):
+    def __setitem__(self, idx, layer):
         r'''set
         idx: Union[int, str]
         Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
         '''
+        assert isinstance(layer, Layer), "assert `layer` is Layer instance"
+        
         if isinstance(idx, str):
             return setattr(self, str(idx), layer)
         else:

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -73,16 +73,6 @@ class Sequential(Layer):
         return idx
 
     def __getitem__(self, idx):
-        """get 
-        Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
-        
-        Parameters: idx: Union[slice, int, str]
-        
-        Examples:
-            .. code-block:: python
-                pass
-             
-        """
         if isinstance(idx, str):
             return self._sub_layers[idx]
         elif isinstance(idx, slice):
@@ -90,17 +80,7 @@ class Sequential(Layer):
         else:
             return self._sub_layers[str(self._get_abs_index(idx))]
 
-    def __setitem__(self, idx, layer):
-        """set
-        Support Operations: mm[1] = 'Layer Instance', mm['L1'] = 'Layer Instance'. Where mm is sequential instance
-        
-        Parameters: idx: Union[int, str]
-
-        Examples:
-            .. code-block:: python
-                pass
-             
-        """      
+    def __setitem__(self, idx, layer): 
         if isinstance(idx, str):
             setattr(self, str(idx), layer)
         else:
@@ -108,16 +88,6 @@ class Sequential(Layer):
             setattr(self, key, layer)
 
     def __delitem__(self, idx):
-        """del 
-        Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
-        
-        Parameters: idx: Union[slice, int, str]
-        
-        Examples:
-            .. code-block:: python
-                pass
-             
-        """
         if isinstance(idx, slice):
             for key in list(self._sub_layers.keys())[idx]:
                 delattr(self, key)

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -80,7 +80,7 @@ class Sequential(Layer):
         
         Examples:
             .. code-block:: python
-             pass
+                pass
              
         """
         if isinstance(idx, str):
@@ -98,14 +98,14 @@ class Sequential(Layer):
 
         Examples:
             .. code-block:: python
-             pass
+                pass
              
         """      
         if isinstance(idx, str):
-            return setattr(self, str(idx), layer)
+            setattr(self, str(idx), layer)
         else:
             key = list(self._sub_layers.keys())[self._get_abs_index(idx)]
-            return setattr(self, key, layer)
+            setattr(self, key, layer)
 
     def __delitem__(self, idx):
         """del 
@@ -115,7 +115,7 @@ class Sequential(Layer):
         
         Examples:
             .. code-block:: python
-             pass
+                pass
              
         """
         if isinstance(idx, slice):

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -78,7 +78,8 @@ class Sequential(Layer):
         elif isinstance(idx, slice):
             return self.__class__(*list(self._sub_layers.items())[idx])
         else:
-            return self._sub_layers[str(self._get_abs_index(idx))]
+            idx = self._get_abs_index(idx)
+            return self._sub_layers[str(idx)]
 
     def __setitem__(self, idx, layer): 
         if isinstance(idx, str):

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -73,7 +73,7 @@ class Sequential(Layer):
         return idx
 
     def __getitem__(self, idx):
-        r"""get 
+        """get 
         Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
         
         Parameters: idx: Union[slice, int, str]

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -94,9 +94,7 @@ class Sequential(Layer):
         r'''set
         idx: Union[int, str]
         Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
-        '''
-        assert isinstance(layer, Layer), "assert `layer` is Layer instance"
-        
+        '''        
         if isinstance(idx, str):
             return setattr(self, str(idx), layer)
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

- get: Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
- set: Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
- del: Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
- example:

```python
mm = Sequential(paddle.nn.Linear(3, 3), 
                  paddle.nn.ReLU(), 
                  paddle.nn.Sequential(paddle.nn.Linear(3, 3), paddle.nn.ReLU()), 
                  paddle.nn.Conv2D(2, 2, 2, 2, 2),
                  paddle.nn.Linear(3, 3))

print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "Linear(input_dim=3, output_dim=3)"
    }
    

### get
```python
print(repr_string(mm[-1]))
```

    "Linear(input_dim=3, output_dim=3)"
    


```python
mm[-1] = paddle.nn.ReLU()
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "ReLU()"
    }
    


```python
print(repr_string(mm[:-2]))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       }
    }
    

### set
```python
print(repr_string(mm))
mm['3'] = paddle.nn.Linear(100, 300)
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "ReLU()"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Linear(input_dim=100, output_dim=300)",
       "4": "ReLU()"
    }
    

### del
```python
del mm[-1]
print(repr_string(mm))

del mm['2']
print(repr_string(mm))

del mm[1:]
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Linear(input_dim=100, output_dim=300)"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "3": "Linear(input_dim=100, output_dim=300)"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)"
    }
    


```python

```


