### PR TITLE
Solve inconsistent order in each card in  dynamic graph

### DIFF
--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -94,7 +94,7 @@ Reducer::Reducer(const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
                  const std::vector<bool> &is_sparse_gradient,
                  std::shared_ptr<imperative::ParallelContext> parallel_ctx,
                  const std::vector<size_t> &group_size_limits,
-                 bool find_unused_vars)
+                 bool find_unused_vars, bool reject_rebuld_group)
     : vars_(vars),
       group_indices_(group_indices),
       is_sparse_gradient_(is_sparse_gradient),
@@ -102,6 +102,7 @@ Reducer::Reducer(const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
       group_size_limits_(group_size_limits),
       find_unused_vars_(find_unused_vars) {
   VLOG(3) << "Start construct the Reducer ...";
+  has_rebuilt_group_ = reject_rebuld_group;
   nrings_ = parallel_ctx->GetNRings();
   // initialize groups
   InitializeGroups(group_indices);

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -435,8 +435,12 @@ void Reducer::MarkVarReady(const size_t var_index, const bool is_used_var) {
       group_tensor.ShareDataWith(*tensor).Resize(
           {static_cast<int64_t>(length)});
     } else {
-      group_tensor.Resize({static_cast<int64_t>(length)});
-      group_tensor.mutable_data(place_, group.dtype_);
+      if (!group_tensor.IsInitialized()) {
+        auto *dev_ctx = platform::DeviceContextPool::Instance().Get(place_);
+        group_tensor.Resize({static_cast<int64_t>(length)});
+        group_tensor.mutable_data(place_, group.dtype_);
+        operators::math::set_constant(*dev_ctx, &group_tensor, 0.0);
+      }
     }
   } else {
     // process sparse group

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -94,7 +94,7 @@ Reducer::Reducer(const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
                  const std::vector<bool> &is_sparse_gradient,
                  std::shared_ptr<imperative::ParallelContext> parallel_ctx,
                  const std::vector<size_t> &group_size_limits,
-                 bool find_unused_vars, bool reject_rebuld_group)
+                 bool find_unused_vars, bool use_rebuild_group)
     : vars_(vars),
       group_indices_(group_indices),
       is_sparse_gradient_(is_sparse_gradient),
@@ -102,7 +102,7 @@ Reducer::Reducer(const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
       group_size_limits_(group_size_limits),
       find_unused_vars_(find_unused_vars) {
   VLOG(3) << "Start construct the Reducer ...";
-  has_rebuilt_group_ = reject_rebuld_group;
+  has_rebuilt_group_ = !use_rebuild_group;
   nrings_ = parallel_ctx->GetNRings();
   // initialize groups
   InitializeGroups(group_indices);

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -165,11 +165,12 @@ class Reducer {
       const std::vector<std::vector<size_t>>& group_indices,
       const std::vector<bool>& is_sparse_gradient,
       std::shared_ptr<imperative::ParallelContext> parallel_ctx,
-      const std::vector<size_t>& group_size_limits, bool find_unused_vars) {
+      const std::vector<size_t>& group_size_limits, bool find_unused_vars,
+      bool reject_rebuld_group) {
     if (NULL == s_instance_) {
       s_instance_.reset(new paddle::imperative::Reducer(
           vars, group_indices, is_sparse_gradient, parallel_ctx,
-          group_size_limits, find_unused_vars));
+          group_size_limits, find_unused_vars, reject_rebuld_group));
     }
     return s_instance_;
   }

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -126,7 +126,7 @@ class Reducer {
       const std::vector<bool>& is_sparse_gradient,
       std::shared_ptr<imperative::ParallelContext> parallel_ctx,
       const std::vector<size_t>& group_size_limits, bool find_unused_vars,
-      bool reject_rebuld_group);
+      bool use_rebuild_group);
 
   virtual ~Reducer() {}
 
@@ -167,11 +167,11 @@ class Reducer {
       const std::vector<bool>& is_sparse_gradient,
       std::shared_ptr<imperative::ParallelContext> parallel_ctx,
       const std::vector<size_t>& group_size_limits, bool find_unused_vars,
-      bool reject_rebuld_group) {
+      bool use_rebuild_group) {
     if (NULL == s_instance_) {
       s_instance_.reset(new paddle::imperative::Reducer(
           vars, group_indices, is_sparse_gradient, parallel_ctx,
-          group_size_limits, find_unused_vars, reject_rebuld_group));
+          group_size_limits, find_unused_vars, use_rebuild_group));
     }
     return s_instance_;
   }

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -142,10 +142,6 @@ class Reducer {
 
   void AddDistHook(size_t var_index);
 
-  // void MarkDenseVarReady(size_t var_index);
-
-  // void MarkSparseVarReady(size_t var_index);
-
   void MarkVarReady(const size_t var_index, const bool is_used_var);
 
   void MarkGroupReady(size_t group_index);

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -125,7 +125,8 @@ class Reducer {
       const std::vector<std::vector<size_t>>& group_indices,
       const std::vector<bool>& is_sparse_gradient,
       std::shared_ptr<imperative::ParallelContext> parallel_ctx,
-      const std::vector<size_t>& group_size_limits, bool find_unused_vars);
+      const std::vector<size_t>& group_size_limits, bool find_unused_vars,
+      bool reject_rebuld_group);
 
   virtual ~Reducer() {}
 

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -29,6 +29,7 @@
 #include "paddle/fluid/imperative/op_base.h"
 #include "paddle/fluid/imperative/variable_wrapper.h"
 #include "paddle/fluid/memory/memory.h"
