### PR TITLE
update `get_api_md5`, using the real api name as the map's key

### DIFF
--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -610,9 +610,13 @@ def get_api_md5(path):
     API_spec = '%s/%s' % (os.path.abspath(os.path.join(os.getcwd(), "..")),
                           path)
     pat = re.compile(r'\((paddle[^,]+)\W*document\W*([0-9a-z]{32})')
+    patArgSpec = re.compile(
+        r'^(paddle[^,]+)\s+\(ArgSpec.*document\W*([0-9a-z]{32})')
     with open(API_spec) as f:
         for line in f.readlines():
             mo = pat.search(line)
+            if not mo:
+                mo = patArgSpec.search(line)
             if mo:
                 api_md5[mo.group(1)] = mo.group(2)
     return api_md5

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -609,12 +609,12 @@ def get_api_md5(path):
     api_md5 = {}
     API_spec = '%s/%s' % (os.path.abspath(os.path.join(os.getcwd(), "..")),
                           path)
+    pat = re.compile(r'\((paddle[^,]+)\W*document\W*([0-9a-z]{32})')
     with open(API_spec) as f:
         for line in f.readlines():
-            api = line.split(' ', 1)[0]
-            md5 = line.split("'document', ")[1].replace(')', '').replace('\n',
-                                                                         '')
-            api_md5[api] = md5
+            mo = pat.search(line)
+            if mo:
+                api_md5[mo.group(1)] = mo.group(2)
     return api_md5
 
 
@@ -629,9 +629,12 @@ def get_incrementapi():
         for key in pr_api:
             if key in dev_api:
                 if dev_api[key] != pr_api[key]:
+                    logger.debug("%s in dev is %s, different from pr's %s", key,
+                                 dev_api[key], pr_api[key])
                     f.write(key)
                     f.write('\n')
             else:
+                logger.debug("%s is not in dev", key)
                 f.write(key)
                 f.write('\n')
 

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -162,10 +162,10 @@ class Test_get_api_md5(unittest.TestCase):
             os.path.join(os.getcwd(), "..", 'paddle/fluid/API_PR.spec'))
         with open(self.api_pr_spec_filename, 'w') as f:
             f.write("\n".join([
-                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
-                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of two_plus_two'))""",
-                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of three_plus_three'))""",
-                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of four_plus_four'))""",
+                """paddle.one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6c55one'))""",
+                """paddle.two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6c55two'))""",
+                """paddle.three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6cthree'))""",
+                """paddle.four_plus_four (paddle.four_plus_four, ('document', 'ff0f188c95030158cc6398d2a6c5four'))""",
             ]))
 
     def tearDown(self):
@@ -174,11 +174,14 @@ class Test_get_api_md5(unittest.TestCase):
 
     def test_get_api_md5(self):
         res = get_api_md5('paddle/fluid/API_PR.spec')
-        self.assertEqual("'md5sum of one_plus_one'", res['one_plus_one'])
-        self.assertEqual("'md5sum of two_plus_two'", res['two_plus_two'])
-        self.assertEqual("'md5sum of three_plus_three'",
-                         res['three_plus_three'])
-        self.assertEqual("'md5sum of four_plus_four'", res['four_plus_four'])
+        self.assertEqual("ff0f188c95030158cc6398d2a6c55one",
+                         res['paddle.one_plus_one'])
+        self.assertEqual("ff0f188c95030158cc6398d2a6c55two",
+                         res['paddle.two_plus_two'])
+        self.assertEqual("ff0f188c95030158cc6398d2a6cthree",
+                         res['paddle.three_plus_three'])
+        self.assertEqual("ff0f188c95030158cc6398d2a6c5four",
+                         res['paddle.four_plus_four'])
 
 
 class Test_get_incrementapi(unittest.TestCase):
@@ -187,16 +190,16 @@ class Test_get_incrementapi(unittest.TestCase):
             os.path.join(os.getcwd(), "..", 'paddle/fluid/API_PR.spec'))
         with open(self.api_pr_spec_filename, 'w') as f:
             f.write("\n".join([
-                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
-                """two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of two_plus_two'))""",
-                """three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of three_plus_three'))""",
-                """four_plus_four (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of four_plus_four'))""",
+                """paddle.one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6c55one'))""",
+                """paddle.two_plus_two (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6c55two'))""",
+                """paddle.three_plus_three (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6cthree'))""",
+                """paddle.four_plus_four (paddle.four_plus_four, ('document', 'ff0f188c95030158cc6398d2a6c5four'))""",
             ]))
         self.api_dev_spec_filename = os.path.abspath(
             os.path.join(os.getcwd(), "..", 'paddle/fluid/API_DEV.spec'))
         with open(self.api_dev_spec_filename, 'w') as f:
             f.write("\n".join([
-                """one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'md5sum of one_plus_one'))""",
+                """paddle.one_plus_one (ArgSpec(args=[], varargs=None, keywords=None, defaults=(,)), ('document', 'ff0f188c95030158cc6398d2a6c55one'))""",
             ]))
         self.api_diff_spec_filename = os.path.abspath(
             os.path.join(os.getcwd(), "dev_pr_diff_api.spec"))
@@ -210,9 +213,10 @@ class Test_get_incrementapi(unittest.TestCase):
         get_incrementapi()
         with open(self.api_diff_spec_filename, 'r') as f:
             lines = f.readlines()
-            self.assertCountEqual(
-                ["two_plus_two\n", "three_plus_three\n", "four_plus_four\n"],
-                lines)
+            self.assertCountEqual([
+                "paddle.two_plus_two\n", "paddle.three_plus_three\n",
+                "paddle.four_plus_four\n"
+            ], lines)
 
 
 class Test_get_wlist(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
function `get_api_md5` may use the alias name as the map's key. It causes some in-sub-module's alias name detected as the changed API.  so update the `get_api_md5`'s logic, use the API' real name as the key.

bug found in https://github.com/PaddlePaddle/Paddle/pull/31946