### PR TITLE
Update op for ssd loss 

### DIFF
--- a/paddle/fluid/operators/detection/bipartite_match_op.cc
+++ b/paddle/fluid/operators/detection/bipartite_match_op.cc
@@ -40,12 +40,21 @@ class BipartiteMatchOp : public framework::OperatorWithKernel {
             "Output(ColToRowMatchDist) of BipartiteMatch should not be null."));
 
     auto dims = ctx->GetInputDim("DistMat");
-    PADDLE_ENFORCE_EQ(dims.size(), 2,
+    PADDLE_ENFORCE(dims.size() == 2UL || dims.size() == 3UL,
                       platform::errors::InvalidArgument(
-                          "The rank of Input(DistMat) must be 2."));
+                          "The rank of Input(DistMat) must be 2 or 3."));
 
-    ctx->SetOutputDim("ColToRowMatchIndices", dims);
-    ctx->SetOutputDim("ColToRowMatchDist", dims);
+    if (dims.size() == 3UL) {
+      ctx->SetOutputDim(
+          "ColToRowMatchIndices",
+          framework::make_ddim({dims[0], dims[2]}));
+      ctx->SetOutputDim(
+          "ColToRowMatchDist",
+          framework::make_ddim({dims[0], dims[2]}));
+    } else {
+      ctx->SetOutputDim("ColToRowMatchIndices", dims);
+      ctx->SetOutputDim("ColToRowMatchDist", dims);
+    }
   }
 
  protected:
