### PR TITLE
improve group norm cpu precision and performance

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_group_norm_op_v2.py
@@ -53,6 +53,15 @@ class TestDygraphGroupNormv2(unittest.TestCase):
                         weight_attr=False,
                         bias_attr=False)
 
+            def test_nn_exception():
+                with fluid.dygraph.guard(p):
+
+                    def attr_data_format():
+                        out = paddle.nn.GroupNorm(
+                            num_groups=2, num_channels=2, data_format="NHWC")
+
+                    self.assertRaises(ValueError, attr_data_format)
+
             x = np.random.randn(*shape).astype("float32")
             y1 = compute_v1(x)
             y2 = compute_v2(x)
@@ -61,6 +70,7 @@ class TestDygraphGroupNormv2(unittest.TestCase):
                 print("y1:", y1, "\ty2:", y2)
             self.assertTrue(result)
             test_weight_bias_false()
+            test_nn_exception()
 
     def test_static(self):
         places = [fluid.CPUPlace()]

--- a/python/paddle/nn/layer/norm.py
+++ b/python/paddle/nn/layer/norm.py
@@ -375,7 +375,7 @@ class GroupNorm(layers.Layer):
         self._num_channels = num_channels
         self._num_groups = num_groups
         if data_format != 'NCHW':
-            raise ValueError("unsupported data layout:" + data_layout)
+            raise ValueError("unsupported data layout:" + data_format)
 
         param_shape = [self._num_channels]
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Performance optimization

### PR changes
OPs

### Describe
问题：paddle.nn.GroupNorm 在float32下CPU计算结果和准确值的相对误差大于e-5
原因：原有计算方法在计算均值和方差时为逐个数相加，当计算数据个数较多 且 累加数比较大 且 单个元素较小 时就容易造成舍入误差 从而导致 最终结果的误差
方案：使用SIMD的思想进行分组累加，最后再归并加和以降低舍入误差，并调研其它框架中的类似算法，均使用此种思想来实现。同时有个附加好处是增加了计算并行性，提升性能
效果：paddle.nn.GroupNorm 在float32下CPU计算结果和准确值的相对误差已经小于e-6，且性能提升7%