### PR TITLE
Fix LayerNorm Problem

### DIFF
--- a/python/paddle/fluid/tests/unittests/test_layer_norm_op_v2.py
+++ b/python/paddle/fluid/tests/unittests/test_layer_norm_op_v2.py
@@ -51,6 +51,7 @@ class TestDygraphLayerNormv2(unittest.TestCase):
             self.assertTrue(np.allclose(y1, y2))
 
     def test_static(self):
+        paddle.enable_static()
         places = [fluid.CPUPlace()]
         if core.is_compiled_with_cuda() and core.op_support_gpu("layer_norm"):
             places.append(fluid.CUDAPlace(0))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->

优化LayerNorm计算过程。
同时修复如下问题：
DLTP-25782 [Bug] 
DLTP-26400 [Bug]

修复LayerNorm在大数输入时输出Nan的bug。
DLTP-28680 [Bug] 

修复LayerNorm在归一化维度长度<kMaxBlockDim时的BlockDim计算错误bug。

修复LayerNorm在大输入shape时输出结果0的bug。