### PR TITLE
Create CCommInitOp and CCreateGroupOp for NPU

### DIFF
--- a/cmake/external/ascend.cmake
+++ b/cmake/external/ascend.cmake
@@ -67,6 +67,7 @@ elseif(WITH_ASCEND_CL)
   set(ATLAS_ATC_DIR ${ASCEND_DIR}/ascend-toolkit/latest/fwkacllib/lib64)
   
   set(atlas_acl_lib ${ATLAS_ACL_DIR}/libascendcl.so)
+  set(ascend_hccl_lib ${ATLAS_ACL_DIR}/libhccl.so)
   set(atlas_acl_op_compiler_lib ${ATLAS_ACL_DIR}/libacl_op_compiler.so)
   set(ATLAS_ACL_INC_DIR ${ASCEND_DIR}/ascend-toolkit/latest/fwkacllib/include)
 
@@ -77,8 +78,12 @@ elseif(WITH_ASCEND_CL)
   ADD_LIBRARY(atlas_acl SHARED IMPORTED GLOBAL)
   SET_PROPERTY(TARGET atlas_acl PROPERTY IMPORTED_LOCATION ${atlas_acl_lib})
 
+  ADD_LIBRARY(ascend_hccl SHARED IMPORTED GLOBAL)
+  SET_PROPERTY(TARGET ascend_hccl PROPERTY IMPORTED_LOCATION ${ascend_hccl_lib})
+
   ADD_LIBRARY(atlas_acl_op_compiler SHARED IMPORTED GLOBAL)
   SET_PROPERTY(TARGET atlas_acl_op_compiler PROPERTY IMPORTED_LOCATION ${atlas_acl_op_compiler_lib})
-  add_custom_target(extern_ascend DEPENDS atlas_acl atlas_acl_op_compiler)
+  
+  add_custom_target(extern_ascend DEPENDS atlas_acl atlas_acl_op_compiler ascend_hccl)
 
 endif()

--- a/paddle/fluid/operators/collective/CMakeLists.txt
+++ b/paddle/fluid/operators/collective/CMakeLists.txt
@@ -11,23 +11,67 @@ foreach(src ${OPS})
     set_source_files_properties(${src} PROPERTIES COMPILE_FLAGS ${COLLECTIVE_COMPILE_FLAGS})
 endforeach()
 
-register_operators(EXCLUDES c_gen_nccl_id_op gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
+register_operators(EXCLUDES c_gen_bkcl_id_op gen_bkcl_id_op c_gen_nccl_id_op gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
+
+# if(WITH_ASCEND_CL)
+#     set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} hccl collective_helper)
+#     op_library(c_gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
+#     op_library(gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
+
+# 	# add_definitions(-DENABLE_DVPP_INTERFACE)
+
+# 	# # Compile options
+# 	# add_compile_options(-std=c++11 -fPIE -fstack-protector-all -Werror -Wno-deprecated-declarations)
+
+# 	# # Skip build rpath
+# 	# set(CMAKE_SKIP_BUILD_RPATH True)
+
+# 	# # Set output directory
+# 	# # set(PROJECT_SRC_ROOT ${CMAKE_CURRENT_LIST_DIR}/code/hccl_c_plus)
+# 	# # set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/bin)
+
+# 	# # Set include directory and library directory
+# 	# # /usr/local/Ascend/ascend-toolkit/latest/acllib/include/
+# 	# set(ACL_INC_DIR $ENV{ASCEND_HOME}/ascend-toolkit/latest/acllib/include)
+# 	# set(ACL_LIB_DIR $ENV{ASCEND_HOME}/ascend-toolkit/latest/acllib/lib64/stub)
+
+# 	# # hccl
+# 	# #/usr/local/Ascend/ascend-toolkit/latest/fwkacllib/include/
+# 	# set(HCCL_INC_DIR $ENV{ASCEND_HOME}/ascend-toolkit/latest/fwkacllib/include)
+# 	# set(HCCL_LIB_DIR $ENV{ASCEND_HOME}/ascend-toolkit/latest/fwkacllib/lib64)
+
+# 	# # Header path
+# 	# include_directories("./")
+# 	# include_directories(${ACL_INC_DIR})
+# 	# include_directories(${HCCL_INC_DIR})
+# 	# include_directories(${ASCEND_BASE_DIR})
+# 	# include_directories(${ASCEND_BASE_DIR}/Framework)
+
+# 	# # add host lib path
+# 	# link_directories(${ACL_LIB_DIR})
+# 	# link_directories(${HCCL_LIB_DIR})
+
+# 	# add_executable(main ${SRC_FILES} ${PROJECT_SRC_ROOT}/example.cpp)
+# 	# add_executable(main ${SRC_FILES} ${ASCEND_BASE_SRC_FILES} ${PROJECT_SRC_ROOT}/main.cpp)
+
+# 	# target_link_libraries(main ascendcl pthread hccl -Wl,-z,relro,-z,now,-z,noexecstack -pie -s)
+# 	# target_link_libraries(main ascendcl acl_dvpp pthread hccl -Wl,-z,relro,-z,now,-z,noexecstack -pie -s)
+# endif()
 
 if(WITH_NCCL)
     set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} nccl_common collective_helper)
-    cc_library(gen_nccl_id_op_helper SRCS gen_nccl_id_op_helper.cc DEPS nccl_common)
-    op_library(c_gen_nccl_id_op DEPS ${COLLECTIVE_DEPS} gen_nccl_id_op_helper)
-    op_library(gen_nccl_id_op DEPS ${COLLECTIVE_DEPS} gen_nccl_id_op_helper)
+    op_library(c_gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
+    op_library(gen_nccl_id_op DEPS ${COLLECTIVE_DEPS})
 endif()
-
-if(WITH_ASCEND)
-    op_library(gen_nccl_id_op)
-    op_library(c_gen_nccl_id_op)
-endif()
-
 
 if(WITH_GLOO)
     set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} gloo_wrapper)
+endif()
+
+if(WITH_XPU_BKCL)
+    set(COLLECTIVE_DEPS ${COLLECTIVE_DEPS} collective_helper)
+    op_library(c_gen_bkcl_id_op DEPS ${COLLECTIVE_DEPS})
+    op_library(gen_bkcl_id_op DEPS ${COLLECTIVE_DEPS})
 endif()
 
 set(OPERATOR_DEPS ${OPERATOR_DEPS} ${COLLECTIVE_DEPS} PARENT_SCOPE)

