### PR TITLE
paddle.to_tensor supports LoDTensor

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -248,6 +248,21 @@ class TestVarBase(unittest.TestCase):
                 a = paddle.to_tensor(a, place=paddle.CUDAPinnedPlace())
                 self.assertEqual(a.place.__repr__(), "CUDAPinnedPlace")
 
+    def test_to_tensor_with_lodtensor(self):
+        if core.is_compiled_with_cuda():
+            a_np = np.random.rand(1024, 1024)
+            with paddle.fluid.dygraph.guard(core.CPUPlace()):
+                lod_tensor = core.LoDTensor()
+                lod_tensor.set(a_np, core.CPUPlace())
+                a = paddle.to_tensor(lod_tensor)
+                self.assertTrue(np.array_equal(a_np, a.numpy()))
+
+            with paddle.fluid.dygraph.guard(core.CUDAPlace(0)):
+                lod_tensor = core.LoDTensor()
+                lod_tensor.set(a_np, core.CUDAPlace(0))
+                a = paddle.to_tensor(lod_tensor)
+                self.assertTrue(np.array_equal(a_np, a.numpy()))
+
     def test_to_variable(self):
         with fluid.dygraph.guard():
             var = fluid.dygraph.to_variable(self.array, name="abc")


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Sometimes, users want to convert a LoDTensor(C++ side) to paddle.Tensor(python side), this PR supports that.

Usage:

```
import paddle
import numpy as np

a = np.random.rand(10, 1024)
t = paddle.fluid.core.LoDTensor()
t.set(a, paddle.CUDAPlace(0))
tt = paddle.to_tensor(t)
print(tt)
```
