### PR TITLE
[NPU] Support test grad of NPU ops in OpTest

### DIFF
--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_add_op_npu.py
@@ -64,28 +64,28 @@ class TestElementwiseAddOp(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False)
 
-    # TODO(ascendrc): Test grad op after it is implemented.
-    # def test_check_grad_normal(self):
-    #     self.check_grad_with_place(
-    #         self.place, ['X', 'Y'],
-    #         'Out',
-    #         max_relative_error=0.006,
-    #         check_dygraph=False)
-    #
-    # def test_check_grad_ingore_x(self):
-    #     self.check_grad_with_place(
-    #         self.place, ['Y'],
-    #         'Out',
-    #         no_grad_set=set("X"),
-    #         max_relative_error=0.006,
-    #         check_dygraph=False)
-    #
-    # def test_check_grad_ingore_y(self):
-    #     self.check_grad_with_place(
-    #         self.place, ['X'],
-    #         'Out',
-    #         no_grad_set=set("Y"),
-    #         max_relative_error=0.006,check_dygraph=False)
+    def test_check_grad_normal(self):
+        self.check_grad_with_place(
+            self.place, ['X', 'Y'],
+            'Out',
+            max_relative_error=0.006,
+            check_dygraph=False)
+
+    def test_check_grad_ingore_x(self):
+        self.check_grad_with_place(
+            self.place, ['Y'],
+            'Out',
+            no_grad_set=set("X"),
+            max_relative_error=0.006,
+            check_dygraph=False)
+
+    def test_check_grad_ingore_y(self):
+        self.check_grad_with_place(
+            self.place, ['X'],
+            'Out',
+            no_grad_set=set("Y"),
+            max_relative_error=0.006,
+            check_dygraph=False)
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
@@ -132,10 +132,6 @@ class TestAddAPI(unittest.TestCase):
                 (z_value == z_expected).all(),
                 True,
                 msg="z_value = {}, but expected {}".format(z_value, z_expected))
-
-    def test_backward(self):
-        # TODO(ascendrc): Test backward after add grad npu op implemented.
-        pass
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),

--- a/python/paddle/fluid/tests/unittests/npu/test_pow_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_pow_op_npu.py
@@ -52,12 +52,9 @@ class TestPow(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False)
 
-    # TODO(ascendrc): Add grad test
-    # def test_check_grad(self):
-    #     if self.dtype == np.float16:
-    #         return
-    #     self.check_grad(['X'], 'Out')
-    #
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            self.place, ['X'], 'Out', check_dygraph=False)
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),

--- a/python/paddle/fluid/tests/unittests/npu/test_slice_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_slice_op_npu.py
@@ -62,6 +62,10 @@ class TestSliceOp(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False)
 
+    def test_check_grad_normal(self):
+        self.check_grad_with_place(
+            self.place, ['Input'], 'Out', check_dygraph=False)
+
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
                  "core is not compiled with NPU")

--- a/python/paddle/fluid/tests/unittests/op_test.py
+++ b/python/paddle/fluid/tests/unittests/op_test.py
@@ -1416,9 +1416,17 @@ class OpTest(unittest.TestCase):
         if not type(output_names) is list:
             output_names = [output_names]
 
+        # FIXME: Replace numeric_place with place to calculate numeric_grads.
+        # NOTE(liym27): There is an unknown error when call op.run() on NPUPlace, which
+        # needs to be fixed.
+        if self.__class__.use_npu == True:
+            numeric_place = paddle.CPUPlace()
+        else:
+            numeric_place = place
+
         numeric_grads = user_defined_grads or [
             get_numeric_gradient(
-                place,
+                numeric_place,
                 self.scope,
                 self.op,
                 self.inputs,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

1. 支持单测中 测试 npu grad op. 
注意：这是一个暂时的方案，当前未解决 op.run() 在 npu 上调用出现 段错误的问题。
2. 在3个 npu op 上成功验证.

---

npu op grad kernel 调用截图：
- elementwise_add_grad
![image](https://user-images.githubusercontent.com/33742067/111475244-da5f6c00-8767-11eb-9629-1a04e5e1bc5a.png)

- pow_grad
![image](https://user-images.githubusercontent.com/33742067/111475314-e9461e80-8767-11eb-9fe7-90fb2fcdc326.png)

- slice_grad
![image](https://user-images.githubusercontent.com/33742067/111475359-f3681d00-8767-11eb-93be-37e734af0c5f.png)

