### PR TITLE
Make assign Doc Same for creation.py and layers/tensor.py

### DIFF
--- a/python/paddle/tensor/creation.py
+++ b/python/paddle/tensor/creation.py
@@ -1036,8 +1036,10 @@ def assign(x, output=None):
     The OP copies the :attr:`x` to the :attr:`output`.
  
     Parameters:
-        x (Tensor|numpy.ndarray|list|tuple|scalar): A tensor, numpy ndarray, tuple, list or scalar,
-            its data type supports float16, float32, float64, int32, int64, and bool.
+        x (Tensor|numpy.ndarray|list|tuple|scalar): A tensor, numpy ndarray, tuple/list of scalar,
+            or scalar. Its data type supports float16, float32, float64, int32, int64, and bool.
+            Note: the float64 data will be converted to float32 because of current platform protobuf
+            data limitation.
         output (Tensor, optional): A tensor. If :attr:`output` is None, a new tensor will
             be created as :attr:`output`. Default: None.
  


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Docs
### Describe
<!-- Describe what this PR does -->
A follow up PR of https://github.com/PaddlePaddle/Paddle/pull/32420, we changed the doc of python/paddle/fluid/layers/tensor.py in that PR and we are changing python/paddle/tensor/creation.py in this PR.

Screenshot:
![image](https://user-images.githubusercontent.com/7913861/116029707-75fbca80-a68c-11eb-924a-f80f0989276c.png)
