### PR TITLE
fix the bug in expand_v2 op

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1444,12 +1444,11 @@ def expand(x, shape, name=None):
 
     helper = LayerHelper('expand', **locals())
 
-    def get_attr_expand_shape(list_expand_shape, flags):
+    def get_attr_expand_shape(list_expand_shape):
         attrs_expand_shape = []
         for idx, shape in enumerate(list_expand_shape):
             if isinstance(shape, Variable):
-                attrs_expand_shape.append(-1)
-                flags[idx] = 1
+                attrs_expand_shape.append(-2)
             else:
                 attrs_expand_shape.append(shape)
                 assert shape > 0 or shape == -1, (
@@ -1460,9 +1459,7 @@ def expand(x, shape, name=None):
         shape.stop_gradient = True
         inputs['Shape'] = shape
     elif isinstance(shape, (list, tuple)):
-        infer_shape_flags = [0] * len(shape)
-        attrs['shape'] = get_attr_expand_shape(shape, infer_shape_flags)
-        attrs['infer_shape_flags'] = infer_shape_flags
+        attrs['shape'] = get_attr_expand_shape(shape)
         if utils._contain_var(shape):
             inputs['expand_shapes_tensor'] = utils._convert_to_tensor_list(
                 shape)

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1444,11 +1444,12 @@ def expand(x, shape, name=None):
 
     helper = LayerHelper('expand', **locals())
 
-    def get_attr_expand_shape(list_expand_shape):
+    def get_attr_expand_shape(list_expand_shape, flags):
         attrs_expand_shape = []
         for idx, shape in enumerate(list_expand_shape):
             if isinstance(shape, Variable):
                 attrs_expand_shape.append(-1)
+                flags[idx] = 1
             else:
                 attrs_expand_shape.append(shape)
                 assert shape > 0 or shape == -1, (
@@ -1459,7 +1460,9 @@ def expand(x, shape, name=None):
         shape.stop_gradient = True
         inputs['Shape'] = shape
     elif isinstance(shape, (list, tuple)):
-        attrs['shape'] = get_attr_expand_shape(shape)
+        infer_shape_flags = [0] * len(shape)
+        attrs['shape'] = get_attr_expand_shape(shape, infer_shape_flags)
+        attrs['infer_shape_flags'] = infer_shape_flags
         if utils._contain_var(shape):
             inputs['expand_shapes_tensor'] = utils._convert_to_tensor_list(
                 shape)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
fix the bug in expand_v2 op.

Paddle框架在编译期使用-1表示未知维度值，如batch size的值。expand_v2 OP使用-1表示保持相应维度地维度值不变。例如，b = expand(a, shape=[4, -1, 2]), 假设a.shape = [2, 3, 2], 则b.shape = [4, 3, 2]。

当expand的shape参数列表中包含var是，例如，c = expand(a, shape=[temp_var, 3, 2])是，expand在编译期会将expand OP的expand_shape属性var对应的值设置为-1， 上例中expand_shape的属性值为[-1, 3, 2]。那么编译期c.shape = [2, 3, 2]。
当temp_var表示未知维度值时，和期望的结果不符，期望的结果是c.shape = [-1, 3, 2]。

本pr在编译器将temp_var对应的维度值设置为-1，表示编译期未知维度，解决上述问题。