### PR TITLE
[cherry-pick]fix error message & label check in softmax_with_cross_entropy 

### DIFF
--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -267,9 +267,9 @@ struct HardLabelSoftmaxWithCrossEntropyFunctor {
     // labels, loss view as [n, remain]
     int idx_lbl = idx_n * remain + idx_remain;
     PADDLE_ENFORCE(labels_[idx_lbl] >= 0 && labels_[idx_lbl] < d_,
-                   "The value of label expected >= 0 and < %ld,"
-                   "but got %ld. Please check input value.",
-                   d_, labels_[idx_lbl]);
+                   "The value of label[%d] expected >= 0 and < %d,"
+                   "but got %d. Please check input value.",
+                   idx_lbl, d_, labels_[idx_lbl]);
     // It also would ignore labels not in range(class_num).
     if (idx_axis != labels_[idx_lbl]) {
       log_softmax_[idx] = exp_on_device(log_softmax_[idx]);

--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -267,8 +267,8 @@ struct HardLabelSoftmaxWithCrossEntropyFunctor {
     // labels, loss view as [n, remain]
     int idx_lbl = idx_n * remain + idx_remain;
     PADDLE_ENFORCE(labels_[idx_lbl] >= 0 && labels_[idx_lbl] < d_,
-                   "The value of label[%d] expected >= 0 and < %d,"
-                   "but got %d. Please check input value.",
+                   "The value of label[%ld] expected >= 0 and < %ld,"
+                   "but got %ld. Please check input value.",
                    idx_lbl, d_, labels_[idx_lbl]);
     // It also would ignore labels not in range(class_num).
     if (idx_axis != labels_[idx_lbl]) {

--- a/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
+++ b/paddle/fluid/operators/softmax_with_cross_entropy_op.cu
@@ -266,6 +266,10 @@ struct HardLabelSoftmaxWithCrossEntropyFunctor {
     int idx_remain = idx % remain;
     // labels, loss view as [n, remain]
     int idx_lbl = idx_n * remain + idx_remain;
+    PADDLE_ENFORCE(labels_[idx_lbl] >= 0 && labels_[idx_lbl] < d_,
+                   "The value of label expected >= 0 and < %ld,"
+                   "but got %ld. Please check input value.",
+                   d_, labels_[idx_lbl]);
     // It also would ignore labels not in range(class_num).
     if (idx_axis != labels_[idx_lbl]) {
       log_softmax_[idx] = exp_on_device(log_softmax_[idx]);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 OPs 
### Describe
<!-- Describe what this PR does -->
cherry-pick #31122 #31201
- In GPU and  numeric_stable_mode=True mode，there is no label error check, so fit it.
- When label < 0 or > D with numeric_stable_mode=True, it will report an error and ignore_index doesn't work. It is not as expected. So fix ignore_index label check in softmax_with_cross_entropy.