### PR TITLE
disable test_analyzer_detect

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -272,11 +272,11 @@ inference_analysis_api_test(test_analyzer_ocr ${OCR_INSTALL_DIR} analyzer_vis_te
 # densebox
 set(DENSEBOX_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/densebox")
 download_data(${DENSEBOX_INSTALL_DIR} "densebox.tar.gz")
-inference_analysis_test(test_analyzer_detect SRCS analyzer_detect_tester.cc 
-  EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
-  ARGS --infer_model=${DENSEBOX_INSTALL_DIR}/model --infer_data=${DENSEBOX_INSTALL_DIR}/detect_input_50.txt 
-       --infer_shape=${DENSEBOX_INSTALL_DIR}/shape_50.txt)
-set_property(TEST test_analyzer_detect PROPERTY ENVIRONMENT GLOG_vmodule=analysis_predictor=2)
+#inference_analysis_test(test_analyzer_detect SRCS analyzer_detect_tester.cc 
+#  EXTRA_DEPS ${INFERENCE_EXTRA_DEPS}
+#  ARGS --infer_model=${DENSEBOX_INSTALL_DIR}/model --infer_data=${DENSEBOX_INSTALL_DIR}/detect_input_50.txt 
+#       --infer_shape=${DENSEBOX_INSTALL_DIR}/shape_50.txt)
+#set_property(TEST test_analyzer_detect PROPERTY ENVIRONMENT GLOG_vmodule=analysis_predictor=2)
 
 # mobilenet with transpose op
 set(MOBILENET_INSTALL_DIR "${INFERENCE_DEMO_INSTALL_DIR}/mobilenet")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
取消 test_analyzer_detect单测。由于  https://github.com/PaddlePaddle/Paddle/pull/30448 引入

分析过程：
1. 从邮件报警看，最早一次是出现在1月15日早上9点54分。https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2320668/job/3280647 这个日志里，test_analyzer_detect跑了4次（1次+retry3次），结果是最后一次过了，也就是成功率25%

2. 看了这个PR的所有CI日志：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/builds/6512?module=github%2FPaddlePaddle%2FPaddle&pipeline=PR-CI-Coverage&branch=pull%2F30448(develop) 同一个commit 1b9ead 重跑了4次才过，前面都失败了。

3. 在paddlepaddle/paddle:latest-dev镜像中，可以稳定复现 child abort情况。revert 该PR后，就不会出现错误了。

此外，在WITH_GPU=OFF情况下。会出现（稳定复现，截图里的 initial_cpu_memory_in_mb是allocator_strategy）
![图片](https://user-images.githubusercontent.com/6836917/104914027-7881c080-59c9-11eb-9ab7-faaf9489cd8b.png)
revert 该PR后，单测顺利通过