### PR TITLE
[Kunlun]add xpu support for spawn

### DIFF
--- a/paddle/fluid/pybind/global_value_getter_setter.cc
+++ b/paddle/fluid/pybind/global_value_getter_setter.cc
@@ -87,6 +87,10 @@ DECLARE_uint64(reallocate_gpu_memory_in_mb);
 // others
 DECLARE_bool(sync_nccl_allreduce);
 #endif
+#ifdef PADDLE_WITH_XPU
+// device management
+DECLARE_string(selected_xpus);
+#endif
 #ifdef PADDLE_WITH_DISTRIBUTE
 DECLARE_int32(rpc_send_thread_num);
 DECLARE_int32(rpc_get_thread_num);
@@ -364,6 +368,9 @@ static void RegisterGlobalVarGetterSetter() {
       FLAGS_fraction_of_gpu_memory_to_use, FLAGS_initial_gpu_memory_in_mb,
       FLAGS_reallocate_gpu_memory_in_mb, FLAGS_enable_cublas_tensor_op_math,
       FLAGS_selected_gpus, FLAGS_sync_nccl_allreduce);
+#endif
+#ifdef PADDLE_WITH_XPU
+  REGISTER_PUBLIC_GLOBAL_VAR(FLAGS_selected_xpus);
 #endif
 #ifdef PADDLE_WITH_DITRIBUTE
   REGISTER_PUBLIC_GLOBAL_VAR(FLAGS_rpc_send_thread_num,

--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -73,7 +73,7 @@ def _py_supported_check():
 
 def _options_valid_check(options):
     # `print_config` keeped as a debug options, not show to users
-    supported_options = ['start_method', 'ips', 'gpus', 'print_config']
+    supported_options = ['start_method', 'ips', 'gpus', 'xpus', 'print_config']
     deprecated_options = [
         'selected_gpus', 'started_port', 'cluster_node_ips', 'node_ip',
         'use_paddlecloud'
@@ -159,9 +159,9 @@ def _get_subprocess_env_list(nprocs, options):
                                      (card_id, ",".join(env_devices_list)))
 
     if core.is_compiled_with_xpu():
-        args.selected_xpus = options.get('xpus', None)
+        args.selected_gpus = options.get('xpus', None)
         if args.selected_xpus is None:
-            args.selected_xpus = options.get('selected_xpus', None)
+            args.selected_gpus = options.get('selected_gpus', None)
         env_devices = os.getenv("XPU_VISIBLE_DEVICES", None)
         if env_devices is None or env_devices == "":
             env_devices_list = [
@@ -169,7 +169,7 @@ def _get_subprocess_env_list(nprocs, options):
             ]
         else:
             env_devices_list = env_devices.split(',')
-        if args.selected_xpus is None:
+        if args.selected_gpus is None:
             if len(env_devices_list) < nprocs:
                 raise RuntimeError(
                     "the number of visible devices(%d) is less than the number "
@@ -177,17 +177,17 @@ def _get_subprocess_env_list(nprocs, options):
                     "`nprocs` argument is passed or the environment variable "
                     "`XPU_VISIBLE_DEVICES` is correctly configured." %
                     (len(env_devices_list), nprocs))
-            args.selected_xpus = ",".join(
+            args.selected_gpus = ",".join(
                 [str(env_devices_list[x]) for x in range(0, nprocs)])
         else:
-            selected_xpu_list = args.selected_xpus.split(',')
-            if len(selected_xpu_list) != nprocs:
+            selected_gpu_list = args.selected_gpus.split(',')
+            if len(selected_gpu_list) != nprocs:
                 raise ValueError(
                     "The number of selected gpus(%s) is not equal to "
                     "the number of spawn processes(%d), please ensure that the "
                     "correct `nprocs` and `gpus` arguments are passed." %
-                    (len(selected_xpu_list), nprocs))
-            for card_id in selected_xpu_list:
+                    (len(selected_gpu_list), nprocs))
+            for card_id in selected_gpu_list:
                 if card_id not in env_devices_list:
                     raise ValueError("The selected gpu card %s cannot found in "
                                      "XPU_VISIBLE_DEVICES (%s)." %

--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -55,6 +55,12 @@ class ParallelEnvArgs(object):
         # for training.
         self.selected_gpus = None
 
+        # It's for xpu training and the training process will run 
+        # on the selected_xpus, each process is bound to a single XPU. 
+        # And if it's not set, this module will use all the xpu cards 
+        # for training.
+        self.selected_xpus = None
+
 
 def _py_supported_check():
     if not sys.version_info >= (3, 4):
@@ -117,39 +123,75 @@ def _get_subprocess_env_list(nprocs, options):
     # if we set FLAGS_selected_gpus to be `0,1,2,3`, it may cause error
     # when using `ParallelEnv`
     # NOTE(chenweihang): use absolute gpu card id
-    args.selected_gpus = options.get('gpus', None)
-    if args.selected_gpus is None:
-        args.selected_gpus = options.get('selected_gpus', None)
-    env_devices = os.getenv("CUDA_VISIBLE_DEVICES", None)
-    if env_devices is None or env_devices == "":
-        env_devices_list = [
-            str(x) for x in six.moves.range(core.get_cuda_device_count())
-        ]
-    else:
-        env_devices_list = env_devices.split(',')
-    if args.selected_gpus is None:
-        if len(env_devices_list) < nprocs:
-            raise RuntimeError(
-                "the number of visible devices(%d) is less than the number "
-                "of spawn processes(%d), please ensure that the correct "
-                "`nprocs` argument is passed or the environment variable "
-                "`CUDA_VISIBLE_DEVICES` is correctly configured." %
-                (len(env_devices_list), nprocs))
-        args.selected_gpus = ",".join(
-            [str(env_devices_list[x]) for x in range(0, nprocs)])
-    else:
-        selected_gpu_list = args.selected_gpus.split(',')
-        if len(selected_gpu_list) != nprocs:
-            raise ValueError(
-                "The number of selected gpus(%s) is not equal to "
-                "the number of spawn processes(%d), please ensure that the "
-                "correct `nprocs` and `gpus` arguments are passed." %
-                (len(selected_gpu_list), nprocs))
-        for card_id in selected_gpu_list:
-            if card_id not in env_devices_list:
-                raise ValueError("The selected gpu card %s cannot found in "
-                                 "CUDA_VISIBLE_DEVICES (%s)." %
-                                 (card_id, ",".join(env_devices_list)))
+    if core.is_compiled_with_cuda():
+        args.selected_gpus = options.get('gpus', None)
+        if args.selected_gpus is None:
+            args.selected_gpus = options.get('selected_gpus', None)
+        env_devices = os.getenv("CUDA_VISIBLE_DEVICES", None)
+        if env_devices is None or env_devices == "":
+            env_devices_list = [
+                str(x) for x in six.moves.range(core.get_cuda_device_count())
+            ]
+        else:
+            env_devices_list = env_devices.split(',')
+        if args.selected_gpus is None:
+            if len(env_devices_list) < nprocs:
+                raise RuntimeError(
+                    "the number of visible devices(%d) is less than the number "
+                    "of spawn processes(%d), please ensure that the correct "
+                    "`nprocs` argument is passed or the environment variable "
+                    "`CUDA_VISIBLE_DEVICES` is correctly configured." %
+                    (len(env_devices_list), nprocs))
+            args.selected_gpus = ",".join(
+                [str(env_devices_list[x]) for x in range(0, nprocs)])
+        else:
+            selected_gpu_list = args.selected_gpus.split(',')
+            if len(selected_gpu_list) != nprocs:
+                raise ValueError(
+                    "The number of selected gpus(%s) is not equal to "
+                    "the number of spawn processes(%d), please ensure that the "
+                    "correct `nprocs` and `gpus` arguments are passed." %
+                    (len(selected_gpu_list), nprocs))
+            for card_id in selected_gpu_list:
+                if card_id not in env_devices_list:
+                    raise ValueError("The selected gpu card %s cannot found in "
+                                     "CUDA_VISIBLE_DEVICES (%s)." %
+                                     (card_id, ",".join(env_devices_list)))
+
+    if core.is_compiled_with_xpu():
+        args.selected_xpus = options.get('xpus', None)
+        if args.selected_xpus is None:
+            args.selected_xpus = options.get('selected_xpus', None)
+        env_devices = os.getenv("XPU_VISIBLE_DEVICES", None)
+        if env_devices is None or env_devices == "":
+            env_devices_list = [
+                str(x) for x in six.moves.range(core.get_xpu_device_count())
+            ]
+        else:
+            env_devices_list = env_devices.split(',')
+        if args.selected_xpus is None:
+            if len(env_devices_list) < nprocs:
+                raise RuntimeError(
+                    "the number of visible devices(%d) is less than the number "
+                    "of spawn processes(%d), please ensure that the correct "
+                    "`nprocs` argument is passed or the environment variable "
+                    "`XPU_VISIBLE_DEVICES` is correctly configured." %
+                    (len(env_devices_list), nprocs))
+            args.selected_xpus = ",".join(
+                [str(env_devices_list[x]) for x in range(0, nprocs)])
+        else:
+            selected_xpu_list = args.selected_xpus.split(',')
+            if len(selected_xpu_list) != nprocs:
+                raise ValueError(
+                    "The number of selected gpus(%s) is not equal to "
+                    "the number of spawn processes(%d), please ensure that the "
+                    "correct `nprocs` and `gpus` arguments are passed." %
+                    (len(selected_xpu_list), nprocs))
+            for card_id in selected_xpu_list:
+                if card_id not in env_devices_list:
+                    raise ValueError("The selected gpu card %s cannot found in "
+                                     "XPU_VISIBLE_DEVICES (%s)." %
+                                     (card_id, ",".join(env_devices_list)))
 
     # set other inner args
     args.node_ip = options.get('node_ip', None)
@@ -190,7 +232,10 @@ def _set_trainer_env(env_dict):
     # main process and set the FLAGS once, but the environment variable has 
     # not been set at this time, which leads to the FLAGS_selected_gpus 
     # is keep same with mainprocess(usually empty), so manually update the flags here
-    set_flags({'FLAGS_selected_gpus': env_dict['FLAGS_selected_gpus']})
+    if core.is_compiled_with_cuda():
+        set_flags({'FLAGS_selected_gpus': env_dict['FLAGS_selected_gpus']})
+    elif core.is_compiled_with_xpu():
+        set_flags({'FLAGS_selected_xpus': env_dict['FLAGS_selected_xpus']})
     for var_name in env_dict:
         os.environ[var_name] = env_dict[var_name]
 
@@ -407,8 +452,10 @@ def spawn(func, args=(), nprocs=-1, join=True, daemon=False, **options):
         if device == 'cpu':
             # TODO: not supports cpu parallel now
             nprocs = _cpu_num()
-        else:
+        elif device == 'gpu':
             nprocs = core.get_cuda_device_count()
+        else:
+            nprocs = core.get_xpu_device_count()
 
     # NOTE(chenweihang): [ why need get cluster info before run? ]
     # when using `paddle.distributed.spawn` start parallel training, 

--- a/python/paddle/distributed/utils.py
+++ b/python/paddle/distributed/utils.py
@@ -24,6 +24,7 @@ import six
 import subprocess
 from contextlib import closing
 import socket
+from paddle.fluid import core
 
 logger = logging.getLogger("root")
 logger.propagate = False
@@ -401,13 +402,24 @@ def find_free_ports(num):
 
 
 def _prepare_trainer_env(cluster, trainer):
-    proc_env = {
-        "FLAGS_selected_gpus": "%s" % ",".join([str(g) for g in trainer.gpus]),
-        "PADDLE_TRAINER_ID": "%d" % trainer.rank,
-        "PADDLE_CURRENT_ENDPOINT": "%s" % trainer.endpoint,
-        "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
-        "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints())
-    }
+    if core.is_compiled_with_xpu():
+        proc_env = {
+            "FLAGS_selected_xpus":
+            "%s" % ",".join([str(g) for g in trainer.gpus]),
+            "PADDLE_TRAINER_ID": "%d" % trainer.rank,
+            "PADDLE_CURRENT_ENDPOINT": "%s" % trainer.endpoint,
+            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints())
+        }
+    else:
+        proc_env = {
+            "FLAGS_selected_gpus":
+            "%s" % ",".join([str(g) for g in trainer.gpus]),
+            "PADDLE_TRAINER_ID": "%d" % trainer.rank,
+            "PADDLE_CURRENT_ENDPOINT": "%s" % trainer.endpoint,
+            "PADDLE_TRAINERS_NUM": "%d" % cluster.trainers_nranks(),
+            "PADDLE_TRAINER_ENDPOINTS": ",".join(cluster.trainers_endpoints())
+        }
     return proc_env
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
add distributed.spawn support for multi xpu

build scripts:
```
#!/bin/bash

unset GREP_OPTIONS

branch=`git branch | grep \* | cut -d ' ' -f2`
place=xpu
build_type=release
rpc=grpc
testing=y
os=ubuntu
py_v=3.7
#py_v=2.7

while true ; do
  case "$1" in
    -b) branch="$2" ; shift 2 ;;
    -p) place="$2" ; shift 2 ;;
    -t) testing="$2" ; shift 2 ;;
    -build_type) build_type="$2" ; shift 2 ;;
    -rpc) rpc="$2" ; shift 2 ;;
    -os) os="$2" ; shift 2 ;;
    *)
       if [[ ${#1} > 0 ]]; then
          echo "not supported arugments ${1}" ; exit 1 ;
       else
           break
       fi
       ;;
  esac
done

if [ "${branch}" != "develop" ]; then
    branch="wxdev"
fi

echo "branch=${branch}"
echo "place=${place}"
echo "build_type=${build_type}"
echo "rpc=${rpc}"
echo "testing=${testing}"

#[[ $place == "gpu" || $place == "cpu" ]] || echo "not support ${place}" ; exit 1 ;
#[[ $testing == "yes" || $testing == "no" ]] || echo "not support ${testing}" ; exit 1 ;
#[[ $build_type == "release" || $build_type == "debug" ]] || echo "not support ${build_type}" ; exit 1 ;
#[[ $rpc == "brpc" || $rpc == "grpc" || $rpc == "brpcrdma" ]] || echo "not support ${rpc}" ; exit 1 ;

echo "last"

case "$place" in
    gpu) WITH_GPU=ON ;;
    cpu) WITH_GPU=OFF ;;
    xpu)
        WITH_XPU=ON
        WITH_GPU=OFF
        WITH_MKLML=OFF
        WITH_MKLDNN=OFF
        ;;
    *) echo "not support ${place}" ; exit 1 ;;
esac

case "$testing" in
    y) WITH_TESTING=ON ;;
    n) WITH_TESTING=ON ;;
    #n) WITH_TESTING=OFF ;;
    *) echo "not support ${testing}" ; exit 1 ;;
esac

case "$build_type" in
    release) CMAKE_BUILD_TYPE=Release ;;
    debug) CMAKE_BUILD_TYPE=RelWithDebInfo ;;
    *) echo "not support ${build_type}" ; exit 1 ;;
esac

case "$rpc" in
    brpc) WITH_GRPC=OFF ;;
    grpc) WITH_GRPC=ON ;;
    rdma) WITH_GRPC=OFF ; WITH_BRPC_RDMA=ON ;;
    *) echo "not support ${rpc}" ; exit 1 ;;
esac

case "$os" in
    cent)
        export LD_LIBRARY_PATH=/opt/_internal/cpython-2.7.11-ucs4/lib:${LD_LIBRARY_PATH#/opt/_internal/cpython-2.7.11-ucs2/lib:}
        export PATH=/opt/python/cp27-cp27mu/bin/:${PATH}
        PYTHON_FLAGS="-DPYTHON_EXECUTABLE:FILEPATH=/opt/python/cp27-cp27mu/bin/python"
        ;;
    ubuntu) ;;
    *) echo "not support ${os}" ; exit 1 ;;
esac

#build_dir=build_${os}_${branch}_${build_type}_${place}_${testing}_${rpc}
build_dir=build_${os}_${branch}_${build_type}_${place}_n_${rpc}_${py_v}
mkdir -p  ${build_dir}
cd ${build_dir}
third_party_dir=${os}_${build_type}_${place}

echo ${WITH_GPU}

set -x
#         -DCUDA_ARCH_NAME=Volta\
#         -DCUDA_ARCH_NAME=Pascal \
cmake ../../  -DTHIRD_PARTY_PATH=/home/liuyuhui/XPUPaddle/build/third_party/${third_party_dir}/ \
         -DWITH_MKLML=${WITH_MKLML:-ON} \
         -DWITH_MKLDNN=${WITH_MKLDNN:-ON} \
         -DWITH_GPU=${WITH_GPU:-ON} \
         -DWITH_XPU=${WITH_XPU:-OFF} \
         -DWITH_XPU_BKCL=${WITH_XPU:-OFF} \
         -DWITH_C_API=OFF \
         -DWITH_DISTRIBUTE=ON \
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE:-RelWithDebInfo} \
         -DWITH_TESTING=${WITH_TESTING:-ON} \
         -DWITH_STYLE_CHECK=OFF \
         -DWITH_CONTRIB=OFF \
         -DWITH_GRPC=${WITH_GRPC:-ON} \
         -DWITH_BRPC_RDMA=${WITH_BRPC_RDMA:-OFF} \
         -DWITH_FLUID_ONLY=ON \
         -DWITH_INFERENCE_API_TEST=OFF \
         -DCMAKE_INSTALL_PREFIX=/root/paddlebuild/${third_party_dir}/install \
         -DWITH_DOC=ON \
         -DCUDA_ARCH_NAME=Volta\
         -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
         -DWITH_PYTHON=ON \
         -DPY_VERSION=${py_v}
set +x

#if [[ $os == "cent" ]]; then
    #cd $build_dir
    make -j 20
#fi
```
cp build scripts into build sub dirs,  and execute it, requires attention about THIRD_PARTY_PATH, make it as your Paddle ROOT PATH.
example code:
```
from __future__ import print_function

import paddle
import paddle.nn as nn
import paddle.optimizer as opt
import paddle.distributed as dist

class LinearNet(nn.Layer):
    def __init__(self):
        super(LinearNet, self).__init__()
        self._linear1 = nn.Linear(10, 10)
        self._linear2 = nn.Linear(10, 1)

    def forward(self, x):
        return self._linear2(self._linear1(x))

def train(print_result=False):
    # 1. initialize parallel environment
    dist.init_parallel_env()

    # 2. create data parallel layer & optimizer
    layer = LinearNet()
    dp_layer = paddle.DataParallel(layer)

    loss_fn = nn.MSELoss()
    adam = opt.Adam(
        learning_rate=0.001, parameters=dp_layer.parameters())

    # 3. run layer
    inputs = paddle.randn([10, 10], 'float32')
    outputs = dp_layer(inputs)
    labels = paddle.randn([10, 1], 'float32')
    loss = loss_fn(outputs, labels)

    if print_result is True:
        print("loss:", loss.numpy())

    loss.backward()

    adam.step()
    adam.clear_grad()

# Usage 1: only pass function.
# If your training method no need any argument, and
# use all visible devices for parallel training.
if __name__ == '__main__':
    dist.spawn(train)

# Usage 2: pass function and arguments.
# If your training method need some arguments, and
# use all visible devices for parallel training.
if __name__ == '__main__':
    dist.spawn(train, args=(True,))

# Usage 3: pass function, arguments and nprocs.
# If your training method need some arguments, and
# only use part of visible devices for parallel training.
# If your machine hold 8 cards {0,1,2,3,4,5,6,7},
# this case will use cards {0,1}
if __name__ == '__main__':
    dist.spawn(train, args=(True,), nprocs=2)

# Usage 4: pass function, arguments, nprocs and gpus.
# If your training method need some arguments, and
# only use part of visible devices for parallel training, 
# you can pass `xpus` to select the XPU cards you want to use. 
# For example, this case will use cards {4,5}  if your machine hold more than 6 cards.
if __name__ == '__main__':
    dist.spawn(train, args=(True,), nprocs=2, xpus='4,5')
```
And results as following:
```
bkcl working thread func rank 0 bkcl dev id0
bkcl working thread func rank 1 bkcl dev id1
W0218 13:50:59.006999 18430 device_context.cc:187] Please NOTE: xpu device: 0
W0218 13:50:59.006999 18431 device_context.cc:187] Please NOTE: xpu device: 1
bkcl op start:1
bkcl op start:0
bkcl_broadcast6 argument: 1 0x2963f60 0x210100000 0x210100000 100 0 0 2
bkcl_broadcast6 argument: 0 0x23cbae0 0x210100000 0x210100000 100 0 0 2
bkcl op start:1
bkcl op start:0
bkcl_broadcast6 argument: 0 0x23cbae0 0x210120000 0x210120000 10 0 0 2
bkcl_broadcast6 argument: 1 0x2963f60 0x210120000 0x210120000 10 0 0 2
bkcl op start:1
bkcl op start:0
bkcl_broadcast6 argument: 1 0x2963f60 0x210140000 0x210140000 10 0 0 2
bkcl_broadcast6 argument: 0 0x23cbae0 0x210140000 0x210140000 10 0 0 2
bkcl op start:1
bkcl op start:0
bkcl_broadcast6 argument: 0 0x23cbae0 0x210160000 0x210160000 1 0 0 2
bkcl_broadcast6 argument: 1 0x2963f60 0x210160000 0x210160000 1 0 0 2
loss: [7.6320724]
loss: [2.853292]
bkcl op start:1
bkcl op start:0
```