### PR TITLE
print the real name for Functions instead of the ArgSpec

### DIFF
--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -33,13 +33,6 @@ member_dict = collections.OrderedDict()
 
 visited_modules = set()
 
-# APIs that should not be printed into API.spec 
-omitted_list = [
-    "paddle.fluid.LoDTensor.set",  # Do not know why it should be omitted
-    "paddle.fluid.io.ComposeNotAligned",
-    "paddle.fluid.io.ComposeNotAligned.__init__",
-]
-
 
 def md5(doc):
     hash = hashlib.md5()
@@ -74,8 +67,6 @@ def format_spec(spec):
 
 
 def queue_dict(member, cur_name):
-    if cur_name in omitted_list:
-        return
     if cur_name != 'paddle':
         try:
             eval(cur_name)

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -76,13 +76,22 @@ def format_spec(spec):
 def queue_dict(member, cur_name):
     if cur_name in omitted_list:
         return
-
-    doc_md5 = md5(member.__doc__)
+    try:
+        eval(cur_name)
+    except AttributeError:
+        print("AttributeError occurred when `eval(%s)`, discard it.", cur_name)
+        return
 
     if (inspect.isclass(member) or inspect.isfunction(member) or
             inspect.ismethod(member)) and hasattr(
                 member, '__module__') and hasattr(member, '__name__'):
         args = member.__module__ + "." + member.__name__
+        try:
+            eval(args)
+        except AttributeError:
+            print("AttributeError occurred when `eval(%s)`, discard it for %s.",
+                  args, cur_name)
+            return
     else:
         try:
             args = inspect.getargspec(member)
@@ -97,6 +106,7 @@ def queue_dict(member, cur_name):
         if not has_type_error:
             args = format_spec(args)
 
+    doc_md5 = md5(member.__doc__)
     member_dict[cur_name] = "({}, ('document', '{}'))".format(args, doc_md5)
 
 

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -27,7 +27,7 @@ import pydoc
 import hashlib
 import six
 import functools
-import logging
+import paddle
 
 member_dict = collections.OrderedDict()
 
@@ -71,8 +71,10 @@ def queue_dict(member, cur_name):
         try:
             eval(cur_name)
         except (AttributeError, NameError, SyntaxError) as e:
-            #print("Error(%s) occurred when `eval(%s)`, discard it.",
-            #      str(e), cur_name)
+            print(
+                "Error({}) occurred when `eval({})`, discard it.".format(
+                    str(e), cur_name),
+                file=sys.stderr)
             return
 
     if (inspect.isclass(member) or inspect.isfunction(member) or
@@ -82,8 +84,10 @@ def queue_dict(member, cur_name):
         try:
             eval(args)
         except (AttributeError, NameError, SyntaxError) as e:
-            #print("AttributeError occurred when `eval(%s)`, discard it for %s.",
-            #      args, cur_name)
+            print(
+                "Error({}) occurred when `eval({})`, discard it for {}.".format(
+                    str(e), args, cur_name),
+                file=sys.stderr)
             return
     else:
         try:
@@ -173,9 +177,10 @@ def visit_all_module(mod):
             visit_all_module(instance)
         else:
             if member_name != instance.__name__:
-                #logging.warning(
-                #    "Found alias API, alias name is: {}, original name is: {}".
-                #    format(member_name, instance.__name__))
+                print(
+                    "Found alias API, alias name is: {}, original name is: {}".
+                    format(member_name, instance.__name__),
+                    file=sys.stderr)
                 visit_member(mod.__name__, instance, member_name)
             else:
                 visit_member(mod.__name__, instance)

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -79,7 +79,9 @@ def queue_dict(member, cur_name):
 
     doc_md5 = md5(member.__doc__)
 
-    if inspect.isclass(member):
+    if (inspect.isclass(member) or inspect.isfunction(member) or
+            inspect.ismethod(member)) and hasattr(
+                member, '__module__') and hasattr(member, '__name__'):
         args = member.__module__ + "." + member.__name__
     else:
         try:
@@ -176,9 +178,10 @@ def visit_all_module(mod):
                 visit_member(mod.__name__, instance)
 
 
-modules = sys.argv[1].split(",")
-for m in modules:
-    visit_all_module(importlib.import_module(m))
+if __name__ == '__main__':
+    modules = sys.argv[1].split(",")
+    for m in modules:
+        visit_all_module(importlib.import_module(m))
 
-for name in member_dict:
-    print(name, member_dict[name])
+    for name in member_dict:
+        print(name, member_dict[name])

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -157,11 +157,14 @@ def visit_all_module(mod):
         return
 
     visited_modules.add(mod)
-
-    for member_name in (
-            name
-            for name in (mod.__all__ if hasattr(mod, "__all__") else dir(mod))
-            if not name.startswith("_")):
+    if hasattr(mod, "__all__"):
+        member_names = (name for name in mod.__all__
+                        if not name.startswith("_"))
+    elif mod_name == 'paddle':
+        member_names = dir(mod)
+    else:
+        return
+    for member_name in member_names:
         instance = getattr(mod, member_name, None)
         if instance is None:
             continue

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -115,8 +115,7 @@ def visit_member(parent_name, member, member_name=None):
     if inspect.isclass(member):
         queue_dict(member, cur_name)
         for name, value in inspect.getmembers(member):
-            if hasattr(value, '__name__') and (not name.startswith("_") or
-                                               name == "__init__"):
+            if hasattr(value, '__name__') and not name.startswith("_"):
                 visit_member(cur_name, value)
     elif inspect.ismethoddescriptor(member):
         return

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -76,11 +76,13 @@ def format_spec(spec):
 def queue_dict(member, cur_name):
     if cur_name in omitted_list:
         return
-    try:
-        eval(cur_name)
-    except AttributeError:
-        print("AttributeError occurred when `eval(%s)`, discard it.", cur_name)
-        return
+    if cur_name != 'paddle':
+        try:
+            eval(cur_name)
+        except AttributeError:
+            print("AttributeError occurred when `eval(%s)`, discard it.",
+                  cur_name)
+            return
 
     if (inspect.isclass(member) or inspect.isfunction(member) or
             inspect.ismethod(member)) and hasattr(

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -70,9 +70,9 @@ def queue_dict(member, cur_name):
     if cur_name != 'paddle':
         try:
             eval(cur_name)
-        except AttributeError:
-            print("AttributeError occurred when `eval(%s)`, discard it.",
-                  cur_name)
+        except (AttributeError, NameError) as e:
+            print("Error(%s) occurred when `eval(%s)`, discard it.",
+                  str(e), cur_name)
             return
 
     if (inspect.isclass(member) or inspect.isfunction(member) or

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -70,9 +70,9 @@ def queue_dict(member, cur_name):
     if cur_name != 'paddle':
         try:
             eval(cur_name)
-        except (AttributeError, NameError) as e:
-            print("Error(%s) occurred when `eval(%s)`, discard it.",
-                  str(e), cur_name)
+        except (AttributeError, NameError, SyntaxError) as e:
+            #print("Error(%s) occurred when `eval(%s)`, discard it.",
+            #      str(e), cur_name)
             return
 
     if (inspect.isclass(member) or inspect.isfunction(member) or
@@ -81,9 +81,9 @@ def queue_dict(member, cur_name):
         args = member.__module__ + "." + member.__name__
         try:
             eval(args)
-        except AttributeError:
-            print("AttributeError occurred when `eval(%s)`, discard it for %s.",
-                  args, cur_name)
+        except (AttributeError, NameError, SyntaxError) as e:
+            #print("AttributeError occurred when `eval(%s)`, discard it for %s.",
+            #      args, cur_name)
             return
     else:
         try:
@@ -173,9 +173,9 @@ def visit_all_module(mod):
             visit_all_module(instance)
         else:
             if member_name != instance.__name__:
-                logging.warn(
-                    "Found alias API, alias name is: {}, original name is: {}".
-                    format(member_name, instance.__name__))
+                #logging.warning(
+                #    "Found alias API, alias name is: {}, original name is: {}".
+                #    format(member_name, instance.__name__))
                 visit_member(mod.__name__, instance, member_name)
             else:
                 visit_member(mod.__name__, instance)

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -44,9 +44,7 @@ if logger.handlers:
 else:
     console = logging.StreamHandler()
     logger.addHandler(console)
-console.setFormatter(
-    logging.Formatter(
-        "%(asctime)s - %(funcName)s:%(lineno)d - %(levelname)s - %(message)s"))
+console.setFormatter(logging.Formatter("%(message)s"))
 
 RUN_ON_DEVICE = 'cpu'
 GPU_ID = 0

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -324,7 +324,7 @@ def srccoms_extract(srcfile, wlist, methods):
     if allidx != -1:
         alllist = []
         # get all list for layers/ops.py
-        if srcfile.name.find("ops.py") != -1:
+        if srcfile.name.find("fluid/layers/ops.py") != -1:
             for ai in range(0, len(srcls)):
                 if srcls[ai].startswith("__all__"):
                     lb = srcls[ai].find('[')

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -539,9 +539,10 @@ def get_filenames():
         list: the modules pending for check .
 
     '''
-    filenames = []
     global methods  # write
     global whl_error
+    import paddle
+    filenames = []
     methods = []
     whl_error = []
     get_incrementapi()

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -201,10 +201,8 @@ def sampcd_extract_and_run(srccom, name, htype="def", hname=""):
         logging.info('running %s', tfname)
         with open(tfname, 'w') as tempf:
             tempf.write(sampcd)
-        if platform.python_version()[0] == "2":
-            cmd = ["python", tfname]
-        elif platform.python_version()[0] == "3":
-            cmd = ["python3", tfname]
+        if platform.python_version()[0] in ["2", "3"]:
+            cmd = [sys.executable, tfname]
         else:
             print("Error: fail to parse python version!")
             result = False

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -19,8 +19,8 @@ import multiprocessing
 import math
 import platform
 import inspect
-import paddle
-import paddle.fluid
+#import paddle
+#import paddle.fluid
 import json
 import argparse
 import shutil
@@ -350,7 +350,7 @@ def srccoms_extract(srcfile, wlist, methods):
         api_count = 0
         handled = []
         # get src contents in layers/ops.py
-        if srcfile.name.find("ops.py") != -1:
+        if srcfile.name.find("fluid/layers/ops.py") != -1:
             for i in range(0, len(srcls)):
                 opname = None
                 opres = re.match(r"^(\w+)\.__doc__", srcls[i])

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -253,7 +253,7 @@ def execute_samplecode_test(tfname):
 
     # msg is the returned code execution report
 
-    return result,tfname, msg
+    return result, tfname, msg
 
 
 def single_defcom_extract(start_from, srcls, is_class_begin=False):

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -271,6 +271,10 @@ class Test_get_wlist(unittest.TestCase):
 class Test_srccoms_extract(unittest.TestCase):
     def setUp(self):
         self.tmpDir = tempfile.mkdtemp()
+        print('tmpDir=', self.tmpDir)
+        self.opsDir = os.path.join(self.tmpDir, 'fluid/layers')
+        os.makedirs(self.opsDir)
+        sys.path.append(self.opsDir)
         sys.path.append(self.tmpDir)
         self.api_pr_spec_filename = os.path.abspath(
             os.path.join(os.getcwd(), "..", 'paddle/fluid/API_PR.spec'))
@@ -283,7 +287,7 @@ class Test_srccoms_extract(unittest.TestCase):
             ]))
 
     def tearDown(self):
-        sys.path.remove(self.tmpDir)
+        #sys.path.remove(self.tmpDir)
         shutil.rmtree(self.tmpDir)
         os.remove(self.api_pr_spec_filename)
 
@@ -332,7 +336,7 @@ add_sample_code(globals()["two_plus_two"], """
                 print(2+2)
 """)
 '''
-        pyfilename = os.path.join(self.tmpDir, 'ops.py')
+        pyfilename = os.path.join(self.opsDir, 'ops.py')
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
         self.assertTrue(os.path.exists(pyfilename))
@@ -374,7 +378,7 @@ def one_plus_one():
             return 1+1
 
 '''
-        pyfilename = os.path.join(self.tmpDir, 'opo.py')
+        pyfilename = os.path.join(self.tmpDir, 'opo.py')  # not ops.py
         with open(pyfilename, 'w') as pyfile:
             pyfile.write(filecont)
         utsp = importlib.import_module('opo')
@@ -382,10 +386,10 @@ def one_plus_one():
         with open(pyfilename, 'r') as pyfile:
             res, error_methods = srccoms_extract(pyfile, [], methods)
             self.assertTrue(res)
-        self.assertTrue(
-            os.path.exists("samplecode_temp/"
-                           "one_plus_one_example.py"))
-        os.remove("samplecode_temp/" "one_plus_one_example.py")
+        expectedFile = os.path.join("samplecode_temp",
+                                    "one_plus_one_example.py")
+        self.assertTrue(os.path.exists(expectedFile))
+        os.remove(expectedFile)
 
     def test_with_empty_wlist(self):
         """
@@ -429,11 +433,12 @@ def three_plus_three():
             res, error_methods = srccoms_extract(pyfile, ['three_plus_three'],
                                                  methods)
             self.assertTrue(res)
-        self.assertTrue(
-            os.path.exists("samplecode_temp/four_plus_four_example.py"))
-        os.remove("samplecode_temp/" "four_plus_four_example.py")
-        self.assertFalse(
-            os.path.exists("samplecode_temp/three_plus_three_example.py"))
+
+        expectedFile = os.path.join("samplecode_temp",
+                                    "four_plus_four_example.py")
+        self.assertTrue(os.path.exists(expectedFile))
+        os.remove(expectedFile)
+        self.assertFalse(os.path.exists(expectedFile))
 
 
 # https://github.com/PaddlePaddle/Paddle/blob/develop/python/paddle/fluid/layers/ops.py

--- a/tools/test_sampcd_processor.py
+++ b/tools/test_sampcd_processor.py
@@ -309,9 +309,11 @@ def exp():
 add_sample_code(globals()["exp"], r"""
 Examples:
     .. code-block:: python
-        import paddle
-        x = paddle.to_tensor([-0.4, -0.2, 0.1, 0.3])
-        out = paddle.exp(x)
+
+        # import paddle
+        # x = paddle.to_tensor([-0.4, -0.2, 0.1, 0.3])
+        # out = paddle.exp(x)
+        out = [0.67032005, 0.81873075, 1.10517092, 1.34985881]
         print(out)
         # [0.67032005 0.81873075 1.10517092 1.34985881]
 """)


### PR DESCRIPTION

### PR types
Bug fixes

### PR changes
Others

### Describe
All the classes/functions/methods 's ArgSpec will not be displayed.
so, we should find all the stories using the output of `print_signatures.py`, such as `API_DEV.spec` and `API_PR.spec` are used by `sampcd_processor.py`.

