### PR TITLE
avoid calling cast twice

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -228,6 +228,7 @@ def cast(x, dtype):
         if not isinstance(dtype, core.VarDesc.VarType):
             dtype = convert_np_dtype_to_dtype_(dtype)
         out = core.ops.cast(x, 'in_dtype', x.dtype, 'out_dtype', dtype)
+        return out
 
     check_variable_and_dtype(
         x, 'x',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> APIs

### Describe
<!-- Describe what this PR does --> avoid calling cast twice

动态图模式下：由于未return，每一次cast API的使用，会导致cast op被调用2次。