### PR TITLE
Modify relu native implementation

### DIFF
--- a/cmake/cuda.cmake
+++ b/cmake/cuda.cmake
@@ -216,6 +216,8 @@ endif(WIN32)
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -w")
 # Set :expt-relaxed-constexpr to suppress Eigen warnings
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
+# Set :expt-extended-lambda to enable HOSTDEVICE annotation on lambdas
+set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 
 if(WIN32)
   set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler \"/wd4244 /wd4267 /wd4819 \"")

--- a/paddle/fluid/operators/activation_op.h
+++ b/paddle/fluid/operators/activation_op.h
@@ -321,7 +321,9 @@ template <typename T>
 struct ReluFunctor : public BaseActivationFunctor<T> {
   template <typename Device, typename X, typename Out>
   void operator()(Device d, X x, Out out) const {
-    out.device(d) = x.cwiseMax(static_cast<T>(0));
+    out.device(d) = x.unaryExpr([] HOSTDEVICE(T v) {
+      return v > static_cast<T>(0) ? v : static_cast<T>(0);
+    });
   }
 };
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
In this patch the native implementation of the `relu` op is modified so the `nan` values in the op's input were treated as `0`, the same way as in GPU and oneDNN kernels.
This fixes the issue https://github.com/PaddlePaddle/Paddle/issues/30905. Tested with the `develop` and `release/2.0` branches.

In my quick benchmark using i9 processor, latency of the new implementation of the `relu` op is about 5% bigger. On the model level, the latency measured for the test from https://github.com/PaddlePaddle/Paddle/issues/30905 was the same for both implementations.
