### PR TITLE
run the sample codes added by `add_sample_code` in ops.py

### DIFF
--- a/tools/check_file_diff_approvals.sh
+++ b/tools/check_file_diff_approvals.sh
@@ -53,6 +53,7 @@ API_FILES=("CMakeLists.txt"
            "python/paddle/fluid/tests/unittests/white_list/check_op_sequence_batch_1_input_white_list.py"
            "python/paddle/fluid/tests/unittests/white_list/no_grad_set_white_list.py"
            "tools/wlist.json"
+           "tools/sampcd_processor.py"
            "paddle/scripts/paddle_build.bat"
            "tools/windows/run_unittests.sh"
            "tools/parallel_UT_rule.py"
@@ -79,6 +80,12 @@ function add_failed(){
     echo_list="${echo_list[@]}$1"
 }
 
+function run_test_sampcd_processor() {
+    CUR_PWD=$(pwd)
+    cd ${PADDLE_ROOT}/tools
+    python test_sampcd_processor.py
+    cd ${CUR_PWD}
+}
 
 if [[ $git_files -gt 19 || $git_count -gt 999 ]];then
     echo_line="You must have Dianhai approval for change 20+ files or add than 1000+ lines of content.\n"
@@ -136,6 +143,9 @@ for API_FILE in ${API_FILES[*]}; do
       elif [ "${API_FILE}" == "tools/wlist.json" ];then
           echo_line="You must have one TPM (jzhang533) approval for the api whitelist for the tools/wlist.json.\n"
           check_approval 1 29231
+      elif [ "${API_FILE}" == "tools/sampcd_processor.py" ];then
+          echo_line="test_sampcd_processor.py will be executed for changed sampcd_processor.py.\n"
+          run_test_sampcd_processor
       elif [ "${API_FILE}" == "python/paddle/distributed/fleet/__init__.py" ]; then
 	      echo_line="You must have (fuyinno4 (Recommend), raindrops2sea) approval for ${API_FILE} changes"
 	      check_approval 1 35824027 38231817

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -480,6 +480,7 @@ def get_filenames():
                 continue
             if len(module.split('.')) > 1:
                 filename = '../python/'
+                # work for .so?
                 module_py = '%s.py' % module.split('.')[-1]
                 for i in range(0, len(module.split('.')) - 1):
                     filename = filename + '%s/' % module.split('.')[i]
@@ -488,8 +489,12 @@ def get_filenames():
                 filename = ''
                 print("\nWARNING:----Exception in get api filename----\n")
                 print("\n" + api + ' module is ' + module + "\n")
-            if filename != '' and filename not in filenames:
+            if filename != '' and filename not in filenames and os.path.exists(
+                    filename):
                 filenames.append(filename)
+            else:
+                print("skip file: {}".format(filename))
+                continue
             # get all methods
             method = ''
             if inspect.isclass(eval(api)):

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -655,6 +655,7 @@ arguments = [
     # flags, dest, type, default, help
     ['--gpu_id', 'gpu_id', int, 0, 'GPU device id to use [0]'],
     ['--logf', 'logf', str, None, 'file for logging'],
+    ['--threads', 'threads', int, 0, 'sub processes number'],
 ]
 
 
@@ -717,7 +718,6 @@ if __name__ == '__main__':
     else:
         os.mkdir(SAMPLECODE_TEMPDIR)
 
-    cpus = multiprocessing.cpu_count()
     filenames = get_filenames()
     if len(filenames) == 0 and len(whl_error) == 0:
         logger.info("-----API_PR.spec is the same as API_DEV.spec-----")
@@ -732,15 +732,11 @@ if __name__ == '__main__':
         logger.info("REMOVE white files: %s", rm_file)
     logger.info("API_PR is diff from API_DEV: %s", filenames)
 
-    one_part_filenum = int(math.ceil(len(filenames) / cpus))
-    if one_part_filenum == 0:
-        one_part_filenum = 1
-    divided_file_list = [
-        filenames[i:i + one_part_filenum]
-        for i in range(0, len(filenames), one_part_filenum)
-    ]
 
-    po = multiprocessing.Pool()
+    threads = multiprocessing.cpu_count()
+    if args.threads:
+        threads = args.threads
+    po = multiprocessing.Pool(threads)
     # results = po.map_async(test, divided_file_list)
     results = po.map_async(run_a_test, filenames)
     po.close()

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -129,7 +129,8 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
             hname(str): the name of the hint  banners , e.t. def hname.
             flushed.
         """
-        print_header(htype, hname)
+        print(htype, " name:", hname)
+        print("-----------------------")
         print("Sample code ", str(y), " extracted for ", name, "   :")
         print(sampcd)
         print("----example code check----\n")
@@ -138,11 +139,9 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
 
     sampcd_begins = find_all(srccom, " code-block:: python")
     if len(sampcd_begins) == 0:
-        print_header(htype, hname)
-        '''
-        detect sample codes using >>> to format
-        and consider this situation as wrong
-        '''
+        # detect sample codes using >>> to format and consider this situation as wrong
+        print(htype, " name:", hname)
+        print("-----------------------")
         if srccom.find("Examples:") != -1:
             print("----example code check----\n")
             if srccom.find(">>>") != -1:
@@ -280,11 +279,6 @@ def single_defcom_extract(start_from, srcls, is_class_begin=False):
     return fcombody
 
 
-def print_header(htype, name):
-    print(htype, " name:", name)
-    print("-----------------------")
-
-
 def srccoms_extract(srcfile, wlist, methods):
     """
     Given a source file ``srcfile``, this function will
@@ -378,7 +372,7 @@ def srccoms_extract(srcfile, wlist, methods):
                     # use list 'handled'  to mark the functions have been handled here
                     # which will be ignored in the following step
                     # handled what?
-        logger.debug('handled: %s', str(handled))
+        logger.debug('%s already handled.', str(handled))
         for i in range(0, len(srcls)):
             if srcls[i].startswith(
                     'def '):  # a function header is detected in line i
@@ -394,10 +388,13 @@ def srccoms_extract(srcfile, wlist, methods):
                 if fn in alllist:
                     api_count += 1
                     if fn in wlist or fn + "@" + srcfile.name in wlist:
+                        logger.info('[file:%s, function:%s] skip by wlist.',
+                                    srcfile_str, fn)
                         continue
                     fcombody = single_defcom_extract(i, srcls)
                     if fcombody == "":  # if no comment
-                        print_header("def", fn)
+                        print("def name:", fn)
+                        print("-----------------------")
                         print("WARNING: no comments in function ", fn,
                               ", but it deserves.")
                         continue
@@ -418,6 +415,8 @@ def srccoms_extract(srcfile, wlist, methods):
                 if cn in alllist:
                     api_count += 1
                     if cn in wlist or cn + "@" + srcfile.name in wlist:
+                        logger.info('[file:%s, class:%s] skip by wlist.',
+                                    srcfile_str, cn)
                         continue
                     # class comment
                     classcom = single_defcom_extract(i, srcls, True)
@@ -449,12 +448,19 @@ def srccoms_extract(srcfile, wlist, methods):
                                 if '%s%s' % (
                                         srcfile_str, name
                                 ) not in methods:  # class method not in api.spec 
-                                    print('{}{}'.format(srcfile_str, name),
-                                          'not in methods, skip it. [name]')
+                                    logger.info(
+                                        '[file:%s, func:%s] not in methods, skip it.',
+                                        srcfile_str, name)
                                     continue
                                 if mn.startswith('_'):
+                                    logger.info(
+                                        '[file:%s, func:%s] startswith _, it\'s private method, skip it.',
+                                        srcfile_str, name)
                                     continue
                                 if name in wlist or name + "@" + srcfile.name in wlist:
+                                    logger.info(
+                                        '[file:%s, class:%s] skip by wlist.',
+                                        srcfile_str, name)
                                     continue
                                 thismethod = [thisl[indent:]
                                               ]  # method body lines

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -281,6 +281,7 @@ def srccoms_extract(srcfile, wlist, methods):
     Args:
         srcfile(file): the source file
         wlist(list): white list
+        methods(list): only elements of this list considered.
 
     Returns:
         result: True or False
@@ -452,7 +453,7 @@ def srccoms_extract(srcfile, wlist, methods):
 
 
 def test(file_list):
-    global methods
+    global methods  # readonly
     process_result = True
     for file in file_list:
         with open(file, 'r') as src:
@@ -461,7 +462,7 @@ def test(file_list):
     return process_result
 
 def run_a_test(tc_filename):
-    global methods
+    global methods  # readonly
     process_result = True
     with open(tc_filename, 'r') as src:
         if not srccoms_extract(src, wlist, methods):
@@ -478,7 +479,7 @@ def get_filenames():
 
     '''
     filenames = []
-    global methods
+    global methods  # write
     global whl_error
     methods = []
     whl_error = []
@@ -551,10 +552,10 @@ def get_incrementapi():
     '''
     this function will get the apis that difference between API_DEV.spec and API_PR.spec.
     '''
-
-    dev_api = get_api_md5('paddle/fluid/API_DEV.spec')
-    pr_api = get_api_md5('paddle/fluid/API_PR.spec')
-    with open('dev_pr_diff_api.spec', 'w') as f:
+    global API_DEV_SPEC_FN, API_PR_SPEC_FN, API_DIFF_SPEC_FN  ## readonly
+    dev_api = get_api_md5(API_DEV_SPEC_FN)
+    pr_api = get_api_md5(API_PR_SPEC_FN)
+    with open(API_DIFF_SPEC_FN, 'w') as f:
         for key in pr_api:
             if key in dev_api:
                 if dev_api[key] != pr_api[key]:
@@ -621,6 +622,9 @@ def parse_args():
 
 methods = []
 whl_error = []
+API_DEV_SPEC_FN = 'paddle/fluid/API_DEV.spec'
+API_PR_SPEC_FN = 'paddle/fluid/API_PR.spec'
+API_DIFF_SPEC_FN = 'dev_pr_diff_api.spec'
 
 if __name__ == '__main__':
     args = parse_args()

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -357,6 +357,8 @@ def srccoms_extract(srcfile, wlist, methods):
                         opcom += srcls[j]
                         if srcls[j].find("\"\"\"") != -1:
                             break
+                    if not sampcd_extract_and_run(opcom, opname, "def", opname):
+                        process_result = False
                     api_count += 1
                     handled.append(
                         opname)  # ops.py also has normal formatted functions
@@ -372,8 +374,8 @@ def srccoms_extract(srcfile, wlist, methods):
                 if "%s%s" % (srcfile_str, fn) not in methods:
                     print('{}:{}'.format(srcfile_str, fn), 'not in methods, skip it. [fn]')
                     continue
-                #if fn in handled:
-                #    continue
+                if fn in handled:
+                    continue
                 if fn in alllist:
                     api_count += 1
                     if fn in wlist or fn + "@" + srcfile.name in wlist:
@@ -394,8 +396,8 @@ def srccoms_extract(srcfile, wlist, methods):
                 if '%s%s' % (srcfile_str, cn) not in methods:
                     print('{}{}'.format(srcfile_str, cn), 'not in methods, skip it. [cn]')
                     continue
-                #if cn in handled:
-                #    continue
+                if cn in handled:
+                    continue
                 if cn in alllist:
                     api_count += 1
                     if cn in wlist or cn + "@" + srcfile.name in wlist:

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -566,7 +566,7 @@ def get_incrementapi():
                 f.write('\n')
 
 
-def get_wlist():
+def get_wlist(fn = "wlist.json"):
     '''
     this function will get the white list of API.
 
@@ -579,7 +579,7 @@ def get_wlist():
     wlist_file = []
     # only white on CPU
     gpu_not_white = []
-    with open("wlist.json", 'r') as load_f:
+    with open(fn, 'r') as load_f:
         load_dict = json.load(load_f)
         for key in load_dict:
             if key == 'wlist_dir':

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -34,6 +34,7 @@ for example, you can run cpu version python2 testing like this:
 
 """
 
+RUN_ON_DEVICE = 'cpu'
 
 def find_all(srcstr, substr):
     """
@@ -165,9 +166,9 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
                 sampcd_to_write.append(cdline[min_indent:])
 
         sampcd = '\n'.join(sampcd_to_write)
-        if sys.argv[1] == "cpu":
+        if RUN_ON_DEVICE == "cpu":
             sampcd = '\nimport os\n' + 'os.environ["CUDA_VISIBLE_DEVICES"] = ""\n' + sampcd
-        if sys.argv[1] == "gpu":
+        if RUN_ON_DEVICE == "gpu":
             sampcd = '\nimport os\n' + 'os.environ["CUDA_VISIBLE_DEVICES"] = "0"\n' + sampcd
         sampcd += '\nprint(' + '\"' + name + ' sample code is executed successfully!\")'
 
@@ -614,6 +615,7 @@ if __name__ == '__main__':
         print("Unrecognized argument:'", args.mode, "' , 'cpu' or 'gpu' is ",
               "desired\n")
         sys.exit("Invalid arguments")
+    RUN_ON_DEVICE = args.mode
     print("API check -- Example Code")
     print("sample_test running under python", platform.python_version())
     if not os.path.isdir("./samplecode_temp"):

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -460,6 +460,13 @@ def test(file_list):
                 process_result = False
     return process_result
 
+def run_a_test(tc_filename):
+    global methods
+    process_result = True
+    with open(tc_filename, 'r') as src:
+        if not srccoms_extract(src, wlist, methods):
+            process_result = False
+    return process_result
 
 def get_filenames():
     '''
@@ -661,7 +668,8 @@ if __name__ == '__main__':
     ]
 
     po = multiprocessing.Pool()
-    results = po.map_async(test, divided_file_list)
+    # results = po.map_async(test, divided_file_list)
+    results = po.map_async(run_a_test, filenames)
     po.close()
     po.join()
 
@@ -690,8 +698,12 @@ if __name__ == '__main__':
         print("----------------------------------------------------")
         exit(1)
     else:
-        for temp in result:
-            if not temp:
+        has_error = False
+        for i in range(len(filenames)):
+            if not result[i]:
+                print(filenames[i], ' error.')
+                has_error = True
+        if has_error:
                 print("Mistakes found in sample codes.")
                 print("Please check sample codes.")
                 exit(1)

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -22,6 +22,7 @@ import inspect
 import paddle
 import paddle.fluid
 import json
+import argparse
 """
 please make sure to run in the tools path
 usage: python sample_test.py {arg1} 
@@ -575,22 +576,42 @@ def get_wlist():
                 wlist = wlist + load_dict[key]
     return wlist, wlist_file, gpu_not_white
 
+arguments = [
+# flags, dest, type, default, help
+]
+def parse_args():
+    """
+    Parse input arguments
+    """
+    global arguments
+    parser = argparse.ArgumentParser(description='run Sample Code Test')
+    # parser.add_argument('--cpu', dest='cpu_mode', action="store_true",
+    #                     help='Use CPU mode (overrides --gpu)')
+    # parser.add_argument('--gpu', dest='gpu_mode', action="store_true")
+    parser.add_argument('--debug', dest='debug', action="store_true")
+    parser.add_argument('mode', type=str, help='run on device', default='cpu')
+    for item in arguments:
+        parser.add_argument(item[0], dest=item[1], help=item[4], type=item[2], default=item[3])
 
-wlist, wlist_file, gpu_not_white = get_wlist()
+    if len(sys.argv) == 1:
+        args = parser.parse_args(['cpu'])
+        return args
+    #    parser.print_help()
+    #    sys.exit(1)
 
-if len(sys.argv) < 2:
-    print("Error: inadequate number of arguments")
-    print('''If you are going to run it on 
-        "CPU: >>> python sampcd_processor.py cpu
-        "GPU: >>> python sampcd_processor.py gpu
-        ''')
-    sys.exit("lack arguments")
-else:
-    if sys.argv[1] == "gpu":
+    args = parser.parse_args()
+    return args
+
+if __name__ == '__main__':
+    args = parse_args()
+
+    wlist, wlist_file, gpu_not_white = get_wlist()
+
+    if args.mode  == "gpu":
         for _gnw in gpu_not_white:
             wlist.remove(_gnw)
-    elif sys.argv[1] != "cpu":
-        print("Unrecognized argument:'", sys.argv[1], "' , 'cpu' or 'gpu' is ",
+    elif args.mode != "cpu":
+        print("Unrecognized argument:'", args.mode, "' , 'cpu' or 'gpu' is ",
               "desired\n")
         sys.exit("Invalid arguments")
     print("API check -- Example Code")
@@ -627,10 +648,11 @@ else:
     result = results.get()
 
     # delete temp files
-    for root, dirs, files in os.walk("./samplecode_temp"):
-        for fntemp in files:
-            os.remove("./samplecode_temp/" + fntemp)
-    os.rmdir("./samplecode_temp")
+    if not args.debug:
+        for root, dirs, files in os.walk("./samplecode_temp"):
+            for fntemp in files:
+                os.remove("./samplecode_temp/" + fntemp)
+        os.rmdir("./samplecode_temp")
 
     print("----------------End of the Check--------------------")
     if len(whl_error) != 0:

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -122,6 +122,8 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
 
     Returns:
         result: True or False
+        name(str): the name of the API.
+        msg(str): messages
     """
     global GPU_ID, RUN_ON_DEVICE, SAMPLECODE_TEMPDIR
 
@@ -197,7 +199,7 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
         sampcd += '\nprint(' + '\"' + name + ' sample code is executed successfully!\")'
 
         tfname = os.path.join(SAMPLECODE_TEMPDIR, '{}_example{}'.format(
-            name, '.py' if len(sampcd_begins) > 1 else '_{}.py'.format(y)))
+            name, '.py' if len(sampcd_begins) == 1 else '_{}.py'.format(y)))
         logging.info('running %s', tfname)
         with open(tfname, 'w') as tempf:
             tempf.write(sampcd)
@@ -302,6 +304,7 @@ def srccoms_extract(srcfile, wlist, methods):
 
     Returns:
         result: True or False
+        error_methods: the methods that failed.
     """
 
     process_result = True

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -39,21 +39,24 @@ for example, you can run cpu version python2 testing like this:
 
 logger = logging.getLogger()
 if logger.handlers:
-    console = logger.handlers[0]  # we assume the first handler is the one we want to configure
+    console = logger.handlers[
+        0]  # we assume the first handler is the one we want to configure
 else:
     console = logging.StreamHandler()
     logger.addHandler(console)
-console.setFormatter(logging.Formatter(
-    "%(asctime)s - %(funcName)s:%(lineno)d - %(levelname)s - %(message)s"))
+console.setFormatter(
+    logging.Formatter(
+        "%(asctime)s - %(funcName)s:%(lineno)d - %(levelname)s - %(message)s"))
 
 RUN_ON_DEVICE = 'cpu'
-GPU_ID=0
+GPU_ID = 0
 methods = []
 whl_error = []
 API_DEV_SPEC_FN = 'paddle/fluid/API_DEV.spec'
 API_PR_SPEC_FN = 'paddle/fluid/API_PR.spec'
 API_DIFF_SPEC_FN = 'dev_pr_diff_api.spec'
 SAMPLECODE_TEMPDIR = 'samplecode_temp'
+
 
 def find_all(srcstr, substr):
     """
@@ -189,11 +192,12 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
         if RUN_ON_DEVICE == "cpu":
             sampcd = '\nimport os\nos.environ["CUDA_VISIBLE_DEVICES"] = ""\n' + sampcd
         if RUN_ON_DEVICE == "gpu":
-            sampcd = '\nimport os\nos.environ["CUDA_VISIBLE_DEVICES"] = "{}"\n'.format(GPU_ID) + sampcd
+            sampcd = '\nimport os\nos.environ["CUDA_VISIBLE_DEVICES"] = "{}"\n'.format(
+                GPU_ID) + sampcd
         sampcd += '\nprint(' + '\"' + name + ' sample code is executed successfully!\")'
 
-        tfname = os.path.join(SAMPLECODE_TEMPDIR, '{}_example{}'.format(name,
-            '.py' if len(sampcd_begins) > 1 else '_{}.py'.format(y)))
+        tfname = os.path.join(SAMPLECODE_TEMPDIR, '{}_example{}'.format(
+            name, '.py' if len(sampcd_begins) > 1 else '_{}.py'.format(y)))
         logging.info('running %s', tfname)
         with open(tfname, 'w') as tempf:
             tempf.write(sampcd)
@@ -371,7 +375,8 @@ def srccoms_extract(srcfile, wlist, methods):
                         opcom += srcls[j]
                         if srcls[j].find("\"\"\"") != -1:
                             break
-                    result,_,_ = sampcd_extract_and_run(opcom, opname, "def", opname)
+                    result, _, _ = sampcd_extract_and_run(opcom, opname, "def",
+                                                          opname)
                     if not result:
                         error_methods.append(opname)
                         process_result = False
@@ -408,7 +413,8 @@ def srccoms_extract(srcfile, wlist, methods):
                               ", but it deserves.")
                         continue
                     else:
-                        result,_,_ = sampcd_extract_and_run(fcombody, fn, "def", fn)
+                        result, _, _ = sampcd_extract_and_run(fcombody, fn,
+                                                              "def", fn)
                         if not result:
                             error_methods.append(fn)
                             process_result = False
@@ -432,7 +438,8 @@ def srccoms_extract(srcfile, wlist, methods):
                     # class comment
                     classcom = single_defcom_extract(i, srcls, True)
                     if classcom != "":
-                        result,_,_ = sampcd_extract_and_run(classcom, cn, "class", cn)
+                        result, _, _ = sampcd_extract_and_run(classcom, cn,
+                                                              "class", cn)
                         if not result:
                             error_methods.append(cn)
                             process_result = False
@@ -492,7 +499,8 @@ def srccoms_extract(srcfile, wlist, methods):
                                 thismtdcom = single_defcom_extract(0,
                                                                    thismethod)
                                 if thismtdcom != "":
-                                    result,_,_ = sampcd_extract_and_run(thismtdcom, name, "method", name)
+                                    result, _, _ = sampcd_extract_and_run(
+                                        thismtdcom, name, "method", name)
                                     if not result:
                                         error_methods.append(name)
                                         process_result = False
@@ -513,10 +521,13 @@ def test(file_list):
 
 
 def run_a_test(tc_filename):
+    """
+    execute a sample code-block.
+    """
     global methods  # readonly
     process_result = True
     with open(tc_filename, 'r') as src:
-        process_result, error_methods  = srccoms_extract(src, wlist, methods)
+        process_result, error_methods = srccoms_extract(src, wlist, methods)
     return process_result, tc_filename, error_methods
 
 
@@ -684,15 +695,16 @@ def parse_args():
     return args
 
 
-
 if __name__ == '__main__':
     args = parse_args()
     if args.debug:
         logger.setLevel(logging.DEBUG)
     if args.logf:
         logfHandler = logging.FileHandler(args.logf)
-        logfHandler.setFormatter(logging.Formatter(
-            "%(asctime)s - %(funcName)s:%(lineno)d - %(levelname)s - %(message)s"))
+        logfHandler.setFormatter(
+            logging.Formatter(
+                "%(asctime)s - %(funcName)s:%(lineno)d - %(levelname)s - %(message)s"
+            ))
         logger.addHandler(logfHandler)
 
     wlist, wlist_file, gpu_not_white = get_wlist()
@@ -732,7 +744,6 @@ if __name__ == '__main__':
         logger.info("REMOVE white files: %s", rm_file)
     logger.info("API_PR is diff from API_DEV: %s", filenames)
 
-
     threads = multiprocessing.cpu_count()
     if args.threads:
         threads = args.threads
@@ -761,7 +772,8 @@ if __name__ == '__main__':
         )
         for temp in result:
             if not temp[0]:
-                logger.info("In addition, mistakes found in sample codes: %s", temp[1])
+                logger.info("In addition, mistakes found in sample codes: %s",
+                            temp[1])
                 logger.info("error_methods: %s", str(temp[2]))
         logger.info("----------------------------------------------------")
         exit(1)
@@ -769,7 +781,8 @@ if __name__ == '__main__':
         has_error = False
         for temp in result:
             if not temp[0]:
-                logger.info("In addition, mistakes found in sample codes: %s", temp[1])
+                logger.info("In addition, mistakes found in sample codes: %s",
+                            temp[1])
                 logger.info("error_methods: %s", str(temp[2]))
                 has_error = True
         if has_error:

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -674,6 +674,8 @@ API_DIFF_SPEC_FN = 'dev_pr_diff_api.spec'
 
 if __name__ == '__main__':
     args = parse_args()
+    if args.debug:
+        logger.setLevel(logging.DEBUG)
 
     wlist, wlist_file, gpu_not_white = get_wlist()
 

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -474,6 +474,10 @@ def get_filenames():
             except AttributeError:
                 whl_error.append(api)
                 continue
+            except SyntaxError:
+                print('line:{}, api:{}'.format(line, api))
+                # paddle.Tensor.<lambda>
+                continue
             if len(module.split('.')) > 1:
                 filename = '../python/'
                 module_py = '%s.py' % module.split('.')[-1]

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -23,6 +23,7 @@ import paddle
 import paddle.fluid
 import json
 import argparse
+import shutil
 """
 please make sure to run in the tools path
 usage: python sample_test.py {arg1} 

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -148,8 +148,11 @@ class Test_srccoms_extract(unittest.TestCase):
         pyfilename = os.path.join(self.tmpDir, 'ops.py')
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
+        self.assertTrue(os.path.exists(pyfilename))
         with open(pyfilename, 'r') as pyfile:
             self.assertTrue(srccoms_extract(pyfile, []))
+        self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 
+        self.assertTrue(os.path.exists("samplecode_temp/" "two_plus_two_example.py"))
     def test_from_not_ops_py(self):
         filecont = r'''
         __all__ = [
@@ -172,11 +175,45 @@ class Test_srccoms_extract(unittest.TestCase):
             pyfile.write(filecont)
         with open(pyfilename, 'r') as pyfile:
             self.assertTrue(srccoms_extract(pyfile, []))
-        pass
+        self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py"))
     def test_with_empty_wlist(self):
+        """
+        see test_from_ops_py
+        """
         pass
     def test_with_wlist(self):
-        pass
+        filecont = r'''
+        __all__ = [
+        'one_plus_one',
+        'three_plus_three'
+        ]
+
+        def one_plus_one():
+            """
+            placeholder
+
+            Examples:
+            .. code-block:: python
+                print(1+1)
+            """
+            return 1+1
+        def three_plus_three():
+            """
+            placeholder
+
+            Examples:
+            .. code-block:: python
+                print(3+3)
+            """
+            return 3+3
+
+        '''
+        pyfilename = os.path.join(self.tmpDir, 'opo.py')
+        with open(pyfilename, 'w') as pyfile:
+            pyfile.write(filecont)
+        with open(pyfilename, 'r') as pyfile:
+            self.assertTrue(srccoms_extract(pyfile, []))
+        self.assertFalse(os.path.exists("samplecode_temp/three_plus_three_example.py"))
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py
 # why? unabled to use the ast module. emmmmm

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -65,14 +65,18 @@ class Test_sampcd_extract_and_run(unittest.TestCase):
                 print(1+1)
         """
         funcname = 'one_plus_one'
-        self.assertTrue(sampcd_extract_and_run(comments, funcname))
+        res, name, msg = sampcd_extract_and_run(comments, funcname)
+        self.assertTrue(res)
+        self.assertEqual(funcname, name)
 
     def test_run_a_def_no_code(self):
         comments = """
         placeholder
         """
         funcname = 'one_plus_one'
-        self.assertFalse(sampcd_extract_and_run(comments, funcname))
+        res, name, msg = sampcd_extract_and_run(comments, funcname)
+        self.assertFalse(res)
+        self.assertEqual(funcname, name)
 
     def test_run_a_def_raise_expection(self):
         comments = """
@@ -82,7 +86,9 @@ class Test_sampcd_extract_and_run(unittest.TestCase):
                 print(1/0)
         """
         funcname = 'one_plus_one'
-        self.assertFalse(sampcd_extract_and_run(comments, funcname))
+        res, name, msg = sampcd_extract_and_run(comments, funcname)
+        self.assertFalse(res)
+        self.assertEqual(funcname, name)
 
 
 class Test_single_defcom_extract(unittest.TestCase):
@@ -329,19 +335,23 @@ add_sample_code(globals()["two_plus_two"], """
         utsp = importlib.import_module('ops')
         print('testing srccoms_extract from ops.py')
         methods = ['one_plus_one', 'two_plus_two', 'exp']
-        os.remove("samplecode_temp/" "one_plus_one_example.py")
+        # os.remove("samplecode_temp/" "one_plus_one_example.py")
         self.assertFalse(
             os.path.exists("samplecode_temp/"
                            "one_plus_one_example.py"))
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(srccoms_extract(pyfile, [], methods))
+            res, error_methods = srccoms_extract(pyfile, [], methods)
+            self.assertTrue(res)
         self.assertTrue(
             os.path.exists("samplecode_temp/"
                            "one_plus_one_example.py"))
+        os.remove("samplecode_temp/" "one_plus_one_example.py")
         self.assertTrue(
             os.path.exists("samplecode_temp/"
                            "two_plus_two_example.py"))
+        os.remove("samplecode_temp/" "two_plus_two_example.py")
         self.assertTrue(os.path.exists("samplecode_temp/" "exp_example.py"))
+        os.remove("samplecode_temp/" "exp_example.py")
 
     def test_from_not_ops_py(self):
         filecont = '''
@@ -366,10 +376,12 @@ def one_plus_one():
         utsp = importlib.import_module('opo')
         methods = ['one_plus_one']
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(srccoms_extract(pyfile, [], methods))
+            res, error_methods = srccoms_extract(pyfile, [], methods)
+            self.assertTrue(res)
         self.assertTrue(
             os.path.exists("samplecode_temp/"
                            "one_plus_one_example.py"))
+        os.remove("samplecode_temp/" "one_plus_one_example.py")
 
     def test_with_empty_wlist(self):
         """
@@ -410,10 +422,12 @@ def three_plus_three():
         utsp = importlib.import_module('three_and_four')
         methods = ['four_plus_four', 'three_plus_three']
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(
-                srccoms_extract(pyfile, ['three_plus_three'], methods))
+            res, error_methods = srccoms_extract(pyfile, ['three_plus_three'],
+                                                 methods)
+            self.assertTrue(res)
         self.assertTrue(
             os.path.exists("samplecode_temp/four_plus_four_example.py"))
+        os.remove("samplecode_temp/" "four_plus_four_example.py")
         self.assertFalse(
             os.path.exists("samplecode_temp/three_plus_three_example.py"))
 

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -168,6 +168,7 @@ class Test_get_incrementapi(unittest.TestCase):
 
 class Test_get_wlist(unittest.TestCase):
     def setUp(self):
+        self.tmpDir = tempfile.mkdtemp()
         self.wlist_filename = os.path.join(self.tmpDir, 'wlist.json')
         with open(self.wlist_filename , 'w') as f:
             f.write(r'''
@@ -200,6 +201,7 @@ class Test_get_wlist(unittest.TestCase):
 )
     def tearDown(self):
         os.remove(self.wlist_filename)
+        shutil.rmtree(self.tmpDir)
     def test_get_wlist(self):
         wlist, wlist_file, gpu_not_white = get_wlist(self.wlist_filename)
         self.assertCountEqual(["xxxxx",
@@ -280,7 +282,10 @@ add_sample_code(globals()["two_plus_two"], """
             pyfile.write(filecont)
         self.assertTrue(os.path.exists(pyfilename))
         utsp = importlib.import_module('ops')
+        print('testing srccoms_extract from ops.py')
         methods = ['one_plus_one','two_plus_two','exp']
+        os.remove("samplecode_temp/" "one_plus_one_example.py") 
+        self.assertFalse(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 
         with open(pyfilename, 'r') as pyfile:
             self.assertTrue(srccoms_extract(pyfile, [], methods))
         self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -121,7 +121,35 @@ class Test_srccoms_extract(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpDir)
     def test_from_ops_py(self):
-        pass
+        filecont = r'''
+        __all__ = []
+        __all__ += ['one_plus_one']
+
+        def one_plus_one():
+            return 1+1
+
+        one_plus_one.__doc__ = r"""
+            placeholder
+
+            Examples:
+            .. code-block:: python
+                print(1+1)
+            """
+
+        __all__ += ['two_plus_two']
+        def two_plus_two():
+            return 2+2
+        add_sample_code(globals()["two_plus_two"], r"""
+            Examples:
+            .. code-block:: python
+                print(2+2)
+        """
+        '''
+        pyfilename = os.path.join(self.tmpDir, 'ops.py')
+        with open(pyfilename, 'w') as pyfile:
+            pyfile.write(filecont)
+        with open(pyfilename, 'r') as pyfile:
+            self.assertTrue(srccoms_extract(pyfile, []))
     def test_from_not_ops_py(self):
         filecont = r'''
         __all__ = [

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -11,6 +11,7 @@ from sampcd_processor import sampcd_extract_and_run
 from sampcd_processor import single_defcom_extract
 from sampcd_processor import srccoms_extract
 from sampcd_processor import get_api_md5
+from sampcd_processor import get_incrementapi
 
 class Test_find_all(unittest.TestCase):
     # def test_srcstr_is_None(self):
@@ -123,20 +124,46 @@ class Test_get_api_md5(unittest.TestCase):
         self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
         with open(self.api_pr_spec_filename, 'w') as f:
             f.write("\n".join([
-                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'one_plus_one'))""",
-                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'two_plus_two'))""",
-                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'three_plus_three'))""",
-                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'four_plus_four'))""",
+                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
+                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of two_plus_two'))""",
+                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of three_plus_three'))""",
+                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of four_plus_four'))""",
                 ]))
     def tearDown(self):
         os.remove(self.api_pr_spec_filename)
         pass
     def test_get_api_md5(self):
         res = get_api_md5('paddle/fluid/API_PR.spec')
