### PR TITLE
add TensorRT6_cuda10.2_cudnn7 in install_trt.sh

### DIFF
--- a/tools/dockerfile/build_scripts/install_trt.sh
+++ b/tools/dockerfile/build_scripts/install_trt.sh
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 VERSION=$(nvcc --version | grep release | grep -oEi "release ([0-9]+)\.([0-9])"| sed "s/release //")
+CUDNN_VERSION="cudnn8"
 
 if [[ "$VERSION" == "10.1" ]];then
   wget -q https://paddle-ci.gz.bcebos.com/TRT/TensorRT6-cuda10.1-cudnn7.tar.gz --no-check-certificate
@@ -26,11 +27,16 @@ elif [[ "$VERSION" == "11.0" ]];then
   tar -zxf TensorRT-7.1.3.4.Ubuntu-16.04.x86_64-gnu.cuda-11.0.cudnn8.0.tar.gz -C /usr/local
   cp -rf /usr/local/TensorRT-7.1.3.4/include/* /usr/include/ && cp -rf /usr/local/TensorRT-7.1.3.4/lib/* /usr/lib/
   rm TensorRT-7.1.3.4.Ubuntu-16.04.x86_64-gnu.cuda-11.0.cudnn8.0.tar.gz
-elif [[ "$VERSION" == "10.2" ]];then
+elif [[ "$VERSION" == "10.2" && "$CUDNN_VERSION" == "cudnn8" ]];then
   wget https://paddle-ci.gz.bcebos.com/TRT/TensorRT7-cuda10.2-cudnn8.tar.gz --no-check-certificate
   tar -zxf TensorRT7-cuda10.2-cudnn8.tar.gz -C /usr/local
   cp -rf /usr/local/TensorRT-7.1.3.4/include/* /usr/include/ && cp -rf /usr/local/TensorRT-7.1.3.4/lib/* /usr/lib/
   rm TensorRT7-cuda10.2-cudnn8.tar.gz
+elif [[ "$VERSION" == "10.2" && "$CUDNN_VERSION" == "cudnn7" ]];then
+  wget https://paddle-ci.gz.bcebos.com/TRT/TensorRT6-cuda10.2-cudnn7.tar.gz --no-check-certificate
+  tar -zxf TensorRT6-cuda10.2-cudnn7.tar.gz -C /usr/local
+  cp -rf /usr/local/TensorRT-6.0.1.8/include/* /usr/include/ && cp -rf /usr/local/TensorRT-6.0.1.8/lib/* /usr/lib/
+  rm TensorRT6-cuda10.2-cudnn7.tar.gz
 elif [[ "$VERSION" == "10.0" ]];then
   wget -q https://paddle-ci.gz.bcebos.com/TRT/TensorRT6-cuda10.0-cudnn7.tar.gz --no-check-certificate
   tar -zxf TensorRT6-cuda10.0-cudnn7.tar.gz -C /usr/local


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
ATT
now only have TensorRT7_cuda10.2_cudnn8
add TensorRT6_cuda10.2_cudnn7