### PR TITLE
if pybind.cc changed, generate total report

### DIFF
--- a/cmake/coveralls.cmake
+++ b/cmake/coveralls.cmake
@@ -63,7 +63,10 @@ endfunction()
 
 if(WITH_COVERAGE)
     if (WITH_INCREMENTAL_COVERAGE)
-        if (NOT ("$ENV{PADDLE_GIT_DIFF_H_FILE}" STREQUAL ""))
+        # if *.h changed, generate coverage report totaly.
+        # if pybind.cc changed, generate coverage report totaly.
+        # Because if pybind.cc add '-g -O0 -fprofile-arcs -ftest-coverage' only, some testcase will fail.
+        if ( (NOT ("$ENV{PADDLE_GIT_DIFF_H_FILE}" STREQUAL "")) OR ("$ENV{PADDLE_GIT_DIFF_CC_FILE}" MATCHES "pybind.cc") )
             set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
             set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -O0 -fprofile-arcs -ftest-coverage")
         endif()

--- a/cmake/generic.cmake
+++ b/cmake/generic.cmake
@@ -268,7 +268,8 @@ endfunction(merge_static_libs)
 
 function(check_coverage_opt TARGET_NAME SRCS)
   if(WITH_COVERAGE AND WITH_INCREMENTAL_COVERAGE)
-    if ("$ENV{PADDLE_GIT_DIFF_H_FILE}" STREQUAL "")
+    # if pybind.cc add '-g -O0 -fprofile-arcs -ftest-coverage' only, some testcase will fail.
+    if ("$ENV{PADDLE_GIT_DIFF_H_FILE}" STREQUAL "" AND (NOT ("$ENV{PADDLE_GIT_DIFF_CC_FILE}" MATCHES "pybind.cc")))
       if (NOT ("$ENV{PADDLE_GIT_DIFF_CC_FILE}" STREQUAL ""))
         string(REPLACE "," ";" CC_FILE_LIST $ENV{PADDLE_GIT_DIFF_CC_FILE})
         set(use_coverage_opt FALSE)

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -117,6 +117,7 @@ DECLARE_bool(use_mkldnn);
 
 // disable auto conversion to list in Python
 PYBIND11_MAKE_OPAQUE(paddle::framework::LoDTensorArray);
+
 PYBIND11_MAKE_OPAQUE(paddle::framework::FetchUnmergedList);
 PYBIND11_MAKE_OPAQUE(paddle::framework::FetchList);
 PYBIND11_MAKE_OPAQUE(paddle::framework::FetchType);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
Coverage流水线增量编译策略，导致只修改pybind.cc时，编译出的Paddle test_py_reader_sample_generator单测会挂掉。原因不详。
为规避该问题，当pybind.cc修改时，生成全量覆盖率报告。