### PR TITLE
Fix retry error in download when exception occurs

### DIFF
--- a/python/paddle/tests/test_download.py
+++ b/python/paddle/tests/test_download.py
@@ -70,6 +70,13 @@ class TestDownload(unittest.TestCase):
         for url in urls:
             get_path_from_url(url, root_dir='./test')
 
+    def test_retry_exception(self, ):
+        with self.assertRaises(RuntimeError):
+            from paddle.utils.download import _download
+            _download(
+                'www.baidu.com',
+                './test', )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/utils/download.py
+++ b/python/paddle/utils/download.py
@@ -186,7 +186,15 @@ def _download(url, path, md5sum=None):
 
         logger.info("Downloading {} from {}".format(fname, url))
 
-        req = requests.get(url, stream=True)
+        try:
+            req = requests.get(url, stream=True)
+        except Exception as e:  # requests.exceptions.ConnectionError
+            logger.info(
+                "Downloading {} from {} failed {} times with exception {}".
+                format(fname, url, retry_cnt + 1, str(e)))
+            time.sleep(1)
+            continue
+
         if req.status_code != 200:
             raise RuntimeError("Downloading from {} failed with code "
                                "{}!".format(url, req.status_code))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- fix retry in download when exception occurs