### PR TITLE
Fix spawn default nprocs get error

### DIFF
--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -89,6 +89,21 @@ def _options_valid_check(options):
                     % key)
 
 
+def _get_default_nprocs():
+    device = get_device()
+    if device == 'cpu':
+        # TODO: not supports cpu parallel now
+        return _cpu_num()
+    elif 'gpu' in device:
+        return core.get_cuda_device_count()
+    elif 'xpu' in device:
+        return core.get_xpu_device_count()
+    else:
+        raise ValueError(
+            "`device` should be a string of `cpu`, 'gpu' or 'xpu', but got {}".
+            format(device))
+
+
 def _get_node_ip(ips):
     node_ip = None
     node_ips = [x.strip() for x in ips.split(',')]
@@ -448,18 +463,7 @@ def spawn(func, args=(), nprocs=-1, join=True, daemon=False, **options):
 
     # get default nprocs
     if nprocs == -1:
-        device = get_device()
-        if device == 'cpu':
-            # TODO: not supports cpu parallel now
-            nprocs = _cpu_num()
-        elif device == 'gpu':
-            nprocs = core.get_cuda_device_count()
-        elif device == 'xpu':
-            nprocs = core.get_xpu_device_count()
-        else:
-            raise ValueError(
-                "`device` should be a string of `cpu`, 'gpu' or 'xpu', but got {}".
-                format(device))
+        nprocs = _get_default_nprocs()
 
     # NOTE(chenweihang): [ why need get cluster info before run? ]
     # when using `paddle.distributed.spawn` start parallel training, 

--- a/python/paddle/distributed/spawn.py
+++ b/python/paddle/distributed/spawn.py
@@ -91,16 +91,13 @@ def _options_valid_check(options):
 
 def _get_default_nprocs():
     device = get_device()
-    if device == 'cpu':
-        # TODO: not supports cpu parallel now
-        return _cpu_num()
-    elif 'gpu' in device:
+    if 'gpu' in device:
         return core.get_cuda_device_count()
     elif 'xpu' in device:
         return core.get_xpu_device_count()
     else:
-        raise ValueError(
-            "`device` should be a string of `cpu`, 'gpu' or 'xpu', but got {}".
+        raise RuntimeError(
+            "`paddle.distributed.spawn` does not support parallel training on device `{}` now.".
             format(device))
 
 

--- a/python/paddle/fluid/tests/unittests/test_spawn_and_init_parallel_env.py
+++ b/python/paddle/fluid/tests/unittests/test_spawn_and_init_parallel_env.py
@@ -20,7 +20,7 @@ import unittest
 
 import paddle
 import paddle.distributed as dist
-from paddle.distributed.spawn import _get_subprocess_env_list, _options_valid_check
+from paddle.distributed.spawn import _get_subprocess_env_list, _options_valid_check, _get_default_nprocs
 
 from paddle.fluid import core
 from paddle.fluid.dygraph import parallel_helper
@@ -86,6 +86,15 @@ class TestSpawnAssistMethod(unittest.TestCase):
         with self.assertRaises(ValueError):
             options['error'] = "error"
             _options_valid_check(options)
+
+    def test_get_default_nprocs(self):
+        paddle.set_device('cpu')
+        nprocs = _get_default_nprocs()
+        self.assertEqual(nprocs, 1)
+
+        paddle.set_device('gpu')
+        nprocs = _get_default_nprocs()
+        self.assertEqual(nprocs, core.get_cuda_device_count())
 
 
 if __name__ == "__main__":

--- a/python/paddle/fluid/tests/unittests/test_spawn_and_init_parallel_env.py
+++ b/python/paddle/fluid/tests/unittests/test_spawn_and_init_parallel_env.py
@@ -89,8 +89,8 @@ class TestSpawnAssistMethod(unittest.TestCase):
 
     def test_get_default_nprocs(self):
         paddle.set_device('cpu')
-        nprocs = _get_default_nprocs()
-        self.assertEqual(nprocs, 1)
+        with self.assertRaises(RuntimeError):
+            nprocs = _get_default_nprocs()
 
         paddle.set_device('gpu')
         nprocs = _get_default_nprocs()


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->

Fix spawn default nprocs get error.

the return value of `get_device()` is `gpu:x` or `xpu:x` when device is gpu or xpu, it can't compare by `==`, fix it.

the original error like:

![image](https://user-images.githubusercontent.com/22561442/120139244-a34b1380-c20a-11eb-95ea-8a533405ede4.png)

related issue: https://github.com/PaddlePaddle/Paddle/issues/33183