### PR TITLE
update 2.0 public api in all left files

### DIFF
--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -244,9 +244,8 @@ from .framework import save  # noqa: F401
 from .framework import load  # noqa: F401
 from .framework import DataParallel  # noqa: F401
 
-from .framework import set_default_dtype  #DEFINE_ALIAS
-from .framework import get_default_dtype  #DEFINE_ALIAS
-from .framework import set_grad_enabled  #DEFINE_ALIAS
+from .framework import set_default_dtype  # noqa: F401
+from .framework import get_default_dtype  # noqa: F401
 
 from .tensor.search import index_sample  # noqa: F401
 from .tensor.stat import mean  # noqa: F401
@@ -484,7 +483,6 @@ __all__ = [     #noqa
            'logical_not',
            'add_n',
            'minimum',
-           'ComplexTensor',
            'scatter',
            'scatter_',
            'floor',
@@ -493,5 +491,6 @@ __all__ = [     #noqa
            'log2',
            'log10',
            'concat',
-           'check_shape'
+           'check_shape',
+           'standard_normal'
 ]

--- a/python/paddle/__init__.py
+++ b/python/paddle/__init__.py
@@ -21,8 +21,7 @@ except ImportError:
      import paddle from the source directory; please install paddlepaddle*.whl firstly.'''
                      )
 
-import paddle.batch
-batch = batch.batch
+from .batch import batch  # noqa: F401
 from .fluid import monkey_patch_variable
 from .fluid.dygraph import monkey_patch_math_varbase
 monkey_patch_variable()
@@ -135,7 +134,6 @@ from .tensor.manipulation import squeeze  # noqa: F401
 from .tensor.manipulation import squeeze_  # noqa: F401
 from .tensor.manipulation import stack  # noqa: F401
 from .tensor.manipulation import strided_slice  # noqa: F401
-from .tensor.manipulation import transpose  # noqa: F401
 from .tensor.manipulation import unique  # noqa: F401
 from .tensor.manipulation import unsqueeze  # noqa: F401
 from .tensor.manipulation import unsqueeze_  # noqa: F401
@@ -191,7 +189,6 @@ from .tensor.math import floor_mod  # noqa: F401
 from .tensor.math import multiply  # noqa: F401
 from .tensor.math import add  # noqa: F401
 from .tensor.math import subtract  # noqa: F401
-from .tensor.math import atan  # noqa: F401
 from .tensor.math import logsumexp  # noqa: F401
 from .tensor.math import inverse  # noqa: F401
 from .tensor.math import log1p  # noqa: F401
@@ -280,7 +277,7 @@ import paddle.vision  # noqa: F401
 from .tensor.random import check_shape  # noqa: F401
 disable_static()
 
-__all__ = [     #noqa
+__all__ = [  # noqa
            'dtype',
            'uint8',
            'int8',
@@ -322,7 +319,6 @@ __all__ = [     #noqa
            'cos',
            'tan',
            'mean',
-           'XPUPlace',
            'mv',
            'in_dynamic_mode',
            'min',
@@ -359,7 +355,6 @@ __all__ = [     #noqa
            'to_tensor',
            'gather_nd',
            'isinf',
-           'set_device',
            'uniform',
            'floor_divide',
            'remainder',
@@ -383,8 +378,6 @@ __all__ = [     #noqa
            'rand',
            'less_equal',
            'triu',
-           'is_compiled_with_cuda',
-           'is_compiled_with_rocm',
            'sin',
            'dist',
            'unbind',
@@ -413,8 +406,6 @@ __all__ = [     #noqa
            'bernoulli',
            'summary',
            'sinh',
-           'is_compiled_with_xpu',
-           'is_compiled_with_npu',
            'round',
            'DataParallel',
            'argmin',
@@ -436,7 +427,6 @@ __all__ = [     #noqa
            'not_equal',
            'sum',
            'tile',
-           'get_device',
            'greater_equal',
            'isfinite',
            'create_parameter',
@@ -469,7 +459,6 @@ __all__ = [     #noqa
            'scatter_nd',
            'set_default_dtype',
            'expand_as',
-           'get_cudnn_version',
            'stack',
            'sqrt',
            'cholesky',

--- a/python/paddle/amp/__init__.py
+++ b/python/paddle/amp/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .auto_cast import auto_cast
-from .grad_scaler import GradScaler
+from .auto_cast import auto_cast  # noqa: F401
+from .grad_scaler import GradScaler  # noqa: F401
 
 __all__ = ['auto_cast', 'GradScaler']

--- a/python/paddle/amp/auto_cast.py
+++ b/python/paddle/amp/auto_cast.py
@@ -14,7 +14,7 @@
 
 from paddle.fluid.dygraph.amp import amp_guard
 
-__all__ = ['auto_cast']
+__all__ = []
 
 
 def auto_cast(enable=True, custom_white_list=None, custom_black_list=None):

--- a/python/paddle/amp/grad_scaler.py
+++ b/python/paddle/amp/grad_scaler.py
@@ -14,7 +14,7 @@
 
 from paddle.fluid.dygraph.amp import AmpScaler
 
-__all__ = ['GradScaler']
+__all__ = []
 
 
 class GradScaler(AmpScaler):

--- a/python/paddle/autograd/__init__.py
+++ b/python/paddle/autograd/__init__.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..fluid.dygraph.base import grad  #DEFINE_ALIAS
-
-from . import backward_mode
-from .backward_mode import backward
-from .py_layer import PyLayer, PyLayerContext
+from ..fluid.dygraph.base import grad  # noqa: F401
+from . import backward_mode  # noqa: F401
+from .backward_mode import backward  # noqa: F401
+from .py_layer import PyLayer, PyLayerContext  # noqa: F401
 
 __all__ = ['grad', 'backward', 'PyLayer', 'PyLayerContext']

--- a/python/paddle/autograd/backward_mode.py
+++ b/python/paddle/autograd/backward_mode.py
@@ -15,7 +15,7 @@
 from paddle.fluid import core
 from paddle.fluid import framework
 import paddle
-__all__ = ['backward']
+__all__ = []
 
 
 @framework.dygraph_only

--- a/python/paddle/autograd/py_layer.py
+++ b/python/paddle/autograd/py_layer.py
@@ -15,7 +15,7 @@
 import paddle
 from paddle.fluid.framework import dygraph_only
 from paddle.fluid import core
-__all__ = ['PyLayer', 'PyLayerContext']
+__all__ = []
 
 
 class PyLayerContext(object):

--- a/python/paddle/batch.py
+++ b/python/paddle/batch.py
@@ -60,7 +60,7 @@ def batch(reader, batch_size, drop_last=False):
             if len(b) == batch_size:
                 yield b
                 b = []
-        if drop_last == False and len(b) != 0:
+        if drop_last is False and len(b) != 0:
             yield b
 
     # Batch size check

--- a/python/paddle/batch.py
+++ b/python/paddle/batch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__all__ = ['batch']
+__all__ = []
 
 
 def batch(reader, batch_size, drop_last=False):
@@ -35,11 +35,11 @@ def batch(reader, batch_size, drop_last=False):
     Examples:
         .. code-block:: python
            
-            import paddle.fluid as fluid
+            import paddle
             def reader():
                 for i in range(10):
                     yield i
-            batch_reader = fluid.io.batch(reader, batch_size=2)
+            batch_reader = paddle.batch(reader, batch_size=2)
             
             for data in batch_reader():
                 print(data)

--- a/python/paddle/compat.py
+++ b/python/paddle/compat.py
@@ -19,7 +19,7 @@ __all__ = []
 
 if six.PY2:
     int_type = int
-    long_type = long
+    long_type = long  # noqa: F821
 else:
     int_type = int
     long_type = int

--- a/python/paddle/compat.py
+++ b/python/paddle/compat.py
@@ -15,14 +15,7 @@
 import six
 import math
 
-__all__ = [
-    'long_type',
-    'to_text',
-    'to_bytes',
-    'round',
-    'floor_division',
-    'get_exception_message',
-]
+__all__ = []
 
 if six.PY2:
     int_type = int

--- a/python/paddle/device.py
+++ b/python/paddle/device.py
@@ -21,7 +21,17 @@ from paddle.fluid.dygraph.parallel import ParallelEnv
 from paddle.fluid.framework import is_compiled_with_cuda  # noqa: F401
 from paddle.fluid.framework import is_compiled_with_rocm  # noqa: F401
 
-__all__ = []
+
+__all__ = [  # npqa
+    'get_cudnn_version',
+    'set_device',
+    'get_device',
+    'XPUPlace',
+    'is_compiled_with_xpu',
+    'is_compiled_with_cuda',
+    'is_compiled_with_rocm',
+    'is_compiled_with_npu'
+]
 
 _cudnn_version = None
 
@@ -113,15 +123,13 @@ def _convert_to_place(device):
         place = core.CPUPlace()
     elif lower_device == 'gpu':
         if not core.is_compiled_with_cuda():
-            raise ValueError(
-                "The device should not be 'gpu', " \
-                "since PaddlePaddle is not compiled with CUDA")
+            raise ValueError("The device should not be 'gpu', "
+                             "since PaddlePaddle is not compiled with CUDA")
         place = core.CUDAPlace(ParallelEnv().dev_id)
     elif lower_device == 'xpu':
         if not core.is_compiled_with_xpu():
-            raise ValueError(
-                "The device should not be 'xpu', " \
-                "since PaddlePaddle is not compiled with XPU")
+            raise ValueError("The device should not be 'xpu', "
+                             "since PaddlePaddle is not compiled with XPU")
         selected_xpus = os.getenv("FLAGS_selected_xpus", "0").split(",")
         device_id = int(selected_xpus[0])
         place = core.XPUPlace(device_id)
@@ -135,7 +143,7 @@ def _convert_to_place(device):
         if avaliable_gpu_device:
             if not core.is_compiled_with_cuda():
                 raise ValueError(
-                    "The device should not be {}, since PaddlePaddle is " \
+                    "The device should not be {}, since PaddlePaddle is "
                     "not compiled with CUDA".format(avaliable_gpu_device))
             device_info_list = device.split(':', 1)
             device_id = device_info_list[1]
@@ -144,7 +152,7 @@ def _convert_to_place(device):
         if avaliable_xpu_device:
             if not core.is_compiled_with_xpu():
                 raise ValueError(
-                    "The device should not be {}, since PaddlePaddle is " \
+                    "The device should not be {}, since PaddlePaddle is "
                     "not compiled with XPU".format(avaliable_xpu_device))
             device_info_list = device.split(':', 1)
             device_id = device_info_list[1]

--- a/python/paddle/device.py
+++ b/python/paddle/device.py
@@ -18,25 +18,10 @@ import os
 from paddle.fluid import core
 from paddle.fluid import framework
 from paddle.fluid.dygraph.parallel import ParallelEnv
-from paddle.fluid.framework import is_compiled_with_cuda  #DEFINE_ALIAS
-from paddle.fluid.framework import is_compiled_with_rocm  #DEFINE_ALIAS
+from paddle.fluid.framework import is_compiled_with_cuda  # noqa: F401
+from paddle.fluid.framework import is_compiled_with_rocm  # noqa: F401
 
-__all__ = [
-    'get_cudnn_version',
-    'set_device',
-    'get_device',
-    'XPUPlace',
-    'is_compiled_with_xpu'
-    #            'cpu_places',
-    #            'CPUPlace',
-    #            'cuda_pinned_places',
-    #            'cuda_places',
-    #            'CUDAPinnedPlace',
-    #            'CUDAPlace',
-    'is_compiled_with_cuda',
-    'is_compiled_with_rocm',
-    'is_compiled_with_npu'
-]
+__all__ = []
 
 _cudnn_version = None
 
@@ -68,7 +53,7 @@ def is_compiled_with_xpu():
         .. code-block:: python
 
             import paddle
-            support_xpu = paddle.device.is_compiled_with_xpu()
+            support_xpu = paddle.is_compiled_with_xpu()
     """
     return core.is_compiled_with_xpu()
 
@@ -82,9 +67,10 @@ def XPUPlace(dev_id):
 
     Examples:
         .. code-block:: python
-
+            # required: xpu
+            
             import paddle
-            place = paddle.device.XPUPlace(0)
+            place = paddle.XPUPlace(0)
     """
     return core.XPUPlace(dev_id)
 

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -150,7 +150,6 @@ def init_parallel_env():
     init_gloo = int(os.getenv("PADDLE_WITH_GLOO", "0"))
     if init_gloo:
         ep_rank_0 = parallel_env.trainer_endpoints[0].split(":")
-        ep_rank = parallel_env.trainer_endpoints[parallel_env.rank].split(":")
         manager = Manager()
         # glboal dict to store status
         http_server_d = manager.dict()

--- a/python/paddle/distributed/parallel.py
+++ b/python/paddle/distributed/parallel.py
@@ -29,9 +29,7 @@ from paddle.fluid.dygraph import parallel_helper
 from paddle.fluid.dygraph.parallel import ParallelEnv
 from paddle.distributed.fleet.base.private_helper_function import wait_server_ready  # noqa: F401
 
-__all__ = [  #noqa
-    "init_parallel_env"
-]
+__all__ = []
 
 ParallelStrategy = core.ParallelStrategy
 

--- a/python/paddle/incubate/__init__.py
+++ b/python/paddle/incubate/__init__.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from . import optimizer
-from . import checkpoint
-from ..fluid.layer_helper import LayerHelper
+from .optimizer import LookAhead  # noqa: F401
+from .optimizer import ModelAverage  # noqa: F401
+from .checkpoint import auto_checkpoint  # noqa: F401
+from ..fluid.layer_helper import LayerHelper  # noqa: F401
 
-__all__ = []
-__all__ += optimizer.__all__
-__all__ += checkpoint.__all__
+__all__ = [  # noqa
+    'LookAhead', 'ModelAverage'
+]

--- a/python/paddle/incubate/checkpoint/__init__.py
+++ b/python/paddle/incubate/checkpoint/__init__.py
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ...fluid.incubate.checkpoint import auto_checkpoint
+from ...fluid.incubate.checkpoint import auto_checkpoint  # noqa: F401
 
-__all__ = ["auto_checkpoint"]
+__all__ = []

--- a/python/paddle/incubate/optimizer/__init__.py
+++ b/python/paddle/incubate/optimizer/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .lookahead import LookAhead
-from .modelaverage import ModelAverage
+from .lookahead import LookAhead  # noqa: F401
+from .modelaverage import ModelAverage  # noqa: F401
 
-__all__ = ['LookAhead', 'ModelAverage']
+__all__ = []

--- a/python/paddle/incubate/optimizer/lookahead.py
+++ b/python/paddle/incubate/optimizer/lookahead.py
@@ -20,7 +20,7 @@ import paddle
 import numpy as np
 from paddle.fluid.dygraph import base as imperative_base
 
-__all__ = ["LookAhead"]
+__all__ = []
 
 
 class LookAhead(Optimizer):
@@ -99,7 +99,7 @@ class LookAhead(Optimizer):
             layer = LinearNet()
             loss_fn = nn.CrossEntropyLoss()
             optimizer = paddle.optimizer.SGD(learning_rate=0.1, parameters=layer.parameters())
-            lookahead = paddle.incubate.optimizer.LookAhead(optimizer, alpha=0.2, k=5)
+            lookahead = paddle.incubate.LookAhead(optimizer, alpha=0.2, k=5)
 
             # create data loader
             dataset = RandomDataset(BATCH_NUM * BATCH_SIZE)
@@ -163,7 +163,7 @@ class LookAhead(Optimizer):
                 out = linear(inp)
                 loss = paddle.mean(out)
                 sgd = paddle.optimizer.SGD(learning_rate=0.1,parameters=linear.parameters())
-                lookahead = paddle.incubate.optimizer.LookAhead(sgd, alpha=0.2, k=5)
+                lookahead = paddle.incubate.LookAhead(sgd, alpha=0.2, k=5)
                 loss.backward()
                 lookahead.step()
                 lookahead.clear_grad()
@@ -274,7 +274,7 @@ class LookAhead(Optimizer):
                 out = linear(inp)
                 loss = paddle.mean(out)
                 sgd = paddle.optimizer.SGD(learning_rate=0.1,parameters=linear.parameters())
-                lookahead = paddle.incubate.optimizer.LookAhead(sgd, alpha=0.2, k=5)
+                lookahead = paddle.incubate.LookAhead(sgd, alpha=0.2, k=5)
                 loss.backward()
                 lookahead.minimize(loss)
                 lookahead.clear_grad()

--- a/python/paddle/incubate/optimizer/lookahead.py
+++ b/python/paddle/incubate/optimizer/lookahead.py
@@ -282,9 +282,6 @@ class LookAhead(Optimizer):
         """
         assert isinstance(loss, Variable), "The loss should be an Tensor."
 
-        parameter_list = parameters if parameters \
-            else self._parameter_list
-
         # Apply inner optimizer to the main_program
         optimize_ops, params_grads = self.inner_optimizer.minimize(
             loss,

--- a/python/paddle/incubate/optimizer/modelaverage.py
+++ b/python/paddle/incubate/optimizer/modelaverage.py
@@ -21,7 +21,7 @@ import numpy as np
 from paddle.fluid.dygraph import base as imperative_base
 from paddle.fluid.wrapped_decorator import signature_safe_contextmanager
 
-__all__ = ["ModelAverage"]
+__all__ = []
 
 
 class ModelAverage(Optimizer):
@@ -129,7 +129,7 @@ class ModelAverage(Optimizer):
         layer = LinearNet()
         loss_fn = nn.CrossEntropyLoss()
         optimizer = opt.Momentum(learning_rate=0.2, momentum=0.1, parameters=layer.parameters())
-        model_average = paddle.incubate.optimizer.ModelAverage(0.15,
+        model_average = paddle.incubate.ModelAverage(0.15,
                                                     parameters=layer.parameters(),
                                                     min_average_window=2,
                                                     max_average_window=10)
@@ -313,7 +313,7 @@ class ModelAverage(Optimizer):
                 sgd = paddle.optimizer.SGD(learning_rate=0.1,parameters=linear.parameters())
                 sgd.minimize(loss)
 
-                modelaverage = paddle.incubate.optimizer.ModelAverage(0.15,
+                modelaverage = paddle.incubate.ModelAverage(0.15,
                                                             parameters=linear.parameters(),
                                                             min_average_window=2,
                                                             max_average_window=4)
@@ -345,7 +345,7 @@ class ModelAverage(Optimizer):
                 out = linear(inp)
                 loss = paddle.mean(out)
                 sgd = paddle.optimizer.SGD(learning_rate=0.1,parameters=linear.parameters())
-                modelaverage = paddle.incubate.optimizer.ModelAverage(0.15,
+                modelaverage = paddle.incubate.ModelAverage(0.15,
                                                             parameters=linear.parameters(),
                                                             min_average_window=2,
                                                             max_average_window=4)
@@ -395,7 +395,7 @@ class ModelAverage(Optimizer):
 
                 sgd = paddle.optimizer.SGD(learning_rate=0.1,parameters=linear.parameters())
 
-                modelaverage = paddle.incubate.optimizer.ModelAverage(0.15,
+                modelaverage = paddle.incubate.ModelAverage(0.15,
                                                             parameters=linear.parameters(),
                                                             min_average_window=2,
                                                             max_average_window=4)
@@ -467,7 +467,7 @@ class ModelAverage(Optimizer):
 
                 sgd = paddle.optimizer.SGD(learning_rate=0.1,parameters=linear.parameters())
 
-                modelaverage = paddle.incubate.optimizer.ModelAverage(0.15,
+                modelaverage = paddle.incubate.ModelAverage(0.15,
                                                             parameters=linear.parameters(),
                                                             min_average_window=2,
                                                             max_average_window=4)

--- a/python/paddle/incubate/optimizer/modelaverage.py
+++ b/python/paddle/incubate/optimizer/modelaverage.py
@@ -415,7 +415,6 @@ class ModelAverage(Optimizer):
                                                         param)
                 old_num_accumulates = self._get_accumulator(
                     'old_num_accumulates', param)
-                num_updates = self._get_accumulator('num_updates', param)
                 sum_1 = self._get_accumulator('sum_1', param)
                 sum_2 = self._get_accumulator('sum_2', param)
                 sum_3 = self._get_accumulator('sum_3', param)
@@ -506,17 +505,15 @@ class ModelAverage(Optimizer):
             self._get_accumulator('num_accumulates', param))
         old_num_accumulates = block._clone_variable(
             self._get_accumulator('old_num_accumulates', param))
-        num_updates = block._clone_variable(
-            self._get_accumulator('num_updates', param))
         # backup param value to grad
         layers.assign(input=param, output=grad)
         # param = (sum_1 + sum_2 + sum_3) / (num_accumulates + old_num_accumulates)
         tmp = layers.sum(x=[num_accumulates, old_num_accumulates])
         sum = layers.sum(x=[sum_1, sum_2, sum_3])
         tmp = layers.cast(
-            x=tmp, dtype='float32' if self._dtype == None else self._dtype)
+            x=tmp, dtype='float32' if self._dtype is None else self._dtype)
         sum = layers.cast(
-            x=sum, dtype='float32' if self._dtype == None else self._dtype)
+            x=sum, dtype='float32' if self._dtype is None else self._dtype)
         layers.ops._elementwise_div(x=sum, y=tmp, out=param)
 
     def _add_average_restore_op(self, block, param):

--- a/python/paddle/inference/__init__.py
+++ b/python/paddle/inference/__init__.py
@@ -12,5 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..fluid.inference import Config, DataType, PlaceType, PrecisionType, Tensor, \
-    Predictor, create_predictor, get_version, get_num_bytes_of_data_type, PredictorPool
+from ..fluid.inference import Config  # noqa: F401
+from ..fluid.inference import DataType  # noqa: F401
+from ..fluid.inference import PlaceType  # noqa: F401
+from ..fluid.inference import PrecisionType  # noqa: F401
+from ..fluid.inference import Tensor  # noqa: F401
+from ..fluid.inference import Predictor  # noqa: F401
+from ..fluid.inference import create_predictor  # noqa: F401
+from ..fluid.inference import get_version  # noqa: F401
+from ..fluid.inference import get_num_bytes_of_data_type  # noqa: F401
+from ..fluid.inference import PredictorPool  # noqa: F401
+
+__all__ = [  # noqa
+    'Config',
+    'DataType',
+    'PlaceType',
+    'PrecisionType',
+    'Tensor',
+    'Predictor',
+    'create_predictor',
+    'get_version',
+    'get_num_bytes_of_data_type',
+    'PredictorPool'
+]

--- a/python/paddle/jit/__init__.py
+++ b/python/paddle/jit/__init__.py
@@ -14,19 +14,26 @@
 
 from __future__ import print_function
 
-from ..fluid.dygraph.jit import save  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import load  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import TracedLayer  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import set_code_level  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import set_verbosity  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import declarative as to_static  #DEFINE_ALIAS
-from ..fluid.dygraph.jit import not_to_static  #DEFINE_ALIAS
-from ..fluid.dygraph import ProgramTranslator  #DEFINE_ALIAS
-from ..fluid.dygraph.io import TranslatedLayer  #DEFINE_ALIAS
+from ..fluid.dygraph.jit import save  # noqa: F401
+from ..fluid.dygraph.jit import load  # noqa: F401
+from ..fluid.dygraph.jit import TracedLayer  # noqa: F401
+from ..fluid.dygraph.jit import set_code_level  # noqa: F401
+from ..fluid.dygraph.jit import set_verbosity  # noqa: F401
+from ..fluid.dygraph.jit import declarative as to_static  # noqa: F401
+from ..fluid.dygraph.jit import not_to_static  # noqa: F401
+from ..fluid.dygraph import ProgramTranslator  # noqa: F401
+from ..fluid.dygraph.io import TranslatedLayer  # noqa: F401
 
-from . import dy2static
+from . import dy2static  # noqa: F401
 
-__all__ = [
-    'save', 'load', 'TracedLayer', 'to_static', 'ProgramTranslator',
-    'TranslatedLayer', 'set_code_level', 'set_verbosity', 'not_to_static'
+__all__ = [  # noqa
+    'save',
+    'load',
+    'TracedLayer',
+    'to_static',
+    'ProgramTranslator',
+    'TranslatedLayer',
+    'set_code_level',
+    'set_verbosity',
+    'not_to_static'
 ]

--- a/python/paddle/jit/dy2static/__init__.py
+++ b/python/paddle/jit/dy2static/__init__.py
@@ -12,18 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-
-from . import convert_operators
-from .convert_operators import *
-
-from . import convert_call_func
-from .convert_call_func import *
-
-from . import variable_trans_func
-from .variable_trans_func import *
+from .convert_call_func import convert_call  # noqa: F401
+from .convert_operators import cast_bool_if_necessary  # noqa: F401
+from .convert_operators import convert_assert  # noqa: F401
+from .convert_operators import convert_ifelse  # noqa: F401
+from .convert_operators import convert_len  # noqa: F401
+from .convert_operators import convert_logical_and  # noqa: F401
+from .convert_operators import convert_logical_not  # noqa: F401
+from .convert_operators import convert_logical_or  # noqa: F401
+from .convert_operators import convert_pop  # noqa: F401
+from .convert_operators import convert_print  # noqa: F401
+from .convert_operators import convert_shape_compare  # noqa: F401
+from .convert_operators import convert_var_dtype  # noqa: F401
+from .convert_operators import convert_var_shape  # noqa: F401
+from .convert_operators import convert_var_shape_simple  # noqa: F401
+from .convert_operators import eval_if_exist_else_none  # noqa: F401
+from .convert_operators import choose_shape_attr_or_api  # noqa: F401
+from .convert_operators import convert_while_loop  # noqa: F401
+from .variable_trans_func import create_bool_as_type  # noqa: F401
+from .variable_trans_func import create_fill_constant_node  # noqa: F401
+from .variable_trans_func import create_static_variable_gast_node  # noqa: F401
+from .variable_trans_func import data_layer_not_check  # noqa: F401
+from .variable_trans_func import to_static_variable  # noqa: F401
+from .variable_trans_func import to_static_variable_gast_node  # noqa: F401
 
 __all__ = []
-__all__ += convert_operators.__all__
-__all__ += convert_call_func.__all__
-__all__ += variable_trans_func.__all__

--- a/python/paddle/jit/dy2static/convert_call_func.py
+++ b/python/paddle/jit/dy2static/convert_call_func.py
@@ -13,6 +13,6 @@
 # limitations under the License.
 from __future__ import print_function
 
-from ...fluid.dygraph.dygraph_to_static.convert_call_func import convert_call  #DEFINE_ALIAS
+from ...fluid.dygraph.dygraph_to_static.convert_call_func import convert_call  # noqa: F401
 
-__all__ = ['convert_call']
+__all__ = []

--- a/python/paddle/jit/dy2static/convert_operators.py
+++ b/python/paddle/jit/dy2static/convert_operators.py
@@ -13,27 +13,21 @@
 # limitations under the License.
 from __future__ import print_function
 
-from ...fluid.dygraph.dygraph_to_static.convert_operators import cast_bool_if_necessary  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_assert  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_ifelse  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_len  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_and  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_not  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_or  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_pop  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_print  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_shape_compare  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_dtype  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_shape  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_shape_simple  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import eval_if_exist_else_none  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import choose_shape_attr_or_api  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_while_loop  #DEFINE_ALIAS
+from ...fluid.dygraph.dygraph_to_static.convert_operators import cast_bool_if_necessary  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_assert  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_ifelse  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_len  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_and  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_not  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_logical_or  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_pop  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_print  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_shape_compare  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_dtype  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_shape  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_var_shape_simple  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import eval_if_exist_else_none  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import choose_shape_attr_or_api  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.convert_operators import convert_while_loop  # noqa: F401
 
-__all__ = [
-    'cast_bool_if_necessary', 'convert_assert', 'convert_ifelse', 'convert_len',
-    'convert_logical_and', 'convert_logical_not', 'convert_logical_or',
-    'convert_pop', 'convert_print', 'convert_shape_compare',
-    'convert_var_dtype', 'convert_var_shape', 'convert_var_shape_simple',
-    'eval_if_exist_else_none', 'choose_shape_attr_or_api', 'convert_while_loop'
-]
+__all__ = []

--- a/python/paddle/jit/dy2static/variable_trans_func.py
+++ b/python/paddle/jit/dy2static/variable_trans_func.py
@@ -14,15 +14,11 @@
 
 from __future__ import print_function
 
-from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_bool_as_type  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_fill_constant_node  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_static_variable_gast_node  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.variable_trans_func import data_layer_not_check  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable  #DEFINE_ALIAS
-from ...fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable_gast_node  #DEFINE_ALIAS
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_bool_as_type  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_fill_constant_node  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import create_static_variable_gast_node  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import data_layer_not_check  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable  # noqa: F401
+from ...fluid.dygraph.dygraph_to_static.variable_trans_func import to_static_variable_gast_node  # noqa: F401
 
-__all__ = [
-    'create_bool_as_type', 'create_fill_constant_node',
-    'create_static_variable_gast_node', 'data_layer_not_check',
-    'to_static_variable', 'to_static_variable_gast_node'
-]
+__all__ = []

--- a/python/paddle/metric/__init__.py
+++ b/python/paddle/metric/__init__.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .metrics import *
-from . import metrics
+from .metrics import Metric  # noqa: F401
+from .metrics import Accuracy  # noqa: F401
+from .metrics import Precision  # noqa: F401
+from .metrics import Recall  # noqa: F401
+from .metrics import Auc  # noqa: F401
+from .metrics import accuracy  # noqa: F401
 
-__all__ = metrics.__all__
+__all__ = [ #noqa
+    'Metric',
+    'Accuracy',
+    'Precision',
+    'Recall',
+    'Auc',
+    'accuracy'
+]

--- a/python/paddle/metric/metrics.py
+++ b/python/paddle/metric/metrics.py
@@ -26,7 +26,7 @@ from ..fluid.layers.nn import topk
 from ..fluid.framework import core, _varbase_creator, in_dygraph_mode
 import paddle
 
-__all__ = ['Metric', 'Accuracy', 'Precision', 'Recall', 'Auc', 'accuracy']
+__all__ = []
 
 
 def _is_numpy_(var):

--- a/python/paddle/nn/__init__.py
+++ b/python/paddle/nn/__init__.py
@@ -286,5 +286,6 @@ __all__ = [     #noqa
            'Swish',
            'PixelShuffle',
            'ELU',
-           'ReLU6'
+           'ReLU6',
+           'LayerDict'
 ]

--- a/python/paddle/nn/functional/__init__.py
+++ b/python/paddle/nn/functional/__init__.py
@@ -194,5 +194,6 @@ __all__ = [     #noqa
            'embedding',
            'gather_tree',
            'one_hot',
-           'normalize'
+           'normalize',
+           'temporal_shift'
 ]

--- a/python/paddle/onnx/__init__.py
+++ b/python/paddle/onnx/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function
-from .export import export
+from .export import export  # noqa: F401
 
 __all__ = ['export']

--- a/python/paddle/onnx/export.py
+++ b/python/paddle/onnx/export.py
@@ -15,7 +15,7 @@
 import os
 from paddle.utils import try_import
 
-__all__ = ['export']
+__all__ = []
 
 
 def export(layer, path, input_spec=None, opset_version=9, **configs):

--- a/python/paddle/static/__init__.py
+++ b/python/paddle/static/__init__.py
@@ -85,11 +85,21 @@ __all__ = [     #noqa
            'load',
            'save_inference_model',
            'load_inference_model',
+           'serialize_program',
+           'serialize_persistables',
+           'save_to_file',
+           'deserialize_program',
+           'deserialize_persistables',
+           'load_from_file',
            'normalize_program',
            'load_program_state',
            'set_program_state',
            'cpu_places',
            'cuda_places',
            'Variable',
-           'create_global_var'
+           'create_global_var',
+           'accuracy',
+           'auc',
+           'device_guard',
+           'create_parameter'
 ]

--- a/python/paddle/static/nn/__init__.py
+++ b/python/paddle/static/nn/__init__.py
@@ -68,7 +68,6 @@ __all__ = [     #noqa
     'conv2d_transpose',
     'conv3d',
     'conv3d_transpose',
-    'create_parameter',
     'crf_decoding',
     'data_norm',
     'deform_conv2d',

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -25,7 +25,6 @@ from .creation import ones_like  # noqa: F401
 from .creation import zeros  # noqa: F401
 from .creation import zeros_like  # noqa: F401
 from .creation import arange  # noqa: F401
-from .creation import eye  # noqa: F401
 from .creation import full  # noqa: F401
 from .creation import full_like  # noqa: F401
 from .creation import triu  # noqa: F401
@@ -82,7 +81,6 @@ from .manipulation import squeeze  # noqa: F401
 from .manipulation import squeeze_  # noqa: F401
 from .manipulation import stack  # noqa: F401
 from .manipulation import strided_slice  # noqa: F401
-from .manipulation import transpose  # noqa: F401
 from .manipulation import unique  # noqa: F401
 from .manipulation import unsqueeze  # noqa: F401
 from .manipulation import unsqueeze_  # noqa: F401
@@ -143,7 +141,6 @@ from .math import add  # noqa: F401
 from .math import add_  # noqa: F401
 from .math import subtract  # noqa: F401
 from .math import subtract_  # noqa: F401
-from .math import atan  # noqa: F401
 from .math import logsumexp  # noqa: F401
 from .math import inverse  # noqa: F401
 from .math import log2  # noqa: F401

--- a/python/paddle/tensor/__init__.py
+++ b/python/paddle/tensor/__init__.py
@@ -227,7 +227,6 @@ tensor_method_func  = [ #noqa
            'log2',
            'log10',
            'logsumexp',
-           'mul',
            'multiplex',
            'pow',
            'prod',


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
update 2.0 public api in all left files
https://github.com/PaddlePaddle/Paddle/pull/33313在release2.1上的cherry-pick

背景：
对于用户调用api的层级，由于之前没有明确的设计，api开放层级比较随意。影响用户使用中的逻辑和正规感受。
目的：
1）重新整理api开放层级，提升用户使用感受
2）API保留自有特色，同时更好地符合行业规范，降低用户学习成本
3）提高框架api逻辑性，便于后续维护和优化
主要实现方法：
1）__all__内容清晰化，内容逐个列出，一行一个。不再使用 __all__ 的向上传递机制，仅在公开API层级添加 __all__，其余的 __all__ 列表统一置空
2）不再使用 #DEFINE_ALIAS
3）导入内容清晰化，原则上不再使用 import *， 按需引入需要的API， 每行一个
4）原则上不再使用 from . import module， from .module import submodule时会引入module，避免重复引用
5）添加新的Public API时，需向上寻找到最近的节点添加 import 并加入 __all__ 列表
6）Public API列表由多个公开API层级的 __all__ 列表共同组成，文档抽取以此为准，这些指定层级是：
    paddle,
    paddle.amp,
    paddle.nn,
    paddle.nn.functional,
    paddle.nn.initializer,
    paddle.nn.utils,
    paddle.static,
    paddle.static.nn,
    paddle.io,
    paddle.jit,
    paddle.metric,
    paddle.distribution,
    paddle.optimizer,
    paddle.optimizer.lr,
    paddle.regularizer,
    paddle.text,
    paddle.utils,
    paddle.utils.download,
    paddle.utils.profiler,
    paddle.utils.cpp_extension,
    paddle.sysconfig,
    paddle.vision,
    paddle.vision.datasets,
    paddle.vision.models,
    paddle.vision.transforms,
    paddle.vision.ops,
    paddle.distributed,
    paddle.distributed.fleet,
    paddle.distributed.fleet.utils,
    paddle.distributed.parallel,
    paddle.distributed.utils,
    paddle.callbacks,
    paddle.hub,
    paddle.autograd,
    paddle.incubate,
    paddle.inference,
    paddle.onnx,
    paddle.Tensor

修改示例展示：
原来写法：
![image](https://user-images.githubusercontent.com/31800336/115989217-ee607e00-a5ef-11eb-9e73-74d45ce75c56.png)
新的写法：
![image](https://user-images.githubusercontent.com/31800336/115989238-059f6b80-a5f0-11eb-9c4b-1c3be18e90f6.png)

对开发者使用API的影响：
1）在指定层级推荐方式：（不受影响）
  from paddle.nn import CTCLoss
  from paddle.nn import Conv2D
2）非指定层级支持但不推荐：（不受影响）
  from paddle.nn.layer.loss import CTCLoss
  from paddle.nn.layer.conv import Conv2D
3）对于import *使用方式不推荐。（非公开层级受影响）
  不再支持：（非公开层级）
  from paddle.nn.layer import *
  from paddle.nn.layer.conv import *
  from paddle.nn.initializer.norm import *
  from paddle.tensor.math import *
  from paddle.optimizer.adam import *
  可以支持：（公开层级）
  from paddle import *
  from paddle.nn import *
  from paddle.utils import *
  from paddle.optimizer import *

本pr涉及的改动：
1） 本pr对剩余一些零散目录进行规范化整理，这些目录包括：amp/autograd/incubate/inference/jit/metric/onnx
其中比较重要的整理是：去掉compat中公开接口；新增paddle.inference公开层级；去掉device中重复api接口。
其他是常规规范操作，例如清理底层py文件中all接口等。
2）对近期发现的一些问题进行修复
paddle.tensor.tensor_method_func 中去掉无实现接口 ’mul’
paddle.__init__ 中去掉无实现接口 ‘ComplexTensor’
去掉重复公开路径：paddle.distributed.parallel.init_parallel_env
新增公开接口：paddle.nn.functional.temporal_shift
static中新增部分公开api