### PR TITLE
Add fused elemwise gelu and optimize performance

### DIFF
--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -57,6 +57,10 @@ constexpr int ELEMWISE_MAX_BLOCK_DIM = 1024;
     *mod = dividend_copy % divisor;            \
   } while (0)
 
+#define DIVUP(x, y) (((x) + (y)-1) / (y))
+
+#define ROUNDUP(x, y) (DIVUP((x), (y)) * (y))
+
 namespace paddle {
 namespace operators {
 
@@ -2581,106 +2585,129 @@ static __global__ void FusedElemwiseAndActGradBroadcast1CUDAKernel(
     const T *x, const T *y, const T *intermediate_out, const T *out,
     const T *dout, int h, int w, DX_OP dx_op, DY_OP dy_op,
     DIntermediate_OP dintermediate_op, T *dx, T *dy, T *d_intermediate) {
-  int j = blockIdx.x;
-  int i = threadIdx.x;
-  int tid = threadIdx.x;
-  T val(0), inter_val(0);
-  int64_t tmp_out_idx, x_idx, y_idx;
+  __shared__ T sdata[BLOCK_Y][BLOCK_X];
+  size_t idx = threadIdx.x + BLOCK_X * blockIdx.x;
+  size_t width_stride = gridDim.x * BLOCK_X;
+
+  size_t full_w = ROUNDUP(w, BLOCK_X);
+
   T zero = static_cast<T>(0);
 
-  do {
-    int offset = i * w + j;
+  for (size_t j = idx; j < full_w; j += width_stride) {
+    T val(0), inter_val(0);
+    if (j < w) {
+      for (size_t i = threadIdx.y; i < h; i += BLOCK_Y) {
+        size_t offset = i * w + j;
 
-    tmp_out_idx = BcastY ? j : offset;
-    y_idx = BcastY ? j : offset;
-    x_idx = BcastY ? offset : j;
-    T x_val = (x == nullptr) ? zero : x[x_idx];
-    T y_val = (y == nullptr) ? zero : y[y_idx];
+        size_t tmp_out_idx = BcastY ? j : offset;
+        size_t y_idx = BcastY ? j : offset;
+        size_t x_idx = BcastY ? offset : j;
+        T x_val = (x == nullptr) ? zero : x[x_idx];
+        T y_val = (y == nullptr) ? zero : y[y_idx];
 
-    if (SameShapeOfIntermediateOutAndOut) {
-      tmp_out_idx = offset;
-    }
+        if (SameShapeOfIntermediateOutAndOut) {
+          tmp_out_idx = offset;
+        }
 
-    if (dx != nullptr) {
-      T tmp = UseIntermediateOut
+        if (dx != nullptr) {
+          T tmp =
+              UseIntermediateOut
                   ? dx_op.UseIntermediateOut(x_val, y_val,
                                              intermediate_out[tmp_out_idx],
                                              out[offset], dout[offset])
                   : dx_op.Recompute(x_val, y_val, out[offset], dout[offset]);
 
-      if (BcastY) {
-        dx[x_idx] = tmp;
-      } else {
-        val += tmp;
-      }
-    }
-    if (dy != nullptr) {
-      T tmp = UseIntermediateOut
+          if (BcastY) {
+            dx[x_idx] = tmp;
+          } else {
+            val += tmp;
+          }
+        }
+        if (dy != nullptr) {
+          T tmp =
+              UseIntermediateOut
                   ? dy_op.UseIntermediateOut(x_val, y_val,
                                              intermediate_out[tmp_out_idx],
                                              out[offset], dout[offset])
                   : dy_op.Recompute(x_val, y_val, out[offset], dout[offset]);
-      if (BcastY) {
-        val += tmp;
-      } else {
-        dy[y_idx] = tmp;
-      }
-    }
-    if (d_intermediate != nullptr) {
-      T tmp = UseIntermediateOut
-                  ? dintermediate_op.UseIntermediateOut(
-                        y[y_idx], intermediate_out[tmp_out_idx], out[offset],
-                        dout[offset])
-                  : dintermediate_op.Recompute(x_val, y_val, out[offset],
-                                               dout[offset]);
-      if (SameShapeOfIntermediateOutAndOut) {
-        d_intermediate[tmp_out_idx] = tmp;
-      } else {
-        inter_val += tmp;
+          if (BcastY) {
+            val += tmp;
+          } else {
+            dy[y_idx] = tmp;
+          }
+        }
+        if (d_intermediate != nullptr) {
+          T tmp = UseIntermediateOut
+                      ? dintermediate_op.UseIntermediateOut(
+                            y[y_idx], intermediate_out[tmp_out_idx],
+                            out[offset], dout[offset])
+                      : dintermediate_op.Recompute(x_val, y_val, out[offset],
+                                                   dout[offset]);
+          if (SameShapeOfIntermediateOutAndOut) {
+            d_intermediate[tmp_out_idx] = tmp;
+          } else {
+            inter_val += tmp;
+          }
+        }
       }
     }
 
-    i += ELEMWISE_MAX_BLOCK_DIM;
-  } while (i < h);
+    // transpose, for ReduceSum with wrap
+    sdata[threadIdx.y][threadIdx.x] = val;
+    __syncthreads();
+    val = sdata[threadIdx.x][threadIdx.y];
+#pragma unroll
+    for (int i = BLOCK_X >> 1; i > 0; i >>= 1) {
+      // reduce sum with wrap
+      val += platform::CudaShuffleXorSync(0xFFFFFFFF, val, i);
+    }
 
-  h = h > ELEMWISE_MAX_BLOCK_DIM ? ELEMWISE_MAX_BLOCK_DIM : h;
-  if (BcastY) {
-    if (dy) {
-      val = paddle::platform::reduceSum(val, tid, h);
-      if (threadIdx.x == 0) {
-        dy[j] = val;
+    size_t idx_j = j + threadIdx.y;
+    if (BcastY) {
+      if (dy) {
+        if (threadIdx.x == 0 && (idx_j < w)) dy[idx_j] = val;
+      }
+    } else {
+      if (dx) {
+        if (threadIdx.x == 0 && (idx_j < w)) dx[idx_j] = val;
       }
     }
-  } else {
-    if (dx) {
-      val = paddle::platform::reduceSum(val, tid, h);
-      if (threadIdx.x == 0) {
-        dx[j] = val;
+
+    if (!SameShapeOfIntermediateOutAndOut) {
+      if (d_intermediate) {
+        sdata[threadIdx.y][threadIdx.x] = inter_val;
+        __syncthreads();
+        inter_val = sdata[threadIdx.x][threadIdx.y];
+#pragma unroll
+        for (int i = BLOCK_X >> 1; i > 0; i >>= 1) {
+          // reduce sum with wrap
+          inter_val += platform::CudaShuffleXorSync(0xFFFFFFFF, inter_val, i);
+        }
+        if (threadIdx.x == 0 && (idx_j < w)) d_intermediate[idx_j] = inter_val;
       }
     }
-  }
-  if (!SameShapeOfIntermediateOutAndOut) {
-    if (d_intermediate) {
-      inter_val = paddle::platform::reduceSum(inter_val, tid, h);
-      if (threadIdx.x == 0) {
-        d_intermediate[j] = inter_val;
-      }
-    }
-  }
+  }  // end for
 }
 
 template <typename T, typename DX_OP, typename DY_OP, typename DIntermediate_OP,
           bool UseIntermediateOut, bool BcastY,
           bool SameShapeOfIntermediateOutAndOut>
 static void FusedElemwiseAndActGradBroadcast1CUDA(
-    gpuStream_t stream, const T *x, const T *y, const T *intermediate_out,
-    const T *out, const T *dout, int h, int w, DX_OP dx_op, DY_OP dy_op,
-    DIntermediate_OP dintermediate_op, T *dx, T *dy, T *d_intermediate) {
-  int block_size = std::min(ELEMWISE_MAX_BLOCK_DIM, h);
-  int gird_size = w;
+    const framework::ExecutionContext &ctx, const T *x, const T *y,
+    const T *intermediate_out, const T *out, const T *dout, int h, int w,
+    DX_OP dx_op, DY_OP dy_op, DIntermediate_OP dintermediate_op, T *dx, T *dy,
+    T *d_intermediate) {
+  gpuStream_t stream = ctx.cuda_device_context().stream();
+
+  dim3 blocks(BLOCK_X, BLOCK_Y);
+  int max_gpu_threads = ctx.cuda_device_context().GetMaxPhysicalThreadCount();
+  int max_blocks = std::max(max_gpu_threads / (BLOCK_X * BLOCK_Y), 1);
+  int theory_block = (w + BLOCK_X - 1) / BLOCK_X;
+  dim3 grids(std::min(theory_block, max_blocks));
+
   FusedElemwiseAndActGradBroadcast1CUDAKernel<
       T, DX_OP, DY_OP, DIntermediate_OP, UseIntermediateOut, BcastY,
-      SameShapeOfIntermediateOutAndOut><<<gird_size, block_size, 0, stream>>>(
+      SameShapeOfIntermediateOutAndOut><<<grids, blocks, 0, stream>>>(
       x, y, intermediate_out, out, dout, h, w, dx_op, dy_op, dintermediate_op,
       dx, dy, d_intermediate);
 }
@@ -2832,7 +2859,7 @@ void FusedElemwiseAndActGradComputeWithBroadcast(
       FusedElemwiseAndActGradBroadcast1CUDA<T, DX_OP, DY_OP, DIntermediate_OP,
                                             UseIntermediateOut, BcastY,
                                             SameShapeOfIntermediateOutAndOut>(
-          ctx.template device_context<DeviceContext>().stream(), x_data, y_data,
+          ctx, x_data, y_data,
           intermediate_out == nullptr ? nullptr : intermediate_out->data<T>(),
           out->data<T>(), dout->data<T>(), h, w, dx_op, dy_op, dintermediate_op,
           dx == nullptr ? nullptr : dx->mutable_data<T>(ctx.GetPlace()),

--- a/paddle/fluid/operators/elementwise/elementwise_op_function.h
+++ b/paddle/fluid/operators/elementwise/elementwise_op_function.h
@@ -2152,10 +2152,10 @@ template <typename T, typename CompoundFunctor, bool BcastY,
 static __global__ void FusedElemwiseAndActBroadcast1CUDAKernel(
     const T *x, const T *y, int h, int w, CompoundFunctor compound_functor,
     T *out, T *intermediate_out) {
-  int j = blockIdx.x;
-  int i = threadIdx.x;
+  int i = blockIdx.x;
+  int j = threadIdx.x;
 
-  while (i < h) {
+  while (j < w) {
     int offset = i * w + j;
 
     T y_val = BcastY ? y[j] : y[offset];
@@ -2181,7 +2181,7 @@ static __global__ void FusedElemwiseAndActBroadcast1CUDAKernel(
       out[offset] = compound_functor.GetOut(x_val, y_val);
     }
 
-    i += ELEMWISE_MAX_BLOCK_DIM;
+    j += ELEMWISE_MAX_BLOCK_DIM;
   }
 }
 
@@ -2192,8 +2192,8 @@ static void FusedElemwiseAndActBroadcast1CUDA(gpuStream_t stream, const T *x,
                                               CompoundFunctor compound_functor,
                                               int h, int w, T *out,
                                               T *intermediate_out) {
-  int block_size = std::min(ELEMWISE_MAX_BLOCK_DIM, h);
-  int gird_size = w;
+  int block_size = std::min(ELEMWISE_MAX_BLOCK_DIM, w);
+  int gird_size = h;
   FusedElemwiseAndActBroadcast1CUDAKernel<
       T, CompoundFunctor, BcastY, KeepIntermediateOut,
       SameShapeOfIntermediateOutAndOut><<<gird_size, block_size, 0, stream>>>(

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.cc
@@ -69,7 +69,7 @@ static bool IsSupportedCompound(const std::vector<std::string> &functors) {
           functors.size(), 2));
 
   static std::unordered_set<std::string> unary_fun = {"scale", "relu", "tanh",
-                                                      "sigmoid"};
+                                                      "sigmoid", "gelu"};
   static std::unordered_set<std::string> binary_fun = {"elementwise_add",
                                                        "elementwise_mul"};
 

--- a/paddle/fluid/operators/fused/fused_elemwise_activation_op.h
+++ b/paddle/fluid/operators/fused/fused_elemwise_activation_op.h
@@ -275,6 +275,13 @@ static void RunFunctors(const framework::ExecutionContext &ctx,
                              paddle::operators::math::SigmoidFunctor<T>>(
         ctx, paddle::operators::math::MulFunctor<T>(),
         paddle::operators::math::SigmoidFunctor<T>(), in_x, in_y, outputs);
+  } else if (funcs_str == "gelu,elementwise_add") {
+    // Z = Unary(Binary(X, Y))
+    RunUnaryCompoundFunctors<DeviceContext, T,
+                             paddle::operators::math::GeluFunctor<T>,
+                             paddle::operators::math::AddFunctor<T>>(
+        ctx, paddle::operators::math::GeluFunctor<T>(),
+        paddle::operators::math::AddFunctor<T>(), in_x, in_y, outputs);
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(
         "%s has not been implemented.", funcs_str));
@@ -373,6 +380,16 @@ static void RunGradFunctors(
         ctx, paddle::operators::math::MulGradFunctor<T>(),
         paddle::operators::math::SigmoidFunctor<T>(),
         paddle::operators::math::SigmoidGradFunctor<T>(), in_x, in_y, in_out,
+        in_intermediate_out, in_out_grad, x_grad, y_grad, d_intermediate_out);
+  } else if (funcs_str == "gelu_grad,elementwise_add_grad") {
+    // The backward of Z = Unary(Binary(X, Y))
+    RunUnaryCompoundGradFunctors<
+        DeviceContext, T, paddle::operators::math::GeluGradFunctor<T>,
+        paddle::operators::math::AddFunctor<T>,
+        paddle::operators::math::AddGradFunctor<T>, InPlace>(
+        ctx, paddle::operators::math::GeluGradFunctor<T>(),
+        paddle::operators::math::AddFunctor<T>(),
+        paddle::operators::math::AddGradFunctor<T>(), in_x, in_y, in_out,
         in_intermediate_out, in_out_grad, x_grad, y_grad, d_intermediate_out);
   } else {
     PADDLE_THROW(platform::errors::InvalidArgument(

--- a/paddle/fluid/operators/math/functors.h
+++ b/paddle/fluid/operators/math/functors.h
@@ -130,6 +130,41 @@ struct SigmoidGradFunctor {
   }
 };
 
+template <typename T>
+struct GeluFunctor {
+  inline HOSTDEVICE T operator()(T x) {
+    // this function is tanh approximation of gelu
+    // actual gelu is:
+    // x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
+    return x * 0.5 * (1.0 + std::tanh(0.79788456 * x * (1 + 0.044715 * x * x)));
+  }
+};
+
+template <typename T>
+struct GeluGradFunctor {
+  inline HOSTDEVICE T UseX(T x) {
+    T tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * x * x));
+    T ans = 0.5 * x * ((1 - tanh_out * tanh_out) *
+                       (0.79788456 + 0.1070322243 * x * x)) +
+            0.5 * (1 + tanh_out);
+    return ans;
+  }
+  inline HOSTDEVICE T UseOut(T x) {
+    T tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * x * x));
+    T ans = 0.5 * x * ((1 - tanh_out * tanh_out) *
+                       (0.79788456 + 0.1070322243 * x * x)) +
+            0.5 * (1 + tanh_out);
+    return ans;
+  }
+  inline HOSTDEVICE T UseXAndOut(T x, T out) {
+    T tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * x * x));
+    T ans = 0.5 * x * ((1 - tanh_out * tanh_out) *
+                       (0.79788456 + 0.1070322243 * x * x)) +
+            0.5 * (1 + tanh_out);
+    return ans;
+  }
+};
+
 }  // namespace math
 }  // namespace operators
 }  // namespace paddle

--- a/paddle/fluid/operators/math/functors.h
+++ b/paddle/fluid/operators/math/functors.h
@@ -14,6 +14,7 @@ limitations under the License. */
 
 #pragma once
 
+#include "paddle/fluid/operators/amp/fp16_type_traits.h"
 #include "paddle/fluid/operators/math.h"
 
 namespace paddle {
@@ -132,36 +133,58 @@ struct SigmoidGradFunctor {
 
 template <typename T>
 struct GeluFunctor {
+  using MT = typename details::MPTypeTrait<T>::Type;
   inline HOSTDEVICE T operator()(T x) {
     // this function is tanh approximation of gelu
     // actual gelu is:
     // x * 0.5 * (1.0 + torch.erf(x * 0.70710678))
-    return x * 0.5 * (1.0 + std::tanh(0.79788456 * x * (1 + 0.044715 * x * x)));
+    MT mx = static_cast<MT>(x);
+    MT out = mx * static_cast<MT>(0.5) *
+             (static_cast<MT>(1.0) +
+              tanh(static_cast<MT>(0.79788456) * mx *
+                   (static_cast<MT>(1) + static_cast<MT>(0.044715) * mx * mx)));
+    return static_cast<T>(out);
   }
 };
 
 template <typename T>
 struct GeluGradFunctor {
+  using MT = typename details::MPTypeTrait<T>::Type;
   inline HOSTDEVICE T UseX(T x) {
-    T tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * x * x));
-    T ans = 0.5 * x * ((1 - tanh_out * tanh_out) *
-                       (0.79788456 + 0.1070322243 * x * x)) +
-            0.5 * (1 + tanh_out);
-    return ans;
+    MT mx = static_cast<MT>(x);
+    MT tanh_out =
+        tanh(static_cast<MT>(0.79788456) * mx *
+             (static_cast<MT>(1) + static_cast<MT>(0.044715) * mx * mx));
+    MT ans = static_cast<MT>(0.5) * mx *
+                 ((static_cast<MT>(1) - tanh_out * tanh_out) *
+                  (static_cast<MT>(0.79788456) +
+                   static_cast<MT>(0.1070322243) * mx * mx)) +
+             static_cast<MT>(0.5) * (static_cast<MT>(1) + tanh_out);
+    return static_cast<T>(ans);
   }
   inline HOSTDEVICE T UseOut(T x) {
-    T tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * x * x));
-    T ans = 0.5 * x * ((1 - tanh_out * tanh_out) *
-                       (0.79788456 + 0.1070322243 * x * x)) +
-            0.5 * (1 + tanh_out);
-    return ans;
+    MT mx = static_cast<MT>(x);
+    MT tanh_out =
+        tanh(static_cast<MT>(0.79788456) * mx *
+             (static_cast<MT>(1) + static_cast<MT>(0.044715) * mx * mx));
+    MT ans = static_cast<MT>(0.5) * mx *
+                 ((static_cast<MT>(1) - tanh_out * tanh_out) *
+                  (static_cast<MT>(0.79788456) +
+                   static_cast<MT>(0.1070322243) * mx * mx)) +
+             static_cast<MT>(0.5) * (static_cast<MT>(1) + tanh_out);
+    return static_cast<T>(ans);
   }
   inline HOSTDEVICE T UseXAndOut(T x, T out) {
-    T tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * x * x));
-    T ans = 0.5 * x * ((1 - tanh_out * tanh_out) *
-                       (0.79788456 + 0.1070322243 * x * x)) +
-            0.5 * (1 + tanh_out);
-    return ans;
+    MT mx = static_cast<MT>(x);
+    MT tanh_out =
+        tanh(static_cast<MT>(0.79788456) * mx *
+             (static_cast<MT>(1) + static_cast<MT>(0.044715) * mx * mx));
+    MT ans = static_cast<MT>(0.5) * mx *
+                 ((static_cast<MT>(1) - tanh_out * tanh_out) *
+                  (static_cast<MT>(0.79788456) +
+                   static_cast<MT>(0.1070322243) * mx * mx)) +
+             static_cast<MT>(0.5) * (static_cast<MT>(1) + tanh_out);
+    return static_cast<T>(ans);
   }
 };
 

