### PR TITLE
Fix the inf problem during the fp16 matrix calculation process.

### DIFF
--- a/paddle/fluid/operators/math/blas_impl.cu.h
+++ b/paddle/fluid/operators/math/blas_impl.cu.h
@@ -755,10 +755,16 @@ void Blas<platform::CUDADeviceContext>::BatchedGEMM(
             << (use_tensor_op_math ? "True" : "False");
 
     auto fp = std::is_same<T, float>::value ? CUDA_R_32F : CUDA_R_16F;
+    cudaDataType_t computeType = CUDA_R_32F;
+    float f_alpha = static_cast<float>(alpha);
+    float f_beta = static_cast<float>(beta);
+
     context_.TensorCoreCublasCallIfAvailable([&](cublasHandle_t handle) {
       PADDLE_ENFORCE_CUDA_SUCCESS(platform::dynload::cublasGemmStridedBatchedEx(
-          handle, cuTransB, cuTransA, N, M, K, &alpha, B, fp, ldb, strideB, A,
-          fp, lda, strideA, &beta, C, fp, ldc, strideC, batchCount, fp, algo));
+          handle, cuTransB, cuTransA, N, M, K,
+          reinterpret_cast<void *>(&f_alpha), B, fp, ldb, strideB, A, fp, lda,
+          strideA, reinterpret_cast<void *>(&f_beta), C, fp, ldc, strideC,
+          batchCount, computeType, algo));
     });
   } else {
 #endif  // CUDA_VERSION >= 9010


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix the inf problem during the fp16 matrix calculation process. This bug will lead to the non-convergence of Ernie-pretrain model when using the AMP training.  Refer to [this link](https://docs.nvidia.com/cuda/cublas/index.html#gemm-algorithms).
![image](https://user-images.githubusercontent.com/17102274/112302791-6debec00-8cd6-11eb-80a2-c9e950c07437.png)
