### PR TITLE
fix quantize error in speical naming model

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/qat.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/qat.py
@@ -255,13 +255,19 @@ class ImperativeQuantAware(object):
             if hasattr(layer, "skip_quant") and layer.skip_quant == True:
                 continue
 
-            scopes = name.split('.')
-            target = scopes[-1]
+            last_idx = 0
+            idx = 0
             obj = model
             parent = model
-            for i in range(len(scopes) - 1):
-                obj = getattr(parent, scopes[i])
-                parent = obj
+
+            while idx < len(name):
+                if (name[idx] == '.'):
+                    if hasattr(parent, name[last_idx:idx]):
+                        obj = getattr(obj, name[last_idx:idx])
+                        parent = obj
+                        last_idx = idx + 1
+                idx += 1
+            target = name[last_idx:idx]
 
             quant_layer = self._get_quantized_counterpart(layer)
             setattr(quant_layer, "layer_name", layer.full_name())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Refine quantize find parent.
For a conv layer name like: `neck`.`yolo_block.0`.`conv_module`.`conv0`.`conv`
User named a module as `yolo_block.0`， the original code will report an error that `neck does not have "yolo_block" attr`.
This PR fixed the issue.
Cherry-pick https://github.com/PaddlePaddle/Paddle/pull/30354