### PR TITLE
Update Xbyak to v5.81

### DIFF
--- a/cmake/external/xbyak.cmake
+++ b/cmake/external/xbyak.cmake
@@ -20,7 +20,7 @@ SET(XBYAK_SOURCE_DIR     ${THIRD_PARTY_PATH}/xbyak/src/extern_xbyak)
 set(XBYAK_INSTALL_ROOT  ${THIRD_PARTY_PATH}/install/xbyak)
 set(XBYAK_INC_DIR       ${XBYAK_INSTALL_ROOT}/include)
 set(XBYAK_REPOSITORY    ${GIT_URL}/herumi/xbyak.git)
-set(XBYAK_TAG           v5.661) # Jul 26th
+set(XBYAK_TAG           v5.81) # Dec 19, 2019
 
 include_directories(${XBYAK_INC_DIR})
 include_directories(${XBYAK_INC_DIR}/xbyak)

--- a/paddle/fluid/operators/jit/gen/jitcode.h
+++ b/paddle/fluid/operators/jit/gen/jitcode.h
@@ -98,7 +98,7 @@ class JitCode : public GenBase, public Xbyak::CodeGenerator {
     ret();
   }
   void L(const char* label) { Xbyak::CodeGenerator::L(label); }
-  void L(const Xbyak::Label& label) { Xbyak::CodeGenerator::L(label); }
+  void L(Xbyak::Label& label) { Xbyak::CodeGenerator::L(label); }  // NOLINT
   // Enhanced vector extension
   Xbyak::Address EVEX_compress_addr(Xbyak::Reg64 base, int offt,
                                     bool bcast = false) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
This PR updates the Xbyak from 5.661 to 5.81. Only from this version, the instructions related to BF16  are correctly checked.
This PR is one part of the assignment to add BF16 instruction checks.
Moreover, because I've changed Xbyak library version from v5.661 to v5.81 it turned out that one of the functions has changed from `void L (const Label & label)` to `void L (Label & label)`, so we also have to remove const from jitcode.h so that there is no error. 
