### PR TITLE
[cherry-pick] optimize top_k_v2 op(#30403)

### DIFF
--- a/paddle/fluid/operators/top_k_v2_op.cu
+++ b/paddle/fluid/operators/top_k_v2_op.cu
@@ -150,7 +150,8 @@ class TopkV2OpCUDAKernel : public framework::OpKernel<T> {
 
       if (k > input_width) k = input_width;
 
-      if ((input_width <= 1024 || k >= 128 || k == input_width)) {
+      if (((input_width <= 1024 && input_height <= 2048) || k >= 128 ||
+           k == input_width)) {
         if (SortTopk<T>(dev_ctx, &trans_input, input_width, input_height, k,
                         &trans_out, &trans_ind, largest)) {
           // last step, tranpose back the indices and output


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
问题起因：
maskrcnn模型在topk处耗时特别高，cub库的`DeviceSegmentedRadixSortKernel`这个kernel耗时占比超过35.8%。

问题分析：
在[`top_k_v2_op.cu#L112`](https://github.com/jerrywgz/Paddle/blob/add_aligned_for_roi_align/paddle/fluid/operators/top_k_v2_op.cu#L112)处有个判断：当`axis`不等于最后一个维度时需要对矩阵进行转置操作，这是为了保证kernel在读取数据时保持`global memory coalesce`。但这存在一个问题，当`input_shape = (20, 242991), axis = 0`时，转置后的矩阵大小就变成了`trans_dim = (242991, 24)`，而在[`top_k_v2_op.cu#L153`](https://github.com/jerrywgz/Paddle/blob/add_aligned_for_roi_align/paddle/fluid/operators/top_k_v2_op.cu#L153)处又有一个判断，当`input_width <= 1024`时会走cub的`SortTopk`函数，很不巧的是，`SortTopk`对于处理这种行数非常大的矩阵很不在行，因此导致了速度非常慢。

优化方案：
修改[`top_k_v2_op.cu#L153`](https://github.com/jerrywgz/Paddle/blob/add_aligned_for_roi_align/paddle/fluid/operators/top_k_v2_op.cu#L153)处的条件来严格限制`SortTopk`的进入条件：

将原有的`input_width <= 1024`条件增加限制为`(input_width <= 1024 && input_height <= 2048)`

优化成果：
测试基于[`mask_rcnn_r50_fpn_1x_coco`](https://github.com/jerrywgz/PaddleDetection/blob/add_mask_fpn_detectron2/dygraph/configs/faster_rcnn_r50_fpn_1x_coco.yml)模型 + coco17数据集 + 取前18条ips平均值：

修改 | ips
---|---|
原始版本 | 4.847311765
去掉`SortTopk`逻辑 | 6.308770588
(input_width <= 1024 && input_height <= 2048) | <font color=#FF0000>6.1157</font>

修改 | profile时间占比
---|---|
原始版本 | 35.8%
(input_width <= 1024 && input_height <= 2048) |  5.8%