### PR TITLE
Fix compiling error if speicify -mf16c

### DIFF
--- a/paddle/fluid/platform/float16.h
+++ b/paddle/fluid/platform/float16.h
@@ -109,6 +109,8 @@ struct PADDLE_ALIGN(2) float16 {
     x = *reinterpret_cast<uint16_t*>(&res);
 
 #elif defined(__F16C__)
+// see: https://clang.llvm.org/doxygen/f16cintrin_8h_source.html
+#include <immintrin.h>  // f16cintrin.h
     x = _cvtss_sh(val, 0);
 
 #else


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

分布式在使用自定义op适配Harvod框架时，遇到指定`-mf16c` flags时编译报错。经排查是`float16.h`在走此分支时为包含对应的头文件。