### PR TITLE
GlobalNormClip use inplace mul

### DIFF
--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
@@ -48,7 +48,8 @@ class GradientClipHelper(object):
             if deperate_op:
                 deperate_op_idx.add(idx)
                 for output_name in op.desc.output_arg_names():
-                    deperated_vars.add(output_name)
+                    if output_name not in op.desc.input_arg_names():
+                        deperated_vars.add(output_name)
 
         if not deperated_vars:
             # got no gradient_clip op
@@ -92,7 +93,6 @@ class GradientClipHelper(object):
                     attrs={OP_ROLE_KEY: OpRole.Optimize})
 
         for var_name in deperated_vars:
-            if block.has_var(var_name):
-                block._remove_var(var_name, sync=False)
+            block._remove_var(var_name, sync=False)
         block._sync_with_cpp()
         return

--- a/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
+++ b/python/paddle/distributed/fleet/meta_optimizers/sharding/gradient_clip_helper.py
@@ -92,6 +92,7 @@ class GradientClipHelper(object):
                     attrs={OP_ROLE_KEY: OpRole.Optimize})
 
         for var_name in deperated_vars:
-            block._remove_var(var_name, sync=False)
+            if block.has_var(var_name):
+                block._remove_var(var_name, sync=False)
         block._sync_with_cpp()
         return

--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -489,9 +489,14 @@ class ClipGradByGlobalNorm(ClipGradBase):
                     continue
 
                 with p.block.program._optimized_guard([p, g]):
-                    new_grad = layers.elementwise_mul(x=g, y=scale_var)
-                param_new_grad_name_dict[p.name] = new_grad.name
-                params_and_grads.append((p, new_grad))
+                    p.block.append_op(
+                        type='elementwise_mul',
+                        inputs={'X': g,
+                                'Y': scale_var},
+                        outputs={'Out': g})
+
+                param_new_grad_name_dict[p.name] = p.name
+                params_and_grads.append((p, p))
 
         _correct_clip_op_role_var(params_and_grads, param_new_grad_name_dict)
         return params_and_grads

--- a/python/paddle/fluid/clip.py
+++ b/python/paddle/fluid/clip.py
@@ -495,8 +495,8 @@ class ClipGradByGlobalNorm(ClipGradBase):
                                 'Y': scale_var},
                         outputs={'Out': g})
 
-                param_new_grad_name_dict[p.name] = p.name
-                params_and_grads.append((p, p))
+                param_new_grad_name_dict[p.name] = g.name
+                params_and_grads.append((p, g))
 
         _correct_clip_op_role_var(params_and_grads, param_new_grad_name_dict)
         return params_and_grads


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Save video memory when using Executor to training.
**Ernie Test**
| develop | this PR|
| -- | -- |
| 6196MB | 5138MB |

save 1058MB