### PR TITLE
tensor support size attr.

### DIFF
--- a/paddle/fluid/operators/shape_op.h
+++ b/paddle/fluid/operators/shape_op.h
@@ -28,17 +28,45 @@ class ShapeKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext& ctx) const override {
     auto* in_var = ctx.InputVar("Input");
-    framework::DDim in_dims;
+    auto axes = ctx.Attr<std::vector<int>>("axes");
+    framework::DDim in_dims, out_dims;
     if (in_var->IsType<SelectedRows>()) {
       in_dims = in_var->Get<SelectedRows>().value().dims();
     } else {
       in_dims = in_var->Get<LoDTensor>().dims();
     }
+
+    if (axes.empty()) {
+      out_dims = in_dims;
+    } else {
+      std::vector<int> out_vec_dims(axes.size());
+      for (size_t i = 0; i < axes.size(); ++i) {
+        int axis = axes[i];
+        if (axis < 0) {
+          axis += in_dims.size();
+        }
+        PADDLE_ENFORCE_LT(static_cast<int>(axis), in_dims.size(),
+                          platform::errors::InvalidArgument(
+                              "The index of dimension in axes must be less "
+                              "than the size of input shape."));
+        out_vec_dims[i] = axis;
+      }
+      out_dims = framework::make_ddim(out_vec_dims);
+    }
+
     auto* out_t = ctx.Output<Tensor>("Out");
-    out_t->Resize({in_dims.size()});
+    out_t->Resize({out_dims.size()});
     auto out_data = out_t->mutable_data<int32_t>(platform::CPUPlace());
-    for (int i = 0; i < in_dims.size(); ++i) {
-      out_data[i] = in_dims[i];
+    for (int i = 0; i < out_dims.size(); ++i) {
+      if (axes.empty()) {
+        out_data[i] = in_dims[i];
+      } else {
+        if (axes[i] < 0) {
+          out_data[i] = in_dims[axes[i] + in_dims.size()];
+        } else {
+          out_data[i] = in_dims[axes[i]];
+        }
+      }
     }
   }
 };

--- a/python/paddle/fluid/backward.py
+++ b/python/paddle/fluid/backward.py
@@ -1850,7 +1850,7 @@ def calc_gradient(targets, inputs, target_gradients=None, no_grad_set=None):
             target_shape = target.name + '_shape'
             block.desc.append_op().copy_from(
                 _create_op_desc_("shape", {'Input': [target.name]},
-                                 {"Out": [target_shape]}, {}))
+                                 {"Out": [target_shape]}, {"axes": []}))
             input_grad_names_set.add(target_shape)
             op_desc = _create_op_desc_("fill_constant",
                                        {"ShapeTensor": [target_shape]},

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -151,10 +151,6 @@ def monkey_patch_math_varbase():
     def _ndim_(var):
         return len(var.shape)
 
-    @property
-    def _size_(var):
-        return np.prod(var.shape)
-
     def _scalar_add_(var, value):
         return _scalar_elementwise_op_(var, 1.0, value)
 
@@ -272,7 +268,6 @@ def monkey_patch_math_varbase():
         ('dim', lambda x: len(x.shape)),
         ('ndimension', lambda x: len(x.shape)),
         ('ndim', _ndim_),
-        ('size', _size_),
         ('__add__',
          _binary_creator_('__add__', 'elementwise_add', False, _scalar_add_)),
         ##  a+b == b+a. Do not need to reverse explicitly

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -330,6 +330,5 @@ def monkey_patch_math_varbase():
             if hasattr(core.VarBase, method_name): continue
             method_impl = getattr(paddle.tensor, method_name, None)
             if method_impl: setattr(core.VarBase, method_name, method_impl)
-        setattr(core.VarBase, 'size', getattr(paddle.tensor, 'shape', None))
 
     _already_patch_varbase = True

--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -330,5 +330,6 @@ def monkey_patch_math_varbase():
             if hasattr(core.VarBase, method_name): continue
             method_impl = getattr(paddle.tensor, method_name, None)
             if method_impl: setattr(core.VarBase, method_name, method_impl)
+        setattr(core.VarBase, 'size', getattr(paddle.tensor, 'shape', None))
 
     _already_patch_varbase = True

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11255,15 +11255,19 @@ def shape(input, axes=None):
     Examples:
         .. code-block:: python
 
-            import paddle
-            ndim_3_tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
-                                               [6, 7, 8, 9, 10]],
-                                              [[11, 12, 13, 14, 15],
-                                               [16, 17, 18, 19, 20]]])
-            print(ndim_3_tensor.size()) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
-            print(ndim_3_tensor.size(2)) # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True, [5])
-            print(ndim_3_tensor.size([-1, 0, 1])) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [5, 2, 2])
-            print(paddle.shape(ndim_3_tensor)) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
+            import paddle.fluid as fluid
+            import numpy as np
+
+            inputs = fluid.data(name="x", shape=[3, 100, 100], dtype="float32")
+            output = fluid.layers.shape(inputs)
+
+            exe = fluid.Executor(fluid.CPUPlace())
+            exe.run(fluid.default_startup_program())
+
+            img = np.ones((3, 100, 100)).astype(np.float32)
+
+            res = exe.run(fluid.default_main_program(), feed={'x':img}, fetch_list=[output])
+            print(res) # [array([  3, 100, 100], dtype=int32)]
     """
     check_variable_and_dtype(
         input, 'input',

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -11218,7 +11218,7 @@ def strided_slice(input, axes, starts, ends, strides):
     return out
 
 
-def shape(input):
+def shape(input, axes=None):
     """
     :alias_main: paddle.shape
 	:alias: paddle.shape,paddle.tensor.shape,paddle.tensor.attribute.shape
