### PR TITLE
add the op def proto, test=develop

### DIFF
--- a/paddle/fluid/framework/CMakeLists.txt
+++ b/paddle/fluid/framework/CMakeLists.txt
@@ -27,6 +27,7 @@ add_subdirectory(fleet)
 add_subdirectory(io)
 #ddim lib
 proto_library(framework_proto SRCS framework.proto)
+proto_library(op_def_proto SRCS op_def.proto)
 proto_library(heter_service_proto SRCS heter_service.proto)
 proto_library(data_feed_proto SRCS data_feed.proto)
 proto_library(trainer_desc_proto SRCS trainer_desc.proto DEPS framework_proto

--- a/paddle/fluid/framework/op_def.proto
+++ b/paddle/fluid/framework/op_def.proto
@@ -1,0 +1,43 @@
+/* Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */
+
+syntax = "proto2";
+
+import "framework.proto";
+package paddle.framework.proto;
+
+message OpDef {
+
+  message VarDef {
+    required string name = 1;
+
+    // For the type of input / output variables.
+    reserved 2;
+  }
+
+  message AttrDef {
+    required string name = 1;
+    required AttrType type = 2;
+  }
+
+  message Desc {
+    repeated VarDef inputs = 1;
+    repeated VarDef outputs = 2;
+    repeated AttrDef attrs = 3;
+  }
+
+  required string type = 1;
+  required Desc def = 2;
+  optional Desc extra = 3;
+}

--- a/paddle/fluid/operators/compat/while.pbtxt
+++ b/paddle/fluid/operators/compat/while.pbtxt
@@ -1,0 +1,49 @@
+type: "while"
+def {
+  inputs {
+    name: "X"
+  }
+  inputs {
+    name: "Condition"
+  }
+  outputs {
+    name: "Out"
+  }
+  outputs {
+    name: "StepScopes"
+  }
+  attrs {
+    name: "sub_block"
+    type: BLOCK
+  }
+}
+extra {
+  attrs {
+    name: "is_test"
+    type: BOOLEAN
+  }
+  attrs {
+    name: "skip_eager_deletion_vars"
+    type: STRINGS
+  }
+  attrs {
+    name: "op_role"
+    type: INT
+  }
+  attrs {
+    name: "op_role_var"
+    type: STRINGS
+  }
+  attrs {
+    name: "op_namescope"
+    type: STRING
+  }
+  attrs {
+    name: "op_callstack"
+    type: STRINGS
+  }
+  attrs {
+    name: "op_device"
+    type: STRING
+  }
+}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs

### Describe
<!-- Describe what this PR does -->

**飞桨算子定义有效性约束数据结构（OpDef）说明**

目前，框架所有可用的算子定义均包含在 `paddle::framework::proto::OpProto` 数据结构中，但此数据结构还包含了一些执行态相关信息，这些信息对用户无效，在序列化时冗余。因为状态的累积，目前仅靠算子参数（及输入输出）名称，已无法自动化分辨哪些属性为必需。所以需要人工摘取算子定义的必要信息，并用一个分类能力更强的数据结构保存这些信息。

在推理 Pass 升级过程中，必须知道哪些输入、输出、参数是需要识别且满足前置要求的（如 `while` 算子仅在参数 `"sub_block"` 存在且取值大于等于 `1` 时才触发某些 Pass；相关信息将包含在下文示例中的 `OpDef::def` 域）。但是，目前原有数据结构 `OpProto` 拿到的算子属性是杂糅的，不易限定，所以给出本提交。

**此提交合入后，在 Pass 升级中，相应负责人需同步对涉及到的算子属性进行分类（即完成算子对应的 `pbtxt` 文本文件书写），并将其存放到指定目录（`paddle/fluid/operators/compat`）中。**

---------------------------------------------

**示例**

下面以 `while` 算子为例，给出一个满足新数据结构的内容形式（`while.pbtxt`）：

```
type: "while" # 算子类型

# def 指 definition，将算子数学表示必需的项目添加到这里。
def {
  inputs {
    name: "X"  
    # 算子的第 1 个必需输入名称为 "X"。
  }
  inputs {
    name: "Condition"
    # 算子的第 2 个必需输入名称为 "Condition"。
  }
  outputs {
    name: "Out" 
    # 算子的第 1 个必需输出名称为 "Out"。
  }
  outputs {
    name: "StepScopes"  
    # 算子的第 2 个必需输出名称为 "StepScopes"。
  }
  attrs {
    name: "sub_block" 
    # 算子的第 1 个必需参数名称为 "sub_block"。
    type: BLOCK
    # 参数类型为 BLOCK。
  }
}

# extra，将算子的冗余项目（输入 / 输出 / 参数）添加到这里，这些项目是推理部署（Pass）不关心的。
extra {
  attrs {
    name: "is_test"
    # 算子的第 1 个冗余参数名称为 "is_test"。
    type: BOOLEAN
    # 参数类型为 BOOLEAN。
  }
  attrs {
    name: "skip_eager_deletion_vars"
    # 算子的第 2 个冗余参数名称为 "skip_eager_deletion_vars"。
    type: STRINGS
  }
  attrs {
    name: "op_role" 
    type: INT  
  }
  attrs {
    name: "op_role_var" 
    type: STRINGS 
  }
  attrs {
    name: "op_namescope"  
    type: STRING
  }
  attrs {
    name: "op_callstack"  
    type: STRINGS  
  }
  attrs {
    name: "op_device"   
    type: STRING  
  }
}
```

**注意事项**
1、`OpDef` 和原有数据结构 `OpProto` 是一一对应的：`OpProto` 中的每个输入、输出、参数，必归属到 `OpDef` 的 `def` 或 `extra` 二者的其中一类。所以 `OpDef` 数据结构实际上是对 `OpProto` 区分为“必需”和“冗余”的二分类过程。
2、每个区分完成的算子定义应提交到 `paddle/fluid/operators/compat` 目录，并以 `"算子名称+.pbtxt"` 文件名存放。
3、CI 应确保 `paddle/fluid/operators/compat` 目录中的每个文件都能被 `OpDef` 正常加载，且 `OpDef` 在二分类过程中相对于 `OpProto` 没有项目丢失。
4、为方便大家快速完成相关工作，不被 Protobuf 文本格式困扰，我们准备了未分类的 `pbtxt` 基础文件（[压缩包下载](https://paddle-inference-dist.bj.bcebos.com/operators/base_opdef_pbtxt.tgz)）。只需挑选对应算子进行增量开发，将一部分属性行从 `def`（必需）移动到 `extra`（冗余），即可完成全部工作。按要求完成如下修改的 `while.pbtxt` 在内容与格式上应与本文档首次出现的示例一致。

```
type: "while"

#  第一步：从 def 剪切所有冗余属性。
def {
  inputs {
    name: "X"
  }
  inputs {
    name: "Condition"
  }
  outputs {
    name: "Out"
  }
  outputs {
    name: "StepScopes"
  }
  attrs {
    name: "sub_block"
    type: BLOCK
  }
  attrs {
    name: "is_test"
    type: BOOLEAN
  }
  attrs {
    name: "skip_eager_deletion_vars"
    type: STRINGS
  }
  attrs {
    name: "op_role"
    type: INT
  }
  attrs {
    name: "op_role_var"
    type: STRINGS
  }
  attrs {
    name: "op_namescope"
    type: STRING
  }
  attrs {
    name: "op_callstack"
    type: STRINGS
  }
  attrs {
    name: "op_device"
    type: STRING
  }
}

#  第二步：将冗余属性粘贴到 extra。注意不要仅删除冗余属性而忘记放到 extra。
extra {
  inputs {
  }
  outputs {
  }
  attrs {
  }
}

```

5、对应地，在对 Pass 进行升级时，下列函数调用的 `Input`、`Output`、`Attr` 只需要关心（**且须全部添加，不能遗漏**）属性中的 `def` 部分。`extra` 属性 <ins>**按需**</ins> 涉及，以避免代码过于冗长。此处的“按需”指的是：根据 `extra` 属性的正误是否影响 Pass 运行，灵活判断是否加入前置条件。

```
AttrCompat& OpCompat::AddAttr(const std::string& attr_name);
InputOrOutputCompat& OpCompat::AddInput(const std::string& name);
InputOrOutputCompat& OpCompat::AddOutput(const std::string& name);
```

6、本提交规范的是框架训练前向算子的通用性。由于推理自身原因，在 Pass 中由于新增 `OpDesc` 并自定义属性，导致出现既不在 `extra` 中的 `OpAttr` 的问题暂未涉及，遇到此类疑问时单独对接处理。

7、Pass 中新增的算子类型如下。这些算子只会出现在经过 Pass 之后的计算图中（是推理优化专用算子，不在训练原始模型出现），所以暂时不需纳入 pbtxt 的统计。
```
conv2d_fusion
conv2d_inception_fusion
fused_batch_norm_act
fused_bn_add_activation
fused_elemwise_activation
fused_elemwise_add_activation
fused_embedding_eltwise_layernorm
fused_embedding_fc_lstm
fused_embedding_seq_pool
fused_fc_elementwise_layernorm
fusion_group
fusion_gru
fusion_lstm
fusion_repeated_fc_relu
fusion_seqconv_eltadd_relu
fusion_seqexpand_concat_fc
fusion_seqpool_concat
fusion_seqpool_cvm_concat
fusion_squared_mat_sub
fusion_transpose_flatten_concat
multi_gru
multihead_matmul
skip_layernorm
```