### PR TITLE
add warning message when dtypes of operator are not same

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -51,6 +51,11 @@ _supported_promote_complex_types_ = [
     '__matmul__',
 ]
 
+_complex_dtypes = [
+    core.VarDesc.VarType.COMPLEX64,
+    core.VarDesc.VarType.COMPLEX128,
+]
+
 _already_patch_varbase = False
 
 
@@ -214,7 +219,9 @@ def monkey_patch_math_varbase():
             # 3. promote types or unify right var type to left var
             rhs_dtype = other_var.dtype
             if lhs_dtype != rhs_dtype:
-                if method_name in _supported_promote_complex_types_:
+                if method_name in _supported_promote_complex_types_ and (
+                        lhs_dtype in _complex_dtypes or
+                        rhs_dtype in _complex_dtypes):
                     # only when lhs_dtype or rhs_dtype is complex type,
                     # the dtype will promote, in other cases, directly
                     # use lhs_dtype, this is consistent will original rule
@@ -225,7 +232,9 @@ def monkey_patch_math_varbase():
                     other_var = other_var if rhs_dtype == promote_dtype else astype(
                         other_var, promote_dtype)
                 else:
-                    other_var = astype(other_var, lhs_dtype)
+                    raise Exception(
+                        'The dtype of left and right variables are not the same, left dtype is {}, but right dtype is {}'.
+                        format(lhs_dtype, rhs_dtype))
 
             if reverse:
                 tmp = self

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -21,6 +21,7 @@ from . import no_grad
 
 import numpy as np
 import six
+import warnings
 
 _supported_int_dtype_ = [
     core.VarDesc.VarType.UINT8,
@@ -232,9 +233,10 @@ def monkey_patch_math_varbase():
                     other_var = other_var if rhs_dtype == promote_dtype else astype(
                         other_var, promote_dtype)
                 else:
-                    raise Exception(
-                        'The dtype of left and right variables are not the same, left dtype is {}, but right dtype is {}'.
-                        format(lhs_dtype, rhs_dtype))
+                    warnings.warn(
+                        'The dtype of left and right variables are not the same, left dtype is {}, but right dtype is {}, the right dtype will convert to {}'.
+                        format(lhs_dtype, rhs_dtype, lhs_dtype))
+                    other_var = astype(other_var, lhs_dtype)
 
             if reverse:
                 tmp = self

--- a/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
@@ -16,7 +16,7 @@ from __future__ import print_function, division
 
 import unittest
 import numpy as np
-
+import warnings
 import paddle
 
 
@@ -26,25 +26,33 @@ class TestTensorTypePromotion(unittest.TestCase):
         self.y = paddle.to_tensor([1.0, 2.0])
 
     def test_operator(self):
-        with self.assertWarns(UserWarning) as context:
+        with warnings.catch_warnings(record=True) as context:
+            warnings.simplefilter("always")
             self.x + self.y
-        self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.warning))
+            self.assertTrue(
+                "The dtype of left and right variables are not the same" in
+                str(context[-1].message))
 
-        with self.assertWarns(UserWarning) as context:
+        with warnings.catch_warnings(record=True) as context:
+            warnings.simplefilter("always")
             self.x - self.y
-        self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.warning))
+            self.assertTrue(
+                "The dtype of left and right variables are not the same" in
+                str(context[-1].message))
 
-        with self.assertWarns(UserWarning) as context:
+        with warnings.catch_warnings(record=True) as context:
+            warnings.simplefilter("always")
             self.x * self.y
-        self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.warning))
+            self.assertTrue(
+                "The dtype of left and right variables are not the same" in
+                str(context[-1].message))
 
-        with self.assertWarns(UserWarning) as context:
+        with warnings.catch_warnings(record=True) as context:
+            warnings.simplefilter("always")
             self.x / self.y
-        self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.warning))
+            self.assertTrue(
+                "The dtype of left and right variables are not the same" in
+                str(context[-1].message))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
@@ -28,27 +28,23 @@ class TestTensorTypePromotion(unittest.TestCase):
     def test_operator(self):
         with self.assertRaises(Exception) as context:
             self.x + self.y
-        self.assertTrue(
-            "the dtype of left and right vars of operator not the same" in
-            str(context.exception))
+        self.assertTrue("The dtype of left and right variables are not the same"
+                        in str(context.exception))
 
         with self.assertRaises(Exception) as context:
             self.x - self.y
-        self.assertTrue(
-            "the dtype of left and right vars of operator not the same" in
-            str(context.exception))
+        self.assertTrue("The dtype of left and right variables are not the same"
+                        in str(context.exception))
 
         with self.assertRaises(Exception) as context:
             self.x * self.y
-        self.assertTrue(
-            "the dtype of left and right vars of operator not the same" in
-            str(context.exception))
+        self.assertTrue("The dtype of left and right variables are not the same"
+                        in str(context.exception))
 
         with self.assertRaises(Exception) as context:
             self.x / self.y
-        self.assertTrue(
-            "the dtype of left and right vars of operator not the same" in
-            str(context.exception))
+        self.assertTrue("The dtype of left and right variables are not the same"
+                        in str(context.exception))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division
+
+import unittest
+import numpy as np
+
+import paddle
+
+
+class TestTensorTypePromotion(unittest.TestCase):
+    def setUp(self):
+        self.x = paddle.to_tensor([2, 3])
+        self.y = paddle.to_tensor([1.0, 2.0])
+
+    def test_operator(self):
+        with self.assertRaises(Exception) as context:
+            self.x + self.y
+        self.assertTrue(
+            "the dtype of left and right vars of operator not the same" in
+            str(context.exception))
+
+        with self.assertRaises(Exception) as context:
+            self.x - self.y
+        self.assertTrue(
+            "the dtype of left and right vars of operator not the same" in
+            str(context.exception))
+
+        with self.assertRaises(Exception) as context:
+            self.x * self.y
+        self.assertTrue(
+            "the dtype of left and right vars of operator not the same" in
+            str(context.exception))
+
+        with self.assertRaises(Exception) as context:
+            self.x / self.y
+        self.assertTrue(
+            "the dtype of left and right vars of operator not the same" in
+            str(context.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_type_promotion.py
@@ -26,25 +26,25 @@ class TestTensorTypePromotion(unittest.TestCase):
         self.y = paddle.to_tensor([1.0, 2.0])
 
     def test_operator(self):
-        with self.assertRaises(Exception) as context:
+        with self.assertWarns(UserWarning) as context:
             self.x + self.y
         self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.exception))
+                        in str(context.warning))
 
-        with self.assertRaises(Exception) as context:
+        with self.assertWarns(UserWarning) as context:
             self.x - self.y
         self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.exception))
+                        in str(context.warning))
 
-        with self.assertRaises(Exception) as context:
+        with self.assertWarns(UserWarning) as context:
             self.x * self.y
         self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.exception))
+                        in str(context.warning))
 
-        with self.assertRaises(Exception) as context:
+        with self.assertWarns(UserWarning) as context:
             self.x / self.y
         self.assertTrue("The dtype of left and right variables are not the same"
-                        in str(context.exception))
+                        in str(context.warning))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
When the dtypes of left variable and right variable are not the same, the operator compute (such as +-*/) will follow with the left variable dtypes. This PR add the warning message to the users.

The problem:
![image](https://user-images.githubusercontent.com/13469016/108802849-1c1b4d80-75d4-11eb-9cdb-2683b9b7bce9.png)
 
![image](https://user-images.githubusercontent.com/13469016/108824235-74fedc00-75fc-11eb-8531-f8d4e2246c01.png)

