### PR TITLE
correct the name of tensor handle, test=develop

### DIFF
--- a/paddle/fluid/inference/CMakeLists.txt
+++ b/paddle/fluid/inference/CMakeLists.txt
@@ -41,7 +41,7 @@ add_subdirectory(api)
 # Create static inference library if needed
 # All static libs in inference/api
 set(STATIC_INFERENCE_API paddle_inference_api analysis_predictor
-     zero_copy_tensor reset_tensor_array
+     tensor_handle reset_tensor_array
         analysis_config paddle_pass_builder activation_functions ${mkldnn_quantizer_cfg})
 #TODO(wilber, T8T9): Do we still need to support windows gpu static library?
 if(WIN32 AND WITH_GPU)
@@ -71,7 +71,7 @@ set(SHARED_INFERENCE_SRCS
     ${CMAKE_CURRENT_SOURCE_DIR}/api/api.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/api_impl.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/api/analysis_predictor.cc
-    ${CMAKE_CURRENT_SOURCE_DIR}/api/details/zero_copy_tensor.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/api/details/tensor_handle.cc
     ${CMAKE_CURRENT_SOURCE_DIR}/utils/io_utils.cc
     ${mkldnn_quantizer_src_file}
     ${PADDLE_CUSTOM_OP_SRCS})

--- a/paddle/fluid/inference/analysis/passes/CMakeLists.txt
+++ b/paddle/fluid/inference/analysis/passes/CMakeLists.txt
@@ -1,6 +1,6 @@
 cc_library(ir_graph_build_pass SRCS ir_graph_build_pass.cc DEPS analysis_pass argument ir_pass_manager)
 cc_library(ir_analysis_pass SRCS ir_analysis_pass.cc DEPS analysis_pass argument ir_pass_manager)
-cc_library(memory_optim_pass SRCS memory_optimize_pass.cc DEPS analysis_pass zero_copy_tensor)
+cc_library(memory_optim_pass SRCS memory_optimize_pass.cc DEPS analysis_pass tensor_handle)
 cc_library(ir_params_sync_among_devices_pass SRCS ir_params_sync_among_devices_pass.cc DEPS analysis_pass argument ir_pass_manager)
 cc_library(ir_graph_to_program_pass SRCS ir_graph_to_program_pass.cc DEPS analysis_pass graph_to_program_pass)
 cc_library(adjust_cudnn_workspace_size_pass SRCS adjust_cudnn_workspace_size_pass.cc DEPS analysis_pass graph_to_program_pass)

--- a/paddle/fluid/inference/api/CMakeLists.txt
+++ b/paddle/fluid/inference/api/CMakeLists.txt
@@ -32,10 +32,10 @@ cc_library(paddle_pass_builder SRCS paddle_pass_builder.cc)
 
 if(WITH_CRYPTO)
     cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
-              analysis_config zero_copy_tensor trainer_desc_proto paddle_crypto)
+              analysis_config tensor_handle trainer_desc_proto paddle_crypto)
 else()
     cc_library(paddle_inference_api SRCS api.cc api_impl.cc helper.cc DEPS lod_tensor scope reset_tensor_array 
-              analysis_config zero_copy_tensor trainer_desc_proto)
+              analysis_config tensor_handle trainer_desc_proto)
 endif()
 
 if(WIN32)
@@ -49,7 +49,7 @@ if(WITH_GPU AND TENSORRT_FOUND)
 endif()
 
 cc_library(analysis_predictor SRCS analysis_predictor.cc ${mkldnn_quantizer_src} DEPS ${inference_deps} 
-          zero_copy_tensor ir_pass_manager op_compatible_info)
+          tensor_handle ir_pass_manager op_compatible_info)
 
 cc_test(test_paddle_inference_api SRCS api_tester.cc DEPS paddle_inference_api)
 

--- a/paddle/fluid/inference/api/analysis_predictor.cc
+++ b/paddle/fluid/inference/api/analysis_predictor.cc
@@ -1206,7 +1206,8 @@ std::vector<std::string> Predictor::GetInputNames() {
   return predictor_->GetInputNames();
 }
 
