### PR TITLE
update 2.0 public api in tensor

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -325,13 +325,7 @@ def monkey_patch_math_varbase():
     else:
         import paddle.tensor
         # Tensor method from module paddle.tensor
-        tensor_methods = paddle.tensor.linalg.__all__ + \
-                         paddle.tensor.math.__all__ + \
-                         paddle.tensor.logic.__all__ + \
-                         paddle.tensor.manipulation.__all__ + \
-                         paddle.tensor.search.__all__ + \
-                         paddle.tensor.stat.__all__ + \
-                         paddle.tensor.attribute.__all__
+        tensor_methods = paddle.tensor.tensor_method_func
         for method_name in tensor_methods:
             if hasattr(core.VarBase, method_name): continue
             method_impl = getattr(paddle.tensor, method_name, None)

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -370,13 +370,7 @@ def monkey_patch_variable():
             setattr(Variable, method_name, method_impl)
     else:
         import paddle.tensor
-        variabel_methods = paddle.tensor.linalg.__all__ + \
-                           paddle.tensor.math.__all__ + \
-                           paddle.tensor.logic.__all__ + \
-                           paddle.tensor.manipulation.__all__ + \
-                           paddle.tensor.search.__all__ + \
-                           paddle.tensor.stat.__all__ + \
-                           paddle.tensor.attribute.__all__
+        variabel_methods = paddle.tensor.tensor_method_func
         for method_name in variabel_methods:
             if hasattr(Variable, method_name): continue
             method_impl = getattr(paddle.tensor, method_name, None)

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -11,205 +11,315 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import print_function
 
-#from .math import *
-#from .creation import *
-#from .linalg import *
+from .attribute import rank  # noqa: F401
+from .attribute import shape  # noqa: F401
+from .attribute import real  # noqa: F401
+from .attribute import imag  # noqa: F401
+from .creation import to_tensor  # noqa: F401
+from .creation import diag  # noqa: F401
+from .creation import eye  # noqa: F401
+from .creation import linspace  # noqa: F401
+from .creation import ones  # noqa: F401
+from .creation import ones_like  # noqa: F401
+from .creation import zeros  # noqa: F401
+from .creation import zeros_like  # noqa: F401
+from .creation import arange  # noqa: F401
+from .creation import eye  # noqa: F401
+from .creation import full  # noqa: F401
+from .creation import full_like  # noqa: F401
+from .creation import triu  # noqa: F401
+from .creation import tril  # noqa: F401
+from .creation import meshgrid  # noqa: F401
+from .creation import empty  # noqa: F401
+from .creation import empty_like  # noqa: F401
+from .linalg import matmul  # noqa: F401
+from .linalg import dot  # noqa: F401
+from .linalg import norm  # noqa: F401
+from .linalg import transpose  # noqa: F401
+from .linalg import dist  # noqa: F401
+from .linalg import t  # noqa: F401
+from .linalg import cross  # noqa: F401
+from .linalg import cholesky  # noqa: F401
+from .linalg import bmm  # noqa: F401
+from .linalg import histogram  # noqa: F401
+from .linalg import mv  # noqa: F401
+from .logic import equal  # noqa: F401
+from .logic import greater_equal  # noqa: F401
+from .logic import greater_than  # noqa: F401
+from .logic import is_empty  # noqa: F401
+from .logic import less_equal  # noqa: F401
+from .logic import less_than  # noqa: F401
+from .logic import logical_and  # noqa: F401
+from .logic import logical_not  # noqa: F401
+from .logic import logical_or  # noqa: F401
+from .logic import logical_xor  # noqa: F401
+from .logic import not_equal  # noqa: F401
+from .logic import allclose  # noqa: F401
+from .logic import equal_all  # noqa: F401
+from .logic import is_tensor  # noqa: F401
+from .manipulation import cast  # noqa: F401
+from .manipulation import concat  # noqa: F401
+from .manipulation import expand  # noqa: F401
+from .manipulation import broadcast_to  # noqa: F401
+from .manipulation import expand_as  # noqa: F401
+from .manipulation import tile  # noqa: F401
+from .manipulation import flatten  # noqa: F401
+from .manipulation import gather  # noqa: F401
+from .manipulation import gather_nd  # noqa: F401
+from .manipulation import reshape  # noqa: F401
+from .manipulation import reshape_  # noqa: F401
+from .manipulation import flip as reverse  # noqa: F401
+from .manipulation import scatter  # noqa: F401
+from .manipulation import scatter_  # noqa: F401
+from .manipulation import scatter_nd_add  # noqa: F401
+from .manipulation import scatter_nd  # noqa: F401
+from .manipulation import shard_index  # noqa: F401
+from .manipulation import slice  # noqa: F401
+from .manipulation import split  # noqa: F401
+from .manipulation import squeeze  # noqa: F401
+from .manipulation import squeeze_  # noqa: F401
+from .manipulation import stack  # noqa: F401
+from .manipulation import strided_slice  # noqa: F401
+from .manipulation import transpose  # noqa: F401
+from .manipulation import unique  # noqa: F401
+from .manipulation import unsqueeze  # noqa: F401
+from .manipulation import unsqueeze_  # noqa: F401
+from .manipulation import unstack  # noqa: F401
+from .manipulation import flip  # noqa: F401
+from .manipulation import unbind  # noqa: F401
+from .manipulation import roll  # noqa: F401
+from .manipulation import chunk  # noqa: F401
+from .math import abs  # noqa: F401
+from .math import acos  # noqa: F401
+from .math import asin  # noqa: F401
+from .math import atan  # noqa: F401
+from .math import ceil  # noqa: F401
+from .math import cos  # noqa: F401
+from .math import tan  # noqa: F401
+from .math import cosh  # noqa: F401
+from .math import cumsum  # noqa: F401
+from .math import exp  # noqa: F401
+from .math import floor  # noqa: F401
+from .math import increment  # noqa: F401
+from .math import log  # noqa: F401
+from .math import multiplex  # noqa: F401
+from .math import pow  # noqa: F401
+from .math import reciprocal  # noqa: F401
+from .math import round  # noqa: F401
+from .math import rsqrt  # noqa: F401
+from .math import scale  # noqa: F401
+from .math import sign  # noqa: F401
+from .math import sin  # noqa: F401
+from .math import sinh  # noqa: F401
+from .math import sqrt  # noqa: F401
+from .math import square  # noqa: F401
+from .math import stanh  # noqa: F401
+from .math import sum  # noqa: F401
+from .math import tanh  # noqa: F401
+from .math import tanh_  # noqa: F401
+from .math import add_n  # noqa: F401
+from .math import max  # noqa: F401
+from .math import maximum  # noqa: F401
+from .math import min  # noqa: F401
+from .math import minimum  # noqa: F401
+from .math import mm  # noqa: F401
+from .math import divide  # noqa: F401
+from .math import floor_divide  # noqa: F401
+from .math import remainder  # noqa: F401
+from .math import mod  # noqa: F401
+from .math import floor_mod  # noqa: F401
+from .math import multiply  # noqa: F401
+from .math import add  # noqa: F401
+from .math import subtract  # noqa: F401
+from .math import atan  # noqa: F401
+from .math import logsumexp  # noqa: F401
+from .math import inverse  # noqa: F401
+from .math import log2  # noqa: F401
+from .math import log10  # noqa: F401
+from .math import log1p  # noqa: F401
+from .math import erf  # noqa: F401
+from .math import addmm  # noqa: F401
+from .math import clip  # noqa: F401
+from .math import trace  # noqa: F401
+from .math import kron  # noqa: F401
+from .math import isfinite  # noqa: F401
+from .math import isinf  # noqa: F401
+from .math import isnan  # noqa: F401
+from .math import prod  # noqa: F401
+from .math import all  # noqa: F401
+from .math import any  # noqa: F401
+from .math import broadcast_shape  # noqa: F401
+from .math import conj  # noqa: F401
 
