### PR TITLE
Fix prec on windows for long args

### DIFF
--- a/paddle/scripts/paddle_build.bat
+++ b/paddle/scripts/paddle_build.bat
@@ -462,26 +462,10 @@ dir %THIRD_PARTY_PATH:/=\%\install\mkldnn\bin
 dir %THIRD_PARTY_PATH:/=\%\install\warpctc\bin
 
 pip install requests
-python %work_dir%\tools\get_quick_disable_lt.py > Output
-if %errorlevel%==0 (
-    set /p disable_ut_quickly=<Output
-    DEL Output
-    ) else (
-    set disable_ut_quickly=''
-)
 
 set PATH=%THIRD_PARTY_PATH:/=\%\install\openblas\lib;%THIRD_PARTY_PATH:/=\%\install\openblas\bin;^
 %THIRD_PARTY_PATH:/=\%\install\zlib\bin;%THIRD_PARTY_PATH:/=\%\install\mklml\lib;^
 %THIRD_PARTY_PATH:/=\%\install\mkldnn\bin;%THIRD_PARTY_PATH:/=\%\install\warpctc\bin;%PATH%
-
-if "%NIGHTLY_MODE%"=="ON" (
-    set nightly_label="()"
-    ) else (
-    set nightly_label="(RUN_TYPE=NIGHTLY^|RUN_TYPE=DIST:NIGHTLY^|RUN_TYPE=EXCLUSIVE:NIGHTLY)"
-    echo    ========================================
-    echo    "Unittests with nightly labels  are only run at night"
-    echo    ========================================
-)
 
 if "%WITH_GPU%"=="ON" (
     goto:parallel_test_base_gpu

--- a/tools/windows/get_prec_ut_list.py
+++ b/tools/windows/get_prec_ut_list.py
@@ -37,6 +37,9 @@ def get_prec_ut_list(all_test_cases, prec_test_cases):
 
 
 if __name__ == '__main__':
+    # get prec cases lists
+    with open('ut_list', 'r') as f:
+        prec_test_cases = f.read()
     all_test_cases = sys.argv[1]
-    prec_test_cases = sys.argv[2]
+    #prec_test_cases = sys.argv[2]
     get_prec_ut_list(all_test_cases, prec_test_cases)

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -231,9 +231,9 @@ if [ ${WITH_GPU:-OFF} == "ON" ];then
 
     set +e
     if [ ${PRECISION_TEST:-OFF} == "ON" ] && [[ "$precision_cases" != "" ]];then
-        UT_list_res=$(python ${PADDLE_ROOT}/tools/windows/get_prec_ut_list.py "$UT_list" "$precision_cases" )
+        UT_list_res=$(python ${PADDLE_ROOT}/tools/windows/get_prec_ut_list.py "$UT_list" )
         UT_list_prec=$(echo "${UT_list_res}" | grep -v 'PRECISION_TEST')
-        UT_list_prec_info=$(echo "${UT_list_res}" | grep 'PRECISION_TEST')
+        echo "${UT_list_res}" | grep 'PRECISION_TEST'
         UT_list=$UT_list_prec
     fi
     set -e

--- a/tools/windows/run_unittests.sh
+++ b/tools/windows/run_unittests.sh
@@ -38,11 +38,13 @@ else
 fi
 
 # check added ut
-set +e
-cp $PADDLE_ROOT/tools/check_added_ut.sh $PADDLE_ROOT/tools/check_added_ut_win.sh
-bash $PADDLE_ROOT/tools/check_added_ut_win.sh
-rm -rf $PADDLE_ROOT/tools/check_added_ut_win.sh
-set -e
+if [ ${WITH_GPU:-OFF} == "ON" ];then
+    set +e
+    cp $PADDLE_ROOT/tools/check_added_ut.sh $PADDLE_ROOT/tools/check_added_ut_win.sh
+    bash $PADDLE_ROOT/tools/check_added_ut_win.sh
+    rm -rf $PADDLE_ROOT/tools/check_added_ut_win.sh
+    set -e
+fi
 
 
 # /*==================Fixed Disabled Windows unittests==============================*/


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复获取精准测试case时，输入参数过长的问题；
移除openblas任务多余的获取disable_ut list的代码；