### PR TITLE
[NPU] Avoid building ascend_parser for WITH_ASCEND_CL

### DIFF
--- a/paddle/fluid/pybind/CMakeLists.txt
+++ b/paddle/fluid/pybind/CMakeLists.txt
@@ -58,7 +58,7 @@ set(PYBIND_SRCS
   compatible.cc
   generator_py.cc)
 
-if(WITH_ASCEND OR WITH_ASCEND_CL)
+if(WITH_ASCEND)
   set(PYBIND_DEPS ${PYBIND_DEPS} ascend_wrapper)
   set(PYBIND_SRCS ${PYBIND_SRCS} ascend_wrapper_py.cc)
 endif()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
[NPU] Avoid building ascend_parser for WITH_ASCEND_CL

ascend_parser  is not used and may result in symbol error.

![image](https://user-images.githubusercontent.com/6888866/115672857-8ce5a880-a37e-11eb-8c0e-3ff9a5848e62.png)
