### PR TITLE
add deprecated for softmax_with_cross_entropy

### DIFF
--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -1162,8 +1162,7 @@ def softmax_with_cross_entropy(logits,
                                ignore_index=kIgnoreIndex,
                                numeric_stable_mode=True,
                                return_softmax=False,
-                               axis=-1,
-                               softmax_switch=True):
+                               axis=-1):
     r"""
 
     This operator implements the cross entropy loss function with softmax. This function 
@@ -1262,7 +1261,7 @@ def softmax_with_cross_entropy(logits,
         softmax, loss = core.ops.softmax_with_cross_entropy(
             logits, label, 'soft_label', soft_label, 'ignore_index',
             ignore_index, 'numeric_stable_mode', numeric_stable_mode, 'axis',
-            axis, 'softmax_switch', softmax_switch)
+            axis)
         if not return_softmax:
             return loss
         else:
@@ -1272,8 +1271,7 @@ def softmax_with_cross_entropy(logits,
         'soft_label': soft_label,
         'ignore_index': ignore_index,
         'numeric_stable_mode': numeric_stable_mode,
-        'axis': axis,
-        'softmax_switch': softmax_switch
+        'axis': axis
     }
     helper = LayerHelper('softmax_with_cross_entropy', **locals())
     softmax = helper.create_variable_for_type_inference(dtype=logits.dtype)

--- a/python/paddle/fluid/layers/loss.py
+++ b/python/paddle/fluid/layers/loss.py
@@ -1162,7 +1162,8 @@ def softmax_with_cross_entropy(logits,
                                ignore_index=kIgnoreIndex,
                                numeric_stable_mode=True,
                                return_softmax=False,
-                               axis=-1):
+                               axis=-1,
+                               softmax_switch=True):
     r"""
 
     This operator implements the cross entropy loss function with softmax. This function 
@@ -1261,7 +1262,7 @@ def softmax_with_cross_entropy(logits,
         softmax, loss = core.ops.softmax_with_cross_entropy(
             logits, label, 'soft_label', soft_label, 'ignore_index',
             ignore_index, 'numeric_stable_mode', numeric_stable_mode, 'axis',
-            axis)
+            axis, 'softmax_switch', softmax_switch)
         if not return_softmax:
             return loss
         else:
@@ -1271,7 +1272,8 @@ def softmax_with_cross_entropy(logits,
         'soft_label': soft_label,
         'ignore_index': ignore_index,
         'numeric_stable_mode': numeric_stable_mode,
-        'axis': axis
+        'axis': axis,
+        'softmax_switch': softmax_switch
     }
     helper = LayerHelper('softmax_with_cross_entropy', **locals())
     softmax = helper.create_variable_for_type_inference(dtype=logits.dtype)

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
@@ -18,6 +18,8 @@ import paddle
 import paddle.fluid as fluid
 import numpy as np
 import unittest
+from test_softmax_op import stable_softmax
+from test_softmax_with_cross_entropy_op import cross_entropy
 
 
 def stable_softmax(x):
@@ -30,7 +32,6 @@ def log_softmax(x, axis=-1):
     softmax_out = np.apply_along_axis(stable_softmax, axis, x)
     return np.log(softmax_out)
 
-
 def cross_entropy_loss_1d(input,
                           label,
                           weight=None,
@@ -42,6 +43,8 @@ def cross_entropy_loss_1d(input,
     C = input_shape[1]
     out = np.zeros_like(label).astype(np.float64)
     total_weight = 0
+    ###1. compute softmax cross_entropy (with weight)
+    ###   Note: only support hard labels.
     for i in range(N):
         cur_target = label[i]
         if cur_target == ignore_index:
@@ -50,6 +53,8 @@ def cross_entropy_loss_1d(input,
         cur_weight = weight[cur_target] if weight is not None else 1
         total_weight += cur_weight
         out[i] = -log_softmax_out[i][cur_target] * cur_weight
+
+    ###2. deal with reduction 
     if reduction == 'sum':
         return np.sum(out), np.array([total_weight]).astype('float64')
     elif reduction == 'mean':
@@ -91,8 +96,574 @@ def cross_entropy_loss_2d(input,
     elif reduction == 'none':
         return out
 
+def cross_entropy_soft(softmax, 
+                       label, 
+                       axis, 
+                       N,
+                       weight=None,
+                       reduction='mean',
+                       ignore_index=-100
+                      ):
+        #1.loss
+        loss = cross_entropy(softmax, 
+                             label, 
+                             True, #soft_label,
+                             axis,
+                             ignore_index)
+
+        if weight is None and reduction=='none':
+            return loss
+
+        #2.weight
+        weighted_loss = loss
+        total_weight = N  #for weight is None
+        if weight is not None:
+            weighted_loss = np.zeros_like(loss).astype(np.float64)
+            total_weight = 0
+            for i in range(N):
+                cur_soft_label = label[i]
+                cur_weight = np.dot(weight, cur_soft_label)
+                total_weight += cur_weight
+                weighted_loss[i] = loss[i] * cur_weight
+      
+        #3.reduce
+        if reduction=='none':
+            return weighted_loss
+       
+        elif reduction=='mean':
+            weighted_loss_sum = np.sum(weighted_loss)
+            weighted_loss_mean = weighted_loss_sum / total_weight
+            return weighted_loss_mean
+
+        else:
+            weighted_loss_sum = np.sum(weighted_loss)
+            return weighted_loss_sum
+
+def cross_entropy_soft_2d(softmax, 
+                       label, 
+                       axis, 
+                       N,
+                       H,
+                       W,
+                       weight=None,
+                       reduction='mean',
+                       ignore_index=-100
+                      ):
+        #1.loss
+        loss = cross_entropy(softmax, 
+                             label, 
+                             True, #soft_label,
+                             axis,
+                             ignore_index)
+
+        if weight is None and reduction=='none':
+            return loss
+
+        #2.weight
+        weighted_loss = loss
+        total_weight = N  #for weight is None
+        if weight is not None:
+            weighted_loss = np.zeros_like(loss).astype(np.float64)
+            total_weight = 0
+            for i in range(N):
+                for h in range(H):
+                    for w in range(W):
+                        cur_soft_label = label[i][h][w]
+                        cur_weight = np.dot(weight, cur_soft_label)
+                        total_weight += cur_weight
+                        weighted_loss[i][h][w] = loss[i][h][w] * cur_weight
+      
+        #3.reduce
+        if reduction=='none':
+            return weighted_loss
+       
+        elif reduction=='mean':
+            weighted_loss_sum = np.sum(weighted_loss)
+            weighted_loss_mean = weighted_loss_sum / total_weight
+            return weighted_loss_mean
+
+        else:
+            weighted_loss_sum = np.sum(weighted_loss)
+            return weighted_loss_sum
+
 
 class CrossEntropyLoss(unittest.TestCase):
+
+    ###chajchaj soft_label start
+
+    ###chajchaj soft_label 1
+    def test_cross_entropy_loss_soft_1d(self):
+        self.numeric_stable_mode = False
+        self.soft_label = True
+        self.dtype = np.float64
+        self.axis = -1
+        self.ignore_index = -100 #should not be changed
+        self.N = 4
+        self.C = 3
+        self.shape = [self.N, self.C]
+        self.softmax_switch = True
+        self.reduction = 'none'
+        self.weight = None
+        self.logits = getattr(
+            self, "logits",
+            np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
+        softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
+
+        self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+        self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
+
+        expected = cross_entropy_soft(
+                                     softmax, 
+                                     self.labels,
+                                     self.axis, 
+                                     self.N,
+                                     weight=self.weight,
+                                     reduction=self.reduction,
+                                     ignore_index=self.ignore_index
+                                     )
+
+        paddle.set_device("cpu")
+
+        #2. dong 
+        paddle.disable_static()
+        paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
+                                                             fluid.dygraph.to_variable(self.logits),  
+                                                             fluid.dygraph.to_variable(self.labels), 
+                                                             soft_label=True, 
+                                                             axis=self.axis, 
+                                                             weight=fluid.dygraph.to_variable(self.weight) if self.weight is not None else None,
+                                                             reduction=self.reduction)
+        dy_ret_value = paddle_loss_none_weight.numpy()
+
+        #3. jing
+        paddle.enable_static()
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.program_guard(prog, startup_prog):
+            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
+            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+ 
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                                                                reduction=self.reduction,
+                                                                soft_label=True
+                                                                )
+            ret = cross_entropy_loss(input, label)
+
+            exe = fluid.Executor(place)
+            static_ret = exe.run(prog,
+                                 feed={
+                                     'input': self.logits, 
+                                     'label': self.labels, 
+                                 },
+                                 fetch_list=[ret])
+            self.assertIsNotNone(static_ret)
+        paddle.disable_static()
+
+        self.assertTrue(np.allclose(static_ret, expected))
+        self.assertTrue(np.allclose(dy_ret_value, expected))
+
+
+    ###chajchaj soft_label 2
+    def test_cross_entropy_loss_soft_1d_weight(self):
+        self.numeric_stable_mode = False
+        self.soft_label = True
+        self.dtype = np.float64
+        self.axis = -1
+        self.ignore_index = -100 #should not be changed
+        self.N = 4
+        self.C = 3
+        self.shape = [self.N, self.C]
+        self.softmax_switch = True
+        self.reduction = 'none'
+        self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
+        self.logits = getattr(
+            self, "logits",
+            np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
+        softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
+
+        if self.soft_label:
+            self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+            self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
+        else:
+            axis_dim = self.shape[self.axis]
+            self.shape[self.axis] = 1
+            self.labels = np.random.randint(0, axis_dim, self.shape, dtype="int64")
+
+        #1. numpy
+        expected = cross_entropy_soft(
+                                     softmax, 
+                                     self.labels,
+                                     self.axis, 
+                                     self.N,
+                                     weight=self.weight,
+                                     reduction=self.reduction,
+                                     ignore_index=self.ignore_index
+                                     )
+
+        paddle.set_device("cpu")
+
+        #2. dong
+        paddle.disable_static()
+        paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
+                                                             fluid.dygraph.to_variable(self.logits),  
+                                                             fluid.dygraph.to_variable(self.labels), 
+                                                             soft_label=True, 
+                                                             axis=self.axis, 
+                                                             weight=fluid.dygraph.to_variable(self.weight),
+                                                             reduction=self.reduction)
+        dy_ret_value = paddle_loss_none_weight.numpy()
+
+        # 3.jing
+        paddle.enable_static()
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.program_guard(prog, startup_prog):
+            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
+            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+            weight = fluid.data(name='weight', shape=[self.C], dtype='float64')
+ 
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                                                                weight=weight, 
+                                                                reduction=self.reduction,
+                                                                soft_label=True
+                                                                )
+            ret = cross_entropy_loss(input, label)
+
+            exe = fluid.Executor(place)
+            static_ret = exe.run(prog,
+                                 feed={
+                                     'input': self.logits, 
+                                     'label': self.labels, 
+                                     "weight": self.weight 
+                                 },
+                                 fetch_list=[ret])
+            self.assertIsNotNone(static_ret)
+        paddle.disable_static()
+
+        self.assertTrue(np.allclose(static_ret, expected))
+        self.assertTrue(np.allclose(dy_ret_value, expected))
+
+
+    ###chajchaj soft_label 3
+    def test_cross_entropy_loss_soft_1d_mean(self):
+        self.numeric_stable_mode = False
+        self.soft_label = True
+        self.dtype = np.float64
+        self.axis = -1
+        self.ignore_index = -1
+        self.ignore_index = -100 #should not be changed
+        self.N = 4
+        self.C = 3
+        self.shape = [self.N, self.C]
+        self.softmax_switch = True
+        self.reduction='mean'
+        self.weight = None
+        self.logits = getattr(
+            self, "logits",
+            np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
+        softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
+
+        self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+        self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
+
+        #1. numpy
+        expected = cross_entropy_soft(
+                                     softmax, 
+                                     self.labels,
+                                     self.axis, 
+                                     self.N,
+                                     weight=self.weight,
+                                     reduction=self.reduction,
+                                     ignore_index=self.ignore_index
+                                     )
+
+        paddle.set_device("cpu")
+
+        #2 dong 
+        paddle.disable_static()
+        paddle_loss_mean = paddle.nn.functional.cross_entropy(
+                                                             fluid.dygraph.to_variable(self.logits),  
+                                                             fluid.dygraph.to_variable(self.labels), 
+                                                             soft_label=True, 
+                                                             axis=self.axis,
+                                                             weight=self.weight,
+                                                             reduction=self.reduction)
+        dy_ret_value = paddle_loss_mean.numpy()
+
+        #3. jing
+        paddle.enable_static()
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.program_guard(prog, startup_prog):
+            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
+            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                reduction=self.reduction,
+                soft_label=True)
+            ret = cross_entropy_loss(input, label)
+
+            exe = fluid.Executor(place)
+            static_ret = exe.run(prog,
+                                 feed={
+                                     'input': self.logits,
+                                     'label': self.labels 
+                                 },
+                                 fetch_list=[ret])
+            self.assertIsNotNone(static_ret)
+        paddle.disable_static()
+
+        self.assertTrue(np.allclose(static_ret, expected))
+        self.assertTrue(np.allclose(dy_ret_value, expected))
+
+
+    ###chajchaj soft_label 4
+    def test_cross_entropy_loss_soft_1d_weight_mean(self):
+        self.numeric_stable_mode = False
+        self.soft_label = True
+        self.dtype = np.float64
+        self.axis = -1
+        self.ignore_index = -100 #should not be changed
+        self.N = 4
+        self.C = 3
+        self.shape = [self.N, self.C]
+        self.softmax_switch = True
+        self.reduction = 'mean'
+        self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
+        self.logits = getattr(
+            self, "logits",
+            np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
+        softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
+
+        self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+        self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
+
+        #1. numpy
+        expected = cross_entropy_soft(
+                                     softmax, 
+                                     self.labels,
+                                     self.axis, 
+                                     self.N,
+                                     weight=self.weight,
+                                     reduction=self.reduction,
+                                     ignore_index=self.ignore_index
+                                     )
+
+        paddle.set_device("cpu")
+        paddle.disable_static()
+
+        #2. dong
+        paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
+                                                             fluid.dygraph.to_variable(self.logits),  
+                                                             fluid.dygraph.to_variable(self.labels), 
+                                                             soft_label=True, 
+                                                             axis=self.axis, 
+                                                             weight=fluid.dygraph.to_variable(self.weight),
+                                                             reduction=self.reduction)
+        dy_ret_value = paddle_loss_none_weight.numpy()
+
+        #3. jing
+        paddle.enable_static()
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.program_guard(prog, startup_prog):
+            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
+            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+            weight = fluid.data(name='weight', shape=[self.C], dtype='float64')
+ 
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                                                                weight=weight, 
+                                                                reduction=self.reduction,
+                                                                soft_label=True
+                                                                )
+            ret = cross_entropy_loss(input, label)
+            exe = fluid.Executor(place)
+            static_ret = exe.run(prog,
+                                 feed={
+                                     'input': self.logits, 
+                                     'label': self.labels, 
+                                     "weight": self.weight 
+                                 },
+                                 fetch_list=[ret])
+            self.assertIsNotNone(static_ret)
+        paddle.disable_static()
+
+        self.assertTrue(np.allclose(static_ret, expected))
+        self.assertTrue(np.allclose(dy_ret_value, expected))
+
+    ###chajchaj soft_label 5
+    def test_cross_entropy_loss_soft_2d(self):
+        self.numeric_stable_mode = False
+        self.soft_label = True
+        self.dtype = np.float64
+        self.axis = -1
+        self.ignore_index = -100 #should not be changed
+        self.N = 3
+        self.H = 2
+        self.W = 2
+        self.C = 5
+        self.shape = [self.N, self.H, self.W, self.C]
+        self.softmax_switch = True
+        self.reduction = 'none'
+        self.weight = None 
+        self.logits = getattr(
+            self, "logits",
+            np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
+        softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
+
+        self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+        self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
+
+        #1. numpy
+        expected = cross_entropy_soft_2d(
+                                     softmax, 
+                                     self.labels,
+                                     self.axis, 
+                                     self.N,
+                                     self.H,
+                                     self.W,
+                                     weight=self.weight,
+                                     reduction=self.reduction,
+                                     ignore_index=self.ignore_index
+                                     )
+
+        paddle.set_device("cpu")
+        paddle.disable_static()
+
+        #2. dong
+        paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
+                                                             fluid.dygraph.to_variable(self.logits),  
+                                                             fluid.dygraph.to_variable(self.labels), 
+                                                             soft_label=True, 
+                                                             axis=self.axis, 
+                                                             weight=fluid.dygraph.to_variable(self.weight) if self.weight is not None else None,
+                                                             reduction=self.reduction)
+        dy_ret_value = paddle_loss_none_weight.numpy()
+
+        #3. jing
+        paddle.enable_static()
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.program_guard(prog, startup_prog):
+            input = fluid.data(name='input', shape=[self.N, self.H, self.W, self.C], dtype='float64')
+            label = fluid.data(name='label', shape=[self.N, self.H, self.W, self.C], dtype='float64')
+ 
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                                                                reduction=self.reduction,
+                                                                soft_label=True
+                                                                )
+            ret = cross_entropy_loss(input, label)
+            exe = fluid.Executor(place)
+            static_ret = exe.run(prog,
+                                 feed={
+                                     'input': self.logits, 
+                                     'label': self.labels, 
+                                 },
+                                 fetch_list=[ret])
+            self.assertIsNotNone(static_ret)
+        paddle.disable_static()
+
+        self.assertTrue(np.allclose(static_ret, dy_ret_value))
+        self.assertTrue(np.allclose(static_ret, expected))
+        self.assertTrue(np.allclose(dy_ret_value, expected))
+
+
+
+    ###chajchaj soft_label 6
+    def test_cross_entropy_loss_soft_2d_weight_mean(self):
+        self.numeric_stable_mode = False
+        self.soft_label = True
+        self.dtype = np.float64
+        self.axis = -1
+        self.ignore_index = -100 #should not be changed
+        self.N = 3
+        self.H = 2
+        self.W = 2
+        self.C = 5
+        self.shape = [self.N, self.H, self.W, self.C]
+        self.softmax_switch = True
+        self.reduction = 'mean'
+        self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
+        self.logits = getattr(
+            self, "logits",
+            np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
+        softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
+
+        self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+        self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
+
+        #1. numpy
+        expected = cross_entropy_soft_2d(
+                                     softmax, 
+                                     self.labels,
+                                     self.axis, 
+                                     self.N,
+                                     self.H,
+                                     self.W,
+                                     weight=self.weight,
+                                     reduction=self.reduction,
+                                     ignore_index=self.ignore_index
+                                     )
+
+        paddle.set_device("cpu")
+        paddle.disable_static()
+
+        #2. dong
+        paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
+                                                             fluid.dygraph.to_variable(self.logits),  
+                                                             fluid.dygraph.to_variable(self.labels), 
+                                                             soft_label=True, 
+                                                             axis=self.axis, 
+                                                             weight=fluid.dygraph.to_variable(self.weight),
+                                                             reduction=self.reduction)
+        dy_ret_value = paddle_loss_none_weight.numpy()
+
+        #3. jing
+        paddle.enable_static()
+        prog = fluid.Program()
+        startup_prog = fluid.Program()
+        place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
+        ) else fluid.CPUPlace()
+        with fluid.program_guard(prog, startup_prog):
+            input = fluid.data(name='input', shape=[self.N, self.H, self.W, self.C], dtype='float64')
+            label = fluid.data(name='label', shape=[self.N, self.H, self.W, self.C], dtype='float64')
+            weight = fluid.data(name='weight', shape=[self.C], dtype='float64')
+ 
+            cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
+                                                                weight=weight, 
+                                                                reduction=self.reduction,
+                                                                soft_label=True
+                                                                )
+            ret = cross_entropy_loss(input, label)
+            exe = fluid.Executor(place)
+            static_ret = exe.run(prog,
+                                 feed={
+                                     'input': self.logits, 
+                                     'label': self.labels, 
+                                     "weight": self.weight 
+                                 },
+                                 fetch_list=[ret])
+            self.assertIsNotNone(static_ret)
+        paddle.disable_static()
+
+        self.assertTrue(np.allclose(static_ret, dy_ret_value))
+        self.assertTrue(np.allclose(static_ret, expected))
+        self.assertTrue(np.allclose(dy_ret_value, expected))
+
+
+
+    ###chajchaj soft_label end
+
     def test_cross_entropy_loss_1d_with_mean_ignore(self):
         input_np = np.random.random([2, 4]).astype(np.float64)
         label_np = np.random.randint(0, 4, size=(2)).astype(np.int64)
