### PR TITLE
[save/load] Fix bug with input_spec=dict[InputSpec] in jit.save

### DIFF
--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -683,9 +683,11 @@ def save(layer, path, input_spec=None, **configs):
             # transform in jit.save, if input_spec is incomplete, declarative will throw error
             # inner_input_spec is list[InputSpec], it should be packed with same sturcture
             # as original input_spec here.
+            if inner_input_spec:
+                inner_input_spec = pack_sequence_as(input_spec,
+                                                    inner_input_spec)
             static_forward = declarative(
-                inner_layer.forward,
-                input_spec=pack_sequence_as(input_spec, inner_input_spec))
+                inner_layer.forward, input_spec=inner_input_spec)
             concrete_program = static_forward.concrete_program
             # the input_spec has been used in declarative, which is equal to
             # @declarative with input_spec and jit.save without input_spec,

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -25,7 +25,7 @@ import paddle
 from paddle.fluid import core
 from paddle.fluid.compiler import BuildStrategy, CompiledProgram, ExecutionStrategy
 from paddle.fluid.data_feeder import check_type
-from paddle.fluid.layers.utils import flatten
+from paddle.fluid.layers.utils import flatten, pack_sequence_as
 from paddle.fluid.dygraph.base import program_desc_tracing_guard, switch_to_static_graph
 from paddle.fluid.dygraph.dygraph_to_static import logging_utils
 from paddle.fluid.dygraph.dygraph_to_static.convert_call_func import ConversionOptions, CONVERSION_OPTIONS
@@ -681,8 +681,11 @@ def save(layer, path, input_spec=None, **configs):
                 inner_input_spec)
         elif 'forward' == attr_func:
             # transform in jit.save, if input_spec is incomplete, declarative will throw error
+            # inner_input_spec is list[InputSpec], it should be packed with same sturcture
+            # as original input_spec here.
             static_forward = declarative(
-                inner_layer.forward, input_spec=inner_input_spec)
+                inner_layer.forward,
+                input_spec=pack_sequence_as(input_spec, inner_input_spec))
             concrete_program = static_forward.concrete_program
             # the input_spec has been used in declarative, which is equal to
             # @declarative with input_spec and jit.save without input_spec,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

### Fix bug with input_spec=dict[InputSpec] in jit.save
当 `jit.save`接受的Layer的forward中参数是dict类型时，用户指定的input_spec也为对应dict的正确类型时，`jit.save`导出模型失败。此PR修复了此问题