### PR TITLE
fix bug:修复一些trt plugin clone出的对象没有初始化的问题（trt 7.1+才会复现）

### DIFF
--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.cu
@@ -165,7 +165,10 @@ template class EmbEltwiseLayernormPluginDynamicImpl<half>;
 #endif
 
 int EmbEltwiseLayernormPluginDynamic::initialize() {
-  impl_->initialize();
+  if (!is_initialized_) {
+    impl_->initialize();
+    is_initialized_ = true;
+  }
 
   return 0;
 }

--- a/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/emb_eltwise_layernorm_plugin.h
@@ -189,6 +189,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
     auto ptr = new EmbEltwiseLayernormPluginDynamic(
         embs_, bias_, scale_, emb_sizes_, bias_size_, scale_size_, hidden_size_,
         eps_, with_fp16_);
+    ptr->initialize();
     return ptr;
   }
 
@@ -294,6 +295,7 @@ class EmbEltwiseLayernormPluginDynamic : public DynamicPluginTensorRT {
   float eps_;
 
   bool own_host_buff_{false};
+  bool is_initialized_{false};
   EmbEltwiseLayernormPluginDynamicImplBase* impl_{nullptr};
 };
 

--- a/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/instance_norm_op_plugin.h
@@ -80,7 +80,12 @@ class InstanceNormPlugin : public PluginTensorRT {
   int initialize() override;
 
   InstanceNormPlugin *clone() const override {
-    return new InstanceNormPlugin(eps_, scale_, bias_);
+    auto *ptr = new InstanceNormPlugin(eps_, scale_, bias_);
+    ptr->handle_ = handle_;
+    ptr->x_desc_ = x_desc_;
+    ptr->y_desc_ = y_desc_;
+    ptr->b_desc_ = b_desc_;
+    return ptr;
   }
 
   const char *getPluginType() const override { return "instance_norm_plugin"; }

--- a/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/prelu_op_plugin.h
@@ -70,7 +70,9 @@ class PReluPlugin : public PluginTensorRT {
   int initialize() override;
 
   PReluPlugin* clone() const override {
-    return new PReluPlugin(weight_.data(), weight_.size(), mode_);
+    auto* ptr = new PReluPlugin(weight_.data(), weight_.size(), mode_);
+    ptr->p_gpu_weight_ = p_gpu_weight_;
+    return ptr;
   }
 
   const char* getPluginType() const override { return "prelu_plugin"; }

--- a/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.cu
+++ b/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.cu
@@ -63,6 +63,9 @@ nvinfer1::Dims SplitPlugin::getOutputDimensions(
 }
 
 int SplitPlugin::initialize() {
+  if (is_initialized_) {
+    return 0;
+  }
   PADDLE_ENFORCE_LE(axis_, nvinfer1::Dims::MAX_DIMS,
                     platform::errors::InvalidArgument(
                         "Axis dimension exceeds max dimension in TensorRT. "
@@ -90,6 +93,7 @@ int SplitPlugin::initialize() {
   d_segment_offsets_ = segment_offsets;
   segment_offsets_ = std::move(segment_offsets);
   d_output_ptrs_.resize(this->getNbOutputs(), nullptr);
+  is_initialized_ = true;
   return 0;
 }
 

--- a/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.h
+++ b/paddle/fluid/inference/tensorrt/plugin/split_op_plugin.h
@@ -40,7 +40,9 @@ class SplitPlugin : public PluginTensorRT {
   }
 
   SplitPlugin* clone() const override {
-    return new SplitPlugin(axis_, output_length_, with_fp16_);
+    auto* ptr = new SplitPlugin(axis_, output_length_, with_fp16_);
+    ptr->initialize();
+    return ptr;
   }
 
   const char* getPluginType() const override { return "split_plugin"; }
@@ -75,6 +77,7 @@ class SplitPlugin : public PluginTensorRT {
   std::vector<int> segment_offsets_;
   thrust::device_vector<int> d_segment_offsets_;
   thrust::device_vector<float*> d_output_ptrs_;
+  bool is_initialized_{false};
 };
 
 #if IS_TRT_VERSION_GE(6000)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
fix bug:修复一些trt plugin clone出的对象没有初始化的问题（trt 7.1+才会复现）。在trt 7.0及以前的版本，clone出来的plugin运行enqueue之前会先调用initialize，但是7.1及以后的版本，clone出来的对象会直接调用enqueue，不会调用initialize。
Paddle中的某些trt plugin之前并未保证clone出来直接可用，本PR修复此问题，适配trt升级前后的行为变化。
<!-- Describe what this PR does -->
