### PR TITLE
Enhance 'Sequential' class, int(plus minus), str and slice

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -54,6 +54,22 @@ class Sequential(Layer):
             model2['l1']  # access l1 layer
             model2.add_sublayer('l3', paddle.nn.Linear(3, 3))  # add sublayer
             res2 = model2(data)  # sequential execution
+            
+            # create Sequential with name Layer pairs
+            model3 = paddle.nn.Sequential(
+                ('l1', paddle.nn.Linear(10, 2)),
+                ('l2', paddle.nn.Linear(2, 3)),
+                ('l3', paddle.nn.Linear(3, 2))
+            )
+            model3[-1] # access l3 layer
+            model3['l1'] # access l1 layer
+            model3[-1] = paddle.nn.Linear(3, 4) # replace l3
+            model3[1:] # select sub seqs
+            
+            del model3[0] # del l1
+            del model3['l1'] # del l1
+            del model3[-1] # del l3
+            del model3[-2:] # del l2 l3
 
     """
 

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -67,8 +67,26 @@ class Sequential(Layer):
             model3[1:] # select sub seqs
             
             del model3[0] # del l1
+            
+            model3 = paddle.nn.Sequential(
+                ('l1', paddle.nn.Linear(10, 2)),
+                ('l2', paddle.nn.Linear(2, 3)),
+                ('l3', paddle.nn.Linear(3, 2))
+            )
             del model3['l1'] # del l1
+            
+            model3 = paddle.nn.Sequential(
+                ('l1', paddle.nn.Linear(10, 2)),
+                ('l2', paddle.nn.Linear(2, 3)),
+                ('l3', paddle.nn.Linear(3, 2))
+            )
             del model3[-1] # del l3
+            
+            model3 = paddle.nn.Sequential(
+                ('l1', paddle.nn.Linear(10, 2)),
+                ('l2', paddle.nn.Linear(2, 3)),
+                ('l3', paddle.nn.Linear(3, 2))
+            )
             del model3[-2:] # del l2 l3
 
     """

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_sequential.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_sequential.py
@@ -51,10 +51,26 @@ class TestImperativeContainerSequential(unittest.TestCase):
             self.assertEqual(len(model2), 3)
             res2 = model2(data)
             self.assertListEqual(res2.shape, [5, 4])
-
             loss2 = fluid.layers.reduce_mean(res2)
             loss2.backward()
 
+            l1 = fluid.Linear(10, 1)
+            l2 = fluid.Linear(1, 3)
+            l3 = fluid.Linear(3, 1)
+            model3 = fluid.dygraph.Sequential(('l1', l1), ('l2', l2), ('l3', l3))
+            model3[-1] # access l3 layer
+            model3['l1'] # access l1 layer
+            model3[-1] = paddle.nn.Linear(3, 4) # replace l3
+            model4 = model3[1:] # select sub seqs
+            self.assertEqual(len(model4), 2)
+            model3 = fluid.dygraph.Sequential(('l1', l1), ('l2', l2), ('l3', l3))
+            del model3[0] # del l1
+            model3 = fluid.dygraph.Sequential(('l1', l1), ('l2', l2), ('l3', l3))
+            del model3['l1'] # del l1
+            model3 = fluid.dygraph.Sequential(('l1', l1), ('l2', l2), ('l3', l3))
+            del model3[-1] # del l3
+            model3 = fluid.dygraph.Sequential(('l1', l1), ('l2', l2), ('l3', l3))
+            del model3[-2:] # del l2 l3
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->

- get: Support Operations: mm[1], mm[-1], mm[1:], mm['L1'], Where mm is sequential instance.
- set: Support Operations: mm[1] = `Layer Instance`, mm['L1'] = `Layer Instance`. Where mm is sequential instance
- del: Support Operations: del mm[1], del mm[-1], del mm[1:], del mm['L1']. Wehre mm is sequential instance.
- example:

```python
mm = Sequential(paddle.nn.Linear(3, 3), 
                  paddle.nn.ReLU(), 
                  paddle.nn.Sequential(paddle.nn.Linear(3, 3), paddle.nn.ReLU()), 
                  paddle.nn.Conv2D(2, 2, 2, 2, 2),
                  paddle.nn.Linear(3, 3))

print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "Linear(input_dim=3, output_dim=3)"
    }
    

### get
```python
print(repr_string(mm[-1]))
```

    "Linear(input_dim=3, output_dim=3)"
    


```python
mm[-1] = paddle.nn.ReLU()
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "ReLU()"
    }
    


```python
print(repr_string(mm[:-2]))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       }
    }
    

### set
```python
print(repr_string(mm))
mm['3'] = paddle.nn.Linear(100, 300)
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Conv2D(2, 2, kernel_size=(2, 2), stride=(2, 2), padding=(2, 2), dilation=(1, 1), )",
       "4": "ReLU()"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Linear(input_dim=100, output_dim=300)",
       "4": "ReLU()"
    }
    

### del
```python
del mm[-1]
print(repr_string(mm))

del mm['2']
print(repr_string(mm))

del mm[1:]
print(repr_string(mm))
```

    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "2 (Sequential)": {
          "0": "Linear(input_dim=3, output_dim=3)",
          "1": "ReLU()"
       },
       "3": "Linear(input_dim=100, output_dim=300)"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)",
       "1": "ReLU()",
       "3": "Linear(input_dim=100, output_dim=300)"
    }
    {
       "0": "Linear(input_dim=3, output_dim=3)"
    }
    


```python

```