--- a/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
@@ -405,7 +405,7 @@ for mode in {0, 1}:
                 grad_chek=False)
             create_test_class(
                 'gelu_add_fp16' + suffix,
-                relu_add_func, {
+                gelu_add_func, {
                     'functor_list': ["gelu", "elementwise_add"],
                     'save_intermediate_out': save_intermediate_out,
                 },

--- a/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
+++ b/python/paddle/fluid/tests/unittests/test_fused_elemwise_activation_op.py
@@ -305,6 +305,15 @@ def mul_scale_func(x, y, x_bcast, y_bcast, scale, mode=0):
         return y, x, x * scale, y_bcast * (x_bcast * scale)
 
 
+def gelu_add_func(x, y, x_bcast, y_bcast, mode=0):
+    im = x_bcast + y_bcast
+    out = im * 0.5 * (1.0 + np.tanh(0.79788456 * im * (1 + 0.044715 * im * im)))
+    if mode == 0:
+        return x, y, im, out
+    else:
+        return y, x, im, out
+
+
 scale = 0.1
 scale_add_func = partial(scale_add_func, scale=scale)
 add_scale_func = partial(add_scale_func, scale=scale)
@@ -316,6 +325,7 @@ for mode in {0, 1}:
     mul_scale_func = partial(mul_scale_func, mode=mode)
     relu_add_func = partial(relu_add_func, mode=mode)
     add_relu_func = partial(add_relu_func, mode=mode)
+    gelu_add_func = partial(gelu_add_func, mode=mode)
 
     for save_intermediate_out in {True, False}:
         suffix = ("_save_intermediate_out" if save_intermediate_out else "") \
@@ -343,6 +353,11 @@ for mode in {0, 1}:
             'functor_list': ["elementwise_mul", "scale"],
             'save_intermediate_out': save_intermediate_out,
         })
