### PR TITLE
add relu forward kernel and backward kernel

### DIFF
--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -10,7 +10,227 @@ See the License for the specific language governing permissions and
 limitations under the License. */
 
 #include "paddle/fluid/operators/activation_op.h"
+#include "paddle/fluid/operators/math/math_cuda_utils.h"
+#include "paddle/fluid/platform/cuda_device_function.h"
 #include "paddle/fluid/platform/float16.h"
+
+namespace paddle {
+namespace operators {
+
+using Tensor = framework::Tensor;
+// result = a > 0 ? b : 0;
+template <typename T>
+__device__ __forceinline__ T reluFunc(const T* a, const T* b);
+
+template <typename T, int N>
+struct GetVecType;
+
+template <typename T>
+struct GetVecType<T, 1> {
+  using type = T;
+};
+template <>
+struct GetVecType<platform::float16, 2> {
+  using type = half2;
+};
+
+template <>
+struct GetVecType<float, 4> {
+  using type = float4;
+};
+// for relu forward and backward
+template <>
+__device__ __forceinline__ double reluFunc<double>(const double* a,
+                                                   const double* b) {
+  return ((*a) > 0.0f) * (*b);
+}
+
+template <>
+__device__ __forceinline__ float4 reluFunc<float4>(const float4* a,
+                                                   const float4* b) {
+  return make_float4((a->x > 0.0f) * (b->x), (a->y > 0.0f) * (b->y),
+                     (a->z > 0.0f) * (b->z), (a->w > 0.0f) * (b->w));
+}
+
+template <>
+__device__ __forceinline__ __half2 reluFunc<__half2>(const __half2* a,
+                                                     const __half2* b) {
+#if __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
+  const half2 kzero = __float2half2_rn(0.0f);
+  return __hmul2(__hgt2(__ldg(a), kzero), __ldg(b));
+#else
+  const float2 xx = __half22float2(*a);
+  const float2 yy = __half22float2(*b);
+  return __floats2half2_rn((xx.x > 0.0f) * static_cast<float>(yy.x),
+                           (xx.y > 0.0f) * static_cast<float>(yy.y));
+#endif
+}
+
+// relu forward kernel
+template <typename T, typename VecType, int VECSIZE>
+__global__ void reluKernelCudaVec(const T* in, T* out, int num) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int stride = blockDim.x * gridDim.x;
+  int loop = num / VECSIZE;
+  int tail = num % VECSIZE;
+  const VecType* src = reinterpret_cast<const VecType*>(in);
+  VecType* dst = reinterpret_cast<VecType*>(out);
+  for (int i = idx; i < loop; i += stride) {
+    dst[i] = reluFunc((src + i), (src + i));
+  }
+  T temp;
+  T zero = (T)(0.0f);
+  while (idx == loop && tail) {
+    temp = in[num - tail];
+    out[num - tail] = temp > zero ? temp : zero;
+    --tail;
+  }
+}
+// relu backward kernel
+template <typename T, typename VecType, int VECSIZE>
+__global__ void reluGradKernelVec(const T* out, const T* dout, T* dx, int num) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int stride = blockDim.x * gridDim.x;
+  int loop = num / VECSIZE;
+  int tail = num % VECSIZE;
+  const VecType* out_v = reinterpret_cast<const VecType*>(out);
+  const VecType* dout_v = reinterpret_cast<const VecType*>(dout);
+  VecType* dx_out = reinterpret_cast<VecType*>(dx);
+  for (int i = idx; i < loop; i += stride) {
+    dx_out[i] = reluFunc((out_v + i), (dout_v + i));
+  }
+  T zero = (T)(0.0f);
+  while (idx == loop && tail) {
+    dx[num - tail] = out[num - tail] > zero ? dout[num - tail] : zero;
+    --tail;
+  }
+}
+template <typename T>
+__global__ void reluGradFunc(const T* out, const T* dout, T* dx, int num) {
+  const float4* out_f = reinterpret_cast<const float4*>(out);
+  const float4* dout_f = reinterpret_cast<const float4*>(dout);
+  float4* dx_f = reinterpret_cast<float4*>(dx);
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  int loop = num / 4;
+  int tail = num % 4;
+  for (int t = i; t < loop; t += blockDim.x * gridDim.x) {
+    dx_f[t].x = (out_f[t].x > 0.0f) * dout_f[t].x;
+    dx_f[t].y = (out_f[t].y > 0.0f) * dout_f[t].y;
+    dx_f[t].z = (out_f[t].z > 0.0f) * dout_f[t].z;
+    dx_f[t].w = (out_f[t].w > 0.0f) * dout_f[t].w;
+  }
+  T zero = (T)(0.0f);
+  while (i == loop && tail) {
+    dx[num - tail] = out[num - tail] > zero ? dout[num - tail] : zero;
+    --tail;
+  }
+}
+template <typename T>
+__global__ void reluGradFunc_half(const T* out, const T* dout, T* dx,
+                                  size_t num) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  if (idx * 2 >= num) return;
+  int loop = num >> 1;
+  int stride = blockDim.x * gridDim.x;
+  const __half2* out_half = reinterpret_cast<const __half2*>(out);
+  const __half2* dout_half = reinterpret_cast<const __half2*>(dout);
+  __half2* dx_half = reinterpret_cast<__half2*>(dx);
+
+  const half2 kzero = __float2half2_rn(0.0f);
+
+  for (int i = idx; i < loop; i += stride) {
+#if __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
+    dx_half[i] =
+        __hmul2(__hgt2(__ldg(out_half + i), kzero), __ldg(dout_half + i));
+#else
+    const float2 xx = __half22float2(out[i]);
+    const float2 yy = __half22float2(dout[i]);
+    dx_half[i] =
+        __floats2half2_rn(xx.x > 0.0f ? static_cast<float>(yy.x) : 0.0f,
+                          xx.y > 0.0f ? static_cast<float>(yy.y) : 0.0f);
+#endif
+  }
+}
+
+template <typename T, int VECSIZE>
+struct ReluGPUFunctor : public BaseActivationFunctor<T> {
+  void operator()(const platform::CUDADeviceContext& context,
+                  const framework::Tensor& in, framework::Tensor* out,
+                  int num) {
+    const T* input_data = in.data<T>();
+    T* output_data = out->mutable_data<T>(context.GetPlace());
+    using VecType = typename GetVecType<T, VECSIZE>::type;
+    int block = 512;
+    if (num > VECSIZE) {
+      int grid = (num / VECSIZE + block - 1) / block;
+      reluKernelCudaVec<T, VecType, VECSIZE><<<grid, block>>>(input_data,
+                                                              output_data, num);
+    } else {
+      int grid1 = (num + block - 1) / block;
+      reluKernelCudaVec<T, T, 1><<<grid1, block>>>(input_data, output_data,
+                                                   num);
+    }
+  }
+};
+template <typename DeviceContext, typename Functor>
+class ReluBaseKernel
+    : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
+ public:
+  using T = typename Functor::ELEMENT_TYPE;
+  void Compute(const framework::ExecutionContext& context) const override {
+    const Tensor* in_x = context.Input<Tensor>("X");
+    Tensor* out = context.Output<Tensor>("Out");
+    auto& dev_ctx = context.template device_context<DeviceContext>();
+    int num = in_x->numel();
+    Functor functor;
+    functor(dev_ctx, *in_x, out, num);
+  }
+};
+
+template <typename T, int VECSIZE>
+struct ReluGradGPUFunctor : public BaseActivationFunctor<T> {
+  void operator()(const platform::CUDADeviceContext& context,
+                  const framework::Tensor* out, const framework::Tensor* d_out,
+                  framework::Tensor* d_x) {
+    auto numel = d_out->numel();
+    auto* dout_data = d_out->data<T>();
+    auto* out_data = out->data<T>();
+    auto* dx_data = d_x->mutable_data<T>(
+        context.GetPlace(), static_cast<size_t>(numel * sizeof(T)));
+    using VecType = typename GetVecType<T, VECSIZE>::type;
+    int block = 512;
+    if (numel > VECSIZE) {
+      int grid = (numel / VECSIZE + block - 1) / block;
+      reluGradKernelVec<T, VecType, VECSIZE><<<grid, block>>>(
+          out_data, dout_data, dx_data, numel);
+    } else {
+      int grid1 = (numel + block - 1) / block;
+      reluGradKernelVec<T, T, 1><<<grid1, block>>>(out_data, dout_data, dx_data,
+                                                   numel);
+    }
+  }
+  // static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepOut; }
+};
+
+template <typename DeviceContext, typename Functor>
+class ReluGradKernel
+    : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
+ public:
+  using T = typename Functor::ELEMENT_TYPE;
+  void Compute(const framework::ExecutionContext& ctx) const override {
+    const framework::Tensor* out = ctx.Input<framework::Tensor>("Out");
+    const framework::Tensor* d_out =
+        ctx.Input<framework::Tensor>(framework::GradVarName("Out"));
+    framework::Tensor* d_x =
+        ctx.Output<framework::Tensor>(framework::GradVarName("X"));
+    Functor functor;
+    auto& dev_ctx = ctx.template device_context<DeviceContext>();
+    functor(dev_ctx, out, d_out, d_x);
+  }
+};
+
+}  // namespace operators
+}  // namespace paddle
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
@@ -60,8 +280,21 @@ REGISTER_OP_CUDA_KERNEL(
 /* ========================================================================== */
 
 /* ===========================    relu register  ============================ */
-REGISTER_ACTIVATION_CUDA_KERNEL(relu, Relu, ReluCUDAFunctor, ReluGradFunctor);
+REGISTER_OP_CUDA_KERNEL(
+    relu, ops::ReluBaseKernel<paddle::platform::CUDADeviceContext,
+                              ops::ReluGPUFunctor<float, 4>>,
+    ops::ReluBaseKernel<paddle::platform::CUDADeviceContext,
+                        ops::ReluGPUFunctor<double, 1>>,
+    ops::ReluBaseKernel<paddle::platform::CUDADeviceContext,
+                        ops::ReluGPUFunctor<plat::float16, 2>>);
 
+REGISTER_OP_CUDA_KERNEL(
+    relu_grad, ops::ReluGradKernel<plat::CUDADeviceContext,
+                                   ops::ReluGradGPUFunctor<float, 4>>,
+    ops::ReluGradKernel<plat::CUDADeviceContext,
+                        ops::ReluGradGPUFunctor<double, 1>>,
+    ops::ReluGradKernel<plat::CUDADeviceContext,
+                        ops::ReluGradGPUFunctor<plat::float16, 2>>);
 REGISTER_OP_CUDA_KERNEL(
     relu_grad_grad,
     ops::ActivationDoubleGradKernel<paddle::platform::CUDADeviceContext,

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -221,7 +221,7 @@ class ActivationGPUKernel
     Functor functor;
     int block = 512;
     constexpr int vecsize = CudaVecType<T>::vecsize;
-    int grid = std::max((num / vecsize + block - 1) / block, 1);
+    int grid = max((num / vecsize + block - 1) / block, 1);
     ActivationkernelVec<T, Functor><<<grid, block>>>(input_data, output_data,
                                                      num, functor);
   }
@@ -256,8 +256,8 @@ class ActivationGradGPUKernel
 
     Functor functor;
     int block = 512;
-    int grid = std::max((num / vecsize + block - 1) / block, 1);
     constexpr int vecsize = CudaVecType<T>::vecsize;
+    int grid = max((numel / vecsize + block - 1) / block, 1);
 
     ActivationGradKernelVec<T, Functor><<<grid, block>>>(
         forward_data, dout_data, dx_data, numel, functor);

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -238,7 +238,7 @@ class ActivationGradGPUKernel
     x = out = d_out = nullptr;
     ExtractActivationGradTensor<Functor::FwdDeps()>(context, &x, &out, &d_out,
                                                     &d_x);
-    auto numel = d_out->numel();
+    int numel = d_out->numel();
     auto& dev_ctx = context.template device_context<DeviceContext>();
     auto* dx_data = d_x->mutable_data<T>(
         dev_ctx.GetPlace(), static_cast<size_t>(numel * sizeof(T)));

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -27,12 +27,6 @@ struct CudaVecType {
 };
 
 template <>
-struct CudaVecType<double> {
-  using type = double;
-  static constexpr int vecsize = 1;
-};
-
-template <>
 struct CudaVecType<platform::float16> {
   using type = __half2;
   static constexpr int vecsize = 2;
@@ -66,7 +60,7 @@ class ReluGPUFuctor : public BaseGPUFunctor<T> {
       const typename CudaVecType<T>::type* a);
 
   // when num % vecsize != 0 this func will be used
-  __device__ __forceinline__ T ComputeReminder(const T a) {
+  __device__ __forceinline__ T ComputeRemainder(const T a) {
     return a > zero_ ? a : zero_;
   }
 };
@@ -119,7 +113,7 @@ class ReluGradGPUFunctor : public BaseGPUFunctor<T> {
       const typename CudaVecType<T>::type* b);
 
   // when num % vecsize != 0 this func will be used
-  __device__ __forceinline__ T ComputeReminder(const T a, const T b) {
+  __device__ __forceinline__ T ComputeRemainder(const T a, const T b) {
     return a > zero_ ? b : zero_;
   }
 
@@ -181,7 +175,7 @@ __global__ void ActivationGradKernelVec(const T* forward_data, const T* dout,
 
   while (idx == loop && tail) {
     dx[num - tail] =
-        functor.ComputeReminder(forward_data[num - tail], dout[num - tail]);
+        functor.ComputeRemainder(forward_data[num - tail], dout[num - tail]);
     --tail;
   }
 }
@@ -203,7 +197,7 @@ __global__ void ActivationkernelVec(const T* src, T* dst, int num,
   }
 
   while (idx == loop && tail) {
-    dst[num - tail] = functor.ComputeReminder(src[num - tail]);
+    dst[num - tail] = functor.ComputeRemainder(src[num - tail]);
     --tail;
   }
 }

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -20,60 +20,119 @@ namespace operators {
 using Tensor = framework::Tensor;
 using float16 = paddle::platform::float16;
 
-template <typename T, int N>
+template <typename T>
 struct GetVecType;
 
-template <typename T>
-struct GetVecType<T, 1> {
-  using type = T;
+template <>
+struct GetVecType<double> {
+  using type = double;
 };
 
 template <>
-struct GetVecType<platform::float16, 2> {
+struct GetVecType<platform::float16> {
   using type = __half2;
 };
 
 template <>
-struct GetVecType<float, 4> {
+struct GetVecType<float> {
   using type = float4;
 };
 
 template <typename T>
-class BaseActivationGPUFunctor {
+class BaseGPUFunctor {
  public:
-  using ELEMENT_TYPE = T;
+  using ELEMENT_TYPE_ = T;
 };
 
+/* ========================================================================== */
+
+/* ===========================    relu forward   ============================ */
 template <typename Type>
-class ReluGPUFunctor : public BaseActivationGPUFunctor<Type> {
+class ReluGPUFuctor : public BaseGPUFunctor<Type> {
  public:
   // for relu forward and backward when T is double
   template <typename T>
-  __device__ __forceinline__ T compute(const T* a, const T* b) {
-#ifdef __CUDA_ARCH__ >= 350 || HIP_VERSION >= 300
-    return __ldg(a) > static_cast<T>(0) ? __ldg(b) : static_cast<T>(0);
-#else
-    return (*a) > static_cast<T>(0) ? (*b) : static_cast<T>(0);
-#endif
-  }
-
+  __device__ __forceinline__ T Compute(const T* a);
   // when num % vecsize != 0 this func will be used
   template <typename T>
-  __device__ __forceinline__ T computeReminder(const T a, const T b) {
-    return a > static_cast<T>(0) ? b : static_cast<T>(0);
+  __device__ __forceinline__ T ComputeReminder(const T a) {
+    return a > static_cast<T>(0.0f) ? a : static_cast<T>(0.0f);
   }
 };
 
 template <>
+__device__ __forceinline__ double ReluGPUFuctor<double>::Compute<double>(
+    const double* a) {
+#ifdef __CUDA_ARCH__ >= 350 || HIP_VERSION >= 300
+  return __ldg(a) > static_cast<double>(0.0f) ? __ldg(a)
+                                              : static_cast<double>(0.0f);
+#else
+  return (*a) > static_cast<double>(0.0f) ? (*a) : static_cast<double>(0.0f);
+#endif
+}
+
+template <>
 __device__ __forceinline__ float4
-ReluGPUFunctor<float>::compute<float4>(const float4* a, const float4* b) {
+ReluGPUFuctor<float>::Compute<float4>(const float4* a) {
+  return make_float4((a->x > 0.0f) * (a->x), (a->y > 0.0f) * (a->y),
+                     (a->z > 0.0f) * (a->z), (a->w > 0.0f) * (a->w));
+}
+
+template <>
+__device__ __forceinline__ __half2
+ReluGPUFuctor<float16>::Compute<__half2>(const __half2* a) {
+#ifdef __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
+  const half2 kzero = __float2half2_rn(0.0f);
+  return __hmul2(__hgt2(__ldg(a), kzero), __ldg(a));
+#else
+  const float2 xx = __half22float2(*a);
+  return __floats2half2_rn((xx.x > 0.0f) * static_cast<float>(xx.x),
+                           (xx.y > 0.0f) * static_cast<float>(xx.y));
+#endif
+}
+/* ========================================================================== */
+
+/* ===========================    relu backward   ============================
+ */
+
+template <typename Type>
+class ReluGradGPUFunctor : public BaseGPUFunctor<Type> {
+ public:
+  // for relu forward and backward when T is double
+  template <typename T>
+  __device__ __forceinline__ T Compute(const T* a, const T* b);
+
+  // when num % vecsize != 0 this func will be used
+  template <typename T>
+  __device__ __forceinline__ T ComputeReminder(const T a, const T b) {
+    return a > static_cast<T>(0) ? b : static_cast<T>(0);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepOut; }
+};
+
+template <>
+__device__ __forceinline__ double ReluGradGPUFunctor<double>::Compute<double>(
+    const double* a, const double* b) {
+#ifdef __CUDA_ARCH__ >= 350 || HIP_VERSION >= 300
+  return __ldg(a) > static_cast<double>(0.0f) ? __ldg(b)
+                                              : static_cast<double>(0.0f);
+#else
+  return (*a) > static_cast<double>(0.0f) ? (*b) : static_cast<double>(0.0f);
+#endif
+}
+
+template <>
+__device__ __forceinline__ float4
+ReluGradGPUFunctor<float>::Compute<float4>(const float4* a, const float4* b) {
   return make_float4((a->x > 0.0f) * (b->x), (a->y > 0.0f) * (b->y),
                      (a->z > 0.0f) * (b->z), (a->w > 0.0f) * (b->w));
 }
 
 template <>
 __device__ __forceinline__ __half2
-ReluGPUFunctor<float16>::compute<__half2>(const __half2* a, const __half2* b) {
+ReluGradGPUFunctor<float16>::Compute<__half2>(const __half2* a,
+                                              const __half2* b) {
 #ifdef __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
   const half2 kzero = __float2half2_rn(0.0f);
   return __hmul2(__hgt2(__ldg(a), kzero), __ldg(b));
@@ -85,36 +144,60 @@ ReluGPUFunctor<float16>::compute<__half2>(const __half2* a, const __half2* b) {
 #endif
 }
 
-template <typename T, typename VecType, int VecSize, typename Functor>
-__global__ void reluKernelCudaVec(const T* src1, const T* src2, T* dst, int num,
-                                  Functor functor) {
+/* ========================================================================== */
+
+template <typename T, typename VecType, typename Functor>
+__global__ void ActivationGradKernelVec(const T* forward_data, const T* dout,
+                                        T* dx, int num, int vecsize,
+                                        Functor functor) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
   int stride = blockDim.x * gridDim.x;
-  int loop = num / VecSize;
-  int tail = num % VecSize;
-  const VecType* in1 = reinterpret_cast<const VecType*>(src1);
-  const VecType* in2 = reinterpret_cast<const VecType*>(src2);
-  VecType* out = reinterpret_cast<VecType*>(dst);
+  int loop = num / vecsize;
+  int tail = num % vecsize;
+  const VecType* in_forward = reinterpret_cast<const VecType*>(forward_data);
+  const VecType* in_dout = reinterpret_cast<const VecType*>(dout);
+  VecType* out = reinterpret_cast<VecType*>(dx);
 
   for (int i = idx; i < loop; i += stride) {
-    out[i] = functor.compute((in1 + i), (in2 + i));
+    out[i] = functor.Compute((in_forward + i), (in_dout + i));
   }
 
   while (idx == loop && tail) {
-    dst[num - tail] =
-        functor.computeReminder(src1[num - tail], src2[num - tail]);
+    dx[num - tail] =
+        functor.ComputeReminder(forward_data[num - tail], dout[num - tail]);
     --tail;
   }
 }
 
-template <typename DeviceContext, typename Functor, int VecSize>
+template <typename T, typename VecType, typename Functor>
+__global__ void ActivationKerenlVec(const T* src, T* dst, int num, int vecsize,
+                                    Functor functor) {
+  int idx = threadIdx.x + blockIdx.x * blockDim.x;
+  int stride = blockDim.x * gridDim.x;
+  int loop = num / vecsize;
+  int tail = num % vecsize;
+  const VecType* in = reinterpret_cast<const VecType*>(src);
+  VecType* out = reinterpret_cast<VecType*>(dst);
+
+  for (int i = idx; i < loop; i += stride) {
+    out[i] = functor.Compute((in + i));
+  }
+
+  while (idx == loop && tail) {
+    dst[num - tail] = functor.ComputeReminder(src[num - tail]);
+    --tail;
+  }
+}
+
+template <typename DeviceContext, typename Functor>
 class ActivationGPUKernel
-    : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
+    : public framework::OpKernel<typename Functor::ELEMENT_TYPE_> {
  public:
-  using T = typename Functor::ELEMENT_TYPE;
+  using T = typename Functor::ELEMENT_TYPE_;
   void Compute(const framework::ExecutionContext& context) const override {
-    const Tensor* in_x = context.Input<Tensor>("X");
-    Tensor* out = context.Output<Tensor>("Out");
+    const framework::Tensor* in_x = nullptr;
+    framework::Tensor* out = nullptr;
+    ExtractActivationTensor(context, &in_x, &out);
     auto& dev_ctx = context.template device_context<DeviceContext>();
 
     int num = in_x->numel();
@@ -122,50 +205,62 @@ class ActivationGPUKernel
     T* output_data = out->mutable_data<T>(dev_ctx.GetPlace(),
                                           static_cast<size_t>(num * sizeof(T)));
 
+    using VecType = typename GetVecType<T>::type;
+    // int vecsize = typename GetVecType<T>::vecsize;
+    int vecsize = sizeof(VecType) / sizeof(T);
     int block = 512;
     int grid = (num + block - 1) / block;
-    if (num > VecSize) {
+    if (num > vecsize) {
       // update grid for float16 and float32
-      grid = (num / VecSize + block - 1) / block;
+      grid = (num / vecsize + block - 1) / block;
     }
 
     Functor functor;
-    using VecType = typename GetVecType<T, VecSize>::type;
-    reluKernelCudaVec<T, VecType, VecSize, Functor><<<grid, block>>>(
-        input_data, input_data, output_data, num, functor);
+    ActivationKerenlVec<T, VecType, Functor><<<grid, block>>>(
+        input_data, output_data, num, vecsize, functor);
   }
 };
 
-template <typename DeviceContext, typename Functor, int VecSize>
+template <typename DeviceContext, typename Functor>
 class ActivationGradGPUKernel
-    : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
+    : public framework::OpKernel<typename Functor::ELEMENT_TYPE_> {
  public:
-  using T = typename Functor::ELEMENT_TYPE;
-  void Compute(const framework::ExecutionContext& ctx) const override {
-    const framework::Tensor* out = ctx.Input<framework::Tensor>("Out");
-    const framework::Tensor* d_out =
-        ctx.Input<framework::Tensor>(framework::GradVarName("Out"));
-    framework::Tensor* d_x =
-        ctx.Output<framework::Tensor>(framework::GradVarName("X"));
-
-    auto& dev_ctx = ctx.template device_context<DeviceContext>();
-    auto* out_data = out->data<T>();
+  using T = typename Functor::ELEMENT_TYPE_;
+  void Compute(const framework::ExecutionContext& context) const override {
+    const framework::Tensor *x, *out, *d_out;
+    framework::Tensor* d_x = nullptr;
+    x = out = d_out = nullptr;
+    ExtractActivationGradTensor<Functor::FwdDeps()>(context, &x, &out, &d_out,
+                                                    &d_x);
     auto numel = d_out->numel();
-    auto* dout_data = d_out->data<T>();
+    auto& dev_ctx = context.template device_context<DeviceContext>();
     auto* dx_data = d_x->mutable_data<T>(
         dev_ctx.GetPlace(), static_cast<size_t>(numel * sizeof(T)));
+    auto* dout_data = d_out->data<T>();
 
+    auto* forward_data = dout_data;
+    if (static_cast<int>(Functor::FwdDeps()) == static_cast<int>(kDepOut)) {
+      forward_data = out->data<T>();
+      // only out
+    } else if (static_cast<int>(Functor::FwdDeps()) ==
+               static_cast<int>(kDepX)) {
+      // only input
+      forward_data = x->data<T>();
+    }
+
+    using VecType = typename GetVecType<T>::type;
+    // int vecsize = typename GetVecType<T>::vecsize;
+    int vecsize = sizeof(VecType) / sizeof(T);
     int block = 512;
     int grid = (numel + block - 1) / block;
-    if (numel >= VecSize) {
+    if (numel >= vecsize) {
       // update grid for float16 and float32
-      grid = (numel / VecSize + block - 1) / block;
+      grid = (numel / vecsize + block - 1) / block;
     }
 
     Functor functor;
-    using VecType = typename GetVecType<T, VecSize>::type;
-    reluKernelCudaVec<T, VecType, VecSize, Functor><<<grid, block>>>(
-        out_data, dout_data, dx_data, numel, functor);
+    ActivationGradKernelVec<T, VecType, Functor><<<grid, block>>>(
+        forward_data, dout_data, dx_data, numel, vecsize, functor);
   }
 };
 
@@ -174,6 +269,7 @@ class ActivationGradGPUKernel
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
+
 #define REGISTER_ACTIVATION_CUDA_KERNEL(act_type, op_name, functor,         \
                                         grad_functor)                       \
   REGISTER_OP_CUDA_KERNEL(                                                  \
@@ -221,19 +317,19 @@ REGISTER_OP_CUDA_KERNEL(
 /* ===========================    relu register  ============================ */
 REGISTER_OP_CUDA_KERNEL(
     relu, ops::ActivationGPUKernel<paddle::platform::CUDADeviceContext,
-                                   ops::ReluGPUFunctor<float>, 4>,
+                                   ops::ReluGPUFuctor<float>>,
     ops::ActivationGPUKernel<paddle::platform::CUDADeviceContext,
-                             ops::ReluGPUFunctor<double>, 1>,
+                             ops::ReluGPUFuctor<double>>,
     ops::ActivationGPUKernel<plat::CUDADeviceContext,
-                             ops::ReluGPUFunctor<plat::float16>, 2>);
+                             ops::ReluGPUFuctor<plat::float16>>);
 
 REGISTER_OP_CUDA_KERNEL(
     relu_grad, ops::ActivationGradGPUKernel<paddle::platform::CUDADeviceContext,
-                                            ops::ReluGPUFunctor<float>, 4>,
+                                            ops::ReluGradGPUFunctor<float>>,
     ops::ActivationGradGPUKernel<paddle::platform::CUDADeviceContext,
-                                 ops::ReluGPUFunctor<double>, 1>,
+                                 ops::ReluGradGPUFunctor<double>>,
     ops::ActivationGradGPUKernel<plat::CUDADeviceContext,
-                                 ops::ReluGPUFunctor<plat::float16>, 2>);
+                                 ops::ReluGradGPUFunctor<plat::float16>>);
 
 REGISTER_OP_CUDA_KERNEL(
     relu_grad_grad,

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -67,12 +67,14 @@ class ReluGPUFuctor : public BaseGPUFunctor<Type> {
 };
 
 template <>
+template <>
 __device__ __forceinline__ float4
 ReluGPUFuctor<float>::Compute<float4>(const float4* a) {
   return make_float4((a->x > 0.0f) * (a->x), (a->y > 0.0f) * (a->y),
                      (a->z > 0.0f) * (a->z), (a->w > 0.0f) * (a->w));
 }
 
+template <>
 template <>
 __device__ __forceinline__ __half2
 ReluGPUFuctor<float16>::Compute<__half2>(const __half2* a) {

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -18,9 +18,7 @@ namespace paddle {
 namespace operators {
 
 using Tensor = framework::Tensor;
-// result = a > 0 ? b : 0;
-template <typename T>
-__device__ __forceinline__ T reluFunc(const T* a, const T* b);
+using float16 = paddle::platform::float16;
 
 template <typename T, int N>
 struct GetVecType;
@@ -29,33 +27,54 @@ template <typename T>
 struct GetVecType<T, 1> {
   using type = T;
 };
+
 template <>
 struct GetVecType<platform::float16, 2> {
-  using type = half2;
+  using type = __half2;
 };
 
 template <>
 struct GetVecType<float, 4> {
   using type = float4;
 };
-// for relu forward and backward
-template <>
-__device__ __forceinline__ double reluFunc<double>(const double* a,
-                                                   const double* b) {
-  return ((*a) > 0.0f) * (*b);
-}
+
+template <typename T>
+class BaseActivationGPUFunctor {
+ public:
+  using ELEMENT_TYPE = T;
+};
+
+template <typename Type>
+class ReluGPUFunctor : public BaseActivationGPUFunctor<Type> {
+ public:
+  // for relu forward and backward when T is double
+  template <typename T>
+  __device__ __forceinline__ T compute(const T* a, const T* b) {
+#ifdef __CUDA_ARCH__ >= 350 || HIP_VERSION >= 300
+    return __ldg(a) > static_cast<T>(0) ? __ldg(b) : static_cast<T>(0);
+#else
+    return (*a) > static_cast<T>(0) ? (*b) : static_cast<T>(0);
+#endif
+  }
+
+  // when num % vecsize != 0 this func will be used
+  template <typename T>
+  __device__ __forceinline__ T computeReminder(const T a, const T b) {
+    return a > static_cast<T>(0) ? b : static_cast<T>(0);
+  }
+};
 
 template <>
-__device__ __forceinline__ float4 reluFunc<float4>(const float4* a,
-                                                   const float4* b) {
+__device__ __forceinline__ float4
+ReluGPUFunctor<float>::compute<float4>(const float4* a, const float4* b) {
   return make_float4((a->x > 0.0f) * (b->x), (a->y > 0.0f) * (b->y),
                      (a->z > 0.0f) * (b->z), (a->w > 0.0f) * (b->w));
 }
 
 template <>
-__device__ __forceinline__ __half2 reluFunc<__half2>(const __half2* a,
-                                                     const __half2* b) {
-#if __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
+__device__ __forceinline__ __half2
+ReluGPUFunctor<float16>::compute<__half2>(const __half2* a, const __half2* b) {
+#ifdef __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
   const half2 kzero = __float2half2_rn(0.0f);
   return __hmul2(__hgt2(__ldg(a), kzero), __ldg(b));
 #else
@@ -66,114 +85,30 @@ __device__ __forceinline__ __half2 reluFunc<__half2>(const __half2* a,
 #endif
 }
 
-// relu forward kernel
-template <typename T, typename VecType, int VECSIZE>
-__global__ void reluKernelCudaVec(const T* in, T* out, int num) {
+template <typename T, typename VecType, int VecSize, typename Functor>
+__global__ void reluKernelCudaVec(const T* src1, const T* src2, T* dst, int num,
+                                  Functor functor) {
   int idx = threadIdx.x + blockIdx.x * blockDim.x;
   int stride = blockDim.x * gridDim.x;
-  int loop = num / VECSIZE;
-  int tail = num % VECSIZE;
-  const VecType* src = reinterpret_cast<const VecType*>(in);
-  VecType* dst = reinterpret_cast<VecType*>(out);
+  int loop = num / VecSize;
+  int tail = num % VecSize;
+  const VecType* in1 = reinterpret_cast<const VecType*>(src1);
+  const VecType* in2 = reinterpret_cast<const VecType*>(src2);
+  VecType* out = reinterpret_cast<VecType*>(dst);
+
   for (int i = idx; i < loop; i += stride) {
-    dst[i] = reluFunc((src + i), (src + i));
+    out[i] = functor.compute((in1 + i), (in2 + i));
   }
-  T temp;
-  T zero = (T)(0.0f);
+
   while (idx == loop && tail) {
-    temp = in[num - tail];
-    out[num - tail] = temp > zero ? temp : zero;
+    dst[num - tail] =
+        functor.computeReminder(src1[num - tail], src2[num - tail]);
     --tail;
   }
 }
-// relu backward kernel
-template <typename T, typename VecType, int VECSIZE>
-__global__ void reluGradKernelVec(const T* out, const T* dout, T* dx, int num) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  int stride = blockDim.x * gridDim.x;
-  int loop = num / VECSIZE;
-  int tail = num % VECSIZE;
-  const VecType* out_v = reinterpret_cast<const VecType*>(out);
-  const VecType* dout_v = reinterpret_cast<const VecType*>(dout);
-  VecType* dx_out = reinterpret_cast<VecType*>(dx);
-  for (int i = idx; i < loop; i += stride) {
-    dx_out[i] = reluFunc((out_v + i), (dout_v + i));
-  }
-  T zero = (T)(0.0f);
-  while (idx == loop && tail) {
-    dx[num - tail] = out[num - tail] > zero ? dout[num - tail] : zero;
-    --tail;
-  }
-}
-template <typename T>
-__global__ void reluGradFunc(const T* out, const T* dout, T* dx, int num) {
-  const float4* out_f = reinterpret_cast<const float4*>(out);
-  const float4* dout_f = reinterpret_cast<const float4*>(dout);
-  float4* dx_f = reinterpret_cast<float4*>(dx);
-  int i = blockDim.x * blockIdx.x + threadIdx.x;
-  int loop = num / 4;
-  int tail = num % 4;
-  for (int t = i; t < loop; t += blockDim.x * gridDim.x) {
-    dx_f[t].x = (out_f[t].x > 0.0f) * dout_f[t].x;
-    dx_f[t].y = (out_f[t].y > 0.0f) * dout_f[t].y;
-    dx_f[t].z = (out_f[t].z > 0.0f) * dout_f[t].z;
-    dx_f[t].w = (out_f[t].w > 0.0f) * dout_f[t].w;
-  }
-  T zero = (T)(0.0f);
-  while (i == loop && tail) {
-    dx[num - tail] = out[num - tail] > zero ? dout[num - tail] : zero;
-    --tail;
-  }
-}
-template <typename T>
-__global__ void reluGradFunc_half(const T* out, const T* dout, T* dx,
-                                  size_t num) {
-  int idx = threadIdx.x + blockIdx.x * blockDim.x;
-  if (idx * 2 >= num) return;
-  int loop = num >> 1;
-  int stride = blockDim.x * gridDim.x;
-  const __half2* out_half = reinterpret_cast<const __half2*>(out);
-  const __half2* dout_half = reinterpret_cast<const __half2*>(dout);
-  __half2* dx_half = reinterpret_cast<__half2*>(dx);
 
-  const half2 kzero = __float2half2_rn(0.0f);
-
-  for (int i = idx; i < loop; i += stride) {
-#if __CUDA_ARCH__ >= 530 || CUDA_VERSION >= 300
-    dx_half[i] =
-        __hmul2(__hgt2(__ldg(out_half + i), kzero), __ldg(dout_half + i));
-#else
-    const float2 xx = __half22float2(out[i]);
-    const float2 yy = __half22float2(dout[i]);
-    dx_half[i] =
-        __floats2half2_rn(xx.x > 0.0f ? static_cast<float>(yy.x) : 0.0f,
-                          xx.y > 0.0f ? static_cast<float>(yy.y) : 0.0f);
-#endif
-  }
-}
-
-template <typename T, int VECSIZE>
-struct ReluGPUFunctor : public BaseActivationFunctor<T> {
-  void operator()(const platform::CUDADeviceContext& context,
-                  const framework::Tensor& in, framework::Tensor* out,
-                  int num) {
-    const T* input_data = in.data<T>();
-    T* output_data = out->mutable_data<T>(context.GetPlace());
-    using VecType = typename GetVecType<T, VECSIZE>::type;
-    int block = 512;
-    if (num > VECSIZE) {
-      int grid = (num / VECSIZE + block - 1) / block;
-      reluKernelCudaVec<T, VecType, VECSIZE><<<grid, block>>>(input_data,
-                                                              output_data, num);
-    } else {
-      int grid1 = (num + block - 1) / block;
-      reluKernelCudaVec<T, T, 1><<<grid1, block>>>(input_data, output_data,
-                                                   num);
-    }
-  }
-};
-template <typename DeviceContext, typename Functor>
-class ReluBaseKernel
+template <typename DeviceContext, typename Functor, int VecSize>
+class ActivationGPUKernel
     : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
  public:
   using T = typename Functor::ELEMENT_TYPE;
@@ -181,39 +116,28 @@ class ReluBaseKernel
     const Tensor* in_x = context.Input<Tensor>("X");
     Tensor* out = context.Output<Tensor>("Out");
     auto& dev_ctx = context.template device_context<DeviceContext>();
+
     int num = in_x->numel();
-    Functor functor;
-    functor(dev_ctx, *in_x, out, num);
-  }
-};
+    const T* input_data = in_x->data<T>();
+    T* output_data = out->mutable_data<T>(dev_ctx.GetPlace(),
+                                          static_cast<size_t>(num * sizeof(T)));
 
-template <typename T, int VECSIZE>
-struct ReluGradGPUFunctor : public BaseActivationFunctor<T> {
-  void operator()(const platform::CUDADeviceContext& context,
-                  const framework::Tensor* out, const framework::Tensor* d_out,
-                  framework::Tensor* d_x) {
-    auto numel = d_out->numel();
-    auto* dout_data = d_out->data<T>();
-    auto* out_data = out->data<T>();
-    auto* dx_data = d_x->mutable_data<T>(
-        context.GetPlace(), static_cast<size_t>(numel * sizeof(T)));
-    using VecType = typename GetVecType<T, VECSIZE>::type;
     int block = 512;
-    if (numel > VECSIZE) {
-      int grid = (numel / VECSIZE + block - 1) / block;
-      reluGradKernelVec<T, VecType, VECSIZE><<<grid, block>>>(
-          out_data, dout_data, dx_data, numel);
-    } else {
-      int grid1 = (numel + block - 1) / block;
-      reluGradKernelVec<T, T, 1><<<grid1, block>>>(out_data, dout_data, dx_data,
-                                                   numel);
+    int grid = (num + block - 1) / block;
+    if (num > VecSize) {
+      // update grid for float16 and float32
+      grid = (num / VecSize + block - 1) / block;
     }
+
+    Functor functor;
+    using VecType = typename GetVecType<T, VecSize>::type;
+    reluKernelCudaVec<T, VecType, VecSize, Functor><<<grid, block>>>(
+        input_data, input_data, output_data, num, functor);
   }
-  // static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepOut; }
 };
 
-template <typename DeviceContext, typename Functor>
-class ReluGradKernel
+template <typename DeviceContext, typename Functor, int VecSize>
+class ActivationGradGPUKernel
     : public framework::OpKernel<typename Functor::ELEMENT_TYPE> {
  public:
   using T = typename Functor::ELEMENT_TYPE;
@@ -223,9 +147,25 @@ class ReluGradKernel
         ctx.Input<framework::Tensor>(framework::GradVarName("Out"));
     framework::Tensor* d_x =
         ctx.Output<framework::Tensor>(framework::GradVarName("X"));
-    Functor functor;
+
     auto& dev_ctx = ctx.template device_context<DeviceContext>();
-    functor(dev_ctx, out, d_out, d_x);
+    auto* out_data = out->data<T>();
+    auto numel = d_out->numel();
+    auto* dout_data = d_out->data<T>();
+    auto* dx_data = d_x->mutable_data<T>(
+        dev_ctx.GetPlace(), static_cast<size_t>(numel * sizeof(T)));
+
+    int block = 512;
+    int grid = (numel + block - 1) / block;
+    if (numel >= VecSize) {
+      // update grid for float16 and float32
+      grid = (numel / VecSize + block - 1) / block;
+    }
+
+    Functor functor;
+    using VecType = typename GetVecType<T, VecSize>::type;
+    reluKernelCudaVec<T, VecType, VecSize, Functor><<<grid, block>>>(
+        out_data, dout_data, dx_data, numel, functor);
   }
 };
 
@@ -234,7 +174,6 @@ class ReluGradKernel
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
-
 #define REGISTER_ACTIVATION_CUDA_KERNEL(act_type, op_name, functor,         \
                                         grad_functor)                       \
   REGISTER_OP_CUDA_KERNEL(                                                  \
@@ -281,20 +220,21 @@ REGISTER_OP_CUDA_KERNEL(
 
 /* ===========================    relu register  ============================ */
 REGISTER_OP_CUDA_KERNEL(
-    relu, ops::ReluBaseKernel<paddle::platform::CUDADeviceContext,
-                              ops::ReluGPUFunctor<float, 4>>,
-    ops::ReluBaseKernel<paddle::platform::CUDADeviceContext,
-                        ops::ReluGPUFunctor<double, 1>>,
-    ops::ReluBaseKernel<paddle::platform::CUDADeviceContext,
-                        ops::ReluGPUFunctor<plat::float16, 2>>);
+    relu, ops::ActivationGPUKernel<paddle::platform::CUDADeviceContext,
+                                   ops::ReluGPUFunctor<float>, 4>,
+    ops::ActivationGPUKernel<paddle::platform::CUDADeviceContext,
+                             ops::ReluGPUFunctor<double>, 1>,
+    ops::ActivationGPUKernel<plat::CUDADeviceContext,
+                             ops::ReluGPUFunctor<plat::float16>, 2>);
 
 REGISTER_OP_CUDA_KERNEL(
-    relu_grad, ops::ReluGradKernel<plat::CUDADeviceContext,
-                                   ops::ReluGradGPUFunctor<float, 4>>,
-    ops::ReluGradKernel<plat::CUDADeviceContext,
-                        ops::ReluGradGPUFunctor<double, 1>>,
-    ops::ReluGradKernel<plat::CUDADeviceContext,
-                        ops::ReluGradGPUFunctor<plat::float16, 2>>);
+    relu_grad, ops::ActivationGradGPUKernel<paddle::platform::CUDADeviceContext,
+                                            ops::ReluGPUFunctor<float>, 4>,
+    ops::ActivationGradGPUKernel<paddle::platform::CUDADeviceContext,
+                                 ops::ReluGPUFunctor<double>, 1>,
+    ops::ActivationGradGPUKernel<plat::CUDADeviceContext,
+                                 ops::ReluGPUFunctor<plat::float16>, 2>);
+
 REGISTER_OP_CUDA_KERNEL(
     relu_grad_grad,
     ops::ActivationDoubleGradKernel<paddle::platform::CUDADeviceContext,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
 Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
add relu forward kernel and backward kernel
:
forward:

dtype | test case | paddle优化前 | pytorch | paddle优化后 | diff | 性能提升 | （pytorch - paddle）/paddle
-- | -- | -- | -- | -- | -- | -- | --
float32 | [16,128,257,257] | 1.4057ms | 1.3111ms | 1.3116ms | diff:0.0 | 6.69% | -0.04%
float32 | [10,128,257,257] | 870.12us | 820.15us | 820.39us | diff:0.0 | 5.72% | -0.03%
float32 | [16,2,257,257] | 22.287us | 22.150us | 21.981us | diff:0.0 | 1.37% | 0.77%
float32 | [128,4,257,257] | 338.39us | 329.02us | 329.04us | diff:0.0 | 2.76% | -0.01%
float32 | [169,333,1,1] | 1.6760us | 1.6250us | 1.5720us | diff:0.0 | 6.21% | 3.35%
float32 | [1,160800,1,10] | 17.249us | 17.445us | 17.169us | diff:0.0 | 0.46% | 1.61%
float16 | [16,128,257,257] | 886.95us | 748.33us | 685.61us | diff:0.0 | 22.70% | 9.15%
float16 | [10,128,257,257] | 528.93us | 468.54us | 428.94us | diff:0.0 | 18.90% | 9.23%
float16 | [16,2,257,257] | 13.892us | 13.548us | 12.191us | diff:0.0 | 12.24% | 11.13%
float16 | [128,4,257,257] | 202.77us | 188.55us | 172.61us | diff:0.0 | 14.87% | 9.23%
float16 | [169,333,1,1] | 1.5700us | 1.6420us | 1.2870us | diff:0.0 | 18.03% | 27.58%
float16 | [1,160800,1,10] | 9.6960us | 10.581us | 9.2800us | diff:0.0 | 4.29% | 14.02%


backward:

case | paddle float32 | fp32 old | fp32 new | (old-new)/new | (pytorch - paddle_new)/paddle_new | pytorch float16 | fp16 old | paddle float16 | (old-new)/new | (pytorch - paddle_new)/paddle_new
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
[333,127,157,1] | 96.034us | 98.676us | 95.654us | 3.15% | -0.40% | 47.038us | 56.100us | 50.317us | 11.49% | -6.52%
[191,2048,127,1] | 701.80us | 738.34us | 701.9us | 5.19% | 0.01% | 315.62us | 410.48us | 361.79us | 13.46% | -12.76%
[16,128,157,157] | 713.08us | 751.29us | 712.96us | 5.38% | -0.02% | 320.31us | 418.49us | 368.1us | 13.69% | -12.98%
[13, 101, 15, 179] | 51.987us | 53.779us | 51.834us | 3.75% | -0.29% | 26.394us | 31.368us | 27.699us | 13.25% | -4.71%


