### PR TITLE
CPU memory allocator using Transparent Huge Pages

### DIFF
--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -23,6 +23,8 @@ limitations under the License. */
 #include <windows.h>  // VirtualLock/VirtualUnlock
 #else
 #include <sys/mman.h>  // for mlock and munlock
+#include <errno.h>
+#include <string.h>
 #endif
 #include "gflags/gflags.h"
 #include "paddle/fluid/memory/allocation/allocator.h"
@@ -70,8 +72,8 @@ void* AlignedMalloc(size_t size) {
   PADDLE_ENFORCE_EQ(
       error, 0,
       platform::errors::InvalidArgument(
-          "Fail to set advice to CPU memory of %ld size. Error code is  %d.",
-          size, error));
+          "Fail to set advice to CPU memory of %ld size. Error: %s.",
+          size, strerror(errno)));
 #endif
 
 #endif

--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -22,6 +22,8 @@ limitations under the License. */
 #endif
 #include <windows.h>  // VirtualLock/VirtualUnlock
 #else
+#include <errno.h>
+#include <string.h>
 #include <sys/mman.h>  // for mlock and munlock
 #endif
 #include "gflags/gflags.h"
@@ -68,7 +70,11 @@ void* AlignedMalloc(size_t size) {
 #ifdef __linux__
   // Advise may fail due to platform capabilities
   // so we will ignore returned error
-  madvise(p, size, MADV_HUGEPAGE | MADV_SEQUENTIAL);
+  error = madvise(p, size, MADV_HUGEPAGE | MADV_SEQUENTIAL);
+  if (error != 0) {
+    VLOG(4) << "Memory Advice (madvice) ignored for size: " << size
+            << " due to error: " << strerror(errno);
+  }
 #endif
 
 #endif

--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -48,8 +48,8 @@ void* AlignedMalloc(size_t size) {
   void* p = nullptr;
   size_t alignment = 32ul;
 #ifdef PADDLE_WITH_MKLDNN
-  // refer to https://github.com/01org/mkl-dnn/blob/master/include/mkldnn.hpp
-  // memory alignment
+// refer to https://github.com/01org/mkl-dnn/blob/master/include/mkldnn.hpp
+// memory alignment
 #ifdef __linux__
   alignment = 1 << 21;
 #else
@@ -64,7 +64,7 @@ void* AlignedMalloc(size_t size) {
       error, 0,
       platform::errors::ResourceExhausted(
           "Fail to alloc memory of %ld size, error code is %d.", size, error));
-//TODO(jczaja): Enable MacOS Huge Pages if desired
+// TODO(jczaja): Enable MacOS Huge Pages if desired
 #ifdef __linux__
   error = madvise(p, size, MADV_HUGEPAGE | MADV_SEQUENTIAL);
   PADDLE_ENFORCE_EQ(

--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -22,9 +22,9 @@ limitations under the License. */
 #endif
 #include <windows.h>  // VirtualLock/VirtualUnlock
 #else
-#include <sys/mman.h>  // for mlock and munlock
 #include <errno.h>
 #include <string.h>
+#include <sys/mman.h>  // for mlock and munlock
 #endif
 #include "gflags/gflags.h"
 #include "paddle/fluid/memory/allocation/allocator.h"
@@ -70,10 +70,9 @@ void* AlignedMalloc(size_t size) {
 #ifdef __linux__
   error = madvise(p, size, MADV_HUGEPAGE | MADV_SEQUENTIAL);
   PADDLE_ENFORCE_EQ(
-      error, 0,
-      platform::errors::InvalidArgument(
-          "Fail to set advice to CPU memory of %ld size. Error: %s.",
-          size, strerror(errno)));
+      error, 0, platform::errors::InvalidArgument(
+                    "Fail to set advice to CPU memory of %ld size. Error: %s.",
+                    size, strerror(errno)));
 #endif
 
 #endif

--- a/paddle/fluid/memory/detail/system_allocator.cc
+++ b/paddle/fluid/memory/detail/system_allocator.cc
@@ -22,8 +22,6 @@ limitations under the License. */
 #endif
 #include <windows.h>  // VirtualLock/VirtualUnlock
 #else
-#include <errno.h>
-#include <string.h>
 #include <sys/mman.h>  // for mlock and munlock
 #endif
 #include "gflags/gflags.h"
@@ -68,11 +66,9 @@ void* AlignedMalloc(size_t size) {
           "Fail to alloc memory of %ld size, error code is %d.", size, error));
 // TODO(jczaja): Enable MacOS Huge Pages if desired
 #ifdef __linux__
-  error = madvise(p, size, MADV_HUGEPAGE | MADV_SEQUENTIAL);
-  PADDLE_ENFORCE_EQ(
-      error, 0, platform::errors::InvalidArgument(
-                    "Fail to set advice to CPU memory of %ld size. Error: %s.",
-                    size, strerror(errno)));
+  // Advise may fail due to platform capabilities
+  // so we will ignore returned error
+  madvise(p, size, MADV_HUGEPAGE | MADV_SEQUENTIAL);
 #endif
 
 #endif


### PR DESCRIPTION
### PR types
Performance optimization

### PR changes
Others

### Describe
CPUAllocator (SystemAllocator for CPU) is now for Linux/MacOS is advised to use Huge Pages when doing allocation. For Operating systems with Huge Pages support , 2MB memory pages may be used to fullfill allocation rather than standard 4KB. This may improve performance(CPU and oneDNN execution) in some scenarios 
