### PR TITLE
Update tinyformat.h

### DIFF
--- a/paddle/fluid/string/tinyformat/tinyformat.h
+++ b/paddle/fluid/string/tinyformat/tinyformat.h
@@ -777,7 +777,7 @@ inline void formatImpl(std::ostream &out, const char *fmt,
 
   // Print remaining part of format string.
   fmt = printFormatStringLiteral(out, fmt);
-  if (*fmt != '\0')
+  if (fmt != nullptr && *fmt != '\0' && *fmt != 0)
     TINYFORMAT_ERROR(
         "tinyformat: Too many conversion specifiers in format string");
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix bugs (Debug, tinyformat) : quick fix to https://github.com/PaddlePaddle/Paddle/issues/13860 and #25494 

Open Paddle/fluid/string/tinyformat/tinyformat.h, move your cursor to detail::formatImpl and line 779

replace the codes
```
  fmt = printFormatStringLiteral(out, fmt);
  if (*fmt != '\0')
    TINYFORMAT_ERROR(
        "tinyformat: Too many conversion specifiers in format string");
```
to 

```
  fmt = printFormatStringLiteral(out, fmt);
  if (fmt != nullptr && *fmt != '\0' && *fmt != 0)
    TINYFORMAT_ERROR(
        "tinyformat: Too many conversion specifiers in format string");
```


When set CMAKE_BUILD_TYPE to Debug, the fluid/operators/controlflow/compare_op.cc is involved 

```
    AddInput("X", string::Sprintf("the left hand operand of %s operator",
                                  comment.type));
```

The safe printer actually passes a C style string pointer **without adding `\0` to the end**!