-        self.assertEqual("'one_plus_one'", res['one_plus_one'])
-        self.assertEqual("'two_plus_two'", res['two_plus_two'])
-        self.assertEqual("'three_plus_three'", res['three_plus_three'])
-        self.assertEqual("'four_plus_four'", res['four_plus_four'])
+        self.assertEqual("'md5sum of one_plus_one'", res['one_plus_one'])
+        self.assertEqual("'md5sum of two_plus_two'", res['two_plus_two'])
+        self.assertEqual("'md5sum of three_plus_three'", res['three_plus_three'])
+        self.assertEqual("'md5sum of four_plus_four'", res['four_plus_four'])
+
+class Test_get_incrementapi(unittest.TestCase):
+    def setUp(self):
+        self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
+        with open(self.api_pr_spec_filename, 'w') as f:
+            f.write("\n".join([
+                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
+                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of two_plus_two'))""",
+                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of three_plus_three'))""",
+                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of four_plus_four'))""",
+                ]))
+        self.api_dev_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_DEV.spec'))
+        with open(self.api_dev_spec_filename, 'w') as f:
+            f.write("\n".join([
+                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
+                ]))
+        self.api_diff_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "dev_pr_diff_api.spec"))
+    def tearDown(self):
+        os.remove(self.api_pr_spec_filename)
+        os.remove(self.api_dev_spec_filename)
+        os.remove(self.api_diff_spec_filename)
+    def test_it(self):
+        get_incrementapi()
+        with open(self.api_diff_spec_filename, 'r') as f:
+            lines = f.readlines()
+            self.assertCountEqual(["two_plus_two\n", "three_plus_three\n", "four_plus_four\n"], lines)
 
 class Test_srccoms_extract(unittest.TestCase):
     def setUp(self):

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -3,11 +3,14 @@ import unittest
 import os
 import tempfile
 import shutil
