### PR TITLE
fix op benchmark ci cmake error by removing PYTHON_ABI

### DIFF
--- a/tools/test_op_benchmark.sh
+++ b/tools/test_op_benchmark.sh
@@ -162,7 +162,6 @@ function compile_install_paddlepaddle {
   export BUILD_TYPE=Release
   export CUDA_ARCH_NAME=Auto
   export WITH_DISTRIBUTE=OFF
-  export PYTHON_ABI=cp37-cp37m
   export CMAKE_BUILD_TYPE=Release
   [ -d build ] && rm -rf build
   bash paddle/scripts/paddle_build.sh build $(nproc)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
修复op benchmark ci中cmake 执行错误。
![image](https://user-images.githubusercontent.com/23427135/114336616-f34e1800-9b81-11eb-936b-b348c4865b2e.png)
