### PR TITLE
Fix some Bugs of Used before Assignment

### DIFF
--- a/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py
@@ -98,13 +98,14 @@ class TestFusionGRUBF16MKLDNNOp(OpTest):
         if self.with_bias:
             self.inputs['Bias'] = bias
 
+        h0_bf16 = convert_float_to_uint16(h0_fp32)
+
         if self.with_h0:
             if self.weights_dtype == 'bf16':
                 self.inputs['H0'] = h0_bf16
             elif self.weights_dtype == 'fp32':
                 self.inputs['H0'] = h0_fp32
 
-        h0_bf16 = convert_float_to_uint16(h0_fp32)
         self.outputs = {'Hidden': (hidden, self.lod)}
 
         self.attrs = {

--- a/python/paddle/fluid/tests/unittests/test_hdfs1.py
+++ b/python/paddle/fluid/tests/unittests/test_hdfs1.py
@@ -39,6 +39,7 @@ class FSTest1(FSTestBase):
         fs.mkdirs(dst)
         fs.mkdirs(dst + "/" + src)
         output = ""
+        cmd = "{} -mv {} {}".format(fs._base_cmd, src, dst)
         try:
             fs.mv(src, dst, test_exists=False)
             self.assertFalse(1, "can't execute cmd:{} output:{}".format(cmd,
@@ -46,7 +47,6 @@ class FSTest1(FSTestBase):
         except FSTimeOut as e:
             print("execute mv {} to {} timeout".format(src, dst))
 
-        cmd = "{} -mv {} {}".format(fs._base_cmd, src, dst)
         ret, output = fluid.core.shell_execute_cmd(cmd, 6 * 1000, 2 * 1000)
         self.assertNotEqual(ret, 0)
         print("second mv ret:{} output:{}".format(ret, output))


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Describe
1. In python/paddle/fluid/tests/unittests/test_hdfs1.py:
   Line 44: Using variable 'cmd' before assignment
   Move statement in Line 49 to Line 42
2. In python/paddle/fluid/tests/unittests/mkldnn/test_fusion_gru_bf16_mkldnn_op.py:
   Line 103: Using variable 'h0_bf16' before assignment
   Move statement in Line 107 to Line 101 