### PR TITLE
fix reshape算子逻辑漏洞

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6143,6 +6143,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
         elif isinstance(shape, Variable):
             shape.stop_gradient = True
             out, _ = core.ops.reshape2(x, shape)
+	else:
+	    raise ValueError("shape desires a Variable or a list/tuple, got {}".format(type(shape)))
 
         return dygraph_utils._append_activation_in_dygraph(out, act)
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

当前reshape算子缺乏fallback逻辑，若输入的shape不是list、tuple或variable时，会报out未定义，而不是type error