### PR TITLE
update 2.0 public api in utils

### DIFF
--- a/python/paddle/utils/__init__.py
+++ b/python/paddle/utils/__init__.py
@@ -12,21 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .profiler import ProfilerOptions
-from .profiler import Profiler
-from .profiler import get_profiler
-from .deprecated import deprecated
-from .lazy_import import try_import
-from .op_version import OpLastCheckpointChecker
-from .install_check import run_check
-from ..fluid.framework import unique_name
-from ..fluid.framework import require_version
+from .profiler import ProfilerOptions  # noqa: F401
+from .profiler import Profiler  # noqa: F401
+from .profiler import get_profiler  # noqa: F401
+from .deprecated import deprecated  # noqa: F401
+from .lazy_import import try_import  # noqa: F401
+from .op_version import OpLastCheckpointChecker  # noqa: F401
+from .install_check import run_check  # noqa: F401
+from ..fluid.framework import unique_name  # noqa: F401
+from ..fluid.framework import require_version  # noqa: F401
 
-from . import download
+from . import download  # noqa: F401
+from . import image_util  # noqa: F401
+from . import cpp_extension  # noqa: F401
 
-from . import cpp_extension
-
-__all__ = ['dump_config', 'deprecated', 'download', 'run_check']
-
-#TODO: define new api under this directory
-__all__ += ['unique_name', 'require_version']
+__all__ = [     #noqa
+           'deprecated',
+           'download',
+           'run_check',
+           'unique_name',
+           'require_version',
+           'try_import'
+]

--- a/python/paddle/utils/cpp_extension/__init__.py
+++ b/python/paddle/utils/cpp_extension/__init__.py
@@ -12,18 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .cpp_extension import CUDAExtension
-from .cpp_extension import CppExtension
-from .cpp_extension import BuildExtension
-from .cpp_extension import load, setup
+from .cpp_extension import CUDAExtension  # noqa: F401
+from .cpp_extension import CppExtension  # noqa: F401
+from .cpp_extension import BuildExtension  # noqa: F401
+from .cpp_extension import load  # noqa: F401
+from .cpp_extension import setup  # noqa: F401
 
-from .extension_utils import parse_op_info
-from .extension_utils import get_build_directory
-from .extension_utils import load_op_meta_info_and_register_op
+from .extension_utils import parse_op_info  # noqa: F401
+from .extension_utils import get_build_directory  # noqa: F401
+from .extension_utils import load_op_meta_info_and_register_op  # noqa: F401
 
-from . import cpp_extension
-from . import extension_utils
-
-__all__ = [
-    'CppExtension', 'CUDAExtension', 'load', 'setup', 'get_build_directory'
+__all__ = [ #noqa
+        'CppExtension',
+        'CUDAExtension',
+        'load',
+        'setup',
+        'get_build_directory'
 ]

--- a/python/paddle/utils/download.py
+++ b/python/paddle/utils/download.py
@@ -55,8 +55,6 @@ except:
 import logging
 logger = logging.getLogger(__name__)
 
-__all__ = ['get_weights_path_from_url']
-
 WEIGHTS_HOME = osp.expanduser("~/.cache/paddle/hapi/weights")
 
 DOWNLOAD_RETRY_LIMIT = 3

--- a/python/paddle/utils/install_check.py
+++ b/python/paddle/utils/install_check.py
@@ -20,8 +20,6 @@ import numpy as np
 
 import paddle
 
-__all__ = ['run_check']
-
 
 def _simple_network():
     """

--- a/python/paddle/utils/op_version.py
+++ b/python/paddle/utils/op_version.py
@@ -14,8 +14,6 @@
 
 from ..fluid import core
 
-__all__ = ['OpLastCheckpointChecker']
-
 
 def Singleton(cls):
     _instance = {}

--- a/python/paddle/utils/profiler.py
+++ b/python/paddle/utils/profiler.py
@@ -18,9 +18,22 @@ import sys
 import warnings
 
 from ..fluid import core
-from ..fluid.profiler import *
+from ..fluid.profiler import cuda_profiler  # noqa: F401
+from ..fluid.profiler import start_profiler
+from ..fluid.profiler import profiler  # noqa: F401
+from ..fluid.profiler import stop_profiler
+from ..fluid.profiler import reset_profiler
 
-__all__ = ['ProfilerOptions', 'Profiler', 'get_profiler']
+__all__ = [     #noqa
+           'Profiler',
+           'get_profiler',
+           'ProfilerOptions',
+           'cuda_profiler',
+           'start_profiler',
+           'profiler',
+           'stop_profiler',
+           'reset_profiler'
+]
 
 
 class ProfilerOptions(object):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in utils

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *

本pr涉及到的api改动：
paddle.utils.__all__中移除dump_config，该函数并未实现
本pr其它修改对api的调用无明显影响