### PR TITLE
fix a bug of Sequential::__getitem__

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -67,7 +67,15 @@ class Sequential(Layer):
                 self.add_sublayer(str(idx), layer)
 
     def __getitem__(self, name):
-        return self._sub_layers[str(name)]
+        if isinstance(name, slice):
+            return self.__class__(*(list(self._sub_layers.values())[name]))
+        else:
+            if name >= len(self._sub_layers):
+                raise IndexError('index {} is out of range'.format(name))
+            elif name < 0:
+                while name < 0:
+                    name += len(self._sub_layers)
+            return self._sub_layers[str(name)]
 
     def __setitem__(self, name, layer):
         assert isinstance(layer, Layer)

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -74,7 +74,7 @@ class Sequential(Layer):
                 raise IndexError('index {} is out of range'.format(name))
             elif name < 0 and name >= -len(self._sub_layers):
                 name += len(self._sub_layers)
-            else:
+            elif name < -len(self._sub_layers):
                 raise IndexError('index {} is out of range'.format(name))
             return self._sub_layers[str(name)]
 

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -72,9 +72,10 @@ class Sequential(Layer):
         else:
             if name >= len(self._sub_layers):
                 raise IndexError('index {} is out of range'.format(name))
-            elif name < 0:
-                while name < 0:
-                    name += len(self._sub_layers)
+            elif name < 0 and name >= -len(self._sub_layers):
+                name += len(self._sub_layers)
+            else:
+                raise IndexError('index {} is out of range'.format(name))
             return self._sub_layers[str(name)]
 
     def __setitem__(self, name, layer):

--- a/python/paddle/fluid/tests/test_sequential.py
+++ b/python/paddle/fluid/tests/test_sequential.py
@@ -1,0 +1,35 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import paddle
+
+class TestDataFeeder(unittest.TestCase):
+    def test_lod_level_1_converter(self):
+        sequential = paddle.nn.Sequential()
+
+        for i in range(10):
+            sequential.add_sublayer(str(i), paddle.nn.Linear(i+1, i+1))
+
+        for item in sequential:
+            tmp = item
+
+        tmp = sequential[3:5]
+        self.assertEqual(len(tmp), 2)
+
+        tmp = sequential[-101]
+        self.assertEqual(tmp, sequential[9])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/test_sequential.py
+++ b/python/paddle/fluid/tests/test_sequential.py
@@ -15,12 +15,13 @@
 import unittest
 import paddle
 
+
 class TestDataFeeder(unittest.TestCase):
     def test_lod_level_1_converter(self):
         sequential = paddle.nn.Sequential()
 
         for i in range(10):
-            sequential.add_sublayer(str(i), paddle.nn.Linear(i+1, i+1))
+            sequential.add_sublayer(str(i), paddle.nn.Linear(i + 1, i + 1))
 
         for item in sequential:
             tmp = item
@@ -30,6 +31,7 @@ class TestDataFeeder(unittest.TestCase):
 
         tmp = sequential[-101]
         self.assertEqual(tmp, sequential[9])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/test_sequential.py
+++ b/python/paddle/fluid/tests/test_sequential.py
@@ -29,6 +29,9 @@ class TestDataFeeder(unittest.TestCase):
         tmp = sequential[3:5]
         self.assertEqual(len(tmp), 2)
 
+        tmp = sequential[-1]
+        self.assertEqual(tmp, sequential[9])
+
         with self.assertRaises(IndexError):
             tmp = sequential[10]
 

--- a/python/paddle/fluid/tests/test_sequential.py
+++ b/python/paddle/fluid/tests/test_sequential.py
@@ -29,8 +29,11 @@ class TestDataFeeder(unittest.TestCase):
         tmp = sequential[3:5]
         self.assertEqual(len(tmp), 2)
 
-        tmp = sequential[-101]
-        self.assertEqual(tmp, sequential[9])
+        with self.assertRaises(IndexError):
+            tmp = sequential[10]
+
+        with self.assertRaises(IndexError):
+            tmp = sequential[-11]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
用户反馈在如下demo下会崩溃：
```
model1 = paddle.nn.Sequential(
    paddle.nn.Linear(10, 1), paddle.nn.Linear(1, 2)
)
for l in model1:
    print(l)

```
报错如下：
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/mnt/sunyanfang01/anaconda3/envs/pytorch_old/lib/python3.7/site-packages/paddle/fluid/dygraph/container.py", line 70, in __getitem__
    return self._sub_layers[str(name)]
KeyError: '2'

本PR修复该bug