### PR TITLE
fix bug of Linux UT parallel level

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -995,19 +995,20 @@ function card_test() {
     fi
 
     testcases=$1
+    parallel_level_base=${CTEST_PARALLEL_LEVEL:-1}
     if (( $# > 1 )); then
         cardnumber=$2
         if (( $cardnumber > $CUDA_DEVICE_COUNT )); then
             cardnumber=$CUDA_DEVICE_COUNT
         fi
         if (( $# > 2 )); then
-            parallel_job=$3
+            parallel_job=`expr $3 \* $parallel_level_base`
         else
-            parallel_job=1
+            parallel_job=$parallel_level_base
         fi
     else
         cardnumber=$CUDA_DEVICE_COUNT
-        parallel_job=1
+        parallel_job=$parallel_level_base
     fi
 
     if [[ "$testcases" == "" ]]; then


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- 修复Linux上并发数量的问题，预期会恢复单测并发策略的8min收益，回降约20min。

![image](https://user-images.githubusercontent.com/52485244/107371325-20009780-6b1f-11eb-9dd9-191b5f009ddf.png)
