### PR TITLE
optimize the gflag manager, test=develop

### DIFF
--- a/paddle/fluid/inference/api/api_impl.cc
+++ b/paddle/fluid/inference/api/api_impl.cc
@@ -345,7 +345,7 @@ std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
     std::vector<std::string> flags;
     if (config.fraction_of_gpu_memory >= 0.0f ||
         config.fraction_of_gpu_memory <= 0.95f) {
-      flags.push_back("dummpy");
+      flags.push_back("dummy");
       std::string flag = "--fraction_of_gpu_memory_to_use=" +
                          num2str<float>(config.fraction_of_gpu_memory);
       flags.push_back(flag);

--- a/paddle/fluid/platform/CMakeLists.txt
+++ b/paddle/fluid/platform/CMakeLists.txt
@@ -32,6 +32,9 @@ if (WITH_PYTHON)
 endif()
 
 cc_library(flags SRCS flags.cc DEPS gflags)
+cc_library(flag_manager SRCS flag_manager.cc DEPS gflags error_codes_proto)
+cc_test(flag_manager_test SRCS flag_manager_test.cc DEPS flag_manager)
+
 cc_library(denormal SRCS denormal.cc DEPS)
 
 cc_library(errors SRCS errors.cc DEPS error_codes_proto)
@@ -97,7 +100,7 @@ cc_library(cudnn_workspace_helper SRCS cudnn_workspace_helper.cc DEPS boost)
 
 # memcpy depends on device_context, here add deps individually for
 # avoiding cycle dependencies
-cc_library(device_context SRCS device_context.cc init.cc DEPS simple_threadpool malloc xxhash ${STREAM_CALLBACK_DEPS}
+cc_library(device_context SRCS device_context.cc init.cc DEPS flag_manager simple_threadpool malloc xxhash ${STREAM_CALLBACK_DEPS}
     place eigen3 stringpiece cpu_helper cpu_info framework_proto ${GPU_CTX_DEPS} ${MKLDNN_CTX_DEPS}
     ${dgc_deps} dlpack cudnn_workspace_helper ${XPU_CTX_DEPS})
 

--- a/paddle/fluid/platform/flag_manager.cc
+++ b/paddle/fluid/platform/flag_manager.cc
@@ -1,0 +1,213 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <mutex>  // NOLINT
+#include <regex>  // NOLINT
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/flag_manager.h"
+
+namespace paddle {
+namespace platform {
+namespace flags {
+
+struct CommandLineFlag {
+  std::string value;
+  std::string filename;
+};
+
+using CommandLineFlagMap = std::unordered_map<std::string, CommandLineFlag>;
+
+class GFlagWrapper {
+ public:
+  static std::unordered_set<std::string> GetFlagNames() {
+    std::unordered_set<std::string> flag_names;
+    std::vector<::GFLAGS_NAMESPACE::CommandLineFlagInfo> gflag_infos;
+    ::GFLAGS_NAMESPACE::GetAllFlags(&gflag_infos);
+    for (const auto& gflag_info : gflag_infos) {
+      flag_names.insert(gflag_info.name);
+    }
+    return flag_names;
+  }
+
+  static bool ParseCommandLineFlags(
+      const CommandLineFlagMap& flags,
+      std::function<uint32_t(int*, char***, bool)> f) {
+    FLAGS_logtostderr = true;
+
+    std::vector<std::string> cmd_vector{"dummy"};
+    const std::string dash{"--"};
+    const std::string assign{"="};
+    for (const auto& flag : flags) {
+      std::string f{dash + flag.first + assign + flag.second.value};
+      cmd_vector.emplace_back(std::move(f));
+    }
+
+    std::vector<char*> argv;
+    for (auto& cmd : cmd_vector) {
+      argv.emplace_back(&cmd[0]);
+    }
+    int argc = argv.size();
+    char** arr = argv.data();
+    f(&argc, &arr, false);
+    return true;
+  }
+};
+
+class CommandLineFlags {
+ public:
+  CommandLineFlags() : internal_gflag_names_{GFlagWrapper::GetFlagNames()} {}
+
+  template <typename T>
+  bool Insert(const std::string& flag, T value, const std::string& filename) {
+    return Insert(flag, std::to_string(value), filename);
+  }
+
+  bool Insert(const std::string& flag, const std::string& value,
+              const std::string& filename);
+  bool Insert(const std::vector<std::string>& flags);
+  bool ParseWithGFlag(uint32_t (*external_func)(int*, char***, bool)) const;
+
+ private:
+  mutable std::once_flag flag_;
+  mutable std::mutex mutex_;
+  std::unordered_set<std::string> internal_gflag_names_;
+  CommandLineFlagMap external_flags_;
+  CommandLineFlagMap internal_flags_;
+};
+
+template <>
+bool CommandLineFlags::Insert<std::string>(const std::string& flag,
+                                           std::string value,
+                                           const std::string& filename) {
+  return Insert(flag, std::move(value), filename);
+}
+
+bool CommandLineFlags::Insert(const std::string& flag, const std::string& value,
+                              const std::string& filename) {
+  std::unique_lock<std::mutex> w_lock{mutex_};
+  if (internal_gflag_names_.count(flag)) {
+    if (!internal_flags_.count(flag)) {
+      VLOG(5) << "[Get internal flag] " << flag << " = " << value;
+      internal_flags_.insert({flag, CommandLineFlag{value, filename}});
+    } else {
+      VLOG(3) << "[Warning] The internal flag '" << flag
+              << "' has been set to value '" << internal_flags_.at(flag).value
+              << " by file '" << filename << "'. It will be replaced by file '"
+              << filename << "' with '" << value << "'.\n";
+      internal_flags_.at(flag) = CommandLineFlag{value, filename};
+    }
+  } else {
+    if (!external_flags_.count(flag)) {
+      VLOG(5) << "[Get external flag] " << flag << " = " << value;
+      external_flags_.insert({flag, CommandLineFlag{value, filename}});
+    } else {
+      VLOG(3) << "[Warning] The external flag '" << flag
+              << "' has been set to value '" << external_flags_.at(flag).value
+              << " by file '" << filename << "'. It will be replaced by file '"
+              << filename << "' with '" << value << "'.\n";
+      external_flags_.at(flag) = CommandLineFlag{value, filename};
+    }
+  }
+  return true;
+}
+
+bool CommandLineFlags::Insert(const std::vector<std::string>& flags) {
+  bool ret = false;
+  size_t front_idx = 0;
+  if (flags.front() == "dummy") {
+    front_idx = 1;
+  }
+  static const std::regex pattern{R"(--(\w+)=(\d*.*\d*|\w+))"};
+  for (size_t i = front_idx; i < flags.size(); ++i) {
+    std::smatch matches;
+    std::regex_search(flags[i], matches, pattern);
+    PADDLE_ENFORCE_EQ(matches.size(), 3UL,
+                      platform::errors::InvalidArgument(
+                          "The pattern of flags '%s' is illegal. It should be "
+                          "like '--flag=value'.",
+                          flags[i]));
+    ret = Insert(std::string{matches[1]}, std::string{matches[2]}, "") && ret;
+  }
+  return ret;
+}
+
+bool CommandLineFlags::ParseWithGFlag(uint32_t (*external_func)(int*, char***,
+                                                                bool)) const {
+  bool ret = false;
+  std::call_once(flag_, [&ret, external_func, this]() {
+    ret = GFlagWrapper::ParseCommandLineFlags(
+              internal_flags_, ::GFLAGS_NAMESPACE::ParseCommandLineFlags) &&
+          ret;
+    if (external_func &&
+        external_func != ::GFLAGS_NAMESPACE::ParseCommandLineFlags) {
+      ret =
+          GFlagWrapper::ParseCommandLineFlags(external_flags_, external_func) &&
+          ret;
+    }
+  });
+  return ret;
+}
+}  // namespace flags
+
+FlagRegistrar::FlagRegistrar() { flags_.reset(new flags::CommandLineFlags); }
+
+FlagRegistrar& FlagRegistrar::Get() {
+  static FlagRegistrar instance;
+  return instance;
+}
+
+template <typename T>
+bool FlagRegistrar::Insert(const std::string& flag, T value,
+                           const std::string& filename) {
+  return flags_->Insert(flag, value, filename);
+}
+
+bool FlagRegistrar::Insert(const std::vector<std::string>& flags) {
+  return flags_->Insert(flags);
+}
+
+bool FlagRegistrar::SyncFlagsOnce(uint32_t (*external_func)(int*, char***,
+                                                            bool)) const {
+  return flags_->ParseWithGFlag(external_func);
+}
+
+template bool FlagRegistrar::Insert<int32_t>(const std::string& flag,
+                                             int32_t value,
+                                             const std::string& filename);
+template bool FlagRegistrar::Insert<int64_t>(const std::string& flag,
+                                             int64_t value,
+                                             const std::string& filename);
+template bool FlagRegistrar::Insert<uint32_t>(const std::string& flag,
+                                              uint32_t value,
+                                              const std::string& filename);
+template bool FlagRegistrar::Insert<uint64_t>(const std::string& flag,
+                                              uint64_t value,
+                                              const std::string& filename);
+template bool FlagRegistrar::Insert<double>(const std::string& flag,
+                                            double value,
+                                            const std::string& filename);
+template bool FlagRegistrar::Insert<bool>(const std::string& flag, bool value,
+                                          const std::string& filename);
+template bool FlagRegistrar::Insert<std::string>(const std::string& flag,
+                                                 std::string value,
+                                                 const std::string& filename);
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/flag_manager.h
+++ b/paddle/fluid/platform/flag_manager.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace paddle {
+namespace platform {
+namespace flags {
+class CommandLineFlags;
+}
+
+class FlagRegistrar {
+ public:
+  static FlagRegistrar& Get();
+
+  template <typename T>
+  bool Insert(const std::string& flag, T value,
+              const std::string& filename = "");
+  bool Insert(const std::vector<std::string>& flags);
+  bool SyncFlagsOnce(uint32_t (*external_func)(int*, char***,
+                                               bool) = nullptr) const;
+
+ private:
+  std::unique_ptr<flags::CommandLineFlags> flags_;
+  FlagRegistrar();
+  FlagRegistrar(const FlagRegistrar&) = delete;
+  FlagRegistrar operator=(const FlagRegistrar&) = delete;
+};
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/flag_manager_test.cc
+++ b/paddle/fluid/platform/flag_manager_test.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "paddle/fluid/platform/flag_manager.h"
+#include <cstring>
+#include <utility>
+#include "gflags/gflags.h"
+#include "glog/logging.h"
+#include "gtest/gtest.h"
+#include "paddle/fluid/platform/enforce.h"
+
+DEFINE_int32(file_manager_test_int32__, -1, "file manager test int32.");
+DEFINE_double(file_manager_test_double__, -1.0, "file manager test float.");
+DEFINE_double(file_manager_test_double_0__, -1.0, "file manager test float.");
+DEFINE_double(file_manager_test_double_1__, -1.0, "file manager test float.");
+DEFINE_bool(file_manager_test_bool__, false, "file manager test bool.");
+
+namespace paddle {
+namespace platform {
+
+TEST(FlagManager, FlagManagerTest) {
+  FlagRegistrar::Get().Insert("file_manager_test_int32__", 1, __FILE__);
+  FlagRegistrar::Get().Insert("file_manager_test_double__", .23, __FILE__);
+  FlagRegistrar::Get().Insert("file_manager_test_double_0__", 3.12, __FILE__);
+  // override the old value of `file_manager_test_double_0__`
+  FlagRegistrar::Get().Insert("file_manager_test_double_0__", 2., __FILE__);
+
+  // Backward compatible
+  std::vector<std::string> flags{"dummy", "--file_manager_test_bool__=true",
+                                 "--file_manager_test_double_1__=4.12",
+                                 "--file_manager_test_double_2__=123"};
+  FlagRegistrar::Get().Insert(std::move(flags));
+
+  auto fake_ParseCommandLineFlags = [](int* argc, char*** argv,
+                                       bool remove_flags) -> uint32_t {
+    CHECK_EQ(std::strcmp(*(*argv + 0), "dummy"), 0);
+    CHECK_EQ(std::strcmp(*(*argv + 1), "--file_manager_test_double_2__=123"),
+             0);
+    return 0;
+  };
+  FlagRegistrar::Get().SyncFlagsOnce(fake_ParseCommandLineFlags);
+
+  CHECK_EQ(FLAGS_file_manager_test_int32__, 1);
+  CHECK_NEAR(FLAGS_file_manager_test_double__, 0.23, 0.0001);
+  CHECK_NEAR(FLAGS_file_manager_test_double_0__, 2.0, 0.0001);
+  CHECK_NEAR(FLAGS_file_manager_test_double_1__, 4.12, 0.0001);
+}
+
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/init.cc
+++ b/paddle/fluid/platform/init.cc
@@ -72,10 +72,9 @@ namespace framework {
 std::once_flag gflags_init_flag;
 std::once_flag glog_init_flag;
 
-bool InitGflags(const std::vector<std::string> &args,
-                uint32_t (*external_func)(int *, char ***, bool)) {
+bool InitGflags(const std::vector<std::string> &args) {
   paddle::platform::FlagRegistrar::Get().Insert(args);
-  return paddle::platform::FlagRegistrar::Get().SyncFlagsOnce(external_func);
+  return paddle::platform::FlagRegistrar::Get().SyncFlagsOnce(nullptr);
 }
 
 void InitCupti() {

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -31,8 +31,7 @@ void ParseCommandLineFlags(int argc, char** argv, bool remove);
 namespace paddle {
 namespace framework {
 
-bool InitGflags(const std::vector<std::string>& args,
-                uint32_t (*external_func)(int*, char***, bool) = nullptr);
+bool InitGflags(const std::vector<std::string>& args);
 
 void InitGLOG(const std::string& prog_name);
 

--- a/paddle/fluid/platform/init.h
+++ b/paddle/fluid/platform/init.h
@@ -31,7 +31,8 @@ void ParseCommandLineFlags(int argc, char** argv, bool remove);
 namespace paddle {
 namespace framework {
 
-bool InitGflags(std::vector<std::string> argv);
+bool InitGflags(const std::vector<std::string>& args,
+                uint32_t (*external_func)(int*, char***, bool) = nullptr);
 
 void InitGLOG(const std::string& prog_name);
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
本提交给出了一个 FlagManager 对框架内部的变量进行管理，是解决不同预测器或者预测与训练交替调用 InitGFlags() 函数出现问题的第一步。Paddle 推理不通过直接传变量的方式进行配置，所有接口将有明确、单一的功能。