### PR TITLE
fix undef var

### DIFF
--- a/python/paddle/distributed/utils.py
+++ b/python/paddle/distributed/utils.py
@@ -25,6 +25,7 @@ import subprocess
 from contextlib import closing
 import socket
 from paddle.fluid import core
+from distutils.util import strtobool
 
 __all__ = [     #noqa
            'get_host_name_ip',
@@ -384,7 +385,7 @@ def add_arguments(argname, type, default, help, argparser, **kwargs):
         add_argument("name", str, "Jonh", "User name.", parser)
         args = parser.parse_args()
     """
-    type = distutils.util.strtobool if type == bool else type
+    type = strtobool if type == bool else type
     argparser.add_argument(
         "--" + argname,
         default=default,

--- a/python/paddle/fluid/optimizer.py
+++ b/python/paddle/fluid/optimizer.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function
 
+import warnings
 import numpy as np
 import six
 import os
@@ -21,6 +22,7 @@ import logging
 from collections import defaultdict
 
 import paddle
+import paddle.fluid as fluid
 from paddle.fluid.distribute_lookup_table import find_distributed_lookup_table
 from paddle.fluid.framework import Program, Variable, name_scope, default_main_program, default_startup_program, device_guard
 
@@ -1383,7 +1385,7 @@ class DGCMomentumOptimizer(Optimizer):
             assert isinstance(
                 num_trainers, int
             ), "The type of num_trainers should be 'int', but received %s" % type(
-                value)
+                num_trainers)
             assert num_trainers > 0, "The value of num_trainers should be greater than 0!"
 
             self._num_trainers = num_trainers

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import unittest
 import numpy as np
 import paddle.fluid.core as core
+import paddle.enable_static as enable_static
 from paddle.fluid.tests.unittests.op_test import OpTest
 
 from paddle.fluid.tests.unittests.test_conv2d_transpose_op import conv2dtranspose_forward_naive, TestConv2DTransposeOp

--- a/python/paddle/fluid/tests/unittests/test_eager_deletion_delete_vars.py
+++ b/python/paddle/fluid/tests/unittests/test_eager_deletion_delete_vars.py
@@ -145,7 +145,7 @@ class TestExecutor(unittest.TestCase):
     def pe_main(self):
         image, label, loss = simple_fc_net()
         loss.persistable = False
-        persitables, non_persistables = get_persistables_and_non_persistables(
+        persistables, non_persistables = get_persistables_and_non_persistables(
             fluid.default_main_program(), [loss.name])
 
         exe = fluid.Executor(self.place)

--- a/python/paddle/fluid/tests/unittests/xpu/test_pool2d_op_xpu.py
+++ b/python/paddle/fluid/tests/unittests/xpu/test_pool2d_op_xpu.py
@@ -26,6 +26,8 @@ import paddle.fluid as fluid
 from paddle.fluid import Program, program_guard
 import paddle
 
+from test_pool2d_op import adaptive_start_index, adaptive_end_index
+
 paddle.enable_static()
 
 

--- a/python/paddle/optimizer/lr.py
+++ b/python/paddle/optimizer/lr.py
@@ -1349,7 +1349,7 @@ class ReduceOnPlateau(LRScheduler):
         if isinstance(metrics, (Tensor, numpy.ndarray)):
             assert len(metrics.shape) == 1 and metrics.shape[0] == 1, "the metrics.shape " \
                 "should be (1L,), but the current metrics.shape is {}. Maybe that "  \
-                "you should call paddle.mean to process it first.".format(loss.shape)
+                "you should call paddle.mean to process it first.".format(metrics.shape)
         elif not isinstance(metrics,
                             (int, float, numpy.float32, numpy.float64)):
             raise TypeError(

--- a/python/paddle/optimizer/optimizer.py
+++ b/python/paddle/optimizer/optimizer.py
@@ -310,11 +310,11 @@ class Optimizer(object):
 
                 assert model_np.shape == load_para_np.shape,  \
                                           "Parameter shape not match, Dygraph Parameter [ {} ] need tensor with shape {} but load tensor with shape {}".format(
-                                                 item.name, model_np.shape, load_para_np.shape)
+                                                 model_np.name, model_np.shape, load_para_np.shape)
 
                 assert model_np.dtype == load_para_np.dtype, \
                                           "Parameter dtype not match, Dygraph Parameter [ {} ] need tensor with dtype {}  but load tensor with dtype {}".format(
-                                                item.name, model_np.dtype, load_para_np.dtype)
+                                                model_np.name, model_np.dtype, load_para_np.dtype)
 
                 tensor.set(load_para_np, framework._current_expected_place())
 

--- a/python/paddle/tests/test_model.py
+++ b/python/paddle/tests/test_model.py
@@ -126,7 +126,7 @@ class TestModel(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         if not fluid.is_compiled_with_cuda():
-            self.skipTest('module not tested when ONLY_CPU compling')
+            cls.skipTest('module not tested when ONLY_CPU compling')
         cls.device = paddle.set_device('gpu')
         fluid.enable_dygraph(cls.device)
 

--- a/python/paddle/text/datasets/wmt14.py
+++ b/python/paddle/text/datasets/wmt14.py
@@ -17,6 +17,7 @@ from __future__ import print_function
 import tarfile
 import numpy as np
 import gzip
+import six
 
 from paddle.io import Dataset
 import paddle.compat as cpt


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. python/paddle/tests/test_model.py:
    Line129: undefine variable name **self**, 
        **use 'cls' instead of 'self'.**
2. python/paddle/fluid/tests/unittests/xpu/test_pool2d_op_xpu.py:
    Line 57, 59, 97, 99, 203, 211: undefine variable name **adaptive_start_index**, 
    Line 58, 60, 98, 100, 204, 212: undefine variable name **adaptive_end_index**, 
   **from test_pool2d_op import adaptive_start_index, adaptive_end_index**
3. python/paddle/fluid/optimizer.py:
    Line 1386: Undefined variable **'value'**,
    **use 'num_trainers' instead of 'value'.**
    Line 1840: Undefined variable 'warnings',
    **import warnings**
    Line 5597: Undefined variable **'fluid'**
    **import paddle.fluid as fluid**
4. python/paddle/optimizer/optimizer.py
    Line 313: Undefined variable **'item'**
    **use 'model_np' instead of 'item'.**
    Line 317: Undefined variable **'item'**
    **use 'model_np' instead of 'item'.**
5. python/paddle/distributed/utils.py
    Line 387: Undefined variable 'distutils'
    **from distutils.util import strtobool**
6. python/paddle/fluid/tests/unittests/test_eager_deletion_delete_vars.py
    Line 178: Undefined variable 'persistables'
    **use 'persistables' instead of 'persitables' in line 148**
7. python/paddle/text/datasets/wmt14.py
    Line 194, 195: Undefined variable 'six'
    **import six**
8. python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
    Line 158: Undefined variable 'enable_static'
    **import paddle.enable_static as enable_static**
9. python/paddle/optimizer/lr.py
    Line 1352: Undefined variable 'loss'
    **use 'metrics' instead of 'loss'**