### PR TITLE
add python2.7 in Dockerfile.ubuntu18

### DIFF
--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -42,14 +42,11 @@ RUN apt-get update && \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils && \
-#   curl https://bootstrap.pypa.io/2.7/get-pip.py -o - | python2.7 && easy_install pip && \
   curl https://bootstrap.pypa.io/3.5/get-pip.py -o - | python3.5 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.6 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.7 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.8 && easy_install pip && \
-#   rm /usr/bin/python && ln -s /usr/bin/python2.7 /usr/bin/python && \
   rm /usr/bin/python3 && ln -s /usr/bin/python3.5 /usr/bin/python3 && \
-#   rm /usr/local/bin/pip && ln -s /usr/local/bin/pip2.7 /usr/local/bin/pip && \
   rm /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.5 /usr/local/bin/pip3
 
 
@@ -81,83 +78,83 @@ RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-20.0.1.tar.gz && \
     rm -r Python-$version setuptools-40.6.2 pip-20.0.1
 
 
-# # install cmake
-# WORKDIR /home
-# RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz && rm cmake-3.16.0-Linux-x86_64.tar.gz
-# ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
+# install cmake
+WORKDIR /home
+RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz && rm cmake-3.16.0-Linux-x86_64.tar.gz
+ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 
-# # remove them when apt-get support 2.27 and higher version
-# RUN wget -q https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz && \ 
-#     tar -xzf binutils-2.33.1.tar.gz && \ 
-#     cd binutils-2.33.1 && \
-#     ./configure && make -j && make install && cd .. && rm -rf binutils-2.33.1 binutils-2.33.1.tar.gz
+# remove them when apt-get support 2.27 and higher version
+RUN wget -q https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz && \ 
+    tar -xzf binutils-2.33.1.tar.gz && \ 
+    cd binutils-2.33.1 && \
+    ./configure && make -j && make install && cd .. && rm -rf binutils-2.33.1 binutils-2.33.1.tar.gz
 
 
-# # Install Go and glide
-# RUN wget -qO- https://paddle-ci.cdn.bcebos.com/go1.8.1.linux-amd64.tar.gz | \
-#     tar -xz -C /usr/local && \
-#     mkdir /root/gopath && \
-#     mkdir /root/gopath/bin && \
-#     mkdir /root/gopath/src
-# ENV GOROOT=/usr/local/go GOPATH=/root/gopath
-# # should not be in the same line with GOROOT definition, otherwise docker build could not find GOROOT.
-# ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
-# # install glide
-# RUN curl -s -q https://glide.sh/get | sh
+# Install Go and glide
+RUN wget -qO- https://paddle-ci.cdn.bcebos.com/go1.8.1.linux-amd64.tar.gz | \
+    tar -xz -C /usr/local && \
+    mkdir /root/gopath && \
+    mkdir /root/gopath/bin && \
+    mkdir /root/gopath/src
+ENV GOROOT=/usr/local/go GOPATH=/root/gopath
+# should not be in the same line with GOROOT definition, otherwise docker build could not find GOROOT.
+ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
+# install glide
+RUN curl -s -q https://glide.sh/get | sh
 
-# # git credential to skip password typing
-# RUN git config --global credential.helper store
+# git credential to skip password typing
+RUN git config --global credential.helper store
 
-# # Fix locales to en_US.UTF-8
-# RUN localedef -i en_US -f UTF-8 en_US.UTF-8
+# Fix locales to en_US.UTF-8
+RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
-# RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-#     pip3 --no-cache-dir install ipykernel==4.6.0 wheel && \
-#     pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-#     pip3.6 --no-cache-dir install ipykernel==4.6.0 wheel && \
-#     pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-#     pip3.7 --no-cache-dir install ipykernel==4.6.0 wheel && \
-#     pip3.8 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-#     pip3.8 --no-cache-dir install ipykernel==4.6.0 wheel && \
-#     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-#     pip --no-cache-dir install ipykernel==4.6.0 wheel 
+RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3 --no-cache-dir install ipykernel==4.6.0 wheel && \
+    pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.6 --no-cache-dir install ipykernel==4.6.0 wheel && \
+    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.7 --no-cache-dir install ipykernel==4.6.0 wheel && \
+    pip3.8 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip3.8 --no-cache-dir install ipykernel==4.6.0 wheel && \
+    pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+    pip --no-cache-dir install ipykernel==4.6.0 wheel 
 
