### PR TITLE
Add bf16 support for save and load ops

### DIFF
--- a/paddle/fluid/operators/load_combine_op.cc
+++ b/paddle/fluid/operators/load_combine_op.cc
@@ -87,6 +87,8 @@ REGISTER_OP_CPU_KERNEL(
     load_combine,
     ops::LoadCombineOpKernel<paddle::platform::CPUDeviceContext, float>,
     ops::LoadCombineOpKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::LoadCombineOpKernel<paddle::platform::CPUDeviceContext,
+                             paddle::platform::bfloat16>,
     ops::LoadCombineOpKernel<paddle::platform::CPUDeviceContext, int>,
     ops::LoadCombineOpKernel<paddle::platform::CPUDeviceContext, int8_t>,
     ops::LoadCombineOpKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/load_op.cc
+++ b/paddle/fluid/operators/load_op.cc
@@ -69,6 +69,8 @@ REGISTER_OPERATOR(load, ops::LoadOp, ops::LoadOpProtoMaker);
 REGISTER_OP_CPU_KERNEL(
     load, ops::LoadOpKernel<paddle::platform::CPUDeviceContext, float>,
     ops::LoadOpKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::LoadOpKernel<paddle::platform::CPUDeviceContext,
+                      paddle::platform::bfloat16>,
     ops::LoadOpKernel<paddle::platform::CPUDeviceContext, int>,
     ops::LoadOpKernel<paddle::platform::CPUDeviceContext, int8_t>,
     ops::LoadOpKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/save_combine_op.cc
+++ b/paddle/fluid/operators/save_combine_op.cc
@@ -102,5 +102,7 @@ REGISTER_OP_CPU_KERNEL(
     save_combine,
     ops::SaveCombineOpKernel<paddle::platform::CPUDeviceContext, float>,
     ops::SaveCombineOpKernel<paddle::platform::CPUDeviceContext, double>,
+    ops::SaveCombineOpKernel<paddle::platform::CPUDeviceContext,
+                             paddle::platform::bfloat16>,
     ops::SaveCombineOpKernel<paddle::platform::CPUDeviceContext, int>,
     ops::SaveCombineOpKernel<paddle::platform::CPUDeviceContext, int64_t>);

--- a/paddle/fluid/operators/save_op.cc
+++ b/paddle/fluid/operators/save_op.cc
@@ -90,6 +90,8 @@ REGISTER_OP_CPU_KERNEL(
     ops::SaveOpKernel<paddle::platform::CPUDeviceContext, double>,
     ops::SaveOpKernel<paddle::platform::CPUDeviceContext,
                       paddle::platform::float16>,
+    ops::SaveOpKernel<paddle::platform::CPUDeviceContext,
+                      paddle::platform::bfloat16>,
     ops::SaveOpKernel<paddle::platform::CPUDeviceContext, int>,
     ops::SaveOpKernel<paddle::platform::CPUDeviceContext, uint8_t>,
     ops::SaveOpKernel<paddle::platform::CPUDeviceContext, int8_t>,

--- a/python/paddle/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/fluid/tests/book/test_fit_a_line.py
@@ -85,8 +85,8 @@ def train(use_cuda, save_dirname, is_local, use_bf16, pure_bf16):
                                           fetch_list=[avg_cost])
                 if avg_loss_value[0] < 10.0 or pure_bf16:
                     if save_dirname is not None:
-                        fluid.io.save_inference_model(save_dirname, ['x'],
-                                                      [y_predict], exe)
+                        paddle.static.save_inference_model(save_dirname, [x],
+                                                           [y_predict], exe)
                     return
                 if math.isnan(float(avg_loss_value)):
                     sys.exit("got NaN loss, training failed.")
@@ -132,7 +132,7 @@ def infer(use_cuda, save_dirname=None, use_bf16=False):
         # data using feed operators), and the fetch_targets (variables that
         # we want to obtain data from using fetch operators).
         [inference_program, feed_target_names,
-         fetch_targets] = fluid.io.load_inference_model(save_dirname, exe)
+         fetch_targets] = paddle.static.load_inference_model(save_dirname, exe)
 
         # The input's dimension should be 2-D and the second dim is 13
         # The input data should be >= 0

--- a/python/paddle/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/fluid/tests/book/test_fit_a_line.py
@@ -127,7 +127,7 @@ def infer(use_cuda, save_dirname=None, use_bf16=False):
 
     inference_scope = fluid.core.Scope()
     with fluid.scope_guard(inference_scope):
-        # Use fluid.io.load_inference_model to obtain the inference program desc,
+        # Use paddle.static.load_inference_model to obtain the inference program desc,
         # the feed_target_names (the names of variables that will be fed
         # data using feed operators), and the fetch_targets (variables that
         # we want to obtain data from using fetch operators).

--- a/python/paddle/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/fluid/tests/book/test_fit_a_line.py
@@ -21,7 +21,6 @@ import paddle.static.amp as amp
 import contextlib
 import numpy
 import unittest
-from paddle.fluid.tests.unittests.op_test import convert_uint16_to_float
 import math
 import sys
 import os
@@ -153,8 +152,7 @@ def infer(use_cuda, save_dirname=None, use_bf16=False):
                           feed={feed_target_names[0]: numpy.array(test_feat)},
                           fetch_list=fetch_targets)
         print("infer shape: ", results[0].shape)
