### PR TITLE
[Cherry-pick] Optimize update_loss_scaling_op(#32554)

### DIFF
--- a/paddle/fluid/operators/amp/check_finite_and_unscale_op.cu
+++ b/paddle/fluid/operators/amp/check_finite_and_unscale_op.cu
@@ -40,8 +40,8 @@ __global__ void CheckFiniteAndUnscale(const T** xs, const MT* scale,
 
   const int64_t num = s_starts[size];
   int xs_index = 0;
-  bool t_found_inf = false;
-  const MT t_scale = *scale;
+  bool local_found_inf = false;
+  const MT local_scale = *scale;
   for (int64_t idx = tid; idx < num; idx += gridDim.x * blockDim.x) {
     // get the "out" index of "id"
     // For example:
@@ -59,16 +59,16 @@ __global__ void CheckFiniteAndUnscale(const T** xs, const MT* scale,
     int64_t in_idx = idx - s_starts[xs_index];
 
     // Unscale
-    MT val = static_cast<MT>(in[in_idx]) * t_scale;
+    MT val = static_cast<MT>(in[in_idx]) * local_scale;
     T narrow_val = static_cast<T>(val);
     out[in_idx] = narrow_val;
 
     // CheckFinite
     if (!isfinite(narrow_val)) {
-      t_found_inf = true;
+      local_found_inf = true;
     }
   }
-  if (t_found_inf) {
+  if (local_found_inf) {
     *found_inf = true;
   }
 }

--- a/paddle/fluid/operators/amp/check_finite_and_unscale_op.cu
+++ b/paddle/fluid/operators/amp/check_finite_and_unscale_op.cu
@@ -39,21 +39,24 @@ __global__ void CheckFiniteAndUnscale(const T** xs, const MT* scale,
   __syncthreads();
 
   const int64_t num = s_starts[size];
-  int pre_xs_index = 0;
+  int xs_index = 0;
   bool t_found_inf = false;
   const MT t_scale = *scale;
   for (int64_t idx = tid; idx < num; idx += gridDim.x * blockDim.x) {
-    // get the xs's index of thread
-    int xs_index = pre_xs_index;
-    while (idx < s_starts[xs_index]) xs_index++;
-    // avoid some tensor's numel is zero
-    while (idx >= s_starts[xs_index]) xs_index++;
-    pre_xs_index = xs_index - 1;
+    // get the "out" index of "id"
+    // For example:
+    // idx = 15, starts = [0, 10, 10, 20, 30]
+    // because 10 <= idx < 20 ==>
+    // the idx element locate in the 3rd tensor (notice the 2nd tensor size is
+    // 0)
+    int next_xs_index = xs_index;
+    while (idx >= s_starts[next_xs_index]) next_xs_index++;
+    xs_index = next_xs_index - 1;
 
     // get in data and out data
-    const T* in = xs[pre_xs_index];
-    T* out = outs[pre_xs_index];
-    int64_t in_idx = idx - s_starts[pre_xs_index];
+    const T* in = xs[xs_index];
+    T* out = outs[xs_index];
+    int64_t in_idx = idx - s_starts[xs_index];
 
     // Unscale
     MT val = static_cast<MT>(in[in_idx]) * t_scale;
@@ -94,28 +97,30 @@ class CheckFiniteAndUnscaleGpuKernel : public framework::OpKernel<T> {
         scale_data, inverse_scale_v, found_inf_data);
 
     size_t xs_size = xs.size();
+    const auto& cpu_place = platform::CPUPlace();
     // calculate each tensor's start index and copy to device
     auto h_starts_tensor =
-        memory::Alloc(platform::CPUPlace(), (xs_size + 1) * sizeof(int64_t));
+        memory::Alloc(cpu_place, (xs_size + 1) * sizeof(int64_t));
     int64_t* h_starts = reinterpret_cast<int64_t*>(h_starts_tensor->ptr());
 
     auto d_starts_tensor =
         memory::Alloc(dev_ctx, (xs_size + 1) * sizeof(int64_t));
     int64_t* d_starts = reinterpret_cast<int64_t*>(d_starts_tensor->ptr());
 
+    // the start index value of each tensor is
+    // the sum of previous tensor's size. For example:
+    // xs = [10, 0, 10, 10] ==> starts = [0, 10, 10, 20, 30]
     h_starts[0] = 0;
     for (int i = 1; i <= xs_size; i++) {
-      // the start index value of each tensor is
-      // the sum of previous tensor's size
       h_starts[i] = h_starts[i - 1] + xs[i - 1]->numel();
     }
     int64_t total_num = h_starts[xs_size];
     memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
-                 d_starts, platform::CPUPlace(), h_starts,
-                 (xs_size + 1) * sizeof(int64_t), dev_ctx.stream());
+                 d_starts, cpu_place, h_starts, (xs_size + 1) * sizeof(int64_t),
+                 dev_ctx.stream());
 
     // copy each tensor's data address to device
-    auto h_mem = memory::Alloc(platform::CPUPlace(), 2 * xs_size * sizeof(T*));
+    auto h_mem = memory::Alloc(cpu_place, 2 * xs_size * sizeof(T*));
     const T** h_xs = reinterpret_cast<const T**>(h_mem->ptr());
     T** h_outs = reinterpret_cast<T**>(h_mem->ptr()) + xs_size;
 
@@ -128,16 +133,18 @@ class CheckFiniteAndUnscaleGpuKernel : public framework::OpKernel<T> {
       h_outs[i] = outs[i]->mutable_data<T>(dev_ctx.GetPlace());
     }
     memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()), d_xs,
-                 platform::CPUPlace(), h_xs, 2 * xs_size * sizeof(T*),
-                 dev_ctx.stream());
+                 cpu_place, h_xs, 2 * xs_size * sizeof(T*), dev_ctx.stream());
 
     // Launch Kernel
