### PR TITLE
[Cherry-pick] optimize range op(#30811)

### DIFF
--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1374,19 +1374,19 @@ def range(start, end, step, dtype, name=None):
 
     if not isinstance(start, Variable):
         with device_guard("cpu"):
-            start = fill_constant([1], dtype, start)
+            start = fill_constant([1], dtype, start, force_cpu=True)
     elif start.dtype != dtype:
         start = cast(start, dtype)
 
     if not isinstance(end, Variable):
         with device_guard("cpu"):
-            end = fill_constant([1], dtype, end)
+            end = fill_constant([1], dtype, end, force_cpu=True)
     elif end.dtype != dtype:
         end = cast(end, dtype)
 
     if not isinstance(step, Variable):
         with device_guard("cpu"):
-            step = fill_constant([1], dtype, step)
+            step = fill_constant([1], dtype, step, force_cpu=True)
     elif step.dtype != dtype:
         step = cast(step, dtype)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
**优化起因**：
现[`paddle.fluid.layers.range`](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/layers/range_cn.html#range)存在三个拷贝点，分别将三个变量从gpu拷贝到cpu上，十分耗时

**优化一**
优化点：
1. 将输入参数放置在gpu上改为放置在cpu上，即在`range`的[python op](https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/tensor.py#L1323)中，使用`fill_constant`转换变量为tensor时指定`force_cpu=True`参数。
2. 判断输入参数是在cpu上还是gpu上，若在cpu上则无需拷贝

优化效果：
和竞品对比（取1000次计算cost）：
条件 | [paddle](https://www.paddlepaddle.org.cn/documentation/docs/zh/api/paddle/fluid/layers/range_cn.html#range) | [tf.range](https://tensorflow.google.cn/api_docs/python/tf/range?hl=en) | [torch.arange](https://pytorch.org/docs/stable/generated/torch.arange.html#torch.arange) | [优化1](https://github.com/PaddlePaddle/Paddle/commit/c9c9561e1c6a6647cce9622f179cb05e08f85304)
---|---|---|---|---|
`size=100` | 0.314474 | 0.071642 | 0.0051 | 0.226910
`size=100000` | 0.304597 | 0.138057 | 27.3776 |  0.228088

[`mask-RCNN`动态图](https://github.com/PaddlePaddle/PaddleDetection/blob/release/2.0-beta/dygraph/configs/mask_rcnn_r50_fpn_1x_coco.yml)速度对比(V100-SXM2-32GB取前18个ips跑4次取平均值)：
版本 | ips
---|---|
优化前 |  6.698619444
优化后 |  7.189104167

待优化点：
1. 在`size=100`和`size=100000`时cost差不多，可以认为大部分时间都耗在了`launch gpu kernel`上。但另一方面，完全放到cpu上更耗时，因为首先需要给cpu上的临时变量alloc空间。
2. 单测op速度还是比不上竞品，猜测原因是tensorflow和pytorch的输入输出都是cpu，不需要分配和拷贝。注：tensorflow实现见[sequence_ops.cc#L35](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/kernels/sequence_ops.cc#L35)，pytorch实现见[utility_ops.h#L1420](https://github.com/pytorch/pytorch/blob/master/caffe2/operators/utility_ops.h#L1420)。待进一步分析。