--- a/paddle/fluid/operators/collective/c_allreduce_max_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_max_op_npu.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/collective/c_allreduce_op.h"
+
+namespace paddle {
+namespace platform {
+struct ASCENDPlace;
+struct float16;
+}  // namespace platform
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_NPU_KERNEL(
+    c_allreduce_max, ops::CAllReduceOpASCENDKernel<ops::kRedMax, float>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedMax, int>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedMax, int64_t>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedMax, plat::float16>)

--- a/paddle/fluid/operators/collective/c_allreduce_min_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_min_op_npu.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/collective/c_allreduce_op.h"
+
+namespace paddle {
+namespace platform {
+struct ASCENDPlace;
+struct float16;
+}  // namespace platform
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_NPU_KERNEL(
+    c_allreduce_min, ops::CAllReduceOpASCENDKernel<ops::kRedMin, float>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedMin, int>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedMin, int64_t>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedMin, plat::float16>)

--- a/paddle/fluid/operators/collective/c_allreduce_op.h
+++ b/paddle/fluid/operators/collective/c_allreduce_op.h
@@ -131,8 +131,8 @@ class CAllReduceOpASCENDKernel : public framework::OpKernel<T> {
     // void* recvbuff = out->mutable_data<T>(place);
 
 
-    int rid = ctx.Attr<int>("ring_id");
-    auto comm = platform::HCCLCommContext::Instance().Get(rid, place);
+    //int rid = ctx.Attr<int>("ring_id");
+    auto comm = platform::HCCLCommContext::Instance().Get();
 
     aclrtStream stream = nullptr;
     if (ctx.Attr<bool>("use_calc_stream")) {

--- a/paddle/fluid/operators/collective/c_allreduce_prod_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_prod_op_npu.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/collective/c_allreduce_op.h"
+
+namespace paddle {
+namespace platform {
+struct ASCENDPlace;
+struct float16;
+}  // namespace platform
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_NPU_KERNEL(
+    c_allreduce_prod, ops::CAllReduceOpASCENDKernel<ops::kRedProd, float>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedProd, int>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedProd, int64_t>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedProd, plat::float16>)

--- a/paddle/fluid/operators/collective/c_allreduce_sum_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_allreduce_sum_op_npu.cc
@@ -1,0 +1,31 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/collective/c_allreduce_op.h"
+
+namespace paddle {
+namespace platform {
+struct ASCENDPlace;
+struct float16;
+}  // namespace platform
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_NPU_KERNEL(
+    c_allreduce_sum, ops::CAllReduceOpASCENDKernel<ops::kRedSum, float>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedSum, int>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedSum, int64_t>,
+    ops::CAllReduceOpASCENDKernel<ops::kRedSum, plat::float16>)

--- a/paddle/fluid/operators/collective/c_broadcast_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_npu.cc
@@ -1,0 +1,95 @@
+/* Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#include "paddle/fluid/operators/collective/c_broadcast_op.h"
+
+#if defined(PADDLE_WITH_ASCEND_CL)
+#include "paddle/fluid/platform/collective_helper.h"
+#include "paddle/fluid/platform/hccl_helper.h"
+#endif
+
+namespace paddle {
+namespace operators {
+
+template <typename T>
+class CBroadcastOpASCENDKernel : public framework::OpKernel<T> {
+ public:
+  void Compute(const framework::ExecutionContext& ctx) const override {
+#if defined(PADDLE_WITH_ASCEND_CL)
+    auto x = ctx.Input<framework::LoDTensor>("X");
+    auto out = ctx.Output<framework::LoDTensor>("Out");
+    int numel = x->numel();
+    HcclDataType dtype = platform::ToHCCLDataType(x->type());
+
+    int rid = ctx.Attr<int>("ring_id");
+    auto place = ctx.GetPlace();
+    auto comm = platform::HCCLCommContext::Instance().Get(rid, place);
+
+    aclrtStream stream = nullptr;
+    if (ctx.Attr<bool>("use_calc_stream")) {
+      auto dev_ctx = platform::DeviceContextPool::Instance().Get(place);
+      stream = static_cast<platform::NPUDeviceContext*>(dev_ctx)->stream();
+    } else {
+      stream = comm->stream();
+    }
+
+    int root = ctx.Attr<int>("root");
+    if (root == comm->rank()) {
+      // PADDLE_ENFORCE_ASCEND_SUCCESS(platform::dynload::HcclBroadcast(
+      //     reinterpret_cast<void*>(const_cast<T*>(x->data<T>())), numel, dtype,
+      //     root, comm->comm(), stream));
+
+      platform::dynload::HcclBroadcast(
+          reinterpret_cast<void*>(const_cast<T*>(x->data<T>())), numel, dtype,
+          root, comm->comm(), stream);
+
+      VLOG(3) << "rank " << comm->rank() << " invoke Bcast. sent "
+              << x->numel();
+
+      if (out != x) {
+        framework::TensorCopy(
+            *static_cast<const framework::Tensor*>(x), place,
+            *platform::DeviceContextPool::Instance().Get(place),
+            static_cast<framework::Tensor*>(out));
+      }
+    } else {
+      
+          platform::dynload::HcclBroadcast(out->mutable_data<T>(place), numel,
+                                       dtype, root, comm->comm(), stream);
+      // PADDLE_ENFORCE_ASCEND_SUCCESS(
+      //     platform::dynload::HcclBroadcast(out->mutable_data<T>(place), numel,
+      //                                  dtype, root, comm->comm(), stream));
+      VLOG(3) << "rank " << comm->rank() << " invoke Bcast. recieved "
+              << framework::product(out->dims());
+    }
+
+    out->Resize(x->dims());
+    out->set_lod(x->lod());
+#else
+    PADDLE_THROW(platform::errors::PreconditionNotMet(
+        "PaddlePaddle should compile with GPU."));
+#endif
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+namespace plat = paddle::platform;
+
+REGISTER_OP_NPU_KERNEL(c_broadcast, ops::CBroadcastOpASCENDKernel<float>,
+                        ops::CBroadcastOpASCENDKernel<int>,
+                        ops::CBroadcastOpASCENDKernel<int64_t>,
+                        ops::CBroadcastOpASCENDKernel<plat::float16>);

--- a/paddle/fluid/operators/collective/c_broadcast_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_npu.cc
@@ -32,9 +32,9 @@ class CBroadcastOpASCENDKernel : public framework::OpKernel<T> {
     int numel = x->numel();
     HcclDataType dtype = platform::ToHCCLDataType(x->type());
 
-    int rid = ctx.Attr<int>("ring_id");
+    //int rid = ctx.Attr<int>("ring_id");
     auto place = ctx.GetPlace();
-    auto comm = platform::HCCLCommContext::Instance().Get(rid, place);
+    auto comm = platform::HCCLCommContext::Instance().Get();
 
     aclrtStream stream = nullptr;
     if (ctx.Attr<bool>("use_calc_stream")) {

--- a/paddle/fluid/operators/collective/c_broadcast_op_npu_test.cc
+++ b/paddle/fluid/operators/collective/c_broadcast_op_npu_test.cc
@@ -1,0 +1,82 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+#include <string>
+#include <thread>  // NOLINT
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/framework/operator.h"
+#include "paddle/fluid/framework/program_desc.h"
+#include "paddle/fluid/operators/dropout_op.h"
+#include "paddle/fluid/operators/math/math_function.h"
+#include "paddle/fluid/string/printf.h"
+
+namespace f = paddle::framework;
+namespace p = paddle::platform;
+namespace m = paddle::operators::math;
+
+USE_OP(c_broadcast);
+USE_OP_DEVICE_KERNEL(c_broadcast, NPU);
+
+void Compare(f::Scope* scope, const p::DeviceContext& ctx) {
+  // init
+  auto x = scope->Var("X");
+  auto tensor_x = x->GetMutable<f::LoDTensor>();
+
+  std::vector<float> init;
+  for (int64_t i = 0; i < 10 * 10; ++i) {
+    init.push_back(1.0);
+  }
+
+  TensorFromVector(init, ctx, tensor_x);
+  tensor_x->Resize({10, 10});
+
+  ctx.Wait();
+
+  auto place = ctx.GetPlace();
+  auto out = scope->Var("Out");
+  auto tensor_out = out->GetMutable<f::LoDTensor>();
+  tensor_out->Resize({10, 10});
+  tensor_out->mutable_data<float>(place);  // allocate
+
+  // run
+  f::AttributeMap attrs;
+  auto op =
+      f::OpRegistry::CreateOp("c_broadcast", {{"X", {"X"}}},
+                              {{"Out", {"Out"}}}, attrs);
+
+  op->Run(*scope, place);
+
+  std::vector<float> out_vec;
+  TensorToVector(*tensor_out, ctx, &out_vec);
+
+  ctx.Wait();
+
+  EXPECT_EQ(out_vec.size(), init.size());
+  for (uint32_t i = 0; i < out_vec.size(); i++) {
+    EXPECT_EQ(out_vec[i], 1.0);
+  }
+}
+
+TEST(c_broadcast, NPU) {
+  f::Scope scope;
+  p::NPUDeviceContext ctx(p::NPUPlace(0));
+  Compare(&scope, ctx);
+}

--- a/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
@@ -40,7 +40,7 @@ class CCommInitOpNPU : public framework::OperatorBase {
 
   void RunImpl(const framework::Scope& scope,
                const platform::Place& place) const override {
-    string rank_table_file = Attr<string>("rank_table_file");
+    std::string rank_table_file = Attr<std::string>("rank_table_file");
     int rank_id = Attr<int>("rank_id");
     int device_id = Attr<int>("device_id");
     platform::HCCLCommContext::Instance().CreateHCCLComm(rank_table_file,
@@ -56,7 +56,7 @@ CCommInit operator on NPU
 
 Initialize collective communication context within this trainer
 )DOC");
-    AddAttr<string>("rank_table_file",
+    AddAttr<std::string>("rank_table_file",
         "(string) path to rank_table_file");
     AddAttr<int>("rank_id", "(int) world rank id of the process");
     AddAttr<int>("device_id", "(int) device id of the process/thread");

--- a/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_comm_init_op_npu.cc
@@ -1,0 +1,74 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#if defined(PADDLE_WITH_ASCEND_CL)
+#include "paddle/fluid/platform/collective_helper.h"
+#include "paddle/fluid/platform/hccl_helper.h"
+
+#include <string>
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace framework {
+class Scope;
+}  // namespace framework
+}  // namespace paddle
+
+namespace paddle {
+namespace operators {
+
+class CCommInitOpNPU : public framework::OperatorBase {
+ public:
+  CCommInitOpNPU(const std::string& type,
+              const framework::VariableNameMap& inputs,
+              const framework::VariableNameMap& outputs,
+              const framework::AttributeMap& attrs)
+      : OperatorBase(type, inputs, outputs, attrs) {}
+
+  void RunImpl(const framework::Scope& scope,
+               const platform::Place& place) const override {
+    string rank_table_file = Attr<string>("rank_table_file");
+    int rank_id = Attr<int>("rank_id");
+    int device_id = Attr<int>("device_id");
+    platform::HCCLCommContext::Instance().CreateHCCLComm(rank_table_file,
+      rank_id, device_id);
+  }
+};
+
+class CCommInitOpNPUMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddComment(R"DOC(
+CCommInit operator on NPU
+
+Initialize collective communication context within this trainer
+)DOC");
+    AddAttr<string>("rank_table_file",
+        "(string) path to rank_table_file");
+    AddAttr<int>("rank_id", "(int) world rank id of the process");
+    AddAttr<int>("device_id", "(int) device id of the process/thread");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(c_comm_init, ops::CCommInitOpNPU,
+   ops::CCommInitOpNPUMaker);
+
+#endif

--- a/paddle/fluid/operators/collective/c_create_group_op_npu.cc
+++ b/paddle/fluid/operators/collective/c_create_group_op_npu.cc
@@ -1,0 +1,75 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include <hccl/hccl.h>
+#include <hccl/hccl_types.h>
+
+#include <string>
+
+#include "paddle/fluid/framework/op_registry.h"
+#include "paddle/fluid/operators/npu_op_runner.h"
+
+namespace paddle {
+namespace framework {
+class Scope;
+}  // namespace framework
+}  // namespace paddle
+
+namespace paddle {
+namespace operators {
+
+class CCreateGroupOpNPU : public framework::OperatorBase {
+ public:
+  CCreateGroupOpNPU(const std::string& type,
+              const framework::VariableNameMap& inputs,
+              const framework::VariableNameMap& outputs,
+              const framework::AttributeMap& attrs)
+      : OperatorBase(type, inputs, outputs, attrs) {}
+
+  void RunImpl(const framework::Scope& scope,
+               const platform::Place& place) const override {
+    string group_name = Attr<string>("group_name");
+    int nranks = Attr<int>("nranks");
+    vector<int> rank_ids = Attr<vector<int>>("rank_ids");
+    platform::HCCLCommContext::Instance().CreateHCCLGroup(
+        group_name, nranks, rank_ids);
+  }
+};
+
+class CCreateGroupOpNPUMaker : public framework::OpProtoAndCheckerMaker {
+ public:
+  void Make() override {
+    AddComment(R"DOC(
+CCreateGroup operator on NPU
+
+Create collective communication group on NPU
+)DOC");
+    AddAttr<string>("group_name",
+        "(string) name of the collective communication group");
+    AddAttr<int>("nranks", "(int) number of the group");
+    AddAttr<int>("rank_ids",
+                 "(list of int) The world rank id of the group members");
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
+
+namespace ops = paddle::operators;
+
+REGISTER_OPERATOR(c_create_group, ops::CCreateGroupOpNPU,
+    ops::CCreateGroupNPUMaker);
+
+#endif

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -149,7 +149,7 @@ class NPUDeviceContext;
 
 class HCCLComm {
  public:
-  virtual string rank_table_file() const = "";
+  virtual std::string rank_table_file() const = 0;
   virtual int rank() const = 0;
   virtual int device_id() const = 0;
   virtual HcclComm comm() const = 0;
@@ -168,50 +168,16 @@ class HCCLCommContext {
 
   HCCLComm* CreateHCCLComm(const std::string& config_file, int rank, int dev_id);
 
-  void CreateHCCLGroup(const std::string& group_name, int nranks, const vector<int>& rank_ids);
-/*
-  // a latter comm with the same dev_id and the same ring_id
-  // will override the former
-  HCCLComm* AssignHCCLComm(HcclComm comm, int nranks, int rank, int dev_id,
-                           int ring_id = 0);
-
-  // retrieve a communicator by the ring id in multiprocessing mode
-  HCCLComm* Get(int ring_id) const {
-    PADDLE_ENFORCE_GT(
-        comm_map_.count(ring_id), 0,
-        platform::errors::InvalidArgument(
-            "Communicator in ring id %d has not been initialized.", ring_id));
-    PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(), 1,
-                      platform::errors::InvalidArgument(
-                          "One device id should be specified to retrieve from "
-                          "multiple communicators."));
-    return comm_map_.at(ring_id).begin()->second.get();
-  }
-
-  // retrieve a communicator by the ring id and the device id
-  HCCLComm* Get(int ring_id, int dev_id) const {
-    PADDLE_ENFORCE_GT(
-        comm_map_.count(ring_id), 0,
-        platform::errors::InvalidArgument(
-            "Communicator of ring id %d has not been initialized.", ring_id));
-    PADDLE_ENFORCE_GT(
-        comm_map_.at(ring_id).count(dev_id), 0,
-        platform::errors::InvalidArgument(
-            "Communicator at device id %d has not been initialized in ring %d.",
-            dev_id, ring_id));
-    return comm_map_.at(ring_id).at(dev_id).get();
-  }
+  void CreateHCCLGroup(const std::string& group_name, int nranks, const std::vector<int>& rank_ids);
 
   // retrieve a communicator by the ring id and place
-  HCCLComm* Get(int ring_id, Place place) const {
-    return Get(ring_id, BOOST_GET_CONST(CUDAPlace, place).device);
+  HCCLComm* Get() const {
+    return comm_.get();
   }
-*/
  private:
   std::once_flag once_flag_;
   std::mutex comm_map_mutex_;
-  // rank id to dev-HCCLComm
-  // std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
+  std::unique_ptr<HCCLComm> comm_;
 
   void ReleaseHCCLComms();
 

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#if defined(PADDLE_WITH_NCCL)
 #include <map>
 #include <memory>
 #include <string>
@@ -24,10 +23,12 @@
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/platform/device_context.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/dynload/hccl.h"
 
 namespace paddle {
 namespace platform {
 
+#if defined(PADDLE_WITH_NCCL)
 // In order to apply hierarchical communication with NCCL, we need
 // a communication ring contains NCCL communicators associated to a global
 // ncclUniqueId. E.g. for a hierarchical case,
@@ -47,6 +48,8 @@ namespace platform {
 //
 // The NCCLComm instance is created and reversed in the NCCLCommContext
 // singleton with a global user specified group id.
+class CUDADeviceContext;
+
 class NCCLComm {
  public:
   virtual int ring_id() const = 0;
@@ -120,8 +123,199 @@ class NCCLCommContext {
   NCCLCommContext() = default;
   DISABLE_COPY_AND_ASSIGN(NCCLCommContext);
 };
+#endif
+
+#if defined(PADDLE_WITH_ASCEND_CL)
+// In order to apply hierarchical communication with HCCL, we need
+// a communication ring contains HCCL communicators associated to a global
+// HCCLUniqueId. E.g. for a hierarchical case,
+//
+//    11 - 12   21 - 22
+//     |    |    |    |
+//    13 - 14 - 23 - 24
+//          |    |
+//    31 - 32 - 41 - 42
+//     |    |    |    |
+//    33 - 34   43 - 44
+//
+// we group (14,23,32,41) as the top, and (11,12,13,14), (21,22,23,24),
+// (31,32,33,34), (41,42,43,44) as bottoms respectively.
+//
+// We could also use a single communication ring for the flatten case
+//
+// The HCCLComm instance is created and reversed in the HCCLCommContext
+// singleton with a global user specified group id.
+class ASCENDDeviceContext;
+
+class HCCLComm {
+ public:
+  virtual int ring_id() const = 0;
+  virtual int nranks() const = 0;
+  virtual int rank() const = 0;
+  virtual int device_id() const = 0;
+  virtual HcclComm comm() const = 0;
+  virtual aclrtStream stream() const = 0;
+  virtual ASCENDDeviceContext* dev_context() const = 0;
+  virtual ~HCCLComm() = default;
+};
+
+// A singleton HCCL communicator context reserves communication ring ids
+class HCCLCommContext {
+ public:
+  static HCCLCommContext& Instance() {
+    static HCCLCommContext comm_ctx;
+    return comm_ctx;
+  }
+
+  HCCLComm* CreateHCCLComm(std::string config_file, int nranks, int rank,
+                           int dev_id, int ring_id = 0);
+
+  void CreateAllHCCLComms(const std::vector<int>& dev_ids, int ring_id = 0);
+
+  // a latter comm with the same dev_id and the same ring_id
+  // will override the former
+  HCCLComm* AssignHCCLComm(HcclComm comm, int nranks, int rank, int dev_id,
+                           int ring_id = 0);
+
+  // retrieve a communicator by the ring id in multiprocessing mode
+  HCCLComm* Get(int ring_id) const {
+    PADDLE_ENFORCE_GT(
+        comm_map_.count(ring_id), 0,
+        platform::errors::InvalidArgument(
+            "Communicator in ring id %d has not been initialized.", ring_id));
+    PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(), 1,
+                      platform::errors::InvalidArgument(
+                          "One device id should be specified to retrieve from "
+                          "multiple communicators."));
+    return comm_map_.at(ring_id).begin()->second.get();
+  }
+
+  // retrieve a communicator by the ring id and the device id
+  HCCLComm* Get(int ring_id, int dev_id) const {
+    PADDLE_ENFORCE_GT(
+        comm_map_.count(ring_id), 0,
+        platform::errors::InvalidArgument(
+            "Communicator of ring id %d has not been initialized.", ring_id));
+    PADDLE_ENFORCE_GT(
+        comm_map_.at(ring_id).count(dev_id), 0,
+        platform::errors::InvalidArgument(
+            "Communicator at device id %d has not been initialized in ring %d.",
+            dev_id, ring_id));
+    return comm_map_.at(ring_id).at(dev_id).get();
+  }
+
+  // retrieve a communicator by the ring id and place
+  HCCLComm* Get(int ring_id, Place place) const {
+    return Get(ring_id, BOOST_GET_CONST(CUDAPlace, place).device);
+  }
+
+ private:
+  std::once_flag once_flag_;
+  std::mutex comm_map_mutex_;
+  // ring id to dev-HCCLComm
+  std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
+
+  void ReleaseHCCLComms();
+
+  HCCLCommContext() = default;
+  DISABLE_COPY_AND_ASSIGN(HCCLCommContext);
+};
+#endif
+
+#if defined(PADDLE_WITH_XPU_BKCL)
+// In order to apply hierarchical communication with BKCL, we need
+// a communication ring contains BKCL communicators associated to a global
+// BKCLUniqueId. E.g. for a hierarchical case,
+//
+//    11 - 12   21 - 22
+//     |    |    |    |
+//    13 - 14 - 23 - 24
+//          |    |
+//    31 - 32 - 41 - 42
+//     |    |    |    |
+//    33 - 34   43 - 44
+//
+// we group (14,23,32,41) as the top, and (11,12,13,14), (21,22,23,24),
+// (31,32,33,34), (41,42,43,44) as bottoms respectively.
+//
+// We could also use a single communication ring for the flatten case
+//
+// The BKCLComm instance is created and reversed in the BKCLCommContext
+// singleton with a global user specified group id.
+class BKCLComm {
+ public:
+  virtual int ring_id() const = 0;
+  virtual int nranks() const = 0;
+  virtual int rank() const = 0;
+  virtual int device_id() const = 0;
+  virtual BKCLContext_t comm() const = 0;
+  virtual XPUStream stream() const = 0;
+  virtual XPUDeviceContext* dev_context() const = 0;
+  virtual ~BKCLComm() = default;
+};
+
+// A singleton BKCL communicator context reserves communication ring ids
+class BKCLCommContext {
+ public:
+  static BKCLCommContext& Instance() {
+    static BKCLCommContext comm_ctx;
+    return comm_ctx;
+  }
+
+  BKCLComm* CreateBKCLComm(BKCLUniqueId* bkcl_id, int nranks, int rank,
+                           int dev_id, int ring_id = 0);
+
+  void CreateAllBKCLComms(const std::vector<int>& dev_ids, int ring_id = 0);
+
+  // a latter comm with the same dev_id and the same ring_id
+  // will override the former
+  BKCLComm* AssignBKCLComm(BKCLContext_t comm, int nranks, int rank, int dev_id,
+                           int ring_id = 0);
+
+  // retrieve a communicator by the ring id in multiprocessing mode
+  BKCLComm* Get(int ring_id) const {
+    PADDLE_ENFORCE_GT(
+        comm_map_.count(ring_id), 0,
+        platform::errors::InvalidArgument(
+            "Communicator in ring id %d has not been initialized.", ring_id));
+    PADDLE_ENFORCE_EQ(comm_map_.at(ring_id).size(), 1,
+                      platform::errors::InvalidArgument(
+                          "One device id should be specified to retrieve from "
+                          "multiple communicators."));
+    return comm_map_.at(ring_id).begin()->second.get();
+  }
+
+  // retrieve a communicator by the ring id and the device id
+  BKCLComm* Get(int ring_id, int dev_id) const {
+    PADDLE_ENFORCE_GT(
+        comm_map_.count(ring_id), 0,
+        platform::errors::InvalidArgument(
+            "Communicator of ring id %d has not been initialized.", ring_id));
+    PADDLE_ENFORCE_GT(
+        comm_map_.at(ring_id).count(dev_id), 0,
+        platform::errors::InvalidArgument(
+            "Communicator at device id %d has not been initialized in ring %d.",
+            dev_id, ring_id));
+    return comm_map_.at(ring_id).at(dev_id).get();
+  }
+
+  // retrieve a communicator by the ring id and place
+  BKCLComm* Get(int ring_id, Place place) const {
+    return Get(ring_id, BOOST_GET_CONST(XPUPlace, place).device);
+  }
+
+ private:
+  std::once_flag once_flag_;
+  std::mutex comm_map_mutex_;
+  // ring id to dev-BKCLComm
+  std::map<int, std::map<int, std::unique_ptr<BKCLComm>>> comm_map_;
+
+  void ReleaseBKCLComms();
+
+  BKCLCommContext() = default;
+  DISABLE_COPY_AND_ASSIGN(BKCLCommContext);
+};
+#endif
 
 }  // namespace platform
 }  // namespace paddle
-
-#endif

--- a/paddle/fluid/platform/collective_helper.h
+++ b/paddle/fluid/platform/collective_helper.h
@@ -145,17 +145,16 @@ class NCCLCommContext {
 //
 // The HCCLComm instance is created and reversed in the HCCLCommContext
 // singleton with a global user specified group id.
-class ASCENDDeviceContext;
+class NPUDeviceContext;
 
 class HCCLComm {
  public:
-  virtual int ring_id() const = 0;
-  virtual int nranks() const = 0;
+  virtual string rank_table_file() const = "";
   virtual int rank() const = 0;
   virtual int device_id() const = 0;
   virtual HcclComm comm() const = 0;
   virtual aclrtStream stream() const = 0;
-  virtual ASCENDDeviceContext* dev_context() const = 0;
+  virtual NPUDeviceContext* dev_context() const = 0;
   virtual ~HCCLComm() = default;
 };
 
@@ -167,11 +166,10 @@ class HCCLCommContext {
     return comm_ctx;
   }
 
-  HCCLComm* CreateHCCLComm(std::string config_file, int nranks, int rank,
-                           int dev_id, int ring_id = 0);
+  HCCLComm* CreateHCCLComm(const std::string& config_file, int rank, int dev_id);
 
-  void CreateAllHCCLComms(const std::vector<int>& dev_ids, int ring_id = 0);
-
+  void CreateHCCLGroup(const std::string& group_name, int nranks, const vector<int>& rank_ids);
+/*
   // a latter comm with the same dev_id and the same ring_id
   // will override the former
   HCCLComm* AssignHCCLComm(HcclComm comm, int nranks, int rank, int dev_id,
@@ -208,12 +206,12 @@ class HCCLCommContext {
   HCCLComm* Get(int ring_id, Place place) const {
     return Get(ring_id, BOOST_GET_CONST(CUDAPlace, place).device);
   }
-
+*/
  private:
   std::once_flag once_flag_;
   std::mutex comm_map_mutex_;
-  // ring id to dev-HCCLComm
-  std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
+  // rank id to dev-HCCLComm
+  // std::map<int, std::map<int, std::unique_ptr<HCCLComm>>> comm_map_;
 
   void ReleaseHCCLComms();
 

--- a/paddle/fluid/platform/collective_helper_npu.cc
+++ b/paddle/fluid/platform/collective_helper_npu.cc
@@ -1,0 +1,137 @@
+//   Copyright (c) 2019 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(PADDLE_WITH_ASCEND_CL)
+#include "paddle/fluid/platform/collective_helper.h"
+#include <utility>
+
+namespace paddle {
+namespace platform {
+
+class HCCLCommImpl : public HCCLComm {
+ public:
+  void set_rank_table_file(std::string rank_table_file) { rank_table_file_ = rank_table_file; }
+  std::string rank_table_file() const override { return rank_table_file_; }
+
+  void set_rank(int rank) { rank_ = rank; }
+  int rank() const override { return rank_; }
+
+  void set_device_id(int device_id) { device_id_ = device_id; }
+  int device_id() const override { return device_id_; }
+
+  void set_comm(HcclComm comm) { comm_ = comm; }
+  HcclComm comm() const override { return comm_; }
+
+  aclrtStream stream() const override { return dev_ctx_->stream(); }
+
+  void set_dev_ctx(std::unique_ptr<NPUDeviceContext>&& dev_ctx) {
+    dev_ctx_ = std::move(dev_ctx);
+  }
+  NPUDeviceContext* dev_context() const override { return dev_ctx_.get(); }
+
+ private:
+  std::string rank_table_file_;
+  int rank_;
+  int device_id_;
+  HcclComm comm_;
+  std::unique_ptr<DeviceContext> dev_ctx_;
+};
+
+NCCLComm* HCCLCommContext::CreateHCCLComm(const std::string& rank_table_file,
+                                          int rank, int dev_id) {
+  PADDLE_ENFORCE_NOT_NULL(rank_table_file,
+                          platform::errors::InvalidArgument(
+                              "The rank table file should not be null."));
+  PADDLE_ENFORCE_GE(rank, 0,
+                    platform::errors::InvalidArgument(
+                        "Expected rank >= 0. But received rank is %d.", rank));
+  PADDLE_ENFORCE_GE(
+      dev_id, 0,
+      platform::errors::InvalidArgument(
+          "Expected dev_id >= 0. But received dev_id is %d.", dev_id));
+
+  HcclComm comm = nullptr;
+  PADDLE_ENFORCE_NPU_SUCCESS(aclrtSetDevice(dev_id));
+  PADDLE_ENFORCE_NPU_SUCCESS(
+      platform::dynload::HcclCommInitClusterInfo(rank_table_file, rank, &comm));
+
+  auto* comm_wrapper = AssignHCCLComm(comm, nranks, rank, dev_id, ring_id);
+
+  VLOG(1) << "hccl communicator of rank " << rank << " has been created on device " << dev_id;
+
+  std::call_once(once_flag_, []() {
+    std::atexit([]() { HCCLCommContext::Instance().ReleaseHCCLComms(); });
+  });
+
+  return comm_wrapper;
+}
+
+NCCLComm* HCCLCommContext::AssignHCCLComm(ncclComm_t comm, string rank_table_file, int rank, int dev_id) {
+  std::unique_ptr<NPUDeviceContext> dev_ctx(
+      new NPUDeviceContext(NPUPlace(dev_id)));
+
+  HCCLCommImpl* c = new HCCLCommImpl;
+  c->set_rank_table_file(rank_table_file);
+  c->set_rank(rank);
+  c->set_device_id(dev_id);
+  c->set_comm(comm);
+  c->set_dev_ctx(std::move(dev_ctx));
+
+  // comm_map_mutex_.lock();
+  // if (comm_map_.count(ring_id) == 0) {
+  //   comm_map_.emplace(ring_id, std::map<int, std::unique_ptr<NCCLComm>>());
+  // }
+  // auto& dev2comm = comm_map_[ring_id];
+
+  // dev2comm.emplace(dev_id, std::unique_ptr<NCCLComm>(c));
+  // comm_map_mutex_.unlock();
+
+  auto* dev_ctx = static_cast<platform::NPUDeviceContext*>(
+      platform::DeviceContextPool::Instance().Get(platform::NPUPlace(dev_id)));
+  dev_ctx->set_hccl_comm(comm);
+
+  // return comm_map_[ring_id][dev_id].get();
+  return c;
+}
+
+void HCCLCommContext::CreateHCCLGroup(const std::string& group_name, int nranks,
+  const vector<int>& rank_ids) {
+  PADDLE_ENFORCE_NOT_NULL(group_name,
+                          platform::errors::InvalidArgument(
+                              "The group name should not be null."));
+  PADDLE_ENFORCE_GT(nranks, 0,
+                    platform::errors::InvalidArgument(
+                        "Expected nranks > 0. But received nranks is %d.", nranks));
+  PADDLE_ENFORCE_NOT_NULL(rank_inds,
+                          platform::errors::InvalidArgument(
+                              "The rank ids should not be null."));
+
+  PADDLE_ENFORCE_NPU_SUCCESS(
+      platform::dynload::HcclCommInitClusterInfo(rank_table_file, rank, &comm));
+
+  VLOG(1) << "hccl group with name " << group_name << " has been created;
+}
+
+void HCCLCommContext::ReleaseHCCLComms() {
+  // for (auto& p : comm_map_) {
+  //   for (auto& q : p.second) {
+  //     q.second.reset();
+  //   }
+  // }
+}
+
+}  // namespace platform
+}  // namespace paddle
+
+#endif

--- a/paddle/fluid/platform/dynload/dynamic_loader.cc
+++ b/paddle/fluid/platform/dynload/dynamic_loader.cc
@@ -36,6 +36,11 @@ DEFINE_string(nccl_dir, "",
               "For instance, /usr/local/cuda/lib64. If default, "
               "dlopen will search cuda from LD_LIBRARY_PATH");
 
+DEFINE_string(hccl_dir, "",
+              "Specify path for loading hccl library, such as libhccl.so. "
+              "For instance, /usr/local/Ascend/ascend-toolkit/latest/fwkacllib/lib64/. If default, "
+              "dlopen will search hccl from LD_LIBRARY_PATH");
+
 DEFINE_string(cupti_dir, "", "Specify path for loading cupti.so.");
 
 DEFINE_string(
@@ -383,6 +388,26 @@ void* GetNCCLDsoHandle() {
                                     warning_msg);
 #endif
 }
+void* GetHCCLDsoHandle() {
+  std::string warning_msg(
+      "You may need to install 'hccl2' from Huawei official website: "
+      "before install PaddlePaddle.");
+#if defined(__APPLE__) || defined(__OSX__)
+  return GetDsoHandleFromSearchPath(FLAGS_nccl_dir, "libnccl.dylib", true, {},
+                                    warning_msg);
+#elif defined(PADDLE_WITH_HIP) && defined(PADDLE_WITH_RCCL)
+  return GetDsoHandleFromSearchPath(FLAGS_rccl_dir, "librccl.so", true);
+
+#elif defined(PADDLE_WITH_ASCEND_CL)
+  return GetDsoHandleFromSearchPath(FLAGS_hccl_dir, "libhccl.so", true, {},
+                                    warning_msg);
+#else
+  return GetDsoHandleFromSearchPath(FLAGS_nccl_dir, "libnccl.so", true, {},
+                                    warning_msg);
+#endif
+}
+
+
 
 void* GetTensorRtDsoHandle() {
 #if defined(__APPLE__) || defined(__OSX__)

--- a/paddle/fluid/platform/dynload/hccl.cc
+++ b/paddle/fluid/platform/dynload/hccl.cc
@@ -12,34 +12,27 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
-#pragma once
-#include <string>
+#include "paddle/fluid/platform/dynload/hccl.h"
 
 namespace paddle {
 namespace platform {
 namespace dynload {
 
-#ifndef _WIN32
-#define DECLARE_TYPE(__name, ...) decltype(__name(__VA_ARGS__))
-#else
-#define DECLARE_TYPE(__name, ...) decltype(auto)
+std::once_flag hccl_dso_flag;
+void *hccl_dso_handle;
+
+#define DEFINE_WRAP(__name) DynLoad__##__name __name
+
+HCCL_RAND_ROUTINE_EACH(DEFINE_WRAP);
+
+#if HCCL_VERSION_CODE >= 2212
+HCCL_RAND_ROUTINE_EACH_AFTER_2212(DEFINE_WRAP)
 #endif
 
-void* GetCublasDsoHandle();
-void* GetCUDNNDsoHandle();
-void* GetCUPTIDsoHandle();
-void* GetCurandDsoHandle();
-void* GetCusolverDsoHandle();
-void* GetNVRTCDsoHandle();
-void* GetCUDADsoHandle();
-void* GetWarpCTCDsoHandle();
-void* GetNCCLDsoHandle();
-void* GetHCCLDsoHandle();
-void* GetTensorRtDsoHandle();
-void* GetMKLMLDsoHandle();
-void* GetOpDsoHandle(const std::string& dso_name);
+#if HCCL_VERSION_CODE >= 2703
+HCCL_RAND_ROUTINE_EACH_AFTER_2703(DEFINE_WRAP)
+#endif
 
-void SetPaddleLibPath(const std::string&);
 }  // namespace dynload
 }  // namespace platform
 }  // namespace paddle

--- a/paddle/fluid/platform/dynload/hccl.h
+++ b/paddle/fluid/platform/dynload/hccl.h
@@ -1,0 +1,113 @@
+/* Copyright (c) 2016 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+#pragma once
+
+#include <hccl/hccl.h>
+#include <hccl/hccl_types.h>
+#include <mutex>  // NOLINT
+
+#include "paddle/fluid/platform/dynload/dynamic_loader.h"
+#include "paddle/fluid/platform/port.h"
+
+
+// typedef enum tagHcclDataType {
+//     HCCL_DATA_TYPE_INT8 = 0,  /**< int8 */
+//     HCCL_DATA_TYPE_INT = 1,   /**< int32 */
+//     HCCL_DATA_TYPE_HALF = 2,  /**< fp16 */
+//     HCCL_DATA_TYPE_FLOAT = 3, /**< fp32 */
+//     HCCL_DATA_TYPE_RESERVED   /**< reserved */
+// } hcclDataType_t;
+
+// typedef enum tagHcclResult {
+//     HCCL_SUCCESS = 0,               /**< success */
+//     HCCL_E_PARA = 1,                /**< parameter error */
+//     HCCL_E_PTR = 2,                 /**< empty pointer */
+//     HCCL_E_MEMORY = 3,              /**< memory error */
+//     HCCL_E_INTERNAL = 4,            /**< internal error */
+//     HCCL_E_NOT_SUPPORT = 5,         /**< not support feature */
+//     HCCL_E_NOT_FOUND = 6,           /**< not found specific resource */
+//     HCCL_E_UNAVAIL = 7,             /**< resource unavailable */
+//     HCCL_E_SYSCALL = 8,             /**< call system interface error */
+//     HCCL_E_TIMEOUT = 9,             /**< timeout */
+//     HCCL_E_OPEN_FILE_FAILURE = 10,  /**< open file fail */
+//     HCCL_E_TCP_CONNECT = 11,        /**< tcp connect fail */
+//     HCCL_E_ROCE_CONNECT = 12,       /**< roce connect fail */
+//     HCCL_E_TCP_TRANSFER = 13,       /**< tcp transfer fail */
+//     HCCL_E_ROCE_TRANSFER = 14,      /**< roce transfer fail */
+//     HCCL_E_RUNTIME = 15,            /**< call runtime api fail */
+//     HCCL_E_DRV = 16,                /**< call driver api fail */
+//     HCCL_E_PROFILING = 17,          /**< call profiling api fail */
+//     HCCL_E_CCE = 18,                /**< call cce api fail */
+//     HCCL_E_NETWORK = 19,            /**< call network api fail */
+//     HCCL_E_RESERVED                 /**< reserved */
+// } hcclResult_t;
+
+HcclResult HcomCreateGroup(const char *group, uint32_t rankNum, uint32_t *rankIds);
+HcclResult HcomSend(const char *tag, void *inputPtr, uint64_t count, HcclDataType dataType,
+    uint32_t destRank, uint32_t srTag, const char *group, void* stream);
+HcclResult HcomReceive(const char *tag, void *outputPtr, uint64_t count, HcclDataType dataType,
+    uint32_t srcRank, uint32_t srTag, const char *group, void* stream);
+
+
+namespace paddle {
+namespace platform {
+namespace dynload {
+
+extern std::once_flag HCCL_dso_flag;
+extern void* HCCL_dso_handle;
+
+#define DECLARE_DYNAMIC_LOAD_HCCL_WRAP(__name)                           \
+  struct DynLoad__##__name {                                             \
+    template <typename... Args>                                          \
+    auto operator()(Args... args) -> decltype(__name(args...)) {         \
+      using HCCL_func = decltype(&::__name);                             \
+      std::call_once(HCCL_dso_flag, []() {                               \
+        HCCL_dso_handle = paddle::platform::dynload::GetHCCLDsoHandle(); \
+      });                                                                \
+      static void* p_##__name = dlsym(HCCL_dso_handle, #__name);         \
+      return reinterpret_cast<HCCL_func>(p_##__name)(args...);           \
+    }                                                                    \
+  };                                                                     \
+  extern DynLoad__##__name __name
+
+#define HCCL_RAND_ROUTINE_EACH(__macro) \
+  __macro(HcclCommInitClusterInfo);     \
+  __macro(HcclGetRootInfo);             \
+  __macro(HcclCommInitRootInfo);        \
+  __macro(HcclAllReduce);               \
+  __macro(HcclBroadcast);               \
+  __macro(HcomCreateGroup);             \
+  __macro(HcomSend);                    \
+  __macro(HcomReceive);                 \
+  __macro(HcclAllGather);               \
+  __macro(HcclReduceScatter);           \
+  __macro(HcclCommDestroy); 
+
+HCCL_RAND_ROUTINE_EACH(DECLARE_DYNAMIC_LOAD_HCCL_WRAP)
+
+#if HCCL_VERSION_CODE >= 2212
+#define HCCL_RAND_ROUTINE_EACH_AFTER_2212(__macro) __macro(HCCLBroadcast);
+HCCL_RAND_ROUTINE_EACH_AFTER_2212(DECLARE_DYNAMIC_LOAD_HCCL_WRAP)
+#endif
+
+#if HCCL_VERSION_CODE >= 2703
+#define HCCL_RAND_ROUTINE_EACH_AFTER_2703(__macro) \
+  __macro(HCCLSend);                               \
+  __macro(HCCLRecv);
+HCCL_RAND_ROUTINE_EACH_AFTER_2703(DECLARE_DYNAMIC_LOAD_HCCL_WRAP)
+#endif
+
+}  // namespace dynload
+}  // namespace platform
+}  // namespace paddle

--- a/paddle/fluid/platform/hccl_helper.h
+++ b/paddle/fluid/platform/hccl_helper.h
@@ -1,0 +1,372 @@
+//   Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL) || defined(PADDLE_WITH_ASCEND_CL)
+
+#include <stdio.h>
+#include <memory>
+#include <string>
+#include <thread>  // NOLINT
+#include <typeindex>
+#include <unordered_map>
+#include <vector>
+
+#include "paddle/fluid/framework/data_type.h"
+#include "paddle/fluid/platform/collective_helper.h"
+
+#ifdef PADDLE_WITH_NCCL
+#include "paddle/fluid/platform/dynload/nccl.h"
+#endif
+
+#ifdef PADDLE_WITH_RCCL
+#include "paddle/fluid/platform/dynload/rccl.h"
+#endif
+
+#ifdef PADDLE_WITH_ASCEND_CL
+#include "paddle/fluid/platform/dynload/hccl.h"
+#endif
+
+#include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/platform/float16.h"
+
+#define NCCL_ID_VARNAME "NCCLID"
+
+namespace paddle {
+namespace platform {
+  
+// HcclDataType description
+// HCCL_DATA_TYPE_INT8 = 0,   /**< int8 */
+// HCCL_DATA_TYPE_INT16 = 1,  /**< int16 */
+// HCCL_DATA_TYPE_INT32 = 2,  /**< int32 */
+// HCCL_DATA_TYPE_FP16 = 3,   /**< fp16 */
+// HCCL_DATA_TYPE_FP32 = 4,   /**< fp32 */
+// HCCL_DATA_TYPE_INT64 = 5,  /**< int64 */
+// HCCL_DATA_TYPE_UINT64 = 6, /**< uint64 */
+
+inline HcclDataType ToHCCLDataType(framework::proto::VarType::Type type) {
+  if (type == framework::proto::VarType::FP32) {
+    return HCCL_DATA_TYPE_FP32;
+  } else if (type == framework::proto::VarType::FP16) {
+    return HCCL_DATA_TYPE_FP16;
+  }else if (type == framework::proto::VarType::INT32) {
+    return HCCL_DATA_TYPE_INT32;
+  } else if (type == framework::proto::VarType::INT64) {
+    return HCCL_DATA_TYPE_INT64;
+  // } 
+  // } else if (type == framework::proto::VarType::FP64) {
+  //   return HCCL_DATA_TYPE_FP32;
+  }else {
+    PADDLE_THROW(platform::errors::Unimplemented(
+        "This datatype in hccl is not supported."));
+  }
+}
+
+// // NOTE(minqiyang): according to the ncclGroupEnd documentations:
+// // https://docs.nvidia.com/deeplearning/sdk/nccl-api/ncclapidoc.html,
+// // ncclGroupEnd will wait for all communicators to be initialized, which will
+// // cause blocking problem when a runtime_error was thrown, so try only guard
+// // NCCL actions when use it.
+// class NCCLGroupGuard {
+//  public:
+//   static std::mutex &NCCLMutex() {
+//     static std::mutex mtx;
+//     return mtx;
+//   }
+
+//   inline NCCLGroupGuard() {
+//     NCCLMutex().lock();
+//     PADDLE_ENFORCE_CUDA_SUCCESS(dynload::ncclGroupStart());
+//   }
+
+//   inline ~NCCLGroupGuard() PADDLE_MAY_THROW {
+//     PADDLE_ENFORCE_CUDA_SUCCESS(dynload::ncclGroupEnd());
+//     NCCLMutex().unlock();
+//   }
+// };
+
+// struct NCCLContext {
+//   std::unique_ptr<CUDADeviceContext> ctx_;
+//   ncclComm_t comm_;
+
+//   explicit NCCLContext(int dev_id)
+//       : ctx_(new CUDADeviceContext(CUDAPlace(dev_id))), comm_{nullptr} {}
+
+//   gpuStream_t stream() const { return ctx_->stream(); }
+//   ncclComm_t comm() const { return comm_; }
+
+//   int device_id() const {
+//     return BOOST_GET_CONST(platform::CUDAPlace, ctx_->GetPlace()).device;
+//   }
+// };
+
+// struct NCCLContextMap {
+//   std::unordered_map<int, NCCLContext> contexts_;
+//   std::vector<int> order_;
+
+//   explicit NCCLContextMap(const std::vector<platform::Place> &places,
+//                           ncclUniqueId *nccl_id = nullptr,
+//                           size_t num_trainers = 1, size_t trainer_id = 0) {
+//     PADDLE_ENFORCE_EQ(!places.empty(), true,
+//                       platform::errors::InvalidArgument(
+//                           "The NCCL place should not be empty."));
+//     order_.reserve(places.size());
+//     for (auto &p : places) {
+//       int dev_id = BOOST_GET_CONST(CUDAPlace, p).device;
+//       order_.emplace_back(dev_id);
+//       contexts_.emplace(dev_id, NCCLContext(dev_id));
+//     }
+//     PADDLE_ENFORCE_EQ(
+//         order_.size(), contexts_.size(),
+//         platform::errors::Unavailable("NCCL Context Map does not support "
+//                                       "contain two or more same device."));
+
+//     std::unique_ptr<ncclComm_t[]> comms(new ncclComm_t[order_.size()]);
+//     // if num_trainers == 1, should create a new nccl id for local comms.
+//     if (num_trainers == 1 && nccl_id == nullptr) {
+//       std::lock_guard<std::mutex> guard(NCCLGroupGuard::NCCLMutex());
+//       PADDLE_RETRY_CUDA_SUCCESS(platform::dynload::ncclCommInitAll(
+//           comms.get(), static_cast<int>(order_.size()), order_.data()));
+//     } else {
+//       PADDLE_ENFORCE_NOT_NULL(nccl_id, platform::errors::InvalidArgument(
+//                                            "The NCCL id should not be null."));
+//       {
+//         int nranks = num_trainers * order_.size();
+//         NCCLGroupGuard gurad;
+//         for (size_t i = 0; i < order_.size(); ++i) {
+//           int gpu_id = order_[i];
+//           int rank;
+//           if (order_.size() > 1) {
+//             rank = trainer_id * order_.size() + i;
+//           } else {
+//             rank = trainer_id;
+//           }
+//           VLOG(1) << "init nccl rank:" << rank << ", nranks:" << nranks
+//                   << ", gpu_id:" << gpu_id << ", dev_id:" << order_[i];
+//           SetDeviceId(gpu_id);
+//           PADDLE_RETRY_CUDA_SUCCESS(platform::dynload::ncclCommInitRank(
+//               comms.get() + i, nranks, *nccl_id, rank));
+//         }
+//       }
+//     }
+//     int i = 0;
+//     for (auto &dev_id : order_) {
+//       contexts_.at(dev_id).comm_ = comms[i++];
+//     }
+//   }
+
+//   NCCLContextMap(const NCCLContextMap &other) = delete;
+//   NCCLContextMap &operator=(const NCCLContextMap &other) = delete;
+
+//   CUDADeviceContext *DevCtx(int dev_id) const { return at(dev_id).ctx_.get(); }
+
+//   CUDADeviceContext *DevCtx(platform::Place p) const {
+//     return DevCtx(BOOST_GET_CONST(CUDAPlace, p).device);
+//   }
+
+//   const NCCLContext &at(platform::Place p) const {
+//     return this->at(BOOST_GET_CONST(CUDAPlace, p).device);
+//   }
+
+//   const NCCLContext &at(int dev_id) const { return contexts_.at(dev_id); }
+
+//   void WaitAll() {
+//     for (auto &p : contexts_) {
+//       p.second.ctx_->Wait();
+//     }
+//   }
+// };
+
+// inline std::string GetFlatNCCLVarName(size_t pos) {
+//   if (pos == 0) {
+//     return NCCL_ID_VARNAME;
+//   }
+//   return string::Sprintf("%s_%d", NCCL_ID_VARNAME, static_cast<int>(pos));
+// }
+
+// inline std::string GetHierarchicalExterNCCLVarName(size_t pos) {
+//   return string::Sprintf("Hierarchical_exter_%s_%d", NCCL_ID_VARNAME,
+//                          static_cast<int>(pos));
+// }
+// inline std::string GetHierarchicalInterNCCLVarName(size_t pos) {
+//   return string::Sprintf("Hierarchical_inter_%s_%d", NCCL_ID_VARNAME,
+//                          static_cast<int>(pos));
+// }
+
+// class NCCLCommunicator {
+//  public:
+//   NCCLCommunicator() {}
+//   virtual ~NCCLCommunicator() PADDLE_MAY_THROW {}
+
+//   NCCLContextMap *DefaultFlatCtx() const {
+//     if (flat_ctxs_.size() == 0) {
+//       return nullptr;
+//     }
+
+//     return flat_ctxs_[0].get();
+//   }
+
+//   std::vector<std::unique_ptr<NCCLContextMap>> *GetFlatCtxs() {
+//     return &flat_ctxs_;
+//   }
+
+//   NCCLContextMap *GetFlatCtx(size_t run_order) const {
+//     return flat_ctxs_[run_order % flat_ctxs_.size()].get();
+//   }
+
+//   NCCLContextMap *GetRunEnvNCCLCtx(size_t run_order,
+//                                    bool use_hierarchical_allreduce) const {
+//     if (!use_hierarchical_allreduce) {
+//       return GetFlatCtx(run_order);
+//     }
+
+//     return GetHierarchicalInterCtx(run_order);
+//   }
+
+  
+//    *When nccl inits nccl comm using ncclCommInitAll, it meets error when
+//    *allreduce ophandle and sync_batch_norm_op use ncclallreduce parallelly. So
+//    *create a new nccl comm for sync_batch_norm_op. And these codes should be
+//    *polished with a unified nccl management.
+  
+//   NCCLContextMap *GetSyncBatchNormCtx(
+//       framework::Scope *scope, const std::vector<platform::Place> &places) {
+//     auto *nccl_id_var = scope->FindVar(NCCL_ID_VARNAME);
+//     if (nccl_id_var != nullptr) {
+//       return DefaultFlatCtx();
+//     }
+
+//     if (sync_batch_norm_ctx_.get() == nullptr) {
+//       sync_batch_norm_ctx_.reset(new NCCLContextMap(places));
+//     }
+//     return sync_batch_norm_ctx_.get();
+//   }
+
+//   void InitFlatCtxs(const std::vector<platform::Place> &places,
+//                     const std::vector<ncclUniqueId *> &nccl_ids,
+//                     size_t trainers_num, size_t trainer_id) {
+//     if (nccl_ids.size() == 0) {
+//       auto ptr = new platform::NCCLContextMap(places);
+//       VLOG(1) << "init local trainer";
+//       flat_ctxs_.emplace_back(ptr);
+//     } else {
+//       for (size_t i = 0; i < nccl_ids.size(); i++) {
+//         auto ptr = new platform::NCCLContextMap(places, nccl_ids[i],
+//                                                 trainers_num, trainer_id);
+//         VLOG(1) << "init trainer_id:" << trainer_id << ", comm no:" << i;
+//         flat_ctxs_.emplace_back(ptr);
+//       }
+//     }
+
+//     // as Executor have no way to use ncclComm created by ParallelExecutor,
+//     // we assign all flatten contexts to NCCLCommContext to fix.
+//     int nranks = static_cast<int>(trainers_num * places.size());
+//     int nrings = static_cast<int>(flat_ctxs_.size());
+//     for (int ring_id = 0; ring_id < nrings; ++ring_id) {
+//       for (size_t p = 0; p < places.size(); ++p) {
+//         int rank = trainer_id * places.size() + p;
+//         int dev_id = BOOST_GET_CONST(CUDAPlace, places[p]).device;
+//         auto &ctx = flat_ctxs_[ring_id]->contexts_.at(dev_id);
+//         NCCLCommContext::Instance().AssignNCCLComm(ctx.comm_, nranks, rank,
+//                                                    dev_id, ring_id);
+//       }
+//     }
+//   }
+
+//   void InitHierarchicalCtxs(const std::vector<platform::Place> &places,
+//                             const std::vector<ncclUniqueId *> &inter_nccl_ids,
+//                             const std::vector<ncclUniqueId *> &exter_nccl_ids,
+//                             size_t trainers_num, size_t trainer_id,
+//                             size_t inter_trainers_num,
+//                             size_t exter_trainers_num) {
+//     PADDLE_ENFORCE_EQ(
+//         trainers_num, inter_trainers_num * exter_trainers_num,
+//         platform::errors::InvalidArgument(
+//             "trainers_num:%llu != inter_trainers_num:%llu * "
+//             "exter_trainers_num:%llu",
+//             trainers_num, inter_trainers_num, exter_trainers_num));
+
+//     PADDLE_ENFORCE_GT(
+//         inter_trainers_num, 1,
+//         platform::errors::InvalidArgument(
+//             "The inter_trainers_num:%llu should be larger than 1.",
+//             inter_trainers_num));
+
+//     int inter_trainer_id = trainer_id % inter_trainers_num;
+//     for (size_t i = 0; i < inter_nccl_ids.size(); i++) {
+//       VLOG(1) << "init inter_trainer_id:" << inter_trainer_id
+//               << ", comm no:" << i;
+//       auto local = new NCCLContextMap(places, inter_nccl_ids[i],
+//                                       inter_trainers_num, inter_trainer_id);
+
+//       h_inter_ctxs_.emplace_back(local);
+//     }
+
+//     int exter_trainer_id = -1;
+//     if (trainer_id % inter_trainers_num == 0) {
+//       exter_trainer_id = trainer_id / inter_trainers_num;
+//     }
+
+//     if (exter_trainer_id >= 0) {
+//       for (size_t i = 0; i < exter_nccl_ids.size(); i++) {
+//         auto ex = new NCCLContextMap(places, exter_nccl_ids[i],
+//                                      exter_trainers_num, exter_trainer_id);
+//         VLOG(1) << "init exter_trainer_id:" << exter_trainer_id
+//                 << ", comm no:" << i;
+//         h_exter_ctxs_.emplace_back(ex);
+//       }
+//     }
+//   }
+
+//   bool NeedExterAllReduce() const { return h_exter_ctxs_.size() > 0; }
+
+//   NCCLContextMap *GetHierarchicalInterCtx(size_t run_order) const {
+//     PADDLE_ENFORCE_GT(h_inter_ctxs_.size(), 0,
+//                       platform::errors::InvalidArgument(
+//                           "Hierarchical ctxs should be initialized firstly!"));
+//     return h_inter_ctxs_[run_order % h_inter_ctxs_.size()].get();
+//   }
+
+//   NCCLContextMap *GetHierarchicalExterCtx(size_t run_order) const {
+//     PADDLE_ENFORCE_GT(h_exter_ctxs_.size(), 0,
+//                       platform::errors::InvalidArgument(
+//                           "Hierarchical ctxs should be initialized firstly!"));
+//     return h_exter_ctxs_[run_order % h_exter_ctxs_.size()].get();
+//   }
+
+//   std::vector<std::unique_ptr<NCCLContextMap>> *GetHierarchicalInterCtxs() {
+//     return &h_inter_ctxs_;
+//   }
+
+//   std::vector<std::unique_ptr<NCCLContextMap>> *GetHierarchicalExterCtxs() {
+//     return &h_exter_ctxs_;
+//   }
+
+//  protected:
+//   // Support multi nccl comm on default nccl ring while NCCLContextMap can't.
+//   std::vector<std::unique_ptr<NCCLContextMap>> flat_ctxs_;
+
+//   // h_inter_ctxs_ and h_exter_ctxs_ are for 2d allreduce.
+//   // And h_exter_ctxs_ can support multi comm too.
+//   std::vector<std::unique_ptr<NCCLContextMap>> h_inter_ctxs_;
+//   std::vector<std::unique_ptr<NCCLContextMap>> h_exter_ctxs_;
+
+//   // just used for sync_batch_norm op.
+//   std::unique_ptr<NCCLContextMap> sync_batch_norm_ctx_;
+// };
+
+}  // namespace platform
+}  // namespace paddle
+#endif


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
Build kernels for CCommInitOp and CCreateGroupOp.

CCommInitOp is used to initialize HcclComm object, which is the communicator for all collective communications on HCCL platform.
CCreateGroupOp is used to build custom rings on HCCL platform.