### PR TITLE
[static setitem] support the index step < 0. eg: tensor_a[3:0:-1] = value

### DIFF
--- a/paddle/fluid/operators/set_value_op.cc
+++ b/paddle/fluid/operators/set_value_op.cc
@@ -86,6 +86,8 @@ class SetValueMaker : public framework::OpProtoAndCheckerMaker {
     AddAttr<std::vector<int64_t>>(
         "ends",
         "(list<int64_t>) Ending indices of corresponding axis in `axes`.");
+    AddAttr<std::vector<int64_t>>(
+        "steps", "(list<int64_t>) Stride step from the start to the end.");
 
     AddAttr<std::vector<int>>("bool_values", "store the bool values")
         .SetDefault({});

--- a/paddle/fluid/operators/set_value_op.h
+++ b/paddle/fluid/operators/set_value_op.h
@@ -60,14 +60,16 @@ inline std::string GetValueName(framework::proto::VarType::Type data_type) {
 
 inline void CheckAndUpdateSlice(const framework::DDim in_dims,
                                 const std::vector<int64_t> axes,
-                                int64_t* starts, int64_t* ends,
-                                int64_t* steps) {
+                                std::vector<int64_t>* starts,
+                                std::vector<int64_t>* ends,
+                                std::vector<int64_t>* steps) {
   for (size_t i = 0; i < axes.size(); ++i) {
     int64_t axis = axes[i];
     int64_t dim_value = in_dims[axis];
 
-    int64_t start = starts[i] < 0 ? (starts[i] + dim_value) : starts[i];
-    int64_t end = ends[i] < 0 ? (ends[i] + dim_value) : ends[i];
+    int64_t start =
+        (*starts)[i] < 0 ? ((*starts)[i] + dim_value) : (*starts)[i];
+    int64_t end = (*ends)[i] < 0 ? ((*ends)[i] + dim_value) : (*ends)[i];
     start = std::max(start, static_cast<int64_t>(0));
     end = std::min(end, dim_value);
 
@@ -76,9 +78,9 @@ inline void CheckAndUpdateSlice(const framework::DDim in_dims,
                                       "received end = %d, start = %d",
                                       end, start));
     // TODO(liym27): deal with steps is less than 1
-    starts[i] = start;
-    ends[i] = end;
-    steps[i] = steps[i];
+    (*starts)[i] = start;
+    (*ends)[i] = end;
+    (*steps)[i] = (*steps)[i];
   }
 }
 
@@ -151,8 +153,7 @@ class SetValueKernel : public framework::OpKernel<T> {
     auto* value_tensor = ctx.Input<framework::LoDTensor>("ValueTensor");
 
     auto in_dims = in->dims();
-    CheckAndUpdateSlice(in_dims, axes, starts.data(), ends.data(),
-                        steps.data());
+    CheckAndUpdateSlice(in_dims, axes, &starts, &ends, &steps);
     auto slice_dims = GetSliceDims(in_dims, axes, starts, ends, steps);
 
     auto place = ctx.GetPlace();

--- a/paddle/fluid/operators/set_value_op.h
+++ b/paddle/fluid/operators/set_value_op.h
@@ -58,12 +58,10 @@ inline std::string GetValueName(framework::proto::VarType::Type data_type) {
   return value_name;
 }
 
-inline framework::DDim GetSliceDims(const framework::DDim in_dims,
-                                    const std::vector<int64_t> axes,
-                                    const std::vector<int64_t> starts,
-                                    const std::vector<int64_t> ends) {
-  framework::DDim slice_dims(in_dims);
-
+inline void CheckAndUpdateSlice(const framework::DDim in_dims,
+                                const std::vector<int64_t> axes,
+                                int64_t* starts, int64_t* ends,
+                                int64_t* steps) {
   for (size_t i = 0; i < axes.size(); ++i) {
     int64_t axis = axes[i];
     int64_t dim_value = in_dims[axis];
@@ -74,10 +72,31 @@ inline framework::DDim GetSliceDims(const framework::DDim in_dims,
     end = std::min(end, dim_value);
 
     PADDLE_ENFORCE_GT(end, start, platform::errors::InvalidArgument(
-                                      "end should greater than start, but "
+                                      "end should be greater than start, but "
                                       "received end = %d, start = %d",
                                       end, start));
-    slice_dims[axis] = end - start;
+    // TODO(liym27): deal with steps is less than 1
+    starts[i] = start;
+    ends[i] = end;
+    steps[i] = steps[i];
+  }
+}
+
+inline framework::DDim GetSliceDims(const framework::DDim in_dims,
+                                    const std::vector<int64_t> axes,
+                                    const std::vector<int64_t> starts,
+                                    const std::vector<int64_t> ends,
+                                    const std::vector<int64_t> steps) {
+  framework::DDim slice_dims(in_dims);
+
+  for (size_t i = 0; i < axes.size(); ++i) {
+    int64_t axis = axes[i];
+
+    int64_t start = starts[i];
+    int64_t end = ends[i];
+    int64_t step = steps[i];
+
+    slice_dims[axis] = (end - start + step - 1) / step;
   }
   return slice_dims;
 }
@@ -127,12 +146,14 @@ class SetValueKernel : public framework::OpKernel<T> {
     auto axes = ctx.Attr<std::vector<int64_t>>("axes");
     auto starts = ctx.Attr<std::vector<int64_t>>("starts");
     auto ends = ctx.Attr<std::vector<int64_t>>("ends");
+    auto steps = ctx.Attr<std::vector<int64_t>>("steps");
     auto shape = ctx.Attr<std::vector<int64_t>>("shape");
     auto* value_tensor = ctx.Input<framework::LoDTensor>("ValueTensor");
 
     auto in_dims = in->dims();
-    auto value_dims = framework::make_ddim(shape);
-    auto slice_dims = GetSliceDims(in_dims, axes, starts, ends);
+    CheckAndUpdateSlice(in_dims, axes, starts.data(), ends.data(),
+                        steps.data());
+    auto slice_dims = GetSliceDims(in_dims, axes, starts, ends, steps);
 
     auto place = ctx.GetPlace();
     auto& eigen_place =
@@ -160,46 +181,37 @@ class SetValueKernel : public framework::OpKernel<T> {
     auto slice_e = framework::EigenTensor<T, D>::From(slice_t, slice_dims);
 
     // Step 1: Set the value of out at `_index` to zero
-    // - Step 1.1 Get a slice tensor from out
-    Eigen::array<int64_t, D> offsets, extents;
-    Eigen::array<std::pair<int64_t, int64_t>, D> paddings;
+    slice_e.device(eigen_place) = slice_e.constant(T(0));
+
+    auto starts_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+    auto ends_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
+    auto strides_indices = Eigen::DSizes<Eigen::DenseIndex, D>();
 
     for (size_t i = 0; i < D; ++i) {
-      offsets[i] = 0;
-      extents[i] = slice_dims[i];
+      starts_indices[i] = 0;
+      ends_indices[i] = slice_dims[i];
+      strides_indices[i] = 1;
     }
-    int64_t start;
-    for (size_t i = 0; i < axes.size(); ++i) {
-      start = starts[i] < 0 ? (starts[i] + in_dims[axes[i]]) : starts[i];
-      start = std::max(start, static_cast<int64_t>(0));
-      offsets[axes[i]] = start;
-    }
-    for (size_t i = 0; i < paddings.size(); ++i) {
-      paddings[i].first = offsets[i];
-      paddings[i].second = (in_dims[i] - slice_dims[i]) - offsets[i];
+    for (size_t i = 0; i < axes.size(); i++) {
+      int axis_index = axes[i];
+      starts_indices[axis_index] = starts[i];
+      ends_indices[axis_index] = ends[i];
+      strides_indices[axis_index] = steps[i];
     }
 
-    slice_e.device(eigen_place) = out_e.slice(offsets, extents);
-
-    // - Step 1.2 Get paded tensor by padding 0 to slice tensor
-    pad_e.device(eigen_place) = slice_e.pad(paddings, T(0));
-
-    // - Step 1.3 Set 0 at `_index` of out tensor
-    out_e.device(eigen_place) = out_e - pad_e;
+    out_e.stridedSlice(starts_indices, ends_indices, strides_indices)
+        .device(eigen_place) = slice_e;
 
     // Step 2: Set a tensor with the same shape as out tensor. And its data at
     // '_index' is the same as value_tensor, and data out of '_index' to zero
-
-    // - Step 2.1 Set the data of slice tensor to 0
-    slice_e.device(eigen_place) = slice_e.constant(T(0));
-
-    // - Step 2.2 Set slice tensor with value
+    // - Step 2.1 Set slice tensor with value
     if (value_tensor != nullptr) {
       // ElementwiseComputeEx can do broadcasting
       ElementwiseComputeEx<SubFunctor<T>, DeviceContext, T>(
           ctx, &slice_t, value_tensor, -1, SubFunctor<T>(), &slice_t);
     } else {
       Tensor value_t(dtype);
+      auto value_dims = framework::make_ddim(shape);
       value_t.mutable_data<T>(value_dims, place);
       auto value_name = GetValueName(dtype);
       CopyVecotorToTensor<T>(value_name.c_str(), &value_t, ctx);
@@ -208,8 +220,10 @@ class SetValueKernel : public framework::OpKernel<T> {
           ctx, &slice_t, &value_t, -1, SubFunctor<T>(), &slice_t);
     }
 
-    // - Step 2.3 Pad slice tensor with 0
-    pad_e.device(eigen_place) = slice_e.pad(paddings, T(0));
+    // - Step 2.2 Pad slice tensor with 0
+    pad_e.device(eigen_place) = pad_e.constant(T(0));
+    pad_e.stridedSlice(starts_indices, ends_indices, strides_indices)
+        .device(eigen_place) = slice_e;
 
     // Step 3: Set out tensor with value_tensor
     out_e.device(eigen_place) = out_e - pad_e;

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -587,8 +587,16 @@ void BindImperative(py::module *m_ptr) {
                                        ? PyTuple_Pack(1, _index.ptr())
                                        : _index.ptr();
              // 1. Check argumnets
-             // 1.1 Check whether _index can be parsed.
+             // 1.1 Check whether value obj is a tensor.
+             bool value_is_tensor = true;
              bool parse_index = true;
+             if (py::isinstance<py::array>(value_obj) ||
+                 py::isinstance<py::int_>(value_obj) ||
+                 py::isinstance<py::float_>(value_obj)) {
+               value_is_tensor = false;
+             }
+
+             // 1.2 Check whether _index can be parsed.
              const int size = PyTuple_GET_SIZE(index_ptr);
              for (int dim = 0; dim < size; ++dim) {
                PyObject *slice_item = PyTuple_GetItem(index_ptr, dim);
@@ -598,34 +606,20 @@ void BindImperative(py::module *m_ptr) {
                }
              }
 
-             // 1.2 Check whether stride is 1.
-             std::vector<int> axes, starts, ends, strides, decrease_axis,
-                 infer_flags;
-
-             bool stride_is_1 = true;
-             if (parse_index) {
-               ParseIndexingSlice(self_tensor, index_ptr, &axes, &starts, &ends,
-                                  &strides, &decrease_axis, &infer_flags);
-               stride_is_1 =
-                   std::all_of(strides.cbegin(), strides.cend(),
-                               [](int64_t stride) { return stride == 1; });
-             }
-
-             // 1.3 Check whether value obj is a tensor.
-             bool value_is_tensor = true;
-             if (py::isinstance<py::array>(value_obj) ||
-                 py::isinstance<py::int_>(value_obj) ||
-                 py::isinstance<py::float_>(value_obj)) {
-               value_is_tensor = false;
-             }
-
              // 2. Call op set_value to speed up if the condition is met,
              // otherwise call TensorToPyArray.
              // TODO(liym27): Try not to call TensorToPyArray because it always
              // copys data to cpu place, which reduces performance.
-             if (parse_index && stride_is_1 && value_is_tensor) {
-               framework::AttributeMap attrs = {
-                   {"axes", axes}, {"starts", starts}, {"ends", ends}};
+             if (parse_index && value_is_tensor) {
+               std::vector<int> axes, starts, ends, steps, decrease_axis,
+                   infer_flags;
+               ParseIndexingSlice(self_tensor, index_ptr, &axes, &starts, &ends,
+                                  &steps, &decrease_axis, &infer_flags);
+
+               framework::AttributeMap attrs = {{"axes", axes},
+                                                {"starts", starts},
+                                                {"ends", ends},
+                                                {"steps", steps}};
 
                imperative::NameVarBaseMap ins = {{"Input", {self}}};
                imperative::NameVarBaseMap outs = {{"Out", {self}}};

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1906,15 +1906,18 @@ class Variable(object):
                 if start is None and end is None and step is None:
                     continue
 
-                start = 0 if start is None else start
                 step = 1 if step is None else step
 
                 # TODO: support cases when step < 1
-                if step < 1:
+                if step == 0:
                     raise ValueError(
-                        "When assign a value to a paddle.Tensor, only support step >= 1, "
+                        "When assign a value to a paddle.Tensor, step can not be 0, "
                         "but received step is {}.".format(step))
-                end = max_integer if end is None else end
+                if start is None:
+                    start = 0 if step > 0 else max_integer
+
+                if end is None:
+                    end = max_integer if step > 0 else (0 - max_integer)
             else:
                 start = slice_item
                 end = slice_item + 1 if slice_item != -1 else max_integer

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -1865,6 +1865,8 @@ class Variable(object):
         axes = []
         starts = []
         ends = []
+        steps = []
+
         max_integer = sys.maxsize
 
         def replace_ellipsis(item):
@@ -1907,20 +1909,22 @@ class Variable(object):
                 start = 0 if start is None else start
                 step = 1 if step is None else step
 
-                # TODO: support cases when step != 1
-                if step != 1:
+                # TODO: support cases when step < 1
+                if step < 1:
                     raise ValueError(
-                        "When assign a value to a paddle.Tensor, only support step is 1, "
+                        "When assign a value to a paddle.Tensor, only support step >= 1, "
                         "but received step is {}.".format(step))
                 end = max_integer if end is None else end
             else:
                 start = slice_item
                 end = slice_item + 1 if slice_item != -1 else max_integer
+                step = 1
             axes.append(dim)
             starts.append(start)
             ends.append(end)
+            steps.append(step)
 
-        attrs = {'axes': axes, 'starts': starts, 'ends': ends}
+        attrs = {'axes': axes, 'starts': starts, 'ends': ends, 'steps': steps}
 
         # 2. Parse value
         dtype = self.dtype

--- a/python/paddle/fluid/tests/unittests/test_set_value_op.py
+++ b/python/paddle/fluid/tests/unittests/test_set_value_op.py
@@ -65,6 +65,7 @@ class TestSetValueApi(TestSetValueBase):
 # 1. Test different type of item: int, python slice, Ellipsis
 # 1.1 item is int
 
+
 class TestSetValueItemInt(TestSetValueApi):
     def _call_setitem(self, x):
         x[0] = self.value
@@ -107,7 +108,7 @@ class TestSetValueItemSlice4(TestSetValueApi):
         self.data[0:, 1:2, :] = self.value
 
 
-# # 1.2.2 step > 1
+# 1.2.2 step > 1
 class TestSetValueItemSliceStep(TestSetValueApi):
     def set_shape(self):
         self.shape = [5, 5, 5]
@@ -146,8 +147,62 @@ class TestSetValueItemSliceStep4(TestSetValueApi):
         self.data[0:, 1:2:2, :] = self.value
 
 
+# 1.2.3 step < 0
+class TestSetValueItemSliceNegetiveStep(TestSetValueApi):
+    def set_shape(self):
+        self.shape = [5, 2]
+
+    def set_value(self):
+        self.value = np.array([3, 4])
+
+    def _call_setitem(self, x):
+        x[5:2:-1] = self.value
+
+    def _get_answer(self):
+        self.data[5:2:-1] = self.value
+
+
+class TestSetValueItemSliceNegetiveStep2(TestSetValueApi):
+    def set_shape(self):
+        self.shape = [5]
+
+    def set_value(self):
+        self.value = np.array([3, 4])
+
+    def _call_setitem(self, x):
+        x[1::-1] = self.value
+
+    def _get_answer(self):
+        self.data[1::-1] = self.value
+
+
+class TestSetValueItemSliceNegetiveStep3(TestSetValueApi):
+    def set_shape(self):
+        self.shape = [3]
+
+    def set_value(self):
+        self.value = np.array([3, 4, 5])
+
+    def _call_setitem(self, x):
+        x[::-1] = self.value
+
+    def _get_answer(self):
+        self.data[::-1] = self.value
+
+
+class TestSetValueItemSliceNegetiveStep4(TestSetValueApi):
+    def set_shape(self):
+        self.shape = [3, 4, 5]
+
+    def _call_setitem(self, x):
+        x[2:0:-1, 0:2, ::-1] = self.value
+
+    def _get_answer(self):
+        self.data[2:0:-1, 0:2, ::-1] = self.value
+
 
 # 1.3 item is Ellipsis
+
 
 class TestSetValueItemEllipsis1(TestSetValueApi):
     def _call_setitem(self, x):
@@ -183,6 +238,7 @@ class TestSetValueItemEllipsis4(TestSetValueApi):
 
 # 2. Test different type of value: int, float, numpy.ndarray, Tensor
 # 2.1 value is int32, int64, float32, float64, bool
+
 
 def create_test_value_int32(parent):
     class TestValueInt(parent):
@@ -574,9 +630,9 @@ class TestError(TestSetValueBase):
             y[0] = 1
 
     def _step_error(self):
-        with self.assertRaisesRegexp(ValueError, "only support step"):
+        with self.assertRaisesRegexp(ValueError, "step can not be 0"):
             x = paddle.ones(shape=self.shape, dtype=self.dtype)
-            x[0:1:-1] = self.value
+            x[0:1:0] = self.value
 
     def _ellipsis_error(self):
         with self.assertRaisesRegexp(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
功能支持：静态图支持 slice 赋值，inplace操作。

本 PR 支持场景：
key支持：反向步长，即 step 小于 0
value支持：int, float, numpy.ndarray, Paddle Tensor
dtype: int32, int64, float32, float64, bool
其他：默认支持广播

```
tensor_x = paddle.to_tensor(np.zeros((5)).astype(np.float32)) # [0,0,0,0,0]
tensor_x[2::-1] = np.array([1,2,3]) # tensor_x : [3,2,1,0,0]
tensor_x[3:0:-2] = paddle.ones([1]) # tensor_x : [0,1,0,1,0]
```

---

**当前 setitem 功能，索引类型支持情况如下**

索引类型 | 示例 | 动态图 | 静态图
-- | -- | -- | --
标量 | x[1]   = y | √ | √
切片 | x[1:2]   = y | √ | √
跨步长 | x[1:10:3]   = y | √ | https://github.com/PaddlePaddle/Paddle/pull/30888
反向步长 | x[1:10:-2]   = y | √ | **本 PR 支持**
省略[Ellipsis] | x[…,   0] = y | √ | https://github.com/PaddlePaddle/Paddle/pull/30836
Tensor | x[tensor_i]   = y | × | ×
布尔 | x[x   != 1] = y | × | ×

