### PR TITLE
[dont merge] to demonstrate using clang-tidy to modernize c++ codes 

### DIFF
--- a/tools/check_api_approvals.sh
+++ b/tools/check_api_approvals.sh
@@ -43,22 +43,22 @@ api_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/flu
 if [ "$api_spec_diff" != "" -o "${api_params_diff}" != "" ]; then
     echo_line="You must have one RD (XiaoguangHu01 or lanxianghit) approval for API change.\n"
     echo_line="${echo_line} and one TPM approval for API change: \n"
-    echo_line="${echo_line} jzhang533/ZhangJun, dingjiaweiww/DingJiaWei, Heeenrrry/LiKunLun, TCChenlong/ChenLong for general APIs\n"
+    echo_line="${echo_line} jzhang533/ZhangJun, dingjiaweiww/DingJiaWei, TCChenlong/ChenLong for general APIs\n"
     echo_line="${echo_line} PangHua/XiangHui for distributed related APIs\n"
-    echo_line="${echo_line} twismon/WangYunKai, CheQiXiao/CheQiXiao for inference related APIs.\n"
+    echo_line="${echo_line} ZihanDong/DongZiHan, CheQiXiao/CheQiXiao for inference related APIs.\n"
 
     check_approval 1 46782768 47554610
-    check_approval 1 29231 23093488 28379894 11935832 2682285 12050047 50894398
+    check_approval 1 29231 23093488 11935832 2682285 23407767 50894398
 fi
 
 api_doc_spec_diff=`python ${PADDLE_ROOT}/tools/diff_api.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.spec.doc  ${PADDLE_ROOT}/paddle/fluid/API_PR.spec.doc` 
 if [ "$api_doc_spec_diff" != "" ]; then
     echo_line="You must have  one TPM approval for API documents change: \n"
-    echo_line="${echo_line} jzhang533/ZhangJun, dingjiaweiww/DingJiaWei, Heeenrrry/LiKunLun, TCChenlong/ChenLong for general API docs\n"
+    echo_line="${echo_line} jzhang533/ZhangJun, dingjiaweiww/DingJiaWei, TCChenlong/ChenLong for general API docs\n"
     echo_line="${echo_line} PangHua/XiangHui for distributed related API docs\n"
-    echo_line="${echo_line} twismon/WangYunKai, CheQiXiao/CheQiXiao for inference related API docs.\n"
+    echo_line="${echo_line} ZihanDong/DongZiHan, CheQiXiao/CheQiXiao for inference related API docs.\n"
 
-    check_approval 1 29231 23093488 28379894 11935832 2682285 12050047 50894398
+    check_approval 1 29231 23093488 11935832 2682285 23407767 50894398
 fi
 
 api_src_spec_diff=`python ${PADDLE_ROOT}/tools/check_api_source_without_core_ops.py ${PADDLE_ROOT}/paddle/fluid/API_DEV.source.md5  ${PADDLE_ROOT}/paddle/fluid/API_PR.source.md5` 


### PR DESCRIPTION
This is a proof-of-concept PR to demonstrate using clang-tidy to modernize c++ codes.
all the check rules started with modernize-* has been applied, and codes are auto fixed.
https://clang.llvm.org/extra/clang-tidy/checks/list.html

see `.clang-tidy` for the clang-tidy config. LLVM clang toolchain version 12 has been used. 

except :
- modernize-use-trailing-return-type: negative filtered because two many lines are triggered.
- modernize-avoid-c-arrays: negative filtered  because no fix is offered by clang-tidy. 