### PR TITLE
Enhance installation error message after separating AVX and NO_AVX compilation

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -15,7 +15,7 @@ else()
   set(paddle_known_gpu_archs7 "30 35 50 52")
   set(paddle_known_gpu_archs8 "30 35 50 52 60 61")
   set(paddle_known_gpu_archs9 "30 35 50 52 60 61 70")
-  set(paddle_known_gpu_archs10 "30 35 50 52 60 61 70 75")
+  set(paddle_known_gpu_archs10 "35 50 52 60 61 70 75")
   set(paddle_known_gpu_archs11 "52 60 61 70 75 80")
 endif()
 

--- a/python/paddle/fluid/core.py
+++ b/python/paddle/fluid/core.py
@@ -283,16 +283,24 @@ if avx_supported():
             from .core_avx import _remove_tensor_list_mmap_fds
     except Exception as e:
         if has_avx_core:
+            sys.stderr.write(
+                'Error: Can not import avx core while this file exists: ' +
+                current_path + os.sep + 'core_avx.' + core_suffix + '\n')
             raise e
         else:
             from .. import compat as cpt
             sys.stderr.write(
-                'WARNING: Do not have avx core. You may not build with AVX, '
-                'but AVX is supported on local machine.\n You could build paddle '
-                'WITH_AVX=ON to get better performance.\n'
-                'The original error is: %s\n' % cpt.get_exception_message(e))
+                "WARNING: AVX is supported on local machine, but you have installed "
+                "paddlepaddle without avx core. Hence, no_avx core which has worse "
+                "preformance will be imported.\nYou could reinstall paddlepaddle by "
+                "'python -m pip install -U paddlepaddle-gpu[==version]' or rebuild "
+                "paddlepaddle WITH_AVX=ON to get better performance.\n"
+                "The original error is: %s\n" % cpt.get_exception_message(e))
             load_noavx = True
 else:
+    sys.stderr.write(
+        "WARNING: AVX is not support on your machine. Hence, no_avx core will be imported, "
+        "It has much worse preformance than avx core.\n")
     load_noavx = True
 
 if load_noavx:
@@ -330,8 +338,14 @@ if load_noavx:
     except Exception as e:
         if has_noavx_core:
             sys.stderr.write(
-                'Error: Can not import noavx core while this file exists ' +
+                'Error: Can not import noavx core while this file exists: ' +
                 current_path + os.sep + 'core_noavx.' + core_suffix + '\n')
+        else:
+            sys.stderr.write(
+                "Error: AVX is not support on your machine, but you have installed "
+                "paddlepaddle with avx core, you should reinstall paddlepaddle by "
+                "'python -m pip install -U paddlepaddle-gpu[==version] -f "
+                "https://paddlepaddle.org.cn/whl/stable_noavx.html'\n")
         raise e
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->


**1.  30架构对应很早期的显卡，在2.0及之后移除该架构编译**

**2. 分离avx与core_avx编译，并优化了安装报错信息，用户分别存在以下几种错误行为：**


A. 用户电脑支持avx，但安装了no_avx版本，提示warning，会使用低性能的no_avx
```
WARNING: AVX is supported on local machine, but you have installed paddlepaddle without avx core. Hence, no_avx core which has worse preformance will be imported.
You could reinstall paddlepaddle by 'python -m pip install -U paddlepaddle-gpu[==version]' or rebuild paddlepaddle WITH_AVX=ON to get better performance.
```

B. 用户电脑不支持avx，但安装了avx版本，直接报错
```
Error: AVX is not support on your machine, but you have installed paddlepaddle with avx core, you should reinstall paddlepaddle by 'python -m pip install -U paddlepaddle-gpu[==version] -f https://paddlepaddle.org.cn/whl/stable_noavx.html'
```

C. 用户电脑不支持avx，会在加载no_avx前提示该版本性能较差
```
WARNING: AVX is not support on your machine. Hence, no_avx core will be imported, It has much worse preformance than avx core.
```

D. 用户电脑支持avx，且安装Paddle的core_avx.so无法正常加载（较少，可能是文件损坏等原因）
```
Error: Can not import avx core while this file exists: /zhouwei/Paddle4/core_avx.so
```


E. 用户电脑不支持avx，且安装的Paddle的core_no_avx.so无法正常加载（较少，可能是文件损坏等原因）
```
Error: Can not import noavx core while this file exists: /zhouwei/Paddle4/core_noavx.so
```

