### PR TITLE
[ROCM] fix dtype for unitttests.

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -17,7 +17,13 @@ from __future__ import print_function
 import unittest
 import numpy as np
 from op_test import OpTest
+import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
+
+paddle.enable_static()
+
+DTYPE = "float32" if core.is_compiled_with_rocm() else "float64"
 
 
 def bcast(x, target_tensor):
@@ -33,8 +39,8 @@ def bcast(x, target_tensor):
 class TestExpandAsOpRank1(OpTest):
     def setUp(self):
         self.op_type = "expand_as"
-        x = np.random.rand(100).astype("float64")
-        target_tensor = np.random.rand(200).astype("float64")
+        x = np.random.rand(100).astype(DTYPE)
+        target_tensor = np.random.rand(200).astype(DTYPE)
         self.inputs = {'X': x, 'target_tensor': target_tensor}
         self.attrs = {}
         bcast_dims = bcast(x, target_tensor)
@@ -51,8 +57,8 @@ class TestExpandAsOpRank1(OpTest):
 class TestExpandAsOpRank2(OpTest):
     def setUp(self):
         self.op_type = "expand_as"
-        x = np.random.rand(10, 12).astype("float64")
-        target_tensor = np.random.rand(20, 24).astype("float64")
+        x = np.random.rand(10, 12).astype(DTYPE)
+        target_tensor = np.random.rand(20, 24).astype(DTYPE)
         self.inputs = {'X': x, 'target_tensor': target_tensor}
         self.attrs = {}
         bcast_dims = bcast(x, target_tensor)
@@ -69,8 +75,8 @@ class TestExpandAsOpRank2(OpTest):
 class TestExpandAsOpRank3(OpTest):
     def setUp(self):
         self.op_type = "expand_as"
-        x = np.random.rand(2, 3, 20).astype("float64")
-        target_tensor = np.random.rand(4, 6, 40).astype("float64")
+        x = np.random.rand(2, 3, 20).astype(DTYPE)
+        target_tensor = np.random.rand(4, 6, 40).astype(DTYPE)
         self.inputs = {'X': x, 'target_tensor': target_tensor}
         self.attrs = {}
         bcast_dims = bcast(x, target_tensor)
@@ -87,8 +93,8 @@ class TestExpandAsOpRank3(OpTest):
 class TestExpandAsOpRank4(OpTest):
     def setUp(self):
         self.op_type = "expand_as"
-        x = np.random.rand(1, 1, 7, 16).astype("float64")
-        target_tensor = np.random.rand(4, 6, 14, 32).astype("float64")
+        x = np.random.rand(1, 1, 7, 16).astype(DTYPE)
+        target_tensor = np.random.rand(4, 6, 14, 32).astype(DTYPE)
         self.inputs = {'X': x, 'target_tensor': target_tensor}
         self.attrs = {}
         bcast_dims = bcast(x, target_tensor)

--- a/python/paddle/fluid/tests/unittests/test_expand_as_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_op.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 from __future__ import print_function
-
 import unittest
+
 import numpy as np
+
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid

--- a/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_as_v2_op.py
@@ -13,19 +13,25 @@
 # limitations under the License.
 
 from __future__ import print_function
-
 import unittest
+
 import numpy as np
+
 from op_test import OpTest
 import paddle
 import paddle.fluid as fluid
+import paddle.fluid.core as core
+
+paddle.enable_static()
+
+DTYPE = "float32" if core.is_compiled_with_rocm() else "float64"
 
 
 class TestExpandAsOpRank1(OpTest):
     def setUp(self):
         self.op_type = "expand_as_v2"
-        x = np.random.rand(100).astype("float64")
-        target_tensor = np.random.rand(2, 100).astype("float64")
+        x = np.random.rand(100).astype(DTYPE)
+        target_tensor = np.random.rand(2, 100).astype(DTYPE)
         self.inputs = {'X': x}
         self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [2, 1]
@@ -42,8 +48,8 @@ class TestExpandAsOpRank1(OpTest):
 class TestExpandAsOpRank2(OpTest):
     def setUp(self):
         self.op_type = "expand_as_v2"
-        x = np.random.rand(10, 12).astype("float64")
-        target_tensor = np.random.rand(10, 12).astype("float64")
+        x = np.random.rand(10, 12).astype(DTYPE)
+        target_tensor = np.random.rand(10, 12).astype(DTYPE)
         self.inputs = {'X': x}
         self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [1, 1]
@@ -60,8 +66,8 @@ class TestExpandAsOpRank2(OpTest):
 class TestExpandAsOpRank3(OpTest):
     def setUp(self):
         self.op_type = "expand_as_v2"
-        x = np.random.rand(2, 3, 20).astype("float64")
-        target_tensor = np.random.rand(2, 3, 20).astype("float64")
+        x = np.random.rand(2, 3, 20).astype(DTYPE)
+        target_tensor = np.random.rand(2, 3, 20).astype(DTYPE)
         self.inputs = {'X': x}
         self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [1, 1, 1]