+        create_test_class('gelu_add' + suffix, gelu_add_func, {
+            'functor_list': ["gelu", "elementwise_add"],
+            'save_intermediate_out': save_intermediate_out,
+        })
+
         if core.is_compiled_with_cuda():
             create_test_class(
                 'scale_add_fp16' + suffix,
@@ -384,6 +399,14 @@ for mode in {0, 1}:
                 mul_scale_func, {
                     'scale': scale,
                     'functor_list': ["elementwise_mul", "scale"],
+                    'save_intermediate_out': save_intermediate_out,
+                },
+                dtype=np.float16,
+                grad_chek=False)
+            create_test_class(
+                'gelu_add_fp16' + suffix,
+                relu_add_func, {
+                    'functor_list': ["gelu", "elementwise_add"],
                     'save_intermediate_out': save_intermediate_out,
                 },
                 dtype=np.float16,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
New features
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
OPs
### Describe
<!-- Describe what this PR does -->
1. fused_elemwise_act op 添加gelu(elemwise_add(x, y)的fuse功能。
2. 优化fused_elemwise_act op在broad_y情况下的性能。
fused_elemwise_act op在该PR中的主要优化为：
- 前向kernel优化前为列遍历，改成了行遍历优先
- 反向kernel优化前为列遍历，由于反向存在ReduceSum操作，改成了(32*32)块处理，一个wrap处理一行，遍历上按照列遍历。

使用tanh(elemwise_add(x, y))作性能测试，测试实验如下：

编号 | 问题规模 | dtype | tanh(add) | | | fused(dev) | | | fused(PR) | | |   |  | 
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | 
  |   |   | 前向(us) | 反向(us) | 总(us) | 前向(us) | 反向(us) | 总(us) | 前向(us) | 反向(us) | 总(us) | 开启fuse后提升 | PR相对dev提升
0 | [10240, 5120] + [5120] | fp32 | 1027.77 | 1544.79 | 2572.56 | 6329.1 | 16348 | 22677.1 | 568.73 | 857.27 | 1426 | 80.40% | 1490.26%
  |   | fp16 | 539.9 | 913.09 | 1452.99 | 3107.6 | 6770.2 | 9877.8 | 441.28 | 682.17 | 1123.45 | 29.33% | 779.24%
1 | [10240, 512] + [512] | fp32 | 107.742 | 210.05 | 317.792 | 403.36 | 672.22 | 1075.58 | 61.568 | 288.29 | 349.858 | -9.17% | 207.43%
  |   | fp16 | 61.058 | 100.26 | 161.318 | 369.53 | 668 | 1037.53 | 52.191 | 259.74 | 311.931 | -48.28% | 232.62%
2 | [4096, 512] + [512] | fp32 | 46.847 | 94.69 | 141.537 | 138.82 | 270.4 | 409.22 | 27.488 | 118.27 | 145.758 | -2.90% | 180.75%
  |   | fp16 | 26.879 | 42.27 | 69.149 | 138.59 | 270.11 | 408.7 | 23.935 | 102.3 | 126.235 | -45.22% | 223.76%
3 | [4096, 128] + [128] | fp32 | 13.28 | 25.79 | 39.07 | 43.008 | 80.447 | 123.455 | 11.008 | 68.448 | 79.456 | -50.83% | 55.38%
  |   | fp16 | 11.159 | 17.21 | 28.369 | 41.856 | 80.063 | 121.919 | 10.624 | 54.496 | 65.12 | -56.44% | 87.22%
4 | [1024, 128] + [128] | fp32 | 8.832 | 16.1 | 24.932 | 13.183 | 23.264 | 36.447 | 5.44 | 16.96 | 22.4 | 11.30% | 62.71%
  |   | fp16 | 8.512 | 12.64 | 21.152 | 13.248 | 23.519 | 36.767 | 5.44 | 17.024 | 22.464 | -5.84% | 63.67%
5 | [1024, 32] + [32] | fp32 | 7.776 | 14.82 | 22.596 | 6.112 | 9.728 | 15.84 | 5.152 | 16.96 | 22.112 | 2.19% | -28.36%
  |   | fp16 | 7.807 | 11.36 | 19.167 | 5.248 | 7.744 | 12.992 | 5.184 | 16.64 | 21.824 | -12.17% | -40.47%
6 | [64, 32] + [32] | fp32 | 7.584 | 11.3 | 18.884 | 3.68 | 4.096 | 7.776 | 3.648 | 5.44 | 9.088 | 107.79% | -14.44%
  |   | fp16 | 7.616 | 10.94 | 18.556 | 3.712 | 4 | 7.712 | 3.552 | 4.992 | 8.544 | 117.18% | -9.74%

性能提升总结：
- 相比develop版本的fuse，本PR在大size下提升有十余倍性能，常规size提升了0.5-2倍性能，小size下性能略降。
- 相比不fuse下的性能，大size下性能有提升，中等规模size略降，fp16由于未优化fuse后反而性能下降，需优化。

fused_elemwise_act op后续优化TODO：
- 前向kernel加上SIMD，fp16优化
- 反向kernel加上SIMD，fp16优化
- 反向kernel使用tmp memory，拆分成两个kernel，第一个kernel计算dx按行，第二个kernel ReduceSum计算dy，看是否加速？
- 反向kernel计算dx和dy公式相同时可复用计算结果，减少不必要的重复计算。
- gelu(elemwise_add())反向时，中间结果和out可以都不需要，fused_elemwise_act反向可以添加不需要out的功能。或者新开gelu add的fuse op，更方便优化。