### PR TITLE
Rule validation of original ElementwiseBroadcast OPs

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_add_op.h
+++ b/paddle/fluid/operators/elementwise/elementwise_add_op.h
@@ -69,6 +69,33 @@ class ElementwiseAddKernel : public framework::OpKernel<T> {
     auto *z = ctx.Output<framework::LoDTensor>("Out");
     z->mutable_data<T>(ctx.GetPlace());
     auto dims_equal = x->dims() == y->dims();
+
+#if 1
+    int size = x->dims().size();
+    auto dim_size = x->dims();
+    std::cout << "x_shape : \t";
+    for (int i = 0; i < size; ++i) {
+      std::cout << dim_size[i] << "\t"; 
+    }
+    std::cout << std::endl;
+
+    size = y->dims().size();
+    dim_size = y->dims();
+    std::cout << "y_shape : \t";
+    for (int i = 0; i < size; ++i) {
+      std::cout << dim_size[i] << "\t"; 
+    }
+    std::cout << std::endl;
+
+    size = z->dims().size();
+    dim_size = z->dims();
+    std::cout << "out_shape : \t";
+    for (int i = 0; i < size; ++i) {
+      std::cout << dim_size[i] << "\t"; 
+    }
+    std::cout << std::endl;
+#endif
+
     if (dims_equal) {
       SameDimsElemwiseAdd<DeviceContext, T> same_dims_add;
       same_dims_add(ctx, x, y, z);

--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -1966,9 +1966,13 @@ void ElementwiseComputeEx(const framework::ExecutionContext &ctx,
     return;
   }
   if (post == 1) {
+    printf("[%s %s %d]: n = %d,\t pre = %d\n", 
+            __FILE__, __func__, __LINE__, n, pre);
     functor.RunRowWise(n, pre);
     return;
   } else {
+    printf("[%s %s %d]: n = %d,\t pre = %d,\t post = %d\n", 
+            __FILE__, __func__, __LINE__, n, pre, post);
     functor.RunMidWise(n, pre, post);
     return;
   }

--- a/python/paddle/fluid/tests/unittests/test_deform_conv2d.py
+++ b/python/paddle/fluid/tests/unittests/test_deform_conv2d.py
@@ -19,22 +19,21 @@ import numpy as np
 import unittest
 from unittest import TestCase
 
-
 class TestDeformConv2D(TestCase):
-    batch_size = 4
-    spatial_shape = (5, 5)
+    batch_size = 1
+    spatial_shape = (3, 3)
     dtype = "float32"
 
     def setUp(self):
-        self.in_channels = 2
-        self.out_channels = 5
+        self.in_channels = 1
+        self.out_channels = 3
         self.kernel_size = [3, 3]
-        self.padding = [0, 0]
+        self.padding = [1, 2]
         self.stride = [1, 1]
         self.dilation = [1, 1]
         self.deformable_groups = 1
         self.groups = 1
-        self.no_bias = True
+        self.no_bias = False
 
     def prepare(self):
         np.random.seed(1)
@@ -114,38 +113,20 @@ class TestDeformConv2D(TestCase):
                 bias_attr=False if self.no_bias else I.Assign(self.bias),
                 modulated=False)
 
-            y_v2 = paddle.fluid.layers.deformable_conv(
-                input=x,
-                offset=offset,
-                mask=mask,
-                num_filters=self.out_channels,
-                filter_size=self.filter_shape,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-                deformable_groups=self.deformable_groups,
-                im2col_step=1,
-                param_attr=I.Assign(self.weight),
-                bias_attr=False if self.no_bias else I.Assign(self.bias))
-
         exe = paddle.static.Executor(self.place)
         exe.run(start)
-        out_v1, out_v2 = exe.run(main,
-                                 feed={
-                                     "input": self.input,
-                                     "offset": self.offset,
-                                     "mask": self.mask
-                                 },
-                                 fetch_list=[y_v1, y_v2])
-        return out_v1, out_v2
+        out_v1 = exe.run(main,feed={
+                                    "input": self.input,
+                                    "offset": self.offset,
+                                    "mask": self.mask },
+                                fetch_list=[y_v1])
+        return out_v1
 
     def dygraph_case_dcn(self):
         paddle.disable_static()
         x = paddle.to_tensor(self.input)
         offset = paddle.to_tensor(self.offset)
         mask = paddle.to_tensor(self.mask)
-
         bias = None if self.no_bias else paddle.to_tensor(self.bias)
 
         deform_conv2d = paddle.vision.ops.DeformConv2D(
@@ -161,448 +142,23 @@ class TestDeformConv2D(TestCase):
             bias_attr=False if self.no_bias else I.Assign(self.bias))
 
         y_v1 = deform_conv2d(x, offset)
-        y_v2 = deform_conv2d(x, offset, mask)
-
         out_v1 = y_v1.numpy()
-        out_v2 = y_v2.numpy()
 
-        return out_v1, out_v2
+        return out_v1
 
     def _test_identity(self):
         self.prepare()
-        static_dcn_v1, static_dcn_v2 = self.static_graph_case_dcn()
-        dy_dcn_v1, dy_dcn_v2 = self.dygraph_case_dcn()
+        static_dcn_v1 = self.static_graph_case_dcn()
+        dy_dcn_v1 = self.dygraph_case_dcn()
+        
+        print(">> static_dcn_v1 : \n", static_dcn_v1)
+        print(">> dy_dcn_v1 : \n", dy_dcn_v1)
+
         np.testing.assert_array_almost_equal(static_dcn_v1, dy_dcn_v1)
-        np.testing.assert_array_almost_equal(static_dcn_v2, dy_dcn_v2)
 
     def test_identity(self):
         self.place = paddle.CPUPlace()
         self._test_identity()
-
-        if paddle.is_compiled_with_cuda():
-            self.place = paddle.CUDAPlace(0)
-            self._test_identity()
-
-
-class TestDeformConv2DFunctional(TestCase):
-    batch_size = 4
-    spatial_shape = (5, 5)
-    dtype = "float32"
-
-    def setUp(self):
-        self.in_channels = 2
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [0, 0]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = True
-
-    def prepare(self):
-        np.random.seed(1)
-        paddle.seed(1)
-        if isinstance(self.kernel_size, int):
-            filter_shape = (self.kernel_size, ) * 2
-        else:
-            filter_shape = tuple(self.kernel_size)
-        self.filter_shape = filter_shape
-
-        self.weight = np.random.uniform(
-            -1, 1, (self.out_channels, self.in_channels // self.groups
-                    ) + filter_shape).astype(self.dtype)
-        if not self.no_bias:
-            self.bias = np.random.uniform(-1, 1, (
-                self.out_channels, )).astype(self.dtype)
-
-        def out_size(in_size, pad_size, dilation_size, kernel_size,
-                     stride_size):
-            return (in_size + 2 * pad_size -
-                    (dilation_size * (kernel_size - 1) + 1)) / stride_size + 1
-
-        out_h = int(
-            out_size(self.spatial_shape[0], self.padding[0], self.dilation[0],
-                     self.kernel_size[0], self.stride[0]))
-        out_w = int(
-            out_size(self.spatial_shape[1], self.padding[1], self.dilation[1],
-                     self.kernel_size[1], self.stride[1]))
-        out_shape = (out_h, out_w)
-
-        self.input_shape = (self.batch_size, self.in_channels
-                            ) + self.spatial_shape
-
-        self.offset_shape = (self.batch_size, self.deformable_groups * 2 *
-                             filter_shape[0] * filter_shape[1]) + out_shape
-
-        self.mask_shape = (self.batch_size, self.deformable_groups *
-                           filter_shape[0] * filter_shape[1]) + out_shape
-
-        self.input = np.random.uniform(-1, 1,
-                                       self.input_shape).astype(self.dtype)
-
-        self.offset = np.random.uniform(-1, 1,
-                                        self.offset_shape).astype(self.dtype)
-
-        self.mask = np.random.uniform(-1, 1, self.mask_shape).astype(self.dtype)
-
-    def static_graph_case_dcn(self):
-        main = paddle.static.Program()
-        start = paddle.static.Program()
-        paddle.enable_static()
-        with paddle.static.program_guard(main, start):
-            x = paddle.static.data(
-                "input", (-1, self.in_channels, -1, -1), dtype=self.dtype)
-            offset = paddle.static.data(
-                "offset", (-1, self.deformable_groups * 2 *
-                           self.filter_shape[0] * self.filter_shape[1], -1, -1),
-                dtype=self.dtype)
-            mask = paddle.static.data(
-                "mask", (-1, self.deformable_groups * self.filter_shape[0] *
-                         self.filter_shape[1], -1, -1),
-                dtype=self.dtype)
-
-            y_v1 = paddle.fluid.layers.deformable_conv(
-                input=x,
-                offset=offset,
-                mask=None,
-                num_filters=self.out_channels,
-                filter_size=self.filter_shape,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-                deformable_groups=self.deformable_groups,
-                im2col_step=1,
-                param_attr=I.Assign(self.weight),
-                bias_attr=False if self.no_bias else I.Assign(self.bias),
-                modulated=False)
-
-            y_v2 = paddle.fluid.layers.deformable_conv(
-                input=x,
-                offset=offset,
-                mask=mask,
-                num_filters=self.out_channels,
-                filter_size=self.filter_shape,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                groups=self.groups,
-                deformable_groups=self.deformable_groups,
-                im2col_step=1,
-                param_attr=I.Assign(self.weight),
-                bias_attr=False if self.no_bias else I.Assign(self.bias))
-
-        exe = paddle.static.Executor(self.place)
-        exe.run(start)
-        out_v1, out_v2 = exe.run(main,
-                                 feed={
-                                     "input": self.input,
-                                     "offset": self.offset,
-                                     "mask": self.mask
-                                 },
-                                 fetch_list=[y_v1, y_v2])
-        return out_v1, out_v2
-
-    def dygraph_case_dcn(self):
-        paddle.disable_static()
-        x = paddle.to_tensor(self.input)
-        offset = paddle.to_tensor(self.offset)
-        mask = paddle.to_tensor(self.mask)
-        weight = paddle.to_tensor(self.weight)
-        bias = None if self.no_bias else paddle.to_tensor(self.bias)
-
-        y_v1 = paddle.vision.ops.deform_conv2d(
-            x=x,
-            offset=offset,
-            weight=weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=self.dilation,
-            deformable_groups=self.deformable_groups,
-            groups=self.groups, )
-
-        y_v2 = paddle.vision.ops.deform_conv2d(
-            x=x,
-            offset=offset,
-            mask=mask,
-            weight=weight,
-            bias=bias,
-            stride=self.stride,
-            padding=self.padding,
-            dilation=self.dilation,
-            deformable_groups=self.deformable_groups,
-            groups=self.groups, )
-
-        out_v1 = y_v1.numpy()
-        out_v2 = y_v2.numpy()
-
-        return out_v1, out_v2
-
-    def new_api_static_graph_case_dcn(self):
-        main = paddle.static.Program()
-        start = paddle.static.Program()
-        paddle.enable_static()
-        with paddle.static.program_guard(main, start):
-            x = paddle.static.data(
-                "input", (-1, self.in_channels, -1, -1), dtype=self.dtype)
-            offset = paddle.static.data(
-                "offset", (-1, self.deformable_groups * 2 *
-                           self.filter_shape[0] * self.filter_shape[1], -1, -1),
-                dtype=self.dtype)
-            mask = paddle.static.data(
-                "mask", (-1, self.deformable_groups * self.filter_shape[0] *
-                         self.filter_shape[1], -1, -1),
-                dtype=self.dtype)
-
-            weight = paddle.static.data(
-                "weight", list(self.weight.shape), dtype=self.dtype)
-
-            if not self.no_bias:
-                bias = paddle.static.data("bias", [-1], dtype=self.dtype)
-
-            y_v1 = paddle.vision.ops.deform_conv2d(
-                x=x,
-                offset=offset,
-                weight=weight,
-                bias=None if self.no_bias else bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                deformable_groups=self.deformable_groups,
-                groups=self.groups, )
-
-            y_v2 = paddle.vision.ops.deform_conv2d(
-                x=x,
-                offset=offset,
-                mask=mask,
-                weight=weight,
-                bias=None if self.no_bias else bias,
-                stride=self.stride,
-                padding=self.padding,
-                dilation=self.dilation,
-                deformable_groups=self.deformable_groups,
-                groups=self.groups, )
-
-        exe = paddle.static.Executor(self.place)
-        exe.run(start)
-        feed_dict = {
-            "input": self.input,
-            "offset": self.offset,
-            "mask": self.mask,
-            "weight": self.weight
-        }
-        if not self.no_bias:
-            feed_dict["bias"] = self.bias
-
-        out_v1, out_v2 = exe.run(main, feed=feed_dict, fetch_list=[y_v1, y_v2])
-        return out_v1, out_v2
-
-    def _test_identity(self):
-        self.prepare()
-        static_dcn_v1, static_dcn_v2 = self.static_graph_case_dcn()
-        dy_dcn_v1, dy_dcn_v2 = self.dygraph_case_dcn()
-        new_static_dcn_v1, new_static_dcn_v2 = self.new_api_static_graph_case_dcn(
-        )
-        np.testing.assert_array_almost_equal(static_dcn_v1, dy_dcn_v1)
-        np.testing.assert_array_almost_equal(static_dcn_v2, dy_dcn_v2)
-        np.testing.assert_array_almost_equal(static_dcn_v1, new_static_dcn_v1)
-        np.testing.assert_array_almost_equal(static_dcn_v2, new_static_dcn_v2)
-
-    def test_identity(self):
-        self.place = paddle.CPUPlace()
-        self._test_identity()
-
-        if paddle.is_compiled_with_cuda():
-            self.place = paddle.CUDAPlace(0)
-            self._test_identity()
-
-
-# testcases for DeformConv2D
-class TestDeformConv2DWithPadding(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [2, 2]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = True
-
-
-class TestDeformConv2DWithBias(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [2, 2]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DWithAsynPadding(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 2]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DWithDilation(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [1, 1]
-        self.dilation = [3, 3]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DWithStride(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [2, 2]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DWithDeformable_Groups(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 5
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 5
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DWithGroups(TestDeformConv2D):
-    def setUp(self):
-        self.in_channels = 5
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 5
-        self.no_bias = False
-
-
-# testcases for deform_conv2d
-class TestDeformConv2DFunctionalWithPadding(TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [2, 2]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = True
-
-
-class TestDeformConv2DFunctionalWithBias(TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [2, 2]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DFunctionalWithAsynPadding(TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 2]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DFunctionalWithDilation(TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [1, 1]
-        self.dilation = [3, 3]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DFunctionalWithStride(TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 3
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [2, 2]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DFunctionalWithDeformable_Groups(
-        TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 5
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 5
-        self.groups = 1
-        self.no_bias = False
-
-
-class TestDeformConv2DFunctionalWithGroups(TestDeformConv2DFunctional):
-    def setUp(self):
-        self.in_channels = 5
-        self.out_channels = 5
-        self.kernel_size = [3, 3]
-        self.padding = [1, 1]
-        self.stride = [1, 1]
-        self.dilation = [1, 1]
-        self.deformable_groups = 1
-        self.groups = 5
-        self.no_bias = False
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/paddle/vision/ops.py
+++ b/python/paddle/vision/ops.py
@@ -536,6 +536,8 @@ def deform_conv2d(x,
             op_type = 'deformable_conv'
             pre_bias = getattr(core.ops, op_type)(x, offset, mask, weight,
                                                   *attrs)
+        print("dygraph Conv_data :\n", pre_bias, '\n')
+        print("dygraph Bias_data :\n", bias, '\n')
         if bias is not None:
             out = nn.elementwise_add(pre_bias, bias, axis=1)
         else:


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
1. Refection of the broadcast rule in develop Paddle.

- 输入 X-tensor (Conv Result):
 
Tensor(shape=[1, 3, 3, 5], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
      

      [[[[-0.02773470,  0.28801087, -0.11862200, -0.28052723,  0.29502571],
          [-0.52502304,  0.49446532, -0.42347118,  0.36837575,  0.24079730],
          [-0.59300148, -0.42739153, -1.15861952,  0.03842974,  0.18261476]],

         [[ 0.00396886,  0.04118913, -0.03734507,  0.05420965, -0.09398693],
          [-0.51070756, -1.22400403, -0.62318528, -0.46624115, -0.28336984],
          [ 0.20690466,  0.17913647, -0.26698101, -0.50789368, -0.07325396]],

         [[ 0.01762870, -0.57170320,  0.72545052,  0.58496952, -0.90632206],
          [ 0.23178613,  0.30585194,  1.77061105, -0.56537664, -0.18101463],
          [ 0.35567763,  0.00622760,  0.55688083,  0.76428586, -0.25850302]]]]) 

- 输入 Y-tensor (Bias data):
  
Parameter containing:
 Tensor(shape=[3], dtype=float32, place=CUDAPlace(0), stop_gradient=False,
        
      [-0.92189044, -0.66033918,  0.75628501]) 

- 静态图计算结果 : 

      [[[[-0.94962513, -0.63387954, -1.0405124 , -1.2024176 , -0.6268647 ],
          [-1.4469135 , -0.42742512, -1.3453616 , -0.5535146 , -0.68109316],
          [-1.5148919 , -1.349282  , -2.08051   , -0.8834607 , -0.7392757 ]],

         [[-0.65637034, -0.61915004, -0.6976842 , -0.6061295 , -0.7543261 ],
          [-1.1710467 , -1.8843431 , -1.2835245 , -1.1265802 , -0.943709  ],
          [-0.45343453, -0.48120272, -0.9273202 , -1.1682329 , -0.7335931 ]],

         [[ 0.77391374,  0.18458176,  1.4817356 ,  1.3412545 , -0.15003705],
          [ 0.98807114,  1.0621369 ,  2.526896  ,  0.19090837, 0.57527035],
          [ 1.1119627 ,  0.7625126 ,  1.3131659 ,  1.5205709 , 0.49778196]]]],

-  动态图计算结果 : 

     [[[[-0.94962513, -0.63387954, -1.0405124,  -1.2024176,  -0.62686473],
          [-1.4469135,  -0.42742512, -1.3453616,  -0.5535147,  -0.68109316],
          [-1.5148919, -1.349282,   -2.08051,   -0.8834607,  -0.7392757 ]],

         [[-0.65637034, -0.61915004, -0.6976842,  -0.6061295, -0.7543261 ],
          [-1.1710467,  -1.8843431,  -1.2835245,  -1.1265804,  -0.943709  ],
          [-0.45343453, -0.48120272, -0.9273202,  -1.1682329,  -0.7335931 ]],

        [[ 0.7739137,   0.18458182,  1.4817355,   1.3412545,  -0.15003705],
          [ 0.98807114,  1.0621369,   2.526896,    0.19090837,  0.5752704 ],
          [ 1.1119627,   0.7625126,   1.3131659,   1.5205709,   0.497782  ]]]],
 

- 总结: ElementBroadcast规则会将 [1, 3, 3, 5]  + [3] 计算调整称为  [1, 3, 3, 5]  + [1, 3, 1, 1]的计算 ，向最高同值维度广播