### PR TITLE
change aclrtSynchronizeDevice to aclrtSynchronizeStream for better performance

### DIFF
--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -254,10 +254,6 @@ NPUDeviceContext::~NPUDeviceContext() {
 
 void NPUDeviceContext::Wait() const {
   platform::RecordEvent record_event("NPUDeviceContext/wait");
-  // NOTE(zhiqiu): Better to guard place before call acl API.
-  // But for better performance, we disbale it and we think it is
-  // ok to do this since stream_ has target device.
-  // NPUDeviceGuard guard(place_.device);
   VLOG(4) << "NPU context Wait";
   stream_->Wait();
 }

--- a/paddle/fluid/platform/device_context.cc
+++ b/paddle/fluid/platform/device_context.cc
@@ -254,9 +254,12 @@ NPUDeviceContext::~NPUDeviceContext() {
 
 void NPUDeviceContext::Wait() const {
   platform::RecordEvent record_event("NPUDeviceContext/wait");
-  NPUDeviceGuard guard(place_.device);
+  // NOTE(zhiqiu): Better to guard place before call acl API.
+  // But for better performance, we disbale it and we think it is
+  // ok to do this since stream_ has target device.
+  // NPUDeviceGuard guard(place_.device);
   VLOG(4) << "NPU context Wait";
-  PADDLE_ENFORCE_NPU_SUCCESS(aclrtSynchronizeDevice());
+  stream_->Wait();
 }
 
 aclrtStream NPUDeviceContext::stream() const { return stream_->raw_stream(); }


### PR DESCRIPTION
…rformace

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Change aclrtSynchronizeDevice to aclrtSynchronizeStream for better performance

1. aclrtSynchronizeStream(about 0.23ms) is faster than aclrtSynchronizeDevice(about 0.39ms).
2. NPUDeviceGuard can be reduced.
3. Got 8403 tokens/s -> 9880 tokens/s, about 17.6%+ speed up on ernie model

- before
![image](https://user-images.githubusercontent.com/6888866/114352898-ff949e00-9b9e-11eb-9c1e-030902f64118.png)
 
- after
![image](https://user-images.githubusercontent.com/6888866/114352913-03282500-9b9f-11eb-8122-852c375b76df.png)
