### PR TITLE
fix compile error of eigen_function

### DIFF
--- a/paddle/fluid/operators/pscore/CMakeLists.txt
+++ b/paddle/fluid/operators/pscore/CMakeLists.txt
@@ -27,7 +27,7 @@ register_operators(DEPS ${DISTRIBUTE_DEPS})
 set(OPERATOR_DEPS ${OPERATOR_DEPS} ${DISTRIBUTE_DEPS} PARENT_SCOPE)
 
 set_source_files_properties(heter_server_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test(heter_server_test SRCS heter_server_test.cc DEPS ${RPC_DEPS} ${DISTRIBUTE_DEPS} executor scope proto_desc scale_op)
+cc_test(heter_server_test SRCS heter_server_test.cc DEPS ${RPC_DEPS} ${DISTRIBUTE_DEPS} executor scope proto_desc scale_op eigen_function)
 
 set_source_files_properties(heter_listen_and_server_test.cc PROPERTIES COMPILE_FLAGS ${DISTRIBUTE_COMPILE_FLAGS})
-cc_test(heter_listen_and_server_test SRCS heter_listen_and_server_test.cc DEPS executor scope proto_desc scale_op heter_listen_and_serv_op ${RPC_DEPS} ${DISTRIBUTE_DEPS})
+cc_test(heter_listen_and_server_test SRCS heter_listen_and_server_test.cc DEPS executor scope proto_desc scale_op heter_listen_and_serv_op ${RPC_DEPS} ${DISTRIBUTE_DEPS} eigen_function)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

fix compile error of eigen_function


```
/usr/local/bin/ld: ../libscale_op.a(scale_op.cc.o): in function `paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext, paddle::platform::float16>::Compute(paddle::framework::ExecutionContext const&) const [clone .constprop.2009]':
scale_op.cc:(.text._ZNK6paddle9operators11ScaleKernelINS_8platform17CUDADeviceContextENS2_7float16EE7ComputeERKNS_9framework16ExecutionContextE.constprop.2009[_ZNSt17_Function_handlerIFvRKN6paddle9framework16ExecutionContextEEZNKS1_24OpKernelRegistrarFunctorINS0_8platform9CUDAPlaceELb0ELm7EJNS0_9operators11ScaleKernelINS7_17CUDADeviceContextEfEENSA_ISB_dEENSA_ISB_hEENSA_ISB_aEENSA_ISB_sEENSA_ISB_iEENSA_ISB_lEENSA_ISB_NS7_7float16EEEEEclEPKcSN_iEUlS4_E_E9_M_invokeERKSt9_Any_dataS4_]+0x38f): undefined reference to `paddle::operators::EigenScale<Eigen::GpuDevice, paddle::platform::float16>::Eval(Eigen::GpuDevice const&, Eigen::TensorMap<Eigen::Tensor<paddle::platform::float16, 1, 1, long>, 0, Eigen::MakePointer>, Eigen::TensorMap<Eigen::Tensor<paddle::platform::float16 const, 1, 1, long>, 0, Eigen::MakePointer> const&, paddle::platform::float16, paddle::platform::float16, bool)'
/usr/local/bin/ld: ../libscale_op.a(scale_op.cc.o): in function `paddle::operators::ScaleKernel<paddle::platform::CUDADeviceContext, paddle::platform::float16>::Compute(paddle::framework::ExecutionContext const&) const':
scale_op.cc:(.text._ZNK6paddle9operators11ScaleKernelINS_8platform17CUDADeviceContextENS2_7float16EE7ComputeERKNS_9framework16ExecutionContextE[_ZNK6paddle9operators11ScaleKernelINS_8platform17CUDADeviceContextENS2_7float16EE7ComputeERKNS_9framework16ExecutionContextE]+0x38f): undefined reference to `paddle::operators::EigenScale<Eigen::GpuDevice, paddle::platform::float16>::Eval(Eigen::GpuDevice const&, Eigen::TensorMap<Eigen::Tensor<paddle::platform::float16, 1, 1, long>, 0, Eigen::MakePointer>, Eigen::TensorMap<Eigen::Tensor<paddle::platform::float16 const, 1, 1, long>, 0, Eigen::MakePointer> const&, paddle::platform::float16, paddle::platform::float16, bool)'
collect2: error: ld returned 1 exit status
paddle/fluid/operators/pscore/CMakeFiles/heter_listen_and_server_test.dir/build.make:270: recipe for target 'paddle/fluid/operators/pscore/heter_listen_and_server_test' failed
```