### PR TITLE
Add new post-quantization methods

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
+++ b/python/paddle/fluid/contrib/slim/quantization/post_training_quantization.py
@@ -280,7 +280,7 @@ class PostTrainingQuantization(object):
             "cannot be None in the same time."
         assert batch_size > 0, "The batch_size should be greater than 0."
         assert algo in self._support_algo_type, \
-            "The algo should be KL, hist, abs_max or min_max."
+            "The algo should be KL, hist, mse, avg, abs_max or min_max."
         assert activation_quantize_type in self._support_activation_quantize_type, \
             "The activation_quantize_type ({}) should in ({}).".format(
             activation_quantize_type, self._support_activation_quantize_type)

--- a/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quantization_pass.py
@@ -1070,6 +1070,7 @@ class QuantizationFreezePass(object):
     def __init__(self,
                  scope,
                  place,
+                 bias_correct=False,
                  weight_bits=8,
                  activation_bits=8,
                  weight_quantize_type='abs_max',
@@ -1085,6 +1086,8 @@ class QuantizationFreezePass(object):
             scope(fluid.Scope): scope is used to get the weight tensor values.
             place(fluid.CPUPlace|fluid.CUDAPlace|str): place is used to restore the weight tensors.
                 If it's string, It can be ``cpu``, and ``gpu:x``, where ``x`` is the index of the GPUs.
+            bias_correct(bool): whether use bias correction for post-training quantization.
+                https://arxiv.org/abs/1810.05723.
             weight_bits(int): quantization bit number for weights.
             activation_bits(int): quantization bit number for activation.
             weight_quantize_type(str): quantization type for weights, support 'abs_max' and 
@@ -1098,6 +1101,7 @@ class QuantizationFreezePass(object):
         assert place is not None, \
             'The place cannot be set None.'
         self._scope = scope
+        self._bias_correct = bias_correct
         self._place = _get_paddle_place(place)
         self._weight_bits = weight_bits
         self._activation_bits = activation_bits
@@ -1154,7 +1158,35 @@ class QuantizationFreezePass(object):
                     else:
                         quant_axis = 0
                     quantized_param_v = self._quant(
-                        param_v, scale_v, self._weight_bits, quant_axis)
+                        param_v.copy(), scale_v, self._weight_bits, quant_axis)
+                    if self._bias_correct == True:
+                        eps = 1e-8
+                        bnt = (1 << (self._weight_bits - 1)) - 1
+                        if isinstance(scale_v, list):
+                            if quant_axis == 0:
+                                for i, s in enumerate(scale_v):
+                                    quantized_param_v[i] = quantized_param_v[i] * s / bnt
+                                quant_bias = param_v - quantized_param_v
+                                mean_bias = quant_bias.reshape(quant_bias.shape[0], -1).mean(-1)
+                                std_orig = param_v.reshape(param_v.shape[0], -1).std(-1)
+                                std_quant = quantized_param_v.reshape(quantized_param_v.shape[0], -1).std(-1)
+                                std_bias = std_orig / (std_quant + eps)
+                             
+                            else:
+                                for i, s in enumerate(scale_v):
+                                    quantized_param_v[:, i] = quantized_param_v[:, i] * s / bnt
+                                quant_bias = param_v - quantized_param_v
+                                mean_bias = np.array([quant_bias[:, i].mean() for i in range(quant_bias.shape[1])])
+                                std_orig = np.array([param_v[:, i].std() for i in range(param_v.shape[1])])
+                                std_quant = np.array([quantized_param_v[:, i].std() for i in range(quantized_param_v.shape[1])])
+                                std_bias = std_orig / (std_quant + eps)
+
+                        if mean_bias.ndim == 1:
+                            std_bias = np.resize(std_bias, param_v.shape)
+                            mean_bias = np.resize(mean_bias, param_v.shape)
+
+                        quantized_param_v = (mean_bias + quantized_param_v) * std_bias
+                        quantized_param_v = self._quant(quantized_param_v, scale_v, self._weight_bits, quant_axis)
                     self._restore_var(input_arg_name, quantized_param_v)
                     self._remove_fake_quant_and_dequant_op(graph, op_node)
 
@@ -1365,7 +1397,7 @@ class QuantizationFreezePass(object):
     def _quant(self, x, scale, num_bits, quant_axis):
         assert quant_axis in [0, 1], 'quant_axis should be 0 or 1 for now.'
         bnt = (1 << (num_bits - 1)) - 1
-
+        eps = 1e-8
         def _clip(x, scale):
             x[x > scale] = scale
             x[x < -scale] = -scale
@@ -1373,6 +1405,8 @@ class QuantizationFreezePass(object):
 
         if isinstance(scale, list):
             for i, s in enumerate(scale):
+                if s == 0.0:
+                    s = eps
                 if quant_axis == 0:
                     x[i] = _clip(x[i], s)
                     x[i] = np.round(x[i] / s * bnt)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
1. Add new methods: 'mse', 'hist', 'avg' of getting threshold values of activations for post-training quantization in 'post_training_quantization.py'. 
2. Add bias correction method in of https://arxiv.org/abs/1810.05723  for post-training quantization in 'quantization_pass.py'. Bias correction changes the quantized weights by the following formulation: 
 
![image](https://user-images.githubusercontent.com/46363693/114363498-075a3f80-9bab-11eb-8ca3-e4ace39302db.png)
