### PR TITLE
【cherry-pick】 Fix xpu compile and cipher symbol problem

### DIFF
--- a/cmake/external/xpu.cmake
+++ b/cmake/external/xpu.cmake
@@ -4,6 +4,8 @@ endif()
 
 INCLUDE(ExternalProject)
 SET(XPU_PROJECT                 "extern_xpu")
+SET(XPU_API_LIB_NAME            "libxpuapi.so")
+SET(XPU_RT_LIB_NAME             "libxpurt.so")
 
 if(NOT XPU_SDK_ROOT)
   if (WITH_AARCH64)
@@ -20,8 +22,6 @@ if(NOT XPU_SDK_ROOT)
   SET(XPU_API_INC_DIR             "${THIRD_PARTY_PATH}/install/xpu/include")
   SET(XPU_LIB_DIR                 "${THIRD_PARTY_PATH}/install/xpu/lib")
 
-  SET(XPU_API_LIB_NAME            "libxpuapi.so")
-  SET(XPU_RT_LIB_NAME             "libxpurt.so")
   SET(XPU_API_LIB                 "${XPU_LIB_DIR}/${XPU_API_LIB_NAME}")
   SET(XPU_RT_LIB                  "${XPU_LIB_DIR}/${XPU_RT_LIB_NAME}")
 

--- a/cmake/third_party.cmake
+++ b/cmake/third_party.cmake
@@ -322,6 +322,7 @@ endif (WITH_LITE)
 
 if (WITH_CRYPTO)
     include(external/cryptopp)   # download, build, install cryptopp
+    add_definitions(-DPADDLE_WITH_CRYPTO)
 endif (WITH_CRYPTO)
 
 add_custom_target(third_party ALL DEPENDS ${third_party_deps})

--- a/paddle/fluid/framework/io/crypto/cipher.cc
+++ b/paddle/fluid/framework/io/crypto/cipher.cc
@@ -56,9 +56,4 @@ std::shared_ptr<Cipher> CipherFactory::CreateCipher(
 }
 
 }  // namespace framework
-
-std::shared_ptr<framework::Cipher> MakeCipher(const std::string& config_file) {
-  return framework::CipherFactory::CreateCipher(config_file);
-}
-
 }  // namespace paddle

--- a/paddle/fluid/inference/api/CMakeLists.txt
+++ b/paddle/fluid/inference/api/CMakeLists.txt
@@ -30,8 +30,14 @@ endif()
 cc_library(analysis_config SRCS analysis_config.cc DEPS ${mkldnn_quantizer_cfg} lod_tensor paddle_pass_builder)
 cc_library(paddle_pass_builder SRCS paddle_pass_builder.cc)
 
-cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
-          analysis_config zero_copy_tensor trainer_desc_proto)
+if(WITH_CRYPTO)
+     cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
+               analysis_config zero_copy_tensor trainer_desc_proto paddle_crypto)
+ else()
+     cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
+               analysis_config zero_copy_tensor trainer_desc_proto)
+ endif()
+
 
 if(WIN32)
     target_link_libraries(paddle_inference_api gflags)

--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -146,4 +146,10 @@ std::string UpdateDllFlag(const char *name, const char *value) {
   return ret;
 }
 
+#ifdef PADDLE_WITH_CRYPTO
+std::shared_ptr<framework::Cipher> MakeCipher(const std::string &config_file) {
+  return framework::CipherFactory::CreateCipher(config_file);
+}
+#endif
+
 }  // namespace paddle

--- a/paddle/fluid/inference/api/api_tester.cc
+++ b/paddle/fluid/inference/api/api_tester.cc
@@ -91,4 +91,9 @@ TEST(paddle_inference_api, AnalysisConfigCopyCtor) {
     CHECK_NE(ps, delete_pass);
   }
 }
+
+#ifdef PADDLE_WITH_CRYPTO
+TEST(paddle_inference_api, crypto) { paddle::MakeCipher(""); }
+#endif
+
 }  // namespace paddle

--- a/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
+++ b/paddle/fluid/inference/api/demo_ci/CMakeLists.txt
@@ -36,11 +36,13 @@ include_directories("${PADDLE_LIB_THIRD_PARTY_PATH}protobuf/include")
 include_directories("${PADDLE_LIB_THIRD_PARTY_PATH}glog/include")
 include_directories("${PADDLE_LIB_THIRD_PARTY_PATH}gflags/include")
 include_directories("${PADDLE_LIB_THIRD_PARTY_PATH}xxhash/include")
+include_directories("${PADDLE_LIB_THIRD_PARTY_PATH}cryptopp/include")
 
 link_directories("${PADDLE_LIB_THIRD_PARTY_PATH}protobuf/lib")
 link_directories("${PADDLE_LIB_THIRD_PARTY_PATH}glog/lib")
 link_directories("${PADDLE_LIB_THIRD_PARTY_PATH}gflags/lib")
 link_directories("${PADDLE_LIB_THIRD_PARTY_PATH}xxhash/lib")
+link_directories("${PADDLE_LIB_THIRD_PARTY_PATH}cryptopp/lib")
 link_directories("${PADDLE_LIB}/paddle/lib")
 
 if (WIN32)
@@ -145,12 +147,12 @@ if (NOT WIN32)
   set(EXTERNAL_LIB "-lrt -ldl -lpthread")
   set(DEPS ${DEPS}
       ${MATH_LIB} ${MKLDNN_LIB}
-      glog gflags protobuf  xxhash
+      glog gflags protobuf xxhash cryptopp
       ${EXTERNAL_LIB})
 else()
   set(DEPS ${DEPS}
       ${MATH_LIB} ${MKLDNN_LIB}
-      glog gflags_static libprotobuf  xxhash ${EXTERNAL_LIB})
+      glog gflags_static libprotobuf xxhash cryptopp-static ${EXTERNAL_LIB})
   set(DEPS ${DEPS} shlwapi.lib)
 endif(NOT WIN32)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

cherry-pick https://github.com/PaddlePaddle/Paddle/pull/31271

1. xpu编译如果给定XPU_SDK_ROOT，则默认把toolchain中的so打入wheel，不需要用户再去下载toolchain
2. 预测库动态库中加入paddle::MakeCipher符号，并修复由此引发的demo_ci中的编译问题