-# TODO: define alias in tensor and framework directory
+from .random import multinomial  # noqa: F401
+from .random import standard_normal  # noqa: F401
+from .random import normal  # noqa: F401
+from .random import uniform  # noqa: F401
+from .random import randn  # noqa: F401
+from .random import rand  # noqa: F401
+from .random import randint  # noqa: F401
+from .random import randperm  # noqa: F401
+from .search import argmax  # noqa: F401
+from .search import argmin  # noqa: F401
+from .search import argsort  # noqa: F401
+from .search import topk  # noqa: F401
+from .search import where  # noqa: F401
+from .search import index_select  # noqa: F401
+from .search import nonzero  # noqa: F401
+from .search import sort  # noqa: F401
+from .search import index_sample  # noqa: F401
+from .search import masked_select  # noqa: F401
+from .stat import mean  # noqa: F401
+from .stat import std  # noqa: F401
+from .stat import var  # noqa: F401
+from .stat import numel  # noqa: F401
+from .stat import median  # noqa: F401
+from .to_string import set_printoptions  # noqa: F401
 
-from .random import randperm
-from .attribute import rank  #DEFINE_ALIAS
-from .attribute import shape  #DEFINE_ALIAS
-from .attribute import real  #DEFINE_ALIAS
-from .attribute import imag  #DEFINE_ALIAS
-from .creation import to_tensor  #DEFINE_ALIAS
-from .creation import diag  #DEFINE_ALIAS
-from .creation import eye  #DEFINE_ALIAS
-# from .creation import fill_constant  #DEFINE_ALIAS
-# from .creation import get_tensor_from_selected_rows        #DEFINE_ALIAS
-from .creation import linspace  #DEFINE_ALIAS
-from .creation import ones  #DEFINE_ALIAS
-from .creation import ones_like  #DEFINE_ALIAS
-from .creation import zeros  #DEFINE_ALIAS
-from .creation import zeros_like  #DEFINE_ALIAS
-from .creation import arange  #DEFINE_ALIAS
-from .creation import eye  #DEFINE_ALIAS
-from .creation import full  #DEFINE_ALIAS
-from .creation import full_like  #DEFINE_ALIAS
-from .creation import triu  #DEFINE_ALIAS
-from .creation import tril  #DEFINE_ALIAS
-from .creation import meshgrid  #DEFINE_ALIAS
-from .creation import empty  #DEFINE_ALIAS
-from .creation import empty_like  #DEFINE_ALIAS
-from .linalg import matmul  #DEFINE_ALIAS
-from .linalg import dot  #DEFINE_ALIAS
-# from .linalg import einsum        #DEFINE_ALIAS
-from .linalg import norm  #DEFINE_ALIAS
-from .linalg import transpose  #DEFINE_ALIAS
-from .linalg import dist  #DEFINE_ALIAS
-from .linalg import t  #DEFINE_ALIAS
-from .linalg import cross  #DEFINE_ALIAS
-from .linalg import cholesky  #DEFINE_ALIAS
-# from .linalg import tensordot        #DEFINE_ALIAS
-from .linalg import bmm  #DEFINE_ALIAS
-from .linalg import histogram  #DEFINE_ALIAS
-from .linalg import mv  #DEFINE_ALIAS
-from .logic import equal  #DEFINE_ALIAS
-from .logic import greater_equal  #DEFINE_ALIAS
-from .logic import greater_than  #DEFINE_ALIAS
-from .logic import is_empty  #DEFINE_ALIAS
-#from .logic import isfinite  #DEFINE_ALIAS
-from .logic import less_equal  #DEFINE_ALIAS
-from .logic import less_than  #DEFINE_ALIAS
-from .logic import logical_and  #DEFINE_ALIAS
-from .logic import logical_not  #DEFINE_ALIAS
-from .logic import logical_or  #DEFINE_ALIAS
-from .logic import logical_xor  #DEFINE_ALIAS
-from .logic import not_equal  #DEFINE_ALIAS
-from .logic import allclose  #DEFINE_ALIAS
-from .logic import equal_all  #DEFINE_ALIAS
-# from .logic import isnan        #DEFINE_ALIAS
-from .logic import is_tensor  #DEFINE_ALIAS
-from .manipulation import cast  #DEFINE_ALIAS
-from .manipulation import concat  #DEFINE_ALIAS
-from .manipulation import expand  #DEFINE_ALIAS
-from .manipulation import broadcast_to  #DEFINE_ALIAS
-from .manipulation import expand_as  #DEFINE_ALIAS
-from .manipulation import tile  #DEFINE_ALIAS
-from .manipulation import flatten  #DEFINE_ALIAS
-from .manipulation import gather  #DEFINE_ALIAS
-from .manipulation import gather_nd  #DEFINE_ALIAS
-from .manipulation import reshape  #DEFINE_ALIAS
-from .manipulation import reshape_  #DEFINE_ALIAS
-from .manipulation import flip as reverse  #DEFINE_ALIAS
-from .manipulation import scatter  #DEFINE_ALIAS
-from .manipulation import scatter_  #DEFINE_ALIAS
-from .manipulation import scatter_nd_add  #DEFINE_ALIAS
-from .manipulation import scatter_nd  #DEFINE_ALIAS
-from .manipulation import shard_index  #DEFINE_ALIAS
-from .manipulation import slice  #DEFINE_ALIAS
-from .manipulation import split  #DEFINE_ALIAS
-from .manipulation import squeeze  #DEFINE_ALIAS
-from .manipulation import squeeze_  #DEFINE_ALIAS
-from .manipulation import stack  #DEFINE_ALIAS
-from .manipulation import strided_slice  #DEFINE_ALIAS
-from .manipulation import transpose  #DEFINE_ALIAS
-from .manipulation import unique  #DEFINE_ALIAS
-from .manipulation import unsqueeze  #DEFINE_ALIAS
-from .manipulation import unsqueeze_  #DEFINE_ALIAS
-from .manipulation import unstack  #DEFINE_ALIAS
-from .manipulation import flip  #DEFINE_ALIAS
-from .manipulation import unbind  #DEFINE_ALIAS
-from .manipulation import roll  #DEFINE_ALIAS
-from .manipulation import chunk  #DEFINE_ALIAS
-from .math import abs  #DEFINE_ALIAS
-from .math import acos  #DEFINE_ALIAS
-from .math import asin  #DEFINE_ALIAS
-from .math import atan  #DEFINE_ALIAS
-from .math import ceil  #DEFINE_ALIAS
-from .math import cos  #DEFINE_ALIAS
-from .math import tan  #DEFINE_ALIAS
-from .math import cosh  #DEFINE_ALIAS
-from .math import cumsum  #DEFINE_ALIAS
-# from .math import elementwise_add  #DEFINE_ALIAS
-# from .math import elementwise_div  #DEFINE_ALIAS
-# from .math import elementwise_floordiv  #DEFINE_ALIAS
-# from .math import elementwise_mul  #DEFINE_ALIAS
-# from .math import elementwise_mod  #DEFINE_ALIAS
-# from .math import elementwise_pow  #DEFINE_ALIAS
-# from .math import elementwise_sub  #DEFINE_ALIAS
-from .math import exp  #DEFINE_ALIAS
-from .math import floor  #DEFINE_ALIAS
-from .math import increment  #DEFINE_ALIAS
-from .math import log  #DEFINE_ALIAS
-from .math import multiplex  #DEFINE_ALIAS
-from .math import pow  #DEFINE_ALIAS
-from .math import reciprocal  #DEFINE_ALIAS
-# from .math import reduce_max  #DEFINE_ALIAS
-# from .math import reduce_min  #DEFINE_ALIAS
-# from .math import reduce_prod  #DEFINE_ALIAS
-# from .math import reduce_sum  #DEFINE_ALIAS
-from .math import round  #DEFINE_ALIAS
-from .math import rsqrt  #DEFINE_ALIAS
-from .math import scale  #DEFINE_ALIAS
-from .math import sign  #DEFINE_ALIAS
-from .math import sin  #DEFINE_ALIAS
-from .math import sinh  #DEFINE_ALIAS
-from .math import sqrt  #DEFINE_ALIAS
-from .math import square  #DEFINE_ALIAS
-from .math import stanh  #DEFINE_ALIAS
-from .math import sum  #DEFINE_ALIAS
-from .math import tanh  #DEFINE_ALIAS
-from .math import tanh_  #DEFINE_ALIAS
-from .math import add_n  #DEFINE_ALIAS
-from .math import max  #DEFINE_ALIAS
-from .math import maximum  #DEFINE_ALIAS
-from .math import min  #DEFINE_ALIAS
-from .math import minimum  #DEFINE_ALIAS
-from .math import mm  #DEFINE_ALIAS
-from .math import divide  #DEFINE_ALIAS
-from .math import floor_divide  #DEFINE_ALIAS
-from .math import remainder  #DEFINE_ALIAS
-from .math import mod  #DEFINE_ALIAS
-from .math import floor_mod  #DEFINE_ALIAS
-from .math import multiply  #DEFINE_ALIAS
-from .math import add  #DEFINE_ALIAS
-from .math import subtract  #DEFINE_ALIAS
-from .math import atan  #DEFINE_ALIAS
-from .math import logsumexp  #DEFINE_ALIAS
-from .math import inverse  #DEFINE_ALIAS
-from .math import log2  #DEFINE_ALIAS
-from .math import log10  #DEFINE_ALIAS
-from .math import log1p  #DEFINE_ALIAS
-from .math import erf  #DEFINE_ALIAS
-from .math import addmm  #DEFINE_ALIAS
-from .math import clip  #DEFINE_ALIAS
-from .math import trace  #DEFINE_ALIAS
-from .math import kron  #DEFINE_ALIAS
-from .math import isfinite  #DEFINE_ALIAS
-from .math import isinf  #DEFINE_ALIAS
-from .math import isnan  #DEFINE_ALIAS
-from .math import prod  #DEFINE_ALIAS
-from .math import all  #DEFINE_ALIAS
-from .math import any  #DEFINE_ALIAS
-from .math import broadcast_shape  #DEFINE_ALIAS
-from .math import conj  #DEFINE_ALIAS
+from .array import array_length  # noqa: F401
+from .array import array_read  # noqa: F401
+from .array import array_write  # noqa: F401
+from .array import create_array  # noqa: F401
 
