### PR TITLE
[Cherry-pick] optimize check_finite_and_unscale_op by fused kernel(#31954)

### DIFF
--- a/paddle/fluid/operators/amp/check_finite_and_unscale_op.cu
+++ b/paddle/fluid/operators/amp/check_finite_and_unscale_op.cu
@@ -28,17 +28,47 @@ __global__ void InverseAndMemset(const T* s, T* o, bool* found_inf) {
 }
 
 template <typename T, typename MT>
-__global__ void CheckFiniteAndUnscale(const T* in, const MT* scale, int num,
-                                      bool* found_inf, T* out) {
-  const int idx = threadIdx.x + blockIdx.x * blockDim.x;
+__global__ void CheckFiniteAndUnscale(const T** xs, const MT* scale,
+                                      int64_t size, int64_t* starts,
+                                      bool* found_inf, T** outs) {
+  const int64_t tid = threadIdx.x + blockIdx.x * blockDim.x;
 
-  if (idx < num) {
-    MT val = static_cast<MT>(in[idx]) * (*scale);
+  // copy starts array from global memory to shared memory
+  extern __shared__ int64_t s_starts[];
+  for (int i = threadIdx.x; i <= size; i += blockDim.x) {
+    s_starts[i] = starts[i];
+  }
+  __syncthreads();
+
+  const int64_t num = s_starts[size];
+  int pre_xs_index = 0;
+  bool t_found_inf = false;
+  const MT t_scale = *scale;
+  for (int64_t idx = tid; idx < num; idx += gridDim.x * blockDim.x) {
+    // get the xs's index of thread
+    int xs_index = pre_xs_index;
+    while (idx < s_starts[xs_index]) xs_index++;
+    // avoid some tensor's numel is zero
+    while (idx >= s_starts[xs_index]) xs_index++;
+    pre_xs_index = xs_index - 1;
+
+    // get in data and out data
+    const T* in = xs[pre_xs_index];
+    T* out = outs[pre_xs_index];
+    int64_t in_idx = idx - s_starts[pre_xs_index];
+
+    // Unscale
+    MT val = static_cast<MT>(in[in_idx]) * t_scale;
     T narrow_val = static_cast<T>(val);
-    out[idx] = narrow_val;
+    out[in_idx] = narrow_val;
+
+    // CheckFinite
     if (!isfinite(narrow_val)) {
-      *found_inf = true;
+      t_found_inf = true;
     }
+  }
+  if (t_found_inf) {
+    *found_inf = true;
   }
 }
 
@@ -65,20 +95,53 @@ class CheckFiniteAndUnscaleGpuKernel : public framework::OpKernel<T> {
     InverseAndMemset<MPDType><<<1, 1, 0, dev_ctx.stream()>>>(
         scale_data, inverse_scale_v, found_inf_data);
 
-    for (size_t i = 0; i < xs.size(); ++i) {
-      const auto* x = xs[i];
-      auto* out = outs[i];
-      const T* x_data = x->data<T>();
-      T* out_data = out->mutable_data<T>(dev_ctx.GetPlace());
+    size_t xs_size = xs.size();
+    // calculate each tensor's start index and copy to device
+    auto h_starts_tensor =
+        memory::Alloc(platform::CPUPlace(), (xs_size + 1) * sizeof(int64_t));
+    int64_t* h_starts = reinterpret_cast<int64_t*>(h_starts_tensor->ptr());
 
-      int num = x->numel();
-      int block = 1024;
-      int grid = (num + block - 1) / block;
-      VLOG(3) << "launch kernel";
-      CheckFiniteAndUnscale<T, MPDType><<<grid, block, 0, dev_ctx.stream()>>>(
-          x_data, inverse_scale_v, num, found_inf_data, out_data);
-      VLOG(3) << "finish kernel";
+    auto d_starts_tensor =
+        memory::Alloc(dev_ctx, (xs_size + 1) * sizeof(int64_t));
+    int64_t* d_starts = reinterpret_cast<int64_t*>(d_starts_tensor->ptr());
+
+    h_starts[0] = 0;
+    for (int i = 1; i <= xs_size; i++) {
+      // the start index value of each tensor is
+      // the sum of previous tensor's size
+      h_starts[i] = h_starts[i - 1] + xs[i - 1]->numel();
     }
+    int64_t total_num = h_starts[xs_size];
+    memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
+                 d_starts, platform::CPUPlace(), h_starts,
+                 (xs_size + 1) * sizeof(int64_t), dev_ctx.stream());
+
+    // copy each tensor's data address to device
+    auto h_mem = memory::Alloc(platform::CPUPlace(), 2 * xs_size * sizeof(T*));
+    const T** h_xs = reinterpret_cast<const T**>(h_mem->ptr());
+    T** h_outs = reinterpret_cast<T**>(h_mem->ptr()) + xs_size;
+
+    auto d_mem = memory::Alloc(dev_ctx, 2 * xs_size * sizeof(T*));
+    const T** d_xs = reinterpret_cast<const T**>(d_mem->ptr());
+    T** d_outs = reinterpret_cast<T**>(d_mem->ptr()) + xs_size;
+
+    for (size_t i = 0; i < xs_size; ++i) {
+      h_xs[i] = xs[i]->data<T>();
+      h_outs[i] = outs[i]->mutable_data<T>(dev_ctx.GetPlace());
+    }
+    memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()), d_xs,
+                 platform::CPUPlace(), h_xs, 2 * xs_size * sizeof(T*),
+                 dev_ctx.stream());
+
+    // Launch Kernel
+    int block = 1024;
+    int block_num = block * 20;  // each thread deal with 20 number
+    int grid = (total_num + block_num - 1) / block_num;
+    VLOG(3) << "launch kernel";
+    CheckFiniteAndUnscale<T, MPDType><<<
+        grid, block, (xs_size + 1) * sizeof(int64_t), dev_ctx.stream()>>>(
+        d_xs, inverse_scale_v, xs_size, d_starts, found_inf_data, d_outs);
+    VLOG(3) << "finish kernel";
   }
 };
 }  // namespace operators


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
# 起因：
`CheckFiniteAndUnscale `在新ernie doc模型timeline中占比高达5.7%，timeline中显示`check_finite_and_unscale_op`在一次运行中多次调用了`CheckFiniteAndUnscale`，最多调用了300次，且其中包含多个小kernel，存在优化点。

