### PR TITLE
fix the modification of set_expected_place

### DIFF
--- a/paddle/fluid/imperative/tests/test_tracer.cc
+++ b/paddle/fluid/imperative/tests/test_tracer.cc
@@ -72,6 +72,13 @@ TEST(test_tracer, test_trace_op) {
   framework::AttributeMap mul_attr_map;
   mul_attr_map["use_mkldnn"] = false;
   tracer.TraceOp("mul", ins, outs, mul_attr_map, place, true);
+
+#ifndef PADDLE_WITH_XPU
+  ASSERT_THROW(tracer.TraceOp("mul", ins, outs, mul_attr_map,
+                              platform::XPUPlace(0), true);
+               , platform::EnforceNotMet);
+#endif
+
   const auto& out_tensor = vout->Var().Get<framework::LoDTensor>();
   for (int i = 0; i < vout->Var().Get<framework::LoDTensor>().numel(); i++) {
     ASSERT_EQ(out_tensor.data<float>()[i], 20.0);
@@ -311,10 +318,6 @@ TEST(test_tracer, test_expected_place) {
     platform::CUDAPlace gpu_place(0);
     tracer.SetExpectedPlace(gpu_place);
     ASSERT_EQ(platform::is_gpu_place(tracer.ExpectedPlace()), true);
-
-    // assert throw
-    platform::XPUPlace xpu_place(0);
-    ASSERT_THROW(tracer.SetExpectedPlace(xpu_place), platform::EnforceNotMet);
 #endif
   }
   {
@@ -323,10 +326,6 @@ TEST(test_tracer, test_expected_place) {
     platform::XPUPlace xpu_place(0);
     tracer.SetExpectedPlace(xpu_place);
     ASSERT_EQ(platform::is_xpu_place(tracer.ExpectedPlace()), true);
-
-    // assert throw
-    platform::CUDAPlace cuda_place(0);
-    ASSERT_THROW(tracer.SetExpectedPlace(cuda_place), platform::EnforceNotMet);
 #endif
   }
 }

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -162,6 +162,23 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
   }
 
   try {
+    if (platform::is_gpu_place(place)) {
+#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+      platform::SetDeviceId(BOOST_GET_CONST(platform::CUDAPlace, place).device);
+#else
+      PADDLE_THROW(platform::errors::PreconditionNotMet(
+          "PaddlePaddle should compile with GPU if use CUDAPlace."));
+#endif
+    } else if (platform::is_xpu_place(place)) {
+#ifdef PADDLE_WITH_XPU
+      platform::SetXPUDeviceId(
+          BOOST_GET_CONST(platform::XPUPlace, place).device);
+#else
+      PADDLE_THROW(platform::errors::PreconditionNotMet(
+          "PaddlePaddle should compile with XPU if use XPUPlace."));
+#endif
+    }
+
     OpBase::Run(*op, new_ins, outs, attrs, place);
   } catch (platform::EnforceNotMet& exception) {
     framework::AppendErrorOpHint(type, &exception);

--- a/paddle/fluid/imperative/tracer.cc
+++ b/paddle/fluid/imperative/tracer.cc
@@ -199,22 +199,6 @@ void Tracer::TraceOp(const std::string& type, const NameVarBaseMap& ins,
 }
 
 void Tracer::SetExpectedPlace(platform::Place place) {
-  // NOTE(wangxi): set device id before launch device kernel
-  if (platform::is_gpu_place(place)) {
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    platform::SetDeviceId(BOOST_GET_CONST(platform::CUDAPlace, place).device);
-#else
-    PADDLE_THROW(platform::errors::PreconditionNotMet(
-        "PaddlePaddle should compile with GPU if use CUDAPlace."));
-#endif
-  } else if (platform::is_xpu_place(place)) {
-#ifdef PADDLE_WITH_XPU
-    platform::SetXPUDeviceId(BOOST_GET_CONST(platform::XPUPlace, place).device);
-#else
-    PADDLE_THROW(platform::errors::PreconditionNotMet(
-        "PaddlePaddle should compile with XPU if use XPUPlace."));
-#endif
-  }
   expected_place_ = place;
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
revert the modification of set_expected_place

I add `cudaSetDevice()` in `SetExpectedPlace` in dygraph mode in PR #30338, and the logic is updated in #30868.

This PR revert the changes since in multi-process dataloader,  using CUDA APIs in subprocess may result in error since the
cuda runtime is not initialized.

![image](https://user-images.githubusercontent.com/6888866/108942162-6f070a80-7691-11eb-8c4a-a3fe720ddf86.png)

So this PR revert that changes, and the problem in PR #30338 can be fixed by adding `DeviceGuard` in `SetTensorFromPyArrayT`, which is already done in #30868.

Reproduce code:
```
import os
import numpy as np
import paddle
import paddle.nn.functional as F
from paddle.io import Dataset, DataLoader, DistributedBatchSampler

class FakeDataset(Dataset):
    def __init__(self, num_samples=1000):
        self.num_samples = num_samples

    def __getitem__(self, idx):
        data1 = np.random.rand(3, 32, 32).astype("float32")
        data2 = np.random.rand(3, 32, 32).astype("float32")
        return [data1, data2]
        
    def __len__(self):
        return self.num_samples


def collate_fn(batch):
    with paddle.fluid.dygraph.guard(place=paddle.CPUPlace()):
        width_list = np.array(
            [image_set_i[0].shape[2] for image_set_i in batch])
        avg_width = int(width_list.mean() / 8 / 2) * 8
        r_imgs = [[] for _ in batch[0]]
        for img_set in batch:
            for j, img in enumerate(img_set):
                img = paddle.to_tensor(
                    np.expand_dims(img, 0), place=paddle.CPUPlace())
                img = F.upsample(img, size=(32, avg_width), mode='bilinear')
                img = paddle.squeeze(img, axis=0)
                r_imgs[j].append(img.numpy())
    return r_imgs

if __name__ == "__main__":
    place = paddle.set_device('gpu')
    dataset = FakeDataset()
    num_workers = 1

    loader = DataLoader(
            dataset,
            batch_size=8,
            collate_fn=collate_fn,
            places=place,
            return_list=True,
            num_workers=num_workers)

    print("finish init dataloader")
    for batch in loader:
        for data in batch:
            print(data.shape)
        exit()
    
```