### PR TITLE
support minus-int idx to LayerList

### DIFF
--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections import OrderedDict
+import operator
 from ..framework import Parameter
 from .layers import Layer
 
@@ -214,7 +215,10 @@ class LayerList(Layer):
                 self.add_sublayer(str(idx), layer)
 
     def _get_abs_idx(self, idx):
-        if isinstance(idx, int) and idx < 0:
+        idx = operator.index(idx)
+        if not (-len(self) <= idx < len(self)):
+            raise IndexError('index {} is out of range'.format(idx))
+        if idx < 0:
             idx += len(self)
         return idx
 

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from collections import OrderedDict
-import operator
 from ..framework import Parameter
 from .layers import Layer
 
@@ -215,11 +214,11 @@ class LayerList(Layer):
                 self.add_sublayer(str(idx), layer)
 
     def _get_abs_idx(self, idx):
-        idx = operator.index(idx)
-        if not (-len(self) <= idx < len(self)):
-            raise IndexError('index {} is out of range'.format(idx))
-        if idx < 0:
-            idx += len(self)
+        if isinstance(idx, int):
+            if not (-len(self) <= idx < len(self)):
+                raise IndexError('index {} is out of range'.format(idx))
+            if idx < 0:
+                idx += len(self)
         return idx
 
     def __getitem__(self, idx):

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -216,7 +216,9 @@ class LayerList(Layer):
     def _get_abs_idx(self, idx):
         if isinstance(idx, int):
             if not (-len(self) <= idx < len(self)):
-                raise IndexError('index {} is out of range'.format(idx))
+                raise IndexError(
+                    'index {} is out of range, should be an integer in range [{}, {})'.
+                    format(idx, -len(self), len(self)))
             if idx < 0:
                 idx += len(self)
         return idx
@@ -286,10 +288,15 @@ class LayerList(Layer):
                 another = paddle.nn.Linear(10, 10)
                 linears.insert(3, another)
                 print(linears[3] is another)  # True
