### PR TITLE
[Fix bug] fix the error of fake_quant_dequant op name

### DIFF
--- a/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
+++ b/python/paddle/fluid/contrib/slim/quantization/imperative/utils.py
@@ -39,7 +39,7 @@ quant_input_layers_map = {
 
 fake_quantize_dequantize_types = [
     "fake_quantize_dequantize_abs_max",
-    "fake_quantize_dequantize_channel_wise_abs_max",
+    "fake_channel_wise_quantize_dequantize_abs_max",
     "fake_quantize_dequantize_moving_average_abs_max"
 ]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix the error of fake_quant_dequant op name

动态图量化训练：
* 如果权重使用channel_wise_abs_max方式，产出的量化模型中原本量化的op会有skip_quant属性，导致部署时所有量化op依旧执行fp32 kernel；
* 如果权重使用abs_max方式，不会有上述问题。
* 权重使用abs_max和channel_wise_abs_max方式，精度基本相同。

在动态图量化训练功能，本PR修复判断的op名字，修复上述问题。