### PR TITLE
add xpu_wait after running each xpu op, *test=kunlun

### DIFF
--- a/paddle/fluid/framework/operator.cc
+++ b/paddle/fluid/framework/operator.cc
@@ -1137,6 +1137,12 @@ void OperatorWithKernel::RunImpl(const Scope& scope,
                                        platform::EventRole::kInnerOp);
     (*kernel_func_)(
         ExecutionContext(*this, exec_scope, *dev_ctx, *runtime_ctx));
+#ifdef PADDLE_WITH_XPU
+    if (std::getenv("FLAGS_opt_xpu_mem") != nullptr &&
+        platform::is_xpu_place(kernel_type_->place_)) {
+      dev_ctx->Wait();
+    }
+#endif
   }
 
   if (!transfered_inplace_vars.empty()) {


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
XPU memory optimization

When this function is open(i.e, export FLAGS_opt_xpu_mem=1), XPU ops would run xpu_wait func after running each op. This reduces the amount of XPU memory fragmentation at runtime.

*test=kunlun