### PR TITLE
cherry-pick:update 2.0 public api in paddle.init (#32034)

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -11,9 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import os
-
 try:
     from paddle.version import full_version as __version__
     from paddle.version import commit as __git_commit__
@@ -30,280 +27,471 @@ from .fluid import monkey_patch_variable
 from .fluid.dygraph import monkey_patch_math_varbase
 monkey_patch_variable()
 monkey_patch_math_varbase()
-import paddle.framework
-from .framework.dtype import dtype as dtype
-from paddle.framework.dtype import uint8
-from paddle.framework.dtype import int8
-from paddle.framework.dtype import int16
-from paddle.framework.dtype import int32
-from paddle.framework.dtype import int64
-from paddle.framework.dtype import float16
-from paddle.framework.dtype import float32
-from paddle.framework.dtype import float64
-from paddle.framework.dtype import bfloat16
-from paddle.framework.dtype import bool
-from paddle.framework.dtype import complex64
-from paddle.framework.dtype import complex128
-from .framework import VarBase as Tensor
-Tensor.__qualname__ = 'Tensor'
-import paddle.compat
-import paddle.distributed
-import paddle.sysconfig
-import paddle.tensor
-import paddle.distribution
-import paddle.nn
-import paddle.distributed.fleet
-import paddle.optimizer
-import paddle.metric
-import paddle.device
-import paddle.regularizer
-import paddle.incubate
-import paddle.autograd
+from .framework.dtype import dtype as dtype  # noqa: F401
+from paddle.framework.dtype import uint8  # noqa: F401
+from paddle.framework.dtype import int8  # noqa: F401
+from paddle.framework.dtype import int16  # noqa: F401
+from paddle.framework.dtype import int32  # noqa: F401
+from paddle.framework.dtype import int64  # noqa: F401
+from paddle.framework.dtype import float16  # noqa: F401
+from paddle.framework.dtype import float32  # noqa: F401
+from paddle.framework.dtype import float64  # noqa: F401
+from paddle.framework.dtype import bfloat16  # noqa: F401
+from paddle.framework.dtype import bool  # noqa: F401
+from paddle.framework.dtype import complex64  # noqa: F401
+from paddle.framework.dtype import complex128  # noqa: F401
+from .framework import VarBase as Tensor  # noqa: F401
+Tensor.__qualname__ = 'Tensor'  # noqa: F401
+import paddle.compat  # noqa: F401
+import paddle.distributed  # noqa: F401
+import paddle.sysconfig  # noqa: F401
+import paddle.distribution  # noqa: F401
+import paddle.nn  # noqa: F401
+import paddle.distributed.fleet  # noqa: F401
+import paddle.optimizer  # noqa: F401
+import paddle.metric  # noqa: F401
+import paddle.regularizer  # noqa: F401
+import paddle.incubate  # noqa: F401
+import paddle.autograd  # noqa: F401
 
-# TODO: define alias in tensor and framework directory
+import paddle.jit  # noqa: F401
+import paddle.amp  # noqa: F401
+import paddle.dataset  # noqa: F401
+import paddle.inference  # noqa: F401
+import paddle.io  # noqa: F401
+import paddle.onnx  # noqa: F401
+import paddle.reader  # noqa: F401
+import paddle.static  # noqa: F401
+import paddle.vision  # noqa: F401
 
-from .tensor.random import randperm
-from .tensor.random import bernoulli
+from .tensor.random import bernoulli  # noqa: F401
 
-from .tensor.attribute import rank  #DEFINE_ALIAS
-from .tensor.attribute import shape  #DEFINE_ALIAS
-from .tensor.attribute import real  #DEFINE_ALIAS
-from .tensor.attribute import imag  #DEFINE_ALIAS
-from .tensor.creation import to_tensor  #DEFINE_ALIAS
-from .tensor.creation import diag  #DEFINE_ALIAS
-from .tensor.creation import eye  #DEFINE_ALIAS
-# from .tensor.creation import fill_constant  #DEFINE_ALIAS
-# from .tensor.creation import get_tensor_from_selected_rows        #DEFINE_ALIAS
-from .tensor.creation import linspace  #DEFINE_ALIAS
-from .tensor.creation import ones  #DEFINE_ALIAS
-from .tensor.creation import ones_like  #DEFINE_ALIAS
-from .tensor.creation import zeros  #DEFINE_ALIAS
-from .tensor.creation import zeros_like  #DEFINE_ALIAS
-from .tensor.creation import arange  #DEFINE_ALIAS
-from .tensor.creation import eye  #DEFINE_ALIAS
-from .tensor.creation import full  #DEFINE_ALIAS
-from .tensor.creation import full_like  #DEFINE_ALIAS
-from .tensor.creation import triu  #DEFINE_ALIAS
-from .tensor.creation import tril  #DEFINE_ALIAS
-from .tensor.creation import meshgrid  #DEFINE_ALIAS
-from .tensor.creation import empty  #DEFINE_ALIAS
-from .tensor.creation import empty_like  #DEFINE_ALIAS
-from .tensor.creation import assign  #DEFINE_ALIAS
-from .tensor.linalg import matmul  #DEFINE_ALIAS
-from .tensor.linalg import dot  #DEFINE_ALIAS
-# from .tensor.linalg import einsum        #DEFINE_ALIAS
-from .tensor.linalg import norm  #DEFINE_ALIAS
-from .tensor.linalg import transpose  #DEFINE_ALIAS
-from .tensor.linalg import dist  #DEFINE_ALIAS
-from .tensor.linalg import t  #DEFINE_ALIAS
-from .tensor.linalg import cross  #DEFINE_ALIAS
-from .tensor.linalg import cholesky  #DEFINE_ALIAS
-# from .tensor.linalg import tensordot        #DEFINE_ALIAS
-from .tensor.linalg import bmm  #DEFINE_ALIAS
-from .tensor.linalg import histogram  #DEFINE_ALIAS
-from .tensor.linalg import mv  #DEFINE_ALIAS
-from .tensor.logic import equal  #DEFINE_ALIAS
-from .tensor.logic import greater_equal  #DEFINE_ALIAS
-from .tensor.logic import greater_than  #DEFINE_ALIAS
-from .tensor.logic import is_empty  #DEFINE_ALIAS
-#from .tensor.logic import isfinite  #DEFINE_ALIAS
-from .tensor.logic import less_equal  #DEFINE_ALIAS
-from .tensor.logic import less_than  #DEFINE_ALIAS
-from .tensor.logic import logical_and  #DEFINE_ALIAS
-from .tensor.logic import logical_not  #DEFINE_ALIAS
-from .tensor.logic import logical_or  #DEFINE_ALIAS
-from .tensor.logic import logical_xor  #DEFINE_ALIAS
-from .tensor.logic import not_equal  #DEFINE_ALIAS
-from .tensor.logic import allclose  #DEFINE_ALIAS
-from .tensor.logic import equal_all  #DEFINE_ALIAS
-# from .tensor.logic import isnan        #DEFINE_ALIAS
-from .tensor.logic import is_tensor  #DEFINE_ALIAS
-from .tensor.manipulation import cast  #DEFINE_ALIAS
-from .tensor.manipulation import concat  #DEFINE_ALIAS
-from .tensor.manipulation import expand  #DEFINE_ALIAS
-from .tensor.manipulation import broadcast_to  #DEFINE_ALIAS
-from .tensor.manipulation import expand_as  #DEFINE_ALIAS
-from .tensor.manipulation import tile  #DEFINE_ALIAS
-from .tensor.manipulation import flatten  #DEFINE_ALIAS
-from .tensor.manipulation import gather  #DEFINE_ALIAS
-from .tensor.manipulation import gather_nd  #DEFINE_ALIAS
-from .tensor.manipulation import reshape  #DEFINE_ALIAS
-from .tensor.manipulation import reshape_  #DEFINE_ALIAS
-from .tensor.manipulation import flip as reverse  #DEFINE_ALIAS
-from .tensor.manipulation import scatter  #DEFINE_ALIAS
-from .tensor.manipulation import scatter_  #DEFINE_ALIAS
-from .tensor.manipulation import scatter_nd_add  #DEFINE_ALIAS
-from .tensor.manipulation import scatter_nd  #DEFINE_ALIAS
-from .tensor.manipulation import shard_index  #DEFINE_ALIAS
-from .tensor.manipulation import slice  #DEFINE_ALIAS
-from .tensor.manipulation import split  #DEFINE_ALIAS
-from .tensor.manipulation import squeeze  #DEFINE_ALIAS
-from .tensor.manipulation import squeeze_  #DEFINE_ALIAS
-from .tensor.manipulation import stack  #DEFINE_ALIAS
-from .tensor.manipulation import strided_slice  #DEFINE_ALIAS
-from .tensor.manipulation import transpose  #DEFINE_ALIAS
-from .tensor.manipulation import unique  #DEFINE_ALIAS
-from .tensor.manipulation import unsqueeze  #DEFINE_ALIAS
-from .tensor.manipulation import unsqueeze_  #DEFINE_ALIAS
-from .tensor.manipulation import unstack  #DEFINE_ALIAS
-from .tensor.manipulation import flip  #DEFINE_ALIAS
-from .tensor.manipulation import unbind  #DEFINE_ALIAS
-from .tensor.manipulation import roll  #DEFINE_ALIAS
-from .tensor.manipulation import chunk  #DEFINE_ALIAS
-from .tensor.manipulation import tolist  #DEFINE_ALIAS
-from .tensor.math import abs  #DEFINE_ALIAS
-from .tensor.math import acos  #DEFINE_ALIAS
-from .tensor.math import asin  #DEFINE_ALIAS
-from .tensor.math import atan  #DEFINE_ALIAS
-from .tensor.math import ceil  #DEFINE_ALIAS
-from .tensor.math import cos  #DEFINE_ALIAS
-from .tensor.math import tan  #DEFINE_ALIAS
-from .tensor.math import cosh  #DEFINE_ALIAS
-from .tensor.math import cumsum  #DEFINE_ALIAS
-# from .tensor.math import elementwise_add  #DEFINE_ALIAS
-# from .tensor.math import elementwise_div  #DEFINE_ALIAS
-# from .tensor.math import elementwise_floordiv  #DEFINE_ALIAS
-# from .tensor.math import elementwise_mod  #DEFINE_ALIAS
-# from .tensor.math import elementwise_pow  #DEFINE_ALIAS
-# from .tensor.math import elementwise_sub  #DEFINE_ALIAS
-from .tensor.math import exp  #DEFINE_ALIAS
-from .tensor.math import floor  #DEFINE_ALIAS
-from .tensor.math import increment  #DEFINE_ALIAS
-from .tensor.math import log  #DEFINE_ALIAS
-from .tensor.math import log2  #DEFINE_ALIAS
-from .tensor.math import log10  #DEFINE_ALIAS
-from .tensor.math import multiplex  #DEFINE_ALIAS
-from .tensor.math import pow  #DEFINE_ALIAS
-from .tensor.math import reciprocal  #DEFINE_ALIAS
-# from .tensor.math import reduce_max  #DEFINE_ALIAS
-# from .tensor.math import reduce_min  #DEFINE_ALIAS
-# from .tensor.math import reduce_prod  #DEFINE_ALIAS
-# from .tensor.math import reduce_sum  #DEFINE_ALIAS
-from .tensor.math import all  #DEFINE_ALIAS
-from .tensor.math import any  #DEFINE_ALIAS
-from .tensor.math import round  #DEFINE_ALIAS
-from .tensor.math import rsqrt  #DEFINE_ALIAS
-from .tensor.math import scale  #DEFINE_ALIAS
-from .tensor.math import sign  #DEFINE_ALIAS
-from .tensor.math import sin  #DEFINE_ALIAS
-from .tensor.math import sinh  #DEFINE_ALIAS
-from .tensor.math import sqrt  #DEFINE_ALIAS
-from .tensor.math import square  #DEFINE_ALIAS
-from .tensor.math import stanh  #DEFINE_ALIAS
-from .tensor.math import sum  #DEFINE_ALIAS
-from .tensor.math import tanh  #DEFINE_ALIAS
-from .tensor.math import tanh_  #DEFINE_ALIAS
-from .tensor.math import add_n  #DEFINE_ALIAS
-from .tensor.math import max  #DEFINE_ALIAS
-from .tensor.math import maximum  #DEFINE_ALIAS
-from .tensor.math import min  #DEFINE_ALIAS
-from .tensor.math import minimum  #DEFINE_ALIAS
-from .tensor.math import mm  #DEFINE_ALIAS
-from .tensor.math import divide  #DEFINE_ALIAS
-from .tensor.math import floor_divide  #DEFINE_ALIAS
-from .tensor.math import remainder  #DEFINE_ALIAS
-from .tensor.math import mod  #DEFINE_ALIAS
-from .tensor.math import floor_mod  #DEFINE_ALIAS
-from .tensor.math import multiply  #DEFINE_ALIAS
-from .tensor.math import add  #DEFINE_ALIAS
-from .tensor.math import subtract  #DEFINE_ALIAS
-from .tensor.math import atan  #DEFINE_ALIAS
-from .tensor.math import logsumexp  #DEFINE_ALIAS
-from .tensor.math import inverse  #DEFINE_ALIAS
-from .tensor.math import log1p  #DEFINE_ALIAS
-from .tensor.math import erf  #DEFINE_ALIAS
-from .tensor.math import addmm  #DEFINE_ALIAS
-from .tensor.math import clip  #DEFINE_ALIAS
-from .tensor.math import trace  #DEFINE_ALIAS
-from .tensor.math import kron  #DEFINE_ALIAS
-from .tensor.math import isfinite  #DEFINE_ALIAS
-from .tensor.math import isinf  #DEFINE_ALIAS
-from .tensor.math import isnan  #DEFINE_ALIAS
-from .tensor.math import prod  #DEFINE_ALIAS
-from .tensor.math import broadcast_shape  #DEFINE_ALIAS
-from .tensor.math import conj  #DEFINE_ALIAS
+from .tensor.attribute import rank  # noqa: F401
+from .tensor.attribute import shape  # noqa: F401
+from .tensor.attribute import real  # noqa: F401
+from .tensor.attribute import imag  # noqa: F401
+from .tensor.creation import to_tensor  # noqa: F401
+from .tensor.creation import diag  # noqa: F401
+from .tensor.creation import eye  # noqa: F401
+from .tensor.creation import linspace  # noqa: F401
+from .tensor.creation import ones  # noqa: F401
+from .tensor.creation import ones_like  # noqa: F401
+from .tensor.creation import zeros  # noqa: F401
+from .tensor.creation import zeros_like  # noqa: F401
+from .tensor.creation import arange  # noqa: F401
+from .tensor.creation import full  # noqa: F401
+from .tensor.creation import full_like  # noqa: F401
+from .tensor.creation import triu  # noqa: F401
+from .tensor.creation import tril  # noqa: F401
+from .tensor.creation import meshgrid  # noqa: F401
+from .tensor.creation import empty  # noqa: F401
+from .tensor.creation import empty_like  # noqa: F401
+from .tensor.creation import assign  # noqa: F401
+from .tensor.linalg import matmul  # noqa: F401
+from .tensor.linalg import dot  # noqa: F401
+from .tensor.linalg import norm  # noqa: F401
+from .tensor.linalg import transpose  # noqa: F401
+from .tensor.linalg import dist  # noqa: F401
+from .tensor.linalg import t  # noqa: F401
+from .tensor.linalg import cross  # noqa: F401
+from .tensor.linalg import cholesky  # noqa: F401
+from .tensor.linalg import bmm  # noqa: F401
+from .tensor.linalg import histogram  # noqa: F401
+from .tensor.linalg import mv  # noqa: F401
+from .tensor.logic import equal  # noqa: F401
+from .tensor.logic import greater_equal  # noqa: F401
+from .tensor.logic import greater_than  # noqa: F401
+from .tensor.logic import is_empty  # noqa: F401
+from .tensor.logic import less_equal  # noqa: F401
+from .tensor.logic import less_than  # noqa: F401
+from .tensor.logic import logical_and  # noqa: F401
+from .tensor.logic import logical_not  # noqa: F401
+from .tensor.logic import logical_or  # noqa: F401
+from .tensor.logic import logical_xor  # noqa: F401
+from .tensor.logic import not_equal  # noqa: F401
+from .tensor.logic import allclose  # noqa: F401
+from .tensor.logic import equal_all  # noqa: F401
+from .tensor.logic import is_tensor  # noqa: F401
+from .tensor.manipulation import cast  # noqa: F401
+from .tensor.manipulation import concat  # noqa: F401
+from .tensor.manipulation import expand  # noqa: F401
+from .tensor.manipulation import broadcast_to  # noqa: F401
+from .tensor.manipulation import expand_as  # noqa: F401
+from .tensor.manipulation import tile  # noqa: F401
+from .tensor.manipulation import flatten  # noqa: F401
+from .tensor.manipulation import gather  # noqa: F401
+from .tensor.manipulation import gather_nd  # noqa: F401
+from .tensor.manipulation import reshape  # noqa: F401
+from .tensor.manipulation import reshape_  # noqa: F401
+from .tensor.manipulation import flip as reverse  # noqa: F401
+from .tensor.manipulation import scatter  # noqa: F401
+from .tensor.manipulation import scatter_  # noqa: F401
+from .tensor.manipulation import scatter_nd_add  # noqa: F401
+from .tensor.manipulation import scatter_nd  # noqa: F401
+from .tensor.manipulation import shard_index  # noqa: F401
+from .tensor.manipulation import slice  # noqa: F401
+from .tensor.manipulation import split  # noqa: F401
+from .tensor.manipulation import squeeze  # noqa: F401
+from .tensor.manipulation import squeeze_  # noqa: F401
+from .tensor.manipulation import stack  # noqa: F401
+from .tensor.manipulation import strided_slice  # noqa: F401
+from .tensor.manipulation import transpose  # noqa: F401
+from .tensor.manipulation import unique  # noqa: F401
+from .tensor.manipulation import unsqueeze  # noqa: F401
+from .tensor.manipulation import unsqueeze_  # noqa: F401
+from .tensor.manipulation import unstack  # noqa: F401
+from .tensor.manipulation import flip  # noqa: F401
+from .tensor.manipulation import unbind  # noqa: F401
+from .tensor.manipulation import roll  # noqa: F401
+from .tensor.manipulation import chunk  # noqa: F401
+from .tensor.manipulation import tolist  # noqa: F401
+from .tensor.math import abs  # noqa: F401
+from .tensor.math import acos  # noqa: F401
+from .tensor.math import asin  # noqa: F401
+from .tensor.math import atan  # noqa: F401
+from .tensor.math import ceil  # noqa: F401
+from .tensor.math import cos  # noqa: F401
+from .tensor.math import tan  # noqa: F401
+from .tensor.math import cosh  # noqa: F401
+from .tensor.math import cumsum  # noqa: F401
+from .tensor.math import exp  # noqa: F401
+from .tensor.math import floor  # noqa: F401
+from .tensor.math import increment  # noqa: F401
+from .tensor.math import log  # noqa: F401
+from .tensor.math import log2  # noqa: F401
+from .tensor.math import log10  # noqa: F401
+from .tensor.math import multiplex  # noqa: F401
+from .tensor.math import pow  # noqa: F401
+from .tensor.math import reciprocal  # noqa: F401
+from .tensor.math import all  # noqa: F401
+from .tensor.math import any  # noqa: F401
+from .tensor.math import round  # noqa: F401
+from .tensor.math import rsqrt  # noqa: F401
+from .tensor.math import scale  # noqa: F401
+from .tensor.math import sign  # noqa: F401
+from .tensor.math import sin  # noqa: F401
+from .tensor.math import sinh  # noqa: F401
+from .tensor.math import sqrt  # noqa: F401
+from .tensor.math import square  # noqa: F401
+from .tensor.math import stanh  # noqa: F401
+from .tensor.math import sum  # noqa: F401
+from .tensor.math import tanh  # noqa: F401
+from .tensor.math import tanh_  # noqa: F401
+from .tensor.math import add_n  # noqa: F401
+from .tensor.math import max  # noqa: F401
+from .tensor.math import maximum  # noqa: F401
+from .tensor.math import min  # noqa: F401
+from .tensor.math import minimum  # noqa: F401
+from .tensor.math import mm  # noqa: F401
+from .tensor.math import divide  # noqa: F401
+from .tensor.math import floor_divide  # noqa: F401
+from .tensor.math import remainder  # noqa: F401
+from .tensor.math import mod  # noqa: F401
+from .tensor.math import floor_mod  # noqa: F401
+from .tensor.math import multiply  # noqa: F401
+from .tensor.math import add  # noqa: F401
+from .tensor.math import subtract  # noqa: F401
+from .tensor.math import atan  # noqa: F401
+from .tensor.math import logsumexp  # noqa: F401
+from .tensor.math import inverse  # noqa: F401
+from .tensor.math import log1p  # noqa: F401
+from .tensor.math import erf  # noqa: F401
+from .tensor.math import addmm  # noqa: F401
+from .tensor.math import clip  # noqa: F401
+from .tensor.math import trace  # noqa: F401
+from .tensor.math import kron  # noqa: F401
+from .tensor.math import isfinite  # noqa: F401
+from .tensor.math import isinf  # noqa: F401
+from .tensor.math import isnan  # noqa: F401
+from .tensor.math import prod  # noqa: F401
+from .tensor.math import broadcast_shape  # noqa: F401
+from .tensor.math import conj  # noqa: F401
 
-from .tensor.random import multinomial  #DEFINE_ALIAS
-from .tensor.random import standard_normal
-from .tensor.random import normal
-from .tensor.random import uniform  #DEFINE_ALIAS
-from .tensor.random import randn  #DEFINE_ALIAS
-from .tensor.random import rand  #DEFINE_ALIAS
-from .tensor.random import randint  #DEFINE_ALIAS
-from .tensor.random import randperm  #DEFINE_ALIAS
-from .tensor.search import argmax  #DEFINE_ALIAS
-from .tensor.search import argmin  #DEFINE_ALIAS
-from .tensor.search import argsort  #DEFINE_ALIAS
-# from .tensor.search import has_inf  #DEFINE_ALIAS
-# from .tensor.search import has_nan  #DEFINE_ALIAS
-from .tensor.search import masked_select  #DEFINE_ALIAS
-from .tensor.search import topk  #DEFINE_ALIAS
-from .tensor.search import where  #DEFINE_ALIAS
-from .tensor.search import index_select  #DEFINE_ALIAS
-from .tensor.search import nonzero  #DEFINE_ALIAS
-from .tensor.search import sort  #DEFINE_ALIAS
+from .tensor.random import multinomial  # noqa: F401
+from .tensor.random import standard_normal  # noqa: F401
+from .tensor.random import normal  # noqa: F401
+from .tensor.random import uniform  # noqa: F401
+from .tensor.random import randn  # noqa: F401
+from .tensor.random import rand  # noqa: F401
+from .tensor.random import randint  # noqa: F401
+from .tensor.random import randperm  # noqa: F401
+from .tensor.search import argmax  # noqa: F401
+from .tensor.search import argmin  # noqa: F401
+from .tensor.search import argsort  # noqa: F401
+from .tensor.search import masked_select  # noqa: F401
+from .tensor.search import topk  # noqa: F401
+from .tensor.search import where  # noqa: F401
+from .tensor.search import index_select  # noqa: F401
+from .tensor.search import nonzero  # noqa: F401
+from .tensor.search import sort  # noqa: F401
 
-from .tensor.to_string import set_printoptions  #DEFINE_ALIAS
+from .tensor.to_string import set_printoptions  # noqa: F401
 
-from .framework.random import seed  #DEFINE_ALIAS
-from .framework.random import get_cuda_rng_state  #DEFINE_ALIAS
-from .framework.random import set_cuda_rng_state  #DEFINE_ALIAS
-from .framework import ParamAttr  #DEFINE_ALIAS
-# from .framework import create_global_var  #DEFINE_ALIAS
-from .framework import create_parameter  #DEFINE_ALIAS
-from .framework import CPUPlace  #DEFINE_ALIAS
-from .framework import CUDAPlace  #DEFINE_ALIAS
-from .framework import NPUPlace  #DEFINE_ALIAS
-from .framework import CUDAPinnedPlace  #DEFINE_ALIAS
+from .framework.random import seed  # noqa: F401
+from .framework.random import get_cuda_rng_state  # noqa: F401
+from .framework.random import set_cuda_rng_state  # noqa: F401
+from .framework import ParamAttr  # noqa: F401
+from .framework import create_parameter  # noqa: F401
+from .framework import CPUPlace  # noqa: F401
+from .framework import CUDAPlace  # noqa: F401
+from .framework import NPUPlace  # noqa: F401
+from .framework import CUDAPinnedPlace  # noqa: F401
 
-from .framework import grad  #DEFINE_ALIAS
-from .framework import no_grad  #DEFINE_ALIAS
-from .framework import set_grad_enabled  #DEFINE_ALIAS
-from .framework import save  #DEFINE_ALIAS
-from .framework import load  #DEFINE_ALIAS
-from .framework import DataParallel  #DEFINE_ALIAS
+from .framework import grad  # noqa: F401
+from .framework import no_grad  # noqa: F401
+from .framework import set_grad_enabled  # noqa: F401
+from .framework import save  # noqa: F401
+from .framework import load  # noqa: F401
+from .framework import DataParallel  # noqa: F401
 
 from .framework import set_default_dtype  #DEFINE_ALIAS
 from .framework import get_default_dtype  #DEFINE_ALIAS
 from .framework import set_grad_enabled  #DEFINE_ALIAS
 
-from .tensor.search import index_sample  #DEFINE_ALIAS
-from .tensor.stat import mean  #DEFINE_ALIAS
-# from .tensor.stat import reduce_mean  #DEFINE_ALIAS
-from .tensor.stat import std  #DEFINE_ALIAS
-from .tensor.stat import var  #DEFINE_ALIAS
-# from .fluid.data import data
-from .tensor.stat import numel  #DEFINE_ALIAS
-from .tensor.stat import median  #DEFINE_ALIAS
-from .device import get_cudnn_version
-from .device import set_device
-from .device import get_device
-from .device import is_compiled_with_cuda  #DEFINE_ALIAS
-from .device import is_compiled_with_xpu
-from .device import is_compiled_with_npu
-from .device import XPUPlace
-# from .tensor.tensor import Tensor        #DEFINE_ALIAS
-# from .tensor.tensor import LoDTensor        #DEFINE_ALIAS
-# from .tensor.tensor import LoDTensorArray        #DEFINE_ALIAS
+from .tensor.search import index_sample  # noqa: F401
+from .tensor.stat import mean  # noqa: F401
+from .tensor.stat import std  # noqa: F401
+from .tensor.stat import var  # noqa: F401
+from .tensor.stat import numel  # noqa: F401
+from .tensor.stat import median  # noqa: F401
+from .device import get_cudnn_version  # noqa: F401
+from .device import set_device  # noqa: F401
+from .device import get_device  # noqa: F401
+from .fluid.framework import is_compiled_with_cuda  # noqa: F401
+from .device import is_compiled_with_xpu  # noqa: F401
+from .device import is_compiled_with_npu  # noqa: F401
+from .device import XPUPlace  # noqa: F401
 
-from .fluid.dygraph.base import enable_dygraph as disable_static  #DEFINE_ALIAS
-from .fluid.dygraph.base import disable_dygraph as enable_static  #DEFINE_ALIAS
-from .fluid.framework import in_dygraph_mode as in_dynamic_mode  #DEFINE_ALIAS
-from .fluid.layers import crop_tensor as crop  #DEFINE_ALIAS
-
-from . import jit
-from . import static
-from . import amp
-from . import onnx
+from .fluid.dygraph.base import enable_dygraph as disable_static  # noqa: F401
+from .fluid.dygraph.base import disable_dygraph as enable_static  # noqa: F401
+from .fluid.framework import in_dygraph_mode as in_dynamic_mode  # noqa: F401
+from .fluid.layers import crop_tensor as crop  # noqa: F401
 
 # high-level api
-from .hapi import Model
-from .hapi import callbacks
-from .hapi import summary
-from .hapi import flops
-from .hapi import hub
+from .hapi import Model  # noqa: F401
+from .hapi import callbacks  # noqa: F401
+from .hapi import summary  # noqa: F401
+from .hapi import flops  # noqa: F401
+from .hapi import hub  # noqa: F401
 
-import paddle.text
-import paddle.vision
+import paddle.text  # noqa: F401
+import paddle.vision  # noqa: F401
 
+from .tensor.random import check_shape  # noqa: F401
 disable_static()
+
+__all__ = [     #noqa
+           'dtype',
+           'uint8',
+           'int8',
+           'int16',
+           'int32',
+           'int64',
+           'float16',
+           'float32',
+           'float64',
+           'bfloat16',
+           'bool',
+           'complex64',
+           'complex128',
+           'addmm',
+           'allclose',
+           't',
+           'add',
+           'subtract',
+           'diag',
+           'isnan',
+           'scatter_nd_add',
+           'unstack',
+           'get_default_dtype',
+           'save',
+           'multinomial',
+           'get_cuda_rng_state',
+           'rank',
+           'empty_like',
+           'eye',
+           'cumsum',
+           'sign',
+           'is_empty',
+           'equal',
+           'equal_all',
+           'is_tensor',
+           'cross',
+           'where',
+           'log1p',
+           'cos',
+           'tan',
+           'mean',
+           'XPUPlace',
+           'mv',
+           'in_dynamic_mode',
+           'min',
+           'any',
+           'slice',
+           'normal',
+           'logsumexp',
+           'full',
+           'unsqueeze',
+           'unsqueeze_',
+           'argmax',
+           'Model',
+           'callbacks',
+           'summary',
+           'flops',
+           'hub',
+           'sort',
+           'split',
+           'logical_and',
+           'full_like',
+           'less_than',
+           'kron',
+           'clip',
+           'Tensor',
+           'crop',
+           'ParamAttr',
+           'stanh',
+           'randint',
+           'assign',
+           'gather',
+           'scale',
+           'zeros',
+           'rsqrt',
+           'squeeze',
+           'squeeze_',
+           'to_tensor',
+           'gather_nd',
+           'isinf',
+           'set_device',
+           'uniform',
+           'floor_divide',
+           'remainder',
+           'floor_mod',
+           'roll',
+           'batch',
+           'max',
+           'norm',
+           'logical_or',
+           'mm',
+           'flip',
+           'histogram',
+           'multiplex',
+           'CUDAPlace',
+           'NPUPlace',
+           'empty',
+           'shape',
+           'real',
+           'imag',
+           'reciprocal',
+           'rand',
+           'less_equal',
+           'triu',
+           'is_compiled_with_cuda',
+           'sin',
+           'dist',
+           'unbind',
+           'meshgrid',
+           'arange',
+           'load',
+           'numel',
+           'median',
+           'inverse',
+           'no_grad',
+           'set_grad_enabled',
+           'mod',
+           'abs',
+           'tril',
+           'pow',
+           'zeros_like',
+           'maximum',
+           'topk',
+           'index_select',
+           'CPUPlace',
+           'matmul',
+           'seed',
+           'acos',
+           'logical_xor',
+           'exp',
+           'bernoulli',
+           'summary',
+           'sinh',
+           'is_compiled_with_xpu',
+           'is_compiled_with_npu',
+           'round',
+           'DataParallel',
+           'argmin',
+           'prod',
+           'broadcast_shape',
+           'conj',
+           'square',
+           'divide',
+           'ceil',
+           'atan',
+           'expand',
+           'broadcast_to',
+           'ones_like',
+           'index_sample',
+           'cast',
+           'grad',
+           'all',
+           'ones',
+           'not_equal',
+           'sum',
+           'tile',
+           'get_device',
+           'greater_equal',
+           'isfinite',
+           'create_parameter',
+           'dot',
+           'increment',
+           'erf',
+           'bmm',
+           'chunk',
+           'tolist',
+           'greater_than',
+           'shard_index',
+           'argsort',
+           'tanh',
+           'tanh_',
+           'transpose',
+           'randn',
+           'strided_slice',
+           'unique',
+           'set_cuda_rng_state',
+           'set_printoptions',
+           'std',
+           'flatten',
+           'asin',
+           'multiply',
+           'disable_static',
+           'masked_select',
+           'var',
+           'trace',
+           'enable_static',
+           'scatter_nd',
+           'set_default_dtype',
+           'expand_as',
+           'get_cudnn_version',
+           'stack',
+           'sqrt',
+           'cholesky',
+           'randperm',
+           'linspace',
+           'reshape',
+           'reshape_',
+           'reverse',
+           'nonzero',
+           'CUDAPinnedPlace',
+           'logical_not',
+           'add_n',
+           'minimum',
+           'ComplexTensor',
+           'scatter',
+           'scatter_',
+           'floor',
+           'cosh',
+           'log',
+           'log2',
+           'log10',
+           'concat',
+           'check_shape'
+]


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
cherry-pick from develop: update 2.0 public api in paddle.init (#32034)

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *

本pr涉及到的api改动：
以下项属于模块文件，非底层api，在__all__中移除，from paddle import *不再包含以下内容：
      "device",
      "autograd",
      "monkey_patch_math_varbase",
      "onnx",
      "tensor",
      "optimizer",
      "reader",
      "standard_normal",
      "jit",
      "distribution",
      "regularizer",
      "framework",
      "utils",
      "fluid",
      "amp",
      "paddle",
      "version",
      "compat",
      "hapi",
      "static",
      "metric",
      "vision",
      "common_ops_import",
      "text",
      "sysconfig",
      "dataset",
      "incubate",
      "nn",
      "monkey_patch_variable",
      "distributed",
      "os",
      "io"