### PR TITLE
[NPU] fix allocator min chunk size

### DIFF
--- a/paddle/fluid/platform/npu_info.cc
+++ b/paddle/fluid/platform/npu_info.cc
@@ -163,8 +163,11 @@ size_t NPUInitAllocSize() { return NPUAllocSize(/* realloc = */ false); }
 size_t NPUReallocSize() { return NPUAllocSize(/* realloc = */ true); }
 
 size_t NPUMinChunkSize() {
-  // Allow to allocate the minimum chunk size is 256 bytes.
-  return 1 << 8;
+  // NOTE(zhiqiu): It seems the min chunk size should be 512 on NPU,
+  // though no document specify that explicitly.
+  // See https://gitee.com/zhiqiuchen/Ascend/tree/master/test_reduce_sum_d for
+  // details.
+  return 1 << 9;
 }
 
 size_t NPUMaxChunkSize() {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[NPU] fix allocator min chunk size, from 256 -> 512 bytes, required by Ascend NPU