+import sys
+import importlib
 from sampcd_processor import find_all
 from sampcd_processor import check_indent
 from sampcd_processor import sampcd_extract_and_run
 from sampcd_processor import single_defcom_extract
 from sampcd_processor import srccoms_extract
+from sampcd_processor import get_api_md5
 
 class Test_find_all(unittest.TestCase):
     # def test_srcstr_is_None(self):
@@ -61,105 +64,140 @@ class Test_sampcd_extract_and_run(unittest.TestCase):
 class Test_single_defcom_extract(unittest.TestCase):
     def test_extract_from_func(self):
         defstr='''
-        import os
-        def foo():
+import os
+def foo():
             """
             foo is a function.
             """
             pass
-        def bar():
+def bar():
             pass
-        '''
-        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+'''
+        comm = single_defcom_extract(2, defstr.splitlines(True), is_class_begin=False)
         self.assertEqual("            foo is a function.\n", comm)
         pass
     def test_extract_from_func_with_no_docstring(self):
         defstr='''
-        import os
-        def bar():
+import os
+def bar():
             pass
-        '''
-        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+'''
+        comm = single_defcom_extract(2, defstr.splitlines(True), is_class_begin=False)
         self.assertEqual('', comm)
         pass
     def test_extract_from_class(self):
-        defstr='''
-        import os
-        class Foo():
-            r"""
-            foo is a class.
+        defstr=r'''
+import os
+class Foo():
+            """
+            Foo is a class.
             second line.
             """
             pass
             def bar():
                 pass
