### PR TITLE
[Kunlun] add xpu multi machines training 

### DIFF
--- a/paddle/fluid/operators/collective/broadcast_op_xpu.cc
+++ b/paddle/fluid/operators/collective/broadcast_op_xpu.cc
@@ -71,6 +71,41 @@ class BKCLBroadcastOpKernel : public framework::OpKernel<T> {
     auto ret = bkcl_broadcast(comm, send_recv_buffer, send_recv_buffer,
                               static_cast<size_t>(in->numel()) * scale,
                               data_type, root_dev_id, stream);
+    float* send_cpu = new float[static_cast<size_t>(in->numel()) * scale];
+    VLOG(0) << "after bkcl_broadcast";
+    if (dev_id == 3) {
+      static std::ofstream stored0_buffer;
+      stored0_buffer.open("send_recv_buffer0.log");
+      // recvfile.open("xpu_1_recv.log");
+      memory::Copy(platform::CPUPlace(), reinterpret_cast<void*> send_cpu,
+                   BOOST_GET_CONST(platform::XPUPlace, ctx.GetPlace()),
+                   reinterpret_cast<void*>(send_recv_buffer),
+                   (static_cast<size_t>(in->numel()) * scale) * sizeof(float));
+      VLOG(0) << "stored0_buffer address = " << send_recv_buffer;
+      for (size_t j = 0; j < static_cast<size_t>(in->numel()) * scale; ++j) {
+        if (j % 10 == 0) {
+          stored0_buffer << "\n " << send_cpu[j];
+        } else {
+          stored0_buffer << " " << send_cpu[j];
+        }
+      }
+    } else {
+      static std::ofstream stored1_buffer;
+      stored1_buffer.open("send_recv_buffer1.log");
+      memory::Copy(platform::CPUPlace(), reinterpret_cast<void*> send_cpu,
+                   BOOST_GET_CONST(platform::XPUPlace, ctx.GetPlace()),
+                   reinterpret_cast<void*>(send_recv_buffer),
+                   (static_cast<size_t>(in->numel()) * scale) * sizeof(float));
+      VLOG(0) << "stored1_buffer address = " << send_recv_buffer;
+      for (size_t j = 0; j < static_cast<size_t>(in->numel()) * scale; ++j) {
+        if (j % 10 == 0) {
+          stored1_buffer << "\n " << send_cpu[j];
+        } else {
+          stored1_buffer << " " << send_cpu[j];
+        }
+      }
+    }
+
     PADDLE_ENFORCE_EQ(ret, BKCL_SUCCESS,
                       platform::errors::Unavailable("bkcl_broadcast failed"));
 

--- a/paddle/fluid/operators/collective/broadcast_op_xpu.cc
+++ b/paddle/fluid/operators/collective/broadcast_op_xpu.cc
@@ -77,7 +77,7 @@ class BKCLBroadcastOpKernel : public framework::OpKernel<T> {
       static std::ofstream stored0_buffer;
       stored0_buffer.open("send_recv_buffer0.log");
       // recvfile.open("xpu_1_recv.log");
-      memory::Copy(platform::CPUPlace(), reinterpret_cast<void*> send_cpu,
+      memory::Copy(platform::CPUPlace(), reinterpret_cast<void*>(send_cpu),
                    BOOST_GET_CONST(platform::XPUPlace, ctx.GetPlace()),
                    reinterpret_cast<void*>(send_recv_buffer),
                    (static_cast<size_t>(in->numel()) * scale) * sizeof(float));
@@ -92,7 +92,7 @@ class BKCLBroadcastOpKernel : public framework::OpKernel<T> {
     } else {
       static std::ofstream stored1_buffer;
       stored1_buffer.open("send_recv_buffer1.log");
-      memory::Copy(platform::CPUPlace(), reinterpret_cast<void*> send_cpu,
+      memory::Copy(platform::CPUPlace(), reinterpret_cast<void*>(send_cpu),
                    BOOST_GET_CONST(platform::XPUPlace, ctx.GetPlace()),
                    reinterpret_cast<void*>(send_recv_buffer),
                    (static_cast<size_t>(in->numel()) * scale) * sizeof(float));

--- a/paddle/fluid/operators/collective/c_allreduce_op.h
+++ b/paddle/fluid/operators/collective/c_allreduce_op.h
@@ -20,9 +20,16 @@ limitations under the License. */
 #include "paddle/fluid/framework/lod_tensor.h"
 #include "paddle/fluid/framework/op_registry.h"
 
-#if defined(PADDLE_WITH_NCCL)
+#if (defined PADDLE_WITH_NCCL) && (defined PADDLE_WITH_XPU_BKCL)
 #include "paddle/fluid/platform/collective_helper.h"
+#endif
+
+#if (defined PADDLE_WITH_NCCL)
 #include "paddle/fluid/platform/nccl_helper.h"
+#endif
+
+#if defined(PADDLE_WITH_XPU_BKCL)
+#include "paddle/fluid/platform/bkcl_helper.h"
 #endif
 
 #if defined(PADDLE_WITH_GLOO)
@@ -101,6 +108,71 @@ class CAllReduceOpCPUKernel : public framework::OpKernel<T> {
 #else
     PADDLE_THROW(platform::errors::Unavailable(
         "PaddlePaddle should compile with GLOO by setting WITH_GLOO=ON"));
+#endif
+  }
+};
+
+template <ReduceType red_type, typename T>
+class CAllReduceOpXPUKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+#if defined(PADDLE_WITH_XPU_BKCL)
+    auto in = ctx.Input<framework::Tensor>("X");
+    auto out = ctx.Output<framework::Tensor>("Out");
+
+    auto place = ctx.GetPlace();
+    BKCLDataType dtype = platform::ToBKCLDataType(in->type());
+    int64_t numel = in->numel();
+    const void* sendbuff = in->data<void>();
+    out->Resize(in->dims());
+    void* recvbuff = out->mutable_data<T>(place);
+
+    int rid = ctx.Attr<int>("ring_id");
+    auto comm = platform::BKCLCommContext::Instance().Get(rid, place);
+
+    XPUStream stream = nullptr;
+    if (ctx.Attr<bool>("use_calc_stream")) {
+      auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      stream = static_cast<platform::XPUDeviceContext*>(dev_ctx)
+                   ->x_context()
+                   ->xpu_stream;
+    } else {
+      stream = comm->stream();
+    }
+
+    BKCLOp bkcl_red_type = BKCL_ADD;
+    switch (red_type) {
+      case kRedSum:
+        bkcl_red_type = BKCL_ADD;
+        break;
+
+      case kRedMax:
+        bkcl_red_type = BKCL_MAX;
+        break;
+
+      case kRedMin:
+        bkcl_red_type = BKCL_MIN;
+        break;
+
+      case kRedProd:
+        bkcl_red_type = BKCL_PRODUCT;
+        break;
+
+      default:
+        PADDLE_THROW(platform::errors::InvalidArgument(
+            "Invalid reduce type: %d", red_type));
+    }
+
+    // PADDLE_ENFORCE_CUDA_SUCCESS(platform::dynload::ncclAllReduce(
+    //     sendbuff, recvbuff, numel, dtype, nccl_red_type, comm->comm(),
+    //     stream));
+    PADDLE_ENFORCE_EQ(bkcl_all_reduce(comm->comm(), sendbuff, recvbuff, numel,
+                                      dtype, bkcl_red_type, stream),
+                      BKCL_SUCCESS, platform::errors::PreconditionNotMet(
+                                        "BKCL all reduce failed"));
+#else
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "PaddlePaddle should be compiled with XPU."));
 #endif
   }
 };

