### PR TITLE
solve elementwise_add_grad tenosr copy bug

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_add_op.cu
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.cu
@@ -112,22 +112,40 @@ elementwise_add_grad(const framework::ExecutionContext& ctx,
                      const framework::Tensor* out,
                      const framework::Tensor* dout, framework::Tensor* dx,
                      framework::Tensor* dy) {
-  auto* dx_data = dx->mutable_data<T>(ctx.GetPlace());
-  auto* dy_data = dy->mutable_data<T>(ctx.GetPlace());
-  auto* dout_data = dout->data<T>();
-  if (dx_data == dout_data && dy_data != dout_data) {
-    VLOG(4) << "Special case when dx_data is the same as dout_data, "
-               "only need copy dout to dy";
-    framework::TensorCopy(
-        *dout, ctx.GetPlace(),
-        ctx.template device_context<platform::DeviceContext>(), dy);
-  } else if (dx_data != dout_data && dy_data == dout_data) {
-    VLOG(4) << "Special case when dy_data is the same as dout_data, "
-               "only need copy dout to dx";
-    framework::TensorCopy(
-        *dout, ctx.GetPlace(),
-        ctx.template device_context<platform::DeviceContext>(), dx);
-  } else if (dx_data != dout_data && dy_data != dout_data) {
+  bool dims_same = (dx->dims() == dout->dims()) && (dy->dims() == dout->dims());
+  bool using_tensorcopy = false;
+  if (dims_same) {
+    auto* dx_data = dx->mutable_data<T>(ctx.GetPlace());
+    auto* dy_data = dy->mutable_data<T>(ctx.GetPlace());
+    auto* dout_data = dout->data<T>();
+    bool dx_data_same = (dx_data == dout_data);
+    bool dy_data_same = (dy_data == dout_data);
+    if (dx_data_same && !dy_data_same) {
+      using_tensorcopy = true;
+      VLOG(4) << "Special case when dx_data is the same as dout_data, "
+                 "only need copy dout to dy";
+      framework::TensorCopy(
+          *dout, ctx.GetPlace(),
+          ctx.template device_context<platform::DeviceContext>(), dy);
+    } else if (dy_data_same && !dx_data_same) {
+      using_tensorcopy = true;
+      VLOG(4) << "Special case when dy_data is the same as dout_data, "
+                 "only need copy dout to dx";
+      framework::TensorCopy(
+          *dout, ctx.GetPlace(),
+          ctx.template device_context<platform::DeviceContext>(), dx);
+    } else if (dy_data_same && dx_data_same) {
+      using_tensorcopy = true;
+      VLOG(4) << "Special case when dy_data is the same as dout_data, "
+                 "and dx_data is the same as dout_data, do not need "
+                 "any operator";
+    } else {
+      // need copy dout to two tensor: dx and dy
+      // using SimpleElemwiseAddGradCUDAKernel faster
+    }
+  }
+
+  if (!using_tensorcopy) {
     auto size = x->numel();
     int vec_size = max(static_cast<int>(sizeof(float4) / sizeof(T)), 1);
     dim3 block_size = dim3(PADDLE_CUDA_THREAD_SIZE, 1);
@@ -140,10 +158,6 @@ elementwise_add_grad(const framework::ExecutionContext& ctx,
              ctx.template device_context<plat::CUDADeviceContext>().stream()>>>(
         dout->data<T>(), size, vec_size, dx->mutable_data<T>(ctx.GetPlace()),
         dy->mutable_data<T>(ctx.GetPlace()));
-  } else {
-    VLOG(4) << "Special case when dy_data is the same as dout_data, "
-               "and dx_data is the same as dout_data, do not need "
-               "any operator";
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
已确认`dout`与`dx`、`dy`的dimension一定是相同的，问题出在其它地方，已关闭。

前置PR：[PR32051](https://github.com/PaddlePaddle/Paddle/pull/32051)

BUG描述：
按之前的逻辑为例：
1. 当`dout`与`dx`的数据地址相同，且`dout`与`dy`的数据地址不同时，只需拷贝`dout`中的数据到`dy`中；
2. 当`dout`的dimension与`dy`相同时这没有问题，但当两者不同时就出错了：`TensorCopy`会改变`dy`的dimension为`dout`的值，因此会对后续的计算造成影响。

修复方案：
在`TensorCopy`前先检查`dout`与`dx`、`dy`的dimension是否相同，若相同则进一步根据判断调用`TensorCopy`，否则直接调用`SimpleElemwiseAddGradCUDAKernel`。

TODO:
使用`memory::Copy`替代`TensorCopy`是不是更简单通用？不用在意dimension是否相同，拷贝大小取`x->numel() * sizeof(T)`，这样只需保证`dout`的大小一定大于等于`size`即可（后者`elementwise`的原理可以保证）。