### PR TITLE
improve performance of depthwise_conv2d

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_conv2d_op.py
+++ b/python/paddle/fluid/tests/unittests/test_conv2d_op.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 
+import paddle
 import paddle.fluid.core as core
 import paddle.fluid as fluid
 from op_test import OpTest
@@ -1327,6 +1328,16 @@ class TestConv2DAPI(unittest.TestCase):
             dilation=[1, 1],
             groups=1,
             data_format="NCHW")
+
+    def test_depthwise_conv2d(self):
+        x_var = paddle.uniform((2, 8, 8, 4), dtype='float32', min=-1., max=1.)
+        conv = paddle.nn.Conv2D(
+            in_channels=4,
+            out_channels=4,
+            kernel_size=(3, 3),
+            groups=4,
+            data_format='NHWC')
+        y_var = conv(x_var)
 
 
 class TestConv2DAPI_Error(unittest.TestCase):

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -110,6 +110,7 @@ def _conv_nd(x,
              use_mkldnn=False,
              name=None):
 
+    # Due to the poor performance of NHWC, we transpose the input to NCHW.
     origin_format = data_format
     if origin_format == "NHWC" and op_type == "depthwise_conv2d":
         x = nn.transpose(x, perm=[0, 3, 1, 2])

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -110,6 +110,11 @@ def _conv_nd(x,
              use_mkldnn=False,
              name=None):
 
+    origin_format = data_format
+    if origin_format == "NHWC" and op_type == "depthwise_conv2d":
+        x = nn.transpose(x, perm=[0, 3, 1, 2])
+        data_format = "NCHW"
+        channel_dim = 1
     if in_dygraph_mode():
         attrs = ('strides', stride, 'paddings', padding, 'dilations', dilation,
                  'groups', groups, 'use_cudnn', use_cudnn, 'use_mkldnn',
@@ -153,6 +158,9 @@ def _conv_nd(x,
                        'use_mkldnn': use_mkldnn})
         else:
             out = pre_bias
+
+    if origin_format == "NHWC" and op_type == "depthwise_conv2d":
+        out = nn.transpose(out, perm=[0, 2, 3, 1])
 
     return out
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> APIs

### Describe
<!-- Describe what this PR does --> improve performance of depthwise_conv2d

当data format为NHWC时，原始实现：
- 前向：c++端对输入transpose为NCHW，使用NCHW计算，再将输出transpose为NHWC，引入2次transpose
- 反向：c++端对input和out_grad分别transpose为NCHW，计算input_grad，然后再将input_grad transpose为NHWC，3次transpose
- c++端使用eigen实现transpose，未深度优化

本PR的修改：
通过在python API里插入transpose，前反向能否减少1次transpose，transpose的性能也相对更优。