-        def foo():
+def foo():
             pass
-        '''
-        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=True)
-        rcomm = r"""            foo is a class.
+'''
+        comm = single_defcom_extract(2, defstr.splitlines(True), is_class_begin=True)
+        rcomm = """            Foo is a class.
             second line.
 """
         self.assertEqual(rcomm, comm)
         pass
     def test_extract_from_class_with_no_docstring(self):
         defstr='''
-        import os
-        class Foo():
+import os
+class Foo():
             pass
             def bar():
                 pass
-        def foo():
+def foo():
             pass
-        '''
+'''
         comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=True)
         self.assertEqual('', comm)
+
+class Test_get_api_md5(unittest.TestCase):
+    def setUp(self):
+        self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
+        with open(self.api_pr_spec_filename, 'w') as f:
+            f.write("\n".join([
+                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'one_plus_one'))""",
+                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'two_plus_two'))""",
+                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'three_plus_three'))""",
+                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'four_plus_four'))""",
+                ]))
+    def tearDown(self):
+        os.remove(self.api_pr_spec_filename)
+        pass
+    def test_get_api_md5(self):
+        res = get_api_md5('paddle/fluid/API_PR.spec')
+        self.assertEqual("'one_plus_one'", res['one_plus_one'])
+        self.assertEqual("'two_plus_two'", res['two_plus_two'])
+        self.assertEqual("'three_plus_three'", res['three_plus_three'])
+        self.assertEqual("'four_plus_four'", res['four_plus_four'])
 
 class Test_srccoms_extract(unittest.TestCase):
     def setUp(self):
         self.tmpDir = tempfile.mkdtemp()
+        sys.path.append(self.tmpDir)
+        self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
+        with open(self.api_pr_spec_filename, 'w') as f:
+            f.write("\n".join([
+                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "one_plus_one"))""",
+                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "two_plus_two"))""",
+                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "three_plus_three"))""",
+                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "four_plus_four"))""",
+                ]))
     def tearDown(self):
+        sys.path.remove(self.tmpDir)
         shutil.rmtree(self.tmpDir)
+        os.remove(self.api_pr_spec_filename)
     def test_from_ops_py(self):
-        filecont = r'''
-        __all__ = []
-        __all__ += ['one_plus_one']
+        filecont = '''
+__all__ = []
+__all__ += ['one_plus_one']
 
-        def one_plus_one():
+def add_sample_code(obj, docstr):
+    pass
+def one_plus_one():
             return 1+1
 
-        one_plus_one.__doc__ = r"""
+one_plus_one.__doc__ = """
             placeholder
 
             Examples:
             .. code-block:: python
                 print(1+1)
-            """
+"""
 
-        __all__ += ['two_plus_two']
-        def two_plus_two():
+__all__ += ['two_plus_two']
+def two_plus_two():
             return 2+2
-        add_sample_code(globals()["two_plus_two"], r"""
+add_sample_code(globals()["two_plus_two"], """
             Examples:
             .. code-block:: python
                 print(2+2)
-        """
-        '''
+""")
+'''
         pyfilename = os.path.join(self.tmpDir, 'ops.py')
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
         self.assertTrue(os.path.exists(pyfilename))
+        utsp = importlib.import_module('ops')
+        methods = ['one_plus_one','two_plus_two']
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(srccoms_extract(pyfile, []))
+            self.assertTrue(srccoms_extract(pyfile, [], methods))
         self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 
         self.assertTrue(os.path.exists("samplecode_temp/" "two_plus_two_example.py"))
     def test_from_not_ops_py(self):
-        filecont = r'''
-        __all__ = [
+        filecont = '''
+__all__ = [
         'one_plus_one'
-        ]
+]
 
-        def one_plus_one():
+def one_plus_one():
             """
             placeholder
 
