### PR TITLE
[WIP][oneDNN] Fallback to CPU when adaptive pooling cannot be supported by oneDNN pool kernel

### DIFF
--- a/paddle/fluid/platform/mkldnn_reuse.h
+++ b/paddle/fluid/platform/mkldnn_reuse.h
@@ -902,15 +902,6 @@ class PoolingMKLDNNHandler : public MKLDNNHandlerT<T, mkldnn::pooling_forward,
       const std::vector<int64_t>& src_tz, std::vector<int64_t>& ksize,
       std::vector<int64_t>& strides) {
     if (ctx.Attr<bool>("adaptive")) {
-      // (jczaja): oneDNN is supporting only unchangable in size pool window
-      PADDLE_ENFORCE_EQ(
-          src_tz[src_tz.size() - 1] % ksize[1], 0,
-          platform::errors::Unimplemented(
-              "Input dim must be divisible by corressponding ksize dim."));
-      PADDLE_ENFORCE_EQ(
-          src_tz[src_tz.size() - 2] % ksize[0], 0,
-          platform::errors::Unimplemented(
-              "Input dim must be divisible by corressponding ksize dim."));
       ksize[0] = src_tz[src_tz.size() - 2] / ksize[0];
       ksize[1] = src_tz[src_tz.size() - 1] / ksize[1];
       strides[0] = ksize[0];


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
This PR is disabling pool oneDNN kernel in sitatuation when adpative pool is to be used when input_shape is not divisible by corresponding pool window dims. This PR is fixing crash repored at  #30115 
