### PR TITLE
fix the bug that the error message is not displayed on mac ci

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -607,7 +607,7 @@ EOF
         ut_startTime_s=`date +%s`
         get_quickly_disable_ut||disable_ut_quickly='' # indicate whether the case was in quickly disable list 
         if [ ${NIGHTLY_MODE:-OFF} == "ON" ]; then
-            nightly_label=""
+            nightly_label="(NIGHTLY_LABEL)"
         else
             nightly_label="(RUN_TYPE=NIGHTLY|RUN_TYPE=DIST:NIGHTLY|RUN_TYPE=EXCLUSIVE:NIGHTLY)"
             echo "========================================="
@@ -617,12 +617,12 @@ EOF
         bash $PADDLE_ROOT/tools/check_added_ut.sh
         get_precision_ut_mac
         if [[ "$on_precision" == "0" ]];then
-            ctest -E "($disable_ut_quickly)" -LE ${nightly_label} --output-on-failure -j $2 | tee $tmpfile
+            ctest -E "($disable_ut_quickly)" --output-on-failure -j $2 | tee $tmpfile
         else
-            ctest -R "($UT_list_prec)" -E "($disable_ut_quickly)" -LE ${nightly_label} --output-on-failure -j $2 | tee $tmpfile
+            ctest -R "($UT_list_prec)" -E "($disable_ut_quickly)" --output-on-failure -j $2 | tee $tmpfile
             tmpfile_rand=`date +%s%N`
             tmpfile=$tmp_dir/$tmpfile_rand
-            ctest -R "($UT_list_prec_1)" -E "($disable_ut_quickly)" -LE ${nightly_label} --output-on-failure -j $2 | tee $tmpfile
+            ctest -R "($UT_list_prec_1)" -E "($disable_ut_quickly)" --output-on-failure -j $2 | tee $tmpfile
         fi
         failed_test_lists=''
         collect_failed_tests

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -617,12 +617,12 @@ EOF
         bash $PADDLE_ROOT/tools/check_added_ut.sh
         get_precision_ut_mac
         if [[ "$on_precision" == "0" ]];then
-            ctest -E "($disable_ut_quickly)" --output-on-failure -j $2 | tee $tmpfile
+            ctest -E "($disable_ut_quickly)" -LE ${nightly_label} --output-on-failure -j $2 | tee $tmpfile
         else
-            ctest -R "($UT_list_prec)" -E "($disable_ut_quickly)" --output-on-failure -j $2 | tee $tmpfile
+            ctest -R "($UT_list_prec)" -E "($disable_ut_quickly)" -LE ${nightly_label} --output-on-failure -j $2 | tee $tmpfile
             tmpfile_rand=`date +%s%N`
             tmpfile=$tmp_dir/$tmpfile_rand
-            ctest -R "($UT_list_prec_1)" -E "($disable_ut_quickly)" --output-on-failure -j $2 | tee $tmpfile
+            ctest -R "($UT_list_prec_1)" -E "($disable_ut_quickly)" -LE ${nightly_label} --output-on-failure -j $2 | tee $tmpfile
         fi
         failed_test_lists=''
         collect_failed_tests

--- a/python/paddle/fluid/tests/unittests/test_context_manager.py
+++ b/python/paddle/fluid/tests/unittests/test_context_manager.py
@@ -30,6 +30,7 @@ class TestContextManagerRaiseException(unittest.TestCase):
         # After test_func1 executed, if fluid.dygraph.guard() in test_func1 safely exited, 
         # fluid.in_dygraph_mode() should be false.
         self.assertEqual(fluid.in_dygraph_mode(), False)
+        self.assertEqual(1, 2)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_context_manager.py
+++ b/python/paddle/fluid/tests/unittests/test_context_manager.py
@@ -30,7 +30,6 @@ class TestContextManagerRaiseException(unittest.TestCase):
         # After test_func1 executed, if fluid.dygraph.guard() in test_func1 safely exited, 
         # fluid.in_dygraph_mode() should be false.
         self.assertEqual(fluid.in_dygraph_mode(), False)
-        self.assertEqual(1, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修复MAC任务不打印失败单测信息的问题