### PR TITLE
Release2.1 hapi

### DIFF
--- a/python/paddle/hapi/__init__.py
+++ b/python/paddle/hapi/__init__.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import logger
-from . import callbacks
-from . import model_summary
-from . import hub
+from . import logger  # noqa: F401
+from . import callbacks  # noqa: F401
+from . import hub  # noqa: F401
+from . import progressbar  # noqa: F401
+from . import static_flops  # noqa: F401
 
-from . import model
-from .model import *
-from .model_summary import summary
-from .dynamic_flops import flops
+from .model import Model  # noqa: F401
+from .model_summary import summary  # noqa: F401
+from .dynamic_flops import flops  # noqa: F401
 
 logger.setup_logger()
 
-__all__ = ['callbacks'] + model.__all__ + ['summary']
-__all__ = model.__all__ + ['flops']
+__all__ = []

--- a/python/paddle/hapi/dynamic_flops.py
+++ b/python/paddle/hapi/dynamic_flops.py
@@ -18,7 +18,7 @@ import paddle.nn as nn
 import numpy as np
 from .static_flops import static_flops, Table
 
-__all__ = ['flops']
+__all__ = []
 
 
 def flops(net, input_size, custom_ops=None, print_detail=False):

--- a/python/paddle/hapi/hub.py
+++ b/python/paddle/hapi/hub.py
@@ -19,6 +19,8 @@ import shutil
 import zipfile
 from paddle.utils.download import get_path_from_url
 
+__all__ = []
+
 DEFAULT_CACHE_DIR = '~/.cache'
 VAR_DEPENDENCY = 'dependencies'
 MODULE_HUBCONF = 'hubconf.py'

--- a/python/paddle/hapi/logger.py
+++ b/python/paddle/hapi/logger.py
@@ -22,6 +22,8 @@ import logging
 
 from paddle.fluid.dygraph.parallel import ParallelEnv
 
+__all__ = []
+
 
 def setup_logger(output=None, name="hapi", log_level=logging.INFO):
     """

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -54,7 +54,7 @@ from paddle.distributed.fleet.base import role_maker
 from .callbacks import config_callbacks, EarlyStopping
 from .model_summary import summary
 
-__all__ = ['Model', ]
+__all__ = []
 
 _parallel_context_initialized = False
 

--- a/python/paddle/hapi/model_summary.py
+++ b/python/paddle/hapi/model_summary.py
@@ -22,7 +22,7 @@ from paddle.static import InputSpec
 
 from collections import OrderedDict
 
-__all__ = ['summary']
+__all__ = []
 
 
 def summary(net, input_size, dtypes=None):

--- a/python/paddle/hapi/progressbar.py
+++ b/python/paddle/hapi/progressbar.py
@@ -22,7 +22,7 @@ import time
 import numpy as np
 from collections import namedtuple
 
-__all__ = ['ProgressBar']
+__all__ = []
 
 
 class ProgressBar(object):

--- a/python/paddle/hapi/static_flops.py
+++ b/python/paddle/hapi/static_flops.py
@@ -18,6 +18,8 @@ import paddle
 from collections import OrderedDict
 from paddle.static import Program, program_guard, Variable
 
+__all__ = []
+
 
 class VarWrapper(object):
     def __init__(self, var, graph):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in hapi
same change of develop pr #32650


背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
- paddle
- paddle.amp
- paddle.nn
- paddle.nn.functional
- paddle.nn.initializer
- paddle.nn.utils
- paddle.static
- paddle.static.nn
- paddle.io
- paddle.jit
- paddle.metric
- paddle.distribution
- paddle.optimizer
- paddle.optimizer.lr
- paddle.regularizer
- paddle.text
- paddle.vision
- paddle.callbacks
- paddle.distributed
- paddle.distributed.fleet
- paddle.distributed.fleet.base.distributed_strategy
- paddle.distributed.fleet.data_generator
- paddle.distributed.fleet.utils
- paddle.distributed.parallel
- paddle.distributed.utils
- paddle.sysconfig
- paddle.utils
- paddle.utils.download
- paddle.utils.profiler
修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *

本pr涉及的改动：对hapi文件夹执行上述规范。
hapi中无指定公开层级，callbacks在paddle.callbacks层级公开