### PR TITLE
[kunlun]fix sync in multi kunlun xpu dygraph training.

### DIFF
--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -635,11 +635,8 @@ void Reducer::MarkGroupReady(size_t group_index) {
 #ifdef PADDLE_WITH_XPU_BKCL
         if (platform::is_xpu_place(group.dense_tensors_[0].place())) {
           parallel_ctx_->WaitComm(run_order);
-#else
-        PADDLE_THROW(platform::errors::PreconditionNotMet(
-            "Please recompile or reinstall Paddle with BKCL support."));
-#endif
         }
+#endif
 
         // Start allreduce
         parallel_ctx_->AllReduceByStream(

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -626,6 +626,15 @@ void Reducer::MarkGroupReady(size_t group_index) {
         // group.dense_tensors ---> group.dense_contents_
         group.ConcatTensors(*parallel_ctx_->GetDeviceContext(run_order));
 
+        if (platform::is_xpu_place(group.dense_tensors_[0].place())) {
+#ifdef PADDLE_WITH_XPU_BKCL
+          parallel_ctx_->WaitComm(run_order);
+#else
+          PADDLE_THROW(platform::errors::PreconditionNotMet(
+              "Please recompile or reinstall Paddle with BKCL support."));
+#endif
+        }
+
         // Start allreduce
         parallel_ctx_->AllReduceByStream(
             group.dense_contents_, &(group.dense_contents_), run_order, false);

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_mnist.py
@@ -55,7 +55,7 @@ class TestParallelDygraphMnistXPU(TestDistBase):
         if fluid.core.is_compiled_with_xpu():
             self.check_with_place(
                 "parallel_dygraph_mnist.py",
-                delta=1e-1,
+                delta=1e-4,
                 check_error_log=True,
                 log_name=flag_name)
 
@@ -94,7 +94,7 @@ class TestFleetDygraphMnistXPU(TestDistBase):
         if fluid.core.is_compiled_with_xpu():
             self.check_with_place(
                 "parallel_dygraph_mnist.py",
-                delta=1e-1,
+                delta=1e-4,
                 check_error_log=True,
                 log_name=flag_name)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Add WaitComm() before AllReduceByStream, fix sync in multi kunlun xpu dygraph training.

The loss precision training between one card and two cards.
- TestParallelDygraphMnistXPU in test_parallel_dygraph_mnist.py:
‘’‘
======= [2.3033028] : [2.303302] =======
======= [2.7378228] : [2.737825] =======
======= [3.3672159] : [3.3672261] =======
======= [2.771242] : [2.7712426] =======
======= [1.5788333] : [1.578834] =======
’‘’
- TestFleetDygraphMnistXPU in test_parallel_dygraph_mnist.py:
‘’‘
======= [2.3033028] : [2.303302] =======
======= [2.7378228] : [2.737825] =======
======= [3.3672159] : [3.3672261] =======
======= [2.771242] : [2.7712426] =======
======= [1.5788333] : [1.578834] =======
’‘’
