### PR TITLE
[CustomOp] Refine name argument in setup

### DIFF
--- a/python/paddle/fluid/tests/custom_op/setup_build.py
+++ b/python/paddle/fluid/tests/custom_op/setup_build.py
@@ -23,10 +23,9 @@ use_new_custom_op_load_method(False)
 file_dir = os.path.dirname(os.path.abspath(__file__))
 
 setup(
-    name='relu2_op_shared',
+    name='librelu2_op_from_setup',
     ext_modules=[
         CUDAExtension(
-            name='librelu2_op_from_setup',
             sources=['relu_op3.cc', 'relu_op3.cu', 'relu_op.cc',
                      'relu_op.cu'],  # test for multi ops
             include_dirs=paddle_includes,

--- a/python/paddle/fluid/tests/custom_op/setup_install.py
+++ b/python/paddle/fluid/tests/custom_op/setup_install.py
@@ -22,11 +22,8 @@ use_new_custom_op_load_method(False)
 
 setup(
     name='custom_relu2',
-    ext_modules=[
-        CUDAExtension(
-            name='custom_relu2',
-            sources=['relu_op.cc', 'relu_op.cu', 'relu_op3.cc',
-                     'relu_op3.cu'],  # test for multi ops
-            include_dirs=paddle_includes,
-            extra_compile_args=extra_compile_args)
-    ])
+    ext_modules=CUDAExtension(  # test for not specific name here.
+        sources=['relu_op.cc', 'relu_op.cu', 'relu_op3.cc',
+                 'relu_op3.cu'],  # test for multi ops
+        include_dirs=paddle_includes,
+        extra_compile_args=extra_compile_args))

--- a/python/paddle/fluid/tests/custom_op/setup_install_simple.py
+++ b/python/paddle/fluid/tests/custom_op/setup_install_simple.py
@@ -19,12 +19,9 @@ from paddle.utils.cpp_extension import CUDAExtension, setup
 
 setup(
     name='simple_setup_relu2',
-    ext_modules=[
-        CUDAExtension(
-            name='simple_setup_relu2',
-            sources=[
-                'relu_op_simple.cc', 'relu_op_simple.cu', 'relu_op3_simple.cc'
-            ],  # test for multi ops
-            include_dirs=paddle_includes,
-            extra_compile_args=extra_compile_args)
-    ])
+    ext_modules=CUDAExtension(  # test for not specific name here.
+        sources=[
+            'relu_op_simple.cc', 'relu_op_simple.cu', 'relu_op3_simple.cc'
+        ],  # test for multi ops
+        include_dirs=paddle_includes,
+        extra_compile_args=extra_compile_args))

--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -109,7 +109,6 @@ def load_op_meta_info_and_register_op(lib_filename):
     if USING_NEW_CUSTOM_OP_LOAD_METHOD:
         core.load_op_meta_info_and_register_op(lib_filename)
     else:
-        print("old branch")
         core.load_op_library(lib_filename)
     return OpProtoHolder.instance().update_op_proto()
 
@@ -152,7 +151,7 @@ def custom_write_stub(resource, pyfile):
 
     # Parse registerring op information
     _, op_info = CustomOpInfo.instance().last()
-    so_path = op_info.build_directory
+    so_path = op_info.so_path
 
     new_custom_ops = load_op_meta_info_and_register_op(so_path)
     assert len(
@@ -175,8 +174,7 @@ def custom_write_stub(resource, pyfile):
                 resource=resource, custom_api='\n\n'.join(api_content)))
 
 
-OpInfo = collections.namedtuple('OpInfo',
-                                ['so_name', 'build_directory', 'out_dtypes'])
+OpInfo = collections.namedtuple('OpInfo', ['so_name', 'so_path'])
 
 
 class CustomOpInfo:
@@ -197,8 +195,8 @@ class CustomOpInfo:
         # NOTE(Aurelius84): Use OrderedDict to save more order information
         self.op_info_map = collections.OrderedDict()
 
-    def add(self, op_name, so_name, build_directory=None, out_dtypes=None):
-        self.op_info_map[op_name] = OpInfo(so_name, build_directory, out_dtypes)
+    def add(self, op_name, so_name, so_path=None):
+        self.op_info_map[op_name] = OpInfo(so_name, so_path)
 
     def last(self):
         """
@@ -266,7 +264,10 @@ def normalize_extension_kwargs(kwargs, use_cuda=False):
 
     # append link flags
     extra_link_args = kwargs.get('extra_link_args', [])
-    extra_link_args.extend(['-lpaddle_framework', '-lcudart'])
+    extra_link_args.append('-lpaddle_framework')
+    if use_cuda:
+        extra_link_args.append('-lcudart')
+
     kwargs['extra_link_args'] = extra_link_args
 
     kwargs['language'] = 'c++'
@@ -536,7 +537,6 @@ def _write_setup_file(name,
         name='{name}',
         ext_modules=[
             {prefix}Extension(
-                name='{name}',
                 sources={sources},
                 include_dirs={include_dirs},
                 extra_compile_args={extra_compile_args},


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

### What's New?

Refine name argument in setup.

Before this PR, users must specific two `name` arguments in `setup`, which will make them confuse the difference. Actually, the only important `name` is Package name, users don't need to know the shared libaray name from extension and it shares same name with Package name now.

**Example(Before):**
```python
setup(
    name='custom_relu2',   # Package Name
    ext_modules=[CUDAExtension(  
        name='custom_relu2',  # Shared library Name
        sources=['relu_op.cc', 'relu_op.cu'], 
       )]
)
```

**Example(After):**
```python
setup(
    name='custom_relu2',
    ext_modules=CUDAExtension(sources=['relu_op.cc', 'relu_op.cu'])
)
```

+ Only one name for package name
+ ext_modules support list or just one value