-        print("infer results: ", results[0] if results[0].dtype != numpy.uint16
-              else convert_uint16_to_float(results[0]))
+        print("infer results: ", results[0])
         print("ground truth: ", test_label)
 
 

--- a/python/paddle/fluid/tests/book/test_fit_a_line.py
+++ b/python/paddle/fluid/tests/book/test_fit_a_line.py
@@ -21,6 +21,7 @@ import paddle.static.amp as amp
 import contextlib
 import numpy
 import unittest
+from paddle.fluid.tests.unittests.op_test import convert_uint16_to_float
 import math
 import sys
 import os
@@ -84,7 +85,7 @@ def train(use_cuda, save_dirname, is_local, use_bf16, pure_bf16):
                                           feed=feeder.feed(data),
                                           fetch_list=[avg_cost])
                 if avg_loss_value[0] < 10.0 or pure_bf16:
-                    if save_dirname is not None and not pure_bf16:
+                    if save_dirname is not None:
                         fluid.io.save_inference_model(save_dirname, ['x'],
                                                       [y_predict], exe)
                     return
@@ -152,7 +153,8 @@ def infer(use_cuda, save_dirname=None, use_bf16=False):
                           feed={feed_target_names[0]: numpy.array(test_feat)},
                           fetch_list=fetch_targets)
         print("infer shape: ", results[0].shape)
-        print("infer results: ", results[0])
+        print("infer results: ", results[0] if results[0].dtype != numpy.uint16
+              else convert_uint16_to_float(results[0]))
         print("ground truth: ", test_label)
 
 

--- a/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
@@ -1,0 +1,131 @@
+#   Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function
+
+import unittest
+import paddle
+import paddle.fluid as fluid
+import paddle.fluid.framework as framework
+from paddle.fluid.optimizer import SGDOptimizer
+from paddle.fluid.tests.unittests.test_imperative_base import new_program_scope
+from paddle.fluid.tests.unittests.test_static_save_load import PtbModel
+import numpy as np
+
+
+class TestSaveLoadBF16(unittest.TestCase):
+    def set_place(self):
+        return fluid.CPUPlace()
+
+    def test_ptb_rnn_cpu_bfloat16(self):
+        seed = 90
+        hidden_size = 10
+        vocab_size = 1000
+        num_layers = 1
+        num_steps = 3
+        init_scale = 0.1
+        batch_size = 4
+        batch_num = 200
+
+        with new_program_scope():
+            fluid.default_startup_program().random_seed = seed
+            fluid.default_main_program().random_seed = seed
+            ptb_model = PtbModel(
+                "ptb_model",
+                hidden_size=hidden_size,
+                vocab_size=vocab_size,
+                num_layers=num_layers,
+                num_steps=num_steps,
+                init_scale=init_scale)
+
+            place = self.set_place()
+            exe = fluid.Executor(place)
+            sgd = SGDOptimizer(learning_rate=1e-3)
+            x = fluid.layers.data(
+                name="x", shape=[-1, num_steps], dtype='int64')
+            y = fluid.layers.data(name="y", shape=[-1, 1], dtype='float32')
+            init_hidden = fluid.layers.data(
+                name="init_hidden", shape=[1], dtype='float32')
+            init_cell = fluid.layers.data(
+                name="init_cell", shape=[1], dtype='float32')
+
+            static_loss, static_last_hidden, static_last_cell = ptb_model(
+                x, y, init_hidden, init_cell)
+
+            sgd = paddle.static.amp.bf16.decorate_bf16(
+                sgd,
+                amp_lists=paddle.static.amp.bf16.AutoMixedPrecisionListsBF16(
+                    custom_fp32_list={'matmul', 'transpose2', 'concat'}),
+                use_bf16_guard=False,
+                use_pure_bf16=True)
+
+            sgd.minimize(static_loss, framework.default_startup_program())
+            out = exe.run(framework.default_startup_program())
+
+            for i in range(batch_num):
+                x_data = np.arange(12).reshape(4, 3).astype('int64')
+                y_data = np.arange(1, 13).reshape(4, 3).astype('int64')
+                x_data = x_data.reshape((-1, num_steps, 1))
+                y_data = y_data.reshape((-1, 1))
+                init_hidden_data = np.zeros(
+                    (num_layers, batch_size, hidden_size), dtype='float32')
+                init_cell_data = np.zeros(
+                    (num_layers, batch_size, hidden_size), dtype='float32')
+                fetch_list = [static_loss, static_last_hidden, static_last_cell]
+                out = exe.run(fluid.default_main_program(),
+                              feed={
+                                  "x": x_data,
+                                  "y": y_data,
+                                  "init_hidden": init_hidden_data,
+                                  "init_cell": init_cell_data
+                              },
+                              fetch_list=fetch_list)
+
+            # get value before save
+            main_program = framework.default_main_program()
+            base_map = {}
+            for var in main_program.list_vars():
+                if isinstance(var, framework.Parameter) or var.persistable:
+                    t = np.array(fluid.global_scope().find_var(var.name)
+                                 .get_tensor())
+                    # make sure all the paramerter or optimizer var have been update
+                    self.assertTrue(np.sum(np.abs(t)) != 0)
+                    base_map[var.name] = t
+
+            fluid.save(main_program, "./test_1")
+
+            # set var to zero
+            for var in main_program.list_vars():
+                if isinstance(var, framework.Parameter) or var.persistable:
+                    ten = fluid.global_scope().find_var(var.name).get_tensor()
+                    ten.set(np.zeros_like(np.array(ten)), place)
+
+                    new_t = np.array(fluid.global_scope().find_var(var.name)
+                                     .get_tensor())
+                    # make sure all the paramerter or optimizer var have been set to zero
+                    self.assertTrue(np.sum(np.abs(new_t)) == 0)
+
+            fluid.load(main_program, "./test_1.pdparams", exe)
+
+            for var in main_program.list_vars():
+                if isinstance(var, framework.Parameter) or var.persistable:
+                    new_t = np.array(fluid.global_scope().find_var(var.name)
+                                     .get_tensor())
+                    base_t = base_map[var.name]
+                    self.assertTrue(np.array_equal(new_t, base_t))
+
+
+if __name__ == '__main__':
+    paddle.enable_static()
+    unittest.main()

