### PR TITLE
fix grad.numpy in test_pylayer_op

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_pylayer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pylayer_op.py
@@ -85,7 +85,8 @@ class TestPyLayer(unittest.TestCase):
         z2 = paddle.tanh(input2) + paddle.tanh(input4)
         z2.mean().backward()
 
-        self.assertTrue(np.max(np.abs((input1.grad - input2.grad))) < 1e-10)
+        self.assertTrue(
+            np.max(np.abs((input1.grad.numpy() - input2.grad.numpy()))) < 1e-10)
 
     def test_simple_pylayer_single_output(self):
         class tanh(PyLayer):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

PR #32142 里将`tensor.grad`变成`Tensor`后，`test_pylayer_op`单测里没有将 Tensor grad 转成 array 报错。