### PR TITLE
[NPU] NpuOpRunner supports default stream

### DIFF
--- a/paddle/fluid/operators/npu_op_runner.h
+++ b/paddle/fluid/operators/npu_op_runner.h
@@ -67,7 +67,7 @@ class NpuOpRunner {
 
   std::vector<aclDataBuffer *> &GetOutputBuffers();
 
-  void Run(aclrtStream stream);
+  void Run(aclrtStream stream == nullptrr);
 
  private:
   aclTensorDesc *CreateTensorDesc(Tensor tensor);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
[NPU] NpuOpRunner supports default stream

Simplify the code of NPU kernel

For example, from
```
    auto runner = NpuOpRunner("Add", {*x, *y}, {*out}, {});
    auto stream =
        ctx.template device_context<paddle::platform::NPUDeviceContext>()
            .stream();
    runner.Run(stream);
```
to 

```
    auto runner = NpuOpRunner("Add", {*x, *y}, {*out}, {});
    runner.Run();
```