### PR TITLE
[Dy2stat]Fix bug with static_convert_var_shape in locals scope

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/convert_operators.py
@@ -302,19 +302,19 @@ def convert_var_shape_simple(x):
         return x.shape
 
 
-def eval_if_exist_else_none(name, local_symbol_table):
+def eval_if_exist_else_none(name, global_symbol_table):
     """
     Args:
         name([str]): Expression passed into `eval`.
-        local_symbol_table(dict): Specified from `locals()`. DO NOT use `globals()`,
-                                  it has a higher priority and will hide away variables
-                                  from `locals()`.
+        local_symbol_table(dict): Specified from `globals()`. DO NOT use `locals()`,
+                                  because all STATIC_CONVERT_VAR_SHAPE_SUFFIX vars is
+                                  declared with keyword `global`.
     
     Returns:
-        Return the variable if found in local_symbol_table else None.
+        Return the variable if found in global_symbol_table else None.
     """
     try:
-        return eval(name, local_symbol_table)
+        return eval(name, global_symbol_table)
     except:
         return None
 

--- a/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/tensor_shape_transformer.py
@@ -293,6 +293,10 @@ class TensorShapeTransformer(gast.NodeTransformer):
         return False
 
     def _update_name_to_var_shape(self, node):
+        def replace_dot(name):
+            # replace all '.' into '_'
+            return name.replace('.', '_')
+
         assert isinstance(node, gast.Assign)
         target_node = node.targets[0]
         value_node = node.value
@@ -307,7 +311,8 @@ class TensorShapeTransformer(gast.NodeTransformer):
                     if value_node.id in self.name_to_var_shape:
                         # TODO(zhhsplendid): is context a problem for the result node of gast.parse?
                         static_shape_var_name = unique_name.generate(
-                            target_id + STATIC_CONVERT_VAR_SHAPE_SUFFIX)
+                            replace_dot(target_id) +
+                            STATIC_CONVERT_VAR_SHAPE_SUFFIX)
                         static_shape_var_node = gast.parse(
                             static_shape_var_name).body[0].value
 
@@ -328,7 +333,8 @@ class TensorShapeTransformer(gast.NodeTransformer):
                 if isinstance(value_node, gast.Attribute):
                     if self._is_var_shape(value_node):  # eg: x.shape
                         static_shape_var_name = unique_name.generate(
-                            target_id + STATIC_CONVERT_VAR_SHAPE_SUFFIX)
+                            replace_dot(target_id) +
+                            STATIC_CONVERT_VAR_SHAPE_SUFFIX)
                         static_shape_var_node = gast.parse(
                             static_shape_var_name).body[0].value
 
@@ -360,7 +366,8 @@ class TensorShapeTransformer(gast.NodeTransformer):
             if isinstance(value_node, gast.Name):
                 if value_node.id in self.name_to_var_shape:
                     static_shape_var_name = unique_name.generate(
-                        target_id + STATIC_CONVERT_VAR_SHAPE_SUFFIX)
+                        replace_dot(target_id) +
+                        STATIC_CONVERT_VAR_SHAPE_SUFFIX)
                     static_shape_var_node = gast.parse(
                         static_shape_var_name).body[0].value
                     static_shape_value_name = self.name_to_var_shape[
@@ -376,7 +383,7 @@ class TensorShapeTransformer(gast.NodeTransformer):
                     self.name_to_var_shape[target_id] = static_shape_var_name
             elif self._is_var_shape(value_node):  # eg: x.shape or x.shape[0]
                 static_shape_var_name = unique_name.generate(
-                    target_id + STATIC_CONVERT_VAR_SHAPE_SUFFIX)
+                    replace_dot(target_id) + STATIC_CONVERT_VAR_SHAPE_SUFFIX)
                 static_shape_var_node = gast.parse(static_shape_var_name).body[
                     0].value
                 static_shape_value_node = copy.deepcopy(value_node)

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_operators.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_operators.py
@@ -191,29 +191,44 @@ class TestChooseShapeAttrOrApi(unittest.TestCase):
 
 
 class TestEvaIfExistElseNone(unittest.TestCase):
-    def test_locals(self):
-        x_shape = [1, 2, 3]
-        self.assertEqual(eval_if_exist_else_none('x_shape', locals()), x_shape)
-
     def test_globals(self):
+        global x_shape
+        x_shape = [1, 2, 3]
+        self.assertEqual(eval_if_exist_else_none('x_shape', locals()), None)
+        self.assertEqual(eval_if_exist_else_none('x_shape', globals()), x_shape)
+
+        del x_shape
+
+    def test_enclosing_scope(self):
+        global x_shape
         x_shape = [1, 2, 3]
 
         def foo():
-            x_shape = [2, 3, 4]
+            y_shape = [2, 3, 4]
             self.assertEqual(
-                eval_if_exist_else_none('x_shape', locals()), [2, 3, 4])
+                eval_if_exist_else_none('x_shape', globals()), [1, 2, 3])
+            self.assertEqual(
+                eval_if_exist_else_none('y_shape', locals()), [2, 3, 4])
 
         foo()
+        del x_shape
 
-    def test_invisible_of_func(self):
+    def test_global_in_func(self):
         x_shape = [1, 2, 3]
 
         def foo():
-            x_shape = [2, 3, 4]
-            return x_shape
+            global y_shape
+            y_shape = [2, 3, 4]
 