# 代码分析：
原有代码中存在一个`for`循环：
```
for (size_t i = 0; i < xs.size(); ++i) {
  ...
  CheckFiniteAndUnscale<<<...>>>(xs[i]->data<T>(),...,outs[i]->data<T>())
  ...
}
```
`xs`和`outs`均为一个`vector<Tensor*>`，不论tensor大小，`for`循环对于其中的每个tensor都要调用一次`CheckFiniteAndUnscale`。

# 优化
## 优化方法1：
commit id:[b2eba11](https://github.com/PaddlePaddle/Paddle/commit/b2eba1147a42408b911ab7b6e17e273ffc780f7f)
显然，融合（**fused**）kernel，将外部`for`循环去掉，改为无论`xs.size()`大小均只用调用一次kernel效果应该最为明显。

### 难点：
1. `xs`和`outs`均为host端的`vector<Tensor*>`变量，需拷贝到device端。
2. `xs`和`outs`中的Tensor数据位置不是连续的，如何判断当前线程处理的是哪个Tensor中的哪个数据？

### 优化点：
1. 通过`memory::Alloc`分配两个大小为`xs.size()`的将指针数组，用于分别存储`xs`和`outs`中每个Tensor的数据的起始地址，并最终通过`memory::Copy`拷贝到device端。
2. 假设所有Tensor中的数据都是一维连续展开的，排列方式与kernel的线程排列方式一致，存储每个Tensor展开后的起始索引值 ---即该Tensor之前所有Tensor大小之和。这样我们就可以将线程id与数据位置相对应：**若当前线程索引大于某个Tensor的起始索引值，且小于下一个Tensor的起始索引值，则说明当前线程处理的是这个Tensor**，Tensor内部索引值即为线程索引值减去该Tensor起始索引值。
3. 实现方案为通过`memory::Alloc`分配一个大小为`xs.size()`的`int64_t`数组`starts`，其中每个元素记录的是Tensor的起始索引值。通过`memory::Copy`拷贝到device端后，由于该数组会经常用到，为避免多次访问`global memory`带来的访存开销，在kernel中将该数组存储到`shared memory`中，以降低访存延迟。
4. 同样的，为避免多次访问`global memory`带来的访存开销，将`found_inf`和`scale`放在寄存器上计算。
5. 由于所有Tensor的总大小非常大，因此若kernel中每个线程只处理一个数据，常常会导致launch kernel时的`grid`值特别大，大量时间花在了block切换上。因此改为**每个线程处理20个数据**。

### 优化效果：
ernie_doc 模型速度(V100-SXM2-16GB机器） | FP32 | AMP | 加速比
---|---|---|---|
优化前 | 4.34 steps/s | 8.49 steps/s | 1.95
[优化1](https://github.com/PaddlePaddle/Paddle/commit/b2eba1147a42408b911ab7b6e17e273ffc780f7f) | 4.34 steps/s | 8.91 steps/s | 2.05

ResNet50 AMP 模型速度(V100-SXM2-32GB机器） | 优化前 |  [优化1](https://github.com/PaddlePaddle/Paddle/commit/b2eba1147a42408b911ab7b6e17e273ffc780f7f)
---|---|---|
ips | 1339 images/sec | 1347 images/sec

timeline占比 | 优化前 | [优化1](https://github.com/PaddlePaddle/Paddle/commit/b2eba1147a42408b911ab7b6e17e273ffc780f7f)
---|---|---|
ernie_doc AMP(BS=2048) | 5.7% | 1.5%
ResNet50 AMP | 0.3 % | 0.2 %

#### ResNet50收敛性验证
模型地址：[ResNet50_fp16.sh](https://github.com/PaddlePaddle/models/blob/develop/PaddleCV/image_classification/scripts/train/ResNet50_fp16.sh)
<img width=60% alt="train loss" src="https://user-images.githubusercontent.com/31386411/114487651-923a4900-9c42-11eb-850b-be948d55ac92.png">
<img width=60% alt="train avg loss" src="https://user-images.githubusercontent.com/31386411/114487655-94040c80-9c42-11eb-839f-449c5aae3673.png">
<img width=60% alt="test avg loss" src="https://user-images.githubusercontent.com/31386411/114487658-949ca300-9c42-11eb-983c-fe10ef06d064.png">
<img width=60% alt="test acc1" src="https://user-images.githubusercontent.com/31386411/114487661-95cdd000-9c42-11eb-9174-19211f1736a6.png">
<img width=60% alt="test acc5" src="https://user-images.githubusercontent.com/31386411/114487666-96666680-9c42-11eb-9bfe-b429c458355a.png">
