### PR TITLE
str in python2 is different to python3's, it make mistakes for some api's docstring

### DIFF
--- a/tools/count_api_without_core_ops.py
+++ b/tools/count_api_without_core_ops.py
@@ -22,6 +22,7 @@ import pydoc
 import hashlib
 import six
 import functools
+import platform
 
 __all__ = ['get_apis_with_and_without_core_ops', ]
 
@@ -34,9 +35,20 @@ omitted_list = [
 
 
 def md5(doc):
-    hash = hashlib.md5()
-    hash.update(str(doc).encode('utf-8'))
-    return hash.hexdigest()
+    try:
+        hashinst = hashlib.md5()
+        if platform.python_version()[0] == "2":
+            hashinst.update(str(doc))
+        else:
+            hashinst.update(str(doc).encode('utf-8'))
+        md5sum = hashinst.hexdigest()
+    except UnicodeDecodeError as e:
+        md5sum = None
+        print(
+            "Error({}) occurred when `md5({})`, discard it.".format(
+                str(e), doc),
+            file=sys.stderr)
+    return md5sum
 
 
 def split_with_and_without_core_ops(member, cur_name):

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -34,9 +34,20 @@ visited_modules = set()
 
 
 def md5(doc):
-    hash = hashlib.md5()
-    hash.update(str(doc).encode('utf-8'))
-    return hash.hexdigest()
+    try:
+        hash = hashlib.md5()
+        if platform.python_version()[0] == "2":
+            hash.update(str(doc))
+        else:
+            hash.update(str(doc).encode('utf-8'))
+        md5sum = hash.hexdigest()
+    except UnicodeDecodeError as e:
+        md5sum = None
+        print(
+            "Error occurred when `md5({})`, discard it.".format(str(e), doc),
+            file=sys.stderr)
+
+    return md5sum
 
 
 def get_functools_partial_spec(func):

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -35,16 +35,17 @@ visited_modules = set()
 
 def md5(doc):
     try:
-        hash = hashlib.md5()
+        hashinst = hashlib.md5()
         if platform.python_version()[0] == "2":
-            hash.update(str(doc))
+            hashinst.update(str(doc))
         else:
-            hash.update(str(doc).encode('utf-8'))
-        md5sum = hash.hexdigest()
+            hashinst.update(str(doc).encode('utf-8'))
+        md5sum = hashinst.hexdigest()
     except UnicodeDecodeError as e:
         md5sum = None
         print(
-            "Error occurred when `md5({})`, discard it.".format(str(e), doc),
+            "Error({}) occurred when `md5({})`, discard it.".format(
+                str(e), doc),
             file=sys.stderr)
 
     return md5sum


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
<!-- Describe what this PR does -->
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 1788: ordinal not in range(128)
str(doc) in python2

test=document_fix

see https://xly.bce.baidu.com/paddlepaddle/paddle/newipipe/detail/2682288/job/3746171

需要修改`count_api_without_core_ops.py`和`print_signatures.py`两个文件。
TODO：这两个文件有一些共同的函数，重构下消除重复。写个专门的utils模块吧