### PR TITLE
support the bool tensor and scalar in elementwise ops

### DIFF
--- a/python/paddle/fluid/dygraph/math_op_patch.py
+++ b/python/paddle/fluid/dygraph/math_op_patch.py
@@ -29,6 +29,7 @@ _supported_int_dtype_ = [
     core.VarDesc.VarType.INT16,
     core.VarDesc.VarType.INT32,
     core.VarDesc.VarType.INT64,
+    core.VarDesc.VarType.BOOL,
 ]
 
 # NOTE(chenweihang): We currently do not fully support the type promotion 

--- a/python/paddle/fluid/layers/math_op_patch.py
+++ b/python/paddle/fluid/layers/math_op_patch.py
@@ -22,6 +22,7 @@ from ..framework import Variable, unique_name
 from .layer_function_generator import OpProtoHolder
 
 _supported_int_dtype_ = [
+    core.VarDesc.VarType.BOOL,
     core.VarDesc.VarType.UINT8,
     core.VarDesc.VarType.INT8,
     core.VarDesc.VarType.INT16,

--- a/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
+++ b/python/paddle/fluid/tests/unittests/test_elementwise_add_op.py
@@ -520,6 +520,23 @@ class TestRealComplexElementwiseAddOp(TestComplexElementwiseAddOp):
         self.grad_y = self.grad_out
 
 
+class TestBoolAddFloatElementwiseAddop(unittest.TestCase):
+    def test_static_add(self):
+        paddle.enable_static()
+        a = 1.5
+        b = paddle.full([4, 5, 6], True, dtype='bool')
+        c = a + b
+        self.assertTrue(c.dtype == core.VarDesc.VarType.FP32)
+        paddle.enable_static()
+
+    def test_dygraph_add(self):
+        paddle.disable_static()
+        a = 1.5
+        b = paddle.full([4, 5, 6], True, dtype='bool')
+        c = a + b
+        self.assertTrue(c.dtype == core.VarDesc.VarType.FP32)
+
+
 if __name__ == '__main__':
     paddle.enable_static()
     unittest.main()


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
APIs

### Describe
support the bool tensor and scalar
之前的版本bool + float的输出一个bool的输出，修复之后即为float类型的输出
```python
import paddle
a = 1.5
b = paddle.full([2, 2, 2], True, dtype='bool')
c = a + b
print(c)
#Tensor(shape=[2, 2, 2], dtype=float32, place=CUDAPlace(0), stop_gradient=True,
#       [[[2.50000000, 2.50000000],
#        [2.50000000, 2.50000000]],

#       [[2.50000000, 2.50000000],
#       [2.50000000, 2.50000000]]])
```