### PR TITLE
follow-up works of gflags export, test=develop

### DIFF
--- a/cmake/external/gflags.cmake
+++ b/cmake/external/gflags.cmake
@@ -46,6 +46,12 @@ ExternalProject_Add(
     SOURCE_DIR      ${GFLAGS_SOURCE_DIR}
     BUILD_COMMAND   ${BUILD_COMMAND}
     INSTALL_COMMAND ${INSTALL_COMMAND}
+    # If we explicitly leave the `UPDATE_COMMAND` of the ExternalProject_Add
+    # function in CMakeLists blank, it will cause another parameter GIT_TAG
+    # to be modified without triggering incremental compilation, and the
+    # third-party library version changes cannot be incorporated.
+    # reference: https://cmake.org/cmake/help/latest/module/ExternalProject.html
+    UPDATE_COMMAND  ""
     CMAKE_ARGS      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                     -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}

--- a/cmake/external/glog.cmake
+++ b/cmake/external/glog.cmake
@@ -42,9 +42,14 @@ ExternalProject_Add(
     ${EXTERNAL_PROJECT_LOG_ARGS}
     ${SHALLOW_CLONE}
     "${GLOG_DOWNLOAD_CMD}"
-    DEPENDS         gflags
     PREFIX          ${GLOG_PREFIX_DIR}
     SOURCE_DIR      ${GLOG_SOURCE_DIR}
+    # If we explicitly leave the `UPDATE_COMMAND` of the ExternalProject_Add
+    # function in CMakeLists blank, it will cause another parameter GIT_TAG
+    # to be modified without triggering incremental compilation, and the
+    # third-party library version changes cannot be incorporated.
+    # reference: https://cmake.org/cmake/help/latest/module/ExternalProject.html
+    UPDATE_COMMAND  ""
     CMAKE_ARGS      -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
                     -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
                     -DCMAKE_CXX_FLAGS=${GLOG_CMAKE_CXX_FLAGS}

--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -46,9 +46,9 @@ set(STATIC_INFERENCE_API paddle_inference_api analysis_predictor
         analysis_config paddle_pass_builder activation_functions ${mkldnn_quantizer_cfg})
 #TODO(wilber, T8T9): Do we still need to support windows gpu static library?
 if(WIN32 AND WITH_GPU)
-  cc_library(paddle_fluid DEPS ${fluid_modules} ${STATIC_INFERENCE_API})
+  cc_library(paddle_fluid DEPS ${fluid_modules} ${STATIC_INFERENCE_API} gflags)
 else()
-  create_static_lib(paddle_fluid ${fluid_modules} ${STATIC_INFERENCE_API})
+  create_static_lib(paddle_fluid ${fluid_modules} ${STATIC_INFERENCE_API} gflags)
 endif()
 
 if(NOT APPLE)

--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -133,7 +133,15 @@ endif()
 
 if(WITH_STATIC_LIB)
   set(DEPS ${PADDLE_LIB}/paddle/lib/libpaddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
+  if(WIN32)
+    set(GFLAGS_DEPS gflags_static)
+  else()
+    set(GFLAGS_DEPS gflags)
+  endif()
 else()
+  # The dynamic library already contains the Gflags interfaces
+  # and should not be statically linked at the same time.
+  set(GFLAGS_DEPS "")
   if(WIN32)
     set(DEPS ${PADDLE_LIB}/paddle/lib/paddle_fluid${CMAKE_STATIC_LIBRARY_SUFFIX})
   else()
@@ -145,12 +153,12 @@ if (NOT WIN32)
   set(EXTERNAL_LIB "-lrt -ldl -lpthread")
   set(DEPS ${DEPS}
       ${MATH_LIB} ${MKLDNN_LIB}
-      glog gflags protobuf  xxhash
+      glog ${GFLAGS_DEPS} protobuf xxhash
       ${EXTERNAL_LIB})
 else()
   set(DEPS ${DEPS}
       ${MATH_LIB} ${MKLDNN_LIB}
-      glog gflags_static libprotobuf  xxhash ${EXTERNAL_LIB})
+      glog ${GFLAGS_DEPS} libprotobuf xxhash ${EXTERNAL_LIB})
   set(DEPS ${DEPS} shlwapi.lib)
 endif(NOT WIN32)
 

--- a/paddle/fluid/inference/paddle_fluid.map
+++ b/paddle/fluid/inference/paddle_fluid.map
@@ -1,9 +1,11 @@
 {
 	global:
-		*paddle*;
-		*Pass*;
-		*profile*;
-		*fL*;
+		extern "C++" {
+			*paddle*;
+			*Pass*;
+			*profile*;
+			*fL*::*;
+		};
 	local:
 		*;
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
为方便用户传入命令行变量，https://github.com/PaddlePaddle/Paddle/pull/30448 导出了预测库 GFlags 接口，所以修改 demo_ci，同时恢复第三方库的 Windows CI 加速。