### PR TITLE
fix the rnn mask memory bug for out of read

### DIFF
--- a/paddle/fluid/operators/rnn_op.h
+++ b/paddle/fluid/operators/rnn_op.h
@@ -960,7 +960,10 @@ class RNNCPUKernel : public framework::OpKernel<T> {
     if (has_seq_length) {
       sequence_length = ctx.Input<Tensor>("SequenceLength");
     }
-    if (!dropout_mask->IsInitialized()) {
+    if (dropout_mask->numel() != output->numel()) {
+      if (dropout_mask->IsInitialized()) {
+        dropout_mask->clear();
+      }
       dropout_mask->mutable_data<uint8_t>(output->dims(), ctx.GetPlace());
     }
 

--- a/paddle/fluid/operators/rnn_op.h
+++ b/paddle/fluid/operators/rnn_op.h
@@ -960,12 +960,10 @@ class RNNCPUKernel : public framework::OpKernel<T> {
     if (has_seq_length) {
       sequence_length = ctx.Input<Tensor>("SequenceLength");
     }
-    if (dropout_mask->numel() != output->numel()) {
-      if (dropout_mask->IsInitialized()) {
-        dropout_mask->clear();
-      }
-      dropout_mask->mutable_data<uint8_t>(output->dims(), ctx.GetPlace());
+    if (dropout_mask->IsInitialized()) {
+      if (dropout_mask->numel() != output->numel()) dropout_mask->clear();
     }
+    dropout_mask->mutable_data<uint8_t>(output->dims(), ctx.GetPlace());
 
     // init the output and allocate the memory
     output->mutable_data<T>(ctx.GetPlace());


### PR DESCRIPTION
### PR types
Bug fixes 
### PR changes
Others

### Describe
#### 修复RNN CPU API在不同batch中Seq lens不同时coredump
- 触发原因
  在RNN系列op里面，有个dropout的mask矩阵需要生成，并且在backward的时候需要用到前向的mask矩阵，因此将mask矩阵设置为output，且为persistable。为了减少mask Variable不断的创建，因此在BUG代码中判断了如果mask矩阵已经进行了初始化操作，则不再进行初始化擦操作。但是在动态图RNN任务中各个Batch的seq_lens可能不一样，那么mask矩阵的矩阵大小就会不一样，因此不再初始化操作很可能会造成内存读越界。

- 修复方法
  判断mask矩阵的大小是否和output一致，如果不一致则重新为mask矩阵分配内存进行初始化，如果一致则不再初始化。

