### PR TITLE
Unify the implementation of activation operation

### DIFF
--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -1331,10 +1331,8 @@ REGISTER_OP_CUDA_KERNEL(
                                    ops::CudaExpFunctor<float>>,
     ops::ActivationCudaKernel<plat::CUDADeviceContext,
                               ops::CudaExpFunctor<double>>,
-    ops::ActivationCudaKernel<plat::CUDADeviceContext,
-                              ops::CudaExpFunctor<int>>,
-    ops::ActivationCudaKernel<plat::CUDADeviceContext,
-                              ops::CudaExpFunctor<int64_t>>,
+    ops::ActivationKernel<plat::CUDADeviceContext, ops::ExpFunctor<int>>,
+    ops::ActivationKernel<plat::CUDADeviceContext, ops::ExpFunctor<int64_t>>,
     ops::ActivationCudaKernel<plat::CUDADeviceContext,
                               ops::CudaExpFunctor<plat::float16>>);
 REGISTER_OP_CUDA_KERNEL(
@@ -1361,6 +1359,7 @@ REGISTER_OP_CUDA_KERNEL(
     ops::LogDoubleGradKernel<plat::CUDADeviceContext,
                              ops::LogGradGradFunctor<plat::float16>>);
 /* ========================================================================== */
+
 REGISTER_ACTIVATION_CUDA_KERNEL(sigmoid, Sigmoid, CudaSigmoidFunctor,
                                 CudaSigmoidGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(logsigmoid, LogSigmoid, CudaLogSigmoidFunctor,

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -169,7 +169,7 @@ struct CudaLogSigmoidGradFunctor : public BaseActivationFunctor<T> {
     MPType dout = static_cast<MPType>(args[0]);
     MPType x = static_cast<MPType>(args[1]);
     MPType temp1 = x > zero ? zero : -x;
-    MPType temp2 = exp(-x - temp);
+    MPType temp2 = exp(-x - temp1);
     return static_cast<T>(dout * (temp2 / (exp(-temp1) + temp2)));
   }
 

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -150,7 +150,7 @@ template <typename T>
 struct CudaAtanGradFunctor : public BaseCudaActiveFunctor<T> {
   T one = static_cast<T>(1.0f);
   __device__ __forceinline__ T operator()(const T* args) const {
-    return args[0] * one / (one + args[1] * args[1]);
+    return args[0] / (one + args[1] * args[1]);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
@@ -167,10 +167,11 @@ struct CudaSoftShrinkFunctor : public BaseCudaActiveFunctor<T> {
   }
 
   __device__ __forceinline__ T operator()(const T* args) const {
-    T lambdaT = static_cast<T>(lambda);
-    T temp1 = static_cast<T>(args[0] > lambdaT);
-    T temp2 = static_cast<T>(args[0] < -lambdaT);
-    return temp1 * (args[0] - lambdaT) + temp2 * (args[0] + lambdaT);
+    T x = args[0];
+    T l = static_cast<T>(lambda);
+    T temp1 = static_cast<T>(x > l);
+    T temp2 = static_cast<T>(x < -l);
+    return temp1 * (x - l) + temp2 * (x + l);
   }
 };
 
@@ -183,10 +184,11 @@ struct CudaSoftShrinkGradFunctor : public BaseCudaActiveFunctor<T> {
   }
 
   __device__ __forceinline__ T operator()(const T* args) const {
-    T lambdaT = static_cast<T>(lambda);
-    T temp1 = static_cast<T>(args[1] > lambdaT);
-    T temp2 = static_cast<T>(args[1] < -lambdaT);
-    return args[0] * static_cast<T>(temp1 + temp2);
+    T x = args[1];
+    T l = static_cast<T>(lambda);
+    T temp1 = static_cast<T>(x > l);
+    T temp2 = static_cast<T>(x < -l);
+    return args[0] * (temp1 + temp2);
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
@@ -323,7 +325,7 @@ struct CudaAsinGradFunctor : public BaseCudaActiveFunctor<T> {
   __device__ __forceinline__ T operator()(const T* args) const {
     CT dout = static_cast<CT>(args[0]);
     CT x = static_cast<CT>(args[1]);
-    return T(dout * one / sqrt(one - x * x));
+    return T(dout / sqrt(one - x * x));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
@@ -347,7 +349,7 @@ struct CudaAcosGradFunctor : public BaseCudaActiveFunctor<T> {
   __device__ __forceinline__ T operator()(const T* args) const {
     CT dout = static_cast<CT>(args[0]);
     CT x = static_cast<CT>(args[1]);
-    return T(-dout * one / sqrt(one - x * x));
+    return T(-dout / sqrt(one - x * x));
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
@@ -418,6 +420,361 @@ struct CudaReciprocalGradFunctor : public BaseCudaActiveFunctor<T> {
   static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepOut; }
 };
 /********************Reciprocal End********************/
+
+/********************Log1p Begin********************/
+template <typename T>
+struct CudaLog1pFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    return T(log(one + x));
+  }
+};
+
+template <typename T>
+struct CudaLog1pGradFunctor : public BaseCudaActiveFunctor<T> {
+  T one = static_cast<T>(1.0f);
+  __device__ __forceinline__ T operator()(const T* args) const {
+    return args[0] / (one + args[1]);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************Log1p End********************/
+
+/********************Log2 Begin********************/
+template <typename T>
+struct CudaLog2Functor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    return T(log2(x));
+  }
+};
+
+template <typename T>
+struct CudaLog2GradFunctor : public BaseCudaActiveFunctor<T> {
+  T log_two = static_cast<T>(log(2));
+  __device__ __forceinline__ T operator()(const T* args) const {
+    return args[0] / (args[1] * log_two);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************Log2 End********************/
+
+/********************Log10 Begin********************/
+template <typename T>
+struct CudaLog10Functor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    return T(log10(x));
+  }
+};
+
+template <typename T>
+struct CudaLog10GradFunctor : public BaseCudaActiveFunctor<T> {
+  T log_ten = static_cast<T>(log(10));
+  __device__ __forceinline__ T operator()(const T* args) const {
+    return args[0] / (args[1] * log_ten);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************Log10 End********************/
+
+/********************BRelu Begin********************/
+template <typename T>
+struct CudaBReluFunctor : public BaseCudaActiveFunctor<T> {
+  float t_min;
+  float t_max;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"t_min", &t_min}, {"t_max", &t_max}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T x = args[0];
+    T t_min_cast = static_cast<T>(t_min);
+    T t_max_cast = static_cast<T>(t_max);
+    return (x > t_min_cast && x < t_max_cast)
+               ? x
+               : (x <= t_min_cast ? t_min_cast : t_max_cast);
+  }
+};
+
+template <typename T>
+struct CudaBReluGradFunctor : public BaseCudaActiveFunctor<T> {
+  T zero = static_cast<T>(0.0f);
+  float t_min;
+  float t_max;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"t_min", &t_min}, {"t_max", &t_max}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T dout = args[0];
+    T x = args[1];
+    T t_min_cast = static_cast<T>(t_min);
+    T t_max_cast = static_cast<T>(t_max);
+    return (x <= t_min_cast || x >= t_max_cast) ? zero : dout;
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************BRelu End********************/
+
+/********************SoftRelu Begin********************/
+template <typename T>
+struct CudaSoftReluFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  float threshold;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    CT t = static_cast<CT>(threshold);
+    CT temp = (x > -t && x < t) ? x : (x <= -t ? -t : t);
+    return T(log(one + exp(temp)));
+  }
+};
+
+template <typename T>
+struct CudaSoftReluGradFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  float threshold;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT dout = static_cast<CT>(args[0]);
+    CT out = static_cast<CT>(args[1]);
+    CT t = static_cast<CT>(threshold);
+    return (out <= -t || out >= t) ? static_cast<T>(0.0f)
+                                   : T(dout * (one - exp(-out)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepOut; }
+};
+/********************SoftRelu End********************/
+
+/********************STanh Begin********************/
+template <typename T>
+struct CudaSTanhFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  float scale_a;
+  float scale_b;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"scale_a", &scale_a}, {"scale_b", &scale_b}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    CT a = static_cast<CT>(scale_a);
+    CT b = static_cast<CT>(scale_b);
+    return T(b * tanh(a * x));
+  }
+};
+
+template <typename T>
+struct CudaSTanhGradFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  float scale_a;
+  float scale_b;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"scale_a", &scale_a}, {"scale_b", &scale_b}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT dout = static_cast<CT>(args[0]);
+    CT x = static_cast<CT>(args[1]);
+    CT a = static_cast<CT>(scale_a);
+    CT b = static_cast<CT>(scale_b);
+    CT temp = tanh(a * x) * tanh(a * x);
+    return T(dout * a * b * (one - temp));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************STanh End********************/
+
+/********************Softplus Begin********************/
+template <typename T>
+struct CudaSoftplusFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  float beta;
+  float threshold;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"beta", &beta}, {"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    CT b = static_cast<CT>(beta);
+    CT t = static_cast<CT>(threshold);
+    CT x_beta = x * beta;
+    return T(x_beta > t ? x : log(one + exp(x_beta)) / b);
+  }
+};
+
+template <typename T>
+struct CudaSoftplusGradFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  float beta;
+  float threshold;
+
+  typename BaseCudaActiveFunctor<T>::AttrPair GetAttrs() {
+    return {{"beta", &beta}, {"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT dout = static_cast<CT>(args[0]);
+    CT x = static_cast<CT>(args[1]);
+    CT b = static_cast<CT>(beta);
+    CT t = static_cast<CT>(threshold);
+    CT x_beta = x * beta;
+    return x_beta > t ? args[0] : T(dout / (one + exp(-x_beta)));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************Softplus End********************/
+
+/********************Softsign Begin********************/
+template <typename T>
+struct CudaSoftsignFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    return T(x / (one + abs(x)));
+  }
+};
+
+template <typename T>
+struct CudaSoftsignGradFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  CT one = static_cast<CT>(1.0f);
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT dout = static_cast<CT>(args[0]);
+    CT x = static_cast<CT>(args[1]);
+    return T(dout / ((one + abs(x)) * (one + abs(x))));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************Softsign End********************/
+
+/********************Relu6 Begin********************/
+template <typename T>
+struct CudaRelu6Functor : public BaseCudaActiveFunctor<T> {
+  T zero = static_cast<T>(0.0f);
+  float threshold;
+
+  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+    return {{"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T t = static_cast<T>(threshold);
+    return args[0] <= zero ? zero : (args[0] < t ? args[0] : t);
+  }
+};
+
+template <typename T>
+struct CudaRelu6GradFunctor : public BaseCudaActiveFunctor<T> {
+  T zero = static_cast<T>(0.0f);
+  float threshold;
+
+  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+    return {{"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T t = static_cast<T>(threshold);
+    return (args[1] > zero && args[1] < t) ? args[0] : zero;
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepOut; }
+};
+/********************Relu6 End********************/
+
+/********************TanhShrink Begin********************/
+template <typename T>
+struct CudaTanhShrinkFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT x = static_cast<CT>(args[0]);
+    return T(x - tanh(x));
+  }
+};
+
+template <typename T>
+struct CudaTanhShrinkGradFunctor : public BaseCudaActiveFunctor<T> {
+  using CT = typename details::MPTypeTrait<T>::Type;
+  __device__ __forceinline__ T operator()(const T* args) const {
+    CT dout = static_cast<CT>(args[0]);
+    CT x = static_cast<CT>(args[1]);
+    return T(dout * tanh(x) * tanh(x));
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************TanhShrink End********************/
+
+/********************HardShrink Begin********************/
+template <typename T>
+struct CudaHardShrinkFunctor : public BaseCudaActiveFunctor<T> {
+  float threshold;
+
+  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+    return {{"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T x = args[0];
+    T t = static_cast<T>(threshold);
+    T temp1 = static_cast<T>(x > t);
+    T temp2 = static_cast<T>(x < -t);
+    return x * (temp1 + temp2);
+  }
+};
+
+template <typename T>
+struct CudaHardShrinkGradFunctor : public BaseCudaActiveFunctor<T> {
+  float threshold;
+
+  typename BaseActivationFunctor<T>::AttrPair GetAttrs() {
+    return {{"threshold", &threshold}};
+  }
+
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T x = args[1];
+    T t = static_cast<T>(threshold);
+    T temp1 = static_cast<T>(x > t);
+    T temp2 = static_cast<T>(x < -t);
+    return args[0] * (temp1 + temp2);
+  }
+
+  static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }
+};
+/********************HardShrink End********************/
 
 template <typename DeviceContext, typename Functor>
 class ActivationGPUKernel
@@ -712,6 +1069,30 @@ REGISTER_ACTIVATION_GPU_KERNEL(cosh, Cosh, CudaCoshFunctor,
                                CudaCoshGradFunctor);
 REGISTER_ACTIVATION_GPU_KERNEL(round, Round, CudaRoundFunctor,
                                CudaZeroGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(reciprocal, Reciprocal, CudaReciprocalFunctor,
+                               CudaReciprocalGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(log1p, Log1p, CudaLog1pFunctor,
+                               CudaLog1pGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(log2, Log2, CudaLog2Functor,
+                               CudaLog2GradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(log10, Log10, CudaLog10Functor,
+                               CudaLog10GradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(brelu, BRelu, CudaBReluFunctor,
+                               CudaBReluGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(soft_relu, SoftRelu, CudaSoftReluFunctor,
+                               CudaSoftReluGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(stanh, STanh, CudaSTanhFunctor,
+                               CudaSTanhGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(softplus, Softplus, CudaSoftplusFunctor,
+                               CudaSoftplusGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(softsign, Softsign, CudaSoftsignFunctor,
+                               CudaSoftsignGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(relu6, Relu6, CudaRelu6Functor,
+                               CudaRelu6GradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(tanh_shrink, TanhShrink, CudaTanhShrinkFunctor,
+                               CudaTanhShrinkGradFunctor);
+REGISTER_ACTIVATION_GPU_KERNEL(hard_shrink, HardShrink, CudaHardShrinkFunctor,
+                               CudaHardShrinkGradFunctor);
 // REGISTER_ACTIVATION_CUDA_KERNEL(sigmoid, Sigmoid, SigmoidFunctor,
 // SigmoidGradFunctor);
 // REGISTER_ACTIVATION_CUDA_KERNEL(logsigmoid, LogSigmoid, LogSigmoidFunctor,
@@ -730,24 +1111,29 @@ REGISTER_ACTIVATION_GPU_KERNEL(round, Round, CudaRoundFunctor,
 // REGISTER_ACTIVATION_CUDA_KERNEL(sinh, Sinh, SinhFunctor, SinhGradFunctor);
 // REGISTER_ACTIVATION_CUDA_KERNEL(cosh, Cosh, CoshFunctor, CoshGradFunctor);
 // REGISTER_ACTIVATION_CUDA_KERNEL(round, Round, RoundFunctor, ZeroGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(reciprocal, Reciprocal, ReciprocalFunctor,
-                                ReciprocalGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(log1p, Log1p, Log1pFunctor, Log1pGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(log2, Log2, Log2Functor, Log2GradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(log10, Log10, Log10Functor, Log10GradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(brelu, BRelu, BReluFunctor, BReluGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(soft_relu, SoftRelu, SoftReluFunctor,
-                                SoftReluGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(stanh, STanh, STanhFunctor, STanhGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(softplus, Softplus, SoftplusFunctor,
-                                SoftplusGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(softsign, Softsign, SoftsignFunctor,
-                                SoftsignGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(relu6, Relu6, Relu6Functor, Relu6GradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(tanh_shrink, TanhShrink, TanhShrinkFunctor,
-                                TanhShrinkGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(hard_shrink, HardShrink, HardShrinkFunctor,
-                                HardShrinkGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(reciprocal, Reciprocal, ReciprocalFunctor,
+//                                ReciprocalGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(log1p, Log1p, Log1pFunctor,
+// Log1pGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(log2, Log2, Log2Functor, Log2GradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(log10, Log10, Log10Functor,
+// Log10GradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(brelu, BRelu, BReluFunctor,
+// BReluGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(soft_relu, SoftRelu, SoftReluFunctor,
+//                                SoftReluGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(stanh, STanh, STanhFunctor,
+// STanhGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(softplus, Softplus, SoftplusFunctor,
+//                                SoftplusGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(softsign, Softsign, SoftsignFunctor,
+//                                SoftsignGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(relu6, Relu6, Relu6Functor,
+// Relu6GradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(tanh_shrink, TanhShrink, TanhShrinkFunctor,
+//                                TanhShrinkGradFunctor);
+// REGISTER_ACTIVATION_CUDA_KERNEL(hard_shrink, HardShrink, HardShrinkFunctor,
+//                                HardShrinkGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(hard_sigmoid, HardSigmoid, HardSigmoidFunctor,
                                 HardSigmoidGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(swish, Swish, SwishFunctor, SwishGradFunctor);

--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -1390,6 +1390,40 @@ REGISTER_OP_CUDA_KERNEL(
                              ops::LogGradGradFunctor<plat::float16>>);
 /* ========================================================================== */
 
+/* ==========================   softrelu register  ============================
+ */
+REGISTER_OP_CUDA_KERNEL(
+    soft_relu,
+    ops::ActivationKernel<plat::CUDADeviceContext, ops::SoftReluFunctor<float>>,
+    ops::ActivationKernel<plat::CUDADeviceContext,
+                          ops::SoftReluFunctor<double>>,
+    ops::ActivationKernel<plat::CUDADeviceContext,
+                          ops::SoftReluFunctor<plat::float16>>);
+REGISTER_OP_CUDA_KERNEL(
+    soft_relu_grad, ops::ActivationGradKernel<plat::CUDADeviceContext,
+                                              ops::SoftReluGradFunctor<float>>,
+    ops::ActivationGradKernel<plat::CUDADeviceContext,
+                              ops::SoftReluGradFunctor<double>>,
+    ops::ActivationGradKernel<plat::CUDADeviceContext,
+                              ops::SoftReluGradFunctor<plat::float16>>);
+/* ========================================================================== */
+
+/* ==========================   swish register  ============================ */
+REGISTER_OP_CUDA_KERNEL(
+    swish,
+    ops::ActivationKernel<plat::CUDADeviceContext, ops::SwishFunctor<float>>,
+    ops::ActivationKernel<plat::CUDADeviceContext, ops::SwishFunctor<double>>,
+    ops::ActivationKernel<plat::CUDADeviceContext,
+                          ops::SwishFunctor<plat::float16>>);
+REGISTER_OP_CUDA_KERNEL(
+    swish_grad, ops::ActivationGradKernel<plat::CUDADeviceContext,
+                                          ops::SwishGradFunctor<float>>,
+    ops::ActivationGradKernel<plat::CUDADeviceContext,
+                              ops::SwishGradFunctor<double>>,
+    ops::ActivationGradKernel<plat::CUDADeviceContext,
+                              ops::SwishGradFunctor<plat::float16>>);
+/* ========================================================================== */
+
 REGISTER_ACTIVATION_CUDA_KERNEL(sigmoid, Sigmoid, CudaSigmoidFunctor,
                                 CudaSigmoidGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(silu, Silu, CudaSiluFunctor,
@@ -1427,8 +1461,6 @@ REGISTER_ACTIVATION_CUDA_KERNEL(log10, Log10, CudaLog10Functor,
                                 CudaLog10GradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(brelu, BRelu, CudaBReluFunctor,
                                 CudaBReluGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(soft_relu, SoftRelu, CudaSoftReluFunctor,
-                                CudaSoftReluGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(stanh, STanh, CudaSTanhFunctor,
                                 CudaSTanhGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(softplus, Softplus, CudaSoftplusFunctor,
@@ -1444,8 +1476,6 @@ REGISTER_ACTIVATION_CUDA_KERNEL(hard_shrink, HardShrink, CudaHardShrinkFunctor,
 REGISTER_ACTIVATION_CUDA_KERNEL(hard_sigmoid, HardSigmoid,
                                 CudaHardSigmoidFunctor,
                                 CudaHardSigmoidGradFunctor);
-REGISTER_ACTIVATION_CUDA_KERNEL(swish, Swish, CudaSwishFunctor,
-                                CudaSwishGradFunctor);
 REGISTER_ACTIVATION_CUDA_KERNEL(thresholded_relu, ThresholdedRelu,
                                 CudaThresholdedReluFunctor,
                                 CudaThresholdedReluGradFunctor);

--- a/paddle/fluid/operators/activation_op.h
+++ b/paddle/fluid/operators/activation_op.h
@@ -455,7 +455,7 @@ struct HardShrinkFunctor : public BaseActivationFunctor<T> {
   void operator()(Device d, X x, Out out) const {
     auto temp1 = x < static_cast<T>(threshold * -1.f);
     auto temp2 = x > static_cast<T>(threshold);
-    out.device(d) = x * (temp1 + temp2).template cast<T>();
+    out.device(d) = x * (temp1 || temp2).template cast<T>();
   }
 };
 
@@ -472,7 +472,7 @@ struct HardShrinkGradFunctor : public BaseActivationFunctor<T> {
   void operator()(Device d, X x, Out out, dOut dout, dX dx) const {
     auto temp1 = x < static_cast<T>(threshold * -1.f);
     auto temp2 = x > static_cast<T>(threshold);
-    dx.device(d) = dout * (temp1 + temp2).template cast<T>();
+    dx.device(d) = dout * (temp1 || temp2).template cast<T>();
   }
 
   static constexpr ActBwdOpFwdDeps FwdDeps() { return kDepX; }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Unify the implementation of activation operation
本次提交共修改激活算子25个，包括其前向和反向，其中

- 三角函数类的 9 个：sin, cos, tan, asin, acos, atan, sinh, cosh, tanh
- relu 类的 3 个：relu, leaky_relu, ~~elu~~
- sigmoid类的 3 个: sigmoid, silu, logsigmoid
- 舍入类的 3 个：ceil, floor, round
- 数学运算类的 6 个：sqrt, rsqrt, square, log, exp, reciprocal
- 缩放类的 1 个：softshrink

每种类型算子的性能提升近似，因此选取每个类别中的一个算子作为示例进行描述，如下表：
case配置：[16, 128, 257, 257]
|OP Name |FP32 old  |FP32 new  |pro  |FP16 old  |FP16 new  |pro  | 
|---|---|---|---|---|---|---|
|elu fwd |1.6077ms | 1.3114ms| 22.6% |898.68us |670.20us | 34.1% | 
|elu bwd| 2.1628ms| 1.9057ms| 13.5% |1.5737ms |963.07us | 63.4% | 
| sigmoid fwd|1.4083ms| 1.3123ms | 7.3% | 1.0360ms |674.24us  | 53.7% | 
| sigmoid bwd| 2.0002ms | 1.9059ms | 4.9% | 1.1890ms |961.18us  | 23.7% | 
| ceil fwd| 1.5198ms |1.3116ms  | 15.9% | 904.18us |670.92us  | 34.8% | 
| ceil bwd| 1.4069ms|603.45us| 133.1% | 909.00us |302.23us  | 200% | 
| sin fwd| 1.5071ms | 1.3132ms | 14.8% | 989.87us | 673.57us | 47.0% | 
| sin bwd| 2.0647ms | 1.9062ms | 8.3% | 1.3319ms | 970.76us | 37.2% | 
| sqrt fwd| 1.4051ms | 1.3121ms | 7.1% | 950.01us | 672.92us | 41.2% | 
| sqrt bwd| 2.0164ms |1.9069ms  | 5.7% | 1.3418ms | 966.90us | 38.7% | 
| softshrink fwd| 1.5230ms | 1.3118ms | 16.1% | 910.58us | 669.97us | 35.9% | 
| softshrink bwd| 2.0644ms | 1.9057ms | 8.3% | 1.2642ms | 963.07us | 31.3% | 