### PR TITLE
revert external gflags, test=develop

### DIFF
--- a/cmake/external/gflags.cmake
+++ b/cmake/external/gflags.cmake
@@ -30,8 +30,6 @@ ENDIF(WIN32)
 
 INCLUDE_DIRECTORIES(${GFLAGS_INCLUDE_DIR})
 
-set(GFLAGS_NAMESPACE "paddle_gflags")
-
 cache_third_party(extern_gflags
     REPOSITORY   ${GFLAGS_REPOSITORY}
     TAG          ${GFLAGS_TAG}
@@ -59,7 +57,6 @@ ExternalProject_Add(
                     -DCMAKE_POSITION_INDEPENDENT_CODE=ON
                     -DBUILD_TESTING=OFF
                     -DCMAKE_BUILD_TYPE=${THIRD_PARTY_BUILD_TYPE}
-                    -DGFLAGS_NAMESPACE=${GFLAGS_NAMESPACE} 
                     ${EXTERNAL_OPTIONAL_ARGS}
     CMAKE_CACHE_ARGS -DCMAKE_INSTALL_PREFIX:PATH=${GFLAGS_INSTALL_DIR}
                      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON

--- a/paddle/fluid/inference/check_symbol.sh
+++ b/paddle/fluid/inference/check_symbol.sh
@@ -18,7 +18,7 @@ lib=$1
 if [ $# -ne 1 ]; then echo "No input library"; exit -1 ; fi
 
 num_paddle_syms=$(nm -D "${lib}" | grep -c paddle )
-num_google_syms=$(nm -D "${lib}" | grep google | grep -v paddle | grep -v brpc | grep -v fL | grep -c "T " )
+num_google_syms=$(nm -D "${lib}" | grep google | grep -v paddle | grep -v brpc | grep -c "T " )
 
 if [ $num_paddle_syms -le 0 ]; then echo "Have no paddle symbols"; exit -1 ; fi
 if [ $num_google_syms -ge 1 ]; then echo "Have some google symbols"; exit -1 ; fi

--- a/paddle/fluid/inference/paddle_fluid.map
+++ b/paddle/fluid/inference/paddle_fluid.map
@@ -3,7 +3,6 @@
 		*paddle*;
 		*Pass*;
 		*profile*;
-		*fL*;
 	local:
 		*;
 };


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
为使不同 GFlags 共存，外部命令可被预测库读取，https://github.com/PaddlePaddle/Paddle/pull/30448 用名称空间作区分尝试解决。但此提交给用户带来的源码（原有硬编码）修改要求比预想要多，且引入了静态链接兼容问题，所以回退提交的一部分。