@@ -169,12 +207,14 @@ class Test_srccoms_extract(unittest.TestCase):
             """
             return 1+1
 
-        '''
+'''
         pyfilename = os.path.join(self.tmpDir, 'opo.py')
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
+        utsp = importlib.import_module('opo')
+        methods = ['one_plus_one']
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(srccoms_extract(pyfile, []))
+            self.assertTrue(srccoms_extract(pyfile, [], methods))
         self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py"))
     def test_with_empty_wlist(self):
         """
@@ -182,22 +222,22 @@ class Test_srccoms_extract(unittest.TestCase):
         """
         pass
     def test_with_wlist(self):
-        filecont = r'''
-        __all__ = [
-        'one_plus_one',
+        filecont = '''
+__all__ = [
+        'four_plus_four',
         'three_plus_three'
         ]
 
-        def one_plus_one():
+def four_plus_four():
             """
             placeholder
 
             Examples:
             .. code-block:: python
-                print(1+1)
+                print(4+4)
             """
-            return 1+1
-        def three_plus_three():
+            return 4+4
+def three_plus_three():
             """
             placeholder
 
@@ -207,12 +247,18 @@ class Test_srccoms_extract(unittest.TestCase):
             """
             return 3+3
 
-        '''
-        pyfilename = os.path.join(self.tmpDir, 'opo.py')
+'''
+        pyfilename = os.path.join(self.tmpDir, 'three_and_four.py')
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
+        utsp = importlib.import_module('three_and_four')
+        methods = [
+        'four_plus_four',
+        'three_plus_three'
+        ]
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(srccoms_extract(pyfile, []))
+            self.assertTrue(srccoms_extract(pyfile, ['three_plus_three'], methods))
+        self.assertTrue(os.path.exists("samplecode_temp/four_plus_four_example.py"))
         self.assertFalse(os.path.exists("samplecode_temp/three_plus_three_example.py"))
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -2,6 +2,7 @@
 import unittest
 from sampcd_processor import find_all
 from sampcd_processor import check_indent
+from sampcd_processor import sampcd_extract_and_run
 
 class Test_find_all(unittest.TestCase):
     # def test_srcstr_is_None(self):
@@ -24,6 +25,33 @@ class Test_check_indent(unittest.TestCase):
     #     with self.assertRaises(Exception):
     #         check_indent("  \thello paddle")
 
+class Test_sampcd_extract_and_run(unittest.TestCase):
+    def test_run_a_defs_samplecode(self):
+        comments = """
+        Examples:
+            .. code-block:: python
+                print(1+1)
+        """
+        funcname = 'one_plus_one'
+        self.assertTrue(sampcd_extract_and_run(comments, funcname))
+    def test_run_a_def_no_code(self):
+        comments = """
+        placeholder
+        """
+        funcname = 'one_plus_one'
+        self.assertFalse(sampcd_extract_and_run(comments, funcname))
+    def test_run_a_def_raise_expection(self):
+        comments = """
+        placeholder
+        Examples:
+            .. code-block:: python
+                print(1/0)
+        """
+        funcname = 'one_plus_one'
+        self.assertFalse(sampcd_extract_and_run(comments, funcname))
+
+# https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py
+# why? unabled to use the ast module. emmmmm
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -1,0 +1,29 @@
+#! python
+import unittest
+from sampcd_processor import find_all
+from sampcd_processor import check_indent
+
+class Test_find_all(unittest.TestCase):
+    # def test_srcstr_is_None(self):
+    #    self.assertIsNone(find_all(None, 'hello world'))
+    def test_find_none(self):
+        self.assertEqual(0, len(find_all('hello', 'world')))
+    def test_find_one(self):
+        self.assertListEqual([0], find_all('hello', 'hello'))
+    def test_find_two(self):
+        self.assertListEqual([1, 15], find_all(' hello, world; hello paddle!', 'hello'))
+
+class Test_check_indent(unittest.TestCase):
+    def test_no_indent(self):
+        self.assertEqual(0, check_indent('hello paddle'))
+    def test_indent_4_spaces(self):
+        self.assertEqual(4, check_indent('    hello paddle'))
+    def test_indent_1_tab(self):
+        self.assertEqual(4, check_indent("\thello paddle"))
+    # def test_indent_mixed_spaces_and_tab(self):
+    #     with self.assertRaises(Exception):
+    #         check_indent("  \thello paddle")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -89,7 +89,7 @@ class Test_single_defcom_extract(unittest.TestCase):
         def foo():
             pass
         '''
-        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=True)
         rcomm = r"""            foo is a class.
             second line.
 """
@@ -105,8 +105,14 @@ class Test_single_defcom_extract(unittest.TestCase):
         def foo():
             pass
         '''
-        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=True)
         self.assertEqual('', comm)
+
+class Test_srccoms_extract(unittest.TestCase):
+    def test_with_empty_wlist():
+        pass
+    def test_with_wlist():
+        pass
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py
 # why? unabled to use the ast module. emmmmm

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -1,9 +1,13 @@
 #! python
 import unittest
+import os
+import tempfile
+import shutil
 from sampcd_processor import find_all
 from sampcd_processor import check_indent
 from sampcd_processor import sampcd_extract_and_run
 from sampcd_processor import single_defcom_extract
+from sampcd_processor import srccoms_extract
 
 class Test_find_all(unittest.TestCase):
     # def test_srcstr_is_None(self):
@@ -27,6 +31,9 @@ class Test_check_indent(unittest.TestCase):
     #         check_indent("  \thello paddle")
 
 class Test_sampcd_extract_and_run(unittest.TestCase):
+    def setUp(self):
+        if not os.path.exists('samplecode_temp/'):
+            os.mkdir('samplecode_temp/')
     def test_run_a_defs_samplecode(self):
         comments = """
         Examples:
