### PR TITLE
[Cherry-pick][Dy2stat] Fix to_tensor Bug Reported from QA (#32701)

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_basic_api_transformation.py
@@ -64,13 +64,11 @@ def dyfunc_int_to_tensor(x):
 
 
 def dyfunc_float_to_tensor(x):
-    res = paddle.to_tensor(2.0)
-    return res
+    return paddle.to_tensor(2.0)
 
 
 def dyfunc_bool_to_tensor(x):
-    res = paddle.to_tensor(True)
-    return res
+    return paddle.to_tensor(True)
 
 
 class TestDygraphBasicApi_ToVariable(unittest.TestCase):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Cherry-pick of https://github.com/PaddlePaddle/Paddle/pull/32701

Dy2stat failed when user writes return paddle.to_tensor(xxx), the reason is that visit_Expr doesn't work when the Expr is in return. Some other statements may trigger same bug. To fix it, we re-wrote a transformer to transform paddle.to_tensor to paddle.assign for all Call nodes.