### PR TITLE
[Paddle-TRT] remove check for optim_cache_dir in trt slim int8

### DIFF
--- a/paddle/fluid/inference/analysis/ir_pass_manager.cc
+++ b/paddle/fluid/inference/analysis/ir_pass_manager.cc
@@ -106,8 +106,8 @@ void IRPassManager::CreatePasses(Argument *argument,
       bool use_static_engine = argument->tensorrt_use_static_engine();
       bool model_from_memory = argument->model_from_memory();
       std::string optim_cache_dir = argument->optim_cache_dir();
-      bool int8_valid =
-          !(model_from_memory && optim_cache_dir.empty() && enable_int8);
+      bool int8_valid = !(model_from_memory && optim_cache_dir.empty() &&
+                          enable_int8 && use_calib_mode);
       PADDLE_ENFORCE_EQ(
           int8_valid, true,
           platform::errors::PreconditionNotMet(


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
remove check for optim_cache_dir in trt slim int8