### PR TITLE
[Dy2Stat]Support non-tensor type in `input_spec`

### DIFF
--- a/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/function_spec.py
@@ -193,14 +193,8 @@ class FunctionSpec(object):
             raise TypeError(
                 "The type(input_spec) should be one of (tuple, list), but received {}.".
                 format(type_name(input_spec)))
-        input_spec = tuple(input_spec)
-        for spec in flatten(input_spec):
-            if not isinstance(spec, paddle.static.InputSpec):
-                raise ValueError(
-                    "The type(elem) from input_spec should be `InputSpec`, but received {}.".
-                    format(type_name(spec)))
 
-        return input_spec
+        return tuple(input_spec)
 
     def __repr__(self):
         return "function: {}({}), input_spec: {}".format(
@@ -326,9 +320,8 @@ def convert_to_input_spec(inputs, input_spec):
     elif isinstance(input_spec, paddle.static.InputSpec):
         return input_spec
     else:
-        raise TypeError(
-            "The type(input_spec) should be a `InputSpec` or dict/list/tuple of it, but received {}.".
-            type_name(input_spec))
+        # NOTE(Aurelius84): Support non-Tensor type as input spec info
+        return input_spec
 
 
 def replace_spec_empty_name(args_name, input_with_spec):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -20,7 +20,6 @@ import inspect
 import six
 import textwrap
 import threading
-import warnings
 import weakref
 
 from paddle.fluid import framework
@@ -314,7 +313,7 @@ class StaticFunction(object):
             # Here calls `warnings.warn` but not `logging_utils.warn` because by default warnings.warn(message)
             # will show up **only once**. StaticFunction.__call__ will run many times, it is appropriate to
             # display this warning message only once.
-            warnings.warn(
+            logging_utils.warn(
                 "The decorator '@paddle.jit.to_static' does NOT work when setting ProgramTranslator.enable to False. "
                 "We will just return dygraph output. If you would like to get static graph output, please call API "
                 "ProgramTranslator.enable(True)")
@@ -481,6 +480,9 @@ class StaticFunction(object):
                 # NOTE(chenweihang): we should always translated program based on the `input_spec`
                 # decorated on forward if it is valid
                 desired_input_spec = self._function_spec.input_spec
+                logging_utils.warn(
+                    "\n\nYou have specified `input_spec` both in function definition (higher priority) and `paddle.jit.save` (will be ignored.)\n\n\t Using: {}\n\n\t Ignore: {}\n".
+                    format(desired_input_spec, input_spec))
 
             has_input_spec = (desired_input_spec is not None)
             if has_input_spec:
@@ -886,7 +888,7 @@ class ProgramTranslator(object):
         if not self.enable_to_static:
             # Here calls `warnings.warn` but not `logging_utils.warn` because by default warnings.warn(message)
             # will show up **only once**.
-            warnings.warn(
+            logging_utils.warn(
                 "The ProgramTranslator.get_output doesn't work when setting ProgramTranslator.enable to False. "
                 "We will just return dygraph output. "
                 "Please call ProgramTranslator.enable(True) if you would like to get static output."

--- a/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/program_translator.py
@@ -480,9 +480,10 @@ class StaticFunction(object):
                 # NOTE(chenweihang): we should always translated program based on the `input_spec`
                 # decorated on forward if it is valid
                 desired_input_spec = self._function_spec.input_spec
-                logging_utils.warn(
-                    "\n\nYou have specified `input_spec` both in function definition (higher priority) and `paddle.jit.save` (will be ignored.)\n\n\t Using: {}\n\n\t Ignore: {}\n".
-                    format(desired_input_spec, input_spec))
+                if input_spec is not None:
+                    logging_utils.warn(
+                        "\n\nYou have specified `input_spec` both in function definition (higher priority) and `paddle.jit.save` (will be ignored.)\n\n\t Using: {}\n\n\t Ignore: {}\n".
+                        format(desired_input_spec, input_spec))
 
             has_input_spec = (desired_input_spec is not None)
             if has_input_spec:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -27,6 +27,7 @@ import tempfile
 import textwrap
 import numpy as np
 
+import paddle
 from paddle.fluid import unique_name
 from paddle.fluid.data_feeder import convert_dtype
 
@@ -1421,10 +1422,10 @@ def input_specs_compatible(src_input_specs, desired_input_specs):
     Returns True if the two input specs are compatible, otherwise False.
 
     args:
-        src_input_spec (list[InputSpec]|tuple(InputSpec)): list/tuple of
-            paddle.static.InputSpec
-        desired_input_specs (list[InputSpec]|tuple(InputSpec)): list/tuple of
-            paddle.static.InputSpec
+        src_input_spec (list or tuple[InputSpec et.al]): list/tuple of
+            paddle.static.InputSpec or or int/str et.al
+        desired_input_specs (list or tuple[InputSpec et.al]): list/tuple of
+            paddle.static.InputSpec or or int/str et.al
     """
     len_specs = len(src_input_specs)
     if len_specs != len(desired_input_specs):
@@ -1433,28 +1434,67 @@ def input_specs_compatible(src_input_specs, desired_input_specs):
         for spec in src_input_specs:
             if spec not in desired_input_specs:
                 return False
-
     else:
-        for i in range(len_specs):
-            src_shape = src_input_specs[i].shape
-            other_shape = desired_input_specs[i].shape
-            len_shape = len(src_shape)
-            if len_shape != len(other_shape):
-                return False
-            for j in range(len_shape):
-                if src_shape[j] is None or src_shape[j] < 0:
-                    continue
-                if other_shape[j] is None or other_shape[j] < 0:
-                    continue
-                if src_shape[j] != other_shape[j]:
+        for (src_spec, desired_spec) in zip(src_input_specs,
+                                            desired_input_specs):
+            if isinstance(src_spec, paddle.static.InputSpec) or isinstance(
+                    desired_spec, paddle.static.InputSpec):
+                if not _compatible_tensor_spec(src_spec, desired_spec):
+                    return False
+            else:
+                if not _compatible_non_tensor_spec(src_spec, desired_spec):
                     return False
 
-            src_dtype = convert_dtype(src_input_specs[i].dtype)
-            other_dtype = convert_dtype(desired_input_specs[i].dtype)
-            if src_dtype != other_dtype:
-                return False
+    return True
+
+
+def _compatible_tensor_spec(src_spec, desired_spec):
+    """
+    Check whether two tensor type spec is compatible.
+    """
+    for spec in [src_spec, desired_spec]:
+        if not isinstance(spec, paddle.static.InputSpec):
+            return False
+    src_shape = src_spec.shape
+    other_shape = desired_spec.shape
+    len_shape = len(src_shape)
+    if len_shape != len(other_shape):
+        return False
+    for j in range(len_shape):
+        if src_shape[j] is None or src_shape[j] < 0:
+            continue
+        if other_shape[j] is None or other_shape[j] < 0:
+            continue
+        if src_shape[j] != other_shape[j]:
+            return False
+
+    src_dtype = convert_dtype(src_spec.dtype)
+    other_dtype = convert_dtype(desired_spec.dtype)
+    if src_dtype != other_dtype:
+        return False
 
     return True
+
+
+def _compatible_non_tensor_spec(src_spec, desired_spec):
+    """
+    Check whether two non-tensor type spec is compatible.
+    """
+
+    def hash_value(spec):
+        try:
+            hash_val = make_hashable(spec)
+        except:
+            hash_val = None
+        return hash_val
+
+    src_hash_val = hash_value(src_spec)
+    desired_hash_val = hash_value(desired_spec)
+
+    if src_hash_val != desired_hash_val:
+        return False
+    else:
+        return True
 
 
 def slice_is_num(slice_node):

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -142,9 +142,9 @@ def make_hashable(x, error_msg=None):
     """
     Makes input `x` hashable.
 
-    For some unhashable objects, such as `dict/list/np.ndarray`,applying hash function by using their values.
+    For some unhashable objects, such as `dict/list/set/np.ndarray`,applying hash function by using their values.
     """
-    if isinstance(x, (tuple, list)):
+    if isinstance(x, (tuple, list, set)):
         return tuple(map(make_hashable, x))
 
     try:

--- a/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
+++ b/python/paddle/fluid/dygraph/dygraph_to_static/utils.py
@@ -1423,9 +1423,9 @@ def input_specs_compatible(src_input_specs, desired_input_specs):
 
     args:
         src_input_spec (list or tuple[InputSpec et.al]): list/tuple of
-            paddle.static.InputSpec or or int/str et.al
+            paddle.static.InputSpec or int/str et.al
         desired_input_specs (list or tuple[InputSpec et.al]): list/tuple of
-            paddle.static.InputSpec or or int/str et.al
+            paddle.static.InputSpec or int/str et.al
     """
     len_specs = len(src_input_specs)
     if len_specs != len(desired_input_specs):

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -426,8 +426,6 @@ def _get_input_var_names(inputs, input_spec):
     else:
         # prune
         for spec in input_spec:
-            if not isinstance(spec, paddle.static.InputSpec):
-                continue
             if spec.name is None:
                 # name is None, the input_spec only can be InputSpec
                 raise ValueError(name_none_error % spec)

--- a/python/paddle/fluid/dygraph/jit.py
+++ b/python/paddle/fluid/dygraph/jit.py
@@ -403,8 +403,15 @@ def _get_input_var_names(inputs, input_spec):
     ]
     if input_spec is None:
         # no prune
-        result_list = input_var_names
-    elif input_spec is not None and len(input_spec) == len(input_var_names):
+        return input_var_names
+    else:
+        # fileter out non-tensor type spec infos.
+        input_spec = [
+            spec for spec in input_spec
+            if isinstance(spec, paddle.static.InputSpec)
+        ]
+
+    if len(input_spec) == len(input_var_names):
         # no prune
         result_list = input_var_names
         # if input spec name not in input_var_names, only raise warning

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_function_spec.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_function_spec.py
@@ -39,10 +39,6 @@ class TestFunctionSpec(unittest.TestCase):
         with self.assertRaises(TypeError):
             foo_spec = FunctionSpec(foo_func, input_spec=a_spec)
 
-        # each element of input_spec should be `InputSpec`
-        with self.assertRaises(ValueError):
-            foo_spec = FunctionSpec(foo_func, input_spec=[a_spec, 10])
-
         foo_spec = FunctionSpec(foo_func, input_spec=[a_spec, b_spec])
         self.assertTrue(len(foo_spec.flat_input_spec) == 2)
 

--- a/python/paddle/fluid/tests/unittests/test_input_spec.py
+++ b/python/paddle/fluid/tests/unittests/test_input_spec.py
@@ -18,6 +18,7 @@ import paddle
 import paddle.fluid as fluid
 from paddle.static import InputSpec
 from paddle.fluid.framework import core, convert_np_dtype_to_dtype_
+from paddle.fluid.dygraph.dygraph_to_static.utils import _compatible_non_tensor_spec
 
 
 class TestInputSpec(unittest.TestCase):
@@ -294,6 +295,26 @@ class TestNetWithNonTensorSpecWithPrune(unittest.TestCase):
         load_out = load_net(self.x)  # no y and no loss
 
         self.assertTrue(np.allclose(st_out, load_out))
+
+
+class UnHashableObject:
+    def __init__(self, val):
+        self.val = val
+
+    def __hash__(self):
+        raise TypeError("Unsupported to call hash()")
+
+
+class TestCompatibleNonTensorSpec(unittest.TestCase):
+    def test_case(self):
+        self.assertTrue(_compatible_non_tensor_spec([1, 2, 3], [1, 2, 3]))
+        self.assertFalse(_compatible_non_tensor_spec([1, 2, 3], [1, 2]))
+        self.assertFalse(_compatible_non_tensor_spec([1, 2, 3], [1, 3, 2]))
+
+        # not supported unhashable object.
+        self.assertTrue(
+            _compatible_non_tensor_spec(
+                UnHashableObject(1), UnHashableObject(1)))
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_input_spec.py
+++ b/python/paddle/fluid/tests/unittests/test_input_spec.py
@@ -157,6 +157,10 @@ class TestNetWithNonTensorSpec(unittest.TestCase):
         self.x_spec = paddle.static.InputSpec([-1, 16], name='x')
         self.x = paddle.randn([4, 16])
 
+    @classmethod
+    def setUpClass(cls):
+        paddle.disable_static()
+
     def test_non_tensor_bool(self):
         specs = [self.x_spec, False]
         self.check_result(specs, 'bool')
@@ -203,8 +207,6 @@ class TestNetWithNonTensorSpec(unittest.TestCase):
         load_out = load_net(self.x)
 
         self.assertTrue(np.allclose(st_out, load_out))
-
-        print(pred_out, st_out, dy_out, load_out)
 
     def test_spec_compatible(self):
         net = NetWithNonTensorSpec(self.in_num, self.out_num)


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
[Dy2Stat]Support non-tensor type in `input_spec`