### PR TITLE
fix model_benchmark ci

### DIFF
--- a/tools/test_model_benchmark.sh
+++ b/tools/test_model_benchmark.sh
@@ -24,6 +24,7 @@ function check_whl {
 
     mkdir -p /tmp/pr && mkdir -p /tmp/develop
     unzip -q build/python/dist/*.whl -d /tmp/pr
+    rm -f build/python/dist/*.whl && rm -f build/python/build/.timestamp
 
     git checkout .
     git checkout -b develop_base_pr upstream/$BRANCH

--- a/tools/test_model_benchmark.sh
+++ b/tools/test_model_benchmark.sh
@@ -30,6 +30,7 @@ function check_whl {
     git checkout -b develop_base_pr upstream/$BRANCH
     cd build
     make -j `nproc`
+    [ $? -ne 0 ] && echo "install paddle failed." && exit 1
     unzip -q python/dist/*.whl -d /tmp/develop
 
     sed -i '/version.py/d' /tmp/pr/*/RECORD


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
fix python timestamp
如果时间超过1分钟，编译时.timestamp则会出现问题，因此提前删除，并且删除develop生成的whl包，不会导致dev和pr的whl包一样退出。
![image](https://user-images.githubusercontent.com/29832297/119070554-cca1bd80-ba1a-11eb-9cc2-29038d2e72de.png)
