### PR TITLE
Add 'self' parameters to function Cluster::update_pods, use variable name 'cur_proxy' instead of 'proxy' in file 'tools/get_pr_ut.py'

### DIFF
--- a/python/paddle/distributed/utils.py
+++ b/python/paddle/distributed/utils.py
@@ -166,7 +166,7 @@ class Cluster(object):
     def __ne__(self, cluster):
         return not self.__eq__(cluster)
 
-    def update_pods(cluster):
+    def update_pods(self, cluster):
         self.pods = copy.copy(cluster.pods)
 
     def trainers_nranks(self):

--- a/tools/get_pr_ut.py
+++ b/tools/get_pr_ut.py
@@ -112,7 +112,7 @@ class PRChecker(object):
                 print(e)
                 print(
                     'PREC download {} error, retry {} time(s) after {} secs.[proxy_option={}]'.
-                    format(url, ix, ix * 10, proxy))
+                    format(url, ix, ix * 10, cur_proxy))
                 continue
             else:
                 return True


### PR DESCRIPTION
### PR types
    Bug fixes 
### PR changes
    Others

### Describe
1. In 'python/paddle/distributed/utils.py', function ***update_pods*** of class ***Cluster*** lacks first parameters 'self' as it is neccesary as member function of class, just like *this* pointer in cpp.
2. In 'tools/get_pr_ut.py', there is a bug of ***undefined variable***: In function ***__urlretrieve*** of class ***PRChecker***, use variable name **cur_proxy** instead of **proxy**.