### PR TITLE
Add lookup_table_v2 BF16 op

### DIFF
--- a/paddle/fluid/operators/lookup_table_v2_op.cc
+++ b/paddle/fluid/operators/lookup_table_v2_op.cc
@@ -197,10 +197,12 @@ REGISTER_OPERATOR(lookup_table_v2_grad, ops::LookupTableV2OpGrad,
                   ops::LookupTableV2OpGradVarTypeInference);
 
 REGISTER_OP_CPU_KERNEL(lookup_table_v2, ops::LookupTableV2Kernel<float>,
-                       ops::LookupTableV2Kernel<double>);
-REGISTER_OP_CPU_KERNEL(lookup_table_v2_grad,
-                       ops::LookupTableV2GradKernel<float>,
-                       ops::LookupTableV2GradKernel<double>);
+                       ops::LookupTableV2Kernel<double>,
+                       ops::LookupTableV2Kernel<paddle::platform::bfloat16>);
+REGISTER_OP_CPU_KERNEL(
+    lookup_table_v2_grad, ops::LookupTableV2GradKernel<float>,
+    ops::LookupTableV2GradKernel<double>,
+    ops::LookupTableV2GradKernel<paddle::platform::bfloat16>);
 
 /* ==========================  register checkpoint ===========================*/
 REGISTER_OP_VERSION(lookup_table_v2)

--- a/python/paddle/fluid/input.py
+++ b/python/paddle/fluid/input.py
@@ -309,7 +309,7 @@ def embedding(input,
 
     helper = LayerHelper('embedding', **locals())
     check_variable_and_dtype(input, 'input', ['int64'], 'fluid.embedding')
-    check_dtype(dtype, 'dtype', ['float16', 'float32', 'float64'],
+    check_dtype(dtype, 'dtype', ['float16', 'float32', 'float64', 'uint16'],
                 'fluid.embedding')
     remote_prefetch = is_sparse and (not is_distributed)
     if remote_prefetch:

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
@@ -25,18 +25,21 @@ from paddle.fluid.op import Operator
 from paddle import enable_static
 
 
-def _lookup(weights, ids, flat_ids):
+def _lookup(weights, ids, flat_ids, op_type="lookup_table"):
     w_shape = weights.shape
-    out_shape = list(ids.shape[:-1])
+    out_shape = list(ids.shape[:-1]) if op_type is "lookup_table" else list(
+        ids.shape)
     out_shape.append(w_shape[-1])
     out = weights[flat_ids].reshape(out_shape)
     return out
 
 
-def _get_grad(weights, ids, flat_ids):
+def _get_grad(weights, ids, flat_ids, op_type="lookup_table"):
     w_shape = weights.shape
     w_grad = np.zeros((w_shape), dtype=weights.dtype)
-    out_grad_shape = (np.prod(ids.shape[:-1]), w_shape[-1])
+    out_shape = list(ids.shape[:-1]) if op_type is "lookup_table" else list(
+        ids.shape)
+    out_grad_shape = (np.prod(out_shape), w_shape[-1])
     out_grad = weights[flat_ids].reshape(out_grad_shape)
     for i, idx in enumerate(flat_ids):
         w_grad[idx, :] += out_grad[i]
@@ -46,18 +49,24 @@ def _get_grad(weights, ids, flat_ids):
 @unittest.skipIf(not core.supports_bfloat16(),
                  "place does not support BF16 evaluation")
 class TestLookupTableBF16Op(OpTest):
-    def setUp(self):
+    def init_test(self):
         self.op_type = "lookup_table"
+        self.ids_shape = (4, 1)
+
+    def setUp(self):
+        self.init_test()
         self.dtype = np.uint16
 
         table = np.random.random((17, 31)).astype("float32")
-        self.ids = np.random.randint(0, 17, (4, 1)).astype("int64")
+        self.ids = np.random.randint(0, 17, self.ids_shape).astype("int64")
         self.flat_ids = self.ids.flatten()
 
         self.w_bf16 = convert_float_to_uint16(table)
-        self.out_bf16 = _lookup(self.w_bf16, self.ids, self.flat_ids)
-        self.out_fp32 = _lookup(table, self.ids, self.flat_ids)
-        self.w_grad_fp32 = _get_grad(table, self.ids, self.flat_ids)
+        self.out_bf16 = _lookup(self.w_bf16, self.ids, self.flat_ids,
+                                self.op_type)
+        self.out_fp32 = _lookup(table, self.ids, self.flat_ids, self.op_type)
+        self.w_grad_fp32 = _get_grad(table, self.ids, self.flat_ids,
+                                     self.op_type)
 
         self.inputs = {'W': self.w_bf16, 'Ids': self.ids}
         self.outputs = {'Out': self.out_fp32}
@@ -79,17 +88,22 @@ class TestLookupTableBF16Op(OpTest):
 @unittest.skipIf(not core.supports_bfloat16(),
                  "place does not support BF16 evaluation")
 class TestLookupTableBF16OpIds4D(TestLookupTableBF16Op):
-    def setUp(self):
-        super(TestLookupTableBF16OpIds4D, self).setUp()
-        self.ids = np.random.randint(0, 17, (2, 4, 5, 1)).astype("int64")
+    def init_test(self):
+        self.op_type = "lookup_table"
+        self.ids_shape = (2, 4, 5, 1)
 
 
 @unittest.skipIf(not core.supports_bfloat16(),
                  "place does not support BF16 evaluation")
 class TestLookupTableBF16OpWIsSelectedRows(unittest.TestCase):
+    def init_test(self):
+        self.op_type = "lookup_table"
+        self.ids_shape = (10, 1)
+
     def setUp(self):
+        self.init_test()
         self.ids = np.random.randint(
-            low=0, high=15, size=(10, 1)).astype("int64")
+            low=0, high=15, size=self.ids_shape).astype("int64")
         self.flat_ids = self.ids.flatten()
         self.w_fp32 = np.random.random((15, 32)).astype("float32")
         self.w_bf16 = convert_float_to_uint16(self.w_fp32)
@@ -120,12 +134,12 @@ class TestLookupTableBF16OpWIsSelectedRows(unittest.TestCase):
         out_tensor = self.scope.var('Out').get_tensor()
 
         # create and run lookup_table operator
-        lookup_table = Operator("lookup_table", W='W', Ids='Ids', Out='Out')
+        lookup_table = Operator(self.op_type, W='W', Ids='Ids', Out='Out')
         lookup_table.run(self.scope, self.place)
 
         # get result from Out
         result_array = np.array(out_tensor)
-        ref = _lookup(self.w_fp32, self.ids, self.flat_ids)
+        ref = _lookup(self.w_fp32, self.ids, self.flat_ids, self.op_type)
         self._check_output(ref, result_array)
 
 
@@ -133,10 +147,12 @@ class TestLookupTableBF16OpWIsSelectedRows(unittest.TestCase):
                  "place does not support BF16 evaluation")
 class TestLookupTableBF16OpWIsSelectedRows4DIds(
         TestLookupTableBF16OpWIsSelectedRows):
