### PR TITLE
improve performance of DepthwiseConv(NHWC)

### DIFF
--- a/paddle/fluid/operators/conv_op.h
+++ b/paddle/fluid/operators/conv_op.h
@@ -967,33 +967,18 @@ class DepthwiseConvGradKernel : public framework::OpKernel<T> {
         context.Attr<std::string>("padding_algorithm");
     const std::string data_format = context.Attr<std::string>("data_format");
 
-    const bool channel_last = (data_format == "NHWC" || data_format == "NDHWC");
-
-    // transform Tensor
-    Tensor transformed_input(input->type());
-    Tensor transformed_output_grad(output_grad->type());
-
-    if (channel_last) {
-      ResizeToChannelFirst<DeviceContext, T>(context, input,
-                                             &transformed_input);
-      TransToChannelFirst<DeviceContext, T>(context, input, &transformed_input);
-
-      ResizeToChannelFirst<DeviceContext, T>(context, output_grad,
-                                             &transformed_output_grad);
-      TransToChannelFirst<DeviceContext, T>(context, output_grad,
-                                            &transformed_output_grad);
-
-    } else {
-      transformed_input = *input;
-      transformed_output_grad = *output_grad;
-    }
-
     // update padding and dilation
-    auto in_dims = transformed_input.dims();
+    auto in_dims = input->dims();
     auto filter_dims = filter.dims();
 
     framework::DDim in_data_dims;
-    in_data_dims = framework::slice_ddim(in_dims, 2, in_dims.size());
+    const framework::DataLayout data_layout =
+        framework::StringToDataLayout(data_format);
+    if (data_layout != framework::DataLayout::kNHWC) {
+      in_data_dims = framework::slice_ddim(in_dims, 2, in_dims.size());
+    } else {
+      in_data_dims = framework::slice_ddim(in_dims, 1, in_dims.size() - 1);
+    }
     framework::DDim filter_data_dims =
         framework::slice_ddim(filter_dims, 2, filter_dims.size());
     std::vector<int> ksize = framework::vectorize<int>(filter_data_dims);
@@ -1011,33 +996,18 @@ class DepthwiseConvGradKernel : public framework::OpKernel<T> {
 
     if (input_grad) {
       input_grad->mutable_data<T>(context.GetPlace());
-      Tensor transformed_input_grad(input_grad->type());
-      if (channel_last) {
-        ResizeToChannelFirst<DeviceContext, T>(context, input_grad,
-                                               &transformed_input_grad);
-
-      } else {
-        transformed_input_grad = *input_grad;
-      }
-
-      set_zero(dev_ctx, &transformed_input_grad, static_cast<T>(0));
+      set_zero(dev_ctx, input_grad, static_cast<T>(0));
 
       if (fuse_relu) {
         math::DepthwiseConvInputGradFunctor<DeviceContext, T, true>
             depthwiseConvInputGrad;
-        depthwiseConvInputGrad(dev_ctx, transformed_input, filter,
-                               transformed_output_grad, strides, paddings,
-                               dilations, &transformed_input_grad);
+        depthwiseConvInputGrad(dev_ctx, *input, filter, *output_grad, strides,
+                               paddings, dilations, input_grad, data_layout);
       } else {
         math::DepthwiseConvInputGradFunctor<DeviceContext, T, false>
             depthwiseConvInputGrad;
-        depthwiseConvInputGrad(dev_ctx, transformed_input, filter,
-                               transformed_output_grad, strides, paddings,
-                               dilations, &transformed_input_grad);
-      }
-      if (channel_last) {
-        TransToChannelLast<DeviceContext, T>(context, &transformed_input_grad,
-                                             input_grad);
+        depthwiseConvInputGrad(dev_ctx, *input, filter, *output_grad, strides,
+                               paddings, dilations, input_grad, data_layout);
       }
     }
 
@@ -1047,15 +1017,13 @@ class DepthwiseConvGradKernel : public framework::OpKernel<T> {
       if (fuse_relu) {
         math::DepthwiseConvFilterGradFunctor<DeviceContext, T, true>
             depthwiseConvFilterGrad;
-        depthwiseConvFilterGrad(dev_ctx, transformed_input,
-                                transformed_output_grad, strides, paddings,
-                                dilations, filter_grad);
+        depthwiseConvFilterGrad(dev_ctx, *input, *output_grad, strides,
+                                paddings, dilations, filter_grad, data_layout);
       } else {
         math::DepthwiseConvFilterGradFunctor<DeviceContext, T, false>
             depthwiseConvFilterGrad;
-        depthwiseConvFilterGrad(dev_ctx, transformed_input,
-                                transformed_output_grad, strides, paddings,
-                                dilations, filter_grad);
+        depthwiseConvFilterGrad(dev_ctx, *input, *output_grad, strides,
+                                paddings, dilations, filter_grad, data_layout);
       }
     }
   }

--- a/paddle/fluid/operators/math/depthwise_conv.cu
+++ b/paddle/fluid/operators/math/depthwise_conv.cu
@@ -675,17 +675,17 @@ __device__ __inline__ void KernelDepthwiseConvFilterGradNHWC(
     const int padding_height, const int padding_width, const int dilate_height,
     const int dilate_width, T* filter_grad_data,
     const DataLayout data_layout = DataLayout::kNCHW) {
-  int image_h = blockIdx.x;
-
+  int image_h = blockIdx.y;
   for (int kernel_id = threadIdx.x; kernel_id < output_channels;
        kernel_id += blockDim.x) {
     T s = 0;
-    int gbid = ((kernel_id * gridDim.z) + blockIdx.z) * gridDim.y + blockIdx.y;
+    int gbid =
+        ((kernel_id * filter_height) + blockIdx.z) * filter_width + blockIdx.x;
     for (int bid = 0; bid < num; bid++) {
       for (int image_w = threadIdx.y; image_w < output_width;
            image_w += blockDim.y) {
         int kernel_h = blockIdx.z * dilate_height - padding_height;
-        int kernel_w = blockIdx.y * dilate_width - padding_width;
+        int kernel_w = blockIdx.x * dilate_width - padding_width;
 
         int image_hk = image_h * stride_height + kernel_h;
         int image_wk = image_w * stride_width + kernel_w;
@@ -959,13 +959,13 @@ class DepthwiseConvInputGradFunctor<platform::CUDADeviceContext, T,
       threads = dim3(std::min(input_width, thread), blocks, 1);
       grid = dim3(input_channels, batch_size, 1);
     } else {
-      if (output_channels > 1024 && output_channels <= 2048) {
-        thread = (output_channels - 1) / 2 + 1;
-      } else if (output_channels > 512 && output_channels <= 1024) {
-        thread = output_channels;
+      if (input_channels > 1024 && input_channels <= 2048) {
+        thread = (input_channels - 1) / 2 + 1;
+      } else if (input_channels > 512 && input_channels <= 1024) {
+        thread = input_channels;
       }
-      blocks = std::min(std::max(thread / output_channels, 1), output_width);
-      threads = dim3(std::min(output_channels, thread), blocks, 1);
+      blocks = std::min(std::max(thread / input_channels, 1), input_width);
+      threads = dim3(std::min(input_channels, thread), blocks, 1);
       grid = dim3((input_height + dilate_height - 1) / dilate_height,
                   dilate_height, batch_size);
     }
@@ -1069,7 +1069,7 @@ class DepthwiseConvFilterGradFunctor<platform::CUDADeviceContext, T,
       }
       blocks =
           std::min(std::max(block_size / output_channels, 1), output_width);
-      grid = dim3(output_height, ksize_width, ksize_height);
+      grid = dim3(ksize_width, output_height, ksize_height);
       threads = dim3(std::min(output_channels, block_size), blocks, 1);
     }
     int filter_multiplier = output_channels / input_channels;

--- a/paddle/fluid/operators/math/depthwise_conv.cu
+++ b/paddle/fluid/operators/math/depthwise_conv.cu
@@ -142,7 +142,7 @@ __device__ __inline__ void KernelDepthwiseConvNHWC(
     for (int w_in = w_in_start; w_in < w_in_end; w_in += dilate_width) {
       if (h_in >= h_start && h_in < h_end && w_in >= w_start && w_in < w_end) {
         int offset = ((batch * input_height + h_in) * input_width + w_in) *
-                         output_channels +
+                         input_channels +
                      c_in;
         T in_data = input_data[offset];
         const T* weight = filter_data + weight_offset * output_channels + c_out;
@@ -648,12 +648,12 @@ class DepthwiseConvFunctor<platform::CUDADeviceContext, T,
     T* output_data = output->mutable_data<T>(context.GetPlace());
 
     if (data_layout == DataLayout::kNHWC) {
-      framework::DDim filter_nhwc_dims({filter.dims()[0], filter.dims()[2],
-                                        filter.dims()[3], filter.dims()[1]});
+      framework::DDim filter_nhwc_dims({filter.dims()[2], filter.dims()[3],
+                                        filter.dims()[0], filter.dims()[1]});
       framework::Tensor filter_nhwc;
       filter_nhwc.Resize(filter_nhwc_dims);
       filter_nhwc.mutable_data<T>(context.GetPlace());
-      std::vector<int> perm_axis({0, 2, 3, 1});
+      std::vector<int> perm_axis({2, 3, 0, 1});
       math::TransposeNormal<platform::CUDADeviceContext, T> trans;
       trans(context, filter, &filter_nhwc, perm_axis);
       filter_data = filter_nhwc.data<T>();

--- a/paddle/fluid/operators/math/depthwise_conv.cu
+++ b/paddle/fluid/operators/math/depthwise_conv.cu
@@ -904,6 +904,9 @@ class DepthwiseConvFunctor<platform::CUDADeviceContext, T,
       threads = dim3(std::min(output_width, thread), blocks, 1);
       grid = dim3(output_channels, batch_size, 1);
     } else {
+#ifdef __HIPCC__
+      thread = std::min(thread, 256);
+#endif
       blocks = std::min(
           std::max(thread / output_channels, 1),
           ((output_width + dilate_width - 1) / dilate_width) * dilate_width);
@@ -930,7 +933,7 @@ class DepthwiseConvFunctor<platform::CUDADeviceContext, T,
            c_filter == -1)) {                                                  \
     if (c_filter == -1) {                                                      \
       threads.x = block_size;                                                  \
-      grid.x = (nums_output + block_size - 1) / block_size;                    \
+      grid.x = grid_size;                                                      \
       threads.y = threads.z = grid.y = grid.z = 1;                             \
     }                                                                          \
     if (data_layout != DataLayout::kNHWC) {                                    \

--- a/paddle/fluid/operators/math/depthwise_conv.cu
+++ b/paddle/fluid/operators/math/depthwise_conv.cu
@@ -536,9 +536,9 @@ __device__ __inline__ void KernelDepthwiseConvInputGradCFilterNHWC(
              h_out += dilate_height, h_f++) {
           for (int w_out = w_out_start, w_f = 0; w_f < c_filter;
                w_out += dilate_width, w_f++) {
-            int s_h_out = h_out / filter_height;
-            int s_w_out = w_out / filter_width;
-            if (h_out % filter_height == 0 && w_out % filter_width == 0 &&
+            int s_h_out = h_out / stride_height;
+            int s_w_out = w_out / stride_width;
+            if (h_out % stride_height == 0 && w_out % stride_width == 0 &&
                 s_h_out >= 0 && s_h_out < output_height && s_w_out >= 0 &&
                 s_w_out < output_width) {
               int output_grad_offset =

--- a/python/paddle/nn/functional/conv.py
+++ b/python/paddle/nn/functional/conv.py
@@ -112,10 +112,6 @@ def _conv_nd(x,
 
     # Due to the poor performance of NHWC, we transpose the input to NCHW.
     origin_format = data_format
-    if origin_format == "NHWC" and op_type == "depthwise_conv2d":
-        x = nn.transpose(x, perm=[0, 3, 1, 2])
-        data_format = "NCHW"
-        channel_dim = 1
     if in_dygraph_mode():
         attrs = ('strides', stride, 'paddings', padding, 'dilations', dilation,
                  'groups', groups, 'use_cudnn', use_cudnn, 'use_mkldnn',
@@ -159,10 +155,6 @@ def _conv_nd(x,
                        'use_mkldnn': use_mkldnn})
         else:
             out = pre_bias
-
-    if origin_format == "NHWC" and op_type == "depthwise_conv2d":
-        out = nn.transpose(out, perm=[0, 2, 3, 1])
-
     return out
 
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] --> Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] --> OPs

### Describe
<!-- Describe what this PR does --> improve performance of DepthwiseConv(NHWC)

### Forward of DepthwiseConv(NHWC)
```python
import paddle
import paddle.nn as nn

x_var = paddle.uniform((8, 64, 64, 1024), dtype='float32', min=-1., max=1.)
conv = nn.Conv2D(1024, 1024, (3, 3), stride=1, padding=1, dilation=1, groups=1024, data_format='NHWC')
y_var = conv(x_var)
```

- Before:  Input transpose + NCHW kernel + Output transpose
- This PR:  Filter transpose + NHWC kernel

> Tested with `GeForce GTX Titan X`

| id   | input_shape(NHWC)  | filter_size(CHW) | stride | padding | dilation | groups | before  | this PR | improve |
| ---- | ------------------ | ---------------- | ------ | ------- | -------- | ------ | ------- | ------- | ------- |
| 0    | (8, 64, 64, 1024)  | (1024, 3, 3)     | 1      | 1       | 1        | 1024   | 4.52ms  | 2.00ms  | +55.75% |
| 1    | (8, 64, 64, 2048)  | (2048, 3, 3)     | 1      | 1       | 1        | 2048   | 9.21ms  | 4.09ms  | +55.59% |
| 2    | (8, 64, 64, 1024)  | (2048, 3, 3)     | 1      | 1       | 1        | 1024   | 9.41ms  | 3.65ms  | +61.21% |
| 3    | (8, 64, 64, 1024)  | (1024, 3, 3)     | 2      | 1       | 1        | 1024   | 2.72ms  | 0.86ms  | +68.38% |
| 4    | (8, 64, 64, 1024)  | (1024, 5, 5)     | 1      | 1       | 1        | 1024   | 14.47ms | 7.24ms  | +49.97% |
| 5    | (8, 256, 256, 64)  | (64, 3, 3)       | 1      | 1       | 1        | 64     | 4.51ms  | 2.09ms  | +53.66% |
| 6    | (8, 64, 128, 2048) | (2048, 3, 3)     | 1      | 12      | 12       | 2048   | 17.44ms | 10.65ms | +38.93% |
| 7    | (8, 64, 128, 2048) | (2048, 3, 3)     | 1      | 24      | 24       | 2048   | 17.02ms | 9.27ms  | +45.53% |
| 8    | (8, 64, 128, 2048) | (2048, 3, 3)     | 1      | 36      | 36       | 2048   | 15.91ms | 7.05ms  | +55.69% |


### Backward of DepthwiseConv(NHWC)
```python
import paddle
import paddle.nn as nn

x_var = paddle.uniform((8, 64, 64, 1024), dtype='float32', min=-1., max=1.)
x_var.stop_gradient = False
conv = nn.Conv2D(1024, 1024, (3, 3), stride=1, padding=1, dilation=1, groups=1024, data_format='NHWC')
y_var = conv(x_var)
paddle.grad(y_var, x_var)
```

- Before:  Input transpose + NCHW kernel + Output transpose
- This PR:  Filter transpose + NHWC kernel

> Tested with `GeForce GTX Titan X`

| id | input_shape(NHWC)  | filter_size(CHW) | stride | padding | dilation | groups | before | this PR | improve |
| ---------------- | ------- | -------- | ------ | -------- | -------- | -------- | -------- | -------- | -------- |
| 0 | (8, 64, 64, 1024) | (1024, 3, 3) | 1    | 1      | 1      | 1024  | 9.11ms | 6.03ms | +33.81% |
| 1 | (8, 64, 64, 2048) | (2048, 3, 3)     | 1    | 1      | 1      | 2048  | 18.48ms | 11.90ms | +35.61% |
| 2 | (8, 64, 64, 1024) | (2048, 3, 3)     | 1    | 1      | 1      | 1024 | 29.35ms | 14.29ms | +51.31% |
| 3 | (8, 64, 64, 1024) | (1024, 3, 3) | 2   | 1      | 1      | 1024  | 5.74ms | 3.33ms | +41.99% |
| 4 | (8, 64, 64, 1024) | (1024, 5, 5) | 1 | 1 | 1 | 1024 | 21.47ms | 18.20ms | +15.23% |
| 5 | (8, 256, 256, 64) | (64, 3, 3) | 1 | 1 | 1 | 64 | 8.81ms | 6.33ms | +28.15% |
| 6 | (8, 64, 128, 2048) | (2048, 3, 3) | 1 | 12 | 12 | 2048 | 34.35ms | 21.86ms | +36.36% |
| 7 | (8, 64, 128, 2048) | (2048, 3, 3) | 1 | 24 | 24 | 2048 | 33.46ms | 19.09ms | +42.95% |
| 8 | (8, 64, 128, 2048) | (2048, 3, 3) | 1 | 36 | 36 | 2048 | 31.62ms | 17.00ms | +46.24% |

