### PR TITLE
add compat check for skip_layernorm

### DIFF
--- a/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.cc
+++ b/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.cc
@@ -129,6 +129,11 @@ void SkipLayerNormFusePass::ApplyImpl(ir::Graph *graph) const {
       return;
     }
 
+    if (!IsCompat(subgraph, graph)) {
+      LOG(WARNING) << "skip_layernorm pass in op compat failed.";
+      return;
+    }
+
     VLOG(4) << "handle SkipLayerNorm fuse";
     GET_IR_NODE_FROM_SUBGRAPH(elementwise, elementwise, fused_pattern);
     GET_IR_NODE_FROM_SUBGRAPH(elementwise_out, elementwise_out, fused_pattern);

--- a/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.h
+++ b/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.h
@@ -33,6 +33,45 @@ class Graph;
 
 class SkipLayerNormFusePass : public FusePassBase {
  public:
+  SkipLayerNormFusePass() {
+    AddOpCompat(OpCompat("elementwise_add"))
+        .AddInput("X")
+        .IsTensor()
+        .End()
+        .AddInput("Y")
+        .IsTensor()
+        .End()
+        .AddOutput("Out")
+        .IsTensor()
+        .End()
+        .AddAttr("axis")  // unconstrained
+        .End();
+
+    AddOpCompat(OpCompat("layer_norm"))
+        .AddInput("X")
+        .IsTensor()
+        .End()
+        .AddInput("Scale")
+        .IsTensor()
+        .End()
+        .AddInput("Bias")
+        .IsTensor()
+        .End()
+        .AddOutput("Y")
+        .IsTensor()
+        .End()
+        .AddOutput("Mean")
+        .IsTensor()
+        .End()
+        .AddOutput("Variance")
+        .IsTensor()
+        .End()
+        .AddAttr("epsilon")  // unconstrained
+        .End()
+        .AddAttr("begin_norm_axis")  // unconstrained
+        .End();
+  }
+
   virtual ~SkipLayerNormFusePass() {}
 
  protected:

--- a/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.h
+++ b/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.h
@@ -44,7 +44,8 @@ class SkipLayerNormFusePass : public FusePassBase {
         .AddOutput("Out")
         .IsTensor()
         .End()
-        .AddAttr("axis")  // unconstrained
+        .AddAttr("axis")
+        .IsNumEQ(0)
         .End();
 
     AddOpCompat(OpCompat("layer_norm"))
@@ -66,9 +67,12 @@ class SkipLayerNormFusePass : public FusePassBase {
         .AddOutput("Variance")
         .IsTensor()
         .End()
-        .AddAttr("epsilon")  // unconstrained
+        .AddAttr("epsilon")
+        .IsNumGE(0.0f)
+        .IsNumLE(0.001f)
         .End()
-        .AddAttr("begin_norm_axis")  // unconstrained
+        .AddAttr("begin_norm_axis")
+        .IsNumGT(0)
         .End();
   }
 

--- a/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.h
+++ b/paddle/fluid/framework/ir/skip_layernorm_fuse_pass.h
@@ -45,7 +45,7 @@ class SkipLayerNormFusePass : public FusePassBase {
         .IsTensor()
         .End()
         .AddAttr("axis")
-        .IsNumEQ(0)
+        .IsIntIn({0, -1})
         .End();
 
     AddOpCompat(OpCompat("layer_norm"))


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->

- 为`skip_layernorm`添加兼容性检查
- 阅读pass逻辑发现，没有针对attr的限制，必须存在attr即可。
- 该pass已有python单测，此pr不需对单测进行修改