### PR TITLE
Change trainable to stop_gradient in optimizer

### DIFF
--- a/python/paddle/optimizer/adam.py
+++ b/python/paddle/optimizer/adam.py
@@ -351,7 +351,7 @@ class Adam(Optimizer):
         """
         params_grads = []
         for param in self._parameter_list:
-            if not param.trainable:
+            if param.stop_gradient:
                 continue
             if param._grad_ivar() is not None:
                 grad_var = param._grad_ivar()

--- a/python/paddle/optimizer/adamax.py
+++ b/python/paddle/optimizer/adamax.py
@@ -184,7 +184,7 @@ class Adamax(Optimizer):
         """
         assert isinstance(block, framework.Block)
         for param, grad in parameters_and_grads:
-            if grad is None or param.trainable is False:
+            if grad is None or param.stop_gradient is True:
                 continue
             with param.block.program._optimized_guard(
                 [param, grad]), name_scope('adamax'):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Change trainable to stop_gradient in optimizer.

Now users need to optimize a `input Tensor` but not `Parameter`, case like:
```
# 输入
img = paddle.to_tensor(img, dtype='float32', place=paddle.CUDAPlace(0), stop_gradient=False)

#设置为不保存梯度值 自然也无法修改
for param in model.parameters():
    param.stop_gradient = True
    
# 设置优化器
optimizer = paddle.optimizer.Adam(learning_rate=0.001, parameters=img)
```
But our optimizer now only support to optimize `Parameter`. Because now our `ParamBase.trainable` is equal to `not ParamBase.stop_gradient`, so we can use stop_gradient directly in optimzier to support optimizer `Tensor`. 

the source code are:

```python
    @property
    def trainable(self):
        return not self.stop_gradient

    @trainable.setter
    def trainable(self, trainable):
        if isinstance(trainable, bool):
            self.stop_gradient = not trainable
        else:
            raise ValueError(
                "The type of trainable MUST be bool, but the type is ",
                type(trainable))
```