### PR TITLE
mode_matmulv2_npu

### DIFF
--- a/paddle/fluid/operators/matmul_v2_op_npu.cc
+++ b/paddle/fluid/operators/matmul_v2_op_npu.cc
@@ -135,9 +135,29 @@ class MatMulV2GradNPUKernel : public framework::OpKernel<T> {
         }
         if (dy) {
           dy->mutable_data<T>(ctx.GetPlace());
-          auto runner_dy = NpuOpRunner("BatchMatMul", {*x, *dout}, {*dy},
-                                       {{"adj_x1", true}, {"adj_x2", false}});
-          runner_dy.Run(stream);
+          if ((x->dims().size() == 3) && (dout->dims().size() == 3) &&
+              (dy->dims().size() == 2)) {
+            framework::Tensor dout_;
+            TensorCopySync(*dout, ctx.GetPlace(), &dout_);
+            std::vector<int> vec_dim = framework::vectorize<int>(dout_.dims());
+            std::vector<int> vec_dim_v{vec_dim[0] * vec_dim[1], vec_dim[2]};
+            dout_.Resize(framework::make_ddim(vec_dim_v));
+
+            framework::Tensor x_;
+            TensorCopySync(*x, ctx.GetPlace(), &x_);
+            std::vector<int> vec_dim_x = framework::vectorize<int>(x_.dims());
+            std::vector<int> vec_dim_x_v{vec_dim_x[0] * vec_dim_x[1],
+                                         vec_dim_x[2]};
+            x_.Resize(framework::make_ddim(vec_dim_x_v));
+            auto runner_dy =
+                NpuOpRunner("MatMul", {x_, dout_}, {*dy},
+                            {{"transpose_x1", true}, {"transpose_x2", false}});
+            runner_dy.Run(stream);
+          } else {
+            auto runner_dy = NpuOpRunner("BatchMatMul", {*x, *dout}, {*dy},
+                                         {{"adj_x1", true}, {"adj_x2", false}});
+            runner_dy.Run(stream);
+          }
         }
       }
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
mode matmulv2 npu op supported the size of x is 3,the size of dout is 3,the size of dy is 2.