### PR TITLE
to avoid bug while value is a lambda expression; for binary ops dim a…

### DIFF
--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -76,7 +76,6 @@ def format_spec(spec):
 def queue_dict(member, cur_name):
     if cur_name in omitted_list:
         return
-
     doc_md5 = md5(member.__doc__)
 
     if inspect.isclass(member):
@@ -108,7 +107,7 @@ def visit_member(parent_name, member, member_name=None):
         for name, value in inspect.getmembers(member):
             if hasattr(value, '__name__') and (not name.startswith("_") or
                                                name == "__init__"):
-                visit_member(cur_name, value)
+                visit_member(cur_name, value, name)
     elif inspect.ismethoddescriptor(member):
         return
     elif inspect.isbuiltin(member):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
to avoid bug while value is a lambda expression; 
for binary ops dim and ndimension:
        ('dim', lambda x: len(x.shape)),
        ('ndimension', lambda x: len(x.shape)),

while api example check in CI test,Error occurs:
2021-04-01 20:44:25 ++ python sampcd_processor.py cpu
2021-04-01 20:44:26 Traceback (most recent call last):
2021-04-01 20:44:26   File "sampcd_processor.py", line 592, in <module>
2021-04-01 20:44:26     filenames = get_filenames()
2021-04-01 20:44:26   File "sampcd_processor.py", line 473, in get_filenames
2021-04-01 20:44:26     module = eval(api).__module__
2021-04-01 20:44:26   File "<string>", line 1
2021-04-01 20:44:26     paddle.tensor.logic.Tensor.\<lambda\>
2021-04-01 20:44:26                                ^
2021-04-01 20:44:26 SyntaxError: invalid syntax