### PR TITLE
add wheel in python/requirements.txt

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,4 @@ Pillow
 six
 decorator==4.4.2
 astor
+wheel


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

Issue：https://github.com/PaddlePaddle/Paddle/issues/33154  中反馈`python/requirements.txt`中没有要求安装`wheel`，但是编译paddle时要求有`wheel`。
因此在`python/requirements.txt`中添加了`wheel`。
（paddle开发镜像中默认会安装`wheel`，所以不会遇到issue中编译时报错的问题）