### PR TITLE
[Dy2Stat]move data to CUDAPlace in advance

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -247,7 +247,7 @@ class PartialProgramLayer(layers.Layer):
                     # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
                     # into CUDAPlace when it's as input of multi Ops. so we move it in advance
                     # to avoid this problem.
-                    var =paddle.to_tensor(
+                    var = paddle.to_tensor(
                         value,
                         dtype=value.dtype,
                         place=framework._current_expected_place(),

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import numpy as np
 import six
 
-from paddle import to_tensor
+import paddle
 from paddle.fluid import framework, backward, core
 from paddle.fluid.dygraph import layers
 from paddle.fluid.dygraph.base import switch_to_static_graph
@@ -247,7 +247,7 @@ class PartialProgramLayer(layers.Layer):
                     # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
                     # into CUDAPlace when it's as input of multi Ops. so we move it in advance
                     # to avoid this problem.
-                    var = to_tensor(
+                    var = paddle.to_tensor(
                         value,
                         dtype=value.dtype,
                         place=framework._current_expected_place(),

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -243,7 +243,7 @@ class PartialProgramLayer(layers.Layer):
                     place=framework._current_expected_place(),
                     zero_copy=True)
             elif isinstance(value, core.VarBase):
-                if var.stop_gradient:
+                if value.stop_gradient:
                     # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
                     # into CUDAPlace when it's as input of multi Ops. so we move it in advance
                     # to avoid this problem.

--- a/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/partial_program.py
@@ -247,7 +247,7 @@ class PartialProgramLayer(layers.Layer):
                     # NOTE(Aurelius84): If var is on CPUPlace, it will be transformed multi times
                     # into CUDAPlace when it's as input of multi Ops. so we move it in advance
                     # to avoid this problem.
-                    var = paddle.to_tensor(
+                    var =paddle.to_tensor(
                         value,
                         dtype=value.dtype,
                         place=framework._current_expected_place(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization 
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

#### 1. PR 描述

PR 之前，若某个input 的 Tensor 参与前向和反向，则存在两次Sync的 PrepareData的数据copy：
![image](https://user-images.githubusercontent.com/9301846/120421993-f0112480-c399-11eb-9c85-f858eb8dc32e.png)

PR 之后，通过提前 inplace 的将数据搬运到GPU上，不存在多余的数据copy：
![image](https://user-images.githubusercontent.com/9301846/120422075-1cc53c00-c39a-11eb-959b-c73306ff6c7c.png)


#### 2. 收益
在 V100 机器上测试 MobileNetV1 模型 batch_size = 64 时的前后训练吞吐ips性能，如下：

> 测试方法，每10个batch计算一次ip，取10个log日志。分别执行4次，共40个log数据，取平均值。
> 这里只会对 input 提前copy，对于loss计算时的label是不会提前处理的。

| 模型(img/s) | batch_size | PR 前 | PR 后 | 提升|
|:----:|:----:|:----:|:----:|:----:|
| MobileNetV1| 64 | 780 | 950 | 21.79%|