-# #For docstring checker
-# RUN pip3 --no-cache-dir install pylint pytest astroid isort && \
-#     pip3.6 --no-cache-dir install pylint pytest astroid isort && \
-#     pip3.7 --no-cache-dir install pylint pytest astroid isort && \
-#     pip3.8 --no-cache-dir install pylint pytest astroid isort && \
-#     pip --no-cache-dir install pylint pytest astroid isort
+#For docstring checker
+RUN pip3 --no-cache-dir install pylint pytest astroid isort && \
+    pip3.6 --no-cache-dir install pylint pytest astroid isort && \
+    pip3.7 --no-cache-dir install pylint pytest astroid isort && \
+    pip3.8 --no-cache-dir install pylint pytest astroid isort && \
+    pip --no-cache-dir install pylint pytest astroid isort
 
-# COPY ./python/requirements.txt /root/
-# RUN pip3 --no-cache-dir install -r /root/requirements.txt && \
-#     pip3.6 --no-cache-dir install -r /root/requirements.txt && \
-#     pip3.7 --no-cache-dir install -r /root/requirements.txt && \
-#     pip3.8 --no-cache-dir install -r /root/requirements.txt && \
-#     pip --no-cache-dir install -r /root/requirements.txt
+COPY ./python/requirements.txt /root/
+RUN pip3 --no-cache-dir install -r /root/requirements.txt && \
+    pip3.6 --no-cache-dir install -r /root/requirements.txt && \
+    pip3.7 --no-cache-dir install -r /root/requirements.txt && \
+    pip3.8 --no-cache-dir install -r /root/requirements.txt && \
+    pip --no-cache-dir install -r /root/requirements.txt
 
 
-# # Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
-# # https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa
-# # So install a newer version here.
-# RUN wget -q https://paddle-ci.cdn.bcebos.com/patchelf_0.10-2_amd64.deb && \
-#     dpkg -i patchelf_0.10-2_amd64.deb
+# Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
+# https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa
+# So install a newer version here.
+RUN wget -q https://paddle-ci.cdn.bcebos.com/patchelf_0.10-2_amd64.deb && \
+    dpkg -i patchelf_0.10-2_amd64.deb
 
-# # Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
-# #RUN mkdir /var/run/sshd && echo 'root:root' | chpasswd && sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
-# #CMD source ~/.bashrc
+# Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
+#RUN mkdir /var/run/sshd && echo 'root:root' | chpasswd && sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+#CMD source ~/.bashrc
 
-# # ccache 3.7.9
-# RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
-#     tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
-#     ./configure -prefix=/usr/local/ccache-3.7.9 && \
-#     make -j8 && make install && \
-#     ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
+# ccache 3.7.9
+RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+    tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+    ./configure -prefix=/usr/local/ccache-3.7.9 && \
+    make -j8 && make install && \
+    ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
 
-# # clang-form 3.8.0
-# RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
-#     tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
-#     cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
+# clang-form 3.8.0
+RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
+    tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
+    cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
 
 EXPOSE 22

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -36,6 +36,11 @@ RUN ln -s /usr/local/gcc-8.2/bin/gcc /usr/bin/gcc
 RUN ln -s /usr/local/gcc-8.2/bin/g++ /usr/bin/g++ 
 ENV PATH=/usr/local/gcc-8.2/bin:$PATH 
 
+# install cmake
+WORKDIR /home
+RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz && rm cmake-3.16.0-Linux-x86_64.tar.gz
+ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
+
 RUN apt-get update && \
   apt-get install -y python2.7-dev \
   python3.5 python3.5-dev \
@@ -76,12 +81,6 @@ RUN python setup.py install
 WORKDIR /home
 RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-20.0.1.tar.gz && \
     rm -r Python-$version setuptools-40.6.2 pip-20.0.1
-
-
-# install cmake
-WORKDIR /home
-RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz && rm cmake-3.16.0-Linux-x86_64.tar.gz
-ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 
 # remove them when apt-get support 2.27 and higher version

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -37,99 +37,127 @@ RUN ln -s /usr/local/gcc-8.2/bin/g++ /usr/bin/g++
 ENV PATH=/usr/local/gcc-8.2/bin:$PATH 
 
 RUN apt-get update && \
-  apt-get install -y python2.7 python2.7-dev \
+  apt-get install -y python2.7-dev \
   python3.5 python3.5-dev \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils && \
-  curl https://bootstrap.pypa.io/2.7/get-pip.py -o - | python2.7 && easy_install pip && \
+#   curl https://bootstrap.pypa.io/2.7/get-pip.py -o - | python2.7 && easy_install pip && \
   curl https://bootstrap.pypa.io/3.5/get-pip.py -o - | python3.5 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.6 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.7 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.8 && easy_install pip && \
