### PR TITLE
Support control flow in DataParallel 

### DIFF
--- a/paddle/fluid/framework/distributed_strategy.proto
+++ b/paddle/fluid/framework/distributed_strategy.proto
@@ -172,7 +172,7 @@ message DistributedStrategy {
   optional bool fp16_allreduce = 25 [ default = false ];
   optional bool sharding = 26 [ default = false ];
   optional float last_comm_group_size_MB = 27 [ default = 1 ];
-  optional bool find_unused_parameters = 28 [ default = true ];
+  optional bool find_unused_parameters = 28 [ default = false ];
   optional bool tensor_parallel = 29 [ default = false ];
   optional bool without_graph_optimization = 30 [ default = false ];
 

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -297,7 +297,7 @@ Reducer::Reducer(const std::vector<std::shared_ptr<imperative::VarBase>> &vars,
       is_sparse_gradient_(is_sparse_gradient),
       parallel_ctx_(parallel_ctx),
       group_size_limits_(group_size_limits),
-      find_unused_vars_(find_unused_vars) {
+      find_unused_vars_each_step_(find_unused_vars) {
   VLOG(3) << "Start construct the Reducer ...";
   nrings_ = parallel_ctx->GetNRings();
   nranks_ = parallel_ctx->GetNRanks();
@@ -457,42 +457,8 @@ void Reducer::PrepareDeps(const std::unordered_set<GradOpNode *> &init_nodes) {
   }
 }
 
-// After each batch is calculated, the counter of each group(group.pending_)
-// and allreudce sequence counter(next_group_) will be cleaned up again.
-void Reducer::PrepareForBackward(
+void Reducer::TraverseBackwardGraph(
     const std::vector<std::shared_ptr<imperative::VarBase>> &outputs) {
-  VLOG(3) << "after forward, then reset count for backward.";
-  next_group_ = 0;
-  std::for_each(groups_.begin(), groups_.end(), [](Group &group) {
-    group.pending_ = group.variable_indices_.size();
-    group.sparse_contents_ = nullptr;
-  });
-
-  // reinitialize vars_marked_ready_ for next iteration
-  vars_marked_ready_.clear();
-  vars_marked_ready_.resize(vars_.size(), false);
-
-  PADDLE_ENFORCE_EQ(
-      groups_need_finalize_, false,
-      platform::errors::PreconditionNotMet(
-          "A serious error has occurred here. There may be several reasons: "
-          "1) Please note that all forward outputs derived from the module "
-          "parameters must participate in the calculation of losses and "
-          "subsequent gradient calculations. If not, the wrapper will hang, "
-          "waiting for autograd to generate gradients for these parameters. "
-          "you can use detach or stop_gradient to make the unused parameters "
-          "detached from the autograd graph. "
-          "2) Used multiple forwards and one backward. You may be able to wrap "
-          "multiple forwards in a model."));
-
-  // The first var to trigger the unused parameter
-  has_marked_unused_vars_ = false;
-  unused_vars_.clear();
-
-  if (!find_unused_vars_) {
-    return;
-  }
-
   node_deps_.clear();
   std::queue<std::shared_ptr<GradOpNode>> q;
   std::unordered_set<VariableWrapper *> var_visited;
@@ -554,22 +520,63 @@ void Reducer::PrepareForBackward(
               << "] is not used";
     }
   }
+}
 
-  if (unused_vars_.empty()) {
-    LOG_FIRST_N(WARNING, 1)
-        << "All parameters are involved in the backward pass. "
-           "It is recommended to set find_unused_parameters to False "
-           "to improve performance. However, if unused parameters "
-           "appear in subsequent iterative training, then an error "
-           "will occur. Please make it clear that in the subsequent "
-           "training, there will be no parameters that are not used "
-           "in the backward pass, and then set find_unused_parameters";
-  } else if (unused_vars_.size() == vars_.size()) {
-    LOG_FIRST_N(WARNING, 1)
-        << "There is no parameter in the device involved "
-           "in the backward calculation. If there are "
-           "parameters on other devices involved in the "
-           "backward, then a serious error will occur here.";
+// After each batch is calculated, the counter of each group(group.pending_)
+// and allreudce sequence counter(next_group_) will be cleaned up again.
+void Reducer::PrepareForBackward(
+    const std::vector<std::shared_ptr<imperative::VarBase>> &outputs) {
+  VLOG(3) << "after forward, then reset count for backward.";
+  next_group_ = 0;
+  std::for_each(groups_.begin(), groups_.end(), [](Group &group) {
+    group.pending_ = group.variable_indices_.size();
+    group.sparse_contents_ = nullptr;
+  });
+
+  // reinitialize vars_marked_ready_ for next iteration
+  vars_marked_ready_.clear();
+  vars_marked_ready_.resize(vars_.size(), false);
+
+  PADDLE_ENFORCE_EQ(
+      groups_need_finalize_, false,
+      platform::errors::PreconditionNotMet(
+          "A serious error has occurred here. There may be several reasons: "
+          "1) Please note that all forward outputs derived from the module "
+          "parameters must participate in the calculation of losses and "
+          "subsequent gradient calculations. If not, the wrapper will hang, "
+          "waiting for autograd to generate gradients for these parameters. "
+          "you can use detach or stop_gradient to make the unused parameters "
+          "detached from the autograd graph. "
+          "2) Used multiple forwards and one backward. You may be able to wrap "
+          "multiple forwards in a model."));
+
+  // The first var to trigger the unused parameter
+  has_marked_unused_vars_ = false;
+
+  if (find_unused_vars_once_ || find_unused_vars_each_step_) {
+    unused_vars_.clear();
+    TraverseBackwardGraph(outputs);
+    // only check once in first step
+    find_unused_vars_once_ = false;
+  }
+
+  if (find_unused_vars_each_step_) {
+    if (unused_vars_.empty()) {
+      LOG_FIRST_N(WARNING, 1)
+          << "All parameters are involved in the backward pass. "
+             "It is recommended to set find_unused_parameters to False "
+             "to improve performance. However, if unused parameters "
+             "appear in subsequent iterative training, then an error "
+             "will occur. Please make it clear that in the subsequent "
+             "training, there will be no parameters that are not used "
+             "in the backward pass, and then set find_unused_parameters";
+    } else if (unused_vars_.size() == vars_.size()) {
+      LOG_FIRST_N(WARNING, 1)
+          << "There is no parameter in the device involved "
+             "in the backward calculation. If there are "
+             "parameters on other devices involved in the "
+             "backward, then a serious error will occur here.";
+    }
   }
 }
 
@@ -595,13 +602,13 @@ void Reducer::AddDistHook(size_t var_index) {
 
   local_used_vars_[var_index] = 1;
 
-  // rebuild group when find_unused_vars_ is false
+  // rebuild group when find_unused_vars_each_step_ is false
   if (NeedRebuildGroup()) {
     rebuild_vars_.push_back(vars_[var_index]);
     rebuild_var_indices_.push_back(var_index);
   }
 
-  if (!has_marked_unused_vars_ && find_unused_vars_) {
+  if (!has_marked_unused_vars_) {
     has_marked_unused_vars_ = true;
     for (const auto &unused_index : unused_vars_) {
       MarkVarReady(unused_index, false);
@@ -943,7 +950,7 @@ void Reducer::FinalizeBackward() {
     InitializeGroups(group_indices_);
   }
 
-  if (find_unused_vars_) {
+  if (find_unused_vars_each_step_) {
 // TODO(liuyuhui) support xpu about Tensorcopy/TensorFromVector/TensorToVector
 #if defined(PADDLE_WITH_NCCL) || defined(PADDLE_WITH_RCCL)
     ProcessUnusedDenseVars();

--- a/paddle/fluid/imperative/reducer.cc
+++ b/paddle/fluid/imperative/reducer.cc
@@ -563,23 +563,23 @@ void Reducer::PrepareForBackward(
     find_unused_vars_once_ = false;
   }
 
-  if (find_unused_vars_each_step_) {
-    if (unused_vars_.empty()) {
-      LOG_FIRST_N(WARNING, 1)
-          << "All parameters are involved in the backward pass. "
-             "It is recommended to set find_unused_parameters to False "
-             "to improve performance. However, if unused parameters "
-             "appear in subsequent iterative training, then an error "
-             "will occur. Please make it clear that in the subsequent "
-             "training, there will be no parameters that are not used "
-             "in the backward pass, and then set find_unused_parameters";
-    } else if (unused_vars_.size() == vars_.size()) {
-      LOG_FIRST_N(WARNING, 1)
-          << "There is no parameter in the device involved "
-             "in the backward calculation. If there are "
-             "parameters on other devices involved in the "
-             "backward, then a serious error will occur here.";
-    }
+  if (find_unused_vars_each_step_ && unused_vars_.empty()) {
+    LOG_FIRST_N(WARNING, 1)
+        << "All parameters are involved in the backward pass. "
+           "It is recommended to set find_unused_parameters to False "
+           "to improve performance. However, if unused parameters "
+           "appear in subsequent iterative training, then an error "
+           "will occur. Please make it clear that in the subsequent "
+           "training, there will be no parameters that are not used "
+           "in the backward pass, and then set find_unused_parameters";
+  }
+
+  if (unused_vars_.size() == vars_.size()) {
+    LOG_FIRST_N(WARNING, 1)
+        << "There is no parameter in the device involved "
+           "in the backward calculation. If there are "
+           "parameters on other devices involved in the "
+           "backward, then a serious error will occur here.";
   }
 }
 

--- a/paddle/fluid/imperative/reducer.h
+++ b/paddle/fluid/imperative/reducer.h
@@ -162,12 +162,15 @@ class Reducer {
   std::vector<std::vector<size_t>> RebuildGruops();
 
   inline bool NeedRebuildGroup() {
-    return !has_rebuilt_group_ && !find_unused_vars_;
+    return !has_rebuilt_group_ && !find_unused_vars_each_step_;
   }
 
   void ProcessUnusedDenseVars();
 
   bool HasGrad(size_t var_index);
+
+  void TraverseBackwardGraph(
+      const std::vector<std::shared_ptr<imperative::VarBase>>& outputs);
 
  private:
   std::vector<std::shared_ptr<imperative::VarBase>> vars_;
@@ -195,7 +198,8 @@ class Reducer {
   std::unordered_map<VariableWrapper*, size_t> var_index_map_;
   std::vector<size_t> unused_vars_;
   bool has_marked_unused_vars_{false};
-  bool find_unused_vars_{false};
+  bool find_unused_vars_each_step_{false};
+  bool find_unused_vars_once_{true};
   bool groups_need_finalize_{false};
 #ifdef PADDLE_WITH_XPU_BKCL
   // comm_pool_ is used for scheduling allreduce in multi Kunlun cards training.

--- a/python/paddle/distributed/fleet/base/distributed_strategy.py
+++ b/python/paddle/distributed/fleet/base/distributed_strategy.py
@@ -626,7 +626,7 @@ class DistributedStrategy(object):
         Indicating whether we are using find_unused_parameters to 
         find unused parameters in DataParallel.
 
-        Default value: True
+        Default value: False
 
         Examples:
 

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -424,7 +424,8 @@ class DataParallel(layers.Layer):
 
     Examples:
         .. code-block:: python
-
+        
+            # required: distributed
             import paddle
             import paddle.nn as nn
             import paddle.optimizer as opt

--- a/python/paddle/fluid/dygraph/parallel.py
+++ b/python/paddle/fluid/dygraph/parallel.py
@@ -417,7 +417,7 @@ class DataParallel(layers.Layer):
                                                 Note that setting the find_unused_parameters to True 
                                                 will affect computing performance. Therefore, if all parameters
                                                 are sure to participate in the loss calculation and the 
-                                                autograd graph construction, please set it False. Default: True.
+                                                autograd graph construction, please set it False. Default: False.
             
     Returns:
         Layer: The data paralleled module.
@@ -474,7 +474,7 @@ class DataParallel(layers.Layer):
                  strategy=None,
                  comm_buffer_size=25,
                  last_comm_buffer_size=1,
-                 find_unused_parameters=True):
+                 find_unused_parameters=False):
         super(DataParallel,
               self).__init__(layers.full_name() + "_data_parallel")
 
@@ -576,12 +576,8 @@ class DataParallel(layers.Layer):
     def forward(self, *inputs, **kwargs):
         outputs = self._layers(*inputs, **kwargs)
         if self._strategy.nranks > 1 and framework._dygraph_tracer()._has_grad:
-            if self.find_unused_parameters:
-                self._reducer.prepare_for_backward(
-                    list(self._find_varbase(outputs)))
-            else:
-                self._reducer.prepare_for_backward(list(self._find_varbase([])))
-
+            self._reducer.prepare_for_backward(
+                list(self._find_varbase(outputs)))
         return outputs
 
     @deprecated(

--- a/python/paddle/fluid/tests/unittests/parallel_dygraph_gradient_check.py
+++ b/python/paddle/fluid/tests/unittests/parallel_dygraph_gradient_check.py
@@ -74,8 +74,8 @@ class TestDistTraning(unittest.TestCase):
         state_dict = model_a.state_dict()
         model_b.set_state_dict(state_dict)
 
-        model_a = paddle.DataParallel(model_a)
-        model_b = paddle.DataParallel(model_b)
+        model_a = paddle.DataParallel(model_a, find_unused_parameters=True)
+        model_b = paddle.DataParallel(model_b, find_unused_parameters=True)
 
         ones_input = paddle.ones(shape=(batch, in_dim))
         ones_input.stop_gradient = True

--- a/python/paddle/fluid/tests/unittests/spawn_runner_base.py
+++ b/python/paddle/fluid/tests/unittests/spawn_runner_base.py
@@ -27,6 +27,7 @@ from test_dist_base import RUN_STEP
 class SpawnAssistTestArgs(object):
     update_method = "local"
     trainer_id = 0
+    find_unused_parameters = False
 
 
 class TestDistSpawnRunner(unittest.TestCase):

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -737,7 +737,7 @@ class TestDistBase(unittest.TestCase):
         self._save_model = False
         self._fuse_all_reduce = None
         self._accumulate_gradient = False
-        self._find_unused_parameters = True
+        self._find_unused_parameters = False
         self._setup_config()
 
         global DIST_UT_PORT

--- a/python/paddle/fluid/tests/unittests/test_dist_base.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_base.py
@@ -548,7 +548,10 @@ class TestParallelDyGraphRunnerBase(object):
         # 4. train model
         model, train_reader, opt = self.get_model()
         if args.update_method == "nccl2":
-            model = paddle.DataParallel(model)
+            if args.find_unused_parameters:
+                model = paddle.DataParallel(model, find_unused_parameters=True)
+            else:
+                model = paddle.DataParallel(model, find_unused_parameters=False)
 
         out_losses = []
         for step_id, data in enumerate(train_reader()):
@@ -581,8 +584,8 @@ class TestParallelDyGraphRunnerBase(object):
 
         # set strategy
         strategy = fleet.DistributedStrategy()
-        if not args.find_unused_parameters:
-            strategy.find_unused_parameters = False
+        if args.find_unused_parameters:
+            strategy.find_unused_parameters = True
 
         # 3. init parallel env
         if args.update_method == "nccl2" or "bkcl":

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_control_flow.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_control_flow.py
@@ -30,6 +30,7 @@ class TestDygraphControlFlowSame(TestDistBase):
         self._sync_mode = False
         self._nccl2_mode = True
         self._dygraph = True
+        self._find_unused_parameters = True
 
     def test_net(self):
         if fluid.core.is_compiled_with_cuda():
@@ -46,6 +47,7 @@ class TestFleetDygraphControlFlowSame(TestDygraphControlFlowSame):
         self._nccl2_mode = True
         self._dygraph = True
         self._use_fleet_api = True
+        self._find_unused_parameters = True
 
 
 class TestFleetDygraphControlFlowSameAccGrad(TestDygraphControlFlowSame):
@@ -54,6 +56,7 @@ class TestFleetDygraphControlFlowSameAccGrad(TestDygraphControlFlowSame):
         self._nccl2_mode = True
         self._dygraph = True
         self._accumulate_gradient = True
+        self._find_unused_parameters = True
 
 
 class TestDygraphControlFlowDiff(TestDistBase):
@@ -61,6 +64,7 @@ class TestDygraphControlFlowDiff(TestDistBase):
         self._sync_mode = False
         self._nccl2_mode = True
         self._dygraph = True
+        self._find_unused_parameters = True
 
     def test_net(self):
         if fluid.core.is_compiled_with_cuda():
@@ -77,6 +81,7 @@ class TestFleetDygraphControlFlowDiff(TestDygraphControlFlowDiff):
         self._nccl2_mode = True
         self._dygraph = True
         self._use_fleet_api = True
+        self._find_unused_parameters = True
 
 
 class TestFleetDygraphControlFlowDiffAccGrad(TestDygraphControlFlowDiff):
@@ -85,6 +90,7 @@ class TestFleetDygraphControlFlowDiffAccGrad(TestDygraphControlFlowDiff):
         self._nccl2_mode = True
         self._dygraph = True
         self._accumulate_gradient = True
+        self._find_unused_parameters = True
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_mnist.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_mnist.py
@@ -31,6 +31,7 @@ class TestParallelDygraphMnist(TestDistBase):
         self._sync_mode = False
         self._nccl2_mode = True
         self._dygraph = True
+        self._find_unused_parameters = True
 
     def test_mnist(self):
         if fluid.core.is_compiled_with_cuda():

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_unused_variables.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_unused_variables.py
@@ -41,50 +41,50 @@ class TestParallelDygraphUnusedVar(TestDistBase):
                 log_name=flag_name)
 
 
-class TestFleetDygraphUnusedVar(TestParallelDygraphUnusedVar):
-    def _setup_config(self):
-        self._sync_mode = False
-        self._nccl2_mode = True
-        self._dygraph = True
-        self._use_fleet_api = True
-
-
-class TestSparseEmbeddingUnusedVarsSpawn(TestDistSpawnRunner):
-    def test_mnist_with_spawn(self):
-        if fluid.core.is_compiled_with_cuda() and sys.version_info >= (3, 4):
-            self.check_dist_result_with_spawn(
-                test_class=TestSparseEmbeddingUnusedVars, delta=1e-5)
-
-
-class TestParallelDygraphNoVar(TestDistBase):
-    def _setup_config(self):
-        self._sync_mode = False
-        self._nccl2_mode = True
-        self._dygraph = True
-
-    def test_net(self):
-        if fluid.core.is_compiled_with_cuda():
-            self.check_with_place(
-                "parallel_dygraph_none_var.py",
-                delta=1e-5,
-                check_error_log=True,
-                log_name=flag_name)
-
-
-class TestParallelDygraphSharedUnusedVariables(TestDistBase):
-    def _setup_config(self):
-        self._sync_mode = False
-        self._nccl2_mode = True
-        self._dygraph = True
-
-    def test_mnist(self):
-        if fluid.core.is_compiled_with_cuda():
-            self.check_with_place(
-                "parallel_dygraph_shared_unused_var.py",
-                delta=1e-5,
-                check_error_log=True,
-                log_name=flag_name)
-
+#class TestFleetDygraphUnusedVar(TestParallelDygraphUnusedVar):
+#    def _setup_config(self):
+#        self._sync_mode = False
+#        self._nccl2_mode = True
+#        self._dygraph = True
+#        self._use_fleet_api = True
+#
+#
+#class TestSparseEmbeddingUnusedVarsSpawn(TestDistSpawnRunner):
+#    def test_mnist_with_spawn(self):
+#        if fluid.core.is_compiled_with_cuda() and sys.version_info >= (3, 4):
+#            self.check_dist_result_with_spawn(
+#                test_class=TestSparseEmbeddingUnusedVars, delta=1e-5)
+#
+#
+#class TestParallelDygraphNoVar(TestDistBase):
+#    def _setup_config(self):
+#        self._sync_mode = False
+#        self._nccl2_mode = True
+#        self._dygraph = True
+#
+#    def test_net(self):
+#        if fluid.core.is_compiled_with_cuda():
+#            self.check_with_place(
+#                "parallel_dygraph_none_var.py",
+#                delta=1e-5,
+#                check_error_log=True,
+#                log_name=flag_name)
+#
+#
+#class TestParallelDygraphSharedUnusedVariables(TestDistBase):
+#    def _setup_config(self):
+#        self._sync_mode = False
+#        self._nccl2_mode = True
+#        self._dygraph = True
+#
+#    def test_mnist(self):
+#        if fluid.core.is_compiled_with_cuda():
+#            self.check_with_place(
+#                "parallel_dygraph_shared_unused_var.py",
+#                delta=1e-5,
+#                check_error_log=True,
+#                log_name=flag_name)
+#
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_parallel_dygraph_unused_variables.py
+++ b/python/paddle/fluid/tests/unittests/test_parallel_dygraph_unused_variables.py
@@ -41,50 +41,50 @@ class TestParallelDygraphUnusedVar(TestDistBase):
                 log_name=flag_name)
 
 
-#class TestFleetDygraphUnusedVar(TestParallelDygraphUnusedVar):
-#    def _setup_config(self):
-#        self._sync_mode = False
-#        self._nccl2_mode = True
-#        self._dygraph = True
-#        self._use_fleet_api = True
-#
-#
-#class TestSparseEmbeddingUnusedVarsSpawn(TestDistSpawnRunner):
-#    def test_mnist_with_spawn(self):
-#        if fluid.core.is_compiled_with_cuda() and sys.version_info >= (3, 4):
-#            self.check_dist_result_with_spawn(
-#                test_class=TestSparseEmbeddingUnusedVars, delta=1e-5)
-#
-#
-#class TestParallelDygraphNoVar(TestDistBase):
-#    def _setup_config(self):
-#        self._sync_mode = False
-#        self._nccl2_mode = True
-#        self._dygraph = True
-#
-#    def test_net(self):
-#        if fluid.core.is_compiled_with_cuda():
-#            self.check_with_place(
-#                "parallel_dygraph_none_var.py",
-#                delta=1e-5,
-#                check_error_log=True,
-#                log_name=flag_name)
-#
-#
-#class TestParallelDygraphSharedUnusedVariables(TestDistBase):
-#    def _setup_config(self):
-#        self._sync_mode = False
-#        self._nccl2_mode = True
-#        self._dygraph = True
-#
-#    def test_mnist(self):
-#        if fluid.core.is_compiled_with_cuda():
-#            self.check_with_place(
-#                "parallel_dygraph_shared_unused_var.py",
-#                delta=1e-5,
-#                check_error_log=True,
-#                log_name=flag_name)
-#
+class TestFleetDygraphUnusedVar(TestParallelDygraphUnusedVar):
+    def _setup_config(self):
+        self._sync_mode = False
+        self._nccl2_mode = True
+        self._dygraph = True
+        self._use_fleet_api = True
+
+
+class TestSparseEmbeddingUnusedVarsSpawn(TestDistSpawnRunner):
+    def test_mnist_with_spawn(self):
+        if fluid.core.is_compiled_with_cuda() and sys.version_info >= (3, 4):
+            self.check_dist_result_with_spawn(
+                test_class=TestSparseEmbeddingUnusedVars, delta=1e-5)
+
+
+class TestParallelDygraphNoVar(TestDistBase):
+    def _setup_config(self):
+        self._sync_mode = False
+        self._nccl2_mode = True
+        self._dygraph = True
+
+    def test_net(self):
+        if fluid.core.is_compiled_with_cuda():
+            self.check_with_place(
+                "parallel_dygraph_none_var.py",
+                delta=1e-5,
+                check_error_log=True,
+                log_name=flag_name)
+
+
+class TestParallelDygraphSharedUnusedVariables(TestDistBase):
+    def _setup_config(self):
+        self._sync_mode = False
+        self._nccl2_mode = True
+        self._dygraph = True
+
+    def test_mnist(self):
+        if fluid.core.is_compiled_with_cuda():
+            self.check_with_place(
+                "parallel_dygraph_shared_unused_var.py",
+                delta=1e-5,
+                check_error_log=True,
+                log_name=flag_name)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
动态图关于unused_parameters主要有以下四个情况。

**情况1，无unused_parameters**
动态图组网中，没有使用stop_gradient/detach 或没有声明额外的参数，即动态图全局声明的参数，训练过程中都会产生梯度，如下组网：
```python
class SimpleDPNet(fluid.dygraph.Layer):
    def __init__(self, vocab_size, hidden_size, inner_size, output_size):
        super(SimpleDPNet, self).__init__()
        self.linear1 = paddle.nn.Linear(hidden_size, inner_size)
        self.linear2 = paddle.nn.Linear(inner_size, hidden_size)
        self.linear3 = paddle.nn.Linear(hidden_size, output_size)
        self.embedding = paddle.nn.Embedding(vocab_size, hidden_size))

    def forward(self, x):
        x = self.embedding(x)
        x = self.linear1(x)
        x = self.linear2(x)
        x = self.linear3(x)
        return x.mean()
```

**情况2，有unused_parameters，计算无控制流**
动态图组网中，全局声明了参数但实际计算没有使用，或者使用stop_gradient/detach/trainable 导致部分参数没有产生梯度，如下组网：

```python
class SimpleDPNet(fluid.dygraph.Layer):
    def __init__(self, vocab_size, hidden_size, inner_size, output_size):
        super(SimpleDPNet, self).__init__()
        self.linear1 = paddle.nn.Linear(hidden_size, inner_size)
        self.linear2 = paddle.nn.Linear(inner_size, hidden_size)
        self.linear3 = paddle.nn.Linear(hidden_size, output_size)
        self.embedding = paddle.nn.Embedding(vocab_size, hidden_size))
       
        # 该layer不参与前向计算，因此该layer中的w，b将不会产生梯度
        self.tmp = paddle.nn.Linear(hidden_size, output_size)

    def forward(self, x):
        x = self.embedding(x)
        x = self.linear1(x)

        # 计算使用stop_gradient，导致linear1 中的w，b不产生梯度, embedding 不产生梯度。
        x.stop_gradient = True
        x = self.linear2(x)
        x = self.linear3(x)
        return x.mean()
```

**情况3，与计算step相关的控制流**
计算过程中，会根据step，调整参数的训练。比如部分Gan网络。

```python
class SimpleDPNet(fluid.dygraph.Layer):
    def __init__(self, vocab_size, hidden_size, inner_size, output_size):
        super(SimpleDPNet, self).__init__()
        self.linear1 = paddle.nn.Linear(hidden_size, inner_size)
        self.linear2 = paddle.nn.Linear(inner_size, hidden_size)
        self.linear3 = paddle.nn.Linear(hidden_size, output_size)
        self.embedding = paddle.nn.Embedding(vocab_size, hidden_size))

    def forward(self, x, step):
        x = self.embedding(x)
        x = self.linear1(x)
        if step > 10:
            # 当step大于10时，linear1 中的w，b不产生梯度， embedding不产生梯度。
            x.stop_gradient = True

        x = self.linear2(x)
        x = self.linear3(x)
        return x.mean()
```

**情况4，与数据输入相关的控制流**
计算过程中，会根据数据的输入，调整输出。比如数据存在脏数据。

```python
class SimpleDPNet(fluid.dygraph.Layer):
    def __init__(self, vocab_size, hidden_size, inner_size, output_size):
        super(SimpleDPNet, self).__init__()
        self.linear1 = paddle.nn.Linear(hidden_size, inner_size)
        self.linear2 = paddle.nn.Linear(inner_size, hidden_size)
        self.linear3 = paddle.nn.Linear(hidden_size, output_size)
        self.embedding = paddle.nn.Embedding(vocab_size, hidden_size))

    def forward(self, x):
        # 存在与数据相关的控制流，当x的和为0，则返回loss为0，所有参数均不产生梯度（分布式下，各个卡梯度不一致）。
        if paddle.sum(x) == 0:
            return 0

        x = self.embedding(x)
        x = self.linear1(x)
        x = self.linear2(x)
        x = self.linear3(x)
        return x.mean()
```

为了解决上述四个情况以及四个情况随机组合的情况，引入参数`find_unused_parameters`， 默认值为False。

1、当`find_unused_parameters=False`时，只会检查在第一个step检查，在前向后，反向前，检查反向图，找到第一个step中，所有的unused_parameter， 并认定以后所有的step中，unused_parameter的列表保持不变。对性能无影响，可以解决上述的情况1，2。

2、当`find_unused_parameters=True`时，每一个step都会进行检查，遍历反向图，会解决上述情况1，2，3，4。但对于情况1，2存在计算性能下降，不推荐设置其为True。

3、目前，如果
- 情况1下，设置`find_unused_parameters=True`，会报warning，提示性能下降。
- 情况3下，设置`find_unused_parameters=False`，则在训练过程中，会出core，提示开启该参数。
- 情况4下，设置`find_unused_parameters=False`，训练会hang，无法报错，需要用户发现并开启该参数。

4、对于情况4而言，由于数据相关的控制流，会导致某张卡一个参数都没有，从而一次梯度hook都不触发。这个情况除了需要设置`find_unused_parameters=True`，还需要添加一个假的叶子结点。需要如下修改：

```python
class SimpleDPNet(fluid.dygraph.Layer):
    def __init__(self, vocab_size, hidden_size, inner_size, output_size):
        super(SimpleDPNet, self).__init__()
        self.linear1 = paddle.nn.Linear(hidden_size, inner_size)
        self.linear2 = paddle.nn.Linear(inner_size, hidden_size)
        self.linear3 = paddle.nn.Linear(hidden_size, output_size)
        self.embedding = paddle.nn.Embedding(vocab_size, hidden_size))

        # 假的叶子结点
        self.phony = self.create_parameter(shape=[1], dtype="float32")

    def forward(self, x):
        # 存在与数据相关的控制流，当x的和为0，则返回loss为0，所有参数均不产生梯度（分布式下，各个卡梯度不一致）。
        if paddle.sum(x) == 0:
            return 0 * self.phony

        x = self.embedding(x)
        x = self.linear1(x)
        x = self.linear2(x)
        x = self.linear3(x)
        return x.mean()
```