### PR TITLE
Make  paddle.save support saving dict in dict checkpoint

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -141,6 +141,15 @@ class TestSaveLoad(unittest.TestCase):
         paddle.save(layer_state_dict, layer_save_path)
         paddle.save(opt_state_dict, opt_save_path)
 
+        # test save dict in dict
+        checkpoint_save_path = "test_paddle_save_load.linear_checkpoint.pdparams"
+        checkpoint = {
+            'state_dict': layer_state_dict,
+            'opt_state_dict': opt_state_dict,
+            'epoch': 100,
+        }
+        paddle.save(checkpoint, checkpoint_save_path)
+
         # load
         load_layer_state_dict = paddle.load(layer_save_path)
         load_opt_state_dict = paddle.load(opt_save_path)

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -45,6 +45,9 @@ def _build_saved_state_dict(state_dict):
         if isinstance(value, (Variable, core.VarBase)):
             save_dict[key] = value.numpy()
             name_table[key] = value.name
+        # FIXME: make Tensor serializable
+        elif isinstance(value, dict):
+            save_dict[key] = _build_saved_state_dict(value)
         else:
             save_dict[key] = value
     save_dict["StructuredToParameterName@@"] = name_table


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
保存如下形式的checkpoint会报错，暂时优化一下：
```
checkpoint = {
            'state_dict': layer_state_dict,
            'opt_state_dict': opt_state_dict,
            'epoch': 100,
        }
```
本质上需要通过支持tensor的可序列化解决。