### PR TITLE
[Dy2stat] Fix the bug that loop_body_func may return single element

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/loop_transformer.py
@@ -594,7 +594,7 @@ class LoopTransformer(gast.NodeTransformer):
         # append return values for loop body
         body_stmts.append(
             gast.Return(value=generate_name_node(
-                loop_var_names, ctx=gast.Load())))
+                loop_var_names, ctx=gast.Load(), gen_tuple_if_single=True)))
         body_func_node = gast.FunctionDef(
             name=unique_name.generate(FOR_BODY_PREFIX),
             args=gast.arguments(

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -381,9 +381,15 @@ def get_attribute_full_name(node):
     return astor.to_source(gast.gast_to_ast(node)).strip()
 
 
-def generate_name_node(name_ids, ctx=gast.Load()):
+def generate_name_node(name_ids, ctx=gast.Load(), gen_tuple_if_single=False):
     """
-    Generate list or gast.Tuple of ast.Name for Return statement.
+    If name_ids is list or tuple or set with multiple strings, this function
+    generates gast.Tuple of gast.Name.
+    If the name_ids is single string or contains only 1 string, this function
+    returns gast.Name if gen_tuple_if_single==False else returns gast.Tuple
+    with only one gast.Name
+
+    This function is used at several gast.Return statements.
     """
     if isinstance(name_ids, six.string_types):
         name_ids = [name_ids]
@@ -395,7 +401,7 @@ def generate_name_node(name_ids, ctx=gast.Load()):
             id=name_id, ctx=ctx, annotation=None, type_comment=None)
         for name_id in name_ids
     ]
-    if len(gast_names) == 1:
+    if len(gast_names) == 1 and not gen_tuple_if_single:
         name_node = gast_names[0]
     else:
         name_node = gast.Tuple(elts=gast_names, ctx=ctx)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Our old `loop_body` function may return single element when loop_vars just contains only 1 element, which can cause bug. Let's see an example, the origin code is the new testcase TestForwardContainsForLayer of this PR. The translated code would be like below before this PR

```
def forward(self, x):
    y = paddle.zeros([10, 2, 3])
    z = []
    i = 0

    def for_loop_condition_0(i):
        return i < self.high - self.low

    def for_loop_body_0(i):
        paddle.jit.dy2static.convert_call(z.append)(paddle.jit.dy2static.
            convert_call(y[i].clone)())
        i += 1
        return i # This PR changes `return i` to `return i,` as a tuple

    [i] = paddle.jit.dy2static.convert_while_loop(for_loop_condition_0,
        for_loop_body_0, [i])
    return z
```

You could notice the `for_loop_body_0` returns `i`, then when the python for loop is running, the loop_vars `[i]` would be updated to `i`, which can cause bug.

The key point of this PR is forcing `loop_body` functions always return tuple.