### PR TITLE
[NPU] change Add to AddN in sum npu op

### DIFF
--- a/paddle/fluid/operators/optimizers/adam_op_npu.cc
+++ b/paddle/fluid/operators/optimizers/adam_op_npu.cc
@@ -36,7 +36,6 @@ class AdamNPUKernel : public framework::OpKernel<T> {
                           "but the received is %s",
                           ctx.InputNames("Param").front(),
                           framework::ToTypeName(param_var->Type())));
-    T epsilon = static_cast<T>(ctx.Attr<float>("epsilon"));
     auto* param = ctx.Input<LoDTensor>("Param");
     auto* grad_var = ctx.InputVar("Grad");
     PADDLE_ENFORCE_EQ(grad_var->IsType<framework::LoDTensor>(), true,

--- a/paddle/fluid/operators/sum_op_npu.cc
+++ b/paddle/fluid/operators/sum_op_npu.cc
@@ -43,13 +43,12 @@ class SumNPUKernel : public framework::OpKernel<T> {
         ctx.template device_context<paddle::platform::NPUDeviceContext>()
             .stream();
 
-    auto runner = NpuOpRunner("Add", {*x[0], *x[1]}, {*out}, {});
-
-    runner.Run(stream);
-    for (int i = 2; i < n; i++) {
-      runner = NpuOpRunner("Add", {*out, *x[i]}, {*out}, {});
-      runner.Run(stream);
+    std::vector<paddle::framework::Tensor> x_list;
+    for (int i = 0; i < n; i++) {
+      x_list.push_back(*x[i]);
     }
+    auto runner = NpuOpRunner("AddN", {x_list}, {*out}, {});
+    runner.Run(stream);
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
@@ -79,7 +79,9 @@ class TestSum2(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        self.check_output_with_place(self.place, check_dygraph=False)
+        # use `AddN` instead of `Add` in `sum` op for better performance, but in
+        # the case of fp16 there will be a loss of accuracy when using `AddN`.
+        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_sum_op_npu.py
@@ -67,7 +67,14 @@ class TestSum2(OpTest):
         x2 = np.random.random((3, 3)).astype(self.dtype)
         x3 = np.random.random((3, 3)).astype(self.dtype)
         self.inputs = {'X': [("x0", x0), ("x1", x1), ("x2", x2), ("x3", x3)]}
-        y = x0 + x1 + x2 + x3
+        # There will be a problem if just using `y=x0+x1+x2+x3` to calculate the
+        # summation result as the reference standard result. The reason is that 
+        # numpy's fp16 data has precision loss when doing `add` operation.
+        # For example, the results of `x0+x1+x2+x3` is different from that of
+        # `x3+x2+x1+x0` if the dtype is fp16.
+        # Therefore, converting the input to fp32 for calculation.
+        y = (x0.astype(np.float32) + x1.astype(np.float32) +
+             x2.astype(np.float32) + x3.astype(np.float32)).astype(self.dtype)
         self.outputs = {'Out': y}
 
         self.attrs = {'use_mkldnn': False}
@@ -79,9 +86,7 @@ class TestSum2(OpTest):
         self.__class__.use_npu = True
 
     def test_check_output(self):
-        # use `AddN` instead of `Add` in `sum` op for better performance, but in
-        # the case of fp16 there will be a loss of accuracy when using `AddN`.
-        self.check_output_with_place(self.place, check_dygraph=False, atol=1e-3)
+        self.check_output_with_place(self.place, check_dygraph=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

use `AddN` instead of `Add`.

- before (use Add)

<img width="832" alt="图片" src="https://user-images.githubusercontent.com/26408901/117626895-31068680-b1aa-11eb-993b-81005f625e8f.png">

As shown in the timeline, the time consumption of `ClipGrad` is 144ms (439ms - 583ms), and the time consumption of `Add` in `ClipGrad` is 23ms (521ms - 544ms), which accounts for 16.0%. 

- after (use AddN)
<img width="741" alt="图片" src="https://user-images.githubusercontent.com/26408901/117627561-df123080-b1aa-11eb-80ae-02553172fbd8.png">

As shown in the timeline, the time consumption of `ClipGrad` is 138ms (471ms - 609ms), and the time consumption of `AddN` in `ClipGrad` is 3ms (562ms - 565ms), which accounts for 2.2%. 

### Performance

Speed up: xxx tokens/s -> xxx tokens/s, +xxx  %


