### PR TITLE
[Dy2Static] Support move data to CUDA in advance before running run_program_op

### DIFF
--- a/paddle/fluid/imperative/layer.cc
+++ b/paddle/fluid/imperative/layer.cc
@@ -333,6 +333,7 @@ void VarBase::MoveTo(const platform::Place& dst_place, bool blocking) {
   framework::TensorCopy(*src_tensor, dst_place, &dst_tensor);
   if (blocking) {
     platform::DeviceContextPool::Instance().Get(dst_place)->Wait();
+    platform::DeviceContextPool::Instance().Get(Place())->Wait();
   }
   // inplace update src tensor data
   src_tensor->ShareBufferWith(dst_tensor);

--- a/paddle/fluid/imperative/layer.h
+++ b/paddle/fluid/imperative/layer.h
@@ -108,7 +108,7 @@ class VarBase {
 
   void ClearGradVarBase() { grad_var_ = nullptr; }
 
-  void SetGradVarBase(VarBase& grad_var) {
+  void SetGradVarBase(const VarBase& grad_var) {
     MutableGradVarBase()->CopyFrom(grad_var, true);
   }
 
@@ -222,6 +222,8 @@ class VarBase {
                                       const bool blocking) const;
 
   void CopyFrom(const imperative::VarBase& src, bool blocking);
+
+  void MoveTo(const platform::Place& dst_place, bool blocking);
 
   void BumpInplaceVersion();
 

--- a/paddle/fluid/pybind/imperative.cc
+++ b/paddle/fluid/pybind/imperative.cc
@@ -1459,6 +1459,43 @@ void BindImperative(py::module *m_ptr) {
              return new_var;
            },
            py::return_value_policy::copy)
+
+      .def("_move_to",
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::CPUPlace &place, bool blocking) {
+             self->MoveTo(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return self;
+           })
+      .def("_move_to",
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::CUDAPinnedPlace &place, bool blocking) {
+             self->MoveTo(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return self;
+           })
+      .def("_move_to",
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::XPUPlace &place, bool blocking) {
+             self->MoveTo(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return self;
+           })
+      .def("_move_to",
+           [](const std::shared_ptr<imperative::VarBase> &self,
+              const platform::CUDAPlace &place, bool blocking) {
+             self->MoveTo(place, blocking);
+             if (!blocking) {
+               IncreaseVarbaseReferenceCountUntilCopyComplete(self, place);
+             }
+             return self;
+           })
       .def("value", [](imperative::VarBase &self) { return self.MutableVar(); },
            py::return_value_policy::reference)
       .def_property("name", &imperative::VarBase::Name,

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -244,6 +244,10 @@ class PartialProgramLayer(layers.Layer):
             elif isinstance(value, core.VarBase):
                 var = value
                 var.name = self._inputs[i].desc.name()
+                # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
+                # into CUDAPlace when it's as input of multi Ops. Because the transformation
+                # is not in-place so we use `_move_to` to move data to avoid this.
+                var._move_to(framework._current_expected_place())
             else:
                 continue
             input_vars.append(var)

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -247,7 +247,7 @@ class PartialProgramLayer(layers.Layer):
                 # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
                 # into CUDAPlace when it's as input of multi Ops. Because the transformation
                 # is not in-place so we use `_move_to` to move data to avoid this.
-                var._move_to(framework._current_expected_place())
+                var._move_to(framework._current_expected_place(), False)
             else:
                 continue
             input_vars.append(var)

--- a/python/paddle/fluid/tests/unittests/test_var_base.py
+++ b/python/paddle/fluid/tests/unittests/test_var_base.py
@@ -439,6 +439,50 @@ class TestVarBase(unittest.TestCase):
                     np.array(copy_selected_rows.get_tensor()),
                     np.array(selected_rows.get_tensor())))
 
+    def _test_move_to(self, in_var, is_selected_row=False):
+        def _get_numpy_data(var, is_selected_row=False):
+            if is_selected_row:
+                np_data = np.array(var.value().get_selected_rows().get_tensor())
+            else:
+                np_data = var.numpy()
+            return np_data
+
+        def _assert_move(var, dst_place, blocking):
+            src_data = _get_numpy_data(var, is_selected_row)
+            var._move_to(dst_place, blocking)
+            self.assertEqual(str(var.place), str(dst_place))
+
+            dst_data = _get_numpy_data(var, is_selected_row)
+            self.assertTrue(np.array_equal(src_data, dst_data))
+
+        for blocking in [True, False]:
+            # CPU -> CUDAPinned -> CUDA
+            _assert_move(in_var, paddle.CPUPlace(), blocking)
+            if core.is_compiled_with_cuda():
+                _assert_move(in_var, paddle.CUDAPinnedPlace(), blocking)
+                _assert_move(in_var, paddle.CUDAPlace(0), blocking)
+                # CUDA -> CUDAPinned -> CPU
+                _assert_move(in_var, paddle.CUDAPinnedPlace(), blocking)
+                _assert_move(in_var, paddle.CPUPlace(), blocking)
+                # CPU -> CUDA -> CPU
+                _assert_move(in_var, paddle.CUDAPlace(0), blocking)
+                _assert_move(in_var, paddle.CPUPlace(), blocking)
+
+    def test_move_to_new_device_inplace(self):
+        # test common VarBase
+        in_var = paddle.to_tensor([1, 2, 3], place=paddle.CPUPlace())
+        self._test_move_to(in_var)
+
+        # test move_to with selected rows
+        x = core.VarBase(core.VarDesc.VarType.FP32, [3, 100],
+                         "selected_rows_var",
+                         core.VarDesc.VarType.SELECTED_ROWS, True)
+        selected_rows = x.value().get_selected_rows()
+        selected_rows.get_tensor().set(np.random.rand(3, 100), core.CPUPlace())
+        selected_rows.set_height(10)
+        selected_rows.set_rows([3, 5, 7])
+        self._test_move_to(x, True)
+
     # test some patched methods
     def test_set_value(self):
         with fluid.dygraph.guard():


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Support move data to CUDA in advance before running run_program_op


PR 之前，若某个input 的 Tensor 参与前向和反向，则存在两次Sync的 PrepareData的数据copy：
![image](https://user-images.githubusercontent.com/9301846/120421993-f0112480-c399-11eb-9c85-f858eb8dc32e.png)

PR 之后，通过提前 inplace 的将数据搬运到GPU上，不存在多余的数据copy：
![image](https://user-images.githubusercontent.com/9301846/120422075-1cc53c00-c39a-11eb-959b-c73306ff6c7c.png)