@@ -109,9 +116,38 @@ class Test_single_defcom_extract(unittest.TestCase):
         self.assertEqual('', comm)
 
 class Test_srccoms_extract(unittest.TestCase):
-    def test_with_empty_wlist():
+    def setUp(self):
+        self.tmpDir = tempfile.mkdtemp()
+    def tearDown(self):
+        shutil.rmtree(self.tmpDir)
+    def test_from_ops_py(self):
         pass
-    def test_with_wlist():
+    def test_from_not_ops_py(self):
+        filecont = r'''
+        __all__ = [
+        'one_plus_one'
+        ]
+
+        def one_plus_one():
+            """
+            placeholder
+
+            Examples:
+            .. code-block:: python
+                print(1+1)
+            """
+            return 1+1
+
+        '''
+        pyfilename = os.path.join(self.tmpDir, 'opo.py')
+        with open(pyfilename, 'w') as pyfile:
+            pyfile.write(filecont)
+        with open(pyfilename, 'r') as pyfile:
+            self.assertTrue(srccoms_extract(pyfile, []))
+        pass
+    def test_with_empty_wlist(self):
+        pass
+    def test_with_wlist(self):
         pass
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -12,6 +12,7 @@ from sampcd_processor import single_defcom_extract
 from sampcd_processor import srccoms_extract
 from sampcd_processor import get_api_md5
 from sampcd_processor import get_incrementapi
+from sampcd_processor import get_wlist
 
 class Test_find_all(unittest.TestCase):
     # def test_srcstr_is_None(self):
@@ -164,6 +165,54 @@ class Test_get_incrementapi(unittest.TestCase):
         with open(self.api_diff_spec_filename, 'r') as f:
             lines = f.readlines()
             self.assertCountEqual(["two_plus_two\n", "three_plus_three\n", "four_plus_four\n"], lines)
+
+class Test_get_wlist(unittest.TestCase):
+    def setUp(self):
+        self.wlist_filename = os.path.join(self.tmpDir, 'wlist.json')
+        with open(self.wlist_filename , 'w') as f:
+            f.write(r'''
+{
+    "wlist_dir":[
+        {
+            "name":"../python/paddle/fluid/contrib",
+            "annotation":""
+        },
+        {
+            "name":"../python/paddle/verison.py",
+            "annotation":""
+        }
+    ],
+    "wlist_api":[
+        {
+            "name":"xxxxx",
+            "annotation":"not a real api, just for example"
+        }
+    ],
+    "wlist_temp_api":[
+        "to_tensor",
+        "save_persistables@dygraph/checkpoint.py"
+    ],
+    "gpu_not_white":[
+        "deformable_conv"
+    ]
+}
+'''
+)
+    def tearDown(self):
+        os.remove(self.wlist_filename)
+    def test_get_wlist(self):
+        wlist, wlist_file, gpu_not_white = get_wlist(self.wlist_filename)
+        self.assertCountEqual(["xxxxx",
+            "to_tensor",
+            "save_persistables@dygraph/checkpoint.py"
+            ], wlist)
+        self.assertCountEqual([
+            "../python/paddle/fluid/contrib",
+            "../python/paddle/verison.py",
+            ], wlist_file)
+        self.assertCountEqual([
+            "deformable_conv"
+            ], gpu_not_white)
 
 class Test_srccoms_extract(unittest.TestCase):
     def setUp(self):

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -3,6 +3,7 @@ import unittest
 from sampcd_processor import find_all
 from sampcd_processor import check_indent
 from sampcd_processor import sampcd_extract_and_run