+    def init_test(self):
+        self.op_type = "lookup_table"
+        self.ids_shape = (3, 4, 5, 1)
+
     def setUp(self):
         super(TestLookupTableBF16OpWIsSelectedRows4DIds, self).setUp()
-        self.ids = np.random.randint(
-            low=0, high=15, size=(3, 4, 5, 1)).astype("int64")
         self.flat_ids = self.ids.flatten()
 
 

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_bf16_op.py
@@ -25,19 +25,19 @@ from paddle.fluid.op import Operator
 from paddle import enable_static
 
 
-def _lookup(weights, ids, flat_ids, op_type="lookup_table"):
+def _lookup(weights, ids, flat_ids, op_version="lookup_table"):
     w_shape = weights.shape
-    out_shape = list(ids.shape[:-1]) if op_type is "lookup_table" else list(
+    out_shape = list(ids.shape[:-1]) if op_version is "lookup_table" else list(
         ids.shape)
     out_shape.append(w_shape[-1])
     out = weights[flat_ids].reshape(out_shape)
     return out
 
 
-def _get_grad(weights, ids, flat_ids, op_type="lookup_table"):
+def _get_grad(weights, ids, flat_ids, op_version="lookup_table"):
     w_shape = weights.shape
     w_grad = np.zeros((w_shape), dtype=weights.dtype)
-    out_shape = list(ids.shape[:-1]) if op_type is "lookup_table" else list(
+    out_shape = list(ids.shape[:-1]) if op_version is "lookup_table" else list(
         ids.shape)
     out_grad_shape = (np.prod(out_shape), w_shape[-1])
     out_grad = weights[flat_ids].reshape(out_grad_shape)

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import unittest
 import numpy as np
+import paddle
 from paddle.fluid.tests.unittests.op_test import (skip_check_grad_ci,
                                                   convert_uint16_to_float)
 from paddle.fluid.tests.unittests.test_lookup_table_bf16_op import (
@@ -30,12 +31,14 @@ class TestLookupTableV2BF16Op(TestLookupTableBF16Op):
     def init_test(self):
         self.op_type = "lookup_table_v2"
         self.ids_shape = (4)
+        self.mkldnn_data_type = "bfloat16"
 
 
 class TestLookupTableV2BF16OpIds4D(TestLookupTableBF16OpIds4D):
     def init_test(self):
         self.op_type = "lookup_table_v2"
         self.ids_shape = (2, 4, 5)
+        self.mkldnn_data_type = "bfloat16"
 
 
 class TestLookupTableV2BF16OpWIsSelectedRows(
@@ -62,7 +65,7 @@ class TestLookupTableBF16OpWithPadding(TestLookupTableV2BF16Op):
         padding_idx = np.random.choice(ids, 1)[0]
         self.outputs['Out'][ids == padding_idx] = np.zeros(31)
         self.attrs = {'padding_idx': int(padding_idx)}
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace())
 
 
 @skip_check_grad_ci(
@@ -76,7 +79,7 @@ class TestLookupTableBF16OpIds4DPadding(TestLookupTableV2BF16OpIds4D):
         padding_idx = np.random.choice(flatten_idx, 1)[0]
         self.outputs['Out'][np.squeeze(ids == padding_idx)] = np.zeros(31)
         self.attrs = {'padding_idx': int(padding_idx)}
-        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+        self.check_output_with_place(core.CPUPlace())
 
 
 class TestEmbeddingLayerBF16ConstantInitializer(unittest.TestCase):
@@ -127,4 +130,5 @@ class TestEmbeddingLayerBF16ConstantInitializer(unittest.TestCase):
 
 
 if __name__ == "__main__":
+    paddle.enable_static()
     unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
@@ -55,10 +55,6 @@ class TestLookupTableV2BF16OpWIsSelectedRows4DIds(
         self.ids_shape = (3, 4, 5)
 
 
-@skip_check_grad_ci(
-    reason="Since paddings are not trainable and fixed in forward,"
-    "the gradient of paddings makes no sense and we don't "
-    "test the gradient here.")
 class TestLookupTableBF16OpWithPadding(TestLookupTableV2BF16Op):
     def test_check_output(self):
         ids = np.squeeze(self.inputs['Ids'])
@@ -68,10 +64,6 @@ class TestLookupTableBF16OpWithPadding(TestLookupTableV2BF16Op):
         self.check_output_with_place(core.CPUPlace())
 
 
-@skip_check_grad_ci(
-    reason="Since paddings are not trainable and fixed in forward,"
-    "the gradient of paddings makes no sense and we don't "
-    "test the gradient here.")
 class TestLookupTableBF16OpIds4DPadding(TestLookupTableV2BF16OpIds4D):
     def test_check_output(self):
         ids = self.inputs['Ids']

--- a/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
+++ b/python/paddle/fluid/tests/unittests/test_lookup_table_v2_bf16_op.py
@@ -1,0 +1,175 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import numpy as np
+from paddle.fluid.tests.unittests.op_test import OpTest, skip_check_grad_ci, convert_float_to_uint16, convert_uint16_to_float
+import paddle.fluid as fluid
+import paddle.fluid.core as core
+from paddle.fluid.op import Operator
+
+
+def _lookup(weights, ids, flat_ids):
+    w_shape = weights.shape
+    out_shape = [ids.shape[-1]]
+    out_shape.append(w_shape[-1])
+    out = weights[flat_ids].reshape(out_shape)
+    return out
+
+
+def _get_grad(weights, ids, flat_ids):
+    w_shape = weights.shape
+    w_grad = np.zeros((w_shape), dtype=weights.dtype)
+    out_grad_shape = (np.prod(ids.shape[-1]), w_shape[-1])
+    out_grad = weights[flat_ids].reshape(out_grad_shape)
+    for i, idx in enumerate(flat_ids):
+        w_grad[idx, :] += out_grad[i]
+    return w_grad
+
+
+class TestLookupTableV2BF16Op(OpTest):
+    def setUp(self):
+        self.op_type = "lookup_table_v2"
+        self.dtype = np.uint16
+
+        table = np.random.random((17, 31)).astype("float32")
+        self.ids = np.random.randint(0, 17, 4).astype("int64")
+        self.flat_ids = self.ids.flatten()
+
+        self.w_bf16 = convert_float_to_uint16(table)
+        self.out_bf16 = _lookup(self.w_bf16, self.ids, self.flat_ids)
+        self.out_fp32 = _lookup(table, self.ids, self.flat_ids)
+        self.w_grad_fp32 = _get_grad(table, self.ids, self.flat_ids)
+
+        self.inputs = {'W': self.w_bf16, 'Ids': self.ids}
+        self.outputs = {'Out': self.out_fp32}
+
+    def test_check_output(self):
+        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+
+    def test_check_grad(self):
+        self.check_grad_with_place(
+            core.CPUPlace(), ['W'],
+            'Out',
+            no_grad_set=set('Ids'),
+            check_dygraph=False,
+            max_relative_error=1.5e-2,
+            user_defined_grads=[self.w_grad_fp32],
+            user_defined_grad_outputs=[self.out_bf16])
+
+
+class TestLookupTableV2BF16OpWIsSelectedRows(unittest.TestCase):
+    def setUp(self):
+        self.ids = np.random.randint(low=0, high=15, size=(10)).astype("int64")
+        self.flat_ids = self.ids.flatten()
+        self.w_fp32 = np.random.random((15, 32)).astype("float32")
+        self.w_bf16 = convert_float_to_uint16(self.w_fp32)
+        self.scope = core.Scope()
+        self.place = core.CPUPlace()
+
+    def prepare_w(self):
+        rows = [a for a in range(self.w_bf16.shape[0])]
+
+        w_selected_rows = self.scope.var('W').get_selected_rows()
+        w_selected_rows.set_height(len(rows))
+        w_selected_rows.set_rows(rows)
+        w_tensor = w_selected_rows.get_tensor()
+        w_tensor.set(self.w_bf16, self.place)
+
+    def prepare_ids(self):
+        ids_tensor = self.scope.var('Ids').get_tensor()
+        ids_tensor.set(self.ids, self.place)
+
+    def _check_output(self, reference, result_array):
+        result_array_fp32 = convert_uint16_to_float(result_array)
+        np.testing.assert_allclose(result_array_fp32, reference, rtol=1e-1)
+
+    def test_check_output(self):
+        self.prepare_ids()
+        self.prepare_w()
+        out_tensor = self.scope.var('Out').get_tensor()
+
+        # create and run lookup_table operator
+        lookup_table = Operator("lookup_table_v2", W='W', Ids='Ids', Out='Out')
+        lookup_table.run(self.scope, self.place)
+
+        # get result from Out
+        result_array = np.array(out_tensor)
+        ref = _lookup(self.w_fp32, self.ids, self.flat_ids)
+        self._check_output(ref, result_array)
+
+
+@skip_check_grad_ci(
+    reason="Since paddings are not trainable and fixed in forward,"
+    "the gradient of paddings makes no sense and we don't "
+    "test the gradient here.")
+class TestLookupTableV2BF16OpWithPadding(TestLookupTableV2BF16Op):
+    def test_check_output(self):
+        ids = np.squeeze(self.inputs['Ids'])
+        padding_idx = np.random.choice(ids, 1)[0]
+        self.outputs['Out'][ids == padding_idx] = np.zeros(31)
+        self.attrs = {'padding_idx': int(padding_idx)}
+        self.check_output_with_place(core.CPUPlace(), check_dygraph=False)
+
+
+class TestEmbeddingLayerBF16ConstantInitializer(unittest.TestCase):
+    """
+    Test embedding layer api and results for bfloat16
+    """
+
+    def set_initializer(self):
+        self.initializer = fluid.initializer.Constant(value=self.value)
+
+    def setUp(self):
+        self.ids_shape = [4]
+        self.w_shape = [10, 64]
+        self.ids = np.random.randint(
+            low=0, high=9, size=self.ids_shape).astype("int64")
+        self.flat_ids = self.ids.flatten()
+        self.value = 3.0
+        self.w_fp32 = np.full(self.w_shape, self.value)
+        self.place = fluid.CPUPlace()
+        self.prog = fluid.Program()
+        self.startup_prog = fluid.Program()
+        self.set_initializer()
+
+        with fluid.program_guard(self.prog, self.startup_prog):
+            x = fluid.layers.data(name='x', shape=self.ids_shape, dtype='int64')
+            self.emb = fluid.input.embedding(
+                input=x,
+                size=self.w_shape,
+                param_attr=fluid.ParamAttr(
+                    name="emb_weight", initializer=self.initializer),
+                is_sparse=False,
+                dtype="uint16")  # bfloat16
+        exe = fluid.Executor(self.place)
+        exe.run(self.startup_prog)
+        self.result = exe.run(self.prog,
+                              feed={'x': self.ids},
+                              fetch_list=['emb_weight', self.emb])
+
+    def test_embedding_weights(self):
+        result = convert_uint16_to_float(self.result[0])
+        self.assertTrue(np.array_equal(self.w_fp32, result))
+
+    def test_lookup_results(self):
+        lookup_result = convert_uint16_to_float(self.result[1])
+        lookup_ref = _lookup(self.w_fp32, self.ids, self.flat_ids)
+        self.assertTrue(np.array_equal(lookup_result, lookup_ref))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/static_mode_white_list.py
+++ b/tools/static_mode_white_list.py
@@ -22,6 +22,7 @@ STATIC_MODE_TESTING_LIST = [
     'test_lod_reset_op',
     'test_lookup_table_op',
     'test_lookup_table_bf16_op',
+    'test_lookup_table_v2_bf16_op',
     'test_pad2d_op',
     'test_scatter_op',
     'test_sequence_concat',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
This PR adds BF16 support for FWD and BWD lookup_table_v2 op. 
Added UT that reuses test `test_lookup_table_bf16_op`.