### PR TITLE
fix type(x)=paddle.VarBase to paddle.Tensor

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -45,6 +45,7 @@ from paddle.framework.dtype import bool
 from paddle.framework.dtype import complex64
 from paddle.framework.dtype import complex128
 from .framework import VarBase as Tensor
+Tensor.__qualname__ = 'Tensor'
 import paddle.compat
 import paddle.distributed
 import paddle.sysconfig

--- a/python/paddle/fluid/tests/unittests/test_Tensor_type.py
+++ b/python/paddle/fluid/tests/unittests/test_Tensor_type.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2020 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+import paddle
+import paddle.fluid.core as core
+
+
+class TensorTypeTest(unittest.TestCase):
+    def test_type_totensor(self):
+        paddle.disable_static()
+        inx = np.array([1, 2])
+        tensorx = paddle.to_tensor(inx)
+        typex_str = str(type(tensorx))
+        expectx = "<class 'paddle.Tensor'>"
+        self.assertEqual((typex_str == expectx), True)
+
+    def test_type_Tensor(self):
+        paddle.disable_static()
+        inx = np.array([1, 2])
+        tensorx = paddle.Tensor(inx)
+        typex_str = str(type(tensorx))
+        expectx = "<class 'paddle.Tensor'>"
+        self.assertEqual((typex_str == expectx), True)
+
+        tensorx = paddle.tensor.logic.Tensor(inx)
+        typex_str = str(type(tensorx))
+        expectx = "<class 'paddle.Tensor'>"
+        self.assertEqual((typex_str == expectx), True)
+
+    def test_type_core(self):
+        paddle.disable_static()
+        inx = np.array([1, 2])
+        tensorx = core.VarBase(inx)
+        typex_str = str(type(tensorx))
+        expectx = "<class 'paddle.Tensor'>"
+        self.assertEqual((typex_str == expectx), True)
+
+        tensorx = paddle.framework.VarBase(inx)
+        typex_str = str(type(tensorx))
+        expectx = "<class 'paddle.Tensor'>"
+        self.assertEqual((typex_str == expectx), True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
fix type(x)=paddle.VarBase to paddle.Tensor