### PR TITLE
conservative judgment

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/elementwise_op.cc
@@ -25,6 +25,10 @@ static bool CheckDims(const nvinfer1::Dims& dims_x,
     return false;
   }
   for (int i = 0; i < dims_x.nbDims; i++) {
+    // conservative judgment
+    if (dims_x.d[i] == -1 || dims_y.d[i] == -1) {
+      return false;
+    }
     if (dims_x.d[i] != dims_y.d[i]) {
       return false;
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
我们发现多个TRT dynamic shape的element 操作级联后会出现
trt shape不匹配的错误（E0415 09:54:52.122642   652 helper.h:78] ../rtExt/cuda/cudaPointWiseRunner.cpp (136) - Assertion Error in execute: 0 (x.d[i] == 1 || x.d[i] == z.d[i])），所以暂时使用plugin来完成这种操作