### PR TITLE
modify to complex template types in reduce_sum OP

### DIFF
--- a/paddle/fluid/operators/reduce_ops/cub_reduce.h
+++ b/paddle/fluid/operators/reduce_ops/cub_reduce.h
@@ -366,33 +366,32 @@ void TensorReduce(const framework::Tensor& x, framework::Tensor* y,
 #undef CUB_BLOCK_DIM_CASE
 }
 
-template <typename Tx, typename ReduceOp, typename TransformOp>
+template <typename Tx, typename ReduceOp,
+          template <typename, typename> class TransformOp>
 struct TensorReduceFunctor {
   const framework::Tensor& x;
   framework::Tensor* y;
   std::vector<int> origin_reduce_dims;
   const double& init;
   const ReduceOp& reducer;
-  const TransformOp& transformer;
   gpuStream_t stream;
   TensorReduceFunctor(const framework::Tensor& x, framework::Tensor* y,
                       std::vector<int> origin_reduce_dims, const double& init,
-                      const ReduceOp& reducer, const TransformOp& transformer,
-                      gpuStream_t stream)
+                      const ReduceOp& reducer, gpuStream_t stream)
       : x(x),
         y(y),
         origin_reduce_dims(origin_reduce_dims),
         init(init),
         reducer(reducer),
-        transformer(transformer),
         stream(stream) {}
 
   template <typename Ty>
 
   void apply() const {
     const Ty& init_cast = static_cast<Ty>(init);
-    TensorReduce<Tx, Ty, ReduceOp, TransformOp>(
-        x, y, origin_reduce_dims, init_cast, reducer, transformer, stream);
+    TensorReduce<Tx, Ty, ReduceOp, TransformOp<Tx, Ty>>(
+        x, y, origin_reduce_dims, init_cast, reducer, TransformOp<Tx, Ty>(),
+        stream);
   }
 };
 

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.cc
@@ -119,9 +119,9 @@ REGISTER_OP_CPU_KERNEL(
     ops::ReduceKernel<paddle::platform::CPUDeviceContext, int64_t,
                       ops::SumFunctor>,
     ops::ReduceKernel<paddle::platform::CPUDeviceContext,
-                      paddle::platform::complex64, ops::SumFunctor>,
+                      paddle::platform::complex<float>, ops::SumFunctor>,
     ops::ReduceKernel<paddle::platform::CPUDeviceContext,
-                      paddle::platform::complex128,
+                      paddle::platform::complex<double>,
 
                       ops::SumFunctor>);
 
@@ -130,10 +130,9 @@ using CPUReduceSumGradKernel =
     ops::ReduceSumGradKernel<paddle::platform::CPUDeviceContext, T,
                              ops::SumGradFunctor, true>;
 
-REGISTER_OP_CPU_KERNEL(reduce_sum_grad, CPUReduceSumGradKernel<bool>,
-                       CPUReduceSumGradKernel<float>,
-                       CPUReduceSumGradKernel<double>,
-                       CPUReduceSumGradKernel<int>,
-                       CPUReduceSumGradKernel<int64_t>,
-                       CPUReduceSumGradKernel<paddle::platform::complex64>,
-                       CPUReduceSumGradKernel<paddle::platform::complex128>);
+REGISTER_OP_CPU_KERNEL(
+    reduce_sum_grad, CPUReduceSumGradKernel<bool>,
+    CPUReduceSumGradKernel<float>, CPUReduceSumGradKernel<double>,
+    CPUReduceSumGradKernel<int>, CPUReduceSumGradKernel<int64_t>,
+    CPUReduceSumGradKernel<paddle::platform::complex<float>>,
+    CPUReduceSumGradKernel<paddle::platform::complex<double>>);

