### PR TITLE
【Cherry-pick 29260】change import math.h to cmath

### DIFF
--- a/paddle/fluid/memory/allocation/best_fit_allocator.cc
+++ b/paddle/fluid/memory/allocation/best_fit_allocator.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "paddle/fluid/memory/allocation/best_fit_allocator.h"
-#include <math.h>
+#include <cmath>
 
 namespace paddle {
 namespace memory {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

When building Paddle 2.0.0 with gcc 5.4, the following error occurs:
```
/data/repos/PaddlePaddle/Paddle/paddle/fluid/memory/allocation/best_fit_allocator.cc: In function ‘int paddle::memory::allocation::HighestBitPos(size_t)’:
/data/repos/PaddlePaddle/Paddle/paddle/fluid/memory/allocation/best_fit_allocator.cc:29:29: error: ‘log2’ is not a member of ‘std’
     return static_cast<int>(std::log2(N) + 1);
                             ^
/data/repos/PaddlePaddle/Paddle/paddle/fluid/memory/allocation/best_fit_allocator.cc:29:29: note: suggested alternative:
In file included from /usr/include/features.h:424:0,
                 from /usr/include/x86_64-linux-gnu/c++/5/bits/os_defines.h:39,
                 from /usr/include/x86_64-linux-gnu/c++/5/bits/c++config.h:489,
                 from /usr/include/c++/5/exception:37,
                 from /usr/include/c++/5/stdexcept:38,
                 from /usr/include/c++/5/array:38,
                 from /data/repos/PaddlePaddle/Paddle/paddle/fluid/memory/allocation/best_fit_allocator.h:16,
                 from /data/repos/PaddlePaddle/Paddle/paddle/fluid/memory/allocation/best_fit_allocator.cc:15:
/usr/include/x86_64-linux-gnu/bits/mathcalls.h:133:1: note:   ‘log2’
 __MATHCALL (log2,, (_Mdouble_ __x));
 ^
paddle/fluid/memory/allocation/CMakeFiles/best_fit_allocator.dir/build.make:82: recipe for target 'paddle/fluid/memory/allocation/CMakeFiles/best_fit_allocator.dir/best_fit_allocator.cc.o' failed
make[2]: *** [paddle/fluid/memory/allocation/CMakeFiles/best_fit_allocator.dir/best_fit_allocator.cc.o] Error 1
CMakeFiles/Makefile2:4914: recipe for target 'paddle/fluid/memory/allocation/CMakeFiles/best_fit_allocator.dir/all' failed
```

PR #29260 solved the problem.