### PR TITLE
Add bf16 GRU model test

### DIFF
--- a/paddle/fluid/inference/tests/api/CMakeLists.txt
+++ b/paddle/fluid/inference/tests/api/CMakeLists.txt
@@ -142,6 +142,19 @@ function(inference_analysis_api_lexical_test_run TARGET_NAME test_binary infer_m
              --iterations=2)
 endfunction()
 
+function(inference_analysis_api_lexical_bfloat16_test_run TARGET_NAME test_binary infer_model data_path)
+    inference_analysis_test_run(${TARGET_NAME}
+    COMMAND ${test_binary}
+        ARGS --infer_model=${infer_model}
+             --infer_data=${data_path}
+             --batch_size=50
+             --cpu_num_threads=${CPU_NUM_THREADS_ON_CI}
+             --with_accuracy_layer=true
+             --use_analysis=true
+             --enable_bf16=true
+             --iterations=2)
+endfunction()
+
 function(preprocess_data2bin_test_run target py_script_source data_dir output_file)
 	py_test(${target} SRCS ${CMAKE_CURRENT_SOURCE_DIR}/${py_script_source}
 	        ARGS --data_dir=${data_dir}
@@ -421,6 +434,8 @@ if(WITH_MKLDNN)
   inference_analysis_api_test_build(${LEXICAL_TEST_APP} ${LEXICAL_TEST_APP_SRC})
   # run lexcial analysis test
   inference_analysis_api_lexical_test_run(test_analyzer_lexical_gru ${LEXICAL_TEST_APP} ${GRU_MODEL_PATH} ${GRU_DATA_PATH})
+  # run bfloat16 lexical analysis test
+  inference_analysis_api_lexical_bfloat16_test_run(test_analyzer_lexical_gru_bfloat16 ${LEXICAL_TEST_APP} ${GRU_MODEL_PATH} ${GRU_DATA_PATH})
 
   ### optimized FP32 vs. Quant INT8 tests
   

--- a/paddle/fluid/inference/tests/api/analyzer_lexical_analysis_gru_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_lexical_analysis_gru_tester.cc
@@ -38,6 +38,7 @@ void SetAnalysisConfig(AnalysisConfig *cfg,
   cfg->SwitchSpecifyInputNames(false);
   cfg->SetCpuMathLibraryNumThreads(num_threads);
   cfg->EnableMKLDNN();
+  cfg->pass_builder()->AppendPass("mkldnn_placement_pass");
 }
 
 std::vector<size_t> ReadSentenceLod(std::ifstream &file, size_t offset,
@@ -210,7 +211,7 @@ TEST(Analyzer_lexical_test, Analyzer_lexical_analysis) {
   if (FLAGS_use_analysis) {
     AnalysisConfig analysis_cfg;
     SetAnalysisConfig(&analysis_cfg, FLAGS_cpu_num_threads);
-    analysis_cfg.pass_builder()->AppendPass("mkldnn_placement_pass");
+    if (FLAGS_enable_bf16) analysis_cfg.EnableMkldnnBfloat16();
     std::vector<double> acc_analysis(3);
     acc_analysis = Lexical_Test(input_slots_all, &outputs, &analysis_cfg, true);
     for (size_t i = 0; i < acc_analysis.size(); i++) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 
### Describe
<!-- Describe what this PR does -->
This PR adds the bfloat16 GRU model test.
The results for the BF16 on the CooperLake are as follows: 

batch size = 50, iterations = 160
|   | Native FP32 | FP32    | BF16    | (BF16/FP32)  |
|--------|-------------|---------|---------|--------------|
| FPS (1 thread)  | 2794.97     | 2700.45 | 4210.27 | 1.56         |
| FPS (4 threads) | 3076.66     | 4756.45 | 6186.94 | 1.30         |

| GRU model  | FP32    | BF16    | diff     |
|------------|---------|---------|----------|
| Precision  | 0.89211 | 0.89225 | -0.00014 |
|  Recall    | 0.89442 | 0.89457 | -0.00015 |
| F1 score   | 0.89326 | 0.89341 | -0.00015 |