### PR TITLE
fix histogram with empty tensor input, test=develop

### DIFF
--- a/paddle/fluid/operators/histogram_op.h
+++ b/paddle/fluid/operators/histogram_op.h
@@ -38,6 +38,11 @@ class HistogramKernel : public framework::OpKernel<T> {
     const T* input_data = input->data<T>();
     auto input_numel = input->numel();
 
+    if (input_data == nullptr) {
+      VLOG(3) << "no input! return";
+      return;
+    }
+
     T output_min = static_cast<T>(minval);
     T output_max = static_cast<T>(maxval);
     if (output_min == output_max) {


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes


### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

OPs

### Describe
<!-- Describe what this PR does -->

Fix histogram OP when input is an empty tensor. 

https://console.cloud.baidu-int.com/devops/icafe/issue/DLTP-27617/show?cid=5&from=email&noticeStatistics=58379443
