### PR TITLE
Use importlib to detect availability of cv2.

### DIFF
--- a/python/paddle/dataset/image.py
+++ b/python/paddle/dataset/image.py
@@ -34,18 +34,14 @@ from __future__ import print_function
 
 import six
 import numpy as np
-# FIXME(minqiyang): this is an ugly fix for the numpy bug reported here
+
+# Test for cv2 avaibility. Do so without importing it so as to
+# avoid the numpy bug reported here.
 # https://github.com/numpy/numpy/issues/12497
 if six.PY3:
-    import subprocess
-    import sys
-    import_cv2_proc = subprocess.Popen(
-        [sys.executable, "-c", "import cv2"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE)
-    out, err = import_cv2_proc.communicate()
-    retcode = import_cv2_proc.poll()
-    if retcode != 0:
+    from importlib.util import find_spec
+
+    if find_spec("cv2") is None:
         cv2 = None
     else:
         import cv2


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
Function optimization

### PR changes
Others

### Describe
<!-- Describe what this PR does -->

This PR replaces the ugly *FIXME* labeled check for whether or not `cv2` is installed with an importlib call which accomplishes the same thing as the original.

The main motivation for getting rid of the original `subprocess.Popen([sys.executable, ...])` is because:
- It fails for embedded Python (where `sys.executable` is typically `None`)
- It causes an infinite loop of subprocesses when frozen with PyInstaller where `sys.executable` is an executable equivalent to `python main-code.py`. In other words, any python script containing `import paddle` will launch itself in a subprocess, then that subprocess will launch itself again in another subprocess, and so on until your computer crashes.
