### PR TITLE
fix compilation errors for missing brpc header files

### DIFF
--- a/paddle/fluid/operators/pscore/CMakeLists.txt
+++ b/paddle/fluid/operators/pscore/CMakeLists.txt
@@ -22,7 +22,7 @@ foreach (src ${OPS})
     set_source_files_properties(${src} PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
 endforeach ()
 
-register_operators()
+register_operators(DEPS ${DISTRIBUTE_DEPS})
 
 set(OPERATOR_DEPS ${OPERATOR_DEPS} ${DISTRIBUTE_DEPS} PARENT_SCOPE)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复CI中发现的编译失败问题。

PR：https://github.com/PaddlePaddle/Paddle/pull/31271
日志：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2459272/job/3449906

![image](https://user-images.githubusercontent.com/23427135/109468623-d4029c00-7aa7-11eb-9237-8553bb64a5a3.png)

该问题由于`paddle/fluid/operators/pscore/CMakeLists.txt`中op没有指定依赖brpc导致。

CI中采用ccache编译缓存工具、第三方库依赖缓存方法来加速编译。当CI机器没有第三方缓存、仅有ccache缓存时，由于没有指定pscore op的依赖，会导致pscore op先于第三方库（含brpc）进行编译，从而造成缺少brpc相关头文件的错误。