### PR TITLE
fix coverage

### DIFF
--- a/tools/coverage/paddle_coverage.sh
+++ b/tools/coverage/paddle_coverage.sh
@@ -46,19 +46,20 @@ function gen_full_html_report() {
         '/paddle/paddle/fluid/inference/*' \
         '/paddle/paddle/fluid/memory/*' \
         '/paddle/paddle/fluid/operators/*' \
-        '/paddle/paddle/fluid/recordio/*' \
         '/paddle/paddle/fluid/string/*' \
+        '/paddle/paddle/fluid/distributed/*' \
+        '/paddle/paddle/fluid/platform/*' \
+        '/paddle/paddle/fluid/extension/*' \
+        '/paddle/paddle/fluid/pybind/*' \
         -o coverage-full.tmp \
         --rc lcov_branch_coverage=0
 
     mv -f coverage-full.tmp coverage-full.info
 
     lcov --remove coverage-full.info \
-        '/paddle/paddle/fluid/framework/*_test*' \
         '/paddle/paddle/fluid/*/*test*' \
         '/paddle/paddle/fluid/*/*/*test*' \
-        '/paddle/paddle/fluid/inference/tests/*' \
-        '/paddle/paddle/fluid/inference/api/demo_ci/*' \
+        '/paddle/paddle/fluid/*/*/*/*test*' \
         -o coverage-full.tmp \
         --rc lcov_branch_coverage=0
 
@@ -74,11 +75,9 @@ function gen_full_html_report_xpu() {
     mv -f coverage-full.tmp coverage-full.info
 
     lcov --remove coverage-full.info \
-        '/paddle/paddle/fluid/framework/*_test*' \
         '/paddle/paddle/fluid/*/*test*' \
         '/paddle/paddle/fluid/*/*/*test*' \
-        '/paddle/paddle/fluid/inference/tests/*' \
-        '/paddle/paddle/fluid/inference/api/demo_ci/*' \
+        '/paddle/paddle/fluid/*/*/*/*test*' \
         -o coverage-full.tmp \
         --rc lcov_branch_coverage=0
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 --><br>### PR types<br><!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --><br>Bug fixes<br><br>### PR changes<br><!-- One of [ OPs | APIs | Docs | Others ] --><br>Others<br>### Describe<br><!-- Describe what this PR does --><br>Fix bugs (Debug, tinyformat) : quick fix to https://github.com/PaddlePaddle/Paddle/issues/13860 and #25494 <br><br>Open Paddle/fluid/string/tinyformat/tinyformat.h, move your cursor to detail::formatImpl and line 779<br><br>replace the codes<br>```<br>  fmt = printFormatStringLiteral(out, fmt);<br>  if (*fmt != '\\0')<br>    TINYFORMAT_ERROR(<br>        \"tinyformat: Too many conversion specifiers in format string\");<br>```<br>to <br><br>```<br>  fmt = printFormatStringLiteral(out, fmt);<br>  if (fmt != nullptr && *fmt != '\\0' && *fmt != 0)<br>    TINYFORMAT_ERROR(<br>        \"tinyformat: Too many conversion specifiers in format string\");<br>```<br><br><br>When set CMAKE_BUILD_TYPE to Debug, the fluid/operators/controlflow/compare_op.cc is involved <br><br>```<br>    AddInput(\"X\", string::Sprintf(\"the left hand operand of %s operator\",<br>                                  comment.type));<br>```<br><br>The safe printer actually passes a C style string pointer **without adding `\\0` to the end**!