### PR TITLE
修正conv2d.pbtxt和con2d_transpose.pbtxt对data_format属性的分类错误

### DIFF
--- a/paddle/fluid/operators/compat/conv2d.pbtxt
+++ b/paddle/fluid/operators/compat/conv2d.pbtxt
@@ -32,6 +32,10 @@ def {
     name: "dilations"
     type: INTS
   }
+  attrs {
+    name: "data_format"
+    type: STRING
+  }
 }
 extra {
   inputs {
@@ -112,10 +116,6 @@ extra {
   attrs {
     name: "force_fp32_output"
     type: BOOLEAN
-  }
-  attrs {
-    name: "data_format"
-    type: STRING
   }
   attrs {
     name: "workspace_size_MB"

--- a/paddle/fluid/operators/compat/conv2d_transpose.pbtxt
+++ b/paddle/fluid/operators/compat/conv2d_transpose.pbtxt
@@ -1,4 +1,4 @@
-type: "reduce_mean"
+type: "conv2d_transpose"
 def {
   inputs {
     name: "Input"
@@ -40,6 +40,10 @@ def {
     name: "padding_algorithm"
     type: STRING
   }
+  attrs {
+    name: "data_format"
+    type: STRING
+  }
 }
 extra {
   attrs {
@@ -77,10 +81,6 @@ extra {
   attrs {
     name: "fuse_beta"
     type: FLOAT
-  }
-  attrs {
-    name: "data_format"
-    type: STRING
   }
   attrs {
     name: "workspace_size_MB"


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others
### Describe
<!-- Describe what this PR does -->
修正conv2d.pbtxt和con2d_transpose.pbtxt对data_format属性的分类错误。这个属性属于def,被错误的分到了extra.予以修正。