-from .random import multinomial  #DEFINE_ALIAS
-from .random import standard_normal
-from .random import normal
-from .random import uniform  #DEFINE_ALIAS
-from .random import randn  #DEFINE_ALIAS
-from .random import rand  #DEFINE_ALIAS
-from .random import randint  #DEFINE_ALIAS
-from .random import randperm  #DEFINE_ALIAS
-from .search import argmax  #DEFINE_ALIAS
-from .search import argmin  #DEFINE_ALIAS
-from .search import argsort  #DEFINE_ALIAS
-# from .search import has_inf  #DEFINE_ALIAS
-# from .search import has_nan  #DEFINE_ALIAS
-# from .search import masked_select        #DEFINE_ALIAS
-from .search import topk  #DEFINE_ALIAS
-from .search import where  #DEFINE_ALIAS
-from .search import index_select  #DEFINE_ALIAS
-from .search import nonzero  #DEFINE_ALIAS
-from .search import sort  #DEFINE_ALIAS
-from .search import index_sample  #DEFINE_ALIAS
-from .search import masked_select  #DEFINE_ALIAS
-from .stat import mean  #DEFINE_ALIAS
-# from .stat import reduce_mean  #DEFINE_ALIAS
-from .stat import std  #DEFINE_ALIAS
-from .stat import var  #DEFINE_ALIAS
-from .stat import numel  #DEFINE_ALIAS
-from .stat import median  #DEFINE_ALIAS
-# from .tensor import Tensor        #DEFINE_ALIAS
-# from .tensor import LoDTensor        #DEFINE_ALIAS
-# from .tensor import LoDTensorArray        #DEFINE_ALIAS
-from .to_string import set_printoptions  #DEFINE_ALIAS
-
-from .array import array_length  #DEFINE_ALIAS
-from .array import array_read  #DEFINE_ALIAS
-from .array import array_write  #DEFINE_ALIAS
-from .array import create_array  #DEFINE_ALIAS
+#this list used in math_op_patch.py for _binary_creator_
+tensor_method_func  = [ #noqa
+           'matmul',
+           'dot',
+           'norm',
+           'transpose',
+           'dist',
+           't',
+           'cross',
+           'cholesky',
+           'bmm',
+           'histogram',
+           'mv',
+           'abs',
+           'acos',
+           'all',
+           'any',
+           'asin',
+           'atan',
+           'ceil',
+           'cos',
+           'cosh',
+           'cumsum',
+           'exp',
+           'floor',
+           'increment',
+           'log',
+           'log2',
+           'log10',
+           'logsumexp',
+           'mul',
+           'multiplex',
+           'pow',
+           'prod',
+           'reciprocal',
+           'round',
+           'rsqrt',
+           'scale',
+           'sign',
+           'sin',
+           'sinh',
+           'sqrt',
+           'square',
+           'stanh',
+           'sum',
+           'tanh',
+           'tanh_',
+           'add_n',
+           'max',
+           'maximum',
+           'min',
+           'minimum',
+           'mm',
+           'divide',
+           'floor_divide',
+           'remainder',
+           'mod',
+           'floor_mod',
+           'multiply',
+           'add',
+           'subtract',
+           'atan',
+           'logsumexp',
+           'inverse',
+           'log1p',
+           'erf',
+           'addmm',
+           'clip',
+           'trace',
+           'kron',
+           'isfinite',
+           'isinf',
+           'isnan',
+           'broadcast_shape',
+           'conj',
+           'equal',
+           'equal_all',
+           'greater_equal',
+           'greater_than',
+           'is_empty',
+           'less_equal',
+           'less_than',
+           'logical_and',
+           'logical_not',
+           'logical_or',
+           'logical_xor',
+           'not_equal',
+           'allclose',
+           'is_tensor',
+           'cast',
+           'concat',
+           'expand',
+           'broadcast_to',
+           'expand_as',
+           'flatten',
+           'gather',
+           'gather_nd',
+           'reshape',
+           'reshape_',
+           'reverse',
+           'scatter',
+           'scatter_',
+           'scatter_nd_add',
+           'scatter_nd',
+           'shard_index',
+           'slice',
+           'split',
+           'chunk',
+           'squeeze',
+           'squeeze_',
+           'stack',
+           'strided_slice',
+           'transpose',
+           'unique',
+           'unsqueeze',
+           'unsqueeze_',
+           'unstack',
+           'flip',
+           'unbind',
+           'roll',
+           'tile',
+           'argmax',
+           'argmin',
+           'argsort',
+           'masked_select',
+           'topk',
+           'where',
+           'index_select',
+           'nonzero',
+           'sort',
+           'index_sample',
+           'mean',
+           'std',
+           'var',
+           'numel',
+           'median',
+           'rank',
+           'shape',
+           'real',
+           'imag'
+]

