### PR TITLE
fix decorator==4.4.2 in py2

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -7,5 +7,5 @@ gast>=0.3.3 ; platform_system != "Windows"
 gast==0.3.3 ; platform_system == "Windows"
 Pillow
 six
-decorator
+decorator==4.4.2
 astor


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
高版本的decorator在脚本中会有问题
![image](https://user-images.githubusercontent.com/29832297/113394871-94431300-93cb-11eb-8ab1-77ba87127a8d.png)
