### PR TITLE
[CP] fix the bug in expand_v2 op

### DIFF
--- a/paddle/fluid/operators/expand_v2_op.cc
+++ b/paddle/fluid/operators/expand_v2_op.cc
@@ -66,6 +66,9 @@ class ExpandV2Op : public framework::OperatorWithKernel {
         out_shape[i] = -1;
       } else if (expand_shape[i] == -1) {
         out_shape[i] = x_dims[i];
+      } else if (expand_shape[i] == -2) {
+        // We use -2 to represent the element in expand_shape is a var.
+        out_shape[i] = -1;
       } else {
         PADDLE_ENFORCE_GT(
             expand_shape[i], 0,
@@ -174,7 +177,7 @@ class ExpandV2GradOp : public framework::OperatorWithKernel {
     x_dim_vec.insert(x_dim_vec.begin(), diff, -1);
 
     for (size_t i = 0; i < expand_shape.size(); ++i) {
-      if (expand_shape[i] == -1 || x_dim_vec[i] == -1) {
+      if (expand_shape[i] < 0 || x_dim_vec[i] == -1) {
         continue;
       } else {
         if (ctx->IsRuntime()) {

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1448,7 +1448,7 @@ def expand(x, shape, name=None):
         attrs_expand_shape = []
         for idx, shape in enumerate(list_expand_shape):
             if isinstance(shape, Variable):
-                attrs_expand_shape.append(-1)
+                attrs_expand_shape.append(-2)
             else:
                 attrs_expand_shape.append(shape)
                 assert shape > 0 or shape == -1, (


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix the bug in expand_v2 op.

Paddle框架在编译期使用-1表示未知维度值，如batch size的值。expand_v2 OP使用-1表示保持相应维度地维度值不变。例如，b = expand(a, shape=[4, -1, 2]), 假设a.shape = [2, 3, 2], 则b.shape = [4, 3, 2]。

当expand的shape参数列表中包含var是，例如，c = expand(a, shape=[temp_var, 3, 2])是，expand在编译期会将expand OP的expand_shape属性var对应的值设置为-1， 上例中expand_shape的属性值为[-1, 3, 2]。那么编译期c.shape = [2, 3, 2]。
当temp_var表示未知维度值时，和期望的结果不符，期望的结果是c.shape = [-1, 3, 2]。

本pr在编译器将temp_var对应的维度值设置为-1，表示编译期未知维度，解决上述问题。