+from sampcd_processor import single_defcom_extract
 
 class Test_find_all(unittest.TestCase):
     # def test_srcstr_is_None(self):
@@ -49,6 +50,63 @@ class Test_sampcd_extract_and_run(unittest.TestCase):
         """
         funcname = 'one_plus_one'
         self.assertFalse(sampcd_extract_and_run(comments, funcname))
+
+class Test_single_defcom_extract(unittest.TestCase):
+    def test_extract_from_func(self):
+        defstr='''
+        import os
+        def foo():
+            """
+            foo is a function.
+            """
+            pass
+        def bar():
+            pass
+        '''
+        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+        self.assertEqual("            foo is a function.\n", comm)
+        pass
+    def test_extract_from_func_with_no_docstring(self):
+        defstr='''
+        import os
+        def bar():
+            pass
+        '''
+        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+        self.assertEqual('', comm)
+        pass
+    def test_extract_from_class(self):
+        defstr='''
+        import os
+        class Foo():
+            r"""
+            foo is a class.
+            second line.
+            """
+            pass
+            def bar():
+                pass
+        def foo():
+            pass
+        '''
+        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+        rcomm = r"""            foo is a class.
+            second line.
+"""
+        self.assertEqual(rcomm, comm)
+        pass
+    def test_extract_from_class_with_no_docstring(self):
+        defstr='''
+        import os
+        class Foo():
+            pass
+            def bar():
+                pass
+        def foo():
+            pass
+        '''
+        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=False)
+        self.assertEqual('', comm)
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py
 # why? unabled to use the ast module. emmmmm

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -156,11 +156,29 @@ class Test_srccoms_extract(unittest.TestCase):
         os.remove(self.api_pr_spec_filename)
     def test_from_ops_py(self):
         filecont = '''
-__all__ = []
-__all__ += ['one_plus_one']
-
 def add_sample_code(obj, docstr):
     pass
+
+__unary_func__ = [
+    'exp',
+]
+
+__all__ = []
+__all__ += __unary_func__
+__all__ += ['one_plus_one']
+
+def exp():
+    pass
+add_sample_code(globals()["exp"], r"""
+Examples:
+    .. code-block:: python
+        import paddle
+        x = paddle.to_tensor([-0.4, -0.2, 0.1, 0.3])
+        out = paddle.exp(x)
+        print(out)
+        # [0.67032005 0.81873075 1.10517092 1.34985881]
+""")
+
 def one_plus_one():
             return 1+1
 
@@ -186,11 +204,12 @@ add_sample_code(globals()["two_plus_two"], """
             pyfile.write(filecont)
         self.assertTrue(os.path.exists(pyfilename))
         utsp = importlib.import_module('ops')
-        methods = ['one_plus_one','two_plus_two']
+        methods = ['one_plus_one','two_plus_two','exp']
         with open(pyfilename, 'r') as pyfile:
             self.assertTrue(srccoms_extract(pyfile, [], methods))
         self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 
         self.assertTrue(os.path.exists("samplecode_temp/" "two_plus_two_example.py"))
+        self.assertTrue(os.path.exists("samplecode_temp/" "exp_example.py"))
     def test_from_not_ops_py(self):
         filecont = '''
 __all__ = [

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -1,4 +1,19 @@
 #! python
+
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import unittest
 import os
 import tempfile
@@ -14,31 +29,35 @@ from sampcd_processor import get_api_md5
 from sampcd_processor import get_incrementapi
 from sampcd_processor import get_wlist
 
+
 class Test_find_all(unittest.TestCase):
-    # def test_srcstr_is_None(self):
-    #    self.assertIsNone(find_all(None, 'hello world'))
     def test_find_none(self):
         self.assertEqual(0, len(find_all('hello', 'world')))
+
     def test_find_one(self):
         self.assertListEqual([0], find_all('hello', 'hello'))
+
     def test_find_two(self):
-        self.assertListEqual([1, 15], find_all(' hello, world; hello paddle!', 'hello'))
+        self.assertListEqual([1, 15],
+                             find_all(' hello, world; hello paddle!', 'hello'))
+
 
 class Test_check_indent(unittest.TestCase):
     def test_no_indent(self):
         self.assertEqual(0, check_indent('hello paddle'))
+
     def test_indent_4_spaces(self):
         self.assertEqual(4, check_indent('    hello paddle'))
+
     def test_indent_1_tab(self):
         self.assertEqual(4, check_indent("\thello paddle"))
-    # def test_indent_mixed_spaces_and_tab(self):
-    #     with self.assertRaises(Exception):
-    #         check_indent("  \thello paddle")
+
 
 class Test_sampcd_extract_and_run(unittest.TestCase):
     def setUp(self):
         if not os.path.exists('samplecode_temp/'):
             os.mkdir('samplecode_temp/')
+
     def test_run_a_defs_samplecode(self):
         comments = """
         Examples:
@@ -47,12 +66,14 @@ class Test_sampcd_extract_and_run(unittest.TestCase):
         """
         funcname = 'one_plus_one'
         self.assertTrue(sampcd_extract_and_run(comments, funcname))
+
     def test_run_a_def_no_code(self):
         comments = """
         placeholder
         """
         funcname = 'one_plus_one'
         self.assertFalse(sampcd_extract_and_run(comments, funcname))
+
     def test_run_a_def_raise_expection(self):
         comments = """
         placeholder
@@ -63,9 +84,10 @@ class Test_sampcd_extract_and_run(unittest.TestCase):
         funcname = 'one_plus_one'
         self.assertFalse(sampcd_extract_and_run(comments, funcname))
 
+
 class Test_single_defcom_extract(unittest.TestCase):
     def test_extract_from_func(self):
-        defstr='''
+        defstr = '''
 import os
 def foo():
             """
@@ -75,20 +97,24 @@ def foo():
 def bar():
             pass
 '''
-        comm = single_defcom_extract(2, defstr.splitlines(True), is_class_begin=False)
+        comm = single_defcom_extract(
+            2, defstr.splitlines(True), is_class_begin=False)
         self.assertEqual("            foo is a function.\n", comm)
         pass
+
     def test_extract_from_func_with_no_docstring(self):
-        defstr='''
+        defstr = '''
 import os
 def bar():
             pass
 '''
-        comm = single_defcom_extract(2, defstr.splitlines(True), is_class_begin=False)
+        comm = single_defcom_extract(
+            2, defstr.splitlines(True), is_class_begin=False)
         self.assertEqual('', comm)
         pass
+
     def test_extract_from_class(self):
-        defstr=r'''
+        defstr = r'''
 import os
 class Foo():
             """
@@ -101,14 +127,16 @@ class Foo():
 def foo():
             pass
 '''
-        comm = single_defcom_extract(2, defstr.splitlines(True), is_class_begin=True)
+        comm = single_defcom_extract(
+            2, defstr.splitlines(True), is_class_begin=True)
         rcomm = """            Foo is a class.
             second line.
 """
         self.assertEqual(rcomm, comm)
         pass
+
     def test_extract_from_class_with_no_docstring(self):
-        defstr='''
+        defstr = '''
 import os
 class Foo():
             pass
