### PR TITLE
[cherry-pick]Fixed a bug of log_softmax: op input was modified to 'nan' (#32937)

### DIFF
--- a/paddle/fluid/operators/log_softmax_op.cu
+++ b/paddle/fluid/operators/log_softmax_op.cu
@@ -104,7 +104,7 @@ __global__ void ComputeLogSoftmaxForwardInWarp(T *dst, const T *src,
 #pragma unroll
   for (int it = 0; it < warp_iter; ++it) {
     int element_index = thread_in_warp_idx + it * kernel_warp_size;
-    if (element_index < element_count) {
+    if (element_index < effective_element_count) {
       dst[batch_id * element_count + element_index] =
           static_cast<T>(elements[it] - max_value - sum);
     } else {
@@ -226,7 +226,7 @@ __global__ void ComputeLogSoftmaxBackwardInWarp(const T *output,
 #pragma unroll
   for (int iter = 0; iter < warp_iter; ++iter) {
     int element_index = thread_in_warp_idx + iter * kernel_warp_size;
-    if (element_index < element_count) {
+    if (element_index < effective_element_count) {
       grad_input[batch_id * element_count + element_index] = static_cast<T>(
           (grad_output_register[iter] - std::exp(output_register[iter]) * sum));
     }


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
 OPs
### Describe
<!-- Describe what this PR does -->

## PR功能
使用op benchmark时发现，当输入数据量小于某个值时，python 端 log_softmax 接口的输入值经过计算过后 会被改变为nan。输出正常。

cherry-pick自 https://github.com/PaddlePaddle/Paddle/pull/32937

## 修复前后对比
- 修复前现象如下：
<img width="630" alt="截屏2021-05-17 15 28 49" src="https://user-images.githubusercontent.com/18277990/118448689-e72b1c80-b724-11eb-83f3-9d33fe1ef436.png">

- 修复后：
<img width="628" alt="截屏2021-05-17 15 25 23" src="https://user-images.githubusercontent.com/18277990/118448701-ebefd080-b724-11eb-95fe-d77a19bbd243.png">