### PR TITLE
fix masked_select infer shape

### DIFF
--- a/paddle/fluid/operators/masked_select_op.cc
+++ b/paddle/fluid/operators/masked_select_op.cc
@@ -26,8 +26,9 @@ class MaskedSelectOp : public framework::OperatorWithKernel {
     OP_INOUT_CHECK(ctx->HasInput("X"), "Input", "Input", "MaskedSelect");
     OP_INOUT_CHECK(ctx->HasInput("Mask"), "Input", "Mask", "MaskedSelect");
     OP_INOUT_CHECK(ctx->HasOutput("Y"), "Output", "Out", "MaskedSelect");
-    framework::DDim output_dims(ctx->GetInputDim("X"));
-    ctx->SetOutputDim("Y", output_dims);
+
+    // output will only be a 1-D Tensor
+    ctx->SetOutputDim("Y", framework::make_ddim({-1}));
     ctx->ShareLoD("X", /*->*/ "Y");
   }
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
修正masked_select 在静态图下形状推导的bug，根据api描述，该op的输出只能为1-D Tensor，与输入的dims无关。
**问题现象**：静态图运行masked_select时，输出为2D-Tensor，如masked_select(a, mask_a).shape=[-1, -1], masked_select(b, mask_b).shape=[16, -1]，两个tensor无法stack。而在动态图时，两个op的结果都应该为1D-Tensor，shape=[128]。
**问题根因**：masked_select的InferShape中，输出的output_dim由输入决定，但是根据api描述的使用场景，该op的输出只能为1-D Tensor，与输入的dims无关。
**解决方案**：修改masked_select的InferShape中对于输出的形状推导方法，使其shape在静态图下始终为-1