### PR TITLE
fix dynamic graph to static graph bug of expand op when shape = -1.

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1447,7 +1447,7 @@ def expand(x, shape, name=None):
     def get_attr_expand_shape(list_expand_shape):
         attrs_expand_shape = []
         for idx, shape in enumerate(list_expand_shape):
-            if isinstance(shape, Variable):
+            if isinstance(shape, Variable) or shape == -1:
                 attrs_expand_shape.append(-2)
             else:
                 attrs_expand_shape.append(shape)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
gx原本shape为(-1, 1, -1)，
t=paddle.expand(gx, [-1, -1, -1])，此时t的shape为(-1, 1, -1)，不符预期，应为(-1, -1, -1)。
因为运行期间，如果expand中shape为（2，480，480），那么输出的shape应为（2，480，480），可实际的shape为（2，1，480）。
shape=-1时不能直接拷贝原shape，应在运行期间决定shape。
与李龙修复的shape中包含变量，应在运行期决定shape，而不是编译期。逻辑相同。