### PR TITLE
[Dy2Stat]BugFix StaticAanlysis with gast.Subscript

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/static_analysis.py
@@ -368,5 +368,8 @@ class StaticAnalysisVisitor(object):
 
             if isinstance(node.func, gast.Name):
                 return self.var_env.get_var_type(node.func.id)
+        if isinstance(node, gast.Subscript):
+            if self.is_tensor_node(node.value):
+                return {NodeVarType.TENSOR}
 
         return {NodeVarType.STATEMENT}

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import unittest
 
+import paddle
 import numpy as np
 import paddle.fluid as fluid
 from paddle.fluid.dygraph.jit import declarative
@@ -59,6 +60,32 @@ def test_list_append_in_for_loop(x, iter_num):
     for i in range(iter_num):
         a.append(x)
     return a[0]
+
+
+def test_list_append_in_for_subscript(x):
+    x = fluid.dygraph.to_variable(x)
+    iter_num = paddle.shape(x)[0]
+    a = []
+    # import pdb
+    # pdb.set_trace()
+    for i in range(iter_num):
+        x = x + 1
+        a.append(x)
+    out = paddle.concat(a)
+    return out[0]
+
+
+def test_list_append_in_while_loop_subscript(x):
+    x = fluid.dygraph.to_variable(x)
+    iter_num = paddle.shape(x)[0]
+    a = []
+    i = 0
+    while i < iter_num:
+        x = x + 1
+        a.append(x)
+        i += 1
+    out = paddle.concat(a)
+    return out[0]
 
 
 def test_list_append_in_for_loop_with_concat(x, iter_num):
@@ -259,6 +286,17 @@ class TestListInForLoop(TestListInWhileLoop):
 class TestListInForLoopWithConcat(TestListInWhileLoopWithStack):
     def init_dygraph_func(self):
         self.all_dygraph_funcs = [test_list_append_in_for_loop_with_concat, ]
+
+
+class TestListInForLoopWithSubscript(TestListWithoutControlFlow):
+    def init_dygraph_func(self):
+        self.all_dygraph_funcs = [
+            test_list_append_in_for_subscript,
+            test_list_append_in_while_loop_subscript
+        ]
+
+    def init_data(self):
+        self.input = np.random.random((3, 4)).astype('float32')
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_list.py
@@ -62,12 +62,13 @@ def test_list_append_in_for_loop(x, iter_num):
     return a[0]
 
 
+paddle.jit.set_code_level(100)
+
+
 def test_list_append_in_for_subscript(x):
     x = fluid.dygraph.to_variable(x)
     iter_num = paddle.shape(x)[0]
     a = []
-    # import pdb
-    # pdb.set_trace()
     for i in range(iter_num):
         x = x + 1
         a.append(x)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

### 1. PR内容
BugFix StaticAanlysis with gast.Subscript

### 2. 复现样例

在有关`for-loop`的语法转换中，依赖的变量如果是从上游tensor slice出来的，则在StaticAnalysis阶段无法被解析为`Tensor`类型。原因是因为StaticAnalysis中缺少对`gast.Subscript`语法的处理。此PR添加此类处理：如果`node.value`是个Variable，则slice出来的类型也是Variable，否则返回为`statement`类型

```python
def test_list_append_in_for_subscript(x):
    x = fluid.dygraph.to_variable(x)
    iter_num = paddle.shape(x)[0]   # iter_num should be consider as Variable
    a = []
    for i in range(iter_num):
        x = x + 1
        a.append(x)
    out = paddle.concat(a)
    return out[0]
```

Before this PR, `a = []` will not be converted because `iter_num` is not considered as `Variable`. The transformed codes is:
```python
def test_list_append_in_for_subscript(x):
    x = paddle.assign(x)
    iter_num = paddle.shape(x)[0]
    a = []
    i = 0

    def for_loop_condition_0(i, iter_num, x):
        return i < iter_num

    def for_loop_body_0(i, iter_num, x):
        x = x + 1
        paddle.jit.dy2static.convert_call(a.append)(x)
        i += 1
        return i, iter_num, x
    [i, iter_num, x] = paddle.jit.dy2static.convert_while_loop(
        for_loop_condition_0, for_loop_body_0, [i, iter_num, x])
    out = paddle.concat(a)
    return out[0]
```

After this PR， The transformed codes is as expected:
```python
def test_list_append_in_for_subscript(x):
    x = paddle.assign(x)
    iter_num = paddle.shape(x)[0]
    a = paddle.tensor.create_array(dtype='float32')
    i = 0

    def for_loop_condition_0(iter_num, a, i, x):
        return i < iter_num

    def for_loop_body_0(iter_num, a, i, x):
        x = x + 1
        paddle.tensor.array_write(x=x, i=paddle.tensor.array_length(a), array=a
            )
        i += 1
        return iter_num, a, i, x
    [iter_num, a, i, x] = paddle.jit.dy2static.convert_while_loop(
        for_loop_condition_0, for_loop_body_0, [iter_num, a, i, x])
    out = paddle.concat(a)
    return out[0]
```