### PR TITLE
Fixed enabling cast op in bf16 mode

### DIFF
--- a/paddle/fluid/operators/cast_op.cc
+++ b/paddle/fluid/operators/cast_op.cc
@@ -85,30 +85,10 @@ class CastOp : public framework::OperatorWithKernel {
 #ifdef PADDLE_WITH_MKLDNN
     int in_dtype = ctx.Attr<int>("in_dtype");
     int out_dtype = ctx.Attr<int>("out_dtype");
-    bool use_mkldnn = ctx.Attr<bool>("use_mkldnn");
-
-    //all_casts++;
-//
-    //if(!this->CanMKLDNNBeUsed(ctx, tensor->type())){
-    //  native_casts++;
-    //  std::cout<< "cast op" << std::endl;
-    //  std::cout<< "in_dtype==fp32 " << int(in_dtype == (int)framework::proto::VarType::FP32) << std::endl;
-    //  std::cout<< "in_dtype==bf16 " << int(in_dtype == (int)framework::proto::VarType::BF16) << std::endl;
-    //  std::cout<< "out_dtype==fp32 " << int(out_dtype == (int)framework::proto::VarType::FP32) << std::endl;
-    //  std::cout<< "out_dtype==bf16 " << int(out_dtype == (int)framework::proto::VarType::BF16) << std::endl;
-    //  std::cout<< "Tensor->type() == bf16 " << (int)(tensor->type() == framework::proto::VarType::BF16) << std::endl;
-    //  std::cout<< "Tensor->type() == fp32 " << (int)(tensor->type() == framework::proto::VarType::FP32) << std::endl;
-    //  std::cout<< "use_mkldnn " << int(use_mkldnn == true) << std::endl;
-    //  std::cout<< "CanMKLDNNBeUsed " << (int)this->CanMKLDNNBeUsed(ctx, tensor->type()) << std::endl << std::endl;
-    //}
-//
-    //std::cout << "all_casts = " << all_casts << std::endl;
-    //std::cout << "native_casts = " << native_casts << std::endl;
-    int dtype_fp32 = static_cast<int>(framework::proto::VarType::FP32);
-    int dtype_bf16 = static_cast<int>(framework::proto::VarType::BF16);
 
     auto MKLDNNSupportsCast = [&]() -> bool {
-
+      int dtype_fp32 = static_cast<int>(framework::proto::VarType::FP32);
+      int dtype_bf16 = static_cast<int>(framework::proto::VarType::BF16);
 
       if ((in_dtype != dtype_fp32 && in_dtype != dtype_bf16) ||
           (out_dtype != dtype_fp32 && out_dtype != dtype_bf16))
@@ -116,11 +96,6 @@ class CastOp : public framework::OperatorWithKernel {
 
       return true;
     };
-
-    if(MKLDNNSupportsCast() && (in_dtype == dtype_bf16 || out_dtype == dtype_bf16))
-      return framework::OpKernelType(tensor->type(), ctx.GetPlace(),
-                                     framework::DataLayout::kMKLDNN,
-                                     framework::LibraryType::kMKLDNN);
 
     if (this->CanMKLDNNBeUsed(ctx, tensor->type()) && MKLDNNSupportsCast()) {
       return framework::OpKernelType(tensor->type(), ctx.GetPlace(),

--- a/python/paddle/fluid/contrib/mixed_precision/bf16/amp_utils.py
+++ b/python/paddle/fluid/contrib/mixed_precision/bf16/amp_utils.py
@@ -109,7 +109,8 @@ def _insert_cast_op(block, op, idx, src_dtype, dest_dtype):
                         outputs={"Out": out_var},
                         attrs={
                             "in_dtype": in_var.dtype,
-                            "out_dtype": out_var.dtype
+                            "out_dtype": out_var.dtype,
+                            "use_mkldnn": True
                         })
                     num_cast_ops += 1
                 _rename_arg(op, in_var.name, out_var.name)
@@ -157,7 +158,8 @@ def _insert_cast_post_op(block, op, idx, src_dtype, dest_dtype, target_name,
             inputs={"X": target_var},
             outputs={"Out": cast_var},
             attrs={"in_dtype": target_var.dtype,
-                   "out_dtype": cast_var.dtype})
+                   "out_dtype": cast_var.dtype,
+                   "use_mkldnn": True})
         num_cast_ops += 1
         op_var_rename_map[block.idx][target_var.name] = cast_var.name
 

--- a/python/paddle/fluid/contrib/mixed_precision/bf16/amp_utils.py
+++ b/python/paddle/fluid/contrib/mixed_precision/bf16/amp_utils.py
@@ -157,9 +157,11 @@ def _insert_cast_post_op(block, op, idx, src_dtype, dest_dtype, target_name,
             type="cast",
             inputs={"X": target_var},
             outputs={"Out": cast_var},
-            attrs={"in_dtype": target_var.dtype,
-                   "out_dtype": cast_var.dtype,
-                   "use_mkldnn": True})
+            attrs={
+                "in_dtype": target_var.dtype,
+                "out_dtype": cast_var.dtype,
+                "use_mkldnn": True
+            })
         num_cast_ops += 1
         op_var_rename_map[block.idx][target_var.name] = cast_var.name
 


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
OPs

### Describe
Added force-enabling oneDNN cast op kernel (both FWD and BWD) in bf16 mode.

