### PR TITLE
[CustomOp] Remove useless extension headers for old custom op

### DIFF
--- a/paddle/extension.h
+++ b/paddle/extension.h
@@ -15,4 +15,4 @@ limitations under the License. */
 #pragma once
 
 // All paddle apis in C++ frontend
-#include "paddle/fluid/extension/include/ext_all.h"
+#include "paddle/extension/include/ext_all.h"

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -392,16 +392,19 @@ if os.name == 'nt':
 elif sys.platform == 'darwin':
     ext_modules = []
 
-def find_files(pattern, root):
+def find_files(pattern, root, recursive=False):
     for dirpath, _, files in os.walk(root):
         for filename in fnmatch.filter(files, pattern):
             yield os.path.join(dirpath, filename)
-        break
+        if not recursive:
+            break
 
 headers = (
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle')) +
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/extension/include')) +  # extension
-    ['${BOOST_INCLUDE_DIR}/boost/any.hpp'] + # boost
+    list(find_files('*', '${BOOST_INCLUDE_DIR}/boost', True)) + # boost
+    # For paddle uew custom op, only copy data type headers from `paddle/fluid/platform`
+    # to `extension/incude`,
     ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex64.h'] +
     ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex128.h'] +
     ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/float16.h'])
@@ -438,11 +441,6 @@ class InstallHeaders(Command):
         self.install_dir = None
         self.force = 0
         self.outfiles = []
-        # For paddle uew custom op, only copy data type headers from `paddle/fluid/platform`
-        # to `extension/incude`,
-        self.data_type_headers = (['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex64.h'] +
-                             ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex128.h'] +
-                             ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/float16.h'])
 
     def finalize_options(self):
         self.set_undefined_options('install',
@@ -454,10 +452,9 @@ class InstallHeaders(Command):
             install_dir = re.sub('${PADDLE_BINARY_DIR}/', '', header)
         elif 'third_party' not in header:
             # paddle headers
-            if header in self.data_type_headers:
-                install_dir = "paddle/fluid/extension/include"
-            else:
-                install_dir = re.sub('@PADDLE_SOURCE_DIR@/', '', header)
+            install_dir = re.sub('@PADDLE_SOURCE_DIR@/', '', header)
+            if 'fluid' in install_dir:
+                install_dir = "paddle/extension/include/"
         else:
             # third_party
             install_dir = re.sub('${THIRD_PARTY_PATH}', 'third_party', header)

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -394,13 +394,17 @@ elif sys.platform == 'darwin':
 
 def find_files(pattern, root):
     for dirpath, _, files in os.walk(root):
-      for filename in fnmatch.filter(files, pattern):
-          yield os.path.join(dirpath, filename)
+        for filename in fnmatch.filter(files, pattern):
+            yield os.path.join(dirpath, filename)
+        break
 
 headers = (
     list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle')) +
-    list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/extension')) +  # extension
-    list(find_files('*', '${BOOST_INCLUDE_DIR}/boost')))  # boost
+    list(find_files('*.h', '@PADDLE_SOURCE_DIR@/paddle/fluid/extension/include')) +  # extension
+    ['${BOOST_INCLUDE_DIR}/boost/any.hpp'] + # boost
+    ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex64.h'] +
+    ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex128.h'] +
+    ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/float16.h'])
 
 if '${WITH_MKLDNN}' == 'ON':
     headers += list(find_files('*', '${MKLDNN_INSTALL_DIR}/include')) # mkldnn
@@ -434,41 +438,30 @@ class InstallHeaders(Command):
         self.install_dir = None
         self.force = 0
         self.outfiles = []
+        # For paddle uew custom op, only copy data type headers from `paddle/fluid/platform`
+        # to `extension/incude`,
+        self.data_type_headers = (['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex64.h'] +
+                             ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex128.h'] +
+                             ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/float16.h'])
 
     def finalize_options(self):
         self.set_undefined_options('install',
                                    ('install_headers', 'install_dir'),
                                    ('force', 'force'))
 
-    def copy_data_type_headers(self):
-        # For paddle uew custom op, only copy data type headers from `paddle/fluid/platform`
-        # to `extension/incude`,
-        data_type_headers = (['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex64.h'] + 
-                             ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/complex128.h'] + 
-                             ['@PADDLE_SOURCE_DIR@/paddle/fluid/platform/float16.h'])
-
-        install_dir = os.path.join(self.install_dir, "paddle/fluid/extension/include")
-        if not os.path.exists(install_dir):
-            self.mkpath(install_dir)
-        for header in data_type_headers:
-            self.copy_file(header, install_dir)
-
     def mkdir_and_copy_file(self, header):
         if 'pb.h' in header:
             install_dir = re.sub('${PADDLE_BINARY_DIR}/', '', header)
         elif 'third_party' not in header:
             # paddle headers
-            install_dir = re.sub('@PADDLE_SOURCE_DIR@/', '', header)
+            if header in self.data_type_headers:
+                install_dir = "paddle/fluid/extension/include"
+            else:
+                install_dir = re.sub('@PADDLE_SOURCE_DIR@/', '', header)
         else:
             # third_party
             install_dir = re.sub('${THIRD_PARTY_PATH}', 'third_party', header)
-            patterns = ['eigen3/src/extern_eigen3', 'boost/src/extern_boost',
-                       'dlpack/src/extern_dlpack/include',
-                       'install/protobuf/include',
-                       'install/gflags/include',
-                       'install/glog/include', 'install/xxhash/include',
-                       'install/mkldnn/include',
-                       'threadpool/src/extern_threadpool']
+            patterns = ['boost/src/extern_boost', 'install/mkldnn/include']
             for pattern in patterns:
                 install_dir = re.sub(pattern, '', install_dir)
         install_dir = os.path.join(self.install_dir, os.path.dirname(install_dir))
@@ -484,7 +477,6 @@ class InstallHeaders(Command):
         for header in hdrs:
             (out, _) = self.mkdir_and_copy_file(header)
             self.outfiles.append(out)
-        self.copy_data_type_headers()
 
     def get_inputs(self):
         return self.distribution.headers or []


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

由于os.walk是会递归访问子目录文件的，所以上次移除头文件并没有达到目标，本PR进行彻底的移除

本次头文件清理，减少了4M的wheel包体积：

- 清理前：`211M Apr 22 03:15 paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.whl`
- 清理后：`207M Apr 22 10:27 paddlepaddle_gpu-0.0.0-cp37-cp37m-linux_x86_64.wh`

同时也把暴露头文件的fluid路径移除了