-  rm /usr/bin/python && ln -s /usr/bin/python2.7 /usr/bin/python && \
+#   rm /usr/bin/python && ln -s /usr/bin/python2.7 /usr/bin/python && \
   rm /usr/bin/python3 && ln -s /usr/bin/python3.5 /usr/bin/python3 && \
-  rm /usr/local/bin/pip && ln -s /usr/local/bin/pip2.7 /usr/local/bin/pip && \
+#   rm /usr/local/bin/pip && ln -s /usr/local/bin/pip2.7 /usr/local/bin/pip && \
   rm /usr/local/bin/pip3 && ln -s /usr/local/bin/pip3.5 /usr/local/bin/pip3
 
 
-# install cmake
+# Install Python2.7.15 to replace original python
 WORKDIR /home
-RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz && rm cmake-3.16.0-Linux-x86_64.tar.gz
-ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
+ENV version=2.7.15
+RUN wget https://www.python.org/ftp/python/$version/Python-$version.tgz && tar -xvf Python-$version.tgz
+WORKDIR /home/Python-$version
+RUN ./configure --enable-unicode=ucs4 --enable-shared CFLAGS=-fPIC --prefix=/usr/local/python2.7.15 && make && make install
+
+RUN echo "export PATH=/usr/local/python2.7.15/include:${PATH}" >> ~/.bashrc && echo "export PATH=/usr/local/python2.7.15/bin:${PATH}" >> ~/.bashrc && echo "export LD_LIBRARY_PATH=/usr/local/python2.7.15/lib:${LD_LIBRARY_PATH}" >> ~/.bashrc && echo "export CPLUS_INCLUDE_PATH=/usr/local/python2.7.15/include/python2.7:$CPLUS_INCLUDE_PATH" >> ~/.bashrc
+ENV PATH=/usr/local/python2.7.15/include:${PATH}
+ENV PATH=/usr/local/python2.7.15/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/python2.7.15/lib:${LD_LIBRARY_PATH}
+ENV CPLUS_INCLUDE_PATH=/usr/local/python2.7.15/include/python2.7:$CPLUS_INCLUDE_PATH
+RUN mv /usr/bin/python /usr/bin/python.bak && ln -s /usr/local/python2.7.15/bin/python2.7 /usr/local/bin/python && ln -s /usr/local/python2.7.15/bin/python2.7 /usr/bin/python
+
+WORKDIR /home
+RUN wget https://files.pythonhosted.org/packages/b0/d1/8acb42f391cba52e35b131e442e80deffbb8d0676b93261d761b1f0ef8fb/setuptools-40.6.2.zip && apt-get -y install unzip && unzip setuptools-40.6.2.zip
+WORKDIR /home/setuptools-40.6.2
+RUN python setup.py build && python setup.py install
+WORKDIR /home
+RUN wget https://files.pythonhosted.org/packages/28/af/2c76c8aa46ccdf7578b83d97a11a2d1858794d4be4a1610ade0d30182e8b/pip-20.0.1.tar.gz && tar -zxvf pip-20.0.1.tar.gz
+WORKDIR pip-20.0.1
+RUN python setup.py install
+
+WORKDIR /home
+RUN rm Python-$version.tgz setuptools-40.6.2.zip pip-20.0.1.tar.gz && \
+    rm -r Python-$version setuptools-40.6.2 pip-20.0.1
 
 
-# remove them when apt-get support 2.27 and higher version
-RUN wget -q https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz && \ 
-    tar -xzf binutils-2.33.1.tar.gz && \ 
-    cd binutils-2.33.1 && \
-    ./configure && make -j && make install && cd .. && rm -rf binutils-2.33.1 binutils-2.33.1.tar.gz
+# # install cmake
+# WORKDIR /home
+# RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && tar -zxvf cmake-3.16.0-Linux-x86_64.tar.gz && rm cmake-3.16.0-Linux-x86_64.tar.gz
+# ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 
-# Install Go and glide
-RUN wget -qO- https://paddle-ci.cdn.bcebos.com/go1.8.1.linux-amd64.tar.gz | \
-    tar -xz -C /usr/local && \
-    mkdir /root/gopath && \
-    mkdir /root/gopath/bin && \
-    mkdir /root/gopath/src
-ENV GOROOT=/usr/local/go GOPATH=/root/gopath
-# should not be in the same line with GOROOT definition, otherwise docker build could not find GOROOT.
-ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
-# install glide
-RUN curl -s -q https://glide.sh/get | sh
-
-# git credential to skip password typing
-RUN git config --global credential.helper store
-
-# Fix locales to en_US.UTF-8
-RUN localedef -i en_US -f UTF-8 en_US.UTF-8
-
-RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-    pip3 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-    pip3.6 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-    pip3.7 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip3.8 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-    pip3.8 --no-cache-dir install ipykernel==4.6.0 wheel && \
-    pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
-    pip --no-cache-dir install ipykernel==4.6.0 wheel 
-
-#For docstring checker
-RUN pip3 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.6 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.7 --no-cache-dir install pylint pytest astroid isort && \
-    pip3.8 --no-cache-dir install pylint pytest astroid isort && \
-    pip --no-cache-dir install pylint pytest astroid isort
-
-COPY ./python/requirements.txt /root/
-RUN pip3 --no-cache-dir install -r /root/requirements.txt && \
-    pip3.6 --no-cache-dir install -r /root/requirements.txt && \
-    pip3.7 --no-cache-dir install -r /root/requirements.txt && \
-    pip3.8 --no-cache-dir install -r /root/requirements.txt && \
-    pip --no-cache-dir install -r /root/requirements.txt
+# # remove them when apt-get support 2.27 and higher version
+# RUN wget -q https://ftp.gnu.org/gnu/binutils/binutils-2.33.1.tar.gz && \ 
+#     tar -xzf binutils-2.33.1.tar.gz && \ 
+#     cd binutils-2.33.1 && \
+#     ./configure && make -j && make install && cd .. && rm -rf binutils-2.33.1 binutils-2.33.1.tar.gz
 
 
-# Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
-# https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa
-# So install a newer version here.
-RUN wget -q https://paddle-ci.cdn.bcebos.com/patchelf_0.10-2_amd64.deb && \
-    dpkg -i patchelf_0.10-2_amd64.deb
+# # Install Go and glide
+# RUN wget -qO- https://paddle-ci.cdn.bcebos.com/go1.8.1.linux-amd64.tar.gz | \
+#     tar -xz -C /usr/local && \
+#     mkdir /root/gopath && \
+#     mkdir /root/gopath/bin && \
+#     mkdir /root/gopath/src
+# ENV GOROOT=/usr/local/go GOPATH=/root/gopath
+# # should not be in the same line with GOROOT definition, otherwise docker build could not find GOROOT.
+# ENV PATH=${PATH}:${GOROOT}/bin:${GOPATH}/bin
+# # install glide
+# RUN curl -s -q https://glide.sh/get | sh
 
-# Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
-#RUN mkdir /var/run/sshd && echo 'root:root' | chpasswd && sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
-#CMD source ~/.bashrc
+# # git credential to skip password typing
+# RUN git config --global credential.helper store
 
-# ccache 3.7.9
-RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
-    tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
-    ./configure -prefix=/usr/local/ccache-3.7.9 && \
-    make -j8 && make install && \
-    ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
+# # Fix locales to en_US.UTF-8
+# RUN localedef -i en_US -f UTF-8 en_US.UTF-8
 
-# clang-form 3.8.0
-RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
-    tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
-    cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
+# RUN pip3 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+#     pip3 --no-cache-dir install ipykernel==4.6.0 wheel && \
+#     pip3.6 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+#     pip3.6 --no-cache-dir install ipykernel==4.6.0 wheel && \
+#     pip3.7 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+#     pip3.7 --no-cache-dir install ipykernel==4.6.0 wheel && \
+#     pip3.8 --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+#     pip3.8 --no-cache-dir install ipykernel==4.6.0 wheel && \
+#     pip --no-cache-dir install pre-commit==1.10.4 ipython==5.3.0 && \
+#     pip --no-cache-dir install ipykernel==4.6.0 wheel 
+
+# #For docstring checker
+# RUN pip3 --no-cache-dir install pylint pytest astroid isort && \
+#     pip3.6 --no-cache-dir install pylint pytest astroid isort && \
+#     pip3.7 --no-cache-dir install pylint pytest astroid isort && \
+#     pip3.8 --no-cache-dir install pylint pytest astroid isort && \
+#     pip --no-cache-dir install pylint pytest astroid isort
+
+# COPY ./python/requirements.txt /root/
+# RUN pip3 --no-cache-dir install -r /root/requirements.txt && \
+#     pip3.6 --no-cache-dir install -r /root/requirements.txt && \
+#     pip3.7 --no-cache-dir install -r /root/requirements.txt && \
+#     pip3.8 --no-cache-dir install -r /root/requirements.txt && \
+#     pip --no-cache-dir install -r /root/requirements.txt
+
+
+# # Older versions of patchelf limited the size of the files being processed and were fixed in this pr.
+# # https://github.com/NixOS/patchelf/commit/ba2695a8110abbc8cc6baf0eea819922ee5007fa
+# # So install a newer version here.
+# RUN wget -q https://paddle-ci.cdn.bcebos.com/patchelf_0.10-2_amd64.deb && \
+#     dpkg -i patchelf_0.10-2_amd64.deb
+
+# # Configure OpenSSH server. c.f. https://docs.docker.com/engine/examples/running_ssh_service
+# #RUN mkdir /var/run/sshd && echo 'root:root' | chpasswd && sed -ri 's/^PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config && sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+# #CMD source ~/.bashrc
+
+# # ccache 3.7.9
+# RUN wget https://paddle-ci.gz.bcebos.com/ccache-3.7.9.tar.gz && \
+#     tar xf ccache-3.7.9.tar.gz && mkdir /usr/local/ccache-3.7.9 && cd ccache-3.7.9 && \
+#     ./configure -prefix=/usr/local/ccache-3.7.9 && \
+#     make -j8 && make install && \
+#     ln -s /usr/local/ccache-3.7.9/bin/ccache /usr/local/bin/ccache
+
+# # clang-form 3.8.0
+# RUN wget https://paddle-ci.cdn.bcebos.com/clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && \ 
+#     tar xf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cd clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && \
+#     cp -r * /usr/local && cd .. && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-3.8.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz 
 
 EXPOSE 22

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -24,6 +24,19 @@ RUN apt-get update && \
     coreutils ntp language-pack-zh-hans python-qt4 libsm6 libxext6 libxrender-dev libgl1-mesa-glx \
     bison graphviz libjpeg-dev zlib1g-dev automake locales swig net-tools libtool module-init-tools
 