--- a/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
@@ -69,7 +69,7 @@ class TestSaveLoadBF16(unittest.TestCase):
             sgd = paddle.static.amp.bf16.decorate_bf16(
                 sgd,
                 amp_lists=paddle.static.amp.bf16.AutoMixedPrecisionListsBF16(
-                    custom_fp32_list={'matmul', 'transpose2', 'concat'}),
+                    custom_fp32_list={'transpose2', 'concat'}),
                 use_bf16_guard=False,
                 use_pure_bf16=True)
 

--- a/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
@@ -34,12 +34,12 @@ class TestSaveLoadBF16(unittest.TestCase):
     def test_ptb_rnn_cpu_bfloat16(self):
         seed = 90
         hidden_size = 10
-        vocab_size = 1000
+        vocab_size = 500
         num_layers = 1
         num_steps = 3
         init_scale = 0.1
         batch_size = 4
-        batch_num = 200
+        batch_num = 100
 
         with new_program_scope():
             fluid.default_startup_program().random_seed = seed

--- a/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
+++ b/python/paddle/fluid/tests/unittests/test_static_save_load_bf16.py
@@ -16,6 +16,7 @@ from __future__ import print_function
 
 import unittest
 import paddle
+import paddle.fluid.core as core
 import paddle.fluid as fluid
 import paddle.fluid.framework as framework
 from paddle.fluid.optimizer import SGDOptimizer
@@ -24,6 +25,8 @@ from paddle.fluid.tests.unittests.test_static_save_load import PtbModel
 import numpy as np
 
 
+@unittest.skipIf(not core.supports_bfloat16(),
+                 "place does not support BF16 evaluation")
 class TestSaveLoadBF16(unittest.TestCase):
     def set_place(self):
         return fluid.CPUPlace()

--- a/tools/static_mode_white_list.py
+++ b/tools/static_mode_white_list.py
@@ -479,6 +479,7 @@ STATIC_MODE_TESTING_LIST = [
     'test_squared_l2_norm_op',
     'test_stack_op',
     'test_static_save_load',
+    'test_static_save_load_bf16',
     'test_sum_op',
     'test_switch',
     'test_switch_case',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs 
### Describe
<!-- Describe what this PR does -->

This PR adds:
-  BF16 support for ops: (`save`, `save_combine`, `load`, `load_combine`)
-  an enablement of save_inference_model for pure_bf16 in `test_fit_a_line.py` 


