### PR TITLE
optimize unity build

### DIFF
--- a/paddle/fluid/operators/kldiv_loss_op.h
+++ b/paddle/fluid/operators/kldiv_loss_op.h
@@ -19,10 +19,6 @@ namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
-
 using Array1 = Eigen::DSizes<int64_t, 1>;
 
 template <typename T>
@@ -64,9 +60,9 @@ class KLDivLossKernel : public framework::OpKernel<T> {
     const int n = input->dims()[0];
 
     loss->mutable_data<T>(ctx.GetPlace());
-    auto input_t = EigenVector<T>::Flatten(*input);
-    auto target_t = EigenVector<T>::Flatten(*target);
-    auto loss_t = EigenVector<T>::Flatten(*loss);
+    auto input_t = framework::EigenVector<T>::Flatten(*input);
+    auto target_t = framework::EigenVector<T>::Flatten(*target);
+    auto loss_t = framework::EigenVector<T>::Flatten(*loss);
     auto output = target_t.binaryExpr(input_t, KLDivLossForward<T>());
     if ("none" == reduction) {
       loss_t.device(place) = output;
@@ -101,10 +97,10 @@ class KLDivLossGradKernel : public framework::OpKernel<T> {
 
     input_grad->mutable_data<T>(ctx.GetPlace());
 
-    auto target_t = EigenVector<T>::Flatten(*target);
+    auto target_t = framework::EigenVector<T>::Flatten(*target);
 
-    auto input_grad_t = EigenVector<T>::Flatten(*input_grad);
-    auto loss_grad_t = EigenVector<T>::Flatten(*loss_grad);
+    auto input_grad_t = framework::EigenVector<T>::Flatten(*input_grad);
+    auto loss_grad_t = framework::EigenVector<T>::Flatten(*loss_grad);
 
     auto loss_grad_expand = loss_grad_t.broadcast(Array1(expand));
     auto grad_t = target_t * loss_grad_expand;

--- a/paddle/fluid/operators/top_k_function_cuda.h
+++ b/paddle/fluid/operators/top_k_function_cuda.h
@@ -500,13 +500,13 @@ bool SortTopk(const platform::CUDADeviceContext& ctx,
     // copy sliced data to output.
     const Eigen::DSizes<Eigen::DenseIndex, 2> slice_indices{0, 0};
     const Eigen::DSizes<Eigen::DenseIndex, 2> slice_sizes{num_rows, k};
-    auto e_indices = EigenMatrix<int64_t>::From(*indices_tensor, dim);
-    auto e_tmp_indices = EigenMatrix<int64_t>::From(temp_indices);
+    auto e_indices = framework::EigenMatrix<int64_t>::From(*indices_tensor, dim);
+    auto e_tmp_indices = framework::EigenMatrix<int64_t>::From(temp_indices);
 
     std::vector<int> odims = {static_cast<int>(num_rows), static_cast<int>(k)};
     auto dim = framework::make_ddim(odims);
-    auto e_values = EigenMatrix<T>::From(*out_tensor, dim);
-    auto e_tmp_values = EigenMatrix<T>::From(temp_values);
+    auto e_values = framework::EigenMatrix<T>::From(*out_tensor, dim);
+    auto e_tmp_values = framework::EigenMatrix<T>::From(temp_values);
 
     e_indices.device(dev) = e_tmp_indices.slice(slice_indices, slice_sizes);
     e_values.device(dev) = e_tmp_values.slice(slice_indices, slice_sizes);

--- a/paddle/fluid/operators/top_k_function_cuda.h
+++ b/paddle/fluid/operators/top_k_function_cuda.h
@@ -500,7 +500,8 @@ bool SortTopk(const platform::CUDADeviceContext& ctx,
     // copy sliced data to output.
     const Eigen::DSizes<Eigen::DenseIndex, 2> slice_indices{0, 0};
     const Eigen::DSizes<Eigen::DenseIndex, 2> slice_sizes{num_rows, k};
-    auto e_indices = framework::EigenMatrix<int64_t>::From(*indices_tensor, dim);
+    auto e_indices =
+        framework::EigenMatrix<int64_t>::From(*indices_tensor, dim);
     auto e_tmp_indices = framework::EigenMatrix<int64_t>::From(temp_indices);
 
     std::vector<int> odims = {static_cast<int>(num_rows), static_cast<int>(k)};

--- a/paddle/fluid/operators/top_k_op.h
+++ b/paddle/fluid/operators/top_k_op.h
@@ -67,7 +67,8 @@ class TopkKernel : public framework::OpKernel<T> {
           vec.push_back(std::pair<T, size_t>(eg_input(j), j));
         }
       } else {
-        auto eg_input = framework::EigenMatrix<T>::Reshape(*input, inputdims.size() - 1);
+        auto eg_input =
+            framework::EigenMatrix<T>::Reshape(*input, inputdims.size() - 1);
         for (size_t j = 0; j < col; j++) {
           vec.push_back(std::pair<T, size_t>(eg_input(i, j), j));
         }

--- a/paddle/fluid/operators/top_k_op.h
+++ b/paddle/fluid/operators/top_k_op.h
@@ -25,14 +25,6 @@ namespace operators {
 
 using Tensor = framework::Tensor;
 
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenMatrix = framework::EigenMatrix<T, MajorType, IndexType>;
-
-template <typename T, int MajorType = Eigen::RowMajor,
-          typename IndexType = Eigen::DenseIndex>
-using EigenVector = framework::EigenVector<T, MajorType, IndexType>;
-
 template <typename DeviceContext, typename T>
 class TopkKernel : public framework::OpKernel<T> {
  public:
@@ -70,12 +62,12 @@ class TopkKernel : public framework::OpKernel<T> {
       vec.reserve(col);
       // 1D vector
       if (inputdims.size() == 1) {
-        auto eg_input = EigenVector<T>::Flatten(*input);
+        auto eg_input = framework::EigenVector<T>::Flatten(*input);
         for (size_t j = 0; j < col; j++) {
           vec.push_back(std::pair<T, size_t>(eg_input(j), j));
         }
       } else {
-        auto eg_input = EigenMatrix<T>::Reshape(*input, inputdims.size() - 1);
+        auto eg_input = framework::EigenMatrix<T>::Reshape(*input, inputdims.size() - 1);
         for (size_t j = 0; j < col; j++) {
           vec.push_back(std::pair<T, size_t>(eg_input(i, j), j));
         }

--- a/paddle/fluid/operators/top_k_v2_op.h
+++ b/paddle/fluid/operators/top_k_v2_op.h
@@ -149,7 +149,8 @@ static void FullTopKAssign(const Type& input_height, const Type& input_width,
       }
     } else {
       auto e_input = framework::EigenMatrix<T>::Reshape(*input, input_dim - 1);
-      auto e_indices = framework::EigenMatrix<Type>::Reshape(*indices, input_dim - 1);
+      auto e_indices =
+          framework::EigenMatrix<Type>::Reshape(*indices, input_dim - 1);
       for (Type j = 0; j < k; ++j) {
         output_data[i * input_width + e_indices(i, j)] = e_input(i, j);
       }

--- a/paddle/fluid/operators/top_k_v2_op.h
+++ b/paddle/fluid/operators/top_k_v2_op.h
@@ -61,12 +61,12 @@ static void FullTopK(Type input_height, Type input_width, int input_dim,
     std::vector<std::pair<T, Type>> col_vec;
     col_vec.reserve(input_width);
     if (input_dim == 1) {
-      auto e_input = EigenVector<T>::Flatten(*input);
+      auto e_input = framework::EigenVector<T>::Flatten(*input);
       for (Type j = 0; j < input_width; ++j) {
         col_vec.emplace_back(std::pair<T, Type>(e_input(j), j));
       }
     } else {
-      auto e_input = EigenMatrix<T>::Reshape(*input, input_dim - 1);
+      auto e_input = framework::EigenMatrix<T>::Reshape(*input, input_dim - 1);
       for (Type j = 0; j < input_width; ++j) {
         col_vec.emplace_back(std::pair<T, Type>(e_input(i, j), j));
       }
@@ -142,14 +142,14 @@ static void FullTopKAssign(const Type& input_height, const Type& input_width,
 #endif
   for (Type i = 0; i < input_height; ++i) {
     if (input_dim == 1) {
-      auto e_input = EigenVector<T>::Flatten(*input);
-      auto e_indices = EigenVector<Type>::Flatten(*indices);
+      auto e_input = framework::EigenVector<T>::Flatten(*input);
+      auto e_indices = framework::EigenVector<Type>::Flatten(*indices);
       for (Type j = 0; j < k; ++j) {
         output_data[i * input_width + e_indices(j)] = e_input(j);
       }
     } else {
-      auto e_input = EigenMatrix<T>::Reshape(*input, input_dim - 1);
-      auto e_indices = EigenMatrix<Type>::Reshape(*indices, input_dim - 1);
+      auto e_input = framework::EigenMatrix<T>::Reshape(*input, input_dim - 1);
+      auto e_indices = framework::EigenMatrix<Type>::Reshape(*indices, input_dim - 1);
       for (Type j = 0; j < k; ++j) {
         output_data[i * input_width + e_indices(i, j)] = e_input(i, j);
       }

--- a/paddle/fluid/operators/unity_build_rule.cmake
+++ b/paddle/fluid/operators/unity_build_rule.cmake
@@ -5,6 +5,7 @@
 # If there are some redefined error in compiling with the source file which
 # in combination rule, you can remove the source file from the following rules.
 register_unity_group(cc
+    abs_op.cc
     add_position_encoding_op.cc
     addmm_op.cc
     affine_channel_op.cc
@@ -42,7 +43,12 @@ register_unity_group(cc
     correlation_op.cc
     cos_sim_op.cc
     crf_decoding_op.cc
-    crop_op.cc)
+    crop_op.cc
+    ascend_trigger_op.cc
+    conj_op.cc
+    imag_op.cc
+    kldiv_loss_op.cc
+    memcpy_op.cc)
 register_unity_group(cc
     cross_entropy_op.cc
     cross_op.cc
@@ -69,7 +75,11 @@ register_unity_group(cc
     edit_distance_op.cc
     empty_op.cc
     enqueue_op.cc
-    erf_op.cc)
+    erf_op.cc
+    py_func_op.cc
+    real_op.cc
+    sync_batch_norm_op.cc
+    top_k_op.cc)
 register_unity_group(cc
     expand_v2_op.cc
     fake_dequantize_op.cc
@@ -309,6 +319,33 @@ register_unity_group(cc
     unbind_op.cu.cc
     unpool_op.cu.cc
     unsqueeze_op.cu.cc)
+register_unity_group(cc
+    arg_max_op.cc
+    arg_min_op.cc
+    squared_l2_distance_op.cc)
+register_unity_group(cc
+    conv_op.cc
+    conv_transpose_op.cc
+    gru_unit_op.cc)
+register_unity_group(cc
+    linear_chain_crf_op.cc
+    lstm_op.cc
+    partial_concat_op.cc
+    pyramid_hash_op.cc
+    recurrent_op.cc
+    run_program_op.cc
+    softmax_with_cross_entropy_op.cc
+    warpctc_op.cc)
+register_unity_group(cc
+    conv_op.cu.cc
+    lstm_op.cu.cc
+    rnn_op.cu.cc
+    split_op.cu.cc
+    activation_cudnn_op.cu.cc
+    assign_value_op.cu.cc
+    merge_selected_rows_op.cu.cc
+    run_program_op.cu.cc
+    warpctc_op.cu.cc)
 register_unity_group(cu
     addmm_op.cu
     affine_channel_op.cu

--- a/paddle/fluid/operators/unity_build_rule.cmake
+++ b/paddle/fluid/operators/unity_build_rule.cmake
@@ -34,7 +34,11 @@ register_unity_group(cc
     chunk_eval_op.cc
     clip_by_norm_op.cc
     clip_op.cc
-    coalesce_tensor_op.cc)
+    coalesce_tensor_op.cc
+    mkldnn/activation_mkldnn_op.cc
+    mkldnn/interpolate_mkldnn_op.cc
+    mkldnn/pool_mkldnn_op.cc
+    mkldnn/softmax_mkldnn_op.cc)
 register_unity_group(cc
     center_loss_op.cc
     mkldnn/concat_mkldnn_op.cc
@@ -79,7 +83,10 @@ register_unity_group(cc
     py_func_op.cc
     real_op.cc
     sync_batch_norm_op.cc
-    top_k_op.cc)
+    top_k_op.cc
+    conv_op.cc
+    conv_transpose_op.cc
+    gru_unit_op.cc)
 register_unity_group(cc
     expand_v2_op.cc
     fake_dequantize_op.cc
@@ -323,10 +330,6 @@ register_unity_group(cc
     arg_max_op.cc
     arg_min_op.cc
     squared_l2_distance_op.cc)
-register_unity_group(cc
-    conv_op.cc
-    conv_transpose_op.cc
-    gru_unit_op.cc)
 register_unity_group(cc
     linear_chain_crf_op.cc
     lstm_op.cc


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
优化`paddle/fluid/operators`目录下cc对应UB编译规则。

windows编译耗时波动较大，在调试机上单独对比该目录下cc文件编译耗时变化从393s减少到338s，减少14% ；