### PR TITLE
remove numpy array check in single-process dataloader

### DIFF
--- a/python/paddle/fluid/dataloader/dataloader_iter.py
+++ b/python/paddle/fluid/dataloader/dataloader_iter.py
@@ -320,7 +320,6 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
                 array = core.LoDTensorArray()
                 for slot in batch:
                     if not isinstance(slot, core.LoDTensor):
-                        self._check_input_array(slot)
                         # FIXME(dkp): blocking_queue only support
                         #             core.LoDTensorArray as input now, read
                         #             numpy data into a LoDTensorArray here,
@@ -345,19 +344,6 @@ class _DataLoaderIterSingleProcess(_DataLoaderIterBase):
             self._thread = None
             logging.warning("DataLoader reader thread raised an exception.")
             six.reraise(*sys.exc_info())
-
-    @classmethod
-    def _check_input_array(cls, item):
-        if isinstance(item, paddle.Tensor):
-            return
-        arr = np.array(item)
-        if arr.dtype == np.object:
-            raise TypeError((
-                "\n\tFaild to convert input data to a regular ndarray :\n\t* Usually "
-                "this means the input data contains nested lists with different lengths. "
-                "\n\t* Check the reader function passed to 'decorate_batch_generator'"
-                " to locate the data causes this issue.\n\t* Please consider using "
-                "'fluid.create_lod_tensor' to convert it to a LoD-Tensor."))
 
     def __next__(self):
         try:


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
APIs

### Describe
user defined collate function may return data in list of Tensor format, do not check data in numpy array format in single-process dataloader
