### PR TITLE
support input integer with shape parameter of reshape

### DIFF
--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6151,7 +6151,7 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
     check_variable_and_dtype(x, 'x', [
         'float16', 'float32', 'float64', 'int32', 'int64', 'bool', 'uint16'
     ], 'reshape')
-    check_type(shape, 'shape', (list, tuple, Variable), 'reshape')
+    check_type(shape, 'shape', (list, tuple, int, Variable), 'reshape')
     check_type(actual_shape, 'actual_shape', (Variable, type(None)), 'reshape')
 
     helper = LayerHelper("reshape2", **locals())

--- a/python/paddle/fluid/layers/nn.py
+++ b/python/paddle/fluid/layers/nn.py
@@ -6134,6 +6134,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
             warnings.warn(
                 "Inplace on reshape is not allowed and will be discarded in dygraph mode currently."
             )
+        if isinstance(shape, int):
+            shape = [shape]
         if isinstance(shape, (list, tuple)):
             shape = [
                 item.numpy().item(0) if isinstance(item, Variable) else item
@@ -6183,6 +6185,8 @@ def reshape(x, shape, actual_shape=None, act=None, inplace=False, name=None):
 
     inputs = {"X": x}
     attrs = {}
+    if isinstance(shape, int):
+        shape = [shape]
     if isinstance(shape, Variable):
         shape.stop_gradient = True
         inputs["Shape"] = shape

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -48,6 +48,30 @@ class TestReshapeOp(OpTest):
         self.check_grad(["X"], "Out")
 
 
+# situation 1: have shape(int, no tensor), no actual shape(Tensor)
+class TestReshapeOpIntShape(OpTest):
+    def setUp(self):
+        self.init_data()
+        self.op_type = "reshape2"
+        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
+        self.attrs = {"shape": self.new_shape}
+        self.outputs = {
+            "Out": self.inputs["X"].reshape(self.infered_shape),
+            'XShape': np.random.random(self.ori_shape).astype("float32")
+        }
+
+    def init_data(self):
+        self.ori_shape = (2, 60)
+        self.new_shape = -1
+        self.infered_shape = -1
+
+    def test_check_output(self):
+        self.check_output(no_check_set=['XShape'])
+
+    def test_check_grad(self):
+        self.check_grad(["X"], "Out")
+
+
 class TestReshapeOpDimInfer1(TestReshapeOp):
     def init_data(self):
         self.ori_shape = (5, 25)

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -457,9 +457,9 @@ class TestDygraphReshapeAPI(unittest.TestCase):
         expected_out = np.reshape(input_1, newshape=[5, 10])
         self.assertTrue(np.allclose(expected_out, out_np))
 
-    def test_shape_int(self):
+    def test_out_shape_int(self):
         paddle.disable_static()
-        input_1 = np.random.random([5, 20]).astype("float32")
+        input_1 = np.random.random([5, 1, 10]).astype("float32")
         input = paddle.to_tensor(input_1)
         output = self.reshape(x=input, shape=-1)
         out_np = output.numpy()

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -457,15 +457,6 @@ class TestDygraphReshapeAPI(unittest.TestCase):
         expected_out = np.reshape(input_1, newshape=[5, 10])
         self.assertTrue(np.allclose(expected_out, out_np))
 
-    def test_out_shape_int(self):
-        paddle.disable_static()
-        input_1 = np.random.random([5, 1, 10]).astype("float32")
-        input = paddle.to_tensor(input_1)
-        output = self.reshape(x=input, shape=-1)
-        out_np = output.numpy()
-        expected_out = np.reshape(input_1, newshape=-1)
-        self.assertTrue(np.allclose(expected_out, out_np))
-
 
 class TestDygraphReshapeInplaceAPI(TestDygraphReshapeAPI):
     def executed_api(self):

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -48,30 +48,6 @@ class TestReshapeOp(OpTest):
         self.check_grad(["X"], "Out")
 
 
-# situation 1: have shape(int, no tensor), no actual shape(Tensor)
-class TestReshapeOpIntShape(OpTest):
-    def setUp(self):
-        self.init_data()
-        self.op_type = "reshape2"
-        self.inputs = {"X": np.random.random(self.ori_shape).astype("float32")}
-        self.attrs = {"shape": self.new_shape}
-        self.outputs = {
-            "Out": self.inputs["X"].reshape(self.infered_shape),
-            'XShape': np.random.random(self.ori_shape).astype("float32")
-        }
-
-    def init_data(self):
-        self.ori_shape = (2, 60)
-        self.new_shape = -1
-        self.infered_shape = -1
-
-    def test_check_output(self):
-        self.check_output(no_check_set=['XShape'])
-
-    def test_check_grad(self):
-        self.check_grad(["X"], "Out")
-
-
 class TestReshapeOpDimInfer1(TestReshapeOp):
     def init_data(self):
         self.ori_shape = (5, 25)
@@ -289,6 +265,7 @@ class TestReshapeAPI(unittest.TestCase):
         paddle.enable_static()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
+        shape_int = -1
         main_prog = Program()
         with program_guard(main_prog, Program()):
             positive_five = self.fill_constant([1], "int32", 5)
@@ -296,7 +273,7 @@ class TestReshapeAPI(unittest.TestCase):
 
             actual_shape = self.data(name="shape", shape=[3], dtype="int32")
 
-            # situation 1: have shape( list, no tensor), no actual shape(Tensor)
+            # situation 1: have shape(list, no tensor), no actual shape(Tensor)
             out_1 = self.reshape(x, shape)
 
             # situation 2: have shape(list, no tensor), have actual shape(Tensor)
@@ -309,17 +286,21 @@ class TestReshapeAPI(unittest.TestCase):
             # Situation 4: have shape(Tensor), no actual shape(Tensor)
             out_4 = self.reshape(x, shape=actual_shape)
 
+            # situation 5: have shape(int, no tensor), no actual shape(Tensor)
+            out_5 = self.reshape(x, shape_int)
+
         exe = paddle.static.Executor(place=paddle.CPUPlace())
-        res_1, res_2, res_3, res_4 = exe.run(
+        res_1, res_2, res_3, res_4, res_5 = exe.run(
             main_prog,
             feed={"x": input,
                   "shape": np.array([2, 5, 5]).astype("int32")},
-            fetch_list=[out_1, out_2, out_3, out_4])
+            fetch_list=[out_1, out_2, out_3, out_4, out_5])
 
         assert np.array_equal(res_1, input.reshape(shape))
         assert np.array_equal(res_2, input.reshape(shape))
         assert np.array_equal(res_3, input.reshape([5, 10]))
         assert np.array_equal(res_4, input.reshape(shape))
+        assert np.array_equal(res_5, input.reshape(shape_int))
 
     def test_paddle_api(self):
         self._set_paddle_api()
@@ -409,12 +390,6 @@ class TestReshapeOpError(unittest.TestCase):
 
             x3 = self.data(name="x3", shape=[2, 25], dtype="float32")
 
-            # The argument shape's type of reshape_op must be list, tuple or Variable.
-            def test_shape_type():
-                self.reshape(x3, shape=1)
-
-            self.assertRaises(TypeError, test_shape_type)
-
             # The argument actual_shape's type of reshape_op must be Variable or None.
             def test_actual_shape_type():
                 self.reshape(x3, shape=[25, 2], actual_shape=1)
@@ -480,6 +455,15 @@ class TestDygraphReshapeAPI(unittest.TestCase):
         output = self.reshape(x=input, shape=[5, 10])
         out_np = output.numpy()
         expected_out = np.reshape(input_1, newshape=[5, 10])
+        self.assertTrue(np.allclose(expected_out, out_np))
+
+    def test_shape_int(self):
+        paddle.disable_static()
+        input_1 = np.random.random([5, 20]).astype("float32")
+        input = paddle.to_tensor(input_1)
+        output = self.reshape(x=input, shape=-1)
+        out_np = output.numpy()
+        expected_out = np.reshape(input_1, newshape=-1)
         self.assertTrue(np.allclose(expected_out, out_np))
 
 

--- a/python/paddle/fluid/tests/unittests/test_reshape_op.py
+++ b/python/paddle/fluid/tests/unittests/test_reshape_op.py
@@ -338,6 +338,7 @@ class TestStaticReshape_(TestReshapeAPI):
         self._set_paddle_api()
         input = np.random.random([2, 25]).astype("float32")
         shape = [2, 5, 5]
+        shape_int = -1
         with fluid.dygraph.guard():
             x = self.to_tensor(input)
             positive_five = self.fill_constant([1], "int32", 5)
@@ -349,9 +350,12 @@ class TestStaticReshape_(TestReshapeAPI):
             shape_tensor = self.to_tensor(np.array([2, 5, 5]).astype("int32"))
             out_3 = self.reshape(x, shape=shape_tensor)
 
+            out_4 = self.reshape(x, shape=shape_int)
+
         assert np.array_equal(out_1.numpy(), input.reshape(shape))
         assert np.array_equal(out_2.numpy(), input.reshape(shape))
         assert np.array_equal(out_3.numpy(), input.reshape(shape))
+        assert np.array_equal(out_4.numpy(), input.reshape(shape_int))
 
 
 # Test Input Error


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Function optimization
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Support input integer with shape parameter of reshape, such as:
```python
a = paddle.ones([2,5]).reshape(-1)
```