### PR TITLE
roll optimize #32852

### DIFF
--- a/paddle/fluid/operators/roll_op.cc
+++ b/paddle/fluid/operators/roll_op.cc
@@ -37,10 +37,13 @@ class RollOp : public framework::OperatorWithKernel {
     auto dims = ctx->Attrs().Get<std::vector<int64_t>>("axis");
     auto shifts = ctx->Attrs().Get<std::vector<int64_t>>("shifts");
 
-    PADDLE_ENFORCE_EQ(dims.size(), shifts.size(),
+    PADDLE_ENFORCE_EQ(dims.size() == shifts.size() ||
+                          (dims.size() == 0 && shifts.size() == 1),
+                      true,
                       platform::errors::InvalidArgument(
                           "Attr(dims).size() should be equl to "
-                          "Attr(shifts).size(). But received "
+                          "Attr(shifts).size() or Attr(dims).size() = 0 "
+                          "Attr(shifts).size() = 1. But received "
                           "Attr(dims).size() = %d, Attr(shifts).size() = %d",
                           dims.size(), shifts.size()));
 
@@ -92,10 +95,7 @@ class RollOpMaker : public framework::OpProtoAndCheckerMaker {
                                   "The number of places by which the elements "
                                   "of the tensor are shifted.")
         .SetDefault({});
-    AddAttr<std::vector<int64_t>>(
-        "axis",
-        "Axis along which to roll. It must have the same size "
-        "with shifts.")
+    AddAttr<std::vector<int64_t>>("axis", "Axis along which to roll.")
         .SetDefault({});
     AddComment(R"DOC(
     Roll the tensor along the given dimension(s). 
@@ -151,8 +151,10 @@ REGISTER_OP_VERSION(roll)
         paddle::framework::compatible::OpVersionDesc()
             .NewAttr("axis",
                      "(std::vector<int64_t>) Axis along which to roll. "
-                     "It must have the same size with shifts.",
+                     "if size = 0, it means reshape as 1-D and roll along with "
+                     "axis = 0",
                      std::vector<int64_t>())
             .DeleteAttr("dims",
                         "(std::vector<int64_t>) Dims along which to roll. "
-                        "It must have the same size with shifts."));
+                        "if size = 0, it means reshape as 1-D and roll along "
+                        "with axis = 0"));