@@ -192,41 +201,78 @@ class BipartiteMatchKernel : public framework::OpKernel<T> {
 
     auto& dev_ctx = context.device_context<platform::CPUDeviceContext>();
 
-    auto col = dist_mat->dims()[1];
+    auto col = dist_mat->dims()[dist_mat->dims().size() - 1];
 
-    int64_t n = dist_mat->lod().size() == 0UL
-                    ? 1
-                    : static_cast<int64_t>(dist_mat->lod().back().size() - 1);
-    if (dist_mat->lod().size()) {
+    if (dist_mat->dims().size() == 3UL) {
+      // new version for DistMat Tensor [N, P, M]
       PADDLE_ENFORCE_EQ(
-          dist_mat->lod().size(), 1UL,
-          platform::errors::InvalidArgument("Only support 1 level of LoD."));
-    }
-    match_indices->mutable_data<int>({n, col}, context.GetPlace());
-    match_dist->mutable_data<T>({n, col}, context.GetPlace());
+          dist_mat->lod().size(), 0UL,
+          platform::errors::InvalidArgument(
+              "When the input dimension is 3, "
+              "The type of input should be Tensor, not LoDTensor. "));
 
-    math::SetConstant<platform::CPUDeviceContext, int> iset;
-    iset(dev_ctx, match_indices, static_cast<int>(-1));
-    math::SetConstant<platform::CPUDeviceContext, T> tset;
-    tset(dev_ctx, match_dist, static_cast<T>(0));
+      int64_t batch_size = dist_mat->dims()[0];
 
-    int* indices = match_indices->data<int>();
-    T* dist = match_dist->data<T>();
-    auto type = context.Attr<std::string>("match_type");
-    auto threshold = context.Attr<float>("dist_threshold");
-    if (n == 1) {
-      BipartiteMatch(*dist_mat, indices, dist);
-      if (type == "per_prediction") {
-        ArgMaxMatch(*dist_mat, indices, dist, threshold);
+      match_indices->mutable_data<int>({batch_size, col}, context.GetPlace());
+      match_dist->mutable_data<T>({batch_size, col}, context.GetPlace());
+
+      math::SetConstant<platform::CPUDeviceContext, int> iset;
+      iset(dev_ctx, match_indices, static_cast<int>(-1));
+      math::SetConstant<platform::CPUDeviceContext, T> tset;
+      tset(dev_ctx, match_dist, static_cast<T>(0));
+
+      int* indices = match_indices->data<int>();
+      T* dist = match_dist->data<T>();
+      auto type = context.Attr<std::string>("match_type");
+      auto threshold = context.Attr<float>("dist_threshold");
+
+      framework::DDim one_ins_shape = {
+                        dist_mat->dims()[1], dist_mat->dims()[2]};
+      for (int64_t i = 0; i < batch_size; ++i) {
+        Tensor one_ins = dist_mat->Slice(i, i + 1).Resize(one_ins_shape);
+        BipartiteMatch(one_ins, indices + i * col, dist + i * col);
+        if (type == "per_prediction") {
+          ArgMaxMatch(one_ins, indices + i * col,
+              dist + i * col, threshold);
+        }
       }
     } else {
-      auto lod = dist_mat->lod().back();
-      for (size_t i = 0; i < lod.size() - 1; ++i) {
-        if (lod[i + 1] > lod[i]) {
-          Tensor one_ins = dist_mat->Slice(lod[i], lod[i + 1]);
-          BipartiteMatch(one_ins, indices + i * col, dist + i * col);
-          if (type == "per_prediction") {
-            ArgMaxMatch(one_ins, indices + i * col, dist + i * col, threshold);
+      // old version for LoDTensor
+      int64_t n = dist_mat->lod().size() == 0UL
+                  ? 1
+                  : static_cast<int64_t>(dist_mat->lod().back().size() - 1);
+      if (dist_mat->lod().size()) {
+        PADDLE_ENFORCE_EQ(
+            dist_mat->lod().size(), 1UL,
+            platform::errors::InvalidArgument("Only support 1 level of LoD."));
+      }
+      match_indices->mutable_data<int>({n, col}, context.GetPlace());
+      match_dist->mutable_data<T>({n, col}, context.GetPlace());
+
+      math::SetConstant<platform::CPUDeviceContext, int> iset;
+      iset(dev_ctx, match_indices, static_cast<int>(-1));
+      math::SetConstant<platform::CPUDeviceContext, T> tset;
+      tset(dev_ctx, match_dist, static_cast<T>(0));
+
+      int* indices = match_indices->data<int>();
+      T* dist = match_dist->data<T>();
+      auto type = context.Attr<std::string>("match_type");
+      auto threshold = context.Attr<float>("dist_threshold");
+      if (n == 1) {
+        BipartiteMatch(*dist_mat, indices, dist);
+        if (type == "per_prediction") {
+          ArgMaxMatch(*dist_mat, indices, dist, threshold);
+        }
+      } else {
+        auto lod = dist_mat->lod().back();
+        for (size_t i = 0; i < lod.size() - 1; ++i) {
+          if (lod[i + 1] > lod[i]) {
+            Tensor one_ins = dist_mat->Slice(lod[i], lod[i + 1]);
+            BipartiteMatch(one_ins, indices + i * col, dist + i * col);
+            if (type == "per_prediction") {
+              ArgMaxMatch(one_ins,
+               indices + i * col, dist + i * col, threshold);
+            }
           }
         }
       }
@@ -240,7 +286,8 @@ class BipartiteMatchOpMaker : public framework::OpProtoAndCheckerMaker {
     AddInput(
         "DistMat",
         "(LoDTensor or Tensor) this input is a 2-D LoDTensor with shape "
-        "[K, M]. It is pair-wise distance matrix between the entities "
+        "[K, M] or 3-D Tensor with shape [B, P, M], where K = B * P. "
+        "It is pair-wise distance matrix between the entities "
         "represented by each row and each column. For example, assumed one "
         "entity is A with shape [K], another entity is B with shape [M]. The "
         "DistMat[i][j] is the distance between A[i] and B[j]. The bigger "
@@ -250,7 +297,7 @@ class BipartiteMatchOpMaker : public framework::OpProtoAndCheckerMaker {
         "entities.");
     AddAttr<std::string>(
         "match_type",
-        "(string, default: per_prediction) "
+        "(string, default: bipartite) "
         "The type of matching method, should be 'bipartite' or "
         "'per_prediction', 'bipartite' by default.")
         .SetDefault("bipartite")

--- a/paddle/fluid/operators/detection/target_assign_op.cc
+++ b/paddle/fluid/operators/detection/target_assign_op.cc
@@ -41,10 +41,10 @@ class TargetAssignOp : public framework::OperatorWithKernel {
     auto in_dims = ctx->GetInputDim("X");
     auto mi_dims = ctx->GetInputDim("MatchIndices");
 
-    PADDLE_ENFORCE_EQ(
-        in_dims.size(), 3,
+    PADDLE_ENFORCE(
+        in_dims.size() == 3UL || in_dims.size() == 4UL,
         platform::errors::InvalidArgument(
-            "Expected the rank of Input(X) is 3. But received %d.",
+            "Expected the rank of Input(X) is 3 or 4. But received %d.",
             in_dims.size()));
     PADDLE_ENFORCE_EQ(mi_dims.size(), 2,
                       platform::errors::InvalidArgument(
@@ -52,13 +52,13 @@ class TargetAssignOp : public framework::OperatorWithKernel {
 
     if (ctx->HasInput("NegIndices")) {
       auto neg_dims = ctx->GetInputDim("NegIndices");
-      PADDLE_ENFORCE_EQ(neg_dims.size(), 2,
+      PADDLE_ENFORCE(neg_dims.size() == 2UL || neg_dims.size() == 3UL,
                         platform::errors::InvalidArgument(
-                            "The rank of Input(NegIndices) must be 2."));
+                            "The rank of Input(NegIndices) must be 2 or 3."));
       PADDLE_ENFORCE_EQ(
-          neg_dims[1], 1,
+          neg_dims[neg_dims.size() - 1], 1,
           platform::errors::InvalidArgument(
-              "The last dimension of Out(NegIndices) must be 1."));
+              "The last dimension of Input(NegIndices) must be 1."));
     }
 
     auto n = mi_dims[0];
@@ -81,7 +81,9 @@ class TargetAssignOpMaker : public framework::OpProtoAndCheckerMaker {
  public:
   void Make() override {
     AddInput("X",
-             "(LoDTensor), This input is a 3D LoDTensor with shape [M, P, K]. "
+             "(LoDTensor or Tensor), When the input is LoDTensor, its shape "
+             "must be [M, P, K]. When the input is Tensor, its shape can be "
+             "[B, F, K] or [B, F, A, K], where M = B * F. "
              "Some elements in X will be assigned to Out based on the "
              "MatchIndices and NegIndices.");
     AddInput("MatchIndices",
@@ -89,9 +91,12 @@ class TargetAssignOpMaker : public framework::OpProtoAndCheckerMaker {
              "with shape [N, P], If MatchIndices[i][j] is -1, the j-th entity "
              "of column is not matched to any entity of row in i-th instance.");
     AddInput("NegIndices",
-             "(LoDTensor, default LoDTensor<int>), The input negative example "
-             "indices are an optional input with shape [Neg, 1], where Neg is "
-             "the total number of negative example indices.")
+             "(LoDTensor or Tensor, default LoDTensor<int>), The input "
+             "negative example indices are an optional input with shape "
+             "[Neg, 1], where Neg is the total number of negative example "
+             "indices and input is LoDTensor. When the input is Tensor, "
+             "its shape must be [B, M, 1], where Neg = B * M and it becomes "
+             "negative example mask. ")
         .AsDispensable();
     AddAttr<int>("mismatch_value",
                  "(int, default 0), Fill this value to the "

--- a/paddle/fluid/operators/detection/target_assign_op.h
+++ b/paddle/fluid/operators/detection/target_assign_op.h
@@ -20,6 +20,7 @@ namespace paddle {
 namespace operators {
 template <typename T, typename WT>
 struct TargetAssignFunctor {
+  // old version for LoDTensor
   const T* in_;
   const int* match_indices_;
   const size_t* lod_;
@@ -73,6 +74,74 @@ struct TargetAssignFunctor {
   }
 };
 
+template <typename T, typename WT>
+struct TargetAssignDynamicFunctor {
+  // new version for dygraph Tensor
+  const T* in_;
+  const int* match_indices_;
+  const int mismatch_value_;
+  const int64_t x_dim_size_;
+  const int64_t batch_size_;
+  const int64_t num_anchors_;
+  const int64_t num_max_boxes_;
+  const int64_t K_;
+  const int* neg_mask_data_;
+
+  T* out_;
+  WT* out_wt_;
+
+  TargetAssignDynamicFunctor(const T* input, const int* match_indices,
+                      const int mismatch_value, const int64_t x_dim_size,
+                      const int64_t batch_size, const int64_t num_anchors,
+                      const int64_t num_max_boxes,
+                      const int64_t k, const int* neg_idx_data,
+                      T* out, WT* out_wt)
+      : in_(input),
+        match_indices_(match_indices),
+        mismatch_value_(mismatch_value),
+        x_dim_size_(x_dim_size),
+        batch_size_(batch_size),
+        num_anchors_(num_anchors),
+        num_max_boxes_(num_max_boxes),
+        K_(k),
+        neg_mask_data_(neg_idx_data),
+        out_(out),
+        out_wt_(out_wt) {}
+
+  HOSTDEVICE void operator()(size_t i) const {
+    int h = i / num_anchors_;
+    int w = i % num_anchors_;
+
+    int id = match_indices_[i];
+
+    T* out = out_ + i * K_;
+    WT* out_wt = out_wt_ + i;
+
+    if (id > -1) {
+      if (x_dim_size_ == 3) {
+        const T* in = in_ + h * num_max_boxes_ + id;
+        out[0] = in[0];
+      } else {
+        const T* in = in_ +
+                ((h * num_max_boxes_ + id) * num_anchors_ + w) * K_;
+        for (int64_t k = 0; k < K_; ++k) {
+          out[k] = in[k];
+        }
+      }
+      out_wt[0] = static_cast<WT>(1.);
+    } else {
+      for (int64_t k = 0; k < K_; ++k) {
+        out[k] = static_cast<T>(mismatch_value_);
+      }
+      out_wt[0] = static_cast<WT>(0.);
+    }
+
+    if (neg_mask_data_) {
+      out_wt[0] += neg_mask_data_[i];
+    }
+  }
+};
+
 template <typename DeviceContext, typename T, typename WT>
 struct NegTargetAssignFunctor {
   void operator()(const platform::DeviceContext& ctx, const int* neg_indices,
@@ -90,9 +159,12 @@ class TargetAssignKernel : public framework::OpKernel<T> {
     auto* out = ctx.Output<framework::Tensor>("Out");
     auto* out_wt = ctx.Output<framework::Tensor>("OutWeight");
 
-    PADDLE_ENFORCE_EQ(x->lod().size(), 1UL,
+    if (x->lod().size()) {
+        PADDLE_ENFORCE_EQ(x->lod().size(), 1UL,
                       platform::errors::InvalidArgument(
                           "TargetAssignOp input(X) needs 1 level of LoD"));
+    }
+
     int mismatch_value = ctx.Attr<int>("mismatch_value");
 
     const T* x_data = x->data<T>();
@@ -101,42 +173,73 @@ class TargetAssignKernel : public framework::OpKernel<T> {
     T* out_data = out->mutable_data<T>(ctx.GetPlace());
     WT* out_wt_data = out_wt->mutable_data<WT>(ctx.GetPlace());
 
-    int64_t n = match_indices->dims()[0];
-    int64_t m = match_indices->dims()[1];
-    int64_t p = x->dims()[1];
-    int64_t k = x->dims()[2];
-
-    auto x_lod = x->lod().back();
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-    size_t* x_lod_data = x_lod.MutableData(ctx.GetPlace());
-#else
-    size_t* x_lod_data = x_lod.data();
-#endif
-
-    TargetAssignFunctor<T, WT> functor(x_data, match_idx_data, x_lod_data,
-                                       mismatch_value, n, m, p, k, out_data,
-                                       out_wt_data);
-
     auto& device_ctx = ctx.template device_context<DeviceContext>();
-    platform::ForRange<DeviceContext> for_range(device_ctx, n * m);
-    for_range(functor);
 
-    auto* neg_indices = ctx.Input<framework::LoDTensor>("NegIndices");
-    if (neg_indices) {
-      PADDLE_ENFORCE_EQ(
-          neg_indices->lod().size(), 1UL,
-          platform::errors::InvalidArgument(
-              "TargetAssignOp input(NegIndices) needs 1 level of LoD"));
-      const int* neg_idx_data = neg_indices->data<int>();
-      auto neg_lod = neg_indices->lod().back();
-#if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
-      size_t* neg_lod_data = neg_lod.MutableData(ctx.GetPlace());
-#else
-      size_t* neg_lod_data = neg_lod.data();
-#endif
-      NegTargetAssignFunctor<DeviceContext, T, WT> neg_trg_functor;
-      neg_trg_functor(device_ctx, neg_idx_data, neg_lod_data, n, m, k,
-                      mismatch_value, out_data, out_wt_data);
+    if (x->lod().size()) {
+        int64_t n = match_indices->dims()[0];
+        int64_t m = match_indices->dims()[1];
+        int64_t p = x->dims()[1];
+        int64_t k = x->dims()[2];
+
+        auto x_lod = x->lod().back();
+    #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+        size_t* x_lod_data = x_lod.MutableData(ctx.GetPlace());
+    #else
+        size_t* x_lod_data = x_lod.data();
+    #endif
+
+        TargetAssignFunctor<T, WT> functor(x_data, match_idx_data, x_lod_data,
+                                           mismatch_value, n, m,
+                                           p, k, out_data,
+                                           out_wt_data);
+
+        platform::ForRange<DeviceContext> for_range(device_ctx, n * m);
+        for_range(functor);
+
+        auto* neg_indices = ctx.Input<framework::LoDTensor>("NegIndices");
+        if (neg_indices) {
+          PADDLE_ENFORCE_EQ(
+              neg_indices->lod().size(), 1UL,
+              platform::errors::InvalidArgument(
+                  "TargetAssignOp input(NegIndices) needs 1 level of LoD"));
+          const int* neg_idx_data = neg_indices->data<int>();
+          auto neg_lod = neg_indices->lod().back();
+    #if defined(PADDLE_WITH_CUDA) || defined(PADDLE_WITH_HIP)
+          size_t* neg_lod_data = neg_lod.MutableData(ctx.GetPlace());
+    #else
+          size_t* neg_lod_data = neg_lod.data();
+    #endif
+          NegTargetAssignFunctor<DeviceContext, T, WT> neg_trg_functor;
+          neg_trg_functor(device_ctx, neg_idx_data, neg_lod_data, n, m, k,
+                          mismatch_value, out_data, out_wt_data);
+        }
+    } else {
+        int64_t x_dim_size = x->dims().size();
+        int64_t batch_size = match_indices->dims()[0];
+        int64_t num_anchors = match_indices->dims()[1];
+        int64_t num_max_boxes = x->dims()[1];
+        int64_t k = x->dims()[x_dim_size - 1];
+
+        auto* neg_indices = ctx.Input<framework::LoDTensor>("NegIndices");
+        if (neg_indices) {
+          PADDLE_ENFORCE_EQ(
+              neg_indices->dims().size(), 3UL,
+              platform::errors::InvalidArgument(
+                  "TargetAssignOp input(NegIndices) must be 3D Tensor"));
+        }
+        const int* neg_idx_data = neg_indices
+                                  ? neg_indices->data<int>()
+                                  : nullptr;
+
+        TargetAssignDynamicFunctor<T, WT> functor(x_data, match_idx_data,
+                               mismatch_value, x_dim_size,
+                               batch_size, num_anchors,
+                               num_max_boxes, k, neg_idx_data,
+                               out_data, out_wt_data);
+
+        platform::ForRange<DeviceContext> for_range(device_ctx,
+            batch_size * num_anchors);
+        for_range(functor);
     }
   }
 };

--- a/paddle/fluid/pybind/op_function_generator.cc
+++ b/paddle/fluid/pybind/op_function_generator.cc
@@ -65,6 +65,7 @@ std::map<std::string, std::set<std::string>> op_ins_map = {
     {"box_coder", {"PriorBox", "PriorBoxVar", "TargetBox"}},
     {"momentum", {"Param", "Grad", "Velocity", "LearningRate"}},
     {"rnn", {"Input", "PreState", "WeightList", "SequenceLength"}},
+    {"target_assign", {"X", "MatchIndices", "NegIndices"}},
 };
 
 // NOTE(zhiqiu): Like op_ins_map.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Ops
### Describe
<!-- Describe what this PR does -->
Update OP BipartiteMatchOp, TargetAssignOp to fit dygraph SSD loss