### PR TITLE
update 2.0 public api in static&text

### DIFF
--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -12,88 +12,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO: import framework api under this directory 
-__all__ = [
-    'append_backward',
-    'gradients',
-    'Executor',
-    'global_scope',
-    'scope_guard',
-    'BuildStrategy',
-    'CompiledProgram',
-    'Print',
-    'py_func',
-    'ExecutionStrategy',
-    'name_scope',
-    'ParallelExecutor',
-    'program_guard',
-    'WeightNormParamAttr',
-    'default_main_program',
-    'default_startup_program',
-    'Program',
-    'data',
-    'InputSpec',
-    'save',
-    'load',
-    'save_inference_model',
-    'load_inference_model',
-    'load_program_state',
-    'set_program_state',
-    'cpu_places',
-    'cuda_places',
-    'xpu_places',
-    'Variable',
-    'load_vars',
-    'save_vars',
-    'auc',
-    'accuracy',
+from . import amp  # noqa: F401
+from . import nn  # noqa: F401
+from .io import save_inference_model  # noqa: F401
+from .io import load_inference_model  # noqa: F401
+from .io import deserialize_persistables  # noqa: F401
+from .io import serialize_persistables  # noqa: F401
+from .io import deserialize_program  # noqa: F401
+from .io import serialize_program  # noqa: F401
+from .io import load_from_file  # noqa: F401
+from .io import save_to_file  # noqa: F401
+from .io import normalize_program  # noqa: F401
+from ..fluid import Scope  # noqa: F401
+from .input import data  # noqa: F401
+from .input import InputSpec  # noqa: F401
+from ..fluid.executor import Executor  # noqa: F401
+from ..fluid.executor import global_scope  # noqa: F401
+from ..fluid.executor import scope_guard  # noqa: F401
+from ..fluid.backward import append_backward  # noqa: F401
+from ..fluid.backward import gradients  # noqa: F401
+from ..fluid.compiler import BuildStrategy  # noqa: F401
+from ..fluid.compiler import CompiledProgram  # noqa: F401
+from ..fluid.compiler import ExecutionStrategy  # noqa: F401
+from ..fluid.framework import default_main_program  # noqa: F401
+from ..fluid.framework import default_startup_program  # noqa: F401
+from ..fluid.framework import device_guard  # noqa: F401
+from ..fluid.framework import Program  # noqa: F401
+from ..fluid.framework import name_scope  # noqa: F401
+from ..fluid.framework import program_guard  # noqa: F401
+from ..fluid.framework import cpu_places  # noqa: F401
+from ..fluid.framework import cuda_places  # noqa: F401
+from ..fluid.framework import xpu_places  # noqa: F401
+from ..fluid.framework import Variable  # noqa: F401
+from ..fluid.layers.control_flow import Print  # noqa: F401
+from ..fluid.layers.nn import py_func  # noqa: F401
+from ..fluid.parallel_executor import ParallelExecutor  # noqa: F401
+from ..fluid.param_attr import WeightNormParamAttr  # noqa: F401
+from ..fluid.io import save  # noqa: F401
+from ..fluid.io import load  # noqa: F401
+from ..fluid.io import load_program_state  # noqa: F401
+from ..fluid.io import set_program_state  # noqa: F401
+
+from ..fluid.io import load_vars  # noqa: F401
+from ..fluid.io import save_vars  # noqa: F401
+
+from ..fluid.layers import create_parameter  # noqa: F401
+from ..fluid.layers import create_global_var  # noqa: F401
+from ..fluid.layers.metric_op import auc  # noqa: F401
+from ..fluid.layers.metric_op import accuracy  # noqa: F401
+
+__all__ = [     #noqa
+           'append_backward',
+           'gradients',
+           'Executor',
+           'global_scope',
+           'scope_guard',
+           'BuildStrategy',
+           'CompiledProgram',
+           'Print',
+           'py_func',
+           'ExecutionStrategy',
+           'name_scope',
+           'ParallelExecutor',
+           'program_guard',
+           'WeightNormParamAttr',
+           'default_main_program',
+           'default_startup_program',
+           'Program',
+           'data',
+           'InputSpec',
+           'save',
+           'load',
+           'save_inference_model',
+           'load_inference_model',
+           'load_program_state',
+           'set_program_state',
+           'cpu_places',
+           'cuda_places',
+           'Variable',
+           'create_global_var'
 ]
-
-from . import nn
-from . import amp
-from .io import save_inference_model  #DEFINE_ALIAS
-from .io import load_inference_model  #DEFINE_ALIAS
-from .io import deserialize_persistables  #DEFINE_ALIAS
-from .io import serialize_persistables  #DEFINE_ALIAS
-from .io import deserialize_program  #DEFINE_ALIAS
-from .io import serialize_program  #DEFINE_ALIAS
-from .io import load_from_file  #DEFINE_ALIAS
-from .io import save_to_file  #DEFINE_ALIAS
-from .io import normalize_program  #DEFINE_ALIAS
-from ..fluid import Scope  #DEFINE_ALIAS
-from .input import data  #DEFINE_ALIAS
-from .input import InputSpec  #DEFINE_ALIAS
-from ..fluid.executor import Executor  #DEFINE_ALIAS
-from ..fluid.executor import global_scope  #DEFINE_ALIAS
-from ..fluid.executor import scope_guard  #DEFINE_ALIAS
-from ..fluid.backward import append_backward  #DEFINE_ALIAS
-from ..fluid.backward import gradients  #DEFINE_ALIAS
-from ..fluid.compiler import BuildStrategy  #DEFINE_ALIAS
-from ..fluid.compiler import CompiledProgram  #DEFINE_ALIAS
-from ..fluid.compiler import ExecutionStrategy  #DEFINE_ALIAS
-from ..fluid.framework import default_main_program  #DEFINE_ALIAS
-from ..fluid.framework import default_startup_program  #DEFINE_ALIAS
-from ..fluid.framework import device_guard  #DEFINE_ALIAS
-from ..fluid.framework import Program  #DEFINE_ALIAS
-from ..fluid.framework import name_scope  #DEFINE_ALIAS
-from ..fluid.framework import program_guard  #DEFINE_ALIAS
-from ..fluid.framework import cpu_places  #DEFINE_ALIAS
-from ..fluid.framework import cuda_places  #DEFINE_ALIAS
-from ..fluid.framework import xpu_places  #DEFINE_ALIAS
-from ..fluid.framework import Variable  #DEFINE_ALIAS
-from ..fluid.layers.control_flow import Print  #DEFINE_ALIAS
-from ..fluid.layers.nn import py_func  #DEFINE_ALIAS
-from ..fluid.parallel_executor import ParallelExecutor  #DEFINE_ALIAS
-from ..fluid.param_attr import WeightNormParamAttr  #DEFINE_ALIAS
-from ..fluid.io import save  #DEFINE_ALIAS
-from ..fluid.io import load  #DEFINE_ALIAS
-from ..fluid.io import load_program_state  #DEFINE_ALIAS
-from ..fluid.io import set_program_state  #DEFINE_ALIAS
-
-from ..fluid.io import load_vars  #DEFINE_ALIAS
-from ..fluid.io import save_vars  #DEFINE_ALIAS
-
-from ..fluid.layers import create_parameter  #DEFINE_ALIAS
-from ..fluid.layers import create_global_var  #DEFINE_ALIAS
-from ..fluid.layers.metric_op import auc  #DEFINE_ALIAS
-from ..fluid.layers.metric_op import accuracy  #DEFINE_ALIAS

--- a/python/paddle/static/amp/__init__.py
+++ b/python/paddle/static/amp/__init__.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...fluid.contrib import mixed_precision
-from ...fluid.contrib.mixed_precision import *
-from ...fluid.contrib.mixed_precision import bf16
-from ...fluid.contrib.mixed_precision.bf16 import *
-
-__all__ = mixed_precision.__all__
-__all__ += bf16.__all__
+from ...fluid.contrib.mixed_precision import decorate  # noqa: F401
+from ...fluid.contrib.mixed_precision import CustomOpLists  # noqa: F401
+from ...fluid.contrib.mixed_precision import AutoMixedPrecisionLists  # noqa: F401
+from ...fluid.contrib.mixed_precision import fp16_guard  # noqa: F401
+from ...fluid.contrib.mixed_precision import cast_model_to_fp16  # noqa: F401
+from ...fluid.contrib.mixed_precision import cast_parameters_to_fp16  # noqa: F401
+from ...fluid.contrib.mixed_precision import AutoMixedPrecisionListsBF16  # noqa: F401
+from ...fluid.contrib.mixed_precision import bf16_guard  # noqa: F401
+from ...fluid.contrib.mixed_precision import rewrite_program_bf16  # noqa: F401
+from ...fluid.contrib.mixed_precision import convert_float_to_uint16  # noqa: F401

--- a/python/paddle/static/input.py
+++ b/python/paddle/static/input.py
@@ -21,8 +21,6 @@ from paddle.fluid.data_feeder import check_type
 from paddle.fluid.framework import convert_np_dtype_to_dtype_
 from paddle.fluid.framework import static_only
 
-__all__ = ['data', 'InputSpec']
-
 
 @static_only
 def data(name, shape, dtype=None, lod_level=0):

--- a/python/paddle/static/io.py
+++ b/python/paddle/static/io.py
@@ -37,18 +37,6 @@ from paddle.fluid.framework import static_only, Parameter
 from paddle.fluid.executor import Executor, global_scope
 from paddle.fluid.log_helper import get_logger
 
-__all__ = [
-    'save_inference_model',
-    'load_inference_model',
-    'serialize_program',
-    'serialize_persistables',
-    'save_to_file',
-    'deserialize_program',
-    'deserialize_persistables',
-    'load_from_file',
-    'normalize_program',
-]
-
 _logger = get_logger(
     __name__, logging.INFO, fmt='%(asctime)s-%(levelname)s: %(message)s')
 

--- a/python/paddle/static/nn/__init__.py
+++ b/python/paddle/static/nn/__init__.py
@@ -12,7 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [
+from .common import fc  # noqa: F401
+from .common import deform_conv2d  # noqa: F401
+
+from ...fluid.layers import batch_norm  # noqa: F401
+from ...fluid.layers import bilinear_tensor_product  # noqa: F401
+from ...fluid.layers import case  # noqa: F401
+from ...fluid.layers import cond  # noqa: F401
+from ...fluid.layers import conv2d  # noqa: F401
+from ...fluid.layers import conv2d_transpose  # noqa: F401
+from ...fluid.layers import conv3d  # noqa: F401
+from ...fluid.layers import conv3d_transpose  # noqa: F401
+from ...fluid.layers import create_parameter  # noqa: F401
+from ...fluid.layers import crf_decoding  # noqa: F401
+from ...fluid.layers import data_norm  # noqa: F401
+from ...fluid.layers import group_norm  # noqa: F401
+from ...fluid.layers import instance_norm  # noqa: F401
+from ...fluid.layers import layer_norm  # noqa: F401
+from ...fluid.layers import multi_box_head  # noqa: F401
+from ...fluid.layers import nce  # noqa: F401
+from ...fluid.layers import prelu  # noqa: F401
+from ...fluid.layers import py_func  # noqa: F401
+from ...fluid.layers import row_conv  # noqa: F401
+from ...fluid.layers import spectral_norm  # noqa: F401
+from ...fluid.layers import switch_case  # noqa: F401
+from ...fluid.layers import while_loop  # noqa: F401
+
+from ...fluid.input import embedding  # noqa: F401
+from ...fluid.contrib.layers import sparse_embedding  # noqa: F401
+
+from ...fluid.layers.sequence_lod import sequence_conv  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_softmax  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_pool  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_concat  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_first_step  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_last_step  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_slice  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_expand  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_expand_as  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_pad  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_unpad  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_reshape  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_scatter  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_enumerate  # noqa: F401
+from ...fluid.layers.sequence_lod import sequence_reverse  # noqa: F401
+
+__all__ = [     #noqa
     'fc',
     'batch_norm',
     'embedding',
@@ -55,48 +100,3 @@ __all__ = [
     'sequence_enumerate',
     'sequence_reverse',
 ]
-
-from .common import fc  #DEFINE_ALIAS
-from .common import deform_conv2d  #DEFINE_ALIAS
-
-from ...fluid.layers import batch_norm  #DEFINE_ALIAS
-from ...fluid.layers import bilinear_tensor_product  #DEFINE_ALIAS
-from ...fluid.layers import case  #DEFINE_ALIAS
-from ...fluid.layers import cond  #DEFINE_ALIAS
-from ...fluid.layers import conv2d  #DEFINE_ALIAS
-from ...fluid.layers import conv2d_transpose  #DEFINE_ALIAS
-from ...fluid.layers import conv3d  #DEFINE_ALIAS
-from ...fluid.layers import conv3d_transpose  #DEFINE_ALIAS
-from ...fluid.layers import create_parameter  #DEFINE_ALIAS
-from ...fluid.layers import crf_decoding  #DEFINE_ALIAS
-from ...fluid.layers import data_norm  #DEFINE_ALIAS
-from ...fluid.layers import group_norm  #DEFINE_ALIAS
-from ...fluid.layers import instance_norm  #DEFINE_ALIAS
-from ...fluid.layers import layer_norm  #DEFINE_ALIAS
-from ...fluid.layers import multi_box_head  #DEFINE_ALIAS
-from ...fluid.layers import nce  #DEFINE_ALIAS
-from ...fluid.layers import prelu  #DEFINE_ALIAS
-from ...fluid.layers import py_func  #DEFINE_ALIAS
-from ...fluid.layers import row_conv  #DEFINE_ALIAS
-from ...fluid.layers import spectral_norm  #DEFINE_ALIAS
-from ...fluid.layers import switch_case  #DEFINE_ALIAS
-from ...fluid.layers import while_loop  #DEFINE_ALIAS
-
-from ...fluid.input import embedding  #DEFINE_ALIAS
-from ...fluid.contrib.layers import sparse_embedding  #DEFINE_ALIAS
-
-from ...fluid.layers.sequence_lod import sequence_conv
-from ...fluid.layers.sequence_lod import sequence_softmax
-from ...fluid.layers.sequence_lod import sequence_pool
-from ...fluid.layers.sequence_lod import sequence_concat
-from ...fluid.layers.sequence_lod import sequence_first_step
-from ...fluid.layers.sequence_lod import sequence_last_step
-from ...fluid.layers.sequence_lod import sequence_slice
-from ...fluid.layers.sequence_lod import sequence_expand
-from ...fluid.layers.sequence_lod import sequence_expand_as
-from ...fluid.layers.sequence_lod import sequence_pad
-from ...fluid.layers.sequence_lod import sequence_unpad
-from ...fluid.layers.sequence_lod import sequence_reshape
-from ...fluid.layers.sequence_lod import sequence_scatter
-from ...fluid.layers.sequence_lod import sequence_enumerate
-from ...fluid.layers.sequence_lod import sequence_reverse

--- a/python/paddle/static/nn/common.py
+++ b/python/paddle/static/nn/common.py
@@ -15,8 +15,6 @@
 import paddle
 from paddle.fluid.framework import static_only
 
-__all__ = ['fc', 'deform_conv2d']
-
 
 @static_only
 def fc(x,

--- a/python/paddle/text/__init__.py
+++ b/python/paddle/text/__init__.py
@@ -12,7 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import datasets
-from .datasets import *
+from .datasets import Conll05st  # noqa: F401
+from .datasets import Imdb  # noqa: F401
+from .datasets import Imikolov  # noqa: F401
+from .datasets import Movielens  # noqa: F401
+from .datasets import UCIHousing  # noqa: F401
+from .datasets import WMT14  # noqa: F401
+from .datasets import WMT16  # noqa: F401
 
-__all__ = datasets.__all__
+
+__all__ = [ #noqa
+           'Conll05st',
+           'Imdb',
+           'Imikolov',
+           'Movielens',
+           'UCIHousing',
+           'WMT14',
+           'WMT16'
+]

--- a/python/paddle/text/datasets/__init__.py
+++ b/python/paddle/text/datasets/__init__.py
@@ -12,26 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import conll05
-from . import imdb
-from . import imikolov
-from . import movielens
-from . import uci_housing
-from . import wmt14
-from . import wmt16
-
-from .conll05 import *
-from .imdb import *
-from .imikolov import *
-from .movielens import *
-from .uci_housing import *
-from .wmt14 import *
-from .wmt16 import *
-
-__all__ = conll05.__all__ \
-          + imdb.__all__ \
-          + imikolov.__all__ \
-          + movielens.__all__ \
-          + uci_housing.__all__ \
-          + wmt14.__all__ \
-          + wmt16.__all__
+from .conll05 import Conll05st  # noqa: F401
+from .imdb import Imdb  # noqa: F401
+from .imikolov import Imikolov  # noqa: F401
+from .movielens import Movielens  # noqa: F401
+from .uci_housing import UCIHousing  # noqa: F401
+from .wmt14 import WMT14  # noqa: F401
+from .wmt16 import WMT16  # noqa: F401

--- a/python/paddle/text/datasets/conll05.py
+++ b/python/paddle/text/datasets/conll05.py
@@ -24,8 +24,6 @@ from paddle.io import Dataset
 import paddle.compat as cpt
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ['Conll05st']
-
 DATA_URL = 'http://paddlemodels.bj.bcebos.com/conll05st/conll05st-tests.tar.gz'
 DATA_MD5 = '387719152ae52d60422c016e92a742fc'
 WORDDICT_URL = 'http://paddlemodels.bj.bcebos.com/conll05st%2FwordDict.txt'

--- a/python/paddle/text/datasets/imdb.py
+++ b/python/paddle/text/datasets/imdb.py
@@ -24,8 +24,6 @@ import collections
 from paddle.io import Dataset
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ['Imdb']
-
 URL = 'https://dataset.bj.bcebos.com/imdb%2FaclImdb_v1.tar.gz'
 MD5 = '7c2ac02c03563afcf9b574c7e56c153a'
 

--- a/python/paddle/text/datasets/imikolov.py
+++ b/python/paddle/text/datasets/imikolov.py
@@ -22,8 +22,6 @@ import collections
 from paddle.io import Dataset
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ['Imikolov']
-
 URL = 'https://dataset.bj.bcebos.com/imikolov%2Fsimple-examples.tgz'
 MD5 = '30177ea32e27c525793142b6bf2c8e2d'
 

--- a/python/paddle/text/datasets/movielens.py
+++ b/python/paddle/text/datasets/movielens.py
@@ -26,8 +26,6 @@ from paddle.io import Dataset
 import paddle.compat as cpt
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ['Movielens']
-
 age_table = [1, 18, 25, 35, 45, 50, 56]
 
 URL = 'https://dataset.bj.bcebos.com/movielens%2Fml-1m.zip'

--- a/python/paddle/text/datasets/uci_housing.py
+++ b/python/paddle/text/datasets/uci_housing.py
@@ -21,8 +21,6 @@ import paddle
 from paddle.io import Dataset
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ["UCIHousing"]
-
 URL = 'http://paddlemodels.bj.bcebos.com/uci_housing/housing.data'
 MD5 = 'd4accdce7a25600298819f8e28e8d593'
 feature_names = [

--- a/python/paddle/text/datasets/wmt14.py
+++ b/python/paddle/text/datasets/wmt14.py
@@ -22,8 +22,6 @@ from paddle.io import Dataset
 import paddle.compat as cpt
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ['WMT14']
-
 URL_DEV_TEST = ('http://www-lium.univ-lemans.fr/~schwenk/'
                 'cslm_joint_paper/data/dev+test.tgz')
 MD5_DEV_TEST = '7d7897317ddd8ba0ae5c5fa7248d3ff5'

--- a/python/paddle/text/datasets/wmt16.py
+++ b/python/paddle/text/datasets/wmt16.py
@@ -27,8 +27,6 @@ from paddle.io import Dataset
 import paddle.compat as cpt
 from paddle.dataset.common import _check_exists_and_download
 
-__all__ = ['WMT16']
-
 DATA_URL = ("http://paddlemodels.bj.bcebos.com/wmt/wmt16.tar.gz")
 DATA_MD5 = "0c38be43600334966403524a40dcd81e"
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in static&text

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *

本pr相关修改对api的调用无明显影响