### PR TITLE
【NPU】Fix elementwise_div_grad op

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_div_op_npu.cc
+++ b/paddle/fluid/operators/elementwise/elementwise_div_op_npu.cc
@@ -110,9 +110,15 @@ class ElementwiseDivGradNPUKernel : public framework::OpKernel<T> {
     if (dy) {
       dy->mutable_data<T>(place);
 
-      Tensor y_grad_w(x->type());
+      Tensor neg_out(y->type());
+      neg_out.mutable_data<T>(y->dims(), place);
+      auto neg_out_runner = NpuOpRunner("Neg", {*out},
+              {neg_out}, {});
+      neg_out_runner.Run(stream);
+
+      Tensor y_grad_w(y->type());
       y_grad_w.mutable_data<T>(y->dims(), place);
-      auto y_grad_w_runner = NpuOpRunner("Mul", {*out, y_power},
+      auto y_grad_w_runner = NpuOpRunner("Div", {neg_out, *y},
               {y_grad_w}, {});
       y_grad_w_runner.Run(stream);
 

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
@@ -32,7 +32,7 @@ class TestElementwiseDiv(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "elementwise_div"
-        self.place = paddle.NPUPlace(0)
+        self.place = paddle.NPUPlace(5)
 
         self.init_dtype()
         np.random.seed(SEED)
@@ -56,12 +56,24 @@ class TestElementwiseDiv(OpTest):
     def test_check_output(self):
         self.check_output_with_place(self.place, check_dygraph=False)
 
-    # TODO(ascendrc): Div grad test
-    # def test_check_grad(self):
-    #     if self.dtype == np.float16:
-    #         return
-    #     self.check_grad(['X'], 'Out')
-    #
+    def test_check_grad_normal(self):
+        self.check_grad_with_place(
+            self.place, ['X', 'Y'],
+            'Out',
+            max_relative_error=0.007,
+            check_dygraph=False)
+
+    def test_check_grad_ingore_x(self):
+        self.check_grad_with_place(
+            self.place, ['Y'],
+            'Out',
+            max_relative_error=0.007,
+            no_grad_set=set("X"),
+            check_dygraph=False)
+
+    def test_check_grad_ingore_y(self):
+        self.check_grad_with_place(
+            self.place, ['X'], 'Out', no_grad_set=set("Y"), check_dygraph=False)
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),
@@ -70,7 +82,7 @@ class TestElementwiseDivFp16(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "elementwise_div"
-        self.place = paddle.NPUPlace(0)
+        self.place = paddle.NPUPlace(5)
 
         self.init_dtype()
         np.random.seed(SEED)
@@ -123,7 +135,7 @@ class TestElementwiseDivNet(unittest.TestCase):
             e = paddle.multiply(a, b)
             f = paddle.multiply(c, d)
             f.stop_gradient = True
-            g = paddle.divide(e, f)
+            g = fluid.layers.elementwise_div(e, f)
 
             fc_1 = fluid.layers.fc(input=g, size=128)
             prediction = fluid.layers.fc(input=fc_1, size=2, act='softmax')
@@ -134,7 +146,7 @@ class TestElementwiseDivNet(unittest.TestCase):
             sgd.minimize(loss)
 
         if run_npu:
-            place = paddle.NPUPlace(0)
+            place = paddle.NPUPlace(5)
         else:
             place = paddle.CPUPlace()
 

--- a/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_elementwise_div_op_npu.py
@@ -32,7 +32,7 @@ class TestElementwiseDiv(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "elementwise_div"
-        self.place = paddle.NPUPlace(5)
+        self.place = paddle.NPUPlace(0)
 
         self.init_dtype()
         np.random.seed(SEED)
@@ -82,7 +82,7 @@ class TestElementwiseDivFp16(OpTest):
     def setUp(self):
         self.set_npu()
         self.op_type = "elementwise_div"
-        self.place = paddle.NPUPlace(5)
+        self.place = paddle.NPUPlace(0)
 
         self.init_dtype()
         np.random.seed(SEED)
@@ -146,7 +146,7 @@ class TestElementwiseDivNet(unittest.TestCase):
             sgd.minimize(loss)
 
         if run_npu:
-            place = paddle.NPUPlace(5)
+            place = paddle.NPUPlace(0)
         else:
             place = paddle.CPUPlace()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
【NPU】Fix elementwise_div_grad op
运行结果：
<img width="566" alt="截屏2021-03-19 下午7 36 56" src="https://user-images.githubusercontent.com/16233945/111777432-4075fb80-88ee-11eb-998a-dcb0cafafff3.png">

elementwise_div调用：
<img width="1082" alt="截屏2021-03-19 下午7 44 10" src="https://user-images.githubusercontent.com/16233945/111777497-57b4e900-88ee-11eb-9fde-00ccd79f6173.png">

elementwise_div_grad调用：
<img width="1083" alt="截屏2021-03-19 下午7 44 30" src="https://user-images.githubusercontent.com/16233945/111777333-1fada600-88ee-11eb-84a2-d397bcdc42a0.png">
