### PR TITLE
fix launch port already in use

### DIFF
--- a/python/paddle/distributed/fleet/launch_utils.py
+++ b/python/paddle/distributed/fleet/launch_utils.py
@@ -12,9 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
 import logging
-import socket
 import time
 import os
 import signal
@@ -27,6 +25,7 @@ from contextlib import closing
 import socket
 import warnings
 import six
+import struct
 
 import paddle
 import paddle.fluid as fluid
@@ -362,6 +361,10 @@ def add_arguments(argname, type, default, help, argparser, **kwargs):
 def find_free_ports(num):
     def __free_port():
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+            # Note(wangxi): Close the connection with a TCP RST instead
+            # of a TCP FIN, to avoid time_wait state.
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
+                         struct.pack('ii', 1, 0))
             s.bind(('', 0))
             return s.getsockname()[1]
 
@@ -376,7 +379,7 @@ def find_free_ports(num):
             return port_set
 
         step += 1
-        if step > 100:
+        if step > 400:
             print(
                 "can't find avilable port and use the specified static port now!"
             )

--- a/python/paddle/fluid/tests/unittests/test_launch_coverage.py
+++ b/python/paddle/fluid/tests/unittests/test_launch_coverage.py
@@ -24,6 +24,7 @@ import paddle.fluid as fluid
 
 from argparse import ArgumentParser, REMAINDER
 from paddle.distributed.utils import _print_arguments, get_gpus, get_cluster_from_args
+from paddle.distributed.fleet.launch_utils import find_free_ports
 
 
 def _parse_args():
@@ -114,6 +115,9 @@ class TestCoverage(unittest.TestCase):
 
         args.use_paddlecloud = True
         cluster, pod = get_cluster_from_args(args, "0")
+
+    def test_find_free_ports(self):
+        find_free_ports(2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
Fix launch port already in use
#### 产生原因
launch寻找空闲端口方式是先绑定，后释放。再提供给C++使用。Already in use可能有两个原因
1. 绑定后释放，出现TIME_WAIT状态，导致后续绑定出现Already in use。
2. 找到空闲端口到给C++使用存在一个时间差，可能被别的程序给占用。此问题暂无解
#### 解决
1. 解决TIME_WAIT导致的Already in use原因（本PR)：
可以通过设置SO_LINGER来规避。关闭链接，跳过TIME_WAIT，直接进入CLOSE。
2. 端口被别的程序占用。代码上暂无解，可以临时规避：
手工设定起始端口，export FLAGS_START_PORT=6001。