### PR TITLE
[Dy2Stat] Fix undefined var used in For

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -243,8 +243,9 @@ class NameVisitor(gast.NodeVisitor):
             assert self.ancestor_nodes[-1] == node
             parent_node = self.ancestor_nodes[-2]
             if isinstance(parent_node, gast.Call) and parent_node.func == node:
-                # e.g: var_list.append(ele), var_list is also a name_id.
-                should_skip = isinstance(node, gast.Attribute) and node.attr in white_func_names
+                # e.g: var_list.append(elem), var_list is also a name_id.
+                should_skip = isinstance(
+                    node, gast.Attribute) and node.attr in white_func_names
                 if not should_skip:
                     return True
         return False

--- a/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/ifelse_transformer.py
@@ -238,11 +238,15 @@ class NameVisitor(gast.NodeVisitor):
         return new_name_ids
 
     def _is_call_func_name_node(self, node):
+        white_func_names = set(['append', 'extend'])
         if len(self.ancestor_nodes) > 1:
             assert self.ancestor_nodes[-1] == node
             parent_node = self.ancestor_nodes[-2]
             if isinstance(parent_node, gast.Call) and parent_node.func == node:
-                return True
+                # e.g: var_list.append(ele), var_list is also a name_id.
+                should_skip = isinstance(node, gast.Attribute) and node.attr in white_func_names
+                if not should_skip:
+                    return True
         return False
 
     def _update_name_ids(self, new_name_ids):
@@ -398,10 +402,13 @@ def parse_cond_return(parent_vars_dict, if_vars_dict, else_vars_dict,
         ])
 
     def _vars_loaded_before_store(ids_dict):
+        """
+        gast.Param is also a kind of `load` semantic.
+        """
         new_dict = defaultdict(list)
         for k, ctxs in six.iteritems(ids_dict):
             for ctx in ctxs:
-                if isinstance(ctx, gast.Load):
+                if isinstance(ctx, (gast.Load, gast.Param)):
                     new_dict[k].append(ctx)
                 elif isinstance(ctx, gast.Store):
                     break

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -342,5 +342,28 @@ class TestDiffModeNet2(TestDiffModeNet):
         self.Net = DiffModeNet2
 
 
+class TestNewVarCreateInOneBranch(unittest.TestCase):
+    def test_var_used_in_another_for(self):
+        
+        def case_func(training):
+            # targets and targets_list is dynamically defined by training
+            if training:
+                targets = [1,2,3]
+                targets_list = [targets]
+
+            num_step = 3
+            for i in range(num_step):
+                if i > 0:
+                    rois, rosi_num = 1, 2
+                    # targets is in loop_vars.
+                    if training:
+                        ros, rosi_num, targets = -1, -2, [-1,-2, -3]
+                        targets_list.append(targets)
+            
+            return rosi_num
+        
+        self.assertEqual(paddle.jit.to_static(case_func)(False), 2)
+        self.assertEqual(paddle.jit.to_static(case_func)(True), -2)
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_ifelse.py
@@ -344,11 +344,10 @@ class TestDiffModeNet2(TestDiffModeNet):
 
 class TestNewVarCreateInOneBranch(unittest.TestCase):
     def test_var_used_in_another_for(self):
-        
         def case_func(training):
             # targets and targets_list is dynamically defined by training
             if training:
-                targets = [1,2,3]
+                targets = [1, 2, 3]
                 targets_list = [targets]
 
             num_step = 3
@@ -357,13 +356,14 @@ class TestNewVarCreateInOneBranch(unittest.TestCase):
                     rois, rosi_num = 1, 2
                     # targets is in loop_vars.
                     if training:
-                        ros, rosi_num, targets = -1, -2, [-1,-2, -3]
+                        ros, rosi_num, targets = -1, -2, [-1, -2, -3]
                         targets_list.append(targets)
-            
+
             return rosi_num
-        
+
         self.assertEqual(paddle.jit.to_static(case_func)(False), 2)
         self.assertEqual(paddle.jit.to_static(case_func)(True), -2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### What's New?

**Fix undefind var used in For**

The reason is if a var is created only in `if`  branch, and is not recognized by `parse_cond_return`. 
+ `gast.Param` should be considered as a kind of `load` semantic.

**A Bug Example**
```python
from paddle.jit import to_static

def case_func(training):
    if training:
        targets = [1,2,3]
        targets_list = [targets]

    num_step = 3
    for i in range(num_step):
        if i > 0:
            rois, rosi_num = 1, 2
            if training:
                ros, rosi_num, targets = -1, -2, [-1,-2, -3]
                targets_list.append(targets)
    
    return rosi_num

to_static(case_func(False))
```

Transformed code is :
```python
def case_func(training):

    def true_fn_0():
        targets = [1, 2, 3]
        targets_list = [targets]
        return

    def false_fn_0():
        return
    paddle.jit.dy2static.convert_ifelse(training, true_fn_0, false_fn_0, (),  <----- targets is not visible here.
        (), ())
    targets = None
    num_step = 3
    rosi_num = paddle.jit.dy2static.data_layer_not_check(name='rosi_num',
        shape=[-1], dtype='float32')
    i = 0

    def for_loop_condition_0(num_step, i, targets, rosi_num):
        return i < num_step

    def for_loop_body_0(num_step, i, targets, rosi_num):

        def true_fn_2(rosi_num, targets, training):
            rois = 1
            rosi_num = 2

            def true_fn_1(rosi_num, targets):
                y = targets
                ros = -1
                rosi_num = -2
                targets = [-1, -2, -3]
                paddle.jit.dy2static.convert_call(targets_list.append)(targets)
                return rosi_num, targets

            def false_fn_1(rosi_num, targets):
                return rosi_num, targets
            rosi_num, targets = paddle.jit.dy2static.convert_ifelse(training,
                true_fn_1, false_fn_1, (rosi_num, targets), (rosi_num,
                targets), (rosi_num, targets))
            return rosi_num, targets

        def false_fn_2(rosi_num, targets):
            return rosi_num, targets
        rosi_num, targets = paddle.jit.dy2static.convert_ifelse(i > 0,
            true_fn_2, false_fn_2, (rosi_num, targets, training), (rosi_num,
            targets), (rosi_num, targets))                              <----- targets is undefined
        i += 1
        return num_step, i, targets, rosi_num
    [num_step, i, targets, rosi_num] = paddle.jit.dy2static.convert_while_loop(
        for_loop_condition_0, for_loop_body_0, [num_step, i, targets, rosi_num]
        )
    return rosi_num
```