--- a/paddle/fluid/operators/collective/c_allreduce_sum_op_xpu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_sum_op_xpu.cc
@@ -1,0 +1,28 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/collective/c_allreduce_op.h"
+
+namespace paddle {
+namespace platform {
+struct XPUPlace;
+struct float16;
+}  // namespace platform
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_XPU_KERNEL(c_allreduce_sum,
+                       ops::CAllReduceOpCUDAKernel<ops::kRedSum, float>)

--- a/python/paddle/fluid/dygraph/parallel_helper.py
+++ b/python/paddle/fluid/dygraph/parallel_helper.py
@@ -48,5 +48,10 @@ def _broadcast_parameters(parameters):
         # so we could not broadcast these parameters.
         if param.is_distributed: continue
 
+        if core.is_compiled_with_xpu():
+            if rank != 0:
+                param = 0
+            collective._c_allreduce(param)
+
         if isinstance(param, Parameter) and param.trainable:
             collective._broadcast(param, 0, sync_mode=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
 add xpu multi machines training:
-[WIP] debug: add  print log in broadcast_op_xpu.cc

example:
fleetrun --xpus 0,1 train.py
```
import os
import time
import paddle
from paddle.vision.datasets import MNIST
import paddle.distributed.fleet as fleet
import paddle.static.nn as nn
import paddle.fluid as fluid

def mnist_on_mlp_model():
    paddle.vision.set_image_backend('cv2')
    train_dataset = paddle.vision.datasets.MNIST(mode='train')
    test_dataset = paddle.vision.datasets.MNIST( mode='test')
    x = paddle.static.data(name="x", shape=[64, 28, 28], dtype='float32')
    y = paddle.static.data(name="y", shape=[64,1], dtype='int64')
    x_flatten = fluid.layers.reshape(x, [64, 784])
    fc_1 = nn.fc(x=x_flatten, size=128, activation='tanh')
    fc_2 = nn.fc(x=fc_1, size=128, activation='tanh')
    prediction = nn.fc(x=[fc_2], size=10, activation='softmax')
    cost = fluid.layers.cross_entropy(input=prediction, label=y)
    acc_top1 = fluid.layers.accuracy(input=prediction, label=y, k=1)
    avg_cost = fluid.layers.mean(x=cost)
    return train_dataset, test_dataset, x, y, avg_cost, acc_top1

paddle.enable_static()
train_data, test_data, x, y, cost, acc = mnist_on_mlp_model()
place = paddle.XPUPlace(int(os.environ.get('FLAGS_selected_xpus', 0)))
train_dataloader = paddle.io.DataLoader(
    train_data, feed_list=[x, y], drop_last=True,
    places=place, batch_size=64, shuffle=True)
fleet.init(is_collective=True)
strategy = fleet.DistributedStrategy()
#optimizer = paddle.optimizer.Adam(learning_rate=0.01)
optimizer = fluid.optimizer.Adam(learning_rate=0.001)
optimizer = fleet.distributed_optimizer(optimizer, strategy=strategy)
optimizer.minimize(cost)

exe = paddle.static.Executor(place)
exe.run(paddle.static.default_startup_program())

epoch = 1
for i in range(epoch):
    total_time = 0
    step = 0
    for data in train_dataloader():
        step += 1
        start_time = time.time()
        loss_val, acc_val = exe.run(
          paddle.static.default_main_program(),
          feed={"x":data[0],"y":data[1]}, fetch_list=[cost.name, acc.name])
        if step % 2 == 0:
            end_time = time.time()
            total_time += (end_time - start_time)
            print(
                    "epoch: %d, step:%d, train_loss: %f, total time cost = %f, speed: %f"
                % (i, step, loss_val[0], total_time,
                   1 / (end_time - start_time) ))
```

