### PR TITLE
【NPU】Add int dtype kernel for reshape2 op

### DIFF
--- a/paddle/fluid/operators/reshape_op_npu.cc
+++ b/paddle/fluid/operators/reshape_op_npu.cc
@@ -68,6 +68,8 @@ namespace ops = paddle::operators;
 REGISTER_OP_NPU_KERNEL(
     reshape2, ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, float>,
     ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, int>,
+    ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, int64_t>,
+    ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, bool>,
     ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, double>,
     ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, uint8_t>,
     ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext,
@@ -76,6 +78,8 @@ REGISTER_OP_NPU_KERNEL(
     reshape2_grad,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, float>,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, int>,
+    ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, int64_t>,
+    ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, bool>,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, double>,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, uint8_t>,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext,

--- a/paddle/fluid/operators/reshape_op_npu.cc
+++ b/paddle/fluid/operators/reshape_op_npu.cc
@@ -67,10 +67,16 @@ namespace ops = paddle::operators;
 
 REGISTER_OP_NPU_KERNEL(
     reshape2, ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, int>,
+    ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, double>,
+    ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext, uint8_t>,
     ops::Reshape2NPUKernel<paddle::platform::NPUDeviceContext,
                            paddle::platform::float16>);
 REGISTER_OP_NPU_KERNEL(
     reshape2_grad,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, float>,
+    ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, int>,
+    ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, double>,
+    ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext, uint8_t>,
     ops::Reshape2GradNPUKernel<paddle::platform::NPUDeviceContext,
                                paddle::platform::float16>);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Add int dtype kernel for reshape2 op