### PR TITLE
Fix bug that epsilon become 0 using power

### DIFF
--- a/paddle/fluid/operators/optimizers/adam_op_npu.cc
+++ b/paddle/fluid/operators/optimizers/adam_op_npu.cc
@@ -15,6 +15,7 @@ limitations under the License. */
 #include <memory>
 #include <string>
 
+#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/operators/npu_op_runner.h"
 #include "paddle/fluid/operators/optimizers/adam_op.h"
 
@@ -122,8 +123,9 @@ class AdamNPUKernel : public framework::OpKernel<T> {
     FillNpuTensorWithConstant<T>(&beta2_tensor, beta2);
 
     Tensor epsilon_tensor(framework::proto::VarType::FP32);
-    epsilon_tensor.mutable_data<T>({1}, ctx.GetPlace());
-    FillNpuTensorWithConstant<T>(&epsilon_tensor, epsilon);
+    TensorFromVector(std::vector<T>{epsilon},
+                     ctx.template device_context<platform::DeviceContext>(),
+                     &epsilon_tensor);
     auto stream =
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Fix bug that epsilon become 0 using power

We found that in ernie-3.0 model, when epsilon is 1e-8, `FillNpuTensorWithConstant`(which use power) returns 0 and may result in -nan on Parameters.
