### PR TITLE
upgrade inference tensor apis, test=develop

### DIFF
--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1195,20 +1195,6 @@ USE_TRT_CONVERTER(clip);
 
 namespace paddle_infer {
 
-void Tensor::Reshape(const std::vector<int> &shape) { tensor_->Reshape(shape); }
-
-std::vector<int> Tensor::shape() const { return tensor_->shape(); }
-
-void Tensor::SetLoD(const std::vector<std::vector<size_t>> &x) {
-  return tensor_->SetLoD(x);
-}
-
-std::vector<std::vector<size_t>> Tensor::lod() const { return tensor_->lod(); }
-
-const std::string &Tensor::name() const { return tensor_->name(); }
-
-DataType Tensor::type() const { return tensor_->type(); }
-
 Predictor::Predictor(const Config &config) {
   const_cast<Config *>(&config)->SwitchUseFeedFetchOps(false);
   // The second parameter indicates that the discard log is not printed
@@ -1221,9 +1207,7 @@ std::vector<std::string> Predictor::GetInputNames() {
 }
 
 std::unique_ptr<Tensor> Predictor::GetInputHandle(const std::string &name) {
-  auto zero_copy_tensor = predictor_->GetInputTensor(name);
-  std::unique_ptr<Tensor> tensor(new Tensor(std::move(zero_copy_tensor)));
-  return tensor;
+  return predictor_->GetInputTensor(name);
 }
 
 std::vector<std::string> Predictor::GetOutputNames() {
@@ -1231,9 +1215,7 @@ std::vector<std::string> Predictor::GetOutputNames() {
 }
 
 std::unique_ptr<Tensor> Predictor::GetOutputHandle(const std::string &name) {
-  auto zero_copy_tensor = predictor_->GetOutputTensor(name);
-  std::unique_ptr<Tensor> tensor(new Tensor(std::move(zero_copy_tensor)));
-  return tensor;
+  return predictor_->GetOutputTensor(name);
 }
 
 bool Predictor::Run() { return predictor_->ZeroCopyRun(); }

--- a/paddle/fluid/inference/api/demo_ci/windows_mobilenet.cc
+++ b/paddle/fluid/inference/api/demo_ci/windows_mobilenet.cc
@@ -62,7 +62,7 @@ void RunAnalysis() {
   auto input_names = predictor->GetInputNames();
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   // 4. run predictor
   predictor->ZeroCopyRun();
@@ -76,7 +76,7 @@ void RunAnalysis() {
                                 std::multiplies<int>());
 
   out_data.resize(out_num);
-  output_t->copy_to_cpu(out_data.data());
+  output_t->CopyToCpu(out_data.data());
   delete[] input;
 }
 

--- a/paddle/fluid/inference/api/details/zero_copy_tensor.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor.cc
@@ -18,125 +18,127 @@
 #include "paddle/fluid/memory/memcpy.h"
 #include "paddle/fluid/platform/enforce.h"
 
-namespace paddle {
+namespace paddle_infer {
 
-void ZeroCopyTensor::Reshape(const std::vector<int> &shape) {
+void Tensor::Reshape(const std::vector<int> &shape) {
   PADDLE_ENFORCE_EQ(
       name_.empty(), false,
-      platform::errors::PreconditionNotMet(
+      paddle::platform::errors::PreconditionNotMet(
           "Need to SetName first, so that the corresponding tensor can "
           "be retrieved."));
   PADDLE_ENFORCE_EQ(input_or_output_, true,
-                    platform::errors::PermissionDenied(
+                    paddle::platform::errors::PermissionDenied(
                         "Can't reshape the output tensor, it is readonly"));
-  PADDLE_ENFORCE_NOT_NULL(scope_, platform::errors::PreconditionNotMet(
+  PADDLE_ENFORCE_NOT_NULL(scope_, paddle::platform::errors::PreconditionNotMet(
                                       "The scope should not be nullptr."));
-  auto *scope = static_cast<framework::Scope *>(scope_);
+  auto *scope = static_cast<paddle::framework::Scope *>(scope_);
   auto *var = scope->FindVar(name_);
   PADDLE_ENFORCE_NOT_NULL(
-      var, platform::errors::PreconditionNotMet(
+      var, paddle::platform::errors::PreconditionNotMet(
                "No tensor called [%s] in the runtime scope", name_));
-  auto *tensor = var->GetMutable<framework::LoDTensor>();
-  tensor->Resize(framework::make_ddim(shape));
+  auto *tensor = var->GetMutable<paddle::framework::LoDTensor>();
+  tensor->Resize(paddle::framework::make_ddim(shape));
 }
 
 #define EAGER_GET_TENSOR    \
   if (!tensor_) {           \
     tensor_ = FindTensor(); \
   }                         \
-  auto *tensor = static_cast<framework::LoDTensor *>(tensor_);
+  auto *tensor = static_cast<paddle::framework::LoDTensor *>(tensor_);
 
 template <typename T>
-T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
+T *Tensor::mutable_data(PlaceType place) {
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_GT(
       tensor->numel(), 0,
-      platform::errors::PreconditionNotMet(
+      paddle::platform::errors::PreconditionNotMet(
           "You should call ZeroCopyTensor::Reshape(const std::vector<int> "
           "&shape)"
           "function before retrieving mutable_data from input tensor."));
   switch (static_cast<int>(place)) {
-    case static_cast<int>(PaddlePlace::kCPU): {
-      return tensor->mutable_data<T>(platform::CPUPlace());
+    case static_cast<int>(PlaceType::kCPU): {
+      return tensor->mutable_data<T>(paddle::platform::CPUPlace());
     }
-    case static_cast<int>(PaddlePlace::kGPU): {
-      return tensor->mutable_data<T>(platform::CUDAPlace(device_));
+    case static_cast<int>(PlaceType::kGPU): {
+      return tensor->mutable_data<T>(paddle::platform::CUDAPlace(device_));
     }
     default:
-      PADDLE_THROW(platform::errors::Unavailable("Unsupported place: %d",
-                                                 static_cast<int>(place)));
+      PADDLE_THROW(paddle::platform::errors::Unavailable(
+          "Unsupported place: %d", static_cast<int>(place)));
       break;
   }
   return nullptr;
 }
 
 template <typename T>
-T *ZeroCopyTensor::data(PaddlePlace *place, int *size) const {
+T *Tensor::data(PlaceType *place, int *size) const {
   EAGER_GET_TENSOR;
   auto *res = tensor->data<T>();
 
-  if (platform::is_cpu_place(tensor->place())) {
-    *place = PaddlePlace::kCPU;
-  } else if (platform::is_gpu_place(tensor->place())) {
-    *place = PaddlePlace::kGPU;
+  if (paddle::platform::is_cpu_place(tensor->place())) {
+    *place = PlaceType::kCPU;
+  } else if (paddle::platform::is_gpu_place(tensor->place())) {
+    *place = PlaceType::kGPU;
   } else {
-    *place = PaddlePlace::kUNK;
+    *place = PlaceType::kUNK;
   }
 
   *size = tensor->numel();
   return res;
 }
 
-PaddleDType ZeroCopyTensor::type() const {
+DataType Tensor::type() const {
   EAGER_GET_TENSOR;
   auto type = tensor->type();
-  if (type == framework::proto::VarType::FP32) {
-    return PaddleDType::FLOAT32;
-  } else if (type == framework::proto::VarType::INT64) {
-    return PaddleDType::INT64;
-  } else if (type == framework::proto::VarType::INT32) {
-    return PaddleDType::INT32;
-  } else if (type == framework::proto::VarType::UINT8) {
-    return PaddleDType::UINT8;
+  if (type == paddle::framework::proto::VarType::FP32) {
+    return DataType::FLOAT32;
+  } else if (type == paddle::framework::proto::VarType::INT64) {
+    return DataType::INT64;
+  } else if (type == paddle::framework::proto::VarType::INT32) {
+    return DataType::INT32;
+  } else if (type == paddle::framework::proto::VarType::UINT8) {
+    return DataType::UINT8;
   }
-  return PaddleDType::FLOAT32;
+  return DataType::FLOAT32;
 }
 
 template <typename T>
-void ZeroCopyTensor::copy_from_cpu(const T *data) {
+void Tensor::CopyFromCpu(const T *data) {
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_GE(tensor->numel(), 0,
-                    platform::errors::PreconditionNotMet(
+                    paddle::platform::errors::PreconditionNotMet(
                         "You should call ZeroCopyTensor::Reshape(const "
                         "std::vector<int> &shape)"
                         "function before copying data from cpu."));
   size_t ele_size = tensor->numel() * sizeof(T);
 
-  if (place_ == PaddlePlace::kCPU) {
-    auto *t_data = tensor->mutable_data<T>(platform::CPUPlace());
+  if (place_ == PlaceType::kCPU) {
+    auto *t_data = tensor->mutable_data<T>(paddle::platform::CPUPlace());
     std::memcpy(static_cast<void *>(t_data), data, ele_size);
-  } else if (place_ == PaddlePlace::kGPU) {
+  } else if (place_ == PlaceType::kGPU) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
-    platform::CUDAPlace gpu_place(device_);
+    paddle::platform::DeviceContextPool &pool =
+        paddle::platform::DeviceContextPool::Instance();
+    paddle::platform::CUDAPlace gpu_place(device_);
     auto *t_data = tensor->mutable_data<T>(gpu_place);
-    auto *dev_ctx =
-        static_cast<const platform::CUDADeviceContext *>(pool.Get(gpu_place));
+    auto *dev_ctx = static_cast<const paddle::platform::CUDADeviceContext *>(
+        pool.Get(gpu_place));
 
-    memory::Copy(gpu_place, static_cast<void *>(t_data), platform::CPUPlace(),
-                 data, ele_size, dev_ctx->stream());
+    paddle::memory::Copy(gpu_place, static_cast<void *>(t_data),
+                         paddle::platform::CPUPlace(), data, ele_size,
+                         dev_ctx->stream());
 #else
-    PADDLE_THROW(platform::errors::Unavailable(
+    PADDLE_THROW(paddle::platform::errors::Unavailable(
         "Not compiled with CUDA, should not reach here."));
 #endif
-  } else if (place_ == PaddlePlace::kXPU) {
+  } else if (place_ == PlaceType::kXPU) {
 #ifdef PADDLE_WITH_XPU
     platform::XPUPlace xpu_place(device_);
     auto *t_data = tensor->mutable_data<T>(xpu_place);
-    memory::Copy(xpu_place, static_cast<void *>(t_data), platform::CPUPlace(),
-                 data, ele_size);
+    memory::Copy(xpu_place, static_cast<void *>(t_data),
+                 paddle::platform::CPUPlace(), data, ele_size);
 #else
-    PADDLE_THROW(platform::errors::Unavailable(
+    PADDLE_THROW(paddle::platform::errors::Unavailable(
         "Not compiled with XPU, should not reach here."));
 #endif
   } else {
@@ -146,38 +148,40 @@ void ZeroCopyTensor::copy_from_cpu(const T *data) {
 }
 
 template <typename T>
-void ZeroCopyTensor::copy_to_cpu(T *data) {
+void Tensor::CopyToCpu(T *data) {
   EAGER_GET_TENSOR;
   auto ele_num = tensor->numel();
   auto *t_data = tensor->data<T>();
   auto t_place = tensor->place();
 
-  if (platform::is_cpu_place(t_place)) {
+  if (paddle::platform::is_cpu_place(t_place)) {
     std::memcpy(static_cast<void *>(data), t_data, ele_num * sizeof(T));
-  } else if (place_ == PaddlePlace::kGPU) {
+  } else if (place_ == PlaceType::kGPU) {
 #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
-    auto gpu_place = BOOST_GET_CONST(platform::CUDAPlace, t_place);
-    auto *dev_ctx =
-        static_cast<const platform::CUDADeviceContext *>(pool.Get(gpu_place));
-    memory::Copy(platform::CPUPlace(), static_cast<void *>(data), gpu_place,
-                 t_data, ele_num * sizeof(T), dev_ctx->stream());
+    paddle::platform::DeviceContextPool &pool =
+        paddle::platform::DeviceContextPool::Instance();
+    auto gpu_place = BOOST_GET_CONST(paddle::platform::CUDAPlace, t_place);
+    auto *dev_ctx = static_cast<const paddle::platform::CUDADeviceContext *>(
+        pool.Get(gpu_place));
+    paddle::memory::Copy(paddle::platform::CPUPlace(),
+                         static_cast<void *>(data), gpu_place, t_data,
+                         ele_num * sizeof(T), dev_ctx->stream());
 #ifdef PADDLE_WITH_HIP
     hipStreamSynchronize(dev_ctx->stream());
 #else
     cudaStreamSynchronize(dev_ctx->stream());
 #endif
 #else
-    PADDLE_THROW(platform::errors::Unavailable(
+    PADDLE_THROW(paddle::platform::errors::Unavailable(
         "Not compile with CUDA, should not reach here."));
 #endif
-  } else if (place_ == PaddlePlace::kXPU) {
+  } else if (place_ == PlaceType::kXPU) {
 #ifdef PADDLE_WITH_XPU
-    auto xpu_place = BOOST_GET_CONST(platform::XPUPlace, t_place);
-    memory::Copy(platform::CPUPlace(), static_cast<void *>(data), xpu_place,
-                 t_data, ele_num * sizeof(T));
+    auto xpu_place = BOOST_GET_CONST(paddle::platform::XPUPlace, t_place);
+    memory::Copy(paddle::platform::CPUPlace(), static_cast<void *>(data),
+                 xpu_place, t_data, ele_num * sizeof(T));
 #else
-    PADDLE_THROW(platform::errors::Unavailable(
+    PADDLE_THROW(paddle::platform::errors::Unavailable(
         "Not compile with XPU, should not reach here."));
 #endif
   } else {
@@ -185,80 +189,70 @@ void ZeroCopyTensor::copy_to_cpu(T *data) {
         "The analysis predictor supports CPU, GPU and XPU now."));
   }
 }
-template PD_INFER_DECL void ZeroCopyTensor::copy_from_cpu<float>(
-    const float *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_from_cpu<int64_t>(
-    const int64_t *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_from_cpu<int32_t>(
-    const int32_t *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_from_cpu<uint8_t>(
-    const uint8_t *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_from_cpu<int8_t>(
-    const int8_t *data);
+template PD_INFER_DECL void Tensor::CopyFromCpu<float>(const float *data);
+template PD_INFER_DECL void Tensor::CopyFromCpu<int64_t>(const int64_t *data);
+template PD_INFER_DECL void Tensor::CopyFromCpu<int32_t>(const int32_t *data);
+template PD_INFER_DECL void Tensor::CopyFromCpu<uint8_t>(const uint8_t *data);
+template PD_INFER_DECL void Tensor::CopyFromCpu<int8_t>(const int8_t *data);
 
-template PD_INFER_DECL void ZeroCopyTensor::copy_to_cpu<float>(float *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_to_cpu<int64_t>(int64_t *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_to_cpu<int32_t>(int32_t *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_to_cpu<uint8_t>(uint8_t *data);
-template PD_INFER_DECL void ZeroCopyTensor::copy_to_cpu<int8_t>(int8_t *data);
+template PD_INFER_DECL void Tensor::CopyToCpu<float>(float *data);
+template PD_INFER_DECL void Tensor::CopyToCpu<int64_t>(int64_t *data);
+template PD_INFER_DECL void Tensor::CopyToCpu<int32_t>(int32_t *data);
+template PD_INFER_DECL void Tensor::CopyToCpu<uint8_t>(uint8_t *data);
+template PD_INFER_DECL void Tensor::CopyToCpu<int8_t>(int8_t *data);
 
-template PD_INFER_DECL float *ZeroCopyTensor::data<float>(PaddlePlace *place,
-                                                          int *size) const;
-template PD_INFER_DECL int64_t *ZeroCopyTensor::data<int64_t>(
-    PaddlePlace *place, int *size) const;
-template PD_INFER_DECL int32_t *ZeroCopyTensor::data<int32_t>(
-    PaddlePlace *place, int *size) const;
-template PD_INFER_DECL uint8_t *ZeroCopyTensor::data<uint8_t>(
-    PaddlePlace *place, int *size) const;
-template PD_INFER_DECL int8_t *ZeroCopyTensor::data<int8_t>(PaddlePlace *place,
-                                                            int *size) const;
+template PD_INFER_DECL float *Tensor::data<float>(PlaceType *place,
+                                                  int *size) const;
+template PD_INFER_DECL int64_t *Tensor::data<int64_t>(PlaceType *place,
+                                                      int *size) const;
+template PD_INFER_DECL int32_t *Tensor::data<int32_t>(PlaceType *place,
+                                                      int *size) const;
+template PD_INFER_DECL uint8_t *Tensor::data<uint8_t>(PlaceType *place,
+                                                      int *size) const;
+template PD_INFER_DECL int8_t *Tensor::data<int8_t>(PlaceType *place,
+                                                    int *size) const;
 
-template PD_INFER_DECL float *ZeroCopyTensor::mutable_data<float>(
-    PaddlePlace place);
-template PD_INFER_DECL int64_t *ZeroCopyTensor::mutable_data<int64_t>(
-    PaddlePlace place);
-template PD_INFER_DECL int32_t *ZeroCopyTensor::mutable_data<int32_t>(
-    PaddlePlace place);
-template PD_INFER_DECL uint8_t *ZeroCopyTensor::mutable_data<uint8_t>(
-    PaddlePlace place);
-template PD_INFER_DECL int8_t *ZeroCopyTensor::mutable_data<int8_t>(
-    PaddlePlace place);
+template PD_INFER_DECL float *Tensor::mutable_data<float>(PlaceType place);
+template PD_INFER_DECL int64_t *Tensor::mutable_data<int64_t>(PlaceType place);
+template PD_INFER_DECL int32_t *Tensor::mutable_data<int32_t>(PlaceType place);
+template PD_INFER_DECL uint8_t *Tensor::mutable_data<uint8_t>(PlaceType place);
+template PD_INFER_DECL int8_t *Tensor::mutable_data<int8_t>(PlaceType place);
 
-void *ZeroCopyTensor::FindTensor() const {
+void *Tensor::FindTensor() const {
   PADDLE_ENFORCE_EQ(
       name_.empty(), false,
-      platform::errors::PreconditionNotMet(
+      paddle::platform::errors::PreconditionNotMet(
           "Need to SetName first, so that the corresponding tensor can "
           "be retrieved."));
-  PADDLE_ENFORCE_NOT_NULL(scope_, platform::errors::PreconditionNotMet(
+  PADDLE_ENFORCE_NOT_NULL(scope_, paddle::platform::errors::PreconditionNotMet(
                                       "The scope should not be nullptr."));
-  auto *scope = static_cast<framework::Scope *>(scope_);
+  auto *scope = static_cast<paddle::framework::Scope *>(scope_);
   auto *var = scope->FindVar(name_);
   PADDLE_ENFORCE_NOT_NULL(
-      var, platform::errors::PreconditionNotMet(
+      var, paddle::platform::errors::PreconditionNotMet(
                "No tensor called [%s] in the runtime scope", name_));
-  auto *tensor = var->GetMutable<framework::LoDTensor>();
+  auto *tensor = var->GetMutable<paddle::framework::LoDTensor>();
   return tensor;
 }
 
-std::vector<int> ZeroCopyTensor::shape() const {
+std::vector<int> Tensor::shape() const {
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_NOT_NULL(
-      tensor_, platform::errors::PreconditionNotMet(
+      tensor_, paddle::platform::errors::PreconditionNotMet(
                    "Not found tensor called %s in the scope", name_));
-  return framework::vectorize<int>(tensor->dims());
+  return paddle::framework::vectorize<int>(tensor->dims());
 }
 
-void ZeroCopyTensor::SetLoD(const std::vector<std::vector<size_t>> &x) {
+void Tensor::SetLoD(const std::vector<std::vector<size_t>> &x) {
   EAGER_GET_TENSOR;
-  framework::LoD lod;
+  paddle::framework::LoD lod;
   for (auto &level : x) {
     lod.emplace_back(level);
   }
   tensor->set_lod(lod);
 }
 
-std::vector<std::vector<size_t>> ZeroCopyTensor::lod() const {
+std::vector<std::vector<size_t>> Tensor::lod() const {
   EAGER_GET_TENSOR;
   std::vector<std::vector<size_t>> res;
   for (auto &level : tensor->lod()) {
@@ -267,4 +261,4 @@ std::vector<std::vector<size_t>> ZeroCopyTensor::lod() const {
   return res;
 }
 
-}  // namespace paddle
+}  // namespace paddle_infer

--- a/paddle/fluid/inference/api/details/zero_copy_tensor_dummy.cc
+++ b/paddle/fluid/inference/api/details/zero_copy_tensor_dummy.cc
@@ -15,35 +15,35 @@
 #include "paddle/fluid/inference/api/paddle_api.h"
 #include "paddle/fluid/inference/api/paddle_infer_declare.h"
 
-namespace paddle {
+namespace paddle_infer {
 
-void ZeroCopyTensor::Reshape(const std::vector<int> &shape) {}
+void Tensor::Reshape(const std::vector<int> &shape) {}
 
 template <typename T>
-T *ZeroCopyTensor::mutable_data(PaddlePlace place) {
+T *Tensor::mutable_data(PlaceType place) {
   return nullptr;
 }
 
 template <typename T>
-T *ZeroCopyTensor::data(PaddlePlace *place, int *size) const {
+T *Tensor::data(PlaceType *place, int *size) const {
   return nullptr;
 }
 
-template PD_INFER_DECL float *ZeroCopyTensor::data<float>(PaddlePlace *place,
-                                                          int *size) const;
-template PD_INFER_DECL int64_t *ZeroCopyTensor::data<int64_t>(
-    PaddlePlace *place, int *size) const;
-template float *ZeroCopyTensor::mutable_data(PaddlePlace place);
-template int64_t *ZeroCopyTensor::mutable_data(PaddlePlace place);
+template PD_INFER_DECL float *Tensor::data<float>(PlaceType *place,
+                                                  int *size) const;
+template PD_INFER_DECL int64_t *Tensor::data<int64_t>(PlaceType *place,
+                                                      int *size) const;
+template float *Tensor::mutable_data(PlaceType place);
+template int64_t *Tensor::mutable_data(PlaceType place);
 
-void *ZeroCopyTensor::FindTensor() const { return nullptr; }
+void *Tensor::FindTensor() const { return nullptr; }
 
-std::vector<int> ZeroCopyTensor::shape() const { return {}; }
+std::vector<int> Tensor::shape() const { return {}; }
 
-void ZeroCopyTensor::SetLoD(const std::vector<std::vector<size_t>> &x) {}
+void Tensor::SetLoD(const std::vector<std::vector<size_t>> &x) {}
 
-std::vector<std::vector<size_t>> ZeroCopyTensor::lod() const {
+std::vector<std::vector<size_t>> Tensor::lod() const {
   return std::vector<std::vector<size_t>>();
 }
 
-}  // namespace paddle
+}  // namespace paddle_infer

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -29,19 +29,14 @@
 #include <vector>
 #include "crypto/cipher.h"
 #include "paddle_infer_declare.h"  // NOLINT
+#include "paddle_tensor.h"         // NOLINT
                                    /*! \namespace paddle
                                     */
 namespace paddle {
 
-/// \brief Paddle data type.
-enum PaddleDType {
-  FLOAT32,
-  INT64,
-  INT32,
-  UINT8,
-  INT8,
-  // TODO(Superjomn) support more data types if needed.
-};
+using PaddleDType = paddle_infer::DataType;
+using PaddlePlace = paddle_infer::PlaceType;
+using ZeroCopyTensor = paddle_infer::Tensor;
 
 /// \brief Memory manager for PaddleTensor.
 ///
@@ -160,91 +155,6 @@ struct PD_INFER_DECL PaddleTensor {
   PaddleBuf data;  ///<  blob of data.
   PaddleDType dtype;
   std::vector<std::vector<size_t>> lod;  ///<  Tensor+LoD equals LoDTensor
-};
-
-enum class PaddlePlace { kUNK = -1, kCPU, kGPU, kXPU };
-
-/// \brief Represents an n-dimensional array of values.
-/// The ZeroCopyTensor is used to store the input or output of the network.
-/// Zero copy means that the tensor supports direct copy of host or device data
-/// to device,
-/// eliminating additional CPU copy. ZeroCopyTensor is only used in the
-/// AnalysisPredictor.
-/// It is obtained through PaddlePredictor::GetinputTensor()
-/// and PaddlePredictor::GetOutputTensor() interface.
-class PD_INFER_DECL ZeroCopyTensor {
- public:
-  /// \brief Reset the shape of the tensor.
-  /// Generally it's only used for the input tensor.
-  /// Reshape must be called before calling mutable_data() or copy_from_cpu()
-  /// \param shape The shape to set.
-  void Reshape(const std::vector<int>& shape);
-
-  /// \brief Get the memory pointer in CPU or GPU with specific data type.
-  /// Please Reshape the tensor first before call this.
-  /// It's usually used to get input data pointer.
-  /// \param place The place of the tensor.
-  template <typename T>
-  T* mutable_data(PaddlePlace place);
-
-  /// \brief Get the memory pointer directly.
-  /// It's usually used to get the output data pointer.
-  /// \param[out] place To get the device type of the tensor.
-  /// \param[out] size To get the data size of the tensor.
-  /// \return The tensor data buffer pointer.
-  template <typename T>
-  T* data(PaddlePlace* place, int* size) const;
-
-  /// \brief Copy the host memory to tensor data.
-  /// It's usually used to set the input tensor data.
-  /// \param data The pointer of the data, from which the tensor will copy.
-  template <typename T>
-  void copy_from_cpu(const T* data);
-
-  /// \brief Copy the tensor data to the host memory.
-  /// It's usually used to get the output tensor data.
-  /// \param[out] data The tensor will copy the data to the address.
-  template <typename T>
-  void copy_to_cpu(T* data);
-
-  /// \brief Return the shape of the Tensor.
-  std::vector<int> shape() const;
-
-  /// \brief Set lod info of the tensor.
-  /// More about LOD can be seen here:
-  ///  https://www.paddlepaddle.org.cn/documentation/docs/zh/beginners_guide/basic_concept/lod_tensor.html#lodtensor
-  /// \param x the lod info.
-  void SetLoD(const std::vector<std::vector<size_t>>& x);
-  /// \brief Return the lod info of the tensor.
-  std::vector<std::vector<size_t>> lod() const;
-  /// \brief Return the name of the tensor.
-  const std::string& name() const { return name_; }
-  void SetPlace(PaddlePlace place, int device = -1) {
-    place_ = place;
-    device_ = device;
-  }
-
-  /// \brief Return the data type of the tensor.
-  /// It's usually used to get the output tensor data type.
-  /// \return The data type of the tensor.
-  PaddleDType type() const;
-
- protected:
-  explicit ZeroCopyTensor(void* scope) : scope_{scope} {}
-  void SetName(const std::string& name) { name_ = name; }
-  void* FindTensor() const;
-
- private:
-  std::string name_;
-  bool input_or_output_;
-  friend class AnalysisPredictor;
-  void* scope_{nullptr};
-  // The corresponding tensor pointer inside Paddle workspace is cached for
-  // performance.
-  mutable void* tensor_{nullptr};
-  PaddlePlace place_;
-  PaddleDType dtype_;
-  int device_;
 };
 
 /// \brief A Predictor for executing inference on a model.

--- a/paddle/fluid/inference/api/paddle_inference_api.h
+++ b/paddle/fluid/inference/api/paddle_inference_api.h
@@ -42,96 +42,9 @@ limitations under the License. */
 ///
 
 namespace paddle_infer {
-using DataType = paddle::PaddleDType;
-using PlaceType = paddle::PaddlePlace;
+
 using PrecisionType = paddle::AnalysisConfig::Precision;
 using Config = paddle::AnalysisConfig;
-
-///
-/// \class Tensor
-///
-/// \brief Represents an n-dimensional array of values.
-/// The Tensor is used to store the input or output of the network.
-/// It is obtained through Predictor::GetinputHandle()
-/// and Predictor::GetOutputHandle() interface.
-///
-class PD_INFER_DECL Tensor {
- public:
-  // Can only be created by predictor->GetInputHandle(cosnt std::string& name)
-  // or predictor->GetOutputHandle(cosnt std::string& name)
-  Tensor() = delete;
-  explicit Tensor(std::unique_ptr<paddle::ZeroCopyTensor>&& tensor)
-      : tensor_(std::move(tensor)) {}
-
-  ///
-  /// \brief Reset the shape of the tensor.
-  /// Generally it's only used for the input tensor.
-  /// Reshape must be called before calling mutable_data() or CopyFromCpu()
-  /// \param shape The shape to set.
-  ///
-  void Reshape(const std::vector<int>& shape);
-
-  ///
-  /// \brief Copy the host memory to tensor data.
-  /// It's usually used to set the input tensor data.
-  /// \param data The pointer of the data, from which the tensor will copy.
-  ///
-  template <typename T>
-  void CopyFromCpu(const T* data);
-
-  ///
-  /// \brief Get the memory pointer in CPU or GPU with specific data type.
-  /// Please Reshape the tensor first before call this.
-  /// It's usually used to get input data pointer.
-  /// \param place The place of the tensor.
-  /// \return The tensor data buffer pointer.
-  ///
-  template <typename T>
-  T* mutable_data(PlaceType place);
-
-  ///
-  /// \brief Copy the tensor data to the host memory.
-  /// It's usually used to get the output tensor data.
-  /// \param[out] data The tensor will copy the data to the address.
-  ///
-  template <typename T>
-  void CopyToCpu(T* data);
-
-  ///
-  /// \brief Get the memory pointer directly.
-  /// It's usually used to get the output data pointer.
-  /// \param[out] place To get the device type of the tensor.
-  /// \param[out] size To get the data size of the tensor.
-  /// \return The tensor data buffer pointer.
-  ///
-  template <typename T>
-  T* data(PlaceType* place, int* size) const;
-
-  ///
-  /// \brief Set lod info of the tensor.
-  /// More about LOD can be seen here:
-  ///  https://www.paddlepaddle.org.cn/documentation/docs/zh/beginners_guide/basic_concept/lod_tensor.html#lodtensor
-  /// \param x the lod info.
-  ///
-  void SetLoD(const std::vector<std::vector<size_t>>& x);
-
-  /// \brief Return the lod info of the tensor.
-  std::vector<std::vector<size_t>> lod() const;
-
-  /// \brief Return the data type of the tensor.
-  /// It's usually used to get the output tensor data type.
-  /// \return The data type of the tensor.
-  DataType type() const;
-
-  /// \brief Return the shape of the Tensor.
-  std::vector<int> shape() const;
-
-  /// \brief Return the name of the tensor.
-  const std::string& name() const;
-
- private:
-  std::unique_ptr<paddle::ZeroCopyTensor> tensor_;
-};
 
 ///
 /// \class Predictor
@@ -258,31 +171,7 @@ PD_INFER_DECL int GetNumBytesOfDataType(DataType dtype);
 PD_INFER_DECL std::string GetVersion();
 PD_INFER_DECL std::string UpdateDllFlag(const char* name, const char* value);
 
-template <typename T>
-void Tensor::CopyFromCpu(const T* data) {
-  tensor_->copy_from_cpu<T>(data);
-}
-
-template <typename T>
-void Tensor::CopyToCpu(T* data) {
-  return tensor_->copy_to_cpu<T>(data);
-}
-
-template <typename T>
-T* Tensor::mutable_data(PlaceType place) {
-  return tensor_->mutable_data<T>(place);
-}
-
-template <typename T>
-T* Tensor::data(PlaceType* place, int* size) const {
-  return tensor_->data<T>(place, size);
-}
-
-}  // namespace paddle_infer
-
-namespace paddle_infer {
 namespace services {
-
 ///
 /// \class PredictorPool
 ///
@@ -308,4 +197,5 @@ class PD_INFER_DECL PredictorPool {
   std::vector<std::unique_ptr<Predictor>> preds_;
 };
 }  // namespace services
+
 }  // namespace paddle_infer

--- a/paddle/fluid/inference/api/paddle_tensor.h
+++ b/paddle/fluid/inference/api/paddle_tensor.h
@@ -1,0 +1,120 @@
+// Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "paddle_infer_declare.h"  // NOLINT
+
+namespace paddle {
+class AnalysisPredictor;
+}
+
+namespace paddle_infer {
+
+/// \brief Paddle data type.
+enum DataType {
+  FLOAT32,
+  INT64,
+  INT32,
+  UINT8,
+  INT8,
+  // TODO(Superjomn) support more data types if needed.
+};
+
+enum class PlaceType { kUNK = -1, kCPU, kGPU, kXPU };
+
+/// \brief Represents an n-dimensional array of values.
+/// The Tensor is used to store the input or output of the network.
+/// Zero copy means that the tensor supports direct copy of host or device data
+/// to device,
+/// eliminating additional CPU copy. Tensor is only used in the
+/// AnalysisPredictor.
+/// It is obtained through PaddlePredictor::GetinputTensor()
+/// and PaddlePredictor::GetOutputTensor() interface.
+class PD_INFER_DECL Tensor {
+ public:
+  /// \brief Reset the shape of the tensor.
+  /// Generally it's only used for the input tensor.
+  /// Reshape must be called before calling mutable_data() or CopyFromCpu()
+  /// \param shape The shape to set.
+  void Reshape(const std::vector<int>& shape);
+
+  /// \brief Get the memory pointer in CPU or GPU with specific data type.
+  /// Please Reshape the tensor first before call this.
+  /// It's usually used to get input data pointer.
+  /// \param place The place of the tensor.
+  template <typename T>
+  T* mutable_data(PlaceType place);
+
+  /// \brief Get the memory pointer directly.
+  /// It's usually used to get the output data pointer.
+  /// \param[out] place To get the device type of the tensor.
+  /// \param[out] size To get the data size of the tensor.
+  /// \return The tensor data buffer pointer.
+  template <typename T>
+  T* data(PlaceType* place, int* size) const;
+
+  /// \brief Copy the host memory to tensor data.
+  /// It's usually used to set the input tensor data.
+  /// \param data The pointer of the data, from which the tensor will copy.
+  template <typename T>
+  void CopyFromCpu(const T* data);
+
+  /// \brief Copy the tensor data to the host memory.
+  /// It's usually used to get the output tensor data.
+  /// \param[out] data The tensor will copy the data to the address.
+  template <typename T>
+  void CopyToCpu(T* data);
+
+  /// \brief Return the shape of the Tensor.
+  std::vector<int> shape() const;
+
+  /// \brief Set lod info of the tensor.
+  /// More about LOD can be seen here:
+  ///  https://www.paddlepaddle.org.cn/documentation/docs/zh/beginners_guide/basic_concept/lod_tensor.html#lodtensor
+  /// \param x the lod info.
+  void SetLoD(const std::vector<std::vector<size_t>>& x);
+  /// \brief Return the lod info of the tensor.
+  std::vector<std::vector<size_t>> lod() const;
+  /// \brief Return the name of the tensor.
+  const std::string& name() const { return name_; }
+  void SetPlace(PlaceType place, int device = -1) {
+    place_ = place;
+    device_ = device;
+  }
+
+  /// \brief Return the data type of the tensor.
+  /// It's usually used to get the output tensor data type.
+  /// \return The data type of the tensor.
+  DataType type() const;
+
+ protected:
+  explicit Tensor(void* scope) : scope_{scope} {}
+  void SetName(const std::string& name) { name_ = name; }
+  void* FindTensor() const;
+
+ private:
+  std::string name_;
+  bool input_or_output_;
+  friend class paddle::AnalysisPredictor;
+  void* scope_{nullptr};
+  // The corresponding tensor pointer inside Paddle workspace is cached for
+  // performance.
+  mutable void* tensor_{nullptr};
+  PlaceType place_;
+  DataType dtype_;
+  int device_;
+};
+
+}  // namespace paddle_infer

--- a/paddle/fluid/inference/capi/pd_predictor.cc
+++ b/paddle/fluid/inference/capi/pd_predictor.cc
@@ -69,7 +69,7 @@ struct PD_ZeroCopyFunctor {
         std::accumulate(output_i->shape, output_i->shape + output_i->shape_size,
                         1, std::multiplies<int>());
     out_data.resize(out_num);
-    output_t->copy_to_cpu(out_data.data());
+    output_t->CopyToCpu(out_data.data());
     output_i->data = reinterpret_cast<void*>(malloc(out_num * sizeof(OutT)));
     memmove(static_cast<OutT*>(output_i->data), out_data.data(),
             out_num * sizeof(OutT));
@@ -142,16 +142,16 @@ bool PD_PredictorZeroCopyRun(const PD_AnalysisConfig* config,
     input_t->Reshape(tensor_shape);
     switch (inputs[i].dtype) {
       case PD_FLOAT32:
-        input_t->copy_from_cpu(static_cast<float*>(inputs[i].data));
+        input_t->CopyFromCpu(static_cast<float*>(inputs[i].data));
         break;
       case PD_INT32:
-        input_t->copy_from_cpu(static_cast<int32_t*>(inputs[i].data));
+        input_t->CopyFromCpu(static_cast<int32_t*>(inputs[i].data));
         break;
       case PD_INT64:
-        input_t->copy_from_cpu(static_cast<int64_t*>(inputs[i].data));
+        input_t->CopyFromCpu(static_cast<int64_t*>(inputs[i].data));
         break;
       case PD_UINT8:
-        input_t->copy_from_cpu(static_cast<uint8_t*>(inputs[i].data));
+        input_t->CopyFromCpu(static_cast<uint8_t*>(inputs[i].data));
         break;
       default:
         PADDLE_THROW(paddle::platform::errors::InvalidArgument(
@@ -226,16 +226,16 @@ void PD_SetZeroCopyInput(PD_Predictor* predictor,
   input->Reshape(std::move(shape));
   switch (tensor->dtype) {
     case PD_FLOAT32:
-      input->copy_from_cpu(static_cast<float*>(tensor->data.data));
+      input->CopyFromCpu(static_cast<float*>(tensor->data.data));
       break;
     case PD_INT32:
-      input->copy_from_cpu(static_cast<int32_t*>(tensor->data.data));
+      input->CopyFromCpu(static_cast<int32_t*>(tensor->data.data));
       break;
     case PD_INT64:
-      input->copy_from_cpu(static_cast<int64_t*>(tensor->data.data));
+      input->CopyFromCpu(static_cast<int64_t*>(tensor->data.data));
       break;
     case PD_UINT8:
-      input->copy_from_cpu(static_cast<uint8_t*>(tensor->data.data));
+      input->CopyFromCpu(static_cast<uint8_t*>(tensor->data.data));
       break;
     default:
       PADDLE_THROW(
@@ -294,16 +294,16 @@ void PD_GetZeroCopyOutput(PD_Predictor* predictor, PD_ZeroCopyTensor* tensor) {
   }
   switch (tensor->dtype) {
     case PD_FLOAT32:
-      output->copy_to_cpu(reinterpret_cast<float*>(tensor->data.data));
+      output->CopyToCpu(reinterpret_cast<float*>(tensor->data.data));
       break;
     case PD_INT32:
-      output->copy_to_cpu(reinterpret_cast<int32_t*>(tensor->data.data));
+      output->CopyToCpu(reinterpret_cast<int32_t*>(tensor->data.data));
       break;
     case PD_INT64:
-      output->copy_to_cpu(reinterpret_cast<int64_t*>(tensor->data.data));
+      output->CopyToCpu(reinterpret_cast<int64_t*>(tensor->data.data));
       break;
     case PD_UINT8:
-      output->copy_to_cpu(reinterpret_cast<uint8_t*>(tensor->data.data));
+      output->CopyToCpu(reinterpret_cast<uint8_t*>(tensor->data.data));
       break;
     default:
       PADDLE_THROW(

--- a/paddle/fluid/inference/tests/api/analyzer_zerocopy_tensor_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_zerocopy_tensor_tester.cc
@@ -45,7 +45,7 @@ TEST(test_zerocopy_tensor, zerocopy_tensor) {
 
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, channels, height, width});
-  input_t->copy_from_cpu<float>(input);
+  input_t->CopyFromCpu<float>(input);
   input_t->data<float>(place, &size);
   input_t->mutable_data<float>(p);
 
@@ -58,7 +58,7 @@ TEST(test_zerocopy_tensor, zerocopy_tensor) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data.resize(out_num);
-  output_t->copy_to_cpu<float>(out_data.data());
+  output_t->CopyToCpu<float>(out_data.data());
 }
 
 }  // namespace inference

--- a/paddle/fluid/inference/tests/api/lite_mul_model_test.cc
+++ b/paddle/fluid/inference/tests/api/lite_mul_model_test.cc
@@ -77,14 +77,14 @@ int test_predictor_zero_copy(const AnalysisConfig& config_in,
   std::vector<float> input({1});
   auto in_tensor{predictor->GetInputTensor(predictor->GetInputNames().front())};
   in_tensor->Reshape({1, 1});
-  in_tensor->copy_from_cpu(input.data());
+  in_tensor->CopyFromCpu(input.data());
 
   predictor->ZeroCopyRun();
 
   auto out_tensor{
       predictor->GetOutputTensor(predictor->GetOutputNames().front())};
   std::vector<float> data_o(10);
-  out_tensor->copy_to_cpu(data_o.data());
+  out_tensor->CopyToCpu(data_o.data());
 
   const std::vector<float> truth_values = {
       -0.00621776f, -0.00620937f, 0.00990623f,  -0.0039817f, -0.00074315f,

--- a/paddle/fluid/inference/tests/api/trt_cascade_rcnn_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_cascade_rcnn_test.cc
@@ -49,11 +49,11 @@ TEST(TensorRT, cascade_rcnn) {
 
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   auto input_t1 = predictor->GetInputTensor(input_names[1]);
   input_t1->Reshape({batch_size, 3});
-  input_t1->copy_from_cpu(im_shape);
+  input_t1->CopyFromCpu(im_shape);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 }

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_serialize_deserialize_test.h
@@ -61,21 +61,21 @@ static void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   // first input
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({run_batch, run_seq_len, 1});
-  input_t->copy_from_cpu(i0);
+  input_t->CopyFromCpu(i0);
 
   // second input
   auto input_t2 = predictor->GetInputTensor(input_names[1]);
   input_t2->Reshape({run_batch, run_seq_len, 1});
-  input_t2->copy_from_cpu(i1);
+  input_t2->CopyFromCpu(i1);
 
   // third input.
   auto input_t3 = predictor->GetInputTensor(input_names[2]);
   input_t3->Reshape({run_batch, run_seq_len, 1});
-  input_t3->copy_from_cpu(i2);
+  input_t3->CopyFromCpu(i2);
 
   auto input_t4 = predictor->GetInputTensor(input_names[3]);
   input_t4->Reshape({run_batch, run_seq_len, 1});
-  input_t4->copy_from_cpu(i3);
+  input_t4->CopyFromCpu(i3);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -85,7 +85,7 @@ static void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data->resize(out_num);
-  output_t->copy_to_cpu(out_data->data());
+  output_t->CopyToCpu(out_data->data());
 }
 
 static void trt_ernie(bool with_fp16, std::vector<float> result) {

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_ernie_test.cc
@@ -56,21 +56,21 @@ void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   // first input
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({run_batch, run_seq_len, 1});
-  input_t->copy_from_cpu(i0);
+  input_t->CopyFromCpu(i0);
 
   // second input
   auto input_t2 = predictor->GetInputTensor(input_names[1]);
   input_t2->Reshape({run_batch, run_seq_len, 1});
-  input_t2->copy_from_cpu(i1);
+  input_t2->CopyFromCpu(i1);
 
   // third input.
   auto input_t3 = predictor->GetInputTensor(input_names[2]);
   input_t3->Reshape({run_batch, run_seq_len, 1});
-  input_t3->copy_from_cpu(i2);
+  input_t3->CopyFromCpu(i2);
 
   auto input_t4 = predictor->GetInputTensor(input_names[3]);
   input_t4->Reshape({run_batch, run_seq_len, 1});
-  input_t4->copy_from_cpu(i3);
+  input_t4->CopyFromCpu(i3);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -80,7 +80,7 @@ void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data->resize(out_num);
-  output_t->copy_to_cpu(out_data->data());
+  output_t->CopyToCpu(out_data->data());
 }
 
 void trt_ernie(bool with_fp16, std::vector<float> result,

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_test.cc
@@ -54,7 +54,7 @@ void TestDynamic(bool with_dynamic = true) {
   memset(input, 0, input_num * sizeof(float));
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({1, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -65,7 +65,7 @@ void TestDynamic(bool with_dynamic = true) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data.resize(out_num);
-  output_t->copy_to_cpu(out_data.data());
+  output_t->CopyToCpu(out_data.data());
 }
 
 void TestDynamic2() {
@@ -100,17 +100,17 @@ void TestDynamic2() {
   auto input_names = predictor->GetInputNames();
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   auto input_t1 = predictor->GetInputTensor(input_names[1]);
   input_t1->Reshape({batch_size, 2, 1, 1});
   std::vector<float> first;
   for (int i = 0; i < batch_size * 2; i++) first.push_back(1.0);
-  input_t1->copy_from_cpu(first.data());
+  input_t1->CopyFromCpu(first.data());
 
   auto input_t2 = predictor->GetInputTensor(input_names[2]);
   input_t2->Reshape({batch_size, 2, 1, 1});
-  input_t2->copy_from_cpu(first.data());
+  input_t2->CopyFromCpu(first.data());
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -121,7 +121,7 @@ void TestDynamic2() {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data.resize(out_num);
-  output_t->copy_to_cpu(out_data.data());
+  output_t->CopyToCpu(out_data.data());
   std::vector<float> result = {0.617728, 1.63504, 2.15771, 0.535556};
   for (size_t i = 0; i < out_data.size(); i++) {
     EXPECT_NEAR(result[i], out_data[i], 1e-5);

--- a/paddle/fluid/inference/tests/api/trt_dynamic_shape_transformer_prune_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_dynamic_shape_transformer_prune_test.cc
@@ -56,21 +56,21 @@ void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   // first input
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({run_batch, run_seq_len, 1});
-  input_t->copy_from_cpu(i0);
+  input_t->CopyFromCpu(i0);
 
   // second input
   auto input_t2 = predictor->GetInputTensor(input_names[1]);
   input_t2->Reshape({run_batch, run_seq_len, 1});
-  input_t2->copy_from_cpu(i1);
+  input_t2->CopyFromCpu(i1);
 
   // third input.
   auto input_t3 = predictor->GetInputTensor(input_names[2]);
   input_t3->Reshape({run_batch, run_seq_len, 1});
-  input_t3->copy_from_cpu(i2);
+  input_t3->CopyFromCpu(i2);
 
   auto input_t4 = predictor->GetInputTensor(input_names[3]);
   input_t4->Reshape({run_batch, run_seq_len, 1});
-  input_t4->copy_from_cpu(i3);
+  input_t4->CopyFromCpu(i3);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -80,7 +80,7 @@ void run(const AnalysisConfig& config, std::vector<float>* out_data) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data->resize(out_num);
-  output_t->copy_to_cpu(out_data->data());
+  output_t->CopyToCpu(out_data->data());
 }
 
 void trt_ernie(bool with_fp16, std::vector<float> result) {

--- a/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_fc_prelu_test.cc
@@ -49,7 +49,7 @@ TEST(ZeroCopyTensor, uint8) {
   memset(input, 1, input_num * sizeof(uint8_t));
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, length});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
   input_t->type();
   input_t->mutable_data<uint8_t>(PaddlePlace::kGPU);
 

--- a/paddle/fluid/inference/tests/api/trt_instance_norm_converter_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_instance_norm_converter_test.cc
@@ -41,7 +41,7 @@ TEST(TensorRT, instance_norm) {
   auto input_names = predictor->GetInputNames();
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, length});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 }

--- a/paddle/fluid/inference/tests/api/trt_quant_int8_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_quant_int8_test.cc
@@ -50,7 +50,7 @@ TEST(quant_int8, resnet50) {
   memset(input, 0, input_num * sizeof(float));
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({1, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -61,7 +61,7 @@ TEST(quant_int8, resnet50) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data.resize(out_num);
-  output_t->copy_to_cpu(out_data.data());
+  output_t->CopyToCpu(out_data.data());
 }
 
 }  // namespace inference

--- a/paddle/fluid/inference/tests/api/trt_quant_int8_yolov3_r50_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_quant_int8_yolov3_r50_test.cc
@@ -41,11 +41,11 @@ TEST(quant_int8, yolov3_resnet50) {
   memset(input, 1.0, input_num * sizeof(float));
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({1, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   auto input_t1 = predictor->GetInputTensor(input_names[1]);
   input_t1->Reshape({1, 2});
-  input_t1->copy_from_cpu(im_shape);
+  input_t1->CopyFromCpu(im_shape);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 
@@ -56,7 +56,7 @@ TEST(quant_int8, yolov3_resnet50) {
   int out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                 std::multiplies<int>());
   out_data.resize(out_num);
-  output_t->copy_to_cpu(out_data.data());
+  output_t->CopyToCpu(out_data.data());
 }
 
 }  // namespace inference

--- a/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
+++ b/paddle/fluid/inference/tests/api/trt_split_converter_test.cc
@@ -46,7 +46,7 @@ TEST(TensorRT, split_converter) {
   auto input_names = predictor->GetInputNames();
   auto input_t = predictor->GetInputTensor(input_names[0]);
   input_t->Reshape({batch_size, channels, height, width});
-  input_t->copy_from_cpu(input);
+  input_t->CopyFromCpu(input);
 
   ASSERT_TRUE(predictor->ZeroCopyRun());
 }

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -147,7 +147,7 @@ void ZeroCopyTensorCreate(
   std::vector<int> shape;
   std::copy_n(data.shape(), data.ndim(), std::back_inserter(shape));
   tensor.Reshape(std::move(shape));
-  tensor.copy_from_cpu(static_cast<const T *>(data.data()));
+  tensor.CopyFromCpu(static_cast<const T *>(data.data()));
 }
 
 template <typename T>
@@ -188,19 +188,19 @@ py::array ZeroCopyTensorToNumpy(ZeroCopyTensor &tensor) {  // NOLINT
 
   switch (tensor.type()) {
     case PaddleDType::INT32:
-      tensor.copy_to_cpu(static_cast<int32_t *>(array.mutable_data()));
+      tensor.CopyToCpu(static_cast<int32_t *>(array.mutable_data()));
       break;
     case PaddleDType::INT64:
-      tensor.copy_to_cpu(static_cast<int64_t *>(array.mutable_data()));
+      tensor.CopyToCpu(static_cast<int64_t *>(array.mutable_data()));
       break;
     case PaddleDType::FLOAT32:
-      tensor.copy_to_cpu<float>(static_cast<float *>(array.mutable_data()));
+      tensor.CopyToCpu<float>(static_cast<float *>(array.mutable_data()));
       break;
     case PaddleDType::UINT8:
-      tensor.copy_to_cpu<uint8_t>(static_cast<uint8_t *>(array.mutable_data()));
+      tensor.CopyToCpu<uint8_t>(static_cast<uint8_t *>(array.mutable_data()));
       break;
     case PaddleDType::INT8:
-      tensor.copy_to_cpu<int8_t>(static_cast<int8_t *>(array.mutable_data()));
+      tensor.CopyToCpu<int8_t>(static_cast<int8_t *>(array.mutable_data()));
       break;
     default:
       PADDLE_THROW(platform::errors::Unimplemented(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
将旧数据结构 `paddle::ZeroCopyTensor` 统一至 `paddle_infer::Tensor`，以减少修改新接口的工作量，并精简代码。
此修改的代价是 `paddle::ZeroCopyTensor` 发生不兼容升级（此接口已在 2.0 弃用）。