### PR TITLE
fix dynamic reshape api type error

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6143,6 +6143,9 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
         elif isinstance(shape, Variable):
             shape.stop_gradient = True
             out, _ = core.ops.reshape2(x, shape)
+        else:
+            raise ValueError("shape desires a Variable or a list/tuple, got {}".
+                             format(type(shape)))
 
         return dygraph_utils._append_activation_in_dygraph(out, act)
 

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -458,6 +458,12 @@ class TestDygraphReshapeAPI(unittest.TestCase):
         expected_out = np.reshape(input_1, newshape=[5, 10])
         self.assertTrue(np.allclose(expected_out, out_np))
 
+    def test_dynamic_api_type_error(self):
+        paddle.disable_static()
+        input_1 = np.random.random([5, 1, 10]).astype("float32")
+        input = paddle.to_tensor(input_1)
+        self.assertRaises(ValueError, paddle.reshape, input, 1)
+
 
 class TestDygraphReshapeInplaceAPI(TestDygraphReshapeAPI):
     def executed_api(self):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
当前reshape算子缺乏fallback逻辑，若输入的shape不是list、tuple或variable时，会报out未定义，而不是type error。会造成误导。此bug存在于2.0及2.1所有版本中。详见