### PR TITLE
Support index is ellipsis for getitem in static mode

### DIFF
--- a/python/paddle/fluid/variable_index.py
+++ b/python/paddle/fluid/variable_index.py
@@ -112,6 +112,7 @@ def _getitem_impl_(var, item):
 
     use_strided_slice = False
     item, none_axes = replace_none(item)
+    item = replace_ellipsis(var, item)
 
     for dim, slice_item in enumerate(item):
         if is_integer_or_scalar_tensor(slice_item):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
As the title

For example:
```
tensor_x = paddle.to_tensor(np.array([[1,2],[3,4]]).astype(np.float32))
tensor_x[...]      # [[1,2],[3,4]]
tensor_x[..., 1]  # [2,4]
```