### PR TITLE
[cherry-pick]fix the bug in repeated_fc_relu_fuse_pass. (#33386)

### DIFF
--- a/paddle/fluid/framework/ir/repeated_fc_relu_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/repeated_fc_relu_fuse_pass.cc
@@ -66,9 +66,13 @@ static bool IsFCWithPaddingWeights(Node* n) {
 }
 
 static bool IsParamOfFC(Node* n, const std::string& param_name) {
-  if (IsInputOfFC(n) && n->inputs.empty() &&
-      (n->Name() == n->outputs[0]->Op()->Input(param_name)[0])) {
-    return true;
+  if (IsInputOfFC(n) && n->inputs.empty()) {
+    for (auto* out : n->outputs) {
+      if (out->Op()->Type() == "fc" &&
+          n->Name() == out->Op()->Input(param_name)[0]) {
+        return true;
+      }
+    }
   }
   return false;
 }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 Others
### Describe
<!-- Describe what this PR does -->
在repeated_fc_relu_fuse_pass里面，检测一个Variable节点是不是fc 算子的参数时，认为该Variable节点只会被一个算子使用，所以直接去拿Variable节点的第一个输出算子的参数进行对比。
当该Variable同时被多个算子使用时，它的第一个输出算子不一定是fc算子。通过该算子去拿参数时，就会因为相应的参数不存在而直接崩溃。
在本次pr中，改为遍历Variable节点的所有输出算子，先判断算子类型是不是fc,再进行下一步。