### PR TITLE
[cherry-pick]Add tf32 support for A100 tensor core acceleration for cuBLAS (#28732)

### DIFF
--- a/paddle/fluid/platform/cuda_helper.h
+++ b/paddle/fluid/platform/cuda_helper.h
@@ -84,8 +84,13 @@ class CublasHandleHolder {
     if (math_type == CUBLAS_TENSOR_OP_MATH) {
       PADDLE_RETRY_CUDA_SUCCESS(
           dynload::cublasSetMathMode(handle_, CUBLAS_TENSOR_OP_MATH));
+#if CUDA_VERSION >= 11000
+    } else if (math_type == CUBLAS_TF32_TENSOR_OP_MATH) {
+      PADDLE_ENFORCE_CUDA_SUCCESS(
+          dynload::cublasSetMathMode(handle_, CUBLAS_TF32_TENSOR_OP_MATH));
+#endif  // CUDA_VERSION >= 11000
     }
-#endif
+#endif  // CUDA_VERSION >= 9000
   }
 
   ~CublasHandleHolder() PADDLE_MAY_THROW {

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -71,6 +71,7 @@ bool AllowTF32Cublas();
 void SetAllowTF32Cudnn(bool active);
 /*Get the global variable allow_tf32_cudnn value*/
 bool AllowTF32Cudnn();
+#endif  // PADDLE_WITH_CUDA
 
 enum DeviceType {
   CPU = 0,
@@ -81,8 +82,6 @@ enum DeviceType {
 constexpr DeviceType kCPU = DeviceType::CPU;
 constexpr DeviceType kCUDA = DeviceType::CUDA;
 constexpr DeviceType kXPU = DeviceType::XPU;
-
-#endif  // PADDLE_WITH_CUDA
 
 class DeviceContext {
  public:

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -71,7 +71,6 @@ bool AllowTF32Cublas();
 void SetAllowTF32Cudnn(bool active);
 /*Get the global variable allow_tf32_cudnn value*/
 bool AllowTF32Cudnn();
-#endif  // PADDLE_WITH_CUDA
 
 enum DeviceType {
   CPU = 0,

--- a/paddle/fluid/pybind/pybind.cc
+++ b/paddle/fluid/pybind/pybind.cc
@@ -58,6 +58,7 @@ limitations under the License. */
 #include "paddle/fluid/operators/py_func_op.h"
 #include "paddle/fluid/platform/cpu_helper.h"
 #include "paddle/fluid/platform/cpu_info.h"
+#include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/dynload/dynamic_loader.h"
 #include "paddle/fluid/platform/enforce.h"
 #include "paddle/fluid/platform/init.h"

--- a/python/paddle/fluid/tests/unittests/test_tf32_cublas.py
+++ b/python/paddle/fluid/tests/unittests/test_tf32_cublas.py
@@ -1,0 +1,57 @@
+#   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import six
+import numpy as np
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+
+
+class TestTF32Switch(unittest.TestCase):
+    def test_on_off(self):
+        if core.is_compiled_with_cuda():
+            place = fluid.CUDAPlace(0)
+            self.assertTrue(core.get_cublas_switch())  # default
+            core.set_cublas_switch(False)
+            self.assertFalse(core.get_cublas_switch())  # turn off
+            core.set_cublas_switch(True)
+            self.assertTrue(core.get_cublas_switch())  # turn on
+
+            core.set_cublas_switch(True)  # restore the switch
+        else:
+            pass
+
+
+class TestTF32OnMatmul(unittest.TestCase):
+    def test_dygraph_without_out(self):
+        if core.is_compiled_with_cuda():
+            place = fluid.CUDAPlace(0)
+            core.set_cublas_switch(False)  # turn off
+            with fluid.dygraph.guard(place):
+                input_array1 = np.random.rand(4, 12, 64, 88).astype("float32")
+                input_array2 = np.random.rand(4, 12, 88, 512).astype("float32")
+                data1 = paddle.to_tensor(input_array1)
+                data2 = paddle.to_tensor(input_array2)
+                out = paddle.matmul(data1, data2)
+                expected_result = np.matmul(input_array1, input_array2)
+            self.assertTrue(np.allclose(expected_result, out.numpy(), 1e-03))
+            core.set_cublas_switch(True)  # restore the switch
+        else:
+            pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
This PR is cherry-picked from PR: https://github.com/PaddlePaddle/Paddle/pull/28732

## Function
Implement TF32 switch for cublas in A100. This switch is turned on by default, users can turn it off manually。

## Usage

```py
def test_dygraph_without_out(self):
    if core.is_compiled_with_cuda():
        place = fluid.CUDAPlace(0)
        core.set_cublas_switch(0)          # turn off
        with fluid.dygraph.guard(place):
            input_array1 = np.random.rand(4, 12, 64, 88).astype("float32")
            input_array2 = np.random.rand(4, 12, 88, 512).astype("float32")
            data1 = paddle.to_tensor(input_array1)
            data2 = paddle.to_tensor(input_array2)
            out = paddle.matmul(data1, data2)
            expected_result = np.matmul(input_array1, input_array2)
        self.assertTrue(np.allclose(expected_result, out.numpy(), 1e-03))

    else:
        pass
```

## Effect
Compute 10240x10240 matrix multiply for testing,  
The execution time is 0.113 s when the switch is off;
The execution time is 0.017 s when the switch is on, 

Acceleration: 6.6x

## The result of fixing some unit tests
Failed unit tests because of precision failure

![100415078-3d909a00-30b6-11eb-9a4b-9b1eaeb7ba60](https://user-images.githubusercontent.com/18277990/105164458-215a2800-5b50-11eb-85e3-6af545f67c8d.png)

Fixed unit test when turning both cudnn and cublas switches off. (TF32 switch for cudnn is in another PR ):

![100415079-3d909a00-30b6-11eb-835d-af5665ab3a49](https://user-images.githubusercontent.com/18277990/105164471-24551880-5b50-11eb-9494-e02ce65abed9.png)