--- a/python/paddle/tensor/attribute.py
+++ b/python/paddle/tensor/attribute.py
@@ -19,10 +19,8 @@ from ..fluid.layer_helper import LayerHelper
 from ..fluid.data_feeder import check_variable_and_dtype
 
 # TODO: define functions to get tensor attributes  
-from ..fluid.layers import rank  #DEFINE_ALIAS
-from ..fluid.layers import shape  #DEFINE_ALIAS
-
-__all__ = ['rank', 'shape', 'real', 'imag']
+from ..fluid.layers import rank  # noqa: F401
+from ..fluid.layers import shape  # noqa: F401
 
 
 def _complex_to_real_dtype(dtype):

--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -14,6 +14,8 @@
 
 from __future__ import print_function
 import numpy as np
+from paddle.common_ops_import import fill_constant
+from ..fluid.layers import utils
 
 from ..fluid.layers import tensor
 from ..fluid.framework import Variable
@@ -25,31 +27,9 @@ from ..fluid.layers import core
 from ..fluid.layer_helper import LayerHelper
 from ..fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype, convert_dtype
 from ..fluid.framework import convert_np_dtype_to_dtype_, in_dygraph_mode, _varbase_creator, device_guard, OpProtoHolder
-from paddle.common_ops_import import *
 # TODO: define functions to get create a tensor  
