### PR TITLE
Other activation op

### DIFF
--- a/paddle/fluid/operators/activation_op.cu
+++ b/paddle/fluid/operators/activation_op.cu
@@ -1074,6 +1074,7 @@ struct CudaHardSigmoidFunctor : public BaseActivationFunctor<T> {
   // hard_sigmoid(x) = 0, when x <= -3
   //                   1, when x >= 3
   //                   x * slope + offset, otherwise
+  // slope = 1/6, offset = 3 by default
   // Inputs: args[0], the input x
   __device__ __forceinline__ T operator()(const T* args) const {
     T temp = args[0] * static_cast<T>(slope) + static_cast<T>(offset);
@@ -1095,6 +1096,7 @@ struct CudaHardSigmoidGradFunctor : public BaseActivationFunctor<T> {
   }
 
   // dx = (out > 0 && out < 1) ? dout * slope : 0
+  // slope = 1/6, offset = 3 by default
   // Inputs: args[0], the input dout
   //         args[1], the input out
   __device__ __forceinline__ T operator()(const T* args) const {

--- a/paddle/fluid/operators/scale_op.cu
+++ b/paddle/fluid/operators/scale_op.cu
@@ -12,21 +12,84 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. */
 
+#include "paddle/fluid/operators/elementwise/elementwise_op_impl.cu.h"
 #include "paddle/fluid/operators/scale_op.h"
 #include "paddle/fluid/platform/float16.h"
+
 namespace plat = paddle::platform;
 
+template <typename T>
+struct CudaAbsFunctor {
+  T one = static_cast<T>(1.0f);
+  float scale;
+  float bias;
+  bool bias_after_scale;
+
+  CudaAbsFunctor(float s, float b, bool bas)
+      : scale(s), bias(b), bias_after_scale(bas) {}
+
+  // scale(x) = scale * x + bias, if bias_after_scale is True
+  //          = scale * (x + bias), if bias_after_scale is False
+  // Inputs: args[0], the input x
+  __device__ __forceinline__ T operator()(const T* args) const {
+    T s = static_cast<T>(scale);
+    T b = static_cast<T>(bias);
+    T bas = static_cast<T>(bias_after_scale);
+    return args[0] * s + b + (s - one) * b * bas;
+  }
+};
+
+template <typename T>
+class ScaleKernel<platform::CUDADeviceContext, T>
+    : public framework::OpKernel<T> {
+ public:
+  virtual void Compute(const framework::ExecutionContext& ctx) const {
+    auto* in_var = ctx.InputVar("X");
+    auto* in = framework::GetLoDTensorOrSelectedRowsValueFromVar(*in_var);
+
+    auto bias = static_cast<T>(ctx.Attr<float>("bias"));
+    auto bias_after_scale = ctx.Attr<bool>("bias_after_scale");
+
+    auto scale = static_cast<T>(ctx.Attr<float>("scale"));
+    if (ctx.HasInput("ScaleTensor")) {
+      auto* scale_tensor = ctx.Input<framework::Tensor>("ScaleTensor");
+      scale = GetAttrFromTensor<T>(scale_tensor);
+    }
+
+    auto* out_var = ctx.OutputVar("Out");
+    if (in_var->IsType<framework::SelectedRows>() && in_var != out_var) {
+      auto& in_slr = in_var->Get<framework::SelectedRows>();
+      auto* out_slr = out_var->GetMutable<framework::SelectedRows>();
+      out_slr->set_rows(in_slr.rows());
+      out_slr->set_height(in_slr.height());
+    }
+
+    auto* out =
+        framework::GetMutableLoDTensorOrSelectedRowsValueFromVar(out_var);
+    out->mutable_data<T>(in->place());
+
+    PADDLE_ENFORCE_EQ(in->dims(), out->dims(),
+                      plat::errors::InvalidArgument(
+                          "the input and output should have the same dim"
+                          "but input dim is %s, output dim is %s",
+                          in->dims(), out->dims()));
+
+    auto& dev = ctx.template device_context<DeviceContext>();
+
+    std::vector<const framework::Tensor*> ins = {x};
+    std::vector<framework::Tensor*> outs = {out};
+    auto functor = CudaAbsFunctor();
+    LaunchElementwiseCudaKernel<ElementwiseType::kUnary, T>(dev, ins, &outs,
+                                                            functor);
+  }
+};
+
 REGISTER_OP_CUDA_KERNEL(
-    scale,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext, float>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext, double>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext,
-                                   uint8_t>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext, int8_t>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext,
-                                   int16_t>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext, int>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext,
-                                   int64_t>,
-    paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext,
-                                   plat::float16>);
+    scale, paddle::operators::ScaleKernel<plat::CUDADeviceContext, float>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, double>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, uint8_t>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, int8_t>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, int16_t>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, int>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, int64_t>,
+    paddle::operators::ScaleKernel<plat::CUDADeviceContext, plat::float16>);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
适配 scale 等不在 activation.h 中的激活算子

|config |dt|paddle old|paddle new  |pro  |pytorch  |diff  | 
|---|---|---|---|---|---|---|
|[16,16,16] |fp16|1.3510us |1.3910us | -3.0% | | % | 
|[16, 16, 1024]|fp16|2.0410us|1.7900us|14.0% | |% | 
|[16, 1024, 1024]|fp16|99.747us |84.394us| 18.2% | |% | 
|[16,16,16] |fp32|1.3930us|1.5090us | -8.0% | | % | 
|[16, 16, 1024]|fp32|2.3270us | 1.9790us| 17.6% | |% | 
|[16, 1024, 1024]|fp32|179.60us|163.88us|9.6% | |% |

因为第一个配置规模较小，因此性能会出现较小的下降，但是当规模较大时，性能会有比较明显的提升。