### PR TITLE
Skip the optimized ops‘ execution when infinite grads found in AMP training. 

### DIFF
--- a/python/paddle/fluid/contrib/mixed_precision/decorator.py
+++ b/python/paddle/fluid/contrib/mixed_precision/decorator.py
@@ -365,7 +365,16 @@ class OptimizerWithMixedPrecision(object):
                         self._decr_ratio,
                         name="update_loss_scaling")
 
-        optimize_ops = self._optimizer.apply_gradients(params_grads)
+        # def apply_fn():
+        #     return self._optimizer.apply_gradients(params_grads)
+
+        # optimize_ops = layers.cond(found_inf, None, apply_fn)
+
+        with layers.Switch() as switch:
+            with switch.case(found_inf):
+                optimize_ops = None
+            with switch.default():
+                optimize_ops = self._optimizer.apply_gradients(params_grads)
         return optimize_ops
 
     def apply_optimize(self, loss, startup_program, params_grads):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
If inf found in gradients during AMP training, the optimized ops will be skipped for execution.