-from ..fluid.layers import linspace  #DEFINE_ALIAS
+from ..fluid.layers import linspace  # noqa: F401
 import paddle
-
-__all__ = [
-    'to_tensor',
-    'diag',
-    #       'get_tensor_from_selected_rows',
-    'linspace',
-    'ones',
-    'ones_like',
-    'zeros',
-    'zeros_like',
-    'arange',
-    'eye',
-    'full',
-    'full_like',
-    'empty',
-    'empty_like',
-    'triu',
-    'tril',
-    'meshgrid',
-    'assign',
-]
 
 
 @dygraph_only
@@ -1058,6 +1038,6 @@ def assign(x, output=None):
           result2 = paddle.assign(data)  # result2 = [[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]]
           result3 = paddle.assign(np.array([[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]], dtype='float32')) # result3 = [[2.5, 2.5], [2.5, 2.5], [2.5, 2.5]]
     """
-    check_type(x, 'x', (Variable, numpy.ndarray, list, tuple, float, int, bool),
+    check_type(x, 'x', (Variable, np.ndarray, list, tuple, float, int, bool),
                'assign')
     return tensor.assign(x, output)

--- a/python/paddle/tensor/linalg.py
+++ b/python/paddle/tensor/linalg.py
@@ -13,28 +13,13 @@
 # limitations under the License.
 
 import numpy as np
-from paddle.common_ops_import import *
 from ..fluid.layer_helper import LayerHelper
 from ..fluid.data_feeder import check_variable_and_dtype, check_type
 from ..fluid.framework import in_dygraph_mode, _varbase_creator
 
-from ..fluid.layers import transpose  #DEFINE_ALIAS
-
-__all__ = [
-    'matmul',
-    'dot',
-    #       'einsum',
-    'norm',
-    'transpose',
-    'dist',
-    't',
-    'cross',
-    'cholesky',
-    #       'tensordot',
-    'bmm',
-    'histogram',
-    'mv'
-]
+from ..fluid.layers import transpose  # noqa: F401
+from paddle.common_ops_import import core
+from paddle.common_ops_import import VarDesc
 
 
 def matmul(x, y, transpose_x=False, transpose_y=False, name=None):

--- a/python/paddle/tensor/logic.py
+++ b/python/paddle/tensor/logic.py
@@ -17,33 +17,16 @@ from ..fluid.data_feeder import check_type, check_variable_and_dtype
 from ..fluid.layers.layer_function_generator import templatedoc
 from .. import fluid
 from ..fluid.framework import in_dygraph_mode
-from paddle.common_ops_import import *
 from ..framework import VarBase as Tensor
 
 # TODO: define logic functions of a tensor  
-from ..fluid.layers import is_empty  #DEFINE_ALIAS
-from ..fluid.layers import logical_and  #DEFINE_ALIAS
-from ..fluid.layers import logical_not  #DEFINE_ALIAS
-from ..fluid.layers import logical_or  #DEFINE_ALIAS
-from ..fluid.layers import logical_xor  #DEFINE_ALIAS
+from ..fluid.layers import is_empty  # noqa: F401
+from ..fluid.layers import logical_and  # noqa: F401
+from ..fluid.layers import logical_not  # noqa: F401
+from ..fluid.layers import logical_or  # noqa: F401
+from ..fluid.layers import logical_xor  # noqa: F401
 
-__all__ = [
-    'equal',
-    'equal_all',
-    'greater_equal',
-    'greater_than',
-    'is_empty',
-    'less_equal',
-    'less_than',
-    'logical_and',
-    'logical_not',
-    'logical_or',
-    'logical_xor',
-    'not_equal',
-    'allclose',
-    'is_tensor'
-    #       'isnan'
-]
+from paddle.common_ops_import import core
 
 
 def equal_all(x, y, name=None):

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -23,51 +23,16 @@ from ..fluid.layers import utils
 import numpy as np
 import six
 # TODO: define functions to manipulate a tensor  
-from ..fluid.layers import cast  #DEFINE_ALIAS
-from ..fluid.layers import slice  #DEFINE_ALIAS
-from ..fluid.layers import transpose  #DEFINE_ALIAS
-from ..fluid.layers import unstack  #DEFINE_ALIAS
+from ..fluid.layers import cast  # noqa: F401
+from ..fluid.layers import slice  # noqa: F401
+from ..fluid.layers import transpose  # noqa: F401
+from ..fluid.layers import unstack  # noqa: F401
 
-from ..fluid.layers import scatter_nd  #DEFINE_ALIAS
-from ..fluid.layers import shard_index  #DEFINE_ALIAS
+from ..fluid.layers import scatter_nd  # noqa: F401
+from ..fluid.layers import shard_index  # noqa: F401
 from ..fluid import layers
 import paddle
 import warnings
-
-__all__ = [
-    'cast',
-    'concat',
-    'expand',
-    'broadcast_to',
-    'expand_as',
-    'flatten',
-    'gather',
-    'gather_nd',
-    'reshape',
-    'reshape_',
-    'reverse',
-    'scatter',
-    'scatter_',
-    'scatter_nd_add',
-    'scatter_nd',
-    'shard_index',
-    'slice',
-    'split',
-    'chunk',
-    'squeeze',
-    'squeeze_',
-    'stack',
-    'strided_slice',
-    'transpose',
-    'unique',
-    'unsqueeze',
-    'unsqueeze_',
-    'unstack',
-    'flip',
-    'unbind',
-    'roll',
-    'tile',
-]
 
 
 def _print_warning_in_static_mode(api_name):

--- a/python/paddle/tensor/math.py
+++ b/python/paddle/tensor/math.py
@@ -17,7 +17,12 @@ math functions
 from __future__ import print_function
 import numpy as np
 
-from paddle.common_ops_import import *
+from paddle.common_ops_import import VarDesc
+from paddle.common_ops_import import dygraph_only
+from paddle.common_ops_import import OpProtoHolder
+from paddle.common_ops_import import templatedoc
+from paddle.common_ops_import import dygraph_utils
+
 from paddle.tensor import cast
 import paddle
 from ..fluid import layers
@@ -29,108 +34,30 @@ from .manipulation import _print_warning_in_static_mode
 
 # TODO: define math functions
 # yapf: disable
-from ..fluid.layers import abs    #DEFINE_ALIAS
-from ..fluid.layers import acos    #DEFINE_ALIAS
-from ..fluid.layers import asin    #DEFINE_ALIAS
-from ..fluid.layers import ceil    #DEFINE_ALIAS
-from ..fluid.layers import cos    #DEFINE_ALIAS
-from ..fluid.layers import tan    #DEFINE_ALIAS
-from ..fluid.layers import sinh    #DEFINE_ALIAS
-from ..fluid.layers import cosh    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_add    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_div    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_floordiv    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_mod    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_mul    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_pow    #DEFINE_ALIAS
-# from ..fluid.layers import elementwise_sub    #DEFINE_ALIAS
-from ..fluid.layers import exp    #DEFINE_ALIAS
-from ..fluid.layers import floor    #DEFINE_ALIAS
-from ..fluid.layers import log    #DEFINE_ALIAS
-from ..fluid.layers import reciprocal    #DEFINE_ALIAS
-# from ..fluid.layers import reduce_max    #DEFINE_ALIAS
-# from ..fluid.layers import reduce_min    #DEFINE_ALIAS
-# from ..fluid.layers import reduce_prod    #DEFINE_ALIAS
-# from ..fluid.layers import reduce_sum    #DEFINE_ALIAS
-from ..fluid.layers import round    #DEFINE_ALIAS
-from ..fluid.layers import rsqrt    #DEFINE_ALIAS
-from ..fluid.layers import scale    #DEFINE_ALIAS
-from ..fluid.layers import square    #DEFINE_ALIAS
-from ..fluid.layers import stanh    #DEFINE_ALIAS
-from ..fluid.layers import atan    #DEFINE_ALIAS
-from ..fluid.layers import erf    #DEFINE_ALIAS
-from ..fluid.layers import sqrt    #DEFINE_ALIAS
-from ..fluid.layers import sin    #DEFINE_ALIAS
+from ..fluid.layers import abs    # noqa: F401
+from ..fluid.layers import acos    # noqa: F401
+from ..fluid.layers import asin    # noqa: F401
+from ..fluid.layers import ceil    # noqa: F401
+from ..fluid.layers import cos    # noqa: F401
+from ..fluid.layers import tan    # noqa: F401
+from ..fluid.layers import sinh    # noqa: F401
+from ..fluid.layers import cosh    # noqa: F401
+from ..fluid.layers import exp    # noqa: F401
+from ..fluid.layers import floor    # noqa: F401
+from ..fluid.layers import log    # noqa: F401
+from ..fluid.layers import reciprocal    # noqa: F401
+from ..fluid.layers import round    # noqa: F401
+from ..fluid.layers import rsqrt    # noqa: F401
+from ..fluid.layers import scale    # noqa: F401
+from ..fluid.layers import square    # noqa: F401
+from ..fluid.layers import stanh    # noqa: F401
+from ..fluid.layers import atan    # noqa: F401
+from ..fluid.layers import erf    # noqa: F401
+from ..fluid.layers import sqrt    # noqa: F401
+from ..fluid.layers import sin    # noqa: F401
 
-from ..fluid.layers import multiplex    #DEFINE_ALIAS
+from ..fluid.layers import multiplex    # noqa: F401
 from ..fluid import layers
-
-
-__all__ = [
-        'abs',
-        'acos',
-        'all',
-        'any',
-        'asin',
-        'atan',
-        'ceil',
-        'cos',
-        'cosh',
-        'cumsum',
-        'exp',
-        'floor',
-        'increment',
-        'log',
-        'log2',
-        'log10',
-        'logsumexp',
-        'mul',
-        'multiplex',
-        'pow',
-        'prod',
-        'reciprocal',
-        'round',
-        'rsqrt',
-        'scale',
-        'sign',
-        'sin',
-        'sinh',
-        'sqrt',
-        'square',
-        'stanh',
-        'sum',
-        'tanh',
-        'tanh_',
-        'add_n',
-        'max',
-        'maximum',
-        'min',
-        'minimum',
-        'mm',
-        'divide',
-        'floor_divide',
-        'remainder',
-        'mod',
-        'floor_mod',
-        'multiply',
-        'add',
-        'subtract',
-        'atan',
-        'logsumexp',
-        'inverse',
-        'log1p',
-        'erf',
-        'addmm',
-        'clip',
-        'trace',
-        'kron',
-        'isfinite',
-        'isinf',
-        'isnan',
-        'broadcast_shape',
-        'conj'
-]
-# yapf: enable.
 
 _supported_int_dtype_ = [
     VarDesc.VarType.UINT8,
@@ -472,8 +399,8 @@ def remainder(x, y, name=None):
     return _elementwise_op(LayerHelper(op_type, **locals()))
 
 
-mod = remainder  #DEFINE_ALIAS
-floor_mod = remainder  #DEFINE_ALIAS
+mod = remainder  # noqa: F841
+floor_mod = remainder  # noqa: F841
 
 
 def multiply(x, y, name=None):

--- a/python/paddle/tensor/random.py
+++ b/python/paddle/tensor/random.py
@@ -21,18 +21,6 @@ from ..fluid.data_feeder import check_variable_and_dtype, check_type, check_dtyp
 from ..fluid.layers import utils
 import paddle
 
-__all__ = [
-    'bernoulli',
-    'multinomial',
-    'standard_normal',
-    'normal',
-    'uniform',
-    'randn',
-    'rand',
-    'randint',
-    'randperm',
-]
-
 
 def bernoulli(x, name=None):
     """

