### PR TITLE
fix the broadcast for the large second input

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -708,10 +708,10 @@ static __global__ void FastCommonGradBroadcastAllCUDAKernel(
       int x_offset = b_i * post + b_j;
       if (dy) {
         dy[y_offset] =
-            dy_op(x[x_offset], y[y_offset], out[x_offset], dout[x_offset]);
+            dy_op(x[x_offset], y[y_offset], out[y_offset], dout[y_offset]);
       }
       if (dx) {
-        val += dx_op(x[x_offset], y[y_offset], out[x_offset], dout[x_offset]);
+        val += dx_op(x[x_offset], y[y_offset], out[y_offset], dout[y_offset]);
       }
     }
     if (dx) {
@@ -1674,7 +1674,6 @@ void CommonElementwiseBroadcastBackward(
   GetBroadcastDimsArrays(x_dims, y_dims, x_dims_array.data(),
                          y_dims_array.data(), out_dims_array.data(), max_dim,
                          axis);
-
   // for inplace strategy. memset will make dx and dout clear and get wrong
   // result.
   if (dx && dx->IsSharedBufferWith(dout)) {
@@ -1762,7 +1761,6 @@ void ElemwiseGradComputeWithBroadcast(
     get_mid_dims(y_dims, x_dims_trimed, axis_trim, &pre, &n, &post,
                  &is_run_common_broadcast);
   }
-
   // special case for common backward implementation.
   if (is_run_common_broadcast) {
     CommonElementwiseBroadcastBackward<DeviceContext, T, DX_OP, DY_OP>(

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -388,7 +388,7 @@ class TestElementwiseAddOp_same_shape_ysize_large(TestElementwiseAddOp):
         self.out = self.x + self.y
 
     def init_axis(self):
-        self.axis = 2
+        self.axis = 0
 
 
 class TestElementwiseAddOpError(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -381,6 +381,16 @@ class TestElementwiseAddOp_xsize_lessthan_ysize_add(TestElementwiseAddOp):
         self.axis = 2
 
 
+class TestElementwiseAddOp_same_shape_ysize_large(TestElementwiseAddOp):
+    def init_input_output(self):
+        self.x = np.random.rand(10, 1, 12).astype(self.dtype)
+        self.y = np.random.rand(10, 3, 12).astype(self.dtype)
+        self.out = self.x + self.y
+
+    def init_axis(self):
+        self.axis = 2
+
+
 class TestElementwiseAddOpError(unittest.TestCase):
     def test_errors(self):
         with program_guard(Program(), Program()):


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
 OPs 

### Describe
在测试过程中发现，发现elementwise_add op的输入shape中，第一个输入的shape小于第二个的shape，则反向梯度无法对齐。下面是复现代码
```python
import numpy as np
import paddle
import torch

a1 = np.random.randn(3, 4, 2).astype(np.float32)
a2 = np.random.randn(3, 1, 2).astype(np.float32)

print(a1 + a2)

def fn1():
      a1_ = paddle.to_tensor(np.copy(a1), stop_gradient=False)
      a2_ = paddle.to_tensor(np.copy(a2), stop_gradient=False)

      out = paddle.nn.functional.relu(a2_ + a1_) # 改成较大的形状在前面就没有问题，但是较小的形状在前面就会有问题
      out.sum().backward()
	
      print(a1_.grad)
      print(a2_.grad)
      #print(a3_.grad)
	
def fn2():
      a1_ = torch.from_numpy(np.copy(a1)).requires_grad_()
      a2_ = torch.from_numpy(np.copy(a2)).requires_grad_()
      out = torch.relu(a2_ + a1_)
      out.sum().backward()

      print(a1_.grad)
      print(a2_.grad)
     #print(a3_.grad)
	
fn1()
fn2()
```