### PR TITLE
Fix bfloat16 compile failed in gcc5.4

### DIFF
--- a/paddle/fluid/platform/bfloat16.h
+++ b/paddle/fluid/platform/bfloat16.h
@@ -16,6 +16,7 @@
 
 #include <stdint.h>
 
+#include <cmath>
 #include <cstring>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Fix bfloat16 compile failed in gcc5.4