@@ -131,19 +702,21 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
     def test_cross_entropy_loss_1d_with_weight_mean_ignore(self):
-        input_np = np.random.random([2, 4]).astype(np.float64)
-        label_np = np.random.randint(0, 4, size=(2)).astype(np.int64)
-        weight_np = np.random.random([4]).astype(np.float64)  #shape:C
+        N=100
+        C=200
+        input_np = np.random.random([N, C]).astype(np.float64)
+        label_np = np.random.randint(0, C, size=(N)).astype(np.int64)
+        weight_np = np.random.random([C]).astype(np.float64)  
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[2, 4], dtype='float64')
-            label = fluid.data(name='label', shape=[2], dtype='int64')
+            input = fluid.data(name='input', shape=[N, C], dtype='float64')
+            label = fluid.data(name='label', shape=[N], dtype='int64')
             weight = fluid.data(
-                name='weight', shape=[4],
+                name='weight', shape=[C],
                 dtype='float64')  #weight for each class
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
                 weight=weight, ignore_index=0)
@@ -158,8 +731,6 @@ class CrossEntropyLoss(unittest.TestCase):
                                  },
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
-        expected = cross_entropy_loss_1d(
-            input_np, label_np, weight=weight_np)[0]
 
         with fluid.dygraph.guard():
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
@@ -173,6 +744,7 @@ class CrossEntropyLoss(unittest.TestCase):
             self.assertIsNotNone(dy_ret_value)
         expected = cross_entropy_loss_1d(
             input_np, label_np, weight=weight_np, ignore_index=0)[0]
+
         self.assertTrue(np.allclose(static_ret, dy_ret_value))
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
@@ -261,10 +833,12 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
+
     def test_cross_entropy_loss_1d_with_weight_none(self):
         input_np = np.random.random([100, 200]).astype(np.float64)  #N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  #N,1
         weight_np = np.random.random([200]).astype(np.float64)  #C
+ 
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -274,6 +848,7 @@ class CrossEntropyLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[100, 200], dtype='float64')
             label = fluid.data(name='label', shape=[100], dtype='int64')
             weight = fluid.data(name='weight', shape=[200], dtype='float64')
+ 
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
                 weight=weight, reduction='none')
             ret = cross_entropy_loss(input, label)

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
@@ -32,6 +32,7 @@ def log_softmax(x, axis=-1):
     softmax_out = np.apply_along_axis(stable_softmax, axis, x)
     return np.log(softmax_out)
 
