### PR TITLE
[Paddle-TRT]fix fc_op trt_converter

### DIFF
--- a/paddle/fluid/inference/tensorrt/convert/fc_op.cc
+++ b/paddle/fluid/inference/tensorrt/convert/fc_op.cc
@@ -1,11 +1,8 @@
 /* Copyright (c) 2018 PaddlePaddle Authors. All Rights Reserved.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
 http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,7 +34,7 @@ class FcOpConverter : public OpConverter {
                   const framework::Scope& scope, bool test_mode) override {
     VLOG(3) << "convert a fluid fc op to tensorrt fc layer without bias";
     framework::OpDesc op_desc(op, nullptr);
-
+    auto output_name = op_desc.Output("Out").front();
     auto input_names = op_desc.InputNames();
     bool with_bias = input_names.size() >= 3;
     std::string w_name = "Y";
@@ -54,12 +51,18 @@ class FcOpConverter : public OpConverter {
         Y_v, platform::errors::NotFound(
                  "Can not find %s presistale var of fc in scope.", w_name));
     auto* Y_t = Y_v->GetMutable<framework::LoDTensor>();
-    const int x_num_col_dims =
+    int x_num_col_dims =
         op_desc.HasAttr("x_num_col_dims")
             ? BOOST_GET_CONST(int, op_desc.GetAttr("x_num_col_dims"))
             : (op_desc.HasAttr("in_num_col_dims")
                    ? BOOST_GET_CONST(int, op_desc.GetAttr("in_num_col_dims"))
                    : 1);
+    PADDLE_ENFORCE_GE(
+        x_num_col_dims, 1,
+        platform::errors::InvalidArgument(
+            "converter expects x_num_col_dims >= 1, but "
+            "x_num_col_dims = %d.",
+            x_num_col_dims));      
     const std::string activation_type =
         op_desc.HasAttr("activation_type")
             ? BOOST_GET_CONST(std::string, op_desc.GetAttr("activation_type"))
@@ -106,8 +109,8 @@ class FcOpConverter : public OpConverter {
     auto regist_fc = [&](nvinfer1::ITensor* inputs, int n_output,
                          TensorRTEngine::Weight& weight,
                          TensorRTEngine::Weight& bias) {
-      nvinfer1::ILayer* fc_layer = nullptr;
       if (enable_int8) {
+        // add conv layer
         PADDLE_ENFORCE_EQ(
             op_desc.HasAttr("out_threshold"), true,
             platform::errors::InvalidArgument(
@@ -115,23 +118,45 @@ class FcOpConverter : public OpConverter {
         float out_scale =
             BOOST_GET_CONST(float, op_desc.GetAttr("out_threshold"));
         nvinfer1::DimsHW nv_ksize(1, 1);
-        fc_layer = TRT_ENGINE_ADD_LAYER(engine_, Convolution, *inputs, n_output,
+        auto* fc_layer_int8 = TRT_ENGINE_ADD_LAYER(engine_, Convolution, *inputs, n_output,
                                         nv_ksize, weight.get(), bias.get());
-        engine_->SetTensorDynamicRange(fc_layer->getOutput(0), out_scale);
+        engine_->SetTensorDynamicRange(fc_layer_int8->getOutput(0), out_scale);
+        if (activation_type == "relu") {
+          nvinfer1::IActivationLayer* relu_layer_int8 =
+              TRT_ENGINE_ADD_LAYER(engine_, Activation, *(fc_layer_int8->getOutput(0)),
+                                      nvinfer1::ActivationType::kRELU);
+          RreplenishLayerAndOutput(relu_layer_int8, "relu_after_fc_shuffle", {output_name}, test_mode);
+        } else {
+          RreplenishLayerAndOutput(fc_layer_int8, "shuffle_after_fc", {output_name}, test_mode);
+        } 
       } else {
-        fc_layer = TRT_ENGINE_ADD_LAYER(engine_, FullyConnected, *inputs,
+        // add fc layer
+        auto* fc_layer_before = TRT_ENGINE_ADD_LAYER(engine_, FullyConnected, *inputs,
                                         n_output, weight.get(), bias.get());
-      }
-
-      auto output_name = op_desc.Output("Out").front();
-      if (activation_type == "relu") {
-        nvinfer1::IActivationLayer* relu_layer =
-            TRT_ENGINE_ADD_LAYER(engine_, Activation, *(fc_layer->getOutput(0)),
-                                 nvinfer1::ActivationType::kRELU);
-        RreplenishLayerAndOutput(relu_layer, "fc", {output_name}, test_mode);
-      } else {
-        RreplenishLayerAndOutput(fc_layer, "fc", {output_name}, test_mode);
-      }
+        fc_layer_before->setName(("fc_layer_before(Output: " + output_name + ")").c_str());
+        // add shuffle after fc
+        nvinfer1::Dims reshape_after_fc_dim;       
+        if(x_num_col_dims==0){
+          reshape_after_fc_dim.nbDims = 1;
+          reshape_after_fc_dim.d[0] = -1;
+        }
+        else{
+          reshape_after_fc_dim.nbDims = x_num_col_dims+1;
+          for(int i=0;i<reshape_after_fc_dim.nbDims;i++){
+            reshape_after_fc_dim.d[i] = 0;
+          }
+        }
+        auto* fc_layer_float = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *fc_layer_before->getOutput(0));
+        fc_layer_float->setReshapeDimensions(reshape_after_fc_dim);  
+        if (activation_type == "relu") {
+          nvinfer1::IActivationLayer* relu_layer_float =
+              TRT_ENGINE_ADD_LAYER(engine_, Activation, *(fc_layer_float->getOutput(0)),
+                                      nvinfer1::ActivationType::kRELU);
+          RreplenishLayerAndOutput(relu_layer_float, "relu_after_fc_shuffle", {output_name}, test_mode);
+        } else {
+          RreplenishLayerAndOutput(fc_layer_float, "shuffle_after_fc", {output_name}, test_mode);
+        }                   
+      }      
     };
 
     std::vector<float> weight_data_tmp;
@@ -157,6 +182,9 @@ class FcOpConverter : public OpConverter {
                                 static_cast<void*>(bias_data),
                                 static_cast<size_t>(bias_num)};
 
+<<<<<<< HEAD
+    auto x_dim = X->getDimensions();
+=======
     if (engine_->with_dynamic_shape()) {
       // not NCHW layout, but NLP layout with added 'x 1 x 1'
       auto x_dim = X->getDimensions();
@@ -205,105 +233,43 @@ class FcOpConverter : public OpConverter {
       for (int i = 0; i < reshape_after_fc_dim.nbDims; i++) {
         reshape_after_fc_dim.d[i] = 0;
       }
+>>>>>>> bda0e60981cd2485fb09b9f8a7c294ebe3433f05
 
-      auto* reshape_after_fc_layer =
-          TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *fc_layer->getOutput(0));
-      reshape_after_fc_layer->setReshapeDimensions(reshape_after_fc_dim);
+    PADDLE_ENFORCE_GT(
+        x_dim.nbDims, x_num_col_dims,
+        platform::errors::InvalidArgument(
+            "Params and input dims mismatch. Paddle-TRT FC "
+            "converter expects x_dim.nbDims > x_num_col_dims, but "
+            "x_dim.nbDims : %d, x_num_col_dims : %d.",
+            x_dim.nbDims, x_num_col_dims));
 
-      if (activation_type == "relu") {
-        reshape_after_fc_layer->setName(
-            ("shuffle_after_fc(Output: " + output_name + ")").c_str());
-        nvinfer1::IActivationLayer* relu_layer = TRT_ENGINE_ADD_LAYER(
-            engine_, Activation, *(reshape_after_fc_layer->getOutput(0)),
-            nvinfer1::ActivationType::kRELU);
-        RreplenishLayerAndOutput(relu_layer, "relu_after_fc_shuffle",
-                                 {output_name}, test_mode);
-      } else {
-        RreplenishLayerAndOutput(reshape_after_fc_layer, "shuffle_after_fc",
-                                 {output_name}, test_mode);
-      }
-      return;
+    // Running the TRT Static Shape mode: x_num_col_dims-1
+    if (!engine_->with_dynamic_shape()) {
+      x_num_col_dims--;
     }
-    // in order to handle situations in NLP models(input dims < 3,
-    // x_num_col_dims != 1, etc.), reshape input to perform FC correctly.
-    auto* reshape_itensor = X;
-    int input_dims = X->getDimensions().nbDims;
-    auto input_d = X->getDimensions().d;
-    int reshape_dim3[3] = {0};
-    int reshape_dim4[4] = {0};
-    PADDLE_ENFORCE_LE(x_num_col_dims, input_dims,
-                      platform::errors::InvalidArgument(
-                          "Params and input dims mismatch. Paddle-TRT FC "
-                          "converter expects x_num_col_dims <= input dims"));
-    if (x_num_col_dims == 1) {
-      if (input_dims == 4) {
-        PADDLE_ENFORCE_EQ(
-            input_d[3], 1,
-            platform::errors::InvalidArgument(
-                "Invalid dimensions. When x_num_col_dims equals to 1 and input "
-                "dims equals to 4, the last dim of input must be 1, but got %d",
-                input_d[3]));
+    // add shuffle before fc
+    nvinfer1::Dims reshape_before_fc_dim;
+    reshape_before_fc_dim.nbDims=x_num_col_dims+3;
+    // padding shape "* x q x 1 x 1"
+    for (int i=0; i<reshape_before_fc_dim.nbDims; i++) {
+      reshape_before_fc_dim.d[i] = 1;
+    }
+    for (int i=0; i<x_dim.nbDims; i++){
+      if (i<x_num_col_dims) {
+        reshape_before_fc_dim.d[i]=0;
       }
-      if (enable_int8) {
-        reshape_dim3[0] = 1;
-        for (int i = 0; i < 3; i++) {
-          reshape_dim3[0] *= input_d[i];
-          if (i > 0) {
-            reshape_dim3[i] = 1;
-          }
-        }
-      } else {
-        for (int i = 0; i < 3; i++) {
-          if (i < input_dims) {
-            reshape_dim3[i] = input_d[i];
-          } else {
-            reshape_dim3[i] = 1;
-          }
-        }
+      else{
+        reshape_before_fc_dim.d[x_num_col_dims]*=x_dim.d[i];
       }
-
-      nvinfer1::Dims3 reshape_dim(reshape_dim3[0], reshape_dim3[1],
-                                  reshape_dim3[2]);
-      auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *X);
-      reshape_layer->setReshapeDimensions(reshape_dim);
-      reshape_itensor = reshape_layer->getOutput(0);
-      if (enable_int8) {
-        engine_->SetTensorDynamicRange(reshape_itensor, in_scale);
-      }
-    } else {
-      PADDLE_ENFORCE_NE(input_dims, 1,
-                        platform::errors::InvalidArgument(
-                            "Invalid dimensions. When x_num_col_dims equals to "
-                            "2, input_dims should not be 1"));
-
-      if (enable_int8) {
-        for (int i = 0; i < 4; i++) {
-          if (i == 0) {
-            reshape_dim4[i] = input_d[i];
-          } else {
-            reshape_dim4[i] = 1;
-            if (i < input_dims) {
-              reshape_dim4[1] *= input_d[i];
-            }
-          }
-        }
-      } else {
-        for (int i = 0; i < 4; i++) {
-          if (i < input_dims) {
-            reshape_dim4[i] = input_d[i];
-          } else {
-            reshape_dim4[i] = 1;
-          }
-        }
-      }
-      nvinfer1::Dims4 reshape_dim(reshape_dim4[0], reshape_dim4[1],
-                                  reshape_dim4[2], reshape_dim4[3]);
-      auto* reshape_layer = TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *X);
-      reshape_layer->setReshapeDimensions(reshape_dim);
-      reshape_itensor = reshape_layer->getOutput(0);
-      if (enable_int8) {
-        engine_->SetTensorDynamicRange(reshape_itensor, in_scale);
-      }
+    }
+    auto* reshape_before_fc_layer =
+        TRT_ENGINE_ADD_LAYER(engine_, Shuffle, *X);
+    reshape_before_fc_layer->setReshapeDimensions(reshape_before_fc_dim);
+    reshape_before_fc_layer->setName(
+        ("shuffle_before_fc(Output: " + output_name + ")").c_str());
+    auto* reshape_itensor = reshape_before_fc_layer->getOutput(0);
+    if (enable_int8){
+        engine_->SetTensorDynamicRange(reshape_itensor, in_scale);    
     }
     regist_fc(reshape_itensor, n_output, weight, bias);
   }

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_fc_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_fc_fuse_pass.py
@@ -31,10 +31,7 @@ class FCFusePassTRTTest(InferencePassTest):
                                       size=128,
                                       num_flatten_dims=1,
                                       act="relu")
-            fc_out2 = fluid.layers.fc(input=fc_out1,
-                                      size=32,
-                                      num_flatten_dims=1)
-            out = fluid.layers.softmax(input=fc_out2)
+            out = fluid.layers.softmax(input=fc_out1)
 
         self.feeds = {
             "data": np.random.random((32, 128, 2, 2)).astype("float32")
@@ -45,6 +42,53 @@ class FCFusePassTRTTest(InferencePassTest):
         # self.enable_trt = True
         # self.trt_parameters = FCFusePassTRTTest.TensorRTParam(
         #     1 << 30, 32, 3, AnalysisConfig.Precision.Float32, False, False)
+        self.fetch_list = [out]
+
+    def test_check_output(self):
+        use_gpu = [False]
+        if core.is_compiled_with_cuda():
+            use_gpu.append(True)
+        for i in range(len(use_gpu)):
+            self.check_output_with_option(use_gpu[i])
+
+
+class FCFusePassTRTStaticDims4Cols1Test(InferencePassTest):
+    def setUp(self):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(name="data", shape=[32, 128, 32, 8], dtype="float32")
+            fc_out1 = fluid.layers.fc(input=data,
+                                      size=64,
+                                      num_flatten_dims=1,
+                                      act="relu")
+            out = fluid.layers.softmax(input=fc_out1)
+
+        self.feeds = {"data": np.random.random((32, 128, 32, 8)).astype("float32")}
+        self.enable_trt = True
+        self.trt_parameters = FCFusePassTRTStaticDims4Cols1Test.TensorRTParam(
+            1 << 30, 32, 2, AnalysisConfig.Precision.Float32, False, False)
+        self.fetch_list = [out]
+
+    def test_check_output(self):
+        use_gpu = [False]
+        if core.is_compiled_with_cuda():
+            use_gpu.append(True)
+        for i in range(len(use_gpu)):
+            self.check_output_with_option(use_gpu[i])
+
+class FCFusePassTRTStaticDims4Cols2Test(InferencePassTest):
+    def setUp(self):
+        with fluid.program_guard(self.main_program, self.startup_program):
+            data = fluid.data(name="data", shape=[3, 24, 16, 16], dtype="float32")
+            fc_out1 = fluid.layers.fc(input=data,
+                                      size=32,
+                                      num_flatten_dims=2,
+                                      act="relu")
+            out = fluid.layers.softmax(input=fc_out1)
+
+        self.feeds = {"data": np.random.random((3, 24, 16, 16)).astype("float32")}
+        self.enable_trt = True
+        self.trt_parameters = FCFusePassTRTStaticDims4Cols2Test.TensorRTParam(
+            1 << 30, 32, 2, AnalysisConfig.Precision.Float32, False, False)
         self.fetch_list = [out]
 
     def test_check_output(self):

--- a/python/paddle/fluid/tests/unittests/ir/inference/test_trt_fc_fuse_pass.py
+++ b/python/paddle/fluid/tests/unittests/ir/inference/test_trt_fc_fuse_pass.py
@@ -55,14 +55,17 @@ class FCFusePassTRTTest(InferencePassTest):
 class FCFusePassTRTStaticDims4Cols1Test(InferencePassTest):
     def setUp(self):
         with fluid.program_guard(self.main_program, self.startup_program):
-            data = fluid.data(name="data", shape=[32, 128, 32, 8], dtype="float32")
+            data = fluid.data(
+                name="data", shape=[32, 128, 32, 8], dtype="float32")
             fc_out1 = fluid.layers.fc(input=data,
                                       size=64,
                                       num_flatten_dims=1,
                                       act="relu")
             out = fluid.layers.softmax(input=fc_out1)
 
-        self.feeds = {"data": np.random.random((32, 128, 32, 8)).astype("float32")}
+        self.feeds = {
+            "data": np.random.random((32, 128, 32, 8)).astype("float32")
+        }
         self.enable_trt = True
         self.trt_parameters = FCFusePassTRTStaticDims4Cols1Test.TensorRTParam(
             1 << 30, 32, 2, AnalysisConfig.Precision.Float32, False, False)
@@ -75,17 +78,21 @@ class FCFusePassTRTStaticDims4Cols1Test(InferencePassTest):
         for i in range(len(use_gpu)):
             self.check_output_with_option(use_gpu[i])
 
+
 class FCFusePassTRTStaticDims4Cols2Test(InferencePassTest):
     def setUp(self):
         with fluid.program_guard(self.main_program, self.startup_program):
-            data = fluid.data(name="data", shape=[3, 24, 16, 16], dtype="float32")
+            data = fluid.data(
+                name="data", shape=[3, 24, 16, 16], dtype="float32")
             fc_out1 = fluid.layers.fc(input=data,
                                       size=32,
                                       num_flatten_dims=2,
                                       act="relu")
             out = fluid.layers.softmax(input=fc_out1)
 
-        self.feeds = {"data": np.random.random((3, 24, 16, 16)).astype("float32")}
+        self.feeds = {
+            "data": np.random.random((3, 24, 16, 16)).astype("float32")
+        }
         self.enable_trt = True
         self.trt_parameters = FCFusePassTRTStaticDims4Cols2Test.TensorRTParam(
             1 << 30, 32, 2, AnalysisConfig.Precision.Float32, False, False)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修改paddle-trt converter的fc_op实现，能支持静态、动态输出，int8，增加单测中的测试情况