### PR TITLE
Implement of warpReduceMin and blockReduceMin function

### DIFF
--- a/paddle/fluid/operators/math/math_cuda_utils.h
+++ b/paddle/fluid/operators/math/math_cuda_utils.h
@@ -242,9 +242,9 @@ __inline__ __device__ T blockReduceMin(T val, unsigned mask) {
   int wid = threadIdx.x >> 5;
   int total_num = blockReduceMax(threadIdx.x, FINAL_MASK) + 1;
   int threshold = (total_num >> 5) << 5;
-  shared_last_idx = ((blockDim.x + warpSize - 1) >> 5) - 1;
 
   if (threadIdx.x < threshold) {
+    shared_last_idx = (threshold >> 5) - 1;
     val = warpReduceMin(val, mask);
     if (lane == 0) shared[wid] = val;
   } else {

--- a/paddle/fluid/operators/math/math_cuda_utils.h
+++ b/paddle/fluid/operators/math/math_cuda_utils.h
@@ -239,7 +239,7 @@ __inline__ __device__ T blockReduceMin(T val, unsigned mask) {
   static __shared__ int shared_last_idx;
   int lane = threadIdx.x & 0x1f;
   int wid = threadIdx.x >> 5;
-  int total_num = math::blockReduceMax(threadIdx.x, FINAL_MASK) + 1;
+  int total_num = blockReduceMax(threadIdx.x, FINAL_MASK) + 1;
   int threshold = (total_num >> 5) << 5;
   shared_last_idx = ((blockDim.x + warpSize - 1) >> 5) - 1;
 

--- a/paddle/fluid/operators/math/math_cuda_utils.h
+++ b/paddle/fluid/operators/math/math_cuda_utils.h
@@ -199,6 +199,17 @@ __inline__ __device__ T warpReduceMax(T val, unsigned lane_mask) {
   return val;
 }
 
+template <typename T>
+__inline__ __device__ T warpReduceMin(T val, unsigned lane_mask) {
+  for (int mask = HALF_WARP; mask > 0; mask >>= 1)
+#if __CUDA_ARCH__ >= 350 && CUDA_VERSION >= 9000
+    val = min(val, __shfl_xor_sync(lane_mask, val, mask, warpSize));
+#else
+    val = min(val, __shfl_xor(val, mask, warpSize));
+#endif
+  return val;
+}
+
 /* Calculate the maximum of all elements in a block */
 template <typename T>
 __inline__ __device__ T blockReduceMax(T val, unsigned mask) {
@@ -217,6 +228,41 @@ __inline__ __device__ T blockReduceMax(T val, unsigned mask) {
   val = (lane < block_span) ? shared[lane] : -1e10f;
   val = warpReduceMax(val, mask);
 
+  return val;
+}
+
+/* Calculate the minimum of all elements in a block */
+template <typename T>
+__inline__ __device__ T blockReduceMin(T val, unsigned mask) {
+  static __shared__ T shared[WARP_SIZE];
+  static __shared__ T shared_last_val;
+  static __shared__ int shared_last_idx;
+  int lane = threadIdx.x & 0x1f;
+  int wid = threadIdx.x >> 5;
+  int total_num = math::blockReduceMax(threadIdx.x, FINAL_MASK) + 1;
+  int threshold = (total_num >> 5) << 5;
+  shared_last_idx = ((blockDim.x + warpSize - 1) >> 5) - 1;
+
+  if (threadIdx.x < threshold) {
+    val = warpReduceMin(val, mask);
+    if (lane == 0) shared[wid] = val;
+  } else {
+    shared_last_idx = threadIdx.x >> 5;
+    shared_last_val = 1e10;
+    platform::CudaAtomicMin(&shared_last_val, val);
+    shared[shared_last_idx] = shared_last_val;
+  }
+  __syncthreads();
+
+  if (threadIdx.x < threshold) {
+    val = (lane <= shared_last_idx) ? shared[lane] : 1e10f;
+    val = warpReduceMin(val, mask);
+    shared_last_val = val;
+  }
+  __syncthreads();
+  if (threadIdx.x >= threshold) {
+    val = shared_last_val;
+  }
   return val;
 }
 

--- a/paddle/fluid/operators/math/math_cuda_utils.h
+++ b/paddle/fluid/operators/math/math_cuda_utils.h
@@ -15,6 +15,7 @@ limitations under the License. */
 #pragma once
 #include <cuda_fp16.h>
 #include <algorithm>
+#include "paddle/fluid/platform/cuda_primitives.h"
 
 namespace paddle {
 namespace operators {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 

### Describe
<!-- Describe what this PR does -->
A. 预置条件：
1. 全部线程所携带的变量名一致；

B. 函数目的 :
1. 增加函数 warpReduceMin，用于直接搜索线程数量等于warpSize情况下，线程内部同名变量最小值
2. 增加函数 PartialWarpReduceMin，用于直接搜索线程数量小于warpSize情况下，线程内部同名变量最小值；
3. 增加函数 blockReduceMin，用于直接搜索线程数量等于BlockDim情况下，线程内部同名变量最小值；
4. 增加函数 PartialWarpReduceMin，用于直接搜索线程数量小于BlockDim情况下，线程内部同名变量最小值；

C. 实现原理：
- warpReduceMin实现原理:
1. 使用__shfl_xor_sync() 接口，用warp折半对比的方式，取得这组线程的最小值；

- PartialWarpReduceMin实现原理:
1.  使用__shfl_sync() 接口，将第一个传入线程携带的变量广播至整个 warp内，完成warp内的初值化操作；
2. 将线程组携带的变量传入已初始化的warp上；
3. 使用__shfl_xor_sync() 接口，用warp折半对比的方式，取得这组线程的最小值；