### PR TITLE
Update norm.py

### DIFF
--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -578,7 +578,7 @@ class _BatchNormBase(layers.Layer):
                 attr=self._weight_attr,
                 shape=param_shape,
                 default_initializer=Constant(1.0))
-            self.weight.stop_gradient = self._weight_attr != None and self._weight_attr.learning_rate == 0.
+            self.weight.stop_gradient = self._weight_attr is not None and self._weight_attr.learning_rate == 0.
 
         if bias_attr == False:
             self.bias = self.create_parameter(
@@ -590,7 +590,7 @@ class _BatchNormBase(layers.Layer):
         else:
             self.bias = self.create_parameter(
                 attr=self._bias_attr, shape=param_shape, is_bias=True)
-            self.bias.stop_gradient = self._bias_attr != None and self._bias_attr.learning_rate == 0.
+            self.bias.stop_gradient = self._bias_attr is not None and self._bias_attr.learning_rate == 0.
 
         moving_mean_name = None
         moving_variance_name = None


### PR DESCRIPTION
`x != None` is not regular rule in python. Use `x is not None` instead.

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