+                another = paddle.nn.Linear(10, 10)
+                linears.insert(-1, another)
+                print(linears[-2] is another) # True
         """
         assert isinstance(index, int) and \
-               0 <= index < len(self._sub_layers), \
-            "index should be an integer in range [0, len(self))"
+               -len(self._sub_layers) <= index < len(self._sub_layers), \
+            "index should be an integer in range [{}, {})".format(-len(self), len(self))
+
+        index = self._get_abs_idx(index)
         for i in range(len(self._sub_layers), index, -1):
             self._sub_layers[str(i)] = self._sub_layers[str(i - 1)]
         self._sub_layers[str(index)] = sublayer

--- a/python/paddle/fluid/dygraph/container.py
+++ b/python/paddle/fluid/dygraph/container.py
@@ -213,13 +213,20 @@ class LayerList(Layer):
             for idx, layer in enumerate(sublayers):
                 self.add_sublayer(str(idx), layer)
 
+    def _get_abs_idx(self, idx):
+        if isinstance(idx, int) and idx < 0:
+            idx += len(self)
+        return idx
+
     def __getitem__(self, idx):
         if isinstance(idx, slice):
             return self.__class__(list(self._sub_layers.values())[idx])
         else:
+            idx = self._get_abs_idx(idx)
             return self._sub_layers[str(idx)]
 
     def __setitem__(self, idx, sublayer):
+        idx = self._get_abs_idx(idx)
         return setattr(self, str(idx), sublayer)
 
     def __delitem__(self, idx):
@@ -227,6 +234,7 @@ class LayerList(Layer):
             for k in range(len(self._sub_layers))[idx]:
                 delattr(self, str(k))
         else:
+            idx = self._get_abs_idx(idx)
             delattr(self, str(idx))
         str_indices = [str(i) for i in range(len(self._sub_layers))]
         self._sub_layers = OrderedDict(

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -85,12 +85,12 @@ class TestImperativeContainer(unittest.TestCase):
             res8.backward()
 
             model4 = MyLayer(layerlist)
-            model4.layerlist[-1] = fluid.dygraph.Linear(2**(size - 1), 5)
+            model4.layerlist[-1] = fluid.dygraph.Linear(3, 5)
             res9 = model4(x)
             self.assertListEqual(res9.shape, [5, 5])
             del model4.layerlist[-1]
             res10 = model4(x)
-            self.assertListEqual(res10.shape, [5, 2**(size - 1)])
+            self.assertListEqual(res10.shape, [5, 3])
             res10.backward()
 
     def test_layer_list(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -90,7 +90,7 @@ class TestImperativeContainer(unittest.TestCase):
             self.assertListEqual(res9.shape, [5, 5])
             del model4.layerlist[-1]
             res10 = model4(x)
-            self.assertListEqual(res3.shape, [5, 2**(size - 1)])
+            self.assertListEqual(res10.shape, [5, 2**(size - 1)])
             res10.backward()
 
     def test_layer_list(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -84,6 +84,15 @@ class TestImperativeContainer(unittest.TestCase):
             self.assertListEqual(res8.shape, [5, 3**3])
             res8.backward()
 
+            model4 = MyLayer(layerlist)
+            model4.layerlist[-1] = fluid.dygraph.Linear(2**(size - 1), 5)
+            res9 = model4(x)
+            self.assertListEqual(res9.shape, [5, 5])
+            del model4.layerlist[-1]
+            res10 = model4(x)
+            self.assertListEqual(res3.shape, [5, 2**(size - 1)])
+            res10.backward()
+
     def test_layer_list(self):
         self.layer_list(True)
         self.layer_list(False)

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -85,12 +85,12 @@ class TestImperativeContainer(unittest.TestCase):
             res8.backward()
 
             model4 = MyLayer(layerlist[:2])
-            model4.layerlist[-1] = fluid.dygraph.Linear(3, 5)
+            model4.layerlist[-1] = fluid.dygraph.Linear(4, 5)
             res9 = model4(x)
             self.assertListEqual(res9.shape, [5, 5])
             del model4.layerlist[-1]
             res10 = model4(x)
-            self.assertListEqual(res10.shape, [5, 3])
+            self.assertListEqual(res10.shape, [5, 4])
             res10.backward()
 
     def test_layer_list(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -85,12 +85,12 @@ class TestImperativeContainer(unittest.TestCase):
             res8.backward()
 
             model4 = MyLayer(layerlist[:2])
-            model4.layerlist[-1] = fluid.dygraph.Linear(4, 5)
+            model4.layerlist[-1] = fluid.dygraph.Linear(2, 5)
             res9 = model4(x)
             self.assertListEqual(res9.shape, [5, 5])
             del model4.layerlist[-1]
             res10 = model4(x)
-            self.assertListEqual(res10.shape, [5, 4])
+            self.assertListEqual(res10.shape, [5, 2])
             res10.backward()
 
     def test_layer_list(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -93,7 +93,7 @@ class TestImperativeContainer(unittest.TestCase):
             self.assertListEqual(res10.shape, [5, 4])
             model4.layerlist.insert(-1, fluid.dygraph.Linear(2, 2))
             res11 = model4(x)
-            self.assertListEqual(res10.shape, [5, 4])
+            self.assertListEqual(res11.shape, [5, 4])
             res11.backward()
 
     def test_layer_list(self):

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -84,14 +84,17 @@ class TestImperativeContainer(unittest.TestCase):
             self.assertListEqual(res8.shape, [5, 3**3])
             res8.backward()
 
-            model4 = MyLayer(layerlist[:2])
-            model4.layerlist[-1] = fluid.dygraph.Linear(2, 5)
+            model4 = MyLayer(layerlist[:3])
+            model4.layerlist[-1] = fluid.dygraph.Linear(4, 5)
             res9 = model4(x)
             self.assertListEqual(res9.shape, [5, 5])
             del model4.layerlist[-1]
             res10 = model4(x)
-            self.assertListEqual(res10.shape, [5, 2])
-            res10.backward()
+            self.assertListEqual(res10.shape, [5, 4])
+            model4.layerlist.insert(-1, fluid.dygraph.Linear(2, 2))
+            res11 = model4(x)
+            self.assertListEqual(res10.shape, [5, 4])
+            res11.backward()
 
     def test_layer_list(self):
         self.layer_list(True)

--- a/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
+++ b/python/paddle/fluid/tests/unittests/test_imperative_container_layerlist.py
@@ -84,7 +84,7 @@ class TestImperativeContainer(unittest.TestCase):
             self.assertListEqual(res8.shape, [5, 3**3])
             res8.backward()
 
-            model4 = MyLayer(layerlist)
+            model4 = MyLayer(layerlist[:2])
             model4.layerlist[-1] = fluid.dygraph.Linear(3, 5)
             res9 = model4(x)
             self.assertListEqual(res9.shape, [5, 5])


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

- support minux-idx for LayerList
- `__getitem__`
- ` __setitem__`
- `__del__`


#### Before
- getitem problem
- setitem problem 
> *will get surprising result here*


```
In [80]: mm = nn.LayerList([nn.Conv2D(2, 2, 2, 2), nn.Linear(10, 10)])

In [81]: mm[-1]
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-81-0325fd583382> in <module>
----> 1 mm[-1]

~/opt/anaconda3/lib/python3.8/site-packages/paddle/fluid/dygraph/container.py in __getitem__(self, idx)
    218             return self.__class__(list(self._sub_layers.values())[idx])
    219         else:
--> 220             return self._sub_layers[str(idx)]
    221 
    222     def __setitem__(self, idx, sublayer):

KeyError: '-1'

In [82]: mm[-1] = nn.ReLU()

In [83]: mm
Out[83]: 
LayerList(
  (0): Conv2D(2, 2, kernel_size=[2, 2], stride=[2, 2], data_format=NCHW)
  (1): Linear(in_features=10, out_features=10, dtype=float32)
  (-1): ReLU()
)
```



#### After

```
In [74]: mm = LayerList([nn.Conv2D(2, 2, 2, 2), nn.Linear(10, 10), nn.ReLU()])

In [75]: mm[-1]
Out[75]: ReLU()

In [76]: mm[-1] = nn.Sigmoid()

In [77]: mm
Out[77]: 
LayerList(
  (0): Conv2D(2, 2, kernel_size=[2, 2], stride=[2, 2], data_format=NCHW)
  (1): Linear(in_features=10, out_features=10, dtype=float32)
  (2): Sigmoid()
)

In [78]: del mm[-1]

In [79]: mm
Out[79]: 
LayerList(
  (0): Conv2D(2, 2, kernel_size=[2, 2], stride=[2, 2], data_format=NCHW)
  (1): Linear(in_features=10, out_features=10, dtype=float32)
)

```



