### PR TITLE
Add fake interface for register_hook in static mode

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -246,11 +246,11 @@ def _static_only_(func):
 def _fake_interface_only_(func):
     def __impl__(*args, **kwargs):
         raise AssertionError(
-            "'%s' should be called by imperative Varible in imperative mode, please run it in dygraph "
-            "mode. You can turn off paddle.enable_static() if you are in static mode, or turn off "
-            "ProgramTranslator if you are using @paddle.jit.to_static. If you have to run ProgramTranslator, "
-            "please use other API to replace '%s'" % (func.__name__,
-                                                      func.__name__))
+            "'%s' only can be called by `paddle.Tensor` in dynamic graph mode. Suggestions:\n"
+            "  1. If you are in static graph mode, you can switch to dynamic graph mode by turning off `paddle.enable_static()` or calling `paddle.disable_static()`.\n"
+            "  2. If you are using `@paddle.jit.to_static`, you can turn off ProgramTranslator by calling `paddle.jit.ProgramTranslator().enable(False)`. "
+            "If you have to translate dynamic graph to static graph, please use other API to replace '%s'."
+            % (func.__name__, func.__name__))
 
     return __impl__
 
@@ -1304,6 +1304,10 @@ class Variable(object):
                     print("After clear {}".format(loss2.gradient()))
 
         """
+        pass
+
+    @fake_interface_only
+    def register_hook(self, hook):
         pass
 
     def __str__(self):

--- a/python/paddle/fluid/tests/unittests/test_detach.py
+++ b/python/paddle/fluid/tests/unittests/test_detach.py
@@ -152,18 +152,8 @@ class Test_Detach(unittest.TestCase):
     def test_detach_exception(self):
         x = fluid.layers.data(name="a", shape=[3, 4], dtype='float32')
         y = fluid.layers.fc(input=x, size=10, bias_attr=True)
-        try:
+        with self.assertRaises(AssertionError):
             y_detach = y.detach()
-        except Exception as e:
-            # Here is to check
-            assert type(e) == AssertionError
-            assert str(e) == (
-                "'detach' should be called by imperative Varible "
-                "in imperative mode, please run it in dygraph mode. You can "
-                "turn off paddle.enable_static() if you are in static mode, "
-                "or turn off ProgramTranslator if you are using "
-                "@paddle.jit.to_static. If you have to run ProgramTranslator, "
-                "please use other API to replace 'detach'")
 
 
 class TestInplace(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_tensor_register_hook.py
+++ b/python/paddle/fluid/tests/unittests/test_tensor_register_hook.py
@@ -477,16 +477,22 @@ class TestTensorRegisterHook(unittest.TestCase):
                     name='x', shape=[None, self.in_size], dtype='float32')
 
                 net = SimpleNetForStatic(self.in_size, self.out_size)
-                out = net(x)
-
-                exe = paddle.static.Executor()
-                exe.run(startup_program)
-
-                data = np.random.uniform(
-                    size=[self.batch_size, self.in_size]).astype('float32')
-                exe.run(main_program, feed={'x': data}, fetch_list=[out.name])
+                with self.assertRaises(AssertionError):
+                    out = net(x)
 
         paddle.disable_static()
+
+    def test_register_hook_in_dy2static_mode(self):
+        net = SimpleNetForStatic(self.in_size, self.out_size)
+        jit_net = paddle.jit.to_static(
+            net, input_spec=[paddle.static.InputSpec([None, self.in_size])])
+
+        data = np.random.uniform(
+            size=[self.batch_size, self.in_size]).astype('float32')
+        data_t = paddle.to_tensor(data)
+
+        with self.assertRaises(AssertionError):
+            out = jit_net(data_t)
 
 
 HOOK_INIT_VALUE = 10


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

add fake interface for register_hook in static mode.

- `Tensor.register_hook` method can only be used in dygraph mode, this PR polish the error message of `register_hook` in static and dy2static mode.
- polish fake_interface error message template for all fake API

- original:

![image](https://user-images.githubusercontent.com/22561442/116352151-51882580-a827-11eb-9acd-a42b4878fe94.png)

- after this PR:

![image](https://user-images.githubusercontent.com/22561442/116352105-40d7af80-a827-11eb-9c91-466bcada353f.png)
