### PR TITLE
Unset ReserveSpace of batch_norm for inference program.

### DIFF
--- a/paddle/fluid/framework/op_desc.cc
+++ b/paddle/fluid/framework/op_desc.cc
@@ -447,6 +447,11 @@ void OpDesc::SetOutput(const std::string &param_name,
   this->outputs_[param_name] = args;
 }
 
+void OpDesc::RemoveOutput(const std::string &name) {
+  outputs_.erase(name);
+  need_update_ = true;
+}
+
 bool OpDesc::HasProtoAttr(const std::string &name) const {
   auto &op_info = OpInfoMap::Instance();
   if (op_info.Has(desc_.type())) {

--- a/paddle/fluid/framework/op_desc.h
+++ b/paddle/fluid/framework/op_desc.h
@@ -65,6 +65,7 @@ class OpDesc {
 
   void SetOutput(const std::string &param_name,
                  const std::vector<std::string> &args);
+  void RemoveOutput(const std::string &name);
 
   bool HasAttr(const std::string &name) const {
     return attrs_.find(name) != attrs_.end();

--- a/paddle/fluid/pybind/protobuf.cc
+++ b/paddle/fluid/pybind/protobuf.cc
@@ -235,6 +235,7 @@ void BindOpDesc(pybind11::module *m) {
               const std::vector<std::string> &vec_var_name) {
              self.SetOutput(name, vec_var_name);
            })
+      .def("remove_output", &pd::OpDesc::RemoveOutput)
       .def("input_arg_names", &pd::OpDesc::InputArgumentNames)
       .def("output_arg_names", &pd::OpDesc::OutputArgumentNames)
       .def("_rename_input", &pd::OpDesc::RenameInput)

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5020,6 +5020,9 @@ class Program(object):
                 op = block.op(j)
                 if op.has_attr('is_test'):
                     op._set_attr('is_test', True)
+                if op.type(
+                ) == "batch_norm" and "ReserveSpace" in op.output_names():
+                    op.set_output("ReserveSpace", [])
         res.blocks = [
             Block(res, i) for i in six.moves.range(res.desc.num_blocks())
         ]

--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5020,9 +5020,9 @@ class Program(object):
                 op = block.op(j)
                 if op.has_attr('is_test'):
                     op._set_attr('is_test', True)
-                if op.type(
-                ) == "batch_norm" and "ReserveSpace" in op.output_names():
-                    op.set_output("ReserveSpace", [])
+                if op.type() == "batch_norm":
+                    # Remove the output ReserveSpace of batch_norm if exists.
+                    op.remove_output("ReserveSpace")
         res.blocks = [
             Block(res, i) for i in six.moves.range(res.desc.num_blocks())
         ]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs

### Describe
<!-- Describe what this PR does -->
- batch_norm的ReserveSpace输出只在训练时需要使用，用以保存一些前向计算的临时结果给反向使用。当前save_inference_model因保存了ReserveSpace，导致Lite模型batch_norm相关的pass匹配失败。因此在save_inference_model接口保存预测模型时，将ReserveSpace输出移除。
- 因有将预测模型加载进来，使用动态图重新训练的需求。所以在将预测program扩展支持训练时，需要将ReserveSpace输出加回来。

- 测试代码
```python
import paddle
import paddle.nn as nn
import numpy as np


class Model(nn.Layer):
    def __init__(self, num_channels, use_global_stats=None):
        super(Model, self).__init__()
        self.conv2d_0 = nn.Conv2D(
            in_channels=num_channels,
            out_channels=6,
            kernel_size=3,
            bias_attr=False,
            data_format='NCHW')
        self.batch_norm_0 = nn.BatchNorm2D(
            num_features=6, data_format='NCHW', use_global_stats=use_global_stats)

        self.conv2d_1 = nn.Conv2D(
            in_channels=6,
            out_channels=8,
            kernel_size=1,
            bias_attr=False,
            data_format='NCHW')
        self.batch_norm_1 = nn.BatchNorm2D(
            num_features=8, data_format='NCHW', use_global_stats=use_global_stats)

        self.in_features = 5408
        self.linear = nn.Linear(in_features=self.in_features, out_features=10)

    def forward(self, input):
        conv_out_0 = self.conv2d_0(input)
        bn_out_0 = self.batch_norm_0(conv_out_0)
        conv_out_1 = self.conv2d_1(bn_out_0)
        bn_out_1 = self.batch_norm_1(conv_out_1)
        bn_out_1 = paddle.reshape(bn_out_1, shape=[-1, self.in_features])
        linear_out = self.linear(bn_out_1)
        out = nn.functional.softmax(linear_out)
        return out


def build_and_save_model(training, path_prefix):
    paddle.enable_static()

    num_channels = 1
    model = Model(num_channels)
    if training:
        model.train()
    else:
        model.eval()

    input = paddle.static.data(name='input', shape=[None, num_channels, 28, 28], dtype='float32')
    predict = model(input)
    loss = paddle.mean(predict)

    optimizer = paddle.optimizer.Momentum()
    optimizer.minimize(loss)

    exe = paddle.static.Executor(paddle.CPUPlace())
    exe.run(paddle.static.default_startup_program())

    paddle.static.save_inference_model(path_prefix, [input], [predict], exe)


def load_and_train(mode="dynamic"):
    path_prefix = "prune_bn"
    build_and_save_model(True, path_prefix)

    if mode == "dynamic":
        paddle.disable_static()

        model = paddle.jit.load(path_prefix)
        model.train()

        data = np.random.random([1, 1, 28, 28]).astype("float32")
        input = paddle.to_tensor(data)
        predict = model(input)

        loss = paddle.mean(predict)
        loss.backward()
        adam = paddle.optimizer.Adam(learning_rate=0.001, parameters=model.parameters())
        adam.step()
        adam.clear_grad()
    else:
        exe = paddle.static.Executor(paddle.CPUPlace())
        [inference_program, feed_target_names, fetch_targets] = paddle.static.load_inference_model(path_prefix, exe)
        print(inference_program)


if __name__ == '__main__':
    load_and_train(mode="static")
```

inference_program模型结构打印如下：
![image](https://user-images.githubusercontent.com/12538138/115991916-6ed9ab80-a5fd-11eb-9edf-1b54cc3fae8a.png)


模型可视化如下：
![image](https://user-images.githubusercontent.com/12538138/115991966-b102ed00-a5fd-11eb-8e2a-ee56a3b689ad.png)