+#include "paddle/fluid/operators/math/math_function.h"
 #include "paddle/fluid/string/string_helper.h"
 
 #if defined(PADDLE_WITH_NCCL)

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1393,10 +1393,10 @@ void BindImperative(py::module *m_ptr) {
              const std::vector<bool> &is_sparse_gradient,
              std::shared_ptr<imperative::ParallelContext> parallel_ctx,
              const std::vector<size_t> &group_size_limits,
-             bool find_unused_vars, bool reject_rebuld_group) {
+             bool find_unused_vars, bool use_rebuild_group) {
             return imperative::Reducer::SetInstance(
                 vars, group_indices, is_sparse_gradient, parallel_ctx,
-                group_size_limits, find_unused_vars, reject_rebuld_group);
+                group_size_limits, find_unused_vars, use_rebuild_group);
           }))
       .def("prepare_for_backward", &imperative::Reducer::PrepareForBackward,
            py::arg("vars"), py::call_guard<py::gil_scoped_release>());

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1387,16 +1387,17 @@ void BindImperative(py::module *m_ptr) {
 
   py::class_<imperative::Reducer, std::shared_ptr<imperative::Reducer>>(
       m, "Reducer", R"DOC()DOC")
-      .def(py::init([](
-          const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
-          const std::vector<std::vector<size_t>> &group_indices,
-          const std::vector<bool> &is_sparse_gradient,
-          std::shared_ptr<imperative::ParallelContext> parallel_ctx,
-          const std::vector<size_t> &group_size_limits, bool find_unused_vars) {
-        return imperative::Reducer::SetInstance(
-            vars, group_indices, is_sparse_gradient, parallel_ctx,
-            group_size_limits, find_unused_vars);
-      }))
+      .def(py::init(
+          [](const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
+             const std::vector<std::vector<size_t>> &group_indices,
+             const std::vector<bool> &is_sparse_gradient,
+             std::shared_ptr<imperative::ParallelContext> parallel_ctx,
+             const std::vector<size_t> &group_size_limits,
+             bool find_unused_vars, bool reject_rebuld_group) {
+            return imperative::Reducer::SetInstance(
+                vars, group_indices, is_sparse_gradient, parallel_ctx,
+                group_size_limits, find_unused_vars, reject_rebuld_group);
+          }))
       .def("prepare_for_backward", &imperative::Reducer::PrepareForBackward,
            py::arg("vars"), py::call_guard<py::gil_scoped_release>());
 

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -471,9 +471,7 @@ class DataParallel(layers.Layer):
         find_unused_vars = True
 
         # TODO solve the problem of inconsistent arrival order of each card
-        use_rebuild_group = False
-        if "PADDLE_REBUILD_GROUP" in os.environ:
-            use_rebuild_group = True
+        use_rebuild_group = int(os.getenv("PADDLE_REBUILD_GROUP", "0")) == 1
 
         self._reducer = core.Reducer(
             trainable_parameters,

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -469,12 +469,16 @@ class DataParallel(layers.Layer):
         # TODO(shenliang03) "find_unused_vars" interface will be exposed in the future 
         # to handle control flow to process unused parameters
         find_unused_vars = True
+
+        # TODO(shenliang03) Solve the problem of inconsistent arrival order of each card
+        reject_rebuld_group = bool(os.getenv("PADDLE_REJECT_REBUILD_GROUP", 1))
+
         self._reducer = core.Reducer(
             trainable_parameters,
             list(reversed(self.group_indices)), is_sparse_gradient,
             parallel_helper.__parallel_ctx__clz__,
             [self.last_comm_buffer_size, self.comm_buffer_size],
-            find_unused_vars)
+            find_unused_vars, reject_rebuld_group)
 
     def _find_varbase(self, obj):
         if isinstance(obj, core.VarBase):

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -470,16 +470,17 @@ class DataParallel(layers.Layer):
         # to handle control flow to process unused parameters
         find_unused_vars = True
 
-        # TODO(shenliang03) Solve the problem of inconsistent arrival order of each card
-        reject_rebuld_group = int(os.getenv("PADDLE_REJECT_REBUILD_GROUP",
-                                            1)) != 0
+        # TODO solve the problem of inconsistent arrival order of each card
+        use_rebuild_group = False
+        if "PADDLE_REBUILD_GROUP" in os.environ:
+            use_rebuild_group = True
 
         self._reducer = core.Reducer(
             trainable_parameters,
             list(reversed(self.group_indices)), is_sparse_gradient,
             parallel_helper.__parallel_ctx__clz__,
             [self.last_comm_buffer_size, self.comm_buffer_size],
-            find_unused_vars, reject_rebuld_group)
+            find_unused_vars, use_rebuild_group)
 
     def _find_varbase(self, obj):
         if isinstance(obj, core.VarBase):

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -471,7 +471,8 @@ class DataParallel(layers.Layer):
         find_unused_vars = True
 
         # TODO(shenliang03) Solve the problem of inconsistent arrival order of each card
-        reject_rebuld_group = bool(os.getenv("PADDLE_REJECT_REBUILD_GROUP", 1))
+        reject_rebuld_group = int(os.getenv("PADDLE_REJECT_REBUILD_GROUP",
+                                            1)) != 0
 
         self._reducer = core.Reducer(
             trainable_parameters,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
The arrival order of the parameters of each card in the gradient of LSTM is inconsistent, resulting in allreduce hang.