### PR TITLE
change the boost download url

### DIFF
--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               a72dc819313f1c07ee327722287d152c
+    URL_MD5               048e82034be39d5ed07e178a2c3331ee
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               dd79ad9553edcac86f3693bdde5868f5
+    URL_MD5               1726e6264c977dbdf01c6306b7854ef3
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               b6f62081998dada229291cf301f3d896
+    URL_MD5               0cdbda1dc3af7a1239e27bc64377ac97
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               1726e6264c977dbdf01c6306b7854ef3
+    URL_MD5               5d1048ab68201665fc8436a9caacbe54
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               048e82034be39d5ed07e178a2c3331ee
+    URL_MD5               dd79ad9553edcac86f3693bdde5868f5
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               0cdbda1dc3af7a1239e27bc64377ac97
+    URL_MD5               68fa4956ec8b568e11e412781cb6a4fc
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -23,8 +23,8 @@ set(BOOST_PROJECT       "extern_boost")
 # checked that the devtools package of CentOS 6 installs boost 1.41.0.
 # So we use 1.41.0 here.
 set(BOOST_VER   "1.41.0")
-set(BOOST_TAR   "boost_1_41_0" CACHE STRING "" FORCE)
-set(BOOST_URL   "http://paddlepaddledeps.bj.bcebos.com/${BOOST_TAR}.tar.gz" CACHE STRING "" FORCE)
+set(BOOST_TAR   "boost_1_41_0_small" CACHE STRING "" FORCE)
+set(BOOST_URL   "https://paddle-ci.gz.bcebos.com/${BOOST_TAR}.tar.gz" CACHE STRING "" FORCE)
 
 MESSAGE(STATUS "BOOST_VERSION: ${BOOST_VER}, BOOST_URL: ${BOOST_URL}")
 
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               f891e8c2c9424f0565f0129ad9ab4aff
+    URL_MD5               a72dc819313f1c07ee327722287d152c
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}

--- a/cmake/external/boost.cmake
+++ b/cmake/external/boost.cmake
@@ -46,7 +46,7 @@ ExternalProject_Add(
     ${BOOST_PROJECT}
     ${EXTERNAL_PROJECT_LOG_ARGS}
     "${BOOST_DOWNLOAD_CMD}"
-    URL_MD5               5d1048ab68201665fc8436a9caacbe54
+    URL_MD5               b6f62081998dada229291cf301f3d896
     PREFIX                ${BOOST_PREFIX_DIR}
     DOWNLOAD_DIR          ${BOOST_SOURCE_DIR}
     SOURCE_DIR            ${BOOST_SOURCE_DIR}


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

Remove the useless files from raw boost library and make it smaller to save the downloading bandwidth.
Change the download url of boost source file from raw library to the smaller source file. 

The comparison of the file size: 

* Raw sourcefile size:  39M.
* Smaller source file size: 904K.

