### PR TITLE
[Cherry-pick] Fix the nan bug when passing all zero values into clip_by_norm_op. (#30777)

### DIFF
--- a/paddle/fluid/operators/clip_by_norm_op.h
+++ b/paddle/fluid/operators/clip_by_norm_op.h
@@ -81,7 +81,12 @@ class ClipByNormKernel : public framework::OpKernel<T> {
         *context.template device_context<DeviceContext>().eigen_device();
 
     auto temp = (x_norm <= max_norm).template cast<T>();
-    auto scaling = temp + (static_cast<T>(1) - temp) * max_norm / x_norm;
+    auto epsilon =
+        ((x_norm <= static_cast<T>(1e-30)).all().template cast<T>()) *
+        static_cast<T>(1e-6);
+
+    auto scaling =
+        temp + (static_cast<T>(1) - temp) * max_norm / (x_norm + epsilon);
     Eigen::array<int, 1> one_dim{{1}};
     Eigen::DSizes<int, 1> m_dsize(input->numel());
     if (context.GetPlace() == platform::CPUPlace()) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
```cpp
0.0 / 0.0 = -nan
1.0 / 0.0 = inf
```
As described above, if all input grads are zero, the output of `clip_by_norm` will be inf or nan.  This pr is used to fix this bug.
