### PR TITLE
Fix hard_swish not fused in quant2_mkldnn_passes

### DIFF
--- a/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/mkldnn/conv_activation_mkldnn_fuse_pass.cc
@@ -18,6 +18,7 @@
 
 #include "paddle/fluid/framework/op_version_registry.h"
 #include "paddle/fluid/platform/enforce.h"
+#include "paddle/fluid/string/pretty_log.h"
 
 namespace paddle {
 namespace framework {
@@ -28,7 +29,7 @@ class OpDesc;
 namespace paddle {
 namespace framework {
 namespace ir {
-
+using string::PrettyLogDetail;
 class Graph;
 
 void ConvActivationFusePass::ApplyImpl(ir::Graph* graph) const {
@@ -95,6 +96,8 @@ void ConvActivationFusePass::ApplyImpl(ir::Graph* graph) const {
   gpd(graph, handler);
 
   AddStatis(found_conv_activation_count);
+  PrettyLogDetail("---    fused %d pairs of conv with %s",
+                  found_conv_activation_count, activation_type());
 }
 
 }  // namespace ir

--- a/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
+++ b/python/paddle/fluid/contrib/slim/quantization/quant2_int8_mkldnn_pass.py
@@ -410,6 +410,8 @@ class Quant2Int8MkldnnPass(object):
         graph = self._apply_pass(graph, 'conv_elementwise_add_mkldnn_fuse_pass')
         graph = self._apply_pass(graph, 'conv_relu_mkldnn_fuse_pass')
         graph = self._apply_pass(graph, 'conv_relu6_mkldnn_fuse_pass')
+        graph = self._apply_pass(graph, 'conv_swish_mkldnn_fuse_pass')
+        graph = self._apply_pass(graph, 'conv_hard_swish_mkldnn_fuse_pass')
         graph = self._apply_pass(graph, 'fc_fuse_pass',
                                  ['use_gpu', 'use_fc_padding'], [False, False])
         graph = self._apply_pass(graph, 'repeated_fc_relu_fuse_pass')


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
Others

### Describe
Added conv_swish pass and conv_hardswish pass in the quant2_int8_mkldnn_pass.py, so that save_quant_model will fuse these activations and save fused int8 model.
