### PR TITLE
[CP] align fleet param

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -139,9 +139,9 @@ message DistributedStrategy {
   optional bool fuse_all_reduce_ops = 18 [ default = true ];
   optional int32 fuse_grad_size_in_MB = 19 [ default = 32 ];
   optional float fuse_grad_size_in_TFLOPS = 20 [ default = 50 ];
-  optional bool cudnn_exhaustive_search = 21 [ default = true ];
+  optional bool cudnn_exhaustive_search = 21 [ default = false ];
   optional int32 conv_workspace_size_limit = 22 [ default = 512 ];
-  optional bool cudnn_batchnorm_spatial_persistent = 23 [ default = true ];
+  optional bool cudnn_batchnorm_spatial_persistent = 23 [ default = false ];
   optional bool adaptive_localsgd = 24 [ default = false ];
   optional bool fp16_allreduce = 25 [ default = false ];
   optional bool sharding = 26 [ default = false ];

--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -140,7 +140,7 @@ message DistributedStrategy {
   optional int32 fuse_grad_size_in_MB = 19 [ default = 32 ];
   optional float fuse_grad_size_in_TFLOPS = 20 [ default = 50 ];
   optional bool cudnn_exhaustive_search = 21 [ default = true ];
-  optional int32 conv_workspace_size_limit = 22 [ default = 4000 ];
+  optional int32 conv_workspace_size_limit = 22 [ default = 512 ];
   optional bool cudnn_batchnorm_spatial_persistent = 23 [ default = true ];
   optional bool adaptive_localsgd = 24 [ default = false ];
   optional bool fp16_allreduce = 25 [ default = false ];

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -115,6 +115,22 @@ class DistributedStrategy(object):
 
         """
         self.strategy = distributed_strategy_pb2.DistributedStrategy()
+
+        # Set the default values of the following flags to the ones set by users
+        key = 'FLAGS_cudnn_batchnorm_spatial_persistent'
+        if core.globals().is_public(key):
+            self.strategy.cudnn_batchnorm_spatial_persistent = bool(
+                core.globals()[key])
+        key = 'FLAGS_conv_workspace_size_limit'
+        if core.globals().is_public(key):
+            self.strategy.conv_workspace_size_limit = int(core.globals()[key])
+        key = 'FLAGS_cudnn_exhaustive_search'
+        if core.globals().is_public(key):
+            self.strategy.cudnn_exhaustive_search = bool(core.globals()[key])
+        key = 'FLAGS_sync_nccl_allreduce'
+        if core.globals().is_public(key):
+            self.strategy.sync_nccl_allreduce = bool(core.globals()[key])
+
         self.__lock_attr = True
 
     def __setattr__(self, key, value):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix the default value of fleet conv_workspace_size_limit to 512 to align to the single card configuration and avoid the issue of OOM.
Align the default value of some configuration for fleet to that of single cards (i.e., the values of main framework instead of the values in fleet).

cudnn_exhaustive_search
cudnn_batchnorm_spatial_persistent
conv_workspace_size_limit
sync_nccl_allreduce
Todo:
how to deal with fuse_parameter_memory_size, the default value of which is -1 in framework, which is incompatible with dygraph (reducer).