@@ -11255,27 +11255,30 @@ def shape(input):
     Examples:
         .. code-block:: python
 
-            import paddle.fluid as fluid
-            import numpy as np
-
-            inputs = fluid.data(name="x", shape=[3, 100, 100], dtype="float32")
-            output = fluid.layers.shape(inputs)
-
-            exe = fluid.Executor(fluid.CPUPlace())
-            exe.run(fluid.default_startup_program())
-
-            img = np.ones((3, 100, 100)).astype(np.float32)
-
-            res = exe.run(fluid.default_main_program(), feed={'x':img}, fetch_list=[output])
-            print(res) # [array([  3, 100, 100], dtype=int32)]
+            import paddle
+            ndim_3_tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
+                                               [6, 7, 8, 9, 10]],
+                                              [[11, 12, 13, 14, 15],
+                                               [16, 17, 18, 19, 20]]])
+            print(ndim_3_tensor.size()) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
+            print(ndim_3_tensor.size(2)) # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True, [5])
+            print(ndim_3_tensor.size([-1, 0, 1])) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [5, 2, 2])
+            print(paddle.shape(ndim_3_tensor)) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
     """
     check_variable_and_dtype(
         input, 'input',
         ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'], 'shape')
+    check_type(axes, 'axes', (int, list, tuple, type(None)), 'shape')
+    if isinstance(axes, int):
+        axes = [axes]
+    attrs = {'axes': axes if axes is not None and axes != [] else []}
     helper = LayerHelper('shape', **locals())
     out = helper.create_variable_for_type_inference(dtype='int32')
     helper.append_op(
-        type='shape', inputs={'Input': input}, outputs={'Out': out})
+        type='shape',
+        inputs={'Input': input},
+        attrs=attrs,
+        outputs={'Out': out})
 
     return out
 

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -312,7 +312,6 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
         self.assertEqual(x.dim(), 2)
         self.assertEqual(x.ndimension(), 2)
         self.assertEqual(x.ndim, 2)
-        self.assertEqual(x.size, 6)
         self.assertEqual(x.numel(), 6)
         self.assertTrue(np.array_equal(x.exp().numpy(), paddle.exp(x).numpy()))
         self.assertTrue(

--- a/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_math_op_patch_var_base.py
@@ -309,6 +309,8 @@ class TestMathOpPatchesVarBase(unittest.TestCase):
         b = paddle.to_tensor([[1, 1], [2, 2], [3, 3]])
 
         # 1. Unary operation for Tensor
+        self.assertTrue((np.array(x_np.shape) == x.size().numpy()).all())
+        self.assertTrue((x.size(0).numpy() == x_np.shape[0]).all())
         self.assertEqual(x.dim(), 2)
         self.assertEqual(x.ndimension(), 2)
         self.assertEqual(x.ndim, 2)

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -24,7 +24,6 @@ from .attribute import rank  #DEFINE_ALIAS
 from .attribute import shape  #DEFINE_ALIAS
 from .attribute import real  #DEFINE_ALIAS
 from .attribute import imag  #DEFINE_ALIAS
-from .attribute import size  #DEFINE_ALIAS
 from .creation import to_tensor  #DEFINE_ALIAS
 from .creation import diag  #DEFINE_ALIAS
 from .creation import eye  #DEFINE_ALIAS

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -22,6 +22,7 @@ from __future__ import print_function
 from .random import randperm
 from .attribute import rank  #DEFINE_ALIAS
 from .attribute import shape  #DEFINE_ALIAS
+from .attribute import size  #DEFINE_ALIAS
 from .attribute import real  #DEFINE_ALIAS
 from .attribute import imag  #DEFINE_ALIAS
 from .creation import to_tensor  #DEFINE_ALIAS

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -24,6 +24,7 @@ from .attribute import rank  #DEFINE_ALIAS
 from .attribute import shape  #DEFINE_ALIAS
 from .attribute import real  #DEFINE_ALIAS
 from .attribute import imag  #DEFINE_ALIAS
+from .attribute import size  #DEFINE_ALIAS
 from .creation import to_tensor  #DEFINE_ALIAS
 from .creation import diag  #DEFINE_ALIAS
 from .creation import eye  #DEFINE_ALIAS

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 from ..fluid.framework import core, in_dygraph_mode, Variable
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.data_feeder import check_variable_and_dtype, check_type
+from ..fluid.data_feeder import check_variable_and_dtype
 
 # TODO: define functions to get tensor attributes  
 from ..fluid.layers import rank  #DEFINE_ALIAS

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -27,12 +27,6 @@ __all__ = ['rank', 'shape', 'real', 'imag', 'size']
 
 def size(input, axes=None):
     """
