### PR TITLE
fix image batch bug

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -93,7 +93,7 @@ def batch_images_from_tar(data_file,
     :rtype: string
     """
     batch_dir = data_file + "_batch"
-    out_path = "%s/%s" % (batch_dir, dataset_name)
+    out_path = "%s/%s_%s" % (batch_dir, dataset_name, os.getpid())
     meta_file = "%s/%s.txt" % (batch_dir, dataset_name)
 
     if os.path.exists(out_path):


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others

### Describe
<!-- Describe what this PR does -->

In multi-process scenario, one process create **out_path** and working on it, another process find **out_path** exists then want to use it right away which raise ERROR since **out_path** is not ready indeed.

This solution may waste, but it works and provides possibility for different process. 
