### PR TITLE
[oneDNN] Made cache to be stored in TLS for prediction

### DIFF
--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -38,7 +38,7 @@ void NaiveExecutor::Prepare(Scope *scope, const ProgramDesc &program_desc,
 void NaiveExecutor::Run() {
 #ifdef PADDLE_WITH_MKLDNN
   // For naive executor we assume inference scenario so
-  // training happens then no communication among threads
+  // then no communication among threads
   // happens so we can keep oneDNN cache per thread
   platform::AttachPointerHashToMKLDNNKey(this, place_, true);
 #endif
@@ -127,13 +127,7 @@ void NaiveExecutor::CleanFeedFetchOps() {
   ops_.swap(ops);
 }
 
-NaiveExecutor::~NaiveExecutor() {
-#ifdef PADDLE_WITH_MKLDNN
-  // Clear mkl-dnn cache,
-  // this is needed to have mkl-dnn unit tests working
-  ClearMKLDNNCache(place_);
-#endif
-}
+NaiveExecutor::~NaiveExecutor() {}
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -37,7 +37,10 @@ void NaiveExecutor::Prepare(Scope *scope, const ProgramDesc &program_desc,
 
 void NaiveExecutor::Run() {
 #ifdef PADDLE_WITH_MKLDNN
-  platform::AttachPointerHashToMKLDNNKey(this, place_);
+  // For naive executor we assume inference scenario so
+  // training happens then no communication among threads
+  // happens so we can keep oneDNN cache per thread
+  platform::AttachPointerHashToMKLDNNKey(this, place_, true);
 #endif
   platform::ScopedFlushDenormal flush;
   for (auto &op : ops_) {

--- a/paddle/fluid/framework/naive_executor.cc
+++ b/paddle/fluid/framework/naive_executor.cc
@@ -127,7 +127,13 @@ void NaiveExecutor::CleanFeedFetchOps() {
   ops_.swap(ops);
 }
 
-NaiveExecutor::~NaiveExecutor() {}
+NaiveExecutor::~NaiveExecutor() {
+#ifdef PADDLE_WITH_MKLDNN
+  // Clear mkl-dnn cache,
+  // this is needed to have mkl-dnn unit tests working
+  ClearMKLDNNCache(place_);
+#endif
+}
 
 }  // namespace framework
 }  // namespace paddle

--- a/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
+++ b/paddle/fluid/operators/mkldnn/conv_mkldnn_op.cc
@@ -235,6 +235,10 @@ class ConvMKLDNNHandlerT
             mkldnn_paddings[0], mkldnn_paddings[1]);
       }
     }
+    PADDLE_ENFORCE_NOT_NULL(
+        this->fwd_pd_,
+        platform::errors::NotFound("Conv FWD_PD %s is not found in cache.",
+                                   this->fwd_pd_));
   }
 
   mkldnn::primitive_attr CreatePostOps(

--- a/paddle/fluid/platform/device_context.h
+++ b/paddle/fluid/platform/device_context.h
@@ -13,6 +13,7 @@ limitations under the License. */
 #include <future>  // NOLINT
 #include <memory>
 #include <mutex>  // NOLINT
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -735,6 +736,12 @@ class MKLDNNDeviceContext : public CPUDeviceContext {
 
   void EnableCacheViaTLS(void) { use_tls_cache_ = true; }
 
+  // Let know oneDNN context that TLS was disactivated so its cache was
+  // destroyed
+  void ReportDeadThread(void) {
+    this->dead_threads.insert(std::this_thread::get_id());
+  }
+
   // Prevent next ResetBlobMap()
   void BlockNextCacheClearing();
 
@@ -765,6 +772,7 @@ class MKLDNNDeviceContext : public CPUDeviceContext {
   std::shared_ptr<std::mutex> p_mutex_;
   bool block_next_cache_clearing_ = false;
   bool use_tls_cache_ = false;
+  std::set<std::thread::id> dead_threads;
 };
 #endif
 


### PR DESCRIPTION
### PR types
Bug fixes 

### PR changes
Others

### Describe
This is second fix to #31992. It does make oneDNN cache to be optionally stored to Thread Local storage location. It is enabled for prediction. 
