### PR TITLE
Fix for calling subprocess while importing in python embedded context and sys.argv error when it is empty

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -32,6 +32,7 @@ the image layout as follows.
 
 from __future__ import print_function
 
+import os
 import six
 import numpy as np
 # FIXME(minqiyang): this is an ugly fix for the numpy bug reported here
@@ -40,7 +41,7 @@ if six.PY3:
     import subprocess
     import sys
     import_cv2_proc = subprocess.Popen(
-        [sys.executable, "-c", "import cv2"],
+        [os.path.join(sys.prefix, 'python.exe'), "-c", "import cv2"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
     out, err = import_cv2_proc.communicate()

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -233,7 +233,8 @@ def __bootstrap__():
             'gpu_memory_limit_mb',
         ]
     core.init_gflags(["--tryfromenv=" + ",".join(read_env_flags)])
-    # core.init_glog(sys.argv[0])
+    if sys.argv:
+        core.init_glog(sys.argv[0])
     # don't init_p2p when in unittest to save time.
     core.init_devices()
 

--- a/python/paddle/fluid/__init__.py
+++ b/python/paddle/fluid/__init__.py
@@ -233,7 +233,7 @@ def __bootstrap__():
             'gpu_memory_limit_mb',
         ]
     core.init_gflags(["--tryfromenv=" + ",".join(read_env_flags)])
-    core.init_glog(sys.argv[0])
+    # core.init_glog(sys.argv[0])
     # don't init_p2p when in unittest to save time.
     core.init_devices()
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
 Bug fixes

### PR changes
Others

### Describe
This will fix the following issues: 
1. `import paddleocr` invokes python embedded software instead of python.exe while opening a subprocess.
2. fixes `list index out of range` error when sys.argv is empty list.
