### PR TITLE
Fix some Bugs of Bad Super Call

### DIFF
--- a/python/paddle/distributed/entry_attr.py
+++ b/python/paddle/distributed/entry_attr.py
@@ -82,7 +82,7 @@ class ProbabilityEntry(EntryAttr):
     """
 
     def __init__(self, probability):
-        super(EntryAttr, self).__init__()
+        super(ProbabilityEntry, self).__init__()
 
         if not isinstance(probability, float):
             raise ValueError("probability must be a float in (0,1)")
@@ -122,7 +122,7 @@ class CountFilterEntry(EntryAttr):
     """
 
     def __init__(self, count_filter):
-        super(EntryAttr, self).__init__()
+        super(CountFilterEntry, self).__init__()
 
         if not isinstance(count_filter, int):
             raise ValueError(

--- a/python/paddle/fluid/entry_attr.py
+++ b/python/paddle/fluid/entry_attr.py
@@ -40,7 +40,7 @@ class EntryAttr(object):
 
 class ProbabilityEntry(EntryAttr):
     def __init__(self, probability):
-        super(EntryAttr, self).__init__()
+        super(ProbabilityEntry, self).__init__()
 
         if not isinstance(probability, float):
             raise ValueError("probability must be a float in (0,1)")
@@ -57,7 +57,7 @@ class ProbabilityEntry(EntryAttr):
 
 class CountFilterEntry(EntryAttr):
     def __init__(self, count_filter):
-        super(EntryAttr, self).__init__()
+        super(CountFilterEntry, self).__init__()
 
         if not isinstance(count_filter, int):
             raise ValueError(

--- a/python/paddle/fluid/incubate/fleet/base/role_maker.py
+++ b/python/paddle/fluid/incubate/fleet/base/role_maker.py
@@ -591,7 +591,7 @@ class GeneralRoleMaker(RoleMakerBase):
     """
 
     def __init__(self, **kwargs):
-        super(RoleMakerBase, self).__init__()
+        super(GeneralRoleMaker, self).__init__()
         self._role_is_generated = False
         self._hdfs_name = kwargs.get("hdfs_name", "")
         self._hdfs_ugi = kwargs.get("hdfs_ugi", "")

--- a/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
+++ b/python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py
@@ -135,7 +135,7 @@ class TestMKLDNNWithValidPad(TestConv2DTransposeMKLDNNOp):
 
 class TestMKLDNNWithValidPad_NHWC(TestMKLDNNWithValidPad):
     def init_test_case(self):
-        super(TestMKLDNNWithValidPad, self).init_test_case()
+        super(TestMKLDNNWithValidPad_NHWC, self).init_test_case()
         self.data_format = "NHWC"
         N, C, H, W = self.input_size
         self.input_size = [N, H, W, C]

--- a/python/paddle/fluid/tests/unittests/test_backward.py
+++ b/python/paddle/fluid/tests/unittests/test_backward.py
@@ -160,7 +160,7 @@ class TestBackward(unittest.TestCase):
 
 class SimpleNet(BackwardNet):
     def __init__(self):
-        super(BackwardNet, self).__init__()
+        super(SimpleNet, self).__init__()
         self.stop_gradient_grad_vars = set([
             u'x_no_grad@GRAD', u'x2_no_grad@GRAD', u'x3_no_grad@GRAD',
             u'label_no_grad@GRAD'
@@ -330,7 +330,7 @@ class TestAppendBackwardWithError(unittest.TestCase):
 # TODO(Aurelius84): add conditional network test
 class ConditionalNet(BackwardNet):
     def __init__(self):
-        super(BackwardNet, self).__init__()
+        super(ConditionalNet, self).__init__()
 
 
 if __name__ == '__main__':

--- a/python/paddle/fluid/tests/unittests/test_fleet_metric.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_metric.py
@@ -35,7 +35,7 @@ class TestFleetMetric(unittest.TestCase):
 
         class FakeUtil(UtilBase):
             def __init__(self, fake_fleet):
-                super(UtilBase, self).__init__()
+                super(FakeUtil, self).__init__()
                 self.fleet = fake_fleet
 
             def all_reduce(self, input, mode="sum", comm_world="worker"):

--- a/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py
+++ b/python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py
@@ -199,7 +199,7 @@ class TestCloudRoleMaker2(unittest.TestCase):
             """
 
             def __init__(self):
-                super(Fleet, self).__init__()
+                super(TmpFleet, self).__init__()
                 self._role_maker = None
 
             def init_worker(self):


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others
### Describe
1. In python/paddle/fluid/tests/unittests/test_fleet_metric.py:
   Line 38: Bad first argument 'UtilBase' given to super()
   **use 'FakeUtil' instead of 'UtilBase'**
2. In python/paddle/fluid/entry_attr.py:
   Line 43, 60: Bad first argument 'EntryAttr' given to super()
   **use 'ProbabilityEntry' instead of 'EntryAttr'**
   **use 'CountFilterEntry' instead of 'EntryAttr'**
3. In python/paddle/distributed/entry_attr.py:
   Line 85, 125: Bad first argument 'EntryAttr' given to super()
   **use 'ProbabilityEntry' instead of 'EntryAttr'**
   **use 'CountFilterEntry' instead of 'EntryAttr'**
4. In python/paddle/fluid/tests/unittests/test_backward.py:
   Line 163, 333: Bad first argument 'BackwardNet' given to super()
   **use 'SimpleNet' instead of 'BackwardNet'**
   **use 'ConditionalNet' instead of 'BackwardNet'**
5. In python/paddle/fluid/tests/unittests/test_fleet_rolemaker_2.py:
   Line 202: Bad first argument 'Fleet' given to super()
   **use 'TmpFleet' instead of 'Fleet'**
6. In python/paddle/fluid/tests/unittests/mkldnn/test_conv2d_transpose_mkldnn_op.py:
   Line 138: Bad first argument 'TestMKLDNNWithValidPad' given to super()
   **use 'TestMKLDNNWithValidPad_NHWC' instead of 'TestMKLDNNWithValidPad'**
7. In python/paddle/fluid/incubate/fleet/base/role_maker.py
   Line 594: Bad first argument 'RoleMakerBase' given to super()
   **use 'GeneralRoleMaker' instead of 'RoleMakerbase'**