### PR TITLE
[UnitTest]Enhance grep syntax to avoid random failed of test_dist_mnist_dgc_nccl

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_dgc_nccl.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_dgc_nccl.py
@@ -25,12 +25,15 @@ flag_name = os.path.splitext(__file__)[0]
 
 
 def count_of_sparse_all_reduce_calls(file_name):
+    # NOTE(Aurelius84): The log file contains some binary contents that causes error
+    # while `grep`. So we add `-a` to fix it.
+    # -a, --text equivalent to --binary-files=text, make binaries equivalent to text.
     cmd = 'grep sparse_all_reduce_op_handle ' + file_name + ' | grep in_numel | wc -l'
     child = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     result = child.communicate()[0]
     print('test_info: result = ' + str(result))
 
-    # note. in python3, result is b'num', != 'num' 
+    # NOTE: in python3, result is b'num', != 'num'
     return int(result)
 
 
@@ -59,7 +62,7 @@ class TestDistMnistNCCL2DGC(TestDistBase):
             # only 1 layer use dgc now, run_step=5, rampup_begin_step=2, so 1 * (5 - 2) = 3
 
             # temp close this test. In python3 CI, the log is right, but the result
-            # has a problem, may be in multi process mode, log is not writed in time.  
+            # has a problem, may be in multi process mode, log is not written in time.
             # self.assertEqual(result, 3)
 
 

--- a/python/paddle/fluid/tests/unittests/test_dist_mnist_dgc_nccl.py
+++ b/python/paddle/fluid/tests/unittests/test_dist_mnist_dgc_nccl.py
@@ -28,7 +28,7 @@ def count_of_sparse_all_reduce_calls(file_name):
     # NOTE(Aurelius84): The log file contains some binary contents that causes error
     # while `grep`. So we add `-a` to fix it.
     # -a, --text equivalent to --binary-files=text, make binaries equivalent to text.
-    cmd = 'grep sparse_all_reduce_op_handle ' + file_name + ' | grep in_numel | wc -l'
+    cmd = 'grep -a sparse_all_reduce_op_handle ' + file_name + ' | grep in_numel | wc -l'
     child = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
     result = child.communicate()[0]
     print('test_info: result = ' + str(result))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

#### 1. 背景
执行器升级PE时，发现test_dist_mnist_dgc_nccl单测会随机挂。经过排查，是因为产出的log 文件可能包含一些二进制文件，导致grep时部分内容无法match，引发后续的assertEqual报错。

#### 2. 解决方法
grep添加`-a`选项，将二进制文本当做正常文本来匹配即可