### PR TITLE
fix the bug that `print_signature.py` cannot get all the public apis

### DIFF
--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2252,11 +2252,6 @@ function main() {
         ;;
       cicheck_py35)
         cmake_gen_and_build ${PYTHON_ABI:-""} ${parallel_number}
-        example_info=$(exec_samplecode_test gpu)
-        example_code=$?
-        check_style_code=0
-        check_style_info=
-        summary_check_problems $check_style_code $example_code "$check_style_info" "$example_info"
         parallel_test
         ;;
       check_xpu)

--- a/paddle/scripts/paddle_build.sh
+++ b/paddle/scripts/paddle_build.sh
@@ -2017,7 +2017,7 @@ function exec_samplecode_test() {
     if [ "$1" = "cpu" ] ; then
         python sampcd_processor.py cpu; example_error=$?
     elif [ "$1" = "gpu" ] ; then
-        python sampcd_processor.py --threads=1 --full-test gpu; example_error=$?
+        python sampcd_processor.py --threads=16 --full-test gpu; example_error=$?
     fi
     if [ "$example_error" != "0" ];then
       echo "Code instance execution failed" >&2

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -311,14 +311,14 @@ def process_module(m, attr="__all__"):
 def get_all_api_from_modulelist():
     modulelist = [
         paddle, paddle.amp, paddle.nn, paddle.nn.functional,
-        paddle.nn.initializer, paddle.nn.utils, paddle.tensor, paddle.static,
-        paddle.static.nn, paddle.io, paddle.jit, paddle.metric,
-        paddle.distribution, paddle.optimizer, paddle.optimizer.lr,
-        paddle.regularizer, paddle.text, paddle.utils, paddle.utils.download,
-        paddle.utils.profiler, paddle.sysconfig, paddle.vision,
+        paddle.nn.initializer, paddle.nn.utils, paddle.static, paddle.static.nn,
+        paddle.io, paddle.jit, paddle.metric, paddle.distribution,
+        paddle.optimizer, paddle.optimizer.lr, paddle.regularizer, paddle.text,
+        paddle.utils, paddle.utils.download, paddle.utils.profiler,
+        paddle.utils.cpp_extension, paddle.sysconfig, paddle.vision,
         paddle.distributed, paddle.distributed.fleet,
         paddle.distributed.fleet.utils, paddle.distributed.parallel,
-        paddle.distributed.utils, paddle.callbacks, paddle.hub
+        paddle.distributed.utils, paddle.callbacks, paddle.hub, paddle.autograd
     ]
     for m in modulelist:
         visit_all_module(m)

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -27,6 +27,7 @@ import pydoc
 import hashlib
 import platform
 import functools
+import paddle
 
 member_dict = collections.OrderedDict()
 
@@ -201,7 +202,6 @@ def visit_all_module(mod):
 
 
 if __name__ == '__main__':
-    import paddle
     modules = sys.argv[1].split(",")
     for m in modules:
         visit_all_module(importlib.import_module(m))

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -213,7 +213,8 @@ def visit_all_module(mod):
                 visit_member(mod.__name__, instance)
 
 
-api_info_dict = {}
+# all from gen_doc.py
+api_info_dict = {}  # used by get_all_api
 
 
 # step 1: walkthrough the paddle package to collect all the apis in api_set
@@ -305,10 +306,29 @@ def process_module(m, attr="__all__"):
     return api_counter
 
 
+def get_all_api_from_modulelist():
+    modulelist = [
+        paddle, paddle.amp, paddle.nn, paddle.nn.functional,
+        paddle.nn.initializer, paddle.nn.utils, paddle.tensor, paddle.static,
+        paddle.static.nn, paddle.io, paddle.jit, paddle.metric,
+        paddle.distribution, paddle.optimizer, paddle.optimizer.lr,
+        paddle.regularizer, paddle.text, paddle.utils, paddle.utils.download,
+        paddle.utils.profiler, paddle.sysconfig, paddle.vision,
+        paddle.distributed, paddle.distributed.fleet,
+        paddle.distributed.fleet.utils, paddle.distributed.parallel,
+        paddle.distributed.utils, paddle.callbacks, paddle.hub
+    ]
+    for m in modulelist:
+        visit_all_module(m)
+
+    return member_dict
+
+
 if __name__ == '__main__':
-    modules = sys.argv[1].split(",")
-    for m in modules:
-        visit_all_module(importlib.import_module(m))
+    # modules = sys.argv[1].split(",")
+    # for m in modules:
+    #    visit_all_module(importlib.import_module(m))
+    get_all_api_from_modulelist()
 
     for name in member_dict:
         print(name, member_dict[name])

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -27,11 +27,24 @@ import pydoc
 import hashlib
 import platform
 import functools
+import pkgutil
+import logging
 import paddle
 
 member_dict = collections.OrderedDict()
 
 visited_modules = set()
+
+logger = logging.getLogger()
+if logger.handlers:
+    # we assume the first handler is the one we want to configure
+    console = logger.handlers[0]
+else:
+    console = logging.StreamHandler(sys.stderr)
+    logger.addHandler(console)
+console.setFormatter(
+    logging.Formatter(
+        "%(asctime)s - %(funcName)s:%(lineno)d - %(levelname)s - %(message)s"))
 
 
 def md5(doc):
@@ -198,7 +211,98 @@ def visit_all_module(mod):
                 visit_member(mod.__name__, instance, member_name)
             else:
                 visit_member(mod.__name__, instance)
-    return member_dict
+
+
+api_info_dict = {}
+
+
+# step 1: walkthrough the paddle package to collect all the apis in api_set
+def get_all_api(root_path='paddle', attr="__all__"):
+    """
+    walk through the paddle package to collect all the apis.
+    """
+    global api_info_dict
+    api_counter = 0
+    for filefinder, name, ispkg in pkgutil.walk_packages(
+            path=paddle.__path__, prefix=paddle.__name__ + '.'):
+        try:
+            if name in sys.modules:
+                m = sys.modules[name]
+            else:
+                # importlib.import_module(name)
+                m = eval(name)
+                continue
+        except AttributeError:
+            logger.warning("AttributeError occurred when `eval(%s)`", name)
+            pass
+        else:
+            api_counter += process_module(m, attr)
+
+    api_counter += process_module(paddle, attr)
+
+    logger.info('%s: collected %d apis, %d distinct apis.', attr, api_counter,
+                len(api_info_dict))
+
+
+def insert_api_into_dict(full_name, gen_doc_anno=None):
+    """
+    insert add api into the api_info_dict
+    Return:
+        api_info object or None
+    """
+    try:
+        obj = eval(full_name)
+        fc_id = id(obj)
+    except AttributeError:
+        logger.warning("AttributeError occurred when `id(eval(%s))`", full_name)
+        return None
+    except:
+        logger.warning("Exception occurred when `id(eval(%s))`", full_name)
+        return None
+    else:
+        logger.debug("adding %s to api_info_dict.", full_name)
+        if fc_id in api_info_dict:
+            api_info_dict[fc_id]["all_names"].add(full_name)
+        else:
+            api_info_dict[fc_id] = {
+                "all_names": set([full_name]),
+                "id": fc_id,
+                "object": obj,
+                "type": type(obj).__name__,
+            }
+            docstr = inspect.getdoc(obj)
+            if docstr:
+                api_info_dict[fc_id]["docstring"] = inspect.cleandoc(docstr)
+            if gen_doc_anno:
+                api_info_dict[fc_id]["gen_doc_anno"] = gen_doc_anno
+        return api_info_dict[fc_id]
+
+
+# step 1 fill field : `id` & `all_names`, type, docstring
+def process_module(m, attr="__all__"):
+    api_counter = 0
+    if hasattr(m, attr):
+        # may have duplication of api
+        for api in set(getattr(m, attr)):
+            if api[0] == '_': continue
+            # Exception occurred when `id(eval(paddle.dataset.conll05.test, get_dict))`
+            if ',' in api: continue
+
+            # api's fullname
+            full_name = m.__name__ + "." + api
+            api_info = insert_api_into_dict(full_name)
+            if api_info is not None:
+                api_counter += 1
+                if inspect.isclass(api_info['object']):
+                    for name, value in inspect.getmembers(api_info['object']):
+                        if (not name.startswith("_")) and hasattr(value,
+                                                                  '__name__'):
+                            method_full_name = full_name + '.' + name  # value.__name__
+                            method_api_info = insert_api_into_dict(
+                                method_full_name, 'class_method')
+                            if method_api_info is not None:
+                                api_counter += 1
+    return api_counter
 
 
 if __name__ == '__main__':

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -244,6 +244,8 @@ def get_all_api(root_path='paddle', attr="__all__"):
     logger.info('%s: collected %d apis, %d distinct apis.', attr, api_counter,
                 len(api_info_dict))
 
+    return [api_info['all_names'][0] for api_info in api_info_dict.values()]
+
 
 def insert_api_into_dict(full_name, gen_doc_anno=None):
     """

--- a/tools/print_signatures.py
+++ b/tools/print_signatures.py
@@ -197,6 +197,7 @@ def visit_all_module(mod):
                 visit_member(mod.__name__, instance, member_name)
             else:
                 visit_member(mod.__name__, instance)
+    return member_dict
 
 
 if __name__ == '__main__':

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -497,7 +497,7 @@ def get_full_api():
     get all the apis
     """
     global API_DIFF_SPEC_FN  ## readonly
-    from .print_signatures import visit_all_module
+    from print_signatures import visit_all_module
     import paddle
     member_dict = visit_all_module(paddle)
     with open(API_DIFF_SPEC_FN, 'w') as f:

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -505,6 +505,17 @@ def get_full_api():
         f.write("\n".join(member_dict.keys()))
 
 
+def get_full_api_by_walk():
+    """
+    get all the apis
+    """
+    global API_DIFF_SPEC_FN  ## readonly
+    from print_signatures import get_all_api
+    apilist = get_all_api()
+    with open(API_DIFF_SPEC_FN, 'w') as f:
+        f.write("\n".join(apilist))
+
+
 def get_incrementapi():
     '''
     this function will get the apis that difference between API_DEV.spec and API_PR.spec.

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -246,13 +246,15 @@ def is_required_match(requirestr, cbtitle='not-specified'):
         False - not match
         None - skipped  # trick
     """
-    global SAMPLE_CODE_TEST_CAPACITY  # readonly
+    global SAMPLE_CODE_TEST_CAPACITY, RUN_ON_DEVICE  # readonly
     requires = set(['cpu'])
     if requirestr:
         for r in requirestr.split(','):
             rr = r.strip().lower()
             if rr:
                 requires.add(rr)
+    else:
+        requires.add(RUN_ON_DEVICE)
     if 'skip' in requires or 'skiptest' in requires:
         logger.info('%s: skipped', cbtitle)
         return None

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -284,8 +284,8 @@ def insert_codes_into_codeblock(codeblock, apiname='not-specified'):
         cpu_str = '\nimport os\nos.environ["CUDA_VISIBLE_DEVICES"] = ""\n'
         gpu_str = '\nimport os\nos.environ["CUDA_VISIBLE_DEVICES"] = "{}"\n'.format(
             GPU_ID)
-        if 'required' in codeblock:
-            if codeblock['required'] is None or codeblock['required'] == 'cpu':
+        if 'required' in codeblock and codeblock['required']:
+            if codeblock['required'] == 'cpu':
                 inserted_codes_f = cpu_str
             elif codeblock['required'] == 'gpu':
                 inserted_codes_f = gpu_str

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -565,6 +565,8 @@ if __name__ == '__main__':
     args = parse_args()
     if args.debug:
         logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.INFO)
     if args.logf:
         logfHandler = logging.FileHandler(args.logf)
         logfHandler.setFormatter(

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -499,9 +499,8 @@ def get_full_api():
     get all the apis
     """
     global API_DIFF_SPEC_FN  ## readonly
-    from print_signatures import visit_all_module
-    import paddle
-    member_dict = visit_all_module(paddle)
+    from print_signatures import get_all_api_from_modulelist
+    member_dict = get_all_api_from_modulelist()
     with open(API_DIFF_SPEC_FN, 'w') as f:
         f.write("\n".join(member_dict.keys()))
 

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -425,9 +425,12 @@ stdout: %s
     return result, tfname, msg, end_time - start_time
 
 
-def get_filenames(increment=True):
+def get_filenames(full_test=False):
     '''
     this function will get the sample code files that pending for check.
+
+    Args:
+        full_test: the full apis or the increment
 
     Returns:
 
@@ -437,10 +440,10 @@ def get_filenames(increment=True):
     global whl_error
     import paddle
     whl_error = []
-    if increment:
-        get_incrementapi()
-    else:
+    if full_test:
         get_full_api()
+    else:
+        get_incrementapi()
     all_sample_code_filenames = {}
     with open(API_DIFF_SPEC_FN) as f:
         for line in f.readlines():
@@ -540,6 +543,7 @@ def parse_args():
     #                     help='Use CPU mode (overrides --gpu)')
     # parser.add_argument('--gpu', dest='gpu_mode', action="store_true")
     parser.add_argument('--debug', dest='debug', action="store_true")
+    parser.add_argument('--full-test', dest='full_test', action="store_true")
     parser.add_argument('mode', type=str, help='run on device', default='cpu')
     for item in arguments:
         parser.add_argument(
@@ -587,7 +591,7 @@ if __name__ == '__main__':
     else:
         os.mkdir(SAMPLECODE_TEMPDIR)
 
-    filenames = get_filenames()
+    filenames = get_filenames(args.full_test)
     if len(filenames) == 0 and len(whl_error) == 0:
         logger.info("-----API_PR.spec is the same as API_DEV.spec-----")
         exit(0)

--- a/tools/sampcd_processor.py
+++ b/tools/sampcd_processor.py
@@ -39,7 +39,7 @@ if logger.handlers:
     console = logger.handlers[
         0]  # we assume the first handler is the one we want to configure
 else:
-    console = logging.StreamHandler()
+    console = logging.StreamHandler(stream=sys.stderr)
     logger.addHandler(console)
 console.setFormatter(logging.Formatter("%(message)s"))
 
@@ -611,6 +611,8 @@ if __name__ == '__main__':
     if not args.debug:
         shutil.rmtree(SAMPLECODE_TEMPDIR)
 
+    stdout_handler = logging.StreamHandler(stream=sys.stdout)
+    logger.addHandler(stdout_handler)
     logger.info("----------------End of the Check--------------------")
     if len(whl_error) != 0:
         logger.info("%s is not in whl.", whl_error)


### PR DESCRIPTION
### PR types
Others

### PR changes
Others

### Describe
CI scripts

因为`__all__`的整理，当前的`print_signature`已不能将遍历到 子packages的api了，故单独使用模块遍历的方法把所有api获取出来。

修改后，print_signature 可以获取到902条API信息。而之前只能获取到paddle根包下的API才两百多。