--- a/python/paddle/tensor/search.py
+++ b/python/paddle/tensor/search.py
@@ -16,25 +16,14 @@ import numpy as np
 from ..fluid.layer_helper import LayerHelper
 from ..fluid.data_feeder import check_variable_and_dtype, check_type, check_dtype
 from ..fluid import core, layers
+from paddle.common_ops_import import in_dygraph_mode
+from paddle.common_ops_import import convert_np_dtype_to_dtype_
+from paddle.common_ops_import import Variable
+from paddle.common_ops_import import VarDesc
 
 # TODO: define searching & indexing functions of a tensor  
 # from ..fluid.layers import has_inf  #DEFINE_ALIAS
 # from ..fluid.layers import has_nan  #DEFINE_ALIAS
-
-__all__ = [
-    'argmax',
-    'argmin',
-    'argsort',
-    'masked_select',
-    'topk',
-    'where',
-    'index_select',
-    'nonzero',
-    'sort',
-    'index_sample',
-]
-
-from paddle.common_ops_import import *
 
 
 def argsort(x, axis=-1, descending=False, name=None):

--- a/python/paddle/tensor/stat.py
+++ b/python/paddle/tensor/stat.py
@@ -14,8 +14,6 @@
 
 # TODO: define statistical functions of a tensor  
 
-__all__ = ['mean', 'std', 'var', 'numel', 'median']
-
 import numpy as np
 from ..fluid.framework import Variable
 from ..fluid.layer_helper import LayerHelper

--- a/python/paddle/tensor/tensor.py
+++ b/python/paddle/tensor/tensor.py
@@ -13,9 +13,3 @@
 # limitations under the License.
 
 # TODO: define the basic tensor classes 
-
-__all__ = [
-    #       'Tensor',
-    #       'LoDTensor',
-    #       'LoDTensorArray'
-]

--- a/python/paddle/tensor/to_string.py
+++ b/python/paddle/tensor/to_string.py
@@ -17,8 +17,6 @@ import numpy as np
 from paddle.fluid.layers import core
 from paddle.fluid.data_feeder import convert_dtype, check_variable_and_dtype, check_type, check_dtype
 
-__all__ = ['set_printoptions']
-
 
 class PrintOptions(object):
     precision = 8


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in tensor

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *

本pr相关修改对api的调用无明显影响