### PR TITLE
change np.int to int to fix paddle warning

### DIFF
--- a/python/paddle/fluid/layers/utils.py
+++ b/python/paddle/fluid/layers/utils.py
@@ -23,7 +23,7 @@ from ..layer_helper import LayerHelper
 from sys import version_info
 
 
-def convert_to_list(value, n, name, dtype=np.int):
+def convert_to_list(value, n, name, dtype=int):
     """
     Converts a single numerical type or iterable of numerical
     types into an numerical type list.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

编包`import paddle`后，会出现warning。为了美观，按warning中提示，将`np.int`改成了`int`。

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/26408901/109145673-c2667f00-779d-11eb-8779-6d4a1a34a2ad.png">
