### PR TITLE
 Support async copy for TensorFromVector with event

### DIFF
--- a/paddle/fluid/operators/npu_op_runner.h
+++ b/paddle/fluid/operators/npu_op_runner.h
@@ -21,6 +21,7 @@ limitations under the License. */
 #include <vector>
 
 #include "acl/acl.h"
+#include "paddle/fluid/framework/tensor_util.h"
 #include "paddle/fluid/operators/npu_op_runner.h"
 
 namespace paddle {
@@ -30,6 +31,7 @@ using Tensor = framework::Tensor;
 using DataLayout = framework::DataLayout;
 using NPUAttribute = framework::NPUAttribute;
 using NPUAttributeMap = framework::NPUAttributeMap;
+using DeviceContextPool = platform::DeviceContextPool;
 
 class NpuOpRunner {
  public:
@@ -90,41 +92,42 @@ aclrtStream GetCurrentNPUStream(int device_id = -1);
 
 template <typename T>
 void FillNpuTensorWithConstant(Tensor *tensor, T val) {
-  // NOTE(zhiqiu): we found that power sometimes returns 0 when val is small
-  // like 1e-8.
-  constexpr float MIN_PRECISION_FOR_POWER = 1e-3;
   PADDLE_ENFORCE_EQ(
       tensor->IsInitialized(), true,
       platform::errors::InvalidArgument("The tensor should be initialized."));
   PADDLE_ENFORCE_EQ(
       platform::is_npu_place(tensor->place()), true,
       platform::errors::InvalidArgument("The tensor should be on NPUPlace."));
-  // do async for better performance
-  if ((typeid(float) == typeid(T) || typeid(platform::float16) == typeid(T)) &&
-      static_cast<float>(val) > MIN_PRECISION_FOR_POWER) {
-    Tensor tmp(tensor->type());
-    tmp.Resize(tensor->dims());
-    tmp.mutable_data<T>(tensor->place());
-    auto stream = GetCurrentNPUStream(
-        BOOST_GET_CONST(platform::NPUPlace, tensor->place()).device);
-    platform::NPUMemsetAsync(tmp.data<void>(), 0, tmp.numel() * sizeof(T),
-                             stream);
-    auto runner = NpuOpRunner("Power", {tmp}, {*tensor},
-                              {{"power", static_cast<float>(1)},
-                               {"scale", static_cast<float>(0)},
-                               {"shift", static_cast<float>(val)}});
-    runner.Run(stream);
-  } else {
-    T *array = new T[tensor->numel()];
-    for (unsigned int i = 0; i < tensor->numel(); ++i) {
-      array[i] = static_cast<T>(val);
-    }
-    std::vector<T> vec(tensor->numel(), static_cast<T>(val));
-    // do sync copy
+
+  int numel = tensor->numel();
+  if (numel == 1) {
+    Tensor npu_pinned_tensor(tensor->type());
+    platform::NPUPinnedPlace npu_pinned_place;
+    auto npu_pinned_ptr =
+        npu_pinned_tensor.mutable_data<T>({1}, npu_pinned_place);
+    *npu_pinned_ptr = val;
+
     memory::Copy(BOOST_GET_CONST(platform::NPUPlace, tensor->place()),
-                 tensor->data<void>(), platform::CPUPlace(), array,
-                 tensor->numel() * sizeof(T), nullptr);
-    delete[] array;
+                 tensor->data<void>(), npu_pinned_place, npu_pinned_ptr,
+                 sizeof(T), GetCurrentNPUStream());
+
+    auto npu_pinned_allocator =
+        static_cast<paddle::memory::allocation::NPUPinnedAllocator *>(
+            paddle::memory::allocation::AllocatorFacade::Instance()
+                .GetAllocator(npu_pinned_place)
+                .get());
+    paddle::memory::allocation::Allocation *allocation =
+        npu_pinned_tensor.Holder().get();
+
+    npu_pinned_allocator->RecordEvent(allocation, GetCurrentNPUStream());
+  } else {
+    std::vector<T> vec(numel, static_cast<T>(val));
+    auto device_id = platform::GetCurrentNPUDeviceId();
+    platform::DeviceContextPool &pool = platform::DeviceContextPool::Instance();
+    auto *dev_ctx = static_cast<platform::NPUDeviceContext *>(
+        pool.Get(platform::NPUPlace(device_id)));
+
+    paddle::framework::TensorFromVector<T>(vec, *dev_ctx, tensor);
   }
 }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Support **async** copy for `TensorFromVector` and `FillNpuTensorWithConstant` with event.

---

### 1. 功能：
利用event 机制，在`TensorFromVector` 和`FillNpuTensorWithConstant`中支持**异步**数据拷贝。
### 2. 收益：
#### 2.1 正确性：保证异步拷贝数据，在拷贝完成前不会被析构
- **问题**：cpu 数据 异步拷贝到 npu Tensor 时，在拷贝完成前，cpu 数据被提前析构，导致拷贝结果不正确。
- **解决方案**：
  - **event 机制保证顺序->"先拷贝再析构"**：
  在cpu->npu 拷贝操作后，插入 event 到 stream，数据析构时，查询该 event 是否完成，未完成则延迟析构数据，保证"拷贝完 再析构"。
  - **NPUPinnedAllocator 管理内存，达到”延迟析构“的目的**：
  先将 cpu 数据 拷贝到一个 cpu tensor，aka `npu pinned tensor`，然后将 `npu pinned tensor` 拷贝到 npu tensor。通过 NPUPinnedAllocator 管理 npu pinned tensor 的内存分配和释放。NPUPinnedAllocator 在 npu pinned tensor 对应的 event 完成后，再释放内存。该功能在 https://github.com/PaddlePaddle/Paddle/pull/32840 中实现
  
  
#### 2.2 性能提升：
异步拷贝 比 同步拷贝，有性能提升。单机训练 ernie3.0，性能如下表所示：

序号|方案 | 速度（tokens/s） | 性能提升
--|-- | -- | --
1|FillNpuTensorWithConstant | 19988.26 | base
2|async | 20545.58 | +2.79%
3|async + malloc/free | 21706.29 | +8.60%
4|async + malloc/free + 避免shape为[1]时cpu tensor拷贝 | 21759.33 | **+8.70%**
5|async + malloc/free +  避免shape为[1]时cpu tensor拷贝+thread | 21466.57 | +7.40%

**本PR代码是方案4。**

> 方案说明：
- FillNpuTensorWithConstant：调用FillNpuTensorWithConstant，实现常量Tensor
- async：通过event 机制，异步拷贝数据，保证数据正确性
- malloc/free：不用昇腾接口 aclrtMallocHost/aclrtFreeHost，使用c++ malloc/free
- 避免shape为[1]时cpu tensor拷贝：shape为[1]的变量的拷贝，直接修改tensor 数据，不调用Copy函数
- thread：线程批量析构数据
