### PR TITLE
bugfix: param init with fill constant str_value

### DIFF
--- a/python/paddle/fluid/initializer.py
+++ b/python/paddle/fluid/initializer.py
@@ -152,6 +152,7 @@ class ConstantInitializer(Initializer):
             out_dtype = var.dtype
             out_var = var
 
+        # fill constant should set the "str_value" to preserve precision
         op = block.append_op(
             type="fill_constant",
             outputs={"Out": out_var},
@@ -159,6 +160,7 @@ class ConstantInitializer(Initializer):
                 "shape": var.shape,
                 "dtype": int(out_dtype),
                 "value": float(self._value),
+                'str_value': str(float(self._value)),
                 'force_cpu': self._force_cpu
             },
             stop_gradient=True)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Bug fixes

### PR changes
OPs

### Describe
in fp64 setting, user set beta1_pow_acc = 0.9, beta2_pow_acc = 0.999 for adamw,

before bugfix the actual value are: beta1_pow_acc = 0.8999999761581421, beta2_pow_acc = 0.9990000128746033
after bugfix the actual value are: beta1_pow_acc = 0.9000000000000000, beta2_pow_acc = 0.9990000000000000

fill constant should set str_value attr to preserve precision in fp64 setting