### PR TITLE
change unique op VisitaDataType from small to tiny

### DIFF
--- a/paddle/fluid/operators/unique_op.h
+++ b/paddle/fluid/operators/unique_op.h
@@ -405,13 +405,13 @@ class UniqueKernel : public framework::OpKernel<T> {
     bool return_counts = context.Attr<bool>("return_counts");
 
     if (axis_vec.empty()) {
-      framework::VisitDataTypeSmall(
+      framework::VisitDataTypeTiny(
           data_type,
           UniqueFlattendTensorFunctor<DeviceContext, T>(
               context, *x, out, return_index, return_inverse, return_counts));
     } else {
       int axis = axis_vec[0];
-      framework::VisitDataTypeSmall(
+      framework::VisitDataTypeTiny(
           data_type, UniqueDimFunctor<DeviceContext, T>(
                          context, *x, out, axis, return_index, return_inverse,
                          return_counts));


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
Change the unique op visiting data strategy from VisitDataTypeSmall to  VisitDataTypeTiny.
VisitDataTypeTiny visit only int32 and int64, which is fitting the type of Index.