### PR TITLE
op benchmark ci retry with specfied id

### DIFF
--- a/paddle/fluid/operators/arg_min_max_op_base.cu.h
+++ b/paddle/fluid/operators/arg_min_max_op_base.cu.h
@@ -16,7 +16,6 @@ limitations under the License. */
 
 #ifdef __NVCC__
 
-
 #include <cub/cub.cuh>
 #include <limits>
 #include <string>

--- a/paddle/fluid/operators/arg_min_max_op_base.cu.h
+++ b/paddle/fluid/operators/arg_min_max_op_base.cu.h
@@ -16,6 +16,7 @@ limitations under the License. */
 
 #ifdef __NVCC__
 
+
 #include <cub/cub.cuh>
 #include <limits>
 #include <string>

--- a/tools/check_op_benchmark_result.py
+++ b/tools/check_op_benchmark_result.py
@@ -135,7 +135,7 @@ def update_api_info_file(fail_case_list, api_info_file):
     with open(api_info_file) as f:
         for line in f:
             line_list = line.split(',')
-            case = line_list[0]
+            case = line_list[0].split(':')[0]
             if case in fail_case_dict:
                 line_list[0] = "%s:%s" % (case, fail_case_dict[case])
                 api_info_list.append(','.join(line_list))

--- a/tools/check_op_benchmark_result.py
+++ b/tools/check_op_benchmark_result.py
@@ -190,7 +190,7 @@ if __name__ == "__main__":
         help="Specify the api info to run benchmark test.")
     args = parser.parse_args()
 
-    check_results = dict(accuracy=list(), speed=["argmax_0 (forward)"])
+    check_results = dict(accuracy=list(), speed=list())
 
     develop_result_dict = load_benchmark_result_from_logs_dir(
         args.develop_logs_dir)

--- a/tools/check_op_benchmark_result.py
+++ b/tools/check_op_benchmark_result.py
@@ -30,7 +30,7 @@ def parse_case_name(log_file_name):
     case_id, case_info = log_file_name.split("-")
     direction = case_info.split(".")[0].split("_")[-1]
 
-    return "%s(%s)" % (case_id, direction)
+    return "%s (%s)" % (case_id, direction)
 
 
 def parse_log_file(log_file):
@@ -127,15 +127,18 @@ def update_api_info_file(fail_case_list, api_info_file):
     check_path_exists(api_info_file)
 
     # set of case names for performance check failures
-    fail_case_set = set(map(lambda x: x.rsplit('_', 1)[0], fail_case_list))
+    parse_case_id_f = lambda x: x.split()[0].rsplit('_', 1)
+    fail_case_dict = dict(map(parse_case_id_f, fail_case_list))
 
     # list of api infos for performance check failures
     api_info_list = list()
     with open(api_info_file) as f:
         for line in f:
-            case = line.split(',')[0]
-            if case in fail_case_set:
-                api_info_list.append(line)
+            line_list = line.split(',')
+            case = line_list[0]
+            if case in fail_case_dict:
+                line_list[0] = "%s:%s" % (case, fail_case_dict[case])
+                api_info_list.append(','.join(line_list))
 
     # update api info file
     with open(api_info_file, 'w') as f:
@@ -187,7 +190,7 @@ if __name__ == "__main__":
         help="Specify the api info to run benchmark test.")
     args = parser.parse_args()
 
-    check_results = dict(accuracy=list(), speed=list())
+    check_results = dict(accuracy=list(), speed=["argmax_0 (forward)"])
 
     develop_result_dict = load_benchmark_result_from_logs_dir(
         args.develop_logs_dir)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
OP性能测试CI失败case自动retry时，指定具体的失败配置进行重试，防止重试全部配置引来其他波动问题。

测试日志：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2364492/job/3334069

修改`arg_min_max_op.cu.h`，强制使`argmax_0`出现性能差异，第一次运行`argmin`/`argmax`各8个配置共16个case的测试：

![image](https://user-images.githubusercontent.com/23427135/106235649-141af880-6236-11eb-99ec-55318af0f3f7.png)

触发失败case自动retry机制，只会执行失败的配置case进行重试：

![image](https://user-images.githubusercontent.com/23427135/106235801-69570a00-6236-11eb-8c8d-962b0f2fb40e.png)
![image](https://user-images.githubusercontent.com/23427135/106236126-26496680-6237-11eb-8f3f-5ab3cc943915.png)

第二次重试仍然只会重试失败的配置case：

![image](https://user-images.githubusercontent.com/23427135/106236218-5264e780-6237-11eb-99e4-91dea0c96897.png)
![image](https://user-images.githubusercontent.com/23427135/106236224-585ac880-6237-11eb-88bc-cbbeeb712e3b.png)