-std::unique_ptr<Tensor> Predictor::GetInputHandle(const std::string &name) {
+std::unique_ptr<TensorHandle> Predictor::GetInputHandle(
+    const std::string &name) {
   return predictor_->GetInputTensor(name);
 }
 
@@ -1214,7 +1215,8 @@ std::vector<std::string> Predictor::GetOutputNames() {
   return predictor_->GetOutputNames();
 }
 
-std::unique_ptr<Tensor> Predictor::GetOutputHandle(const std::string &name) {
+std::unique_ptr<TensorHandle> Predictor::GetOutputHandle(
+    const std::string &name) {
   return predictor_->GetOutputTensor(name);
 }
 

--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -116,7 +116,10 @@ int PaddleDtypeSize(PaddleDType dtype) {
     case PaddleDType::UINT8:
       return sizeof(uint8_t);
     default:
-      assert(false);
+      PADDLE_THROW(paddle::platform::errors::InvalidArgument(
+          "The dtype must be one in the list: FLOAT32, INT64, INT32, UINT8. "
+          "But it is `%d`",
+          static_cast<int>(dtype)));
       return -1;
   }
 }

--- a/paddle/fluid/inference/api/api.cc
+++ b/paddle/fluid/inference/api/api.cc
@@ -105,7 +105,7 @@ void HostBuffer::Free() {
 
 namespace paddle {
 
-int PaddleDtypeSize(PaddleDType dtype) {
+size_t PaddleDtypeSize(PaddleDType dtype) {
   switch (dtype) {
     case PaddleDType::FLOAT32:
       return sizeof(float);
@@ -120,7 +120,7 @@ int PaddleDtypeSize(PaddleDType dtype) {
           "The dtype must be one in the list: FLOAT32, INT64, INT32, UINT8. "
           "But it is `%d`",
           static_cast<int>(dtype)));
-      return -1;
+      return 0;
   }
 }
 

--- a/paddle/fluid/inference/api/api_impl_tester.cc
+++ b/paddle/fluid/inference/api/api_impl_tester.cc
@@ -88,6 +88,7 @@ void MainWord2Vec(const paddle::PaddlePlace& place) {
   ASSERT_EQ(outputs.size(), 1UL);
   size_t len = outputs[0].data.length();
   float* data = static_cast<float*>(outputs[0].data.data());
+  ASSERT_FALSE(outputs[0].data.empty());
   for (size_t j = 0; j < len / sizeof(float); ++j) {
     ASSERT_LT(data[j], 1.0);
     ASSERT_GT(data[j], -1.0);
@@ -321,6 +322,22 @@ TEST(PassBuilder, Delete) {
   const auto& passes = config.pass_builder()->AllPasses();
   auto it = std::find(passes.begin(), passes.end(), "attention_lstm_fuse_pass");
   ASSERT_EQ(it, passes.end());
+}
+
+TEST(PaddleDtypeSize, Size) {
+  CHECK_EQ(paddle::PaddleDtypeSize(PaddleDType::FLOAT32), sizeof(float));
+  CHECK_EQ(paddle::PaddleDtypeSize(PaddleDType::INT64), sizeof(int64_t));
+  CHECK_EQ(paddle::PaddleDtypeSize(PaddleDType::INT32), sizeof(int32_t));
+  CHECK_EQ(paddle::PaddleDtypeSize(PaddleDType::UINT8), sizeof(uint8_t));
+}
+
+TEST(PaddleBuf, NotOwned) {
+  constexpr size_t N{1};
+  char* a = new char[N];
+  PaddleBuf buf_0(a, N * sizeof(char));
+  PaddleBuf buf_1(N);
+  buf_1.Reset(a, N * sizeof(char));
+  delete[] a;
 }
 
 }  // namespace paddle

--- a/paddle/fluid/inference/api/details/CMakeLists.txt
+++ b/paddle/fluid/inference/api/details/CMakeLists.txt
@@ -14,7 +14,7 @@
 #
 
 cc_library(reset_tensor_array SRCS reset_tensor_array.cc DEPS lod_tensor scope)
-cc_library(zero_copy_tensor SRCS zero_copy_tensor.cc DEPS scope lod_tensor enforce)
-cc_library(zero_copy_tensor_dummy SRCS zero_copy_tensor_dummy.cc)
+cc_library(tensor_handle SRCS tensor_handle.cc DEPS scope lod_tensor enforce)
+cc_library(tensor_handle_dummy SRCS tensor_handle_dummy.cc)
 
-cc_test(zero_copy_tensor_test SRCS zero_copy_tensor_test.cc DEPS paddle_inference_api)
+cc_test(tensor_handle_test SRCS tensor_handle_test.cc DEPS paddle_inference_api)

--- a/paddle/fluid/inference/api/details/tensor_handle.cc
+++ b/paddle/fluid/inference/api/details/tensor_handle.cc
@@ -20,7 +20,7 @@
 
 namespace paddle_infer {
 
-void Tensor::Reshape(const std::vector<int> &shape) {
+void TensorHandle::Reshape(const std::vector<int> &shape) {
   PADDLE_ENFORCE_EQ(
       name_.empty(), false,
       paddle::platform::errors::PreconditionNotMet(
@@ -45,7 +45,7 @@ void Tensor::Reshape(const std::vector<int> &shape) {
   auto *tensor = static_cast<paddle::framework::LoDTensor *>(tensor_);
 
 template <typename T>
-T *Tensor::mutable_data(PlaceType place) {
+T *TensorHandle::mutable_data(PlaceType place) {
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_GT(
       tensor->numel(), 0,
@@ -74,7 +74,7 @@ T *Tensor::mutable_data(PlaceType place) {
 }
 
 template <typename T>
-T *Tensor::data(PlaceType *place, int *size) const {
+T *TensorHandle::data(PlaceType *place, int *size) const {
   EAGER_GET_TENSOR;
   auto *res = tensor->data<T>();
 
@@ -92,7 +92,7 @@ T *Tensor::data(PlaceType *place, int *size) const {
   return res;
 }
 
-DataType Tensor::type() const {
+DataType TensorHandle::type() const {
   EAGER_GET_TENSOR;
   auto type = tensor->type();
   if (type == paddle::framework::proto::VarType::FP32) {
@@ -108,7 +108,7 @@ DataType Tensor::type() const {
 }
 
 template <typename T>
-void Tensor::CopyFromCpu(const T *data) {
+void TensorHandle::CopyFromCpu(const T *data) {
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_GE(tensor->numel(), 0,
                     paddle::platform::errors::PreconditionNotMet(
@@ -155,7 +155,7 @@ void Tensor::CopyFromCpu(const T *data) {
 }
 
 template <typename T>
-void Tensor::CopyToCpu(T *data) {
+void TensorHandle::CopyToCpu(T *data) {
   EAGER_GET_TENSOR;
   auto ele_num = tensor->numel();
   auto *t_data = tensor->data<T>();
@@ -199,43 +199,52 @@ void Tensor::CopyToCpu(T *data) {
         "The analysis predictor supports CPU, GPU and XPU now."));
   }
 }
-template PD_INFER_DECL void Tensor::CopyFromCpu<float>(const float *data);
-template PD_INFER_DECL void Tensor::CopyFromCpu<int64_t>(const int64_t *data);
-template PD_INFER_DECL void Tensor::CopyFromCpu<int32_t>(const int32_t *data);
-template PD_INFER_DECL void Tensor::CopyFromCpu<uint8_t>(const uint8_t *data);
-template PD_INFER_DECL void Tensor::CopyFromCpu<int8_t>(const int8_t *data);
+template PD_INFER_DECL void TensorHandle::CopyFromCpu<float>(const float *data);
+template PD_INFER_DECL void TensorHandle::CopyFromCpu<int64_t>(
+    const int64_t *data);
+template PD_INFER_DECL void TensorHandle::CopyFromCpu<int32_t>(
+    const int32_t *data);
+template PD_INFER_DECL void TensorHandle::CopyFromCpu<uint8_t>(
+    const uint8_t *data);
+template PD_INFER_DECL void TensorHandle::CopyFromCpu<int8_t>(
+    const int8_t *data);
 
-template PD_INFER_DECL void Tensor::CopyToCpu<float>(float *data);
-template PD_INFER_DECL void Tensor::CopyToCpu<int64_t>(int64_t *data);
-template PD_INFER_DECL void Tensor::CopyToCpu<int32_t>(int32_t *data);
-template PD_INFER_DECL void Tensor::CopyToCpu<uint8_t>(uint8_t *data);
-template PD_INFER_DECL void Tensor::CopyToCpu<int8_t>(int8_t *data);
+template PD_INFER_DECL void TensorHandle::CopyToCpu<float>(float *data);
+template PD_INFER_DECL void TensorHandle::CopyToCpu<int64_t>(int64_t *data);
+template PD_INFER_DECL void TensorHandle::CopyToCpu<int32_t>(int32_t *data);
+template PD_INFER_DECL void TensorHandle::CopyToCpu<uint8_t>(uint8_t *data);
+template PD_INFER_DECL void TensorHandle::CopyToCpu<int8_t>(int8_t *data);
 
-template PD_INFER_DECL float *Tensor::data<float>(PlaceType *place,
-                                                  int *size) const;
-template PD_INFER_DECL int64_t *Tensor::data<int64_t>(PlaceType *place,
-                                                      int *size) const;
-template PD_INFER_DECL int32_t *Tensor::data<int32_t>(PlaceType *place,
-                                                      int *size) const;
-template PD_INFER_DECL uint8_t *Tensor::data<uint8_t>(PlaceType *place,
-                                                      int *size) const;
-template PD_INFER_DECL int8_t *Tensor::data<int8_t>(PlaceType *place,
-                                                    int *size) const;
+template PD_INFER_DECL float *TensorHandle::data<float>(PlaceType *place,
+                                                        int *size) const;
+template PD_INFER_DECL int64_t *TensorHandle::data<int64_t>(PlaceType *place,
+                                                            int *size) const;
+template PD_INFER_DECL int32_t *TensorHandle::data<int32_t>(PlaceType *place,
+                                                            int *size) const;
+template PD_INFER_DECL uint8_t *TensorHandle::data<uint8_t>(PlaceType *place,
+                                                            int *size) const;
+template PD_INFER_DECL int8_t *TensorHandle::data<int8_t>(PlaceType *place,
+                                                          int *size) const;
 
-template PD_INFER_DECL float *Tensor::mutable_data<float>(PlaceType place);
-template PD_INFER_DECL int64_t *Tensor::mutable_data<int64_t>(PlaceType place);
-template PD_INFER_DECL int32_t *Tensor::mutable_data<int32_t>(PlaceType place);
-template PD_INFER_DECL uint8_t *Tensor::mutable_data<uint8_t>(PlaceType place);
-template PD_INFER_DECL int8_t *Tensor::mutable_data<int8_t>(PlaceType place);
+template PD_INFER_DECL float *TensorHandle::mutable_data<float>(
+    PlaceType place);
+template PD_INFER_DECL int64_t *TensorHandle::mutable_data<int64_t>(
+    PlaceType place);
+template PD_INFER_DECL int32_t *TensorHandle::mutable_data<int32_t>(
+    PlaceType place);
+template PD_INFER_DECL uint8_t *TensorHandle::mutable_data<uint8_t>(
+    PlaceType place);
+template PD_INFER_DECL int8_t *TensorHandle::mutable_data<int8_t>(
+    PlaceType place);
 
-Tensor::Tensor(void *scope) : scope_{scope} {
+TensorHandle::TensorHandle(void *scope) : scope_{scope} {
   PADDLE_ENFORCE_NOT_NULL(scope_,
                           paddle::platform::errors::PreconditionNotMet(
                               "The `scope` can not be nullptr. It should be "
                               "set to the pointer of scope."));
 }
 
-void *Tensor::FindTensor() const {
+void *TensorHandle::FindTensor() const {
   PADDLE_ENFORCE_EQ(
       name_.empty(), false,
       paddle::platform::errors::PreconditionNotMet(
@@ -250,7 +259,7 @@ void *Tensor::FindTensor() const {
   return tensor;
 }
 
-std::vector<int> Tensor::shape() const {
+std::vector<int> TensorHandle::shape() const {
   EAGER_GET_TENSOR;
   PADDLE_ENFORCE_NOT_NULL(
       tensor_, paddle::platform::errors::PreconditionNotMet(
@@ -258,7 +267,7 @@ std::vector<int> Tensor::shape() const {
   return paddle::framework::vectorize<int>(tensor->dims());
 }
 
-void Tensor::SetLoD(const std::vector<std::vector<size_t>> &x) {
+void TensorHandle::SetLoD(const std::vector<std::vector<size_t>> &x) {
   EAGER_GET_TENSOR;
   paddle::framework::LoD lod;
   for (auto &level : x) {
@@ -267,7 +276,7 @@ void Tensor::SetLoD(const std::vector<std::vector<size_t>> &x) {
   tensor->set_lod(lod);
 }
 
-std::vector<std::vector<size_t>> Tensor::lod() const {
+std::vector<std::vector<size_t>> TensorHandle::lod() const {
   EAGER_GET_TENSOR;
   std::vector<std::vector<size_t>> res;
   for (auto &level : tensor->lod()) {
@@ -276,11 +285,11 @@ std::vector<std::vector<size_t>> Tensor::lod() const {
   return res;
 }
 
-void Tensor::SetName(const std::string &name) { name_ = name; }
+void TensorHandle::SetName(const std::string &name) { name_ = name; }
 
-const std::string &Tensor::name() const { return name_; }
+const std::string &TensorHandle::name() const { return name_; }
 
-void Tensor::SetPlace(PlaceType place, int device) {
+void TensorHandle::SetPlace(PlaceType place, int device) {
   place_ = place;
   device_ = device;
 }

--- a/paddle/fluid/inference/api/details/tensor_handle_dummy.cc
+++ b/paddle/fluid/inference/api/details/tensor_handle_dummy.cc
@@ -17,32 +17,32 @@
 
 namespace paddle_infer {
 
-void Tensor::Reshape(const std::vector<int> &shape) {}
+void TensorHandle::Reshape(const std::vector<int> &shape) {}
 
 template <typename T>
-T *Tensor::mutable_data(PlaceType place) {
+T *TensorHandle::mutable_data(PlaceType place) {
   return nullptr;
 }
 
 template <typename T>
-T *Tensor::data(PlaceType *place, int *size) const {
+T *TensorHandle::data(PlaceType *place, int *size) const {
   return nullptr;
 }
 
-template PD_INFER_DECL float *Tensor::data<float>(PlaceType *place,
-                                                  int *size) const;
-template PD_INFER_DECL int64_t *Tensor::data<int64_t>(PlaceType *place,
-                                                      int *size) const;
-template float *Tensor::mutable_data(PlaceType place);
-template int64_t *Tensor::mutable_data(PlaceType place);
+template PD_INFER_DECL float *TensorHandle::data<float>(PlaceType *place,
+                                                        int *size) const;
+template PD_INFER_DECL int64_t *TensorHandle::data<int64_t>(PlaceType *place,
+                                                            int *size) const;
+template float *TensorHandle::mutable_data(PlaceType place);
+template int64_t *TensorHandle::mutable_data(PlaceType place);
 
-void *Tensor::FindTensor() const { return nullptr; }
+void *TensorHandle::FindTensor() const { return nullptr; }
 
-std::vector<int> Tensor::shape() const { return {}; }
+std::vector<int> TensorHandle::shape() const { return {}; }
 
-void Tensor::SetLoD(const std::vector<std::vector<size_t>> &x) {}
+void TensorHandle::SetLoD(const std::vector<std::vector<size_t>> &x) {}
 
-std::vector<std::vector<size_t>> Tensor::lod() const {
+std::vector<std::vector<size_t>> TensorHandle::lod() const {
   return std::vector<std::vector<size_t>>();
 }
 

--- a/paddle/fluid/inference/api/details/tensor_handle_test.cc
+++ b/paddle/fluid/inference/api/details/tensor_handle_test.cc
@@ -24,7 +24,7 @@
 #include "paddle/fluid/framework/data_type.h"
 #include "paddle/fluid/framework/scope.h"
 #include "paddle/fluid/inference/api/helper.h"
-#include "paddle/fluid/inference/api/paddle_infer_tensor_handle.h"
+#include "paddle/fluid/inference/api/paddle_infer_tensor.h"
 #include "paddle/fluid/platform/place.h"
 
 namespace paddle_infer {

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -269,7 +269,7 @@ template <>
 PD_INFER_DECL std::unique_ptr<PaddlePredictor> CreatePaddlePredictor<
     AnalysisConfig, PaddleEngineKind::kAnalysis>(const AnalysisConfig& config);
 
-PD_INFER_DECL int PaddleDtypeSize(PaddleDType dtype);
+PD_INFER_DECL size_t PaddleDtypeSize(PaddleDType dtype);
 
 PD_INFER_DECL std::string get_version();
 

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -28,10 +28,10 @@
 #include <string>
 #include <vector>
 #include "crypto/cipher.h"
-#include "paddle_infer_declare.h"  // NOLINT
-#include "paddle_tensor.h"         // NOLINT
-                                   /*! \namespace paddle
-                                    */
+#include "paddle_infer_declare.h"        // NOLINT
+#include "paddle_infer_tensor_handle.h"  // NOLINT
+                                         /*! \namespace paddle
+                                          */
 namespace paddle {
 
 using PaddleDType = paddle_infer::DataType;
@@ -165,7 +165,7 @@ struct PD_INFER_DECL PaddleTensor {
 /// It is obtained through PaddlePredictor::GetinputTensor()
 /// and PaddlePredictor::GetOutputTensor() interface.
 
-class PD_INFER_DECL ZeroCopyTensor : public paddle_infer::Tensor {
+class PD_INFER_DECL ZeroCopyTensor : public paddle_infer::TensorHandle {
  public:
   /// \brief Copy the host memory to tensor data.
   /// It's usually used to set the input tensor data.
@@ -184,7 +184,7 @@ class PD_INFER_DECL ZeroCopyTensor : public paddle_infer::Tensor {
 
  private:
   friend class AnalysisPredictor;
-  explicit ZeroCopyTensor(void* scope) : paddle_infer::Tensor{scope} {}
+  explicit ZeroCopyTensor(void* scope) : paddle_infer::TensorHandle{scope} {}
 };
 
 /// \brief A Predictor for executing inference on a model.

--- a/paddle/fluid/inference/api/paddle_api.h
+++ b/paddle/fluid/inference/api/paddle_api.h
@@ -28,133 +28,16 @@
 #include <string>
 #include <vector>
 #include "crypto/cipher.h"
-#include "paddle_infer_declare.h"        // NOLINT
-#include "paddle_infer_tensor_handle.h"  // NOLINT
-                                         /*! \namespace paddle
-                                          */
+#include "paddle_infer_declare.h"  // NOLINT
+#include "paddle_infer_tensor.h"   // NOLINT
+                                   /*! \namespace paddle
+                                    */
 namespace paddle {
 
 using PaddleDType = paddle_infer::DataType;
 using PaddlePlace = paddle_infer::PlaceType;
-
-/// \brief Memory manager for PaddleTensor.
-///
-/// The PaddleBuf holds a buffer for data input or output. The memory can be
-/// allocated by user or by PaddleBuf itself, but in any case, the PaddleBuf
-/// should be reused for better performance.
-///
-/// For user allocated memory, the following API can be used:
-/// - PaddleBuf(void* data, size_t length) to set an external memory by
-/// specifying the memory address and length.
-/// - Reset(void* data, size_t length) to reset the PaddleBuf with an external
-/// memory.
-/// ATTENTION, for user allocated memory, deallocation should be done by users
-/// externally after the program finished. The PaddleBuf won't do any allocation
-/// or deallocation.
-///
-/// To have the PaddleBuf allocate and manage the memory:
-/// - PaddleBuf(size_t length) will allocate a memory of size `length`.
-/// - Resize(size_t length) resize the memory to no less than `length`,
-/// ATTENTION
-///  if the allocated memory is larger than `length`, nothing will done.
-///
-/// Usage:
-///
-/// Let PaddleBuf manage the memory internally.
-/// \code{cpp}
-/// const int num_elements = 128;
-/// PaddleBuf buf(num_elements/// sizeof(float));
-/// \endcode
-///
-/// Or
-/// \code{cpp}
-/// PaddleBuf buf;
-/// buf.Resize(num_elements/// sizeof(float));
-/// \endcode
-/// Works the exactly the same.
-///
-/// One can also make the `PaddleBuf` use the external memory.
-/// \code{cpp}
-/// PaddleBuf buf;
-/// void* external_memory = new float[num_elements];
-/// buf.Reset(external_memory, num_elements*sizeof(float));
-/// ...
-/// delete[] external_memory; // manage the memory lifetime outside.
-/// \endcode
-///
-class PD_INFER_DECL PaddleBuf {
- public:
-  ///
-  /// \brief PaddleBuf allocate memory internally, and manage it.
-  ///
-  /// \param[in] length The length of data.
-  ///
-  explicit PaddleBuf(size_t length)
-      : data_(new char[length]), length_(length), memory_owned_(true) {}
-  ///
-  /// \brief Set external memory, the PaddleBuf won't manage it.
-  ///
-  /// \param[in] data The start address of the external memory.
-  /// \param[in] length The length of data.
-  ///
-  PaddleBuf(void* data, size_t length)
-      : data_(data), length_(length), memory_owned_{false} {}
-  ///
-  /// \brief Copy only available when memory is managed externally.
-  ///
-  /// \param[in] other another `PaddleBuf`
-  ///
-  explicit PaddleBuf(const PaddleBuf& other);
-  ///
-  /// \brief Resize the memory.
-  ///
-  /// \param[in] length The length of data.
-  ///
-  void Resize(size_t length);
-  ///
-  /// \brief Reset to external memory, with address and length set.
-  ///
-  /// \param[in] data The start address of the external memory.
-  /// \param[in] length The length of data.
-  ///
-  void Reset(void* data, size_t length);
-  ///
-  /// \brief Tell whether the buffer is empty.
-  ///
-  bool empty() const { return length_ == 0; }
-  ///
-  /// \brief Get the data's memory address.
-  ///
-  void* data() const { return data_; }
-  ///
-  /// \brief Get the memory length.
-  ///
-  size_t length() const { return length_; }
-
-  ~PaddleBuf() { Free(); }
-  PaddleBuf& operator=(const PaddleBuf&);
-  PaddleBuf& operator=(PaddleBuf&&);
-  PaddleBuf() = default;
-  PaddleBuf(PaddleBuf&& other);
-
- private:
-  void Free();
-  void* data_{nullptr};  ///< pointer to the data memory.
-  size_t length_{0};     ///< number of memory bytes.
-  bool memory_owned_{true};
-};
-
-///
-/// \brief Basic input and output data structure for PaddlePredictor.
-///
-struct PD_INFER_DECL PaddleTensor {
-  PaddleTensor() = default;
-  std::string name;  ///<  variable name.
-  std::vector<int> shape;
-  PaddleBuf data;  ///<  blob of data.
-  PaddleDType dtype;
-  std::vector<std::vector<size_t>> lod;  ///<  Tensor+LoD equals LoDTensor
-};
+using PaddleBuf = paddle_infer::HostBuffer;
+using PaddleTensor = paddle_infer::HostTensor;
 
 /// \brief Represents an n-dimensional array of values.
 /// The ZeroCopyTensor is used to store the input or output of the network.

--- a/paddle/fluid/inference/api/paddle_infer_tensor_handle.h
+++ b/paddle/fluid/inference/api/paddle_infer_tensor_handle.h
@@ -31,14 +31,12 @@ enum DataType {
 enum class PlaceType { kUNK = -1, kCPU, kGPU, kXPU };
 
 /// \brief Represents an n-dimensional array of values.
-/// The Tensor is used to store the input or output of the network.
-/// Zero copy means that the tensor supports direct copy of host or device data
-/// to device,
-/// eliminating additional CPU copy. Tensor is only used in the
-/// AnalysisPredictor.
-/// It is obtained through PaddlePredictor::GetinputTensor()
-/// and PaddlePredictor::GetOutputTensor() interface.
-class PD_INFER_DECL Tensor {
+/// TensorHandle is used to refer to a tensor in the predictor.
+/// It is a handle, and the user cannot construct it directly.
+/// It supports direct copy of host or device data to device,
+/// eliminating additional CPU copy. It is obtained through Predictor::
+/// GetInputHandle() and PaddlePredictor::GetOutputHandle() interface.
+class PD_INFER_DECL TensorHandle {
  public:
   /// \brief Reset the shape of the tensor.
   /// Generally it's only used for the input tensor.
@@ -61,19 +59,19 @@ class PD_INFER_DECL Tensor {
   template <typename T>
   T* data(PlaceType* place, int* size) const;
 
-  /// \brief Copy the host memory to tensor data.
+  /// \brief Copy the host memory to the referenced tensor.
   /// It's usually used to set the input tensor data.
   /// \param data The pointer of the data, from which the tensor will copy.
   template <typename T>
   void CopyFromCpu(const T* data);
 
-  /// \brief Copy the tensor data to the host memory.
+  /// \brief Copy the referenced tensor data to the host memory.
   /// It's usually used to get the output tensor data.
   /// \param[out] data The tensor will copy the data to the address.
   template <typename T>
   void CopyToCpu(T* data);
 
-  /// \brief Return the shape of the Tensor.
+  /// \brief Return the shape of the tensor.
   std::vector<int> shape() const;
 
   /// \brief Set lod info of the tensor.
@@ -81,8 +79,10 @@ class PD_INFER_DECL Tensor {
   ///  https://www.paddlepaddle.org.cn/documentation/docs/zh/beginners_guide/basic_concept/lod_tensor.html#lodtensor
   /// \param x the lod info.
   void SetLoD(const std::vector<std::vector<size_t>>& x);
+
   /// \brief Return the lod info of the tensor.
   std::vector<std::vector<size_t>> lod() const;
+
   /// \brief Return the name of the tensor.
   const std::string& name() const;
 
@@ -92,7 +92,7 @@ class PD_INFER_DECL Tensor {
   DataType type() const;
 
  protected:
-  explicit Tensor(void* scope);
+  explicit TensorHandle(void* scope);
   void* FindTensor() const;
   void SetPlace(PlaceType place, int device = -1);
   void SetName(const std::string& name);

--- a/paddle/fluid/inference/api/paddle_inference_api.h
+++ b/paddle/fluid/inference/api/paddle_inference_api.h
@@ -98,12 +98,12 @@ class PD_INFER_DECL Predictor {
   std::vector<std::string> GetInputNames();
 
   ///
-  /// \brief Get the Input Tensor object
+  /// \brief Get the intput tensor handle
   ///
   /// \param[in] name input name
   /// \return input tensor
   ///
-  std::unique_ptr<Tensor> GetInputHandle(const std::string& name);
+  std::unique_ptr<TensorHandle> GetInputHandle(const std::string& name);
 
   ///
   /// \brief Run the prediction engine
@@ -120,12 +120,12 @@ class PD_INFER_DECL Predictor {
   std::vector<std::string> GetOutputNames();
 
   ///
-  /// \brief Get the Output Tensor object
+  /// \brief Get the output tensor handle
   ///
   /// \param[in] name otuput name
   /// \return output tensor
   ///
-  std::unique_ptr<Tensor> GetOutputHandle(const std::string& name);
+  std::unique_ptr<TensorHandle> GetOutputHandle(const std::string& name);
 
   ///
   /// \brief Clone to get the new predictor. thread safe.

--- a/paddle/fluid/inference/utils/io_utils.h
+++ b/paddle/fluid/inference/utils/io_utils.h
@@ -21,10 +21,6 @@
 #include "paddle/fluid/inference/api/paddle_api.h"
 
 namespace paddle {
-struct PaddleTensor;
-}  // namespace paddle
-
-namespace paddle {
 namespace inference {
 
 constexpr uint32_t kCurPDTensorVersion = 0;

--- a/paddle/fluid/pybind/inference_api.cc
+++ b/paddle/fluid/pybind/inference_api.cc
@@ -152,7 +152,7 @@ void ZeroCopyTensorCreate(
 
 template <typename T>
 void PaddleInferTensorCreate(
-    paddle_infer::Tensor &tensor,  // NOLINT
+    paddle_infer::TensorHandle &tensor,  // NOLINT
     py::array_t<T, py::array::c_style | py::array::forcecast> data) {
   std::vector<int> shape;
   std::copy_n(data.shape(), data.ndim(), std::back_inserter(shape));
@@ -210,7 +210,8 @@ py::array ZeroCopyTensorToNumpy(ZeroCopyTensor &tensor) {  // NOLINT
   return array;
 }
 
-py::array PaddleInferTensorToNumpy(paddle_infer::Tensor &tensor) {  // NOLINT
+py::array PaddleInferTensorToNumpy(
+    paddle_infer::TensorHandle &tensor) {  // NOLINT
   py::dtype dt = PaddleDTypeToNumpyDType(tensor.type());
   auto tensor_shape = tensor.shape();
   py::array::ShapeContainer shape(tensor_shape.begin(), tensor_shape.end());
@@ -638,16 +639,16 @@ void BindZeroCopyTensor(py::module *m) {
 }
 
 void BindPaddleInferTensor(py::module *m) {
-  py::class_<paddle_infer::Tensor>(*m, "PaddleInferTensor")
-      .def("reshape", &paddle_infer::Tensor::Reshape)
+  py::class_<paddle_infer::TensorHandle>(*m, "PaddleInferTensor")
+      .def("reshape", &paddle_infer::TensorHandle::Reshape)
       .def("copy_from_cpu", &PaddleInferTensorCreate<int32_t>)
       .def("copy_from_cpu", &PaddleInferTensorCreate<int64_t>)
       .def("copy_from_cpu", &PaddleInferTensorCreate<float>)
       .def("copy_to_cpu", &PaddleInferTensorToNumpy)
-      .def("shape", &paddle_infer::Tensor::shape)
-      .def("set_lod", &paddle_infer::Tensor::SetLoD)
-      .def("lod", &paddle_infer::Tensor::lod)
-      .def("type", &paddle_infer::Tensor::type);
+      .def("shape", &paddle_infer::TensorHandle::shape)
+      .def("set_lod", &paddle_infer::TensorHandle::SetLoD)
+      .def("lod", &paddle_infer::TensorHandle::lod)
+      .def("type", &paddle_infer::TensorHandle::type);
 }
 
 void BindPredictorPool(py::module *m) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
【目标】
明确 Paddle Inference 2.0 C++ 用户接口 Tensor 概念。

【背景及内容】
在较早版本中，为了节省 `AnalysisPredictor` 输入输出与用户数据结构之间的一次数据拷贝，Paddle 引入了 `ZeroCopyTensor`。在 2.0 版本中，为减少冗余概念，将 `paddle::AnalysisPredictor` 重命名为 `paddle_infer::Predictor`；将 `paddle::ZeroCopyTensor` 重命名为 `paddle_infer::Tensor`。

但 `paddle_infer::Tensor` 实际上是 `LoDTensor` 的读写**句柄**：前者不管理资源（不能被用户构造 / 拷贝 / 移动），它只能被内部的 `Predictor` 构造，且需传入 `Scope` 变量，并指定属于输入还是输出类型。因此，本提交将 `Tensor` 名称修正为 `TensorHandle`，将 `Tensor` 概念明确为一个“可管理资源（构造 / 拷贝 / 移动）的数据结构”，以使后续迭代更加清晰。

本提交还将 `PaddleTensor` 与 `PaddleBuf` 的实现移动到了 `paddle_infer` 名称空间。

【兼容性说明】
1、`Tensor` 到 `TensorHandle` 的修改是一个不向后兼容的修复。经检查，Paddle 的示例代码此处使用了 `auto` 关键字代指 `Tensor` 或 `TensorHandle`，所以对用户不会造成较大影响；
2、其余修改均向后兼容；
3、本提交仅涉及 C++ 接口，Python 实现暂未改动、不受影响；
4、此提交合入后，会同步更新相关文档。

【备注】
上述目标的另一种实现方式是统一 `paddle_infer::HostTensor` 与 `paddle_infer::TensorHandle` 为 `paddle_infer::Tensor`，使其变为一个独占资源的句柄；并将 `paddle_infer::Predictor::GetInputHandle` 的返回类型调整为 `paddle_infer::Tensor*`。但考虑到向后兼容与工作量，没有进行。