### PR TITLE
Fix some Bugs of Lack 'self' Parameter in Method

### DIFF
--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
@@ -245,7 +245,7 @@ class TestDynamicToStaticCode(unittest.TestCase):
     def set_answer_func(self):
         class StaticCode():
             @paddle.jit.not_to_static
-            def func_not_to_static(x):
+            def func_not_to_static(self, x):
                 res = func_sum(x)
                 return res
 
@@ -274,7 +274,7 @@ class TestDynamicToStaticCode2(TestDynamicToStaticCode):
 
     def set_answer_func(self):
         class StaticCode():
-            def func_convert_then_not_to_static(x):
+            def func_convert_then_not_to_static(self, x):
                 y = paddle.jit.dy2static.convert_call(func_not_to_static)(x)
                 return y
 

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
@@ -62,7 +62,7 @@ def get_source_code(func):
 
 
 class StaticCode1():
-    def dyfunc_with_if_else(x_v, label=None):
+    def dyfunc_with_if_else(self, x_v, label=None):
         __return_value_init_0 = paddle.fluid.layers.fill_constant(
             shape=[1], dtype='float64', value=0.0)
         __return_value_0 = __return_value_init_0
@@ -114,7 +114,7 @@ class StaticCode1():
 
 class StaticCode2():
     # TODO: Transform return statement
-    def dyfunc_with_if_else(x_v, label=None):
+    def dyfunc_with_if_else(self, x_v, label=None):
         __return_value_init_1 = paddle.fluid.layers.fill_constant(
             shape=[1], dtype='float64', value=0.0)
         __return_value_1 = __return_value_init_1

--- a/python/paddle/fluid/tests/unittests/dygraph_to_static/test_utils.py
+++ b/python/paddle/fluid/tests/unittests/dygraph_to_static/test_utils.py
@@ -42,7 +42,7 @@ def dyfunc_assign(input):
 
 
 class StaticCode():
-    def dyfunc_assign(input):
+    def dyfunc_assign(self, input):
         b = 1
         a = b
         e = a

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
@@ -79,7 +79,7 @@ class TestDeQuantizeOp(OpTest):
     def set_shift(self):
         pass
 
-    def set_data_type(OpTest):
+    def set_data_type(self, OpTest):
         pass
 
     def set_input_size(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
@@ -79,7 +79,7 @@ class TestDeQuantizeOp(OpTest):
     def set_shift(self):
         pass
 
-    def set_data_type(self, OpTest):
+    def set_data_type(self):
         pass
 
     def set_input_size(self):

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
@@ -100,7 +100,7 @@ class TestReQuantizeOp(OpTest):
     def set_shifts(self):
         pass
 
-    def set_input_data_type(OpTest):
+    def set_input_data_type(self, OpTest):
         pass
 
 

--- a/python/paddle/fluid/tests/unittests/test_fleet_meta_optimizer_base.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_meta_optimizer_base.py
@@ -22,7 +22,7 @@ from paddle.distributed.fleet.meta_optimizers.meta_optimizer_base import MetaOpt
 
 
 class TestFleetMetaOptimizerBase(unittest.TestCase):
-    def net(main_prog, startup_prog):
+    def net(self, main_prog, startup_prog):
         with fluid.program_guard(main_prog, startup_prog):
             with fluid.unique_name.guard():
                 role = role_maker.PaddleCloudRoleMaker(is_collective=True)


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. python/paddle/fluid/tests/unittests/mkldnn/test_dequantize_mkldnn_op.py
   Line 82: Method should have "self" as first argument
2. python/paddle/fluid/tests/unittests/dygraph_to_static/test_utils.py
   Line 45: Method should have "self" as first argument
3. python/paddle/fluid/tests/unittests/test_fleet_meta_optimizer_base.py
   Line 25: Method should have "self" as first argument
4. python/paddle/fluid/tests/unittests/dygraph_to_static/test_program_translator.py
   Line 65, 117: Method should have "self" as first argument
5. python/paddle/fluid/tests/unittests/mkldnn/test_requantize_mkldnn_op.py
   Line 103: Method should have "self" as first argument
6. python/paddle/fluid/tests/unittests/dygraph_to_static/test_convert_call.py
   Line 248, 277: Method should have "self" as first argument
add 'self' argument to method