### PR TITLE
Fix fc doc string and add more restriction on the input.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_fleet_amp_init.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_amp_init.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import unittest
+
+import numpy as np
+
 import paddle
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet as fleet
 import paddle.fluid as fluid
-import unittest
 import paddle.nn.functional as F
-import numpy as np
 
 paddle.enable_static()
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_amp_init.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_amp_init.py
@@ -34,7 +34,7 @@ def gen_data():
 def mlp(input_x, input_y, hid_dim=128, label_dim=2):
     fc_1 = paddle.static.nn.fc(x=input_x, size=hid_dim, activation='tanh')
     fc_2 = paddle.static.nn.fc(x=fc_1, size=hid_dim, activation='tanh')
-    prediction = paddle.static.nn.fc(x=[fc_2],
+    prediction = paddle.static.nn.fc(x=fc_2,
                                      size=label_dim,
                                      activation='softmax')
     cost = F.cross_entropy(input=prediction, label=input_y)

--- a/python/paddle/fluid/tests/unittests/test_fleet_amp_init.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_amp_init.py
@@ -19,7 +19,6 @@ import numpy as np
 import paddle
 import paddle.distributed.fleet.base.role_maker as role_maker
 import paddle.distributed.fleet as fleet
-import paddle.fluid as fluid
 import paddle.nn.functional as F
 
 paddle.enable_static()
@@ -46,7 +45,7 @@ def mlp(input_x, input_y, hid_dim=128, label_dim=2):
 
 class TestFleetAMPInit(unittest.TestCase):
     def test_fleet_amp_init(self):
-        if not fluid.core.is_compiled_with_cuda():
+        if not paddle.is_compiled_with_cuda():
             return
 
         main_program = paddle.static.Program()
@@ -65,7 +64,7 @@ class TestFleetAMPInit(unittest.TestCase):
             optimizer = paddle.optimizer.Momentum(
                 learning_rate=0.001,
                 momentum=0.9,
-                weight_decay=fluid.regularizer.L2Decay(1e-4),
+                weight_decay=paddle.regularizer.L2Decay(1e-4),
                 multi_precision=True)
 
             optimizer = paddle.static.amp.decorate(optimizer)
@@ -85,7 +84,7 @@ class TestFleetAMPInit(unittest.TestCase):
                                fetch_list=[cost.name])
 
     def test_fleet_amp_meta_optimizer_init(self):
-        if not fluid.core.is_compiled_with_cuda():
+        if not paddle.is_compiled_with_cuda():
             return
 
         main_program = paddle.static.Program()
@@ -104,7 +103,7 @@ class TestFleetAMPInit(unittest.TestCase):
             optimizer = paddle.optimizer.Momentum(
                 learning_rate=0.001,
                 momentum=0.9,
-                weight_decay=fluid.regularizer.L2Decay(1e-4),
+                weight_decay=paddle.regularizer.L2Decay(1e-4),
                 multi_precision=True)
 
             strategy = paddle.distributed.fleet.DistributedStrategy()

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -73,23 +73,10 @@ def fc(x,
         out.data = [[0.83234344], [0.34936576]]
         out.shape = (1, 2, 1)
 
-        # Case 2, input is a list of tensor:
-        x0.data = [[[0.1, 0.2],
-                    [0.3, 0.4]]]
-        x0.shape = (1, 2, 2) # 1 is batch_size
-
-        x1.data = [[[0.1, 0.2, 0.3]]]
-        x1.shape = (1, 1, 3)
-
-        out = paddle.static.nn.fc(x=[x0, x1], size=2)
-
-        # Get the output:
-        out.data = [[0.18669507, 0.1893476]]
-        out.shape = (1, 2)
-
     Args:
-        x (Tensor|list of Tensor): A tensor or a list of tensor. The number of dimensions
-            of each tensor is at least 2. The data type should be float16, float32 or float64.
+        x (Tensor): A tensor. X should not be a list of tensor otherwise the parameter would
+            not be correct. The number of dimensions of each tensor is at least 2. 
+            The data type should be float16, float32 or float64.
         size (int): The number of output units in this layer, which also means the feature
             size of output tensor.
         num_flatten_dims (int, optional): The fc layer can accept an input tensor with more than
@@ -130,10 +117,11 @@ def fc(x,
           import paddle
           paddle.enable_static()
 
-          # When input is a single tensor
+          # input should be a single tensor
           x = paddle.static.data(name="x", shape=[1, 2, 2], dtype="float32")
           # x: [[[0.1 0.2]
           #      [0.3 0.4]]]
+
           out = paddle.static.nn.fc(
               x=x,
               size=1,
@@ -142,20 +130,11 @@ def fc(x,
               bias_attr=paddle.ParamAttr(initializer=paddle.nn.initializer.Constant(value=1.0)))
           # out: [[[1.15]
           #        [1.35]]]
-
-          # When input is multiple tensors
-          x0 = paddle.static.data(name="x0", shape=[1, 2, 2], dtype="float32")
-          # x0: [[[0.1 0.2]
-          #       [0.3 0.4]]]
-          x1 = paddle.static.data(name="x1", shape=[1, 1, 3], dtype="float32")
-          # x1: [[[0.1 0.2 0.3]]]
-          out = paddle.static.nn.fc(
-              x=[x0, x1],
-              size=2,
-              weight_attr=paddle.ParamAttr(initializer=paddle.nn.initializer.Constant(value=0.5)),
-              bias_attr=paddle.ParamAttr(initializer=paddle.nn.initializer.Constant(value=1.0)))
-          # out: [[1.8 1.8]]
     """
+    if isinstance(x, list):
+        raise TypeError(
+            "the type of 'x' for fc API should be tensor, but received type of x: {}".
+            format(type(x)))
     return paddle.fluid.layers.fc(input=x,
                                   size=size,
                                   num_flatten_dims=num_flatten_dims,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Fix fc doc string and add more restriction on the input, because otherwise the weight_atrr parameter will not match with the input x.

```
import paddle.fluid as fluid
import paddle
from paddle.fluid.param_attr import ParamAttr
paddle.enable_static()
#x = fluid.layers.data(name='x', shape=[5], dtype='float32')

data_21 = fluid.layers.data(name="data_21", shape=[8,8], dtype="float32")
data_22 = fluid.layers.data(name="data_22", shape=[8,8], dtype="float32")
data_23 = fluid.layers.concat(input=[data_21, data_22], axis=-1)

fc21 = paddle.static.nn.fc(x=data_23, size=128, weight_attr=ParamAttr(name='fc21.w'), bias_attr=ParamAttr(name='fc21.b'))

fc22 = paddle.static.nn.fc(x=[data_21, data_22], size=128, weight_attr=ParamAttr(name='fc22.w'), bias_attr=ParamAttr(name='fc22.b'))

# get tensor
place = fluid.CPUPlace()
exe = fluid.Executor(place)
exe.run(fluid.default_startup_program())
ret21w = fluid.global_scope().find_var("fc21.w").get_tensor()
ret21b = fluid.global_scope().find_var("fc21.b").get_tensor()
ret22w = fluid.global_scope().find_var("fc22.w").get_tensor()
ret22b = fluid.global_scope().find_var("fc22.b").get_tensor()

import numpy as np
print(np.array(ret21w).shape)
print(np.array(ret21b).shape)
print(np.array(ret22w).shape)
print(np.array(ret22b).shape)

# output the following
```
![image](https://user-images.githubusercontent.com/18322401/109267516-a2d66180-7844-11eb-8c8b-1a0a739878c0.png)