+# Prepare packages for Python
+RUN apt-get update && \
+    apt-get install -y make build-essential libbz2-dev \
+    libreadline-dev libsqlite3-dev llvm libncurses5-dev libncursesw5-dev \
+    tk-dev libffi-dev liblzma-dev
+
+RUN apt-get update && \
+    apt-get install -y --allow-downgrades --allow-change-held-packages \
+    patchelf git python-pip python-dev python-opencv openssh-server bison \
+    sed grep python-matplotlib clang-format  \
+    liblapack-dev liblapacke-dev && \
+    apt-get clean -y
+
 # Downgrade gcc&&g++
 WORKDIR /usr/bin 
 COPY tools/dockerfile/build_scripts /build_scripts 
@@ -42,8 +55,7 @@ RUN wget -q https://cmake.org/files/v3.16/cmake-3.16.0-Linux-x86_64.tar.gz && ta
 ENV PATH=/home/cmake-3.16.0-Linux-x86_64/bin:$PATH
 
 RUN apt-get update && \
-  apt-get install -y python2.7-dev \
-  python3.5 python3.5-dev \
+  apt-get install -y python3.5 python3.5-dev \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils && \

--- a/tools/dockerfile/Dockerfile.ubuntu18
+++ b/tools/dockerfile/Dockerfile.ubuntu18
@@ -59,7 +59,7 @@ RUN apt-get update && \
   python3.6 python3.6-dev \
   python3.7 python3.7-dev \
   python3.8 python3.8-dev python3.8-distutils && \
-  curl https://bootstrap.pypa.io/3.5/get-pip.py -o - | python3.5 && easy_install pip && \
+  curl https://bootstrap.pypa.io/pip/3.5/get-pip.py -o - | python3.5 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.6 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.7 && easy_install pip && \
   curl https://bootstrap.pypa.io/ez_setup.py -o - | python3.8 && easy_install pip && \

--- a/tools/dockerfile/ubuntu18_dev.sh
+++ b/tools/dockerfile/ubuntu18_dev.sh
@@ -33,7 +33,7 @@ function ref_whl(){
   fi
 
   if [[ ${WITH_GPU} != "ON" ]]; then
-    ref_gcc = ""
+    ref_gcc=""
   elif [[ ${gcc_version} == "8.2.0" ]];then
     ref_gcc=_gcc8.2
   fi


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

ubuntu18.04+cuda11的镜像（registry.baidubce.com/paddlepaddle/paddle:latest-dev-cuda11.0-cudnn8-gcc82）的python2和python3都在`/usr/bin`目录下，如果在这个镜像里装了python2和python3 两个python版本的paddle2.0，某些文件就不能共存了，例如`fleetrun`。

本PR在这个镜像中重新装了python2.7，路径为`/usr/local/python2.7.15/bin`。
