### PR TITLE
update trt int8 calibrator to IEntropyCalibratorV2

### DIFF
--- a/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
+++ b/paddle/fluid/inference/tensorrt/trt_int8_calibrator.h
@@ -34,7 +34,7 @@ namespace tensorrt {
 
 class TensorRTEngine;
 
-struct TRTInt8Calibrator : public nvinfer1::IInt8EntropyCalibrator {
+struct TRTInt8Calibrator : public nvinfer1::IInt8EntropyCalibrator2 {
  public:
   TRTInt8Calibrator(const std::unordered_map<std::string, size_t>& buffers,
                     int batch_size, std::string engine_name,

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
-#include <dirent.h>
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 #include <unistd.h>
@@ -26,22 +25,6 @@ limitations under the License. */
 
 namespace paddle {
 namespace inference {
-
-static int DeleteCache(std::string path) {
-  DIR* dir = opendir(path.c_str());
-  if (dir == NULL) return 0;
-  struct dirent* ptr;
-  while ((ptr = readdir(dir)) != NULL) {
-    if (std::strcmp(ptr->d_name, ".") == 0 ||
-        std::strcmp(ptr->d_name, "..") == 0) {
-      continue;
-    } else if (ptr->d_type == 8) {
-      std::string file_rm = path + "/" + ptr->d_name;
-      return remove(file_rm.c_str());
-    }
-  }
-  return 0;
-}
 
 static void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   auto predictor = CreatePaddlePredictor(config);
@@ -111,7 +94,7 @@ static void trt_ernie(bool with_fp16, std::vector<float> result) {
   // Delete serialization cache to perform serialization first rather than
   // deserialization.
   std::string opt_cache_dir = FLAGS_infer_model + "/_opt_cache";
-  DeleteCache(opt_cache_dir);
+  delete_cache_files(opt_cache_dir);
 
   SetConfig(&config, model_dir, true /* use_gpu */);
 

--- a/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
@@ -23,6 +23,9 @@ namespace inference {
 
 TEST(TensorRT, split_converter) {
   std::string model_dir = FLAGS_infer_model + "/split_converter";
+  std::string opt_cache_dir = model_dir + "/_opt_cache";
+  delete_cache_files(opt_cache_dir);
+
   AnalysisConfig config;
   int batch_size = 4;
   config.EnableUseGpu(100, 0);

--- a/paddle/fluid/inference/tests/api/trt_test_helper.h
+++ b/paddle/fluid/inference/tests/api/trt_test_helper.h
@@ -12,6 +12,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 #pragma once
+#include <dirent.h>
 #include <string>
 #include <vector>
 
@@ -131,6 +132,21 @@ void compare_continuous_input(std::string model_dir, bool use_tensorrt) {
     }
     CompareNativeAndAnalysis(native_pred.get(), analysis_pred.get(),
                              inputs_all);
+  }
+}
+
+void delete_cache_files(std::string path) {
+  DIR* dir = opendir(path.c_str());
+  if (dir == NULL) return;
+  struct dirent* ptr;
+  while ((ptr = readdir(dir)) != NULL) {
+    if (std::strcmp(ptr->d_name, ".") == 0 ||
+        std::strcmp(ptr->d_name, "..") == 0) {
+      continue;
+    } else if (ptr->d_type == 8) {
+      std::string file_rm = path + "/" + ptr->d_name;
+      remove(file_rm.c_str());
+    }
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Others
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
Others
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
更新trt的离线量化calibrator，从IEntropyCalibrator更新为更为推荐的IEntropyCalibratorV2，且DLA的支持需要后者。
不同的calibrator介绍见：https://docs.nvidia.com/deeplearning/tensorrt/archives/tensorrt-601/tensorrt-developer-guide/index.html#optimizing_int8_c
摘录如下：
IEntropyCalibratorV2
This is the preferred calibrator and is required for DLA as it supports per activation tensor scaling.
IMinMaxCalibrator
This is the preferred calibrator for NLP tasks for all backends. It supports per activation tensor scaling.
IEntropyCalibrator
This is the legacy entropy calibrator which supports per channel scaling. This is less complicated than legacy calibrator and produces better results.
ILegacyCalibrator
This calibrator is for compatibility with 2.0EA. It is deprecated and should not be used.
<!-- Describe what this PR does -->
