### PR TITLE
Fix bug: GetAttrValue should deal with attr with attrType vector<double>

### DIFF
--- a/paddle/fluid/framework/attribute.cc
+++ b/paddle/fluid/framework/attribute.cc
@@ -69,6 +69,15 @@ Attribute GetAttrValue(const proto::OpDesc::Attr& attr_desc) {
       }
       return val;
     }
+
+    case proto::AttrType::FLOAT64S: {
+      std::vector<double> val(attr_desc.float64s_size());
+      for (int i = 0; i < attr_desc.float64s_size(); ++i) {
+        val[i] = attr_desc.float64s(i);
+      }
+      return val;
+    }
+
     default:
       PADDLE_THROW(platform::errors::Unavailable("Unsupport attribute type %d.",
                                                  attr_desc.type()));

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_slice.py
@@ -95,6 +95,18 @@ def test_set_value(x):
     return x
 
 
+class LayerWithSetValue(paddle.nn.Layer):
+    def __init__(self, input_dim, hidden):
+        super(LayerWithSetValue, self).__init__()
+        self.linear = paddle.nn.Linear(input_dim, hidden)
+
+    @paddle.jit.to_static
+    def forward(self, x):
+        x = self.linear(x)
+        x[0] = 1
+        return x
+
+
 class TestSliceWithoutControlFlow(unittest.TestCase):
     def setUp(self):
         self.init_input()
@@ -150,6 +162,18 @@ class TestSetValue(TestSliceWithoutControlFlow):
 
     def init_dygraph_func(self):
         self.dygraph_func = test_set_value
+
+
+class TestSetValueWithLayerAndSave(unittest.TestCase):
+    def test_set_value_with_save(self):
+        prog_trans.enable(True)
+        model = LayerWithSetValue(input_dim=10, hidden=1)
+        x = paddle.full(shape=[5, 10], fill_value=5.0, dtype="float32")
+        paddle.jit.save(
+            layer=model,
+            path="./layer_use_set_value",
+            input_spec=[x],
+            output_spec=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
As the title

Before this PR, run code as follows:
```python
model = LayerWithSetValue(input_dim=10, hidden=1)
x = paddle.full(shape=[5, 10], fill_value=5.0, dtype="float32")
paddle.jit.save(
    layer=model,
    path="./layer_use_set_value",
    input_spec=[x],
    output_spec=None)
```

RuntimeError:
```
RuntimeError: (Unavailable) Unsupport attribute type 12. (at/home/teamcity/work/ef54dc8a5b211854/paddle/fluid/framework/attribute.cc:74)
```