### PR TITLE
delete the lite meta info because of ccache, test=develop

### DIFF
--- a/cmake/external/lite.cmake
+++ b/cmake/external/lite.cmake
@@ -58,6 +58,7 @@ if (NOT LITE_SOURCE_DIR OR NOT LITE_BINARY_DIR)
                            -DLITE_BUILD_EXTRA=ON
                            -DLITE_WITH_XPU=${LITE_WITH_XPU}
                            -DXPU_SDK_ROOT=${XPU_SDK_ROOT}
+                           -DLITE_WITH_CODE_META_INFO=OFF
                            -DLITE_WITH_ARM=ON)
     ExternalProject_Add(
       ${LITE_PROJECT}
@@ -99,6 +100,7 @@ if (NOT LITE_SOURCE_DIR OR NOT LITE_BINARY_DIR)
                            -DCUDA_ARCH_NAME=${CUDA_ARCH_NAME}
                            -DLITE_WITH_XPU=${LITE_WITH_XPU}
                            -DXPU_SDK_ROOT=${XPU_SDK_ROOT}
+                           -DLITE_WITH_CODE_META_INFO=OFF
                            -DLITE_WITH_ARM=OFF)
 
     ExternalProject_Add(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
因为 Lite version.h 中包含了 git commit id，导致子图无法命中 Paddle CI 的 ccache，此提交用于解决这个问题。