### PR TITLE
Try to fix test_multiprocess_reader_exception failed

### DIFF
--- a/python/paddle/fluid/tests/unittests/CMakeLists.txt
+++ b/python/paddle/fluid/tests/unittests/CMakeLists.txt
@@ -653,7 +653,7 @@ if(NOT WIN32 AND NOT APPLE)
 endif()
 
 if (NOT WIN32)
-    set_tests_properties(test_multiprocess_reader_exception PROPERTIES TIMEOUT 120)
+    set_tests_properties(test_multiprocess_reader_exception PROPERTIES LABELS "RUN_TYPE=EXCLUSIVE")
     set_tests_properties(test_layers PROPERTIES TIMEOUT 120)
     set_tests_properties(test_ir_memory_optimize_transformer PROPERTIES TIMEOUT 120)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Try to fix test_multiprocess_reader_exception failed

观察：
1. 这个单测自记录以来挂过3次，均为Timeout，而且通过rerun都可以通过，本身出现非常低频，且本地无法复现
2. 这个单测正常执行仅需10余秒，但Timeout均是120秒之后还未执行完成，这基本就是hang住了，不是单测本身执行时间长
![image](https://user-images.githubusercontent.com/22561442/108936698-6f9ba300-7689-11eb-9fa3-295dbf61c2bf.png)
![image](https://user-images.githubusercontent.com/22561442/108937023-84783680-7689-11eb-9fb8-667babc87604.png)

推断结论：
- 这是个要频繁使用python multiprocessing模块的单测，之前在处理多进程dataloader单测时遇到过这种情况，multiprocessing在py3 CI单测并行调度时，会偶尔出现hang住的情况，这种解决方法就是单测独占执行，所以修改了这个单测的cmake配置
- 超时不用设置，直接设置独占就可以，对整体时间的影响不大