### PR TITLE
Add option "verbose" for predict api

### DIFF
--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1831,7 +1831,7 @@ class Model(object):
                 batch_size=1,
                 num_workers=0,
                 stack_outputs=False,
-                verbose=2,
+                verbose=1,
                 callbacks=None):
         """
         Compute the output predictions on testing data.
@@ -1853,7 +1853,7 @@ class Model(object):
                 is False. stack_outputs as False is used for LoDTensor output situation,
                 it is recommended set as True if outputs contains no LoDTensor. Default: False.
             verbose (int): The verbosity mode, should be 0, 1, or 2. 0 = silent,
-                1 = progress bar, 2 = one line per epoch. Default: 2.
+                1 = progress bar, 2 = one line per batch. Default: 1.
             callbacks(Callback): A Callback instance, default None.
 
         Returns:

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1855,7 +1855,7 @@ class Model(object):
             verbose (int): The verbosity mode, should be 0, 1, or 2. 0 = silent,
                 1 = progress bar, 2 = one line per epoch. Default: 2.
             callbacks(Callback): A Callback instance, default None.
-            
+
         Returns:
             list: output of models.
 
@@ -1915,7 +1915,7 @@ class Model(object):
 
         self._test_dataloader = test_loader
 
-        cbks = config_callbacks(callbacks, model=self, verbose=1)
+        cbks = config_callbacks(callbacks, model=self, verbose=verbose)
 
         test_steps = self._len_data_loader(test_loader)
         logs = {'steps': test_steps}

--- a/python/paddle/hapi/model.py
+++ b/python/paddle/hapi/model.py
@@ -1831,6 +1831,7 @@ class Model(object):
                 batch_size=1,
                 num_workers=0,
                 stack_outputs=False,
+                verbose=2,
                 callbacks=None):
         """
         Compute the output predictions on testing data.
@@ -1851,7 +1852,10 @@ class Model(object):
                 be a length N list in shape [[X, Y], [X, Y], ....[X, Y]] if stack_outputs
                 is False. stack_outputs as False is used for LoDTensor output situation,
                 it is recommended set as True if outputs contains no LoDTensor. Default: False.
+            verbose (int): The verbosity mode, should be 0, 1, or 2. 0 = silent,
+                1 = progress bar, 2 = one line per epoch. Default: 2.
             callbacks(Callback): A Callback instance, default None.
+            
         Returns:
             list: output of models.
 


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
Add option "verbose" for predict api