### PR TITLE
update 2.0 public api in dataset&framework

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -264,6 +264,7 @@ from .framework import DataParallel  #DEFINE_ALIAS
 
 from .framework import set_default_dtype  #DEFINE_ALIAS
 from .framework import get_default_dtype  #DEFINE_ALIAS
+from .framework import set_grad_enabled  #DEFINE_ALIAS
 
 from .tensor.search import index_sample  #DEFINE_ALIAS
 from .tensor.stat import mean  #DEFINE_ALIAS

--- a/python/paddle/dataset/__init__.py
+++ b/python/paddle/dataset/__init__.py
@@ -15,18 +15,18 @@
 Dataset package.
 """
 
-import paddle.dataset.mnist
-import paddle.dataset.imikolov
-import paddle.dataset.imdb
-import paddle.dataset.cifar
-import paddle.dataset.movielens
-import paddle.dataset.conll05
-import paddle.dataset.uci_housing
-import paddle.dataset.wmt14
-import paddle.dataset.wmt16
-import paddle.dataset.flowers
-import paddle.dataset.voc2012
-import paddle.dataset.image
+import paddle.dataset.mnist  # noqa: F401
+import paddle.dataset.imikolov  # noqa: F401
+import paddle.dataset.imdb  # noqa: F401
+import paddle.dataset.cifar  # noqa: F401
+import paddle.dataset.movielens  # noqa: F401
+import paddle.dataset.conll05  # noqa: F401
+import paddle.dataset.uci_housing  # noqa: F401
+import paddle.dataset.wmt14  # noqa: F401
+import paddle.dataset.wmt16  # noqa: F401
+import paddle.dataset.flowers  # noqa: F401
+import paddle.dataset.voc2012  # noqa: F401
+import paddle.dataset.image  # noqa: F401
 
 # set __all__ as empty for not showing APIs under paddle.dataset
 __all__ = []

--- a/python/paddle/dataset/cifar.py
+++ b/python/paddle/dataset/cifar.py
@@ -37,8 +37,6 @@ import tarfile
 import six
 from six.moves import cPickle as pickle
 
-__all__ = ['train100', 'test100', 'train10', 'test10']
-
 URL_PREFIX = 'https://dataset.bj.bcebos.com/cifar/'
 CIFAR10_URL = URL_PREFIX + 'cifar-10-python.tar.gz'
 CIFAR10_MD5 = 'c58f30108f718f92721af3b95e74349a'

--- a/python/paddle/dataset/common.py
+++ b/python/paddle/dataset/common.py
@@ -26,14 +26,6 @@ import paddle.dataset
 import six.moves.cPickle as pickle
 import glob
 
-__all__ = [
-    'DATA_HOME',
-    'download',
-    'md5file',
-    'split',
-    'cluster_files_reader',
-]
-
 HOME = os.path.expanduser('~')
 DATA_HOME = os.path.join(HOME, '.cache', 'paddle', 'dataset')
 

--- a/python/paddle/dataset/conll05.py
+++ b/python/paddle/dataset/conll05.py
@@ -30,8 +30,6 @@ import paddle.compat as cpt
 import paddle.utils.deprecated as deprecated
 from six.moves import zip, range
 
-__all__ = ['test, get_dict', 'get_embedding']
-
 DATA_URL = 'http://paddlemodels.bj.bcebos.com/conll05st/conll05st-tests.tar.gz'
 DATA_MD5 = '387719152ae52d60422c016e92a742fc'
 WORDDICT_URL = 'http://paddlemodels.bj.bcebos.com/conll05st%2FwordDict.txt'

--- a/python/paddle/dataset/flowers.py
+++ b/python/paddle/dataset/flowers.py
@@ -35,7 +35,12 @@ import itertools
 import functools
 from .common import download
 import tarfile
-from paddle.dataset.image import *
+
+from paddle.dataset.image import load_image_bytes
+from paddle.dataset.image import load_image
+from paddle.dataset.image import simple_transform
+from paddle.dataset.image import batch_images_from_tar
+
 from paddle.reader import map_readers, xmap_readers
 from paddle import compat as cpt
 import paddle.utils.deprecated as deprecated
@@ -45,7 +50,6 @@ from multiprocessing import cpu_count
 import six
 from six.moves import cPickle as pickle
 from paddle.utils import try_import
-__all__ = ['train', 'test', 'valid']
 
 DATA_URL = 'http://paddlemodels.bj.bcebos.com/flowers/102flowers.tgz'
 LABEL_URL = 'http://paddlemodels.bj.bcebos.com/flowers/imagelabels.mat'

--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -58,12 +58,6 @@ import os
 import tarfile
 import six.moves.cPickle as pickle
 
-__all__ = [
-    "load_image_bytes", "load_image", "resize_short", "to_chw", "center_crop",
-    "random_crop", "left_right_flip", "simple_transform", "load_and_transform",
-    "batch_images_from_tar"
-]
-
 
 def _check_cv2():
     if cv2 is None:

--- a/python/paddle/dataset/imdb.py
+++ b/python/paddle/dataset/imdb.py
@@ -30,8 +30,6 @@ import re
 import string
 import six
 
-__all__ = ['build_dict', 'train', 'test']
-
 #URL = 'http://ai.stanford.edu/%7Eamaas/data/sentiment/aclImdb_v1.tar.gz'
 URL = 'https://dataset.bj.bcebos.com/imdb%2FaclImdb_v1.tar.gz'
 MD5 = '7c2ac02c03563afcf9b574c7e56c153a'

--- a/python/paddle/dataset/imikolov.py
+++ b/python/paddle/dataset/imikolov.py
@@ -27,8 +27,6 @@ import collections
 import tarfile
 import six
 
-__all__ = ['train', 'test', 'build_dict']
-
 #URL = 'http://www.fit.vutbr.cz/~imikolov/rnnlm/simple-examples.tgz'
 URL = 'https://dataset.bj.bcebos.com/imikolov%2Fsimple-examples.tgz'
 MD5 = '30177ea32e27c525793142b6bf2c8e2d'

--- a/python/paddle/dataset/mnist.py
+++ b/python/paddle/dataset/mnist.py
@@ -26,7 +26,6 @@ import gzip
 import numpy
 import struct
 from six.moves import range
-__all__ = ['train', 'test']
 
 URL_PREFIX = 'https://dataset.bj.bcebos.com/mnist/'
 TEST_IMAGE_URL = URL_PREFIX + 't10k-images-idx3-ubyte.gz'

--- a/python/paddle/dataset/movielens.py
+++ b/python/paddle/dataset/movielens.py
@@ -34,11 +34,6 @@ import functools
 import six
 import paddle.compat as cpt
 
-__all__ = [
-    'train', 'test', 'get_movie_title_dict', 'max_movie_id', 'max_user_id',
-    'age_table', 'movie_categories', 'max_job_id', 'user_info', 'movie_info'
-]
-
 age_table = [1, 18, 25, 35, 45, 50, 56]
 
 #URL = 'http://files.grouplens.org/datasets/movielens/ml-1m.zip'

--- a/python/paddle/dataset/uci_housing.py
+++ b/python/paddle/dataset/uci_housing.py
@@ -29,8 +29,6 @@ import os
 import paddle.dataset.common
 import paddle.utils.deprecated as deprecated
 
-__all__ = ['train', 'test']
-
 URL = 'http://paddlemodels.bj.bcebos.com/uci_housing/housing.data'
 MD5 = 'd4accdce7a25600298819f8e28e8d593'
 feature_names = [

--- a/python/paddle/dataset/voc2012.py
+++ b/python/paddle/dataset/voc2012.py
@@ -29,8 +29,6 @@ from paddle.dataset.image import *
 import paddle.utils.deprecated as deprecated
 from PIL import Image
 
-__all__ = ['train', 'test', 'val']
-
 VOC_URL = 'http://host.robots.ox.ac.uk/pascal/VOC/voc2012/\
 VOCtrainval_11-May-2012.tar'
 

--- a/python/paddle/dataset/wmt14.py
+++ b/python/paddle/dataset/wmt14.py
@@ -30,12 +30,6 @@ import paddle.dataset.common
 import paddle.compat as cpt
 import paddle.utils.deprecated as deprecated
 
-__all__ = [
-    'train',
-    'test',
-    'get_dict',
-]
-
 URL_DEV_TEST = ('http://www-lium.univ-lemans.fr/~schwenk/'
                 'cslm_joint_paper/data/dev+test.tgz')
 MD5_DEV_TEST = '7d7897317ddd8ba0ae5c5fa7248d3ff5'

--- a/python/paddle/dataset/wmt16.py
+++ b/python/paddle/dataset/wmt16.py
@@ -40,14 +40,6 @@ import paddle
 import paddle.compat as cpt
 import paddle.utils.deprecated as deprecated
 
-__all__ = [
-    "train",
-    "test",
-    "validation",
-    "fetch",
-    "get_dict",
-]
-
 DATA_URL = ("http://paddlemodels.bj.bcebos.com/wmt/wmt16.tar.gz")
 DATA_MD5 = "0c38be43600334966403524a40dcd81e"
 

--- a/python/paddle/framework/__init__.py
+++ b/python/paddle/framework/__init__.py
@@ -12,35 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: import framework api under this directory
-__all__ = [
-    'create_parameter', 'ParamAttr', 'CPUPlace', 'CUDAPlace', 'CUDAPinnedPlace',
-    'NPUPlace', 'get_default_dtype', 'set_default_dtype'
-]
+# TODO: import framework api under this directory 
 
-__all__ += [
-    'grad', 'set_grad_enabled', 'LayerList', 'load', 'save', 'no_grad',
-    'DataParallel'
-]
+from . import random  # noqa: F401
+from .random import seed  # noqa: F401
+from .framework import get_default_dtype  # noqa: F401
+from .framework import set_default_dtype  # noqa: F401
+from .framework import set_grad_enabled  # noqa: F401
 
-from . import random
-from .random import seed
-from .framework import get_default_dtype
-from .framework import set_default_dtype
-from .framework import set_grad_enabled
+from ..fluid.param_attr import ParamAttr  # noqa: F401
+from ..fluid.layers.tensor import create_parameter  # noqa: F401
+from ..fluid.core import CPUPlace  # noqa: F401
+from ..fluid.core import CUDAPlace  # noqa: F401
+from ..fluid.core import CUDAPinnedPlace  # noqa: F401
+from ..fluid.core import NPUPlace  # noqa: F401
+from ..fluid.core import VarBase  # noqa: F401
 
-from ..fluid.param_attr import ParamAttr  #DEFINE_ALIAS
-# from ..fluid.layers.tensor import create_global_var  #DEFINE_ALIAS
-from ..fluid.layers.tensor import create_parameter  #DEFINE_ALIAS
-from ..fluid.core import CPUPlace  #DEFINE_ALIAS
-from ..fluid.core import CUDAPlace  #DEFINE_ALIAS
-from ..fluid.core import CUDAPinnedPlace  #DEFINE_ALIAS
-from ..fluid.core import NPUPlace  #DEFINE_ALIAS
-from ..fluid.core import VarBase  #DEFINE_ALIAS
-
-from paddle.fluid import core  #DEFINE_ALIAS
-from ..fluid.dygraph.base import no_grad_ as no_grad  #DEFINE_ALIAS
-from ..fluid.dygraph.base import grad  #DEFINE_ALIAS
-from .io import save
-from .io import load
-from ..fluid.dygraph.parallel import DataParallel  #DEFINE_ALIAS
+from paddle.fluid import core  # noqa: F401
+from ..fluid.dygraph.base import no_grad_ as no_grad  # noqa: F401
+from ..fluid.dygraph.base import grad  # noqa: F401
+from .io import save  # noqa: F401
+from .io import load  # noqa: F401
+from ..fluid.dygraph.parallel import DataParallel  # noqa: F401

--- a/python/paddle/framework/framework.py
+++ b/python/paddle/framework/framework.py
@@ -19,8 +19,6 @@ from paddle.fluid.framework import _dygraph_tracer
 import numpy as np
 from contextlib import contextmanager
 
-__all__ = ['set_default_dtype', 'get_default_dtype']
-
 
 def set_default_dtype(d):
     """

--- a/python/paddle/framework/io.py
+++ b/python/paddle/framework/io.py
@@ -38,11 +38,6 @@ from paddle.fluid.dygraph.jit import _SaveLoadConfig
 from paddle.fluid.dygraph.io import _construct_program_holders, _construct_params_and_buffers
 from paddle.fluid.dygraph.io import INFER_MODEL_SUFFIX, INFER_PARAMS_SUFFIX, INFER_PARAMS_INFO_SUFFIX
 
-__all__ = [
-    'save',
-    'load',
-]
-
 
 def _build_saved_state_dict(state_dict):
     save_dict = {}

--- a/python/paddle/framework/random.py
+++ b/python/paddle/framework/random.py
@@ -16,8 +16,6 @@
 import paddle.fluid as fluid
 from paddle.fluid import core
 
-__all__ = ['seed', 'get_cuda_rng_state', 'set_cuda_rng_state']
-
 
 def seed(seed):
     """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in dataset&framework

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *


本pr相关修改对api的调用无明显影响