### PR TITLE
fix bug of windows chinese compiler msvc

### DIFF
--- a/python/paddle/utils/cpp_extension/extension_utils.py
+++ b/python/paddle/utils/cpp_extension/extension_utils.py
@@ -982,7 +982,10 @@ def check_abi_compatibility(compiler, verbose=False):
             compiler_info = subprocess.check_output(
                 compiler, stderr=subprocess.STDOUT)
             if six.PY3:
-                compiler_info = compiler_info.decode()
+                try:
+                    compiler_info = compiler_info.decode('UTF-8')
+                except UnicodeDecodeError:
+                    compiler_info = compiler_info.decode('gbk')
             match = re.search(r'(\d+)\.(\d+)\.(\d+)', compiler_info.strip())
             if match is not None:
                 version = match.groups()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

**Windows下自定义OP的bug**：当Windows机器安装中文版本的VS时，使用自定义OP会报错，因为Windows中文字符串使用`'gbk'`编码方式，需要使用 `'gbk'` 解码：

![image](https://user-images.githubusercontent.com/52485244/110439304-426fdb80-80f2-11eb-8713-e293b938015c.png)
