### PR TITLE
fix path error on windows when precision switch is turn on

### DIFF
--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -233,9 +233,9 @@ class PRChecker(object):
 
     def get_all_count(self):
         os.system(
-            "cd %s/build && ctest -N|grep 'Total Tests:' | awk -F ': ' '{print $2}' > testCount"
+            "cd %sbuild && ctest -N|grep 'Total Tests:' | awk -F ': ' '{print $2}' > testCount"
             % PADDLE_ROOT)
-        f = open("%s/build/testCount" % PADDLE_ROOT)
+        f = open("%sbuild/testCount" % PADDLE_ROOT)
         testCount = f.read()
         f.close()
         return int(testCount.strip())


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix path error on windows when precision switch is turn on
![image](https://user-images.githubusercontent.com/32428676/118969002-2795cf00-b99f-11eb-82e3-988fd3315192.png)
