### PR TITLE
Fix the bug that `ParamBase` lose attributes when `paddle.save(Layer)` 

### DIFF
--- a/python/paddle/fluid/framework.py
+++ b/python/paddle/fluid/framework.py
@@ -5535,6 +5535,18 @@ class ParamBase(core.VarBase):
         core.varbase_copy(self, new_param, device, blocking)
         return new_param
 
+    def __reduce__(self):
+        value = self.numpy()
+        state = (self.name, self.persistable, self.stop_gradient)
+        return ParamBase, (self.shape, self.dtype), (self.__dict__, value,
+                                                     state)
+
+    def __setstate__(self, state):
+        self.__dict__.update(state[0])
+        t = self.value().get_tensor()
+        t.set(state[1], _current_expected_place())
+        self.name, self.persistable, self.stop_gradient = state[2]
+
     __repr__ = __str__
 
 

--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -874,13 +874,6 @@ class TestSaveLoadLayer(unittest.TestCase):
         path = "test_save_load_layer_/layer.pdmodel"
         paddle.save(origin_layer, path)
 
-        # static
-        paddle.enable_static()
-        with self.assertRaises(ValueError):
-            paddle.load(path)
-        # dygraph
-        paddle.disable_static()
-
         loaded_layer = paddle.load(path)
         loaded_result = [l(inps) for l in loaded_layer]
         for i in range(len(origin)):

--- a/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
+++ b/python/paddle/fluid/tests/unittests/test_paddle_save_load.py
@@ -869,9 +869,10 @@ class TestSaveLoadLayer(unittest.TestCase):
         layer2 = LinearNet()
         layer1.eval()
         layer2.eval()
+        origin_layer = (layer1, layer2)
         origin = (layer1(inps), layer2(inps))
         path = "test_save_load_layer_/layer.pdmodel"
-        paddle.save((layer1, layer2), path)
+        paddle.save(origin_layer, path)
 
         # static
         paddle.enable_static()
@@ -884,6 +885,8 @@ class TestSaveLoadLayer(unittest.TestCase):
         loaded_result = [l(inps) for l in loaded_layer]
         for i in range(len(origin)):
             self.assertTrue((origin[i] - loaded_result[i]).abs().max() < 1e-10)
+            for k, v in origin_layer[i]._linear.weight.__dict__.items():
+                self.assertTrue(v == loaded_layer[i]._linear.weight.__dict__[k])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
APIs
### Describe
<!-- Describe what this PR does -->
修复paddle.save(Layer)时参数属性丢失的问题:通过实现__reduce__的方式保存layer中的`ParamBase`的所有信息。


### pickle原理简介：

```python
def __reduce__(self):
    value = self.numpy()
    state = (self.name, self.persistable, self.stop_gradient)
    
    # (self.__dict__, value,state) 为__setstate__的输入，因此这个参数决定了保存ParamBase的信息量。
    return ParamBase, (self.shape, self.dtype), (self.__dict__, value,state)

def __setstate__(self, state):
    self.__dict__.update(state[0])
    t = self.value().get_tensor()
    t.set(state[1], _current_expected_place())
    self.name, self.persistable, self.stop_gradient = state[2]

```
- pickle.dump:
    - 调用__reduce__()，把reduce的返回值(构造函数，构造函数的输入，__setstate__ 的输入)保存下来。其中ParamBase保存的是module路径字符串（"paddle.fluid.framework"）和对象名（"ParamBase"）。

- pickle.load:
    - 先调用ParamBase(self.shape, self.dtype)构建ParamBase对象，再调用ParamBase.__setstate__设置这个对象的属性。

[pickle详情参考](https://docs.python.org/3/library/pickle.html)。
### 兼容性问题：
如果 Layer、ParamBase、__setstate__改变将对加载模型造成影响。

- 对于Layer和ParamBase。load时，pickle调用paddle内部的ParamBase类、Layer类来恢复出Layer、ParamBase。Linear、Conv等都继承自Layer。因此如果保存了Linear、Conv2D等，在load时都需要Linear类、Conv2D类才能恢复出保存的对象。而pickle是用过记录模块位置来找Linear类、Conv2D类的（例如：paddle.nn.Linear），一旦这个类的位置变了，或者构造函数变了都将导致pickle.load无法恢复保存的模型。由于paddle中有大量的Layer，如果这些类的位置改变或者构造函数改变，将无法恢复加载的模型。
- 由于paddle2.1 ParamBase 没有__setstate__函数，所以无发加载2.1.1保存的layer。

#### 结论如下：

- paddle2.1 无法加载paddle2.1.1 保存的Layer对象。paddle2.1.1可以加载paddle2.1保存的Layer对象。
- 对于非Layer对象，如state_dict等，2.1与2.1.1完全兼容，2.1可以加载2.1.1保存的非Layer对象。可以脱离框架加载pickle格式的模型文件。