### PR TITLE
enable exhaustive_search for forward and backward algos when dtype is float16

### DIFF
--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -203,7 +203,6 @@ struct SearchAlgorithm<cudnnConvolutionFwdAlgoPerf_t> {
                      const framework::ExecutionContext& ctx) {
     auto dtype = platform::CudnnDataType<T>::type;
     bool has_got_workspace_size = true;
-    bool exhaustive = (exhaustive_search) & (dtype != CUDNN_DATA_HALF);
     size_t workspace_size_limit = FLAGS_conv_workspace_size_limit * 1024 * 1024;
     size_t workspace_size = 0;
     algo_t algo;
@@ -227,7 +226,7 @@ struct SearchAlgorithm<cudnnConvolutionFwdAlgoPerf_t> {
     }
 #endif
 
-    if (!exhaustive && !deterministic) {
+    if (!exhaustive_search && !deterministic) {
 #if CUDNN_VERSION >= 7001
       int perf_count;
       int best_algo_idx = 0;

--- a/paddle/fluid/operators/conv_cudnn_helper.h
+++ b/paddle/fluid/operators/conv_cudnn_helper.h
@@ -337,7 +337,6 @@ struct SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t> {
                      bool deterministic,
                      const framework::ExecutionContext& ctx) {
     auto dtype = platform::CudnnDataType<T>::type;
-    bool exhaustive = (exhaustive_search) & (dtype != CUDNN_DATA_HALF);
     size_t workspace_size_limit = FLAGS_conv_workspace_size_limit * 1024 * 1024;
     size_t workspace_size = 0;
     bool has_got_workspace_size = true;
@@ -361,7 +360,7 @@ struct SearchAlgorithm<cudnnConvolutionBwdDataAlgoPerf_t> {
     }
 #endif
 
-    if (!exhaustive && !deterministic) {
+    if (!exhaustive_search && !deterministic) {
 #if CUDNN_VERSION >= 7001
       int perf_count;
       int best_algo_idx = 0;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> enable exhaustive_search for forward and backward algos when dtype is float16

### Performance of DeepLabv3+
#### CUDA11
AMP Training Speed：13.70 imgs/s -> 14.98 imgs/s (+8%). Because the CPU time of conv2d is reduced.

- before
```
Event                                    Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
conv2d_grad                              650         1329.18     528.182332 (0.397374)   800.998421 (0.602626)   0.661176    7.06804     2.04489     0.24716
conv2d                                   650         891.009     546.336114 (0.613166)   344.672888 (0.386834)   0.582741    6.89205     1.37078     0.165682
```
- after
```
Event                                    Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
conv2d_grad                              650         1032.53     230.018010 (0.222771)   802.513547 (0.777229)   0.290519    6.29382     1.58851     0.169211
conv2d                                   650         524.496     202.720515 (0.386505)   321.775916 (0.613495)   0.287171    4.78682     0.806918    0.0859543
```

#### CUDA10
AMPTraining Speed：5.60 imgs/s -> 13.16 imgs/s (2.35x). The GPU time of conv2d_grad is greatly reduced.

- before
```
Event                                    Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
conv2d_grad                              650         5387.36     160.838245 (0.029855)   5226.517884 (0.970145)  0.309789    261.268     8.28824     0.348446
conv2d                                   650         513.636     192.535391 (0.374848)   321.100872 (0.625152)   0.257809    12.8506     0.79021     0.0332212
```
- after
```
Event                                    Calls       Total       CPU Time (Ratio)        GPU Time (Ratio)        Min.        Max.        Ave.        Ratio.
conv2d_grad                              650         1371.61     188.505491 (0.137434)   1183.102403 (0.862566)  0.282237    20.9035     2.11017     0.188158
conv2d                                   650         487.729     152.423144 (0.312516)   335.305523 (0.687484)   0.216278    7.27278     0.750352    0.0669067
```