### PR TITLE
insert fake_quantize_dequantize node before the OPs that will be used in VIS's faceid models

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -460,6 +460,10 @@ class PostTrainingQuantization(object):
         graph = _apply_pass(self._scope, graph, 'conv_bn_fuse_pass')
         graph = _apply_pass(self._scope, graph, 'depthwise_conv_bn_fuse_pass')
         graph = _apply_pass(self._scope, graph, 'conv_transpose_bn_fuse_pass')
+        graph = _apply_pass(self._scope, graph, 'conv_eltwiseadd_bn_fuse_pass')
+        graph = _apply_pass(self._scope, graph,
+                            'depthwise_conv_eltwiseadd_bn_fuse_pass')
+
         self._program = graph.to_program()
 
     def _collect_target_varnames(self):

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -74,6 +74,11 @@ _out_scale_op_list = [
     "bilinear_interp",
     "nearest_interp",
     "trilinear_interp",
+    "flatten",
+    "flatten2",
+    "transpose",
+    "pad2d",
+    "reshape",
 ]
 
 # list op real input and output names, to avoid processing input such as AxisTensor.
@@ -121,6 +126,9 @@ _op_real_in_out_name = {
     "hard_sigmoid": [["X"], ["Out"]],
     "gru": [["Input", "Weight"], ["Hidden"]],
     "lstm": [["Input", "Weight"], ["Hidden"]],
+    "pad2d": [["X"], ["Out"]],
+    "flatten": [["X"], ["Out"]],
+    "flatten2": [["X"], ["Out"]],
 }
 
 _conv_ops = ['conv2d', 'depthwise_conv2d', 'conv2d_transpose']
@@ -1691,7 +1699,8 @@ class AddQuantDequantPass(object):
         "less_than", "mean", "not_equal", "reshape", "reshape2",
         "bilinear_interp", "nearest_interp", "trilinear_interp", "slice",
         "squeeze", "elementwise_sub", "mul", "matmul", "relu", "relu6",
-        "leaky_relu", "tanh", "swish"
+        "leaky_relu", "tanh", "swish", "scale", "transpose", "transpose2",
+        "sigmoid", "pad2d", "flatten", "flatten2", "batch_norm"
     ]
 
     # To be compatible with PaddleSlim, not remove _activation_type for now


### PR DESCRIPTION
### PR types
New features

### PR changes
Others

### Describe
make OPs: "scale", "transpose", "transpose2", "sigmoid", "pad2d", "flatten", "flatten2" to support post-quantize, insert the 
fake_quantize_dequantize node before these OPs.
take "scale" for example
Before：
![image](https://user-images.githubusercontent.com/74164525/105481823-89d90e80-5ce2-11eb-829a-5fe2fc23a543.png)


After:
![image](https://user-images.githubusercontent.com/74164525/105481858-9493a380-5ce2-11eb-9f91-0dbd0a399b82.png)

### 