@@ -78,8 +84,8 @@ class TestExpandAsOpRank3(OpTest):
 class TestExpandAsOpRank4(OpTest):
     def setUp(self):
         self.op_type = "expand_as_v2"
-        x = np.random.rand(1, 1, 7, 16).astype("float64")
-        target_tensor = np.random.rand(4, 6, 7, 16).astype("float64")
+        x = np.random.rand(1, 1, 7, 16).astype(DTYPE)
+        target_tensor = np.random.rand(4, 6, 7, 16).astype(DTYPE)
         self.inputs = {'X': x}
         self.attrs = {'target_shape': target_tensor.shape}
         bcast_dims = [4, 6, 1, 1]

--- a/python/paddle/fluid/tests/unittests/test_expand_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_op.py
@@ -13,13 +13,18 @@
 # limitations under the License.
 
 from __future__ import print_function
-
 import unittest
+
 import numpy as np
-from op_test import OpTest
-import paddle.fluid as fluid
-from paddle.fluid import compiler, Program, program_guard
+
 import paddle
+import paddle.fluid as fluid
+from paddle.fluid import compiler, Program, program_guard, core
+from op_test import OpTest
+
+paddle.enable_static()
+
+DTYPE = "float32" if core.is_compiled_with_rocm() else "float64"
 
 
 # Situation 1: expand_times is a list(without tensor)
@@ -28,7 +33,7 @@ class TestExpandOpRank1(OpTest):
         self.op_type = "expand"
         self.init_data()
 
-        self.inputs = {'X': np.random.random(self.ori_shape).astype("float64")}
+        self.inputs = {'X': np.random.random(self.ori_shape).astype(DTYPE)}
         self.attrs = {'expand_times': self.expand_times}
         output = np.tile(self.inputs['X'], self.expand_times)
         self.outputs = {'Out': output}
@@ -85,7 +90,7 @@ class TestExpandOpRank1_tensor_attr(OpTest):
                 (1)).astype('int32') * ele))
 
         self.inputs = {
-            'X': np.random.random(self.ori_shape).astype("float64"),
+            'X': np.random.random(self.ori_shape).astype(DTYPE),
             'expand_times_tensor': expand_times_tensor,
         }
         self.attrs = {"expand_times": self.infer_expand_times}
@@ -125,7 +130,7 @@ class TestExpandOpRank1_tensor(OpTest):
         self.init_data()
 
         self.inputs = {
-            'X': np.random.random(self.ori_shape).astype("float64"),
+            'X': np.random.random(self.ori_shape).astype(DTYPE),
             'ExpandTimes': np.array(self.expand_times).astype("int32"),
         }
         self.attrs = {}

--- a/python/paddle/fluid/tests/unittests/test_expand_v2_op.py
+++ b/python/paddle/fluid/tests/unittests/test_expand_v2_op.py
@@ -13,13 +13,19 @@
 # limitations under the License.
 
 from __future__ import print_function
-
 import unittest
+
 import numpy as np
-from op_test import OpTest
+
+import paddle
 import paddle.fluid as fluid
 from paddle.fluid import compiler, Program, program_guard
-import paddle
+import paddle.fluid.core as core
+from op_test import OpTest
+
+paddle.enable_static()
+
+DTYPE = "float32" if core.is_compiled_with_rocm() else "float64"
 
 
 # Situation 1: shape is a list(without tensor)
@@ -28,7 +34,7 @@ class TestExpandV2OpRank1(OpTest):
         self.op_type = "expand_v2"
         self.init_data()
 
-        self.inputs = {'X': np.random.random(self.ori_shape).astype("float64")}
+        self.inputs = {'X': np.random.random(self.ori_shape).astype(DTYPE)}
         self.attrs = {'shape': self.shape}
         output = np.tile(self.inputs['X'], self.expand_times)
         self.outputs = {'Out': output}
@@ -84,7 +90,7 @@ class TestExpandV2OpRank1_tensor_attr(OpTest):
                 (1)).astype('int32') * ele))
 
         self.inputs = {
-            'X': np.random.random(self.ori_shape).astype("float64"),
+            'X': np.random.random(self.ori_shape).astype(DTYPE),
             'expand_shapes_tensor': expand_shapes_tensor,
         }
         self.attrs = {"shape": self.infer_expand_shape}
@@ -119,7 +125,7 @@ class TestExpandV2OpRank1_tensor(OpTest):
         self.init_data()
 
         self.inputs = {
-            'X': np.random.random(self.ori_shape).astype("float64"),
+            'X': np.random.random(self.ori_shape).astype(DTYPE),
             'Shape': np.array(self.expand_shape).astype("int32"),
         }
         self.attrs = {}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix dtype for rocm platform with the following unitttests:

- test_expand_op.py 
- test_expand_as_v2_op.py 
- test_expand_as_op.py 
- test_expand_v2_op.py

ctest -R output after the fix:
![image](https://user-images.githubusercontent.com/18322401/110604289-dd37eb00-81c2-11eb-8c2b-bfd0d94da2dc.png)

