### PR TITLE
fix python pass builder error.

### DIFF
--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -543,7 +543,10 @@ void BindAnalysisConfig(py::module *m) {
            [](AnalysisConfig &self, const std::string &pass) {
              self.pass_builder()->DeletePass(pass);
            })
-      .def("pass_builder", &AnalysisConfig::pass_builder,
+      .def("pass_builder",
+           [](AnalysisConfig &self) {
+             return dynamic_cast<PaddlePassBuilder *>(self.pass_builder());
+           },
            py::return_value_policy::reference);
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
规避python下使用pass_builder出错的问题。

```
from paddle.inference import Config

config = Config()
pass_builder = config.pass_builder()
print('all_pass')
print(pass_builder.all_passes())
print('add_pass')
pass_builder.append_pass('fc_fuse_pass')
print(pass_builder.all_passes())

print('delete pass')
config.pass_builder().delete_pass('fc_fuse_pass')
print(pass_builder.all_passes())
print('append_pass')
config.pass_builder().append_pass('fc_fuse_pass')
print(pass_builder.all_passes())
print('delete_pass')
config.pass_builder().delete_pass('fc_fuse_pass')
print(config.pass_builder().all_passes())

print('all analysis_pass')
print(config.pass_builder().analysis_passes())
```


输出log
```
I0207 09:03:44.356910 95034 analysis_config.cc:37] Create CPU IR passes
all_pass
['simplify_with_basic_ops_pass', 'attention_lstm_fuse_pass', 'seqconv_eltadd_relu_fuse_pass', 'seqpool_cvm_concat_fuse_pass', 'mul_lstm_fuse_pass', 'fc_gru_fuse_pass', 'mul_gru_fuse_pass', 'seq_concat_fc_fuse_pass', 'squeeze2_matmul_fuse_pass', 'reshape2_matmul_fuse_pass', 'flatten2_matmul_fuse_pass', 'map_matmul_to_mul_pass', 'fc_fuse_pass', 'repeated_fc_relu_fuse_pass', 'squared_mat_sub_fuse_pass', 'conv_bn_fuse_pass', 'conv_eltwiseadd_bn_fuse_pass', 'conv_transpose_bn_fuse_pass', 'conv_transpose_eltwiseadd_bn_fuse_pass', 'is_test_pass', 'runtime_context_cache_pass']
add_pass
['simplify_with_basic_ops_pass', 'attention_lstm_fuse_pass', 'seqconv_eltadd_relu_fuse_pass', 'seqpool_cvm_concat_fuse_pass', 'mul_lstm_fuse_pass', 'fc_gru_fuse_pass', 'mul_gru_fuse_pass', 'seq_concat_fc_fuse_pass', 'squeeze2_matmul_fuse_pass', 'reshape2_matmul_fuse_pass', 'flatten2_matmul_fuse_pass', 'map_matmul_to_mul_pass', 'fc_fuse_pass', 'repeated_fc_relu_fuse_pass', 'squared_mat_sub_fuse_pass', 'conv_bn_fuse_pass', 'conv_eltwiseadd_bn_fuse_pass', 'conv_transpose_bn_fuse_pass', 'conv_transpose_eltwiseadd_bn_fuse_pass', 'is_test_pass', 'runtime_context_cache_pass', 'fc_fuse_pass']
delete pass
['simplify_with_basic_ops_pass', 'attention_lstm_fuse_pass', 'seqconv_eltadd_relu_fuse_pass', 'seqpool_cvm_concat_fuse_pass', 'mul_lstm_fuse_pass', 'fc_gru_fuse_pass', 'mul_gru_fuse_pass', 'seq_concat_fc_fuse_pass', 'squeeze2_matmul_fuse_pass', 'reshape2_matmul_fuse_pass', 'flatten2_matmul_fuse_pass', 'map_matmul_to_mul_pass', 'repeated_fc_relu_fuse_pass', 'squared_mat_sub_fuse_pass', 'conv_bn_fuse_pass', 'conv_eltwiseadd_bn_fuse_pass', 'conv_transpose_bn_fuse_pass', 'conv_transpose_eltwiseadd_bn_fuse_pass', 'is_test_pass', 'runtime_context_cache_pass']
append_pass
['simplify_with_basic_ops_pass', 'attention_lstm_fuse_pass', 'seqconv_eltadd_relu_fuse_pass', 'seqpool_cvm_concat_fuse_pass', 'mul_lstm_fuse_pass', 'fc_gru_fuse_pass', 'mul_gru_fuse_pass', 'seq_concat_fc_fuse_pass', 'squeeze2_matmul_fuse_pass', 'reshape2_matmul_fuse_pass', 'flatten2_matmul_fuse_pass', 'map_matmul_to_mul_pass', 'repeated_fc_relu_fuse_pass', 'squared_mat_sub_fuse_pass', 'conv_bn_fuse_pass', 'conv_eltwiseadd_bn_fuse_pass', 'conv_transpose_bn_fuse_pass', 'conv_transpose_eltwiseadd_bn_fuse_pass', 'is_test_pass', 'runtime_context_cache_pass', 'fc_fuse_pass']
delete_pass
['simplify_with_basic_ops_pass', 'attention_lstm_fuse_pass', 'seqconv_eltadd_relu_fuse_pass', 'seqpool_cvm_concat_fuse_pass', 'mul_lstm_fuse_pass', 'fc_gru_fuse_pass', 'mul_gru_fuse_pass', 'seq_concat_fc_fuse_pass', 'squeeze2_matmul_fuse_pass', 'reshape2_matmul_fuse_pass', 'flatten2_matmul_fuse_pass', 'map_matmul_to_mul_pass', 'repeated_fc_relu_fuse_pass', 'squared_mat_sub_fuse_pass', 'conv_bn_fuse_pass', 'conv_eltwiseadd_bn_fuse_pass', 'conv_transpose_bn_fuse_pass', 'conv_transpose_eltwiseadd_bn_fuse_pass', 'is_test_pass', 'runtime_context_cache_pass']
all analysis_pass
['ir_graph_build_pass', 'ir_graph_clean_pass', 'ir_analysis_pass', 'ir_params_sync_among_devices_pass', 'adjust_cudnn_workspace_size_pass', 'inference_op_replace_pass', 'ir_graph_to_program_pass']
```