-        self.assertEqual(
-            eval_if_exist_else_none('x_shape', locals()), [1, 2, 3])
+            self.assertEqual(
+                eval_if_exist_else_none('y_shape', globals()), [2, 3, 4])
+            self.assertEqual(eval_if_exist_else_none('x_shape', locals()), None)
+            self.assertEqual(
+                eval_if_exist_else_none('x_shape', globals()), None)
+
+            del y_shape
+
+        foo()
 
     def test_none(self):
         def foo():

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_tensor_shape.py
@@ -541,5 +541,27 @@ class TestChangeShapeAfterAssign(TestTensorShapeBasic):
         self.expected_slice_op_num = 2
 
 
+def dyfunc_with_static_convert_var_shape(x):
+    # Note: this will create `batch_size__static_convert_var_shape_suffix_0` firstly.
+    batch_size = x.shape[0]
+    if len(x.shape) < 1:
+        res = x
+    else:
+        # Test for correctly to find `batch_size__static_convert_var_shape_suffix_0` in
+        # deeply nested scope.
+        res = fluid.layers.fill_constant(
+            value=8, shape=[batch_size], dtype="int32")
+
+    return res
+
+
+class TestFindStatiConvertVarShapeSuffixVar(unittest.TestCase):
+    def test(self):
+        x_spec = paddle.static.InputSpec(shape=[None, 10])
+        func = paddle.jit.to_static(dyfunc_with_if_2, input_spec=[x_spec])
+        # Call this function to trigger program translation.
+        func.concrete_program
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->


#### 问题描述
考虑如下一个模型使用样例：
```python
def dyfunc_with_static_convert_var_shape(x):
    batch_size = x.shape[0]
    if len(x.shape) < 1:
        res = x
    else:
        res = fluid.layers.fill_constant(
            value=8, shape=[batch_size], dtype="int32")

    return res
```
经过代码转换，会得到如下静态图代码：
```python
def dyfunc_with_if_2(x):
    x = paddle.assign(x)
    batch_size = x.shape[0]
    batch_size__static_convert_var_shape_suffix_0 = (paddle.jit.dy2static.
        convert_var_shape_simple(x)[0])
    res = paddle.jit.dy2static.data_layer_not_check(name='res', shape=[-1],
        dtype='float32')

    def true_fn_0(x):
        res = x
        return res

    def false_fn_0(batch_size):
        res = fluid.layers.fill_constant(value=8, shape=[paddle.jit.
            dy2static.choose_shape_attr_or_api(batch_size, paddle.jit.
            dy2static.eval_if_exist_else_none(
            'batch_size__static_convert_var_shape_suffix_0', locals()))], # 注意此处的 eval()将返回None
            dtype='int32')
        return res
    res = paddle.jit.dy2static.convert_ifelse(paddle.jit.dy2static.
        convert_call(len)(paddle.jit.dy2static.convert_var_shape(x,
        in_control_flow=True)) < 1, true_fn_0, false_fn_0, (x,), (
        batch_size,), (res,))
    return res
```

问题出在`eval_if_exist_else_none('batch_size__static_convert_var_shape_suffix_0', locals())`这里。由于 **Python 函数闭包**的作用，locals() 里是无法访问外层函数定义的变量，导致框架调用 `eval_if_exist_else_none`返回是None。因此报错如下：
```bash
    File "test_tensor_shape.py", line 122, in dyfunc_with_if_2 (* user code *)
        res = fluid.layers.fill_constant(value=8, shape=[batch_size], dtype="int32")
    File "/home/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/tensor.py", line 708, in fill_constant
        check_shape(shape)
    File "/home/env3.7/lib/python3.7/site-packages/paddle/fluid/layers/utils.py", line 375, in check_shape
        "All elements in ``shape`` must be positive when it's a list or tuple"
    ValueError: All elements in ``shape`` must be positive when it's a list or tuple
```

#### 解决方案
由于 `batch_size__static_convert_var_shape_suffix_0`变量为框架生成的具有**唯一**性的变量，因此可以将其声明为global，在`eval_if_exist_else_none`传入`globals()`作为搜索的scope即可。

新方案生成的代码如下：
```python
def dyfunc_with_if_2(x):
    x = paddle.assign(x)
    batch_size = x.shape[0]
    global batch_size__static_convert_var_shape_suffix_0  # 新增这一行
    batch_size__static_convert_var_shape_suffix_0 = (paddle.jit.dy2static.
        convert_var_shape_simple(x)[0])
    res = paddle.jit.dy2static.data_layer_not_check(name='res', shape=[-1],
        dtype='float32')

    def true_fn_0(x):
        res = x
        return res

    def false_fn_0(batch_size):
        res = fluid.layers.fill_constant(value=8, shape=[paddle.jit.
            dy2static.choose_shape_attr_or_api(batch_size, paddle.jit.
            dy2static.eval_if_exist_else_none(
            'batch_size__static_convert_var_shape_suffix_0', globals()))], # 变更为 globals()
            dtype='int32')
        return res
    res = paddle.jit.dy2static.convert_ifelse(paddle.jit.dy2static.
        convert_call(len)(paddle.jit.dy2static.convert_var_shape(x,
        in_control_flow=True)) < 1, true_fn_0, false_fn_0, (x,), (
        batch_size,), (res,))
    return res
```