### PR TITLE
[Kunlun]fix multi xpu dygraph hang, test=kunlun

### DIFF
--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -763,7 +763,7 @@ void Reducer::MarkGroupReady(size_t group_index) {
     // otherwise the main thread will continue to run when an exception is
     // thrown in comm_pool_.
     auto next_group = next_group_;
-    comm_pool_->enqueue([&, run_order, next_group] {
+    comm_pool_->enqueue([this, run_order, next_group, &group] {
       auto dev_id = BOOST_GET_CONST(platform::XPUPlace, place_).device;
       platform::SetXPUDeviceId(dev_id);
       FusedAllReduceSchedule(run_order, group, next_group);

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -762,7 +762,7 @@ void Reducer::MarkGroupReady(size_t group_index) {
     // TODO(liuyuhui): Add try catch to deal with exception later,
     // otherwise the main thread will continue to run when an exception is
     // thrown in comm_pool_.
-    comm_pool_->enqueue([&] {
+    comm_pool_->enqueue([=, &group] {
       auto dev_id = BOOST_GET_CONST(platform::XPUPlace, place_).device;
       platform::SetXPUDeviceId(dev_id);
       FusedAllReduceSchedule(run_order, group, next_group_);

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -762,10 +762,11 @@ void Reducer::MarkGroupReady(size_t group_index) {
     // TODO(liuyuhui): Add try catch to deal with exception later,
     // otherwise the main thread will continue to run when an exception is
     // thrown in comm_pool_.
-    comm_pool_->enqueue([=, &group] {
+    auto next_group = next_group_;
+    comm_pool_->enqueue([&, run_order, next_group] {
       auto dev_id = BOOST_GET_CONST(platform::XPUPlace, place_).device;
       platform::SetXPUDeviceId(dev_id);
-      FusedAllReduceSchedule(run_order, group, next_group_);
+      FusedAllReduceSchedule(run_order, group, next_group);
       {
         std::lock_guard<std::mutex> lock(mutex_);
         comm_op_count_ -= 1;  // lock


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix multi kunlun XPU cards dygraph running hang.
ref to PaddleClas [PR690]:https://github.com/PaddlePaddle/PaddleClas/pull/690
```
python3.7 -m paddle.distributed.launch --xpus=2,3 --log_dir log tools/train.py -c ./configs/quick_start/ResNet50_vd_finetune_kunlun.yaml
```
```
2021-04-29 08:21:19,988 - INFO - epoch:19 , train step:0   , top1: 0.93750, top5: 1.00000, loss: 0.92145, lr: 0.000023, batch_cost: 0.96966 s, reader_cost: 0.23445 s, ips: 33.00113 images/sec, eta: 0:00:14
2021-04-29 08:21:26,911 - INFO - epoch:19 , train step:10  , top1: 0.93750, top5: 1.00000, loss: 1.03136, lr: 0.000003, batch_cost: 0.69550 s, reader_cost: 0.00019 s, ips: 46.01037 images/sec, eta: 0:00:03
2021-04-29 08:21:29,695 - INFO - END epoch:19  train top1: 0.92292, top5: 0.98542, loss: 0.95281,  batch_cost: 0.69007 s, reader_cost: 0.00025 s, batch_cost_sum: 3.45033 s, ips: 46.37236 images/sec.
```