### PR TITLE
[NPU] refine lookup_table_v2_grad npu_kernel 

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op_npu.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op_npu.cc
@@ -59,7 +59,7 @@ class LookupTableV2GradNPUKernel : public framework::OpKernel<T> {
         ctx.Input<framework::LoDTensor>(framework::GradVarName("Out"));
     auto *table_grad_t =
         ctx.Output<framework::LoDTensor>(framework::GradVarName("W"));
-    auto *p = table_grad_t->mutable_data<T>(ctx.GetPlace());
+    table_grad_t->mutable_data<T>(ctx.GetPlace());
 
     auto stream =
         ctx.template device_context<paddle::platform::NPUDeviceContext>()

--- a/paddle/fluid/operators/lookup_table_v2_op_npu.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op_npu.cc
@@ -55,7 +55,6 @@ class LookupTableV2GradNPUKernel : public framework::OpKernel<T> {
  public:
   void Compute(const framework::ExecutionContext &ctx) const override {
     auto *ids_t = ctx.Input<framework::LoDTensor>("Ids");
-
     auto *output_grad_t =
         ctx.Input<framework::LoDTensor>(framework::GradVarName("Out"));
     auto *table_grad_t =
@@ -66,8 +65,9 @@ class LookupTableV2GradNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    platform::NPUMemsetAsync(static_cast<void *>(p), 0,
-                             table_grad_t->numel() * sizeof(T), stream);
+    auto runner_zeros =
+        NpuOpRunner("ZerosLike", {*table_grad_t}, {*table_grad_t});
+    runner_zeros.Run(stream);
 
     // NOTE(zhiqiu): It seems in cann 20.1, the first input and output
     // can be different tensor, but in cann 20.2+, it does inplace operation.


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
use ZerosLike instead of NPUMemsetAsync

- before
![image](https://user-images.githubusercontent.com/6888866/115946429-9e9c8c80-a4f3-11eb-867a-6ea926aa047d.png)
As shown in the timeline, before `ScatterAdd` (called in lookup_table_v2_grad), there is a blank that is caused by NPUMemsetAsync. This PR solved the problem.

![image](https://user-images.githubusercontent.com/6888866/115946452-dc011a00-a4f3-11eb-98da-992da4b31150.png)

- after 
![image](https://user-images.githubusercontent.com/6888866/115946442-c2f86900-a4f3-11eb-80f6-1b9beca7d517.png)

![image](https://user-images.githubusercontent.com/6888866/115946444-c855b380-a4f3-11eb-9943-43151ed3a653.png)

### performance
**Speed up: 18850 tokens/s -> 19448 tokens/s, + 3.2 %**