### PR TITLE
Remove np Deprecation Warning since `np.bool` is alias of `bool`

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_cond.py
+++ b/python/paddle/fluid/tests/unittests/test_cond.py
@@ -96,7 +96,7 @@ class TestCondInputOutput(unittest.TestCase):
         self.assertTrue(
             np.allclose(np.asarray(ret[0]), np.full((1, 2), 1, np.int32)))
         self.assertTrue(
-            np.allclose(np.asarray(ret[1]), np.full((2, 3), True, np.bool)))
+            np.allclose(np.asarray(ret[1]), np.full((2, 3), True, bool)))
 
     def test_pass_and_modify_var(self):
         """


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Remove np Deprecation Warning since `np.bool` is alias of `bool`

The warning report from test:

```
2021-04-30 15:29:32 /workspace/Paddle/build/python/paddle/fluid/framework.py:689: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
2021-04-30 15:29:32 Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
2021-04-30 15:29:32   elif dtype == np.bool:
2021-04-30 15:29:32 /workspace/Paddle/build/python/paddle/fluid/layers/utils.py:77: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
2021-04-30 15:29:32   return (isinstance(seq, collections.Sequence) and
2021-04-30 15:29:32 /workspace/Paddle/build/python/paddle/fluid/tests/unittests/test_cond.py:99: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
```