### PR TITLE
fix op benchmark ci error

### DIFF
--- a/tools/test_op_benchmark.sh
+++ b/tools/test_op_benchmark.sh
@@ -187,7 +187,7 @@ function run_op_benchmark_test {
   done
   # install tensorflow for testing accuary
   pip install tensorflow==2.3.0 tensorflow-probability
-  for branch_name in "develop" "test_pr"
+  for branch_name in "develop" "test"
   do
     git checkout $branch_name
     [ $? -ne 0 ] && LOG "[FATAL] Missing branch ${branch_name}." && exit 7


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复OP benchmark CI中`Missing branch test_pr`的错误。

失败日志：https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2572055/job/3586198

失败原因：CI升级统一使用一份git clone的代码，其中pr所用测试分支统一使用为`test`，OP benchmark CI使用的为`test_pr`。