### PR TITLE
Try to fix reader and signal test failed

### DIFF
--- a/paddle/fluid/operators/reader/reader_blocking_queue_test.cc
+++ b/paddle/fluid/operators/reader/reader_blocking_queue_test.cc
@@ -68,7 +68,7 @@ TEST(BlockingQueue, SenderBlockingTest) {
       ++send_count;
     }
   });
-  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
   q.Close();
   sender.join();
   EXPECT_EQ(send_count, queue_cap);

--- a/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_signal_handler.py
@@ -70,16 +70,26 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             core._set_process_signal_handler()
             os.kill(os.getpid(), signal.SIGSEGV)
 
-        exception = None
-        try:
-            test_process = multiprocessing.Process(target=__test_process__)
-            test_process.start()
+        def try_except_exit():
+            exception = None
+            try:
+                test_process = multiprocessing.Process(target=__test_process__)
+                test_process.start()
 
-            set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(10)
-        except SystemError as ex:
-            self.assertIn("Segmentation fault", cpt.get_exception_message(ex))
-            exception = ex
+                set_child_signal_handler(id(self), test_process.pid)
+                time.sleep(5)
+            except SystemError as ex:
+                self.assertIn("Segmentation fault",
+                              cpt.get_exception_message(ex))
+                exception = ex
+            return exception
+
+        try_time = 10
+        exception = None
+        for i in range(try_time):
+            exception = try_except_exit()
+            if exception is not None:
+                break
 
         self.assertIsNotNone(exception)
 
@@ -88,16 +98,25 @@ class TestDygraphDataLoaderSingalHandler(unittest.TestCase):
             core._set_process_signal_handler()
             os.kill(os.getpid(), signal.SIGBUS)
 
-        exception = None
-        try:
-            test_process = multiprocessing.Process(target=__test_process__)
-            test_process.start()
+        def try_except_exit():
+            exception = None
+            try:
+                test_process = multiprocessing.Process(target=__test_process__)
+                test_process.start()
 
-            set_child_signal_handler(id(self), test_process.pid)
-            time.sleep(10)
-        except SystemError as ex:
-            self.assertIn("Bus error", cpt.get_exception_message(ex))
-            exception = ex
+                set_child_signal_handler(id(self), test_process.pid)
+                time.sleep(5)
+            except SystemError as ex:
+                self.assertIn("Bus error", cpt.get_exception_message(ex))
+                exception = ex
+            return exception
+
+        try_time = 10
+        exception = None
+        for i in range(try_time):
+            exception = try_except_exit()
+            if exception is not None:
+                break
 
         self.assertIsNotNone(exception)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Try to fix reader and signal test failed

reader_blocking_queue_test
- 之前在CI机器上循环1000遍未复现，猜测是极端情况下调度导致线程未执行就进行了check，所以延长了 sleep时间

test_imperative_signal_handler
- 在CI环境下，调度原因导致有时候子进程的signal会来不及catch，加入retry