### PR TITLE
[Cherry-Pick] Clear 'BasicEngine' when an exception occurs in the backward. (#32546)

### DIFF
--- a/paddle/fluid/imperative/basic_engine.cc
+++ b/paddle/fluid/imperative/basic_engine.cc
@@ -470,12 +470,20 @@ void BasicEngine::Execute() {
 
       {
         VLOG(3) << "Start to execute grad op " << cur_op.Type();
-        if (tmp_ins_ptr == nullptr) {
-          OpBase::Run(cur_op.InnerOp(), bwd_ins, tmp_outs, cur_op.Attrs(),
-                      cur_op.place());
-        } else {
-          OpBase::Run(cur_op.InnerOp(), *tmp_ins_ptr, tmp_outs, cur_op.Attrs(),
-                      cur_op.place());
+        try {
+          if (tmp_ins_ptr == nullptr) {
+            OpBase::Run(cur_op.InnerOp(), bwd_ins, tmp_outs, cur_op.Attrs(),
+                        cur_op.place());
+          } else {
+            OpBase::Run(cur_op.InnerOp(), *tmp_ins_ptr, tmp_outs,
+                        cur_op.Attrs(), cur_op.place());
+          }
+        } catch (platform::EnforceNotMet& exception) {
+          Clear();
+          throw std::move(exception);
+        } catch (std::exception& ex) {
+          Clear();
+          PADDLE_THROW(platform::errors::External("%s", ex.what()));
         }
       }
 

--- a/paddle/fluid/imperative/py_layer_fwd.h
+++ b/paddle/fluid/imperative/py_layer_fwd.h
@@ -115,12 +115,12 @@ py::object PyLayerApply(const platform::Place& place, const py::object& cls,
               tuple_result[i].cast<std::shared_ptr<imperative::VarBase>>();
           output_vars.push_back(temp_out);
         } catch (py::cast_error&) {
-          PADDLE_THROW(platform::errors::Unimplemented(
-              "The output of `PyLayer.forward` should be `Tensor`."));
+          // Only collect Tensor type in 'kwargs' and pass them to backward.
+          // Ignore other types of input temporarily.
         }
       } else {
-        PADDLE_THROW(platform::errors::Unimplemented(
-            "The output of `PyLayer.forward` can not be `None`."));
+        // Only collect Tensor type in 'kwargs' and pass them to backward.
+        // Ignore other types of input temporarily.
       }
     }
   } else {
@@ -130,13 +130,17 @@ py::object PyLayerApply(const platform::Place& place, const py::object& cls,
             result_forward.cast<std::shared_ptr<imperative::VarBase>>();
         output_vars.push_back(temp_out);
       } catch (py::cast_error&) {
-        PADDLE_THROW(platform::errors::Unimplemented(
-            "The output of `PyLayer.forward` should be `Tensor`."));
+        // Only collect Tensor type in 'kwargs' and pass them to backward.
+        // Ignore other types of input temporarily.
       }
     } else {
-      PADDLE_THROW(platform::errors::Unimplemented(
-          "The output of `PyLayer.forward` can not be `None`."));
+      // Only collect Tensor type in 'kwargs' and pass them to backward.
+      // Ignore other types of input temporarily.
     }
+  }
+  if (output_vars.size() == 0) {
+    PADDLE_THROW(platform::errors::InvalidArgument(
+        "At least one output of `PyLayer.forward` is a `Tensor`."));
   }
 
   NameVarBaseMap outs = {{"Out", output_vars}};

--- a/paddle/fluid/operators/py_layer_op.cc
+++ b/paddle/fluid/operators/py_layer_op.cc
@@ -86,6 +86,12 @@ void RunPyObject(py::object *py_object,
       }
     }
   } else {
+    if (1 != outs->size()) {
+      PADDLE_THROW(platform::errors::InvalidArgument(
+          "The number of outputs of `PyLayer.backward` should be %d, but "
+          "received 1.",
+          outs->size()));
+    }
     if ((*outs)[0] != nullptr) {
       if (Py_None != py_result.ptr()) {
         try {

--- a/python/paddle/fluid/tests/unittests/test_pylayer_op.py
+++ b/python/paddle/fluid/tests/unittests/test_pylayer_op.py
@@ -234,8 +234,7 @@ class TestPyLayer(unittest.TestCase):
         z = Layer_bk_none1.apply(input2)
 
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z.sum().backward()
+            z.sum().backward()
 
         class Layer_bk_none2(PyLayer):
             @staticmethod
@@ -249,9 +248,9 @@ class TestPyLayer(unittest.TestCase):
         input1 = paddle.randn([2, 3]).astype("float64")
         input1.stop_gradient = False
         z = Layer_bk_none2.apply(input1, input1)
+
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z.mean().backward()
+            z.mean().backward()
 
         class Layer_bk_one1(PyLayer):
             @staticmethod
@@ -265,9 +264,9 @@ class TestPyLayer(unittest.TestCase):
         input1 = paddle.randn([2, 3]).astype("float64")
         input1.stop_gradient = False
         z = Layer_bk_one1.apply(input1)
+
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z.mean().backward()
+            z.mean().backward()
 
         class Layer_bk_one2(PyLayer):
             @staticmethod
@@ -280,11 +279,11 @@ class TestPyLayer(unittest.TestCase):
 
         input1 = paddle.randn([2, 3]).astype("float64")
         input1.stop_gradient = False
+
         y = Layer_bk_one2.apply(input1, input1)
         z = y[0] + y[1]
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z.mean().backward()
+            z.mean().backward()
 
         class Layer_no_bk(PyLayer):
             @staticmethod
@@ -295,10 +294,9 @@ class TestPyLayer(unittest.TestCase):
         input1.stop_gradient = False
         z = Layer_no_bk.apply(input1)
 
-        with self.assertRaises(NotImplementedError):
-            with paddle.fluid.dygraph.guard():
-                z = z[0] + z[1]
-                z.mean().backward()
+        with self.assertRaises(OSError):
+            z = z[0] + z[1]
+            z.mean().backward()
 
         class Layer_bk_match(PyLayer):
             @staticmethod
@@ -313,9 +311,8 @@ class TestPyLayer(unittest.TestCase):
         input1.stop_gradient = False
         z = Layer_bk_match.apply(input1)
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z = z[0] + z[1]
-                z.mean().backward()
+            z = z[0] + z[1]
+            z.mean().backward()
 
     def test_pylayer_bk_return_none(self):
         class Layer_bk_none1(PyLayer):
@@ -334,8 +331,7 @@ class TestPyLayer(unittest.TestCase):
         z = Layer_bk_none1.apply(input1, input2)
 
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z.mean().backward()
+            z.mean().backward()
 
         class Layer_bk_none2(PyLayer):
             @staticmethod
@@ -353,8 +349,7 @@ class TestPyLayer(unittest.TestCase):
         z = Layer_bk_none2.apply(input1, input2)
         z = z[0] + z[1]
         with self.assertRaises(ValueError):
-            with paddle.fluid.dygraph.guard():
-                z.mean().backward()
+            z.mean().backward()
 
     def test_pylayer_inplace(self):
         class cus_tanh(PyLayer):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- 支持forward返回任意类型。
- backward 发生异常时清理BasicEngine:
  - 当PyLayer.backward只有一个输出且返回 None时，没有检测到，导致发生了tensor 没有被初始化的错误，无法被catch捕捉。
  - 修复方式：增加检测backward只有一个输出且返回 None的情况。
- 原始PR：https://github.com/PaddlePaddle/Paddle/pull/32546  https://github.com/PaddlePaddle/Paddle/pull/32661