-    int block = 1024;
-    int block_num = block * 20;  // each thread deal with 20 number
-    int grid = (total_num + block_num - 1) / block_num;
+    int threads_per_block = std::min(static_cast<int64_t>(1024), total_num);
+    int elements_per_block =
+        threads_per_block * 20;  // each thread deal with 20 number
+    int blocks_per_grid =
+        (total_num + elements_per_block - 1) / elements_per_block;
     VLOG(3) << "launch kernel";
-    CheckFiniteAndUnscale<T, MPDType><<<
-        grid, block, (xs_size + 1) * sizeof(int64_t), dev_ctx.stream()>>>(
+    CheckFiniteAndUnscale<
+        T, MPDType><<<blocks_per_grid, threads_per_block,
+                      (xs_size + 1) * sizeof(int64_t), dev_ctx.stream()>>>(
         d_xs, inverse_scale_v, xs_size, d_starts, found_inf_data, d_outs);
     VLOG(3) << "finish kernel";
   }

--- a/paddle/fluid/operators/amp/update_loss_scaling_op.cu
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op.cu
@@ -34,13 +34,37 @@ __global__ void GpuUpdateLossScaling(
 }
 
 template <typename T>
-__global__ void FillIf(T* data, const int64_t num, const T value,
-                       const bool* has_inf) {
-  if (*has_inf) {
-    int tid = threadIdx.x + blockIdx.x * blockDim.x;
-    for (int i = tid; i < num; i += blockDim.x * gridDim.x) {
-      data[i] = value;
-    }
+__global__ void FusedFillIf(T** outs, const size_t xs_size,
+                            const int64_t* starts, const T value,
+                            const bool* has_inf) {
+  if (!(*has_inf)) return;
+
+  const int tid = threadIdx.x + blockIdx.x * blockDim.x;
+
+  // copy starts array from global memory to shared memory
+  extern __shared__ int64_t starts_s[];
+  for (int i = threadIdx.x; i <= xs_size; i += blockDim.x) {
+    starts_s[i] = starts[i];
+  }
+  __syncthreads();
+
+  const int64_t total_num = starts_s[xs_size];
+  int out_index = 0;
+
+  for (int64_t id = tid; id < total_num; id += blockDim.x * gridDim.x) {
+    // get the "out" index of "id"
+    int next_out_index = out_index;
+    while (id < starts_s[next_out_index]) next_out_index++;
+    // avoid some tensor's numel is zero
+    while (id >= starts_s[next_out_index]) next_out_index++;
+    out_index = next_out_index - 1;
+
+    // get data pointer and index
+    T* out_data = outs[out_index];
+    int64_t idx = id - starts_s[out_index];
+
+    // set value
+    out_data[idx] = value;
   }
 }
 
@@ -68,15 +92,49 @@ class LazyZeros<platform::CUDADeviceContext, T> {
                   const bool* found_inf_data,
                   const std::vector<const framework::Tensor*>& xs,
                   const std::vector<framework::Tensor*>& outs) const {
-    for (size_t i = 0; i < xs.size(); ++i) {
-      auto* out = outs[i];
-      T* out_data = out->mutable_data<T>(dev_ctx.GetPlace());
-      int64_t num = out->numel();
-      int block = 1024;
-      int grid = (block - 1 + num) / block;
-      FillIf<<<grid, block, 0, dev_ctx.stream()>>>(
-          out_data, num, static_cast<T>(0), found_inf_data);
+    size_t xs_size = xs.size();
+    // alloc each tensor's start index and copy to device
+    auto starts_h_tensor =
+        memory::Alloc(platform::CPUPlace(), (xs_size + 1) * sizeof(int64_t));
+    int64_t* starts_h = reinterpret_cast<int64_t*>(starts_h_tensor->ptr());
+
+    auto starts_d_tensor =
+        memory::Alloc(dev_ctx, (xs_size + 1) * sizeof(int64_t));
+    int64_t* starts_d = reinterpret_cast<int64_t*>(starts_d_tensor->ptr());
+
+    starts_h[0] = 0;
+    for (int i = 0; i < xs_size; i++) {
+      // the start index value of each tensor is
+      // the sum of previous tensor's size
+      starts_h[i + 1] = starts_h[i] + outs[i]->numel();
     }
+    memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
+                 starts_d, platform::CPUPlace(), starts_h,
+                 (xs_size + 1) * sizeof(int64_t), dev_ctx.stream());
+
+    // copy each tensor of "outs" data address array to device
+    auto outs_addr_h_tensor =
+        memory::Alloc(platform::CPUPlace(), xs_size * sizeof(T*));
+    T** outs_addr_h = reinterpret_cast<T**>(outs_addr_h_tensor->ptr());
+
+    auto outs_addr_d_tensor = memory::Alloc(dev_ctx, xs_size * sizeof(T*));
+    T** outs_addr_d = reinterpret_cast<T**>(outs_addr_d_tensor->ptr());
+
+    for (size_t i = 0; i < xs_size; ++i) {
+      outs_addr_h[i] = outs[i]->mutable_data<T>(dev_ctx.GetPlace());
+    }
+    memory::Copy(BOOST_GET_CONST(platform::CUDAPlace, dev_ctx.GetPlace()),
+                 outs_addr_d, platform::CPUPlace(), outs_addr_h,
+                 xs_size * sizeof(T*), dev_ctx.stream());
+
+    // launch cuda kernel
+    int64_t total_num = starts_h[xs_size];
+    int64_t block = std::min(static_cast<int64_t>(1024), total_num);
+    int64_t block_num = block * 50;  // each thread deal with 50 data
+    int64_t grid = (total_num + block_num - 1) / block_num;
+    FusedFillIf<
+        T><<<grid, block, (xs_size + 1) * sizeof(int64_t), dev_ctx.stream()>>>(
+        outs_addr_d, xs_size, starts_d, static_cast<T>(0), found_inf_data);
   }
 };
 

--- a/paddle/fluid/operators/amp/update_loss_scaling_op.cu
+++ b/paddle/fluid/operators/amp/update_loss_scaling_op.cu
@@ -117,11 +117,11 @@ class LazyZeros<platform::CUDADeviceContext, T> {
                  dev_ctx.stream());
 
     // copy each tensor of "outs" data address array to device
-    auto h_out_addrs_tensor = memory::Alloc(cpu_place, xs_size * sizeof(T*));
-    T** h_out_addrs = reinterpret_cast<T**>(h_out_addrs_tensor->ptr());
+    auto h_out_addrs_mem = memory::Alloc(cpu_place, xs_size * sizeof(T*));
+    T** h_out_addrs = reinterpret_cast<T**>(h_out_addrs_mem->ptr());
 
-    auto d_out_addrs_tensor = memory::Alloc(dev_ctx, xs_size * sizeof(T*));
-    T** d_out_addrs = reinterpret_cast<T**>(d_out_addrs_tensor->ptr());
+    auto d_out_addrs_mem = memory::Alloc(dev_ctx, xs_size * sizeof(T*));
+    T** d_out_addrs = reinterpret_cast<T**>(d_out_addrs_mem->ptr());
 
     for (size_t i = 0; i < xs_size; ++i) {
       h_out_addrs[i] = outs[i]->mutable_data<T>(dev_ctx.GetPlace());


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
# 起因：
与`CheckFiniteAndUnscale `类似，timeline中显示`update_loss_scaling_op`在一次运行中多次调用了`FillIf`，最多调用了300次，且其中包含多个小kernel，存在优化点。

# 代码分析：
同样的，原有代码中存在一个`for`循环：
```
for (size_t i = 0; i < xs.size(); ++i) {
	...
	FillIf<<<...>>>(outs[i]->mutable_data<T>(),...);
	...
}
```
`outs`为一个`vector<Tensor*>`，无论tensor多大，`for`循环对其中的每个`tensor`都需要调用一次`FillIf`。

# 优化
## 优化方法1：
commit id：[ad79dff](https://github.com/PaddlePaddle/Paddle/commit/ad79dff7e8b13231fd5c71014e527ae29ee51761)
显然，融合（**fused**）kernel，将外部`for`循环去掉，改为无论`xs.size()`大小均只用调用一次kernel效果应该最为明显。

基本思路与[PR31954](https://github.com/PaddlePaddle/Paddle/pull/31954)相同，这里不再赘叙。需要额外提一句的是，由于该`FillIf`只是将`value`一个个赋值给`outs`中的值，因此若一个thread只处理一个数据会导致线程数过多，计算资源利用率低，为改善这种现象，因此这里设置为一个线程处理50个数据以降低warp切换开销。

## 优化2：
commit id：[527779a](https://github.com/PaddlePaddle/Paddle/pull/32554/commits/527779a2c94258b26b1e060de81946648fe70499)

1. 删除了`check_finite_and_unscale`和`update_loss_scaling_op`kernel中的无用行`while (id < s_starts[index]) index++;`，经验证，此行在两kernel中都不会被走到。
2. 优化了`check_finite_and_unscale`和`update_loss_scaling_op`kernel中变量的命名，使之更清晰明了。
3. 添加了若干注释，方便后来者理解和维护。

### 优化效果：
ernie_doc 模型速度(V100-SXM2-16GB机器单卡） | FP32 | AMP | 加速比
---|---|---|---|
优化前(BS=2048) | 4.48 sequence/s | 9.78 sequence/s | 2.18
[优化1](https://github.com/PaddlePaddle/Paddle/commit/ad79dff7e8b13231fd5c71014e527ae29ee51761)(BS=2048) | 4.48 sequence/s | 9.85 sequence/s | 2.19

 ernie_doc op cost | 优化前 |  [优化1](https://github.com/PaddlePaddle/Paddle/commit/ad79dff7e8b13231fd5c71014e527ae29ee51761)
---|---|---|
`update_loss_scaling_op`  | 1.406 ms | 0.685 ms

`ResNet50 AMP`模型速度(V100-SXM2-16GB机器单卡) | 优化前 | 优化1
---|---|---|
10~510 step平均ips（BS=208） | 1415 images/sec | 1416 images/sec
10~510 step平均ips（BS=128） | 1331 images/sec | 1331 images/sec

timeline占比 | 优化前 | [优化1](https://github.com/PaddlePaddle/Paddle/commit/b2eba1147a42408b911ab7b6e17e273ffc780f7f)
---|---|---|
ernie_doc AMP(BS=2048) | 1% | 0.7%
ResNet50 AMP（BS=208） | 0.2% | <0.1%
ResNet50 AMP（BS=128） | 0.4% | <0.1%

#### ResNet50收敛性验证
模型地址：[ResNet50_fp16.sh]<img width="987" alt="train loss" src="https://user-images.githubusercontent.com/31386411/116335494-8eddba80-a809-11eb-9d2f-b5b99aff85a8.png">
<img width="983" alt="train avg loss" src="https://user-images.githubusercontent.com/31386411/116335500-90a77e00-a809-11eb-9f43-f9d3c274e71f.png">
<img width="985" alt="test avg loss" src="https://user-images.githubusercontent.com/31386411/116335503-91401480-a809-11eb-9f64-4cfe2072e99c.png">
<img width="990" alt="test acc 1" src="https://user-images.githubusercontent.com/31386411/116335504-91d8ab00-a809-11eb-9bf6-e786adc1c1da.png">
<img width="984" alt="test acc 5" src="https://user-images.githubusercontent.com/31386411/116335506-92714180-a809-11eb-9831-f85c217e17ec.png">