### PR TITLE
fix fleetrun kill ps

### DIFF
--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -969,13 +969,13 @@ class ParameterServerLauncher(object):
             if len(self.procs["heter_worker"]) > 0:
                 for i, proc in enumerate(self.procs["heter_worker"]):
                     self.log_fns["heter_worker"][i].close()
-                    self.procs["heter_worker"][i].proc.terminate()
+                    self.procs["heter_worker"][i].proc.kill()
                 logger.info("all heter_worker are killed")
 
             if len(self.procs["server"]) > 0:
                 for i, proc in enumerate(self.procs["server"]):
                     self.log_fns["server"][i].close()
-                    self.procs["server"][i].proc.terminate()
+                    self.procs["server"][i].proc.kill()
                 logger.info("all parameter server are killed")
 
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix `fleetrun` core dump at the end of training when running with PServer .