--- a/paddle/fluid/operators/reduce_ops/reduce_sum_op.cu
+++ b/paddle/fluid/operators/reduce_ops/reduce_sum_op.cu
@@ -18,11 +18,13 @@
 namespace paddle {
 namespace operators {
 
-template <typename T>
+template <typename Tx, typename Ty = Tx>
 struct IdentityFunctor {
   HOSTDEVICE explicit inline IdentityFunctor() {}
 
-  HOSTDEVICE inline T operator()(const T& x) const { return x; }
+  HOSTDEVICE inline Ty operator()(const Tx& x) const {
+    return static_cast<Ty>(x);
+  }
 };
 
 template <typename T>
@@ -56,13 +58,13 @@ class ReduceSumKernel : public framework::OpKernel<T> {
     if (out_dtype >= 0) {
       framework::VisitDataTypeSmall(
           static_cast<framework::proto::VarType::Type>(out_dtype),
-          TensorReduceFunctor<T, cub::Sum, IdentityFunctor<T>>(
+          TensorReduceFunctor<T, cub::Sum, IdentityFunctor>(
               *input, output, reduce_dims, static_cast<double>(0.0), cub::Sum(),
-              IdentityFunctor<T>(), stream));
+              stream));
     } else {
-      TensorReduce<T, T, cub::Sum, IdentityFunctor<T>>(
+      TensorReduce<T, T, cub::Sum, IdentityFunctor<T, T>>(
           *input, output, reduce_dims, static_cast<T>(0), cub::Sum(),
-          IdentityFunctor<T>(), stream);
+          IdentityFunctor<T, T>(), stream);
     }
   }
 };
@@ -70,9 +72,9 @@ class ReduceSumKernel : public framework::OpKernel<T> {
 }  // namespace operators
 }  // namespace paddle
 
-REGISTER_OP_CUDA_KERNEL(reduce_sum, ops::ReduceSumKernel<bool>,
-                        ops::ReduceSumKernel<float>,
-                        ops::ReduceSumKernel<double>, ops::ReduceSumKernel<int>,
-                        ops::ReduceSumKernel<int64_t>,
-                        ops::ReduceSumKernel<paddle::platform::complex64>,
-                        ops::ReduceSumKernel<paddle::platform::complex128>);
+REGISTER_OP_CUDA_KERNEL(
+    reduce_sum, ops::ReduceSumKernel<bool>, ops::ReduceSumKernel<float>,
+    ops::ReduceSumKernel<double>, ops::ReduceSumKernel<int>,
+    ops::ReduceSumKernel<int64_t>,
+    ops::ReduceSumKernel<paddle::platform::complex<float>>,
+    ops::ReduceSumKernel<paddle::platform::complex<double>>);


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
本PR将reduce_sum Op 的复数类型从complex64/128 替换为 complex<float/double> 模板类型。

由于模板类型中 从complex<T> 转换为 实数类型 是explicit的，且原 IdentityFunctor 中不会改变数据类型，因此在编译过程中会遇到`paddle::platform::complex<float> to float` ， `paddle::platform::complex<float> to int64` 等类似的类型转换失败的报错内容。

(注： 由于原来的complex64 和complex128 类型 可以隐式地转为实数类型，因此即使 IdentityFunctor 中不会修改数据类型，编译仍可通过，但这种隐式转换会在不注意的时候导致虚部数据丢失)

报错的地方如下
```cpp
framework::VisitDataTypeSmall(
     static_cast<framework::proto::VarType::Type>(out_dtype),
     TensorReduceFunctor<T, cub::Sum, IdentityFunctor<T>>(
        *input, output, reduce_dims, static_cast<double>(0.0), cub::Sum(),
        IdentityFunctor<T>(), stream));
```

为了解决这个问题，本PR需要在IdentityFunctor中显示地指定数据类型转换， 主要修改了如下2个地方。
1. IdentityFunctor 的模板参数个数从1个增加为2个，从而可以显示地支持不同数据类型间的转换。
修改前：
```
template <typename T>
struct IdentityFunctor {
    HOSTDEVICE inline T operator()(const T& x) const { return x; }
};
```
修改后：
```
template <typename Tx, typename Ty = Tx>
struct IdentityFunctor {
   HOSTDEVICE inline Ty operator()(const Tx& x) const {
    return static_cast<Ty>(x);
  }
};
```

2. IdentityFunctor 的特化和实例化 延后至 TensorReduceFunctor中的 apply()函数中，因为一直到apply中 IdentityFunctor 所需要的2个模板类型参数才能确定。
修改前：
```
  void apply() const {
    const Ty& init_cast = static_cast<Ty>(init);
    TensorReduce<Tx, Ty, ReduceOp, TransformOp>(
        x, y, origin_reduce_dims, init_cast, reducer, transformer, stream);
  }
```
修改后：
```
  void apply() const {
    const Ty& init_cast = static_cast<Ty>(init);
    TensorReduce<Tx, Ty, ReduceOp, TransformOp<Tx, Ty>>(
        x, y, origin_reduce_dims, init_cast, reducer, TransformOp<Tx, Ty>(),
        stream);
  }
```
