### PR TITLE
[Not merge] Support loss scale for adam

### DIFF
--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -141,6 +141,7 @@ class Adam(Optimizer):
                  grad_clip=None,
                  lazy_mode=False,
                  multi_precision=False,
+                 scale=1024,
                  name=None):
         assert learning_rate is not None
         assert beta1 is not None
@@ -165,6 +166,7 @@ class Adam(Optimizer):
         self._lazy_mode = lazy_mode
         self._multi_precision = multi_precision
         self._master_weights = {}
+        self._scale = scale
 
     def _create_master_weight(self, param):
         assert isinstance(self.helper, LayerHelper)
@@ -280,9 +282,11 @@ class Adam(Optimizer):
 
             return None
 
+        new_grad = param_and_grad[1] / self._scale
+
         inputs = {
             "Param": [param_and_grad[0]],
-            "Grad": [param_and_grad[1]],
+            "Grad": [new_grad],
             "LearningRate": [lr],
             "Moment1": [moment1],
             "Moment2": [moment2],

--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -141,7 +141,7 @@ class Adam(Optimizer):
                  grad_clip=None,
                  lazy_mode=False,
                  multi_precision=False,
-                 scale=1024,
+                 scale=1.0,
                  name=None):
         assert learning_rate is not None
         assert beta1 is not None

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -878,6 +878,8 @@ class Optimizer(object):
         """
         assert isinstance(loss, Variable), "The loss should be an Tensor."
 
+        loss = loss * self._scale
+
         parameter_list = parameters if parameters \
             else self._parameter_list
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Support loss scale for adam

Usage example:
```
import paddle
import numpy as np
import paddle.static as static

np.random.seed(1)
paddle.seed(1)

paddle.enable_static()

main_program = static.Program()
startup_program = static.Program()

with static.program_guard(main_program=main_program, startup_program=startup_program):
    x = static.data(name="x", shape=[-1, 10], dtype='float32')
    linear = paddle.nn.Linear(10, 10)
    out = linear(x)
    loss = paddle.mean(out)
    adam = paddle.optimizer.Adam(learning_rate=0.1, scale=1024)
    adam.minimize(loss)

    exe = paddle.static.Executor()
    exe.run(startup_program)
    print(main_program)

    for i in range(10):
        loss_ = exe.run(main_program, feed={"x": np.random.random(size=(3, 10)).astype('float32')}, fetch_list=[loss])
        print(loss_)
```