### PR TITLE
equal_op add float16

### DIFF
--- a/python/paddle/fluid/layers/control_flow.py
+++ b/python/paddle/fluid/layers/control_flow.py
@@ -1827,10 +1827,10 @@ def equal(x, y, cond=None, name=None):
           out1 = fluid.layers.equal(x=label,y=limit) #out1=[True, False]
           out2 = fluid.layers.equal(x=label_cond,y=limit, cond=out_cond) #out2=[False, True] out_cond=[False, True]
     """
-    check_variable_and_dtype(x, "x", ["float32", "float64", "int32", "int64"],
-                             "equal")
-    check_variable_and_dtype(y, "y", ["float32", "float64", "int32", "int64"],
-                             "equal")
+    check_variable_and_dtype(
+        x, "x", ["float16", "float32", "float64", "int32", "int64"], "equal")
+    check_variable_and_dtype(
+        y, "y", ["float16", "float32", "float64", "int32", "int64"], "equal")
     if cond is not None:
         check_type(cond, "cond", Variable, "equal")
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->
python端允许类型为float16