@@ -117,60 +145,75 @@ class Foo():
 def foo():
             pass
 '''
-        comm = single_defcom_extract(0, defstr.splitlines(True), is_class_begin=True)
+        comm = single_defcom_extract(
+            0, defstr.splitlines(True), is_class_begin=True)
         self.assertEqual('', comm)
+
 
 class Test_get_api_md5(unittest.TestCase):
     def setUp(self):
-        self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
+        self.api_pr_spec_filename = os.path.abspath(
+            os.path.join(os.getcwd(), "..", 'paddle/fluid/API_PR.spec'))
         with open(self.api_pr_spec_filename, 'w') as f:
             f.write("\n".join([
                 """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
                 """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of two_plus_two'))""",
                 """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of three_plus_three'))""",
                 """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of four_plus_four'))""",
-                ]))
+            ]))
+
     def tearDown(self):
         os.remove(self.api_pr_spec_filename)
         pass
+
     def test_get_api_md5(self):
         res = get_api_md5('paddle/fluid/API_PR.spec')
         self.assertEqual("'md5sum of one_plus_one'", res['one_plus_one'])
         self.assertEqual("'md5sum of two_plus_two'", res['two_plus_two'])
-        self.assertEqual("'md5sum of three_plus_three'", res['three_plus_three'])
+        self.assertEqual("'md5sum of three_plus_three'",
+                         res['three_plus_three'])
         self.assertEqual("'md5sum of four_plus_four'", res['four_plus_four'])
+
 
 class Test_get_incrementapi(unittest.TestCase):
     def setUp(self):
-        self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
+        self.api_pr_spec_filename = os.path.abspath(
+            os.path.join(os.getcwd(), "..", 'paddle/fluid/API_PR.spec'))
         with open(self.api_pr_spec_filename, 'w') as f:
             f.write("\n".join([
                 """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
                 """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of two_plus_two'))""",
                 """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of three_plus_three'))""",
                 """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of four_plus_four'))""",
-                ]))
-        self.api_dev_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_DEV.spec'))
+            ]))
+        self.api_dev_spec_filename = os.path.abspath(
+            os.path.join(os.getcwd(), "..", 'paddle/fluid/API_DEV.spec'))
         with open(self.api_dev_spec_filename, 'w') as f:
             f.write("\n".join([
                 """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
-                ]))
-        self.api_diff_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "dev_pr_diff_api.spec"))
+            ]))
+        self.api_diff_spec_filename = os.path.abspath(
+            os.path.join(os.getcwd(), "dev_pr_diff_api.spec"))
+
     def tearDown(self):
         os.remove(self.api_pr_spec_filename)
         os.remove(self.api_dev_spec_filename)
         os.remove(self.api_diff_spec_filename)
+
     def test_it(self):
         get_incrementapi()
         with open(self.api_diff_spec_filename, 'r') as f:
             lines = f.readlines()
-            self.assertCountEqual(["two_plus_two\n", "three_plus_three\n", "four_plus_four\n"], lines)
+            self.assertCountEqual(
+                ["two_plus_two\n", "three_plus_three\n", "four_plus_four\n"],
+                lines)
+
 
 class Test_get_wlist(unittest.TestCase):
     def setUp(self):
         self.tmpDir = tempfile.mkdtemp()
         self.wlist_filename = os.path.join(self.tmpDir, 'wlist.json')
-        with open(self.wlist_filename , 'w') as f:
+        with open(self.wlist_filename, 'w') as f:
             f.write(r'''
 {
     "wlist_dir":[
@@ -197,41 +240,43 @@ class Test_get_wlist(unittest.TestCase):
         "deformable_conv"
     ]
 }
-'''
-)
+''')
+
     def tearDown(self):
         os.remove(self.wlist_filename)
         shutil.rmtree(self.tmpDir)
+
     def test_get_wlist(self):
         wlist, wlist_file, gpu_not_white = get_wlist(self.wlist_filename)
-        self.assertCountEqual(["xxxxx",
-            "to_tensor",
-            "save_persistables@dygraph/checkpoint.py"
-            ], wlist)
+        self.assertCountEqual(
+            ["xxxxx", "to_tensor",
+             "save_persistables@dygraph/checkpoint.py"], wlist)
         self.assertCountEqual([
             "../python/paddle/fluid/contrib",
             "../python/paddle/verison.py",
-            ], wlist_file)
-        self.assertCountEqual([
-            "deformable_conv"
-            ], gpu_not_white)
+        ], wlist_file)
+        self.assertCountEqual(["deformable_conv"], gpu_not_white)
+
 
 class Test_srccoms_extract(unittest.TestCase):
     def setUp(self):
         self.tmpDir = tempfile.mkdtemp()
         sys.path.append(self.tmpDir)
-        self.api_pr_spec_filename = os.path.abspath(os.path.join(os.getcwd(), "..",'paddle/fluid/API_PR.spec'))
+        self.api_pr_spec_filename = os.path.abspath(
+            os.path.join(os.getcwd(), "..", 'paddle/fluid/API_PR.spec'))
         with open(self.api_pr_spec_filename, 'w') as f:
             f.write("\n".join([
                 """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "one_plus_one"))""",
                 """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "two_plus_two"))""",
                 """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "three_plus_three"))""",
                 """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', "four_plus_four"))""",
-                ]))
+            ]))
+
     def tearDown(self):
         sys.path.remove(self.tmpDir)
         shutil.rmtree(self.tmpDir)
         os.remove(self.api_pr_spec_filename)
+
     def test_from_ops_py(self):
         filecont = '''
 def add_sample_code(obj, docstr):
@@ -283,14 +328,21 @@ add_sample_code(globals()["two_plus_two"], """
         self.assertTrue(os.path.exists(pyfilename))
         utsp = importlib.import_module('ops')
         print('testing srccoms_extract from ops.py')
-        methods = ['one_plus_one','two_plus_two','exp']
-        os.remove("samplecode_temp/" "one_plus_one_example.py") 
-        self.assertFalse(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 
+        methods = ['one_plus_one', 'two_plus_two', 'exp']
+        os.remove("samplecode_temp/" "one_plus_one_example.py")
+        self.assertFalse(
+            os.path.exists("samplecode_temp/"
+                           "one_plus_one_example.py"))
         with open(pyfilename, 'r') as pyfile:
             self.assertTrue(srccoms_extract(pyfile, [], methods))
-        self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py")) 
-        self.assertTrue(os.path.exists("samplecode_temp/" "two_plus_two_example.py"))
+        self.assertTrue(
+            os.path.exists("samplecode_temp/"
+                           "one_plus_one_example.py"))
+        self.assertTrue(
+            os.path.exists("samplecode_temp/"
+                           "two_plus_two_example.py"))
         self.assertTrue(os.path.exists("samplecode_temp/" "exp_example.py"))
+
     def test_from_not_ops_py(self):
         filecont = '''
 __all__ = [
@@ -315,12 +367,16 @@ def one_plus_one():
         methods = ['one_plus_one']
         with open(pyfilename, 'r') as pyfile:
             self.assertTrue(srccoms_extract(pyfile, [], methods))
-        self.assertTrue(os.path.exists("samplecode_temp/" "one_plus_one_example.py"))
+        self.assertTrue(
+            os.path.exists("samplecode_temp/"
+                           "one_plus_one_example.py"))
+
     def test_with_empty_wlist(self):
         """
         see test_from_ops_py
         """
         pass
+
     def test_with_wlist(self):
         filecont = '''
 __all__ = [
@@ -352,14 +408,15 @@ def three_plus_three():
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
         utsp = importlib.import_module('three_and_four')
-        methods = [
-        'four_plus_four',
-        'three_plus_three'
-        ]
+        methods = ['four_plus_four', 'three_plus_three']
         with open(pyfilename, 'r') as pyfile:
-            self.assertTrue(srccoms_extract(pyfile, ['three_plus_three'], methods))
-        self.assertTrue(os.path.exists("samplecode_temp/four_plus_four_example.py"))
-        self.assertFalse(os.path.exists("samplecode_temp/three_plus_three_example.py"))
+            self.assertTrue(
+                srccoms_extract(pyfile, ['three_plus_three'], methods))
+        self.assertTrue(
+            os.path.exists("samplecode_temp/four_plus_four_example.py"))
+        self.assertFalse(
+            os.path.exists("samplecode_temp/three_plus_three_example.py"))
+
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py
 # why? unabled to use the ast module. emmmmm


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-23536/show

1 bugfix: the sample codes added py `add_sample_code` not run in Doc CI, all then are in the file : https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py 
2 using `argparse` in `sampcd_processor.py` to handle the program parameters.
3 unittests `test_sampcd_processor.py` for `sampcd_processor.py`
~~4 add class `Flowers` into the wlist_temp_api, IT waste so many times to print the downloaded datasets.~~

see https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2585244/job/3605231 , I modified a op's docstring in https://github.com/wadefelix/Paddle/commit/f0dac636eb5fa8d5ee0072b69d8c82005b2a8a88 , triggered successfully.
see https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2587053/job/3608290 , empty the API_DEV.spec https://github.com/PaddlePaddle/Paddle/pull/31863/commits/d35fac7f39749f44399efa0061966dc1015198ef to run all the sample codes. YES, all the sample codes are extracted, but some tests failed for some reason, such as missing `enable_static()`.

