### PR TITLE
[NPU] refine update_loss_scaling npu kernel

### DIFF
--- a/paddle/fluid/operators/amp/update_loss_scaling_op_npu.cc
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op_npu.cc
@@ -150,11 +150,9 @@ class LazyZerosNPU {
       if (found_inf_vec[0]) {
         VLOG(4) << "-- UpdateLossScaling: Find infinite grads. --";
 
-        auto place = dev_ctx.GetPlace();
         auto stream = dev_ctx.stream();
-        auto g = out->mutable_data<T>(place);
-        platform::NPUMemsetAsync(static_cast<void*>(g), 0,
-                                 out->numel() * sizeof(T), stream);
+        auto runner_zeros = NpuOpRunner("ZerosLike", {*out}, {*out});
+        runner_zeros.Run(stream);
       }
     }
   }

--- a/paddle/fluid/operators/amp/update_loss_scaling_op_npu.cc
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op_npu.cc
@@ -150,7 +150,9 @@ class LazyZerosNPU {
       if (found_inf_vec[0]) {
         VLOG(4) << "-- UpdateLossScaling: Find infinite grads. --";
 
+        auto place = dev_ctx.GetPlace();
         auto stream = dev_ctx.stream();
+        out->mutable_data<T>(place);
         auto runner_zeros = NpuOpRunner("ZerosLike", {*out}, {*out});
         runner_zeros.Run(stream);
       }

--- a/paddle/fluid/operators/amp/update_loss_scaling_op_npu.cc
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op_npu.cc
@@ -146,18 +146,6 @@ class LazyZerosNPU {
                   const std::vector<bool> found_inf_vec,
                   const std::vector<const framework::Tensor*>& xs,
                   const std::vector<framework::Tensor*>& outs) const {
-    /*for (size_t i = 0; i < xs.size(); ++i) {
-      auto* out = outs[i];
-      if (found_inf_vec[0]) {
-        VLOG(4) << "-- UpdateLossScaling: Find infinite grads. --";
-
-        auto place = dev_ctx.GetPlace();
-        auto stream = dev_ctx.stream();
-        out->mutable_data<T>(place);
-        auto runner_zeros = NpuOpRunner("ZerosLike", {*out}, {*out});
-        runner_zeros.Run(stream);
-      }
-    }*/
     if (!xs.size()) {
       return;
     }

--- a/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_update_loss_scaling_op_npu.py
@@ -71,8 +71,7 @@ class TestUpdateLossScalingOp(OpTest):
         }
 
     def test_check_output(self):
-        self.check_output_with_place(
-            self.place, check_dygraph=False, no_check_set=['Out'])
+        self.check_output_with_place(self.place, check_dygraph=False)
 
 
 class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
@@ -102,9 +101,6 @@ class TestUpdateLossScalingOpBad(TestUpdateLossScalingOp):
             'OutGoodSteps': self.zero_steps,
             'OutBadSteps': self.zero_steps
         }
-
-    def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
 
 
 @unittest.skipIf(not paddle.is_compiled_with_npu(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

use `ZerosLike` and `Memcpy` instead of `NPUMemsetAsync`.

- before (use NPUMemsetAsync)
<img width="1115" alt="图片" src="https://user-images.githubusercontent.com/26408901/116392062-8fe70a00-a852-11eb-90c4-0ed6dccc7350.png">

As shown in the timeline, there is a blank correspondding to `update_loss_scaling_op` caused by `NPUMemsetAsync`.
`update_loss_scaling_op` cost about 103 ms.

![图片](https://user-images.githubusercontent.com/26408901/116395093-40a2d880-a856-11eb-8fec-5162ef73de0b.png)


- only use ZerosLike
If only use `ZerosLike` to replace `NPUMemsetAsync`.
<img width="1084" alt="图片" src="https://user-images.githubusercontent.com/26408901/116393270-020c1e80-a854-11eb-8c78-8bf65ab0a4c3.png">

`update_loss_scaling_op` will launch many `ZerosLike` NPU ops.
`update_loss_scaling_op` cost about 22.2 ms.

- In this PR, use ZerosLike and Memcpy
<img width="1092" alt="图片" src="https://user-images.githubusercontent.com/26408901/116393331-16e8b200-a854-11eb-943d-ba8b8fdc5edc.png">

`update_loss_scaling_op` will launch only 1 `ZerosLike` NPU op, and then use `Memcpy` to set tensor to 0.
`update_loss_scaling_op` cost about 5.5 ms.


![图片](https://user-images.githubusercontent.com/26408901/117416811-55fdbe00-af4c-11eb-9670-85270f39072d.png)



### Performance

Speed up: 19448 tokens/s -> 20679 tokens/s, +6.33  %


