### PR TITLE
update 2.0 public api in io&reader

### DIFF
--- a/python/paddle/io/__init__.py
+++ b/python/paddle/io/__init__.py
@@ -13,26 +13,37 @@
 # limitations under the License.
 
 # TODO: define all functions about input & output in this directory 
-__all__ = [
-    'Dataset',
-    'IterableDataset',
-    'TensorDataset',
-    'ComposeDataset',
-    'ChainDataset',
-    'BatchSampler',
-    'DistributedBatchSampler',
-    #            'Transform',
-    'DataLoader',
-    'get_worker_info',
-    'Sampler',
-    'SequenceSampler',
-    'RandomSampler',
-    'WeightedRandomSampler',
-    'random_split',
-    'Subset'
-]
 
-from ..fluid.io import DataLoader
-from ..fluid.dataloader import Dataset, IterableDataset, BatchSampler, get_worker_info, \
-        TensorDataset, Sampler, SequenceSampler, RandomSampler, DistributedBatchSampler, \
-        ComposeDataset, ChainDataset, WeightedRandomSampler, Subset, random_split
+from ..fluid.io import DataLoader  # noqa: F401
+from ..fluid.dataloader import Dataset  # noqa: F401
+from ..fluid.dataloader import IterableDataset  # noqa: F401
+from ..fluid.dataloader import BatchSampler  # noqa: F401
+from ..fluid.dataloader import get_worker_info  # noqa: F401
+from ..fluid.dataloader import TensorDataset  # noqa: F401
+from ..fluid.dataloader import Sampler  # noqa: F401
+from ..fluid.dataloader import SequenceSampler  # noqa: F401
+from ..fluid.dataloader import RandomSampler  # noqa: F401
+from ..fluid.dataloader import DistributedBatchSampler  # noqa: F401
+from ..fluid.dataloader import ComposeDataset  # noqa: F401
+from ..fluid.dataloader import ChainDataset  # noqa: F401
+from ..fluid.dataloader import WeightedRandomSampler  # noqa: F401
+from ..fluid.dataloader import Subset  # noqa: F401
+from ..fluid.dataloader import random_split  # noqa: F401
+
+__all__ = [ #noqa
+           'Dataset',
+           'IterableDataset',
+           'TensorDataset',
+           'ComposeDataset',
+           'ChainDataset',
+           'BatchSampler',
+           'DistributedBatchSampler',
+           'DataLoader',
+           'get_worker_info',
+           'Sampler',
+           'SequenceSampler',
+           'RandomSampler',
+           'WeightedRandomSampler',
+           'random_split',
+           'Subset'
+]

--- a/python/paddle/reader/__init__.py
+++ b/python/paddle/reader/__init__.py
@@ -63,7 +63,15 @@ An example implementation for multiple item data reader creator:
 
 """
 
-import paddle.reader.decorator
-from paddle.reader.decorator import *
+from paddle.reader.decorator import map_readers  # noqa: F401
+from paddle.reader.decorator import shuffle  # noqa: F401
+from paddle.reader.decorator import xmap_readers  # noqa: F401
+from paddle.reader.decorator import firstn  # noqa: F401
+from paddle.reader.decorator import buffered  # noqa: F401
+from paddle.reader.decorator import compose  # noqa: F401
+from paddle.reader.decorator import cache  # noqa: F401
+from paddle.reader.decorator import ComposeNotAligned  # noqa: F401
+from paddle.reader.decorator import chain  # noqa: F401
+from paddle.reader.decorator import multiprocess_reader  # noqa: F401
 
 __all__ = []

--- a/python/paddle/reader/decorator.py
+++ b/python/paddle/reader/decorator.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = [
-    'cache', 'map_readers', 'buffered', 'compose', 'chain', 'shuffle',
-    'ComposeNotAligned', 'firstn', 'xmap_readers', 'multiprocess_reader'
-]
-
 from threading import Thread
 import subprocess
 import multiprocessing


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in io&reader

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *


本pr相关修改对api的调用无明显影响