+
 def cross_entropy_loss_1d(input,
                           label,
                           weight=None,
@@ -96,95 +97,97 @@ def cross_entropy_loss_2d(input,
     elif reduction == 'none':
         return out
 
-def cross_entropy_soft(softmax, 
-                       label, 
-                       axis, 
+
+def cross_entropy_soft(softmax,
+                       label,
+                       axis,
                        N,
                        weight=None,
                        reduction='mean',
-                       ignore_index=-100
-                      ):
-        #1.loss
-        loss = cross_entropy(softmax, 
-                             label, 
-                             True, #soft_label,
-                             axis,
-                             ignore_index)
+                       ignore_index=-100):
+    #1.loss
+    loss = cross_entropy(
+        softmax,
+        label,
+        True,  #soft_label,
+        axis,
+        ignore_index)
 
-        if weight is None and reduction=='none':
-            return loss
+    if weight is None and reduction == 'none':
+        return loss
 
-        #2.weight
-        weighted_loss = loss
-        total_weight = N  #for weight is None
-        if weight is not None:
-            weighted_loss = np.zeros_like(loss).astype(np.float64)
-            total_weight = 0
-            for i in range(N):
-                cur_soft_label = label[i]
-                cur_weight = np.dot(weight, cur_soft_label)
-                total_weight += cur_weight
-                weighted_loss[i] = loss[i] * cur_weight
-      
-        #3.reduce
-        if reduction=='none':
-            return weighted_loss
-       
-        elif reduction=='mean':
-            weighted_loss_sum = np.sum(weighted_loss)
-            weighted_loss_mean = weighted_loss_sum / total_weight
-            return weighted_loss_mean
+    #2.weight
+    weighted_loss = loss
+    total_weight = N  #for weight is None
+    if weight is not None:
+        weighted_loss = np.zeros_like(loss).astype(np.float64)
+        total_weight = 0
+        for i in range(N):
+            cur_soft_label = label[i]
+            cur_weight = np.dot(weight, cur_soft_label)
+            total_weight += cur_weight
+            weighted_loss[i] = loss[i] * cur_weight
 
-        else:
-            weighted_loss_sum = np.sum(weighted_loss)
-            return weighted_loss_sum
+    #3.reduce
+    if reduction == 'none':
+        return weighted_loss
 
-def cross_entropy_soft_2d(softmax, 
-                       label, 
-                       axis, 
-                       N,
-                       H,
-                       W,
-                       weight=None,
-                       reduction='mean',
-                       ignore_index=-100
-                      ):
-        #1.loss
-        loss = cross_entropy(softmax, 
-                             label, 
-                             True, #soft_label,
-                             axis,
-                             ignore_index)
+    elif reduction == 'mean':
+        weighted_loss_sum = np.sum(weighted_loss)
+        weighted_loss_mean = weighted_loss_sum / total_weight
+        return weighted_loss_mean
 
-        if weight is None and reduction=='none':
-            return loss
+    else:
+        weighted_loss_sum = np.sum(weighted_loss)
+        return weighted_loss_sum
 
-        #2.weight
-        weighted_loss = loss
-        total_weight = N  #for weight is None
-        if weight is not None:
-            weighted_loss = np.zeros_like(loss).astype(np.float64)
-            total_weight = 0
-            for i in range(N):
-                for h in range(H):
-                    for w in range(W):
-                        cur_soft_label = label[i][h][w]
-                        cur_weight = np.dot(weight, cur_soft_label)
-                        total_weight += cur_weight
-                        weighted_loss[i][h][w] = loss[i][h][w] * cur_weight
-      
-        #3.reduce
-        if reduction=='none':
-            return weighted_loss
-       
-        elif reduction=='mean':
-            weighted_loss_sum = np.sum(weighted_loss)
-            weighted_loss_mean = weighted_loss_sum / total_weight
-            return weighted_loss_mean
 
-        else:
-            weighted_loss_sum = np.sum(weighted_loss)
-            return weighted_loss_sum
+def cross_entropy_soft_2d(softmax,
+                          label,
+                          axis,
+                          N,
+                          H,
+                          W,
+                          weight=None,
+                          reduction='mean',
+                          ignore_index=-100):
+    #1.loss
+    loss = cross_entropy(
+        softmax,
+        label,
+        True,  #soft_label,
+        axis,
+        ignore_index)
+
+    if weight is None and reduction == 'none':
+        return loss
+
+    #2.weight
+    weighted_loss = loss
+    total_weight = N  #for weight is None
+    if weight is not None:
+        weighted_loss = np.zeros_like(loss).astype(np.float64)
+        total_weight = 0
+        for i in range(N):
+            for h in range(H):
+                for w in range(W):
+                    cur_soft_label = label[i][h][w]
+                    cur_weight = np.dot(weight, cur_soft_label)
+                    total_weight += cur_weight
+                    weighted_loss[i][h][w] = loss[i][h][w] * cur_weight
+
+    #3.reduce
+    if reduction == 'none':
+        return weighted_loss
+
+    elif reduction == 'mean':
+        weighted_loss_sum = np.sum(weighted_loss)
+        weighted_loss_mean = weighted_loss_sum / total_weight
+        return weighted_loss_mean
+
+    else:
+        weighted_loss_sum = np.sum(weighted_loss)
+        return weighted_loss_sum
 
 
 class CrossEntropyLoss(unittest.TestCase):
@@ -197,7 +200,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.soft_label = True
         self.dtype = np.float64
         self.axis = -1
-        self.ignore_index = -100 #should not be changed
+        self.ignore_index = -100  #should not be changed
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
@@ -213,26 +216,26 @@ class CrossEntropyLoss(unittest.TestCase):
         self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
 
         expected = cross_entropy_soft(
-                                     softmax, 
-                                     self.labels,
-                                     self.axis, 
-                                     self.N,
-                                     weight=self.weight,
-                                     reduction=self.reduction,
-                                     ignore_index=self.ignore_index
-                                     )
+            softmax,
+            self.labels,
+            self.axis,
+            self.N,
+            weight=self.weight,
+            reduction=self.reduction,
+            ignore_index=self.ignore_index)
 
         paddle.set_device("cpu")
 
         #2. dong 
         paddle.disable_static()
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
-                                                             fluid.dygraph.to_variable(self.logits),  
-                                                             fluid.dygraph.to_variable(self.labels), 
-                                                             soft_label=True, 
-                                                             axis=self.axis, 
-                                                             weight=fluid.dygraph.to_variable(self.weight) if self.weight is not None else None,
-                                                             reduction=self.reduction)
+            fluid.dygraph.to_variable(self.logits),
+            fluid.dygraph.to_variable(self.labels),
+            soft_label=True,
+            axis=self.axis,
+            weight=fluid.dygraph.to_variable(self.weight)
+            if self.weight is not None else None,
+            reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
         #3. jing
@@ -242,20 +245,20 @@ class CrossEntropyLoss(unittest.TestCase):
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
-            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
- 
+            input = fluid.data(
+                name='input', shape=[self.N, self.C], dtype='float64')
+            label = fluid.data(
+                name='label', shape=[self.N, self.C], dtype='float64')
+
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                                                                reduction=self.reduction,
-                                                                soft_label=True
-                                                                )
+                reduction=self.reduction, soft_label=True)
             ret = cross_entropy_loss(input, label)
 
             exe = fluid.Executor(place)
             static_ret = exe.run(prog,
                                  feed={
-                                     'input': self.logits, 
-                                     'label': self.labels, 
+                                     'input': self.logits,
+                                     'label': self.labels,
                                  },
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
@@ -264,55 +267,55 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-
     ###chajchaj soft_label 2
     def test_cross_entropy_loss_soft_1d_weight(self):
         self.numeric_stable_mode = False
         self.soft_label = True
         self.dtype = np.float64
         self.axis = -1
-        self.ignore_index = -100 #should not be changed
+        self.ignore_index = -100  #should not be changed
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
         self.use_softmax = True
         self.reduction = 'none'
-        self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
+        self.weight = np.random.uniform(0.1, 1.0, self.C).astype(self.dtype)
         self.logits = getattr(
             self, "logits",
             np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
         softmax = np.apply_along_axis(stable_softmax, self.axis, self.logits)
 
         if self.soft_label:
-            self.labels = np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype)
+            self.labels = np.random.uniform(0.1, 1.0,
+                                            self.shape).astype(self.dtype)
             self.labels /= np.sum(self.labels, axis=self.axis, keepdims=True)
         else:
             axis_dim = self.shape[self.axis]
             self.shape[self.axis] = 1
-            self.labels = np.random.randint(0, axis_dim, self.shape, dtype="int64")
+            self.labels = np.random.randint(
+                0, axis_dim, self.shape, dtype="int64")
 
         #1. numpy
         expected = cross_entropy_soft(
-                                     softmax, 
-                                     self.labels,
-                                     self.axis, 
-                                     self.N,
-                                     weight=self.weight,
-                                     reduction=self.reduction,
-                                     ignore_index=self.ignore_index
-                                     )
+            softmax,
+            self.labels,
+            self.axis,
+            self.N,
+            weight=self.weight,
+            reduction=self.reduction,
+            ignore_index=self.ignore_index)
 
         paddle.set_device("cpu")
 
         #2. dong
         paddle.disable_static()
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
-                                                             fluid.dygraph.to_variable(self.logits),  
-                                                             fluid.dygraph.to_variable(self.labels), 
-                                                             soft_label=True, 
-                                                             axis=self.axis, 
-                                                             weight=fluid.dygraph.to_variable(self.weight),
-                                                             reduction=self.reduction)
+            fluid.dygraph.to_variable(self.logits),
+            fluid.dygraph.to_variable(self.labels),
+            soft_label=True,
+            axis=self.axis,
+            weight=fluid.dygraph.to_variable(self.weight),
+            reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
         # 3.jing
@@ -322,23 +325,22 @@ class CrossEntropyLoss(unittest.TestCase):
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
-            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+            input = fluid.data(
+                name='input', shape=[self.N, self.C], dtype='float64')
+            label = fluid.data(
+                name='label', shape=[self.N, self.C], dtype='float64')
             weight = fluid.data(name='weight', shape=[self.C], dtype='float64')
- 
+
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                                                                weight=weight, 
-                                                                reduction=self.reduction,
-                                                                soft_label=True
-                                                                )
+                weight=weight, reduction=self.reduction, soft_label=True)
             ret = cross_entropy_loss(input, label)
 
             exe = fluid.Executor(place)
             static_ret = exe.run(prog,
                                  feed={
-                                     'input': self.logits, 
-                                     'label': self.labels, 
-                                     "weight": self.weight 
+                                     'input': self.logits,
+                                     'label': self.labels,
+                                     "weight": self.weight
                                  },
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
@@ -347,20 +349,18 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-
     ###chajchaj soft_label 3
     def test_cross_entropy_loss_soft_1d_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
         self.dtype = np.float64
         self.axis = -1
-        self.ignore_index = -1
-        self.ignore_index = -100 #should not be changed
+        self.ignore_index = -100  #should not be changed
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
         self.use_softmax = True
-        self.reduction='mean'
+        self.reduction = 'mean'
         self.weight = None
         self.logits = getattr(
             self, "logits",
@@ -372,26 +372,25 @@ class CrossEntropyLoss(unittest.TestCase):
 
         #1. numpy
         expected = cross_entropy_soft(
-                                     softmax, 
-                                     self.labels,
-                                     self.axis, 
-                                     self.N,
-                                     weight=self.weight,
-                                     reduction=self.reduction,
-                                     ignore_index=self.ignore_index
-                                     )
+            softmax,
+            self.labels,
+            self.axis,
+            self.N,
+            weight=self.weight,
+            reduction=self.reduction,
+            ignore_index=self.ignore_index)
 
         paddle.set_device("cpu")
 
         #2 dong 
         paddle.disable_static()
         paddle_loss_mean = paddle.nn.functional.cross_entropy(
-                                                             fluid.dygraph.to_variable(self.logits),  
-                                                             fluid.dygraph.to_variable(self.labels), 
-                                                             soft_label=True, 
-                                                             axis=self.axis,
-                                                             weight=self.weight,
-                                                             reduction=self.reduction)
+            fluid.dygraph.to_variable(self.logits),
+            fluid.dygraph.to_variable(self.labels),
+            soft_label=True,
+            axis=self.axis,
+            weight=self.weight,
+            reduction=self.reduction)
         dy_ret_value = paddle_loss_mean.numpy()
 
         #3. jing
@@ -401,27 +400,26 @@ class CrossEntropyLoss(unittest.TestCase):
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
-            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+            input = fluid.data(
+                name='input', shape=[self.N, self.C], dtype='float64')
+            label = fluid.data(
+                name='label', shape=[self.N, self.C], dtype='float64')
 
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                reduction=self.reduction,
-                soft_label=True)
+                reduction=self.reduction, soft_label=True)
             ret = cross_entropy_loss(input, label)
 
             exe = fluid.Executor(place)
-            static_ret = exe.run(prog,
-                                 feed={
-                                     'input': self.logits,
-                                     'label': self.labels 
-                                 },
-                                 fetch_list=[ret])
+            static_ret = exe.run(
+                prog,
+                feed={'input': self.logits,
+                      'label': self.labels},
+                fetch_list=[ret])
             self.assertIsNotNone(static_ret)
         paddle.disable_static()
 
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
-
 
     ###chajchaj soft_label 4
     def test_cross_entropy_loss_soft_1d_weight_mean(self):
@@ -429,13 +427,13 @@ class CrossEntropyLoss(unittest.TestCase):
         self.soft_label = True
         self.dtype = np.float64
         self.axis = -1
-        self.ignore_index = -100 #should not be changed
+        self.ignore_index = -100  #should not be changed
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
         self.use_softmax = True
         self.reduction = 'mean'
-        self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
+        self.weight = np.random.uniform(0.1, 1.0, self.C).astype(self.dtype)
         self.logits = getattr(
             self, "logits",
             np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
@@ -446,26 +444,25 @@ class CrossEntropyLoss(unittest.TestCase):
 
         #1. numpy
         expected = cross_entropy_soft(
-                                     softmax, 
-                                     self.labels,
-                                     self.axis, 
-                                     self.N,
-                                     weight=self.weight,
-                                     reduction=self.reduction,
-                                     ignore_index=self.ignore_index
-                                     )
+            softmax,
+            self.labels,
+            self.axis,
+            self.N,
+            weight=self.weight,
+            reduction=self.reduction,
+            ignore_index=self.ignore_index)
 
         paddle.set_device("cpu")
         paddle.disable_static()
 
         #2. dong
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
-                                                             fluid.dygraph.to_variable(self.logits),  
-                                                             fluid.dygraph.to_variable(self.labels), 
-                                                             soft_label=True, 
-                                                             axis=self.axis, 
-                                                             weight=fluid.dygraph.to_variable(self.weight),
-                                                             reduction=self.reduction)
+            fluid.dygraph.to_variable(self.logits),
+            fluid.dygraph.to_variable(self.labels),
+            soft_label=True,
+            axis=self.axis,
+            weight=fluid.dygraph.to_variable(self.weight),
+            reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
         #3. jing
@@ -475,22 +472,21 @@ class CrossEntropyLoss(unittest.TestCase):
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[self.N,  self.C], dtype='float64')
-            label = fluid.data(name='label', shape=[self.N,  self.C], dtype='float64')
+            input = fluid.data(
+                name='input', shape=[self.N, self.C], dtype='float64')
+            label = fluid.data(
+                name='label', shape=[self.N, self.C], dtype='float64')
             weight = fluid.data(name='weight', shape=[self.C], dtype='float64')
