### PR TITLE
【NPU】Add TensorCopy to NPU kernel for reduce_sum op 

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op_npu.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op_npu.cc
@@ -83,6 +83,11 @@ class ReduceSumGradNPUKernel : public framework::OpKernel<T> {
       Tensor out_grad_tmp(out_grad->type());
       out_grad_tmp.Resize(out_dims);
       out_grad_tmp.mutable_data<T>(ctx.GetPlace());
+      framework::TensorCopy(
+          *out_grad, ctx.GetPlace(),
+          ctx.template device_context<platform::DeviceContext>(),
+          &out_grad_tmp);
+      out_grad_tmp.Resize(out_dims);
 
       auto runner = NpuOpRunner("BroadcastToD", {out_grad_tmp}, {*x_grad},
                                 {{"shape", framework::vectorize(x->dims())}});

--- a/python/paddle/fluid/tests/unittests/npu/test_reduce_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_reduce_sum_op_npu.py
@@ -102,7 +102,9 @@ class TestReduceSumNet(unittest.TestCase):
             label = paddle.static.data(
                 name="label", shape=[2, 1], dtype='int64')
 
-            z = paddle.add(a, b)
+            a_1 = fluid.layers.fc(input=a, size=4, num_flatten_dims=2, act=None)
+            b_1 = fluid.layers.fc(input=b, size=4, num_flatten_dims=2, act=None)
+            z = paddle.add(a_1, b_1)
             z_1 = self.set_reduce_sum_function(z)
 
             prediction = fluid.layers.fc(input=z_1, size=2, act='softmax')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
PR #31620 为 `reduce_sum` op 添加了 NPU Kernel。

- 问题
NPU Kernel 实现中，求反向，创建临时Tensor时，未对该临时Tensor赋值。会导致reduce_sum op的反向计算错误，观察到错误的梯度全部为0。

- 反向计算错误时单测通过的原因
因为组网时，reduce_sum前面的网络中没有任何参数，即使reduce_sum导致梯度计算错误，也不会影响参数更新。
![图片](https://user-images.githubusercontent.com/26408901/111298639-eecd3700-8689-11eb-9111-01998a6e3158.png)


- 修复
这个PR修复了这个问题，使用TensorCopy，将grad_out的值赋值给创建的临时变量。
单测中，在reduce_sum操作前加入fc层，引入参数。

- 新的单测执行结果
<img width="539" alt="图片" src="https://user-images.githubusercontent.com/26408901/111303058-0e1a9300-868f-11eb-9c1c-4b80d795e448.png">