-    :alias_main: paddle.shape
-	:alias: paddle.shape,paddle.tensor.shape,paddle.tensor.attribute.shape
-	:old_api: paddle.fluid.layers.shape
-
-    **Shape Layer**
-
     Get the shape of the input.
 
     .. code-block:: text

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -16,13 +16,13 @@ from __future__ import print_function
 
 from ..fluid.framework import core, in_dygraph_mode, Variable
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.data_feeder import check_variable_and_dtype
+from ..fluid.data_feeder import check_variable_and_dtype, check_type
 
 # TODO: define functions to get tensor attributes  
 from ..fluid.layers import rank  #DEFINE_ALIAS
 from ..fluid.layers import shape  #DEFINE_ALIAS
 
-__all__ = ['rank', 'shape', 'real', 'imag']
+__all__ = ['rank', 'shape', 'real', 'imag', "size"]
 
 
 def _complex_to_real_dtype(dtype):
@@ -32,6 +32,59 @@ def _complex_to_real_dtype(dtype):
         return core.VarDesc.VarType.FP64
     else:
         return dtype
+
+
+def size(input, axes=None):
+    """
+    **Shape Layer**
+
+    Get the shape of the input.
+
+    .. code-block:: text
+
+        Case1:
+            Given N-D Tensor:
+                input = [ [1, 2, 3, 4], [5, 6, 7, 8] ]
+
+            Then:
+                input.shape = [2, 4]
+
+    Args:
+        input (Variable): The input can be N-D Tensor or SelectedRows with data type bool, float16, float32, float64, int32, int64.
+                          If input variable is type of SelectedRows, returns the shape of it's inner tensor.
+
+    Returns:
+        Variable (Tensor): The shape of the input variable.
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+            ndim_3_tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
+                                               [6, 7, 8, 9, 10]],
+                                              [[11, 12, 13, 14, 15],
+                                               [16, 17, 18, 19, 20]]])
+            print(ndim_3_tensor.size()) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
+            print(ndim_3_tensor.size(2)) # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True, [5])
+            print(ndim_3_tensor.size([-1, 0, 1])) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [5, 2, 2])
+
+    """
+    check_variable_and_dtype(
+        input, 'input',
+        ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'], 'shape')
+    check_type(axes, 'axes', (int, list, tuple), 'shape')
+    if isinstance(axes, int):
+        axes = [axes]
+
+    attrs = {'axes': axes if axes is not None and axes != [] else []}
+    helper = LayerHelper('shape', **locals())
+    out = helper.create_variable_for_type_inference(dtype='int32')
+    helper.append_op(
+        type='shape',
+        inputs={'Input': input},
+        attrs=attrs,
+        outputs={'Out': out})
+    return out
 
 
 def real(x, name=None):

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -22,7 +22,7 @@ from ..fluid.data_feeder import check_variable_and_dtype, check_type
 from ..fluid.layers import rank  #DEFINE_ALIAS
 from ..fluid.layers import shape  #DEFINE_ALIAS
 
-__all__ = ['rank', 'shape', 'real', 'imag', "size"]
+__all__ = ['rank', 'shape', 'real', 'imag']
 
 
 def _complex_to_real_dtype(dtype):
@@ -32,59 +32,6 @@ def _complex_to_real_dtype(dtype):
         return core.VarDesc.VarType.FP64
     else:
         return dtype
-
-
-def size(input, axes=None):
-    """
-    **Shape Layer**
-
-    Get the shape of the input.
-
-    .. code-block:: text
-
-        Case1:
-            Given N-D Tensor:
-                input = [ [1, 2, 3, 4], [5, 6, 7, 8] ]
-
-            Then:
-                input.shape = [2, 4]
-
-    Args:
-        input (Variable): The input can be N-D Tensor or SelectedRows with data type bool, float16, float32, float64, int32, int64.
-                          If input variable is type of SelectedRows, returns the shape of it's inner tensor.
-
-    Returns:
-        Variable (Tensor): The shape of the input variable.
-
-    Examples:
-        .. code-block:: python
-
-            import paddle
-            ndim_3_tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
-                                               [6, 7, 8, 9, 10]],
-                                              [[11, 12, 13, 14, 15],
-                                               [16, 17, 18, 19, 20]]])
-            print(ndim_3_tensor.size()) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
-            print(ndim_3_tensor.size(2)) # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True, [5])
-            print(ndim_3_tensor.size([-1, 0, 1])) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [5, 2, 2])
-
-    """
-    check_variable_and_dtype(
-        input, 'input',
-        ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'], 'shape')
-    check_type(axes, 'axes', (int, list, tuple), 'shape')
-    if isinstance(axes, int):
-        axes = [axes]
-
-    attrs = {'axes': axes if axes is not None and axes != [] else []}
-    helper = LayerHelper('shape', **locals())
-    out = helper.create_variable_for_type_inference(dtype='int32')
-    helper.append_op(
-        type='shape',
-        inputs={'Input': input},
-        attrs=attrs,
-        outputs={'Out': out})
-    return out
 
 
 def real(x, name=None):

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -22,7 +22,63 @@ from ..fluid.data_feeder import check_variable_and_dtype
 from ..fluid.layers import rank  #DEFINE_ALIAS
 from ..fluid.layers import shape  #DEFINE_ALIAS
 
-__all__ = ['rank', 'shape', 'real', 'imag']
+__all__ = ['rank', 'shape', 'real', 'imag', 'size']
+
+
+def size(input, axes=None):
+    """
+    :alias_main: paddle.shape
+	:alias: paddle.shape,paddle.tensor.shape,paddle.tensor.attribute.shape
+	:old_api: paddle.fluid.layers.shape
+
+    **Shape Layer**
+
+    Get the shape of the input.
+
+    .. code-block:: text
+
+        Given N-D Tensor:
+            input = [ [1, 2, 3, 4], [5, 6, 7, 8] ]
+
+        Then:
+            input.shape = [2, 4]
+
+    Args:
+        input (Variable): The input can be N-D Tensor or SelectedRows with data type bool, float16, float32, float64, int32, int64.
+                          If input variable is type of SelectedRows, returns the shape of it's inner tensor.
+
+    Returns:
+        Variable (Tensor): The shape of the input variable.
+
+    Examples:
+        .. code-block:: python
+
+            import paddle
+             ndim_3_tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
+                                                [6, 7, 8, 9, 10]],
+                                               [[11, 12, 13, 14, 15],
+                                                [16, 17, 18, 19, 20]]])
+             print(ndim_3_tensor.size()) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
+             print(ndim_3_tensor.size(2)) # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True, [5])
+             print(ndim_3_tensor.size([-1, 0, 1])) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [5, 2, 2])
+             print(paddle.shape(ndim_3_tensor)) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
+    """
+    check_variable_and_dtype(
+        input, 'input',
+        ['bool', 'float16', 'float32', 'float64', 'int32', 'int64'], 'shape')
+    check_type(axes, 'axes', (int, list, tuple, type(None)), 'shape')
+    if isinstance(axes, int):
+        axes = [axes]
+    attrs = {'axes': axes if axes is not None and axes != [] else []}
+    helper = LayerHelper('shape', **locals())
+    out = helper.create_variable_for_type_inference(dtype='int32')
+    helper.append_op(
+        type='shape',
+        inputs={'Input': input},
+        attrs=attrs,
+        outputs={'Out': out})
+
+    return out
 
 
 def _complex_to_real_dtype(dtype):

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 
 from ..fluid.framework import core, in_dygraph_mode, Variable
 from ..fluid.layer_helper import LayerHelper
-from ..fluid.data_feeder import check_variable_and_dtype
+from ..fluid.data_feeder import check_variable_and_dtype, check_type
 
 # TODO: define functions to get tensor attributes  
 from ..fluid.layers import rank  #DEFINE_ALIAS


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

目前获取 shape tensor 需要 paddle.shape(a_tenosr)
期望语法，同pytroch 的 a_tensor.size()
期望支持语法：
shape_tensor = a_tensor.size()
1dim_tensor = a_tensor.size(1)


tensor支持size方法.

```
import paddle
ndim_3_tensor = paddle.to_tensor([[[1, 2, 3, 4, 5],
                                   [6, 7, 8, 9, 10]],
                                  [[11, 12, 13, 14, 15],
                                   [16, 17, 18, 19, 20]]])
print(ndim_3_tensor.size()) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [2, 2, 5])
print(ndim_3_tensor.size(2)) # Tensor(shape=[1], dtype=int32, place=CPUPlace, stop_gradient=True, [5])
print(ndim_3_tensor.size([-1, 0, 1])) # Tensor(shape=[3], dtype=int32, place=CPUPlace, stop_gradient=True, [5, 2, 2])
```