- 
+
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                                                                weight=weight, 
-                                                                reduction=self.reduction,
-                                                                soft_label=True
-                                                                )
+                weight=weight, reduction=self.reduction, soft_label=True)
             ret = cross_entropy_loss(input, label)
             exe = fluid.Executor(place)
             static_ret = exe.run(prog,
                                  feed={
-                                     'input': self.logits, 
-                                     'label': self.labels, 
-                                     "weight": self.weight 
+                                     'input': self.logits,
+                                     'label': self.labels,
+                                     "weight": self.weight
                                  },
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
@@ -505,7 +501,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.soft_label = True
         self.dtype = np.float64
         self.axis = -1
-        self.ignore_index = -100 #should not be changed
+        self.ignore_index = -100  #should not be changed
         self.N = 3
         self.H = 2
         self.W = 2
@@ -513,7 +509,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.shape = [self.N, self.H, self.W, self.C]
         self.use_softmax = True
         self.reduction = 'none'
-        self.weight = None 
+        self.weight = None
         self.logits = getattr(
             self, "logits",
             np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
@@ -524,28 +520,28 @@ class CrossEntropyLoss(unittest.TestCase):
 
         #1. numpy
         expected = cross_entropy_soft_2d(
-                                     softmax, 
-                                     self.labels,
-                                     self.axis, 
-                                     self.N,
-                                     self.H,
-                                     self.W,
-                                     weight=self.weight,
-                                     reduction=self.reduction,
-                                     ignore_index=self.ignore_index
-                                     )
+            softmax,
+            self.labels,
+            self.axis,
+            self.N,
+            self.H,
+            self.W,
+            weight=self.weight,
+            reduction=self.reduction,
+            ignore_index=self.ignore_index)
 
         paddle.set_device("cpu")
         paddle.disable_static()
 
         #2. dong
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
-                                                             fluid.dygraph.to_variable(self.logits),  
-                                                             fluid.dygraph.to_variable(self.labels), 
-                                                             soft_label=True, 
-                                                             axis=self.axis, 
-                                                             weight=fluid.dygraph.to_variable(self.weight) if self.weight is not None else None,
-                                                             reduction=self.reduction)
+            fluid.dygraph.to_variable(self.logits),
+            fluid.dygraph.to_variable(self.labels),
+            soft_label=True,
+            axis=self.axis,
+            weight=fluid.dygraph.to_variable(self.weight)
+            if self.weight is not None else None,
+            reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
         #3. jing
@@ -555,19 +551,23 @@ class CrossEntropyLoss(unittest.TestCase):
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[self.N, self.H, self.W, self.C], dtype='float64')
-            label = fluid.data(name='label', shape=[self.N, self.H, self.W, self.C], dtype='float64')
- 
+            input = fluid.data(
+                name='input',
+                shape=[self.N, self.H, self.W, self.C],
+                dtype='float64')
+            label = fluid.data(
+                name='label',
+                shape=[self.N, self.H, self.W, self.C],
+                dtype='float64')
+
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                                                                reduction=self.reduction,
-                                                                soft_label=True
-                                                                )
+                reduction=self.reduction, soft_label=True)
             ret = cross_entropy_loss(input, label)
             exe = fluid.Executor(place)
             static_ret = exe.run(prog,
                                  feed={
-                                     'input': self.logits, 
-                                     'label': self.labels, 
+                                     'input': self.logits,
+                                     'label': self.labels,
                                  },
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
@@ -576,8 +576,6 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, dy_ret_value))
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
-
-
 
     ###chajchaj soft_label 6
     def test_cross_entropy_loss_soft_2d_weight_mean(self):
@@ -585,7 +583,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.soft_label = True
         self.dtype = np.float64
         self.axis = -1
-        self.ignore_index = -100 #should not be changed
+        self.ignore_index = -100  #should not be changed
         self.N = 3
         self.H = 2
         self.W = 2
@@ -593,7 +591,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.shape = [self.N, self.H, self.W, self.C]
         self.use_softmax = True
         self.reduction = 'mean'
-        self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
+        self.weight = np.random.uniform(0.1, 1.0, self.C).astype(self.dtype)
         self.logits = getattr(
             self, "logits",
             np.random.uniform(0.1, 1.0, self.shape).astype(self.dtype))
@@ -604,28 +602,27 @@ class CrossEntropyLoss(unittest.TestCase):
 
         #1. numpy
         expected = cross_entropy_soft_2d(
-                                     softmax, 
-                                     self.labels,
-                                     self.axis, 
-                                     self.N,
-                                     self.H,
-                                     self.W,
-                                     weight=self.weight,
-                                     reduction=self.reduction,
-                                     ignore_index=self.ignore_index
-                                     )
+            softmax,
+            self.labels,
+            self.axis,
+            self.N,
+            self.H,
+            self.W,
+            weight=self.weight,
+            reduction=self.reduction,
+            ignore_index=self.ignore_index)
 
         paddle.set_device("cpu")
         paddle.disable_static()
 
         #2. dong
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
-                                                             fluid.dygraph.to_variable(self.logits),  
-                                                             fluid.dygraph.to_variable(self.labels), 
-                                                             soft_label=True, 
-                                                             axis=self.axis, 
-                                                             weight=fluid.dygraph.to_variable(self.weight),
-                                                             reduction=self.reduction)
+            fluid.dygraph.to_variable(self.logits),
+            fluid.dygraph.to_variable(self.labels),
+            soft_label=True,
+            axis=self.axis,
+            weight=fluid.dygraph.to_variable(self.weight),
+            reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
         #3. jing
@@ -635,22 +632,25 @@ class CrossEntropyLoss(unittest.TestCase):
         place = fluid.CUDAPlace(0) if fluid.core.is_compiled_with_cuda(
         ) else fluid.CPUPlace()
         with fluid.program_guard(prog, startup_prog):
-            input = fluid.data(name='input', shape=[self.N, self.H, self.W, self.C], dtype='float64')
-            label = fluid.data(name='label', shape=[self.N, self.H, self.W, self.C], dtype='float64')
+            input = fluid.data(
+                name='input',
+                shape=[self.N, self.H, self.W, self.C],
+                dtype='float64')
+            label = fluid.data(
+                name='label',
+                shape=[self.N, self.H, self.W, self.C],
+                dtype='float64')
             weight = fluid.data(name='weight', shape=[self.C], dtype='float64')
- 
+
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                                                                weight=weight, 
-                                                                reduction=self.reduction,
-                                                                soft_label=True
-                                                                )
+                weight=weight, reduction=self.reduction, soft_label=True)
             ret = cross_entropy_loss(input, label)
             exe = fluid.Executor(place)
             static_ret = exe.run(prog,
                                  feed={
-                                     'input': self.logits, 
-                                     'label': self.labels, 
-                                     "weight": self.weight 
+                                     'input': self.logits,
+                                     'label': self.labels,
+                                     "weight": self.weight
                                  },
                                  fetch_list=[ret])
             self.assertIsNotNone(static_ret)
@@ -659,8 +659,6 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, dy_ret_value))
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
-
-
 
     ###chajchaj soft_label end
 
@@ -702,11 +700,11 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
     def test_cross_entropy_loss_1d_with_weight_mean_ignore(self):
-        N=100
-        C=200
+        N = 100
+        C = 200
         input_np = np.random.random([N, C]).astype(np.float64)
         label_np = np.random.randint(0, C, size=(N)).astype(np.int64)
-        weight_np = np.random.random([C]).astype(np.float64)  
+        weight_np = np.random.random([C]).astype(np.float64)
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -833,12 +831,11 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-
     def test_cross_entropy_loss_1d_with_weight_none(self):
         input_np = np.random.random([100, 200]).astype(np.float64)  #N,C
         label_np = np.random.randint(0, 100, size=(100)).astype(np.int64)  #N,1
         weight_np = np.random.random([200]).astype(np.float64)  #C
- 
+
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -848,7 +845,7 @@ class CrossEntropyLoss(unittest.TestCase):
             input = fluid.data(name='input', shape=[100, 200], dtype='float64')
             label = fluid.data(name='label', shape=[100], dtype='int64')
             weight = fluid.data(name='weight', shape=[200], dtype='float64')
