### PR TITLE
[cherry-pick] specify multihead_matmul_fuse_pass_v3 QK path (#32659)

### DIFF
--- a/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/multihead_matmul_fuse_pass.cc
@@ -753,7 +753,7 @@ PDNode* MultiHeadMatmulV3Pattern::operator()() {
       pattern->NewNode(transpose2_0_repr())->assert_is_op("transpose2");
   auto* transpose2_0_out_var = pattern->NewNode(transpose2_0_out_repr())
                                    ->assert_is_op_output("transpose2");
-  transpose2_0_out_var->AsIntermediate()->assert_is_op_input("matmul");
+  transpose2_0_out_var->AsIntermediate()->assert_is_op_input("matmul", "X");
 
   auto* matmul_qk = pattern->NewNode(matmul_qk_repr())->assert_is_op("matmul");
   auto* matmul_qk_out_var =
@@ -827,7 +827,7 @@ PDNode* MultiHeadMatmulV3Pattern::operator()() {
   auto* transpose2_1_out_var = pattern->NewNode(transpose2_1_out_repr())
                                    ->assert_is_op_output("transpose2");
   transpose2_1_out_var->AsIntermediate()->assert_is_op_input(
-      "matmul");  // link to matmul qk
+      "matmul", "Y");  // link to matmul qk
 
   // Third path to matmul
   auto* mul2 = pattern->NewNode(mul2_repr())->assert_is_op("matmul");


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
cherrypick PR#32659: specify multihead_matmul_fuse_pass_v3 QK path