### PR TITLE
clear tensor in context after backward.

### DIFF
--- a/paddle/fluid/operators/py_layer_op.h
+++ b/paddle/fluid/operators/py_layer_op.h
@@ -27,9 +27,7 @@ namespace py = ::pybind11;
 
 class PyLayerContext {
  public:
-  explicit PyLayerContext(PyObject* context) : context_(context) {
-    Py_INCREF(context_);
-  }
+  explicit PyLayerContext(PyObject* context) : context_(context) {}
 
   PyLayerContext() = delete;
 

--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -45,7 +45,7 @@ class PyLayerContext(object):
     """
 
     def __init__(self):
-        self.container = None
+        self.container = list()
 
     def save_for_backward(self, *tensors):
         """
@@ -83,7 +83,9 @@ class PyLayerContext(object):
                         return grad
 
         """
-        self.container = tensors
+        #self.container = tensors
+        for t in tensors:
+            self.container.append(t)
 
     def saved_tensor(self):
         """
@@ -178,7 +180,10 @@ class PyLayerBackward(PyLayerContext):
     def backward(self, *args, **kwargs):
         with paddle.fluid.dygraph.guard():
             with paddle.fluid.dygraph.no_grad():
-                return self._forward_cls.backward(*args, **kwargs)
+                grads = self._forward_cls.backward(*args, **kwargs)
+                # clear tensor in ctx
+                args[0].container.clear()
+                return grads
 
 
 class LayerMeta(type):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
bug：使用save_for_backward后，tensor无法析构。
解决办法：每次执行完backward清理save_for_backward存的tensor