### PR TITLE
linear use matmul bug not matmul_v2

### DIFF
--- a/python/paddle/nn/functional/common.py
+++ b/python/paddle/nn/functional/common.py
@@ -1446,7 +1446,9 @@ def linear(x, weight, bias=None, name=None):
           #     [2.1077576  2.1077576  2.1077576  2.1077576 ]]
     """
     if in_dygraph_mode():
-        pre_bias = core.ops.matmul_v2(x, weight)
+        pre_bias = _varbase_creator(dtype=x.dtype)
+        core.ops.matmul(x, weight, pre_bias, 'transpose_X', False,
+                        'transpose_Y', False, "alpha", 1)
 
         if bias is None:
             return pre_bias


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs 
### Describe
<!-- Describe what this PR does -->

PR https://github.com/PaddlePaddle/Paddle/pull/32125 中将matmul改为了matmul_v2
但由于matmul_v2没有DoubleGrad OP导致 gan的stylegan_v2_256_ffhq模型挂掉。
这里将matmul_v2改回matmul。
