### PR TITLE
Add assertion to ensure that size of each dim of paramerter is larger than 0

### DIFF
--- a/python/paddle/fluid/layer_helper_base.py
+++ b/python/paddle/fluid/layer_helper_base.py
@@ -312,6 +312,10 @@ class LayerHelperBase(object):
         if not attr:
             return None
         assert isinstance(attr, ParamAttr)
+        for i, size in enumerate(shape):
+            assert size > 0, (
+                "Expected every dim's size to be larger than 0, "
+                "but the size of the {}-th dim is {}".format(i, size))
         # set global dtype
         if not dtype:
             dtype = self.__dtype


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->
Add an assertion to ensure that the size of each dim of the parameter to be created is larger than 0.

When trying to create a parameter that has some dim's size == 0, currently an exception would be raised when the initializer is calculating some shape related statistics. But this exception is not always raised because some dimensions' sizes are not relavant to these statistics and some initializers do not compute such statistics.

So we add an exception to ensure that size of each dimension of the parameter to be created is larger than 0 to avoid consequent errors. A parameter with num_element == 0 is meaningless in this case.
