### PR TITLE
[NPU] cast indices and label if their type is not consistent in accuracy npu op

### DIFF
--- a/paddle/fluid/operators/metrics/accuracy_op_npu.cc
+++ b/paddle/fluid/operators/metrics/accuracy_op_npu.cc
@@ -64,6 +64,9 @@ class AccuracyNPUKernel : public framework::OpKernel<T> {
       } else {
         cast_label.ShareDataWith(*label);
       }
+    } else {
+      cast_indices.ShareDataWith(*indices);
+      cast_label.ShareDataWith(*label);
     }
 
     // equal

--- a/paddle/fluid/operators/metrics/accuracy_op_npu.cc
+++ b/paddle/fluid/operators/metrics/accuracy_op_npu.cc
@@ -39,12 +39,39 @@ class AccuracyNPUKernel : public framework::OpKernel<T> {
       return;
     }
 
+    // cast `indices` or `label` if their type is not consistent
+    Tensor cast_indices(framework::proto::VarType::INT32);
+    Tensor cast_label(framework::proto::VarType::INT32);
+    if (indices->type() != label->type()) {
+      auto dst_dtype = ConvertToNpuDtype(framework::proto::VarType::INT32);
+      if (indices->type() != framework::proto::VarType::INT32) {
+        cast_indices.Resize(indices->dims());
+        cast_indices.mutable_data<int>(ctx.GetPlace());
+        auto runner_cast_indices =
+            NpuOpRunner("Cast", {*indices}, {cast_indices},
+                        {{"dst_type", static_cast<int>(dst_dtype)}});
+        runner_cast_indices.Run(stream);
+      } else {
+        cast_indices.ShareDataWith(*indices);
+      }
+      if (label->type() != framework::proto::VarType::INT32) {
+        cast_label.Resize(label->dims());
+        cast_label.mutable_data<int>(ctx.GetPlace());
+        auto runner_cast_label =
+            NpuOpRunner("Cast", {*label}, {cast_label},
+                        {{"dst_type", static_cast<int>(dst_dtype)}});
+        runner_cast_label.Run(stream);
+      } else {
+        cast_label.ShareDataWith(*label);
+      }
+    }
+
     // equal
     Tensor tmp_equal(framework::proto::VarType::BOOL);
     tmp_equal.Resize(inference->dims());
     tmp_equal.mutable_data<bool>(ctx.GetPlace());
     auto runner_equal =
-        NpuOpRunner("Equal", {*indices, *label}, {tmp_equal}, {});
+        NpuOpRunner("Equal", {cast_indices, cast_label}, {tmp_equal}, {});
     runner_equal.Run(stream);
 
     // cast equal

--- a/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
@@ -111,5 +111,29 @@ class TestAccuracyType(TestAccuracy):
         }
 
 
+class TestAccuracyType2(TestAccuracy):
+    def setUp(self):
+        self.op_type = "accuracy"
+        self.set_npu()
+        self.init_dtype()
+        np.random.seed(SEED)
+        n = 8192
+        infer = np.random.random((n, 100)).astype(self.dtype)
+        indices = np.random.randint(0, 1000, (n, 100)).astype('int32')
+        label = np.random.randint(0, 1000, (n, 1)).astype('int64')
+        self.inputs = {'Out': infer, 'Indices': indices, "Label": label}
+        num_correct = 0
+        for rowid in range(n):
+            for ele in indices[rowid]:
+                if ele == label[rowid]:
+                    num_correct += 1
+                    break
+        self.outputs = {
+            'Accuracy': np.array([num_correct / float(n)]).astype(self.dtype),
+            'Correct': np.array([num_correct]).astype("int32"),
+            'Total': np.array([n]).astype("int32")
+        }
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
+++ b/python/paddle/fluid/tests/unittests/npu/test_accuracy_op_npu.py
@@ -87,5 +87,29 @@ class TestAccuracy2(TestAccuracy):
         }
 
 
+class TestAccuracyType(TestAccuracy):
+    def setUp(self):
+        self.op_type = "accuracy"
+        self.set_npu()
+        self.init_dtype()
+        np.random.seed(SEED)
+        n = 8192
+        infer = np.random.random((n, 100)).astype(self.dtype)
+        indices = np.random.randint(0, 1000, (n, 100)).astype('int64')
+        label = np.random.randint(0, 1000, (n, 1)).astype('int32')
+        self.inputs = {'Out': infer, 'Indices': indices, "Label": label}
+        num_correct = 0
+        for rowid in range(n):
+            for ele in indices[rowid]:
+                if ele == label[rowid]:
+                    num_correct += 1
+                    break
+        self.outputs = {
+            'Accuracy': np.array([num_correct / float(n)]).astype(self.dtype),
+            'Correct': np.array([num_correct]).astype("int32"),
+            'Total': np.array([n]).astype("int32")
+        }
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->
The inputs `indices` and `label` in `accuracy` op may be different types, resulting in an error when doing equal operations.
In this PR, compare the types of `indices` and `label` before the `equal` operation. If they are inconsistent, cast them to int32.

unittest result:
<img width="529" alt="图片" src="https://user-images.githubusercontent.com/26408901/118939736-97499100-b982-11eb-85b6-ce46745411bb.png">

GLOG:

<img width="727" alt="图片" src="https://user-images.githubusercontent.com/26408901/118940012-de378680-b982-11eb-856c-085a9141f4bd.png">


