### PR TITLE
[Static setitem] Support index is ellipsis for setitem in static mode

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1866,6 +1866,35 @@ class Variable(object):
         starts = []
         ends = []
         max_integer = sys.maxsize
+
+        def replace_ellipsis(item):
+            # Use slice(None) to replace Ellipsis.
+            # For var, var.shape = [3,4,5,6]
+            #
+            #   var[..., 1:2] -> var[:, :, :, 1:2]
+            #   var[0, ...] -> var[0]
+            #   var[0, ..., 1:2] -> var[0, :, :, 1:2]
+
+            item = list(item)
+            ell_count = item.count(Ellipsis)
+            if ell_count == 0:
+                return item
+            elif ell_count > 1:
+                raise IndexError(
+                    "An index can only have a single ellipsis ('...')")
+
+            ell_idx = item.index(Ellipsis)
+
+            if ell_idx == len(item) - 1:
+                return item[:-1]
+            else:
+                item[ell_idx:ell_idx + 1] = [slice(None)] * (
+                    len(self.shape) - len(item) + 1)
+
+            return item
+
+        item = replace_ellipsis(item)
+
         for dim, slice_item in enumerate(item):
             if isinstance(slice_item, slice):
                 start = slice_item.start

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -52,7 +52,6 @@ class TestSetValueApi(TestSetValueBase):
 
         exe = paddle.static.Executor(paddle.CPUPlace())
         out = exe.run(self.program, fetch_list=[x])
-
         self._get_answer()
         self.assertTrue(
             (self.data == out).all(),
@@ -60,7 +59,7 @@ class TestSetValueApi(TestSetValueBase):
                 self.data, out))
 
 
-# 1. Test different type of item: int, python slice
+# 1. Test different type of item: int, python slice, Ellipsis
 class TestSetValueItemInt(TestSetValueApi):
     def _call_setitem(self, x):
         x[0] = self.value
@@ -99,6 +98,38 @@ class TestSetValueItemSlice4(TestSetValueApi):
 
     def _get_answer(self):
         self.data[0:, 1:2, :] = self.value
+
+
+class TestSetValueItemEllipsis1(TestSetValueApi):
+    def _call_setitem(self, x):
+        x[0:, ..., 1:] = self.value
+
+    def _get_answer(self):
+        self.data[0:, ..., 1:] = self.value
+
+
+class TestSetValueItemEllipsis2(TestSetValueApi):
+    def _call_setitem(self, x):
+        x[0:, ...] = self.value
+
+    def _get_answer(self):
+        self.data[0:, ...] = self.value
+
+
+class TestSetValueItemEllipsis3(TestSetValueApi):
+    def _call_setitem(self, x):
+        x[..., 1:] = self.value
+
+    def _get_answer(self):
+        self.data[..., 1:] = self.value
+
+
+class TestSetValueItemEllipsis4(TestSetValueApi):
+    def _call_setitem(self, x):
+        x[...] = self.value
+
+    def _get_answer(self):
+        self.data[...] = self.value
 
 
 # 2. Test different type of value: int, float, numpy.ndarray, Tensor
@@ -498,6 +529,12 @@ class TestError(TestSetValueBase):
         with self.assertRaisesRegexp(ValueError, "only support step is 1"):
             x = paddle.ones(shape=self.shape, dtype=self.dtype)
             x[0:1:2] = self.value
+
+    def _ellipsis_error(self):
+        with self.assertRaisesRegexp(
+                IndexError, "An index can only have a single ellipsis"):
+            x = paddle.ones(shape=self.shape, dtype=self.dtype)
+            x[..., ...] = self.value
 
     def _broadcast_mismatch(self):
         program = paddle.static.Program()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
功能支持：静态图支持 slice 赋值，inplace操作。

本 PR 支持场景：
key支持：Ellipsis
value支持：int, float, numpy.ndarray, Paddle Tensor
dtype: int32, int64, float32, float64, bool
其他：默认支持广播

```
tensor_x = paddle.to_tensor(np.ones((2, 3)).astype(np.float32)) # [[1,1,1], [1,1,1]]
tensor_x[...] = 0   # tensor_x : [[0, 0, 0], [0, 0, 0]]
tensor_x[...] = np.array([3,3,3]) # tensor_x : [[3, 3, 3], [3, 3, 3]]
tensor_x[...] = paddle.ones([3]) # tensor_x : [[1,1,1], [1,1,1]]
```

---

**当前 setitem 功能，索引类型支持情况如下**

索引类型 | 示例 | 动态图 | 静态图
-- | -- | -- | --
标量 | x[1]   = y | √ | √
切片 | x[1:2]   = y | √ | √
跨步长 | x[1:10:3]   = y | √ | ×
反向步长 | x[1:10:-2]   = y | √ | ×
省略[Ellipsis] | x[…,   0] = y | √ | **本 PR 支持**
Tensor | x[tensor_i]   = y | × | ×
布尔 | x[x   != 1] = y | × | ×

