### PR TITLE
Fix layernorm grad kernel launch

### DIFF
--- a/paddle/fluid/operators/layer_norm_op.cu
+++ b/paddle/fluid/operators/layer_norm_op.cu
@@ -359,10 +359,11 @@ __global__ void LayerNormBackwardComputeGradInput(
     // epsilon, const T* gamma,
     const U *__restrict__ mean, const U *__restrict__ var, const float epsilon,
     const U *gamma, T *grad_input) {
+  {
 #ifdef __HIPCC__
-  for (auto i1 = hipBlockIdx_y; i1 < n1; i1 += hipGridDim_y) {
+    auto i1 = hipBlockIdx_x;
 #else
-  for (auto i1 = blockIdx.y; i1 < n1; i1 += gridDim.y) {
+    auto i1 = blockIdx.x;
 #endif
     U sum_loss1 = U(0);
     U sum_loss2 = U(0);
@@ -831,9 +832,8 @@ static void LayerNormBackward(const T *x, const T *d_y, const U *scale,
       constexpr int BDIMX1 = 32;
       constexpr int BDIMY1 = 4;
       dim3 threads1(BDIMX1, BDIMY1, 1);
-      const dim3 blocks1(1, batch_size, 1);
       LayerNormBackwardComputeGradInput<
-          T, U, BDIMX1, BDIMY1><<<blocks1, threads1, 0, stream>>>(
+          T, U, BDIMX1, BDIMY1><<<batch_size, threads1, 0, stream>>>(
           d_y, x, batch_size, feature_size, mean, var, epsilon, scale, d_x);
       break;
     }

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -214,7 +214,7 @@ class TestLayerNormOp(unittest.TestCase):
                 self.__assert_close(y, out[0], "y")
                 self.__assert_close(mean, out[1], "mean")
                 self.__assert_close(variance, out[2], "variance", 1e-3)
-                self.__assert_close(x_grad, out[3], "x_grad")
+                self.__assert_close(x_grad, out[3], "x_grad", 1e-3)
                 if has_scale:
                     self.__assert_close(scale_grad,
                                         out[fetch_list.index('scale@GRAD')],
@@ -273,6 +273,9 @@ class TestLayerNormOp(unittest.TestCase):
             has_scale=False,
             has_bias=False,
             y_grad_scale=0.1)
+
+    def test_check_forward_backward_with_large_batch(self):
+        self.check_forward_backward(shape=[128, 512, 4], begin_norm_axis=2)
 
 
 class TestLayerNormAPI(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op.py
@@ -214,7 +214,7 @@ class TestLayerNormOp(unittest.TestCase):
                 self.__assert_close(y, out[0], "y")
                 self.__assert_close(mean, out[1], "mean")
                 self.__assert_close(variance, out[2], "variance", 1e-3)
-                self.__assert_close(x_grad, out[3], "x_grad", 1e-3)
+                self.__assert_close(x_grad, out[3], "x_grad")
                 if has_scale:
                     self.__assert_close(scale_grad,
                                         out[fetch_list.index('scale@GRAD')],
@@ -273,9 +273,6 @@ class TestLayerNormOp(unittest.TestCase):
             has_scale=False,
             has_bias=False,
             y_grad_scale=0.1)
-
-    def test_check_forward_backward_with_large_batch(self):
-        self.check_forward_backward(shape=[128, 512, 4], begin_norm_axis=2)
 
 
 class TestLayerNormAPI(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
CUDA grid only allows up to 65535 for the `y` and `z` dim, not enough for some large batch cases ,
 e.g., transformer with batch * step of 128 * 512 (will error out with "invalid configuration arguments"),
OTOH the `x` dim can go up to `2^31`.

**NOTE:** ideally a unit test with large batch should be added, but it takes > 1min to run, therefore not included.