### PR TITLE
[cherry-pick][CustomOP]Set GLIBCXX_USE_CXX11_ABI=1  to fix potential GCC ABI problem(#33153)

### DIFF
--- a/python/paddle/utils/cpp_extension/cpp_extension.py
+++ b/python/paddle/utils/cpp_extension/cpp_extension.py
@@ -427,6 +427,12 @@ class BuildExtension(build_ext, object):
                 elif isinstance(cflags, dict):
                     cflags = cflags['cxx']
 
+                # NOTE(Aurelius84): Since Paddle 2.0, we require gcc version > 5.x,
+                # so we add this flag to ensure the symbol names from user compiled
+                # shared library have same ABI suffix with core_(no)avx.so.
+                # See https://stackoverflow.com/questions/34571583/understanding-gcc-5s-glibcxx-use-cxx11-abi-or-the-new-abi
+                add_compile_flag(['-D_GLIBCXX_USE_CXX11_ABI=1'], cflags)
+
                 add_std_without_repeat(
                     cflags, self.compiler.compiler_type, use_std14=False)
                 original_compile(obj, src, ext, cc_args, cflags, pp_opts)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

cherry-pick (#33153)