--- a/paddle/fluid/operators/roll_op.cu
+++ b/paddle/fluid/operators/roll_op.cu
@@ -80,9 +80,13 @@ class RollCUDAKernel : public framework::OpKernel<T> {
     auto stride_dim = framework::stride(input_dim);
 
     if (nums == 1) {
-      int64_t dim_idx = dims[0];
-      int64_t size = stride_dim[dim_idx];
-      int64_t dim_size = input_dim[dim_idx];
+      int64_t size = 1;
+      int64_t dim_size = numel;
+      if (dims.size() > 0) {
+        int64_t dim_idx = dims[0] >= 0 ? dims[0] : dims[0] + input_dim.size();
+        size = stride_dim[dim_idx];
+        dim_size = input_dim[dim_idx];
+      }
       // shift > 0
       int64_t shift = shifts[0] > 0 ? (shifts[0] % dim_size)
                                     : (shifts[0] % dim_size + dim_size);
@@ -155,9 +159,13 @@ class RollGradCUDAKernel : public framework::OpKernel<T> {
 
     // optimize roll when the num of shift dimension is equal 1
     if (nums == 1) {
-      int64_t dim_idx = dims[0];
-      int64_t size = stride_dim[dim_idx];
-      int64_t dim_size = input_dim[dim_idx];
+      int64_t size = 1;
+      int64_t dim_size = numel;
+      if (dims.size() > 0) {
+        int64_t dim_idx = dims[0] >= 0 ? dims[0] : dims[0] + input_dim.size();
+        size = stride_dim[dim_idx];
+        dim_size = input_dim[dim_idx];
+      }
       // shift > 0
       int64_t shift = shifts[0] > 0 ? (dim_size - shifts[0] % dim_size)
                                     : (-shifts[0] % dim_size);

--- a/paddle/fluid/operators/roll_op.h
+++ b/paddle/fluid/operators/roll_op.h
@@ -88,7 +88,13 @@ class RollKernel : public framework::OpKernel<T> {
     TensorToVector(input, context.device_context(), &out_vec);
 
     size_t nums = shifts.size();
-    const DDim input_dim = input.dims();
+    DDim input_dim = input.dims();
+
+    // axis=[] reshape as 1-D tensor
+    if (dims.size() == 0) {
+      dims.push_back(0);
+      input_dim = framework::Dim<1>(out_vec.size());
+    }
 
     for (size_t i = 0; i < nums; i++) {
       PADDLE_ENFORCE_EQ(
@@ -101,7 +107,7 @@ class RollKernel : public framework::OpKernel<T> {
     }
     output->mutable_data<T>(context.GetPlace());
     framework::TensorFromVector(out_vec, context.device_context(), output);
-    output->Resize(input_dim);
+    output->Resize(input.dims());
   }
 };
 
@@ -120,14 +126,20 @@ class RollGradKernel : public framework::OpKernel<T> {
     TensorToVector(input, context.device_context(), &out_vec);
 
     size_t nums = shifts.size();
-    const DDim input_dim = input.dims();
+    DDim input_dim = input.dims();
+
+    // axis=[] reshape as 1-D tensor
+    if (dims.size() == 0) {
+      dims.push_back(0);
+      input_dim = framework::Dim<1>(out_vec.size());
+    }
 
     for (size_t i = 0; i < nums; i++) {
       shift_along_dim(out_vec.data(), input_dim, dims[i], 0 - shifts[i]);
     }
     output->mutable_data<T>(context.GetPlace());
     framework::TensorFromVector(out_vec, context.device_context(), output);
-    output->Resize(input_dim);
+    output->Resize(input.dims());
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/test_roll_op.py
+++ b/python/paddle/fluid/tests/unittests/test_roll_op.py
@@ -63,6 +63,7 @@ class TestRollAPI(unittest.TestCase):
     def test_roll_op_api(self):
         self.input_data()
 
+        paddle.enable_static()
         # case 1:
         with program_guard(Program(), Program()):
             x = fluid.layers.data(name='x', shape=[-1, 3])

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -369,15 +369,13 @@ def roll(x, shifts, axis=None, name=None):
 
     if in_dygraph_mode():
         if axis is None:
-            x = core.ops.reshape(x, 'shape', [-1, 1])
-            axis = [0]
+            axis = []
         return core.ops.roll(x, 'axis', axis, 'shifts', shifts)
 
     out = helper.create_variable_for_type_inference(x.dtype)
 
     if axis is None:
-        x = reshape(x, shape=[-1, 1])
-        axis = [0]
+        axis = []
 
     helper.append_op(
         type='roll',

--- a/python/paddle/tensor/manipulation.py
+++ b/python/paddle/tensor/manipulation.py
@@ -371,8 +371,7 @@ def roll(x, shifts, axis=None, name=None):
         if axis is None:
             x = core.ops.reshape(x, 'shape', [-1, 1])
             axis = [0]
-        out = core.ops.roll(x, 'axis', axis, 'shifts', shifts)
-        return core.ops.reshape(out, 'shape', origin_shape)
+        return core.ops.roll(x, 'axis', axis, 'shifts', shifts)
 
     out = helper.create_variable_for_type_inference(x.dtype)
 
@@ -386,7 +385,6 @@ def roll(x, shifts, axis=None, name=None):
         outputs={'Out': out},
         attrs={'axis': axis,
                'shifts': shifts})
-    out = layers.reshape(out, shape=origin_shape)
     return out
 
 


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
 #32852 

- optimize cuda kernel when roll on one diemsion
- remove reshape

when roll on one dimension,  using  an new cuda kernel replace of the new one. 
Removing the reshape operation which was used as a post process. 