### PR TITLE
[oneDNN] Second fix to #33021

### DIFF
--- a/paddle/fluid/inference/tests/api/analyzer_detect_functional_mkldnn_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_detect_functional_mkldnn_tester.cc
@@ -120,6 +120,19 @@ void validate_cache_onednn(int cache_capacity = 1) {
   file.close();
   infer_file.close();
 
+  // Pick first output tensor from model
+  // as internally reorders may be called
+  // so it will impact cache size
+  auto output_names = predictor->GetOutputNames();
+  auto output_t = predictor->GetOutputHandle(output_names[0]);
+  std::vector<int> output_shape = output_t->shape();
+  size_t out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
+                                   std::multiplies<int>());
+  std::vector<float> out_data;
+  out_data.resize(out_num);
+  output_t->CopyToCpu(out_data.data());
+
+  // Release predictor (relevant cache should be emptied)
   predictor.reset(nullptr);
   cache_filling.push_back(GetNumCachedObjects());
 

--- a/paddle/fluid/inference/tests/api/analyzer_detect_functional_mkldnn_tester.cc
+++ b/paddle/fluid/inference/tests/api/analyzer_detect_functional_mkldnn_tester.cc
@@ -124,7 +124,7 @@ void validate_cache_onednn(int cache_capacity = 1) {
   // as internally reorders may be called
   // so it will impact cache size
   auto output_names = predictor->GetOutputNames();
-  auto output_t = predictor->GetOutputHandle(output_names[0]);
+  auto output_t = predictor->GetOutputTensor(output_names[0]);
   std::vector<int> output_shape = output_t->shape();
   size_t out_num = std::accumulate(output_shape.begin(), output_shape.end(), 1,
                                    std::multiplies<int>());


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
It is second part of fixes to #33021. Problem addressed here was that Predictor after finishing execution of Run() is restoring default settings of cache. Those default settings are unrestriced size of cache (cache_capacity = 0). but after Run() is completed , There are sometimes Tensor:: CopyToCpu() methods called which are using oneDNN objects and could make cache growing. 
