### PR TITLE
Make range API set its out shape when possible

### DIFF
--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -381,7 +381,10 @@ class LayerHelperBase(object):
             return self.main_program.global_block().create_parameter(
                 dtype=dtype, shape=shape, type=type, **attr._to_kwargs())
 
-    def create_variable_for_type_inference(self, dtype, stop_gradient=False):
+    def create_variable_for_type_inference(self,
+                                           dtype,
+                                           stop_gradient=False,
+                                           shape=None):
         """Create a temporary variable that should be type inferred layer.
 
         Note:
@@ -397,6 +400,7 @@ class LayerHelperBase(object):
             name=unique_name.generate_with_ignorable_key(".".join(
                 [self.name, 'tmp'])),
             dtype=dtype,
+            shape=shape,
             type=core.VarDesc.VarType.LOD_TENSOR,
             persistable=False,
             stop_gradient=stop_gradient)

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1374,9 +1374,10 @@ def range(start, end, step, dtype, name=None):
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
+    out_shape = None
     if not isinstance(start, Variable) and not isinstance(
             end, Variable) and not isinstance(step, Variable):
-        out_numel = math.ceil((end - start) / step)
+        out_shape = [math.ceil((end - start) / step)]
 
     if not isinstance(start, Variable):
         with device_guard("cpu"):
@@ -1402,7 +1403,7 @@ def range(start, end, step, dtype, name=None):
     check_dtype(dtype, 'dtype', ['float32', 'float64', 'int32', 'int64'],
                 'range/arange')
     helper = LayerHelper('range', **locals())
-    out = helper.create_variable_for_type_inference(dtype, shape=[out_numel])
+    out = helper.create_variable_for_type_inference(dtype, shape=out_shape)
     helper.append_op(
         type='range',
         inputs={'Start': start,

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1376,7 +1376,7 @@ def range(start, end, step, dtype, name=None):
 
     if not isinstance(start, Variable) and not isinstance(
             end, Variable) and not isinstance(step, Variable):
-        out_numel = ceil((end - start) / step)
+        out_numel = math.ceil((end - start) / step)
 
     if not isinstance(start, Variable):
         with device_guard("cpu"):

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import math
 import numpy
 import six
 import warnings
@@ -1373,6 +1374,10 @@ def range(start, end, step, dtype, name=None):
     if not isinstance(dtype, core.VarDesc.VarType):
         dtype = convert_np_dtype_to_dtype_(dtype)
 
+    if not isinstance(start, Variable) and not isinstance(
+            end, Variable) and not isinstance(step, Variable):
+        out_numel = ceil((end - start) / step)
+
     if not isinstance(start, Variable):
         with device_guard("cpu"):
             start = fill_constant([1], dtype, start, force_cpu=True)
@@ -1397,7 +1402,7 @@ def range(start, end, step, dtype, name=None):
     check_dtype(dtype, 'dtype', ['float32', 'float64', 'int32', 'int64'],
                 'range/arange')
     helper = LayerHelper('range', **locals())
-    out = helper.create_variable_for_type_inference(dtype)
+    out = helper.create_variable_for_type_inference(dtype, shape=[out_numel])
     helper.append_op(
         type='range',
         inputs={'Start': start,

--- a/python/paddle/fluid/layers/tensor.py
+++ b/python/paddle/fluid/layers/tensor.py
@@ -1377,7 +1377,7 @@ def range(start, end, step, dtype, name=None):
     out_shape = None
     if not isinstance(start, Variable) and not isinstance(
             end, Variable) and not isinstance(step, Variable):
-        out_shape = [math.ceil((end - start) / step)]
+        out_shape = [int(math.ceil((end - start) / step))]
 
     if not isinstance(start, Variable):
         with device_guard("cpu"):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
`range` API set its output shape in dygraph but not in static graph, which can cause Dy2stat error. This PR set the shape of `range` API when possible.