- 
+
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
                 weight=weight, reduction='none')
             ret = cross_entropy_loss(input, label)

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
@@ -192,7 +192,7 @@ def cross_entropy_soft_2d(softmax,
 
 class CrossEntropyLoss(unittest.TestCase):
 
-    ###chajchaj  test for deprecated softmax_with_cross_entropy
+    ###test for deprecated softmax_with_cross_entropy
     def test_softmax_with_cross_entropy(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -224,7 +224,6 @@ class CrossEntropyLoss(unittest.TestCase):
 
         paddle.set_device("cpu")
 
-        #2. swce 
         paddle.disable_static()
         paddle_loss_swce = paddle.nn.functional.softmax_with_cross_entropy(
             fluid.dygraph.to_variable(self.logits),
@@ -232,7 +231,6 @@ class CrossEntropyLoss(unittest.TestCase):
             soft_label=True,
             axis=self.axis)
 
-        #3. ce
         paddle_loss_ce = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
             fluid.dygraph.to_variable(self.labels),
@@ -245,8 +243,8 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(paddle_loss_swce.numpy(), expected))
         self.assertTrue(np.allclose(paddle_loss_ce.numpy(), expected))
 
-    ###chajchaj soft_label start
-    ###chajchaj soft_label 1
+    ###soft_label test start
+    ###soft_label test 1
     def test_cross_entropy_loss_soft_1d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -278,7 +276,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
         paddle.set_device("cpu")
 
-        #2. dong 
+        #2. dygraph
         paddle.disable_static()
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
@@ -290,7 +288,7 @@ class CrossEntropyLoss(unittest.TestCase):
             reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
-        #3. jing
+        #3. static
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -319,7 +317,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-    ###chajchaj soft_label 2
+    ###soft_label test 2
     def test_cross_entropy_loss_soft_1d_weight(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -359,7 +357,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
         paddle.set_device("cpu")
 
-        #2. dong
+        #2. dygraph
         paddle.disable_static()
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
@@ -370,7 +368,7 @@ class CrossEntropyLoss(unittest.TestCase):
             reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
-        # 3.jing
+        # 3.static
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -401,7 +399,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-    ###chajchaj soft_label 3
+    ###soft_label test 3
     def test_cross_entropy_loss_soft_1d_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -434,7 +432,7 @@ class CrossEntropyLoss(unittest.TestCase):
 
         paddle.set_device("cpu")
 
-        #2 dong 
+        #2 dygraph 
         paddle.disable_static()
         paddle_loss_mean = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
@@ -445,7 +443,7 @@ class CrossEntropyLoss(unittest.TestCase):
             reduction=self.reduction)
         dy_ret_value = paddle_loss_mean.numpy()
 
-        #3. jing
+        #3. static
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -473,7 +471,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-    ###chajchaj soft_label 4
+    ###soft_label test 4
     def test_cross_entropy_loss_soft_1d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -507,7 +505,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.set_device("cpu")
         paddle.disable_static()
 
-        #2. dong
+        #2. dygraph
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
             fluid.dygraph.to_variable(self.labels),
@@ -517,7 +515,7 @@ class CrossEntropyLoss(unittest.TestCase):
             reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
-        #3. jing
+        #3. static
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -547,7 +545,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-    ###chajchaj soft_label 5
+    ###soft_label test 5
     def test_cross_entropy_loss_soft_2d(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -585,7 +583,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.set_device("cpu")
         paddle.disable_static()
 
-        #2. dong
+        #2. dygraph
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
             fluid.dygraph.to_variable(self.labels),
@@ -596,7 +594,7 @@ class CrossEntropyLoss(unittest.TestCase):
             reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
-        #3. jing
+        #3. static
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -629,7 +627,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-    ###chajchaj soft_label 6
+    ###soft_label test 6
     def test_cross_entropy_loss_soft_2d_weight_mean(self):
         self.numeric_stable_mode = False
         self.soft_label = True
@@ -667,7 +665,7 @@ class CrossEntropyLoss(unittest.TestCase):
         paddle.set_device("cpu")
         paddle.disable_static()
 
-        #2. dong
+        #2. dygraph
         paddle_loss_none_weight = paddle.nn.functional.cross_entropy(
             fluid.dygraph.to_variable(self.logits),
             fluid.dygraph.to_variable(self.labels),
@@ -677,7 +675,7 @@ class CrossEntropyLoss(unittest.TestCase):
             reduction=self.reduction)
         dy_ret_value = paddle_loss_none_weight.numpy()
 
-        #3. jing
+        #3. static
         paddle.enable_static()
         prog = fluid.Program()
         startup_prog = fluid.Program()
@@ -712,7 +710,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.assertTrue(np.allclose(static_ret, expected))
         self.assertTrue(np.allclose(dy_ret_value, expected))
 
-    ###chajchaj soft_label end
+    ###soft_label test end
 
     def test_cross_entropy_loss_1d_with_mean_ignore(self):
         input_np = np.random.random([2, 4]).astype(np.float64)

--- a/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
+++ b/python/paddle/fluid/tests/unittests/test_cross_entropy_loss.py
@@ -201,7 +201,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
-        self.softmax_switch = True
+        self.use_softmax = True
         self.reduction = 'none'
         self.weight = None
         self.logits = getattr(
@@ -275,7 +275,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
-        self.softmax_switch = True
+        self.use_softmax = True
         self.reduction = 'none'
         self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
         self.logits = getattr(
@@ -359,7 +359,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
-        self.softmax_switch = True
+        self.use_softmax = True
         self.reduction='mean'
         self.weight = None
         self.logits = getattr(
@@ -433,7 +433,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.N = 4
         self.C = 3
         self.shape = [self.N, self.C]
-        self.softmax_switch = True
+        self.use_softmax = True
         self.reduction = 'mean'
         self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
         self.logits = getattr(
@@ -511,7 +511,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.W = 2
         self.C = 5
         self.shape = [self.N, self.H, self.W, self.C]
-        self.softmax_switch = True
+        self.use_softmax = True
         self.reduction = 'none'
         self.weight = None 
         self.logits = getattr(
@@ -591,7 +591,7 @@ class CrossEntropyLoss(unittest.TestCase):
         self.W = 2
         self.C = 5
         self.shape = [self.N, self.H, self.W, self.C]
-        self.softmax_switch = True
+        self.use_softmax = True
         self.reduction = 'mean'
         self.weight = np.random.uniform( 0.1, 1.0, self.C ).astype(self.dtype)
         self.logits = getattr(

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -54,7 +54,7 @@ __all__ = [
     'npair_loss',
     'sigmoid_focal_loss',
     'smooth_l1_loss',
-    'softmax_with_cross_entropy',
+    'test_softmax_with_cross_entropy',
     'square_error_cost',
     'ctc_loss',
 ]
@@ -1121,6 +1121,15 @@ def test_softmax_with_cross_entropy(logits,
                                numeric_stable_mode=True,
                                return_softmax=False,
                                axis=-1):
+    r"""
+    
+    ..warning:
+        This operator is deprecated since paddlepaddle 2.0.0, and it's updated to 
+        paddle.nn.functional.cross_entropy. We will remove softmax_with_cross_entropy 
+        in the future.
+        
+
+    """
     return fluid_softmax_with_cross_entropy(logits, label, soft_label,
                                             ignore_index, numeric_stable_mode,
                                             return_softmax, axis)

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1162,76 +1162,75 @@ def cross_entropy(input,
 
         1. Hard label (each sample can only be assigned into one category)
 
-        .. math::
-          \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
+            .. math::
+              \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
 
-        where, N is the number of samples and C is the number of categories.
+            where, N is the number of samples and C is the number of categories.
 
-        2. Soft label (each sample is assigned to multiple categories with a certain probability, 
-        and the probability sum is 1).
+        2. Soft label (each sample is assigned to multiple categories with a certain probability, and the probability sum is 1).
 
-        .. math::
-          \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
+            .. math::
+              \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
 
-        where, N is the number of samples and C is the number of categories.
+            where, N is the number of samples and C is the number of categories.
 
 
     - **II. Weight and reduction processing**
 
         1. Weight
 
-        If the ``weight`` parameter is ``none`` , go to the next step directly.
+            If the ``weight`` parameter is ``none`` , go to the next step directly.
 
-        If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
-        according to soft_label = False or True as follows.
+            If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+            according to soft_label = False or True as follows.
 
-        1.1. Hard labels (soft_label = False)
+            1.1. Hard labels (soft_label = False)
 
-        .. math::
-            \\loss_j=loss_j*weight[label_j] 
+            .. math::
+                \\loss_j=loss_j*weight[label_j] 
 
 
-        1.2. Soft labels (soft_label = True)
+            1.2. Soft labels (soft_label = True)
 
-         .. math::
-            \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
+             .. math::
+                \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
 
         2. reduction
 
-        2.1 if the ``reduction`` parameter is ``none`` 
+            2.1 if the ``reduction`` parameter is ``none`` 
 
-            Return the previous result directly
+                Return the previous result directly
 
-        2.2 if the ``reduction`` parameter is ``sum`` 
+            2.2 if the ``reduction`` parameter is ``sum`` 
 
-            Return the sum of the previous results
+                Return the sum of the previous results
 
-        .. math::
-           \\loss=\sum_{j}loss_j
+            .. math::
+               \\loss=\sum_{j}loss_j
 
-        2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
-        the ``weight`` parameter as follows. 
+            2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
+            the ``weight`` parameter as follows. 
 
-        2.3.1. If the  ``weight``  parameter is ``none`` 
+            2.3.1. If the  ``weight``  parameter is ``none`` 
 
-               Return the average value of the previous results
+                   Return the average value of the previous results
 
-         .. math::
-            \\loss=\sum_{j}loss_j/N
+             .. math::
+                \\loss=\sum_{j}loss_j/N
 
-              where, N is the number of samples and C is the number of categories.
+                  where, N is the number of samples and C is the number of categories.
 
-        2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+            2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
 
-        (1) Hard labels (soft_label = False)
+            (1) Hard labels (soft_label = False)
 
-         .. math::
-            \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+             .. math::
+                \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
 
-        (2) Soft labels (soft_label = True)
+            (2) Soft labels (soft_label = True)
 
-         .. math::
-            \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
+             .. math::
+                \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
  
  
     Parameters:

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*
 #   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1149,7 +1150,7 @@ def cross_entropy(input,
 
     The calculation of this operator includes the following two steps.
 
-    - **I.softmax cross entropy**
+    - **1.softmax cross entropy**
 
         1. Hard label (each sample can only be assigned into one category)
 
@@ -1166,7 +1167,7 @@ def cross_entropy(input,
             where, N is the number of samples and C is the number of categories.
 
 
-    - **II. Weight and reduction processing**
+    - **2. Weight and reduction processing**
 
         1. Weight
 
@@ -1235,7 +1236,7 @@ def cross_entropy(input,
 
         - **label** (Tensor)
 
-            1. If soft_label=False，the shape is 
+            1. If soft_label=False, the shape is
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
             the data type is int32, int64, float32, float64. 
 

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -38,7 +38,6 @@ from ...fluid.framework import _varbase_creator
 from ...fluid.framework import Variable
 from paddle.utils import deprecated
 
-
 __all__ = [
     'binary_cross_entropy',
     'binary_cross_entropy_with_logits',
@@ -684,7 +683,6 @@ def l1_loss(input, label, reduction='mean', name=None):
 
             import paddle
 
-            paddle.disable_static()
             input = paddle.to_tensor([[1.5, 0.8], [0.2, 1.3]])
             label = paddle.to_tensor([[1.7, 1], [0.4, 0.5]])
 
@@ -1113,6 +1111,7 @@ def ctc_loss(log_probs,
         loss_out = paddle.sum(loss_out)
     return loss_out
 
+
 @deprecated(since="2.0.0", update_to="paddle.nn.functional.cross_entropy")
 def softmax_with_cross_entropy(logits,
                                label,
@@ -1121,14 +1120,10 @@ def softmax_with_cross_entropy(logits,
                                numeric_stable_mode=True,
                                return_softmax=False,
                                axis=-1):
-    return fluid_softmax_with_cross_entropy(logits,
-                                            label,
-                                            soft_label,
-                                            ignore_index,
-                                            numeric_stable_mode,
-                                            return_softmax,
-                                            axis)
- 
+    return fluid_softmax_with_cross_entropy(logits, label, soft_label,
+                                            ignore_index, numeric_stable_mode,
+                                            return_softmax, axis)
+
 
 def cross_entropy(input,
                   label,
@@ -1367,9 +1362,9 @@ def cross_entropy(input,
     if ignore_index > 0 and soft_label == True:
         raise ValueError(
             "When soft_label == True, the value of 'ignore_index' in softmax_cross_entropy"
-            "should be '-100', but received %s, which is not allowed."
-            % ignore_index)
- 
+            "should be '-100', but received %s, which is not allowed." %
+            ignore_index)
+
     input_dims = len(list(input.shape))
     label_dims = len(list(label.shape))
     if input_dims - 1 != label_dims and input_dims != label_dims:
@@ -1381,9 +1376,9 @@ def cross_entropy(input,
     if in_dygraph_mode():
         _, out = core.ops.softmax_with_cross_entropy(
             input, label, 'soft_label', soft_label, 'ignore_index',
-            ignore_index, 'numeric_stable_mode', True, 'axis',
-            axis, 'use_softmax', use_softmax)
-     
+            ignore_index, 'numeric_stable_mode', True, 'axis', axis,
+            'use_softmax', use_softmax)
+
         if weight is not None:
 
             #trans weight from class to sample, shape:N or [N,H,W] for 1d and 2d cases.
@@ -1392,20 +1387,22 @@ def cross_entropy(input,
                 # weight's shape is C, where C is class num.
                 # for 1d case: label's shape is [N,C], weight_gather's shape is N.
                 # for 2d case: label's shape is [N,H,W,C], weight_gather's shape is [N,H,W].
-                weight_gather = paddle.matmul(x=paddle.cast(label, weight.dtype),
-                                              y=weight, 
-                                              transpose_x=False, 
-                                              transpose_y=True)
+                weight_gather = paddle.matmul(
+                    x=paddle.cast(label, weight.dtype),
+                    y=weight,
+                    transpose_x=False,
+                    transpose_y=True)
                 out_shape = list(out.shape)
                 weight_gather_reshape = reshape(weight_gather, shape=out_shape)
                 out = paddle.cast(out, weight_gather_reshape.dtype)
+
                 out = core.ops.elementwise_mul(out, weight_gather_reshape)
 
             else:
-                weight_gather = core.ops.gather_nd(
-                    weight, label)  
+                weight_gather = core.ops.gather_nd(weight, label)
                 input_shape = list(label.shape)
-                weight_gather_reshape = reshape(weight_gather, shape=input_shape)
+                weight_gather_reshape = reshape(
+                    weight_gather, shape=input_shape)
                 out = paddle.cast(out, weight_gather_reshape.dtype)
                 out = core.ops.elementwise_mul(out, weight_gather_reshape)
 
@@ -1474,7 +1471,7 @@ def cross_entropy(input,
         outputs={'Softmax': softmax,
                  'Loss': out},
         attrs=attrs)
- 
+
     if weight is not None:
         fluid.data_feeder.check_variable_and_dtype(
             weight, 'weight', ['float32', 'float64'], 'softmax_cross_entropy')
@@ -1485,10 +1482,11 @@ def cross_entropy(input,
             # weight's shape is C, where C is class num.
             # for 1d case: label's shape is [N,C], weight_gather's shape is N.
             # for 2d case: label's shape is [N,H,W,C], weight_gather's shape is [N,H,W].
-            weight_gather = paddle.matmul(x=paddle.cast(label, weight.dtype),
-                                          y=weight, 
-                                          transpose_x=False, 
-                                          transpose_y=True)
+            weight_gather = paddle.matmul(
+                x=paddle.cast(label, weight.dtype),
+                y=weight,
+                transpose_x=False,
+                transpose_y=True)
 
             out_shape = list(out.shape)
             weight_gather_reshape = reshape(weight_gather, shape=out_shape)
@@ -1499,7 +1497,6 @@ def cross_entropy(input,
             input_shape = list(label.shape)
             weight_gather_reshape = reshape(weight_gather, shape=input_shape)
         out = paddle.multiply(out, weight_gather_reshape, name=weight_name)
-
 
     if reduction == "sum":
         return paddle.sum(out, name=name)

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -54,7 +54,7 @@ __all__ = [
     'npair_loss',
     'sigmoid_focal_loss',
     'smooth_l1_loss',
-    'test_softmax_with_cross_entropy',
+    'softmax_with_cross_entropy',
     'square_error_cost',
     'ctc_loss',
 ]
@@ -1114,7 +1114,7 @@ def ctc_loss(log_probs,
 
 
 @deprecated(since="2.0.0", update_to="paddle.nn.functional.cross_entropy")
-def test_softmax_with_cross_entropy(logits,
+def softmax_with_cross_entropy(logits,
                                label,
                                soft_label=False,
                                ignore_index=-100,

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1235,52 +1235,78 @@ def cross_entropy(input,
  
  
     Parameters:
-    :::::::::
-        - **input** (Tensor): Input tensor, the data type is float32, float64. Shape is
+
+        - **input** (Tensor)
+
+            Input tensor, the data type is float32, float64. Shape is
 	    :math:`[N_1, N_2, ..., N_k, C]`, where C is number of classes ,  ``k >= 1`` . 
             Note: it expects unscaled logits. This operator should not be used with the 
             output of softmax operator, which will produce incorrect results.
-        - **label** (Tensor): Label tensor. 
+
+        - **label** (Tensor)
+
             1) If soft_label=False，the shape is 
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
             the data type is int32, int64, float32, float64. 
+
             2) If soft_label=True, the shape and data type should be same with ``input`` , 
             and the sum of the labels for each sample should be 1.
-        - **weight** (Tensor, optional): a manual rescaling weight given to each class. 
+
+        - **weight** (Tensor, optional)
+
+            a manual rescaling weight given to each class. 
             If given, has to be a Tensor of size C and the data type is float32, float64. 
             Default is ``'None'`` .
-        - **ignore_index** (int64, optional): Specifies a target value that is ignored
+
+        - **ignore_index** (int64, optional)
+
+            Specifies a target value that is ignored
             and does not contribute to the loss. A negative value means that no label 
             value needs to be ignored. Only valid when soft_label = False.  
             Default is ``-100`` .
-        - **reduction** (str, optional): Indicate how to average the loss by batch_size,
+
+        - **reduction** (str, optional)
+
+            Indicate how to average the loss by batch_size,
             the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
             If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned;
             If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned.
             If :attr:`reduction` is ``'none'``, the unreduced loss is returned.
             Default is ``'mean'``.
-        - **soft_label** (bool, optional): Indicate whether label is soft. 
+
+        - **soft_label** (bool, optional)
+
+            Indicate whether label is soft. 
             If soft_label=False, the label is hard.  If soft_label=True, the label is soft.
             Default is ``False``.
-        - **axis** (int, optional): The index of dimension to perform softmax calculations. 
+
+        - **axis** (int, optional)
+
+            The index of dimension to perform softmax calculations. 
             It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the rank of 
             input :attr:`input`. 
             Default is ``-1`` .
-        - **name** (str，optional: The name of the operator. Default is ``None`` .
+
+        - **name** (str，optional)
+
+            The name of the operator. Default is ``None`` .
             For more information, please refer to :ref:`api_guide_Name` .
 
     Returns:
-    :::::::::
+
         Tensor. Return the softmax cross_entropy loss of ``input`` and ``label``.
         The data type is the same as input.
+
         If :attr:`reduction` is ``'mean'`` or ``'sum'`` , the dimension of return value is ``1``.
+
         If :attr:`reduction` is ``'none'``:
+
         1) If soft_label = False, the dimension of return value is the same with ``label`` . 
+
         2) if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
 
 
     Examples:
-    :::::::::
 
         .. code-block:: python
 

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1146,83 +1146,160 @@ def cross_entropy(input,
     r"""
     This operator implements the cross entropy loss function with softmax. This function 
     combines the calculation of the softmax operation and the cross entropy loss function 
-    to provide a more numerically stable gradient.
-    Because this operator performs a softmax on logits internally, it expects
-    unscaled logits. This operator should not be used with the output of
-    softmax operator since that would produce incorrect results.
+    to provide a more numerically stable computing.
 
-    When the attribute :attr:`soft_label` is set :attr:`False`, this operators 
-    expects mutually exclusive hard labels, each sample in a batch is in exactly 
-    one class with a probability of 1.0. Each sample in the batch will have a 
-    single label.
+    By default, this operator will calculate the mean of the result, and you can also affect 
+    the default behavior by using the reduction parameter. Please refer to the part of 
+    parameters for details.
 
-    The equation is as follows:
+    This operator can be used to calculate the softmax cross entropy loss with soft and hard labels.
+    Where, the hard labels mean the actual label value, 0, 1, 2, etc.  And the soft labels 
+    mean the probability of the actual label, 0.6, 0.8, 0.2, etc.
 
-    1) Hard label (one-hot label, so every sample has exactly one class)
+    The calculation of this operator includes the following two steps.
 
-    .. math::
+    - ** I. softmax cross entropy **
 
-        loss_j =  -\\text{logits}_{label_j} +
-        \\log\\left(\\sum_{i=0}^{K}\\exp(\\text{logits}_i)\\right), j = 1,..., K
-
-    2) Soft label (each sample can have a distribution over all classes)
+    1. Hard label (each sample can only be assigned into one category)
 
     .. math::
+      \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
 
-        loss_j =  -\\sum_{i=0}^{K}\\text{label}_i
-        \\left(\\text{logits}_i - \\log\\left(\\sum_{i=0}^{K}
-        \\exp(\\text{logits}_i)\\right)\\right), j = 1,...,K
+    where, N is the number of samples and C is the number of categories.
 
+    2. Soft label (each sample is assigned to multiple categories with a certain probability, 
+    and the probability sum is 1).
+
+    .. math::
+      \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
+
+    where, N is the number of samples and C is the number of categories.
+
+
+    - ** II. Weight and reduction processing **
+
+    1. Weight
+
+    If the ``weight`` parameter is ``none`` , go to the next step directly.
+
+    If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+    according to soft_label = False or True as follows.
+
+    1.1. Hard labels (soft_label = False)
+
+    .. math::
+        \\loss_j=loss_j*weight[label_j] 
+
+
+    1.2. Soft labels (soft_label = True)
+
+     .. math::
+        \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
+
+    2. reduction
+
+    2.1 if the ``reduction`` parameter is ``none`` 
+
+    Return the previous result directly
+
+    2.2 if the ``reduction`` parameter is ``sum`` 
+
+    Return the sum of the previous results
+
+    .. math::
+       \\loss=\sum_{j}loss_j
+
+    2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
+    the ``weight`` parameter as follows. 
+
+    2.3.1. If the  ``weight``  parameter is ``none`` 
+
+    Return the average value of the previous results
+
+     .. math::
+        \\loss=\sum_{j}loss_j/N
+
+    where, N is the number of samples and C is the number of categories.
+
+    2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+
+    (1) Hard labels (soft_label = False)
+
+     .. math::
+        \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+
+    (2) Soft labels (soft_label = True)
+
+     .. math::
+        \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
  
-    It is useful when training a classification problem with ``C`` classes.
-
-
+ 
     Parameters:
-        input (Tensor): Input tensor, the data type is float32, float64. Shape is
-	    (N, C), where C is number of classes, and if shape is more than 2D, this
-	    is (N, D1, D2,..., Dk, C), k >= 1.
-        label (Tensor): Label tensor, the data type is int64. Shape is (N), where each
-	    value is 0 <= label[i] <= C-1, and if shape is more than 2D, this is
-	    (N, D1, D2,..., Dk), k >= 1.
-        weight (Tensor, optional):a manual rescaling weight given to each class. 
+    :::::::::
+        - **input** (Tensor): Input tensor, the data type is float32, float64. Shape is
+	    :math:`[N_1, N_2, ..., N_k, C]`, where C is number of classes ,  ``k >= 1`` . 
+            Note: it expects unscaled logits. This operator should not be used with the 
+            output of softmax operator, which will produce incorrect results.
+        - **label** (Tensor): Label tensor. 
+            1) If soft_label=False，the shape is 
+            :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
+            the data type is int32, int64, float32, float64. 
+            2) If soft_label=True, the shape and data type should be same with ``input`` , 
+            and the sum of the labels for each sample should be 1.
+        - **weight** (Tensor, optional): a manual rescaling weight given to each class. 
             If given, has to be a Tensor of size C and the data type is float32, float64. 
-            Default is ``'None'``.
-        reduction (str, optional): Indicate how to average the loss by batch_size,
+            Default is ``'None'`` .
+        - **ignore_index** (int64, optional): Specifies a target value that is ignored
+            and does not contribute to the loss. A negative value means that no label 
+            value needs to be ignored. Only valid when soft_label = False.  
+            Default is ``-100`` .
+        - **reduction** (str, optional): Indicate how to average the loss by batch_size,
             the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
             If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned;
             If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned.
             If :attr:`reduction` is ``'none'``, the unreduced loss is returned.
             Default is ``'mean'``.
-        ignore_index (int64, optional): Specifies a target value that is ignored
-            and does not contribute to the input gradient. Default is ``-100``.
-        soft_label (bool): indicate whether label is soft. Default False, meaning that
-                the label is hard. If soft_label=True, the label is soft.
-        axis (int, optional): The index of dimension to perform softmax calculations. It 
-                              should be in range :math:`[-1, rank - 1]`, while :math:`rank`
-                              is the rank of input :attr:`logits`. Default: -1.
-
+        - **soft_label** (bool, optional): Indicate whether label is soft. 
+            If soft_label=False, the label is hard.  If soft_label=True, the label is soft.
+            Default is ``False``.
+        - **axis** (int, optional): The index of dimension to perform softmax calculations. 
+            It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the rank of 
+            input :attr:`input`. 
+            Default is ``-1`` .
+        - **name** (str，optional: The name of the operator. Default is ``None`` .
+            For more information, please refer to :ref:`api_guide_Name` .
 
     Returns:
-        Tensor.The tensor storing the cross_entropy_loss of input and label.
+    :::::::::
+        Tensor. Return the softmax cross_entropy loss of ``input`` and ``label``.
+        The data type is the same as input.
+        If :attr:`reduction` is ``'mean'`` or ``'sum'`` , the dimension of return value is ``1``.
+        If :attr:`reduction` is ``'none'``:
+        1) If soft_label = False, the dimension of return value is the same with ``label`` . 
+        2) if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
 
 
     Examples:
+    :::::::::
+
         .. code-block:: python
 
             import paddle
             import numpy as np
-
+ 
             input_data = np.random.random([5, 100]).astype("float64")
             label_data = np.random.randint(0, 100, size=(5)).astype(np.int64)
             weight_data = np.random.random([100]).astype("float64")
-
+ 
             input =  paddle.to_tensor(input_data)
             label =  paddle.to_tensor(label_data)
             weight = paddle.to_tensor(weight_data)
-
+ 
             loss = paddle.nn.functional.cross_entropy(input=input, label=label, weight=weight)
             print(loss)
             # [4.28546723]
+ 
+
     """
 
     if reduction not in ['sum', 'mean', 'none']:

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1329,7 +1329,7 @@ def cross_entropy(input,
 
 
 
-    Example1(soft labels):
+    Example2(soft labels):
 
         .. code-block:: python
             

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1114,7 +1114,7 @@ def ctc_loss(log_probs,
 
 
 @deprecated(since="2.0.0", update_to="paddle.nn.functional.cross_entropy")
-def softmax_with_cross_entropy(logits,
+def test_softmax_with_cross_entropy(logits,
                                label,
                                soft_label=False,
                                ignore_index=-100,

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1170,9 +1170,9 @@ def cross_entropy(input,
 
         1. Weight
 
-            If the ``weight`` parameter is ``none`` , go to the next step directly.
+            If the ``weight`` parameter is ``None`` , go to the next step directly.
 
-            If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+            If the ``weight`` parameter is not ``None`` , the cross entropy of each sample is weighted by weight
             according to soft_label = False or True as follows.
 
             1.1. Hard labels (soft_label = False)
@@ -1202,7 +1202,7 @@ def cross_entropy(input,
             2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
             the ``weight`` parameter as follows. 
 
-            2.3.1. If the  ``weight``  parameter is ``none`` 
+            2.3.1. If the  ``weight``  parameter is ``None`` 
 
                    Return the average value of the previous results
 
@@ -1211,14 +1211,14 @@ def cross_entropy(input,
 
                   where, N is the number of samples and C is the number of categories.
 
-            2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+            2.3.2. If the 'weight' parameter is not 'None', the weighted average value of the previous result will be returned
 
-            (1) Hard labels (soft_label = False)
+            1. Hard labels (soft_label = False)
 
              .. math::
                 \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
 
-            (2) Soft labels (soft_label = True)
+            2. Soft labels (soft_label = True)
 
              .. math::
                 \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
@@ -1235,11 +1235,11 @@ def cross_entropy(input,
 
         - **label** (Tensor)
 
-            1) If soft_label=False，the shape is 
+            1. If soft_label=False，the shape is 
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
             the data type is int32, int64, float32, float64. 
 
-            2) If soft_label=True, the shape and data type should be same with ``input`` , 
+            2. If soft_label=True, the shape and data type should be same with ``input`` , 
             and the sum of the labels for each sample should be 1.
 
         - **weight** (Tensor, optional)
@@ -1296,9 +1296,9 @@ def cross_entropy(input,
 
         If :attr:`reduction` is ``'none'``:
 
-        1) If soft_label = False, the dimension of return value is the same with ``label`` . 
+        1. If soft_label = False, the dimension of return value is the same with ``label`` . 
 
-        2) if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
+        2. if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
 
 
      Example1(hard labels):
@@ -1345,7 +1345,6 @@ def cross_entropy(input,
             labels = np.random.uniform(0.1, 1.0, shape).astype(dtype)
             labels /= np.sum(labels, axis=axis, keepdims=True)
             paddle.set_device("cpu")
-            paddle.disable_static()
             paddle_loss_mean = paddle.nn.functional.cross_entropy(
                                                                  paddle.to_tensor(logits),  
                                                                  paddle.to_tensor(labels), 

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1158,80 +1158,80 @@ def cross_entropy(input,
 
     The calculation of this operator includes the following two steps.
 
-    - ** I. softmax cross entropy **
+    - **I.softmax cross entropy**
 
-    1. Hard label (each sample can only be assigned into one category)
+        1. Hard label (each sample can only be assigned into one category)
 
-    .. math::
-      \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
+        .. math::
+          \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
 
-    where, N is the number of samples and C is the number of categories.
+        where, N is the number of samples and C is the number of categories.
 
-    2. Soft label (each sample is assigned to multiple categories with a certain probability, 
-    and the probability sum is 1).
+        2. Soft label (each sample is assigned to multiple categories with a certain probability, 
+        and the probability sum is 1).
 
-    .. math::
-      \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
+        .. math::
+          \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
 
-    where, N is the number of samples and C is the number of categories.
-
-
-    - ** II. Weight and reduction processing **
-
-    1. Weight
-
-    If the ``weight`` parameter is ``none`` , go to the next step directly.
-
-    If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
-    according to soft_label = False or True as follows.
-
-    1.1. Hard labels (soft_label = False)
-
-    .. math::
-        \\loss_j=loss_j*weight[label_j] 
+        where, N is the number of samples and C is the number of categories.
 
 
-    1.2. Soft labels (soft_label = True)
+    - **II. Weight and reduction processing**
 
-     .. math::
-        \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
+        1. Weight
 
-    2. reduction
+        If the ``weight`` parameter is ``none`` , go to the next step directly.
 
-    2.1 if the ``reduction`` parameter is ``none`` 
+        If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+        according to soft_label = False or True as follows.
 
-    Return the previous result directly
+        1.1. Hard labels (soft_label = False)
 
-    2.2 if the ``reduction`` parameter is ``sum`` 
+        .. math::
+            \\loss_j=loss_j*weight[label_j] 
 
-    Return the sum of the previous results
 
-    .. math::
-       \\loss=\sum_{j}loss_j
+        1.2. Soft labels (soft_label = True)
 
-    2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
-    the ``weight`` parameter as follows. 
+         .. math::
+            \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
 
-    2.3.1. If the  ``weight``  parameter is ``none`` 
+        2. reduction
 
-    Return the average value of the previous results
+        2.1 if the ``reduction`` parameter is ``none`` 
 
-     .. math::
-        \\loss=\sum_{j}loss_j/N
+            Return the previous result directly
 
-    where, N is the number of samples and C is the number of categories.
+        2.2 if the ``reduction`` parameter is ``sum`` 
 
-    2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+            Return the sum of the previous results
 
-    (1) Hard labels (soft_label = False)
+        .. math::
+           \\loss=\sum_{j}loss_j
 
-     .. math::
-        \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+        2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
+        the ``weight`` parameter as follows. 
 
-    (2) Soft labels (soft_label = True)
+        2.3.1. If the  ``weight``  parameter is ``none`` 
 
-     .. math::
-        \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
+               Return the average value of the previous results
+
+         .. math::
+            \\loss=\sum_{j}loss_j/N
+
+              where, N is the number of samples and C is the number of categories.
+
+        2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+
+        (1) Hard labels (soft_label = False)
+
+         .. math::
+            \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+
+        (2) Soft labels (soft_label = True)
+
+         .. math::
+            \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
  
  
     Parameters:

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1302,8 +1302,8 @@ def cross_entropy(input,
         - **axis** (int, optional)
 
             The index of dimension to perform softmax calculations. 
-            It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the rank of 
-            input :attr:`input`. 
+            It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the 
+            number of dimensions of input :attr:`input`. 
             Default is ``-1`` .
 
         - **use_softmax** (bool, optional)
@@ -1335,7 +1335,6 @@ def cross_entropy(input,
         .. code-block:: python
             
             import paddle
-            import numpy as np
             paddle.seed(99999)
             N=100
             C=200
@@ -1357,7 +1356,7 @@ def cross_entropy(input,
         .. code-block:: python
             
             import paddle
-            import numpy as np
+            paddle.seed(99999)
             axis = -1
             ignore_index = -100
             N = 4
@@ -1365,10 +1364,9 @@ def cross_entropy(input,
             shape = [N, C]
             reduction='mean'
             weight = None
-            logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0, seed=99999)
-            labels = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0, seed=99999)
+            logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0)
+            labels = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0)
             labels /= paddle.sum(labels, axis=axis, keepdim=True)
-            paddle.set_device("cpu")
             paddle_loss_mean = paddle.nn.functional.cross_entropy(
                                                                   logits,  
                                                                   labels, 
@@ -1376,7 +1374,7 @@ def cross_entropy(input,
                                                                   axis=axis,
                                                                   weight=weight,
                                                                   reduction=reduction)
-            print(paddle_loss_mean.numpy()) #[1.05313515]
+            print(paddle_loss_mean.numpy()) #[1.12908343]
 
     """
 

--- a/python/paddle/nn/functional/loss.py
+++ b/python/paddle/nn/functional/loss.py
@@ -1296,7 +1296,6 @@ def cross_entropy(input,
         - **soft_label** (bool, optional)
 
             Indicate whether label is soft. 
-            If soft_label=False, the label is hard.  If soft_label=True, the label is soft.
             Default is ``False``.
 
         - **axis** (int, optional)

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -142,9 +142,11 @@ class BCEWithLogitsLoss(fluid.dygraph.Layer):
 
 class CrossEntropyLoss(fluid.dygraph.Layer):
     r"""
-    This operator implements the cross entropy loss function with softmax. This function 
+    By default, this operator implements the cross entropy loss function with softmax. This function 
     combines the calculation of the softmax operation and the cross entropy loss function 
     to provide a more numerically stable computing.
+
+    This operator will calculate the cross entropy loss function without softmax when use_softmax=False.
 
     By default, this operator will calculate the mean of the result, and you can also affect 
     the default behavior by using the reduction parameter. Please refer to the part of 
@@ -160,18 +162,37 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
         1. Hard label (each sample can only be assigned into one category)
 
+        1.1. when use_softmax=True
+
             .. math::
               \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
 
             where, N is the number of samples and C is the number of categories.
 
-        2. Soft label (each sample is assigned to multiple categories with a certain probability, 
-        and the probability sum is 1).
+        1.2. when use_softmax=False
+
+            .. math::
+              \\loss_j=-\log\left({P}_{label_j}\right) , j = 1,...,N
+
+            where, N is the number of samples and C is the number of categories, P is input(the output of softmax).
+
+
+        2. Soft label (each sample is assigned to multiple categories with a certain probability, and the probability sum is 1).
+
+        2.1. when use_softmax=True
 
             .. math::
               \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
 
             where, N is the number of samples and C is the number of categories.
+
+        2.2. when use_softmax=False
+
+            .. math::
+              \\loss_j=-\sum_{j=0}^{C}\left({label}_j*\log\left({P}_{label_j}\right)\right) , j = 1,...,N
+
+            where, N is the number of samples and C is the number of categories, P is input(the output of softmax).
+
 
 
     -  **II.Weight and reduction processing** 
@@ -286,14 +307,20 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
             Input tensor, the data type is float32, float64. Shape is
 	    :math:`[N_1, N_2, ..., N_k, C]`, where C is number of classes ,  ``k >= 1`` . 
-            Note: it expects unscaled logits. This operator should not be used with the 
-            output of softmax operator, which will produce incorrect results.
+
+            Note: 
+
+                1. when use_softmax=True, it expects unscaled logits. This operator should not be used with the 
+                output of softmax operator, which will produce incorrect results.
+
+                2. when use_softmax=False, it expects the output of softmax operator.
+ 
 
         - **label** (Tensor)
 
             1. If soft_label=False，the shape is 
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
-            the data type is int32, int64, float32, float64. 
+            the data type is int32, int64, float32, float64, where each value is [0, C-1].
 
             2. If soft_label=True, the shape and data type should be same with ``input`` , 
             and the sum of the labels for each sample should be 1.

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -286,8 +286,8 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
         - **axis** (int, optional)
 
             The index of dimension to perform softmax calculations. 
-            It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the rank of 
-            input :attr:`input`. 
+            It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the number 
+            of dimensions of input :attr:`input`. 
             Default is ``-1`` .
 
         - **use_softmax** (bool, optional)
@@ -344,7 +344,6 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
         .. code-block:: python
             
             import paddle
-            import numpy as np
             paddle.seed(99999)
             N=100
             C=200
@@ -366,7 +365,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
         .. code-block:: python
             
             import paddle
-            import numpy as np
+            paddle.seed(99999)
             axis = -1
             ignore_index = -100
             N = 4
@@ -374,10 +373,9 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             shape = [N, C]
             reduction='mean'
             weight = None
-            logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0, seed=99999)
-            labels = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0, seed=99999)
+            logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0)
+            labels = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0)
             labels /= paddle.sum(labels, axis=axis, keepdim=True)
-            paddle.set_device("cpu")
             paddle_loss_mean = paddle.nn.functional.cross_entropy(
                                                                   logits,  
                                                                   labels, 
@@ -385,7 +383,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
                                                                   axis=axis,
                                                                   weight=weight,
                                                                   reduction=reduction)
-            print(paddle_loss_mean.numpy()) #[1.05313515]
+            print(paddle_loss_mean.numpy()) #[1.12908343]
 
     """
 

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -334,6 +334,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
                  reduction='mean',
                  soft_label=False,
                  axis=-1,
+                 softmax_switch=True,
                  name=None):
         super(CrossEntropyLoss, self).__init__()
         self.weight = weight
@@ -341,6 +342,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
         self.ignore_index = ignore_index
         self.soft_label = soft_label
         self.axis = axis
+        self.softmax_switch = softmax_switch
         self.name = name
 
     def forward(self, input, label):
@@ -352,6 +354,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             reduction=self.reduction,
             soft_label=self.soft_label,
             axis=self.axis,
+            softmax_switch=self.softmax_switch,
             name=self.name)
 
         return ret

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -161,76 +161,76 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
         1. Hard label (each sample can only be assigned into one category)
 
-        .. math::
-          \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
+            .. math::
+              \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
 
-        where, N is the number of samples and C is the number of categories.
+            where, N is the number of samples and C is the number of categories.
 
         2. Soft label (each sample is assigned to multiple categories with a certain probability, 
         and the probability sum is 1).
 
-        .. math::
-          \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
+            .. math::
+              \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
 
-        where, N is the number of samples and C is the number of categories.
+            where, N is the number of samples and C is the number of categories.
 
 
     -  **II.Weight and reduction processing** 
 
         1. Weight
 
-        If the ``weight`` parameter is ``none`` , go to the next step directly.
+            If the ``weight`` parameter is ``none`` , go to the next step directly.
 
-        If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
-        according to soft_label = False or True as follows.
+            If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+            according to soft_label = False or True as follows.
 
-        1.1. Hard labels (soft_label = False)
+            1.1. Hard labels (soft_label = False)
 
-        .. math::
-            \\loss_j=loss_j*weight[label_j] 
+            .. math::
+                \\loss_j=loss_j*weight[label_j] 
 
 
-        1.2. Soft labels (soft_label = True)
+            1.2. Soft labels (soft_label = True)
 
-         .. math::
-            \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
+             .. math::
+                \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
 
         2. reduction
 
-        2.1 if the ``reduction`` parameter is ``none`` 
+            2.1 if the ``reduction`` parameter is ``none`` 
 
-        Return the previous result directly
+            Return the previous result directly
 
-        2.2 if the ``reduction`` parameter is ``sum`` 
+            2.2 if the ``reduction`` parameter is ``sum`` 
 
-        Return the sum of the previous results
+            Return the sum of the previous results
 
-        .. math::
-           \\loss=\sum_{j}loss_j
+            .. math::
+               \\loss=\sum_{j}loss_j
 
-        2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
-        the ``weight`` parameter as follows. 
+            2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
+            the ``weight`` parameter as follows. 
 
-        2.3.1. If the  ``weight``  parameter is ``none`` 
+            2.3.1. If the  ``weight``  parameter is ``none`` 
 
-        Return the average value of the previous results
+            Return the average value of the previous results
 
-         .. math::
-            \\loss=\sum_{j}loss_j/N
+             .. math::
+                \\loss=\sum_{j}loss_j/N
 
-        where, N is the number of samples and C is the number of categories.
+            where, N is the number of samples and C is the number of categories.
 
-        2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+            2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
 
-        (1) Hard labels (soft_label = False)
+            (1) Hard labels (soft_label = False)
 
-         .. math::
-            \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+             .. math::
+                \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
 
-        (2) Soft labels (soft_label = True)
+            (2) Soft labels (soft_label = True)
 
-         .. math::
-            \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
+             .. math::
+                \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
  
  
     Parameters:

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -177,9 +177,9 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
         1. Weight
 
-            If the ``weight`` parameter is ``none`` , go to the next step directly.
+            If the ``weight`` parameter is ``None`` , go to the next step directly.
 
-            If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+            If the ``weight`` parameter is not ``None`` , the cross entropy of each sample is weighted by weight
             according to soft_label = False or True as follows.
 
             1.1. Hard labels (soft_label = False)
@@ -209,7 +209,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
             the ``weight`` parameter as follows. 
 
-            2.3.1. If the  ``weight``  parameter is ``none`` 
+            2.3.1. If the  ``weight``  parameter is ``None`` 
 
             Return the average value of the previous results
 
@@ -218,14 +218,14 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
             where, N is the number of samples and C is the number of categories.
 
-            2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+            2.3.2. If the 'weight' parameter is not 'None', the weighted average value of the previous result will be returned
 
-            (1) Hard labels (soft_label = False)
+            1. Hard labels (soft_label = False)
 
              .. math::
                 \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
 
-            (2) Soft labels (soft_label = True)
+            2. Soft labels (soft_label = True)
 
              .. math::
                 \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
@@ -290,11 +290,11 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
         - **label** (Tensor)
 
-            1) If soft_label=False，the shape is 
+            1. If soft_label=False，the shape is 
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
             the data type is int32, int64, float32, float64. 
 
-            2) If soft_label=True, the shape and data type should be same with ``input`` , 
+            2. If soft_label=True, the shape and data type should be same with ``input`` , 
             and the sum of the labels for each sample should be 1.
  
         - **output** (Tensor)
@@ -307,9 +307,9 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
             If :attr:`reduction` is ``'none'``:
 
-            1) If soft_label = False, the dimension of return value is the same with ``label`` . 
+            1. If soft_label = False, the dimension of return value is the same with ``label`` . 
 
-            2) if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
+            2. if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
 
 
     Example1(hard labels):

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -157,80 +157,80 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
     The calculation of this operator includes the following two steps.
 
-    -  I. softmax cross entropy 
+    -  **I.softmax cross entropy** 
 
-    1. Hard label (each sample can only be assigned into one category)
+        1. Hard label (each sample can only be assigned into one category)
 
-    .. math::
-      \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
+        .. math::
+          \\loss_j=-\text{logits}_{label_j}+\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right) , j = 1,...,N
 
-    where, N is the number of samples and C is the number of categories.
+        where, N is the number of samples and C is the number of categories.
 
-    2. Soft label (each sample is assigned to multiple categories with a certain probability, 
-    and the probability sum is 1).
+        2. Soft label (each sample is assigned to multiple categories with a certain probability, 
+        and the probability sum is 1).
 
-    .. math::
-      \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
+        .. math::
+          \\loss_j=-\sum_{i=0}^{C}\text{label}_i\left(\text{logits}_i-\log\left(\sum_{i=0}^{C}\exp(\text{logits}_i)\right)\right) , j = 1,...,N
 
-    where, N is the number of samples and C is the number of categories.
-
-
-    -  II. Weight and reduction processing 
-
-    1. Weight
-
-    If the ``weight`` parameter is ``none`` , go to the next step directly.
-
-    If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
-    according to soft_label = False or True as follows.
-
-    1.1. Hard labels (soft_label = False)
-
-    .. math::
-        \\loss_j=loss_j*weight[label_j] 
+        where, N is the number of samples and C is the number of categories.
 
 
-    1.2. Soft labels (soft_label = True)
+    -  **II.Weight and reduction processing** 
 
-     .. math::
-        \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
+        1. Weight
 
-    2. reduction
+        If the ``weight`` parameter is ``none`` , go to the next step directly.
 
-    2.1 if the ``reduction`` parameter is ``none`` 
+        If the ``weight`` parameter is not ``none`` , the cross entropy of each sample is weighted by weight
+        according to soft_label = False or True as follows.
 
-    Return the previous result directly
+        1.1. Hard labels (soft_label = False)
 
-    2.2 if the ``reduction`` parameter is ``sum`` 
+        .. math::
+            \\loss_j=loss_j*weight[label_j] 
 
-    Return the sum of the previous results
 
-    .. math::
-       \\loss=\sum_{j}loss_j
+        1.2. Soft labels (soft_label = True)
 
-    2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
-    the ``weight`` parameter as follows. 
+         .. math::
+            \\loss_j=loss_j*\sum_{i}\left(weight[label_i]*logits_i\right)
 
-    2.3.1. If the  ``weight``  parameter is ``none`` 
+        2. reduction
 
-    Return the average value of the previous results
+        2.1 if the ``reduction`` parameter is ``none`` 
 
-     .. math::
-        \\loss=\sum_{j}loss_j/N
+        Return the previous result directly
 
-    where, N is the number of samples and C is the number of categories.
+        2.2 if the ``reduction`` parameter is ``sum`` 
 
-    2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+        Return the sum of the previous results
 
-    (1) Hard labels (soft_label = False)
+        .. math::
+           \\loss=\sum_{j}loss_j
 
-     .. math::
-        \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+        2.3 if the ``reduction`` parameter is ``mean`` , it will be processed according to 
+        the ``weight`` parameter as follows. 
 
-    (2) Soft labels (soft_label = True)
+        2.3.1. If the  ``weight``  parameter is ``none`` 
 
-     .. math::
-        \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
+        Return the average value of the previous results
+
+         .. math::
+            \\loss=\sum_{j}loss_j/N
+
+        where, N is the number of samples and C is the number of categories.
+
+        2.3.2. If the 'weight' parameter is not 'none', the weighted average value of the previous result will be returned
+
+        (1) Hard labels (soft_label = False)
+
+         .. math::
+            \\loss=\sum_{j}loss_j/\sum_{j}weight[label_j] 
+
+        (2) Soft labels (soft_label = True)
+
+         .. math::
+            \\loss=\sum_{j}loss_j/\sum_{j}\left(\sum_{i}weight[label_i]\right)
  
  
     Parameters:
@@ -274,6 +274,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
             The name of the operator. Default is ``None`` .
             For more information, please refer to :ref:`api_guide_Name` .
+
 
     Shape:
 

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*
 #   Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -311,28 +312,26 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
             2. if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
 
-
-    Example1(hard labels):
+     Example1(hard labels):
 
         .. code-block:: python
             
             import paddle
             import numpy as np
-            np.random.seed(99999)
+            paddle.seed(99999)
             N=100
             C=200
             reduction='mean'
-            input_np = np.random.random([N, C]).astype(np.float64)  
-            label_np = np.random.randint(0, C, size=(N)).astype(np.int64)  
-            weight_np = np.random.random([C]).astype(np.float64)  
+            input =  paddle.rand([N, C], dtype='float64')  
+            label =  paddle.randint(0, C, shape=[N], dtype='int64')
+            weight = paddle.rand([C], dtype='float64') 
             
             cross_entropy_loss = paddle.nn.loss.CrossEntropyLoss(
-                weight=paddle.to_tensor(weight_np), reduction=reduction)
+                weight=weight, reduction=reduction)
             dy_ret = cross_entropy_loss(
-                paddle.to_tensor(input_np),
-                paddle.to_tensor(label_np))
-            print(dy_ret.numpy()) #[5.37996124]
-
+                                       input,
+                                       label)
+            print(dy_ret.numpy()) #[5.41993642]
 
 
     Example2(soft labels):
@@ -341,30 +340,25 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             
             import paddle
             import numpy as np
-            np.random.seed(99999)
-            soft_label = True
-            dtype = np.float64
             axis = -1
-            ignore_index = -100 #should not be changed
+            ignore_index = -100
             N = 4
             C = 3
             shape = [N, C]
-            use_softmax = True
             reduction='mean'
             weight = None
-            logits = np.random.uniform(0.1, 1.0, shape).astype(dtype)
-            labels = np.random.uniform(0.1, 1.0, shape).astype(dtype)
-            labels /= np.sum(labels, axis=axis, keepdims=True)
+            logits = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0, seed=99999)
+            labels = paddle.uniform(shape, dtype='float64', min=0.1, max=1.0, seed=99999)
+            labels /= paddle.sum(labels, axis=axis, keepdim=True)
             paddle.set_device("cpu")
             paddle_loss_mean = paddle.nn.functional.cross_entropy(
-                                                                 paddle.to_tensor(logits),  
-                                                                 paddle.to_tensor(labels), 
-                                                                 soft_label=True, 
-                                                                 axis=axis,
-                                                                 weight=weight,
-                                                                 reduction=reduction)
-            print("paddle_loss_mean:",paddle_loss_mean.numpy()) #[1.11473992]
-
+                                                                  logits,  
+                                                                  labels, 
+                                                                  soft_label=True, 
+                                                                  axis=axis,
+                                                                  weight=weight,
+                                                                  reduction=reduction)
+            print(paddle_loss_mean.numpy()) #[1.05313515]
 
     """
 

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -108,7 +108,6 @@ class BCEWithLogitsLoss(fluid.dygraph.Layer):
 
         .. code-block:: python
             import paddle
-            paddle.disable_static()
             logit = paddle.to_tensor([5.0, 1.0, 3.0], dtype="float32")
             label = paddle.to_tensor([1.0, 0.0, 1.0], dtype="float32")
             bce_logit_loss = paddle.nn.BCEWithLogitsLoss()
@@ -141,7 +140,6 @@ class BCEWithLogitsLoss(fluid.dygraph.Layer):
 
 
 class CrossEntropyLoss(fluid.dygraph.Layer):
-
     r"""
     This operator implements the cross entropy loss function with softmax. This function 
     combines the calculation of the softmax operation and the cross entropy loss function 
@@ -358,7 +356,6 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             labels = np.random.uniform(0.1, 1.0, shape).astype(dtype)
             labels /= np.sum(labels, axis=axis, keepdims=True)
             paddle.set_device("cpu")
-            paddle.disable_static()
             paddle_loss_mean = paddle.nn.functional.cross_entropy(
                                                                  paddle.to_tensor(logits),  
                                                                  paddle.to_tensor(labels), 

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -337,7 +337,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
 
 
-    Example1(soft labels):
+    Example2(soft labels):
 
         .. code-block:: python
             

--- a/python/paddle/nn/layer/loss.py
+++ b/python/paddle/nn/layer/loss.py
@@ -157,7 +157,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
 
     The calculation of this operator includes the following two steps.
 
-    - ** I. softmax cross entropy **
+    -  I. softmax cross entropy 
 
     1. Hard label (each sample can only be assigned into one category)
 
@@ -175,7 +175,7 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
     where, N is the number of samples and C is the number of categories.
 
 
-    - ** II. Weight and reduction processing **
+    -  II. Weight and reduction processing 
 
     1. Weight
 
@@ -234,45 +234,57 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
  
  
     Parameters:
-    :::::::::
 
-        - **weight** (Tensor, optional): a manual rescaling weight given to each class. 
+        - **weight** (Tensor, optional)
+
+            a manual rescaling weight given to each class. 
             If given, has to be a Tensor of size C and the data type is float32, float64. 
             Default is ``'None'`` .
 
-        - **ignore_index** (int64, optional): Specifies a target value that is ignored
+        - **ignore_index** (int64, optional)
+
+            Specifies a target value that is ignored
             and does not contribute to the loss. A negative value means that no label 
             value needs to be ignored. Only valid when soft_label = False.  
             Default is ``-100`` .
 
-        - **reduction** (str, optional): Indicate how to average the loss by batch_size,
+        - **reduction** (str, optional)
+
+            Indicate how to average the loss by batch_size,
             the candicates are ``'none'`` | ``'mean'`` | ``'sum'``.
             If :attr:`reduction` is ``'mean'``, the reduced mean loss is returned;
             If :attr:`size_average` is ``'sum'``, the reduced sum loss is returned.
             If :attr:`reduction` is ``'none'``, the unreduced loss is returned.
             Default is ``'mean'``.
 
-        - **soft_label** (bool, optional): Indicate whether label is soft. 
+        - **soft_label** (bool, optional)
+
+            Indicate whether label is soft. 
             If soft_label=False, the label is hard.  If soft_label=True, the label is soft.
             Default is ``False``.
 
-        - **axis** (int, optional): The index of dimension to perform softmax calculations. 
+        - **axis** (int, optional)
+
+            The index of dimension to perform softmax calculations. 
             It should be in range :math:`[-1, rank - 1]`, where :math:`rank` is the rank of 
             input :attr:`input`. 
             Default is ``-1`` .
 
-        - **name** (str，optional: The name of the operator. Default is ``None`` .
+        - **name** (str，optional)
+
+            The name of the operator. Default is ``None`` .
             For more information, please refer to :ref:`api_guide_Name` .
 
     Shape:
-    :::::::::
 
-        - **input** (Tensor): Input tensor, the data type is float32, float64. Shape is
+        - **input** (Tensor)
+
+            Input tensor, the data type is float32, float64. Shape is
 	    :math:`[N_1, N_2, ..., N_k, C]`, where C is number of classes ,  ``k >= 1`` . 
             Note: it expects unscaled logits. This operator should not be used with the 
             output of softmax operator, which will produce incorrect results.
 
-        - **label** (Tensor): Label tensor. 
+        - **label** (Tensor)
 
             1) If soft_label=False，the shape is 
             :math:`[N_1, N_2, ..., N_k]` or :math:`[N_1, N_2, ..., N_k, 1]`, k >= 1.
@@ -281,21 +293,22 @@ class CrossEntropyLoss(fluid.dygraph.Layer):
             2) If soft_label=True, the shape and data type should be same with ``input`` , 
             and the sum of the labels for each sample should be 1.
  
-        - **output** (Tensor): - Return the softmax cross_entropy loss of ``input`` and ``label``.
+        - **output** (Tensor)
 
-                             The data type is the same as input.
+            Return the softmax cross_entropy loss of ``input`` and ``label``.
 
-                             If :attr:`reduction` is ``'mean'`` or ``'sum'`` , the dimension of return value is ``1``.
+            The data type is the same as input.
 
-                             If :attr:`reduction` is ``'none'``:
+            If :attr:`reduction` is ``'mean'`` or ``'sum'`` , the dimension of return value is ``1``.
 
-                             1) If soft_label = False, the dimension of return value is the same with ``label`` . 
+            If :attr:`reduction` is ``'none'``:
 
-                             2) if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
+            1) If soft_label = False, the dimension of return value is the same with ``label`` . 
+
+            2) if soft_label = True, the dimension of return value is :math:`[N_1, N_2, ..., N_k, 1]` . 
 
 
     Example:
-    :::::::::
 
         .. code-block:: python
             


### PR DESCRIPTION
### PR types
Function optimization

### PR changes
APIs

### Describe
1、softmax_with_cross_entropy是历史原因保留的api，2.0下并不推荐用户使用，所以增加打印deprecated警告
2、完善nn/functional/loss.py中cross_entropy的英文文档
3、完善nn/layer/loss.py中CrossEntropyLoss的英文文档
4、修复softlabel为true，并指定weight参数时cross_entropy报错问题
5、python端加开关softmax_switch