### PR TITLE
Optimize cudnn version softmax

### DIFF
--- a/paddle/fluid/operators/math/math_cuda_utils.h
+++ b/paddle/fluid/operators/math/math_cuda_utils.h
@@ -97,6 +97,11 @@ __device__ __forceinline__ __half2 FloatsToPair<__half2>(const float a,
 }
 
 template <>
+__device__ __forceinline__ double exp_func<double>(double a) {
+  return exp(a);
+}
+
+template <>
 __device__ __forceinline__ float exp_func<float>(float a) {
   return expf(a);
 }

--- a/paddle/fluid/operators/softmax_cudnn_op.cu
+++ b/paddle/fluid/operators/softmax_cudnn_op.cu
@@ -410,7 +410,7 @@ __global__ void KeLoopDimSoftmaxBackward(T* __restrict__ dx,
 }
 
 template <typename T, int VECSIZE>
-inline void LaunchLoopDimSoftmaxBackwardKernel(const cudaStream_t& stream,
+inline void LaunchLoopDimSoftmaxBackwardKernel(const gpuStream_t& stream,
                                                T* dx_data, const T* out_data,
                                                const T* dout_data, const int N,
                                                const int dim, const int D) {
@@ -424,7 +424,7 @@ inline void LaunchLoopDimSoftmaxBackwardKernel(const cudaStream_t& stream,
 }
 
 template <typename T>
-inline void LaunchLoopDimSoftmaxBackward(const cudaStream_t& stream, T* dx_data,
+inline void LaunchLoopDimSoftmaxBackward(const gpuStream_t& stream, T* dx_data,
                                          const T* out_data, const T* dout_data,
                                          const int N, const int dim,
                                          const int D, const int sm_count) {
@@ -524,7 +524,7 @@ __global__ void KeSpandDimDSoftmaxForward(T* __restrict__ dst,
   }
 }
 template <typename T, int VECSIZE>
-inline void LaunchSpandDimDSoftmaxForwardKernel(const cudaStream_t& stream,
+inline void LaunchSpandDimDSoftmaxForwardKernel(const gpuStream_t& stream,
                                                 const T* in_data, T* out_data,
                                                 const int N, const int dim,
                                                 const int D) {
@@ -547,7 +547,7 @@ inline void LaunchSpandDimDSoftmaxForwardKernel(const cudaStream_t& stream,
       out_data, in_data, N, dim, D);
 }
 template <typename T>
-inline void LaunchSpandDimDSoftmaxForward(const cudaStream_t& stream,
+inline void LaunchSpandDimDSoftmaxForward(const gpuStream_t& stream,
                                           const T* in_data, T* out_data,
                                           const int N, const int dim,
                                           const int D) {
@@ -629,7 +629,7 @@ __global__ void KeSpandDimDSoftmaxBackward(T* __restrict__ dx,
 }
 
 template <typename T, int VECSIZE>
-inline void LaunchSpandDimDSoftmaxBackwardKernel(const cudaStream_t& stream,
+inline void LaunchSpandDimDSoftmaxBackwardKernel(const gpuStream_t& stream,
                                                  T* dx_data, const T* out_data,
                                                  const T* dout_data,
                                                  const int N, const int dim,
@@ -655,7 +655,7 @@ inline void LaunchSpandDimDSoftmaxBackwardKernel(const cudaStream_t& stream,
 }
 
 template <typename T>
-inline void LaunchSpandDimDSoftmaxBackward(const cudaStream_t& stream,
+inline void LaunchSpandDimDSoftmaxBackward(const gpuStream_t& stream,
                                            T* dx_data, const T* out_data,
                                            const T* dout_data, const int N,
                                            const int dim, const int D) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
优化`softmax` op性能

**起因**：
1. 在ernie doc模型中，cudnn的softmax相关kernel耗时占比很高，其中前向kernel `softmax_fw_channel_4d_kernel`耗时占比7.4%，后向kernel  `softmax_bw_channel_4d_kernel`耗时占比6.4%.

**问题分析**：
1. 现有kernel，不论是forward还是backward，主要是针对`D==1`的情况进行了优化，且条件极为苛刻，大部分情况特别是`D>1`时仍然需要使用cudnn进行计算。而ernie doc模型的softmax输入`shape=[512, 896, 4, 12], axis=1`就是使用的cudnn实现。
2. 对于`D>1`的情况，cudnn的性能不足，存在进一步的优化点。
3. 对于任意输入`shape`，都可以按`axis`reshape为`[N, dim, D]`，故而问题就是要求`dim`个数的max value和sum value以求出最终softmax value。


**总体优化效果**:
|模型速度(V100-SXM2-16GB机器） | FP32(BS=4) | AMP(BS=4) | 加速比
|---|---|---|---|
| elemwise grad(上次优化) |1.75 steps/s | 2.75 steps/s | 1.57 |
| 优化后 | 1.83 steps/s | 2.96 steps/s | 1.61 |

| timeline占比 | baseline | 优化后 |
|---|---|---|
| softmax fw channel 4d | 7.4% |  3.7% |
| softmax bw channel 4d | 6.4% | 4.1% |

竞品对比（`x=[512, 896, 4, 12];axis=1`循环**1000**次`forward+backward` cost）：
| type | [paddle](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/layers/softmax_cn.html#softmax) | [tensorflow](https://tensorflow.google.cn/api_docs/python/tf/nn/softmax?hl=en) | [pytorch](https://pytorch.org/docs/stable/nn.functional.html?highlight=softmax#torch.nn.functional.softmax) | 优化后 |
|---|---|---|---|---|
| float16 | 2.90 s | 1.66 s | 1.68 s | 0.964 s |
| float32 | 2.97 s | 2.587 s | 2.230 s | 1.629 s |

**Bug修复**：
使用`gpuStream_t`替换原来的`cudaStream_t`，否则不能通过ROCM CI。

**优化四**：
commit id：[fd7a512](https://github.com/PaddlePaddle/Paddle/pull/31503/commits/fd7a512152754fe7e917b26ca531b7cabc7ca59c)

优化起因：
PR-CI-Py3、PR-CI-Windows、PR-CI-Coverage一直挂，失败原因在于backward在`double`时结果误差太大

问题分析：
1. 由于CI只在`double`类型时会挂，在`float16`和`float`类型下都不会挂，因此排除了代码逻辑错误；
2. 仔细分析backward代码未发现会导致`float`和`double`不一致的diff点；
3. 反过来分析forawrd代码发现在除`sum_val`处存在防除0的`+ 1e-6f`保护机制，考虑到`double`的有效位为`15~16`位，远大于`float`类型的有效位`6~7`位，此处对于值小于`1e-6f`的`double`而言反而会造成很大的误差

优化点：
1. 将forward处的`+ 1e-6f`改为`+ std::numeric_limits<AccT>::min()`


**优化三**：
commit id：[1cd1ebb](https://github.com/PaddlePaddle/Paddle/pull/31503/commits/1cd1ebb3b1d73e03c43c53469ba3804c5f530908)

优化起因：
op-benchmark挂在了`shape=[128 128 16 16], axis=1`，仅进一步测试，`LaunchLoopDimSoftmaxForward`在大部分情况下性能均比不上cudnn的实现，但`LaunchLoopDimSoftmaxBackward`在并行度足够：即block数目大于SM数目乘4的情况下比cudnn要快很多

优化点：
1. 删除`LaunchLoopDimSoftmaxForward`的逻辑；
2. 增加`LaunchLoopDimSoftmaxBackward`的调用条件，要求block大小大于`sm_count * 4`。


**第二次优化**：
本次commit id为：[1c631ac](https://github.com/PaddlePaddle/Paddle/pull/31503/commits/1c631acc603383be84ac75908dba11c7e4c4917e)。

本次优化原因和优化点较为简单，分别如下：

优化原因：
1. 经实测，对于backward`D==1`的情况，优化kernel相比cudnn并没有提升多少性能，单op float类型最多只提升了10%的性能，但相比之下代码修改了近千行，得不偿失。

优化点：
  - 删去了backward`D==1`时的三个kernel，仍然使用原kernel。
  - 保留forward和backward`D>1`时的优化kernel

**第一次优化**：
commit id为[ecdc2db](https://github.com/PaddlePaddle/Paddle/pull/31503/commits/ecdc2db13d0db8908db96f835b9530a688db7b56)。

本次优化点较多，既优化了forward又优化了backward，既优化了`D==1`的情况，又优化了`D>1`的情况，优化点分别如下：
1. forward`D==1`的情况：
 - 自写kernel性能不如原有实现，故原有代码保持不变
2. forward`D>1`的情况：
 - `D>1`时kernel的问题主要在于地址不连续，因而导致global memory访存not coalescing，故而此kernel优化的关键在于线程应按`D`维度来排列，而非通常的`dim`维度。按此思路又可以分为两种方法：
    - 完全按`D`维展开，每个线程计算`dim`个数的softmax value，即代码中的`KeLoopDimSoftmaxForward`。显而易见的是，该方法在`dim`较小时速度非常快，但`dim`较大时每个cuda core计算负担太重，速度反而会变化许多。经测试在大部分情况下`dim<=512`可以保证性能最佳。
    - 按`dim * D`来展开，每个block计算`dim * D`个数的softmax value，每个线程计算自己的max value和sum value，最后通过shared memory同步得到同`dim`总的max和sum，即代码中的`KeSpandDimDSoftmaxForward`。此方法使用范围较广，但由于中间需要通过shared memory同步，为保证每个线程计算的是同一个`dim`的数据，blockDim必须能整除`D`，且`D`必须满足`D<MAX_BLOCK_DIM`，否则计算错误。
  - 其它情况仍使用cudnn计算。
3. backward`D==1`的情况：
  - `D==1`保证了相邻线程间数据地址连续，因此无论什么方法一般都能保证global memory的coalescing。唯一的问题在于如何减少多次访问global memory。同样的，根据`shape`大小可以分为三种方法：
    - `dim <= 512`：此时每个warp处理`dim`个数据并通过`Warp Shuffle Functions`同步性能最佳，即`KeD1WarpSoftmaxBackward`。另外考虑到每个block最多可用32k或64k个32-bit registers，`dim <= 512`时完全可以每个线程将输入数据和中间结果存储在寄存器中，这样只需读写global memory各一次。注：为什么不是`dim <= 1024`？因为有两个输入值`out`和`dout`。
    - `512<dim<=2048`：此时寄存器已经不够用了，但可以利用shared memory存储输入数据和中间结果，同时为降低每个cuda core的负担，改为每个block计算`dim`个数据，即`KeD1BlockSharedSoftmaxBackward`。由于shared memory的大小限制，这里只运行`dim<=2048`时使用此方法。
    - `2048<dim`： 此时shared memory也不够用了，因此虽然还是每个block计算`dim`个数据，但必须读取两次global memory：`out[i]*dout[i]`一次，`dout[i]*(out[i]-sum_val)`一次，写只需一次，即`KeD1BlockSoftmaxBackward`。
4. backward`D>1`的情况：
  - 类似forward`D>1`，`D>1`时最大的难点在于很难利用寄存器或shared memory存储输入数据和中间数据，而backward由于`out`和`dout`对L1/L2 cache的相互flush使得global memory的访问延迟相比forward会更高，这点仍待解决。
5. 最后通过vectorizing操作提高单次访问global memory的利用率。