### PR TITLE
[2.1API]rm inplace strategy for reshape

### DIFF
--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -1477,11 +1477,6 @@ def reshape(x, shape, name=None):
     """
     This operator changes the shape of ``x`` without changing its data.
 
-    Note that the output Tensor will share data with origin Tensor and doesn't
-    have a Tensor copy in ``dygraph`` mode. 
-    If you want to use the Tensor copy version, please use `Tensor.clone` like 
-    ``reshape_clone_x = x.reshape([-1]).clone()``.
-
     Some tricks exist when specifying the target shape.
 
     1. -1 means the value of this dimension is inferred from the total element
@@ -1543,10 +1538,6 @@ def reshape(x, shape, name=None):
             out = paddle.reshape(x, shape=shape_tensor)
             print(out)
             # the shape is [8, 6].
-            # out shares data with x in dygraph mode
-            x[0, 0, 0] = 10.
-            print(out[0, 0])
-            # the value is [10.]
 
     """
     return paddle.fluid.layers.reshape(x=x, shape=shape, name=name)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
there is a new reshape_ API support inplace strategy, and origin reshape api doesn't support inplace strategy.