### PR TITLE
optimize slice_grad kernel

### DIFF
--- a/paddle/fluid/operators/slice_op.cu
+++ b/paddle/fluid/operators/slice_op.cu
@@ -12,11 +12,120 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include "paddle/fluid/framework/ddim.h"
 #include "paddle/fluid/operators/slice_op.h"
 #include "paddle/fluid/platform/float16.h"
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
+
+namespace paddle {
+namespace operators {
+
+using float16 = plat::float16;
+using CUDADeviceContext = paddle::platform::CUDADeviceContext;
+
+template <size_t D>
+using EigenIndexArray = Eigen::array<Eigen::Index, D>;
+
+template <size_t D>
+using EigenPairArray = Eigen::array<std::pair<int64_t, int64_t>, D>;
+
+template <typename T, size_t D>
+__global__ void KePaddingEigen(const T *input_data,
+                               const EigenIndexArray<D> in_stride_array,
+                               const int64_t in_size,
+                               const EigenPairArray<D> paddings, T *output_data,
+                               const EigenIndexArray<D> out_stride_array) {
+  const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+
+  for (int index = tid; index < in_size; index += blockDim.x * gridDim.x) {
+    // compute each dimension index of input
+    int dims[D]{0};
+    int64_t k = index;
+#pragma unroll
+    for (int i = 0; i < D; i++) {
+      dims[i] = k / in_stride_array[i];
+      k -= dims[i] * in_stride_array[i];
+    }
+
+    // compute the total index of output
+    int64_t out_id = 0;
+#pragma unroll
+    for (int i = 0; i < D; i++) {
+      out_id += (dims[i] + paddings[i].first) * out_stride_array[i];
+    }
+    output_data[out_id] = input_data[index];
+  }
+}
+
+template <typename T, size_t D>
+void LaunchSlicePaddingKernel(const gpuStream_t &stream, const T *input_data,
+                              const EigenIndexArray<D> &in_stride_array,
+                              const int64_t in_size,
+                              const EigenPairArray<D> &paddings, T *output_data,
+                              const EigenIndexArray<D> &out_stride_array,
+                              const int64_t out_size) {
+  // Padding zero for output
+  cudaMemsetAsync(output_data, 0, out_size * sizeof(T), stream);
+
+  int threads = 256;
+  int block_num = threads * 10;
+  int grids = (in_size + block_num - 1) / block_num;
+  KePaddingEigen<T, D><<<grids, threads, 0, stream>>>(
+      input_data, in_stride_array, in_size, paddings, output_data,
+      out_stride_array);
+}
+
+template <typename T, size_t D>
+void LaunchSlicePaddingFunction(
+    const framework::ExecutionContext &context, framework::Tensor *d_input,
+    const framework::DDim &in_dims, const framework::Tensor *d_out,
+    const framework::DDim &out_dims,
+    const Eigen::array<std::pair<int64_t, int64_t>, D> &paddings) {
+  auto &dev_ctx = context.template device_context<CUDADeviceContext>();
+
+  int64_t in_size = 1, out_size = 1;
+#pragma unroll
+  for (int i = 0; i < D; i++) {
+    in_size *= in_dims[i];
+    out_size *= out_dims[i];
+  }
+
+  Eigen::array<Eigen::Index, D> in_stride_array, out_stride_array;
+  in_stride_array[D - 1] = out_stride_array[D - 1] = 1;
+  for (int i = D - 2; i >= 0; i--) {
+    in_stride_array[i] = in_stride_array[i + 1] * in_dims[i + 1];
+    out_stride_array[i] = out_stride_array[i + 1] * out_dims[i + 1];
+  }
+
+  LaunchSlicePaddingKernel<T, D>(
+      dev_ctx.stream(), d_out->data<T>(), out_stride_array, out_size, paddings,
+      d_input->mutable_data<T>(context.GetPlace()), in_stride_array, in_size);
+}
+
+template <>
+template <size_t D>
+void SliceGradKernel<CUDADeviceContext, float16>::SliceComputeFunction(
+    const framework::ExecutionContext &context, framework::Tensor *d_input,
+    const framework::DDim &in_dims, const framework::Tensor *d_out,
+    const framework::DDim &out_dims,
+    const Eigen::array<std::pair<int64_t, int64_t>, D> &paddings) const {
+  int64_t pad_size = 0;
+#pragma unroll
+  for (int i = 0; i < D; i++) {
+    pad_size += paddings[i].first + paddings[i].second;
+  }
+  if (pad_size >= 100) {
+    LaunchSlicePaddingFunction<float16, D>(context, d_input, in_dims, d_out,
+                                           out_dims, paddings);
+  } else {
+    LaunchEigenFunction<D>(context, d_input, in_dims, d_out, out_dims,
+                           paddings);
+  }
+}
+}  // namespace operators
+}  // namespace paddle
 
 REGISTER_OP_CUDA_KERNEL(
     slice, ops::SliceKernel<paddle::platform::CUDADeviceContext, float>,

--- a/paddle/fluid/operators/slice_op.cu
+++ b/paddle/fluid/operators/slice_op.cu
@@ -15,6 +15,7 @@ limitations under the License. */
 #include "paddle/fluid/framework/ddim.h"
 #include "paddle/fluid/operators/slice_op.h"
 #include "paddle/fluid/platform/float16.h"
+#include "paddle/fluid/platform/gpu_info.h"
 
 namespace ops = paddle::operators;
 namespace plat = paddle::platform;
@@ -67,7 +68,7 @@ void LaunchSlicePaddingKernel(const gpuStream_t &stream, const T *input_data,
                               const EigenIndexArray<D> &out_stride_array,
                               const int64_t out_size) {
   // Padding zero for output
-  cudaMemsetAsync(output_data, 0, out_size * sizeof(T), stream);
+  platform::GpuMemsetAsync(output_data, 0, out_size * sizeof(T), stream);
 
   int threads = 256;
   int block_num = threads * 10;


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
**CLOSE！！！**新优化请转移至[PR32266](https://github.com/PaddlePaddle/Paddle/pull/32266)

# 起因：
`Eigen::TensorPaddingOp`在新ernie doc模型timeline中占比高达9.98%，timeline中显示该kernel仅在slice_grad中被调用，尝试对此进行优化。

# 代码分析
`Eigen::TensorPaddingOp`的源码可在eigen的官方git上查看：[TensorPadding.h](https://gitlab.com/libeigen/eigen/-/blob/master/unsupported/Eigen/CXX11/src/Tensor/TensorPadding.h)，但其实现十分晦涩难懂，不建议细读。

尽管`slice`操作在其它框架中并不存在，但`slice grad`调用的`pad`操作却是十分常见。因此我们可以直接参考`pad`操作的实现来优化即可，paddle的`pad`指南见[paddle.nn.functional.pad](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/nn/functional/common/pad_cn.html#pad)。

# 优化
## 优化方法1：
commit id:[5eeafb1](https://github.com/PaddlePaddle/Paddle/commit/5eeafb15237c5f422cbc18bfcbd233fc05c272b2)
既然`slice grad`的`pad value`为0，那么很简单的想法是先通过`cudaMemsetAsync`操作将`dx`中的值都先清空为0，然后将`dout`中的值拷贝到`dx`中的对应位置即可。

## 难点：
1. 如何将当前线程索引值映射到`dout`和`dx`的各个维度的索引值上呢？
2. 多维也意味着函数与维度相关的参数数目有多个，如何低延迟的将多个参数数据传递到GPU上呢？
3. 如何保证global memory的访问是coalescing的呢？

## 优化点：
1. 首先利用`cudaMemsetAsync`操作将输出`dx`中的所有值清零，避免后续kernel出现warp diverge。
2. 将`dout`和`dx`每维的步长通过`Eigen::array`传入kernel，编译器会将参数放在`constant memory`区域，通过`constant cache`可以极大的降低访问延迟。`paddings`的值也一样。
3. 对于输入Tensor`dout`的每个维度，当前线程索引除以该维步长即可得到`dout`在该维处的索引值，再将该索引值加上`paddings[i].first`即可得到输出Tensor`dx`每个维度的索引值。
4. 由于`padding`区域早已通过`cudaMemsetAsync`操作清零，kernel会跳过此区域。理想情况下，只要`dout`最后几个无padding维的积的值为16的倍数即可保证globol memory都是coalesced的。最差情况下，最后一维大小为1且该维`padding`值非0就完全做不到coalesced，这种情况也没法处理。

## 优化效果
经简单测试，当`paddings`中所有值相加后大于100且数据类型为`float16`时调用优化kernel性能更好，否则应该调用原有的`Eigen::TensorPaddingOp`。

单kernel耗时 | 优化前 | [优化1](https://github.com/PaddlePaddle/Paddle/commit/5eeafb15237c5f422cbc18bfcbd233fc05c272b2)
---|---|---|
cost | 393 us | 274 us

模型速度(V100-SXM2-16GB机器） | FP32 | AMP | 加速比
---|---|---|---|
优化前 | 4.34 sequence/s | 9.0 sequence/s | 2.05
[优化1](https://github.com/PaddlePaddle/Paddle/commit/5eeafb15237c5f422cbc18bfcbd233fc05c272b2) | 4.34 sequence/s | 9.27 sequence/s | 2.13

## TODO
1. 目前对该kernel的对比测试较少，调用条件较为模糊，需要做进一步测试以确定确切的临界值。
2. 目前该优化只在`float16`下表现的比`Eigen::TensorPaddingOp`要好，能否做到在所有类型（比如`float`）下都要好呢？